### PR TITLE
Remove string length limit from levenshtein()

### DIFF
--- a/ext/standard/levenshtein.c
+++ b/ext/standard/levenshtein.c
@@ -17,8 +17,6 @@
 #include "php.h"
 #include "php_string.h"
 
-#define LEVENSHTEIN_MAX_LENGTH 255
-
 /* {{{ reference_levdist
  * reference implementation, only optimized for memory usage, not speed */
 static zend_long reference_levdist(const zend_string *string1, const zend_string *string2, zend_long cost_ins, zend_long cost_rep, zend_long cost_del )
@@ -75,24 +73,12 @@ PHP_FUNCTION(levenshtein)
 	zend_long cost_ins = 1;
 	zend_long cost_rep = 1;
 	zend_long cost_del = 1;
-	zend_long distance = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|lll", &string1, &string2, &cost_ins, &cost_rep, &cost_del) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	if (ZSTR_LEN(string1) > LEVENSHTEIN_MAX_LENGTH) {
-		zend_argument_value_error(1, "must be less than %d characters", LEVENSHTEIN_MAX_LENGTH + 1);
-		RETURN_THROWS();
-	}
 
-	if (ZSTR_LEN(string2) > LEVENSHTEIN_MAX_LENGTH) {
-		zend_argument_value_error(2, "must be less than %d characters", LEVENSHTEIN_MAX_LENGTH + 1);
-		RETURN_THROWS();
-	}
-
-	distance = reference_levdist(string1, string2, cost_ins, cost_rep, cost_del);
-
-	RETURN_LONG(distance);
+	RETURN_LONG(reference_levdist(string1, string2, cost_ins, cost_rep, cost_del));
 }
 /* }}} */

--- a/ext/standard/tests/strings/levenshtein_error_conditions.phpt
+++ b/ext/standard/tests/strings/levenshtein_error_conditions.phpt
@@ -1,7 +1,9 @@
 --TEST--
-levenshtein() error conditions
+levenshtein() former error conditions
 --FILE--
 <?php
+
+// levenshtein no longer has a maximum string length limit.
 
 echo '--- String 1 ---' . \PHP_EOL;
 var_dump(levenshtein('AbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrstuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsuvwxyzAbcdefghijklmnopqrtsu', 'A'));
@@ -25,7 +27,7 @@ try {
 --EXPECT--
 --- String 1 ---
 int(254)
-levenshtein(): Argument #1 ($string1) must be less than 256 characters
+int(255)
 --- String 2 ---
 int(254)
-levenshtein(): Argument #2 ($string2) must be less than 256 characters
+int(255)


### PR DESCRIPTION
As noted on https://bugs.php.net/bug.php?id=80073, I don't think having this limitation makes sense. The similar_text() function has much worse asymptotic complexity than levenshtein() and does not enforce such a limitation. levenshtein() does have fairly high memory requirements, but they are a fixed factor of the string length (and subject to memory limit).