### PR TITLE
Remove PHP_CHECK_GCC_ARG()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -214,7 +214,11 @@ PHP 8.0 INTERNALS UPGRADE NOTES
   b. Unix build system changes
 
     1.  --enable-maintainer-zts is renamed --enable-zts for parity with Windows
-        and as recognition that ZTS is not a "maintainer" or experimental feature.
+        and as recognition that ZTS is not a "maintainer" or experimental
+        feature.
+
+    2.  The PHP_CHECK_GCC_ARG() m4 macro has been removed in favor of
+        AX_CHECK_COMPILE_FLAG().
 
   c. Windows build system changes
 

--- a/build/php.m4
+++ b/build/php.m4
@@ -305,30 +305,6 @@ fi
 ])
 
 dnl
-dnl PHP_CHECK_GCC_ARG(arg, action-if-found, action-if-not-found)
-dnl
-AC_DEFUN([PHP_CHECK_GCC_ARG],[
-  gcc_arg_name=[ac_cv_gcc_arg]translit($1,A-Z=-,a-z__)
-  AC_CACHE_CHECK([whether $CC supports $1], [ac_cv_gcc_arg]translit($1,A-Z=-,a-z__), [
-  echo 'void somefunc() { };' > conftest.c
-  cmd='$CC $1 -c conftest.c'
-  if eval $cmd 2>&1 | $EGREP -e $1 >/dev/null ; then
-    ac_result=no
-  else
-    ac_result=yes
-  fi
-  eval $gcc_arg_name=$ac_result
-  rm -f conftest.*
-  ])
-  if eval test "\$$gcc_arg_name" = "yes"; then
-    $2
-  else
-    :
-    $3
-  fi
-])
-
-dnl
 dnl PHP_LIBGCC_LIBPATH(gcc)
 dnl
 dnl Stores the location of libgcc in libgcc_libpath.

--- a/configure.ac
+++ b/configure.ac
@@ -224,10 +224,8 @@ case $host_alias in
     ;;
   *darwin*)
     if test -n "$GCC"; then
-      PHP_CHECK_GCC_ARG(-no-cpp-precomp, gcc_no_cpp_precomp=yes)
-      if test "$gcc_no_cpp_precomp" = "yes"; then
-        CPPFLAGS="$CPPFLAGS -no-cpp-precomp"
-      fi
+      AX_CHECK_COMPILE_FLAG([-no-cpp-precomp],
+                            [CPPFLAGS="$CPPFLAGS -no-cpp-precomp"])
     fi
     ;;
   *mips*)


### PR DESCRIPTION
In favor of AX_CHECK_COMPILE_FLAG(), which we bundle since at least PHP 7.