### PR TITLE
Fix #80312: change default engine from MyISAM to InnoDB

### DIFF
--- a/ext/mysqli/tests/connect.inc
+++ b/ext/mysqli/tests/connect.inc
@@ -13,7 +13,7 @@
 	$user      = getenv("MYSQL_TEST_USER")     ?: "root";
 	$passwd    = getenv("MYSQL_TEST_PASSWD")   ?: "";
 	$db        = getenv("MYSQL_TEST_DB")       ?: "test";
-	$engine    = getenv("MYSQL_TEST_ENGINE")   ?: "MyISAM";
+	$engine    = getenv("MYSQL_TEST_ENGINE")   ?: "InnoDB";
 	$socket    = getenv("MYSQL_TEST_SOCKET")   ?: null;
 	$skip_on_connect_failure  = getenv("MYSQL_TEST_SKIP_CONNECT_FAILURE") ?: true;
 	$connect_flags = (int)getenv("MYSQL_TEST_CONNECT_FLAGS") ?: 0;

--- a/ext/pdo_mysql/tests/config.inc
+++ b/ext/pdo_mysql/tests/config.inc
@@ -20,7 +20,7 @@ foreach ($config['ENV'] as $k => $v) {
 }
 
 /* MySQL specific settings */
-define('PDO_MYSQL_TEST_ENGINE', (false !== getenv('PDO_MYSQL_TEST_ENGINE')) ? getenv('PDO_MYSQL_TEST_ENGINE') : 'MyISAM');
+define('PDO_MYSQL_TEST_ENGINE', (false !== getenv('PDO_MYSQL_TEST_ENGINE')) ? getenv('PDO_MYSQL_TEST_ENGINE') : 'InnoDB');
 define('PDO_MYSQL_TEST_HOST', (false !== getenv('PDO_MYSQL_TEST_HOST')) ? getenv('PDO_MYSQL_TEST_HOST') : 'localhost');
 define('PDO_MYSQL_TEST_PORT', (false !== getenv('PDO_MYSQL_TEST_PORT')) ? getenv('PDO_MYSQL_TEST_PORT') : NULL);
 define('PDO_MYSQL_TEST_DB', (false !== getenv('PDO_MYSQL_TEST_DB')) ? getenv('PDO_MYSQL_TEST_DB') : 'test');


### PR DESCRIPTION
change mysqli and pdo_mysql tests configuration to use by default
InnoDB instead of MyISAM