### PR TITLE
Properly fix #80220

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -3726,7 +3726,8 @@ PHP_FUNCTION(imap_mail_compose)
 				convert_to_string_ex(pvalue);
 				bod->md5 = cpystr(Z_STRVAL_P(pvalue));
 			}
-		} else if (Z_TYPE_P(data) == IS_ARRAY && topbod->type == TYPEMULTIPART) {
+		} else if (Z_TYPE_P(data) == IS_ARRAY && (topbod->type == TYPEMULTIPART ||
+				(topbod->type == TYPEMESSAGE && !strcmp(topbod->subtype, "RFC822")))) {
 			short type = 0;
 			SEPARATE_ARRAY(data);
 			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type", sizeof("type") - 1)) != NULL) {


### PR DESCRIPTION
The original fix for that bug[1] broke the formerly working composition
of message/rfc822 messages, which results in a segfault when freeing
the message body now.  While `imap_mail_compose()` does not really
support composition of meaningful message/rfc822 messages (although
libc-client appears to support that), some code may still use this to
compose partial messages, and using string manipulation to create the
final message.  As such, we fix this to avoid a regression.

[1] <http://git.php.net/?p=php-src.git;a=commit;h=0d022ddf03c5fabaaa22e486d1e4a367ed9170a7>

---

This fix is most ugly, but apparently libc-client uses the same distinction in multiple places to dispatch to the `nested` union members. I have not attached a test for this issue, because composing message/rfc822 messages inevitably leaks at least a single byte. I should also mention that this patch doesn't fix the guaranteed segfault if somebody tries to compose a multipart message with a message/rfc822 part, because that was already broken, and should be considered a separate issue.