### PR TITLE
Fix #80366: Return Value of zend_fstat() not Checked

### DIFF
--- a/ext/standard/iptc.c
+++ b/ext/standard/iptc.c
@@ -217,7 +217,9 @@ PHP_FUNCTION(iptcembed)
 	}
 
 	if (spool < 2) {
-		zend_fstat(fileno(fp), &sb);
+		if (zend_fstat(fileno(fp), &sb) != 0) {
+			RETURN_FALSE;
+		}
 
 		spoolbuf = zend_string_safe_alloc(1, iptcdata_len + sizeof(psheader) + 1024 + 1, sb.st_size, 0);
 		poi = (unsigned char*)ZSTR_VAL(spoolbuf);


### PR DESCRIPTION
In the somewhat unlikely case that `zend_fstat()` fails, we must not
proceed executing the function, but return `false` instead.

Patch based on the patch contributed by sagpant at microsoft dot com.