### PR TITLE
Fix better zend API changes

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -309,7 +309,7 @@ PHP 8.0 INTERNALS UPGRADE NOTES
         - zend_multibyte_set_filter()
         - zend_lex_tstring()
         - _zend_module_entry module_startup_func, module_shutdown_func,
-          request_startup_func, and request_shutdown_func function pointers
+          request_startup_func, request_shutdown_func, and post_deactivate_func function pointers
         - (*zend_encoding_list_parser) typedef
         - (*zend_encoding_internal_encoding_setter) typedef
         - zend_multibyte_set_functions()

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -180,6 +180,8 @@ PHP 8.0 INTERNALS UPGRADE NOTES
         - zend_stack_init()
         - zend_stack_del_top()
         - zend_stack_destroy()
+        - _zend_module_entry module_shutdown_func, request_shutdown_func,
+            and post_deactivate_func function pointers
      2. Argument int to uint32_t in Zend Engine 4.0:
         - _zend_get_parameters_array_ex()
         - zend_copy_parameters_array()
@@ -308,8 +310,7 @@ PHP 8.0 INTERNALS UPGRADE NOTES
         - zend_create_internal_iterator_zval()
         - zend_multibyte_set_filter()
         - zend_lex_tstring()
-        - _zend_module_entry module_startup_func, module_shutdown_func,
-          request_startup_func, request_shutdown_func, and post_deactivate_func function pointers
+        - _zend_module_entry module_startup_func, and request_startup_func function pointers
         - (*zend_encoding_list_parser) typedef
         - (*zend_encoding_internal_encoding_setter) typedef
         - zend_multibyte_set_functions()

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -183,10 +183,10 @@ typedef struct _zend_fcall_info_cache {
 
 /* Declaration macros */
 #define ZEND_MODULE_STARTUP_D(module)		zend_result ZEND_MODULE_STARTUP_N(module)(INIT_FUNC_ARGS)
-#define ZEND_MODULE_SHUTDOWN_D(module)		zend_result ZEND_MODULE_SHUTDOWN_N(module)(SHUTDOWN_FUNC_ARGS)
+#define ZEND_MODULE_SHUTDOWN_D(module)		void ZEND_MODULE_SHUTDOWN_N(module)(SHUTDOWN_FUNC_ARGS)
 #define ZEND_MODULE_ACTIVATE_D(module)		zend_result ZEND_MODULE_ACTIVATE_N(module)(INIT_FUNC_ARGS)
-#define ZEND_MODULE_DEACTIVATE_D(module)	zend_result ZEND_MODULE_DEACTIVATE_N(module)(SHUTDOWN_FUNC_ARGS)
-#define ZEND_MODULE_POST_ZEND_DEACTIVATE_D(module)	zend_result ZEND_MODULE_POST_ZEND_DEACTIVATE_N(module)(void)
+#define ZEND_MODULE_DEACTIVATE_D(module)	void ZEND_MODULE_DEACTIVATE_N(module)(SHUTDOWN_FUNC_ARGS)
+#define ZEND_MODULE_POST_ZEND_DEACTIVATE_D(module)	void ZEND_MODULE_POST_ZEND_DEACTIVATE_N(module)(void)
 #define ZEND_MODULE_INFO_D(module)			ZEND_COLD void ZEND_MODULE_INFO_N(module)(ZEND_MODULE_INFO_FUNC_ARGS)
 #define ZEND_MODULE_GLOBALS_CTOR_D(module)  void ZEND_MODULE_GLOBALS_CTOR_N(module)(zend_##module##_globals *module##_globals)
 #define ZEND_MODULE_GLOBALS_DTOR_D(module)  void ZEND_MODULE_GLOBALS_DTOR_N(module)(zend_##module##_globals *module##_globals)

--- a/Zend/zend_modules.h
+++ b/Zend/zend_modules.h
@@ -91,7 +91,7 @@ struct _zend_module_entry {
 #endif
 	void (*globals_ctor)(void *global);
 	void (*globals_dtor)(void *global);
-	int (*post_deactivate_func)(void);
+	zend_result (*post_deactivate_func)(void);
 	int module_started;
 	unsigned char type;
 	void *handle;

--- a/Zend/zend_modules.h
+++ b/Zend/zend_modules.h
@@ -78,9 +78,9 @@ struct _zend_module_entry {
 	const char *name;
 	const struct _zend_function_entry *functions;
 	zend_result (*module_startup_func)(INIT_FUNC_ARGS);
-	zend_result (*module_shutdown_func)(SHUTDOWN_FUNC_ARGS);
+	void (*module_shutdown_func)(SHUTDOWN_FUNC_ARGS);
 	zend_result (*request_startup_func)(INIT_FUNC_ARGS);
-	zend_result (*request_shutdown_func)(SHUTDOWN_FUNC_ARGS);
+	void (*request_shutdown_func)(SHUTDOWN_FUNC_ARGS);
 	void (*info_func)(ZEND_MODULE_INFO_FUNC_ARGS);
 	const char *version;
 	size_t globals_size;
@@ -91,7 +91,7 @@ struct _zend_module_entry {
 #endif
 	void (*globals_ctor)(void *global);
 	void (*globals_dtor)(void *global);
-	zend_result (*post_deactivate_func)(void);
+	void (*post_deactivate_func)(void);
 	int module_started;
 	unsigned char type;
 	void *handle;


### PR DESCRIPTION
Forgot to change the return type of the ``post_deactivate_func()`` function entry in ``_zend_module_entry `` thanks to @MartaSadowskaBarankiewicz for pointing this out.

However I wonder if it's not best to voidify them as the result of calling them is never used internally, thoughts @nikic?