### PR TITLE
Remove embedded property from mysqli_driver

### DIFF
--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -577,7 +577,6 @@ PHP_MINIT_FUNCTION(mysqli)
 	zend_declare_property_null(ce, "client_info", 		sizeof("client_info") - 1, ZEND_ACC_PUBLIC);
 	zend_declare_property_null(ce, "client_version", 	sizeof("client_version") - 1, ZEND_ACC_PUBLIC);
 	zend_declare_property_null(ce, "driver_version", 	sizeof("driver_version") - 1, ZEND_ACC_PUBLIC);
-	zend_declare_property_null(ce, "embedded", 			sizeof("embedded") - 1, ZEND_ACC_PUBLIC);
 	zend_declare_property_null(ce, "reconnect",			sizeof("reconnect") - 1, ZEND_ACC_PUBLIC);
 	zend_declare_property_null(ce, "report_mode", 		sizeof("report_mode") - 1, ZEND_ACC_PUBLIC);
 	ce->ce_flags |= ZEND_ACC_FINAL;

--- a/ext/mysqli/mysqli_driver.c
+++ b/ext/mysqli/mysqli_driver.c
@@ -78,16 +78,6 @@ static int driver_report_write(mysqli_object *obj, zval *value)
 }
 /* }}} */
 
-/* {{{ property driver_embedded_read */
-static int driver_embedded_read(mysqli_object *obj, zval *retval, zend_bool quiet)
-{
-	/* No longer supported */
-	ZVAL_FALSE(retval);
-
-	return SUCCESS;
-}
-/* }}} */
-
 /* {{{ property driver_client_version_read */
 static int driver_client_version_read(mysqli_object *obj, zval *retval, zend_bool quiet)
 {
@@ -135,7 +125,6 @@ const mysqli_property_entry mysqli_driver_property_entries[] = {
 	{"client_info", sizeof("client_info") - 1, driver_client_info_read, NULL},
 	{"client_version", sizeof("client_version") - 1, driver_client_version_read, NULL},
 	{"driver_version", sizeof("driver_version") - 1, driver_driver_version_read, NULL},
-	{"embedded", sizeof("embedded") - 1, driver_embedded_read, NULL},
 	{"reconnect", sizeof("reconnect") - 1, driver_reconnect_read, driver_reconnect_write},
 	{"report_mode", sizeof("report_mode") - 1, driver_report_read, driver_report_write},
 	{NULL, 0, NULL, NULL}

--- a/ext/mysqli/tests/073.phpt
+++ b/ext/mysqli/tests/073.phpt
@@ -6,7 +6,6 @@ mysqli_driver properties
 <?php
     require_once("connect.inc");
 
-    var_dump($driver->embedded);
     var_dump($driver->client_version);
     var_dump($driver->client_info);
     var_dump($driver->driver_version);
@@ -15,7 +14,6 @@ mysqli_driver properties
     print "done!";
 ?>
 --EXPECTF--
-bool(false)
 int(%d)
 string(%d) "%s"
 int(%d)

--- a/ext/mysqli/tests/mysqli_class_mysqli_driver_interface.phpt
+++ b/ext/mysqli/tests/mysqli_class_mysqli_driver_interface.phpt
@@ -72,9 +72,6 @@ require_once('skipifconnectfailure.inc');
     $driver->report_mode = MYSQLI_REPORT_STRICT;
     assert($driver->report_mode === MYSQLI_REPORT_STRICT);
 
-    assert(is_bool($driver->embedded));
-    printf("driver->embedded = '%s'\n", $driver->embedded);
-
     printf("driver->reconnect = '%s'\n", $driver->reconnect);
 
     printf("\nAccess to undefined properties:\n");
@@ -93,7 +90,6 @@ Class variables:
 client_info
 client_version
 driver_version
-embedded
 reconnect
 report_mode
 
@@ -101,7 +97,6 @@ Object variables:
 client_info
 client_version
 driver_version
-embedded
 reconnect
 report_mode
 
@@ -110,7 +105,6 @@ driver->client_info = '%s'
 driver->client_version = '%d'
 driver->driver_version = '%d'
 driver->report_mode = '%d'
-driver->embedded = ''
 driver->reconnect = ''
 
 Access to undefined properties:

--- a/ext/mysqli/tests/mysqli_driver.phpt
+++ b/ext/mysqli/tests/mysqli_driver.phpt
@@ -102,10 +102,6 @@ require_once('skipifconnectfailure.inc');
     $driver->reconnect = false;
     $driver->reconnect = $reconnect;
 
-    if (!is_bool($embedded = $driver->embedded))
-        printf("[020] Expecting boolean/any, got %s/%s\n",
-            gettype($embedded), $embedded);
-
     print "done!";
 ?>
 --EXPECTF--


### PR DESCRIPTION
Since the embedded mysqli server support was completely dropped we should remember to remove embedded property from mysqli_driver. 