### PR TITLE
Fix #80138: skip getservbyname() and getservbyport() tests on *nix if there is no /etc/services file

### DIFF
--- a/ext/standard/tests/general_functions/getservbyname_basic.phpt
+++ b/ext/standard/tests/general_functions/getservbyname_basic.phpt
@@ -5,6 +5,12 @@ Italian PHP TestFest 2009 Cesena 19-20-21 june
 Fabio Fabbrucci (fabbrucci@grupporetina.com)
 Michele Orselli (mo@ideato.it)
 Simone Gentili (sensorario@gmail.com)
+--SKIPIF--
+<?php
+    if(in_array(PHP_OS_FAMILY, ['BSD', 'Darwin', 'Solaris', 'Linux'])){
+        if (!file_exists("/etc/services")) die("skip reason: missing /etc/services");
+    }
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/getservbyport_basic.phpt
+++ b/ext/standard/tests/general_functions/getservbyport_basic.phpt
@@ -5,6 +5,12 @@ Italian PHP TestFest 2009 Cesena 19-20-21 june
 Fabio Fabbrucci (fabbrucci@grupporetina.com)
 Michele Orselli (mo@ideato.it)
 Simone Gentili (sensorario@gmail.com)
+--SKIPIF--
+<?php
+    if(in_array(PHP_OS_FAMILY, ['BSD', 'Darwin', 'Solaris', 'Linux'])){
+        if (!file_exists("/etc/services")) die("skip reason: missing /etc/services");
+    }
+?>
 --FILE--
 <?php
     if (file_exists("/etc/services")) {

--- a/ext/standard/tests/general_functions/getservbyport_variation1.phpt
+++ b/ext/standard/tests/general_functions/getservbyport_variation1.phpt
@@ -7,6 +7,12 @@ Italian PHP TestFest 2009 Cesena 19-20-21 june
 Fabio Fabbrucci (fabbrucci@grupporetina.com)
 Michele Orselli (mo@ideato.it)
 Simone Gentili (sensorario@gmail.com)
+--SKIPIF--
+<?php
+    if(in_array(PHP_OS_FAMILY, ['BSD', 'Darwin', 'Solaris', 'Linux'])){
+        if (!file_exists("/etc/services")) die("skip reason: missing /etc/services");
+    }
+?>
 --FILE--
 <?php
     var_dump(getservbyport( -1, "tcp" ));


### PR DESCRIPTION
Fix proposal for https://bugs.php.net/bug.php?id=80138

Skip the failing tests if
* test is run on *nix
* /etc/services is missing