### PR TITLE
Bug #80458	PDOStatement::fetchAll() throws for upsert queries

### DIFF
--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -1116,7 +1116,10 @@ MYSQLND_METHOD(mysqlnd_stmt, fetch)(MYSQLND_STMT * const s, zend_bool * const fe
 	}
 	DBG_INF_FMT("stmt=%lu", stmt->stmt_id);
 
-	if (!stmt->result || stmt->state < MYSQLND_STMT_WAITING_USE_OR_STORE) {
+	if (!stmt->result) {
+		DBG_RETURN(FAIL);
+	}
+	else if (stmt->state < MYSQLND_STMT_WAITING_USE_OR_STORE) {
 		SET_CLIENT_ERROR(stmt->error_info, CR_COMMANDS_OUT_OF_SYNC, UNKNOWN_SQLSTATE, mysqlnd_out_of_sync);
 		DBG_ERR("command out of sync");
 		DBG_RETURN(FAIL);

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -656,7 +656,6 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 #endif /* PDO_USE_MYSQLND */
 
 	if (!S->result) {
-		strcpy(stmt->error_code, "HY000");
 		PDO_DBG_RETURN(0);
 	}
 #ifdef PDO_USE_MYSQLND

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -1,0 +1,83 @@
+--TEST--
+Bug #80458 PDOStatement::fetchAll() throws for upsert queries
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_mysql')) die('skip not loaded');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'skipif.inc');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+MySQLPDOTest::skip();
+?>
+--FILE--
+<?php
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+
+$db = MySQLPDOTest::factory();
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+$db->query('DROP TABLE IF EXISTS test');
+$db->query('CREATE TABLE test (first int) ENGINE = InnoDB');
+$res = $db->query('INSERT INTO test(first) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9)');
+var_dump($res->fetchAll());
+
+$stmt = $db->prepare('DELETE FROM test WHERE first=1');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+$stmt2 = $db->prepare('DELETE FROM test WHERE first=2');
+$stmt2->execute();
+foreach($stmt2 as $row){
+    // expect nothing
+}
+
+$stmt3 = $db->prepare('DELETE FROM test WHERE first=3');
+$stmt3->execute();
+if(false !== $stmt3->fetch(PDO::FETCH_ASSOC)) {
+    print("Expecting false");
+}
+
+$stmt = $db->prepare('SELECT first FROM test WHERE first=4');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+
+$stmt3 = $db->prepare('DELETE FROM test WHERE first=5');
+$stmt3->execute();
+if(false !== $stmt3->fetch(PDO::FETCH_ASSOC)) {
+    print("Expecting false");
+}
+
+$stmt = $db->prepare('SELECT first FROM test WHERE first=6');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+MySQLPDOTest::dropTestTable();
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}
+array(1) {
+  [0]=>
+  array(2) {
+    ["first"]=>
+    int(4)
+    [0]=>
+    int(4)
+  }
+}
+array(1) {
+  [0]=>
+  array(2) {
+    ["first"]=>
+    string(1) "6"
+    [0]=>
+    string(1) "6"
+  }
+}


### PR DESCRIPTION
While the previous fixes did improve error reporting, it turns out that a lack of a result set is not an error. MySQLnd always triggers an OOS error if you try to fetch from a prepared statement and there is no result. The behaviour is now more or less aligned with emulated prepares which would throw an exception with "General error" if a result set was not present. However, in my opinion, a lack of a result is not an error. For UPDATE/DELETE and any other query that doesn't produce results, it is expected that there will be no result returned. As can be observed by the 2 bug reports the community expects an empty array instead of some confusing exception. 

This PR aims to fix the problem. First, we check in mysqlnd for a missing result. If there is no result then we return false without an exception. Second, when using emulated prepares and performing an UPSERT query we do the same. This aligns emulated prepares and native prepares back again and produces an empty array when calling `fetchAll()`. 