### PR TITLE
Fix #79805: sapi_windows_vt100_support throws TypeError

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1314,7 +1314,7 @@ function stream_isatty($stream): bool {}
 
 #ifdef PHP_WIN32
 /** @param resource $stream */
-function sapi_windows_vt100_support($stream, bool $enable = UNKNOWN): bool {}
+function sapi_windows_vt100_support($stream, ?bool $enable = null): bool {}
 #endif
 
 /** @param resource $stream */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 05b740207a70a9d272b4c327882fd0b52016a0af */
+ * Stub hash: 49142ce7a3c79618e87a350b87994e01b1d69ff8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2028,7 +2028,7 @@ ZEND_END_ARG_INFO()
 #if defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_vt100_support, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, stream)
-	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enable, _IS_BOOL, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1643,11 +1643,14 @@ PHP_FUNCTION(sapi_windows_vt100_support)
 		php_stream_cast(stream, PHP_STREAM_AS_FD, (void*)&fileno, 0);
 	}
 	else {
-		zend_type_error(
-			"%s() was not able to analyze the specified stream",
-			get_active_function_name()
-		);
-		RETURN_THROWS();
+		if (argc > 1) {
+			php_error_docref(
+				NULL,
+				E_WARNING,
+				"not able to analyze the specified stream"
+			);
+		}
+		RETURN_FALSE;
 	}
 
 	/* Check if the file descriptor is a console */

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1623,15 +1623,13 @@ PHP_FUNCTION(sapi_windows_vt100_support)
 {
 	zval *zsrc;
 	php_stream *stream;
-	zend_bool enable;
+	zend_bool enable, enable_is_null = 1;
 	zend_long fileno;
-
-	int argc = ZEND_NUM_ARGS();
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_RESOURCE(zsrc)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_BOOL(enable)
+		Z_PARAM_BOOL_OR_NULL(enable, enable_is_null)
 	ZEND_PARSE_PARAMETERS_END();
 
 	php_stream_from_zval(stream, zsrc);
@@ -1643,7 +1641,7 @@ PHP_FUNCTION(sapi_windows_vt100_support)
 		php_stream_cast(stream, PHP_STREAM_AS_FD, (void*)&fileno, 0);
 	}
 	else {
-		if (argc > 1) {
+		if (!enable_is_null) {
 			php_error_docref(
 				NULL,
 				E_WARNING,
@@ -1658,7 +1656,7 @@ PHP_FUNCTION(sapi_windows_vt100_support)
 		RETURN_FALSE;
 	}
 
-	if (argc == 1) {
+	if (enable_is_null) {
 		/* Check if the Windows standard handle has VT100 control codes enabled */
 		if (php_win32_console_fileno_has_vt100(fileno)) {
 			RETURN_TRUE;

--- a/tests/output/sapi_windows_vt100_support.inc
+++ b/tests/output/sapi_windows_vt100_support.inc
@@ -35,7 +35,6 @@ function testToStdOut()
         'STDERR (constant)'             => STDERR,
         'STDERR (fopen)'                => fopen('php://stderr', 'wb'),
         'STDERR (php://fd/2)'           => fopen('php://fd/2', 'wb'),
-        'Not a stream'                  => 'foo',
         'Invalid stream (php://temp)'   => fopen('php://temp', 'wb'),
         'Invalid stream (php://input)'  => fopen('php://input', 'wb'),
         'Invalid stream (php://memory)' => fopen('php://memory', 'wb'),

--- a/tests/output/sapi_windows_vt100_support_winko_err.phpt
+++ b/tests/output/sapi_windows_vt100_support_winko_err.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(false)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  :bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winko_in-err.phpt
+++ b/tests/output/sapi_windows_vt100_support_winko_in-err.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(false)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winko_in-out-err.phpt
+++ b/tests/output/sapi_windows_vt100_support_winko_in-out-err.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(false)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winko_in-out.phpt
+++ b/tests/output/sapi_windows_vt100_support_winko_in-out.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(true)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winko_out-err.phpt
+++ b/tests/output/sapi_windows_vt100_support_winko_out-err.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(false)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winko_out.phpt
+++ b/tests/output/sapi_windows_vt100_support_winko_out.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(true)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winok_err.phpt
+++ b/tests/output/sapi_windows_vt100_support_winok_err.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(false)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winok_in-err.phpt
+++ b/tests/output/sapi_windows_vt100_support_winok_in-err.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(false)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winok_in-out-err.phpt
+++ b/tests/output/sapi_windows_vt100_support_winok_in-out-err.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(false)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winok_in-out.phpt
+++ b/tests/output/sapi_windows_vt100_support_winok_in-out.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(true)
 - disabling VT100: bool(true)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winok_out-err.phpt
+++ b/tests/output/sapi_windows_vt100_support_winok_out-err.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(false)
 - disabling VT100: bool(false)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)

--- a/tests/output/sapi_windows_vt100_support_winok_out.phpt
+++ b/tests/output/sapi_windows_vt100_support_winok_out.phpt
@@ -76,70 +76,36 @@ STDERR (php://fd/2):
 - current value  : bool(true)
 - disabling VT100: bool(true)
 - current value  : bool(false)
-Not a stream:
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support(): Argument #1 must be of type resource, string given in %s on line %d
-bool(false)
 Invalid stream (php://temp):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://input):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 Invalid stream (php://memory):
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- enabling VT100 : 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- enabling VT100 :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
+- current value  : bool(false)
+- disabling VT100: 
+Warning: sapi_windows_vt100_support(): not able to analyze the specified stream in %s on line %d
 bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- disabling VT100:
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
-- current value  :
-Warning: sapi_windows_vt100_support() was not able to analyze the specified stream in %s on line %d
-bool(false)
+- current value  : bool(false)
 File stream:
 - current value  : bool(false)
 - enabling VT100 : bool(false)


### PR DESCRIPTION
It does not make sense to throw a `TypeError` when the stream can't be
analyzed.  If `sapi_windows_vt100_support()` is used as getter, we just
return `false` in that case; if the function is used as setter, we
additionally trigger a warning.

We also fix the test cases for this function, which have been broken
before.  Note that these tests are still whitespace sensitive.