### PR TITLE
Disallow version_compare() $operator abbreviations

### DIFF
--- a/ext/standard/tests/versioning/version_compare_op_abbrev.phpt
+++ b/ext/standard/tests/versioning/version_compare_op_abbrev.phpt
@@ -1,0 +1,21 @@
+--TEST--
+version_compare() no longer supports operator abbreviations
+--FILE--
+<?php
+$abbrevs = ['', 'l', 'g', 'e', '!', 'n'];
+foreach ($abbrevs as $op) {
+    try {
+        version_compare('1', '2', $op);
+        echo "'$op' succeeded\n";
+    } catch (ValueError $err) {
+        echo "'$op' failed\n";
+    }
+}
+?>
+--EXPECT--
+'' failed
+'l' failed
+'g' failed
+'e' failed
+'!' failed
+'n' failed

--- a/ext/standard/versioning.c
+++ b/ext/standard/versioning.c
@@ -205,7 +205,7 @@ PHP_FUNCTION(version_compare)
 {
 	char *v1, *v2;
 	zend_string *op = NULL;
-	size_t v1_len, v2_len, op_len = 0;
+	size_t v1_len, v2_len;
 	int compare;
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)

--- a/ext/standard/versioning.c
+++ b/ext/standard/versioning.c
@@ -203,7 +203,8 @@ php_version_compare(const char *orig_ver1, const char *orig_ver2)
 
 PHP_FUNCTION(version_compare)
 {
-	char *v1, *v2, *op = NULL;
+	char *v1, *v2;
+	zend_string *op = NULL;
 	size_t v1_len, v2_len, op_len = 0;
 	int compare;
 
@@ -211,29 +212,29 @@ PHP_FUNCTION(version_compare)
 		Z_PARAM_STRING(v1, v1_len)
 		Z_PARAM_STRING(v2, v2_len)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_STRING_OR_NULL(op, op_len)
+		Z_PARAM_STR_OR_NULL(op)
 	ZEND_PARSE_PARAMETERS_END();
 
 	compare = php_version_compare(v1, v2);
 	if (!op) {
 		RETURN_LONG(compare);
 	}
-	if (!strncmp(op, "<", op_len) || !strncmp(op, "lt", op_len)) {
+	if (zend_string_equals_literal(op, "<") || zend_string_equals_literal(op, "lt")) {
 		RETURN_BOOL(compare == -1);
 	}
-	if (!strncmp(op, "<=", op_len) || !strncmp(op, "le", op_len)) {
+	if (zend_string_equals_literal(op, "<=") || zend_string_equals_literal(op, "le")) {
 		RETURN_BOOL(compare != 1);
 	}
-	if (!strncmp(op, ">", op_len) || !strncmp(op, "gt", op_len)) {
+	if (zend_string_equals_literal(op, ">") || zend_string_equals_literal(op, "gt")) {
 		RETURN_BOOL(compare == 1);
 	}
-	if (!strncmp(op, ">=", op_len) || !strncmp(op, "ge", op_len)) {
+	if (zend_string_equals_literal(op, ">=") || zend_string_equals_literal(op, "ge")) {
 		RETURN_BOOL(compare != -1);
 	}
-	if (!strncmp(op, "==", op_len) || !strncmp(op, "=", op_len) || !strncmp(op, "eq", op_len)) {
+	if (zend_string_equals_literal(op, "==") || zend_string_equals_literal(op, "=") || zend_string_equals_literal(op, "eq")) {
 		RETURN_BOOL(compare == 0);
 	}
-	if (!strncmp(op, "!=", op_len) || !strncmp(op, "<>", op_len) || !strncmp(op, "ne", op_len)) {
+	if (zend_string_equals_literal(op, "!=") || zend_string_equals_literal(op, "<>") || zend_string_equals_literal(op, "ne")) {
 		RETURN_BOOL(compare != 0);
 	}
 


### PR DESCRIPTION
`version_compare()` does a sloppy check for the `$operators` argument
which allows arbitrary abbreviations of the supported operators to be
accepted.  This is both undocumented and unexpected, and could lead to
subtle BC breaks, if the order of the comparisions will be changed.
Therefore we change to strict comparisons.

---

Since this comparision behavior is there since PHP 4.3.0 or so, of course, this change would constitute a BC break. Thus I do not actually propose to merge this change, but like to bring that issue to more attention. Maybe we should leave it as is, but document the behavior; maybe we want to get rid of the `$operator` parameter altogether.

PS: see also https://bugs.php.net/80503