### PR TITLE
Consolidate XML api parameter names

### DIFF
--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -8,12 +8,12 @@ class DOMDocumentType
 
 class DOMCdataSection
 {
-    public function __construct(string $value) {}
+    public function __construct(string $data) {}
 }
 
 class DOMComment
 {
-    public function __construct(string $value = "") {}
+    public function __construct(string $data = "") {}
 }
 
 interface DOMParentNode
@@ -42,16 +42,16 @@ interface DOMChildNode
 class DOMNode
 {
     /** @return DOMNode|false */
-    public function appendChild(DOMNode $newChild) {}
+    public function appendChild(DOMNode $node) {}
 
     /** @return string|false */
-    public function C14N(bool $exclusive = false, bool $with_comments = false, ?array $xpath = null, ?array $ns_prefixes = null) {}
+    public function C14N(bool $exclusive = false, bool $withComments = false, ?array $xpath = null, ?array $nsPrefixes = null) {}
 
     /** @return int|false */
-    public function C14NFile(string $uri, bool $exclusive = false, bool $with_comments = false, ?array $xpath = null, ?array $ns_prefixes = null) {}
+    public function C14NFile(string $uri, bool $exclusive = false, bool $withComments = false, ?array $xpath = null, ?array $nsPrefixes = null) {}
 
     /** @return DOMNode|false */
-    public function cloneNode(bool $recursive = false) {}
+    public function cloneNode(bool $deep = false) {}
 
     /** @return int */
     public function getLineNo() {}
@@ -67,13 +67,13 @@ class DOMNode
     public function hasChildNodes() {}
 
     /** @return DOMNode|false */
-    public function insertBefore(DOMNode $newChild, ?DOMNode $refChild = null) {}
+    public function insertBefore(DOMNode $node, ?DOMNode $child = null) {}
 
     /** @return bool */
-    public function isDefaultNamespace(string $namespaceURI) {}
+    public function isDefaultNamespace(string $namespace) {}
 
     /** @return bool */
-    public function isSameNode(DOMNode $other) {}
+    public function isSameNode(DOMNode $otherNode) {}
 
     /** @return bool */
     public function isSupported(string $feature, string $version) {}
@@ -82,16 +82,16 @@ class DOMNode
     public function lookupNamespaceURI(?string $prefix) {}
 
     /** @return string|null */
-    public function lookupPrefix(string $namespaceURI) {}
+    public function lookupPrefix(string $namespace) {}
 
     /** @return void */
     public function normalize() {}
 
     /** @return DOMNode|false */
-    public function removeChild(DOMNode $oldChild) {}
+    public function removeChild(DOMNode $child) {}
 
     /** @return DOMNode|false */
-    public function replaceChild(DOMNode $newChild, DOMNode $oldChild) {}
+    public function replaceChild(DOMNode $node, DOMNode $child) {}
 }
 
 class DOMImplementation
@@ -106,7 +106,7 @@ class DOMImplementation
     public function createDocumentType(string $qualifiedName, string $publicId = "", string $systemId = "") {}
 
     /** @return DOMDocument|false */
-    public function createDocument(string $namespaceURI = "", string $qualifiedName = "", ?DOMDocumentType $doctype = null) {}
+    public function createDocument(string $namespace = "", string $qualifiedName = "", ?DOMDocumentType $doctype = null) {}
 }
 
 class DOMDocumentFragment implements DOMParentNode
@@ -173,46 +173,46 @@ class DOMAttr
 
 class DOMElement implements DOMParentNode, DOMChildNode
 {
-    public function __construct(string $name, ?string $value = null, string $uri = "") {}
+    public function __construct(string $qualifiedName, ?string $value = null, string $namespace = "") {}
 
     /** @return string */
-    public function getAttribute(string $name) {}
+    public function getAttribute(string $qualifiedName) {}
 
     /** @return string */
-    public function getAttributeNS(?string $namespaceURI, string $localName) {}
+    public function getAttributeNS(?string $namespace, string $localName) {}
 
     /** @return DOMAttr|DOMNamespaceNode|false */
-    public function getAttributeNode(string $name) {}
+    public function getAttributeNode(string $qualifiedName) {}
 
     /** @return DOMAttr|DOMNamespaceNode|null */
-    public function getAttributeNodeNS(?string $namespaceURI, string $localName) {}
+    public function getAttributeNodeNS(?string $namespace, string $localName) {}
 
     /** @return DOMNodeList */
-    public function getElementsByTagName(string $name) {}
+    public function getElementsByTagName(string $qualifiedName) {}
 
     /** @return DOMNodeList */
-    public function getElementsByTagNameNS(string $namespaceURI, string $localName) {}
+    public function getElementsByTagNameNS(string $namespace, string $localName) {}
 
     /** @return bool */
-    public function hasAttribute(string $name) {}
+    public function hasAttribute(string $qualifiedName) {}
 
     /** @return bool */
-    public function hasAttributeNS(?string $namespaceURI, string $localName) {}
+    public function hasAttributeNS(?string $namespace, string $localName) {}
 
     /** @return bool */
-    public function removeAttribute(string $name) {}
+    public function removeAttribute(string $qualifiedName) {}
 
     /** @return DOMAttr|false */
-    public function removeAttributeNS(?string $namespaceURI, string $localName) {}
+    public function removeAttributeNS(?string $namespace, string $localName) {}
 
     /** @return DOMAttr|false */
-    public function removeAttributeNode(string $name) {}
+    public function removeAttributeNode(string $qualifiedName) {}
 
     /** @return DOMAttr|bool */
-    public function setAttribute(string $name, string $value) {}
+    public function setAttribute(string $qualifiedName, string $value) {}
 
     /** @return null|false */
-    public function setAttributeNS(?string $namespaceURI, string $localName, string $value) {}
+    public function setAttributeNS(?string $namespace, string $qualifiedName, string $value) {}
 
     /** @return DOMAttr|null|false */
     public function setAttributeNode(DOMAttr $attr) {}
@@ -221,10 +221,10 @@ class DOMElement implements DOMParentNode, DOMChildNode
     public function setAttributeNodeNS(DOMAttr $attr) {}
 
     /** @return void */
-    public function setIdAttribute(string $name, bool $isId) {}
+    public function setIdAttribute(string $qualifiedName, bool $isId) {}
 
     /** @return void */
-    public function setIdAttributeNS(string $namespaceURI, string $localName, bool $isId) {}
+    public function setIdAttributeNS(string $namespace, string $qualifiedName, bool $isId) {}
 
     /** @return void */
     public function setIdAttributeNode(DOMAttr $attr, bool $isId) {}
@@ -252,10 +252,10 @@ class DOMDocument implements DOMParentNode
     public function __construct(string $version = "1.0", string $encoding = "") {}
 
     /** @return DOMAttr|false */
-    public function createAttribute(string $name) {}
+    public function createAttribute(string $localName) {}
 
     /** @return DOMAttr|false */
-    public function createAttributeNS(?string $namespaceURI, string $qualifiedName) {}
+    public function createAttributeNS(?string $namespace, string $qualifiedName) {}
 
     /** @return DOMCdataSection|false */
     public function createCDATASection(string $data) {}
@@ -267,10 +267,10 @@ class DOMDocument implements DOMParentNode
     public function createDocumentFragment() {}
 
     /** @return DOMElement|false */
-    public function createElement(string $tagName, string $value = "") {}
+    public function createElement(string $localName, string $value = "") {}
 
     /** @return DOMElement|false */
-    public function createElementNS(?string $namespaceURI, string $qualifiedName, string $value = "") {}
+    public function createElementNS(?string $namespace, string $qualifiedName, string $value = "") {}
 
     /** @return DOMEntityReference|false */
     public function createEntityReference(string $name) {}
@@ -285,13 +285,13 @@ class DOMDocument implements DOMParentNode
     public function getElementById(string $elementId) {}
 
     /** @return DOMNodeList */
-    public function getElementsByTagName(string $tagName) {}
+    public function getElementsByTagName(string $qualifiedName) {}
 
     /** @return DOMNodeList */
-    public function getElementsByTagNameNS(string $namespaceURI, string $localName) {}
+    public function getElementsByTagNameNS(string $namespace, string $localName) {}
 
     /** @return DOMNode|false */
-    public function importNode(DOMNode $importedNode, bool $deep = false) {}
+    public function importNode(DOMNode $node, bool $deep = false) {}
 
     /** @return DOMDocument|bool */
     public function load(string $filename, int $options = 0) {}
@@ -303,7 +303,7 @@ class DOMDocument implements DOMParentNode
     public function normalizeDocument() {}
 
     /** @return bool */
-    public function registerNodeClass(string $baseclass, ?string $extendedclass) {}
+    public function registerNodeClass(string $baseClass, ?string $extendedClass) {}
 
     /** @return int|false */
     public function save(string $filename, int $options = 0) {}
@@ -346,7 +346,7 @@ class DOMDocument implements DOMParentNode
     public function xinclude(int $options = 0) {}
 
     /** @return DOMNode|false */
-    public function adoptNode(DOMNode $source) {}
+    public function adoptNode(DOMNode $node) {}
 
     /** @var ...DOMNode|string $nodes */
     public function append(...$nodes): void {}
@@ -361,7 +361,7 @@ final class DOMException extends Exception
 
 class DOMText
 {
-    public function __construct(string $value = "") {}
+    public function __construct(string $data = "") {}
 
     /** @return bool */
     public function isWhitespaceInElementContent() {}
@@ -379,10 +379,10 @@ class DOMText
 class DOMNamedNodeMap implements IteratorAggregate, Countable
 {
     /** @return DOMNode|null */
-    public function getNamedItem(string $name) {}
+    public function getNamedItem(string $qualifiedName) {}
 
     /** @return DOMNode|null */
-    public function getNamedItemNS(?string $namespaceURI, string $localName) {}
+    public function getNamedItemNS(?string $namespace, string $localName) {}
 
     /** @return DOMNode|null */
     public function item(int $index) {}
@@ -414,16 +414,16 @@ class DOMProcessingInstruction
 #ifdef LIBXML_XPATH_ENABLED
 class DOMXPath
 {
-    public function __construct(DOMDocument $doc, bool $registerNodeNS = true) {}
+    public function __construct(DOMDocument $document, bool $registerNodeNS = true) {}
 
     /** @return mixed */
-    public function evaluate(string $expr, ?DOMNode $context = null, bool $registerNodeNS = true) {}
+    public function evaluate(string $expression, ?DOMNode $contextNode = null, bool $registerNodeNS = true) {}
 
     /** @return mixed */
-    public function query(string $expr, ?DOMNode $context = null, bool $registerNodeNS = true) {}
+    public function query(string $expression, ?DOMNode $contextNode = null, bool $registerNodeNS = true) {}
 
     /** @return bool */
-    public function registerNamespace(string $prefix, string $namespaceURI) {}
+    public function registerNamespace(string $prefix, string $namespace) {}
 
     /** @return void */
     public function registerPhpFunctions(string|array|null $restrict = null) {}

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,16 +1,16 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a30205758df3a00757ffdfdd0c500b090e022d4f */
+ * Stub hash: 3ecc7d640235675f1f573f043e68f11a4fca0bad */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 1)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMCdataSection___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMComment___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_STRING, 0, "\"\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, data, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DOMParentNode_append, 0, 0, IS_VOID, 0)
@@ -29,26 +29,26 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DOMChildNode_replaceWith arginfo_class_DOMParentNode_append
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_appendChild, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, newChild, DOMNode, 0)
+	ZEND_ARG_OBJ_INFO(0, node, DOMNode, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_C14N, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, exclusive, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, with_comments, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, withComments, _IS_BOOL, 0, "false")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, xpath, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ns_prefixes, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nsPrefixes, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_C14NFile, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, exclusive, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, with_comments, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, withComments, _IS_BOOL, 0, "false")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, xpath, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ns_prefixes, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, nsPrefixes, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_cloneNode, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, recursive, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, deep, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_getLineNo, 0, 0, 0)
@@ -61,16 +61,16 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DOMNode_hasChildNodes arginfo_class_DOMNode_getLineNo
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_insertBefore, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, newChild, DOMNode, 0)
-	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, refChild, DOMNode, 1, "null")
+	ZEND_ARG_OBJ_INFO(0, node, DOMNode, 0)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, child, DOMNode, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_isDefaultNamespace, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_isSameNode, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, other, DOMNode, 0)
+	ZEND_ARG_OBJ_INFO(0, otherNode, DOMNode, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_isSupported, 0, 0, 2)
@@ -87,12 +87,12 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DOMNode_normalize arginfo_class_DOMNode_getLineNo
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_removeChild, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, oldChild, DOMNode, 0)
+	ZEND_ARG_OBJ_INFO(0, child, DOMNode, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNode_replaceChild, 0, 0, 2)
-	ZEND_ARG_OBJ_INFO(0, newChild, DOMNode, 0)
-	ZEND_ARG_OBJ_INFO(0, oldChild, DOMNode, 0)
+	ZEND_ARG_OBJ_INFO(0, node, DOMNode, 0)
+	ZEND_ARG_OBJ_INFO(0, child, DOMNode, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DOMImplementation_getFeature arginfo_class_DOMNode_isSupported
@@ -106,16 +106,14 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMImplementation_createDocumentType, 0, 0,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMImplementation_createDocument, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, namespaceURI, IS_STRING, 0, "\"\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, namespace, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, qualifiedName, IS_STRING, 0, "\"\"")
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, doctype, DOMDocumentType, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DOMDocumentFragment___construct arginfo_class_DOMNode_getLineNo
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocumentFragment_appendXML, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DOMDocumentFragment_appendXML arginfo_class_DOMCdataSection___construct
 
 #define arginfo_class_DOMDocumentFragment_append arginfo_class_DOMParentNode_append
 
@@ -130,7 +128,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMNodeList_item, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_DOMCharacterData_appendData arginfo_class_DOMDocumentFragment_appendXML
+#define arginfo_class_DOMCharacterData_appendData arginfo_class_DOMCdataSection___construct
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMCharacterData_substringData, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
@@ -166,17 +164,17 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DOMAttr_isId arginfo_class_DOMNode_getLineNo
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMElement___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 0, "\"\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, namespace, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMElement_getAttribute, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMElement_getAttributeNS, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, localName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -187,7 +185,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DOMElement_getElementsByTagName arginfo_class_DOMElement_getAttribute
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMElement_getElementsByTagNameNS, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, localName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -202,13 +200,13 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DOMElement_removeAttributeNode arginfo_class_DOMElement_getAttribute
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMElement_setAttribute, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMElement_setAttributeNS, 0, 0, 3)
-	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, localName, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -219,13 +217,13 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DOMElement_setAttributeNodeNS arginfo_class_DOMElement_setAttributeNode
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMElement_setIdAttribute, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, isId, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMElement_setIdAttributeNS, 0, 0, 3)
-	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, localName, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, isId, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -251,51 +249,53 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_DOMDocument_createAttribute arginfo_class_DOMElement_getAttribute
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_createAttribute, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, localName, IS_STRING, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_createAttributeNS, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_DOMDocument_createCDATASection arginfo_class_DOMDocumentFragment_appendXML
+#define arginfo_class_DOMDocument_createCDATASection arginfo_class_DOMCdataSection___construct
 
-#define arginfo_class_DOMDocument_createComment arginfo_class_DOMDocumentFragment_appendXML
+#define arginfo_class_DOMDocument_createComment arginfo_class_DOMCdataSection___construct
 
 #define arginfo_class_DOMDocument_createDocumentFragment arginfo_class_DOMNode_getLineNo
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_createElement, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, tagName, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, localName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_createElementNS, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_DOMDocument_createEntityReference arginfo_class_DOMElement_getAttribute
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_createEntityReference, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_createProcessingInstruction, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, data, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_DOMDocument_createTextNode arginfo_class_DOMDocumentFragment_appendXML
+#define arginfo_class_DOMDocument_createTextNode arginfo_class_DOMCdataSection___construct
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_getElementById, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, elementId, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_getElementsByTagName, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, tagName, IS_STRING, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DOMDocument_getElementsByTagName arginfo_class_DOMElement_getAttribute
 
 #define arginfo_class_DOMDocument_getElementsByTagNameNS arginfo_class_DOMElement_getElementsByTagNameNS
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_importNode, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, importedNode, DOMNode, 0)
+	ZEND_ARG_OBJ_INFO(0, node, DOMNode, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, deep, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
@@ -312,8 +312,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DOMDocument_normalizeDocument arginfo_class_DOMNode_getLineNo
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_registerNodeClass, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, baseclass, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, extendedclass, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, baseClass, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, extendedClass, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_DOMDocument_save arginfo_class_DOMDocument_load
@@ -381,9 +381,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_xinclude, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_adoptNode, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, source, DOMNode, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_DOMDocument_adoptNode arginfo_class_DOMNode_appendChild
 
 #define arginfo_class_DOMDocument_append arginfo_class_DOMParentNode_append
 
@@ -409,21 +407,21 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DOMNamedNodeMap_getIterator arginfo_class_DOMNodeList_getIterator
 
-#define arginfo_class_DOMEntityReference___construct arginfo_class_DOMElement_getAttribute
+#define arginfo_class_DOMEntityReference___construct arginfo_class_DOMDocument_createEntityReference
 
 #define arginfo_class_DOMProcessingInstruction___construct arginfo_class_DOMAttr___construct
 
 #if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMXPath___construct, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, doc, DOMDocument, 0)
+	ZEND_ARG_OBJ_INFO(0, document, DOMDocument, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, registerNodeNS, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMXPath_evaluate, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, expr, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, context, DOMNode, 1, "null")
+	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, contextNode, DOMNode, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, registerNodeNS, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 #endif
@@ -435,7 +433,7 @@ ZEND_END_ARG_INFO()
 #if defined(LIBXML_XPATH_ENABLED)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMXPath_registerNamespace, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, namespaceURI, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 

--- a/ext/simplexml/simplexml.stub.php
+++ b/ext/simplexml/simplexml.stub.php
@@ -2,19 +2,19 @@
 
 /** @generate-function-entries */
 
-function simplexml_load_file(string $filename, ?string $class_name = SimpleXMLElement::class, int $options = 0, string $ns = '', bool $is_prefix = false): SimpleXMLElement|false {}
+function simplexml_load_file(string $filename, ?string $class_name = SimpleXMLElement::class, int $options = 0, string $namespace_or_prefix = '', bool $is_prefix = false): SimpleXMLElement|false {}
 
-function simplexml_load_string(string $data, ?string $class_name = SimpleXMLElement::class, int $options = 0, string $ns = '', bool $is_prefix = false): SimpleXMLElement|false {}
+function simplexml_load_string(string $data, ?string $class_name = SimpleXMLElement::class, int $options = 0, string $namespace_or_prefix = '', bool $is_prefix = false): SimpleXMLElement|false {}
 
 function simplexml_import_dom(DOMNode $node, ?string $class_name = SimpleXMLElement::class): ?SimpleXMLElement {}
 
 class SimpleXMLElement implements Stringable, Countable, RecursiveIterator
 {
     /** @return array|false */
-    public function xpath(string $path) {}
+    public function xpath(string $expression) {}
 
     /** @return bool */
-    public function registerXPathNamespace(string $prefix, string $ns) {}
+    public function registerXPathNamespace(string $prefix, string $namespace) {}
 
     /** @return string|bool */
     public function asXML(string $filename = UNKNOWN) {}
@@ -29,21 +29,21 @@ class SimpleXMLElement implements Stringable, Countable, RecursiveIterator
     public function getNamespaces(bool $recursive = false) {}
 
     /** @return array|false */
-    public function getDocNamespaces(bool $recursive = false, bool $from_root = true) {}
+    public function getDocNamespaces(bool $recursive = false, bool $fromRoot = true) {}
 
     /** @return SimpleXMLIterator */
-    public function children(?string $ns = null, bool $is_prefix = false) {}
+    public function children(?string $namespaceOrPrefix = null, bool $isPrefix = false) {}
 
     /** @return SimpleXMLIterator */
-    public function attributes(?string $ns = null, bool $is_prefix = false) {}
+    public function attributes(?string $namespaceOrPrefix = null, bool $isPrefix = false) {}
 
-    public function __construct(string $data, int $options = 0, bool $data_is_url = false, string $ns = '', bool $is_prefix = false) {}
-
-    /** @return SimpleXMLElement */
-    public function addChild(string $name, ?string $value = null, ?string $ns = null) {}
+    public function __construct(string $data, int $options = 0, bool $dataIsURL = false, string $namespaceOrPrefix = '', bool $isPrefix = false) {}
 
     /** @return SimpleXMLElement */
-    public function addAttribute(string $name, ?string $value = null, ?string $ns = null) {}
+    public function addChild(string $qualifiedName, ?string $value = null, ?string $namespace = null) {}
+
+    /** @return SimpleXMLElement */
+    public function addAttribute(string $qualifiedName, ?string $value = null, ?string $namespace = null) {}
 
     /** @return string */
     public function getName() {}

--- a/ext/simplexml/simplexml_arginfo.h
+++ b/ext/simplexml/simplexml_arginfo.h
@@ -1,11 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7b3ff8b991fc7e424aaf1e86cfbebe662a30c48f */
+ * Stub hash: fbe25d8a7a0a1de0cbd5dc9118e77a2e8d5dbd67 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_simplexml_load_file, 0, 1, SimpleXMLElement, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class_name, IS_STRING, 1, "SimpleXMLElement::class")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ns, IS_STRING, 0, "\'\'")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, namespace_or_prefix, IS_STRING, 0, "\'\'")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, is_prefix, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
@@ -13,7 +13,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_simplexml_load_string, 0, 1,
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class_name, IS_STRING, 1, "SimpleXMLElement::class")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ns, IS_STRING, 0, "\'\'")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, namespace_or_prefix, IS_STRING, 0, "\'\'")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, is_prefix, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
@@ -23,12 +23,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_simplexml_import_dom, 0, 1, Simpl
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SimpleXMLElement_xpath, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SimpleXMLElement_registerXPathNamespace, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, ns, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SimpleXMLElement_asXML, 0, 0, 0)
@@ -43,12 +43,12 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SimpleXMLElement_getDocNamespaces, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, recursive, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, from_root, _IS_BOOL, 0, "true")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fromRoot, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SimpleXMLElement_children, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ns, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, is_prefix, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, namespaceOrPrefix, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isPrefix, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_SimpleXMLElement_attributes arginfo_class_SimpleXMLElement_children
@@ -56,15 +56,15 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SimpleXMLElement___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, data_is_url, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ns, IS_STRING, 0, "\'\'")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, is_prefix, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dataIsURL, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, namespaceOrPrefix, IS_STRING, 0, "\'\'")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isPrefix, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SimpleXMLElement_addChild, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ns, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, namespace, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_SimpleXMLElement_addAttribute arginfo_class_SimpleXMLElement_addChild


### PR DESCRIPTION
This PR uses the [official DOM WhatWG specification](https://dom.spec.whatwg.org) as a guide to rename the parameters of ext/dom and ext/simplexml in a more consistent way.