### PR TITLE
Skip unnecessary unknown() frames in backtraces

### DIFF
--- a/ext/phar/tests/cache_list/frontcontroller29.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller29.phpt
@@ -16,7 +16,6 @@ Content-type: text/html; charset=UTF-8
 --EXPECTF--
 Fatal error: Uncaught Error: Call to undefined function oopsie_daisy() in phar://%sfatalerror.phps:1
 Stack trace:
-#0 [internal function]: unknown()
-#1 %s(%d): Phar::webPhar('whatever', 'index.php', '404.php', Array)
-#2 {main}
+#0 %s(%d): Phar::webPhar('whatever', 'index.php', '404.php', Array)
+#1 {main}
   thrown in phar://%sfatalerror.phps on line 1

--- a/ext/phar/tests/frontcontroller29.phpt
+++ b/ext/phar/tests/frontcontroller29.phpt
@@ -15,7 +15,6 @@ Content-type: text/html; charset=UTF-8
 --EXPECTF--
 Fatal error: Uncaught Error: Call to undefined function oopsie_daisy() in phar://%sfatalerror.phps:1
 Stack trace:
-#0 [internal function]: unknown()
-#1 %s(%d): Phar::webPhar('whatever', 'index.php', '404.php', Array)
-#2 {main}
+#0 %s(%d): Phar::webPhar('whatever', 'index.php', '404.php', Array)
+#1 {main}
   thrown in phar://%sfatalerror.phps on line 1


### PR DESCRIPTION
Noticed this while working on attributes strict_types handling. We sometimes insert dummy frames internally, but I don't think these should show up in debug_backtrace output unless they're needed, either to display an include call or to preserve file/line information that would otherwise get lost.