### PR TITLE
Mysqli "[%d] Couldn't fetch %s" => "%s object is already closed"

### DIFF
--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -859,6 +859,7 @@ PHP_FUNCTION(mysqli_poll)
 	if (e_array != NULL) {
 		if (mysqlnd_zval_array_to_mysqlnd_array(e_array, &new_e_array) == FAILURE) {
 			efree(new_e_array);
+			efree(new_r_array); // free the array from the previous if statement
 			RETURN_THROWS();
 		}
 	}

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -769,8 +769,8 @@ static int mysqlnd_zval_array_from_mysqlnd_array(MYSQLND **in_array, zval *out_a
 			MYSQLI_RESOURCE *my_res;
 			mysqli_object *intern = Z_MYSQLI_P(elem);
 			if (!(my_res = (MYSQLI_RESOURCE *)intern->ptr)) {
-		  		php_error_docref(NULL, E_WARNING, "[%d] Couldn't fetch %s", i, ZSTR_VAL(intern->zo.ce->name));
-				continue;
+		  		zend_throw_error(NULL, "%s object is already closed", ZSTR_VAL(intern->zo.ce->name));
+				return FAILURE;
 		  	}
 			mysql = (MY_MYSQL *) my_res->ptr;
 			if (mysql->mysql == *p) {

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -754,12 +754,11 @@ static int mysqlnd_zval_array_from_mysqlnd_array(MYSQLND **in_array, zval *out_a
 	MYSQLND **p = in_array;
 	zval dest_array;
 	zval *elem, *dest_elem;
-	int ret = 0, i = 0;
+	int ret = 0;
 
 	array_init_size(&dest_array, zend_hash_num_elements(Z_ARRVAL_P(out_array)));
 
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(out_array), elem) {
-		i++;
 		if (Z_TYPE_P(elem) != IS_OBJECT ||
 				!instanceof_function(Z_OBJCE_P(elem), mysqli_link_class_entry)) {
 			continue;

--- a/ext/mysqli/mysqli_warning.c
+++ b/ext/mysqli/mysqli_warning.c
@@ -201,7 +201,7 @@ static int mysqli_warning_message(mysqli_object *obj, zval *retval, zend_bool qu
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
 		if (!quiet) {
-			zend_throw_error(NULL, "Couldn't fetch %s", ZSTR_VAL(obj->zo.ce->name));
+			zend_throw_error(NULL, "%s object is already closed", ZSTR_VAL(obj->zo.ce->name));
 		}
 
 		return FAILURE;
@@ -221,7 +221,7 @@ static int mysqli_warning_sqlstate(mysqli_object *obj, zval *retval, zend_bool q
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
 		if (!quiet) {
-			zend_throw_error(NULL, "Couldn't fetch %s", ZSTR_VAL(obj->zo.ce->name));
+			zend_throw_error(NULL, "%s object is already closed", ZSTR_VAL(obj->zo.ce->name));
 		}
 
 		return FAILURE;
@@ -241,7 +241,7 @@ static int mysqli_warning_errno(mysqli_object *obj, zval *retval, zend_bool quie
 
 	if (!obj->ptr || !((MYSQLI_RESOURCE *)(obj->ptr))->ptr) {
 		if (!quiet) {
-			zend_throw_error(NULL, "Couldn't fetch %s", ZSTR_VAL(obj->zo.ce->name));
+			zend_throw_error(NULL, "%s object is already closed", ZSTR_VAL(obj->zo.ce->name));
 		}
 
 		return FAILURE;

--- a/ext/mysqli/tests/mysqli_poll.phpt
+++ b/ext/mysqli/tests/mysqli_poll.phpt
@@ -39,6 +39,14 @@ if (!$IS_MYSQLND)
     } catch (\ValueError $e) {
         echo $e->getMessage() . \PHP_EOL;
     }
+    
+    $link->close();
+    $read[0] = get_connection();
+    try {
+        mysqli_poll($read, $error, $reject, 0, 1);
+    } catch (\Error $e) {
+        echo $e->getMessage() . \PHP_EOL;
+    }
 
     function poll_async($offset, $link, $links, $errors, $reject, $exp_ready, $use_oo_syntax) {
 
@@ -116,6 +124,7 @@ if (!$IS_MYSQLND)
 --EXPECTF--
 mysqli_poll(): Argument #4 ($seconds) must be greater than or equal to 0
 mysqli_poll(): Argument #5 ($microseconds) must be greater than or equal to 0
+mysqli object is already closed
 [012 + 6] Rejecting thread %d: 0/
 [013 + 6] Rejecting thread %d: 0/
 [014 + 6] Rejecting thread %d: 0/


### PR DESCRIPTION
Promoting unreachable warning to exception. I can't write a test case for this because this exception is never going to be executed in my opinion. However, I am proposing the change for consistency. 

I would like to suggest that the error message is still quite confusing. This error can happen when MySQL is switched off and no connection can be established at all. What if we change these messages to say "%s object is closed" or even better "%s connection is closed"