### PR TITLE
Use getrandom in uniqid() and mt_rand() / mt_srand().

### DIFF
--- a/ext/standard/mt_rand.c
+++ b/ext/standard/mt_rand.c
@@ -24,6 +24,7 @@
 
 #include "php.h"
 #include "php_rand.h"
+#include "php_random.h"
 #include "php_mt_rand.h"
 
 /* MT RAND FUNCTIONS */
@@ -161,7 +162,11 @@ PHPAPI uint32_t php_mt_rand(void)
 	register uint32_t s1;
 
 	if (UNEXPECTED(!BG(mt_rand_is_seeded))) {
-		php_mt_srand(GENERATE_SEED());
+		zend_long bytes;
+		if (php_random_bytes_silent(&bytes, sizeof(zend_long)) == FAILURE) {
+			bytes = GENERATE_SEED();
+		}
+		php_mt_srand(bytes);
 	}
 
 	if (BG(left) == 0) {
@@ -189,8 +194,11 @@ PHP_FUNCTION(mt_srand)
 		Z_PARAM_LONG(mode)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (ZEND_NUM_ARGS() == 0)
-		seed = GENERATE_SEED();
+	if (ZEND_NUM_ARGS() == 0) {
+		if (php_random_bytes_silent(&seed, sizeof(zend_long)) == FAILURE) {
+			seed = GENERATE_SEED();
+		}
+	}
 
 	switch (mode) {
 		case MT_RAND_PHP:

--- a/ext/standard/uniqid.c
+++ b/ext/standard/uniqid.c
@@ -77,7 +77,7 @@ PHP_FUNCTION(uniqid)
 		if (php_random_bytes_silent(&bytes, sizeof(uint32_t)) == FAILURE) {
 			seed = php_combined_lcg() * 10;
 		} else {
-			seed = 1.0 / ((double) UINT32_MAX / bytes);
+			seed = (10.0 / ((double) UINT32_MAX / bytes));
 		}
 		uniqid = strpprintf(0, "%s%08x%05x%.8F", prefix, sec, usec, seed);
 	} else {

--- a/ext/standard/uniqid.c
+++ b/ext/standard/uniqid.c
@@ -32,6 +32,7 @@
 #endif
 
 #include "php_lcg.h"
+#include "php_random.h"
 
 #ifdef HAVE_GETTIMEOFDAY
 ZEND_TLS struct timeval prev_tv = { 0, 0 };
@@ -71,7 +72,14 @@ PHP_FUNCTION(uniqid)
 	 * digits for usecs.
 	 */
 	if (more_entropy) {
-		uniqid = strpprintf(0, "%s%08x%05x%.8F", prefix, sec, usec, php_combined_lcg() * 10);
+		uint32_t bytes;
+		double seed;
+		if (php_random_bytes_silent(&bytes, sizeof(uint32_t)) == FAILURE) {
+			seed = php_combined_lcg() * 10;
+		} else {
+			seed = 1.0 / ((double) UINT32_MAX / bytes);
+		}
+		uniqid = strpprintf(0, "%s%08x%05x%.8F", prefix, sec, usec, seed);
 	} else {
 		uniqid = strpprintf(0, "%s%08x%05x", prefix, sec, usec);
 	}

--- a/ext/standard/uniqid.c
+++ b/ext/standard/uniqid.c
@@ -77,7 +77,7 @@ PHP_FUNCTION(uniqid)
 		if (php_random_bytes_silent(&bytes, sizeof(uint32_t)) == FAILURE) {
 			seed = php_combined_lcg() * 10;
 		} else {
-			seed = (10.0 / ((double) UINT32_MAX / bytes));
+			seed = ((double) bytes / UINT32_MAX) * 10.0;
 		}
 		uniqid = strpprintf(0, "%s%08x%05x%.8F", prefix, sec, usec, seed);
 	} else {


### PR DESCRIPTION
Proposal to Internals: https://externals.io/message/112525

For these functions, use the more secure random source provided by the operating system if available.
A slight performance degradation is expected (Especially Linux, kernel's uses spinlock.), but the impact is minor and only at first time.

Also, no changes has provided for GENERATE_SEED() in gmp. This is because I am not familiar with this extension.