### PR TITLE
Fix #63527: DCOM does not work with Username, Password parameter

### DIFF
--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -133,7 +133,7 @@ PHP_FUNCTION(com_create_instance)
 		info.pwszName = php_com_string_to_olestring(server_name, server_name_len, obj->code_page);
 
 		if (user_name) {
-			authid.User = php_com_string_to_olestring(user_name, -1, obj->code_page);
+			authid.User = (OLECHAR*)user_name;
 			authid.UserLength = (ULONG)user_name_len;
 
 			if (password) {


### PR DESCRIPTION
We must not mix multibyte and wide character strings in the
`COAUTHIDENTITY` structure.  Using wide character strings throughout
would have the advantage that the remote connection can be established
regardless of the code page of the server, but that would more likely
break BC, so we just drop the wide character string conversion of the
username.