### PR TITLE
Remove unnecassry Zend API macros

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -22,6 +22,7 @@ PHP 8.0 INTERNALS UPGRADE NOTES
   s. zend_fcall_info no_separation flag removed
   t. Signature changes
   u. Error Notification callbacks to replace zend_error_cb overwrite use-cases
+  v. Removed Zend APIs
 
 2. Build system changes
   a. Abstract
@@ -200,6 +201,17 @@ PHP 8.0 INTERNALS UPGRADE NOTES
 			zend_string *message) {
 		}
 		zend_register_error_notify_callback(my_error_notify_cb);
+
+  v. The following APIs have been removed from the Zend Engine:
+     - zend_ts_hash_init_ex(), drop the last argument and use zend_ts_hash_init() instead
+     - zend_hash_init_ex(), drop the last argument and use zend_hash_init() instead
+     - zval_internal_dtor(), use zval_internal_ptr_dtor() instead
+     - zval_dtor_func(), use rc_dtor_func() instead
+     - zval_ptr_dtor_wrapper(), use zval_ptr_dtor() instead
+     - zval_internal_ptr_dtor_wrapper(), use zval_internal_ptr_dtor() instead
+
+  w. The following APIs have been renamed:
+     - _zend_ts_hash_init() to zend_ts_hash_init()
 
 ========================
 2. Build system changes

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -650,17 +650,17 @@ static void compiler_globals_ctor(zend_compiler_globals *compiler_globals) /* {{
 	compiler_globals->compiled_filename = NULL;
 
 	compiler_globals->function_table = (HashTable *) malloc(sizeof(HashTable));
-	zend_hash_init_ex(compiler_globals->function_table, 1024, NULL, ZEND_FUNCTION_DTOR, 1, 0);
+	zend_hash_init(compiler_globals->function_table, 1024, NULL, ZEND_FUNCTION_DTOR, 1);
 	zend_hash_copy(compiler_globals->function_table, global_function_table, function_copy_ctor);
 
 	compiler_globals->class_table = (HashTable *) malloc(sizeof(HashTable));
-	zend_hash_init_ex(compiler_globals->class_table, 64, NULL, ZEND_CLASS_DTOR, 1, 0);
+	zend_hash_init(compiler_globals->class_table, 64, NULL, ZEND_CLASS_DTOR, 1);
 	zend_hash_copy(compiler_globals->class_table, global_class_table, zend_class_add_ref);
 
 	zend_set_default_compile_time_values();
 
 	compiler_globals->auto_globals = (HashTable *) malloc(sizeof(HashTable));
-	zend_hash_init_ex(compiler_globals->auto_globals, 8, NULL, auto_global_dtor, 1, 0);
+	zend_hash_init(compiler_globals->auto_globals, 8, NULL, auto_global_dtor, 1);
 	zend_hash_copy(compiler_globals->auto_globals, global_auto_globals_table, auto_global_copy_ctor);
 
 	compiler_globals->script_encoding_list = NULL;
@@ -894,12 +894,12 @@ int zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	GLOBAL_AUTO_GLOBALS_TABLE = (HashTable *) malloc(sizeof(HashTable));
 	GLOBAL_CONSTANTS_TABLE = (HashTable *) malloc(sizeof(HashTable));
 
-	zend_hash_init_ex(GLOBAL_FUNCTION_TABLE, 1024, NULL, ZEND_FUNCTION_DTOR, 1, 0);
-	zend_hash_init_ex(GLOBAL_CLASS_TABLE, 64, NULL, ZEND_CLASS_DTOR, 1, 0);
-	zend_hash_init_ex(GLOBAL_AUTO_GLOBALS_TABLE, 8, NULL, auto_global_dtor, 1, 0);
-	zend_hash_init_ex(GLOBAL_CONSTANTS_TABLE, 128, NULL, ZEND_CONSTANT_DTOR, 1, 0);
+	zend_hash_init(GLOBAL_FUNCTION_TABLE, 1024, NULL, ZEND_FUNCTION_DTOR, 1);
+	zend_hash_init(GLOBAL_CLASS_TABLE, 64, NULL, ZEND_CLASS_DTOR, 1);
+	zend_hash_init(GLOBAL_AUTO_GLOBALS_TABLE, 8, NULL, auto_global_dtor, 1);
+	zend_hash_init(GLOBAL_CONSTANTS_TABLE, 128, NULL, ZEND_CONSTANT_DTOR, 1);
 
-	zend_hash_init_ex(&module_registry, 32, NULL, module_destructor_zval, 1, 0);
+	zend_hash_init(&module_registry, 32, NULL, module_destructor_zval, 1);
 	zend_init_rsrc_list_dtors();
 
 #ifdef ZTS

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1810,9 +1810,9 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, zend_bool nullify
 
 	ce->default_properties_table = NULL;
 	ce->default_static_members_table = NULL;
-	zend_hash_init_ex(&ce->properties_info, 8, NULL, (persistent_hashes ? zend_destroy_property_info_internal : NULL), persistent_hashes, 0);
-	zend_hash_init_ex(&ce->constants_table, 8, NULL, NULL, persistent_hashes, 0);
-	zend_hash_init_ex(&ce->function_table, 8, NULL, ZEND_FUNCTION_DTOR, persistent_hashes, 0);
+	zend_hash_init(&ce->properties_info, 8, NULL, (persistent_hashes ? zend_destroy_property_info_internal : NULL), persistent_hashes);
+	zend_hash_init(&ce->constants_table, 8, NULL, NULL, persistent_hashes);
+	zend_hash_init(&ce->function_table, 8, NULL, ZEND_FUNCTION_DTOR, persistent_hashes);
 
 	if (ce->type == ZEND_INTERNAL_CLASS) {
 		ZEND_MAP_PTR_INIT(ce->static_members_table, NULL);

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -103,8 +103,6 @@ ZEND_API void ZEND_FASTCALL zend_hash_clean(HashTable *ht);
 
 #define zend_hash_init(ht, nSize, pHashFunction, pDestructor, persistent) \
 	_zend_hash_init((ht), (nSize), (pDestructor), (persistent))
-#define zend_hash_init_ex(ht, nSize, pHashFunction, pDestructor, persistent, bApplyProtection) \
-	_zend_hash_init((ht), (nSize), (pDestructor), (persistent))
 
 ZEND_API void ZEND_FASTCALL zend_hash_real_init(HashTable *ht, zend_bool packed);
 ZEND_API void ZEND_FASTCALL zend_hash_real_init_packed(HashTable *ht);

--- a/Zend/zend_ini.c
+++ b/Zend/zend_ini.c
@@ -96,7 +96,7 @@ ZEND_API int zend_ini_startup(void) /* {{{ */
 	EG(ini_directives) = registered_zend_ini_directives;
 	EG(modified_ini_directives) = NULL;
 	EG(error_reporting_ini_entry) = NULL;
-	zend_hash_init_ex(registered_zend_ini_directives, 128, NULL, free_ini_entry, 1, 0);
+	zend_hash_init(registered_zend_ini_directives, 128, NULL, free_ini_entry, 1);
 	return SUCCESS;
 }
 /* }}} */
@@ -164,7 +164,7 @@ ZEND_API int zend_copy_ini_directives(void) /* {{{ */
 	EG(modified_ini_directives) = NULL;
 	EG(error_reporting_ini_entry) = NULL;
 	EG(ini_directives) = (HashTable *) malloc(sizeof(HashTable));
-	zend_hash_init_ex(EG(ini_directives), registered_zend_ini_directives->nNumOfElements, NULL, free_ini_entry, 1, 0);
+	zend_hash_init(EG(ini_directives), registered_zend_ini_directives->nNumOfElements, NULL, free_ini_entry, 1);
 	zend_hash_copy(EG(ini_directives), registered_zend_ini_directives, copy_ini_entry);
 	return SUCCESS;
 }

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -699,7 +699,7 @@ ZEND_API zend_ast *zend_compile_string_to_ast(
 	zend_restore_lexical_state(&original_lex_state);
 	CG(in_compilation) = original_in_compilation;
 
-	zval_dtor(&code_zv);
+	zval_ptr_dtor_nogc(&code_zv);
 
 	return ast;
 }

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -699,7 +699,7 @@ ZEND_API zend_ast *zend_compile_string_to_ast(
 	zend_restore_lexical_state(&original_lex_state);
 	CG(in_compilation) = original_in_compilation;
 
-	zval_ptr_dtor_nogc(&code_zv);
+	zval_ptr_dtor_str(&code_zv);
 
 	return ast;
 }

--- a/Zend/zend_list.c
+++ b/Zend/zend_list.c
@@ -213,7 +213,7 @@ ZEND_API int zend_init_rsrc_list(void)
 
 int zend_init_rsrc_plist(void)
 {
-	zend_hash_init_ex(&EG(persistent_list), 8, NULL, plist_entry_destructor, 1, 0);
+	zend_hash_init(&EG(persistent_list), 8, NULL, plist_entry_destructor, 1);
 	return SUCCESS;
 }
 

--- a/Zend/zend_ts_hash.c
+++ b/Zend/zend_ts_hash.c
@@ -57,7 +57,7 @@ static void end_write(TsHashTable *ht)
 }
 
 /* delegates */
-ZEND_API void _zend_ts_hash_init(TsHashTable *ht, uint32_t nSize, dtor_func_t pDestructor, zend_bool persistent)
+ZEND_API void zend_ts_hash_init(TsHashTable *ht, uint32_t nSize, dtor_func_t pDestructor, zend_bool persistent)
 {
 #ifdef ZTS
 	ht->mx_reader = tsrm_mutex_alloc();

--- a/Zend/zend_ts_hash.h
+++ b/Zend/zend_ts_hash.h
@@ -35,14 +35,12 @@ BEGIN_EXTERN_C()
 #define TS_HASH(table) (&(table->hash))
 
 /* startup/shutdown */
-ZEND_API void _zend_ts_hash_init(TsHashTable *ht, uint32_t nSize, dtor_func_t pDestructor, zend_bool persistent);
+ZEND_API void zend_ts_hash_init(TsHashTable *ht, uint32_t nSize, dtor_func_t pDestructor, zend_bool persistent);
 ZEND_API void zend_ts_hash_destroy(TsHashTable *ht);
 ZEND_API void zend_ts_hash_clean(TsHashTable *ht);
 
-#define zend_ts_hash_init(ht, nSize, pHashFunction, pDestructor, persistent)	\
-	_zend_ts_hash_init(ht, nSize, pDestructor, persistent)
 #define zend_ts_hash_init_ex(ht, nSize, pHashFunction, pDestructor, persistent, bApplyProtection)	\
-	_zend_ts_hash_init(ht, nSize, pDestructor, persistent)
+	zend_ts_hash_init(ht, nSize, pDestructor, persistent)
 
 
 /* additions/updates/changes */

--- a/Zend/zend_ts_hash.h
+++ b/Zend/zend_ts_hash.h
@@ -39,9 +39,6 @@ ZEND_API void zend_ts_hash_init(TsHashTable *ht, uint32_t nSize, dtor_func_t pDe
 ZEND_API void zend_ts_hash_destroy(TsHashTable *ht);
 ZEND_API void zend_ts_hash_clean(TsHashTable *ht);
 
-#define zend_ts_hash_init_ex(ht, nSize, pHashFunction, pDestructor, persistent, bApplyProtection)	\
-	zend_ts_hash_init(ht, nSize, pDestructor, persistent)
-
 
 /* additions/updates/changes */
 ZEND_API zval *zend_ts_hash_update(TsHashTable *ht, zend_string *key, zval *pData);

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -80,7 +80,6 @@ ZEND_API void zval_ptr_dtor(zval *zval_ptr);
 ZEND_API void zval_internal_ptr_dtor(zval *zvalue);
 
 /* Kept for compatibility */
-#define zval_dtor(zvalue) zval_ptr_dtor_nogc(zvalue)
 #define zval_internal_dtor(zvalue) zval_internal_ptr_dtor(zvalue)
 #define zval_dtor_func rc_dtor_func
 #define zval_ptr_dtor_wrapper zval_ptr_dtor

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -80,7 +80,6 @@ ZEND_API void zval_ptr_dtor(zval *zval_ptr);
 ZEND_API void zval_internal_ptr_dtor(zval *zvalue);
 
 /* Kept for compatibility */
-#define zval_internal_dtor(zvalue) zval_internal_ptr_dtor(zvalue)
 #define zval_dtor_func rc_dtor_func
 #define zval_ptr_dtor_wrapper zval_ptr_dtor
 #define zval_internal_ptr_dtor_wrapper zval_internal_ptr_dtor

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -78,6 +78,10 @@ static zend_always_inline void zval_ptr_dtor_str(zval *zval_ptr)
 
 ZEND_API void zval_ptr_dtor(zval *zval_ptr);
 ZEND_API void zval_internal_ptr_dtor(zval *zvalue);
+
+/* Kept for compatibility */
+#define zval_dtor(zvalue) zval_ptr_dtor_nogc(zvalue)
+
 ZEND_API void zval_add_ref(zval *p);
 
 END_EXTERN_C()

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -81,7 +81,6 @@ ZEND_API void zval_internal_ptr_dtor(zval *zvalue);
 
 /* Kept for compatibility */
 #define zval_dtor_func rc_dtor_func
-#define zval_internal_ptr_dtor_wrapper zval_internal_ptr_dtor
 
 ZEND_API void zval_add_ref(zval *p);
 

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -78,10 +78,6 @@ static zend_always_inline void zval_ptr_dtor_str(zval *zval_ptr)
 
 ZEND_API void zval_ptr_dtor(zval *zval_ptr);
 ZEND_API void zval_internal_ptr_dtor(zval *zvalue);
-
-/* Kept for compatibility */
-#define zval_dtor_func rc_dtor_func
-
 ZEND_API void zval_add_ref(zval *p);
 
 END_EXTERN_C()

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -81,7 +81,6 @@ ZEND_API void zval_internal_ptr_dtor(zval *zvalue);
 
 /* Kept for compatibility */
 #define zval_dtor_func rc_dtor_func
-#define zval_ptr_dtor_wrapper zval_ptr_dtor
 #define zval_internal_ptr_dtor_wrapper zval_internal_ptr_dtor
 
 ZEND_API void zval_add_ref(zval *p);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -61596,7 +61596,7 @@ static void init_opcode_serialiser(void)
 	zval tmp;
 
 	zend_handlers_table = malloc(sizeof(HashTable));
-	zend_hash_init_ex(zend_handlers_table, zend_handlers_count, NULL, NULL, 1, 0);
+	zend_hash_init(zend_handlers_table, zend_handlers_count, NULL, NULL, 1);
 	zend_hash_real_init(zend_handlers_table, 0);
 	Z_TYPE_INFO(tmp) = IS_LONG;
 	for (i = 0; i < zend_handlers_count; i++) {

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -85,7 +85,7 @@ static void init_opcode_serialiser(void)
 	zval tmp;
 
 	zend_handlers_table = malloc(sizeof(HashTable));
-	zend_hash_init_ex(zend_handlers_table, zend_handlers_count, NULL, NULL, 1, 0);
+	zend_hash_init(zend_handlers_table, zend_handlers_count, NULL, NULL, 1);
 	zend_hash_real_init(zend_handlers_table, 0);
 	Z_TYPE_INFO(tmp) = IS_LONG;
 	for (i = 0; i < zend_handlers_count; i++) {

--- a/ext/fileinfo/libmagic.patch
+++ b/ext/fileinfo/libmagic.patch
@@ -1,6 +1,6 @@
 diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
 --- libmagic.orig/apprentice.c	2019-02-20 03:35:27.000000000 +0100
-+++ libmagic/apprentice.c	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/apprentice.c	2020-08-21 17:02:45.104803600 +0200
 @@ -29,6 +29,8 @@
   * apprentice - make one pass through /etc/magic, learning its secrets.
   */
@@ -642,12 +642,12 @@ diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
 +			convert_libmagic_pattern(&pattern, m->value.s, strlen(m->value.s), options);
 +
 +			if ((pce = pcre_get_compiled_regex_cache(Z_STR(pattern))) == NULL) {
-+				zval_dtor(&pattern);
++				zval_ptr_dtor_nogc(&pattern);
 +				return -1;
  			}
 -			file_regfree(&rx);
 -			return rc ? -1 : 0;
-+			zval_dtor(&pattern);
++			zval_ptr_dtor_nogc(&pattern);
 +
 +			return 0;
  		}
@@ -974,7 +974,7 @@ diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
  	}
 diff -u libmagic.orig/ascmagic.c libmagic/ascmagic.c
 --- libmagic.orig/ascmagic.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/ascmagic.c	2020-08-21 16:09:54.656316500 +0200
++++ libmagic/ascmagic.c	2020-08-21 17:02:41.887436300 +0200
 @@ -51,7 +51,7 @@
  #define ISSPC(x) ((x) == ' ' || (x) == '\t' || (x) == '\r' || (x) == '\n' \
  		  || (x) == 0x85 || (x) == '\f')
@@ -1040,7 +1040,7 @@ diff -u libmagic.orig/ascmagic.c libmagic/ascmagic.c
  	unsigned char *end = buf + len;
 diff -u libmagic.orig/buffer.c libmagic/buffer.c
 --- libmagic.orig/buffer.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/buffer.c	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/buffer.c	2020-04-07 22:25:10.501740300 +0200
 @@ -31,19 +31,23 @@
  #endif	/* lint */
  
@@ -1097,7 +1097,7 @@ diff -u libmagic.orig/buffer.c libmagic/buffer.c
  
 diff -u libmagic.orig/cdf.c libmagic/cdf.c
 --- libmagic.orig/cdf.c	2019-02-20 03:35:27.000000000 +0100
-+++ libmagic/cdf.c	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/cdf.c	2020-05-05 20:05:37.698461100 +0200
 @@ -43,7 +43,17 @@
  #include <err.h>
  #endif
@@ -1376,7 +1376,7 @@ diff -u libmagic.orig/cdf.c libmagic/cdf.c
  #endif
 diff -u libmagic.orig/cdf.h libmagic/cdf.h
 --- libmagic.orig/cdf.h	2019-02-20 02:24:19.000000000 +0100
-+++ libmagic/cdf.h	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/cdf.h	2020-04-07 22:25:10.517321000 +0200
 @@ -35,10 +35,10 @@
  #ifndef _H_CDF_
  #define _H_CDF_
@@ -1401,7 +1401,7 @@ diff -u libmagic.orig/cdf.h libmagic/cdf.h
  #define CDF_SECID_FREE					-1
 diff -u libmagic.orig/cdf_time.c libmagic/cdf_time.c
 --- libmagic.orig/cdf_time.c	2019-03-12 21:43:05.000000000 +0100
-+++ libmagic/cdf_time.c	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/cdf_time.c	2020-04-07 22:25:10.517321000 +0200
 @@ -23,6 +23,7 @@
   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   * POSSIBILITY OF SUCH DAMAGE.
@@ -1430,7 +1430,7 @@ diff -u libmagic.orig/cdf_time.c libmagic/cdf_time.c
  	(void)snprintf(buf, 26, "*Bad* %#16.16" INT64_T_FORMAT "x\n",
 diff -u libmagic.orig/compress.c libmagic/compress.c
 --- libmagic.orig/compress.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/compress.c	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/compress.c	2020-08-07 20:46:25.154923400 +0200
 @@ -45,13 +45,11 @@
  #endif
  #include <string.h>
@@ -1580,7 +1580,7 @@ diff -u libmagic.orig/compress.c libmagic/compress.c
 +#endif
 diff -u libmagic.orig/der.c libmagic/der.c
 --- libmagic.orig/der.c	2019-02-20 03:35:27.000000000 +0100
-+++ libmagic/der.c	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/der.c	2020-04-07 22:25:10.517321000 +0200
 @@ -51,7 +51,9 @@
  #include "magic.h"
  #include "der.h"
@@ -1610,7 +1610,7 @@ diff -u libmagic.orig/der.c libmagic/der.c
  			snprintf(buf + z, blen - z, "%.2x", d[i]);
 diff -u libmagic.orig/elfclass.h libmagic/elfclass.h
 --- libmagic.orig/elfclass.h	2019-02-20 02:30:19.000000000 +0100
-+++ libmagic/elfclass.h	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/elfclass.h	2020-04-07 22:25:10.517321000 +0200
 @@ -41,7 +41,7 @@
  			return toomany(ms, "program headers", phnum);
  		flags |= FLAGS_IS_CORE;
@@ -1640,7 +1640,7 @@ diff -u libmagic.orig/elfclass.h libmagic/elfclass.h
  		    CAST(int, elf_getu16(swap, elfhdr.e_shstrndx)),
 diff -u libmagic.orig/encoding.c libmagic/encoding.c
 --- libmagic.orig/encoding.c	2019-04-15 18:48:41.000000000 +0200
-+++ libmagic/encoding.c	2020-08-21 16:09:54.670315100 +0200
++++ libmagic/encoding.c	2020-08-21 17:02:41.890255300 +0200
 @@ -44,14 +44,14 @@
  #include <stdlib.h>
  
@@ -1830,7 +1830,7 @@ diff -u libmagic.orig/encoding.c libmagic/encoding.c
  			return 0;
 diff -u libmagic.orig/file.h libmagic/file.h
 --- libmagic.orig/file.h	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/file.h	2020-08-21 16:09:54.697579400 +0200
++++ libmagic/file.h	2020-08-21 17:02:41.894108600 +0200
 @@ -33,18 +33,9 @@
  #ifndef __file_h__
  #define __file_h__
@@ -2134,7 +2134,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  #endif
 diff -u libmagic.orig/fsmagic.c libmagic/fsmagic.c
 --- libmagic.orig/fsmagic.c	2019-05-07 04:26:48.000000000 +0200
-+++ libmagic/fsmagic.c	2020-08-21 15:28:20.802569900 +0200
++++ libmagic/fsmagic.c	2020-04-07 22:25:10.532971400 +0200
 @@ -66,26 +66,10 @@
  # define minor(dev)  ((dev) & 0xff)
  #endif
@@ -2427,7 +2427,7 @@ diff -u libmagic.orig/fsmagic.c libmagic/fsmagic.c
  	case S_IFSOCK:
 diff -u libmagic.orig/funcs.c libmagic/funcs.c
 --- libmagic.orig/funcs.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/funcs.c	2020-08-21 15:46:02.589327200 +0200
++++ libmagic/funcs.c	2020-08-07 20:46:25.164794200 +0200
 @@ -31,87 +31,80 @@
  #endif	/* lint */
  
@@ -2799,7 +2799,7 @@ diff -u libmagic.orig/funcs.c libmagic/funcs.c
  
 diff -u libmagic.orig/magic.c libmagic/magic.c
 --- libmagic.orig/magic.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/magic.c	2020-08-21 15:28:20.818197700 +0200
++++ libmagic/magic.c	2020-04-07 22:25:10.532971400 +0200
 @@ -25,11 +25,6 @@
   * SUCH DAMAGE.
   */
@@ -3263,8 +3263,8 @@ diff -u libmagic.orig/magic.c libmagic/magic.c
  public const char *
  magic_error(struct magic_set *ms)
 diff -u libmagic.orig/magic.h libmagic/magic.h
---- libmagic.orig/magic.h	2020-08-21 16:11:36.790038600 +0200
-+++ libmagic/magic.h	2020-08-21 15:28:20.818197700 +0200
+--- libmagic.orig/magic.h	2020-08-21 17:03:04.181135100 +0200
++++ libmagic/magic.h	2020-04-07 22:25:10.548560600 +0200
 @@ -124,6 +124,7 @@
  
  const char *magic_getpath(const char *, int);
@@ -3275,7 +3275,7 @@ diff -u libmagic.orig/magic.h libmagic/magic.h
  
 diff -u libmagic.orig/print.c libmagic/print.c
 --- libmagic.orig/print.c	2019-03-12 21:43:05.000000000 +0100
-+++ libmagic/print.c	2020-08-21 15:46:02.589327200 +0200
++++ libmagic/print.c	2020-08-07 18:30:21.155794100 +0200
 @@ -28,6 +28,7 @@
  /*
   * print.c - debugging printout routines
@@ -3349,7 +3349,7 @@ diff -u libmagic.orig/print.c libmagic/print.c
  		goto out;
 diff -u libmagic.orig/readcdf.c libmagic/readcdf.c
 --- libmagic.orig/readcdf.c	2019-03-12 21:43:05.000000000 +0100
-+++ libmagic/readcdf.c	2020-08-21 15:28:20.818197700 +0200
++++ libmagic/readcdf.c	2020-04-07 22:25:10.548560600 +0200
 @@ -31,7 +31,11 @@
  
  #include <assert.h>
@@ -3468,7 +3468,7 @@ diff -u libmagic.orig/readcdf.c libmagic/readcdf.c
  	if (i != -1)
 diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 --- libmagic.orig/softmagic.c	2019-05-17 04:24:59.000000000 +0200
-+++ libmagic/softmagic.c	2020-08-21 15:28:20.818197700 +0200
++++ libmagic/softmagic.c	2020-04-26 00:43:35.734037100 +0200
 @@ -43,6 +43,10 @@
  #include <time.h>
  #include "der.h"
@@ -3835,7 +3835,7 @@ diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
  	case FILE_INDIRECT:
 diff -u libmagic.orig/strcasestr.c libmagic/strcasestr.c
 --- libmagic.orig/strcasestr.c	2014-09-11 17:05:33.000000000 +0200
-+++ libmagic/strcasestr.c	2020-06-15 11:16:08.173462200 +0200
++++ libmagic/strcasestr.c	2019-12-19 20:37:55.833385900 +0100
 @@ -39,6 +39,8 @@
  
  #include "file.h"

--- a/ext/fileinfo/libmagic.patch
+++ b/ext/fileinfo/libmagic.patch
@@ -1,6 +1,6 @@
 diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
 --- libmagic.orig/apprentice.c	2019-02-20 03:35:27.000000000 +0100
-+++ libmagic/apprentice.c	2020-08-21 17:02:45.104803600 +0200
++++ libmagic/apprentice.c	2020-08-25 15:13:14.549715400 +0200
 @@ -29,6 +29,8 @@
   * apprentice - make one pass through /etc/magic, learning its secrets.
   */
@@ -635,19 +635,19 @@ diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
 -			if (rc) {
 -				if (ms->flags & MAGIC_CHECK)
 -					file_regerror(&rx, rc, ms);
-+			zval pattern;
++			zend_string *pattern;
 +			int options = 0;
 +			pcre_cache_entry *pce;
 +
-+			convert_libmagic_pattern(&pattern, m->value.s, strlen(m->value.s), options);
++			pattern = convert_libmagic_pattern(m->value.s, strlen(m->value.s), options);
 +
-+			if ((pce = pcre_get_compiled_regex_cache(Z_STR(pattern))) == NULL) {
-+				zval_ptr_dtor_nogc(&pattern);
++			if ((pce = pcre_get_compiled_regex_cache(pattern)) == NULL) {
++				zend_string_release(pattern);
 +				return -1;
  			}
 -			file_regfree(&rx);
 -			return rc ? -1 : 0;
-+			zval_ptr_dtor_nogc(&pattern);
++			zend_string_release(pattern);
 +
 +			return 0;
  		}
@@ -974,7 +974,7 @@ diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
  	}
 diff -u libmagic.orig/ascmagic.c libmagic/ascmagic.c
 --- libmagic.orig/ascmagic.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/ascmagic.c	2020-08-21 17:02:41.887436300 +0200
++++ libmagic/ascmagic.c	2020-08-24 14:22:57.162970900 +0200
 @@ -51,7 +51,7 @@
  #define ISSPC(x) ((x) == ' ' || (x) == '\t' || (x) == '\r' || (x) == '\n' \
  		  || (x) == 0x85 || (x) == '\f')
@@ -1640,7 +1640,7 @@ diff -u libmagic.orig/elfclass.h libmagic/elfclass.h
  		    CAST(int, elf_getu16(swap, elfhdr.e_shstrndx)),
 diff -u libmagic.orig/encoding.c libmagic/encoding.c
 --- libmagic.orig/encoding.c	2019-04-15 18:48:41.000000000 +0200
-+++ libmagic/encoding.c	2020-08-21 17:02:41.890255300 +0200
++++ libmagic/encoding.c	2020-08-24 14:22:57.172802500 +0200
 @@ -44,14 +44,14 @@
  #include <stdlib.h>
  
@@ -1830,7 +1830,7 @@ diff -u libmagic.orig/encoding.c libmagic/encoding.c
  			return 0;
 diff -u libmagic.orig/file.h libmagic/file.h
 --- libmagic.orig/file.h	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/file.h	2020-08-21 17:02:41.894108600 +0200
++++ libmagic/file.h	2020-08-25 15:11:06.907695900 +0200
 @@ -33,18 +33,9 @@
  #ifndef __file_h__
  #define __file_h__
@@ -2004,7 +2004,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
      size_t *);
  protected size_t file_pstring_length_size(const struct magic *);
  protected size_t file_pstring_get_length(const struct magic *, const char *);
-@@ -513,34 +498,13 @@
+@@ -513,34 +498,12 @@
      size_t);
  #endif /* __EMX__ */
  
@@ -2037,12 +2037,11 @@ diff -u libmagic.orig/file.h libmagic/file.h
 -    int);
 -protected void file_regfree(file_regex_t *);
 -protected void file_regerror(file_regex_t *, int, struct magic_set *);
-+public void
-+convert_libmagic_pattern(zval *pattern, char *val, size_t len, uint32_t options);
++public zend_string* convert_libmagic_pattern(char *val, size_t len, uint32_t options);
  
  typedef struct {
  	char *buf;
-@@ -550,28 +514,13 @@
+@@ -550,28 +513,13 @@
  protected file_pushbuf_t *file_push_buffer(struct magic_set *);
  protected char  *file_pop_buffer(struct magic_set *, file_pushbuf_t *);
  
@@ -2073,7 +2072,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  size_t strlcat(char *, const char *, size_t);
  #endif
  #ifndef HAVE_STRCASESTR
-@@ -587,39 +536,6 @@
+@@ -587,39 +535,6 @@
  #ifndef HAVE_ASCTIME_R
  char   *asctime_r(const struct tm *, char *);
  #endif
@@ -2113,7 +2112,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  
  #if defined(HAVE_MMAP) && defined(HAVE_SYS_MMAN_H) && !defined(QUICK)
  #define QUICK
-@@ -645,6 +561,18 @@
+@@ -645,6 +560,18 @@
  #else
  #define FILE_RCSID(id)
  #endif
@@ -2427,7 +2426,7 @@ diff -u libmagic.orig/fsmagic.c libmagic/fsmagic.c
  	case S_IFSOCK:
 diff -u libmagic.orig/funcs.c libmagic/funcs.c
 --- libmagic.orig/funcs.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/funcs.c	2020-08-07 20:46:25.164794200 +0200
++++ libmagic/funcs.c	2020-08-25 15:11:06.872908800 +0200
 @@ -31,87 +31,80 @@
  #endif	/* lint */
  
@@ -2686,7 +2685,7 @@ diff -u libmagic.orig/funcs.c libmagic/funcs.c
 -			nm++;
 -		}
 -		rv = nm;
-+	zval patt;
++	zend_string *pattern;
 +	uint32_t opts = 0;
 +	pcre_cache_entry *pce;
 +	zend_string *res;
@@ -2694,9 +2693,9 @@ diff -u libmagic.orig/funcs.c libmagic/funcs.c
 +	size_t rep_cnt = 0;
 +
 +	opts |= PCRE2_MULTILINE;
-+	convert_libmagic_pattern(&patt, (char*)pat, strlen(pat), opts);
-+	if ((pce = pcre_get_compiled_regex_cache_ex(Z_STR(patt), 0)) == NULL) {
-+		zval_ptr_dtor(&patt);
++	pattern = convert_libmagic_pattern((char*)pat, strlen(pat), opts);
++	if ((pce = pcre_get_compiled_regex_cache_ex(pattern, 0)) == NULL) {
++		zend_string_release(pattern);
 +		rep_cnt = -1;
 +		goto out;
  	}
@@ -2704,7 +2703,7 @@ diff -u libmagic.orig/funcs.c libmagic/funcs.c
 -	file_regfree(&rx);
 -	return rv;
 -}
-+	zval_ptr_dtor(&patt);
++	zend_string_release(pattern);
  
 -protected int
 -file_regcomp(file_regex_t *rx, const char *pat, int flags)
@@ -3263,7 +3262,7 @@ diff -u libmagic.orig/magic.c libmagic/magic.c
  public const char *
  magic_error(struct magic_set *ms)
 diff -u libmagic.orig/magic.h libmagic/magic.h
---- libmagic.orig/magic.h	2020-08-21 17:03:04.181135100 +0200
+--- libmagic.orig/magic.h	2020-08-25 15:19:32.346097700 +0200
 +++ libmagic/magic.h	2020-04-07 22:25:10.548560600 +0200
 @@ -124,6 +124,7 @@
  
@@ -3275,7 +3274,7 @@ diff -u libmagic.orig/magic.h libmagic/magic.h
  
 diff -u libmagic.orig/print.c libmagic/print.c
 --- libmagic.orig/print.c	2019-03-12 21:43:05.000000000 +0100
-+++ libmagic/print.c	2020-08-07 18:30:21.155794100 +0200
++++ libmagic/print.c	2020-08-22 19:28:45.849356800 +0200
 @@ -28,6 +28,7 @@
  /*
   * print.c - debugging printout routines
@@ -3468,7 +3467,7 @@ diff -u libmagic.orig/readcdf.c libmagic/readcdf.c
  	if (i != -1)
 diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 --- libmagic.orig/softmagic.c	2019-05-17 04:24:59.000000000 +0200
-+++ libmagic/softmagic.c	2020-04-26 00:43:35.734037100 +0200
++++ libmagic/softmagic.c	2020-08-25 15:15:35.784945600 +0200
 @@ -43,6 +43,10 @@
  #include <time.h>
  #include "der.h"
@@ -3641,12 +3640,11 @@ diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
  		return rv;
  
  	case FILE_USE:
-@@ -1926,6 +1904,61 @@
+@@ -1926,6 +1904,60 @@
  	return file_strncmp(a, b, len, flags);
  }
  
-+public void
-+convert_libmagic_pattern(zval *pattern, char *val, size_t len, uint32_t options)
++public zend_string* convert_libmagic_pattern(char *val, size_t len, uint32_t options)
 +{
 +	int i, j;
 +	zend_string *t;
@@ -3697,20 +3695,20 @@ diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 +	ZSTR_VAL(t)[j]='\0';
 +	ZSTR_LEN(t) = j;
 +
-+	ZVAL_NEW_STR(pattern, t);
++	return t;
 +}
 +
  private int
  magiccheck(struct magic_set *ms, struct magic *m)
  {
-@@ -2104,65 +2137,77 @@
+@@ -2104,65 +2136,77 @@
  		break;
  	}
  	case FILE_REGEX: {
 -		int rc;
 -		file_regex_t rx;
 -		const char *search;
-+		zval pattern;
++		zend_string *pattern;
 +		uint32_t options = 0;
 +		pcre_cache_entry *pce;
  
@@ -3729,11 +3727,11 @@ diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 +			options |= PCRE2_CASELESS;
 +		}
 +
-+		convert_libmagic_pattern(&pattern, (char *)m->value.s, m->vallen, options);
++		pattern = convert_libmagic_pattern((char *)m->value.s, m->vallen, options);
 +
 +		l = v = 0;
-+		if ((pce = pcre_get_compiled_regex_cache(Z_STR(pattern))) == NULL) {
-+			zval_ptr_dtor(&pattern);
++		if ((pce = pcre_get_compiled_regex_cache(pattern)) == NULL) {
++			zend_string_release(pattern);
 +			return -1;
  		} else {
 -			regmatch_t pmatch;
@@ -3769,7 +3767,7 @@ diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 +
 +			if (Z_LVAL(retval) < 0) {
 +				zval_ptr_dtor(&subpats);
-+				zval_ptr_dtor(&pattern);
++				zend_string_release(pattern);
 +				return -1;
 +			} else if ((Z_LVAL(retval) > 0) && (Z_TYPE(subpats) == IS_ARRAY)) {
 +				/* Need to fetch global match which equals pmatch[0] */
@@ -3796,7 +3794,7 @@ diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 +				} else {
 +error_out:
 +					zval_ptr_dtor(&subpats);
-+					zval_ptr_dtor(&pattern);
++					zend_string_release(pattern);
 +					return -1;
 +				}
  			} else {
@@ -3825,7 +3823,7 @@ diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 -				break;
  			}
 +			zval_ptr_dtor(&subpats);
-+			zval_ptr_dtor(&pattern);
++			zend_string_release(pattern);
  		}
 -		file_regfree(&rx);
 -		if (v == CAST(uint64_t, -1))

--- a/ext/fileinfo/libmagic/apprentice.c
+++ b/ext/fileinfo/libmagic/apprentice.c
@@ -2590,17 +2590,17 @@ getvalue(struct magic_set *ms, struct magic *m, const char **p, int action)
 			return -1;
 		}
 		if (m->type == FILE_REGEX) {
-			zval pattern;
+			zend_string *pattern;
 			int options = 0;
 			pcre_cache_entry *pce;
 
-			convert_libmagic_pattern(&pattern, m->value.s, strlen(m->value.s), options);
+			pattern = convert_libmagic_pattern(m->value.s, strlen(m->value.s), options);
 
-			if ((pce = pcre_get_compiled_regex_cache(Z_STR(pattern))) == NULL) {
-				zval_ptr_dtor_str(&pattern);
+			if ((pce = pcre_get_compiled_regex_cache(pattern)) == NULL) {
+				zend_string_release(pattern);
 				return -1;
 			}
-			zval_ptr_dtor_str(&pattern);
+			zend_string_release(pattern);
 
 			return 0;
 		}

--- a/ext/fileinfo/libmagic/apprentice.c
+++ b/ext/fileinfo/libmagic/apprentice.c
@@ -2597,10 +2597,10 @@ getvalue(struct magic_set *ms, struct magic *m, const char **p, int action)
 			convert_libmagic_pattern(&pattern, m->value.s, strlen(m->value.s), options);
 
 			if ((pce = pcre_get_compiled_regex_cache(Z_STR(pattern))) == NULL) {
-				zval_ptr_dtor_nogc(&pattern);
+				zval_ptr_dtor_str(&pattern);
 				return -1;
 			}
-			zval_ptr_dtor_nogc(&pattern);
+			zval_ptr_dtor_str(&pattern);
 
 			return 0;
 		}

--- a/ext/fileinfo/libmagic/apprentice.c
+++ b/ext/fileinfo/libmagic/apprentice.c
@@ -2597,10 +2597,10 @@ getvalue(struct magic_set *ms, struct magic *m, const char **p, int action)
 			convert_libmagic_pattern(&pattern, m->value.s, strlen(m->value.s), options);
 
 			if ((pce = pcre_get_compiled_regex_cache(Z_STR(pattern))) == NULL) {
-				zval_dtor(&pattern);
+				zval_ptr_dtor_nogc(&pattern);
 				return -1;
 			}
-			zval_dtor(&pattern);
+			zval_ptr_dtor_nogc(&pattern);
 
 			return 0;
 		}

--- a/ext/fileinfo/libmagic/file.h
+++ b/ext/fileinfo/libmagic/file.h
@@ -503,8 +503,7 @@ protected void buffer_init(struct buffer *, int, const zend_stat_t *,
 protected void buffer_fini(struct buffer *);
 protected int buffer_fill(const struct buffer *);
 
-public void
-convert_libmagic_pattern(zval *pattern, char *val, size_t len, uint32_t options);
+public zend_string* convert_libmagic_pattern(char *val, size_t len, uint32_t options);
 
 typedef struct {
 	char *buf;

--- a/ext/fileinfo/libmagic/funcs.c
+++ b/ext/fileinfo/libmagic/funcs.c
@@ -516,7 +516,7 @@ file_printedlen(const struct magic_set *ms)
 protected int
 file_replace(struct magic_set *ms, const char *pat, const char *rep)
 {
-	zval patt;
+	zend_string *pattern;
 	uint32_t opts = 0;
 	pcre_cache_entry *pce;
 	zend_string *res;
@@ -524,13 +524,13 @@ file_replace(struct magic_set *ms, const char *pat, const char *rep)
 	size_t rep_cnt = 0;
 
 	opts |= PCRE2_MULTILINE;
-	convert_libmagic_pattern(&patt, (char*)pat, strlen(pat), opts);
-	if ((pce = pcre_get_compiled_regex_cache_ex(Z_STR(patt), 0)) == NULL) {
-		zval_ptr_dtor(&patt);
+	pattern = convert_libmagic_pattern((char*)pat, strlen(pat), opts);
+	if ((pce = pcre_get_compiled_regex_cache_ex(pattern, 0)) == NULL) {
+		zend_string_release(pattern);
 		rep_cnt = -1;
 		goto out;
 	}
-	zval_ptr_dtor(&patt);
+	zend_string_release(pattern);
 
 	repl = zend_string_init(rep, strlen(rep), 0);
 	res = php_pcre_replace_impl(pce, NULL, ms->o.buf, strlen(ms->o.buf), repl, -1, &rep_cnt);

--- a/ext/oci8/oci8_failover.c
+++ b/ext/oci8/oci8_failover.c
@@ -69,7 +69,7 @@ sb4 callback_fn(void *svchp, void *envhp, void *fo_ctx, ub4 fo_type, ub4 fo_even
 		returnValue = (sb4) Z_LVAL(retval);
 	}
 
-	/* Setting params[0] to null so resource isn't destroyed on zval_dtor */
+	/* Setting params[0] to null so resource isn't destroyed on zval_ptr_dtor */
 	ZVAL_NULL(&params[0]);
 
 	/* Cleanup */

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1207,8 +1207,8 @@ int pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
 	}
 
 	dbh->cls_methods[kind] = pemalloc(sizeof(HashTable), dbh->is_persistent);
-	zend_hash_init_ex(dbh->cls_methods[kind], 8, NULL,
-			dbh->is_persistent? cls_method_pdtor : cls_method_dtor, dbh->is_persistent, 0);
+	zend_hash_init(dbh->cls_methods[kind], 8, NULL,
+			dbh->is_persistent? cls_method_pdtor : cls_method_dtor, dbh->is_persistent);
 
 	memset(&func, 0, sizeof(func));
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -911,8 +911,8 @@ static PHP_GINIT_FUNCTION(pgsql)
 #endif
 	memset(pgsql_globals, 0, sizeof(zend_pgsql_globals));
 	/* Initialize notice message hash at MINIT only */
-	zend_hash_init_ex(&pgsql_globals->notices, 0, NULL, ZVAL_PTR_DTOR, 1, 0);
-	zend_hash_init_ex(&pgsql_globals->hashes, 0, NULL, ZVAL_PTR_DTOR, 1, 0);
+	zend_hash_init(&pgsql_globals->notices, 0, NULL, ZVAL_PTR_DTOR, 1);
+	zend_hash_init(&pgsql_globals->hashes, 0, NULL, ZVAL_PTR_DTOR, 1);
 }
 /* }}} */
 

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -418,8 +418,8 @@ static int browscap_read_file(char *filename, browser_data *browdata, int persis
 	}
 
 	browdata->htab = pemalloc(sizeof *browdata->htab, persistent);
-	zend_hash_init_ex(browdata->htab, 0, NULL,
-		persistent ? browscap_entry_dtor_persistent : browscap_entry_dtor, persistent, 0);
+	zend_hash_init(browdata->htab, 0, NULL,
+		persistent ? browscap_entry_dtor_persistent : browscap_entry_dtor, persistent);
 
 	browdata->kv_size = 16 * 1024;
 	browdata->kv_used = 0;

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -592,8 +592,8 @@ PHP_FUNCTION(password_get_info)
 	add_assoc_string(return_value, "algoName", algo->name);
 	if (algo->get_info &&
 		(FAILURE == algo->get_info(&options, hash))) {
-		zval_dtor(&options);
-		zval_dtor(return_value);
+		zval_ptr_dtor_nogc(&options);
+		zval_ptr_dtor_nogc(return_value);
 		RETURN_NULL();
 	}
 	add_assoc_zval(return_value, "options", &options);

--- a/ext/standard/scanf.c
+++ b/ext/standard/scanf.c
@@ -906,7 +906,7 @@ literal:
 						__buf[0] = sch;
 						__buf[1] = '\0';
 						current = args[objIndex++];
-						zval_dtor(*current);
+						zval_ptr_dtor_nogc(*current);
 						ZVAL_STRINGL( *current, __buf, 1);
 					} else {
 						add_index_stringl(return_value, objIndex++, &sch, 1);

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -597,7 +597,7 @@ string_key:
 			if (!zend_verify_prop_assignable_by_ref(info, data, /* strict */ 1)) {
 				zval_ptr_dtor(data);
 				ZVAL_UNDEF(data);
-				zval_dtor(&key);
+				zval_ptr_dtor_nogc(&key);
 				goto failure;
 			}
 			if (Z_ISREF_P(data)) {

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -54,7 +54,7 @@ static void _type_dtor(zval *zv)
 static void sapi_globals_ctor(sapi_globals_struct *sapi_globals)
 {
 	memset(sapi_globals, 0, sizeof(*sapi_globals));
-	zend_hash_init_ex(&sapi_globals->known_post_content_types, 8, NULL, _type_dtor, 1, 0);
+	zend_hash_init(&sapi_globals->known_post_content_types, 8, NULL, _type_dtor, 1);
 	php_setup_sapi_content_types();
 }
 

--- a/win32/signal.c
+++ b/win32/signal.c
@@ -110,7 +110,7 @@ PHP_FUNCTION(sapi_windows_set_ctrl_handler)
 	}
 
 	if (!ZEND_FCI_INITIALIZED(fci)) {
-		zval_ptr_dtor_nogc(&ctrl_handler);
+		zval_ptr_dtor(&ctrl_handler);
 		ZVAL_UNDEF(&ctrl_handler);
 		if (!SetConsoleCtrlHandler(NULL, add)) {
 			RETURN_FALSE;

--- a/win32/signal.c
+++ b/win32/signal.c
@@ -110,7 +110,7 @@ PHP_FUNCTION(sapi_windows_set_ctrl_handler)
 	}
 
 	if (!ZEND_FCI_INITIALIZED(fci)) {
-		zval_dtor(&ctrl_handler);
+		zval_ptr_dtor_nogc(&ctrl_handler);
 		ZVAL_UNDEF(&ctrl_handler);
 		if (!SetConsoleCtrlHandler(NULL, add)) {
 			RETURN_FALSE;
@@ -125,7 +125,7 @@ PHP_FUNCTION(sapi_windows_set_ctrl_handler)
 		RETURN_FALSE;
 	}
 
-	zval_dtor(&ctrl_handler);
+	zval_ptr_dtor_nogc(&ctrl_handler);
 	ZVAL_COPY(&ctrl_handler, &fci.function_name);
 
 	RETURN_TRUE;


### PR DESCRIPTION
This PR removes APIs provided by Zend via macros as a compatibility layer or to cover up unused arguments.

The only one which had some usage other than ``zend_hash_init_ex()`` is ``zval_dtor()`` whose expansion is ``zval_ptr_dtor_nogc()`` which seems rather strange and I suppose they should use ``zval_ptr_dtor()`` for the most part.  