### PR TITLE
don't display default value for variadic

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -674,7 +674,7 @@ static void _parameter_string(smart_str *str, zend_function *fptr, struct _zend_
 	smart_str_append_printf(str, "$%s", has_internal_arg_info(fptr)
 		? ((zend_internal_arg_info*)arg_info)->name : ZSTR_VAL(arg_info->name));
 
-	if (!required) {
+	if (!required && !ZEND_ARG_IS_VARIADIC(arg_info)) {
 		if (fptr->type == ZEND_INTERNAL_FUNCTION) {
 			smart_str_appends(str, " = ");
 			/* TODO: We don't have a way to fetch the default value for an internal function

--- a/ext/reflection/tests/ReflectionClass_toString_001.phpt
+++ b/ext/reflection/tests/ReflectionClass_toString_001.phpt
@@ -261,7 +261,7 @@ Class [ <internal:Reflection> class ReflectionClass implements Reflector, String
     Method [ <internal:Reflection> public method newInstance ] {
 
       - Parameters [1] {
-        Parameter #0 [ <optional> mixed ...$args = <default> ]
+        Parameter #0 [ <optional> mixed ...$args ]
       }
     }
 


### PR DESCRIPTION
Running `php --re  standard`:

Before:
```
    Function [ <internal:standard> function compact ] {

      - Parameters [2] {
        Parameter #0 [ <required> $var_name ]
        Parameter #1 [ <optional> ...$var_names = <default> ]
      }
      - Return [ array ]
    }

```

After:

```
    Function [ <internal:standard> function compact ] {

      - Parameters [2] {
        Parameter #0 [ <required> $var_name ]
        Parameter #1 [ <optional> ...$var_names ]
      }
      - Return [ array ]
```

And by consistency with **zend_get_function_declaration** which uses:

`			if (i >= required && !ZEND_ARG_IS_VARIADIC(arg_info)) {`
