### PR TITLE
Fix #73060: php failed with error after temp folder cleaned up

### DIFF
--- a/ext/opcache/shared_alloc_win32.c
+++ b/ext/opcache/shared_alloc_win32.c
@@ -31,9 +31,10 @@
 
 #define ACCEL_FILEMAP_NAME "ZendOPcache.SharedMemoryArea"
 #define ACCEL_MUTEX_NAME "ZendOPcache.SharedMemoryMutex"
-#define ACCEL_FILEMAP_BASE_DEFAULT 0x01000000
-#define ACCEL_FILEMAP_BASE "ZendOPcache.MemoryBase"
 #define ACCEL_EVENT_SOURCE "Zend OPcache"
+
+/* address of mapping base and address of execute_ex */
+#define ACCEL_BASE_POINTER_SIZE (2 * sizeof(void*))
 
 static HANDLE memfile = NULL, memory_mutex = NULL;
 static void *mapping_base;
@@ -125,7 +126,7 @@ static int zend_shared_alloc_reattach(size_t requested_size, char **error_in)
 	void *execute_ex_base;
 	int execute_ex_moved;
 
-	mapping_base = MapViewOfFileEx(memfile, FILE_MAP_ALL_ACCESS, 0, 0, 2 * sizeof(void*), NULL);
+	mapping_base = MapViewOfFileEx(memfile, FILE_MAP_ALL_ACCESS, 0, 0, ACCEL_BASE_POINTER_SIZE, NULL);
 	if (mapping_base == NULL) {
 		err = GetLastError();
 		zend_win_error_message(ACCEL_LOG_FATAL, "Unable to read base address", err);
@@ -190,7 +191,7 @@ static int zend_shared_alloc_reattach(size_t requested_size, char **error_in)
 		}
 		return ALLOC_FAIL_MAPPING;
 	}
-	smm_shared_globals = (zend_smm_shared_globals *) ((char*)mapping_base + 2 * sizeof(void*));
+	smm_shared_globals = (zend_smm_shared_globals *) ((char*)mapping_base + ACCEL_BASE_POINTER_SIZE);
 
 	return SUCCESSFULLY_REATTACHED;
 }
@@ -310,8 +311,8 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 	} else {
 		((void**)mapping_base)[0] = mapping_base;
 		((void**)mapping_base)[1] = (void*)execute_ex;
-		((char*)shared_segment->p) += 2 * sizeof(void*);
-		}
+		((char*)shared_segment->p) += ACCEL_BASE_POINTER_SIZE;
+	}
 
 	shared_segment->pos = 0;
 	shared_segment->size = requested_size;


### PR DESCRIPTION
Instead of storing the mapping base address and the address of
`execute_ex()` in a separate file in the temporary folder, we store
them right at the beginning of the memory mapping.

---

Note that https://bugs.php.net/73060 has been closed as WONTFIX by @weltling long ago, but I don't see why this issue should not be addressed – in my opinion, cleaning the temp folder from time to time shouldn't cause new worker processes failing to start.