### PR TITLE
Flesh out HashTable insertion APIs

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1531,6 +1531,33 @@ ZEND_API void add_assoc_stringl_ex(zval *arg, const char *key, size_t key_len, c
 }
 /* }}} */
 
+ZEND_API void add_assoc_array_ex(zval *arg, const char *key, size_t key_len, zend_array *arr) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_ARR(&tmp, arr);
+	zend_symtable_str_update(Z_ARRVAL_P(arg), key, key_len, &tmp);
+}
+/* }}} */
+
+ZEND_API void add_assoc_object_ex(zval *arg, const char *key, size_t key_len, zend_object *obj) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_OBJ(&tmp, obj);
+	zend_symtable_str_update(Z_ARRVAL_P(arg), key, key_len, &tmp);
+}
+/* }}} */
+
+ZEND_API void add_assoc_reference_ex(zval *arg, const char *key, size_t key_len, zend_reference *ref) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_REF(&tmp, ref);
+	zend_symtable_str_update(Z_ARRVAL_P(arg), key, key_len, &tmp);
+}
+/* }}} */
+
 ZEND_API void add_assoc_zval_ex(zval *arg, const char *key, size_t key_len, zval *value) /* {{{ */
 {
 	zend_symtable_str_update(Z_ARRVAL_P(arg), key, key_len, value);
@@ -1609,6 +1636,33 @@ ZEND_API void add_index_stringl(zval *arg, zend_ulong index, const char *str, si
 }
 /* }}} */
 
+ZEND_API void add_index_array(zval *arg, zend_ulong index, zend_array *arr) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_ARR(&tmp, arr);
+	zend_hash_index_update(Z_ARRVAL_P(arg), index, &tmp);
+}
+/* }}} */
+
+ZEND_API void add_index_object(zval *arg, zend_ulong index, zend_object *obj) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_OBJ(&tmp, obj);
+	zend_hash_index_update(Z_ARRVAL_P(arg), index, &tmp);
+}
+/* }}} */
+
+ZEND_API void add_index_reference(zval *arg, zend_ulong index, zend_reference *ref) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_REF(&tmp, ref);
+	zend_hash_index_update(Z_ARRVAL_P(arg), index, &tmp);
+}
+/* }}} */
+
 ZEND_API zend_result add_next_index_long(zval *arg, zend_long n) /* {{{ */
 {
 	zval tmp;
@@ -1677,6 +1731,33 @@ ZEND_API zend_result add_next_index_stringl(zval *arg, const char *str, size_t l
 	zval tmp;
 
 	ZVAL_STRINGL(&tmp, str, length);
+	return zend_hash_next_index_insert(Z_ARRVAL_P(arg), &tmp) ? SUCCESS : FAILURE;
+}
+/* }}} */
+
+ZEND_API zend_result add_next_index_array(zval *arg, zend_array *arr) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_ARR(&tmp, arr);
+	return zend_hash_next_index_insert(Z_ARRVAL_P(arg), &tmp) ? SUCCESS : FAILURE;
+}
+/* }}} */
+
+ZEND_API zend_result add_next_index_object(zval *arg, zend_object *obj) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_OBJ(&tmp, obj);
+	return zend_hash_next_index_insert(Z_ARRVAL_P(arg), &tmp) ? SUCCESS : FAILURE;
+}
+/* }}} */
+
+ZEND_API zend_result add_next_index_reference(zval *arg, zend_reference *ref) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_REF(&tmp, ref);
 	return zend_hash_next_index_insert(Z_ARRVAL_P(arg), &tmp) ? SUCCESS : FAILURE;
 }
 /* }}} */
@@ -1793,6 +1874,36 @@ ZEND_API void add_property_stringl_ex(zval *arg, const char *key, size_t key_len
 	zval tmp;
 
 	ZVAL_STRINGL(&tmp, str, length);
+	add_property_zval_ex(arg, key, key_len, &tmp);
+	zval_ptr_dtor(&tmp); /* write_property will add 1 to refcount */
+}
+/* }}} */
+
+ZEND_API void add_property_array_ex(zval *arg, const char *key, size_t key_len, zend_array *arr) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_ARR(&tmp, arr);
+	add_property_zval_ex(arg, key, key_len, &tmp);
+	zval_ptr_dtor(&tmp); /* write_property will add 1 to refcount */
+}
+/* }}} */
+
+ZEND_API void add_property_object_ex(zval *arg, const char *key, size_t key_len, zend_object *obj) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_OBJ(&tmp, obj);
+	add_property_zval_ex(arg, key, key_len, &tmp);
+	zval_ptr_dtor(&tmp); /* write_property will add 1 to refcount */
+}
+/* }}} */
+
+ZEND_API void add_property_reference_ex(zval *arg, const char *key, size_t key_len, zend_reference *ref) /* {{{ */
+{
+	zval tmp;
+
+	ZVAL_REF(&tmp, ref);
 	add_property_zval_ex(arg, key, key_len, &tmp);
 	zval_ptr_dtor(&tmp); /* write_property will add 1 to refcount */
 }

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -442,6 +442,9 @@ ZEND_API void add_assoc_double_ex(zval *arg, const char *key, size_t key_len, do
 ZEND_API void add_assoc_str_ex(zval *arg, const char *key, size_t key_len, zend_string *str);
 ZEND_API void add_assoc_string_ex(zval *arg, const char *key, size_t key_len, const char *str);
 ZEND_API void add_assoc_stringl_ex(zval *arg, const char *key, size_t key_len, const char *str, size_t length);
+ZEND_API void add_assoc_array_ex(zval *arg, const char *key, size_t key_len, zend_array *arr);
+ZEND_API void add_assoc_object_ex(zval *arg, const char *key, size_t key_len, zend_object *obj);
+ZEND_API void add_assoc_reference_ex(zval *arg, const char *key, size_t key_len, zend_reference *ref);
 ZEND_API void add_assoc_zval_ex(zval *arg, const char *key, size_t key_len, zval *value);
 
 #define add_assoc_long(__arg, __key, __n) add_assoc_long_ex(__arg, __key, strlen(__key), __n)
@@ -452,6 +455,9 @@ ZEND_API void add_assoc_zval_ex(zval *arg, const char *key, size_t key_len, zval
 #define add_assoc_str(__arg, __key, __str) add_assoc_str_ex(__arg, __key, strlen(__key), __str)
 #define add_assoc_string(__arg, __key, __str) add_assoc_string_ex(__arg, __key, strlen(__key), __str)
 #define add_assoc_stringl(__arg, __key, __str, __length) add_assoc_stringl_ex(__arg, __key, strlen(__key), __str, __length)
+#define add_assoc_array(__arg, __key, __arr) add_assoc_array_ex(__arg, __key, strlen(__key), __arr)
+#define add_assoc_object(__arg, __key, __obj) add_assoc_object_ex(__arg, __key, strlen(__key), __obj)
+#define add_assoc_reference(__arg, __key, __ref) add_assoc_object_ex(__arg, __key, strlen(__key), __ref)
 #define add_assoc_zval(__arg, __key, __value) add_assoc_zval_ex(__arg, __key, strlen(__key), __value)
 
 ZEND_API void add_index_long(zval *arg, zend_ulong index, zend_long n);
@@ -462,6 +468,9 @@ ZEND_API void add_index_double(zval *arg, zend_ulong index, double d);
 ZEND_API void add_index_str(zval *arg, zend_ulong index, zend_string *str);
 ZEND_API void add_index_string(zval *arg, zend_ulong index, const char *str);
 ZEND_API void add_index_stringl(zval *arg, zend_ulong index, const char *str, size_t length);
+ZEND_API void add_index_array(zval *arg, zend_ulong index, zend_array *arr);
+ZEND_API void add_index_object(zval *arg, zend_ulong index, zend_object *obj);
+ZEND_API void add_index_reference(zval *arg, zend_ulong index, zend_reference *ref);
 
 static zend_always_inline zend_result add_index_zval(zval *arg, zend_ulong index, zval *value)
 {
@@ -476,6 +485,9 @@ ZEND_API zend_result add_next_index_double(zval *arg, double d);
 ZEND_API zend_result add_next_index_str(zval *arg, zend_string *str);
 ZEND_API zend_result add_next_index_string(zval *arg, const char *str);
 ZEND_API zend_result add_next_index_stringl(zval *arg, const char *str, size_t length);
+ZEND_API zend_result add_next_index_array(zval *arg, zend_array *arr);
+ZEND_API zend_result add_next_index_object(zval *arg, zend_object *obj);
+ZEND_API zend_result add_next_index_reference(zval *arg, zend_reference *ref);
 
 static zend_always_inline zend_result add_next_index_zval(zval *arg, zval *value)
 {
@@ -492,6 +504,9 @@ ZEND_API void add_property_double_ex(zval *arg, const char *key, size_t key_len,
 ZEND_API void add_property_str_ex(zval *arg, const char *key, size_t key_len, zend_string *str);
 ZEND_API void add_property_string_ex(zval *arg, const char *key, size_t key_len, const char *str);
 ZEND_API void add_property_stringl_ex(zval *arg, const char *key, size_t key_len,  const char *str, size_t length);
+ZEND_API void add_property_array_ex(zval *arg, const char *key, size_t key_len, zend_array *arr);
+ZEND_API void add_property_object_ex(zval *arg, const char *key, size_t key_len, zend_object *obj);
+ZEND_API void add_property_reference_ex(zval *arg, const char *key, size_t key_len, zend_reference *ref);
 ZEND_API void add_property_zval_ex(zval *arg, const char *key, size_t key_len, zval *value);
 
 #define add_property_long(__arg, __key, __n) add_property_long_ex(__arg, __key, strlen(__key), __n)
@@ -502,6 +517,9 @@ ZEND_API void add_property_zval_ex(zval *arg, const char *key, size_t key_len, z
 #define add_property_str(__arg, __key, __str) add_property_str_ex(__arg, __key, strlen(__key), __str)
 #define add_property_string(__arg, __key, __str) add_property_string_ex(__arg, __key, strlen(__key), __str)
 #define add_property_stringl(__arg, __key, __str, __length) add_property_stringl_ex(__arg, __key, strlen(__key), __str, __length)
+#define add_property_array(__arg, __key, __arr) add_property_array_ex(__arg, __key, strlen(__key), __arr)
+#define add_property_object(__arg, __key, __obj) add_property_object_ex(__arg, __key, strlen(__key), __obj)
+#define add_property_reference(__arg, __key, __ref) add_property_reference_ex(__arg, __key, strlen(__key), __ref)
 #define add_property_zval(__arg, __key, __value) add_property_zval_ex(__arg, __key, strlen(__key), __value)
 
 

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -402,12 +402,12 @@ static HashTable *zend_weakmap_get_properties_for(zend_object *object, zend_prop
 	zend_ulong obj_addr;
 	zval *val;
 	ZEND_HASH_FOREACH_NUM_KEY_VAL(&wm->ht, obj_addr, val) {
+		zend_object *obj = (zend_object*)obj_addr;
 		zval pair;
-		zval obj_zv;
 		array_init(&pair);
 
-		ZVAL_OBJ_COPY(&obj_zv, (zend_object *) obj_addr);
-		add_assoc_zval(&pair, "key", &obj_zv);
+		GC_ADDREF(obj);
+		add_assoc_object(&pair, "key", obj);
 		Z_TRY_ADDREF_P(val);
 		add_assoc_zval(&pair, "value", val);
 

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -175,8 +175,8 @@ static void mail_close_it(zend_resource *rsrc)
 }
 /* }}} */
 
-/* {{{ add_assoc_object */
-static zval *add_assoc_object(zval *arg, char *key, zval *tmp)
+/* {{{ php_imap_hash_add_object */
+static zval *php_imap_hash_add_object(zval *arg, char *key, zval *tmp)
 {
 	HashTable *symtable;
 
@@ -189,8 +189,8 @@ static zval *add_assoc_object(zval *arg, char *key, zval *tmp)
 }
 /* }}} */
 
-/* {{{ add_next_index_object */
-static inline zval *add_next_index_object(zval *arg, zval *tmp)
+/* {{{ php_imap_list_add_object */
+static inline zval *php_imap_list_add_object(zval *arg, zval *tmp)
 {
 	HashTable *symtable;
 
@@ -1513,7 +1513,7 @@ PHP_FUNCTION(imap_getmailboxes)
 #else
 		add_property_string(&mboxob, "delimiter", cur->delimiter);
 #endif
-		add_next_index_object(return_value, &mboxob);
+		php_imap_list_add_object(return_value, &mboxob);
 		cur=cur->next;
 	}
 	mail_free_foblist(&IMAPG(imap_folder_objects), &IMAPG(imap_folder_objects_tail));
@@ -1820,7 +1820,7 @@ PHP_FUNCTION(imap_getsubscribed)
 #else
 		add_property_string(&mboxob, "delimiter", cur->delimiter);
 #endif
-		add_next_index_object(return_value, &mboxob);
+		php_imap_list_add_object(return_value, &mboxob);
 		cur=cur->next;
 	}
 	mail_free_foblist (&IMAPG(imap_sfolder_objects), &IMAPG(imap_sfolder_objects_tail));
@@ -2294,7 +2294,7 @@ PHP_FUNCTION(imap_rfc822_parse_adrlist)
 		if (addresstmp->adl) {
 			add_property_string(&tovals, "adl", addresstmp->adl);
 		}
-		add_next_index_object(return_value, &tovals);
+		php_imap_list_add_object(return_value, &tovals);
 	} while ((addresstmp = addresstmp->next));
 
 	mail_free_envelope(&env);
@@ -2974,9 +2974,9 @@ PHP_FUNCTION(imap_bodystruct)
 			object_init(&dparam);
 			add_property_string(&dparam, "attribute", dpar->attribute);
 			add_property_string(&dparam, "value", dpar->value);
-			add_next_index_object(&dparametres, &dparam);
+			php_imap_list_add_object(&dparametres, &dparam);
 		} while ((dpar = dpar->next));
-		add_assoc_object(return_value, "dparameters", &dparametres);
+		php_imap_hash_add_object(return_value, "dparameters", &dparametres);
 	} else {
 		add_property_long(return_value, "ifdparameters", 0);
 	}
@@ -2995,13 +2995,13 @@ PHP_FUNCTION(imap_bodystruct)
 				add_property_string(&param, "value", par->value);
 			}
 
-			add_next_index_object(&parametres, &param);
+			php_imap_list_add_object(&parametres, &param);
 		} while ((par = par->next));
 	} else {
 		object_init(&parametres);
 		add_property_long(return_value, "ifparameters", 0);
 	}
-	add_assoc_object(return_value, "parameters", &parametres);
+	php_imap_hash_add_object(return_value, "parameters", &parametres);
 }
 
 /* }}} */
@@ -3083,7 +3083,7 @@ PHP_FUNCTION(imap_fetch_overview)
 				add_property_long(&myoverview, "seen", elt->seen);
 				add_property_long(&myoverview, "draft", elt->draft);
 				add_property_long(&myoverview, "udate", mail_longdate(elt));
-				add_next_index_object(return_value, &myoverview);
+				php_imap_list_add_object(return_value, &myoverview);
 			}
 		}
 	}
@@ -4068,7 +4068,7 @@ static zend_string* _php_imap_parse_address (ADDRESS *addresslist, zval *paddres
 		if (addresstmp->adl) add_property_string(&tmpvals, "adl", addresstmp->adl);
 		if (addresstmp->mailbox) add_property_string(&tmpvals, "mailbox", addresstmp->mailbox);
 		if (addresstmp->host) add_property_string(&tmpvals, "host", addresstmp->host);
-		add_next_index_object(paddress, &tmpvals);
+		php_imap_list_add_object(paddress, &tmpvals);
 	} while ((addresstmp = addresstmp->next));
 	return fulladdress;
 }
@@ -4099,7 +4099,7 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		if (fulladdress) {
 			add_property_str(myzvalue, "toaddress", fulladdress);
 		}
-		add_assoc_object(myzvalue, "to", &paddress);
+		php_imap_hash_add_object(myzvalue, "to", &paddress);
 	}
 
 	if (en->from) {
@@ -4108,7 +4108,7 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		if (fulladdress) {
 			add_property_str(myzvalue, "fromaddress", fulladdress);
 		}
-		add_assoc_object(myzvalue, "from", &paddress);
+		php_imap_hash_add_object(myzvalue, "from", &paddress);
 	}
 
 	if (en->cc) {
@@ -4117,7 +4117,7 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		if (fulladdress) {
 			add_property_str(myzvalue, "ccaddress", fulladdress);
 		}
-		add_assoc_object(myzvalue, "cc", &paddress);
+		php_imap_hash_add_object(myzvalue, "cc", &paddress);
 	}
 
 	if (en->bcc) {
@@ -4126,7 +4126,7 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		if (fulladdress) {
 			add_property_str(myzvalue, "bccaddress", fulladdress);
 		}
-		add_assoc_object(myzvalue, "bcc", &paddress);
+		php_imap_hash_add_object(myzvalue, "bcc", &paddress);
 	}
 
 	if (en->reply_to) {
@@ -4135,7 +4135,7 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		if (fulladdress) {
 			add_property_str(myzvalue, "reply_toaddress", fulladdress);
 		}
-		add_assoc_object(myzvalue, "reply_to", &paddress);
+		php_imap_hash_add_object(myzvalue, "reply_to", &paddress);
 	}
 
 	if (en->sender) {
@@ -4144,7 +4144,7 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		if (fulladdress) {
 			add_property_str(myzvalue, "senderaddress", fulladdress);
 		}
-		add_assoc_object(myzvalue, "sender", &paddress);
+		php_imap_hash_add_object(myzvalue, "sender", &paddress);
 	}
 
 	if (en->return_path) {
@@ -4153,7 +4153,7 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		if (fulladdress) {
 			add_property_str(myzvalue, "return_pathaddress", fulladdress);
 		}
-		add_assoc_object(myzvalue, "return_path", &paddress);
+		php_imap_hash_add_object(myzvalue, "return_path", &paddress);
 	}
 }
 /* }}} */
@@ -4218,9 +4218,9 @@ void _php_imap_add_body(zval *arg, BODY *body)
 			object_init(&dparam);
 			add_property_string(&dparam, "attribute", dpar->attribute);
 			add_property_string(&dparam, "value", dpar->value);
-			add_next_index_object(&dparametres, &dparam);
+			php_imap_list_add_object(&dparametres, &dparam);
 		} while ((dpar = dpar->next));
-		add_assoc_object(arg, "dparameters", &dparametres);
+		php_imap_hash_add_object(arg, "dparameters", &dparametres);
 	} else {
 		add_property_long(arg, "ifdparameters", 0);
 	}
@@ -4239,13 +4239,13 @@ void _php_imap_add_body(zval *arg, BODY *body)
 				add_property_string(&param, "value", par->value);
 			}
 
-			add_next_index_object(&parametres, &param);
+			php_imap_list_add_object(&parametres, &param);
 		} while ((par = par->next));
 	} else {
 		object_init(&parametres);
 		add_property_long(arg, "ifparameters", 0);
 	}
-	add_assoc_object(arg, "parameters", &parametres);
+	php_imap_hash_add_object(arg, "parameters", &parametres);
 
 	/* multipart message ? */
 	if (body->type == TYPEMULTIPART) {
@@ -4253,9 +4253,9 @@ void _php_imap_add_body(zval *arg, BODY *body)
 		for (part = body->CONTENT_PART; part; part = part->next) {
 			object_init(&param);
 			_php_imap_add_body(&param, &part->body);
-			add_next_index_object(&parametres, &param);
+			php_imap_list_add_object(&parametres, &param);
 		}
-		add_assoc_object(arg, "parts", &parametres);
+		php_imap_hash_add_object(arg, "parts", &parametres);
 	}
 
 	/* encapsulated message ? */
@@ -4264,8 +4264,8 @@ void _php_imap_add_body(zval *arg, BODY *body)
 		array_init(&parametres);
 		object_init(&param);
 		_php_imap_add_body(&param, body);
-		add_next_index_object(&parametres, &param);
-		add_assoc_object(arg, "parts", &parametres);
+		php_imap_list_add_object(&parametres, &param);
+		php_imap_hash_add_object(arg, "parts", &parametres);
 	}
 }
 /* }}} */

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -604,17 +604,15 @@ PHP_FUNCTION(spl_autoload_functions)
 	if (SPL_G(autoload_functions)) {
 		ZEND_HASH_FOREACH_PTR(SPL_G(autoload_functions), alfi) {
 			if (alfi->closure) {
-				zval obj_zv;
-				ZVAL_OBJ_COPY(&obj_zv, alfi->closure);
-				add_next_index_zval(return_value, &obj_zv);
+				GC_ADDREF(alfi->closure);
+				add_next_index_object(return_value, alfi->closure);
 			} else if (alfi->func_ptr->common.scope) {
 				zval tmp;
 
 				array_init(&tmp);
 				if (alfi->obj) {
-					zval obj_zv;
-					ZVAL_OBJ_COPY(&obj_zv, alfi->obj);
-					add_next_index_zval(&tmp, &obj_zv);
+					GC_ADDREF(alfi->obj);
+					add_next_index_object(&tmp, alfi->obj);
 				} else {
 					add_next_index_str(&tmp, zend_string_copy(alfi->ce->name));
 				}


### PR DESCRIPTION
Fills out the array/object-property insert helpers for zend_array, zend_object, and zend_reference.

This adds the following matrix of 18 APIs
add_next_index_T()
add_index_T()
add_assoc_T()
add_assoc_T_ex()
add_property_T()
add_property_T_ex()

Where T in array, object, reference

Converted internal callsites currently doing an explicit object wrap.