### PR TITLE
Make ReflectionUnionType final

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6529,6 +6529,7 @@ PHP_MINIT_FUNCTION(reflection) /* {{{ */
 
 	INIT_CLASS_ENTRY(_reflection_entry, "ReflectionUnionType", class_ReflectionUnionType_methods);
 	reflection_init_class_handlers(&_reflection_entry);
+	_reflection_entry.ce_flags |= ZEND_ACC_FINAL | ZEND_ACC_NO_DYNAMIC_PROPERTIES;
 	reflection_union_type_ptr = zend_register_internal_class_ex(&_reflection_entry, reflection_type_ptr);
 
 	INIT_CLASS_ENTRY(_reflection_entry, "ReflectionMethod", class_ReflectionMethod_methods);

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -568,7 +568,7 @@ class ReflectionNamedType extends ReflectionType
     public function isBuiltin() {}
 }
 
-class ReflectionUnionType extends ReflectionType
+final class ReflectionUnionType extends ReflectionType
 {
     public function getTypes(): array {}
 }

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ec7607b8087ddd4297bf51cc4072465d2a0f27af */
+ * Stub hash: 4b759a151e33cdd91e414ac332e3a2760534a1d6 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)


### PR DESCRIPTION
In spite of the fact that `ReflectionNamedType` is a non-final class, we can still decide about `ReflectionUnionType`.

Furthermore, we could also add `ZEND_ACC_NO_DYNAMIC_PROPERTIES` to `ReflectionAttribute`, if it's really desirable.