### PR TITLE
Change imap_mail_compose() $body param to $bodies

### DIFF
--- a/ext/imap/php_imap.stub.php
+++ b/ext/imap/php_imap.stub.php
@@ -112,7 +112,7 @@ function imap_mail_copy($imap, string $message_nums, string $mailbox, int $flags
 /** @param resource $imap */
 function imap_mail_move($imap, string $message_nums, string $mailbox, int $flags = 0): bool {}
 
-function imap_mail_compose(array $envelope, array $body): string|false {}
+function imap_mail_compose(array $envelope, array $bodies): string|false {}
 
 /** @param resource $imap */
 function imap_createmailbox($imap, string $mailbox): bool {}

--- a/ext/imap/php_imap_arginfo.h
+++ b/ext/imap/php_imap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 621ebf610e043ce30c981f4c78ab79358c2aaeb9 */
+ * Stub hash: c230b35425ab6b707f22158f2e6176c81d4137e9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_imap_open, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
@@ -137,7 +137,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_mail_compose, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, envelope, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, body, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, bodies, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_createmailbox, 0, 2, _IS_BOOL, 0)


### PR DESCRIPTION
This parameter actually expects an array of bodies, so we should name
it accordingly.