### PR TITLE
Catch potential exceptions during to string conversion

### DIFF
--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -85,7 +85,9 @@ PHP_FUNCTION(com_create_instance)
 
 		if (NULL != (tmp = zend_hash_str_find(Z_ARRVAL_P(server_params),
 				"Server", sizeof("Server")-1))) {
-			convert_to_string_ex(tmp);
+			if (!try_convert_to_string(tmp)) {
+				return;
+			}
 			server_name = Z_STRVAL_P(tmp);
 			server_name_len = Z_STRLEN_P(tmp);
 			ctx = CLSCTX_REMOTE_SERVER;
@@ -93,21 +95,27 @@ PHP_FUNCTION(com_create_instance)
 
 		if (NULL != (tmp = zend_hash_str_find(Z_ARRVAL_P(server_params),
 				"Username", sizeof("Username")-1))) {
-			convert_to_string_ex(tmp);
+			if (!try_convert_to_string(tmp)) {
+				return;
+			}
 			user_name = Z_STRVAL_P(tmp);
 			user_name_len = Z_STRLEN_P(tmp);
 		}
 
 		if (NULL != (tmp = zend_hash_str_find(Z_ARRVAL_P(server_params),
 				"Password", sizeof("Password")-1))) {
-			convert_to_string_ex(tmp);
+			if (!try_convert_to_string(tmp)) {
+				return;
+			}
 			password = Z_STRVAL_P(tmp);
 			password_len = Z_STRLEN_P(tmp);
 		}
 
 		if (NULL != (tmp = zend_hash_str_find(Z_ARRVAL_P(server_params),
 				"Domain", sizeof("Domain")-1))) {
-			convert_to_string_ex(tmp);
+			if (!try_convert_to_string(tmp)) {
+				return;
+			}
 			domain_name = Z_STRVAL_P(tmp);
 			domain_name_len = Z_STRLEN_P(tmp);
 		}
@@ -720,7 +728,9 @@ PHP_FUNCTION(com_event_sink)
 		if ((tmp = zend_hash_index_find(Z_ARRVAL_P(sink), 1)) != NULL && Z_TYPE_P(tmp) == IS_STRING)
 			dispname = Z_STRVAL_P(tmp);
 	} else if (sink != NULL) {
-		convert_to_string(sink);
+		if (!try_convert_to_string(sink)) {
+			return;
+		}
 		dispname = Z_STRVAL_P(sink);
 	}
 

--- a/ext/com_dotnet/com_saproxy.c
+++ b/ext/com_dotnet/com_saproxy.c
@@ -108,7 +108,10 @@ static zval *saproxy_read_dimension(zval *object, zval *offset, int type, zval *
 		}
 		ZVAL_COPY_VALUE(&args[i-1], offset);
 
-		convert_to_string(&proxy->indices[0]);
+		if (!try_convert_to_string(&proxy->indices[0])) {
+			efree(args);
+			return rv;
+		}
 		VariantInit(&v);
 
 		res = php_com_do_invoke(proxy->obj, Z_STRVAL(proxy->indices[0]),
@@ -223,7 +226,10 @@ static void saproxy_write_dimension(zval *object, zval *offset, zval *value)
 		ZVAL_COPY_VALUE(&args[i-1], offset);
 		ZVAL_COPY_VALUE(&args[i], value);
 
-		convert_to_string(&proxy->indices[0]);
+		if (!try_convert_to_string(&proxy->indices[0])) {
+			efree(args);
+			return;
+		}
 		VariantInit(&v);
 		if (SUCCESS == php_com_do_invoke(proxy->obj, Z_STRVAL(proxy->indices[0]),
 					Z_STRLEN(proxy->indices[0]), DISPATCH_PROPERTYPUT, &v, proxy->dimensions + 1,


### PR DESCRIPTION
As of PHP 7.4.0, exceptions are allowed to be thrown from inside
`__toString()` methods; we have to cater to that, and catch these
exceptions early.