### PR TITLE
Fix #48725: Support for flushing in zlib stream

### DIFF
--- a/ext/zlib/tests/bug48725.phpt
+++ b/ext/zlib/tests/bug48725.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #48725 (Support for flushing in zlib stream)
+--SKIPIF--
+<?php
+if (!extension_loaded('zlib')) die('skip zip extension not available');
+?>
+--FILE--
+<?php
+$text = str_repeat('0123456789abcdef', 1000);
+
+$temp = fopen('php://temp', 'r+');
+stream_filter_append($temp, 'zlib.deflate', STREAM_FILTER_WRITE);
+fwrite($temp, $text);
+
+rewind($temp);
+
+var_dump(bin2hex(stream_get_contents($temp)));
+var_dump(ftell($temp));
+
+fclose($temp);
+?>
+--EXPECT--
+string(138) "ecc7c901c0100000b09594bac641d97f840e22f9253c31bdb9d4d6c75cdf3ec1ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddaffc0f0000ffff"
+int(69)


### PR DESCRIPTION
When `php_zlib_deflate_filter()` is called with `PSFS_FLAG_FLUSH_INC`
but without new buckets being available (e.g. because a user calls
`rewind()` after writing to the stream), we have to make sure that any
pending data are flushed.  This could basically be done like in the
attached patch[1], but that could cause unnessary flushes, which can be
harmful for compression, and adds unnecessary flush markers to the
stream.  Thus, we use the `php_zlib_filter_data.finished` field, which
has not been used for `zlib.deflate` filters, and properly keep track
of the need to flush.

[1] <https://bugs.php.net/patch-display.php?bug_id=48725&patch=zlib-filter-flush-fix.patch&revision=latest>