### PR TITLE
Add Spl\ForwardArrayIterator and Spl\ReverseArrayIterator

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -11,6 +11,7 @@
    | license@php.net so we can mail you a copy immediately.               |
    +----------------------------------------------------------------------+
    | Authors: Marcus Boerger <helly@php.net>                              |
+   | Authors: Levi Morrison <levim@php.net>                               |
    +----------------------------------------------------------------------+
  */
 
@@ -40,6 +41,12 @@ PHPAPI zend_class_entry  *spl_ce_ArrayObject;
 zend_object_handlers spl_handler_ArrayIterator;
 PHPAPI zend_class_entry  *spl_ce_ArrayIterator;
 PHPAPI zend_class_entry  *spl_ce_RecursiveArrayIterator;
+
+zend_object_handlers spl_handler_ForwardArrayIterator;
+PHPAPI zend_class_entry  *spl_ce_ForwardArrayIterator;
+
+zend_object_handlers spl_handler_ReverseArrayIterator;
+PHPAPI zend_class_entry  *spl_ce_ReverseArrayIterator;
 
 #define SPL_ARRAY_STD_PROP_LIST      0x00000001
 #define SPL_ARRAY_ARRAY_AS_PROPS     0x00000002
@@ -1839,9 +1846,551 @@ PHP_METHOD(ArrayObject, __debugInfo)
 	RETURN_ARR(spl_array_get_debug_info(Z_OBJ_P(ZEND_THIS)));
 } /* }}} */
 
+
+/* Used by:
+ *   1. Spl\ForwardArrayIterator
+ *   2. Spl\ReverseArrayIterator
+ */
+typedef struct {
+	HashPosition current;
+	HashTable *ht;
+	zend_object std;
+} ArrayIterator;
+
+static zend_always_inline ArrayIterator *ArrayIterator_from_obj(zend_object *obj)
+{
+	return (ArrayIterator *) ((char*)(obj) - XtOffsetOf(ArrayIterator, std));
+}
+
+
+static void ArrayIterator_dtor_obj(zend_object *object)
+{
+	ArrayIterator *iterator = ArrayIterator_from_obj(object);
+		zend_hash_release(iterator->ht);
+		iterator->current = 0;
+		iterator->ht = (HashTable *)&zend_empty_array;
+}
+
+static void ArrayIterator_free_obj(zend_object *object)
+{
+	ArrayIterator_dtor_obj(object);
+	zend_object_std_dtor(object);
+}
+
+static int ArrayIterator_count_elements(zend_object *obj, zend_long *count)
+{
+	ArrayIterator *iterator = ArrayIterator_from_obj(obj);
+	*count = zend_hash_num_elements(iterator->ht);
+	return SUCCESS;
+}
+
+static HashTable *ArrayIterator_get_properties_for(zend_object *object, zend_prop_purpose purpose)
+{
+	// todo: determine if it is worthwhile to implement any other purposes
+	if (purpose != ZEND_PROP_PURPOSE_DEBUG) {
+		return NULL;
+	}
+
+	ArrayIterator *iterator = ArrayIterator_from_obj(object);
+	HashTable *properties = zend_new_array(2);
+	zval inner, offset;
+
+	/* At the time of this writing, there isn't a macro that sets the
+	 * correct type info on the zval if the array is immutable, so do it
+	 * manually, as returning `zend_empty_array` (either from our own
+	 * .create_obj handler or from an array literal in a script) will
+	 * cause a sigsegv if the flags are not set correctly.
+	 */
+	HashTable *ht = iterator->ht;
+	{
+		Z_ARR(inner) = ht;
+		if (!(GC_FLAGS(ht) & GC_IMMUTABLE)) {
+			GC_ADDREF(ht);
+			Z_TYPE_INFO(inner) = IS_ARRAY_EX;
+		} else {
+			Z_TYPE_INFO(inner) = IS_ARRAY;
+		}
+	}
+	zend_hash_str_add(properties, ZEND_STRL("inner"), &inner);
+
+	// For the offset property we ignore holes, which are hidden from PHP.
+	HashPosition pos = 0, target = iterator->current;
+	zend_long current = 0;
+	for (
+		zend_hash_internal_pointer_reset_ex(ht, &pos);
+		pos != target && zend_hash_get_current_key_type_ex(ht, &pos) != HASH_KEY_NON_EXISTENT;
+		zend_hash_move_forward_ex(ht, &pos)
+	) {
+		++current;
+	}
+	ZVAL_LONG(&offset, current);
+	zend_hash_str_add(properties, ZEND_STRL("offset"), &offset);
+
+	return properties;
+}
+
+/* Spl\ForwardArrayIterator {{{ */
+typedef ArrayIterator ForwardArrayIterator;
+
+static void ForwardArrayIterator_it_dtor(zend_object_iterator *iterator)
+{
+	zval_ptr_dtor(&iterator->data);
+}
+
+static void ForwardArrayIterator_rewind(ForwardArrayIterator *iterator)
+{
+	iterator->current = 0;
+}
+
+static void ForwardArrayIterator_it_rewind(zend_object_iterator *zoi)
+{
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	ForwardArrayIterator_rewind(iterator);
+}
+
+static bool ForwardArrayIterator_valid(ForwardArrayIterator *iterator)
+{
+	HashTable *ht = iterator->ht;
+	return zend_hash_get_current_key_type_ex(ht, &iterator->current) != HASH_KEY_NON_EXISTENT;
+}
+
+static int ForwardArrayIterator_it_valid(zend_object_iterator *zoi)
+{
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	return ForwardArrayIterator_valid(iterator) ? SUCCESS : FAILURE;
+}
+
+static zval *ForwardArrayIterator_current(ForwardArrayIterator *iterator)
+{
+	if (UNEXPECTED(!ForwardArrayIterator_valid(iterator))) {
+		zend_throw_error(NULL, "Spl\\ForwardArrayIterator::current() must not be called on an invalid iterator");
+		return NULL;
+	}
+
+	return zend_hash_get_current_data_ex(iterator->ht, &iterator->current);
+}
+
+static zval *ForwardArrayIterator_it_get_current_data(zend_object_iterator *zoi)
+{
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	return ForwardArrayIterator_current(iterator);
+}
+
+static void ForwardArrayIterator_key(ForwardArrayIterator *iterator, zval *key)
+{
+	if (UNEXPECTED(!ForwardArrayIterator_valid(iterator))) {
+		zend_throw_error(NULL, "Spl\\ForwardArrayIterator::key() must not be called on an invalid iterator");
+		return;
+	}
+
+	zend_hash_get_current_key_zval_ex(iterator->ht, key, &iterator->current);
+}
+
+static void ForwardArrayIterator_it_get_current_key(zend_object_iterator *zoi, zval *key)
+{
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	ForwardArrayIterator_key(iterator, key);
+}
+
+static void ForwardArrayIterator_next(ForwardArrayIterator *iterator)
+{
+	// Why is `next` being called on an invalid iterator? Fix your code!
+	if (!ForwardArrayIterator_valid(iterator)) {
+		zend_throw_error(NULL, "Spl\\ForwardArrayIterator::next() must not be called on an invalid iterator");
+		return;
+	}
+
+	zend_hash_move_forward_ex(iterator->ht, &iterator->current);
+}
+
+static void ForwardArrayIterator_it_move_forward(zend_object_iterator *zoi)
+{
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	ForwardArrayIterator_next(iterator);
+}
+
+
+static const zend_object_iterator_funcs spl_ForwardArrayIterator_it_funcs = {
+	ForwardArrayIterator_it_dtor,
+	ForwardArrayIterator_it_valid,
+	ForwardArrayIterator_it_get_current_data,
+	ForwardArrayIterator_it_get_current_key,
+	ForwardArrayIterator_it_move_forward,
+	ForwardArrayIterator_it_rewind,
+	NULL,
+	NULL,
+};
+
+static zend_object_iterator *ForwardArrayIterator_get_iterator(zend_class_entry *ce, zval *object, int by_ref)
+{
+	if (UNEXPECTED(by_ref)) {
+		zend_throw_error(NULL, "An iterator cannot be used with foreach by reference");
+		return NULL;
+	}
+
+	if (UNEXPECTED(ce != spl_ce_ForwardArrayIterator || Z_OBJCE_P(object) != spl_ce_ForwardArrayIterator)) {
+		zend_throw_error(NULL, "Spl\\ForwardArrayIterator is final");
+		return NULL;
+	}
+
+	zend_object_iterator *zoi = emalloc(sizeof(zend_object_iterator));
+	zend_iterator_init(zoi);
+
+	ZVAL_OBJ_COPY(&zoi->data, Z_OBJ_P(object));
+	zoi->funcs = &spl_ForwardArrayIterator_it_funcs;
+	return zoi;
+}
+
+static zend_object *spl_ForwardArrayIterator_new(zend_class_entry *class_type)
+{
+	zend_class_entry *ce = spl_ce_ForwardArrayIterator;
+	ZEND_ASSERT(class_type == ce);
+
+	ForwardArrayIterator *iterator =
+		zend_object_alloc(sizeof(ForwardArrayIterator), ce);
+
+	zend_object_std_init(&iterator->std, ce);
+
+	iterator->std.handlers = &spl_handler_ForwardArrayIterator;
+
+	/* Initialize the inner array to the empty array, then call rewind.
+	 * This ensures a consistent object.
+	 */
+	iterator->ht = (HashTable *)&zend_empty_array;
+
+	ForwardArrayIterator_rewind(iterator);
+
+	return &iterator->std;
+
+}
+
+ZEND_METHOD(Spl_ForwardArrayIterator, __construct)
+{
+	zval *array;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY(array)
+	ZEND_PARSE_PARAMETERS_END();
+
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+
+	iterator->ht = Z_ARR_P(array);
+	GC_TRY_ADDREF(iterator->ht);
+
+	ForwardArrayIterator_rewind(iterator);
+}
+
+ZEND_METHOD(Spl_ForwardArrayIterator, count)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	Z_TYPE_INFO_P(return_value) = IS_LONG;
+	ArrayIterator_count_elements(Z_OBJ_P(ZEND_THIS), &Z_LVAL_P(return_value));
+}
+
+ZEND_METHOD(Spl_ForwardArrayIterator, rewind)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	ForwardArrayIterator_rewind(iterator);
+}
+
+ZEND_METHOD(Spl_ForwardArrayIterator, valid)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	RETURN_BOOL(ForwardArrayIterator_valid(iterator));
+}
+
+ZEND_METHOD(Spl_ForwardArrayIterator, key)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	ForwardArrayIterator_key(iterator, return_value);
+}
+
+ZEND_METHOD(Spl_ForwardArrayIterator, current)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	zval *current = ForwardArrayIterator_current(iterator);
+	if (EXPECTED(current)) {
+		ZVAL_COPY(return_value, current);
+	}
+}
+
+ZEND_METHOD(Spl_ForwardArrayIterator, next)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ForwardArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	ForwardArrayIterator_next(iterator);
+}
+
+static void register_ForwardArrayIterator(void)
+{
+	zend_class_entry tmp;
+	INIT_NS_CLASS_ENTRY(tmp, "Spl", "ForwardArrayIterator", class_Spl_ForwardArrayIterator_methods)
+
+	zend_class_entry *ce = spl_ce_ForwardArrayIterator = zend_register_internal_class(&tmp);
+	zend_class_implements(ce, 2, zend_ce_countable, zend_ce_iterator);
+
+	ce->ce_flags |= ZEND_ACC_FINAL | ZEND_ACC_NO_DYNAMIC_PROPERTIES;
+
+	/* Spl\ForwardArrayIterator object handlers */
+	zend_object_handlers *obj_handlers = &spl_handler_ForwardArrayIterator;
+	memcpy(obj_handlers, &std_object_handlers, sizeof std_object_handlers);
+	obj_handlers->free_obj = ArrayIterator_free_obj;
+	obj_handlers->offset = XtOffsetOf(ArrayIterator, std);
+	obj_handlers->count_elements = ArrayIterator_count_elements;
+	obj_handlers->get_properties_for = ArrayIterator_get_properties_for;
+
+	/* Spl\ForwardArrayIterator class handlers */
+	ce->create_object = spl_ForwardArrayIterator_new;
+	ce->get_iterator = ForwardArrayIterator_get_iterator;
+	ce->serialize = zend_class_serialize_deny;
+	ce->unserialize = zend_class_unserialize_deny;
+}
+/* }}} */
+
+/* Spl\ReverseArrayIterator {{{ */
+typedef ArrayIterator ReverseArrayIterator;
+
+static void ReverseArrayIterator_it_dtor(zend_object_iterator *iterator)
+{
+	zval_ptr_dtor(&iterator->data);
+}
+
+static void ReverseArrayIterator_rewind(ReverseArrayIterator *iterator)
+{
+	zend_hash_internal_pointer_end_ex(iterator->ht, &iterator->current);
+}
+
+static void ReverseArrayIterator_it_rewind(zend_object_iterator *zoi)
+{
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	ReverseArrayIterator_rewind(iterator);
+}
+
+static bool ReverseArrayIterator_valid(ReverseArrayIterator *iterator)
+{
+	HashTable *ht = iterator->ht;
+	return zend_hash_get_current_key_type_ex(ht, &iterator->current) != HASH_KEY_NON_EXISTENT;
+}
+
+static int ReverseArrayIterator_it_valid(zend_object_iterator *zoi)
+{
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	return ReverseArrayIterator_valid(iterator) ? SUCCESS : FAILURE;
+}
+
+static zval *ReverseArrayIterator_current(ReverseArrayIterator *iterator)
+{
+	if (UNEXPECTED(!ReverseArrayIterator_valid(iterator))) {
+		zend_throw_error(NULL, "Spl\\ReverseArrayIterator::current() must not be called on an invalid iterator");
+		return NULL;
+	}
+
+	return zend_hash_get_current_data_ex(iterator->ht, &iterator->current);
+}
+
+static zval *ReverseArrayIterator_it_get_current_data(zend_object_iterator *zoi)
+{
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	return ReverseArrayIterator_current(iterator);
+}
+
+static void ReverseArrayIterator_key(ReverseArrayIterator *iterator, zval *key)
+{
+	if (UNEXPECTED(!ReverseArrayIterator_valid(iterator))) {
+		zend_throw_error(NULL, "Spl\\ReverseArrayIterator::key() must not be called on an invalid iterator");
+		return;
+	}
+
+	HashTable *ht = iterator->ht;
+	zend_hash_get_current_key_zval_ex(ht, key, &iterator->current);
+}
+
+static void ReverseArrayIterator_it_get_current_key(zend_object_iterator *zoi, zval *key)
+{
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	ReverseArrayIterator_key(iterator, key);
+}
+
+static void ReverseArrayIterator_next(ReverseArrayIterator *iterator)
+{
+	// Why is `next` being called on an invalid iterator? Fix your code!
+	if (!ReverseArrayIterator_valid(iterator)) {
+		zend_throw_error(NULL, "Spl\\ReverseArrayIterator::next() must not be called on an invalid iterator");
+		return;
+	}
+
+	zend_hash_move_backwards_ex(iterator->ht, &iterator->current);
+}
+
+static void ReverseArrayIterator_it_move_forward(zend_object_iterator *zoi)
+{
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ(zoi->data));
+	ReverseArrayIterator_next(iterator);
+}
+
+
+static const zend_object_iterator_funcs spl_ReverseArrayIterator_it_funcs = {
+	ReverseArrayIterator_it_dtor,
+	ReverseArrayIterator_it_valid,
+	ReverseArrayIterator_it_get_current_data,
+	ReverseArrayIterator_it_get_current_key,
+	ReverseArrayIterator_it_move_forward,
+	ReverseArrayIterator_it_rewind,
+	NULL,
+	NULL,
+};
+
+static zend_object_iterator *ReverseArrayIterator_get_iterator(zend_class_entry *ce, zval *object, int by_ref)
+{
+	if (UNEXPECTED(by_ref)) {
+		zend_throw_error(NULL, "An iterator cannot be used with foreach by reference");
+		return NULL;
+	}
+
+	if (UNEXPECTED(ce != spl_ce_ReverseArrayIterator || Z_OBJCE_P(object) != spl_ce_ReverseArrayIterator)) {
+		zend_throw_error(NULL, "Spl\\ReverseArrayIterator is final");
+		return NULL;
+	}
+
+	zend_object_iterator *zoi = emalloc(sizeof(zend_object_iterator));
+	zend_iterator_init(zoi);
+
+	ZVAL_OBJ_COPY(&zoi->data, Z_OBJ_P(object));
+	zoi->funcs = &spl_ReverseArrayIterator_it_funcs;
+	return zoi;
+}
+
+static zend_object *spl_ReverseArrayIterator_new(zend_class_entry *class_type)
+{
+	zend_class_entry *ce = spl_ce_ReverseArrayIterator;
+	ZEND_ASSERT(class_type == ce);
+
+	ReverseArrayIterator *iterator =
+		zend_object_alloc(sizeof(ReverseArrayIterator), ce);
+
+	zend_object_std_init(&iterator->std, ce);
+
+	iterator->std.handlers = &spl_handler_ReverseArrayIterator;
+
+	/* Initialize the inner array to the empty array, then call rewind.
+	 * This ensures a consistent object.
+	 */
+	iterator->ht = (HashTable *)&zend_empty_array;
+
+	ReverseArrayIterator_rewind(iterator);
+
+	return &iterator->std;
+
+}
+
+ZEND_METHOD(Spl_ReverseArrayIterator, __construct)
+{
+	zval *array;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY(array)
+	ZEND_PARSE_PARAMETERS_END();
+
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+
+	iterator->ht = Z_ARR_P(array);
+	GC_TRY_ADDREF(iterator->ht);
+
+	ReverseArrayIterator_rewind(iterator);
+}
+
+ZEND_METHOD(Spl_ReverseArrayIterator, count)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	Z_TYPE_INFO_P(return_value) = IS_LONG;
+	ArrayIterator_count_elements(Z_OBJ_P(ZEND_THIS), &Z_LVAL_P(return_value));
+}
+
+ZEND_METHOD(Spl_ReverseArrayIterator, rewind)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	ReverseArrayIterator_rewind(iterator);
+}
+
+ZEND_METHOD(Spl_ReverseArrayIterator, valid)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	RETURN_BOOL(ReverseArrayIterator_valid(iterator));
+}
+
+ZEND_METHOD(Spl_ReverseArrayIterator, key)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	ReverseArrayIterator_key(iterator, return_value);
+}
+
+ZEND_METHOD(Spl_ReverseArrayIterator, current)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	zval *current = ReverseArrayIterator_current(iterator);
+	if (EXPECTED(current)) {
+		ZVAL_COPY(return_value, current);
+	}
+}
+
+ZEND_METHOD(Spl_ReverseArrayIterator, next)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	ReverseArrayIterator *iterator = ArrayIterator_from_obj(Z_OBJ_P(ZEND_THIS));
+	ReverseArrayIterator_next(iterator);
+}
+
+static void register_ReverseArrayIterator(void)
+{
+	zend_class_entry tmp;
+	INIT_NS_CLASS_ENTRY(tmp, "Spl", "ReverseArrayIterator", class_Spl_ReverseArrayIterator_methods)
+
+	spl_ce_ReverseArrayIterator = zend_register_internal_class(&tmp);
+	zend_class_entry *ce = spl_ce_ReverseArrayIterator;
+	zend_class_implements(ce, 2, zend_ce_countable, zend_ce_iterator);
+
+	ce->ce_flags |= ZEND_ACC_FINAL | ZEND_ACC_NO_DYNAMIC_PROPERTIES;
+
+	/* Spl\ReverseArrayIterator object handlers */
+	zend_object_handlers *obj_handlers = &spl_handler_ReverseArrayIterator;
+	memcpy(obj_handlers, &std_object_handlers, sizeof std_object_handlers);
+	obj_handlers->free_obj = ArrayIterator_free_obj;
+	obj_handlers->offset = XtOffsetOf(ArrayIterator, std);
+	obj_handlers->count_elements = ArrayIterator_count_elements;
+	obj_handlers->get_properties_for = ArrayIterator_get_properties_for;
+
+	/* Spl\ReverseArrayIterator class handlers */
+	ce->create_object = spl_ReverseArrayIterator_new;
+	ce->get_iterator = ReverseArrayIterator_get_iterator;
+	ce->serialize = zend_class_serialize_deny;
+	ce->unserialize = zend_class_unserialize_deny;
+}
+/* }}} */
+
 /* {{{ PHP_MINIT_FUNCTION(spl_array) */
 PHP_MINIT_FUNCTION(spl_array)
 {
+	register_ForwardArrayIterator();
+	register_ReverseArrayIterator();
+
 	REGISTER_SPL_STD_CLASS_EX(ArrayObject, spl_array_object_new, class_ArrayObject_methods);
 	REGISTER_SPL_IMPLEMENTS(ArrayObject, Aggregate);
 	REGISTER_SPL_IMPLEMENTS(ArrayObject, ArrayAccess);

--- a/ext/spl/spl_array.stub.php
+++ b/ext/spl/spl_array.stub.php
@@ -2,6 +2,8 @@
 
 /** @generate-function-entries */
 
+namespace {
+
 class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Countable
 {
     public function __construct(array|object $array = [], int $flags = 0, string $iteratorClass = ArrayIterator::class) {}
@@ -246,3 +248,41 @@ class RecursiveArrayIterator extends ArrayIterator implements RecursiveIterator
     /** @return RecursiveArrayIterator|null */
     public function getChildren() {}
 }
+
+} // namespace
+
+namespace Spl {
+
+final class ForwardArrayIterator
+    implements \Countable, \Iterator
+{
+    public function __construct(array $array) {}
+
+    public function count(): int {}
+    public function rewind(): void {}
+    public function valid(): bool {}
+    public function key(): int|string {}
+
+    /** @return mixed */
+    public function current() {}
+
+    public function next(): void {}
+}
+
+final class ReverseArrayIterator
+    implements \Countable, \Iterator
+{
+    public function __construct(array $array) {}
+
+    public function count(): int {}
+    public function rewind(): void {}
+    public function valid(): bool {}
+    public function key(): int|string {}
+
+    /** @return mixed */
+    public function current() {}
+
+    public function next(): void {}
+}
+
+} // namespace Spl

--- a/ext/spl/spl_array_arginfo.h
+++ b/ext/spl/spl_array_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: da85db1e5e985ddbefaf38598133e3cba46475f2 */
+ * Stub hash: 6ad79bc9054f23420d8e522eaa58d045e22df920 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ArrayObject___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_MASK(0, array, MAY_BE_ARRAY|MAY_BE_OBJECT, "[]")
@@ -140,6 +140,40 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_RecursiveArrayIterator_getChildren arginfo_class_ArrayObject_getArrayCopy
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Spl_ForwardArrayIterator___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Spl_ForwardArrayIterator_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Spl_ForwardArrayIterator_rewind, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Spl_ForwardArrayIterator_valid, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Spl_ForwardArrayIterator_key, 0, 0, MAY_BE_LONG|MAY_BE_STRING)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Spl_ForwardArrayIterator_current arginfo_class_ArrayObject_getArrayCopy
+
+#define arginfo_class_Spl_ForwardArrayIterator_next arginfo_class_Spl_ForwardArrayIterator_rewind
+
+#define arginfo_class_Spl_ReverseArrayIterator___construct arginfo_class_Spl_ForwardArrayIterator___construct
+
+#define arginfo_class_Spl_ReverseArrayIterator_count arginfo_class_Spl_ForwardArrayIterator_count
+
+#define arginfo_class_Spl_ReverseArrayIterator_rewind arginfo_class_Spl_ForwardArrayIterator_rewind
+
+#define arginfo_class_Spl_ReverseArrayIterator_valid arginfo_class_Spl_ForwardArrayIterator_valid
+
+#define arginfo_class_Spl_ReverseArrayIterator_key arginfo_class_Spl_ForwardArrayIterator_key
+
+#define arginfo_class_Spl_ReverseArrayIterator_current arginfo_class_ArrayObject_getArrayCopy
+
+#define arginfo_class_Spl_ReverseArrayIterator_next arginfo_class_Spl_ForwardArrayIterator_rewind
+
 
 ZEND_METHOD(ArrayObject, __construct);
 ZEND_METHOD(ArrayObject, offsetExists);
@@ -175,6 +209,20 @@ ZEND_METHOD(ArrayIterator, valid);
 ZEND_METHOD(ArrayIterator, seek);
 ZEND_METHOD(RecursiveArrayIterator, hasChildren);
 ZEND_METHOD(RecursiveArrayIterator, getChildren);
+ZEND_METHOD(Spl_ForwardArrayIterator, __construct);
+ZEND_METHOD(Spl_ForwardArrayIterator, count);
+ZEND_METHOD(Spl_ForwardArrayIterator, rewind);
+ZEND_METHOD(Spl_ForwardArrayIterator, valid);
+ZEND_METHOD(Spl_ForwardArrayIterator, key);
+ZEND_METHOD(Spl_ForwardArrayIterator, current);
+ZEND_METHOD(Spl_ForwardArrayIterator, next);
+ZEND_METHOD(Spl_ReverseArrayIterator, __construct);
+ZEND_METHOD(Spl_ReverseArrayIterator, count);
+ZEND_METHOD(Spl_ReverseArrayIterator, rewind);
+ZEND_METHOD(Spl_ReverseArrayIterator, valid);
+ZEND_METHOD(Spl_ReverseArrayIterator, key);
+ZEND_METHOD(Spl_ReverseArrayIterator, current);
+ZEND_METHOD(Spl_ReverseArrayIterator, next);
 
 
 static const zend_function_entry class_ArrayObject_methods[] = {
@@ -242,5 +290,29 @@ static const zend_function_entry class_ArrayIterator_methods[] = {
 static const zend_function_entry class_RecursiveArrayIterator_methods[] = {
 	ZEND_ME(RecursiveArrayIterator, hasChildren, arginfo_class_RecursiveArrayIterator_hasChildren, ZEND_ACC_PUBLIC)
 	ZEND_ME(RecursiveArrayIterator, getChildren, arginfo_class_RecursiveArrayIterator_getChildren, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Spl_ForwardArrayIterator_methods[] = {
+	ZEND_ME(Spl_ForwardArrayIterator, __construct, arginfo_class_Spl_ForwardArrayIterator___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ForwardArrayIterator, count, arginfo_class_Spl_ForwardArrayIterator_count, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ForwardArrayIterator, rewind, arginfo_class_Spl_ForwardArrayIterator_rewind, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ForwardArrayIterator, valid, arginfo_class_Spl_ForwardArrayIterator_valid, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ForwardArrayIterator, key, arginfo_class_Spl_ForwardArrayIterator_key, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ForwardArrayIterator, current, arginfo_class_Spl_ForwardArrayIterator_current, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ForwardArrayIterator, next, arginfo_class_Spl_ForwardArrayIterator_next, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Spl_ReverseArrayIterator_methods[] = {
+	ZEND_ME(Spl_ReverseArrayIterator, __construct, arginfo_class_Spl_ReverseArrayIterator___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ReverseArrayIterator, count, arginfo_class_Spl_ReverseArrayIterator_count, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ReverseArrayIterator, rewind, arginfo_class_Spl_ReverseArrayIterator_rewind, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ReverseArrayIterator, valid, arginfo_class_Spl_ReverseArrayIterator_valid, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ReverseArrayIterator, key, arginfo_class_Spl_ReverseArrayIterator_key, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ReverseArrayIterator, current, arginfo_class_Spl_ReverseArrayIterator_current, ZEND_ACC_PUBLIC)
+	ZEND_ME(Spl_ReverseArrayIterator, next, arginfo_class_Spl_ReverseArrayIterator_next, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/ext/spl/tests/SplForwardArrayIterator/countable.phpt
+++ b/ext/spl/tests/SplForwardArrayIterator/countable.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Spl\ForwardArrayIterator: Countable
+--FILE--
+<?php
+
+$it = new Spl\ForwardArrayIterator([]);
+
+echo 'Countable? ', ($it instanceof Countable ? 'yes' : 'no'), "\n";
+echo 'Count: ', count($it), "\n";
+
+$it = new Spl\ForwardArrayIterator([1, 3]);
+echo 'Count: ', count($it), "\n";
+
+?>
+--EXPECTF--
+Countable? yes
+Count: 0
+Count: 2
+

--- a/ext/spl/tests/SplForwardArrayIterator/final.phpt
+++ b/ext/spl/tests/SplForwardArrayIterator/final.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Spl\ForwardArrayIterator: is final
+--FILE--
+<?php
+
+$it = new Spl\ForwardArrayIterator([]);
+
+echo 'Is final? ', (new ReflectionClass($it))->isFinal() ? 'yes' : 'no', "\n";
+
+eval('class OopsIterator extends Spl\ForwardArrayIterator {}');
+
+?>
+--EXPECTF--
+Is final? yes
+
+Fatal error: Class OopsIterator may not inherit from final class (Spl\ForwardArrayIterator) in %s(%d) : eval()'d code on line %d

--- a/ext/spl/tests/SplForwardArrayIterator/iterator_001.phpt
+++ b/ext/spl/tests/SplForwardArrayIterator/iterator_001.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Spl\ForwardArrayIterator: Iterator interface (empty)
+--FILE--
+<?php
+
+$ht = []; 
+
+$it = new Spl\ForwardArrayIterator($ht);
+
+var_dump($it);
+foreach ($it as $key => $value) {
+    var_export([$key => $value]);
+    echo "\n";
+}
+var_dump($it);
+
+echo "\nagain, manually this time\n\n";
+
+$it->rewind();
+var_dump($it);
+while ($it->valid()) {
+    var_export([$it->key() => $it->current()]);
+    echo "\n";
+}
+var_dump($it);
+
+?>
+--EXPECTF--
+object(Spl\ForwardArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(0) {
+  }
+  ["offset"]=>
+  int(0)
+}
+object(Spl\ForwardArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(0) {
+  }
+  ["offset"]=>
+  int(0)
+}
+
+again, manually this time
+
+object(Spl\ForwardArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(0) {
+  }
+  ["offset"]=>
+  int(0)
+}
+object(Spl\ForwardArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(0) {
+  }
+  ["offset"]=>
+  int(0)
+}

--- a/ext/spl/tests/SplForwardArrayIterator/iterator_002.phpt
+++ b/ext/spl/tests/SplForwardArrayIterator/iterator_002.phpt
@@ -1,0 +1,102 @@
+--TEST--
+Spl\ForwardArrayIterator: Iterator interface (not-empty)
+--FILE--
+<?php
+
+$ht = [1, 3, 5]; 
+
+$it = new Spl\ForwardArrayIterator($ht);
+
+var_dump($it);
+foreach ($it as $key => $value) {
+    var_export([$key => $value]);
+    echo "\n";
+}
+var_dump($it);
+
+echo "\nagain, manually this time\n\n";
+
+$it->rewind();
+var_dump($it);
+while ($it->valid()) {
+    var_export([$it->key() => $it->current()]);
+    echo "\n";
+    $it->next();
+}
+var_dump($it);
+
+?>
+--EXPECTF--
+object(Spl\ForwardArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(3)
+    [2]=>
+    int(5)
+  }
+  ["offset"]=>
+  int(0)
+}
+array (
+  0 => 1,
+)
+array (
+  1 => 3,
+)
+array (
+  2 => 5,
+)
+object(Spl\ForwardArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(3)
+    [2]=>
+    int(5)
+  }
+  ["offset"]=>
+  int(3)
+}
+
+again, manually this time
+
+object(Spl\ForwardArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(3)
+    [2]=>
+    int(5)
+  }
+  ["offset"]=>
+  int(0)
+}
+array (
+  0 => 1,
+)
+array (
+  1 => 3,
+)
+array (
+  2 => 5,
+)
+object(Spl\ForwardArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(3)
+    [2]=>
+    int(5)
+  }
+  ["offset"]=>
+  int(3)
+}

--- a/ext/spl/tests/SplForwardArrayIterator/iterator_003.phpt
+++ b/ext/spl/tests/SplForwardArrayIterator/iterator_003.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Spl\ForwardArrayIterator: Iterator invalid states
+--FILE--
+<?php
+
+$ht = [1];
+
+$it = new Spl\ForwardArrayIterator($ht);
+$it->rewind();
+$it->next();
+
+assert(!$it->valid());
+try {
+    $it->current();
+} catch (Throwable $ex) {
+    echo "Caught current.\n";
+}
+
+try {
+    $it->key();
+} catch (Throwable $ex) {
+    echo "Caught key.\n";
+}
+
+try {
+    $it->next();
+} catch (Throwable $ex) {
+    echo "Caught next.\n";
+}
+
+?>
+--EXPECTF--
+Caught current.
+Caught key.
+Caught next.

--- a/ext/spl/tests/SplForwardArrayIterator/refcount_001.phpt
+++ b/ext/spl/tests/SplForwardArrayIterator/refcount_001.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Spl\ForwardArrayIterator: protected from changes
+--FILE--
+<?php
+
+$ht = [1];
+
+$it = new Spl\ForwardArrayIterator($ht);
+
+\array_pop($ht);
+var_export($ht);
+echo "\n";
+
+echo 'Count of iterator: ', count($it), "\n";
+
+foreach ($it as $key => $value) {
+    var_export([$key => $value]);
+    echo "\n";
+}
+
+?>
+--EXPECTF--
+array (
+)
+Count of iterator: 1
+array (
+  0 => 1,
+)
+

--- a/ext/spl/tests/SplReverseArrayIterator/countable.phpt
+++ b/ext/spl/tests/SplReverseArrayIterator/countable.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Spl\ReverseArrayIterator: Countable
+--FILE--
+<?php
+
+$it = new Spl\ReverseArrayIterator([]);
+
+echo 'Countable? ', ($it instanceof Countable ? 'yes' : 'no'), "\n";
+echo 'Count: ', count($it), "\n";
+
+$it = new Spl\ReverseArrayIterator([1, 3]);
+echo 'Count: ', count($it), "\n";
+
+?>
+--EXPECTF--
+Countable? yes
+Count: 0
+Count: 2
+

--- a/ext/spl/tests/SplReverseArrayIterator/final.phpt
+++ b/ext/spl/tests/SplReverseArrayIterator/final.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Spl\ReverseArrayIterator: is final
+--FILE--
+<?php
+
+$it = new Spl\ReverseArrayIterator([]);
+
+echo 'Is final? ', (new ReflectionClass($it))->isFinal() ? 'yes' : 'no', "\n";
+
+eval('class OopsIterator extends Spl\ReverseArrayIterator {}');
+
+?>
+--EXPECTF--
+Is final? yes
+
+Fatal error: Class OopsIterator may not inherit from final class (Spl\ReverseArrayIterator) in %s(%d) : eval()'d code on line %d

--- a/ext/spl/tests/SplReverseArrayIterator/iterator_001.phpt
+++ b/ext/spl/tests/SplReverseArrayIterator/iterator_001.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Spl\ReverseArrayIterator: Iterator interface (empty)
+--FILE--
+<?php
+
+$ht = []; 
+
+$it = new Spl\ReverseArrayIterator($ht);
+
+var_dump($it);
+foreach ($it as $key => $value) {
+    var_export([$key => $value]);
+    echo "\n";
+}
+var_dump($it);
+
+echo "\nagain, manually this time\n\n";
+
+$it->rewind();
+var_dump($it);
+while ($it->valid()) {
+    var_export([$it->key() => $it->current()]);
+    echo "\n";
+}
+var_dump($it);
+
+?>
+--EXPECTF--
+object(Spl\ReverseArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(0) {
+  }
+  ["offset"]=>
+  int(0)
+}
+object(Spl\ReverseArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(0) {
+  }
+  ["offset"]=>
+  int(0)
+}
+
+again, manually this time
+
+object(Spl\ReverseArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(0) {
+  }
+  ["offset"]=>
+  int(0)
+}
+object(Spl\ReverseArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(0) {
+  }
+  ["offset"]=>
+  int(0)
+}

--- a/ext/spl/tests/SplReverseArrayIterator/iterator_002.phpt
+++ b/ext/spl/tests/SplReverseArrayIterator/iterator_002.phpt
@@ -1,0 +1,102 @@
+--TEST--
+Spl\ReverseArrayIterator: Iterator interface (not-empty)
+--FILE--
+<?php
+
+$ht = [1, 3, 5]; 
+
+$it = new Spl\ReverseArrayIterator($ht);
+
+var_dump($it);
+foreach ($it as $key => $value) {
+    var_export([$key => $value]);
+    echo "\n";
+}
+var_dump($it);
+
+echo "\nagain, manually this time\n\n";
+
+$it->rewind();
+var_dump($it);
+while ($it->valid()) {
+    var_export([$it->key() => $it->current()]);
+    echo "\n";
+    $it->next();
+}
+var_dump($it);
+
+?>
+--EXPECTF--
+object(Spl\ReverseArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(3)
+    [2]=>
+    int(5)
+  }
+  ["offset"]=>
+  int(2)
+}
+array (
+  2 => 5,
+)
+array (
+  1 => 3,
+)
+array (
+  0 => 1,
+)
+object(Spl\ReverseArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(3)
+    [2]=>
+    int(5)
+  }
+  ["offset"]=>
+  int(3)
+}
+
+again, manually this time
+
+object(Spl\ReverseArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(3)
+    [2]=>
+    int(5)
+  }
+  ["offset"]=>
+  int(2)
+}
+array (
+  2 => 5,
+)
+array (
+  1 => 3,
+)
+array (
+  0 => 1,
+)
+object(Spl\ReverseArrayIterator)#%d (2) {
+  ["inner"]=>
+  array(3) {
+    [0]=>
+    int(1)
+    [1]=>
+    int(3)
+    [2]=>
+    int(5)
+  }
+  ["offset"]=>
+  int(3)
+}

--- a/ext/spl/tests/SplReverseArrayIterator/iterator_003.phpt
+++ b/ext/spl/tests/SplReverseArrayIterator/iterator_003.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Spl\ReverseArrayIterator: Iterator invalid states
+--FILE--
+<?php
+
+$ht = [1];
+
+$it = new Spl\ReverseArrayIterator($ht);
+$it->rewind();
+$it->next();
+
+assert(!$it->valid());
+try {
+    $it->current();
+} catch (Throwable $ex) {
+    echo "Caught current.\n";
+}
+
+try {
+    $it->key();
+} catch (Throwable $ex) {
+    echo "Caught key.\n";
+}
+
+try {
+    $it->next();
+} catch (Throwable $ex) {
+    echo "Caught next.\n";
+}
+
+?>
+--EXPECTF--
+Caught current.
+Caught key.
+Caught next.

--- a/ext/spl/tests/SplReverseArrayIterator/refcount_001.phpt
+++ b/ext/spl/tests/SplReverseArrayIterator/refcount_001.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Spl\ReverseArrayIterator: protected from changes
+--FILE--
+<?php
+
+$ht = [1];
+
+$it = new Spl\ReverseArrayIterator($ht);
+
+\array_pop($ht);
+var_export($ht);
+echo "\n";
+
+echo 'Count of iterator: ', count($it), "\n";
+
+foreach ($it as $key => $value) {
+    var_export([$key => $value]);
+    echo "\n";
+}
+
+?>
+--EXPECTF--
+array (
+)
+Count of iterator: 1
+array (
+  0 => 1,
+)
+


### PR DESCRIPTION
## Spl\ReverseArrayIterator

`Spl\ReverseArrayIterator` iterates over the array in reverse order, preserving keys.

```php
$array = [ 
    "one" => 1,
    "two" => 2,
    "three" => 3,
];

$iterator = new Spl\ReverseArrayIterator($array);
foreach ($iterator as $key => $current) {
    echo "[{$key} => {$current}]\n";
}
/* outputs:
[three => 3]
[two => 2]
[one => 1]
*/
```

## Spl\ForwardArrayIterator

ForwardArrayIterator is a simple array iterator which does not dup the array (though if the user modifies it after making an iterator then normal copy-on-write will apply and make a copy then). It iterates over the array in order. The API is intentionally very small. In contrast, `ArrayIterator` has a large API which requires it to almost always duplicate the array.

`Spl\ForwardArrayIterator` is intended to replace many usages of `new \ArrayIterator($array)` where iterating over the array in an iterator form is the intended use case. It is not intended to replace other usages, such as `ArrayIterator::sort`.

```php
$array = [ 
    "one" => 1,
    "two" => 2,
    "three" => 3,
];

$iterator = new Spl\ForwardArrayIterator($array);
foreach ($iterator as $key => $current) {
    echo "[{$key} => {$current}]\n";
}
/* outputs:
[one => 1]
[two => 2]
[three => 3]
*/
```

For such simple cases I recommend using the `$array` directly, but sometimes an iterator is needed for generic code, such as:

```php

function reduce_values(iterable $of, callable $by)
{
    // Uses Iterator API to avoid re-implementing it for arrays 
    $iterator = to_iterator($of);
    $iterator->rewind();
    if (!$iterator->valid()) {
        throw new \ValueException(
            __FUNCTION__ . " requires an iterable that contains at least one value"
        );
    }
    $result = $iterator->current();
    for ($iterator->next(); $iterator->valid(); $iterator->next()) {
        $result = $by($result, $iterator->current());
    }
    return $result;
}

// to_iterator may look something like this:
function to_iterator(iterable $subject): \Iterator
{
    if (\is_array($subject)) {
        /* Use \Spl\ForwardArrayIterator over \ArrayIterator so
         * so that we don't duplicate the $subject just to
         * construct an iterator.
         */
        return new \Spl\ForwardArrayIterator($subject);
    } elseif ($subject instanceof \Iterator) {
        return $subject;
    } else /* if ($subject instanceof \IteratorAggregate) */ {
        /* Technically IteratorAggregate::getIterator doesn't
         * have to return an Iterator, just any Traversable.
         * Protect it with a recursive call.
         */
        return namespace\to_iterator($subject->getIterator());
    }
}
```

## Status

  - [x] Spl\ForwardArrayIterator
      - [x] Countable
      - [x] Iterator
      - [x] Forbid unserialization and serialization
      - [x] Tests
  - [x] Spl\ReverseArrayIterator
      - [x] Countable
      - [x] Iterator
      - [x] Forbid unserialization and serialization
      - [x] Tests