### PR TITLE
Make http stream wrapper advertise HTTP/1.1 by default

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -495,6 +495,14 @@ PHP 8.0 UPGRADE NOTES
     accept parameters by reference will now warn if a callback with reference
     parameters is used. Examples include array_filter() and array_reduce().
     This was already the case for most, but not all, functions previously.
+  . The HTTP stream wrapper as used by functions like file_get_contents()
+    now advertises HTTP/1.1 rather than HTTP/1.0 by default. This does not
+    change the behaviour of the client, but may cause servers to respond
+    differently. To retain the old behaviour, set the 'protocol_version'
+    stream context option, e.g.
+
+        $ctx = stream_context_create(['http' => ['protocol_version' => '1.0']]);
+        echo file_get_contents('http://example.org', false, $ctx);
 
 - Sysvmsg:
   . msg_get_queue() will now return an SysvMessageQueue object rather than a

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -419,7 +419,7 @@ finish:
 		smart_str_appends(&req_buf, "\r\n");
 		efree(protocol_version);
 	} else {
-		smart_str_appends(&req_buf, " HTTP/1.0\r\n");
+		smart_str_appends(&req_buf, " HTTP/1.1\r\n");
 	}
 
 	if (context && (tmpzval = php_stream_context_get_option(context, "http", "header")) != NULL) {

--- a/sapi/cli/tests/bug69655.phpt
+++ b/sapi/cli/tests/bug69655.phpt
@@ -17,11 +17,11 @@ foreach (['MKCO', 'MKCOLL', 'M'] as $method) {
 }
 ?>
 --EXPECTF--
-Warning: file_get_contents(http://localhost:8964): Failed to open stream: HTTP request failed! HTTP/1.0 501 Not Implemented
+Warning: file_get_contents(http://localhost:8964): Failed to open stream: HTTP request failed! HTTP/1.1 501 Not Implemented
  in %s on line %d
 
-Warning: file_get_contents(http://localhost:8964): Failed to open stream: HTTP request failed! HTTP/1.0 501 Not Implemented
+Warning: file_get_contents(http://localhost:8964): Failed to open stream: HTTP request failed! HTTP/1.1 501 Not Implemented
  in %s on line %d
 
-Warning: file_get_contents(http://localhost:8964): Failed to open stream: HTTP request failed! HTTP/1.0 501 Not Implemented
+Warning: file_get_contents(http://localhost:8964): Failed to open stream: HTTP request failed! HTTP/1.1 501 Not Implemented
  in %s on line %d

--- a/sapi/cli/tests/bug70264.phpt
+++ b/sapi/cli/tests/bug70264.phpt
@@ -14,8 +14,8 @@ echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/..\\CREDITS");
 echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/..%5CCREDITS");
 ?>
 --EXPECTF--
-Warning: file_get_contents(http://%s/..\CREDITS): Failed to open stream: HTTP request failed! HTTP/1.0 404 Not Found
+Warning: file_get_contents(http://%s/..\CREDITS): Failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found
  in %sbug70264.php on line %d
 
-Warning: file_get_contents(http://%s/..%5CCREDITS): Failed to open stream: HTTP request failed! HTTP/1.0 404 Not Found
+Warning: file_get_contents(http://%s/..%5CCREDITS): Failed to open stream: HTTP request failed! HTTP/1.1 404 Not Found
  in %sbug70264.php on line %d


### PR DESCRIPTION
In practice, we always act as an HTTP/1.1 client, for compatibility
with servers which ignore protocol version. Sending the version in
the request will avoid problems with servers which don't ignore it.

HTTP/1.0 can still be forced using a stream context option.