### PR TITLE
Colorize --show-diff, only on stdout

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1767,10 +1767,16 @@ function run_worker(): void
 function show_file_block(string $file, string $block, ?string $section = null): void
 {
     global $cfg;
+    global $colorize;
 
     if ($cfg['show'][$file]) {
         if (is_null($section)) {
             $section = strtoupper($file);
+        }
+        if ($section === 'DIFF' && $colorize) {
+            // '-' is Light Red for removal, '+' is Light Green for addition
+            $block = preg_replace('/^[0-9]+\-\s.*$/m', "\e[1;31m\\0\e[0m", $block);
+            $block = preg_replace('/^[0-9]+\+\s.*$/m', "\e[1;32m\\0\e[0m", $block);
         }
 
         echo "\n========" . $section . "========\n";


### PR DESCRIPTION
Don't add colors to the saved `.diff` file.

Related to a41cf3e1d2ed3ae38ad6115a8b65e5f14dae0b49