### PR TITLE
Fix #79922: Crash after multiple calls to xml_parser_free()

### DIFF
--- a/ext/xml/tests/bug79922.phpt
+++ b/ext/xml/tests/bug79922.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #79922 (Crash after multiple calls to xml_parser_free())
+--SKIPIF--
+<?php
+if (!extension_loaded('xml')) die('skip xml extension not available');
+?>
+--FILE--
+<?php
+$c=xml_parser_create_ns();
+$a=xml_parser_free($c);
+$a=xml_parser_free($c);
+$c=0;
+var_dump($a);
+?>
+--EXPECTF--
+Warning: xml_parser_free(): supplied resource is not a valid XML Parser resource in %s on line %d
+bool(false)

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1132,7 +1132,7 @@ static void php_xml_parser_create_impl(INTERNAL_FUNCTION_PARAMETERS, int ns_supp
 	XML_SetUserData(parser->parser, parser);
 
 	RETVAL_RES(zend_register_resource(parser, le_xml_parser));
-	ZVAL_COPY(&parser->index, return_value);
+	ZVAL_COPY_VALUE(&parser->index, return_value);
 }
 /* }}} */
 
@@ -1559,7 +1559,7 @@ PHP_FUNCTION(xml_parser_free)
 		RETURN_FALSE;
 	}
 
-	if (zend_list_delete(Z_RES(parser->index)) == FAILURE) {
+	if (zend_list_close(Z_RES(parser->index)) == FAILURE) {
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
We must not call `zend_list_delete()` in resource closer functions
exposed to userland, because decreasing the refcount there leads to
use-after-free scenarios.  In this case, commit 4a42fbb worked for
typical use-cases where `xml_parser_free()` has been called exactly
once for the resource, because there is an internal zval (`->index`)
referencing the same resource which already increased the refcount by
one.  However, when `xml_parser_free()` is called multiple times on the
same XML parser resource, the resource would be freed prematurely.

Instead we forcefully close the resource in `xml_parser_free()`.  We
also could decrease the refcount of the resource there, but that would
require to call `xml_parser_free()` which is somewhat uncommon, and
would be particularly bad wrt. PHP 8 where that function is a NOP, and
as such doesn't have to be called.  So we do no longer increase the
refcount of the resource when copying it to the internal zval, and let
the usualy refcounting semantics take care of the resource destruction.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=4a42fbbbc73aad7427aef5c89974d1833636e082>