### PR TITLE
Fix tests for MariaDB

### DIFF
--- a/ext/mysqli/tests/mysqli_change_user_new.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_new.phpt
@@ -11,6 +11,9 @@ if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
 
 if (mysqli_get_server_version($link) < 50600)
     die("SKIP For MySQL >= 5.6.0");
+
+if (mysqli_get_server_version($link) >= 10_00_00)
+    die("SKIP Not applicable for MariaDB");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_change_user_old.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_old.phpt
@@ -9,7 +9,7 @@ if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     die(sprintf("SKIP Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
         $host, $user, $db, $port, $socket));
 
-if (mysqli_get_server_version($link) >= 50600)
+if (mysqli_get_server_version($link) >= 50600 && mysqli_get_server_version($link) < 10_00_00)
     die("SKIP For MySQL < 5.6.0");
 ?>
 --FILE--
@@ -102,10 +102,14 @@ if (mysqli_get_server_version($link) >= 50600)
 
     mysqli_close($link);
 
-    if (false !== ($tmp = @mysqli_change_user($link, $user, $passwd, $db)))
-        printf("[026] Expecting false, got %s/%s\n", gettype($tmp), $tmp);
+    try {
+        mysqli_change_user($link, $user, $passwd, $db);
+    } catch (Error $exception) {
+        echo $exception->getMessage() . "\n";
+    }
 
     print "done!";
 ?>
 --EXPECT--
+mysqli object is already closed
 done!

--- a/ext/pdo_mysql/tests/bug_38546.phpt
+++ b/ext/pdo_mysql/tests/bug_38546.phpt
@@ -230,14 +230,14 @@ Array
     [3] => 2
 )
 
-Warning: PDOStatement::execute(): SQLSTATE[HY000]: General error: 1366 Incorrect integer value: 'true' for column 'some_bool_1' at row 1 in %s
+Warning: PDOStatement::execute(): SQLSTATE[%s]: %s: 1366 Incorrect integer value: 'true' for column %s at row 1 in %s
 array(3) {
   [0]=>
-  string(5) "HY000"
+  string(5) "%s"
   [1]=>
   int(1366)
   [2]=>
-  string(65) "Incorrect integer value: 'true' for column 'some_bool_1' at row 1"
+  string(%d) "Incorrect integer value: 'true' for column %s at row 1"
 }
 Array
 (

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_multi_statements.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_multi_statements.phpt
@@ -73,7 +73,7 @@ array(1) {
   }
 }
 
-Warning: PDO::query(): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'INSERT INTO %s(id) VALUES (3)' at line 1 in %s on line %d
+Warning: PDO::query(): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'INSERT INTO %s(id) VALUES (3)' at line 1 in %s on line %d
 bool(false)
 string(5) "42000"
 array(2) {

--- a/ext/pdo_mysql/tests/pdo_mysql_multi_stmt_nextrowset.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_multi_stmt_nextrowset.phpt
@@ -175,7 +175,7 @@ array(3) {
 }
 bool(false)
 
-Warning: PDO::query(): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'INSERT INTO test (id, label) VALUES (99, 'x')' at line 1 in %s on line %d
+Warning: PDO::query(): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'INSERT INTO test (id, label) VALUES (99, 'x')' at line 1 in %s on line %d
 string(5) "42000"
 
 Testing with PDO::MYSQL_ATTR_MULTI_STATEMENTS set to true


### PR DESCRIPTION
MariaDB and MySQL are diverging and there are small differences. When executing tests using MariaDB some of them fail. This PR tries to fix 3 test cases for MariaDB