### PR TITLE
Fix #67465: NULL Pointer dereference in odbc_handle_preparer

### DIFF
--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -179,6 +179,8 @@ static int odbc_handle_preparer(pdo_dbh_t *dbh, const char *sql, size_t sql_len,
 		return 0;
 	}
 
+	stmt->driver_data = S;
+
 	cursor_type = pdo_attr_lval(driver_options, PDO_ATTR_CURSOR, PDO_CURSOR_FWDONLY);
 	if (cursor_type != PDO_CURSOR_FWDONLY) {
 		rc = SQLSetStmtAttr(S->stmt, SQL_ATTR_CURSOR_SCROLLABLE, (void*)SQL_SCROLLABLE, 0);
@@ -197,7 +199,6 @@ static int odbc_handle_preparer(pdo_dbh_t *dbh, const char *sql, size_t sql_len,
 		efree(nsql);
 	}
 
-	stmt->driver_data = S;
 	stmt->methods = &odbc_stmt_methods;
 
 	if (rc != SQL_SUCCESS) {

--- a/ext/pdo_odbc/tests/bug67465.phpt
+++ b/ext/pdo_odbc/tests/bug67465.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #67465 (NULL Pointer dereference in odbc_handle_preparer)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_odbc')) die('skip pdo_odbc extension not available');
+require 'ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require 'ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+$db->prepare("SELECT 1", [PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL]);
+echo "done\n";
+?>
+--EXPECT--
+done


### PR DESCRIPTION
We have to initialize `stmt->driver_data` before we use it.