### PR TITLE
Update PHP-Parser from 4.3.0 to 4.9.0

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1105,7 +1105,7 @@ function initPhpParser() {
     }
 
     $isInitialized = true;
-    $version = "4.3.0";
+    $version = "4.9.0";
     $phpParserDir = __DIR__ . "/PHP-Parser-$version";
     if (!is_dir($phpParserDir)) {
         installPhpParser($version, $phpParserDir);


### PR DESCRIPTION
PHP-Parser 4.3.0 failed to recognize that the `match` keyword could be
used as a class constant name.
4.9.0 also adds support for keywords in namespaced names.
See https://github.com/nikic/PHP-Parser/releases

So forcing regeneration of spl_iterators.stub.php failed.

PECL extensions using gen_stub.php would also be affected
by the same issue for those keywords.

```
// PHP 4.3.0 is not aware of the T_MATCH token
ext/spl/spl_iterators.stub.php
    public function __construct(Iterator $iterator, string $regex,
    int $mode = self::MATCH, int $flags = 0, int $preg_flags = 0) {}
```

Testing: I successfully regenerated stubs by setting forceRegeneration to true
and running `touch **/*.stub.php; make`.
The stubs did not change, as expected.

CC @nikic @kocsismate @cmb69 