### PR TITLE
[opcache] [jit] Attribute support

### DIFF
--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -28,9 +28,9 @@
 
 #define ZEND_JIT_ON_SCRIPT_LOAD    0
 #define ZEND_JIT_ON_FIRST_EXEC     1
-#define ZEND_JIT_ON_PROF_REQUEST   2     /* compile the most frequently caled on first request functions */
+#define ZEND_JIT_ON_PROF_REQUEST   2     /* compile the most frequently called on first request functions */
 #define ZEND_JIT_ON_HOT_COUNTERS   3     /* compile functions after N calls or loop iterations */
-#define ZEND_JIT_ON_DOC_COMMENT    4     /* compile functions with "@jit" tag in doc-comments */
+#define ZEND_JIT_ON_ATTRIBUTE      4     /* compile functions with @@Jit attribute, unused at the moment */
 #define ZEND_JIT_ON_HOT_TRACE      5     /* trace functions after N calls or loop iterations */
 
 #define ZEND_JIT_REG_ALLOC_LOCAL  (1<<0) /* local linear scan register allocation */
@@ -175,5 +175,7 @@ struct _zend_lifetime_interval {
 	zend_lifetime_interval *used_as_hint;
 	zend_lifetime_interval *list_next;
 };
+
+zend_class_entry *zend_ce_opcache_jit_attribute;
 
 #endif /* HAVE_JIT_H */

--- a/ext/opcache/tests/jit/attributes_001.phpt
+++ b/ext/opcache/tests/jit/attributes_001.phpt
@@ -1,0 +1,22 @@
+--TEST--
+JIT disabled with attributes, assert no jit debug output
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+opcache.jit=1205
+opcache.jit_debug=1
+opcache.protect_memory=1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+@@Jit("off")
+function foo($a) {
+    return $a * $a;
+}
+?>
+okey
+--EXPECT--
+okey

--- a/ext/opcache/tests/jit/attributes_002.phpt
+++ b/ext/opcache/tests/jit/attributes_002.phpt
@@ -1,0 +1,21 @@
+--TEST--
+JIT trigger with attributes
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+opcache.jit=1205
+opcache.jit_debug=1
+opcache.protect_memory=1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+@@Jit("something else")
+function foo($a) {
+    return $a * $a;
+}
+?>
+--EXPECTF--
+Fatal error: @@Jit argument $mode only supports the value 'off' %s


### PR DESCRIPTION
Remove the obsolete doc-comment based JIT trigger. Since function and
tracing JITs are recommended for now, the attribute based trigger mode
is removed for now.

Only `@@jit("off")` is available to disable the JIT for a function/method.

Open Questions:
- [ ] Are we ok with removing ´@Jit("on")`, `@@Jit("tracing")` and `@@Jit("function")` for now to thoroughly discuss best approach for 8.1?
- [ ] Rename `@@Jit` to something more specific like `@@JitOptions`, `@@JitConfig` or `@@JitHint`?
- [ ] Remove the attribute trigger constant 4, and move tracing JIT to use 4 instead of 5?