### PR TITLE
Adds test and fix to bug 74371 but for php8

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4778,6 +4778,22 @@ PHPAPI size_t php_strip_tags(char *rbuf, size_t len, const char *allow, size_t a
 }
 /* }}} */
 
+//in tag && in quote ...
+#define _PHP_STRIP_TAGS_WE_ARE_IN_QUOTE_WITH_ALLOW_CHAR(CHAR) \
+			(state == 1 && in_q>1 && allow && c == CHAR) 
+
+ //resize for the encode char &gt; or &lt;
+#define _PHP_STRIP_TAGS_ENCODE_CHAR(ENCODE_CHAR)  \
+			if (((tp - tbuf) + 4) >= PHP_TAG_BUF_SIZE) { \
+				pos = tp - tbuf; \
+				tbuf = erealloc(tbuf, pos + PHP_TAG_BUF_SIZE + 4 ); \
+				tp = tbuf + pos; \
+			} \
+			\
+			memcpy(tp, ENCODE_CHAR, (tp-tbuf)+4); \
+			tp+=4;
+
+
 /* {{{ php_strip_tags
 
 	A simple little state-machine to strip out html and php tags
@@ -4832,6 +4848,12 @@ state_0:
 		case '\0':
 			break;
 		case '<':
+		
+			if (_PHP_STRIP_TAGS_WE_ARE_IN_QUOTE_WITH_ALLOW_CHAR('<')) {
+				_PHP_STRIP_TAGS_ENCODE_CHAR("&lt;")
+				break;
+			}
+ 
 			if (in_q) {
 				break;
 			}
@@ -4857,6 +4879,11 @@ state_0:
 				break;
 			}
 
+			if (_PHP_STRIP_TAGS_WE_ARE_IN_QUOTE_WITH_ALLOW_CHAR('>')) {
+				_PHP_STRIP_TAGS_ENCODE_CHAR("&gt;")
+				break;
+			}
+
 			if (in_q) {
 				break;
 			}
@@ -4879,6 +4906,12 @@ state_1:
 		case '\0':
 			break;
 		case '<':
+
+			if (_PHP_STRIP_TAGS_WE_ARE_IN_QUOTE_WITH_ALLOW_CHAR('<')) {
+				_PHP_STRIP_TAGS_ENCODE_CHAR("&lt;")
+				break;
+			}
+
 			if (in_q) {
 				break;
 			}
@@ -4892,6 +4925,12 @@ state_1:
 				depth--;
 				break;
 			}
+
+			if (_PHP_STRIP_TAGS_WE_ARE_IN_QUOTE_WITH_ALLOW_CHAR('>')) {
+				_PHP_STRIP_TAGS_ENCODE_CHAR("&gt;")
+				break;
+			}
+
 			if (in_q) {
 				break;
 			}
@@ -4986,6 +5025,12 @@ state_2:
 				depth--;
 				break;
 			}
+
+			if (_PHP_STRIP_TAGS_WE_ARE_IN_QUOTE_WITH_ALLOW_CHAR('>')) {
+				_PHP_STRIP_TAGS_ENCODE_CHAR("&gt;")
+				break;
+			}
+
 			if (in_q) {
 				break;
 			}
@@ -5046,6 +5091,12 @@ state_3:
 				depth--;
 				break;
 			}
+
+			if (_PHP_STRIP_TAGS_WE_ARE_IN_QUOTE_WITH_ALLOW_CHAR('>')) {
+				_PHP_STRIP_TAGS_ENCODE_CHAR("&gt;")
+				break;
+			}
+
 			if (in_q) {
 				break;
 			}

--- a/ext/standard/tests/strings/bugXXX.phpt
+++ b/ext/standard/tests/strings/bugXXX.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #XXXXX: strip_tags strip >< in attributes with allow tag
+Bug #74371: strip_tags strip >< in attributes with allow tag
+--FILE--
+<?php
+
+echo strip_tags('<ta alt="x< " >', '<ta>').PHP_EOL;
+echo strip_tags('<ta alt="x> " >', '<ta>').PHP_EOL;
+
+?>
+--EXPECT--
+<ta alt="x&lt; " >
+<ta alt="x&gt; " >


### PR DESCRIPTION
This Pr point to resolve this bug 
https://bugs.php.net/bug.php?id=74371
https://github.com/php/php-src/pull/3570

Originally created for PHP 7.1.3 but still present also in PHP 8 this fix it's for PHP 8.

Note:
The number of bug is not present because I not understood how to create a bug for a specific version 
or comment description of the original bug post.

Like the comment of the original PR, I followed the solution (for security aspects) of decoding the '<' and '>' instead of allowed. Because misuse of this function seems a more pragmatic approach. 

The code of PHP 8 it's more readable ma still complex to manage. For this, I chose this approach.

Another solution may refactor the entire function. To allow the internal "state machine" to 
know which context it's and change behavior based on this know-how for example. 
This solution requires more effort.

To improve the readability I chose to use a macro I don't know if this choice follows the best practices 
or the coding standard if not I can convert it to a static function.

For last if this PR it's appreciated, I can try to fix also the previous version like 7.x.

This it's my first PR for this repo so sorry if it does not respect the standard flow. 

My apologies but It's been a long time since I wrote code in c. If need I try to improve the quality of code
