### PR TITLE
Bump minimal OpenSSL version to 1.0.2

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1903,7 +1903,7 @@ dnl
 AC_DEFUN([PHP_SETUP_OPENSSL],[
   found_openssl=no
 
-  PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.1], [found_openssl=yes])
+  PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.2], [found_openssl=yes])
 
   if test "$found_openssl" = "yes"; then
     PHP_EVAL_LIBLINE($OPENSSL_LIBS, $1)

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -1,7 +1,7 @@
 PHP_ARG_WITH([openssl],
   [for OpenSSL support],
   [AS_HELP_STRING([--with-openssl],
-    [Include OpenSSL support (requires OpenSSL >= 1.0.1)])])
+    [Include OpenSSL support (requires OpenSSL >= 1.0.2)])])
 
 PHP_ARG_WITH([kerberos],
   [for Kerberos support],

--- a/ext/openssl/php_openssl.h
+++ b/ext/openssl/php_openssl.h
@@ -35,9 +35,7 @@ extern zend_module_entry openssl_module_entry;
 #endif
 #else
 /* OpenSSL version check */
-#if OPENSSL_VERSION_NUMBER < 0x10002000L
-#define PHP_OPENSSL_API_VERSION 0x10001
-#elif OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define PHP_OPENSSL_API_VERSION 0x10002
 #else
 #define PHP_OPENSSL_API_VERSION 0x10100

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -33,11 +33,8 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
-
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
 #include <openssl/bn.h>
 #include <openssl/dh.h>
-#endif
 
 #ifdef PHP_WIN32
 #include "win32/winutil.h"
@@ -80,9 +77,7 @@
 
 #ifndef OPENSSL_NO_TLSEXT
 #define HAVE_TLS_SNI 1
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
 #define HAVE_TLS_ALPN 1
-#endif
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
@@ -1294,12 +1289,8 @@ static int php_openssl_set_server_ecdh_curve(php_stream *stream, SSL_CTX *ctx) /
 
 	zvcurve = php_stream_context_get_option(PHP_STREAM_CONTEXT(stream), "ssl", "ecdh_curve");
 	if (zvcurve == NULL) {
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
 		SSL_CTX_set_ecdh_auto(ctx, 1);
 		return SUCCESS;
-#else
-		curve_nid = NID_X9_62_prime256v1;
-#endif
 	} else {
 		if (!try_convert_to_string(zvcurve)) {
 			return FAILURE;


### PR DESCRIPTION
This PR drops support for OpenSSL 1.0.1. It means that the new minimal version is 1.0.2.