### PR TITLE
Fix bug #28790

### DIFF
--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -146,6 +146,7 @@ static void cwd_globals_ctor(virtual_cwd_globals *cwd_g) /* {{{ */
 	cwd_g->realpath_cache_size = 0;
 	cwd_g->realpath_cache_size_limit = REALPATH_CACHE_SIZE;
 	cwd_g->realpath_cache_ttl = REALPATH_CACHE_TTL;
+	cwd_g->disable_stat_cache = 0;
 	memset(cwd_g->realpath_cache, 0, sizeof(cwd_g->realpath_cache));
 }
 /* }}} */

--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -222,6 +222,7 @@ typedef struct _virtual_cwd_globals {
 	zend_long                   realpath_cache_size;
 	zend_long                   realpath_cache_size_limit;
 	zend_long                   realpath_cache_ttl;
+	zend_bool                   disable_stat_cache;
 	realpath_cache_bucket *realpath_cache[1024];
 } virtual_cwd_globals;
 

--- a/main/main.c
+++ b/main/main.c
@@ -758,6 +758,7 @@ PHP_INI_BEGIN()
 
 	STD_PHP_INI_ENTRY("realpath_cache_size",	"4096K",	PHP_INI_SYSTEM,		OnUpdateLong,	realpath_cache_size_limit,	virtual_cwd_globals,	cwd_globals)
 	STD_PHP_INI_ENTRY("realpath_cache_ttl",		"120",		PHP_INI_SYSTEM,		OnUpdateLong,	realpath_cache_ttl,			virtual_cwd_globals,	cwd_globals)
+	STD_PHP_INI_BOOLEAN("disable_stat_cache",	"0",		PHP_INI_SYSTEM,		OnUpdateBool,	disable_stat_cache,			virtual_cwd_globals,	cwd_globals)
 
 	STD_PHP_INI_ENTRY("user_ini.filename",		".user.ini",	PHP_INI_SYSTEM,		OnUpdateString,		user_ini_filename,	php_core_globals,		core_globals)
 	STD_PHP_INI_ENTRY("user_ini.cache_ttl",		"300",			PHP_INI_SYSTEM,		OnUpdateLong,		user_ini_cache_ttl,	php_core_globals,		core_globals)

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1959,7 +1959,7 @@ PHPAPI int _php_stream_stat_path(const char *path, int flags, php_stream_statbuf
 
 	memset(ssb, 0, sizeof(*ssb));
 
-	if (!(flags & PHP_STREAM_URL_STAT_NOCACHE)) {
+	if (!CWDG(disable_stat_cache) && !(flags & PHP_STREAM_URL_STAT_NOCACHE)) {
 		/* Try to hit the cache first */
 		if (flags & PHP_STREAM_URL_STAT_LINK) {
 			if (BG(CurrentLStatFile) && strcmp(path, BG(CurrentLStatFile)) == 0) {
@@ -1978,7 +1978,7 @@ PHPAPI int _php_stream_stat_path(const char *path, int flags, php_stream_statbuf
 	if (wrapper && wrapper->wops->url_stat) {
 		ret = wrapper->wops->url_stat(wrapper, path_to_open, flags, ssb, context);
 		if (ret == 0) {
-		        if (!(flags & PHP_STREAM_URL_STAT_NOCACHE)) {
+			if (!CWDG(disable_stat_cache) && !(flags & PHP_STREAM_URL_STAT_NOCACHE)) {
 				/* Drop into cache */
 				if (flags & PHP_STREAM_URL_STAT_LINK) {
 					if (BG(CurrentLStatFile)) {


### PR DESCRIPTION
Provide an option to disable the stat cache.

This helps to remove a class of subtle, frustrating bugs that occur for certain types of applications. It would be better to remove stat caching entirely as the OS already does this in a more reliable way.

The default behaviour is the same as it currently is. You need to add `disable_stat_cache = True` to the ini file to disable the stat cache. By default this setting is `False`.