### PR TITLE
Fix #44618: Fetching may rely on uninitialized data

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1811,6 +1811,7 @@ static void php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, int result_type)
 				if (rc == SQL_SUCCESS_WITH_INFO) {
 					ZVAL_STRINGL(&tmp, buf, result->longreadlen);
 				} else if (rc != SQL_SUCCESS) {
+					php_error_docref(NULL, E_WARNING, "Can't get data of column #%d (retcode %u)", i + 1, rc);
 					ZVAL_FALSE(&tmp);
 				} else if (result->values[i].vallen == SQL_NULL_DATA) {
 					ZVAL_NULL(&tmp);
@@ -1965,6 +1966,7 @@ PHP_FUNCTION(odbc_fetch_into)
 				if (rc == SQL_SUCCESS_WITH_INFO) {
 					ZVAL_STRINGL(&tmp, buf, result->longreadlen);
 				} else if (rc != SQL_SUCCESS) {
+					php_error_docref(NULL, E_WARNING, "Can't get data of column #%d (retcode %u)", i + 1, rc);
 					ZVAL_FALSE(&tmp);
 				} else if (result->values[i].vallen == SQL_NULL_DATA) {
 					ZVAL_NULL(&tmp);
@@ -2205,6 +2207,7 @@ PHP_FUNCTION(odbc_result)
 
 			if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
 				zend_string_efree(field_str);
+				php_error_docref(NULL, E_WARNING, "Can't get data of column #%d (retcode %u)", field_ind + 1, rc);
 				RETURN_FALSE;
 			} else if (result->values[field_ind].vallen == SQL_NULL_DATA) {
 				zend_string_efree(field_str);
@@ -2255,6 +2258,7 @@ PHP_FUNCTION(odbc_result)
 		}
 
 		if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
+			php_error_docref(NULL, E_WARNING, "Can't get data of column #%d (retcode %u)", field_ind + 1, rc);
 			efree(field);
 			RETURN_FALSE;
 		}
@@ -2370,6 +2374,7 @@ PHP_FUNCTION(odbc_result_all)
 						PHPWRITE(buf, result->longreadlen);
 					} else if (rc != SQL_SUCCESS) {
 						php_printf("</td></tr></table>");
+						php_error_docref(NULL, E_WARNING, "Can't get data of column #%d (retcode %u)", i + 1, rc);
 						efree(buf);
 						RETURN_FALSE;
 					} else if (result->values[i].vallen == SQL_NULL_DATA) {

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2369,6 +2369,7 @@ PHP_FUNCTION(odbc_result_all)
 					if (rc == SQL_SUCCESS_WITH_INFO) {
 						PHPWRITE(buf, result->longreadlen);
 					} else if (rc != SQL_SUCCESS) {
+						php_printf("</td></tr></table>");
 						efree(buf);
 						RETURN_FALSE;
 					} else if (result->values[i].vallen == SQL_NULL_DATA) {

--- a/ext/odbc/tests/bug44618.phpt
+++ b/ext/odbc/tests/bug44618.phpt
@@ -53,4 +53,4 @@ array(3) {
 }
 bool(false)
 <table><tr><th>ID</th><th>real1</th><th>text1</th></tr>
-<tr><td>1</td><td>10.02</td><td>
+<tr><td>1</td><td>10.02</td><td></td></tr></table>

--- a/ext/odbc/tests/bug44618.phpt
+++ b/ext/odbc/tests/bug44618.phpt
@@ -34,7 +34,8 @@ include __DIR__ . "/config.inc";
 $conn = odbc_connect($dsn, $user, $pass);
 odbc_exec($conn, "DROP TABLE bug44618");
 ?>
---EXPECT--
+--EXPECTF--
+Warning: odbc_fetch_array(): Can't get data of column #3 (retcode 100) in %s on line %d
 array(3) {
   ["ID"]=>
   string(1) "1"
@@ -43,6 +44,8 @@ array(3) {
   ["text1"]=>
   bool(false)
 }
+
+Warning: odbc_fetch_into(): Can't get data of column #3 (retcode 100) in %s on line %d
 array(3) {
   [0]=>
   string(1) "1"
@@ -51,6 +54,9 @@ array(3) {
   [2]=>
   bool(false)
 }
+
+Warning: odbc_result(): Can't get data of column #3 (retcode 100) in %s on line %d
 bool(false)
 <table><tr><th>ID</th><th>real1</th><th>text1</th></tr>
 <tr><td>1</td><td>10.02</td><td></td></tr></table>
+Warning: odbc_result_all(): Can't get data of column #3 (retcode 100) in %s on line %d

--- a/ext/odbc/tests/bug44618.phpt
+++ b/ext/odbc/tests/bug44618.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Bug #44618 (Fetching may rely on uninitialized data)
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include __DIR__ . "/config.inc";
+$conn = odbc_connect($dsn, $user, $pass, SQL_CUR_USE_ODBC);
+
+odbc_exec($conn, "CREATE TABLE bug44618(ID INT, real1 REAL, text1 TEXT)");
+odbc_exec($conn, "INSERT INTO bug44618 VALUES (1, 10.0199995, 'testing 1,2,3')");
+
+$result = odbc_exec($conn, "SELECT * FROM bug44618");
+var_dump(odbc_fetch_array($result));
+$result = null;
+
+$result = odbc_exec($conn, "SELECT * FROM bug44618");
+odbc_fetch_into($result, $array);
+var_dump($array);
+$result = null;
+
+$result = odbc_exec($conn, "SELECT * FROM bug44618");
+odbc_fetch_row($result);
+var_dump(odbc_result($result, "text1"));
+$result = null;
+
+$result = odbc_exec($conn, "SELECT * FROM bug44618");
+odbc_result_all($result);
+$result = null;
+?>
+--CLEAN--
+<?php
+include __DIR__ . "/config.inc";
+$conn = odbc_connect($dsn, $user, $pass);
+odbc_exec($conn, "DROP TABLE bug44618");
+?>
+--EXPECT--
+array(3) {
+  ["ID"]=>
+  string(1) "1"
+  ["real1"]=>
+  string(5) "10.02"
+  ["text1"]=>
+  bool(false)
+}
+array(3) {
+  [0]=>
+  string(1) "1"
+  [1]=>
+  string(5) "10.02"
+  [2]=>
+  bool(false)
+}
+bool(false)
+<table><tr><th>ID</th><th>real1</th><th>text1</th></tr>
+<tr><td>1</td><td>10.02</td><td>


### PR DESCRIPTION
Unless `SQLGetData()` returns `SQL_SUCCESS` or `SQL_SUCCESS_WITH_INFO`,
the `StrLen_or_IndPtr` output argument is not guaranteed to be properly
set.  Thus we handle retrieval failure other than `SQL_ERROR` by
silently yielding `false` for those column values.

---

Alternative handling of retrieval failure would be to raise `E_WARNING` as well, and/or let the whole `odbc_fetch_into()`/`odbc_fetch_array()` fail.

I don't really mind how exactly we solve this, but that bug needs to be fixed.