### PR TITLE
opcache illus build fix proposal.

### DIFF
--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -1025,7 +1025,7 @@ int zend_file_cache_script_store(zend_persistent_script *script, int in_shm)
 #endif
 
 #ifdef HAVE_SYS_UIO_H
-	vec[0].iov_base = &info;
+	vec[0].iov_base = (void *)&info;
 	vec[0].iov_len = sizeof(info);
 	vec[1].iov_base = buf;
 	vec[1].iov_len = script->size;


### PR DESCRIPTION
These systems has two versions of the iovec interface dependent on compiler flags passed,
the legacy version causing little build issue.