### PR TITLE
Make argument type error message consistent for variadics

### DIFF
--- a/Zend/tests/arrow_functions/006.phpt
+++ b/Zend/tests/arrow_functions/006.phpt
@@ -41,4 +41,4 @@ array(3) {
   [2]=>
   int(30)
 }
-{closure}(): Argument #2 ($args) must be of type ?int, string given, called in %s on line %d
+{closure}(): Argument #2 must be of type ?int, string given, called in %s on line %d

--- a/Zend/tests/function_arguments/variadic_argument_type_error.phpt
+++ b/Zend/tests/function_arguments/variadic_argument_type_error.phpt
@@ -19,5 +19,5 @@ try {
 
 ?>
 --EXPECTF--
-foo(): Argument #2 ($bar) must be of type int, array given, called in %s on line %d
-foo(): Argument #4 ($bar) must be of type int, array given, called in %s on line %d
+foo(): Argument #2 must be of type int, array given, called in %s on line %d
+foo(): Argument #4 must be of type int, array given, called in %s on line %d

--- a/Zend/tests/variadic/typehint_error.phpt
+++ b/Zend/tests/variadic/typehint_error.phpt
@@ -33,7 +33,7 @@ array(3) {
   }
 }
 
-Fatal error: Uncaught TypeError: test(): Argument #3 ($args) must be of type array, int given, called in %s:%d
+Fatal error: Uncaught TypeError: test(): Argument #3 must be of type array, int given, called in %s:%d
 Stack trace:
 #0 %s(%d): test(Array, Array, 2)
 #1 {main}

--- a/Zend/tests/variadic/typehint_suppressed_error.phpt
+++ b/Zend/tests/variadic/typehint_suppressed_error.phpt
@@ -15,4 +15,4 @@ try {
 
 ?>
 --EXPECTF--
-string(%d) "test(): Argument #3 ($args) must be of type array, int given, called in %s on line %d"
+string(%d) "test(): Argument #3 must be of type array, int given, called in %s on line %d"

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -701,23 +701,16 @@ ZEND_API ZEND_COLD void zend_verify_arg_error(
 	zend_verify_type_error_common(
 		zf, arg_info, value, &fname, &fsep, &fclass, &need_msg, &given_msg);
 
-	if (zf->common.type == ZEND_USER_FUNCTION) {
-		if (ptr && ptr->func && ZEND_USER_CODE(ptr->func->common.type)) {
-			zend_type_error("%s%s%s(): Argument #%d ($%s) must be of type %s, %s given, called in %s on line %d",
-				fclass, fsep, fname,
-				arg_num, ZSTR_VAL(arg_info->name),
-				ZSTR_VAL(need_msg), given_msg,
-				ZSTR_VAL(ptr->func->op_array.filename), ptr->opline->lineno
-			);
-		} else {
-			zend_type_error("%s%s%s(): Argument #%d ($%s) must be of type %s, %s given",
-				fclass, fsep, fname, arg_num, ZSTR_VAL(arg_info->name), ZSTR_VAL(need_msg), given_msg
-			);
-		}
-	} else {
-		zend_type_error("%s%s%s(): Argument #%d ($%s) must be of type %s, %s given",
-			fclass, fsep, fname, arg_num, ((zend_internal_arg_info*) arg_info)->name, ZSTR_VAL(need_msg), given_msg
+	ZEND_ASSERT(zf->common.type == ZEND_USER_FUNCTION
+		&& "Arginfo verification is not performed for internal functions");
+	if (ptr && ptr->func && ZEND_USER_CODE(ptr->func->common.type)) {
+		zend_argument_type_error(arg_num, "must be of type %s, %s given, called in %s on line %d",
+			ZSTR_VAL(need_msg), given_msg,
+			ZSTR_VAL(ptr->func->op_array.filename), ptr->opline->lineno
 		);
+	} else {
+		zend_argument_type_error(arg_num,
+			"must be of type %s, %s given", ZSTR_VAL(need_msg), given_msg);
 	}
 
 	zend_string_release(need_msg);


### PR DESCRIPTION
If an argument error refers to a variadic argument, we normally
do not print the name of the variadic (as it is not referring to
an individual argument, but to the collection of all of them).
However, this was not the case for the userland argument type
error message, which did it's own formatting.