### PR TITLE
Fixed bug #79821

### DIFF
--- a/ext/standard/tests/bug79821.phpt
+++ b/ext/standard/tests/bug79821.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #79821 (array grow during var_dump)
+--FILE--
+<?php
+
+$foo = $bar = [];
+for ($i = 0; $i < 3; $i++) {
+    $foo = [$foo, [&$bar]];
+}
+ob_start(function (string $buffer) use (&$bar) {
+    $bar[][] = null;
+    return '';
+}, 1);
+var_dump($foo[0]);
+ob_end_clean();
+
+echo "OK\n";
+
+?>
+--EXPECT--
+OK

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -127,6 +127,7 @@ again:
 					PUTS("*RECURSION*\n");
 					return;
 				}
+				GC_ADDREF(myht);
 				GC_PROTECT_RECURSION(myht);
 			}
 			count = zend_array_count(myht);
@@ -135,8 +136,10 @@ again:
 			ZEND_HASH_FOREACH_KEY_VAL_IND(myht, num, key, val) {
 				php_array_element_dump(val, num, key, level);
 			} ZEND_HASH_FOREACH_END();
+
 			if (!(GC_FLAGS(myht) & GC_IMMUTABLE)) {
 				GC_UNPROTECT_RECURSION(myht);
+				GC_DELREF(myht);
 			}
 			if (level > 1) {
 				php_printf("%*c", level-1, ' ');


### PR DESCRIPTION
HashTable was reallocated (`zend_hash_packed_grow`) during `php_var_dump`, so we should call `GC_ADDREF` to make `SEPARATE_ARRAY` work

`var_dump` should have been treated as a read-only function, but the output handler breaks this

It looks like this bug affects all PHP versions
