### PR TITLE
Remove return types from XMLWriter stubs

### DIFF
--- a/ext/xmlwriter/php_xmlwriter.stub.php
+++ b/ext/xmlwriter/php_xmlwriter.stub.php
@@ -88,129 +88,255 @@ function xmlwriter_flush(XMLWriter $writer, bool $empty = true): string|int {}
 
 class XMLWriter
 {
-    /** @alias xmlwriter_open_uri */
-    public function openUri(string $uri): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_open_uri
+     */
+    public function openUri(string $uri) {}
 
-    /** @alias xmlwriter_open_memory */
-    public function openMemory(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_open_memory
+     */
+    public function openMemory() {}
 
-    /** @alias xmlwriter_set_indent */
-    public function setIndent(bool $enable): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_set_indent
+     */
+    public function setIndent(bool $enable) {}
 
-    /** @alias xmlwriter_set_indent_string */
-    public function setIndentString(string $indentation): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_set_indent_string
+     */
+    public function setIndentString(string $indentation) {}
 
-    /** @alias xmlwriter_start_comment */
-    public function startComment(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_comment
+     */
+    public function startComment() {}
 
-    /** @alias xmlwriter_end_comment */
-    public function endComment(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_comment
+     */
+    public function endComment() {}
 
-    /** @alias xmlwriter_start_attribute */
-    public function startAttribute(string $name): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_attribute
+     */
+    public function startAttribute(string $name) {}
 
-    /** @alias xmlwriter_end_attribute */
-    public function endAttribute(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_attribute
+     */
+    public function endAttribute() {}
 
-    /** @alias xmlwriter_write_attribute */
-    public function writeAttribute(string $name, string $value): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_attribute
+     */
+    public function writeAttribute(string $name, string $value) {}
 
-    /** @alias xmlwriter_start_attribute_ns */
-    public function startAttributeNs(?string $prefix, string $name, ?string $namespace): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_attribute_ns
+     */
+    public function startAttributeNs(?string $prefix, string $name, ?string $namespace) {}
 
-    /** @alias xmlwriter_write_attribute_ns */
-    public function writeAttributeNs(?string $prefix, string $name, ?string $namespace, string $value): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_attribute_ns
+     */
+    public function writeAttributeNs(?string $prefix, string $name, ?string $namespace, string $value) {}
 
-    /** @alias xmlwriter_start_element */
-    public function startElement(string $name): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_element
+     */
+    public function startElement(string $name) {}
 
-    /** @alias xmlwriter_end_element */
-    public function endElement(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_element
+     */
+    public function endElement() {}
 
-    /** @alias xmlwriter_full_end_element */
-    public function fullEndElement(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_full_end_element
+     */
+    public function fullEndElement() {}
 
-    /** @alias xmlwriter_start_element_ns */
-    public function startElementNs(?string $prefix, string $name, ?string $namespace): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_element_ns
+     */
+    public function startElementNs(?string $prefix, string $name, ?string $namespace) {}
 
-    /** @alias xmlwriter_write_element */
-    public function writeElement(string $name, ?string $content = null): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_element
+     */
+    public function writeElement(string $name, ?string $content = null) {}
 
-    /** @alias xmlwriter_write_element_ns */
-    public function writeElementNs(?string $prefix, string $name, ?string $namespace, ?string $content = null): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_element_ns
+     */
+    public function writeElementNs(?string $prefix, string $name, ?string $namespace, ?string $content = null) {}
 
-    /** @alias xmlwriter_start_pi */
-    public function startPi(string $target): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_pi
+     */
+    public function startPi(string $target) {}
 
-    /** @alias xmlwriter_end_pi */
-    public function endPi(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_pi
+     */
+    public function endPi() {}
 
-    /** @alias xmlwriter_write_pi */
-    public function writePi(string $target, string $content): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_pi
+     */
+    public function writePi(string $target, string $content) {}
 
-    /** @alias xmlwriter_start_cdata */
-    public function startCdata(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_cdata
+     */
+    public function startCdata() {}
 
-    /** @alias xmlwriter_end_cdata */
-    public function endCdata(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_cdata
+     * */
+    public function endCdata() {}
 
-    /** @alias xmlwriter_write_cdata */
-    public function writeCdata(string $content): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_cdata
+     */
+    public function writeCdata(string $content) {}
 
-    /** @alias xmlwriter_text */
-    public function text(string $content): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_text
+     */
+    public function text(string $content) {}
 
-    /** @alias xmlwriter_write_raw */
-    public function writeRaw(string $content): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_raw
+     */
+    public function writeRaw(string $content) {}
 
-    /** @alias xmlwriter_start_document */
-    public function startDocument(?string $version = "1.0", ?string $encoding = null, ?string $standalone = null): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_document
+     */
+    public function startDocument(?string $version = "1.0", ?string $encoding = null, ?string $standalone = null) {}
 
-    /** @alias xmlwriter_end_document */
-    public function endDocument(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_document
+     */
+    public function endDocument() {}
 
-    /** @alias xmlwriter_write_comment */
-    public function writeComment(string $content): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_comment
+     */
+    public function writeComment(string $content) {}
 
-    /** @alias xmlwriter_start_dtd */
-    public function startDtd(string $qualifiedName, ?string $publicId = null, ?string $systemId = null): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_dtd
+     */
+    public function startDtd(string $qualifiedName, ?string $publicId = null, ?string $systemId = null) {}
 
-    /** @alias xmlwriter_end_dtd */
-    public function endDtd(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_dtd
+     */
+    public function endDtd() {}
 
-    /** @alias xmlwriter_write_dtd */
-    public function writeDtd(string $name, ?string $publicId = null, ?string $systemId = null, ?string $content = null): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_dtd
+     */
+    public function writeDtd(string $name, ?string $publicId = null, ?string $systemId = null, ?string $content = null) {}
 
-    /** @alias xmlwriter_start_dtd_element */
-    public function startDtdElement(string $qualifiedName): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_dtd_element
+     */
+    public function startDtdElement(string $qualifiedName) {}
 
-    /** @alias xmlwriter_end_dtd_element */
-    public function endDtdElement(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_dtd_element
+     */
+    public function endDtdElement() {}
 
-    /** @alias xmlwriter_write_dtd_element */
-    public function writeDtdElement(string $name, string $content): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_dtd_element
+     */
+    public function writeDtdElement(string $name, string $content) {}
 
-    /** @alias xmlwriter_start_dtd_attlist */
-    public function startDtdAttlist(string $name): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_dtd_attlist
+     */
+    public function startDtdAttlist(string $name) {}
 
-    /** @alias xmlwriter_end_dtd_attlist */
-    public function endDtdAttlist(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_dtd_attlist
+     */
+    public function endDtdAttlist() {}
 
-    /** @alias xmlwriter_write_dtd_attlist */
-    public function writeDtdAttlist(string $name, string $content): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_dtd_attlist
+     */
+    public function writeDtdAttlist(string $name, string $content) {}
 
-    /** @alias xmlwriter_start_dtd_entity */
-    public function startDtdEntity(string $name, bool $isParam): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_start_dtd_entity
+     */
+    public function startDtdEntity(string $name, bool $isParam) {}
 
-    /** @alias xmlwriter_end_dtd_entity */
-    public function endDtdEntity(): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_end_dtd_entity
+     */
+    public function endDtdEntity() {}
 
-    /** @alias xmlwriter_write_dtd_entity */
-    public function writeDtdEntity(string $name, string $content, bool $isParam = false, ?string $publicId = null, ?string $systemId = null, ?string $notationData = null): bool {}
+    /**
+     * @return bool
+     * @alias xmlwriter_write_dtd_entity
+     */
+    public function writeDtdEntity(string $name, string $content, bool $isParam = false, ?string $publicId = null, ?string $systemId = null, ?string $notationData = null) {}
 
-    /** @alias xmlwriter_output_memory */
-    public function outputMemory(bool $flush = true): string {}
+    /**
+     * @return string
+     * @alias xmlwriter_output_memory
+     */
+    public function outputMemory(bool $flush = true) {}
 
-    /** @alias xmlwriter_flush */
-    public function flush(bool $empty = true): string|int {}
+    /**
+     * @return string|int
+     * @alias xmlwriter_flush
+     */
+    public function flush(bool $empty = true) {}
 }

--- a/ext/xmlwriter/php_xmlwriter_arginfo.h
+++ b/ext/xmlwriter/php_xmlwriter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 891054e4aaf1d24b0965828de8287392b6a389a3 */
+ * Stub hash: df2a62a48636bd2c7b1e62ac28480ae27233f100 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_xmlwriter_open_uri, 0, 1, XMLWriter, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
@@ -175,18 +175,18 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_xmlwriter_flush, 0, 1, MAY_BE_ST
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, empty, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_openUri, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_openUri, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_openMemory, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_openMemory, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_setIndent, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_setIndent, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_setIndentString, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_setIndentString, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, indentation, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -194,24 +194,24 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_endComment arginfo_class_XMLWriter_openMemory
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startAttribute, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_startAttribute, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_endAttribute arginfo_class_XMLWriter_openMemory
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeAttribute, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writeAttribute, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startAttributeNs, 0, 3, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_startAttributeNs, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeAttributeNs, 0, 4, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writeAttributeNs, 0, 0, 4)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 1)
@@ -226,25 +226,25 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_startElementNs arginfo_class_XMLWriter_startAttributeNs
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeElement, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writeElement, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, content, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeElementNs, 0, 3, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writeElementNs, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, namespace, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, content, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startPi, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_startPi, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_endPi arginfo_class_XMLWriter_openMemory
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writePi, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writePi, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -253,7 +253,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_endCdata arginfo_class_XMLWriter_openMemory
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeCdata, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writeCdata, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -261,7 +261,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_writeRaw arginfo_class_XMLWriter_writeCdata
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startDocument, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_startDocument, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, version, IS_STRING, 1, "\"1.0\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, standalone, IS_STRING, 1, "null")
@@ -271,7 +271,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_writeComment arginfo_class_XMLWriter_writeCdata
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startDtd, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_startDtd, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, publicId, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, systemId, IS_STRING, 1, "null")
@@ -279,20 +279,20 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_endDtd arginfo_class_XMLWriter_openMemory
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeDtd, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writeDtd, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, publicId, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, systemId, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, content, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startDtdElement, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_startDtdElement, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, qualifiedName, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_endDtdElement arginfo_class_XMLWriter_openMemory
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeDtdElement, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writeDtdElement, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -303,14 +303,14 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_writeDtdAttlist arginfo_class_XMLWriter_writeDtdElement
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_startDtdEntity, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_startDtdEntity, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, isParam, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_XMLWriter_endDtdEntity arginfo_class_XMLWriter_openMemory
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeDtdEntity, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_writeDtdEntity, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, isParam, _IS_BOOL, 0, "false")
@@ -319,11 +319,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_writeDtdEntity, 
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, notationData, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_XMLWriter_outputMemory, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_outputMemory, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flush, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_XMLWriter_flush, 0, 0, MAY_BE_STRING|MAY_BE_LONG)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_XMLWriter_flush, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, empty, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
These break BC, and as such we have to stick with docblock annotations.