### PR TITLE
Fix #79979: passing value to by-ref param via CUF(A) crashes

### DIFF
--- a/Zend/tests/bug79979.phpt
+++ b/Zend/tests/bug79979.phpt
@@ -2,22 +2,16 @@
 Bug #79979 (passing value to by-ref param via CUF(A) crashes)
 --FILE--
 <?php
-call_user_func_array('exec', ['echo foo', '', '']);
+call_user_func_array("str_replace", ["a", "b", "c", 0]);
 
-$cufa = 'call_user_func_array';
-$cufa('exec', ['echo foo', '', '']);
+$cufa = "call_user_func_array";
+$cufa("str_replace", ["a", "b", "c", 0]);
 
-call_user_func_array($cufa, ['exec', ['echo foo', '', '']]);
+call_user_func_array($cufa, ["str_replace", ["a", "b", "c", 0]]);
 ?>
 --EXPECTF--
-Warning: Parameter 2 to exec() expected to be a reference, value given in %s on line %d
+Warning: Parameter 4 to str_replace() expected to be a reference, value given in %s on line %d
 
-Warning: Parameter 3 to exec() expected to be a reference, value given in %s on line %d
+Warning: Parameter 4 to str_replace() expected to be a reference, value given in %s on line %d
 
-Warning: Parameter 2 to exec() expected to be a reference, value given in %s on line %d
-
-Warning: Parameter 3 to exec() expected to be a reference, value given in %s on line %d
-
-Warning: Parameter 2 to exec() expected to be a reference, value given in %s on line %d
-
-Warning: Parameter 3 to exec() expected to be a reference, value given in %s on line %d
+Warning: Parameter 4 to str_replace() expected to be a reference, value given in %s on line %d

--- a/Zend/tests/bug79979.phpt
+++ b/Zend/tests/bug79979.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #79979 (passing value to by-ref param via CUF(A) crashes)
+--FILE--
+<?php
+call_user_func_array('exec', ['echo foo', '', '']);
+
+$cufa = 'call_user_func_array';
+$cufa('exec', ['echo foo', '', '']);
+
+call_user_func_array($cufa, ['exec', ['echo foo', '', '']]);
+?>
+--EXPECTF--
+Warning: Parameter 2 to exec() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 3 to exec() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 2 to exec() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 3 to exec() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 2 to exec() expected to be a reference, value given in %s on line %d
+
+Warning: Parameter 3 to exec() expected to be a reference, value given in %s on line %d

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -765,12 +765,13 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 					ZVAL_NEW_REF(arg, arg);
 				} else if (!ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
 					/* By-value send is not allowed -- emit a warning,
-					 * but still perform the call with a by-value send. */
+					 * and perform the call with the value wrapped in a reference. */
 					zend_error(E_WARNING,
 						"Parameter %d to %s%s%s() expected to be a reference, value given", i+1,
 						func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
 						func->common.scope ? "::" : "",
 						ZSTR_VAL(func->common.function_name));
+					ZVAL_NEW_REF(arg, arg);
 					if (UNEXPECTED(EG(exception))) {
 						ZEND_CALL_NUM_ARGS(call) = i;
 						zend_vm_stack_free_args(call);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5128,6 +5128,7 @@ ZEND_VM_C_LABEL(send_array):
 				arg_num = 1;
 				param = ZEND_CALL_ARG(EX(call), 1);
 				ZEND_HASH_FOREACH_VAL(ht, arg) {
+					zend_bool must_wrap = 0;
 					if (skip > 0) {
 						skip--;
 						continue;
@@ -5139,6 +5140,7 @@ ZEND_VM_C_LABEL(send_array):
 								/* By-value send is not allowed -- emit a warning,
 								 * but still perform the call. */
 								zend_param_must_be_ref(EX(call)->func, arg_num);
+								must_wrap = 1;
 							}
 						}
 					} else {
@@ -5148,7 +5150,11 @@ ZEND_VM_C_LABEL(send_array):
 							arg = Z_REFVAL_P(arg);
 						}
 					}
-					ZVAL_COPY(param, arg);
+					if (EXPECTED(!must_wrap)) {
+						ZVAL_COPY(param, arg);
+					} else {
+						ZVAL_NEW_REF(param, arg);
+					}
 					ZEND_CALL_NUM_ARGS(EX(call))++;
 					arg_num++;
 					param++;
@@ -5160,12 +5166,14 @@ ZEND_VM_C_LABEL(send_array):
 			arg_num = 1;
 			param = ZEND_CALL_ARG(EX(call), 1);
 			ZEND_HASH_FOREACH_VAL(ht, arg) {
+				zend_bool must_wrap = 0;
 				if (ARG_SHOULD_BE_SENT_BY_REF(EX(call)->func, arg_num)) {
 					if (UNEXPECTED(!Z_ISREF_P(arg))) {
 						if (!ARG_MAY_BE_SENT_BY_REF(EX(call)->func, arg_num)) {
 							/* By-value send is not allowed -- emit a warning,
 							 * but still perform the call. */
 							zend_param_must_be_ref(EX(call)->func, arg_num);
+							must_wrap = 1;
 						}
 					}
 				} else {
@@ -5175,7 +5183,11 @@ ZEND_VM_C_LABEL(send_array):
 						arg = Z_REFVAL_P(arg);
 					}
 				}
-				ZVAL_COPY(param, arg);
+				if (EXPECTED(!must_wrap)) {
+					ZVAL_COPY(param, arg);
+				} else {
+					ZVAL_NEW_REF(param, arg);
+				}
 				ZEND_CALL_NUM_ARGS(EX(call))++;
 				arg_num++;
 				param++;

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -250,7 +250,7 @@ static void php_exec_ex(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 
 		ret = php_exec(2, cmd, ret_array, return_value);
 	}
-	if (ret_code && Z_ISREF_P(ret_code)) {
+	if (ret_code) {
 		ZEND_TRY_ASSIGN_REF_LONG(ret_code, ret);
 	}
 }

--- a/ext/standard/exec.c
+++ b/ext/standard/exec.c
@@ -250,7 +250,7 @@ static void php_exec_ex(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 
 		ret = php_exec(2, cmd, ret_array, return_value);
 	}
-	if (ret_code) {
+	if (ret_code && Z_ISREF_P(ret_code)) {
 		ZEND_TRY_ASSIGN_REF_LONG(ret_code, ret);
 	}
 }


### PR DESCRIPTION
Passing values to by-reference parameters is an error, if the function
is called directly.  If the function is called via `call_user_func()`
or `call_user_func_array()`, however, only a warning is triggered.
Therefore we have to make sure to not call `ZEND_TRY_ASSIGN_REF_*()`
for non-references.

---

This is just an examplary fix for `exec`; sever other functions would need to be fixed the same way.

An alternative fix would be to make the `ZEND_TRY_ASSIGN_REF_*()` macros more liberal, e.g.
````.patch
 Zend/zend_API.h | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)

diff --git a/Zend/zend_API.h b/Zend/zend_API.h
index 2a3b582902..99994bcc69 100644
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -799,8 +799,9 @@ ZEND_API int zend_try_assign_typed_ref_zval_ex(zend_reference *ref, zval *zv, ze
 	_ZEND_TRY_ASSIGN_LONG(zv, lval, 0)
 
 #define ZEND_TRY_ASSIGN_REF_LONG(zv, lval) do { \
-	ZEND_ASSERT(Z_ISREF_P(zv)); \
-	_ZEND_TRY_ASSIGN_LONG(zv, lval, 1); \
+	if (Z_ISREF_P(zv)) { \
+		_ZEND_TRY_ASSIGN_LONG(zv, lval, 1); \
+	} \
 } while (0)
 
 #define _ZEND_TRY_ASSIGN_DOUBLE(zv, dval, is_ref) do { \
````