### PR TITLE
Drop freetype from i386

### DIFF
--- a/azure/i386/apt.yml
+++ b/azure/i386/apt.yml
@@ -40,7 +40,6 @@ steps:
                               libpq-dev:i386 \
                               libreadline-dev:i386 \
                               libffi-dev:i386 \
-                              libfreetype6-dev:i386 \
                               libsodium-dev:i386 \
                               ${{ parameters.packages }}
     displayName: 'APT'

--- a/azure/i386/apt.yml
+++ b/azure/i386/apt.yml
@@ -7,7 +7,7 @@ steps:
       sudo apt-get update -y | true
       sudo apt-get install -y gcc-multilib
       sudo apt-get install -y g++-multilib
-      sudo apt-get purge -y libxml2 libsqlite3-0
+      sudo apt-get purge -y libxml2
       # TODO: Reenable postgresql + postgresql-contrib packages once they work again.
       sudo apt-get install -y bison \
                               re2c \

--- a/azure/i386/apt.yml
+++ b/azure/i386/apt.yml
@@ -9,7 +9,7 @@ steps:
       sudo apt-get install -y g++-multilib
       sudo apt-get purge -y libxml2
       # TODO: Reenable postgresql + postgresql-contrib packages once they work again.
-      sudo apt-get purge -y postgresql
+      sudo apt-get purge -y libpq5
       sudo apt-get install -y bison \
                               re2c \
                               locales \

--- a/azure/i386/apt.yml
+++ b/azure/i386/apt.yml
@@ -40,6 +40,7 @@ steps:
                               libpq-dev:i386 \
                               libreadline-dev:i386 \
                               libffi-dev:i386 \
+                              libfreetype6-dev:i386 \
                               libsodium-dev:i386 \
                               ${{ parameters.packages }}
     displayName: 'APT'

--- a/azure/i386/apt.yml
+++ b/azure/i386/apt.yml
@@ -9,6 +9,7 @@ steps:
       sudo apt-get install -y g++-multilib
       sudo apt-get purge -y libxml2
       # TODO: Reenable postgresql + postgresql-contrib packages once they work again.
+      sudo apt-get purge -y postgresql
       sudo apt-get install -y bison \
                               re2c \
                               locales \

--- a/azure/i386/job.yml
+++ b/azure/i386/job.yml
@@ -31,6 +31,7 @@ jobs:
             --enable-gd \
             --with-jpeg \
             --with-webp \
+            --with-freetype \
             --with-xpm \
             --enable-exif \
             --with-zip \

--- a/azure/i386/job.yml
+++ b/azure/i386/job.yml
@@ -31,7 +31,6 @@ jobs:
             --enable-gd \
             --with-jpeg \
             --with-webp \
-            --with-freetype \
             --with-xpm \
             --enable-exif \
             --with-zip \


### PR DESCRIPTION
We're picking up the amd64 library again -- not the first time
this happens...