### PR TITLE
Convert file_info resources to objects

### DIFF
--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -51,21 +51,11 @@ typedef struct _finfo_object {
 	zend_object zo;
 } finfo_object;
 
-#define FILEINFO_DECLARE_INIT_OBJECT(object) \
-	zval *object = getThis();
-
 static inline finfo_object *php_finfo_fetch_object(zend_object *obj) {
 	return (finfo_object *)((char*)(obj) - XtOffsetOf(finfo_object, zo));
 }
 
 #define Z_FINFO_P(zv) php_finfo_fetch_object(Z_OBJ_P((zv)))
-
-#define FILEINFO_REGISTER_OBJECT(_object, _ptr) \
-{ \
-	finfo_object *obj; \
-    obj = Z_FINFO_P(_object); \
-    obj->ptr = _ptr; \
-}
 
 #define FILEINFO_FROM_OBJECT(finfo, object) \
 { \
@@ -112,20 +102,6 @@ PHP_FILEINFO_API zend_object *finfo_objects_new(zend_class_entry *class_type)
 				options, magic_errno(magic), magic_error(magic)); \
 		RETURN_FALSE; \
 	}
-
-/* True global resources - no need for thread safety here */
-static int le_fileinfo;
-/* }}} */
-
-void finfo_resource_destructor(zend_resource *rsrc) /* {{{ */
-{
-	if (rsrc->ptr) {
-		php_fileinfo *finfo = (php_fileinfo *) rsrc->ptr;
-		magic_close(finfo->magic);
-		efree(rsrc->ptr);
-		rsrc->ptr = NULL;
-	}
-}
 /* }}} */
 
 /* {{{ PHP_MINIT_FUNCTION */
@@ -143,8 +119,6 @@ PHP_MINIT_FUNCTION(finfo)
 	finfo_object_handlers.offset = XtOffsetOf(finfo_object, zo);
 	finfo_object_handlers.free_obj = finfo_objects_free;
 	finfo_object_handlers.clone_obj = NULL;
-
-	le_fileinfo = zend_register_list_destructors_ex(finfo_resource_destructor, NULL, "file_info", module_number);
 
 	REGISTER_LONG_CONSTANT("FILEINFO_NONE",			MAGIC_NONE, CONST_CS|CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("FILEINFO_SYMLINK",		MAGIC_SYMLINK, CONST_CS|CONST_PERSISTENT);
@@ -204,14 +178,14 @@ PHP_MINFO_FUNCTION(fileinfo)
 }
 /* }}} */
 
-/* {{{ Create a new fileinfo resource. */
+/* {{{ Construct a new fileinfo object. */
 PHP_FUNCTION(finfo_open)
 {
 	zend_long options = MAGIC_NONE;
 	char *file = NULL;
 	size_t file_len = 0;
 	php_fileinfo *finfo;
-	FILEINFO_DECLARE_INIT_OBJECT(object)
+	zval *object = getThis();
 	char resolved_path[MAXPATHLEN];
 	zend_error_handling zeh;
 
@@ -287,29 +261,27 @@ PHP_FUNCTION(finfo_open)
 	}
 
 	if (object) {
+		finfo_object *obj;
 		zend_restore_error_handling(&zeh);
-		FILEINFO_REGISTER_OBJECT(object, finfo);
+		obj = Z_FINFO_P(object);
+		obj->ptr = finfo;
 	} else {
-		RETURN_RES(zend_register_resource(finfo, le_fileinfo));
+		zend_object *zobj = finfo_objects_new(finfo_class_entry);
+		finfo_object *obj = php_finfo_fetch_object(zobj);
+		obj->ptr = finfo;
+		RETURN_OBJ(zobj);
 	}
 }
 /* }}} */
 
-/* {{{ Close fileinfo resource. */
+/* {{{ Close fileinfo object - a NOP. */
 PHP_FUNCTION(finfo_close)
 {
-	php_fileinfo *finfo;
-	zval *zfinfo;
+	zval *self;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &zfinfo) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &self, finfo_class_entry) == FAILURE) {
 		RETURN_THROWS();
 	}
-
-	if ((finfo = (php_fileinfo *)zend_fetch_resource(Z_RES_P(zfinfo), "file_info", le_fileinfo)) == NULL) {
-		RETURN_THROWS();
-	}
-
-	zend_list_close(Z_RES_P(zfinfo));
 
 	RETURN_TRUE;
 }
@@ -320,22 +292,12 @@ PHP_FUNCTION(finfo_set_flags)
 {
 	zend_long options;
 	php_fileinfo *finfo;
-	zval *zfinfo;
-	FILEINFO_DECLARE_INIT_OBJECT(object)
+	zval *self;
 
-	if (object) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &options) == FAILURE) {
-			RETURN_THROWS();
-		}
-		FILEINFO_FROM_OBJECT(finfo, object);
-	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &zfinfo, &options) == FAILURE) {
-			RETURN_THROWS();
-		}
-		if ((finfo = (php_fileinfo *)zend_fetch_resource(Z_RES_P(zfinfo), "file_info", le_fileinfo)) == NULL) {
-			RETURN_THROWS();
-		}
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Ol", &self, finfo_class_entry, &options) == FAILURE) {
+		RETURN_THROWS();
 	}
+	FILEINFO_FROM_OBJECT(finfo, self);
 
 	FINFO_SET_OPTION(finfo->magic, options)
 	finfo->options = options;
@@ -354,12 +316,10 @@ static void _php_finfo_get_type(INTERNAL_FUNCTION_PARAMETERS, int mode, int mime
 	char *ret_val = NULL, *buffer = NULL;
 	size_t buffer_len;
 	php_fileinfo *finfo = NULL;
-	zval *zfinfo, *zcontext = NULL;
+	zval *zcontext = NULL;
 	zval *what;
 	char mime_directory[] = "directory";
-
 	struct magic_set *magic = NULL;
-	FILEINFO_DECLARE_INIT_OBJECT(object)
 
 	if (mimetype_emu) {
 
@@ -389,19 +349,12 @@ static void _php_finfo_get_type(INTERNAL_FUNCTION_PARAMETERS, int mode, int mime
 			php_error_docref(NULL, E_WARNING, "Failed to load magic database");
 			goto common;
 		}
-	} else if (object) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|lr!", &buffer, &buffer_len, &options, &zcontext) == FAILURE) {
-			RETURN_THROWS();
-		}
-		FILEINFO_FROM_OBJECT(finfo, object);
-		magic = finfo->magic;
 	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "rs|lr!", &zfinfo, &buffer, &buffer_len, &options, &zcontext) == FAILURE) {
+		zval *self;
+		if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Os|lr!", &self, finfo_class_entry, &buffer, &buffer_len, &options, &zcontext) == FAILURE) {
 			RETURN_THROWS();
 		}
-		if ((finfo = (php_fileinfo *)zend_fetch_resource(Z_RES_P(zfinfo), "file_info", le_fileinfo)) == NULL) {
-			RETURN_THROWS();
-		}
+		FILEINFO_FROM_OBJECT(finfo, self);
 		magic = finfo->magic;
 	}
 

--- a/ext/fileinfo/fileinfo.stub.php
+++ b/ext/fileinfo/fileinfo.stub.php
@@ -28,30 +28,21 @@ class finfo
     public function set_flags(int $flags) {}
 }
 
-/** @return resource|false */
-function finfo_open(int $flags = FILEINFO_NONE, string $magic_database = "") {}
+function finfo_open(int $flags = FILEINFO_NONE, string $magic_database = ""): finfo|false {}
+
+function finfo_close(finfo $finfo): bool {}
+
+function finfo_set_flags(finfo $finfo, int $flags): bool {}
 
 /**
- * @param resource $finfo
- */
-function finfo_close($finfo): bool {}
-
-/**
- * @param resource $finfo
- */
-function finfo_set_flags($finfo, int $flags): bool {}
-
-/**
- * @param resource $finfo
  * @param resource|null $context
  */
-function finfo_file($finfo, string $filename, int $flags = FILEINFO_NONE, $context = null): string|false {}
+function finfo_file(finfo $finfo, string $filename, int $flags = FILEINFO_NONE, $context = null): string|false {}
 
 /**
- * @param resource $finfo
  * @param resource|null $context
  */
-function finfo_buffer($finfo, string $string, int $flags = FILEINFO_NONE, $context = null): string|false {}
+function finfo_buffer(finfo $finfo, string $string, int $flags = FILEINFO_NONE, $context = null): string|false {}
 
 /**
  * @param resource|string $filename

--- a/ext/fileinfo/fileinfo_arginfo.h
+++ b/ext/fileinfo/fileinfo_arginfo.h
@@ -1,29 +1,29 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: be858509df27550b51d8a7a51a3629eceb6d0aa6 */
+ * Stub hash: 1282a20b1d007bbcc9c0d4efe400db43a5450307 */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_finfo_open, 0, 0, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_finfo_open, 0, 0, finfo, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FILEINFO_NONE")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, magic_database, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_finfo_close, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, finfo)
+	ZEND_ARG_OBJ_INFO(0, finfo, finfo, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_finfo_set_flags, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, finfo)
+	ZEND_ARG_OBJ_INFO(0, finfo, finfo, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_finfo_file, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, finfo)
+	ZEND_ARG_OBJ_INFO(0, finfo, finfo, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FILEINFO_NONE")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, context, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_finfo_buffer, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, finfo)
+	ZEND_ARG_OBJ_INFO(0, finfo, finfo, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FILEINFO_NONE")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, context, "null")
@@ -33,7 +33,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mime_content_type, 0, 1, MAY_BE_
 	ZEND_ARG_INFO(0, filename)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_finfo___construct arginfo_finfo_open
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_finfo___construct, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FILEINFO_NONE")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, magic_database, IS_STRING, 0, "\"\"")
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_finfo_file, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)

--- a/ext/fileinfo/tests/bug61964-mb.phpt
+++ b/ext/fileinfo/tests/bug61964-mb.phpt
@@ -45,8 +45,10 @@ rmdir($dir);
 ?>
 --EXPECTF--
 bool(false)%A
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
 bool(false)%A
 Warning: finfo_open(): offset `string' invalid in %sbug61964-mb.php on line %d
 

--- a/ext/fileinfo/tests/bug61964.phpt
+++ b/ext/fileinfo/tests/bug61964.phpt
@@ -45,8 +45,10 @@ rmdir($dir);
 ?>
 --EXPECTF--
 bool(false)%A
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
 bool(false)%A
 Warning: finfo_open(): offset `string' invalid in %sbug61964.php on line %d
 

--- a/ext/fileinfo/tests/finfo_close_basic.phpt
+++ b/ext/fileinfo/tests/finfo_close_basic.phpt
@@ -21,7 +21,8 @@ unset( $finfo );
 ?>
 --EXPECTF--
 *** Testing finfo_close() : basic functionality ***
-resource(%d) of type (file_info)
+object(finfo)#%d (0) {
+}
 bool(true)
 object(finfo)#%d (%d) {
 }

--- a/ext/fileinfo/tests/finfo_close_error.phpt
+++ b/ext/fileinfo/tests/finfo_close_error.phpt
@@ -19,4 +19,4 @@ try {
 *** Testing finfo_close() : error conditions ***
 
 -- Testing finfo_close() function with wrong resource type --
-finfo_close(): supplied resource is not a valid file_info resource
+finfo_close(): Argument #1 ($finfo) must be of type finfo, resource given

--- a/ext/fileinfo/tests/finfo_open_001.phpt
+++ b/ext/fileinfo/tests/finfo_open_001.phpt
@@ -20,8 +20,10 @@ var_dump(finfo_open(FILEINFO_MIME, '/foo/bar/inexistent'));
 ?>
 --EXPECTF--
 finfo_open(): Argument #2 ($magic_database) must not contain any null bytes
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
 
 Warning: finfo_open(%s123): Failed to open stream: No such file or directory in %s on line %d
 

--- a/ext/fileinfo/tests/finfo_open_basic.phpt
+++ b/ext/fileinfo/tests/finfo_open_basic.phpt
@@ -25,14 +25,21 @@ var_dump( new finfo() );
 ?>
 --EXPECTF--
 *** Testing finfo_open() : basic functionality ***
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
-object(finfo)#%d (%d) {
+object(finfo)#%d (0) {
 }
-object(finfo)#%d (%d) {
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
 }

--- a/ext/fileinfo/tests/finfo_open_error.phpt
+++ b/ext/fileinfo/tests/finfo_open_error.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test finfo_open() function : error functionality
 --SKIPIF--
-<?php require_once(__DIR__ . '/skipif.inc');
+<?php require_once(__DIR__ . '/skipif.inc')?>
 --FILE--
 <?php
 $magicFile = __DIR__ . DIRECTORY_SEPARATOR . 'magic';
@@ -35,6 +35,7 @@ Warning: finfo_open(): Failed to load magic database at "%sfoobarfile" in %sfinf
 bool(false)
 
 Warning: finfo_open(): using regular magic file `%smagic' in %sfinfo_open_error.php on line %d
-resource(6) of type (file_info)
+object(finfo)#%d (0) {
+}
 finfo_open(): Argument #1 ($flags) must be of type int, string given
 finfo::__construct(): Argument #1 ($flags) must be of type int, string given

--- a/ext/fileinfo/tests/finfo_open_variation1.phpt
+++ b/ext/fileinfo/tests/finfo_open_variation1.phpt
@@ -16,5 +16,7 @@ var_dump( finfo_open( FILEINFO_DEVICES | FILEINFO_RAW, $magicFile ) );
 ?>
 --EXPECTF--
 *** Testing finfo_open() : variations in opening ***
-resource(%d) of type (file_info)
-resource(%d) of type (file_info)
+object(finfo)#%d (0) {
+}
+object(finfo)#%d (0) {
+}

--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -776,7 +776,7 @@ static const func_info_t func_infos[] = {
 #endif
 
 	/* ext/fileinfo */
-	F1("finfo_open",							MAY_BE_FALSE | MAY_BE_RESOURCE),
+	F1("finfo_open",							MAY_BE_FALSE | MAY_BE_OBJECT),
 	F1("finfo_file",							MAY_BE_FALSE | MAY_BE_STRING),
 	F1("finfo_buffer",							MAY_BE_FALSE | MAY_BE_STRING),
 	F1("mime_content_type",						MAY_BE_FALSE | MAY_BE_STRING),


### PR DESCRIPTION
Besides our general desire to get rid of the legacy resource types,
this is particularly appealing for fileinfo, because there are already
respective objects.

---

Should probably inline `php_fileinfo` in `finfo_object` right away. Also, I wonder about serialization and cloning of finfo objects – is that properly supported?