### PR TITLE
Implement GC for PDO SQLite driver data

### DIFF
--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1294,7 +1294,7 @@ static HashTable *dbh_get_gc(zend_object *object, zval **gc_data, int *gc_count)
 	zend_get_gc_buffer *gc_buffer = zend_get_gc_buffer_create();
 	zend_get_gc_buffer_add_zval(gc_buffer, &dbh->def_stmt_ctor_args);
 	if (dbh->methods->get_gc) {
-		dbh->methods->get_gc(gc_buffer);
+		dbh->methods->get_gc(dbh, gc_buffer);
 	}
 	zend_get_gc_buffer_use(gc_buffer, gc_data, gc_count);
 	return zend_std_get_properties(object);

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1291,8 +1291,12 @@ static int dbh_compare(zval *object1, zval *object2)
 static HashTable *dbh_get_gc(zend_object *object, zval **gc_data, int *gc_count)
 {
 	pdo_dbh_t *dbh = php_pdo_dbh_fetch_inner(object);
-	*gc_data = &dbh->def_stmt_ctor_args;
-	*gc_count = 1;
+	zend_get_gc_buffer *gc_buffer = zend_get_gc_buffer_create();
+	zend_get_gc_buffer_add_zval(gc_buffer, &dbh->def_stmt_ctor_args);
+	if (dbh->methods->get_gc) {
+		dbh->methods->get_gc(gc_buffer);
+	}
+	zend_get_gc_buffer_use(gc_buffer, gc_data, gc_count);
 	return zend_std_get_properties(object);
 }
 

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -288,7 +288,7 @@ typedef void (*pdo_dbh_request_shutdown)(pdo_dbh_t *dbh);
 
 /* Called when the PDO handle is scanned for GC. Should populate the get_gc buffer
  * with any zvals in the driver_data that would be freed if the handle is destroyed. */
-typedef void (*pdo_dbh_get_gc_func)(zend_get_gc_buffer *buffer);
+typedef void (*pdo_dbh_get_gc_func)(pdo_dbh_t *dbh, zend_get_gc_buffer *buffer);
 
 /* for adding methods to the dbh or stmt objects
 pointer to a list of driver specific functions. The convention is

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -286,6 +286,10 @@ typedef int (*pdo_dbh_check_liveness_func)(pdo_dbh_t *dbh);
  * scope */
 typedef void (*pdo_dbh_request_shutdown)(pdo_dbh_t *dbh);
 
+/* Called when the PDO handle is scanned for GC. Should populate the get_gc buffer
+ * with any zvals in the driver_data that would be freed if the handle is destroyed. */
+typedef void (*pdo_dbh_get_gc_func)(zend_get_gc_buffer *buffer);
+
 /* for adding methods to the dbh or stmt objects
 pointer to a list of driver specific functions. The convention is
 to prefix the function names using the PDO driver name; this will
@@ -316,6 +320,7 @@ struct pdo_dbh_methods {
 	pdo_dbh_get_driver_methods_func get_driver_methods;
 	pdo_dbh_request_shutdown	persistent_shutdown;
 	pdo_dbh_txn_func		in_transaction;
+	pdo_dbh_get_gc_func		get_gc;
 };
 
 /* }}} */

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -417,7 +417,8 @@ static const struct pdo_dbh_methods dblib_methods = {
 	NULL, /* check liveness */
 	NULL, /* get driver methods */
 	NULL, /* request shutdown */
-	NULL  /* in transaction */
+	NULL, /* in transaction */
+	NULL /* get gc */
 };
 
 static int pdo_dblib_handle_factory(pdo_dbh_t *dbh, zval *driver_options)

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -1005,7 +1005,11 @@ static const struct pdo_dbh_methods firebird_methods = { /* {{{ */
 	NULL, /* last_id not supported */
 	pdo_firebird_fetch_error_func,
 	firebird_handle_get_attribute,
-	NULL /* check_liveness */
+	NULL, /* check_liveness */
+	NULL, /* get driver methods */
+	NULL, /* request shutdown */
+	NULL, /* in transaction */
+	NULL /* get gc */
 };
 /* }}} */
 

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -563,7 +563,8 @@ static const struct pdo_dbh_methods mysql_methods = {
 	pdo_mysql_check_liveness,
 	NULL,
 	pdo_mysql_request_shutdown,
-	pdo_mysql_in_transaction
+	pdo_mysql_in_transaction,
+	NULL /* get_gc */
 };
 /* }}} */
 

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -705,9 +705,10 @@ static const struct pdo_dbh_methods oci_methods = {
 	pdo_oci_fetch_error_func,
 	oci_handle_get_attribute,
 	pdo_oci_check_liveness,	/* check_liveness */
-	NULL,	/* get_driver_methods */
-	NULL,
-	NULL
+	NULL, /* get_driver_methods */
+	NULL, /* request_shutdown */
+	NULL, /* in_transaction */
+	NULL /* get_gc */
 };
 
 static int pdo_oci_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ */

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -384,7 +384,11 @@ static const struct pdo_dbh_methods odbc_methods = {
 	NULL,	/* last id */
 	pdo_odbc_fetch_error_func,
 	odbc_handle_get_attr,	/* get attr */
-	NULL,	/* check_liveness */
+	NULL, /* check_liveness */
+	NULL, /* get_driver_methods */
+	NULL, /* request_shutdown */
+	NULL, /* in_transaction */
+	NULL /* get_gc */
 };
 
 static int pdo_odbc_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ */

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -1179,6 +1179,7 @@ static const struct pdo_dbh_methods pgsql_methods = {
 	pdo_pgsql_get_driver_methods,  /* get_driver_methods */
 	NULL,
 	pgsql_handle_in_transaction,
+	NULL /* get_gc */
 };
 
 static int pdo_pgsql_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ */

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -710,7 +710,8 @@ static const struct pdo_dbh_methods sqlite_methods = {
 	NULL,	/* check_liveness: not needed */
 	get_driver_methods,
 	pdo_sqlite_request_shutdown,
-	NULL
+	NULL, /* in_transaction */
+	NULL /* get_gc */
 };
 
 static char *make_filename_safe(const char *filename)

--- a/ext/pdo_sqlite/tests/gc.phpt
+++ b/ext/pdo_sqlite/tests/gc.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GC support for PDO Sqlite driver data
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_sqlite')) print 'skip not loaded';
+?>
+--FILE--
+<?php
+
+class Obj {
+	public $a;
+	public function callback() { }
+}
+
+$obj = new Obj;
+$obj->a = new PDO('sqlite::memory:');
+$obj->a->sqliteCreateFunction('func1', function() use ($obj) {}, 1);
+$obj->a->sqliteCreateAggregate('func2', function() use ($obj) {}, function() use($obj) {});
+$obj->a->sqliteCreateCollation('col', function() use ($obj) {});
+
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
Add a handler to integrate PDO driver data with GC and implement it for PDO sqlite callbacks.

Targeting 8.1 due to ABI break.