### PR TITLE
Expose curl api

### DIFF
--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -82,5 +82,6 @@ int main(int argc, char *argv[])
   ])
 
   PHP_NEW_EXTENSION(curl, interface.c multi.c share.c curl_file.c, $ext_shared)
+  PHP_INSTALL_HEADERS([ext/curl], [php_curl.h])
   PHP_SUBST(CURL_SHARED_LIBADD)
 fi

--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -29,6 +29,7 @@ if (PHP_CURL != "no") {
 		EXTENSION("curl", "interface.c multi.c share.c curl_file.c");
 		AC_DEFINE('HAVE_CURL', 1, 'Have cURL library');
 		ADD_FLAG("CFLAGS_CURL", "/D CURL_STATICLIB");
+		PHP_INSTALL_HEADERS("ext/curl", "php_curl.h");
 		// TODO: check for curl_version_info
 	} else {
 		WARNING("curl not enabled; libraries and headers not found");

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -50,7 +50,7 @@
 
 /* CurlMultiHandle class */
 
-static zend_class_entry *curl_multi_ce;
+zend_class_entry *curl_multi_ce;
 
 static inline php_curlm *curl_multi_from_obj(zend_object *obj) {
 	return (php_curlm *)((char *)(obj) - XtOffsetOf(php_curlm, std));

--- a/ext/curl/php_curl.h
+++ b/ext/curl/php_curl.h
@@ -171,6 +171,7 @@ static inline php_curlsh *curl_share_from_obj(zend_object *obj) {
 #define Z_CURL_SHARE_P(zv) curl_share_from_obj(Z_OBJ_P(zv))
 
 PHP_CURL_API extern zend_class_entry *curl_ce;
+PHP_CURL_API extern zend_class_entry *curl_multi_ce;
 PHP_CURL_API extern zend_class_entry *curl_share_ce;
 
 void curl_multi_register_class(const zend_function_entry *method_entries);


### PR DESCRIPTION
In an extension, to accept a `CurlHandle` or `CurlMultiHandle` as an argument of a function/method, I would write something like:
```C
#include "ext/curl/php_curl.h"

ZEND_PARSE_PARAMETERS_START(1, 1)
    Z_PARAM_OBJECT_OF_CLASS(zid, curl_ce)
ZEND_PARSE_PARAMETERS_END();

/* or */
ZEND_PARSE_PARAMETERS_START(1, 1)
    Z_PARAM_OBJECT_OF_CLASS(zid, curl_multi_ce)
ZEND_PARSE_PARAMETERS_END();
```

But in order to do that, two things needs to be changed:

1. `ext/curl/php_curl.h` must be installed.
2. `curl_multi_ce` must also be accessible.

This PR addresses this.

Thanks