### PR TITLE
fix crypt_r detection under BSD system.

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2217,6 +2217,17 @@ crypt_r("passwd", "hash", &buffer);
     fi
     ])
 
+    if test "$php_cv_crypt_r_style" = "none"; then
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <stdlib.h>
+#include <unistd.h>
+]],[[
+struct crypt_data buffer;
+crypt_r("passwd", "hash", &buffer);
+]])],[php_cv_crypt_r_style=struct_crypt_data],[])
+    fi
+    ])
+
   if test "$php_cv_crypt_r_style" = "cryptd"; then
     AC_DEFINE(CRYPT_R_CRYPTD, 1, [Define if crypt_r has uses CRYPTD])
   fi

--- a/ext/standard/crypt.c
+++ b/ext/standard/crypt.c
@@ -21,6 +21,9 @@
 
 #include "php.h"
 
+#if HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif


### PR DESCRIPTION
OpenBSD needs additional header too.