### PR TITLE
Improve error_handing replacement functions

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -344,7 +344,6 @@ typedef enum {
 typedef struct {
 	zend_error_handling_t  handling;
 	zend_class_entry       *exception;
-	zval                   user_handler;
 } zend_error_handling;
 
 ZEND_API void zend_save_error_handling(zend_error_handling *current);

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4242,7 +4242,6 @@ ZEND_API void zend_save_error_handling(zend_error_handling *current) /* {{{ */
 {
 	current->handling = EG(error_handling);
 	current->exception = EG(exception_class);
-	ZVAL_COPY(&current->user_handler, &EG(user_error_handler));
 }
 /* }}} */
 
@@ -4250,25 +4249,17 @@ ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, 
 {
 	if (current) {
 		zend_save_error_handling(current);
-		if (error_handling != EH_NORMAL && Z_TYPE(EG(user_error_handler)) != IS_UNDEF) {
-			zval_ptr_dtor(&EG(user_error_handler));
-			ZVAL_UNDEF(&EG(user_error_handler));
-		}
 	}
+	ZEND_ASSERT(error_handling == EH_THROW || exception_class == NULL);
 	EG(error_handling) = error_handling;
-	EG(exception_class) = error_handling == EH_THROW ? exception_class : NULL;
+	EG(exception_class) = exception_class;
 }
 /* }}} */
 
 ZEND_API void zend_restore_error_handling(zend_error_handling *saved) /* {{{ */
 {
 	EG(error_handling) = saved->handling;
-	EG(exception_class) = saved->handling == EH_THROW ? saved->exception : NULL;
-	if (Z_TYPE(saved->user_handler) != IS_UNDEF) {
-		zval_ptr_dtor(&EG(user_error_handler));
-		ZVAL_COPY_VALUE(&EG(user_error_handler), &saved->user_handler);
-		ZVAL_UNDEF(&saved->user_handler);
-	}
+	EG(exception_class) = saved->exception;
 }
 /* }}} */
 


### PR DESCRIPTION
It looks that it's unnecessary to make user_error_handler UNDEF.
The usage of `zend_replace_error_handling()` is to convert warnings to exceptions, it does not involve the call to user_error_handler.

And it also breaks the security of coroutine switching, following is an example:
```php
// 0
set_error_handler(function () {
    // 9
    var_dump(func_get_args());
});

// 1
$wr = new WaitReference();

// 2
Coroutine::run(function () use ($wr) {
    // 3
    // zend_replace_error_handling() was called
    // then stream_connect() was called
    // it yield from __construct
    new PDO('mysql:host=127.0.0.1;charset=utf8', 'root', 'root');
    // 6
});

// error handler is UNDEF here
// 4
trigger_error('foo', E_USER_WARNING);

// 5
// it's same with WaitGroup
$wr::wait($wr);
// 7

// 8
// after PDO __construct() done
// zend_restore_error_handling() was restored
// user error handler will be called
trigger_error('foo', E_USER_WARNING);

// 10
```
