### PR TITLE
Fix #77040: tidyNode::isHtml() is completely broken

### DIFF
--- a/ext/tidy/tests/bug77040.phpt
+++ b/ext/tidy/tests/bug77040.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #77040 (tidyNode::isHtml() is completely broken)
+--SKIPIF--
+<?php
+if (!extension_loaded('tidy')) die('skip tidy extension not available');
+?>
+--FILE--
+<?php
+$tidy = new tidy;
+$tidy->parseString("<p>text</p>");
+$p = $tidy->body()->child[0]->child[0];
+var_dump($p->type === TIDY_NODETYPE_TEXT);
+var_dump($p->isHtml());
+?>
+--EXPECT--
+bool(true)
+bool(false)

--- a/ext/tidy/tests/bug77040.phpt
+++ b/ext/tidy/tests/bug77040.phpt
@@ -7,11 +7,21 @@ if (!extension_loaded('tidy')) die('skip tidy extension not available');
 --FILE--
 <?php
 $tidy = new tidy;
-$tidy->parseString("<p>text</p>");
-$p = $tidy->body()->child[0]->child[0];
-var_dump($p->type === TIDY_NODETYPE_TEXT);
+$tidy->parseString("<p>text</p><p><![CDATA[cdata]]></p>");
+$p = $tidy->body()->child[0];
+var_dump($p->type === TIDY_NODETYPE_START);
 var_dump($p->isHtml());
+$text = $p->child[0];
+var_dump($text->type === TIDY_NODETYPE_TEXT);
+var_dump($text->isHtml());
+$cdata = $tidy->body()->child[1]->child[0];
+var_dump($cdata->type === TIDY_NODETYPE_CDATA);
+var_dump($cdata->isHtml());
 ?>
 --EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(false)
 bool(true)
 bool(false)

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -1785,8 +1785,8 @@ static TIDY_NODE_METHOD(isComment)
 static TIDY_NODE_METHOD(isHtml)
 {
 	TIDY_FETCH_ONLY_OBJECT;
-	int type;
-	switch (type = tidyNodeGetType(obj->node)) {
+
+	switch (tidyNodeGetType(obj->node)) {
 		case TidyNode_Start:
 		case TidyNode_End:
 		case TidyNode_StartEnd:

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -1785,12 +1785,15 @@ static TIDY_NODE_METHOD(isComment)
 static TIDY_NODE_METHOD(isHtml)
 {
 	TIDY_FETCH_ONLY_OBJECT;
-
-	if (tidyNodeGetType(obj->node) & (TidyNode_Start | TidyNode_End | TidyNode_StartEnd)) {
-		RETURN_TRUE;
+	int type;
+	switch (type = tidyNodeGetType(obj->node)) {
+		case TidyNode_Start:
+		case TidyNode_End:
+		case TidyNode_StartEnd:
+			RETURN_TRUE;
+		default:
+			RETURN_FALSE;
 	}
-
-	RETURN_FALSE;
 }
 /* }}} */
 


### PR DESCRIPTION
The documentation of `tidyNode::isHtml()` states that this method
"checks if a node is part of a HTML document".  That is, of course,
nonsense, since a tidyNode is "an HTML node in an HTML file, as
detected by tidy."

What this method is actually supposed to do is to check whether a node
is an element (unless it is the root element).  This has been broken by
commit d8eeb8e[1], which assumed that `enum TidyNodeType` would
represent flags of a bitmask, what it does not.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=d8eeb8e28673236bca3f066ded75037a5bdf6378>