### PR TITLE
Fix #78479: Use getaddrinfo to replace gethostbyname_r

### DIFF
--- a/ext/sockets/sockaddr_conv.c
+++ b/ext/sockets/sockaddr_conv.c
@@ -107,7 +107,7 @@ int php_set_inet_addr(struct sockaddr_in *sin, char *string, php_socket *php_soc
 			php_error_docref(NULL, E_WARNING, "Host lookup failed: Non AF_INET domain returned on AF_INET socket");
 			return 0;
 		}
-		memcpy(&(sin->sin_addr.s_addr), aip->ai_addr, aip->ai_addrlen);
+		memcpy(&(sin->sin_addr.s_addr), &((struct sockaddr_in *) aip->ai_addr)->sin_addr, aip->ai_addrlen);
 	}
 
 	return 1;

--- a/ext/sockets/sockaddr_conv.c
+++ b/ext/sockets/sockaddr_conv.c
@@ -94,7 +94,7 @@ int php_set_inet_addr(struct sockaddr_in *sin, char *string, php_socket *php_soc
 #endif
 		sin->sin_addr.s_addr = tmp.s_addr;
 	} else {
-		if (strlen(string) > MAXFQDNLEN || ! (aip = php_network_getaddrinfo(string))) {
+		if (strlen(string) > MAXFQDNLEN || ! (aip = php_network_getaddrinfo(string, AF_INET))) {
 			/* Note: < -10000 indicates a host lookup error */
 #ifdef PHP_WIN32
 			PHP_SOCKET_ERROR(php_sock, "Host lookup failed", WSAGetLastError());

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -230,9 +230,9 @@ static int php_open_listen_sock(php_socket *sock, int port, int backlog) /* {{{ 
 	struct addrinfo		*aip;
 
 #ifndef PHP_WIN32
-	if ((aip = php_network_getaddrinfo("0.0.0.0")) == NULL) {
+	if ((aip = php_network_getaddrinfo("0.0.0.0", AF_INET)) == NULL) {
 #else
-	if ((aip = php_network_getaddrinfo("localhost")) == NULL) {
+	if ((aip = php_network_getaddrinfo("localhost", AF_INET)) == NULL) {
 #endif
 		return 0;
 	}

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -237,7 +237,7 @@ static int php_open_listen_sock(php_socket *sock, int port, int backlog) /* {{{ 
 		return 0;
 	}
 
-	memcpy((char *) &la.sin_addr, aip->ai_addr, aip->ai_addrlen);
+	memcpy((char *) &la.sin_addr, &((struct sockaddr_in *) aip->ai_addr)->sin_addr, sizeof(la.sin_addr));
 	la.sin_family = aip->ai_family;
 	la.sin_port = htons((unsigned short) port);
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -227,18 +227,18 @@ int inet_ntoa_lock = 0;
 static int php_open_listen_sock(php_socket *sock, int port, int backlog) /* {{{ */
 {
 	struct sockaddr_in  la;
-	struct hostent		*hp;
+	struct addrinfo		*aip;
 
 #ifndef PHP_WIN32
-	if ((hp = php_network_gethostbyname("0.0.0.0")) == NULL) {
+	if ((aip = php_network_getaddrinfo("0.0.0.0")) == NULL) {
 #else
-	if ((hp = php_network_gethostbyname("localhost")) == NULL) {
+	if ((aip = php_network_getaddrinfo("localhost")) == NULL) {
 #endif
 		return 0;
 	}
 
-	memcpy((char *) &la.sin_addr, hp->h_addr, hp->h_length);
-	la.sin_family = hp->h_addrtype;
+	memcpy((char *) &la.sin_addr, aip->ai_addr, aip->ai_addrlen);
+	la.sin_family = aip->ai_family;
 	la.sin_port = htons((unsigned short) port);
 
 	sock->bsd_socket = socket(PF_INET, SOCK_STREAM, 0);

--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -255,7 +255,7 @@ PHP_FUNCTION(gethostbynamel)
 		RETURN_FALSE;
 	}
 
-	result = php_network_getaddrinfo(hostname);
+	result = php_network_getaddrinfo(hostname, AF_UNSPEC);
 	if (!result) {
 		RETURN_FALSE;
 	}
@@ -290,7 +290,7 @@ static zend_string *php_gethostbyname(char *name)
 	struct in6_addr in6;
 	const char *address;
 
-	result = php_network_getaddrinfo(name);
+	result = php_network_getaddrinfo(name, AF_UNSPEC);
 	if (!result) {
 		return zend_string_init(name, strlen(name), 0);
 	}

--- a/ext/standard/tests/network/gethostbyname_basic003.phpt
+++ b/ext/standard/tests/network/gethostbyname_basic003.phpt
@@ -6,6 +6,6 @@ echo "*** Testing gethostbyname() : basic functionality ***\n";
 
 echo gethostbyname("localhost")."\n";
 ?>
---EXPECTF--
-*** Testing gethostbyname() : basic functionality ***
-127.0.%d.1
+--EXPECTREGEX--
+\*\*\* Testing gethostbyname\(\) : basic functionality \*\*\*
+(127.0.\d.1|::1)

--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -696,7 +696,7 @@ int fcgi_listen(const char *path, int backlog)
 				} else {
 					aip = php_network_getaddrinfo(host);
 				}
-				if (!aip || aip->ai_family != AF_INET || aip->ai_family != AF_INET6 || !aip->ai_addr) {
+				if (!aip || !aip->ai_addr) {
 					fcgi_log(FCGI_ERROR, "Cannot resolve host name '%s'!\n", host);
 					return -1;
 				} else if (aip->ai_next) {

--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -694,7 +694,7 @@ int fcgi_listen(const char *path, int backlog)
 				if(strlen(host) > MAXFQDNLEN) {
 					aip = NULL;
 				} else {
-					aip = php_network_getaddrinfo(host);
+					aip = php_network_getaddrinfo(host, AF_UNSPEC);
 				}
 				if (!aip || !aip->ai_addr) {
 					fcgi_log(FCGI_ERROR, "Cannot resolve host name '%s'!\n", host);

--- a/main/network.c
+++ b/main/network.c
@@ -1203,11 +1203,11 @@ PHPAPI int php_poll2(php_pollfd *ufds, unsigned int nfds, int timeout)
 }
 #endif
 
- PHPAPI struct addrinfo* php_network_getaddrinfo(const char *name)
+ PHPAPI struct addrinfo* php_network_getaddrinfo(const char *name, const int family)
  {
 	struct addrinfo hints, *result;
     memset(&hints, 0, sizeof(struct addrinfo));
-    hints.ai_family = AF_UNSPEC;
+    hints.ai_family = family;
     hints.ai_socktype = SOCK_DGRAM;
 
     if (getaddrinfo(name, NULL, &hints, &result) != SUCCESS) {

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -326,7 +326,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
 PHPAPI int php_network_parse_network_address_with_port(const char *addr,
 		zend_long addrlen, struct sockaddr *sa, socklen_t *sl);
 
-PHPAPI struct addrinfo*	php_network_getaddrinfo(const char *name);
+PHPAPI struct addrinfo*	php_network_getaddrinfo(const char *name, const int family);
 
 PHPAPI int php_set_sock_blocking(php_socket_t socketd, int block);
 END_EXTERN_C()

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -78,6 +78,10 @@ END_EXTERN_C()
 #include <sys/socket.h>
 #endif
 
+#ifdef HAVE_GETHOSTBYNAME_R
+#include <netdb.h>
+#endif
+
 #ifdef PHP_WIN32
 #include <Ws2tcpip.h>
 #endif

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -78,8 +78,8 @@ END_EXTERN_C()
 #include <sys/socket.h>
 #endif
 
-#ifdef HAVE_GETHOSTBYNAME_R
-#include <netdb.h>
+#ifdef PHP_WIN32
+#include <Ws2tcpip.h>
 #endif
 
 /* These are here, rather than with the win32 counterparts above,
@@ -322,7 +322,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
 PHPAPI int php_network_parse_network_address_with_port(const char *addr,
 		zend_long addrlen, struct sockaddr *sa, socklen_t *sl);
 
-PHPAPI struct hostent*	php_network_gethostbyname(const char *name);
+PHPAPI struct addrinfo*	php_network_getaddrinfo(const char *name);
 
 PHPAPI int php_set_sock_blocking(php_socket_t socketd, int block);
 END_EXTERN_C()


### PR DESCRIPTION
`gethostbyname_r` can return both `AF_INET` and `AF_INET6` addresses, but `php_gethostbyname` will always memcopy the result into an `in_addr` (v4 only) struct.
This PR therefore replaces `php_network_gethostbyname` with `php_network_getaddrinfo` and adjust all references to `php_network_gethostbyname` to now use the new method and cope with the returned struct addrinfo

The original bug can be reproduced by enabling `inet6` in`resolv.conf`, e.g. with Docker: `docker run -it --rm --dns-opt inet6 php sh -c "echo '<?php echo gethostbyname(\"www.google.com\"); echo \"\\n\"; echo gethostbyname(\"downloads.wordpress.org\"); echo \"\\n\"; ?>' | php"` will return
```
42.0.20.80
0.0.0.0
```
See [Bug #78479](https://bugs.php.net/bug.php?id=78479) for more information.

Below you can see how the return values change when resolving a IPv4-only, IPv6-only and dual-stacked hostname. Current state in `master` (41d2785f4d8e069300115f9f16d18eef607488a8):
```
# echo "<?php var_dump(gethostbyname(\"ipv4.lookup.test-ipv6.com\")); ?>" | php
string(13) "176.58.89.223"
# echo "<?php var_dump(gethostbyname(\"ipv6.lookup.test-ipv6.com\")); ?>" | php
string(25) "ipv6.lookup.test-ipv6.com"
# echo "<?php var_dump(gethostbynamel(\"ipv4.lookup.test-ipv6.com\")); ?>" | php
array(2) {
  [0]=>
  string(13) "176.58.89.223"
  [1]=>
  string(15) "216.218.223.250"
}
# echo "<?php var_dump(gethostbynamel(\"ipv6.lookup.test-ipv6.com\")); ?>" | php
bool(false)
# echo "<?php var_dump(gethostbyname(\"google.com\")); ?>" | php
string(13) "172.217.16.78"
# echo "<?php var_dump(gethostbynamel(\"google.com\")); ?>" | php
array(1) {
  [0]=>
  string(13) "172.217.16.78"
}
````
This PR:
```
# echo "<?php var_dump(gethostbyname(\"ipv4.lookup.test-ipv6.com\")); ?>" | ./sapi/cli/php
string(13) "176.58.89.223"
# echo "<?php var_dump(gethostbyname(\"ipv6.lookup.test-ipv6.com\")); ?>" | ./sapi/cli/php
string(17) "2a00:dd80:3c::b3f
# echo "<?php var_dump(gethostbynamel(\"ipv4.lookup.test-ipv6.com\")); ?>" | ./sapi/cli/php
array(2) {
  [0]=>
  string(13) "176.58.89.223"
  [1]=>
  string(15) "216.218.223.250"
}
# echo "<?php var_dump(gethostbynamel(\"ipv6.lookup.test-ipv6.com\")); ?>" | ./sapi/cli/php
array(2) {
  [0]=>
  string(17) "2a00:dd80:3c::b3f"
  [1]=>
  string(22) "2001:470:1:18::223:250"
}
# echo "<?php var_dump(gethostbyname(\"google.com\")); ?>" | ./sapi/cli/php
string(13) "172.217.16.78"
# echo "<?php var_dump(gethostbynamel(\"google.com\")); ?>" | ./sapi/cli/php
array(2) {
  [0]=>
  string(13) "172.217.16.78"
  [1]=>
  string(24) "2a00:1450:4001:830::200e"
}
```
