### PR TITLE
Simplify and fix generator tree management

### DIFF
--- a/Zend/tests/generators/backtrace_multi_yield_from.phpt
+++ b/Zend/tests/generators/backtrace_multi_yield_from.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Generator backtrace with multi yield from
+--FILE--
+<?php
+
+function gen() {
+    yield 1;
+    debug_print_backtrace();
+    yield 2;
+}
+
+function from($gen) {
+    yield from $gen;
+}
+
+$gen1 = gen();
+$gen2 = from($gen1);
+$gen3 = from($gen2);
+var_dump($gen3->current());
+$gen2->next();
+var_dump($gen2->current());
+$gen2->next();
+var_dump($gen2->current());
+
+?>
+--EXPECTF--
+int(1)
+int(1)
+#0  gen() called at [%s:10]
+#1  from(Generator Object ())
+#2  Generator->next() called at [%s:19]
+int(2)

--- a/Zend/tests/generators/bug80240.phpt
+++ b/Zend/tests/generators/bug80240.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #80240: Use after free multi yield from
+--FILE--
+<?php
+
+function gen() {
+    yield 0;
+    yield from gen();
+}
+
+function bar($gen) {
+    yield from $gen;
+}
+
+$gen = gen();
+$a = bar($gen);
+$b = bar($gen);
+$a->rewind();
+$b->rewind();
+$a->next();
+unset($gen);
+unset($a);
+unset($b);
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/generators/yield_from_chain_dtor_order.phpt
+++ b/Zend/tests/generators/yield_from_chain_dtor_order.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Leaf link may need to be invalidated depending on dtor order
+--FILE--
+<?php
+
+function gen2() {
+    yield 1;
+}
+function gen() {
+    yield from gen2();
+}
+function bar($g) {
+    yield from $g;
+}
+
+$gen = gen();
+$bar = bar($gen);
+var_dump($bar->current());
+$copy = $bar;
+unset($gen);
+
+?>
+--EXPECT--
+int(1)

--- a/Zend/zend_generators.h
+++ b/Zend/zend_generators.h
@@ -42,13 +42,15 @@ struct _zend_generator_node {
 	union {
 		HashTable *ht; /* if multiple children */
 		struct { /* if one child */
-			zend_generator *leaf;
+			zend_generator *leaf; /* TODO: Unused, remove. */
 			zend_generator *child;
 		} single;
 	} child;
+	/* One generator can cache a direct pointer to the current root.
+	 * The leaf member points back to the generator using the root cache. */
 	union {
-		zend_generator *leaf; /* if > 0 children */
-		zend_generator *root; /* if 0 children */
+		zend_generator *leaf; /* if parent != NULL */
+		zend_generator *root; /* if parent == NULL */
 	} ptr;
 };
 
@@ -104,26 +106,26 @@ ZEND_API zend_execute_data* zend_generator_freeze_call_stack(zend_execute_data *
 void zend_generator_yield_from(zend_generator *generator, zend_generator *from);
 ZEND_API zend_execute_data *zend_generator_check_placeholder_frame(zend_execute_data *ptr);
 
-ZEND_API zend_generator *zend_generator_update_current(zend_generator *generator, zend_generator *leaf);
+ZEND_API zend_generator *zend_generator_update_current(zend_generator *generator);
+ZEND_API zend_generator *zend_generator_update_root(zend_generator *generator);
 static zend_always_inline zend_generator *zend_generator_get_current(zend_generator *generator)
 {
-	zend_generator *leaf;
-	zend_generator *root;
-
 	if (EXPECTED(generator->node.parent == NULL)) {
 		/* we're not in yield from mode */
 		return generator;
 	}
 
-	leaf = generator->node.children ? generator->node.ptr.leaf : generator;
-	root = leaf->node.ptr.root;
+	zend_generator *root = generator->node.ptr.root;
+	if (!root) {
+		root = zend_generator_update_root(generator);
+	}
 
-	if (EXPECTED(root->execute_data && root->node.parent == NULL)) {
+	if (EXPECTED(root->execute_data)) {
 		/* generator still running */
 		return root;
 	}
 
-	return zend_generator_update_current(generator, leaf);
+	return zend_generator_update_current(generator);
 }
 
 END_EXTERN_C()


### PR DESCRIPTION
This makes a number of related changes to the generator tree management, that should hopefully make it easier to understand, more robust and faster for the common linear-chain case. Fixes https://bugs.php.net/bug.php?id=80240, which was the original motivation here.

 * Generators now only add a ref to their direct parent.
 * Nodes only store their children, not their leafs, which avoids any need for leaf updating. This means it's no longer possible to fetch the child for a certain leaf, which is something we only needed in one place (update_current). If multi-children nodes are involved, this will require doing a walk in the other direction (from leaf to root). It does not affect the common case of single-child nodes.
 * The root/leaf pointers are now seen as a pair. *One* leaf generator can point to the current root. If a different leaf generator is used, we'll move the root pointer over to that one. Again, this is a cache to make the common linear chain case fast, trees may need to scan up the parent link.

