### PR TITLE
Fix #80215: imap_mail_compose() may modify by-val parameters

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -3544,7 +3544,7 @@ PHP_FUNCTION(imap_mail_compose)
 	int toppart = 0;
 	int first;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "aa", &envelope, &body) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a/a/", &envelope, &body) == FAILURE) {
 		return;
 	}
 
@@ -3602,6 +3602,7 @@ PHP_FUNCTION(imap_mail_compose)
 	if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(envelope), "custom_headers", sizeof("custom_headers") - 1)) != NULL) {
 		if (Z_TYPE_P(pvalue) == IS_ARRAY) {
 			custom_headers_param = tmp_param = NULL;
+			SEPARATE_ARRAY(pvalue);
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(pvalue), env_data) {
 				custom_headers_param = mail_newbody_parameter();
 				convert_to_string_ex(env_data);
@@ -3623,6 +3624,7 @@ PHP_FUNCTION(imap_mail_compose)
 				php_error_docref(NULL, E_WARNING, "body parameter must be a non-empty array");
 				RETURN_FALSE;
 			}
+			SEPARATE_ARRAY(data);
 
 			bod = mail_newbody();
 			topbod = bod;
@@ -3644,6 +3646,7 @@ PHP_FUNCTION(imap_mail_compose)
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type.parameters", sizeof("type.parameters") - 1)) != NULL) {
 				if(Z_TYPE_P(pvalue) == IS_ARRAY) {
 					disp_param = tmp_param = NULL;
+					SEPARATE_ARRAY(pvalue);
 					ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(pvalue), key, disp_data) {
 						disp_param = mail_newbody_parameter();
 						disp_param->attribute = cpystr(ZSTR_VAL(key));
@@ -3676,6 +3679,7 @@ PHP_FUNCTION(imap_mail_compose)
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition", sizeof("disposition") - 1)) != NULL) {
 				if (Z_TYPE_P(pvalue) == IS_ARRAY) {
 					disp_param = tmp_param = NULL;
+					SEPARATE_ARRAY(pvalue);
 					ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(pvalue), key, disp_data) {
 						disp_param = mail_newbody_parameter();
 						disp_param->attribute = cpystr(ZSTR_VAL(key));
@@ -3710,6 +3714,7 @@ PHP_FUNCTION(imap_mail_compose)
 			}
 		} else if (Z_TYPE_P(data) == IS_ARRAY) {
 			short type = -1;
+			SEPARATE_ARRAY(data);
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type", sizeof("type") - 1)) != NULL) {
 				type = (short) zval_get_long(pvalue);
 			}
@@ -3744,6 +3749,7 @@ PHP_FUNCTION(imap_mail_compose)
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type.parameters", sizeof("type.parameters") - 1)) != NULL) {
 				if (Z_TYPE_P(pvalue) == IS_ARRAY) {
 					disp_param = tmp_param = NULL;
+					SEPARATE_ARRAY(pvalue);
 					ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(pvalue), key, disp_data) {
 						disp_param = mail_newbody_parameter();
 						disp_param->attribute = cpystr(ZSTR_VAL(key));
@@ -3776,6 +3782,7 @@ PHP_FUNCTION(imap_mail_compose)
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition", sizeof("disposition") - 1)) != NULL) {
 				if (Z_TYPE_P(pvalue) == IS_ARRAY) {
 					disp_param = tmp_param = NULL;
+					SEPARATE_ARRAY(pvalue);
 					ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(pvalue), key, disp_data) {
 						disp_param = mail_newbody_parameter();
 						disp_param->attribute = cpystr(ZSTR_VAL(key));

--- a/ext/imap/tests/bug80215.phpt
+++ b/ext/imap/tests/bug80215.phpt
@@ -1,0 +1,69 @@
+--TEST--
+Bug #80215 (imap_mail_compose() may modify by-val parameters)
+--SKIPIF--
+<?php
+if (!extension_loaded('imap')) die('skip imap extension not available');
+?>
+--FILE--
+<?php
+$envelope = [
+    "from" => 1,
+    "to" => 2,
+    "custom_headers" => [3],
+];
+$body = [[
+    "contents.data" => 4,
+    "type.parameters" => ['foo' => 5],
+    "disposition" => ['bar' => 6],
+], [
+    "contents.data" => 7,
+    "type.parameters" => ['foo' => 8],
+    "disposition" => ['bar' => 9],
+]];
+imap_mail_compose($envelope, $body);
+var_dump($envelope, $body);
+?>
+--EXPECT--
+array(3) {
+  ["from"]=>
+  int(1)
+  ["to"]=>
+  int(2)
+  ["custom_headers"]=>
+  array(1) {
+    [0]=>
+    int(3)
+  }
+}
+array(2) {
+  [0]=>
+  array(3) {
+    ["contents.data"]=>
+    int(4)
+    ["type.parameters"]=>
+    array(1) {
+      ["foo"]=>
+      int(5)
+    }
+    ["disposition"]=>
+    array(1) {
+      ["bar"]=>
+      int(6)
+    }
+  }
+  [1]=>
+  array(3) {
+    ["contents.data"]=>
+    int(7)
+    ["type.parameters"]=>
+    array(1) {
+      ["foo"]=>
+      int(8)
+    }
+    ["disposition"]=>
+    array(1) {
+      ["bar"]=>
+      int(9)
+    }
+  }
+}


### PR DESCRIPTION
We separate the input arrays and all sub-arrays to avoid modification
of the passed parameters.

This should be rewritten to use `zend_string`s for the "master" branch.