### PR TITLE
Fix failing VirtualProtect() calls

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4175,6 +4175,7 @@ ZEND_EXT_API int zend_jit_check_support(void)
 	    zend_jit_vm_kind != ZEND_VM_KIND_HYBRID) {
 		zend_error(E_WARNING, "JIT is compatible only with CALL and HYBRID VM. JIT disabled.");
 		JIT_G(enabled) = 0;
+		JIT_G(on) = 0;
 		return FAILURE;
 	}
 
@@ -4183,6 +4184,7 @@ ZEND_EXT_API int zend_jit_check_support(void)
 			zend_error(E_WARNING, "JIT is incompatible with third party extensions that override zend_execute_ex(). JIT disabled.");
 		}
 		JIT_G(enabled) = 0;
+		JIT_G(on) = 0;
 		return FAILURE;
 	}
 
@@ -4190,6 +4192,7 @@ ZEND_EXT_API int zend_jit_check_support(void)
 		if (zend_get_user_opcode_handler(i) != NULL) {
 			zend_error(E_WARNING, "JIT is incompatible with third party extensions that setup user opcode handlers. JIT disabled.");
 			JIT_G(enabled) = 0;
+			JIT_G(on) = 0;
 			return FAILURE;
 		}
 	}

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1201,7 +1201,7 @@ zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script
 	ZCG(mem) = (void*)((char*)ZCG(mem) + script->arena_size);
 
 #ifdef HAVE_JIT
-	if (JIT_G(enabled) && JIT_G(on) && for_shm) {
+	if (JIT_G(on) && for_shm) {
 		zend_jit_unprotect();
 	}
 #endif
@@ -1223,7 +1223,7 @@ zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script
 	}
 
 #ifdef HAVE_JIT
-	if (JIT_G(enabled) && JIT_G(on) && for_shm) {
+	if (JIT_G(on) && for_shm) {
 		if (JIT_G(opt_level) >= ZEND_JIT_LEVEL_OPT_SCRIPT) {
 			zend_jit_script(&script->script);
 		}

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1201,7 +1201,7 @@ zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script
 	ZCG(mem) = (void*)((char*)ZCG(mem) + script->arena_size);
 
 #ifdef HAVE_JIT
-	if (JIT_G(on) && for_shm) {
+	if (JIT_G(enabled) && JIT_G(on) && for_shm) {
 		zend_jit_unprotect();
 	}
 #endif
@@ -1223,7 +1223,7 @@ zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script
 	}
 
 #ifdef HAVE_JIT
-	if (JIT_G(on) && for_shm) {
+	if (JIT_G(enabled) && JIT_G(on) && for_shm) {
 		if (JIT_G(opt_level) >= ZEND_JIT_LEVEL_OPT_SCRIPT) {
 			zend_jit_script(&script->script);
 		}


### PR DESCRIPTION
If JIT is disabled due to incompatible `zend_execute_ex`, only
`JIT_G(enabled)` is set to zero, but `JIT_G(on)` keeps its value.
However, calling `VirtualProtect()` with `NULL` fails with
`ERROR_INVALID_PARAMETER`.  Thus, we check for `JIT_G(enabled)` as
well, before (un)protecting the SHM.

---

For reference: the [diff](https://ci.appveyor.com/project/php/php-src/builds/36580067/job/woa6ulup8iuhyhwo?fullLog=true#L9299) of the failing test case.

However, with this patch, the test is still marked as borked:
````
=====================================================================
BORKED TEST SUMMARY
---------------------------------------------------------------------
Warning: JIT is incompatible with third party extensions that override zend_execute_ex(). JIT disabled. in Unknown on line 0 [%s\ext\opcache\tests\jit\bug426.phpt]
=====================================================================
````