### PR TITLE
Fix #79884: PHP_CONFIG_FILE_PATH is meaningless

### DIFF
--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -9,7 +9,7 @@
 #define NTDDI_VERSION 0x06010000
 
 /* Default PHP / PEAR directories */
-#define PHP_CONFIG_FILE_PATH (getenv("SystemRoot")?getenv("SystemRoot"):"")
+#define PHP_CONFIG_FILE_PATH ""
 #define CONFIGURATION_FILE_PATH "php.ini"
 #define PEAR_INSTALLDIR "@PREFIX@\\pear"
 #define PHP_BINDIR "@PREFIX@"


### PR DESCRIPTION
It does not make sense to make assumptions about `PHP_CONFIG_FILE_PATH`
during build time, since that value is never used during run time on
Windows.  Since there is no `--with-config-file-path` on Windows
either, we define `PHP_CONFIG_FILE_PATH` as `""`.