### PR TITLE
datetime: new format "p", same as "P" but returning "Z" for UTC

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@ PHP                                                                        NEWS
   . Fixed bug #79108 (Referencing argument in a function makes it a reference
     in the stack trace). (Nikita)
 
+- Date:
+  . Implemented FR #79903 (datetime: new format "p", same as "P" but returning
+    "Z" for UTC). (gharlan)
+
 - JIT:
   . Fixed bug #79864 (JIT segfault in Symfony OptionsResolver). (Dmitry)
 

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -711,6 +711,12 @@ static zend_string *date_format(const char *format, size_t format_len, timelib_t
 
 			/* timezone */
 			case 'I': length = slprintf(buffer, sizeof(buffer), "%d", localtime ? offset->is_dst : 0); break;
+			case 'p': 
+				if (!localtime || strcmp(offset->abbr, "UTC") == 0 || strcmp(offset->abbr, "Z") == 0) {
+					length = slprintf(buffer, sizeof(buffer), "%s", "Z");
+					break;
+				}
+				/* break intentionally missing */
 			case 'P': rfc_colon = 1; /* break intentionally missing */
 			case 'O': length = slprintf(buffer, sizeof(buffer), "%c%02d%s%02d",
 											localtime ? ((offset->offset < 0) ? '-' : '+') : '+',

--- a/ext/date/tests/date_format_timezone.phpt
+++ b/ext/date/tests/date_format_timezone.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test date_format() function : timezone offset
+--FILE--
+<?php
+
+$tz = array("UTC", "Europe/London", "Europe/Berlin", "America/Chicago");
+
+foreach ($tz as $zone) {
+    echo $zone, "\n";
+    date_default_timezone_set($zone);
+
+    $date = date_create("2020-03-10 22:30:41");
+
+    var_dump( date_format($date, "O") );
+    var_dump( date_format($date, "P") );
+    var_dump( date_format($date, "p") );
+}
+
+echo "Z\n";
+$date = date_create("2020-03-10 22:30:41Z");
+
+var_dump( date_format($date, "p") );
+
+?>
+--EXPECT--
+UTC
+string(5) "+0000"
+string(6) "+00:00"
+string(1) "Z"
+Europe/London
+string(5) "+0000"
+string(6) "+00:00"
+string(6) "+00:00"
+Europe/Berlin
+string(5) "+0100"
+string(6) "+01:00"
+string(6) "+01:00"
+America/Chicago
+string(5) "-0500"
+string(6) "-05:00"
+string(6) "-05:00"
+Z
+string(1) "Z"


### PR DESCRIPTION
ISO 8601 differentiates between local time (without time zone), UTC with letter "Z" and time offsets from UTC like "+02:00".
https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators

When formatting datetimes, it is sometimes desired to get the "Z" for UTC times and otherwise the offset.
But at the moment there are only the formatting chars "O" (for "+0200" etc.) and "P" (for "+02:00" etc.).

I suggest to add another formatting char ~"Q"~ lower case "p" which behaves the same as "P" but returns "Z" for UTC datetimes.

```php
$datetime = new DateTime('2020-07-26 20:00:00', new DateTimeZone('UTC'));
$datetime->format('Y-m-d\TH:i:sP'); // '2020-07-26T20:00:00+00:00'
$datetime->format('Y-m-d\TH:i:sp'); // '2020-07-26T20:00:00Z'

$datetime = new DateTime('2020-07-26 20:00:00', new DateTimeZone('Europe/London'));
$datetime->format('Y-m-d\TH:i:sP'); // '2020-07-26T20:00:00+00:00'
$datetime->format('Y-m-d\TH:i:sp'); // '2020-07-26T20:00:00+00:00'

$datetime = new DateTime('2020-07-26 20:00:00', new DateTimeZone('Europe/Berlin'));
$datetime->format('Y-m-d\TH:i:sP'); // '2020-07-26T20:00:00+02:00'
$datetime->format('Y-m-d\TH:i:sp'); // '2020-07-26T20:00:00+02:00'
```

I'm not sure if it is useful enough to deserve a new formatting char. So don't worry about rejecting this proposal!
