### PR TITLE
Extensions should have the final say on their compiler flags

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -251,10 +251,10 @@ dnl Append to the array which has been dynamically chosen at m4 time.
 
 dnl Choose the right compiler/flags/etc. for the source-file.
       case $ac_src in
-        *.c[)] ac_comp="$b_c_pre $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $3 $b_c_post" ;;
-        *.s[)] ac_comp="$b_c_pre $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $3 $b_c_post" ;;
-        *.S[)] ac_comp="$b_c_pre $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $3 $b_c_post" ;;
-        *.cpp|*.cc|*.cxx[)] ac_comp="$b_cxx_pre $ac_inc $b_cxx_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $3 $b_cxx_post" ;;
+        *.c[)] ac_comp="$b_c_pre $ac_inc $b_c_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
+        *.s[)] ac_comp="$b_c_pre $ac_inc $b_c_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
+        *.S[)] ac_comp="$b_c_pre $ac_inc $b_c_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_c_post" ;;
+        *.cpp|*.cc|*.cxx[)] ac_comp="$b_cxx_pre $ac_inc $b_cxx_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_cxx_post" ;;
       esac
 
 dnl Create a rule for the object/source combo.

--- a/build/php.m4
+++ b/build/php.m4
@@ -218,7 +218,7 @@ ifelse($1,shared,[
 ])
 
 dnl
-dnl PHP_ADD_SOURCES_X(source-path, sources[, special-flags[, target-var[, shared[, special-post-flags]]]])
+dnl PHP_ADD_SOURCES_X(source-path, sources[, special-flags[, target-var[, shared]]])
 dnl
 dnl Additional to PHP_ADD_SOURCES (see above), this lets you set the name of the
 dnl array target-var directly, as well as whether shared objects will be built
@@ -251,10 +251,10 @@ dnl Append to the array which has been dynamically chosen at m4 time.
 
 dnl Choose the right compiler/flags/etc. for the source-file.
       case $ac_src in
-        *.c[)] ac_comp="$b_c_pre $3 $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $6$b_c_post" ;;
-        *.s[)] ac_comp="$b_c_pre $3 $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $6$b_c_post" ;;
-        *.S[)] ac_comp="$b_c_pre $3 $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $6$b_c_post" ;;
-        *.cpp|*.cc|*.cxx[)] ac_comp="$b_cxx_pre $3 $ac_inc $b_cxx_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $6$b_cxx_post" ;;
+        *.c[)] ac_comp="$b_c_pre $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $3 $b_c_post" ;;
+        *.s[)] ac_comp="$b_c_pre $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $3 $b_c_post" ;;
+        *.S[)] ac_comp="$b_c_pre $ac_inc $b_c_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $3 $b_c_post" ;;
+        *.cpp|*.cc|*.cxx[)] ac_comp="$b_cxx_pre $ac_inc $b_cxx_meta -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $3 $b_cxx_post" ;;
       esac
 
 dnl Create a rule for the object/source combo.


### PR DESCRIPTION
Currently compiler flags passed by extensions using the standard  ``PHP_NEW_EXTENSION`` and ``PHP_ADD_SOURCES`` m4 macros are prepended before the ones defined by ``Zend/Zend.m4``. This was not really an issue before as ``Zend.m4`` only included ``-Wall`` but since the addition of ``-Wextra`` various issue about disabling flags have been brought up, notably by @bwoebi and I've hit this once again in #6199 

A preliminary attempt was https://github.com/php/php-src/commit/5c1cf7669b937dcb4589cb0c8deccd343dfd85f9 but this turns out to be more or less irrelevant.

The root issue is that  ``PHP_NEW_EXTENSION`` and ``PHP_ADD_SOURCES`` call the ``PHP_ADD_SOURCES_X`` macro and pass their flags as the 3rd argument which prepends the flags. There exists a 6th argument for this macro which appends them but from a cursory look at https://heap.space/search?full=PHP_ADD_SOURCES_X&project=php-src this is not used. Moreover, the comment describing this macro explicitly informs that this macro should not be used directly.

The proposal is to drop the 6th argument of ``PHP_ADD_SOURCES_X`` and move the `special-flags` argument to be appended instead of prepended.