### PR TITLE
 Fix memory leaks in ldap.c (PHP-7.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ addons:
     packages:
       - locales
       - language-pack-de
+      - ldap-utils
+      - openssl
+      - slapd
       - re2c
       - libgmp-dev
       - libicu-dev
+      - libldap2-dev
       - libtidy-dev
       - libenchant-dev
       - libaspell-dev
@@ -64,6 +68,7 @@ before_script:
     - . ./travis/ext/pdo_mysql/setup.sh
     - . ./travis/ext/pgsql/setup.sh
     - . ./travis/ext/pdo_pgsql/setup.sh
+    - . ./travis/ext/ldap/setup.sh
 
 # Run PHPs run-tests.php
 script:

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -167,15 +167,17 @@ static void _php_ldap_control_to_array(LDAP *ld, LDAPControl* ctrl, zval* array,
 		}
 	} else if (strcmp(ctrl->ldctl_oid, LDAP_CONTROL_PAGEDRESULTS) == 0) {
 		int lestimated, rc;
-		struct berval lcookie;
+		struct berval lcookie = { 0L, NULL };
 		zval value;
 
 		if (ctrl->ldctl_value.bv_len) {
+			/* ldap_parse_pageresponse_control() allocates lcookie.bv_val */
 			rc = ldap_parse_pageresponse_control(ld, ctrl, &lestimated, &lcookie);
 		} else {
 			/* ldap_parse_pageresponse_control will crash if value is empty */
 			rc = -1;
 		}
+
 		if ( rc == LDAP_SUCCESS ) {
 			array_init(&value);
 			add_assoc_long(&value, "size", lestimated);
@@ -183,6 +185,10 @@ static void _php_ldap_control_to_array(LDAP *ld, LDAPControl* ctrl, zval* array,
 			add_assoc_zval(array, "value", &value);
 		} else {
 			add_assoc_null(array, "value");
+		}
+
+		if (lcookie.bv_val) {
+			ldap_memfree(lcookie.bv_val);
 		}
 	} else if ((strcmp(ctrl->ldctl_oid, LDAP_CONTROL_PRE_READ) == 0) || (strcmp(ctrl->ldctl_oid, LDAP_CONTROL_POST_READ) == 0)) {
 		BerElement *ber;
@@ -302,27 +308,23 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 		control_iscritical = 0;
 	}
 
-	struct berval *control_value = NULL;
+	BerElement *ber = NULL;
+	struct berval control_value = { 0L, NULL };
+	int control_value_alloc = 0;
 
 	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "value", sizeof("value") - 1)) != NULL) {
 		if (Z_TYPE_P(val) != IS_ARRAY) {
-			control_value = ber_memalloc(sizeof * control_value);
-			if (control_value == NULL) {
+			tmpstring = zval_get_string(val);
+			if (EG(exception)) {
 				rc = -1;
-				php_error_docref(NULL, E_WARNING, "Failed to allocate control value");
-			} else {
-				tmpstring = zval_get_string(val);
-				if (EG(exception)) {
-					rc = -1;
-					goto failure;
-				}
-				control_value->bv_val = ZSTR_VAL(tmpstring);
-				control_value->bv_len = ZSTR_LEN(tmpstring);
+				goto failure;
 			}
+			control_value.bv_val = ZSTR_VAL(tmpstring);
+			control_value.bv_len = ZSTR_LEN(tmpstring);
 		} else if (strcmp(ZSTR_VAL(control_oid), LDAP_CONTROL_PAGEDRESULTS) == 0) {
 			zval* tmp;
 			int pagesize = 1;
-			struct berval cookie = { 0, NULL };
+			struct berval cookie = { 0L, NULL };
 			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "size", sizeof("size") - 1)) != NULL) {
 				pagesize = zval_get_long(tmp);
 			}
@@ -335,15 +337,11 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				cookie.bv_val = ZSTR_VAL(tmpstring);
 				cookie.bv_len = ZSTR_LEN(tmpstring);
 			}
-			control_value = ber_memalloc(sizeof * control_value);
-			if (control_value == NULL) {
-				rc = -1;
-				php_error_docref(NULL, E_WARNING, "Failed to allocate control value");
-			} else {
-				rc = ldap_create_page_control_value(ld, pagesize, &cookie, control_value);
-				if (rc != LDAP_SUCCESS) {
-					php_error_docref(NULL, E_WARNING, "Failed to create paged result control value: %s (%d)", ldap_err2string(rc), rc);
-				}
+			/* ldap_create_page_control_value() allocates memory for control_value.bv_val */
+			control_value_alloc = 1;
+			rc = ldap_create_page_control_value(ld, pagesize, &cookie, &control_value);
+			if (rc != LDAP_SUCCESS) {
+				php_error_docref(NULL, E_WARNING, "Failed to create paged result control value: %s (%d)", ldap_err2string(rc), rc);
 			}
 		} else if (strcmp(ZSTR_VAL(control_oid), LDAP_CONTROL_ASSERT) == 0) {
 			zval* tmp;
@@ -357,19 +355,15 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 					rc = -1;
 					goto failure;
 				}
-				control_value = ber_memalloc(sizeof * control_value);
-				if (control_value == NULL) {
-					rc = -1;
-					php_error_docref(NULL, E_WARNING, "Failed to allocate control value");
-				} else {
-					/* ldap_create_assertion_control_value does not reset ld_errno, we need to do it ourselves
-					   See http://www.openldap.org/its/index.cgi/Incoming?id=8674 */
-					int success = LDAP_SUCCESS;
-					ldap_set_option(ld, LDAP_OPT_RESULT_CODE, &success);
-					rc = ldap_create_assertion_control_value(ld, ZSTR_VAL(assert), control_value);
-					if (rc != LDAP_SUCCESS) {
-						php_error_docref(NULL, E_WARNING, "Failed to create assert control value: %s (%d)", ldap_err2string(rc), rc);
-					}
+				/* ldap_create_assertion_control_value does not reset ld_errno, we need to do it ourselves
+					 See http://www.openldap.org/its/index.cgi/Incoming?id=8674 */
+				int success = LDAP_SUCCESS;
+				ldap_set_option(ld, LDAP_OPT_RESULT_CODE, &success);
+				/* ldap_create_assertion_control_value() allocates memory for control_value.bv_val */
+				control_value_alloc = 1;
+				rc = ldap_create_assertion_control_value(ld, ZSTR_VAL(assert), &control_value);
+				if (rc != LDAP_SUCCESS) {
+					php_error_docref(NULL, E_WARNING, "Failed to create assert control value: %s (%d)", ldap_err2string(rc), rc);
 				}
 				zend_string_release(assert);
 			}
@@ -379,9 +373,8 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				rc = -1;
 				php_error_docref(NULL, E_WARNING, "Filter missing from control value array");
 			} else {
-				BerElement *vrber = ber_alloc_t(LBER_USE_DER);
-				control_value = ber_memalloc(sizeof * control_value);
-				if ((control_value == NULL) || (vrber == NULL)) {
+				ber = ber_alloc_t(LBER_USE_DER);
+				if (ber == NULL) {
 					rc = -1;
 					php_error_docref(NULL, E_WARNING, "Failed to allocate control value");
 				} else {
@@ -390,14 +383,11 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 						rc = -1;
 						goto failure;
 					}
-					if (ldap_put_vrFilter(vrber, ZSTR_VAL(tmpstring)) == -1) {
-						ber_free(vrber, 1);
+					if (ldap_put_vrFilter(ber, ZSTR_VAL(tmpstring)) == -1) {
 						rc = -1;
 						php_error_docref(NULL, E_WARNING, "Failed to create control value: Bad ValuesReturnFilter: %s", ZSTR_VAL(tmpstring));
-					} else {
-						if (ber_flatten2(vrber, control_value, 0) == -1) {
-							rc = -1;
-						}
+					} else if (ber_flatten2(ber, &control_value, control_value_alloc) == -1) {
+						rc = -1;
 					}
 				}
 			}
@@ -407,10 +397,9 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				rc = -1;
 				php_error_docref(NULL, E_WARNING, "Attributes list missing from control value array");
 			} else {
-				BerElement *ber = ber_alloc_t(LBER_USE_DER);
+				ber = ber_alloc_t(LBER_USE_DER);
 
-				control_value = ber_memalloc(sizeof * control_value);
-				if ((control_value == NULL) || (ber == NULL)) {
+				if (ber == NULL) {
 					rc = -1;
 					php_error_docref(NULL, E_WARNING, "Failed to allocate control value");
 				} else {
@@ -446,7 +435,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 						php_error_docref(NULL, E_WARNING, "Failed to encode attribute list");
 					} else {
 						int err;
-						err = ber_flatten2(ber, control_value, 0);
+						err = ber_flatten2(ber, &control_value, control_value_alloc);
 						if (err < 0) {
 							rc = -1;
 							php_error_docref(NULL, E_WARNING, "Failed to encode control value (%d)", err);
@@ -505,15 +494,11 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				}
 			}
 			sort_keys[num_keys] = NULL;
-			control_value = ber_memalloc(sizeof * control_value);
-			if (control_value == NULL) {
-				rc = -1;
-				php_error_docref(NULL, E_WARNING, "Failed to allocate control value");
-			} else {
-				rc = ldap_create_sort_control_value(ld, sort_keys, control_value);
-				if (rc != LDAP_SUCCESS) {
-					php_error_docref(NULL, E_WARNING, "Failed to create sort control value: %s (%d)", ldap_err2string(rc), rc);
-				}
+			/* ldap_create_sort_control_value() allocates memory for control_value.bv_val */
+			control_value_alloc = 1;
+			rc = ldap_create_sort_control_value(ld, sort_keys, &control_value);
+			if (rc != LDAP_SUCCESS) {
+				php_error_docref(NULL, E_WARNING, "Failed to create sort control value: %s (%d)", ldap_err2string(rc), rc);
 			}
 		} else if (strcmp(ZSTR_VAL(control_oid), LDAP_CONTROL_VLVREQUEST) == 0) {
 			zval* tmp;
@@ -575,15 +560,11 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				vlvInfo.ldvlv_context = NULL;
 			}
 
-			control_value = ber_memalloc(sizeof * control_value);
-			if (control_value == NULL) {
-				rc = -1;
-				php_error_docref(NULL, E_WARNING, "Failed to allocate control value");
-			} else {
-				rc = ldap_create_vlv_control_value(ld, &vlvInfo, control_value);
-				if (rc != LDAP_SUCCESS) {
-					php_error_docref(NULL, E_WARNING, "Failed to create VLV control value: %s (%d)", ldap_err2string(rc), rc);
-				}
+			/* ldap_create_vlv_control_value() allocates memory for control_value.bv_val */
+			control_value_alloc = 1;
+			rc = ldap_create_vlv_control_value(ld, &vlvInfo, &control_value);
+			if (rc != LDAP_SUCCESS) {
+				php_error_docref(NULL, E_WARNING, "Failed to create VLV control value: %s (%d)", ldap_err2string(rc), rc);
 			}
 		} else {
 			php_error_docref(NULL, E_WARNING, "Control OID %s does not expect an array as value", ZSTR_VAL(control_oid));
@@ -592,7 +573,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 	}
 
 	if (rc == LDAP_SUCCESS) {
-		rc = ldap_control_create(ZSTR_VAL(control_oid), control_iscritical, control_value, 1, ctrl);
+		rc = ldap_control_create(ZSTR_VAL(control_oid), control_iscritical, &control_value, 1, ctrl);
 	}
 
 failure:
@@ -614,9 +595,11 @@ failure:
 		}
 		efree(tmpstrings2);
 	}
-	if (control_value != NULL) {
-		ber_memfree(control_value);
-		control_value = NULL;
+	if (control_value.bv_val != NULL && control_value_alloc != 0) {
+		ber_memfree(control_value.bv_val);
+	}
+	if (ber != NULL) {
+		ber_free(ber, 1);
 	}
 	if (ldap_attrs != NULL) {
 		efree(ldap_attrs);
@@ -1488,7 +1471,7 @@ static void php_ldap_do_search(INTERNAL_FUNCTION_PARAMETERS, int scope)
 	zend_string *ldap_filter = NULL, *ldap_base_dn = NULL;
 	char **ldap_attrs = NULL;
 	ldap_linkdata *ld = NULL;
-	LDAPMessage *ldap_res;
+	LDAPMessage *ldap_res = NULL;
 	LDAPControl **lserverctrls = NULL;
 	int ldap_attrsonly = 0, ldap_sizelimit = -1, ldap_timelimit = -1, ldap_deref = -1;
 	int old_ldap_sizelimit = -1, old_ldap_timelimit = -1, old_ldap_deref = -1;
@@ -1688,6 +1671,11 @@ cleanup_parallel:
 			&& errno != LDAP_REFERRAL
 #endif
 		) {
+			/* ldap_res should be freed regardless of return value of ldap_search_ext_s()
+			 * see: https://linux.die.net/man/3/ldap_search_ext_s */
+			if (ldap_res != NULL) {
+				ldap_msgfree(ldap_res);
+			}
 			php_error_docref(NULL, E_WARNING, "Search: %s", ldap_err2string(errno));
 			ret = 0;
 		} else {
@@ -4016,7 +4004,7 @@ PHP_FUNCTION(ldap_control_paged_result)
 	zval *link;
 	char *cookie = NULL;
 	size_t cookie_len = 0;
-	struct berval lcookie = { 0, NULL };
+	struct berval lcookie = { 0L, NULL };
 	ldap_linkdata *ld;
 	LDAP *ldap;
 	BerElement *ber = NULL;
@@ -4311,38 +4299,31 @@ PHP_FUNCTION(ldap_exop)
 PHP_FUNCTION(ldap_exop_passwd)
 {
 	zval *link, *serverctrls;
-	struct berval luser, loldpw, lnewpw, lgenpasswd;
-	LDAPControl **lserverctrls = NULL, **requestctrls = NULL;
-	LDAPControl *ctrl, **ctrlp;
-	LDAPMessage* ldap_res;
+	struct berval luser = { 0L, NULL };
+	struct berval loldpw = { 0L, NULL };
+	struct berval lnewpw = { 0L, NULL };
+	struct berval lgenpasswd = { 0L, NULL };
+	LDAPControl *ctrl, **lserverctrls = NULL, *requestctrls[2] = { NULL, NULL };
+	LDAPMessage* ldap_res = NULL;
 	ldap_linkdata *ld;
 	int rc, myargcount = ZEND_NUM_ARGS(), msgid, err;
-	char* errmsg;
-
-	luser.bv_len = 0;
-	loldpw.bv_len = 0;
-	lnewpw.bv_len = 0;
+	char* errmsg = NULL;
 
 	if (zend_parse_parameters(myargcount, "r|sssz/", &link, &luser.bv_val, &luser.bv_len, &loldpw.bv_val, &loldpw.bv_len, &lnewpw.bv_val, &lnewpw.bv_len, &serverctrls) == FAILURE) {
 		return;
 	}
 
 	if ((ld = (ldap_linkdata *)zend_fetch_resource(Z_RES_P(link), "ldap link", le_link)) == NULL) {
-		RETURN_FALSE;
+		RETVAL_FALSE;
+		goto cleanup;
 	}
 
 	switch (myargcount) {
 		case 5:
-			requestctrls = safe_emalloc(2, sizeof(*requestctrls), 0);
-			*requestctrls = NULL;
-			ctrlp = requestctrls;
-
+			/* ldap_create_passwordpolicy_control() allocates ctrl */
 			if (ldap_create_passwordpolicy_control(ld->link, &ctrl) == LDAP_SUCCESS) {
-				*ctrlp = ctrl;
-				++ctrlp;
+				requestctrls[0] = ctrl;
 			}
-
-			*ctrlp = NULL;
 	}
 
 	/* asynchronous call to get result and controls */
@@ -4352,35 +4333,44 @@ PHP_FUNCTION(ldap_exop_passwd)
 		requestctrls,
 		NULL, &msgid);
 
-	if (requestctrls != NULL) {
-		efree(requestctrls);
+	if (requestctrls[0] != NULL) {
+		ldap_control_free(requestctrls[0]);
 	}
 
 	if (rc != LDAP_SUCCESS ) {
 		php_error_docref(NULL, E_WARNING, "Passwd modify extended operation failed: %s (%d)", ldap_err2string(rc), rc);
-		RETURN_FALSE;
+		RETVAL_FALSE;
+		goto cleanup;
 	}
 
 	rc = ldap_result(ld->link, msgid, 1 /* LDAP_MSG_ALL */, NULL, &ldap_res);
 	if ((rc < 0) || !ldap_res) {
 		rc = _get_lderrno(ld->link);
 		php_error_docref(NULL, E_WARNING, "Passwd modify extended operation failed: %s (%d)", ldap_err2string(rc), rc);
-		RETURN_FALSE;
+		RETVAL_FALSE;
+		goto cleanup;
 	}
 
 	rc = ldap_parse_passwd(ld->link, ldap_res, &lgenpasswd);
 	if( rc != LDAP_SUCCESS ) {
 		php_error_docref(NULL, E_WARNING, "Passwd modify extended operation failed: %s (%d)", ldap_err2string(rc), rc);
-		ldap_msgfree(ldap_res);
-		RETURN_FALSE;
+		RETVAL_FALSE;
+		goto cleanup;
 	}
 
-	rc = ldap_parse_result(ld->link, ldap_res, &err, NULL, &errmsg, NULL, (myargcount > 4 ? &lserverctrls : NULL), 1);
+	rc = ldap_parse_result(ld->link, ldap_res, &err, NULL, &errmsg, NULL, (myargcount > 4 ? &lserverctrls : NULL), 0);
 	if( rc != LDAP_SUCCESS ) {
 		php_error_docref(NULL, E_WARNING, "Passwd modify extended operation failed: %s (%d)", ldap_err2string(rc), rc);
-		RETURN_FALSE;
+		RETVAL_FALSE;
+		goto cleanup;
 	}
 
+	if (myargcount > 4) {
+		zval_ptr_dtor(serverctrls);
+		_php_ldap_controls_to_array(ld->link, lserverctrls, serverctrls, 0);
+	}
+
+	/* return */
 	if (lnewpw.bv_len == 0) {
 		if (lgenpasswd.bv_len == 0) {
 			RETVAL_EMPTY_STRING();
@@ -4394,12 +4384,16 @@ PHP_FUNCTION(ldap_exop_passwd)
 		RETVAL_FALSE;
 	}
 
-	if (myargcount > 4) {
-		zval_ptr_dtor(serverctrls);
-		_php_ldap_controls_to_array(ld->link, lserverctrls, serverctrls, 0);
+cleanup:
+	if (lgenpasswd.bv_val != NULL) {
+		ldap_memfree(lgenpasswd.bv_val);
 	}
-
-	ldap_memfree(lgenpasswd.bv_val);
+	if (ldap_res != NULL) {
+		ldap_msgfree(ldap_res);
+	}
+	if (errmsg != NULL) {
+		ldap_memfree(errmsg);
+	}
 }
 /* }}} */
 #endif

--- a/ext/ldap/tests/connect.inc
+++ b/ext/ldap/tests/connect.inc
@@ -5,14 +5,15 @@ Default values are "localhost", "cn=Manager,dc=my-domain,dc=com", and password "
 Change the LDAP_TEST_* environment values if you want to use another configuration.
 */
 
-$host			= getenv("LDAP_TEST_HOST")	? getenv("LDAP_TEST_HOST")	: "localhost";
-$port			= getenv("LDAP_TEST_PORT")	? getenv("LDAP_TEST_PORT")	: 389;
-$base			= getenv("LDAP_TEST_BASE")	? getenv("LDAP_TEST_BASE")	: "dc=my-domain,dc=com";
-$user			= getenv("LDAP_TEST_USER")	? getenv("LDAP_TEST_USER")	: "cn=Manager,$base";
-$sasl_user		= getenv("LDAP_TEST_SASL_USER")	? getenv("LDAP_TEST_SASL_USER")	: "Manager";
-$passwd			= getenv("LDAP_TEST_PASSWD")	? getenv("LDAP_TEST_PASSWD")	: "secret";
-$protocol_version	= getenv("LDAP_TEST_OPT_PROTOCOL_VERSION")	? getenv("LDAP_TEST_OPT_PROTOCOL_VERSION")	: 3;
-$skip_on_bind_failure	= getenv("LDAP_TEST_SKIP_BIND_FAILURE") ? getenv("LDAP_TEST_SKIP_BIND_FAILURE") : true;
+$host           = getenv("LDAP_TEST_HOST")  ?: "localhost";
+$port           = getenv("LDAP_TEST_PORT")  ?: 389;
+$base           = getenv("LDAP_TEST_BASE")  ?: "dc=my-domain,dc=com";
+$user           = getenv("LDAP_TEST_USER")  ?: "cn=Manager,$base";
+$passwd         = getenv("LDAP_TEST_PASSWD")    ?: "secret";
+$sasl_user      = getenv("LDAP_TEST_SASL_USER") ?: "userA";
+$sasl_passwd    = getenv("LDAP_TEST_SASL_PASSWD")   ?: "oops";
+$protocol_version   = getenv("LDAP_TEST_OPT_PROTOCOL_VERSION")  ?: 3;
+$skip_on_bind_failure   = getenv("LDAP_TEST_SKIP_BIND_FAILURE") ?: true;
 
 function ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version) {
 	$link = ldap_connect($host, $port);

--- a/ext/ldap/tests/ldap_sasl_bind_basic.phpt
+++ b/ext/ldap/tests/ldap_sasl_bind_basic.phpt
@@ -17,11 +17,22 @@ Patrick Allaert <patrickallaert@php.net>
 <?php
 require "connect.inc";
 
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+insert_dummy_data($link, $base);
+ldap_unbind($link);
+
 $link = ldap_connect($host, $port);
 ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
-var_dump(ldap_sasl_bind($link, null, $passwd, 'DIGEST-MD5', 'realm', $sasl_user));
+var_dump(ldap_sasl_bind($link, null, $sasl_passwd, 'DIGEST-MD5', 'realm', $sasl_user));
 ?>
 ===DONE===
+--CLEAN--
+<?php
+include "connect.inc";
+
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+remove_dummy_data($link, $base);
+?>
 --EXPECT--
 bool(true)
 ===DONE===

--- a/ext/ldap/tests/ldap_sasl_bind_error.phpt
+++ b/ext/ldap/tests/ldap_sasl_bind_error.phpt
@@ -11,6 +11,10 @@ Patrick Allaert <patrickallaert@php.net>
 <?php
 require "connect.inc";
 
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+insert_dummy_data($link, $base);
+ldap_unbind($link);
+
 $link = ldap_connect($host, $port);
 ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
 
@@ -18,20 +22,27 @@ ldap_set_option($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version);
 var_dump(ldap_sasl_bind());
 
 // Invalid DN
-var_dump(ldap_sasl_bind($link, "Invalid DN", $passwd, 'DIGEST-MD5', 'realm', $sasl_user));
+var_dump(ldap_sasl_bind($link, "Invalid DN", $sasl_passwd, 'DIGEST-MD5', 'realm', $sasl_user));
 
 // Invalid user
-var_dump(ldap_sasl_bind($link, null, "ThisIsNotCorrect$passwd", 'DIGEST-MD5', "realm", "invalid$sasl_user"));
+var_dump(ldap_sasl_bind($link, null, "ThisIsNotCorrect$sasl_passwd", 'DIGEST-MD5', "realm", "invalid$sasl_user"));
 
 // Invalid password
-var_dump(ldap_sasl_bind($link, null, "ThisIsNotCorrect$passwd", 'DIGEST-MD5', "realm", $sasl_user));
+var_dump(ldap_sasl_bind($link, null, "ThisIsNotCorrect$sasl_passwd", 'DIGEST-MD5', "realm", $sasl_user));
 
-var_dump(ldap_sasl_bind($link, null, $passwd, 'DIGEST-MD5', "realm", "Manager", "test"));
+var_dump(ldap_sasl_bind($link, null, $sasl_passwd, 'DIGEST-MD5', "realm", "Manager", "test"));
 
 // Invalid DN syntax
-var_dump(ldap_sasl_bind($link, "unexistingProperty=weirdValue,$user", $passwd));
+var_dump(ldap_sasl_bind($link, "unexistingProperty=weirdValue,$user", $sasl_passwd));
 ?>
 ===DONE===
+--CLEAN--
+<?php
+include "connect.inc";
+
+$link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
+remove_dummy_data($link, $base);
+?>
 --EXPECTF--
 Warning: ldap_sasl_bind() expects at least 1 parameter, 0 given in %s on line %d
 bool(false)

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -77,6 +77,8 @@ $TS \
 --with-kerberos \
 --enable-sysvmsg \
 --enable-zend-test=shared \
+--with-ldap \
+--with-ldap-sasl \
 > "$CONFIG_LOG_FILE"
 
 make "-j${MAKE_JOBS}" $MAKE_QUIET > "$MAKE_LOG_FILE"

--- a/travis/ext/ldap/setup.sh
+++ b/travis/ext/ldap/setup.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+
+# Create TLS certificate
+sudo mkdir -p /etc/ldap/ssl
+sudo chown -R "`id -u -n`:`id -g -n`" /etc/ldap/ssl
+
+alt_names() {
+  (
+      (
+        (hostname && hostname -a && hostname -A && hostname -f) |
+        xargs -n 1 |
+        sort -u |
+        sed -e 's/\(\S\+\)/DNS:\1/g'
+      ) && (
+        (hostname -i && hostname -I && echo "127.0.0.1 ::1") |
+        xargs -n 1 |
+        sort -u |
+        sed -e 's/\(\S\+\)/IP:\1/g'
+      )
+  ) | paste -d, -s
+}
+
+req_config() {
+  cat << EOF
+[req]
+prompt = no
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+
+[req_distinguished_name]
+countryName = US
+stateOrProvinceName = CA
+localityName = Los Angeles
+organizationName = PHP
+commonName = localhost
+
+[v3_ca]
+subjectAltName=`alt_names`
+EOF
+}
+
+openssl req -newkey rsa:4096 -x509 -nodes -days 3650 \
+  -out /etc/ldap/ssl/server.crt -keyout /etc/ldap/ssl/server.key \
+  -config <( req_config )
+
+sudo chown -R openldap:openldap /etc/ldap/ssl
+
+# Display the TLS certificate (should be world readable)
+openssl x509 -noout -text -in /etc/ldap/ssl/server.crt
+
+# Point to the certificate generated
+if ! grep -q 'TLS_CACERT \/etc\/ldap\/ssl\/server.crt' /etc/ldap/ldap.conf; then
+  sudo sed -e 's|^\s*TLS_CACERT|# TLS_CACERT|' -i /etc/ldap/ldap.conf
+  echo 'TLS_CACERT /etc/ldap/ssl/server.crt' | sudo tee -a /etc/ldap/ldap.conf
+fi
+
+# Configure LDAP protocols to serve.
+sudo sed -e 's|^\s*SLAPD_SERVICES\s*=.*$|SLAPD_SERVICES="ldap:/// ldaps:/// ldapi:///"|' -i /etc/default/slapd
+
+# Configure LDAP database.
+DBDN=`sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(&(olcRootDN=*)(olcSuffix=*))' dn | grep -i '^dn:' | sed -e 's/^dn:\s*//'`;
+
+sudo ldapadd -Q -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/ppolicy.ldif
+
+sudo service slapd restart
+
+sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: $DBDN
+changetype: modify
+replace: olcSuffix
+olcSuffix: dc=my-domain,dc=com
+-
+replace: olcRootDN
+olcRootDN: cn=Manager,dc=my-domain,dc=com
+-
+replace: olcRootPW
+olcRootPW: secret
+
+dn: cn=config
+changetype: modify
+add: olcTLSCACertificateFile
+olcTLSCACertificateFile: /etc/ldap/ssl/server.crt
+-
+add: olcTLSCertificateFile
+olcTLSCertificateFile: /etc/ldap/ssl/server.crt
+-
+add: olcTLSCertificateKeyFile
+olcTLSCertificateKeyFile: /etc/ldap/ssl/server.key
+-
+add: olcTLSVerifyClient
+olcTLSVerifyClient: never
+-
+add: olcAuthzRegexp
+olcAuthzRegexp: uid=usera,cn=digest-md5,cn=auth cn=usera,dc=my-domain,dc=com
+-
+replace: olcLogLevel
+olcLogLevel: -1
+
+dn: cn=module{0},cn=config
+changetype: modify
+add: olcModuleLoad
+olcModuleLoad: sssvlv
+-
+add: olcModuleLoad
+olcModuleLoad: ppolicy
+-
+add: olcModuleLoad
+olcModuleLoad: dds
+EOF
+
+sudo service slapd restart
+
+sudo ldapadd -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: olcOverlay=sssvlv,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcSssVlvConfig
+olcOverlay: sssvlv
+olcSssVlvMax: 10
+olcSssVlvMaxKeys: 5
+
+dn: olcOverlay=ppolicy,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcPPolicyConfig
+olcOverlay: ppolicy
+### This would clutter our DIT and make tests to fail, while ppolicy does not
+### seem to work as we expect (it does not seem to provide expected controls)
+## olcPPolicyDefault: cn=default,ou=pwpolicies,dc=my-domain,dc=com
+## olcPPolicyHashCleartext: FALSE
+## olcPPolicyUseLockout: TRUE
+
+dn: olcOverlay=dds,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcDdsConfig
+olcOverlay: dds
+EOF
+
+sudo service slapd restart
+
+sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: $DBDN
+changetype: modify
+add: olcDbIndex
+olcDbIndex: entryExpireTimestamp eq
+EOF
+
+sudo service slapd restart
+
+ldapadd -H ldapi:/// -D cn=Manager,dc=my-domain,dc=com -w secret <<EOF
+dn: dc=my-domain,dc=com
+objectClass: top
+objectClass: organization
+objectClass: dcObject
+dc: my-domain
+o: php ldap tests
+
+### This would clutter our DIT and make tests to fail, while ppolicy does not
+### seem to work as we expect (it does not seem to provide expected controls)
+## dn: ou=pwpolicies,dc=my-domain,dc=com
+## objectClass: top
+## objectClass: organizationalUnit
+## ou: pwpolicies
+##
+## dn: cn=default,ou=pwpolicies,dc=my-domain,dc=com
+## objectClass: top
+## objectClass: person
+## objectClass: pwdPolicy
+## cn: default
+## sn: default
+## pwdAttribute: userPassword
+## pwdMaxAge: 2592000
+## pwdExpireWarning: 3600
+## #pwdInHistory: 0
+## pwdCheckQuality: 0
+## pwdMaxFailure: 5
+## pwdLockout: TRUE
+## #pwdLockoutDuration: 0
+## #pwdGraceAuthNLimit: 0
+## #pwdFailureCountInterval: 0
+## pwdMustChange: FALSE
+## pwdMinLength: 3
+## pwdAllowUserChange: TRUE
+## pwdSafeModify: FALSE
+EOF
+
+# Verify TLS connection
+
+ldapsearch -d 255 -H ldaps://localhost -D cn=Manager,dc=my-domain,dc=com -w secret -s base -b dc=my-domain,dc=com 'objectclass=*'


### PR DESCRIPTION
I'd like to reopen a discussion started [here](https://github.com/php/php-src/pull/5799#pullrequestreview-445790892). Looks like the ldap still needs some fixing (memory leak). I have no ldap server installed locally, so I let to myself to enable ext/ldap/tests on Travis-CI in this PR.