### PR TITLE
Bump minimum re2c version to 0.13.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,7 @@ PHP_RUNPATH_SWITCH
 dnl Checks for some support/generator progs.
 PHP_PROG_AWK
 PHP_PROG_BISON([3.0.0])
-PHP_PROG_RE2C([0.13.4])
+PHP_PROG_RE2C([0.13.7])
 
 PHP_ARG_ENABLE([re2c-cgoto],
   [whether to enable computed goto gcc extension with re2c],


### PR DESCRIPTION
We recently merged PR #6464, but that fix actually requires re2c 0.13.7 (released 2014-07-25), while the current requirement of PHP-8.0 is re2c 0.13.4 (released 2008-04-05). That bugfix has been [reverted from PHP-7.4.14](https://github.com/php/php-src/commit/a668ce82de2987502268a10c2b867b66d24d0708), because PHP 7.4 is packaged with re2c 0.13.5, but PHP 8.0.0RC1 has it, becaused it's packaged with re2c 0.16.0. Given that users building from the release tarballs would not be affected by this re2c version bump at all, and that the minimum required version has been released more than six years ago, in my opinion this late requirements bump is acceptable.

@sgolemon, @carusogabriel, what do you think?