### PR TITLE
[WIP]fix: -9223372036854775808 will be converted to float

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -1113,6 +1113,8 @@ static zend_always_inline zend_result mul_function_fast(zval *result, zval *op1,
 		return SUCCESS;
 	} else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG))) {
 		ZVAL_DOUBLE(result, Z_DVAL_P(op1) * ((double)Z_LVAL_P(op2)));
+		// TODO: if op1 is overflow, we should convert double to long
+		ZVAL_LONG(result, (zend_long) Z_DVAL(*result));
 		return SUCCESS;
 	} else {
 		return FAILURE;


### PR DESCRIPTION
This is a tentative PR because there is still some work to be done.

Here is the code:

```php
<?php

var_dump(PHP_INT_MIN);
var_dump(-9223372036854775808);

var_dump(PHP_INT_MIN === -9223372036854775808);
```

The results are as follows:

```bash
int(-9223372036854775808)
float(-9.223372036854776E+18)
bool(false)
```

Because`PHP_INT_MIN` will be resolved to LABEL, while`-9223372036854775808` will be resolved to "-" and "9223372036854775808". Since `PHP_INT_MAX` is `9223372036854775807`, `9223372036854775808` will be converted into float during the phase of lexical analysis. Finally, the code is executed:

```php
else if (EXPECTED(type_pair == TYPE_PAIR(IS_DOUBLE, IS_LONG))) {
    ZVAL_DOUBLE(result, Z_DVAL_P(op1) * ((double)Z_LVAL_P(op2)));
    return SUCCESS;
}
```

So, we're going to end up with a float.

Maybe we need to mark this `op1` as `PHP_INT_MIN` somewhere?

However, I'm not sure if this is a feature?

