### PR TITLE
Pass $origThis when calling __clone()

### DIFF
--- a/Zend/tests/bug73288.phpt
+++ b/Zend/tests/bug73288.phpt
@@ -28,7 +28,7 @@ test_clone();
 --EXPECTF--
 Fatal error: Uncaught Exception: No Cloneable in %sbug73288.php:%d
 Stack trace:
-#0 %s(%d): NoClone->__clone()
+#0 %s(%d): NoClone->__clone(Object(NoClone))
 #1 %s(%d): test_clone()
 #2 {main}
   thrown in %sbug73288.php on line %d

--- a/Zend/tests/errmsg_015.phpt
+++ b/Zend/tests/errmsg_015.phpt
@@ -1,14 +1,14 @@
 --TEST--
-errmsg: __clone() cannot accept any arguments
+errmsg: __clone() cannot take more than 1 argument
 --FILE--
 <?php
 
 class test {
-    function __clone($var) {
+    function __clone($origThis, $var) {
     }
 }
 
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Method test::__clone() cannot take arguments in %s on line %d
+Fatal error: Method test::__clone() cannot take more than 1 argument in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2134,7 +2134,10 @@ ZEND_API void zend_check_magic_method_implementation(const zend_class_entry *ce,
 		zend_check_magic_method_non_static(ce, fptr, error_type);
 		zend_check_magic_method_no_return_type(ce, fptr, error_type);
 	} else if (zend_string_equals_literal(lcname, ZEND_CLONE_FUNC_NAME)) {
-		zend_check_magic_method_args(0, ce, fptr, error_type);
+        if (fptr->common.num_args > 1) {
+            zend_error(error_type, "Method %s::__clone() cannot take more than 1 argument",
+                ZSTR_VAL(ce->name));
+        }
 		zend_check_magic_method_non_static(ce, fptr, error_type);
 		zend_check_magic_method_return_type(ce, fptr, error_type, MAY_BE_VOID);
 	} else if (zend_string_equals_literal(lcname, ZEND_GET_FUNC_NAME)) {

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -247,7 +247,9 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 
 	if (old_object->ce->clone) {
 		GC_ADDREF(new_object);
-		zend_call_known_instance_method_with_0_params(new_object->ce->clone, new_object, NULL);
+		zval old_object_param;
+		ZVAL_OBJ(&old_object_param, old_object);
+		zend_call_known_instance_method_with_1_params(new_object->ce->clone, new_object, NULL, &old_object_param);
 		OBJ_RELEASE(new_object);
 	}
 }

--- a/tests/classes/clone_with_orig_this.phpt
+++ b/tests/classes/clone_with_orig_this.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Clone method with parameter that accepts the original object.
+--FILE--
+<?php
+class Cl {
+    public $backupThis;
+
+    public function __construct() {
+        $this->backupThis = $this;
+    }
+
+    public function __clone(self $origThis) {
+        var_dump($origThis === $this->backupThis);
+        var_dump($origThis === $this);
+    }
+}
+
+$obj = new Cl();
+clone $obj;
+echo "Done\n";
+?>
+--EXPECT--
+bool(true)
+bool(false)
+Done


### PR DESCRIPTION
usecase: https://stackoverflow.com/questions/63675888/get-original-source-instance-in-clone

no BC break - user may accept this extra argument or declare function __clone() without any param like until now

with this change, user may declare __clone method like:
```
class Cl {
    function __clone(self $origThis): void {
        // example use
        $origCacheId = spl_object_hash($origThis);
    }
}
```