### PR TITLE
make json_decode param $assoc compatible with  documentation

### DIFF
--- a/ext/json/json.stub.php
+++ b/ext/json/json.stub.php
@@ -4,7 +4,7 @@
 
 function json_encode(mixed $value, int $options = 0, int $depth = 512): string|false {}
 
-function json_decode(string $json, ?bool $assoc = null, int $depth = 512, int $options = 0): mixed {}
+function json_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0): mixed {}
 
 function json_last_error(): int {}
 


### PR DESCRIPTION
This PR is not finished. I cannot finish it due to personal reasons.
But I would really like someone to take over it.

In the docs (https://www.php.net/manual/en/function.json-decode.php) we have ` bool $assoc = FALSE` where default value is `false` and type `bool` (not nullable)

as you can see in `stub` files current version is `?bool $assoc = null` which is not compatible with docs.

I think the docs edition is right, but it's a little bit BC break.