### PR TITLE
Rename zend_error_notify APIs to zend_observer_error*

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -370,19 +370,19 @@ PHP 8.0 INTERNALS UPGRADE NOTES
 
   u. Instead of overwriting zend_error_cb extensions with debugging, monitoring
      use-cases catching Errors/Exceptions are strongly encouraged to use
-	 the new error notification API instead.
+	 the new error observer API instead.
 
-	 Error notification callbacks are guaranteed to be called regardless of
+	 Error observering callbacks are guaranteed to be called regardless of
 	 the users error_reporting setting or userland error handler return values.
 
-     Register notification callbacks during MINIT of an extension:
+     Register observer callbacks during MINIT of an extension:
 
-		void my_error_notify_cb(int type,
+		void my_error_observer_cb(int type,
 			const char *error_filename,
 			uint32_t error_lineno,
 			zend_string *message) {
 		}
-		zend_register_error_notify_callback(my_error_notify_cb);
+		zend_observer_error_register(my_error_observer_cb);
 
   v. The following APIs have been removed from the Zend Engine:
      - zend_ts_hash_init_ex(), drop the last argument and use zend_ts_hash_init() instead

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -62,8 +62,6 @@ ZEND_TSRMLS_CACHE_DEFINE()
 ZEND_API zend_utility_values zend_uv;
 ZEND_API zend_bool zend_dtrace_enabled;
 
-zend_llist zend_error_notify_callbacks;
-
 /* version information */
 static char *zend_version_info;
 static uint32_t zend_version_info_length;
@@ -832,7 +830,7 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 
 	zend_startup_strtod();
 	zend_startup_extensions_mechanism();
-	zend_startup_error_notify_callbacks();
+	zend_observer_error_startup();
 
 	/* Set up utility functions and values */
 	zend_error_cb = utility_functions->error_function;
@@ -865,7 +863,7 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 			zend_execute_ex = dtrace_execute_ex;
 			zend_execute_internal = dtrace_execute_internal;
 
-			zend_register_error_notify_callback(dtrace_error_notify_cb);
+			zend_observer_error_register(dtrace_error_notify_cb);
 		} else {
 			zend_compile_file = compile_file;
 			zend_execute_ex = execute_ex;
@@ -1093,7 +1091,7 @@ void zend_shutdown(void) /* {{{ */
 	zend_hash_destroy(GLOBAL_AUTO_GLOBALS_TABLE);
 	free(GLOBAL_AUTO_GLOBALS_TABLE);
 
-	zend_shutdown_error_notify_callbacks();
+	zend_observer_error_shutdown();
 	zend_shutdown_extensions();
 	free(zend_version_info);
 
@@ -1329,7 +1327,7 @@ static ZEND_COLD void zend_error_impl(
 		}
 	}
 
-	zend_error_notify_all_callbacks(type, error_filename, error_lineno, message);
+	zend_observer_error_notify(type, error_filename, error_lineno, message);
 
 	/* if we don't have a user defined error handler */
 	if (Z_TYPE(EG(user_error_handler)) == IS_UNDEF
@@ -1790,31 +1788,5 @@ ZEND_API void zend_map_ptr_extend(size_t last)
 		ptr = (void**)ZEND_MAP_PTR_REAL_BASE(CG(map_ptr_base)) + CG(map_ptr_last);
 		memset(ptr, 0, (last - CG(map_ptr_last)) * sizeof(void*));
 		CG(map_ptr_last) = last;
-	}
-}
-
-void zend_startup_error_notify_callbacks(void)
-{
-	zend_llist_init(&zend_error_notify_callbacks, sizeof(zend_error_notify_cb), NULL, 1);
-}
-
-void zend_shutdown_error_notify_callbacks(void)
-{
-	zend_llist_destroy(&zend_error_notify_callbacks);
-}
-
-ZEND_API void zend_register_error_notify_callback(zend_error_notify_cb cb)
-{
-	zend_llist_add_element(&zend_error_notify_callbacks, &cb);
-}
-
-void zend_error_notify_all_callbacks(int type, const char *error_filename, uint32_t error_lineno, zend_string *message)
-{
-	zend_llist_element *element;
-	zend_error_notify_cb callback;
-
-	for (element = zend_error_notify_callbacks.head; element; element = element->next) {
-		callback = *(zend_error_notify_cb *) (element->data);
-		callback(type, error_filename, error_lineno, message);
 	}
 }

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -830,7 +830,6 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 
 	zend_startup_strtod();
 	zend_startup_extensions_mechanism();
-	zend_observer_error_startup();
 
 	/* Set up utility functions and values */
 	zend_error_cb = utility_functions->error_function;
@@ -1091,7 +1090,6 @@ void zend_shutdown(void) /* {{{ */
 	zend_hash_destroy(GLOBAL_AUTO_GLOBALS_TABLE);
 	free(GLOBAL_AUTO_GLOBALS_TABLE);
 
-	zend_observer_error_shutdown();
 	zend_shutdown_extensions();
 	free(zend_version_info);
 

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -350,15 +350,6 @@ ZEND_API void zend_save_error_handling(zend_error_handling *current);
 ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, zend_class_entry *exception_class, zend_error_handling *current);
 ZEND_API void zend_restore_error_handling(zend_error_handling *saved);
 
-typedef void (*zend_error_notify_cb)(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
-
-BEGIN_EXTERN_C()
-ZEND_API void zend_register_error_notify_callback(zend_error_notify_cb callback);
-void zend_startup_error_notify_callbacks(void);
-void zend_shutdown_error_notify_callbacks(void);
-void zend_error_notify_all_callbacks(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
-END_EXTERN_C()
-
 #define DEBUG_BACKTRACE_PROVIDE_OBJECT (1<<0)
 #define DEBUG_BACKTRACE_IGNORE_ARGS    (1<<1)
 

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -28,6 +28,7 @@
 #include "zend_dtrace.h"
 #include "zend_smart_str.h"
 #include "zend_exceptions_arginfo.h"
+#include "zend_observer.h"
 
 ZEND_API zend_class_entry *zend_ce_throwable;
 ZEND_API zend_class_entry *zend_ce_exception;

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -900,7 +900,7 @@ static void zend_error_va(int type, const char *file, uint32_t lineno, const cha
 	va_list args;
 	va_start(args, format);
 	zend_string *message = zend_vstrpprintf(0, format, args);
-	zend_error_notify_all_callbacks(type, file, lineno, message);
+	zend_observer_error_notify(type, file, lineno, message);
 	zend_error_cb(type, file, lineno, message);
 	zend_string_release(message);
 	va_end(args);
@@ -923,7 +923,7 @@ ZEND_API ZEND_COLD zend_result zend_exception_error(zend_object *ex, int severit
 		zend_long line = zval_get_long(GET_PROPERTY_SILENT(&exception, ZEND_STR_LINE));
 		int type = (ce_exception == zend_ce_parse_error ? E_PARSE : E_COMPILE_ERROR) | E_DONT_BAIL;
 
-		zend_error_notify_all_callbacks(type, ZSTR_VAL(file), line, message);
+		zend_observer_error_notify(type, ZSTR_VAL(file), line, message);
 		zend_error_cb(type, ZSTR_VAL(file), line, message);
 
 		zend_string_release_ex(file, 0);

--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -60,6 +60,7 @@ ZEND_API void zend_observer_fcall_register(zend_observer_fcall_init init) {
 // Called by engine before MINITs
 ZEND_API void zend_observer_startup(void) {
 	zend_llist_init(&zend_observers_fcall_list, sizeof(zend_observer_fcall_init), NULL, 1);
+	zend_llist_init(&zend_observer_error_callbacks, sizeof(zend_observer_error_cb), NULL, 1);
 }
 
 ZEND_API void zend_observer_activate(void) {
@@ -76,6 +77,7 @@ ZEND_API void zend_observer_deactivate(void) {
 
 ZEND_API void zend_observer_shutdown(void) {
 	zend_llist_destroy(&zend_observers_fcall_list);
+	zend_llist_destroy(&zend_observer_error_callbacks);
 }
 
 ZEND_API void zend_observer_fcall_install(zend_function *function) {
@@ -173,14 +175,4 @@ void zend_observer_error_notify(int type, const char *error_filename, uint32_t e
 		callback = *(zend_observer_error_cb *) (element->data);
 		callback(type, error_filename, error_lineno, message);
 	}
-}
-
-void zend_observer_error_startup(void)
-{
-	zend_llist_init(&zend_observer_error_callbacks, sizeof(zend_observer_error_cb), NULL, 1);
-}
-
-void zend_observer_error_shutdown(void)
-{
-	zend_llist_destroy(&zend_observer_error_callbacks);
 }

--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -114,8 +114,6 @@ typedef void (*zend_observer_error_cb)(int type, const char *error_filename, uin
 
 ZEND_API void zend_observer_error_register(zend_observer_error_cb callback);
 void zend_observer_error_notify(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
-void zend_observer_error_startup(void);
-void zend_observer_error_shutdown(void);
 
 END_EXTERN_C()
 

--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -110,6 +110,13 @@ ZEND_API zend_always_inline void zend_observer_maybe_fcall_call_end(
 	}
 }
 
+typedef void (*zend_observer_error_cb)(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
+
+ZEND_API void zend_observer_error_register(zend_observer_error_cb callback);
+void zend_observer_error_notify(int type, const char *error_filename, uint32_t error_lineno, zend_string *message);
+void zend_observer_error_startup(void);
+void zend_observer_error_shutdown(void);
+
 END_EXTERN_C()
 
 #endif /* ZEND_OBSERVER_H */

--- a/main/main.c
+++ b/main/main.c
@@ -2045,7 +2045,7 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	zend_update_current_locale();
 
 #if ZEND_DEBUG
-	zend_register_error_notify_callback(report_zend_debug_error_notify_cb);
+	zend_observer_error_register(report_zend_debug_error_notify_cb);
 #endif
 
 #if HAVE_TZSET


### PR DESCRIPTION
My previous PR #4555 introduced a new error notification callback API. After merging #5857 for PHP 8 as well, this PR moves the error notification API into `zend_observer.h` and `zend_observer.c`.

This will produce a more consistent naming for future, where we provide a general observer API into different parts of PHP engine.

A soft goal would be that we can replace all parts of Dtrace support that are currently hardcoded into the engine using this general observer API provided by `zend_observer.h` at some point in the future, so that dtrace can become an extension instead of being coupled into the engine.

/cc @morrisonlevi @SammyK