### PR TITLE
Fix #78179: mysqli/mysqlnd transaction extensions

### DIFF
--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -2131,23 +2131,16 @@ MYSQLND_METHOD(mysqlnd_conn_data, tx_begin)(MYSQLND_CONN_DATA * conn, const unsi
 				}
 				smart_str_appendl(&tmp_str, "WITH CONSISTENT SNAPSHOT", sizeof("WITH CONSISTENT SNAPSHOT") - 1);
 			}
-			if (mode & (TRANS_START_READ_WRITE | TRANS_START_READ_ONLY)) {
-				zend_ulong server_version = conn->m->get_server_version(conn);
-				if (server_version < 50605L) {
-					php_error_docref(NULL, E_WARNING, "This server version doesn't support 'READ WRITE' and 'READ ONLY'. Minimum 5.6.5 is required");
-					smart_str_free(&tmp_str);
-					break;
-				} else if (mode & TRANS_START_READ_WRITE) {
-					if (tmp_str.s && ZSTR_LEN(tmp_str.s)) {
-						smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
-					}
-					smart_str_appendl(&tmp_str, "READ WRITE", sizeof("READ WRITE") - 1);
-				} else if (mode & TRANS_START_READ_ONLY) {
-					if (tmp_str.s && ZSTR_LEN(tmp_str.s)) {
-						smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
-					}
-					smart_str_appendl(&tmp_str, "READ ONLY", sizeof("READ ONLY") - 1);
+			if (mode & TRANS_START_READ_WRITE) {
+				if (tmp_str.s && ZSTR_LEN(tmp_str.s)) {
+					smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
 				}
+				smart_str_appendl(&tmp_str, "READ WRITE", sizeof("READ WRITE") - 1);
+			} else if (mode & TRANS_START_READ_ONLY) {
+				if (tmp_str.s && ZSTR_LEN(tmp_str.s)) {
+					smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
+				}
+				smart_str_appendl(&tmp_str, "READ ONLY", sizeof("READ ONLY") - 1);
 			}
 			smart_str_0(&tmp_str);
 
@@ -2166,6 +2159,11 @@ MYSQLND_METHOD(mysqlnd_conn_data, tx_begin)(MYSQLND_CONN_DATA * conn, const unsi
 				}
 				ret = conn->m->query(conn, query, query_len);
 				mnd_sprintf_free(query);
+				if (ret && mode & (TRANS_START_READ_WRITE | TRANS_START_READ_ONLY) &&
+					mysqlnd_stmt_errno(conn) == 1064) {
+					php_error_docref(NULL, E_WARNING, "This server version doesn't support 'READ WRITE' and 'READ ONLY'. Minimum 5.6.5 is required");
+					break;
+				}
 			}
 		} while (0);
 		conn->m->local_tx_end(conn, this_func, ret);


### PR DESCRIPTION
MariaDB versioning created a mess with regarding testing
features based on version. We sidestep the problem here
by assuming the extensions are present, and if a syntax
error occurs with a SQL mode TRANS_START_READ_WRITE |
TRANS_START_READ_ONLY enabled, then output the same
warning as before.

Test MDEV-23141.php
<pre>
?php

$db = new mysqli("localhost", "root", "", "test");
$db->begin_transaction(MYSQLI_TRANS_START_READ_WRITE);

$v = $db->server_version;
print "server version $v\n";

$db = new mysqli("127.0.0.1", "dan", "bob", "test", 3306);
$db->begin_transaction(MYSQLI_TRANS_START_READ_WRITE);

$v = $db->server_version;
print "server version $v\n";
</pre>

Test with dbdeployer mysql-5.5.62 on /tmp/mysql_sandbox5562.sock and MariaDB-10.4.13 (fc32 package) on 3306.
<pre>
./configure --enable-debug --with-mysqli=mysqlnd --with-mysql-sock=/tmp/mysql_sandbox5562.sock
..

$ ./sapi/cli/php  ../MDEV-23141.php
Warning: mysqli::begin_transaction(): This server version doesn't support 'READ WRITE' and 'READ ONLY'. Minimum 5.6.5 is required in /home/dan/repos/MDEV-23141.php on line 5
server version 50562
server version 100413
</pre>


<pre>
$ make distclean
$ ./configure --enable-debug --with-mysqli --with-mysql-sock=/tmp/mysql_sandbox5562.sock

checking whether to enable mysqlnd... no
checking whether to disable compressed protocol support in mysqlnd... yes.
..
$ ./sapi/cli/php  ../MDEV-23141.php

Warning: mysqli::begin_transaction(): This server version doesn't support 'READ WRITE' and 'READ ONLY'. Minimum 5.6.5 is required in /home/dan/repos/MDEV-23141.php on line 5
server version 50562
server version 100413
</pre>

So successfully starts a transaction on MariaDb-10.4 and generates the same warning on MySQL-5.5.62