### PR TITLE
Fix tests regarding negative fileinode()

### DIFF
--- a/ext/standard/tests/file/fileinode_basic.phpt
+++ b/ext/standard/tests/file/fileinode_basic.phpt
@@ -28,9 +28,9 @@ unlink (__DIR__."/inode.tmp");
 ?>
 --EXPECTF--
 *** Testing fileinode() with file, directory ***
-%d
-%d
-%d
-%d
+%i
+%i
+%i
+%i
 
 *** Done ***

--- a/ext/standard/tests/file/fileinode_variation.phpt
+++ b/ext/standard/tests/file/fileinode_variation.phpt
@@ -89,24 +89,24 @@ echo "\n*** Done ***";
 --EXPECTF--
 *** Testing fileinode() with files, links and directories ***
 -- Testing with files --
-%d
-%d
+%i
+%i
 -- Testing with links: hard link --
-%d
-%d
+%i
+%i
 -- Testing with links: soft link --
-%d
-%d
+%i
+%i
 -- Testing after copying a file --
-%d
-%d
+%i
+%i
 -- Testing after renaming the file --
-%d
-%d
+%i
+%i
 -- Testing with directories --
-%d
-%d
+%i
+%i
 -- Testing with binary input --
-%d
-%d
+%i
+%i
 *** Done ***

--- a/ext/standard/tests/file/filestat.phpt
+++ b/ext/standard/tests/file/filestat.phpt
@@ -30,17 +30,17 @@ var_dump(filectime("/no/such/file/or/dir"));
 echo "Done\n";
 ?>
 --EXPECTF--
+int(%i)
 int(%d)
 int(%d)
 int(%d)
 int(%d)
+int(%i)
 int(%d)
 int(%d)
 int(%d)
 int(%d)
-int(%d)
-int(%d)
-int(%d)
+int(%i)
 int(%d)
 int(%d)
 int(%d)

--- a/ext/standard/tests/file/tempnam_variation1.phpt
+++ b/ext/standard/tests/file/tempnam_variation1.phpt
@@ -66,51 +66,51 @@ echo "*** Done ***\n";
 -- Iteration 1 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 2 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 3 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 4 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 5 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 6 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 7 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 8 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 9 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 -- Iteration 10 --
 File name is => %s%etempnam_variation1.tmp%s
 File permissions are => 100600
-File inode is => %d
+File inode is => %i
 File created in => directory specified
 *** Done ***


### PR DESCRIPTION
The results of `fileinode()` may be negative due to wrap-around
behavior (at least on Windows as of PHP 7.4.0).