### PR TITLE
Allow sleep() to accept non-integer values

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -283,7 +283,7 @@ function getopt(string $options, array $longopts = [], &$optind = null): array|f
 
 function flush(): void {}
 
-function sleep(float $seconds): float|false {}
+function sleep(float $seconds): int|float|false {}
 
 function usleep(int $microseconds): void {}
 

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -283,7 +283,7 @@ function getopt(string $options, array $longopts = [], &$optind = null): array|f
 
 function flush(): void {}
 
-function sleep(int $seconds): int {}
+function sleep(float $seconds): float|false {}
 
 function usleep(int $microseconds): void {}
 

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -285,7 +285,7 @@ function flush(): void {}
 
 function sleep(float $seconds): int|float|false {}
 
-function usleep(int $microseconds): void {}
+function usleep(float $microseconds): void {}
 
 #if HAVE_NANOSLEEP
 function time_nanosleep(int $seconds, int $nanoseconds): array|bool {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3b5ff5719c60f5eaf20970a585fab3430f1aa080 */
+ * Stub hash: 83a83116b6ef5d27626dec749d6761a9ecdd5268 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -413,7 +413,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sleep, 0, 1, MAY_BE_LONG|MAY_BE_
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_usleep, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, microseconds, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, microseconds, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
 #if HAVE_NANOSLEEP

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 954539f96cc6431a198aea2213b861c1062cc705 */
+ * Stub hash: 3b5ff5719c60f5eaf20970a585fab3430f1aa080 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -408,7 +408,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_flush, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sleep, 0, 1, MAY_BE_DOUBLE|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sleep, 0, 1, MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8b6ef365e9635c92ef86adb40b2aba077867f3b2 */
+ * Stub hash: 954539f96cc6431a198aea2213b861c1062cc705 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -408,8 +408,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_flush, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sleep, 0, 1, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sleep, 0, 1, MAY_BE_DOUBLE|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, seconds, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_usleep, 0, 1, IS_VOID, 0)

--- a/ext/standard/tests/misc/time_nanosleep_error5.phpt
+++ b/ext/standard/tests/misc/time_nanosleep_error5.phpt
@@ -11,7 +11,7 @@ time_nanosleep(0, 1000000000);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ValueError: Nanoseconds was not in the range 0 to 999 999 999 or seconds was negative in %s:%d
+Fatal error: Uncaught ValueError: time_nanosleep(): Argument #2 ($nanoseconds) must be less than or equal to 999 999 999 in %s:%d
 Stack trace:
 #0 %s(%d): time_nanosleep(0, 1000000000)
 #1 {main}


### PR DESCRIPTION
UPDATED on 20th Aug 2020

## Preface ##

Originally, decision to accept integer values only was made probably based on the standard/underlaying C `sleep` which accepts only integers.

## Why? ##

Usable function design should be prioritized over design based on the implementation based one. `sleep` function should delay the program execution by a given number of seconds. As "second" is a continous time unit, non-discrete/non-integer input should be allowed.

## Examples ##

Sleep is very often used for waiting/pooling with typical delay in range of millisecons. For examples, consider waiting for 100 ms.

Currently the best option is to use `usleep` like:
```
usleep(100_000);
```
or
```
$delaySeconds = 0.1;
...
usleep((int)($delaySeconds * 1000_000));
```
when the delay is defined with a variable in SI base time unit.

With this RFC, the examples can be simplified to:
```
sleep(0.1);
```
respectively
```
sleep($delaySeconds);
```

Another reason is that
```
sleep(0.1);
```
is silently accepted now (without strict types enabled), but the input is casted to 0 and thus producing unexpected behaviour if the user is not aware of the current method prototype. This can be observed in the comments in the documentation - https://www.php.net/manual/en/function.sleep.php .

## BC ##
The function prototype is changed from:
```
function sleep(int $seconds): int;
```
to
```
function sleep(float $seconds): int|float;
```

### Param type change ###
As integer is casted to float implicitly, there should be no BC break for php code (even with strict type enabled).


### Return type change ###
~~Php code may need a change if return value was used to check for success with strict comparison like `=== 0`.~~

For BC, return value of uninterrupted sleep remains `0` (integer zero). If sleep was interrupted, the return type is floating point number of seconds left.

Based on quick research on existing popular projects, the return type is not used at all. One obvious reason for that is that the return is not needed, but another reason is that the return value is always 192 on Windows if the call was interrupted.

### Implementation details ###

Implemented using `nanosleep` which is not guaranteed to be available everywhere. The proposed patch has fallback to always available `sleep` thus all existing delays will keep working as before.

### BC summary ###

The original param and return unit is unchanged. No code changed required if return type ~~is not used~~ is used only for checking for success or not used at all. Return type is normally not used (based on research on popular projects/uses) thus this RFC is fully BC.

As an implementation side effect, the specific return value on Windows should be fixed.