### PR TITLE
IBM i PASE doesn't support ITIMER_PROF

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1382,7 +1382,7 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 			t_r.it_value.tv_sec = seconds;
 			t_r.it_value.tv_usec = t_r.it_interval.tv_sec = t_r.it_interval.tv_usec = 0;
 
-# ifdef __CYGWIN__
+# if defined(__CYGWIN__) || defined(__PASE__)
 			setitimer(ITIMER_REAL, &t_r, NULL);
 		}
 		signo = SIGALRM;
@@ -1444,7 +1444,7 @@ void zend_unset_timeout(void) /* {{{ */
 
 		no_timeout.it_value.tv_sec = no_timeout.it_value.tv_usec = no_timeout.it_interval.tv_sec = no_timeout.it_interval.tv_usec = 0;
 
-# ifdef __CYGWIN__
+# if defined(__CYGWIN__) || defined(__PASE__)
 		setitimer(ITIMER_REAL, &no_timeout, NULL);
 # else
 		setitimer(ITIMER_PROF, &no_timeout, NULL);

--- a/Zend/zend_signal.c
+++ b/Zend/zend_signal.c
@@ -62,7 +62,8 @@ ZEND_API zend_signal_globals_t zend_signal_globals;
 static void zend_signal_handler(int signo, siginfo_t *siginfo, void *context);
 static int zend_signal_register(int signo, void (*handler)(int, siginfo_t*, void*));
 
-#ifdef __CYGWIN__
+#if defined(__CYGWIN__) || defined(__PASE__)
+/* Matches zend_excute_API.c; these platforms don't support ITIMER_PROF. */
 #define TIMEOUT_SIG SIGALRM
 #else
 #define TIMEOUT_SIG SIGPROF


### PR DESCRIPTION
Like Cygwin, this platform needs to use a real-time timer.

This was based on a patch by @kadler, but it didn't handle unsetting
the timer, so the timeout would continue to be active, triggering
`hard_timeout` unexpectedly. The patch is fixed to handle unsetting.