### PR TITLE
Deprecate mysqli::init()

### DIFF
--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -114,6 +114,7 @@ class mysqli
 
     /**
      * @return mysqli|false
+     * @deprecated
      */
     public function init() {}
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 480939b71e1dacbdbb4634dbabf375943e399b6f */
+ * Stub hash: 9015b0ee3c4f69f1d5fbf2fe343a15908e22b2b1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -967,7 +967,7 @@ static const zend_function_entry class_mysqli_methods[] = {
 #endif
 	ZEND_ME_MAPPING(get_server_info, mysqli_get_server_info, arginfo_class_mysqli_get_server_info, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(get_warnings, mysqli_get_warnings, arginfo_class_mysqli_get_warnings, ZEND_ACC_PUBLIC)
-	ZEND_ME(mysqli, init, arginfo_class_mysqli_init, ZEND_ACC_PUBLIC)
+	ZEND_ME(mysqli, init, arginfo_class_mysqli_init, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 	ZEND_ME_MAPPING(kill, mysqli_kill, arginfo_class_mysqli_kill, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(multi_query, mysqli_multi_query, arginfo_class_mysqli_multi_query, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(more_results, mysqli_more_results, arginfo_class_mysqli_more_results, ZEND_ACC_PUBLIC)

--- a/ext/mysqli/tests/bug33263.phpt
+++ b/ext/mysqli/tests/bug33263.phpt
@@ -12,7 +12,7 @@ require_once('skipifconnectfailure.inc');
     class test extends mysqli
     {
         public function __construct($host, $user, $passwd, $db, $port, $socket) {
-            parent::init();
+            parent::__construct();
             parent::real_connect($host, $user, $passwd, $db, $port, $socket);
         }
     }

--- a/ext/mysqli/tests/bug46109.phpt
+++ b/ext/mysqli/tests/bug46109.phpt
@@ -14,5 +14,8 @@ require_once('skipifconnectfailure.inc');
     $mysqli->init();
     echo "done";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method mysqli::init() is deprecated in %s on line %d
+
+Deprecated: Method mysqli::init() is deprecated in %s on line %d
 done

--- a/ext/mysqli/tests/connect.inc
+++ b/ext/mysqli/tests/connect.inc
@@ -91,7 +91,7 @@
                 $flags = ($enable_env_flags) ? $connect_flags : 0;
 
                 if ($flags !== false) {
-                    parent::init();
+                    parent::__construct();
                     $this->real_connect($host, $user, $passwd, $db, $port, $socket, $flags);
                 } else {
                     parent::__construct($host, $user, $passwd, $db, $port, $socket);


### PR DESCRIPTION
There exists `mysqli_init()` and `mysqli::init()`. The manual says that they are the same thing, but they are not. `mysqli::init()` returns NULL and is just an alias of `mysqli::__construct()` without any arguments.

Given that the usage is very confusing and the method is completely redundant I propose to deprecate it. 

**Alternative:**  
The only "real" use case for that method was in polymorphism. If you extend mysqli class you could call `init()` instead of the constructor. Since you can just as easily call the constructor, and it makes more sense to call a constructor from child constructor, the only change required would be:
```
class test extends mysqli
{
    public function __construct($host, $user, $passwd, $db, $port, $socket) {
        // parent::init();
        // change to:
        parent::__construct();
        parent::real_connect($host, $user, $passwd, $db, $port, $socket);
    }
}
```