### PR TITLE
Fix #64076: imap_sort() does not return FALSE on failure

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -3181,6 +3181,9 @@ PHP_FUNCTION(imap_sort)
 	} else {
 		spg = mail_newsearchpgm();
 	}
+	if (spg == NIL) {
+		RETURN_FALSE;
+	}
 
 	mypgm = mail_newsortpgm();
 	mypgm->reverse = rev;

--- a/ext/imap/tests/bug64076.phpt
+++ b/ext/imap/tests/bug64076.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #64076 (imap_sort() does not return FALSE on failure)
+--SKIPIF--
+<?php
+require_once __DIR__ . '/skipif.inc';
+?>
+--FILE--
+<?php
+require_once __DIR__ . '/imap_include.inc';
+$stream = setup_test_mailbox('', 2);
+imap_errors(); // clear error stack
+var_dump(imap_sort($stream, SORTFROM, 0, 0, 'UNSUPPORTED SEARCH CRITERIUM'));
+var_dump(imap_errors() !== false);
+?>
+--CLEAN--
+<?php
+require_once __DIR__ . '/clean.inc';
+?>
+--EXPECT--
+Create a temporary mailbox and add 2 msgs
+.. mailbox '{127.0.0.1:143/norsh}INBOX.phpttest' created
+bool(false)
+bool(true)


### PR DESCRIPTION
If unsupported `$search_criteria` are passed to `imap_sort()`, the
function returns an empty array, but there is also an error on the
libc-client error stack ("Unknown search criterion: UNSUPPORTED
(errflg=2)").  If, on the other hand, unsupported `$criteria` or
unsupported `$flags` are passed, the function returns `false`.  We
solve this inconsistency by returning `false` for unsupported
`$search_criteria` as well.

---

I'm unsure about the "details" here. Silently failing is unusual, but seems to be pretty common for ext/imap. Also I'm not sure which branch to target. While I consider the behavior a bug, returning an empty array is not terribly wrong, so maybe 8.0/master would be more appropriate.