### PR TITLE
Adjust assignment line number for match

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -3063,6 +3063,7 @@ void zend_compile_assign(znode *result, zend_ast *ast) /* {{{ */
 			zend_delayed_compile_var(&var_node, var_ast, BP_VAR_W, 0);
 			zend_compile_expr(&expr_node, expr_ast);
 			zend_delayed_compile_end(offset);
+			CG(zend_lineno) = zend_ast_get_lineno(var_ast);
 			zend_emit_op_tmp(result, ZEND_ASSIGN, &var_node, &expr_node);
 			return;
 		case ZEND_AST_STATIC_PROP:

--- a/sapi/phpdbg/tests/match_breakpoints_001.phpt
+++ b/sapi/phpdbg/tests/match_breakpoints_001.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test match default breakpoint with variable assignment
+--INI--
+opcache.enable_cli=0
+--PHPDBG--
+b 5
+b 10
+r
+q
+--EXPECTF--
+[Successful compilation of %s.php]
+prompt> [Breakpoint #0 added at %s.php:5]
+prompt> [Breakpoint #1 added at %s.php:10]
+prompt> [Breakpoint #1 at %s.php:10, hits: 1]
+>00010:     default => 'bar',
+ 00011: };
+ 00012: 
+prompt>
+--FILE--
+<?php
+
+$foo = match (0) {
+    0 => 'foo',
+    default => 'bar',
+};
+
+$foo = match (1) {
+    0 => 'foo',
+    default => 'bar',
+};

--- a/sapi/phpdbg/tests/match_breakpoints_002.phpt
+++ b/sapi/phpdbg/tests/match_breakpoints_002.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test match default breakpoint with property assignment
+--INI--
+opcache.enable_cli=0
+--PHPDBG--
+b 7
+b 12
+r
+q
+--EXPECTF--
+[Successful compilation of %s.php]
+prompt> [Breakpoint #0 added at %s.php:7]
+prompt> [Breakpoint #1 added at %s.php:12]
+prompt> [Breakpoint #1 at %s.php:12, hits: 1]
+>00012:     default => 'bar',
+ 00013: };
+ 00014: 
+prompt>
+--FILE--
+<?php
+
+$foo = new stdClass();
+
+$foo->bar = match (0) {
+    0 => 'foo',
+    default => 'bar',
+};
+
+$foo->bar = match (1) {
+    0 => 'foo',
+    default => 'bar',
+};

--- a/sapi/phpdbg/tests/match_breakpoints_003.phpt
+++ b/sapi/phpdbg/tests/match_breakpoints_003.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test match default breakpoint with dim assignment
+--INI--
+opcache.enable_cli=0
+--PHPDBG--
+b 7
+b 12
+r
+q
+--EXPECTF--
+[Successful compilation of %s.php]
+prompt> [Breakpoint #0 added at %s.php:7]
+prompt> [Breakpoint #1 added at %s.php:12]
+prompt> [Breakpoint #1 at %s.php:12, hits: 1]
+>00012:     default => 'bar',
+ 00013: };
+ 00014: 
+prompt>
+--FILE--
+<?php
+
+$foo = [];
+
+$foo['foo'] = match (0) {
+    0 => 'foo',
+    default => 'bar',
+};
+
+$foo->bar = match (1) {
+    0 => 'foo',
+    default => 'bar',
+};

--- a/sapi/phpdbg/tests/match_breakpoints_004.phpt
+++ b/sapi/phpdbg/tests/match_breakpoints_004.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test match default breakpoint with static variable assignment
+--INI--
+opcache.enable_cli=0
+--PHPDBG--
+b 9
+b 14
+r
+q
+--EXPECTF--
+[Successful compilation of %s.php]
+prompt> [Breakpoint #0 added at %s.php:9]
+prompt> [Breakpoint #1 added at %s.php:14]
+prompt> [Breakpoint #1 at %s.php:14, hits: 1]
+>00014:     default => 'bar',
+ 00015: };
+ 00016: 
+prompt>
+--FILE--
+<?php
+
+class Foo {
+    public static $bar;
+}
+
+Foo::$bar = match (0) {
+    0 => 'foo',
+    default => 'bar',
+};
+
+Foo::$bar = match (1) {
+    0 => 'foo',
+    default => 'bar',
+};


### PR DESCRIPTION
Otherwise the assignment will have the same number as the default arm which will 1. mis-trigger a breakpoint and 2. mark the line as covered even when it isn't.

/cc @derickr

@nikic The line number does not need to be reset, right? Tests are passing but I don't think line numbers are extensively tested.