### PR TITLE
define COMPILER and ARCHITECTURE from environment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1278,6 +1278,12 @@ AC_DEFINE_UNQUOTED(PHP_BUILD_SYSTEM,"$PHP_BUILD_SYSTEM",[builder uname output])
 if test -n "${PHP_BUILD_PROVIDER}"; then
   AC_DEFINE_UNQUOTED(PHP_BUILD_PROVIDER,"$PHP_BUILD_PROVIDER",[build provider])
 fi
+if test -n "${PHP_BUILD_COMPILER}"; then
+  AC_DEFINE_UNQUOTED(COMPILER,"$PHP_BUILD_COMPILER",[used compiler for build])
+fi
+if test -n "${PHP_BUILD_ARCH}"; then
+  AC_DEFINE_UNQUOTED(ARCHITECTURE,"$PHP_BUILD_ARCH",[build architecture])
+fi
 
 PHP_SUBST_OLD(PHP_INSTALLED_SAPIS)
 


### PR DESCRIPTION
`COMPILER` and `ARCHITECTURE` macros exist for a very long time and are used in some build (IIRC in Windows)

Using environment will make their usage simpler

I choose `PHP_BUILD_COMPILER` and `PHP_BUILD_ARCH` as names to avoid too generic names which may create conflicts (and we already have some `PHP_BUILD_*`, also only used for phpinfo)