### PR TITLE
Promote foreach warning about argument type to TypeError

### DIFF
--- a/Zend/tests/bug79792.phpt
+++ b/Zend/tests/bug79792.phpt
@@ -3,14 +3,18 @@ Bug #79792: HT iterators not removed if empty array is destroyed
 --FILE--
 <?php
 $a = [42];
-foreach ($a as &$c) {
-    // Make the array empty.
-    unset($a[0]);
-    // Destroy the array.
-    $a = null;
+try {
+    foreach ($a as &$c) {
+        // Make the array empty.
+        unset($a[0]);
+        // Destroy the array.
+        $a = null;
+    }
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 ?>
 ===DONE===
---EXPECTF--
-Warning: foreach() argument must be of type array|object, null given in %s on line %d
+--EXPECT--
+foreach() argument must be of type array|object, null given
 ===DONE===

--- a/Zend/tests/foreach_over_null.phpt
+++ b/Zend/tests/foreach_over_null.phpt
@@ -4,12 +4,16 @@ foreach over null
 <?php
 
 function test() {
-    foreach (null as $v) {
-        echo "Foo\n";
+    try {
+        foreach (null as $v) {
+            echo "Foo\n";
+        }
+    } catch (\TypeError $e) {
+        echo $e->getMessage(), \PHP_EOL;
     }
 }
 test();
 
 ?>
---EXPECTF--
-Warning: foreach() argument must be of type array|object, null given in %s on line %d
+--EXPECT--
+foreach() argument must be of type array|object, null given

--- a/Zend/tests/foreach_undefined.phpt
+++ b/Zend/tests/foreach_undefined.phpt
@@ -3,12 +3,15 @@ foreach() & undefined var
 --FILE--
 <?php
 
-foreach($a as $val);
+try {
+    foreach($a as $val);
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
+}
 
 echo "Done\n";
 ?>
 --EXPECTF--
 Warning: Undefined variable $a in %s on line %d
-
-Warning: foreach() argument must be of type array|object, null given in %s on line %d
+foreach() argument must be of type array|object, null given
 Done

--- a/Zend/tests/nullsafe_operator/023.phpt
+++ b/Zend/tests/nullsafe_operator/023.phpt
@@ -9,8 +9,12 @@ class Foo {
 
 $foo = new Foo();
 
-foreach ($foo?->bar as &$value) {
-    var_dump($value);
+try {
+    foreach ($foo?->bar as &$value) {
+        var_dump($value);
+    }
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 
 // Don't convert $foo->bar into a reference.
@@ -30,8 +34,8 @@ foreach ($foo?->bar as &$value) {
 var_dump($foo->bar);
 
 ?>
---EXPECTF--
-Warning: foreach() argument must be of type array|object, null given in %s on line %d
+--EXPECT--
+foreach() argument must be of type array|object, null given
 int(42)
 array(1) {
   [0]=>

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -6519,8 +6519,10 @@ ZEND_VM_HANDLER(77, ZEND_FE_RESET_R, CONST|TMP|VAR|CV, JMP_ADDR)
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 		FREE_OP1();
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
@@ -6608,8 +6610,10 @@ ZEND_VM_COLD_CONST_HANDLER(125, ZEND_FE_RESET_RW, CONST|TMP|VAR|CV, JMP_ADDR)
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 		if (OP1_TYPE == IS_VAR) {
 			FREE_OP1_VAR_PTR();
@@ -6916,11 +6920,9 @@ ZEND_VM_HANDLER(126, ZEND_FE_FETCH_RW, VAR, ANY, JMP_ADDR)
 			value_type = Z_TYPE_INFO_P(value);
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array));
-		if (UNEXPECTED(EG(exception))) {
-			UNDEF_RESULT();
-			HANDLE_EXCEPTION();
-		}
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
 ZEND_VM_C_LABEL(fe_fetch_w_exit):
 		ZEND_VM_SET_RELATIVE_OPCODE(opline, opline->extended_value);
 		ZEND_VM_CONTINUE();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4878,8 +4878,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_RESET_R_SPEC_CONST_HANDLER(
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
@@ -4966,8 +4968,10 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_RESET_RW_SPEC_
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 		if (IS_CONST == IS_VAR) {
 
@@ -18874,8 +18878,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_RESET_R_SPEC_TMP_HANDLER(ZE
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
@@ -18962,8 +18968,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_RESET_RW_SPEC_TMP_HANDLER(Z
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 		if (IS_TMP_VAR == IS_VAR) {
 
@@ -21425,8 +21433,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_RESET_R_SPEC_VAR_HANDLER(ZE
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 		zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
@@ -21514,8 +21524,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_RESET_RW_SPEC_VAR_HANDLER(Z
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 		if (IS_VAR == IS_VAR) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -21822,11 +21834,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FETCH_RW_SPEC_VAR_HANDLER(Z
 			value_type = Z_TYPE_INFO_P(value);
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array));
-		if (UNEXPECTED(EG(exception))) {
-			UNDEF_RESULT();
-			HANDLE_EXCEPTION();
-		}
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
 fe_fetch_w_exit:
 		ZEND_VM_SET_RELATIVE_OPCODE(opline, opline->extended_value);
 		ZEND_VM_CONTINUE();
@@ -38125,8 +38135,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_RESET_R_SPEC_CV_HANDLER(ZEN
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 
 		ZEND_VM_JMP(OP_JMP_ADDR(opline, opline->op2));
@@ -38213,8 +38225,10 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_RESET_RW_SPEC_CV_HANDLER(ZE
 			}
 		}
 	} else {
-		zend_error(E_WARNING, "foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
-		ZVAL_UNDEF(EX_VAR(opline->result.var));
+		zend_type_error("foreach() argument must be of type array|object, %s given", zend_zval_type_name(array_ptr));
+		UNDEF_RESULT();
+		HANDLE_EXCEPTION();
+		/* ZVAL_UNDEF(EX_VAR(opline->result.var)); */
 		Z_FE_ITER_P(EX_VAR(opline->result.var)) = (uint32_t)-1;
 		if (IS_CV == IS_VAR) {
 

--- a/ext/opcache/tests/bug79412.phpt
+++ b/ext/opcache/tests/bug79412.phpt
@@ -10,16 +10,19 @@ opcache.optimization_level=-1
 $limitPerRun = 10;
 foreach ($foo as $bar) {
     $count = 0;
-    foreach ($runs as $run) {
-        ++$count;
-        if ($count >= $limitPerRun) {
-            break;
+    try {
+        foreach ($runs as $run) {
+            ++$count;
+            if ($count >= $limitPerRun) {
+                break;
+            }
         }
+    } catch (\TypeError $e) {
+        echo $e->getMessage(), \PHP_EOL;
     }
     foo($limitPerRun);
 }
 ?>
 --EXPECTF--
 Warning: Undefined variable $foo in %s on line %d
-
-Warning: foreach() argument must be of type array|object, null given in %s on line %d
+foreach() argument must be of type array|object, null given

--- a/ext/simplexml/tests/bug38347.phpt
+++ b/ext/simplexml/tests/bug38347.phpt
@@ -8,8 +8,12 @@ Bug #38347 (Segmentation fault when using foreach with an unknown/empty SimpleXM
 function iterate($xml)
 {
     print_r($xml);
-    foreach ($xml->item as $item) {
-        echo "This code will crash!";
+    try {
+        foreach ($xml->item as $item) {
+            echo "This code will crash!";
+        }
+    } catch (\TypeError $e) {
+        echo $e->getMessage(), \PHP_EOL;
     }
 }
 
@@ -19,10 +23,9 @@ iterate($xml->unknown);
 
 echo "Done\n";
 ?>
---EXPECTF--
+--EXPECT--
 SimpleXMLElement Object
 (
 )
-
-Warning: foreach() argument must be of type array|object, null given in %sbug38347.php on line 6
+foreach() argument must be of type array|object, null given
 Done

--- a/ext/simplexml/tests/sxe_003.phpt
+++ b/ext/simplexml/tests/sxe_003.phpt
@@ -37,10 +37,14 @@ EOF;
 
 $sxe = simplexml_load_string($xml, 'SimpleXMLIterator');
 
-foreach($sxe->getChildren() as $name => $data) {
-    var_dump($name);
-    var_dump(get_class($data));
-    var_dump(trim($data));
+try {
+    foreach($sxe->getChildren() as $name => $data) {
+        var_dump($name);
+        var_dump(get_class($data));
+        var_dump(trim($data));
+    }
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 
 echo "===RESET===\n";
@@ -57,8 +61,8 @@ for ($sxe->rewind(); $sxe->valid(); $sxe->next()) {
 }
 
 ?>
---EXPECTF--
-Warning: foreach() argument must be of type array|object, null given in %ssxe_003.php on line %d
+--EXPECT--
+foreach() argument must be of type array|object, null given
 ===RESET===
 bool(true)
 string(5) "elem1"

--- a/tests/classes/bug27468.phpt
+++ b/tests/classes/bug27468.phpt
@@ -4,7 +4,12 @@ Bug #27468 (foreach in __destruct() causes segfault)
 <?php
 class foo {
     function __destruct() {
-        foreach ($this->x as $x);
+        try {
+            foreach ($this->x as $x);
+        }
+        catch (\TypeError $e) {
+            echo $e->getMessage(), \PHP_EOL;
+        }
     }
 }
 new foo();
@@ -12,6 +17,5 @@ echo 'OK';
 ?>
 --EXPECTF--
 Warning: Undefined property: foo::$x in %s on line %d
-
-Warning: foreach() argument must be of type array|object, null given in %sbug27468.php on line 4
+foreach() argument must be of type array|object, null given
 OK

--- a/tests/lang/bug27439.phpt
+++ b/tests/lang/bug27439.phpt
@@ -32,19 +32,39 @@ class test {
     }
 
     public function case2() {
-        foreach ($this->foobar as $foo);
+        try {
+            foreach ($this->foobar as $foo);
+        }
+        catch (\TypeError $e) {
+            echo $e->getMessage(), \PHP_EOL;
+        }
     }
 
     public function case3() {
-        foreach ($this->string as $foo);
+        try {
+            foreach ($this->string as $foo);
+        }
+        catch (\TypeError $e) {
+            echo $e->getMessage(), \PHP_EOL;
+        }
     }
 
     public function case4() {
-        foreach ($this->getArray() as $foo);
+        try {
+            foreach ($this->getArray() as $foo);
+        }
+        catch (\TypeError $e) {
+            echo $e->getMessage(), \PHP_EOL;
+        }
     }
 
     public function case5() {
-        foreach ($this->getString() as $foo);
+        try {
+            foreach ($this->getString() as $foo);
+        }
+        catch (\TypeError $e) {
+            echo $e->getMessage(), \PHP_EOL;
+        }
     }
 
     public function case6() {
@@ -66,11 +86,8 @@ echo "===DONE===";
 --EXPECTF--
 123
 Warning: Undefined property: test::$foobar in %s on line %d
-
-Warning: foreach() argument must be of type array|object, null given in %s on line %d
-
-Warning: foreach() argument must be of type array|object, string given in %s on line %d
-
-Warning: foreach() argument must be of type array|object, string given in %s on line %d
+foreach() argument must be of type array|object, null given
+foreach() argument must be of type array|object, string given
+foreach() argument must be of type array|object, string given
 123
 ===DONE===

--- a/tests/lang/bug29566.phpt
+++ b/tests/lang/bug29566.phpt
@@ -7,10 +7,12 @@ $var="This is a string";
 $dummy="";
 unset($dummy);
 
-foreach($var['0nosuchkey'] as $v) {
+try {
+    foreach($var['0nosuchkey'] as $v) {}
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 ?>
 --EXPECTF--
 Warning: Illegal string offset "0nosuchkey" in %s on line %d
-
-Warning: foreach() argument must be of type array|object, string given in %sbug29566.php on line %d
+foreach() argument must be of type array|object, string given

--- a/tests/lang/foreachLoop.003.phpt
+++ b/tests/lang/foreachLoop.003.phpt
@@ -4,42 +4,57 @@ Foreach loop tests - error case: not an array.
 <?php
 echo "\nNot an array.\n";
 $a = TRUE;
-foreach ($a as $v) {
-    var_dump($v);
+try {
+    foreach ($a as $v) {
+        var_dump($v);
+    }
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 
 $a = null;
-foreach ($a as $v) {
-    var_dump($v);
+try {
+    foreach ($a as $v) {
+        var_dump($v);
+    }
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 
 $a = 1;
-foreach ($a as $v) {
-    var_dump($v);
+try {
+    foreach ($a as $v) {
+        var_dump($v);
+    }
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 
 $a = 1.5;
-foreach ($a as $v) {
-    var_dump($v);
+try {
+    foreach ($a as $v) {
+        var_dump($v);
+    }
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 
 $a = "hello";
-foreach ($a as $v) {
-    var_dump($v);
+try {
+    foreach ($a as $v) {
+        var_dump($v);
+    }
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
 }
 
 echo "done.\n";
 ?>
 --EXPECTF--
 Not an array.
-
-Warning: foreach() argument must be of type array|object, bool given in %s on line 4
-
-Warning: foreach() argument must be of type array|object, null given in %s on line 9
-
-Warning: foreach() argument must be of type array|object, int given in %s on line 14
-
-Warning: foreach() argument must be of type array|object, float given in %s on line 19
-
-Warning: foreach() argument must be of type array|object, string given in %s on line 24
+foreach() argument must be of type array|object, bool given
+foreach() argument must be of type array|object, null given
+foreach() argument must be of type array|object, int given
+foreach() argument must be of type array|object, float given
+foreach() argument must be of type array|object, string given
 done.


### PR DESCRIPTION
This seems to have been missed as part of the Reclassifying engine warnings RFC (https://wiki.php.net/rfc/engine_warnings)