### PR TITLE
Add more tests to IMAP to prevent regressions and consistent handling of arguments

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -152,6 +152,28 @@ static int le_imap;
 		RETURN_FALSE;	\
 	}	\
 
+#define PHP_IMAP_CHECK_MSGNO_MAYBE_UID_PRE_FLAG_CHECKS(msgindex, arg_pos) \
+	if (msgindex < 1) { \
+		zend_argument_value_error(arg_pos, "must be greater than 0"); \
+		RETURN_THROWS(); \
+	} \
+
+#define PHP_IMAP_CHECK_MSGNO_MAYBE_UID_POST_FLAG_CHECKS(msgindex, arg_pos, func_flags, uid_flag) \
+	if (func_flags & uid_flag) { \
+		/* This should be cached; if it causes an extra RTT to the  IMAP server, */ \
+		/* then that's the price we pay for making sure we don't crash. */ \
+		unsigned int msg_no_from_uid = mail_msgno(imap_le_struct->imap_stream, msgindex); \
+		if (msg_no_from_uid == 0) { \
+			php_error_docref(NULL, E_WARNING, "UID does not exist"); \
+			RETURN_FALSE; \
+		} \
+	} else { \
+		if (((unsigned) msgindex) > imap_le_struct->imap_stream->nmsgs) { \
+			php_error_docref(NULL, E_WARNING, "Bad message number"); \
+			RETURN_FALSE; \
+		} \
+	} \
+
 /* {{{ mail_close_it */
 static void mail_close_it(zend_resource *rsrc)
 {
@@ -1258,7 +1280,6 @@ PHP_FUNCTION(imap_body)
 	zval *streamind;
 	zend_long msgno, flags = 0;
 	pils *imap_le_struct;
-	unsigned long msgindex;
 	char *body;
 	unsigned long body_len = 0;
 
@@ -1270,32 +1291,15 @@ PHP_FUNCTION(imap_body)
 		RETURN_THROWS();
 	}
 
-	if (msgno < 1) {
-		zend_argument_value_error(2, "must be greater than 0");
-		RETURN_THROWS();
-	}
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_PRE_FLAG_CHECKS(msgno, 2);
 
 	if (flags && ((flags & ~(FT_UID|FT_PEEK|FT_INTERNAL)) != 0)) {
 		zend_argument_value_error(3, "must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL");
 		RETURN_THROWS();
 	}
 
-	if (flags && (flags & FT_UID)) {
-		/* This should be cached; if it causes an extra RTT to the
-		   IMAP server, then that's the price we pay for making
-		   sure we don't crash. */
-		msgindex = mail_msgno(imap_le_struct->imap_stream, msgno);
-		if (msgindex == 0) {
-			php_error_docref(NULL, E_WARNING, "UID does not exist");
-			RETURN_FALSE;
-		}
-	} else {
-		msgindex = (unsigned long) msgno;
-	}
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_POST_FLAG_CHECKS(msgno, 2, flags, FT_UID);
 
-	PHP_IMAP_CHECK_MSGNO(msgindex, 2);
-
-	/* TODO Shouldn't this pass msgindex??? */
 	body = mail_fetchtext_full (imap_le_struct->imap_stream, msgno, &body_len, flags);
 	if (body_len == 0) {
 		RETVAL_EMPTY_STRING();
@@ -1305,6 +1309,7 @@ PHP_FUNCTION(imap_body)
 }
 /* }}} */
 
+/* TODO UID Tests */
 /* {{{ Copy specified message to a mailbox */
 PHP_FUNCTION(imap_mail_copy)
 {
@@ -1334,6 +1339,7 @@ PHP_FUNCTION(imap_mail_copy)
 }
 /* }}} */
 
+/* TODO UID Tests */
 /* {{{ Move specified message to a mailbox */
 PHP_FUNCTION(imap_mail_move)
 {
@@ -1605,13 +1611,15 @@ PHP_FUNCTION(imap_delete)
 		RETURN_THROWS();
 	}
 
+	// TODO Check sequence validity?
+
 	if (flags && ((flags & ~FT_UID) != 0)) {
 		zend_argument_value_error(3, "must be FT_UID or 0");
 		RETURN_THROWS();
 	}
 
 	mail_setflag_full(imap_le_struct->imap_stream, ZSTR_VAL(sequence), "\\DELETED", flags);
-	RETVAL_TRUE;
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1882,7 +1890,6 @@ PHP_FUNCTION(imap_fetchstructure)
 	zend_long msgno, flags = 0;
 	pils *imap_le_struct;
 	BODY *body;
-	int msgindex;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl|l", &streamind, &msgno, &flags) == FAILURE) {
 		RETURN_THROWS();
@@ -1892,34 +1899,18 @@ PHP_FUNCTION(imap_fetchstructure)
 		RETURN_THROWS();
 	}
 
-	if (msgno < 1) {
-		zend_argument_value_error(2, "must be greater than 0");
-		RETURN_THROWS();
-	}
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_PRE_FLAG_CHECKS(msgno, 2);
 
 	if (flags && ((flags & ~FT_UID) != 0)) {
 		zend_argument_value_error(3, "must be FT_UID or 0");
 		RETURN_THROWS();
 	}
 
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_POST_FLAG_CHECKS(msgno, 2, flags, FT_UID);
+
 	object_init(return_value);
 
-	if (flags & FT_UID) {
-		/* This should be cached; if it causes an extra RTT to the
-		   IMAP server, then that's the price we pay for making
-		   sure we don't crash. */
-		msgindex = mail_msgno(imap_le_struct->imap_stream, msgno);
-		if (msgindex == 0) {
-			php_error_docref(NULL, E_WARNING, "UID does not exist");
-			RETURN_FALSE;
-		}
-	} else {
-		msgindex = msgno;
-	}
-	PHP_IMAP_CHECK_MSGNO(msgindex, 2);
-
-	/* TODO Shouldn't this pass msgindex??? */
-	mail_fetchstructure_full(imap_le_struct->imap_stream, msgno, &body , (ZEND_NUM_ARGS() == 3 ? flags : NIL));
+	mail_fetchstructure_full(imap_le_struct->imap_stream, msgno, &body , flags);
 
 	if (!body) {
 		php_error_docref(NULL, E_WARNING, "No body information available");
@@ -1948,20 +1939,14 @@ PHP_FUNCTION(imap_fetchbody)
 		RETURN_THROWS();
 	}
 
-	if (msgno < 1) {
-		zend_argument_value_error(2, "must be greater than 0");
-		RETURN_THROWS();
-	}
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_PRE_FLAG_CHECKS(msgno, 2);
 
 	if (flags && ((flags & ~(FT_UID|FT_PEEK|FT_INTERNAL)) != 0)) {
 		zend_argument_value_error(4, "must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL");
 		RETURN_THROWS();
 	}
 
-	if (!(flags & FT_UID)) {
-		/* only perform the check if the msgno is a message number and not a UID */
-		PHP_IMAP_CHECK_MSGNO(msgno, 2);
-	}
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_POST_FLAG_CHECKS(msgno, 2, flags, FT_UID);
 
 	body = mail_fetchbody_full(imap_le_struct->imap_stream, msgno, ZSTR_VAL(sec), &len, flags);
 
@@ -1989,24 +1974,18 @@ PHP_FUNCTION(imap_fetchmime)
 		RETURN_THROWS();
 	}
 
-	if (msgno < 1) {
-		zend_argument_value_error(2, "must be greater than 0");
+	if ((imap_le_struct = (pils *)zend_fetch_resource(Z_RES_P(streamind), "imap", le_imap)) == NULL) {
 		RETURN_THROWS();
 	}
+
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_PRE_FLAG_CHECKS(msgno, 2);
 
 	if (flags && ((flags & ~(FT_UID|FT_PEEK|FT_INTERNAL)) != 0)) {
 		zend_argument_value_error(4, "must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL");
 		RETURN_THROWS();
 	}
 
-	if ((imap_le_struct = (pils *)zend_fetch_resource(Z_RES_P(streamind), "imap", le_imap)) == NULL) {
-		RETURN_THROWS();
-	}
-
-	if (!(flags & FT_UID)) {
-		/* only perform the check if the msgno is a message number and not a UID */
-		PHP_IMAP_CHECK_MSGNO(msgno, 2);
-	}
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_POST_FLAG_CHECKS(msgno, 2, flags, FT_UID);
 
 	body = mail_fetch_mime(imap_le_struct->imap_stream, msgno, ZSTR_VAL(sec), &len, flags);
 
@@ -2037,18 +2016,14 @@ PHP_FUNCTION(imap_savebody)
 		RETURN_THROWS();
 	}
 
-	// TODO Fix for UID and normal MSGNO
-	//PHP_IMAP_CHECK_MSGNO(msgno, 3);
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_PRE_FLAG_CHECKS(msgno, 3)
 
 	if (flags && ((flags & ~(FT_UID|FT_PEEK|FT_INTERNAL)) != 0)) {
 		zend_argument_value_error(5, "must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL");
 		RETURN_THROWS();
 	}
 
-	// TODO Drop this?
-	if (!imap_le_struct) {
-		RETURN_FALSE;
-	}
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_POST_FLAG_CHECKS(msgno, 3, flags, FT_UID);
 
 	switch (Z_TYPE_P(out))
 	{
@@ -2772,9 +2747,8 @@ PHP_FUNCTION(imap_sort)
 PHP_FUNCTION(imap_fetchheader)
 {
 	zval *streamind;
-	zend_long msgno, flags = 0L;
+	zend_long msgno, flags = 0;
 	pils *imap_le_struct;
-	int msgindex;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "rl|l", &streamind, &msgno, &flags) == FAILURE) {
 		RETURN_THROWS();
@@ -2784,30 +2758,16 @@ PHP_FUNCTION(imap_fetchheader)
 		RETURN_THROWS();
 	}
 
-	// TODO Check for msgno < 1 now or wait later for PHP_IMAP_CHECK_MSGNO check?
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_PRE_FLAG_CHECKS(msgno, 2);
 
 	if (flags && ((flags & ~(FT_UID|FT_INTERNAL|FT_PREFETCHTEXT)) != 0)) {
 		zend_argument_value_error(3, "must be a bitmask of FT_UID, FT_PREFETCHTEXT, and FT_INTERNAL");
 		RETURN_THROWS();
 	}
 
-	if (flags & FT_UID) {
-		/* This should be cached; if it causes an extra RTT to the
-		   IMAP server, then that's the price we pay for making sure
-		   we don't crash. */
-		msgindex = mail_msgno(imap_le_struct->imap_stream, msgno);
-		if (msgindex == 0) {
-			php_error_docref(NULL, E_WARNING, "UID does not exist");
-			RETURN_FALSE;
-		}
-	} else {
-		msgindex = msgno;
-	}
+	PHP_IMAP_CHECK_MSGNO_MAYBE_UID_POST_FLAG_CHECKS(msgno, 2, flags, FT_UID);
 
-	PHP_IMAP_CHECK_MSGNO(msgindex, 2);
-
-	/* TODO Check shouldn't this pass msgindex???? */
-	RETVAL_STRING(mail_fetchheader_full(imap_le_struct->imap_stream, msgno, NIL, NIL, (ZEND_NUM_ARGS() == 3 ? flags : NIL)));
+	RETVAL_STRING(mail_fetchheader_full(imap_le_struct->imap_stream, msgno, NIL, NIL, flags));
 }
 /* }}} */
 

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -2037,7 +2037,8 @@ PHP_FUNCTION(imap_savebody)
 		RETURN_THROWS();
 	}
 
-	PHP_IMAP_CHECK_MSGNO(msgno, 3);
+	// TODO Fix for UID and normal MSGNO
+	//PHP_IMAP_CHECK_MSGNO(msgno, 3);
 
 	if (flags && ((flags & ~(FT_UID|FT_PEEK|FT_INTERNAL)) != 0)) {
 		zend_argument_value_error(5, "must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL");

--- a/ext/imap/tests/bug80438.phpt
+++ b/ext/imap/tests/bug80438.phpt
@@ -10,14 +10,7 @@ require_once(__DIR__.'/setup/skipif.inc');
 require_once __DIR__.'/setup/imap_include.inc';
 
 // create a new mailbox and add 10 new messages to it
-$mail_box = setup_test_mailbox('bug80438', 10);
-
-// Delete messages to remove the numerical ordering
-imap_delete($mail_box, 5);
-imap_delete($mail_box, 6);
-imap_delete($mail_box, 7);
-imap_delete($mail_box, 8);
-imap_expunge($mail_box);
+$mail_box = setup_test_mailbox_for_uid_tests('bug80438');
 
 $message_number_array = imap_search($mail_box, 'ALL', SE_UID);
 
@@ -42,15 +35,16 @@ require_once __DIR__.'/setup/clean.inc';
 --EXPECT--
 Create a temporary mailbox and add 10 msgs
 New mailbox created
+Delete 4 messages for Unique ID generation
 array(6) {
   [0]=>
   int(1)
   [1]=>
   int(2)
   [2]=>
-  int(3)
+  int(7)
   [3]=>
-  int(4)
+  int(8)
   [4]=>
   int(9)
   [5]=>
@@ -60,9 +54,9 @@ Unique ID: int(1)
 Ordered message number: int(1)
 Unique ID: int(2)
 Ordered message number: int(2)
-Unique ID: int(3)
+Unique ID: int(7)
 Ordered message number: int(3)
-Unique ID: int(4)
+Unique ID: int(8)
 Ordered message number: int(4)
 Unique ID: int(9)
 Ordered message number: int(5)

--- a/ext/imap/tests/imap_body_errors.phpt
+++ b/ext/imap/tests/imap_body_errors.phpt
@@ -1,5 +1,5 @@
 --TEST--
-imap_body() ValueError
+imap_body() errors: ValueError and Warnings
 --CREDITS--
 Paul Sohier
 #phptestfest utrecht
@@ -12,28 +12,29 @@ require_once(__DIR__.'/setup/skipif.inc');
 
 require_once(__DIR__.'/setup/imap_include.inc');
 
-$imap_stream = setup_test_mailbox("imapbodyvalueerror", 0);
+$imap_mail_box = setup_test_mailbox("imapbodyerror", 0);
 
 try {
-    imap_body($imap_stream,-1);
+    imap_body($imap_mail_box, -1);
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
-    imap_body($imap_stream,1,-1);
+    imap_body($imap_mail_box, 1, -1);
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 
-//Access not existing
-var_dump(imap_body($imap_stream, 255, FT_UID));
+// Access not existing
+var_dump(imap_body($imap_mail_box, 255));
+var_dump(imap_body($imap_mail_box, 255, FT_UID));
 
-imap_close($imap_stream);
+imap_close($imap_mail_box);
 
 ?>
 --CLEAN--
 <?php
-$mailbox_suffix = 'imapbodyvalueerror';
+$mailbox_suffix = 'imapbodyerror';
 require_once(__DIR__ . '/setup/clean.inc');
 ?>
 --EXPECTF--
@@ -41,6 +42,9 @@ Create a temporary mailbox and add 0 msgs
 New mailbox created
 imap_body(): Argument #2 ($message_num) must be greater than 0
 imap_body(): Argument #3 ($flags) must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL
+
+Warning: imap_body(): Bad message number in %s on line %d
+bool(false)
 
 Warning: imap_body(): UID does not exist in %s on line %d
 bool(false)

--- a/ext/imap/tests/imap_body_uid.phpt
+++ b/ext/imap/tests/imap_body_uid.phpt
@@ -1,0 +1,28 @@
+--TEST--
+imap_body() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapbodyuid", $msg_no, $uid);
+
+var_dump(imap_body($imap_mail_box, $uid, FT_UID) === imap_body($imap_mail_box, $msg_no));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapbodyuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+bool(true)

--- a/ext/imap/tests/imap_clearflag_full_uid.phpt
+++ b/ext/imap/tests/imap_clearflag_full_uid.phpt
@@ -1,0 +1,90 @@
+--TEST--
+imap_clearflag_full() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapclearflagfulluid");
+
+/* This works on the assumption that UID message 3 to 6 inclusive are deleted. */
+
+imap_setflag_full($imap_mail_box, '2,8,9', '\Answered', ST_UID);
+imap_setflag_full($imap_mail_box, '7,10', '\Deleted', ST_UID);
+imap_setflag_full($imap_mail_box, '7:9', '\Flagged', ST_UID);
+
+// Testing individual entry
+imap_clearflag_full($imap_mail_box, '10', '\Deleted', ST_UID);
+// Testing multiple entries entry
+imap_clearflag_full($imap_mail_box, '2,9', '\Answered', ST_UID);
+// Testing entry range
+imap_clearflag_full($imap_mail_box, '7:8', '\Flagged', ST_UID);
+
+
+echo 'ALL: ';
+var_dump(imap_search($imap_mail_box, 'ALL'));
+echo 'ALL (with UID correspondance): ';
+var_dump(imap_search($imap_mail_box, 'ALL', SE_UID));
+echo 'ANSWERED: ';
+var_dump(imap_search($imap_mail_box, 'ANSWERED'));
+echo 'DELETED: ';
+var_dump(imap_search($imap_mail_box, 'DELETED'));
+echo 'FLAGGED: ';
+var_dump(imap_search($imap_mail_box, 'FLAGGED'));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapclearflagfulluid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+ALL: array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  int(4)
+  [4]=>
+  int(5)
+  [5]=>
+  int(6)
+}
+ALL (with UID correspondance): array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(7)
+  [3]=>
+  int(8)
+  [4]=>
+  int(9)
+  [5]=>
+  int(10)
+}
+ANSWERED: array(1) {
+  [0]=>
+  int(4)
+}
+DELETED: array(1) {
+  [0]=>
+  int(3)
+}
+FLAGGED: array(1) {
+  [0]=>
+  int(5)
+}

--- a/ext/imap/tests/imap_delete_uid.phpt
+++ b/ext/imap/tests/imap_delete_uid.phpt
@@ -1,0 +1,51 @@
+--TEST--
+imap_delete() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapdeleteuid", $msg_no, $uid);
+
+imap_delete($imap_mail_box, $uid, FT_UID);
+var_dump(imap_search($imap_mail_box, 'DELETED', SE_UID));
+imap_expunge($imap_mail_box);
+
+echo 'After expunging: ';
+var_dump(imap_search($imap_mail_box, 'DELETED', SE_UID));
+
+var_dump(imap_search($imap_mail_box, 'ALL', SE_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapdeleteuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+array(1) {
+  [0]=>
+  int(9)
+}
+After expunging: bool(false)
+array(5) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(7)
+  [3]=>
+  int(8)
+  [4]=>
+  int(10)
+}

--- a/ext/imap/tests/imap_fetch_overview_uid.phpt
+++ b/ext/imap/tests/imap_fetch_overview_uid.phpt
@@ -1,0 +1,29 @@
+--TEST--
+imap_fetch_overview() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapfetchoverviewuid", $msg_no, $uid);
+
+// Usage of == because comparing objects
+var_dump(imap_fetch_overview($imap_mail_box, $uid, FT_UID) == imap_fetch_overview($imap_mail_box, $msg_no));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchoverviewuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+bool(true)

--- a/ext/imap/tests/imap_fetchbody_errors.phpt
+++ b/ext/imap/tests/imap_fetchbody_errors.phpt
@@ -1,0 +1,49 @@
+--TEST--
+imap_fetchbody() errors: ValueError and Warnings
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox("imapfetchbodyerrors", 0);
+
+$section = '';
+
+try {
+    imap_fetchbody($imap_mail_box, -1, $section);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    imap_fetchbody($imap_mail_box, 1, $section, -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+// Access not existing
+var_dump(imap_fetchbody($imap_mail_box, 255, $section));
+var_dump(imap_fetchbody($imap_mail_box, 255, $section, FT_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchbodyerrors';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECTF--
+Create a temporary mailbox and add 0 msgs
+New mailbox created
+imap_fetchbody(): Argument #2 ($message_num) must be greater than 0
+imap_fetchbody(): Argument #4 ($flags) must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL
+
+Warning: imap_fetchbody(): Bad message number in %s on line %d
+bool(false)
+
+Warning: imap_fetchbody(): UID does not exist in %s on line %d
+bool(false)

--- a/ext/imap/tests/imap_fetchbody_uid.phpt
+++ b/ext/imap/tests/imap_fetchbody_uid.phpt
@@ -1,0 +1,29 @@
+--TEST--
+imap_fetchbody() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapfetchbodyuid", $msg_no, $uid);
+
+$section = '2';
+var_dump(imap_fetchbody($imap_mail_box, $uid, $section, FT_UID) === imap_fetchbody($imap_mail_box, $msg_no, $section));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchbodyuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+bool(true)

--- a/ext/imap/tests/imap_fetchheader_errors.phpt
+++ b/ext/imap/tests/imap_fetchheader_errors.phpt
@@ -1,0 +1,47 @@
+--TEST--
+imap_fetchheader() errors: ValueError and Warnings
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox("imapfetchheadererrors", 0);
+
+try {
+    imap_fetchheader($imap_mail_box, -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    imap_fetchheader($imap_mail_box, 1, -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+// Access not existing
+var_dump(imap_fetchheader($imap_mail_box, 255));
+var_dump(imap_fetchheader($imap_mail_box, 255, FT_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchheadererrors';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECTF--
+Create a temporary mailbox and add 0 msgs
+New mailbox created
+imap_fetchheader(): Argument #2 ($message_num) must be greater than 0
+imap_fetchheader(): Argument #3 ($flags) must be a bitmask of FT_UID, FT_PREFETCHTEXT, and FT_INTERNAL
+
+Warning: imap_fetchheader(): Bad message number in %s on line %d
+bool(false)
+
+Warning: imap_fetchheader(): UID does not exist in %s on line %d
+bool(false)

--- a/ext/imap/tests/imap_fetchheader_uid.phpt
+++ b/ext/imap/tests/imap_fetchheader_uid.phpt
@@ -1,0 +1,28 @@
+--TEST--
+imap_fetchheader() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapfetchheaderuid", $msg_no, $uid);
+
+var_dump(imap_fetchheader($imap_mail_box, $uid, FT_UID) === imap_fetchheader($imap_mail_box, $msg_no));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchheaderuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+bool(true)

--- a/ext/imap/tests/imap_fetchmime_errors.phpt
+++ b/ext/imap/tests/imap_fetchmime_errors.phpt
@@ -1,0 +1,49 @@
+--TEST--
+imap_fetchmime() errors: ValueError and Warnings
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox("imapfetchmimeerrors", 0);
+
+$section = '';
+
+try {
+    imap_fetchmime($imap_mail_box, -1, $section);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    imap_fetchmime($imap_mail_box, 1, $section, -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+// Access not existing
+var_dump(imap_fetchmime($imap_mail_box, 255, $section));
+var_dump(imap_fetchmime($imap_mail_box, 255, $section, FT_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchmimeerrors';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECTF--
+Create a temporary mailbox and add 0 msgs
+New mailbox created
+imap_fetchmime(): Argument #2 ($message_num) must be greater than 0
+imap_fetchmime(): Argument #4 ($flags) must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL
+
+Warning: imap_fetchmime(): Bad message number in %s on line %d
+bool(false)
+
+Warning: imap_fetchmime(): UID does not exist in %s on line %d
+bool(false)

--- a/ext/imap/tests/imap_fetchmime_uid.phpt
+++ b/ext/imap/tests/imap_fetchmime_uid.phpt
@@ -1,0 +1,29 @@
+--TEST--
+imap_fetchmime() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapfetchmimeuid", $msg_no, $uid);
+
+$section = '2';
+var_dump(imap_fetchbody($imap_mail_box, $uid, $section, FT_UID) === imap_fetchbody($imap_mail_box, $msg_no, $section));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchmimeuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+bool(true)

--- a/ext/imap/tests/imap_fetchstructure_errors.phpt
+++ b/ext/imap/tests/imap_fetchstructure_errors.phpt
@@ -1,0 +1,47 @@
+--TEST--
+imap_fetchstructure() errors: ValueError and Warnings
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox("imapfetchstructureerrors", 0);
+
+try {
+    imap_fetchstructure($imap_mail_box, -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    imap_fetchstructure($imap_mail_box, 1, -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+// Access not existing
+var_dump(imap_fetchstructure($imap_mail_box, 255));
+var_dump(imap_fetchstructure($imap_mail_box, 255, FT_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchstructureerrors';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECTF--
+Create a temporary mailbox and add 0 msgs
+New mailbox created
+imap_fetchstructure(): Argument #2 ($message_num) must be greater than 0
+imap_fetchstructure(): Argument #3 ($flags) must be FT_UID or 0
+
+Warning: imap_fetchstructure(): Bad message number in %s on line %d
+bool(false)
+
+Warning: imap_fetchstructure(): UID does not exist in %s on line %d
+bool(false)

--- a/ext/imap/tests/imap_fetchstructure_uid.phpt
+++ b/ext/imap/tests/imap_fetchstructure_uid.phpt
@@ -1,0 +1,29 @@
+--TEST--
+imap_fetchstructure() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapfetchstructureuid", $msg_no, $uid);
+
+// Usage of == because comparing objects
+var_dump(imap_fetchstructure($imap_mail_box, $uid, FT_UID) == imap_fetchstructure($imap_mail_box, $msg_no));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapfetchstructureuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+bool(true)

--- a/ext/imap/tests/imap_savebody_errors.phpt
+++ b/ext/imap/tests/imap_savebody_errors.phpt
@@ -1,0 +1,49 @@
+--TEST--
+imap_savebody() errors: ValueError and Warnings
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox("imapsavebodyerrors", 0);
+
+$section = '';
+
+try {
+    imap_savebody($imap_mail_box, '', -1, $section);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+try {
+    imap_savebody($imap_mail_box, '', 1, $section, -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+// Access not existing
+var_dump(imap_savebody($imap_mail_box, '', 255, $section));
+var_dump(imap_savebody($imap_mail_box, '', 255, $section, FT_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapsavebodyerrors';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECTF--
+Create a temporary mailbox and add 0 msgs
+New mailbox created
+imap_savebody(): Argument #3 ($message_num) must be greater than 0
+imap_savebody(): Argument #5 ($flags) must be a bitmask of FT_UID, FT_PEEK, and FT_INTERNAL
+
+Warning: imap_savebody(): Bad message number in %s on line %d
+bool(false)
+
+Warning: imap_savebody(): UID does not exist in %s on line %d
+bool(false)

--- a/ext/imap/tests/imap_savebody_uid.phpt
+++ b/ext/imap/tests/imap_savebody_uid.phpt
@@ -1,0 +1,39 @@
+--TEST--
+imap_savebody() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapsavebodyuid", $msg_no, $uid);
+
+$section = '';
+
+$stream_uid = fopen('php://memory', 'w+');
+imap_savebody($imap_mail_box, $stream_uid, $uid, $section, FT_UID);
+
+$stream_msg_no = fopen('php://memory', 'w+');
+imap_savebody($imap_mail_box, $stream_msg_no, $msg_no, $section);
+
+// Compare what was written.
+rewind($stream_uid);
+rewind($stream_msg_no);
+var_dump(stream_get_contents($stream_uid) === stream_get_contents($stream_msg_no));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapsavebodyuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+bool(true)

--- a/ext/imap/tests/imap_search_basic.phpt
+++ b/ext/imap/tests/imap_search_basic.phpt
@@ -1,0 +1,41 @@
+--TEST--
+imap_search() with unique ID (SE_UID) flag
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapsearchuid");
+
+var_dump(imap_search($imap_mail_box, 'ALL', SE_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapsearchuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(7)
+  [3]=>
+  int(8)
+  [4]=>
+  int(9)
+  [5]=>
+  int(10)
+}

--- a/ext/imap/tests/imap_setflag_full_basic.phpt
+++ b/ext/imap/tests/imap_setflag_full_basic.phpt
@@ -1,0 +1,82 @@
+--TEST--
+imap_setflag_full() basic test
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox("imapsetflagfullbasic", 10);
+
+// Testing individual entry
+imap_setflag_full($imap_mail_box, '1', '\Answered');
+
+// Testing multiple entries entry
+imap_setflag_full($imap_mail_box, '2,7', '\Deleted');
+
+// Testing entry range
+imap_setflag_full($imap_mail_box, '3:5', '\Flagged');
+
+echo 'ALL: ';
+var_dump(imap_search($imap_mail_box, 'ALL'));
+echo 'ANSWERED: ';
+var_dump(imap_search($imap_mail_box, 'ANSWERED'));
+echo 'DELETED: ';
+var_dump(imap_search($imap_mail_box, 'DELETED'));
+echo 'FLAGGED: ';
+var_dump(imap_search($imap_mail_box, 'FLAGGED'));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapsetflagfullbasic';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+ALL: array(10) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  int(4)
+  [4]=>
+  int(5)
+  [5]=>
+  int(6)
+  [6]=>
+  int(7)
+  [7]=>
+  int(8)
+  [8]=>
+  int(9)
+  [9]=>
+  int(10)
+}
+ANSWERED: array(1) {
+  [0]=>
+  int(1)
+}
+DELETED: array(2) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(7)
+}
+FLAGGED: array(3) {
+  [0]=>
+  int(3)
+  [1]=>
+  int(4)
+  [2]=>
+  int(5)
+}

--- a/ext/imap/tests/imap_setflag_full_uid.phpt
+++ b/ext/imap/tests/imap_setflag_full_uid.phpt
@@ -1,0 +1,108 @@
+--TEST--
+imap_setflag_full() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapsetflagfulluid");
+
+/* This works on the assumption that UID message 3 to 6 inclusive are deleted. */
+
+// Testing individual entry
+imap_setflag_full($imap_mail_box, '8', '\Answered', ST_UID);
+
+// Testing multiple entries entry
+imap_setflag_full($imap_mail_box, '7,10', '\Deleted', ST_UID);
+
+// Testing entry range
+imap_setflag_full($imap_mail_box, '7:9', '\Flagged', ST_UID);
+
+// Testing entry range invalid
+var_dump(imap_setflag_full($imap_mail_box, '4:9', '\Seen', ST_UID));
+
+
+echo 'ALL: ';
+var_dump(imap_search($imap_mail_box, 'ALL'));
+echo 'ALL (with UID correspondance): ';
+var_dump(imap_search($imap_mail_box, 'ALL', SE_UID));
+echo 'ANSWERED: ';
+var_dump(imap_search($imap_mail_box, 'ANSWERED'));
+echo 'DELETED: ';
+var_dump(imap_search($imap_mail_box, 'DELETED'));
+echo 'FLAGGED: ';
+var_dump(imap_search($imap_mail_box, 'FLAGGED'));
+echo 'SEEN: ';
+var_dump(imap_search($imap_mail_box, 'SEEN'));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapsetflagfulluid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+bool(true)
+ALL: array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  int(4)
+  [4]=>
+  int(5)
+  [5]=>
+  int(6)
+}
+ALL (with UID correspondance): array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(7)
+  [3]=>
+  int(8)
+  [4]=>
+  int(9)
+  [5]=>
+  int(10)
+}
+ANSWERED: array(1) {
+  [0]=>
+  int(4)
+}
+DELETED: array(2) {
+  [0]=>
+  int(3)
+  [1]=>
+  int(6)
+}
+FLAGGED: array(3) {
+  [0]=>
+  int(3)
+  [1]=>
+  int(4)
+  [2]=>
+  int(5)
+}
+SEEN: array(3) {
+  [0]=>
+  int(3)
+  [1]=>
+  int(4)
+  [2]=>
+  int(5)
+}

--- a/ext/imap/tests/imap_sort_uid.phpt
+++ b/ext/imap/tests/imap_sort_uid.phpt
@@ -1,0 +1,56 @@
+--TEST--
+imap_sort() basics
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapsortbasic");
+
+var_dump(imap_sort($imap_mail_box, SORTSUBJECT, 0));
+var_dump(imap_sort($imap_mail_box, SORTSUBJECT, 0, SE_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapsortbasic';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(6)
+  [2]=>
+  int(2)
+  [3]=>
+  int(3)
+  [4]=>
+  int(4)
+  [5]=>
+  int(5)
+}
+array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(10)
+  [2]=>
+  int(2)
+  [3]=>
+  int(7)
+  [4]=>
+  int(8)
+  [5]=>
+  int(9)
+}

--- a/ext/imap/tests/imap_undelete_uid.phpt
+++ b/ext/imap/tests/imap_undelete_uid.phpt
@@ -1,0 +1,45 @@
+--TEST--
+imap_undelete() passing a unique ID
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__.'/setup/imap_include.inc');
+
+$imap_mail_box = setup_test_mailbox_for_uid_tests("imapundeleteuid", $msg_no, $uid);
+
+imap_delete($imap_mail_box, $uid, FT_UID);
+imap_undelete($imap_mail_box, $uid, FT_UID);
+imap_expunge($imap_mail_box);
+
+var_dump(imap_search($imap_mail_box, 'ALL', SE_UID));
+
+imap_close($imap_mail_box);
+
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'imapundeleteuid';
+require_once(__DIR__ . '/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 10 msgs
+New mailbox created
+Delete 4 messages for Unique ID generation
+array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(7)
+  [3]=>
+  int(8)
+  [4]=>
+  int(9)
+  [5]=>
+  int(10)
+}

--- a/ext/imap/tests/setup/imap_include.inc
+++ b/ext/imap/tests/setup/imap_include.inc
@@ -123,6 +123,22 @@ function create_mailbox($imap_stream, string $mailbox_suffix, int $message_count
     return $mailbox;
 }
 
+function setup_test_mailbox_for_uid_tests(string $mailbox_suffix, &$msg_no = null, &$msg_uid = null)
+{
+    $mail_box = setup_test_mailbox($mailbox_suffix, 10);
+    echo "Delete 4 messages for Unique ID generation\n";
+    // Delete messages to remove the numerical ordering
+    imap_delete($mail_box, 3);
+    imap_delete($mail_box, 4);
+    imap_delete($mail_box, 5);
+    imap_delete($mail_box, 6);
+    imap_expunge($mail_box);
+    $msg_no = 5;
+    $msg_uid = 9;
+
+    return $mail_box;
+}
+
 /**
  * Populate a mailbox with generic emails
  *


### PR DESCRIPTION
Adding test about using Unique IDs (UIDs) instead of just normal message numbers.

This caught another regression in the ``imap_savebody()`` which got introduced by using ValueError for failure states.

This also normalizes the behaviour of what happen when an invalid UID is provided.

Message number sequences are currently still not validated as this would require parsing a string which seems to much of a hassle.

Tests about said error conditions and the ValueError/Warnings they generate ~~still need to be written~~ have also been added.