### PR TITLE
Fix #48585: com_load_typelib holds reference, fails on second call

### DIFF
--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -248,7 +248,7 @@ PHP_FUNCTION(com_create_instance)
 		TL = php_com_load_typelib_via_cache(typelib_name, obj->code_page, &cached);
 
 		if (TL) {
-			if (COMG(autoreg_on) && !cached) {
+			if (COMG(autoreg_on)) {
 				php_com_import_typelib(TL, mode, obj->code_page);
 			}
 
@@ -838,9 +838,7 @@ PHP_FUNCTION(com_load_typelib)
 	php_com_initialize();
 	pTL = php_com_load_typelib_via_cache(name, codepage, &cached);
 	if (pTL) {
-		if (cached) {
-			RETVAL_TRUE;
-		} else if (php_com_import_typelib(pTL, cs ? CONST_CS : 0, codepage) == SUCCESS) {
+		if (php_com_import_typelib(pTL, cs ? CONST_CS : 0, codepage) == SUCCESS) {
 			RETVAL_TRUE;
 		}
 

--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -252,9 +252,7 @@ static PHP_INI_MH(OnTypeLibFileUpdate)
 		}
 
 		if ((pTL = php_com_load_typelib_via_cache(typelib_name, COMG(code_page), &cached)) != NULL) {
-			if (!cached) {
-				php_com_import_typelib(pTL, mode, COMG(code_page));
-			}
+			php_com_import_typelib(pTL, mode, COMG(code_page));
 			ITypeLib_Release(pTL);
 		}
 	}


### PR DESCRIPTION
Whether the type library is cached is actually irrelevant here; what
matters is that the symbols are imported, and since these are not
cached, we have to import them for every request.  And we cannot cache
the symbols, because the import depends on the current codepage, but
the codepage is a `PHP_INI_ALL` setting.

---

I'm not sure what to do with the `cached` parameter of `php_com_load_typelib_via_cache()`; it's no longer needed after this change, but the function is exported, although it is declared in the internal header. Maybe just stick with the param for PHP 7, and remove for PHP 8?

I'm also not sure if it's worth writing a PHPT, because that would likely require the built-in webserver to be able to do multiple requests.
