### PR TITLE
Fix #80213: imap_mail_compose() segfaults on certain $bodies

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -3645,6 +3645,7 @@ PHP_FUNCTION(imap_mail_compose)
 				if(Z_TYPE_P(pvalue) == IS_ARRAY) {
 					disp_param = tmp_param = NULL;
 					ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(pvalue), key, disp_data) {
+						if (key == NULL) continue;
 						disp_param = mail_newbody_parameter();
 						disp_param->attribute = cpystr(ZSTR_VAL(key));
 						convert_to_string_ex(disp_data);
@@ -3677,6 +3678,7 @@ PHP_FUNCTION(imap_mail_compose)
 				if (Z_TYPE_P(pvalue) == IS_ARRAY) {
 					disp_param = tmp_param = NULL;
 					ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(pvalue), key, disp_data) {
+						if (key == NULL) continue;
 						disp_param = mail_newbody_parameter();
 						disp_param->attribute = cpystr(ZSTR_VAL(key));
 						convert_to_string_ex(disp_data);
@@ -3745,6 +3747,7 @@ PHP_FUNCTION(imap_mail_compose)
 				if (Z_TYPE_P(pvalue) == IS_ARRAY) {
 					disp_param = tmp_param = NULL;
 					ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(pvalue), key, disp_data) {
+						if (key == NULL) continue;
 						disp_param = mail_newbody_parameter();
 						disp_param->attribute = cpystr(ZSTR_VAL(key));
 						convert_to_string_ex(disp_data);
@@ -3777,6 +3780,7 @@ PHP_FUNCTION(imap_mail_compose)
 				if (Z_TYPE_P(pvalue) == IS_ARRAY) {
 					disp_param = tmp_param = NULL;
 					ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(pvalue), key, disp_data) {
+						if (key == NULL) continue;
 						disp_param = mail_newbody_parameter();
 						disp_param->attribute = cpystr(ZSTR_VAL(key));
 						convert_to_string_ex(disp_data);

--- a/ext/imap/tests/bug80213.phpt
+++ b/ext/imap/tests/bug80213.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #80213 (imap_mail_compose() segfaults on certain $bodies)
+--SKIPIF--
+<?php
+if (!extension_loaded('imap')) die('skip imap extension not available');
+?>
+--FILE--
+<?php
+$envelope = [];
+$body = [[
+    'type.parameters' => ['param'],
+    'disposition' => ['disp'],
+], [
+    'type.parameters' => ['param'],
+    'disposition' => ['disp'],
+]];
+imap_mail_compose($envelope, $body);
+echo "done\n";
+?>
+--EXPECT--
+done


### PR DESCRIPTION
We have to cater to non-associative arrays where the key may be `NULL`;
we just skip these elements.