### PR TITLE
Enable -Wstrict-prototypes

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -214,6 +214,7 @@ AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough=1], CFLAGS="$CFLAGS -Wimplicit-fal
 AX_CHECK_COMPILE_FLAG([-Wduplicated-cond], CFLAGS="-Wduplicated-cond $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wlogical-op], CFLAGS="-Wlogical-op $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wformat-truncation], CFLAGS="-Wformat-truncation $CFLAGS", , [-Werror])
+AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes], CFLAGS="-Wstrict-prototypes $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-fno-common], CFLAGS="-fno-common $CFLAGS", , [-Werror])
 
 test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"

--- a/azure/macos/job.yml
+++ b/azure/macos/job.yml
@@ -65,7 +65,6 @@ jobs:
             --with-mhash \
             --with-sodium \
             --enable-dba \
-            --enable-werror \
             --with-config-file-path=/etc \
             --with-config-file-scan-dir=/etc/php.d
       displayName: 'Configure Build'

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -138,7 +138,8 @@ dnl
 if test "$PHP_GD" != "no"; then
 
   if test "$PHP_EXTERNAL_GD" = "no"; then
-    GD_CFLAGS=""
+    dnl Disable strict prototypes as GD takes advantages of variadic function signatures for function pointers.
+    GD_CFLAGS="-Wno-strict-prototypes"
     extra_sources="libgd/gd.c libgd/gd_gd.c libgd/gd_gd2.c libgd/gd_io.c libgd/gd_io_dp.c \
                   libgd/gd_io_file.c libgd/gd_ss.c libgd/gd_io_ss.c libgd/gd_webp.c \
                   libgd/gd_png.c libgd/gd_jpeg.c libgd/gdxpm.c libgd/gdfontt.c libgd/gdfonts.c \

--- a/ext/intl/collator/collator_is_numeric.c
+++ b/ext/intl/collator/collator_is_numeric.c
@@ -110,10 +110,7 @@ static double collator_u_strtod(const UChar *nptr, UChar **endptr) /* {{{ */
  *
  * Ignores `locale' stuff.
  */
-static zend_long collator_u_strtol(nptr, endptr, base)
-	const UChar *nptr;
-	UChar **endptr;
-	register int base;
+static zend_long collator_u_strtol(const UChar *nptr, UChar **endptr, register int base)
 {
 	register const UChar *s = nptr;
 	register zend_ulong acc;

--- a/ext/intl/collator/collator_is_numeric.c
+++ b/ext/intl/collator/collator_is_numeric.c
@@ -110,13 +110,13 @@ static double collator_u_strtod(const UChar *nptr, UChar **endptr) /* {{{ */
  *
  * Ignores `locale' stuff.
  */
-static zend_long collator_u_strtol(const UChar *nptr, UChar **endptr, register int base)
+static zend_long collator_u_strtol(const UChar *nptr, UChar **endptr, int base)
 {
-	register const UChar *s = nptr;
-	register zend_ulong acc;
-	register UChar c;
-	register zend_ulong cutoff;
-	register int neg = 0, any, cutlim;
+	const UChar *s = nptr;
+	zend_ulong acc;
+	UChar c;
+	zend_ulong cutoff;
+	int neg = 0, any, cutlim;
 
 	if (s == NULL) {
 		errno = ERANGE;

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -89,7 +89,8 @@ static void pcntl_siginfo_to_zval(int, siginfo_t*, zval*);
 #else
 static void pcntl_signal_handler(int);
 #endif
-static void pcntl_signal_dispatch();
+static void pcntl_signal_dispatch(void);
+static void pcntl_signal_dispatch_tick_function(int dummy_int, void *dummy_pointer);
 static void pcntl_interrupt_function(zend_execute_data *execute_data);
 
 void php_register_signal_constants(INIT_FUNC_ARGS)
@@ -424,7 +425,7 @@ static PHP_GINIT_FUNCTION(pcntl)
 
 PHP_RINIT_FUNCTION(pcntl)
 {
-	php_add_tick_function(pcntl_signal_dispatch, NULL);
+	php_add_tick_function(pcntl_signal_dispatch_tick_function, NULL);
 	zend_hash_init(&PCNTL_G(php_signal_table), 16, NULL, ZVAL_PTR_DTOR, 0);
 	PCNTL_G(head) = PCNTL_G(tail) = PCNTL_G(spares) = NULL;
 	PCNTL_G(async_signals) = 0;
@@ -1383,6 +1384,11 @@ void pcntl_signal_dispatch()
 
 	/* return signal mask to previous state */
 	sigprocmask(SIG_SETMASK, &old_mask, NULL);
+}
+
+void pcntl_signal_dispatch_tick_function(int dummy_int, void *dummy_pointer)
+{
+	return pcntl_signal_dispatch();
 }
 
 /* {{{ Enable/disable asynchronous signal handling and return the old setting. */

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1386,7 +1386,7 @@ void pcntl_signal_dispatch()
 	sigprocmask(SIG_SETMASK, &old_mask, NULL);
 }
 
-void pcntl_signal_dispatch_tick_function(int dummy_int, void *dummy_pointer)
+static void pcntl_signal_dispatch_tick_function(int dummy_int, ZEND_ATTRIBUTE_UNUSED void *dummy_pointer)
 {
 	return pcntl_signal_dispatch();
 }

--- a/ext/pspell/config.m4
+++ b/ext/pspell/config.m4
@@ -4,7 +4,8 @@ PHP_ARG_WITH([pspell],
     [Include PSPELL support. GNU Aspell version 0.50.0 or higher required])])
 
 if test "$PHP_PSPELL" != "no"; then
-	PHP_NEW_EXTENSION(pspell, pspell.c, $ext_shared)
+    dnl Add -Wno-strict-prototypes as depends on user libs
+	PHP_NEW_EXTENSION(pspell, pspell.c, $ext_shared, , "-Wno-strict-prototypes")
 	if test "$PHP_PSPELL" != "yes"; then
 	    PSPELL_SEARCH_DIRS=$PHP_PSPELL
 	else

--- a/ext/pspell/config.m4
+++ b/ext/pspell/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_WITH([pspell],
     [Include PSPELL support. GNU Aspell version 0.50.0 or higher required])])
 
 if test "$PHP_PSPELL" != "no"; then
-    dnl Add -Wno-strict-prototypes as depends on user libs
+	dnl Add -Wno-strict-prototypes as depends on user libs
 	PHP_NEW_EXTENSION(pspell, pspell.c, $ext_shared, , "-Wno-strict-prototypes")
 	if test "$PHP_PSPELL" != "yes"; then
 	    PSPELL_SEARCH_DIRS=$PHP_PSPELL

--- a/ext/readline/config.m4
+++ b/ext/readline/config.m4
@@ -137,6 +137,7 @@ elif test "$PHP_LIBEDIT" != "no"; then
 fi
 
 if test "$PHP_READLINE" != "no" || test "$PHP_LIBEDIT" != "no"; then
-  PHP_NEW_EXTENSION(readline, readline.c readline_cli.c, $ext_shared, cli)
+  dnl Add -Wno-strict-prototypes as depends on user libs
+  PHP_NEW_EXTENSION(readline, readline.c readline_cli.c, $ext_shared, cli, "-Wno-strict-prototypes")
   PHP_SUBST(READLINE_SHARED_LIBADD)
 fi

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -743,7 +743,7 @@ this extension sharedto offer compatibility.
 #define GET_SHELL_CB(cb) \
 	do { \
 		(cb) = NULL; \
-		cli_shell_callbacks_t *(*get_callbacks)(); \
+		cli_shell_callbacks_t *(*get_callbacks)(void); \
 		get_callbacks = dlsym(RTLD_DEFAULT, "php_cli_get_shell_callbacks"); \
 		if (get_callbacks) { \
 			(cb) = get_callbacks(); \

--- a/ext/standard/scanf.c
+++ b/ext/standard/scanf.c
@@ -583,7 +583,7 @@ PHPAPI int php_sscanf_internal( char *string, char *format,
 	int  base = 0;
 	int  underflow = 0;
 	size_t width;
-	zend_long (*fn)() = NULL;
+	zend_long (*fn)(const char*, char**, int) = NULL;
 	char *ch, sch;
 	int  flags;
 	char buf[64];	/* Temporary buffer to hold scanned number
@@ -740,29 +740,29 @@ literal:
 			case 'D':
 				op = 'i';
 				base = 10;
-				fn = (zend_long (*)())ZEND_STRTOL_PTR;
+				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOL_PTR;
 				break;
 			case 'i':
 				op = 'i';
 				base = 0;
-				fn = (zend_long (*)())ZEND_STRTOL_PTR;
+				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOL_PTR;
 				break;
 			case 'o':
 				op = 'i';
 				base = 8;
-				fn = (zend_long (*)())ZEND_STRTOL_PTR;
+				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOL_PTR;
 				break;
 			case 'x':
 			case 'X':
 				op = 'i';
 				base = 16;
-				fn = (zend_long (*)())ZEND_STRTOL_PTR;
+				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOL_PTR;
 				break;
 			case 'u':
 				op = 'i';
 				base = 10;
 				flags |= SCAN_UNSIGNED;
-				fn = (zend_long (*)())ZEND_STRTOUL_PTR;
+				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOUL_PTR;
 				break;
 
 			case 'f':

--- a/ext/standard/scanf.c
+++ b/ext/standard/scanf.c
@@ -106,6 +106,8 @@ typedef struct CharSet {
 	} *ranges;
 } CharSet;
 
+typedef zend_long (*int_string_formater)(const char*, char**, int);
+
 /*
  * Declarations for functions used only in this file.
  */
@@ -583,7 +585,7 @@ PHPAPI int php_sscanf_internal( char *string, char *format,
 	int  base = 0;
 	int  underflow = 0;
 	size_t width;
-	zend_long (*fn)(const char*, char**, int) = NULL;
+	int_string_formater fn = NULL;
 	char *ch, sch;
 	int  flags;
 	char buf[64];	/* Temporary buffer to hold scanned number
@@ -740,29 +742,29 @@ literal:
 			case 'D':
 				op = 'i';
 				base = 10;
-				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOL_PTR;
+				fn = (int_string_formater)ZEND_STRTOL_PTR;
 				break;
 			case 'i':
 				op = 'i';
 				base = 0;
-				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOL_PTR;
+				fn = (int_string_formater)ZEND_STRTOL_PTR;
 				break;
 			case 'o':
 				op = 'i';
 				base = 8;
-				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOL_PTR;
+				fn = (int_string_formater)ZEND_STRTOL_PTR;
 				break;
 			case 'x':
 			case 'X':
 				op = 'i';
 				base = 16;
-				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOL_PTR;
+				fn = (int_string_formater)ZEND_STRTOL_PTR;
 				break;
 			case 'u':
 				op = 'i';
 				base = 10;
 				flags |= SCAN_UNSIGNED;
-				fn = (zend_long (*)(const char*, char**, int))ZEND_STRTOUL_PTR;
+				fn = (int_string_formater)ZEND_STRTOUL_PTR;
 				break;
 
 			case 'f':

--- a/sapi/fpm/fpm/events/kqueue.c
+++ b/sapi/fpm/fpm/events/kqueue.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 
 static int fpm_event_kqueue_init(int max);
-static int fpm_event_kqueue_clean();
+static int fpm_event_kqueue_clean(void);
 static int fpm_event_kqueue_wait(struct fpm_event_queue_s *queue, unsigned long int timeout);
 static int fpm_event_kqueue_add(struct fpm_event_s *ev);
 static int fpm_event_kqueue_remove(struct fpm_event_s *ev);


### PR DESCRIPTION
As I've been prompted by #5887 

I'm not totally sure how to fix the GD and scanf ones.
pspell will need to have the warning disabled as we are working with system libraries.

Hopefully not too many more pop up from Azure.