### PR TITLE
Add SplFixedArray::__set_state

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,5 +11,8 @@ PHP                                                                        NEWS
 - PSpell:
   . Convert resource<pspell> to object \PSpell. (Sara)
   . Convert resource<pspell config> to object \PSPellConfig. (Sara)
+- SPL:
+  . Add SplFixedArray::__set_state (FR #75268) (levim). Note this converts
+    SplFixedArray from get_properties to get_properties_for.
 
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/ext/spl/spl_fixedarray.stub.php
+++ b/ext/spl/spl_fixedarray.stub.php
@@ -49,4 +49,7 @@ class SplFixedArray implements IteratorAggregate, ArrayAccess, Countable
     public function offsetUnset($index) {}
 
     public function getIterator(): Iterator {}
+
+    /** @return SplFixedArray */
+    public static function __set_state(array $state) {}
 }

--- a/ext/spl/spl_fixedarray_arginfo.h
+++ b/ext/spl/spl_fixedarray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 831fe70055eb62135ae49321e5e5f3fe08c3d95f */
+ * Stub hash: 54028c566f2d868da1f91e5f4f627fbe6e823bb5 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFixedArray___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size, IS_LONG, 0, "0")
@@ -39,6 +39,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_SplFixedArray_getIterator, 0, 0, Iterator, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFixedArray___set_state, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, state, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 
 ZEND_METHOD(SplFixedArray, __construct);
 ZEND_METHOD(SplFixedArray, __wakeup);
@@ -52,6 +56,7 @@ ZEND_METHOD(SplFixedArray, offsetGet);
 ZEND_METHOD(SplFixedArray, offsetSet);
 ZEND_METHOD(SplFixedArray, offsetUnset);
 ZEND_METHOD(SplFixedArray, getIterator);
+ZEND_METHOD(SplFixedArray, __set_state);
 
 
 static const zend_function_entry class_SplFixedArray_methods[] = {
@@ -67,5 +72,6 @@ static const zend_function_entry class_SplFixedArray_methods[] = {
 	ZEND_ME(SplFixedArray, offsetSet, arginfo_class_SplFixedArray_offsetSet, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFixedArray, offsetUnset, arginfo_class_SplFixedArray_offsetUnset, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFixedArray, getIterator, arginfo_class_SplFixedArray_getIterator, ZEND_ACC_PUBLIC)
+	ZEND_ME(SplFixedArray, __set_state, arginfo_class_SplFixedArray___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END
 };

--- a/ext/spl/tests/ArrayObject_overloaded_object_incompatible.phpt
+++ b/ext/spl/tests/ArrayObject_overloaded_object_incompatible.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Objects with overloaded get_properties are incompatible with ArrayObject
+--XFAIL--
+SplFixedArray has migrated to get_properties_for; find new test case
 --FILE--
 <?php
 

--- a/ext/spl/tests/spl_fixedarray___set_state.phpt
+++ b/ext/spl/tests/spl_fixedarray___set_state.phpt
@@ -1,0 +1,60 @@
+--TEST--
+SplFixedArray: __set_state
+--FILE--
+<?php
+
+$fixed = SplFixedArray::__set_state([1, 2, 3]);
+var_export($fixed);
+echo "\n---\n";
+
+// dynamic properties
+$fixed->undefined = 'undef';
+var_export($fixed);
+echo "\n---\n";
+
+// inheritance
+class Vec
+    extends SplFixedArray
+{
+    public $type;
+}
+$vec = new Vec(3);
+$vec[0] = 1;
+$vec[1] = 2;
+$vec[2] = 3;
+$vec->type = 'int';
+var_export($vec);
+echo "\n---\n";
+
+$vec->undefined = 'undef';
+var_export($vec);
+
+?>
+--EXPECT--
+SplFixedArray::__set_state(array(
+   0 => 1,
+   1 => 2,
+   2 => 3,
+))
+---
+SplFixedArray::__set_state(array(
+   'undefined' => 'undef',
+   0 => 1,
+   1 => 2,
+   2 => 3,
+))
+---
+Vec::__set_state(array(
+   'type' => 'int',
+   0 => 1,
+   1 => 2,
+   2 => 3,
+))
+---
+Vec::__set_state(array(
+   'type' => 'int',
+   'undefined' => 'undef',
+   0 => 1,
+   1 => 2,
+   2 => 3,
+))

--- a/ext/spl/tests/spl_fixedarray___set_state_errors.phpt
+++ b/ext/spl/tests/spl_fixedarray___set_state_errors.phpt
@@ -1,0 +1,36 @@
+--TEST--
+SplFixedArray: __set_state
+--FILE--
+<?php
+
+try {
+    $fixed = SplFixedArray::__set_state([1 => 2]);
+} catch (ValueError $error) {
+    var_dump($error->getMessage());
+}
+
+try {
+    $fixed = SplFixedArray::__set_state([0 => 1, 1 => 2, 3 => 4]);
+} catch (ValueError $error) {
+    var_dump($error->getMessage());
+}
+
+try {
+    $fixed = SplFixedArray::__set_state([-1 => 2]);
+} catch (ValueError $error) {
+    var_dump($error->getMessage());
+}
+
+echo "-----\n";
+
+try {
+    $fixed = SplFixedArray::__set_state([0 => 1, 'type' => 'undefined']);
+} catch (ValueError $error) {
+    var_dump($error->getMessage());
+}
+--EXPECTF--
+string(%d) "SplFixedArray::__set_state(): Argument #1 ($state) did not have integer keys that start at 0 and increment sequentially"
+string(%d) "SplFixedArray::__set_state(): Argument #1 ($state) did not have integer keys that start at 0 and increment sequentially"
+string(%d) "SplFixedArray::__set_state(): Argument #1 ($state) did not have integer keys that start at 0 and increment sequentially"
+-----
+string(%d) "SplFixedArray::__set_state(): Argument #1 ($state) must have all its string keys come before all integer keys"

--- a/ext/spl/tests/spl_fixedarray_export_import.phpt
+++ b/ext/spl/tests/spl_fixedarray_export_import.phpt
@@ -1,0 +1,49 @@
+--TEST--
+SplFixedArray: __set_state export and import
+--FILE--
+<?php
+
+function compare_export($var, string $case) {
+    $exported = var_export($var, true);
+
+    $imported = eval("return {$exported};");
+    $reexported = var_export($imported, true);
+
+    if ($exported == $reexported) {
+        echo "Pass {$case}.\n";
+    } else {
+        echo "Fail {$case}.\nExpected:\n{$exported}\nActual:\n{$reexported}\n";
+    }
+}
+
+// simple
+$fixed = SplFixedArray::__set_state([1, 2, 3]);
+compare_export($fixed, 'simple');
+
+// dynamic properties
+$fixed->undefined = 'undef';
+compare_export($fixed, 'dynamic properties');
+
+// inheritance
+class Vec
+    extends SplFixedArray
+{
+    public $type;
+}
+$vec = new Vec(3);
+$vec[0] = 1;
+$vec[1] = 2;
+$vec[2] = 3;
+$vec->type = 'int';
+
+compare_export($vec, 'inheritance');
+
+// dynamic properties and inheritance
+$vec->undefined = 'undef';
+compare_export($vec, 'dynamic properties and inheritance');
+
+--EXPECT--
+Pass simple.
+Pass dynamic properties.
+Pass inheritance.
+Pass dynamic properties and inheritance.


### PR DESCRIPTION
Add SplFixedArray::__set_state

Fixes [bug 75268](https://bugs.php.net/bug.php?id=75268).

The design is that all string keys must come before all integer
keys. The string keys become properties and the integer keys become
values in the array.

Other serialization/unserialization methods should adopt this same
strategy as there are bugs:
https://3v4l.org/IMnI5

Migrate SplFixedArray to get_properties_for.

Extract spl_fixedarray_import, as I expect to reuse this code for
other cases as well, such as the serialization bug mentioned above.