### PR TITLE
Fix #76735: Incorrect message in fopen on invalid mode

### DIFF
--- a/ext/bz2/tests/002.phpt
+++ b/ext/bz2/tests/002.phpt
@@ -83,12 +83,12 @@ bool(false)
 resource(%d) of type (stream)
 resource(%d) of type (stream)
 
-Warning: fopen(bz_open_002.txt): failed to open stream: Bad file %s in %s on line %d
+Warning: fopen(bz_open_002.txt): failed to open stream: `br' is not a valid mode for fopen in %s on line %d
 
 Warning: bzopen(): first parameter has to be string or file-resource in %s on line %d
 bool(false)
 
-Warning: fopen(bz_open_002.txt): failed to open stream: Bad file %s in %s on line %d
+Warning: fopen(bz_open_002.txt): failed to open stream: `br' is not a valid mode for fopen in %s on line %d
 
 Warning: bzopen(): first parameter has to be string or file-resource in %s on line %d
 bool(false)

--- a/ext/standard/tests/file/bug76735.phpt
+++ b/ext/standard/tests/file/bug76735.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Bug #76735 (Incorrect message in fopen on invalid mode)
+--FILE--
+<?php
+fopen(__FILE__, 'Q');
+?>
+--EXPECTF--
+Warning: fopen(%s): failed to open stream: `Q' is not a valid mode for fopen in %s on line %d

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1021,9 +1021,7 @@ PHPAPI php_stream *_php_stream_fopen(const char *filename, const char *mode, zen
 	char *persistent_id = NULL;
 
 	if (FAILURE == php_stream_parse_fopen_modes(mode, &open_flags)) {
-		if (options & REPORT_ERRORS) {
-			php_error_docref(NULL, E_WARNING, "`%s' is not a valid mode for fopen", mode);
-		}
+		php_stream_wrapper_log_error(&php_plain_files_wrapper, options, "`%s' is not a valid mode for fopen", mode);
 		return NULL;
 	}
 


### PR DESCRIPTION
We have to log errors in `stream_opener` callbacks to the wrapper's
error log, because otherwise we may pick up an unrelated `errno` or a
most generic message.

---

Does anybody know why we *toggle* `REPORT_ERRORS` when opening the stream:
https://github.com/php/php-src/blob/c15e2532a2468e1e48429d203ed002ec029c61b0/main/streams/streams.c#L2047