### PR TITLE
Revert "Fix out-of-bounds write"

### DIFF
--- a/ext/mbstring/oniguruma/src/regcomp.c
+++ b/ext/mbstring/oniguruma/src/regcomp.c
@@ -5603,7 +5603,7 @@ concat_opt_exact_str(OptStr* to, UChar* s, UChar* end, OnigEncoding enc)
 
   for (i = to->len, p = s; p < end && i < OPT_EXACT_MAXLEN; ) {
     len = enclen(enc, p);
-    if (i + len >= OPT_EXACT_MAXLEN) break;
+    if (i + len > OPT_EXACT_MAXLEN) break;
     for (j = 0; j < len && p < end; j++)
       to->s[i++] = *p++;
   }


### PR DESCRIPTION
This reverts commit bf6873a18e3b6b00f82a645c0893a281ae8eadb8.

CVE-2020-26159 is bogus; the "bug" was apparently a false positive
reported by Coverity, and the "fix" apparently wrong, see
<https://github.com/kkos/oniguruma/issues/221>.