### PR TITLE
Fix inconsistency between grapheme_substr() and substr()

### DIFF
--- a/ext/intl/grapheme/grapheme_string.c
+++ b/ext/intl/grapheme/grapheme_string.c
@@ -375,7 +375,9 @@ PHP_FUNCTION(grapheme_substr)
 		RETURN_THROWS();
 	}
 
-	if ( OUTSIDE_STRING(lstart, str_len)) {
+	if (str_len == 0 && lstart == 0) {
+		RETURN_EMPTY_STRING();
+	} else if (OUTSIDE_STRING(lstart, str_len)) {
 		zend_argument_value_error(2, "must be contained in argument #1 ($string)");
 		RETURN_THROWS();
 	}

--- a/ext/intl/tests/grapheme_substr.phpt
+++ b/ext/intl/tests/grapheme_substr.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test grapheme_substr() function
+--SKIPIF--
+<?php if( !extension_loaded( 'intl' ) ) print 'skip'; ?>
+--FILE--
+<?php
+
+ini_set("intl.error_level", E_WARNING);
+
+var_dump(grapheme_substr("", 0, 5));
+
+try {
+    grapheme_substr("", 1, 5);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+var_dump(grapheme_substr("abc", 0, 5));
+
+try {
+    grapheme_substr("abc", 3, 5);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+string(0) ""
+grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)
+string(3) "abc"
+grapheme_substr(): Argument #2 ($start) must be contained in argument #1 ($string)


### PR DESCRIPTION
`grapheme_substr("", 0, $length)` should return an empty string no matter what integer value `$length` has. This hasn't been the case before, so let's make this behaviour consistent with `substr()`.

A remaining inconcistency is that while `grapheme_substr("abc", strlen("abc"), $length)` throws an exception, `substr("abc", strlen("abc"), $length)` returns `""`, but  `substr("abc", strlen("abc") + 1, $length)` returns `false`. It seems to me that `substr()` is even inconsistent with itself, but it's pretty much probable that I forgot about this change, and the reasoning behind this.
