### PR TITLE
Fix #79986: str_ireplace bug with diacritics characters

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3156,7 +3156,7 @@ static zend_string* php_char_to_str_ex(zend_string *str, char from, char *to, si
 {
 	zend_string *result;
 	size_t char_count = 0;
-	char lc_from = 0;
+	int lc_from = 0;
 	const char *source, *source_end= ZSTR_VAL(str) + ZSTR_LEN(str);
 	char *target;
 

--- a/ext/standard/tests/strings/bug79986.phpt
+++ b/ext/standard/tests/strings/bug79986.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #79986 (str_ireplace bug with diacritics characters)
+--SKIPIF--
+<?php
+if (!setlocale(LC_ALL, 'de_DE.ISO-8859-1', 'de-DE')) die('skip German locale not available');
+?>
+--FILE--
+<?php
+setlocale(LC_ALL, 'de_DE.ISO-8859-1', 'de-DE');
+echo str_ireplace(["\xE4", "\xF6", "\xFC"], ['1', '2', '3'], "\xE4\xC4 \xF6\xD6 \xFC\xDC") . PHP_EOL;
+?>
+--EXPECT--
+11 22 33


### PR DESCRIPTION
`tolower()` returns an `int`, so we must not convert to `char` which
may be `signed` and as such may be subject to overflow (actually,
implementation defined behavior).