### PR TITLE
Add flag to suppress stream errors

### DIFF
--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -263,6 +263,7 @@ MYSQLND_METHOD(mysqlnd_vio, post_connect_set_opt)(MYSQLND_VIO * const vio, const
 		}
 
 		net_stream->chunk_size = vio->data->options.net_read_buffer_size;
+		net_stream->flags |= PHP_STREAM_FLAG_SUPPRESS_ERRORS;
 	}
 
 	DBG_VOID_RETURN;

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -971,7 +971,6 @@ size_t php_mysqlnd_cmd_write(MYSQLND_CONN_DATA * conn, void * _packet)
 	MYSQLND_VIO * vio = conn->vio;
 	MYSQLND_STATS * stats = conn->stats;
 	MYSQLND_CONNECTION_STATE * connection_state = &conn->state;
-	const unsigned int error_reporting = EG(error_reporting);
 	size_t sent = 0;
 
 	DBG_ENTER("php_mysqlnd_cmd_write");
@@ -980,10 +979,6 @@ size_t php_mysqlnd_cmd_write(MYSQLND_CONN_DATA * conn, void * _packet)
 	  Every command starts a new TX and packet numbers are reset to 0.
 	*/
 	pfc->data->m.reset(pfc, stats, error_info);
-
-	if (error_reporting) {
-		EG(error_reporting) = 0;
-	}
 
 	MYSQLND_INC_CONN_STATISTIC(stats, STAT_PACKETS_SENT_CMD);
 
@@ -1017,10 +1012,6 @@ size_t php_mysqlnd_cmd_write(MYSQLND_CONN_DATA * conn, void * _packet)
 		}
 	}
 end:
-	if (error_reporting) {
-		/* restore error reporting */
-		EG(error_reporting) = error_reporting;
-	}
 	if (!sent) {
 		SET_CONNECTION_STATE(connection_state, CONN_QUIT_SENT);
 	}

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -181,6 +181,10 @@ struct _php_stream_wrapper	{
 
 #define PHP_STREAM_FLAG_NO_FCLOSE					0x80
 
+/* Suppress generation of PHP warnings on stream read/write errors.
+ * Currently for internal use only. */
+#define PHP_STREAM_FLAG_SUPPRESS_ERRORS				0x100
+
 #define PHP_STREAM_FLAG_WAS_WRITTEN					0x80000000
 
 struct _php_stream  {

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -358,7 +358,9 @@ static ssize_t php_stdiop_write(php_stream *stream, const char *buf, size_t coun
 				/* TODO: Should this be treated as a proper error or not? */
 				return bytes_written;
 			}
-			php_error_docref(NULL, E_NOTICE, "Write of %zu bytes failed with errno=%d %s", count, errno, strerror(errno));
+			if (!(stream->flags & PHP_STREAM_FLAG_SUPPRESS_ERRORS)) {
+				php_error_docref(NULL, E_NOTICE, "Write of %zu bytes failed with errno=%d %s", count, errno, strerror(errno));
+			}
 		}
 		return bytes_written;
 	} else {
@@ -426,7 +428,9 @@ static ssize_t php_stdiop_read(php_stream *stream, char *buf, size_t count)
 			} else if (errno == EINTR) {
 				/* TODO: Should this be treated as a proper error or not? */
 			} else {
-				php_error_docref(NULL, E_NOTICE, "Read of %zu bytes failed with errno=%d %s", count, errno, strerror(errno));
+				if (!(stream->flags & PHP_STREAM_FLAG_SUPPRESS_ERRORS)) {
+					php_error_docref(NULL, E_NOTICE, "Read of %zu bytes failed with errno=%d %s", count, errno, strerror(errno));
+				}
 
 				/* TODO: Remove this special-case? */
 				if (errno != EBADF) {

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -103,10 +103,13 @@ retry:
 			}
 		}
 
-		estr = php_socket_strerror(err, NULL, 0);
-		php_error_docref(NULL, E_NOTICE, "Send of " ZEND_LONG_FMT " bytes failed with errno=%d %s",
+		if (!(stream->flags & PHP_STREAM_FLAG_SUPPRESS_ERRORS)) {
+			estr = php_socket_strerror(err, NULL, 0);
+			php_error_docref(NULL, E_NOTICE,
+				"Send of " ZEND_LONG_FMT " bytes failed with errno=%d %s",
 				(zend_long)count, err, estr);
-		efree(estr);
+			efree(estr);
+		}
 	}
 
 	if (didwrite > 0) {


### PR DESCRIPTION
mysqlnd currently sets error_reporting=0 to suppress errors while writing to streams. Unfortunately these errors are still visible to userland error handlers, which is a common source of confusion. See for example https://bugs.php.net/bug.php?id=80412.

This patch instead adds a stream flag to suppress read/write errors, which is set by mysqlnd and respected by the plain & socket streams.