### PR TITLE
Fix #80268: loadHTML() truncates at NUL bytes

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -2024,7 +2024,6 @@ static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 		}
 		ctxt = htmlCreateFileParserCtxt(source, NULL);
 	} else {
-		source_len = xmlStrlen((xmlChar *) source);
 		if (ZEND_SIZE_T_INT_OVFL(source_len)) {
 			php_error_docref(NULL, E_WARNING, "Input string is too long");
 			RETURN_FALSE;

--- a/ext/dom/tests/bug80268.phpt
+++ b/ext/dom/tests/bug80268.phpt
@@ -15,6 +15,10 @@ $doc->loadHTMLFile(__DIR__ . '/80268.html');
 $html = $doc->saveHTML();
 var_dump(strpos($html, '<p>foo</p>') !== false);
 ?>
+--CLEAN--
+<?
+unlink(__DIR__ . '/80268.html');
+?>
 --EXPECT--
 bool(true)
 bool(true)

--- a/ext/dom/tests/bug80268.phpt
+++ b/ext/dom/tests/bug80268.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #80268 (loadHTML() truncates at NUL bytes)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadHTML("<p>foobar</p>");
+$html = $doc->saveHTML();
+var_dump(strpos($html, 'foobar') !== false);
+?>
+--EXPECT--
+bool(true)

--- a/ext/dom/tests/bug80268.phpt
+++ b/ext/dom/tests/bug80268.phpt
@@ -16,7 +16,7 @@ $html = $doc->saveHTML();
 var_dump(strpos($html, '<p>foo</p>') !== false);
 ?>
 --CLEAN--
-<?
+<?php
 unlink(__DIR__ . '/80268.html');
 ?>
 --EXPECT--

--- a/ext/dom/tests/bug80268.phpt
+++ b/ext/dom/tests/bug80268.phpt
@@ -5,9 +5,16 @@ Bug #80268 (loadHTML() truncates at NUL bytes)
 --FILE--
 <?php
 $doc = new DOMDocument;
-$doc->loadHTML("<p>foobar</p>");
+$doc->loadHTML("<p>foo\0bar</p>");
 $html = $doc->saveHTML();
-var_dump(strpos($html, 'foobar') !== false);
+var_dump(strpos($html, '<p>foo</p>') !== false);
+
+file_put_contents(__DIR__ . '/80268.html', "<p>foo\0bar</p>");
+$doc = new DOMDocument;
+$doc->loadHTMLFile(__DIR__ . '/80268.html');
+$html = $doc->saveHTML();
+var_dump(strpos($html, '<p>foo</p>') !== false);
 ?>
 --EXPECT--
+bool(true)
 bool(true)


### PR DESCRIPTION
libxml2 has no issues parsing HTML strings with NUL bytes; these are
just ignored.  Particularly, `::loadHTMLFile()` already supports NUL
bytes, so `::loadHTML()` should as well.