### PR TITLE
Fix #78792: zlib.output_compression disabled by Content-Type: image/

### DIFF
--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -762,13 +762,6 @@ SAPI_API int sapi_header_op(sapi_header_op_enum op, void *arg)
 					len--;
 				}
 
-				/* Disable possible output compression for images */
-				if (!strncmp(ptr, "image/", sizeof("image/")-1)) {
-					zend_string *key = zend_string_init("zlib.output_compression", sizeof("zlib.output_compression")-1, 0);
-					zend_alter_ini_entry_chars(key, "0", sizeof("0") - 1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
-					zend_string_release_ex(key, 0);
-				}
-
 				mimetype = estrdup(ptr);
 				newlen = sapi_apply_default_charset(&mimetype, len);
 				if (!SG(sapi_headers).mimetype){


### PR DESCRIPTION
Disabling output compression for images has served to fix bug #16109,
where zlib compressed images apparently have caused issues with
Navigator 4.  This shouldn't be an issue with somewhat contemporary
browsers.  Other than that, this is an arbitrary restriction – why
don't we disable the compression for some other media types as well
(e.g. video/* and audio/*)?  All in all, we should leave that decision
to userland.