### PR TITLE
Fix #80280: ADD_EXTENSION_DEP() fails for ext/standard and ext/date

### DIFF
--- a/ext/date/config.w32
+++ b/ext/date/config.w32
@@ -1,6 +1,7 @@
 // vim:ft=javascript
 
 EXTENSION("date", "php_date.c", false, "/Iext/date/lib /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /DHAVE_TIMELIB_CONFIG_H=1");
+PHP_DATE = "yes";
 ADD_SOURCES("ext/date/lib", "astro.c timelib.c dow.c parse_date.c parse_tz.c tm2unixtime.c unixtime2tm.c parse_iso_intervals.c interval.c", "date");
 AC_DEFINE('HAVE_DATE', 1, 'Have date/time support');
 

--- a/ext/standard/config.w32
+++ b/ext/standard/config.w32
@@ -37,7 +37,8 @@ EXTENSION("standard", "array.c base64.c basic_functions.c browscap.c \
 	user_filters.c uuencode.c filters.c proc_open.c password.c \
 	streamsfuncs.c http.c flock_compat.c random.c hrtime.c", false /* never shared */,
 	'/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
-	PHP_INSTALL_HEADERS("", "ext/standard");
+PHP_INSTALL_HEADERS("", "ext/standard");
+PHP_STANDARD = "yes";
 if (PHP_MBREGEX != "no") {
 	CHECK_HEADER_ADD_INCLUDE("oniguruma.h", "CFLAGS_STANDARD", PHP_MBREGEX + ";ext\\mbstring\\oniguruma")
 }


### PR DESCRIPTION
`ADD_EXTENSION_DEP()` relies on the `PHP_<extname>` config variables to
be set to `"yes"`, and since the standard and date extension are always
enabled, we define the respective variables uncoditionally.