### PR TITLE
[Observer] Save opline before calling begin/end handlers

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7710,7 +7710,6 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 
 	/* Uncaught exception */
 	if (zend_observer_fcall_op_array_extension != -1) {
-		EX(opline) = opline;
 		zend_observer_fcall_end(execute_data, EX(return_value));
 	}
 	cleanup_live_vars(execute_data, op_num, 0);
@@ -8518,7 +8517,6 @@ ZEND_VM_HANDLER(158, ZEND_CALL_TRAMPOLINE, ANY, ANY, SPEC(OBSERVER))
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
-			ZEND_OBSERVER_SAVE_OPLINE();
 			ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3956,6 +3956,7 @@ ZEND_VM_HOT_HANDLER(130, ZEND_DO_UCALL, ANY, ANY, SPEC(RETVAL,OBSERVER))
 	call->prev_execute_data = execute_data;
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
+	ZEND_OBSERVER_SAVE_OPLINE();
 	ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 	LOAD_OPLINE_EX();
 
@@ -3981,6 +3982,7 @@ ZEND_VM_HOT_HANDLER(131, ZEND_DO_FCALL_BY_NAME, ANY, ANY, SPEC(RETVAL,OBSERVER))
 		call->prev_execute_data = execute_data;
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
+		ZEND_OBSERVER_SAVE_OPLINE();
 		ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 		LOAD_OPLINE_EX();
 
@@ -4075,13 +4077,15 @@ ZEND_VM_HOT_HANDLER(60, ZEND_DO_FCALL, ANY, ANY, SPEC(RETVAL,OBSERVER))
 		call->prev_execute_data = execute_data;
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
-		ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+			ZEND_OBSERVER_SAVE_OPLINE();
+			ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+			ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
@@ -4299,6 +4303,7 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 			}
 		}
 	}
+	ZEND_OBSERVER_SAVE_OPLINE();
 	ZEND_OBSERVER_FCALL_END(execute_data, return_value);
 	ZEND_VM_DISPATCH_TO_HELPER(zend_leave_helper);
 }
@@ -7705,6 +7710,7 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 
 	/* Uncaught exception */
 	if (zend_observer_fcall_op_array_extension != -1) {
+		EX(opline) = opline;
 		zend_observer_fcall_end(execute_data, EX(return_value));
 	}
 	cleanup_live_vars(execute_data, op_num, 0);
@@ -8511,12 +8517,14 @@ ZEND_VM_HANDLER(158, ZEND_CALL_TRAMPOLINE, ANY, ANY, SPEC(OBSERVER))
 		}
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
-		ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+			ZEND_OBSERVER_SAVE_OPLINE();
+			ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+			ZEND_OBSERVER_FCALL_BEGIN(execute_data);
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1351,6 +1351,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_UCALL_SPEC_RETV
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
+
 	LOAD_OPLINE_EX();
 
 	ZEND_VM_ENTER_EX();
@@ -1375,6 +1376,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_UCALL_SPEC_RETV
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
+
 	LOAD_OPLINE_EX();
 
 	ZEND_VM_ENTER_EX();
@@ -1398,6 +1400,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_UCALL_SPEC_OBS
 	call->prev_execute_data = execute_data;
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
+	EX(opline) = opline;
 	zend_observer_fcall_begin(execute_data);
 	LOAD_OPLINE_EX();
 
@@ -1423,6 +1426,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		call->prev_execute_data = execute_data;
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
+
 
 		LOAD_OPLINE_EX();
 
@@ -1518,6 +1522,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
+
 		LOAD_OPLINE_EX();
 
 		ZEND_VM_ENTER_EX();
@@ -1611,6 +1616,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_
 		call->prev_execute_data = execute_data;
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
+		EX(opline) = opline;
 		zend_observer_fcall_begin(execute_data);
 		LOAD_OPLINE_EX();
 
@@ -1707,10 +1713,13 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+
+
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
@@ -1812,10 +1821,13 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+
+
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
@@ -1915,13 +1927,15 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_OBS
 		call->prev_execute_data = execute_data;
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
-		zend_observer_fcall_begin(execute_data);
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+			EX(opline) = opline;
+			zend_observer_fcall_begin(execute_data);
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+			zend_observer_fcall_begin(execute_data);
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
@@ -2895,6 +2909,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try
 
 	/* Uncaught exception */
 	if (zend_observer_fcall_op_array_extension != -1) {
+		EX(opline) = opline;
 		zend_observer_fcall_end(execute_data, EX(return_value));
 	}
 	cleanup_live_vars(execute_data, op_num, 0);
@@ -3136,12 +3151,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 		}
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
-
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+
+
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
@@ -3270,12 +3287,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_OBSERVER_
 		}
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
-		zend_observer_fcall_begin(execute_data);
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
+			EX(opline) = opline;
+			zend_observer_fcall_begin(execute_data);
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();
 		} else {
 			SAVE_OPLINE_EX();
+			zend_observer_fcall_begin(execute_data);
 			execute_data = EX(prev_execute_data);
 			LOAD_OPLINE();
 			ZEND_ADD_CALL_FLAG(call, ZEND_CALL_TOP);
@@ -4069,6 +4088,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 		}
 	}
 
+
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -4141,6 +4161,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 			}
 		}
 	}
+	EX(opline) = opline;
 	zend_observer_fcall_end(execute_data, return_value);
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
@@ -18574,6 +18595,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 		}
 	}
 
+
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -21138,6 +21160,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 			}
 		}
 	}
+
 
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
@@ -37669,6 +37692,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 			}
 		}
 	}
+
 
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
@@ -54736,6 +54760,7 @@ zend_leave_helper_SPEC_LABEL:
 		}
 	}
 
+
 	goto zend_leave_helper_SPEC_LABEL;
 }
 
@@ -54809,6 +54834,7 @@ zend_leave_helper_SPEC_LABEL:
 			}
 		}
 	}
+	EX(opline) = opline;
 	zend_observer_fcall_end(execute_data, return_value);
 	goto zend_leave_helper_SPEC_LABEL;
 }
@@ -56344,6 +56370,7 @@ zend_leave_helper_SPEC_LABEL:
 		}
 	}
 
+
 	goto zend_leave_helper_SPEC_LABEL;
 }
 
@@ -56641,6 +56668,7 @@ zend_leave_helper_SPEC_LABEL:
 			}
 		}
 	}
+
 
 	goto zend_leave_helper_SPEC_LABEL;
 }
@@ -57755,6 +57783,7 @@ zend_leave_helper_SPEC_LABEL:
 			}
 		}
 	}
+
 
 	goto zend_leave_helper_SPEC_LABEL;
 }

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2909,7 +2909,6 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try
 
 	/* Uncaught exception */
 	if (zend_observer_fcall_op_array_extension != -1) {
-		EX(opline) = opline;
 		zend_observer_fcall_end(execute_data, EX(return_value));
 	}
 	cleanup_live_vars(execute_data, op_num, 0);
@@ -3153,7 +3152,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
 
-
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();
 		} else {
@@ -3288,7 +3286,6 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_OBSERVER_
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
-			EX(opline) = opline;
 			zend_observer_fcall_begin(execute_data);
 			LOAD_OPLINE_EX();
 			ZEND_VM_ENTER_EX();

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -794,6 +794,7 @@ function gen_code($f, $spec, $kind, $code, $op1, $op2, $name, $extra_spec=null) 
             ($extra_spec['ISSET'] == 0 ? "\\0" : "opline->extended_value")
             : "\\0",
         "/ZEND_OBSERVER_ENABLED/" => isset($extra_spec['OBSERVER']) && $extra_spec['OBSERVER'] == 1 ? "1" : "0",
+        "/ZEND_OBSERVER_SAVE_OPLINE\(\)/" => isset($extra_spec['OBSERVER']) && $extra_spec['OBSERVER'] == 1 ? "EX(opline) = opline" : "",
         "/ZEND_OBSERVER_FCALL_BEGIN\(\s*(.*)\s*\)/" => isset($extra_spec['OBSERVER']) ?
             ($extra_spec['OBSERVER'] == 0 ? "" : "zend_observer_fcall_begin(\\1)")
             : "",

--- a/ext/zend_test/tests/observer_opline_01.phpt
+++ b/ext/zend_test/tests/observer_opline_01.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Observer: Ensure opline exists on the execute_data
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_opcode=1
+--FILE--
+<?php
+function foo()
+{
+    echo 'Foo' . PHP_EOL;
+}
+
+foo();
+include __DIR__ . '/observer.inc';
+echo array_sum([1,2,3]) . PHP_EOL;
+foo();
+?>
+--EXPECTF--
+<!-- init '%s/observer_opline_%d.php' -->
+<!-- opcode: 'ZEND_INIT_FCALL' -->
+<file '%s/observer_opline_%d.php'>
+  <!-- opcode: 'ZEND_INIT_FCALL' -->
+  <!-- init foo() -->
+  <!-- opcode: 'ZEND_ECHO' -->
+  <foo>
+    <!-- opcode: 'ZEND_ECHO' -->
+Foo
+    <!-- opcode: 'ZEND_RETURN' -->
+  </foo>
+  <!-- init '%s/observer.inc' -->
+  <!-- opcode: 'ZEND_INIT_FCALL' -->
+  <file '%s/observer.inc'>
+    <!-- opcode: 'ZEND_INIT_FCALL' -->
+    <!-- init foo_observer_test() -->
+    <!-- opcode: 'ZEND_ECHO' -->
+    <foo_observer_test>
+      <!-- opcode: 'ZEND_ECHO' -->
+foo_observer_test
+      <!-- opcode: 'ZEND_RETURN' -->
+    </foo_observer_test>
+    <!-- opcode: 'ZEND_RETURN' -->
+  </file '%s/observer.inc'>
+6
+  <foo>
+    <!-- opcode: 'ZEND_ECHO' -->
+Foo
+    <!-- opcode: 'ZEND_RETURN' -->
+  </foo>
+  <!-- opcode: 'ZEND_RETURN' -->
+</file '%s/observer_opline_%d.php'>


### PR DESCRIPTION
This PR fixes a SIGSEGV that can occur on builds that have support for global register variables (`gcc-global-regs`). On those builds, when an extension requires access to the opline from an observer begin or end handler, the opline on the `execute_data` will be `NULL` or the wrong opcode in many cases. This showed up for us when we called `zend_call_function` from a begin handler and it crashed when the [null opline was accessed](https://github.com/php/php-src/blob/ada2a55/Zend/zend_execute_API.c#L695-L698).

cc/ @dstogov 