### PR TITLE
Fix #77322: PharData::addEmptyDir('/') Possible integer overflow

### DIFF
--- a/ext/phar/tests/bug77322.phpt
+++ b/ext/phar/tests/bug77322.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #77322 (PharData::addEmptyDir('/') Possible integer overflow)
+--SKIPIF--
+<?php
+if (!extension_loaded('phar')) die('skip phar extension not available');
+?>
+--FILE--
+<?php
+$zip = new PharData(__DIR__ . '/bug77322.zip');
+$zip->addEmptyDir('/');
+var_dump($zip->count());
+
+$tar = new PharData(__DIR__ . '/bug77322.tar');
+$tar->addEmptyDir('/');
+var_dump($tar->count());
+?>
+--EXPECT--
+int(1)
+int(1)
+--CLEAN--
+<?php
+unlink(__DIR__ . '/bug77322.zip');
+unlink(__DIR__ . '/bug77322.tar');
+?>

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -567,7 +567,7 @@ phar_entry_data *phar_get_or_create_entry_data(char *fname, size_t fname_len, ch
 	} else {
 		etemp.flags = etemp.old_flags = PHAR_ENT_PERM_DEF_FILE;
 	}
-	if (is_dir) {
+	if (is_dir && path_len) {
 		etemp.filename_len--; /* strip trailing / */
 		path_len--;
 	}


### PR DESCRIPTION
`phar_path_check()` already strips a leading slash, so we must not
attempt to strip the trailing slash from an now empty directory name.