### PR TITLE
Add more tests that document late static binding

### DIFF
--- a/Zend/tests/lsb_023.phpt
+++ b/Zend/tests/lsb_023.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Late Static Binding static:: calls protected / public method of child class even then
+the method is private in parent class
+--FILE--
+<?php
+class A {
+    public static function out() {
+        echo static::value(), PHP_EOL;
+    }
+
+    private static function value() { return 'A'; }
+}
+class B extends A {
+    protected static function value() { return 'B'; }
+}
+class C extends A {
+    public static function value() { return 'C'; }
+}
+A::out();
+B::out();
+C::out();
+echo PHP_EOL;
+--EXPECT--
+A
+B
+C

--- a/Zend/tests/lsb_024.phpt
+++ b/Zend/tests/lsb_024.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Late Static Binding static:: accesses protected / public static variables of child 
+class when the variable is private in parent class
+--FILE--
+<?php
+class A {
+    private static $value = 'A';
+
+    public static function out() {
+        echo static::$value, PHP_EOL;
+    }
+}
+class B extends A {
+    protected static $value = 'B';
+}
+class C extends A {
+    public static $value = 'C';
+}
+A::out();
+B::out();
+C::out();
+--EXPECT--
+A
+B
+C


### PR DESCRIPTION
This pull requests adds two more tests for late static binding. I noticed this behaviour when using infection/infection and getting false positives due to late static binding.

Essentially these tests cover the case if a parent class defines a method or static property as private and the child class as protected or public, then the parent class can access it. 