### PR TITLE
Fix newly introduced test case for Windows

### DIFF
--- a/ext/com_dotnet/tests/variants.phpt
+++ b/ext/com_dotnet/tests/variants.phpt
@@ -34,7 +34,7 @@ foreach ($values as $t => $val) {
                 echo "$op:\n";
                 echo "\tvariant_$op($v, $op2)\n";
                 echo "\texception " . $e->getMessage();
-                printf("\tcode %08x\n\n", $e->getCode());
+                printf("\n\tcode %08x\n\n", $e->getCode());
             }
         }
     }
@@ -74,63 +74,63 @@ xor: 46
 --
 add:
 	variant_add(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: 42hello
 sub:
 	variant_sub(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -141,19 +141,19 @@ mul: 0
 and: 0
 div:
 	variant_div(42, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 eqv: -43
 idiv:
 	variant_idiv(42, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 imp: -43
 mod:
 	variant_mod(42, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 or: 42
@@ -190,63 +190,63 @@ xor: 0
 --
 add:
 	variant_add(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: 3.5hello
 sub:
 	variant_sub(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -257,19 +257,19 @@ mul: 0
 and: 0
 div:
 	variant_div(3.5, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 eqv: -5
 idiv:
 	variant_idiv(3.5, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 imp: -5
 mod:
 	variant_mod(3.5, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 or: 4
@@ -278,125 +278,125 @@ xor: 4
 --
 add:
 	variant_add(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: hello42
 sub:
 	variant_sub(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
 add:
 	variant_add(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: hello3.5
 sub:
 	variant_sub(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -404,119 +404,119 @@ add: hellohello
 cat: hellohello
 sub:
 	variant_sub(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
 add:
 	variant_add(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: helloFalse
 sub:
 	variant_sub(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -550,63 +550,63 @@ xor: 4
 --
 add:
 	variant_add(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: Falsehello
 sub:
 	variant_sub(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -617,19 +617,19 @@ mul: 0
 and: 0
 div:
 	variant_div(0, )
-	exception Out of present range.
+	exception Out of present range
 	code 8002000a
 
 eqv: -1
 idiv:
 	variant_idiv(0, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 imp: -1
 mod:
 	variant_mod(0, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 or: 0

--- a/ext/com_dotnet/tests/variants_x64.phpt
+++ b/ext/com_dotnet/tests/variants_x64.phpt
@@ -37,7 +37,7 @@ foreach ($values as $t => $val) {
                 echo "$op:\n";
                 echo "\tvariant_$op($v, $op2)\n";
                 echo "\texception " . $e->getMessage();
-                printf("\tcode %08x\n\n", $e->getCode());
+                printf("\n\tcode %08x\n\n", $e->getCode());
             }
         }
     }
@@ -77,63 +77,63 @@ xor: 46
 --
 add:
 	variant_add(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: 42hello
 sub:
 	variant_sub(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(42, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -144,19 +144,19 @@ mul: 0
 and: 0
 div:
 	variant_div(42, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 eqv: -43
 idiv:
 	variant_idiv(42, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 imp: -43
 mod:
 	variant_mod(42, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 or: 42
@@ -193,63 +193,63 @@ xor: 0
 --
 add:
 	variant_add(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: 3.5hello
 sub:
 	variant_sub(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(3.5, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -260,19 +260,19 @@ mul: 0
 and: 0
 div:
 	variant_div(3.5, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 eqv: -5
 idiv:
 	variant_idiv(3.5, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 imp: -5
 mod:
 	variant_mod(3.5, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 or: 4
@@ -281,125 +281,125 @@ xor: 4
 --
 add:
 	variant_add(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: hello42
 sub:
 	variant_sub(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(hello, 42)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
 add:
 	variant_add(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: hello3.5
 sub:
 	variant_sub(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(hello, 3.5)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -407,119 +407,119 @@ add: hellohello
 cat: hellohello
 sub:
 	variant_sub(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(hello, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
 add:
 	variant_add(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: helloFalse
 sub:
 	variant_sub(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(hello, )
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -553,63 +553,63 @@ xor: 4
 --
 add:
 	variant_add(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 cat: Falsehello
 sub:
 	variant_sub(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mul:
 	variant_mul(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 and:
 	variant_and(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 div:
 	variant_div(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 eqv:
 	variant_eqv(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 idiv:
 	variant_idiv(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 imp:
 	variant_imp(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 mod:
 	variant_mod(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 or:
 	variant_or(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 pow:
 	variant_pow(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 xor:
 	variant_xor(0, hello)
-	exception Type mismatch.
+	exception Type mismatch
 	code 80020005
 
 --
@@ -620,19 +620,19 @@ mul: 0
 and: 0
 div:
 	variant_div(0, )
-	exception Out of present range.
+	exception Out of present range
 	code 8002000a
 
 eqv: -1
 idiv:
 	variant_idiv(0, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 imp: -1
 mod:
 	variant_mod(0, )
-	exception Division by zero.
+	exception Division by zero
 	code 80020012
 
 or: 0

--- a/ext/sockets/tests/socket_accept_failure.phpt
+++ b/ext/sockets/tests/socket_accept_failure.phpt
@@ -8,5 +8,5 @@ var_dump(socket_accept($socket));
 
 ?>
 --EXPECTF--
-Warning: socket_accept(): unable to accept incoming connection [%d]: %a in %s on line %d
+Warning: socket_accept(): unable to accept incoming connection [%d]: %s in %s on line %d
 bool(false)

--- a/ext/sockets/tests/socket_accept_failure.phpt
+++ b/ext/sockets/tests/socket_accept_failure.phpt
@@ -8,5 +8,5 @@ var_dump(socket_accept($socket));
 
 ?>
 --EXPECTF--
-Warning: socket_accept(): unable to accept incoming connection [%d]: %s in %s on line %d
+Warning: socket_accept(): unable to accept incoming connection [%d]: %a in %s on line %d
 bool(false)

--- a/ext/sockets/tests/socket_clear_error-win32.phpt
+++ b/ext/sockets/tests/socket_clear_error-win32.phpt
@@ -26,7 +26,6 @@ unset($socket);
 unset($socketConn);
 ?>
 --EXPECTF--
-Warning: socket_connect(): unable to connect [%d]: No connection could be made because the target machine actively refused it.
- in %s on line %d
+Warning: socket_connect(): unable to connect [%d]: No connection could be made because the target machine actively refused it in %s on line %d
 int(%d)
 int(%d)

--- a/ext/sockets/tests/socket_export_stream-4-win.phpt
+++ b/ext/sockets/tests/socket_export_stream-4-win.phpt
@@ -94,12 +94,10 @@ close stream
 stream_set_blocking TypeError: stream_set_blocking(): supplied resource is not a valid stream resource
 
 socket_set_block 
-Warning: socket_set_block(): unable to set blocking mode [%d]: An operation was attempted on something that is not a socket.
- in %s on line %d
+Warning: socket_set_block(): unable to set blocking mode [%d]: An operation was attempted on something that is not a socket in %s on line %d
 
 socket_get_option 
-Warning: socket_get_option(): Unable to retrieve socket option [%d]: An operation was attempted on something that is not a socket.
- in %s on line %d
+Warning: socket_get_option(): Unable to retrieve socket option [%d]: An operation was attempted on something that is not a socket in %s on line %d
 
 
 

--- a/ext/sockets/tests/socket_import_stream-4-win.phpt
+++ b/ext/sockets/tests/socket_import_stream-4-win.phpt
@@ -89,12 +89,10 @@ close stream
 stream_set_blocking TypeError: stream_set_blocking(): supplied resource is not a valid stream resource
 
 socket_set_block 
-Warning: socket_set_block(): unable to set blocking mode [10038]: %s
- in %ssocket_import_stream-4-win.php on line %d
+Warning: socket_set_block(): unable to set blocking mode [10038]: %s in %ssocket_import_stream-4-win.php on line %d
 
 socket_get_option 
-Warning: socket_get_option(): Unable to retrieve socket option [10038]: %s
- in %ssocket_import_stream-4-win.php on line %d
+Warning: socket_get_option(): Unable to retrieve socket option [10038]: %s in %ssocket_import_stream-4-win.php on line %d
 
 
 

--- a/ext/sockets/tests/socket_sentto_recvfrom_ipv6_udp-win32.phpt
+++ b/ext/sockets/tests/socket_sentto_recvfrom_ipv6_udp-win32.phpt
@@ -46,8 +46,7 @@ require 'ipv6_skipif.inc';
     socket_close($socket);
 ?>
 --EXPECTF--
-Warning: socket_recvfrom(): unable to recvfrom [10022]: %s
- in %s on line %d
+Warning: socket_recvfrom(): unable to recvfrom [10022]: %s in %s on line %d
 Received Ping! from remote address ::1 and remote port 1223
 --CREDITS--
 Falko Menge <mail at falko-menge dot de>

--- a/ext/sockets/tests/socket_shutdown-win32.phpt
+++ b/ext/sockets/tests/socket_shutdown-win32.phpt
@@ -50,10 +50,8 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: socket_shutdown(): Unable to shutdown socket [%d]: A request to send or receive data was disallowed because the socket is not connected and (when sending on a datagram socket using a sendto call) no address was supplied.
- in %s on line %d
+Warning: socket_shutdown(): Unable to shutdown socket [%d]: A request to send or receive data was disallowed because the socket is not connected and (when sending on a datagram socket using a sendto call) no address was supplied in %s on line %d
 bool(false)
 
-Warning: socket_shutdown(): Unable to shutdown socket [%d]: An invalid argument was supplied.
- in %s on line %d
+Warning: socket_shutdown(): Unable to shutdown socket [%d]: An invalid argument was supplied in %s on line %d
 bool(false)

--- a/ext/sockets/tests/wsaprotocol_info_0.phpt
+++ b/ext/sockets/tests/wsaprotocol_info_0.phpt
@@ -57,7 +57,6 @@ object(Socket)#%d (0) {
 object(Socket)#%d (0) {
 }
 
-Warning: socket_wsaprotocol_info_export(): Unable to export WSA protocol info [0x00002726]: %s
- in %s on line %d
+Warning: socket_wsaprotocol_info_export(): Unable to export WSA protocol info [0x00002726]: %s in %s on line %d
 
 Warning: socket_wsaprotocol_info_import(): Unable to open file mapping [0x00000002] in %s on line %d

--- a/ext/standard/tests/file/disk_free_space_error-win32.phpt
+++ b/ext/standard/tests/file/disk_free_space_error-win32.phpt
@@ -30,20 +30,16 @@ unlink($file_path."/disk_free_space.tmp");
 --EXPECTF--
 *** Testing error conditions ***
 
-Warning: disk_free_space(): The system cannot find the path specified.
- in %s on line %d
+Warning: disk_free_space(): The system cannot find the path specified in %s on line %d
 bool(false)
 
-Warning: diskfreespace(): The system cannot find the path specified.
- in %s on line %d
+Warning: diskfreespace(): The system cannot find the path specified in %s on line %d
 bool(false)
 
-Warning: disk_free_space(): The directory name is invalid.
- in %s on line %d
+Warning: disk_free_space(): The directory name is invalid in %s on line %d
 bool(false)
 
-Warning: diskfreespace(): The directory name is invalid.
- in %s on line %d
+Warning: diskfreespace(): The directory name is invalid in %s on line %d
 bool(false)
 
 -- Done --

--- a/ext/standard/tests/file/disk_total_space_error-win32.phpt
+++ b/ext/standard/tests/file/disk_total_space_error-win32.phpt
@@ -29,12 +29,10 @@ unlink($file_path."/disk_total_space.tmp");
 --EXPECTF--
 *** Testing error conditions ***
 
-Warning: disk_total_space(): The system cannot find the path specified.
- in %s on line %d
+Warning: disk_total_space(): The system cannot find the path specified in %s on line %d
 bool(false)
 
-Warning: disk_total_space(): The directory name is invalid.
- in %s on line %d
+Warning: disk_total_space(): The directory name is invalid in %s on line %d
 bool(false)
 
 --- Done ---

--- a/ext/standard/tests/file/rename_variation-win32.phpt
+++ b/ext/standard/tests/file/rename_variation-win32.phpt
@@ -65,7 +65,7 @@ bool(false)
 bool(true)
 -- Iteration 2 --
 
-Warning: rename(%s/rename_variation/rename_variation.tmp/,%s/rename_variation2.tmp): The filename, directory name, or volume label syntax is incorrect. (code: 123) in %s on line %d
+Warning: rename(%s/rename_variation/rename_variation.tmp/,%s/rename_variation2.tmp): The filename, directory name, or volume label syntax is incorrect (code: 123) in %s on line %d
 bool(false)
 bool(false)
 bool(false)

--- a/ext/standard/tests/file/rename_variation11-win32.phpt
+++ b/ext/standard/tests/file/rename_variation11-win32.phpt
@@ -86,12 +86,12 @@ bool(true)
 
 -- Iteration 5 --
 
-Warning: rename(%s\renameVar11\renameVar11Sub\..\\\renameVar11Sub\\..\\..\renameVar11Sub\renameMe.tmp,%s\renameVar11\renameVar11Sub\..\\\renameVar11Sub\\..\\..\renameVar11Sub\IwasRenamed.tmp): The system cannot find the path specified. (code: 3) in %s on line %d
+Warning: rename(%s\renameVar11\renameVar11Sub\..\\\renameVar11Sub\\..\\..\renameVar11Sub\renameMe.tmp,%s\renameVar11\renameVar11Sub\..\\\renameVar11Sub\\..\\..\renameVar11Sub\IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
 bool(false)
 
 -- Iteration 6 --
 
-Warning: rename(%s\renameVar11\renameVar11Sub\BADDIR\renameMe.tmp,%s\renameVar11\renameVar11Sub\BADDIR\IwasRenamed.tmp): The system cannot find the path specified. (code: 3) in %s on line %d
+Warning: rename(%s\renameVar11\renameVar11Sub\BADDIR\renameMe.tmp,%s\renameVar11\renameVar11Sub\BADDIR\IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
 bool(false)
 
 -- Iteration 7 --
@@ -112,7 +112,7 @@ bool(true)
 
 -- Iteration 11 --
 
-Warning: rename(BADDIR\renameMe.tmp,BADDIR\IwasRenamed.tmp): The system cannot find the path specified. (code: 3) in %s on line %d
+Warning: rename(BADDIR\renameMe.tmp,BADDIR\IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
 bool(false)
 
 -- Iteration 12 --

--- a/ext/standard/tests/file/rename_variation12-win32.phpt
+++ b/ext/standard/tests/file/rename_variation12-win32.phpt
@@ -83,12 +83,12 @@ bool(true)
 
 -- Iteration 5 --
 
-Warning: rename(%s/renameVar11/renameVar11Sub/..///renameVar11Sub//..//../renameVar11Sub/renameMe.tmp,%s/renameVar11/renameVar11Sub/..///renameVar11Sub//..//../renameVar11Sub/IwasRenamed.tmp): The system cannot find the path specified. (code: 3) in %s on line %d
+Warning: rename(%s/renameVar11/renameVar11Sub/..///renameVar11Sub//..//../renameVar11Sub/renameMe.tmp,%s/renameVar11/renameVar11Sub/..///renameVar11Sub//..//../renameVar11Sub/IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
 bool(false)
 
 -- Iteration 6 --
 
-Warning: rename(%s/renameVar11/renameVar11Sub/BADDIR/renameMe.tmp,%s/renameVar11/renameVar11Sub/BADDIR/IwasRenamed.tmp): The system cannot find the path specified. (code: 3) in %s on line %d
+Warning: rename(%s/renameVar11/renameVar11Sub/BADDIR/renameMe.tmp,%s/renameVar11/renameVar11Sub/BADDIR/IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
 bool(false)
 
 -- Iteration 7 --
@@ -109,7 +109,7 @@ bool(true)
 
 -- Iteration 11 --
 
-Warning: rename(BADDIR/renameMe.tmp,BADDIR/IwasRenamed.tmp): The system cannot find the path specified. (code: 3) in %s on line %d
+Warning: rename(BADDIR/renameMe.tmp,BADDIR/IwasRenamed.tmp): The system cannot find the path specified (code: 3) in %s on line %d
 bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/rename_variation13-win32.phpt
+++ b/ext/standard/tests/file/rename_variation13-win32.phpt
@@ -66,52 +66,52 @@ rmdir($file_path);
 -- 0 testing '-1' integer --
 bool(true)
 
-Warning: rename(-1,%safile.tmp): The system cannot find the file specified. (code: 2) in %srename_variation13-win32.php on line %d
+Warning: rename(-1,%safile.tmp): The system cannot find the file specified (code: 2) in %srename_variation13-win32.php on line %d
 bool(false)
 -- 1 testing '1' boolean --
 bool(true)
 
-Warning: rename(1,%safile.tmp): The system cannot find the file specified. (code: 2) in %srename_variation13-win32.php on line %d
+Warning: rename(1,%safile.tmp): The system cannot find the file specified (code: 2) in %srename_variation13-win32.php on line %d
 bool(false)
 -- 2 testing '' boolean --
 
-Warning: rename(%safile.tmp,): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified)\. \(code: \d+\))%r in %srename_variation13-win32.php on line %d
+Warning: rename(%safile.tmp,): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified) \(code: \d+\))%r in %srename_variation13-win32.php on line %d
 bool(false)
 
-Warning: rename(,%safile.tmp): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified)\. \(code: \d+\))%r in %srename_variation13-win32.php on line %d
+Warning: rename(,%safile.tmp): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified) \(code: \d+\))%r in %srename_variation13-win32.php on line %d
 bool(false)
 -- 3 testing '' NULL --
 
-Warning: rename(%safile.tmp,): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified)\. \(code: \d+\))%r in %srename_variation13-win32.php on line %d
+Warning: rename(%safile.tmp,): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified) \(code: \d+\))%r in %srename_variation13-win32.php on line %d
 bool(false)
 
-Warning: rename(,%safile.tmp): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified)\. \(code: \d+\))%r in %srename_variation13-win32.php on line %d
+Warning: rename(,%safile.tmp): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified) \(code: \d+\))%r in %srename_variation13-win32.php on line %d
 bool(false)
 -- 4 testing '' string --
 
-Warning: rename(%safile.tmp,): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified)\. \(code: \d+\))%r in %srename_variation13-win32.php on line %d
+Warning: rename(%safile.tmp,): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified) \(code: \d+\))%r in %srename_variation13-win32.php on line %d
 bool(false)
 
-Warning: rename(,%safile.tmp): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified)\. \(code: \d+\))%r in %srename_variation13-win32.php on line %d
+Warning: rename(,%safile.tmp): %r(Invalid argument|(The parameter is incorrect|The system cannot find the path specified) \(code: \d+\))%r in %srename_variation13-win32.php on line %d
 bool(false)
 -- 5 testing ' ' string --
 
-Warning: rename(%s): The filename, directory name, or volume label syntax is incorrect. (code: 123) in %srename_variation13-win32.php on line %d
+Warning: rename(%s): The filename, directory name, or volume label syntax is incorrect (code: 123) in %srename_variation13-win32.php on line %d
 bool(false)
 
-Warning: rename(%s): The filename, directory name, or volume label syntax is incorrect. (code: 123) in %srename_variation13-win32.php on line %d
+Warning: rename(%s): The filename, directory name, or volume label syntax is incorrect (code: 123) in %srename_variation13-win32.php on line %d
 bool(false)
 -- 6 testing '/no/such/file/dir' string --
 
-Warning: rename(%safile.tmp,/no/such/file/dir): The system cannot find the path specified. (code: 3) in %srename_variation13-win32.php on line %d
+Warning: rename(%safile.tmp,/no/such/file/dir): The system cannot find the path specified (code: 3) in %srename_variation13-win32.php on line %d
 bool(false)
 
-Warning: rename(/no/such/file/dir,%safile.tmp): The system cannot find the path specified. (code: 3) in %srename_variation13-win32.php on line %d
+Warning: rename(/no/such/file/dir,%safile.tmp): The system cannot find the path specified (code: 3) in %srename_variation13-win32.php on line %d
 bool(false)
 -- 7 testing 'php/php' string --
 
-Warning: rename(%safile.tmp,php/php): The system cannot find the path specified. (code: 3) in %srename_variation13-win32.php on line %d
+Warning: rename(%safile.tmp,php/php): The system cannot find the path specified (code: 3) in %srename_variation13-win32.php on line %d
 bool(false)
 
-Warning: rename(php/php,%safile.tmp): The system cannot find the path specified. (code: 3) in %srename_variation13-win32.php on line %d
+Warning: rename(php/php,%safile.tmp): The system cannot find the path specified (code: 3) in %srename_variation13-win32.php on line %d
 bool(false)

--- a/ext/standard/tests/file/rename_variation3-win32.phpt
+++ b/ext/standard/tests/file/rename_variation3-win32.phpt
@@ -67,7 +67,7 @@ bool(true)
 
 -- Renaming existing file to existing directory name --
 
-Warning: rename(%s/rename_variation3.tmp,%s/rename_variation3_dir): Access is denied. (code: 5) in %s on line %d
+Warning: rename(%s/rename_variation3.tmp,%s/rename_variation3_dir): Access is denied (code: 5) in %s on line %d
 bool(false)
 bool(true)
 bool(true)

--- a/ext/standard/tests/file/rename_variation8-win32.phpt
+++ b/ext/standard/tests/file/rename_variation8-win32.phpt
@@ -46,7 +46,7 @@ rmdir(__DIR__."/rename_basic_dir1");
 --EXPECTF--
 *** Testing rename() on non-existing file ***
 
-Warning: rename(%s/non_existent_file.tmp,%s/rename_variation8_new.tmp): The system cannot find the file specified. (code: 2) in %s on line %d
+Warning: rename(%s/non_existent_file.tmp,%s/rename_variation8_new.tmp): The system cannot find the file specified (code: 2) in %s on line %d
 bool(false)
 bool(false)
 bool(false)
@@ -58,7 +58,7 @@ bool(true)
 
 *** Testing rename() on non-existing directory ***
 
-Warning: rename(%s/non_existent_dir,%s/rename_basic_dir2): The system cannot find the file specified. (code: 2) in %s on line %d
+Warning: rename(%s/non_existent_dir,%s/rename_basic_dir2): The system cannot find the file specified (code: 2) in %s on line %d
 bool(false)
 bool(false)
 bool(false)

--- a/ext/standard/tests/streams/bug49936_win32.phpt
+++ b/ext/standard/tests/streams/bug49936_win32.phpt
@@ -17,14 +17,12 @@ var_dump(opendir($dir));
 
 ?>
 --EXPECTF--
-Warning: opendir(): connect() failed: %s
- in %s on line %d
+Warning: opendir(): connect() failed: %s in %s on line %d
 
 Warning: opendir(ftp://...@localhost/): Failed to open directory: operation failed in %s on line %d
 bool(false)
 
-Warning: opendir(): connect() failed: %s
- in %s on line %d
+Warning: opendir(): connect() failed: %s in %s on line %d
 
 Warning: opendir(ftp://...@localhost/): Failed to open directory: operation failed in %s on line %d
 bool(false)

--- a/main/main.c
+++ b/main/main.c
@@ -1110,13 +1110,6 @@ PHPAPI ZEND_COLD void php_error_docref2(const char *docref, const char *param1, 
 #ifdef PHP_WIN32
 PHPAPI ZEND_COLD void php_win32_docref2_from_error(DWORD error, const char *param1, const char *param2) {
 	char *buf = php_win32_error_to_msg(error);
-	size_t buf_len;
-
-	buf_len = strlen(buf);
-	if (buf_len >= 2) {
-		buf[buf_len - 1] = '\0';
-		buf[buf_len - 2] = '\0';
-	}
 	php_error_docref2(NULL, param1, param2, E_WARNING, "%s (code: %lu)", buf, error);
 	php_win32_error_msg_free(buf);
 }

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -36,12 +36,9 @@ PHP_WINUTIL_API char *php_win32_error_to_msg(HRESULT error)
 		return "";
 	}
 
-	size_t lenw = wcslen(bufw);
-	if (lenw > 0) {
-		/* strip trailing line breaks and periods */
-		for (pw = bufw + lenw - 1; *pw == L'\r' || *pw == L'\n' || *pw == L'.'; pw--);
-		pw[1] = L'\0';
-	}
+	/* strip trailing line breaks and periods */
+	for (pw = bufw + wcslen(bufw) - 1; pw >= bufw && (*pw == L'\r' || *pw == L'\n' || *pw == L'.'); pw--);
+	pw[1] = L'\0';
 
 	buf = php_win32_cp_conv_w_to_any(bufw, ret, PHP_WIN32_CP_IGNORE_LEN_P);
 

--- a/win32/winutil.c
+++ b/win32/winutil.c
@@ -24,7 +24,7 @@
 
 PHP_WINUTIL_API char *php_win32_error_to_msg(HRESULT error)
 {/*{{{*/
-	wchar_t *bufw = NULL;
+	wchar_t *bufw = NULL, *pw;
 	char *buf;
 
 	DWORD ret = FormatMessageW(
@@ -34,6 +34,13 @@ PHP_WINUTIL_API char *php_win32_error_to_msg(HRESULT error)
 
 	if (!ret || !bufw) {
 		return "";
+	}
+
+	size_t lenw = wcslen(bufw);
+	if (lenw > 0) {
+		/* strip trailing line breaks and periods */
+		for (pw = bufw + lenw - 1; *pw == L'\r' || *pw == L'\n' || *pw == L'.'; pw--);
+		pw[1] = L'\0';
 	}
 
 	buf = php_win32_cp_conv_w_to_any(bufw, ret, PHP_WIN32_CP_IGNORE_LEN_P);


### PR DESCRIPTION
On Windows, the actual error message has a trailing newline, so we
replace the `%s` specifier with `%a`.
