### PR TITLE
Allow passing $tag for non-authenticated encryption

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7156,8 +7156,6 @@ PHP_OPENSSL_API zend_string* php_openssl_encrypt(
 			}
 		} else if (tag) {
 			ZEND_TRY_ASSIGN_REF_NULL(tag);
-			php_error_docref(NULL, E_WARNING,
-					"The authenticated tag cannot be provided for cipher that doesn not support AEAD");
 		} else if (mode.is_aead) {
 			php_error_docref(NULL, E_WARNING, "A tag should be provided when using AEAD mode");
 			zend_string_release_ex(outbuf, 0);

--- a/ext/openssl/tests/openssl_decrypt_basic.phpt
+++ b/ext/openssl/tests/openssl_decrypt_basic.phpt
@@ -28,9 +28,15 @@ var_dump(rtrim($output));
 $encrypted = openssl_encrypt($data, "bf-ecb", $password, OPENSSL_DONT_ZERO_PAD_KEY);
 $output = openssl_decrypt($encrypted, "bf-ecb", $password, OPENSSL_DONT_ZERO_PAD_KEY);
 var_dump($output);
+
+// It's okay to pass $tag for a non-AAD cipher. It will be populated with null in that case.
+openssl_encrypt($data, $method, $password, 0, $iv, $tag);
+var_dump($tag);
+
 ?>
 --EXPECT--
 string(45) "openssl_encrypt() and openssl_decrypt() tests"
 string(45) "openssl_encrypt() and openssl_decrypt() tests"
 string(45) "openssl_encrypt() and openssl_decrypt() tests"
 string(45) "openssl_encrypt() and openssl_decrypt() tests"
+NULL

--- a/ext/openssl/tests/openssl_decrypt_error.phpt
+++ b/ext/openssl/tests/openssl_decrypt_error.phpt
@@ -20,8 +20,6 @@ var_dump(openssl_decrypt($wrong, $wrong, $password));
 var_dump(openssl_decrypt($encrypted, $wrong, $wrong));
 var_dump(openssl_decrypt($wrong, $wrong, $wrong));
 
-// invalid using of an authentication tag
-var_dump(openssl_encrypt($data, $method, $password, 0, $iv, $wrong));
 ?>
 --EXPECTF--
 Warning: openssl_encrypt(): Using an empty Initialization Vector (iv) is potentially insecure and not recommended in %s on line %d
@@ -41,6 +39,3 @@ bool(false)
 
 Warning: openssl_decrypt(): Unknown cipher algorithm in %s on line %d
 bool(false)
-
-Warning: openssl_encrypt(): The authenticated tag cannot be provided for cipher that doesn not support AEAD in %s on line %d
-string(44) "yof6cPPH4mLee6TOc0YQSrh4dvywMqxGUyjp0lV6+aM="

--- a/ext/openssl/tests/openssl_encrypt_error.phpt
+++ b/ext/openssl/tests/openssl_encrypt_error.phpt
@@ -15,18 +15,12 @@ $arr = array(1);
 // wrong parameters tests
 var_dump(openssl_encrypt($data, $wrong, $password));
 
-// invalid using of an authentication tag
-var_dump(openssl_encrypt($data, $method, $password, 0, $iv, $wrong));
-
 // padding of the key is disabled
 var_dump(openssl_encrypt($data, $method, $password, OPENSSL_DONT_ZERO_PAD_KEY, $iv));
 ?>
 --EXPECTF--
 Warning: openssl_encrypt(): Unknown cipher algorithm in %s on line %d
 bool(false)
-
-Warning: openssl_encrypt(): The authenticated tag cannot be provided for cipher that doesn not support AEAD in %s on line %d
-string(44) "iPR4HulskuaP5Z6me5uImk6BqVyJG73+63tkPauVZYk="
 
 Warning: openssl_encrypt(): Key length cannot be set for the cipher algorithm in %s on line %d
 bool(false)


### PR DESCRIPTION
openssl_encrypt() currently throws a warning if the `$tag` out parameter is passed for a non-authenticated cipher. This violates the principle that a function should behave the same if a parameter is not passed, and if the default value is passed for the parameter.

I believe this warning should simply be dropped and the `$tag` be populated with null, as is already the case. Otherwise, it is not possible to use openssl_encrypt() in generic wrapper APIs, that are compatible with both authenticated and non-authenticated encryption.

(If we don't do this, we'll just mark the parameter as UNKNOWN.)