### PR TITLE
Fix #80137: skip getprotobyname() and getprotobynumber() tests on *nix if there is no /etc/protocols file

### DIFF
--- a/ext/standard/tests/network/getprotobyname_basic.phpt
+++ b/ext/standard/tests/network/getprotobyname_basic.phpt
@@ -2,6 +2,12 @@
 getprotobyname function basic test
 --CREDITS--
 edgarsandi - <edgar.r.sandi@gmail.com>
+--SKIPIF--
+<?php
+    if(in_array(PHP_OS_FAMILY, ['BSD', 'Darwin', 'Solaris', 'Linux'])){
+        if (!file_exists("/etc/protocols")) die("skip reason: missing /etc/protocols");
+    }
+?>
 --FILE--
 <?php
     var_dump(getprotobyname('tcp'));

--- a/ext/standard/tests/network/getprotobynumber_basic.phpt
+++ b/ext/standard/tests/network/getprotobynumber_basic.phpt
@@ -2,6 +2,12 @@
 getprotobynumber function basic test
 --CREDITS--
 edgarsandi - <edgar.r.sandi@gmail.com>
+--SKIPIF--
+<?php
+    if(in_array(PHP_OS_FAMILY, ['BSD', 'Darwin', 'Solaris', 'Linux'])){
+        if (!file_exists("/etc/protocols")) die("skip reason: missing /etc/protocols");
+    }
+?>
 --FILE--
 <?php
     var_dump(getprotobynumber(6));


### PR DESCRIPTION
Fix proposal for https://bugs.php.net/bug.php?id=80137

Skip failing tests on *nix if there is no /etc/protocols file.