### PR TITLE
sqlite3 linkage issue on some systems/package combinations fix.

### DIFF
--- a/ext/sqlite3/config.w32
+++ b/ext/sqlite3/config.w32
@@ -8,6 +8,7 @@ if (PHP_SQLITE3 != "no") {
 
 		AC_DEFINE("HAVE_SQLITE3", 1, "SQLite support");
 		AC_DEFINE("HAVE_SQLITE3_ERRSTR", 1, "have sqlite3_errstr function");
+		AC_DEFINE("HAVE_SQLITE3_EXPANDED_SQL", 1, "have sqlite3_expanded_sql function");
 	} else {
 		WARNING("sqlite3 not enabled; libraries and/or headers not found");
 	}

--- a/ext/sqlite3/config0.m4
+++ b/ext/sqlite3/config0.m4
@@ -15,6 +15,10 @@ if test $PHP_SQLITE3 != "no"; then
     AC_DEFINE(HAVE_SQLITE3_ERRSTR, 1, [have sqlite3_errstr function])
   ], [], [$SQLITE3_SHARED_LIBADD])
 
+  PHP_CHECK_LIBRARY(sqlite3, sqlite3_expanded_sql, [
+    AC_DEFINE(HAVE_SQLITE3_EXPANDED_SQL, 1, [have sqlite3_expanded_sql function])
+  ], [], [$SQLITE3_SHARED_LIBADD])
+
   PHP_CHECK_LIBRARY(sqlite3,sqlite3_load_extension,
     [],
     [AC_DEFINE(SQLITE_OMIT_LOAD_EXTENSION, 1, [have sqlite3 with extension support])],

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1641,7 +1641,7 @@ PHP_METHOD(SQLite3Stmt, getSQL)
 	}
 
 	if (expanded) {
-#if SQLITE_VERSION_NUMBER >= 3014000
+#ifdef HAVE_SQLITE3_EXPANDED_SQL
 		char *sql = sqlite3_expanded_sql(stmt_obj->stmt);
 		RETVAL_STRING(sql);
 		sqlite3_free(sql);


### PR DESCRIPTION
Checking the version is not enough, the function might be available
but the symbols are not present still.