### PR TITLE
Fix bug79177.phpt wrt. JIT

### DIFF
--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -32,12 +32,23 @@ extern zend_module_entry zend_test_module_entry;
 ZEND_TSRMLS_CACHE_EXTERN()
 #endif
 
+#ifdef PHP_WIN32
+#	define ZEND_TEST_API __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#	define ZEND_TEST_API __attribute__ ((visibility("default")))
+#else
+#	define ZEND_TEST_API
+#endif
+
 struct bug79096 {
 	uint64_t a;
 	uint64_t b;
 };
 
-ZEND_API struct bug79096 bug79096(void);
-ZEND_API void bug79532(off_t *array, size_t elems);
+ZEND_TEST_API struct bug79096 bug79096(void);
+ZEND_TEST_API void bug79532(off_t *array, size_t elems);
+
+extern ZEND_TEST_API int *(*bug79177_cb)(void);
+ZEND_TEST_API void bug79177(void);
 
 #endif

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -340,5 +340,5 @@ void bug79532(off_t *array, size_t elems)
 ZEND_TEST_API int *(*bug79177_cb)(void);
 void bug79177(void)
 {
-	int *dummy = bug79177_cb();
+	bug79177_cb();
 }

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -336,3 +336,9 @@ void bug79532(off_t *array, size_t elems)
 		array[i] = i;
 	}
 }
+
+ZEND_TEST_API int *(*bug79177_cb)(void);
+void bug79177(void)
+{
+	int *dummy = bug79177_cb();
+}


### PR DESCRIPTION
JIT ignores that the `zend_write` callback is overwritten, so we define
our own callback and caller.

We also fix the "inconsistent DLL binding" warnings on Windows, by
introducing `ZEND_TEST_API`.

---

/cc @dstogov @nikic 