### PR TITLE
UPGRADING: (real) cast has been removed

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -29,6 +29,7 @@ PHP 8.0 UPGRADE NOTES
   . Removed ability to call non-static methods statically.
     Thus `is_callable` will fail when checking for a non-static method with a
     classname (must check with an object instance).
+  . Removed (real) cast.
   . Removed (unset) cast.
   . Removed track_errors ini directive. This means that $php_errormsg is no
     longer available. The error_get_last() function may be used instead.


### PR DESCRIPTION
.. but the removal wasn't mentioned in the `UPGRADING` docs yet.

Ref:
* https://github.com/php/php-src/pull/5220
* https://github.com/php/php-src/commit/c9db32271a8083721582c5ec1dd09c4d4f562c74

[ci-skip]

Q: should this also be pulled to the `8.0.0` branch ?