### PR TITLE
set -ex on travis/compile.sh

### DIFF
--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 if [[ "$ENABLE_MAINTAINER_ZTS" == 1 ]]; then
 	TS="--enable-maintainer-zts";
 else


### PR DESCRIPTION
-e to fail early: ./configure may fail and further errors from make bury the original problem in the logs.

-x for easier debugging