### PR TITLE
Rename mysqli parameters to be more logical.

### DIFF
--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -10,7 +10,7 @@ class mysqli
 {
     public function __construct(
         ?string $host = null,
-        ?string $user = null,
+        ?string $username = null,
         ?string $password = null,
         ?string $database = null,
         ?int $port = null,
@@ -21,7 +21,7 @@ class mysqli
      * @return bool
      * @alias mysqli_autocommit
      */
-    public function autocommit(bool $mode) {}
+    public function autocommit(bool $enable) {}
 
     /**
      * @return bool
@@ -33,7 +33,7 @@ class mysqli
      * @return bool
      * @alias mysqli_change_user
      */
-    public function change_user(string $user, string $password, ?string $database) {}
+    public function change_user(string $username, string $password, ?string $database) {}
 
     /**
      * @return string|null
@@ -59,7 +59,7 @@ class mysqli
      */
     public function connect(
         ?string $host = null,
-        ?string $user = null,
+        ?string $username = null,
         ?string $password = null,
         ?string $database = null,
         ?int $port = null,
@@ -76,7 +76,7 @@ class mysqli
      * @return bool
      * @alias mysqli_debug
      */
-    public function debug(string $debug_options) {}
+    public function debug(string $options) {}
 
     /**
      * @return object|null
@@ -120,7 +120,7 @@ class mysqli
      * @return bool
      * @alias mysqli_kill
      */
-    public function kill(int $connection_id) {}
+    public function kill(int $process_id) {}
 
     /**
      * @return bool
@@ -151,7 +151,7 @@ class mysqli
      * @return int|false
      * @alias mysqli_poll
      */
-    public static function poll(?array &$read, ?array &$write, array &$error, int $sec, int $usec = 0) {}
+    public static function poll(?array &$read, ?array &$write, array &$error, int $seconds, int $microseconds = 0) {}
 #endif
 
     /**
@@ -172,7 +172,7 @@ class mysqli
      */
     public function real_connect(
         ?string $host = null,
-        ?string $user = null,
+        ?string $username = null,
         ?string $password = null,
         ?string $database = null,
         ?int $port = null,
@@ -184,7 +184,7 @@ class mysqli
      * @return string
      * @alias mysqli_real_escape_string
      */
-    public function real_escape_string(string $string_to_escape) {}
+    public function real_escape_string(string $string) {}
 
 #if defined(MYSQLI_USE_MYSQLND)
     /**
@@ -198,7 +198,7 @@ class mysqli
      * @return string
      * @alias mysqli_real_escape_string
      */
-    public function escape_string(string $string_to_escape) {}
+    public function escape_string(string $string) {}
 
     /**
      * @return bool
@@ -256,10 +256,10 @@ class mysqli
      */
     public function ssl_set(
         string $key,
-        string $cert,
-        string $certificate_authority,
-        string $certificate_authority_path,
-        string $cipher
+        string $certificate,
+        string $ca_certificate,
+        string $ca_path,
+        string $cipher_algos
     ) {}
 
     /**
@@ -278,7 +278,7 @@ class mysqli
      * @return mysqli_result|false
      * @alias mysqli_store_result
      */
-    public function store_result(int $flags = 0) {}
+    public function store_result(int $mode = 0) {}
 
     /**
      * @return bool
@@ -296,12 +296,12 @@ class mysqli
      * @return bool
      * @alias mysqli_refresh
      */
-    public function refresh(int $options) {}
+    public function refresh(int $flags) {}
 }
 
 class mysqli_result implements IteratorAggregate
 {
-    public function __construct(mysqli $mysqli_link, int $result_mode = MYSQLI_STORE_RESULT) {}
+    public function __construct(mysqli $mysql, int $result_mode = MYSQLI_STORE_RESULT) {}
 
     /**
      * @return void
@@ -337,21 +337,21 @@ class mysqli_result implements IteratorAggregate
      * @return object|false
      * @alias mysqli_fetch_field_direct
      */
-    public function fetch_field_direct(int $field_nr) {}
+    public function fetch_field_direct(int $index) {}
 
 #if defined(MYSQLI_USE_MYSQLND)
     /**
      * @return array|false
      * @alias mysqli_fetch_all
      */
-    public function fetch_all(int $result_type = MYSQLI_NUM) {}
+    public function fetch_all(int $mode = MYSQLI_NUM) {}
 #endif
 
     /**
      * @return array|null|false
      * @alias mysqli_fetch_array
      */
-    public function fetch_array(int $result_type = MYSQLI_BOTH) {}
+    public function fetch_array(int $mode = MYSQLI_BOTH) {}
 
     /**
      * @return array|null
@@ -363,7 +363,7 @@ class mysqli_result implements IteratorAggregate
      * @return object|null
      * @alias mysqli_fetch_object
      */
-    public function fetch_object(string $class_name = "stdClass", array $params = []) {}
+    public function fetch_object(string $class = "stdClass", array $params = []) {}
 
     /**
      * @return array|null
@@ -375,7 +375,7 @@ class mysqli_result implements IteratorAggregate
      * @return bool
      * @alias mysqli_field_seek
      */
-    public function field_seek(int $field_nr) {}
+    public function field_seek(int $index) {}
 
     /**
      * @return void
@@ -388,19 +388,19 @@ class mysqli_result implements IteratorAggregate
 
 class mysqli_stmt
 {
-    public function __construct(mysqli $mysqli_link, ?string $statement = null) {}
+    public function __construct(mysqli $mysql, ?string $query = null) {}
 
     /**
      * @return int|false
      * @alias mysqli_stmt_attr_get
      */
-    public function attr_get(int $attr) {}
+    public function attr_get(int $attribute) {}
 
     /**
      * @return bool
      * @alias mysqli_stmt_attr_set
      */
-    public function attr_set(int $attr, int $mode_in) {}
+    public function attr_set(int $attribute, int $value) {}
 
     /**
      * @return bool
@@ -474,7 +474,7 @@ class mysqli_stmt
      * @return bool
      * @alias mysqli_stmt_send_long_data
      */
-    public function send_long_data(int $param_nr, string $data) {}
+    public function send_long_data(int $param_num, string $data) {}
 
     /**
      * @return void
@@ -511,7 +511,7 @@ class mysqli_stmt
 
 final class mysqli_warning
 {
-    protected function __construct(object $mysqli_link) {}
+    protected function __construct(object $mysql) {}
 
     public function next(): bool {}
 }
@@ -520,23 +520,23 @@ final class mysqli_sql_exception extends RuntimeException
 {
 }
 
-function mysqli_affected_rows(mysqli $mysql_link): int|string {}
+function mysqli_affected_rows(mysqli $mysql): int|string {}
 
-function mysqli_autocommit(mysqli $mysql_link, bool $mode): bool {}
+function mysqli_autocommit(mysqli $mysql, bool $enable): bool {}
 
-function mysqli_begin_transaction(mysqli $mysql_link, int $flags = 0, ?string $name = null): bool {}
+function mysqli_begin_transaction(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
 
-function mysqli_change_user(mysqli $mysql_link, string $user, string $password, ?string $database): bool {}
+function mysqli_change_user(mysqli $mysql, string $username, string $password, ?string $database): bool {}
 
-function mysqli_character_set_name(mysqli $mysql_link): ?string {}
+function mysqli_character_set_name(mysqli $mysql): ?string {}
 
-function mysqli_close(mysqli $mysql_link): bool {}
+function mysqli_close(mysqli $mysql): bool {}
 
-function mysqli_commit(mysqli $mysql_link, int $flags = -1, ?string $name = null): bool {}
+function mysqli_commit(mysqli $mysql, int $flags = -1, ?string $name = null): bool {}
 
 function mysqli_connect(
     ?string $host = null,
-    ?string $user = null,
+    ?string $username = null,
     ?string $password = null,
     ?string $database = null,
     ?int $port = null,
@@ -547,112 +547,112 @@ function mysqli_connect_errno(): int {}
 
 function mysqli_connect_error(): ?string {}
 
-function mysqli_data_seek(mysqli_result $mysql_result, int $offset): bool {}
+function mysqli_data_seek(mysqli_result $result, int $offset): bool {}
 
-function mysqli_dump_debug_info(mysqli $mysql_link): bool {}
+function mysqli_dump_debug_info(mysqli $mysql): bool {}
 
 function mysqli_debug(string $debug): bool {}
 
-function mysqli_errno(mysqli $mysql_link): int {}
+function mysqli_errno(mysqli $mysql): int {}
 
-function mysqli_error(mysqli $mysql_link): ?string {}
+function mysqli_error(mysqli $mysql): ?string {}
 
-function mysqli_error_list(mysqli $mysql_link): array {}
+function mysqli_error_list(mysqli $mysql): array {}
 
-function mysqli_stmt_execute(mysqli_stmt $mysql_stmt): bool {}
+function mysqli_stmt_execute(mysqli_stmt $stmt): bool {}
 
 /** @alias mysqli_stmt_execute */
-function mysqli_execute(mysqli_stmt $mysql_stmt): bool {}
+function mysqli_execute(mysqli_stmt $stmt): bool {}
 
-function mysqli_fetch_field(mysqli_result $mysql_result): object|false {}
+function mysqli_fetch_field(mysqli_result $result): object|false {}
 
-function mysqli_fetch_fields(mysqli_result $mysql_result): array {}
+function mysqli_fetch_fields(mysqli_result $result): array {}
 
-function mysqli_fetch_field_direct(mysqli_result $mysql_result, int $offset): object|false {}
+function mysqli_fetch_field_direct(mysqli_result $result, int $offset): object|false {}
 
-function mysqli_fetch_lengths(mysqli_result $mysql_result): array|false {}
+function mysqli_fetch_lengths(mysqli_result $result): array|false {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_fetch_all(mysqli_result $mysql_result, int $mode = MYSQLI_NUM): array|false {}
+function mysqli_fetch_all(mysqli_result $result, int $mode = MYSQLI_NUM): array|false {}
 #endif
 
-function mysqli_fetch_array(mysqli_result $mysql_result, int $fetchtype = MYSQLI_BOTH): array|null|false {}
+function mysqli_fetch_array(mysqli_result $result, int $mode = MYSQLI_BOTH): array|null|false {}
 
-function mysqli_fetch_assoc(mysqli_result $mysql_result): ?array {}
+function mysqli_fetch_assoc(mysqli_result $result): ?array {}
 
-function mysqli_fetch_object(mysqli_result $mysqli_result, string $class_name = "stdClass", array $params = []): ?object {}
+function mysqli_fetch_object(mysqli_result $result, string $class = "stdClass", array $params = []): ?object {}
 
-function mysqli_fetch_row(mysqli_result $mysqli_result): ?array {}
+function mysqli_fetch_row(mysqli_result $result): ?array {}
 
-function mysqli_field_count(mysqli $mysqli_link): int {}
+function mysqli_field_count(mysqli $mysql): int {}
 
-function mysqli_field_seek(mysqli_result $mysqli_result, int $field_nr): bool {}
+function mysqli_field_seek(mysqli_result $result, int $index): bool {}
 
-function mysqli_field_tell(mysqli_result $mysqli_result): int {}
+function mysqli_field_tell(mysqli_result $result): int {}
 
-function mysqli_free_result(mysqli_result $mysqli_result): void {}
+function mysqli_free_result(mysqli_result $result): void {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_get_connection_stats(mysqli $mysqli_link): array {}
+function mysqli_get_connection_stats(mysqli $mysql): array {}
 
 function mysqli_get_client_stats(): array {}
 #endif
 
-function mysqli_get_charset(mysqli $mysqli_link): ?object {}
+function mysqli_get_charset(mysqli $mysql): ?object {}
 
-function mysqli_get_client_info(?mysqli $mysqli_link = null): ?string {}
+function mysqli_get_client_info(?mysqli $mysql = null): ?string {}
 
 function mysqli_get_client_version(): int {}
 
 function mysqli_get_links_stats(): array {}
 
-function mysqli_get_host_info(mysqli $mysqli_link): string {}
+function mysqli_get_host_info(mysqli $mysql): string {}
 
-function mysqli_get_proto_info(mysqli $mysqli_link): int {}
+function mysqli_get_proto_info(mysqli $mysql): int {}
 
-function mysqli_get_server_info(mysqli $mysqli_link): string {}
+function mysqli_get_server_info(mysqli $mysql): string {}
 
-function mysqli_get_server_version(mysqli $mysqli_link): int {}
+function mysqli_get_server_version(mysqli $mysql): int {}
 
-function mysqli_get_warnings(mysqli $mysqli_link): mysqli_warning|false {}
+function mysqli_get_warnings(mysqli $mysql): mysqli_warning|false {}
 
 function mysqli_init(): mysqli|false {}
 
-function mysqli_info(mysqli $mysqli_link): ?string {}
+function mysqli_info(mysqli $mysql): ?string {}
 
-function mysqli_insert_id(mysqli $mysqli_link): int|string {}
+function mysqli_insert_id(mysqli $mysql): int|string {}
 
-function mysqli_kill(mysqli $mysqli_link, int $connection_id): bool {}
+function mysqli_kill(mysqli $mysql, int $process_id): bool {}
 
-function mysqli_more_results(mysqli $mysqli_link): bool {}
+function mysqli_more_results(mysqli $mysql): bool {}
 
-function mysqli_multi_query(mysqli $mysqli_link, string $query): bool {}
+function mysqli_multi_query(mysqli $mysql, string $query): bool {}
 
-function mysqli_next_result(mysqli $mysqli_link): bool {}
+function mysqli_next_result(mysqli $mysql): bool {}
 
-function mysqli_num_fields(mysqli_result $mysql_result): int {}
+function mysqli_num_fields(mysqli_result $result): int {}
 
-function mysqli_num_rows(mysqli_result $mysqli_result): int|string {}
+function mysqli_num_rows(mysqli_result $result): int|string {}
 
 /** @param string|int $value */
-function mysqli_options(mysqli $mysqli_link, int $option, $value): bool {}
+function mysqli_options(mysqli $mysql, int $option, $value): bool {}
 
-function mysqli_ping(mysqli $mysqli_link): bool {}
+function mysqli_ping(mysqli $mysql): bool {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_poll(?array &$read, ?array &$write, array &$error, int $sec, int $usec = 0): int|false {}
+function mysqli_poll(?array &$read, ?array &$write, array &$error, int $seconds, int $microseconds = 0): int|false {}
 #endif
 
-function mysqli_prepare(mysqli $mysqli_link, string $query): mysqli_stmt|false {}
+function mysqli_prepare(mysqli $mysql, string $query): mysqli_stmt|false {}
 
 function mysqli_report(int $flags): bool {}
 
-function mysqli_query(mysqli $mysqli_link, string $query, int $result_mode = MYSQLI_STORE_RESULT): mysqli_result|bool {}
+function mysqli_query(mysqli $mysql, string $query, int $result_mode = MYSQLI_STORE_RESULT): mysqli_result|bool {}
 
 function mysqli_real_connect(
-    mysqli $mysqli_link,
+    mysqli $mysql,
     ?string $host = null,
-    ?string $user = null,
+    ?string $username = null,
     ?string $password = null,
     ?string $database = null,
     ?int $port = null,
@@ -660,112 +660,112 @@ function mysqli_real_connect(
     int $flags = 0
 ): bool {}
 
-function mysqli_real_escape_string(mysqli $mysqli_link, string $string_to_escape): string {}
+function mysqli_real_escape_string(mysqli $mysql, string $string): string {}
 
-function mysqli_real_query(mysqli $mysqli_link, string $query): bool {}
-
-#if defined(MYSQLI_USE_MYSQLND)
-function mysqli_reap_async_query(mysqli $mysqli_link): mysqli_result|bool {}
-#endif
-
-function mysqli_release_savepoint(mysqli $mysqli_link, string $name): bool {}
-
-function mysqli_rollback(mysqli $mysqli_link, int $flags = 0, ?string $name = null): bool {}
-
-function mysqli_savepoint(mysqli $mysqli_link, string $name): bool {}
-
-function mysqli_select_db(mysqli $mysqli_link, string $dbname): bool {}
-
-function mysqli_set_charset(mysqli $mysqli_link, string $charset): bool {}
-
-function mysqli_stmt_affected_rows(mysqli_stmt $mysql_stmt): int|string {}
-
-function mysqli_stmt_attr_get(mysqli_stmt $mysql_stmt, int $attr): int {}
-
-function mysqli_stmt_attr_set(mysqli_stmt $mysql_stmt, int $attr, int $mode_in): bool {}
-
-function mysqli_stmt_bind_param(mysqli_stmt $mysql_stmt, string $types, mixed &...$vars): bool {}
-
-function mysqli_stmt_bind_result(mysqli_stmt $mysql_stmt, mixed &...$vars): bool {}
-
-function mysqli_stmt_close(mysqli_stmt $mysql_stmt): bool {}
-
-function mysqli_stmt_data_seek(mysqli_stmt $mysql_stmt, int $offset): void {}
-
-function mysqli_stmt_errno(mysqli_stmt $mysql_stmt): int {}
-
-function mysqli_stmt_error(mysqli_stmt $mysql_stmt): ?string {}
-
-function mysqli_stmt_error_list(mysqli_stmt $mysql_stmt): array {}
-
-function mysqli_stmt_fetch(mysqli_stmt $mysql_stmt): ?bool {}
-
-function mysqli_stmt_field_count(mysqli_stmt $mysql_stmt): int {}
-
-function mysqli_stmt_free_result(mysqli_stmt $mysql_stmt): void {}
+function mysqli_real_query(mysqli $mysql, string $query): bool {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_stmt_get_result(mysqli_stmt $mysql_stmt): mysqli_result|false {}
+function mysqli_reap_async_query(mysqli $mysql): mysqli_result|bool {}
 #endif
 
-function mysqli_stmt_get_warnings(mysqli_stmt $mysql_stmt): mysqli_warning|false {}
+function mysqli_release_savepoint(mysqli $mysql, string $name): bool {}
 
-function mysqli_stmt_init(mysqli $mysql_link): mysqli_stmt|false {}
+function mysqli_rollback(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
 
-function mysqli_stmt_insert_id(mysqli_stmt $mysql_stmt): int|string {}
+function mysqli_savepoint(mysqli $mysql, string $name): bool {}
+
+function mysqli_select_db(mysqli $mysql, string $database): bool {}
+
+function mysqli_set_charset(mysqli $mysql, string $charset): bool {}
+
+function mysqli_stmt_affected_rows(mysqli_stmt $stmt): int|string {}
+
+function mysqli_stmt_attr_get(mysqli_stmt $stmt, int $attribute): int {}
+
+function mysqli_stmt_attr_set(mysqli_stmt $stmt, int $attribute, int $value): bool {}
+
+function mysqli_stmt_bind_param(mysqli_stmt $stmt, string $types, mixed &...$vars): bool {}
+
+function mysqli_stmt_bind_result(mysqli_stmt $stmt, mixed &...$vars): bool {}
+
+function mysqli_stmt_close(mysqli_stmt $stmt): bool {}
+
+function mysqli_stmt_data_seek(mysqli_stmt $stmt, int $offset): void {}
+
+function mysqli_stmt_errno(mysqli_stmt $stmt): int {}
+
+function mysqli_stmt_error(mysqli_stmt $stmt): ?string {}
+
+function mysqli_stmt_error_list(mysqli_stmt $stmt): array {}
+
+function mysqli_stmt_fetch(mysqli_stmt $stmt): ?bool {}
+
+function mysqli_stmt_field_count(mysqli_stmt $stmt): int {}
+
+function mysqli_stmt_free_result(mysqli_stmt $stmt): void {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_stmt_more_results(mysqli_stmt $mysql_stmt): bool {}
-
-function mysqli_stmt_next_result(mysqli_stmt $mysql_stmt): bool {}
+function mysqli_stmt_get_result(mysqli_stmt $stmt): mysqli_result|false {}
 #endif
 
-function mysqli_stmt_num_rows(mysqli_stmt $mysql_stmt): int|string {}
+function mysqli_stmt_get_warnings(mysqli_stmt $stmt): mysqli_warning|false {}
 
-function mysqli_stmt_param_count(mysqli_stmt $mysql_stmt): int {}
+function mysqli_stmt_init(mysqli $mysql): mysqli_stmt|false {}
 
-function mysqli_stmt_prepare(mysqli_stmt $mysql_stmt, string $query): bool {}
+function mysqli_stmt_insert_id(mysqli_stmt $stmt): int|string {}
 
-function mysqli_stmt_reset(mysqli_stmt $mysql_stmt): bool {}
+#if defined(MYSQLI_USE_MYSQLND)
+function mysqli_stmt_more_results(mysqli_stmt $stmt): bool {}
 
-function mysqli_stmt_result_metadata(mysqli_stmt $mysql_stmt): mysqli_result|false {}
+function mysqli_stmt_next_result(mysqli_stmt $stmt): bool {}
+#endif
 
-function mysqli_stmt_send_long_data(mysqli_stmt $mysql_stmt, int $param_nr, string $data): bool {}
+function mysqli_stmt_num_rows(mysqli_stmt $stmt): int|string {}
 
-function mysqli_stmt_store_result(mysqli_stmt $mysql_stmt): bool {}
+function mysqli_stmt_param_count(mysqli_stmt $stmt): int {}
 
-function mysqli_stmt_sqlstate(mysqli_stmt $mysql_stmt): ?string {}
+function mysqli_stmt_prepare(mysqli_stmt $stmt, string $query): bool {}
 
-function mysqli_sqlstate(mysqli $mysqli_link): ?string {}
+function mysqli_stmt_reset(mysqli_stmt $stmt): bool {}
+
+function mysqli_stmt_result_metadata(mysqli_stmt $stmt): mysqli_result|false {}
+
+function mysqli_stmt_send_long_data(mysqli_stmt $stmt, int $param_num, string $data): bool {}
+
+function mysqli_stmt_store_result(mysqli_stmt $stmt): bool {}
+
+function mysqli_stmt_sqlstate(mysqli_stmt $stmt): ?string {}
+
+function mysqli_sqlstate(mysqli $mysql): ?string {}
 
 function mysqli_ssl_set(
-    mysqli $mysql_link,
+    mysqli $mysql,
     string $key,
-    string $cert,
-    string $certificate_authority,
-    string $certificate_authority_path,
-    string $cipher
+    string $certificate,
+    string $ca_certificate,
+    string $ca_path,
+    string $cipher_algos
 ): bool {}
 
-function mysqli_stat(mysqli $mysql_link): string|false {}
+function mysqli_stat(mysqli $mysql): string|false {}
 
-function mysqli_store_result(mysqli $mysql_link, int $flags = 0): mysqli_result|false {}
+function mysqli_store_result(mysqli $mysql, int $mode = 0): mysqli_result|false {}
 
-function mysqli_thread_id(mysqli $mysql_link): int {}
+function mysqli_thread_id(mysqli $mysql): int {}
 
 function mysqli_thread_safe(): bool {}
 
-function mysqli_use_result(mysqli $mysql_link): mysqli_result|false {}
+function mysqli_use_result(mysqli $mysql): mysqli_result|false {}
 
-function mysqli_warning_count(mysqli $mysql_link): int {}
+function mysqli_warning_count(mysqli $mysql): int {}
 
-function mysqli_refresh(mysqli $mysqli_link, int $options): bool {}
+function mysqli_refresh(mysqli $mysql, int $flags): bool {}
 
 /** @alias mysqli_real_escape_string */
-function mysqli_escape_string(mysqli $mysqli_link, string $string_to_escape): string {}
+function mysqli_escape_string(mysqli $mysql, string $string): string {}
 
 /**
  * @param string|int $value
  * @alias mysqli_options
  */
-function mysqli_set_opt(mysqli $mysqli_link, int $option, $value): bool {}
+function mysqli_set_opt(mysqli $mysql, int $option, $value): bool {}

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,45 +1,45 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 20d9c5578108df89a863dd93f289e6f79d1db183 */
+ * Stub hash: 54e11efaf9b7b020e27cb0b7a30098af93e1c6f9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_autocommit, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO(0, mode, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_begin_transaction, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_change_user, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO(0, user, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO(0, username, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_character_set_name, 0, 1, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_close, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_commit, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "-1")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_connect, 0, 0, mysqli, MAY_BE_NULL|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, user, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 1, "null")
@@ -53,7 +53,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_connect_error, 0, 0, IS_S
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_data_seek, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -64,84 +64,80 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_debug, 0, 1, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_errno, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_error arginfo_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_error_list, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_execute, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_execute arginfo_mysqli_stmt_execute
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_field, 0, 1, MAY_BE_OBJECT|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_fetch_fields, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_field_direct, 0, 2, MAY_BE_OBJECT|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_lengths, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_all, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "MYSQLI_NUM")
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_array, 0, 1, MAY_BE_ARRAY|MAY_BE_NULL|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fetchtype, IS_LONG, 0, "MYSQLI_BOTH")
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "MYSQLI_BOTH")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_fetch_assoc, 0, 1, IS_ARRAY, 1)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_fetch_object, 0, 1, IS_OBJECT, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli_result, mysqli_result, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class_name, IS_STRING, 0, "\"stdClass\"")
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class, IS_STRING, 0, "\"stdClass\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_fetch_row, 0, 1, IS_ARRAY, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli_result, mysqli_result, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_fetch_row arginfo_mysqli_fetch_assoc
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_field_count, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_field_count arginfo_mysqli_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_field_seek, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_result, mysqli_result, 0)
-	ZEND_ARG_TYPE_INFO(0, field_nr, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_field_tell, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_free_result, 0, 1, IS_VOID, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_connection_stats, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -151,11 +147,11 @@ ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_charset, 0, 1, IS_OBJECT, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_client_info, 0, 0, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, mysqli_link, mysqli, 1, "null")
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, mysql, mysqli, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_get_client_version arginfo_mysqli_connect_errno
@@ -164,74 +160,66 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_links_stats, 0, 0, IS
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_host_info, 0, 1, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_mysqli_get_proto_info arginfo_mysqli_field_count
+#define arginfo_mysqli_get_proto_info arginfo_mysqli_errno
 
 #define arginfo_mysqli_get_server_info arginfo_mysqli_get_host_info
 
-#define arginfo_mysqli_get_server_version arginfo_mysqli_field_count
+#define arginfo_mysqli_get_server_version arginfo_mysqli_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_get_warnings, 0, 1, mysqli_warning, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_init, 0, 0, mysqli, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_info, 0, 1, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_info arginfo_mysqli_character_set_name
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_insert_id, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_insert_id arginfo_mysqli_affected_rows
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_kill, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO(0, connection_id, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_more_results, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_more_results arginfo_mysqli_close
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_multi_query, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_mysqli_next_result arginfo_mysqli_more_results
+#define arginfo_mysqli_next_result arginfo_mysqli_close
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_num_fields, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_result, mysqli_result, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_num_fields arginfo_mysqli_field_tell
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_num_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
-	ZEND_ARG_OBJ_INFO(0, mysqli_result, mysqli_result, 0)
+	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_options, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
-#define arginfo_mysqli_ping arginfo_mysqli_more_results
+#define arginfo_mysqli_ping arginfo_mysqli_close
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_poll, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO(1, write, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO(1, error, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, sec, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, usec, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microseconds, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_prepare, 0, 2, mysqli_stmt, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -240,15 +228,15 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_report, 0, 1, _IS_BOOL, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_query, 0, 2, mysqli_result, MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_mode, IS_LONG, 0, "MYSQLI_STORE_RESULT")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_connect, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, user, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 1, "null")
@@ -257,115 +245,111 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_connect, 0, 1, _IS_B
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_escape_string, 0, 2, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO(0, string_to_escape, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_real_query arginfo_mysqli_multi_query
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_reap_async_query, 0, 1, mysqli_result, MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_release_savepoint, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_rollback, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_rollback arginfo_mysqli_begin_transaction
 
 #define arginfo_mysqli_savepoint arginfo_mysqli_release_savepoint
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_select_db, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO(0, dbname, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_set_charset, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, charset, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_stmt_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_attr_get, 0, 2, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
-	ZEND_ARG_TYPE_INFO(0, attr, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_TYPE_INFO(0, attribute, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_attr_set, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
-	ZEND_ARG_TYPE_INFO(0, attr, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, mode_in, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_TYPE_INFO(0, attribute, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_param, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, types, IS_STRING, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_result, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_close arginfo_mysqli_stmt_execute
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_data_seek, 0, 2, IS_VOID, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_errno, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_error, 0, 1, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_error_list, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_fetch, 0, 1, _IS_BOOL, 1)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_field_count arginfo_mysqli_stmt_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_free_result, 0, 1, IS_VOID, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_get_result, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_get_warnings, 0, 1, mysqli_warning, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_init, 0, 1, mysqli_stmt, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_insert_id arginfo_mysqli_stmt_affected_rows
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_more_results, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -378,19 +362,19 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_stmt_param_count arginfo_mysqli_stmt_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_prepare, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_reset arginfo_mysqli_stmt_execute
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_result_metadata, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_send_long_data, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_stmt, mysqli_stmt, 0)
-	ZEND_ARG_TYPE_INFO(0, param_nr, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_TYPE_INFO(0, param_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -398,24 +382,24 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_sqlstate arginfo_mysqli_stmt_error
 
-#define arginfo_mysqli_sqlstate arginfo_mysqli_info
+#define arginfo_mysqli_sqlstate arginfo_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_ssl_set, 0, 6, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, cert, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, certificate_authority, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, certificate_authority_path, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, cipher, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, certificate, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, ca_certificate, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, ca_path, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, cipher_algos, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_stat, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_store_result, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_thread_id arginfo_mysqli_errno
@@ -424,14 +408,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_thread_safe, 0, 0, _IS_BO
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_use_result, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_warning_count arginfo_mysqli_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_refresh, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO(0, options, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_escape_string arginfo_mysqli_real_escape_string
@@ -440,7 +424,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, user, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 1, "null")
@@ -448,7 +432,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_autocommit, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, mode, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_begin_transaction, 0, 0, 0)
@@ -457,7 +441,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_begin_transaction, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_change_user, 0, 0, 3)
-	ZEND_ARG_TYPE_INFO(0, user, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, username, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 1)
 ZEND_END_ARG_INFO()
@@ -477,7 +461,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_dump_debug_info arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_debug, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, debug_options, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_get_charset arginfo_class_mysqli_character_set_name
@@ -496,7 +480,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_init arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_kill, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, connection_id, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_multi_query, 0, 0, 1)
@@ -514,8 +498,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_poll, 0, 0, 4)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO(1, write, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO(1, error, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, sec, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, usec, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microseconds, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -528,7 +512,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_real_connect, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, user, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 1, "null")
@@ -537,7 +521,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_real_connect, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_real_escape_string, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, string_to_escape, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
@@ -573,10 +557,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_ssl_set, 0, 0, 5)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, cert, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, certificate_authority, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, certificate_authority_path, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, cipher, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, certificate, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, ca_certificate, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, ca_path, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, cipher_algos, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_stat arginfo_class_mysqli_character_set_name
@@ -584,7 +568,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_stmt_init arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_store_result, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_thread_safe arginfo_class_mysqli_character_set_name
@@ -592,11 +576,11 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_use_result arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_refresh, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, options, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_result___construct, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_mode, IS_LONG, 0, "MYSQLI_STORE_RESULT")
 ZEND_END_ARG_INFO()
 
@@ -613,23 +597,23 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_result_fetch_fields arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_result_fetch_field_direct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, field_nr, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_result_fetch_all, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "MYSQLI_NUM")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "MYSQLI_NUM")
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_result_fetch_array, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "MYSQLI_BOTH")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "MYSQLI_BOTH")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_result_fetch_assoc arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_result_fetch_object, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class_name, IS_STRING, 0, "\"stdClass\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class, IS_STRING, 0, "\"stdClass\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
@@ -643,17 +627,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_mysqli_result_getIterator, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt___construct, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli_link, mysqli, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, statement, IS_STRING, 1, "null")
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, query, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_attr_get, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, attr, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, attribute, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_attr_set, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, attr, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, mode_in, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, attribute, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_bind_param, 0, 0, 1)
@@ -688,7 +672,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_stmt_num_rows arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_send_long_data, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, param_nr, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, param_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -705,7 +689,7 @@ ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_warning___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, mysqli_link, IS_OBJECT, 0)
+	ZEND_ARG_TYPE_INFO(0, mysql, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_warning_next arginfo_mysqli_thread_safe

--- a/ext/mysqli/tests/mysqli_fetch_all_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_all_oo.phpt
@@ -435,6 +435,6 @@ array(1) {
     string(1) "1"
   }
 }
-mysqli_result::fetch_all(): Argument #1 ($result_type) must be one of MYSQLI_FETCH_NUM, MYSQLI_FETCH_ASSOC, or MYSQLI_FETCH_BOTH
+mysqli_result::fetch_all(): Argument #1 ($mode) must be one of MYSQLI_FETCH_NUM, MYSQLI_FETCH_ASSOC, or MYSQLI_FETCH_BOTH
 mysqli_result object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_fetch_array.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_array.phpt
@@ -359,7 +359,7 @@ array(11) {
   ["e"]=>
   string(1) "1"
 }
-mysqli_fetch_array(): Argument #2 ($fetchtype) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
-mysqli_fetch_array(): Argument #2 ($fetchtype) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
+mysqli_fetch_array(): Argument #2 ($mode) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
+mysqli_fetch_array(): Argument #2 ($mode) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
 mysqli_result object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_fetch_array_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_array_oo.phpt
@@ -355,7 +355,7 @@ array(11) {
   ["e"]=>
   string(1) "1"
 }
-mysqli_result::fetch_array(): Argument #1 ($result_type) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
-mysqli_result::fetch_array(): Argument #1 ($result_type) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
+mysqli_result::fetch_array(): Argument #1 ($mode) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
+mysqli_result::fetch_array(): Argument #1 ($mode) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
 mysqli_result object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_fetch_field_direct_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field_direct_oo.phpt
@@ -57,7 +57,7 @@ require_once('skipifconnectfailure.inc');
 ?>
 --EXPECTF--
 mysqli object is not fully initialized
-mysqli_result::fetch_field_direct(): Argument #1 ($field_nr) must be greater than or equal to 0
+mysqli_result::fetch_field_direct(): Argument #1 ($index) must be greater than or equal to 0
 object(stdClass)#%d (13) {
   ["name"]=>
   string(2) "ID"
@@ -86,6 +86,6 @@ object(stdClass)#%d (13) {
   ["decimals"]=>
   int(%d)
 }
-mysqli_result::fetch_field_direct(): Argument #1 ($field_nr) must be less than the number of fields for this result set
+mysqli_result::fetch_field_direct(): Argument #1 ($index) must be less than the number of fields for this result set
 mysqli_result object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_fetch_object.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object.phpt
@@ -148,5 +148,5 @@ NULL
 NULL
 mysqli_result object is already closed
 [0] mysqli_fetch_object(): Argument #3 ($params) must be of type array, string given in %s on line %d
-mysqli_fetch_object(): Argument #2 ($class_name) must be a valid class name, this_class_does_not_exist given
+mysqli_fetch_object(): Argument #2 ($class) must be a valid class name, this_class_does_not_exist given
 done!

--- a/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
@@ -139,5 +139,5 @@ Exception: Too few arguments to function mysqli_fetch_object_construct::__constr
 NULL
 NULL
 mysqli_result object is already closed
-mysqli_result::fetch_object(): Argument #1 ($class_name) must be a valid class name, this_class_does_not_exist given
+mysqli_result::fetch_object(): Argument #1 ($class) must be a valid class name, this_class_does_not_exist given
 done!

--- a/ext/mysqli/tests/mysqli_field_seek.phpt
+++ b/ext/mysqli/tests/mysqli_field_seek.phpt
@@ -122,7 +122,7 @@ require_once('skipifconnectfailure.inc');
     require_once("clean_table.inc");
 ?>
 --EXPECTF--
-mysqli_field_seek(): Argument #2 ($field_nr) must be greater than or equal to 0
+mysqli_field_seek(): Argument #2 ($index) must be greater than or equal to 0
 object(stdClass)#%d (13) {
   ["name"]=>
   string(2) "id"
@@ -210,7 +210,7 @@ object(stdClass)#%d (13) {
   int(0)
 }
 int(2)
-mysqli_field_seek(): Argument #2 ($field_nr) must be less than the number of fields for this result set
+mysqli_field_seek(): Argument #2 ($index) must be less than the number of fields for this result set
 bool(false)
 bool(true)
 object(stdClass)#%d (13) {

--- a/ext/mysqli/tests/mysqli_field_tell.phpt
+++ b/ext/mysqli/tests/mysqli_field_tell.phpt
@@ -88,9 +88,9 @@ object(stdClass)#%d (13) {
 }
 bool(false)
 int(1)
-mysqli_field_seek(): Argument #2 ($field_nr) must be less than the number of fields for this result set
+mysqli_field_seek(): Argument #2 ($index) must be less than the number of fields for this result set
 int(1)
-mysqli_field_seek(): Argument #2 ($field_nr) must be greater than or equal to 0
+mysqli_field_seek(): Argument #2 ($index) must be greater than or equal to 0
 int(1)
 bool(true)
 int(0)

--- a/ext/mysqli/tests/mysqli_kill.phpt
+++ b/ext/mysqli/tests/mysqli_kill.phpt
@@ -80,7 +80,7 @@ require_once('skipifconnectfailure.inc');
     require_once("clean_table.inc");
 ?>
 --EXPECTF--
-mysqli_kill(): Argument #2 ($connection_id) must be greater than 0
+mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 string(%d) "%s"
 bool(false)
 object(mysqli)#%d (%d) {
@@ -131,10 +131,10 @@ object(mysqli)#%d (%d) {
   ["warning_count"]=>
   int(0)
 }
-mysqli_kill(): Argument #2 ($connection_id) must be greater than 0
+mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 array(1) {
   ["id"]=>
   string(1) "1"
 }
-mysqli_kill(): Argument #2 ($connection_id) must be greater than 0
+mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 done!

--- a/ext/mysqli/tests/mysqli_poll.phpt
+++ b/ext/mysqli/tests/mysqli_poll.phpt
@@ -114,8 +114,8 @@ if (!$IS_MYSQLND)
     print "done!";
 ?>
 --EXPECTF--
-mysqli_poll(): Argument #4 ($sec) must be greater than or equal to 0
-mysqli_poll(): Argument #5 ($usec) must be greater than or equal to 0
+mysqli_poll(): Argument #4 ($seconds) must be greater than or equal to 0
+mysqli_poll(): Argument #5 ($microseconds) must be greater than or equal to 0
 [012 + 6] Rejecting thread %d: 0/
 [013 + 6] Rejecting thread %d: 0/
 [014 + 6] Rejecting thread %d: 0/

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -287,12 +287,12 @@ require_once('skipifconnectfailure.inc');
 Warning: mysqli_multi_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'BAR; FOO' at line 1 in %s on line %d
 
 Warning: mysqli_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
-mysqli_kill(): Argument #2 ($connection_id) must be greater than 0
+mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
 Warning: mysqli_real_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
-mysqli_kill(): Argument #2 ($connection_id) must be greater than 0
+mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_stmt_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 [013] Access denied for user '%s'@'%s' (using password: YES)

--- a/ext/mysqli/tests/mysqli_stmt_attr_get.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_attr_get.phpt
@@ -52,7 +52,7 @@ require_once('skipifconnectfailure.inc');
     require_once("clean_table.inc");
 ?>
 --EXPECT--
-mysqli_stmt_attr_get(): Argument #2 ($attr) must be one of MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH, MYSQLI_STMT_ATTR_PREFETCH_ROWS, or STMT_ATTR_CURSOR_TYPE
+mysqli_stmt_attr_get(): Argument #2 ($attribute) must be one of MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH, MYSQLI_STMT_ATTR_PREFETCH_ROWS, or STMT_ATTR_CURSOR_TYPE
 mysqli_stmt object is already closed
 mysqli_stmt object is already closed
 mysqli_stmt object is already closed

--- a/ext/mysqli/tests/mysqli_stmt_attr_set.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_attr_set.phpt
@@ -242,9 +242,9 @@ require_once("connect.inc");
 ?>
 --EXPECT--
 Error: mysqli_stmt object is not fully initialized
-mysqli_stmt_attr_set(): Argument #2 ($attr) must be one of MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH, MYSQLI_STMT_ATTR_PREFETCH_ROWS, or STMT_ATTR_CURSOR_TYPE
-mysqli_stmt::attr_set(): Argument #2 ($mode_in) must be 0 or 1 for attribute MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH
+mysqli_stmt_attr_set(): Argument #2 ($attribute) must be one of MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH, MYSQLI_STMT_ATTR_PREFETCH_ROWS, or STMT_ATTR_CURSOR_TYPE
+mysqli_stmt::attr_set(): Argument #2 ($value) must be 0 or 1 for attribute MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH
 bool(true)
-mysqli_stmt::attr_set(): Argument #2 ($mode_in) must be one of the MYSQLI_CURSOR_TYPE_* constants for attribute MYSQLI_STMT_ATTR_CURSOR_TYPE
-mysqli_stmt::attr_set(): Argument #2 ($mode_in) must be greater than 0 for attribute MYSQLI_STMT_ATTR_PREFETCH_ROWS
+mysqli_stmt::attr_set(): Argument #2 ($value) must be one of the MYSQLI_CURSOR_TYPE_* constants for attribute MYSQLI_STMT_ATTR_CURSOR_TYPE
+mysqli_stmt::attr_set(): Argument #2 ($value) must be greater than 0 for attribute MYSQLI_STMT_ATTR_PREFETCH_ROWS
 done!

--- a/ext/mysqli/tests/mysqli_stmt_send_long_data.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_send_long_data.phpt
@@ -108,5 +108,5 @@ require_once('skipifconnectfailure.inc');
     require_once("clean_table.inc");
 ?>
 --EXPECT--
-mysqli_stmt_send_long_data(): Argument #2 ($param_nr) must be greater than or equal to 0
+mysqli_stmt_send_long_data(): Argument #2 ($index) must be greater than or equal to 0
 done!

--- a/ext/mysqli/tests/mysqli_stmt_send_long_data.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_send_long_data.phpt
@@ -108,5 +108,5 @@ require_once('skipifconnectfailure.inc');
     require_once("clean_table.inc");
 ?>
 --EXPECT--
-mysqli_stmt_send_long_data(): Argument #2 ($index) must be greater than or equal to 0
+mysqli_stmt_send_long_data(): Argument #2 ($param_num) must be greater than or equal to 0
 done!


### PR DESCRIPTION
* autocommit()'s boolean parameter now called `$enabled`, not `$mode`.
* Various parameters named `_nr` changed to `$index`, which is more self-descriptive.
* attr mode changed to use a more traditional `$attribute`/`$value` pair.
* s/`$user`/`$username`/ for consistency.
* s/`$class_name/`$class`/ for consistency.
* s/`$string_to_escape`/`$string`/ because seriously?
* s/`$dbname`/`$database`/ for consistency.
* s/`$mysql_link`/`$mysqli`/ for clarity/consistency.
* s/`$mysql_stmt`/`$stmt`/ for brevity.
* s/`$mysqli_result`/`$result`/ for brevity.
* s/`$sec`/`$seconds`/ for clarity.
* s/`$usec`/`$microseconds`/ for clarity.
* Bitmask parameters standardized on `$flags`.
* s/`$flags`/`$mode`/ on one function for correctness.  (It's a single-value setting, thus not a flags bitmask.)
* Various parameters in the SSL methods renamed to match their ext/ssl equivalents.

Still an open question:

* `$fetchtype` is a bad name.  `$fetch_type` is not much better.  `$result_mode` is also used for the same thing, I think.  PDO uses `$fetch_style`.  We should standardize all of those, but probably in a separate PR that is cross-DB.