### PR TITLE
Fix #80203: imap_mime_header_decode() is not binary safe

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -4313,7 +4313,7 @@ PHP_FUNCTION(imap_mime_header_decode)
 					}
 					object_init(&myobject);
 					add_property_string(&myobject, "charset", charset);
-					add_property_string(&myobject, "text", decode);
+					add_property_stringl(&myobject, "text", decode, newlength);
 					zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &myobject);
 
 					/* only free decode if it was allocated by rfc822_qprint or rfc822_base64 */

--- a/ext/imap/tests/bug80203.phpt
+++ b/ext/imap/tests/bug80203.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #80203 (imap_mime_header_decode() is not binary safe)
+--SKIPIF--
+<?php
+if (!extension_loaded("imap")) die("skip imap extension not available");
+?>
+--FILE--
+<?php
+var_dump(bin2hex(imap_mime_header_decode("=?UTF-8?Q?foo=00bar?=")[0]->text));
+var_dump(bin2hex(imap_mime_header_decode("=?UTF-8?B?Zm9vAGJhcg==?=")[0]->text));
+?>
+--EXPECT--
+string(14) "666f6f00626172"
+string(14) "666f6f00626172"


### PR DESCRIPTION
We have to build the property value with the correct length.