### PR TITLE
constant size for bench.php

### DIFF
--- a/ext/hash/bench.php
+++ b/ext/hash/bench.php
@@ -3,8 +3,7 @@
 
 error_reporting(E_ALL);
 
-// 2240 comes from the fact that it used to be file_get_contents(__FILE__);
-$data = str_repeat("\x00", 2240);
+$data = str_repeat("\x00", (int) ($argv[1] ?? (2 * 1024)));
 $time = array();
 foreach (hash_algos() as $algo) {
     $time[$algo] = 0;

--- a/ext/hash/bench.php
+++ b/ext/hash/bench.php
@@ -3,7 +3,8 @@
 
 error_reporting(E_ALL);
 
-$data = file_get_contents(__FILE__);
+// 2240 comes from the fact that it used to be file_get_contents(__FILE__);
+$data = str_repeat("\x00", 2240);
 $time = array();
 foreach (hash_algos() as $algo) {
     $time[$algo] = 0;


### PR DESCRIPTION
i don't like the previous behaviour where the bytes to hash change every time the code change, 
that may make it difficult to compare hash() performance changes over time,

as a recent example, Nikita's commit from 2020-10-26 changed the bytes to hash from 2240 bytes to 503 bytes.. ( e0ea3e8a0180ec86e3c5da80e4a0bf5b12dea84d )