### PR TITLE
MessageFormatter parse error improvements

### DIFF
--- a/ext/intl/msgformat/msgformat.c
+++ b/ext/intl/msgformat/msgformat.c
@@ -34,6 +34,8 @@ static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 	int         spattern_len = 0;
 	zval*       object;
 	MessageFormatter_object* mfo;
+	UParseError parse_error;
+
 	intl_error_reset( NULL );
 
 	object = return_value;
@@ -74,10 +76,24 @@ static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 	(mfo)->mf_data.orig_format_len = pattern_len;
 
 	/* Create an ICU message formatter. */
-	MSG_FORMAT_OBJECT(mfo) = umsg_open(spattern, spattern_len, locale, NULL, &INTL_DATA_ERROR_CODE(mfo));
+	MSG_FORMAT_OBJECT(mfo) = umsg_open(spattern, spattern_len, locale, &parse_error, &INTL_DATA_ERROR_CODE(mfo));
 
 	if(spattern) {
 		efree(spattern);
+	}
+
+	if (INTL_DATA_ERROR_CODE( mfo ) == U_PATTERN_SYNTAX_ERROR) {
+		char *msg = NULL;
+		smart_str parse_error_str;
+		parse_error_str = intl_parse_error_to_string( &parse_error );
+		spprintf( &msg, 0, "pattern syntax error (%s)", parse_error_str.s? ZSTR_VAL(parse_error_str.s) : "unknown parser error" );
+		smart_str_free( &parse_error_str );
+
+		intl_error_set_code( NULL, INTL_DATA_ERROR_CODE( mfo ) );
+		intl_errors_set_custom_msg( INTL_DATA_ERROR_P( mfo ), msg, 1 );
+
+		efree( msg );
+		return FAILURE;
 	}
 
 	INTL_CTOR_CHECK_STATUS(mfo, "msgfmt_create: message formatter creation failed");
@@ -105,7 +121,9 @@ PHP_METHOD( MessageFormatter, __construct )
 	return_value = ZEND_THIS;
 	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
 		if (!EG(exception)) {
-			zend_throw_exception(IntlException_ce_ptr, "Constructor failed", 0);
+			zend_string *err = intl_error_get_message(NULL);
+			zend_throw_exception(IntlException_ce_ptr, ZSTR_VAL(err), intl_error_get_code(NULL));
+			zend_string_release_ex(err, 0);
 		}
 	}
 	zend_restore_error_handling(&error_handling);

--- a/ext/intl/tests/msgfmt_fail2.phpt
+++ b/ext/intl/tests/msgfmt_fail2.phpt
@@ -126,12 +126,12 @@ ArgumentCountError: msgfmt_create() expects exactly 2 arguments, 1 given in %s o
 ArgumentCountError: MessageFormatter::create() expects exactly 2 arguments, 1 given in %s on line %d
 'U_ZERO_ERROR'
 
-IntlException: Constructor failed in %s on line %d
+IntlException: msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR in %s on line %d
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 
-IntlException: Constructor failed in %s on line %d
+IntlException: msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR in %s on line %d
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
@@ -145,17 +145,17 @@ TypeError: MessageFormatter::create(): Argument #1 ($locale) must be of type str
 TypeError: msgfmt_create(): Argument #1 ($locale) must be of type string, array given in %s on line %d
 'U_ZERO_ERROR'
 
-IntlException: Constructor failed in %s on line %d
+IntlException: pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR in %s on line %d
 'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 
-IntlException: Constructor failed in %s on line %d
+IntlException: msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES in %s on line %d
 'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
 'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
 'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
 
-IntlException: Constructor failed in %s on line %d
+IntlException: msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND in %s on line %d
 'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
 'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
 'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'

--- a/ext/intl/tests/msgfmt_fail2.phpt
+++ b/ext/intl/tests/msgfmt_fail2.phpt
@@ -146,9 +146,9 @@ TypeError: msgfmt_create(): Argument #1 ($locale) must be of type string, array 
 'U_ZERO_ERROR'
 
 IntlException: Constructor failed in %s on line %d
-'msgfmt_create: message formatter creation failed: U_PATTERN_SYNTAX_ERROR'
-'msgfmt_create: message formatter creation failed: U_PATTERN_SYNTAX_ERROR'
-'msgfmt_create: message formatter creation failed: U_PATTERN_SYNTAX_ERROR'
+'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
+'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
+'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 
 IntlException: Constructor failed in %s on line %d
 'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'


### PR DESCRIPTION
Looking into `MessageFormatter` and the underlying ICU pattern documentation, I was blown away by the functionality offered by the patterns that `MessageFormatter` understands. This is incredibly useful and I was totally going to look into making use of this in our main product which already relies on `intl` for number and date formatting, but uses a home-grown solution for message localization.

However, while playing around with this, I came across a usability-issue around `MessageFormatter::formatMessage()` and especially `MessageFormatter::__construct()`:

As the formatting patterns can be pretty complex, it's likely that they contain parsing errors (especially in my case as I was *just* getting into this), so it would be helpful to  get to details of such parsing errors.

Unfortunately, `MessageFormatter::formatMessage()` via `intl_get_error_message()` would just report a generic `U_PATTERN_SYNTAX_ERROR` and, even worse, `MessageFormatter:__construct()` would turn *any* possible internal error into a generic `Constructor failed` error message.

It doesn't have to be that way though: ICU is capable of reporting additional information about a parser error and indeed, the `intl` extension is already making use of this in other places.

So this PR contains two commits that

1. fix the problem for `MessageFormatter::formatMessage()` and `intl_get_error_message()` to report the additional parsing error message (see updated tests)
2. fix `MessageFormatter::__construct()` to report the actual error message rather than a generic "Constructor failed"
