### PR TITLE
Fixing segfault with get_result and PS cursors

### DIFF
--- a/ext/mysqli/tests/mysqli_stmt_get_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result.phpt
@@ -109,31 +109,62 @@ if (!function_exists('mysqli_stmt_get_result'))
 
     mysqli_stmt_close($stmt);
 
+    // get_result cannot be used in PS cursor mode
     if (!$stmt = mysqli_stmt_init($link))
-        printf("[032] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+        printf("[030] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
-        printf("[033] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+        printf("[031] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+
+    if (!mysqli_stmt_attr_set($stmt, MYSQLI_STMT_ATTR_CURSOR_TYPE, MYSQLI_CURSOR_TYPE_READ_ONLY))
+        printf("[032] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (!mysqli_stmt_execute($stmt))
-        printf("[034] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+        printf("[033] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+    try {
+        $res = mysqli_stmt_get_result($stmt);
+        // we expect no segfault if we try to fetch a row because get_result should throw an error or return false
+        mysqli_fetch_assoc($res);
+    } catch (\mysqli_sql_exception $e) {
+        echo $e->getMessage() . "\n";
+    }
+
+    try {
+        $res = $stmt->get_result();
+        // we expect no segfault if we try to fetch a row because get_result should throw an error or return false
+        $res->fetch_assoc();
+    } catch (\mysqli_sql_exception $e) {
+        echo $e->getMessage() . "\n";
+    }
+    mysqli_report(MYSQLI_REPORT_OFF);
+
+    if (!$stmt = mysqli_stmt_init($link))
+        printf("[034] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+
+    if (!mysqli_stmt_prepare($stmt, "SELECT id, label FROM test ORDER BY id LIMIT 2"))
+        printf("[035] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+
+    if (!mysqli_stmt_execute($stmt))
+        printf("[036] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     $id = NULL;
     $label = NULL;
     if (true !== ($tmp = mysqli_stmt_bind_result($stmt, $id, $label)))
-        printf("[035] Expecting boolean/true, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
+        printf("[037] Expecting boolean/true, got %s/%s\n", gettype($tmp), var_export($tmp, 1));
 
     if (!is_object($tmp = $result = mysqli_stmt_get_result($stmt)))
-        printf("[036] Expecting array, got %s/%s, [%d] %s\n",
+        printf("[038] Expecting array, got %s/%s, [%d] %s\n",
             gettype($tmp), var_export($tmp, 1),
             mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
     if (false !== ($tmp = mysqli_stmt_fetch($stmt)))
-        printf("[037] Expecting boolean/false, got %s/%s, [%d] %s\n",
+        printf("[039] Expecting boolean/false, got %s/%s, [%d] %s\n",
             gettype($tmp), $tmp, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
-    printf("[038] [%d] [%s]\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
-    printf("[039] [%d] [%s]\n", mysqli_errno($link), mysqli_error($link));
+    printf("[040] [%d] [%s]\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
+    printf("[041] [%d] [%s]\n", mysqli_errno($link), mysqli_error($link));
     while ($row = mysqli_fetch_assoc($result)) {
         var_dump($row);
     }
@@ -165,8 +196,10 @@ if (!function_exists('mysqli_stmt_get_result'))
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is not fully initialized
-[038] [2014] [Commands out of sync; you can't run this command now]
-[039] [0] []
+mysqli_stmt_get_result() cannot be used with cursors
+get_result() cannot be used with cursors
+[040] [2014] [Commands out of sync; you can't run this command now]
+[041] [0] []
 array(2) {
   ["id"]=>
   int(1)

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -161,7 +161,7 @@ MYSQLND_METHOD(mysqlnd_stmt, get_result)(MYSQLND_STMT * const s)
 
 	/* Nothing to store for UPSERT/LOAD DATA*/
 	if (GET_CONNECTION_STATE(&conn->state) != CONN_FETCHING_DATA || stmt->state != MYSQLND_STMT_WAITING_USE_OR_STORE) {
-		SET_CLIENT_ERROR(conn->error_info, CR_COMMANDS_OUT_OF_SYNC, UNKNOWN_SQLSTATE, mysqlnd_out_of_sync);
+		SET_CLIENT_ERROR(stmt->error_info, CR_COMMANDS_OUT_OF_SYNC, UNKNOWN_SQLSTATE, mysqlnd_out_of_sync);
 		DBG_RETURN(NULL);
 	}
 

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -149,8 +149,14 @@ MYSQLND_METHOD(mysqlnd_stmt, get_result)(MYSQLND_STMT * const s)
 	}
 
 	if (stmt->cursor_exists) {
-		/* Silently convert buffered to unbuffered, for now */
-		DBG_RETURN(s->m->use_result(s));
+		/* Prepared statement cursors are not supported as of yet */
+		char * msg;
+		mnd_sprintf(&msg, 0, "%s() cannot be used with cursors", get_active_function_name());
+		SET_CLIENT_ERROR(stmt->error_info, CR_NOT_IMPLEMENTED, UNKNOWN_SQLSTATE, msg);
+		if (msg) {
+			mnd_sprintf_free(msg);
+		}
+		DBG_RETURN(NULL);
 	}
 
 	/* Nothing to store for UPSERT/LOAD DATA*/


### PR DESCRIPTION
This is a > 10-year-old bug. A segfault happens when you try to use `get_result()` when the prepared statement has been executed in cursor mode. The cause for this bug was a silent switch from buffered to unbuffered when calling get_result(). We could fix this functionality and implement proper logic for unbuffered `get_result` with cursors but in my opinion it doesn't make much sense. There's probably only a handful of people in the world who would encounter this segfault. Even our test cases for cursor mode do not use `get_result()`. Putting effort into redesigning the code to make this work is not worth the effort. 

The segfault can be reproduced easily with 

```
$stmtQuery = $mysqli->prepare("SELECT 42, 'name' ");
$stmtQuery->attr_set(MYSQLI_STMT_ATTR_CURSOR_TYPE, MYSQLI_CURSOR_TYPE_READ_ONLY);
$stmtQuery->execute();
$res = $stmtQuery->get_result();
$res->fetch_assoc();
```

My proposal to address this segfault is to simply throw an error when someone tries to use `get_result()` with `MYSQLI_CURSOR_TYPE_READ_ONLY`


P.S. While debugging I made 2 small formatting improvements
