### PR TITLE
Simplify error type filter

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1310,30 +1310,21 @@ static ZEND_COLD void zend_error_impl(
 		zend_execute_data *ex;
 		const zend_op *opline;
 
-		switch (type) {
-			case E_CORE_ERROR:
-			case E_ERROR:
-			case E_RECOVERABLE_ERROR:
-			case E_PARSE:
-			case E_COMPILE_ERROR:
-			case E_USER_ERROR:
-				ex = EG(current_execute_data);
-				opline = NULL;
-				while (ex && (!ex->func || !ZEND_USER_CODE(ex->func->type))) {
-					ex = ex->prev_execute_data;
-				}
-				if (ex && ex->opline->opcode == ZEND_HANDLE_EXCEPTION &&
-				    EG(opline_before_exception)) {
-					opline = EG(opline_before_exception);
-				}
-				zend_exception_error(EG(exception), E_WARNING);
-				EG(exception) = NULL;
-				if (opline) {
-					ex->opline = opline;
-				}
-				break;
-			default:
-				break;
+		if (type & E_FATAL_ERRORS) {
+			ex = EG(current_execute_data);
+			opline = NULL;
+			while (ex && (!ex->func || !ZEND_USER_CODE(ex->func->type))) {
+				ex = ex->prev_execute_data;
+			}
+			if (ex && ex->opline->opcode == ZEND_HANDLE_EXCEPTION &&
+			    EG(opline_before_exception)) {
+				opline = EG(opline_before_exception);
+			}
+			zend_exception_error(EG(exception), E_WARNING);
+			EG(exception) = NULL;
+			if (opline) {
+				ex->opline = opline;
+			}
 		}
 	}
 

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -1842,12 +1842,7 @@ static zend_never_inline ZEND_COLD void soap_real_error_handler(int error_num, c
 		     use_exceptions = 1;
 		}
 
-		if ((error_num == E_USER_ERROR ||
-		     error_num == E_COMPILE_ERROR ||
-		     error_num == E_CORE_ERROR ||
-		     error_num == E_ERROR ||
-		     error_num == E_PARSE) &&
-		    use_exceptions) {
+		if ((error_num & E_FATAL_ERRORS) && use_exceptions) {
 			zval fault;
 			char *code = SOAP_GLOBAL(error_code);
 			if (code == NULL) {
@@ -1869,12 +1864,7 @@ static zend_never_inline ZEND_COLD void soap_real_error_handler(int error_num, c
 		int fault = 0;
 		zval fault_obj;
 
-		if (error_num == E_USER_ERROR ||
-		    error_num == E_COMPILE_ERROR ||
-		    error_num == E_CORE_ERROR ||
-		    error_num == E_ERROR ||
-		    error_num == E_PARSE) {
-
+		if (error_num & E_FATAL_ERRORS) {
 			char* code = SOAP_GLOBAL(error_code);
 			zend_string *buffer;
 			zval outbuf;

--- a/main/main.c
+++ b/main/main.c
@@ -1229,11 +1229,11 @@ static ZEND_COLD void php_error_cb(int orig_type, const char *error_filename, co
 			case E_CORE_WARNING:
 			case E_COMPILE_WARNING:
 			case E_USER_WARNING:
-				/* throw an exception if we are in EH_THROW mode and the type is warning
-				 * fatal errors are real errors and cannot be made exceptions
-				 * exclude deprecated for the sake of BC to old damaged code
-				 * notices are no errors and are not treated as such like E_WARNINGS
-				 * DO NOT overwrite a pending exception
+				/* throw an exception if we are in EH_THROW mode and the type is warning.
+				 * fatal errors are real errors and cannot be made exceptions.
+				 * exclude deprecated for the sake of BC to old damaged code.
+				 * notices are no errors and are not treated as such like E_WARNINGS.
+				 * DO NOT overwrite a pending exception.
 				 */
 				if (!EG(exception)) {
 					zend_throw_error_exception(EG(exception_class), message, 0, type);

--- a/main/main.c
+++ b/main/main.c
@@ -1225,30 +1225,22 @@ static ZEND_COLD void php_error_cb(int orig_type, const char *error_filename, co
 	/* according to error handling mode, throw exception or show it */
 	if (EG(error_handling) == EH_THROW) {
 		switch (type) {
-			case E_ERROR:
-			case E_CORE_ERROR:
-			case E_COMPILE_ERROR:
-			case E_USER_ERROR:
-			case E_PARSE:
-				/* fatal errors are real errors and cannot be made exceptions */
-				break;
-			case E_STRICT:
-			case E_DEPRECATED:
-			case E_USER_DEPRECATED:
-				/* for the sake of BC to old damaged code */
-				break;
-			case E_NOTICE:
-			case E_USER_NOTICE:
-				/* notices are no errors and are not treated as such like E_WARNINGS */
-				break;
-			default:
-				/* throw an exception if we are in EH_THROW mode
-				 * but DO NOT overwrite a pending exception
+			case E_WARNING:
+			case E_CORE_WARNING:
+			case E_COMPILE_WARNING:
+			case E_USER_WARNING:
+				/* throw an exception if we are in EH_THROW mode and the type is warning
+				 * fatal errors are real errors and cannot be made exceptions
+				 * exclude deprecated for the sake of BC to old damaged code
+				 * notices are no errors and are not treated as such like E_WARNINGS
+				 * DO NOT overwrite a pending exception
 				 */
 				if (!EG(exception)) {
 					zend_throw_error_exception(EG(exception_class), message, 0, type);
 				}
 				return;
+			default:
+				break;
 		}
 	}
 

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1169,19 +1169,13 @@ static void php_cli_server_log_response(php_cli_server_client *client, int statu
 	zend_bool append_error_message = 0;
 
 	if (PG(last_error_message)) {
-		switch (PG(last_error_type)) {
-			case E_ERROR:
-			case E_CORE_ERROR:
-			case E_COMPILE_ERROR:
-			case E_USER_ERROR:
-			case E_PARSE:
-				if (status == 200) {
-					/* the status code isn't changed by a fatal error, so fake it */
-					effective_status = 500;
-				}
+		if (PG(last_error_type) & E_FATAL_ERRORS) {
+			if (status == 200) {
+				/* the status code isn't changed by a fatal error, so fake it */
+				effective_status = 500;
+			}
 
-				append_error_message = 1;
-				break;
+			append_error_message = 1;
 		}
 	}
 

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -798,32 +798,25 @@ static void php_sapi_phpdbg_log_message(const char *message, int syslog_type_int
 			return;
 		}
 
-		switch (PG(last_error_type)) {
-			case E_ERROR:
-			case E_CORE_ERROR:
-			case E_COMPILE_ERROR:
-			case E_USER_ERROR:
-			case E_PARSE:
-			case E_RECOVERABLE_ERROR: {
-				const char *file_char = zend_get_executed_filename();
-				zend_string *file = zend_string_init(file_char, strlen(file_char), 0);
-				phpdbg_list_file(file, 3, zend_get_executed_lineno() - 1, zend_get_executed_lineno());
-				zend_string_release(file);
+		if (PG(last_error_type) & E_FATAL_ERRORS) {
+			const char *file_char = zend_get_executed_filename();
+			zend_string *file = zend_string_init(file_char, strlen(file_char), 0);
+			phpdbg_list_file(file, 3, zend_get_executed_lineno() - 1, zend_get_executed_lineno());
+			zend_string_release(file);
 
-				if (!phpdbg_fully_started) {
-					return;
-				}
-
-				do {
-					switch (phpdbg_interactive(1, NULL)) {
-						case PHPDBG_LEAVE:
-						case PHPDBG_FINISH:
-						case PHPDBG_UNTIL:
-						case PHPDBG_NEXT:
-							return;
-					}
-				} while (!(PHPDBG_G(flags) & PHPDBG_IS_STOPPING));
+			if (!phpdbg_fully_started) {
+				return;
 			}
+
+			do {
+				switch (phpdbg_interactive(1, NULL)) {
+					case PHPDBG_LEAVE:
+					case PHPDBG_FINISH:
+					case PHPDBG_UNTIL:
+					case PHPDBG_NEXT:
+						return;
+				}
+			} while (!(PHPDBG_G(flags) & PHPDBG_IS_STOPPING));
 		}
 	} else {
 		fprintf(stdout, "%s\n", message);


### PR DESCRIPTION
I'm a little curious that we have `unwind_exit` now, so could `E_RECOVERABLE_ERROR` be a real recoverable error? (without bailout)
If it couldn't, it maybe not worth the cost of keeping.