### PR TITLE
Fix #80223: imap_mail_compose() leaks envelope on malformed bodies

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -3622,7 +3622,8 @@ PHP_FUNCTION(imap_mail_compose)
 
 			if (Z_TYPE_P(data) != IS_ARRAY) {
 				php_error_docref(NULL, E_WARNING, "body parameter must be a non-empty array");
-				RETURN_FALSE;
+				RETVAL_FALSE;
+				goto done;
 			}
 			SEPARATE_ARRAY(data);
 
@@ -3824,7 +3825,8 @@ PHP_FUNCTION(imap_mail_compose)
 
 	if (first) {
 		php_error_docref(NULL, E_WARNING, "body parameter must be a non-empty array");
-		RETURN_FALSE;
+		RETVAL_FALSE;
+		goto done;
 	}
 
 	if (bod && bod->type == TYPEMULTIPART && (!bod->nested.part || !bod->nested.part->next)) {

--- a/ext/imap/tests/bug80223.phpt
+++ b/ext/imap/tests/bug80223.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #80223 (imap_mail_compose() leaks envelope on malformed bodies)
+--SKIPIF--
+<?php
+if (!extension_loaded('imap')) die('skip imap extension not available');
+?>
+--FILE--
+<?php
+imap_mail_compose([], []);
+imap_mail_compose([], [1]);
+?>
+--EXPECTF--
+Warning: imap_mail_compose(): body parameter must be a non-empty array in %s on line %d
+
+Warning: imap_mail_compose(): body parameter must be a non-empty array in %s on line %d


### PR DESCRIPTION
We have to clean up even on failure.