### PR TITLE
Fix #80147: BINARY strings may not be properly zero-terminated

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2221,6 +2221,7 @@ PHP_FUNCTION(odbc_result)
 			if (rc != SQL_SUCCESS_WITH_INFO) {
 				field_str = zend_string_truncate(field_str, result->values[field_ind].vallen, 0);
 			}
+			ZSTR_VAL(field_str)[ZSTR_LEN(field_str)] = '\0';
 			RETURN_NEW_STR(field_str);
 			break;
 

--- a/ext/odbc/tests/bug80147.phpt
+++ b/ext/odbc/tests/bug80147.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #80147 (BINARY strings may not be properly zero-terminated)
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'config.inc';
+
+$conn = odbc_connect($dsn, $user, $pass);
+
+odbc_exec($conn, "CREATE TABLE bug80147 (id INT, whatever VARBINARY(50))");
+odbc_exec($conn, "INSERT INTO bug80147 VALUES (1, CONVERT(VARBINARY(50), 'whatever'))");
+
+$res = odbc_exec($conn, "SELECT * FROM bug80147");
+odbc_binmode($res, ODBC_BINMODE_RETURN);
+odbc_fetch_row($res);
+var_dump(odbc_result($res, 'whatever'));
+?>
+--CLEAN--
+<?php
+include 'config.inc';
+
+$conn = odbc_connect($dsn, $user, $pass);
+odbc_exec($conn, "DROP TABLE bug80147");
+?>
+--EXPECT--
+string(8) "whatever"


### PR DESCRIPTION
We have to manually ensure that all strings fetched from a data source
are zero-terminated.