### PR TITLE
Promote warnings to exceptions in ext/intl

### DIFF
--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -693,8 +693,8 @@ PHP_METHOD(UConverter, reasonText) {
 		UCNV_REASON_CASE(CLOSE)
 		UCNV_REASON_CASE(CLONE)
 		default:
-			php_error_docref(NULL, E_WARNING, "Unknown UConverterCallbackReason: " ZEND_LONG_FMT, reason);
-			RETURN_FALSE;
+			zend_argument_value_error(1, "must be a UConverter::REASON_* constant");
+			RETURN_THROWS();
 	}
 }
 /* }}} */

--- a/ext/intl/converter/converter.stub.php
+++ b/ext/intl/converter/converter.stub.php
@@ -45,7 +45,7 @@ class UConverter
     /** @return string|false|null */
     public function getSubstChars() {}
 
-    /** @return string|false */
+    /** @return string */
     public static function reasonText(int $reason) {}
 
     /** @return bool */

--- a/ext/intl/converter/converter_arginfo.h
+++ b/ext/intl/converter/converter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9eef3fe293c07ab77f4c8b6d8d53a3798f8a9865 */
+ * Stub hash: e33e2614c969c59b79c6062f7a347a8e8e486d85 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_UConverter___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, destination_encoding, IS_STRING, 1, "null")

--- a/ext/intl/formatter/formatter_format.c
+++ b/ext/intl/formatter/formatter_format.c
@@ -105,9 +105,8 @@ PHP_FUNCTION( numfmt_format )
 			break;
 
 		default:
-			php_error_docref(NULL, E_WARNING, "Unsupported format type " ZEND_LONG_FMT, type);
-			RETURN_FALSE;
-			break;
+			zend_argument_value_error(3, "must be a NumberFormatter::TYPE_* constant");
+			RETURN_THROWS();
 	}
 
 	INTL_METHOD_RETVAL_UTF8( nfo, formatted, formatted_len, ( formatted != format_buf ) );

--- a/ext/intl/formatter/formatter_parse.c
+++ b/ext/intl/formatter/formatter_parse.c
@@ -44,13 +44,13 @@ PHP_FUNCTION( numfmt_parse )
 	FORMATTER_METHOD_INIT_VARS;
 
 	/* Parse parameters. */
-	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|lz!",
+	if (zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "Os|lz!",
 		&object, NumberFormatter_ce_ptr,  &str, &str_len, &type, &zposition ) == FAILURE )
 	{
 		RETURN_THROWS();
 	}
 
-	if(zposition) {
+	if (zposition) {
 		position = (int32_t) zval_get_long(zposition);
 		position_p = &position;
 	}
@@ -86,17 +86,20 @@ PHP_FUNCTION( numfmt_parse )
 			RETVAL_DOUBLE(val_double);
 			break;
 		default:
-			php_error_docref(NULL, E_WARNING, "Unsupported format type " ZEND_LONG_FMT, type);
-			RETVAL_FALSE;
-			break;
+			zend_argument_value_error(3, "must be a NumberFormatter::TYPE_* constant");
+			goto cleanup;
 	}
+
+	if (zposition) {
+		ZEND_TRY_ASSIGN_REF_LONG(zposition, position);
+	}
+
+cleanup:
+
 #if ICU_LOCALE_BUG && defined(LC_NUMERIC)
 	setlocale(LC_NUMERIC, oldlocale);
 	efree(oldlocale);
 #endif
-	if(zposition) {
-		ZEND_TRY_ASSIGN_REF_LONG(zposition, position);
-	}
 
 	if (sstr) {
 		efree(sstr);

--- a/ext/intl/grapheme/grapheme_string.c
+++ b/ext/intl/grapheme/grapheme_string.c
@@ -125,8 +125,8 @@ PHP_FUNCTION(grapheme_strpos)
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
 
 	if (needle_len == 0) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_strpos: Empty delimiter", 1 );
-		RETURN_FALSE;
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
 	}
 
 	if (offset >= 0) {
@@ -184,8 +184,8 @@ PHP_FUNCTION(grapheme_stripos)
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
 
 	if (needle_len == 0) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_stripos: Empty delimiter", 1 );
-		RETURN_FALSE;
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
 	}
 
 	is_ascii = ( grapheme_ascii_check((unsigned char*)haystack, haystack_len) >= 0 );
@@ -250,7 +250,7 @@ PHP_FUNCTION(grapheme_strrpos)
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
 
 	if (needle_len == 0) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_strpos: Empty delimiter", 1 );
+		zend_argument_value_error(2, "cannot be empty");
 		RETURN_FALSE;
 	}
 
@@ -310,8 +310,8 @@ PHP_FUNCTION(grapheme_strripos)
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
 
 	if (needle_len == 0) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_strpos: Empty delimiter", 1 );
-		RETURN_FALSE;
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
 	}
 
 	is_ascii = grapheme_ascii_check((unsigned char *)haystack, haystack_len) >= 0;
@@ -582,10 +582,8 @@ static void strstr_common_handler(INTERNAL_FUNCTION_PARAMETERS, int f_ignore_cas
 	}
 
 	if (needle_len == 0) {
-
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_strpos: Empty delimiter", 1 );
-
-		RETURN_FALSE;
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
 	}
 
 
@@ -783,9 +781,8 @@ PHP_FUNCTION(grapheme_extract)
 	}
 
 	if ( extract_type < GRAPHEME_EXTRACT_TYPE_MIN || extract_type > GRAPHEME_EXTRACT_TYPE_MAX ) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,
-			 "grapheme_extract: unknown extract type param", 0 );
-		RETURN_FALSE;
+		zend_argument_value_error(3, "must be either GRAPHEME_EXTR_COUNT, GRAPHEME_EXTR_MAXBYTES, or GRAPHEME_EXTR_MAXCHARS");
+		RETURN_THROWS();
 	}
 
 	if ( lstart > INT32_MAX || lstart < 0 || (size_t)lstart >= str_len ) {
@@ -793,10 +790,16 @@ PHP_FUNCTION(grapheme_extract)
 		RETURN_FALSE;
 	}
 
-	if ( size > INT32_MAX || size < 0) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_extract: size is invalid", 0 );
-		RETURN_FALSE;
+	if (size < 0) {
+		zend_argument_value_error(2, "must be greater than or equal to 0");
+		RETURN_THROWS();
 	}
+
+	if ( size > INT32_MAX) {
+		zend_argument_value_error(2, "is too large");
+		RETURN_THROWS();
+	}
+
 	if (size == 0) {
 		RETURN_EMPTY_STRING();
 	}

--- a/ext/intl/grapheme/grapheme_string.c
+++ b/ext/intl/grapheme/grapheme_string.c
@@ -792,7 +792,7 @@ PHP_FUNCTION(grapheme_extract)
 		RETURN_THROWS();
 	}
 
-	if ( size > INT32_MAX) {
+	if (size > INT32_MAX) {
 		zend_argument_value_error(2, "is too large");
 		RETURN_THROWS();
 	}

--- a/ext/intl/grapheme/grapheme_string.c
+++ b/ext/intl/grapheme/grapheme_string.c
@@ -124,6 +124,11 @@ PHP_FUNCTION(grapheme_strpos)
 
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
 
+	if (needle_len == 0) {
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
+	}
+
 	if (offset >= 0) {
 		/* quick check to see if the string might be there
 		 * I realize that 'offset' is 'grapheme count offset' but will work in spite of that
@@ -176,6 +181,11 @@ PHP_FUNCTION(grapheme_stripos)
 	offset = (int32_t) loffset;
 
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
+
+	if (needle_len == 0) {
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
+	}
 
 	is_ascii = ( grapheme_ascii_check((unsigned char*)haystack, haystack_len) >= 0 );
 
@@ -238,6 +248,11 @@ PHP_FUNCTION(grapheme_strrpos)
 
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
 
+	if (needle_len == 0) {
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
+	}
+
 	is_ascii = grapheme_ascii_check((unsigned char *)haystack, haystack_len) >= 0;
 
 	if ( is_ascii ) {
@@ -292,6 +307,11 @@ PHP_FUNCTION(grapheme_strripos)
 	offset = (int32_t) loffset;
 
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
+
+	if (needle_len == 0) {
+		zend_argument_value_error(2, "cannot be empty");
+		RETURN_THROWS();
+	}
 
 	is_ascii = grapheme_ascii_check((unsigned char *)haystack, haystack_len) >= 0;
 
@@ -556,6 +576,11 @@ static void strstr_common_handler(INTERNAL_FUNCTION_PARAMETERS, int f_ignore_cas
 	zend_bool part = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss|b", &haystack, &haystack_len, &needle, &needle_len, &part) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (needle_len == 0) {
+		zend_argument_value_error(2, "cannot be empty");
 		RETURN_THROWS();
 	}
 

--- a/ext/intl/grapheme/grapheme_string.c
+++ b/ext/intl/grapheme/grapheme_string.c
@@ -114,8 +114,8 @@ PHP_FUNCTION(grapheme_strpos)
 	}
 
 	if ( OUTSIDE_STRING(loffset, haystack_len) ) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_strpos: Offset not contained in string", 1 );
-		RETURN_FALSE;
+		zend_argument_value_error(3, "must be contained in argument #1 ($haystack)");
+		RETURN_THROWS();
 	}
 
 	/* we checked that it will fit: */
@@ -123,11 +123,6 @@ PHP_FUNCTION(grapheme_strpos)
 	noffset = offset >= 0 ? offset : (int32_t)haystack_len + offset;
 
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
-
-	if (needle_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
-		RETURN_THROWS();
-	}
 
 	if (offset >= 0) {
 		/* quick check to see if the string might be there
@@ -154,7 +149,6 @@ PHP_FUNCTION(grapheme_strpos)
 	} else {
 		RETURN_FALSE;
 	}
-
 }
 /* }}} */
 
@@ -174,19 +168,14 @@ PHP_FUNCTION(grapheme_stripos)
 	}
 
 	if ( OUTSIDE_STRING(loffset, haystack_len) ) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_stripos: Offset not contained in string", 1 );
-		RETURN_FALSE;
+		zend_argument_value_error(3, "must be contained in argument #1 ($haystack)");
+		RETURN_THROWS();
 	}
 
 	/* we checked that it will fit: */
 	offset = (int32_t) loffset;
 
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
-
-	if (needle_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
-		RETURN_THROWS();
-	}
 
 	is_ascii = ( grapheme_ascii_check((unsigned char*)haystack, haystack_len) >= 0 );
 
@@ -240,19 +229,14 @@ PHP_FUNCTION(grapheme_strrpos)
 	}
 
 	if ( OUTSIDE_STRING(loffset, haystack_len) ) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_strpos: Offset not contained in string", 1 );
-		RETURN_FALSE;
+		zend_argument_value_error(3, "must be contained in argument #1 ($haystack)");
+		RETURN_THROWS();
 	}
 
 	/* we checked that it will fit: */
 	offset = (int32_t) loffset;
 
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
-
-	if (needle_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
-		RETURN_FALSE;
-	}
 
 	is_ascii = grapheme_ascii_check((unsigned char *)haystack, haystack_len) >= 0;
 
@@ -300,19 +284,14 @@ PHP_FUNCTION(grapheme_strripos)
 	}
 
 	if ( OUTSIDE_STRING(loffset, haystack_len) ) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_strpos: Offset not contained in string", 1 );
-		RETURN_FALSE;
+		zend_argument_value_error(3, "must be contained in argument #1 ($haystack)");
+		RETURN_THROWS();
 	}
 
 	/* we checked that it will fit: */
 	offset = (int32_t) loffset;
 
 	/* the offset is 'grapheme count offset' so it still might be invalid - we'll check it later */
-
-	if (needle_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
-		RETURN_THROWS();
-	}
 
 	is_ascii = grapheme_ascii_check((unsigned char *)haystack, haystack_len) >= 0;
 
@@ -377,8 +356,8 @@ PHP_FUNCTION(grapheme_substr)
 	}
 
 	if ( OUTSIDE_STRING(lstart, str_len)) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_substr: start not contained in string", 1 );
-		RETURN_FALSE;
+		zend_argument_value_error(2, "must be contained in argument #1 ($string)");
+		RETURN_THROWS();
 	}
 
 	/* we checked that it will fit: */
@@ -532,10 +511,9 @@ PHP_FUNCTION(grapheme_substr)
 
 	if ( UBRK_DONE == sub_str_end_pos) {
 		if(length < 0) {
-			intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR, "grapheme_substr: length not contained in string", 1 );
-
+			zend_argument_value_error(3, "must be contained in argument #1 ($string)");
 			efree(ustr);
-			RETURN_FALSE;
+			RETURN_THROWS();
 		} else {
 			sub_str_end_pos = ustr_len;
 		}
@@ -580,12 +558,6 @@ static void strstr_common_handler(INTERNAL_FUNCTION_PARAMETERS, int f_ignore_cas
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss|b", &haystack, &haystack_len, &needle, &needle_len, &part) == FAILURE) {
 		RETURN_THROWS();
 	}
-
-	if (needle_len == 0) {
-		zend_argument_value_error(2, "cannot be empty");
-		RETURN_THROWS();
-	}
-
 
 	if ( !f_ignore_case ) {
 

--- a/ext/intl/locale/locale_methods.c
+++ b/ext/intl/locale/locale_methods.c
@@ -882,10 +882,9 @@ PHP_FUNCTION(locale_compose)
 	/* Not grandfathered */
 	result = append_key_value(loc_name, hash_arr , LOC_LANG_TAG);
 	if( result == LOC_NOT_FOUND ){
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,
-		"locale_compose: parameter array does not contain 'language' tag.", 0 );
+		zend_argument_value_error(1, "must contain a \"%s\" key", LOC_LANG_TAG);
 		smart_str_free(loc_name);
-		RETURN_FALSE;
+		RETURN_THROWS();
 	}
 	if( !handleAppendResult( result, loc_name)){
 		RETURN_FALSE;
@@ -1348,7 +1347,7 @@ static zend_string* lookup_loc_range(const char* loc_range, HashTable* hash_arr,
 	/* convert the array to lowercase , also replace hyphens with the underscore and store it in cur_arr */
 		if(Z_TYPE_P(ele_value)!= IS_STRING) {
 			/* element value is not a string */
-			intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "lookup_loc_range: locale array element is not a string", 0);
+			zend_argument_type_error(2, "must only contain string values");
 			LOOKUP_CLEAN_RETURN(NULL);
 		}
 		cur_arr[cur_arr_len*2] = estrndup(Z_STRVAL_P(ele_value), Z_STRLEN_P(ele_value));

--- a/ext/intl/normalizer/normalizer_normalize.c
+++ b/ext/intl/normalizer/normalizer_normalize.c
@@ -121,9 +121,8 @@ PHP_FUNCTION( normalizer_normalize )
 #endif
 			break;
 		default:
-			intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,
-						"normalizer_normalize: illegal normalization form", 0 );
-			RETURN_FALSE;
+			zend_argument_value_error(2, "must be a a valid normalization form");
+			RETURN_THROWS();
 	}
 
 	/*
@@ -248,9 +247,8 @@ PHP_FUNCTION( normalizer_is_normalized )
 #endif
 			break;
 		default:
-			intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,
-						"normalizer_normalize: illegal normalization form", 0 );
-			RETURN_FALSE;
+			zend_argument_value_error(2, "must be a a valid normalization form");
+			RETURN_THROWS();
 	}
 
 

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -105,9 +105,7 @@ static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS)
 	}
 
 	if (bundlename_len >= MAXPATHLEN) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,	"Bundle name too long", 0 );
-		zval_ptr_dtor(return_value);
-		ZVAL_NULL(return_value);
+		zend_argument_value_error(2, "is too long");
 		return FAILURE;
 	}
 
@@ -296,8 +294,8 @@ PHP_FUNCTION( resourcebundle_locales )
 	}
 
 	if (bundlename_len >= MAXPATHLEN) {
-		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,	"resourcebundle_locales: bundle name too long", 0 );
-		RETURN_FALSE;
+		zend_argument_value_error(1, "is too long");
+		RETURN_THROWS();
 	}
 
 	if(bundlename_len == 0) {

--- a/ext/intl/tests/bug61487.phpt
+++ b/ext/intl/tests/bug61487.phpt
@@ -6,9 +6,18 @@ if (PHP_INT_SIZE != 8) die('skip 64-bit only');
 ?>
 --FILE--
 <?php
-var_dump(grapheme_stripos(1,1,2147483648));
-var_dump(grapheme_strpos(1,1,2147483648));
+try {
+    grapheme_stripos(1,1,2147483648);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    grapheme_strpos(1,1,2147483648);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 ?>
 --EXPECT--
-bool(false)
-bool(false)
+grapheme_stripos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)
+grapheme_strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)

--- a/ext/intl/tests/bug62083.phpt
+++ b/ext/intl/tests/bug62083.phpt
@@ -7,7 +7,11 @@ if (!extension_loaded('intl'))
 --FILE--
 <?php
 $arr1 = array();
-var_dump(grapheme_extract(-1, -1, -1,-1, $arr1));
+try {
+    grapheme_extract(-1, -1, -1,-1, $arr1);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 ?>
 --EXPECT--
-bool(false)
+grapheme_extract(): Argument #3 ($extract_type) must be either GRAPHEME_EXTR_COUNT, GRAPHEME_EXTR_MAXBYTES, or GRAPHEME_EXTR_MAXCHARS

--- a/ext/intl/tests/grapheme.phpt
+++ b/ext/intl/tests/grapheme.phpt
@@ -400,11 +400,19 @@ function ut_main()
         $arg0 = urlencode($test[0]);
         $res_str .= "substring of \"$arg0\" from \"$test[1]\" - grapheme_substr";
         if ( 3 == count( $test ) ) {
-            $result = grapheme_substr($test[0], $test[1]);
+            try {
+                $result = grapheme_substr($test[0], $test[1]);
+            } catch (ValueError $exception) {
+                echo $exception->getMessage() . "\n";
+            }
         }
         else {
             $res_str .= " with length $test[2]";
-            $result = grapheme_substr($test[0], $test[1], $test[2]);
+            try {
+                $result = grapheme_substr($test[0], $test[1], $test[2]);
+            } catch (ValueError $exception) {
+                echo $exception->getMessage() . "\n";
+            }
         }
         $res_str .= " = ";
         if ( $result === false ) {
@@ -465,11 +473,19 @@ function ut_main()
         $arg0 = urlencode($test[0]);
         $res_str .= "find \"$arg1\" in \"$arg0\" - grapheme_strstr";
         if ( 3 == count( $test ) ) {
-            $result = grapheme_strstr($test[0], $test[1]);
+            try {
+                $result = grapheme_strstr($test[0], $test[1]);
+            } catch (ValueError $exception) {
+                echo $exception->getMessage() . "\n";
+            }
         }
         else {
             $res_str .= " before flag is " . ( $test[2] ? "TRUE" : "FALSE" );
-            $result = grapheme_strstr($test[0], $test[1], $test[2]);
+            try {
+                $result = grapheme_strstr($test[0], $test[1], $test[2]);
+            } catch (ValueError $exception) {
+                echo $exception->getMessage() . "\n";
+            }
         }
         $res_str .= " = ";
         if ( $result === false ) {

--- a/ext/intl/tests/grapheme.phpt
+++ b/ext/intl/tests/grapheme.phpt
@@ -403,7 +403,7 @@ function ut_main()
             try {
                 $result = grapheme_substr($test[0], $test[1]);
             } catch (ValueError $exception) {
-                echo $exception->getMessage() . "\n";
+                $res_str .= ": " . $exception->getMessage() . "\n";
             }
         }
         else {
@@ -411,7 +411,7 @@ function ut_main()
             try {
                 $result = grapheme_substr($test[0], $test[1], $test[2]);
             } catch (ValueError $exception) {
-                echo $exception->getMessage() . "\n";
+                $res_str .= ": " . $exception->getMessage() . "\n";
             }
         }
         $res_str .= " = ";
@@ -476,7 +476,7 @@ function ut_main()
             try {
                 $result = grapheme_strstr($test[0], $test[1]);
             } catch (ValueError $exception) {
-                echo $exception->getMessage() . "\n";
+                $res_str .= ": " . $exception->getMessage() . "\n";
             }
         }
         else {
@@ -484,7 +484,7 @@ function ut_main()
             try {
                 $result = grapheme_strstr($test[0], $test[1], $test[2]);
             } catch (ValueError $exception) {
-                echo $exception->getMessage() . "\n";
+                $res_str .= ": " . $exception->getMessage() . "\n";
             }
         }
         $res_str .= " = ";
@@ -973,7 +973,8 @@ find "a%CC%8ABca%CC%8A" in "o%CC%88a%CC%8AaA%CC%8AbCa%CC%8Adef" - grapheme_strri
 
 function grapheme_substr($string, $start, $length = -1) {}
 
-substring of "abc" from "3" - grapheme_substr = false == false
+substring of "abc" from "3" - grapheme_substr: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+ = 3 == false **FAILED** 
 substring of "aa%CC%8Abco%CC%88" from "5" - grapheme_substr = false == false
 substring of "aoa%CC%8Abco%CC%88O" from "2" - grapheme_substr = a%CC%8Abco%CC%88O == a%CC%8Abco%CC%88O
 substring of "o%CC%88a%CC%8AaA%CC%8Abc" from "2" - grapheme_substr = aA%CC%8Abc == aA%CC%8Abc
@@ -982,14 +983,17 @@ substring of "aa%CC%8Abco%CC%88" from "5" - grapheme_substr = false == false
 substring of "aa%CC%8AbcO%CC%88" from "4" - grapheme_substr = O%CC%88 == O%CC%88
 substring of "o%CC%88aa%CC%8Abc" from "2" - grapheme_substr = a%CC%8Abc == a%CC%8Abc
 substring of "aA%CC%8Abc" from "1" - grapheme_substr = A%CC%8Abc == A%CC%8Abc
-substring of "Abc" from "-5" - grapheme_substr = false == false
+substring of "Abc" from "-5" - grapheme_substr: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+ = A%CC%8Abc == false **FAILED** 
 substring of "a%CC%8Abc" from "3" - grapheme_substr = false == false
-substring of "abc" from "4" - grapheme_substr = false == false
+substring of "abc" from "4" - grapheme_substr: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+ = false == false
 substring of "abC" from "2" - grapheme_substr = C == C
 substring of "abc" from "1" - grapheme_substr = bc == bc
 substring of "Abc" from "1" - grapheme_substr with length 1 = b == b
 substring of "abc" from "0" - grapheme_substr with length 2 = ab == ab
-substring of "Abc" from "-4" - grapheme_substr with length 1 = false == false
+substring of "Abc" from "-4" - grapheme_substr with length 1: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+ = ab == false **FAILED** 
 substring of "ababc" from "1" - grapheme_substr with length 2 = ba == ba
 substring of "ababc" from "0" - grapheme_substr with length 10 = ababc == ababc
 substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length 10 = aa%CC%8Abco%CC%88Opq == aa%CC%8Abco%CC%88Opq
@@ -1007,7 +1011,8 @@ substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -5 = 
 substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -6 = aa%CC%8A == aa%CC%8A
 substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -7 = a == a
 substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -8 =  == 
-substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -9 = false == false
+substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -9: grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
+ =  == false **FAILED** 
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr = aa%CC%8Abco%CC%88Opq == aa%CC%8Abco%CC%88Opq
 substring of "aa%CC%8Abco%CC%88Opq" from "-7" - grapheme_substr = a%CC%8Abco%CC%88Opq == a%CC%8Abco%CC%88Opq
 substring of "aa%CC%8Abco%CC%88Opq" from "-6" - grapheme_substr = bco%CC%88Opq == bco%CC%88Opq
@@ -1016,7 +1021,8 @@ substring of "aa%CC%8Abco%CC%88Opq" from "-4" - grapheme_substr = o%CC%88Opq == 
 substring of "aa%CC%8Abco%CC%88Opq" from "-3" - grapheme_substr = Opq == Opq
 substring of "aa%CC%8Abco%CC%88Opq" from "-2" - grapheme_substr = pq == pq
 substring of "aa%CC%8Abco%CC%88Opq" from "-1" - grapheme_substr = q == q
-substring of "aa%CC%8Abco%CC%88Opq" from "-999" - grapheme_substr = false == false
+substring of "aa%CC%8Abco%CC%88Opq" from "-999" - grapheme_substr: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+ = q == false **FAILED** 
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 8 = aa%CC%8Abco%CC%88Opq == aa%CC%8Abco%CC%88Opq
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 7 = aa%CC%8Abco%CC%88Op == aa%CC%8Abco%CC%88Op
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 6 = aa%CC%8Abco%CC%88O == aa%CC%8Abco%CC%88O
@@ -1026,7 +1032,8 @@ substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 3 = 
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 2 = aa%CC%8A == aa%CC%8A
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 1 = a == a
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 0 =  == 
-substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -999 = false == false
+substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -999: grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
+ =  == false **FAILED** 
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -1 = aa%CC%8Abco%CC%88Op == aa%CC%8Abco%CC%88Op
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -2 = aa%CC%8Abco%CC%88O == aa%CC%8Abco%CC%88O
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -3 = aa%CC%8Abco%CC%88 == aa%CC%8Abco%CC%88
@@ -1035,7 +1042,8 @@ substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -5 =
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -6 = aa%CC%8A == aa%CC%8A
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -7 = a == a
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -8 =  == 
-substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -9 = false == false
+substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -9: grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
+ =  == false **FAILED** 
 
 function grapheme_strstr($haystack, $needle, $before_needle = FALSE) {}
 

--- a/ext/intl/tests/grapheme2.phpt
+++ b/ext/intl/tests/grapheme2.phpt
@@ -416,7 +416,7 @@ function ut_main()
             }
             $res_str .= " == " . urlencode($test[count($test)-1]) . check_result($result, $test[count($test)-1]) . "\n";
         } catch (ValueError $exception) {
-            echo $exception->getMessage() . "\n";
+             $res_str .= ": " . $exception->getMessage() . "\n";
         }
     }
 
@@ -786,15 +786,6 @@ function check_result($result, $expected) {
 
 ?>
 --EXPECT--
-grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
-grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
-grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
-grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
-grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
-grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
-grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
-grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
-
 function grapheme_strlen($string) {}
 
 "hindi" in devanagari strlen 2
@@ -970,7 +961,7 @@ find "a%CC%8ABca%CC%8A" in "o%CC%88a%CC%8AaA%CC%8AbCa%CC%8Adef" - grapheme_strri
 
 function grapheme_substr($string, $start, $length = -1) {}
 
-substring of "abc" from "3" - grapheme_substr = false == false
+substring of "abc" from "3" - grapheme_substr: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
 substring of "aa%CC%8Abco%CC%88" from "5" - grapheme_substr = false == false
 substring of "aoa%CC%8Abco%CC%88O" from "2" - grapheme_substr = a%CC%8Abco%CC%88O == a%CC%8Abco%CC%88O
 substring of "o%CC%88a%CC%8AaA%CC%8Abc" from "2" - grapheme_substr = aA%CC%8Abc == aA%CC%8Abc
@@ -979,14 +970,14 @@ substring of "aa%CC%8Abco%CC%88" from "5" - grapheme_substr = false == false
 substring of "aa%CC%8AbcO%CC%88" from "4" - grapheme_substr = O%CC%88 == O%CC%88
 substring of "o%CC%88aa%CC%8Abc" from "2" - grapheme_substr = a%CC%8Abc == a%CC%8Abc
 substring of "aA%CC%8Abc" from "1" - grapheme_substr = A%CC%8Abc == A%CC%8Abc
-substring of "Abc" from "-5" - grapheme_substr = false == false
+substring of "Abc" from "-5" - grapheme_substr: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
 substring of "a%CC%8Abc" from "3" - grapheme_substr = false == false
-substring of "abc" from "4" - grapheme_substr = false == false
+substring of "abc" from "4" - grapheme_substr: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
 substring of "abC" from "2" - grapheme_substr = C == C
 substring of "abc" from "1" - grapheme_substr = bc == bc
 substring of "Abc" from "1" - grapheme_substr with length 1 = b == b
 substring of "abc" from "0" - grapheme_substr with length 2 = ab == ab
-substring of "Abc" from "-4" - grapheme_substr with length 1 = false == false
+substring of "Abc" from "-4" - grapheme_substr with length 1: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
 substring of "ababc" from "1" - grapheme_substr with length 2 = ba == ba
 substring of "ababc" from "0" - grapheme_substr with length 10 = ababc == ababc
 substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length 10 = aa%CC%8Abco%CC%88Opq == aa%CC%8Abco%CC%88Opq
@@ -1004,7 +995,7 @@ substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -5 = 
 substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -6 = aa%CC%8A == aa%CC%8A
 substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -7 = a == a
 substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -8 =  == 
-substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -9 = false == false
+substring of "aa%CC%8Abco%CC%88Opq" from "0" - grapheme_substr with length -9: grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr = aa%CC%8Abco%CC%88Opq == aa%CC%8Abco%CC%88Opq
 substring of "aa%CC%8Abco%CC%88Opq" from "-7" - grapheme_substr = a%CC%8Abco%CC%88Opq == a%CC%8Abco%CC%88Opq
 substring of "aa%CC%8Abco%CC%88Opq" from "-6" - grapheme_substr = bco%CC%88Opq == bco%CC%88Opq
@@ -1013,7 +1004,7 @@ substring of "aa%CC%8Abco%CC%88Opq" from "-4" - grapheme_substr = o%CC%88Opq == 
 substring of "aa%CC%8Abco%CC%88Opq" from "-3" - grapheme_substr = Opq == Opq
 substring of "aa%CC%8Abco%CC%88Opq" from "-2" - grapheme_substr = pq == pq
 substring of "aa%CC%8Abco%CC%88Opq" from "-1" - grapheme_substr = q == q
-substring of "aa%CC%8Abco%CC%88Opq" from "-999" - grapheme_substr = false == false
+substring of "aa%CC%8Abco%CC%88Opq" from "-999" - grapheme_substr: grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 8 = aa%CC%8Abco%CC%88Opq == aa%CC%8Abco%CC%88Opq
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 7 = aa%CC%8Abco%CC%88Op == aa%CC%8Abco%CC%88Op
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 6 = aa%CC%8Abco%CC%88O == aa%CC%8Abco%CC%88O
@@ -1023,7 +1014,7 @@ substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 3 = 
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 2 = aa%CC%8A == aa%CC%8A
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 1 = a == a
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length 0 =  == 
-substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -999 = false == false
+substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -999: grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -1 = aa%CC%8Abco%CC%88Op == aa%CC%8Abco%CC%88Op
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -2 = aa%CC%8Abco%CC%88O == aa%CC%8Abco%CC%88O
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -3 = aa%CC%8Abco%CC%88 == aa%CC%8Abco%CC%88
@@ -1032,7 +1023,7 @@ substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -5 =
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -6 = aa%CC%8A == aa%CC%8A
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -7 = a == a
 substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -8 =  == 
-substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -9 = false == false
+substring of "aa%CC%8Abco%CC%88Opq" from "-8" - grapheme_substr with length -9: grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
 
 function grapheme_strstr($haystack, $needle, $before_needle = FALSE) {}
 

--- a/ext/intl/tests/grapheme2.phpt
+++ b/ext/intl/tests/grapheme2.phpt
@@ -397,23 +397,27 @@ function ut_main()
     );
 
     foreach( $tests as $test ) {
-        $arg0 = urlencode($test[0]);
-        $res_str .= "substring of \"$arg0\" from \"$test[1]\" - grapheme_substr";
-        if ( 3 == count( $test ) ) {
-            $result = grapheme_substr($test[0], $test[1]);
+        try {
+            $arg0 = urlencode($test[0]);
+            $res_str .= "substring of \"$arg0\" from \"$test[1]\" - grapheme_substr";
+            if ( 3 == count( $test ) ) {
+                $result = grapheme_substr($test[0], $test[1]);
+            }
+            else {
+                $res_str .= " with length $test[2]";
+                $result = grapheme_substr($test[0], $test[1], $test[2]);
+            }
+            $res_str .= " = ";
+            if ( $result === false ) {
+                $res_str .= 'false';
+            }
+            else {
+                $res_str .= urlencode($result);
+            }
+            $res_str .= " == " . urlencode($test[count($test)-1]) . check_result($result, $test[count($test)-1]) . "\n";
+        } catch (ValueError $exception) {
+            echo $exception->getMessage() . "\n";
         }
-        else {
-            $res_str .= " with length $test[2]";
-            $result = grapheme_substr($test[0], $test[1], $test[2]);
-        }
-        $res_str .= " = ";
-        if ( $result === false ) {
-            $res_str .= 'false';
-        }
-        else {
-            $res_str .= urlencode($result);
-        }
-        $res_str .= " == " . urlencode($test[count($test)-1]) . check_result($result, $test[count($test)-1]) . "\n";
     }
 
 
@@ -782,6 +786,15 @@ function check_result($result, $expected) {
 
 ?>
 --EXPECT--
+grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
+grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
+grapheme_substr(): Argument #3 ($length) must be contained in argument #1 ($string)
+
 function grapheme_strlen($string) {}
 
 "hindi" in devanagari strlen 2

--- a/ext/intl/tests/grapheme_empty.phpt
+++ b/ext/intl/tests/grapheme_empty.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test grapheme_strpos-alike functions with empty needle
+--SKIPIF--
+<?php if( !extension_loaded( 'intl' ) ) print 'skip'; ?>
+--FILE--
+<?php
+
+var_dump(grapheme_strpos("abc", ""));
+var_dump(grapheme_stripos("abc", ""));
+var_dump(grapheme_strrpos("abc", ""));
+var_dump(grapheme_strripos("abc", ""));
+var_dump(grapheme_strstr("abc", ""));
+var_dump(grapheme_stristr("abc", ""));
+
+?>
+--EXPECT--
+int(0)
+int(0)
+int(3)
+int(3)
+string(3) "abc"
+bool(false)

--- a/ext/intl/tests/grapheme_empty.phpt
+++ b/ext/intl/tests/grapheme_empty.phpt
@@ -5,18 +5,84 @@ Test grapheme_strpos-alike functions with empty needle
 --FILE--
 <?php
 
-var_dump(grapheme_strpos("abc", ""));
-var_dump(grapheme_stripos("abc", ""));
-var_dump(grapheme_strrpos("abc", ""));
-var_dump(grapheme_strripos("abc", ""));
-var_dump(grapheme_strstr("abc", ""));
-var_dump(grapheme_stristr("abc", ""));
+ini_set("intl.error_level", E_WARNING);
+
+try {
+    var_dump(grapheme_strpos("abc", "", -1));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_strpos("abc", ""));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_strpos("abc", "", -1));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_stripos("abc", ""));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_stripos("abc", "", -1));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_strrpos("abc", ""));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_strrpos("abc", "", -1));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_strripos("abc", ""));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_strripos("abc", "", 1));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_strstr("abc", ""));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    var_dump(grapheme_stristr("abc", ""));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 ?>
 --EXPECT--
-int(0)
-int(0)
-int(3)
-int(3)
-string(3) "abc"
-bool(false)
+grapheme_strpos(): Argument #2 ($needle) cannot be empty
+grapheme_strpos(): Argument #2 ($needle) cannot be empty
+grapheme_strpos(): Argument #2 ($needle) cannot be empty
+grapheme_stripos(): Argument #2 ($needle) cannot be empty
+grapheme_stripos(): Argument #2 ($needle) cannot be empty
+grapheme_strrpos(): Argument #2 ($needle) cannot be empty
+grapheme_strrpos(): Argument #2 ($needle) cannot be empty
+grapheme_strripos(): Argument #2 ($needle) cannot be empty
+grapheme_strripos(): Argument #2 ($needle) cannot be empty
+grapheme_strstr(): Argument #2 ($needle) cannot be empty
+grapheme_stristr(): Argument #2 ($needle) cannot be empty

--- a/ext/intl/tests/locale_compose_locale.phpt
+++ b/ext/intl/tests/locale_compose_locale.phpt
@@ -113,14 +113,17 @@ function ut_main()
             $res_str .=  $valKey ."->".$valValue."  " ;
         }
 */
-
-        $locale = ut_loc_locale_compose( $value);
-        $res_str .= "\n\nComposed Locale: ";
-        if( $locale){
-            $res_str .= "$locale";
-        }else{
-            $res_str .= "No values found from Locale compose due to the following error:\n";
-            $res_str .= intl_get_error_message() ;
+        try {
+            $locale = ut_loc_locale_compose( $value);
+            $res_str .= "\n\nComposed Locale: ";
+            if( $locale){
+                $res_str .= "$locale";
+            }else{
+                $res_str .= "No values found from Locale compose due to the following error:\n";
+                $res_str .= intl_get_error_message() ;
+            }
+        } catch (ValueError $exception) {
+            echo $exception->getMessage() . "\n";
         }
     }
 
@@ -135,6 +138,9 @@ ut_run();
 
 ?>
 --EXPECT--
+Locale::composeLocale(): Argument #1 ($subtags) must contain a "language" key
+locale_compose(): Argument #1 ($subtags) must contain a "language" key
+
 ------------
 Input Array name is : loc1
 
@@ -169,9 +175,6 @@ Input Array name is : loc8
 Composed Locale: en_lng_ing_Hans_CN_nedis_rozaj_x_prv1_prv2
 ------------
 Input Array name is : loc9
-
-Composed Locale: No values found from Locale compose due to the following error:
-locale_compose: parameter array does not contain 'language' tag.: U_ILLEGAL_ARGUMENT_ERROR
 ------------
 Input Array name is : loc10
 

--- a/ext/intl/tests/transliterator_transliterate_error.phpt
+++ b/ext/intl/tests/transliterator_transliterate_error.phpt
@@ -11,7 +11,12 @@ $tr = Transliterator::create("latin");
 
 //Arguments
 var_dump(transliterator_transliterate($tr,"str",7));
-var_dump(transliterator_transliterate($tr,"str",7,6));
+
+try {
+    transliterator_transliterate($tr,"str",7,6);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 
 //bad UTF-8
 transliterator_transliterate($tr, "\x80\x03");
@@ -21,9 +26,7 @@ echo "Done.\n";
 --EXPECTF--
 Warning: transliterator_transliterate(): transliterator_transliterate: Neither "start" nor the "end" arguments can exceed the number of UTF-16 code units (in this case, 3) in %s on line %d
 bool(false)
-
-Warning: transliterator_transliterate(): transliterator_transliterate: "start" argument should be non-negative and not bigger than "end" (if defined) in %s on line %d
-bool(false)
+transliterator_transliterate(): Argument #2 ($subject) must be less than or equal to argument #3 ($end)
 
 Warning: transliterator_transliterate(): String conversion of string to UTF-16 failed in %s on line %d
 Done.

--- a/ext/intl/transliterator/transliterator_class.c
+++ b/ext/intl/transliterator/transliterator_class.c
@@ -179,8 +179,7 @@ err:
 	else
 	{
 		/* We shouldn't have unconstructed objects in the first place */
-		php_error_docref( NULL, E_WARNING,
-			"Cloning unconstructed transliterator." );
+		zend_throw_error(NULL, "Unconstructed Transliterator object cannot be cloned");
 	}
 
 	return ret_val;
@@ -215,7 +214,7 @@ static zval *Transliterator_read_property( zend_object *object, zend_string *nam
 		( zend_binary_strcmp( "id", sizeof( "id" ) - 1,
 		ZSTR_VAL( name ), ZSTR_LEN( name ) ) == 0 ) )
 	{
-		php_error_docref(NULL, E_WARNING, "The property \"id\" is read-only" );
+		zend_throw_error(NULL, "Transliterator::$id is read-only");
 		retval = &EG( uninitialized_zval );
 	}
 	else
@@ -243,7 +242,7 @@ static zval *Transliterator_write_property( zend_object *object, zend_string *na
 		( zend_binary_strcmp( "id", sizeof( "id" ) - 1,
 		ZSTR_VAL( name ), ZSTR_LEN( name ) ) == 0 ) )
 	{
-		php_error_docref(NULL, E_WARNING, "The property \"id\" is read-only" );
+		zend_throw_error(NULL, "Transliterator::$id is read-only");
 	}
 	else
 	{


### PR DESCRIPTION
There is quite a few `intl_error_set()` invocations remaining, out of which probably a few could also be promoted to an exception.