### PR TITLE
Inline functions instead of macros

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -252,8 +252,9 @@ ZEND_API void zend_print_zval_r(zval *expr, int indent);
 ZEND_API zend_string *zend_print_zval_r_to_str(zval *expr, int indent);
 ZEND_API void zend_print_flat_zval_r(zval *expr);
 
-#define zend_print_variable(var) \
-	zend_print_zval((var), 0)
+static zend_always_inline size_t zend_print_variable(zval *var) {
+	return zend_print_zval(var, 0);
+}
 
 ZEND_API ZEND_COLD void zend_output_debug_string(zend_bool trigger_break, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
 
@@ -269,6 +270,7 @@ ZEND_API void free_estring(char **str_p);
 END_EXTERN_C()
 
 /* output support */
+// TODO Convert to inline functions?
 #define ZEND_WRITE(str, str_len)		zend_write((str), (str_len))
 #define ZEND_WRITE_EX(str, str_len)		write_func((str), (str_len))
 #define ZEND_PUTS(str)					zend_write((str), strlen((str)))

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -42,7 +42,7 @@ static zend_module_entry **module_post_deactivate_handlers;
 
 static zend_class_entry  **class_cleanup_handlers;
 
-ZEND_API zend_result _zend_get_parameters_array_ex(uint32_t param_count, zval *argument_array) /* {{{ */
+ZEND_API zend_result zend_get_parameters_array_ex(uint32_t param_count, zval *argument_array) /* {{{ */
 {
 	zval *param_ptr;
 	uint32_t arg_count;

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -283,15 +283,14 @@ typedef struct _zend_fcall_info_cache {
 ZEND_API int zend_next_free_module(void);
 
 BEGIN_EXTERN_C()
-ZEND_API zend_result _zend_get_parameters_array_ex(uint32_t param_count, zval *argument_array);
+ZEND_API zend_result zend_get_parameters_array_ex(uint32_t param_count, zval *argument_array);
 
 /* internal function to efficiently copy parameters when executing __call() */
 ZEND_API zend_result zend_copy_parameters_array(uint32_t param_count, zval *argument_array);
 
+// TODO Replace _ex version with zend_get_parameters_array()
 #define zend_get_parameters_array(ht, param_count, argument_array) \
-	_zend_get_parameters_array_ex(param_count, argument_array)
-#define zend_get_parameters_array_ex(param_count, argument_array) \
-	_zend_get_parameters_array_ex(param_count, argument_array)
+	zend_get_parameters_array_ex(param_count, argument_array)
 #define zend_parse_parameters_none() \
 	(EXPECTED(ZEND_NUM_ARGS() == 0) ? SUCCESS : (zend_wrong_parameters_none_error(), FAILURE))
 #define zend_parse_parameters_none_throw() \

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -336,8 +336,9 @@ ZEND_API void zend_class_implements(zend_class_entry *class_entry, int num_inter
 
 ZEND_API zend_result zend_register_class_alias_ex(const char *name, size_t name_len, zend_class_entry *ce, bool persistent);
 
-#define zend_register_class_alias(name, ce) \
-	zend_register_class_alias_ex(name, sizeof(name)-1, ce, 1)
+static inline zend_result zend_register_class_alias(const char *name, zend_class_entry *ce) {
+	return zend_register_class_alias_ex(name, strlen(name), ce, 1);
+}
 #define zend_register_ns_class_alias(ns, name, ce) \
 	zend_register_class_alias_ex(ZEND_NS_NAME(ns, name), sizeof(ZEND_NS_NAME(ns, name))-1, ce, 1)
 
@@ -444,15 +445,33 @@ ZEND_API void add_assoc_string_ex(zval *arg, const char *key, size_t key_len, co
 ZEND_API void add_assoc_stringl_ex(zval *arg, const char *key, size_t key_len, const char *str, size_t length);
 ZEND_API void add_assoc_zval_ex(zval *arg, const char *key, size_t key_len, zval *value);
 
-#define add_assoc_long(__arg, __key, __n) add_assoc_long_ex(__arg, __key, strlen(__key), __n)
-#define add_assoc_null(__arg, __key) add_assoc_null_ex(__arg, __key, strlen(__key))
-#define add_assoc_bool(__arg, __key, __b) add_assoc_bool_ex(__arg, __key, strlen(__key), __b)
-#define add_assoc_resource(__arg, __key, __r) add_assoc_resource_ex(__arg, __key, strlen(__key), __r)
-#define add_assoc_double(__arg, __key, __d) add_assoc_double_ex(__arg, __key, strlen(__key), __d)
-#define add_assoc_str(__arg, __key, __str) add_assoc_str_ex(__arg, __key, strlen(__key), __str)
-#define add_assoc_string(__arg, __key, __str) add_assoc_string_ex(__arg, __key, strlen(__key), __str)
-#define add_assoc_stringl(__arg, __key, __str, __length) add_assoc_stringl_ex(__arg, __key, strlen(__key), __str, __length)
-#define add_assoc_zval(__arg, __key, __value) add_assoc_zval_ex(__arg, __key, strlen(__key), __value)
+static inline void add_assoc_long(zval *arg, const char *key, zend_long n) {
+	add_assoc_long_ex(arg, key, strlen(key), n);
+}
+static inline void add_assoc_null(zval *arg, const char *key) {
+	add_assoc_null_ex(arg, key, strlen(key));
+}
+static inline void add_assoc_bool(zval *arg, const char *key, int b) {
+	add_assoc_bool_ex(arg, key, strlen(key), b);
+}
+static inline void add_assoc_resource(zval *arg, const char *key, zend_resource *r) {
+	add_assoc_resource_ex(arg, key, strlen(key), r);
+}
+static inline void add_assoc_double(zval *arg, const char *key, double d) {
+	add_assoc_double_ex(arg, key, strlen(key), d);
+}
+static inline void add_assoc_str(zval *arg, const char *key, zend_string *str) {
+	add_assoc_str_ex(arg, key, strlen(key), str);
+}
+static inline void add_assoc_string(zval *arg, const char *key, const char *str) {
+	add_assoc_string_ex(arg, key, strlen(key), str);
+}
+static inline void add_assoc_stringl(zval *arg, const char *key, const char *str, size_t length) {
+	add_assoc_stringl_ex(arg, key, strlen(key), str, length);
+}
+static inline void add_assoc_zval(zval *arg, const char *key, zval *value) {
+	add_assoc_zval_ex(arg, key, strlen(key), value);
+}
 
 ZEND_API void add_index_long(zval *arg, zend_ulong index, zend_long n);
 ZEND_API void add_index_null(zval *arg, zend_ulong index);
@@ -494,17 +513,35 @@ ZEND_API void add_property_string_ex(zval *arg, const char *key, size_t key_len,
 ZEND_API void add_property_stringl_ex(zval *arg, const char *key, size_t key_len,  const char *str, size_t length);
 ZEND_API void add_property_zval_ex(zval *arg, const char *key, size_t key_len, zval *value);
 
-#define add_property_long(__arg, __key, __n) add_property_long_ex(__arg, __key, strlen(__key), __n)
-#define add_property_null(__arg, __key) add_property_null_ex(__arg, __key, strlen(__key))
-#define add_property_bool(__arg, __key, __b) add_property_bool_ex(__arg, __key, strlen(__key), __b)
-#define add_property_resource(__arg, __key, __r) add_property_resource_ex(__arg, __key, strlen(__key), __r)
-#define add_property_double(__arg, __key, __d) add_property_double_ex(__arg, __key, strlen(__key), __d)
-#define add_property_str(__arg, __key, __str) add_property_str_ex(__arg, __key, strlen(__key), __str)
-#define add_property_string(__arg, __key, __str) add_property_string_ex(__arg, __key, strlen(__key), __str)
-#define add_property_stringl(__arg, __key, __str, __length) add_property_stringl_ex(__arg, __key, strlen(__key), __str, __length)
-#define add_property_zval(__arg, __key, __value) add_property_zval_ex(__arg, __key, strlen(__key), __value)
+static inline void add_property_long(zval *arg, const char *key, zend_long n) {
+	add_property_long_ex(arg, key, strlen(key), n);
+}
+static inline void add_property_null(zval *arg, const char *key) {
+	add_property_null_ex(arg, key, strlen(key));
+}
+static inline void add_property_bool(zval *arg, const char *key, bool b) {
+	add_property_bool_ex(arg, key, strlen(key), b);
+}
+static inline void add_property_resource(zval *arg, const char *key, zend_resource *r) {
+	add_property_resource_ex(arg, key, strlen(key), r);
+}
+static inline void add_property_double(zval *arg, const char *key, double d) {
+	add_property_double_ex(arg, key, strlen(key), d);
+}
+static inline void add_property_str(zval *arg, const char *key, zend_string *str) {
+	add_property_str_ex(arg, key, strlen(key), str);
+}
+static inline void add_property_string(zval *arg, const char *key, const char *str) {
+	add_property_string_ex(arg, key, strlen(key), str);
+}
+static inline void add_property_stringl(zval *arg, const char *key, const char *str, size_t length) {
+	add_property_stringl_ex(arg, key, strlen(key), str, length);
+}
+static inline void add_property_zval(zval *arg, const char *key, zval *value) {
+	add_property_zval_ex(arg, key, strlen(key), value);
+}
 
-
+// TODO Drop function_table argument?
 ZEND_API zend_result _call_user_function_impl(zval *object, zval *function_name, zval *retval_ptr, uint32_t param_count, zval params[], HashTable *named_params);
 
 #define call_user_function(function_table, object, function_name, retval_ptr, param_count, params) \

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2374,7 +2374,7 @@ ZEND_API zend_result ZEND_FASTCALL zend_hash_move_backwards_ex(HashTable *ht, Ha
 
 
 /* This function should be made binary safe  */
-ZEND_API int ZEND_FASTCALL zend_hash_get_current_key_ex(const HashTable *ht, zend_string **str_index, zend_ulong *num_index, HashPosition *pos)
+ZEND_API int ZEND_FASTCALL zend_hash_get_current_key_ex(const HashTable *ht, zend_string **str_index, zend_ulong *num_index, const HashPosition *pos)
 {
 	uint32_t idx;
 	Bucket *p;
@@ -2394,7 +2394,7 @@ ZEND_API int ZEND_FASTCALL zend_hash_get_current_key_ex(const HashTable *ht, zen
 	return HASH_KEY_NON_EXISTENT;
 }
 
-ZEND_API void ZEND_FASTCALL zend_hash_get_current_key_zval_ex(const HashTable *ht, zval *key, HashPosition *pos)
+ZEND_API void ZEND_FASTCALL zend_hash_get_current_key_zval_ex(const HashTable *ht, zval *key, const HashPosition *pos)
 {
 	uint32_t idx;
 	Bucket *p;

--- a/Zend/zend_inheritance.h
+++ b/Zend/zend_inheritance.h
@@ -27,8 +27,9 @@ BEGIN_EXTERN_C()
 ZEND_API void zend_do_implement_interface(zend_class_entry *ce, zend_class_entry *iface);
 ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *parent_ce, zend_bool checked);
 
-#define zend_do_inheritance(ce, parent_ce) \
-	zend_do_inheritance_ex(ce, parent_ce, 0)
+static inline void zend_do_inheritance(zend_class_entry *ce, zend_class_entry *parent_ce) {
+	zend_do_inheritance_ex(ce, parent_ce, 0);
+}
 
 ZEND_API zend_result zend_do_link_class(zend_class_entry *ce, zend_string *lc_parent_name);
 

--- a/Zend/zend_ini.h
+++ b/Zend/zend_ini.h
@@ -138,22 +138,41 @@ END_EXTERN_C()
 	ZEND_INI_ENTRY3_EX(name, default_value, modifiable, on_modify, (void *) XtOffsetOf(struct_type, property_name), (void *) &struct_ptr, NULL, zend_ini_boolean_displayer_cb)
 #endif
 
-#define INI_INT(name) zend_ini_long((name), strlen(name), 0)
-#define INI_FLT(name) zend_ini_double((name), strlen(name), 0)
-#define INI_STR(name) zend_ini_string_ex((name), strlen(name), 0, NULL)
-#define INI_BOOL(name) ((zend_bool) INI_INT(name))
-
-#define INI_ORIG_INT(name)	zend_ini_long((name), strlen(name), 1)
-#define INI_ORIG_FLT(name)	zend_ini_double((name), strlen(name), 1)
-#define INI_ORIG_STR(name)	zend_ini_string((name), strlen(name), 1)
-#define INI_ORIG_BOOL(name) ((zend_bool) INI_ORIG_INT(name))
+static inline zend_long INI_INT(const char *name) {
+	return zend_ini_long(name, strlen(name), 0);
+}
+static inline double INI_FLT(const char *name) {
+	return zend_ini_double(name, strlen(name), 0);
+}
+static inline char* INI_STR(const char *name) {
+	return zend_ini_string_ex(name, strlen(name), 0, NULL);
+}
+static inline bool INI_BOOL(const char *name) {
+	return (bool) zend_ini_long(name, strlen(name), 0);
+}
+static inline zend_long INI_ORIG_INT(const char *name) {
+	return zend_ini_long(name, strlen(name), 1);
+}
+static inline double INI_ORIG_FLT(const char *name) {
+	return zend_ini_double(name, strlen(name), 1);
+}
+static inline char* INI_ORIG_STR(const char *name) {
+	return zend_ini_string(name, strlen(name), 1);
+}
+static inline bool INI_ORIG_BOOL(const char *name) {
+	return (bool) zend_ini_long(name, strlen(name), 1);
+}
 
 #define REGISTER_INI_ENTRIES() zend_register_ini_entries(ini_entries, module_number)
 #define UNREGISTER_INI_ENTRIES() zend_unregister_ini_entries(module_number)
 #define DISPLAY_INI_ENTRIES() display_ini_entries(zend_module)
 
-#define REGISTER_INI_DISPLAYER(name, displayer) zend_ini_register_displayer((name), strlen(name), displayer)
-#define REGISTER_INI_BOOLEAN(name) REGISTER_INI_DISPLAYER(name, zend_ini_boolean_displayer_cb)
+static inline zend_result REGISTER_INI_DISPLAYER(const char *name, void (*displayer)(zend_ini_entry *ini_entry, int type)) {
+	return zend_ini_register_displayer(name, strlen(name), displayer);
+}
+static inline zend_result REGISTER_INI_BOOLEAN(const char *name) {
+	return zend_ini_register_displayer(name, strlen(name), zend_ini_boolean_displayer_cb);
+}
 
 /* Standard message handlers */
 BEGIN_EXTERN_C()

--- a/Zend/zend_interfaces.h
+++ b/Zend/zend_interfaces.h
@@ -40,14 +40,23 @@ typedef struct _zend_user_iterator {
 
 ZEND_API zval* zend_call_method(zend_object *object, zend_class_entry *obj_ce, zend_function **fn_proxy, const char *function_name, size_t function_name_len, zval *retval, uint32_t param_count, zval* arg1, zval* arg2);
 
-#define zend_call_method_with_0_params(obj, obj_ce, fn_proxy, function_name, retval) \
-	zend_call_method(obj, obj_ce, fn_proxy, function_name, sizeof(function_name)-1, retval, 0, NULL, NULL)
+static inline zval* zend_call_method_with_0_params(zend_object *object, zend_class_entry *obj_ce,
+		zend_function **fn_proxy, const char *function_name, zval *retval)
+{
+	return zend_call_method(object, obj_ce, fn_proxy, function_name, strlen(function_name), retval, 0, NULL, NULL);
+}
 
-#define zend_call_method_with_1_params(obj, obj_ce, fn_proxy, function_name, retval, arg1) \
-	zend_call_method(obj, obj_ce, fn_proxy, function_name, sizeof(function_name)-1, retval, 1, arg1, NULL)
+static inline zval* zend_call_method_with_1_params(zend_object *object, zend_class_entry *obj_ce,
+		zend_function **fn_proxy, const char *function_name, zval *retval, zval* arg1)
+{
+	return zend_call_method(object, obj_ce, fn_proxy, function_name, strlen(function_name), retval, 1, arg1, NULL);
+}
 
-#define zend_call_method_with_2_params(obj, obj_ce, fn_proxy, function_name, retval, arg1, arg2) \
-	zend_call_method(obj, obj_ce, fn_proxy, function_name, sizeof(function_name)-1, retval, 2, arg1, arg2)
+static inline zval* zend_call_method_with_2_params(zend_object *object, zend_class_entry *obj_ce,
+		zend_function **fn_proxy, const char *function_name, zval *retval, zval* arg1, zval* arg2)
+{
+	return zend_call_method(object, obj_ce, fn_proxy, function_name, strlen(function_name), retval, 2, arg1, arg2);
+}
 
 #define REGISTER_MAGIC_INTERFACE(class_name, class_name_str) \
 	{\

--- a/Zend/zend_llist.h
+++ b/Zend/zend_llist.h
@@ -66,10 +66,25 @@ ZEND_API void *zend_llist_get_last_ex(zend_llist *l, zend_llist_position *pos);
 ZEND_API void *zend_llist_get_next_ex(zend_llist *l, zend_llist_position *pos);
 ZEND_API void *zend_llist_get_prev_ex(zend_llist *l, zend_llist_position *pos);
 
-#define zend_llist_get_first(l) zend_llist_get_first_ex(l, NULL)
-#define zend_llist_get_last(l) zend_llist_get_last_ex(l, NULL)
-#define zend_llist_get_next(l) zend_llist_get_next_ex(l, NULL)
-#define zend_llist_get_prev(l) zend_llist_get_prev_ex(l, NULL)
+static inline void *zend_llist_get_first(zend_llist *l)
+{
+	return zend_llist_get_first_ex(l, NULL);
+}
+
+static inline void *zend_llist_get_last(zend_llist *l)
+{
+	return zend_llist_get_last_ex(l, NULL);
+}
+
+static inline void *zend_llist_get_next(zend_llist *l)
+{
+	return zend_llist_get_next_ex(l, NULL);
+}
+
+static inline void *zend_llist_get_prev(zend_llist *l)
+{
+	return zend_llist_get_prev_ex(l, NULL);
+}
 
 END_EXTERN_C()
 

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -420,7 +420,9 @@ ZEND_API char*        ZEND_FASTCALL zend_str_tolower_dup(const char *source, siz
 ZEND_API char*        ZEND_FASTCALL zend_str_tolower_dup_ex(const char *source, size_t length);
 ZEND_API zend_string* ZEND_FASTCALL zend_string_tolower_ex(zend_string *str, bool persistent);
 
-#define zend_string_tolower(str) zend_string_tolower_ex(str, 0)
+static inline zend_string* zend_string_tolower(zend_string *str) {
+	return zend_string_tolower_ex(str, 0);
+}
 
 ZEND_API int ZEND_FASTCALL zend_binary_zval_strcmp(zval *s1, zval *s2);
 ZEND_API int ZEND_FASTCALL zend_binary_zval_strncmp(zval *s1, zval *s2, zval *s3);

--- a/Zend/zend_smart_str.h
+++ b/Zend/zend_smart_str.h
@@ -21,29 +21,6 @@
 #include "zend_globals.h"
 #include "zend_smart_str_public.h"
 
-#define smart_str_appends_ex(dest, src, what) \
-	smart_str_appendl_ex((dest), (src), strlen(src), (what))
-#define smart_str_appends(dest, src) \
-	smart_str_appendl((dest), (src), strlen(src))
-#define smart_str_extend(dest, len) \
-	smart_str_extend_ex((dest), (len), 0)
-#define smart_str_appendc(dest, c) \
-	smart_str_appendc_ex((dest), (c), 0)
-#define smart_str_appendl(dest, src, len) \
-	smart_str_appendl_ex((dest), (src), (len), 0)
-#define smart_str_append(dest, src) \
-	smart_str_append_ex((dest), (src), 0)
-#define smart_str_append_smart_str(dest, src) \
-	smart_str_append_smart_str_ex((dest), (src), 0)
-#define smart_str_sets(dest, src) \
-	smart_str_setl((dest), (src), strlen(src));
-#define smart_str_append_long(dest, val) \
-	smart_str_append_long_ex((dest), (val), 0)
-#define smart_str_append_unsigned(dest, val) \
-	smart_str_append_unsigned_ex((dest), (val), 0)
-#define smart_str_free(dest) \
-	smart_str_free_ex((dest), 0)
-
 BEGIN_EXTERN_C()
 
 ZEND_API void ZEND_FASTCALL smart_str_erealloc(smart_str *str, size_t len);
@@ -78,12 +55,22 @@ static zend_always_inline char* smart_str_extend_ex(smart_str *dest, size_t len,
 	return ret;
 }
 
+static inline char* smart_str_extend(smart_str *dest, size_t length)
+{
+	return smart_str_extend_ex(dest, length, 0);
+}
+
 static zend_always_inline void smart_str_free_ex(smart_str *str, zend_bool persistent) {
 	if (str->s) {
 		zend_string_release_ex(str->s, persistent);
 		str->s = NULL;
 	}
 	str->a = 0;
+}
+
+static inline void smart_str_free(smart_str *str)
+{
+	smart_str_free_ex(str, 0);
 }
 
 static zend_always_inline void smart_str_0(smart_str *str) {
@@ -136,10 +123,45 @@ static zend_always_inline void smart_str_append_long_ex(smart_str *dest, zend_lo
 	smart_str_appendl_ex(dest, result, buf + sizeof(buf) - 1 - result, persistent);
 }
 
+static inline void smart_str_append_long(smart_str *dest, zend_long num)
+{
+	smart_str_append_long_ex(dest, num, 0);
+}
+
 static zend_always_inline void smart_str_append_unsigned_ex(smart_str *dest, zend_ulong num, zend_bool persistent) {
 	char buf[32];
 	char *result = zend_print_ulong_to_buf(buf + sizeof(buf) - 1, num);
 	smart_str_appendl_ex(dest, result, buf + sizeof(buf) - 1 - result, persistent);
+}
+
+static inline void smart_str_append_unsigned(smart_str *dest, zend_ulong num)
+{
+	smart_str_append_unsigned_ex(dest, num, 0);
+}
+
+static inline void smart_str_appendl(smart_str *dest, const char *src, size_t length)
+{
+	smart_str_appendl_ex(dest, src, length, 0);
+}
+static inline void smart_str_appends_ex(smart_str *dest, const char *src, bool persistent)
+{
+	smart_str_appendl_ex(dest, src, strlen(src), persistent);
+}
+static inline void smart_str_appends(smart_str *dest, const char *src)
+{
+	smart_str_appendl_ex(dest, src, strlen(src), 0);
+}
+static inline void smart_str_append(smart_str *dest, const zend_string *src)
+{
+	smart_str_append_ex(dest, src, 0);
+}
+static inline void smart_str_appendc(smart_str *dest, char ch)
+{
+	smart_str_appendc_ex(dest, ch, 0);
+}
+static inline void smart_str_append_smart_str(smart_str *dest, const smart_str *src)
+{
+	smart_str_append_smart_str_ex(dest, src, 0);
 }
 
 static zend_always_inline void smart_str_setl(smart_str *dest, const char *src, size_t len) {
@@ -147,4 +169,8 @@ static zend_always_inline void smart_str_setl(smart_str *dest, const char *src, 
 	smart_str_appendl(dest, src, len);
 }
 
+static inline void smart_str_sets(smart_str *dest, const char *src)
+{
+	smart_str_setl(dest, src, strlen(src));
+}
 #endif


### PR DESCRIPTION
This PR converts various macros in inline functions.

Notable omissions of this pass:
 - Zend Smart String (the one using char*)
 - Zend Virtual CWD
 - Zend/zend_string.h
 - Zend/zend_compile.h
 - Zend/zend_types.h