### PR TITLE
Fix #80226: imap_sort() leaks sortpgm memory

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -3189,6 +3189,7 @@ PHP_FUNCTION(imap_sort)
 
 	slst = mail_sort(imap_le_struct->imap_stream, (argc == 6 ? ZSTR_VAL(charset) : NIL), spg, mypgm, (argc >= 4 ? flags : NIL));
 
+	mail_free_sortpgm(&mypgm);
 	if (spg && !(flags & SE_FREE)) {
 		mail_free_searchpgm(&spg);
 	}

--- a/ext/imap/tests/bug80226.phpt
+++ b/ext/imap/tests/bug80226.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #80226 (imap_sort() leaks sortpgm memory)
+--SKIPIF--
+<?php
+require_once(__DIR__.'/skipif.inc');
+?>
+--FILE--
+<?php
+require_once(__DIR__.'/imap_include.inc');
+$stream = imap_open($default_mailbox, $username, $password);
+imap_sort($stream, SORTFROM, 0);
+?>
+--EXPECT--


### PR DESCRIPTION
We need to free what we have allocated.