### PR TITLE
Warning promotion / Consistent handling of NULL bytes in file paths (WIP)

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1306,8 +1306,8 @@ static void dom_parse_document(INTERNAL_FUNCTION_PARAMETERS, int mode) {
 	}
 
 	if (!source_len) {
-		php_error_docref(NULL, E_WARNING, "Empty string supplied as input");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must not be empty");
+		RETURN_THROWS();
 	}
 	if (ZEND_SIZE_T_INT_OVFL(source_len)) {
 		php_error_docref(NULL, E_WARNING, "Input string is too long");
@@ -1389,8 +1389,8 @@ PHP_METHOD(DOMDocument, save)
 	}
 
 	if (file_len == 0) {
-		php_error_docref(NULL, E_WARNING, "Invalid Filename");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must not be empty");
+		RETURN_THROWS();
 	}
 
 	DOM_GET_OBJ(docp, id, xmlDocPtr, intern);
@@ -1624,9 +1624,9 @@ static void _dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 		RETURN_THROWS();
 	}
 
-	if (source_len == 0) {
-		php_error_docref(NULL, E_WARNING, "Invalid Schema source");
-		RETURN_FALSE;
+	if (!source_len) {
+		zend_argument_value_error(1, "must not be empty");
+		RETURN_THROWS();
 	}
 
 	DOM_GET_OBJ(docp, id, xmlDocPtr, intern);
@@ -1725,9 +1725,9 @@ static void _dom_document_relaxNG_validate(INTERNAL_FUNCTION_PARAMETERS, int typ
 		RETURN_THROWS();
 	}
 
-	if (source_len == 0) {
-		php_error_docref(NULL, E_WARNING, "Invalid Schema source");
-		RETURN_FALSE;
+	if (!source_len) {
+		zend_argument_value_error(1, "must not be empty");
+		RETURN_THROWS();
 	}
 
 	DOM_GET_OBJ(docp, id, xmlDocPtr, intern);
@@ -1824,8 +1824,8 @@ static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 	}
 
 	if (!source_len) {
-		php_error_docref(NULL, E_WARNING, "Empty string supplied as input");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must not be empty");
+		RETURN_THROWS();
 	}
 
 	if (ZEND_LONG_EXCEEDS_INT(options)) {
@@ -1931,8 +1931,8 @@ PHP_METHOD(DOMDocument, saveHTMLFile)
 	}
 
 	if (file_len == 0) {
-		php_error_docref(NULL, E_WARNING, "Invalid Filename");
-		RETURN_FALSE;
+		zend_argument_value_error(1, "must not be empty");
+		RETURN_THROWS();
 	}
 
 	DOM_GET_OBJ(docp, id, xmlDocPtr, intern);

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1195,16 +1195,17 @@ static xmlDocPtr dom_document_parser(zval *id, int mode, char *source, size_t so
 	xmlInitParser();
 
 	if (mode == DOM_LOAD_FILE) {
-		char *file_dest;
+		char *file_source;
 		if (CHECK_NULL_PATH(source, source_len)) {
 			zend_value_error("Path to document must not contain any null bytes");
 			return NULL;
 		}
-		file_dest = _dom_get_valid_file_path(source, resolved_path, MAXPATHLEN);
-		if (file_dest) {
-			ctxt = xmlCreateFileParserCtxt(file_dest);
+		file_source = _dom_get_valid_file_path(source, resolved_path, MAXPATHLEN);
+		if (!file_source) {
+			zend_value_error("Path to document is not a valid path");
+			return NULL;
 		}
-
+		ctxt = xmlCreateFileParserCtxt(file_source);
 	} else {
 		ctxt = xmlCreateMemoryParserCtxt(source, source_len);
 	}
@@ -1639,8 +1640,8 @@ static void _dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 		}
 		valid_file = _dom_get_valid_file_path(source, resolved_path, MAXPATHLEN);
 		if (!valid_file) {
-			php_error_docref(NULL, E_WARNING, "Invalid Schema file source");
-			RETURN_FALSE;
+			zend_argument_value_error(1, "is not a valid path");
+			RETURN_THROWS();
 		}
 		parser = xmlSchemaNewParserCtxt(valid_file);
 		break;
@@ -1740,8 +1741,8 @@ static void _dom_document_relaxNG_validate(INTERNAL_FUNCTION_PARAMETERS, int typ
 		}
 		valid_file = _dom_get_valid_file_path(source, resolved_path, MAXPATHLEN);
 		if (!valid_file) {
-			php_error_docref(NULL, E_WARNING, "Invalid RelaxNG file source");
-			RETURN_FALSE;
+			zend_argument_value_error(1, "is not a valid path");
+			RETURN_THROWS();
 		}
 		parser = xmlRelaxNGNewParserCtxt(valid_file);
 		break;

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1197,6 +1197,7 @@ static xmlDocPtr dom_document_parser(zval *id, int mode, char *source, size_t so
 	if (mode == DOM_LOAD_FILE) {
 		char *file_dest;
 		if (CHECK_NULL_PATH(source, source_len)) {
+			zend_value_error("Path to document must not contain any null bytes");
 			return NULL;
 		}
 		file_dest = _dom_get_valid_file_path(source, resolved_path, MAXPATHLEN);
@@ -1633,8 +1634,8 @@ static void _dom_document_schema_validate(INTERNAL_FUNCTION_PARAMETERS, int type
 	switch (type) {
 	case DOM_LOAD_FILE:
 		if (CHECK_NULL_PATH(source, source_len)) {
-			php_error_docref(NULL, E_WARNING, "Invalid Schema file source");
-			RETURN_FALSE;
+			zend_argument_value_error(1, "must not contain any null bytes");
+			RETURN_THROWS();
 		}
 		valid_file = _dom_get_valid_file_path(source, resolved_path, MAXPATHLEN);
 		if (!valid_file) {
@@ -1734,8 +1735,8 @@ static void _dom_document_relaxNG_validate(INTERNAL_FUNCTION_PARAMETERS, int typ
 	switch (type) {
 	case DOM_LOAD_FILE:
 		if (CHECK_NULL_PATH(source, source_len)) {
-			php_error_docref(NULL, E_WARNING, "Invalid RelaxNG file source");
-			RETURN_FALSE;
+			zend_argument_value_error(1, "must not contain any null bytes");
+			RETURN_THROWS();
 		}
 		valid_file = _dom_get_valid_file_path(source, resolved_path, MAXPATHLEN);
 		if (!valid_file) {
@@ -1834,8 +1835,8 @@ static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 
 	if (mode == DOM_LOAD_FILE) {
 		if (CHECK_NULL_PATH(source, source_len)) {
-			php_error_docref(NULL, E_WARNING, "Invalid file source");
-			RETURN_FALSE;
+			zend_argument_value_error(1, "must not contain any null bytes");
+			RETURN_THROWS();
 		}
 		ctxt = htmlCreateFileParserCtxt(source, NULL);
 	} else {

--- a/ext/dom/tests/DOMDocument_loadHTML_error2.phpt
+++ b/ext/dom/tests/DOMDocument_loadHTML_error2.phpt
@@ -9,7 +9,11 @@ require_once('skipif.inc');
 --FILE--
 <?php
 $doc = new DOMDocument();
-$doc->loadHTML('');
+try {
+    $doc->loadHTML('');
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
 ?>
---EXPECTF--
-Warning: DOMDocument::loadHTML(): Empty string supplied as input in %s on line %d
+--EXPECT--
+DOMDocument::loadHTML(): Argument #1 ($source) must not be empty

--- a/ext/dom/tests/DOMDocument_loadHTMLfile_error2.phpt
+++ b/ext/dom/tests/DOMDocument_loadHTMLfile_error2.phpt
@@ -14,10 +14,12 @@ $doc = new DOMDocument();
 $result = $doc->loadHTMLFile("");
 assert($result === false);
 $doc = new DOMDocument();
-$result = $doc->loadHTMLFile("text.html\0something");
-assert($result === false);
+try {
+    $result = $doc->loadHTMLFile("text.html\0something");
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
 ?>
 --EXPECTF--
 %r(PHP ){0,1}%rWarning: DOMDocument::loadHTMLFile(): Empty string supplied as input %s
-
-%r(PHP ){0,1}%rWarning: DOMDocument::loadHTMLFile(): Invalid file source %s
+DOMDocument::loadHTMLFile(): Argument #1 ($filename) must not contain any null bytes

--- a/ext/dom/tests/DOMDocument_loadHTMLfile_error2.phpt
+++ b/ext/dom/tests/DOMDocument_loadHTMLfile_error2.phpt
@@ -11,8 +11,12 @@ assert.bail=true
 --FILE--
 <?php
 $doc = new DOMDocument();
-$result = $doc->loadHTMLFile("");
-assert($result === false);
+try {
+    $result = $doc->loadHTMLFile("");
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
+
 $doc = new DOMDocument();
 try {
     $result = $doc->loadHTMLFile("text.html\0something");
@@ -20,6 +24,6 @@ try {
     echo $e->getMessage() . "\n";
 }
 ?>
---EXPECTF--
-%r(PHP ){0,1}%rWarning: DOMDocument::loadHTMLFile(): Empty string supplied as input %s
+--EXPECT--
+DOMDocument::loadHTMLFile(): Argument #1 ($filename) must not be empty
 DOMDocument::loadHTMLFile(): Argument #1 ($filename) must not contain any null bytes

--- a/ext/dom/tests/DOMDocument_loadXML_error6.phpt
+++ b/ext/dom/tests/DOMDocument_loadXML_error6.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test DOMDocument::loadXML() with empty file path
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+// create dom document
+$dom = new DOMDocument();
+try {
+    $dom->loadXML("");
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+?>
+--EXPECT--
+DOMDocument::loadXML(): Argument #1 ($source) must not be empty

--- a/ext/dom/tests/DOMDocument_load_error6.phpt
+++ b/ext/dom/tests/DOMDocument_load_error6.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test DOMDocument::load() with invalid paths
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+// create dom document
+$dom = new DOMDocument();
+try {
+    $dom->load("");
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    $dom->load("/path/with/\0/byte");
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    // Path is too long
+    $dom->load(str_repeat(" ", PHP_MAXPATHLEN + 1));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+?>
+--EXPECT--
+DOMDocument::load(): Argument #1 ($filename) must not be empty
+Path to document must not contain any null bytes
+Path to document is not a valid path

--- a/ext/dom/tests/DOMDocument_saveHTMLFile_invalid_filename.phpt
+++ b/ext/dom/tests/DOMDocument_saveHTMLFile_invalid_filename.phpt
@@ -19,7 +19,11 @@ $title = $doc->createElement('title');
 $title = $head->appendChild($title);
 $text = $doc->createTextNode('This is the title');
 $text = $title->appendChild($text);
-$bytes = $doc->saveHTMLFile($filename);
+try {
+    $doc->saveHTMLFile($filename);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
 ?>
---EXPECTF--
-Warning: DOMDocument::saveHTMLFile(): Invalid Filename in %s on line %d
+--EXPECT--
+DOMDocument::saveHTMLFile(): Argument #1 ($filename) must not be empty

--- a/ext/dom/tests/DOMDocument_schemaValidateSource_error3.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidateSource_error3.phpt
@@ -12,10 +12,12 @@ $doc = new DOMDocument;
 
 $doc->load(__DIR__."/book.xml");
 
-$result = $doc->schemaValidateSource('');
-var_dump($result);
+try {
+    $doc->schemaValidateSource('');
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
 
 ?>
---EXPECTF--
-Warning: DOMDocument::schemaValidateSource(): Invalid Schema source in %s.php on line %d
-bool(false)
+--EXPECT--
+DOMDocument::schemaValidateSource(): Argument #1 ($source) must not be empty

--- a/ext/dom/tests/DOMDocument_schemaValidate_error3.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidate_error3.phpt
@@ -12,10 +12,12 @@ $doc = new DOMDocument;
 
 $doc->load(__DIR__."/book.xml");
 
-$result = $doc->schemaValidate('');
-var_dump($result);
+try {
+    $doc->schemaValidate('');
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
 
 ?>
---EXPECTF--
-Warning: DOMDocument::schemaValidate(): Invalid Schema source in %s.php on line %d
-bool(false)
+--EXPECT--
+DOMDocument::schemaValidate(): Argument #1 ($filename) must not be empty

--- a/ext/dom/tests/DOMDocument_schemaValidate_error6.phpt
+++ b/ext/dom/tests/DOMDocument_schemaValidate_error6.phpt
@@ -1,0 +1,27 @@
+--TEST--
+DomDocument::schemaValidate() - invalid path to schema
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+
+$doc->load(__DIR__."/book.xml");
+
+try {
+    $doc->schemaValidate("/path/with/\0/byte");
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    $doc->schemaValidate(str_repeat(" ", PHP_MAXPATHLEN + 1));
+} catch (ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+DOMDocument::schemaValidate(): Argument #1 ($filename) must not contain any null bytes
+DOMDocument::schemaValidate(): Argument #1 ($filename) is not a valid path

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -444,7 +444,7 @@ static void _php_finfo_get_type(INTERNAL_FUNCTION_PARAMETERS, int mode, int mime
 				goto clean;
 			}
 			if (CHECK_NULL_PATH(buffer, buffer_len)) {
-				zend_argument_type_error(1, "must not contain null bytes");
+				zend_argument_type_error(1, "must not contain any null bytes");
 				goto clean;
 			}
 

--- a/ext/fileinfo/tests/finfo_file_001.phpt
+++ b/ext/fileinfo/tests/finfo_file_001.phpt
@@ -26,7 +26,7 @@ var_dump(finfo_file($fp, '&'));
 
 ?>
 --EXPECTF--
-finfo_file(): Argument #1 ($finfo) must not contain null bytes
+finfo_file(): Argument #1 ($finfo) must not contain any null bytes
 finfo_file(): Argument #1 ($finfo) cannot be empty
 finfo_file(): Argument #1 ($finfo) cannot be empty
 string(9) "directory"

--- a/ext/fileinfo/tests/finfo_file_basic.phpt
+++ b/ext/fileinfo/tests/finfo_file_basic.phpt
@@ -25,4 +25,4 @@ try {
 string(28) "text/x-php; charset=us-ascii"
 string(22) "PHP script, ASCII text"
 string(25) "text/plain; charset=utf-8"
-finfo_file(): Argument #1 ($finfo) must not contain null bytes
+finfo_file(): Argument #1 ($finfo) must not contain any null bytes

--- a/ext/fileinfo/tests/mime_content_type_001.phpt
+++ b/ext/fileinfo/tests/mime_content_type_001.phpt
@@ -48,4 +48,4 @@ mime_content_type(): Argument #2 must be of type resource|string, array given
 
 Warning: mime_content_type(foo/inexistent): Failed to open stream: No such file or directory in %s on line %d
 mime_content_type(): Argument #1 ($filename) cannot be empty
-mime_content_type(): Argument #1 ($filename) must not contain null bytes
+mime_content_type(): Argument #1 ($filename) must not contain any null bytes

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1243,12 +1243,7 @@ PHP_METHOD(SQLite3, openBlob)
 
 	db_obj = Z_SQLITE3_DB_P(object);
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssl|sl", &table, &table_len, &column, &column_len, &rowid, &dbname, &dbname_len, &flags) == FAILURE) {
-		RETURN_THROWS();
-	}
-
-	if (ZEND_NUM_ARGS() >= 4 && CHECK_NULL_PATH(dbname, dbname_len)) {
-		zend_argument_type_error(4, "must not contain null bytes");
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ssl|pl", &table, &table_len, &column, &column_len, &rowid, &dbname, &dbname_len, &flags) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -1346,17 +1341,7 @@ PHP_METHOD(SQLite3, backup)
 	sqlite3_backup *dbBackup;
 	int rc; // Return code
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|ss", &destination_zval, php_sqlite3_sc_entry, &source_dbname, &source_dbname_length, &destination_dbname, &destination_dbname_length) == FAILURE) {
-		RETURN_THROWS();
-	}
-
-	if (ZEND_NUM_ARGS() >= 2 && CHECK_NULL_PATH(source_dbname, source_dbname_length)) {
-		zend_argument_type_error(2, "must not contain null bytes");
-		RETURN_THROWS();
-	}
-
-	if (ZEND_NUM_ARGS() >= 3 && CHECK_NULL_PATH(destination_dbname, destination_dbname_length)) {
-		zend_argument_type_error(3, "must not contain null bytes");
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|pp", &destination_zval, php_sqlite3_sc_entry, &source_dbname, &source_dbname_length, &destination_dbname, &destination_dbname_length) == FAILURE) {
 		RETURN_THROWS();
 	}
 


### PR DESCRIPTION
Not all extensions consistently throw exceptions when the user passes
a path name containing null bytes. Also, some extensions would throw
a ValueError while others would throw a TypeError. Error messages
also varied.

Now a ValueError is thrown after all failed path checks, at least for
as far as these occur in functions that are exposed to userland.