### PR TITLE
Fix #80175: PHP8 RC1 - JIT Buffer not works

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3000,7 +3000,7 @@ static zend_result accel_post_startup(void)
 				zend_accel_error(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - probably not enough shared memory.");
 				return SUCCESS;
 			case SUCCESSFULLY_REATTACHED:
-#ifdef HAVE_JIT
+#if defined(HAVE_JIT) && !defined(ZEND_WIN32)
 				reattached = 1;
 #endif
 				zend_shared_alloc_lock();


### PR DESCRIPTION
On Windows, `SUCCESSFULLY_REATTACHED` does not imply that the process
has already been properly initialized; thus we must not skip some setup
steps in `zend_jit_startup()`.