### PR TITLE
Added SameSite attribute to cookie to help mitigate CSRF on PHP 5.6.40 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1473,6 +1473,11 @@ PHP                                                                        NEWS
   . Fixed bug #69227 (Use after free in zval_scan caused by
      spl_object_storage_get_gc). (adam dot scarr at 99designs dot com)
 
+- Standard:
+  . Added support for the SameSite cookie directive, including an alternative
+    signature for setcookie(), setrawcookie() and session_set_cookie_params().
+    (Frederik Bosch, pmmaga)
+    
 - Sqlite3:
   . Fixed bug #68760 (SQLITE segfaults if custom collator throws an exception).
      (Dan Ackroyd)

--- a/UPGRADING
+++ b/UPGRADING
@@ -278,6 +278,24 @@ PHP 5.6 UPGRADE NOTES
 - JSON:
   Added JSON_PRESERVE_ZERO_FRACTION option (PHP >= 5.6.5)
 
+Session:
+  . session_set_cookie_params() now also supports the following signature:
+    session_set_cookie_params(array $options)
+    where $options is an associative array which may have any of the keys
+    "lifetime", "path", "domain", "secure", "httponly" and "samesite".
+    Accordingly, the return value of session_get_cookie_params() now also has an
+    element with the key "samesite".
+
+Standard:
+  . debug_zval_dump() was changed to display recursive arrays and objects
+    in the same way as var_dump(). Now, it doesn't display them twice.
+  . array_push() and array_unshift() can now also be called with a single
+    argument, which is particularly convenient wrt. the spread operator.
+  . setcookie() and setrawcookie() now also support the following signature:
+    set(raw)cookie(string $name, [string $value, [array $options]])
+    where $options is an associative array which may have any of the keys
+    "expires", "path", "domain", "secure", "httponly" and "samesite".
+
 ========================================
 6. New Functions
 ========================================
@@ -467,6 +485,11 @@ PHP 5.6 UPGRADE NOTES
 - OpenSSL:
   openssl.cafile and openssl.capath ini directives have been added to allow
   global CA default specification as necessary.
+
+- session.cookie_samesite
+  . New INI option to allow to set the SameSite directive for cookies. Defaults
+    to "" (empty string), so no SameSite directive is set. Can be set to "Lax"
+    or "Strict", which sets the respective SameSite directive.
 
 ========================================
 12. Other Changes

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -131,6 +131,7 @@ typedef struct _php_ps_globals {
 	char *cookie_domain;
 	zend_bool  cookie_secure;
 	zend_bool  cookie_httponly;
+	char *cookie_samesite;
 	ps_module *mod;
 	ps_module *default_mod;
 	void *mod_data;

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1438,6 +1438,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_setcookie, 0, 0, 1)
 	ZEND_ARG_INFO(0, domain)
 	ZEND_ARG_INFO(0, secure)
 	ZEND_ARG_INFO(0, httponly)
+	ZEND_ARG_INFO(0, samesite)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_setrawcookie, 0, 0, 1)

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -73,7 +73,7 @@ PHPAPI int php_header(TSRMLS_D)
 }
 
 
-PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, time_t expires, char *path, int path_len, char *domain, int domain_len, int secure, int url_encode, int httponly TSRMLS_DC)
+PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, time_t expires, char *path, int path_len, char *domain, int domain_len, int secure, int url_encode, int httponly, char *samesite, int samesite_len TSRMLS_DC)
 {
 	char *cookie, *encoded_value = NULL;
 	int len=sizeof("Set-Cookie: ");
@@ -106,6 +106,9 @@ PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, t
 	}
 	if (domain) {
 		len += domain_len;
+	}
+	if (samesite) {
+		len += samesite_len;
 	}
 
 	cookie = emalloc(len + 100);
@@ -162,7 +165,12 @@ PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, t
 	if (httponly) {
 		strlcat(cookie, "; httponly", len + 100);
 	}
-
+	
+	if (samesite && samesite_len > 0) {
+		strlcat(cookie, "; SameSite=", len + 100);
+		strlcat(cookie, samesite, len + 100);
+	}
+	
 	ctr.line = cookie;
 	ctr.line_len = strlen(cookie);
 
@@ -177,18 +185,18 @@ PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, t
    Send a cookie */
 PHP_FUNCTION(setcookie)
 {
-	char *name, *value = NULL, *path = NULL, *domain = NULL;
+	char *name, *value = NULL, *path = NULL, *domain = NULL, *samesite = NULL;
 	long expires = 0;
 	zend_bool secure = 0, httponly = 0;
-	int name_len, value_len = 0, path_len = 0, domain_len = 0;
+	int name_len, value_len = 0, path_len = 0, domain_len = 0, samesite_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|slssbb", &name,
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|slssbbs", &name,
 							  &name_len, &value, &value_len, &expires, &path,
-							  &path_len, &domain, &domain_len, &secure, &httponly) == FAILURE) {
+							  &path_len, &domain, &domain_len, &secure, &httponly,&samesite, &samesite_len) == FAILURE) {
 		return;
 	}
 
-	if (php_setcookie(name, name_len, value, value_len, expires, path, path_len, domain, domain_len, secure, 1, httponly TSRMLS_CC) == SUCCESS) {
+	if (php_setcookie(name, name_len, value, value_len, expires, path, path_len, domain, domain_len, secure, 1, httponly,samesite, samesite_len TSRMLS_CC) == SUCCESS) {
 		RETVAL_TRUE;
 	} else {
 		RETVAL_FALSE;
@@ -200,18 +208,18 @@ PHP_FUNCTION(setcookie)
    Send a cookie with no url encoding of the value */
 PHP_FUNCTION(setrawcookie)
 {
-	char *name, *value = NULL, *path = NULL, *domain = NULL;
+	char *name, *value = NULL, *path = NULL, *domain = NULL, *samesite = NULL;
 	long expires = 0;
 	zend_bool secure = 0, httponly = 0;
-	int name_len, value_len = 0, path_len = 0, domain_len = 0;
+	int name_len, value_len = 0, path_len = 0, domain_len = 0, samesite_len = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|slssbb", &name,
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|slssbbs", &name,
 							  &name_len, &value, &value_len, &expires, &path,
-							  &path_len, &domain, &domain_len, &secure, &httponly) == FAILURE) {
+							  &path_len, &domain, &domain_len, &secure, &httponly,&samesite, &samesite_len) == FAILURE) {
 		return;
 	}
 
-	if (php_setcookie(name, name_len, value, value_len, expires, path, path_len, domain, domain_len, secure, 0, httponly TSRMLS_CC) == SUCCESS) {
+	if (php_setcookie(name, name_len, value, value_len, expires, path, path_len, domain, domain_len, secure, 0, httponly,samesite, samesite_len TSRMLS_CC) == SUCCESS) {
 		RETVAL_TRUE;
 	} else {
 		RETVAL_FALSE;

--- a/ext/standard/head.h
+++ b/ext/standard/head.h
@@ -31,6 +31,6 @@ PHP_FUNCTION(headers_list);
 PHP_FUNCTION(http_response_code);
 
 PHPAPI int php_header(TSRMLS_D);
-PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, time_t expires, char *path, int path_len, char *domain, int domain_len, int secure, int url_encode, int httponly TSRMLS_DC);
+PHPAPI int php_setcookie(char *name, int name_len, char *value, int value_len, time_t expires, char *path, int path_len, char *domain, int domain_len, int secure, int url_encode, int httponly, char *samesite,int samesite_len TSRMLS_DC);
 
 #endif

--- a/php.ini-development
+++ b/php.ini-development
@@ -1490,6 +1490,12 @@ session.cookie_domain =
 ; http://php.net/session.cookie-httponly
 session.cookie_httponly =
 
+; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
+; Current valid values are "Strict", "Lax" or "None". When using "None",
+; make sure to include the quotes, as `none` is interpreted like `false` in ini files.
+; https://tools.ietf.org/html/draft-west-first-party-cookies-07
+session.cookie_samesite =
+
 ; Handler used to serialize data.  php is the standard serializer of PHP.
 ; http://php.net/session.serialize-handler
 session.serialize_handler = php

--- a/php.ini-production
+++ b/php.ini-production
@@ -1490,6 +1490,12 @@ session.cookie_domain =
 ; http://php.net/session.cookie-httponly
 session.cookie_httponly =
 
+; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
+; Current valid values are "Strict", "Lax" or "None". When using "None",
+; make sure to include the quotes, as `none` is interpreted like `false` in ini files.
+; https://tools.ietf.org/html/draft-west-first-party-cookies-07
+session.cookie_samesite =
+
 ; Handler used to serialize data.  php is the standard serializer of PHP.
 ; http://php.net/session.serialize-handler
 session.serialize_handler = php


### PR DESCRIPTION
Added SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
Current valid values are "Strict", "Lax" or "None".
In php.ini, when using "None", make sure to include the quotes, as `none` is interpreted
like `false` in ini files.

https://tools.ietf.org/html/draft-west-first-party-cookies-07

Build tested on Debian 8.11

New Features
========================================

Session:
  . Added support for the SameSite cookie directive for setcookie(),
    setrawcookie() and session_set_cookie_params().
    Port from PHP 7.x branch
    they all have an "samesite" additionnal parameter at the very end (string)

prototypes:
bool setcookie(string name [, string value [, int expires [, string path [, string domain [, bool secure[, bool httponly[, string samesite]]]]]]])
bool setrawcookie(string name [, string value [, int expires [, string path [, string domain [, bool secure[, bool httponly[, string samesite]]]]]]])
void session_set_cookie_params(int lifetime [, string path [, string domain [, bool secure[, bool httponly[, string samesite]]]]])
(session_get_cookie_params updated too)

Changes to INI File Handling
========================================

- session.cookie_samesite
  . New INI option to allow to set the SameSite directive for cookies. Defaults
    to "" (empty string), so no SameSite directive is set. Can be set to "Lax"
    or "Strict", or "None" which sets the respective SameSite directive.
    when using "None", make sure to include the quotes, as `none` is interpreted
    like `false` in ini files.