### PR TITLE
Improve various error messages

### DIFF
--- a/Zend/tests/008.phpt
+++ b/Zend/tests/008.phpt
@@ -27,13 +27,13 @@ echo "Done\n";
 --EXPECTF--
 TypeError: define(): Argument #1 ($constant_name) must be of type string, array given
 
-Notice: Constant TRUE already defined in %s on line %d
+Notice: Constant TRUE has already been defined in %s on line %d
 bool(false)
 bool(true)
 bool(true)
 bool(true)
 
-Notice: Constant test const already defined in %s on line %d
+Notice: Constant test const has already been defined in %s on line %d
 bool(false)
 bool(true)
 bool(true)

--- a/Zend/tests/access_modifiers_008.phpt
+++ b/Zend/tests/access_modifiers_008.phpt
@@ -18,4 +18,4 @@ B2::test();
 
 ?>
 --EXPECTF--
-Fatal error: Call to protected method B1::f() from scope B2 in %s on line %d
+Fatal error: Protected method B1::f() cannot be called from the scope of class B2 in %s on line %d

--- a/Zend/tests/access_modifiers_009.phpt
+++ b/Zend/tests/access_modifiers_009.phpt
@@ -23,4 +23,4 @@ B2::test();
 --EXPECTF--
 bool(false)
 
-Fatal error: Call to protected method B1::f() from scope B2 in %s on line %d
+Fatal error: Protected method B1::f() cannot be called from the scope of class B2 in %s on line %d

--- a/Zend/tests/access_modifiers_010.phpt
+++ b/Zend/tests/access_modifiers_010.phpt
@@ -28,7 +28,7 @@ new c;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private method d::test2() from scope a in %s:%d
+Fatal error: Uncaught Error: Private method d::test2() cannot be called from the scope of class a in %s:%d
 Stack trace:
 #0 %s(%d): a->test()
 #1 %s(%d): c->__construct()

--- a/Zend/tests/array_unpack/classes.phpt
+++ b/Zend/tests/array_unpack/classes.phpt
@@ -43,4 +43,4 @@ array(3) {
   [2]=>
   int(3)
 }
-Exception: Cannot declare self-referencing constant self::B
+Exception: Constant self::B cannot reference itself

--- a/Zend/tests/attributes/008_wrong_attribution.phpt
+++ b/Zend/tests/attributes/008_wrong_attribution.phpt
@@ -6,4 +6,4 @@ Attributes: Prevent Attribute on non classes
 <<Attribute>>
 function foo() {}
 --EXPECTF--
-Fatal error: Attribute "Attribute" cannot target function (allowed targets: class) in %s
+Fatal error: Attribute Attribute cannot target function (allowed targets: class) in %s on line %d

--- a/Zend/tests/attributes/024_internal_target_validation.phpt
+++ b/Zend/tests/attributes/024_internal_target_validation.phpt
@@ -8,4 +8,4 @@ function a1() { }
 
 ?>
 --EXPECTF--
-Fatal error: Attribute "Attribute" cannot target function (allowed targets: class) in %s
+Fatal error: Attribute Attribute cannot target function (allowed targets: class) in %s on line %d

--- a/Zend/tests/attributes/025_internal_repeatable_validation.phpt
+++ b/Zend/tests/attributes/025_internal_repeatable_validation.phpt
@@ -9,4 +9,4 @@ class A1 { }
 
 ?>
 --EXPECTF--
-Fatal error: Attribute "Attribute" must not be repeated in %s
+Fatal error: Attribute Attribute must not be repeated in %s on line %d

--- a/Zend/tests/break_error_001.phpt
+++ b/Zend/tests/break_error_001.phpt
@@ -7,4 +7,4 @@ function foo () {
 }
 ?>
 --EXPECTF--
-Fatal error: 'break' operator accepts only positive integers in %sbreak_error_001.php on line 3
+Fatal error: break statement accepts only an integer argument greater than or equal to 0 in %s on line %d

--- a/Zend/tests/break_error_002.phpt
+++ b/Zend/tests/break_error_002.phpt
@@ -7,4 +7,4 @@ function foo () {
 }
 ?>
 --EXPECTF--
-Fatal error: 'break' operator with non-integer operand is no longer supported in %sbreak_error_002.php on line 3
+Fatal error: break statement with non-integer argument is no longer supported in %s on line %d

--- a/Zend/tests/break_error_003.phpt
+++ b/Zend/tests/break_error_003.phpt
@@ -7,4 +7,4 @@ function foo () {
 }
 ?>
 --EXPECTF--
-Fatal error: 'break' not in the 'loop' or 'switch' context in %sbreak_error_003.php on line 3
+Fatal error: break statement can only be used inside a loop or a switch statement in %s on line %d

--- a/Zend/tests/break_error_004.phpt
+++ b/Zend/tests/break_error_004.phpt
@@ -9,4 +9,4 @@ function foo () {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot 'break' 2 levels in %sbreak_error_004.php on line 4
+Fatal error: Cannot break 2 levels in %s on line %d

--- a/Zend/tests/bug29015.phpt
+++ b/Zend/tests/bug29015.phpt
@@ -15,7 +15,7 @@ object(stdClass)#1 (1) {
   string(10) "string('')"
 }
 
-Fatal error: Uncaught Error: Cannot access property starting with "\0" in %s:%d
+Fatal error: Uncaught Error: Property starting with "\0" cannot be accessed in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug29674.phpt
+++ b/Zend/tests/bug29674.phpt
@@ -33,12 +33,12 @@ $obj->printVars();
 ===BASE===
 string(4) "Base"
 
-Warning: Undefined property: BaseClass::$private_child in %s on line %d
+Warning: Undefined property BaseClass::$private_child in %s on line %d
 NULL
 ===CHILD===
 string(4) "Base"
 
-Fatal error: Uncaught Error: Cannot access private property ChildClass::$private_child in %sbug29674.php:%d
+Fatal error: Uncaught Error: Private property ChildClass::$private_child cannot be accessed from the scope of class BaseClass in %s:%d
 Stack trace:
 #0 %s(%d): BaseClass->printVars()
 #1 {main}

--- a/Zend/tests/bug29689.phpt
+++ b/Zend/tests/bug29689.phpt
@@ -52,7 +52,7 @@ $baz->printFoo();
 --EXPECTF--
 foo: foo foo2
 bar: bar 
-Warning: Undefined property: bar::$foo2 in %s on line %d
+Warning: Undefined property bar::$foo2 in %s on line %d
 
 ---baz--
 foo: foo foo2

--- a/Zend/tests/bug29890.phpt
+++ b/Zend/tests/bug29890.phpt
@@ -20,4 +20,4 @@ define("TEST",3);
 
 ?>
 --EXPECT--
-error :Constant TEST already defined
+error :Constant TEST has already been defined

--- a/Zend/tests/bug30820.phpt
+++ b/Zend/tests/bug30820.phpt
@@ -21,8 +21,8 @@ $b = new Blah();
 $b->show();
 ?>
 --EXPECTF--
-Notice: Accessing static property Blah::$x as non static in %sbug30820.php on line 7
+Notice: Accessing static property Blah::$x as non-static in %s on line %d
 Blah::$x = 1
 
-Notice: Accessing static property Blah::$x as non static in %sbug30820.php on line 10
+Notice: Accessing static property Blah::$x as non-static in %s on line %d
 $this->x = 5

--- a/Zend/tests/bug37632.phpt
+++ b/Zend/tests/bug37632.phpt
@@ -132,7 +132,7 @@ B2::doTest
 C2::test
 B4::doTest
 
-Fatal error: Uncaught Error: Call to protected C4::__construct() from scope B4 in %s:%d
+Fatal error: Uncaught Error: Protected method C4::__construct() cannot be called from the scope of class B4 in %s:%d
 Stack trace:
 #0 %s(%d): B4::doTest()
 #1 {main}

--- a/Zend/tests/bug38461.phpt
+++ b/Zend/tests/bug38461.phpt
@@ -22,7 +22,7 @@ $op->x = 'test';
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access private property ExtOperation::$x in %s:%d
+Fatal error: Uncaught Error: Private property ExtOperation::$x cannot be accessed from the scope of class Operation in %s:%d
 Stack trace:
 #0 %s(%d): Operation->__set('x', 'test')
 #1 {main}

--- a/Zend/tests/bug41117_1.phpt
+++ b/Zend/tests/bug41117_1.phpt
@@ -10,4 +10,4 @@ class foo {
 $obj = new foo("Hello world");
 ?>
 --EXPECTF--
-Fatal error: Cannot use $this as parameter in %s on line %d
+Fatal error: foo::__construct(): Parameter #1 cannot be called $this in %s on line %d

--- a/Zend/tests/bug41633_3.phpt
+++ b/Zend/tests/bug41633_3.phpt
@@ -9,7 +9,7 @@ class Foo {
 echo Foo::A;
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot declare self-referencing constant Foo::B in %s:%d
+Fatal error: Uncaught Error: Constant Foo::B cannot reference itself in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sbug41633_3.php on line %d

--- a/Zend/tests/bug43332_2.phpt
+++ b/Zend/tests/bug43332_2.phpt
@@ -12,4 +12,4 @@ $foo = new foo;
 $foo->bar($foo); // Ok!
 $foo->bar(new stdclass); // Error, ok!
 --EXPECTF--
-Fatal error: '\self' is an invalid class name in %sbug43332_2.php on line 5
+Fatal error: "\self" is an invalid class name in %s on line %d

--- a/Zend/tests/bug44141.phpt
+++ b/Zend/tests/bug44141.phpt
@@ -22,7 +22,7 @@ class Y extends X
 $y = Y::cheat(5);
 echo $y->x, PHP_EOL;
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private X::__construct() from scope Y in %s:%d
+Fatal error: Uncaught Error: Private method X::__construct() cannot be called from the scope of class Y in %s:%d
 Stack trace:
 #0 %s(%d): Y::cheat(5)
 #1 {main}

--- a/Zend/tests/bug44899.phpt
+++ b/Zend/tests/bug44899.phpt
@@ -34,5 +34,5 @@ echo "\n";
 isset
 empty
 
-Warning: Undefined property: myclass::$foo in %s on line %d
+Warning: Undefined property myclass::$foo in %s on line %d
 empty

--- a/Zend/tests/bug45186.phpt
+++ b/Zend/tests/bug45186.phpt
@@ -54,4 +54,4 @@ string(1) "y"
 ok
 __callstatic:
 string(3) "www"
-call_user_func(): Argument #1 ($function) must be a valid callback, cannot access "self" when no class scope is active
+call_user_func(): Argument #1 ($function) must be a valid callback, "self" cannot be used in the global scope

--- a/Zend/tests/bug45186_2.phpt
+++ b/Zend/tests/bug45186_2.phpt
@@ -53,4 +53,4 @@ __call:
 string(1) "y"
 ok
 call_user_func(): Argument #1 ($function) must be a valid callback, class bar does not have a method "www"
-call_user_func(): Argument #1 ($function) must be a valid callback, cannot access "self" when no class scope is active
+call_user_func(): Argument #1 ($function) must be a valid callback, "self" cannot be used in the global scope

--- a/Zend/tests/bug48248.phpt
+++ b/Zend/tests/bug48248.phpt
@@ -21,7 +21,7 @@ var_dump($b->test);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access private property B::$test in %s:%d
+Fatal error: Uncaught Error: Private property B::$test cannot be accessed from the scope of class A in %s:%d
 Stack trace:
 #0 %s(%d): A->__get('test')
 #1 {main}

--- a/Zend/tests/bug52484.phpt
+++ b/Zend/tests/bug52484.phpt
@@ -16,7 +16,7 @@ unset($a->$prop);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access property starting with "\0" in %s:%d
+Fatal error: Uncaught Error: Property starting with "\0" cannot be accessed in %s:%d
 Stack trace:
 #0 %s(%d): A->__unset('\x00')
 #1 {main}

--- a/Zend/tests/bug52484_2.phpt
+++ b/Zend/tests/bug52484_2.phpt
@@ -16,7 +16,7 @@ $a->$prop = 2;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access property starting with "\0" in %s:%d
+Fatal error: Uncaught Error: Property starting with "\0" cannot be accessed in %s:%d
 Stack trace:
 #0 %s(%d): A->__set('\x00', 2)
 #1 {main}

--- a/Zend/tests/bug52484_3.phpt
+++ b/Zend/tests/bug52484_3.phpt
@@ -16,7 +16,7 @@ var_dump($a->$prop);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access property starting with "\0" in %s:%d
+Fatal error: Uncaught Error: Property starting with "\0" cannot be accessed in %s:%d
 Stack trace:
 #0 %s(%d): A->__get('\x00')
 #1 {main}

--- a/Zend/tests/bug53305.phpt
+++ b/Zend/tests/bug53305.phpt
@@ -14,6 +14,6 @@ var_dump(constant('__COMPILER_HALT_OFFSET__1'.chr(0)));
 
 ?>
 --EXPECTF--
-Notice: Constant __COMPILER_HALT_OFFSET__ already defined in %s on line %d
+Notice: Constant __COMPILER_HALT_OFFSET__ has already been defined in %s on line %d
 int(1)
 int(4)

--- a/Zend/tests/bug54013.phpt
+++ b/Zend/tests/bug54013.phpt
@@ -21,4 +21,4 @@ var_dump($params[0], $params[1]);
 
 ?>
 --EXPECTF--
-Fatal error: Redefinition of parameter $aaaaaaaa in %sbug54013.php on line 5
+Fatal error: a::b(): Parameter #2 ($aaaaaaaa) cannot be redefined in %s on line %d

--- a/Zend/tests/bug60536_001.phpt
+++ b/Zend/tests/bug60536_001.phpt
@@ -22,5 +22,5 @@ $a->__construct();
 echo "DONE";
 ?>
 --EXPECTF--
-Warning: Undefined property: Z::$x in %s on line %d
+Warning: Undefined property Z::$x in %s on line %d
 DONE

--- a/Zend/tests/bug61025.phpt
+++ b/Zend/tests/bug61025.phpt
@@ -16,9 +16,9 @@ echo $b->__invoke();
 
 ?>
 --EXPECTF--
-Warning: The magic method Bar::__invoke() must have public visibility in %sbug61025.php on line %d
+Warning: Method Bar::__invoke() must have public visibility in %sbug61025.php on line %d
 Bar
-Fatal error: Uncaught Error: Call to private method Bar::__invoke() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method Bar::__invoke() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sbug61025.php on line %d

--- a/Zend/tests/bug61970_1.phpt
+++ b/Zend/tests/bug61970_1.phpt
@@ -11,4 +11,4 @@ class Bar extends Foo {
     protected function __construct(){}
 }
 --EXPECTF--
-Fatal error: Access level to Bar::__construct() must be public (as in class Foo) in %s on line 8
+Fatal error: Method Bar::__construct() must have public visibility to be compatible with overridden method Foo::__construct() in %s on line %d

--- a/Zend/tests/bug61970_2.phpt
+++ b/Zend/tests/bug61970_2.phpt
@@ -15,4 +15,4 @@ class Baz extends Bar {
     protected function __construct(){}
 }
 --EXPECTF--
-Fatal error: Access level to Baz::__construct() must be public (as in class Foo) in %s on line 12
+Fatal error: Method Baz::__construct() must have public visibility to be compatible with overridden method Foo::__construct() in %s on line %d

--- a/Zend/tests/bug62814.phpt
+++ b/Zend/tests/bug62814.phpt
@@ -17,4 +17,4 @@ class C extends B {
 
 ?>
 --EXPECTF--
-Fatal error: Access level to C::test() must be protected (as in class B) or weaker in %s on line 12
+Fatal error: Method C::test() must have protected or public visibility to be compatible with overridden method B::test() in %s on line %d

--- a/Zend/tests/bug63111.phpt
+++ b/Zend/tests/bug63111.phpt
@@ -31,7 +31,7 @@ bool(true)
 bool(true)
 ok
 
-Fatal error: Uncaught Error: Cannot call abstract method Foo::bar() in %sbug63111.php:20
+Fatal error: Uncaught Error: Abstract method Foo::bar() cannot be called in %sbug63111.php:20
 Stack trace:
 #0 {main}
   thrown in %sbug63111.php on line 20

--- a/Zend/tests/bug63219.phpt
+++ b/Zend/tests/bug63219.phpt
@@ -15,4 +15,4 @@ class C {
 echo "okey";
 ?>
 --EXPECTF--
-Fatal error: Could not find trait Typo in %sbug63219.php on line %d
+Fatal error: Trait Typo cannot be found in %s on line %d

--- a/Zend/tests/bug63462.phpt
+++ b/Zend/tests/bug63462.phpt
@@ -52,16 +52,16 @@ $test->privateProperty   = 'value';
 --EXPECTF--
 __get nonExisting
 
-Warning: Undefined property: Test::$nonExisting in %s on line %d
+Warning: Undefined property Test::$nonExisting in %s on line %d
 __get publicProperty
 
-Warning: Undefined property: Test::$publicProperty in %s on line %d
+Warning: Undefined property Test::$publicProperty in %s on line %d
 __get protectedProperty
 
-Warning: Undefined property: Test::$protectedProperty in %s on line %d
+Warning: Undefined property Test::$protectedProperty in %s on line %d
 __get privateProperty
 
-Warning: Undefined property: Test::$privateProperty in %s on line %d
+Warning: Undefined property Test::$privateProperty in %s on line %d
 __isset nonExisting
 __isset publicProperty
 __isset protectedProperty

--- a/Zend/tests/bug64515.phpt
+++ b/Zend/tests/bug64515.phpt
@@ -9,4 +9,4 @@ foo();
 echo "okey";
 ?>
 --EXPECTF--
-Fatal error: Redefinition of parameter $unused in %sbug64515.php on line 2
+Fatal error: foo(): Parameter #2 ($unused) cannot be redefined in %s on line %d

--- a/Zend/tests/bug65322.phpt
+++ b/Zend/tests/bug65322.phpt
@@ -19,6 +19,6 @@ eval('class A { private function __invoke() { } }');
 
 ?>
 --EXPECTF--
-string(%d) "The magic method A::__invoke() must have public visibility"
+string(48) "Method A::__invoke() must have public visibility"
 string(%d) "%s(%d) : eval()'d code"
 string(1) "X"

--- a/Zend/tests/bug66609.phpt
+++ b/Zend/tests/bug66609.phpt
@@ -24,5 +24,5 @@ $foo->blah--;    //crash
 echo "okey";
 ?>
 --EXPECTF--
-Warning: Undefined property: Bar::$bar in %s on line %d
+Warning: Undefined property Bar::$bar in %s on line %d
 okey

--- a/Zend/tests/bug67436/bug67436.phpt
+++ b/Zend/tests/bug67436/bug67436.phpt
@@ -22,6 +22,6 @@ a::staticTest();
 $b = new b();
 $b->test();
 --EXPECTF--
-string(%d) "The magic method b::__invoke() must have public visibility"
+string(%d) "Method b::__invoke() must have public visibility"
 b::test()
 a::test(c::TESTCONSTANT)

--- a/Zend/tests/bug67436/bug67436_nohandler.phpt
+++ b/Zend/tests/bug67436/bug67436_nohandler.phpt
@@ -14,6 +14,6 @@ a::staticTest();
 $b = new b();
 $b->test();
 --EXPECTF--
-Warning: The magic method b::__invoke() must have public visibility in %s on line %d
+Warning: Method b::__invoke() must have public visibility in %s on line %d
 b::test()
 a::test(c::TESTCONSTANT)

--- a/Zend/tests/bug69388.phpt
+++ b/Zend/tests/bug69388.phpt
@@ -15,4 +15,4 @@ eval('namespace {use Exception;}');
 
 ?>
 --EXPECT--
-The use statement with non-compound name 'Exception' has no effect
+The use statement with non-compound name Exception has no effect

--- a/Zend/tests/bug69388_2.phpt
+++ b/Zend/tests/bug69388_2.phpt
@@ -12,4 +12,4 @@ eval('namespace {use Exception;}');
 
 ?>
 --EXPECT--
-The use statement with non-compound name 'Exception' has no effect
+The use statement with non-compound name Exception has no effect

--- a/Zend/tests/bug69467.phpt
+++ b/Zend/tests/bug69467.phpt
@@ -18,4 +18,4 @@ $test = new Foo();
 var_dump($test instanceof Baz);
 ?>
 --EXPECTF--
-Fatal error: Access level to Foo::bad() must be public (as in class Baz) in %sbug69467.php on line %d
+Fatal error: Method Foo::bad() must have public visibility to be compatible with overridden method Baz::bad() in %s on line %d

--- a/Zend/tests/bug69732.phpt
+++ b/Zend/tests/bug69732.phpt
@@ -20,7 +20,7 @@ $wpq->interesting =& ret_assoc();
 $x = $wpq->interesting;
 printf("%s\n", $x);
 --EXPECTF--
-Warning: Undefined property: wpq::$interesting in %s on line %d
+Warning: Undefined property wpq::$interesting in %s on line %d
 
 Notice: Indirect modification of overloaded property wpq::$interesting has no effect in %sbug69732.php on line 16
 

--- a/Zend/tests/bug69767.phpt
+++ b/Zend/tests/bug69767.phpt
@@ -5,4 +5,4 @@ Bug #69767 (Default parameter value with wrong type segfaults)
 function foo(String $bar = 0) {}
 ?>
 --EXPECTF--
-Fatal error: Cannot use int as default value for parameter $bar of type string in %s on line %d
+Fatal error: foo(): Parameter #1 ($bar) of type string cannot have a default value of type int in %s on line %d

--- a/Zend/tests/bug70873.phpt
+++ b/Zend/tests/bug70873.phpt
@@ -27,7 +27,7 @@ $b = new C;
 $b->bar();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access private property B::$x in %sbug70873.php:%d
+Fatal error: Uncaught Error: Private property B::$x cannot be accessed from the scope of class B in %s:%d
 Stack trace:
 #0 %sbug70873.php(%d): B->bar()
 #1 {main}

--- a/Zend/tests/bug70918.phpt
+++ b/Zend/tests/bug70918.phpt
@@ -39,9 +39,9 @@ try {
 }
 ?>
 --EXPECT--
-string(52) "Cannot access "static" when no class scope is active"
-string(52) "Cannot access "parent" when no class scope is active"
-string(50) "Cannot access "self" when no class scope is active"
-string(52) "Cannot access "static" when no class scope is active"
-string(52) "Cannot access "static" when no class scope is active"
-string(52) "Cannot access "static" when no class scope is active"
+string(43) ""static" cannot be used in the global scope"
+string(43) ""parent" cannot be used in the global scope"
+string(41) ""self" cannot be used in the global scope"
+string(43) ""static" cannot be used in the global scope"
+string(43) ""static" cannot be used in the global scope"
+string(43) ""static" cannot be used in the global scope"

--- a/Zend/tests/bug71221.phpt
+++ b/Zend/tests/bug71221.phpt
@@ -4,7 +4,7 @@ Bug #71221 (Null pointer deref (segfault) in get_defined_vars via ob_start)
 <?php
 register_shutdown_function("get_defined_vars");
 --EXPECT--
-Fatal error: Uncaught Error: Cannot call get_defined_vars() dynamically in [no active file]:0
+Fatal error: Uncaught Error: get_defined_vars() cannot be called dynamically in [no active file]:0
 Stack trace:
 #0 [internal function]: get_defined_vars()
 #1 {main}

--- a/Zend/tests/bug71737.phpt
+++ b/Zend/tests/bug71737.phpt
@@ -13,4 +13,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use $this as parameter in %s on line %d
+Fatal error: {closure}(): Parameter #1 cannot be called $this in %s on line %d

--- a/Zend/tests/bug71871.phpt
+++ b/Zend/tests/bug71871.phpt
@@ -9,4 +9,4 @@ interface test {
 
 ?>
 --EXPECTF--
-Fatal error: Access type for interface method test::test() must be omitted in %s on line %d
+Fatal error: Interface method test::test() cannot be final in %s on line %d

--- a/Zend/tests/bug71871_2.phpt
+++ b/Zend/tests/bug71871_2.phpt
@@ -9,4 +9,4 @@ interface test {
 
 ?>
 --EXPECTF--
-Fatal error: Access type for interface method test::test() must be omitted in %s on line %d
+Fatal error: Interface method test::test() cannot be abstract in %s on line %d

--- a/Zend/tests/bug74340.phpt
+++ b/Zend/tests/bug74340.phpt
@@ -24,7 +24,7 @@ $test->test;
 --EXPECTF--
 __get test
 
-Warning: Undefined property: Test::$test in %s on line %d
+Warning: Undefined property Test::$test in %s on line %d
 __get test2
 
-Warning: Undefined property: Test::$test in %s on line %d
+Warning: Undefined property Test::$test in %s on line %d

--- a/Zend/tests/bug75079_2.phpt
+++ b/Zend/tests/bug75079_2.phpt
@@ -29,7 +29,7 @@ var_dump($f->bindTo($a, A::CLASS)()());
 --EXPECTF--
 int(123)
 
-Fatal error: Uncaught Error: Cannot access private property Foo::$bar in %s:%d
+Fatal error: Uncaught Error: Private property Foo::$bar cannot be accessed from the scope of class A in %s:%d
 Stack trace:
 #0 %s(%d): A->{closure}()
 #1 {main}

--- a/Zend/tests/bug76860.phpt
+++ b/Zend/tests/bug76860.phpt
@@ -15,17 +15,17 @@ class B extends A {
 new B;
 ?>
 --EXPECTF--
-Notice: Accessing static property B::$a as non static in %sbug76860.php on line 7
+Notice: Accessing static property B::$a as non-static in %s on line %d
 
-Warning: Undefined property: B::$a in %s on line %d
+Warning: Undefined property B::$a in %s on line %d
 
-Notice: Accessing static property B::$b as non static in %sbug76860.php on line 7
+Notice: Accessing static property B::$b as non-static in %s on line %d
 
-Warning: Undefined property: B::$b in %s on line %d
+Warning: Undefined property B::$b in %s on line %d
 
-Notice: Accessing static property B::$c as non static in %sbug76860.php on line 7
+Notice: Accessing static property B::$c as non-static in %s on line %d
 
-Warning: Undefined property: B::$c in %s on line %d
+Warning: Undefined property B::$c in %s on line %d
 NULL
 NULL
 NULL

--- a/Zend/tests/bug76860_2.phpt
+++ b/Zend/tests/bug76860_2.phpt
@@ -18,17 +18,17 @@ class B extends A {
 new B;
 ?>
 --EXPECTF--
-Notice: Accessing static property B::$a as non static in %sbug76860_2.php on line 7
+Notice: Accessing static property B::$a as non-static in %s on line %d
 
-Warning: Undefined property: B::$a in %s on line %d
+Warning: Undefined property B::$a in %s on line %d
 
-Notice: Accessing static property B::$b as non static in %sbug76860_2.php on line 7
+Notice: Accessing static property B::$b as non-static in %s on line %d
 
-Warning: Undefined property: B::$b in %s on line %d
+Warning: Undefined property B::$b in %s on line %d
 
-Notice: Accessing static property B::$c as non static in %sbug76860_2.php on line 7
+Notice: Accessing static property B::$c as non-static in %s on line %d
 
-Warning: Undefined property: B::$c in %s on line %d
+Warning: Undefined property B::$c in %s on line %d
 NULL
 NULL
 NULL

--- a/Zend/tests/bug76869.phpt
+++ b/Zend/tests/bug76869.phpt
@@ -20,4 +20,4 @@ try {
 }
 ?>
 --EXPECT--
-Exception: Call to protected method B::f() from global scope
+Exception: Protected method B::f() cannot be called from the global scope

--- a/Zend/tests/bug77494.phpt
+++ b/Zend/tests/bug77494.phpt
@@ -12,5 +12,5 @@ var_dump($a->name);
 --EXPECTF--
 Warning: CURLFile() has been disabled for security reasons in %sbug77494.php on line 2
 
-Warning: Undefined property: CURLFile::$name in %s on line %d
+Warning: Undefined property CURLFile::$name in %s on line %d
 NULL

--- a/Zend/tests/bug77660.phpt
+++ b/Zend/tests/bug77660.phpt
@@ -7,4 +7,4 @@ Bug #77660 (Segmentation fault on break 2147483648)
 for(;;) break 2147483648;
 ?>
 --EXPECTF--
-Fatal error: Cannot 'break' 2147483648 levels in %sbug77660.php on line %d
+Fatal error: Cannot break 2147483648 levels in %s on line %d

--- a/Zend/tests/bug78344.phpt
+++ b/Zend/tests/bug78344.phpt
@@ -17,7 +17,7 @@ class C extends B {
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access protected constant A::FOO in %s:%d
+Fatal error: Uncaught Error: Protected constant A::FOO cannot be accessed from the scope of class C in %s:%d
 Stack trace:
 #0 %s(%d): C->method()
 #1 {main}

--- a/Zend/tests/bug78776.phpt
+++ b/Zend/tests/bug78776.phpt
@@ -25,4 +25,4 @@ B::createApp();
 
 ?>
 --EXPECTF--
-Fatal error: Cannot make non static method A::createApp() static in class C in %s on line %d
+Fatal error: Method C::createApp() must not be static to be compatible with overridden method A::createApp() in %s on line %d

--- a/Zend/tests/bug79862.phpt
+++ b/Zend/tests/bug79862.phpt
@@ -37,9 +37,9 @@ $c = new c;
 
 ?>
 --EXPECTF--
-Notice: Accessing static property c::$prop5 as non static in %s on line %d
+Notice: Accessing static property c::$prop5 as non-static in %s on line %d
 
-Notice: Accessing static property c::$prop6 as non static in %s on line %d
+Notice: Accessing static property c::$prop6 as non-static in %s on line %d
 NULL
 NULL
 NULL

--- a/Zend/tests/call_to_abstract_method_args.phpt
+++ b/Zend/tests/call_to_abstract_method_args.phpt
@@ -22,5 +22,5 @@ try {
 
 ?>
 --EXPECT--
-Cannot call abstract method Test::method()
-Cannot call abstract method Test::method()
+Abstract method Test::method() cannot be called
+Abstract method Test::method() cannot be called

--- a/Zend/tests/call_user_func_005.phpt
+++ b/Zend/tests/call_user_func_005.phpt
@@ -18,11 +18,11 @@ var_dump(call_user_func(array('foo', 'teste')));
 
 ?>
 --EXPECTF--
-Deprecated: Required parameter $b follows optional parameter $a in %s on line %d
+Deprecated: Required parameter $b should precede optional parameter $a in %s on line %d
 string(1) "x"
 array(1) {
   [0]=>
-  object(Closure)#%d (1) {
+  object(Closure)#1 (1) {
     ["parameter"]=>
     array(2) {
       ["$a"]=>

--- a/Zend/tests/class_alias_002.phpt
+++ b/Zend/tests/class_alias_002.phpt
@@ -9,4 +9,4 @@ class_alias('foo', 'FOO');
 
 ?>
 --EXPECTF--
-Warning: Cannot declare class FOO, because the name is already in use in %s on line %d
+Warning: class FOO cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/class_alias_004.phpt
+++ b/Zend/tests/class_alias_004.phpt
@@ -12,4 +12,4 @@ class_alias('foo', 'test');
 
 ?>
 --EXPECTF--
-Warning: Cannot declare class test, because the name is already in use in %s on line %d
+Warning: class test cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/class_alias_008.phpt
+++ b/Zend/tests/class_alias_008.phpt
@@ -13,7 +13,7 @@ new $a;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot instantiate abstract class foo in %s:%d
+Fatal error: Uncaught Error: Abstract class foo cannot be instantiated in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/class_alias_010.phpt
+++ b/Zend/tests/class_alias_010.phpt
@@ -11,4 +11,4 @@ class b { }
 
 ?>
 --EXPECTF--
-Warning: Cannot declare interface b, because the name is already in use in %s on line %d
+Warning: interface b cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/class_alias_019.phpt
+++ b/Zend/tests/class_alias_019.phpt
@@ -14,4 +14,4 @@ class_alias('\foo', 'foo');
 
 ?>
 --EXPECTF--
-Warning: Cannot declare class foo, because the name is already in use in %s on line %d
+Warning: class foo cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/class_name_as_scalar_error_002.phpt
+++ b/Zend/tests/class_name_as_scalar_error_002.phpt
@@ -11,4 +11,4 @@ namespace Foo\Bar {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use "parent" when current class scope has no parent in %s on line %d
+Fatal error: "parent" cannot be used when current class scope has no parent in %s on line %d

--- a/Zend/tests/class_properties_const.phpt
+++ b/Zend/tests/class_properties_const.phpt
@@ -16,10 +16,10 @@ var_dump($a->{function(){}});
 Warning: Array to string conversion in %s on line %d
 runtime
 
-Warning: Undefined property: A::$Array in %s on line %d
+Warning: Undefined property A::$Array in %s on line %d
 NULL
 
-Warning: Undefined property: A::$1 in %s on line %d
+Warning: Undefined property A::$1 in %s on line %d
 NULL
 
 Fatal error: Uncaught Error: Object of class Closure could not be converted to string in %s:%d

--- a/Zend/tests/closure_020.phpt
+++ b/Zend/tests/closure_020.phpt
@@ -40,7 +40,7 @@ object(foo)#%d (2) {
 bool(true)
 bool(true)
 
-Fatal error: Uncaught Error: Cannot access private property foo::$test in %s:%d
+Fatal error: Uncaught Error: Private property foo::$test cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/closure_033.phpt
+++ b/Zend/tests/closure_033.phpt
@@ -25,7 +25,7 @@ $o->func();
 --EXPECTF--
 {closure}()
 
-Fatal error: Uncaught Error: Call to private method Test::func() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method Test::func() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sclosure_033.php on line %d

--- a/Zend/tests/closure_038.phpt
+++ b/Zend/tests/closure_038.phpt
@@ -55,7 +55,7 @@ Testing with scope as string
 int(23)
 int(24)
 
-Fatal error: Uncaught Error: Cannot access private property B::$x in %s:%d
+Fatal error: Uncaught Error: Private property B::$x cannot be accessed from the scope of class Closure in %s:%d
 Stack trace:
 #0 %s(%d): Closure->{closure}()
 #1 {main}

--- a/Zend/tests/closure_039.phpt
+++ b/Zend/tests/closure_039.phpt
@@ -55,7 +55,7 @@ Testing with scope as string
 int(23)
 int(24)
 
-Fatal error: Uncaught Error: Cannot access private property B::$x in %s:%d
+Fatal error: Uncaught Error: Private property B::$x cannot be accessed from the scope of class Closure in %s:%d
 Stack trace:
 #0 %s(%d): Closure->{closure}()
 #1 {main}

--- a/Zend/tests/closure_use_parameter_name.phpt
+++ b/Zend/tests/closure_use_parameter_name.phpt
@@ -11,4 +11,4 @@ $fn(2);
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use lexical variable $a as a parameter name in %s on line %d
+Fatal error: Lexical variable $a cannot be used as a parameter name in %s on line %d

--- a/Zend/tests/closure_use_variable_twice.phpt
+++ b/Zend/tests/closure_use_variable_twice.phpt
@@ -12,4 +12,4 @@ var_dump($a);
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use variable $a twice in %s on line %d
+Fatal error: Variable $a cannot be used multiple times in %s on line %d

--- a/Zend/tests/constant_expressions_self_referencing_array.phpt
+++ b/Zend/tests/constant_expressions_self_referencing_array.phpt
@@ -9,7 +9,7 @@ class A {
 var_dump(A::FOO);
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot declare self-referencing constant self::BAR in %s:%d
+Fatal error: Uncaught Error: Constant self::BAR cannot reference itself in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/constants_001.phpt
+++ b/Zend/tests/constants_001.phpt
@@ -17,7 +17,7 @@ var_dump(constant('1foo'));
 
 ?>
 --EXPECTF--
-Notice: Constant 1 already defined in %s on line %d
+Notice: Constant 1 has already been defined in %s on line %d
 int(2)
 int(2)
 int(2)

--- a/Zend/tests/constants_004.phpt
+++ b/Zend/tests/constants_004.phpt
@@ -10,4 +10,4 @@ const foo = 2;
 
 ?>
 --EXPECTF--
-Notice: Constant foo\foo already defined in %s on line %d
+Notice: Constant foo\foo has already been defined in %s on line %d

--- a/Zend/tests/constants_008.phpt
+++ b/Zend/tests/constants_008.phpt
@@ -13,5 +13,5 @@ if (defined('a')) {
 
 ?>
 --EXPECTF--
-Notice: Constant a already defined in %s on line %d
+Notice: Constant a has already been defined in %s on line %d
 2

--- a/Zend/tests/ctor_promotion_abstract.phpt
+++ b/Zend/tests/ctor_promotion_abstract.phpt
@@ -9,4 +9,4 @@ abstract class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare promoted property in an abstract constructor in %s on line %d
+Fatal error: Promoted property Test::$x cannot be declared in an abstract constructor in %s on line %d

--- a/Zend/tests/ctor_promotion_callable_type.phpt
+++ b/Zend/tests/ctor_promotion_callable_type.phpt
@@ -9,4 +9,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Property Test::$callable cannot have type callable in %s on line %d
+Fatal error: Promoted property Test::$callable cannot be of type callable in %s on line %d

--- a/Zend/tests/ctor_promotion_free_function.phpt
+++ b/Zend/tests/ctor_promotion_free_function.phpt
@@ -7,4 +7,4 @@ function __construct(public $prop) {}
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare promoted property outside a constructor in %s on line %d
+Fatal error: __construct(): Promoted property $prop cannot be declared outside a constructor in %s on line %d

--- a/Zend/tests/ctor_promotion_interface.phpt
+++ b/Zend/tests/ctor_promotion_interface.phpt
@@ -9,4 +9,4 @@ interface Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare promoted property in an abstract constructor in %s on line %d
+Fatal error: Promoted property Test::$x cannot be declared in an abstract constructor in %s on line %d

--- a/Zend/tests/ctor_promotion_not_a_ctor.phpt
+++ b/Zend/tests/ctor_promotion_not_a_ctor.phpt
@@ -9,4 +9,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare promoted property outside a constructor in %s on line %d
+Fatal error: Test::foobar(): Promoted property $x cannot be declared outside a constructor in %s on line %d

--- a/Zend/tests/ctor_promotion_null_default.phpt
+++ b/Zend/tests/ctor_promotion_null_default.phpt
@@ -9,4 +9,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use null as default value for parameter $x of type int in %s on line %d
+Fatal error: Test::__construct(): Parameter #1 ($x) of type int cannot have a default value of type null in %s on line %d

--- a/Zend/tests/ctor_promotion_repeated_prop.phpt
+++ b/Zend/tests/ctor_promotion_repeated_prop.phpt
@@ -11,4 +11,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare Test::$prop in %s on line %d
+Fatal error: Promoted property Test::$prop cannot redeclare standard property in %s on line %d

--- a/Zend/tests/ctor_promotion_variadic.phpt
+++ b/Zend/tests/ctor_promotion_variadic.phpt
@@ -9,4 +9,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare variadic promoted property in %s on line %d
+Fatal error: Variadic promoted property Test::$strings cannot be declared in %s on line %d

--- a/Zend/tests/declare_001.phpt
+++ b/Zend/tests/declare_001.phpt
@@ -20,8 +20,8 @@ print 'DONE';
 
 ?>
 --EXPECTF--
-Warning: Unsupported encoding [1] in %sdeclare_001.php on line %d
+Warning: Encoding "1" is unsupported in %sdeclare_001.php on line %d
 
-Warning: Unsupported encoding [1.1231312321313E+20] in %sdeclare_001.php on line %d
+Warning: Encoding "1.1231312321313E+20" is unsupported in %sdeclare_001.php on line %d
 
 Fatal error: Encoding must be a literal in %s on line %d

--- a/Zend/tests/declare_002.phpt
+++ b/Zend/tests/declare_002.phpt
@@ -20,8 +20,8 @@ print 'DONE';
 
 ?>
 --EXPECTF--
-Warning: Unsupported encoding [%d] in %sdeclare_002.php on line 3
+Warning: Encoding "%d" is unsupported in %sdeclare_002.php on line 3
 
-Warning: Unsupported encoding [%f] in %sdeclare_002.php on line 4
+Warning: Encoding "%f" is unsupported in %sdeclare_002.php on line 4
 
 Fatal error: Encoding must be a literal in %sdeclare_002.php on line 6

--- a/Zend/tests/declare_003.phpt
+++ b/Zend/tests/declare_003.phpt
@@ -14,8 +14,8 @@ print 'DONE';
 
 ?>
 --EXPECTF--
-Warning: Unsupported encoding [1] in %sdeclare_003.php on line %d
+Warning: Encoding "1" is unsupported in %s on line %d
 
-Warning: Unsupported encoding [11111111111111] in %sdeclare_003.php on line %d
+Warning: Encoding "11111111111111" is unsupported in %s on line %d
 
 Fatal error: Encoding must be a literal in %s on line %d

--- a/Zend/tests/declare_004.phpt
+++ b/Zend/tests/declare_004.phpt
@@ -13,8 +13,8 @@ print 'DONE';
 
 ?>
 --EXPECTF--
-Warning: Unsupported encoding [%d] in %sdeclare_004.php on line 3
+Warning: Encoding "1" is unsupported in %s on line %d
 
-Warning: Unsupported encoding [%f] in %sdeclare_004.php on line 4
+Warning: Encoding "%f" is unsupported in %s on line %d
 
 Fatal error: Encoding must be a literal in %sdeclare_004.php on line 5

--- a/Zend/tests/declare_already_in_use.phpt
+++ b/Zend/tests/declare_already_in_use.phpt
@@ -11,4 +11,4 @@ test();
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare class A, because the name is already in use in %s on line %d
+Fatal error: class A cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/dereference_002.phpt
+++ b/Zend/tests/dereference_002.phpt
@@ -78,7 +78,7 @@ NULL
 
 Notice: Undefined array key 3 in %s on line %d
 
-Fatal error: Uncaught Error: Call to a member function bar() on null in %s:%d
+Fatal error: Uncaught Error: Call to method bar() on null in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/duplicate_label_error.phpt
+++ b/Zend/tests/duplicate_label_error.phpt
@@ -9,4 +9,4 @@ goto foo;
 
 ?>
 --EXPECTF--
-Fatal error: Label 'foo' already defined in %s on line %d
+Fatal error: Label foo cannot be redefined in %s on line %d

--- a/Zend/tests/dynamic_call_005.phpt
+++ b/Zend/tests/dynamic_call_005.phpt
@@ -31,6 +31,6 @@ test_calls('extract');
 
 ?>
 --EXPECT--
-Cannot call extract() dynamically
-Cannot call extract() dynamically
-Cannot call extract() dynamically
+extract() cannot be called dynamically
+extract() cannot be called dynamically
+extract() cannot be called dynamically

--- a/Zend/tests/dynamic_call_006.phpt
+++ b/Zend/tests/dynamic_call_006.phpt
@@ -50,9 +50,9 @@ test();
 
 ?>
 --EXPECT--
-Cannot call extract() dynamically
-Cannot call compact() dynamically
-Cannot call get_defined_vars() dynamically
-Cannot call func_get_args() dynamically
-Cannot call func_get_arg() dynamically
-Cannot call func_num_args() dynamically
+extract() cannot be called dynamically
+compact() cannot be called dynamically
+get_defined_vars() cannot be called dynamically
+func_get_args() cannot be called dynamically
+func_get_arg() cannot be called dynamically
+func_num_args() cannot be called dynamically

--- a/Zend/tests/dynamic_call_007.phpt
+++ b/Zend/tests/dynamic_call_007.phpt
@@ -17,5 +17,5 @@ test();
 
 ?>
 --EXPECT--
-Cannot call extract() dynamically
+extract() cannot be called dynamically
 int(2)

--- a/Zend/tests/dynamic_call_008.phpt
+++ b/Zend/tests/dynamic_call_008.phpt
@@ -14,4 +14,4 @@ test();
 
 ?>
 --EXPECT--
-Cannot call extract() dynamically
+extract() cannot be called dynamically

--- a/Zend/tests/errmsg_001.phpt
+++ b/Zend/tests/errmsg_001.phpt
@@ -13,4 +13,4 @@ class Impl extends Test {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Non-abstract method Impl::Foo() must contain body in %s on line %d
+Fatal error: Non-abstract method Impl::Foo() must have a body in %s on line %d

--- a/Zend/tests/errmsg_002.phpt
+++ b/Zend/tests/errmsg_002.phpt
@@ -11,4 +11,4 @@ abstract class test {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Abstract function test::foo() cannot be declared private in %s on line %d
+Fatal error: Abstract method test::foo() must have public or protected visibility in %s on line %d

--- a/Zend/tests/errmsg_011.phpt
+++ b/Zend/tests/errmsg_011.phpt
@@ -13,4 +13,4 @@ class test {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare test::foo() in %s on line %d
+Fatal error: Method test::foo() cannot be redeclared in %s on line %d

--- a/Zend/tests/errmsg_013.phpt
+++ b/Zend/tests/errmsg_013.phpt
@@ -11,4 +11,4 @@ class test {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot use string as default value for parameter $a of type array in %s on line %d
+Fatal error: test::foo(): Parameter #1 ($a) of type array cannot have a default value of type string in %s on line %d

--- a/Zend/tests/errmsg_023.phpt
+++ b/Zend/tests/errmsg_023.phpt
@@ -14,4 +14,4 @@ class test extends test1 {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Access level to test::$var must be protected (as in class test1) or weaker in %s on line %d
+Fatal error: Property test::$var must have protected or public visibility to be compatible with overridden property test1::$var in %s on line %d

--- a/Zend/tests/errmsg_026.phpt
+++ b/Zend/tests/errmsg_026.phpt
@@ -9,4 +9,4 @@ class stdclass {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot declare class stdclass, because the name is already in use in %s on line %d
+Fatal error: class stdclass cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/errmsg_028.phpt
+++ b/Zend/tests/errmsg_028.phpt
@@ -9,4 +9,4 @@ class self {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'self' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "self" as class name as it is reserved in %s on line %d

--- a/Zend/tests/errmsg_029.phpt
+++ b/Zend/tests/errmsg_029.phpt
@@ -9,4 +9,4 @@ class parent {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'parent' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "parent" as class name as it is reserved in %s on line %d

--- a/Zend/tests/errmsg_038.phpt
+++ b/Zend/tests/errmsg_038.phpt
@@ -10,4 +10,4 @@ class test {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot declare property test::$var final, the final modifier is allowed only for methods and classes in %s on line %d
+Fatal error: Property test::$var cannot be declared final, the final modifier is allowed only for methods and classes in %s on line %d

--- a/Zend/tests/errmsg_039.phpt
+++ b/Zend/tests/errmsg_039.phpt
@@ -11,4 +11,4 @@ class test {
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare test::$var in %s on line %d
+Fatal error: Property test::$var cannot be redeclared in %s on line %d

--- a/Zend/tests/errmsg_045.phpt
+++ b/Zend/tests/errmsg_045.phpt
@@ -14,7 +14,7 @@ eval('class A { private function __invoke() { } }');
 
 ?>
 --EXPECTF--
-string(%d) "The magic method A::__invoke() must have public visibility"
+string(%d) "Method A::__invoke() must have public visibility"
 string(%d) "%s(%d) : eval()'d code"
 
 Warning: Undefined variable $undefined in %s on line %d

--- a/Zend/tests/exception_005.phpt
+++ b/Zend/tests/exception_005.phpt
@@ -9,7 +9,7 @@ throw new a();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot instantiate interface a in %s:%d
+Fatal error: Uncaught Error: Interface a cannot be instantiated in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/exception_013.phpt
+++ b/Zend/tests/exception_013.phpt
@@ -29,7 +29,7 @@ var_dump(C::$a);
 --EXPECTF--
 Exception: Access to undeclared static property C::$a in %s on line %d
 
-Exception: Cannot access private property C::$p in %sexception_013.php on line 13
+Exception: Private property C::$p cannot be accessed from the global scope in %s on line %d
 
 Exception: Attempt to unset static property C::$a in %sexception_013.php on line 19
 

--- a/Zend/tests/exception_014.phpt
+++ b/Zend/tests/exception_014.phpt
@@ -16,9 +16,9 @@ try {
 var_dump($x->p);
 ?>
 --EXPECTF--
-Exception: Cannot access private property C::$p in %sexception_014.php on line %d
+Exception: Private property C::$p cannot be accessed from the global scope in %s on line %d
 
-Fatal error: Uncaught Error: Cannot access private property C::$p in %sexception_014.php:%d
+Fatal error: Uncaught Error: Private property C::$p cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sexception_014.php on line %d

--- a/Zend/tests/exception_017.phpt
+++ b/Zend/tests/exception_017.phpt
@@ -24,7 +24,7 @@ try {
 C::foo();
 ?>
 --EXPECTF--
-Error: Cannot call abstract method C::foo() in %s:%d
+Error: Abstract method C::foo() cannot be called in %s:%d
 Stack trace:
 #0 {main}
 
@@ -34,7 +34,7 @@ Stack trace:
 #1 {main}
 
 
-Fatal error: Uncaught Error: Cannot call abstract method C::foo() in %s:%d
+Fatal error: Uncaught Error: Abstract method C::foo() cannot be called in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/function_redecl.phpt
+++ b/Zend/tests/function_redecl.phpt
@@ -6,4 +6,4 @@ function f() {}
 function f() {}
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare f() (previously declared in %s:%d) in %s on line %d
+Fatal error: Function f() cannot be redeclared (previous declaration in %s on line %d

--- a/Zend/tests/generators/errors/generator_extend_error.phpt
+++ b/Zend/tests/generators/errors/generator_extend_error.phpt
@@ -7,4 +7,4 @@ class ExtendedGenerator extends Generator { }
 
 ?>
 --EXPECTF--
-Fatal error: Class ExtendedGenerator may not inherit from final class (Generator) in %s on line %d
+Fatal error: Class ExtendedGenerator cannot extend final class Generator in %s on line %d

--- a/Zend/tests/get_class_vars_002.phpt
+++ b/Zend/tests/get_class_vars_002.phpt
@@ -41,9 +41,9 @@ array(3) {
   int(6)
 }
 
-Warning: Undefined property: C::$b in %s on line %d
+Warning: Undefined property C::$b in %s on line %d
 
-Warning: Undefined property: C::$c in %s on line %d
+Warning: Undefined property C::$c in %s on line %d
 int(1)
 NULL
 NULL

--- a/Zend/tests/grammar/regression_003.phpt
+++ b/Zend/tests/grammar/regression_003.phpt
@@ -10,4 +10,4 @@ class Obj
 
 ?>
 --EXPECTF--
-Fatal error: A class constant must not be called 'class'; it is reserved for class name fetching in %s on line %d
+Fatal error: A class constant must not be called "class"; it is reserved for class name fetching in %s on line %d

--- a/Zend/tests/grandparent_prototype.phpt
+++ b/Zend/tests/grandparent_prototype.phpt
@@ -8,7 +8,7 @@ class A {
 }
 class B extends A {
     public function test2($x) {
-        $x->test(); // Uncaught Error: Call to protected method D::test() from scope B
+        $x->test(); // Uncaught Error: Protected method D::test() cannot be called from the scope of class B
     }
 }
 class C extends A {

--- a/Zend/tests/halt_compiler3.phpt
+++ b/Zend/tests/halt_compiler3.phpt
@@ -5,4 +5,4 @@ __HALT_COMPILER(); bad define() of __COMPILER_HALT_OFFSET__ 1
 define ('__COMPILER_HALT_OFFSET__', 1);
 ?>
 --EXPECTF--
-Notice: Constant __COMPILER_HALT_OFFSET__ already defined in %s on line %d
+Notice: Constant __COMPILER_HALT_OFFSET__ has already been defined in %s on line %d

--- a/Zend/tests/halt_compiler4.phpt
+++ b/Zend/tests/halt_compiler4.phpt
@@ -7,4 +7,4 @@ __HALT_COMPILER();
 ?>
 ==DONE==
 --EXPECTF--
-Notice: Constant __COMPILER_HALT_OFFSET__ already defined in %s on line %d
+Notice: Constant __COMPILER_HALT_OFFSET__ has already been defined in %s on line %d

--- a/Zend/tests/inter_007.phpt
+++ b/Zend/tests/inter_007.phpt
@@ -17,4 +17,4 @@ interface a extends d, w { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot make non static method c::B() static in class d in %s on line 4
+Fatal error: Method d::B() must not be static to be compatible with overridden method c::B() in %s on line %d

--- a/Zend/tests/inter_06.phpt
+++ b/Zend/tests/inter_06.phpt
@@ -7,4 +7,4 @@ interface stdClass { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare interface stdClass, because the name is already in use in %s on line %d
+Fatal error: interface stdClass cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/invalid_parent_const_ref_leak.phpt
+++ b/Zend/tests/invalid_parent_const_ref_leak.phpt
@@ -15,4 +15,4 @@ try {
 
 ?>
 --EXPECT--
-Cannot access "parent" when current class scope has no parent
+"parent" cannot be used when current class scope has no parent

--- a/Zend/tests/jump06.phpt
+++ b/Zend/tests/jump06.phpt
@@ -5,4 +5,4 @@ jump 06: goto to undefined label
 goto L1;
 ?>
 --EXPECTF--
-Fatal error: 'goto' to undefined label 'L1' in %sjump06.php on line 2
+Fatal error: goto to undefined label L1 in %s on line %d

--- a/Zend/tests/jump07.phpt
+++ b/Zend/tests/jump07.phpt
@@ -8,4 +8,4 @@ while (0) {
 goto L1;
 ?>
 --EXPECTF--
-Fatal error: 'goto' into loop or switch statement is disallowed in %sjump07.php on line 5
+Fatal error: goto into a loop or switch statement is disallowed in %s on line %d

--- a/Zend/tests/jump08.phpt
+++ b/Zend/tests/jump08.phpt
@@ -8,4 +8,4 @@ while (0) {
 }
 ?>
 --EXPECTF--
-Fatal error: 'goto' into loop or switch statement is disallowed in %sjump08.php on line 2
+Fatal error: goto into a loop or switch statement is disallowed in %s on line %d

--- a/Zend/tests/jump09.phpt
+++ b/Zend/tests/jump09.phpt
@@ -10,4 +10,4 @@ switch (0) {
 goto L1;
 ?>
 --EXPECTF--
-Fatal error: 'goto' into loop or switch statement is disallowed in %sjump09.php on line 7
+Fatal error: goto into a loop or switch statement is disallowed in %s on line %d

--- a/Zend/tests/jump10.phpt
+++ b/Zend/tests/jump10.phpt
@@ -10,4 +10,4 @@ switch (0) {
 }
 ?>
 --EXPECTF--
-Fatal error: 'goto' into loop or switch statement is disallowed in %sjump10.php on line 2
+Fatal error: goto into a loop or switch statement is disallowed in %s on line %d

--- a/Zend/tests/magic_methods_002.phpt
+++ b/Zend/tests/magic_methods_002.phpt
@@ -11,4 +11,4 @@ class foo {
 
 ?>
 --EXPECTF--
-Warning: The magic method foo::__unset() must have public visibility in %s on line %d
+Warning: Method foo::__unset() must have public visibility in %s on line %d

--- a/Zend/tests/magic_methods_004.phpt
+++ b/Zend/tests/magic_methods_004.phpt
@@ -11,4 +11,4 @@ class foo {
 
 ?>
 --EXPECTF--
-Warning: The magic method foo::__unset() must have public visibility in %s on line %d
+Warning: Method foo::__unset() must have public visibility in %s on line %d

--- a/Zend/tests/magic_methods_008.phpt
+++ b/Zend/tests/magic_methods_008.phpt
@@ -14,6 +14,6 @@ class a extends b {
 
 ?>
 --EXPECTF--
-Warning: The magic method a::__set() must have public visibility in %s on line %d
+Warning: Method a::__set() must have public visibility in %s on line %d
 
-Fatal error: Access level to a::__set() must be public (as in class b) in %s on line 8
+Fatal error: Method a::__set() must have public visibility to be compatible with overridden method b::__set() in %s on line %d

--- a/Zend/tests/magic_methods_009.phpt
+++ b/Zend/tests/magic_methods_009.phpt
@@ -10,4 +10,4 @@ class a {
 
 ?>
 --EXPECTF--
-Warning: The magic method a::__callstatic() must have public visibility in %s on line %d
+Warning: Method a::__callstatic() must have public visibility in %s on line %d

--- a/Zend/tests/methods-on-non-objects-call-user-func.phpt
+++ b/Zend/tests/methods-on-non-objects-call-user-func.phpt
@@ -1,5 +1,5 @@
 --TEST--
-call_user_func() in combination with "Call to a member function method() on a non-object"
+call_user_func() in combination with "Call to method method() on a non-object"
 --FILE--
 <?php
 $comparator = null;

--- a/Zend/tests/methods-on-non-objects-catch.phpt
+++ b/Zend/tests/methods-on-non-objects-catch.phpt
@@ -14,7 +14,7 @@ try {
 }
 echo "Alive\n";
 ?>
---EXPECTF--
+--EXPECT--
 int(0)
-string(%d) "Call to a member function method() on null"
+string(31) "Call to method method() on null"
 Alive

--- a/Zend/tests/methods-on-non-objects-usort.phpt
+++ b/Zend/tests/methods-on-non-objects-usort.phpt
@@ -1,5 +1,5 @@
 --TEST--
-usort() in combination with "Call to a member function method() on null"
+usort() in combination with "Call to method method() on null"
 --FILE--
 <?php
 set_error_handler(function($code, $message) {
@@ -21,13 +21,13 @@ echo "Alive\n";
 ?>
 --EXPECT--
 int(0)
-string(43) "Call to a member function compare() on null"
+string(32) "Call to method compare() on null"
 int(0)
-string(43) "Call to a member function compare() on null"
+string(32) "Call to method compare() on null"
 int(0)
-string(43) "Call to a member function compare() on null"
+string(32) "Call to method compare() on null"
 int(0)
-string(43) "Call to a member function compare() on null"
+string(32) "Call to method compare() on null"
 array(5) {
   [0]=>
   int(1)

--- a/Zend/tests/methods-on-non-objects.phpt
+++ b/Zend/tests/methods-on-non-objects.phpt
@@ -8,7 +8,7 @@ $x->method();
 echo "Should not get here!\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to a member function method() on null in %s:%d
+Fatal error: Uncaught Error: Call to method method() on null in %s:%d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d 
+  thrown in %s on line %d

--- a/Zend/tests/name_collision_01.phpt
+++ b/Zend/tests/name_collision_01.phpt
@@ -8,4 +8,4 @@ class A { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare class A, because the name is already in use in %s on line %d
+Fatal error: class A cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/name_collision_02.phpt
+++ b/Zend/tests/name_collision_02.phpt
@@ -8,4 +8,4 @@ interface A { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare interface A, because the name is already in use in %s on line %d
+Fatal error: interface A cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/name_collision_03.phpt
+++ b/Zend/tests/name_collision_03.phpt
@@ -8,4 +8,4 @@ trait A { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare trait A, because the name is already in use in %s on line %d
+Fatal error: trait A cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/name_collision_04.phpt
+++ b/Zend/tests/name_collision_04.phpt
@@ -8,4 +8,4 @@ interface A { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare interface A, because the name is already in use in %s on line %d
+Fatal error: interface A cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/name_collision_05.phpt
+++ b/Zend/tests/name_collision_05.phpt
@@ -8,4 +8,4 @@ trait A { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare trait A, because the name is already in use in %s on line %d
+Fatal error: trait A cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/name_collision_06.phpt
+++ b/Zend/tests/name_collision_06.phpt
@@ -8,4 +8,4 @@ trait A { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare trait A, because the name is already in use in %s on line %d
+Fatal error: trait A cannot be declared, because the name is already in use in %s on line %d

--- a/Zend/tests/name_collision_07.phpt
+++ b/Zend/tests/name_collision_07.phpt
@@ -12,4 +12,4 @@ namespace Bazzle {
     class Bar {}
 }
 --EXPECTF--
-Fatal error: Cannot declare class Bazzle\Bar because the name is already in use in %s on line %d
+Fatal error: Class Bazzle\Bar cannot be declared because the name is already in use in %s on line %d

--- a/Zend/tests/name_collision_08.phpt
+++ b/Zend/tests/name_collision_08.phpt
@@ -12,4 +12,4 @@ namespace Bazzle {
     function bar() {}
 }
 --EXPECTF--
-Fatal error: Cannot declare function Bazzle\bar because the name is already in use in %s on line %d
+Fatal error: Function Bazzle\bar() cannot be declared because the name is already in use in %s on line %d

--- a/Zend/tests/name_collision_09.phpt
+++ b/Zend/tests/name_collision_09.phpt
@@ -12,4 +12,4 @@ namespace Bazzle {
     const BAR = 24;
 }
 --EXPECTF--
-Fatal error: Cannot declare const Bazzle\BAR because the name is already in use in %s on line %d
+Fatal error: Constant Bazzle\BAR cannot be declared because the name is already in use in %s on line %d

--- a/Zend/tests/ns_029.phpt
+++ b/Zend/tests/ns_029.phpt
@@ -9,4 +9,4 @@ class Foo {
 
 new Foo();
 --EXPECTF--
-Fatal error: Cannot declare class Foo because the name is already in use in %sns_029.php on line 4
+Fatal error: Class Foo cannot be declared because the name is already in use in %s on line %d

--- a/Zend/tests/ns_033.phpt
+++ b/Zend/tests/ns_033.phpt
@@ -5,6 +5,6 @@
 use A;
 use \B;
 --EXPECTF--
-Warning: The use statement with non-compound name 'A' has no effect in %sns_033.php on line 2
+Warning: The use statement with non-compound name A has no effect in %s on line %d
 
-Warning: The use statement with non-compound name 'B' has no effect in %sns_033.php on line 3
+Warning: The use statement with non-compound name B has no effect in %s on line %d

--- a/Zend/tests/ns_075.phpt
+++ b/Zend/tests/ns_075.phpt
@@ -7,4 +7,4 @@ const NULL = 1;
 
 echo NULL;
 --EXPECTF--
-Fatal error: Cannot redeclare constant 'NULL' in %sns_075.php on line %d
+Fatal error: Constant NULL cannot be redeclared in %s on line %d

--- a/Zend/tests/object_types/invalid_default_value.phpt
+++ b/Zend/tests/object_types/invalid_default_value.phpt
@@ -7,4 +7,4 @@ function test(object $obj = 42) { }
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use int as default value for parameter $obj of type object in %s on line %d
+Fatal error: test(): Parameter #1 ($obj) of type object cannot have a default value of type int in %s on line %d

--- a/Zend/tests/objects_017.phpt
+++ b/Zend/tests/objects_017.phpt
@@ -15,7 +15,7 @@ test()->test = 2;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access private property foo::$test in %s:%d
+Fatal error: Uncaught Error: Private property foo::$test cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/property_access_errors_for_guarded_properties.phpt
+++ b/Zend/tests/property_access_errors_for_guarded_properties.phpt
@@ -50,6 +50,6 @@ try {
 
 ?>
 --EXPECT--
-Cannot access private property Test::$prop
-Cannot access private property Test::$prop
-Cannot access private property Test::$prop
+Private property Test::$prop cannot be accessed from the global scope
+Private property Test::$prop cannot be accessed from the global scope
+Private property Test::$prop cannot be accessed from the global scope

--- a/Zend/tests/required_param_after_optional.phpt
+++ b/Zend/tests/required_param_after_optional.phpt
@@ -9,6 +9,6 @@ function test3(Type $test3A = null, Type2 $test3B = null, $test3C) {}
 
 ?>
 --EXPECTF--
-Deprecated: Required parameter $testC follows optional parameter $testA in %s on line %d
+Deprecated: Required parameter $testC should precede optional parameter $testA in %s on line %d
 
-Deprecated: Required parameter $test2C follows optional parameter $test2B in %s on line %d
+Deprecated: Required parameter $test2C should precede optional parameter $test2B in %s on line %d

--- a/Zend/tests/return_types/024.phpt
+++ b/Zend/tests/return_types/024.phpt
@@ -5,4 +5,4 @@ Return type of self is not allowed in function
 
 function test(): self {}
 --EXPECTF--
-Fatal error: Cannot use "self" when no class scope is active in %s on line 3
+Fatal error: "self" cannot be used in the global scope in %s on line %d

--- a/Zend/tests/return_types/026.phpt
+++ b/Zend/tests/return_types/026.phpt
@@ -5,4 +5,4 @@ Return type of parent is not allowed in function
 
 function test(): parent {}
 --EXPECTF--
-Fatal error: Cannot use "parent" when no class scope is active in %s on line %d
+Fatal error: "parent" cannot be used in the global scope in %s on line %d

--- a/Zend/tests/return_types/generators002.phpt
+++ b/Zend/tests/return_types/generators002.phpt
@@ -6,4 +6,4 @@ function test1() : StdClass {
     yield 1;
 }
 --EXPECTF--
-Fatal error: Generator return type must be a supertype of Generator, StdClass given in %s on line %d
+Fatal error: Generator return type must be a supertype of Generator, StdClass returned in %s on line %d

--- a/Zend/tests/return_types/generators006.phpt
+++ b/Zend/tests/return_types/generators006.phpt
@@ -6,4 +6,4 @@ function test1() : StdClass|ArrayObject|array {
     yield 1;
 }
 --EXPECTF--
-Fatal error: Generator return type must be a supertype of Generator, StdClass|ArrayObject|array given in %s on line %d
+Fatal error: Generator return type must be a supertype of Generator, StdClass|ArrayObject|array returned in %s on line %d

--- a/Zend/tests/return_types/void_disallowed1.phpt
+++ b/Zend/tests/return_types/void_disallowed1.phpt
@@ -9,4 +9,4 @@ function foo(): void {
 
 // Note the lack of function call: function validated at compile-time
 --EXPECTF--
-Fatal error: A void function must not return a value (did you mean "return;" instead of "return null;"?) in %s on line %d
+Fatal error: Function foo() with return type void must not return a value (did you mean "return;" instead of "return null;"?) in %s on line %d

--- a/Zend/tests/return_types/void_disallowed2.phpt
+++ b/Zend/tests/return_types/void_disallowed2.phpt
@@ -9,4 +9,4 @@ function foo(): void {
 
 // Note the lack of function call: function validated at compile-time
 --EXPECTF--
-Fatal error: A void function must not return a value in %s on line %d
+Fatal error: Function foo() with return type void must not return a value in %s on line %d

--- a/Zend/tests/return_types/void_parameter.phpt
+++ b/Zend/tests/return_types/void_parameter.phpt
@@ -4,5 +4,7 @@ void return type: not valid as a parameter type
 <?php
 
 function foobar(void $a) {}
+
+?>
 --EXPECTF--
-Fatal error: void cannot be used as a parameter type in %s on line %d
+Fatal error: foobar(): Parameter #1 ($a) cannot be of type void in %s on line %d

--- a/Zend/tests/self_class_const_in_unknown_scope.phpt
+++ b/Zend/tests/self_class_const_in_unknown_scope.phpt
@@ -20,7 +20,7 @@ var_dump(BAR);
 --EXPECTF--
 string(4) "Test"
 
-Fatal error: Uncaught Error: Cannot use "self" when no class scope is active in %s:%d
+Fatal error: Uncaught Error: "self" cannot be used in the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/self_class_const_outside_class.phpt
+++ b/Zend/tests/self_class_const_outside_class.phpt
@@ -7,4 +7,4 @@ function test() {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use "self" when no class scope is active in %s on line %d
+Fatal error: "self" cannot be used in the global scope in %s on line %d

--- a/Zend/tests/self_instanceof_outside_class.phpt
+++ b/Zend/tests/self_instanceof_outside_class.phpt
@@ -14,4 +14,4 @@ $fn();
 
 ?>
 --EXPECT--
-Cannot access "self" when no class scope is active
+"self" cannot be used in the global scope

--- a/Zend/tests/self_method_or_prop_outside_class.phpt
+++ b/Zend/tests/self_method_or_prop_outside_class.phpt
@@ -30,7 +30,7 @@ $fn();
 
 ?>
 --EXPECT--
-Cannot access "self" when no class scope is active
-Cannot access "self" when no class scope is active
-Cannot access "self" when no class scope is active
-Cannot access "self" when no class scope is active
+"self" cannot be used in the global scope
+"self" cannot be used in the global scope
+"self" cannot be used in the global scope
+"self" cannot be used in the global scope

--- a/Zend/tests/special_name_error1.phpt
+++ b/Zend/tests/special_name_error1.phpt
@@ -7,4 +7,4 @@ namespace self;
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'self' as namespace name in %s on line %d
+Fatal error: "self" cannot be used as namespace name in %s on line %d

--- a/Zend/tests/special_name_error3.phpt
+++ b/Zend/tests/special_name_error3.phpt
@@ -7,4 +7,4 @@ trait self {}
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'self' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "self" as class name as it is reserved in %s on line %d

--- a/Zend/tests/strict_002.phpt
+++ b/Zend/tests/strict_002.phpt
@@ -19,7 +19,7 @@ var_dump($t);
 echo "Done\n";
 ?>
 --EXPECTF--
-Notice: Accessing static property test::$foo as non static in %s on line %d
+Notice: Accessing static property test::$foo as non-static in %s on line %d
 object(test)#%d (1) {
   ["foo"]=>
   int(5)

--- a/Zend/tests/this_as_parameter.phpt
+++ b/Zend/tests/this_as_parameter.phpt
@@ -8,4 +8,4 @@ function foo($this) {
 foo(5);
 ?>
 --EXPECTF--
-Fatal error: Cannot use $this as parameter in %sthis_as_parameter.php on line 2
+Fatal error: foo(): Parameter #1 cannot be called $this in %sthis_as_parameter.php on line 2

--- a/Zend/tests/traits/abstract_method_5.phpt
+++ b/Zend/tests/traits/abstract_method_5.phpt
@@ -15,4 +15,4 @@ class C {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot make static method T::method() non static in class C in %s on line %d
+Fatal error: Method C::method() must be static to be compatible with overridden method T::method() in %s on line %d

--- a/Zend/tests/traits/bug60173.phpt
+++ b/Zend/tests/traits/bug60173.phpt
@@ -8,7 +8,7 @@ trait foo { }
 $rc = new ReflectionClass('foo');
 $rc->newInstance();
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot instantiate trait foo in %s:%d
+Fatal error: Uncaught Error: Trait foo cannot be instantiated in %s:%d
 Stack trace:
 #0 %s(%d): ReflectionClass->newInstance()
 #1 {main}

--- a/Zend/tests/traits/bug64235.phpt
+++ b/Zend/tests/traits/bug64235.phpt
@@ -31,4 +31,4 @@ class TestChildClass extends TestParentClass
 }
 ?>
 --EXPECTF--
-Fatal error: Class TestParentClass is not a trait, Only traits may be used in 'as' and 'insteadof' statements in %sbug64235.php on line %d
+Fatal error: Class TestParentClass is not a trait, only traits may be used in "as" and "insteadof" statements in %s on line %d

--- a/Zend/tests/traits/bug64235b.phpt
+++ b/Zend/tests/traits/bug64235b.phpt
@@ -32,4 +32,4 @@ class TestChildClass extends TestParentClass
 
 ?>
 --EXPECTF--
-Fatal error: Class TestParentClass is not a trait, Only traits may be used in 'as' and 'insteadof' statements in %sbug64235b.php on line %d
+Fatal error: Class TestParentClass is not a trait, only traits may be used in "as" and "insteadof" statements in %s on line %d

--- a/Zend/tests/traits/error_001.phpt
+++ b/Zend/tests/traits/error_001.phpt
@@ -25,4 +25,4 @@ class A extends foo {
 
 ?>
 --EXPECTF--
-Fatal error: Class A cannot extend from trait foo in %s on line %d
+Fatal error: Class A cannot extend trait foo in %s on line %d

--- a/Zend/tests/traits/error_007.phpt
+++ b/Zend/tests/traits/error_007.phpt
@@ -10,7 +10,7 @@ new abc;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot instantiate trait abc in %s:%d
+Fatal error: Uncaught Error: Trait abc cannot be instantiated in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/error_009.phpt
+++ b/Zend/tests/traits/error_009.phpt
@@ -9,4 +9,4 @@ class foo extends abc { }
 
 ?>
 --EXPECTF--
-Fatal error: Class foo cannot extend from trait abc in %s on line %d
+Fatal error: Class foo cannot extend trait abc in %s on line %d

--- a/Zend/tests/traits/error_012.phpt
+++ b/Zend/tests/traits/error_012.phpt
@@ -16,7 +16,7 @@ var_dump($x->test());
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to protected method bar::test() from global scope in %s:%d
+Fatal error: Uncaught Error: Protected method bar::test() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/error_013.phpt
+++ b/Zend/tests/traits/error_013.phpt
@@ -16,4 +16,4 @@ var_dump($x->test());
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'static' as method modifier in %s on line %d
+Fatal error: Cannot use "static" as method modifier in %s on line %d

--- a/Zend/tests/traits/error_014.phpt
+++ b/Zend/tests/traits/error_014.phpt
@@ -20,4 +20,4 @@ var_dump($x->test());
 
 ?>
 --EXPECTF--
-Fatal error: Cannot override final method baz::test() in %s on line %d
+Fatal error: Method foo::test() cannot override final method baz::test() in %s on line %d

--- a/Zend/tests/traits/language008a.phpt
+++ b/Zend/tests/traits/language008a.phpt
@@ -20,7 +20,7 @@ $o->sayHello();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to protected method MyClass::sayHello() from global scope in %s:%d
+Fatal error: Uncaught Error: Protected method MyClass::sayHello() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/language008b.phpt
+++ b/Zend/tests/traits/language008b.phpt
@@ -27,7 +27,7 @@ $o->sayHelloWorld();
 ?>
 --EXPECTF--
 Hello World!Hello World!
-Fatal error: Uncaught Error: Call to private method MyClass::sayHelloWorld() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method MyClass::sayHelloWorld() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/traits/language015.phpt
+++ b/Zend/tests/traits/language015.phpt
@@ -14,4 +14,4 @@ class C {
     }
 }
 --EXPECTF--
-Fatal error: Required Trait T2 wasn't added to C in %slanguage015.php on line %d
+Fatal error: Required trait T2 wasn't added to C in %s on line %d

--- a/Zend/tests/traits/language016.phpt
+++ b/Zend/tests/traits/language016.phpt
@@ -14,4 +14,4 @@ class C {
     }
 }
 --EXPECTF--
-Fatal error: Required Trait T2 wasn't added to C in %slanguage016.php on line %d
+Fatal error: Required trait T2 wasn't added to C in %s on line %d

--- a/Zend/tests/traits/language017.phpt
+++ b/Zend/tests/traits/language017.phpt
@@ -14,4 +14,4 @@ class C {
     }
 }
 --EXPECTF--
-Fatal error: Required Trait T2 wasn't added to C in %slanguage017.php on line %d
+Fatal error: Required trait T2 wasn't added to C in %s on line %d

--- a/Zend/tests/traits/language018.phpt
+++ b/Zend/tests/traits/language018.phpt
@@ -12,4 +12,4 @@ class C1 {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'abstract' as method modifier in %s on line %d
+Fatal error: Cannot use "abstract" as method modifier in %s on line %d

--- a/Zend/tests/traits/language019.phpt
+++ b/Zend/tests/traits/language019.phpt
@@ -12,4 +12,4 @@ class C1 {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'final' as method modifier in %s on line %d
+Fatal error: Cannot use "final" as method modifier in %s on line %d

--- a/Zend/tests/try/try_finally_011.phpt
+++ b/Zend/tests/try/try_finally_011.phpt
@@ -12,4 +12,4 @@ function foo () {
 foo();
 ?>
 --EXPECTF--
-Fatal error: 'break' not in the 'loop' or 'switch' context in %stry_finally_011.php on line %d
+Fatal error: break statement can only be used inside a loop or a switch statement in %s on line %d

--- a/Zend/tests/type_declarations/confusable_type_warning.phpt
+++ b/Zend/tests/type_declarations/confusable_type_warning.phpt
@@ -39,7 +39,7 @@ Warning: "double" will be interpreted as a class name. Did you mean "float"? Wri
 
 Warning: "boolean" will be interpreted as a class name. Did you mean "bool"? Write "\boolean" to suppress this warning in %s on line %d
 
-Warning: "resource" is not a supported builtin type and will be interpreted as a class name. Write "\resource" to suppress this warning in %s on line %d
+Warning: "resource" is not a supported built-in type and will be interpreted as a class name. Write "\resource" to suppress this warning in %s on line %d
 
 Warning: "boolean" will be interpreted as a class name. Did you mean "bool"? Write "\Foo\boolean" or import the class with "use" to suppress this warning in %s on line %d
 

--- a/Zend/tests/type_declarations/iterable_002.phpt
+++ b/Zend/tests/type_declarations/iterable_002.phpt
@@ -17,4 +17,4 @@ function baz(iterable $iterable = 1) {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use int as default value for parameter $iterable of type iterable in %s on line %d
+Fatal error: baz(): Parameter #1 ($iterable) of type iterable cannot have a default value of type int in %s on line %d

--- a/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error1.phpt
+++ b/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error1.phpt
@@ -15,4 +15,4 @@ class Bar extends Foo
 
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$property1 must be mixed (as in class Foo) in %s on line %d
+Fatal error: Property Bar::$property1 must be of type mixed to be compatible with overridden property Foo::$property1 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error2.phpt
+++ b/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error2.phpt
@@ -15,4 +15,4 @@ class Bar extends Foo
 
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$property1 must be mixed (as in class Foo) in %s on line %d
+Fatal error: Property Bar::$property1 must be of type mixed to be compatible with overridden property Foo::$property1 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error3.phpt
+++ b/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error3.phpt
@@ -15,4 +15,4 @@ class Bar extends Foo
 
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$property1 must be mixed (as in class Foo) in %s on line %d
+Fatal error: Property Bar::$property1 must be of type mixed to be compatible with overridden property Foo::$property1 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error4.phpt
+++ b/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error4.phpt
@@ -15,4 +15,4 @@ class Bar extends Foo
 
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$property1 must be mixed (as in class Foo) in %s on line %d
+Fatal error: Property Bar::$property1 must be of type mixed to be compatible with overridden property Foo::$property1 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error5.phpt
+++ b/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error5.phpt
@@ -15,4 +15,4 @@ class Bar extends Foo
 
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$property1 must be int (as in class Foo) in %s on line %d
+Fatal error: Property Bar::$property1 must be of type int to be compatible with overridden property Foo::$property1 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error6.phpt
+++ b/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error6.phpt
@@ -15,4 +15,4 @@ class Bar extends Foo
 
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$property1 must be stdClass (as in class Foo) in %s on line %d
+Fatal error: Property Bar::$property1 must be of type stdClass to be compatible with overridden property Foo::$property1 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error7.phpt
+++ b/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error7.phpt
@@ -15,4 +15,4 @@ class Bar extends Foo
 
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$property1 must not be defined (as in class Foo) in %s on line %d
+Fatal error: Property Bar::$property1 must not have a type to be compatible with overridden property Foo::$property1 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error8.phpt
+++ b/Zend/tests/type_declarations/mixed/inheritance/mixed_property_inheritance_error8.phpt
@@ -15,4 +15,4 @@ class Bar extends Foo
 
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$property1 must be object|array|string|int|float|bool|null (as in class Foo) in %s on line %d
+Fatal error: Property Bar::$property1 must be of type object|array|string|int|float|bool|null to be compatible with overridden property Foo::$property1 in %s on line %d

--- a/Zend/tests/type_declarations/mixed/syntax/mixed_class_error.phpt
+++ b/Zend/tests/type_declarations/mixed/syntax/mixed_class_error.phpt
@@ -9,4 +9,4 @@ class mixed
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'mixed' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "mixed" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/nullable_typed_return_without_value.phpt
+++ b/Zend/tests/type_declarations/nullable_typed_return_without_value.phpt
@@ -11,4 +11,4 @@ test();
 
 ?>
 --EXPECTF--
-Fatal error: A function with return type must return a value (did you mean "return null;" instead of "return;"?) in %s on line %d
+Fatal error: Function test() with return type ?int must return a value (did you mean "return null;" instead of "return;"?) in %s on line %d

--- a/Zend/tests/type_declarations/scalar_float_with_invalid_default.phpt
+++ b/Zend/tests/type_declarations/scalar_float_with_invalid_default.phpt
@@ -12,4 +12,4 @@ test();
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use bool as default value for parameter $arg of type float in %s on line %d
+Fatal error: test(): Parameter #1 ($arg) of type float cannot have a default value of type bool in %s on line %d

--- a/Zend/tests/type_declarations/scalar_relative_typehint_disallowed.phpt
+++ b/Zend/tests/type_declarations/scalar_relative_typehint_disallowed.phpt
@@ -11,4 +11,4 @@ foo(10);
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'bar\int' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "bar\int" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved2.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved2.phpt
@@ -5,4 +5,4 @@ Scalar type names cannot be used as class, trait or interface names (2)
 
 class int {}
 --EXPECTF--
-Fatal error: Cannot use 'int' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "int" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved2_class_alias.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved2_class_alias.phpt
@@ -6,4 +6,4 @@ Scalar type names cannot be used as class, trait or interface names (2) - class_
 class foobar {}
 class_alias("foobar", "int");
 --EXPECTF--
-Fatal error: Cannot use 'int' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "int" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved3.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved3.phpt
@@ -5,4 +5,4 @@ Scalar type names cannot be used as class, trait or interface names (3)
 
 class float {}
 --EXPECTF--
-Fatal error: Cannot use 'float' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "float" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved3_class_alias.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved3_class_alias.phpt
@@ -6,4 +6,4 @@ Scalar type names cannot be used as class, trait or interface names (3) - class_
 class foobar {}
 class_alias("foobar", "float");
 --EXPECTF--
-Fatal error: Cannot use 'float' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "float" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved4.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved4.phpt
@@ -5,4 +5,4 @@ Scalar type names cannot be used as class, trait or interface names (4)
 
 class string {}
 --EXPECTF--
-Fatal error: Cannot use 'string' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "string" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved4_class_alias.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved4_class_alias.phpt
@@ -6,4 +6,4 @@ Scalar type names cannot be used as class, trait or interface names (4) - class_
 class foobar {}
 class_alias("foobar", "string");
 --EXPECTF--
-Fatal error: Cannot use 'string' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "string" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved6.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved6.phpt
@@ -5,4 +5,4 @@ Scalar type names cannot be used as class, trait or interface names (6)
 
 class bool {}
 --EXPECTF--
-Fatal error: Cannot use 'bool' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "bool" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved6_class_alias.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved6_class_alias.phpt
@@ -6,4 +6,4 @@ Scalar type names cannot be used as class, trait or interface names (6) - class_
 class foobar {}
 class_alias("foobar", "bool");
 --EXPECTF--
-Fatal error: Cannot use 'bool' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "bool" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/scalar_reserved7.phpt
+++ b/Zend/tests/type_declarations/scalar_reserved7.phpt
@@ -6,4 +6,4 @@ namespace foo;
 
 class int {}
 --EXPECTF--
-Fatal error: Cannot use 'int' as class name as it is reserved in %s on line %d
+Fatal error: Cannot use "int" as class name as it is reserved in %s on line %d

--- a/Zend/tests/type_declarations/static_type_outside_class.phpt
+++ b/Zend/tests/type_declarations/static_type_outside_class.phpt
@@ -7,4 +7,4 @@ function test(): static {}
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use "static" when no class scope is active in %s on line %d
+Fatal error: "static" cannot be used in the global scope in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_006.phpt
+++ b/Zend/tests/type_declarations/typed_properties_006.phpt
@@ -11,4 +11,4 @@ class Bar extends Foo {
 }
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$qux must be int (as in class Foo) in %s on line 8
+Fatal error: Property Bar::$qux must be of type int to be compatible with overridden property Foo::$qux in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_007.phpt
+++ b/Zend/tests/type_declarations/typed_properties_007.phpt
@@ -14,4 +14,4 @@ class Bar extends Foo {
 }
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$qux must be Whatever (as in class Foo) in %s on line 11
+Fatal error: Property Bar::$qux must be of type Whatever to be compatible with overridden property Foo::$qux in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_008.phpt
+++ b/Zend/tests/type_declarations/typed_properties_008.phpt
@@ -11,4 +11,4 @@ class Bar extends Foo {
 }
 ?>
 --EXPECTF--
-Fatal error: Type of Bar::$qux must be int (as in class Foo) in %s on line 8
+Fatal error: Property Bar::$qux must be of type int to be compatible with overridden property Foo::$qux in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_013.phpt
+++ b/Zend/tests/type_declarations/typed_properties_013.phpt
@@ -7,4 +7,4 @@ class Foo {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use string as default value for property Foo::$bar of type int in %s on line 3
+Fatal error: Property Foo::$bar of type int cannot have a default value of type string in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_014.phpt
+++ b/Zend/tests/type_declarations/typed_properties_014.phpt
@@ -7,4 +7,4 @@ class Foo {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use int as default value for property Foo::$bar of type array in %s on line 3
+Fatal error: Property Foo::$bar of type array cannot have a default value of type int in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_015.phpt
+++ b/Zend/tests/type_declarations/typed_properties_015.phpt
@@ -7,4 +7,4 @@ class Foo {
 }
 ?>
 --EXPECTF--
-Fatal error: Default value for property of type stdClass may not be null. Use the nullable type ?stdClass to allow null default value in %s on line %d
+Fatal error: Property Foo:$bar of type stdClass cannot have a default value of null. Use the nullable type ?stdClass to allow a null default value in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_017.phpt
+++ b/Zend/tests/type_declarations/typed_properties_017.phpt
@@ -9,4 +9,4 @@ class Foo {
 $foo = new Foo();
 ?>
 --EXPECTF--
-Fatal error: Property Foo::$int cannot have type void in %s on line 3
+Fatal error: Property Foo::$int cannot be of type void in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_035.phpt
+++ b/Zend/tests/type_declarations/typed_properties_035.phpt
@@ -10,4 +10,4 @@ class Baz extends Foo{
     public int $bar = 33;
 }
 --EXPECTF--
-Fatal error: Type of Baz::$bar must not be defined (as in class Foo) in %s on line 8
+Fatal error: Property Baz::$bar must not have a type to be compatible with overridden property Foo::$bar in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_049.phpt
+++ b/Zend/tests/type_declarations/typed_properties_049.phpt
@@ -7,4 +7,4 @@ class Foo {
 }
 ?>
 --EXPECTF--
-Fatal error: Default value for property of type int may not be null. Use the nullable type ?int to allow null default value in %s on line %d
+Fatal error: Property Foo:$foo of type int cannot have a default value of null. Use the nullable type ?int to allow a null default value in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_053.phpt
+++ b/Zend/tests/type_declarations/typed_properties_053.phpt
@@ -9,4 +9,4 @@ $obj = new A;
 var_dump($obj);
 ?>
 --EXPECTF--
-Fatal error: Property A::$a cannot have type callable in %s on line %d
+Fatal error: Property A::$a cannot be of type callable in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_054.phpt
+++ b/Zend/tests/type_declarations/typed_properties_054.phpt
@@ -9,4 +9,4 @@ $obj = new A;
 var_dump($obj);
 ?>
 --EXPECTF--
-Fatal error: Property A::$a cannot have type ?callable in %s on line %d
+Fatal error: Property A::$a cannot be of type ?callable in %s on line %d

--- a/Zend/tests/type_declarations/typed_properties_103.phpt
+++ b/Zend/tests/type_declarations/typed_properties_103.phpt
@@ -15,7 +15,7 @@ function foo() {
 foo();
 ?>
 --EXPECTF--
-Warning: Undefined property: C::$a in %s on line %d
+Warning: Undefined property C::$a in %s on line %d
 object(C)#1 (1) {
   ["a"]=>
   int(2)

--- a/Zend/tests/type_declarations/typed_properties_protected_inheritance_mismatch.phpt
+++ b/Zend/tests/type_declarations/typed_properties_protected_inheritance_mismatch.phpt
@@ -8,4 +8,4 @@ class B extends A { protected $x; }
 
 ?>
 --EXPECTF--
-Fatal error: Type of B::$x must be int (as in class A) in %s on line %d
+Fatal error: Property B::$x must be of type int to be compatible with overridden property A::$x in %s on line %d

--- a/Zend/tests/type_declarations/typed_return_without_value.phpt
+++ b/Zend/tests/type_declarations/typed_return_without_value.phpt
@@ -11,4 +11,4 @@ test();
 
 ?>
 --EXPECTF--
-Fatal error: A function with return type must return a value in %s on line %d
+Fatal error: Function test() with return type int must return a value in %s on line %d

--- a/Zend/tests/type_declarations/union_types/illegal_default_value_argument.phpt
+++ b/Zend/tests/type_declarations/union_types/illegal_default_value_argument.phpt
@@ -8,4 +8,4 @@ function test(int|float $arg = "0") {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use string as default value for parameter $arg of type int|float in %s on line %d
+Fatal error: test(): Parameter #1 ($arg) of type int|float cannot have a default value of type string in %s on line %d

--- a/Zend/tests/type_declarations/union_types/illegal_default_value_property.phpt
+++ b/Zend/tests/type_declarations/union_types/illegal_default_value_property.phpt
@@ -9,4 +9,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use string as default value for property Test::$prop of type int|float in %s on line %d
+Fatal error: Property Test::$prop of type int|float cannot have a default value of type string in %s on line %d

--- a/Zend/tests/type_declarations/union_types/variance/invalid_004.phpt
+++ b/Zend/tests/type_declarations/union_types/variance/invalid_004.phpt
@@ -10,4 +10,4 @@ class B extends A {
 }
 ?>
 --EXPECTF--
-Fatal error: Type of B::$prop must be X|B (as in class A) in %s on line %d
+Fatal error: Property B::$prop must be of type X|B to be compatible with overridden property A::$prop in %s on line %d

--- a/Zend/tests/type_declarations/variance/parent_in_class_failure1.phpt
+++ b/Zend/tests/type_declarations/variance/parent_in_class_failure1.phpt
@@ -13,4 +13,4 @@ class B extends A {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use "parent" when current class scope has no parent in %s on line %d
+Fatal error: "parent" cannot be used when current class scope has no parent in %s on line %d

--- a/Zend/tests/typehints/bug76198.phpt
+++ b/Zend/tests/typehints/bug76198.phpt
@@ -10,4 +10,4 @@ var_dump(foo());
 
 ?>
 --EXPECTF--
-Fatal error: Type declaration 'iterable' must be unqualified in %s on line %d
+Fatal error: Type declaration "iterable" must be unqualified in %s on line %d

--- a/Zend/tests/typehints/fully_qualified_scalar.phpt
+++ b/Zend/tests/typehints/fully_qualified_scalar.phpt
@@ -10,4 +10,4 @@ foo(1);
 
 ?>
 --EXPECTF--
-Fatal error: Type declaration 'int' must be unqualified in %s on line %d
+Fatal error: Type declaration "int" must be unqualified in %s on line %d

--- a/Zend/tests/typehints/namespace_relative_scalar.phpt
+++ b/Zend/tests/typehints/namespace_relative_scalar.phpt
@@ -8,4 +8,4 @@ test(0);
 
 ?>
 --EXPECTF--
-Fatal error: Type declaration 'int' must be unqualified in %s on line %d
+Fatal error: Type declaration "int" must be unqualified in %s on line %d

--- a/Zend/tests/use_const/define_imported.phpt
+++ b/Zend/tests/use_const/define_imported.phpt
@@ -11,4 +11,4 @@ namespace {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare const bar because the name is already in use in %s on line %d
+Fatal error: Constant bar cannot be declared because the name is already in use in %s on line %d

--- a/Zend/tests/use_function/define_imported.phpt
+++ b/Zend/tests/use_function/define_imported.phpt
@@ -11,4 +11,4 @@ namespace {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot declare function bar because the name is already in use in %s on line %d
+Fatal error: Function bar() cannot be declared because the name is already in use in %s on line %d

--- a/Zend/tests/varSyntax/constant_object_deref.phpt
+++ b/Zend/tests/varSyntax/constant_object_deref.phpt
@@ -20,5 +20,5 @@ try {
 
 ?>
 --EXPECT--
-Call to a member function length() on string
-Call to a member function length() on string
+Call to method length() on string
+Call to method length() on string

--- a/Zend/tests/varSyntax/encapsed_string_deref.phpt
+++ b/Zend/tests/varSyntax/encapsed_string_deref.phpt
@@ -24,6 +24,6 @@ string(1) "f"
 
 Warning: Attempt to read property "prop" on string in %s on line %d
 NULL
-Call to a member function method() on string
+Call to method method() on string
 int(42)
 int(42)

--- a/Zend/tests/varSyntax/magic_const_deref.phpt
+++ b/Zend/tests/varSyntax/magic_const_deref.phpt
@@ -21,4 +21,4 @@ string(1) "t"
 
 Warning: Attempt to read property "prop" on string in %s on line %d
 NULL
-Call to a member function method() on string
+Call to method method() on string

--- a/Zend/tests/varSyntax/method_call_on_string_literal.phpt
+++ b/Zend/tests/varSyntax/method_call_on_string_literal.phpt
@@ -5,7 +5,7 @@ Method call on string literal
 "string"->length();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to a member function length() on string in %s:%d
+Fatal error: Uncaught Error: Call to method length() on string in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/variadic/no_default_error.phpt
+++ b/Zend/tests/variadic/no_default_error.phpt
@@ -7,4 +7,4 @@ function test(...$args = 123) {}
 
 ?>
 --EXPECTF--
-Fatal error: Variadic parameter cannot have a default value in %s on line %d
+Fatal error: test(): Variadic parameter #1 ($args) cannot have a default value in %s on line %d

--- a/Zend/tests/variadic/only_last_error.phpt
+++ b/Zend/tests/variadic/only_last_error.phpt
@@ -7,4 +7,4 @@ function test($foo, ...$bar, $baz) {}
 
 ?>
 --EXPECTF--
-Fatal error: Only the last parameter can be variadic in %s on line %d
+Fatal error: test(): Parameter #3 ($baz) cannot be variadic in %s on line %d

--- a/Zend/tests/weakrefs/weakmap_error_conditions.phpt
+++ b/Zend/tests/weakrefs/weakmap_error_conditions.phpt
@@ -82,11 +82,11 @@ Cannot append to WeakMap
 Cannot append to WeakMap
 Object stdClass#2 not contained in WeakMap
 
-Warning: Undefined property: WeakMap::$prop in %s on line %d
+Warning: Undefined property WeakMap::$prop in %s on line %d
 NULL
 bool(false)
-Cannot create dynamic property WeakMap::$prop
-Cannot create dynamic property WeakMap::$prop
-Cannot create dynamic property WeakMap::$prop
+Dynamic property WeakMap::$prop cannot be created
+Dynamic property WeakMap::$prop cannot be created
+Dynamic property WeakMap::$prop cannot be created
 Serialization of 'WeakMap' is not allowed
 Unserialization of 'WeakMap' is not allowed

--- a/Zend/tests/weakrefs/weakrefs_003.phpt
+++ b/Zend/tests/weakrefs/weakrefs_003.phpt
@@ -21,8 +21,8 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined property: WeakReference::$disallow in %s on line %d
+Warning: Undefined property WeakReference::$disallow in %s on line %d
 NULL
 bool(false)
-string(55) "Cannot create dynamic property WeakReference::$disallow"
-string(57) "Cannot create dynamic property WeakReference::$disallowed"
+string(59) "Dynamic property WeakReference::$disallow cannot be created"
+string(61) "Dynamic property WeakReference::$disallowed cannot be created"

--- a/Zend/tests/weakrefs/weakrefs_004.phpt
+++ b/Zend/tests/weakrefs/weakrefs_004.phpt
@@ -5,4 +5,4 @@ WeakReference no inheritance
 class Test extends WeakReference {}
 ?>
 --EXPECTF--
-Fatal error: Class Test may not inherit from final class (WeakReference) in %s on line %d
+Fatal error: Class Test cannot extend final class WeakReference in %s on line %d

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1505,6 +1505,103 @@ ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_at_noreturn(
 	abort();
 }
 
+static ZEND_COLD void ZEND_FASTCALL zend_function_error_noreturn_variadic(
+	int orig_type, const char *error_filename, uint32_t error_lineno, const char *function, const char *format, va_list args
+) {
+	zend_op_array *op_array = CG(active_op_array);
+	zend_class_entry *scope = op_array->scope;
+	zend_string *function_name = op_array->function_name;
+
+	zend_string *message1 = zend_vstrpprintf(0, format, args);
+	zend_string *message2 = zend_strpprintf(
+		0, "%s %s%s%s() %s",
+		function ? function : (scope ? "Method" : "Function"),
+		scope ? ZSTR_VAL(scope->name) : "", scope ? "::" : "", ZSTR_VAL(function_name), ZSTR_VAL(message1)
+	);
+
+	zend_error_impl(orig_type, error_filename, error_lineno, message2);
+}
+
+ZEND_API ZEND_COLD ZEND_NORETURN void zend_function_error_noreturn(int type, const char *function, const char *format, ...)
+{
+	const char *filename;
+	uint32_t lineno;
+	va_list args;
+
+	get_filename_lineno(type, &filename, &lineno);
+	va_start(args, format);
+	zend_function_error_noreturn_variadic(type, filename, lineno, function, format, args);
+	va_end(args);
+	/* Should never reach this. */
+	abort();
+}
+
+static ZEND_COLD void ZEND_FASTCALL zend_parameter_error_noreturn_variadic(
+	int orig_type, const char *error_filename, uint32_t error_lineno,
+	const char *parameter, int parameter_number, const char *parameter_name, const char *format, va_list args
+) {
+	zend_op_array *op_array = CG(active_op_array);
+	zend_class_entry *scope = op_array->scope;
+	zend_string *function_name = op_array->function_name;
+
+	zend_string *message1 = zend_vstrpprintf(0, format, args);
+	zend_string *message2 = zend_strpprintf(
+		0, "%s%s%s(): %s #%d%s%s%s %s",
+		scope ? ZSTR_VAL(scope->name) : "", scope ? "::" : "", ZSTR_VAL(function_name),
+		parameter ? parameter : "Parameter", parameter_number,
+		parameter_name ? " ($" : "", parameter_name ? parameter_name : "",
+		parameter_name ? ")" : "", ZSTR_VAL(message1)
+	);
+
+	zend_error_impl(orig_type, error_filename, error_lineno, message2);
+}
+
+ZEND_API ZEND_COLD ZEND_NORETURN void zend_parameter_error_noreturn(
+	int type, const char *parameter, int parameter_number, const char *parameter_name, const char *format, ...
+) {
+	const char *filename;
+	uint32_t lineno;
+	va_list args;
+
+	get_filename_lineno(type, &filename, &lineno);
+	va_start(args, format);
+	zend_parameter_error_noreturn_variadic(type, filename, lineno, parameter, parameter_number, parameter_name, format, args);
+	va_end(args);
+	/* Should never reach this. */
+	abort();
+}
+
+static ZEND_COLD void ZEND_FASTCALL zend_property_error_noreturn_variadic(
+	int orig_type, const char *error_filename, uint32_t error_lineno,
+	const char *property, const char *property_name, const char *format, va_list args
+) {
+	zend_op_array *op_array = CG(active_op_array);
+	zend_class_entry *scope = op_array->scope;
+
+	zend_string *message1 = zend_vstrpprintf(0, format, args);
+	zend_string *message2 = zend_strpprintf(
+		0, "%s %s::$%s %s",
+		property ? property : "Property", scope ? ZSTR_VAL(scope->name) : "", property_name, ZSTR_VAL(message1)
+	);
+
+	zend_error_impl(orig_type, error_filename, error_lineno, message2);
+}
+
+ZEND_API ZEND_COLD ZEND_NORETURN void zend_property_error_noreturn(
+	int type, const char *property, const char *property_name, const char *format, ...
+) {
+	const char *filename;
+	uint32_t lineno;
+	va_list args;
+
+	get_filename_lineno(type, &filename, &lineno);
+	va_start(args, format);
+	zend_property_error_noreturn_variadic(type, filename, lineno, property, property_name, format, args);
+	va_end(args);
+	/* Should never reach this. */
+	abort();
+}
+
 ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_noreturn(int type, const char *format, ...)
 {
 	const char *filename;

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -297,6 +297,9 @@ extern ZEND_API void (*zend_post_shutdown_cb)(void);
 extern ZEND_API int (*zend_preload_autoload)(zend_string *filename);
 
 ZEND_API ZEND_COLD void zend_error(int type, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
+ZEND_API ZEND_COLD ZEND_NORETURN void zend_function_error_noreturn(int type, const char *function, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 3, 4);
+ZEND_API ZEND_COLD ZEND_NORETURN void zend_parameter_error_noreturn(int type, const char *parameter, int parameter_number, const char *parameter_name, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 5, 6);
+ZEND_API ZEND_COLD ZEND_NORETURN void zend_property_error_noreturn(int type, const char *property, const char *property_name, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 4, 5);
 ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_noreturn(int type, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
 /* If filename is NULL the default filename is used. */
 ZEND_API ZEND_COLD void zend_error_at(int type, const char *filename, uint32_t lineno, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 4, 5);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -608,7 +608,7 @@ static zend_always_inline int zend_forbid_dynamic_call(const char *func_name)
 	ZEND_ASSERT(ex != NULL && ex->func != NULL);
 
 	if (ZEND_CALL_INFO(ex) & ZEND_CALL_DYNAMIC) {
-		zend_throw_error(NULL, "Cannot call %s dynamically", func_name);
+		zend_throw_error(NULL, "%s cannot be called dynamically", func_name);
 		return FAILURE;
 	}
 

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -577,7 +577,7 @@ ZEND_API int ZEND_FASTCALL zend_ast_evaluate(zval *result, zend_ast *ast, zend_c
 			break;
 		case ZEND_AST_CLASS_NAME:
 			if (!scope) {
-				zend_throw_error(NULL, "Cannot use \"self\" when no class scope is active");
+				zend_throw_error(NULL, "\"self\" cannot be used in the global scope");
 				return FAILURE;
 			}
 			if (ast->attr == ZEND_FETCH_CLASS_SELF) {
@@ -585,7 +585,7 @@ ZEND_API int ZEND_FASTCALL zend_ast_evaluate(zval *result, zend_ast *ast, zend_c
 			} else if (ast->attr == ZEND_FETCH_CLASS_PARENT) {
 				if (!scope->parent) {
 					zend_throw_error(NULL,
-						"Cannot use \"parent\" when current class scope has no parent");
+						"\"parent\" cannot be used when current class scope has no parent");
 					return FAILURE;
 				}
 				ZVAL_STR_COPY(result, scope->parent->name);

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1116,7 +1116,7 @@ ZEND_FUNCTION(class_alias)
 			if (zend_register_class_alias_ex(alias_name, alias_name_len, ce, 0) == SUCCESS) {
 				RETURN_TRUE;
 			} else {
-				zend_error(E_WARNING, "Cannot declare %s %s, because the name is already in use", zend_get_object_type(ce), alias_name);
+				zend_error(E_WARNING, "%s %s cannot be declared, because the name is already in use", zend_get_object_type(ce), alias_name);
 				RETURN_FALSE;
 			}
 		} else {

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -353,6 +353,7 @@ typedef struct _zend_oparray_context {
 #define ZEND_ACC_CALL_VIA_HANDLER     ZEND_ACC_CALL_VIA_TRAMPOLINE
 
 char *zend_visibility_string(uint32_t fn_flags);
+char *zend_visibility_string_capitalized(uint32_t fn_flags);
 
 typedef struct _zend_property_info {
 	uint32_t offset; /* property offset for object properties or

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1949,7 +1949,7 @@ static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_undefined_method(cons
 
 static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_invalid_method_call(zval *object, zval *function_name)
 {
-	zend_throw_error(NULL, "Call to a member function %s() on %s",
+	zend_throw_error(NULL, "Call to method %s() on %s",
 		Z_STRVAL_P(function_name), zend_zval_type_name(object));
 }
 
@@ -3327,9 +3327,9 @@ static zend_never_inline void zend_fetch_this_var(int type OPLINE_DC EXECUTE_DAT
 
 static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_wrong_clone_call(zend_function *clone, zend_class_entry *scope)
 {
-	zend_throw_error(NULL, "Call to %s %s::__clone() from %s%s",
-		zend_visibility_string(clone->common.fn_flags), ZSTR_VAL(clone->common.scope->name),
-		scope ? "scope " : "global scope",
+	zend_throw_error(NULL, "%s method %s::__clone() cannot be called from the %s%s",
+		zend_visibility_string_capitalized(clone->common.fn_flags), ZSTR_VAL(clone->common.scope->name),
+		scope ? "scope of class " : "global scope",
 		scope ? ZSTR_VAL(scope->name) : ""
 	);
 }

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1354,23 +1354,23 @@ check_fetch_type:
 		case ZEND_FETCH_CLASS_SELF:
 			scope = zend_get_executed_scope();
 			if (UNEXPECTED(!scope)) {
-				zend_throw_or_error(fetch_type, NULL, "Cannot access \"self\" when no class scope is active");
+				zend_throw_or_error(fetch_type, NULL, "\"self\" cannot be used in the global scope");
 			}
 			return scope;
 		case ZEND_FETCH_CLASS_PARENT:
 			scope = zend_get_executed_scope();
 			if (UNEXPECTED(!scope)) {
-				zend_throw_or_error(fetch_type, NULL, "Cannot access \"parent\" when no class scope is active");
+				zend_throw_or_error(fetch_type, NULL, "\"parent\" cannot be used in the global scope");
 				return NULL;
 			}
 			if (UNEXPECTED(!scope->parent)) {
-				zend_throw_or_error(fetch_type, NULL, "Cannot access \"parent\" when current class scope has no parent");
+				zend_throw_or_error(fetch_type, NULL, "\"parent\" cannot be used in the global scope");
 			}
 			return scope->parent;
 		case ZEND_FETCH_CLASS_STATIC:
 			ce = zend_get_called_scope(EG(current_execute_data));
 			if (UNEXPECTED(!ce)) {
-				zend_throw_or_error(fetch_type, NULL, "Cannot access \"static\" when no class scope is active");
+				zend_throw_or_error(fetch_type, NULL, "\"static\" cannot be used in the global scope");
 				return NULL;
 			}
 			return ce;

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -107,16 +107,16 @@ ZEND_API void zend_objects_destroy_object(zend_object *object)
 
 					if (object->ce != scope) {
 						zend_throw_error(NULL,
-							"Call to private %s::__destruct() from %s%s",
+							"Private method %s::__destruct() cannot be called from the %s%s",
 							ZSTR_VAL(object->ce->name),
-							scope ? "scope " : "global scope",
+							scope ? "scope of class " : "global scope",
 							scope ? ZSTR_VAL(scope->name) : ""
 						);
 						return;
 					}
 				} else {
 					zend_error(E_WARNING,
-						"Call to private %s::__destruct() from global scope during shutdown ignored",
+						"Call to private %s::__destruct() from the global scope during shutdown is ignored",
 						ZSTR_VAL(object->ce->name));
 					return;
 				}
@@ -128,16 +128,16 @@ ZEND_API void zend_objects_destroy_object(zend_object *object)
 
 					if (!zend_check_protected(zend_get_function_root_class(destructor), scope)) {
 						zend_throw_error(NULL,
-							"Call to protected %s::__destruct() from %s%s",
+							"Protected method %s::__destruct() cannot be called from the %s%s",
 							ZSTR_VAL(object->ce->name),
-							scope ? "scope " : "global scope",
+							scope ? "scope of class " : "global scope",
 							scope ? ZSTR_VAL(scope->name) : ""
 						);
 						return;
 					}
 				} else {
 					zend_error(E_WARNING,
-						"Call to protected %s::__destruct() from global scope during shutdown ignored",
+						"Call to protected %s::__destruct() from the global scope during shutdown is ignored",
 						ZSTR_VAL(object->ce->name));
 					return;
 				}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5802,7 +5802,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -5946,7 +5949,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_CONS
 			c = Z_PTR_P(zv);
 			scope = EX(func)->op_array.scope;
 			if (!zend_verify_const_access(c, scope)) {
-				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(Z_ACCESS_FLAGS(c->value)), ZSTR_VAL(ce->name), Z_STRVAL_P(RT_CONSTANT(opline, opline->op2)));
+				zend_throw_error(NULL, "%s constant %s::%s cannot be accessed from the %s%s",
+					zend_visibility_string_capitalized(Z_ACCESS_FLAGS(c->value)), ZSTR_VAL(ce->name), Z_STRVAL_P(RT_CONSTANT(opline, opline->op2)),
+					scope ? "scope of class " : "global scope",
+					scope ? ZSTR_VAL(scope->name) : ""
+				);
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -6266,7 +6274,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DECLARE_CLASS_DELAYED_SPEC_CON
 			ce = Z_CE_P(zv);
 			zv = zend_hash_set_bucket_key(EG(class_table), (Bucket*)zv, Z_STR_P(lcname));
 			if (UNEXPECTED(!zv)) {
-				zend_error_noreturn(E_COMPILE_ERROR, "Cannot declare %s %s, because the name is already in use", zend_get_object_type(ce), ZSTR_VAL(ce->name));
+				zend_error_noreturn(E_COMPILE_ERROR, "%s %s cannot be declared, because the name is already in use", zend_get_object_type(ce), ZSTR_VAL(ce->name));
 			} else {
 				if (zend_do_link_class(ce, Z_STR_P(RT_CONSTANT(opline, opline->op2))) == FAILURE) {
 					/* Reload bucket pointer, the hash table may have been reallocated */
@@ -8014,7 +8022,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -8755,7 +8766,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -10283,7 +10297,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -22886,7 +22903,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -22969,7 +22989,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_VAR_
 			c = Z_PTR_P(zv);
 			scope = EX(func)->op_array.scope;
 			if (!zend_verify_const_access(c, scope)) {
-				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(Z_ACCESS_FLAGS(c->value)), ZSTR_VAL(ce->name), Z_STRVAL_P(RT_CONSTANT(opline, opline->op2)));
+				zend_throw_error(NULL, "%s constant %s::%s cannot be accessed from the %s%s",
+					zend_visibility_string_capitalized(Z_ACCESS_FLAGS(c->value)), ZSTR_VAL(ce->name), Z_STRVAL_P(RT_CONSTANT(opline, opline->op2)),
+					scope ? "scope of class " : "global scope",
+					scope ? ZSTR_VAL(scope->name) : ""
+				);
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -25108,7 +25133,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -26402,7 +26430,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -28669,7 +28700,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -30852,7 +30886,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -30951,7 +30988,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_UNUS
 			c = Z_PTR_P(zv);
 			scope = EX(func)->op_array.scope;
 			if (!zend_verify_const_access(c, scope)) {
-				zend_throw_error(NULL, "Cannot access %s constant %s::%s", zend_visibility_string(Z_ACCESS_FLAGS(c->value)), ZSTR_VAL(ce->name), Z_STRVAL_P(RT_CONSTANT(opline, opline->op2)));
+				zend_throw_error(NULL, "%s constant %s::%s cannot be accessed from the %s%s",
+					zend_visibility_string_capitalized(Z_ACCESS_FLAGS(c->value)), ZSTR_VAL(ce->name), Z_STRVAL_P(RT_CONSTANT(opline, opline->op2)),
+					scope ? "scope of class " : "global scope",
+					scope ? ZSTR_VAL(scope->name) : ""
+				);
+
 				ZVAL_UNDEF(EX_VAR(opline->result.var));
 				HANDLE_EXCEPTION();
 			}
@@ -32716,7 +32758,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -33130,7 +33175,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;
@@ -35112,7 +35160,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			HANDLE_EXCEPTION();
 		}
 		if (Z_TYPE(EX(This)) == IS_OBJECT && Z_OBJ(EX(This))->ce != ce->constructor->common.scope && (ce->constructor->common.fn_flags & ZEND_ACC_PRIVATE)) {
-			zend_throw_error(NULL, "Cannot call private %s::__construct()", ZSTR_VAL(ce->name));
+			zend_throw_error(NULL, "Private method %s::__construct() cannot be called from the %s%s", ZSTR_VAL(ce->name),
+				Z_OBJ(EX(This))->ce ? "scope of class " : "global scope",
+				Z_OBJ(EX(This))->ce ? ZSTR_VAL(Z_OBJ(EX(This))->ce->name) : ""
+			);
 			HANDLE_EXCEPTION();
 		}
 		fbc = ce->constructor;

--- a/ext/date/tests/bug62500.phpt
+++ b/ext/date/tests/bug62500.phpt
@@ -23,6 +23,6 @@ try {
 NULL
 int(3)
 
-Warning: Undefined property: Crasher::$2 in %s on line %d
+Warning: Undefined property Crasher::$2 in %s on line %d
 NULL
 string(%s) "DateInterval::__construct(): Unknown or bad format (blah)"

--- a/ext/date/tests/bug74852.phpt
+++ b/ext/date/tests/bug74852.phpt
@@ -13,5 +13,5 @@ var_dump($interval->abcde);
 bool(false)
 bool(false)
 
-Warning: Undefined property: DateInterval::$abcde in %s on line %d
+Warning: Undefined property DateInterval::$abcde in %s on line %d
 NULL

--- a/ext/date/tests/bug75232.phpt
+++ b/ext/date/tests/bug75232.phpt
@@ -14,7 +14,7 @@ echo $d2->date, "\n";
 
 ?>
 --EXPECTF--
-Warning: Undefined property: DateTime::$date in %s on line %d
+Warning: Undefined property DateTime::$date in %s on line %d
 
 DateTime Object
 (
@@ -23,4 +23,4 @@ DateTime Object
     [timezone] => UTC
 )
 
-Warning: Undefined property: DateTime::$date in %s on line %d
+Warning: Undefined property DateTime::$date in %s on line %d

--- a/ext/dom/tests/DOMAttr_ownerElement_error_001.phpt
+++ b/ext/dom/tests/DOMAttr_ownerElement_error_001.phpt
@@ -19,5 +19,5 @@ var_dump($attr->ownerElement);
 --EXPECTF--
 Warning: Couldn't fetch DOMAttr. Node no longer exists in %s on line %d
 
-Warning: Undefined property: DOMAttr::$ownerElement in %s on line %d
+Warning: Undefined property DOMAttr::$ownerElement in %s on line %d
 NULL

--- a/ext/dom/tests/bug36756.phpt
+++ b/ext/dom/tests/bug36756.phpt
@@ -31,5 +31,5 @@ child
 
 Warning: Couldn't fetch DOMElement. Node no longer exists in %sbug36756.php on line %d
 
-Warning: Undefined property: DOMElement::$nodeType in %s on line %d
+Warning: Undefined property DOMElement::$nodeType in %s on line %d
 nodeType:

--- a/ext/hash/tests/new-context.phpt
+++ b/ext/hash/tests/new-context.phpt
@@ -9,4 +9,4 @@ try {
   echo "Exception: {$e->getMessage()}\n";
 }
 --EXPECT--
-Exception: Call to private HashContext::__construct() from global scope
+Exception: Private method HashContext::__construct() cannot be called from the global scope

--- a/ext/intl/tests/breakiter___construct.phpt
+++ b/ext/intl/tests/breakiter___construct.phpt
@@ -10,7 +10,7 @@ ini_set("intl.error_level", E_WARNING);
 
 new IntlBreakIterator();
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private IntlBreakIterator::__construct() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method IntlBreakIterator::__construct() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/mysqli/tests/bug33491.phpt
+++ b/ext/mysqli/tests/bug33491.phpt
@@ -26,7 +26,7 @@ $DB->query_single('SELECT DATE()');
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to a member function fetch_row() on bool in %sbug33491.php:%d
+Fatal error: Uncaught Error: Call to method fetch_row() on bool in %sbug33491.php:%d
 Stack trace:
 #0 %s(%d): DB->query_single('SELECT DATE()')
 #1 {main}

--- a/ext/mysqli/tests/bug38003.phpt
+++ b/ext/mysqli/tests/bug38003.phpt
@@ -17,7 +17,7 @@ $DB = new DB();
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private DB::__construct() from global scope in %s
+Fatal error: Uncaught Error: Private method DB::__construct() cannot be called from the global scope in %s
 Stack trace:
 #0 {main}
   thrown in %s

--- a/ext/oci8/tests/fetch_object.phpt
+++ b/ext/oci8/tests/fetch_object.phpt
@@ -106,15 +106,15 @@ object(stdClass)#1 (3) {
 Test 2
 123
 1st row col2 string
-1 more text    
+1 more text
 456
 2nd row col2 string
-2 more text    
+2 more text
 789
 3rd row col2 string
-3 more text    
+3 more text
 Test 3
 123
 
-Warning: Undefined property: stdClass::$CASESENSITIVE in %sfetch_object.php on line %d
+Warning: Undefined property stdClass::$CASESENSITIVE in %sfetch_object.php on line %d
 

--- a/ext/oci8/tests/fetch_object_1.phpt
+++ b/ext/oci8/tests/fetch_object_1.phpt
@@ -106,15 +106,15 @@ object(stdClass)#%d (3) {
 Test 2
 123
 1st row col2 string
-1 more text    
+1 more text
 456
 2nd row col2 string
-2 more text    
+2 more text
 789
 3rd row col2 string
-3 more text    
+3 more text
 Test 3
 123
 
-Warning: Undefined property: stdClass::$CASESENSITIVE in %sfetch_object_1.php on line %d
+Warning: Undefined property stdClass::$CASESENSITIVE in %sfetch_object_1.php on line %d
 

--- a/ext/opcache/tests/bug67215.phpt
+++ b/ext/opcache/tests/bug67215.phpt
@@ -25,4 +25,4 @@ unlink($file_c);
 unlink($file_p);
 ?>
 --EXPECTF--
-Fatal error: Cannot declare class c, because the name is already in use in %sbug67215.c.php on line %d
+Fatal error: class c cannot be declared, because the name is already in use in %sbug67215.c.php on line %d

--- a/ext/opcache/tests/bug71127.phpt
+++ b/ext/opcache/tests/bug71127.phpt
@@ -21,5 +21,5 @@ include($file);
 @unlink(__DIR__ . "/bug71127.inc");
 ?>
 --EXPECTF--
-Notice: Constant FOO already defined in %sbug71127.inc on line %d
+Notice: Constant FOO has already been defined in %sbug71127.inc on line %d
 okey

--- a/ext/opcache/tests/bug73583.phpt
+++ b/ext/opcache/tests/bug73583.phpt
@@ -16,4 +16,4 @@ if (true) {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare A() (previously declared in %sbug73583.php:4) in %sbug73583.php on line 5
+Fatal error: Function A() cannot be redeclared (previous declaration in %sbug73583.php:4) in %sbug73583.php on line 5

--- a/ext/opcache/tests/invalid_new_dce.phpt
+++ b/ext/opcache/tests/invalid_new_dce.phpt
@@ -36,7 +36,7 @@ try { test4(); } catch (Error $e) { echo $e->getMessage(), "\n"; }
 
 ?>
 --EXPECT--
-Cannot instantiate abstract class Foo
-Cannot instantiate interface Bar
-Cannot instantiate trait Baz
-Cannot declare self-referencing constant Abc::BAR
+Abstract class Foo cannot be instantiated
+Interface Bar cannot be instantiated
+Trait Baz cannot be instantiated
+Constant Abc::BAR cannot reference itself

--- a/ext/opcache/tests/jit/fetch_obj_002.phpt
+++ b/ext/opcache/tests/jit/fetch_obj_002.phpt
@@ -35,7 +35,7 @@ bar();
 --EXPECTF--
 int(2)
 
-Warning: Undefined property: A::$y in %s on line %d
+Warning: Undefined property A::$y in %s on line %d
 NULL
 int(3)
 string(5) "__get"

--- a/ext/opcache/tests/jit/fetch_obj_003.phpt
+++ b/ext/opcache/tests/jit/fetch_obj_003.phpt
@@ -31,13 +31,13 @@ foo();
 bar();
 ?>
 --EXPECTF--
-Warning: Undefined property: C::$a in %s on line %d
+Warning: Undefined property C::$a in %s on line %d
 object(C)#1 (1) {
   ["a"]=>
   int(2)
 }
 
-Warning: Undefined property: C::$a in %s on line %d
+Warning: Undefined property C::$a in %s on line %d
 object(C)#1 (2) {
   ["a"]=>
   int(2)

--- a/ext/opcache/tests/method_call_on_literal.phpt
+++ b/ext/opcache/tests/method_call_on_literal.phpt
@@ -13,4 +13,4 @@ try {
 
 ?>
 --EXPECT--
-Call to a member function foo() on int
+Call to method foo() on int

--- a/ext/opcache/tests/warning_replay.phpt
+++ b/ext/opcache/tests/warning_replay.phpt
@@ -10,6 +10,6 @@ require __DIR__ . '/warning_replay.inc';
 
 ?>
 --EXPECTF--
-Warning: Unsupported declare 'unknown' in %swarning_replay.inc on line 3
+Warning: "unknown" declaration is unsupported in %swarning_replay.inc on line 3
 
-Warning: Unsupported declare 'unknown' in %swarning_replay.inc on line 3
+Warning: "unknown" declaration is unsupported in %swarning_replay.inc on line 3

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -465,12 +465,12 @@ failure:
 	CG(zend_lineno) = function1->op_array.opcodes[0].lineno;
 	if (function2->type == ZEND_USER_FUNCTION
 		&& function2->op_array.last > 0) {
-		zend_error(E_ERROR, "Cannot redeclare %s() (previously declared in %s:%d)",
+		zend_error(E_ERROR, "Function %s() cannot be redeclared (previous declaration in %s:%d)",
 				   ZSTR_VAL(function1->common.function_name),
 				   ZSTR_VAL(function2->op_array.filename),
 				   (int)function2->op_array.opcodes[0].lineno);
 	} else {
-		zend_error(E_ERROR, "Cannot redeclare %s()", ZSTR_VAL(function1->common.function_name));
+		zend_error(E_ERROR, "Function %s() cannot be redeclared", ZSTR_VAL(function1->common.function_name));
 	}
 }
 
@@ -509,12 +509,12 @@ failure:
 	CG(zend_lineno) = function1->op_array.opcodes[0].lineno;
 	if (function2->type == ZEND_USER_FUNCTION
 		&& function2->op_array.last > 0) {
-		zend_error(E_ERROR, "Cannot redeclare %s() (previously declared in %s:%d)",
+		zend_error(E_ERROR, "%s() cannot be redeclared (previous declaration in %s:%d)",
 				   ZSTR_VAL(function1->common.function_name),
 				   ZSTR_VAL(function2->op_array.filename),
 				   (int)function2->op_array.opcodes[0].lineno);
 	} else {
-		zend_error(E_ERROR, "Cannot redeclare %s()", ZSTR_VAL(function1->common.function_name));
+		zend_error(E_ERROR, "Function %s() cannot be redeclared", ZSTR_VAL(function1->common.function_name));
 	}
 }
 
@@ -541,7 +541,7 @@ static void zend_accel_class_hash_copy(HashTable *target, HashTable *source)
 					zend_set_compiled_filename(ce1->info.user.filename);
 					CG(zend_lineno) = ce1->info.user.line_start;
 					zend_error(E_ERROR,
-							"Cannot declare %s %s, because the name is already in use",
+							"%s %s cannot be declared, because the name is already in use",
 							zend_get_object_type(ce1), ZSTR_VAL(ce1->name));
 					return;
 				}
@@ -578,7 +578,7 @@ static void zend_accel_class_hash_copy_from_shm(HashTable *target, HashTable *so
 					zend_set_compiled_filename(ce1->info.user.filename);
 					CG(zend_lineno) = ce1->info.user.line_start;
 					zend_error(E_ERROR,
-							"Cannot declare %s %s, because the name is already in use",
+							"%s %s cannot be declared, because the name is already in use",
 							zend_get_object_type(ce1), ZSTR_VAL(ce1->name));
 					return;
 				}

--- a/ext/pdo/tests/bug_47769.phpt
+++ b/ext/pdo/tests/bug_47769.phpt
@@ -34,7 +34,7 @@ this is a protected method.
 this is a private method.
 foo
 
-Fatal error: Uncaught Error: Call to protected method test::isProtected() from global scope in %s:%d
+Fatal error: Uncaught Error: Protected method test::isProtected() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo/tests/pdo_025.phpt
+++ b/ext/pdo/tests/pdo_025.phpt
@@ -110,7 +110,7 @@ object(Test)#%d (3) {
 }
 ===FAIL===
 
-Fatal error: Uncaught Error: Cannot access protected property Fail::$id in %spdo_025.php:%d
+Fatal error: Uncaught Error: Protected property Fail::$id cannot be accessed from the global scope in %spdo_025.php:%d
 Stack trace:
 #0 {main}
   thrown in %spdo_025.php on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_statement_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_statement_class.phpt
@@ -149,7 +149,7 @@ array(1) {
   }
 }
 
-Fatal error: Uncaught Error: Cannot instantiate abstract class mystatement6 in %s:%d
+Fatal error: Uncaught Error: Abstract class mystatement6 cannot be instantiated in %s:%d
 Stack trace:
 #0 %s(%d): PDO->query('SELECT id, labe...')
 #1 {main}

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_clear_error.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_clear_error.phpt
@@ -93,7 +93,7 @@ array(1) {
 
 Warning: PDO::prepare(): SQLSTATE[42S22]: Column not found: 1054 Unknown column 'unknown_column' in 'field list' in %s on line %d
 
-Fatal error: Uncaught Error: Call to a member function execute() on bool in %s:%d
+Fatal error: Uncaught Error: Call to method execute() on bool in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_mixed_style.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_mixed_style.phpt
@@ -36,7 +36,7 @@ Warning: PDO::prepare(): SQLSTATE[HY093]: Invalid parameter number: mixed named 
 
 Warning: PDO::prepare(): SQLSTATE[HY093]: Invalid parameter number in %s on line %d
 
-Fatal error: Uncaught Error: Call to a member function execute() on bool in %s:%d
+Fatal error: Uncaught Error: Call to method execute() on bool in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_errorcode.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_errorcode.phpt
@@ -56,7 +56,7 @@ Testing native PS...
 
 Warning: PDO::prepare(): SQLSTATE[42S02]: Base table or view not found: 1146 Table '%s.ihopeitdoesnotexist' doesn't exist in %s on line %d
 
-Fatal error: Uncaught Error: Call to a member function execute() on bool in %s:%d
+Fatal error: Uncaught Error: Call to method execute() on bool in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_multiquery.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_multiquery.phpt
@@ -99,7 +99,7 @@ Native Prepared Statements...
 
 Warning: PDO::query(): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near '%SSELECT label FROM test ORDER BY id ASC LIMIT 1' at line %d in %s on line %d
 
-Fatal error: Uncaught Error: Call to a member function errorInfo() on bool in %s:%d
+Fatal error: Uncaught Error: Call to method errorInfo() on bool in %s:%d
 Stack trace:
 #0 %s(%d): mysql_stmt_multiquery_wrong_usage(Object(PDO))
 #1 {main}

--- a/ext/reflection/tests/ReflectionAttribute_final.phpt
+++ b/ext/reflection/tests/ReflectionAttribute_final.phpt
@@ -7,4 +7,4 @@ class T extends ReflectionAttribute {}
 
 ?>
 --EXPECTF--
-Fatal error: Class T may not inherit from final class (ReflectionAttribute) in %s on line %d
+Fatal error: Class T cannot extend final class ReflectionAttribute in %s on line %d

--- a/ext/reflection/tests/ReflectionReference_errors.phpt
+++ b/ext/reflection/tests/ReflectionReference_errors.phpt
@@ -40,7 +40,7 @@ var_dump(unserialize('O:19:"ReflectionReference":0:{}'));
 
 ?>
 --EXPECTF--
-Call to private ReflectionReference::__construct() from global scope
+Private method ReflectionReference::__construct() cannot be called from the global scope
 ReflectionReference::fromArrayElement(): Argument #1 ($array) must be of type array, stdClass given
 ReflectionReference::fromArrayElement(): Argument #2 ($key) must be of type string|int, float given
 Array key not found

--- a/ext/reflection/tests/bug62715.phpt
+++ b/ext/reflection/tests/bug62715.phpt
@@ -17,7 +17,7 @@ foreach ($r->getParameters() as $p) {
 }
 ?>
 --EXPECTF--
-Deprecated: Required parameter $c follows optional parameter $b in %s on line %d
+Deprecated: Required parameter $c should precede optional parameter $b in %s on line %d
 bool(true)
 bool(true)
 bool(false)

--- a/ext/reflection/tests/bug76936.phpt
+++ b/ext/reflection/tests/bug76936.phpt
@@ -40,6 +40,6 @@ foreach ((new ReflectionObject($f))->getProperties() as $p) {
 ?>
 --EXPECT--
 dummy1 = 
-ErrorHandler::handleError dealing with error Undefined property: Foo::$dummy2
+ErrorHandler::handleError dealing with error Undefined property Foo::$dummy2
 THIS IS PRIVATE
 dummy2 =

--- a/ext/spl/tests/arrayObject___construct_basic2.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic2.phpt
@@ -61,7 +61,7 @@ bool(true)
 bool(true)
   - Unset:
 
-Warning: Undefined property: ArrayObject::$prop in %s on line %d
+Warning: Undefined property ArrayObject::$prop in %s on line %d
 
 Notice: Undefined array key "prop" in %s on line %d
 NULL
@@ -89,7 +89,7 @@ bool(true)
 bool(true)
   - Unset:
 
-Warning: Undefined property: MyArrayObject::$prop in %s on line %d
+Warning: Undefined property MyArrayObject::$prop in %s on line %d
 
 Notice: Undefined array key "prop" in %s on line %d
 NULL

--- a/ext/spl/tests/arrayObject___construct_basic3.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic3.phpt
@@ -61,7 +61,7 @@ bool(true)
 bool(true)
   - Unset:
 
-Warning: Undefined property: ArrayObject::$prop in %s on line %d
+Warning: Undefined property ArrayObject::$prop in %s on line %d
 
 Notice: Undefined array key "prop" in %s on line %d
 NULL
@@ -89,7 +89,7 @@ bool(true)
 bool(true)
   - Unset:
 
-Warning: Undefined property: MyArrayObject::$prop in %s on line %d
+Warning: Undefined property MyArrayObject::$prop in %s on line %d
 
 Notice: Undefined array key "prop" in %s on line %d
 NULL

--- a/ext/spl/tests/arrayObject_magicMethods2.phpt
+++ b/ext/spl/tests/arrayObject_magicMethods2.phpt
@@ -102,7 +102,7 @@ object(ArrayObject)#2 (3) {
 --> Read existent, non-existent and dynamic:
 string(7) "changed"
 
-Warning: Undefined property: ArrayObject::$nonexistent in %s on line %d
+Warning: Undefined property ArrayObject::$nonexistent in %s on line %d
 NULL
 string(11) "new.changed"
   Original wrapped object:

--- a/ext/spl/tests/arrayObject_setFlags_basic2.phpt
+++ b/ext/spl/tests/arrayObject_setFlags_basic2.phpt
@@ -26,7 +26,7 @@ string(6) "secret"
 string(6) "public"
 string(6) "secret"
 
-Fatal error: Uncaught Error: Cannot access private property C::$x in %s:19
+Fatal error: Uncaught Error: Private property C::$x cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line 19

--- a/ext/spl/tests/bug54323.phpt
+++ b/ext/spl/tests/bug54323.phpt
@@ -17,7 +17,7 @@ function testAccess($c, $ao) {
         var_dump($c->prop, $ao['prop']);
 }
 --EXPECTF--
-Warning: Undefined property: C::$prop in %s on line %d
+Warning: Undefined property C::$prop in %s on line %d
 
 Notice: Undefined array key "prop" in %sbug54323.php on line 14
 NULL

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1604,7 +1604,7 @@ PHP_FUNCTION(forward_static_call)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!EX(prev_execute_data)->func->common.scope) {
-		zend_throw_error(NULL, "Cannot call forward_static_call() when no class scope is active");
+		zend_throw_error(NULL, "forward_static_call() cannot be called from the global scope");
 		RETURN_THROWS();
 	}
 

--- a/ext/standard/tests/array/bug71220.phpt
+++ b/ext/standard/tests/array/bug71220.phpt
@@ -11,4 +11,4 @@ try {
 ?>
 
 --EXPECT--
-Cannot call compact() dynamically
+compact() cannot be called dynamically

--- a/ext/standard/tests/class_object/bug78638.phpt
+++ b/ext/standard/tests/class_object/bug78638.phpt
@@ -6,4 +6,4 @@ $c = new class('bar') extends __PHP_Incomplete_Class {
 };
 ?>
 --EXPECTF--
-Fatal error: Class __PHP_Incomplete_Class@anonymous may not inherit from final class (__PHP_Incomplete_Class) in %s on line %d
+Fatal error: Class __PHP_Incomplete_Class@anonymous cannot extend final class __PHP_Incomplete_Class in %s on line %d

--- a/ext/standard/tests/class_object/forward_static_call_002.phpt
+++ b/ext/standard/tests/class_object/forward_static_call_002.phpt
@@ -18,7 +18,7 @@ test();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot call forward_static_call() when no class scope is active in %s:%d
+Fatal error: Uncaught Error: forward_static_call() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 %s(%d): forward_static_call(Array)
 #1 %s(%d): test()

--- a/ext/standard/tests/general_functions/bug72920.phpt
+++ b/ext/standard/tests/general_functions/bug72920.phpt
@@ -13,4 +13,4 @@ try {
 }
 ?>
 --EXPECT--
-Cannot access private constant Foo::C1
+Private constant Foo::C1 cannot be accessed from the global scope

--- a/ext/standard/tests/serialize/serialization_objects_005.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_005.phpt
@@ -66,7 +66,7 @@ string(9) "p.changed"
 bool(false)
 bool(true)
 
-Warning: Undefined property: C::$x in %s on line %d
+Warning: Undefined property C::$x in %s on line %d
 NULL
 
 

--- a/ext/standard/tests/serialize/unserialize_abstract_class.phpt
+++ b/ext/standard/tests/serialize/unserialize_abstract_class.phpt
@@ -12,4 +12,4 @@ try {
 
 ?>
 --EXPECT--
-Cannot instantiate abstract class RecursiveFilterIterator
+Abstract class RecursiveFilterIterator cannot be instantiated

--- a/ext/standard/tests/streams/bug53903.phpt
+++ b/ext/standard/tests/streams/bug53903.phpt
@@ -24,7 +24,7 @@ $s[] = 1; //  Cannot use a scalar value as an array
 
 print_r($s);
 --EXPECTF--
-Warning: Undefined property: sw::$undefined in %s on line %d
+Warning: Undefined property sw::$undefined in %s on line %d
 Array
 (
     [0] => 1

--- a/ext/tidy/tests/035.phpt
+++ b/ext/tidy/tests/035.phpt
@@ -9,7 +9,7 @@ tidyNode::__construct()
 new tidyNode;
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private tidyNode::__construct() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method tidyNode::__construct() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/tokenizer/tests/PhpToken_extension_errors.phpt
+++ b/ext/tokenizer/tests/PhpToken_extension_errors.phpt
@@ -27,4 +27,4 @@ try {
 ?>
 --EXPECT--
 Undefined constant "UNKNOWN"
-Cannot instantiate abstract class MyPhpToken2
+Abstract class MyPhpToken2 cannot be instantiated

--- a/ext/tokenizer/tests/PhpToken_final_constructor.phpt
+++ b/ext/tokenizer/tests/PhpToken_final_constructor.phpt
@@ -12,4 +12,4 @@ class MyPhpToken extends PhpToken {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot override final method PhpToken::__construct() in %s on line %d
+Fatal error: Method MyPhpToken::__construct() cannot override final method PhpToken::__construct() in %s on line %d

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -108,7 +108,7 @@ PHP_METHOD(PhpToken, getAll)
 
 	/* Check construction preconditions in advance, so these are not repeated for each token. */
 	if (token_class->ce_flags & ZEND_ACC_EXPLICIT_ABSTRACT_CLASS) {
-		zend_throw_error(NULL, "Cannot instantiate abstract class %s", ZSTR_VAL(token_class->name));
+		zend_throw_error(NULL, "Abstract class %s cannot be instantiated", ZSTR_VAL(token_class->name));
 		RETURN_THROWS();
 	}
 	if (zend_update_class_constants(token_class) == FAILURE) {

--- a/ext/xml/tests/bug78563_final.phpt
+++ b/ext/xml/tests/bug78563_final.phpt
@@ -12,4 +12,4 @@ class Dummy extends Xmlparser {
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Class Dummy may not inherit from final class (XmlParser) in %s on line %d
+Fatal error: Class Dummy cannot extend final class XmlParser in %s on line %d

--- a/ext/zip/tests/oo_properties.phpt
+++ b/ext/zip/tests/oo_properties.phpt
@@ -40,7 +40,7 @@ zip->numFiles (4):
 	empty(): 0
 	isset(): 1
 
-Warning: Undefined property: ZipArchive::$bogus in %s on line %d
+Warning: Undefined property ZipArchive::$bogus in %s on line %d
 zip->bogus (0):
 	empty(): 1
 	isset(): 0

--- a/sapi/cgi/tests/004.phpt
+++ b/sapi/cgi/tests/004.phpt
@@ -40,7 +40,7 @@ echo "Done\n";
 --EXPECTF--
 string(%d) "
 <br />
-<b>Fatal error</b>:  Uncaught Error: Cannot access private property test::$pri in %s004.test.php:8
+<b>Fatal error</b>:  Uncaught Error: Private property test::$pri cannot be accessed from the global scope in %s004.test.php:8
 Stack trace:
 #0 {main}
   thrown in <b>%s004.test.php</b> on line <b>8</b><br />

--- a/sapi/cli/tests/008.phpt
+++ b/sapi/cli/tests/008.phpt
@@ -36,7 +36,7 @@ echo "Done\n";
 --EXPECTF--
 string(%d) "
 
-Fatal error: Uncaught Error: Cannot access private property test::$pri in %s:%d
+Fatal error: Uncaught Error: Private property test::$pri cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/__call_005.phpt
+++ b/tests/classes/__call_005.phpt
@@ -22,7 +22,7 @@ $b = new B();
 $b->test();
 ?>
 --EXPECTF--
-Warning: The magic method A::__call() must have public visibility in %s__call_005.php on line 3
+Warning: Method A::__call() must have public visibility in %s on line %d
 In A::__call(test1, array(1,a))
 object(B)#1 (0) {
 }

--- a/tests/classes/abstract.phpt
+++ b/tests/classes/abstract.phpt
@@ -25,7 +25,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call to function show()
 
-Fatal error: Uncaught Error: Cannot call abstract method fail::show() in %s:%d
+Fatal error: Uncaught Error: Abstract method fail::show() cannot be called in %s:%d
 Stack trace:
 #0 %s(%d): pass->error()
 #1 {main}

--- a/tests/classes/abstract_by_interface_001.phpt
+++ b/tests/classes/abstract_by_interface_001.phpt
@@ -27,7 +27,7 @@ class Fails extends Root implements MyInterface {
 ?>
 ===DONE===
 --EXPECTF--
-object(Leaf)#%d (0) {
+object(Leaf)#1 (0) {
 }
 
-Fatal error: Class Fails contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (MyInterface::MyInterfaceFunc) in %sabstract_by_interface_001.php on line %d
+Fatal error: Class Fails contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (MyInterface::MyInterfaceFunc) in %s on line %d

--- a/tests/classes/abstract_by_interface_002.phpt
+++ b/tests/classes/abstract_by_interface_002.phpt
@@ -27,7 +27,7 @@ class Fails extends Root implements MyInterface {
 ?>
 ===DONE===
 --EXPECTF--
-object(Leaf)#%d (0) {
+object(Leaf)#1 (0) {
 }
 
-Fatal error: Class Fails contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (MyInterface::MyInterfaceFunc) in %sabstract_by_interface_002.php on line %d
+Fatal error: Class Fails contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (MyInterface::MyInterfaceFunc) in %s on line %d

--- a/tests/classes/abstract_class.phpt
+++ b/tests/classes/abstract_class.phpt
@@ -24,7 +24,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call to function show()
 
-Fatal error: Uncaught Error: Cannot instantiate abstract class fail in %s:%d
+Fatal error: Uncaught Error: Abstract class fail cannot be instantiated in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/abstract_inherit.phpt
+++ b/tests/classes/abstract_inherit.phpt
@@ -16,7 +16,7 @@ $t = new pass();
 echo "Done\n"; // Shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot instantiate abstract class fail in %s:%d
+Fatal error: Uncaught Error: Abstract class fail cannot be instantiated in %s:%d
 Stack trace:
 #0 {main}
-  thrown in %s on line %d 
+  thrown in %s on line %d

--- a/tests/classes/abstract_static.phpt
+++ b/tests/classes/abstract_static.phpt
@@ -31,4 +31,4 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call to function show()
 
-Fatal error: Class fail contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (fail::func) in %sabstract_static.php(%d) : eval()'d code on line %d
+Fatal error: Class fail contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (fail::func) in %s on line %d

--- a/tests/classes/abstract_user_call.phpt
+++ b/tests/classes/abstract_user_call.phpt
@@ -29,4 +29,4 @@ try {
 ?>
 --EXPECT--
 test::func()
-call_user_func(): Argument #1 ($function) must be a valid callback, cannot call abstract method test_base::func()
+call_user_func(): Argument #1 ($function) must be a valid callback, abstract method test_base::func() cannot be called

--- a/tests/classes/array_access_009.phpt
+++ b/tests/classes/array_access_009.phpt
@@ -122,15 +122,15 @@ $people[0]['name'] = 'BlaBla';
 var_dump($people[0]['name']);
 
 ?>
---EXPECTF--
+--EXPECT--
 string(3) "Foo"
 string(6) "FooBar"
 string(9) "FooBarBaz"
 ===ArrayOverloading===
 ArrayProxy::__construct(0)
-object(ArrayProxy)#%d (2) {
+object(ArrayProxy)#1 (2) {
   ["object":"ArrayProxy":private]=>
-  object(Peoples)#%d (1) {
+  object(Peoples)#2 (1) {
     ["person"]=>
     array(1) {
       [0]=>
@@ -165,9 +165,9 @@ string(12) "FooBarBarBaz"
 ArrayProxy::__construct(0)
 ArrayProxy::offsetUnset(0, name)
 ArrayProxy::__construct(0)
-object(ArrayProxy)#%d (2) {
+object(ArrayProxy)#1 (2) {
   ["object":"ArrayProxy":private]=>
-  object(Peoples)#%d (1) {
+  object(Peoples)#2 (1) {
     ["person"]=>
     array(1) {
       [0]=>

--- a/tests/classes/autoload_006.phpt
+++ b/tests/classes/autoload_006.phpt
@@ -24,12 +24,12 @@ var_dump(interface_exists('autoload_interface', false));
 var_dump(class_exists('autoload_implements', false));
 
 ?>
---EXPECTF--
+--EXPECT--
 bool(false)
 bool(false)
 autoload(autoload_interface)
 autoload(Autoload_Implements)
-object(autoload_implements)#%d (0) {
+object(autoload_implements)#2 (0) {
 }
 bool(true)
 bool(true)

--- a/tests/classes/bug27468.phpt
+++ b/tests/classes/bug27468.phpt
@@ -11,7 +11,7 @@ new foo();
 echo 'OK';
 ?>
 --EXPECTF--
-Warning: Undefined property: foo::$x in %s on line %d
+Warning: Undefined property foo::$x in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %sbug27468.php on line 4
 OK

--- a/tests/classes/bug27504.phpt
+++ b/tests/classes/bug27504.phpt
@@ -28,4 +28,4 @@ try {
 --EXPECT--
 Called function foo:bar(1)
 call_user_func_array(): Argument #1 ($function) must be a valid callback, cannot access private method foo::bar()
-Call to private method foo::bar() from global scope
+Private method foo::bar() cannot be called from the global scope

--- a/tests/classes/bug29446.phpt
+++ b/tests/classes/bug29446.phpt
@@ -16,4 +16,4 @@ $test = new testClass;
 
 ?>
 --EXPECTF--
-Fatal error: Cannot redefine class constant testClass::TEST_CONST in %s on line 5
+Fatal error: Constant testClass::TEST_CONST cannot be redefined in %s on line %d

--- a/tests/classes/class_abstract.phpt
+++ b/tests/classes/class_abstract.phpt
@@ -23,7 +23,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 base
 
-Fatal error: Uncaught Error: Cannot instantiate abstract class base in %s:%d
+Fatal error: Uncaught Error: Abstract class base cannot be instantiated in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/class_final.phpt
+++ b/tests/classes/class_final.phpt
@@ -17,4 +17,4 @@ class derived extends base {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Class derived may not inherit from final class (base) in %s on line %d
+Fatal error: Class derived cannot extend final class base in %s on line %d

--- a/tests/classes/clone_005.phpt
+++ b/tests/classes/clone_005.phpt
@@ -16,4 +16,4 @@ class test extends base {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot override final method base::__clone() in %sclone_005.php on line 11
+Fatal error: Method test::__clone() cannot override final method base::__clone() in %s on line %d

--- a/tests/classes/clone_006.phpt
+++ b/tests/classes/clone_006.phpt
@@ -33,14 +33,14 @@ echo $clone->address . "\n";
 
 ?>
 --EXPECTF--
-Notice: Accessing static property MyCloneable::$id as non static in %s on line %d
+Notice: Accessing static property MyCloneable::$id as non-static in %s on line %d
 
-Notice: Accessing static property MyCloneable::$id as non static in %s on line %d
+Notice: Accessing static property MyCloneable::$id as non-static in %s on line %d
 0
 
-Notice: Accessing static property MyCloneable::$id as non static in %s on line %d
+Notice: Accessing static property MyCloneable::$id as non-static in %s on line %d
 
-Notice: Accessing static property MyCloneable::$id as non static in %s on line %d
+Notice: Accessing static property MyCloneable::$id as non-static in %s on line %d
 1
 Hello
 New York

--- a/tests/classes/constants_basic_002.phpt
+++ b/tests/classes/constants_basic_002.phpt
@@ -23,7 +23,7 @@ string(5) "hello"
 
 Fail to read class constant from instance.
 
-Warning: Undefined property: aclass::$myConst in %s on line %d
+Warning: Undefined property aclass::$myConst in %s on line %d
 NULL
 
 Class constant not visible in object var_dump.

--- a/tests/classes/constants_error_001.phpt
+++ b/tests/classes/constants_error_001.phpt
@@ -9,4 +9,4 @@ Error case: duplicate class constant definition
   }
 ?>
 --EXPECTF--
-Fatal error: Cannot redefine class constant myclass::myConst in %s on line 5
+Fatal error: Constant myclass::myConst cannot be redefined in %s on line %d

--- a/tests/classes/constants_visibility_002.phpt
+++ b/tests/classes/constants_visibility_002.phpt
@@ -24,4 +24,4 @@ try {
 --EXPECT--
 string(14) "protectedConst"
 string(14) "protectedConst"
-Cannot access protected constant A::protectedConst
+Protected constant A::protectedConst cannot be accessed from the global scope

--- a/tests/classes/constants_visibility_003.phpt
+++ b/tests/classes/constants_visibility_003.phpt
@@ -24,4 +24,4 @@ try {
 --EXPECT--
 string(12) "privateConst"
 string(12) "privateConst"
-Cannot access private constant A::privateConst
+Private constant A::privateConst cannot be accessed from the global scope

--- a/tests/classes/constants_visibility_005.phpt
+++ b/tests/classes/constants_visibility_005.phpt
@@ -7,4 +7,4 @@ class A {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'static' as constant modifier in %s on line 3
+Fatal error: Cannot use "static" as constant modifier in %s on line %d

--- a/tests/classes/constants_visibility_006.phpt
+++ b/tests/classes/constants_visibility_006.phpt
@@ -7,4 +7,4 @@ class A {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'abstract' as constant modifier in %s on line 3
+Fatal error: Cannot use "abstract" as constant modifier in %s on line %d

--- a/tests/classes/constants_visibility_007.phpt
+++ b/tests/classes/constants_visibility_007.phpt
@@ -7,4 +7,4 @@ class A {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use 'final' as constant modifier in %s on line 3
+Fatal error: Cannot use "final" as constant modifier in %s on line %d

--- a/tests/classes/constants_visibility_error_001.phpt
+++ b/tests/classes/constants_visibility_error_001.phpt
@@ -10,7 +10,7 @@ var_dump(A::privateConst);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access private constant A::privateConst in %s:6
+Fatal error: Uncaught Error: Private constant A::privateConst cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line 6

--- a/tests/classes/constants_visibility_error_002.phpt
+++ b/tests/classes/constants_visibility_error_002.phpt
@@ -10,7 +10,7 @@ var_dump(A::protectedConst);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot access protected constant A::protectedConst in %s:6
+Fatal error: Uncaught Error: Protected constant A::protectedConst cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line 6

--- a/tests/classes/constants_visibility_error_003.phpt
+++ b/tests/classes/constants_visibility_error_003.phpt
@@ -11,4 +11,4 @@ class B extends A {
     protected const publicConst = 1;
 }
 --EXPECTF--
-Fatal error: Access level to B::publicConst must be public (as in class A) in %s on line 9
+Fatal error: Constant B::publicConst must have public visibility to be compatible with overridden constant A::publicConst in %s on line %d

--- a/tests/classes/constants_visibility_error_004.phpt
+++ b/tests/classes/constants_visibility_error_004.phpt
@@ -11,4 +11,4 @@ class B extends A {
     private const protectedConst = 1;
 }
 --EXPECTF--
-Fatal error: Access level to B::protectedConst must be protected (as in class A) or weaker in %s on line 9
+Fatal error: Constant B::protectedConst must have protected or public visibility to be compatible with overridden constant A::protectedConst in %s on line %d

--- a/tests/classes/ctor_visibility.phpt
+++ b/tests/classes/ctor_visibility.phpt
@@ -66,7 +66,7 @@ Test::__construct()
 TestPriv::__construct()
 DerivedPriv::__construct()
 
-Fatal error: Uncaught Error: Cannot call private TestPriv::__construct() in %sctor_visibility.php:%d
+Fatal error: Uncaught Error: Private method TestPriv::__construct() cannot be called from the scope of class DerivedPriv in %s:%d
 Stack trace:
 #0 %s(%d): DerivedPriv->__construct()
 #1 %s(%d): DerivedPriv::f()

--- a/tests/classes/destructor_visibility_001.phpt
+++ b/tests/classes/destructor_visibility_001.phpt
@@ -19,7 +19,7 @@ unset($obj);
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private Derived::__destruct() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method Derived::__destruct() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sdestructor_visibility_001.php on line %d

--- a/tests/classes/destructor_visibility_002.phpt
+++ b/tests/classes/destructor_visibility_002.phpt
@@ -19,4 +19,4 @@ $obj = new Derived;
 --EXPECT--
 ===DONE===
 
-Warning: Call to private Derived::__destruct() from global scope during shutdown ignored in Unknown on line 0
+Warning: Call to private Derived::__destruct() from the global scope during shutdown is ignored in Unknown on line 0

--- a/tests/classes/factory_and_singleton_002.phpt
+++ b/tests/classes/factory_and_singleton_002.phpt
@@ -95,4 +95,4 @@ int(1)
 int(1)
 Done
 
-Warning: Call to protected test::__destruct() from global scope during shutdown ignored in Unknown on line 0
+Warning: Call to protected test::__destruct() from the global scope during shutdown is ignored in Unknown on line 0

--- a/tests/classes/factory_and_singleton_003.phpt
+++ b/tests/classes/factory_and_singleton_003.phpt
@@ -13,7 +13,7 @@ $obj = new test;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to protected test::__construct() from global scope in %s:%d
+Fatal error: Uncaught Error: Protected method test::__construct() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/factory_and_singleton_004.phpt
+++ b/tests/classes/factory_and_singleton_004.phpt
@@ -13,7 +13,7 @@ $obj = new test;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private test::__construct() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method test::__construct() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/factory_and_singleton_005.phpt
+++ b/tests/classes/factory_and_singleton_005.phpt
@@ -14,7 +14,7 @@ $obj = NULL;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to protected test::__destruct() from global scope in %s:%d
+Fatal error: Uncaught Error: Protected method test::__destruct() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sfactory_and_singleton_005.php on line %d

--- a/tests/classes/factory_and_singleton_006.phpt
+++ b/tests/classes/factory_and_singleton_006.phpt
@@ -14,7 +14,7 @@ $obj = NULL;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private test::__destruct() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method test::__destruct() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sfactory_and_singleton_006.php on line %d

--- a/tests/classes/factory_and_singleton_007.phpt
+++ b/tests/classes/factory_and_singleton_007.phpt
@@ -15,7 +15,7 @@ $obj = NULL;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to protected test::__clone() from global scope in %s:%d
+Fatal error: Uncaught Error: Protected method test::__clone() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/factory_and_singleton_008.phpt
+++ b/tests/classes/factory_and_singleton_008.phpt
@@ -15,7 +15,7 @@ $obj = NULL;
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to private test::__clone() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method test::__clone() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/factory_and_singleton_009.phpt
+++ b/tests/classes/factory_and_singleton_009.phpt
@@ -16,4 +16,4 @@ $obj = new test;
 --EXPECT--
 ===DONE===
 
-Warning: Call to protected test::__destruct() from global scope during shutdown ignored in Unknown on line 0
+Warning: Call to protected test::__destruct() from the global scope during shutdown is ignored in Unknown on line 0

--- a/tests/classes/factory_and_singleton_010.phpt
+++ b/tests/classes/factory_and_singleton_010.phpt
@@ -16,4 +16,4 @@ $obj = new test;
 --EXPECT--
 ===DONE===
 
-Warning: Call to private test::__destruct() from global scope during shutdown ignored in Unknown on line 0
+Warning: Call to private test::__destruct() from the global scope during shutdown is ignored in Unknown on line 0

--- a/tests/classes/final_ctor1.phpt
+++ b/tests/classes/final_ctor1.phpt
@@ -23,4 +23,4 @@ class Extended extends Base
 
 ?>
 --EXPECTF--
-Fatal error: Cannot override final method Base::__construct() in %s on line %d
+Fatal error: Method Extended::__construct() cannot override final method Base::__construct() in %s on line %d

--- a/tests/classes/final_private_ctor.phpt
+++ b/tests/classes/final_private_ctor.phpt
@@ -18,4 +18,4 @@ class Extended extends Base
 
 ?>
 --EXPECTF--
-Fatal error: Cannot override final method Base::__construct() in %s on line %d
+Fatal error: Method Extended::__construct() cannot override final method Base::__construct() in %s on line %d

--- a/tests/classes/final_redeclare.phpt
+++ b/tests/classes/final_redeclare.phpt
@@ -20,4 +20,4 @@ class fail extends pass {
 echo "Done\n"; // Shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Cannot override final method pass::show() in %s on line 12
+Fatal error: Method fail::show() cannot override final method pass::show() in %s on line %d

--- a/tests/classes/interface_and_extends.phpt
+++ b/tests/classes/interface_and_extends.phpt
@@ -21,4 +21,4 @@ $o->show();
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Class Tester cannot extend from interface Test in %sinterface_and_extends.php on line %d
+Fatal error: Class Tester cannot extend interface Test in %s on line %d

--- a/tests/classes/interface_constant_inheritance_006.phpt
+++ b/tests/classes/interface_constant_inheritance_006.phpt
@@ -6,4 +6,4 @@ interface A {
     protected const FOO = 10;
 }
 --EXPECTF--
-Fatal error: Access type for interface constant A::FOO must be public in %s on line 3
+Fatal error: Interface constant A::FOO must have public visibility in %s on line %d

--- a/tests/classes/interface_constant_inheritance_007.phpt
+++ b/tests/classes/interface_constant_inheritance_007.phpt
@@ -6,4 +6,4 @@ interface A {
     private const FOO = 10;
 }
 --EXPECTF--
-Fatal error: Access type for interface constant A::FOO must be public in %s on line 3
+Fatal error: Interface constant A::FOO must have public visibility in %s on line %d

--- a/tests/classes/interface_instantiate.phpt
+++ b/tests/classes/interface_instantiate.phpt
@@ -11,7 +11,7 @@ $t = new if_a();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot instantiate interface if_a in %s:%d
+Fatal error: Uncaught Error: Interface if_a cannot be instantiated in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/interface_method.phpt
+++ b/tests/classes/interface_method.phpt
@@ -9,4 +9,4 @@ interface if_a {
 
 ?>
 --EXPECTF--
-Fatal error: Interface function if_a::err() cannot contain body %s on line %d
+Fatal error: Interface method if_a::err() cannot have a body in %s on line %d

--- a/tests/classes/interface_method_private.phpt
+++ b/tests/classes/interface_method_private.phpt
@@ -9,4 +9,4 @@ interface if_a {
 
 ?>
 --EXPECTF--
-Fatal error: Access type for interface method if_a::err() must be omitted in %s on line %d
+Fatal error: Interface method if_a::err() must have public visibility in %s on line %d

--- a/tests/classes/interfaces_003.phpt
+++ b/tests/classes/interfaces_003.phpt
@@ -22,8 +22,8 @@ $obj = new MyTestClass;
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Uncaught ArgumentCountError: Too few arguments to function MyTestClass::__construct(), 0 passed in %sinterfaces_003.php on line 17 and exactly 1 expected in %sinterfaces_003.php:12
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function MyTestClass::__construct(), 0 passed in %s:%d
 Stack trace:
 #0 %s(%d): MyTestClass->__construct()
 #1 {main}
-  thrown in %sinterfaces_003.php on line %d
+  thrown in %s on line %d

--- a/tests/classes/private_001.phpt
+++ b/tests/classes/private_001.phpt
@@ -21,7 +21,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught Error: Call to private method pass::show() from global scope in %s:%d
+Fatal error: Uncaught Error: Private method pass::show() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/private_002.phpt
+++ b/tests/classes/private_002.phpt
@@ -30,7 +30,7 @@ echo "Done\n"; // shouldn't be displayed
 Call pass::show()
 Call fail::show()
 
-Fatal error: Uncaught Error: Call to private method pass::show() from scope fail in %s:%d
+Fatal error: Uncaught Error: Private method pass::show() cannot be called from the scope of class fail in %s:%d
 Stack trace:
 #0 %s(%d): fail::show()
 #1 {main}

--- a/tests/classes/private_003.phpt
+++ b/tests/classes/private_003.phpt
@@ -31,7 +31,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught Error: Call to private method pass::show() from scope fail in %s:%d
+Fatal error: Uncaught Error: Private method pass::show() cannot be called from the scope of class fail in %s:%d
 Stack trace:
 #0 %s(%d): fail::not_ok()
 #1 {main}

--- a/tests/classes/private_003b.phpt
+++ b/tests/classes/private_003b.phpt
@@ -32,7 +32,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught Error: Call to private method pass::show() from scope fail in %s:%d
+Fatal error: Uncaught Error: Private method pass::show() cannot be called from the scope of class fail in %s:%d
 Stack trace:
 #0 %s(%d): fail->not_ok()
 #1 {main}

--- a/tests/classes/private_004.phpt
+++ b/tests/classes/private_004.phpt
@@ -27,7 +27,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught Error: Call to private method pass::show() from scope fail in %s:%d
+Fatal error: Uncaught Error: Private method pass::show() cannot be called from the scope of class fail in %s:%d
 Stack trace:
 #0 %s(%d): fail::do_show()
 #1 {main}

--- a/tests/classes/private_004b.phpt
+++ b/tests/classes/private_004b.phpt
@@ -30,7 +30,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught Error: Call to private method pass::show() from scope fail in %s:%d
+Fatal error: Uncaught Error: Private method pass::show() cannot be called from the scope of class fail in %s:%d
 Stack trace:
 #0 %s(%d): fail->do_show()
 #1 {main}

--- a/tests/classes/private_005.phpt
+++ b/tests/classes/private_005.phpt
@@ -27,7 +27,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call show()
 
-Fatal error: Uncaught Error: Call to private method pass::show() from scope fail in %s:%d
+Fatal error: Uncaught Error: Private method pass::show() cannot be called from the scope of class fail in %s:%d
 Stack trace:
 #0 %s(%d): fail::do_show()
 #1 {main}

--- a/tests/classes/private_redeclare.phpt
+++ b/tests/classes/private_redeclare.phpt
@@ -35,7 +35,7 @@ test
 derived
 base
 
-Fatal error: Uncaught Error: Call to private method base::show() from scope derived in %s:%d
+Fatal error: Uncaught Error: Private method base::show() cannot be called from the scope of class derived in %s:%d
 Stack trace:
 #0 %s(%d): derived->test()
 #1 {main}

--- a/tests/classes/property_override_protectedStatic_private.phpt
+++ b/tests/classes/property_override_protectedStatic_private.phpt
@@ -28,4 +28,4 @@ Redeclare inherited protected static property as private.
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare static A::$p as non static B::$p in %s on line 18
+Fatal error: Property B::$p must be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_protectedStatic_privateStatic.phpt
+++ b/tests/classes/property_override_protectedStatic_privateStatic.phpt
@@ -27,4 +27,4 @@ Redeclare inherited protected static property as private static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Access level to B::$p must be protected (as in class A) or weaker in %s on line 18
+Fatal error: Property B::$p must have protected or public visibility to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_protectedStatic_protected.phpt
+++ b/tests/classes/property_override_protectedStatic_protected.phpt
@@ -28,4 +28,4 @@ Redeclare inherited protected static property as protected.
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare static A::$p as non static B::$p in %s on line 18
+Fatal error: Property B::$p must be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_protectedStatic_public.phpt
+++ b/tests/classes/property_override_protectedStatic_public.phpt
@@ -28,4 +28,4 @@ Redeclare inherited protected static property as public.
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare static A::$p as non static B::$p in %s on line 18
+Fatal error: Property B::$p must be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_protected_private.phpt
+++ b/tests/classes/property_override_protected_private.phpt
@@ -29,4 +29,4 @@ Redeclare inherited protected property as private (duplicates Zend/tests/errmsg_
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Access level to B::$p must be protected (as in class A) or weaker in %s on line 18
+Fatal error: Property B::$p must have protected or public visibility to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_protected_privateStatic.phpt
+++ b/tests/classes/property_override_protected_privateStatic.phpt
@@ -29,4 +29,4 @@ Redeclare inherited protected property as private static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare non static A::$p as static B::$p in %s on line 18
+Fatal error: Property B::$p must not be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_protected_protectedStatic.phpt
+++ b/tests/classes/property_override_protected_protectedStatic.phpt
@@ -29,4 +29,4 @@ Redeclare inherited protected property as protected static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare non static A::$p as static B::$p in %s on line 18
+Fatal error: Property B::$p must not be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_protected_publicStatic.phpt
+++ b/tests/classes/property_override_protected_publicStatic.phpt
@@ -29,4 +29,4 @@ Redeclare inherited protected property as public static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare non static A::$p as static B::$p in %s on line 18
+Fatal error: Property B::$p must not be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_publicStatic_private.phpt
+++ b/tests/classes/property_override_publicStatic_private.phpt
@@ -28,4 +28,4 @@ Redeclare inherited public static property as private.
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare static A::$p as non static B::$p in %s on line 18
+Fatal error: Property B::$p must be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_publicStatic_privateStatic.phpt
+++ b/tests/classes/property_override_publicStatic_privateStatic.phpt
@@ -27,4 +27,4 @@ Redeclare inherited public static property as private static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Access level to B::$p must be public (as in class A) in %s on line 18
+Fatal error: Property B::$p must have public visibility to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_publicStatic_protected.phpt
+++ b/tests/classes/property_override_publicStatic_protected.phpt
@@ -28,4 +28,4 @@ Redeclare inherited public static property as protected.
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare static A::$p as non static B::$p in %s on line 18
+Fatal error: Property B::$p must be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_publicStatic_protectedStatic.phpt
+++ b/tests/classes/property_override_publicStatic_protectedStatic.phpt
@@ -27,4 +27,4 @@ Redeclare inherited public static property as protected static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Access level to B::$p must be public (as in class A) in %s on line 18
+Fatal error: Property B::$p must have public visibility to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_publicStatic_public.phpt
+++ b/tests/classes/property_override_publicStatic_public.phpt
@@ -28,4 +28,4 @@ Redeclare inherited public static property as public.
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare static A::$p as non static B::$p in %s on line 18
+Fatal error: Property B::$p must be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_public_private.phpt
+++ b/tests/classes/property_override_public_private.phpt
@@ -29,4 +29,4 @@ Redeclare inherited public property as private.
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Access level to B::$p must be public (as in class A) in %s on line 18
+Fatal error: Property B::$p must have public visibility to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_public_privateStatic.phpt
+++ b/tests/classes/property_override_public_privateStatic.phpt
@@ -29,4 +29,4 @@ Redeclare inherited public property as private static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare non static A::$p as static B::$p in %s on line 18
+Fatal error: Property B::$p must not be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_public_protected.phpt
+++ b/tests/classes/property_override_public_protected.phpt
@@ -29,4 +29,4 @@ Redeclare inherited public property as protected.
   $b->showB();
 ?>
 --EXPECTF--
-Fatal error: Access level to B::$p must be public (as in class A) in %s on line 18
+Fatal error: Property B::$p must have public visibility to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_public_protectedStatic.phpt
+++ b/tests/classes/property_override_public_protectedStatic.phpt
@@ -29,4 +29,4 @@ Redeclare inherited public property as protected static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare non static A::$p as static B::$p in %s on line 18
+Fatal error: Property B::$p must not be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_override_public_publicStatic.phpt
+++ b/tests/classes/property_override_public_publicStatic.phpt
@@ -29,4 +29,4 @@ Redeclare inherited public property as public static.
   B::showB();
 ?>
 --EXPECTF--
-Fatal error: Cannot redeclare non static A::$p as static B::$p in %s on line 18
+Fatal error: Property B::$p must not be static to be compatible with overridden property A::$p in %s on line %d

--- a/tests/classes/property_recreate_private.phpt
+++ b/tests/classes/property_recreate_private.phpt
@@ -78,7 +78,7 @@ object(C)#%d (1) {
 
 Unset a private property, and attempt to recreate at global scope (expecting failure):
 
-Fatal error: Uncaught Error: Cannot access private property C::$p in %s:46
+Fatal error: Uncaught Error: Private property C::$p cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line 46

--- a/tests/classes/property_recreate_protected.phpt
+++ b/tests/classes/property_recreate_protected.phpt
@@ -50,7 +50,7 @@ object(D)#%d (1) {
 
 Unset a protected property, and attempt to recreate it outside of scope (expected failure):
 
-Fatal error: Uncaught Error: Cannot access protected property %s::$p in %s:32
+Fatal error: Uncaught Error: Protected property D::$p cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line 32

--- a/tests/classes/protected_001.phpt
+++ b/tests/classes/protected_001.phpt
@@ -21,7 +21,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call fail()
 
-Fatal error: Uncaught Error: Call to protected method pass::fail() from global scope in %s:%d
+Fatal error: Uncaught Error: Protected method pass::fail() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/protected_001b.phpt
+++ b/tests/classes/protected_001b.phpt
@@ -22,7 +22,7 @@ echo "Done\n"; // shouldn't be displayed
 --EXPECTF--
 Call fail()
 
-Fatal error: Uncaught Error: Call to protected method pass::fail() from global scope in %s:%d
+Fatal error: Uncaught Error: Protected method pass::fail() cannot be called from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/protected_002.phpt
+++ b/tests/classes/protected_002.phpt
@@ -30,7 +30,7 @@ echo "Done\n"; // shouldn't be displayed
 Call pass::show()
 Call fail::show()
 
-Fatal error: Uncaught Error: Call to protected method pass::show() from scope fail in %s:%d
+Fatal error: Uncaught Error: Protected method pass::show() cannot be called from the scope of class fail in %s:%d
 Stack trace:
 #0 %s(%d): fail::show()
 #1 {main}

--- a/tests/classes/static_mix_1.phpt
+++ b/tests/classes/static_mix_1.phpt
@@ -21,4 +21,4 @@ fail::show();
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Cannot make static method pass::show() non static in class fail in %s on line 10
+Fatal error: Method fail::show() must be static to be compatible with overridden method pass::show() in %s on line %d

--- a/tests/classes/static_mix_2.phpt
+++ b/tests/classes/static_mix_2.phpt
@@ -22,4 +22,4 @@ fail::show();
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Cannot make non static method pass::show() static in class fail in %s on line 10
+Fatal error: Method fail::show() must not be static to be compatible with overridden method pass::show() in %s on line %d

--- a/tests/classes/static_properties_003.phpt
+++ b/tests/classes/static_properties_003.phpt
@@ -29,17 +29,17 @@ var_dump(isset($c->y));
 --> Access visible static prop like instance prop:
 bool(false)
 
-Notice: Accessing static property C::$x as non static in %s on line 11
+Notice: Accessing static property C::$x as non-static in %s on line %d
 
-Notice: Accessing static property C::$x as non static in %s on line 12
+Notice: Accessing static property C::$x as non-static in %s on line %d
 
-Warning: Undefined property: C::$x in %s on line %d
+Warning: Undefined property C::$x in %s on line %d
 
-Notice: Accessing static property C::$x as non static in %s on line 13
+Notice: Accessing static property C::$x as non-static in %s on line %d
 
-Notice: Accessing static property C::$x as non static in %s on line 15
+Notice: Accessing static property C::$x as non-static in %s on line %d
 
-Notice: Accessing static property C::$x as non static in %s on line 16
+Notice: Accessing static property C::$x as non-static in %s on line %d
 string(3) "ref"
 string(5) "C::$x"
 

--- a/tests/classes/static_properties_003_error1.phpt
+++ b/tests/classes/static_properties_003_error1.phpt
@@ -14,7 +14,7 @@ unset($c->y);
 --EXPECTF--
 --> Access non-visible static prop like instance prop:
 
-Fatal error: Uncaught Error: Cannot access protected property C::$y in %s:8
+Fatal error: Uncaught Error: Protected property C::$y cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line 8

--- a/tests/classes/static_properties_003_error2.phpt
+++ b/tests/classes/static_properties_003_error2.phpt
@@ -14,7 +14,7 @@ echo $c->y;
 --EXPECTF--
 --> Access non-visible static prop like instance prop:
 
-Fatal error: Uncaught Error: Cannot access protected property C::$y in %s:8
+Fatal error: Uncaught Error: Protected property C::$y cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line 8

--- a/tests/classes/static_properties_003_error3.phpt
+++ b/tests/classes/static_properties_003_error3.phpt
@@ -14,7 +14,7 @@ $c->y = 1;
 --EXPECTF--
 --> Access non-visible static prop like instance prop:
 
-Fatal error: Uncaught Error: Cannot access protected property C::$y in %s:8
+Fatal error: Uncaught Error: Protected property C::$y cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line 8

--- a/tests/classes/static_properties_003_error4.phpt
+++ b/tests/classes/static_properties_003_error4.phpt
@@ -16,6 +16,6 @@ try {
 ?>
 --EXPECTF--
 --> Access non-visible static prop like instance prop:
-Error: Cannot access protected property C::$y in %s:%d
+Error: Protected property C::$y cannot be accessed from the global scope in %s:%d
 Stack trace:
 #0 {main}

--- a/tests/classes/static_this.phpt
+++ b/tests/classes/static_this.phpt
@@ -28,4 +28,4 @@ TestClass::Test2(new stdClass);
 ?>
 ===DONE===
 --EXPECTF--
-Fatal error: Cannot use $this as parameter in %sstatic_this.php on line 16
+Fatal error: TestClass::Test2(): Parameter #1 cannot be called $this in %s on line %d

--- a/tests/classes/type_hinting_001.phpt
+++ b/tests/classes/type_hinting_001.phpt
@@ -32,8 +32,8 @@ $a->b($b);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: FooBar::a(): Argument #1 ($foo) must be of type Foo, Blort given, called in %s on line 27 and defined in %s:12
+Fatal error: Uncaught TypeError: FooBar::a(): Argument #1 ($foo) must be of type Foo, Blort given, called in %s:%d
 Stack trace:
 #0 %s(%d): FooBar->a(Object(Blort))
 #1 {main}
-  thrown in %s on line 12
+  thrown in %s on line %d

--- a/tests/classes/visibility_000a.phpt
+++ b/tests/classes/visibility_000a.phpt
@@ -28,4 +28,4 @@ class fail extends same {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Access level to fail::f0() must be public (as in class same) in %s on line 22
+Fatal error: Method fail::f0() must have public visibility to be compatible with overridden method same::f0() in %s on line %d

--- a/tests/classes/visibility_000b.phpt
+++ b/tests/classes/visibility_000b.phpt
@@ -28,4 +28,4 @@ class fail extends same {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Access level to fail::f0() must be public (as in class same) in %s on line 22
+Fatal error: Method fail::f0() must have public visibility to be compatible with overridden method same::f0() in %s on line %d

--- a/tests/classes/visibility_001a.phpt
+++ b/tests/classes/visibility_001a.phpt
@@ -28,4 +28,4 @@ class fail extends same {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Access level to fail::f1() must be public (as in class same) in %s on line 22
+Fatal error: Method fail::f1() must have public visibility to be compatible with overridden method same::f1() in %s on line %d

--- a/tests/classes/visibility_001b.phpt
+++ b/tests/classes/visibility_001b.phpt
@@ -28,4 +28,4 @@ class fail extends same {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Access level to fail::f1() must be public (as in class same) in %s on line 22
+Fatal error: Method fail::f1() must have public visibility to be compatible with overridden method same::f1() in %s on line %d

--- a/tests/classes/visibility_002a.phpt
+++ b/tests/classes/visibility_002a.phpt
@@ -28,4 +28,4 @@ class fail extends same {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Access level to fail::f2() must be public (as in class same) in %s on line 22
+Fatal error: Method fail::f2() must have public visibility to be compatible with overridden method same::f2() in %s on line %d

--- a/tests/classes/visibility_002b.phpt
+++ b/tests/classes/visibility_002b.phpt
@@ -28,4 +28,4 @@ class fail extends same {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Access level to fail::f2() must be public (as in class same) in %s on line 22
+Fatal error: Method fail::f2() must have public visibility to be compatible with overridden method same::f2() in %s on line %d

--- a/tests/classes/visibility_003b.phpt
+++ b/tests/classes/visibility_003b.phpt
@@ -28,4 +28,4 @@ class fail extends same {
 echo "Done\n"; // shouldn't be displayed
 ?>
 --EXPECTF--
-Fatal error: Access level to fail::f3() must be protected (as in class same) or weaker in %s on line 22
+Fatal error: Method fail::f3() must have protected or public visibility to be compatible with overridden method same::f3() in %s on line %d

--- a/tests/lang/bug27439.phpt
+++ b/tests/lang/bug27439.phpt
@@ -65,7 +65,7 @@ echo "===DONE===";
 ?>
 --EXPECTF--
 123
-Warning: Undefined property: test::$foobar in %s on line %d
+Warning: Undefined property test::$foobar in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d
 

--- a/tests/lang/foreachLoopObjects.004.phpt
+++ b/tests/lang/foreachLoopObjects.004.phpt
@@ -33,13 +33,13 @@ Removing the current element from an iterated object.
 string(10) "Original a"
 string(10) "Original b"
 
-Warning: Undefined property: C::$b in %s on line %d
+Warning: Undefined property C::$b in %s on line %d
 string(10) "Original c"
 
-Warning: Undefined property: C::$b in %s on line %d
+Warning: Undefined property C::$b in %s on line %d
 string(10) "Original d"
 
-Warning: Undefined property: C::$b in %s on line %d
+Warning: Undefined property C::$b in %s on line %d
 string(10) "Original e"
 object(C)#%d (4) {
   ["a"]=>

--- a/tests/lang/type_hints_003.phpt
+++ b/tests/lang/type_hints_003.phpt
@@ -8,4 +8,4 @@ class T {
 }
 ?>
 --EXPECTF--
-Fatal error: Cannot use int as default value for parameter $p of type P in %s on line %d
+Fatal error: T::f(): Parameter #1 ($p) of type P cannot have a default value of type int in %s on line %d


### PR DESCRIPTION
This PR tries to make quite a few error message more uniform with the already refactored error messages by using a similar message format, using better wording, adding more context, and sometimes fixing factual errors (e.g. a few messages mentioned `break operator` while it's a statement).

However, probably the core change in this PR is the many messages will follow a similar order of wording. Currently, the "target" of the problem (which is usually the subject or the object of the sentence) can either be mentioned in the beginning, in the middle, or at the end:
- **Class A** cannot extend from trait foo
- Call to **protected C4::__construct()** from scope B4
- Cannot declare self-referencing **constant self::B**

I believe this inconsistency increases the mental overhead of processing the error messages. I even remember a few cases when I faced many consecutive errors and it wasn't easy for me to adapt to the different order of the words. With this PR, many messages were changed to start with the "target", so the above examples will look like the following way:
- **Class A** cannot extend trait foo
- **Protected method C4::__construct()** cannot be called from the scope of class B4
- **Constant self::B** cannot reference itself