### PR TITLE
Fix #80216: imap_mail_compose() does not validate types/encodings

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -3630,10 +3630,16 @@ PHP_FUNCTION(imap_mail_compose)
 			topbod = bod;
 
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type", sizeof("type") - 1)) != NULL) {
-				bod->type = (short) zval_get_long(pvalue);
+				zend_long type = zval_get_long(pvalue);
+				if (type >= 0 && type <= TYPEMAX && body_types[type] != NULL) {
+					bod->type = (short) type;
+				}
 			}
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "encoding", sizeof("encoding") - 1)) != NULL) {
-				bod->encoding = (short) zval_get_long(pvalue);
+				zend_long encoding = zval_get_long(pvalue);
+				if (encoding >= 0 && encoding <= ENCMAX && body_encodings[encoding] != NULL) {
+					bod->encoding = (short) encoding;
+				}
 			}
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "charset", sizeof("charset") - 1)) != NULL) {
 				convert_to_string_ex(pvalue);
@@ -3715,10 +3721,13 @@ PHP_FUNCTION(imap_mail_compose)
 				bod->md5 = cpystr(Z_STRVAL_P(pvalue));
 			}
 		} else if (Z_TYPE_P(data) == IS_ARRAY && topbod->type == TYPEMULTIPART) {
-			short type = -1;
+			short type = 0;
 			SEPARATE_ARRAY(data);
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type", sizeof("type") - 1)) != NULL) {
-				type = (short) zval_get_long(pvalue);
+				zend_long tmp_type = zval_get_long(pvalue);
+				if (tmp_type >= 0 && tmp_type <= TYPEMAX && tmp_type != TYPEMULTIPART && body_types[tmp_type] != NULL) {
+					type = (short) tmp_type;
+				}
 			}
 
 			if (!toppart) {
@@ -3731,13 +3740,13 @@ PHP_FUNCTION(imap_mail_compose)
 			}
 
 			bod = &mypart->body;
-
-			if (type != TYPEMULTIPART) {
-				bod->type = type;
-			}
+			bod->type = type;
 
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "encoding", sizeof("encoding") - 1)) != NULL) {
-				bod->encoding = (short) zval_get_long(pvalue);
+				zend_long encoding = zval_get_long(pvalue);
+				if (encoding >= 0 && encoding <= ENCMAX && body_encodings[encoding] != NULL) {
+					bod->encoding = (short) encoding;
+				}
 			}
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "charset", sizeof("charset") - 1)) != NULL) {
 				convert_to_string_ex(pvalue);

--- a/ext/imap/tests/bug80216.phpt
+++ b/ext/imap/tests/bug80216.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #80216 (imap_mail_compose() does not validate types/encodings)
+--SKIPIF--
+<?php
+if (!extension_loaded('imap')) die('skip imap extension not available');
+?>
+--FILE--
+<?php
+imap_mail_compose([], [['type' => TYPEMULTIPART], []]);
+imap_mail_compose([], [['type' => 12]]);
+imap_mail_compose([], [['type' => TYPEMULTIPART], ['type' => 12]]);
+imap_mail_compose([], [['encoding' => 8]]);
+imap_mail_compose([], [['type' => TYPEMULTIPART], ['encoding' => 8]]);
+echo "done\n";
+?>
+--EXPECT--
+done


### PR DESCRIPTION
We need to check whether the given `type`s and `encoding`s are within
bounds to avoid segfaults and out-of-bound reads.

---

This is ugly. In order to detect whether the custom types and encodings are actually supported, we have to access the global `body_types` and `body_encodings` which are declared in mail.h, but not be exported. There is no issue on Windows, because libc-client is linked statically (at least with the official dependencies), but otherwise this patch may not even build.