### PR TITLE
Fix #67351: copy() should handle HTTP 304 response

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -697,7 +697,7 @@ finish:
 			}
 			/* all status codes in the 2xx range are defined by the specification as successful;
 			 * all status codes in the 3xx range are for redirection, and so also should never
-			 * fail, except for 304 if follow_location is requested */
+			 * fail, except for 304 */
 			if (response_code >= 200 && response_code < 400 && response_code != 304) {
 				reqok = 1;
 			} else {
@@ -706,16 +706,6 @@ finish:
 						php_stream_notify_error(context, PHP_STREAM_NOTIFY_AUTH_RESULT,
 								tmp_line, response_code);
 						break;
-					case 304:
-						reqok = 1;
-						if (context && (tmpzval = php_stream_context_get_option(context, "http", "follow_location")) != NULL) {
-							follow_location = zval_is_true(tmpzval);
-							reqok = !follow_location;
-						}
-						if (reqok) {
-							break;
-						}
-						/* fallthrough */
 					default:
 						/* safety net in the event tmp_line == NULL */
 						if (!tmp_line_len) {

--- a/ext/standard/tests/http/bug67351.phpt
+++ b/ext/standard/tests/http/bug67351.phpt
@@ -20,16 +20,10 @@ function test() {
         'http' => [
             'method' => 'GET',
             'protocol_version' => '1.1',
-            'follow_location' => false,
-            'ignore_errors' => true,
-            'header' => "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 +0000\r\n"
+            'header' => "If-Modified-Since: Tue, 19 Jan 2038 03:14:07 GMT\r\n"
         ]
     ];
-
     var_dump(file_get_contents('http://127.0.0.1:22346/', false, stream_context_create($options)));
-
-    $options['http']['follow_location'] = true;
-
     var_dump(copy('http://127.0.0.1:22346/', __FILE__ . '.txt', stream_context_create($options)));
 }
 test();
@@ -37,7 +31,9 @@ test();
 http_server_kill($pid);
 ?>
 --EXPECTF--
-string(0) ""
+Warning: file_get_contents(http://127.0.0.1:22346/): failed to open stream: HTTP request failed! HTTP/1.0 304 Not Modified
+ in %s on line %d
+bool(false)
 
 Warning: copy(http://127.0.0.1:22346/): failed to open stream: HTTP request failed! HTTP/1.0 304 Not Modified
  in %s on line %d

--- a/ext/standard/tests/http/bug67351.phpt
+++ b/ext/standard/tests/http/bug67351.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Bug #67351 (copy() should handle HTTP 304 response)
+--SKIPIF--
+<?php require 'server.inc'; http_server_skipif('tcp://127.0.0.1:22346'); ?>
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+require 'server.inc';
+
+$responses = array(
+	"data://text/plain,HTTP/1.0 304 Not Modified\r\n\r\n",
+	"data://text/plain,HTTP/1.0 304 Not Modified\r\n\r\n",
+);
+
+$pid = http_server("tcp://127.0.0.1:22346", $responses, $output);
+
+function test() {
+    $options = [
+        'http' => [
+            'method' => 'GET',
+            'protocol_version' => '1.1',
+            'follow_location' => false,
+            'ignore_errors' => true,
+            'header' => "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 +0000\r\n"
+        ]
+    ];
+
+    var_dump(file_get_contents('http://127.0.0.1:22346/', false, stream_context_create($options)));
+
+    $options['http']['follow_location'] = true;
+
+    var_dump(copy('http://127.0.0.1:22346/', __FILE__ . '.txt', stream_context_create($options)));
+}
+test();
+
+http_server_kill($pid);
+?>
+--EXPECTF--
+string(0) ""
+
+Warning: copy(http://127.0.0.1:22346/): failed to open stream: HTTP request failed! HTTP/1.0 304 Not Modified
+ in %s on line %d
+bool(false)


### PR DESCRIPTION
If the server answers with 304 Not Modified, and the stream context
has the `follow_location` option set, we are supposed to follow the
location.  Since there is no `Location` header, we cannot, though, and
therefore the request has to fail.