### PR TITLE
Enable -Wimplicit-fallthrough compiler warning

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -6,6 +6,7 @@ PHP 8.1 INTERNALS UPGRADE NOTES
   c. zend_get_opcode_id()
 
 2. Build system changes
+  a. New compiler flags
 
 3. Module changes
   a. ext/hash
@@ -39,7 +40,9 @@ PHP 8.1 INTERNALS UPGRADE NOTES
 ========================
 2. Build system changes
 ========================
-
+  a. New compiler flags
+     - [-Wimplicit-fallthrough=1] is now enabled by default.
+       It is possible to use the new ZEND_FALLTHROUGH macro keyword to suppress the warning.
 ========================
 3. Module changes
 ========================

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -206,9 +206,11 @@ else
   AC_DEFINE(ZEND_DEBUG,0,[ ])
 fi
 
-test -n "$GCC" && CFLAGS="-Wall -Wextra -Wno-strict-aliasing -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-sign-compare $CFLAGS"
+test -n "$GCC" && CFLAGS="-Wall -Wextra -Wno-strict-aliasing -Wno-unused-parameter -Wno-sign-compare $CFLAGS"
 dnl Check if compiler supports -Wno-clobbered (only GCC)
 AX_CHECK_COMPILE_FLAG([-Wno-clobbered], CFLAGS="-Wno-clobbered $CFLAGS", , [-Werror])
+dnl Check for support for implicit fallthrough level 1, also add after previous CFLAGS as level 3 is enabled in -Wextra
+AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough=1], CFLAGS="$CFLAGS -Wimplicit-fallthrough=1", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wduplicated-cond], CFLAGS="-Wduplicated-cond $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wlogical-op], CFLAGS="-Wlogical-op $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wformat-truncation], CFLAGS="-Wformat-truncation $CFLAGS", , [-Werror])

--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -4,7 +4,7 @@ AC_CHECK_HEADERS([io.h])
 dnl Check for strtoll, atoll
 AC_CHECK_FUNCS(strtoll atoll)
 
-PHP_DATE_CFLAGS="-I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
+PHP_DATE_CFLAGS="-Wno-implicit-fallthrough -I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
 timelib_sources="lib/astro.c lib/dow.c lib/parse_date.c lib/parse_tz.c lib/parse_posix.c
                  lib/timelib.c lib/tm2unixtime.c lib/unixtime2tm.c lib/parse_iso_intervals.c lib/interval.c"
 

--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -28,7 +28,8 @@ else
     SHA3_OPT_SRC="$SHA3_DIR/KeccakP-1600-opt64.c"
   ])
   EXT_HASH_SHA3_SOURCES="$SHA3_OPT_SRC $SHA3_DIR/KeccakHash.c $SHA3_DIR/KeccakSponge.c hash_sha3.c"
-  PHP_HASH_CFLAGS="-I@ext_srcdir@/$SHA3_DIR -DKeccakP200_excluded -DKeccakP400_excluded -DKeccakP800_excluded -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  dnl Add -Wno-implicit-fallthrough flag as it happens on 32 bit builds
+  PHP_HASH_CFLAGS="-Wno-implicit-fallthrough -I@ext_srcdir@/$SHA3_DIR -DKeccakP200_excluded -DKeccakP400_excluded -DKeccakP800_excluded -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
 
   PHP_ADD_BUILD_DIR(ext/hash/$SHA3_DIR, 1)
 fi

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -326,7 +326,7 @@ int main() {
 	shared_alloc_mmap.c \
 	shared_alloc_posix.c \
 	$ZEND_JIT_SRC,
-	shared,,-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1,,yes)
+	shared,,"-Wno-implicit-fallthrough -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1",,yes)
 
   PHP_ADD_EXTENSION_DEP(opcache, pcre)
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -690,7 +690,7 @@ PDO_API bool pdo_get_long_param(zend_long *lval, zval *value)
 			if (IS_LONG == is_numeric_str_function(Z_STR_P(value), lval, NULL)) {
 				return true;
 			}
-			/* fallthrough */
+			ZEND_FALLTHROUGH;
 		default:
 			zend_type_error("Attribute value must be of type int for selected attribute, %s given", zend_zval_type_name(value));
 			return false;

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -918,6 +918,8 @@ static int php_stdiop_set_option(php_stream *stream, int option, int value, void
 				case PHP_STREAM_SYNC_FDSYNC:
 					return php_stdiop_sync(stream, 1) == 0 ? PHP_STREAM_OPTION_RETURN_OK : PHP_STREAM_OPTION_RETURN_ERR;
 			}
+			/* Invalid option passed */
+			return PHP_STREAM_OPTION_RETURN_ERR;
 
 		case PHP_STREAM_OPTION_TRUNCATE_API:
 			switch (value) {


### PR DESCRIPTION
Introduce a pseudo-keyword ``fallthrough`` (following the Linux Kernal style) to indicate that a switch case fall-through to the following one.
This has a couple of benefits in that it normalizes our fall-through comments (which have various formulation even within the same file) and let's use enable `-Wimplicit-fallthrough=3` which is included in `-Wextra`.

I enabled level 5 temporarily (which disables all comments) to use the newly introduce pseudo-keyword instead of comments in extension code under our control.

A couple of issues remain:
 - TimeLib would need to be patched upstream to include a ``/* fallthrough */`` comment in an instance or we suppress this warning for DateTime
- The JIT: the simplest solution would be to disable the compiler warning for it (or even OpCache altogether), as otherwise we would need to patch the integrated libs.