### PR TITLE
php_tidy_create_node() expects a fixed set of node_types

### DIFF
--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -770,9 +770,7 @@ static void php_tidy_create_node(INTERNAL_FUNCTION_PARAMETERS, tidy_base_nodetyp
 			node = tidyGetBody(obj->ptdoc->doc);
 			break;
 
-		default:
-			RETURN_NULL();
-			break;
+		EMPTY_SWITCH_DEFAULT_CASE()
 	}
 
 	if (!node) {


### PR DESCRIPTION
This static function is not supposed to deal with arbitrary
`node_type`s, so there is no need to do so.