### PR TITLE
Shorter functions

### DIFF
--- a/Zend/tests/short_functions/short-func-match.phpt
+++ b/Zend/tests/short_functions/short-func-match.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Short functions with match statements.
+--FILE--
+<?php
+
+function pick_one(int $a) => match($a) {
+    1 => 'One',
+    2 => 'Two',
+    3 => 'Three',
+    default => 'More',
+};
+
+print pick_one(1) . PHP_EOL;
+print pick_one(2) . PHP_EOL;
+print pick_one(3) . PHP_EOL;
+print pick_one(4) . PHP_EOL;
+
+?>
+--EXPECT--
+One
+Two
+Three
+More

--- a/Zend/tests/short_functions/short-func-match.phpt
+++ b/Zend/tests/short_functions/short-func-match.phpt
@@ -3,7 +3,7 @@ Short functions with match statements.
 --FILE--
 <?php
 
-function pick_one(int $a) => match($a) {
+fn pick_one(int $a) => match($a) {
     1 => 'One',
     2 => 'Two',
     3 => 'Three',

--- a/Zend/tests/short_functions/short-func-no-statement.phpt
+++ b/Zend/tests/short_functions/short-func-no-statement.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Non-expression statements parse error in short functions.
+--FILE--
+<?php
+
+function test(array $a) => foreach ($a as $v) print $v;
+
+test([1, 2, 3]);
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected token "foreach" in %s on line %d

--- a/Zend/tests/short_functions/short-func-no-statement.phpt
+++ b/Zend/tests/short_functions/short-func-no-statement.phpt
@@ -3,7 +3,7 @@ Non-expression statements parse error in short functions.
 --FILE--
 <?php
 
-function test(array $a) => foreach ($a as $v) print $v;
+fn test(array $a) => foreach ($a as $v) print $v;
 
 test([1, 2, 3]);
 

--- a/Zend/tests/short_functions/short-func.phpt
+++ b/Zend/tests/short_functions/short-func.phpt
@@ -1,0 +1,12 @@
+--TEST--
+
+--FILE--
+<?php
+
+function test(int $a) => $a + 1;
+
+print test(5);
+
+?>
+--EXPECT--
+6

--- a/Zend/tests/short_functions/short-func.phpt
+++ b/Zend/tests/short_functions/short-func.phpt
@@ -1,9 +1,11 @@
 --TEST--
-
+Basic short functions return values.
 --FILE--
 <?php
 
 function test(int $a) => $a + 1;
+
+function test2(int $b) => return $b . 'error';
 
 print test(5);
 

--- a/Zend/tests/short_functions/short-func.phpt
+++ b/Zend/tests/short_functions/short-func.phpt
@@ -5,10 +5,13 @@ Basic short functions return values.
 
 function test(int $a) => $a + 1;
 
-function test2(int $b) => return $b . 'error';
+function test2(int $b)
+    => $b + 1;
 
-print test(5);
+print test(5) . PHP_EOL;
+print test2(5) . PHP_EOL;
 
 ?>
 --EXPECT--
+6
 6

--- a/Zend/tests/short_functions/short-func.phpt
+++ b/Zend/tests/short_functions/short-func.phpt
@@ -5,7 +5,7 @@ Basic short functions return values.
 
 function test(int $a) => $a + 1;
 
-function test2(int $b)
+function test2(int $b): int
     => $b + 1;
 
 print test(5) . PHP_EOL;

--- a/Zend/tests/short_functions/short-func.phpt
+++ b/Zend/tests/short_functions/short-func.phpt
@@ -3,10 +3,9 @@ Basic short functions return values.
 --FILE--
 <?php
 
-function test(int $a) => $a + 1;
+fn test(int $a) => $a + 1;
 
-function test2(int $b): int
-    => $b + 1;
+fn test2(int $b): int => $b + 1;
 
 print test(5) . PHP_EOL;
 print test2(5) . PHP_EOL;

--- a/Zend/tests/short_functions/short-method-no-statement.phpt
+++ b/Zend/tests/short_functions/short-method-no-statement.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Short methods.
+--FILE--
+<?php
+
+class Test {
+
+    public function __construct(private int $b) {}
+
+    public function out(array $a) => foreach ($a as $v) print $v;
+}
+
+$t = new Test(1);
+
+print $t->out([1, 2, 3]) . PHP_EOL;
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected token "foreach" in %s on line %d

--- a/Zend/tests/short_functions/short-method-no-statement.phpt
+++ b/Zend/tests/short_functions/short-method-no-statement.phpt
@@ -7,7 +7,7 @@ class Test {
 
     public function __construct(private int $b) {}
 
-    public function out(array $a) => foreach ($a as $v) print $v;
+    public fn out(array $a) => foreach ($a as $v) print $v;
 }
 
 $t = new Test(1);

--- a/Zend/tests/short_functions/short-method.phpt
+++ b/Zend/tests/short_functions/short-method.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Basic short functions return values.
+Short methods.
 --FILE--
 <?php
 
@@ -8,12 +8,17 @@ class Test {
     public function __construct(private int $b) {}
 
     public function addUp(int $a) => $a + $this->b;
+
+    public function addUp2(int $a)
+        => $a + $this->b;
 }
 
 $t = new Test(1);
 
-print $t->addUp(5);
+print $t->addUp(5) . PHP_EOL;
+print $t->addUp2(5) . PHP_EOL;
 
 ?>
 --EXPECT--
+6
 6

--- a/Zend/tests/short_functions/short-method.phpt
+++ b/Zend/tests/short_functions/short-method.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Basic short functions return values.
+--FILE--
+<?php
+
+class Test {
+
+    public function __construct(private int $b) {}
+
+    public function addUp(int $a) => $a + $this->b;
+}
+
+$t = new Test(1);
+
+print $t->addUp(5);
+
+?>
+--EXPECT--
+6

--- a/Zend/tests/short_functions/short-method.phpt
+++ b/Zend/tests/short_functions/short-method.phpt
@@ -9,7 +9,7 @@ class Test {
 
     public function addUp(int $a) => $a + $this->b;
 
-    public function addUp2(int $a)
+    public function addUp2(int $a): int
         => $a + $this->b;
 }
 

--- a/Zend/tests/short_functions/short-method.phpt
+++ b/Zend/tests/short_functions/short-method.phpt
@@ -7,10 +7,9 @@ class Test {
 
     public function __construct(private int $b) {}
 
-    public function addUp(int $a) => $a + $this->b;
+    public fn addUp(int $a) => $a + $this->b;
 
-    public function addUp2(int $a): int
-        => $a + $this->b;
+    public fn addUp2(int $a): int => $a + $this->b;
 }
 
 $t = new Test(1);

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -927,6 +927,7 @@ absolute_trait_method_reference:
 method_body:
 		';' /* abstract method */		{ $$ = NULL; }
 	|	'{' inner_statement_list '}'	{ $$ = $2; }
+	|   T_DOUBLE_ARROW inner_statement  { $$ = zend_ast_create(ZEND_AST_RETURN, $2); }
 ;
 
 variable_modifiers:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -549,7 +549,7 @@ function_declaration_statement:
 		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2 | $13, $1, $4,
 		      zend_ast_get_str($3), $6, NULL, $11, $8, NULL); CG(extra_fn_flags) = $9; }
    | function returns_ref T_STRING backup_doc_comment '(' parameter_list ')' return_type
-     	backup_fn_flags T_DOUBLE_ARROW inner_statement backup_fn_flags
+        backup_fn_flags T_DOUBLE_ARROW expr ';' backup_fn_flags
      		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2, $1, $4,
      		      zend_ast_get_str($3), $6, NULL, zend_ast_create(ZEND_AST_RETURN, $11), $8, NULL); CG(extra_fn_flags) = $9; }
 ;
@@ -927,7 +927,7 @@ absolute_trait_method_reference:
 method_body:
 		';' /* abstract method */		{ $$ = NULL; }
 	|	'{' inner_statement_list '}'	{ $$ = $2; }
-	|   T_DOUBLE_ARROW inner_statement  { $$ = zend_ast_create(ZEND_AST_RETURN, $2); }
+	|   T_DOUBLE_ARROW expr ';'  { $$ = zend_ast_create(ZEND_AST_RETURN, $2); }
 ;
 
 variable_modifiers:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -548,7 +548,7 @@ function_declaration_statement:
 	backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
 		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2 | $13, $1, $4,
 		      zend_ast_get_str($3), $6, NULL, $11, $8, NULL); CG(extra_fn_flags) = $9; }
-   | function returns_ref T_STRING backup_doc_comment '(' parameter_list ')' return_type
+   | fn returns_ref T_STRING backup_doc_comment '(' parameter_list ')' return_type
         backup_fn_flags T_DOUBLE_ARROW expr ';' backup_fn_flags
      		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2, $1, $4,
      		      zend_ast_get_str($3), $6, NULL, zend_ast_create(ZEND_AST_RETURN, $11), $8, NULL); CG(extra_fn_flags) = $9; }
@@ -863,6 +863,11 @@ attributed_class_statement:
 		return_type backup_fn_flags method_body backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1 | $12, $2, $5,
 				  zend_ast_get_str($4), $7, NULL, $11, $9, NULL); CG(extra_fn_flags) = $10; }
+	|	method_modifiers fn returns_ref identifier backup_doc_comment '(' parameter_list ')'
+		return_type backup_fn_flags T_DOUBLE_ARROW expr ';' backup_fn_flags
+			{ $$ = zend_ast_create_decl(ZEND_AST_METHOD, $3 | $1 | $14, $2, $5,
+				  zend_ast_get_str($4), $7, NULL, zend_ast_create(ZEND_AST_RETURN, $12), $9, NULL);
+				  CG(extra_fn_flags) = $10; }
 ;
 
 class_statement:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -548,6 +548,10 @@ function_declaration_statement:
 	backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
 		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2 | $13, $1, $4,
 		      zend_ast_get_str($3), $6, NULL, $11, $8, NULL); CG(extra_fn_flags) = $9; }
+   | function returns_ref T_STRING backup_doc_comment '(' parameter_list ')' return_type
+     	backup_fn_flags '=>' inner_statement backup_fn_flags
+     		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2, $1, $4,
+     		      zend_ast_get_str($3), $6, NULL, zend_ast_create(ZEND_AST_RETURN, $11), $8, NULL); CG(extra_fn_flags) = $9; }
 ;
 
 is_reference:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -549,7 +549,7 @@ function_declaration_statement:
 		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2 | $13, $1, $4,
 		      zend_ast_get_str($3), $6, NULL, $11, $8, NULL); CG(extra_fn_flags) = $9; }
    | function returns_ref T_STRING backup_doc_comment '(' parameter_list ')' return_type
-     	backup_fn_flags '=>' inner_statement backup_fn_flags
+     	backup_fn_flags T_DOUBLE_ARROW inner_statement backup_fn_flags
      		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2, $1, $4,
      		      zend_ast_get_str($3), $6, NULL, zend_ast_create(ZEND_AST_RETURN, $11), $8, NULL); CG(extra_fn_flags) = $9; }
 ;


### PR DESCRIPTION
An alternate version of #6221 that uses `fn` instead of `function`.  Same RFC.