### PR TITLE
MessageFormatter parse error improvements (PHP-7.4 edition)

### DIFF
--- a/ext/intl/msgformat/msgformat_format.c
+++ b/ext/intl/msgformat/msgformat_format.c
@@ -94,6 +94,7 @@ PHP_FUNCTION( msgfmt_format_message )
 	size_t      slocale_len = 0;
 	MessageFormatter_object mf;
 	MessageFormatter_object *mfo = &mf;
+	UParseError parse_error;
 
 	/* Parse parameters. */
 	if( zend_parse_method_parameters( ZEND_NUM_ARGS(), getThis(), "ssa",
@@ -136,10 +137,25 @@ PHP_FUNCTION( msgfmt_format_message )
 #endif
 
 	/* Create an ICU message formatter. */
-	MSG_FORMAT_OBJECT(mfo) = umsg_open(spattern, spattern_len, slocale, NULL, &INTL_DATA_ERROR_CODE(mfo));
+	MSG_FORMAT_OBJECT(mfo) = umsg_open(spattern, spattern_len, slocale, &parse_error, &INTL_DATA_ERROR_CODE(mfo));
 	if(spattern && spattern_len) {
 		efree(spattern);
 	}
+
+	if (INTL_DATA_ERROR_CODE( mfo ) == U_PATTERN_SYNTAX_ERROR) {
+		char *msg = NULL;
+		smart_str parse_error_str;
+		parse_error_str = intl_parse_error_to_string( &parse_error );
+		spprintf( &msg, 0, "pattern syntax error (%s)", parse_error_str.s? ZSTR_VAL(parse_error_str.s) : "unknown parser error" );
+		smart_str_free( &parse_error_str );
+
+		intl_error_set_code( NULL, INTL_DATA_ERROR_CODE( mfo ) );
+		intl_errors_set_custom_msg( INTL_DATA_ERROR_P( mfo ), msg, 1 );
+
+		efree( msg );
+		RETURN_FALSE;
+	}
+
 	INTL_METHOD_CHECK_STATUS(mfo, "Creating message formatter failed");
 
 	msgfmt_do_format(mfo, args, return_value);

--- a/ext/intl/tests/msgfmt_fail2.phpt
+++ b/ext/intl/tests/msgfmt_fail2.phpt
@@ -96,12 +96,12 @@ Warning: msgfmt_create() expects exactly 2 parameters, 1 given in %s on line %d
 Warning: MessageFormatter::create() expects exactly 2 parameters, 1 given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
-IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
+IntlException: msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR in %s on line %d
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 
-IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
+IntlException: msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR in %s on line %d
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
 'msgfmt_create: message formatter creation failed: U_ILLEGAL_ARGUMENT_ERROR'
@@ -115,17 +115,17 @@ Warning: MessageFormatter::create() expects parameter 1 to be string, array give
 Warning: msgfmt_create() expects parameter 1 to be string, array given in %s on line %d
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
-IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
+IntlException: pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR in %s on line %d
 'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 
-IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
+IntlException: msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES in %s on line %d
 'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
 'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
 'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'
 
-IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
+IntlException: msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND in %s on line %d
 'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
 'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'
 'msgfmt_create: error converting pattern to UTF-16: U_INVALID_CHAR_FOUND'

--- a/ext/intl/tests/msgfmt_fail2.phpt
+++ b/ext/intl/tests/msgfmt_fail2.phpt
@@ -116,9 +116,9 @@ Warning: msgfmt_create() expects parameter 1 to be string, array given in %s on 
 'msgfmt_create: unable to parse input parameters: U_ILLEGAL_ARGUMENT_ERROR'
 
 IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
-'msgfmt_create: message formatter creation failed: U_PATTERN_SYNTAX_ERROR'
-'msgfmt_create: message formatter creation failed: U_PATTERN_SYNTAX_ERROR'
-'msgfmt_create: message formatter creation failed: U_PATTERN_SYNTAX_ERROR'
+'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
+'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
+'pattern syntax error (parse error at offset 1, after "{", before or at "0,choice}"): U_PATTERN_SYNTAX_ERROR'
 
 IntlException: Constructor failed in %smsgfmt_fail2.php on line %d
 'msgfmt_create: message formatter creation failed: U_UNMATCHED_BRACES'


### PR DESCRIPTION
This is the PHP 7.4 version of #6306, targeting `PHP-7.4` as @nikic said in the other PR that this might possibly go into 7.4.

There were a few minor conflicts which I have fixed as part of this rebase.

Feel free to close whichever of the two PRs you don't want to merge.