### PR TITLE
Refactor SplFileObject methods

### DIFF
--- a/ext/spl/config.m4
+++ b/ext/spl/config.m4
@@ -1,3 +1,4 @@
 PHP_NEW_EXTENSION(spl, php_spl.c spl_functions.c spl_engine.c spl_iterators.c spl_array.c spl_directory.c spl_exceptions.c spl_observer.c spl_dllist.c spl_heap.c spl_fixedarray.c, no,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 PHP_INSTALL_HEADERS([ext/spl], [php_spl.h spl_array.h spl_directory.h spl_engine.h spl_exceptions.h spl_functions.h spl_iterators.h spl_observer.h spl_dllist.h spl_heap.h spl_fixedarray.h])
-PHP_ADD_EXTENSION_DEP(standard, spl, pcre, true)
+PHP_ADD_EXTENSION_DEP(spl, pcre, true)
+PHP_ADD_EXTENSION_DEP(spl, standard, true)

--- a/ext/spl/config.m4
+++ b/ext/spl/config.m4
@@ -1,3 +1,3 @@
 PHP_NEW_EXTENSION(spl, php_spl.c spl_functions.c spl_engine.c spl_iterators.c spl_array.c spl_directory.c spl_exceptions.c spl_observer.c spl_dllist.c spl_heap.c spl_fixedarray.c, no,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 PHP_INSTALL_HEADERS([ext/spl], [php_spl.h spl_array.h spl_directory.h spl_engine.h spl_exceptions.h spl_functions.h spl_iterators.h spl_observer.h spl_dllist.h spl_heap.h spl_fixedarray.h])
-PHP_ADD_EXTENSION_DEP(spl, pcre, true)
+PHP_ADD_EXTENSION_DEP(standard, spl, pcre, true)

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -59,6 +59,13 @@ PHPAPI zend_class_entry *spl_ce_GlobIterator;
 PHPAPI zend_class_entry *spl_ce_SplFileObject;
 PHPAPI zend_class_entry *spl_ce_SplTempFileObject;
 
+// TODO Use standard Error
+#define CHECK_SPL_FILE_OBJECT_IS_INITIALIZED() \
+	if (!intern->u.file.stream) { \
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized"); \
+		RETURN_THROWS(); \
+	}
+
 static void spl_filesystem_file_free_line(spl_filesystem_object *intern) /* {{{ */
 {
 	if (intern->u.file.current_line) {
@@ -2019,7 +2026,7 @@ static int spl_filesystem_file_read_line(zval * this_ptr, spl_filesystem_object 
 
 static void spl_filesystem_file_rewind(zval * this_ptr, spl_filesystem_object *intern) /* {{{ */
 {
-	if(!intern->u.file.stream) {
+	if (!intern->u.file.stream) {
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
 		return;
 	}
@@ -2147,10 +2154,7 @@ PHP_METHOD(SplFileObject, eof)
 		RETURN_THROWS();
 	}
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	RETURN_BOOL(php_stream_eof(intern->u.file.stream));
 } /* }}} */
@@ -2183,10 +2187,7 @@ PHP_METHOD(SplFileObject, fgets)
 		RETURN_THROWS();
 	}
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	if (spl_filesystem_file_read(intern, 0) == FAILURE) {
 		RETURN_FALSE;
@@ -2203,10 +2204,7 @@ PHP_METHOD(SplFileObject, current)
 		RETURN_THROWS();
 	}
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	if (!intern->u.file.current_line && Z_ISUNDEF(intern->u.file.current_zval)) {
 		spl_filesystem_file_read_line(ZEND_THIS, intern, 1);
@@ -2337,10 +2335,7 @@ PHP_METHOD(SplFileObject, fgetcsv)
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|sss", &delim, &d_len, &enclo, &e_len, &esc, &esc_len) == SUCCESS) {
 
-		if(!intern->u.file.stream) {
-			zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-			RETURN_THROWS();
-		}
+		CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 		switch(ZEND_NUM_ARGS())
 		{
@@ -2527,10 +2522,7 @@ PHP_METHOD(SplFileObject, flock)
 		RETURN_THROWS();
 	}
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	act = operation & PHP_LOCK_UN;
 	// TODO doesn't this fail if operation is a bitmask with LOCK_NB?
@@ -2561,10 +2553,7 @@ PHP_METHOD(SplFileObject, fflush)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	RETURN_BOOL(!php_stream_flush(intern->u.file.stream));
 } /* }}} */
@@ -2575,10 +2564,7 @@ PHP_METHOD(SplFileObject, ftell)
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 	zend_long ret;
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	ret = php_stream_tell(intern->u.file.stream);
 
@@ -2599,10 +2585,7 @@ PHP_METHOD(SplFileObject, fseek)
 		RETURN_THROWS();
 	}
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	spl_filesystem_file_free_line(intern);
 	RETURN_LONG(php_stream_seek(intern->u.file.stream, pos, (int)whence));
@@ -2615,10 +2598,7 @@ PHP_METHOD(SplFileObject, fgetc)
 	char buf[2];
 	int result;
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	spl_filesystem_file_free_line(intern);
 
@@ -2642,10 +2622,7 @@ PHP_METHOD(SplFileObject, fpassthru)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	RETURN_LONG(php_stream_passthru(intern->u.file.stream));
 } /* }}} */
@@ -2662,10 +2639,7 @@ PHP_METHOD(SplFileObject, fscanf)
 		RETURN_THROWS();
 	}
 
-	if (!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	/* Get next line */
 	if (spl_filesystem_file_read(intern, 0) == FAILURE) {
@@ -2693,10 +2667,7 @@ PHP_METHOD(SplFileObject, fwrite)
 		RETURN_THROWS();
 	}
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	if (ZEND_NUM_ARGS() > 1) {
 		if (length >= 0) {
@@ -2727,10 +2698,7 @@ PHP_METHOD(SplFileObject, fread)
 		RETURN_THROWS();
 	}
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	if (length <= 0) {
 		php_error_docref(NULL, E_WARNING, "Length parameter must be greater than 0");
@@ -2779,10 +2747,7 @@ PHP_METHOD(SplFileObject, ftruncate)
 		RETURN_THROWS();
 	}
 
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	if (!php_stream_truncate_supported(intern->u.file.stream)) {
 		zend_throw_exception_ex(spl_ce_LogicException, 0, "Can't truncate file %s", intern->file_name);
@@ -2801,10 +2766,8 @@ PHP_METHOD(SplFileObject, seek)
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &line_pos) == FAILURE) {
 		RETURN_THROWS();
 	}
-	if(!intern->u.file.stream) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
+
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
 	if (line_pos < 0) {
 		zend_throw_exception_ex(spl_ce_LogicException, 0, "Can't seek file %s to negative line " ZEND_LONG_FMT, intern->file_name, line_pos);

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -20,12 +20,11 @@
 
 #include "php.h"
 #include "php_ini.h"
-#include "ext/standard/info.h"
 #include "ext/standard/file.h"
+#include "ext/standard/php_filestat.h"
 #include "ext/standard/flock_compat.h"
 #include "ext/standard/scanf.h"
 #include "ext/standard/php_string.h"
-#include "zend_compile.h"
 #include "zend_exceptions.h"
 #include "zend_interfaces.h"
 
@@ -36,12 +35,6 @@
 #include "spl_directory.h"
 #include "spl_directory_arginfo.h"
 #include "spl_exceptions.h"
-
-#include "php.h"
-#include "fopen_wrappers.h"
-
-#include "ext/standard/basic_functions.h"
-#include "ext/standard/php_filestat.h"
 
 #define SPL_HAS_FLAG(flags, test_flag) ((flags & test_flag) ? 1 : 0)
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2493,13 +2493,6 @@ PHP_METHOD(SplFileObject, getCsvControl)
 }
 /* }}} */
 
-/* Because apparently it doesn't want to pull them from flock_compat.h for some stupid reason */
-#define LOCK_SH 1
-#define LOCK_EX 2
-#define LOCK_NB 4
-#define LOCK_UN 8
-
-
 static int flock_values[] = { LOCK_SH, LOCK_EX, LOCK_UN };
 
 /* {{{ Portable file locking, copy pasted from ext/standard/file.c flock() function.

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2511,8 +2511,6 @@ PHP_METHOD(SplFileObject, flock)
 	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	act = operation & PHP_LOCK_UN;
-	// TODO doesn't this fail if operation is a bitmask with LOCK_NB?
-	//if (act != PHP_LOCK_SH && act != PHP_LOCK_EX && act != PHP_LOCK_UN) {
 	if (act < 1 || act > 3) {
 		zend_argument_value_error(1, "must be either LOCK_SH, LOCK_EX, or LOCK_UN");
 		RETURN_THROWS();

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2378,15 +2378,6 @@ PHP_METHOD(SplFileObject, getChildren)
 	/* return NULL */
 } /* }}} */
 
-/* {{{ FileFunction */
-#define FileFunction(func_name) \
-PHP_METHOD(SplFileObject, func_name) \
-{ \
-	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS); \
-	FileFunctionCall(func_name, ZEND_NUM_ARGS()); \
-}
-/* }}} */
-
 /* {{{ Return current line as csv */
 PHP_METHOD(SplFileObject, fgetcsv)
 {
@@ -2567,7 +2558,11 @@ PHP_METHOD(SplFileObject, getCsvControl)
 /* }}} */
 
 /* {{{ Portable file locking */
-FileFunction(flock)
+PHP_METHOD(SplFileObject, flock)
+{
+	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
+	FileFunctionCall(flock, ZEND_NUM_ARGS());
+}
 /* }}} */
 
 /* {{{ Flush the file */
@@ -2746,7 +2741,11 @@ PHP_METHOD(SplFileObject, fread)
 }
 
 /* {{{ Stat() on a filehandle */
-FileFunction(fstat)
+PHP_METHOD(SplFileObject, fstat)
+{
+	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
+	FileFunctionCall(fstat, ZEND_NUM_ARGS());
+}
 /* }}} */
 
 /* {{{ Truncate file to 'size' length */

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2706,6 +2706,7 @@ PHP_METHOD(SplFileObject, fread)
 }
 
 /* {{{ Stat() on a filehandle */
+// TODO Don't call fstat? As it may be undefined if it is disabled via disable_functions
 PHP_METHOD(SplFileObject, fstat)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
@@ -2717,7 +2718,7 @@ PHP_METHOD(SplFileObject, fstat)
 
 	func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "fstat", sizeof("fstat") - 1);
 	if (func_ptr == NULL) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function fstat() not found. Please report");
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "fstat() is not defined");
 		RETURN_THROWS();
 	}
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1944,17 +1944,6 @@ static int spl_filesystem_file_call(spl_filesystem_object *intern, zend_function
 	return result;
 } /* }}} */
 
-#define FileFunctionCall(func_name, pass_num_args) /* {{{ */ \
-{ \
-	zend_function *func_ptr; \
-	func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), #func_name, sizeof(#func_name) - 1); \
-	if (func_ptr == NULL) { \
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function %s() not found. Please report", #func_name); \
-		return; \
-	} \
-	spl_filesystem_file_call(intern, func_ptr, pass_num_args, return_value); \
-} /* }}} */
-
 static int spl_filesystem_file_read_csv(spl_filesystem_object *intern, char delimiter, char enclosure, int escape, zval *return_value) /* {{{ */
 {
 	int ret = SUCCESS;
@@ -2561,7 +2550,14 @@ PHP_METHOD(SplFileObject, getCsvControl)
 PHP_METHOD(SplFileObject, flock)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
-	FileFunctionCall(flock, ZEND_NUM_ARGS());
+	zend_function *func_ptr;
+
+    func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "flock", sizeof("flock") - 1);
+    if (func_ptr == NULL) {
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function flock() not found. Please report");
+		RETURN_THROWS();
+    }
+    spl_filesystem_file_call(intern, func_ptr, ZEND_NUM_ARGS(), return_value);
 }
 /* }}} */
 
@@ -2663,6 +2659,7 @@ PHP_METHOD(SplFileObject, fpassthru)
 PHP_METHOD(SplFileObject, fscanf)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
+	zend_function *func_ptr;
 
 	if(!intern->u.file.stream) {
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
@@ -2672,7 +2669,12 @@ PHP_METHOD(SplFileObject, fscanf)
 	spl_filesystem_file_free_line(intern);
 	intern->u.file.current_line_num++;
 
-	FileFunctionCall(fscanf, ZEND_NUM_ARGS());
+    func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "fscanf", sizeof("fscanf") - 1);
+    if (func_ptr == NULL) {
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function fscanf() not found. Please report");
+		RETURN_THROWS();
+    }
+    spl_filesystem_file_call(intern, func_ptr, ZEND_NUM_ARGS(), return_value);
 }
 /* }}} */
 
@@ -2744,7 +2746,14 @@ PHP_METHOD(SplFileObject, fread)
 PHP_METHOD(SplFileObject, fstat)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
-	FileFunctionCall(fstat, ZEND_NUM_ARGS());
+	zend_function *func_ptr;
+
+    func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "fstat", sizeof("fstat") - 1);
+    if (func_ptr == NULL) {
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function fstat() not found. Please report");
+		RETURN_THROWS();
+    }
+    spl_filesystem_file_call(intern, func_ptr, ZEND_NUM_ARGS(), return_value);
 }
 /* }}} */
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -53,8 +53,8 @@ PHPAPI zend_class_entry *spl_ce_SplFileObject;
 PHPAPI zend_class_entry *spl_ce_SplTempFileObject;
 
 // TODO Use standard Error
-#define CHECK_SPL_FILE_OBJECT_IS_INITIALIZED() \
-	if (!intern->u.file.stream) { \
+#define CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(spl_filesystem_object_pointer) \
+	if (!(spl_filesystem_object_pointer)->u.file.stream) { \
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized"); \
 		RETURN_THROWS(); \
 	}
@@ -2147,7 +2147,7 @@ PHP_METHOD(SplFileObject, eof)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	RETURN_BOOL(php_stream_eof(intern->u.file.stream));
 } /* }}} */
@@ -2180,7 +2180,7 @@ PHP_METHOD(SplFileObject, fgets)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	if (spl_filesystem_file_read(intern, 0) == FAILURE) {
 		RETURN_FALSE;
@@ -2197,7 +2197,7 @@ PHP_METHOD(SplFileObject, current)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	if (!intern->u.file.current_line && Z_ISUNDEF(intern->u.file.current_zval)) {
 		spl_filesystem_file_read_line(ZEND_THIS, intern, 1);
@@ -2328,7 +2328,7 @@ PHP_METHOD(SplFileObject, fgetcsv)
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|sss", &delim, &d_len, &enclo, &e_len, &esc, &esc_len) == SUCCESS) {
 
-		CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+		CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 		switch(ZEND_NUM_ARGS())
 		{
@@ -2508,7 +2508,7 @@ PHP_METHOD(SplFileObject, flock)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	act = operation & PHP_LOCK_UN;
 	// TODO doesn't this fail if operation is a bitmask with LOCK_NB?
@@ -2539,7 +2539,7 @@ PHP_METHOD(SplFileObject, fflush)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	RETURN_BOOL(!php_stream_flush(intern->u.file.stream));
 } /* }}} */
@@ -2550,7 +2550,7 @@ PHP_METHOD(SplFileObject, ftell)
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 	zend_long ret;
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	ret = php_stream_tell(intern->u.file.stream);
 
@@ -2571,7 +2571,7 @@ PHP_METHOD(SplFileObject, fseek)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	spl_filesystem_file_free_line(intern);
 	RETURN_LONG(php_stream_seek(intern->u.file.stream, pos, (int)whence));
@@ -2584,7 +2584,7 @@ PHP_METHOD(SplFileObject, fgetc)
 	char buf[2];
 	int result;
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	spl_filesystem_file_free_line(intern);
 
@@ -2608,7 +2608,7 @@ PHP_METHOD(SplFileObject, fpassthru)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	RETURN_LONG(php_stream_passthru(intern->u.file.stream));
 } /* }}} */
@@ -2625,7 +2625,7 @@ PHP_METHOD(SplFileObject, fscanf)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	/* Get next line */
 	if (spl_filesystem_file_read(intern, 0) == FAILURE) {
@@ -2653,7 +2653,7 @@ PHP_METHOD(SplFileObject, fwrite)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	if (ZEND_NUM_ARGS() > 1) {
 		if (length >= 0) {
@@ -2684,7 +2684,7 @@ PHP_METHOD(SplFileObject, fread)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	if (length <= 0) {
 		php_error_docref(NULL, E_WARNING, "Length parameter must be greater than 0");
@@ -2707,7 +2707,7 @@ PHP_METHOD(SplFileObject, fstat)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	php_fstat(intern->u.file.stream, return_value);
 }
@@ -2723,7 +2723,7 @@ PHP_METHOD(SplFileObject, ftruncate)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	if (!php_stream_truncate_supported(intern->u.file.stream)) {
 		zend_throw_exception_ex(spl_ce_LogicException, 0, "Can't truncate file %s", intern->file_name);
@@ -2743,7 +2743,7 @@ PHP_METHOD(SplFileObject, seek)
 		RETURN_THROWS();
 	}
 
-	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
 	if (line_pos < 0) {
 		zend_throw_exception_ex(spl_ce_LogicException, 0, "Can't seek file %s to negative line " ZEND_LONG_FMT, intern->file_name, line_pos);

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2552,12 +2552,12 @@ PHP_METHOD(SplFileObject, flock)
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 	zend_function *func_ptr;
 
-    func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "flock", sizeof("flock") - 1);
-    if (func_ptr == NULL) {
+	func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "flock", sizeof("flock") - 1);
+	if (func_ptr == NULL) {
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function flock() not found. Please report");
 		RETURN_THROWS();
-    }
-    spl_filesystem_file_call(intern, func_ptr, ZEND_NUM_ARGS(), return_value);
+	}
+	spl_filesystem_file_call(intern, func_ptr, ZEND_NUM_ARGS(), return_value);
 }
 /* }}} */
 
@@ -2669,12 +2669,12 @@ PHP_METHOD(SplFileObject, fscanf)
 	spl_filesystem_file_free_line(intern);
 	intern->u.file.current_line_num++;
 
-    func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "fscanf", sizeof("fscanf") - 1);
-    if (func_ptr == NULL) {
+		func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "fscanf", sizeof("fscanf") - 1);
+		if (func_ptr == NULL) {
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function fscanf() not found. Please report");
 		RETURN_THROWS();
-    }
-    spl_filesystem_file_call(intern, func_ptr, ZEND_NUM_ARGS(), return_value);
+		}
+		spl_filesystem_file_call(intern, func_ptr, ZEND_NUM_ARGS(), return_value);
 }
 /* }}} */
 
@@ -2748,12 +2748,22 @@ PHP_METHOD(SplFileObject, fstat)
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 	zend_function *func_ptr;
 
-    func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "fstat", sizeof("fstat") - 1);
-    if (func_ptr == NULL) {
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "fstat", sizeof("fstat") - 1);
+	if (func_ptr == NULL) {
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function fstat() not found. Please report");
 		RETURN_THROWS();
-    }
-    spl_filesystem_file_call(intern, func_ptr, ZEND_NUM_ARGS(), return_value);
+	}
+
+	if (Z_ISUNDEF_P(&intern->u.file.zresource)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
+		RETURN_THROWS();
+	}
+
+	zend_call_known_function(func_ptr, NULL, NULL, return_value, 0, NULL, NULL);	
 }
 /* }}} */
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1901,13 +1901,13 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent) /
 	return SUCCESS;
 } /* }}} */
 
-static int spl_filesystem_file_call(spl_filesystem_object *intern, zend_function *func_ptr, int pass_num_args, zval *return_value, zval *arg2) /* {{{ */
+static int spl_filesystem_file_call(spl_filesystem_object *intern, zend_function *func_ptr, int pass_num_args, zval *return_value) /* {{{ */
 {
 	zend_fcall_info fci;
 	zend_fcall_info_cache fcic;
 	zval *zresource_ptr = &intern->u.file.zresource, *params;
 	int result;
-	int num_args = pass_num_args + (arg2 ? 2 : 1);
+	int num_args = pass_num_args + 1;
 
 	if (Z_ISUNDEF_P(zresource_ptr)) {
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
@@ -1917,11 +1917,7 @@ static int spl_filesystem_file_call(spl_filesystem_object *intern, zend_function
 	params = (zval*)safe_emalloc(num_args, sizeof(zval), 0);
 	params[0] = *zresource_ptr;
 
-	if (arg2) {
-		params[1] = *arg2;
-	}
-
-	if (zend_get_parameters_array_ex(pass_num_args, params + (arg2 ? 2 : 1)) != SUCCESS) {
+	if (zend_get_parameters_array_ex(pass_num_args, params + 1) != SUCCESS) {
 		efree(params);
 		WRONG_PARAM_COUNT_WITH_RETVAL(FAILURE);
 	}
@@ -1948,7 +1944,7 @@ static int spl_filesystem_file_call(spl_filesystem_object *intern, zend_function
 	return result;
 } /* }}} */
 
-#define FileFunctionCall(func_name, pass_num_args, arg2) /* {{{ */ \
+#define FileFunctionCall(func_name, pass_num_args) /* {{{ */ \
 { \
 	zend_function *func_ptr; \
 	func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), #func_name, sizeof(#func_name) - 1); \
@@ -1956,7 +1952,7 @@ static int spl_filesystem_file_call(spl_filesystem_object *intern, zend_function
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Internal error, function %s() not found. Please report", #func_name); \
 		return; \
 	} \
-	spl_filesystem_file_call(intern, func_ptr, pass_num_args, return_value, arg2); \
+	spl_filesystem_file_call(intern, func_ptr, pass_num_args, return_value); \
 } /* }}} */
 
 static int spl_filesystem_file_read_csv(spl_filesystem_object *intern, char delimiter, char enclosure, int escape, zval *return_value) /* {{{ */
@@ -2387,7 +2383,7 @@ PHP_METHOD(SplFileObject, getChildren)
 PHP_METHOD(SplFileObject, func_name) \
 { \
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS); \
-	FileFunctionCall(func_name, ZEND_NUM_ARGS(), NULL); \
+	FileFunctionCall(func_name, ZEND_NUM_ARGS()); \
 }
 /* }}} */
 
@@ -2681,7 +2677,7 @@ PHP_METHOD(SplFileObject, fscanf)
 	spl_filesystem_file_free_line(intern);
 	intern->u.file.current_line_num++;
 
-	FileFunctionCall(fscanf, ZEND_NUM_ARGS(), NULL);
+	FileFunctionCall(fscanf, ZEND_NUM_ARGS());
 }
 /* }}} */
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2699,28 +2699,17 @@ PHP_METHOD(SplFileObject, fread)
 }
 
 /* {{{ Stat() on a filehandle */
-// TODO Don't call fstat? As it may be undefined if it is disabled via disable_functions
 PHP_METHOD(SplFileObject, fstat)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
-	zend_function *func_ptr;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	func_ptr = (zend_function *)zend_hash_str_find_ptr(EG(function_table), "fstat", sizeof("fstat") - 1);
-	if (func_ptr == NULL) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "fstat() is not defined");
-		RETURN_THROWS();
-	}
+	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED();
 
-	if (Z_ISUNDEF_P(&intern->u.file.zresource)) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		RETURN_THROWS();
-	}
-
-	zend_call_known_function(func_ptr, NULL, NULL, return_value, 0, NULL, NULL);
+	php_fstat(intern->u.file.stream, return_value);
 }
 /* }}} */
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2548,10 +2548,17 @@ PHP_METHOD(SplFileObject, getCsvControl)
 }
 /* }}} */
 
-/* {{{ Portable file locking, copy pasted from ext/standard/file.c flock() function.
- * This is done to prevent this to fail if flock is disabled via disable_functions */
+/* Because apparently it doesn't want to pull them from flock_compat.h for some stupid reason */
+#define LOCK_SH 1
+#define LOCK_EX 2
+#define LOCK_NB 4
+#define LOCK_UN 8
+
+
 static int flock_values[] = { LOCK_SH, LOCK_EX, LOCK_UN };
 
+/* {{{ Portable file locking, copy pasted from ext/standard/file.c flock() function.
+ * This is done to prevent this to fail if flock is disabled via disable_functions */
 PHP_METHOD(SplFileObject, flock)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1903,49 +1903,6 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent) /
 	return SUCCESS;
 } /* }}} */
 
-static int spl_filesystem_file_call(spl_filesystem_object *intern, zend_function *func_ptr, int pass_num_args, zval *return_value) /* {{{ */
-{
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcic;
-	zval *zresource_ptr = &intern->u.file.zresource, *params;
-	int result;
-	int num_args = pass_num_args + 1;
-
-	if (Z_ISUNDEF_P(zresource_ptr)) {
-		zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Object not initialized");
-		return FAILURE;
-	}
-
-	params = (zval*)safe_emalloc(num_args, sizeof(zval), 0);
-	params[0] = *zresource_ptr;
-
-	if (zend_get_parameters_array_ex(pass_num_args, params + 1) != SUCCESS) {
-		efree(params);
-		WRONG_PARAM_COUNT_WITH_RETVAL(FAILURE);
-	}
-
-	fci.size = sizeof(fci);
-	fci.object = NULL;
-	fci.retval = return_value;
-	fci.param_count = num_args;
-	fci.params = params;
-	fci.named_params = NULL;
-	ZVAL_STR(&fci.function_name, func_ptr->common.function_name);
-
-	fcic.function_handler = func_ptr;
-	fcic.called_scope = NULL;
-	fcic.object = NULL;
-
-	result = zend_call_function(&fci, &fcic);
-
-	if (result == FAILURE || Z_ISUNDEF_P(return_value)) {
-		RETVAL_FALSE;
-	}
-
-	efree(params);
-	return result;
-} /* }}} */
-
 static int spl_filesystem_file_read_csv(spl_filesystem_object *intern, char delimiter, char enclosure, int escape, zval *return_value) /* {{{ */
 {
 	int ret = SUCCESS;

--- a/ext/spl/tests/SplFileObject_fstat_with_basic_fstat_disabled.phpt
+++ b/ext/spl/tests/SplFileObject_fstat_with_basic_fstat_disabled.phpt
@@ -5,11 +5,60 @@ disable_functions="fstat"
 --FILE--
 <?php
 $obj = New SplFileObject(__DIR__.'/SplFileObject_testinput.csv');
-try {
-    var_dump($obj->fstat());
-} catch (\RuntimeException $e) {
-    echo $e->getMessage() . \PHP_EOL;
-}
+var_dump($obj->fstat());
 ?>
---EXPECT--
-fstat() is not defined
+--EXPECTF--
+array(26) {
+  [0]=>
+  int(%i)
+  [1]=>
+  int(%i)
+  [2]=>
+  int(%i)
+  [3]=>
+  int(%i)
+  [4]=>
+  int(%i)
+  [5]=>
+  int(%i)
+  [6]=>
+  int(%i)
+  [7]=>
+  int(%i)
+  [8]=>
+  int(%i)
+  [9]=>
+  int(%i)
+  [10]=>
+  int(%i)
+  [11]=>
+  int(%i)
+  [12]=>
+  int(%i)
+  ["dev"]=>
+  int(%i)
+  ["ino"]=>
+  int(%i)
+  ["mode"]=>
+  int(%i)
+  ["nlink"]=>
+  int(%i)
+  ["uid"]=>
+  int(%i)
+  ["gid"]=>
+  int(%i)
+  ["rdev"]=>
+  int(%i)
+  ["size"]=>
+  int(%i)
+  ["atime"]=>
+  int(%i)
+  ["mtime"]=>
+  int(%i)
+  ["ctime"]=>
+  int(%i)
+  ["blksize"]=>
+  int(%i)
+  ["blocks"]=>
+  int(%i)
+}

--- a/ext/spl/tests/SplFileObject_fstat_with_basic_fstat_disabled.phpt
+++ b/ext/spl/tests/SplFileObject_fstat_with_basic_fstat_disabled.phpt
@@ -1,0 +1,15 @@
+--TEST--
+SplFileObject::fstat when fstat() has been disabled.
+--INI--
+disable_functions="fstat"
+--FILE--
+<?php
+$obj = New SplFileObject(__DIR__.'/SplFileObject_testinput.csv');
+try {
+    var_dump($obj->fstat());
+} catch (\RuntimeException $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+?>
+--EXPECT--
+fstat() is not defined

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -345,8 +345,6 @@ PHP_FUNCTION(flock)
 	PHP_STREAM_TO_ZVAL(stream, res);
 
 	act = operation & PHP_LOCK_UN;
-	// TODO doesn't this fail if operation is a bitmask with LOCK_NB?
-	//if (act != PHP_LOCK_SH && act != PHP_LOCK_EX && act != PHP_LOCK_UN) {
 	if (act < 1 || act > 3) {
 		zend_argument_value_error(2, "must be either LOCK_SH, LOCK_EX, or LOCK_UN");
 		RETURN_THROWS();

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -1489,25 +1489,15 @@ PHP_FUNCTION(ftruncate)
 	RETURN_BOOL(0 == php_stream_truncate_set_size(stream, size));
 }
 /* }}} */
-
-/* {{{ Stat() on a filehandle */
-PHP_FUNCTION(fstat)
+PHPAPI void php_fstat(php_stream *stream, zval *return_value)
 {
-	zval *fp;
+	php_stream_statbuf stat_ssb;
 	zval stat_dev, stat_ino, stat_mode, stat_nlink, stat_uid, stat_gid, stat_rdev,
 		 stat_size, stat_atime, stat_mtime, stat_ctime, stat_blksize, stat_blocks;
-	php_stream *stream;
-	php_stream_statbuf stat_ssb;
 	char *stat_sb_names[13] = {
 		"dev", "ino", "mode", "nlink", "uid", "gid", "rdev",
 		"size", "atime", "mtime", "ctime", "blksize", "blocks"
 	};
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_RESOURCE(fp)
-	ZEND_PARSE_PARAMETERS_END();
-
-	PHP_STREAM_TO_ZVAL(stream, fp);
 
 	if (php_stream_stat(stream, &stat_ssb)) {
 		RETURN_FALSE;
@@ -1569,6 +1559,21 @@ PHP_FUNCTION(fstat)
 	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[10], strlen(stat_sb_names[10]), &stat_ctime);
 	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[11], strlen(stat_sb_names[11]), &stat_blksize);
 	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[12], strlen(stat_sb_names[12]), &stat_blocks);
+}
+
+/* {{{ Stat() on a filehandle */
+PHP_FUNCTION(fstat)
+{
+	zval *fp;
+	php_stream *stream;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_RESOURCE(fp)
+	ZEND_PARSE_PARAMETERS_END();
+
+	PHP_STREAM_TO_ZVAL(stream, fp);
+
+	php_fstat(stream, return_value);
 }
 /* }}} */
 

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -344,7 +344,9 @@ PHP_FUNCTION(flock)
 
 	PHP_STREAM_TO_ZVAL(stream, res);
 
-	act = operation & 3;
+	act = operation & PHP_LOCK_UN;
+	// TODO doesn't this fail if operation is a bitmask with LOCK_NB?
+	//if (act != PHP_LOCK_SH && act != PHP_LOCK_EX && act != PHP_LOCK_UN) {
 	if (act < 1 || act > 3) {
 		zend_argument_value_error(2, "must be either LOCK_SH, LOCK_EX, or LOCK_UN");
 		RETURN_THROWS();
@@ -354,7 +356,7 @@ PHP_FUNCTION(flock)
 		ZEND_TRY_ASSIGN_REF_LONG(wouldblock, 0);
 	}
 
-	/* flock_values contains all possible actions if (operation & 4) we won't block on the lock */
+	/* flock_values contains all possible actions if (operation & PHP_LOCK_NB) we won't block on the lock */
 	act = flock_values[act - 1] | (operation & PHP_LOCK_NB ? LOCK_NB : 0);
 	if (php_stream_lock(stream, act)) {
 		if (operation && errno == EWOULDBLOCK && wouldblock) {

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -43,6 +43,7 @@ PHPAPI int php_copy_file_ex(const char *src, const char *dest, int src_chk);
 PHPAPI int php_copy_file_ctx(const char *src, const char *dest, int src_chk, php_stream_context *ctx);
 PHPAPI int php_mkdir_ex(const char *dir, zend_long mode, int options);
 PHPAPI int php_mkdir(const char *dir, zend_long mode);
+PHPAPI void php_fstat(php_stream *stream, zval *return_value);
 
 #define PHP_CSV_NO_ESCAPE EOF
 PHPAPI void php_fgetcsv(php_stream *stream, char delimiter, char enclosure, int escape_char, size_t buf_len, char *buf, zval *return_value);

--- a/ext/standard/flock_compat.c
+++ b/ext/standard/flock_compat.c
@@ -18,17 +18,6 @@
 #include <errno.h>
 #include "ext/standard/flock_compat.h"
 
-#if HAVE_STRUCT_FLOCK
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/file.h>
-#endif
-
-#ifdef PHP_WIN32
-#include <io.h>
-#include "config.w32.h"
-#endif
-
 #ifndef HAVE_FLOCK
 PHPAPI int flock(int fd, int operation)
 {

--- a/ext/standard/flock_compat.h
+++ b/ext/standard/flock_compat.h
@@ -17,6 +17,17 @@
 #ifndef FLOCK_COMPAT_H
 #define FLOCK_COMPAT_H
 
+#if HAVE_STRUCT_FLOCK
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/file.h>
+#endif
+
+#ifdef PHP_WIN32
+#include <io.h>
+#include "config.w32.h"
+#endif
+
 /* php_flock internally uses fcntl whether or not flock is available
  * This way our php_flock even works on NFS files.
  * More info: /usr/src/linux/Documentation


### PR DESCRIPTION
This is an attempted at making this class a bit easier to follow...

However since PHP 8 disabled functions are unregistered it's possible to hit some new unconventional paths which I tried to drop ~~however I ran into some issues with ``flock()``.~~ [The compatibility layer wasn't completely useful and just needed some tweaks...]

For ``fstat()`` the best way to mitigate this is by extracting the actual part populating the array into a separate function which is exported so that SPL can call that.
