### PR TITLE
Proposal: Make match expression a constant expression (when parts are constant)

### DIFF
--- a/Zend/tests/match/043.phpt
+++ b/Zend/tests/match/043.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Match expression can be used as a constant expression
+--FILE--
+<?php
+
+// Here, this test uses strtolower because the locale dependence and change to the string
+// ensures PHP has to use a temporary value instead of a literal, to test memory management.
+//
+// It's already possible to throw from a constant expression (e.g. undeclared constants),
+// and match() can be seen as a much shorter way than changed ternary conditions on the same constant expressions.
+define('dynamic_value', strtolower('FOO'));
+function my_test($invalid = match(dynamic_value) {}) {
+    return $invalid;
+}
+
+const X = match (dynamic_value) {
+    default => 123,
+};
+echo "X=",X,"\n";
+const Y = match (dynamic_value) {
+    'a', 'b' => 'default',
+    default => dynamic_value . 'd',
+};
+echo "Y=",Y,"\n";
+const Z = match (dynamic_value) {
+    'a', 'foo', 'b' => [dynamic_value],
+    default => dynamic_value,
+};
+echo "Z=",json_encode(Z),"\n";
+
+echo json_encode(my_test([dynamic_value])), "\n";
+for ($i = 0; $i < 2; $i++) {
+    try {
+        my_test();
+    } catch (UnhandledMatchError $e) {
+        echo "Caught {$e->getMessage()} at line {$e->getLine()}\n";
+    }
+}
+
+?>
+--EXPECT--
+X=123
+Y=food
+Z=["foo"]
+["foo"]
+Caught Unhandled match value of type string at line 9
+Caught Unhandled match value of type string at line 9

--- a/Zend/tests/match/044.phpt
+++ b/Zend/tests/match/044.phpt
@@ -3,12 +3,10 @@ Match expression can be used as a constant expression unless parts aren't consta
 --FILE--
 <?php
 
-// Here, this test uses strtolower because the locale dependence and change to the string
-// ensures PHP has to use a temporary value instead of a literal
-
+// This is an uncatchable fatal error caused by compiling this file.
 const X = match ($x) {
     default => 123,
 };
 ?>
 --EXPECTF--
-Fatal error: Constant expression contains invalid operations in %s044.php on line 6
+Fatal error: Constant expression contains invalid operations in %s044.php on line 4

--- a/Zend/tests/match/044.phpt
+++ b/Zend/tests/match/044.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Match expression can be used as a constant expression unless parts aren't constant
+--FILE--
+<?php
+
+// Here, this test uses strtolower because the locale dependence and change to the string
+// ensures PHP has to use a temporary value instead of a literal
+
+const X = match ($x) {
+    default => 123,
+};
+?>
+--EXPECTF--
+Fatal error: Constant expression contains invalid operations in %s044.php on line 6

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9144,7 +9144,9 @@ zend_bool zend_is_allowed_in_const_expr(zend_ast_kind kind) /* {{{ */
 		|| kind == ZEND_AST_UNPACK
 		|| kind == ZEND_AST_CONST || kind == ZEND_AST_CLASS_CONST
 		|| kind == ZEND_AST_CLASS_NAME
-		|| kind == ZEND_AST_MAGIC_CONST || kind == ZEND_AST_COALESCE;
+		|| kind == ZEND_AST_MAGIC_CONST || kind == ZEND_AST_COALESCE
+		|| kind == ZEND_AST_MATCH || kind == ZEND_AST_MATCH_ARM
+		|| kind == ZEND_AST_MATCH_ARM_LIST || kind == ZEND_AST_EXPR_LIST;
 }
 /* }}} */
 


### PR DESCRIPTION
Motivations: This would be potentially useful for class constant and static variable declarations that would previously need to use `(some_value == b ? c : (some_value == d || some_value == d2 ? e : f))` instead of `match (some_value) { b => c, d, d2 => e, default => f}`

I'd forgotten to check if this was part of the original RFC earlier.
It seems like constant expressions using match can be thought of as a much
more concise form of conditional than chained ternary(a?b:c) operators.

It's already possible for constant expressions to throw, e.g.
- Undeclared constants.
- Wrong operands for unary or binary operators.

(But the UnhandledMatchError would be new,)

@nikic @iluuu1994 - thoughts on allowing this for PHP 8.0 or 8.1? I'd personally assumed this would be an implementation oversight since I don't remember seeing constant expressions discussed (it was a large PR)
Prior to this proposed change, the error message was always `Constant expression contains invalid operations`