### PR TITLE
Default assert.exception to 1

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -21,6 +21,8 @@ PHP 8.0 UPGRADE NOTES
 ========================================
 
 - Core:
+  . Assertion failures now throw by default. If the old behavior is desired,
+    then set `assert.exception=0` in INI settings.
   . Methods with the same name as the class are no longer interpreted as
     constructors. The __construct() method should be used instead.
   . Removed ability to call non-static methods statically.

--- a/Zend/tests/arrow_functions/007.phpt
+++ b/Zend/tests/arrow_functions/007.phpt
@@ -1,5 +1,8 @@
 --TEST--
 Pretty printing for arrow functions
+--INI--
+zend.assertions=1
+assert.exception=0
 --FILE--
 <?php
 

--- a/Zend/tests/ast/zend-pow-assign.phpt
+++ b/Zend/tests/ast/zend-pow-assign.phpt
@@ -2,6 +2,7 @@
 ZEND_POW_ASSIGN
 --INI--
 zend.assertions=1
+assert.exception=0
 --FILE--
 <?php
 

--- a/Zend/tests/ast_serialize_backtick_literal.phpt
+++ b/Zend/tests/ast_serialize_backtick_literal.phpt
@@ -2,6 +2,7 @@
 Serialization of backtick literal is incorrect
 --INI--
 zend.assertions=1
+assert.exception=0
 --FILE--
 <?php
 

--- a/Zend/tests/attributes/012_ast_export.phpt
+++ b/Zend/tests/attributes/012_ast_export.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Attributes AST can be exported.
+--INI--
+zend.assertions=1
+assert.exception=0
+assert.warning=1
 --FILE--
 <?php
 

--- a/Zend/tests/match/009.phpt
+++ b/Zend/tests/match/009.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Pretty printing for match expression
+--INI--
+assert.exception=0
 --FILE--
 <?php
 

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -77,7 +77,7 @@ PHP_INI_BEGIN()
 	 STD_PHP_INI_BOOLEAN("assert.bail",		"0",	PHP_INI_ALL,	OnUpdateBool,		bail,	 			zend_assert_globals,		assert_globals)
 	 STD_PHP_INI_BOOLEAN("assert.warning",	"1",	PHP_INI_ALL,	OnUpdateBool,		warning, 			zend_assert_globals,		assert_globals)
 	 PHP_INI_ENTRY("assert.callback",		NULL,	PHP_INI_ALL,	OnChangeCallback)
-	 STD_PHP_INI_BOOLEAN("assert.exception",	"0",	PHP_INI_ALL,	OnUpdateBool,		exception, 			zend_assert_globals,		assert_globals)
+	 STD_PHP_INI_BOOLEAN("assert.exception",	"1",	PHP_INI_ALL,	OnUpdateBool,		exception, 			zend_assert_globals,		assert_globals)
 PHP_INI_END()
 
 static void php_assert_init_globals(zend_assert_globals *assert_globals_p) /* {{{ */

--- a/ext/standard/tests/assert/assert.phpt
+++ b/ext/standard/tests/assert/assert.phpt
@@ -5,6 +5,7 @@ assert.active = 0
 assert.warning = 1
 assert.callback =
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 function a($file, $line, $unused, $desc)

--- a/ext/standard/tests/assert/assert03.phpt
+++ b/ext/standard/tests/assert/assert03.phpt
@@ -5,6 +5,7 @@ assert.active = 1
 assert.warning = 0
 assert.callback =
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 function a($file, $line, $unused, $desc)

--- a/ext/standard/tests/assert/assert04.phpt
+++ b/ext/standard/tests/assert/assert04.phpt
@@ -5,6 +5,7 @@ assert.active = 1
 assert.warning = 1
 assert.callback =
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 /* Assert not active */

--- a/ext/standard/tests/assert/assert_basic.phpt
+++ b/ext/standard/tests/assert/assert_basic.phpt
@@ -5,6 +5,7 @@ assert.active = 1
 assert.warning = 0
 assert.callback = f1
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 function f1()

--- a/ext/standard/tests/assert/assert_basic2.phpt
+++ b/ext/standard/tests/assert/assert_basic2.phpt
@@ -5,6 +5,7 @@ assert.active = 1
 assert.warning = 1
 assert.callback=f1
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 function f2()

--- a/ext/standard/tests/assert/assert_basic3.phpt
+++ b/ext/standard/tests/assert/assert_basic3.phpt
@@ -5,6 +5,7 @@ assert.active = 1
 assert.warning = 1
 assert.callback = f1
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 function f1()

--- a/ext/standard/tests/assert/assert_basic5.phpt
+++ b/ext/standard/tests/assert/assert_basic5.phpt
@@ -5,6 +5,7 @@ assert.active = 1
 assert.warning = 0
 assert.callback = f1
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 function f1()

--- a/ext/standard/tests/assert/assert_closures.phpt
+++ b/ext/standard/tests/assert/assert_closures.phpt
@@ -4,6 +4,7 @@ assert() - basic - accept closures as callback.
 assert.active = 1
 assert.warning = 1
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 assert_options(ASSERT_CALLBACK, function () { echo "Hello World!\n"; });

--- a/ext/standard/tests/assert/assert_error2.phpt
+++ b/ext/standard/tests/assert/assert_error2.phpt
@@ -5,6 +5,7 @@ assert.active = 1
 assert.warning = 1
 assert.callback = f1
 assert.bail = 0
+assert.exception=0
 error_reporting = -1
 display_errors = 1
 --FILE--

--- a/ext/standard/tests/assert/assert_variation.phpt
+++ b/ext/standard/tests/assert/assert_variation.phpt
@@ -5,6 +5,7 @@ assert.active = 1
 assert.warning = 0
 assert.callback = f1
 assert.bail = 0
+assert.exception=0
 --FILE--
 <?php
 function f1()


### PR DESCRIPTION
As discussed on the mailing list, this changes the default of `assert.exception` from `0` to `1`, meaning exceptions will now throw by default. To restore the old value set `assert.exception=0` in an INI file.

I opted to leave existing tests as written and instead just changed the `--INI--` section to have the old value.