### PR TITLE
Bug #80458 PDOStatement::fetchAll() throws for upsert queries

### DIFF
--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -1116,7 +1116,10 @@ MYSQLND_METHOD(mysqlnd_stmt, fetch)(MYSQLND_STMT * const s, zend_bool * const fe
 	}
 	DBG_INF_FMT("stmt=%lu", stmt->stmt_id);
 
-	if (!stmt->result || stmt->state < MYSQLND_STMT_WAITING_USE_OR_STORE) {
+	if (!stmt->result) {
+		DBG_RETURN(FAIL);
+	}
+	else if (stmt->state < MYSQLND_STMT_WAITING_USE_OR_STORE) {
 		SET_CLIENT_ERROR(stmt->error_info, CR_COMMANDS_OUT_OF_SYNC, UNKNOWN_SQLSTATE, mysqlnd_out_of_sync);
 		DBG_ERR("command out of sync");
 		DBG_RETURN(FAIL);

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -1116,10 +1116,7 @@ MYSQLND_METHOD(mysqlnd_stmt, fetch)(MYSQLND_STMT * const s, zend_bool * const fe
 	}
 	DBG_INF_FMT("stmt=%lu", stmt->stmt_id);
 
-	if (!stmt->result) {
-		DBG_RETURN(FAIL);
-	}
-	else if (stmt->state < MYSQLND_STMT_WAITING_USE_OR_STORE) {
+	if (!stmt->result || stmt->state < MYSQLND_STMT_WAITING_USE_OR_STORE) {
 		SET_CLIENT_ERROR(stmt->error_info, CR_COMMANDS_OUT_OF_SYNC, UNKNOWN_SQLSTATE, mysqlnd_out_of_sync);
 		DBG_ERR("command out of sync");
 		DBG_RETURN(FAIL);

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -620,14 +620,8 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 {
 	pdo_mysql_stmt *S = (pdo_mysql_stmt*)stmt->driver_data;
 
-	if(S->stmt) {
-		MYSQL_RES     *prepare_meta_result;
-		if(!(prepare_meta_result = mysql_stmt_result_metadata(S->stmt))) {
-			pdo_mysql_error_stmt(stmt);
-			PDO_DBG_RETURN(0);
-		} else {
-			mysql_free_result(prepare_meta_result);
-		}
+	if(S->stmt && S->stmt->data && !S->stmt->data->result) {
+		PDO_DBG_RETURN(0);
 	}
 
 #ifdef PDO_USE_MYSQLND

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -620,7 +620,7 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 {
 	pdo_mysql_stmt *S = (pdo_mysql_stmt*)stmt->driver_data;
 
-	if(S->stmt && S->stmt->data && !S->stmt->data->result) {
+	if (!S->result) {
 		PDO_DBG_RETURN(0);
 	}
 
@@ -660,9 +660,6 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 	}
 #endif /* PDO_USE_MYSQLND */
 
-	if (!S->result) {
-		PDO_DBG_RETURN(0);
-	}
 #ifdef PDO_USE_MYSQLND
 	if (!S->stmt && S->current_data) {
 		mnd_free(S->current_data);

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -656,7 +656,6 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 #endif /* PDO_USE_MYSQLND */
 
 	if (!S->result) {
-		strcpy(stmt->error_code, "HY000");
 		PDO_DBG_RETURN(0);
 	}
 #ifdef PDO_USE_MYSQLND

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -619,6 +619,12 @@ static int pdo_mysql_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_da
 static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori, zend_long offset) /* {{{ */
 {
 	pdo_mysql_stmt *S = (pdo_mysql_stmt*)stmt->driver_data;
+
+	if(S->stmt && !mysql_stmt_result_metadata(S->stmt)) {
+		pdo_mysql_error_stmt(stmt);
+		PDO_DBG_RETURN(0);
+	}
+
 #ifdef PDO_USE_MYSQLND
 	zend_bool fetched_anything;
 

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -620,9 +620,14 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 {
 	pdo_mysql_stmt *S = (pdo_mysql_stmt*)stmt->driver_data;
 
-	if(S->stmt && !mysql_stmt_result_metadata(S->stmt)) {
-		pdo_mysql_error_stmt(stmt);
-		PDO_DBG_RETURN(0);
+	if(S->stmt) {
+		MYSQL_RES     *prepare_meta_result;
+		if(!(prepare_meta_result = mysql_stmt_result_metadata(S->stmt))) {
+			pdo_mysql_error_stmt(stmt);
+			PDO_DBG_RETURN(0);
+		} else {
+			mysql_free_result(prepare_meta_result);
+		}
 	}
 
 #ifdef PDO_USE_MYSQLND

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -637,6 +637,10 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 
 		PDO_DBG_RETURN(1);
 	}
+
+	if (!S->stmt && S->current_data) {
+		mnd_free(S->current_data);
+	}
 #else
 	int ret;
 
@@ -657,12 +661,6 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 		}
 
 		PDO_DBG_RETURN(1);
-	}
-#endif /* PDO_USE_MYSQLND */
-
-#ifdef PDO_USE_MYSQLND
-	if (!S->stmt && S->current_data) {
-		mnd_free(S->current_data);
 	}
 #endif /* PDO_USE_MYSQLND */
 

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -1,0 +1,83 @@
+--TEST--
+Bug #80458 PDOStatement::fetchAll() throws for upsert queries
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_mysql')) die('skip not loaded');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'skipif.inc');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+MySQLPDOTest::skip();
+?>
+--FILE--
+<?php
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+
+$db = MySQLPDOTest::factory();
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+$db->query('DROP TABLE IF EXISTS test');
+$db->query('CREATE TABLE test (first int) ENGINE = InnoDB');
+$res = $db->query('INSERT INTO test(first) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9)');
+var_dump($res->fetchAll());
+
+$stmt = $db->prepare('DELETE FROM test WHERE first=1');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+$stmt2 = $db->prepare('DELETE FROM test WHERE first=2');
+$stmt2->execute();
+foreach($stmt2 as $row){
+    // expect nothing
+}
+
+$stmt3 = $db->prepare('DELETE FROM test WHERE first=3');
+$stmt3->execute();
+if(false !== $stmt3->fetch(PDO::FETCH_ASSOC)) {
+    print("Expecting false");
+}
+
+$stmt = $db->prepare('SELECT first FROM test WHERE first=4');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+
+$stmt3 = $db->prepare('DELETE FROM test WHERE first=5');
+$stmt3->execute();
+if(false !== $stmt3->fetch(PDO::FETCH_ASSOC)) {
+    print("Expecting false");
+}
+
+$stmt = $db->prepare('SELECT first FROM test WHERE first=6');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+MySQLPDOTest::dropTestTable();
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}
+array(1) {
+  [0]=>
+  array(2) {
+    ["first"]=>
+    int(4)
+    [0]=>
+    int(4)
+  }
+}
+array(1) {
+  [0]=>
+  array(2) {
+    ["first"]=>
+    string(1) "6"
+    [0]=>
+    string(1) "6"
+  }
+}

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -41,12 +41,12 @@ $stmt = $db->prepare('SELECT first FROM test WHERE first=5');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
-$db->exec('DROP PROCEDURE IF EXISTS empty');
-$db->exec('CREATE PROCEDURE empty() BEGIN DELETE FROM test WHERE first=6; END;');
-$stmt4 = $db->prepare('CALL empty()');
+$db->exec('DROP PROCEDURE IF EXISTS nores');
+$db->exec('CREATE PROCEDURE nores() BEGIN DELETE FROM test WHERE first=6; END;');
+$stmt4 = $db->prepare('CALL nores()');
 $stmt4->execute();
 var_dump($stmt4->fetchAll());
-$db->exec('DROP PROCEDURE IF EXISTS empty');
+$db->exec('DROP PROCEDURE IF EXISTS nores');
 
 $db->exec('DROP PROCEDURE IF EXISTS ret');
 $db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test WHERE first=7; END;');
@@ -82,12 +82,12 @@ $stmt = $db->prepare('SELECT first FROM test WHERE first=12');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
-$db->exec('DROP PROCEDURE IF EXISTS empty');
-$db->exec('CREATE PROCEDURE empty() BEGIN DELETE FROM test WHERE first=13; END;');
-$stmt4 = $db->prepare('CALL empty()');
+$db->exec('DROP PROCEDURE IF EXISTS nores');
+$db->exec('CREATE PROCEDURE nores() BEGIN DELETE FROM test WHERE first=13; END;');
+$stmt4 = $db->prepare('CALL nores()');
 $stmt4->execute();
 var_dump($stmt4->fetchAll());
-$db->exec('DROP PROCEDURE IF EXISTS empty');
+$db->exec('DROP PROCEDURE IF EXISTS nores');
 
 $db->exec('DROP PROCEDURE IF EXISTS ret');
 $db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test WHERE first=14; END;');

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -17,7 +17,7 @@ $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 
 $db->query('DROP TABLE IF EXISTS test');
 $db->query('CREATE TABLE test (first int) ENGINE = InnoDB');
-$res = $db->query('INSERT INTO test(first) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14)');
+$res = $db->query('INSERT INTO test(first) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16)');
 var_dump($res->fetchAll());
 
 $stmt = $db->prepare('DELETE FROM test WHERE first=1');
@@ -98,6 +98,17 @@ $stmt5->nextRowset(); // needed to fetch the empty result set of CALL
 var_dump($stmt5->fetchAll());
 $db->exec('DROP PROCEDURE IF EXISTS ret');
 
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+$db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+
+$stmt = $db->prepare('DELETE FROM test WHERE first=15');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+$stmt = $db->prepare('SELECT first FROM test WHERE first=16');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
 ?>
 --CLEAN--
 <?php
@@ -161,4 +172,15 @@ array(1) {
   }
 }
 array(0) {
+}
+array(0) {
+}
+array(1) {
+  [0]=>
+  array(2) {
+    ["first"]=>
+    int(16)
+    [0]=>
+    int(16)
+  }
 }

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -54,9 +54,11 @@ $stmt5 = $db->prepare('CALL ret()');
 $stmt5->execute();
 var_dump($stmt5->fetchAll());
 $stmt5->nextRowset(); // needed to fetch the empty result set of CALL
+var_dump($stmt5->fetchAll());
 $db->exec('DROP PROCEDURE IF EXISTS ret');
 
 /* With emulated prepares */
+print("Emulated prepares\n");
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
 $stmt = $db->prepare('DELETE FROM test WHERE first=8');
@@ -93,6 +95,7 @@ $stmt5 = $db->prepare('CALL ret()');
 $stmt5->execute();
 var_dump($stmt5->fetchAll());
 $stmt5->nextRowset(); // needed to fetch the empty result set of CALL
+var_dump($stmt5->fetchAll());
 $db->exec('DROP PROCEDURE IF EXISTS ret');
 
 ?>
@@ -131,6 +134,9 @@ array(1) {
 }
 array(0) {
 }
+Emulated prepares
+array(0) {
+}
 array(0) {
 }
 bool(false)
@@ -153,4 +159,6 @@ array(1) {
     [0]=>
     string(2) "14"
   }
+}
+array(0) {
 }

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -17,40 +17,83 @@ $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 
 $db->query('DROP TABLE IF EXISTS test');
 $db->query('CREATE TABLE test (first int) ENGINE = InnoDB');
-$res = $db->query('INSERT INTO test(first) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9)');
+$res = $db->query('INSERT INTO test(first) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14)');
 var_dump($res->fetchAll());
 
 $stmt = $db->prepare('DELETE FROM test WHERE first=1');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
-$stmt2 = $db->prepare('DELETE FROM test WHERE first=2');
+$res = $db->query('DELETE FROM test WHERE first=2');
+var_dump($res->fetchAll());
+
+$stmt2 = $db->prepare('DELETE FROM test WHERE first=3');
 $stmt2->execute();
 foreach($stmt2 as $row){
     // expect nothing
 }
 
-$stmt3 = $db->prepare('DELETE FROM test WHERE first=3');
+$stmt3 = $db->prepare('DELETE FROM test WHERE first=4');
 $stmt3->execute();
-if(false !== $stmt3->fetch(PDO::FETCH_ASSOC)) {
-    print("Expecting false");
-}
+var_dump($stmt3->fetch(PDO::FETCH_ASSOC));
 
-$stmt = $db->prepare('SELECT first FROM test WHERE first=4');
+$stmt = $db->prepare('SELECT first FROM test WHERE first=5');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
+$db->exec('DROP PROCEDURE IF EXISTS empty');
+$db->exec('CREATE PROCEDURE empty() BEGIN DELETE FROM test WHERE first=6; END;');
+$stmt4 = $db->prepare('CALL empty()');
+$stmt4->execute();
+var_dump($stmt4->fetchAll());
+$db->exec('DROP PROCEDURE IF EXISTS empty');
+
+$db->exec('DROP PROCEDURE IF EXISTS ret');
+$db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test WHERE first=7; END;');
+$stmt5 = $db->prepare('CALL ret()');
+$stmt5->execute();
+var_dump($stmt5->fetchAll());
+$stmt5->nextRowset(); // needed to fetch the empty result set of CALL
+$db->exec('DROP PROCEDURE IF EXISTS ret');
+
+/* With emulated prepares */
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
-$stmt3 = $db->prepare('DELETE FROM test WHERE first=5');
-$stmt3->execute();
-if(false !== $stmt3->fetch(PDO::FETCH_ASSOC)) {
-    print("Expecting false");
-}
-
-$stmt = $db->prepare('SELECT first FROM test WHERE first=6');
+$stmt = $db->prepare('DELETE FROM test WHERE first=8');
 $stmt->execute();
 var_dump($stmt->fetchAll());
+
+$res = $db->query('DELETE FROM test WHERE first=9');
+var_dump($res->fetchAll());
+
+$stmt2 = $db->prepare('DELETE FROM test WHERE first=10');
+$stmt2->execute();
+foreach($stmt2 as $row){
+    // expect nothing
+}
+
+$stmt3 = $db->prepare('DELETE FROM test WHERE first=11');
+$stmt3->execute();
+var_dump($stmt3->fetch(PDO::FETCH_ASSOC));
+
+$stmt = $db->prepare('SELECT first FROM test WHERE first=12');
+$stmt->execute();
+var_dump($stmt->fetchAll());
+
+$db->exec('DROP PROCEDURE IF EXISTS empty');
+$db->exec('CREATE PROCEDURE empty() BEGIN DELETE FROM test WHERE first=13; END;');
+$stmt4 = $db->prepare('CALL empty()');
+$stmt4->execute();
+var_dump($stmt4->fetchAll());
+$db->exec('DROP PROCEDURE IF EXISTS empty');
+
+$db->exec('DROP PROCEDURE IF EXISTS ret');
+$db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test WHERE first=14; END;');
+$stmt5 = $db->prepare('CALL ret()');
+$stmt5->execute();
+var_dump($stmt5->fetchAll());
+$stmt5->nextRowset(); // needed to fetch the empty result set of CALL
+$db->exec('DROP PROCEDURE IF EXISTS ret');
 
 ?>
 --CLEAN--
@@ -63,21 +106,51 @@ array(0) {
 }
 array(0) {
 }
+array(0) {
+}
+bool(false)
 array(1) {
   [0]=>
   array(2) {
     ["first"]=>
-    int(4)
+    int(5)
     [0]=>
-    int(4)
+    int(5)
   }
+}
+array(0) {
 }
 array(1) {
   [0]=>
   array(2) {
     ["first"]=>
-    string(1) "6"
+    int(7)
     [0]=>
-    string(1) "6"
+    int(7)
+  }
+}
+array(0) {
+}
+array(0) {
+}
+bool(false)
+array(1) {
+  [0]=>
+  array(2) {
+    ["first"]=>
+    string(2) "12"
+    [0]=>
+    string(2) "12"
+  }
+}
+array(0) {
+}
+array(1) {
+  [0]=>
+  array(2) {
+    ["first"]=>
+    string(2) "14"
+    [0]=>
+    string(2) "14"
   }
 }


### PR DESCRIPTION
While the previous fixes did improve error reporting, it turns out that a lack of a result set is not an error. MySQLnd always triggers an OOS error if you try to fetch from a prepared statement and there is no result. The behaviour is now more or less aligned with emulated prepares which would throw an exception with "General error" if a result set was not present. However, in my opinion, a lack of a result is not an error. For UPDATE/DELETE and any other query that doesn't produce results, it is expected that there will be no result returned. As can be observed by the 2 bug reports the community expects an empty array instead of some confusing exception.

This PR aims to fix the problem. First, we check in mysqlnd for a missing result. If there is no result then we return false without an exception. Second, when using emulated prepares and performing an UPSERT query we do the same. This aligns emulated prepares and native prepares back again and produces an empty array when calling fetchAll().