### PR TITLE
Handle bindto error

### DIFF
--- a/ext/standard/tests/network/bindto.phpt
+++ b/ext/standard/tests/network/bindto.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test invalid bindto
+--FILE--
+<?php
+$ctx = stream_context_create([
+    'socket' => [
+        'bindto' => 'invalid',
+    ],
+]);
+$fp = stream_socket_client(
+    'tcp://www.' . str_repeat('x', 100) . '.com:80',
+    $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $ctx
+);
+?>
+--EXPECTF--
+Warning: stream_socket_client(): Unable to connect to tcp://%s:80 (Failed to parse address "invalid") in %s on line %d

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -747,6 +747,10 @@ static inline int php_tcp_sockop_connect(php_stream *stream, php_netstream_data_
 			return -1;
 		}
 		bindto = parse_ip_address_ex(Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval), &bindport, xparam->want_errortext, &xparam->outputs.error_text);
+		if (bindto == NULL) {
+			efree(host);
+			return -1;
+		}
 	}
 
 #ifdef SO_BROADCAST


### PR DESCRIPTION
code:
```php
$ctx = stream_context_create([
    'socket' => [
        'bindto' => 'invalid',
    ],
]);
$fp = stream_socket_client(
    'tcp://www.' . str_repeat('x', 100) . '.com:80',
    $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $ctx
);
?>
```
before:
```
Warning: stream_socket_client(): php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known in %s/bindto.php on line 17

Warning: stream_socket_client(): unable to connect to tcp://www.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.com:80 (php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known) in %s/bindto.php on line 17
[Wed Jul 29 12:07:22 2020]  Script:  '%s/bindto.php'
Zend/zend_string.h(133) :  Freeing 0x000000010cd13f00 (224 bytes), script=%s/bindto.php
=== Total 1 memory leaks detected ===
```
after:
```
Warning: stream_socket_client(): Unable to connect to tcp://%s:80 (Failed to parse address "invalid") in %s on line %d
```
