### PR TITLE
Fixed bug #79831

### DIFF
--- a/Zend/tests/bug79831.phpt
+++ b/Zend/tests/bug79831.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Bug #79831 (unset var in set_error_handler)
+--FILE--
+<?php
+
+foreach (['+', '-'] as $t) {
+    foreach ([true, false] as $o) {
+        unset($a);
+        set_error_handler(function () {
+            unset($GLOBALS['a']);
+        });
+        echo ($o ?
+                ($t === '+' ? $a++ : $a--) :
+                ($t === '+' ? ++$a : --$a)
+            ) . "OK\n";
+        unset($a);
+        set_error_handler(function () {
+            $GLOBALS['a'] = 'I am ';
+        });
+        echo ($o ?
+                ($t === '+' ? $a++ : $a--) :
+                ($t === '+' ? ++$a : --$a)
+            ) . "OK\n";
+    }
+}
+
+?>
+--EXPECT--
+OK
+OK
+1OK
+1OK
+OK
+OK
+OK
+OK

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1463,8 +1463,9 @@ ZEND_VM_HELPER(zend_pre_inc_helper, VAR|CV, ANY)
 
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -1514,8 +1515,9 @@ ZEND_VM_HELPER(zend_pre_dec_helper, VAR|CV, ANY)
 
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -1566,8 +1568,9 @@ ZEND_VM_HELPER(zend_post_inc_helper, VAR|CV, ANY)
 
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -1614,8 +1617,9 @@ ZEND_VM_HELPER(zend_post_dec_helper, VAR|CV, ANY)
 
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -19641,8 +19641,9 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_inc_help
 
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -19710,8 +19711,9 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_dec_help
 
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -19780,8 +19782,9 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_inc_hel
 
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -19828,8 +19831,9 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_dec_hel
 
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -35392,8 +35396,9 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_inc_help
 
 	SAVE_OPLINE();
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -35460,8 +35465,9 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_dec_help
 
 	SAVE_OPLINE();
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -35529,8 +35535,9 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_inc_hel
 
 	SAVE_OPLINE();
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {
@@ -35576,8 +35583,9 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_dec_hel
 
 	SAVE_OPLINE();
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
-		ZVAL_NULL(var_ptr);
 		ZVAL_UNDEFINED_OP1();
+		zval_ptr_dtor_nogc(var_ptr);
+		ZVAL_NULL(var_ptr);
 	}
 
 	do {


### PR DESCRIPTION
First of all, I think this bug has no practical meaning... I can't find an elegant solution
anyway, I thought of two solutions:
one way is to ignore changes during the increment/decrement (that's what this patch does, but it does not cover the JIT or other unexpected situations...)
the other way is to treat `UNDEF` as `NULL` in `increment_function`/`decrement_function` (can cover any unexpected situation, equal to defensive programming)

The following example shows possible results:
```php
echo set_error_handler(function () {
        $GLOBALS['a'] = 'I am ';
    }) . $a++ . "OK\n";
```
1. `OK`
2. `I am OK`
