### PR TITLE
Make is_file() and friends return false when path contains 0-byte

### DIFF
--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -729,6 +729,9 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
 	php_stream_wrapper *wrapper;
 
 	if (!filename_length || CHECK_NULL_PATH(filename, filename_length)) {
+		if (filename_length && !IS_EXISTS_CHECK(type)) {
+			php_error_docref(NULL, E_WARNING, "Filename contains null byte");
+		}
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -728,7 +728,7 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
 	const char *local;
 	php_stream_wrapper *wrapper;
 
-	if (!filename_length) {
+	if (!filename_length || strlen(filename) != filename_length) {
 		RETURN_FALSE;
 	}
 
@@ -937,7 +937,7 @@ ZEND_NAMED_FUNCTION(name) { \
 	size_t filename_len; \
 	\
 	ZEND_PARSE_PARAMETERS_START(1, 1) \
-		Z_PARAM_PATH(filename, filename_len) \
+		Z_PARAM_STRING(filename, filename_len) \
 	ZEND_PARSE_PARAMETERS_END(); \
 	\
 	php_stat(filename, filename_len, funcnum, return_value); \

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -728,7 +728,7 @@ PHPAPI void php_stat(const char *filename, size_t filename_length, int type, zva
 	const char *local;
 	php_stream_wrapper *wrapper;
 
-	if (!filename_length || strlen(filename) != filename_length) {
+	if (!filename_length || CHECK_NULL_PATH(filename, filename_length)) {
 		RETURN_FALSE;
 	}
 

--- a/ext/standard/tests/file/bug39863.phpt
+++ b/ext/standard/tests/file/bug39863.phpt
@@ -6,12 +6,7 @@ Andrew van der Stock, vanderaj @ owasp.org
 <?php
 
 $filename = __FILE__ . chr(0). ".ridiculous";
-
-try {
-    var_dump(file_exists($filename));
-} catch (ValueError $e) {
-    echo $e->getMessage(), "\n";
-}
+var_dump(file_exists($filename));
 ?>
 --EXPECT--
-file_exists(): Argument #1 ($filename) must not contain any null bytes
+bool(false)

--- a/ext/standard/tests/file/filegroup_variation3.phpt
+++ b/ext/standard/tests/file/filegroup_variation3.phpt
@@ -75,8 +75,12 @@ bool(false)
 Warning: filegroup(): stat failed for %s/filegroup_variation3/filegroup*.tmp in %s on line %d
 bool(false)
 - Iteration 7 -
+
+Warning: filegroup(): Filename contains null byte in %s on line %d
 bool(false)
 - Iteration 8 -
+
+Warning: filegroup(): Filename contains null byte in %s on line %d
 bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/filegroup_variation3.phpt
+++ b/ext/standard/tests/file/filegroup_variation3.phpt
@@ -75,8 +75,8 @@ bool(false)
 Warning: filegroup(): stat failed for %s/filegroup_variation3/filegroup*.tmp in %s on line %d
 bool(false)
 - Iteration 7 -
-filegroup(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 - Iteration 8 -
-filegroup(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/fileinode_variation3.phpt
+++ b/ext/standard/tests/file/fileinode_variation3.phpt
@@ -74,8 +74,8 @@ bool(false)
 Warning: fileinode(): stat failed for %s/fileinode_variation3/fileinode*.tmp in %s on line %d
 bool(false)
 - Iteration 7 -
-fileinode(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 - Iteration 8 -
-fileinode(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/fileinode_variation3.phpt
+++ b/ext/standard/tests/file/fileinode_variation3.phpt
@@ -74,8 +74,12 @@ bool(false)
 Warning: fileinode(): stat failed for %s/fileinode_variation3/fileinode*.tmp in %s on line %d
 bool(false)
 - Iteration 7 -
+
+Warning: fileinode(): Filename contains null byte in %s on line %d
 bool(false)
 - Iteration 8 -
+
+Warning: fileinode(): Filename contains null byte in %s on line %d
 bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/fileowner_variation3.phpt
+++ b/ext/standard/tests/file/fileowner_variation3.phpt
@@ -75,8 +75,12 @@ bool(false)
 Warning: fileowner(): stat failed for %s/fileowner_variation3/fileowner*.tmp in %s on line %d
 bool(false)
 - Iteration 7 -
+
+Warning: fileowner(): Filename contains null byte in %s on line %d
 bool(false)
 - Iteration 8 -
+
+Warning: fileowner(): Filename contains null byte in %s on line %d
 bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/fileowner_variation3.phpt
+++ b/ext/standard/tests/file/fileowner_variation3.phpt
@@ -75,8 +75,8 @@ bool(false)
 Warning: fileowner(): stat failed for %s/fileowner_variation3/fileowner*.tmp in %s on line %d
 bool(false)
 - Iteration 7 -
-fileowner(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 - Iteration 8 -
-fileowner(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/fileperms_variation3.phpt
+++ b/ext/standard/tests/file/fileperms_variation3.phpt
@@ -74,8 +74,8 @@ bool(false)
 Warning: fileperms(): stat failed for %s/fileperms_variation3/fileperms*.tmp in %s on line %d
 bool(false)
 - Iteration 7 -
-fileperms(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 - Iteration 8 -
-fileperms(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/fileperms_variation3.phpt
+++ b/ext/standard/tests/file/fileperms_variation3.phpt
@@ -74,8 +74,12 @@ bool(false)
 Warning: fileperms(): stat failed for %s/fileperms_variation3/fileperms*.tmp in %s on line %d
 bool(false)
 - Iteration 7 -
+
+Warning: fileperms(): Filename contains null byte in %s on line %d
 bool(false)
 - Iteration 8 -
+
+Warning: fileperms(): Filename contains null byte in %s on line %d
 bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/is_dir_variation4.phpt
+++ b/ext/standard/tests/file/is_dir_variation4.phpt
@@ -76,9 +76,9 @@ bool(true)
 bool(false)
 
 -- Iteration 9 --
-is_dir(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 
 -- Iteration 10 --
-is_dir(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/is_executable_variation1.phpt
+++ b/ext/standard/tests/file/is_executable_variation1.phpt
@@ -76,9 +76,9 @@ bool(false)
 -- Iteration 5 --
 bool(false)
 -- Iteration 6 --
-is_executable(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 -- Iteration 7 --
-is_executable(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 -- Iteration 8 --
 bool(false)
 -- Iteration 9 --

--- a/ext/standard/tests/file/is_file_variation4.phpt
+++ b/ext/standard/tests/file/is_file_variation4.phpt
@@ -66,8 +66,8 @@ bool(false)
 - Iteration 6 -
 bool(false)
 - Iteration 7 -
-is_file(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 - Iteration 8 -
-is_file(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 
 *** Done ***

--- a/ext/standard/tests/file/is_readable_variation1.phpt
+++ b/ext/standard/tests/file/is_readable_variation1.phpt
@@ -77,11 +77,11 @@ bool(false)
 -- Iteration 6 --
 bool(false)
 -- Iteration 7 --
-is_readable(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 -- Iteration 8 --
-is_readable(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 -- Iteration 9 --
-is_readable(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
 -- Iteration 10 --
 bool(true)
 -- Iteration 11 --

--- a/ext/standard/tests/file/is_writable_variation1.phpt
+++ b/ext/standard/tests/file/is_writable_variation1.phpt
@@ -87,14 +87,14 @@ bool(false)
 bool(false)
 bool(false)
 -- Iteration 7 --
-is_writable(): Argument #1 ($filename) must not contain any null bytes
-is_writeable(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
+bool(false)
 -- Iteration 8 --
-is_writable(): Argument #1 ($filename) must not contain any null bytes
-is_writeable(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
+bool(false)
 -- Iteration 9 --
-is_writable(): Argument #1 ($filename) must not contain any null bytes
-is_writeable(): Argument #1 ($filename) must not contain any null bytes
+bool(false)
+bool(false)
 -- Iteration 10 --
 bool(true)
 bool(true)


### PR DESCRIPTION
Full list of affected functions:
is_writable, is_readable, is_executable, is_file, is_dir, is_link,
fileperms, fileinode, filesize, fileowner, filegroup, filetype,
fileatime, filemtime, filectime,
file_exists, lstat, stat