### PR TITLE
Mysqli bind in execute

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -91,6 +91,9 @@ PHP 8.1 UPGRADE NOTES
     for details of behavior changes and how to explicitly set this attribute. To
     keep the old behavior, use mysqli_report(MYSQLI_REPORT_OFF);
     RFC: https://wiki.php.net/rfc/mysqli_default_errmode
+  . Classes extending mysqli_stmt::execute() will be required to specify the
+    additional parameter now.
+    RFC: https://wiki.php.net/rfc/mysqli_bind_in_execute
 
 - MySQLnd:
   . The mysqlnd.fetch_copy_data ini setting has been removed. However, this
@@ -218,6 +221,9 @@ PHP 8.1 UPGRADE NOTES
     used to specify a directory from which files are allowed to be loaded. It
     is only meaningful if mysqli.allow_local_infile is not enabled, as all
     directories are allowed in that case.
+  . Binding in execute has been added to mysqli prepared statements.
+    Parameters can now be passed to mysqli_stmt::execute as an array.
+    RFC: https://wiki.php.net/rfc/mysqli_bind_in_execute
 
 - PDO MySQL:
   . The PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY attribute has been added, which

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -505,7 +505,7 @@ class mysqli_stmt
      * @return bool
      * @alias mysqli_stmt_execute
      */
-    public function execute() {}
+    public function execute(?array $params = null) {}
 
     /**
      * @return bool|null
@@ -642,10 +642,10 @@ function mysqli_error(mysqli $mysql): string {}
 
 function mysqli_error_list(mysqli $mysql): array {}
 
-function mysqli_stmt_execute(mysqli_stmt $statement): bool {}
+function mysqli_stmt_execute(mysqli_stmt $statement, ?array $params = null): bool {}
 
 /** @alias mysqli_stmt_execute */
-function mysqli_execute(mysqli_stmt $statement): bool {}
+function mysqli_execute(mysqli_stmt $statement, ?array $params = null): bool {}
 
 function mysqli_fetch_field(mysqli_result $result): object|false {}
 

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -505,7 +505,7 @@ class mysqli_stmt
      * @return bool
      * @alias mysqli_stmt_execute
      */
-    public function execute(?array $params = null) {}
+    public function execute(array $params = []) {}
 
     /**
      * @return bool|null
@@ -642,10 +642,10 @@ function mysqli_error(mysqli $mysql): string {}
 
 function mysqli_error_list(mysqli $mysql): array {}
 
-function mysqli_stmt_execute(mysqli_stmt $statement, ?array $params = null): bool {}
+function mysqli_stmt_execute(mysqli_stmt $statement, array $params = []): bool {}
 
 /** @alias mysqli_stmt_execute */
-function mysqli_execute(mysqli_stmt $statement, ?array $params = null): bool {}
+function mysqli_execute(mysqli_stmt $statement, array $params = []): bool {}
 
 function mysqli_fetch_field(mysqli_result $result): object|false {}
 

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -505,7 +505,7 @@ class mysqli_stmt
      * @return bool
      * @alias mysqli_stmt_execute
      */
-    public function execute(array $params = []) {}
+    public function execute(?array $params = null) {}
 
     /**
      * @return bool|null
@@ -642,10 +642,10 @@ function mysqli_error(mysqli $mysql): string {}
 
 function mysqli_error_list(mysqli $mysql): array {}
 
-function mysqli_stmt_execute(mysqli_stmt $statement, array $params = []): bool {}
+function mysqli_stmt_execute(mysqli_stmt $statement, ?array $params = null): bool {}
 
 /** @alias mysqli_stmt_execute */
-function mysqli_execute(mysqli_stmt $statement, array $params = []): bool {}
+function mysqli_execute(mysqli_stmt $statement, ?array $params = null): bool {}
 
 function mysqli_fetch_field(mysqli_result $result): object|false {}
 

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -823,7 +823,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 
 	// bind-in-execute
 #if defined(MYSQLI_USE_MYSQLND)
-	if(input_params) {
+	if (input_params) {
 		zval *tmp;
 		unsigned int index;
 		unsigned int hash_num_elements;
@@ -832,7 +832,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 
 		hash_num_elements = zend_hash_num_elements(Z_ARRVAL_P(input_params));
 		param_count = mysql_stmt_param_count(stmt->stmt);
-		if(hash_num_elements != param_count) {
+		if (hash_num_elements != param_count) {
 			zend_argument_value_error(ERROR_ARG_POS(2), "must consist of exactly %d elements, %d present", param_count, hash_num_elements);
 			RETURN_THROWS();
 		}
@@ -850,7 +850,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 			index++;
 		} ZEND_HASH_FOREACH_END();
 
-		if(mysqlnd_stmt_bind_param(stmt->stmt, params)) {
+		if (mysqlnd_stmt_bind_param(stmt->stmt, params)) {
 			MYSQLI_REPORT_STMT_ERROR(stmt->stmt);
 			RETVAL_FALSE;
 		}

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -830,6 +830,11 @@ PHP_FUNCTION(mysqli_stmt_execute)
 		unsigned int param_count;
 		MYSQLND_PARAM_BIND	*params;
 
+		if (!zend_array_is_list(input_params)) {
+			zend_argument_value_error(ERROR_ARG_POS(2), "must be a list array");
+			RETURN_THROWS();
+		}
+
 		hash_num_elements = zend_hash_num_elements(input_params);
 		param_count = mysql_stmt_param_count(stmt->stmt);
 		if (hash_num_elements != param_count) {

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -811,12 +811,12 @@ PHP_FUNCTION(mysqli_stmt_execute)
 {
 	MY_STMT		*stmt;
 	zval		*mysql_stmt;
-	zval		*input_params = NULL;
+	HashTable	*input_params = NULL;
 #ifndef MYSQLI_USE_MYSQLND
 	unsigned int	i;
 #endif
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|a!", &mysql_stmt, mysqli_stmt_class_entry, &input_params) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|h!", &mysql_stmt, mysqli_stmt_class_entry, &input_params) == FAILURE) {
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
@@ -830,7 +830,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 		unsigned int param_count;
 		MYSQLND_PARAM_BIND	*params;
 
-		hash_num_elements = zend_hash_num_elements(Z_ARRVAL_P(input_params));
+		hash_num_elements = zend_hash_num_elements(input_params);
 		param_count = mysql_stmt_param_count(stmt->stmt);
 		if (hash_num_elements != param_count) {
 			zend_argument_value_error(ERROR_ARG_POS(2), "must consist of exactly %d elements, %d present", param_count, hash_num_elements);
@@ -844,7 +844,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 		}
 
 		index = 0;
-		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(input_params), tmp) {
+		ZEND_HASH_FOREACH_VAL(input_params, tmp) {
 			ZVAL_COPY_VALUE(&params[index].zv, tmp);
 			params[index].type = MYSQL_TYPE_VAR_STRING;
 			index++;

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -816,7 +816,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 	unsigned int	i;
 #endif
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|h", &mysql_stmt, mysqli_stmt_class_entry, &input_params) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|h!", &mysql_stmt, mysqli_stmt_class_entry, &input_params) == FAILURE) {
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -816,7 +816,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 	unsigned int	i;
 #endif
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|a", &mysql_stmt, mysqli_stmt_class_entry, &input_params) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|a!", &mysql_stmt, mysqli_stmt_class_entry, &input_params) == FAILURE) {
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -822,8 +822,8 @@ PHP_FUNCTION(mysqli_stmt_execute)
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
 	// bind-in-execute
-#if defined(MYSQLI_USE_MYSQLND)
 	if (input_params) {
+#if defined(MYSQLI_USE_MYSQLND)
 		zval *tmp;
 		unsigned int index;
 		unsigned int hash_num_elements;
@@ -854,8 +854,11 @@ PHP_FUNCTION(mysqli_stmt_execute)
 			MYSQLI_REPORT_STMT_ERROR(stmt->stmt);
 			RETVAL_FALSE;
 		}
-	}
+#else
+		zend_argument_count_error("Binding parameters in execute is not supported with libmysqlclient");
+		RETURN_THROWS();
 #endif
+	}
 
 #ifndef MYSQLI_USE_MYSQLND
 	if (stmt->param.var_cnt) {

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -828,6 +828,11 @@ PHP_FUNCTION(mysqli_stmt_execute)
 		unsigned int index;
 		MYSQLND_PARAM_BIND	*params;
 
+		if(zend_hash_num_elements(Z_ARRVAL_P(input_params)) > mysql_stmt_param_count(stmt->stmt)) {
+			zend_argument_count_error("The number of values must match the number of parameters in the prepared statement");
+			RETURN_THROWS();
+		}
+
 		params = mysqlnd_stmt_alloc_param_bind(stmt->stmt);
 		if (!params) {
 			// can we safely return here?

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -843,10 +843,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 		}
 
 		params = mysqlnd_stmt_alloc_param_bind(stmt->stmt);
-		if (!params) {
-			// can we safely return here?
-			RETVAL_FALSE;
-		}
+		ZEND_ASSERT(params);
 
 		index = 0;
 		ZEND_HASH_FOREACH_VAL(input_params, tmp) {

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -826,10 +826,14 @@ PHP_FUNCTION(mysqli_stmt_execute)
 	if(input_params) {
 		zval *tmp;
 		unsigned int index;
+		unsigned int hash_num_elements;
+		unsigned int param_count;
 		MYSQLND_PARAM_BIND	*params;
 
-		if(zend_hash_num_elements(Z_ARRVAL_P(input_params)) > mysql_stmt_param_count(stmt->stmt)) {
-			zend_argument_count_error("The number of values must match the number of parameters in the prepared statement");
+		hash_num_elements = zend_hash_num_elements(Z_ARRVAL_P(input_params));
+		param_count = mysql_stmt_param_count(stmt->stmt);
+		if(hash_num_elements != param_count) {
+			zend_argument_value_error(ERROR_ARG_POS(2), "must consist of exactly %d elements, %d present", param_count, hash_num_elements);
 			RETURN_THROWS();
 		}
 

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -816,7 +816,7 @@ PHP_FUNCTION(mysqli_stmt_execute)
 	unsigned int	i;
 #endif
 
-	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|h!", &mysql_stmt, mysqli_stmt_class_entry, &input_params) == FAILURE) {
+	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O|h", &mysql_stmt, mysqli_stmt_class_entry, &input_params) == FAILURE) {
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1c01e60c65f87e4f59435c3712296137d265dfdc */
+ * Stub hash: 3f3d19da5a2b7c8edc6dba0fde6215b93d10bb32 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -71,6 +71,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_execute, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_execute arginfo_mysqli_stmt_execute
@@ -300,7 +301,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_result, 0, 1, _
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_mysqli_stmt_close arginfo_mysqli_stmt_execute
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_close, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_data_seek, 0, 2, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
@@ -351,7 +354,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_more_results, 0, 1, 
 ZEND_END_ARG_INFO()
 #endif
 
-#define arginfo_mysqli_stmt_next_result arginfo_mysqli_stmt_execute
+#define arginfo_mysqli_stmt_next_result arginfo_mysqli_stmt_close
 
 #define arginfo_mysqli_stmt_num_rows arginfo_mysqli_stmt_affected_rows
 
@@ -362,7 +365,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_prepare, 0, 2, _IS_B
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_mysqli_stmt_reset arginfo_mysqli_stmt_execute
+#define arginfo_mysqli_stmt_reset arginfo_mysqli_stmt_close
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_result_metadata, 0, 1, mysqli_result, MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
@@ -374,7 +377,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_send_long_data, 0, 3
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_mysqli_stmt_store_result arginfo_mysqli_stmt_execute
+#define arginfo_mysqli_stmt_store_result arginfo_mysqli_stmt_close
 
 #define arginfo_mysqli_stmt_sqlstate arginfo_mysqli_stmt_error
 
@@ -640,7 +643,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_stmt_data_seek arginfo_class_mysqli_result_data_seek
 
-#define arginfo_class_mysqli_stmt_execute arginfo_class_mysqli_character_set_name
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_execute, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_stmt_fetch arginfo_class_mysqli_character_set_name
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 35c309740ea0ee7328ec5dfdbbad057097ca24e7 */
+ * Stub hash: 3f3d19da5a2b7c8edc6dba0fde6215b93d10bb32 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -71,7 +71,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_execute, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_execute arginfo_mysqli_stmt_execute
@@ -644,7 +644,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_stmt_data_seek arginfo_class_mysqli_result_data_seek
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_execute, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_stmt_fetch arginfo_class_mysqli_character_set_name

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3f3d19da5a2b7c8edc6dba0fde6215b93d10bb32 */
+ * Stub hash: 35c309740ea0ee7328ec5dfdbbad057097ca24e7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -71,7 +71,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_execute, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_execute arginfo_mysqli_stmt_execute
@@ -644,7 +644,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_stmt_data_seek arginfo_class_mysqli_result_data_seek
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_execute, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_stmt_fetch arginfo_class_mysqli_character_set_name

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -1,0 +1,137 @@
+--TEST--
+mysqli_stmt_execute() - bind in execute
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
+if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
+}
+if (mysqli_get_server_version($link) <= 40100) {
+    die(sprintf('skip Needs MySQL 4.1+, found version %d.', mysqli_get_server_version($link)));
+}
+?>
+--FILE--
+<?php
+    require_once("connect.inc");
+
+    require('table.inc');
+
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+    // first, control case
+    $id = 1;
+    $abc = 'abc';
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    $stmt->bind_param('sss', ...[&$abc, 42, $id]);
+    $stmt->execute();
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+    $stmt = null;
+
+    // 1. same as the control case, but skipping the middle-man (bind_param)
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    $stmt->execute([&$abc, 42, $id]);
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+    $stmt = null;
+
+    // 2. param number has to match - missing 1 parameter
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    try {
+        $stmt->execute([&$abc, 42]);
+    } catch (mysqli_sql_exception $e) {
+        echo '[001] '.$e->getMessage()."\n";
+    }
+    $stmt = null;
+
+    // 3. param number has to match - missing all parameters
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    try {
+        $stmt->execute([]);
+    } catch (mysqli_sql_exception $e) {
+        echo '[002] '.$e->getMessage()."\n";
+    }
+    $stmt = null;
+
+    // 4. param number has to match - missing argument to execute()
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    try {
+        $stmt->execute();
+    } catch (mysqli_sql_exception $e) {
+        echo '[003] '.$e->getMessage()."\n";
+    }
+    $stmt = null;
+
+    // 5. wrong argument to execute()
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    try {
+        $stmt->execute(42);
+    } catch (TypeError $e) {
+		echo '[004] '.$e->getMessage()."\n";
+    }
+    $stmt = null;
+
+    // 6. objects are not arrays and are not accepted
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    try {
+        $stmt->execute((object)[&$abc, 42, $id]);
+    } catch (TypeError $e) {
+        echo '[005] '.$e->getMessage()."\n";
+    }
+    $stmt = null;
+
+    // 7. arrays by reference work too
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    $arr = [&$abc, 42, $id];
+    $arr2 = &$arr;
+    $stmt->execute($arr2);
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+    $stmt = null;
+
+    // 8. no placeholders in statement. params are ignored
+    $stmt = $link->prepare('SELECT label FROM test WHERE id=1');
+    $stmt->execute(['I am ignored']);
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a']);
+    $stmt = null;
+
+    // 9. once bound the values are persisted. Just like in PDO
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    $stmt->execute(['abc', 42, $id]);
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+    $stmt->execute(); // no argument here. Values are already bound
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+    try {
+		$stmt->execute([]); // no params here. PDO doesn't throw an error, but mysqli does
+    } catch (mysqli_sql_exception $e) {
+        echo '[006] '.$e->getMessage()."\n";
+    }
+    $stmt = null;
+
+    // 10. mixing binding styles not possible. Also, NULL should stay NULL when bound as string
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    $stmt->bind_param('sss', ...['abc', 42, null]);
+	$stmt->execute([null, null, $id]);
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>null, 'num' => null]);
+    $stmt = null;
+
+    // 11. array keys are ignored. Even numerical indices are not considered (PDO does a weird thing with the numerical indices)
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+	$stmt->execute(['A'=>'abc', 2=>42, null=>$id]);
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+    $stmt = null;
+
+
+    mysqli_close($link);
+    print "done!";
+?>
+--CLEAN--
+<?php
+    require_once("clean_table.inc");
+?>
+--EXPECT--
+[001] No data supplied for 1 parameter in prepared statement
+[002] No data supplied for 3 parameters in prepared statement
+[003] No data supplied for parameters in prepared statement
+[004] mysqli_stmt::execute(): Argument #1 must be of type array, int given
+[005] mysqli_stmt::execute(): Argument #1 must be of type array, stdClass given
+[006] No data supplied for 3 parameters in prepared statement
+done!

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -125,10 +125,13 @@ if (!stristr(mysqli_get_client_info(), 'mysqlnd')) {
     assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>null, 'num' => null]);
     $stmt = null;
 
-    // 12. array keys are ignored. Even numerical indices are not considered (PDO does a weird thing with the numerical indices)
+    // 12. Only list arrays are allowed
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    $stmt->execute(['A'=>'abc', 2=>42, null=>$id]);
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+    try {
+        $stmt->execute(['A'=>'abc', 2=>42, null=>$id]);
+    } catch (ValueError $e) {
+        echo '[008] '.$e->getMessage()."\n";
+    }
     $stmt = null;
 
 
@@ -147,4 +150,5 @@ if (!stristr(mysqli_get_client_info(), 'mysqlnd')) {
 [005] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, int given
 [006] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, stdClass given
 [007] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 0 present
+[008] mysqli_stmt::execute(): Argument #1 ($params) must be a list array
 done!

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -131,7 +131,7 @@ if (mysqli_get_server_version($link) <= 40100) {
 [001] No data supplied for 1 parameter in prepared statement
 [002] No data supplied for 3 parameters in prepared statement
 [003] No data supplied for parameters in prepared statement
-[004] mysqli_stmt::execute(): Argument #1 must be of type array, int given
-[005] mysqli_stmt::execute(): Argument #1 must be of type array, stdClass given
+[004] mysqli_stmt::execute(): Argument #1 ($params) must be of type array, int given
+[005] mysqli_stmt::execute(): Argument #1 ($params) must be of type array, stdClass given
 [006] No data supplied for 3 parameters in prepared statement
 done!

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -147,8 +147,8 @@ if (!stristr(mysqli_get_client_info(), 'mysqlnd')) {
 [002] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 4 present
 [003] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 0 present
 [004] No data supplied for parameters in prepared statement
-[005] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, int given
-[006] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, stdClass given
+[005] mysqli_stmt::execute(): Argument #1 ($params) must be of type array, int given
+[006] mysqli_stmt::execute(): Argument #1 ($params) must be of type array, stdClass given
 [007] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 0 present
 [008] mysqli_stmt::execute(): Argument #1 ($params) must be a list array
 done!

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -10,6 +10,9 @@ if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 if (mysqli_get_server_version($link) <= 40100) {
     die(sprintf('skip Needs MySQL 4.1+, found version %d.', mysqli_get_server_version($link)));
 }
+if (!stristr(mysqli_get_client_info(), 'mysqlnd')) {
+    die("skip: only available in mysqlnd");
+}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -2,145 +2,138 @@
 mysqli_stmt_execute() - bind in execute
 --SKIPIF--
 <?php
-require_once('skipif.inc');
-require_once('skipifconnectfailure.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
-}
-if (mysqli_get_server_version($link) <= 40100) {
-    die(sprintf('skip Needs MySQL 4.1+, found version %d.', mysqli_get_server_version($link)));
-}
+require_once 'skipif.inc';
+require_once 'skipifconnectfailure.inc';
 if (!stristr(mysqli_get_client_info(), 'mysqlnd')) {
     die("skip: only available in mysqlnd");
 }
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+require_once "connect.inc";
 
-    require('table.inc');
+require 'table.inc';
 
-    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
-    // first, control case
-    $id = 1;
-    $abc = 'abc';
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    $stmt->bind_param('sss', ...[&$abc, 42, $id]);
-    $stmt->execute();
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
-    $stmt = null;
+// first, control case
+$id = 1;
+$abc = 'abc';
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+$stmt->bind_param('sss', ...[&$abc, 42, $id]);
+$stmt->execute();
+assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+$stmt = null;
 
-    // 1. same as the control case, but skipping the middle-man (bind_param)
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    $stmt->execute([&$abc, 42, $id]);
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
-    $stmt = null;
+// 1. same as the control case, but skipping the middle-man (bind_param)
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+$stmt->execute([&$abc, 42, $id]);
+assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+$stmt = null;
 
-    // 2. param number has to match - missing 1 parameter
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    try {
-        $stmt->execute([&$abc, 42]);
-    } catch (ValueError $e) {
-        echo '[001] '.$e->getMessage()."\n";
-    }
-    $stmt = null;
+// 2. param number has to match - missing 1 parameter
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+try {
+    $stmt->execute([&$abc, 42]);
+} catch (ValueError $e) {
+    echo '[001] '.$e->getMessage()."\n";
+}
+$stmt = null;
 
-    // 3. Too many parameters 
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    try {
-        $stmt->execute([&$abc, null, $id, 24]);
-    } catch (ValueError $e) {
-        echo '[002] '.$e->getMessage()."\n";
-    }
-    $stmt = null;
+// 3. Too many parameters 
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+try {
+    $stmt->execute([&$abc, null, $id, 24]);
+} catch (ValueError $e) {
+    echo '[002] '.$e->getMessage()."\n";
+}
+$stmt = null;
 
-    // 4. param number has to match - missing all parameters
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    try {
-        $stmt->execute([]);
-    } catch (ValueError $e) {
-        echo '[003] '.$e->getMessage()."\n";
-    }
-    $stmt = null;
-
-    // 5. param number has to match - missing argument to execute()
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    try {
-        $stmt->execute();
-    } catch (mysqli_sql_exception $e) {
-        echo '[004] '.$e->getMessage()."\n";
-    }
-    $stmt = null;
-
-    // 6. wrong argument to execute()
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    try {
-        $stmt->execute(42);
-    } catch (TypeError $e) {
-        echo '[005] '.$e->getMessage()."\n";
-    }
-    $stmt = null;
-
-    // 7. objects are not arrays and are not accepted
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    try {
-        $stmt->execute((object)[&$abc, 42, $id]);
-    } catch (TypeError $e) {
-        echo '[006] '.$e->getMessage()."\n";
-    }
-    $stmt = null;
-
-    // 8. arrays by reference work too
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    $arr = [&$abc, 42, $id];
-    $arr2 = &$arr;
-    $stmt->execute($arr2);
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
-    $stmt = null;
-
-    // 9. no placeholders in statement. nothing to bind in an empty array
-    $stmt = $link->prepare('SELECT label FROM test WHERE id=1');
+// 4. param number has to match - missing all parameters
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+try {
     $stmt->execute([]);
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a']);
-    $stmt = null;
+} catch (ValueError $e) {
+    echo '[003] '.$e->getMessage()."\n";
+}
+$stmt = null;
 
-    // 10. once bound the values are persisted. Just like in PDO
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    $stmt->execute(['abc', 42, $id]);
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
-    $stmt->execute(); // no argument here. Values are already bound
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
-    try {
-        $stmt->execute([]); // no params here. PDO doesn't throw an error, but mysqli does
-    } catch (ValueError $e) {
-        echo '[007] '.$e->getMessage()."\n";
-    }
-    $stmt = null;
+// 5. param number has to match - missing argument to execute()
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+try {
+    $stmt->execute();
+} catch (mysqli_sql_exception $e) {
+    echo '[004] '.$e->getMessage()."\n";
+}
+$stmt = null;
 
-    // 11. mixing binding styles not possible. Also, NULL should stay NULL when bound as string
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    $stmt->bind_param('sss', ...['abc', 42, null]);
-    $stmt->execute([null, null, $id]);
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>null, 'num' => null]);
-    $stmt = null;
+// 6. wrong argument to execute()
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+try {
+    $stmt->execute(42);
+} catch (TypeError $e) {
+    echo '[005] '.$e->getMessage()."\n";
+}
+$stmt = null;
 
-    // 12. Only list arrays are allowed
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    try {
-        $stmt->execute(['A'=>'abc', 2=>42, null=>$id]);
-    } catch (ValueError $e) {
-        echo '[008] '.$e->getMessage()."\n";
-    }
-    $stmt = null;
+// 7. objects are not arrays and are not accepted
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+try {
+    $stmt->execute((object)[&$abc, 42, $id]);
+} catch (TypeError $e) {
+    echo '[006] '.$e->getMessage()."\n";
+}
+$stmt = null;
+
+// 8. arrays by reference work too
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+$arr = [&$abc, 42, $id];
+$arr2 = &$arr;
+$stmt->execute($arr2);
+assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+$stmt = null;
+
+// 9. no placeholders in statement. nothing to bind in an empty array
+$stmt = $link->prepare('SELECT label FROM test WHERE id=1');
+$stmt->execute([]);
+assert($stmt->get_result()->fetch_assoc() === ['label'=>'a']);
+$stmt = null;
+
+// 10. once bound the values are persisted. Just like in PDO
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+$stmt->execute(['abc', 42, $id]);
+assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+$stmt->execute(); // no argument here. Values are already bound
+assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+try {
+    $stmt->execute([]); // no params here. PDO doesn't throw an error, but mysqli does
+} catch (ValueError $e) {
+    echo '[007] '.$e->getMessage()."\n";
+}
+$stmt = null;
+
+// 11. mixing binding styles not possible. Also, NULL should stay NULL when bound as string
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+$stmt->bind_param('sss', ...['abc', 42, null]);
+$stmt->execute([null, null, $id]);
+assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>null, 'num' => null]);
+$stmt = null;
+
+// 12. Only list arrays are allowed
+$stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+try {
+    $stmt->execute(['A'=>'abc', 2=>42, null=>$id]);
+} catch (ValueError $e) {
+    echo '[008] '.$e->getMessage()."\n";
+}
+$stmt = null;
 
 
-    mysqli_close($link);
-    print "done!";
+mysqli_close($link);
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 [001] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 2 present
@@ -151,4 +144,3 @@ if (!stristr(mysqli_get_client_info(), 'mysqlnd')) {
 [006] mysqli_stmt::execute(): Argument #1 ($params) must be of type array, stdClass given
 [007] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 0 present
 [008] mysqli_stmt::execute(): Argument #1 ($params) must be a list array
-done!

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -38,7 +38,7 @@ if (mysqli_get_server_version($link) <= 40100) {
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     try {
         $stmt->execute([&$abc, 42]);
-    } catch (mysqli_sql_exception $e) {
+    } catch (ValueError $e) {
         echo '[001] '.$e->getMessage()."\n";
     }
     $stmt = null;
@@ -47,7 +47,7 @@ if (mysqli_get_server_version($link) <= 40100) {
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     try {
         $stmt->execute([&$abc, null, $id, 24]);
-    } catch (ArgumentCountError $e) {
+    } catch (ValueError $e) {
         echo '[002] '.$e->getMessage()."\n";
     }
     $stmt = null;
@@ -56,7 +56,7 @@ if (mysqli_get_server_version($link) <= 40100) {
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     try {
         $stmt->execute([]);
-    } catch (mysqli_sql_exception $e) {
+    } catch (ValueError $e) {
         echo '[003] '.$e->getMessage()."\n";
     }
     $stmt = null;
@@ -110,7 +110,7 @@ if (mysqli_get_server_version($link) <= 40100) {
     assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
     try {
         $stmt->execute([]); // no params here. PDO doesn't throw an error, but mysqli does
-    } catch (mysqli_sql_exception $e) {
+    } catch (ValueError $e) {
         echo '[007] '.$e->getMessage()."\n";
     }
     $stmt = null;
@@ -137,11 +137,11 @@ if (mysqli_get_server_version($link) <= 40100) {
     require_once("clean_table.inc");
 ?>
 --EXPECT--
-[001] No data supplied for 1 parameter in prepared statement
-[002] The number of values must match the number of parameters in the prepared statement
-[003] No data supplied for 3 parameters in prepared statement
+[001] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 2 present
+[002] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 4 present
+[003] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 0 present
 [004] No data supplied for parameters in prepared statement
 [005] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, int given
 [006] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, stdClass given
-[007] No data supplied for 3 parameters in prepared statement
+[007] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 0 present
 done!

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -140,7 +140,7 @@ require_once "clean_table.inc";
 [002] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 4 present
 [003] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 0 present
 [004] No data supplied for parameters in prepared statement
-[005] mysqli_stmt::execute(): Argument #1 ($params) must be of type array, int given
-[006] mysqli_stmt::execute(): Argument #1 ($params) must be of type array, stdClass given
+[005] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, int given
+[006] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, stdClass given
 [007] mysqli_stmt::execute(): Argument #1 ($params) must consist of exactly 3 elements, 0 present
 [008] mysqli_stmt::execute(): Argument #1 ($params) must be a list array

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -43,43 +43,52 @@ if (mysqli_get_server_version($link) <= 40100) {
     }
     $stmt = null;
 
-    // 3. param number has to match - missing all parameters
+    // 3. Too many parameters 
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     try {
-        $stmt->execute([]);
-    } catch (mysqli_sql_exception $e) {
+        $stmt->execute([&$abc, null, $id, 24]);
+    } catch (ArgumentCountError $e) {
         echo '[002] '.$e->getMessage()."\n";
     }
     $stmt = null;
 
-    // 4. param number has to match - missing argument to execute()
+    // 4. param number has to match - missing all parameters
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     try {
-        $stmt->execute();
+        $stmt->execute([]);
     } catch (mysqli_sql_exception $e) {
         echo '[003] '.$e->getMessage()."\n";
     }
     $stmt = null;
 
-    // 5. wrong argument to execute()
+    // 5. param number has to match - missing argument to execute()
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     try {
-        $stmt->execute(42);
-    } catch (TypeError $e) {
+        $stmt->execute();
+    } catch (mysqli_sql_exception $e) {
         echo '[004] '.$e->getMessage()."\n";
     }
     $stmt = null;
 
-    // 6. objects are not arrays and are not accepted
+    // 6. wrong argument to execute()
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     try {
-        $stmt->execute((object)[&$abc, 42, $id]);
+        $stmt->execute(42);
     } catch (TypeError $e) {
         echo '[005] '.$e->getMessage()."\n";
     }
     $stmt = null;
 
-    // 7. arrays by reference work too
+    // 7. objects are not arrays and are not accepted
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    try {
+        $stmt->execute((object)[&$abc, 42, $id]);
+    } catch (TypeError $e) {
+        echo '[006] '.$e->getMessage()."\n";
+    }
+    $stmt = null;
+
+    // 8. arrays by reference work too
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     $arr = [&$abc, 42, $id];
     $arr2 = &$arr;
@@ -87,13 +96,13 @@ if (mysqli_get_server_version($link) <= 40100) {
     assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
     $stmt = null;
 
-    // 8. no placeholders in statement. params are ignored
+    // 9. no placeholders in statement. nothing to bind in an empty array
     $stmt = $link->prepare('SELECT label FROM test WHERE id=1');
-    $stmt->execute(['I am ignored']);
+    $stmt->execute([]);
     assert($stmt->get_result()->fetch_assoc() === ['label'=>'a']);
     $stmt = null;
 
-    // 9. once bound the values are persisted. Just like in PDO
+    // 10. once bound the values are persisted. Just like in PDO
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     $stmt->execute(['abc', 42, $id]);
     assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
@@ -102,27 +111,21 @@ if (mysqli_get_server_version($link) <= 40100) {
     try {
         $stmt->execute([]); // no params here. PDO doesn't throw an error, but mysqli does
     } catch (mysqli_sql_exception $e) {
-        echo '[006] '.$e->getMessage()."\n";
+        echo '[007] '.$e->getMessage()."\n";
     }
     $stmt = null;
 
-    // 10. mixing binding styles not possible. Also, NULL should stay NULL when bound as string
+    // 11. mixing binding styles not possible. Also, NULL should stay NULL when bound as string
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     $stmt->bind_param('sss', ...['abc', 42, null]);
     $stmt->execute([null, null, $id]);
     assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>null, 'num' => null]);
     $stmt = null;
 
-    // 11. array keys are ignored. Even numerical indices are not considered (PDO does a weird thing with the numerical indices)
+    // 12. array keys are ignored. Even numerical indices are not considered (PDO does a weird thing with the numerical indices)
     $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
     $stmt->execute(['A'=>'abc', 2=>42, null=>$id]);
     assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
-    $stmt = null;
-
-    // 12. Too many parameters is not a problem. The redundant ones just get ignored
-    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
-    $stmt->execute(['abc', null, $id, 42]);
-    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => null]);
     $stmt = null;
 
 
@@ -135,9 +138,10 @@ if (mysqli_get_server_version($link) <= 40100) {
 ?>
 --EXPECT--
 [001] No data supplied for 1 parameter in prepared statement
-[002] No data supplied for 3 parameters in prepared statement
-[003] No data supplied for parameters in prepared statement
-[004] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, int given
-[005] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, stdClass given
-[006] No data supplied for 3 parameters in prepared statement
+[002] The number of values must match the number of parameters in the prepared statement
+[003] No data supplied for 3 parameters in prepared statement
+[004] No data supplied for parameters in prepared statement
+[005] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, int given
+[006] mysqli_stmt::execute(): Argument #1 ($params) must be of type ?array, stdClass given
+[007] No data supplied for 3 parameters in prepared statement
 done!

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind_libmysql.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind_libmysql.phpt
@@ -1,0 +1,52 @@
+--TEST--
+mysqli_stmt_execute() - bind in execute
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
+if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
+}
+if (mysqli_get_server_version($link) <= 40100) {
+    die(sprintf('skip Needs MySQL 4.1+, found version %d.', mysqli_get_server_version($link)));
+}
+if (stristr(mysqli_get_client_info(), 'mysqlnd')) {
+    die("skip: only applicable for libmysqlclient");
+}
+?>
+--FILE--
+<?php
+    require_once("connect.inc");
+
+    require('table.inc');
+
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+    // first, control case
+    $id = 1;
+    $abc = 'abc';
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    $stmt->bind_param('sss', ...[&$abc, 42, $id]);
+    $stmt->execute();
+    assert($stmt->get_result()->fetch_assoc() === ['label'=>'a', 'anon'=>'abc', 'num' => '42']);
+    $stmt = null;
+
+    // 1. same as the control case, but skipping the middle-man (bind_param)
+    $stmt = $link->prepare('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?');
+    try {
+        $stmt->execute([&$abc, 42, $id]);
+    } catch (ArgumentCountError $e) {
+        echo '[001] '.$e->getMessage()."\n";
+    }
+    $stmt = null;
+
+    mysqli_close($link);
+    print "done!";
+?>
+--CLEAN--
+<?php
+    require_once("clean_table.inc");
+?>
+--EXPECT--
+[001] Binding parameters in execute is not supported with libmysqlclient
+done!


### PR DESCRIPTION
Target Version: PHP 8.1

# Introduction
PDO has always offered binding values to the prepared statement directly in the `execute()` call by providing an array with the values. The same functionality was never present in mysqli, but many users have been confused by that lack of seemingly easy functionality. (See [Bug #40891](https://bugs.php.net/bug.php?id=40891), [Bug #31096](https://bugs.php.net/bug.php?id=31096))

# Proposal
I would like to propose adding a new optional argument to [`mysqli_stmt::execute()`](https://www.php.net/manual/en/mysqli-stmt.execute.php) same as PDO does with `PDOStatement::execute()`. The goal of this proposal is to simplify mysqli usage with a simple fix which does not require major refactoring. 

This proposal tries to address the following mysqli limitations:
```
// mysqli can only bind by reference and each variable needs to be passed as a separate argument. 
$id = 1;
$name = trim(' Dharman ');
$stmt = $mysqli->prepare('INSERT INTO users(id, name) VALUES(?,?)');
$stmt->bind_param('ss', $id, $name);
$stmt->execute();

// The following would fail and throw an error
$stmt = $mysqli->prepare('INSERT INTO users(id, name) VALUES(?,?)');
$stmt->bind_param('ss', 1, trim(' Dharman '));
$stmt->execute();

// Binding an array can be very confusing
$arr = [2,3,5,8,13];
$stmt = $mysqli->prepare('SELECT name FROM users WHERE id IN ('.str_repeat('?,', count($arr) - 1) . '?)');
$stmt->bind_param(str_repeat('s', count($arr)), ...$arr);
$stmt->execute();

// SOLUTION:  bind in execute 
// it is now possible to bind by value
$stmt = $mysqli->prepare('INSERT INTO users(id, name) VALUES(?,?)');
$stmt->execute([1, trim(' Dharman ')]);

// binding an array becomes less of a chore
$arr = [2,3,5,8,13];
$stmt = $mysqli->prepare('SELECT name FROM users WHERE id IN ('.str_repeat('?,', count($arr) - 1) . '?)');
$stmt->execute($arr);
```

# What about type specifications?
MySQL can type juggle as easily as PHP. The safest way to bind parameters if you are not 100% certain of their type is to bind as a string. In many cases, this is the preferred simplest way. Type specifications should only be used in rare situations when the data should be passed to MySQL with a specific type. In reality, such situations are extremely rare and they depend on the SQL not on PHP data type. For these rare cases, we can continue using `bind_param()` with the right type specification. 

# Difference between PDO and mysqli
While the idea came from PDO bind-in-execute implementation, the mysqli proposal differs in two small ways. 
1. Array keys are completely ignored. mysqli doesn't have emulated prepares nor does it have named parameters. Relying on the array keys/indices would make the implementation unnecessarily complex and it would cause unintentional confusion. 
2. Re-binding empty array throws an error in mysqli. PDO simply ignores an empty array and continues to use previously bound values. 

# libmysql support?
Unfortunately, I am limited to Windows programming and I have no way of developing the same for libmysql and testing it myself. In theory, it should be possible to add this for libmysql with slight adjustments, but support for libmysql is not actively maintained at the moment and there are more problems that would probably need to be addressed by whoever decides to maintain libmysql support. 

# Backward Incompatible Changes
None that I can find.
