### PR TITLE
Disables extended cpu instructions support on OpenBSD.

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -531,7 +531,7 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 # define ZEND_INTRIN_HAVE_IFUNC_TARGET 1
 #endif
 
-#if (defined(__i386__) || defined(__x86_64__))
+#if (defined(__i386__) || defined(__x86_64__)) && !defined(__OpenBSD__)
 # if PHP_HAVE_SSSE3_INSTRUCTIONS && defined(HAVE_TMMINTRIN_H)
 # define PHP_HAVE_SSSE3
 # endif
@@ -550,7 +550,7 @@ static zend_always_inline double _zend_get_nan(void) /* {{{ */
 # endif
 #endif
 
-#ifdef __SSSE3__
+#if defined(__SSSE3__) && !defined(__OpenBSD__)
 /* Instructions compiled directly. */
 # define ZEND_INTRIN_SSSE3_NATIVE 1
 #elif (defined(HAVE_FUNC_ATTRIBUTE_TARGET) && defined(PHP_HAVE_SSSE3)) || defined(ZEND_WIN32)

--- a/configure.ac
+++ b/configure.ac
@@ -543,10 +543,17 @@ dnl Check __builtin_cpu_supports
 PHP_CHECK_BUILTIN_CPU_SUPPORTS
 
 dnl Check instructions.
-PHP_CHECK_CPU_SUPPORTS([ssse3])
-PHP_CHECK_CPU_SUPPORTS([sse4.2])
-PHP_CHECK_CPU_SUPPORTS([avx])
-PHP_CHECK_CPU_SUPPORTS([avx2])
+case $host_alias in
+  *openbsd*)
+      AC_MSG_RESULT([extended cpu instructions disabled])
+      ;;
+  *)
+      PHP_CHECK_CPU_SUPPORTS([ssse3])
+      PHP_CHECK_CPU_SUPPORTS([sse4.2])
+      PHP_CHECK_CPU_SUPPORTS([avx])
+      PHP_CHECK_CPU_SUPPORTS([avx2])
+      ;;
+esac
 
 dnl Check for structure members.
 AC_CHECK_MEMBERS([struct tm.tm_gmtoff],,,[#include <time.h>])

--- a/configure.ac
+++ b/configure.ac
@@ -543,17 +543,10 @@ dnl Check __builtin_cpu_supports
 PHP_CHECK_BUILTIN_CPU_SUPPORTS
 
 dnl Check instructions.
-case $host_alias in
-  *openbsd*)
-      AC_MSG_RESULT([extended cpu instructions disabled])
-      ;;
-  *)
-      PHP_CHECK_CPU_SUPPORTS([ssse3])
-      PHP_CHECK_CPU_SUPPORTS([sse4.2])
-      PHP_CHECK_CPU_SUPPORTS([avx])
-      PHP_CHECK_CPU_SUPPORTS([avx2])
-      ;;
-esac
+PHP_CHECK_CPU_SUPPORTS([ssse3])
+PHP_CHECK_CPU_SUPPORTS([sse4.2])
+PHP_CHECK_CPU_SUPPORTS([avx])
+PHP_CHECK_CPU_SUPPORTS([avx2])
 
 dnl Check for structure members.
 AC_CHECK_MEMBERS([struct tm.tm_gmtoff],,,[#include <time.h>])


### PR DESCRIPTION
For example the sse4.2 version of addslahes segfault with clang
 and sse instructions are unsupported (e.g. vmovq) with egcc
 thus simply disabling them at configure time.