### PR TITLE
Forbid attributes on promoted properties

### DIFF
--- a/Zend/tests/bug79897.phpt
+++ b/Zend/tests/bug79897.phpt
@@ -23,16 +23,5 @@ const X = 42;
 var_dump((new ReflectionParameter(['A', '__construct'], 'b'))->getAttributes()[0]->getArguments());
 var_dump((new ReflectionProperty('A', 'b'))->getAttributes()[0]->getArguments());
 ?>
---EXPECT--
-array(2) {
-  [0]=>
-  int(12)
-  [1]=>
-  int(42)
-}
-array(2) {
-  [0]=>
-  int(12)
-  [1]=>
-  int(42)
-}
+--EXPECTF--
+Fatal error: Attributes on promoted properties are currently not supported in %s on line %d

--- a/Zend/tests/ctor_promotion_attributes.phpt
+++ b/Zend/tests/ctor_promotion_attributes.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Attributes on promoted properties are assigned to both the property and parameter
+Attributes on promoted properties are currently not supported
 --FILE--
 <?php
 
@@ -17,6 +17,5 @@ $param = new ReflectionParameter([Test::class, '__construct'], 'num');
 var_dump($param->getAttributes()[0]->getName());
 
 ?>
---EXPECT--
-string(11) "NonNegative"
-string(11) "NonNegative"
+--EXPECTF--
+Fatal error: Attributes on promoted properties are currently not supported in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6470,6 +6470,10 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32_t fall
 					"Property %s::$%s cannot have type %s",
 					ZSTR_VAL(scope->name), ZSTR_VAL(name), ZSTR_VAL(str));
 			}
+			if (attributes_ast) {
+				zend_error_noreturn(E_COMPILE_ERROR,
+					"Attributes on promoted properties are currently not supported");
+			}
 
 			/* Recompile the type, as it has different memory management requirements. */
 			zend_type type = ZEND_TYPE_INIT_NONE(0);
@@ -6488,12 +6492,8 @@ void zend_compile_params(zend_ast *ast, zend_ast *return_type_ast, uint32_t fall
 
 			zend_string *doc_comment =
 				doc_comment_ast ? zend_string_copy(zend_ast_get_str(doc_comment_ast)) : NULL;
-			zend_property_info *prop = zend_declare_typed_property(
+			zend_declare_typed_property(
 				scope, name, &default_value, visibility | ZEND_ACC_PROMOTED, doc_comment, type);
-			if (attributes_ast) {
-				zend_compile_attributes(
-					&prop->attributes, attributes_ast, 0, ZEND_ATTRIBUTE_TARGET_PROPERTY);
-			}
 		}
 	}
 


### PR DESCRIPTION
If we can't decide how attributes on promoted properties should behave, we'll have to forbid this for now.

This is relating to https://externals.io/message/111942.