### PR TITLE
Fix #80185: jdtounix() fails after 2037

### DIFF
--- a/ext/calendar/cal_unix.c
+++ b/ext/calendar/cal_unix.c
@@ -23,6 +23,8 @@
 #include "sdncal.h"
 #include <time.h>
 
+#define SECS_PER_DAY (24 * 3600)
+
 /* {{{ proto int unixtojd([int timestamp])
    Convert UNIX timestamp to Julian Day */
 PHP_FUNCTION(unixtojd)
@@ -62,11 +64,11 @@ PHP_FUNCTION(jdtounix)
 	}
 	uday -= 2440588 /* J.D. of 1.1.1970 */;
 
-	if (uday < 0 || uday > 24755) { /* before beginning of unix epoch or behind end of unix epoch */
+	if (uday < 0 || uday > ZEND_LONG_MAX / SECS_PER_DAY) { /* before beginning of unix epoch or greater than representable */
 		RETURN_FALSE;
 	}
 
-	RETURN_LONG(uday * 24 * 3600);
+	RETURN_LONG(uday * SECS_PER_DAY);
 }
 /* }}} */
 

--- a/ext/calendar/tests/bug80185.phpt
+++ b/ext/calendar/tests/bug80185.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #80185 (jdtounix() fails after 2037)
+--SKIPIF--
+<?php
+if (!extension_loaded('calendar')) die('skip ext/calendar required');
+if (PHP_INT_SIZE != 8) die("skip for 64bit platforms only");
+?>
+--FILE--
+<?php
+var_dump(jdtounix(2465712));
+var_dump(jdtounix(PHP_INT_MAX / 86400 + 2440588));
+var_dump(jdtounix(PHP_INT_MAX / 86400 + 2440589));
+?>
+--EXPECT--
+int(2170713600)
+int(9223372036854720000)
+bool(false)

--- a/ext/calendar/tests/bug80185_32bit.phpt
+++ b/ext/calendar/tests/bug80185_32bit.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #80185 (jdtounix() fails after 2037)
+--SKIPIF--
+<?php
+if (!extension_loaded('calendar')) die('skip ext/calendar required');
+if (PHP_INT_SIZE != 4) die("skip for 32bit platforms only");
+?>
+--FILE--
+<?php
+var_dump(jdtounix(2465712));
+var_dump(jdtounix(PHP_INT_MAX / 86400 + 2440588));
+var_dump(jdtounix(PHP_INT_MAX / 86400 + 2440589));
+?>
+--EXPECT--
+bool(false)
+int(2147472000)
+bool(false)


### PR DESCRIPTION
There is no such thing as the "end of the unix epoch", and if it was,
it would certainly not be 2037-10-11T02:00:00.  There is, however,
potential integer overflow which we need to avoid.