### PR TITLE
Verify parameter names of function aliases

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1345,7 +1345,7 @@ if ($verify) {
         }
     }
 
-    echo implode("\n", $errors), "\n";
+    echo implode("\n", $errors);
     if (!empty($errors)) {
         exit(1);
     }

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1326,7 +1326,7 @@ if ($verify) {
     }
 
     foreach ($aliases as $alias) {
-        if ($alias->alias === null || !isset($funcMap[$alias->alias->__toString()])) {
+        if (!isset($funcMap[$alias->alias->__toString()])) {
             $errors[] = "Aliased function {$alias->alias}() cannot be found";
             continue;
         }

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -778,7 +778,7 @@ function parseFunctionLike(
                     $paramMeta[$varName] = [];
                 }
                 $paramMeta[$varName]['preferRef'] = true;
-            } else if ($tag->name === 'alias' || $tag->name === 'implementation-alias') {
+            } else if ($tag->name === 'alias' || $tag->name === 'implementation-alias' || $tag->name === 'static-method-alias') {
                 $aliasType = $tag->name;
                 $aliasParts = explode("::", $tag->getValue());
                 if (count($aliasParts) === 1) {
@@ -1342,7 +1342,7 @@ if ($verify) {
             /** @var FuncInfo $funcInfo */
             $funcMap[$funcInfo->name->__toString()] = $funcInfo;
 
-            if ($funcInfo->aliasType === "alias") {
+            if ($funcInfo->aliasType === "alias" || $funcInfo->aliasType === "static-method-alias") {
                 $aliases[] = $funcInfo;
             }
         }
@@ -1358,7 +1358,7 @@ if ($verify) {
         $aliasedArgs = $aliasedFunc->args;
         $aliasArgs = $aliasFunc->args;
 
-        if ($aliasFunc->isInstanceMethod() !== $aliasedFunc->isInstanceMethod()) {
+        if ($aliasFunc->isInstanceMethod() !== $aliasedFunc->isInstanceMethod() && $aliasFunc->aliasType !== "static-method-alias") {
             if ($aliasFunc->isInstanceMethod()) {
                 $aliasedArgs = array_slice($aliasedArgs, 1);
             }

--- a/ext/bz2/bz2.stub.php
+++ b/ext/bz2/bz2.stub.php
@@ -13,19 +13,19 @@ function bzread($bz, int $length = 1024): string|false {}
 
 /**
  * @param resource $bz
- * @alias fwrite
+ * @implementation-alias fwrite
  */
 function bzwrite($bz, string $data, ?int $length = null): int|false {}
 
 /**
  * @param resource $bz
- * @alias fflush
+ * @implementation-alias fflush
  */
 function bzflush($bz): bool {}
 
 /**
  * @param resource $bz
- * @alias fclose
+ * @implementation-alias fclose
  */
 function bzclose($bz): bool {}
 

--- a/ext/bz2/bz2_arginfo.h
+++ b/ext/bz2/bz2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6953f91be31777e4d4e3652f75eec6d968cf636a */
+ * Stub hash: 0cd7792480671883ebae30ae8358b8f8e3390474 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_bzopen, 0, 0, 2)
 	ZEND_ARG_INFO(0, file)

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -337,7 +337,7 @@ class DateTimeZone
      * @return int
      * @alias timezone_offset_get
      */
-    public function getOffset(DateTimeInterface $object) {}
+    public function getOffset(DateTimeInterface $datetime) {}
 
     /**
      * @return array|false

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -69,7 +69,7 @@ function date_time_set(
 
 function date_date_set(DateTime $object, int $year, int $month, int $day): DateTime {}
 
-function date_isodate_set(DateTime $object, int $year, int $week, int $day = 1): DateTime {}
+function date_isodate_set(DateTime $object, int $year, int $week, int $dayOfWeek = 1): DateTime {}
 
 function date_timestamp_set(DateTime $object, int $timestamp): DateTime {}
 
@@ -291,7 +291,7 @@ class DateTimeImmutable implements DateTimeInterface
      * @return DateInterval|false
      * @alias date_diff
      */
-    public function diff(DateTimeInterface $object, bool $absolute = false) {}
+    public function diff(DateTimeInterface $targetObject, bool $absolute = false) {}
 
     /** @return DateTimeImmutable|false */
     public function modify(string $modifier) {}

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2129f4a8e4f6011ecdbda8b780d77d40512ad2d6 */
+ * Stub hash: 04954b7aac5b3ee8e789b3ddd254ad5eda299c2b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -368,7 +368,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_DateTimeZone_getName arginfo_class_DateTimeInterface_getTimezone
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateTimeZone_getOffset, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, object, DateTimeInterface, 0)
+	ZEND_ARG_OBJ_INFO(0, datetime, DateTimeInterface, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateTimeZone_getTransitions, 0, 0, 0)

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 561c6ad41ccedfc8b778d3b64323c7154dffcdb5 */
+ * Stub hash: 2129f4a8e4f6011ecdbda8b780d77d40512ad2d6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -143,7 +143,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_date_isodate_set, 0, 3, DateTime,
 	ZEND_ARG_OBJ_INFO(0, object, DateTime, 0)
 	ZEND_ARG_TYPE_INFO(0, year, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, week, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, day, IS_LONG, 0, "1")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dayOfWeek, IS_LONG, 0, "1")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_date_timestamp_set, 0, 2, DateTime, 0)
@@ -335,10 +335,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateTimeImmutable_getTimestamp arginfo_class_DateTimeInterface_getTimezone
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DateTimeImmutable_diff, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, object, DateTimeInterface, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, absolute, _IS_BOOL, 0, "false")
-ZEND_END_ARG_INFO()
+#define arginfo_class_DateTimeImmutable_diff arginfo_class_DateTimeInterface_diff
 
 #define arginfo_class_DateTimeImmutable_modify arginfo_class_DateTime_modify
 

--- a/ext/date/tests/68062.phpt
+++ b/ext/date/tests/68062.phpt
@@ -15,4 +15,4 @@ try {
 ?>
 --EXPECT--
 3600
-DateTimeZone::getOffset(): Argument #1 ($object) must be of type DateTimeInterface, int given
+DateTimeZone::getOffset(): Argument #1 ($datetime) must be of type DateTimeInterface, int given

--- a/ext/intl/calendar/calendar.stub.php
+++ b/ext/intl/calendar/calendar.stub.php
@@ -218,11 +218,11 @@ class IntlCalendar
     public function isWeekend(?float $timestamp = null) {}
 
     /**
-     * @param int|bool $amountOrUpOrDown
+     * @param int|bool $value
      * @return bool
      * @alias intlcal_roll
      */
-    public function roll(int $field, $amountOrUpOrDown) {}
+    public function roll(int $field, $value) {}
 
     /**
      * @return bool

--- a/ext/intl/calendar/calendar_arginfo.h
+++ b/ext/intl/calendar/calendar_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cac6d4040481ab7de4775315079b1d28a44cbcac */
+ * Stub hash: ee755d4a500e2d1ba4d589c233b7d09a06b5cce8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -106,7 +106,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar_roll, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, field, IS_LONG, 0)
-	ZEND_ARG_INFO(0, amountOrUpOrDown)
+	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_IntlCalendar_isSet arginfo_class_IntlCalendar_get

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -89,7 +89,7 @@ function intlcal_set_repeated_wall_time_option(IntlCalendar $calendar, int $opti
 
 function intlcal_set_skipped_wall_time_option(IntlCalendar $calendar, int $option): bool {}
 
-function intlcal_from_date_time(DateTime|string $dateTime, ?string $locale = null): ?IntlCalendar {}
+function intlcal_from_date_time(DateTime|string $datetime, ?string $locale = null): ?IntlCalendar {}
 
 function intlcal_to_date_time(IntlCalendar $calendar): DateTime|false {}
 
@@ -131,7 +131,7 @@ function collator_sort(Collator $object, array &$array, int $flags = Collator::S
 
 function collator_sort_with_sort_keys(Collator $object, array &$array): bool {}
 
-function collator_asort(Collator $object, array &$arr, int $flags = Collator::SORT_REGULAR): bool {}
+function collator_asort(Collator $object, array &$array, int $flags = Collator::SORT_REGULAR): bool {}
 
 function collator_get_locale(Collator $object, int $type): string|false {}
 
@@ -349,7 +349,7 @@ function resourcebundle_create(?string $locale, ?string $bundle, bool $fallback 
  * @param string|int $index
  * @return mixed
  */
-function resourcebundle_get(ResourceBundle $bundle, $index) {}
+function resourcebundle_get(ResourceBundle $bundle, $index, bool $fallback = true) {}
 
 function resourcebundle_count(ResourceBundle $bundle): int {}
 

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8340252225ea91a68fe61657f20c08a1876949c8 */
+ * Stub hash: c890e3cde79ffeade4623001cc369aa734812959 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -162,7 +162,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_intlcal_set_skipped_wall_time_option arginfo_intlcal_set_repeated_wall_time_option
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_from_date_time, 0, 1, IntlCalendar, 1)
-	ZEND_ARG_OBJ_TYPE_MASK(0, dateTime, DateTime, MAY_BE_STRING, NULL)
+	ZEND_ARG_OBJ_TYPE_MASK(0, datetime, DateTime, MAY_BE_STRING, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, locale, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
@@ -242,11 +242,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collator_sort_with_sort_keys, 0,
 	ZEND_ARG_TYPE_INFO(1, array, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_collator_asort, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, object, Collator, 0)
-	ZEND_ARG_TYPE_INFO(1, arr, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "Collator::SORT_REGULAR")
-ZEND_END_ARG_INFO()
+#define arginfo_collator_asort arginfo_collator_sort
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_collator_get_locale, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, object, Collator, 0)
@@ -637,6 +633,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_resourcebundle_get, 0, 0, 2)
 	ZEND_ARG_OBJ_INFO(0, bundle, ResourceBundle, 0)
 	ZEND_ARG_INFO(0, index)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fallback, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_resourcebundle_count, 0, 1, IS_LONG, 0)

--- a/ext/intl/timezone/timezone.stub.php
+++ b/ext/intl/timezone/timezone.stub.php
@@ -66,7 +66,7 @@ class IntlTimeZone
      * @return string|false
      * @alias intltz_get_equivalent_id
      */
-    public static function getEquivalentID(string $timezoneId, int $index) {}
+    public static function getEquivalentID(string $timezoneId, int $offset) {}
 
     /**
      * @return int|false

--- a/ext/intl/timezone/timezone_arginfo.h
+++ b/ext/intl/timezone/timezone_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6bdd65d7ba5a32b32c96511e391beb876d9d20c3 */
+ * Stub hash: afd0e74b29d54cde9789787b924af9b43539a7f4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlTimeZone___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -41,7 +41,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlTimeZone_getEquivalentID, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, timezoneId, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_IntlTimeZone_getErrorCode arginfo_class_IntlTimeZone___construct

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -9,7 +9,7 @@ final class mysqli_driver
 class mysqli
 {
     public function __construct(
-        ?string $host = null,
+        ?string $hostname = null,
         ?string $username = null,
         ?string $password = null,
         ?string $database = null,
@@ -57,8 +57,8 @@ class mysqli
      * @return mysqli|null|false
      * @alias mysqli_connect
      */
-    public function connect(
-        ?string $host = null,
+    public static function connect(
+        ?string $hostname = null,
         ?string $username = null,
         ?string $password = null,
         ?string $database = null,
@@ -76,7 +76,7 @@ class mysqli
      * @return bool
      * @alias mysqli_debug
      */
-    public function debug(string $message) {}
+    public static function debug(string $options) {}
 
     /**
      * @return object|null
@@ -170,7 +170,7 @@ class mysqli
      * @alias mysqli_real_connect
      */
     public function real_connect(
-        ?string $host = null,
+        ?string $hostname = null,
         ?string $username = null,
         ?string $password = null,
         ?string $database = null,
@@ -534,7 +534,7 @@ function mysqli_close(mysqli $mysql): bool {}
 function mysqli_commit(mysqli $mysql, int $flags = -1, ?string $name = null): bool {}
 
 function mysqli_connect(
-    ?string $host = null,
+    ?string $hostname = null,
     ?string $username = null,
     ?string $password = null,
     ?string $database = null,
@@ -550,7 +550,7 @@ function mysqli_data_seek(mysqli_result $result, int $offset): bool {}
 
 function mysqli_dump_debug_info(mysqli $mysql): bool {}
 
-function mysqli_debug(string $message): bool {}
+function mysqli_debug(string $options): bool {}
 
 function mysqli_errno(mysqli $mysql): int {}
 
@@ -650,7 +650,7 @@ function mysqli_query(mysqli $mysql, string $query, int $result_mode = MYSQLI_ST
 
 function mysqli_real_connect(
     mysqli $mysql,
-    ?string $host = null,
+    ?string $hostname = null,
     ?string $username = null,
     ?string $password = null,
     ?string $database = null,

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -76,7 +76,7 @@ class mysqli
      * @return bool
      * @alias mysqli_debug
      */
-    public function debug(string $options) {}
+    public function debug(string $message) {}
 
     /**
      * @return object|null
@@ -112,7 +112,6 @@ class mysqli
 
     /**
      * @return mysqli|false
-     * @alias mysqli_init_method
      */
     public function init() {}
 
@@ -551,7 +550,7 @@ function mysqli_data_seek(mysqli_result $result, int $offset): bool {}
 
 function mysqli_dump_debug_info(mysqli $mysql): bool {}
 
-function mysqli_debug(string $debug): bool {}
+function mysqli_debug(string $message): bool {}
 
 function mysqli_errno(mysqli $mysql): int {}
 
@@ -568,7 +567,7 @@ function mysqli_fetch_field(mysqli_result $result): object|false {}
 
 function mysqli_fetch_fields(mysqli_result $result): array {}
 
-function mysqli_fetch_field_direct(mysqli_result $result, int $offset): object|false {}
+function mysqli_fetch_field_direct(mysqli_result $result, int $index): object|false {}
 
 function mysqli_fetch_lengths(mysqli_result $result): array|false {}
 

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -55,7 +55,8 @@ class mysqli
 
     /**
      * @return mysqli|null|false
-     * @static-method-alias mysqli_connect
+     * @alias mysqli_connect
+     * @no-verify
      */
     public function connect(
         ?string $hostname = null,

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -55,9 +55,9 @@ class mysqli
 
     /**
      * @return mysqli|null|false
-     * @alias mysqli_connect
+     * @static-method-alias mysqli_connect
      */
-    public static function connect(
+    public function connect(
         ?string $hostname = null,
         ?string $username = null,
         ?string $password = null,

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1482,13 +1482,6 @@ PHP_FUNCTION(mysqli_init)
 }
 /* }}} */
 
-/* {{{ Initialize mysqli and return a resource for use with mysql_real_connect */
-PHP_FUNCTION(mysqli_init_method)
-{
-	php_mysqli_init(INTERNAL_FUNCTION_PARAM_PASSTHRU, TRUE);
-}
-/* }}} */
-
 /* {{{ Get the ID generated from the previous INSERT operation */
 PHP_FUNCTION(mysqli_insert_id)
 {

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b156847f2617389de5381e5bd5e2fedb27bd7eed */
+ * Stub hash: a08c78e8f2cd934224679f34b1556c170c97737a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0c4478112ac85b80838c47eee6ff726319edae49 */
+ * Stub hash: 200fdd7f3ae0ded20b43486f162d207b7fd09712 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -38,7 +38,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_commit, 0, 1, _IS_BOOL, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_connect, 0, 0, mysqli, MAY_BE_NULL|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hostname, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 1, "null")
@@ -60,7 +60,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_dump_debug_info arginfo_mysqli_close
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_debug, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_errno, 0, 1, IS_LONG, 0)
@@ -235,7 +235,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_connect, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hostname, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 1, "null")
@@ -423,7 +423,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_set_opt arginfo_mysqli_options
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hostname, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 1, "null")
@@ -461,7 +461,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_dump_debug_info arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_debug, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_get_charset arginfo_class_mysqli_character_set_name
@@ -511,7 +511,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_query, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_real_connect, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, host, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hostname, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, database, IS_STRING, 1, "null")
@@ -957,9 +957,9 @@ static const zend_function_entry class_mysqli_methods[] = {
 	ZEND_ME_MAPPING(character_set_name, mysqli_character_set_name, arginfo_class_mysqli_character_set_name, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(close, mysqli_close, arginfo_class_mysqli_close, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(commit, mysqli_commit, arginfo_class_mysqli_commit, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(connect, mysqli_connect, arginfo_class_mysqli_connect, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(connect, mysqli_connect, arginfo_class_mysqli_connect, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(dump_debug_info, mysqli_dump_debug_info, arginfo_class_mysqli_dump_debug_info, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(debug, mysqli_debug, arginfo_class_mysqli_debug, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(debug, mysqli_debug, arginfo_class_mysqli_debug, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(get_charset, mysqli_get_charset, arginfo_class_mysqli_get_charset, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(get_client_info, mysqli_get_client_info, arginfo_class_mysqli_get_client_info, ZEND_ACC_PUBLIC)
 #if defined(MYSQLI_USE_MYSQLND)

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cc90d40e43462557087c123f0583e7865f281179 */
+ * Stub hash: 0c4478112ac85b80838c47eee6ff726319edae49 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -60,7 +60,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_dump_debug_info arginfo_mysqli_close
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_debug, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, debug, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_errno, 0, 1, IS_LONG, 0)
@@ -89,7 +89,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_field_direct, 0, 2, MAY_BE_OBJECT|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
-	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_lengths, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
@@ -461,7 +461,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_mysqli_dump_debug_info arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_debug, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, options, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_get_charset arginfo_class_mysqli_character_set_name
@@ -811,7 +811,7 @@ ZEND_FUNCTION(mysqli_use_result);
 ZEND_FUNCTION(mysqli_warning_count);
 ZEND_FUNCTION(mysqli_refresh);
 ZEND_METHOD(mysqli, __construct);
-ZEND_FUNCTION(mysqli_init_method);
+ZEND_METHOD(mysqli, init);
 ZEND_METHOD(mysqli_result, __construct);
 ZEND_METHOD(mysqli_result, getIterator);
 ZEND_METHOD(mysqli_stmt, __construct);
@@ -967,7 +967,7 @@ static const zend_function_entry class_mysqli_methods[] = {
 #endif
 	ZEND_ME_MAPPING(get_server_info, mysqli_get_server_info, arginfo_class_mysqli_get_server_info, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(get_warnings, mysqli_get_warnings, arginfo_class_mysqli_get_warnings, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(init, mysqli_init_method, arginfo_class_mysqli_init, ZEND_ACC_PUBLIC)
+	ZEND_ME(mysqli, init, arginfo_class_mysqli_init, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(kill, mysqli_kill, arginfo_class_mysqli_kill, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(multi_query, mysqli_multi_query, arginfo_class_mysqli_multi_query, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(more_results, mysqli_more_results, arginfo_class_mysqli_more_results, ZEND_ACC_PUBLIC)

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 200fdd7f3ae0ded20b43486f162d207b7fd09712 */
+ * Stub hash: b156847f2617389de5381e5bd5e2fedb27bd7eed */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -957,7 +957,7 @@ static const zend_function_entry class_mysqli_methods[] = {
 	ZEND_ME_MAPPING(character_set_name, mysqli_character_set_name, arginfo_class_mysqli_character_set_name, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(close, mysqli_close, arginfo_class_mysqli_close, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(commit, mysqli_commit, arginfo_class_mysqli_commit, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(connect, mysqli_connect, arginfo_class_mysqli_connect, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME_MAPPING(connect, mysqli_connect, arginfo_class_mysqli_connect, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(dump_debug_info, mysqli_dump_debug_info, arginfo_class_mysqli_dump_debug_info, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(debug, mysqli_debug, arginfo_class_mysqli_debug, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(get_charset, mysqli_get_charset, arginfo_class_mysqli_get_charset, ZEND_ACC_PUBLIC)

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -383,6 +383,13 @@ PHP_METHOD(mysqli, __construct)
 	mysqli_common_connect(INTERNAL_FUNCTION_PARAM_PASSTHRU, FALSE, TRUE);
 }
 
+/* {{{ Initialize mysqli and return a resource for use with mysql_real_connect */
+PHP_METHOD(mysqli, init)
+{
+	php_mysqli_init(INTERNAL_FUNCTION_PARAM_PASSTHRU, TRUE);
+}
+/* }}} */
+
 /* {{{ Returns the numerical value of the error message from last connect command */
 PHP_FUNCTION(mysqli_connect_errno)
 {

--- a/ext/mysqli/tests/mysqli_fetch_field_direct.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field_direct.phpt
@@ -44,7 +44,7 @@ require_once('skipifconnectfailure.inc');
     require_once("clean_table.inc");
 ?>
 --EXPECTF--
-mysqli_fetch_field_direct(): Argument #2 ($offset) must be greater than or equal to 0
+mysqli_fetch_field_direct(): Argument #2 ($index) must be greater than or equal to 0
 object(stdClass)#%d (13) {
   ["name"]=>
   string(2) "ID"
@@ -73,6 +73,6 @@ object(stdClass)#%d (13) {
   ["decimals"]=>
   int(%d)
 }
-mysqli_fetch_field_direct(): Argument #2 ($offset) must be less than the number of fields for this result set
+mysqli_fetch_field_direct(): Argument #2 ($index) must be less than the number of fields for this result set
 mysqli_result object is already closed
 done!

--- a/ext/oci8/oci8.stub.php
+++ b/ext/oci8/oci8.stub.php
@@ -89,10 +89,6 @@ function oci_lob_is_equal(OCILob $lob1, OCILob $lob2): bool {}
 
 function oci_lob_export(OCILob $lob, string $filename, ?int $offset = null, ?int $length = null): bool {}
 
-function oci_lob_write_temporary(OCILob $lob, string $data, int $type = OCI_TEMP_CLOB): bool {}
-
-function oci_lob_close(OCILob $lob): bool {}
-
 /**
  * @alias oci_lob_export
  * @deprecated
@@ -658,16 +654,10 @@ class OCILob {
      */
     public function export(string $filename, ?int $offset = null, ?int $length = null) {}
 
-    /**
-     * @alias oci_lob_write_temporary
-     * @return bool
-     */
+    /** @return bool */
     public function writetemporary(string $data, int $type = OCI_TEMP_CLOB) {}
 
-    /**
-     * @alias oci_lob_close
-     * @return bool
-     */
+    /** @return bool */
     public function close() {}
 
     /**

--- a/ext/oci8/oci8.stub.php
+++ b/ext/oci8/oci8.stub.php
@@ -89,6 +89,10 @@ function oci_lob_is_equal(OCILob $lob1, OCILob $lob2): bool {}
 
 function oci_lob_export(OCILob $lob, string $filename, ?int $offset = null, ?int $length = null): bool {}
 
+function oci_lob_write_temporary(OCILob $lob, string $data, int $type = OCI_TEMP_CLOB): bool {}
+
+function oci_lob_close(OCILob $lob): bool {}
+
 /**
  * @alias oci_lob_export
  * @deprecated
@@ -604,7 +608,7 @@ class OCILob {
      * @alias oci_lob_write
      * @return int|false
      */
-    public function write(string $string, ?int $length = null) {}
+    public function write(string $data, ?int $length = null) {}
 
     /**
      * @alias oci_lob_append

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7f000371ef4b61c401b5a59d2ab19c0e0f9a1987 */
+ * Stub hash: 7fc2631cb9b0ec3c50c895e2789774dec45adf15 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_define_by_name, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, statement)
@@ -128,6 +128,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_lob_export, 0, 2, _IS_BOOL, 
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, offset, IS_LONG, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_lob_write_temporary, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, lob, OCILob, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "OCI_TEMP_CLOB")
+ZEND_END_ARG_INFO()
+
+#define arginfo_oci_lob_close arginfo_oci_free_descriptor
 
 #define arginfo_ociwritelobtofile arginfo_oci_lob_export
 
@@ -470,7 +478,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_OCILob_size arginfo_class_OCILob_load
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_write, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
@@ -565,6 +573,8 @@ ZEND_FUNCTION(ocigetbufferinglob);
 ZEND_FUNCTION(oci_lob_copy);
 ZEND_FUNCTION(oci_lob_is_equal);
 ZEND_FUNCTION(oci_lob_export);
+ZEND_FUNCTION(oci_lob_write_temporary);
+ZEND_FUNCTION(oci_lob_close);
 ZEND_FUNCTION(oci_new_descriptor);
 ZEND_FUNCTION(oci_rollback);
 ZEND_FUNCTION(oci_commit);
@@ -619,8 +629,6 @@ ZEND_FUNCTION(oci_collection_trim);
 ZEND_FUNCTION(oci_new_collection);
 ZEND_FUNCTION(oci_register_taf_callback);
 ZEND_FUNCTION(oci_unregister_taf_callback);
-ZEND_FUNCTION(oci_lob_write_temporary);
-ZEND_FUNCTION(oci_lob_close);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -653,6 +661,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(oci_lob_copy, arginfo_oci_lob_copy)
 	ZEND_FE(oci_lob_is_equal, arginfo_oci_lob_is_equal)
 	ZEND_FE(oci_lob_export, arginfo_oci_lob_export)
+	ZEND_FE(oci_lob_write_temporary, arginfo_oci_lob_write_temporary)
+	ZEND_FE(oci_lob_close, arginfo_oci_lob_close)
 	ZEND_DEP_FALIAS(ociwritelobtofile, oci_lob_export, arginfo_ociwritelobtofile)
 	ZEND_FE(oci_new_descriptor, arginfo_oci_new_descriptor)
 	ZEND_DEP_FALIAS(ocinewdescriptor, oci_new_descriptor, arginfo_ocinewdescriptor)

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7fc2631cb9b0ec3c50c895e2789774dec45adf15 */
+ * Stub hash: e7a7a9402b2668136f9f47d6e547e3af46a78a50 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_define_by_name, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, statement)
@@ -128,14 +128,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_lob_export, 0, 2, _IS_BOOL, 
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, offset, IS_LONG, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_lob_write_temporary, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, lob, OCILob, 0)
-	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "OCI_TEMP_CLOB")
-ZEND_END_ARG_INFO()
-
-#define arginfo_oci_lob_close arginfo_oci_free_descriptor
 
 #define arginfo_ociwritelobtofile arginfo_oci_lob_export
 
@@ -573,8 +565,6 @@ ZEND_FUNCTION(ocigetbufferinglob);
 ZEND_FUNCTION(oci_lob_copy);
 ZEND_FUNCTION(oci_lob_is_equal);
 ZEND_FUNCTION(oci_lob_export);
-ZEND_FUNCTION(oci_lob_write_temporary);
-ZEND_FUNCTION(oci_lob_close);
 ZEND_FUNCTION(oci_new_descriptor);
 ZEND_FUNCTION(oci_rollback);
 ZEND_FUNCTION(oci_commit);
@@ -629,6 +619,8 @@ ZEND_FUNCTION(oci_collection_trim);
 ZEND_FUNCTION(oci_new_collection);
 ZEND_FUNCTION(oci_register_taf_callback);
 ZEND_FUNCTION(oci_unregister_taf_callback);
+ZEND_METHOD(OCILob, writetemporary);
+ZEND_METHOD(OCILob, close);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -661,8 +653,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(oci_lob_copy, arginfo_oci_lob_copy)
 	ZEND_FE(oci_lob_is_equal, arginfo_oci_lob_is_equal)
 	ZEND_FE(oci_lob_export, arginfo_oci_lob_export)
-	ZEND_FE(oci_lob_write_temporary, arginfo_oci_lob_write_temporary)
-	ZEND_FE(oci_lob_close, arginfo_oci_lob_close)
 	ZEND_DEP_FALIAS(ociwritelobtofile, oci_lob_export, arginfo_ociwritelobtofile)
 	ZEND_FE(oci_new_descriptor, arginfo_oci_new_descriptor)
 	ZEND_DEP_FALIAS(ocinewdescriptor, oci_new_descriptor, arginfo_ocinewdescriptor)
@@ -781,8 +771,8 @@ static const zend_function_entry class_OCILob_methods[] = {
 	ZEND_ME_MAPPING(getbuffering, ocigetbufferinglob, arginfo_class_OCILob_getbuffering, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(writetofile, oci_lob_export, arginfo_class_OCILob_writetofile, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(export, oci_lob_export, arginfo_class_OCILob_export, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(writetemporary, oci_lob_write_temporary, arginfo_class_OCILob_writetemporary, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(close, oci_lob_close, arginfo_class_OCILob_close, ZEND_ACC_PUBLIC)
+	ZEND_ME(OCILob, writetemporary, arginfo_class_OCILob_writetemporary, ZEND_ACC_PUBLIC)
+	ZEND_ME(OCILob, close, arginfo_class_OCILob_close, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(free, oci_free_descriptor, arginfo_class_OCILob_free, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -916,7 +916,7 @@ PHP_FUNCTION(oci_lob_export)
 /* }}} */
 
 /* {{{ Writes temporary blob */
-PHP_FUNCTION(oci_lob_write_temporary)
+PHP_METHOD(OCILob, writetemporary)
 {
 	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;
@@ -943,7 +943,7 @@ PHP_FUNCTION(oci_lob_write_temporary)
 /* }}} */
 
 /* {{{ Closes lob descriptor */
-PHP_FUNCTION(oci_lob_close)
+PHP_METHOD(OCILob, close)
 {
 	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -299,8 +299,8 @@ function pg_lo_open($connection, $oid = UNKNOWN, string $mode = UNKNOWN) {}
  */
 function pg_loopen($connection, $oid = UNKNOWN, string $mode = UNKNOWN) {}
 
-/** @param resource $large_object */
-function pg_lo_close($large_object): bool {}
+/** @param resource $lob */
+function pg_lo_close($lob): bool {}
 
 /**
  * @param resource $lob

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cf7903b6548240de5be9f167a63478f846111e0f */
+ * Stub hash: 26edbb4ade84f0faad592dd270756c17e396519b */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_connect, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -225,12 +225,10 @@ ZEND_END_ARG_INFO()
 #define arginfo_pg_loopen arginfo_pg_lo_open
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_lo_close, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_INFO(0, large_object)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_loclose, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, lob)
 ZEND_END_ARG_INFO()
+
+#define arginfo_pg_loclose arginfo_pg_lo_close
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_lo_read, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, lob)

--- a/ext/tidy/tidy.stub.php
+++ b/ext/tidy/tidy.stub.php
@@ -78,13 +78,13 @@ class tidy
      * @return bool
      * @alias tidy_repair_string
      */
-    public function repairString(string $string, array|string|null $config = null, ?string $encoding = null) {}
+    public static function repairString(string $string, array|string|null $config = null, ?string $encoding = null) {}
 
     /**
      * @return bool
      * @alias tidy_repair_file
      */
-    public function repairFile(string $filename, array|string|null $config = null, ?string $encoding = null, bool $useIncludePath = false) {}
+    public static function repairFile(string $filename, array|string|null $config = null, ?string $encoding = null, bool $useIncludePath = false) {}
 
     /**
      * @return bool

--- a/ext/tidy/tidy_arginfo.h
+++ b/ext/tidy/tidy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ac4cd960d6c65653994b8b044dcc52c179a57d45 */
+ * Stub hash: 4042c33d3ea3f5fb87cfb696488f6280b6ec7e7f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_tidy_parse_string, 0, 1, tidy, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
@@ -248,8 +248,8 @@ static const zend_function_entry class_tidy_methods[] = {
 	ZEND_ME_MAPPING(cleanRepair, tidy_clean_repair, arginfo_class_tidy_cleanRepair, ZEND_ACC_PUBLIC)
 	ZEND_ME(tidy, parseFile, arginfo_class_tidy_parseFile, ZEND_ACC_PUBLIC)
 	ZEND_ME(tidy, parseString, arginfo_class_tidy_parseString, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(repairString, tidy_repair_string, arginfo_class_tidy_repairString, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(repairFile, tidy_repair_file, arginfo_class_tidy_repairFile, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(repairString, tidy_repair_string, arginfo_class_tidy_repairString, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME_MAPPING(repairFile, tidy_repair_file, arginfo_class_tidy_repairFile, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(diagnose, tidy_diagnose, arginfo_class_tidy_diagnose, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(getRelease, tidy_get_release, arginfo_class_tidy_getRelease, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(getConfig, tidy_get_config, arginfo_class_tidy_getConfig, ZEND_ACC_PUBLIC)

--- a/ext/xmlwriter/php_xmlwriter.stub.php
+++ b/ext/xmlwriter/php_xmlwriter.stub.php
@@ -90,13 +90,13 @@ class XMLWriter
 {
     /**
      * @return bool
-     * @alias xmlwriter_open_uri
+     * @static-method-alias xmlwriter_open_uri
      */
-    public static function openUri(string $uri) {}
+    public function openUri(string $uri) {}
 
     /**
      * @return bool
-     * @alias xmlwriter_open_memory
+     * @static-method-alias xmlwriter_open_memory
      */
     public function openMemory() {}
 

--- a/ext/xmlwriter/php_xmlwriter.stub.php
+++ b/ext/xmlwriter/php_xmlwriter.stub.php
@@ -92,7 +92,7 @@ class XMLWriter
      * @return bool
      * @alias xmlwriter_open_uri
      */
-    public function openUri(string $uri) {}
+    public static function openUri(string $uri) {}
 
     /**
      * @return bool

--- a/ext/xmlwriter/php_xmlwriter.stub.php
+++ b/ext/xmlwriter/php_xmlwriter.stub.php
@@ -90,13 +90,15 @@ class XMLWriter
 {
     /**
      * @return bool
-     * @static-method-alias xmlwriter_open_uri
+     * @alias xmlwriter_open_uri
+     * @no-verify
      */
     public function openUri(string $uri) {}
 
     /**
      * @return bool
-     * @static-method-alias xmlwriter_open_memory
+     * @alias xmlwriter_open_memory
+     * @no-verify
      */
     public function openMemory() {}
 

--- a/ext/xmlwriter/php_xmlwriter_arginfo.h
+++ b/ext/xmlwriter/php_xmlwriter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8607fe498af4c678f099231d52c3c8aabf5b7e9e */
+ * Stub hash: 8c40633407c5bf49e47504ae93c2031af3b7e718 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_xmlwriter_open_uri, 0, 1, XMLWriter, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)

--- a/ext/xmlwriter/php_xmlwriter_arginfo.h
+++ b/ext/xmlwriter/php_xmlwriter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: df2a62a48636bd2c7b1e62ac28480ae27233f100 */
+ * Stub hash: 1dac866f8b92d14862818a3350cc4f902c35dc65 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_xmlwriter_open_uri, 0, 1, XMLWriter, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
@@ -420,7 +420,7 @@ static const zend_function_entry ext_functions[] = {
 
 
 static const zend_function_entry class_XMLWriter_methods[] = {
-	ZEND_ME_MAPPING(openUri, xmlwriter_open_uri, arginfo_class_XMLWriter_openUri, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(openUri, xmlwriter_open_uri, arginfo_class_XMLWriter_openUri, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(openMemory, xmlwriter_open_memory, arginfo_class_XMLWriter_openMemory, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(setIndent, xmlwriter_set_indent, arginfo_class_XMLWriter_setIndent, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(setIndentString, xmlwriter_set_indent_string, arginfo_class_XMLWriter_setIndentString, ZEND_ACC_PUBLIC)

--- a/ext/xmlwriter/php_xmlwriter_arginfo.h
+++ b/ext/xmlwriter/php_xmlwriter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1dac866f8b92d14862818a3350cc4f902c35dc65 */
+ * Stub hash: 8607fe498af4c678f099231d52c3c8aabf5b7e9e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_xmlwriter_open_uri, 0, 1, XMLWriter, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
@@ -420,7 +420,7 @@ static const zend_function_entry ext_functions[] = {
 
 
 static const zend_function_entry class_XMLWriter_methods[] = {
-	ZEND_ME_MAPPING(openUri, xmlwriter_open_uri, arginfo_class_XMLWriter_openUri, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME_MAPPING(openUri, xmlwriter_open_uri, arginfo_class_XMLWriter_openUri, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(openMemory, xmlwriter_open_memory, arginfo_class_XMLWriter_openMemory, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(setIndent, xmlwriter_set_indent, arginfo_class_XMLWriter_setIndent, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(setIndentString, xmlwriter_set_indent_string, arginfo_class_XMLWriter_setIndentString, ZEND_ACC_PUBLIC)

--- a/ext/zlib/zlib.stub.php
+++ b/ext/zlib/zlib.stub.php
@@ -99,7 +99,7 @@ function gzread($stream, int $length): string|false {}
 
 /**
  * @param resource $stream
- * @alias fgets
+ * @implementation-alias fgets
  */
 function gzgets($stream, int $length = 1024): string|false {}
 

--- a/ext/zlib/zlib_arginfo.h
+++ b/ext/zlib/zlib_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4106a50d3930915e47548be72f984420c5af6149 */
+ * Stub hash: 940858ddc4ddc7edb1e00960334ffa473224fd85 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ob_gzhandler, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)


### PR DESCRIPTION
Remaining errors that I'm not sure what to do with:

```
bzwrite(): Argument $bz of aliased function fwrite() is missing
bzflush(): Argument $bz of aliased function fflush() is missing
bzclose(): Argument $bz of aliased function fclose() is missing

```