### PR TITLE
Only force log startup errors if display_startup_errors disabled

### DIFF
--- a/ext/mbstring/tests/ini_mbstring_invalid.phpt
+++ b/ext/mbstring/tests/ini_mbstring_invalid.phpt
@@ -18,13 +18,6 @@ mbstring.strict_detection=BOOL_STRICT_DETECTION
 // Empty as we are only testing INI settings
 ?>
 --EXPECT--
-PHP Warning:  PHP Startup: INI setting contains invalid encoding "DETECT_ORDER" in Unknown on line 0
-PHP Deprecated:  PHP Startup: Use of mbstring.http_input is deprecated in Unknown on line 0
-PHP Warning:  PHP Startup: INI setting contains invalid encoding "HTTP_INPUT" in Unknown on line 0
-PHP Deprecated:  PHP Startup: Use of mbstring.http_output is deprecated in Unknown on line 0
-PHP Deprecated:  PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
-PHP Warning:  PHP Startup: Unknown encoding "UNKNOWN_ENCODING" in ini setting in Unknown on line 0
-
 Warning: PHP Startup: INI setting contains invalid encoding "DETECT_ORDER" in Unknown on line 0
 
 Deprecated: PHP Startup: Use of mbstring.http_input is deprecated in Unknown on line 0

--- a/ext/mbstring/tests/mb_get_info.phpt
+++ b/ext/mbstring/tests/mb_get_info.phpt
@@ -23,10 +23,6 @@ foreach (array_keys($result) as $key) {
 }
 ?>
 --EXPECT--
-PHP Deprecated:  PHP Startup: Use of mbstring.http_input is deprecated in Unknown on line 0
-PHP Deprecated:  PHP Startup: Use of mbstring.http_output is deprecated in Unknown on line 0
-PHP Deprecated:  PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
-
 Deprecated: PHP Startup: Use of mbstring.http_input is deprecated in Unknown on line 0
 
 Deprecated: PHP Startup: Use of mbstring.http_output is deprecated in Unknown on line 0

--- a/ext/mbstring/tests/mb_internal_encoding_ini_basic2.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_ini_basic2.phpt
@@ -20,8 +20,6 @@ echo ini_get('mbstring.internal_encoding')."\n";
 
 ?>
 --EXPECT--
-PHP Deprecated:  PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
-
 Deprecated: PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
 *** Testing INI mbstring.internal_encoding : basic functionality ***
 ISO-8859-7

--- a/ext/mbstring/tests/mb_internal_encoding_ini_invalid_encoding.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_ini_invalid_encoding.phpt
@@ -20,9 +20,6 @@ echo ini_get('mbstring.internal_encoding')."\n";
 
 ?>
 --EXPECT--
-PHP Deprecated:  PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
-PHP Warning:  PHP Startup: Unknown encoding "BAD" in ini setting in Unknown on line 0
-
 Deprecated: PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
 
 Warning: PHP Startup: Unknown encoding "BAD" in ini setting in Unknown on line 0

--- a/ext/session/tests/bug60860.phpt
+++ b/ext/session/tests/bug60860.phpt
@@ -6,7 +6,6 @@ include('skipif.inc');
 ?>
 --INI--
 session.save_handler=user
-display_errors=off
 error_log=
 --FILE--
 <?php
@@ -16,5 +15,5 @@ echo "ok\n";
 
 ?>
 --EXPECT--
-PHP Recoverable fatal error:  PHP Startup: Cannot set 'user' save handler by ini_set() or session_module_name() in Unknown on line 0
+Recoverable fatal error: PHP Startup: Cannot set 'user' save handler by ini_set() or session_module_name() in Unknown on line 0
 ok

--- a/ext/session/tests/bug66481.phpt
+++ b/ext/session/tests/bug66481.phpt
@@ -12,8 +12,6 @@ ob_start();
 var_dump(session_name("foo"));
 var_dump(session_name("bar"));
 --EXPECT--
-PHP Warning:  PHP Startup: session.name cannot be a numeric or empty '' in Unknown on line 0
-
 Warning: PHP Startup: session.name cannot be a numeric or empty '' in Unknown on line 0
 string(9) "PHPSESSID"
 string(3) "foo"

--- a/ext/session/tests/rfc1867_invalid_settings.phpt
+++ b/ext/session/tests/rfc1867_invalid_settings.phpt
@@ -12,7 +12,5 @@ include('skipif.inc');
 var_dump(ini_get("session.upload_progress.freq"));
 ?>
 --EXPECTF--
-PHP Warning:  PHP Startup: session.upload_progress.freq must be greater than or equal to zero in %s
-
 Warning: PHP Startup: session.upload_progress.freq must be greater than or equal to zero in %s
 string(%d) "1%"

--- a/ext/session/tests/rfc1867_invalid_settings_2.phpt
+++ b/ext/session/tests/rfc1867_invalid_settings_2.phpt
@@ -12,7 +12,5 @@ include('skipif.inc');
 var_dump(ini_get("session.upload_progress.freq"));
 ?>
 --EXPECTF--
-PHP Warning:  PHP Startup: session.upload_progress.freq cannot be over 100% in %s
-
 Warning: PHP Startup: session.upload_progress.freq cannot be over 100% in %s
 string(%d) "1%"

--- a/ext/session/tests/session_set_save_handler_class_014.phpt
+++ b/ext/session/tests/session_set_save_handler_class_014.phpt
@@ -3,8 +3,6 @@ Test session_set_save_handler() : calling default handler when save_handler=user
 --INI--
 session.save_handler=user
 session.name=PHPSESSID
-display_errors=off
-error_log=
 --SKIPIF--
 <?php
 include('skipif.inc');
@@ -22,5 +20,5 @@ session_set_save_handler($handler);
 
 session_start();
 --EXPECT--
-PHP Recoverable fatal error:  PHP Startup: Cannot set 'user' save handler by ini_set() or session_module_name() in Unknown on line 0
+Recoverable fatal error: PHP Startup: Cannot set 'user' save handler by ini_set() or session_module_name() in Unknown on line 0
 *** Testing session_set_save_handler() : calling default handler when save_handler=user ***

--- a/ext/standard/tests/strings/htmlentities25.phpt
+++ b/ext/standard/tests/strings/htmlentities25.phpt
@@ -15,7 +15,5 @@ var_dump(htmlentities('äöü'));
 
 ?>
 --EXPECT--
-PHP Deprecated:  PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
-
 Deprecated: PHP Startup: Use of mbstring.internal_encoding is deprecated in Unknown on line 0
 string(18) "&auml;&ouml;&uuml;"

--- a/main/main.c
+++ b/main/main.c
@@ -1312,7 +1312,7 @@ static ZEND_COLD void php_error_cb(int orig_type, const char *error_filename, co
 				break;
 		}
 
-		if (!module_initialized || PG(log_errors)) {
+		if (PG(log_errors) || (!module_initialized && !PG(display_startup_errors))) {
 			char *log_buffer;
 #ifdef PHP_WIN32
 			if (type == E_CORE_ERROR || type == E_CORE_WARNING) {

--- a/tests/run-test/bug75042-3.phpt
+++ b/tests/run-test/bug75042-3.phpt
@@ -9,4 +9,4 @@ nonexistentsharedmodule
 --FILE--
 <?php
 --EXPECTF--
-PHP Warning:  PHP Startup: Unable to load dynamic library '%snonexistentsharedmodule.%s' %A
+Warning: PHP Startup: Unable to load dynamic library '%snonexistentsharedmodule.%s' %A


### PR DESCRIPTION
Otherwise this results in duplicate errors.