### PR TITLE
Changed the wording of the error message

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -740,9 +740,9 @@ PHP_FUNCTION(mysqli_data_seek)
 
 	if (mysqli_result_is_unbuffered(result)) {
 		if (getThis()) {
-			zend_throw_error(NULL, "mysqli_result::data_seek() cannot be used with MYSQLI_USE_RESULT");
+			zend_throw_error(NULL, "mysqli_result::data_seek() cannot be used in MYSQLI_USE_RESULT mode");
 		} else {
-			zend_throw_error(NULL, "mysqli_data_seek() cannot be used with MYSQLI_USE_RESULT");
+			zend_throw_error(NULL, "mysqli_data_seek() cannot be used in MYSQLI_USE_RESULT mode");
 		}
 		RETURN_THROWS();
 	}
@@ -1626,7 +1626,7 @@ PHP_FUNCTION(mysqli_num_rows)
 	MYSQLI_FETCH_RESOURCE(result, MYSQL_RES *, mysql_result, "mysqli_result", MYSQLI_STATUS_VALID);
 
 	if (mysqli_result_is_unbuffered_and_not_everything_is_fetched(result)) {
-		zend_throw_error(NULL, "mysqli_num_rows() cannot be used with MYSQLI_USE_RESULT");
+		zend_throw_error(NULL, "mysqli_num_rows() cannot be used in MYSQLI_USE_RESULT mode");
 		RETURN_THROWS();
 	}
 

--- a/ext/mysqli/tests/bug55582.phpt
+++ b/ext/mysqli/tests/bug55582.phpt
@@ -34,12 +34,12 @@ require_once("connect.inc");
 ?>
 --EXPECT--
 bool(true)
-mysqli_num_rows() cannot be used with MYSQLI_USE_RESULT
+mysqli_num_rows() cannot be used in MYSQLI_USE_RESULT mode
 array(1) {
   [1]=>
   string(1) "1"
 }
-mysqli_num_rows() cannot be used with MYSQLI_USE_RESULT
+mysqli_num_rows() cannot be used in MYSQLI_USE_RESULT mode
 NULL
 int(1)
 done

--- a/ext/mysqli/tests/mysqli_data_seek.phpt
+++ b/ext/mysqli/tests/mysqli_data_seek.phpt
@@ -66,6 +66,6 @@ require_once('skipifconnectfailure.inc');
 ?>
 --EXPECT--
 mysqli_data_seek(): Argument #2 ($offset) must be greater than or equal to 0
-mysqli_data_seek() cannot be used with MYSQLI_USE_RESULT
+mysqli_data_seek() cannot be used in MYSQLI_USE_RESULT mode
 mysqli_result object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_data_seek_oo.phpt
+++ b/ext/mysqli/tests/mysqli_data_seek_oo.phpt
@@ -78,6 +78,6 @@ require_once('skipifconnectfailure.inc');
 --EXPECT--
 mysqli_result object is already closed
 mysqli_result::data_seek(): Argument #1 ($offset) must be greater than or equal to 0
-mysqli_result::data_seek() cannot be used with MYSQLI_USE_RESULT
+mysqli_result::data_seek() cannot be used in MYSQLI_USE_RESULT mode
 mysqli_result object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_num_rows.phpt
+++ b/ext/mysqli/tests/mysqli_num_rows.phpt
@@ -80,5 +80,5 @@ mysqli_result object is already closed
 mysqli_result object is already closed
 mysqli_result object is already closed
 run_tests.php don't fool me with your 'ungreedy' expression '.+?'!
-mysqli_num_rows() cannot be used with MYSQLI_USE_RESULT
+mysqli_num_rows() cannot be used in MYSQLI_USE_RESULT mode
 done!

--- a/ext/mysqli/tests/mysqli_use_result.phpt
+++ b/ext/mysqli/tests/mysqli_use_result.phpt
@@ -56,6 +56,6 @@ require_once('skipifconnectfailure.inc');
 	require_once("clean_table.inc");
 ?>
 --EXPECT--
-mysqli_data_seek() cannot be used with MYSQLI_USE_RESULT
+mysqli_data_seek() cannot be used in MYSQLI_USE_RESULT mode
 mysqli object is already closed
 done!


### PR DESCRIPTION
"cannot be used in MYSQLI_USE_RESULT mode" sounds more correct than "cannot be used with MYSQLI_USE_RESULT"