### PR TITLE
Separate Closure::bind() implementations

### DIFF
--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -192,18 +192,11 @@ ZEND_METHOD(Closure, call)
 }
 /* }}} */
 
-/* {{{ Create a closure from another one and bind to another object and scope */
-ZEND_METHOD(Closure, bind)
+
+static zend_always_inline void do_closure_bind(zval *return_value, zval *zclosure, zval *newthis, zval *scope_arg)
 {
-	zval *newthis, *zclosure, *scope_arg = NULL;
-	zend_closure *closure;
 	zend_class_entry *ce, *called_scope;
-
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "Oo!|z", &zclosure, zend_ce_closure, &newthis, &scope_arg) == FAILURE) {
-		RETURN_THROWS();
-	}
-
-	closure = (zend_closure *)Z_OBJ_P(zclosure);
+	zend_closure *closure = (zend_closure *) Z_OBJ_P(zclosure);
 
 	if (scope_arg != NULL) { /* scope argument was given */
 		if (Z_TYPE_P(scope_arg) == IS_OBJECT) {
@@ -239,6 +232,30 @@ ZEND_METHOD(Closure, bind)
 	zend_create_closure(return_value, &closure->func, ce, called_scope, newthis);
 }
 /* }}} */
+
+/* {{{ Create a closure from another one and bind to another object and scope */
+ZEND_METHOD(Closure, bind)
+{
+	zval *newthis, *zclosure, *scope_arg = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oo!|z", &zclosure, zend_ce_closure, &newthis, &scope_arg) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	do_closure_bind(return_value, zclosure, newthis, scope_arg);
+}
+
+/* {{{ Create a closure from another one and bind to another object and scope */
+ZEND_METHOD(Closure, bindTo)
+{
+	zval *newthis, *scope_arg = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "o!|z", &newthis, &scope_arg) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	do_closure_bind(return_value, getThis(), newthis, scope_arg);
+}
 
 static ZEND_NAMED_FUNCTION(zend_closure_call_magic) /* {{{ */ {
 	zend_fcall_info fci;

--- a/Zend/zend_closures.stub.php
+++ b/Zend/zend_closures.stub.php
@@ -9,10 +9,7 @@ final class Closure
     /** @param object|string|null $newScope */
     public static function bind(Closure $closure, ?object $newThis, $newScope = UNKNOWN): ?Closure {}
 
-    /**
-     * @param object|string|null $newScope
-     * @alias Closure::bind
-     */
+    /** @param object|string|null $newScope */
     public function bindTo(?object $newThis, $newScope = UNKNOWN): ?Closure {}
 
     public function call(object $newThis, mixed ...$arguments): mixed {}

--- a/Zend/zend_closures_arginfo.h
+++ b/Zend/zend_closures_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 124654da4652ea828875f471a2ddcc4afae147ae */
+ * Stub hash: abbbe7b04323dc44b0675ad58700e996a6d7c43b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Closure___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -27,6 +27,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_METHOD(Closure, __construct);
 ZEND_METHOD(Closure, bind);
+ZEND_METHOD(Closure, bindTo);
 ZEND_METHOD(Closure, call);
 ZEND_METHOD(Closure, fromCallable);
 
@@ -34,7 +35,7 @@ ZEND_METHOD(Closure, fromCallable);
 static const zend_function_entry class_Closure_methods[] = {
 	ZEND_ME(Closure, __construct, arginfo_class_Closure___construct, ZEND_ACC_PRIVATE)
 	ZEND_ME(Closure, bind, arginfo_class_Closure_bind, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	ZEND_MALIAS(Closure, bindTo, bind, arginfo_class_Closure_bindTo, ZEND_ACC_PUBLIC)
+	ZEND_ME(Closure, bindTo, arginfo_class_Closure_bindTo, ZEND_ACC_PUBLIC)
 	ZEND_ME(Closure, call, arginfo_class_Closure_call, ZEND_ACC_PUBLIC)
 	ZEND_ME(Closure, fromCallable, arginfo_class_Closure_fromCallable, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END


### PR DESCRIPTION
`Closure::bind()` and `Closure::bindTo()` are currently reported as aliases in stubs because they have a single implementation. They are not aliases in fact though, they just use `zend_parse_method_parameters()` cleverly.

Thus, let's separate their implementation so that we don't have to alias `Closure::bindTo()` anymore. This will also have the advantage that the two ZPP implementations become more clear.

We could also use a currently hypothetical `@implementation-alias` PHPDoc annotation, but I think we are better off by choosing separation.