### PR TITLE
fix: fix build error

### DIFF
--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -1,6 +1,8 @@
 dnl HAVE_JSON is always 1 as of php 8.0 and the constant will be removed in the future.
 dnl Note that HAVE_JSON was never defined for Windows builds (see config.w32)
 AC_DEFINE([HAVE_JSON],1 ,[whether to enable JavaScript Object Serialization support])
+$RE2C -t ext/json/php_json_scanner_defs.h --no-generation-date -bci -o ext/json/json_scanner.c ext/json/json_scanner.re
+$YACC --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c
 PHP_NEW_EXTENSION(json,
 	  json.c \
 	  json_encoder.c \

--- a/ext/json/config.m4
+++ b/ext/json/config.m4
@@ -1,8 +1,6 @@
 dnl HAVE_JSON is always 1 as of php 8.0 and the constant will be removed in the future.
 dnl Note that HAVE_JSON was never defined for Windows builds (see config.w32)
 AC_DEFINE([HAVE_JSON],1 ,[whether to enable JavaScript Object Serialization support])
-$RE2C -t ext/json/php_json_scanner_defs.h --no-generation-date -bci -o ext/json/json_scanner.c ext/json/json_scanner.re
-$YACC --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c
 PHP_NEW_EXTENSION(json,
 	  json.c \
 	  json_encoder.c \

--- a/ext/json/config.w32
+++ b/ext/json/config.w32
@@ -2,15 +2,6 @@
 
 EXTENSION('json', 'json.c', false /* never shared */, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
-if (!FSO.FileExists("ext/json/json_scanner.c")) {
-    STDOUT.WriteLine("Generating ext/json/json_scanner.c");
-    STDOUT.WriteLine(execute(PATH_PROG("re2c") + " -t ext/json/php_json_scanner_defs.h --no-generation-date -bci -o ext/json/json_scanner.c ext/json/json_scanner.re"));
-}
-if (!FSO.FileExists("ext/json/json_parser.tab.c")) {
-    STDOUT.WriteLine("Generating ext/json/json_parser.tab.c");
-    STDOUT.WriteLine(execute(PATH_PROG("bison") + " --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c"));
-}
-
 ADD_SOURCES(configure_module_dirname, "json_encoder.c json_parser.tab.c json_scanner.c", "json");
 
 ADD_MAKEFILE_FRAGMENT();


### PR DESCRIPTION
When I pull the latest master code to recompile, I found that `json_parser.tab.c` was still old and failed to compile.