### PR TITLE
mysqli_set_charset now throws an mysqli_sql_exception when incorrect charset is provided

### DIFF
--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -1039,6 +1039,7 @@ PHP_FUNCTION(mysqli_set_charset)
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 
 	if (mysql_set_character_set(mysql->mysql, cs_name)) {
+		MYSQLI_REPORT_MYSQL_ERROR(mysql->mysql);
 		RETURN_FALSE;
 	}
 	RETURN_TRUE;

--- a/ext/mysqli/tests/mysqli_set_charset.phpt
+++ b/ext/mysqli/tests/mysqli_set_charset.phpt
@@ -102,6 +102,14 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
     }
     mysqli_free_result($res);
 
+    // Make sure that set_charset throws an exception in exception mode
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+    try {
+        $link->set_charset('invalid');
+    } catch (\mysqli_sql_exception $exception) {
+        echo $exception->getMessage() . "\n";
+    }
+
     mysqli_close($link);
 
     try {
@@ -117,5 +125,6 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
 	require_once("clean_table.inc");
 ?>
 --EXPECT--
+Invalid character set was provided
 mysqli object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_set_charset.phpt
+++ b/ext/mysqli/tests/mysqli_set_charset.phpt
@@ -108,6 +108,12 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
         $link->set_charset('invalid');
     } catch (\mysqli_sql_exception $exception) {
         echo $exception->getMessage() . "\n";
+	}
+	
+    try {
+        $link->set_charset('ucs2');
+    } catch (\mysqli_sql_exception $exception) {
+        echo $exception->getMessage() . "\n";
     }
 
     mysqli_close($link);
@@ -126,5 +132,6 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
 ?>
 --EXPECT--
 Invalid character set was provided
+Variable 'character_set_client' can't be set to the value of 'ucs2'
 mysqli object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_set_charset.phpt
+++ b/ext/mysqli/tests/mysqli_set_charset.phpt
@@ -108,8 +108,8 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
         $link->set_charset('invalid');
     } catch (\mysqli_sql_exception $exception) {
         echo $exception->getMessage() . "\n";
-	}
-	
+    }
+
     try {
         $link->set_charset('ucs2');
     } catch (\mysqli_sql_exception $exception) {

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -1152,8 +1152,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, set_charset)(MYSQLND_CONN_DATA * const conn, c
 	DBG_INF_FMT("conn=%llu cs=%s", conn->thread_id, csname);
 
 	if (!charset) {
-		SET_CLIENT_ERROR(conn->error_info, CR_CANT_FIND_CHARSET, UNKNOWN_SQLSTATE,
-						 "Invalid characterset or character set not supported");
+		SET_CLIENT_ERROR(conn->error_info, CR_CANT_FIND_CHARSET, UNKNOWN_SQLSTATE, "Invalid character set was provided");
 		DBG_RETURN(ret);
 	}
 
@@ -1161,9 +1160,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, set_charset)(MYSQLND_CONN_DATA * const conn, c
 		char * query;
 		size_t query_len = mnd_sprintf(&query, 0, "SET NAMES %s", csname);
 
-		if (FAIL == (ret = conn->m->query(conn, query, query_len))) {
-			php_error_docref(NULL, E_WARNING, "Error executing query");
-		} else if (conn->error_info->error_no) {
+		if (FAIL == (ret = conn->m->query(conn, query, query_len)) || conn->error_info->error_no) {
 			ret = FAIL;
 		} else {
 			conn->charset = charset;


### PR DESCRIPTION
Previously mysqli didn't throw an exception when report mode was set to exception and a wrong charset was provided. 

Additionally if an unsupported charset was provided and the pre-check didn't catch it then there would be a confusing warning "Error executing query". Instead let mysqli throw an exception if it is set to exception mode. 

This results in 2 new behaviours. 
- If the charset provided is not available in mysqlnd list then an exception will be thrown with a message "Invalid character set was provided". 
- If the charset is in mysqlnd list but the server does not recognize it then we get an exception: mysqli_sql_exception: Unknown character set: '\<charset\>'

I was unable to find a suitable test case for this. I am new to writing PHP test cases and I don't know if I should create a new one or change an existing one. I would appreciate some guidance. 