### PR TITLE
Short match

### DIFF
--- a/Zend/tests/match/short-match-ast.phpt
+++ b/Zend/tests/match/short-match-ast.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Short-hand match with implicit true subject, AST printing.
+--INI--
+assert.exception=0
+--FILE--
+<?php
+
+assert((function () {
+    $a = 3;
+    match {
+      $a < 2 => 'small',
+      $a == 3 => 'medium',
+      default => 'large',
+    };
+})());
+
+?>
+--EXPECTF--
+Warning: assert(): assert(function () {
+    $a = 3;
+    match {
+        $a < 2 => 'small',
+        $a == 3 => 'medium',
+        default => 'large',
+    };
+}()) failed in %s on line %d

--- a/Zend/tests/match/short-match.phpt
+++ b/Zend/tests/match/short-match.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test multiple default arms in match in different arms
+Short-hand match with implicit true subject.
 --FILE--
 <?php
 

--- a/Zend/tests/match/short-match.phpt
+++ b/Zend/tests/match/short-match.phpt
@@ -5,7 +5,7 @@ Test multiple default arms in match in different arms
 
 $a = 3;
 
-match {
+print match {
   $a < 2 => 'small',
   $a == 3 => 'medium',
   default => 'large',

--- a/Zend/tests/match/short-match.phpt
+++ b/Zend/tests/match/short-match.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test multiple default arms in match in different arms
+--FILE--
+<?php
+
+$a = 3;
+
+match {
+  $a < 2 => 'small',
+  $a == 3 => 'medium',
+  default => 'large',
+};
+
+?>
+--EXPECTF--
+medium

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1979,12 +1979,22 @@ simple_list:
 			zend_ast_export_stmt(str, ast->child[1], indent + 1);
 			break;
 		case ZEND_AST_MATCH:
-			smart_str_appends(str, "match (");
-			zend_ast_export_ex(str, ast->child[0], 0, indent);
-			smart_str_appends(str, ") {\n");
-			zend_ast_export_ex(str, ast->child[1], 0, indent + 1);
-			zend_ast_export_indent(str, indent);
-			smart_str_appendc(str, '}');
+			if (ast->attr & ZEND_MATCH_SHORT) {
+				smart_str_appends(str, "match {\n");
+//				zend_ast_export_ex(str, ast->child[0], 0, indent);
+//				smart_str_appends(str, ") {\n");
+				zend_ast_export_ex(str, ast->child[1], 0, indent + 1);
+				zend_ast_export_indent(str, indent);
+				smart_str_appendc(str, '}');
+			}
+			else {
+				smart_str_appends(str, "match (");
+				zend_ast_export_ex(str, ast->child[0], 0, indent);
+				smart_str_appends(str, ") {\n");
+				zend_ast_export_ex(str, ast->child[1], 0, indent + 1);
+				zend_ast_export_indent(str, indent);
+				smart_str_appendc(str, '}');
+			}
 			break;
 		case ZEND_AST_MATCH_ARM:
 			zend_ast_export_indent(str, indent);

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1981,8 +1981,6 @@ simple_list:
 		case ZEND_AST_MATCH:
 			if (ast->attr & ZEND_MATCH_SHORT) {
 				smart_str_appends(str, "match {\n");
-//				zend_ast_export_ex(str, ast->child[0], 0, indent);
-//				smart_str_appends(str, ") {\n");
 				zend_ast_export_ex(str, ast->child[1], 0, indent + 1);
 				zend_ast_export_indent(str, indent);
 				smart_str_appendc(str, '}');

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1981,18 +1981,15 @@ simple_list:
 		case ZEND_AST_MATCH:
 			if (ast->attr & ZEND_MATCH_SHORT) {
 				smart_str_appends(str, "match {\n");
-				zend_ast_export_ex(str, ast->child[1], 0, indent + 1);
-				zend_ast_export_indent(str, indent);
-				smart_str_appendc(str, '}');
 			}
 			else {
 				smart_str_appends(str, "match (");
 				zend_ast_export_ex(str, ast->child[0], 0, indent);
 				smart_str_appends(str, ") {\n");
-				zend_ast_export_ex(str, ast->child[1], 0, indent + 1);
-				zend_ast_export_indent(str, indent);
-				smart_str_appendc(str, '}');
 			}
+			zend_ast_export_ex(str, ast->child[1], 0, indent + 1);
+			zend_ast_export_indent(str, indent);
+			smart_str_appendc(str, '}');
 			break;
 		case ZEND_AST_MATCH_ARM:
 			zend_ast_export_indent(str, indent);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -896,6 +896,8 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 #define ZEND_PARAM_REF      (1<<3)
 #define ZEND_PARAM_VARIADIC (1<<4)
 
+#define ZEND_MATCH_SHORT (1<<5)
+
 #define ZEND_NAME_FQ       0
 #define ZEND_NAME_NOT_FQ   1
 #define ZEND_NAME_RELATIVE 2

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -654,7 +654,10 @@ match:
 		T_MATCH '(' expr ')' '{' match_arm_list '}'
 			{ $$ = zend_ast_create(ZEND_AST_MATCH, $3, $6); }
 		| T_MATCH '{' match_arm_list '}'
-			{ $$ = zend_ast_create(ZEND_AST_MATCH, 'true', $3); }
+			{
+			zval zv;
+			ZVAL_BOOL(&zv, 1);
+			$$ = zend_ast_create(ZEND_AST_MATCH, zend_ast_create_zval(&zv), $3); }
 ;
 
 match_arm_list:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -655,9 +655,11 @@ match:
 			{ $$ = zend_ast_create(ZEND_AST_MATCH, $3, $6); }
 		| T_MATCH '{' match_arm_list '}'
 			{
-			zval zv;
-			ZVAL_BOOL(&zv, 1);
-			$$ = zend_ast_create(ZEND_AST_MATCH, zend_ast_create_zval(&zv), $3); }
+				zval zv;
+				ZVAL_BOOL(&zv, 1);
+				$$ = zend_ast_create(ZEND_AST_MATCH, zend_ast_create_zval(&zv), $3);
+				$$->attr = ZEND_MATCH_SHORT;
+			}
 ;
 
 match_arm_list:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -652,7 +652,9 @@ case_separator:
 
 match:
 		T_MATCH '(' expr ')' '{' match_arm_list '}'
-			{ $$ = zend_ast_create(ZEND_AST_MATCH, $3, $6); };
+			{ $$ = zend_ast_create(ZEND_AST_MATCH, $3, $6); }
+		| T_MATCH '{' match_arm_list '}'
+			{ $$ = zend_ast_create(ZEND_AST_MATCH, 'true', $3); }
 ;
 
 match_arm_list:


### PR DESCRIPTION
Adds support for short-circuiting a match() expression to match against boolean true.  This is a convenience feature left out of the original match() RFC for simplicity but widely supported, so let's bring it back.

https://wiki.php.net/rfc/short-match