### PR TITLE
Cleanup argument handling of Zend functions and methods

### DIFF
--- a/Zend/tests/001.phpt
+++ b/Zend/tests/001.phpt
@@ -40,20 +40,23 @@ class test {
 }
 
 test::test1(1);
-var_dump(func_num_args());
+
+try {
+    func_num_args();
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 echo "Done\n";
 ?>
 --EXPECTF--
 int(0)
 int(1)
-Exception: Too few arguments to function test2(), 0 passed in %s001.php on line 18 and exactly 1 expected
+Exception: Too few arguments to function test2(), 0 passed in %s on line %d and exactly 1 expected
 int(2)
 int(0)
-Exception: Too few arguments to function test3(), 1 passed in %s001.php on line 27 and exactly 2 expected
+Exception: Too few arguments to function test3(), 1 passed in %s on line %d and exactly 2 expected
 int(2)
 int(1)
-
-Warning: func_num_args():  Called from the global scope - no function context in %s on line %d
-int(-1)
+func_num_args() must be called from a function context
 Done

--- a/Zend/tests/002.phpt
+++ b/Zend/tests/002.phpt
@@ -96,26 +96,26 @@ try {
 echo "Done\n";
 ?>
 --EXPECTF--
-func_get_arg(): Argument #1 ($arg_num) must be greater than or equal to 0
-func_get_arg(): Argument 0 not passed to function
-func_get_arg(): Argument 1 not passed to function
-func_get_arg(): Argument #1 ($arg_num) must be greater than or equal to 0
+func_get_arg(): Argument #1 ($argument_number) must be greater than or equal to 0
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($argument_number) must be greater than or equal to 0
 int(10)
-func_get_arg(): Argument 1 not passed to function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
 int(1)
-func_get_arg(): Argument 1 not passed to function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
 Exception: Too few arguments to function test2(), 0 passed in %s002.php on line %d and exactly 1 expected
 int(1)
 int(2)
-func_get_arg(): Argument 2 not passed to function
-func_get_arg(): Argument #1 ($arg_num) must be greater than or equal to 0
-func_get_arg(): Argument 0 not passed to function
-func_get_arg(): Argument 1 not passed to function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($argument_number) must be greater than or equal to 0
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
 Exception: Too few arguments to function test3(), 1 passed in %s on line %d and exactly 2 expected
 int(1)
 int(2)
-func_get_arg(): Argument 2 not passed to function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
 int(1)
-func_get_arg(): Argument 1 not passed to function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
 func_get_arg() cannot be called from the global scope
 Done

--- a/Zend/tests/002.phpt
+++ b/Zend/tests/002.phpt
@@ -96,26 +96,26 @@ try {
 echo "Done\n";
 ?>
 --EXPECTF--
-func_get_arg(): Argument #1 ($argument_number) must be greater than or equal to 0
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
-func_get_arg(): Argument #1 ($argument_number) must be greater than or equal to 0
+func_get_arg(): Argument #1 ($position) must be greater than or equal to 0
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be greater than or equal to 0
 int(10)
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
 int(1)
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
 Exception: Too few arguments to function test2(), 0 passed in %s002.php on line %d and exactly 1 expected
 int(1)
 int(2)
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
-func_get_arg(): Argument #1 ($argument_number) must be greater than or equal to 0
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be greater than or equal to 0
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
 Exception: Too few arguments to function test3(), 1 passed in %s on line %d and exactly 2 expected
 int(1)
 int(2)
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
 int(1)
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function
 func_get_arg() cannot be called from the global scope
 Done

--- a/Zend/tests/004.phpt
+++ b/Zend/tests/004.phpt
@@ -16,7 +16,7 @@ var_dump(strncmp("qwerty", "qwerty123", 7));
 ?>
 --EXPECT--
 int(0)
-strncmp(): Argument #3 ($len) must be greater than or equal to 0
+strncmp(): Argument #3 ($length) must be greater than or equal to 0
 int(0)
 int(0)
 int(-1)

--- a/Zend/tests/006.phpt
+++ b/Zend/tests/006.phpt
@@ -19,7 +19,7 @@ var_dump(strncasecmp("01", "01", 1000));
 
 ?>
 --EXPECT--
-strncasecmp(): Argument #3 ($len) must be greater than or equal to 0
+strncasecmp(): Argument #3 ($length) must be greater than or equal to 0
 int(0)
 int(-3)
 int(0)

--- a/Zend/tests/008.phpt
+++ b/Zend/tests/008.phpt
@@ -42,7 +42,7 @@ Notice: Constant test const already defined in %s on line %d
 bool(false)
 bool(true)
 bool(true)
-define(): Argument #2 ($value) must be of type bool|int|float|string|array|resource|null, stdClass given
+define(): Argument #2 ($value) cannot be an object, stdClass given
 int(1)
 int(2)
 int(3)

--- a/Zend/tests/008.phpt
+++ b/Zend/tests/008.phpt
@@ -16,7 +16,12 @@ var_dump(define("test const", 3));
 var_dump(define("test const", 3));
 var_dump(define("test", array(1)));
 var_dump(define("test1", fopen(__FILE__, 'r')));
+
+try {
 var_dump(define("test2", new stdclass));
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 var_dump(constant(" "));
 var_dump(constant("[[["));
@@ -37,9 +42,7 @@ Notice: Constant test const already defined in %s on line %d
 bool(false)
 bool(true)
 bool(true)
-
-Warning: Constants may only evaluate to scalar values, arrays or resources in %s on line %d
-bool(false)
+define(): Argument #2 ($value) must be of type bool|int|float|string|array|resource|null, stdClass given
 int(1)
 int(2)
 int(3)

--- a/Zend/tests/010.phpt
+++ b/Zend/tests/010.phpt
@@ -75,10 +75,10 @@ bool(false)
 string(3) "foo"
 bool(false)
 bool(false)
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, string given
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, string given
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, string given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, string given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, string given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 bool(false)
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, array given
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, int given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, array given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 Done

--- a/Zend/tests/020.phpt
+++ b/Zend/tests/020.phpt
@@ -26,4 +26,4 @@ try {
 ?>
 --EXPECT--
 func_get_arg() cannot be called from the global scope
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function

--- a/Zend/tests/020.phpt
+++ b/Zend/tests/020.phpt
@@ -26,4 +26,4 @@ try {
 ?>
 --EXPECT--
 func_get_arg() cannot be called from the global scope
-func_get_arg(): Argument 1 not passed to function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function

--- a/Zend/tests/bug37811.phpt
+++ b/Zend/tests/bug37811.phpt
@@ -11,19 +11,23 @@ class TestClass
     }
 }
 
-define("Bar",new TestClass);
+define("Bar", new TestClass);
 var_dump(Bar);
-define("Baz",new stdClass);
-var_dump(Baz);
+
+try {
+    define("Baz", new stdClass);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(Baz);
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 ?>
-===DONE===
---EXPECTF--
+--EXPECT--
 string(3) "Foo"
-
-Warning: Constants may only evaluate to scalar values, arrays or resources in %sbug37811.php on line %d
-
-Fatal error: Uncaught Error: Undefined constant "Baz" in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+define(): Argument #2 ($value) must be of type bool|int|float|string|array|resource|null, stdClass given
+Undefined constant "Baz"

--- a/Zend/tests/bug37811.phpt
+++ b/Zend/tests/bug37811.phpt
@@ -29,5 +29,5 @@ try {
 ?>
 --EXPECT--
 string(3) "Foo"
-define(): Argument #2 ($value) must be of type bool|int|float|string|array|resource|null, stdClass given
+define(): Argument #2 ($value) cannot be an object, stdClass given
 Undefined constant "Baz"

--- a/Zend/tests/bug44827.phpt
+++ b/Zend/tests/bug44827.phpt
@@ -2,10 +2,20 @@
 Bug #44827 (define() allows :: in constant names)
 --FILE--
 <?php
-define('foo::bar', 1);
-define('::', 1);
-?>
---EXPECTF--
-Warning: Class constants cannot be defined or redefined in %sbug44827.php on line %d
 
-Warning: Class constants cannot be defined or redefined in %sbug44827.php on line %d
+try {
+    define('foo::bar', 1);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    define('::', 1);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+define(): Argument #1 ($constant_name) cannot be a class constant
+define(): Argument #1 ($constant_name) cannot be a class constant

--- a/Zend/tests/bug72162.phpt
+++ b/Zend/tests/bug72162.phpt
@@ -4,11 +4,12 @@ Bug #72162 (use-after-free - error_reporting)
 <?php
 error_reporting(E_ALL);
 $var11 = new StdClass();
-$var16 = error_reporting($var11);
+
+try {
+    $var16 = error_reporting($var11);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Object of class stdClass could not be converted to string in %s:%d
-Stack trace:
-#0 %s(%d): error_reporting(Object(stdClass))
-#1 {main}
-  thrown in %s on line %d
+--EXPECT--
+error_reporting(): Argument #1 ($error_level) must be of type ?int, stdClass given

--- a/Zend/tests/class_alias_006.phpt
+++ b/Zend/tests/class_alias_006.phpt
@@ -3,8 +3,12 @@ Testing creation of alias to an internal class
 --FILE--
 <?php
 
-class_alias('stdclass', 'foo');
+try {
+    class_alias('stdclass', 'foo');
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 ?>
---EXPECTF--
-Warning: First argument of class_alias() must be a name of user defined class in %s on line %d
+--EXPECT--
+class_alias(): Argument #1 ($original_class_name) must be a user-defined class name, internal class name given

--- a/Zend/tests/class_alias_006.phpt
+++ b/Zend/tests/class_alias_006.phpt
@@ -11,4 +11,4 @@ try {
 
 ?>
 --EXPECT--
-class_alias(): Argument #1 ($original_class_name) must be a user-defined class name, internal class name given
+class_alias(): Argument #1 ($class) must be a user-defined class name, internal class name given

--- a/Zend/tests/closure_040.phpt
+++ b/Zend/tests/closure_040.phpt
@@ -25,6 +25,7 @@ $ca = $a->getIncrementor();
 $cas = $a->getStaticIncrementor();
 
 $ca->bindTo($a, array());
+
 $cas->bindTo($a, 'A');
 
 ?>

--- a/Zend/tests/constant_arrays.phpt
+++ b/Zend/tests/constant_arrays.phpt
@@ -101,5 +101,5 @@ array(1) {
   [0]=>
   int(7)
 }
-define(): Argument #2 ($value) must be of type bool|int|float|string|array|resource|null, stdClass given
+define(): Argument #2 ($value) cannot be an object, stdClass given
 define(): Argument #2 ($value) cannot be a recursive array

--- a/Zend/tests/constant_arrays.phpt
+++ b/Zend/tests/constant_arrays.phpt
@@ -24,12 +24,21 @@ $y[0] = 3;
 var_dump($x, $y, QUX);
 
 // ensure objects not allowed in arrays
-var_dump(define('ELEPHPANT', [new StdClass]));
+try {
+    define('ELEPHPANT', [new StdClass]);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 // ensure recursion doesn't crash
 $recursive = [];
 $recursive[0] = &$recursive;
-var_dump(define('RECURSION', $recursive));
+
+try {
+    define('RECURSION', $recursive);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 --EXPECTF--
 array(4) {
   [0]=>
@@ -92,9 +101,5 @@ array(1) {
   [0]=>
   int(7)
 }
-
-Warning: Constants may only evaluate to scalar values, arrays or resources in %s on line %d
-bool(false)
-
-Warning: Constants cannot be recursive arrays in %s on line %d
-bool(false)
+define(): Argument #2 ($value) must be of type bool|int|float|string|array|resource|null, stdClass given
+define(): Argument #2 ($value) cannot be a recursive array

--- a/Zend/tests/constants_002.phpt
+++ b/Zend/tests/constants_002.phpt
@@ -3,7 +3,12 @@ Defining constants with non-scalar values
 --FILE--
 <?php
 
-define('foo', new stdClass);
+try {
+    define('foo', new stdClass);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
 try {
     var_dump(foo);
 } catch (Error $e) {
@@ -14,7 +19,7 @@ define('foo', fopen(__FILE__, 'r'));
 var_dump(foo);
 
 ?>
---EXPECTF--
-Warning: Constants may only evaluate to scalar values, arrays or resources in %s on line %d
+--EXPECT--
+define(): Argument #2 ($value) must be of type bool|int|float|string|array|resource|null, stdClass given
 Undefined constant "foo"
 resource(5) of type (stream)

--- a/Zend/tests/constants_002.phpt
+++ b/Zend/tests/constants_002.phpt
@@ -20,6 +20,6 @@ var_dump(foo);
 
 ?>
 --EXPECT--
-define(): Argument #2 ($value) must be of type bool|int|float|string|array|resource|null, stdClass given
+define(): Argument #2 ($value) cannot be an object, stdClass given
 Undefined constant "foo"
 resource(5) of type (stream)

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -499,8 +499,7 @@ ZEND_FUNCTION(define)
 	}
 
 	if (non_cs) {
-		zend_error(E_WARNING, "define(): Declaration of case-insensitive constants is no longer supported");
-    	RETURN_FALSE;
+		zend_error(E_WARNING, "define(): Argument #3 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported");
     }
 
 	ZVAL_UNDEF(&val_free);

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -6,23 +6,24 @@ function zend_version(): string {}
 
 function func_num_args(): int {}
 
-function func_get_arg(int $arg_num): mixed {}
+function func_get_arg(int $argument_number): mixed {}
 
 function func_get_args(): array {}
 
-function strlen(string $str): int {}
+function strlen(string $string): int {}
 
-function strcmp(string $str1, string $str2): int {}
+function strcmp(string $string1, string $string2): int {}
 
-function strncmp(string $str1, string $str2, int $len): int {}
+function strncmp(string $string1, string $string2, int $length): int {}
 
-function strcasecmp(string $str1, string $str2): int {}
+function strcasecmp(string $string1, string $string2): int {}
 
-function strncasecmp(string $str1, string $str2, int $len): int {}
+function strncasecmp(string $string1, string $string2, int $length): int {}
 
-function error_reporting($new_error_level = UNKNOWN): int {}
+function error_reporting(?int $error_level = null): int {}
 
-function define(string $constant_name, $value, bool $case_insensitive = false): bool {}
+/** @param bool|int|float|string|array|resource|null $value */
+function define(string $constant_name, $value): bool {}
 
 function defined(string $constant_name): bool {}
 
@@ -38,25 +39,28 @@ function is_a($object, string $class_name, bool $allow_string = false): bool {}
 
 function get_class_vars(string $class_name): array|false {}
 
-function get_object_vars(object $obj): array {}
+function get_object_vars(object $object): array {}
 
-function get_mangled_object_vars(object $obj): array {}
+function get_mangled_object_vars(object $object): array {}
 
-function get_class_methods(string|object $class): array {}
+/** string|object $class */
+function get_class_methods($class): array {}
 
+/** @param object|string $object_or_class */
 function method_exists($object_or_class, string $method): bool {}
 
+/** @param object|string $object_or_class */
 function property_exists($object_or_class, string $property_name): bool {}
 
-function class_exists(string $classname, bool $autoload = true): bool {}
+function class_exists(string $class_name, bool $autoload = true): bool {}
 
-function interface_exists(string $classname, bool $autoload = true): bool {}
+function interface_exists(string $interface_name, bool $autoload = true): bool {}
 
-function trait_exists(string $traitname, bool $autoload = true): bool {}
+function trait_exists(string $trait_name, bool $autoload = true): bool {}
 
 function function_exists(string $function_name): bool {}
 
-function class_alias(string $user_class_name, string $alias_name, bool $autoload = true): bool {}
+function class_alias(string $original_class_name, string $alias, bool $autoload = true): bool {}
 
 function get_included_files(): array {}
 
@@ -88,11 +92,13 @@ function get_defined_functions(bool $exclude_disabled = true): array {}
 
 function get_defined_vars(): array {}
 
-function get_resource_type($res): string {}
+/** @param resource $resource */
+function get_resource_type($resource): string {}
 
-function get_resource_id($res): int {}
+/** @param resource $resource */
+function get_resource_id($resource): int {}
 
-function get_resources(string $type = UNKNOWN): array {}
+function get_resources(?string $type = null): array {}
 
 function get_loaded_extensions(bool $zend_extensions = false): array {}
 
@@ -102,9 +108,9 @@ function debug_backtrace(int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT, int $lim
 
 function debug_print_backtrace(int $options = 0, int $limit = 0): void {}
 
-function extension_loaded(string $extension_name): bool {}
+function extension_loaded(string $extension): bool {}
 
-function get_extension_funcs(string $extension_name): array|false {}
+function get_extension_funcs(string $extension): array|false {}
 
 #if ZEND_DEBUG && defined(ZTS)
 function zend_thread_id(): int {}

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -23,7 +23,7 @@ function strncasecmp(string $string1, string $string2, int $length): int {}
 function error_reporting(?int $error_level = null): int {}
 
 /** @param bool|int|float|string|array|resource|null $value */
-function define(string $constant_name, $value): bool {}
+function define(string $constant_name, $value, $case_insensitive = false): bool {}
 
 function defined(string $constant_name): bool {}
 

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -31,22 +31,21 @@ function get_class(object $object = UNKNOWN): string {}
 
 function get_called_class(): string {}
 
-function get_parent_class(string|object $object = UNKNOWN): string|false {}
+function get_parent_class(object|string $object_or_class = UNKNOWN): string|false {}
 
-/** @param object|string $object */
-function is_subclass_of(mixed $object, string $class_name, bool $allow_string = true): bool {}
+/** @param object|string $object_or_class */
+function is_subclass_of(mixed $object_or_class, string $class, bool $allow_string = true): bool {}
 
-/** @param object|string $object */
-function is_a(mixed $object, string $class_name, bool $allow_string = false): bool {}
+/** @param object|string $object_or_class */
+function is_a(mixed $object_or_class, string $class, bool $allow_string = false): bool {}
 
-function get_class_vars(string $class_name): array|false {}
+function get_class_vars(string $class): array|false {}
 
 function get_object_vars(object $object): array {}
 
 function get_mangled_object_vars(object $object): array {}
 
-/** string|object $class */
-function get_class_methods($class): array {}
+function get_class_methods(object|string $object_or_class): array {}
 
 /** @param object|string $object_or_class */
 function method_exists(mixed $object_or_class, string $method): bool {}
@@ -54,15 +53,15 @@ function method_exists(mixed $object_or_class, string $method): bool {}
 /** @param object|string $object_or_class */
 function property_exists(mixed $object_or_class, string $property): bool {}
 
-function class_exists(string $class_name, bool $autoload = true): bool {}
+function class_exists(string $class, bool $autoload = true): bool {}
 
-function interface_exists(string $interface_name, bool $autoload = true): bool {}
+function interface_exists(string $interface, bool $autoload = true): bool {}
 
-function trait_exists(string $trait_name, bool $autoload = true): bool {}
+function trait_exists(string $trait, bool $autoload = true): bool {}
 
-function function_exists(string $function_name): bool {}
+function function_exists(string $function): bool {}
 
-function class_alias(string $original_class_name, string $alias, bool $autoload = true): bool {}
+function class_alias(string $class, string $alias, bool $autoload = true): bool {}
 
 function get_included_files(): array {}
 

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -6,7 +6,7 @@ function zend_version(): string {}
 
 function func_num_args(): int {}
 
-function func_get_arg(int $argument_number): mixed {}
+function func_get_arg(int $position): mixed {}
 
 function func_get_args(): array {}
 
@@ -22,7 +22,7 @@ function strncasecmp(string $string1, string $string2, int $length): int {}
 
 function error_reporting(?int $error_level = null): int {}
 
-/** @param bool|int|float|string|array|resource|null $value */
+/** @param mixed $value */
 function define(string $constant_name, $value, $case_insensitive = false): bool {}
 
 function defined(string $constant_name): bool {}
@@ -33,9 +33,11 @@ function get_called_class(): string {}
 
 function get_parent_class(string|object $object = UNKNOWN): string|false {}
 
-function is_subclass_of($object, string $class_name, bool $allow_string = true): bool {}
+/** @param object|string $object */
+function is_subclass_of(mixed $object, string $class_name, bool $allow_string = true): bool {}
 
-function is_a($object, string $class_name, bool $allow_string = false): bool {}
+/** @param object|string $object */
+function is_a(mixed $object, string $class_name, bool $allow_string = false): bool {}
 
 function get_class_vars(string $class_name): array|false {}
 
@@ -47,10 +49,10 @@ function get_mangled_object_vars(object $object): array {}
 function get_class_methods($class): array {}
 
 /** @param object|string $object_or_class */
-function method_exists($object_or_class, string $method): bool {}
+function method_exists(mixed $object_or_class, string $method): bool {}
 
 /** @param object|string $object_or_class */
-function property_exists($object_or_class, string $property_name): bool {}
+function property_exists(mixed $object_or_class, string $property): bool {}
 
 function class_exists(string $class_name, bool $autoload = true): bool {}
 

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b54cd767a1c2fd07865460fc9df8368ee988c823 */
+ * Stub hash: d1ab4864c1159916b45c8f272a2a1d708b2dca65 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -54,23 +54,23 @@ ZEND_END_ARG_INFO()
 #define arginfo_get_called_class arginfo_zend_version
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_get_parent_class, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_MASK(0, object, MAY_BE_STRING|MAY_BE_OBJECT, NULL)
+	ZEND_ARG_TYPE_MASK(0, object_or_class, MAY_BE_OBJECT|MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_is_subclass_of, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, object, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, object_or_class, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, class, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, allow_string, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_is_a, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, object, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, object_or_class, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, class, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, allow_string, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_get_class_vars, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, class, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_object_vars, 0, 1, IS_ARRAY, 0)
@@ -80,40 +80,40 @@ ZEND_END_ARG_INFO()
 #define arginfo_get_mangled_object_vars arginfo_get_object_vars
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_class_methods, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_INFO(0, class)
+	ZEND_ARG_TYPE_MASK(0, object_or_class, MAY_BE_OBJECT|MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_method_exists, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, object_or_class)
+	ZEND_ARG_TYPE_INFO(0, object_or_class, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, method, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_property_exists, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, object_or_class)
+	ZEND_ARG_TYPE_INFO(0, object_or_class, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, property, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_exists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, class, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_interface_exists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, interface_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, interface, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_trait_exists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, trait_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, trait, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_function_exists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, function, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_alias, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, original_class_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, class, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, alias, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f915bc6d966efc2520aa706b9d00c72ead1954d */
+ * Stub hash: 13ccb76ae84972dc12a26555e9d8652e58150378 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -40,6 +40,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_define, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, constant_name, IS_STRING, 0)
 	ZEND_ARG_INFO(0, value)
+	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, case_insensitive, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_defined, 0, 1, _IS_BOOL, 0)

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 13ccb76ae84972dc12a26555e9d8652e58150378 */
+ * Stub hash: b54cd767a1c2fd07865460fc9df8368ee988c823 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -8,7 +8,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_func_num_args, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_func_get_arg, 0, 1, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, argument_number, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, position, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_func_get_args, 0, 0, IS_ARRAY, 0)
@@ -58,13 +58,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_get_parent_class, 0, 0, MAY_BE_S
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_is_subclass_of, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, object)
+	ZEND_ARG_TYPE_INFO(0, object, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, allow_string, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_is_a, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, object)
+	ZEND_ARG_TYPE_INFO(0, object, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, allow_string, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
@@ -90,7 +90,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_property_exists, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, object_or_class)
-	ZEND_ARG_TYPE_INFO(0, property_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, property, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_exists, 0, 1, _IS_BOOL, 0)

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0d3c035fc2b9f0dcdbf6efe3c740d8aa3805ec32 */
+ * Stub hash: 8f915bc6d966efc2520aa706b9d00c72ead1954d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -8,25 +8,25 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_func_num_args, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_func_get_arg, 0, 1, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, arg_num, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, argument_number, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_func_get_args, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_strlen, 0, 1, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, str, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_strcmp, 0, 2, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, str1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, str2, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string2, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_strncmp, 0, 3, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, str1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, str2, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, len, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, string1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string2, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_strcasecmp arginfo_strcmp
@@ -34,13 +34,12 @@ ZEND_END_ARG_INFO()
 #define arginfo_strncasecmp arginfo_strncmp
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_error_reporting, 0, 0, IS_LONG, 0)
-	ZEND_ARG_INFO(0, new_error_level)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, error_level, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_define, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, constant_name, IS_STRING, 0)
 	ZEND_ARG_INFO(0, value)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, case_insensitive, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_defined, 0, 1, _IS_BOOL, 0)
@@ -74,13 +73,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_get_class_vars, 0, 1, MAY_BE_ARR
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_object_vars, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, obj, IS_OBJECT, 0)
+	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_get_mangled_object_vars arginfo_get_object_vars
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_class_methods, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_MASK(0, class, MAY_BE_STRING|MAY_BE_OBJECT, NULL)
+	ZEND_ARG_INFO(0, class)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_method_exists, 0, 2, _IS_BOOL, 0)
@@ -94,14 +93,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_property_exists, 0, 2, _IS_BOOL,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_exists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, classname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, class_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
-#define arginfo_interface_exists arginfo_class_exists
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_interface_exists, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, interface_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_trait_exists, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, traitname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, trait_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
@@ -110,8 +112,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_function_exists, 0, 1, _IS_BOOL,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_alias, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, user_class_name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, alias_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, original_class_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, alias, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoload, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
@@ -153,15 +155,15 @@ ZEND_END_ARG_INFO()
 #define arginfo_get_defined_vars arginfo_func_get_args
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_resource_type, 0, 1, IS_STRING, 0)
-	ZEND_ARG_INFO(0, res)
+	ZEND_ARG_INFO(0, resource)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_resource_id, 0, 1, IS_LONG, 0)
-	ZEND_ARG_INFO(0, res)
+	ZEND_ARG_INFO(0, resource)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_resources, 0, 0, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, type, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_get_loaded_extensions, 0, 0, IS_ARRAY, 0)
@@ -183,11 +185,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_debug_print_backtrace, 0, 0, IS_
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_extension_loaded, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, extension_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, extension, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_get_extension_funcs, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, extension_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, extension, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #if ZEND_DEBUG && defined(ZTS)

--- a/Zend/zend_closures.stub.php
+++ b/Zend/zend_closures.stub.php
@@ -6,13 +6,17 @@ final class Closure
 {
     private function __construct() {}
 
-    public static function bind(Closure $closure, ?object $newthis, $newscope = UNKNOWN): ?Closure {}
+    /** @param object|string|null $newScope */
+    public static function bind(Closure $closure, ?object $newThis, $newScope = UNKNOWN): ?Closure {}
 
-    /** @alias Closure::bind */
-    public function bindTo(?object $newthis, $newscope = UNKNOWN): ?Closure {}
+    /**
+     * @param object|string|null $newScope
+     * @alias Closure::bind
+     */
+    public function bindTo(?object $newThis, $newScope = UNKNOWN): ?Closure {}
 
-    public function call(object $newthis, mixed ...$parameters): mixed {}
+    public function call(object $newThis, mixed ...$arguments): mixed {}
 
-    /** @param callable $callable Not a proper type annotation due to bug #78770 */
-    public static function fromCallable($callable): Closure {}
+    /** @param callable $callback Not a proper type annotation due to bug #78770 */
+    public static function fromCallable($callback): Closure {}
 }

--- a/Zend/zend_closures_arginfo.h
+++ b/Zend/zend_closures_arginfo.h
@@ -1,27 +1,27 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3352191f3a07009ef853829816a3209156afb0bc */
+ * Stub hash: 57771cb65a3193bd683be75efd04f7daff0f8585 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Closure___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Closure_bind, 0, 2, Closure, 1)
 	ZEND_ARG_OBJ_INFO(0, closure, Closure, 0)
-	ZEND_ARG_TYPE_INFO(0, newthis, IS_OBJECT, 1)
-	ZEND_ARG_INFO(0, newscope)
+	ZEND_ARG_TYPE_INFO(0, newThis, IS_OBJECT, 1)
+	ZEND_ARG_INFO(0, newScope)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Closure_bindTo, 0, 1, Closure, 1)
-	ZEND_ARG_TYPE_INFO(0, newthis, IS_OBJECT, 1)
-	ZEND_ARG_INFO(0, newscope)
+	ZEND_ARG_TYPE_INFO(0, newThis, IS_OBJECT, 1)
+	ZEND_ARG_INFO(0, newScope)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Closure_call, 0, 1, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, newthis, IS_OBJECT, 0)
-	ZEND_ARG_VARIADIC_TYPE_INFO(0, parameters, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, newThis, IS_OBJECT, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, arguments, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Closure_fromCallable, 0, 1, Closure, 0)
-	ZEND_ARG_INFO(0, callable)
+	ZEND_ARG_INFO(0, callback)
 ZEND_END_ARG_INFO()
 
 

--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -821,8 +821,7 @@ PHP_FUNCTION(com_load_typelib)
 	}
 
 	if (!cs) {
-		php_error_docref(NULL, E_WARNING, "Declaration of case-insensitive constants is no longer supported");
-		RETURN_FALSE;
+		php_error_docref(NULL, E_WARNING, "com_load_typelib(): Argument #2 ($case_insensitive) is ignored since declaration of case-insensitive constants is no longer supported");
 	}
 
 	RETVAL_FALSE;

--- a/ext/standard/tests/class_object/get_class_methods_basic_001.phpt
+++ b/ext/standard/tests/class_object/get_class_methods_basic_001.phpt
@@ -57,5 +57,5 @@ Argument is name of class which has no methods:
 array(0) {
 }
 Argument is non existent class:
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, string given
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 Done

--- a/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
@@ -69,13 +69,13 @@ $values = array(
 // loop through each element of the array for class
 
 foreach($values as $value) {
-      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . " \n";
+      echo "\nArg value " . (is_object($value) ? get_class($value) : $value) . "\n";
       try {
             var_dump( get_class_methods($value) );
       } catch (TypeError $exception) {
             echo $exception->getMessage() . "\n";
       }
-};
+}
 echo "Done";
 ?>
 --EXPECT--
@@ -83,90 +83,90 @@ echo "Done";
 Error: 2 - Undefined variable $undefined_var
 Error: 2 - Undefined variable $unset_var
 
-Arg value 0 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, int given
+Arg value 0
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 
-Arg value 1 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, int given
+Arg value 1
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 
-Arg value 12345 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, int given
+Arg value 12345
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 
-Arg value -2345 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, int given
+Arg value -2345
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 
-Arg value 10.5 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, float given
+Arg value 10.5
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 
-Arg value -10.5 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, float given
+Arg value -10.5
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 
-Arg value 101234567000 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, float given
+Arg value 101234567000
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 
-Arg value 1.07654321E-9 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, float given
+Arg value 1.07654321E-9
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 
-Arg value 0.5 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, float given
+Arg value 0.5
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 Error: 2 - Array to string conversion
 
-Arg value Array 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, array given
+Arg value Array
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 Error: 2 - Array to string conversion
 
-Arg value Array 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, array given
+Arg value Array
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 Error: 2 - Array to string conversion
 
-Arg value Array 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, array given
+Arg value Array
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 Error: 2 - Array to string conversion
 
-Arg value Array 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, array given
+Arg value Array
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 Error: 2 - Array to string conversion
 
-Arg value Array 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, array given
+Arg value Array
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 
-Arg value  
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, null given
+Arg value 
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, null given
 
-Arg value  
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, null given
+Arg value 
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, null given
 
-Arg value 1 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, bool given
+Arg value 1
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, bool given
 
-Arg value  
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, bool given
+Arg value 
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, bool given
 
-Arg value 1 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, bool given
+Arg value 1
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, bool given
 
-Arg value  
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, bool given
+Arg value 
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, bool given
 
-Arg value  
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, string given
+Arg value 
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 
-Arg value  
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, string given
+Arg value 
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 
-Arg value string 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, string given
+Arg value string
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 
-Arg value string 
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, string given
+Arg value string
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 
-Arg value stdClass 
+Arg value stdClass
 array(0) {
 }
 
-Arg value  
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, null given
+Arg value 
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, null given
 
-Arg value  
-get_class_methods(): Argument #1 ($class) must be a valid class name or object, null given
+Arg value 
+get_class_methods(): Argument #1 ($object_or_class) must be a valid class name or object, null given
 Done

--- a/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
+++ b/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
@@ -87,90 +87,90 @@ Error: 2 - Undefined variable $undefined_var
 Error: 2 - Undefined variable $unset_var
 
 Arg value 0
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, int given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 
 Arg value 1
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, int given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 
 Arg value 12345
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, int given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 
 Arg value -2345
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, int given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, int given
 
 Arg value 10.5
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, float given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 
 Arg value -10.5
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, float given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 
 Arg value 101234567000
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, float given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 
 Arg value 1.07654321E-9
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, float given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 
 Arg value 0.5
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, float given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, float given
 Error: 2 - Array to string conversion
 
 Arg value Array
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, array given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 Error: 2 - Array to string conversion
 
 Arg value Array
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, array given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 Error: 2 - Array to string conversion
 
 Arg value Array
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, array given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 Error: 2 - Array to string conversion
 
 Arg value Array
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, array given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 Error: 2 - Array to string conversion
 
 Arg value Array
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, array given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, array given
 
 Arg value 
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, null given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, null given
 
 Arg value 
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, null given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, null given
 
 Arg value 1
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, bool given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, bool given
 
 Arg value 
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, bool given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, bool given
 
 Arg value 1
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, bool given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, bool given
 
 Arg value 
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, bool given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, bool given
 
 Arg value 
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, string given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 
 Arg value 
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, string given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 
 Arg value string
 In autoload(string)
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, string given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 
 Arg value String
 In autoload(String)
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, string given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, string given
 
 Arg value stdClass
 bool(false)
 
 Arg value 
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, null given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, null given
 
 Arg value 
-get_parent_class(): Argument #1 ($object) must be a valid class name or object, null given
+get_parent_class(): Argument #1 ($object_or_class) must be a valid class name or object, null given
 Done

--- a/ext/standard/tests/general_functions/bug41970.phpt
+++ b/ext/standard/tests/general_functions/bug41970.phpt
@@ -23,9 +23,9 @@ echo "Done\n";
 --EXPECTF--
 Warning: sort(): Argument #1 ($arg) must be passed by reference, value given in %s on line %d
 bool(true)
-strlen(): Argument #1 ($str) must be of type string, array given
+strlen(): Argument #1 ($string) must be of type string, array given
 
 Warning: sort(): Argument #1 ($arg) must be passed by reference, value given in %s on line %d
 bool(true)
-strlen(): Argument #1 ($str) must be of type string, array given
+strlen(): Argument #1 ($string) must be of type string, array given
 Done

--- a/ext/standard/tests/strings/bug36944.phpt
+++ b/ext/standard/tests/strings/bug36944.phpt
@@ -21,9 +21,9 @@ var_dump(strncasecmp("test ", "E", 0));
 
 ?>
 --EXPECTF--
-strncmp(): Argument #3 ($len) must be greater than or equal to 0
+strncmp(): Argument #3 ($length) must be greater than or equal to 0
 int(%d)
 int(0)
-strncasecmp(): Argument #3 ($len) must be greater than or equal to 0
+strncasecmp(): Argument #3 ($length) must be greater than or equal to 0
 int(%d)
 int(0)

--- a/ext/standard/tests/strings/strncasecmp_error.phpt
+++ b/ext/standard/tests/strings/strncasecmp_error.phpt
@@ -19,4 +19,4 @@ try {
 --EXPECT--
 *** Testing strncasecmp() function: error conditions ***
 -- Testing strncasecmp() function with invalid argument --
-strncasecmp(): Argument #3 ($len) must be greater than or equal to 0
+strncasecmp(): Argument #3 ($length) must be greater than or equal to 0

--- a/ext/standard/tests/strings/strncmp_error.phpt
+++ b/ext/standard/tests/strings/strncmp_error.phpt
@@ -20,4 +20,4 @@ try {
 ?>
 --EXPECT--
 *** Testing strncmp() function: error conditions ***
-strncmp(): Argument #3 ($len) must be greater than or equal to 0
+strncmp(): Argument #3 ($length) must be greater than or equal to 0

--- a/tests/lang/bug44827.phpt
+++ b/tests/lang/bug44827.phpt
@@ -6,14 +6,20 @@ sebs@php.net
 Testfest Munich 2009
 --FILE--
 <?php
-define('::', true);
 try {
-    var_dump(constant('::'));
+    define('::', true);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    constant('::');
 } catch (Error $e) {
     echo $e->getMessage(), "\n";
 }
+
 ?>
 --EXPECTF--
-Warning: Class constants cannot be defined or redefined in %s on line %d
+define(): Argument #1 ($constant_name) cannot be a class constant
 
 Fatal error: Class "" not found in %s on line %d

--- a/tests/lang/func_get_arg.004.phpt
+++ b/tests/lang/func_get_arg.004.phpt
@@ -15,4 +15,4 @@ foo(2, 3);
 
 ?>
 --EXPECT--
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function

--- a/tests/lang/func_get_arg.004.phpt
+++ b/tests/lang/func_get_arg.004.phpt
@@ -15,4 +15,4 @@ foo(2, 3);
 
 ?>
 --EXPECT--
-func_get_arg(): Argument 2 not passed to function
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function

--- a/tests/lang/func_get_arg_variation.phpt
+++ b/tests/lang/func_get_arg_variation.phpt
@@ -22,5 +22,5 @@ foo(2);
 
 ?>
 --EXPECT--
-func_get_arg(): Argument #1 ($arg_num) must be greater than or equal to 0
-func_get_arg(): Argument 2 not passed to function
+func_get_arg(): Argument #1 ($argument_number) must be greater than or equal to 0
+func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function

--- a/tests/lang/func_get_arg_variation.phpt
+++ b/tests/lang/func_get_arg_variation.phpt
@@ -22,5 +22,5 @@ foo(2);
 
 ?>
 --EXPECT--
-func_get_arg(): Argument #1 ($argument_number) must be greater than or equal to 0
-func_get_arg(): Argument #1 ($argument_number) must be less than the number of the arguments passed to the currently executed function
+func_get_arg(): Argument #1 ($position) must be greater than or equal to 0
+func_get_arg(): Argument #1 ($position) must be less than the number of the arguments passed to the currently executed function

--- a/tests/lang/func_num_args.003.phpt
+++ b/tests/lang/func_num_args.003.phpt
@@ -3,9 +3,12 @@ func_num_args() outside of a function declaration
 --FILE--
 <?php
 
-var_dump(func_num_args());
+try {
+    func_num_args();
+} catch (Error $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 ?>
---EXPECTF--
-Warning: func_num_args():  Called from the global scope - no function context in %s on line %d
-int(-1)
+--EXPECT--
+func_num_args() must be called from a function context


### PR DESCRIPTION
- Changed a few parameter names
- Improved a few error messages
- Promoted a few warnings to exceptions
- Fixed an `UNKNOWN` default value

~Additionally, I removed the `$non_cs` parameter of `define()`, but actually, I wasn't sure it's really the right time to do it.~