### PR TITLE
FPM: Add pm.status_listen option

### DIFF
--- a/sapi/fpm/fpm/fpm_children.c
+++ b/sapi/fpm/fpm/fpm_children.c
@@ -346,7 +346,7 @@ static void fpm_child_resources_use(struct fpm_child_s *child) /* {{{ */
 {
 	struct fpm_worker_pool_s *wp;
 	for (wp = fpm_worker_all_pools; wp; wp = wp->next) {
-		if (wp == child->wp) {
+		if (wp == child->wp || wp == child->wp->shared) {
 			continue;
 		}
 		fpm_scoreboard_free(wp->scoreboard);

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -73,6 +73,7 @@ struct fpm_worker_pool_config_s {
 	int pm_process_idle_timeout;
 	int pm_max_requests;
 	char *pm_status_path;
+	char *pm_status_listen;
 	char *ping_path;
 	char *ping_response;
 	char *access_log;

--- a/sapi/fpm/fpm/fpm_process_ctl.c
+++ b/sapi/fpm/fpm/fpm_process_ctl.c
@@ -417,7 +417,9 @@ static void fpm_pctl_perform_idle_server_maintenance(struct timeval *now) /* {{{
 				wp->idle_spawn_rate = 1;
 				continue;
 			}
-			wp->warn_max_children = 0;
+			if (!wp->shared) {
+				wp->warn_max_children = 0;
+			}
 
 			fpm_children_make(wp, 1, children_to_fork, 1);
 
@@ -528,8 +530,9 @@ void fpm_pctl_on_socket_accept(struct fpm_event_s *ev, short which, void *arg) /
 			return;
 		}
 	}
-
-	wp->warn_max_children = 0;
+	if (!wp->shared) {
+		wp->warn_max_children = 0;
+	}
 	fpm_children_make(wp, 1, 1, 1);
 
 	if (fpm_globals.is_child) {

--- a/sapi/fpm/fpm/fpm_scoreboard.c
+++ b/sapi/fpm/fpm/fpm_scoreboard.c
@@ -71,6 +71,11 @@ int fpm_scoreboard_init_main() /* {{{ */
 		wp->scoreboard->pm          = wp->config->pm;
 		wp->scoreboard->start_epoch = time(NULL);
 		strlcpy(wp->scoreboard->pool, wp->config->name, sizeof(wp->scoreboard->pool));
+
+		if (wp->shared) {
+			/* shared pool is added after non shared ones so the shared scoreboard is allocated */
+			wp->scoreboard->shared = wp->shared->scoreboard;
+		}
 	}
 	return 0;
 }

--- a/sapi/fpm/fpm/fpm_scoreboard.h
+++ b/sapi/fpm/fpm/fpm_scoreboard.h
@@ -63,6 +63,7 @@ struct fpm_scoreboard_s {
 	unsigned int nprocs;
 	int free_proc;
 	unsigned long int slow_rq;
+	struct fpm_scoreboard_s *shared;
 	struct fpm_scoreboard_proc_s *procs[];
 };
 

--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -171,6 +171,9 @@ int fpm_status_handle_request(void) /* {{{ */
 		fpm_request_executing();
 
 		scoreboard_p = fpm_scoreboard_get();
+		if (scoreboard_p->shared) {
+			scoreboard_p = scoreboard_p->shared;
+		}
 		if (!scoreboard_p) {
 			zlog(ZLOG_ERROR, "status: unable to find or access status shared memory");
 			SG(sapi_headers).http_response_code = 500;

--- a/sapi/fpm/fpm/fpm_worker_pool.h
+++ b/sapi/fpm/fpm/fpm_worker_pool.h
@@ -18,6 +18,7 @@ enum fpm_address_domain {
 
 struct fpm_worker_pool_s {
 	struct fpm_worker_pool_s *next;
+	struct fpm_worker_pool_s *shared;
 	struct fpm_worker_pool_config_s *config;
 	char *user, *home;									/* for setting env USER and HOME */
 	enum fpm_address_domain listen_address_domain;

--- a/sapi/fpm/tests/status-listen.phpt
+++ b/sapi/fpm/tests/status-listen.phpt
@@ -1,0 +1,51 @@
+--TEST--
+FPM: Status listen test
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+pm.status_listen = {{ADDR[status]}}
+pm.status_path = /status
+EOT;
+
+$expectedStatusData = [
+    'pool'                 => 'unconfined',
+    'process manager'      => 'static',
+    'listen queue'         => 0,
+    'max listen queue'     => 0,
+    'idle processes'       => 1,
+    'active processes'     => 0,
+    'total processes'      => 1,
+    'max active processes' => 1,
+    'max children reached' => 0,
+    'slow requests'        => 0,
+];
+
+$tester = new FPM\Tester($cfg);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectEmptyBody();
+$tester->status($expectedStatusData, '{{ADDR[status]}}');
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -238,6 +238,22 @@ pm.max_spare_servers = 3
 ; Default Value: not set
 ;pm.status_path = /status
 
+; The address on which to accept FastCGI status request. This creates a new
+; invisible pool that can handle requests independently. This is useful
+; if the main pool is busy with long running requests because it is still possible
+; to get the status before finishing the long running requests.
+;
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Default Value: value of the listen option
+;pm.status_listen = 127.0.0.1:9001
+
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside
 ; that FPM is alive and responding, or to


### PR DESCRIPTION
This option allows getting status from different endpoint (e.g. port
or UDS file) which is useful for getting status when all children are
busy with serving long running requests.

Internally a new shared pool with ondemand process manager is used. It
means that the status requests have reserved resources and should not
be blocked by other requests.