### PR TITLE
Don't allow passing unknown named params to class without ctor

### DIFF
--- a/Zend/tests/named_params/ctor_extra_named_args.phpt
+++ b/Zend/tests/named_params/ctor_extra_named_args.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Passing unknown named args to a non-existing ctor
+--FILE--
+<?php
+
+try {
+    new stdClass(x: "nope");
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Unknown named parameter $x

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -130,13 +130,12 @@ static ZEND_FUNCTION(pass)
 }
 
 ZEND_BEGIN_ARG_INFO_EX(zend_pass_function_arg_info, 0, 0, 0)
-	ZEND_ARG_VARIADIC_INFO(0, args)
 ZEND_END_ARG_INFO()
 
 ZEND_API const zend_internal_function zend_pass_function = {
 	ZEND_INTERNAL_FUNCTION, /* type              */
 	{0, 0, 0},              /* arg_flags         */
-	ZEND_ACC_VARIADIC,      /* fn_flags          */
+	0,                      /* fn_flags          */
 	NULL,                   /* name              */
 	NULL,                   /* scope             */
 	NULL,                   /* prototype         */
@@ -1097,6 +1096,11 @@ static zend_never_inline ZEND_ATTRIBUTE_UNUSED bool zend_verify_internal_arg_typ
  * trust that arginfo matches what is enforced by zend_parse_parameters. */
 static zend_always_inline zend_bool zend_internal_call_should_throw(zend_function *fbc, zend_execute_data *call)
 {
+	if (fbc->internal_function.handler == ZEND_FN(pass)) {
+		/* Be lenient about the special pass function. */
+		return 0;
+	}
+
 	if (fbc->common.required_num_args > ZEND_CALL_NUM_ARGS(call)) {
 		/* Required argument not passed. */
 		return 1;


### PR DESCRIPTION
This has been brought up by @TysonAndre in https://externals.io/message/112083.