### PR TITLE
Don't strip -lpthread

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -478,7 +478,7 @@ dnl Internal, don't use.
 dnl
 AC_DEFUN([_PHP_ADD_LIBRARY_SKELETON],[
   case $1 in
-  c|c_r|pthread*[)] ;;
+  c|c_r[)] ;;
   *[)] ifelse($3,,[
     _PHP_X_ADD_LIBRARY($1,$2,$5)
   ],[


### PR DESCRIPTION
Fix for https://bugs.php.net/bug.php?id=80402.

The current behavior has been introduced 20 years ago in https://github.com/php/php-src/commit/f9e375f493a1aeacbbcc8f2f00880d05b4ba7aaf. It's not clear to me why `-lpthread` is receiving special treatment here.