### PR TITLE
Bug #79757 segfault when passing NULL to zend_list_delete

### DIFF
--- a/Zend/zend_list.c
+++ b/Zend/zend_list.c
@@ -44,7 +44,7 @@ ZEND_API zval* ZEND_FASTCALL zend_list_insert(void *ptr, int type)
 
 ZEND_API int ZEND_FASTCALL zend_list_delete(zend_resource *res)
 {
-	if (GC_DELREF(res) <= 0) {
+	if (res && GC_DELREF(res) <= 0) {
 		return zend_hash_index_del(&EG(regular_list), res->handle);
 	} else {
 		return SUCCESS;


### PR DESCRIPTION
related with Bug #79757 https://bugs.php.net/bug.php?id=79757
Also i reproduced this bug with fopen
`#0  zend_list_delete (res=res@entry=0x0) at /data/work/php-7.4.4/Zend/zend_list.c:47
No locals.
#1  0x00007fffe39be7d1 in php_ssh2_fopen_wraper_parse_path (
    path=path@entry=0x7ffff3a82088 "ssh2.sftp://EDITED/test.zip",
    type=type@entry=0x7fffe39c1d24 "sftp", context=<optimized out>, psession=psession@entry=0x7fffffffd020, presource=presource@entry=0x7fffffffd030,
    psftp=psftp@entry=0x7fffffffd028, psftp_rsrc=0x7fffffffd038) at /home/jaca/ssh2-1.2/ssh2_fopen_wrappers.c:45`
When passing NULL pointer to zend_list_delete and trying to access it with GC_DELREF segfault is thrown. 
My fix solves this issue.