### PR TITLE
Improve argument types and names in ext/ctype

### DIFF
--- a/ext/ctype/ctype.stub.php
+++ b/ext/ctype/ctype.stub.php
@@ -2,24 +2,35 @@
 
 /** @generate-function-entries */
 
-function ctype_alnum($text): bool {}
+/** @param string|int $input */
+function ctype_alnum(mixed $input): bool {}
 
-function ctype_alpha($text): bool {}
+/** @param string|int $input */
+function ctype_alpha(mixed $input): bool {}
 
-function ctype_cntrl($text): bool {}
+/** @param string|int $input */
+function ctype_cntrl(mixed $input): bool {}
 
-function ctype_digit($text): bool {}
+/** @param string|int $input */
+function ctype_digit(mixed $input): bool {}
 
-function ctype_lower($text): bool {}
+/** @param string|int $input */
+function ctype_lower(mixed $input): bool {}
 
-function ctype_graph($text): bool {}
+/** @param string|int $input */
+function ctype_graph(mixed $input): bool {}
 
-function ctype_print($text): bool {}
+/** @param string|int $input */
+function ctype_print(mixed $input): bool {}
 
-function ctype_punct($text): bool {}
+/** @param string|int $input */
+function ctype_punct(mixed $input): bool {}
 
-function ctype_space($text): bool {}
+/** @param string|int $input */
+function ctype_space(mixed $input): bool {}
 
-function ctype_upper($text): bool {}
+/** @param string|int $input */
+function ctype_upper(mixed $input): bool {}
 
-function ctype_xdigit($text): bool {}
+/** @param string|int $input */
+function ctype_xdigit(mixed $input): bool {}

--- a/ext/ctype/ctype_arginfo.h
+++ b/ext/ctype/ctype_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a5de84e1cb6919e7dfc69a42b7f05967ebca24c3 */
+ * Stub hash: 203a0af69b71e3255a1a4c0b371d9ac704d74f71 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ctype_alnum, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, text)
+	ZEND_ARG_TYPE_INFO(0, input, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_ctype_alpha arginfo_ctype_alnum


### PR DESCRIPTION
Unfortunately, we can't use the `string|int` union type in ZPP since ctype functions rely on strict argument handling, so I added the `mixed` parameter type declaration, and the `string|int` PHPDoc type hint.

Additionally, I think the `$input` parameter name is better than `$text` in this context.