### PR TITLE
Fix #79919: Stack use-after-scope in define

### DIFF
--- a/Zend/tests/bug79919.phpt
+++ b/Zend/tests/bug79919.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #79919 (Stack use-after-scope in define)
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === 'Windows') die('skip need ASan instrumentation');
+if (!extension_loaded('simplexml')) die('skip simplexml extension not available');
+?>
+--FILE--
+<?php
+$b = error_log(0);
+$b = simplexml_load_string('<xml/>', null, $b);
+define(0, $b);
+?>
+--EXPECT--
+0

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -882,9 +882,7 @@ repeat:
 		case IS_OBJECT:
 			if (Z_TYPE(val_free) == IS_UNDEF) {
 				if (Z_OBJ_HT_P(val)->get) {
-					zval rv;
-					val = Z_OBJ_HT_P(val)->get(val, &rv);
-					ZVAL_COPY_VALUE(&val_free, val);
+					val = Z_OBJ_HT_P(val)->get(val, &val_free);
 					goto repeat;
 				} else if (Z_OBJ_HT_P(val)->cast_object) {
 					if (Z_OBJ_HT_P(val)->cast_object(val, &val_free, IS_STRING) == SUCCESS) {


### PR DESCRIPTION
Instead of the temporary `rv`, we use the `val_free` which is there for
this purpose.