### PR TITLE
Change parameters types from int to bool

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -2700,14 +2700,15 @@ PHP_FUNCTION(imap_sort)
 {
 	zval *streamind;
 	zend_string *criteria = NULL, *charset = NULL;
-	zend_long sort, rev, flags = 0;
+	zend_long sort, flags = 0;
+	zend_bool rev;
 	pils *imap_le_struct;
 	unsigned long *slst, *sl;
 	char *search_criteria;
 	SORTPGM *mypgm=NIL;
 	SEARCHPGM *spg=NIL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rll|lS!S!", &streamind, &sort, &rev, &flags, &criteria, &charset) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rlb|lS!S!", &streamind, &sort, &rev, &flags, &criteria, &charset) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/ext/imap/php_imap.stub.php
+++ b/ext/imap/php_imap.stub.php
@@ -173,7 +173,7 @@ function imap_setflag_full($imap, string $sequence, string $flag, int $options =
 function imap_clearflag_full($imap, string $sequence, string $flag, int $options = 0): bool {}
 
 /** @param resource $imap */
-function imap_sort($imap, int $criteria, int $reverse, int $flags = 0, ?string $search_criteria = null, ?string $charset = null): array|false {}
+function imap_sort($imap, int $criteria, bool $reverse, int $flags = 0, ?string $search_criteria = null, ?string $charset = null): array|false {}
 
 /** @param resource $imap */
 function imap_uid($imap, int $message_num): int|false {}

--- a/ext/imap/php_imap_arginfo.h
+++ b/ext/imap/php_imap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c230b35425ab6b707f22158f2e6176c81d4137e9 */
+ * Stub hash: 326cb0410034aecc702e9397cd88ef91adaa254c */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_imap_open, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
@@ -207,7 +207,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_sort, 0, 3, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, imap)
 	ZEND_ARG_TYPE_INFO(0, criteria, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, reverse, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, reverse, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, search_criteria, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, charset, IS_STRING, 1, "null")

--- a/ext/odbc/odbc.stub.php
+++ b/ext/odbc/odbc.stub.php
@@ -108,7 +108,7 @@ function odbc_field_scale($result_id, int $field_number): int|false {}
 function odbc_field_num($result_id, string $field_name): int|false {}
 
 /** @param resource $connection_id */
-function odbc_autocommit($connection_id, int $onoff = 0): int|bool {}
+function odbc_autocommit($connection_id, bool $onoff = false): int|bool {}
 
 /** @param resource $connection_id */
 function odbc_commit($connection_id): bool {}

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 53069f42e460cfea8e2daf499277f6ceb9c760f7 */
+ * Stub hash: bdf94bcc0fd30c5b08aa80ecc6c2ff8ca6de3e62 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_close_all, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
@@ -126,7 +126,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_odbc_autocommit, 0, 1, MAY_BE_LONG|MAY_BE_BOOL)
 	ZEND_ARG_INFO(0, connection_id)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, onoff, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, onoff, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_odbc_commit, 0, 1, _IS_BOOL, 0)

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2521,9 +2521,9 @@ PHP_FUNCTION(odbc_autocommit)
 	odbc_connection *conn;
 	RETCODE rc;
 	zval *pv_conn;
-	zend_long pv_onoff = 0;
+	zend_bool pv_onoff = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|l", &pv_conn, &pv_onoff) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|b", &pv_conn, &pv_onoff) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -2532,7 +2532,7 @@ PHP_FUNCTION(odbc_autocommit)
 	}
 
 	if (ZEND_NUM_ARGS() > 1) {
-		rc = SQLSetConnectOption(conn->hdbc, SQL_AUTOCOMMIT, (pv_onoff) ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF);
+		rc = SQLSetConnectOption(conn->hdbc, SQL_AUTOCOMMIT, pv_onoff ? SQL_AUTOCOMMIT_ON : SQL_AUTOCOMMIT_OFF);
 		if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
 			odbc_sql_error(conn, SQL_NULL_HSTMT, "Set autocommit");
 			RETURN_FALSE;


### PR DESCRIPTION
These are typical boolean parameters, so we shouldn't advertize them as
integers.  For the `$reverse` parameter that even fixes expectations,
because the `reverse` member is a bitfield of 1 bit, so assigning any
even integer would not set it.