### PR TITLE
gethostbyname_basic003.phpt: travis(ubuntu bionic) returns 127.0.1.1 so a little tolerance

### DIFF
--- a/ext/standard/tests/network/gethostbyname_basic003.phpt
+++ b/ext/standard/tests/network/gethostbyname_basic003.phpt
@@ -12,7 +12,7 @@ echo "*** Testing gethostbyname() : basic functionality ***\n";
 echo gethostbyname("localhost")."\n";
 ?>
 ===DONE===
---EXPECT--
+--EXPECTF--
 *** Testing gethostbyname() : basic functionality ***
-127.0.0.1
+127.0.%d.1
 ===DONE===


### PR DESCRIPTION
Submitted as part of #6126 to show tests can still pass with a travis (bionic), bug however its worthy as a separate inclusion.

This was the somewhat minimal change to get it going. Technical it could extend all the way to  a 127.%d.%d.%d.