### PR TITLE
Fix #76943: Inconsistent stream_wrapper_restore() errors

### DIFF
--- a/ext/standard/tests/streams/bug76943.phpt
+++ b/ext/standard/tests/streams/bug76943.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #76943 (Inconsistent stream_wrapper_restore() errors)
+--SKIPIF--
+<?php
+if (!in_array('phar', stream_get_wrappers())) die('skip phar wrapper not registered');
+?>
+--FILE--
+<?php
+var_dump(stream_wrapper_restore('foo'));
+var_dump(stream_wrapper_restore('phar'));
+
+stream_wrapper_register('bar', 'stdClass');
+
+var_dump(stream_wrapper_restore('foo'));
+var_dump(stream_wrapper_restore('phar'));
+?>
+--EXPECTF--
+Warning: stream_wrapper_restore(): foo:// never existed, nothing to restore in %s on line %d
+bool(false)
+
+Notice: stream_wrapper_restore(): phar:// was never changed, nothing to restore in %s on line %d
+bool(true)
+
+Warning: stream_wrapper_restore(): foo:// never existed, nothing to restore in %s on line %d
+bool(false)
+
+Notice: stream_wrapper_restore(): phar:// was never changed, nothing to restore in %s on line %d
+bool(true)

--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -559,21 +559,22 @@ PHP_FUNCTION(stream_wrapper_restore)
 {
 	zend_string *protocol;
 	php_stream_wrapper *wrapper;
-	HashTable *global_wrapper_hash;
+	HashTable *global_wrapper_hash, *wrapper_hash;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &protocol) == FAILURE) {
 		RETURN_FALSE;
 	}
 
 	global_wrapper_hash = php_stream_get_url_stream_wrappers_hash_global();
-	if (php_stream_get_url_stream_wrappers_hash() == global_wrapper_hash) {
-		php_error_docref(NULL, E_NOTICE, "%s:// was never changed, nothing to restore", ZSTR_VAL(protocol));
-		RETURN_TRUE;
-	}
-
 	if ((wrapper = zend_hash_find_ptr(global_wrapper_hash, protocol)) == NULL) {
 		php_error_docref(NULL, E_WARNING, "%s:// never existed, nothing to restore", ZSTR_VAL(protocol));
 		RETURN_FALSE;
+	}
+
+	wrapper_hash = php_stream_get_url_stream_wrappers_hash();
+	if (wrapper_hash == global_wrapper_hash || zend_hash_find_ptr(wrapper_hash, protocol) == wrapper) {
+		php_error_docref(NULL, E_NOTICE, "%s:// was never changed, nothing to restore", ZSTR_VAL(protocol));
+		RETURN_TRUE;
 	}
 
 	/* A failure here could be okay given that the protocol might have been merely unregistered */


### PR DESCRIPTION
If restoring of any not registered built-in wrapper is requested, the
function is supposed to fail with a warning, so we have to check this
condition first.

Furthermore, to be able to detect whether a built-in wrapper has been
changed, it is not sufficient to check whether *any* userland wrapper
has been registered, but rather whether the specific wrapper has been
modified.