### PR TITLE
Removed broken php_url_encode_hash macro

### DIFF
--- a/ext/standard/php_http.h
+++ b/ext/standard/php_http.h
@@ -25,6 +25,5 @@ PHPAPI void php_url_encode_hash_ex(HashTable *ht, smart_str *formstr,
 				const char *key_prefix, size_t key_prefix_len,
 				const char *key_suffix, size_t key_suffix_len,
 				zval *type, const char *arg_sep, int enc_type);
-#define php_url_encode_hash(ht, formstr)	php_url_encode_hash_ex((ht), (formstr), NULL, 0, NULL, 0, NULL, 0, NULL)
 
 #endif


### PR DESCRIPTION
Broken since ~15 years ago (2994c2367062a63394753fc367708b3d1f4955e8)

The macro calls `php_url_encode_hash_ex()` with 2 missing arguments and couldn't possibly be used since **PHP 5.1.2**.