### PR TITLE
Use ServerClientTestCase in a test for default_socket_timeout=-1

### DIFF
--- a/ext/openssl/tests/bug62890.phpt
+++ b/ext/openssl/tests/bug62890.phpt
@@ -3,14 +3,51 @@ Bug #62890 (default_socket_timeout=-1 causes connection to timeout)
 --SKIPIF--
 <?php
 if (!extension_loaded('openssl')) die('skip openssl extension not available');
-if (getenv('SKIP_ONLINE_TESTS')) die('skip online test');
+if (!function_exists("proc_open")) die("skip no proc_open");
 ?>
 --INI--
 default_socket_timeout=-1
 --FILE--
 <?php
-$clientCtx = stream_context_create(['ssl' => ['verify_peer' => false]]);
-var_dump((bool) file_get_contents('https://www.php.net', false, $clientCtx));
+$certFile = __DIR__ . DIRECTORY_SEPARATOR . 'bug62890.pem.tmp';
+
+$serverCode = <<<'CODE'
+    $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+    $ctx = stream_context_create(['ssl' => [
+        'local_cert' => '%s',
+        'security_level' => 1,
+    ]]);
+
+    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
+    phpt_notify();
+    @stream_socket_accept($server, 3);
+CODE;
+$serverCode = sprintf($serverCode, $certFile);
+
+$clientCode = <<<'CODE'
+    $flags = STREAM_CLIENT_CONNECT;
+    $ctx = stream_context_create(['ssl' => [
+        'verify_peer' => false,
+        'verify_peer_name' => false,
+        'security_level' => 1,
+    ]]);
+
+    phpt_wait();
+
+    $client = stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 3, $flags, $ctx);
+    var_dump($client);
+CODE;
+
+include 'CertificateGenerator.inc';
+$certificateGenerator = new CertificateGenerator();
+$certificateGenerator->saveNewCertAsFileWithKey('bug62890', $certFile);
+
+include 'ServerClientTestCase.inc';
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
 ?>
---EXPECT--
-bool(true)
+--CLEAN--
+<?php
+@unlink(__DIR__ . DIRECTORY_SEPARATOR . 'bug62890.pem.tmp');
+?>
+--EXPECTF--
+resource(%d) of type (stream)


### PR DESCRIPTION
Create a test for bug62890 (default_socket_timeout=-1 causes connection to timeout) that is not online and can be run in the pipeline using ServerClientTestCase.