### PR TITLE
Improve handling of `#[` attributes in `php -a`

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -518,7 +518,7 @@ TODO:
 	}
 	if (text[0] == '$') {
 		retval = cli_completion_generator_var(text, textlen, &cli_completion_state);
-	} else if (text[0] == '#') {
+	} else if (text[0] == '#' && text[1] != '[') {
 		retval = cli_completion_generator_ini(text, textlen, &cli_completion_state);
 	} else {
 		char *lc_text, *class_name_end;
@@ -630,7 +630,7 @@ static int readline_shell_run(void) /* {{{ */
 
 		len = strlen(line);
 
-		if (line[0] == '#') {
+		if (line[0] == '#' && line[1] != '[') {
 			char *param = strstr(&line[1], "=");
 			if (param) {
 				zend_string *cmd;


### PR DESCRIPTION
a.k.a. "The handling of `#[` in `php -a` is terrible, are we sure we're OK with it?"

PHP treats `#ini_setting=value` as a call to
`ini_set('ini_setting', 'value')` *(only in `php -a`)* ,
and silently skips undeclared settings.

This is a problem due to `#[` becoming supported attribute syntax:

- `#[Attr] const X = 123;` (this is not a valid place to put an attribute)
  This does not create a constant.
- `#[Attr] function test($x=false){}` also contains `=`.
  This does not create a function.

Instead, only treat lines starting with `#` as a special case
when the next character isn't `[`