### PR TITLE
fix misspelled method names

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -982,8 +982,8 @@ PHP 8.0 UPGRADE NOTES
 - Zip:
   . ZipArchive::setMtimeName and ZipArchive::setMtimeIndex to set the
     modification time of an entry.
-  . ZipArchive::setProgressCallback to provide updates during archive close.
-  . ZipArchive::setCancelCallback to allow cancellation during archive close.
+  . ZipArchive::registerProgressCallback to provide updates during archive close.
+  . ZipArchive::registerCancelCallback to allow cancellation during archive close.
   . ZipArchive::replaceFile to replace an entry content.
   . ZipArchive::isCompressionMethodSupported to check optional compression
     features.


### PR DESCRIPTION
Hey there :vulcan_salute: 

by going through php/php-tasks#26 I found that these two methods actually are named `registerProgressCallback` and `registerCancelCallback` instead of `setProgressCallback` and `setCancelCallback`. See also https://github.com/php/doc-en/pull/228#issuecomment-733058952

/Flo