### PR TITLE
Drop support for max_length in mysqli_fetch_fields()

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -19,6 +19,12 @@ PHP 8.1 UPGRADE NOTES
 1. Backward Incompatible Changes
 ========================================
 
+- MySQLi:
+  . mysqli_fetch_fields() and mysqli_fetch_field_direct() will now always return
+    zero for max_length. You can compute this information by iterating over the
+    result set and taking the maximum length. This is what PHP was doing
+    internally previously.
+
 - Standard:
   . version_compare() no longer accepts undocumented operator abbreviations.
 

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1116,7 +1116,7 @@ static void php_add_field_properties(zval *value, const MYSQL_FIELD *field)
 	 */
 	add_property_string(value, "catalog", "def");
 
-	add_property_long(value, "max_length", field->max_length);
+	add_property_long(value, "max_length", 0);
 	add_property_long(value, "length", field->length);
 	add_property_long(value, "charsetnr", field->charsetnr);
 	add_property_long(value, "flags", field->flags);

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1459,7 +1459,7 @@ void php_mysqli_init(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_method)
 	  We create always persistent, as if the user want to connect
 	  to p:somehost, we can't convert the handle then
 	*/
-	if (!(mysql->mysql = mysqlnd_init(MYSQLND_CLIENT_KNOWS_RSET_COPY_DATA, TRUE)))
+	if (!(mysql->mysql = mysqlnd_init(MYSQLND_CLIENT_NO_FLAG, TRUE)))
 #endif
 	{
 		efree(mysql);
@@ -2527,11 +2527,7 @@ PHP_FUNCTION(mysqli_store_result)
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
-#ifdef MYSQLI_USE_MYSQLND
-	result = flags & MYSQLI_STORE_RESULT_COPY_DATA? mysqlnd_store_result_ofs(mysql->mysql) : mysqlnd_store_result(mysql->mysql);
-#else
 	result = mysql_store_result(mysql->mysql);
-#endif
 	if (!result) {
 		MYSQLI_REPORT_MYSQL_ERROR(mysql->mysql);
 		RETURN_FALSE;

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -245,7 +245,7 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_real_conne
 #ifndef MYSQLI_USE_MYSQLND
 		if (!(mysql->mysql = mysql_init(NULL))) {
 #else
-		if (!(mysql->mysql = mysqlnd_init(MYSQLND_CLIENT_KNOWS_RSET_COPY_DATA, persistent))) {
+		if (!(mysql->mysql = mysqlnd_init(MYSQLND_CLIENT_NO_FLAG, persistent))) {
 #endif
 			goto err;
 		}
@@ -307,7 +307,7 @@ void mysqli_common_connect(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_real_conne
 		}
 	}
 	if (mysqlnd_connect(mysql->mysql, hostname, username, passwd, passwd_len, dbname, dbname_len,
-						port, socket, flags, MYSQLND_CLIENT_KNOWS_RSET_COPY_DATA) == NULL)
+						port, socket, flags, MYSQLND_CLIENT_NO_FLAG) == NULL)
 #endif
 	{
 		/* Save error messages - for mysqli_connect_error() & mysqli_connect_errno() */
@@ -689,12 +689,7 @@ PHP_FUNCTION(mysqli_query)
 	switch (resultmode & ~MYSQLI_ASYNC) {
 #endif
 		case MYSQLI_STORE_RESULT:
-#ifdef MYSQLI_USE_MYSQLND
-			if (resultmode & MYSQLI_STORE_RESULT_COPY_DATA) {
-				result = mysqlnd_store_result_ofs(mysql->mysql);
-			} else
-#endif
-				result = mysql_store_result(mysql->mysql);
+			result = mysql_store_result(mysql->mysql);
 			break;
 		case MYSQLI_USE_RESULT:
 			result = mysql_use_result(mysql->mysql);

--- a/ext/mysqli/mysqli_warning.c
+++ b/ext/mysqli/mysqli_warning.c
@@ -125,7 +125,7 @@ MYSQLI_WARNING * php_get_warnings(MYSQLND_CONN_DATA * mysql)
 		return NULL;
 	}
 
-	result = mysql->m->use_result(mysql, 0);
+	result = mysql->m->use_result(mysql);
 
 	for (;;) {
 		zval *entry;

--- a/ext/mysqli/tests/mysqli_fetch_field.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field.phpt
@@ -35,10 +35,6 @@ require_once('skipifconnectfailure.inc');
         printf("[004] Expecting charset %s/%d got %d\n",
             $charsetInfo->charset, $charsetInfo->number, $tmp->charsetnr);
     }
-    if ($tmp->length != $charsetInfo->max_length) {
-        printf("[005] Expecting length %d got %d\n",
-            $charsetInfo->max_length, $tmp->max_length);
-    }
     if ($tmp->db != $db) {
         printf("011] Expecting database '%s' got '%s'\n",
             $db, $tmp->db);
@@ -97,7 +93,7 @@ object(stdClass)#%d (13) {
   ["catalog"]=>
   string(%d) "%s"
   ["max_length"]=>
-  int(1)
+  int(0)
   ["length"]=>
   int(11)
   ["charsetnr"]=>
@@ -159,7 +155,7 @@ object(stdClass)#%d (13) {
   ["catalog"]=>
   string(%d) "%s"
   ["max_length"]=>
-  int(1)
+  int(0)
   ["length"]=>
   int(11)
   ["charsetnr"]=>

--- a/ext/mysqli/tests/mysqli_fetch_field_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field_oo.phpt
@@ -42,10 +42,6 @@ require_once('skipifconnectfailure.inc');
         printf("[005] Expecting charset %s/%d got %d\n",
             $charsetInfo->charset, $charsetInfo->number, $tmp->charsetnr);
     }
-    if ($tmp->length != $charsetInfo->max_length) {
-        printf("[006] Expecting length %d got %d\n",
-            $charsetInfo->max_length, $tmp->max_length);
-    }
     if ($tmp->db != $db) {
         printf("[007] Expecting database '%s' got '%s'\n",
           $db, $tmp->db);
@@ -86,7 +82,7 @@ object(stdClass)#%d (13) {
   ["catalog"]=>
   string(%d) "%s"
   ["max_length"]=>
-  int(1)
+  int(0)
   ["length"]=>
   int(11)
   ["charsetnr"]=>

--- a/ext/mysqli/tests/mysqli_fetch_fields.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_fields.phpt
@@ -35,11 +35,6 @@ require_once('skipifconnectfailure.inc');
                         $charsetInfo->charset,
                         $charsetInfo->number, $field->charsetnr);
                 }
-                if ($field->length != $charsetInfo->max_length) {
-                    printf("[005] Expecting length %d got %d\n",
-                        $charsetInfo->max_length,
-                        $field->max_length);
-                }
                 break;
         }
     }
@@ -76,7 +71,7 @@ object(stdClass)#%d (13) {
   ["catalog"]=>
   string(%d) "%s"
   ["max_length"]=>
-  int(1)
+  int(0)
   ["length"]=>
   int(11)
   ["charsetnr"]=>
@@ -104,7 +99,7 @@ object(stdClass)#%d (13) {
   ["catalog"]=>
   string(%d) "%s"
   ["max_length"]=>
-  int(1)
+  int(0)
   ["length"]=>
   int(%d)
   ["charsetnr"]=>

--- a/ext/mysqli/tests/mysqli_stmt_attr_set.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_attr_set.phpt
@@ -61,7 +61,7 @@ require_once("connect.inc");
     $res->close();
     $stmt->close();
 
-    // expecting max_length to _be_ set
+    // MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH is no longer supported, expect no change in behavior.
     $stmt = mysqli_stmt_init($link);
     $stmt->prepare("SELECT label FROM test");
     var_dump($stmt->attr_set(MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH, 1));
@@ -75,8 +75,8 @@ require_once("connect.inc");
     $max_lengths = array();
     foreach ($fields as $k => $meta) {
         $max_lengths[$meta->name] = $meta->max_length;
-        if ($meta->max_length === 0)
-            printf("[008] max_length should be set (!= 0), got %s for field %s\n", $meta->max_length, $meta->name);
+        if ($meta->max_length !== 0)
+            printf("[008] max_length should be not set (= 0), got %s for field %s\n", $meta->max_length, $meta->name);
     }
     $res->close();
     $stmt->close();

--- a/ext/mysqli/tests/mysqli_stmt_get_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result.phpt
@@ -109,7 +109,7 @@ if (!function_exists('mysqli_stmt_get_result'))
 
     mysqli_stmt_close($stmt);
 
-    // get_result cannot be used in PS cursor mode
+    // get_result can be used in PS cursor mode
     if (!$stmt = mysqli_stmt_init($link))
         printf("[030] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
@@ -122,23 +122,10 @@ if (!function_exists('mysqli_stmt_get_result'))
     if (!mysqli_stmt_execute($stmt))
         printf("[033] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
-    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
-    try {
-        $res = mysqli_stmt_get_result($stmt);
-        // we expect no segfault if we try to fetch a row because get_result should throw an error or return false
-        mysqli_fetch_assoc($res);
-    } catch (\mysqli_sql_exception $e) {
-        echo $e->getMessage() . "\n";
+    $result = mysqli_stmt_get_result($stmt);
+    while ($row = mysqli_fetch_assoc($result)) {
+        var_dump($row);
     }
-
-    try {
-        $res = $stmt->get_result();
-        // we expect no segfault if we try to fetch a row because get_result should throw an error or return false
-        $res->fetch_assoc();
-    } catch (\mysqli_sql_exception $e) {
-        echo $e->getMessage() . "\n";
-    }
-    mysqli_report(MYSQLI_REPORT_OFF);
 
     if (!$stmt = mysqli_stmt_init($link))
         printf("[034] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -196,8 +183,18 @@ if (!function_exists('mysqli_stmt_get_result'))
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is not fully initialized
 mysqli_stmt object is not fully initialized
-mysqli_stmt_get_result() cannot be used with cursors
-get_result() cannot be used with cursors
+array(2) {
+  ["id"]=>
+  int(1)
+  ["label"]=>
+  string(1) "a"
+}
+array(2) {
+  ["id"]=>
+  int(2)
+  ["label"]=>
+  string(1) "b"
+}
 [040] [2014] [Commands out of sync; you can't run this command now]
 [041] [0] []
 array(2) {

--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -112,9 +112,8 @@ PHPAPI void mysqlnd_debug(const char *mode);
 
 PHPAPI enum_func_status mysqlnd_poll(MYSQLND **r_array, MYSQLND **e_array, MYSQLND ***dont_poll, long sec, long usec, int * desc_num);
 
-#define mysqlnd_use_result(conn)		((conn)->data)->m->use_result((conn)->data, 0)
-#define mysqlnd_store_result(conn)		((conn)->data)->m->store_result((conn)->data, MYSQLND_STORE_NO_COPY)
-#define mysqlnd_store_result_ofs(conn)	((conn)->data)->m->store_result((conn)->data, MYSQLND_STORE_COPY)
+#define mysqlnd_use_result(conn)		((conn)->data)->m->use_result((conn)->data)
+#define mysqlnd_store_result(conn)		((conn)->data)->m->store_result((conn)->data)
 #define mysqlnd_next_result(conn)		((conn)->data)->m->next_result((conn)->data)
 #define mysqlnd_more_results(conn)		((conn)->data)->m->more_results((conn)->data)
 #define mysqlnd_free_result(r,e_or_i)	((MYSQLND_RES*)r)->m.free_result(((MYSQLND_RES*)(r)), (e_or_i))
@@ -311,7 +310,6 @@ ZEND_BEGIN_MODULE_GLOBALS(mysqlnd)
 	zend_long		debug_calloc_fail_threshold;
 	zend_long		debug_realloc_fail_threshold;
 	char *			sha256_server_public_key;
-	zend_bool		fetch_data_copy;
 	zend_bool		collect_statistics;
 	zend_bool		collect_memory_statistics;
 ZEND_END_MODULE_GLOBALS(mysqlnd)

--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -100,6 +100,8 @@ PHPAPI void mysqlnd_debug(const char *mode);
 /* Query */
 #define mysqlnd_fetch_into(result, flags, ret_val)	(result)->m.fetch_into((result), (flags), (ret_val) ZEND_FILE_LINE_CC)
 #define mysqlnd_fetch_row_c(result)						(result)->m.fetch_row_c((result))
+#define mysqlnd_fetch_row_zval(result, row_ptr, fetched) \
+	(result)->m.fetch_row((result), (row_ptr), 0, (fetched))
 #define mysqlnd_fetch_all(result, flags, return_value)	(result)->m.fetch_all((result), (flags), (return_value) ZEND_FILE_LINE_CC)
 #define mysqlnd_get_connection_stats(conn, values)		((conn)->data)->m->get_statistics((conn)->data,  (values) ZEND_FILE_LINE_CC)
 #define mysqlnd_get_client_stats(values)				_mysqlnd_get_client_stats(mysqlnd_global_stats, (values) ZEND_FILE_LINE_CC)

--- a/ext/mysqlnd/mysqlnd_enum_n_def.h
+++ b/ext/mysqlnd/mysqlnd_enum_n_def.h
@@ -686,18 +686,6 @@ enum php_mysqlnd_server_command
 #define MYSQLND_REFRESH_BACKUP_LOG	0x200000L
 
 
-#define MYSQLND_STORE_PS		1
-#define MYSQLND_STORE_NO_COPY	2
-#define MYSQLND_STORE_COPY		4
-
-enum mysqlnd_buffered_type
-{
-	MYSQLND_BUFFERED_TYPE_ZVAL = 1,
-	MYSQLND_BUFFERED_TYPE_C
-};
-
-
 #define MYSQLND_CLIENT_NO_FLAG				0
-#define MYSQLND_CLIENT_KNOWS_RSET_COPY_DATA	1
 
 #endif	/* MYSQLND_ENUM_N_DEF_H */

--- a/ext/mysqlnd/mysqlnd_ext_plugin.c
+++ b/ext/mysqlnd/mysqlnd_ext_plugin.c
@@ -83,30 +83,16 @@ mysqlnd_plugin__get_plugin_result_unbuffered_data(const MYSQLND_RES_UNBUFFERED *
 }
 /* }}} */
 
-
-/* {{{ _mysqlnd_plugin__get_plugin_result_buffered_data */
-static void **
-mysqlnd_plugin__get_plugin_result_buffered_data_zval(const MYSQLND_RES_BUFFERED_ZVAL * result, const unsigned int plugin_id)
-{
-	DBG_ENTER("_mysqlnd_plugin__get_plugin_result_data");
-	DBG_INF_FMT("plugin_id=%u", plugin_id);
-	if (!result || plugin_id >= mysqlnd_plugin_count()) {
-		return NULL;
-	}
-	DBG_RETURN((void *)((char *)result + sizeof(MYSQLND_RES_BUFFERED_ZVAL) + plugin_id * sizeof(void *)));
-}
-/* }}} */
-
 /* {{{ mysqlnd_plugin__get_plugin_result_buffered_data */
 static void **
-mysqlnd_plugin__get_plugin_result_buffered_data_c(const MYSQLND_RES_BUFFERED_C * result, const unsigned int plugin_id)
+mysqlnd_plugin__get_plugin_result_buffered_data(const MYSQLND_RES_BUFFERED * result, const unsigned int plugin_id)
 {
 	DBG_ENTER("mysqlnd_plugin__get_plugin_result_data");
 	DBG_INF_FMT("plugin_id=%u", plugin_id);
 	if (!result || plugin_id >= mysqlnd_plugin_count()) {
 		return NULL;
 	}
-	DBG_RETURN((void *)((char *)result + sizeof(MYSQLND_RES_BUFFERED_C) + plugin_id * sizeof(void *)));
+	DBG_RETURN((void *)((char *)result + sizeof(MYSQLND_RES_BUFFERED) + plugin_id * sizeof(void *)));
 }
 /* }}} */
 
@@ -172,8 +158,7 @@ struct st_mysqlnd_plugin__plugin_area_getters mysqlnd_plugin_area_getters =
 	mysqlnd_plugin__get_plugin_connection_data_data,
 	mysqlnd_plugin__get_plugin_result_data,
 	mysqlnd_plugin__get_plugin_result_unbuffered_data,
-	mysqlnd_plugin__get_plugin_result_buffered_data_zval,
-	mysqlnd_plugin__get_plugin_result_buffered_data_c,
+	mysqlnd_plugin__get_plugin_result_buffered_data,
 	mysqlnd_plugin__get_plugin_stmt_data,
 	mysqlnd_plugin__get_plugin_protocol_data,
 	mysqlnd_plugin__get_plugin_pfc_data,

--- a/ext/mysqlnd/mysqlnd_ext_plugin.h
+++ b/ext/mysqlnd/mysqlnd_ext_plugin.h
@@ -25,8 +25,7 @@ struct st_mysqlnd_plugin__plugin_area_getters
 	void ** (*get_connection_data_area)(const MYSQLND_CONN_DATA * conn, const unsigned int plugin_id);
 	void ** (*get_result_area)(const MYSQLND_RES * result, const unsigned int plugin_id);
 	void ** (*get_unbuffered_area)(const MYSQLND_RES_UNBUFFERED * result, const unsigned int plugin_id);
-	void ** (*get_result_buffered_area)(const MYSQLND_RES_BUFFERED_ZVAL * result, const unsigned int plugin_id);
-	void ** (*get_result_buffered_aread_c)(const MYSQLND_RES_BUFFERED_C * result, const unsigned int plugin_id);
+	void ** (*get_result_buffered_aread)(const MYSQLND_RES_BUFFERED * result, const unsigned int plugin_id);
 	void ** (*get_stmt_area)(const MYSQLND_STMT * stmt, const unsigned int plugin_id);
 	void ** (*get_protocol_decoder_area)(const MYSQLND_PROTOCOL_PAYLOAD_DECODER_FACTORY * factory, const unsigned int plugin_id);
 	void ** (*get_pfc_area)(const MYSQLND_PFC * pfc, const unsigned int plugin_id);
@@ -39,8 +38,7 @@ PHPAPI extern struct st_mysqlnd_plugin__plugin_area_getters mysqlnd_plugin_area_
 #define mysqlnd_plugin_get_plugin_connection_data_data(c, p_id)			mysqlnd_plugin_area_getters.get_connection_data_area((c), (p_id))
 #define mysqlnd_plugin_get_plugin_result_data(res, p_id)				mysqlnd_plugin_area_getters.get_result_area((res), (p_id))
 #define mysqlnd_plugin_get_plugin_result_unbuffered_data(res, p_id)		mysqlnd_plugin_area_getters.get_unbuffered_area((res), (p_id))
-#define mysqlnd_plugin_get_plugin_result_buffered_data_zval(res, p_id)	mysqlnd_plugin_area_getters.get_result_buffered_area((res), (p_id))
-#define mysqlnd_plugin_get_plugin_result_buffered_data_c(res, p_id)		mysqlnd_plugin_area_getters.get_result_buffered_aread_c((res), (p_id))
+#define mysqlnd_plugin_get_plugin_result_buffered_data_c(res, p_id)		mysqlnd_plugin_area_getters.get_result_buffered_aread((res), (p_id))
 #define mysqlnd_plugin_get_plugin_stmt_data(stmt, p_id)					mysqlnd_plugin_area_getters.get_stmt_area((stmt), (p_id))
 #define mysqlnd_plugin_get_plugin_protocol_data(proto, p_id)			mysqlnd_plugin_area_getters.get_protocol_decoder_area((proto), (p_id))
 #define mysqlnd_plugin_get_plugin_pfc_data(pfc, p_id)					mysqlnd_plugin_area_getters.get_pfc_area((pfc), (p_id))

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -37,6 +37,36 @@ enum_func_status mysqlnd_stmt_execute_batch_generate_request(MYSQLND_STMT * cons
 
 static void mysqlnd_stmt_separate_result_bind(MYSQLND_STMT * const stmt);
 
+static enum_func_status mysqlnd_stmt_send_cursor_fetch_command(
+		const MYSQLND_STMT_DATA *stmt, unsigned max_rows)
+{
+	MYSQLND_CONN_DATA *conn = stmt->conn;
+	zend_uchar buf[MYSQLND_STMT_ID_LENGTH /* statement id */ + 4 /* number of rows to fetch */];
+	const MYSQLND_CSTRING payload = {(const char*) buf, sizeof(buf)};
+
+	int4store(buf, stmt->stmt_id);
+	int4store(buf + MYSQLND_STMT_ID_LENGTH, max_rows);
+
+	if (conn->command->stmt_fetch(conn, payload) == FAIL) {
+		COPY_CLIENT_ERROR(stmt->error_info, *conn->error_info);
+		return FAIL;
+	}
+	return PASS;
+}
+
+static zend_bool mysqlnd_stmt_check_state(const MYSQLND_STMT_DATA *stmt)
+{
+	const MYSQLND_CONN_DATA *conn = stmt->conn;
+	if (stmt->state != MYSQLND_STMT_WAITING_USE_OR_STORE) {
+		return 0;
+	}
+	if (stmt->cursor_exists) {
+		return GET_CONNECTION_STATE(&conn->state) == CONN_READY;
+	} else {
+		return GET_CONNECTION_STATE(&conn->state) == CONN_FETCHING_DATA;
+	}
+}
+
 /* {{{ mysqlnd_stmt::store_result */
 static MYSQLND_RES *
 MYSQLND_METHOD(mysqlnd_stmt, store_result)(MYSQLND_STMT * const s)
@@ -57,14 +87,8 @@ MYSQLND_METHOD(mysqlnd_stmt, store_result)(MYSQLND_STMT * const s)
 		DBG_RETURN(NULL);
 	}
 
-	if (stmt->cursor_exists) {
-		/* Silently convert buffered to unbuffered, for now */
-		DBG_RETURN(s->m->use_result(s));
-	}
-
 	/* Nothing to store for UPSERT/LOAD DATA*/
-	if (GET_CONNECTION_STATE(&conn->state) != CONN_FETCHING_DATA || stmt->state != MYSQLND_STMT_WAITING_USE_OR_STORE)
-	{
+	if (!mysqlnd_stmt_check_state(stmt)) {
 		SET_CLIENT_ERROR(conn->error_info, CR_COMMANDS_OUT_OF_SYNC, UNKNOWN_SQLSTATE, mysqlnd_out_of_sync);
 		DBG_RETURN(NULL);
 	}
@@ -74,6 +98,12 @@ MYSQLND_METHOD(mysqlnd_stmt, store_result)(MYSQLND_STMT * const s)
 	SET_EMPTY_ERROR(stmt->error_info);
 	SET_EMPTY_ERROR(conn->error_info);
 	MYSQLND_INC_CONN_STATISTIC(conn->stats, STAT_PS_BUFFERED_SETS);
+
+	if (stmt->cursor_exists) {
+		if (mysqlnd_stmt_send_cursor_fetch_command(stmt, -1) == FAIL) {
+			DBG_RETURN(NULL);
+		}
+	}
 
 	result = stmt->result;
 	result->type			= MYSQLND_RES_PS_BUF;
@@ -127,19 +157,8 @@ MYSQLND_METHOD(mysqlnd_stmt, get_result)(MYSQLND_STMT * const s)
 		DBG_RETURN(NULL);
 	}
 
-	if (stmt->cursor_exists) {
-		/* Prepared statement cursors are not supported as of yet */
-		char * msg;
-		mnd_sprintf(&msg, 0, "%s() cannot be used with cursors", get_active_function_name());
-		SET_CLIENT_ERROR(stmt->error_info, CR_NOT_IMPLEMENTED, UNKNOWN_SQLSTATE, msg);
-		if (msg) {
-			mnd_sprintf_free(msg);
-		}
-		DBG_RETURN(NULL);
-	}
-
 	/* Nothing to store for UPSERT/LOAD DATA*/
-	if (GET_CONNECTION_STATE(&conn->state) != CONN_FETCHING_DATA || stmt->state != MYSQLND_STMT_WAITING_USE_OR_STORE) {
+	if (!mysqlnd_stmt_check_state(stmt)) {
 		SET_CLIENT_ERROR(stmt->error_info, CR_COMMANDS_OUT_OF_SYNC, UNKNOWN_SQLSTATE, mysqlnd_out_of_sync);
 		DBG_RETURN(NULL);
 	}
@@ -147,6 +166,12 @@ MYSQLND_METHOD(mysqlnd_stmt, get_result)(MYSQLND_STMT * const s)
 	SET_EMPTY_ERROR(stmt->error_info);
 	SET_EMPTY_ERROR(conn->error_info);
 	MYSQLND_INC_CONN_STATISTIC(conn->stats, STAT_BUFFERED_SETS);
+
+	if (stmt->cursor_exists) {
+		if (mysqlnd_stmt_send_cursor_fetch_command(stmt, -1) == FAIL) {
+			DBG_RETURN(NULL);
+		}
+	}
 
 	do {
 		result = conn->m->result_init(stmt->result->field_count);
@@ -718,11 +743,7 @@ MYSQLND_METHOD(mysqlnd_stmt, use_result)(MYSQLND_STMT * s)
 	}
 	DBG_INF_FMT("stmt=%lu", stmt->stmt_id);
 
-	if (!stmt->field_count ||
-		(!stmt->cursor_exists && GET_CONNECTION_STATE(&conn->state) != CONN_FETCHING_DATA) ||
-		(stmt->cursor_exists && GET_CONNECTION_STATE(&conn->state) != CONN_READY) ||
-		(stmt->state != MYSQLND_STMT_WAITING_USE_OR_STORE))
-	{
+	if (!stmt->field_count || !mysqlnd_stmt_check_state(stmt)) {
 		SET_CLIENT_ERROR(conn->error_info, CR_COMMANDS_OUT_OF_SYNC, UNKNOWN_SQLSTATE, mysqlnd_out_of_sync);
 		DBG_ERR("command out of sync");
 		DBG_RETURN(NULL);
@@ -752,7 +773,6 @@ mysqlnd_fetch_stmt_row_cursor(MYSQLND_RES * result, zval **row_ptr, const unsign
 	enum_func_status ret;
 	MYSQLND_STMT_DATA * stmt = result->unbuf->stmt;
 	MYSQLND_CONN_DATA * conn = stmt->conn;
-	zend_uchar buf[MYSQLND_STMT_ID_LENGTH /* statement id */ + 4 /* number of rows to fetch */];
 	MYSQLND_PACKET_ROW * row_packet;
 
 	DBG_ENTER("mysqlnd_fetch_stmt_row_cursor");
@@ -776,18 +796,9 @@ mysqlnd_fetch_stmt_row_cursor(MYSQLND_RES * result, zval **row_ptr, const unsign
 	SET_EMPTY_ERROR(stmt->error_info);
 	SET_EMPTY_ERROR(conn->error_info);
 
-	int4store(buf, stmt->stmt_id);
-	int4store(buf + MYSQLND_STMT_ID_LENGTH, 1); /* for now fetch only one row */
-
-	{
-		const MYSQLND_CSTRING payload = {(const char*) buf, sizeof(buf)};
-
-		ret = conn->command->stmt_fetch(conn, payload);
-		if (ret == FAIL) {
-			COPY_CLIENT_ERROR(stmt->error_info, *conn->error_info);
-			DBG_RETURN(FAIL);
-		}
-
+	/* for now fetch only one row */
+	if (mysqlnd_stmt_send_cursor_fetch_command(stmt, 1) == FAIL) {
+		DBG_RETURN(FAIL);
 	}
 
 	UPSERT_STATUS_RESET(stmt->upsert_status);

--- a/ext/mysqlnd/mysqlnd_ps.h
+++ b/ext/mysqlnd/mysqlnd_ps.h
@@ -32,8 +32,8 @@ struct st_mysqlnd_perm_bind {
 
 extern struct st_mysqlnd_perm_bind mysqlnd_ps_fetch_functions[MYSQL_TYPE_LAST + 1];
 
-enum_func_status mysqlnd_stmt_fetch_row_buffered(MYSQLND_RES * result, void * param, const unsigned int flags, zend_bool * fetched_anything);
-enum_func_status mysqlnd_fetch_stmt_row_cursor(MYSQLND_RES * result, void * param, const unsigned int flags, zend_bool * fetched_anything);
+enum_func_status mysqlnd_stmt_fetch_row_buffered(MYSQLND_RES * result, zval **row_data, const unsigned int flags, zend_bool * fetched_anything);
+enum_func_status mysqlnd_fetch_stmt_row_cursor(MYSQLND_RES * result, zval **row_data, const unsigned int flags, zend_bool * fetched_anything);
 
 void _mysqlnd_init_ps_subsystem();/* This one is private, mysqlnd_library_init() will call it */
 void _mysqlnd_init_ps_fetch_subsystem();

--- a/ext/mysqlnd/mysqlnd_result.h
+++ b/ext/mysqlnd/mysqlnd_result.h
@@ -19,9 +19,8 @@
 #define MYSQLND_RESULT_H
 
 PHPAPI MYSQLND_RES * mysqlnd_result_init(const unsigned int field_count);
-PHPAPI MYSQLND_RES_UNBUFFERED * mysqlnd_result_unbuffered_init(MYSQLND_RES * result, const unsigned int field_count, const zend_bool ps);
-PHPAPI MYSQLND_RES_BUFFERED_ZVAL * mysqlnd_result_buffered_zval_init(MYSQLND_RES * result, const unsigned int field_count, const zend_bool ps);
-PHPAPI MYSQLND_RES_BUFFERED_C * mysqlnd_result_buffered_c_init(MYSQLND_RES * result, const unsigned int field_count, const zend_bool ps);
+PHPAPI MYSQLND_RES_UNBUFFERED * mysqlnd_result_unbuffered_init(MYSQLND_RES * result, const unsigned int field_count, MYSQLND_STMT_DATA *stmt);
+PHPAPI MYSQLND_RES_BUFFERED * mysqlnd_result_buffered_init(MYSQLND_RES * result, const unsigned int field_count, MYSQLND_STMT_DATA *stmt);
 
 enum_func_status mysqlnd_query_read_result_set_header(MYSQLND_CONN_DATA * conn, MYSQLND_STMT * stmt);
 

--- a/ext/mysqlnd/mysqlnd_result_meta.c
+++ b/ext/mysqlnd/mysqlnd_result_meta.c
@@ -215,9 +215,8 @@ MYSQLND_METHOD(mysqlnd_res_meta, fetch_field)(MYSQLND_RES_METADATA * const meta)
 		DBG_INF("no more fields");
 		DBG_RETURN(NULL);
 	}
-	DBG_INF_FMT("name=%s max_length=%u",
-		meta->fields[meta->current_field].name? meta->fields[meta->current_field].name:"",
-		meta->fields[meta->current_field].max_length);
+	DBG_INF_FMT("name=%s",
+		meta->fields[meta->current_field].name? meta->fields[meta->current_field].name:"");
 	DBG_RETURN(&meta->fields[meta->current_field++]);
 }
 /* }}} */
@@ -229,9 +228,8 @@ MYSQLND_METHOD(mysqlnd_res_meta, fetch_field_direct)(const MYSQLND_RES_METADATA 
 {
 	DBG_ENTER("mysqlnd_res_meta::fetch_field_direct");
 	DBG_INF_FMT("fieldnr=%u", fieldnr);
-	DBG_INF_FMT("name=%s max_length=%u",
-		meta->fields[meta->current_field].name? meta->fields[meta->current_field].name:"",
-		meta->fields[meta->current_field].max_length);
+	DBG_INF_FMT("name=%s",
+		meta->fields[meta->current_field].name? meta->fields[meta->current_field].name:"");
 	DBG_RETURN(&meta->fields[fieldnr]);
 }
 /* }}} */

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -89,7 +89,6 @@ typedef struct st_mysqlnd_field
 	const char  *catalog;		/* Catalog for table */
 	char  *def;                 /* Default value */
 	zend_ulong length;		/* Width of column (create length) */
-	zend_ulong max_length;	/* Max width for selected set */
 	unsigned int name_length;
 	unsigned int org_name_length;
 	unsigned int table_length;
@@ -718,8 +717,6 @@ MYSQLND_CLASS_METHODS_TYPE(mysqlnd_result_unbuffered)
 };
 
 typedef uint64_t			(*func_mysqlnd_result_buffered__num_rows)(const MYSQLND_RES_BUFFERED * const result);
-typedef enum_func_status	(*func_mysqlnd_result_buffered__initialize_result_set_rest)(MYSQLND_RES_BUFFERED * const result, MYSQLND_RES_METADATA * const meta,
-																						MYSQLND_STATS * stats, const zend_bool int_and_float_native);
 typedef const size_t *		(*func_mysqlnd_result_buffered__fetch_lengths)(const MYSQLND_RES_BUFFERED * const result);
 typedef enum_func_status	(*func_mysqlnd_result_buffered__data_seek)(MYSQLND_RES_BUFFERED * const result, const uint64_t row);
 typedef void				(*func_mysqlnd_result_buffered__free_result)(MYSQLND_RES_BUFFERED * const result);
@@ -731,7 +728,6 @@ MYSQLND_CLASS_METHODS_TYPE(mysqlnd_result_buffered)
 	func_mysqlnd_result_buffered__num_rows		num_rows;
 	func_mysqlnd_result_buffered__fetch_lengths	fetch_lengths;
 	func_mysqlnd_result_buffered__data_seek		data_seek;
-	func_mysqlnd_result_buffered__initialize_result_set_rest initialize_result_set_rest;
 	func_mysqlnd_result_buffered__free_result	free_result;
 };
 
@@ -1185,7 +1181,6 @@ struct st_mysqlnd_result_metadata
 #define def_mysqlnd_buffered_result_parent 			\
 	MYSQLND_ROW_BUFFER	*row_buffers;				\
 	uint64_t			row_count;					\
-	uint64_t			initialized_rows;			\
 													\
 	/*  Column lengths of current row - both buffered and unbuffered. For buffered results it duplicates the data found in **data */ \
 	size_t				*lengths;					\
@@ -1224,7 +1219,6 @@ struct st_mysqlnd_buffered_result_c
 {
 	def_mysqlnd_buffered_result_parent;
 
-	zend_uchar	*initialized; /* every row is a single bit */
 	uint64_t	current_row;
 };
 

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -1369,7 +1369,7 @@ php_mysqlnd_read_row_ex(MYSQLND_PFC * pfc,
 	*/
 
 	/*
-	  We're allocating an extra byte, as php_mysqlnd_rowp_read_text_protocol_aux
+	  We're allocating an extra byte, as php_mysqlnd_rowp_read_text_protocol
 	  needs to be able to append a terminating \0 for atoi/atof.
 	*/
 	prealloc_more_bytes = 1;
@@ -1525,7 +1525,7 @@ php_mysqlnd_rowp_read_binary_protocol(MYSQLND_ROW_BUFFER * row_buffer, zval * fi
 
 /* {{{ php_mysqlnd_rowp_read_text_protocol */
 enum_func_status
-php_mysqlnd_rowp_read_text_protocol_aux(MYSQLND_ROW_BUFFER * row_buffer, zval * fields,
+php_mysqlnd_rowp_read_text_protocol(MYSQLND_ROW_BUFFER * row_buffer, zval * fields,
 									unsigned int field_count, const MYSQLND_FIELD * fields_metadata,
 									zend_bool as_int_or_float, MYSQLND_STATS * stats)
 {
@@ -1535,7 +1535,7 @@ php_mysqlnd_rowp_read_text_protocol_aux(MYSQLND_ROW_BUFFER * row_buffer, zval * 
 	const size_t data_size = row_buffer->size;
 	const zend_uchar * const packet_end = (zend_uchar*) p + data_size;
 
-	DBG_ENTER("php_mysqlnd_rowp_read_text_protocol_aux");
+	DBG_ENTER("php_mysqlnd_rowp_read_text_protocol");
 
 	if (!fields) {
 		DBG_RETURN(FAIL);
@@ -1663,34 +1663,6 @@ php_mysqlnd_rowp_read_text_protocol_aux(MYSQLND_ROW_BUFFER * row_buffer, zval * 
 	}
 
 	DBG_RETURN(PASS);
-}
-/* }}} */
-
-
-/* {{{ php_mysqlnd_rowp_read_text_protocol_zval */
-enum_func_status
-php_mysqlnd_rowp_read_text_protocol_zval(MYSQLND_ROW_BUFFER * row_buffer, zval * fields,
-										 const unsigned int field_count, const MYSQLND_FIELD * fields_metadata,
-										 const zend_bool as_int_or_float, MYSQLND_STATS * stats)
-{
-	enum_func_status ret;
-	DBG_ENTER("php_mysqlnd_rowp_read_text_protocol_zval");
-	ret = php_mysqlnd_rowp_read_text_protocol_aux(row_buffer, fields, field_count, fields_metadata, as_int_or_float, stats);
-	DBG_RETURN(ret);
-}
-/* }}} */
-
-
-/* {{{ php_mysqlnd_rowp_read_text_protocol_c */
-enum_func_status
-php_mysqlnd_rowp_read_text_protocol_c(MYSQLND_ROW_BUFFER * row_buffer, zval * fields,
-									  const unsigned int field_count, const MYSQLND_FIELD * const fields_metadata,
-									  const zend_bool as_int_or_float, MYSQLND_STATS * const stats)
-{
-	enum_func_status ret;
-	DBG_ENTER("php_mysqlnd_rowp_read_text_protocol_c");
-	ret = php_mysqlnd_rowp_read_text_protocol_aux(row_buffer, fields, field_count, fields_metadata, as_int_or_float, stats);
-	DBG_RETURN(ret);
 }
 /* }}} */
 

--- a/ext/mysqlnd/mysqlnd_wireprotocol.h
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.h
@@ -308,11 +308,7 @@ enum_func_status php_mysqlnd_rowp_read_binary_protocol(MYSQLND_ROW_BUFFER * row_
 										 zend_bool as_int_or_float, MYSQLND_STATS * stats);
 
 
-enum_func_status php_mysqlnd_rowp_read_text_protocol_zval(MYSQLND_ROW_BUFFER * row_buffer, zval * fields,
-										 unsigned int field_count, const MYSQLND_FIELD * fields_metadata,
-										 zend_bool as_int_or_float, MYSQLND_STATS * stats);
-
-enum_func_status php_mysqlnd_rowp_read_text_protocol_c(MYSQLND_ROW_BUFFER * row_buffer, zval * fields,
+enum_func_status php_mysqlnd_rowp_read_text_protocol(MYSQLND_ROW_BUFFER * row_buffer, zval * fields,
 										 unsigned int field_count, const MYSQLND_FIELD * fields_metadata,
 										 zend_bool as_int_or_float, MYSQLND_STATS * stats);
 

--- a/ext/mysqlnd/php_mysqlnd.c
+++ b/ext/mysqlnd/php_mysqlnd.c
@@ -153,7 +153,6 @@ static PHP_GINIT_FUNCTION(mysqlnd)
 	mysqlnd_globals->debug_calloc_fail_threshold = -1;
 	mysqlnd_globals->debug_realloc_fail_threshold = -1;
 	mysqlnd_globals->sha256_server_public_key = NULL;
-	mysqlnd_globals->fetch_data_copy = FALSE;
 }
 /* }}} */
 
@@ -186,7 +185,6 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("mysqlnd.log_mask",				"0", 	PHP_INI_ALL,	OnUpdateLong,	log_mask, zend_mysqlnd_globals, mysqlnd_globals)
 	STD_PHP_INI_ENTRY("mysqlnd.mempool_default_size","16000",   PHP_INI_ALL,	OnUpdateLong,	mempool_default_size,	zend_mysqlnd_globals,		mysqlnd_globals)
 	STD_PHP_INI_ENTRY("mysqlnd.sha256_server_public_key",NULL, 	PHP_INI_PERDIR, OnUpdateString,	sha256_server_public_key, zend_mysqlnd_globals, mysqlnd_globals)
-	STD_PHP_INI_BOOLEAN("mysqlnd.fetch_data_copy",	"0", 		PHP_INI_ALL,	OnUpdateBool,	fetch_data_copy, zend_mysqlnd_globals, mysqlnd_globals)
 #if PHP_DEBUG
 
 	STD_PHP_INI_ENTRY("mysqlnd.debug_malloc_fail_threshold","-1",   PHP_INI_SYSTEM,	OnUpdateLong,	debug_malloc_fail_threshold,	zend_mysqlnd_globals,		mysqlnd_globals)

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -826,6 +826,14 @@ static int pdo_mysql_handle_factory(pdo_dbh_t *dbh, zval *driver_options)
 		goto cleanup;
 	}
 
+#ifdef PDO_USE_MYSQLND
+	bool int_and_float_native = true;
+	if (mysql_options(H->server, MYSQLND_OPT_INT_AND_FLOAT_NATIVE, (const char *) &int_and_float_native)) {
+		pdo_mysql_error(dbh);
+		goto cleanup;
+	}
+#endif
+
 	if (vars[0].optval && mysql_options(H->server, MYSQL_SET_CHARSET_NAME, vars[0].optval)) {
 		pdo_mysql_error(dbh);
 		goto cleanup;

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -34,7 +34,6 @@
 #	define pdo_mysql_stmt_execute_prepared(stmt) pdo_mysql_stmt_execute_prepared_libmysql(stmt)
 #endif
 
-
 static void pdo_mysql_free_result(pdo_mysql_stmt *S)
 {
 	if (S->result) {
@@ -52,8 +51,16 @@ static void pdo_mysql_free_result(pdo_mysql_stmt *S)
 			efree(S->out_length);
 			S->bound_result = NULL;
 		}
+#else
+		if (S->current_row) {
+			unsigned column_count = mysql_num_fields(S->result);
+			for (unsigned i = 0; i < column_count; i++) {
+				zval_ptr_dtor_nogc(&S->current_row[i]);
+			}
+			efree(S->current_row);
+			S->current_row = NULL;
+		}
 #endif
-
 		mysql_free_result(S->result);
 		S->result = NULL;
 	}
@@ -103,12 +110,6 @@ static int pdo_mysql_stmt_dtor(pdo_stmt_t *stmt) /* {{{ */
 			}
 		}
 	}
-
-#ifdef PDO_USE_MYSQLND
-	if (!S->stmt && S->current_data) {
-		mnd_efree(S->current_data);
-	}
-#endif /* PDO_USE_MYSQLND */
 
 	efree(S);
 	PDO_DBG_RETURN(1);
@@ -553,9 +554,24 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 		PDO_DBG_RETURN(1);
 	}
 
-	if (!S->stmt && S->current_data) {
-		mnd_efree(S->current_data);
+	zval *row_data;
+	if (mysqlnd_fetch_row_zval(S->result, &row_data, &fetched_anything) == FAIL) {
+		pdo_mysql_error_stmt(stmt);
+		PDO_DBG_RETURN(0);
 	}
+
+	if (!fetched_anything) {
+		PDO_DBG_RETURN(0);
+	}
+
+	if (!S->current_row) {
+		S->current_row = ecalloc(sizeof(zval), stmt->column_count);
+	}
+	for (unsigned i = 0; i < stmt->column_count; i++) {
+		zval_ptr_dtor_nogc(&S->current_row[i]);
+		ZVAL_COPY_VALUE(&S->current_row[i], &row_data[i]);
+	}
+	PDO_DBG_RETURN(1);
 #else
 	int ret;
 
@@ -577,7 +593,6 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 
 		PDO_DBG_RETURN(1);
 	}
-#endif /* PDO_USE_MYSQLND */
 
 	if ((S->current_data = mysql_fetch_row(S->result)) == NULL) {
 		if (!S->H->buffered && mysql_errno(S->H->server)) {
@@ -588,6 +603,7 @@ static int pdo_mysql_stmt_fetch(pdo_stmt_t *stmt, enum pdo_fetch_orientation ori
 
 	S->current_lengths = mysql_fetch_lengths(S->result);
 	PDO_DBG_RETURN(1);
+#endif /* PDO_USE_MYSQLND */
 }
 /* }}} */
 
@@ -626,13 +642,10 @@ static int pdo_mysql_stmt_describe(pdo_stmt_t *stmt, int colno) /* {{{ */
 		cols[i].maxlen = S->fields[i].length;
 
 #ifdef PDO_USE_MYSQLND
-		if (S->stmt) {
-			cols[i].param_type = PDO_PARAM_ZVAL;
-		} else
+		cols[i].param_type = PDO_PARAM_ZVAL;
+#else
+		cols[i].param_type = PDO_PARAM_STR;
 #endif
-		{
-			cols[i].param_type = PDO_PARAM_STR;
-		}
 	}
 	PDO_DBG_RETURN(1);
 }
@@ -648,13 +661,6 @@ static int pdo_mysql_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr, size_
 		PDO_DBG_RETURN(0);
 	}
 
-	/* With mysqlnd data is stored inside mysqlnd, not S->current_data */
-	if (!S->stmt) {
-		if (S->current_data == NULL || !S->result) {
-			PDO_DBG_RETURN(0);
-		}
-	}
-
 	if (colno >= stmt->column_count) {
 		/* error invalid column */
 		PDO_DBG_RETURN(0);
@@ -663,9 +669,12 @@ static int pdo_mysql_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr, size_
 	if (S->stmt) {
 		Z_TRY_ADDREF(S->stmt->data->result_bind[colno].zv);
 		*ptr = (char*)&S->stmt->data->result_bind[colno].zv;
-		*len = sizeof(zval);
-		PDO_DBG_RETURN(1);
+	} else {
+		Z_TRY_ADDREF(S->current_row[colno]);
+		*ptr = (char*)&S->current_row[colno];
 	}
+	*len = sizeof(zval);
+	PDO_DBG_RETURN(1);
 #else
 	if (S->stmt) {
 		if (S->out_null[colno]) {
@@ -684,10 +693,14 @@ static int pdo_mysql_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr, size_
 		*len = S->out_length[colno];
 		PDO_DBG_RETURN(1);
 	}
-#endif
+
+	if (S->current_data == NULL) {
+		PDO_DBG_RETURN(0);
+	}
 	*ptr = S->current_data[colno];
 	*len = S->current_lengths[colno];
 	PDO_DBG_RETURN(1);
+#endif
 } /* }}} */
 
 static char *type_to_name_native(int type) /* {{{ */

--- a/ext/pdo_mysql/php_pdo_mysql_int.h
+++ b/ext/pdo_mysql/php_pdo_mysql_int.h
@@ -120,12 +120,6 @@ typedef struct {
 	pdo_mysql_db_handle 	*H;
 	MYSQL_RES				*result;
 	const MYSQL_FIELD		*fields;
-	MYSQL_ROW				current_data;
-#ifdef PDO_USE_MYSQLND
-	const size_t			*current_lengths;
-#else
-	unsigned long			*current_lengths;
-#endif
 	pdo_mysql_error_info 	einfo;
 #ifdef PDO_USE_MYSQLND
 	MYSQLND_STMT 			*stmt;
@@ -137,10 +131,14 @@ typedef struct {
 #ifndef PDO_USE_MYSQLND
 	my_bool					*in_null;
 	zend_ulong			*in_length;
-#endif
 	PDO_MYSQL_PARAM_BIND	*bound_result;
 	my_bool					*out_null;
 	zend_ulong				*out_length;
+	MYSQL_ROW				current_data;
+	unsigned long			*current_lengths;
+#else
+	zval					*current_row;
+#endif
 	unsigned				max_length:1;
 	/* Whether all result sets have been fully consumed.
 	 * If this flag is not set, they need to be consumed during destruction. */

--- a/ext/pdo_mysql/tests/bug44327.phpt
+++ b/ext/pdo_mysql/tests/bug44327.phpt
@@ -45,17 +45,17 @@ object(PDORow)#%d (2) {
   ["queryString"]=>
   string(17) "SELECT 1 AS "one""
   ["one"]=>
-  string(1) "1"
+  int(1)
 }
-string(1) "1"
-string(1) "1"
+int(1)
+int(1)
 string(17) "SELECT 1 AS "one""
 ----------------------------------
-object(PDORow)#%d (2) {
+object(PDORow)#5 (2) {
   ["queryString"]=>
   string(19) "SELECT id FROM test"
   ["id"]=>
-  string(1) "1"
+  int(1)
 }
 string(19) "SELECT id FROM test"
 ----------------------------------

--- a/ext/pdo_mysql/tests/bug71145.phpt
+++ b/ext/pdo_mysql/tests/bug71145.phpt
@@ -14,6 +14,7 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $attr = array(
     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
     PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci; SET SESSION sql_mode=traditional',
+    PDO::ATTR_STRINGIFY_FETCHES => true,
 );
 putenv('PDOTEST_ATTR=' . serialize($attr));
 

--- a/ext/pdo_mysql/tests/bug75177.phpt
+++ b/ext/pdo_mysql/tests/bug75177.phpt
@@ -18,14 +18,23 @@ $pdo->query("INSERT INTO $tbl (`bit`) VALUES (1)");
 $pdo->query("INSERT INTO $tbl (`bit`) VALUES (0b011)");
 $pdo->query("INSERT INTO $tbl (`bit`) VALUES (0b01100)");
 
+$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 $ret = $pdo->query("SELECT * FROM $tbl")->fetchAll();
+foreach ($ret as $i) {
+    var_dump($i["bit"]);
+}
 
+$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+$ret = $pdo->query("SELECT * FROM $tbl")->fetchAll();
 foreach ($ret as $i) {
     var_dump($i["bit"]);
 }
 
 ?>
 --EXPECT--
-string(1) "1"
-string(1) "3"
-string(2) "12"
+int(1)
+int(3)
+int(12)
+int(1)
+int(3)
+int(12)

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -14,6 +14,7 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $db = MySQLPDOTest::factory();
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
 $db->query('DROP TABLE IF EXISTS test');
 $db->query('CREATE TABLE test (first int) ENGINE = InnoDB');
@@ -127,9 +128,9 @@ array(1) {
   [0]=>
   array(2) {
     ["first"]=>
-    int(5)
+    string(1) "5"
     [0]=>
-    int(5)
+    string(1) "5"
   }
 }
 array(0) {
@@ -138,9 +139,9 @@ array(1) {
   [0]=>
   array(2) {
     ["first"]=>
-    int(7)
+    string(1) "7"
     [0]=>
-    int(7)
+    string(1) "7"
   }
 }
 array(0) {
@@ -179,8 +180,8 @@ array(1) {
   [0]=>
   array(2) {
     ["first"]=>
-    int(16)
+    string(2) "16"
     [0]=>
-    int(16)
+    string(2) "16"
   }
 }

--- a/ext/pdo_mysql/tests/bug_33689.phpt
+++ b/ext/pdo_mysql/tests/bug_33689.phpt
@@ -27,8 +27,8 @@ $stmt->execute();
 $tmp = $stmt->getColumnMeta(0);
 
 // libmysql and mysqlnd will show the pdo_type entry at a different position in the hash
-if (!isset($tmp['pdo_type']) || (isset($tmp['pdo_type']) && $tmp['pdo_type'] != 2))
-    printf("Expecting pdo_type = 2 got %s\n", $tmp['pdo_type']);
+if (!isset($tmp['pdo_type']) || (isset($tmp['pdo_type']) && $tmp['pdo_type'] != 1))
+    printf("Expecting pdo_type = 1 got %s\n", $tmp['pdo_type']);
 else
     unset($tmp['pdo_type']);
 

--- a/ext/pdo_mysql/tests/bug_41125.phpt
+++ b/ext/pdo_mysql/tests/bug_41125.phpt
@@ -21,6 +21,7 @@ if ($version < 40100)
 <?php
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $db = MySQLPDOTest::factory();
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 $db->exec("DROP TABLE IF EXISTS test");
 
 // And now allow the evil to do his work

--- a/ext/pdo_mysql/tests/bug_41997.phpt
+++ b/ext/pdo_mysql/tests/bug_41997.phpt
@@ -21,6 +21,7 @@ if ($version < 50000)
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
 $db->exec('DROP PROCEDURE IF EXISTS p');
 $db->exec('CREATE PROCEDURE p() BEGIN SELECT 1 AS "one"; END');

--- a/ext/pdo_mysql/tests/change_column_count.phpt
+++ b/ext/pdo_mysql/tests/change_column_count.phpt
@@ -12,7 +12,8 @@ MySQLPDOTest::skip();
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 
 $db = MySQLPDOTest::factory();
-$db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
 $db->exec('DROP TABLE IF EXISTS test');
 $db->exec('CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(255) NOT NULL)');

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_case.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_case.phpt
@@ -11,6 +11,7 @@ $db = MySQLPDOTest::factory();
 <?php
     require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
     $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
     MySQLPDOTest::createTestTable($db);
 
     $default =  $db->getAttribute(PDO::ATTR_CASE);

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_init_command.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_init_command.phpt
@@ -24,6 +24,7 @@ error_reporting=E_ALL
     $create = sprintf('CREATE TABLE %s(id INT)', $table);
     var_dump($create);
     $db = new PDO($dsn, $user, $pass, array(PDO::MYSQL_ATTR_INIT_COMMAND => $create));
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
     $info = $db->errorInfo();
     var_dump($info[0]);

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_multi_statements.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_multi_statements.phpt
@@ -20,6 +20,7 @@ error_reporting=E_ALL
     $table = sprintf("test_%s", md5(mt_rand(0, PHP_INT_MAX)));
     $db = new PDO($dsn, $user, $pass);
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
     $db->exec(sprintf('DROP TABLE IF EXISTS %s', $table));
     $create = sprintf('CREATE TABLE %s(id INT)', $table);
     $db->exec($create);
@@ -37,6 +38,7 @@ error_reporting=E_ALL
     // New connection, does not allow multiple statements.
     $db = new PDO($dsn, $user, $pass, array(PDO::MYSQL_ATTR_MULTI_STATEMENTS => false));
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
     $stmt = $db->query(sprintf('SELECT * FROM %s; INSERT INTO %s(id) VALUES (3)', $table, $table));
     var_dump($stmt);
     $info = $db->errorInfo();

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_statement_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_statement_class.phpt
@@ -11,6 +11,7 @@ $db = MySQLPDOTest::factory();
 <?php
     require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
     $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
     MySQLPDOTest::createTestTable($db);
 
     $default =  $db->getAttribute(PDO::ATTR_STATEMENT_CLASS);

--- a/ext/pdo_mysql/tests/pdo_mysql_begintransaction.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_begintransaction.phpt
@@ -13,6 +13,7 @@ if (false == MySQLPDOTest::detect_transactional_mysql_engine($db))
 <?php
     require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
     $db = MySQLPDOTest::factory();
+
     MySQLPDOTest::createTestTable($db, MySQLPDOTest::detect_transactional_mysql_engine($db));
 
     if (1 !== $db->getAttribute(PDO::ATTR_AUTOCOMMIT))
@@ -31,6 +32,7 @@ if (false == MySQLPDOTest::detect_transactional_mysql_engine($db))
     /* This is the PDO way to close a connection */
     $db = null;
     $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
     /* Autocommit was off - by definition. Commit was not issued. DELETE should have been rolled back. */
     if (!($stmt = $db->query('SELECT id, label FROM test ORDER BY id ASC')))

--- a/ext/pdo_mysql/tests/pdo_mysql_closecursor_error.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_closecursor_error.phpt
@@ -10,6 +10,7 @@ MySQLPDOTest::skip();
 <?php
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $db = MySQLPDOTest::factory();
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
 $stmt = $db->query('SELECT 1; SELECT x FROM does_not_exist');
 var_dump($stmt->fetchAll());

--- a/ext/pdo_mysql/tests/pdo_mysql_pconnect.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_pconnect.phpt
@@ -23,7 +23,7 @@ MySQLPDOTest::skip();
         $db1->exec('SET @pdo_persistent_connection=1');
         $stmt = $db2->query('SELECT @pdo_persistent_connection as _pers');
         $tmp = $stmt->fetch(PDO::FETCH_ASSOC);
-        if ($tmp['_pers'] !== '1')
+        if ($tmp['_pers'] != 1)
             printf("[001] Both handles should use the same connection.");
 
         $stmt = $db1->query('SELECT CONNECTION_ID() as _con1');

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated.phpt
@@ -11,6 +11,7 @@ $db = MySQLPDOTest::factory();
 <?php
     require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
     $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
     function prepex($offset, &$db, $query, $input_params = null, $error_info = null) {
 

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_clear_error.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_clear_error.phpt
@@ -11,6 +11,7 @@ $db = MySQLPDOTest::factory();
 <?php
     require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
     $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
     try {
 

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_dup_named_placeholder.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_dup_named_placeholder.phpt
@@ -11,6 +11,7 @@ $db = MySQLPDOTest::factory();
 <?php
     require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
     $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
     try {
 

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_placeholder_everywhere.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_placeholder_everywhere.phpt
@@ -11,6 +11,8 @@ $db = MySQLPDOTest::factory();
 <?php
     require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
     $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+
     try {
         $db->setAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY, 1);
         if (1 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
@@ -82,7 +84,7 @@ array(1) {
     ["?"]=>
     string(2) "id"
     ["id"]=>
-    int(1)
+    string(1) "1"
     ["label"]=>
     string(4) "row1"
   }

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetchobject.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetchobject.phpt
@@ -21,6 +21,7 @@ if (!$ok)
 <?php
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $db = MySQLPDOTest::factory();
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 MySQLPDOTest::createTestTable($db);
 
 try {

--- a/ext/pdo_mysql/tests/pdo_mysql_subclass.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_subclass.phpt
@@ -51,6 +51,7 @@ MySQLPDOTest::skip();
         }
 
         $db = new MyPDO(PDO_MYSQL_TEST_DSN, PDO_MYSQL_TEST_USER, PDO_MYSQL_TEST_PASS);
+        $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
         $db->exec('DROP TABLE IF EXISTS test');
         $db->exec('CREATE TABLE test(id INT)');
         $db->exec('INSERT INTO test(id) VALUES (1), (2)');


### PR DESCRIPTION
Retain the field, but always populate it with zero. This was
already the case for PS without length updating.

max_length has nothing lost in the field metadata -- it is a
property of the specific result set, and requires scanning the
whole result set to compute. PHP itself never uses max_length
with mysqlnd, it is only exposed in the raw mysqli API.

Keeping it for just that purpose is not worthwhile given the costs
involved. People who actually need this for some unfathomable
reason can easily calculate it themselves, while making it obvious
that the calculation requires a full result set scan.