### PR TITLE
Fix Bug #80438: imap_msgno() incorrectly warns and return false on valid UIDs in PHP 8.0.0

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -2835,10 +2835,10 @@ PHP_FUNCTION(imap_uid)
 PHP_FUNCTION(imap_msgno)
 {
 	zval *streamind;
-	zend_long msgno;
+	zend_long msg_uid;
 	pils *imap_le_struct;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &streamind, &msgno) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl", &streamind, &msg_uid) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -2846,9 +2846,13 @@ PHP_FUNCTION(imap_msgno)
 		RETURN_THROWS();
 	}
 
-	PHP_IMAP_CHECK_MSGNO(msgno, 2);
+	/* Do NOT use the PHP_IMAP_CHECK_MSGNO() macro as UID cannot be checked for their upper bound. */
+	if (msg_uid < 1) {
+		zend_argument_value_error(2, "must be greater than 0");
+		RETURN_THROWS();
+	}
 
-	RETURN_LONG(mail_msgno(imap_le_struct->imap_stream, msgno));
+	RETURN_LONG(mail_msgno(imap_le_struct->imap_stream, msg_uid));
 }
 /* }}} */
 

--- a/ext/imap/tests/bug80438.phpt
+++ b/ext/imap/tests/bug80438.phpt
@@ -1,0 +1,72 @@
+--TEST--
+Bug #80438: imap_msgno() incorrectly warns and return false on valid UIDs in PHP 8.0.0
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+echo "*** Testing imap_fetch_overview() : basic functionality ***\n";
+
+require_once __DIR__.'/setup/imap_include.inc';
+
+// create a new mailbox and add 10 new messages to it
+$mail_box = setup_test_mailbox('bug80438', 10);
+
+// Delete messages to remove the numerical ordering
+imap_delete($mail_box, 5);
+imap_delete($mail_box, 6);
+imap_delete($mail_box, 7);
+imap_delete($mail_box, 8);
+imap_expunge($mail_box);
+
+$message_number_array = imap_search($mail_box, 'ALL', SE_UID);
+
+var_dump($message_number_array);
+
+foreach ($message_number_array as $message_unique_id)
+{
+    echo 'Unique ID: ';
+    var_dump($message_unique_id);
+    echo 'Ordered message number: ';
+    var_dump(imap_msgno($mail_box, $message_unique_id));
+}
+
+imap_close($mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'bug80438';
+require_once __DIR__.'/setup/clean.inc';
+?>
+--EXPECT--
+*** Testing imap_fetch_overview() : basic functionality ***
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  int(4)
+  [4]=>
+  int(9)
+  [5]=>
+  int(10)
+}
+Unique ID: int(1)
+Ordered message number: int(1)
+Unique ID: int(2)
+Ordered message number: int(2)
+Unique ID: int(3)
+Ordered message number: int(3)
+Unique ID: int(4)
+Ordered message number: int(4)
+Unique ID: int(9)
+Ordered message number: int(5)
+Unique ID: int(10)
+Ordered message number: int(6)


### PR DESCRIPTION
Checking for a valid Unique ID (UID) cannot use the convenience macro as they might
be larger than the message number which has for maximum value the total number of
current messages available in the mailbox.