### PR TITLE
Disallow seeking on filtered streams

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1294,6 +1294,10 @@ PHPAPI zend_off_t _php_stream_tell(php_stream *stream)
 
 PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence)
 {
+	if (php_stream_is_filtered(stream)) {
+		return -1;
+	}
+
 	if (stream->fclose_stdiocast == PHP_STREAM_FCLOSE_FOPENCOOKIE) {
 		/* flush to commit data written to the fopencookie FILE* */
 		fflush(stream->stdiocast);


### PR DESCRIPTION
Most filters cannot deal with that, so we should disallow it.

---

This is the bluntest implementation of @pilif's suggestion from https://bugs.php.net/49874. Possibly, we could let individual filters announce whether they support seeking (e.g. `string.rot13` certainly could support seeking). 