### PR TITLE
Fix Bug #75785: Add extra check for Maker's Note endianness

### DIFF
--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -3173,6 +3173,23 @@ static int exif_process_IFD_in_MAKERNOTE(image_info_type *ImageInfo, char * valu
 
 	NumDirEntries = php_ifd_get16u(dir_start, ImageInfo->motorola_intel);
 
+	/* It can be that motorola_intel is wrongly mapped, let's try inverting it */
+	if ((2+NumDirEntries*12) > value_len) {
+		exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Potentially invalid endianess, trying again with different endianness before imminent failure.");
+
+		ImageInfo->motorola_intel = ImageInfo->motorola_intel == 0 ? 1 : 0;
+		NumDirEntries = php_ifd_get16u(dir_start, ImageInfo->motorola_intel);
+	}
+
+	if ((2+NumDirEntries*12) > value_len) {
+		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Illegal IFD size: 2 + 0x%04X*12 = 0x%04X > 0x%04X", NumDirEntries, 2+NumDirEntries*12, value_len);
+		return FALSE;
+	}
+	if ((dir_start - value_ptr) > value_len - (2+NumDirEntries*12)) {
+		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Illegal IFD size: 0x%04X > 0x%04X", (dir_start - value_ptr) + (2+NumDirEntries*12), value_len);
+		return FALSE;
+	}
+
 	switch (maker_note->offset_mode) {
 		case MN_OFFSET_MAKER:
 			offset_base = value_ptr;
@@ -3201,15 +3218,6 @@ static int exif_process_IFD_in_MAKERNOTE(image_info_type *ImageInfo, char * valu
 		case MN_OFFSET_NORMAL:
 			data_len = value_len;
 			break;
-	}
-
-	if ((2+NumDirEntries*12) > value_len) {
-		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Illegal IFD size: 2 + 0x%04X*12 = 0x%04X > 0x%04X", NumDirEntries, 2+NumDirEntries*12, value_len);
-		return FALSE;
-	}
-	if ((dir_start - value_ptr) > value_len - (2+NumDirEntries*12)) {
-		exif_error_docref("exif_read_data#error_ifd" EXIFERR_CC, ImageInfo, E_WARNING, "Illegal IFD size: 0x%04X > 0x%04X", (dir_start - value_ptr) + (2+NumDirEntries*12), value_len);
-		return FALSE;
 	}
 
 	for (de=0;de<NumDirEntries;de++) {

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -66,7 +66,7 @@ typedef unsigned char uchar;
 
 #define EFREE_IF(ptr)	if (ptr) efree(ptr)
 
-#define MAX_IFD_NESTING_LEVEL 150
+#define MAX_IFD_NESTING_LEVEL 200
 
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO(arginfo_exif_tagname, 0)

--- a/ext/exif/tests/bug75785/bug75785.phpt
+++ b/ext/exif/tests/bug75785/bug75785.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #75785 fix corrupt EXIF header issues; Related to mixed endianness. (Thank you @Richard Matzinger for providing the test photo)
+--SKIPIF--
+<?php if (!extension_loaded('exif')) print 'skip exif extension not available';?>
+--FILE--
+<?php
+$mixedEndiannessFile = dirname(__FILE__).'/P1000506.JPG';
+$tags = exif_read_data($mixedEndiannessFile, 'EXIF', true, false);
+
+echo $tags['GPS']['GPSLatitude'][0] . PHP_EOL;
+echo $tags['GPS']['GPSLongitude'][0] . PHP_EOL;
+?>
+===DONE===
+--EXPECTF--
+38/1
+122/1
+===DONE===


### PR DESCRIPTION
This pull request adds a naive recovery mechanism for ext/exif when extracting Maker Notes IFD tags and solves most of the warnings described in [this bug ticket](https://bugs.php.net/bug.php?id=75785)

The current behaviour expects the byte order to follow the same defined in the TIFF header. But some manufacturers might change this order. That's why the current exif.c file has a lookup table with valid manufacturers and their expected endianness.

Different camera models may also produce IFD Tags using a byte order other than the one specified by the lookup table. For this case, this pull request adds a naive attempt to switch the byte order before completely failing.

Original context where this pull request came from: https://github.com/nawarian/The-PHP-Website/issues/32