### PR TITLE
Prepend compiler warning flags to CFLAG instead to append them

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -212,9 +212,9 @@ else
   AC_DEFINE(ZEND_DEBUG,0,[ ])
 fi
 
-test -n "$GCC" && CFLAGS="$CFLAGS -Wall -Wextra -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare"
+test -n "$GCC" && CFLAGS="-Wall -Wextra -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare $CFLAGS"
 dnl Check if compiler supports -Wno-clobbered (only GCC)
-AX_CHECK_COMPILE_FLAG([-Wno-clobbered], CFLAGS="$CFLAGS -Wno-clobbered", , [-Werror])
+AX_CHECK_COMPILE_FLAG([-Wno-clobbered], CFLAGS="-Wno-clobbered $CFLAGS", , [-Werror])
 
 test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"
 


### PR DESCRIPTION
Credit to @bwoebi for the idea, just running CI to see if this breaks anything.