### PR TITLE
fix mbfl function prototypes

### DIFF
--- a/ext/mbstring/libmbfl/filters/mbfilter_cp5022x.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_cp5022x.c
@@ -586,8 +586,8 @@ mbfl_filt_conv_wchar_cp50220_ctor(mbfl_convert_filter *filt)
 	ctx->last.data = filt->data;
 	filt->filter_function = vtbl_tl_jisx0201_jisx0208.filter_function;
 	filt->filter_flush = vtbl_tl_jisx0201_jisx0208.filter_flush;
-	filt->output_function = (int(*)(int, void *))ctx->last.filter_function;
-	filt->flush_function = ctx->last.filter_flush;
+	filt->output_function = (output_function_t)ctx->last.filter_function;
+	filt->flush_function = (flush_function_t)ctx->last.filter_flush;
 	filt->data = &ctx->last;
 	filt->opaque = ctx;
 	vtbl_tl_jisx0201_jisx0208.filter_ctor(filt);

--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -129,8 +129,8 @@ mbfl_buffer_converter_new(
 		if (convd->filter2 != NULL) {
 			convd->filter1 = mbfl_convert_filter_new(from,
 					&mbfl_encoding_wchar,
-					(int (*)(int, void*))convd->filter2->filter_function,
-					convd->filter2->filter_flush,
+					(output_function_t)convd->filter2->filter_function,
+					(flush_function_t)convd->filter2->filter_flush,
 					convd->filter2);
 			if (convd->filter1 == NULL) {
 				mbfl_convert_filter_delete(convd->filter2);
@@ -1196,8 +1196,8 @@ mbfl_strcut(
 		}
 
 		/* switch the drain direction */
-		encoder->output_function = (int(*)(int,void *))decoder->filter_function;
-		encoder->flush_function = decoder->filter_flush;
+		encoder->output_function = (output_function_t)decoder->filter_function;
+		encoder->flush_function = (flush_function_t)decoder->filter_flush;
 		encoder->data = decoder;
 
 		q = string->val + string->len;
@@ -1605,7 +1605,7 @@ mbfl_ja_jp_hantozen(
 	tl_filter = mbfl_convert_filter_new2(
 		&vtbl_tl_jisx0201_jisx0208,
 		(int(*)(int, void*))next_filter->filter_function,
-		next_filter->filter_flush,
+		(flush_function_t)next_filter->filter_flush,
 		next_filter);
 	if (tl_filter == NULL) {
 		efree(param);
@@ -1619,7 +1619,7 @@ mbfl_ja_jp_hantozen(
 		string->encoding,
 		&mbfl_encoding_wchar,
 		(int(*)(int, void*))next_filter->filter_function,
-		next_filter->filter_flush,
+		(flush_function_t)next_filter->filter_flush,
 		next_filter);
 	if (encoder == NULL) {
 		goto out;
@@ -2637,7 +2637,7 @@ mbfl_html_numeric_entity(
 		    string->encoding,
 		    &mbfl_encoding_wchar,
 		    collector_decode_htmlnumericentity,
-		    mbfl_filt_decode_htmlnumericentity_flush, &pc);
+		    (flush_function_t)mbfl_filt_decode_htmlnumericentity_flush, &pc);
 	}
 	if (pc.decoder == NULL || encoder == NULL) {
 		mbfl_convert_filter_delete(encoder);

--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
@@ -175,6 +175,12 @@ void mbfl_convert_filter_delete(mbfl_convert_filter *filter)
 	efree(filter);
 }
 
+/* Feed a char, return 0 if ok - used by mailparse ext */
+int mbfl_convert_filter_feed(int c, mbfl_convert_filter *filter)
+{
+	return (*filter->filter_function)(c, filter);
+}
+
 /* Feed string into `filter` byte by byte; return pointer to first byte not processed */
 unsigned char* mbfl_convert_filter_feed_string(mbfl_convert_filter *filter, unsigned char *p, size_t len)
 {

--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
@@ -116,7 +116,7 @@ static const struct mbfl_convert_vtbl *mbfl_special_filter_list[] = {
 };
 
 static void mbfl_convert_filter_common_init(mbfl_convert_filter *filter, const mbfl_encoding *from, const mbfl_encoding *to,
-	const struct mbfl_convert_vtbl *vtbl, filter_output_func output_function, filter_flush_func flush_function, void* data)
+	const struct mbfl_convert_vtbl *vtbl, output_function_t output_function, flush_function_t flush_function, void* data)
 {
 	/* encoding structure */
 	filter->from = from;
@@ -143,8 +143,8 @@ static void mbfl_convert_filter_common_init(mbfl_convert_filter *filter, const m
 }
 
 
-mbfl_convert_filter* mbfl_convert_filter_new(const mbfl_encoding *from, const mbfl_encoding *to, filter_output_func output_function,
-	filter_flush_func flush_function, void* data)
+mbfl_convert_filter* mbfl_convert_filter_new(const mbfl_encoding *from, const mbfl_encoding *to, output_function_t output_function,
+	flush_function_t flush_function, void* data)
 {
 	const struct mbfl_convert_vtbl *vtbl = mbfl_convert_filter_get_vtbl(from, to);
 	if (vtbl == NULL) {
@@ -156,8 +156,8 @@ mbfl_convert_filter* mbfl_convert_filter_new(const mbfl_encoding *from, const mb
 	return filter;
 }
 
-mbfl_convert_filter* mbfl_convert_filter_new2(const struct mbfl_convert_vtbl *vtbl, filter_output_func output_function,
-	filter_flush_func flush_function, void* data)
+mbfl_convert_filter* mbfl_convert_filter_new2(const struct mbfl_convert_vtbl *vtbl, output_function_t output_function,
+	flush_function_t flush_function, void* data)
 {
 	const mbfl_encoding *from_encoding = mbfl_no2encoding(vtbl->from);
 	const mbfl_encoding *to_encoding = mbfl_no2encoding(vtbl->to);

--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.h
@@ -68,6 +68,7 @@ MBFLAPI extern mbfl_convert_filter *mbfl_convert_filter_new(const mbfl_encoding 
 MBFLAPI extern mbfl_convert_filter *mbfl_convert_filter_new2(const struct mbfl_convert_vtbl *vtbl, output_function_t output_function,
 	flush_function_t flush_function, void *data);
 MBFLAPI extern void mbfl_convert_filter_delete(mbfl_convert_filter *filter);
+MBFLAPI extern int mbfl_convert_filter_feed(int c, mbfl_convert_filter *filter);
 MBFLAPI extern unsigned char* mbfl_convert_filter_feed_string(mbfl_convert_filter *filter, unsigned char *p, size_t len);
 MBFLAPI extern int mbfl_convert_filter_flush(mbfl_convert_filter *filter);
 MBFLAPI extern void mbfl_convert_filter_reset(mbfl_convert_filter *filter, const mbfl_encoding *from, const mbfl_encoding *to);

--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.h
@@ -37,17 +37,21 @@
 
 typedef struct _mbfl_convert_filter mbfl_convert_filter;
 
-typedef int (*filter_output_func)(int, void*);
-typedef int (*filter_flush_func)(mbfl_convert_filter*);
+/* internal */
+typedef int (*filter_flush_t)(mbfl_convert_filter*);
+
+/* defined by mbfl_convert_filter_{new,new2,init} */
+typedef int (*output_function_t)(int, void*);
+typedef int (*flush_function_t)(void *);
 
 struct _mbfl_convert_filter {
 	void (*filter_ctor)(mbfl_convert_filter *filter);
 	void (*filter_dtor)(mbfl_convert_filter *filter);
 	void (*filter_copy)(mbfl_convert_filter *src, mbfl_convert_filter *dest);
 	int (*filter_function)(int c, mbfl_convert_filter *filter);
-	filter_flush_func  filter_flush;
-	filter_output_func output_function;
-	filter_flush_func  flush_function;
+	filter_flush_t  filter_flush;
+	output_function_t output_function;
+	flush_function_t flush_function;
 	void *data;
 	int status;
 	int cache;
@@ -59,10 +63,10 @@ struct _mbfl_convert_filter {
 	void *opaque;
 };
 
-MBFLAPI extern mbfl_convert_filter *mbfl_convert_filter_new(const mbfl_encoding *from, const mbfl_encoding *to, filter_output_func output_function,
-	filter_flush_func flush_function, void *data);
-MBFLAPI extern mbfl_convert_filter *mbfl_convert_filter_new2(const struct mbfl_convert_vtbl *vtbl, filter_output_func output_function,
-	filter_flush_func flush_function, void *data);
+MBFLAPI extern mbfl_convert_filter *mbfl_convert_filter_new(const mbfl_encoding *from, const mbfl_encoding *to, output_function_t output_function,
+	flush_function_t flush_function, void *data);
+MBFLAPI extern mbfl_convert_filter *mbfl_convert_filter_new2(const struct mbfl_convert_vtbl *vtbl, output_function_t output_function,
+	flush_function_t flush_function, void *data);
 MBFLAPI extern void mbfl_convert_filter_delete(mbfl_convert_filter *filter);
 MBFLAPI extern unsigned char* mbfl_convert_filter_feed_string(mbfl_convert_filter *filter, unsigned char *p, size_t len);
 MBFLAPI extern int mbfl_convert_filter_flush(mbfl_convert_filter *filter);


### PR DESCRIPTION
Broken by 409aa20ab0f1c4673366b2cbfc4d618e710ff7bf

As 
```
	(*filter->filter_flush)(filter);
	return filter->flush_function ? (*filter->flush_function)(filter->data) : 0;

```

`flush_function `must accept a `void *` (data)
while `filter_flush` must accept a `mbfl_convert_filter*`

ping @alexdowad 

the mbfilter.c have to be reviewed, old code have some pointer cast.... changing the type aoid the cast but is obviously wrong.

P.S. used in mailparse extension.