### PR TITLE
Use MySQL syntax only for parsing MySQL statements

### DIFF
--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -577,8 +577,12 @@ struct _pdo_stmt_t {
 	 * bindParam() for its prepared statements, if false, PDO should
 	 * emulate prepare and bind on its behalf */
 	unsigned supports_placeholders:2;
+	/* if true, the statement SQL should be parsed using MySQL syntax */
+	unsigned mysql_compat:1;
 
-	unsigned _reserved:29;
+	/* the sum of the number of bits here and the bit fields preceding should
+	 * equal 32 */
+	unsigned _reserved:28;
 
 	/* the number of columns in the result set; not valid until after
 	 * the statement has been executed at least once.  In some cases, might

--- a/ext/pdo/tests/bug_79276.phpt
+++ b/ext/pdo/tests/bug_79276.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Parsing string literals on non-MySQL databases
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip');
+$dir = getenv('REDIR_TEST_DIR');
+if (false == $dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+
+$conn = PDOTest::factory();
+if ($conn->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') {
+    die('skip mysql');
+}
+?>
+--FILE--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+
+$conn  = PDOTest::factory();
+$query = <<<'SQL'
+SELECT '\'', ?'
+SQL;
+
+switch ($conn->getAttribute(PDO::ATTR_DRIVER_NAME)) {
+    case 'oci':
+        $query .= ' FROM DUAL';
+        break;
+    case 'firebird':
+        $query .= ' FROM RDB$DATABASE';
+        break;
+}
+
+$stmt = $conn->prepare($query);
+$stmt->execute();
+echo $stmt->fetchColumn(), \PHP_EOL;
+
+--EXPECT--
+\', ?

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -170,6 +170,7 @@ static int mysql_handle_preparer(pdo_dbh_t *dbh, const char *sql, size_t sql_len
 	S->H = H;
 	stmt->driver_data = S;
 	stmt->methods = &mysql_stmt_methods;
+	stmt->mysql_compat = 1;
 
 	if (H->emulate_prepare) {
 		goto end;


### PR DESCRIPTION
In order to support both the standard and MySQL string literal syntaxes, an alternative parser for MySQL is introduced.

The choice of syntax is made based on the newly introduced statement flag which, as far as I understand, makes this change unacceptable for backporting. It would be nice to identify some other way to detect the syntax using the existing statement properties.