### PR TITLE
Fix #76813: Access_violation_near_NULL_on_source_operand

### DIFF
--- a/sapi/phpdbg/phpdbg_lexer.l
+++ b/sapi/phpdbg/phpdbg_lexer.l
@@ -33,7 +33,7 @@ void phpdbg_init_lexer (phpdbg_param_t *stack, char *input) {
 
 	YYSETCONDITION(INITIAL);
 
-	LEX(text) = YYCURSOR = (unsigned char *) input;
+	LEX(text) = YYCURSOR = YYMARKER = (unsigned char *) input;
 	LEX(len) = strlen(input);
 }
 
@@ -84,10 +84,7 @@ ADDR        [0][x][a-fA-F0-9]+
 OPCODE      (ZEND_|zend_)([A-Za-z])+
 INPUT       ("\\"[#"']|["]("\\\\"|"\\"["]|[^\n\000"])+["]|[']("\\"[']|"\\\\"|[^\n\000'])+[']|[^\n\000#"'])+
 
-<!*> {
-	if (YYCURSOR == NULL) return T_UNEXPECTED;
-	yyleng = (size_t) YYCURSOR - (size_t) yytext;
-}
+<!*> := yyleng = (size_t) YYCURSOR - (size_t) yytext;
 
 <*>[\n\000] {
 	return 0;
@@ -166,6 +163,10 @@ INPUT       ("\\"[#"']|["]("\\\\"|"\\"["]|[^\n\000"])+["]|[']("\\"[']|"\\\\"|[^\
 	yylval->str = estrndup(yytext, yyleng - unescape_string(yytext));
 	yylval->len = yyleng;
 	return T_ID;
+}
+
+<NORMAL>* {
+	return T_UNEXPECTED;
 }
 
 <RAW>{INPUT} {

--- a/sapi/phpdbg/phpdbg_lexer.l
+++ b/sapi/phpdbg/phpdbg_lexer.l
@@ -84,7 +84,10 @@ ADDR        [0][x][a-fA-F0-9]+
 OPCODE      (ZEND_|zend_)([A-Za-z])+
 INPUT       ("\\"[#"']|["]("\\\\"|"\\"["]|[^\n\000"])+["]|[']("\\"[']|"\\\\"|[^\n\000'])+[']|[^\n\000#"'])+
 
-<!*> := yyleng = (size_t) YYCURSOR - (size_t) yytext;
+<!*> {
+	if (YYCURSOR == NULL) return T_UNEXPECTED;
+	yyleng = (size_t) YYCURSOR - (size_t) yytext;
+}
 
 <*>[\n\000] {
 	return 0;

--- a/sapi/phpdbg/phpdbg_parser.y
+++ b/sapi/phpdbg/phpdbg_parser.y
@@ -63,9 +63,13 @@ typedef void* yyscan_t;
 %% /* Rules */
 
 input
-	: command { $$ = $1; }
-	| input T_SEPARATOR command { phpdbg_stack_separate($1.top); $$ = $3; }
+	: non_empty_input { $$ = $1; }
 	| /* empty */
+	;
+
+non_empty_input
+	: command { $$ = $1; }
+	| non_empty_input T_SEPARATOR command { phpdbg_stack_separate($1.top); $$ = $3; }
 	;
 
 command

--- a/sapi/phpdbg/tests/bug76813.phpt
+++ b/sapi/phpdbg/tests/bug76813.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #76813 (Access_violation_near_NULL_on_source_operand)
+--PHPDBG--
+"#!==)===\377\377\276\242="
+#!==)===\377\377\276\242=
+--EXPECT--
+prompt> [Parse Error: syntax error, unexpected input, expecting $end]
+prompt> [Parse Error: syntax error, unexpected # (pound sign), expecting $end]
+prompt> [Parse Error: syntax error, unexpected # (pound sign), expecting $end]
+prompt>


### PR DESCRIPTION
If no valid token has been recognized, we return `T_UNEXPECTED` instead
of proceeding with an invalid scanner state.

We also fix the only superficially related issue regarding empty input
followed by `T_SEPARATOR` and command, which caused another segfault.