### PR TITLE
Remove IGNORE_URL_WIN macro

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -625,7 +625,7 @@ PHP_FUNCTION(imageloadfont)
 		RETURN_THROWS();
 	}
 
-	stream = php_stream_open_wrapper(ZSTR_VAL(file), "rb", IGNORE_PATH | IGNORE_URL_WIN | REPORT_ERRORS, NULL);
+	stream = php_stream_open_wrapper(ZSTR_VAL(file), "rb", IGNORE_PATH | REPORT_ERRORS, NULL);
 	if (stream == NULL) {
 		RETURN_FALSE;
 	}
@@ -1584,7 +1584,7 @@ static void _php_image_create_from(INTERNAL_FUNCTION_PARAMETERS, int image_type,
 	}
 
 
-	stream = php_stream_open_wrapper(file, "rb", REPORT_ERRORS|IGNORE_PATH|IGNORE_URL_WIN, NULL);
+	stream = php_stream_open_wrapper(file, "rb", REPORT_ERRORS|IGNORE_PATH, NULL);
 	if (stream == NULL)	{
 		RETURN_FALSE;
 	}
@@ -1883,7 +1883,7 @@ PHP_FUNCTION(imagexbm)
 	im = php_gd_libgdimageptr_from_zval_p(imgind);
 
 	if (file != NULL) {
-		stream = php_stream_open_wrapper(file, "wb", REPORT_ERRORS|IGNORE_PATH|IGNORE_URL_WIN, NULL);
+		stream = php_stream_open_wrapper(file, "wb", REPORT_ERRORS|IGNORE_PATH, NULL);
 		if (stream == NULL) {
 			RETURN_FALSE;
 		}
@@ -4092,7 +4092,7 @@ static gdIOCtx *create_stream_context_from_zval(zval *to_zval) {
 			return NULL;
 		}
 
-		stream = php_stream_open_wrapper(Z_STRVAL_P(to_zval), "wb", REPORT_ERRORS|IGNORE_PATH|IGNORE_URL_WIN, NULL);
+		stream = php_stream_open_wrapper(Z_STRVAL_P(to_zval), "wb", REPORT_ERRORS|IGNORE_PATH, NULL);
 		if (stream == NULL) {
 			return NULL;
 		}

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1472,7 +1472,7 @@ PHPAPI int _php_error_log_ex(int opt_err, const char *message, size_t message_le
 			return FAILURE;
 
 		case 3:		/*save to a file */
-			stream = php_stream_open_wrapper(opt, "a", IGNORE_URL_WIN | REPORT_ERRORS, NULL);
+			stream = php_stream_open_wrapper(opt, "a", REPORT_ERRORS, NULL);
 			if (!stream) {
 				return FAILURE;
 			}

--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -371,7 +371,7 @@ void php_mail_log_to_syslog(char *message) {
 
 void php_mail_log_to_file(char *filename, char *message, size_t message_size) {
 	/* Write 'message' to the given file. */
-	uint32_t flags = IGNORE_URL_WIN | REPORT_ERRORS | STREAM_DISABLE_OPEN_BASEDIR;
+	uint32_t flags = REPORT_ERRORS | STREAM_DISABLE_OPEN_BASEDIR;
 	php_stream *stream = php_stream_open_wrapper(filename, "a", flags, NULL);
 	if (stream) {
 		php_stream_write(stream, message, message_size);

--- a/main/main.c
+++ b/main/main.c
@@ -1450,7 +1450,7 @@ PHP_FUNCTION(set_time_limit)
 /* {{{ php_fopen_wrapper_for_zend */
 static FILE *php_fopen_wrapper_for_zend(const char *filename, zend_string **opened_path)
 {
-	return php_stream_open_wrapper_as_file((char *)filename, "rb", USE_PATH|IGNORE_URL_WIN|REPORT_ERRORS|STREAM_OPEN_FOR_INCLUDE, opened_path);
+	return php_stream_open_wrapper_as_file((char *)filename, "rb", USE_PATH|REPORT_ERRORS|STREAM_OPEN_FOR_INCLUDE, opened_path);
 }
 /* }}} */
 

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -550,9 +550,6 @@ END_EXTERN_C()
 /* Allow blocking reads on anonymous pipes on Windows. */
 #define STREAM_USE_BLOCKING_PIPE        0x00008000
 
-/* Antique - no longer has meaning */
-#define IGNORE_URL_WIN 0
-
 int php_init_stream_wrappers(int module_number);
 int php_shutdown_stream_wrappers(int module_number);
 void php_shutdown_stream_hashes(void);


### PR DESCRIPTION
This macro is defined to zero as of PHP 5.0.0, and as the comment
indicates, is no longer relevant.  Thus, we remove the definition and
all usages from the core and bundled extensions.