### PR TITLE
Fix #79806: realpath() erroneously resolves link to link

### DIFF
--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -845,6 +845,7 @@ static size_t tsrm_realpath_r(char *path, size_t start, size_t len, int *ll, tim
 		}
 
 #ifdef ZEND_WIN32
+retry_reparse_point:
 		if (save) {
 			pathw = php_win32_ioutil_any_to_w(path);
 			if (!pathw) {
@@ -867,7 +868,7 @@ static size_t tsrm_realpath_r(char *path, size_t start, size_t len, int *ll, tim
 		tmp = do_alloca(len+1, use_heap);
 		memcpy(tmp, path, len+1);
 
-retry:
+retry_reparse_tag_cloud:
 		if(save &&
 				!(IS_UNC_PATH(path, len) && len >= 3 && path[2] != '?') &&
                                (dataw.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
@@ -928,7 +929,7 @@ retry:
 					dataw.dwFileAttributes = fileInformation.dwFileAttributes;
 					CloseHandle(hLink);
 					(*ll)--;
-					goto retry;
+					goto retry_reparse_tag_cloud;
 				}
 				free_alloca(tmp, use_heap);
 				CloseHandle(hLink);
@@ -1074,6 +1075,15 @@ retry:
 #endif
 			free_alloca(pbuffer, use_heap_large);
 			free(substitutename);
+
+			{
+				DWORD attrs = GetFileAttributesA(path);
+				if (!isVolume && (attrs & FILE_ATTRIBUTE_REPARSE_POINT)) {
+					free_alloca(tmp, use_heap);
+					FREE_PATHW()
+					goto retry_reparse_point;
+				}
+			}
 
 			if(isabsolute == 1) {
 				if (!((j == 3) && (path[1] == ':') && (path[2] == '\\'))) {

--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -1077,8 +1077,15 @@ retry_reparse_tag_cloud:
 			free(substitutename);
 
 			{
-				DWORD attrs = GetFileAttributesA(path);
-				if (!isVolume && (attrs & FILE_ATTRIBUTE_REPARSE_POINT)) {
+				DWORD attrs;
+
+				FREE_PATHW()
+				pathw = php_win32_ioutil_any_to_w(path);
+				if (!pathw) {
+					return (size_t)-1;
+				}
+				attrs = GetFileAttributesW(pathw);
+				if (!isVolume && attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_REPARSE_POINT)) {
 					free_alloca(tmp, use_heap);
 					FREE_PATHW()
 					goto retry_reparse_point;

--- a/ext/standard/tests/file/realpath_basic4.phpt
+++ b/ext/standard/tests/file/realpath_basic4.phpt
@@ -1,11 +1,5 @@
 --TEST--
 Test realpath() with relative paths
---SKIPIF--
-<?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip no symlinks on Windows');
-}
-?>
 --FILE--
 <?php
 $file_path = dirname(__FILE__);


### PR DESCRIPTION
After resolving reparse points, the path still may be a reparse point;
in that case we have to resolve that reparse point as well.