### PR TITLE
Skip upload_2G.phpt if disk_free_space() <= 2GB

### DIFF
--- a/sapi/cli/tests/upload_2G.phpt
+++ b/sapi/cli/tests/upload_2G.phpt
@@ -8,6 +8,10 @@ if (PHP_INT_SIZE < 8) {
 	die("skip need PHP_INT_SIZE>=8");
 }
 
+if (disk_free_space(sys_get_temp_dir()) < 2300000000) {
+	die("skip need more than 2.15G of free disk space for the uploaded file");
+}
+
 if (!file_exists('/proc/meminfo')) {
 	die('skip Cannot check free RAM from /proc/meminfo on this platform');
 }


### PR DESCRIPTION
This test failed when the free disk space is close to 2.15GB.
I see the file size in the .out file as 0.
PHP has to save the full file contents to disk (the path is in `$_FILES`)

Add to that check in case other tests/processes create temporary files.

Related to GH-5283