### PR TITLE
[Observer] Provide unused retvals to observers

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4304,7 +4304,7 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 		}
 	}
 	ZEND_OBSERVER_SAVE_OPLINE();
-	ZEND_OBSERVER_FCALL_END(execute_data, return_value);
+	ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 	ZEND_VM_DISPATCH_TO_HELPER(zend_leave_helper);
 }
 
@@ -4365,7 +4365,7 @@ ZEND_VM_COLD_CONST_HANDLER(111, ZEND_RETURN_BY_REF, CONST|TMP|VAR|CV, ANY, SRC, 
 		FREE_OP1_VAR_PTR();
 	} while (0);
 
-	ZEND_OBSERVER_FCALL_END(execute_data, EX(return_value));
+	ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 	ZEND_VM_DISPATCH_TO_HELPER(zend_leave_helper);
 }
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4333,10 +4333,12 @@ ZEND_VM_COLD_CONST_HANDLER(111, ZEND_RETURN_BY_REF, CONST|TMP|VAR|CV, ANY, SRC, 
 
 			retval_ptr = GET_OP1_ZVAL_PTR(BP_VAR_R);
 			if (!EX(return_value)) {
+				ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 				FREE_OP1();
 			} else {
 				if (OP1_TYPE == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
 					ZVAL_COPY_VALUE(EX(return_value), retval_ptr);
+					ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 					break;
 				}
 
@@ -4344,6 +4346,7 @@ ZEND_VM_COLD_CONST_HANDLER(111, ZEND_RETURN_BY_REF, CONST|TMP|VAR|CV, ANY, SRC, 
 				if (OP1_TYPE == IS_CONST) {
 					Z_TRY_ADDREF_P(retval_ptr);
 				}
+				ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 			}
 			break;
 		}
@@ -4356,7 +4359,9 @@ ZEND_VM_COLD_CONST_HANDLER(111, ZEND_RETURN_BY_REF, CONST|TMP|VAR|CV, ANY, SRC, 
 				zend_error(E_NOTICE, "Only variable references should be returned by reference");
 				if (EX(return_value)) {
 					ZVAL_NEW_REF(EX(return_value), retval_ptr);
+					ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 				} else {
+					ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 					FREE_OP1_VAR_PTR();
 				}
 				break;
@@ -4372,10 +4377,10 @@ ZEND_VM_COLD_CONST_HANDLER(111, ZEND_RETURN_BY_REF, CONST|TMP|VAR|CV, ANY, SRC, 
 			ZVAL_REF(EX(return_value), Z_REF_P(retval_ptr));
 		}
 
+		ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 		FREE_OP1_VAR_PTR();
 	} while (0);
 
-	ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 	ZEND_VM_DISPATCH_TO_HELPER(zend_leave_helper);
 }
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7719,15 +7719,19 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 	}
 
 	/* Uncaught exception */
-	if (zend_observer_fcall_op_array_extension != -1) {
-		zend_observer_fcall_end(execute_data, EX(return_value));
-	}
-	cleanup_live_vars(execute_data, op_num, 0);
 	if (UNEXPECTED((EX_CALL_INFO() & ZEND_CALL_GENERATOR) != 0)) {
 		zend_generator *generator = zend_get_running_generator(EXECUTE_DATA_C);
+		if (zend_observer_fcall_op_array_extension != -1) {
+			zend_observer_fcall_end(execute_data, &generator->retval);
+		}
+		cleanup_live_vars(execute_data, op_num, 0);
 		zend_generator_close(generator, 1);
 		ZEND_VM_RETURN();
 	} else {
+		if (zend_observer_fcall_op_array_extension != -1) {
+			zend_observer_fcall_end(execute_data, EX(return_value));
+		}
+		cleanup_live_vars(execute_data, op_num, 0);
 		/* We didn't execute RETURN, and have to initialize return_value */
 		if (EX(return_value)) {
 			ZVAL_UNDEF(EX(return_value));

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4251,14 +4251,14 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 		ZEND_OBSERVER_SAVE_OPLINE();
 		ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 	} else if (!return_value) {
+		ZEND_OBSERVER_SAVE_OPLINE();
+		ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 		if (OP1_TYPE & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-		ZEND_OBSERVER_SAVE_OPLINE();
-		ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 	} else {
 		if ((OP1_TYPE & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -4248,6 +4248,8 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+		ZEND_OBSERVER_SAVE_OPLINE();
+		ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 	} else if (!return_value) {
 		if (OP1_TYPE & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -4255,6 +4257,8 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+		ZEND_OBSERVER_SAVE_OPLINE();
+		ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 	} else {
 		if ((OP1_TYPE & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -4263,6 +4267,8 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 					Z_ADDREF_P(return_value);
 				}
 			}
+			ZEND_OBSERVER_SAVE_OPLINE();
+			ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 		} else if (OP1_TYPE == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -4274,6 +4280,8 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+							ZEND_OBSERVER_SAVE_OPLINE();
+							ZEND_OBSERVER_FCALL_END(execute_data, return_value);
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -4286,6 +4294,8 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+				ZEND_OBSERVER_SAVE_OPLINE();
+				ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 			} while (0);
 		} else /* if (OP1_TYPE == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -4301,10 +4311,10 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY, SPEC(OBSERVER))
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+			ZEND_OBSERVER_SAVE_OPLINE();
+			ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 		}
 	}
-	ZEND_OBSERVER_SAVE_OPLINE();
-	ZEND_OBSERVER_FCALL_END(execute_data, retval_ptr);
 	ZEND_VM_DISPATCH_TO_HELPER(zend_leave_helper);
 }
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7719,19 +7719,15 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 	}
 
 	/* Uncaught exception */
+	if (zend_observer_fcall_op_array_extension != -1) {
+		zend_observer_fcall_end(execute_data, EX(return_value));
+	}
+	cleanup_live_vars(execute_data, op_num, 0);
 	if (UNEXPECTED((EX_CALL_INFO() & ZEND_CALL_GENERATOR) != 0)) {
 		zend_generator *generator = zend_get_running_generator(EXECUTE_DATA_C);
-		if (zend_observer_fcall_op_array_extension != -1) {
-			zend_observer_fcall_end(execute_data, &generator->retval);
-		}
-		cleanup_live_vars(execute_data, op_num, 0);
 		zend_generator_close(generator, 1);
 		ZEND_VM_RETURN();
 	} else {
-		if (zend_observer_fcall_op_array_extension != -1) {
-			zend_observer_fcall_end(execute_data, EX(return_value));
-		}
-		cleanup_live_vars(execute_data, op_num, 0);
 		/* We didn't execute RETURN, and have to initialize return_value */
 		if (EX(return_value)) {
 			ZVAL_UNDEF(EX(return_value));

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7720,7 +7720,7 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 
 	/* Uncaught exception */
 	if (zend_observer_fcall_op_array_extension != -1) {
-		zend_observer_fcall_end(execute_data, EX(return_value));
+		zend_observer_fcall_end(execute_data, NULL);
 	}
 	cleanup_live_vars(execute_data, op_num, 0);
 	if (UNEXPECTED((EX_CALL_INFO() & ZEND_CALL_GENERATOR) != 0)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4157,7 +4157,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 		}
 	}
 	SAVE_OPLINE();
-	zend_observer_fcall_end(execute_data, return_value);
+	zend_observer_fcall_end(execute_data, retval_ptr);
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -4277,7 +4277,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 		if (opline->op1_type == IS_VAR) {zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));};
 	} while (0);
 
-	zend_observer_fcall_end(execute_data, EX(return_value));
+	zend_observer_fcall_end(execute_data, retval_ptr);
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -54830,7 +54830,7 @@ zend_leave_helper_SPEC_LABEL:
 		}
 	}
 	SAVE_OPLINE();
-	zend_observer_fcall_end(execute_data, return_value);
+	zend_observer_fcall_end(execute_data, retval_ptr);
 	goto zend_leave_helper_SPEC_LABEL;
 }
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4027,6 +4027,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+
+
 	} else if (!return_value) {
 		if (IS_CONST & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -4034,6 +4036,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+
+
 	} else {
 		if ((IS_CONST & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -4042,6 +4046,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 					Z_ADDREF_P(return_value);
 				}
 			}
+
+
 		} else if (IS_CONST == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -4053,6 +4059,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+
+
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -4065,6 +4073,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+
+
 			} while (0);
 		} else /* if (IS_CONST == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -4080,10 +4090,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+
+
 		}
 	}
-
-
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -4101,6 +4111,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+		SAVE_OPLINE();
+		zend_observer_fcall_end(execute_data, retval_ptr);
 	} else if (!return_value) {
 		if (opline->op1_type & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -4108,6 +4120,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+		SAVE_OPLINE();
+		zend_observer_fcall_end(execute_data, retval_ptr);
 	} else {
 		if ((opline->op1_type & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -4116,6 +4130,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 					Z_ADDREF_P(return_value);
 				}
 			}
+			SAVE_OPLINE();
+			zend_observer_fcall_end(execute_data, retval_ptr);
 		} else if (opline->op1_type == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -4127,6 +4143,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+							SAVE_OPLINE();
+							zend_observer_fcall_end(execute_data, return_value);
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -4139,6 +4157,8 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+				SAVE_OPLINE();
+				zend_observer_fcall_end(execute_data, retval_ptr);
 			} while (0);
 		} else /* if (opline->op1_type == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -4154,10 +4174,10 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+			SAVE_OPLINE();
+			zend_observer_fcall_end(execute_data, retval_ptr);
 		}
 	}
-	SAVE_OPLINE();
-	zend_observer_fcall_end(execute_data, retval_ptr);
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -18534,6 +18554,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+
+
 	} else if (!return_value) {
 		if (IS_TMP_VAR & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -18541,6 +18563,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+
+
 	} else {
 		if ((IS_TMP_VAR & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -18549,6 +18573,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 					Z_ADDREF_P(return_value);
 				}
 			}
+
+
 		} else if (IS_TMP_VAR == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -18560,6 +18586,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+
+
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -18572,6 +18600,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+
+
 			} while (0);
 		} else /* if (IS_TMP_VAR == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -18587,10 +18617,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+
+
 		}
 	}
-
-
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -21100,6 +21130,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+
+
 	} else if (!return_value) {
 		if (IS_VAR & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -21107,6 +21139,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+
+
 	} else {
 		if ((IS_VAR & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -21115,6 +21149,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 					Z_ADDREF_P(return_value);
 				}
 			}
+
+
 		} else if (IS_VAR == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -21126,6 +21162,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+
+
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -21138,6 +21176,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+
+
 			} while (0);
 		} else /* if (IS_VAR == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -21153,10 +21193,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+
+
 		}
 	}
-
-
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -37632,6 +37672,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+
+
 	} else if (!return_value) {
 		if (IS_CV & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -37639,6 +37681,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+
+
 	} else {
 		if ((IS_CV & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -37647,6 +37691,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 					Z_ADDREF_P(return_value);
 				}
 			}
+
+
 		} else if (IS_CV == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -37658,6 +37704,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+
+
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -37670,6 +37718,8 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+
+
 			} while (0);
 		} else /* if (IS_CV == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -37685,10 +37735,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+
+
 		}
 	}
-
-
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -54699,6 +54749,8 @@ zend_leave_helper_SPEC_LABEL:
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+
+
 	} else if (!return_value) {
 		if (IS_CONST & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -54706,6 +54758,8 @@ zend_leave_helper_SPEC_LABEL:
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+
+
 	} else {
 		if ((IS_CONST & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -54714,6 +54768,8 @@ zend_leave_helper_SPEC_LABEL:
 					Z_ADDREF_P(return_value);
 				}
 			}
+
+
 		} else if (IS_CONST == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -54725,6 +54781,8 @@ zend_leave_helper_SPEC_LABEL:
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+
+
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -54737,6 +54795,8 @@ zend_leave_helper_SPEC_LABEL:
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+
+
 			} while (0);
 		} else /* if (IS_CONST == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -54752,10 +54812,10 @@ zend_leave_helper_SPEC_LABEL:
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+
+
 		}
 	}
-
-
 	goto zend_leave_helper_SPEC_LABEL;
 }
 
@@ -54774,6 +54834,8 @@ zend_leave_helper_SPEC_LABEL:
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+		SAVE_OPLINE();
+		zend_observer_fcall_end(execute_data, retval_ptr);
 	} else if (!return_value) {
 		if (opline->op1_type & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -54781,6 +54843,8 @@ zend_leave_helper_SPEC_LABEL:
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+		SAVE_OPLINE();
+		zend_observer_fcall_end(execute_data, retval_ptr);
 	} else {
 		if ((opline->op1_type & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -54789,6 +54853,8 @@ zend_leave_helper_SPEC_LABEL:
 					Z_ADDREF_P(return_value);
 				}
 			}
+			SAVE_OPLINE();
+			zend_observer_fcall_end(execute_data, retval_ptr);
 		} else if (opline->op1_type == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -54800,6 +54866,8 @@ zend_leave_helper_SPEC_LABEL:
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+							SAVE_OPLINE();
+							zend_observer_fcall_end(execute_data, return_value);
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -54812,6 +54880,8 @@ zend_leave_helper_SPEC_LABEL:
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+				SAVE_OPLINE();
+				zend_observer_fcall_end(execute_data, retval_ptr);
 			} while (0);
 		} else /* if (opline->op1_type == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -54827,10 +54897,10 @@ zend_leave_helper_SPEC_LABEL:
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+			SAVE_OPLINE();
+			zend_observer_fcall_end(execute_data, retval_ptr);
 		}
 	}
-	SAVE_OPLINE();
-	zend_observer_fcall_end(execute_data, retval_ptr);
 	goto zend_leave_helper_SPEC_LABEL;
 }
 
@@ -56309,6 +56379,8 @@ zend_leave_helper_SPEC_LABEL:
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+
+
 	} else if (!return_value) {
 		if (IS_TMP_VAR & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -56316,6 +56388,8 @@ zend_leave_helper_SPEC_LABEL:
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+
+
 	} else {
 		if ((IS_TMP_VAR & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -56324,6 +56398,8 @@ zend_leave_helper_SPEC_LABEL:
 					Z_ADDREF_P(return_value);
 				}
 			}
+
+
 		} else if (IS_TMP_VAR == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -56335,6 +56411,8 @@ zend_leave_helper_SPEC_LABEL:
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+
+
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -56347,6 +56425,8 @@ zend_leave_helper_SPEC_LABEL:
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+
+
 			} while (0);
 		} else /* if (IS_TMP_VAR == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -56362,10 +56442,10 @@ zend_leave_helper_SPEC_LABEL:
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+
+
 		}
 	}
-
-
 	goto zend_leave_helper_SPEC_LABEL;
 }
 
@@ -56608,6 +56688,8 @@ zend_leave_helper_SPEC_LABEL:
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+
+
 	} else if (!return_value) {
 		if (IS_VAR & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -56615,6 +56697,8 @@ zend_leave_helper_SPEC_LABEL:
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+
+
 	} else {
 		if ((IS_VAR & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -56623,6 +56707,8 @@ zend_leave_helper_SPEC_LABEL:
 					Z_ADDREF_P(return_value);
 				}
 			}
+
+
 		} else if (IS_VAR == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -56634,6 +56720,8 @@ zend_leave_helper_SPEC_LABEL:
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+
+
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -56646,6 +56734,8 @@ zend_leave_helper_SPEC_LABEL:
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+
+
 			} while (0);
 		} else /* if (IS_VAR == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -56661,10 +56751,10 @@ zend_leave_helper_SPEC_LABEL:
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+
+
 		}
 	}
-
-
 	goto zend_leave_helper_SPEC_LABEL;
 }
 
@@ -57723,6 +57813,8 @@ zend_leave_helper_SPEC_LABEL:
 		if (return_value) {
 			ZVAL_NULL(return_value);
 		}
+
+
 	} else if (!return_value) {
 		if (IS_CV & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
@@ -57730,6 +57822,8 @@ zend_leave_helper_SPEC_LABEL:
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
+
+
 	} else {
 		if ((IS_CV & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -57738,6 +57832,8 @@ zend_leave_helper_SPEC_LABEL:
 					Z_ADDREF_P(return_value);
 				}
 			}
+
+
 		} else if (IS_CV == IS_CV) {
 			do {
 				if (Z_OPT_REFCOUNTED_P(retval_ptr)) {
@@ -57749,6 +57845,8 @@ zend_leave_helper_SPEC_LABEL:
 								gc_possible_root(ref);
 							}
 							ZVAL_NULL(retval_ptr);
+
+
 							break;
 						} else {
 							Z_ADDREF_P(retval_ptr);
@@ -57761,6 +57859,8 @@ zend_leave_helper_SPEC_LABEL:
 					}
 				}
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
+
+
 			} while (0);
 		} else /* if (IS_CV == IS_VAR) */ {
 			if (UNEXPECTED(Z_ISREF_P(retval_ptr))) {
@@ -57776,10 +57876,10 @@ zend_leave_helper_SPEC_LABEL:
 			} else {
 				ZVAL_COPY_VALUE(return_value, retval_ptr);
 			}
+
+
 		}
 	}
-
-
 	goto zend_leave_helper_SPEC_LABEL;
 }
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4030,14 +4030,14 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 
 
 	} else if (!return_value) {
+
+
 		if (IS_CONST & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-
-
 	} else {
 		if ((IS_CONST & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -4114,14 +4114,14 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_OBSER
 		SAVE_OPLINE();
 		zend_observer_fcall_end(execute_data, retval_ptr);
 	} else if (!return_value) {
+		SAVE_OPLINE();
+		zend_observer_fcall_end(execute_data, retval_ptr);
 		if (opline->op1_type & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-		SAVE_OPLINE();
-		zend_observer_fcall_end(execute_data, retval_ptr);
 	} else {
 		if ((opline->op1_type & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -18557,14 +18557,14 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 
 
 	} else if (!return_value) {
+
+
 		if (IS_TMP_VAR & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-
-
 	} else {
 		if ((IS_TMP_VAR & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -21133,14 +21133,14 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 
 
 	} else if (!return_value) {
+
+
 		if (IS_VAR & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-
-
 	} else {
 		if ((IS_VAR & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -37675,14 +37675,14 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 
 
 	} else if (!return_value) {
+
+
 		if (IS_CV & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-
-
 	} else {
 		if ((IS_CV & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -54752,14 +54752,14 @@ zend_leave_helper_SPEC_LABEL:
 
 
 	} else if (!return_value) {
+
+
 		if (IS_CONST & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-
-
 	} else {
 		if ((IS_CONST & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -54837,14 +54837,14 @@ zend_leave_helper_SPEC_LABEL:
 		SAVE_OPLINE();
 		zend_observer_fcall_end(execute_data, retval_ptr);
 	} else if (!return_value) {
+		SAVE_OPLINE();
+		zend_observer_fcall_end(execute_data, retval_ptr);
 		if (opline->op1_type & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-		SAVE_OPLINE();
-		zend_observer_fcall_end(execute_data, retval_ptr);
 	} else {
 		if ((opline->op1_type & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -56382,14 +56382,14 @@ zend_leave_helper_SPEC_LABEL:
 
 
 	} else if (!return_value) {
+
+
 		if (IS_TMP_VAR & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-
-
 	} else {
 		if ((IS_TMP_VAR & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -56691,14 +56691,14 @@ zend_leave_helper_SPEC_LABEL:
 
 
 	} else if (!return_value) {
+
+
 		if (IS_VAR & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-
-
 	} else {
 		if ((IS_VAR & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);
@@ -57816,14 +57816,14 @@ zend_leave_helper_SPEC_LABEL:
 
 
 	} else if (!return_value) {
+
+
 		if (IS_CV & (IS_VAR|IS_TMP_VAR)) {
 			if (Z_REFCOUNTED_P(retval_ptr) && !Z_DELREF_P(retval_ptr)) {
 				SAVE_OPLINE();
 				rc_dtor_func(Z_COUNTED_P(retval_ptr));
 			}
 		}
-
-
 	} else {
 		if ((IS_CV & (IS_CONST|IS_TMP_VAR))) {
 			ZVAL_COPY_VALUE(return_value, retval_ptr);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2904,19 +2904,15 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try
 	}
 
 	/* Uncaught exception */
+	if (zend_observer_fcall_op_array_extension != -1) {
+		zend_observer_fcall_end(execute_data, EX(return_value));
+	}
+	cleanup_live_vars(execute_data, op_num, 0);
 	if (UNEXPECTED((EX_CALL_INFO() & ZEND_CALL_GENERATOR) != 0)) {
 		zend_generator *generator = zend_get_running_generator(EXECUTE_DATA_C);
-		if (zend_observer_fcall_op_array_extension != -1) {
-			zend_observer_fcall_end(execute_data, &generator->retval);
-		}
-		cleanup_live_vars(execute_data, op_num, 0);
 		zend_generator_close(generator, 1);
 		ZEND_VM_RETURN();
 	} else {
-		if (zend_observer_fcall_op_array_extension != -1) {
-			zend_observer_fcall_end(execute_data, EX(return_value));
-		}
-		cleanup_live_vars(execute_data, op_num, 0);
 		/* We didn't execute RETURN, and have to initialize return_value */
 		if (EX(return_value)) {
 			ZVAL_UNDEF(EX(return_value));

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -4197,9 +4197,11 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 			retval_ptr = RT_CONSTANT(opline, opline->op1);
 			if (!EX(return_value)) {
 
+
 			} else {
 				if (IS_CONST == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
 					ZVAL_COPY_VALUE(EX(return_value), retval_ptr);
+
 					break;
 				}
 
@@ -4207,6 +4209,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 				if (IS_CONST == IS_CONST) {
 					Z_TRY_ADDREF_P(retval_ptr);
 				}
+
 			}
 			break;
 		}
@@ -4219,7 +4222,9 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 				zend_error(E_NOTICE, "Only variable references should be returned by reference");
 				if (EX(return_value)) {
 					ZVAL_NEW_REF(EX(return_value), retval_ptr);
+
 				} else {
+
 
 				}
 				break;
@@ -4234,6 +4239,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 			}
 			ZVAL_REF(EX(return_value), Z_REF_P(retval_ptr));
 		}
+
 
 	} while (0);
 
@@ -4255,10 +4261,12 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 
 			retval_ptr = get_zval_ptr(opline->op1_type, opline->op1, BP_VAR_R);
 			if (!EX(return_value)) {
+				zend_observer_fcall_end(execute_data, retval_ptr);
 				FREE_OP(opline->op1_type, opline->op1.var);
 			} else {
 				if (opline->op1_type == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
 					ZVAL_COPY_VALUE(EX(return_value), retval_ptr);
+					zend_observer_fcall_end(execute_data, retval_ptr);
 					break;
 				}
 
@@ -4266,6 +4274,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 				if (opline->op1_type == IS_CONST) {
 					Z_TRY_ADDREF_P(retval_ptr);
 				}
+				zend_observer_fcall_end(execute_data, retval_ptr);
 			}
 			break;
 		}
@@ -4278,7 +4287,9 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 				zend_error(E_NOTICE, "Only variable references should be returned by reference");
 				if (EX(return_value)) {
 					ZVAL_NEW_REF(EX(return_value), retval_ptr);
+					zend_observer_fcall_end(execute_data, retval_ptr);
 				} else {
+					zend_observer_fcall_end(execute_data, retval_ptr);
 					if (opline->op1_type == IS_VAR) {zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));};
 				}
 				break;
@@ -4294,10 +4305,10 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPE
 			ZVAL_REF(EX(return_value), Z_REF_P(retval_ptr));
 		}
 
+		zend_observer_fcall_end(execute_data, retval_ptr);
 		if (opline->op1_type == IS_VAR) {zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));};
 	} while (0);
 
-	zend_observer_fcall_end(execute_data, retval_ptr);
 	ZEND_VM_TAIL_CALL(zend_leave_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
 }
 
@@ -18639,10 +18650,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_TMP_HANDLER
 
 			retval_ptr = _get_zval_ptr_tmp(opline->op1.var EXECUTE_DATA_CC);
 			if (!EX(return_value)) {
+
 				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 			} else {
 				if (IS_TMP_VAR == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
 					ZVAL_COPY_VALUE(EX(return_value), retval_ptr);
+
 					break;
 				}
 
@@ -18650,6 +18663,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_TMP_HANDLER
 				if (IS_TMP_VAR == IS_CONST) {
 					Z_TRY_ADDREF_P(retval_ptr);
 				}
+
 			}
 			break;
 		}
@@ -18662,7 +18676,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_TMP_HANDLER
 				zend_error(E_NOTICE, "Only variable references should be returned by reference");
 				if (EX(return_value)) {
 					ZVAL_NEW_REF(EX(return_value), retval_ptr);
+
 				} else {
+
 
 				}
 				break;
@@ -18677,6 +18693,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_TMP_HANDLER
 			}
 			ZVAL_REF(EX(return_value), Z_REF_P(retval_ptr));
 		}
+
 
 	} while (0);
 
@@ -21215,10 +21232,12 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_VAR_HANDLER
 
 			retval_ptr = _get_zval_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 			if (!EX(return_value)) {
+
 				zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 			} else {
 				if (IS_VAR == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
 					ZVAL_COPY_VALUE(EX(return_value), retval_ptr);
+
 					break;
 				}
 
@@ -21226,6 +21245,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_VAR_HANDLER
 				if (IS_VAR == IS_CONST) {
 					Z_TRY_ADDREF_P(retval_ptr);
 				}
+
 			}
 			break;
 		}
@@ -21238,7 +21258,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_VAR_HANDLER
 				zend_error(E_NOTICE, "Only variable references should be returned by reference");
 				if (EX(return_value)) {
 					ZVAL_NEW_REF(EX(return_value), retval_ptr);
+
 				} else {
+
 					zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 				}
 				break;
@@ -37758,9 +37780,11 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_CV_HANDLER(
 			retval_ptr = _get_zval_ptr_cv_BP_VAR_R(opline->op1.var EXECUTE_DATA_CC);
 			if (!EX(return_value)) {
 
+
 			} else {
 				if (IS_CV == IS_VAR && UNEXPECTED(Z_ISREF_P(retval_ptr))) {
 					ZVAL_COPY_VALUE(EX(return_value), retval_ptr);
+
 					break;
 				}
 
@@ -37768,6 +37792,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_CV_HANDLER(
 				if (IS_CV == IS_CONST) {
 					Z_TRY_ADDREF_P(retval_ptr);
 				}
+
 			}
 			break;
 		}
@@ -37780,7 +37805,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_CV_HANDLER(
 				zend_error(E_NOTICE, "Only variable references should be returned by reference");
 				if (EX(return_value)) {
 					ZVAL_NEW_REF(EX(return_value), retval_ptr);
+
 				} else {
+
 
 				}
 				break;
@@ -37795,6 +37822,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_BY_REF_SPEC_CV_HANDLER(
 			}
 			ZVAL_REF(EX(return_value), Z_REF_P(retval_ptr));
 		}
+
 
 	} while (0);
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2905,7 +2905,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try
 
 	/* Uncaught exception */
 	if (zend_observer_fcall_op_array_extension != -1) {
-		zend_observer_fcall_end(execute_data, EX(return_value));
+		zend_observer_fcall_end(execute_data, NULL);
 	}
 	cleanup_live_vars(execute_data, op_num, 0);
 	if (UNEXPECTED((EX_CALL_INFO() & ZEND_CALL_GENERATOR) != 0)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2904,15 +2904,19 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try
 	}
 
 	/* Uncaught exception */
-	if (zend_observer_fcall_op_array_extension != -1) {
-		zend_observer_fcall_end(execute_data, EX(return_value));
-	}
-	cleanup_live_vars(execute_data, op_num, 0);
 	if (UNEXPECTED((EX_CALL_INFO() & ZEND_CALL_GENERATOR) != 0)) {
 		zend_generator *generator = zend_get_running_generator(EXECUTE_DATA_C);
+		if (zend_observer_fcall_op_array_extension != -1) {
+			zend_observer_fcall_end(execute_data, &generator->retval);
+		}
+		cleanup_live_vars(execute_data, op_num, 0);
 		zend_generator_close(generator, 1);
 		ZEND_VM_RETURN();
 	} else {
+		if (zend_observer_fcall_op_array_extension != -1) {
+			zend_observer_fcall_end(execute_data, EX(return_value));
+		}
+		cleanup_live_vars(execute_data, op_num, 0);
 		/* We didn't execute RETURN, and have to initialize return_value */
 		if (EX(return_value)) {
 			ZVAL_UNDEF(EX(return_value));

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -794,6 +794,9 @@ function gen_code($f, $spec, $kind, $code, $op1, $op2, $name, $extra_spec=null) 
             ($extra_spec['ISSET'] == 0 ? "\\0" : "opline->extended_value")
             : "\\0",
         "/ZEND_OBSERVER_ENABLED/" => isset($extra_spec['OBSERVER']) && $extra_spec['OBSERVER'] == 1 ? "1" : "0",
+        "/ZEND_OBSERVER_USE_RETVAL/" => isset($extra_spec['OBSERVER']) && $extra_spec['OBSERVER'] == 1 ? "zval observer_retval" : "",
+        "/ZEND_OBSERVER_SET_RETVAL\(\)/" => isset($extra_spec['OBSERVER']) && $extra_spec['OBSERVER'] == 1 ? "if (!return_value) { return_value = &observer_retval; }" : "",
+        "/ZEND_OBSERVER_FREE_RETVAL\(\)/" => isset($extra_spec['OBSERVER']) && $extra_spec['OBSERVER'] == 1 ? "if (return_value == &observer_retval) { zval_ptr_dtor_nogc(&observer_retval); }" : "",
         "/ZEND_OBSERVER_SAVE_OPLINE\(\)/" => isset($extra_spec['OBSERVER']) && $extra_spec['OBSERVER'] == 1 ? "SAVE_OPLINE()" : "",
         "/ZEND_OBSERVER_FCALL_BEGIN\(\s*(.*)\s*\)/" => isset($extra_spec['OBSERVER']) ?
             ($extra_spec['OBSERVER'] == 0 ? "" : "zend_observer_fcall_begin(\\1)")

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -480,7 +480,14 @@ static void get_retval_info(zval *retval, smart_str *buf)
 	if (retval == NULL) {
 		smart_str_appendl(buf, "NULL", 4);
 	} else if (ZT_G(observer_show_return_value)) {
-		php_var_export_ex(retval, 2 * ZT_G(observer_nesting_depth) + 3, buf);
+		if (Z_TYPE_P(retval) == IS_OBJECT) {
+			smart_str_appendl(buf, "object(", 7);
+			smart_str_append(buf, Z_OBJCE_P(retval)->name);
+			smart_str_appendl(buf, ")#", 2);
+			smart_str_append_long(buf, Z_OBJ_HANDLE_P(retval));
+		} else {
+			php_var_export_ex(retval, 2 * ZT_G(observer_nesting_depth) + 3, buf);
+		}
 	} else if (ZT_G(observer_show_return_type)) {
 		smart_str_appends(buf, zend_zval_type_name(retval));
 	}

--- a/ext/zend_test/tests/observer_retval_01.phpt
+++ b/ext/zend_test/tests/observer_retval_01.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Observer: Unused retvals are still observable
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+function foo() { return 'I should be observable'; }
+foo();
+echo 'Done' . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_retval_%d.php' -->
+<file '%s/observer_retval_%d.php'>
+  <!-- init foo() -->
+  <foo>
+  </foo:'I should be observable'>
+Done
+</file '%s/observer_retval_%d.php'>

--- a/ext/zend_test/tests/observer_retval_02.phpt
+++ b/ext/zend_test/tests/observer_retval_02.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Observer: Unused retvals from generators are still observable
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+function foo() {
+    yield 'I should be observable';
+    yield 'Me too!';
+}
+
+$gen = foo();
+$gen->current();
+$gen->next();
+$gen->current();
+
+echo 'Done' . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_retval_%d.php' -->
+<file '%s/observer_retval_%d.php'>
+  <!-- init foo() -->
+  <foo>
+  </foo:'I should be observable'>
+  <foo>
+  </foo:'Me too!'>
+Done
+</file '%s/observer_retval_%d.php'>

--- a/ext/zend_test/tests/observer_retval_03.phpt
+++ b/ext/zend_test/tests/observer_retval_03.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Observer: Retvals are observable that are: IS_CONST
+Observer: Retvals are observable that are: refcounted, IS_CV
 --SKIPIF--
 <?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
 --INI--
@@ -8,8 +8,11 @@ zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--
 <?php
+class MyRetval {}
+
 function foo() {
-    return 'I should be observable'; // IS_CONST
+    $retval = new MyRetval(); // Refcounted
+    return $retval; // IS_CV
 }
 
 $res = foo(); // Retval used
@@ -22,8 +25,8 @@ echo 'Done' . PHP_EOL;
 <file '%s/observer_retval_%d.php'>
   <!-- init foo() -->
   <foo>
-  </foo:'I should be observable'>
+  </foo:object(MyRetval)#%d>
   <foo>
-  </foo:'I should be observable'>
+  </foo:object(MyRetval)#%d>
 Done
 </file '%s/observer_retval_%d.php'>

--- a/ext/zend_test/tests/observer_retval_04.phpt
+++ b/ext/zend_test/tests/observer_retval_04.phpt
@@ -21,6 +21,13 @@ function foo() {
 $res = foo(); // Retval used
 foo(); // Retval unused
 
+function bar($what) {
+  return 'This gets ' . $what . ' in the return handler when unused'; // Refcounted + IS_VAR
+}
+
+$res = bar('freed'); // Retval used
+bar('freed'); // Retval unused
+
 echo 'Done' . PHP_EOL;
 ?>
 --EXPECTF--
@@ -36,5 +43,10 @@ echo 'Done' . PHP_EOL;
     <getObj>
     </getObj:object(MyRetval)#%d>
   </foo:object(MyRetval)#%d>
+  <!-- init bar() -->
+  <bar>
+  </bar:'This gets freed in the return handler when unused'>
+  <bar>
+  </bar:'This gets freed in the return handler when unused'>
 Done
 </file '%s/observer_retval_%d.php'>

--- a/ext/zend_test/tests/observer_retval_04.phpt
+++ b/ext/zend_test/tests/observer_retval_04.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Observer: Retvals are observable that are: IS_CONST
+Observer: Retvals are observable that are: refcounted, IS_VAR
 --SKIPIF--
 <?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
 --INI--
@@ -8,8 +8,14 @@ zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--
 <?php
+class MyRetval {}
+
+function getObj() {
+    return new MyRetval(); // Refcounted
+}
+
 function foo() {
-    return 'I should be observable'; // IS_CONST
+    return getObj(); // IS_VAR
 }
 
 $res = foo(); // Retval used
@@ -22,8 +28,13 @@ echo 'Done' . PHP_EOL;
 <file '%s/observer_retval_%d.php'>
   <!-- init foo() -->
   <foo>
-  </foo:'I should be observable'>
+    <!-- init getObj() -->
+    <getObj>
+    </getObj:object(MyRetval)#%d>
+  </foo:object(MyRetval)#%d>
   <foo>
-  </foo:'I should be observable'>
+    <getObj>
+    </getObj:object(MyRetval)#%d>
+  </foo:object(MyRetval)#%d>
 Done
 </file '%s/observer_retval_%d.php'>

--- a/ext/zend_test/tests/observer_retval_05.phpt
+++ b/ext/zend_test/tests/observer_retval_05.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Observer: Retvals are observable that are: IS_CONST
+Observer: Retvals are observable that are: IS_CV, IS_UNDEF
 --SKIPIF--
 <?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
 --INI--
@@ -9,7 +9,7 @@ zend_test.observer.show_return_value=1
 --FILE--
 <?php
 function foo() {
-    return 'I should be observable'; // IS_CONST
+    return $i_do_not_exist; // IS_CV && IS_UNDEF
 }
 
 $res = foo(); // Retval used
@@ -22,8 +22,12 @@ echo 'Done' . PHP_EOL;
 <file '%s/observer_retval_%d.php'>
   <!-- init foo() -->
   <foo>
-  </foo:'I should be observable'>
+
+Warning: Undefined variable $i_do_not_exist in %s on line %d
+  </foo:NULL>
   <foo>
-  </foo:'I should be observable'>
+
+Warning: Undefined variable $i_do_not_exist in %s on line %d
+  </foo:NULL>
 Done
 </file '%s/observer_retval_%d.php'>

--- a/ext/zend_test/tests/observer_retval_06.phpt
+++ b/ext/zend_test/tests/observer_retval_06.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Observer: Retvals are observable that are: IS_CONST
+Observer: Retvals are observable that are: IS_CV
 --SKIPIF--
 <?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
 --INI--
@@ -9,7 +9,8 @@ zend_test.observer.show_return_value=1
 --FILE--
 <?php
 function foo() {
-    return 'I should be observable'; // IS_CONST
+    $retval = 'I should be observable';
+    return $retval; // IS_CV
 }
 
 $res = foo(); // Retval used

--- a/ext/zend_test/tests/observer_retval_07.phpt
+++ b/ext/zend_test/tests/observer_retval_07.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Observer: Retvals are observable that are: IS_CONST
+Observer: Retvals are observable that are: IS_REFERENCE, IS_VAR
 --SKIPIF--
 <?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
 --INI--
@@ -8,8 +8,13 @@ zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--
 <?php
+function &getMessage() {
+    $retval = 'I should be observable';
+    return $retval;
+}
+
 function foo() {
-    return 'I should be observable'; // IS_CONST
+    return getMessage(); // IS_REFERENCE + IS_VAR
 }
 
 $res = foo(); // Retval used
@@ -22,8 +27,13 @@ echo 'Done' . PHP_EOL;
 <file '%s/observer_retval_%d.php'>
   <!-- init foo() -->
   <foo>
+    <!-- init getMessage() -->
+    <getMessage>
+    </getMessage:'I should be observable'>
   </foo:'I should be observable'>
   <foo>
+    <getMessage>
+    </getMessage:'I should be observable'>
   </foo:'I should be observable'>
 Done
 </file '%s/observer_retval_%d.php'>

--- a/ext/zend_test/tests/observer_retval_by_ref_01.phpt
+++ b/ext/zend_test/tests/observer_retval_by_ref_01.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Observer: Retvals are observable that are: IS_CONST
+Observer: Retvals by reference are observable that are: IS_CV
 --SKIPIF--
 <?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
 --INI--
@@ -8,8 +8,9 @@ zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--
 <?php
-function foo() {
-    return 'I should be observable'; // IS_CONST
+function &foo() {
+    $retval = 'I should be observable';
+    return $retval; // IS_CV
 }
 
 $res = foo(); // Retval used
@@ -18,12 +19,12 @@ foo(); // Retval unused
 echo 'Done' . PHP_EOL;
 ?>
 --EXPECTF--
-<!-- init '%s/observer_retval_%d.php' -->
-<file '%s/observer_retval_%d.php'>
+<!-- init '%s/observer_retval_by_ref_%d.php' -->
+<file '%s/observer_retval_by_ref_%d.php'>
   <!-- init foo() -->
   <foo>
   </foo:'I should be observable'>
   <foo>
   </foo:'I should be observable'>
 Done
-</file '%s/observer_retval_%d.php'>
+</file '%s/observer_retval_by_ref_%d.php'>

--- a/ext/zend_test/tests/observer_retval_by_ref_02.phpt
+++ b/ext/zend_test/tests/observer_retval_by_ref_02.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Observer: Retvals by reference are observable that are: IS_TMP_VAR
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+function &foo() {
+    $retval = 'I should be ';
+    return $retval . 'observable'; // IS_TMP_VAR
+}
+
+$res = foo(); // Retval used
+foo(); // Retval unused
+
+echo 'Done' . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_retval_by_ref_%d.php' -->
+<file '%s/observer_retval_by_ref_%d.php'>
+  <!-- init foo() -->
+  <foo>
+
+Notice: Only variable references should be returned by reference in %s on line %d
+  </foo:'I should be observable'>
+  <foo>
+
+Notice: Only variable references should be returned by reference in %s on line %d
+  </foo:'I should be observable'>
+Done
+</file '%s/observer_retval_by_ref_%d.php'>

--- a/ext/zend_test/tests/observer_retval_by_ref_03.phpt
+++ b/ext/zend_test/tests/observer_retval_by_ref_03.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Observer: Retvals by reference are observable that are: IS_VAR, ZEND_RETURNS_FUNCTION
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+function getMessage() {
+  return 'I should be observable';
+}
+
+function &foo() {
+    return getMessage(); // IS_VAR + ZEND_RETURNS_FUNCTION
+}
+
+$res = foo(); // Retval used
+foo(); // Retval unused
+
+echo 'Done' . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_retval_by_ref_%d.php' -->
+<file '%s/observer_retval_by_ref_%d.php'>
+  <!-- init foo() -->
+  <foo>
+    <!-- init getMessage() -->
+    <getMessage>
+    </getMessage:'I should be observable'>
+
+Notice: Only variable references should be returned by reference in %s on line %d
+  </foo:'I should be observable'>
+  <foo>
+    <getMessage>
+    </getMessage:'I should be observable'>
+
+Notice: Only variable references should be returned by reference in %s on line %d
+  </foo:'I should be observable'>
+Done
+</file '%s/observer_retval_by_ref_%d.php'>

--- a/ext/zend_test/tests/observer_shutdown_01.phpt
+++ b/ext/zend_test/tests/observer_shutdown_01.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Observer: Function calls from a shutdown handler are observable
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+register_shutdown_function(function () {
+    echo 'Shutdown: ' . foo() . PHP_EOL;
+});
+
+function bar() {
+    return 42;
+}
+
+function foo() {
+    bar();
+    return bar();
+}
+
+echo 'Done: ' . bar() . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_shutdown_%d.php' -->
+<file '%s/observer_shutdown_%d.php'>
+  <!-- init bar() -->
+  <bar>
+  </bar:42>
+Done: 42
+</file '%s/observer_shutdown_%d.php'>
+<!-- init {closure}() -->
+<{closure}>
+  <!-- init foo() -->
+  <foo>
+    <bar>
+    </bar:42>
+    <bar>
+    </bar:42>
+  </foo:42>
+Shutdown: 42
+</{closure}:NULL>

--- a/ext/zend_test/tests/observer_shutdown_02.phpt
+++ b/ext/zend_test/tests/observer_shutdown_02.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Observer: Function calls from a __destruct during shutdown are observable
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=1
+--FILE--
+<?php
+class MyClass
+{
+    public function __destruct()
+    {
+        echo 'Shutdown: ' . foo() . PHP_EOL;
+    }
+}
+
+function bar() {
+    return 42;
+}
+
+function foo() {
+    bar();
+    return bar();
+}
+
+$mc = new MyClass();
+
+echo 'Done: ' . bar() . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s/observer_shutdown_%d.php' -->
+<file '%s/observer_shutdown_%d.php'>
+  <!-- init bar() -->
+  <bar>
+  </bar:42>
+Done: 42
+</file '%s/observer_shutdown_%d.php'>
+<!-- init MyClass::__destruct() -->
+<MyClass::__destruct>
+  <!-- init foo() -->
+  <foo>
+    <bar>
+    </bar:42>
+    <bar>
+    </bar:42>
+  </foo:42>
+Shutdown: 42
+</MyClass::__destruct:NULL>


### PR DESCRIPTION
This PR ensures that if a retval is not used, it is still available to observer end handlers.