### PR TITLE
Remove very old -no-cpp-precomp compatibility flag on Mac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,12 +222,6 @@ case $host_alias in
   *dgux*)
     CPPFLAGS="$CPPFLAGS -D_BSD_TIMEOFDAY_FLAVOR"
     ;;
-  *darwin*)
-    if test -n "$GCC"; then
-      AX_CHECK_COMPILE_FLAG([-no-cpp-precomp],
-                            [CPPFLAGS="$CPPFLAGS -no-cpp-precomp"])
-    fi
-    ;;
   *mips*)
     CPPFLAGS="$CPPFLAGS -D_XPG_IV"
     ;;


### PR DESCRIPTION
Here are a few links that say this was obsoleted at least 7 years ago:

- https://bugzilla.mozilla.org/show_bug.cgi?id=409224 (obsolete in GCC)
- https://bz.apache.org/bugzilla/show_bug.cgi?id=48483#c3 (obsolete on Mac)

It didn't cause my any problems, but I noticed this flag when building on a Mac and thought it was odd, so did some investigating.