### PR TITLE
Update ext/pgsql parameter names

### DIFF
--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -3,10 +3,10 @@
 /** @generate-function-entries */
 
 /** @return resource|false */
-function pg_connect(string $connection_string, int $connection_type = 0) {}
+function pg_connect(string $connection_string, int $flags = 0) {}
 
 /** @return resource|false */
-function pg_pconnect(string $connection_string, int $connection_type = 0) {}
+function pg_pconnect(string $connection_string, int $flags = 0) {}
 
 /** @param resource $connection */
 function pg_connect_poll($connection): int {}
@@ -43,7 +43,7 @@ function pg_host($connection = null): string {}
 function pg_version($connection = null): array {}
 
 /** @param resource|string $connection */
-function pg_parameter_status($connection, string $param_name = UNKNOWN): string|false {}
+function pg_parameter_status($connection, string $name = UNKNOWN): string|false {}
 
 /** @param resource|null $connection */
 function pg_ping($connection = null): bool {}
@@ -112,122 +112,122 @@ function pg_affected_rows($result): int {}
 function pg_cmdtuples($result): int {}
 
 /** @param resource $connection */
-function pg_last_notice($connection, int $option = PGSQL_NOTICE_LAST): array|string|bool {}
+function pg_last_notice($connection, int $mode = PGSQL_NOTICE_LAST): array|string|bool {}
 
 /** @param resource $result */
-function pg_field_table($result, int $field_number, bool $oid_only = false): string|int|false {}
+function pg_field_table($result, int $field, bool $oid_only = false): string|int|false {}
 
 /** @param resource $result */
-function pg_field_name($result, int $field_number): string {}
+function pg_field_name($result, int $field): string {}
 
 /**
  * @param resource $result
  * @alias pg_field_name
  * @deprecated
  */
-function pg_fieldname($result, int $field_number): string {}
+function pg_fieldname($result, int $field): string {}
 
 /** @param resource $result */
-function pg_field_size($result, int $field_number): int {}
+function pg_field_size($result, int $field): int {}
 
 /**
  * @param resource $result
  * @alias pg_field_size
  * @deprecated
  */
-function pg_fieldsize($result, int $field_number): int {}
+function pg_fieldsize($result, int $field): int {}
 
 /** @param resource $result */
-function pg_field_type($result, int $field_number): string {}
+function pg_field_type($result, int $field): string {}
 
 /**
  * @param resource $result
  * @alias pg_field_type
  * @deprecated
  */
-function pg_fieldtype($result, int $field_number): string {}
+function pg_fieldtype($result, int $field): string {}
 
 /** @param resource $result */
-function pg_field_type_oid($result, int $field_number): string|int {}
+function pg_field_type_oid($result, int $field): string|int {}
 
 /** @param resource $result */
-function pg_field_num($result, string $field_name): int {}
+function pg_field_num($result, string $field): int {}
 
 /**
  * @param resource $result
  * @alias pg_field_num
  * @deprecated
  */
-function pg_fieldnum($result, string $field_name): int {}
+function pg_fieldnum($result, string $field): int {}
 
 /**
  * @param resource $result
- * @param string|int $row_number
+ * @param string|int $row
  */
-function pg_fetch_result($result, $row_number, string|int $field = UNKNOWN): string|false|null {}
+function pg_fetch_result($result, $row, string|int $field = UNKNOWN): string|false|null {}
 
 /**
  * @param resource $result
- * @param string|int $row_number
+ * @param string|int $row
  * @alias pg_fetch_result
  * @deprecated
  */
-function pg_result($result, $row_number, string|int $field = UNKNOWN): string|false|null {}
+function pg_result($result, $row, string|int $field = UNKNOWN): string|false|null {}
 
 /**
  * @param resource $result
  */
-function pg_fetch_row($result, ?int $row_number = null, int $result_type = PGSQL_NUM): array|false {}
+function pg_fetch_row($result, ?int $row = null, int $mode = PGSQL_NUM): array|false {}
 
 /**
  * @param resource $result
  */
-function pg_fetch_assoc($result, ?int $row_number = null): array|false {}
+function pg_fetch_assoc($result, ?int $row = null): array|false {}
 
 /**
  * @param resource $result
  */
-function pg_fetch_array($result, ?int $row_number = null, int $result_type = PGSQL_BOTH): array|false {}
+function pg_fetch_array($result, ?int $row = null, int $mode = PGSQL_BOTH): array|false {}
 
 /** @param resource $result */
-function pg_fetch_object($result, ?int $row_number = null, string $class_name = "stdClass", ?array $ctor_params = null): object|false {}
+function pg_fetch_object($result, ?int $row = null, string $class = "stdClass", ?array $ctor_args = null): object|false {}
 
 /** @param resource $result */
-function pg_fetch_all($result, int $result_type = PGSQL_ASSOC): array {}
+function pg_fetch_all($result, int $mode = PGSQL_ASSOC): array {}
 
 /** @param resource $result */
-function pg_fetch_all_columns($result, int $field_number = 0): array {}
+function pg_fetch_all_columns($result, int $field = 0): array {}
 
 /** @param resource $result */
-function pg_result_seek($result, int $row_number): bool {}
+function pg_result_seek($result, int $row): bool {}
 
 /**
  * @param resource $result
- * @param string|int $row_number
+ * @param string|int $row
  */
-function pg_field_prtlen($result, $row_number, string|int $field = UNKNOWN): int|false {}
+function pg_field_prtlen($result, $row, string|int $field = UNKNOWN): int|false {}
 
 /**
  * @param resource $result
- * @param string|int $row_number
+ * @param string|int $row
  * @alias pg_field_prtlen
  * @deprecated
  */
-function pg_fieldprtlen($result, $row_number, string|int $field = UNKNOWN): int|false {}
+function pg_fieldprtlen($result, $row, string|int $field = UNKNOWN): int|false {}
 
 /**
  * @param resource $result
- * @param string|int $row_number
+ * @param string|int $row
  */
-function pg_field_is_null($result, $row_number, string|int $field = UNKNOWN): int|false {}
+function pg_field_is_null($result, $row, string|int $field = UNKNOWN): int|false {}
 
 /**
  * @param resource $result
- * @param string|int $row_number
+ * @param string|int $row
  * @alias pg_field_is_null
  * @deprecated
  */
-function pg_fieldisnull($result, $row_number, string|int $field = UNKNOWN): int|false {}
+function pg_fieldisnull($result, $row, string|int $field = UNKNOWN): int|false {}
 
 /** @param resource $result */
 function pg_free_result($result): bool {}
@@ -257,132 +257,132 @@ function pg_untrace($connection = null): bool {}
 
 /**
  * @param resource $connection
- * @param string|int $large_object_id
+ * @param string|int $oid
  */
-function pg_lo_create($connection = UNKNOWN, $large_object_id = UNKNOWN): string|int|false {}
+function pg_lo_create($connection = UNKNOWN, $oid = UNKNOWN): string|int|false {}
 
 /**
  * @param resource $connection
- * @param string|int $large_object_id
+ * @param string|int $oid
  * @alias pg_lo_create
  * @deprecated
  */
-function pg_locreate($connection = UNKNOWN, $large_object_id = UNKNOWN): string|int|false {}
+function pg_locreate($connection = UNKNOWN, $oid = UNKNOWN): string|int|false {}
 
 /**
  * @param resource $connection
- * @param string|int $large_object_id
+ * @param string|int $oid
  */
-function pg_lo_unlink($connection, $large_object_id = UNKNOWN): bool {}
+function pg_lo_unlink($connection, $oid = UNKNOWN): bool {}
 
 /**
  * @param resource $connection
- * @param string|int $large_object_id
+ * @param string|int $oid
  * @alias pg_lo_unlink
  * @deprecated
  */
-function pg_lounlink($connection, $large_object_id = UNKNOWN): bool {}
+function pg_lounlink($connection, $oid = UNKNOWN): bool {}
 
 /**
  * @param resource $connection
- * @param string|int $large_object_id
+ * @param string|int $oid
  * @return resource|false
  */
-function pg_lo_open($connection, $large_object_id = UNKNOWN, string $mode = UNKNOWN) {}
+function pg_lo_open($connection, $oid = UNKNOWN, string $mode = UNKNOWN) {}
 
 /**
  * @param resource $connection
- * @param string|int $large_object_id
+ * @param string|int $oid
  * @return resource|false
  * @alias pg_lo_open
  * @deprecated
  */
-function pg_loopen($connection, $large_object_id = UNKNOWN, string $mode = UNKNOWN) {}
+function pg_loopen($connection, $oid = UNKNOWN, string $mode = UNKNOWN) {}
 
 /** @param resource $large_object */
 function pg_lo_close($large_object): bool {}
 
 /**
- * @param resource $large_object
+ * @param resource $lob
  * @alias pg_lo_close
  * @deprecated
  */
-function pg_loclose($large_object): bool {}
+function pg_loclose($lob): bool {}
 
-/** @param resource $large_object */
-function pg_lo_read($large_object, int $len = 8192): string|false {}
+/** @param resource $lob */
+function pg_lo_read($lob, int $length = 8192): string|false {}
 
 /**
- * @param resource $large_object
+ * @param resource $lob
  * @alias pg_lo_read
  * @deprecated
  */
-function pg_loread($large_object, int $len = 8192): string|false {}
+function pg_loread($lob, int $length = 8192): string|false {}
 
-/** @param resource $large_object */
-function pg_lo_write($large_object, string $buf, ?int $len = null): int|false {}
+/** @param resource $lob */
+function pg_lo_write($lob, string $data, ?int $length = null): int|false {}
 
 /**
- * @param resource $large_object
+ * @param resource $lob
  * @alias pg_lo_write
  * @deprecated
  */
-function pg_lowrite($large_object, string $buf, ?int $len = null): int|false {}
+function pg_lowrite($lob, string $data, ?int $length = null): int|false {}
 
-/** @param resource $large_object */
-function pg_lo_read_all($large_object): int {}
+/** @param resource $lob */
+function pg_lo_read_all($lob): int {}
 
 /**
- * @param resource $large_object
+ * @param resource $lob
  * @alias pg_lo_read_all
  * @deprecated
  */
-function pg_loreadall($large_object): int {}
+function pg_loreadall($lob): int {}
 
 /**
  * @param resource|string $connection
  * @param string|int $filename
- * @param string|int $large_object_id
+ * @param string|int $oid
  * @return resource|false
  */
-function pg_lo_import($connection, $filename = UNKNOWN, $large_object_id = UNKNOWN): string|int|false {}
+function pg_lo_import($connection, $filename = UNKNOWN, $oid = UNKNOWN): string|int|false {}
 
 /**
  * @param resource|string $connection
  * @param string|int $filename
- * @param string|int $large_object_id
+ * @param string|int $oid
  * @return resource|false
  * @alias pg_lo_import
  * @deprecated
  */
-function pg_loimport($connection, $filename = UNKNOWN, $large_object_id = UNKNOWN): string|int|false {}
+function pg_loimport($connection, $filename = UNKNOWN, $oid = UNKNOWN): string|int|false {}
 
 /**
  * @param resource|string|int $connection
- * @param string|int $large_object_id
+ * @param string|int $oid
  * @param string|int $filename
  * @return resource|false
  */
-function pg_lo_export($connection, $large_object_id = UNKNOWN, $filename = UNKNOWN): bool {}
+function pg_lo_export($connection, $oid = UNKNOWN, $filename = UNKNOWN): bool {}
 
 /**
  * @param resource|string|int $connection
- * @param string|int $large_object_id
+ * @param string|int $oid
  * @param string|int $filename
  * @return resource|false
  * @alias pg_lo_export
  * @deprecated
  */
-function pg_loexport($connection, $large_object_id = UNKNOWN, $filename = UNKNOWN): bool {}
+function pg_loexport($connection, $oid = UNKNOWN, $filename = UNKNOWN): bool {}
 
-/** @param resource $large_object */
-function pg_lo_seek($large_object, int $offset, int $whence = SEEK_CUR): bool {}
+/** @param resource $lob */
+function pg_lo_seek($lob, int $offset, int $whence = SEEK_CUR): bool {}
 
-/** @param resource $large_object */
-function pg_lo_tell($large_object): int {}
+/** @param resource $lob */
+function pg_lo_tell($lob): int {}
 
-/** @param resource $large_object */
-function pg_lo_truncate($large_object, int $size): bool {}
+/** @param resource $lob */
+function pg_lo_truncate($lob, int $size): bool {}
 
 /** @param resource|int $connection */
 function pg_set_error_verbosity($connection, int $verbosity = UNKNOWN): int|false {}
@@ -414,30 +414,30 @@ function pg_end_copy($connection = null): bool {}
 function pg_put_line($connection, string $query = UNKNOWN): bool {}
 
 /** @param resource $connection */
-function pg_copy_to($connection, string $table_name, string $delimiter = "\t", string $null_as = "\\\\N"): array|false {}
+function pg_copy_to($connection, string $table_name, string $separator = "\t", string $null_as = "\\\\N"): array|false {}
 
 /** @param resource $connection */
-function pg_copy_from($connection, string $table_name, array $rows, string $delimiter = "\t", string $null_as = "\\\\N"): bool {}
+function pg_copy_from($connection, string $table_name, array $rows, string $separator = "\t", string $null_as = "\\\\N"): bool {}
 
 /** @param resource|string $connection */
-function pg_escape_string($connection, string $data = UNKNOWN): string {}
+function pg_escape_string($connection, string $string = UNKNOWN): string {}
 
 /** @param resource|string $connection */
-function pg_escape_bytea($connection, string $data = UNKNOWN): string {}
+function pg_escape_bytea($connection, string $string = UNKNOWN): string {}
 
-function pg_unescape_bytea(?string $data = null): string {}
-
-/** @param resource|string $connection */
-function pg_escape_literal($connection, string $data = UNKNOWN): string|false {}
+function pg_unescape_bytea(?string $string = null): string {}
 
 /** @param resource|string $connection */
-function pg_escape_identifier($connection, string $data = UNKNOWN): string|false {}
+function pg_escape_literal($connection, string $string = UNKNOWN): string|false {}
+
+/** @param resource|string $connection */
+function pg_escape_identifier($connection, string $string = UNKNOWN): string|false {}
 
 /** @param resource $result */
 function pg_result_error($result): string|false {}
 
 /** @param resource $result */
-function pg_result_error_field($result, int $fieldcode): string|false|null {}
+function pg_result_error_field($result, int $field_code): string|false|null {}
 
 /** @param resource $connection */
 function pg_connection_status($connection): int {}
@@ -461,7 +461,7 @@ function pg_send_query($connection, string $query): int|bool {}
 function pg_send_query_params($connection, string $query, array $params): int|bool {}
 
 /** @param resource $connection */
-function pg_send_prepare($connection, string $stmtname, string $query): int|bool {}
+function pg_send_prepare($connection, string $stmt_name, string $query): int|bool {}
 
 /** @param resource $connection */
 function pg_send_execute($connection, string $query, array $params): int|bool {}
@@ -473,10 +473,10 @@ function pg_send_execute($connection, string $query, array $params): int|bool {}
 function pg_get_result($connection) {}
 
 /** @param resource $result */
-function pg_result_status($result, int $result_type = PGSQL_STATUS_LONG): string|int {}
+function pg_result_status($result, int $mode = PGSQL_STATUS_LONG): string|int {}
 
 /** @param resource $result */
-function pg_get_notify($result, int $result_type = PGSQL_ASSOC): array|false {}
+function pg_get_notify($result, int $mode = PGSQL_ASSOC): array|false {}
 
 /** @param resource $connection */
 function pg_get_pid($connection): int {}
@@ -506,10 +506,10 @@ function pg_convert($connection, string $table_name, array $values, int $options
 function pg_insert($connection, string $table_name, array $values, int $options = 0) {}
 
 /** @param resource $connection */
-function pg_update($connection, string $table_name, array $values, array $ids, int $options = 0): string|bool {}
+function pg_update($connection, string $table_name, array $values, array $conditions, int $options = 0): string|bool {}
 
 /** @param resource $connection */
-function pg_delete($connection, string $table_name, array $ids, int $options = 0): string|bool {}
+function pg_delete($connection, string $table_name, array $conditions, int $options = 0): string|bool {}
 
 /** @param resource $connection */
-function pg_select($connection, string $table_name, array $ids, int $options = 0, int $result_type = PGSQL_ASSOC): array|string|false {}
+function pg_select($connection, string $table_name, array $conditions, int $options = 0, int $mode = PGSQL_ASSOC): array|string|false {}

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -72,14 +72,14 @@ function pg_query_params($connection, $query, array $params = UNKNOWN) {}
  * @param resource|string $connection
  * @return resource|false
  */
-function pg_prepare($connection, string $stmt_name, string $query = UNKNOWN) {}
+function pg_prepare($connection, string $statement_name, string $query = UNKNOWN) {}
 
 /**
  * @param resource|string $connection
- * @param string|array $stmt_name
+ * @param string|array $statement_name
  * @return resource|false
  */
-function pg_execute($connection, $stmt_name, array $params = UNKNOWN) {}
+function pg_execute($connection, $statement_name, array $params = UNKNOWN) {}
 
 /** @param resource $result */
 function pg_num_rows($result): int {}
@@ -461,7 +461,7 @@ function pg_send_query($connection, string $query): int|bool {}
 function pg_send_query_params($connection, string $query, array $params): int|bool {}
 
 /** @param resource $connection */
-function pg_send_prepare($connection, string $stmt_name, string $query): int|bool {}
+function pg_send_prepare($connection, string $statement_name, string $query): int|bool {}
 
 /** @param resource $connection */
 function pg_send_execute($connection, string $query, array $params): int|bool {}

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2256dc582b4869c84f5168ebe6bd51dcfd059134 */
+ * Stub hash: 6733b22afa059adf9f42a3b46c509f7678589fb6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_connect, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -58,13 +58,13 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_prepare, 0, 0, 2)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO(0, stmt_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, statement_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_execute, 0, 0, 2)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_INFO(0, stmt_name)
+	ZEND_ARG_INFO(0, statement_name)
 	ZEND_ARG_TYPE_INFO(0, params, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
@@ -372,7 +372,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_send_prepare, 0, 3, MAY_BE_LONG|MAY_BE_BOOL)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO(0, stmt_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, statement_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,9 +1,9 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9735dbc8a4ca642ee825ae8942470ac2dec89f50 */
+ * Stub hash: 2256dc582b4869c84f5168ebe6bd51dcfd059134 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_connect, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, connection_type, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_pconnect arginfo_pg_connect
@@ -38,7 +38,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_parameter_status, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO(0, param_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_ping arginfo_pg_close
@@ -84,25 +84,25 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_last_notice, 0, 1, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, option, IS_LONG, 0, "PGSQL_NOTICE_LAST")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PGSQL_NOTICE_LAST")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_field_table, 0, 2, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO(0, field_number, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, field, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, oid_only, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_field_name, 0, 2, IS_STRING, 0)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO(0, field_number, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, field, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_fieldname arginfo_pg_field_name
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_field_size, 0, 2, IS_LONG, 0)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO(0, field_number, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, field, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_fieldsize arginfo_pg_field_size
@@ -113,19 +113,19 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_field_type_oid, 0, 2, MAY_BE_STRING|MAY_BE_LONG)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO(0, field_number, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, field, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_field_num, 0, 2, IS_LONG, 0)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO(0, field_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_fieldnum arginfo_pg_field_num
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_fetch_result, 0, 2, MAY_BE_STRING|MAY_BE_FALSE|MAY_BE_NULL)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_INFO(0, row_number)
+	ZEND_ARG_INFO(0, row)
 	ZEND_ARG_TYPE_MASK(0, field, MAY_BE_STRING|MAY_BE_LONG, NULL)
 ZEND_END_ARG_INFO()
 
@@ -133,46 +133,46 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_fetch_row, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "PGSQL_NUM")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PGSQL_NUM")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_fetch_assoc, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_fetch_array, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "PGSQL_BOTH")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PGSQL_BOTH")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_fetch_object, 0, 1, MAY_BE_OBJECT|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row_number, IS_LONG, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class_name, IS_STRING, 0, "\"stdClass\"")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ctor_params, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class, IS_STRING, 0, "\"stdClass\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ctor_args, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_fetch_all, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "PGSQL_ASSOC")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PGSQL_ASSOC")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_fetch_all_columns, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, field_number, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, field, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_result_seek, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO(0, row_number, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, row, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_field_prtlen, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_INFO(0, row_number)
+	ZEND_ARG_INFO(0, row)
 	ZEND_ARG_TYPE_MASK(0, field, MAY_BE_STRING|MAY_BE_LONG, NULL)
 ZEND_END_ARG_INFO()
 
@@ -204,21 +204,21 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_lo_create, 0, 0, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_INFO(0, large_object_id)
+	ZEND_ARG_INFO(0, oid)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_locreate arginfo_pg_lo_create
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_lo_unlink, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_INFO(0, large_object_id)
+	ZEND_ARG_INFO(0, oid)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_lounlink arginfo_pg_lo_unlink
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_lo_open, 0, 0, 1)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_INFO(0, large_object_id)
+	ZEND_ARG_INFO(0, oid)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -228,25 +228,27 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_lo_close, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, large_object)
 ZEND_END_ARG_INFO()
 
-#define arginfo_pg_loclose arginfo_pg_lo_close
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_loclose, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_INFO(0, lob)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_lo_read, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, large_object)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, len, IS_LONG, 0, "8192")
+	ZEND_ARG_INFO(0, lob)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "8192")
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_loread arginfo_pg_lo_read
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_lo_write, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, large_object)
-	ZEND_ARG_TYPE_INFO(0, buf, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, len, IS_LONG, 1, "null")
+	ZEND_ARG_INFO(0, lob)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_lowrite arginfo_pg_lo_write
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_lo_read_all, 0, 1, IS_LONG, 0)
-	ZEND_ARG_INFO(0, large_object)
+	ZEND_ARG_INFO(0, lob)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_loreadall arginfo_pg_lo_read_all
@@ -254,21 +256,21 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_lo_import, 0, 1, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_INFO(0, filename)
-	ZEND_ARG_INFO(0, large_object_id)
+	ZEND_ARG_INFO(0, oid)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_loimport arginfo_pg_lo_import
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_lo_export, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_INFO(0, large_object_id)
+	ZEND_ARG_INFO(0, oid)
 	ZEND_ARG_INFO(0, filename)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_loexport arginfo_pg_lo_export
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_lo_seek, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, large_object)
+	ZEND_ARG_INFO(0, lob)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, whence, IS_LONG, 0, "SEEK_CUR")
 ZEND_END_ARG_INFO()
@@ -276,7 +278,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_pg_lo_tell arginfo_pg_lo_read_all
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_lo_truncate, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, large_object)
+	ZEND_ARG_INFO(0, lob)
 	ZEND_ARG_TYPE_INFO(0, size, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -306,7 +308,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_copy_to, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, delimiter, IS_STRING, 0, "\"\\t\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, separator, IS_STRING, 0, "\"\\t\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, null_as, IS_STRING, 0, "\"\\\\\\\\N\"")
 ZEND_END_ARG_INFO()
 
@@ -314,24 +316,24 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_copy_from, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, rows, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, delimiter, IS_STRING, 0, "\"\\t\"")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, separator, IS_STRING, 0, "\"\\t\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, null_as, IS_STRING, 0, "\"\\\\\\\\N\"")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_escape_string, 0, 1, IS_STRING, 0)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_escape_bytea arginfo_pg_escape_string
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_unescape_bytea, 0, 0, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, data, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, string, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_escape_literal, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_escape_identifier arginfo_pg_escape_literal
@@ -342,7 +344,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_result_error_field, 0, 2, MAY_BE_STRING|MAY_BE_FALSE|MAY_BE_NULL)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO(0, fieldcode, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, field_code, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_connection_status arginfo_pg_connect_poll
@@ -370,7 +372,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_send_prepare, 0, 3, MAY_BE_LONG|MAY_BE_BOOL)
 	ZEND_ARG_INFO(0, connection)
-	ZEND_ARG_TYPE_INFO(0, stmtname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, stmt_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -382,12 +384,12 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_result_status, 0, 1, MAY_BE_STRING|MAY_BE_LONG)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "PGSQL_STATUS_LONG")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PGSQL_STATUS_LONG")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_get_notify, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, result)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "PGSQL_ASSOC")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PGSQL_ASSOC")
 ZEND_END_ARG_INFO()
 
 #define arginfo_pg_get_pid arginfo_pg_connect_poll
@@ -424,23 +426,23 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_update, 0, 4, MAY_BE_STRING|M
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, values, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, ids, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, conditions, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_delete, 0, 3, MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, ids, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, conditions, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_select, 0, 3, MAY_BE_ARRAY|MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, connection)
 	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, ids, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, conditions, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "PGSQL_ASSOC")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "PGSQL_ASSOC")
 ZEND_END_ARG_INFO()
 
 

--- a/ext/pgsql/tests/03sync_query.phpt
+++ b/ext/pgsql/tests/03sync_query.phpt
@@ -136,15 +136,15 @@ echo "OK";
 Argument #3 must be greater than or equal to 0
 Argument #3 must be less than the number of fields for this result set
 Argument #3 must be a field name from this result set
-pg_fetch_all_columns(): Argument #2 ($field_number) must be greater than or equal to 0
-pg_fetch_all_columns(): Argument #2 ($field_number) must be less than the number of fields for this result set
+pg_fetch_all_columns(): Argument #2 ($field) must be greater than or equal to 0
+pg_fetch_all_columns(): Argument #2 ($field) must be less than the number of fields for this result set
 Argument #2 must be greater than or equal to 0
 Argument #2 must be less than the number of fields for this result set
 Argument #2 must be a field name from this result set
-pg_field_name(): Argument #2 ($field_number) must be greater than or equal to 0
-pg_field_name(): Argument #2 ($field_number) must be less than the number of fields for this result set
-pg_field_table(): Argument #2 ($field_number) must be greater than or equal to 0
-pg_field_table(): Argument #2 ($field_number) must be less than the number of fields for this result set
+pg_field_name(): Argument #2 ($field) must be greater than or equal to 0
+pg_field_name(): Argument #2 ($field) must be less than the number of fields for this result set
+pg_field_table(): Argument #2 ($field) must be greater than or equal to 0
+pg_field_table(): Argument #2 ($field) must be less than the number of fields for this result set
 array(0) {
 }
 OK

--- a/ext/pgsql/tests/09notice.phpt
+++ b/ext/pgsql/tests/09notice.phpt
@@ -72,4 +72,4 @@ bool(true)
 string(0) ""
 array(0) {
 }
-pg_last_notice(): Argument #2 ($option) must be one of PGSQL_NOTICE_LAST, PGSQL_NOTICE_ALL, or PGSQL_NOTICE_CLEAR
+pg_last_notice(): Argument #2 ($mode) must be one of PGSQL_NOTICE_LAST, PGSQL_NOTICE_ALL, or PGSQL_NOTICE_CLEAR

--- a/ext/pgsql/tests/22pg_fetch_object.phpt
+++ b/ext/pgsql/tests/22pg_fetch_object.phpt
@@ -40,5 +40,5 @@ object(test_class)#1 (3) {
   ["bin"]=>
   NULL
 }
-pg_fetch_object(): Argument #3 ($class_name) must be a valid class name, does_not_exist given
+pg_fetch_object(): Argument #3 ($class) must be a valid class name, does_not_exist given
 Ok

--- a/ext/pgsql/tests/bug60244.phpt
+++ b/ext/pgsql/tests/bug60244.phpt
@@ -42,10 +42,10 @@ pg_close($db);
 
 ?>
 --EXPECT--
-pg_fetch_array(): Argument #2 ($row_number) must be greater than or equal to 0
-pg_fetch_assoc(): Argument #2 ($row_number) must be greater than or equal to 0
-pg_fetch_object(): Argument #2 ($row_number) must be greater than or equal to 0
-pg_fetch_row(): Argument #2 ($row_number) must be greater than or equal to 0
+pg_fetch_array(): Argument #2 ($row) must be greater than or equal to 0
+pg_fetch_assoc(): Argument #2 ($row) must be greater than or equal to 0
+pg_fetch_object(): Argument #2 ($row) must be greater than or equal to 0
+pg_fetch_row(): Argument #2 ($row) must be greater than or equal to 0
 array(2) {
   [0]=>
   string(1) "a"


### PR DESCRIPTION
Because of how pervasive it is in the API, I retained the $field terminology (rather than $column).