### PR TITLE
Support NO_COLOR environment variable in run-tests.php

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -114,7 +114,8 @@ Options:
 
     --no-clean  Do not execute clean section if any.
 
-    --no-color Do not colorize the result type in the test result
+    --color
+    --no-color  Do/Don't colorize the result type in the test result.
 
 
 HELP;
@@ -538,6 +539,9 @@ function main(): void
                     break;
                 case '--no-clean':
                     $no_clean = true;
+                    break;
+                case '--color':
+                    $colorize = true;
                     break;
                 case '--no-color':
                     $colorize = false;

--- a/run-tests.php
+++ b/run-tests.php
@@ -390,6 +390,9 @@ function main(): void
     if (function_exists('sapi_windows_vt100_support') && !sapi_windows_vt100_support(STDOUT, true)) {
         $colorize = false;
     }
+    if (array_key_exists('NO_COLOR', $_ENV)) {
+        $colorize = false;
+    }
     $selected_tests = false;
     $slow_min_ms = INF;
     $preload = false;


### PR DESCRIPTION
See https://no-color.org/

> an informal standard is hereby proposed:
>
> All command-line software which outputs text with ANSI color added should check
> for the presence of a `NO_COLOR` environment variable that, when present
> **(regardless of its value),** prevents the addition of ANSI color.

E.g. CI environments may not process colors properly, or some OSes or terminals may have unanticipated issues with ansi color codes