### PR TITLE
Allow PHP_CURL_APIs to be imported by DLLs

### DIFF
--- a/ext/curl/config.w32
+++ b/ext/curl/config.w32
@@ -28,7 +28,7 @@ if (PHP_CURL != "no") {
 		) {
 		EXTENSION("curl", "interface.c multi.c share.c curl_file.c");
 		AC_DEFINE('HAVE_CURL', 1, 'Have cURL library');
-		ADD_FLAG("CFLAGS_CURL", "/D CURL_STATICLIB");
+		ADD_FLAG("CFLAGS_CURL", "/D CURL_STATICLIB /D PHP_CURL_EXPORTS=1");
 		PHP_INSTALL_HEADERS("ext/curl", "php_curl.h");
 		// TODO: check for curl_version_info
 	} else {

--- a/ext/curl/php_curl.h
+++ b/ext/curl/php_curl.h
@@ -21,7 +21,11 @@
 #include "php.h"
 
 #ifdef PHP_WIN32
-# define PHP_CURL_API __declspec(dllexport)
+# ifdef PHP_CURL_EXPORTS
+#  define PHP_CURL_API __declspec(dllexport)
+# else
+#  define PHP_CURL_API __declspec(dllimport)
+# endif
 #elif defined(__GNUC__) && __GNUC__ >= 4
 # define PHP_CURL_API __attribute__ ((visibility("default")))
 #else


### PR DESCRIPTION
I just received a report that the blackfire extension won't build with 8.0. Unfortunately, I can't test, but I think this should fix the issue.

In the long run, we may consider to introduce a general macro for this.