### PR TITLE
[Observer] Pass zend_execute_data instead of zend_function to fcall init

### DIFF
--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -89,9 +89,10 @@ ZEND_API void zend_observer_shutdown(void) {
 	zend_llist_destroy(&zend_observer_error_callbacks);
 }
 
-static void zend_observer_fcall_install(zend_function *function) {
+static void zend_observer_fcall_install(zend_execute_data *execute_data) {
 	zend_llist_element *element;
 	zend_llist *list = &zend_observers_fcall_list;
+	zend_function *function = execute_data->func;
 	zend_op_array *op_array = &function->op_array;
 
 	if (fcall_handlers_arena == NULL) {
@@ -105,7 +106,7 @@ static void zend_observer_fcall_install(zend_function *function) {
 	for (element = list->head; element; element = element->next) {
 		zend_observer_fcall_init init;
 		memcpy(&init, element->data, sizeof init);
-		zend_observer_fcall_handlers handlers = init(function);
+		zend_observer_fcall_handlers handlers = init(execute_data);
 		if (handlers.begin || handlers.end) {
 			zend_llist_add_element(&handlers_list, &handlers);
 		}
@@ -150,7 +151,7 @@ static void ZEND_FASTCALL _zend_observe_fcall_begin(zend_execute_data *execute_d
 
 	fcall_data = ZEND_OBSERVER_DATA(op_array);
 	if (!fcall_data) {
-		zend_observer_fcall_install((zend_function *)op_array);
+		zend_observer_fcall_install(execute_data);
 		fcall_data = ZEND_OBSERVER_DATA(op_array);
 	}
 

--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -50,7 +50,7 @@ typedef struct _zend_observer_fcall_handlers {
 } zend_observer_fcall_handlers;
 
 /* If the fn should not be observed then return {NULL, NULL} */
-typedef zend_observer_fcall_handlers (*zend_observer_fcall_init)(zend_function *func);
+typedef zend_observer_fcall_handlers (*zend_observer_fcall_init)(zend_execute_data *execute_data);
 
 // Call during minit/startup ONLY
 ZEND_API void zend_observer_fcall_register(zend_observer_fcall_init);

--- a/ext/zend_test/tests/observer_backtrace_01.phpt
+++ b/ext/zend_test/tests/observer_backtrace_01.phpt
@@ -1,0 +1,106 @@
+--TEST--
+Observer: Show backtrace on init
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_init_backtrace=1
+--FILE--
+<?php
+class TestClass
+{
+    private function bar($number)
+    {
+        return $number + 2;
+    }
+
+    public function foo()
+    {
+        return array_map(function ($value) {
+            return $this->bar($value);
+        }, [40, 1335]);
+    }
+}
+
+function gen()
+{
+    $test = new TestClass();
+    yield $test->foo();
+}
+
+function foo()
+{
+    return gen()->current();
+}
+
+var_dump(foo());
+?>
+--EXPECTF--
+<!-- init '%s/observer_backtrace_%d.php' -->
+<!--
+    {main} %s/observer_backtrace_%d.php
+-->
+<file '%s/observer_backtrace_%d.php'>
+  <!-- init foo() -->
+  <!--
+      foo()
+      {main} %s/observer_backtrace_%d.php
+  -->
+  <foo>
+    <!-- init gen() -->
+    <!--
+        gen()
+        Generator::current()
+        foo()
+        {main} %s/observer_backtrace_%d.php
+    -->
+    <gen>
+      <!-- init TestClass::foo() -->
+      <!--
+          TestClass::foo()
+          gen()
+          Generator::current()
+          foo()
+          {main} %s/observer_backtrace_%d.php
+      -->
+      <TestClass::foo>
+        <!-- init TestClass::{closure}() -->
+        <!--
+            TestClass::{closure}()
+            array_map()
+            TestClass::foo()
+            gen()
+            Generator::current()
+            foo()
+            {main} %s/observer_backtrace_%d.php
+        -->
+        <TestClass::{closure}>
+          <!-- init TestClass::bar() -->
+          <!--
+              TestClass::bar()
+              TestClass::{closure}()
+              array_map()
+              TestClass::foo()
+              gen()
+              Generator::current()
+              foo()
+              {main} %s/observer_backtrace_%d.php
+          -->
+          <TestClass::bar>
+          </TestClass::bar>
+        </TestClass::{closure}>
+        <TestClass::{closure}>
+          <TestClass::bar>
+          </TestClass::bar>
+        </TestClass::{closure}>
+      </TestClass::foo>
+    </gen>
+  </foo>
+array(2) {
+  [0]=>
+  int(42)
+  [1]=>
+  int(1337)
+}
+</file '%s/observer_backtrace_%d.php'>


### PR DESCRIPTION
This changes the observer API signature for `zend_observer_fcall_init`:

```diff
- typedef zend_observer_fcall_handlers (*zend_observer_fcall_init)(zend_function *func);
+ typedef zend_observer_fcall_handlers (*zend_observer_fcall_init)(zend_execute_data *execute_data);
```

The motivation for this change is to prevent extensions from having to check executor globals for the current execute_data during function call init. (See [this example](https://github.com/amphp/ext-fiber/blob/8d7f557/src/fiber.c#L315) from @trowski's work on `amphp/ext-fiber`.)

A previous implementation of the observer API initialized the function call from runtime cache initialization before execute_data was allocated which is why `zend_function` was passed in instead. But now that the observer API is implemented via opcode specialization, it makes sense to pass in the execute_data.

This also keeps the API a bit more consistent for existing extensions that already hook `zend_execute_ex`.

/cc @morrisonlevi and @beberlei