### PR TITLE
Proposal: Add iterable\any(iterable $input, ?callable $cb=null), all(...), none(...), find(...), reduce(...)

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6498,7 +6498,7 @@ PHP_FUNCTION(reduce)
 		Z_PARAM_FUNC(fci, fci_cache)
 	ZEND_PARSE_PARAMETERS_END();
 
-	zend_result result = php_iterable_reduce(input, &fci, &fci_cache, return_value);
+	iterable_reduce_result result = php_iterable_reduce(input, &fci, &fci_cache, return_value);
 
 	if (result == REDUCE_EEMPTY) {
 		zend_argument_value_error(1, "must not be empty");

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5788,7 +5788,7 @@ static int php_traversable_reduce_elem(zend_object_iterator *iter, void *puser) 
 		goto keep;
 	}
 
-	ZVAL_COPY(&reduce_data->args[0], fci->retval);
+	ZVAL_COPY_VALUE(&reduce_data->args[0], fci->retval);
 	ZVAL_COPY(&reduce_data->args[1], operand);
 	ZVAL_NULL(fci->retval);
 	zend_result result = zend_call_function(&reduce_data->fci, &reduce_data->fcc);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6194,3 +6194,154 @@ PHP_FUNCTION(array_combine)
 	} ZEND_HASH_FOREACH_END();
 }
 /* }}} */
+
+static inline void php_array_until(zval *return_value, HashTable *htbl, zend_fcall_info fci, zend_fcall_info_cache fci_cache, int stop_value) /* {{{ */
+{
+	zval args[1];
+	zend_bool have_callback = 0;
+	zval *operand;
+	zval retval;
+	int result;
+
+	if (zend_hash_num_elements(htbl) == 0) {
+		RETURN_BOOL(!stop_value);
+	}
+
+	if (ZEND_FCI_INITIALIZED(fci)) {
+		have_callback = 1;
+		fci.retval = &retval;
+		fci.param_count = 1;
+		fci.params = args;
+	}
+
+	ZEND_HASH_FOREACH_VAL(htbl, operand) {
+		if (have_callback) {
+			zend_bool retval_true;
+			ZVAL_COPY(&args[0], operand);
+
+			/* Treat the operand like an array of size 1  */
+			result = zend_call_function(&fci, &fci_cache);
+			zval_ptr_dtor(operand);
+			if (result == FAILURE) {
+				return;
+			}
+			retval_true = zend_is_true(&retval);
+			zval_ptr_dtor(&retval);
+			/* The user-provided callback rarely returns refcounted values. */
+			if (retval_true == stop_value) {
+				RETURN_BOOL(stop_value);
+			}
+		} else {
+			if (zend_is_true(operand) == stop_value) {
+				RETURN_BOOL(stop_value);
+			}
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	RETURN_BOOL(!stop_value);
+}
+/* }}} */
+
+typedef struct {
+	zval                   *obj;
+	int                    stop_value;
+	int                    result;
+	int                    found;
+	zend_long              has_callback;
+	zend_fcall_info        fci;
+	zend_fcall_info_cache  fcc;
+} php_iterator_until_info;
+
+static int php_traversable_func_until(zend_object_iterator *iter, void *puser) /* {{{ */
+{
+	zend_fcall_info fci;
+	zval retval;
+	php_iterator_until_info *until_info = (php_iterator_until_info*) puser;
+	int result;
+	zend_bool stop;
+
+	fci = until_info->fci;
+	if (ZEND_FCI_INITIALIZED(fci)) {
+		zval *operand = iter->funcs->get_current_data(iter);
+		fci.retval = &retval;
+		fci.param_count = 1;
+		/* Use the operand like an array of size 1 */
+		fci.params = operand;
+		fci.retval = &retval;
+		Z_TRY_ADDREF_P(operand);
+		result = zend_call_function(&fci, &until_info->fcc);
+		zval_ptr_dtor(operand);
+		if (result == FAILURE) {
+			until_info->result = FAILURE;
+			return ZEND_HASH_APPLY_STOP;
+		}
+
+		stop = zend_is_true(&retval) == until_info->stop_value;
+		zval_ptr_dtor(&retval);
+	} else {
+		stop = zend_is_true(iter->funcs->get_current_data(iter)) == until_info->stop_value;
+	}
+	if (stop) {
+		until_info->found = 1;
+		return ZEND_HASH_APPLY_STOP;
+	}
+	return ZEND_HASH_APPLY_KEEP;
+}
+/* }}} */
+
+static inline void php_iterable_until(INTERNAL_FUNCTION_PARAMETERS, int stop_value) /* {{{ */
+{
+	zval *input;
+	zend_fcall_info fci = empty_fcall_info;
+	zend_fcall_info_cache fci_cache = empty_fcall_info_cache;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_ZVAL(input)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_FUNC_OR_NULL(fci, fci_cache)
+	ZEND_PARSE_PARAMETERS_END();
+
+	switch (Z_TYPE_P(input)) {
+		case IS_ARRAY:
+			php_array_until(return_value, Z_ARRVAL_P(input), fci, fci_cache, stop_value);
+			return;
+		case IS_OBJECT:
+			if (instanceof_function(Z_OBJCE_P(input), zend_ce_traversable)) {
+				php_iterator_until_info until_info;
+
+				until_info.obj = input;
+				until_info.fci = fci;
+				until_info.fcc = fci_cache;
+
+				until_info.stop_value = stop_value;
+				until_info.result = SUCCESS;
+				until_info.found = 0;
+
+				if (spl_iterator_apply(until_info.obj, php_traversable_func_until, (void*)&until_info) == SUCCESS && until_info.result == SUCCESS) {
+					RETURN_BOOL(!(until_info.found ^ stop_value));
+				}
+				return;
+			}
+			/* fallthrough */
+		default:
+			zend_argument_type_error(1, "must be of type iterable, %s given", zend_zval_type_name(input));
+			RETURN_THROWS();
+			break;
+	}
+}
+
+/* {{{ proto bool all(array input, ?callable predicate = null)
+   Determines whether the predicate holds for all elements in the array */
+PHP_FUNCTION(all)
+{
+	php_iterable_until(INTERNAL_FUNCTION_PARAM_PASSTHRU, 0);
+}
+/* }}} */
+
+/* {{{ proto bool any(array input, ?callable predicate = null)
+   Determines whether the predicate holds for at least one element in the array */
+PHP_FUNCTION(any)
+{
+	php_iterable_until(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1);
+}
+/* }}} */

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5731,7 +5731,7 @@ PHP_FUNCTION(array_product)
 }
 /* }}} */
 
-static zend_always_inline void php_array_reduce(HashTable *htbl, zend_fcall_info fci, zend_fcall_info_cache fci_cache, zval* return_value) /* {{{ */
+static void php_array_reduce(HashTable *htbl, zend_fcall_info fci, zend_fcall_info_cache fci_cache, zval* return_value) /* {{{ */
 {
 	zval args[2];
 	zval *operand;
@@ -5793,7 +5793,7 @@ static int php_traversable_reduce_elem(zend_object_iterator *iter, void *puser) 
 	return ZEND_HASH_APPLY_KEEP;
 }
 
-static zend_always_inline void php_traversable_reduce(zval *obj, zend_fcall_info fci, zend_fcall_info_cache fci_cache, zval* return_value) /* {{{ */
+static void php_traversable_reduce(zval *obj, zend_fcall_info fci, zend_fcall_info_cache fci_cache, zval* return_value) /* {{{ */
 {
 	traversable_reduce_data reduce_data;
 	reduce_data.fci = fci;
@@ -6236,7 +6236,7 @@ PHP_FUNCTION(array_combine)
 }
 /* }}} */
 
-static inline void php_array_until(zval *return_value, HashTable *htbl, zend_fcall_info fci, zend_fcall_info_cache fci_cache, int stop_value, int negate) /* {{{ */
+static void php_array_until(zval *return_value, HashTable *htbl, zend_fcall_info fci, zend_fcall_info_cache fci_cache, int stop_value, int negate) /* {{{ */
 {
 	zval args[1];
 	bool have_callback = 0;
@@ -6341,7 +6341,7 @@ static int php_traversable_func_until(zend_object_iterator *iter, void *puser) /
 }
 /* }}} */
 
-static inline void php_iterable_until(INTERNAL_FUNCTION_PARAMETERS, int stop_value, int negate) /* {{{ */
+static void php_iterable_until(INTERNAL_FUNCTION_PARAMETERS, int stop_value, int negate) /* {{{ */
 {
 	zval *input;
 	zend_fcall_info fci = empty_fcall_info;
@@ -6434,7 +6434,7 @@ PHP_FUNCTION(reduce)
 }
 /* }}} */
 
-static zend_always_inline void php_array_find(HashTable *htbl, zend_fcall_info fci, zend_fcall_info_cache fci_cache, zval* return_value, zval *default_value) /* {{{ */
+static void php_array_find(HashTable *htbl, zend_fcall_info fci, zend_fcall_info_cache fci_cache, zval* return_value, zval *default_value) /* {{{ */
 {
 	zval retval;
 	zval *operand;
@@ -6512,7 +6512,7 @@ static int php_traversable_find_elem(zend_object_iterator *iter, void *puser) /*
 	return ZEND_HASH_APPLY_KEEP;
 }
 
-static zend_always_inline void php_traversable_find(zval *obj, zend_fcall_info fci, zend_fcall_info_cache fci_cache, zval* return_value, zval *default_value) /* {{{ */
+static void php_traversable_find(zval *obj, zend_fcall_info fci, zend_fcall_info_cache fci_cache, zval* return_value, zval *default_value) /* {{{ */
 {
 	traversable_find_data find_data;
 	find_data.fci = fci;

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1524,4 +1524,6 @@ function none(iterable $iterable, ?callable $callback = null): bool {}
 
 function reduce(iterable $iterable, callable $callback, mixed $initial = null): mixed {}
 
+function find(iterable $iterable, callable $callback, mixed $default = null): mixed {}
+
 }

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1516,14 +1516,16 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): bool {}
 
 namespace iterable {
 
-function any(iterable $iterable, ?callable $callback = null): bool {}
-
 function all(iterable $iterable, ?callable $callback = null): bool {}
+
+function any(iterable $iterable, ?callable $callback = null): bool {}
 
 function none(iterable $iterable, ?callable $callback = null): bool {}
 
-function reduce(iterable $iterable, callable $callback, mixed $initial = null): mixed {}
-
 function find(iterable $iterable, callable $callback, mixed $default = null): mixed {}
+
+//function fold(iterable $iterable, callable $by, mixed $initial): mixed {}
+
+function reduce(iterable $iterable, callable $by): mixed {}
 
 }

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1522,4 +1522,6 @@ function all(iterable $iterable, ?callable $callback = null): bool {}
 
 function none(iterable $iterable, ?callable $callback = null): bool {}
 
+function reduce(iterable $iterable, callable $callback, mixed $initial = null): mixed {}
+
 }

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -10,6 +10,8 @@ class AssertionError extends Error
 {
 }
 
+namespace {
+
 /* main/main.c */
 
 function set_time_limit(int $seconds): bool {}
@@ -1510,3 +1512,12 @@ function sapi_windows_set_ctrl_handler(?callable $handler, bool $add = true): bo
 
 function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): bool {}
 #endif
+} // end global namespace
+
+namespace PHP\iterable {
+
+function any(iterable $iterable, ?callable $callback = null): bool {}
+
+function all(iterable $iterable, ?callable $callback = null): bool {}
+
+}

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1520,4 +1520,6 @@ function any(iterable $iterable, ?callable $callback = null): bool {}
 
 function all(iterable $iterable, ?callable $callback = null): bool {}
 
+function none(iterable $iterable, ?callable $callback = null): bool {}
+
 }

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2,6 +2,8 @@
 
 /** @generate-class-entries */
 
+namespace {
+
 final class __PHP_Incomplete_Class
 {
 }
@@ -9,8 +11,6 @@ final class __PHP_Incomplete_Class
 class AssertionError extends Error
 {
 }
-
-namespace {
 
 /* main/main.c */
 
@@ -1514,7 +1514,7 @@ function sapi_windows_generate_ctrl_event(int $event, int $pid = 0): bool {}
 #endif
 } // end global namespace
 
-namespace PHP\iterable {
+namespace iterable {
 
 function any(iterable $iterable, ?callable $callback = null): bool {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 59dd3527ae66c463cb59b6cc20b41d7fbdcc0ff0 */
+ * Stub hash: abc9b998fe34151e0bd8b5dbbea97ada44484a08 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2227,6 +2227,12 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_iterable_none arginfo_iterable_any
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_reduce, 0, 2, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, initial, IS_MIXED, 0, "null")
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(set_time_limit);
 ZEND_FUNCTION(header_register_callback);
@@ -2851,6 +2857,7 @@ ZEND_FUNCTION(sapi_windows_generate_ctrl_event);
 ZEND_FUNCTION(any);
 ZEND_FUNCTION(all);
 ZEND_FUNCTION(none);
+ZEND_FUNCTION(reduce);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -3507,6 +3514,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_NS_FE("iterable", any, arginfo_iterable_any)
 	ZEND_NS_FE("iterable", all, arginfo_iterable_all)
 	ZEND_NS_FE("iterable", none, arginfo_iterable_none)
+	ZEND_NS_FE("iterable", reduce, arginfo_iterable_reduce)
 	ZEND_FE_END
 };
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f57589852a699be9edd08f434073007b9fef4e34 */
+ * Stub hash: c04b8fad2fb795a23786e6340a514c63d9edf5a1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2218,25 +2218,24 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_generate_ctrl_event
 ZEND_END_ARG_INFO()
 #endif
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_any, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_all, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, callback, IS_CALLABLE, 1, "null")
 ZEND_END_ARG_INFO()
 
-#define arginfo_iterable_all arginfo_iterable_any
+#define arginfo_iterable_any arginfo_iterable_all
 
-#define arginfo_iterable_none arginfo_iterable_any
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_reduce, 0, 2, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
-	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, initial, IS_MIXED, 0, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_iterable_none arginfo_iterable_all
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_find, 0, 2, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, default, IS_MIXED, 0, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_reduce, 0, 2, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_TYPE_INFO(0, by, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 
 
@@ -2860,11 +2859,11 @@ ZEND_FUNCTION(sapi_windows_set_ctrl_handler);
 #if defined(PHP_WIN32)
 ZEND_FUNCTION(sapi_windows_generate_ctrl_event);
 #endif
-ZEND_FUNCTION(any);
 ZEND_FUNCTION(all);
+ZEND_FUNCTION(any);
 ZEND_FUNCTION(none);
-ZEND_FUNCTION(reduce);
 ZEND_FUNCTION(find);
+ZEND_FUNCTION(reduce);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -3518,11 +3517,11 @@ static const zend_function_entry ext_functions[] = {
 #if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_generate_ctrl_event, arginfo_sapi_windows_generate_ctrl_event)
 #endif
-	ZEND_NS_FE("iterable", any, arginfo_iterable_any)
 	ZEND_NS_FE("iterable", all, arginfo_iterable_all)
+	ZEND_NS_FE("iterable", any, arginfo_iterable_any)
 	ZEND_NS_FE("iterable", none, arginfo_iterable_none)
-	ZEND_NS_FE("iterable", reduce, arginfo_iterable_reduce)
 	ZEND_NS_FE("iterable", find, arginfo_iterable_find)
+	ZEND_NS_FE("iterable", reduce, arginfo_iterable_reduce)
 	ZEND_FE_END
 };
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: abc9b998fe34151e0bd8b5dbbea97ada44484a08 */
+ * Stub hash: f57589852a699be9edd08f434073007b9fef4e34 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2233,6 +2233,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_reduce, 0, 2, IS_MIXED,
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, initial, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_find, 0, 2, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, default, IS_MIXED, 0, "null")
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(set_time_limit);
 ZEND_FUNCTION(header_register_callback);
@@ -2858,6 +2864,7 @@ ZEND_FUNCTION(any);
 ZEND_FUNCTION(all);
 ZEND_FUNCTION(none);
 ZEND_FUNCTION(reduce);
+ZEND_FUNCTION(find);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -3515,6 +3522,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_NS_FE("iterable", all, arginfo_iterable_all)
 	ZEND_NS_FE("iterable", none, arginfo_iterable_none)
 	ZEND_NS_FE("iterable", reduce, arginfo_iterable_reduce)
+	ZEND_NS_FE("iterable", find, arginfo_iterable_find)
 	ZEND_FE_END
 };
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 088e107c889f44d0a9762c47fce668f4d82f28ba */
+ * Stub hash: 1bbe2028d78f83db95e129acff83e14f57456f3e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2218,12 +2218,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_generate_ctrl_event
 ZEND_END_ARG_INFO()
 #endif
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_PHP_iterable_any, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterable_any, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, callback, IS_CALLABLE, 1, "null")
 ZEND_END_ARG_INFO()
 
-#define arginfo_PHP_iterable_all arginfo_PHP_iterable_any
+#define arginfo_iterable_all arginfo_iterable_any
 
 
 ZEND_FUNCTION(set_time_limit);
@@ -3501,8 +3501,8 @@ static const zend_function_entry ext_functions[] = {
 #if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_generate_ctrl_event, arginfo_sapi_windows_generate_ctrl_event)
 #endif
-	ZEND_NS_FE("PHP\\iterable", any, arginfo_PHP_iterable_any)
-	ZEND_NS_FE("PHP\\iterable", all, arginfo_PHP_iterable_all)
+	ZEND_NS_FE("iterable", any, arginfo_iterable_any)
+	ZEND_NS_FE("iterable", all, arginfo_iterable_all)
 	ZEND_FE_END
 };
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1bbe2028d78f83db95e129acff83e14f57456f3e */
+ * Stub hash: 59dd3527ae66c463cb59b6cc20b41d7fbdcc0ff0 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2225,6 +2225,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_iterable_all arginfo_iterable_any
 
+#define arginfo_iterable_none arginfo_iterable_any
+
 
 ZEND_FUNCTION(set_time_limit);
 ZEND_FUNCTION(header_register_callback);
@@ -2848,6 +2850,7 @@ ZEND_FUNCTION(sapi_windows_generate_ctrl_event);
 #endif
 ZEND_FUNCTION(any);
 ZEND_FUNCTION(all);
+ZEND_FUNCTION(none);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -3503,6 +3506,7 @@ static const zend_function_entry ext_functions[] = {
 #endif
 	ZEND_NS_FE("iterable", any, arginfo_iterable_any)
 	ZEND_NS_FE("iterable", all, arginfo_iterable_all)
+	ZEND_NS_FE("iterable", none, arginfo_iterable_none)
 	ZEND_FE_END
 };
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -2218,6 +2218,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sapi_windows_generate_ctrl_event
 ZEND_END_ARG_INFO()
 #endif
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_PHP_iterable_any, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, callback, IS_CALLABLE, 1, "null")
+ZEND_END_ARG_INFO()
+
+#define arginfo_PHP_iterable_all arginfo_PHP_iterable_any
+
 
 ZEND_FUNCTION(set_time_limit);
 ZEND_FUNCTION(header_register_callback);
@@ -2839,6 +2846,8 @@ ZEND_FUNCTION(sapi_windows_set_ctrl_handler);
 #if defined(PHP_WIN32)
 ZEND_FUNCTION(sapi_windows_generate_ctrl_event);
 #endif
+ZEND_FUNCTION(any);
+ZEND_FUNCTION(all);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -3492,6 +3501,8 @@ static const zend_function_entry ext_functions[] = {
 #if defined(PHP_WIN32)
 	ZEND_FE(sapi_windows_generate_ctrl_event, arginfo_sapi_windows_generate_ctrl_event)
 #endif
+	ZEND_NS_FE("PHP\\iterable", any, arginfo_PHP_iterable_any)
+	ZEND_NS_FE("PHP\\iterable", all, arginfo_PHP_iterable_all)
 	ZEND_FE_END
 };
 

--- a/ext/standard/tests/iterable/all_array.phpt
+++ b/ext/standard/tests/iterable/all_array.phpt
@@ -3,7 +3,7 @@ Test all() function
 --FILE--
 <?php
 
-use function PHP\iterable\all;
+use function iterable\all;
 
 /*
     Prototype: bool all(array $array, mixed $callback);
@@ -50,11 +50,11 @@ echo "\nDone";
 ?>
 --EXPECT--
 *** Testing not enough or wrong arguments ***
-Caught ArgumentCountError: PHP\iterable\all() expects at least 1 argument, 0 given
-Caught TypeError: PHP\iterable\all(): Argument #1 ($iterable) must be of type iterable, bool given
+Caught ArgumentCountError: iterable\all() expects at least 1 argument, 0 given
+Caught TypeError: iterable\all(): Argument #1 ($iterable) must be of type iterable, bool given
 bool(true)
-Caught TypeError: PHP\iterable\all(): Argument #1 ($iterable) must be of type iterable, bool given
-Caught TypeError: PHP\iterable\all(): Argument #2 ($callback) must be a valid callback, no array or string given
+Caught TypeError: iterable\all(): Argument #1 ($iterable) must be of type iterable, bool given
+Caught TypeError: iterable\all(): Argument #2 ($callback) must be a valid callback or null, no array or string given
 
 *** Testing basic functionality ***
 bool(true)

--- a/ext/standard/tests/iterable/all_array.phpt
+++ b/ext/standard/tests/iterable/all_array.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Test all() function
+--FILE--
+<?php
+
+use function PHP\iterable\all;
+
+/*
+    Prototype: bool all(array $array, mixed $callback);
+    Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($item)
+{
+    return is_int($item);
+}
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+function dump_all(...$args) {
+    try {
+        var_dump(all(...$args));
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+dump_all();
+dump_all(true);
+dump_all([]);
+dump_all(true, function () {});
+dump_all([], true);
+
+echo "\n*** Testing basic functionality ***\n";
+
+dump_all([1, 2, 3], 'is_int_ex');
+dump_all(['hello', 1, 2, 3], 'is_int_ex');
+$iterations = 0;
+dump_all(['hello', 1, 2, 3], function($item) use (&$iterations) {
+    ++$iterations;
+    return is_int($item);
+});
+var_dump($iterations);
+
+echo "\n*** Testing edge cases ***\n";
+
+dump_all([], 'is_int_ex');
+
+echo "\nDone";
+?>
+--EXPECT--
+*** Testing not enough or wrong arguments ***
+Caught ArgumentCountError: PHP\iterable\all() expects at least 1 argument, 0 given
+Caught TypeError: PHP\iterable\all(): Argument #1 ($iterable) must be of type iterable, bool given
+bool(true)
+Caught TypeError: PHP\iterable\all(): Argument #1 ($iterable) must be of type iterable, bool given
+Caught TypeError: PHP\iterable\all(): Argument #2 ($callback) must be a valid callback, no array or string given
+
+*** Testing basic functionality ***
+bool(true)
+bool(false)
+bool(false)
+int(1)
+
+*** Testing edge cases ***
+bool(true)
+
+Done

--- a/ext/standard/tests/iterable/all_traversable.phpt
+++ b/ext/standard/tests/iterable/all_traversable.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Test all() function
+--FILE--
+<?php
+
+use function php\iterable\all;
+
+/*
+    Prototype: bool all(array $array, ?callable $callback = null, int $use_type = 0);
+    Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($item)
+{
+    return is_int($item);
+}
+
+function dump_all(...$args) {
+    try {
+        var_dump(all(...$args));
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+dump_all(new ArrayIterator());
+dump_all(new ArrayIterator(), true);
+
+echo "\n*** Testing basic functionality ***\n";
+
+dump_all(new ArrayIterator([1, 2, 3]), 'is_int_ex');
+dump_all(new ArrayIterator(['hello', 1, 2, 3]), 'is_int_ex');
+$iterations = 0;
+dump_all(new ArrayIterator(['hello', 1, 2, 3]), function($item) use (&$iterations) {
+    ++$iterations;
+    return is_int($item);
+});
+var_dump($iterations);
+
+echo "\n*** Testing edge cases ***\n";
+
+dump_all(new ArrayIterator(), 'is_int_ex');
+
+echo "\nDone";
+?>
+--EXPECT--
+*** Testing not enough or wrong arguments ***
+bool(true)
+Caught TypeError: PHP\iterable\all(): Argument #2 ($callback) must be a valid callback, no array or string given
+
+*** Testing basic functionality ***
+bool(true)
+bool(false)
+bool(false)
+int(1)
+
+*** Testing edge cases ***
+bool(true)
+
+Done

--- a/ext/standard/tests/iterable/all_traversable.phpt
+++ b/ext/standard/tests/iterable/all_traversable.phpt
@@ -3,7 +3,7 @@ Test all() function
 --FILE--
 <?php
 
-use function php\iterable\all;
+use function iterable\all;
 
 /*
     Prototype: bool all(array $array, ?callable $callback = null, int $use_type = 0);
@@ -49,7 +49,7 @@ echo "\nDone";
 --EXPECT--
 *** Testing not enough or wrong arguments ***
 bool(true)
-Caught TypeError: PHP\iterable\all(): Argument #2 ($callback) must be a valid callback, no array or string given
+Caught TypeError: iterable\all(): Argument #2 ($callback) must be a valid callback or null, no array or string given
 
 *** Testing basic functionality ***
 bool(true)

--- a/ext/standard/tests/iterable/any_array.phpt
+++ b/ext/standard/tests/iterable/any_array.phpt
@@ -3,7 +3,7 @@ Test any() function
 --FILE--
 <?php
 
-use function PHP\iterable\any;
+use function iterable\any;
 
 /*
 	Prototype: bool any(array $iterable, mixed $callback);
@@ -59,11 +59,11 @@ echo "\nDone";
 ?>
 --EXPECT--
 *** Testing not enough or wrong arguments ***
-Caught ArgumentCountError: PHP\iterable\any() expects at least 1 argument, 0 given
-Caught TypeError: PHP\iterable\any(): Argument #1 ($iterable) must be of type iterable, bool given
+Caught ArgumentCountError: iterable\any() expects at least 1 argument, 0 given
+Caught TypeError: iterable\any(): Argument #1 ($iterable) must be of type iterable, bool given
 bool(false)
-Caught TypeError: PHP\iterable\any(): Argument #1 ($iterable) must be of type iterable, bool given
-Caught TypeError: PHP\iterable\any(): Argument #2 ($callback) must be a valid callback, no array or string given
+Caught TypeError: iterable\any(): Argument #1 ($iterable) must be of type iterable, bool given
+Caught TypeError: iterable\any(): Argument #2 ($callback) must be a valid callback or null, no array or string given
 
 *** Testing basic functionality ***
 bool(false)

--- a/ext/standard/tests/iterable/any_array.phpt
+++ b/ext/standard/tests/iterable/any_array.phpt
@@ -1,0 +1,81 @@
+--TEST--
+Test any() function
+--FILE--
+<?php
+
+use function PHP\iterable\any;
+
+/*
+	Prototype: bool any(array $iterable, mixed $callback);
+	Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($nr)
+{
+	return is_int($nr);
+}
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+function dump_any(...$args) {
+    try {
+        var_dump(any(...$args));
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+dump_any();
+dump_any(true);
+dump_any([]);
+dump_any(true, function () {});
+dump_any([], true);
+
+echo "\n*** Testing basic functionality ***\n";
+
+dump_any(['hello', 'world'], 'is_int_ex');
+dump_any(['hello', 1, 2, 3], 'is_int_ex');
+$iterations = 0;
+dump_any(['hello', 1, 2, 3], function($item) use (&$iterations) {
+	++$iterations;
+	return is_int($item);
+});
+var_dump($iterations);
+
+echo "\n*** Testing second argument to predicate ***\n";
+
+dump_any([1, 2, 3], function($item, $key) {
+	var_dump($key);
+	return false;
+});
+
+echo "\n*** Testing edge cases ***\n";
+
+dump_any([], 'is_int_ex');
+
+dump_any(['key' => 'x'], null);
+
+echo "\nDone";
+?>
+--EXPECT--
+*** Testing not enough or wrong arguments ***
+Caught ArgumentCountError: PHP\iterable\any() expects at least 1 argument, 0 given
+Caught TypeError: PHP\iterable\any(): Argument #1 ($iterable) must be of type iterable, bool given
+bool(false)
+Caught TypeError: PHP\iterable\any(): Argument #1 ($iterable) must be of type iterable, bool given
+Caught TypeError: PHP\iterable\any(): Argument #2 ($callback) must be a valid callback, no array or string given
+
+*** Testing basic functionality ***
+bool(false)
+bool(true)
+bool(true)
+int(2)
+
+*** Testing second argument to predicate ***
+Caught ArgumentCountError: Too few arguments to function {closure}(), 1 passed and exactly 2 expected
+
+*** Testing edge cases ***
+bool(false)
+bool(true)
+
+Done

--- a/ext/standard/tests/iterable/any_traversable.phpt
+++ b/ext/standard/tests/iterable/any_traversable.phpt
@@ -3,7 +3,7 @@ Test any() function
 --FILE--
 <?php
 
-use function PHP\iterable\any;
+use function iterable\any;
 
 /*
     Prototype: bool any(array $array, ?callable $callback = null, int $use_type = 0);
@@ -73,7 +73,7 @@ echo "\nDone";
 --EXPECT--
 *** Testing not enough or wrong arguments ***
 bool(false)
-Caught TypeError: PHP\iterable\any(): Argument #2 ($callback) must be a valid callback, no array or string given
+Caught TypeError: iterable\any(): Argument #2 ($callback) must be a valid callback or null, no array or string given
 
 *** Testing basic functionality ***
 bool(true)

--- a/ext/standard/tests/iterable/any_traversable.phpt
+++ b/ext/standard/tests/iterable/any_traversable.phpt
@@ -1,0 +1,100 @@
+--TEST--
+Test any() function
+--FILE--
+<?php
+
+use function PHP\iterable\any;
+
+/*
+    Prototype: bool any(array $array, ?callable $callback = null, int $use_type = 0);
+    Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($item)
+{
+    return is_int($item);
+}
+
+function dump_any(...$args) {
+    try {
+        var_dump(any(...$args));
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+dump_any(new ArrayIterator());
+dump_any(new ArrayIterator(), true);
+
+echo "\n*** Testing basic functionality ***\n";
+
+dump_any(new ArrayIterator([1, 2, 3]), 'is_int_ex');
+dump_any(new ArrayIterator(['hello', 1, 2, 3]), 'is_int_ex');
+$iterations = 0;
+dump_any(new ArrayIterator(['hello', 1, 2, 3]), function($item) use (&$iterations) {
+    ++$iterations;
+    return is_int($item);
+});
+var_dump($iterations);
+
+echo "\n*** Testing edge cases ***\n";
+
+dump_any(new ArrayIterator([[], 0, '', 'hello']), function($item) {
+    var_dump($item);
+    return $item;
+});
+
+dump_any(new ArrayIterator(), 'is_int_ex');
+
+dump_any(new ArrayObject(['key' => true]), null);
+
+echo "testing generator\n";
+function my_generator() {
+    yield false;
+    echo "Before returning []\n";
+    yield [];
+    echo "Before returning true\n";
+    yield true;
+    echo "Unreachable\n";
+}
+dump_any(my_generator());
+
+function my_other_generator() {
+    yield false;
+    echo "Before my_other_generator() end\n";
+}
+dump_any(my_other_generator());
+
+echo "\nDone";
+?>
+--EXPECT--
+*** Testing not enough or wrong arguments ***
+bool(false)
+Caught TypeError: PHP\iterable\any(): Argument #2 ($callback) must be a valid callback, no array or string given
+
+*** Testing basic functionality ***
+bool(true)
+bool(true)
+bool(true)
+int(2)
+
+*** Testing edge cases ***
+array(0) {
+}
+int(0)
+string(0) ""
+string(5) "hello"
+bool(true)
+bool(false)
+bool(true)
+testing generator
+Before returning []
+Before returning true
+bool(true)
+Before my_other_generator() end
+bool(false)
+
+Done

--- a/ext/standard/tests/iterable/find_array.phpt
+++ b/ext/standard/tests/iterable/find_array.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test find() function
+--FILE--
+<?php
+
+use function iterable\find;
+
+/*
+    Prototype: mixed iterable\find(array $array, callable($item): bool $callback, mixed $default = null);
+    Description: Iterate over iterable and either return the first element matching $callback or the default.
+*/
+
+function dump_find(...$args) {
+    try {
+        $result = find(...$args);
+        echo "Result: ";
+        var_dump($result);
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+// The result of strtolower/strtoupper is locale-dependent, meaning that it cannot be converted to a constant by opcache.
+dump_find([]);
+dump_find([], function ($value) { return false; }, strtoupper('default'));
+dump_find(explode(' ', strtolower('ABCDEF GHIJK LMNOP QRSTUV')), function (string $item): bool {
+    var_dump($item); return false;
+}, strtolower('DEFAULT'));
+
+dump_find(explode(' ', strtolower('ABCDEF GHIJK')), function (string $item): bool {
+    var_dump($item); return $item === 'ghijk';
+}, strtolower('DEFAULT'));
+
+?>
+--EXPECT--
+Caught ArgumentCountError: iterable\find() expects at least 2 arguments, 1 given
+Result: string(7) "DEFAULT"
+string(6) "abcdef"
+string(5) "ghijk"
+string(5) "lmnop"
+string(6) "qrstuv"
+Result: string(7) "default"
+string(6) "abcdef"
+string(5) "ghijk"
+Result: string(5) "ghijk"

--- a/ext/standard/tests/iterable/find_traversable.phpt
+++ b/ext/standard/tests/iterable/find_traversable.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Test find() function
+--FILE--
+<?php
+
+use function iterable\find;
+
+/*
+    Prototype: mixed iterable\find(array $array, callable($item): bool $callback, mixed $default = null);
+    Description: Iterate over iterable and either return the first element matching $callback or the default.
+*/
+
+function dump_find(...$args) {
+    try {
+        $result = find(...$args);
+        echo "Result: ";
+        var_dump($result);
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+var_dump(find(range(1, 5), fn(int $x): bool => $x * $x === 9));
+
+// The result of strtolower/strtoupper is locale-dependent, meaning that it cannot be converted to a constant by opcache.
+dump_find(new ArrayObject([]));
+dump_find(new ArrayObject([]), function ($value) { return false; }, strtoupper('default'));
+dump_find(new ArrayObject(explode(' ', strtolower('ABCDEF GHIJK LMNOP QRSTUV'))), function (string $item): bool {
+    var_dump($item); return false;
+}, strtolower('DEFAULT'));
+
+dump_find(new ArrayObject(explode(' ', strtolower('ABCDEF GHIJK'))), function (string $item): bool {
+    var_dump($item); return $item === 'ghijk';
+}, strtolower('DEFAULT'));
+
+?>
+--EXPECT--
+int(3)
+Caught ArgumentCountError: iterable\find() expects at least 2 arguments, 1 given
+Result: string(7) "DEFAULT"
+string(6) "abcdef"
+string(5) "ghijk"
+string(5) "lmnop"
+string(6) "qrstuv"
+Result: string(7) "default"
+string(6) "abcdef"
+string(5) "ghijk"
+Result: string(5) "ghijk"

--- a/ext/standard/tests/iterable/none_array.phpt
+++ b/ext/standard/tests/iterable/none_array.phpt
@@ -1,0 +1,81 @@
+--TEST--
+Test none() function
+--FILE--
+<?php
+
+use function iterable\none;
+
+/*
+	Prototype: bool none(array $iterable, mixed $callback);
+	Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($nr)
+{
+	return is_int($nr);
+}
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+function dump_none(...$args) {
+    try {
+        var_dump(none(...$args));
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+dump_none();
+dump_none(true);
+dump_none([]);
+dump_none(true, function () {});
+dump_none([], true);
+
+echo "\n*** Testing basic functionality ***\n";
+
+dump_none(['hello', 'world'], 'is_int_ex');
+dump_none(['hello', 1, 2, 3], 'is_int_ex');
+$iterations = 0;
+dump_none(['hello', 1, 2, 3], function($item) use (&$iterations) {
+	++$iterations;
+	return is_int($item);
+});
+var_dump($iterations);
+
+echo "\n*** Testing second argument to predicate ***\n";
+
+dump_none([1, 2, 3], function($item, $key) {
+	var_dump($key);
+	return false;
+});
+
+echo "\n*** Testing edge cases ***\n";
+
+dump_none([], 'is_int_ex');
+
+dump_none(['key' => 'x'], null);
+
+echo "\nDone";
+?>
+--EXPECT--
+*** Testing not enough or wrong arguments ***
+Caught ArgumentCountError: iterable\none() expects at least 1 argument, 0 given
+Caught TypeError: iterable\none(): Argument #1 ($iterable) must be of type iterable, bool given
+bool(true)
+Caught TypeError: iterable\none(): Argument #1 ($iterable) must be of type iterable, bool given
+Caught TypeError: iterable\none(): Argument #2 ($callback) must be a valid callback or null, no array or string given
+
+*** Testing basic functionality ***
+bool(true)
+bool(false)
+bool(false)
+int(2)
+
+*** Testing second argument to predicate ***
+Caught ArgumentCountError: Too few arguments to function {closure}(), 1 passed and exactly 2 expected
+
+*** Testing edge cases ***
+bool(true)
+bool(false)
+
+Done

--- a/ext/standard/tests/iterable/none_traversable.phpt
+++ b/ext/standard/tests/iterable/none_traversable.phpt
@@ -1,0 +1,100 @@
+--TEST--
+Test none() function
+--FILE--
+<?php
+
+use function iterable\none;
+
+/*
+    Prototype: bool none(array $array, ?callable $callback = null, int $use_type = 0);
+    Description: Iterate array and stop based on return value of callback
+*/
+
+function is_int_ex($item)
+{
+    return is_int($item);
+}
+
+function dump_none(...$args) {
+    try {
+        var_dump(none(...$args));
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+
+echo "\n*** Testing not enough or wrong arguments ***\n";
+
+dump_none(new ArrayIterator());
+dump_none(new ArrayIterator(), true);
+
+echo "\n*** Testing basic functionality ***\n";
+
+dump_none(new ArrayIterator([1, 2, 3]), 'is_int_ex');
+dump_none(new ArrayIterator(['hello', 1, 2, 3]), 'is_int_ex');
+$iterations = 0;
+dump_none(new ArrayIterator(['hello', 1, 2, 3]), function($item) use (&$iterations) {
+    ++$iterations;
+    return is_int($item);
+});
+var_dump($iterations);
+
+echo "\n*** Testing edge cases ***\n";
+
+dump_none(new ArrayIterator([[], 0, '', 'hello']), function($item) {
+    var_dump($item);
+    return $item;
+});
+
+dump_none(new ArrayIterator(), 'is_int_ex');
+
+dump_none(new ArrayObject(['key' => true]), null);
+
+echo "testing generator\n";
+function my_generator() {
+    yield false;
+    echo "Before returning []\n";
+    yield [];
+    echo "Before returning true\n";
+    yield true;
+    echo "Unreachable\n";
+}
+dump_none(my_generator());
+
+function my_other_generator() {
+    yield false;
+    echo "Before my_other_generator() end\n";
+}
+dump_none(my_other_generator());
+
+echo "\nDone";
+?>
+--EXPECT--
+*** Testing not enough or wrong arguments ***
+bool(true)
+Caught TypeError: iterable\none(): Argument #2 ($callback) must be a valid callback or null, no array or string given
+
+*** Testing basic functionality ***
+bool(false)
+bool(false)
+bool(false)
+int(2)
+
+*** Testing edge cases ***
+array(0) {
+}
+int(0)
+string(0) ""
+string(5) "hello"
+bool(false)
+bool(true)
+bool(false)
+testing generator
+Before returning []
+Before returning true
+bool(false)
+Before my_other_generator() end
+bool(true)
+
+Done

--- a/ext/standard/tests/iterable/reduce_array.phpt
+++ b/ext/standard/tests/iterable/reduce_array.phpt
@@ -20,15 +20,15 @@ function dump_reduce(...$args) {
 
 // The result of strtolower is locale-dependent, meaning that it cannot be converted to a constant by opcache.
 dump_reduce([]);
-dump_reduce([], function () {}, strtolower('TEST'));
-dump_reduce(['x', 'y', 'z'], function ($carry, $item) { $carry .= $item; return $carry; }, strtolower('TEST'));
-dump_reduce([strtolower('WORLD'), '!'], function ($carry, $item) { $carry .= $item; return $carry; }, strtolower('HELLO'));
-dump_reduce([strtolower('WORLD')], function (string $carry, string $item): string { return $carry . $item; }, strtolower('HELLO'));
+dump_reduce([], function () {});
+dump_reduce(['x', 'y', 'z'], function ($carry, $item) { $carry .= $item; return $carry; });
+dump_reduce([strtolower('WORLD'), '!'], function ($carry, $item) { $carry .= $item; return $carry; });
+dump_reduce([strtolower('WORLD')], function (string $carry, string $item): string { return $carry . $item; });
 
 ?>
 --EXPECT--
-Caught ArgumentCountError: iterable\reduce() expects at least 2 arguments, 1 given
-string(4) "test"
-string(7) "testxyz"
-string(11) "helloworld!"
-string(10) "helloworld"
+Caught ArgumentCountError: iterable\reduce() expects exactly 2 arguments, 1 given
+Caught ValueError: iterable\reduce(): Argument #1 ($iterable) must not be empty
+string(3) "xyz"
+string(6) "world!"
+string(5) "world"

--- a/ext/standard/tests/iterable/reduce_array.phpt
+++ b/ext/standard/tests/iterable/reduce_array.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test reduce() function
+--FILE--
+<?php
+
+use function iterable\reduce;
+
+/*
+    Prototype: mixed iterable\reduce(array $array, callable($carry, $item): mixed $callback);
+    Description: Iterate over iterable and reduce
+*/
+
+function dump_reduce(...$args) {
+    try {
+        var_dump(reduce(...$args));
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+// The result of strtolower is locale-dependent, meaning that it cannot be converted to a constant by opcache.
+dump_reduce([]);
+dump_reduce([], function () {}, strtolower('TEST'));
+dump_reduce(['x', 'y', 'z'], function ($carry, $item) { $carry .= $item; return $carry; }, strtolower('TEST'));
+dump_reduce([strtolower('WORLD'), '!'], function ($carry, $item) { $carry .= $item; return $carry; }, strtolower('HELLO'));
+dump_reduce([strtolower('WORLD')], function (string $carry, string $item): string { return $carry . $item; }, strtolower('HELLO'));
+
+?>
+--EXPECT--
+Caught ArgumentCountError: iterable\reduce() expects at least 2 arguments, 1 given
+string(4) "test"
+string(7) "testxyz"
+string(11) "helloworld!"
+string(10) "helloworld"

--- a/ext/standard/tests/iterable/reduce_traversable.phpt
+++ b/ext/standard/tests/iterable/reduce_traversable.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Test reduce() function on Traversable
+--FILE--
+<?php
+
+use function iterable\reduce;
+
+/*
+    Prototype: mixed iterable\reduce(array $array, callable($carry, $item): mixed $callback);
+    Description: Iterate over iterable and reduce
+*/
+
+function dump_reduce(...$args) {
+    try {
+        var_dump(reduce(...$args));
+    } catch (Error $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+function generate_strings() {
+    yield strtoupper('Hello');
+    yield ' ';
+    yield strtoupper('World!');
+    return strtoupper('UNUSED');
+}
+
+// The result of strtolower is locale-dependent, meaning that it cannot be converted to a constant by opcache. Also, test reference counting.
+dump_reduce(new ArrayObject([]));
+dump_reduce(new ArrayObject([]), function () {}, strtolower('TEST'));
+dump_reduce(new ArrayObject(['x', 'y', 'z']), function ($carry, $item) { $carry .= $item; return $carry; }, strtolower('TEST'));
+dump_reduce(new ArrayObject([strtolower('WORLD'), '!']), function ($carry, $item) { $carry .= $item; return $carry; }, strtolower('HELLO'));
+dump_reduce(new ArrayObject([strtolower('WORLD')]), function (string $carry, string $item): string { return $carry . $item; }, strtolower('HELLO'));
+dump_reduce(generate_strings(), function (string $carry, string $item): string { return $carry . $item; }, '');
+dump_reduce(generate_strings(), function ($carry, $item): string { $item = $carry . $item; unset($carry);return $item; }, '');
+// Passing by reference is not supported.
+dump_reduce(generate_strings(), function (string &$carry, string $item): string { $carry .= $item; return $carry;}, '');
+
+?>
+--EXPECTF--
+Caught ArgumentCountError: iterable\reduce() expects at least 2 arguments, 1 given
+string(4) "test"
+string(7) "testxyz"
+string(11) "helloworld!"
+string(10) "helloworld"
+string(12) "HELLO WORLD!"
+string(12) "HELLO WORLD!"
+
+Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in %s on line 12
+
+Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in %s on line 12
+
+Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in %s on line 12
+string(12) "HELLO WORLD!"

--- a/ext/standard/tests/iterable/reduce_traversable.phpt
+++ b/ext/standard/tests/iterable/reduce_traversable.phpt
@@ -46,7 +46,7 @@ string(5) "world"
 string(12) "HELLO WORLD!"
 string(12) "HELLO WORLD!"
 
-Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in /Users/levi.morrison/Projects/php/branch-master/ext/standard/tests/iterable/reduce_traversable.php on line 12
+Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in %s on line 12
 
-Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in /Users/levi.morrison/Projects/php/branch-master/ext/standard/tests/iterable/reduce_traversable.php on line 12
+Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in %s on line 12
 string(12) "HELLO WORLD!"

--- a/ext/standard/tests/iterable/reduce_traversable.phpt
+++ b/ext/standard/tests/iterable/reduce_traversable.phpt
@@ -27,28 +27,26 @@ function generate_strings() {
 
 // The result of strtolower is locale-dependent, meaning that it cannot be converted to a constant by opcache. Also, test reference counting.
 dump_reduce(new ArrayObject([]));
-dump_reduce(new ArrayObject([]), function () {}, strtolower('TEST'));
-dump_reduce(new ArrayObject(['x', 'y', 'z']), function ($carry, $item) { $carry .= $item; return $carry; }, strtolower('TEST'));
-dump_reduce(new ArrayObject([strtolower('WORLD'), '!']), function ($carry, $item) { $carry .= $item; return $carry; }, strtolower('HELLO'));
-dump_reduce(new ArrayObject([strtolower('WORLD')]), function (string $carry, string $item): string { return $carry . $item; }, strtolower('HELLO'));
-dump_reduce(generate_strings(), function (string $carry, string $item): string { return $carry . $item; }, '');
-dump_reduce(generate_strings(), function ($carry, $item): string { $item = $carry . $item; unset($carry);return $item; }, '');
+dump_reduce(new ArrayObject([]), function () {});
+dump_reduce(new ArrayObject(['x', 'y', 'z']), function ($carry, $item) { $carry .= $item; return $carry; });
+dump_reduce(new ArrayObject([strtolower('WORLD'), '!']), function ($carry, $item) { $carry .= $item; return $carry; });
+dump_reduce(new ArrayObject([strtolower('WORLD')]), function (string $carry, string $item): string { return $carry . $item; });
+dump_reduce(generate_strings(), function (string $carry, string $item): string { return $carry . $item; });
+dump_reduce(generate_strings(), function ($carry, $item): string { $item = $carry . $item; unset($carry);return $item; });
 // Passing by reference is not supported.
-dump_reduce(generate_strings(), function (string &$carry, string $item): string { $carry .= $item; return $carry;}, '');
+dump_reduce(generate_strings(), function (string &$carry, string $item): string { $carry .= $item; return $carry;});
 
 ?>
 --EXPECTF--
-Caught ArgumentCountError: iterable\reduce() expects at least 2 arguments, 1 given
-string(4) "test"
-string(7) "testxyz"
-string(11) "helloworld!"
-string(10) "helloworld"
+Caught ArgumentCountError: iterable\reduce() expects exactly 2 arguments, 1 given
+Caught ValueError: iterable\reduce(): Argument #1 ($iterable) must not be empty
+string(3) "xyz"
+string(6) "world!"
+string(5) "world"
 string(12) "HELLO WORLD!"
 string(12) "HELLO WORLD!"
 
-Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in %s on line 12
+Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in /Users/levi.morrison/Projects/php/branch-master/ext/standard/tests/iterable/reduce_traversable.php on line 12
 
-Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in %s on line 12
-
-Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in %s on line 12
+Warning: {closure}(): Argument #1 ($carry) must be passed by reference, value given in /Users/levi.morrison/Projects/php/branch-master/ext/standard/tests/iterable/reduce_traversable.php on line 12
 string(12) "HELLO WORLD!"


### PR DESCRIPTION
**EDIT (2021-06-01): The namespace changed from PHP\iterable\ to iterable\ and several functions were added**
TODO: Change namespace to `Iterable\`

This is an alternative approach to https://externals.io/message/103357 and https://github.com/php/php-src/pull/3597/files by `bugreportuser`
with the following changes:

- Having two different helpers for array/Traversable seemed like an unnecessary distinction since the return type was `bool`, unlike array_filter and array_map.
  Unify to any() and all() for arrays and Traversables
- Fix memory leaks for reference-counted keys such as strings
- Make the callback optional - check if the values are truthy if it is null.
- Move from the global namespace to `iterable\` after discussion of whether PHP should start using namespaces for new collections of internal functionality and collecting feedback on namespace choices - https://wiki.php.net/rfc/any_all_on_iterable_straw_poll_namespace#vote - After that vote was held, a different RFC https://wiki.php.net/rfc/namespaces_in_bundled_extensions passed forbidding vendored namespaces and `Spl\`
- Add none(), find(), reduce() after feedback by a significant fraction of voters opposed to the change (https://wiki.php.net/rfc/any_all_on_iterable#straw_poll) that this was too small in scope 

**The following can be used as a polyfill** (and also documents how this is meant to work)

```php
<?php

namespace iterable;

/**
 * Determines whether any element of the iterable satisfies the predicate.
 *
 *
 * If the value returned by the callback is truthy
 * (e.g. true, non-zero number, non-empty array, truthy object, etc.),
 * this is treated as satisfying the predicate.
 *
 * @param iterable $input
 * @param null|callable(mixed):mixed $callback
 */
function any(iterable $input, ?callable $callback = null): bool {
    foreach ($input as $v) {
        if ($callback !== null ? $callback($v) : $v) {
            return true;
        }
    }
    return false;
}

/**
 * Determines whether all elements of the iterable satisfy the predicate.
 *
 * If the value returned by the callback is truthy
 * (e.g. true, non-zero number, non-empty array, truthy object, etc.),
 * this is treated as satisfying the predicate.
 *
 * @param iterable $input
 * @param null|callable(mixed):mixed $callback
 */
function all(iterable $input, ?callable $callback = null): bool {
    foreach ($input as $v) {
        if (!($callback !== null ? $callback($v) : $v)) {
            return false;
        }
    }
    return true;
}

/**
 * Determines whether no elements of the iterable satisfies the predicate.
 *
 *
 * If the value returned by the callback is truthy
 * (e.g. true, non-zero number, non-empty array, truthy object, etc.),
 * this is treated as satisfying the predicate.
 *
 * @param iterable $input
 * @param null|callable(mixed):mixed $callback
 */
function none(iterable $input, ?callable $callback = null): bool {
    return !\iterable\any($input, $callback);
}

/**
 * Returns the first element of $input satisfying $callback, or returns $default
 * 
 * If the value returned by the callback is truthy
 * (e.g. true, non-zero number, non-empty array, truthy object, etc.),
 * this is treated as satisfying the predicate.
 */
function find(iterable $input, callable $callback, mixed $default = null): mixed {
    foreach ($input as $v) {
         if ($callback($v)) {
             return $v;
         }
    }
    return $default;
}

/**
 * Similar to array_reduce but also acts on Traversables.
 */
function reduce(iterable $input, callable $callback, mixed $initial = null): mixed {
    foreach ($input as $v) {
         $initial = $callback($initial, $input);
    }
    return $initial;
}
```

------

For example, the following code could be shortened significantly:

```php
// The old version
$satisifies_predicate = false;
foreach ($item_list as $item) {
    // Performs DB operations or external service requests, stops on first match by design.
    if (API::satisfiesCondition($item)) {
        $satisfies_predicate = true;
        break;
    }
}
if (!$satisfies_predicate) {
    throw new APIException("No matches found");
}
// more code....
```

```php
use function Iterable\any;
// ...

// The new version is much shorter, readable, and easier to review,
// without creating temporary variables or helper functions that are used in only one place.
 
// Performs DB operations or external service requests, stops on first match by design.
if (!any($item_list, fn($item) => API::satisfiesCondition($item))) {
    throw new APIException("No matches found");
}
```

----

Potential future scope:

- `Iterable\apply(iterable $input, callable(mixed):unused $callback)` (alternate names: walk/foreach_value) - Unlike `array_walk`, this does not convert array values to references and should avoid the resulting memory usage increase. Unlike https://www.php.net/iterator_apply - this passes the value - closure use variables are newer than iterator_apply.
- `Iterable\map(iterable $input, callable(mixed):mixed $callback): ImmutableKeyValueSequence`
- `Iterable\filter_entries(iterable $input, callable(mixed $value, mixed $key):bool $callback): ImmutableKeyValueSequence` (same arg order as ARRAY_FILTER_USE_BOTH)
- `Iterable\filter_values(iterable $input, callable(mixed $value):unused $callback = null): array` (discards keys and returns a list of values that satisfy the predicate (or are truthy) (with keys 0,1,2,3...))
- `Iterable\filter_keys(iterable $input, callable(mixed $key):bool $callback = null): array`
- `Iterable\is_empty(iterable $input): bool`
- `Iterable\keys(iterable $input): array` (like array_keys)
- `Iterable\values(iterable $input): array` (like array_values/iterator_to_array but working on both. returns a list of values)
- `Iterable\sorted_values(iterable $input): array` (like sort but (1) returns a sorted array instead of taking a reference, (2) also acts on Traversables)
- `Iterable\contains_value(iterable $input, mixed $value): bool` (contains_key seems redundant with ArrayAccess/array_key_exist)
- slice/chunk/flip
- any_key/all_key/no_key?
