### PR TITLE
Intl collator align is_numeric behaviour

### DIFF
--- a/ext/intl/collator/collator_convert.c
+++ b/ext/intl/collator/collator_convert.c
@@ -320,7 +320,7 @@ zval* collator_convert_string_to_double( zval* str, zval *rv )
  */
 zval* collator_convert_string_to_number_if_possible( zval* str, zval *rv )
 {
-	int is_numeric = 0;
+	zend_uchar is_numeric = 0;
 	zend_long lval      = 0;
 	double dval    = 0;
 
@@ -329,7 +329,7 @@ zval* collator_convert_string_to_number_if_possible( zval* str, zval *rv )
 		COLLATOR_CONVERT_RETURN_FAILED( str );
 	}
 
-	if( ( is_numeric = collator_is_numeric( (UChar*) Z_STRVAL_P(str), UCHARS( Z_STRLEN_P(str) ), &lval, &dval, 1 ) ) )
+	if ( ( is_numeric = collator_is_numeric( (UChar*) Z_STRVAL_P(str), UCHARS( Z_STRLEN_P(str) ), &lval, &dval, /* allow_errors */ 1 ) ) )
 	{
 		if( is_numeric == IS_LONG ) {
 			ZVAL_LONG(rv, lval);

--- a/ext/intl/collator/collator_is_numeric.c
+++ b/ext/intl/collator/collator_is_numeric.c
@@ -207,7 +207,7 @@ static zend_long collator_u_strtol(nptr, endptr, base)
 /* {{{ collator_is_numeric]
  * Taken from PHP6:is_numeric_unicode()
  */
-zend_uchar collator_is_numeric( UChar *str, int32_t length, zend_long *lval, double *dval, int allow_errors )
+zend_uchar collator_is_numeric( UChar *str, int32_t length, zend_long *lval, double *dval, bool allow_errors )
 {
 	zend_long local_lval;
 	double local_dval;
@@ -251,9 +251,6 @@ zend_uchar collator_is_numeric( UChar *str, int32_t length, zend_long *lval, dou
 
 	if (!allow_errors) {
 		return 0;
-	}
-	if (allow_errors == -1) {
-		zend_error(E_NOTICE, "A non well formed numeric value encountered");
 	}
 
 	if (allow_errors) {

--- a/ext/intl/collator/collator_is_numeric.c
+++ b/ext/intl/collator/collator_is_numeric.c
@@ -212,19 +212,13 @@ zend_uchar collator_is_numeric( UChar *str, int32_t length, zend_long *lval, dou
 	zend_long local_lval;
 	double local_dval;
 	UChar *end_ptr_long, *end_ptr_double;
-	int conv_base=10;
 
 	if (!length) {
 		return 0;
 	}
 
-	/* handle hex numbers */
-	if (length>=2 && str[0]=='0' && (str[1]=='x' || str[1]=='X')) {
-		conv_base=16;
-	}
-
 	errno=0;
-	local_lval = collator_u_strtol(str, &end_ptr_long, conv_base);
+	local_lval = collator_u_strtol(str, &end_ptr_long, 10);
 	if (errno != ERANGE) {
 		if (end_ptr_long == str+length) { /* integer string */
 			if (lval) {
@@ -236,11 +230,6 @@ zend_uchar collator_is_numeric( UChar *str, int32_t length, zend_long *lval, dou
 		}
 	} else {
 		end_ptr_long = NULL;
-	}
-
-	if (conv_base == 16) { /* hex string, under UNIX strtod() messes it up */
-		/* UTODO: keep compatibility with is_numeric_string() here? */
-		return 0;
 	}
 
 	local_dval = collator_u_strtod(str, &end_ptr_double);

--- a/ext/intl/collator/collator_is_numeric.h
+++ b/ext/intl/collator/collator_is_numeric.h
@@ -19,6 +19,6 @@
 #include <php.h>
 #include <unicode/uchar.h>
 
-zend_uchar collator_is_numeric( UChar *str, int32_t length, zend_long *lval, double *dval, int allow_errors );
+zend_uchar collator_is_numeric( UChar *str, int32_t length, zend_long *lval, double *dval, bool allow_errors );
 
 #endif // COLLATOR_IS_NUMERIC_H


### PR DESCRIPTION
@nikic I checked the usage of this function and it was only used with allow_error ``1`` meaning it allows all errors silently, I did a bit of clean-up but unsure if it's worth investing time to make it align with zend_is_numeric_string() if it's going to accept gibberish anyway.

Thoughts?