### PR TITLE
Implementation for StackFrame class as an alternative to debug_backtrace()

### DIFF
--- a/Zend/tests/stack_frame_001.phpt
+++ b/Zend/tests/stack_frame_001.phpt
@@ -16,10 +16,12 @@ var_dump([
     'type' => $frame->type,
     'object' => $frame->object,
     'args' => $frame->args,
+    'object_class' => $frame->object_class,
+    'closure' => $frame->closure,
 ]);
 
 --EXPECTF--
-array(7) {
+array(%d) {
   ["file"]=>
   string(%d) "%s.php"
   ["line"]=>
@@ -35,4 +37,8 @@ array(7) {
   ["args"]=>
   array(0) {
   }
+  ["object_class"]=>
+  NULL
+  ["closure"]=>
+  NULL
 }

--- a/Zend/tests/stack_frame_001.phpt
+++ b/Zend/tests/stack_frame_001.phpt
@@ -1,0 +1,38 @@
+--TEST--
+StackFrame read properties
+--FILE--
+<?php
+
+function frames() {
+    return StackFrame::getTrace();
+}
+$frame = frames()[0];
+
+var_dump([
+    'file' => $frame->file,
+    'line' => $frame->line,
+    'function' => $frame->function,
+    'class' => $frame->class,
+    'type' => $frame->type,
+    'object' => $frame->object,
+    'args' => $frame->args,
+]);
+
+--EXPECTF--
+array(7) {
+  ["file"]=>
+  string(%d) "%s.php"
+  ["line"]=>
+  int(%d)
+  ["function"]=>
+  string(6) "frames"
+  ["class"]=>
+  NULL
+  ["type"]=>
+  NULL
+  ["object"]=>
+  NULL
+  ["args"]=>
+  array(0) {
+  }
+}

--- a/Zend/tests/stack_frame_002.phpt
+++ b/Zend/tests/stack_frame_002.phpt
@@ -1,0 +1,38 @@
+--TEST--
+StackFrame read dimensions
+--FILE--
+<?php
+
+function frames() {
+    return StackFrame::getTrace();
+}
+$frame = frames()[0];
+
+var_dump([
+    'file' => $frame['file'],
+    'line' => $frame['line'],
+    'function' => $frame['function'],
+    'class' => $frame['class'],
+    'type' => $frame['type'],
+    'object' => $frame['object'],
+    'args' => $frame['args'],
+]);
+
+--EXPECTF--
+array(7) {
+  ["file"]=>
+  string(%d) "%s.php"
+  ["line"]=>
+  int(%d)
+  ["function"]=>
+  string(6) "frames"
+  ["class"]=>
+  NULL
+  ["type"]=>
+  NULL
+  ["object"]=>
+  NULL
+  ["args"]=>
+  array(0) {
+  }
+}

--- a/Zend/tests/stack_frame_002.phpt
+++ b/Zend/tests/stack_frame_002.phpt
@@ -16,10 +16,12 @@ var_dump([
     'type' => $frame['type'],
     'object' => $frame['object'],
     'args' => $frame['args'],
+    'object_class' => $frame['object_class'],
+    'closure' => $frame['closure'],
 ]);
 
 --EXPECTF--
-array(7) {
+array(%d) {
   ["file"]=>
   string(%d) "%s.php"
   ["line"]=>
@@ -35,4 +37,8 @@ array(7) {
   ["args"]=>
   array(0) {
   }
+  ["object_class"]=>
+  NULL
+  ["closure"]=>
+  NULL
 }

--- a/Zend/tests/stack_frame_003.phpt
+++ b/Zend/tests/stack_frame_003.phpt
@@ -1,0 +1,38 @@
+--TEST--
+StackFrame getters
+--FILE--
+<?php
+
+function frames() {
+    return StackFrame::getTrace();
+}
+$frame = frames()[0];
+
+var_dump([
+    'file' => $frame->getFile(),
+    'line' => $frame->getLine(),
+    'function' => $frame->getFunction(),
+    'class' => $frame->getClass(),
+    'type' => $frame->getType(),
+    'object' => $frame->getObject(),
+    'args' => $frame->getArgs(),
+]);
+
+--EXPECTF--
+array(7) {
+  ["file"]=>
+  string(%d) "%s.php"
+  ["line"]=>
+  int(%d)
+  ["function"]=>
+  string(6) "frames"
+  ["class"]=>
+  NULL
+  ["type"]=>
+  NULL
+  ["object"]=>
+  NULL
+  ["args"]=>
+  array(0) {
+  }
+}

--- a/Zend/tests/stack_frame_003.phpt
+++ b/Zend/tests/stack_frame_003.phpt
@@ -16,10 +16,12 @@ var_dump([
     'type' => $frame->getType(),
     'object' => $frame->getObject(),
     'args' => $frame->getArgs(),
+    'object_class' => $frame->getObjectClass(),
+    'closure' => $frame->getClosure(),
 ]);
 
 --EXPECTF--
-array(7) {
+array(%d) {
   ["file"]=>
   string(%d) "%s.php"
   ["line"]=>
@@ -35,4 +37,8 @@ array(7) {
   ["args"]=>
   array(0) {
   }
+  ["object_class"]=>
+  NULL
+  ["closure"]=>
+  NULL
 }

--- a/Zend/zend_builtin_functions.h
+++ b/Zend/zend_builtin_functions.h
@@ -23,7 +23,7 @@
 int zend_startup_builtin_functions(void);
 
 BEGIN_EXTERN_C()
-ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int options, int limit);
+ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int options, int limit, int as_objects);
 END_EXTERN_C()
 
 #endif /* ZEND_BUILTIN_FUNCTIONS_H */

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -796,13 +796,6 @@ static ZEND_COLD zend_function *zend_stack_frame_get_constructor(zend_object *ob
 	return NULL;
 }
 
-static ZEND_COLD zval *zend_stack_frame_object_write_property(zend_object *object, zend_string *name, zval *value, void **cache_slot)
-{
-	zend_throw_error(NULL, "'%s' objects are immutable and do not support writing properties", ZSTR_VAL(object->ce->name));
-
-	return &EG(uninitialized_zval);
-}
-
 static ZEND_COLD zval *zend_stack_frame_read_dimension(zend_object *object, zval *offset, int type, zval *rv)
 {
 	zval *retval = rv;
@@ -982,8 +975,7 @@ void zend_register_default_exception(void) /* {{{ */
 	declare_stack_frame_properties(zend_ce_stack_frame);
 
 	memcpy(&zend_stack_frame_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	// this needs different approach as it blocks property updates
-	// zend_stack_frame_handlers.write_property = zend_stack_frame_object_write_property;
+	// this needs different approach than adding fake write_property as it blocks property updates
 	zend_stack_frame_handlers.read_dimension = zend_stack_frame_read_dimension;
 	zend_stack_frame_handlers.write_dimension = zend_stack_frame_write_dimension;
 	zend_stack_frame_handlers.has_dimension = zend_stack_frame_has_dimension;

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -35,6 +35,9 @@ extern ZEND_API zend_class_entry *zend_ce_argument_count_error;
 extern ZEND_API zend_class_entry *zend_ce_value_error;
 extern ZEND_API zend_class_entry *zend_ce_arithmetic_error;
 extern ZEND_API zend_class_entry *zend_ce_division_by_zero_error;
+extern ZEND_API zend_class_entry *zend_ce_stack_frame;
+
+extern zend_object_handlers zend_stack_frame_handlers;
 
 ZEND_API void zend_exception_set_previous(zend_object *exception, zend_object *add_previous);
 ZEND_API void zend_exception_save(void);

--- a/Zend/zend_exceptions.stub.php
+++ b/Zend/zend_exceptions.stub.php
@@ -122,7 +122,7 @@ class DivisionByZeroError extends ArithmeticError
 
 final class StackFrame
 {
-    public static function getTrace(): array {}
+    public static function getTrace(int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT, int $limit = 0): array {}
 
     public function getFile(): string {}
 
@@ -133,6 +133,10 @@ final class StackFrame
     public function getClass(): ?string {}
 
     public function getObject(): ?object {}
+
+    public function getObjectClass(): ?string {}
+
+    public function getClosure(): ?\Closure {}
 
     public function getType(): ?string {}
 

--- a/Zend/zend_exceptions.stub.php
+++ b/Zend/zend_exceptions.stub.php
@@ -119,3 +119,22 @@ class ArithmeticError extends Error
 class DivisionByZeroError extends ArithmeticError
 {
 }
+
+final class StackFrame
+{
+    public static function getTrace(): array {}
+
+    public function getFile(): string {}
+
+    public function getLine(): int {}
+
+    public function getFunction(): ?string {}
+
+    public function getClass(): ?string {}
+
+    public function getObject(): ?object {}
+
+    public function getType(): ?string {}
+
+    public function getArgs(): array {}
+}

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 686db33b530c54804faf1fe5d4f8b1d6a6b06d6e */
+ * Stub hash: ef999915ca870d847b00554a51ae420e44a8602c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Throwable_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -79,7 +79,10 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Error___toString arginfo_class_Throwable_getMessage
 
-#define arginfo_class_StackFrame_getTrace arginfo_class_Throwable_getTrace
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_StackFrame_getTrace, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "DEBUG_BACKTRACE_PROVIDE_OBJECT")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_StackFrame_getFile arginfo_class_Throwable_getMessage
 
@@ -91,6 +94,11 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_StackFrame_getClass arginfo_class_StackFrame_getFunction
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_StackFrame_getObject, 0, 0, IS_OBJECT, 1)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_StackFrame_getObjectClass arginfo_class_StackFrame_getFunction
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_StackFrame_getClosure, 0, 0, Closure, 1)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_StackFrame_getType arginfo_class_StackFrame_getFunction
@@ -117,6 +125,8 @@ ZEND_METHOD(StackFrame, getLine);
 ZEND_METHOD(StackFrame, getFunction);
 ZEND_METHOD(StackFrame, getClass);
 ZEND_METHOD(StackFrame, getObject);
+ZEND_METHOD(StackFrame, getObjectClass);
+ZEND_METHOD(StackFrame, getClosure);
 ZEND_METHOD(StackFrame, getType);
 ZEND_METHOD(StackFrame, getArgs);
 
@@ -214,6 +224,8 @@ static const zend_function_entry class_StackFrame_methods[] = {
 	ZEND_ME(StackFrame, getFunction, arginfo_class_StackFrame_getFunction, ZEND_ACC_PUBLIC)
 	ZEND_ME(StackFrame, getClass, arginfo_class_StackFrame_getClass, ZEND_ACC_PUBLIC)
 	ZEND_ME(StackFrame, getObject, arginfo_class_StackFrame_getObject, ZEND_ACC_PUBLIC)
+	ZEND_ME(StackFrame, getObjectClass, arginfo_class_StackFrame_getObjectClass, ZEND_ACC_PUBLIC)
+	ZEND_ME(StackFrame, getClosure, arginfo_class_StackFrame_getClosure, ZEND_ACC_PUBLIC)
 	ZEND_ME(StackFrame, getType, arginfo_class_StackFrame_getType, ZEND_ACC_PUBLIC)
 	ZEND_ME(StackFrame, getArgs, arginfo_class_StackFrame_getArgs, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7eb20393f4ca314324d9813983124f724189ce8a */
+ * Stub hash: 686db33b530c54804faf1fe5d4f8b1d6a6b06d6e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Throwable_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -79,6 +79,24 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Error___toString arginfo_class_Throwable_getMessage
 
+#define arginfo_class_StackFrame_getTrace arginfo_class_Throwable_getTrace
+
+#define arginfo_class_StackFrame_getFile arginfo_class_Throwable_getMessage
+
+#define arginfo_class_StackFrame_getLine arginfo_class_Throwable_getLine
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_StackFrame_getFunction, 0, 0, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_StackFrame_getClass arginfo_class_StackFrame_getFunction
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_StackFrame_getObject, 0, 0, IS_OBJECT, 1)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_StackFrame_getType arginfo_class_StackFrame_getFunction
+
+#define arginfo_class_StackFrame_getArgs arginfo_class_Throwable_getTrace
+
 
 ZEND_METHOD(Exception, __clone);
 ZEND_METHOD(Exception, __construct);
@@ -93,6 +111,14 @@ ZEND_METHOD(Exception, getTraceAsString);
 ZEND_METHOD(Exception, __toString);
 ZEND_METHOD(ErrorException, __construct);
 ZEND_METHOD(ErrorException, getSeverity);
+ZEND_METHOD(StackFrame, getTrace);
+ZEND_METHOD(StackFrame, getFile);
+ZEND_METHOD(StackFrame, getLine);
+ZEND_METHOD(StackFrame, getFunction);
+ZEND_METHOD(StackFrame, getClass);
+ZEND_METHOD(StackFrame, getObject);
+ZEND_METHOD(StackFrame, getType);
+ZEND_METHOD(StackFrame, getArgs);
 
 
 static const zend_function_entry class_Throwable_methods[] = {
@@ -177,5 +203,18 @@ static const zend_function_entry class_ArithmeticError_methods[] = {
 
 
 static const zend_function_entry class_DivisionByZeroError_methods[] = {
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_StackFrame_methods[] = {
+	ZEND_ME(StackFrame, getTrace, arginfo_class_StackFrame_getTrace, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(StackFrame, getFile, arginfo_class_StackFrame_getFile, ZEND_ACC_PUBLIC)
+	ZEND_ME(StackFrame, getLine, arginfo_class_StackFrame_getLine, ZEND_ACC_PUBLIC)
+	ZEND_ME(StackFrame, getFunction, arginfo_class_StackFrame_getFunction, ZEND_ACC_PUBLIC)
+	ZEND_ME(StackFrame, getClass, arginfo_class_StackFrame_getClass, ZEND_ACC_PUBLIC)
+	ZEND_ME(StackFrame, getObject, arginfo_class_StackFrame_getObject, ZEND_ACC_PUBLIC)
+	ZEND_ME(StackFrame, getType, arginfo_class_StackFrame_getType, ZEND_ACC_PUBLIC)
+	ZEND_ME(StackFrame, getArgs, arginfo_class_StackFrame_getArgs, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -2145,7 +2145,7 @@ ZEND_METHOD(ReflectionGenerator, getTrace)
 	}
 
 	EG(current_execute_data) = root_generator->execute_data;
-	zend_fetch_debug_backtrace(return_value, 0, options, 0);
+	zend_fetch_debug_backtrace(return_value, 0, options, 0, 0);
 	EG(current_execute_data) = ex_backup;
 
 	root_generator->execute_data->prev_execute_data = root_prev;

--- a/sapi/phpdbg/phpdbg_frame.c
+++ b/sapi/phpdbg/phpdbg_frame.c
@@ -277,7 +277,7 @@ void phpdbg_dump_backtrace(size_t num) /* {{{ */
 	}
 
 	phpdbg_try_access {
-		zend_fetch_debug_backtrace(&zbacktrace, 0, 0, limit);
+		zend_fetch_debug_backtrace(&zbacktrace, 0, 0, limit, 0);
 	} phpdbg_catch_access {
 		phpdbg_error("signalsegv", "", "Couldn't fetch backtrace, invalid data source");
 		return;


### PR DESCRIPTION
This PR implements [StackFrame class](https://wiki.php.net/rfc/stack-frame-class)