### PR TITLE
Auto-capturing multi-statement closures

### DIFF
--- a/Zend/tests/arrow_functions/001.phpt
+++ b/Zend/tests/arrow_functions/001.phpt
@@ -47,11 +47,13 @@ $var = 11;
 $foo = fn() => ++$var;
 var_dump($var);
 var_dump($foo());
+var_dump($var);
 
 $var = 13;
 $foo = fn() => { return ++$var; };
 var_dump($var);
 var_dump($foo());
+var_dump($var);
 
 // Nested arrow functions
 $var = 14;
@@ -81,8 +83,10 @@ int(9)
 int(10)
 int(11)
 int(12)
+int(11)
 int(13)
 int(14)
+int(13)
 int(14)
 int(15)
 int(16)

--- a/Zend/tests/arrow_functions/001.phpt
+++ b/Zend/tests/arrow_functions/001.phpt
@@ -4,26 +4,26 @@ Basic arrow function functionality check
 <?php
 
 // No return value
-$foo = fn() => {};
+$foo = fn() {};
 var_dump($foo());
 
 // Return value
 $foo = fn() => 1;
 var_dump($foo());
 
-$foo = fn() => { return 2; };
+$foo = fn() { return 2; };
 var_dump($foo());
 
 $foo = fn($x) => $x;
 var_dump($foo(3));
 
-$foo = fn($x) => { return $x; };
+$foo = fn($x) { return $x; };
 var_dump($foo(4));
 
 $foo = fn($x, $y) => $x + $y;
 var_dump($foo(4, 1));
 
-$foo = fn($x, $y) => { return $x + $y; };
+$foo = fn($x, $y) { return $x + $y; };
 var_dump($foo(5, 1));
 
 // Closing over $var
@@ -32,14 +32,14 @@ $foo = fn() => $var;
 var_dump($foo());
 
 $var = 8;
-$foo = fn() => { return $var; };
+$foo = fn() { return $var; };
 var_dump($foo());
 
 // Not closing over $var, it's a parameter
 $foo = fn($var) => $var;
 var_dump($foo(9));
 
-$foo = fn($var) => { return $var; };
+$foo = fn($var) { return $var; };
 var_dump($foo(10));
 
 // Close over $var by-value, not by-reference
@@ -50,7 +50,7 @@ var_dump($foo());
 var_dump($var);
 
 $var = 13;
-$foo = fn() => { return ++$var; };
+$foo = fn() { return ++$var; };
 var_dump($var);
 var_dump($foo());
 var_dump($var);
@@ -63,10 +63,10 @@ $var = 15;
 var_dump((fn() => function() use($var) { return $var; })()());
 
 $var = 16;
-var_dump((fn() => { return fn() => { return $var; }; })()());
+var_dump((fn() { return fn() { return $var; }; })()());
 
 // Nested arrow functions with null return value
-var_dump((fn() => { return fn() => {}; })()());
+var_dump((fn() { return fn() {}; })()());
 
 ?>
 --EXPECT--

--- a/Zend/tests/arrow_functions/001.phpt
+++ b/Zend/tests/arrow_functions/001.phpt
@@ -3,43 +3,87 @@ Basic arrow function functionality check
 --FILE--
 <?php
 
+// No return value
+$foo = fn() => {};
+var_dump($foo());
+
+// Return value
 $foo = fn() => 1;
 var_dump($foo());
 
+$foo = fn() => { return 2; };
+var_dump($foo());
+
 $foo = fn($x) => $x;
-var_dump($foo(2));
+var_dump($foo(3));
+
+$foo = fn($x) => { return $x; };
+var_dump($foo(4));
 
 $foo = fn($x, $y) => $x + $y;
-var_dump($foo(1, 2));
+var_dump($foo(4, 1));
+
+$foo = fn($x, $y) => { return $x + $y; };
+var_dump($foo(5, 1));
 
 // Closing over $var
-$var = 4;
+$var = 7;
 $foo = fn() => $var;
+var_dump($foo());
+
+$var = 8;
+$foo = fn() => { return $var; };
 var_dump($foo());
 
 // Not closing over $var, it's a parameter
 $foo = fn($var) => $var;
-var_dump($foo(5));
+var_dump($foo(9));
+
+$foo = fn($var) => { return $var; };
+var_dump($foo(10));
 
 // Close over $var by-value, not by-reference
-$var = 5;
+$var = 11;
 $foo = fn() => ++$var;
-var_dump($foo());
 var_dump($var);
+var_dump($foo());
 
-// Nested arrow functions closing over variable
-$var = 6;
+$var = 13;
+$foo = fn() => { return ++$var; };
+var_dump($var);
+var_dump($foo());
+
+// Nested arrow functions
+$var = 14;
 var_dump((fn() => fn() => $var)()());
+
+$var = 15;
 var_dump((fn() => function() use($var) { return $var; })()());
+
+$var = 16;
+var_dump((fn() => { return fn() => { return $var; }; })()());
+
+// Nested arrow functions with null return value
+var_dump((fn() => { return fn() => {}; })()());
 
 ?>
 --EXPECT--
+NULL
 int(1)
 int(2)
 int(3)
 int(4)
 int(5)
 int(6)
-int(5)
-int(6)
-int(6)
+int(7)
+int(8)
+int(9)
+int(10)
+int(11)
+int(12)
+int(13)
+int(14)
+int(14)
+int(15)
+int(16)
+NULL

--- a/Zend/tests/arrow_functions/002.phpt
+++ b/Zend/tests/arrow_functions/002.phpt
@@ -7,7 +7,13 @@ $b = 1;
 
 var_dump((fn() => $b + $c)());
 
+$d = 2;
+var_dump((fn() => { return $d + $e; } )());
+
 ?>
 --EXPECTF--
 Warning: Undefined variable $c in %s on line %d
 int(1)
+
+Warning: Undefined variable $e in %s on line %d
+int(2)

--- a/Zend/tests/arrow_functions/002.phpt
+++ b/Zend/tests/arrow_functions/002.phpt
@@ -8,7 +8,7 @@ $b = 1;
 var_dump((fn() => $b + $c)());
 
 $d = 2;
-var_dump((fn() => { return $d + $e; } )());
+var_dump((fn() { return $d + $e; } )());
 
 ?>
 --EXPECTF--

--- a/Zend/tests/arrow_functions/003.phpt
+++ b/Zend/tests/arrow_functions/003.phpt
@@ -8,8 +8,17 @@ $var = "a";
 $fn = fn() => $$var;
 var_dump($fn());
 
-${5} = 2;
+$b = 2;
+$var = "b";
+$fn = fn() => { return $$var; };
+var_dump($fn());
+
+${5} = 3;
 $fn = fn() => ${5};
+var_dump($fn());
+
+${6} = 4;
+$fn = fn() => { return ${6}; };
 var_dump($fn());
 
 ?>
@@ -17,5 +26,11 @@ var_dump($fn());
 Warning: Undefined variable $a in %s on line %d
 NULL
 
+Warning: Undefined variable $b in %s on line %d
+NULL
+
 Warning: Undefined variable $5 in %s on line %d
+NULL
+
+Warning: Undefined variable $6 in %s on line %d
 NULL

--- a/Zend/tests/arrow_functions/003.phpt
+++ b/Zend/tests/arrow_functions/003.phpt
@@ -10,7 +10,7 @@ var_dump($fn());
 
 $b = 2;
 $var = "b";
-$fn = fn() => { return $$var; };
+$fn = fn() { return $$var; };
 var_dump($fn());
 
 ${5} = 3;
@@ -18,7 +18,7 @@ $fn = fn() => ${5};
 var_dump($fn());
 
 ${6} = 4;
-$fn = fn() => { return ${6}; };
+$fn = fn() { return ${6}; };
 var_dump($fn());
 
 ?>

--- a/Zend/tests/arrow_functions/004.phpt
+++ b/Zend/tests/arrow_functions/004.phpt
@@ -9,7 +9,7 @@ $fn = fn() => $GLOBALS['a'];
 var_dump($fn());
 
 $a = 456;
-$fn = fn() => { return $GLOBALS['a']; };
+$fn = fn() { return $GLOBALS['a']; };
 var_dump($fn());
 
 ?>

--- a/Zend/tests/arrow_functions/004.phpt
+++ b/Zend/tests/arrow_functions/004.phpt
@@ -8,6 +8,11 @@ $a = 123;
 $fn = fn() => $GLOBALS['a'];
 var_dump($fn());
 
+$a = 456;
+$fn = fn() => { return $GLOBALS['a']; };
+var_dump($fn());
+
 ?>
 --EXPECT--
 int(123)
+int(456)

--- a/Zend/tests/arrow_functions/005.phpt
+++ b/Zend/tests/arrow_functions/005.phpt
@@ -10,24 +10,46 @@ class Test {
         $r = new ReflectionFunction($fn);
         var_dump($r->getClosureThis());
 
+        $fn = fn() => {};
+        $r = new ReflectionFunction($fn);
+        var_dump($r->getClosureThis());
+
         $fn = fn() => $this;
+        var_dump($fn());
+
+        $fn = fn() => { return $this; };
         var_dump($fn());
 
         $fn = fn() => Test::method2();
         $fn();
 
+        $fn = fn() => { return Test::method2(); };
+        $fn();
+
         $fn = fn() => call_user_func('Test::method2');
+        $fn();
+
+        $fn = fn() => { return call_user_func('Test::method2'); };
         $fn();
 
         $thisName = "this";
         $fn = fn() => $$thisName;
         var_dump($fn());
 
+        $fn = fn() => { return $$thisName; };
+        var_dump($fn());
+
         $fn = fn() => self::class;
+        var_dump($fn());
+
+        $fn = fn() => { return self::class; };
         var_dump($fn());
 
         // static can be used to unbind $this
         $fn = static fn() => isset($this);
+        var_dump($fn());
+
+        $fn = static fn() => { return isset($this); };
         var_dump($fn());
     }
 
@@ -50,5 +72,17 @@ object(Test)#1 (0) {
 }
 object(Test)#1 (0) {
 }
+object(Test)#1 (0) {
+}
+object(Test)#1 (0) {
+}
+object(Test)#1 (0) {
+}
+object(Test)#1 (0) {
+}
+object(Test)#1 (0) {
+}
 string(4) "Test"
+string(4) "Test"
+bool(false)
 bool(false)

--- a/Zend/tests/arrow_functions/005.phpt
+++ b/Zend/tests/arrow_functions/005.phpt
@@ -10,46 +10,46 @@ class Test {
         $r = new ReflectionFunction($fn);
         var_dump($r->getClosureThis());
 
-        $fn = fn() => {};
+        $fn = fn() {};
         $r = new ReflectionFunction($fn);
         var_dump($r->getClosureThis());
 
         $fn = fn() => $this;
         var_dump($fn());
 
-        $fn = fn() => { return $this; };
+        $fn = fn() { return $this; };
         var_dump($fn());
 
         $fn = fn() => Test::method2();
         $fn();
 
-        $fn = fn() => { return Test::method2(); };
+        $fn = fn() { return Test::method2(); };
         $fn();
 
         $fn = fn() => call_user_func('Test::method2');
         $fn();
 
-        $fn = fn() => { return call_user_func('Test::method2'); };
+        $fn = fn() { return call_user_func('Test::method2'); };
         $fn();
 
         $thisName = "this";
         $fn = fn() => $$thisName;
         var_dump($fn());
 
-        $fn = fn() => { return $$thisName; };
+        $fn = fn() { return $$thisName; };
         var_dump($fn());
 
         $fn = fn() => self::class;
         var_dump($fn());
 
-        $fn = fn() => { return self::class; };
+        $fn = fn() { return self::class; };
         var_dump($fn());
 
         // static can be used to unbind $this
         $fn = static fn() => isset($this);
         var_dump($fn());
 
-        $fn = static fn() => { return isset($this); };
+        $fn = static fn() { return isset($this); };
         var_dump($fn());
     }
 

--- a/Zend/tests/arrow_functions/006.phpt
+++ b/Zend/tests/arrow_functions/006.phpt
@@ -10,7 +10,7 @@ $ref =& $id($var);
 $ref++;
 var_dump($var);
 
-$id = fn&(&$x) => { return $x; };
+$id = fn&(&$x) { return $x; };
 $ref =& $id($var);
 $ref++;
 var_dump($var);
@@ -26,7 +26,7 @@ try {
 }
 
 $var = 11;
-$int_fn = fn(int $x): int => { return $x; };
+$int_fn = fn(int $x): int { return $x; };
 var_dump($int_fn($var));
 try {
     $int_fn("foo");
@@ -42,7 +42,7 @@ try {
     echo $e->getMessage(), "\n";
 }
 
-$varargs = fn(?int... $args): array => { return $args; };
+$varargs = fn(?int... $args): array { return $args; };
 var_dump($varargs(40, null, 50));
 try {
     $varargs(60, "foo");

--- a/Zend/tests/arrow_functions/006.phpt
+++ b/Zend/tests/arrow_functions/006.phpt
@@ -10,9 +10,23 @@ $ref =& $id($var);
 $ref++;
 var_dump($var);
 
+$id = fn&(&$x) => { return $x; };
+$ref =& $id($var);
+$ref++;
+var_dump($var);
+
 // int argument and return type
 $var = 10;
 $int_fn = fn(int $x): int => $x;
+var_dump($int_fn($var));
+try {
+    $int_fn("foo");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$var = 11;
+$int_fn = fn(int $x): int => { return $x; };
 var_dump($int_fn($var));
 try {
     $int_fn("foo");
@@ -28,10 +42,21 @@ try {
     echo $e->getMessage(), "\n";
 }
 
+$varargs = fn(?int... $args): array => { return $args; };
+var_dump($varargs(40, null, 50));
+try {
+    $varargs(60, "foo");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
 ?>
 --EXPECTF--
 int(2)
+int(3)
 int(10)
+{closure}(): Argument #1 ($x) must be of type int, string given, called in %s on line %d
+int(11)
 {closure}(): Argument #1 ($x) must be of type int, string given, called in %s on line %d
 array(3) {
   [0]=>
@@ -40,5 +65,14 @@ array(3) {
   NULL
   [2]=>
   int(30)
+}
+{closure}(): Argument #2 must be of type ?int, string given, called in %s on line %d
+array(3) {
+  [0]=>
+  int(40)
+  [1]=>
+  NULL
+  [2]=>
+  int(50)
 }
 {closure}(): Argument #2 must be of type ?int, string given, called in %s on line %d

--- a/Zend/tests/arrow_functions/007.phpt
+++ b/Zend/tests/arrow_functions/007.phpt
@@ -8,10 +8,23 @@ assert.exception=0
 
 // TODO We're missing parentheses for the direct call
 assert((fn() => false)());
+assert((fn() => { return false; })());
+
 assert((fn&(int... $args): ?bool => $args[0])(false));
+assert((fn&(int... $args): ?bool => { return $args[0]; })(false));
 
 ?>
 --EXPECTF--
 Warning: assert(): assert(fn() => false()) failed in %s on line %d
 
+Warning: assert(): assert(fn() {
+    return false;
+}
+()) failed in %s on line %d
+
 Warning: assert(): assert(fn&(int ...$args): ?bool => $args[0](false)) failed in %s on line %d
+
+Warning: assert(): assert(fn&(int ...$args): ?bool {
+    return $args[0];
+}
+(false)) failed in %s on line %d

--- a/Zend/tests/arrow_functions/007.phpt
+++ b/Zend/tests/arrow_functions/007.phpt
@@ -8,10 +8,10 @@ assert.exception=0
 
 // TODO We're missing parentheses for the direct call
 assert((fn() => false)());
-assert((fn() => { return false; })());
+assert((fn() { return false; })());
 
 assert((fn&(int... $args): ?bool => $args[0])(false));
-assert((fn&(int... $args): ?bool => { return $args[0]; })(false));
+assert((fn&(int... $args): ?bool { return $args[0]; })(false));
 
 ?>
 --EXPECTF--

--- a/Zend/tests/arrow_functions/008.phpt
+++ b/Zend/tests/arrow_functions/008.phpt
@@ -5,24 +5,43 @@ Yield inside arrow functions
 
 // This doesn't make terribly much sense, but it works...
 
-$fn = fn() => yield 123;
+$fn = fn() => yield 1;
 foreach ($fn() as $val) {
     var_dump($val);
 }
 
-$fn = fn() => yield from [456, 789];
+$fn = fn() => { return yield 2; };
 foreach ($fn() as $val) {
     var_dump($val);
 }
 
-$fn = fn() => fn() => yield 987;
+$fn = fn() => yield from [3, 4];
+foreach ($fn() as $val) {
+    var_dump($val);
+}
+
+$fn = fn() => { yield from [5, 6]; };
+foreach ($fn() as $val) {
+    var_dump($val);
+}
+
+$fn = fn() => fn() => yield 7;
+foreach ($fn()() as $val) {
+    var_dump($val);
+}
+
+$fn = fn() => fn() => { yield 8; };
 foreach ($fn()() as $val) {
     var_dump($val);
 }
 
 ?>
 --EXPECT--
-int(123)
-int(456)
-int(789)
-int(987)
+int(1)
+int(2)
+int(3)
+int(4)
+int(5)
+int(6)
+int(7)
+int(8)

--- a/Zend/tests/arrow_functions/008.phpt
+++ b/Zend/tests/arrow_functions/008.phpt
@@ -10,7 +10,7 @@ foreach ($fn() as $val) {
     var_dump($val);
 }
 
-$fn = fn() => { return yield 2; };
+$fn = fn() { return yield 2; };
 foreach ($fn() as $val) {
     var_dump($val);
 }
@@ -20,7 +20,7 @@ foreach ($fn() as $val) {
     var_dump($val);
 }
 
-$fn = fn() => { yield from [5, 6]; };
+$fn = fn() { yield from [5, 6]; };
 foreach ($fn() as $val) {
     var_dump($val);
 }
@@ -30,7 +30,7 @@ foreach ($fn()() as $val) {
     var_dump($val);
 }
 
-$fn = fn() => fn() => { yield 8; };
+$fn = fn() => fn() { yield 8; };
 foreach ($fn()() as $val) {
     var_dump($val);
 }

--- a/Zend/tests/arrow_functions/009.phpt
+++ b/Zend/tests/arrow_functions/009.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Arrow functions in match
+--FILE--
+<?php
+
+$fn = match (true) {
+    default => fn () => 1,
+};
+var_dump($fn());
+
+$ret = match (true) {
+    default => (fn () => 2)(),
+};
+var_dump($ret);
+
+$ret = match (true) {
+    default => (fn () => null)(),
+};
+var_dump($ret);
+
+$fn = match (true) {
+    default => fn () {
+        return 3;
+    },
+};
+var_dump($fn());
+
+$ret = match (true) {
+    default => (fn () {
+        return 4;
+    })(),
+};
+var_dump($ret);
+
+$ret = match (true) {
+    default => (fn () {})(),
+};
+var_dump($ret);
+
+?>
+--EXPECT--
+int(1)
+int(2)
+NULL
+int(3)
+int(4)
+NULL

--- a/Zend/tests/arrow_functions/010.phpt
+++ b/Zend/tests/arrow_functions/010.phpt
@@ -1,0 +1,91 @@
+--TEST--
+Arrow functions auto-capture variables, by value.
+--FILE--
+<?php
+
+$a = 0;
+$fn = fn() {
+    var_dump(isset($a));
+    $a = 1;
+    var_dump($a);
+};
+var_dump($a);
+$fn();
+var_dump($a);
+
+$a = 2;
+$fn = fn() {
+    $a++;
+    var_dump($a);
+};
+var_dump($a);
+$fn();
+var_dump($a);
+
+$a = 3;
+$fn = fn() {
+    if (false) $a = 4;
+    var_dump($a);
+};
+var_dump($a);
+$fn();
+var_dump($a);
+
+$a = 5;
+$fn = fn() {
+    var_dump($a);
+    if (false) $a = 6;
+};
+var_dump($a);
+$fn();
+var_dump($a);
+
+$a = 7;
+$fn = fn() {
+    unset($a);
+    var_dump(isset($a));
+};
+var_dump($a);
+$fn();
+var_dump($a);
+
+$a = 8;
+$fn = fn() {
+    $a = 9;
+    unset($a);
+    var_dump(isset($a));
+};
+var_dump($a);
+$fn();
+var_dump($a);
+
+$a = 10;
+$fn = fn() { return fn () { var_dump($a); }; };
+var_dump($a);
+$fn()();
+var_dump($a);
+
+?>
+--EXPECT--
+int(0)
+bool(true)
+int(1)
+int(0)
+int(2)
+int(3)
+int(2)
+int(3)
+int(3)
+int(3)
+int(5)
+int(5)
+int(5)
+int(7)
+bool(false)
+int(7)
+int(8)
+bool(false)
+int(8)
+int(10)
+int(10)
+int(10)

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1575,8 +1575,7 @@ tail_call:
 				zend_ast_export_type(str, decl->child[3], indent);
 			}
 			if (decl->child[2]) {
-				if (decl->kind == ZEND_AST_ARROW_FUNC) {
-					ZEND_ASSERT(decl->child[2]->kind == ZEND_AST_RETURN);
+				if (decl->kind == ZEND_AST_ARROW_FUNC && decl->child[2]->kind == ZEND_AST_RETURN) {
 					smart_str_appends(str, " => ");
 					zend_ast_export_ex(str, decl->child[2]->child[0], 0, indent);
 					break;

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1178,11 +1178,11 @@ inline_function:
 				  ((zend_ast_decl *) $$)->lex_pos = $10;
 				  CG(extra_fn_flags) = $9; }
 	|	fn returns_ref backup_doc_comment '(' parameter_list ')' return_type
-		T_DOUBLE_ARROW backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
-			{ $$ = zend_ast_create_decl(ZEND_AST_ARROW_FUNC, $2 | $13, $1, $3,
+		backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
+			{ $$ = zend_ast_create_decl(ZEND_AST_ARROW_FUNC, $2 | $12, $1, $3,
 				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0), $5, NULL,
-				  $11, $7, NULL);
-				  CG(extra_fn_flags) = $9; }
+				  $10, $7, NULL);
+				  CG(extra_fn_flags) = $8; }
 ;
 
 fn:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1177,6 +1177,12 @@ inline_function:
 				  zend_ast_create(ZEND_AST_RETURN, $11), $7, NULL);
 				  ((zend_ast_decl *) $$)->lex_pos = $10;
 				  CG(extra_fn_flags) = $9; }
+	|	fn returns_ref backup_doc_comment '(' parameter_list ')' return_type
+		T_DOUBLE_ARROW backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
+			{ $$ = zend_ast_create_decl(ZEND_AST_ARROW_FUNC, $2 | $13, $1, $3,
+				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0), $5, NULL,
+				  $11, $7, NULL);
+				  CG(extra_fn_flags) = $9; }
 ;
 
 fn:


### PR DESCRIPTION
As you may already know, [PHP 7.4 has introduced one-liner arrow functions (aka short closures)](https://wiki.php.net/rfc/arrow_functions_v2). Now, this pull request adds the possibility of those **arrow functions to be multi-line**. Let's see an example:

```php
$users = [/** */];
$guestsIds = [/** */];
$repository = /** */;

$guests = array_filter($users, fn ($user) {
    $guest = $repository->findByUserId($user->id);

    return $guest !== null && in_array($guest->id, $guestsIds);
});
```

This pull request should be targeting **PHP 8.1**, and it will be followed by an RFC in the next couple of days - but in short, the advantages are:
```diff
-$values = array_filter($values, function ($value) use ($first, $second, $third, $four) {
+$values = array_filter($values, fn ($value) {
```

- Multi-line arrow functions don't require the `use` keyword to be able to **access data from the outer scope**.
- Also, in some cases, `fn (/** */) {` is just shorter and **simpler** than `function (/** */) use (/** */) {`.

It is my first contribution to the core of PHP, so let me know if something in this pull request needs to be better. 👍🏻
