### PR TITLE
Rename PDO parameters.

### DIFF
--- a/Zend/tests/bug70914.phpt
+++ b/Zend/tests/bug70914.phpt
@@ -18,4 +18,4 @@ try {
 }
 ?>
 --EXPECT--
-PDOStatement::fetchObject(): Argument #1 ($class_name) must be a valid class name, %Z given
+PDOStatement::fetchObject(): Argument #1 ($class) must be a valid class name, %Z given

--- a/ext/pdo/pdo_dbh.stub.php
+++ b/ext/pdo/pdo_dbh.stub.php
@@ -4,7 +4,7 @@
 
 class PDO
 {
-    public function __construct(string $dsn, ?string $username = null, ?string $passwd = null, ?array $options = null) {}
+    public function __construct(string $dsn, ?string $username = null, ?string $password = null, ?array $options = null) {}
 
     /** @return bool */
     public function beginTransaction() {}
@@ -34,13 +34,13 @@ class PDO
     public function lastInsertId(?string $name = null) {}
 
     /** @return PDOStatement|false */
-    public function prepare(string $statement, array $driver_options = []) {}
+    public function prepare(string $query, array $driver_options = []) {}
 
     /** @return PDOStatement|false */
-    public function query(string $statement, ?int $fetch_mode = null, mixed ...$fetch_mode_args) {}
+    public function query(string $query, ?int $fetch_mode = null, mixed ...$fetch_mode_args) {}
 
     /** @return string|false */
-    public function quote(string $string, int $parameter_type = PDO::PARAM_STR) {}
+    public function quote(string $string, int $type = PDO::PARAM_STR) {}
 
     /** @return bool */
     public function rollBack() {}

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0c7acc78768ad1fb77a09a24ebd4d4e660b350c9 */
+ * Stub hash: 2bee02a9952faf3f768873bafe1be9ef89086029 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, dsn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, passwd, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
@@ -34,19 +34,19 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO_lastInsertId, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO_prepare, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, statement, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, driver_options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO_query, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, statement, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fetch_mode, IS_LONG, 1, "null")
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, fetch_mode_args, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO_quote, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, parameter_type, IS_LONG, 0, "PDO::PARAM_STR")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "PDO::PARAM_STR")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_PDO_rollBack arginfo_class_PDO_beginTransaction

--- a/ext/pdo/pdo_stmt.stub.php
+++ b/ext/pdo/pdo_stmt.stub.php
@@ -5,13 +5,13 @@
 class PDOStatement implements IteratorAggregate
 {
     /** @return bool */
-    public function bindColumn(string|int $column, mixed &$param, int $type = 0, int $maxlen = 0, mixed $driverdata = null) {}
+    public function bindColumn(string|int $column, mixed &$param, int $type = 0, int $max_length = 0, mixed $driver_options = null) {}
 
     /** @return bool */
-    public function bindParam(string|int $parameter, mixed &$param, int $type = PDO::PARAM_STR, int $maxlen = 0, mixed $driverdata = null) {}
+    public function bindParam(string|int $param, mixed &$bind_var, int $type = PDO::PARAM_STR, int $max_length = 0, mixed $driver_options = null) {}
 
     /** @return bool */
-    public function bindValue(string|int $parameter, mixed $value, int $type = PDO::PARAM_STR) {}
+    public function bindValue(string|int $param, mixed $value, int $type = PDO::PARAM_STR) {}
 
     /** @return bool */
     public function closeCursor() {}
@@ -32,22 +32,22 @@ class PDOStatement implements IteratorAggregate
     public function execute(?array $input_parameters = null) {}
 
     /** @return mixed */
-    public function fetch(int $fetch_style = PDO::FETCH_BOTH, int $cursor_orientation = PDO::FETCH_ORI_NEXT, int $cursor_offset = 0) {}
+    public function fetch(int $mode = PDO::FETCH_BOTH, int $cursor_orientation = PDO::FETCH_ORI_NEXT, int $cursor_offset = 0) {}
 
     /** @return array */
-    public function fetchAll(int $fetch_style = PDO::FETCH_BOTH, mixed ...$fetch_mode_args) {}
+    public function fetchAll(int $mode = PDO::FETCH_BOTH, mixed ...$args) {}
 
     /** @return mixed */
-    public function fetchColumn(int $column_number = 0) {}
+    public function fetchColumn(int $index = 0) {}
 
     /** @return mixed */
-    public function fetchObject(?string $class_name = "stdClass", ?array $ctor_args = null) {}
+    public function fetchObject(?string $class = "stdClass", ?array $constructor_args = null) {}
 
     /** @return mixed */
-    public function getAttribute(int $attribute) {}
+    public function getAttribute(int $name) {}
 
     /** @return array|false */
-    public function getColumnMeta(int $column) {}
+    public function getColumnMeta(int $index) {}
 
     /** @return bool */
     public function nextRowset() {}

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -1,24 +1,28 @@
 /* This is a generated file, edit the .stub.php file instead.
+<<<<<<< HEAD
  * Stub hash: c12bc1c5d1e3dbd8cce67e50c974b20ec5564e67 */
+=======
+ * Stub hash: c9ad501fee826e75bb1101edd6fee762958e6e03 */
+>>>>>>> 8218779939... Fix PDO parameters.
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_bindColumn, 0, 0, 2)
 	ZEND_ARG_TYPE_MASK(0, column, MAY_BE_STRING|MAY_BE_LONG, NULL)
 	ZEND_ARG_TYPE_INFO(1, param, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxlen, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, driverdata, IS_MIXED, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, max_length, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, driver_options, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_bindParam, 0, 0, 2)
-	ZEND_ARG_TYPE_MASK(0, parameter, MAY_BE_STRING|MAY_BE_LONG, NULL)
-	ZEND_ARG_TYPE_INFO(1, param, IS_MIXED, 0)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_STRING|MAY_BE_LONG, NULL)
+	ZEND_ARG_TYPE_INFO(1, bind_var, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "PDO::PARAM_STR")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, maxlen, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, driverdata, IS_MIXED, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, max_length, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, driver_options, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_bindValue, 0, 0, 2)
-	ZEND_ARG_TYPE_MASK(0, parameter, MAY_BE_STRING|MAY_BE_LONG, NULL)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_STRING|MAY_BE_LONG, NULL)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "PDO::PARAM_STR")
 ZEND_END_ARG_INFO()
@@ -39,31 +43,36 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_execute, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_fetch, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fetch_style, IS_LONG, 0, "PDO::FETCH_BOTH")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PDO::FETCH_BOTH")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, cursor_orientation, IS_LONG, 0, "PDO::FETCH_ORI_NEXT")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, cursor_offset, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_fetchAll, 0, 0, 0)
+<<<<<<< HEAD
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fetch_style, IS_LONG, 0, "PDO::FETCH_BOTH")
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, fetch_mode_args, IS_MIXED, 0)
+=======
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PDO::FETCH_BOTH")
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, args, IS_MIXED, 0)
+>>>>>>> 8218779939... Fix PDO parameters.
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_fetchColumn, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, column_number, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, index, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_fetchObject, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class_name, IS_STRING, 1, "\"stdClass\"")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ctor_args, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class, IS_STRING, 1, "\"stdClass\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, constructor_args, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_getAttribute, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, attribute, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_getColumnMeta, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, column, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_PDOStatement_nextRowset arginfo_class_PDOStatement_closeCursor

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -1,9 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
-<<<<<<< HEAD
- * Stub hash: c12bc1c5d1e3dbd8cce67e50c974b20ec5564e67 */
-=======
- * Stub hash: c9ad501fee826e75bb1101edd6fee762958e6e03 */
->>>>>>> 8218779939... Fix PDO parameters.
+ * Stub hash: b3338fc077eab1280da093f059fac14dd7f19678 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_bindColumn, 0, 0, 2)
 	ZEND_ARG_TYPE_MASK(0, column, MAY_BE_STRING|MAY_BE_LONG, NULL)
@@ -49,13 +45,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_fetch, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_fetchAll, 0, 0, 0)
-<<<<<<< HEAD
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fetch_style, IS_LONG, 0, "PDO::FETCH_BOTH")
-	ZEND_ARG_VARIADIC_TYPE_INFO(0, fetch_mode_args, IS_MIXED, 0)
-=======
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PDO::FETCH_BOTH")
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, args, IS_MIXED, 0)
->>>>>>> 8218779939... Fix PDO parameters.
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_fetchColumn, 0, 0, 0)

--- a/ext/pdo_mysql/tests/bug_37445.phpt
+++ b/ext/pdo_mysql/tests/bug_37445.phpt
@@ -17,7 +17,7 @@ $stmt = $db->prepare("SELECT 1");
 $stmt->bindParam(':a', 'b');
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: PDOStatement::bindParam(): Argument #2 ($param) cannot be passed by reference in %sbug_37445.php:%d
+Fatal error: Uncaught Error: PDOStatement::bindParam(): Argument #2 ($bind_var) cannot be passed by reference in %sbug_37445.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug_37445.php on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native.phpt
@@ -344,7 +344,7 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test');
 ?>
 --EXPECT--
-PDO::prepare(): Argument #1 ($statement) cannot be empty
+PDO::prepare(): Argument #1 ($query) cannot be empty
 array(1) {
   [0]=>
   array(1) {

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetchobject.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetchobject.phpt
@@ -111,5 +111,5 @@ object(myclass)#%d (4) {
   ["null"]=>
   NULL
 }
-PDOStatement::fetchObject(): Argument #1 ($class_name) must be a valid class name, class_does_not_exist given
+PDOStatement::fetchObject(): Argument #1 ($class) must be a valid class name, class_does_not_exist given
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_getcolumnmeta.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_getcolumnmeta.phpt
@@ -302,6 +302,6 @@ $db->exec('DROP TABLE IF EXISTS test');
 print "done!";
 ?>
 --EXPECT--
-PDOStatement::getColumnMeta(): Argument #1 ($column) must be greater than or equal to 0
+PDOStatement::getColumnMeta(): Argument #1 ($index) must be greater than or equal to 0
 Testing native PS...
 done!


### PR DESCRIPTION
* s/`$passwd`/`$password`.
* s/`$driverdata`/`$driver_options` to match docs.
* s/`$class_name`/`$class`, as we've done elsewhere.
* Standardize on `$param` instead of `$parameter`.
* Get rid of `$ctor_args` because really?
* Don't repeat function name as variable name.
* Standardize `$fetch_style`/`$fetch_mode` on the latter, since there is a `setFetchMode` method.  Except in cases where "fetch" is already in the method name, then just use `$mode`.  (I'm unsure about this one.)