### PR TITLE
Fix #54902: fseek inconsistencies with large (>2GB) files

### DIFF
--- a/ext/standard/tests/streams/bug54902.phpt
+++ b/ext/standard/tests/streams/bug54902.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #54902 (fseek inconsistencies with large (>2GB) files)
+--SKIPIF--
+<?php
+if (getenv('SKIP_SLOW_TESTS')) die('skip slow test');
+if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");
+if (disk_free_space(__DIR__) < 0xc0000000) die('skip not enough disk space');
+?>
+--FILE--
+<?php
+$data = str_repeat('ab', 4096);
+$stream = fopen(__DIR__ . '/bug54902.txt', 'w+');
+for ($i = 0; $i < 0x40001; ++$i) {
+    fwrite($stream, $data);
+}
+rewind($stream);
+
+var_dump(fseek($stream, 0x7fffffff, SEEK_SET));
+var_dump(ftell($stream));
+var_dump(fseek($stream, 1, SEEK_CUR));
+var_dump(ftell($stream));
+var_dump(fread($stream, 1));
+var_dump(ftell($stream));
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/bug54902.txt');
+?>
+--EXPECT--
+int(0)
+int(2147483647)
+int(-1)
+int(2147483647)
+string(0) ""
+int(2147483647)

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -528,6 +528,10 @@ fprintf(stderr, "stream_free: %s:%p[%s] preserve_handle=%d release_cast=%d remov
 
 PHPAPI void _php_stream_fill_read_buffer(php_stream *stream, size_t size)
 {
+	if (size > ZEND_LONG_MAX - stream->position) {
+		return FAILURE;
+	}
+
 	/* allocate/fill the buffer */
 
 	if (stream->readfilters.head) {
@@ -1257,6 +1261,9 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 		switch(whence) {
 			case SEEK_CUR:
 				if (offset > 0 && offset <= stream->writepos - stream->readpos) {
+					if (offset > ZEND_LONG_MAX - stream->position) {
+						return -1;
+					}
 					stream->readpos += offset; /* if offset = ..., then readpos = writepos */
 					stream->position += offset;
 					stream->eof = 0;


### PR DESCRIPTION
We store the stream position in a `zend_off_t` value, which is a signed
32bit value on 32bit systems.  That leads to overflow when the position
is beyond 2GB.  We catch that, and do no longer allow to read beyond
that position.

---

Note that I'm not actually suggesting to apply that (at least not to stable branches), because it would break the abitility to read files >= 2GB (and < 4GB) on 32bit systems. In my opinion the current behavior (you can read beyond 2GB, but you can't seek beyond that boundary) is a bug, but I don't see a good solution for that (besides implementing large file support on platforms where that is available, but even this might not be worth the trouble); see also my [comment on the bug ticket](https://bugs.php.net/bug.php?id=54902#1597414780). So I'm mainly bringing this forward to resolve that topic. Maybe WONTFIX and some documentation regarding the behavior is appropriate.

Also note that the patch is incomplete, because it does not address writing yet.
