### PR TITLE
Improve handling of `#[` attributes in `php -a` (finding end of statement)

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -250,6 +250,10 @@ static int cli_is_valid_code(char *code, size_t len, zend_string **prompt) /* {{
 						code_type = dstring;
 						break;
 					case '#':
+						if (code[i+1] == '[') {
+							valid_end = 0;
+							break;
+						}
 						code_type = comment_line;
 						break;
 					case '/':


### PR DESCRIPTION
a.k.a. "The handling of `#[` in `php -a` is still terrible, are we sure we're OK with it?"

`php -a` treats lines starting with `#` as comments when deciding if
the provided statement is valid.

So it passed `#[MyAttr]` to the parser after the user hits enter,
causing a syntax error for multi-line statements..

With this patch, the following snippet is parsed correctly

```
php > #[Attr]
php > function x() { }
php > var_export((new ReflectionFunction('x'))->getAttributes()[0]->getName());
'Attr'
php > echo "test"; # my comment
test
php > echo "test"; #
test
```

Followup to GH-6085