### PR TITLE
Optimize Dovecot configuration for IMAP tests

### DIFF
--- a/ext/imap/tests/imap_errors_basic.phpt
+++ b/ext/imap/tests/imap_errors_basic.phpt
@@ -10,22 +10,24 @@ echo "*** Testing imap_errors() : invalid password ***\n";
 require_once __DIR__.'/setup/imap_include.inc';
 $password = "bogus"; // invalid password to use in this test
 
-echo "Issue opening with invalid password, 1 retry\n";
-$mbox = imap_open(IMAP_DEFAULT_MAILBOX, IMAP_MAILBOX_USERNAME, $password, OP_READONLY, 1);
+echo "Issue opening with invalid password, 1 attempt\n";
+$mbox = @imap_open(
+    IMAP_DEFAULT_MAILBOX,
+    IMAP_MAILBOX_USERNAME,
+    $password,
+    OP_READONLY,
+    1,
+);
 
 echo "List any errors\n";
 var_dump(imap_errors());
 
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing imap_errors() : invalid password ***
-Issue opening with invalid password, 1 retry
-
-Warning: imap_open(): Couldn't open stream %s in %s on line %d
+Issue opening with invalid password, 1 attempt
 List any errors
-array(%d) {
+array(1) {
   [0]=>
-  string(%d) "%s"
-  [1]=>
-  string(%d) "%s"
+  string(82) "Can not authenticate to IMAP server: [AUTHENTICATIONFAILED] Authentication failed."
 }

--- a/ext/imap/tests/setup/dovecot.conf
+++ b/ext/imap/tests/setup/dovecot.conf
@@ -2,15 +2,29 @@
 # Pigeonhole version 0.4.21 (92477967)
 listen = *, ::
 
-# To make authentication work
+# For SSL need to setup a certificate
+# See https://wiki.dovecot.org/SSL/DovecotConfiguration
 ssl = no
-disable_plaintext_auth = no
 
-auth_mechanisms = plain cram-md5
+# Disable plaintext to prevent a warning at each login
+disable_plaintext_auth = yes
+
+auth_mechanisms = cram-md5
 auth_username_format = %u
-auth_debug = yes
 auth_verbose = yes
-#log
+auth_debug = yes
+auth_failure_delay = 1secs
+
+# This need dovecot 2.3.12.
+# login_proxy_timeout = 500milliseconds
+# ^ This would allow to kill login processes early, but needs testing. So would use v instead
+# login_proxy_timeout = 5s
+# There is a 1 second delay between each reconnection attempt.
+# https://doc.dovecot.org/settings/core/#login-proxy-max-reconnects
+# This need dovecot 2.3.12.
+# login_proxy_max_reconnects = 3
+
+# Log config
 log_path = /var/log/dovecot.log
 # If not set, use the value from log_path
 info_log_path = /var/log/dovecot-info.log


### PR DESCRIPTION
This halves the time taken by the SKIPIF section with parallel testing when the ``ext/imap/tests/imap_errors_basic.phpt`` is running (and possibly others) as it's hogging the connections by providing an invalid password.

Another possibility is to reduce the number of attempts in the SKIPIF section, as it turns out the ``retries`` parameter, actually corresponds to "attempts" and using 0, just retries until the mail-server terminates the connection after too many retries/too long.

@cmb69 could you test that the modification to the test still work on Windows?