### PR TITLE
Fix invalid memory read on libpath

### DIFF
--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -374,13 +374,13 @@ static void php_load_zend_extension_cb(void *arg)
 
 			efree(orig_libpath);
 			efree(err1);
-			efree(libpath);
 		}
 
 #ifdef PHP_WIN32
 		if (!php_win32_image_compatible(handle, &err1)) {
 				php_error(E_CORE_WARNING, err1);
 				efree(err1);
+				efree(libpath);
 				DL_UNLOAD(handle);
 				return;
 		}


### PR DESCRIPTION
Introduced in 3e33e1e86d15e262cd9e0224a9604e252f5d9284

(target to PHP-8.0)