### PR TITLE
Fix #55847: DOTNET .NET 4.0 GAC new location

### DIFF
--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -144,6 +144,7 @@ PHP_INI_BEGIN()
     STD_PHP_INI_ENTRY("com.autoregister_casesensitive",	"1", PHP_INI_ALL, OnAutoregisterCasesensitive, autoreg_case_sensitive, zend_com_dotnet_globals, com_dotnet_globals)
 	STD_PHP_INI_ENTRY("com.code_page", "", PHP_INI_ALL, OnUpdateLong, code_page, zend_com_dotnet_globals, com_dotnet_globals)
 	PHP_INI_ENTRY("com.typelib_file", "", PHP_INI_SYSTEM, OnTypeLibFileUpdate)
+	PHP_INI_ENTRY("com.dotnet_version", NULL, PHP_INI_SYSTEM, NULL)
 PHP_INI_END()
 /* }}} */
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -1614,6 +1614,10 @@ zend.assertions = 1
 ; Default: system ANSI code page
 ;com.code_page=
 
+; The version of the .NET framework to use. The value of the setting are the first three parts
+; of the framework's version number, separated by dots, and prefixed with "v", e.g. "v4.0.30319".
+;com.dotnet_version=
+
 [mbstring]
 ; language for internal character representation.
 ; This affects mb_send_mail() and mbstring.detect_order.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1618,6 +1618,10 @@ zend.assertions = -1
 ; Default: system ANSI code page
 ;com.code_page=
 
+; The version of the .NET framework to use. The value of the setting are the first three parts
+; of the framework's version number, separated by dots, and prefixed with "v", e.g. "v4.0.30319".
+;com.dotnet_version=
+
 [mbstring]
 ; language for internal character representation.
 ; This affects mb_send_mail() and mbstring.detect_order.


### PR DESCRIPTION
If we do not specify the exact version of the .NET framework to use,
the default CLR is loaded, which is typically CLR 2, which is very old.
Therefore, we introduce a `PHP_INI_SYSTEM` setting, which allows users
to choose the desired .NET framework version.  The value of the setting
are the first three parts of the framework's version number, separated
by dots, and prefixed with "v", e.g. "v4.0.30319".  If the value of the
INI setting is `NULL` (the default) or an empty string, the default CLR
is used.

Internally, we switch from the most generic `CoCreateInstance()` to
`CorBindToRuntime()` which is implemented in mscoree.dll.  To avoid the
hard dependency to that library, we load dynamically.

So this fix is supposed to be fully backwards compatible.