### PR TITLE
Extract common flock code

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2498,15 +2498,11 @@ PHP_METHOD(SplFileObject, getCsvControl)
 }
 /* }}} */
 
-static int flock_values[] = { LOCK_SH, LOCK_EX, LOCK_UN };
-
-/* {{{ Portable file locking, copy pasted from ext/standard/file.c flock() function.
- * This is done to prevent this to fail if flock is disabled via disable_functions */
+/* {{{ Portable file locking */
 PHP_METHOD(SplFileObject, flock)
 {
 	spl_filesystem_object *intern = Z_SPLFILESYSTEM_P(ZEND_THIS);
 	zval *wouldblock = NULL;
-	int act;
 	zend_long operation = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|z", &operation, &wouldblock) == FAILURE) {
@@ -2515,25 +2511,11 @@ PHP_METHOD(SplFileObject, flock)
 
 	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
-	act = operation & PHP_LOCK_UN;
-	if (act < 1 || act > 3) {
+	if (FAILURE == php_flock_common(intern->u.file.stream, operation, wouldblock, return_value)) {
 		zend_argument_value_error(1, "must be either LOCK_SH, LOCK_EX, or LOCK_UN");
 		RETURN_THROWS();
 	}
-
-	if (wouldblock) {
-		ZEND_TRY_ASSIGN_REF_LONG(wouldblock, 0);
-	}
-
-	/* flock_values contains all possible actions if (operation & PHP_LOCK_NB) we won't block on the lock */
-	act = flock_values[act - 1] | (operation & PHP_LOCK_NB ? LOCK_NB : 0);
-	if (php_stream_lock(intern->u.file.stream, act)) {
-		if (operation && errno == EWOULDBLOCK && wouldblock) {
-			ZEND_TRY_ASSIGN_REF_LONG(wouldblock, 1);
-		}
-		RETURN_FALSE;
-	}
-	RETURN_TRUE;
+	/* return_value is already set by php_parse_flock_arguments */
 }
 /* }}} */
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2511,11 +2511,7 @@ PHP_METHOD(SplFileObject, flock)
 
 	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
-	if (FAILURE == php_flock_common(intern->u.file.stream, operation, wouldblock, return_value)) {
-		zend_argument_value_error(1, "must be either LOCK_SH, LOCK_EX, or LOCK_UN");
-		RETURN_THROWS();
-	}
-	/* return_value is already set by php_parse_flock_arguments */
+	php_flock_common(intern->u.file.stream, operation, 1, wouldblock, return_value);
 }
 /* }}} */
 

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -44,6 +44,7 @@ PHPAPI int php_copy_file_ctx(const char *src, const char *dest, int src_chk, php
 PHPAPI int php_mkdir_ex(const char *dir, zend_long mode, int options);
 PHPAPI int php_mkdir(const char *dir, zend_long mode);
 PHPAPI void php_fstat(php_stream *stream, zval *return_value);
+PHPAPI zend_result php_flock_common(php_stream *stream, zend_long operation, zval *wouldblock, zval *return_value);
 
 #define PHP_CSV_NO_ESCAPE EOF
 PHPAPI void php_fgetcsv(php_stream *stream, char delimiter, char enclosure, int escape_char, size_t buf_len, char *buf, zval *return_value);

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -44,7 +44,8 @@ PHPAPI int php_copy_file_ctx(const char *src, const char *dest, int src_chk, php
 PHPAPI int php_mkdir_ex(const char *dir, zend_long mode, int options);
 PHPAPI int php_mkdir(const char *dir, zend_long mode);
 PHPAPI void php_fstat(php_stream *stream, zval *return_value);
-PHPAPI zend_result php_flock_common(php_stream *stream, zend_long operation, zval *wouldblock, zval *return_value);
+PHPAPI void php_flock_common(php_stream *stream, zend_long operation, uint32_t operation_arg_num,
+	zval *wouldblock, zval *return_value);
 
 #define PHP_CSV_NO_ESCAPE EOF
 PHPAPI void php_fgetcsv(php_stream *stream, char delimiter, char enclosure, int escape_char, size_t buf_len, char *buf, zval *return_value);


### PR DESCRIPTION
I've extracted the flock code common to file and SPL @cmb69, not sure about the naming because `php_flock()` is already used moreover should this go into the flock compat layer or in file.c ?