### PR TITLE
travis-ci: mysqli test native driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,8 @@ before_script:
 
 # Run PHPs run-tests.php
 script:
-    - ./sapi/cli/php run-tests.php -P -d extension=`pwd`/modules/zend_test.so $(if [ $ENABLE_DEBUG == 0 ]; then echo "-d opcache.enable_cli=1 -d zend_extension=`pwd`/modules/opcache.so"; fi) -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --show-slow 1000 --set-timeout 120
+    - if [ -n "$LIBMYSQL" ]; then TESTS="ext/mysqli/tests/*phpt  ext/pdo_mysql/tests/*phpt" ; fi
+    - ./sapi/cli/php run-tests.php -P -d extension=`pwd`/modules/zend_test.so $(if [ $ENABLE_DEBUG == 0 ]; then echo "-d opcache.enable_cli=1 -d zend_extension=`pwd`/modules/opcache.so"; fi) -g "FAIL,XFAIL,BORK,WARN,LEAK,SKIP" --offline --show-diff --show-slow 1000 --set-timeout 120 ${TESTS}
     - sapi/cli/php -d extension_dir=`pwd`/modules -r 'dl("zend_test");'
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,16 @@ env:
       - ENABLE_MAINTAINER_ZTS=0 ENABLE_DEBUG=0
       - ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
 
+jobs:
+    include:
+      - env: LIBMYSQL=mysql-5.6.49-linux-glibc2.12-x86_64.tar.gz ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
+      - env: LIBMYSQL=mysql-5.7.31-linux-glibc2.12-x86_64.tar.gz ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
+      - env: LIBMYSQL=mysql-8.0.21-linux-glibc2.12-x86_64.tar.xz ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
+    allow_failures:
+      - env: LIBMYSQL=mysql-5.6.49-linux-glibc2.12-x86_64.tar.gz ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
+      - env: LIBMYSQL=mysql-5.7.31-linux-glibc2.12-x86_64.tar.gz ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
+      - env: LIBMYSQL=mysql-8.0.21-linux-glibc2.12-x86_64.tar.xz ENABLE_MAINTAINER_ZTS=1 ENABLE_DEBUG=1
+
 before_script:
     - ccache --version
     - ccache --zero-stats

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 git:
   quiet: true
 
-dist: trusty
+dist: bionic
+services:
+  - mysql
+  - postgresql
 language: c
 sudo: required
 addons:
@@ -19,7 +22,6 @@ addons:
       - librecode-dev
       - libsasl2-dev
       - libxpm-dev
-      - libt1-dev
       - libzip-dev
 
 notifications:

--- a/ext/ftp/tests/ftp_ssl_connect_error.phpt
+++ b/ext/ftp/tests/ftp_ssl_connect_error.phpt
@@ -12,14 +12,6 @@ echo "*** Testing ftp_ssl_connect() function : error conditions ***\n";
 echo "\n-- Testing ftp_ssl_connect() function on failure --\n";
 var_dump(ftp_ssl_connect('totes.invalid'));
 
-echo "\n-- Testing ftp_ssl_connect() function invalid argument type --\n";
-ftp_ssl_connect([]);
-ftp_ssl_connect('totes.invalid', []);
-ftp_ssl_connect('totes.invalid', 21, []);
-
-echo "\n-- Testing ftp_ssl_connect() function with more than expected no. of arguments --\n";
-ftp_ssl_connect('totes.invalid', 21, 1, []);
-
 echo "\n-- Testing ftp_ssl_connect() function timeout warning for value 0 --\n";
 ftp_ssl_connect('totes.invalid', 21, 0);
 
@@ -29,20 +21,8 @@ echo "===DONE===\n";
 
 -- Testing ftp_ssl_connect() function on failure --
 
-Warning: ftp_ssl_connect(): php_network_getaddresses: getaddrinfo failed: Name or service not known in %s on line %d
+Warning: ftp_ssl_connect(): php_network_getaddresses: getaddrinfo failed: %s in %s on line %d
 bool(false)
-
--- Testing ftp_ssl_connect() function invalid argument type --
-
-Warning: ftp_ssl_connect() expects parameter 1 to be string, array given in %s on line %d
-
-Warning: ftp_ssl_connect() expects parameter 2 to be int, array given in %s on line %d
-
-Warning: ftp_ssl_connect() expects parameter 3 to be int, array given in %s on line %d
-
--- Testing ftp_ssl_connect() function with more than expected no. of arguments --
-
-Warning: ftp_ssl_connect() expects at most 3 parameters, 4 given in %s on line %d
 
 -- Testing ftp_ssl_connect() function timeout warning for value 0 --
 

--- a/ext/mysqli/config.m4
+++ b/ext/mysqli/config.m4
@@ -57,9 +57,6 @@ elif test "$PHP_MYSQLI" != "no"; then
     MYSQL_LIB_CFG='--libmysqld-libs'
     dnl mysqlnd doesn't support embedded, so we have to add some extra stuff
     mysqli_extra_sources="mysqli_embedded.c"
-  elif test "$enable_maintainer_zts" = "yes"; then
-    MYSQL_LIB_CFG='--libs_r'
-    MYSQL_LIB_NAME='mysqlclient_r'
   else
     MYSQL_LIB_CFG='--libs'
   fi

--- a/ext/mysqli/tests/bug55283.phpt
+++ b/ext/mysqli/tests/bug55283.phpt
@@ -12,6 +12,9 @@ if ($IS_MYSQLND && !extension_loaded("openssl"))
 if (!($link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)))
 	die(sprintf("skip Connect failed, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
+if (false === strpos($link->host_info, 'TCP/IP'))
+	die(sprintf("skip SSL only supported on TCP/IP"));
+
 $row = NULL;
 if ($res = $link->query('SHOW VARIABLES LIKE "have_ssl"')) {
 	$row = $res->fetch_row();
@@ -36,40 +39,40 @@ $link->close();
 ?>
 --FILE--
 <?php
-	include "connect.inc";
-	$db1 = new mysqli();
+    require_once "connect.inc";
+    $db1 = new mysqli();
 
 
-	$flags = MYSQLI_CLIENT_SSL | MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+    $flags = MYSQLI_CLIENT_SSL | MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
 
-	$link = mysqli_init();
-	mysqli_ssl_set($link, null, null, null, null, "RC4-MD5");
-	if (my_mysqli_real_connect($link, 'p:' . $host, $user, $passwd, $db, $port, null, $flags)) {
-		$r = $link->query("SHOW STATUS LIKE 'Ssl_cipher'");
-		var_dump($r->fetch_row());
-	}
+    $link = mysqli_init();
+    mysqli_ssl_set($link, null, null, null, null, "AES256-SHA");
+    if (my_mysqli_real_connect($link, 'p:' . $host, $user, $passwd, $db, $port, null, $flags)) {
+        $r = $link->query("SHOW STATUS LIKE 'Ssl_cipher'");
+        var_dump($r->fetch_row());
+    }
 
-	/* non-persistent connection */
-	$link2 = mysqli_init();
-	mysqli_ssl_set($link2, null, null, null, null, "RC4-MD5");
-	if (my_mysqli_real_connect($link2, $host, $user, $passwd, $db, $port, null, $flags)) {
-		$r2 = $link2->query("SHOW STATUS LIKE 'Ssl_cipher'");
-		var_dump($r2->fetch_row());
-	}
+    /* non-persistent connection */
+    $link2 = mysqli_init();
+    mysqli_ssl_set($link2, null, null, null, null, "AES256-SHA");
+    if (my_mysqli_real_connect($link2, $host, $user, $passwd, $db, $port, null, $flags)) {
+        $r2 = $link2->query("SHOW STATUS LIKE 'Ssl_cipher'");
+        var_dump($r2->fetch_row());
+    }
 
-	echo "done\n";
+    echo "done\n";
 ?>
---EXPECT--
+--EXPECTF--
 array(2) {
   [0]=>
   string(10) "Ssl_cipher"
   [1]=>
-  string(7) "RC4-MD5"
+  string(%d) "%rAES256-SHA|TLS_AES_256_GCM_SHA384%r"
 }
 array(2) {
   [0]=>
   string(10) "Ssl_cipher"
   [1]=>
-  string(7) "RC4-MD5"
+  string(%d) "%rAES256-SHA|TLS_AES_256_GCM_SHA384%r"
 }
 done

--- a/ext/pdo_mysql/config.m4
+++ b/ext/pdo_mysql/config.m4
@@ -66,13 +66,8 @@ if test "$PHP_PDO_MYSQL" != "no"; then
       if test "x$SED" = "x"; then
         AC_PATH_PROG(SED, sed)
       fi
-      if test "$enable_maintainer_zts" = "yes"; then
-        PDO_MYSQL_LIBNAME=mysqlclient_r
-        PDO_MYSQL_LIBS=`$PDO_MYSQL_CONFIG --libs_r | $SED -e "s/'//g"`
-      else
-        PDO_MYSQL_LIBNAME=mysqlclient
-        PDO_MYSQL_LIBS=`$PDO_MYSQL_CONFIG --libs | $SED -e "s/'//g"`
-      fi
+      PDO_MYSQL_LIBNAME=mysqlclient
+      PDO_MYSQL_LIBS=`$PDO_MYSQL_CONFIG --libs | $SED -e "s/'//g"`
       PDO_MYSQL_INCLUDE=`$PDO_MYSQL_CONFIG --cflags | $SED -e "s/'//g"`
     elif test -n "$PDO_MYSQL_DIR"; then
       AC_MSG_RESULT([not found])

--- a/ext/standard/tests/network/gethostbyname_basic003.phpt
+++ b/ext/standard/tests/network/gethostbyname_basic003.phpt
@@ -11,8 +11,6 @@ echo "*** Testing gethostbyname() : basic functionality ***\n";
 
 echo gethostbyname("localhost")."\n";
 ?>
-===DONE===
---EXPECT--
+--EXPECTF--
 *** Testing gethostbyname() : basic functionality ***
-127.0.0.1
-===DONE===
+127.0.%d.1

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -23,12 +23,23 @@ if [[ -z "$MAKE_LOG_FILE" ]]; then
 else
 	MAKE_QUIET=""
 fi
+if [[ -n "$LIBMYSQL" ]]; then
+	case "$LIBMYSQL" in
+	*.gz) EXTRACT=zxf ;;
+	*.xz) EXTRACT=Jxf ;;
+	esac
+	MYSQL_BASE=${LIBMYSQL%%-linux-*}
+	MYSQL_VERSION=${MYSQL_BASE#*-}
+	MYSQL_DIR=$HOME/$MYSQL_BASE
+        mkdir -p $MYSQL_DIR
+	URL=https://cdn.mysql.com//Downloads/MySQL-${MYSQL_VERSION%.*}/$LIBMYSQL
+	wget $URL -O - | tar -${EXTRACT} - --strip-components=1  -C $MYSQL_DIR
+fi
 if [[ -z "$MYSQL_DIR" ]]; then
         PDOMYSQL=mysqlnd
         MYSQLI=mysqlnd
 else
         PDOMYSQL=${MYSQL_DIR}
-        [ -f ${MYSQL_DIR}/bin/mariadb_config ] && MYSQLI=${MYSQL_DIR}/bin/mariadb_config
         [ -f ${MYSQL_DIR}/bin/mysql_config ] && MYSQLI=${MYSQL_DIR}/bin/mysql_config
 fi
 MAKE_JOBS=${MAKE_JOBS:-2}

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -23,19 +23,29 @@ if [[ -z "$MAKE_LOG_FILE" ]]; then
 else
 	MAKE_QUIET=""
 fi
-
+if [[ -z "$MYSQL_DIR" ]]; then
+        PDOMYSQL=mysqlnd
+        MYSQLI=mysqlnd
+else
+        PDOMYSQL=${MYSQL_DIR}
+        [ -f ${MYSQL_DIR}/bin/mariadb_config ] && MYSQLI=${MYSQL_DIR}/bin/mariadb_config
+        [ -f ${MYSQL_DIR}/bin/mysql_config ] && MYSQLI=${MYSQL_DIR}/bin/mysql_config
+fi
 MAKE_JOBS=${MAKE_JOBS:-2}
 
-./buildconf --force
-./configure \
+if [ ! -f ${TRAVIS_BUILD_DIR}/configure ]; then
+        (cd ${TRAVIS_BUILD_DIR} ; ./buildconf --force )
+fi
+
+${TRAVIS_BUILD_DIR}/configure \
 --prefix="$HOME"/php-install \
 $CONFIG_QUIET \
 $DEBUG \
 $TS \
 --enable-phpdbg \
 --enable-fpm \
---with-pdo-mysql=mysqlnd \
---with-mysqli=mysqlnd \
+--with-pdo-mysql=${PDOMYSQL} \
+--with-mysqli=${MYSQLI} \
 --with-pgsql \
 --with-pdo-pgsql \
 --with-pdo-sqlite \

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -99,7 +99,7 @@ $TS \
 --with-kerberos \
 --enable-sysvmsg \
 --enable-zend-test=shared \
-> "$CONFIG_LOG_FILE"
+> "$CONFIG_LOG_FILE" || (cat config.log; exit 2)
 
 make "-j${MAKE_JOBS}" $MAKE_QUIET > "$MAKE_LOG_FILE"
 make install >> "$MAKE_LOG_FILE"


### PR DESCRIPTION
In testing how well the libmysqlclient performs in mysqli and the pdo_mysql I've made the following changes to get them running on travis.

There are about 33 test failures in the mysqli/pdo_mysql test suites associated with these so I've left the as travis 'allow_failure" jobs for now. Marking these as XFAIL was going to be detrimental to the mysqlnd coverage.

I've included a bump from trusty to bionic. As I was looking at running docker container version of the mysql major versions on the server side. With the existing failures, and bionic running a 5.7 MySQL version, I thought I'd wait off adding more complexity.

A few other minor tests needed small corrections to run on bionic/the travis environment.

libmysqlclient_r was replaces with libmysqlclient consistent with Oracle upstream. The libmysqlclient_r symlink is only in mysql-5.6, the currently earliest support upstream version.

<pre>
$ find /usr/local/m* -name libmysqlclient\* -ls
 12194632   8856 -rwxr-xr-x   1 7161     31415     9065576 Jun  2 16:15 /usr/local/mysql-5.6.49-linux-glibc2.12-x86_64/lib/libmysqlclient.so.18.1.0
 12193009      0 lrwxrwxrwx   1 7161     31415          20 Jun  2 16:17 /usr/local/mysql-5.6.49-linux-glibc2.12-x86_64/lib/libmysqlclient_r.so.18 -> libmysqlclient.so.18
 12193010      0 lrwxrwxrwx   1 7161     31415          24 Jun  2 16:17 /usr/local/mysql-5.6.49-linux-glibc2.12-x86_64/lib/libmysqlclient_r.so.18.1.0 -> libmysqlclient.so.18.1.0
 12193006      0 lrwxrwxrwx   1 7161     31415          24 Jun  2 16:17 /usr/local/mysql-5.6.49-linux-glibc2.12-x86_64/lib/libmysqlclient.so.18 -> libmysqlclient.so.18.1.0
 12194631  16880 -rw-r--r--   1 7161     31415    17284614 Jun  2 16:15 /usr/local/mysql-5.6.49-linux-glibc2.12-x86_64/lib/libmysqlclient.a
 12193007      0 lrwxrwxrwx   1 7161     31415          16 Jun  2 16:17 /usr/local/mysql-5.6.49-linux-glibc2.12-x86_64/lib/libmysqlclient_r.a -> libmysqlclient.a
 12193008      0 lrwxrwxrwx   1 7161     31415          17 Jun  2 16:17 /usr/local/mysql-5.6.49-linux-glibc2.12-x86_64/lib/libmysqlclient_r.so -> libmysqlclient.so
 12193005      0 lrwxrwxrwx   1 7161     31415          20 Jun  2 16:17 /usr/local/mysql-5.6.49-linux-glibc2.12-x86_64/lib/libmysqlclient.so -> libmysqlclient.so.18
 11803348   9224 -rwxr-xr-x   1 7161     31415     9445360 Jun  2 22:55 /usr/local/mysql-5.7.31-linux-glibc2.12-x86_64/lib/libmysqlclient.so.20.3.18
 11803257      0 lrwxrwxrwx   1 7161     31415          25 Jun  2 23:08 /usr/local/mysql-5.7.31-linux-glibc2.12-x86_64/lib/libmysqlclient.so.20 -> libmysqlclient.so.20.3.18
 11803347  18548 -rw-r--r--   1 7161     31415    18991104 Jun  2 22:55 /usr/local/mysql-5.7.31-linux-glibc2.12-x86_64/lib/libmysqlclient.a
 11803256      0 lrwxrwxrwx   1 7161     31415          20 Jun  2 23:08 /usr/local/mysql-5.7.31-linux-glibc2.12-x86_64/lib/libmysqlclient.so -> libmysqlclient.so.20
 10879166  21428 -rwxr-xr-x   1 7161     31415    21942240 Jun 17 07:01 /usr/local/mysql-8.0.21-linux-glibc2.12-x86_64/lib/libmysqlclient.so.21.1.21
 10879162      0 lrwxrwxrwx   1 7161     31415          25 Jun 17 07:53 /usr/local/mysql-8.0.21-linux-glibc2.12-x86_64/lib/libmysqlclient.so.21 -> libmysqlclient.so.21.1.21
 10879154  56568 -rw-r--r--   1 7161     31415    57922986 Jun 17 07:01 /usr/local/mysql-8.0.21-linux-glibc2.12-x86_64/lib/libmysqlclient.a
 10879165      0 lrwxrwxrwx   1 7161     31415          20 Jun 17 07:53 /usr/local/mysql-8.0.21-linux-glibc2.12-x86_64/lib/libmysqlclient.so -> libmysqlclient.so.21
</pre>