### PR TITLE
Expose php_during_module_{startup|shutdown}()

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -744,14 +744,14 @@ static int module_startup = 1;
 static int module_shutdown = 0;
 
 /* {{{ php_during_module_startup */
-static int php_during_module_startup(void)
+PHPAPI int php_during_module_startup(void)
 {
 	return module_startup;
 }
 /* }}} */
 
 /* {{{ php_during_module_shutdown */
-static int php_during_module_shutdown(void)
+PHPAPI int php_during_module_shutdown(void)
 {
 	return module_shutdown;
 }

--- a/main/php.h
+++ b/main/php.h
@@ -311,6 +311,8 @@ void phperror(char *error);
 PHPAPI size_t php_write(void *buf, size_t size);
 PHPAPI size_t php_printf(const char *format, ...) PHP_ATTRIBUTE_FORMAT(printf, 1, 2);
 PHPAPI size_t php_printf_unchecked(const char *format, ...);
+PHPAPI int php_during_module_startup(void);
+PHPAPI int php_during_module_shutdown(void);
 PHPAPI int php_get_module_initialized(void);
 #ifdef HAVE_SYSLOG_H
 #include "php_syslog.h"


### PR DESCRIPTION
This can be handy when trying to determine if it is safe to access request globals amongst other things. @morrisonlevi and I have run into needing access to these a number of times. :)