### PR TITLE
sockets: Fix variable/macro name collision on AIX

### DIFF
--- a/ext/sockets/sendrecvmsg.c
+++ b/ext/sockets/sendrecvmsg.c
@@ -295,8 +295,8 @@ PHP_FUNCTION(socket_cmsg_space)
 	}
 
 	if (entry->var_el_size > 0) {
-		size_t rem_size = ZEND_LONG_MAX - entry->size;
-		size_t n_max = rem_size / entry->var_el_size;
+		size_t _rem_size = ZEND_LONG_MAX - entry->size;
+		size_t n_max = _rem_size / entry->var_el_size;
 		size_t size = entry->size + n * entry->var_el_size;
 		size_t total_size = CMSG_SPACE(size);
 		if (n > n_max /* zend_long overflow */


### PR DESCRIPTION
The name "rem_size" is used by a macro in a system header on AIX, specifically `sys/xmem.h`. Without changing the name, you get the name mangled like so:

```
In file included from /usr/include/sys/uio.h:92:0,
                 from /QOpenSys/pkgs/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/include-fixed-7.1/sys/socket.h:83,
                 from /usr/include/sys/syslog.h:151,
                 from /usr/include/syslog.h:29,
                 from /home/calvin/rpmbuild/BUILD/php-8.0.0RC5/main/php_syslog.h:27,
                 from /home/calvin/rpmbuild/BUILD/php-8.0.0RC5/main/php.h:318,
                 from /home/calvin/rpmbuild/BUILD/php-8.0.0RC5/ext/sockets/sendrecvmsg.c:17:
/home/calvin/rpmbuild/BUILD/php-8.0.0RC5/ext/sockets/sendrecvmsg.c: In function 'zif_socket_cmsg_space':
/home/calvin/rpmbuild/BUILD/php-8.0.0RC5/ext/sockets/sendrecvmsg.c:298:10: error: expected '=', ',', ';', 'asm' or '__attribute__' before '.' token
   size_t rem_size = ZEND_LONG_MAX - entry->size;
          ^
/home/calvin/rpmbuild/BUILD/php-8.0.0RC5/ext/sockets/sendrecvmsg.c:298:10: error: expected expression before '.' token
/home/calvin/rpmbuild/BUILD/php-8.0.0RC5/ext/sockets/sendrecvmsg.c:299:18: error: 'u2' undeclared (first use in this function)
   size_t n_max = rem_size / entry->var_el_size;
                  ^
/home/calvin/rpmbuild/BUILD/php-8.0.0RC5/ext/sockets/sendrecvmsg.c:299:18: note: each undeclared identifier is reported only once for each function it appears in
```

...because of the declaration in `sys/xmem.h`:

```
#define rem_size        u2._subspace_id2
```

This just renames the variable so that it won't trip on this definition. Tested to fix the build on IBM i PASE.