### PR TITLE
Unifying mysqli exceptions

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -169,6 +169,7 @@ PHP_FUNCTION(mysqli_autocommit)
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
 
 	if (mysql_autocommit(mysql->mysql, (my_bool)automode)) {
+		MYSQLI_REPORT_MYSQL_ERROR(mysql->mysql);
 		RETURN_FALSE;
 	}
 	RETURN_TRUE;
@@ -708,6 +709,7 @@ PHP_FUNCTION(mysqli_commit)
 #else
 	if (FAIL == mysqlnd_commit(mysql->mysql, flags, name)) {
 #endif
+		MYSQLI_REPORT_MYSQL_ERROR(mysql->mysql);
 		RETURN_FALSE;
 	}
 	RETURN_TRUE;
@@ -1927,6 +1929,7 @@ PHP_FUNCTION(mysqli_rollback)
 #else
 	if (FAIL == mysqlnd_rollback(mysql->mysql, flags, name)) {
 #endif
+		MYSQLI_REPORT_MYSQL_ERROR(mysql->mysql);
 		RETURN_FALSE;
 	}
 	RETURN_TRUE;
@@ -2297,6 +2300,7 @@ PHP_FUNCTION(mysqli_stmt_attr_set)
 #else
 	if (FAIL == mysql_stmt_attr_set(stmt->stmt, attr, mode_p)) {
 #endif
+		MYSQLI_REPORT_STMT_ERROR(stmt->stmt);
 		RETURN_FALSE;
 	}
 	RETURN_TRUE;

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -53,6 +53,8 @@ require_once('skipifconnectfailure.inc');
     mysqli_autocommit($link, true);
     mysqli_commit($link);
     mysqli_rollback($link);
+    $stmt = mysqli_stmt_init($link);
+    mysqli_stmt_prepare($stmt, "SELECT id FROM test WHERE id > ?");
     while(mysqli_more_results($link)) {
         mysqli_next_result($link);
         $res = mysqli_store_result($link);
@@ -81,6 +83,8 @@ require_once('skipifconnectfailure.inc');
     mysqli_autocommit($link, true);
     mysqli_commit($link);
     mysqli_rollback($link);
+    $stmt = mysqli_stmt_init($link);
+    mysqli_stmt_prepare($stmt, "SELECT id FROM test WHERE id > ?");
     while(mysqli_more_results($link)) {
         mysqli_next_result($link);
         $res = mysqli_store_result($link);
@@ -323,6 +327,8 @@ Warning: mysqli_autocommit(): (%s/%d): Commands out of sync; you can't run this 
 Warning: mysqli_commit(): (%s/%d): Commands out of sync; you can't run this command now in %s on line %d
 
 Warning: mysqli_rollback(): (%s/%d): Commands out of sync; you can't run this command now in %s on line %d
+
+Warning: mysqli_stmt_prepare(): (%s/%d): Commands out of sync; you can't run this command now in %s on line %d
 
 Warning: mysqli_store_result(): (%s/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -49,6 +49,18 @@ require_once('skipifconnectfailure.inc');
         printf("[009] select_db should have failed\n");
     // mysqli_store_result() and mysqli_use_result() cannot be tested, because one would need to cause an error inside the C function to test it
 
+    mysqli_multi_query($link, "SELECT 1; FOO;");
+    mysqli_autocommit($link, true);
+    mysqli_commit($link);
+    mysqli_rollback($link);
+    while(mysqli_more_results($link)) {
+        mysqli_next_result($link);
+        $res = mysqli_store_result($link);
+    }
+    mysqli_next_result($link);
+
+    $stmt = mysqli_prepare($link, "SELECT 1");
+    mysqli_stmt_attr_set($stmt, MYSQLI_STMT_ATTR_CURSOR_TYPE, MYSQLI_CURSOR_TYPE_FOR_UPDATE);
 
     // Check that none of the above would have caused any error messages if MYSQL_REPORT_ERROR would
     // not have been set. If that would be the case, the test would be broken.
@@ -64,6 +76,19 @@ require_once('skipifconnectfailure.inc');
     mysqli_prepare($link, "FOO");
     mysqli_real_query($link, "FOO");
     mysqli_select_db($link, "Oh lord, let this be an unknown database name");
+
+    mysqli_multi_query($link, "SELECT 1; FOO;");
+    mysqli_autocommit($link, true);
+    mysqli_commit($link);
+    mysqli_rollback($link);
+    while(mysqli_more_results($link)) {
+        mysqli_next_result($link);
+        $res = mysqli_store_result($link);
+    }
+    mysqli_next_result($link);
+
+    $stmt = mysqli_prepare($link, "SELECT 1");
+    mysqli_stmt_attr_set($stmt, MYSQLI_STMT_ATTR_CURSOR_TYPE, MYSQLI_CURSOR_TYPE_FOR_UPDATE);
 
     /*
     Internal macro MYSQL_REPORT_STMT_ERROR
@@ -292,6 +317,16 @@ mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 Warning: mysqli_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
 Warning: mysqli_real_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
+
+Warning: mysqli_autocommit(): (%s/%d): Commands out of sync; you can't run this command now in %s on line %d
+
+Warning: mysqli_commit(): (%s/%d): Commands out of sync; you can't run this command now in %s on line %d
+
+Warning: mysqli_rollback(): (%s/%d): Commands out of sync; you can't run this command now in %s on line %d
+
+Warning: mysqli_store_result(): (%s/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
+
+Warning: mysqli_stmt_attr_set(): (%s/%d): Not implemented in %s on line %d
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_stmt_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -407,6 +407,7 @@ MYSQLND_METHOD(mysqlnd_stmt, prepare)(MYSQLND_STMT * const s, const char * const
 
 		ret = conn->command->stmt_prepare(conn, query_string);
 		if (FAIL == ret) {
+			COPY_CLIENT_ERROR(stmt->error_info, *conn->error_info);
 			goto fail;
 		}
 	}


### PR DESCRIPTION
Mysqli should be treating all client errors the same, however some functions are not converting client errors to warnings/exceptions. The reason for this is a missing call to either `MYSQLI_REPORT_MYSQL_ERROR()` or `MYSQLI_REPORT_STMT_ERROR()`

`mysqli_set_charset()` fix has been addressed in a separate PR https://github.com/php/php-src/pull/6142