### PR TITLE
ext/soap: Compare Set-Cookie header case-insensitively

### DIFF
--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -23,6 +23,7 @@
 #include "ext/standard/md5.h"
 #include "ext/standard/php_random.h"
 
+static char *get_http_header_value_nodup(char *headers, char *type, size_t *len);
 static char *get_http_header_value(char *headers, char *type);
 static zend_string *get_http_body(php_stream *socketd, int close, char *headers);
 static zend_string *get_http_headers(php_stream *socketd);
@@ -350,6 +351,7 @@ int make_http_soap_request(zval        *this_ptr,
 	int use_ssl;
 	zend_string *http_body;
 	char *content_type, *http_version, *cookie_itt;
+	size_t cookie_len;
 	int http_close;
 	zend_string *http_headers;
 	char *connection;
@@ -968,8 +970,9 @@ try_again:
 	   we shouldn't be changing urls so path doesn't
 	   matter too much
 	*/
-	cookie_itt = strstr(ZSTR_VAL(http_headers), "Set-Cookie: ");
-	while (cookie_itt) {
+	cookie_itt = ZSTR_VAL(http_headers);
+
+	while ((cookie_itt = get_http_header_value_nodup(cookie_itt, "Set-Cookie: ", &cookie_len))) {
 		char *cookie;
 		char *eqpos, *sempos;
 		zval *cookies;
@@ -981,7 +984,7 @@ try_again:
 			cookies = zend_hash_str_update(Z_OBJPROP_P(this_ptr), "_cookies", sizeof("_cookies")-1, &tmp_cookies);
 		}
 
-		cookie = get_http_header_value(cookie_itt,"Set-Cookie: ");
+		cookie = estrndup(cookie_itt, cookie_len);
 
 		eqpos = strstr(cookie, "=");
 		sempos = strstr(cookie, ";");
@@ -1039,7 +1042,7 @@ try_again:
 			smart_str_free(&name);
 		}
 
-		cookie_itt = strstr(cookie_itt + sizeof("Set-Cookie: "), "Set-Cookie: ");
+		cookie_itt = cookie_itt + cookie_len;
 		efree(cookie);
 	}
 
@@ -1357,7 +1360,7 @@ try_again:
 	return TRUE;
 }
 
-static char *get_http_header_value(char *headers, char *type)
+static char *get_http_header_value_nodup(char *headers, char *type, size_t *len)
 {
 	char *pos, *tmp = NULL;
 	int typelen, headerslen;
@@ -1394,7 +1397,9 @@ static char *get_http_header_value(char *headers, char *type)
 					eol--;
 				}
 			}
-			return estrndup(tmp, eol - tmp);
+
+			*len = eol - tmp;
+			return tmp;
 		}
 
 		/* find next line */
@@ -1404,6 +1409,20 @@ static char *get_http_header_value(char *headers, char *type)
 		}
 
 	} while (pos);
+
+	return NULL;
+}
+
+static char *get_http_header_value(char *headers, char *type)
+{
+	size_t len;
+	char *value;
+
+	value = get_http_header_value_nodup(headers, type, &len);
+
+	if (value) {
+		return estrndup(value, len);
+	}
 
 	return NULL;
 }


### PR DESCRIPTION
When the SOAP server sends HTTP headers in all-lowercase, the SoapClient does not recognize the `set-cookie` header and skips over it.

Fix this by searching for the `Set-Cookie` header in a case-insensitive manner.