### PR TITLE
Rename array_diff parameter names to be more user-friendly.

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -200,26 +200,26 @@ function array_intersect_uassoc(array $array1, array $array2, ...$rest): array {
 /** @param array|callable $rest */
 function array_uintersect_uassoc(array $array1, array $array2, ...$rest): array {}
 
-function array_diff_key(array $array1, array $array2, array ...$arrays): array {}
+function array_diff_key(array $source, array $exclude, array ...$rest): array {}
 
 /** @param array|callable $rest */
-function array_diff_ukey(array $array1, array $array2, ...$rest): array {}
+function array_diff_ukey(array $source, array $exclude, ...$rest): array {}
 
-function array_diff(array $array1, array $array2, array ...$arrays): array {}
-
-/** @param array|callable $rest */
-function array_udiff(array $array1, array $array2, ...$rest): array {}
-
-function array_diff_assoc(array $array1, array $array2, array ...$arrays): array {}
+function array_diff(array $source, array $exclude, array ...$rest): array {}
 
 /** @param array|callable $rest */
-function array_diff_uassoc(array $array1, array $array2, ...$rest): array {}
+function array_udiff(array $source, array $exclude, ...$rest): array {}
+
+function array_diff_assoc(array $source, array $exclude, array ...$rest): array {}
 
 /** @param array|callable $rest */
-function array_udiff_assoc(array $array1, array $array2, ...$rest): array {}
+function array_diff_uassoc(array $source, array $exclude, ...$rest): array {}
 
 /** @param array|callable $rest */
-function array_udiff_uassoc(array $array1, array $array2, ...$rest): array {}
+function array_udiff_assoc(array $source, array $exclude, ...$rest): array {}
+
+/** @param array|callable $rest */
+function array_udiff_uassoc(array $source, array $exclude, ...$rest): array {}
 
 /**
  * @param array $array1

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -200,26 +200,26 @@ function array_intersect_uassoc(array $array1, array $array2, ...$rest): array {
 /** @param array|callable $rest */
 function array_uintersect_uassoc(array $array1, array $array2, ...$rest): array {}
 
-function array_diff_key(array $source, array $exclude, array ...$rest): array {}
+function array_diff_key(array $input, array $exclude, array ...$rest): array {}
 
 /** @param array|callable $rest */
-function array_diff_ukey(array $source, array $exclude, ...$rest): array {}
+function array_diff_ukey(array $input, array $exclude, ...$rest): array {}
 
-function array_diff(array $source, array $exclude, array ...$rest): array {}
-
-/** @param array|callable $rest */
-function array_udiff(array $source, array $exclude, ...$rest): array {}
-
-function array_diff_assoc(array $source, array $exclude, array ...$rest): array {}
+function array_diff(array $input, array $exclude, array ...$rest): array {}
 
 /** @param array|callable $rest */
-function array_diff_uassoc(array $source, array $exclude, ...$rest): array {}
+function array_udiff(array $input, array $exclude, ...$rest): array {}
+
+function array_diff_assoc(array $input, array $exclude, array ...$rest): array {}
 
 /** @param array|callable $rest */
-function array_udiff_assoc(array $source, array $exclude, ...$rest): array {}
+function array_diff_uassoc(array $input, array $exclude, ...$rest): array {}
 
 /** @param array|callable $rest */
-function array_udiff_uassoc(array $source, array $exclude, ...$rest): array {}
+function array_udiff_assoc(array $input, array $exclude, ...$rest): array {}
+
+/** @param array|callable $rest */
+function array_udiff_uassoc(array $input, array $exclude, ...$rest): array {}
 
 /**
  * @param array $array1

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8b6ef365e9635c92ef86adb40b2aba077867f3b2 */
+ * Stub hash: 51ff985f775bae325186922a1b4b4f7335089081 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -297,21 +297,29 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_array_uintersect_uassoc arginfo_array_intersect_ukey
 
-#define arginfo_array_diff_key arginfo_array_intersect_key
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_diff_key, 0, 2, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, source, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, exclude, IS_ARRAY, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, rest, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
 
-#define arginfo_array_diff_ukey arginfo_array_intersect_ukey
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_diff_ukey, 0, 2, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, source, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, exclude, IS_ARRAY, 0)
+	ZEND_ARG_VARIADIC_INFO(0, rest)
+ZEND_END_ARG_INFO()
 
-#define arginfo_array_diff arginfo_array_intersect_key
+#define arginfo_array_diff arginfo_array_diff_key
 
-#define arginfo_array_udiff arginfo_array_intersect_ukey
+#define arginfo_array_udiff arginfo_array_diff_ukey
 
-#define arginfo_array_diff_assoc arginfo_array_intersect_key
+#define arginfo_array_diff_assoc arginfo_array_diff_key
 
-#define arginfo_array_diff_uassoc arginfo_array_intersect_ukey
+#define arginfo_array_diff_uassoc arginfo_array_diff_ukey
 
-#define arginfo_array_udiff_assoc arginfo_array_intersect_ukey
+#define arginfo_array_udiff_assoc arginfo_array_diff_ukey
 
-#define arginfo_array_udiff_uassoc arginfo_array_intersect_ukey
+#define arginfo_array_udiff_uassoc arginfo_array_diff_ukey
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_multisort, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(ZEND_SEND_PREFER_REF, array1)

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 51ff985f775bae325186922a1b4b4f7335089081 */
+ * Stub hash: 7a35741aa95538773f364eb8b0b7ab0f046cfb33 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -298,13 +298,13 @@ ZEND_END_ARG_INFO()
 #define arginfo_array_uintersect_uassoc arginfo_array_intersect_ukey
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_diff_key, 0, 2, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, source, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, input, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, exclude, IS_ARRAY, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, rest, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_array_diff_ukey, 0, 2, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, source, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, input, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, exclude, IS_ARRAY, 0)
 	ZEND_ARG_VARIADIC_INFO(0, rest)
 ZEND_END_ARG_INFO()

--- a/ext/standard/tests/array/array_diff_1.phpt
+++ b/ext/standard/tests/array/array_diff_1.phpt
@@ -15,5 +15,5 @@ try {
 echo "OK!";
 ?>
 --EXPECT--
-array_diff(): Argument #2 ($array2) must be of type array, int given
+array_diff(): Argument #2 ($exclude) must be of type array, int given
 OK!

--- a/ext/standard/tests/array/array_diff_assoc_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_assoc_variation1.phpt
@@ -100,80 +100,80 @@ echo "Done";
 *** Testing array_diff_assoc() : usage variations ***
 
 -- Iteration 1 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, int given
+array_diff_assoc(): Argument #1 ($source) must be of type array, int given
 
 -- Iteration 2 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, int given
+array_diff_assoc(): Argument #1 ($source) must be of type array, int given
 
 -- Iteration 3 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, int given
+array_diff_assoc(): Argument #1 ($source) must be of type array, int given
 
 -- Iteration 4 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, int given
+array_diff_assoc(): Argument #1 ($source) must be of type array, int given
 
 -- Iteration 5 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_assoc(): Argument #1 ($source) must be of type array, float given
 
 -- Iteration 6 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_assoc(): Argument #1 ($source) must be of type array, float given
 
 -- Iteration 7 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_assoc(): Argument #1 ($source) must be of type array, float given
 
 -- Iteration 8 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_assoc(): Argument #1 ($source) must be of type array, float given
 
 -- Iteration 9 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_assoc(): Argument #1 ($source) must be of type array, float given
 
 -- Iteration 10 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, null given
+array_diff_assoc(): Argument #1 ($source) must be of type array, null given
 
 -- Iteration 11 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, null given
+array_diff_assoc(): Argument #1 ($source) must be of type array, null given
 
 -- Iteration 12 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, bool given
+array_diff_assoc(): Argument #1 ($source) must be of type array, bool given
 
 -- Iteration 13 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, bool given
+array_diff_assoc(): Argument #1 ($source) must be of type array, bool given
 
 -- Iteration 14 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, bool given
+array_diff_assoc(): Argument #1 ($source) must be of type array, bool given
 
 -- Iteration 15 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, bool given
+array_diff_assoc(): Argument #1 ($source) must be of type array, bool given
 
 -- Iteration 16 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_assoc(): Argument #1 ($source) must be of type array, string given
 
 -- Iteration 17 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_assoc(): Argument #1 ($source) must be of type array, string given
 
 -- Iteration 18 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_assoc(): Argument #1 ($source) must be of type array, string given
 
 -- Iteration 19 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_assoc(): Argument #1 ($source) must be of type array, string given
 
 -- Iteration 20 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_assoc(): Argument #1 ($source) must be of type array, string given
 
 -- Iteration 21 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_assoc(): Argument #1 ($source) must be of type array, string given
 
 -- Iteration 22 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_assoc(): Argument #1 ($source) must be of type array, string given
 
 -- Iteration 23 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, classA given
+array_diff_assoc(): Argument #1 ($source) must be of type array, classA given
 
 -- Iteration 24 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, null given
+array_diff_assoc(): Argument #1 ($source) must be of type array, null given
 
 -- Iteration 25 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, null given
+array_diff_assoc(): Argument #1 ($source) must be of type array, null given
 
 -- Iteration 26 --
-array_diff_assoc(): Argument #1 ($array1) must be of type array, resource given
+array_diff_assoc(): Argument #1 ($source) must be of type array, resource given
 Done

--- a/ext/standard/tests/array/array_diff_assoc_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_assoc_variation1.phpt
@@ -100,80 +100,80 @@ echo "Done";
 *** Testing array_diff_assoc() : usage variations ***
 
 -- Iteration 1 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, int given
+array_diff_assoc(): Argument #1 ($input) must be of type array, int given
 
 -- Iteration 2 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, int given
+array_diff_assoc(): Argument #1 ($input) must be of type array, int given
 
 -- Iteration 3 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, int given
+array_diff_assoc(): Argument #1 ($input) must be of type array, int given
 
 -- Iteration 4 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, int given
+array_diff_assoc(): Argument #1 ($input) must be of type array, int given
 
 -- Iteration 5 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, float given
+array_diff_assoc(): Argument #1 ($input) must be of type array, float given
 
 -- Iteration 6 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, float given
+array_diff_assoc(): Argument #1 ($input) must be of type array, float given
 
 -- Iteration 7 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, float given
+array_diff_assoc(): Argument #1 ($input) must be of type array, float given
 
 -- Iteration 8 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, float given
+array_diff_assoc(): Argument #1 ($input) must be of type array, float given
 
 -- Iteration 9 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, float given
+array_diff_assoc(): Argument #1 ($input) must be of type array, float given
 
 -- Iteration 10 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, null given
+array_diff_assoc(): Argument #1 ($input) must be of type array, null given
 
 -- Iteration 11 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, null given
+array_diff_assoc(): Argument #1 ($input) must be of type array, null given
 
 -- Iteration 12 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, bool given
+array_diff_assoc(): Argument #1 ($input) must be of type array, bool given
 
 -- Iteration 13 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, bool given
+array_diff_assoc(): Argument #1 ($input) must be of type array, bool given
 
 -- Iteration 14 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, bool given
+array_diff_assoc(): Argument #1 ($input) must be of type array, bool given
 
 -- Iteration 15 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, bool given
+array_diff_assoc(): Argument #1 ($input) must be of type array, bool given
 
 -- Iteration 16 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, string given
+array_diff_assoc(): Argument #1 ($input) must be of type array, string given
 
 -- Iteration 17 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, string given
+array_diff_assoc(): Argument #1 ($input) must be of type array, string given
 
 -- Iteration 18 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, string given
+array_diff_assoc(): Argument #1 ($input) must be of type array, string given
 
 -- Iteration 19 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, string given
+array_diff_assoc(): Argument #1 ($input) must be of type array, string given
 
 -- Iteration 20 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, string given
+array_diff_assoc(): Argument #1 ($input) must be of type array, string given
 
 -- Iteration 21 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, string given
+array_diff_assoc(): Argument #1 ($input) must be of type array, string given
 
 -- Iteration 22 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, string given
+array_diff_assoc(): Argument #1 ($input) must be of type array, string given
 
 -- Iteration 23 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, classA given
+array_diff_assoc(): Argument #1 ($input) must be of type array, classA given
 
 -- Iteration 24 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, null given
+array_diff_assoc(): Argument #1 ($input) must be of type array, null given
 
 -- Iteration 25 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, null given
+array_diff_assoc(): Argument #1 ($input) must be of type array, null given
 
 -- Iteration 26 --
-array_diff_assoc(): Argument #1 ($source) must be of type array, resource given
+array_diff_assoc(): Argument #1 ($input) must be of type array, resource given
 Done

--- a/ext/standard/tests/array/array_diff_assoc_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_assoc_variation2.phpt
@@ -100,80 +100,80 @@ echo "Done";
 *** Testing array_diff_assoc() : usage variations ***
 
 -- Iteration 1 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, int given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, int given
 
 -- Iteration 2 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, int given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, int given
 
 -- Iteration 3 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, int given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, int given
 
 -- Iteration 4 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, int given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, int given
 
 -- Iteration 5 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 -- Iteration 6 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 -- Iteration 7 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 -- Iteration 8 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 -- Iteration 9 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 -- Iteration 10 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, null given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, null given
 
 -- Iteration 11 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, null given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, null given
 
 -- Iteration 12 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, bool given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, bool given
 
 -- Iteration 13 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, bool given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, bool given
 
 -- Iteration 14 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, bool given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, bool given
 
 -- Iteration 15 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, bool given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, bool given
 
 -- Iteration 16 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 -- Iteration 17 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 -- Iteration 18 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 -- Iteration 19 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 -- Iteration 20 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 -- Iteration 21 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 -- Iteration 22 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 -- Iteration 23 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, classA given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, classA given
 
 -- Iteration 24 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, null given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, null given
 
 -- Iteration 25 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, null given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, null given
 
 -- Iteration 26 --
-array_diff_assoc(): Argument #2 ($array2) must be of type array, resource given
+array_diff_assoc(): Argument #2 ($exclude) must be of type array, resource given
 Done

--- a/ext/standard/tests/array/array_diff_key_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_key_variation1.phpt
@@ -103,105 +103,105 @@ fclose($fp);
 *** Testing array_diff_key() : usage variation ***
 
 --int 0--
-array_diff_key(): Argument #1 ($array1) must be of type array, int given
-array_diff_key(): Argument #1 ($array1) must be of type array, int given
+array_diff_key(): Argument #1 ($source) must be of type array, int given
+array_diff_key(): Argument #1 ($source) must be of type array, int given
 
 --int 1--
-array_diff_key(): Argument #1 ($array1) must be of type array, int given
-array_diff_key(): Argument #1 ($array1) must be of type array, int given
+array_diff_key(): Argument #1 ($source) must be of type array, int given
+array_diff_key(): Argument #1 ($source) must be of type array, int given
 
 --int 12345--
-array_diff_key(): Argument #1 ($array1) must be of type array, int given
-array_diff_key(): Argument #1 ($array1) must be of type array, int given
+array_diff_key(): Argument #1 ($source) must be of type array, int given
+array_diff_key(): Argument #1 ($source) must be of type array, int given
 
 --int -12345--
-array_diff_key(): Argument #1 ($array1) must be of type array, int given
-array_diff_key(): Argument #1 ($array1) must be of type array, int given
+array_diff_key(): Argument #1 ($source) must be of type array, int given
+array_diff_key(): Argument #1 ($source) must be of type array, int given
 
 --float 10.5--
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
 
 --float -10.5--
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
 
 --float .5--
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
-array_diff_key(): Argument #1 ($array1) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($source) must be of type array, float given
 
 --uppercase NULL--
-array_diff_key(): Argument #1 ($array1) must be of type array, null given
-array_diff_key(): Argument #1 ($array1) must be of type array, null given
+array_diff_key(): Argument #1 ($source) must be of type array, null given
+array_diff_key(): Argument #1 ($source) must be of type array, null given
 
 --lowercase null--
-array_diff_key(): Argument #1 ($array1) must be of type array, null given
-array_diff_key(): Argument #1 ($array1) must be of type array, null given
+array_diff_key(): Argument #1 ($source) must be of type array, null given
+array_diff_key(): Argument #1 ($source) must be of type array, null given
 
 --lowercase true--
-array_diff_key(): Argument #1 ($array1) must be of type array, bool given
-array_diff_key(): Argument #1 ($array1) must be of type array, bool given
+array_diff_key(): Argument #1 ($source) must be of type array, bool given
+array_diff_key(): Argument #1 ($source) must be of type array, bool given
 
 --lowercase false--
-array_diff_key(): Argument #1 ($array1) must be of type array, bool given
-array_diff_key(): Argument #1 ($array1) must be of type array, bool given
+array_diff_key(): Argument #1 ($source) must be of type array, bool given
+array_diff_key(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_key(): Argument #1 ($array1) must be of type array, bool given
-array_diff_key(): Argument #1 ($array1) must be of type array, bool given
+array_diff_key(): Argument #1 ($source) must be of type array, bool given
+array_diff_key(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_key(): Argument #1 ($array1) must be of type array, bool given
-array_diff_key(): Argument #1 ($array1) must be of type array, bool given
+array_diff_key(): Argument #1 ($source) must be of type array, bool given
+array_diff_key(): Argument #1 ($source) must be of type array, bool given
 
 --empty string DQ--
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
 
 --empty string SQ--
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
 
 --string DQ--
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
 
 --string SQ--
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
 
 --mixed case string--
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
 
 --heredoc--
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
-array_diff_key(): Argument #1 ($array1) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($source) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_key(): Argument #1 ($array1) must be of type array, classWithToString given
-array_diff_key(): Argument #1 ($array1) must be of type array, classWithToString given
+array_diff_key(): Argument #1 ($source) must be of type array, classWithToString given
+array_diff_key(): Argument #1 ($source) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_key(): Argument #1 ($array1) must be of type array, classWithoutToString given
-array_diff_key(): Argument #1 ($array1) must be of type array, classWithoutToString given
+array_diff_key(): Argument #1 ($source) must be of type array, classWithoutToString given
+array_diff_key(): Argument #1 ($source) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_key(): Argument #1 ($array1) must be of type array, null given
-array_diff_key(): Argument #1 ($array1) must be of type array, null given
+array_diff_key(): Argument #1 ($source) must be of type array, null given
+array_diff_key(): Argument #1 ($source) must be of type array, null given
 
 --unset var--
-array_diff_key(): Argument #1 ($array1) must be of type array, null given
-array_diff_key(): Argument #1 ($array1) must be of type array, null given
+array_diff_key(): Argument #1 ($source) must be of type array, null given
+array_diff_key(): Argument #1 ($source) must be of type array, null given
 
 --resource--
-array_diff_key(): Argument #1 ($array1) must be of type array, resource given
-array_diff_key(): Argument #1 ($array1) must be of type array, resource given
+array_diff_key(): Argument #1 ($source) must be of type array, resource given
+array_diff_key(): Argument #1 ($source) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_key_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_key_variation1.phpt
@@ -103,105 +103,105 @@ fclose($fp);
 *** Testing array_diff_key() : usage variation ***
 
 --int 0--
-array_diff_key(): Argument #1 ($source) must be of type array, int given
-array_diff_key(): Argument #1 ($source) must be of type array, int given
+array_diff_key(): Argument #1 ($input) must be of type array, int given
+array_diff_key(): Argument #1 ($input) must be of type array, int given
 
 --int 1--
-array_diff_key(): Argument #1 ($source) must be of type array, int given
-array_diff_key(): Argument #1 ($source) must be of type array, int given
+array_diff_key(): Argument #1 ($input) must be of type array, int given
+array_diff_key(): Argument #1 ($input) must be of type array, int given
 
 --int 12345--
-array_diff_key(): Argument #1 ($source) must be of type array, int given
-array_diff_key(): Argument #1 ($source) must be of type array, int given
+array_diff_key(): Argument #1 ($input) must be of type array, int given
+array_diff_key(): Argument #1 ($input) must be of type array, int given
 
 --int -12345--
-array_diff_key(): Argument #1 ($source) must be of type array, int given
-array_diff_key(): Argument #1 ($source) must be of type array, int given
+array_diff_key(): Argument #1 ($input) must be of type array, int given
+array_diff_key(): Argument #1 ($input) must be of type array, int given
 
 --float 10.5--
-array_diff_key(): Argument #1 ($source) must be of type array, float given
-array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
 
 --float -10.5--
-array_diff_key(): Argument #1 ($source) must be of type array, float given
-array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_key(): Argument #1 ($source) must be of type array, float given
-array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_key(): Argument #1 ($source) must be of type array, float given
-array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
 
 --float .5--
-array_diff_key(): Argument #1 ($source) must be of type array, float given
-array_diff_key(): Argument #1 ($source) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
+array_diff_key(): Argument #1 ($input) must be of type array, float given
 
 --uppercase NULL--
-array_diff_key(): Argument #1 ($source) must be of type array, null given
-array_diff_key(): Argument #1 ($source) must be of type array, null given
+array_diff_key(): Argument #1 ($input) must be of type array, null given
+array_diff_key(): Argument #1 ($input) must be of type array, null given
 
 --lowercase null--
-array_diff_key(): Argument #1 ($source) must be of type array, null given
-array_diff_key(): Argument #1 ($source) must be of type array, null given
+array_diff_key(): Argument #1 ($input) must be of type array, null given
+array_diff_key(): Argument #1 ($input) must be of type array, null given
 
 --lowercase true--
-array_diff_key(): Argument #1 ($source) must be of type array, bool given
-array_diff_key(): Argument #1 ($source) must be of type array, bool given
+array_diff_key(): Argument #1 ($input) must be of type array, bool given
+array_diff_key(): Argument #1 ($input) must be of type array, bool given
 
 --lowercase false--
-array_diff_key(): Argument #1 ($source) must be of type array, bool given
-array_diff_key(): Argument #1 ($source) must be of type array, bool given
+array_diff_key(): Argument #1 ($input) must be of type array, bool given
+array_diff_key(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_key(): Argument #1 ($source) must be of type array, bool given
-array_diff_key(): Argument #1 ($source) must be of type array, bool given
+array_diff_key(): Argument #1 ($input) must be of type array, bool given
+array_diff_key(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_key(): Argument #1 ($source) must be of type array, bool given
-array_diff_key(): Argument #1 ($source) must be of type array, bool given
+array_diff_key(): Argument #1 ($input) must be of type array, bool given
+array_diff_key(): Argument #1 ($input) must be of type array, bool given
 
 --empty string DQ--
-array_diff_key(): Argument #1 ($source) must be of type array, string given
-array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
 
 --empty string SQ--
-array_diff_key(): Argument #1 ($source) must be of type array, string given
-array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
 
 --string DQ--
-array_diff_key(): Argument #1 ($source) must be of type array, string given
-array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
 
 --string SQ--
-array_diff_key(): Argument #1 ($source) must be of type array, string given
-array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
 
 --mixed case string--
-array_diff_key(): Argument #1 ($source) must be of type array, string given
-array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
 
 --heredoc--
-array_diff_key(): Argument #1 ($source) must be of type array, string given
-array_diff_key(): Argument #1 ($source) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
+array_diff_key(): Argument #1 ($input) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_key(): Argument #1 ($source) must be of type array, classWithToString given
-array_diff_key(): Argument #1 ($source) must be of type array, classWithToString given
+array_diff_key(): Argument #1 ($input) must be of type array, classWithToString given
+array_diff_key(): Argument #1 ($input) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_key(): Argument #1 ($source) must be of type array, classWithoutToString given
-array_diff_key(): Argument #1 ($source) must be of type array, classWithoutToString given
+array_diff_key(): Argument #1 ($input) must be of type array, classWithoutToString given
+array_diff_key(): Argument #1 ($input) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_key(): Argument #1 ($source) must be of type array, null given
-array_diff_key(): Argument #1 ($source) must be of type array, null given
+array_diff_key(): Argument #1 ($input) must be of type array, null given
+array_diff_key(): Argument #1 ($input) must be of type array, null given
 
 --unset var--
-array_diff_key(): Argument #1 ($source) must be of type array, null given
-array_diff_key(): Argument #1 ($source) must be of type array, null given
+array_diff_key(): Argument #1 ($input) must be of type array, null given
+array_diff_key(): Argument #1 ($input) must be of type array, null given
 
 --resource--
-array_diff_key(): Argument #1 ($source) must be of type array, resource given
-array_diff_key(): Argument #1 ($source) must be of type array, resource given
+array_diff_key(): Argument #1 ($input) must be of type array, resource given
+array_diff_key(): Argument #1 ($input) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_key_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_key_variation2.phpt
@@ -104,105 +104,105 @@ fclose($fp);
 *** Testing array_diff_key() : usage variation ***
 
 --int 0--
-array_diff_key(): Argument #2 ($array2) must be of type array, int given
-array_diff_key(): Argument #2 ($array2) must be of type array, int given
+array_diff_key(): Argument #2 ($exclude) must be of type array, int given
+array_diff_key(): Argument #2 ($exclude) must be of type array, int given
 
 --int 1--
-array_diff_key(): Argument #2 ($array2) must be of type array, int given
-array_diff_key(): Argument #2 ($array2) must be of type array, int given
+array_diff_key(): Argument #2 ($exclude) must be of type array, int given
+array_diff_key(): Argument #2 ($exclude) must be of type array, int given
 
 --int 12345--
-array_diff_key(): Argument #2 ($array2) must be of type array, int given
-array_diff_key(): Argument #2 ($array2) must be of type array, int given
+array_diff_key(): Argument #2 ($exclude) must be of type array, int given
+array_diff_key(): Argument #2 ($exclude) must be of type array, int given
 
 --int -12345--
-array_diff_key(): Argument #2 ($array2) must be of type array, int given
-array_diff_key(): Argument #2 ($array2) must be of type array, int given
+array_diff_key(): Argument #2 ($exclude) must be of type array, int given
+array_diff_key(): Argument #2 ($exclude) must be of type array, int given
 
 --float 10.5--
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
 
 --float -10.5--
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
 
 --float .5--
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
-array_diff_key(): Argument #2 ($array2) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
+array_diff_key(): Argument #2 ($exclude) must be of type array, float given
 
 --uppercase NULL--
-array_diff_key(): Argument #2 ($array2) must be of type array, null given
-array_diff_key(): Argument #2 ($array2) must be of type array, null given
+array_diff_key(): Argument #2 ($exclude) must be of type array, null given
+array_diff_key(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase null--
-array_diff_key(): Argument #2 ($array2) must be of type array, null given
-array_diff_key(): Argument #2 ($array2) must be of type array, null given
+array_diff_key(): Argument #2 ($exclude) must be of type array, null given
+array_diff_key(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase true--
-array_diff_key(): Argument #2 ($array2) must be of type array, bool given
-array_diff_key(): Argument #2 ($array2) must be of type array, bool given
+array_diff_key(): Argument #2 ($exclude) must be of type array, bool given
+array_diff_key(): Argument #2 ($exclude) must be of type array, bool given
 
 --lowercase false--
-array_diff_key(): Argument #2 ($array2) must be of type array, bool given
-array_diff_key(): Argument #2 ($array2) must be of type array, bool given
+array_diff_key(): Argument #2 ($exclude) must be of type array, bool given
+array_diff_key(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_key(): Argument #2 ($array2) must be of type array, bool given
-array_diff_key(): Argument #2 ($array2) must be of type array, bool given
+array_diff_key(): Argument #2 ($exclude) must be of type array, bool given
+array_diff_key(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_key(): Argument #2 ($array2) must be of type array, bool given
-array_diff_key(): Argument #2 ($array2) must be of type array, bool given
+array_diff_key(): Argument #2 ($exclude) must be of type array, bool given
+array_diff_key(): Argument #2 ($exclude) must be of type array, bool given
 
 --empty string DQ--
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
 
 --empty string SQ--
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
 
 --string DQ--
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
 
 --string SQ--
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
 
 --mixed case string--
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
 
 --heredoc--
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
-array_diff_key(): Argument #2 ($array2) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
+array_diff_key(): Argument #2 ($exclude) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_key(): Argument #2 ($array2) must be of type array, classWithToString given
-array_diff_key(): Argument #2 ($array2) must be of type array, classWithToString given
+array_diff_key(): Argument #2 ($exclude) must be of type array, classWithToString given
+array_diff_key(): Argument #2 ($exclude) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_key(): Argument #2 ($array2) must be of type array, classWithoutToString given
-array_diff_key(): Argument #2 ($array2) must be of type array, classWithoutToString given
+array_diff_key(): Argument #2 ($exclude) must be of type array, classWithoutToString given
+array_diff_key(): Argument #2 ($exclude) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_key(): Argument #2 ($array2) must be of type array, null given
-array_diff_key(): Argument #2 ($array2) must be of type array, null given
+array_diff_key(): Argument #2 ($exclude) must be of type array, null given
+array_diff_key(): Argument #2 ($exclude) must be of type array, null given
 
 --unset var--
-array_diff_key(): Argument #2 ($array2) must be of type array, null given
-array_diff_key(): Argument #2 ($array2) must be of type array, null given
+array_diff_key(): Argument #2 ($exclude) must be of type array, null given
+array_diff_key(): Argument #2 ($exclude) must be of type array, null given
 
 --resource--
-array_diff_key(): Argument #2 ($array2) must be of type array, resource given
-array_diff_key(): Argument #2 ($array2) must be of type array, resource given
+array_diff_key(): Argument #2 ($exclude) must be of type array, resource given
+array_diff_key(): Argument #2 ($exclude) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_uassoc_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_uassoc_variation1.phpt
@@ -110,79 +110,79 @@ fclose($fp);
 *** Testing array_diff_uassoc() : usage variation ***
 
 --int 0--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, int given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, int given
 
 --int 1--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, int given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, int given
 
 --int 12345--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, int given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, int given
 
 --int -12345--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, int given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, int given
 
 --float 10.5--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --float -10.5--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --float .5--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --uppercase NULL--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, null given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, null given
 
 --lowercase null--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, null given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, null given
 
 --lowercase true--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, bool given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, bool given
 
 --lowercase false--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, bool given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, bool given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, bool given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, bool given
 
 --empty string DQ--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --empty string SQ--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --string DQ--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --string SQ--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --mixed case string--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --heredoc--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, classWithToString given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, classWithoutToString given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, null given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, null given
 
 --unset var--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, null given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, null given
 
 --resource--
-array_diff_uassoc(): Argument #1 ($array1) must be of type array, resource given
+array_diff_uassoc(): Argument #1 ($source) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_uassoc_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_uassoc_variation1.phpt
@@ -110,79 +110,79 @@ fclose($fp);
 *** Testing array_diff_uassoc() : usage variation ***
 
 --int 0--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, int given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, int given
 
 --int 1--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, int given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, int given
 
 --int 12345--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, int given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, int given
 
 --int -12345--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, int given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, int given
 
 --float 10.5--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --float -10.5--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --float .5--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --uppercase NULL--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, null given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, null given
 
 --lowercase null--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, null given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, null given
 
 --lowercase true--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, bool given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, bool given
 
 --lowercase false--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, bool given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, bool given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, bool given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, bool given
 
 --empty string DQ--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --empty string SQ--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --string DQ--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --string SQ--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --mixed case string--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --heredoc--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, classWithToString given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, classWithoutToString given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, null given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, null given
 
 --unset var--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, null given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, null given
 
 --resource--
-array_diff_uassoc(): Argument #1 ($source) must be of type array, resource given
+array_diff_uassoc(): Argument #1 ($input) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_uassoc_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_uassoc_variation2.phpt
@@ -110,79 +110,79 @@ fclose($fp);
 *** Testing array_diff_uassoc() : usage variation ***
 
 --int 0--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, int given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int 1--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, int given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int 12345--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, int given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int -12345--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, int given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, int given
 
 --float 10.5--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float -10.5--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float .5--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --uppercase NULL--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, null given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase null--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, null given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase true--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, bool given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --lowercase false--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, bool given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, bool given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, bool given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --empty string DQ--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --empty string SQ--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --string DQ--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --string SQ--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --mixed case string--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --heredoc--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, classWithToString given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, classWithoutToString given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, null given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, null given
 
 --unset var--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, null given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, null given
 
 --resource--
-array_diff_uassoc(): Argument #2 ($array2) must be of type array, resource given
+array_diff_uassoc(): Argument #2 ($exclude) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_ukey_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_ukey_variation1.phpt
@@ -111,105 +111,105 @@ fclose($fp);
 *** Testing array_diff_ukey() : usage variation ***
 
 --int 0--
-array_diff_ukey(): Argument #1 ($source) must be of type array, int given
-array_diff_ukey(): Argument #1 ($source) must be of type array, int given
+array_diff_ukey(): Argument #1 ($input) must be of type array, int given
+array_diff_ukey(): Argument #1 ($input) must be of type array, int given
 
 --int 1--
-array_diff_ukey(): Argument #1 ($source) must be of type array, int given
-array_diff_ukey(): Argument #1 ($source) must be of type array, int given
+array_diff_ukey(): Argument #1 ($input) must be of type array, int given
+array_diff_ukey(): Argument #1 ($input) must be of type array, int given
 
 --int 12345--
-array_diff_ukey(): Argument #1 ($source) must be of type array, int given
-array_diff_ukey(): Argument #1 ($source) must be of type array, int given
+array_diff_ukey(): Argument #1 ($input) must be of type array, int given
+array_diff_ukey(): Argument #1 ($input) must be of type array, int given
 
 --int -12345--
-array_diff_ukey(): Argument #1 ($source) must be of type array, int given
-array_diff_ukey(): Argument #1 ($source) must be of type array, int given
+array_diff_ukey(): Argument #1 ($input) must be of type array, int given
+array_diff_ukey(): Argument #1 ($input) must be of type array, int given
 
 --float 10.5--
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
 
 --float -10.5--
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
 
 --float .5--
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
-array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
+array_diff_ukey(): Argument #1 ($input) must be of type array, float given
 
 --uppercase NULL--
-array_diff_ukey(): Argument #1 ($source) must be of type array, null given
-array_diff_ukey(): Argument #1 ($source) must be of type array, null given
+array_diff_ukey(): Argument #1 ($input) must be of type array, null given
+array_diff_ukey(): Argument #1 ($input) must be of type array, null given
 
 --lowercase null--
-array_diff_ukey(): Argument #1 ($source) must be of type array, null given
-array_diff_ukey(): Argument #1 ($source) must be of type array, null given
+array_diff_ukey(): Argument #1 ($input) must be of type array, null given
+array_diff_ukey(): Argument #1 ($input) must be of type array, null given
 
 --lowercase true--
-array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
-array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($input) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($input) must be of type array, bool given
 
 --lowercase false--
-array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
-array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($input) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
-array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($input) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
-array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($input) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($input) must be of type array, bool given
 
 --empty string DQ--
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
 
 --empty string SQ--
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
 
 --string DQ--
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
 
 --string SQ--
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
 
 --mixed case string--
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
 
 --heredoc--
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
-array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
+array_diff_ukey(): Argument #1 ($input) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_ukey(): Argument #1 ($source) must be of type array, classWithToString given
-array_diff_ukey(): Argument #1 ($source) must be of type array, classWithToString given
+array_diff_ukey(): Argument #1 ($input) must be of type array, classWithToString given
+array_diff_ukey(): Argument #1 ($input) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_ukey(): Argument #1 ($source) must be of type array, classWithoutToString given
-array_diff_ukey(): Argument #1 ($source) must be of type array, classWithoutToString given
+array_diff_ukey(): Argument #1 ($input) must be of type array, classWithoutToString given
+array_diff_ukey(): Argument #1 ($input) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_ukey(): Argument #1 ($source) must be of type array, null given
-array_diff_ukey(): Argument #1 ($source) must be of type array, null given
+array_diff_ukey(): Argument #1 ($input) must be of type array, null given
+array_diff_ukey(): Argument #1 ($input) must be of type array, null given
 
 --unset var--
-array_diff_ukey(): Argument #1 ($source) must be of type array, null given
-array_diff_ukey(): Argument #1 ($source) must be of type array, null given
+array_diff_ukey(): Argument #1 ($input) must be of type array, null given
+array_diff_ukey(): Argument #1 ($input) must be of type array, null given
 
 --resource--
-array_diff_ukey(): Argument #1 ($source) must be of type array, resource given
-array_diff_ukey(): Argument #1 ($source) must be of type array, resource given
+array_diff_ukey(): Argument #1 ($input) must be of type array, resource given
+array_diff_ukey(): Argument #1 ($input) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_ukey_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_ukey_variation1.phpt
@@ -111,105 +111,105 @@ fclose($fp);
 *** Testing array_diff_ukey() : usage variation ***
 
 --int 0--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, int given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, int given
+array_diff_ukey(): Argument #1 ($source) must be of type array, int given
+array_diff_ukey(): Argument #1 ($source) must be of type array, int given
 
 --int 1--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, int given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, int given
+array_diff_ukey(): Argument #1 ($source) must be of type array, int given
+array_diff_ukey(): Argument #1 ($source) must be of type array, int given
 
 --int 12345--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, int given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, int given
+array_diff_ukey(): Argument #1 ($source) must be of type array, int given
+array_diff_ukey(): Argument #1 ($source) must be of type array, int given
 
 --int -12345--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, int given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, int given
+array_diff_ukey(): Argument #1 ($source) must be of type array, int given
+array_diff_ukey(): Argument #1 ($source) must be of type array, int given
 
 --float 10.5--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
 
 --float -10.5--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
 
 --float .5--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
+array_diff_ukey(): Argument #1 ($source) must be of type array, float given
 
 --uppercase NULL--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, null given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, null given
+array_diff_ukey(): Argument #1 ($source) must be of type array, null given
+array_diff_ukey(): Argument #1 ($source) must be of type array, null given
 
 --lowercase null--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, null given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, null given
+array_diff_ukey(): Argument #1 ($source) must be of type array, null given
+array_diff_ukey(): Argument #1 ($source) must be of type array, null given
 
 --lowercase true--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, bool given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
 
 --lowercase false--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, bool given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, bool given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, bool given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
+array_diff_ukey(): Argument #1 ($source) must be of type array, bool given
 
 --empty string DQ--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
 
 --empty string SQ--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
 
 --string DQ--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
 
 --string SQ--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
 
 --mixed case string--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
 
 --heredoc--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
+array_diff_ukey(): Argument #1 ($source) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, classWithToString given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, classWithToString given
+array_diff_ukey(): Argument #1 ($source) must be of type array, classWithToString given
+array_diff_ukey(): Argument #1 ($source) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, classWithoutToString given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, classWithoutToString given
+array_diff_ukey(): Argument #1 ($source) must be of type array, classWithoutToString given
+array_diff_ukey(): Argument #1 ($source) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, null given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, null given
+array_diff_ukey(): Argument #1 ($source) must be of type array, null given
+array_diff_ukey(): Argument #1 ($source) must be of type array, null given
 
 --unset var--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, null given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, null given
+array_diff_ukey(): Argument #1 ($source) must be of type array, null given
+array_diff_ukey(): Argument #1 ($source) must be of type array, null given
 
 --resource--
-array_diff_ukey(): Argument #1 ($array1) must be of type array, resource given
-array_diff_ukey(): Argument #1 ($array1) must be of type array, resource given
+array_diff_ukey(): Argument #1 ($source) must be of type array, resource given
+array_diff_ukey(): Argument #1 ($source) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_ukey_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_ukey_variation2.phpt
@@ -115,105 +115,105 @@ fclose($fp);
 *** Testing array_diff_ukey() : usage variation ***
 
 --int 0--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, int given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, int given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, int given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, int given
 
 --int 1--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, int given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, int given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, int given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, int given
 
 --int 12345--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, int given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, int given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, int given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, int given
 
 --int -12345--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, int given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, int given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, int given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, int given
 
 --float 10.5--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
 
 --float -10.5--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
 
 --float 12.3456789000e10--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
 
 --float -12.3456789000e10--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
 
 --float .5--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, float given
 
 --uppercase NULL--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, null given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, null given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, null given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase null--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, null given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, null given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, null given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase true--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, bool given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, bool given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, bool given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, bool given
 
 --lowercase false--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, bool given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, bool given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, bool given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase TRUE--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, bool given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, bool given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, bool given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase FALSE--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, bool given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, bool given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, bool given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, bool given
 
 --empty string DQ--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
 
 --empty string SQ--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
 
 --string DQ--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
 
 --string SQ--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
 
 --mixed case string--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
 
 --heredoc--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, string given
 
 --instance of classWithToString--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, classWithToString given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, classWithToString given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, classWithToString given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, classWithoutToString given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, classWithoutToString given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, classWithoutToString given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, classWithoutToString given
 
 --undefined var--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, null given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, null given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, null given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, null given
 
 --unset var--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, null given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, null given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, null given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, null given
 
 --resource--
-array_diff_ukey(): Argument #2 ($array2) must be of type array, resource given
-array_diff_ukey(): Argument #2 ($array2) must be of type array, resource given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, resource given
+array_diff_ukey(): Argument #2 ($exclude) must be of type array, resource given

--- a/ext/standard/tests/array/array_diff_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_variation1.phpt
@@ -100,55 +100,55 @@ echo "Done";
 --EXPECT--
 *** Testing array_diff() : usage variations ***
 
--- Iteration 1 --array_diff(): Argument #1 ($array1) must be of type array, int given
+-- Iteration 1 --array_diff(): Argument #1 ($source) must be of type array, int given
 
--- Iteration 2 --array_diff(): Argument #1 ($array1) must be of type array, int given
+-- Iteration 2 --array_diff(): Argument #1 ($source) must be of type array, int given
 
--- Iteration 3 --array_diff(): Argument #1 ($array1) must be of type array, int given
+-- Iteration 3 --array_diff(): Argument #1 ($source) must be of type array, int given
 
--- Iteration 4 --array_diff(): Argument #1 ($array1) must be of type array, int given
+-- Iteration 4 --array_diff(): Argument #1 ($source) must be of type array, int given
 
--- Iteration 5 --array_diff(): Argument #1 ($array1) must be of type array, float given
+-- Iteration 5 --array_diff(): Argument #1 ($source) must be of type array, float given
 
--- Iteration 6 --array_diff(): Argument #1 ($array1) must be of type array, float given
+-- Iteration 6 --array_diff(): Argument #1 ($source) must be of type array, float given
 
--- Iteration 7 --array_diff(): Argument #1 ($array1) must be of type array, float given
+-- Iteration 7 --array_diff(): Argument #1 ($source) must be of type array, float given
 
--- Iteration 8 --array_diff(): Argument #1 ($array1) must be of type array, float given
+-- Iteration 8 --array_diff(): Argument #1 ($source) must be of type array, float given
 
--- Iteration 9 --array_diff(): Argument #1 ($array1) must be of type array, float given
+-- Iteration 9 --array_diff(): Argument #1 ($source) must be of type array, float given
 
--- Iteration 10 --array_diff(): Argument #1 ($array1) must be of type array, null given
+-- Iteration 10 --array_diff(): Argument #1 ($source) must be of type array, null given
 
--- Iteration 11 --array_diff(): Argument #1 ($array1) must be of type array, null given
+-- Iteration 11 --array_diff(): Argument #1 ($source) must be of type array, null given
 
--- Iteration 12 --array_diff(): Argument #1 ($array1) must be of type array, bool given
+-- Iteration 12 --array_diff(): Argument #1 ($source) must be of type array, bool given
 
--- Iteration 13 --array_diff(): Argument #1 ($array1) must be of type array, bool given
+-- Iteration 13 --array_diff(): Argument #1 ($source) must be of type array, bool given
 
--- Iteration 14 --array_diff(): Argument #1 ($array1) must be of type array, bool given
+-- Iteration 14 --array_diff(): Argument #1 ($source) must be of type array, bool given
 
--- Iteration 15 --array_diff(): Argument #1 ($array1) must be of type array, bool given
+-- Iteration 15 --array_diff(): Argument #1 ($source) must be of type array, bool given
 
--- Iteration 16 --array_diff(): Argument #1 ($array1) must be of type array, string given
+-- Iteration 16 --array_diff(): Argument #1 ($source) must be of type array, string given
 
--- Iteration 17 --array_diff(): Argument #1 ($array1) must be of type array, string given
+-- Iteration 17 --array_diff(): Argument #1 ($source) must be of type array, string given
 
--- Iteration 18 --array_diff(): Argument #1 ($array1) must be of type array, string given
+-- Iteration 18 --array_diff(): Argument #1 ($source) must be of type array, string given
 
--- Iteration 19 --array_diff(): Argument #1 ($array1) must be of type array, string given
+-- Iteration 19 --array_diff(): Argument #1 ($source) must be of type array, string given
 
--- Iteration 20 --array_diff(): Argument #1 ($array1) must be of type array, string given
+-- Iteration 20 --array_diff(): Argument #1 ($source) must be of type array, string given
 
--- Iteration 21 --array_diff(): Argument #1 ($array1) must be of type array, string given
+-- Iteration 21 --array_diff(): Argument #1 ($source) must be of type array, string given
 
--- Iteration 22 --array_diff(): Argument #1 ($array1) must be of type array, string given
+-- Iteration 22 --array_diff(): Argument #1 ($source) must be of type array, string given
 
--- Iteration 23 --array_diff(): Argument #1 ($array1) must be of type array, classA given
+-- Iteration 23 --array_diff(): Argument #1 ($source) must be of type array, classA given
 
--- Iteration 24 --array_diff(): Argument #1 ($array1) must be of type array, null given
+-- Iteration 24 --array_diff(): Argument #1 ($source) must be of type array, null given
 
--- Iteration 25 --array_diff(): Argument #1 ($array1) must be of type array, null given
+-- Iteration 25 --array_diff(): Argument #1 ($source) must be of type array, null given
 
--- Iteration 26 --array_diff(): Argument #1 ($array1) must be of type array, resource given
+-- Iteration 26 --array_diff(): Argument #1 ($source) must be of type array, resource given
 Done

--- a/ext/standard/tests/array/array_diff_variation1.phpt
+++ b/ext/standard/tests/array/array_diff_variation1.phpt
@@ -100,55 +100,55 @@ echo "Done";
 --EXPECT--
 *** Testing array_diff() : usage variations ***
 
--- Iteration 1 --array_diff(): Argument #1 ($source) must be of type array, int given
+-- Iteration 1 --array_diff(): Argument #1 ($input) must be of type array, int given
 
--- Iteration 2 --array_diff(): Argument #1 ($source) must be of type array, int given
+-- Iteration 2 --array_diff(): Argument #1 ($input) must be of type array, int given
 
--- Iteration 3 --array_diff(): Argument #1 ($source) must be of type array, int given
+-- Iteration 3 --array_diff(): Argument #1 ($input) must be of type array, int given
 
--- Iteration 4 --array_diff(): Argument #1 ($source) must be of type array, int given
+-- Iteration 4 --array_diff(): Argument #1 ($input) must be of type array, int given
 
--- Iteration 5 --array_diff(): Argument #1 ($source) must be of type array, float given
+-- Iteration 5 --array_diff(): Argument #1 ($input) must be of type array, float given
 
--- Iteration 6 --array_diff(): Argument #1 ($source) must be of type array, float given
+-- Iteration 6 --array_diff(): Argument #1 ($input) must be of type array, float given
 
--- Iteration 7 --array_diff(): Argument #1 ($source) must be of type array, float given
+-- Iteration 7 --array_diff(): Argument #1 ($input) must be of type array, float given
 
--- Iteration 8 --array_diff(): Argument #1 ($source) must be of type array, float given
+-- Iteration 8 --array_diff(): Argument #1 ($input) must be of type array, float given
 
--- Iteration 9 --array_diff(): Argument #1 ($source) must be of type array, float given
+-- Iteration 9 --array_diff(): Argument #1 ($input) must be of type array, float given
 
--- Iteration 10 --array_diff(): Argument #1 ($source) must be of type array, null given
+-- Iteration 10 --array_diff(): Argument #1 ($input) must be of type array, null given
 
--- Iteration 11 --array_diff(): Argument #1 ($source) must be of type array, null given
+-- Iteration 11 --array_diff(): Argument #1 ($input) must be of type array, null given
 
--- Iteration 12 --array_diff(): Argument #1 ($source) must be of type array, bool given
+-- Iteration 12 --array_diff(): Argument #1 ($input) must be of type array, bool given
 
--- Iteration 13 --array_diff(): Argument #1 ($source) must be of type array, bool given
+-- Iteration 13 --array_diff(): Argument #1 ($input) must be of type array, bool given
 
--- Iteration 14 --array_diff(): Argument #1 ($source) must be of type array, bool given
+-- Iteration 14 --array_diff(): Argument #1 ($input) must be of type array, bool given
 
--- Iteration 15 --array_diff(): Argument #1 ($source) must be of type array, bool given
+-- Iteration 15 --array_diff(): Argument #1 ($input) must be of type array, bool given
 
--- Iteration 16 --array_diff(): Argument #1 ($source) must be of type array, string given
+-- Iteration 16 --array_diff(): Argument #1 ($input) must be of type array, string given
 
--- Iteration 17 --array_diff(): Argument #1 ($source) must be of type array, string given
+-- Iteration 17 --array_diff(): Argument #1 ($input) must be of type array, string given
 
--- Iteration 18 --array_diff(): Argument #1 ($source) must be of type array, string given
+-- Iteration 18 --array_diff(): Argument #1 ($input) must be of type array, string given
 
--- Iteration 19 --array_diff(): Argument #1 ($source) must be of type array, string given
+-- Iteration 19 --array_diff(): Argument #1 ($input) must be of type array, string given
 
--- Iteration 20 --array_diff(): Argument #1 ($source) must be of type array, string given
+-- Iteration 20 --array_diff(): Argument #1 ($input) must be of type array, string given
 
--- Iteration 21 --array_diff(): Argument #1 ($source) must be of type array, string given
+-- Iteration 21 --array_diff(): Argument #1 ($input) must be of type array, string given
 
--- Iteration 22 --array_diff(): Argument #1 ($source) must be of type array, string given
+-- Iteration 22 --array_diff(): Argument #1 ($input) must be of type array, string given
 
--- Iteration 23 --array_diff(): Argument #1 ($source) must be of type array, classA given
+-- Iteration 23 --array_diff(): Argument #1 ($input) must be of type array, classA given
 
--- Iteration 24 --array_diff(): Argument #1 ($source) must be of type array, null given
+-- Iteration 24 --array_diff(): Argument #1 ($input) must be of type array, null given
 
--- Iteration 25 --array_diff(): Argument #1 ($source) must be of type array, null given
+-- Iteration 25 --array_diff(): Argument #1 ($input) must be of type array, null given
 
--- Iteration 26 --array_diff(): Argument #1 ($source) must be of type array, resource given
+-- Iteration 26 --array_diff(): Argument #1 ($input) must be of type array, resource given
 Done

--- a/ext/standard/tests/array/array_diff_variation2.phpt
+++ b/ext/standard/tests/array/array_diff_variation2.phpt
@@ -99,55 +99,55 @@ echo "Done";
 --EXPECT--
 *** Testing array_diff() : usage variations ***
 
--- Iteration 1 --array_diff(): Argument #2 ($array2) must be of type array, int given
+-- Iteration 1 --array_diff(): Argument #2 ($exclude) must be of type array, int given
 
--- Iteration 2 --array_diff(): Argument #2 ($array2) must be of type array, int given
+-- Iteration 2 --array_diff(): Argument #2 ($exclude) must be of type array, int given
 
--- Iteration 3 --array_diff(): Argument #2 ($array2) must be of type array, int given
+-- Iteration 3 --array_diff(): Argument #2 ($exclude) must be of type array, int given
 
--- Iteration 4 --array_diff(): Argument #2 ($array2) must be of type array, int given
+-- Iteration 4 --array_diff(): Argument #2 ($exclude) must be of type array, int given
 
--- Iteration 5 --array_diff(): Argument #2 ($array2) must be of type array, float given
+-- Iteration 5 --array_diff(): Argument #2 ($exclude) must be of type array, float given
 
--- Iteration 6 --array_diff(): Argument #2 ($array2) must be of type array, float given
+-- Iteration 6 --array_diff(): Argument #2 ($exclude) must be of type array, float given
 
--- Iteration 7 --array_diff(): Argument #2 ($array2) must be of type array, float given
+-- Iteration 7 --array_diff(): Argument #2 ($exclude) must be of type array, float given
 
--- Iteration 8 --array_diff(): Argument #2 ($array2) must be of type array, float given
+-- Iteration 8 --array_diff(): Argument #2 ($exclude) must be of type array, float given
 
--- Iteration 9 --array_diff(): Argument #2 ($array2) must be of type array, float given
+-- Iteration 9 --array_diff(): Argument #2 ($exclude) must be of type array, float given
 
--- Iteration 10 --array_diff(): Argument #2 ($array2) must be of type array, null given
+-- Iteration 10 --array_diff(): Argument #2 ($exclude) must be of type array, null given
 
--- Iteration 11 --array_diff(): Argument #2 ($array2) must be of type array, null given
+-- Iteration 11 --array_diff(): Argument #2 ($exclude) must be of type array, null given
 
--- Iteration 12 --array_diff(): Argument #2 ($array2) must be of type array, bool given
+-- Iteration 12 --array_diff(): Argument #2 ($exclude) must be of type array, bool given
 
--- Iteration 13 --array_diff(): Argument #2 ($array2) must be of type array, bool given
+-- Iteration 13 --array_diff(): Argument #2 ($exclude) must be of type array, bool given
 
--- Iteration 14 --array_diff(): Argument #2 ($array2) must be of type array, bool given
+-- Iteration 14 --array_diff(): Argument #2 ($exclude) must be of type array, bool given
 
--- Iteration 15 --array_diff(): Argument #2 ($array2) must be of type array, bool given
+-- Iteration 15 --array_diff(): Argument #2 ($exclude) must be of type array, bool given
 
--- Iteration 16 --array_diff(): Argument #2 ($array2) must be of type array, string given
+-- Iteration 16 --array_diff(): Argument #2 ($exclude) must be of type array, string given
 
--- Iteration 17 --array_diff(): Argument #2 ($array2) must be of type array, string given
+-- Iteration 17 --array_diff(): Argument #2 ($exclude) must be of type array, string given
 
--- Iteration 18 --array_diff(): Argument #2 ($array2) must be of type array, string given
+-- Iteration 18 --array_diff(): Argument #2 ($exclude) must be of type array, string given
 
--- Iteration 19 --array_diff(): Argument #2 ($array2) must be of type array, string given
+-- Iteration 19 --array_diff(): Argument #2 ($exclude) must be of type array, string given
 
--- Iteration 20 --array_diff(): Argument #2 ($array2) must be of type array, string given
+-- Iteration 20 --array_diff(): Argument #2 ($exclude) must be of type array, string given
 
--- Iteration 21 --array_diff(): Argument #2 ($array2) must be of type array, string given
+-- Iteration 21 --array_diff(): Argument #2 ($exclude) must be of type array, string given
 
--- Iteration 22 --array_diff(): Argument #2 ($array2) must be of type array, string given
+-- Iteration 22 --array_diff(): Argument #2 ($exclude) must be of type array, string given
 
--- Iteration 23 --array_diff(): Argument #2 ($array2) must be of type array, classA given
+-- Iteration 23 --array_diff(): Argument #2 ($exclude) must be of type array, classA given
 
--- Iteration 24 --array_diff(): Argument #2 ($array2) must be of type array, null given
+-- Iteration 24 --array_diff(): Argument #2 ($exclude) must be of type array, null given
 
--- Iteration 25 --array_diff(): Argument #2 ($array2) must be of type array, null given
+-- Iteration 25 --array_diff(): Argument #2 ($exclude) must be of type array, null given
 
--- Iteration 26 --array_diff(): Argument #2 ($array2) must be of type array, resource given
+-- Iteration 26 --array_diff(): Argument #2 ($exclude) must be of type array, resource given
 Done

--- a/ext/standard/tests/array/array_udiff_assoc_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_assoc_variation1.phpt
@@ -98,76 +98,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff_assoc() : usage variation ***
 
 --int 0--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, int given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, int given
 
 --int 1--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, int given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, int given
 
 --int 12345--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, int given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, int given
 
 --int -12345--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, int given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, int given
 
 --float 10.5--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, float given
 
 --float -10.5--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, float given
 
 --float .5--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, float given
 
 --uppercase NULL--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, null given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, null given
 
 --lowercase null--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, null given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, null given
 
 --lowercase true--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, bool given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, bool given
 
 --lowercase false--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, bool given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, bool given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, bool given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, bool given
 
 --empty string DQ--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, string given
 
 --empty string SQ--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, string given
 
 --string DQ--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, string given
 
 --string SQ--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, string given
 
 --mixed case string--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, string given
 
 --heredoc--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, classWithToString given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, classWithoutToString given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, null given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, null given
 
 --unset var--
-array_udiff_assoc(): Argument #1 ($source) must be of type array, null given
+array_udiff_assoc(): Argument #1 ($input) must be of type array, null given

--- a/ext/standard/tests/array/array_udiff_assoc_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_assoc_variation1.phpt
@@ -98,76 +98,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff_assoc() : usage variation ***
 
 --int 0--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, int given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, int given
 
 --int 1--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, int given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, int given
 
 --int 12345--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, int given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, int given
 
 --int -12345--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, int given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, int given
 
 --float 10.5--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
 
 --float -10.5--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
 
 --float .5--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, float given
 
 --uppercase NULL--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, null given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, null given
 
 --lowercase null--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, null given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, null given
 
 --lowercase true--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, bool given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, bool given
 
 --lowercase false--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, bool given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, bool given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, bool given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, bool given
 
 --empty string DQ--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
 
 --empty string SQ--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
 
 --string DQ--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
 
 --string SQ--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
 
 --mixed case string--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
 
 --heredoc--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, classWithToString given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, classWithoutToString given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, null given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, null given
 
 --unset var--
-array_udiff_assoc(): Argument #1 ($array1) must be of type array, null given
+array_udiff_assoc(): Argument #1 ($source) must be of type array, null given

--- a/ext/standard/tests/array/array_udiff_assoc_variation2.phpt
+++ b/ext/standard/tests/array/array_udiff_assoc_variation2.phpt
@@ -98,76 +98,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff_assoc() : usage variation ***
 
 --int 0--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, int given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int 1--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, int given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int 12345--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, int given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int -12345--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, int given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, int given
 
 --float 10.5--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float -10.5--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float .5--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, float given
 
 --uppercase NULL--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, null given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase null--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, null given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase true--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, bool given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --lowercase false--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, bool given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, bool given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, bool given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --empty string DQ--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 --empty string SQ--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 --string DQ--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 --string SQ--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 --mixed case string--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 --heredoc--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, classWithToString given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, classWithoutToString given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, null given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, null given
 
 --unset var--
-array_udiff_assoc(): Argument #2 ($array2) must be of type array, null given
+array_udiff_assoc(): Argument #2 ($exclude) must be of type array, null given

--- a/ext/standard/tests/array/array_udiff_uassoc_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_uassoc_variation1.phpt
@@ -99,76 +99,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff_uassoc() : usage variation ***
 
 --int 0--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, int given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, int given
 
 --int 1--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, int given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, int given
 
 --int 12345--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, int given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, int given
 
 --int -12345--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, int given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, int given
 
 --float 10.5--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --float -10.5--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --float .5--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, float given
 
 --uppercase NULL--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, null given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, null given
 
 --lowercase null--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, null given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, null given
 
 --lowercase true--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, bool given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, bool given
 
 --lowercase false--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, bool given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, bool given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, bool given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, bool given
 
 --empty string DQ--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --empty string SQ--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --string DQ--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --string SQ--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --mixed case string--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --heredoc--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, classWithToString given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, classWithoutToString given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, null given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, null given
 
 --unset var--
-array_udiff_uassoc(): Argument #1 ($source) must be of type array, null given
+array_udiff_uassoc(): Argument #1 ($input) must be of type array, null given

--- a/ext/standard/tests/array/array_udiff_uassoc_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_uassoc_variation1.phpt
@@ -99,76 +99,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff_uassoc() : usage variation ***
 
 --int 0--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, int given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, int given
 
 --int 1--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, int given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, int given
 
 --int 12345--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, int given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, int given
 
 --int -12345--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, int given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, int given
 
 --float 10.5--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --float -10.5--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --float .5--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, float given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, float given
 
 --uppercase NULL--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, null given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, null given
 
 --lowercase null--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, null given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, null given
 
 --lowercase true--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, bool given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, bool given
 
 --lowercase false--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, bool given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, bool given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, bool given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, bool given
 
 --empty string DQ--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --empty string SQ--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --string DQ--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --string SQ--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --mixed case string--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --heredoc--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, string given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, classWithToString given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, classWithoutToString given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, null given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, null given
 
 --unset var--
-array_udiff_uassoc(): Argument #1 ($array1) must be of type array, null given
+array_udiff_uassoc(): Argument #1 ($source) must be of type array, null given

--- a/ext/standard/tests/array/array_udiff_uassoc_variation2.phpt
+++ b/ext/standard/tests/array/array_udiff_uassoc_variation2.phpt
@@ -99,76 +99,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff_uassoc() : usage variation ***
 
 --int 0--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, int given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int 1--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, int given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int 12345--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, int given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, int given
 
 --int -12345--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, int given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, int given
 
 --float 10.5--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float -10.5--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --float .5--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, float given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, float given
 
 --uppercase NULL--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, null given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase null--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, null given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase true--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, bool given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --lowercase false--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, bool given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, bool given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, bool given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, bool given
 
 --empty string DQ--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --empty string SQ--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --string DQ--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --string SQ--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --mixed case string--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --heredoc--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, string given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, classWithToString given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, classWithoutToString given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, null given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, null given
 
 --unset var--
-array_udiff_uassoc(): Argument #2 ($array2) must be of type array, null given
+array_udiff_uassoc(): Argument #2 ($exclude) must be of type array, null given

--- a/ext/standard/tests/array/array_udiff_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_variation1.phpt
@@ -98,76 +98,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff() : usage variation ***
 
 --int 0--
-array_udiff(): Argument #1 ($array1) must be of type array, int given
+array_udiff(): Argument #1 ($source) must be of type array, int given
 
 --int 1--
-array_udiff(): Argument #1 ($array1) must be of type array, int given
+array_udiff(): Argument #1 ($source) must be of type array, int given
 
 --int 12345--
-array_udiff(): Argument #1 ($array1) must be of type array, int given
+array_udiff(): Argument #1 ($source) must be of type array, int given
 
 --int -12345--
-array_udiff(): Argument #1 ($array1) must be of type array, int given
+array_udiff(): Argument #1 ($source) must be of type array, int given
 
 --float 10.5--
-array_udiff(): Argument #1 ($array1) must be of type array, float given
+array_udiff(): Argument #1 ($source) must be of type array, float given
 
 --float -10.5--
-array_udiff(): Argument #1 ($array1) must be of type array, float given
+array_udiff(): Argument #1 ($source) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff(): Argument #1 ($array1) must be of type array, float given
+array_udiff(): Argument #1 ($source) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff(): Argument #1 ($array1) must be of type array, float given
+array_udiff(): Argument #1 ($source) must be of type array, float given
 
 --float .5--
-array_udiff(): Argument #1 ($array1) must be of type array, float given
+array_udiff(): Argument #1 ($source) must be of type array, float given
 
 --uppercase NULL--
-array_udiff(): Argument #1 ($array1) must be of type array, null given
+array_udiff(): Argument #1 ($source) must be of type array, null given
 
 --lowercase null--
-array_udiff(): Argument #1 ($array1) must be of type array, null given
+array_udiff(): Argument #1 ($source) must be of type array, null given
 
 --lowercase true--
-array_udiff(): Argument #1 ($array1) must be of type array, bool given
+array_udiff(): Argument #1 ($source) must be of type array, bool given
 
 --lowercase false--
-array_udiff(): Argument #1 ($array1) must be of type array, bool given
+array_udiff(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff(): Argument #1 ($array1) must be of type array, bool given
+array_udiff(): Argument #1 ($source) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff(): Argument #1 ($array1) must be of type array, bool given
+array_udiff(): Argument #1 ($source) must be of type array, bool given
 
 --empty string DQ--
-array_udiff(): Argument #1 ($array1) must be of type array, string given
+array_udiff(): Argument #1 ($source) must be of type array, string given
 
 --empty string SQ--
-array_udiff(): Argument #1 ($array1) must be of type array, string given
+array_udiff(): Argument #1 ($source) must be of type array, string given
 
 --string DQ--
-array_udiff(): Argument #1 ($array1) must be of type array, string given
+array_udiff(): Argument #1 ($source) must be of type array, string given
 
 --string SQ--
-array_udiff(): Argument #1 ($array1) must be of type array, string given
+array_udiff(): Argument #1 ($source) must be of type array, string given
 
 --mixed case string--
-array_udiff(): Argument #1 ($array1) must be of type array, string given
+array_udiff(): Argument #1 ($source) must be of type array, string given
 
 --heredoc--
-array_udiff(): Argument #1 ($array1) must be of type array, string given
+array_udiff(): Argument #1 ($source) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff(): Argument #1 ($array1) must be of type array, classWithToString given
+array_udiff(): Argument #1 ($source) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff(): Argument #1 ($array1) must be of type array, classWithoutToString given
+array_udiff(): Argument #1 ($source) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff(): Argument #1 ($array1) must be of type array, null given
+array_udiff(): Argument #1 ($source) must be of type array, null given
 
 --unset var--
-array_udiff(): Argument #1 ($array1) must be of type array, null given
+array_udiff(): Argument #1 ($source) must be of type array, null given

--- a/ext/standard/tests/array/array_udiff_variation1.phpt
+++ b/ext/standard/tests/array/array_udiff_variation1.phpt
@@ -98,76 +98,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff() : usage variation ***
 
 --int 0--
-array_udiff(): Argument #1 ($source) must be of type array, int given
+array_udiff(): Argument #1 ($input) must be of type array, int given
 
 --int 1--
-array_udiff(): Argument #1 ($source) must be of type array, int given
+array_udiff(): Argument #1 ($input) must be of type array, int given
 
 --int 12345--
-array_udiff(): Argument #1 ($source) must be of type array, int given
+array_udiff(): Argument #1 ($input) must be of type array, int given
 
 --int -12345--
-array_udiff(): Argument #1 ($source) must be of type array, int given
+array_udiff(): Argument #1 ($input) must be of type array, int given
 
 --float 10.5--
-array_udiff(): Argument #1 ($source) must be of type array, float given
+array_udiff(): Argument #1 ($input) must be of type array, float given
 
 --float -10.5--
-array_udiff(): Argument #1 ($source) must be of type array, float given
+array_udiff(): Argument #1 ($input) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff(): Argument #1 ($source) must be of type array, float given
+array_udiff(): Argument #1 ($input) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff(): Argument #1 ($source) must be of type array, float given
+array_udiff(): Argument #1 ($input) must be of type array, float given
 
 --float .5--
-array_udiff(): Argument #1 ($source) must be of type array, float given
+array_udiff(): Argument #1 ($input) must be of type array, float given
 
 --uppercase NULL--
-array_udiff(): Argument #1 ($source) must be of type array, null given
+array_udiff(): Argument #1 ($input) must be of type array, null given
 
 --lowercase null--
-array_udiff(): Argument #1 ($source) must be of type array, null given
+array_udiff(): Argument #1 ($input) must be of type array, null given
 
 --lowercase true--
-array_udiff(): Argument #1 ($source) must be of type array, bool given
+array_udiff(): Argument #1 ($input) must be of type array, bool given
 
 --lowercase false--
-array_udiff(): Argument #1 ($source) must be of type array, bool given
+array_udiff(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff(): Argument #1 ($source) must be of type array, bool given
+array_udiff(): Argument #1 ($input) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff(): Argument #1 ($source) must be of type array, bool given
+array_udiff(): Argument #1 ($input) must be of type array, bool given
 
 --empty string DQ--
-array_udiff(): Argument #1 ($source) must be of type array, string given
+array_udiff(): Argument #1 ($input) must be of type array, string given
 
 --empty string SQ--
-array_udiff(): Argument #1 ($source) must be of type array, string given
+array_udiff(): Argument #1 ($input) must be of type array, string given
 
 --string DQ--
-array_udiff(): Argument #1 ($source) must be of type array, string given
+array_udiff(): Argument #1 ($input) must be of type array, string given
 
 --string SQ--
-array_udiff(): Argument #1 ($source) must be of type array, string given
+array_udiff(): Argument #1 ($input) must be of type array, string given
 
 --mixed case string--
-array_udiff(): Argument #1 ($source) must be of type array, string given
+array_udiff(): Argument #1 ($input) must be of type array, string given
 
 --heredoc--
-array_udiff(): Argument #1 ($source) must be of type array, string given
+array_udiff(): Argument #1 ($input) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff(): Argument #1 ($source) must be of type array, classWithToString given
+array_udiff(): Argument #1 ($input) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff(): Argument #1 ($source) must be of type array, classWithoutToString given
+array_udiff(): Argument #1 ($input) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff(): Argument #1 ($source) must be of type array, null given
+array_udiff(): Argument #1 ($input) must be of type array, null given
 
 --unset var--
-array_udiff(): Argument #1 ($source) must be of type array, null given
+array_udiff(): Argument #1 ($input) must be of type array, null given

--- a/ext/standard/tests/array/array_udiff_variation2.phpt
+++ b/ext/standard/tests/array/array_udiff_variation2.phpt
@@ -98,76 +98,76 @@ foreach($inputs as $key =>$value) {
 *** Testing array_udiff() : usage variation ***
 
 --int 0--
-array_udiff(): Argument #2 ($array2) must be of type array, int given
+array_udiff(): Argument #2 ($exclude) must be of type array, int given
 
 --int 1--
-array_udiff(): Argument #2 ($array2) must be of type array, int given
+array_udiff(): Argument #2 ($exclude) must be of type array, int given
 
 --int 12345--
-array_udiff(): Argument #2 ($array2) must be of type array, int given
+array_udiff(): Argument #2 ($exclude) must be of type array, int given
 
 --int -12345--
-array_udiff(): Argument #2 ($array2) must be of type array, int given
+array_udiff(): Argument #2 ($exclude) must be of type array, int given
 
 --float 10.5--
-array_udiff(): Argument #2 ($array2) must be of type array, float given
+array_udiff(): Argument #2 ($exclude) must be of type array, float given
 
 --float -10.5--
-array_udiff(): Argument #2 ($array2) must be of type array, float given
+array_udiff(): Argument #2 ($exclude) must be of type array, float given
 
 --float 12.3456789000e10--
-array_udiff(): Argument #2 ($array2) must be of type array, float given
+array_udiff(): Argument #2 ($exclude) must be of type array, float given
 
 --float -12.3456789000e10--
-array_udiff(): Argument #2 ($array2) must be of type array, float given
+array_udiff(): Argument #2 ($exclude) must be of type array, float given
 
 --float .5--
-array_udiff(): Argument #2 ($array2) must be of type array, float given
+array_udiff(): Argument #2 ($exclude) must be of type array, float given
 
 --uppercase NULL--
-array_udiff(): Argument #2 ($array2) must be of type array, null given
+array_udiff(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase null--
-array_udiff(): Argument #2 ($array2) must be of type array, null given
+array_udiff(): Argument #2 ($exclude) must be of type array, null given
 
 --lowercase true--
-array_udiff(): Argument #2 ($array2) must be of type array, bool given
+array_udiff(): Argument #2 ($exclude) must be of type array, bool given
 
 --lowercase false--
-array_udiff(): Argument #2 ($array2) must be of type array, bool given
+array_udiff(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase TRUE--
-array_udiff(): Argument #2 ($array2) must be of type array, bool given
+array_udiff(): Argument #2 ($exclude) must be of type array, bool given
 
 --uppercase FALSE--
-array_udiff(): Argument #2 ($array2) must be of type array, bool given
+array_udiff(): Argument #2 ($exclude) must be of type array, bool given
 
 --empty string DQ--
-array_udiff(): Argument #2 ($array2) must be of type array, string given
+array_udiff(): Argument #2 ($exclude) must be of type array, string given
 
 --empty string SQ--
-array_udiff(): Argument #2 ($array2) must be of type array, string given
+array_udiff(): Argument #2 ($exclude) must be of type array, string given
 
 --string DQ--
-array_udiff(): Argument #2 ($array2) must be of type array, string given
+array_udiff(): Argument #2 ($exclude) must be of type array, string given
 
 --string SQ--
-array_udiff(): Argument #2 ($array2) must be of type array, string given
+array_udiff(): Argument #2 ($exclude) must be of type array, string given
 
 --mixed case string--
-array_udiff(): Argument #2 ($array2) must be of type array, string given
+array_udiff(): Argument #2 ($exclude) must be of type array, string given
 
 --heredoc--
-array_udiff(): Argument #2 ($array2) must be of type array, string given
+array_udiff(): Argument #2 ($exclude) must be of type array, string given
 
 --instance of classWithToString--
-array_udiff(): Argument #2 ($array2) must be of type array, classWithToString given
+array_udiff(): Argument #2 ($exclude) must be of type array, classWithToString given
 
 --instance of classWithoutToString--
-array_udiff(): Argument #2 ($array2) must be of type array, classWithoutToString given
+array_udiff(): Argument #2 ($exclude) must be of type array, classWithoutToString given
 
 --undefined var--
-array_udiff(): Argument #2 ($array2) must be of type array, null given
+array_udiff(): Argument #2 ($exclude) must be of type array, null given
 
 --unset var--
-array_udiff(): Argument #2 ($array2) must be of type array, null given
+array_udiff(): Argument #2 ($exclude) must be of type array, null given


### PR DESCRIPTION
With named parameters, array1/array2 is not a particularly good set of names. :smile: These should be better.