### PR TITLE
FPM: create socket directory

### DIFF
--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -207,8 +207,14 @@ static int fpm_sockets_new_listening_socket(struct fpm_worker_pool_s *wp, struct
 		}
 		p = strrchr(((struct sockaddr_un *) sa)->sun_path, DEFAULT_SLASH);
 		if (p) {
+			struct stat st;
 			*p = 0;
-			mkdir(((struct sockaddr_un *) sa)->sun_path, 0755);
+			if (stat(((struct sockaddr_un *) sa)->sun_path, &st)) {
+				if (mkdir(((struct sockaddr_un *) sa)->sun_path, 0755)) {
+					zlog(ZLOG_SYSERROR, "unable to create directory '%s'", ((struct sockaddr_un *) sa)->sun_path);
+					return -1;
+				}
+			}
 			*p = DEFAULT_SLASH;
 		}
 		unlink( ((struct sockaddr_un *) sa)->sun_path);

--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -199,10 +199,17 @@ static int fpm_sockets_new_listening_socket(struct fpm_worker_pool_s *wp, struct
 	}
 
 	if (wp->listen_address_domain == FPM_AF_UNIX) {
+		char *p;
 		if (fpm_socket_unix_test_connect((struct sockaddr_un *)sa, socklen) == 0) {
 			zlog(ZLOG_ERROR, "Another FPM instance seems to already listen on %s", ((struct sockaddr_un *) sa)->sun_path);
 			close(sock);
 			return -1;
+		}
+		p = strrchr(((struct sockaddr_un *) sa)->sun_path, DEFAULT_SLASH);
+		if (p) {
+			*p = 0;
+			mkdir(((struct sockaddr_un *) sa)->sun_path, 0755);
+			*p = DEFAULT_SLASH;
 		}
 		unlink( ((struct sockaddr_un *) sa)->sun_path);
 		saved_umask = umask(0777 ^ wp->socket_mode);

--- a/sapi/fpm/tests/socket-uds-basic2.phpt
+++ b/sapi/fpm/tests/socket-uds-basic2.phpt
@@ -15,6 +15,7 @@ $sock_exp = "$dir/fpm.sock";
 $cfg = <<<EOT
 [global]
 error_log = {{FILE:LOG}}
+pid = $dir/fpm.pid
 [default]
 listen = $sock
 ping.path = /ping
@@ -30,6 +31,7 @@ $tester = new FPM\Tester($cfg);
 $tester->start();
 $tester->expectLogStartNotices();
 $tester->ping($sock_exp);
+var_dump(file_exists("$dir/fpm.pid"));
 $tester->terminate();
 $tester->expectLogTerminatingNotices();
 $tester->close();
@@ -39,6 +41,7 @@ var_dump(rmdir($dir));
 ?>
 Done
 --EXPECT--
+bool(true)
 bool(true)
 Done
 --CLEAN--

--- a/sapi/fpm/tests/socket-uds-basic2.phpt
+++ b/sapi/fpm/tests/socket-uds-basic2.phpt
@@ -1,0 +1,48 @@
+--TEST--
+FPM: UDS connection, expand $pool and create socket directory
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$dir = __DIR__ . '/' . basename(__FILE__, '.php') . '-$pool';
+$sock = "$dir/fpm.sock";
+$dir = __DIR__ . '/' . basename(__FILE__, '.php') . '-default';
+$sock_exp = "$dir/fpm.sock";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[default]
+listen = $sock
+ping.path = /ping
+ping.response = pong
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->ping($sock_exp);
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+var_dump(rmdir($dir));
+
+?>
+Done
+--EXPECT--
+bool(true)
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
Try to create last directory from socket path before the socket

Use cases:

# 1/ $pool expension

When a large number of auto-generated pools, with

`listen = /var/run/fpm-$pool/fpm.sock`

# 2/ downstream

Some Linux distribution have directory created on service startup

default_pool.conf:
```
listen = /run/php-fpm/www.sock
```

php-fpm.service:
```
RuntimeDirectory=php-fpm
RuntimeDirectoryMode=0755

```

Only `/run` exists, and `/run/php-fpm` is created by systemd
Which may break when launched from CLI or inside a container.


