### PR TITLE
Migrate zend_*_property APIs to accept zend_object* instead of zval*

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -1,7 +1,7 @@
 PHP 8.0 INTERNALS UPGRADE NOTES
 
 1. Internal API changes
-  a. Object Handlers API
+  a. Object Handlers API and APIs accepting objects
   b. ZEND_OVERLOADED_FUNCTION and corresponding call_method() object handler
   c. TSRM changes
   d. get() and set() object handlers
@@ -34,9 +34,10 @@ PHP 8.0 INTERNALS UPGRADE NOTES
 1. Internal API changes
 ========================
 
-  a. Object Handlers API and some related functions, e.g. zend_call_method() and
+  a. Object Handlers API and some related functions, e.g. zend_call_method(),
+     zend_read_property(), zend_update_property(), zend_unset_property() and
      zend_objects_clone_obj() were changed to receive zend_object* instead of
-     zval* and zend_string* instead of zval* for property names.
+     zval* for objects and zend_string* instead of zval* for property names.
 
   b. ZEND_OVERLOADED_FUNCTION and corresponding call_method() object handler
      were removed. ZEND_INTERNAL_FUNCTION with ZEND_ACC_CALL_VIA_HANDLER and

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4007,7 +4007,7 @@ ZEND_API void zend_update_property_null(zend_class_entry *scope, zval *object, c
 }
 /* }}} */
 
-ZEND_API void zend_unset_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length) /* {{{ */
+ZEND_API void zend_unset_property(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length) /* {{{ */
 {
 	zend_string *property;
 	zend_class_entry *old_scope = EG(fake_scope);
@@ -4015,7 +4015,7 @@ ZEND_API void zend_unset_property(zend_class_entry *scope, zval *object, const c
 	EG(fake_scope) = scope;
 
 	property = zend_string_init(name, name_length, 0);
-	Z_OBJ_HT_P(object)->unset_property(Z_OBJ_P(object), property, 0);
+	object->handlers->unset_property(object, property, 0);
 	zend_string_release_ex(property, 0);
 
 	EG(fake_scope) = old_scope;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4179,21 +4179,21 @@ ZEND_API int zend_update_static_property_stringl(zend_class_entry *scope, const 
 }
 /* }}} */
 
-ZEND_API zval *zend_read_property_ex(zend_class_entry *scope, zval *object, zend_string *name, zend_bool silent, zval *rv) /* {{{ */
+ZEND_API zval *zend_read_property_ex(zend_class_entry *scope, zend_object *object, zend_string *name, zend_bool silent, zval *rv) /* {{{ */
 {
 	zval *value;
 	zend_class_entry *old_scope = EG(fake_scope);
 
 	EG(fake_scope) = scope;
 
-	value = Z_OBJ_HT_P(object)->read_property(Z_OBJ_P(object), name, silent?BP_VAR_IS:BP_VAR_R, NULL, rv);
+	value = object->handlers->read_property(object, name, silent?BP_VAR_IS:BP_VAR_R, NULL, rv);
 
 	EG(fake_scope) = old_scope;
 	return value;
 }
 /* }}} */
 
-ZEND_API zval *zend_read_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_bool silent, zval *rv) /* {{{ */
+ZEND_API zval *zend_read_property(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zend_bool silent, zval *rv) /* {{{ */
 {
 	zval *value;
 	zend_string *str;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3971,19 +3971,19 @@ ZEND_API void zend_declare_class_constant_string(zend_class_entry *ce, const cha
 }
 /* }}} */
 
-ZEND_API void zend_update_property_ex(zend_class_entry *scope, zval *object, zend_string *name, zval *value) /* {{{ */
+ZEND_API void zend_update_property_ex(zend_class_entry *scope, zend_object *object, zend_string *name, zval *value) /* {{{ */
 {
 	zend_class_entry *old_scope = EG(fake_scope);
 
 	EG(fake_scope) = scope;
 
-	Z_OBJ_HT_P(object)->write_property(Z_OBJ_P(object), name, value, NULL);
+	object->handlers->write_property(object, name, value, NULL);
 
 	EG(fake_scope) = old_scope;
 }
 /* }}} */
 
-ZEND_API void zend_update_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zval *value) /* {{{ */
+ZEND_API void zend_update_property(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zval *value) /* {{{ */
 {
 	zend_string *property;
 	zend_class_entry *old_scope = EG(fake_scope);
@@ -3991,14 +3991,14 @@ ZEND_API void zend_update_property(zend_class_entry *scope, zval *object, const 
 	EG(fake_scope) = scope;
 
 	property = zend_string_init(name, name_length, 0);
-	Z_OBJ_HT_P(object)->write_property(Z_OBJ_P(object), property, value, NULL);
+	object->handlers->write_property(object, property, value, NULL);
 	zend_string_release_ex(property, 0);
 
 	EG(fake_scope) = old_scope;
 }
 /* }}} */
 
-ZEND_API void zend_update_property_null(zend_class_entry *scope, zval *object, const char *name, size_t name_length) /* {{{ */
+ZEND_API void zend_update_property_null(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length) /* {{{ */
 {
 	zval tmp;
 
@@ -4022,7 +4022,7 @@ ZEND_API void zend_unset_property(zend_class_entry *scope, zend_object *object, 
 }
 /* }}} */
 
-ZEND_API void zend_update_property_bool(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_long value) /* {{{ */
+ZEND_API void zend_update_property_bool(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zend_long value) /* {{{ */
 {
 	zval tmp;
 
@@ -4031,7 +4031,7 @@ ZEND_API void zend_update_property_bool(zend_class_entry *scope, zval *object, c
 }
 /* }}} */
 
-ZEND_API void zend_update_property_long(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_long value) /* {{{ */
+ZEND_API void zend_update_property_long(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zend_long value) /* {{{ */
 {
 	zval tmp;
 
@@ -4040,7 +4040,7 @@ ZEND_API void zend_update_property_long(zend_class_entry *scope, zval *object, c
 }
 /* }}} */
 
-ZEND_API void zend_update_property_double(zend_class_entry *scope, zval *object, const char *name, size_t name_length, double value) /* {{{ */
+ZEND_API void zend_update_property_double(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, double value) /* {{{ */
 {
 	zval tmp;
 
@@ -4049,7 +4049,7 @@ ZEND_API void zend_update_property_double(zend_class_entry *scope, zval *object,
 }
 /* }}} */
 
-ZEND_API void zend_update_property_str(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_string *value) /* {{{ */
+ZEND_API void zend_update_property_str(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zend_string *value) /* {{{ */
 {
 	zval tmp;
 
@@ -4058,7 +4058,7 @@ ZEND_API void zend_update_property_str(zend_class_entry *scope, zval *object, co
 }
 /* }}} */
 
-ZEND_API void zend_update_property_string(zend_class_entry *scope, zval *object, const char *name, size_t name_length, const char *value) /* {{{ */
+ZEND_API void zend_update_property_string(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, const char *value) /* {{{ */
 {
 	zval tmp;
 
@@ -4068,7 +4068,7 @@ ZEND_API void zend_update_property_string(zend_class_entry *scope, zval *object,
 }
 /* }}} */
 
-ZEND_API void zend_update_property_stringl(zend_class_entry *scope, zval *object, const char *name, size_t name_length, const char *value, size_t value_len) /* {{{ */
+ZEND_API void zend_update_property_stringl(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, const char *value, size_t value_len) /* {{{ */
 {
 	zval tmp;
 

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -389,7 +389,7 @@ ZEND_API void zend_update_property_double(zend_class_entry *scope, zval *object,
 ZEND_API void zend_update_property_str(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_string *value);
 ZEND_API void zend_update_property_string(zend_class_entry *scope, zval *object, const char *name, size_t name_length, const char *value);
 ZEND_API void zend_update_property_stringl(zend_class_entry *scope, zval *object, const char *name, size_t name_length, const char *value, size_t value_length);
-ZEND_API void zend_unset_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length);
+ZEND_API void zend_unset_property(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length);
 
 ZEND_API int zend_update_static_property_ex(zend_class_entry *scope, zend_string *name, zval *value);
 ZEND_API int zend_update_static_property(zend_class_entry *scope, const char *name, size_t name_length, zval *value);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -380,15 +380,15 @@ ZEND_API void zend_declare_class_constant_string(zend_class_entry *ce, const cha
 
 ZEND_API int zend_update_class_constants(zend_class_entry *class_type);
 
-ZEND_API void zend_update_property_ex(zend_class_entry *scope, zval *object, zend_string *name, zval *value);
-ZEND_API void zend_update_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zval *value);
-ZEND_API void zend_update_property_null(zend_class_entry *scope, zval *object, const char *name, size_t name_length);
-ZEND_API void zend_update_property_bool(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_long value);
-ZEND_API void zend_update_property_long(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_long value);
-ZEND_API void zend_update_property_double(zend_class_entry *scope, zval *object, const char *name, size_t name_length, double value);
-ZEND_API void zend_update_property_str(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_string *value);
-ZEND_API void zend_update_property_string(zend_class_entry *scope, zval *object, const char *name, size_t name_length, const char *value);
-ZEND_API void zend_update_property_stringl(zend_class_entry *scope, zval *object, const char *name, size_t name_length, const char *value, size_t value_length);
+ZEND_API void zend_update_property_ex(zend_class_entry *scope, zend_object *object, zend_string *name, zval *value);
+ZEND_API void zend_update_property(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zval *value);
+ZEND_API void zend_update_property_null(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length);
+ZEND_API void zend_update_property_bool(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zend_long value);
+ZEND_API void zend_update_property_long(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zend_long value);
+ZEND_API void zend_update_property_double(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, double value);
+ZEND_API void zend_update_property_str(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zend_string *value);
+ZEND_API void zend_update_property_string(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, const char *value);
+ZEND_API void zend_update_property_stringl(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, const char *value, size_t value_length);
 ZEND_API void zend_unset_property(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length);
 
 ZEND_API int zend_update_static_property_ex(zend_class_entry *scope, zend_string *name, zval *value);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -400,8 +400,8 @@ ZEND_API int zend_update_static_property_double(zend_class_entry *scope, const c
 ZEND_API int zend_update_static_property_string(zend_class_entry *scope, const char *name, size_t name_length, const char *value);
 ZEND_API int zend_update_static_property_stringl(zend_class_entry *scope, const char *name, size_t name_length, const char *value, size_t value_length);
 
-ZEND_API zval *zend_read_property_ex(zend_class_entry *scope, zval *object, zend_string *name, zend_bool silent, zval *rv);
-ZEND_API zval *zend_read_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_bool silent, zval *rv);
+ZEND_API zval *zend_read_property_ex(zend_class_entry *scope, zend_object *object, zend_string *name, zend_bool silent, zval *rv);
+ZEND_API zval *zend_read_property(zend_class_entry *scope, zend_object *object, const char *name, size_t name_length, zend_bool silent, zval *rv);
 
 ZEND_API zval *zend_read_static_property_ex(zend_class_entry *scope, zend_string *name, zend_bool silent);
 ZEND_API zval *zend_read_static_property(zend_class_entry *scope, const char *name, size_t name_length, zend_bool silent);

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -99,16 +99,16 @@ void zend_exception_set_previous(zend_object *exception, zend_object *add_previo
 	ZVAL_OBJ(&zv, exception);
 	ex = &zv;
 	do {
-		ancestor = zend_read_property_ex(i_get_exception_base(&pv), &pv, ZSTR_KNOWN(ZEND_STR_PREVIOUS), 1, &rv);
+		ancestor = zend_read_property_ex(i_get_exception_base(&pv), Z_OBJ(pv), ZSTR_KNOWN(ZEND_STR_PREVIOUS), 1, &rv);
 		while (Z_TYPE_P(ancestor) == IS_OBJECT) {
 			if (Z_OBJ_P(ancestor) == Z_OBJ_P(ex)) {
 				OBJ_RELEASE(add_previous);
 				return;
 			}
-			ancestor = zend_read_property_ex(i_get_exception_base(ancestor), ancestor, ZSTR_KNOWN(ZEND_STR_PREVIOUS), 1, &rv);
+			ancestor = zend_read_property_ex(i_get_exception_base(ancestor), Z_OBJ_P(ancestor), ZSTR_KNOWN(ZEND_STR_PREVIOUS), 1, &rv);
 		}
 		base_ce = i_get_exception_base(ex);
-		previous = zend_read_property_ex(base_ce, ex, ZSTR_KNOWN(ZEND_STR_PREVIOUS), 1, &rv);
+		previous = zend_read_property_ex(base_ce, Z_OBJ_P(ex), ZSTR_KNOWN(ZEND_STR_PREVIOUS), 1, &rv);
 		if (Z_TYPE_P(previous) == IS_NULL) {
 			zend_update_property_ex(base_ce, ex, ZSTR_KNOWN(ZEND_STR_PREVIOUS), &pv);
 			GC_DELREF(add_previous);
@@ -309,7 +309,7 @@ ZEND_METHOD(Exception, __construct)
 
 /* {{{ Exception unserialize checks */
 #define CHECK_EXC_TYPE(id, type) \
-	pvalue = zend_read_property_ex(i_get_exception_base(object), (object), ZSTR_KNOWN(id), 1, &value); \
+	pvalue = zend_read_property_ex(i_get_exception_base(object), Z_OBJ_P(object), ZSTR_KNOWN(id), 1, &value); \
 	if (Z_TYPE_P(pvalue) != IS_NULL && Z_TYPE_P(pvalue) != type) { \
 		zend_unset_property(i_get_exception_base(object), object, ZSTR_VAL(ZSTR_KNOWN(id)), ZSTR_LEN(ZSTR_KNOWN(id))); \
 	}
@@ -375,9 +375,9 @@ ZEND_METHOD(ErrorException, __construct)
 /* }}} */
 
 #define GET_PROPERTY(object, id) \
-	zend_read_property_ex(i_get_exception_base(object), (object), ZSTR_KNOWN(id), 0, &rv)
+	zend_read_property_ex(i_get_exception_base(object), Z_OBJ_P(object), ZSTR_KNOWN(id), 0, &rv)
 #define GET_PROPERTY_SILENT(object, id) \
-	zend_read_property_ex(i_get_exception_base(object), (object), ZSTR_KNOWN(id), 1, &rv)
+	zend_read_property_ex(i_get_exception_base(object), Z_OBJ_P(object), ZSTR_KNOWN(id), 1, &rv)
 
 /* {{{ Get the file in which the exception occurred */
 ZEND_METHOD(Exception, getFile)
@@ -603,7 +603,7 @@ ZEND_METHOD(Exception, getTraceAsString)
 	object = ZEND_THIS;
 	base_ce = i_get_exception_base(object);
 
-	trace = zend_read_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_TRACE), 1, &rv);
+	trace = zend_read_property_ex(base_ce, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_TRACE), 1, &rv);
 	if (EG(exception)) {
 		RETURN_THROWS();
 	}

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -311,7 +311,7 @@ ZEND_METHOD(Exception, __construct)
 #define CHECK_EXC_TYPE(id, type) \
 	pvalue = zend_read_property_ex(i_get_exception_base(Z_OBJ_P(object)), Z_OBJ_P(object), ZSTR_KNOWN(id), 1, &value); \
 	if (Z_TYPE_P(pvalue) != IS_NULL && Z_TYPE_P(pvalue) != type) { \
-		zend_unset_property(i_get_exception_base(Z_OBJ_P(object)), object, ZSTR_VAL(ZSTR_KNOWN(id)), ZSTR_LEN(ZSTR_KNOWN(id))); \
+		zend_unset_property(i_get_exception_base(Z_OBJ_P(object)), Z_OBJ_P(object), ZSTR_VAL(ZSTR_KNOWN(id)), ZSTR_LEN(ZSTR_KNOWN(id))); \
 	}
 
 ZEND_METHOD(Exception, __wakeup)

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -110,7 +110,7 @@ void zend_exception_set_previous(zend_object *exception, zend_object *add_previo
 		base_ce = i_get_exception_base(Z_OBJ_P(ex));
 		previous = zend_read_property_ex(base_ce, Z_OBJ_P(ex), ZSTR_KNOWN(ZEND_STR_PREVIOUS), 1, &rv);
 		if (Z_TYPE_P(previous) == IS_NULL) {
-			zend_update_property_ex(base_ce, ex, ZSTR_KNOWN(ZEND_STR_PREVIOUS), &pv);
+			zend_update_property_ex(base_ce, Z_OBJ_P(ex), ZSTR_KNOWN(ZEND_STR_PREVIOUS), &pv);
 			GC_DELREF(add_previous);
 			return;
 		}
@@ -215,14 +215,13 @@ ZEND_API void zend_clear_exception(void) /* {{{ */
 
 static zend_object *zend_default_exception_new_ex(zend_class_entry *class_type, int skip_top_traces) /* {{{ */
 {
-	zval obj, tmp;
-	zend_object *object;
+	zval tmp;
 	zval trace;
 	zend_class_entry *base_ce;
 	zend_string *filename;
 
-	Z_OBJ(obj) = object = zend_objects_new(class_type);
-	Z_OBJ_HT(obj) = &default_exception_handlers;
+	zend_object *object = zend_objects_new(class_type);
+	object->handlers = &default_exception_handlers;
 
 	object_properties_init(object, class_type);
 
@@ -240,17 +239,17 @@ static zend_object *zend_default_exception_new_ex(zend_class_entry *class_type, 
 	if (EXPECTED((class_type != zend_ce_parse_error && class_type != zend_ce_compile_error)
 			|| !(filename = zend_get_compiled_filename()))) {
 		ZVAL_STRING(&tmp, zend_get_executed_filename());
-		zend_update_property_ex(base_ce, &obj, ZSTR_KNOWN(ZEND_STR_FILE), &tmp);
+		zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_FILE), &tmp);
 		zval_ptr_dtor(&tmp);
 		ZVAL_LONG(&tmp, zend_get_executed_lineno());
-		zend_update_property_ex(base_ce, &obj, ZSTR_KNOWN(ZEND_STR_LINE), &tmp);
+		zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_LINE), &tmp);
 	} else {
 		ZVAL_STR(&tmp, filename);
-		zend_update_property_ex(base_ce, &obj, ZSTR_KNOWN(ZEND_STR_FILE), &tmp);
+		zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_FILE), &tmp);
 		ZVAL_LONG(&tmp, zend_get_compiled_lineno());
-		zend_update_property_ex(base_ce, &obj, ZSTR_KNOWN(ZEND_STR_LINE), &tmp);
+		zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_LINE), &tmp);
 	}
-	zend_update_property_ex(base_ce, &obj, ZSTR_KNOWN(ZEND_STR_TRACE), &trace);
+	zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_TRACE), &trace);
 
 	return object;
 }
@@ -293,16 +292,16 @@ ZEND_METHOD(Exception, __construct)
 
 	if (message) {
 		ZVAL_STR(&tmp, message);
-		zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_MESSAGE), &tmp);
+		zend_update_property_ex(base_ce, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_MESSAGE), &tmp);
 	}
 
 	if (code) {
 		ZVAL_LONG(&tmp, code);
-		zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_CODE), &tmp);
+		zend_update_property_ex(base_ce, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_CODE), &tmp);
 	}
 
 	if (previous) {
-		zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_PREVIOUS), previous);
+		zend_update_property_ex(base_ce, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_PREVIOUS), previous);
 	}
 }
 /* }}} */
@@ -345,31 +344,31 @@ ZEND_METHOD(ErrorException, __construct)
 
 	if (message) {
 		ZVAL_STR_COPY(&tmp, message);
-		zend_update_property_ex(zend_ce_exception, object, ZSTR_KNOWN(ZEND_STR_MESSAGE), &tmp);
+		zend_update_property_ex(zend_ce_exception, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_MESSAGE), &tmp);
 		zval_ptr_dtor(&tmp);
 	}
 
 	if (code) {
 		ZVAL_LONG(&tmp, code);
-		zend_update_property_ex(zend_ce_exception, object, ZSTR_KNOWN(ZEND_STR_CODE), &tmp);
+		zend_update_property_ex(zend_ce_exception, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_CODE), &tmp);
 	}
 
 	if (previous) {
-		zend_update_property_ex(zend_ce_exception, object, ZSTR_KNOWN(ZEND_STR_PREVIOUS), previous);
+		zend_update_property_ex(zend_ce_exception, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_PREVIOUS), previous);
 	}
 
 	ZVAL_LONG(&tmp, severity);
-	zend_update_property_ex(zend_ce_exception, object, ZSTR_KNOWN(ZEND_STR_SEVERITY), &tmp);
+	zend_update_property_ex(zend_ce_exception, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_SEVERITY), &tmp);
 
 	if (argc >= 4) {
 		ZVAL_STR_COPY(&tmp, filename);
-		zend_update_property_ex(zend_ce_exception, object, ZSTR_KNOWN(ZEND_STR_FILE), &tmp);
+		zend_update_property_ex(zend_ce_exception, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_FILE), &tmp);
 		zval_ptr_dtor(&tmp);
     	if (argc < 5) {
     	    lineno = 0; /* invalidate lineno */
     	}
 		ZVAL_LONG(&tmp, lineno);
-		zend_update_property_ex(zend_ce_exception, object, ZSTR_KNOWN(ZEND_STR_LINE), &tmp);
+		zend_update_property_ex(zend_ce_exception, Z_OBJ_P(object), ZSTR_KNOWN(ZEND_STR_LINE), &tmp);
 	}
 }
 /* }}} */
@@ -726,7 +725,7 @@ ZEND_METHOD(Exception, __toString)
 	/* We store the result in the private property string so we can access
 	 * the result in uncaught exception handlers without memleaks. */
 	ZVAL_STR(&tmp, str);
-	zend_update_property_ex(base_ce, exception, ZSTR_KNOWN(ZEND_STR_STRING), &tmp);
+	zend_update_property_ex(base_ce, Z_OBJ_P(exception), ZSTR_KNOWN(ZEND_STR_STRING), &tmp);
 
 	RETURN_STR(str);
 }
@@ -847,11 +846,11 @@ static zend_object *zend_throw_exception_zstr(zend_class_entry *exception_ce, ze
 
 	if (message) {
 		ZVAL_STR(&tmp, message);
-		zend_update_property_ex(exception_ce, &ex, ZSTR_KNOWN(ZEND_STR_MESSAGE), &tmp);
+		zend_update_property_ex(exception_ce, Z_OBJ(ex), ZSTR_KNOWN(ZEND_STR_MESSAGE), &tmp);
 	}
 	if (code) {
 		ZVAL_LONG(&tmp, code);
-		zend_update_property_ex(exception_ce, &ex, ZSTR_KNOWN(ZEND_STR_CODE), &tmp);
+		zend_update_property_ex(exception_ce, Z_OBJ(ex), ZSTR_KNOWN(ZEND_STR_CODE), &tmp);
 	}
 
 	zend_throw_exception_internal(Z_OBJ(ex));
@@ -888,11 +887,10 @@ ZEND_API ZEND_COLD zend_object *zend_throw_exception_ex(zend_class_entry *except
 
 ZEND_API ZEND_COLD zend_object *zend_throw_error_exception(zend_class_entry *exception_ce, zend_string *message, zend_long code, int severity) /* {{{ */
 {
-	zval ex, tmp;
+	zval tmp;
 	zend_object *obj = zend_throw_exception_zstr(exception_ce, message, code);
-	ZVAL_OBJ(&ex, obj);
 	ZVAL_LONG(&tmp, severity);
-	zend_update_property_ex(zend_ce_error_exception, &ex, ZSTR_KNOWN(ZEND_STR_SEVERITY), &tmp);
+	zend_update_property_ex(zend_ce_error_exception, obj, ZSTR_KNOWN(ZEND_STR_SEVERITY), &tmp);
 	return obj;
 }
 /* }}} */
@@ -935,12 +933,12 @@ ZEND_API ZEND_COLD int zend_exception_error(zend_object *ex, int severity) /* {{
 		zend_string *str, *file = NULL;
 		zend_long line = 0;
 
-		zend_call_known_instance_method_with_0_params(ex->ce->__tostring, Z_OBJ(exception), &tmp);
+		zend_call_known_instance_method_with_0_params(ex->ce->__tostring, ex, &tmp);
 		if (!EG(exception)) {
 			if (Z_TYPE(tmp) != IS_STRING) {
 				zend_error(E_WARNING, "%s::__toString() must return a string", ZSTR_VAL(ce_exception->name));
 			} else {
-				zend_update_property_ex(i_get_exception_base(ex), &exception, ZSTR_KNOWN(ZEND_STR_STRING), &tmp);
+				zend_update_property_ex(i_get_exception_base(ex), ex, ZSTR_KNOWN(ZEND_STR_STRING), &tmp);
 			}
 		}
 		zval_ptr_dtor(&tmp);

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -45,7 +45,7 @@ ZEND_API ZEND_COLD void zend_throw_exception_internal(zend_object *exception);
 
 void zend_register_default_exception(void);
 
-ZEND_API zend_class_entry *zend_get_exception_base(zval *object);
+ZEND_API zend_class_entry *zend_get_exception_base(zend_object *object);
 
 /* Deprecated - Use zend_ce_exception directly instead */
 ZEND_API zend_class_entry *zend_exception_get_default(void);

--- a/ext/com_dotnet/com_wrapper.c
+++ b/ext/com_dotnet/com_wrapper.c
@@ -280,7 +280,7 @@ static HRESULT STDMETHODCALLTYPE disp_invokeex(
 		if (wFlags & DISPATCH_PROPERTYGET) {
 			retval = zend_read_property(Z_OBJCE(disp->object), Z_OBJ(disp->object), Z_STRVAL_P(name), Z_STRLEN_P(name)+1, 1, &rv);
 		} else if (wFlags & DISPATCH_PROPERTYPUT) {
-			zend_update_property(Z_OBJCE(disp->object), &disp->object, Z_STRVAL_P(name), Z_STRLEN_P(name), &params[0]);
+			zend_update_property(Z_OBJCE(disp->object), Z_OBJ(disp->object), Z_STRVAL_P(name), Z_STRLEN_P(name), &params[0]);
 		} else if (wFlags & DISPATCH_METHOD) {
 			zend_try {
 				retval = &rv;

--- a/ext/com_dotnet/com_wrapper.c
+++ b/ext/com_dotnet/com_wrapper.c
@@ -278,7 +278,7 @@ static HRESULT STDMETHODCALLTYPE disp_invokeex(
 		 * and expose it as a COM exception */
 
 		if (wFlags & DISPATCH_PROPERTYGET) {
-			retval = zend_read_property(Z_OBJCE(disp->object), &disp->object, Z_STRVAL_P(name), Z_STRLEN_P(name)+1, 1, &rv);
+			retval = zend_read_property(Z_OBJCE(disp->object), Z_OBJ(disp->object), Z_STRVAL_P(name), Z_STRLEN_P(name)+1, 1, &rv);
 		} else if (wFlags & DISPATCH_PROPERTYPUT) {
 			zend_update_property(Z_OBJCE(disp->object), &disp->object, Z_STRVAL_P(name), Z_STRLEN_P(name), &params[0]);
 		} else if (wFlags & DISPATCH_METHOD) {

--- a/ext/curl/curl_file.c
+++ b/ext/curl/curl_file.c
@@ -39,14 +39,14 @@ static void curlfile_ctor(INTERNAL_FUNCTION_PARAMETERS)
 		Z_PARAM_STR_OR_NULL(postname)
 	ZEND_PARSE_PARAMETERS_END();
 
-	zend_update_property_string(curl_CURLFile_class, cf, "name", sizeof("name")-1, ZSTR_VAL(fname));
+	zend_update_property_string(curl_CURLFile_class, Z_OBJ_P(cf), "name", sizeof("name")-1, ZSTR_VAL(fname));
 
 	if (mime) {
-		zend_update_property_string(curl_CURLFile_class, cf, "mime", sizeof("mime")-1, ZSTR_VAL(mime));
+		zend_update_property_string(curl_CURLFile_class, Z_OBJ_P(cf), "mime", sizeof("mime")-1, ZSTR_VAL(mime));
 	}
 
 	if (postname) {
-		zend_update_property_string(curl_CURLFile_class, cf, "postname", sizeof("postname")-1, ZSTR_VAL(postname));
+		zend_update_property_string(curl_CURLFile_class, Z_OBJ_P(cf), "postname", sizeof("postname")-1, ZSTR_VAL(postname));
 	}
 }
 
@@ -83,7 +83,7 @@ static void curlfile_set_property(char *name, size_t name_len, INTERNAL_FUNCTION
 		Z_PARAM_STR(arg)
 	ZEND_PARSE_PARAMETERS_END();
 
-	zend_update_property_string(curl_CURLFile_class, ZEND_THIS, name, name_len, ZSTR_VAL(arg));
+	zend_update_property_string(curl_CURLFile_class, Z_OBJ_P(ZEND_THIS), name, name_len, ZSTR_VAL(arg));
 }
 
 /* {{{ Get file name */

--- a/ext/curl/curl_file.c
+++ b/ext/curl/curl_file.c
@@ -71,7 +71,7 @@ static void curlfile_get_property(char *name, size_t name_len, INTERNAL_FUNCTION
 	zval *res, rv;
 
 	ZEND_PARSE_PARAMETERS_NONE();
-	res = zend_read_property(curl_CURLFile_class, ZEND_THIS, name, name_len, 1, &rv);
+	res = zend_read_property(curl_CURLFile_class, Z_OBJ_P(ZEND_THIS), name, name_len, 1, &rv);
 	ZVAL_COPY_DEREF(return_value, res);
 }
 

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2047,7 +2047,7 @@ static inline int build_mime_structure_from_hash(php_curl *ch, zval *zpostfields
 			curl_seek_callback seekfunc = seek_cb;
 #endif
 
-			prop = zend_read_property(curl_CURLFile_class, current, "name", sizeof("name")-1, 0, &rv);
+			prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "name", sizeof("name")-1, 0, &rv);
 			if (Z_TYPE_P(prop) != IS_STRING) {
 				php_error_docref(NULL, E_WARNING, "Invalid filename for key %s", ZSTR_VAL(string_key));
 			} else {
@@ -2057,11 +2057,11 @@ static inline int build_mime_structure_from_hash(php_curl *ch, zval *zpostfields
 					return 1;
 				}
 
-				prop = zend_read_property(curl_CURLFile_class, current, "mime", sizeof("mime")-1, 0, &rv);
+				prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "mime", sizeof("mime")-1, 0, &rv);
 				if (Z_TYPE_P(prop) == IS_STRING && Z_STRLEN_P(prop) > 0) {
 					type = Z_STRVAL_P(prop);
 				}
-				prop = zend_read_property(curl_CURLFile_class, current, "postname", sizeof("postname")-1, 0, &rv);
+				prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "postname", sizeof("postname")-1, 0, &rv);
 				if (Z_TYPE_P(prop) == IS_STRING && Z_STRLEN_P(prop) > 0) {
 					filename = Z_STRVAL_P(prop);
 				}

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1539,11 +1539,8 @@ static int dom_nodelist_has_dimension(zend_object *object, zval *member, int che
 	if (offset < 0) {
 		return 0;
 	} else {
-		zval obj;
-		zval *length;
-
-		ZVAL_OBJ(&obj, object);
-		length = zend_read_property(object->ce, &obj, "length", sizeof("length") - 1, 0, &rv);
+		zval *length = zend_read_property(
+			object->ce, object, "length", sizeof("length") - 1, 0, &rv);
 		return length && offset < Z_LVAL_P(length);
 	}
 } /* }}} end dom_nodelist_has_dimension */

--- a/ext/intl/transliterator/transliterator_class.c
+++ b/ext/intl/transliterator/transliterator_class.c
@@ -54,7 +54,7 @@ int transliterator_object_construct( zval *object,
 	}
 
 	ZVAL_NEW_STR(&tmp, u8str);
-	zend_update_property(Transliterator_ce_ptr, object,
+	zend_update_property(Transliterator_ce_ptr, Z_OBJ_P(object),
 		"id", sizeof( "id" ) - 1, &tmp );
 	GC_DELREF(u8str);
 	return SUCCESS;

--- a/ext/mysqli/mysqli_exception.c
+++ b/ext/mysqli/mysqli_exception.c
@@ -46,20 +46,20 @@ void php_mysqli_throw_sql_exception(char *sqlstate, int errorno, char *format, .
 	object_init_ex(&sql_ex, mysqli_exception_class_entry);
 
 	if (message) {
-		zend_update_property_string(mysqli_exception_class_entry, &sql_ex, "message", sizeof("message") - 1,
-									message);
+		zend_update_property_string(
+			mysqli_exception_class_entry, Z_OBJ(sql_ex), "message", sizeof("message") - 1, message);
 	}
 
 	if (sqlstate) {
-		zend_update_property_string(mysqli_exception_class_entry, &sql_ex, "sqlstate", sizeof("sqlstate") - 1,
-									sqlstate);
+		zend_update_property_string(
+			mysqli_exception_class_entry, Z_OBJ(sql_ex), "sqlstate", sizeof("sqlstate") - 1, sqlstate);
 	} else {
-		zend_update_property_string(mysqli_exception_class_entry, &sql_ex, "sqlstate", sizeof("sqlstate") - 1,
-									"00000");
+		zend_update_property_string(
+			mysqli_exception_class_entry, Z_OBJ(sql_ex), "sqlstate", sizeof("sqlstate") - 1, "00000");
 	}
 
 	efree(message);
-	zend_update_property_long(mysqli_exception_class_entry, &sql_ex, "code", sizeof("code") - 1, errorno);
+	zend_update_property_long(mysqli_exception_class_entry, Z_OBJ(sql_ex), "code", sizeof("code") - 1, errorno);
 
 	zend_throw_exception_object(&sql_ex);
 }

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -77,14 +77,14 @@ void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *sqlstate
 
 		object_init_ex(&ex, pdo_ex);
 
-		zend_update_property_string(def_ex, &ex, "message", sizeof("message")-1, message);
-		zend_update_property_string(def_ex, &ex, "code", sizeof("code")-1, *pdo_err);
+		zend_update_property_string(def_ex, Z_OBJ(ex), "message", sizeof("message")-1, message);
+		zend_update_property_string(def_ex, Z_OBJ(ex), "code", sizeof("code")-1, *pdo_err);
 
 		array_init(&info);
 
 		add_next_index_string(&info, *pdo_err);
 		add_next_index_long(&info, 0);
-		zend_update_property(pdo_ex, &ex, "errorInfo", sizeof("errorInfo")-1, &info);
+		zend_update_property(pdo_ex, Z_OBJ(ex), "errorInfo", sizeof("errorInfo")-1, &info);
 		zval_ptr_dtor(&info);
 
 		zend_throw_exception_object(&ex);
@@ -152,11 +152,11 @@ PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt) /* {{{ */
 
 		object_init_ex(&ex, pdo_ex);
 
-		zend_update_property_str(def_ex, &ex, "message", sizeof("message") - 1, message);
-		zend_update_property_string(def_ex, &ex, "code", sizeof("code") - 1, *pdo_err);
+		zend_update_property_str(def_ex, Z_OBJ(ex), "message", sizeof("message") - 1, message);
+		zend_update_property_string(def_ex, Z_OBJ(ex), "code", sizeof("code") - 1, *pdo_err);
 
 		if (!Z_ISUNDEF(info)) {
-			zend_update_property(pdo_ex, &ex, "errorInfo", sizeof("errorInfo") - 1, &info);
+			zend_update_property(pdo_ex, Z_OBJ(ex), "errorInfo", sizeof("errorInfo") - 1, &info);
 		}
 
 		zend_throw_exception_object(&ex);

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -997,7 +997,7 @@ static int do_fetch(pdo_stmt_t *stmt, int do_bind, zval *return_value, enum pdo_
 
 				case PDO_FETCH_OBJ:
 				case PDO_FETCH_INTO:
-					zend_update_property_ex(NULL, return_value,
+					zend_update_property_ex(NULL, Z_OBJ_P(return_value),
 						stmt->columns[i].name,
 						&val);
 					zval_ptr_dtor(&val);
@@ -1005,7 +1005,7 @@ static int do_fetch(pdo_stmt_t *stmt, int do_bind, zval *return_value, enum pdo_
 
 				case PDO_FETCH_CLASS:
 					if ((flags & PDO_FETCH_SERIALIZE) == 0 || idx) {
-						zend_update_property_ex(ce, return_value,
+						zend_update_property_ex(ce, Z_OBJ_P(return_value),
 							stmt->columns[i].name,
 							&val);
 						zval_ptr_dtor(&val);

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -5316,7 +5316,7 @@ ZEND_METHOD(ReflectionProperty, getValue)
 			RETURN_THROWS();
 		}
 
-		member_p = zend_read_property_ex(intern->ce, object, ref->unmangled_name, 0, &rv);
+		member_p = zend_read_property_ex(intern->ce, Z_OBJ_P(object), ref->unmangled_name, 0, &rv);
 		if (member_p != &rv) {
 			ZVAL_COPY_DEREF(return_value, member_p);
 		} else {

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -5360,7 +5360,7 @@ ZEND_METHOD(ReflectionProperty, setValue)
 			RETURN_THROWS();
 		}
 
-		zend_update_property_ex(intern->ce, object, ref->unmangled_name, value);
+		zend_update_property_ex(intern->ce, Z_OBJ_P(object), ref->unmangled_name, value);
 	}
 }
 /* }}} */

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -1170,7 +1170,7 @@ static void set_zval_property(zval* object, char* name, zval* val)
 static zval* get_zval_property(zval* object, char* name, zval *rv)
 {
 	if (Z_TYPE_P(object) == IS_OBJECT) {
-		zval *data = zend_read_property(Z_OBJCE_P(object), object, name, strlen(name), 1, rv);
+		zval *data = zend_read_property(Z_OBJCE_P(object), Z_OBJ_P(object), name, strlen(name), 1, rv);
 		if (data == &EG(uninitialized_zval)) {
 			return NULL;
 		}

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -1163,7 +1163,7 @@ static xmlNodePtr to_xml_null(encodeTypePtr type, zval *data, int style, xmlNode
 
 static void set_zval_property(zval* object, char* name, zval* val)
 {
-	zend_update_property(Z_OBJCE_P(object), object, name, strlen(name), val);
+	zend_update_property(Z_OBJCE_P(object), Z_OBJ_P(object), name, strlen(name), val);
 	Z_TRY_DELREF_P(val);
 }
 

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -1185,7 +1185,7 @@ static zval* get_zval_property(zval* object, char* name, zval *rv)
 static void unset_zval_property(zval* object, char* name)
 {
 	if (Z_TYPE_P(object) == IS_OBJECT) {
-		zend_unset_property(Z_OBJCE_P(object), object, name, strlen(name));
+		zend_unset_property(Z_OBJCE_P(object), Z_OBJ_P(object), name, strlen(name));
 	} else if (Z_TYPE_P(object) == IS_ARRAY) {
 		zend_hash_str_del(Z_ARRVAL_P(object), name, strlen(name));
 	}

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -643,10 +643,10 @@ PHP_METHOD(SoapFault, __toString)
 	}
 
 	this_ptr = ZEND_THIS;
-	faultcode   = zend_read_property(soap_fault_class_entry, this_ptr, "faultcode", sizeof("faultcode")-1, 1, &rv1);
-	faultstring = zend_read_property(soap_fault_class_entry, this_ptr, "faultstring", sizeof("faultstring")-1, 1, &rv2);
-	file = zend_read_property(soap_fault_class_entry, this_ptr, "file", sizeof("file")-1, 1, &rv3);
-	line = zend_read_property(soap_fault_class_entry, this_ptr, "line", sizeof("line")-1, 1, &rv4);
+	faultcode = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "faultcode", sizeof("faultcode")-1, 1, &rv1);
+	faultstring = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "faultstring", sizeof("faultstring")-1, 1, &rv2);
+	file = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "file", sizeof("file")-1, 1, &rv3);
+	line = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "line", sizeof("line")-1, 1, &rv4);
 
 	zend_call_method_with_0_params(
 		Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), NULL, "gettraceasstring", &trace);
@@ -1176,7 +1176,7 @@ static void _soap_server_exception(soapServicePtr service, sdlFunctionPtr functi
 	} else if (instanceof_function(Z_OBJCE(exception_object), zend_ce_error)) {
 		if (service->send_errors) {
 			zval rv;
-			zend_string *msg = zval_get_string(zend_read_property(zend_ce_error, &exception_object, "message", sizeof("message")-1, 0, &rv));
+			zend_string *msg = zval_get_string(zend_read_property(zend_ce_error, Z_OBJ(exception_object), "message", sizeof("message")-1, 0, &rv));
 			add_soap_fault_ex(&exception_object, this_ptr, "Server", ZSTR_VAL(msg), NULL, NULL);
 			zend_string_release_ex(msg, 0);
 		} else {
@@ -2241,7 +2241,7 @@ static int do_request(zval *this_ptr, xmlDoc *request, char *location, char *act
 				zval exception_object;
 
 				ZVAL_OBJ(&exception_object, EG(exception));
-				msg = zval_get_string(zend_read_property(zend_ce_error, &exception_object, "message", sizeof("message")-1, 0, &rv));
+				msg = zval_get_string(zend_read_property(zend_ce_error, Z_OBJ(exception_object), "message", sizeof("message")-1, 0, &rv));
 				/* change class */
 				EG(exception)->ce = soap_fault_class_entry;
 				set_soap_fault(&exception_object, NULL, "Client", ZSTR_VAL(msg), NULL, NULL, NULL);

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -2941,7 +2941,7 @@ static void set_soap_fault(zval *obj, char *fault_code_ns, char *fault_code, cha
 	}
 
 	add_property_string(obj, "faultstring", fault_string ? fault_string : "");
-	zend_update_property_string(zend_ce_exception, obj, "message", sizeof("message")-1, (fault_string ? fault_string : ""));
+	zend_update_property_string(zend_ce_exception, Z_OBJ_P(obj), "message", sizeof("message")-1, (fault_string ? fault_string : ""));
 
 	if (fault_code != NULL) {
 		int soap_version = SOAP_GLOBAL(soap_version);

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -99,7 +99,7 @@ static void sodium_remove_param_values_from_backtrace(zend_object *obj) {
 	zval obj_zv, rv, *trace;
 
 	ZVAL_OBJ(&obj_zv, obj);
-	trace = zend_read_property(zend_get_exception_base(&obj_zv), &obj_zv, "trace", sizeof("trace")-1, 0, &rv);
+	trace = zend_read_property(zend_get_exception_base(&obj_zv), Z_OBJ(obj_zv), "trace", sizeof("trace")-1, 0, &rv);
 	if (trace && Z_TYPE_P(trace) == IS_ARRAY) {
 		zval *frame;
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(trace), frame) {

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -96,10 +96,8 @@ ZEND_GET_MODULE(sodium)
 
 /* Remove argument information from backtrace to prevent information leaks */
 static void sodium_remove_param_values_from_backtrace(zend_object *obj) {
-	zval obj_zv, rv, *trace;
-
-	ZVAL_OBJ(&obj_zv, obj);
-	trace = zend_read_property(zend_get_exception_base(&obj_zv), Z_OBJ(obj_zv), "trace", sizeof("trace")-1, 0, &rv);
+	zval rv;
+	zval *trace = zend_read_property(zend_get_exception_base(obj), obj, "trace", sizeof("trace")-1, 0, &rv);
 	if (trace && Z_TYPE_P(trace) == IS_ARRAY) {
 		zval *frame;
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(trace), frame) {

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1863,7 +1863,7 @@ PHP_METHOD(RegexIterator, accept)
 			break;
 
 		case REGIT_MODE_REPLACE: {
-			zval *replacement = zend_read_property(intern->std.ce, ZEND_THIS, "replacement", sizeof("replacement")-1, 1, &rv);
+			zval *replacement = zend_read_property(intern->std.ce, Z_OBJ_P(ZEND_THIS), "replacement", sizeof("replacement")-1, 1, &rv);
 			zend_string *replacement_str = zval_try_get_string(replacement);
 			if (UNEXPECTED(!replacement_str)) {
 				return;

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1067,12 +1067,10 @@ static int do_cli(int argc, char **argv) /* {{{ */
 						pce->constructor, Z_OBJ(ref), NULL, &arg);
 
 					if (EG(exception)) {
-						zval tmp, *msg, rv;
-
-						ZVAL_OBJ(&tmp, EG(exception));
-						msg = zend_read_property(zend_ce_exception, &tmp, "message", sizeof("message")-1, 0, &rv);
+						zval rv;
+						zval *msg = zend_read_property(zend_ce_exception, EG(exception), "message", sizeof("message")-1, 0, &rv);
 						zend_printf("Exception: %s\n", Z_STRVAL_P(msg));
-						zval_ptr_dtor(&tmp);
+						zend_object_release(EG(exception));
 						EG(exception) = NULL;
 					} else {
 						zend_print_zval(&ref, 0);

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -720,11 +720,10 @@ static inline void phpdbg_handle_exception(void) /* {{{ */
 	zend_object *ex = EG(exception);
 	zend_string *msg, *file;
 	zend_long line;
-	zval zv, rv, tmp;
+	zval rv, tmp;
 
 	EG(exception) = NULL;
 
-	ZVAL_OBJ(&zv, ex);
 	zend_call_known_instance_method_with_0_params(ex->ce->__tostring, ex, &tmp);
 	file = zval_get_string(zend_read_property(zend_get_exception_base(ex), ex, ZEND_STRL("file"), 1, &rv));
 	line = zval_get_long(zend_read_property(zend_get_exception_base(ex), ex, ZEND_STRL("line"), 1, &rv));
@@ -733,7 +732,7 @@ static inline void phpdbg_handle_exception(void) /* {{{ */
 		EG(exception) = NULL;
 		msg = ZSTR_EMPTY_ALLOC();
 	} else {
-		zend_update_property_string(zend_get_exception_base(ex), &zv, ZEND_STRL("string"), Z_STRVAL(tmp));
+		zend_update_property_string(zend_get_exception_base(ex), ex, ZEND_STRL("string"), Z_STRVAL(tmp));
 		zval_ptr_dtor(&tmp);
 		msg = zval_get_string(zend_read_property(zend_get_exception_base(ex), ex, ZEND_STRL("string"), 1, &rv));
 	}

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -726,16 +726,16 @@ static inline void phpdbg_handle_exception(void) /* {{{ */
 
 	ZVAL_OBJ(&zv, ex);
 	zend_call_known_instance_method_with_0_params(ex->ce->__tostring, ex, &tmp);
-	file = zval_get_string(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("file"), 1, &rv));
-	line = zval_get_long(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("line"), 1, &rv));
+	file = zval_get_string(zend_read_property(zend_get_exception_base(ex), ex, ZEND_STRL("file"), 1, &rv));
+	line = zval_get_long(zend_read_property(zend_get_exception_base(ex), ex, ZEND_STRL("line"), 1, &rv));
 
 	if (EG(exception)) {
 		EG(exception) = NULL;
 		msg = ZSTR_EMPTY_ALLOC();
 	} else {
-		zend_update_property_string(zend_get_exception_base(&zv), &zv, ZEND_STRL("string"), Z_STRVAL(tmp));
+		zend_update_property_string(zend_get_exception_base(ex), &zv, ZEND_STRL("string"), Z_STRVAL(tmp));
 		zval_ptr_dtor(&tmp);
-		msg = zval_get_string(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("string"), 1, &rv));
+		msg = zval_get_string(zend_read_property(zend_get_exception_base(ex), ex, ZEND_STRL("string"), 1, &rv));
 	}
 
 	phpdbg_error("exception", "name=\"%s\" file=\"%s\" line=\"" ZEND_LONG_FMT "\"", "Uncaught %s in %s on line " ZEND_LONG_FMT, ZSTR_VAL(ex->ce->name), ZSTR_VAL(file), line);
@@ -1721,9 +1721,6 @@ void phpdbg_execute_ex(zend_execute_data *execute_data) /* {{{ */
 		/* check for uncaught exceptions */
 		if (exception && PHPDBG_G(handled_exception) != exception && !(PHPDBG_G(flags) & PHPDBG_IN_EVAL)) {
 			zend_execute_data *prev_ex = execute_data;
-			zval zv, rv;
-			zend_string *file, *msg;
-			zend_long line;
 
 			do {
 				prev_ex = zend_generator_check_placeholder_frame(prev_ex);
@@ -1739,10 +1736,10 @@ void phpdbg_execute_ex(zend_execute_data *execute_data) /* {{{ */
 
 			PHPDBG_G(handled_exception) = exception;
 
-			ZVAL_OBJ(&zv, exception);
-			file = zval_get_string(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("file"), 1, &rv));
-			line = zval_get_long(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("line"), 1, &rv));
-			msg = zval_get_string(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("message"), 1, &rv));
+			zval rv;
+			zend_string *file = zval_get_string(zend_read_property(zend_get_exception_base(exception), exception, ZEND_STRL("file"), 1, &rv));
+			zend_long line = zval_get_long(zend_read_property(zend_get_exception_base(exception), exception, ZEND_STRL("line"), 1, &rv));
+			zend_string *msg = zval_get_string(zend_read_property(zend_get_exception_base(exception), exception, ZEND_STRL("message"), 1, &rv));
 
 			phpdbg_error("exception",
 				"name=\"%s\" file=\"%s\" line=\"" ZEND_LONG_FMT "\"",

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -726,8 +726,8 @@ static inline void phpdbg_handle_exception(void) /* {{{ */
 
 	ZVAL_OBJ(&zv, ex);
 	zend_call_known_instance_method_with_0_params(ex->ce->__tostring, ex, &tmp);
-	file = zval_get_string(zend_read_property(zend_get_exception_base(&zv), &zv, ZEND_STRL("file"), 1, &rv));
-	line = zval_get_long(zend_read_property(zend_get_exception_base(&zv), &zv, ZEND_STRL("line"), 1, &rv));
+	file = zval_get_string(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("file"), 1, &rv));
+	line = zval_get_long(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("line"), 1, &rv));
 
 	if (EG(exception)) {
 		EG(exception) = NULL;
@@ -735,7 +735,7 @@ static inline void phpdbg_handle_exception(void) /* {{{ */
 	} else {
 		zend_update_property_string(zend_get_exception_base(&zv), &zv, ZEND_STRL("string"), Z_STRVAL(tmp));
 		zval_ptr_dtor(&tmp);
-		msg = zval_get_string(zend_read_property(zend_get_exception_base(&zv), &zv, ZEND_STRL("string"), 1, &rv));
+		msg = zval_get_string(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("string"), 1, &rv));
 	}
 
 	phpdbg_error("exception", "name=\"%s\" file=\"%s\" line=\"" ZEND_LONG_FMT "\"", "Uncaught %s in %s on line " ZEND_LONG_FMT, ZSTR_VAL(ex->ce->name), ZSTR_VAL(file), line);
@@ -1740,9 +1740,9 @@ void phpdbg_execute_ex(zend_execute_data *execute_data) /* {{{ */
 			PHPDBG_G(handled_exception) = exception;
 
 			ZVAL_OBJ(&zv, exception);
-			file = zval_get_string(zend_read_property(zend_get_exception_base(&zv), &zv, ZEND_STRL("file"), 1, &rv));
-			line = zval_get_long(zend_read_property(zend_get_exception_base(&zv), &zv, ZEND_STRL("line"), 1, &rv));
-			msg = zval_get_string(zend_read_property(zend_get_exception_base(&zv), &zv, ZEND_STRL("message"), 1, &rv));
+			file = zval_get_string(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("file"), 1, &rv));
+			line = zval_get_long(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("line"), 1, &rv));
+			msg = zval_get_string(zend_read_property(zend_get_exception_base(&zv), Z_OBJ(zv), ZEND_STRL("message"), 1, &rv));
 
 			phpdbg_error("exception",
 				"name=\"%s\" file=\"%s\" line=\"" ZEND_LONG_FMT "\"",


### PR DESCRIPTION
As pointed out by @derickr, the current state of property APIs in PHP 8 is inconsistent. We've migrated large parts of the object-related API to accept `zend_object*` instead of `zval*`. However, the `zend_*_property()` family of functions still accepts zvals. This leaves us in an odd situation where the `read_property()` object handler accepts `zend_object*`, while the `zend_read_property` function accepts `zval*`. This is inconsistent and causes friction in places where such APIs interact, because it may be necessary to create dummy zval wrappers.

This patch changes the `zend_*_property` family of functions to require `zend_object*` as well, in line with underlying APIs.