### PR TITLE
phar: use crc32 bulk method instead.

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -2374,7 +2374,7 @@ int phar_open_executed_filename(char *alias, size_t alias_len, char **error) /* 
 int phar_postprocess_file(phar_entry_data *idata, uint32_t crc32, char **error, int process_zip) /* {{{ */
 {
 	uint32_t crc = ~0;
-	int len = idata->internal_file->uncompressed_filesize;
+	int len = idata->internal_file->uncompressed_filesize, ret;
 	php_stream *fp = idata->fp;
 	phar_entry_info *entry = idata->internal_file;
 
@@ -2439,11 +2439,11 @@ int phar_postprocess_file(phar_entry_data *idata, uint32_t crc32, char **error, 
 
 	php_stream_seek(fp, idata->zero, SEEK_SET);
 
-	crc = crc32_stream_bulk_update(crc, fp, len);
+	ret = crc32_stream_bulk_update(&crc, fp, len);
 
 	php_stream_seek(fp, idata->zero, SEEK_SET);
 
-	if (~crc == crc32) {
+	if (SUCCESS == ret && ~crc == crc32) {
 		entry->is_crc_checked = 1;
 		return SUCCESS;
 	} else {
@@ -2794,7 +2794,7 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 			return EOF;
 		}
 		newcrc32 = ~0;
-		newcrc32 = crc32_stream_bulk_update(newcrc32, file, entry->uncompressed_filesize);
+		crc32_stream_bulk_update(&newcrc32, file, entry->uncompressed_filesize);
 		entry->crc32 = ~newcrc32;
 		entry->is_crc_checked = 1;
 		if (!(entry->flags & PHAR_ENT_COMPRESSION_MASK)) {

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -914,7 +914,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 		efp = phar_get_efp(entry, 0);
 		newcrc32 = ~0;
 
-		newcrc32 = crc32_stream_bulk_update(newcrc32, efp, entry->uncompressed_filesize);
+		crc32_stream_bulk_update(&newcrc32, efp, entry->uncompressed_filesize);
 
 		entry->crc32 = ~newcrc32;
 		PHAR_SET_32(central.uncompsize, entry->uncompressed_filesize);

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -882,7 +882,6 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 
 	/* do extra field for perms later */
 	if (entry->is_modified) {
-		uint32_t loc;
 		php_stream_filter *filter;
 		php_stream *efp;
 
@@ -915,9 +914,7 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 		efp = phar_get_efp(entry, 0);
 		newcrc32 = ~0;
 
-		for (loc = 0;loc < entry->uncompressed_filesize; ++loc) {
-			CRC32(newcrc32, php_stream_getc(efp));
-		}
+		newcrc32 = crc32_stream_bulk_update(newcrc32, efp, entry->uncompressed_filesize);
 
 		entry->crc32 = ~newcrc32;
 		PHAR_SET_32(central.uncompsize, entry->uncompressed_filesize);

--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -89,6 +89,46 @@ static uint32_t crc32_aarch64(uint32_t crc, char *p, size_t nr) {
 # endif
 #endif
 
+uint32_t crc32_bulk_update(uint32_t crc, const char *p, size_t nr)
+{
+#if HAVE_AARCH64_CRC32
+	if (has_crc32_insn()) {
+		crc = crc32_aarch64(crc, p, nr);
+		return crc;
+	}
+#endif
+
+#if ZEND_INTRIN_SSE4_2_PCLMUL_NATIVE || ZEND_INTRIN_SSE4_2_PCLMUL_RESOLVER
+	size_t nr_simd = crc32_x86_simd_update(X86_CRC32B, &crc, (const unsigned char *)p, nr);
+	nr -= nr_simd;
+	p += nr_simd;
+#endif
+
+	/* The trailing part */
+	for (; nr--; ++p) {
+		crc = ((crc >> 8) & 0x00FFFFFF) ^ crc32tab[(crc ^ (*p)) & 0xFF ];
+	}
+
+	return crc;
+}
+
+uint32_t crc32_stream_bulk_update(uint32_t crc, php_stream *fp, size_t nr)
+{
+	size_t handled = 0, n;
+	char buf[1024];
+
+	while (handled < nr) {
+		n = nr - handled;
+		n = (n < sizeof(buf)) ? n : sizeof(buf); /* tweak to buf size */
+
+		php_stream_read(fp, buf, n);
+		crc = crc32_bulk_update(crc, buf, n);
+		handled += n;
+	}
+
+	return crc;
+}
+
 /* {{{ Calculate the crc32 polynomial of a string */
 PHP_FUNCTION(crc32)
 {
@@ -103,22 +143,8 @@ PHP_FUNCTION(crc32)
 
 	crc = crcinit^0xFFFFFFFF;
 
-#if HAVE_AARCH64_CRC32
-	if (has_crc32_insn()) {
-		crc = crc32_aarch64(crc, p, nr);
-		RETURN_LONG(crc^0xFFFFFFFF);
-	}
-#endif
+	crc = crc32_bulk_update(crc, p, nr);
 
-#if ZEND_INTRIN_SSE4_2_PCLMUL_NATIVE || ZEND_INTRIN_SSE4_2_PCLMUL_RESOLVER
-	size_t nr_simd = crc32_x86_simd_update(X86_CRC32B, &crc, (const unsigned char *)p, nr);
-	nr -= nr_simd;
-	p += nr_simd;
-#endif
-
-	for (; nr--; ++p) {
-		crc = ((crc >> 8) & 0x00FFFFFF) ^ crc32tab[(crc ^ (*p)) & 0xFF ];
-	}
 	RETURN_LONG(crc^0xFFFFFFFF);
 }
 /* }}} */

--- a/ext/standard/crc32.h
+++ b/ext/standard/crc32.h
@@ -25,7 +25,8 @@
 
 uint32_t crc32_bulk_update(uint32_t crc, const char *p, size_t nr);
 
-uint32_t crc32_stream_bulk_update(uint32_t crc, php_stream *fp, size_t nr);
+/* Return FAILURE if stream reading fail */
+int crc32_stream_bulk_update(uint32_t *crc, php_stream *fp, size_t nr);
 
 /* generated using the AUTODIN II polynomial
  *	x^32 + x^26 + x^23 + x^22 + x^16 +

--- a/ext/standard/crc32.h
+++ b/ext/standard/crc32.h
@@ -23,6 +23,10 @@
 
 #define CRC32(crc, ch)	 (crc = (crc >> 8) ^ crc32tab[(crc ^ (ch)) & 0xff])
 
+uint32_t crc32_bulk_update(uint32_t crc, const char *p, size_t nr);
+
+uint32_t crc32_stream_bulk_update(uint32_t crc, php_stream *fp, size_t nr);
+
 /* generated using the AUTODIN II polynomial
  *	x^32 + x^26 + x^23 + x^22 + x^16 +
  *	x^12 + x^11 + x^10 + x^8 + x^7 + x^5 + x^4 + x^2 + x^1 + 1


### PR DESCRIPTION
Benefit from the hardware crc32 computing.

Signed-off-by: Frank Du <frank.du@intel.com>