### PR TITLE
Bugfix 80097: Have ReflectionAttribute implement Reflector, __toString

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6412,8 +6412,8 @@ ZEND_METHOD(ReflectionAttribute, __toString)
 
 	GET_REFLECTION_OBJECT_PTR(attr);
 
-	smart_str_append_printf(&str, "Attribute [ ");
-	smart_str_append_printf(&str, "%s", ZSTR_VAL(attr->data->name));
+	smart_str_appends(&str, "Attribute [ ");
+	smart_str_append(&str, "%s", attr->data->name);
 	smart_str_append_printf(&str, " ]");
 
 	if (attr->data->argc > 0) {

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -680,13 +680,15 @@ final class ReflectionReference
     private function __construct() {}
 }
 
-final class ReflectionAttribute
+final class ReflectionAttribute implements Reflector
 {
     public function getName(): string {}
     public function getTarget(): int {}
     public function isRepeated(): bool {}
     public function getArguments(): array {}
     public function newInstance(): object {}
+
+    public function __toString(): string {}
 
     private function __clone(): void {}
 

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b7cb399903fb1965ba6294c4dcf9364539e93b5b */
+ * Stub hash: 3a424463071c9252fd0b6551d8b6e794f139f8f7 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -539,6 +539,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionAttribute_newInstance, 0, 0, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_ReflectionAttribute___toString arginfo_class_ReflectionFunction___toString
+
 #define arginfo_class_ReflectionAttribute___clone arginfo_class_ReflectionFunctionAbstract___clone
 
 #define arginfo_class_ReflectionAttribute___construct arginfo_class_ReflectionReference___construct
@@ -794,6 +796,7 @@ ZEND_METHOD(ReflectionAttribute, getTarget);
 ZEND_METHOD(ReflectionAttribute, isRepeated);
 ZEND_METHOD(ReflectionAttribute, getArguments);
 ZEND_METHOD(ReflectionAttribute, newInstance);
+ZEND_METHOD(ReflectionAttribute, __toString);
 ZEND_METHOD(ReflectionAttribute, __clone);
 ZEND_METHOD(ReflectionAttribute, __construct);
 ZEND_METHOD(ReflectionEnum, __construct);
@@ -1117,6 +1120,7 @@ static const zend_function_entry class_ReflectionAttribute_methods[] = {
 	ZEND_ME(ReflectionAttribute, isRepeated, arginfo_class_ReflectionAttribute_isRepeated, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionAttribute, getArguments, arginfo_class_ReflectionAttribute_getArguments, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionAttribute, newInstance, arginfo_class_ReflectionAttribute_newInstance, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionAttribute, __toString, arginfo_class_ReflectionAttribute___toString, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionAttribute, __clone, arginfo_class_ReflectionAttribute___clone, ZEND_ACC_PRIVATE)
 	ZEND_ME(ReflectionAttribute, __construct, arginfo_class_ReflectionAttribute___construct, ZEND_ACC_PRIVATE)
 	ZEND_FE_END
@@ -1412,13 +1416,14 @@ static zend_class_entry *register_class_ReflectionReference(void)
 	return class_entry;
 }
 
-static zend_class_entry *register_class_ReflectionAttribute(void)
+static zend_class_entry *register_class_ReflectionAttribute(zend_class_entry *class_entry_Reflector)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReflectionAttribute", class_ReflectionAttribute_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+	zend_class_implements(class_entry, 1, class_entry_Reflector);
 
 	return class_entry;
 }

--- a/ext/reflection/tests/ReflectionAttribute_toString.phpt
+++ b/ext/reflection/tests/ReflectionAttribute_toString.phpt
@@ -1,0 +1,26 @@
+--TEST--
+ReflectionAttribute::__toString
+--FILE--
+<?php
+
+#[Foo, Bar(a: "foo", b: 1234), Baz("foo", 1234)]
+function foo() {}
+
+$refl = new ReflectionFunction('foo');
+echo $refl->getAttributes()[0];
+echo $refl->getAttributes()[1];
+echo $refl->getAttributes()[2];
+--EXPECTF--
+Attribute [ Foo ]
+Attribute [ Bar ] {
+  - Arguments [2] {
+    Argument #0 [ a = 'foo' ]
+    Argument #1 [ b = 1234 ]
+  }
+}
+Attribute [ Baz ] {
+  - Arguments [2] {
+    Argument #0 [ 'foo' ]
+    Argument #1 [ 1234 ]
+  }
+}


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=80097

Questions:
- Is this the right representation? Arguments could potentially be very complex, I don't think they should be rendered?
- what about attributes on all reflectors, should we print them as well? so when you echo a ReflectionFunction with an attribute for example.
- What about `php -r*`?