### PR TITLE
Fix warning of strict-prototypes

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1774,12 +1774,12 @@ ZEND_API void zend_map_ptr_extend(size_t last)
 	}
 }
 
-void zend_startup_error_notify_callbacks()
+void zend_startup_error_notify_callbacks(void)
 {
 	zend_llist_init(&zend_error_notify_callbacks, sizeof(zend_error_notify_cb), NULL, 1);
 }
 
-void zend_shutdown_error_notify_callbacks()
+void zend_shutdown_error_notify_callbacks(void)
 {
 	zend_llist_destroy(&zend_error_notify_callbacks);
 }

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -356,8 +356,8 @@ typedef void (*zend_error_notify_cb)(int type, const char *error_filename, uint3
 BEGIN_EXTERN_C()
 
 void zend_register_error_notify_callback(zend_error_notify_cb callback);
-void zend_startup_error_notify_callbacks();
-void zend_shutdown_error_notify_callbacks();
+void zend_startup_error_notify_callbacks(void);
+void zend_shutdown_error_notify_callbacks(void);
 void zend_error_notify_all_callbacks(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
 END_EXTERN_C()
 

--- a/Zend/zend_cpuinfo.h
+++ b/Zend/zend_cpuinfo.h
@@ -97,7 +97,7 @@ typedef enum _zend_cpu_feature {
 	/*intentionally don't support   = (1<<31 | ZEND_CPU_EDX_MASK)*/
 } zend_cpu_feature;
 
-void zend_cpu_startup();
+void zend_cpu_startup(void);
 ZEND_API int zend_cpu_supports(zend_cpu_feature feature);
 
 #ifndef __has_attribute

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -998,7 +998,7 @@ ZEND_API ZEND_COLD void zend_throw_exception_object(zval *exception) /* {{{ */
 }
 /* }}} */
 
-ZEND_API ZEND_COLD void zend_throw_unwind_exit()
+ZEND_API ZEND_COLD void zend_throw_unwind_exit(void)
 {
 	ZEND_ASSERT(!EG(exception));
 	EG(exception) = zend_objects_new(&zend_ce_unwind_exit);

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -140,7 +140,7 @@ static void zend_weakref_unregister(zend_object *object, void *payload) {
 	}
 }
 
-void zend_weakrefs_init() {
+void zend_weakrefs_init(void) {
 	zend_hash_init(&EG(weakrefs), 8, NULL, NULL, 0);
 }
 
@@ -158,7 +158,7 @@ void zend_weakrefs_notify(zend_object *object) {
 	}
 }
 
-void zend_weakrefs_shutdown() {
+void zend_weakrefs_shutdown(void) {
 	zend_ulong obj_addr;
 	void *tagged_ptr;
 	ZEND_HASH_FOREACH_NUM_KEY_PTR(&EG(weakrefs), obj_addr, tagged_ptr) {

--- a/Zend/zend_weakrefs.h
+++ b/Zend/zend_weakrefs.h
@@ -23,8 +23,8 @@ extern ZEND_API zend_class_entry *zend_ce_weakref;
 
 void zend_register_weakref_ce(void);
 
-void zend_weakrefs_init();
-void zend_weakrefs_shutdown();
+void zend_weakrefs_init(void);
+void zend_weakrefs_shutdown(void);
 
 ZEND_API void zend_weakrefs_notify(zend_object *object);
 

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1114,7 +1114,7 @@ PHPAPI void php_var_serialize(smart_str *buf, zval *struc, php_serialize_data_t 
 }
 /* }}} */
 
-PHPAPI php_serialize_data_t php_var_serialize_init() {
+PHPAPI php_serialize_data_t php_var_serialize_init(void) {
 	struct php_serialize_data *d;
 	/* fprintf(stderr, "SERIALIZE_INIT      == lock: %u, level: %u\n", BG(serialize_lock), BG(serialize).level); */
 	if (BG(serialize_lock) || !BG(serialize).level) {

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -52,7 +52,7 @@ struct php_unserialize_data {
 	var_entries       entries;
 };
 
-PHPAPI php_unserialize_data_t php_var_unserialize_init() {
+PHPAPI php_unserialize_data_t php_var_unserialize_init(void) {
 	php_unserialize_data_t d;
 	/* fprintf(stderr, "UNSERIALIZE_INIT    == lock: %u, level: %u\n", BG(serialize_lock), BG(unserialize).level); */
 	if (BG(serialize_lock) || !BG(unserialize).level) {

--- a/main/main.c
+++ b/main/main.c
@@ -522,7 +522,7 @@ static PHP_INI_DISP(display_errors_mode)
 }
 /* }}} */
 
-PHPAPI const char *php_get_internal_encoding() {
+PHPAPI const char *php_get_internal_encoding(void) {
 	if (PG(internal_encoding) && PG(internal_encoding)[0]) {
 		return PG(internal_encoding);
 	} else if (SG(default_charset) && SG(default_charset)[0]) {
@@ -531,7 +531,7 @@ PHPAPI const char *php_get_internal_encoding() {
 	return "UTF-8";
 }
 
-PHPAPI const char *php_get_input_encoding() {
+PHPAPI const char *php_get_input_encoding(void) {
 	if (PG(input_encoding) && PG(input_encoding)[0]) {
 		return PG(input_encoding);
 	} else if (SG(default_charset) && SG(default_charset)[0]) {
@@ -540,7 +540,7 @@ PHPAPI const char *php_get_input_encoding() {
 	return "UTF-8";
 }
 
-PHPAPI const char *php_get_output_encoding() {
+PHPAPI const char *php_get_output_encoding(void) {
 	if (PG(output_encoding) && PG(output_encoding)[0]) {
 		return PG(output_encoding);
 	} else if (SG(default_charset) && SG(default_charset)[0]) {

--- a/win32/sendmail.c
+++ b/win32/sendmail.c
@@ -300,7 +300,7 @@ PHPAPI int TSendMail(const char *host, int *error, char **error_message,
 // Author/Date:  jcar 20/9/96
 // History:
 //********************************************************************/
-PHPAPI void TSMClose()
+PHPAPI void TSMClose(void)
 {
 	Post("QUIT\r\n");
 	Ack(NULL);


### PR DESCRIPTION
I compiled all header files with gcc and fixed all -Wstrict-prototypes warnings in the output
Every time I do a similar fix is due to some annoying warnings appeared when I compiled my extension...
It would be great if someone could solve it in CI
