### PR TITLE
Fix #79270: segfault in libodbc.so.2.0.0

### DIFF
--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -134,7 +134,9 @@ static int odbc_handle_closer(pdo_dbh_t *dbh)
 	}
 	SQLFreeHandle(SQL_HANDLE_ENV, H->env);
 	H->env = NULL;
-	pefree(H, dbh->is_persistent);
+	if (EG(active)) {
+		pefree(H, dbh->is_persistent);
+	}
 	dbh->driver_data = NULL;
 
 	return 0;

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -140,12 +140,15 @@ static void free_cols(pdo_stmt_t *stmt, pdo_odbc_stmt *S)
 static int odbc_stmt_dtor(pdo_stmt_t *stmt)
 {
 	pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
+	pdo_odbc_db_handle *H = S->H;
 
 	if (S->stmt != SQL_NULL_HANDLE) {
-		if (stmt->executed) {
-			SQLCloseCursor(S->stmt);
+		if (H != NULL && H->env != NULL) {
+			if (stmt->executed) {
+				SQLCloseCursor(S->stmt);
+			}
+			SQLFreeHandle(SQL_HANDLE_STMT, S->stmt);
 		}
-		SQLFreeHandle(SQL_HANDLE_STMT, S->stmt);
 		S->stmt = SQL_NULL_HANDLE;
 	}
 

--- a/ext/pdo_odbc/tests/bug79270.phpt
+++ b/ext/pdo_odbc/tests/bug79270.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Bug #79270 (segfault in libodbc.so.2.0.0)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_odbc')) die('skip pdo_odbc extension not available');
+require 'ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--INI--
+zend.enable_gc=0
+--FILE--
+<?php
+require 'ext/pdo/tests/pdo_test.inc';
+
+class Core {
+    public $conn;
+    public function __construct() {
+      $this->circularReference = $this;
+    }
+
+    public function connect() {
+      $this->conn = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+    }
+
+    public $stm;
+
+    function createStm( string $foo ) {
+      $this->connect();
+      $this->stm = $this->conn->prepare("SELECT 1");
+    }
+}
+
+function someReflection( $function ) {
+    $rParameters = (new \ReflectionFunction($function))->getParameters();
+}
+
+someReflection("implode");
+
+$app = new Core;
+$app->createStm("bar");
+echo "done\n";
+?>
+--EXPECT--
+done


### PR DESCRIPTION
We must not assume that a statement handle is still valid, if the
environment handle already has been freed, which would happen if the
PDO connection object is destroyed before its associated statement
handles during shutdown.