### PR TITLE
Fix inconsistency in PDO transaction state

### DIFF
--- a/ext/pdo_mysql/tests/pdo_mysql_commit.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_commit.phpt
@@ -23,9 +23,14 @@ if (false == MySQLPDOTest::detect_transactional_mysql_engine($db))
         // DDL will issue an implicit commit
         $db->exec(sprintf('DROP TABLE IF EXISTS test_commit'));
         $db->exec(sprintf('CREATE TABLE test_commit(id INT) ENGINE=%s', MySQLPDOTest::detect_transactional_mysql_engine($db)));
-        if (true !== ($tmp = $db->commit())) {
-            printf("[002] No commit allowed? [%s] %s\n",
-                $db->errorCode(), implode(' ', $db->errorInfo()));
+        try {
+            $db->commit();
+            $failed = false;
+        } catch (PDOException $e) {
+            $failed = true;
+        }
+        if (!$failed) {
+            printf("[002] Commit should have failed\n");
         }
 
         // pdo_transaction_transitions should check this as well...

--- a/ext/pdo_mysql/tests/pdo_mysql_inTransaction.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_inTransaction.phpt
@@ -38,6 +38,18 @@ for ($b = 0; $b < count(BEGIN); $b++) {
         }
     }
 }
+echo "\n";
+
+// DDL query causes an implicit commit.
+$db->beginTransaction();
+var_dump($db->inTransaction());
+$db->exec('DROP TABLE IF EXISTS test');
+var_dump($db->inTransaction());
+
+// We should be able to start a new transaction after the implicit commit.
+$db->beginTransaction();
+var_dump($db->inTransaction());
+$db->commit();
 
 ?>
 --EXPECT--
@@ -65,3 +77,7 @@ bool(true)
 bool(false)
 bool(true)
 bool(false)
+
+bool(true)
+bool(false)
+bool(true)

--- a/ext/pdo_mysql/tests/pdo_mysql_rollback.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_rollback.phpt
@@ -37,12 +37,15 @@ if (false == MySQLPDOTest::detect_transactional_mysql_engine($db))
     $db->query('DROP TABLE IF EXISTS test2');
     $db->query('CREATE TABLE test2(id INT)');
     $num++;
-    $db->rollBack();
-    $row = $db->query('SELECT COUNT(*) AS _num FROM test')->fetch(PDO::FETCH_ASSOC);
-    if ($row['_num'] != $num)
-        printf("[002] ROLLBACK should have no effect because of the implicit COMMIT
-            triggered by DROP/CREATE TABLE\n");
-
+    try {
+        $db->rollBack();
+        $failed = false;
+    } catch (PDOException $e) {
+        $failed = true;
+    }
+    if (!$failed) {
+        printf("[003] Rollback should have failed\n");
+    }
 
     $db->query('DROP TABLE IF EXISTS test2');
     $db->query('CREATE TABLE test2(id INT) ENGINE=MyISAM');


### PR DESCRIPTION
This addresses an issue introduced by #4996 and reported in https://bugs.php.net/bug.php?id=80260.

Now that `PDO::inTransaction()` reports the real transaction state of the connection, there may be a mismatch with PDOs internal transaction state (in_tcx). This is compounded by the fact that MySQL performs [implicit commits](https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html) for DDL queries.

This PR fixes the issue by making beginTransaction/commit/rollBack work on the real transaction state provided by the driver as well (or falling back to in_tcx if the driver does not support it).

This does mean that writing something like

```
$pdo->beginTransaction();
$pdo->exec('CREATE DATABASE ...');
$pdo->rollBack(); // <- illegal
```

will now result in an error, because the `CREATE DATABASE` already committed the transaction. I believe this behavior is both correct and desired -- otherwise, there is no indication that the code did not behave correctly and the rollBack() was effectively ignored. However, this is still a BC break, so I wanted to double check this point.

If we don't do this change, I think we need to revert #4996 and not add full inTransaction() support for MySQL.