### PR TITLE
Check for missing arginfo arguments

### DIFF
--- a/Zend/tests/arginfo_zpp_mismatch.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch.phpt
@@ -3,10 +3,27 @@ Test that there is no arginfo/zpp mismatch
 --FILE--
 <?php
 
-foreach (get_defined_functions()["internal"] as $function) {
+function test($function) {
     try {
         @$function(null, null, null, null, null, null, null, null);
-    } catch (ArgumentCountError|Error) {
+    } catch (Throwable) {
+    }
+}
+
+foreach (get_defined_functions()["internal"] as $function) {
+    test($function);
+}
+
+foreach (get_declared_classes() as $class) {
+    try {
+        $rc = new ReflectionClass($class);
+        $obj = $rc->newInstanceWithoutConstructor();
+    } catch (Throwable) {
+        continue;
+    }
+
+    foreach (get_class_methods($class) as $method) {
+        test([$obj, $method]);
     }
 }
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -130,7 +130,7 @@ static ZEND_FUNCTION(pass)
 ZEND_API const zend_internal_function zend_pass_function = {
 	ZEND_INTERNAL_FUNCTION, /* type              */
 	{0, 0, 0},              /* arg_flags         */
-	0,                      /* fn_flags          */
+	ZEND_ACC_VARIADIC,      /* fn_flags          */
 	NULL,                   /* name              */
 	NULL,                   /* scope             */
 	NULL,                   /* prototype         */
@@ -1122,6 +1122,14 @@ static zend_never_inline ZEND_ATTRIBUTE_UNUSED int zend_verify_internal_arg_type
 static zend_always_inline zend_bool zend_internal_call_should_throw(zend_function *fbc, zend_execute_data *call)
 {
 	if (fbc->common.required_num_args > ZEND_CALL_NUM_ARGS(call)) {
+		/* Required argument not passed. */
+		return 1;
+	}
+
+	if (fbc->common.num_args < ZEND_CALL_NUM_ARGS(call)
+			&& !(fbc->common.fn_flags & ZEND_ACC_VARIADIC)) {
+		/* Too many arguments passed. For internal functions (unlike userland functions),
+		 * this should always throw. */
 		return 1;
 	}
 


### PR DESCRIPTION
Internal functions error when too many arguments are passed. Make this part of the verification we do in debug builds. This will help avoid cases where an argument is missing in the stubs, as recently encountered in https://github.com/php/php-src/commit/6d96f0f9ce3455edfea5a3218f8c21d7e9cc7ca7.

This is going to need some fixes in the pgsql extension, which has liberal use of ZEND_PARSE_PARAMS_QUIET for some god forsaken reason.