### PR TITLE
Fix #80048: Bug #69100 has not been fixed for Windows

### DIFF
--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -786,15 +786,11 @@ static int php_stdiop_set_option(php_stream *stream, int option, int value, void
 						}
 
 						size = GetFileSize(hfile, NULL);
-						if (range->length == 0 && range->offset > 0 && range->offset < size) {
-							range->length = size - range->offset;
-						}
-						if (range->length == 0 || range->length > size) {
-							range->length = size;
-						}
-						if (range->offset >= size) {
+						if (range->offset > size) {
 							range->offset = size;
-							range->length = 0;
+						}
+						if (range->length == 0 || range->length > size - range->offset) {
+							range->length = size - range->offset;
 						}
 
 						/* figure out how big a chunk to map to be able to view the part that we need */


### PR DESCRIPTION
We fix the erroneous length calculation on Windows, too.