### PR TITLE
Fix PDOStatement::fetchObject() stub

### DIFF
--- a/ext/pdo/pdo_stmt.stub.php
+++ b/ext/pdo/pdo_stmt.stub.php
@@ -40,7 +40,7 @@ class PDOStatement implements IteratorAggregate
     /** @return mixed */
     public function fetchColumn(int $column = 0) {}
 
-    /** @return mixed */
+    /** @return object|false */
     public function fetchObject(?string $class = "stdClass", ?array $ctorArgs = null) {}
 
     /** @return mixed */


### PR DESCRIPTION
As mentioned in https://github.com/php/doc-en/pull/218, [PDOStatement::fetchObject](https://www.php.net/manual/en/pdostatement.fetchobject.php) returns `object|false`:

> Returns an instance of the required class with property names that correspond to the column names or FALSE on failure.