### PR TITLE
Change MySQL liveness function to check for EOF

### DIFF
--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -142,6 +142,7 @@ PHPAPI enum_func_status mysqlnd_poll(MYSQLND **r_array, MYSQLND **e_array, MYSQL
 #define mysqlnd_get_proto_info(conn)	((conn)->data)->m->get_protocol_information((conn)->data)
 #define mysqlnd_thread_id(conn)			((conn)->data)->m->get_thread_id((conn)->data)
 #define mysqlnd_get_server_status(conn)	((conn)->data)->m->get_server_status((conn)->data)
+#define mysqlnd_check_stream_eof(conn)	php_stream_eof(((conn)->data)->vio->data->m.get_stream((conn)->data->vio))
 
 #define mysqlnd_num_rows(result)		(result)->m.num_rows((result))
 #define mysqlnd_num_fields(result)		(result)->m.num_fields((result))

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -506,10 +506,17 @@ static int pdo_mysql_check_liveness(pdo_dbh_t *dbh)
 	PDO_DBG_ENTER("pdo_mysql_check_liveness");
 	PDO_DBG_INF_FMT("dbh=%p", dbh);
 
+#ifdef PDO_USE_MYSQLND
+	if (mysqlnd_check_stream_eof(H->server)) {
+		PDO_DBG_RETURN(FAILURE);
+	}
+	PDO_DBG_RETURN(SUCCESS);
+#else
 	if (mysql_ping(H->server)) {
 		PDO_DBG_RETURN(FAILURE);
 	}
 	PDO_DBG_RETURN(SUCCESS);
+#endif
 }
 /* }}} */
 


### PR DESCRIPTION
Inspired by https://github.blog/2020-05-20-three-bugs-in-the-go-mysql-driver/, this PR proposes changing the `check_liveness` function in `pdo_mysql` from an active "ping" to a non-blocking read via `php_stream_eof` when using `mysqlnd`.

The end result is the same, and it eliminates the overhead and latency of sending a MySQL command. A trade-off, however, is that the ping command would reset MySQL's `wait_timeout`, whereas this implementation does not. I believe there is precedent for my change from other drivers - [if I understand correctly, pdo_pgsql operates this way](https://github.com/php/php-src/blob/196f8fdfc3e792d316311b55e50a4ae4c97c5b71/ext/pdo_pgsql/pgsql_driver.c#L488-L497) - but I would be open to adding an explicit`PDO::ping` method for people that may still want that behavior for drivers that support it.

I wasn't entirely sure if implementing the underlying `mysqlnd` functionality solely as a macro was appropriate (although it seems simple enough), so feel free to point me at the right place to put it if necessary.
