### PR TITLE
opcache: optimize some more functions on compile time

### DIFF
--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -844,13 +844,20 @@ static inline int ct_eval_func_call(
 				|| zend_string_equals_literal(name, "urldecode")
 				|| zend_string_equals_literal(name, "rawurlencode")
 				|| zend_string_equals_literal(name, "rawurldecode")
-				|| zend_string_equals_literal(name, "php_uname")) {
+				|| zend_string_equals_literal(name, "php_uname")
+				|| zend_string_equals_literal(name, "dirname")
+				|| zend_string_equals_literal(name, "basename")
+				|| zend_string_equals_literal(name, "md5")
+				|| zend_string_equals_literal(name, "crc32")
+				|| zend_string_equals_literal(name, "sha1")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING) {
 				return FAILURE;
 			}
 			/* pass */
 		} else if (zend_string_equals_literal(name, "array_keys")
-				|| zend_string_equals_literal(name, "array_values")) {
+				|| zend_string_equals_literal(name, "array_values")
+				|| zend_string_equals_literal(name, "array_unique")
+				|| zend_string_equals_literal(name, "array_filter")) {
 			if (Z_TYPE_P(args[0]) != IS_ARRAY) {
 				return FAILURE;
 			}
@@ -903,6 +910,12 @@ static inline int ct_eval_func_call(
 					|| (Z_TYPE_P(args[0]) != IS_LONG
 						&& Z_TYPE_P(args[0]) != IS_STRING
 						&& Z_TYPE_P(args[0]) != IS_NULL)) {
+				return FAILURE;
+			}
+			/* pass */
+		} else if (zend_string_equals_literal(name, "dirname")) {
+			if (Z_TYPE_P(args[0]) != IS_STRING
+					|| (Z_TYPE_P(args[1]) != IS_LONG)) {
 				return FAILURE;
 			}
 			/* pass */
@@ -962,7 +975,8 @@ static inline int ct_eval_func_call(
 				|| zend_string_equals_literal(name, "str_contains")
 				|| zend_string_equals_literal(name, "str_starts_with")
 				|| zend_string_equals_literal(name, "str_ends_with")
-				|| zend_string_equals_literal(name, "version_compare")) {
+				|| zend_string_equals_literal(name, "version_compare")
+				|| zend_string_equals_literal(name, "basename")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING
 					|| Z_TYPE_P(args[1]) != IS_STRING) {
 				return FAILURE;
@@ -1004,7 +1018,8 @@ static inline int ct_eval_func_call(
 				}
 			}
 			/* pass */
-		} else if (zend_string_equals_literal(name, "version_compare")) {
+		} else if (zend_string_equals_literal(name, "version_compare")
+				|| zend_string_equals_literal(name, "str_replace")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING
 					|| Z_TYPE_P(args[1]) != IS_STRING
 					|| Z_TYPE_P(args[2]) != IS_STRING) {

--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -844,8 +844,7 @@ static inline int ct_eval_func_call(
 				|| zend_string_equals_literal(name, "urldecode")
 				|| zend_string_equals_literal(name, "rawurlencode")
 				|| zend_string_equals_literal(name, "rawurldecode")
-				|| zend_string_equals_literal(name, "strtoupper")
-				|| zend_string_equals_literal(name, "strtolower")
+				|| zend_string_equals_literal(name, "php_uname")
 				|| zend_string_equals_literal(name, "dirname")
 				|| zend_string_equals_literal(name, "crc32")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING) {
@@ -872,7 +871,7 @@ static inline int ct_eval_func_call(
 			} ZEND_HASH_FOREACH_END();
 			/* pass */
 		} else if (zend_string_equals_literal(name, "implode")
-                || zend_string_equals_literal(name, "array_unique")) {
+				|| zend_string_equals_literal(name, "array_unique")) {
 			zval *entry;
 
 			if (Z_TYPE_P(args[0]) != IS_ARRAY) {
@@ -916,6 +915,11 @@ static inline int ct_eval_func_call(
 					|| (Z_TYPE_P(args[1]) != IS_LONG)) {
 				return FAILURE;
 			}
+			if (Z_LVAL_P(args[1]) < 1) {
+				// levels must be >= 1, else we get a ValueError
+				return FAILURE;
+			}
+
 			/* pass */
 		} else if (zend_string_equals_literal(name, "trim")
 				|| zend_string_equals_literal(name, "rtrim")
@@ -1015,6 +1019,7 @@ static inline int ct_eval_func_call(
 				}
 			}
 			/* pass */
+		// todo: version_compare with 3 arguments got removed, as we should add a proper check for the comperator, else we hide a ValueError
 		} else if (zend_string_equals_literal(name, "str_replace")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING
 					|| Z_TYPE_P(args[1]) != IS_STRING

--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -844,19 +844,16 @@ static inline int ct_eval_func_call(
 				|| zend_string_equals_literal(name, "urldecode")
 				|| zend_string_equals_literal(name, "rawurlencode")
 				|| zend_string_equals_literal(name, "rawurldecode")
-				|| zend_string_equals_literal(name, "php_uname")
+				|| zend_string_equals_literal(name, "strtoupper")
+				|| zend_string_equals_literal(name, "strtolower")
 				|| zend_string_equals_literal(name, "dirname")
-				|| zend_string_equals_literal(name, "basename")
-				|| zend_string_equals_literal(name, "md5")
-				|| zend_string_equals_literal(name, "crc32")
-				|| zend_string_equals_literal(name, "sha1")) {
+				|| zend_string_equals_literal(name, "crc32")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING) {
 				return FAILURE;
 			}
 			/* pass */
 		} else if (zend_string_equals_literal(name, "array_keys")
 				|| zend_string_equals_literal(name, "array_values")
-				|| zend_string_equals_literal(name, "array_unique")
 				|| zend_string_equals_literal(name, "array_filter")) {
 			if (Z_TYPE_P(args[0]) != IS_ARRAY) {
 				return FAILURE;
@@ -874,7 +871,8 @@ static inline int ct_eval_func_call(
 				}
 			} ZEND_HASH_FOREACH_END();
 			/* pass */
-		} else if (zend_string_equals_literal(name, "implode")) {
+		} else if (zend_string_equals_literal(name, "implode")
+                || zend_string_equals_literal(name, "array_unique")) {
 			zval *entry;
 
 			if (Z_TYPE_P(args[0]) != IS_ARRAY) {
@@ -975,8 +973,7 @@ static inline int ct_eval_func_call(
 				|| zend_string_equals_literal(name, "str_contains")
 				|| zend_string_equals_literal(name, "str_starts_with")
 				|| zend_string_equals_literal(name, "str_ends_with")
-				|| zend_string_equals_literal(name, "version_compare")
-				|| zend_string_equals_literal(name, "basename")) {
+				|| zend_string_equals_literal(name, "version_compare")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING
 					|| Z_TYPE_P(args[1]) != IS_STRING) {
 				return FAILURE;
@@ -1018,8 +1015,7 @@ static inline int ct_eval_func_call(
 				}
 			}
 			/* pass */
-		} else if (zend_string_equals_literal(name, "version_compare")
-				|| zend_string_equals_literal(name, "str_replace")) {
+		} else if (zend_string_equals_literal(name, "str_replace")) {
 			if (Z_TYPE_P(args[0]) != IS_STRING
 					|| Z_TYPE_P(args[1]) != IS_STRING
 					|| Z_TYPE_P(args[2]) != IS_STRING) {


### PR DESCRIPTION
I profiled our production code and found some (more or less rare) function calls which could get evaluated on compile time already + extended it by some other function calls which should always return a static result.

**List: (updated one)**
- dirname(string[, int]) 
- array_unique(array)
- array_filter(array)
- crc32(string)
- str_replace(string, string, string)


Dummy code:
```
// source from official docs: https://www.php.net/manual/en/function.php-uname.php
if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
    echo 'This is a server using Windows!';
} else {
    echo 'This is a server not using Windows!';
}

function getRoot()
{
    return dirname(__DIR__);
}

function getBaseCacheKey()
{
    return str_replace('a', 'z', md5(PHP_VERSION));
}

class A {
    public const BASE_ABILITIES = [
        1,
        2,
    ];
}
class B extends A {
    public const ABILITIES = [
        2,
        3,
        4,
        0,
    ];

    public function getAllAbilities(): string
    {
        return implode(',', array_filter(
            array_unique(array_merge(self::BASE_ABILITIES, self::ABILITIES)))
        );
    }
}
```

**Opcodes before:**
```
$_main:
     ; (lines=9, args=0, vars=0, tmps=2)
     ; (after optimizer)
     ; /www/php-src/test.php:1-144
0000 INIT_FCALL 1 96 string("strtoupper")
0001 SEND_VAL string("Lin") 1
0002 V1 = DO_ICALL
0003 T0 = IS_IDENTICAL V1 string("WIN")
0004 JMPZ T0 0007
0005 ECHO string("This is a server using Windows!")
0006 RETURN int(1)
0007 ECHO string("This is a server not using Windows!")
0008 RETURN int(1)

getRoot:
     ; (lines=1, args=0, vars=0, tmps=0)
     ; (after optimizer)
     ; /www/php-src/test.php:8-11
0000 RETURN string("/www")

getBaseCacheKey:
     ; (lines=10, args=0, vars=0, tmps=1)
     ; (after optimizer)
     ; /www/php-src/test.php:13-16
0000 INIT_FCALL 3 128 string("str_replace")
0001 SEND_VAL string("a") 1
0002 SEND_VAL string("z") 2
0003 INIT_FCALL 1 96 string("md5")
0004 SEND_VAL string("8.0.0-dev") 1
0005 V0 = DO_ICALL
0006 SEND_VAR V0 3
0007 V0 = DO_ICALL
0008 VERIFY_RETURN_TYPE V0
0009 RETURN V0
LIVE RANGES:
     0: 0008 - 0009 (tmp/var)

B::getAllAbilities:
     ; (lines=11, args=0, vars=0, tmps=1)
     ; (after optimizer)
     ; /www/php-src/test.php:32-37
0000 INIT_FCALL 2 112 string("implode")
0001 SEND_VAL string(",") 1
0002 INIT_FCALL 1 96 string("array_filter")
0003 INIT_FCALL 1 96 string("array_unique")
0004 SEND_VAL array(...) 1
0005 V0 = DO_ICALL
0006 SEND_VAR V0 1
0007 V0 = DO_ICALL
0008 SEND_VAR V0 2
0009 V0 = DO_ICALL
0010 RETURN V0
```

**Opcodes afterwards:**
```
$_main:
     ; (lines=2, args=0, vars=0, tmps=0)
     ; (after optimizer)
     ; /www/php-src/test.php:1-159
0000 ECHO string("This is a server not using Windows!")
0001 RETURN int(1)


getRoot:
     ; (lines=1, args=0, vars=0, tmps=0)
     ; (after optimizer)
     ; /www/php-src/test.php:8-11
0000 RETURN string("/www")

getBaseCacheKey:
     ; (lines=1, args=0, vars=0, tmps=0)
     ; (after optimizer)
     ; /www/php-src/test.php:13-16
0000 RETURN string("0583081z712641ez72e8bb3fz6d3d645")

B::getAllAbilities:
     ; (lines=2, args=0, vars=0, tmps=1)
     ; (after optimizer)
     ; /www/php-src/test.php:32-37
0000 V0 = QM_ASSIGN string("1,2,3,4")
0001 RETURN V0
``` 