### PR TITLE
Fix typo in changelog

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1879,7 +1879,7 @@ PHP                                                                        NEWS
   . Implemented asynchronous signal handling without TICKS. (Dmitry)
   . Added pcntl_signal_get_handler() that returns the current signal handler
     for a particular signal. Addresses FR #72409. (David Walker)
-  . Add signinfo to pcntl_signal() handler args (Bishop Bettini, David Walker)
+  . Add siginfo to pcntl_signal() handler args (Bishop Bettini, David Walker)
 
 - PCRE:
   . Fixed bug #73483 (Segmentation fault on pcre_replace_callback). (Laruence)


### PR DESCRIPTION
This relates to https://github.com/php/doc-en/pull/274. The [PHP 7.1.0 changelog](https://www.php.net/ChangeLog-7.php#7.1.0) has the following entry:

> Add sig**n**info to pcntl_signal() handler args (Bishop Bettini, David Walker)

As described in the PR above, the pcntl_signal docs page incorrectly used both the spelling `siginfo` and the typo `signinfo` interchangably to represent this one argument. The source itself always uses the former:

https://github.com/php/php-src/blob/22bf92564ca2ff7e4827e69c364942c4291931dc/ext/pcntl/pcntl.c#L1287

Now the docs have been fixed to consistently use this spelling, it would be good if the changelog did too; a typo in the feature name itself makes it difficult to search for.