### PR TITLE
Fix grammar/typo nits in docs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -99,11 +99,11 @@ PHP                                                                        NEWS
     that allow global flag to configure query() or evaluate() calls.
 
 - Enchant:
-  . Add LIBENCHANT_VERSION macro
-  . Deprecate enchant_broker_set_dict_path, enchant_broker_get_dict_path
-    enchant_dict_add_to_personal and enchant_dict_is_in_session
-  . Add enchant_dict_add and enchant_dict_is_added functions
-  . Use libenchant-2 when available
+  . Add LIBENCHANT_VERSION macro.
+  . Deprecate enchant_broker_set_dict_path, enchant_broker_get_dict_path,
+    enchant_dict_add_to_personal and enchant_dict_is_in_session.
+  . Add enchant_dict_add and enchant_dict_is_added functions.
+  . Use libenchant-2 when available.
 
 - FPM:
   . Fixed bug #64865 (Search for .user.ini files from script dir up to

--- a/UPGRADING
+++ b/UPGRADING
@@ -226,7 +226,7 @@ PHP 8.0 UPGRADE NOTES
      - Increment and decrement operations
     The concept of a "leading-numeric string" has been mostly dropped; the
     cases where this remains exist in order to ease migration. Strings which
-    emitted an E_NOTICE "A non well formed numeric value encountered" will now
+    emitted an E_NOTICE "A non well-formed numeric value encountered" will now
     emit an E_WARNING "A non-numeric value encountered" and all strings which
     emitted an E_WARNING "A non-numeric value encountered" will now throw a
     TypeError. This mostly affects:
@@ -780,7 +780,7 @@ PHP 8.0 UPGRADE NOTES
    . env_method
    . enc_password
  . ZipArchive::addEmptyDir, ZipArchive::addFile and aZipArchive::addFromString
-   methods have a new "flags" argument. This allow to manage name encoding
+   methods have a new "flags" argument. This allows managing name encoding
    (ZipArchive::FL_ENC_*) and entry replacement (ZipArchive::FL_OVERWRITE)
  . ZipArchive::extractTo now restore file modification time.
 

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -209,7 +209,7 @@ PHP 8.0 INTERNALS UPGRADE NOTES
         with extremely constrained memory, and compilation fails with an "out
         of memory" message, add "-O0" to CFLAGS.
 
-    5.  build system and provider are displayed in phpinfo from enviroment:
+    5.  build system and provider are displayed in phpinfo from environment:
         - PHP_BUILD_SYSTEM (default is same as PHP_UNAME)
         - PHP_BUILD_PROVIDER (no default)
 


### PR DESCRIPTION
The PHP error message says "well-formed", not "well formed"