### PR TITLE
Fix #76929: zip-based phar does not respect phar.require_hash

### DIFF
--- a/ext/phar/tests/zip/badalias.phpt
+++ b/ext/phar/tests/zip/badalias.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar: invalid aliases
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip no zlib"); ?>

--- a/ext/phar/tests/zip/bzip2.phpt
+++ b/ext/phar/tests/zip/bzip2.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar: process bzip2-compressed zip entry
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("bz2")) die("skip bz2 not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller1.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller1.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller other zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller11.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller11.phar.phpt
@@ -2,6 +2,7 @@
 Phar front controller mime type extension is not a string zip-based
 --INI--
 default_charset=
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip phar extension not loaded"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller12.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller12.phar.phpt
@@ -2,6 +2,7 @@
 Phar front controller mime type unknown int zip-based
 --INI--
 default_charset=UTF-8
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller13.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller13.phar.phpt
@@ -2,6 +2,7 @@
 Phar front controller mime type not string/int zip-based
 --INI--
 default_charset=UTF-8
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller14.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller14.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller mime type override, other zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller15.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller15.phar.phpt
@@ -2,6 +2,7 @@
 Phar front controller mime type override, Phar::PHPS zip-based
 --INI--
 default_charset=UTF-8
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller16.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller16.phar.phpt
@@ -2,6 +2,7 @@
 Phar front controller mime type override, Phar::PHP zip-based
 --INI--
 default_charset=UTF-8
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller17.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller17.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller mime type unknown zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller18.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller18.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller $_SERVER munging failure zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller19.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller19.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller $_SERVER munging failure 2 zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller2.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller2.phar.phpt
@@ -2,6 +2,7 @@
 Phar front controller PHP test zip-based
 --INI--
 default_charset=UTF-8
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller20.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller20.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller $_SERVER munging failure 3 zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller3.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller3.phar.phpt
@@ -2,6 +2,7 @@
 Phar front controller phps zip-based
 --INI--
 default_charset=UTF-8
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller4.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller4.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller index.php relocate (no /) zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller5.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller5.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller index.php relocate zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller6.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller6.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller 404 zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/frontcontroller7.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller7.phar.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar front controller alternate index file zip-based
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/tests/zip/getalias.phpt
+++ b/ext/phar/tests/zip/getalias.phpt
@@ -4,6 +4,7 @@ Phar: getAlias() with an existing phar.zip
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 --INI--
 phar.readonly=0
+phar.require_hash=0
 --FILE--
 <?php
 

--- a/ext/phar/tests/zip/require_hash.phpt
+++ b/ext/phar/tests/zip/require_hash.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Phar: zip-based phar, require_hash=1, no signature
+--SKIPIF--
+<?php if (!extension_loaded('phar')) die('skip'); ?>
+--INI--
+phar.readonly=1
+phar.require_hash=0
+--FILE--
+<?php
+ini_set('phar.require_hash', 1);
+include __DIR__ . '/files/zipmaker.php.inc';
+$fname = __DIR__ . '/require_hash.phar.zip';
+$alias = 'phar://' . $fname;
+$fname2 = __DIR__ . '/require_hash.zip';
+
+$zip = new zipmaker($fname);
+$zip->init();
+$zip->addFile('zip_001.php', '<?php var_dump(__FILE__);');
+$zip->addFile('internal/file/here', "hi there!\n");
+$zip->addFile('.phar/stub.php', "__HALT_COMPILER();");
+$zip->close();
+
+try {
+	$phar = new Phar($fname);
+	var_dump($phar->getStub());
+} catch (Exception $e) {
+	echo $e->getMessage()."\n";
+}
+ini_set('phar.require_hash', 0);
+try {
+	$phar = new PharData($fname2);
+	$phar['file'] = 'hi';
+	var_dump($phar->getSignature());
+	$phar->setSignatureAlgorithm(Phar::MD5);
+	var_dump($phar->getSignature());
+} catch (Exception $e) {
+	echo $e->getMessage()."\n";
+}
+
+?>
+===DONE===
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/require_hash.phar.zip');
+@unlink(__DIR__ . '/require_hash.zip');
+?>
+--EXPECTF--
+zip-based phar "%srequire_hash.phar.zip" does not have a signature
+bool(false)
+array(2) {
+  ["hash"]=>
+  string(32) "%s"
+  ["hash_type"]=>
+  string(3) "MD5"
+}
+===DONE===

--- a/ext/phar/tests/zip/zlib.phpt
+++ b/ext/phar/tests/zip/zlib.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Phar: process zlib-compressed zip alias
+--INI--
+phar.require_hash=0
 --SKIPIF--
 <?php if (!extension_loaded("phar")) die("skip"); ?>
 <?php if (!extension_loaded("zlib")) die("skip zlib not available"); ?>

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -684,6 +684,16 @@ foundit:
 		mydata->is_data = 1;
 	}
 
+	/* ensure signature set */
+	if (!mydata->is_data && PHAR_G(require_hash) && !mydata->signature) {
+		php_stream_close(fp);
+		phar_destroy_phar_data(mydata);
+		if (error) {
+			spprintf(error, 0, "zip-based phar \"%s\" does not have a signature", fname);
+		}
+		return FAILURE;
+	}
+
 	zend_hash_str_add_ptr(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len, mydata);
 
 	if (actual_alias) {


### PR DESCRIPTION
Based on the patch provided by david at bamsoftware.