### PR TITLE
Raise E_WARNING on PHP related errors

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -289,11 +289,13 @@ static int php_zip_add_file(struct zip *za, const char *filename, size_t filenam
 	}
 
 	if (!expand_filepath(filename, resolved_path)) {
+		php_error_docref(NULL, E_WARNING, "No such file or directory");
 		return -1;
 	}
 
 	php_stat(resolved_path, strlen(resolved_path), FS_EXISTS, &exists_flag);
 	if (Z_TYPE(exists_flag) == IS_FALSE) {
+		php_error_docref(NULL, E_WARNING, "No such file or directory");
 		return -1;
 	}
 
@@ -1166,6 +1168,7 @@ static PHP_NAMED_FUNCTION(zif_zip_open)
 	}
 
 	if(!expand_filepath(ZSTR_VAL(filename), resolved_path)) {
+		php_error_docref(NULL, E_WARNING, "No such file or directory");
 		RETURN_FALSE;
 	}
 
@@ -1456,6 +1459,7 @@ static ZIPARCHIVE_METHOD(open)
 	}
 
 	if (!(resolved_path = expand_filepath(ZSTR_VAL(filename), NULL))) {
+		php_error_docref(NULL, E_WARNING, "No such file or directory");
 		RETURN_FALSE;
 	}
 

--- a/ext/zip/tests/bug64342_0.phpt
+++ b/ext/zip/tests/bug64342_0.phpt
@@ -37,6 +37,8 @@ DONE
 @unlink(__DIR__ . '/bug64342.zip');
 --EXPECTF--
 %s.txt
+
+Warning: ZipArchive::addFile(): No such file or directory in %s on line %d
 add failed
 close ok
 DONE

--- a/ext/zip/tests/bug64342_1-mb.phpt
+++ b/ext/zip/tests/bug64342_1-mb.phpt
@@ -37,6 +37,7 @@ if ($zip->status == ZIPARCHIVE::ER_OK) {
 }
 @unlink($file);
 ?>
---EXPECT--
+--EXPECTF--
+Warning: ZipArchive::addFile(): No such file or directory in %s on line %d
 failed
 OK

--- a/ext/zip/tests/bug64342_1.phpt
+++ b/ext/zip/tests/bug64342_1.phpt
@@ -37,6 +37,7 @@ if ($zip->status == ZIPARCHIVE::ER_OK) {
 }
 @unlink($file);
 ?>
---EXPECT--
+--EXPECTF--
+Warning: ZipArchive::addFile(): No such file or directory in %s on line %d
 failed
 OK


### PR DESCRIPTION
If Zip operations fails due to PHP error conditions before libzip even
has been called, there is no meaningful indication what failed; the
functions just return false, and the Zip status indicated that no error
did occur.  Therefore we raise `E_WARNING` in these cases.

---

As can be seen from the need to "fix" some existing tests, this might be too much of a BC break for 7.3 and even 7.4. Maybe just target 8.0?