### PR TITLE
Promote warnings to exceptions in ext/curl

### DIFF
--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -477,7 +477,7 @@ static int _php_curl_multi_setopt(php_curlm *mh, zend_long option, zval *zvalue,
 			break;
 #endif
 		default:
-			php_error_docref(NULL, E_WARNING, "Invalid curl multi configuration option");
+			zend_argument_value_error(2, "is not a valid cURL multi option");
 			error = CURLM_UNKNOWN_OPTION;
 			break;
 	}

--- a/ext/curl/share.c
+++ b/ext/curl/share.c
@@ -67,7 +67,7 @@ static int _php_curl_share_setopt(php_curlsh *sh, zend_long option, zval *zvalue
 			break;
 
 		default:
-			php_error_docref(NULL, E_WARNING, "Invalid curl share configuration option");
+			zend_argument_value_error(2, "is not a valid cURL share option");
 			error = CURLSHE_BAD_OPTION;
 			break;
 	}

--- a/ext/curl/tests/bug48207.phpt
+++ b/ext/curl/tests/bug48207.phpt
@@ -33,16 +33,21 @@ if(!empty($host)) {
 
 
 $tempfile	= tempnam(sys_get_temp_dir(), 'CURL_FILE_HANDLE');
+$fp = fopen($tempfile, "r"); // Opening 'fubar' with the incorrect readonly flag
 
 $ch = curl_init($url);
-$fp = fopen($tempfile, "r"); // Opening 'fubar' with the incorrect readonly flag
-curl_setopt($ch, CURLOPT_FILE, $fp);
+try {
+    curl_setopt($ch, CURLOPT_FILE, $fp);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
 curl_exec($ch);
 curl_close($ch);
 is_file($tempfile) and @unlink($tempfile);
 isset($tempname) and is_file($tempname) and @unlink($tempname);
 ?>
---EXPECTF--
-Warning: curl_setopt(): The provided file handle is not writable in %s on line %d
+--EXPECT--
+curl_setopt(): The provided file handle must be writable
 Hello World!
 Hello World!

--- a/ext/curl/tests/bug68089.phpt
+++ b/ext/curl/tests/bug68089.phpt
@@ -9,10 +9,15 @@ include 'skipif.inc';
 <?php
 $url = "file:///etc/passwd\0http://google.com";
 $ch = curl_init();
-var_dump(curl_setopt($ch, CURLOPT_URL, $url));
+
+try {
+    curl_setopt($ch, CURLOPT_URL, $url);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
 ?>
 Done
---EXPECTF--
-Warning: curl_setopt(): Curl option contains invalid characters (\0) in %s%ebug68089.php on line 4
-bool(false)
+--EXPECT--
+curl_setopt(): cURL option cannot contain any null-bytes
 Done

--- a/ext/curl/tests/curl_file_upload.phpt
+++ b/ext/curl/tests/curl_file_upload.phpt
@@ -42,7 +42,12 @@ var_dump($file->getPostFilename());
 curl_setopt($ch, CURLOPT_POSTFIELDS, array("file" => $file));
 var_dump(curl_exec($ch));
 
-curl_setopt($ch, CURLOPT_SAFE_UPLOAD, 0);
+try {
+    curl_setopt($ch, CURLOPT_SAFE_UPLOAD, 0);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
 $params = array('file' => '@' . __DIR__ . '/curl_testdata1.txt');
 curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
 var_dump(curl_exec($ch));
@@ -69,8 +74,7 @@ string(%d) "%s/curl_testdata1.txt"
 string(%d) "curl_testdata1.txt|text/plain|6"
 string(%d) "foo.txt"
 string(%d) "foo.txt|application/octet-stream|6"
-
-Warning: curl_setopt(): Disabling safe uploads is no longer supported in %s on line %d
+curl_setopt(): Disabling safe uploads is no longer supported
 string(0) ""
 string(0) ""
 string(%d) "array(1) {

--- a/ext/curl/tests/curl_multi_errno_strerror_001.phpt
+++ b/ext/curl/tests/curl_multi_errno_strerror_001.phpt
@@ -14,7 +14,12 @@ $errno = curl_multi_errno($mh);
 echo $errno . PHP_EOL;
 echo curl_multi_strerror($errno) . PHP_EOL;
 
-@curl_multi_setopt($mh, -1, -1);
+try {
+    curl_multi_setopt($mh, -1, -1);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
 $errno = curl_multi_errno($mh);
 echo $errno . PHP_EOL;
 echo curl_multi_strerror($errno) . PHP_EOL;
@@ -22,5 +27,6 @@ echo curl_multi_strerror($errno) . PHP_EOL;
 --EXPECT--
 0
 No error
+curl_multi_setopt(): Argument #2 ($option) is not a valid cURL multi option
 6
 Unknown option

--- a/ext/curl/tests/curl_multi_setopt_basic001.phpt
+++ b/ext/curl/tests/curl_multi_setopt_basic001.phpt
@@ -11,11 +11,14 @@ if (!extension_loaded("curl")) {
 
 $mh = curl_multi_init();
 var_dump(curl_multi_setopt($mh, CURLMOPT_PIPELINING, 0));
-var_dump(curl_multi_setopt($mh, -1, 0));
+
+try {
+    curl_multi_setopt($mh, -1, 0);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 bool(true)
-
-Warning: curl_multi_setopt(): Invalid curl multi configuration option in %s on line %d
-bool(false)
+curl_multi_setopt(): Argument #2 ($option) is not a valid cURL multi option

--- a/ext/curl/tests/curl_setopt_basic003.phpt
+++ b/ext/curl/tests/curl_setopt_basic003.phpt
@@ -17,7 +17,11 @@ echo "*** curl_setopt() call with CURLOPT_HTTPHEADER\n";
 $url = "{$host}/";
 $ch = curl_init();
 
-curl_setopt($ch, CURLOPT_HTTPHEADER, 1);
+try {
+    curl_setopt($ch, CURLOPT_HTTPHEADER, 1);
+} catch (TypeError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 $curl_content = curl_exec($ch);
 curl_close($ch);
@@ -36,9 +40,8 @@ curl_close($ch);
 
 var_dump( $curl_content );
 ?>
---EXPECTF--
+--EXPECT--
 *** curl_setopt() call with CURLOPT_HTTPHEADER
-
-Warning: curl_setopt(): You must pass an array with the CURLOPT_HTTPHEADER argument in %s on line %d
+curl_setopt(): The CURLOPT_HTTPHEADER option must have an array value
 bool(false)
 bool(true)

--- a/ext/curl/tests/curl_setopt_error.phpt
+++ b/ext/curl/tests/curl_setopt_error.phpt
@@ -16,10 +16,21 @@ try {
     echo $e->getMessage(), "\n";
 }
 
-curl_setopt($ch, -10, 0);
+try {
+    curl_setopt($ch, -10, 0);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    curl_setopt($ch, 1000, 0);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
 ?>
---EXPECTF--
+--EXPECT--
 *** curl_setopt() call with incorrect parameters
 curl_setopt(): Argument #2 ($option) must be of type int, string given
-
-Warning: curl_setopt(): Invalid curl configuration option in %scurl_setopt_error.php on line %d
+curl_setopt(): Argument #2 ($option) is not a valid cURL option
+curl_setopt(): Argument #2 ($option) is not a valid cURL option

--- a/ext/curl/tests/curl_share_errno_strerror_001.phpt
+++ b/ext/curl/tests/curl_share_errno_strerror_001.phpt
@@ -14,7 +14,12 @@ $errno = curl_share_errno($sh);
 echo $errno . PHP_EOL;
 echo curl_share_strerror($errno) . PHP_EOL;
 
-@curl_share_setopt($sh, -1, -1);
+try {
+    curl_share_setopt($sh, -1, -1);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
 $errno = curl_share_errno($sh);
 echo $errno . PHP_EOL;
 echo curl_share_strerror($errno) . PHP_EOL;
@@ -22,5 +27,6 @@ echo curl_share_strerror($errno) . PHP_EOL;
 --EXPECT--
 0
 No error
+curl_share_setopt(): Argument #2 ($option) is not a valid cURL share option
 1
 Unknown share option

--- a/ext/curl/tests/curl_share_setopt_basic001.phpt
+++ b/ext/curl/tests/curl_share_setopt_basic001.phpt
@@ -12,12 +12,15 @@ if (!extension_loaded("curl")) {
 $sh = curl_share_init();
 var_dump(curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE));
 var_dump(curl_share_setopt($sh, CURLSHOPT_UNSHARE, CURL_LOCK_DATA_DNS));
-var_dump(curl_share_setopt($sh, -1, 0));
+
+try {
+    curl_share_setopt($sh, -1, 0);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
 
 ?>
---EXPECTF--
+--EXPECT--
 bool(true)
 bool(true)
-
-Warning: curl_share_setopt(): Invalid curl share configuration option in %s on line %d
-bool(false)
+curl_share_setopt(): Argument #2 ($option) is not a valid cURL share option


### PR DESCRIPTION
It should be checked if there is any other warnings in ext/curl that should be promoted