### PR TITLE
Fix #80380: Cannot access numeric property in ArrayObject

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -311,7 +311,7 @@ try_again:
 	case IS_STRING:
 	   offset_key = Z_STR_P(offset);
 fetch_dim_string:
-		retval = zend_symtable_find(ht, offset_key);
+		retval = zend_hash_find(ht, offset_key);
 		if (retval) {
 			if (Z_TYPE_P(retval) == IS_INDIRECT) {
 				retval = Z_INDIRECT_P(retval);

--- a/ext/spl/tests/bug80380.phpt
+++ b/ext/spl/tests/bug80380.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #80380 (Cannot access numeric property in ArrayObject)
+--FILE--
+<?php
+$object = new stdClass;
+$object->prop = 'test1';
+$object->{'1'} = 'test2';
+
+$arrayObject = new ArrayObject($object);
+var_dump($arrayObject['prop']);
+var_dump($arrayObject['1']);
+
+$arrayObject = new ArrayObject($object, ArrayObject::ARRAY_AS_PROPS);
+var_dump($arrayObject->prop);
+var_dump($arrayObject->{'1'});
+?>
+--EXPECT--
+string(5) "test1"
+string(5) "test2"
+string(5) "test1"
+string(5) "test2"


### PR DESCRIPTION
Accessing numeric properties of objects which have been cast to array
is possible as of PHP 7.2.0, so this should be supported by ArrayObject
as well.