### PR TITLE
Expose zend_valid_closure_binding

### DIFF
--- a/Zend/zend_closures.h
+++ b/Zend/zend_closures.h
@@ -37,6 +37,7 @@ ZEND_API void zend_create_fake_closure(zval *res, zend_function *op_array, zend_
 ZEND_API zend_function *zend_get_closure_invoke_method(zend_object *obj);
 ZEND_API const zend_function *zend_get_closure_method_def(zend_object *obj);
 ZEND_API zval* zend_get_closure_this_ptr(zval *obj);
+ZEND_API zend_bool zend_valid_closure_binding(zend_object *closure, zval *newthis, zend_class_entry *scope, zend_bool loud);
 
 END_EXTERN_C()
 

--- a/Zend/zend_closures.h
+++ b/Zend/zend_closures.h
@@ -37,7 +37,7 @@ ZEND_API void zend_create_fake_closure(zval *res, zend_function *op_array, zend_
 ZEND_API zend_function *zend_get_closure_invoke_method(zend_object *obj);
 ZEND_API const zend_function *zend_get_closure_method_def(zend_object *obj);
 ZEND_API zval* zend_get_closure_this_ptr(zval *obj);
-ZEND_API zend_bool zend_valid_closure_binding(zend_object *closure, zval *newthis, zend_class_entry *scope, zend_bool loud);
+ZEND_API zend_bool zend_valid_closure_binding(zend_object *closure, zend_object *newthis, zend_class_entry *scope, zend_bool loud);
 
 END_EXTERN_C()
 


### PR DESCRIPTION
This exposes `zend_valid_closure_binding` for extensions to use. Also provide a "be quiet" option while I'm at it.

In retrospect this leads to wanting a `zend_closure_call` API for extensions that basically does `$closure->call(...)` but with the more primitive types; working on that next.