### PR TITLE
Add some compiler flags which aren't included in -Wall or -Wextra

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -215,6 +215,10 @@ fi
 test -n "$GCC" && CFLAGS="-Wall -Wextra -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare $CFLAGS"
 dnl Check if compiler supports -Wno-clobbered (only GCC)
 AX_CHECK_COMPILE_FLAG([-Wno-clobbered], CFLAGS="-Wno-clobbered $CFLAGS", , [-Werror])
+AX_CHECK_COMPILE_FLAG([-Wduplicated-cond], CFLAGS="-Wduplicated-cond $CFLAGS", , [-Werror])
+AX_CHECK_COMPILE_FLAG([-Wlogical-op], CFLAGS="-Wlogical-op $CFLAGS", , [-Werror])
+AX_CHECK_COMPILE_FLAG([-Wformat-truncation], CFLAGS="-Wformat-truncation $CFLAGS", , [-Werror])
+AX_CHECK_COMPILE_FLAG([-fno-common], CFLAGS="-fno-common $CFLAGS", , [-Werror])
 
 test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"
 

--- a/ext/sodium/config.m4
+++ b/ext/sodium/config.m4
@@ -11,8 +11,9 @@ if test "$PHP_SODIUM" != "no"; then
 
   AC_DEFINE(HAVE_LIBSODIUMLIB, 1, [ ])
 
-  dnl Add -Wno-type-limits as this may arise on 32bits platforms
+  dnl Add -Wno-type-limits and -Wno-logical-op as this may arise on 32bits platforms
   SODIUM_COMPILER_FLAGS="$LIBSODIUM_CFLAGS -Wno-type-limits"
+  AX_CHECK_COMPILE_FLAG([-Wno-logical-op], SODIUM_COMPILER_FLAGS="$SODIUM_COMPILER_FLAGS -Wno-logical-op", , [-Werror])
   PHP_NEW_EXTENSION(sodium, libsodium.c sodium_pwhash.c, $ext_shared, , $SODIUM_COMPILER_FLAGS)
   PHP_SUBST(SODIUM_SHARED_LIBADD)
 fi


### PR DESCRIPTION
This adds ``-Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wformat-truncation`` and `` -fno-common`` compiler flags.

``-Wlogical-op`` did seem to find some legit bugs. 

EDIT: Need to figure out a way to get around Windows for the GCC pragma