### PR TITLE
Change type of max_num_args to uint32_t

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1256,7 +1256,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 #define ZEND_PARSE_PARAMETERS_START_EX(flags, min_num_args, max_num_args) do { \
 		const int _flags = (flags); \
 		uint32_t _min_num_args = (min_num_args); \
-		int _max_num_args = (max_num_args);  /* TODO uint32_t */ \
+		uint32_t _max_num_args = (uint32_t) (max_num_args); \
 		uint32_t _num_args = EX_NUM_ARGS(); \
 		uint32_t _i = 0; \
 		zval *_real_arg, *_arg = NULL; \
@@ -1274,8 +1274,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_argument_value_error(uint32_t arg_num
 		\
 		do { \
 			if (UNEXPECTED(_num_args < _min_num_args) || \
-			    (UNEXPECTED(_num_args > _max_num_args) && \
-			     EXPECTED(_max_num_args >= 0))) { \
+			    UNEXPECTED(_num_args > _max_num_args)) { \
 				if (!(_flags & ZEND_PARSE_PARAMS_QUIET)) { \
 					zend_wrong_parameters_count_error(_min_num_args, _max_num_args); \
 				} \


### PR DESCRIPTION
`Warning: comparison between signed and unsigned integer expressions`

The easiest way is to let it overflow, but the conversion from signed to unsigned is undefined behavior in the C standard...
Usually, it is a constant, so I think that the compiler will optimize it.
