### PR TITLE
Fix incorrect/unused macro

### DIFF
--- a/Zend/zend_ts_hash.h
+++ b/Zend/zend_ts_hash.h
@@ -128,6 +128,6 @@ END_EXTERN_C()
 	ZEND_TS_INIT_SYMTABLE_EX(ht, 2, 0)
 
 #define ZEND_TS_INIT_SYMTABLE_EX(ht, n, persistent)			\
-	zend_ts_hash_init(ht, n, NULL, ZVAL_PTR_DTOR, persistent)
+	zend_ts_hash_init(ht, n, ZVAL_PTR_DTOR, persistent)
 
 #endif							/* ZEND_HASH_H */


### PR DESCRIPTION
zend_ts_hash_init accepts 4 arguments, not 5.
The pHashFunction parameter was removed in 5d2576264653c2faaca9cd7d64218d10ab612408

Alternately, the macro could just be removed, since this wasn't reported and nothing would be using it?