### PR TITLE
Allow attributes to be applied to property/constant groups

### DIFF
--- a/Zend/tests/attributes/014_class_const_group.phpt
+++ b/Zend/tests/attributes/014_class_const_group.phpt
@@ -1,14 +1,36 @@
 --TEST--
-Attributes cannot be applied to groups of class constants.
+Attributes can be applied to groups of class constants
 --FILE--
 <?php
 
-class C1
+class C
 {
-    #[A1]
+    #[A(1, X)]
     public const A = 1, B = 2;
 }
 
+const X = 2;
+
+$rp1 = new ReflectionClassConstant('C', 'A');
+$ra1 = $rp1->getAttributes()[0];
+var_dump($ra1->getName(), $ra1->getArguments());
+$rp2 = new ReflectionClassConstant('C', 'B');
+$ra2 = $rp2->getAttributes()[0];
+var_dump($ra2->getName(), $ra2->getArguments());
+
 ?>
---EXPECTF--
-Fatal error: Cannot apply attributes to a group of constants in %s
+--EXPECT--
+string(1) "A"
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+}
+string(1) "A"
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+}

--- a/Zend/tests/attributes/015_property_group.phpt
+++ b/Zend/tests/attributes/015_property_group.phpt
@@ -1,14 +1,36 @@
 --TEST--
-Attributes cannot be applied to groups of properties.
+Attributes can be applied to groups of properties
 --FILE--
 <?php
 
-class C1
+class C
 {
-    #[A1]
+    #[A(1, X)]
     public $x, $y;
 }
 
+const X = 2;
+
+$rp1 = new ReflectionProperty('C', 'x');
+$ra1 = $rp1->getAttributes()[0];
+var_dump($ra1->getName(), $ra1->getArguments());
+$rp2 = new ReflectionProperty('C', 'y');
+$ra2 = $rp2->getAttributes()[0];
+var_dump($ra2->getName(), $ra2->getArguments());
+
 ?>
---EXPECTF--
-Fatal error: Cannot apply attributes to a group of properties in %s
+--EXPECT--
+string(1) "A"
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+}
+string(1) "A"
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7069,11 +7069,6 @@ void zend_compile_prop_group(zend_ast *ast) /* {{{ */
 	zend_ast *prop_ast = ast->child[1];
 	zend_ast *attr_ast = ast->child[2];
 
-	if (attr_ast && zend_ast_get_list(prop_ast)->children > 1) {
-		zend_error_noreturn(E_COMPILE_ERROR, "Cannot apply attributes to a group of properties");
-		return;
-	}
-
 	zend_compile_prop_decl(prop_ast, type_ast, ast->attr, attr_ast);
 }
 /* }}} */
@@ -7129,12 +7124,6 @@ void zend_compile_class_const_group(zend_ast *ast) /* {{{ */
 {
 	zend_ast *const_ast = ast->child[0];
 	zend_ast *attr_ast = ast->child[1];
-
-	if (attr_ast && zend_ast_get_list(const_ast)->children > 1) {
-		zend_error_noreturn(E_COMPILE_ERROR, "Cannot apply attributes to a group of constants");
-
-		return;
-	}
 
 	zend_compile_class_const_decl(const_ast, ast->attr, attr_ast);
 }


### PR DESCRIPTION
This is a case that was not discussed in the RFC, and where we decided to go for the conservative option when reviewing the implementation. However, the restriction seems very arbitrary and I don't think we should keep it.