### PR TITLE
FPM: Return 404 if the fcgi request is without SCRIPT_FILENAME

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -973,7 +973,7 @@ static void init_request_info(void)
 
 	/* initialize the defaults */
 	SG(request_info).path_translated = NULL;
-	SG(request_info).request_method = NULL;
+	SG(request_info).request_method = FCGI_GETENV(request, "REQUEST_METHOD");
 	SG(request_info).proto_num = 1000;
 	SG(request_info).query_string = NULL;
 	SG(request_info).request_uri = NULL;
@@ -1314,7 +1314,6 @@ static void init_request_info(void)
 			SG(request_info).path_translated = estrdup(script_path_translated);
 		}
 
-		SG(request_info).request_method = FCGI_GETENV(request, "REQUEST_METHOD");
 		/* FIXME - Work out proto_num here */
 		SG(request_info).query_string = FCGI_GETENV(request, "QUERY_STRING");
 		SG(request_info).content_type = (content_type ? content_type : "" );

--- a/sapi/fpm/tests/bug69625-no-script-filename.phpt
+++ b/sapi/fpm/tests/bug69625-no-script-filename.phpt
@@ -1,0 +1,45 @@
+--TEST--
+FPM: bug69625 - 404 should be returned on missing SCRIPT_FILENAME
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$code = <<<EOT
+<?php
+echo "Test\n";
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester
+    ->request('', ['SCRIPT_FILENAME' => null])
+    ->expectHeader('Status', '404 Not Found')
+    ->expectError('Primary script unknown');
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -99,6 +99,34 @@ class Response
     }
 
     /**
+     * @param string $name
+     * @param string $value
+     * @return Response
+     */
+    public function expectHeader($name, $value)
+    {
+        $this->checkHeader($name, $value);
+
+        return $this;
+    }
+
+    /**
+     * @param string $errorMessage
+     * @return Response
+     */
+    public function expectError($errorMessage)
+    {
+        $errorData = $this->getErrorData();
+        if ($errorData !== $errorMessage) {
+            $this->error(
+                "The expected error message '$errorMessage' is not equal to returned error '$errorData'"
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * @param string $contentType
      * @return string|null
      */

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -564,6 +564,10 @@ class Tester
             ],
             $headers
         );
+        $params = array_filter($params, function($value) {
+            return !is_null($value);
+        });
+
         try {
             $this->response = new Response(
                 $this->getClient($address, $connKeepAlive)->request_data($params, false)


### PR DESCRIPTION
This PR fixes [bug 69625](https://bugs.php.net/bug.php?id=69625). The reason is that `(SG).request_method` did not get set because `script_path_translated` was empty. The fix sets `request_method` first so it has got value even if `SCRIPT_FILENAME` is empty. That will keep the behavior for empty `REQUEST_METHOD` but fixes it for empty `SCRIPT_FILENAME`.