### PR TITLE
Use $statement in mysqli

### DIFF
--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -559,10 +559,10 @@ function mysqli_error(mysqli $mysql): ?string {}
 
 function mysqli_error_list(mysqli $mysql): array {}
 
-function mysqli_stmt_execute(mysqli_stmt $stmt): bool {}
+function mysqli_stmt_execute(mysqli_stmt $statement): bool {}
 
 /** @alias mysqli_stmt_execute */
-function mysqli_execute(mysqli_stmt $stmt): bool {}
+function mysqli_execute(mysqli_stmt $statement): bool {}
 
 function mysqli_fetch_field(mysqli_result $result): object|false {}
 
@@ -678,63 +678,63 @@ function mysqli_select_db(mysqli $mysql, string $database): bool {}
 
 function mysqli_set_charset(mysqli $mysql, string $charset): bool {}
 
-function mysqli_stmt_affected_rows(mysqli_stmt $stmt): int|string {}
+function mysqli_stmt_affected_rows(mysqli_stmt $statement): int|string {}
 
-function mysqli_stmt_attr_get(mysqli_stmt $stmt, int $attribute): int {}
+function mysqli_stmt_attr_get(mysqli_stmt $statement, int $attribute): int {}
 
-function mysqli_stmt_attr_set(mysqli_stmt $stmt, int $attribute, int $value): bool {}
+function mysqli_stmt_attr_set(mysqli_stmt $statement, int $attribute, int $value): bool {}
 
-function mysqli_stmt_bind_param(mysqli_stmt $stmt, string $types, mixed &...$vars): bool {}
+function mysqli_stmt_bind_param(mysqli_stmt $statement, string $types, mixed &...$vars): bool {}
 
-function mysqli_stmt_bind_result(mysqli_stmt $stmt, mixed &...$vars): bool {}
+function mysqli_stmt_bind_result(mysqli_stmt $statement, mixed &...$vars): bool {}
 
-function mysqli_stmt_close(mysqli_stmt $stmt): bool {}
+function mysqli_stmt_close(mysqli_stmt $statement): bool {}
 
-function mysqli_stmt_data_seek(mysqli_stmt $stmt, int $offset): void {}
+function mysqli_stmt_data_seek(mysqli_stmt $statement, int $offset): void {}
 
-function mysqli_stmt_errno(mysqli_stmt $stmt): int {}
+function mysqli_stmt_errno(mysqli_stmt $statement): int {}
 
-function mysqli_stmt_error(mysqli_stmt $stmt): ?string {}
+function mysqli_stmt_error(mysqli_stmt $statement): ?string {}
 
-function mysqli_stmt_error_list(mysqli_stmt $stmt): array {}
+function mysqli_stmt_error_list(mysqli_stmt $statement): array {}
 
-function mysqli_stmt_fetch(mysqli_stmt $stmt): ?bool {}
+function mysqli_stmt_fetch(mysqli_stmt $statement): ?bool {}
 
-function mysqli_stmt_field_count(mysqli_stmt $stmt): int {}
+function mysqli_stmt_field_count(mysqli_stmt $statement): int {}
 
-function mysqli_stmt_free_result(mysqli_stmt $stmt): void {}
+function mysqli_stmt_free_result(mysqli_stmt $statement): void {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_stmt_get_result(mysqli_stmt $stmt): mysqli_result|false {}
+function mysqli_stmt_get_result(mysqli_stmt $statement): mysqli_result|false {}
 #endif
 
-function mysqli_stmt_get_warnings(mysqli_stmt $stmt): mysqli_warning|false {}
+function mysqli_stmt_get_warnings(mysqli_stmt $statement): mysqli_warning|false {}
 
 function mysqli_stmt_init(mysqli $mysql): mysqli_stmt|false {}
 
-function mysqli_stmt_insert_id(mysqli_stmt $stmt): int|string {}
+function mysqli_stmt_insert_id(mysqli_stmt $statement): int|string {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_stmt_more_results(mysqli_stmt $stmt): bool {}
+function mysqli_stmt_more_results(mysqli_stmt $statement): bool {}
 
-function mysqli_stmt_next_result(mysqli_stmt $stmt): bool {}
+function mysqli_stmt_next_result(mysqli_stmt $statement): bool {}
 #endif
 
-function mysqli_stmt_num_rows(mysqli_stmt $stmt): int|string {}
+function mysqli_stmt_num_rows(mysqli_stmt $statement): int|string {}
 
-function mysqli_stmt_param_count(mysqli_stmt $stmt): int {}
+function mysqli_stmt_param_count(mysqli_stmt $statement): int {}
 
-function mysqli_stmt_prepare(mysqli_stmt $stmt, string $query): bool {}
+function mysqli_stmt_prepare(mysqli_stmt $statement, string $query): bool {}
 
-function mysqli_stmt_reset(mysqli_stmt $stmt): bool {}
+function mysqli_stmt_reset(mysqli_stmt $statement): bool {}
 
-function mysqli_stmt_result_metadata(mysqli_stmt $stmt): mysqli_result|false {}
+function mysqli_stmt_result_metadata(mysqli_stmt $statement): mysqli_result|false {}
 
-function mysqli_stmt_send_long_data(mysqli_stmt $stmt, int $param_num, string $data): bool {}
+function mysqli_stmt_send_long_data(mysqli_stmt $statement, int $param_num, string $data): bool {}
 
-function mysqli_stmt_store_result(mysqli_stmt $stmt): bool {}
+function mysqli_stmt_store_result(mysqli_stmt $statement): bool {}
 
-function mysqli_stmt_sqlstate(mysqli_stmt $stmt): ?string {}
+function mysqli_stmt_sqlstate(mysqli_stmt $statement): ?string {}
 
 function mysqli_sqlstate(mysqli $mysql): ?string {}
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7687edcf18fa03c0ae95ac4b3d32c196790ba65e */
+ * Stub hash: cc90d40e43462557087c123f0583e7865f281179 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -74,7 +74,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_error_list, 0, 1, IS_ARRA
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_execute, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_execute arginfo_mysqli_stmt_execute
@@ -277,68 +277,68 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_set_charset, 0, 2, _IS_BO
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_stmt_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_attr_get, 0, 2, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, attribute, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_attr_set, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, attribute, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_param, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, types, IS_STRING, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_result, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_close arginfo_mysqli_stmt_execute
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_data_seek, 0, 2, IS_VOID, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_errno, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_error, 0, 1, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_error_list, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_fetch, 0, 1, _IS_BOOL, 1)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_field_count arginfo_mysqli_stmt_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_free_result, 0, 1, IS_VOID, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_get_result, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_get_warnings, 0, 1, mysqli_warning, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_init, 0, 1, mysqli_stmt, MAY_BE_FALSE)
@@ -349,7 +349,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_more_results, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -362,18 +362,18 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_stmt_param_count arginfo_mysqli_stmt_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_prepare, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_reset arginfo_mysqli_stmt_execute
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_result_metadata, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_send_long_data, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, stmt, mysqli_stmt, 0)
+	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, param_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
As we went with $statement rather than $stmts in other places, let's also use it in mysqli. The discrepancy with mysqli_stmt is a bit unfortunate, but we can't be consistent with *both*.

(Also cc @cmb69 with regard to #6303.)