### PR TITLE
FTP: Disallow direct `FTPConnection` construction

### DIFF
--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -82,6 +82,11 @@ static zend_object* ftp_object_create(zend_class_entry* ce) {
 	return zobj;
 }
 
+static zend_function *ftp_object_get_constructor(zend_object *zobj) {
+	zend_throw_error(NULL, "Cannot directly construct FTPConnection, use ftp_connect() or ftp_ssl_connect() instead");
+	return NULL;
+}
+
 static void ftp_object_destroy(zend_object *zobj) {
 	php_ftp_object *obj = ftp_object_from_zend_object(zobj);
 
@@ -114,6 +119,7 @@ PHP_MINIT_FUNCTION(ftp)
 
 	memcpy(&ftp_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	ftp_object_handlers.offset = XtOffsetOf(php_ftp_object, std);
+	ftp_object_handlers.get_constructor = ftp_object_get_constructor;
 	ftp_object_handlers.dtor_obj = ftp_object_destroy;
 	ftp_object_handlers.clone_obj = NULL;
 

--- a/ext/ftp/tests/ftp_constructor.phpt
+++ b/ext/ftp/tests/ftp_constructor.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Attempt to instantiate an FTPConnection directly
+--SKIPIF--
+<?php
+require 'skipif.inc';
+--FILE--
+<?php
+
+try {
+    new FTPConnection();
+} catch (Error $ex) {
+    echo "Exception: ", $ex->getMessage(), "\n";
+}
+--EXPECT--
+Exception: Cannot directly construct FTPConnection, use ftp_connect() or ftp_ssl_connect() instead


### PR DESCRIPTION
Similar to other resource to object migrations, `FTPConnection` class is not allowed to be constructed with `new FTPConnection`.
Related to b4503fbf882e490f16d85915e83173bd1e414e84.

As of now, it is possible to construct an `FTPConnection` object with `new FTPConnection`. @sgolemon did an amazing work with the resource to object migration, but I think this was overlooked? I put together this PR that basically throws an exception similar to other resource-class objects when using `new FTPConnection`, forcing users to continue to use `ftp_connect` and `ftp_ssl_connect`. 

Thank you. 
