### PR TITLE
Built-in web server: Don't write to stderr if not an error

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -754,14 +754,14 @@ static void sapi_cli_server_register_variables(zval *track_vars_array) /* {{{ */
 
 static void sapi_cli_server_log_write(int type, const char *msg) /* {{{ */
 {
-    FILE *out;
+	FILE *out;
 	char buf[52];
 
 	if (php_cli_server_log_level < type) {
 		return;
 	}
 
-    out = type==PHP_CLI_SERVER_LOG_ERROR ? stderr : stdout;
+	out = type==PHP_CLI_SERVER_LOG_ERROR ? stderr : stdout;
 	if (php_cli_server_get_system_time(buf) != 0) {
 		memmove(buf, "unknown time, can't be fetched", sizeof("unknown time, can't be fetched"));
 	} else {

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -761,7 +761,7 @@ static void sapi_cli_server_log_write(int type, const char *msg) /* {{{ */
 		return;
 	}
 
-	out = type==PHP_CLI_SERVER_LOG_ERROR ? stderr : stdout;
+	out = type == PHP_CLI_SERVER_LOG_ERROR ? stderr : stdout;
 	if (php_cli_server_get_system_time(buf) != 0) {
 		memmove(buf, "unknown time, can't be fetched", sizeof("unknown time, can't be fetched"));
 	} else {

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -754,12 +754,14 @@ static void sapi_cli_server_register_variables(zval *track_vars_array) /* {{{ */
 
 static void sapi_cli_server_log_write(int type, const char *msg) /* {{{ */
 {
+    FILE *out;
 	char buf[52];
 
 	if (php_cli_server_log_level < type) {
 		return;
 	}
 
+    out = type==PHP_CLI_SERVER_LOG_ERROR ? stderr : stdout;
 	if (php_cli_server_get_system_time(buf) != 0) {
 		memmove(buf, "unknown time, can't be fetched", sizeof("unknown time, can't be fetched"));
 	} else {
@@ -772,12 +774,12 @@ static void sapi_cli_server_log_write(int type, const char *msg) /* {{{ */
 	}
 #ifdef HAVE_FORK
 	if (php_cli_server_workers_max > 1) {
-		fprintf(stderr, "[%ld] [%s] %s\n", (long) getpid(), buf, msg);
+		fprintf(out, "[%ld] [%s] %s\n", (long) getpid(), buf, msg);
 	} else {
-		fprintf(stderr, "[%s] %s\n", buf, msg);
+		fprintf(out, "[%s] %s\n", buf, msg);
 	}
 #else
-	fprintf(stderr, "[%s] %s\n", buf, msg);
+	fprintf(out, "[%s] %s\n", buf, msg);
 #endif
 } /* }}} */
 


### PR DESCRIPTION
The built-in web server currently shows normal messages and error messages in the terminal. If normal messages would be written to `stdout` and error messages to `stderr`, then it would give users the possibility to handle them differently. 
Here's the output from the built-in web server:

```
$ php -S localhost:8000 router.php
[Fri Sep  4 21:05:05 2020] PHP 7.4.9 Development Server (http://localhost:8000) started
[Fri Sep  4 21:05:14 2020] 127.0.0.1:51158 Accepted
[Fri Sep  4 21:05:14 2020] 127.0.0.1:51158 Closing
[Fri Sep  4 21:05:14 2020] 127.0.0.1:51160 Accepted
[Fri Sep  4 21:05:14 2020] 127.0.0.1:51160 Closing
[Fri Sep  4 21:05:15 2020] 127.0.0.1:51161 Accepted
```

What problem does this PR solve, why does this matter? For static site generators. When you want to test a website on your computer before uploading it to your production web server. With this patch you could run the built-in web server in "silent mode" and still show useful error messages. For example by closing stdout or redirecting it to `/dev/null`.

See also [#68334](https://bugs.php.net/bug.php?id=68334) and [comments in #60832](https://bugs.php.net/bug.php?id=60832).

