### PR TITLE
Fix #77961: finfo_open crafted magic parsing SIGABRT

### DIFF
--- a/ext/fileinfo/libmagic.patch
+++ b/ext/fileinfo/libmagic.patch
@@ -1,6 +1,6 @@
 diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
 --- libmagic.orig/apprentice.c	2019-02-20 03:35:27.000000000 +0100
-+++ libmagic/apprentice.c	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/apprentice.c	2020-11-19 11:50:32.412674100 +0100
 @@ -29,6 +29,8 @@
   * apprentice - make one pass through /etc/magic, learning its secrets.
   */
@@ -974,7 +974,7 @@ diff -u libmagic.orig/apprentice.c libmagic/apprentice.c
  	}
 diff -u libmagic.orig/ascmagic.c libmagic/ascmagic.c
 --- libmagic.orig/ascmagic.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/ascmagic.c	2020-02-26 23:18:22.605400700 +0100
++++ libmagic/ascmagic.c	2020-09-07 00:42:14.447562400 +0200
 @@ -96,7 +96,7 @@
  		rv = file_ascmagic_with_encoding(ms, &bb,
  		    ubuf, ulen, code, type, text);
@@ -1005,7 +1005,7 @@ diff -u libmagic.orig/ascmagic.c libmagic/ascmagic.c
  }
 diff -u libmagic.orig/buffer.c libmagic/buffer.c
 --- libmagic.orig/buffer.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/buffer.c	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/buffer.c	2020-09-07 00:42:14.447562400 +0200
 @@ -31,19 +31,23 @@
  #endif	/* lint */
  
@@ -1062,7 +1062,7 @@ diff -u libmagic.orig/buffer.c libmagic/buffer.c
  
 diff -u libmagic.orig/cdf.c libmagic/cdf.c
 --- libmagic.orig/cdf.c	2019-02-20 03:35:27.000000000 +0100
-+++ libmagic/cdf.c	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/cdf.c	2020-09-07 00:42:14.447562400 +0200
 @@ -43,7 +43,17 @@
  #include <err.h>
  #endif
@@ -1341,7 +1341,7 @@ diff -u libmagic.orig/cdf.c libmagic/cdf.c
  #endif
 diff -u libmagic.orig/cdf.h libmagic/cdf.h
 --- libmagic.orig/cdf.h	2019-02-20 02:24:19.000000000 +0100
-+++ libmagic/cdf.h	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/cdf.h	2020-09-07 00:42:14.447562400 +0200
 @@ -35,10 +35,10 @@
  #ifndef _H_CDF_
  #define _H_CDF_
@@ -1366,7 +1366,7 @@ diff -u libmagic.orig/cdf.h libmagic/cdf.h
  #define CDF_SECID_FREE					-1
 diff -u libmagic.orig/cdf_time.c libmagic/cdf_time.c
 --- libmagic.orig/cdf_time.c	2019-03-12 21:43:05.000000000 +0100
-+++ libmagic/cdf_time.c	2020-02-26 23:18:22.611402900 +0100
++++ libmagic/cdf_time.c	2020-09-07 00:42:14.447562400 +0200
 @@ -23,6 +23,7 @@
   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   * POSSIBILITY OF SUCH DAMAGE.
@@ -1395,7 +1395,7 @@ diff -u libmagic.orig/cdf_time.c libmagic/cdf_time.c
  	(void)snprintf(buf, 26, "*Bad* %#16.16" INT64_T_FORMAT "x\n",
 diff -u libmagic.orig/compress.c libmagic/compress.c
 --- libmagic.orig/compress.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/compress.c	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/compress.c	2020-09-07 00:42:14.447562400 +0200
 @@ -45,13 +45,11 @@
  #endif
  #include <string.h>
@@ -1545,7 +1545,7 @@ diff -u libmagic.orig/compress.c libmagic/compress.c
 +#endif
 diff -u libmagic.orig/der.c libmagic/der.c
 --- libmagic.orig/der.c	2019-02-20 03:35:27.000000000 +0100
-+++ libmagic/der.c	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/der.c	2020-09-07 00:42:14.447562400 +0200
 @@ -51,7 +51,9 @@
  #include "magic.h"
  #include "der.h"
@@ -1575,7 +1575,7 @@ diff -u libmagic.orig/der.c libmagic/der.c
  			snprintf(buf + z, blen - z, "%.2x", d[i]);
 diff -u libmagic.orig/elfclass.h libmagic/elfclass.h
 --- libmagic.orig/elfclass.h	2019-02-20 02:30:19.000000000 +0100
-+++ libmagic/elfclass.h	2020-02-26 23:18:22.613401700 +0100
++++ libmagic/elfclass.h	2020-09-07 00:42:14.447562400 +0200
 @@ -41,7 +41,7 @@
  			return toomany(ms, "program headers", phnum);
  		flags |= FLAGS_IS_CORE;
@@ -1605,7 +1605,7 @@ diff -u libmagic.orig/elfclass.h libmagic/elfclass.h
  		    CAST(int, elf_getu16(swap, elfhdr.e_shstrndx)),
 diff -u libmagic.orig/encoding.c libmagic/encoding.c
 --- libmagic.orig/encoding.c	2019-04-15 18:48:41.000000000 +0200
-+++ libmagic/encoding.c	2020-02-26 23:18:22.614402300 +0100
++++ libmagic/encoding.c	2020-09-07 00:42:14.447562400 +0200
 @@ -89,13 +89,13 @@
  	*code_mime = "binary";
  
@@ -1636,7 +1636,7 @@ diff -u libmagic.orig/encoding.c libmagic/encoding.c
  }
 diff -u libmagic.orig/file.h libmagic/file.h
 --- libmagic.orig/file.h	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/file.h	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/file.h	2020-11-23 17:11:36.234964700 +0100
 @@ -33,18 +33,9 @@
  #ifndef __file_h__
  #define __file_h__
@@ -1658,7 +1658,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
    #ifdef _WIN64
      #define SIZE_T_FORMAT "I64"
    #else
-@@ -57,19 +48,34 @@
+@@ -57,32 +48,49 @@
    #define INT64_T_FORMAT "ll"
    #define INTMAX_T_FORMAT "j"
  #endif
@@ -1698,7 +1698,14 @@ diff -u libmagic.orig/file.h libmagic/file.h
  #include <sys/param.h>
  #endif
  /* Do this here and now, because struct stat gets re-defined on solaris */
-@@ -82,7 +88,7 @@
+ #include <sys/stat.h>
+ #include <stdarg.h>
+ 
++#define abort()	zend_error_noreturn(E_ERROR, "fatal libmagic error")
++
+ #define ENABLE_CONDITIONALS
+ 
+ #ifndef MAGIC
  #define MAGIC "/etc/magic"
  #endif
  
@@ -1707,7 +1714,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  #define PATHSEP	';'
  #else
  #define PATHSEP	':'
-@@ -116,12 +122,6 @@
+@@ -116,12 +124,6 @@
  #endif
  #endif
  
@@ -1720,7 +1727,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  #ifndef MIN
  #define	MIN(a,b)	(((a) < (b)) ? (a) : (b))
  #endif
-@@ -150,10 +150,10 @@
+@@ -150,10 +152,10 @@
  
  struct buffer {
  	int fd;
@@ -1733,7 +1740,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  	void *ebuf;
  	size_t elen;
  };
-@@ -243,7 +243,7 @@
+@@ -243,7 +245,7 @@
  #define				FILE_DER	48
  #define				FILE_NAMES_SIZE	49 /* size of array to contain all names */
  
@@ -1742,7 +1749,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  	((t) == FILE_STRING || \
  	 (t) == FILE_PSTRING || \
  	 (t) == FILE_BESTRING16 || \
-@@ -447,28 +447,23 @@
+@@ -447,28 +449,23 @@
  /* Type for Unicode characters */
  typedef unsigned long unichar;
  
@@ -1776,7 +1783,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  protected int file_zmagic(struct magic_set *, const struct buffer *,
      const char *);
  #endif
-@@ -491,13 +486,9 @@
+@@ -491,13 +488,9 @@
  protected void file_badread(struct magic_set *);
  protected void file_badseek(struct magic_set *);
  protected void file_oomem(struct magic_set *, size_t);
@@ -1793,7 +1800,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  protected void file_showstr(FILE *, const char *, size_t);
  protected size_t file_mbswidth(const char *);
  protected const char *file_getbuffer(struct magic_set *);
-@@ -513,34 +504,13 @@
+@@ -513,34 +506,13 @@
      size_t);
  #endif /* __EMX__ */
  
@@ -1831,7 +1838,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  
  typedef struct {
  	char *buf;
-@@ -550,28 +520,13 @@
+@@ -550,28 +522,13 @@
  protected file_pushbuf_t *file_push_buffer(struct magic_set *);
  protected char  *file_pop_buffer(struct magic_set *, file_pushbuf_t *);
  
@@ -1862,7 +1869,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  size_t strlcat(char *, const char *, size_t);
  #endif
  #ifndef HAVE_STRCASESTR
-@@ -587,39 +542,6 @@
+@@ -587,39 +544,6 @@
  #ifndef HAVE_ASCTIME_R
  char   *asctime_r(const struct tm *, char *);
  #endif
@@ -1902,7 +1909,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  
  #if defined(HAVE_MMAP) && defined(HAVE_SYS_MMAN_H) && !defined(QUICK)
  #define QUICK
-@@ -645,6 +567,18 @@
+@@ -645,6 +569,18 @@
  #else
  #define FILE_RCSID(id)
  #endif
@@ -1923,7 +1930,7 @@ diff -u libmagic.orig/file.h libmagic/file.h
  #endif
 diff -u libmagic.orig/fsmagic.c libmagic/fsmagic.c
 --- libmagic.orig/fsmagic.c	2019-05-07 04:26:48.000000000 +0200
-+++ libmagic/fsmagic.c	2020-02-26 23:18:22.616403500 +0100
++++ libmagic/fsmagic.c	2020-09-07 00:42:14.447562400 +0200
 @@ -66,26 +66,10 @@
  # define minor(dev)  ((dev) & 0xff)
  #endif
@@ -2216,7 +2223,7 @@ diff -u libmagic.orig/fsmagic.c libmagic/fsmagic.c
  	case S_IFSOCK:
 diff -u libmagic.orig/funcs.c libmagic/funcs.c
 --- libmagic.orig/funcs.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/funcs.c	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/funcs.c	2020-09-07 00:42:14.447562400 +0200
 @@ -31,7 +31,6 @@
  #endif	/* lint */
  
@@ -2572,7 +2579,7 @@ diff -u libmagic.orig/funcs.c libmagic/funcs.c
  
 diff -u libmagic.orig/magic.c libmagic/magic.c
 --- libmagic.orig/magic.c	2019-05-07 04:27:11.000000000 +0200
-+++ libmagic/magic.c	2020-02-26 23:18:22.621402800 +0100
++++ libmagic/magic.c	2020-09-07 00:42:14.447562400 +0200
 @@ -25,11 +25,6 @@
   * SUCH DAMAGE.
   */
@@ -3036,8 +3043,8 @@ diff -u libmagic.orig/magic.c libmagic/magic.c
  public const char *
  magic_error(struct magic_set *ms)
 diff -u libmagic.orig/magic.h libmagic/magic.h
---- libmagic.orig/magic.h	2020-03-02 15:24:27.253951700 +0100
-+++ libmagic/magic.h	2020-02-26 23:18:22.622402300 +0100
+--- libmagic.orig/magic.h	2020-11-23 17:12:12.776465800 +0100
++++ libmagic/magic.h	2020-09-07 00:42:14.447562400 +0200
 @@ -124,6 +124,7 @@
  
  const char *magic_getpath(const char *, int);
@@ -3048,7 +3055,7 @@ diff -u libmagic.orig/magic.h libmagic/magic.h
  
 diff -u libmagic.orig/print.c libmagic/print.c
 --- libmagic.orig/print.c	2019-03-12 21:43:05.000000000 +0100
-+++ libmagic/print.c	2020-02-26 23:18:22.625401800 +0100
++++ libmagic/print.c	2020-09-07 00:42:14.447562400 +0200
 @@ -28,6 +28,7 @@
  /*
   * print.c - debugging printout routines
@@ -3122,7 +3129,7 @@ diff -u libmagic.orig/print.c libmagic/print.c
  		goto out;
 diff -u libmagic.orig/readcdf.c libmagic/readcdf.c
 --- libmagic.orig/readcdf.c	2019-03-12 21:43:05.000000000 +0100
-+++ libmagic/readcdf.c	2020-02-27 11:45:38.445854000 +0100
++++ libmagic/readcdf.c	2020-09-07 00:42:14.463191200 +0200
 @@ -31,7 +31,11 @@
  
  #include <assert.h>
@@ -3241,7 +3248,7 @@ diff -u libmagic.orig/readcdf.c libmagic/readcdf.c
  	if (i != -1)
 diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
 --- libmagic.orig/softmagic.c	2019-05-17 04:24:59.000000000 +0200
-+++ libmagic/softmagic.c	2020-03-02 15:23:10.176763300 +0100
++++ libmagic/softmagic.c	2020-09-07 00:42:14.463191200 +0200
 @@ -43,6 +43,10 @@
  #include <time.h>
  #include "der.h"
@@ -3608,7 +3615,7 @@ diff -u libmagic.orig/softmagic.c libmagic/softmagic.c
  	case FILE_INDIRECT:
 diff -u libmagic.orig/strcasestr.c libmagic/strcasestr.c
 --- libmagic.orig/strcasestr.c	2014-09-11 17:05:33.000000000 +0200
-+++ libmagic/strcasestr.c	2019-11-29 08:49:38.434136600 +0100
++++ libmagic/strcasestr.c	2020-08-05 15:01:55.644887300 +0200
 @@ -39,6 +39,8 @@
  
  #include "file.h"

--- a/ext/fileinfo/libmagic/file.h
+++ b/ext/fileinfo/libmagic/file.h
@@ -82,7 +82,7 @@
 #include <sys/stat.h>
 #include <stdarg.h>
 
-#define abort()	php_error_docref(NULL, E_ERROR, "fatal libmagic error")
+#define abort()	zend_error_noreturn(E_ERROR, "fatal libmagic error")
 
 #define ENABLE_CONDITIONALS
 

--- a/ext/fileinfo/libmagic/file.h
+++ b/ext/fileinfo/libmagic/file.h
@@ -82,6 +82,8 @@
 #include <sys/stat.h>
 #include <stdarg.h>
 
+#define abort()	php_error_docref(NULL, E_ERROR, "fatal libmagic error")
+
 #define ENABLE_CONDITIONALS
 
 #ifndef MAGIC

--- a/ext/fileinfo/tests/bug77961.magic
+++ b/ext/fileinfo/tests/bug77961.magic
@@ -1,0 +1,50 @@
+0   string  1
+>1   regex   \^[0-9:,\ ]*-->[0-9:,\ ]*   SubRip File
+!:mime text/x-srt
+
+0	lelong		0xc3cbc6c5	RISC OS Chunk data
+>12	string		OBJ_		\b, AOF object
+>12	string		LIB_		\b, ALF library
+
+0	name		mach-o		\b [
+>0	use		mach-o-cpu	\b
+>(8.L)	indirect	8		\b:
+>0	belong		x		\b]
+
+0	belong		0xcafed00d	JAR compressed with pack200,
+>5	byte		x		version %d.
+>4	byte		x		\b%d
+!:mime	application/x-java-pack200
+
+# Objective-C
+0	regex	\^#import			Objective-C source text
+!:strength + 25
+!:mime	text/x-objective-c
+
+0	string	\x20\x20\x20\x20\x20\x20\x20\x20-:\x20\x20\x20\ 0:Source:
+>&0	search/128	\x20\x20\x20\x20\x20\x20\x20\x20-:\x20\x20\x20\ 0:Graph:
+>>&0	search/128	\x20\x20\x20\x20\x20\x20\x20\x20-:\x20\x20\x20\ 0:Data:	GCOV coverage report
+
+0	name	certinfo
+>0	der	seq
+>>&0	der	set
+>>>&0	der	seq
+>>>>&0	der	obj_id3=550406
+>>>>&0	der	prt_str=x	\b, countryName=%s
+>>&0	der	set
+>>>&0	der	seq
+>>>>&0	der	obj_id3=550408
+>>>>&0	der	utf8_str=x	\b, stateOrProvinceName=%s
+>>&0	der	set
+>>>&0	der	seq
+>>>>&0	der	obj_id3=55040a
+>>>>&0	der	utf8_str=x	\b, organizationName=%s
+>>&0	der	set
+>>>&0	der	seq
+>>>>&0	der	obj_id3=550403
+>>>>&0	der	utf8_str=x	\b, commonName=%s
+>>&0	der	seq
+
+0	search/1	FONT		ASCII vfont text
+0	short		0436		Berkeley vfont data
+0	short		017001		byte-swapped Berkeley vfont data

--- a/ext/fileinfo/tests/bug77961.phpt
+++ b/ext/fileinfo/tests/bug77961.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #77961 (finfo_open crafted magic parsing SIGABRT)
+--SKIPIF--
+<?php
+if (!extension_loaded('finfo')) die('finfo extension not available');
+?>
+--FILE--
+<?php
+finfo_open(FILEINFO_NONE, __DIR__ . '/bug77961.magic');
+?>
+--EXPECTF--
+Notice: finfo_open(): Warning: Expected numeric type got `indirect' in %s on line %d
+
+Fatal error: finfo_open(): fatal libmagic error in %s on line %d

--- a/ext/fileinfo/tests/bug77961.phpt
+++ b/ext/fileinfo/tests/bug77961.phpt
@@ -11,4 +11,4 @@ finfo_open(FILEINFO_NONE, __DIR__ . '/bug77961.magic');
 --EXPECTF--
 Notice: finfo_open(): Warning: Expected numeric type got `indirect' in %s on line %d
 
-Fatal error: finfo_open(): fatal libmagic error in %s on line %d
+Fatal error: fatal libmagic error in %s on line %d


### PR DESCRIPTION
libmagic may abort the running process, which is not desirable for PHP;
we raise a fatal error instead.

---

Just a basic check whether this works at all. Would need to update libmagic.patch if so.