### PR TITLE
Fix minor memory leak of CG(script_encoding_list)

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1086,6 +1086,11 @@ void zend_shutdown(void) /* {{{ */
 		CG(map_ptr_base) = NULL;
 		CG(map_ptr_size) = 0;
 	}
+	if (CG(script_encoding_list)) {
+		free(CG(script_encoding_list));
+		CG(script_encoding_list) = NULL;
+		CG(script_encoding_list_size) = 0;
+	}
 #endif
 	zend_destroy_rsrc_list_dtors();
 }


### PR DESCRIPTION
This only leaks at the end of the process, so per se not an issue, but
the leak is caught by MSVC's CRT leak checker, so we better properly
clean up to avoid false positives.