### PR TITLE
Fix #79968: Manipulation on unattached DOMChildNode should throw DOMException

### DIFF
--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -134,6 +134,11 @@ xmlNode* dom_zvals_to_fragment(php_libxml_ref_obj *document, xmlNode *contextNod
 	dom_object *newNodeObj;
 	int stricterror;
 
+	if (document == NULL) {
+		php_dom_throw_error(HIERARCHY_REQUEST_ERR, 1);
+		return NULL;
+	}
+
 	if (contextNode->type == XML_DOCUMENT_NODE || contextNode->type == XML_HTML_DOCUMENT_NODE) {
 		documentNode = (xmlDoc *) contextNode;
 	} else {

--- a/ext/dom/tests/bug79968.phpt
+++ b/ext/dom/tests/bug79968.phpt
@@ -1,0 +1,17 @@
+--TEST--
+dom: Bug #79968 - Crash when calling before without valid hierachy
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$cdata = new DOMText;
+
+try {
+    $cdata->before("string");
+} catch (DOMException $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECT--
+Hierarchy Request Error


### PR DESCRIPTION
This fixes https://bugs.php.net/bug.php?id=79968

Missing logic implemented from specification:

```
node . before(...nodes)

    Inserts nodes just before node, while replacing strings in nodes with equivalent Text nodes.

    **Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.**
```