### PR TITLE
Fix #79177: FFI doesn't handle well PHP exceptions within callback

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -886,6 +886,10 @@ static void zend_ffi_callback_trampoline(ffi_cif* cif, void* ret, void** args, v
 	}
 	free_alloca(fci.params, use_heap);
 
+	if (EG(exception)) {
+		return;
+	}
+
 	ret_type = ZEND_FFI_TYPE(callback_data->type->func.ret_type);
 	if (ret_type->kind != ZEND_FFI_TYPE_VOID) {
 		zend_ffi_zval_to_cdata(ret, ret_type, &retval);

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -887,7 +887,7 @@ static void zend_ffi_callback_trampoline(ffi_cif* cif, void* ret, void** args, v
 	free_alloca(fci.params, use_heap);
 
 	if (EG(exception)) {
-		zend_throw_error(zend_ffi_exception_ce, "Uncaught %s in PHP FFI callback", ZSTR_VAL(EG(exception)->ce->name));
+		zend_throw_error(zend_ffi_exception_ce, "Throwing from FFI callbacks is not allowed");
 		zend_exception_error(EG(exception), E_ERROR);
 	}
 

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -887,8 +887,7 @@ static void zend_ffi_callback_trampoline(ffi_cif* cif, void* ret, void** args, v
 	free_alloca(fci.params, use_heap);
 
 	if (EG(exception)) {
-		zend_throw_error(zend_ffi_exception_ce, "Throwing from FFI callbacks is not allowed");
-		zend_exception_error(EG(exception), E_ERROR);
+		zend_error(E_ERROR, "Throwing from FFI callbacks is not allowed");
 	}
 
 	ret_type = ZEND_FFI_TYPE(callback_data->type->func.ret_type);

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -887,7 +887,8 @@ static void zend_ffi_callback_trampoline(ffi_cif* cif, void* ret, void** args, v
 	free_alloca(fci.params, use_heap);
 
 	if (EG(exception)) {
-		return;
+		zend_throw_error(zend_ffi_exception_ce, "Uncaught %s in PHP FFI callback", ZSTR_VAL(EG(exception)->ce->name));
+		zend_exception_error(EG(exception), E_ERROR);
 	}
 
 	ret_type = ZEND_FFI_TYPE(callback_data->type->func.ret_type);

--- a/ext/ffi/tests/bug79177.phpt
+++ b/ext/ffi/tests/bug79177.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug #79177 (FFI doesn't handle well PHP exceptions within callback)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('utils.inc');
+try {
+    ffi_cdef("extern void *zend_printf;", ffi_get_php_dll_name());
+} catch (Throwable $e) {
+    die('skip PHP symbols not available');
+}
+?>
+--FILE--
+<?php
+require_once('utils.inc');
+$php = ffi_cdef("
+typedef char (*zend_write_func_t)(const char *str, size_t str_length);
+extern zend_write_func_t zend_write;
+", ffi_get_php_dll_name());
+
+echo "Before", PHP_EOL;
+
+$originalHandler = clone $php->zend_write;
+$php->zend_write = function($str, $len): string {
+    throw new \RuntimeException('Not allowed');
+};
+try { 
+    echo "After", PHP_EOL;
+} catch (\Throwable $exception) {
+    // Do not output anything here, as handler is overridden
+} finally {
+    $php->zend_write = $originalHandler;
+}
+if (isset($exception)) {
+    echo $exception->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+Before
+Not allowed

--- a/ext/ffi/tests/bug79177.phpt
+++ b/ext/ffi/tests/bug79177.phpt
@@ -43,7 +43,7 @@ Stack trace:
 #0 %s(15): {closure}('After\n', 6)
 #1 {main}
 
-Next FFI\Exception: Uncaught RuntimeException in PHP FFI callback in %s:%d
+Next FFI\Exception: Throwing from FFI callbacks is not allowed in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/ffi/tests/bug79177.phpt
+++ b/ext/ffi/tests/bug79177.phpt
@@ -38,12 +38,10 @@ if (isset($exception)) {
 --EXPECTF--
 Before
 
-Fatal error: Uncaught RuntimeException: Not allowed in %s:%d
+Warning: Uncaught RuntimeException: Not allowed in %s:%d
 Stack trace:
-#0 %s(15): {closure}('After\n', 6)
+#0 %s(%d): {closure}('After\n', 6)
 #1 {main}
-
-Next FFI\Exception: Throwing from FFI callbacks is not allowed in %s:%d
-Stack trace:
-#0 {main}
   thrown in %s on line %d
+
+Fatal error: Throwing from FFI callbacks is not allowed in %s on line %d

--- a/ext/ffi/tests/bug79177.phpt
+++ b/ext/ffi/tests/bug79177.phpt
@@ -18,14 +18,14 @@ typedef char (*zend_write_func_t)(const char *str, size_t str_length);
 extern zend_write_func_t zend_write;
 ", ffi_get_php_dll_name());
 
-echo "Before", PHP_EOL;
+echo "Before\n";
 
 $originalHandler = clone $php->zend_write;
 $php->zend_write = function($str, $len): string {
     throw new \RuntimeException('Not allowed');
 };
 try { 
-    echo "After", PHP_EOL;
+    echo "After\n";
 } catch (\Throwable $exception) {
     // Do not output anything here, as handler is overridden
 } finally {
@@ -35,6 +35,15 @@ if (isset($exception)) {
     echo $exception->getMessage(), PHP_EOL;
 }
 ?>
---EXPECT--
+--EXPECTF--
 Before
-Not allowed
+
+Fatal error: Uncaught RuntimeException: Not allowed in %s:%d
+Stack trace:
+#0 %s(15): {closure}('After\n', 6)
+#1 {main}
+
+Next FFI\Exception: Uncaught RuntimeException in PHP FFI callback in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
When an FII callback function throws an unhandled exception, it makes
not much sense to return value to the C code.  Instead, we declare that
the return value is undefined in this case, and let userland deal with
that.

---

Alternative fixes would be to clearly define the return value in this case, or to disallow unhandled exceptions in FFI callback functions altogether.