### PR TITLE
Add support for `@implementation-alias` in stubs

### DIFF
--- a/Zend/zend_exceptions.stub.php
+++ b/Zend/zend_exceptions.stub.php
@@ -55,40 +55,40 @@ class ErrorException extends Exception
 
 class Error implements Throwable
 {
-    /** @alias Exception::__clone */
+    /** @implementation-alias Exception::__clone */
     final private function __clone() {}
 
-    /** @alias Exception::__construct */
+    /** @implementation-alias Exception::__construct */
     public function __construct(string $message = UNKNOWN, int $code = 0, ?Throwable $previous = null) {}
 
-    /** @alias Exception::__wakeup */
+    /** @implementation-alias Exception::__wakeup */
     public function __wakeup() {}
 
-    /** @alias Exception::getMessage */
+    /** @implementation-alias Exception::getMessage */
     final public function getMessage(): string {}
 
     /**
      * @return int
-     * @alias Exception::getCode
+     * @implementation-alias Exception::getCode
      */
     final public function getCode() {}
 
-    /** @alias Exception::getFile */
+    /** @implementation-alias Exception::getFile */
     final public function getFile(): string {}
 
-    /** @alias Exception::getLine */
+    /** @implementation-alias Exception::getLine */
     final public function getLine(): int {}
 
-    /** @alias Exception::getTrace */
+    /** @implementation-alias Exception::getTrace */
     final public function getTrace(): array {}
 
-    /** @alias Exception::getPrevious */
+    /** @implementation-alias Exception::getPrevious */
     final public function getPrevious(): ?Throwable {}
 
-    /** @alias Exception::getTraceAsString */
+    /** @implementation-alias Exception::getTraceAsString */
     final public function getTraceAsString(): string {}
 
-    /** @alias Exception::__toString */
+    /** @implementation-alias Exception::__toString */
     public function __toString(): string {}
 }
 

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7eb20393f4ca314324d9813983124f724189ce8a */
+ * Stub hash: d0679a3c11f089dcb31cfdfe56f0336ceba301a9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Throwable_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -362,6 +362,8 @@ class FuncInfo {
     public $name;
     /** @var int */
     public $flags;
+    /** @var string|null */
+    public $aliasType;
     /** @var FunctionName|null */
     public $alias;
     /** @var bool */
@@ -378,6 +380,7 @@ class FuncInfo {
     public function __construct(
         FunctionName $name,
         int $flags,
+        ?string $aliasType,
         ?FunctionName $alias,
         bool $isDeprecated,
         array $args,
@@ -387,6 +390,7 @@ class FuncInfo {
     ) {
         $this->name = $name;
         $this->flags = $flags;
+        $this->aliasType = $aliasType;
         $this->alias = $alias;
         $this->isDeprecated = $isDeprecated;
         $this->args = $args;
@@ -617,6 +621,7 @@ function parseFunctionLike(
 ): FuncInfo {
     $comment = $func->getDocComment();
     $paramMeta = [];
+    $aliasType = null;
     $alias = null;
     $isDeprecated = false;
     $haveDocReturnType = false;
@@ -631,7 +636,8 @@ function parseFunctionLike(
                     $paramMeta[$varName] = [];
                 }
                 $paramMeta[$varName]['preferRef'] = true;
-            } else if ($tag->name === 'alias') {
+            } else if ($tag->name === 'alias' || $tag->name === 'implementation-alias') {
+                $aliasType = $tag->name;
                 $aliasParts = explode("::", $tag->getValue());
                 if (count($aliasParts) === 1) {
                     $alias = new FunctionName(null, $aliasParts[0]);
@@ -721,6 +727,7 @@ function parseFunctionLike(
     return new FuncInfo(
         $name,
         $flags,
+        $aliasType,
         $alias,
         $isDeprecated,
         $args,

--- a/ext/phar/phar_object.stub.php
+++ b/ext/phar/phar_object.stub.php
@@ -181,191 +181,191 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
 
 class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAccess
 {
-    /** @alias Phar::__construct */
+    /** @implementation-alias Phar::__construct */
     public function __construct(string $filename, int $flags = FilesystemIterator::SKIP_DOTS|FilesystemIterator::UNIX_PATHS, ?string $alias = null, int $fileformat = 0) {}
 
-    /** @alias Phar::__destruct */
+    /** @implementation-alias Phar::__destruct */
     public function __destruct() {}
 
     /**
      * @return void
-     * @alias Phar::addEmptyDir
+     * @implementation-alias Phar::addEmptyDir
      */
     public function addEmptyDir(string $dirname) {}
 
     /**
      * @return void
-     * @alias Phar::addFile
+     * @implementation-alias Phar::addFile
      */
     public function addFile(string $filename, ?string $localname = null) {}
 
     /**
      * @return void
-     * @alias Phar::addFromString
+     * @implementation-alias Phar::addFromString
      */
     public function addFromString(string $localname, string $contents) {}
 
     /**
      * @return array|false
-     * @alias Phar::buildFromDirectory
+     * @implementation-alias Phar::buildFromDirectory
      */
     public function buildFromDirectory(string $base_dir, string $regex = "") {}
 
     /**
      * @return array|false
-     * @alias Phar::buildFromIterator
+     * @implementation-alias Phar::buildFromIterator
      */
     public function buildFromIterator(Traversable $iterator, ?string $base_directory = null) {}
 
     /**
      * @return void
-     * @alias Phar::compressFiles
+     * @implementation-alias Phar::compressFiles
      */
     public function compressFiles(int $compression_type) {}
 
     /**
      * @return bool
-     * @alias Phar::decompressFiles
+     * @implementation-alias Phar::decompressFiles
      */
     public function decompressFiles() {}
 
     /**
      * @return Phar|null
-     * @alias Phar::compress
+     * @implementation-alias Phar::compress
      */
     public function compress(int $compression_type, ?string $file_ext = null) {}
 
     /**
      * @return Phar|null
-     * @alias Phar::decompress
+     * @implementation-alias Phar::decompress
      */
     public function decompress(?string $file_ext = null) {}
 
     /**
      * @return Phar|null
-     * @alias Phar::convertToExecutable
+     * @implementation-alias Phar::convertToExecutable
      */
     public function convertToExecutable(int $format = 9021976, int $compression_type = 9021976, ?string $file_ext = null) {}
 
     /**
      * @return Phar|null
-     * @alias Phar::convertToData
+     * @implementation-alias Phar::convertToData
      */
     public function convertToData(int $format = 9021976, int $compression_type = 9021976, ?string $file_ext = null) {}
 
     /**
      * @return bool
-     * @alias Phar::copy
+     * @implementation-alias Phar::copy
      */
     public function copy(string $newfile, string $oldfile) {}
 
     /**
      * @return int
-     * @alias Phar::count
+     * @implementation-alias Phar::count
      */
     public function count(int $mode = COUNT_NORMAL) {}
 
     /**
      * @return bool
-     * @alias Phar::delete
+     * @implementation-alias Phar::delete
      */
     public function delete(string $entry) {}
 
     /**
      * @return bool
-     * @alias Phar::delMetadata
+     * @implementation-alias Phar::delMetadata
      */
     public function delMetadata() {}
 
     /**
      * @return bool
-     * @alias Phar::extractTo
+     * @implementation-alias Phar::extractTo
      */
     public function extractTo(string $pathto, array|string|null $files = null, bool $overwrite = false) {}
 
     /**
      * @return string|null
-     * @alias Phar::getAlias
+     * @implementation-alias Phar::getAlias
      */
     public function getAlias() {}
 
     /**
      * @return string
-     * @alias Phar::getPath
+     * @implementation-alias Phar::getPath
      */
     public function getPath() {}
 
     /**
      * @return mixed
-     * @alias Phar::getMetadata
+     * @implementation-alias Phar::getMetadata
      */
     public function getMetadata(array $unserialize_options = []) {}
 
     /**
      * @return bool
-     * @alias Phar::getModified
+     * @implementation-alias Phar::getModified
      */
     public function getModified() {}
 
     /**
      * @return array|false
-     * @alias Phar::getSignature
+     * @implementation-alias Phar::getSignature
      */
     public function getSignature() {}
 
     /**
      * @return string
-     * @alias Phar::getStub
+     * @implementation-alias Phar::getStub
      */
     public function getStub() {}
 
     /**
      * @return string
-     * @alias Phar::getVersion
+     * @implementation-alias Phar::getVersion
      */
     public function getVersion() {}
 
     /**
      * @return bool
-     * @alias Phar::hasMetadata
+     * @implementation-alias Phar::hasMetadata
      */
     public function hasMetadata() {}
 
     /**
      * @return bool
-     * @alias Phar::isBuffering
+     * @implementation-alias Phar::isBuffering
      */
     public function isBuffering() {}
 
     /**
      * @return int|false
-     * @alias Phar::isCompressed
+     * @implementation-alias Phar::isCompressed
      */
     public function isCompressed() {}
 
     /**
      * @return bool
-     * @alias Phar::isFileFormat
+     * @implementation-alias Phar::isFileFormat
      */
     public function isFileFormat(int $fileformat) {}
 
     /**
      * @return bool
-     * @alias Phar::isWritable
+     * @implementation-alias Phar::isWritable
      */
     public function isWritable() {}
 
     /**
      * @param string $entry
      * @return bool
-     * @alias Phar::offsetExists
+     * @implementation-alias Phar::offsetExists
      */
     public function offsetExists($entry) {}
 
     /**
      * @param string $entry
      * @return PharFileInfo
-     * @alias Phar::offsetGet
+     * @implementation-alias Phar::offsetGet
      */
     public function offsetGet($entry) {}
 
@@ -373,104 +373,104 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @param string $entry
      * @param resource|string $value
      * @return void
-     * @alias Phar::offsetSet
+     * @implementation-alias Phar::offsetSet
      */
     public function offsetSet($entry, $value) {}
 
     /**
      * @param string $entry
      * @return bool
-     * @alias Phar::offsetUnset
+     * @implementation-alias Phar::offsetUnset
      */
     public function offsetUnset($entry) {}
 
     /**
      * @return bool
-     * @alias Phar::setAlias
+     * @implementation-alias Phar::setAlias
      */
     public function setAlias(string $alias) {}
 
     /**
      * @return bool
-     * @alias Phar::setDefaultStub
+     * @implementation-alias Phar::setDefaultStub
      */
     public function setDefaultStub(?string $index = null, ?string $webindex = null) {}
 
     /**
      * @return void
-     * @alias Phar::setMetadata
+     * @implementation-alias Phar::setMetadata
      */
     public function setMetadata(mixed $metadata) {}
 
     /**
      * @return void
-     * @alias Phar::setSignatureAlgorithm
+     * @implementation-alias Phar::setSignatureAlgorithm
      */
     public function setSignatureAlgorithm(int $algorithm, ?string $privatekey = null) {}
 
     /**
      * @param resource $newstub
      * @return bool
-     * @alias Phar::setStub
+     * @implementation-alias Phar::setStub
      */
     public function setStub($newstub, int $maxlen = -1) {}
 
     /**
      * @return void
-     * @alias Phar::startBuffering
+     * @implementation-alias Phar::startBuffering
      */
     public function startBuffering() {}
 
     /**
      * @return void
-     * @alias Phar::stopBuffering
+     * @implementation-alias Phar::stopBuffering
      */
     public function stopBuffering() {}
 
-    /** @alias Phar::apiVersion */
+    /** @implementation-alias Phar::apiVersion */
     final public static function apiVersion(): string {}
 
-    /** @alias Phar::canCompress */
+    /** @implementation-alias Phar::canCompress */
     final public static function canCompress(int $method = 0): bool {}
 
-    /** @alias Phar::canWrite */
+    /** @implementation-alias Phar::canWrite */
     final public static function canWrite(): bool {}
 
-    /** @alias Phar::createDefaultStub */
+    /** @implementation-alias Phar::createDefaultStub */
     final public static function createDefaultStub(?string $index = null, ?string $webindex = null): string {}
 
-    /** @alias Phar::getSupportedCompression */
+    /** @implementation-alias Phar::getSupportedCompression */
     final public static function getSupportedCompression(): array {}
 
-    /** @alias Phar::getSupportedSignatures */
+    /** @implementation-alias Phar::getSupportedSignatures */
     final public static function getSupportedSignatures(): array {}
 
-    /** @alias Phar::interceptFileFuncs */
+    /** @implementation-alias Phar::interceptFileFuncs */
     final public static function interceptFileFuncs(): void {}
 
-    /** @alias Phar::isValidPharFilename */
+    /** @implementation-alias Phar::isValidPharFilename */
     final public static function isValidPharFilename(
         string $filename, bool $executable = true): bool {}
 
-    /** @alias Phar::loadPhar */
+    /** @implementation-alias Phar::loadPhar */
     final public static function loadPhar(string $filename, ?string $alias = null): bool {}
 
-    /** @alias Phar::mapPhar */
+    /** @implementation-alias Phar::mapPhar */
     final public static function mapPhar(?string $alias = null, int $offset = 0): bool {}
 
-    /** @alias Phar::running */
+    /** @implementation-alias Phar::running */
     final public static function running(bool $retphar = true): string {}
 
-    /** @alias Phar::mount */
+    /** @implementation-alias Phar::mount */
     final public static function mount(string $inphar, string $externalfile): void {}
 
-    /** @alias Phar::mungServer */
+    /** @implementation-alias Phar::mungServer */
     final public static function mungServer(array $munglist): void {}
 
-    /** @alias Phar::unlinkArchive */
+    /** @implementation-alias Phar::unlinkArchive */
     final public static function unlinkArchive(string $archive): bool {}
 
-    /** @alias Phar::webPhar */
+    /** @implementation-alias Phar::webPhar */
     final public static function webPhar(
         ?string $alias = null, ?string $index = null, string $f404 = "",
         array $mimetypes = [], ?callable $rewrites = null): void {}

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f92d8a7b1266cdec193336b36b2319235fbc40c */
+ * Stub hash: e67cd4d59555843688a1bdd90ecd7d3924f1ee29 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -18,7 +18,7 @@ interface Reflector extends Stringable
 
 abstract class ReflectionFunctionAbstract implements Reflector
 {
-    /** @alias ReflectionClass::__clone */
+    /** @implementation-alias ReflectionClass::__clone */
     final private function __clone() {}
 
     /** @return bool */
@@ -369,7 +369,7 @@ class ReflectionObject extends ReflectionClass
 
 class ReflectionProperty implements Reflector
 {
-    /** @alias ReflectionClass::__clone */
+    /** @implementation-alias ReflectionClass::__clone */
     final private function __clone() {}
 
     public function __construct(object|string $class, string $property) {}
@@ -434,7 +434,7 @@ class ReflectionProperty implements Reflector
 
 class ReflectionClassConstant implements Reflector
 {
-    /** @alias ReflectionClass::__clone */
+    /** @implementation-alias ReflectionClass::__clone */
     final private function __clone() {}
 
     public function __construct(object|string $class, string $constant) {}
@@ -471,7 +471,7 @@ class ReflectionClassConstant implements Reflector
 
 class ReflectionParameter implements Reflector
 {
-    /** @alias ReflectionClass::__clone */
+    /** @implementation-alias ReflectionClass::__clone */
     final private function __clone() {}
 
     /** @param string|array|object $function */
@@ -550,7 +550,7 @@ class ReflectionParameter implements Reflector
 
 abstract class ReflectionType implements Stringable
 {
-    /** @alias ReflectionClass::__clone */
+    /** @implementation-alias ReflectionClass::__clone */
     final private function __clone() {}
 
     /** @return bool */
@@ -575,7 +575,7 @@ class ReflectionUnionType extends ReflectionType
 
 class ReflectionExtension implements Reflector
 {
-    /** @alias ReflectionClass::__clone */
+    /** @implementation-alias ReflectionClass::__clone */
     final private function __clone() {}
 
     public function __construct(string $name) {}
@@ -618,7 +618,7 @@ class ReflectionExtension implements Reflector
 
 class ReflectionZendExtension implements Reflector
 {
-    /** @alias ReflectionClass::__clone */
+    /** @implementation-alias ReflectionClass::__clone */
     final private function __clone() {}
 
     public function __construct(string $name) {}
@@ -647,7 +647,7 @@ final class ReflectionReference
 
     public function getId(): string {}
 
-    /** @alias ReflectionClass::__clone */
+    /** @implementation-alias ReflectionClass::__clone */
     private function __clone() {}
 
     private function __construct() {}

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c2bd96bf9b5ca866860f8f3c04937c9fff5c3afa */
+ * Stub hash: 35e17de0cdf6c11a315f6d10fd711492d1da567c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)

--- a/ext/spl/spl_array.stub.php
+++ b/ext/spl/spl_array.stub.php
@@ -98,118 +98,118 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
     /**
      * @param string|int $index
      * @return bool
-     * @alias ArrayObject::offsetExists
+     * @implementation-alias ArrayObject::offsetExists
      */
     public function offsetExists($index) {}
 
     /**
      * @param string|int $index
      * @return mixed
-     * @alias ArrayObject::offsetGet
+     * @implementation-alias ArrayObject::offsetGet
      */
     public function offsetGet($index) {}
 
     /**
      * @param string|int $index
      * @return void
-     * @alias ArrayObject::offsetSet
+     * @implementation-alias ArrayObject::offsetSet
      */
     public function offsetSet($index, mixed $value) {}
 
     /**
      * @param string|int $index
      * @return void
-     * @alias ArrayObject::offsetUnset
+     * @implementation-alias ArrayObject::offsetUnset
      */
     public function offsetUnset($index) {}
 
     /**
      * @return void
-     * @alias ArrayObject::append
+     * @implementation-alias ArrayObject::append
      */
     public function append(mixed $value) {}
 
     /**
      * @return array
-     * @alias ArrayObject::getArrayCopy
+     * @implementation-alias ArrayObject::getArrayCopy
      */
     public function getArrayCopy() {}
 
     /**
      * @return int
-     * @alias ArrayObject::count
+     * @implementation-alias ArrayObject::count
      */
     public function count() {}
 
     /**
      * @return int
-     * @alias ArrayObject::getFlags
+     * @implementation-alias ArrayObject::getFlags
      */
     public function getFlags() {}
 
     /**
      * @return void
-     * @alias ArrayObject::setFlags
+     * @implementation-alias ArrayObject::setFlags
      */
     public function setFlags(int $flags) {}
 
     /**
      * @return bool
-     * @alias ArrayObject::asort
+     * @implementation-alias ArrayObject::asort
      */
     public function asort(int $sort_flags = SORT_REGULAR) {}
 
     /**
      * @return bool
-     * @alias ArrayObject::ksort
+     * @implementation-alias ArrayObject::ksort
      */
     public function ksort(int $sort_flags = SORT_REGULAR) {}
 
     /**
      * @return bool
-     * @alias ArrayObject::uasort
+     * @implementation-alias ArrayObject::uasort
      */
     public function uasort(callable $cmp_function) {}
 
     /**
      * @return bool
-     * @alias ArrayObject::uksort
+     * @implementation-alias ArrayObject::uksort
      */
     public function uksort(callable $cmp_function) {}
 
     /**
      * @return bool
-     * @alias ArrayObject::natsort
+     * @implementation-alias ArrayObject::natsort
      */
     public function natsort() {}
 
     /**
      * @return bool
-     * @alias ArrayObject::natcasesort
+     * @implementation-alias ArrayObject::natcasesort
      */
     public function natcasesort() {}
 
     /**
      * @return void
-     * @alias ArrayObject::unserialize
+     * @implementation-alias ArrayObject::unserialize
      */
     public function unserialize(string $serialized) {}
 
     /**
      * @return string
-     * @alias ArrayObject::serialize
+     * @implementation-alias ArrayObject::serialize
      */
     public function serialize() {}
 
     /**
      * @return array
-     * @alias ArrayObject::__serialize
+     * @implementation-alias ArrayObject::__serialize
      */
     public function __serialize() {}
 
     /**
      * @return void
-     * @alias ArrayObject::__unserialize
+     * @implementation-alias ArrayObject::__unserialize
      */
     public function __unserialize(array $data) {}
 
@@ -233,7 +233,7 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
 
     /**
      * @return array
-     * @alias ArrayObject::__debugInfo
+     * @implementation-alias ArrayObject::__debugInfo
      */
     public function __debugInfo() {}
 }

--- a/ext/spl/spl_array_arginfo.h
+++ b/ext/spl/spl_array_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bedd13338707177e28a021722df64be2f74a7945 */
+ * Stub hash: 1b93d102c6dfa12f65a95a50bbc78c03802e261c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ArrayObject___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_MASK(0, input, MAY_BE_ARRAY|MAY_BE_OBJECT, "[]")

--- a/ext/spl/spl_directory.stub.php
+++ b/ext/spl/spl_directory.stub.php
@@ -90,7 +90,7 @@ class SplFileInfo
     /** @return void */
     public function setInfoClass(string $class_name = SplFileInfo::class) {}
 
-    /** @alias SplFileInfo::getPathname */
+    /** @implementation-alias SplFileInfo::getPathname */
     public function __toString(): string {}
 
     /** @return array */
@@ -134,7 +134,7 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator
     /** @return void */
     public function seek(int $position) {}
 
-    /** @alias DirectoryIterator::getFilename */
+    /** @implementation-alias DirectoryIterator::getFilename */
     public function __toString(): string {}
 }
 
@@ -286,7 +286,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      */
     public function getCurrentLine() {}
 
-    /** @alias SplFileObject::fgets */
+    /** @implementation-alias SplFileObject::fgets */
     public function __toString(): string {}
 }
 

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4bf9a6a3687e5d14883d35b26c13b05216c86ac3 */
+ * Stub hash: 071a92d8e5998c518e377b5620dfdda6fb189a1d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFileInfo___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, file_name, IS_STRING, 0)

--- a/ext/spl/spl_dllist.stub.php
+++ b/ext/spl/spl_dllist.stub.php
@@ -99,13 +99,13 @@ class SplQueue extends SplDoublyLinkedList
 {
     /**
      * @return void
-     * @alias SplDoublyLinkedList::push
+     * @implementation-alias SplDoublyLinkedList::push
      */
     public function enqueue(mixed $value) {}
 
     /**
      * @return mixed
-     * @alias SplDoublyLinkedList::shift
+     * @implementation-alias SplDoublyLinkedList::shift
      */
     public function dequeue() {}
 }

--- a/ext/spl/spl_dllist_arginfo.h
+++ b/ext/spl/spl_dllist_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 26a454261393ea3bdb6252b2d8140434664b5771 */
+ * Stub hash: 9d17266fba7a05a5fddca0ddf6b64b1c2f683cae */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplDoublyLinkedList_add, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)

--- a/ext/spl/spl_heap.stub.php
+++ b/ext/spl/spl_heap.stub.php
@@ -21,19 +21,19 @@ class SplPriorityQueue implements Iterator, Countable
 
     /**
      * @return int
-     * @alias SplHeap::count
+     * @implementation-alias SplHeap::count
      */
     public function count() {}
 
     /**
      * @return bool
-     * @alias SplHeap::isEmpty
+     * @implementation-alias SplHeap::isEmpty
      */
     public function isEmpty() {}
 
     /**
      * @return void
-     * @alias SplHeap::rewind
+     * @implementation-alias SplHeap::rewind
      */
     public function rewind() {}
 
@@ -42,31 +42,31 @@ class SplPriorityQueue implements Iterator, Countable
 
     /**
      * @return int
-     * @alias SplHeap::key
+     * @implementation-alias SplHeap::key
      */
     public function key() {}
 
     /**
      * @return void
-     * @alias SplHeap::next
+     * @implementation-alias SplHeap::next
      */
     public function next() {}
 
     /**
      * @return bool
-     * @alias SplHeap::valid
+     * @implementation-alias SplHeap::valid
      */
     public function valid() {}
 
     /**
      * @return bool
-     * @alias SplHeap::recoverFromCorruption
+     * @implementation-alias SplHeap::recoverFromCorruption
      */
     public function recoverFromCorruption() {}
 
     /**
      * @return bool
-     * @alias SplHeap::isCorrupted
+     * @implementation-alias SplHeap::isCorrupted
      */
     public function isCorrupted() {}
 

--- a/ext/spl/spl_heap_arginfo.h
+++ b/ext/spl/spl_heap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e57b1d7e9139aa2759f548cf800857cccf1d1f25 */
+ * Stub hash: 510a58000a5473c4cbb33886f43b9f3050b3a36d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplPriorityQueue_compare, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, priority1, IS_MIXED, 0)

--- a/ext/spl/spl_iterators.stub.php
+++ b/ext/spl/spl_iterators.stub.php
@@ -34,7 +34,7 @@ class RecursiveCallbackFilterIterator extends CallbackFilterIterator implements 
 
     /**
      * @return bool
-     * @alias RecursiveFilterIterator::hasChildren
+     * @implementation-alias RecursiveFilterIterator::hasChildren
      */
     public function hasChildren() {}
 
@@ -168,7 +168,7 @@ class ParentIterator extends RecursiveFilterIterator
 
     /**
      * @return bool
-     * @alias RecursiveFilterIterator::hasChildren
+     * @implementation-alias RecursiveFilterIterator::hasChildren
      */
     public function accept() {}
 }
@@ -357,7 +357,7 @@ class RecursiveRegexIterator extends RegexIterator implements RecursiveIterator
 
     /**
      * @return bool
-     * @alias RecursiveFilterIterator::hasChildren
+     * @implementation-alias RecursiveFilterIterator::hasChildren
      */
     public function hasChildren() {}
 

--- a/ext/spl/spl_iterators_arginfo.h
+++ b/ext/spl/spl_iterators_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3d98c82203230f2636c7fedb5717da5f7ab973f2 */
+ * Stub hash: 38fb46070ea48e774343e59de53797969acf4b06 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_EmptyIterator_current, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/ext/spl/spl_observer.stub.php
+++ b/ext/spl/spl_observer.stub.php
@@ -73,7 +73,7 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
     /**
      * @param object $object
      * @return bool
-     * @alias SplObjectStorage::contains
+     * @implementation-alias SplObjectStorage::contains
      */
     public function offsetExists($object) {}
 
@@ -86,14 +86,14 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
     /**
      * @param object $object
      * @return void
-     * @alias SplObjectStorage::attach
+     * @implementation-alias SplObjectStorage::attach
      */
     public function offsetSet($object, mixed $info = null) {}
 
     /**
      * @param object $object
      * @return void
-     * @alias SplObjectStorage::detach
+     * @implementation-alias SplObjectStorage::detach
      */
     public function offsetUnset($object) {}
 
@@ -149,7 +149,7 @@ class MultipleIterator implements Iterator
 
     /**
      * @return array
-     * @alias SplObjectStorage::__debugInfo
+     * @implementation-alias SplObjectStorage::__debugInfo
      */
     public function __debugInfo() {}
 }

--- a/ext/spl/spl_observer_arginfo.h
+++ b/ext/spl/spl_observer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: aab6134fb2223ffe4d686f3a601e66da17c99511 */
+ * Stub hash: c526488c83b1de019f4257e2ddaaa8fb8f1bb323 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplObserver_update, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, subject, SplSubject, 0)

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -4,7 +4,7 @@
 
 class SQLite3
 {
-    /** @alias SQLite3::open */
+    /** @implementation-alias SQLite3::open */
     public function __construct(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryption_key = "") {}
 
     /** @return void */

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 749f2c1a6b0bf3b889a294ad621995ba74e8ab39 */
+ * Stub hash: 293f1041949989de457a4091b751674bf301c2bd */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1309,7 +1309,8 @@ function stream_set_write_buffer($stream, int $buffer): int {}
 
 /**
  * @param resource $stream
- * @alias stream_set_write_buffer */
+ * @alias stream_set_write_buffer
+ */
 function set_file_buffer($stream, int $buffer): int {}
 
 /** @param resource $stream */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: df6d5ebb0449274b94f1e8707ab54978fd4b7d2f */
+ * Stub hash: 3dc6fc3e3cd4bb5442bfd50c34463b3834bba289 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)

--- a/ext/standard/dir.stub.php
+++ b/ext/standard/dir.stub.php
@@ -7,21 +7,21 @@ class Directory
     /**
      * @param resource|null $dir_handle
      * @return void
-     * @alias closedir
+     * @implementation-alias closedir
      */
     public function close($dir_handle = null) {}
 
     /**
      * @param resource|null $dir_handle
      * @return void
-     * @alias rewinddir
+     * @implementation-alias rewinddir
      */
     public function rewind($dir_handle = null) {}
 
     /**
      * @param resource|null $dir_handle
      * @return string|false
-     * @alias readdir
+     * @implementation-alias readdir
      */
     public function read($dir_handle = null) {}
 }

--- a/ext/standard/dir_arginfo.h
+++ b/ext/standard/dir_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2670287ef059725cceda0a8f9ac6515cdcedb521 */
+ * Stub hash: d8d8c93a1659e1790b25a65d7e1d0d7430724e9d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Directory_close, 0, 0, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, dir_handle, "null")


### PR DESCRIPTION
Currently, we have three use-cases for the `@alias` annotation in stubs:
- real aliasing: `array_key_exists()` and `key_exists()`
- aliasing procedural and OO interfaces: `date_diff()` and `DateTime::diff()`
- reusing the same implementation for unrelated methods: `ReflectionProperty::__clone()` and `ReflectionParameter::__clone()`

In order to make it easier to generate method synopses for the manual, I think we should distinguish at least the last use-case from the others. That's why this PR adds support for an `@implementation-alias` annotation to denote the fact that two methods don't have much to do with each other, even though they share the same implementation. To be honest, it *might* be possible to achieve the same by using the following heuristics: if the alias and the aliased methods are defined in different classes then they are only "implementation-aliases". I think it's nice to make the distinction between "real" and "implementation" aliasing more explicit, so I'd still prefer to add the new annotation.

Another question is if we want to distinguish the first two use-cases. Currently, it seems that it's not strictly required for generating signatures for the manual, but I'm wondering if static analysis tools like Phan or PHPStan need to know if a method has a procedural counterpart (e.g. by using a new `@method-alias` annotation). @TysonAndre @ondrejmirtes can you please share with us if you need such information?

Finally, I've just found yet another gotcha: in case of "type 2" aliasing, stubs always take the procedural API as the base, while the OO interface is the alias. On the other hand, the manual does this the other way around, at least for the extensions I checked: ext/date and ext/mysqli. So it might be possible that we have to change the direction of the aliases if alias information is really needed for generating synopses for the manual. I don't exactly understand this, so @cmb69 can you please share your insights? :)