### PR TITLE
Promote warning to ValueError for Spoofchecker::setRestrictionLevel()

### DIFF
--- a/ext/intl/spoofchecker/spoofchecker_main.c
+++ b/ext/intl/spoofchecker/spoofchecker_main.c
@@ -125,6 +125,7 @@ PHP_METHOD(Spoofchecker, setChecks)
 /* }}} */
 
 #if U_ICU_VERSION_MAJOR_NUM >= 58
+/* TODO Document this method on PHP.net */
 /* {{{ Set the loosest restriction level allowed for strings. */
 PHP_METHOD(Spoofchecker, setRestrictionLevel)
 {
@@ -143,7 +144,9 @@ PHP_METHOD(Spoofchecker, setRestrictionLevel)
 			USPOOF_MODERATELY_RESTRICTIVE != level &&
 			USPOOF_MINIMALLY_RESTRICTIVE != level &&
 			USPOOF_UNRESTRICTIVE != level) {
-		zend_argument_value_error(1, "must be one of the Spoofchecker::*_RESTRICTIVE constants or Spoofchecker::UNRESTRICTIVE");
+		zend_argument_value_error(1, "must be one of Spoofchecker::ASCII, Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE, "
+			"Spoofchecker::SINGLE_HIGHLY_RESTRICTIVE, Spoofchecker::SINGLE_MODERATELY_RESTRICTIVE, "
+			"Spoofchecker::SINGLE_MINIMALLY_RESTRICTIVE, or Spoofchecker::UNRESTRICTIVE");
 		RETURN_THROWS();
 	}
 

--- a/ext/intl/spoofchecker/spoofchecker_main.c
+++ b/ext/intl/spoofchecker/spoofchecker_main.c
@@ -143,8 +143,8 @@ PHP_METHOD(Spoofchecker, setRestrictionLevel)
 			USPOOF_MODERATELY_RESTRICTIVE != level &&
 			USPOOF_MINIMALLY_RESTRICTIVE != level &&
 			USPOOF_UNRESTRICTIVE != level) {
-		php_error_docref(NULL, E_WARNING, "Invalid restriction level value");
-		return;
+		zend_argument_value_error(1, "must be one of the Spoofchecker::*_RESTRICTIVE constants or Spoofchecker::UNRESTRICTIVE");
+		RETURN_THROWS();
 	}
 
 	uspoof_setRestrictionLevel(co->uspoof, (URestrictionLevel)level);

--- a/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
+++ b/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Spoofchecker attempting to pass an unknown restriction level
+--SKIPIF--
+<?php if(!extension_loaded('intl') || !class_exists("Spoofchecker")) print 'skip'; ?>
+--FILE--
+<?php
+
+$x = new Spoofchecker();
+try {
+    $x->setRestrictionLevel(Spoofchecker::SINGLE_SCRIPT);
+} catch (\ValueError $e) {
+    echo $e->getMessage(), \PHP_EOL;
+}
+
+?>
+--EXPECT--
+Spoofchecker::setRestrictionLevel(): Argument #1 ($level) must be one of the Spoofchecker::*_RESTRICTIVE constants or Spoofchecker::UNRESTRICTIVE

--- a/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
+++ b/ext/intl/tests/spoofchecker_unknown_restriction_level.phpt
@@ -14,4 +14,4 @@ try {
 
 ?>
 --EXPECT--
-Spoofchecker::setRestrictionLevel(): Argument #1 ($level) must be one of the Spoofchecker::*_RESTRICTIVE constants or Spoofchecker::UNRESTRICTIVE
+Spoofchecker::setRestrictionLevel(): Argument #1 ($level) must be one of Spoofchecker::ASCII, Spoofchecker::SINGLE_SCRIPT_RESTRICTIVE, Spoofchecker::SINGLE_HIGHLY_RESTRICTIVE, Spoofchecker::SINGLE_MODERATELY_RESTRICTIVE, Spoofchecker::SINGLE_MINIMALLY_RESTRICTIVE, or Spoofchecker::UNRESTRICTIVE


### PR DESCRIPTION
@kocsismate is this error message fine? Or do you have a better idea on how to integrate the Spoofchecker::UNRESTRICTIVE constant with the other 4?