### PR TITLE
Fix #80345: PHPIZE configuration has outdated PHP_RELEASE_VERSION

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -94,12 +94,14 @@ if (typeof(CWD) == "undefined") {
 	CWD = FSO.GetParentFolderName(FSO.GetParentFolderName(FSO.GetAbsolutePathName("main\\php_version.h")));
 }
 
-/* defaults; we pick up the precise versions from configure.ac */
-var PHP_VERSION = 7;
-var PHP_MINOR_VERSION = 4;
-var PHP_RELEASE_VERSION = 0;
-var PHP_EXTRA_VERSION = "";
-var PHP_VERSION_STRING = "7.4.0";
+if (!MODE_PHPIZE) {
+	/* defaults; we pick up the precise versions from configure.ac */
+	var PHP_VERSION = 7;
+	var PHP_MINOR_VERSION = 4;
+	var PHP_RELEASE_VERSION = 0;
+	var PHP_EXTRA_VERSION = "";
+	var PHP_VERSION_STRING = "7.4.0";
+}
 
 /* Get version numbers and DEFINE as a string */
 function get_version_numbers()
@@ -2340,6 +2342,8 @@ function generate_phpize()
 	MF.WriteLine("var PHP_VERSION=" + PHP_VERSION);
 	MF.WriteLine("var PHP_MINOR_VERSION=" + PHP_MINOR_VERSION);
 	MF.WriteLine("var PHP_RELEASE_VERSION=" + PHP_RELEASE_VERSION);
+	MF.WriteLine("var PHP_EXTRA_VERSION=\"" + PHP_EXTRA_VERSION + "\"");
+	MF.WriteLine("var PHP_VERSION_STRING=\"" + PHP_VERSION_STRING + "\"");
 	MF.WriteBlankLines(1);
 	MF.WriteLine("/* Genereted extensions list with mode (static/shared) */");
 

--- a/win32/build/phpize.js.in
+++ b/win32/build/phpize.js.in
@@ -217,6 +217,12 @@ C.WriteLine("var PHP_ANALYZER = 'disabled';");
 C.WriteLine("var PHP_PGO = 'no';");
 C.WriteLine("var PHP_PGI = 'no';");
 
+C.WriteLine("var PHP_VERSION=" + PHP_VERSION);
+C.WriteLine("var PHP_MINOR_VERSION=" + PHP_MINOR_VERSION);
+C.WriteLine("var PHP_RELEASE_VERSION=" + PHP_RELEASE_VERSION);
+C.WriteLine("var PHP_EXTRA_VERSION=\"" + PHP_EXTRA_VERSION + "\"");
+C.WriteLine("var PHP_VERSION_STRING=\"" + PHP_VERSION_STRING + "\"");
+
 C.Write(file_get_contents(PHP_DIR + "//script//ext_deps.js"));
 if (FSO.FileExists(PHP_DIR + "/script/ext_pickle.js")) {
 	C.Write(file_get_contents(PHP_DIR + "//script//ext_pickle.js"));


### PR DESCRIPTION
We must not redefine the version "constants" for phpize builds, because
these have already generated in phpize.js, from where we pass these
variables forward to configure.js.

We also add `PHP_EXTRA_VERSION` and `PHP_VERSION_STRING` to the files
for completeness.