### PR TITLE
Fix brittle test

### DIFF
--- a/ext/session/tests/session_module_name_variation4.phpt
+++ b/ext/session/tests/session_module_name_variation4.phpt
@@ -29,10 +29,11 @@ $_SESSION["Blah"] = "Hello World!";
 $_SESSION["Foo"] = FALSE;
 $_SESSION["Guff"] = 1234567890;
 var_dump($_SESSION);
+$oldsession = $_SESSION;
 
 var_dump(session_write_close());
 session_start();
-var_dump($_SESSION);
+var_dump($_SESSION === $oldsession || $_SESSION === []);
 var_dump(session_destroy());
 session_start();
 var_dump($_SESSION);
@@ -51,14 +52,7 @@ array(3) {
   int(1234567890)
 }
 bool(true)
-array(3) {
-  ["Blah"]=>
-  string(12) "Hello World!"
-  ["Foo"]=>
-  bool(false)
-  ["Guff"]=>
-  int(1234567890)
-}
+bool(true)
 bool(true)
 array(0) {
 }


### PR DESCRIPTION
This test fails occasionally due to timing issues, because the session
file may have been unlinked by the first `session_start()`'s GC.  We
adapt the test expectation to this reality.