### PR TITLE
RFC: Custom callback to dump results in `php -a`

### DIFF
--- a/ext/readline/readline.stub.php
+++ b/ext/readline/readline.stub.php
@@ -24,6 +24,7 @@ function readline_write_history(?string $filename = null): bool {}
 
 function readline_completion_function(callable $callback): bool {}
 
+function readline_interactive_shell_result_function(?callable $callback): bool {}
 
 #if HAVE_RL_CALLBACK_READ_CHAR
 function readline_callback_handler_install(string $prompt, callable $callback): bool {}

--- a/ext/readline/readline_arginfo.h
+++ b/ext/readline/readline_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 226b138a99e3e32aea90cbb5c44446ac7c16db71 */
+ * Stub hash: f756ad4cde88bfef32707a677ddf6624fa4ed146 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_readline, 0, 0, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, prompt, IS_STRING, 1, "null")
@@ -30,6 +30,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_completion_function, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_readline_interactive_shell_result_function, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 1)
 ZEND_END_ARG_INFO()
 
 #if HAVE_RL_CALLBACK_READ_CHAR
@@ -69,6 +73,7 @@ ZEND_FUNCTION(readline_list_history);
 ZEND_FUNCTION(readline_read_history);
 ZEND_FUNCTION(readline_write_history);
 ZEND_FUNCTION(readline_completion_function);
+ZEND_FUNCTION(readline_interactive_shell_result_function);
 #if HAVE_RL_CALLBACK_READ_CHAR
 ZEND_FUNCTION(readline_callback_handler_install);
 #endif
@@ -97,6 +102,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(readline_read_history, arginfo_readline_read_history)
 	ZEND_FE(readline_write_history, arginfo_readline_write_history)
 	ZEND_FE(readline_completion_function, arginfo_readline_completion_function)
+	ZEND_FE(readline_interactive_shell_result_function, arginfo_readline_interactive_shell_result_function)
 #if HAVE_RL_CALLBACK_READ_CHAR
 	ZEND_FE(readline_callback_handler_install, arginfo_readline_callback_handler_install)
 #endif

--- a/ext/readline/readline_cli.h
+++ b/ext/readline/readline_cli.h
@@ -22,6 +22,7 @@ ZEND_BEGIN_MODULE_GLOBALS(cli_readline)
 	char *pager;
 	char *prompt;
 	smart_str *prompt_str;
+	zend_bool enable_interactive_shell_result_function;
 ZEND_END_MODULE_GLOBALS(cli_readline)
 
 #ifdef ZTS
@@ -35,5 +36,7 @@ extern PHP_MSHUTDOWN_FUNCTION(cli_readline);
 extern PHP_MINFO_FUNCTION(cli_readline);
 
 char **php_readline_completion_cb(const char *text, int start, int end);
+void php_readline_dump_interactive_result(const char* code, const size_t codelen, zval *returned_zv);
+zend_bool php_readline_should_dump_interactive_result();
 
 ZEND_EXTERN_MODULE_GLOBALS(cli_readline)

--- a/ext/readline/readline_cli.h
+++ b/ext/readline/readline_cli.h
@@ -22,7 +22,7 @@ ZEND_BEGIN_MODULE_GLOBALS(cli_readline)
 	char *pager;
 	char *prompt;
 	smart_str *prompt_str;
-	zend_bool enable_interactive_shell_result_function;
+	bool enable_interactive_shell_result_function;
 ZEND_END_MODULE_GLOBALS(cli_readline)
 
 #ifdef ZTS
@@ -37,6 +37,6 @@ extern PHP_MINFO_FUNCTION(cli_readline);
 
 char **php_readline_completion_cb(const char *text, int start, int end);
 void php_readline_dump_interactive_result(const char* code, const size_t codelen, zval *returned_zv);
-zend_bool php_readline_should_dump_interactive_result();
+bool php_readline_should_dump_interactive_result();
 
 ZEND_EXTERN_MODULE_GLOBALS(cli_readline)

--- a/ext/readline/tests/bug77812-libedit.phpt
+++ b/ext/readline/tests/bug77812-libedit.phpt
@@ -27,6 +27,7 @@ Interactive shell
 
 bar
 xx
+=> 1
 xxx
 
 Warning: Uncaught Error: Undefined constant "FOO" in php shell code:1

--- a/ext/readline/tests/bug77812-readline.phpt
+++ b/ext/readline/tests/bug77812-readline.phpt
@@ -33,6 +33,7 @@ php > print(<<<FOO
 <<< > xx
 <<< > FOO);
 xx
+=> 1
 php > echo <<<FOO
 <<< >     xxx
 <<< >     FOO;

--- a/ext/readline/tests/libedit_interactive_result.phpt
+++ b/ext/readline/tests/libedit_interactive_result.phpt
@@ -37,6 +37,8 @@ resource(%d) of type (process)
 Interactive shell
 
 
+bool(true)
+
 int(2)
 test
 

--- a/ext/readline/tests/libedit_interactive_result.phpt
+++ b/ext/readline/tests/libedit_interactive_result.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Configurable interactive results with libedit
+--SKIPIF--
+<?php
+if (!extension_loaded('readline')) die('skip readline extension not available');
+if (READLINE_LIB !== 'libedit') { die('skip libedit only'); }
+if (!function_exists('proc_open')) die('skip proc_open() not available');
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+var_dump($proc);
+
+// var_dump, json_encode, or any more complex dumping can be used in readline_interactive_shell_result_function.
+fwrite($pipes[0], <<<'EOT'
+readline_interactive_shell_result_function(
+    function(string $code, $result) {
+        if (isset($result)) {
+            echo "\n";
+            var_dump($result);
+        }});
+
+EOT);
+fwrite($pipes[0], "1+1;\n");
+fwrite($pipes[0], 'echo "test\n";' . "\n");
+fwrite($pipes[0], "__FILE__;\n");
+fwrite($pipes[0], "namespace\MyClass::class;\n");
+fwrite($pipes[0], "fn()=>true;");
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+resource(%d) of type (process)
+Interactive shell
+
+
+int(2)
+test
+
+string(14) "php shell code"
+
+string(7) "MyClass"
+
+object(Closure)#%d (0) {
+}

--- a/ext/readline/tests/libedit_interactive_result_error.phpt
+++ b/ext/readline/tests/libedit_interactive_result_error.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Configurable interactive results in libedit (error handling)
+--SKIPIF--
+<?php
+if (!extension_loaded('readline')) die('skip readline extension not available');
+if (READLINE_LIB !== 'libedit') { die('skip libedit only'); }
+if (!function_exists('proc_open')) die('skip proc_open() not available');
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+var_dump($proc);
+
+// var_dump, json_encode, or any more complex dumping can be used in readline_interactive_shell_result_function.
+fwrite($pipes[0], <<<'EOT'
+readline_interactive_shell_result_function(
+    function(string $code, $result, $unexpectedExtraParam) {
+        if (isset($result)) {
+            echo "\n";
+            var_dump($result);
+        }});
+
+EOT);
+fwrite($pipes[0], "sprintf('hello, %s', 'world');;\n");
+fwrite($pipes[0], 'for($i = 0; $i < 10; $i++) { echo $i; }; echo "\n";' . "\n");
+fwrite($pipes[0], "fn()=>true;");
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+resource(%d) of type (process)
+Interactive shell
+
+
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function {closure}(), 2 passed and exactly 3 expected in php shell code:2
+Stack trace:
+#0 [internal function]: {closure}('sprintf('hello,...', 'hello, world')
+#1 {main}
+  thrown in php shell code on line 2
+0123456789
+
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function {closure}(), 2 passed and exactly 3 expected in php shell code:2
+Stack trace:
+#0 [internal function]: {closure}('fn()=>true;\n', Object(Closure))
+#1 {main}
+  thrown in php shell code on line 2

--- a/ext/readline/tests/libedit_interactive_result_error.phpt
+++ b/ext/readline/tests/libedit_interactive_result_error.phpt
@@ -37,6 +37,12 @@ Interactive shell
 
 Fatal error: Uncaught ArgumentCountError: Too few arguments to function {closure}(), 2 passed and exactly 3 expected in php shell code:2
 Stack trace:
+#0 [internal function]: {closure}('readline_intera...', true)
+#1 {main}
+  thrown in php shell code on line 2
+
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function {closure}(), 2 passed and exactly 3 expected in php shell code:2
+Stack trace:
 #0 [internal function]: {closure}('sprintf('hello,...', 'hello, world')
 #1 {main}
   thrown in php shell code on line 2

--- a/ext/readline/tests/readline_interactive_result.phpt
+++ b/ext/readline/tests/readline_interactive_result.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Configurable interactive results in readline
+--INI--
+cli.enable_interactive_shell_result_function=1
+--SKIPIF--
+<?php
+if (!extension_loaded('readline')) die('skip readline extension not available');
+if (READLINE_LIB !== 'readline') { die('skip readline only'); }
+if (!function_exists('proc_open')) die('skip proc_open() not available');
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+var_dump($proc);
+
+// var_dump, json_encode, or any more complex dumping can be used in readline_interactive_shell_result_function.
+fwrite($pipes[0], <<<'EOT'
+readline_interactive_shell_result_function(
+    function(string $code, $result) {
+        if (isset($result)) {
+            echo "\n";
+            var_dump($result);
+        }});
+
+EOT);
+fwrite($pipes[0], "1+1;\n");
+fwrite($pipes[0], 'echo "test\n";' . "\n");
+fwrite($pipes[0], "__FILE__;\n");
+fwrite($pipes[0], "namespace\MyClass::class;\n");
+fwrite($pipes[0], "fn()=>true;");
+// Setting the callback to null clears the handler.
+fwrite($pipes[0], "readline_interactive_shell_result_function(null);\n");
+fwrite($pipes[0], "1+1;\n");
+// This passes (string $code, $result) to any callable
+fwrite($pipes[0], "readline_interactive_shell_result_function('var_dump');\n");
+fwrite($pipes[0], "2+2;\n");
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+resource(%d) of type (process)
+Interactive shell
+
+php > readline_interactive_shell_result_function(
+php (     function(string $code, $result) {
+php (         if (isset($result)) {
+php (             echo "\n";
+php (             var_dump($result);
+php (         }});
+php > 1+1;
+
+int(2)
+php > echo "test\n";
+test
+php > __FILE__;
+
+string(14) "php shell code"
+php > namespace\MyClass::class;
+
+string(7) "MyClass"
+php > fn()=>true;readline_interactive_shell_result_function(null);
+php > 1+1;
+php > readline_interactive_shell_result_function('var_dump');
+php > 2+2;
+string(5) "2+2;
+"
+int(4)
+php >

--- a/ext/readline/tests/readline_interactive_result.phpt
+++ b/ext/readline/tests/readline_interactive_result.phpt
@@ -50,6 +50,8 @@ php (         if (isset($result)) {
 php (             echo "\n";
 php (             var_dump($result);
 php (         }});
+
+bool(true)
 php > 1+1;
 
 int(2)

--- a/ext/readline/tests/readline_interactive_result_default.phpt
+++ b/ext/readline/tests/readline_interactive_result_default.phpt
@@ -18,18 +18,6 @@ var_dump($proc);
 
 // var_dump, json_encode, or any more complex dumping can be used in readline_interactive_shell_result_function.
 $write_line = fn(string $line) => fwrite($pipes[0], $line . "\n");
-$write_line(<<<'EOT'
-readline_interactive_shell_result_function(
-    function(string $code, $result) {
-        if (!isset($result)) {
-            return;
-        }
-        if (is_scalar($result)) {
-            echo "=> " . var_export($result, true) . "\n";
-        } else {
-            echo "=> "; var_dump($result);
-        }});
-EOT);
 $write_line('1+1;');
 $write_line('0.5 * 2;');
 $write_line('namespace\MyClass::class;');
@@ -43,6 +31,8 @@ $write_line('function do_something() { echo "in do_something()\n"; }');
 $write_line('do_something();');
 $write_line('json_decode(\'{"key": "value"}\');');
 $write_line('throw new RuntimeException("test");');
+$write_line('printf("newline is automatically appended by shell");');
+$write_line('printf("newline not automatically appended by shell\n");');
 fclose($pipes[0]);
 proc_close($proc);
 ?>
@@ -50,17 +40,6 @@ proc_close($proc);
 resource(5) of type (process)
 Interactive shell
 
-php > readline_interactive_shell_result_function(
-php (     function(string $code, $result) {
-php (         if (!isset($result)) {
-php (             return;
-php (         }
-php (         if (is_scalar($result)) {
-php (             echo "=> " . var_export($result, true) . "\n";
-php (         } else {
-php (             echo "=> "; var_dump($result);
-php (         }});
-=> true
 php > 1+1;
 => 2
 php > 0.5 * 2;
@@ -68,7 +47,7 @@ php > 0.5 * 2;
 php > namespace\MyClass::class;
 => 'MyClass'
 php > fn()=>true;
-=> object(Closure)#2 (0) {
+=> object(Closure)#1 (0) {
 }
 php > $x = ["foo", "bar"];
 => array(2) {
@@ -93,7 +72,7 @@ php > function do_something() { echo "in do_something()\n"; }
 php > do_something();
 in do_something()
 php > json_decode('{"key": "value"}');
-=> object(stdClass)#2 (1) {
+=> object(stdClass)#1 (1) {
   ["key"]=>
   string(5) "value"
 }
@@ -103,4 +82,10 @@ Warning: Uncaught RuntimeException: test in php shell code:1
 Stack trace:
 #0 {main}
   thrown in php shell code on line 1
+php > printf("newline is automatically appended by shell");
+newline is automatically appended by shell
+=> 42
+php > printf("newline not automatically appended by shell\n");
+newline not automatically appended by shell
+=> 44
 php >

--- a/ext/readline/tests/readline_interactive_result_disabled.phpt
+++ b/ext/readline/tests/readline_interactive_result_disabled.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Interactive results in readline disabled
+--INI--
+cli.enable_interactive_shell_result_function=0
+--SKIPIF--
+<?php
+if (!extension_loaded('readline')) die('skip readline extension not available');
+if (READLINE_LIB !== 'readline') { die('skip readline only'); }
+if (!function_exists('proc_open')) die('skip proc_open() not available');
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+var_dump($proc);
+
+// var_dump, json_encode, or any more complex dumping can be used in readline_interactive_shell_result_function.
+$write_line = fn(string $line) => fwrite($pipes[0], $line . "\n");
+// Result expressions aren't dumped when this functionality is disabled.
+$write_line('1+1;');
+$write_line('printf("Test\n");');
+// Calling readline_interactive_shell_result_function is deliberately a no-op when this functionality
+// is disabled.
+$write_line(<<<'EOT'
+readline_interactive_shell_result_function(
+    function(string $code, $result) { var_dump($result); });
+EOT);
+$write_line('1+1;');
+$write_line('printf("Test\n");');
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+resource(5) of type (process)
+Interactive shell
+
+php > 1+1;
+php > printf("Test\n");
+Test
+php > readline_interactive_shell_result_function(
+php (     function(string $code, $result) { var_dump($result); });
+php > 1+1;
+php > printf("Test\n");
+Test
+php >

--- a/ext/readline/tests/readline_interactive_result_error.phpt
+++ b/ext/readline/tests/readline_interactive_result_error.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Configurable interactive results in readline
+--INI--
+cli.enable_interactive_shell_result_function=1
+--SKIPIF--
+<?php
+if (!extension_loaded('readline')) die('skip readline extension not available');
+if (READLINE_LIB !== 'readline') { die('skip readline only'); }
+if (!function_exists('proc_open')) die('skip proc_open() not available');
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+var_dump($proc);
+
+// var_dump, json_encode, or any more complex dumping can be used in readline_interactive_shell_result_function.
+fwrite($pipes[0], <<<'EOT'
+readline_interactive_shell_result_function(
+    function(string $code, $result, $unexpectedExtraParam) {
+        if (isset($result)) {
+            echo "\n";
+            var_dump($result);
+        }});
+
+EOT);
+fwrite($pipes[0], "sprintf('hello, %s', 'world');;\n");
+fwrite($pipes[0], 'for($i = 0; $i < 10; $i++) { echo $i; }; echo "\n";' . "\n");
+fwrite($pipes[0], "fn()=>true;");
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+resource(%d) of type (process)
+Interactive shell
+
+php > readline_interactive_shell_result_function(
+php (     function(string $code, $result, $unexpectedExtraParam) {
+php (         if (isset($result)) {
+php (             echo "\n";
+php (             var_dump($result);
+php (         }});
+php > sprintf('hello, %s', 'world');;
+
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function {closure}(), 2 passed and exactly 3 expected in php shell code:2
+Stack trace:
+#0 [internal function]: {closure}('sprintf('hello,...', 'hello, world')
+#1 {main}
+  thrown in php shell code on line 2
+php > for($i = 0; $i < 10; $i++) { echo $i; }; echo "\n";
+0123456789
+php > fn()=>true;
+
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function {closure}(), 2 passed and exactly 3 expected in php shell code:2
+Stack trace:
+#0 [internal function]: {closure}('fn()=>true;\n', Object(Closure))
+#1 {main}
+  thrown in php shell code on line 2
+php >

--- a/ext/readline/tests/readline_interactive_result_error.phpt
+++ b/ext/readline/tests/readline_interactive_result_error.phpt
@@ -42,6 +42,12 @@ php (         if (isset($result)) {
 php (             echo "\n";
 php (             var_dump($result);
 php (         }});
+
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function {closure}(), 2 passed and exactly 3 expected in php shell code:2
+Stack trace:
+#0 [internal function]: {closure}('readline_intera...', true)
+#1 {main}
+  thrown in php shell code on line 2
 php > sprintf('hello, %s', 'world');;
 
 Fatal error: Uncaught ArgumentCountError: Too few arguments to function {closure}(), 2 passed and exactly 3 expected in php shell code:2

--- a/ext/readline/tests/readline_interactive_result_pretty_proposed_default.phpt
+++ b/ext/readline/tests/readline_interactive_result_pretty_proposed_default.phpt
@@ -1,0 +1,105 @@
+--TEST--
+Configurable interactive results in readline
+--INI--
+cli.enable_interactive_shell_result_function=1
+--SKIPIF--
+<?php
+if (!extension_loaded('readline')) die('skip readline extension not available');
+if (READLINE_LIB !== 'readline') { die('skip readline only'); }
+if (!function_exists('proc_open')) die('skip proc_open() not available');
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+$proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+var_dump($proc);
+
+// var_dump, json_encode, or any more complex dumping can be used in readline_interactive_shell_result_function.
+$write_line = fn(string $line) => fwrite($pipes[0], $line . "\n");
+$write_line(<<<'EOT'
+readline_interactive_shell_result_function(
+    function(string $code, $result) {
+        if (!isset($result)) {
+            return;
+        }
+        if (is_scalar($result)) {
+            echo "=> " . var_export($result, true) . "\n";
+        } else {
+            echo "=> "; var_dump($result);
+        }});
+EOT);
+$write_line('1+1;');
+$write_line('0.5 * 2;');
+$write_line('namespace\MyClass::class;');
+$write_line('fn()=>true;');
+$write_line('$x = ["foo", "bar"];');
+$write_line('asort($x);');
+$write_line('$x;');
+$write_line('json_encode($x);');
+$write_line('unset($x);');
+$write_line('function do_something() { echo "in do_something()\n"; }');
+$write_line('do_something();');
+$write_line('json_decode(\'{"key": "value"}\');');
+$write_line('throw new RuntimeException("test");');
+fclose($pipes[0]);
+proc_close($proc);
+?>
+--EXPECTF--
+resource(5) of type (process)
+Interactive shell
+
+php > readline_interactive_shell_result_function(
+php (     function(string $code, $result) {
+php (         if (!isset($result)) {
+php (             return;
+php (         }
+php (         if (is_scalar($result)) {
+php (             echo "=> " . var_export($result, true) . "\n";
+php (         } else {
+php (             echo "=> "; var_dump($result);
+php (         }});
+php > 1+1;
+=> 2
+php > 0.5 * 2;
+=> 1.0
+php > namespace\MyClass::class;
+=> 'MyClass'
+php > fn()=>true;
+=> object(Closure)#2 (0) {
+}
+php > $x = ["foo", "bar"];
+=> array(2) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+}
+php > asort($x);
+=> true
+php > $x;
+=> array(2) {
+  [1]=>
+  string(3) "bar"
+  [0]=>
+  string(3) "foo"
+}
+php > json_encode($x);
+=> '{"1":"bar","0":"foo"}'
+php > unset($x);
+php > function do_something() { echo "in do_something()\n"; }
+php > do_something();
+in do_something()
+php > json_decode('{"key": "value"}');
+=> object(stdClass)#2 (1) {
+  ["key"]=>
+  string(5) "value"
+}
+php > throw new RuntimeException("test");
+
+Warning: Uncaught RuntimeException: test in php shell code:1
+Stack trace:
+#0 {main}
+  thrown in php shell code on line 1
+php >


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/readline_interactive_shell_result_function

1. This adds `readline_interactive_shell_result_function()`
   that can be used to configure a custom callback to dump results of standalone expressions.
   (For interactive shells)
2. This also adds a default dumper for expressions, which behaves like the following snippet. (see test cases)
3. The original behavior of never dumping expression results can be restored by setting `cli.enable_interactive_shell_result_function=0`

```php
readline_interactive_shell_result_function(
    function(string $code, $result) {
        if (!isset($result)) {
            return;
        }
        if (is_scalar($result)) {
            echo "=> " . var_export($result, true) . "\n";
        } else {
            echo "=> "; var_dump($result);
        }});
```

See ext/readline/tests/readline_interactive_result.phpt for an example of how a
customized callback could be set.

Those hooks can use projects such as php-parser or php-ast to customize
the logic of whether the value of assignments or print() expressions
should not be printed.
Example usage:

```php
readline_interactive_shell_result_function(
    function (string $code, $result) {
        echo "Saw " . trim($code) . "\n";
        echo json_encode($result);
    });
```

The system ini setting `cli.enable_interactive_shell_result_function`
can be used to disable this functionality to debug applications that load
buggy handlers. It is enabled by default.

Currently, this only attempts to support single expressions terminated by `;`,
if the ini setting is enabled, a handler is configured, and parsing the code doesn't throw a ParseError/CompileError.
See ext/readline/tests/libedit_interactive_result.phpt for an example session.

Related to https://externals.io/message/111073

