### PR TITLE
Check for duplicate names in gen_stub.php

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -650,6 +650,7 @@ function parseFunctionLike(
         }
     }
 
+    $varNameSet = [];
     $args = [];
     $numRequiredArgs = 0;
     $foundVariadic = false;
@@ -657,6 +658,11 @@ function parseFunctionLike(
         $varName = $param->var->name;
         $preferRef = !empty($paramMeta[$varName]['preferRef']);
         unset($paramMeta[$varName]);
+
+        if (isset($varNameSet[$varName])) {
+            throw new Exception("Duplicate parameter name $varName for function $name");
+        }
+        $varNameSet[$varName] = true;
 
         if ($preferRef) {
             $sendBy = ArgInfo::SEND_PREFER_REF;


### PR DESCRIPTION
With named arguments in php 8.0, it's important that php's modules
or PECL extensions using gen_stub.php don't generate functions
with duplicate names.

Warn if a parameter name is repeated,
even if the last occurrence is a variadic parameter.
Previously, this would not be an error when compiling php-src

Related to https://github.com/php/php-tasks/issues/16 and https://github.com/php/php-src/pull/6015/files

Tested by
- Running `touch **/*.stub.php; make **/*_arginfo.h`
- Verifying that an exception was thrown when renaming a parameter to have the same name as a previous parameter