### PR TITLE
IMAP: Resource object constructor and stub

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -170,6 +170,11 @@ static zend_object* imap_object_create(zend_class_entry* ce) {
 	return zobj;
 }
 
+static zend_function *imap_object_get_constructor(zend_object *zobj) {
+	zend_throw_error(NULL, "Cannot directly construct IMAPConnection, use imap_open() instead");
+	return NULL;
+}
+
 static void imap_object_destroy(zend_object *zobj) {
 	php_imap_object *obj = imap_object_from_zend_object(zobj);
 
@@ -483,6 +488,7 @@ PHP_MINIT_FUNCTION(imap)
 
 	memcpy(&imap_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	imap_object_handlers.offset = XtOffsetOf(php_imap_object, std);
+	imap_object_handlers.get_constructor = imap_object_get_constructor;
 	imap_object_handlers.dtor_obj = imap_object_destroy;
 	imap_object_handlers.clone_obj = NULL;
 

--- a/ext/imap/php_imap.stub.php
+++ b/ext/imap/php_imap.stub.php
@@ -1,7 +1,7 @@
 <?php
 
 /** @generate-function-entries */
-class IMAPConnection {
+final class IMAPConnection {
 
 }
 

--- a/ext/imap/tests/imap_constructor.phpt
+++ b/ext/imap/tests/imap_constructor.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Attempt to instantiate an IMAPConnection directly
+--SKIPIF--
+<?php
+extension_loaded('imap') or die('skip imap extension not available in this build');
+--FILE--
+<?php
+
+try {
+    new IMAPConnection();
+} catch (Error $ex) {
+    echo "Exception: ", $ex->getMessage(), "\n";
+}
+--EXPECT--
+Exception: Cannot directly construct IMAPConnection, use imap_open() instead

--- a/ext/imap/tests/imap_final.phpt
+++ b/ext/imap/tests/imap_final.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Check that IMAPConnection is declared final
+--SKIPIF--
+<?php
+extension_loaded('imap') or die('skip imap extension not available in this build');
+--FILE--
+<?php
+
+class T extends IMAPConnection {}
+--EXPECTF--
+Fatal error: Class T may not inherit from final class (IMAPConnection) in %s on line %d


### PR DESCRIPTION
This is similar to #6533 (`FTPConnection`), but for `IMAPConnection` resource class.

As of now, direct construction of `IMAPConnection` class is allowed, and I think it was meant to be disallowed just like other new resource objects. In this PR:

 - Disallow `new IMAPConnection` constructor with `\Error` exception `Cannot directly construct IMAPConnection, use imap_open() instead`.
 - Update the stub to declare `IMAPConnection` with `final` flag.

Thank you.