### PR TITLE
Change int types to bool when possible

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -37,8 +37,7 @@ function ob_list_handlers(): array {}
 
 function ob_get_status(bool $full_status = false): array {}
 
-// TODO: Shouldn't this be a bool argument?
-function ob_implicit_flush(int $flag = 1): void {}
+function ob_implicit_flush(bool $flag = true): void {}
 
 function output_reset_rewrite_vars(): bool {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f80246569ba9de48eebc8b68f476723f78b8f77 */
+ * Stub hash: df6d5ebb0449274b94f1e8707ab54978fd4b7d2f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -45,7 +45,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ob_get_status, 0, 0, IS_ARRAY, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ob_implicit_flush, 0, 0, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flag, IS_LONG, 0, "1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flag, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 #define arginfo_output_reset_rewrite_vars arginfo_ob_flush

--- a/ext/sysvsem/sysvsem.c
+++ b/ext/sysvsem/sysvsem.c
@@ -187,13 +187,14 @@ PHP_MINFO_FUNCTION(sysvsem)
 /* {{{ Return an id for the semaphore with the given key, and allow max_acquire (default 1) processes to acquire it simultaneously */
 PHP_FUNCTION(sem_get)
 {
-	zend_long key, max_acquire = 1, perm = 0666, auto_release = 1;
+	zend_long key, max_acquire = 1, perm = 0666;
+	zend_bool auto_release = 1;
 	int semid;
 	struct sembuf sop[3];
 	int count;
 	sysvsem_sem *sem_ptr;
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "l|lll", &key, &max_acquire, &perm, &auto_release)) {
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "l|llb", &key, &max_acquire, &perm, &auto_release)) {
 		RETURN_THROWS();
 	}
 
@@ -289,7 +290,7 @@ PHP_FUNCTION(sem_get)
 	sem_ptr->key   = key;
 	sem_ptr->semid = semid;
 	sem_ptr->count = 0;
-	sem_ptr->auto_release = auto_release;
+	sem_ptr->auto_release = (int) auto_release;
 }
 /* }}} */
 

--- a/ext/sysvsem/sysvsem.stub.php
+++ b/ext/sysvsem/sysvsem.stub.php
@@ -6,10 +6,7 @@ final class SysvSemaphore
 {
 }
 
-/**
- * @todo use bool for $auto_release
- */
-function sem_get(int $key, int $max_acquire = 1, int $perm = 0666, int $auto_release = 1): SysvSemaphore|false {}
+function sem_get(int $key, int $max_acquire = 1, int $perm = 0666, bool $auto_release = true): SysvSemaphore|false {}
 
 function sem_acquire(SysvSemaphore $semaphore, bool $nowait = false): bool {}
 

--- a/ext/sysvsem/sysvsem_arginfo.h
+++ b/ext/sysvsem/sysvsem_arginfo.h
@@ -1,11 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a9de9877facd28112e1fe21cf7c6f1c7fdc8014d */
+ * Stub hash: d00524488977b77475f9aa78c132a6dd53ab4dd0 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_sem_get, 0, 1, SysvSemaphore, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, key, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, max_acquire, IS_LONG, 0, "1")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, perm, IS_LONG, 0, "0666")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, auto_release, IS_LONG, 0, "1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, auto_release, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sem_acquire, 0, 1, _IS_BOOL, 0)

--- a/main/output.c
+++ b/main/output.c
@@ -1507,11 +1507,11 @@ PHP_FUNCTION(ob_implicit_flush)
 {
 	zend_long flag = 1;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &flag) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &flag) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	php_output_set_implicit_flush(flag);
+	php_output_set_implicit_flush((int) flag);
 }
 /* }}} */
 


### PR DESCRIPTION
This changes `ob_implicit_flush()` and `sem_get()` to accept a `bool` instead of an `int` when the parameter behaves as a `bool`.

If it's really possible to make this change, I'll add an UPGRADING entry.