### PR TITLE
[Observer] Fatal error support

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1323,6 +1323,16 @@ static ZEND_COLD void zend_error_impl(
 
 	zend_observer_error_notify(type, error_filename, error_lineno, message);
 
+	/* Call all the observer end handlers for fatal errors */
+	if (ZEND_OBSERVER_ENABLED && (type & E_FATAL_ERRORS) && EG(current_execute_data)) {
+		zend_execute_data *ex = EG(current_execute_data);
+		do {
+			if (ex->func->type != ZEND_INTERNAL_FUNCTION) {
+				zend_observer_fcall_end(ex, NULL);
+			}
+		} while ((ex = ex->prev_execute_data) != NULL);
+	}
+
 	/* if we don't have a user defined error handler */
 	if (Z_TYPE(EG(user_error_handler)) == IS_UNDEF
 		|| !(EG(user_error_handler_error_reporting) & type)

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1329,6 +1329,11 @@ static ZEND_COLD void zend_error_impl(
 		do {
 			if (ex->func->type != ZEND_INTERNAL_FUNCTION) {
 				zend_observer_fcall_end(ex, NULL);
+				/* If an extension catches a fatal error and raises another one, the
+				 * observer end handlers will fire more than once. This requires us
+				 * to "unobserve" the functions after the end handlers have fired the
+				 * first time. */
+				zend_observer_fcall_unobserve(ex->func);
 			}
 		} while ((ex = ex->prev_execute_data) != NULL);
 	}

--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -210,6 +210,15 @@ ZEND_API void ZEND_FASTCALL zend_observer_fcall_end(
 	}
 }
 
+ZEND_API void zend_observer_fcall_unobserve(zend_function *func)
+{
+	if (ZEND_OBSERVER_ENABLED
+		&& ZEND_OBSERVABLE_FN(func->common.fn_flags)
+		&& ZEND_OBSERVER_DATA(&func->op_array)) {
+		ZEND_OBSERVER_DATA(&func->op_array) = ZEND_OBSERVER_NOT_OBSERVED;
+	}
+}
+
 ZEND_API void zend_observer_error_register(zend_observer_error_cb cb)
 {
 	zend_llist_add_element(&zend_observer_error_callbacks, &cb);

--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -70,6 +70,8 @@ ZEND_API void ZEND_FASTCALL zend_observer_fcall_end(
 	zend_execute_data *execute_data,
 	zval *return_value);
 
+ZEND_API void zend_observer_fcall_unobserve(zend_function *func);
+
 typedef void (*zend_observer_error_cb)(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
 
 ZEND_API void zend_observer_error_register(zend_observer_error_cb callback);

--- a/ext/zend_test/tests/observer_call_user_func_01.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_01.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Observer: call_user_func() from root namespace
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+namespace Test {
+    final class MyClass
+    {
+        public static function myMethod()
+        {
+            echo 'MyClass::myMethod called' . PHP_EOL;
+        }
+    }
+
+    function my_function()
+    {
+        echo 'my_function called' . PHP_EOL;
+    }
+}
+namespace {
+    call_user_func('Test\\MyClass::myMethod');
+    call_user_func('Test\\my_function');
+}
+?>
+--EXPECTF--
+<!-- init '%s/observer_call_user_func_%d.php' -->
+<file '%s/observer_call_user_func_%d.php'>
+  <!-- init Test\MyClass::myMethod() -->
+  <Test\MyClass::myMethod>
+MyClass::myMethod called
+  </Test\MyClass::myMethod>
+  <!-- init Test\my_function() -->
+  <Test\my_function>
+my_function called
+  </Test\my_function>
+</file '%s/observer_call_user_func_%d.php'>

--- a/ext/zend_test/tests/observer_call_user_func_02.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_02.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Observer: call_user_func_array() from root namespace
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+namespace Test {
+    final class MyClass
+    {
+        public static function myMethod(string $msg)
+        {
+            echo 'MyClass::myMethod ' . $msg . PHP_EOL;
+        }
+    }
+
+    function my_function(string $msg)
+    {
+        echo 'my_function ' . $msg . PHP_EOL;
+    }
+}
+namespace {
+    call_user_func_array('Test\\MyClass::myMethod', ['called']);
+    call_user_func_array('Test\\my_function', ['called']);
+}
+?>
+--EXPECTF--
+<!-- init '%s/observer_call_user_func_%d.php' -->
+<file '%s/observer_call_user_func_%d.php'>
+  <!-- init Test\MyClass::myMethod() -->
+  <Test\MyClass::myMethod>
+MyClass::myMethod called
+  </Test\MyClass::myMethod>
+  <!-- init Test\my_function() -->
+  <Test\my_function>
+my_function called
+  </Test\my_function>
+</file '%s/observer_call_user_func_%d.php'>

--- a/ext/zend_test/tests/observer_call_user_func_03.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_03.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Observer: call_user_func() from namespace
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+namespace Test {
+    final class MyClass
+    {
+        public static function myMethod()
+        {
+            echo 'MyClass::myMethod called' . PHP_EOL;
+        }
+    }
+
+    function my_function()
+    {
+        echo 'my_function called' . PHP_EOL;
+    }
+
+    call_user_func('Test\\MyClass::myMethod');
+    call_user_func('Test\\my_function');
+}
+?>
+--EXPECTF--
+<!-- init '%s/observer_call_user_func_%d.php' -->
+<file '%s/observer_call_user_func_%d.php'>
+  <!-- init Test\MyClass::myMethod() -->
+  <Test\MyClass::myMethod>
+MyClass::myMethod called
+  </Test\MyClass::myMethod>
+  <!-- init Test\my_function() -->
+  <Test\my_function>
+my_function called
+  </Test\my_function>
+</file '%s/observer_call_user_func_%d.php'>

--- a/ext/zend_test/tests/observer_call_user_func_04.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_04.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Observer: call_user_func_array() from namespace
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+namespace Test {
+    final class MyClass
+    {
+        public static function myMethod(string $msg)
+        {
+            echo 'MyClass::myMethod ' . $msg . PHP_EOL;
+        }
+    }
+
+    function my_function(string $msg)
+    {
+        echo 'my_function ' . $msg . PHP_EOL;
+    }
+
+    call_user_func_array('Test\\MyClass::myMethod', ['called']);
+    call_user_func_array('Test\\my_function', ['called']);
+}
+?>
+--EXPECTF--
+<!-- init '%s/observer_call_user_func_%d.php' -->
+<file '%s/observer_call_user_func_%d.php'>
+  <!-- init Test\MyClass::myMethod() -->
+  <Test\MyClass::myMethod>
+MyClass::myMethod called
+  </Test\MyClass::myMethod>
+  <!-- init Test\my_function() -->
+  <Test\my_function>
+my_function called
+  </Test\my_function>
+</file '%s/observer_call_user_func_%d.php'>

--- a/ext/zend_test/tests/observer_error_01.phpt
+++ b/ext/zend_test/tests/observer_error_01.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Observer: End handlers fire after a fatal error
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+memory_limit=1M
+--FILE--
+<?php
+function foo()
+{
+    str_repeat('.', 1024 * 1024 * 2); // 2MB
+}
+
+foo();
+
+echo 'You should not see this.';
+?>
+--EXPECTF--
+<!-- init '%s/observer_error_%d.php' -->
+<file '%s/observer_error_%d.php'>
+  <!-- init foo() -->
+  <foo>
+  </foo:NULL>
+</file '%s/observer_error_%d.php'>
+
+Fatal error: Allowed memory size of 2097152 bytes exhausted%s(tried to allocate %d bytes) in %s on line %d

--- a/ext/zend_test/tests/observer_error_02.phpt
+++ b/ext/zend_test/tests/observer_error_02.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Observer: End handlers fire after a userland fatal error
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+function foo()
+{
+    trigger_error('Foo error', E_USER_ERROR);
+}
+
+foo();
+
+echo 'You should not see this.';
+?>
+--EXPECTF--
+<!-- init '%s/observer_error_%d.php' -->
+<file '%s/observer_error_%d.php'>
+  <!-- init foo() -->
+  <foo>
+  </foo:NULL>
+</file '%s/observer_error_%d.php'>
+
+Fatal error: Foo error in %s on line %d

--- a/ext/zend_test/tests/observer_error_03.phpt
+++ b/ext/zend_test/tests/observer_error_03.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Observer: non-fatal errors do not fire end handlers prematurely
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+function foo()
+{
+    return $this_does_not_exit; // E_WARNING
+}
+
+function main()
+{
+    foo();
+    echo 'After error.' . PHP_EOL;
+}
+
+main();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_error_%d.php' -->
+<file '%s/observer_error_%d.php'>
+  <!-- init main() -->
+  <main>
+    <!-- init foo() -->
+    <foo>
+
+Warning: Undefined variable $this_does_not_exit in %s on line %d
+    </foo:NULL>
+After error.
+  </main:NULL>
+Done.
+</file '%s/observer_error_%d.php'>

--- a/ext/zend_test/tests/observer_error_04.phpt
+++ b/ext/zend_test/tests/observer_error_04.phpt
@@ -11,12 +11,8 @@ zend_test.observer.show_return_value=1
 <?php
 function foo()
 {
-    try {
-        // ext/soap catches a fatal error and then throws an exception
-        $client = new SoapClient('foo');
-    } catch (SoapFault $e) {
-        echo $e->getMessage() . PHP_EOL;
-    }
+    // ext/soap catches a fatal error and then throws an exception
+    $client = new SoapClient('foo');
 }
 
 function main()
@@ -24,7 +20,12 @@ function main()
     foo();
 }
 
-main();
+// try/catch is on main() to ensure ZEND_HANDLE_EXCEPTION does not fire the end handlers again
+try {
+    main();
+} catch (SoapFault $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
 
 echo 'Done.' . PHP_EOL;
 ?>

--- a/ext/zend_test/tests/observer_error_04.phpt
+++ b/ext/zend_test/tests/observer_error_04.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Observer: fatal errors caught with zend_try will fire end handlers once
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+<?php if (!extension_loaded('soap')) die('skip: soap extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+function foo()
+{
+    try {
+        // ext/soap catches a fatal error and then throws an exception
+        $client = new SoapClient('foo');
+    } catch (SoapFault $e) {
+        echo $e->getMessage() . PHP_EOL;
+    }
+}
+
+function main()
+{
+    foo();
+}
+
+main();
+
+echo 'Done.' . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_error_%d.php' -->
+<file '%s/observer_error_%d.php'>
+  <!-- init main() -->
+  <main>
+    <!-- init foo() -->
+    <foo>
+    </foo:NULL>
+  </main:NULL>
+</file '%s/observer_error_%d.php'>
+SOAP-ERROR: Parsing WSDL: Couldn't load from 'foo' : failed to load external entity "foo"
+
+Done.

--- a/ext/zend_test/tests/observer_generator_05.phpt
+++ b/ext/zend_test/tests/observer_generator_05.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Observer: Generator with uncaught exception
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+function fooResults() {
+    yield 0;
+    yield 1;
+    throw new RuntimeException('Oops!');
+}
+
+function doSomething() {
+    $generator = fooResults();
+    foreach ($generator as $value) {
+        echo $value . PHP_EOL;
+    }
+
+    return 'You should not see this';
+}
+
+echo doSomething() . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_generator_%d.php' -->
+<file '%s/observer_generator_%d.php'>
+  <!-- init doSomething() -->
+  <doSomething>
+    <!-- init fooResults() -->
+    <fooResults>
+    </fooResults:0>
+0
+    <fooResults>
+    </fooResults:1>
+1
+    <fooResults>
+      <!-- Exception: RuntimeException -->
+    </fooResults:NULL>
+    <!-- Exception: RuntimeException -->
+  </doSomething:NULL>
+  <!-- Exception: RuntimeException -->
+</file '%s/observer_generator_%d.php'>
+
+Fatal error: Uncaught RuntimeException: Oops! in %s/observer_generator_%d.php:%d
+Stack trace:
+#0 %s/observer_generator_%d.php(%d): fooResults()
+#1 %s/observer_generator_%d.php(%d): doSomething()
+#2 {main}
+  thrown in %s/observer_generator_%d.php on line %d


### PR DESCRIPTION
This is another follow up PR to #5857. 

This fixes an issue where fatal errors would not call the observer end handlers. And also adds a few missing tests.