### PR TITLE
Renaming parameter names in ext/sqlite3

### DIFF
--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -32,20 +32,20 @@ class SQLite3
     public function changes() {}
 
     /** @return bool */
-    public function busyTimeout(int $ms) {}
+    public function busyTimeout(int $milliseconds) {}
 
 #ifndef SQLITE_OMIT_LOAD_EXTENSION
     /** @return bool */
-    public function loadExtension(string $shared_library) {}
+    public function loadExtension(string $name) {}
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3006011
     /** @return bool */
-    public function backup(SQLite3 $destination_db, string $source_dbname = "main", string $destination_dbname = "main") {}
+    public function backup(SQLite3 $sqlite3, string $source_database = "main", string $destination_database = "main") {}
 #endif
 
     /** @return string */
-    public static function escapeString(string $value) {}
+    public static function escapeString(string $string) {}
 
     /** @return SQLite3Stmt|false */
     public function prepare(string $query) {}
@@ -69,10 +69,10 @@ class SQLite3
     public function createCollation(string $name, callable $callback) {}
 
     /** @return resource|false */
-    public function openBlob(string $table, string $column, int $rowid, string $dbname = "main", int $flags = SQLITE3_OPEN_READONLY) {}
+    public function openBlob(string $table, string $column, int $rowid, string $database = "main", int $flags = SQLITE3_OPEN_READONLY) {}
 
     /** @return bool */
-    public function enableExceptions(bool $enableExceptions = false) {}
+    public function enableExceptions(bool $enable = false) {}
 
     /** @return bool */
     public function enableExtendedResultCodes(bool $enable = true) {}
@@ -86,10 +86,10 @@ class SQLite3Stmt
     private function __construct(SQLite3 $sqlite3, string $sql) {}
 
     /** @return bool */
-    public function bindParam(string|int $param_number, mixed &$param, int $type = SQLITE3_TEXT) {}
+    public function bindParam(string|int $param, mixed &$bind_var, int $type = SQLITE3_TEXT) {}
 
     /** @return bool */
-    public function bindValue(string|int $param_number, mixed $param, int $type = SQLITE3_TEXT) {}
+    public function bindValue(string|int $param, mixed $value, int $type = SQLITE3_TEXT) {}
 
     /** @return bool */
     public function clear() {}
@@ -101,7 +101,7 @@ class SQLite3Stmt
     public function execute() {}
 
     /** @return string|false */
-    public function getSQL(bool $expanded = false) {}
+    public function getSQL(bool $expand = false) {}
 
     /** @return int */
     public function paramCount() {}
@@ -121,10 +121,10 @@ class SQLite3Result
     public function numColumns() {}
 
     /** @return string|false */
-    public function columnName(int $column_number) {}
+    public function columnName(int $index) {}
 
     /** @return int|false */
-    public function columnType(int $column_number) {}
+    public function columnType(int $index) {}
 
     /** @return array|false */
     public function fetchArray(int $mode = SQLITE3_BOTH) {}

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -5,10 +5,10 @@
 class SQLite3
 {
     /** @implementation-alias SQLite3::open */
-    public function __construct(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryption_key = "") {}
+    public function __construct(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryptionKey = "") {}
 
     /** @return void */
-    public function open(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryption_key = "") {}
+    public function open(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryptionKey = "") {}
 
     /** @return bool */
     public function close() {}
@@ -41,7 +41,7 @@ class SQLite3
 
 #if SQLITE_VERSION_NUMBER >= 3006011
     /** @return bool */
-    public function backup(SQLite3 $sqlite3, string $source_database = "main", string $destination_database = "main") {}
+    public function backup(SQLite3 $destination, string $sourceDatabase = "main", string $destinationDatabase = "main") {}
 #endif
 
     /** @return string */
@@ -57,13 +57,13 @@ class SQLite3
     public function query(string $query) {}
 
     /** @return mixed */
-    public function querySingle(string $query, bool $entire_row = false) {}
+    public function querySingle(string $query, bool $entireRow = false) {}
 
     /** @return bool */
-    public function createFunction(string $name, callable $callback, int $argument_count = -1, int $flags = 0) {}
+    public function createFunction(string $name, callable $callback, int $argCount = -1, int $flags = 0) {}
 
     /** @return bool */
-    public function createAggregate(string $name, callable $step_callback, callable $final_callback, int $argument_count = -1) {}
+    public function createAggregate(string $name, callable $stepCallback, callable $finalCallback, int $argCount = -1) {}
 
     /** @return bool */
     public function createCollation(string $name, callable $callback) {}
@@ -83,10 +83,10 @@ class SQLite3
 
 class SQLite3Stmt
 {
-    private function __construct(SQLite3 $sqlite3, string $sql) {}
+    private function __construct(SQLite3 $sqlite3, string $query) {}
 
     /** @return bool */
-    public function bindParam(string|int $param, mixed &$bind_var, int $type = SQLITE3_TEXT) {}
+    public function bindParam(string|int $param, mixed &$var, int $type = SQLITE3_TEXT) {}
 
     /** @return bool */
     public function bindValue(string|int $param, mixed $value, int $type = SQLITE3_TEXT) {}
@@ -121,10 +121,10 @@ class SQLite3Result
     public function numColumns() {}
 
     /** @return string|false */
-    public function columnName(int $index) {}
+    public function columnName(int $column) {}
 
     /** @return int|false */
-    public function columnType(int $index) {}
+    public function columnType(int $column) {}
 
     /** @return array|false */
     public function fetchArray(int $mode = SQLITE3_BOTH) {}

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 343a1ef283e97363ab012922c7af1913728d1ca6 */
+ * Stub hash: 20d9cd75afa2a9b9d4eb6c8019e7c47d34778df4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encryption_key, IS_STRING, 0, "\"\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encryptionKey, IS_STRING, 0, "\"\"")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_SQLite3_open arginfo_class_SQLite3___construct
@@ -36,9 +36,9 @@ ZEND_END_ARG_INFO()
 
 #if SQLITE_VERSION_NUMBER >= 3006011
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_backup, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, sqlite3, SQLite3, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, source_database, IS_STRING, 0, "\"main\"")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, destination_database, IS_STRING, 0, "\"main\"")
+	ZEND_ARG_OBJ_INFO(0, destination, SQLite3, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, sourceDatabase, IS_STRING, 0, "\"main\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, destinationDatabase, IS_STRING, 0, "\"main\"")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -56,21 +56,21 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_querySingle, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, entire_row, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, entireRow, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_createFunction, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, argument_count, IS_LONG, 0, "-1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, argCount, IS_LONG, 0, "-1")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_createAggregate, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, step_callback, IS_CALLABLE, 0)
-	ZEND_ARG_TYPE_INFO(0, final_callback, IS_CALLABLE, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, argument_count, IS_LONG, 0, "-1")
+	ZEND_ARG_TYPE_INFO(0, stepCallback, IS_CALLABLE, 0)
+	ZEND_ARG_TYPE_INFO(0, finalCallback, IS_CALLABLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, argCount, IS_LONG, 0, "-1")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_createCollation, 0, 0, 2)
@@ -100,12 +100,12 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Stmt___construct, 0, 0, 2)
 	ZEND_ARG_OBJ_INFO(0, sqlite3, SQLite3, 0)
-	ZEND_ARG_TYPE_INFO(0, sql, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Stmt_bindParam, 0, 0, 2)
 	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_STRING|MAY_BE_LONG, NULL)
-	ZEND_ARG_TYPE_INFO(1, bind_var, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(1, var, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "SQLITE3_TEXT")
 ZEND_END_ARG_INFO()
 
@@ -136,7 +136,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_SQLite3Result_numColumns arginfo_class_SQLite3_close
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Result_columnName, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, column, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_SQLite3Result_columnType arginfo_class_SQLite3Result_columnName

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 293f1041949989de457a4091b751674bf301c2bd */
+ * Stub hash: 343a1ef283e97363ab012922c7af1913728d1ca6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -25,25 +25,25 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_SQLite3_changes arginfo_class_SQLite3_close
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_busyTimeout, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, ms, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, milliseconds, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if !defined(SQLITE_OMIT_LOAD_EXTENSION)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_loadExtension, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, shared_library, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if SQLITE_VERSION_NUMBER >= 3006011
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_backup, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, destination_db, SQLite3, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, source_dbname, IS_STRING, 0, "\"main\"")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, destination_dbname, IS_STRING, 0, "\"main\"")
+	ZEND_ARG_OBJ_INFO(0, sqlite3, SQLite3, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, source_database, IS_STRING, 0, "\"main\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, destination_database, IS_STRING, 0, "\"main\"")
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_escapeString, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_prepare, 0, 0, 1)
@@ -82,12 +82,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_openBlob, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, table, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, column, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, rowid, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dbname, IS_STRING, 0, "\"main\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 0, "\"main\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "SQLITE3_OPEN_READONLY")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_enableExceptions, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enableExceptions, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, enable, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3_enableExtendedResultCodes, 0, 0, 0)
@@ -104,14 +104,14 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Stmt___construct, 0, 0, 2)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Stmt_bindParam, 0, 0, 2)
-	ZEND_ARG_TYPE_MASK(0, param_number, MAY_BE_STRING|MAY_BE_LONG, NULL)
-	ZEND_ARG_TYPE_INFO(1, param, IS_MIXED, 0)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_STRING|MAY_BE_LONG, NULL)
+	ZEND_ARG_TYPE_INFO(1, bind_var, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "SQLITE3_TEXT")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Stmt_bindValue, 0, 0, 2)
-	ZEND_ARG_TYPE_MASK(0, param_number, MAY_BE_STRING|MAY_BE_LONG, NULL)
-	ZEND_ARG_TYPE_INFO(0, param, IS_MIXED, 0)
+	ZEND_ARG_TYPE_MASK(0, param, MAY_BE_STRING|MAY_BE_LONG, NULL)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "SQLITE3_TEXT")
 ZEND_END_ARG_INFO()
 
@@ -122,7 +122,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_SQLite3Stmt_execute arginfo_class_SQLite3_close
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Stmt_getSQL, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, expanded, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, expand, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_SQLite3Stmt_paramCount arginfo_class_SQLite3_close
@@ -136,7 +136,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_SQLite3Result_numColumns arginfo_class_SQLite3_close
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3Result_columnName, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, column_number, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_SQLite3Result_columnType arginfo_class_SQLite3Result_columnName

--- a/ext/sqlite3/tests/sqlite3_33_createAggregate_notcallable.phpt
+++ b/ext/sqlite3/tests/sqlite3_33_createAggregate_notcallable.phpt
@@ -32,7 +32,7 @@ $db->close();
 echo "Done"
 ?>
 --EXPECT--
-SQLite3::createAggregate(): Argument #2 ($step_callback) must be a valid callback, function "aggregate_test_step" not found or invalid function name
-SQLite3::createAggregate(): Argument #3 ($final_callback) must be a valid callback, function "aggregate_test_final" not found or invalid function name
+SQLite3::createAggregate(): Argument #2 ($stepCallback) must be a valid callback, function "aggregate_test_step" not found or invalid function name
+SQLite3::createAggregate(): Argument #3 ($finalCallback) must be a valid callback, function "aggregate_test_final" not found or invalid function name
 bool(true)
 Done


### PR DESCRIPTION
`s/ms/milliseconds`
`s/destination_db/sqlite3` - should it be `destination_sqlite3`?
`s/source_dbname/source_database`
`s/destination_dbname/destination_database`
`s/dbname/database`
`s/param_number/param` - same as is in PDO
`s/param/bind_var`
`s/expanded/expand` 
`s/column_number/index`

