### PR TITLE
fix ifdefs for non-windows systems without long double

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -312,7 +312,7 @@ static ffi_type *zend_ffi_make_fake_struct_type(zend_ffi_type *type) /* {{{ */
 			case ZEND_FFI_TYPE_DOUBLE:
 				t->elements[i] = &ffi_type_double;
 				break;
-#ifndef PHP_WIN32
+#ifdef HAVE_LONG_DOUBLE
 			case ZEND_FFI_TYPE_LONGDOUBLE:
 				t->elements[i] = &ffi_type_longdouble;
 				break;
@@ -359,7 +359,7 @@ again:
 			return &ffi_type_float;
 		case ZEND_FFI_TYPE_DOUBLE:
 			return &ffi_type_double;
-#ifndef PHP_WIN32
+#ifdef HAVE_LONG_DOUBLE
 		case ZEND_FFI_TYPE_LONGDOUBLE:
 			return &ffi_type_longdouble;
 #endif


### PR DESCRIPTION
In ext/c/ffi.c, there is an #ifdef on line 70:

```
#ifdef HAVE_LONG_DOUBLE
	ZEND_FFI_TYPE_LONGDOUBLE,
#endif
```

Then later on line 315:

```
#ifndef PHP_WIN32
	case ZEND_FFI_TYPE_LONGDOUBLE:
		t->elements[i] = &ffi_type_longdouble;
		break;
#endif
```

A similar inconsistency occurs on line 362.  This should be changed to #ifdef HAVE_LONG_DOUBLE, else it will fail to compile on any non-windows system when HAVE_LONG_DOUBLE is undefined.  

This doesn't actually come up in normal compilation on Linux, only when I was fiddling with the build system and neglected to include the proper headers. So in some sense it's developer error, but it still ought to be corrected.
  
