### PR TITLE
fix mysqli_stmt_get_result_metadata_fetch_field test for mariadb

### DIFF
--- a/ext/mysqli/tests/mysqli_stmt_get_result_metadata_fetch_field.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_metadata_fetch_field.phpt
@@ -176,6 +176,6 @@ object(stdClass)#%d (13) {
   ["type"]=>
   int(253)
   ["decimals"]=>
-  int(31)
+  int(3%d)
 }
 done!


### PR DESCRIPTION
MariaDB extended the default decimal field to 39 characters
instead of MySQL's 31 characters.

This small change allows the test to pass on MySQL and MariaDB.