### PR TITLE
All (gm)mktime() parameters should be optional

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1065,21 +1065,27 @@ PHP_FUNCTION(strtotime)
 PHPAPI void php_mktime(INTERNAL_FUNCTION_PARAMETERS, int gmt)
 {
 	zend_long hou, min, sec, mon, day, yea;
-	zend_bool min_is_null = 1, sec_is_null = 1, mon_is_null = 1, day_is_null = 1, yea_is_null = 1;
+	zend_bool hou_is_null = 1, min_is_null = 1, sec_is_null = 1, mon_is_null = 1, day_is_null = 1, yea_is_null = 1;
 	timelib_time *now;
 	timelib_tzinfo *tzi = NULL;
 	zend_long ts, adjust_seconds = 0;
 	int epoch_does_not_fit_in_zend_long;
 
-	ZEND_PARSE_PARAMETERS_START(1, 6)
-		Z_PARAM_LONG(hou)
+	ZEND_PARSE_PARAMETERS_START(0, 6)
 		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG_OR_NULL(hou, hou_is_null)
 		Z_PARAM_LONG_OR_NULL(min, min_is_null)
 		Z_PARAM_LONG_OR_NULL(sec, sec_is_null)
 		Z_PARAM_LONG_OR_NULL(mon, mon_is_null)
 		Z_PARAM_LONG_OR_NULL(day, day_is_null)
 		Z_PARAM_LONG_OR_NULL(yea, yea_is_null)
 	ZEND_PARSE_PARAMETERS_END();
+
+	/* at least one arg is required, although it does not matter which one is given */
+	if (hou_is_null && min_is_null && sec_is_null && mon_is_null && day_is_null && yea_is_null) {
+		zend_argument_count_error("%s() expects at least 1 argument", gmt ? "gmmktime" : "mktime");
+		RETURN_THROWS();
+	}
 
 	/* Initialize structure with current time */
 	now = timelib_time_ctor();
@@ -1092,7 +1098,9 @@ PHPAPI void php_mktime(INTERNAL_FUNCTION_PARAMETERS, int gmt)
 		timelib_unixtime2local(now, (timelib_sll) php_time());
 	}
 
-	now->h = hou;
+	if (!hou_is_null) {
+		now->h = hou;
+	}
 
 	if (!min_is_null) {
 		now->i = min;

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -11,11 +11,11 @@ function idate(string $format, ?int $timestamp = null): int|false {}
 function gmdate(string $format, ?int $timestamp = null): string {}
 
 function mktime(
-    int $hour, ?int $minute = null, ?int $second = null,
+    ?int $hour = null, ?int $minute = null, ?int $second = null,
     ?int $month = null, ?int $day = null, ?int $year = null): int|false {}
 
 function gmmktime(
-    int $hour, ?int $minute = null, ?int $second = null,
+    ?int $hour = null, ?int $minute = null, ?int $second = null,
     ?int $month = null, ?int $day = null, ?int $year = null): int|false {}
 
 function checkdate(int $month, int $day, int $year): bool {}

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 339c2c91f38eeaafac6134ac04573243069502f5 */
+ * Stub hash: c16083a04d98295c036218354358080966ae91f5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -18,8 +18,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_gmdate arginfo_date
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mktime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, hour, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mktime, 0, 0, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hour, IS_LONG, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, minute, IS_LONG, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, second, IS_LONG, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, month, IS_LONG, 1, "null")


### PR DESCRIPTION
While it makes no sense to call these functions without any arguments,
and that is deprecated as of PHP 7.0.0, and issued a E_STRICT notice as
of 5.1.0, it seriously limits the usefulness of calling these functions
with named parameters.  Therefore, we make the `$hour` optional, but
still enforce that at least a single parameter is given.

Note that this requirement cannot be expressed by reflection, though.