### PR TITLE
Give a bool a bool default value.

### DIFF
--- a/ext/json/json.stub.php
+++ b/ext/json/json.stub.php
@@ -4,7 +4,7 @@
 
 function json_encode(mixed $value, int $options = 0, int $depth = 512): string|false {}
 
-function json_decode(string $json, ?bool $assoc = null, int $depth = 512, int $options = 0): mixed {}
+function json_decode(string $json, ?bool $assoc = false, int $depth = 512, int $options = 0): mixed {}
 
 function json_last_error(): int {}
 

--- a/ext/json/json_arginfo.h
+++ b/ext/json/json_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7dbc9b323b73714227d91cc9566cc3c0c90cd7be */
+ * Stub hash: 626ae672561aecbf9f065e79d7ecd7fd21eec158 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_json_encode, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
@@ -9,7 +9,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_json_decode, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, json, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, assoc, _IS_BOOL, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, assoc, _IS_BOOL, 1, "false")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, depth, IS_LONG, 0, "512")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
The public documentation already has a `FALSE` default value here, so let's keep in sync.