### PR TITLE
Fix #78470: odbc_specialcolumns() no longer accepts $nullable

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -3668,7 +3668,7 @@ PHP_FUNCTION(odbc_specialcolumns)
 	SQLUSMALLINT type, scope, nullable;
 	RETCODE rc;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rls!ssl", &pv_conn, &vtype, &cat, &cat_len, &schema, &schema_len,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rls!ssll", &pv_conn, &vtype, &cat, &cat_len, &schema, &schema_len,
 		&name, &name_len, &vscope, &vnullable) == FAILURE) {
 		return;
 	}

--- a/ext/odbc/tests/bug78470.phpt
+++ b/ext/odbc/tests/bug78470.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #78470 (odbc_specialcolumns() no longer accepts $nullable)
+--SKIPIF--
+<?php
+if (!extension_loaded('odbc')) die('skip odbc extension not available');
+?>
+--FILE--
+<?php
+include 'config.inc';
+
+$conn = odbc_connect($dsn, $user, $pass);
+var_dump(odbc_specialcolumns($conn, SQL_BEST_ROWID, '', '', '', SQL_SCOPE_CURROW, SQL_NO_NULLS));
+?>
+--EXPECTF--
+resource(%d) of type (odbc result)


### PR DESCRIPTION
It is mandatory to pass either `SQL_NO_NULLS` or `SQL_NULLABLE` as
tenth parameter to `SQLSpecialColumns()`; otherwise the function call
fails.  Therefore the user must be allowed to pass the desired value
as parameter to `odbc_specialcolumns()` again.