### PR TITLE
in version 3 xdebug removed xdebug.default_enable

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -885,7 +885,7 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         'session' => ['session.auto_start=0'],
         'tidy' => ['tidy.clean_output=0'],
         'zlib' => ['zlib.output_compression=Off'],
-        'xdebug' => ['xdebug.default_enable=0','xdebug.mode=off'],
+        'xdebug' => ['xdebug.mode=off'],
         'mbstring' => ['mbstring.func_overload=0'],
     ];
 


### PR DESCRIPTION
see https://3.xdebug.org/docs/upgrade_guide