### PR TITLE
Throw value exception on invalid characters in _php_math_basetozval

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -717,7 +717,7 @@ PHPAPI zend_long _php_math_basetolong(zval *arg, int base)
 /*
  * Convert a string representation of a base(2-36) number to a zval.
  */
-PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret)
+PHPAPI zend_result _php_math_basetozval(zend_string *str, int base, zval *ret)
 {
 	zend_long num = 0;
 	double fnum = 0;
@@ -780,7 +780,8 @@ PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret)
 	}
 
 	if (invalidchars > 0) {
-		zend_error(E_DEPRECATED, "Invalid characters passed for attempted conversion, these have been ignored");
+		zend_value_error("Invalid characters passed for attempted conversion");
+		return FAILURE;
 	}
 
 	if (mode == 1) {
@@ -788,6 +789,7 @@ PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret)
 	} else {
 		ZVAL_LONG(ret, num);
 	}
+	return SUCCESS;
 }
 /* }}} */
 
@@ -905,7 +907,9 @@ PHP_FUNCTION(bindec)
 		Z_PARAM_STR(arg)
 	ZEND_PARSE_PARAMETERS_END();
 
-	_php_math_basetozval(arg, 2, return_value);
+	if (_php_math_basetozval(arg, 2, return_value) == FAILURE) {
+		RETURN_THROWS();
+	}
 }
 /* }}} */
 
@@ -918,7 +922,9 @@ PHP_FUNCTION(hexdec)
 		Z_PARAM_STR(arg)
 	ZEND_PARSE_PARAMETERS_END();
 
-	_php_math_basetozval(arg, 16, return_value);
+	if (_php_math_basetozval(arg, 16, return_value) == FAILURE) {
+		RETURN_THROWS();
+	}
 }
 /* }}} */
 
@@ -931,7 +937,9 @@ PHP_FUNCTION(octdec)
 		Z_PARAM_STR(arg)
 	ZEND_PARSE_PARAMETERS_END();
 
-	_php_math_basetozval(arg, 8, return_value);
+	if (_php_math_basetozval(arg, 8, return_value) == FAILURE) {
+		RETURN_THROWS();
+	}
 }
 /* }}} */
 
@@ -997,7 +1005,9 @@ PHP_FUNCTION(base_convert)
 		RETURN_THROWS();
 	}
 
-	_php_math_basetozval(number, (int)frombase, &temp);
+	if (_php_math_basetozval(number, (int)frombase, &temp) == FAILURE) {
+		RETURN_THROWS();
+	}
 	result = _php_math_zvaltobase(&temp, (int)tobase);
 	if (!result) {
 		RETURN_THROWS();

--- a/ext/standard/php_math.h
+++ b/ext/standard/php_math.h
@@ -23,7 +23,7 @@ PHPAPI zend_string *_php_math_number_format(double d, int dec, char dec_point, c
 PHPAPI zend_string *_php_math_number_format_ex(double d, int dec, const char *dec_point, size_t dec_point_len, const char *thousand_sep, size_t thousand_sep_len);
 PHPAPI zend_string * _php_math_longtobase(zend_long arg, int base);
 PHPAPI zend_long _php_math_basetolong(zval *arg, int base);
-PHPAPI void _php_math_basetozval(zend_string *str, int base, zval *ret);
+PHPAPI zend_result _php_math_basetozval(zend_string *str, int base, zval *ret);
 PHPAPI zend_string * _php_math_zvaltobase(zval *arg, int base);
 
 #include <math.h>


### PR DESCRIPTION
The first vote of the base_convert changes RFC[1] was about deprecating
passing strings containing invalid characters to base_convert() and
friends in PHP 7.4, and to raise an exception in PHP 8.  Apparently, it
has been forgotten to actually throw the exception, so we catch up on
this.

[1] <https://wiki.php.net/rfc/base_convert_improvements>

---

Probably too late for PHP-8.0 due to the potential ABI break, and might be an issue to introduce in PHP-8.1 because of the exception.

