### PR TITLE
Fix #80284: Return Value Not Checked from Function Call

### DIFF
--- a/win32/signal.c
+++ b/win32/signal.c
@@ -36,7 +36,9 @@ static void php_win32_signal_ctrl_interrupt_function(zend_execute_data *execute_
 		ZVAL_LONG(&params[0], ctrl_evt);
 
 		/* If the function returns, */
-		call_user_function(NULL, NULL, &ctrl_handler, &retval, 1, params);
+		if (FAILURE == call_user_function(NULL, NULL, &ctrl_handler, &retval, 1, params)) {
+			ZEND_ASSERT(Z_TYPE(retval) == IS_UNDEF);
+		}
 		zval_ptr_dtor(&retval);
 	}
 


### PR DESCRIPTION
We assert that `retval` `IS_UNDEF` if `call_user_function()`, to catch
a potentially uninitialized `retval`.  This might also help static code
analyzers to avoid raising false positives.

---

I don't see any [issues with the current code](https://bugs.php.net/bug.php?id=80284#1603734422), but still it might be a good idea to assert this condition. Probably PHP-8.0 or the "master" branch would be more appropriate targets for this change.