### PR TITLE
Fix #78236: convert error on receiving variables when duplicate [

### DIFF
--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -189,8 +189,14 @@ PHPAPI void php_register_variable_ex(char *var_name, zval *val, zval *track_vars
 			} else {
 				ip = strchr(ip, ']');
 				if (!ip) {
-					/* PHP variables cannot contain '[' in their names, so we replace the character with a '_' */
+					/* not an index; un-terminate the var name */
 					*(index_s - 1) = '_';
+					/* PHP variables cannot contain ' ', '.', '[' in their names, so we replace the characters with a '_' */
+					for (p = index_s; *p; p++) {
+						if (*p == ' ' || *p == '.' || *p == '[') {
+							*p = '_';
+						}
+					}
 
 					index_len = 0;
 					if (index) {

--- a/tests/basic/bug78236.phpt
+++ b/tests/basic/bug78236.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #78236 (convert error on receiving variables when duplicate [)
+--POST--
+id[name=1&id[[name=a&id[na me.=3
+--FILE--
+<?php
+var_dump($_POST);
+?>
+--EXPECT--
+array(3) {
+  ["id_name"]=>
+  string(1) "1"
+  ["id__name"]=>
+  string(1) "a"
+  ["id_na_me_"]=>
+  string(1) "3"
+}


### PR DESCRIPTION
When an input variable name contains a non matched open bracket, we not
only have to replace that with an underscore, but also all following
forbidden characters.

---

This might better be postponed to PHP 8.0 for BC reasons.
