### PR TITLE
Fix typo 'variabled' in named_params/undef_var.phpt

### DIFF
--- a/Zend/tests/named_params/undef_var.phpt
+++ b/Zend/tests/named_params/undef_var.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Passing undefined variabled to named arg
+Passing undefined variable to named arg
 --FILE--
 <?php
 


### PR DESCRIPTION
Just fix typo in phpt file.
