### PR TITLE
Fix more basic function stubs

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -149,7 +149,7 @@ PHP 8.0 UPGRADE NOTES
         new class {};
         // -> class@anonymous
 
-    The name shown above is still followed by a null byte and and a unique
+    The name shown above is still followed by a null byte and a unique
     suffix.
   . Non-absolute trait method references in trait alias adaptations are now
     required to be unambiguous:

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -169,13 +169,13 @@ function array_count_values(array $array): array {}
 
 function array_column(array $array, int|string|null $column_key, int|string|null $index_key = null): array {}
 
-function array_reverse(array $input, bool $preserve_keys = false): array {}
+function array_reverse(array $array, bool $preserve_keys = false): array {}
 
 function array_pad(array $array, int $pad_size, mixed $pad_value): array {}
 
 function array_flip(array $array): array {}
 
-function array_change_key_case(array $input, int $case = CASE_LOWER): array {}
+function array_change_key_case(array $array, int $case = CASE_LOWER): array {}
 
 function array_unique(array $array, int $flags = SORT_STRING): array {}
 
@@ -1500,11 +1500,11 @@ function convert_uudecode(string $data): string|false {}
 
 /* var.c */
 
-function var_dump(mixed $value, mixed ...$value): void {}
+function var_dump(mixed $value, mixed ...$values): void {}
 
 function var_export(mixed $value, bool $return = false): ?string {}
 
-function debug_zval_dump(mixed $value, mixed ...$value): void {}
+function debug_zval_dump(mixed $value, mixed ...$values): void {}
 
 function serialize(mixed $value): string {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 269d4da84e4bc6fae246b90e4c50e48463b86f41 */
+ * Stub hash: 8b6ef365e9635c92ef86adb40b2aba077867f3b2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -251,7 +251,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_column, 0, 2, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_reverse, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, input, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, preserve_keys, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
@@ -264,7 +264,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_array_flip arginfo_array_values
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_change_key_case, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, input, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, case, IS_LONG, 0, "CASE_LOWER")
 ZEND_END_ARG_INFO()
 
@@ -2173,7 +2173,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_var_dump, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
-	ZEND_ARG_VARIADIC_TYPE_INFO(0, value, IS_MIXED, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, values, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_var_export, 0, 1, IS_STRING, 1)


### PR DESCRIPTION
User-defined functions can't have multiple parameters with the same name.
Don't do that for var_dump/debug_zval_dump.

Consistently use array $array to match docs