### PR TITLE
Fix unixtojd long parameter parsing

### DIFF
--- a/ext/calendar/cal_unix.c
+++ b/ext/calendar/cal_unix.c
@@ -28,16 +28,19 @@
 PHP_FUNCTION(unixtojd)
 {
 	time_t ts = 0;
+	zend_long tl = 0;
 	struct tm *ta, tmbuf;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &ts) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &tl) == FAILURE) {
 		return;
 	}
 
-	if (!ts) {
+	if (!tl) {
 		ts = time(NULL);
-	} else if (ts < 0) {
+	} else if (tl < 0) {
 		RETURN_FALSE;
+	} else {
+		ts = (time_t)tl;
 	}
 
 	if (!(ta = php_localtime_r(&ts, &tmbuf))) {


### PR DESCRIPTION
Expected parameter is long but used `time_t` may vary depending on arch (32 or 64 bits).
Patch makes always use long (`zend_long`) for function argument and cast it to `time_t` if needed

Also it fixes test on 32-bit armv7 and x86
- `Test unixtojd() function : error conditions [ext/calendar/tests/unixtojd_error1.phpt]`

Source of discussion https://gitlab.alpinelinux.org/alpine/aports/-/issues/11782#note_104912

Patch for PHP 8 a bit different and used in https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/9848