### PR TITLE
Fix #80152: odbc_execute() moves internal pointer of $params

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1309,7 +1309,7 @@ PHP_FUNCTION(odbc_execute)
 	int numArgs = ZEND_NUM_ARGS(), i, ne;
 	RETCODE rc;
 
-	if (zend_parse_parameters(numArgs, "r|a", &pv_res, &pv_param_arr) == FAILURE) {
+	if (zend_parse_parameters(numArgs, "r|a/", &pv_res, &pv_param_arr) == FAILURE) {
 		return;
 	}
 

--- a/ext/odbc/tests/bug80152.phpt
+++ b/ext/odbc/tests/bug80152.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #80152 (odbc_execute() moves internal pointer of $params)
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'config.inc';
+
+$conn = odbc_connect($dsn, $user, $pass);
+odbc_exec($conn,"CREATE TABLE bug80152 (id INT, name CHAR(24))"); 
+$stmt = odbc_prepare($conn,"INSERT INTO bug80152 (id, name) VALUES (?, ?)");
+$params = [1, "John", "Lim"];
+var_dump(key($params));
+odbc_execute($stmt, $params);
+var_dump(key($params));
+?>
+--CLEAN--
+<?php
+include 'config.inc';
+
+$conn = odbc_connect($dsn, $user, $pass);
+odbc_exec($conn, "DROP TABLE bug80152");
+?>
+--EXPECT--
+int(0)
+int(0)


### PR DESCRIPTION
As least intrusive fix, we separate the passed array argument.

---

For the "master" branch, the following fix seems to be preferable:
````.patch
 ext/odbc/php_odbc.c | 23 +++++++----------------
 1 file changed, 7 insertions(+), 16 deletions(-)

diff --git a/ext/odbc/php_odbc.c b/ext/odbc/php_odbc.c
index bfb72bcff7..a8a8042c12 100644
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -991,25 +991,13 @@ PHP_FUNCTION(odbc_execute)
 			RETURN_FALSE;
 		}
 
-		zend_hash_internal_pointer_reset(pv_param_ht);
 		params = (params_t *)safe_emalloc(sizeof(params_t), result->numparams, 0);
 		for(i = 0; i < result->numparams; i++) {
 			params[i].fp = -1;
 		}
 
-		for(i = 1; i <= result->numparams; i++) {
-			if ((tmp = zend_hash_get_current_data(pv_param_ht)) == NULL) {
-				php_error_docref(NULL, E_WARNING,"Error getting parameter");
-				SQLFreeStmt(result->stmt,SQL_RESET_PARAMS);
-				for (i = 0; i < result->numparams; i++) {
-					if (params[i].fp != -1) {
-						close(params[i].fp);
-					}
-				}
-				efree(params);
-				RETURN_FALSE;
-			}
-
+		i = 1;
+		ZEND_HASH_FOREACH_VAL(pv_param_ht, tmp) {
 			otype = Z_TYPE_P(tmp);
 			if (!try_convert_to_string(tmp)) {
 				SQLFreeStmt(result->stmt, SQL_RESET_PARAMS);
@@ -1099,8 +1087,11 @@ PHP_FUNCTION(odbc_execute)
 				efree(params);
 				RETURN_FALSE;
 			}
-			zend_hash_move_forward(pv_param_ht);
-		}
+			if (i > result->numparams) {
+				break;
+			}
+			i++;
+		} ZEND_HASH_FOREACH_END();
 	}
 	/* Close cursor, needed for doing multiple selects */
 	rc = SQLFreeStmt(result->stmt, SQL_CLOSE);
````