### PR TITLE
Fix #72941: Modifying bucket->data by-ref has no effect any longer

### DIFF
--- a/ext/standard/tests/filters/bug72941.phpt
+++ b/ext/standard/tests/filters/bug72941.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #72941 (Modifying bucket->data by-ref has no effect any longer)
+--FILE--
+<?php
+class rotate_filter_nw extends php_user_filter
+{
+    function filter($in, $out, &$consumed, $closing)
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $this->rotate($bucket->data);
+            $consumed += $bucket->datalen;
+            stream_bucket_prepend($out, $bucket);
+        }
+
+        return PSFS_PASS_ON;
+    }
+
+    function rotate(&$data)
+    {
+        $n = strlen($data);
+        for ($i = 0; $i < $n - 1; ++$i) {
+            $data[$i] = $data[$i + 1];
+        }
+    }
+}
+
+stream_filter_register("rotator_notWorking", rotate_filter_nw::class);
+$stream = fopen('php://memory', 'w+');
+fwrite($stream, 'hello, world');
+rewind($stream);
+stream_filter_append($stream, "rotator_notWorking");
+var_dump(stream_get_contents($stream));
+?>
+--EXPECT--
+string(12) "ello, worldd"

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -448,19 +448,15 @@ static void php_stream_bucket_attach(int append, INTERNAL_FUNCTION_PARAMETERS)
 		RETURN_FALSE;
 	}
 
-	if (NULL != (pzdata = zend_hash_str_find(Z_OBJPROP_P(zobject), "data", sizeof("data")-1))) {
-		zval zdata;
-		ZVAL_COPY_DEREF(&zdata, pzdata);
-		if (Z_TYPE_P(&zdata) == IS_STRING) {
-			if (!bucket->own_buf) {
-				bucket = php_stream_bucket_make_writeable(bucket);
-			}
-			if (bucket->buflen != Z_STRLEN_P(&zdata)) {
-				bucket->buf = perealloc(bucket->buf, Z_STRLEN_P(&zdata), bucket->is_persistent);
-				bucket->buflen = Z_STRLEN_P(&zdata);
-			}
-			memcpy(bucket->buf, Z_STRVAL_P(&zdata), bucket->buflen);
+	if (NULL != (pzdata = zend_hash_str_find_deref(Z_OBJPROP_P(zobject), "data", sizeof("data")-1)) && Z_TYPE_P(pzdata) == IS_STRING) {
+		if (!bucket->own_buf) {
+			bucket = php_stream_bucket_make_writeable(bucket);
 		}
+		if (bucket->buflen != Z_STRLEN_P(pzdata)) {
+			bucket->buf = perealloc(bucket->buf, Z_STRLEN_P(pzdata), bucket->is_persistent);
+			bucket->buflen = Z_STRLEN_P(pzdata);
+		}
+		memcpy(bucket->buf, Z_STRVAL_P(pzdata), bucket->buflen);
 	}
 
 	if (append) {

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -434,7 +434,7 @@ static void php_stream_bucket_attach(int append, INTERNAL_FUNCTION_PARAMETERS)
 		Z_PARAM_OBJECT(zobject)
 	ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
 
-	if (NULL == (pzbucket = zend_hash_str_find(Z_OBJPROP_P(zobject), "bucket", sizeof("bucket")-1))) {
+	if (NULL == (pzbucket = zend_hash_str_find_deref(Z_OBJPROP_P(zobject), "bucket", sizeof("bucket")-1))) {
 		php_error_docref(NULL, E_WARNING, "Object has no bucket property");
 		RETURN_FALSE;
 	}


### PR DESCRIPTION
To match the PHP 5 behavior, we have to explicitly cater to `data`
being a reference.

---

Given that this regression has been introduced in PHP 7.0.0, that the bug report didn't get much traction, and that using references here might not be the best idea anyway, I'm fine with treating the ticket as doc issue.