### PR TITLE
Refactor and clarify PDO's handlers

### DIFF
--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -578,7 +578,7 @@ PHP_METHOD(PDO, prepare)
 /* }}} */
 
 
-static zend_bool pdo_is_in_transaction(pdo_dbh_t *dbh) {
+static bool pdo_is_in_transaction(pdo_dbh_t *dbh) {
 	if (dbh->methods->in_transaction) {
 		return dbh->methods->in_transaction(dbh);
 	}
@@ -606,7 +606,7 @@ PHP_METHOD(PDO, beginTransaction)
 	}
 
 	if (dbh->methods->begin(dbh)) {
-		dbh->in_txn = 1;
+		dbh->in_txn = true;
 		RETURN_TRUE;
 	}
 
@@ -630,7 +630,7 @@ PHP_METHOD(PDO, commit)
 	}
 
 	if (dbh->methods->commit(dbh)) {
-		dbh->in_txn = 0;
+		dbh->in_txn = false;
 		RETURN_TRUE;
 	}
 
@@ -654,7 +654,7 @@ PHP_METHOD(PDO, rollBack)
 	}
 
 	if (dbh->methods->rollback(dbh)) {
-		dbh->in_txn = 0;
+		dbh->in_txn = false;
 		RETURN_TRUE;
 	}
 
@@ -1462,7 +1462,7 @@ static void pdo_dbh_free_storage(zend_object *std)
 	pdo_dbh_t *dbh = php_pdo_dbh_fetch_inner(std);
 	if (dbh->in_txn && dbh->methods && dbh->methods->rollback) {
 		dbh->methods->rollback(dbh);
-		dbh->in_txn = 0;
+		dbh->in_txn = false;
 	}
 
 	if (dbh->is_persistent && dbh->methods && dbh->methods->persistent_shutdown) {

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -600,8 +600,7 @@ PHP_METHOD(PDO, beginTransaction)
 	}
 
 	if (!dbh->methods->begin) {
-		/* TODO: this should be an exception; see the auto-commit mode
-		 * comments below */
+		/* Throw an exception when the driver does not support transactions */
 		zend_throw_exception_ex(php_pdo_get_exception(), 0, "This driver doesn't support transactions");
 		RETURN_THROWS();
 	}
@@ -904,6 +903,8 @@ PHP_METHOD(PDO, getAttribute)
 			RETURN_FALSE;
 
 		default:
+			/* No error state, just return as the return_value has been assigned
+			 * by the get_attribute handler */
 			return;
 	}
 }

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -148,21 +148,20 @@ PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt) /* {{{ */
 
 	ZVAL_UNDEF(&info);
 	if (dbh->methods->fetch_err) {
+		zval *item;
 		array_init(&info);
 
 		add_next_index_string(&info, *pdo_err);
 
-		if (dbh->methods->fetch_err(dbh, stmt, &info)) {
-			zval *item;
+		dbh->methods->fetch_err(dbh, stmt, &info);
 
-			if ((item = zend_hash_index_find(Z_ARRVAL(info), 1)) != NULL
-					&& Z_TYPE_P(item) == IS_LONG) {
-				native_code = Z_LVAL_P(item);
-			}
+		if ((item = zend_hash_index_find(Z_ARRVAL(info), 1)) != NULL
+				&& Z_TYPE_P(item) == IS_LONG) {
+			native_code = Z_LVAL_P(item);
+		}
 
-			if ((item = zend_hash_index_find(Z_ARRVAL(info), 2)) != NULL) {
-				supp = estrndup(Z_STRVAL_P(item), Z_STRLEN_P(item));
-			}
+		if ((item = zend_hash_index_find(Z_ARRVAL(info), 2)) != NULL) {
+			supp = estrndup(Z_STRVAL_P(item), Z_STRLEN_P(item));
 		}
 	}
 

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -2018,7 +2018,7 @@ PHP_METHOD(PDOStatement, getIterator)
 /* {{{ overloaded handlers for PDOStatement class */
 static zval *dbstmt_prop_write(zend_object *object, zend_string *name, zval *value, void **cache_slot)
 {
-	if (strcmp(ZSTR_VAL(name), "queryString") == 0) {
+	if (zend_string_equals_literal(name, "queryString")) {
 		zend_throw_error(NULL, "Property queryString is read only");
 		return value;
 	} else {
@@ -2028,7 +2028,7 @@ static zval *dbstmt_prop_write(zend_object *object, zend_string *name, zval *val
 
 static void dbstmt_prop_delete(zend_object *object, zend_string *name, void **cache_slot)
 {
-	if (strcmp(ZSTR_VAL(name), "queryString") == 0) {
+	if (zend_string_equals_literal(name, "queryString")) {
 		zend_throw_error(NULL, "Property queryString is read only");
 	} else {
 		zend_std_unset_property(object, name, cache_slot);
@@ -2282,8 +2282,7 @@ static zval *row_prop_read(zend_object *object, zend_string *name, int type, voi
 					return rv;
 				}
 			}
-			if (strcmp(ZSTR_VAL(name), "queryString") == 0) {
-				//zval_ptr_dtor(rv);
+			if (zend_string_equals_literal(name, "queryString")) {
 				return zend_std_read_property(&stmt->std, name, type, cache_slot, rv);
 			}
 		}
@@ -2324,8 +2323,7 @@ static zval *row_dim_read(zend_object *object, zval *member, int type, zval *rv)
 					return rv;
 				}
 			}
-			if (strcmp(Z_STRVAL_P(member), "queryString") == 0) {
-				//zval_ptr_dtor(rv);
+			if (zend_string_equals_literal(Z_STR_P(member), "queryString")) {
 				return zend_std_read_property(&stmt->std, Z_STR_P(member), type, NULL, rv);
 			}
 		}

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -228,8 +228,9 @@ typedef struct {
 /* close or otherwise disconnect the database */
 typedef void (*pdo_dbh_close_func)(pdo_dbh_t *dbh);
 
-/* prepare a statement and stash driver specific portion into stmt */
-typedef int (*pdo_dbh_prepare_func)(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options);
+/* prepare a statement and stash driver specific portion into stmt
+ * return true on success, false otherwise */
+typedef bool (*pdo_dbh_prepare_func)(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options);
 
 /* execute a statement (that does not return a result set) */
 typedef zend_long (*pdo_dbh_do_func)(pdo_dbh_t *dbh, const char *sql, size_t sql_len);

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -265,7 +265,7 @@ typedef int (*pdo_dbh_get_attr_func)(pdo_dbh_t *dbh, zend_long attr, zval *val);
 /* checking/pinging persistent connections; return SUCCESS if the connection
  * is still alive and ready to be used, FAILURE otherwise.
  * You may set this handler to NULL, which is equivalent to returning SUCCESS. */
-typedef int (*pdo_dbh_check_liveness_func)(pdo_dbh_t *dbh);
+typedef zend_result (*pdo_dbh_check_liveness_func)(pdo_dbh_t *dbh);
 
 /* called at request end for each persistent dbh; this gives the driver
  * the opportunity to safely release resources that only have per-request

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -226,7 +226,7 @@ typedef struct {
 /* {{{ methods for a database handle */
 
 /* close or otherwise disconnect the database */
-typedef int (*pdo_dbh_close_func)(pdo_dbh_t *dbh);
+typedef void (*pdo_dbh_close_func)(pdo_dbh_t *dbh);
 
 /* prepare a statement and stash driver specific portion into stmt */
 typedef int (*pdo_dbh_prepare_func)(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options);

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -237,8 +237,9 @@ typedef zend_long (*pdo_dbh_do_func)(pdo_dbh_t *dbh, const char *sql, size_t sql
 /* quote a string */
 typedef int (*pdo_dbh_quote_func)(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype);
 
-/* transaction related */
-typedef int (*pdo_dbh_txn_func)(pdo_dbh_t *dbh);
+/* transaction related (beingTransaction(), commit, rollBack, inTransaction)
+ * return true in case of success, false otherwise */
+typedef bool (*pdo_dbh_txn_func)(pdo_dbh_t *dbh);
 
 /* setting of attributes */
 typedef int (*pdo_dbh_set_attr_func)(pdo_dbh_t *dbh, zend_long attr, zval *val);
@@ -305,7 +306,8 @@ struct pdo_dbh_methods {
 	pdo_dbh_check_liveness_func	check_liveness;
 	pdo_dbh_get_driver_methods_func get_driver_methods;
 	pdo_dbh_request_shutdown	persistent_shutdown;
-	pdo_dbh_txn_func		in_transaction;
+	pdo_dbh_txn_func		in_transaction; /* if defined to NULL, PDO will use
+					                 * its internal transaction tracking state */
 	pdo_dbh_get_gc_func		get_gc;
 };
 
@@ -446,7 +448,7 @@ struct _pdo_dbh_t {
 	unsigned alloc_own_columns:1;
 
 	/* if true, commit or rollBack is allowed to be called */
-	unsigned in_txn:1;
+	bool in_txn:1;
 
 	/* max length a single character can become after correct quoting */
 	unsigned max_escaped_char_length:3;

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -241,8 +241,9 @@ typedef int (*pdo_dbh_quote_func)(pdo_dbh_t *dbh, const char *unquoted, size_t u
  * return true in case of success, false otherwise */
 typedef bool (*pdo_dbh_txn_func)(pdo_dbh_t *dbh);
 
-/* setting of attributes */
-typedef int (*pdo_dbh_set_attr_func)(pdo_dbh_t *dbh, zend_long attr, zval *val);
+/* setting of attributes
+ * Return true on success and false in case of failure */
+typedef bool (*pdo_dbh_set_attr_func)(pdo_dbh_t *dbh, zend_long attr, zval *val);
 
 /* return last insert id.  NULL indicates error condition, otherwise, the return value
  * MUST be an emalloc'd NULL terminated string. */

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -262,9 +262,9 @@ typedef bool (*pdo_dbh_fetch_error_func)(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval 
 
 /* fetching of attributes
  * There are 3 return states:
- * ¤ -1 for errors while retrieving a valid attribute
- * ¤ 0 for attempting to retrieve an attribute which is not supported by the driver
- * ¤ any other value for success, *val must be set to the attribute value */
+ * * -1 for errors while retrieving a valid attribute
+ * * 0 for attempting to retrieve an attribute which is not supported by the driver
+ * * any other value for success, *val must be set to the attribute value */
 typedef int (*pdo_dbh_get_attr_func)(pdo_dbh_t *dbh, zend_long attr, zval *val);
 
 /* checking/pinging persistent connections; return SUCCESS if the connection

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -250,15 +250,16 @@ typedef bool (*pdo_dbh_set_attr_func)(pdo_dbh_t *dbh, zend_long attr, zval *val)
  * MUST be an emalloc'd NULL terminated string. */
 typedef char *(*pdo_dbh_last_id_func)(pdo_dbh_t *dbh, const char *name, size_t *len);
 
-/* fetch error information.  if stmt is not null, fetch information pertaining
- * to the statement, otherwise fetch global error information.
- * Return true if there messages, otherwise return false.
+/* Fetch error information.
+ * If stmt is not null, fetch information pertaining to the statement,
+ * otherwise fetch global error information.
+ * info is an initialized PHP array, if there are no messages leave it empty.
  * The driver should add the following information to the array "info" in this order:
  * - native error code
  * - string representation of the error code ... any other optional driver
  *   specific data ...
  * PDO takes care of normalizing the array. */
-typedef bool (*pdo_dbh_fetch_error_func)(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info);
+typedef void (*pdo_dbh_fetch_error_func)(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info);
 
 /* fetching of attributes
  * There are 3 return states:

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -235,7 +235,7 @@ typedef int (*pdo_dbh_prepare_func)(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t
 typedef zend_long (*pdo_dbh_do_func)(pdo_dbh_t *dbh, const char *sql, size_t sql_len);
 
 /* quote a string */
-typedef int (*pdo_dbh_quote_func)(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype);
+typedef bool (*pdo_dbh_quote_func)(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype);
 
 /* transaction related (beingTransaction(), commit, rollBack, inTransaction)
  * return true in case of success, false otherwise */

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -255,7 +255,11 @@ typedef char *(*pdo_dbh_last_id_func)(pdo_dbh_t *dbh, const char *name, size_t *
  *   specific data ...  */
 typedef	int (*pdo_dbh_fetch_error_func)(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info);
 
-/* fetching of attributes */
+/* fetching of attributes
+ * There are 3 return states:
+ * ¤ -1 for errors while retrieving a valid attribute
+ * ¤ 0 for attempting to retrieve an attribute which is not supported by the driver
+ * ¤ any other value for success, *val must be set to the attribute value */
 typedef int (*pdo_dbh_get_attr_func)(pdo_dbh_t *dbh, zend_long attr, zval *val);
 
 /* checking/pinging persistent connections; return SUCCESS if the connection

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -251,12 +251,14 @@ typedef bool (*pdo_dbh_set_attr_func)(pdo_dbh_t *dbh, zend_long attr, zval *val)
 typedef char *(*pdo_dbh_last_id_func)(pdo_dbh_t *dbh, const char *name, size_t *len);
 
 /* fetch error information.  if stmt is not null, fetch information pertaining
- * to the statement, otherwise fetch global error information.  The driver
- * should add the following information to the array "info" in this order:
+ * to the statement, otherwise fetch global error information.
+ * Return true if there messages, otherwise return false.
+ * The driver should add the following information to the array "info" in this order:
  * - native error code
  * - string representation of the error code ... any other optional driver
- *   specific data ...  */
-typedef	int (*pdo_dbh_fetch_error_func)(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info);
+ *   specific data ...
+ * PDO takes care of normalizing the array. */
+typedef bool (*pdo_dbh_fetch_error_func)(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info);
 
 /* fetching of attributes
  * There are 3 return states:

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -239,7 +239,7 @@ typedef zend_long (*pdo_dbh_do_func)(pdo_dbh_t *dbh, const char *sql, size_t sql
 typedef bool (*pdo_dbh_quote_func)(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype);
 
 /* transaction related (beingTransaction(), commit, rollBack, inTransaction)
- * return true in case of success, false otherwise */
+ * Return true if currently inside a transaction, false otherwise. */
 typedef bool (*pdo_dbh_txn_func)(pdo_dbh_t *dbh);
 
 /* setting of attributes
@@ -310,8 +310,8 @@ struct pdo_dbh_methods {
 	pdo_dbh_check_liveness_func	check_liveness;
 	pdo_dbh_get_driver_methods_func get_driver_methods;
 	pdo_dbh_request_shutdown	persistent_shutdown;
-	pdo_dbh_txn_func		in_transaction; /* if defined to NULL, PDO will use
-					                 * its internal transaction tracking state */
+	/* if defined to NULL, PDO will use its internal transaction tracking state */
+	pdo_dbh_txn_func		in_transaction;
 	pdo_dbh_get_gc_func		get_gc;
 };
 

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -145,7 +145,7 @@ static zend_long dblib_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_l
 	return DBCOUNT(H->link);
 }
 
-static int dblib_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype)
+static bool dblib_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 	zend_bool use_national_character_set = 0;
@@ -192,7 +192,7 @@ static int dblib_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unqu
 
 	*q = 0;
 
-	return 1;
+	return true;
 }
 
 static bool pdo_dblib_transaction_cmd(const char *cmd, pdo_dbh_t *dbh)

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -74,7 +74,7 @@ static int dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 }
 
 
-static int dblib_handle_closer(pdo_dbh_t *dbh)
+static void dblib_handle_closer(pdo_dbh_t *dbh)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 
@@ -91,7 +91,6 @@ static int dblib_handle_closer(pdo_dbh_t *dbh)
 		pefree(H, dbh->is_persistent);
 		dbh->driver_data = NULL;
 	}
-	return 0;
 }
 
 static int dblib_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -195,32 +195,32 @@ static int dblib_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unqu
 	return 1;
 }
 
-static int pdo_dblib_transaction_cmd(const char *cmd, pdo_dbh_t *dbh)
+static bool pdo_dblib_transaction_cmd(const char *cmd, pdo_dbh_t *dbh)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 
 	if (FAIL == dbcmd(H->link, cmd)) {
-		return 0;
+		return false;
 	}
 
 	if (FAIL == dbsqlexec(H->link)) {
-		return 0;
+		return false;
 	}
 
-	return 1;
+	return true;
 }
 
-static int dblib_handle_begin(pdo_dbh_t *dbh)
+static bool dblib_handle_begin(pdo_dbh_t *dbh)
 {
 	return pdo_dblib_transaction_cmd("BEGIN TRANSACTION", dbh);
 }
 
-static int dblib_handle_commit(pdo_dbh_t *dbh)
+static bool dblib_handle_commit(pdo_dbh_t *dbh)
 {
 	return pdo_dblib_transaction_cmd("COMMIT TRANSACTION", dbh);
 }
 
-static int dblib_handle_rollback(pdo_dbh_t *dbh)
+static bool dblib_handle_rollback(pdo_dbh_t *dbh)
 {
 	return pdo_dblib_transaction_cmd("ROLLBACK TRANSACTION", dbh);
 }
@@ -417,7 +417,7 @@ static const struct pdo_dbh_methods dblib_methods = {
 	NULL, /* check liveness */
 	NULL, /* get driver methods */
 	NULL, /* request shutdown */
-	NULL, /* in transaction */
+	NULL, /* in transaction, use PDO's internal tracking mechanism */
 	NULL /* get gc */
 };
 

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -93,7 +93,7 @@ static void dblib_handle_closer(pdo_dbh_t *dbh)
 	}
 }
 
-static int dblib_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
+static bool dblib_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 	pdo_dblib_stmt *S = ecalloc(1, sizeof(*S));
@@ -105,7 +105,7 @@ static int dblib_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *s
 	S->computed_column_name_count = 0;
 	S->err.sqlstate = stmt->error_code;
 
-	return 1;
+	return true;
 }
 
 static zend_long dblib_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len)

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -269,28 +269,28 @@ char *dblib_handle_last_id(pdo_dbh_t *dbh, const char *name, size_t *len)
 	return id;
 }
 
-static int dblib_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
+static bool dblib_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 
 	switch(attr) {
 		case PDO_ATTR_DEFAULT_STR_PARAM:
 			H->assume_national_character_set_strings = zval_get_long(val) == PDO_PARAM_STR_NATL ? 1 : 0;
-			return 1;
+			return true;
 		case PDO_ATTR_TIMEOUT:
 		case PDO_DBLIB_ATTR_QUERY_TIMEOUT:
-			return SUCCEED == dbsettime(zval_get_long(val)) ? 1 : 0;
+			return SUCCEED == dbsettime(zval_get_long(val));
 		case PDO_DBLIB_ATTR_STRINGIFY_UNIQUEIDENTIFIER:
 			H->stringify_uniqueidentifier = zval_get_long(val);
-			return 1;
+			return true;
 		case PDO_DBLIB_ATTR_SKIP_EMPTY_ROWSETS:
 			H->skip_empty_rowsets = zval_is_true(val);
-			return 1;
+			return true;
 		case PDO_DBLIB_ATTR_DATETIME_CONVERT:
 			H->datetime_convert = zval_get_long(val);
-			return 1;
+			return true;
 		default:
-			return 0;
+			return false;
 	}
 }
 

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -31,7 +31,7 @@
 /* Cache of the server supported datatypes, initialized in handle_factory */
 zval* pdo_dblib_datatypes;
 
-static bool dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+static void dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 	pdo_dblib_err *einfo = &H->err;
@@ -55,7 +55,7 @@ static bool dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 
 	/* don't return anything if there's nothing to return */
 	if (msg == NULL && einfo->dberr == 0 && einfo->oserr == 0 && einfo->severity == 0) {
-		return false;
+		return;
 	}
 
 	spprintf(&message, 0, "%s [%d] (severity %d) [%s]",
@@ -69,8 +69,6 @@ static bool dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 	if (einfo->oserrstr) {
 		add_next_index_string(info, einfo->oserrstr);
 	}
-
-	return true;
 }
 
 

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -31,7 +31,7 @@
 /* Cache of the server supported datatypes, initialized in handle_factory */
 zval* pdo_dblib_datatypes;
 
-static int dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+static bool dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 	pdo_dblib_err *einfo = &H->err;
@@ -55,7 +55,7 @@ static int dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 
 	/* don't return anything if there's nothing to return */
 	if (msg == NULL && einfo->dberr == 0 && einfo->oserr == 0 && einfo->severity == 0) {
-		return 0;
+		return false;
 	}
 
 	spprintf(&message, 0, "%s [%d] (severity %d) [%s]",
@@ -70,7 +70,7 @@ static int dblib_fetch_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 		add_next_index_string(info, einfo->oserrstr);
 	}
 
-	return 1;
+	return true;
 }
 
 

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -467,7 +467,7 @@ void _firebird_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, char const *file, zend_lo
 #define RECORD_ERROR(dbh) _firebird_error(dbh, NULL, __FILE__, __LINE__)
 
 /* called by PDO to close a db handle */
-static int firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
+static void firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 {
 	pdo_firebird_db_handle *H = (pdo_firebird_db_handle *)dbh->driver_data;
 
@@ -498,8 +498,6 @@ static int firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 	}
 
 	pefree(H, dbh->is_persistent);
-
-	return 0;
 }
 /* }}} */
 

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -502,7 +502,7 @@ static void firebird_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 /* }}} */
 
 /* called by PDO to prepare an SQL query */
-static int firebird_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, /* {{{ */
+static bool firebird_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, /* {{{ */
 	pdo_stmt_t *stmt, zval *driver_options)
 {
 	pdo_firebird_db_handle *H = (pdo_firebird_db_handle *)dbh->driver_data;
@@ -566,7 +566,7 @@ static int firebird_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, /* {{{ */
 		stmt->methods = &firebird_stmt_methods;
 		stmt->supports_placeholders = PDO_PLACEHOLDER_POSITIONAL;
 
-		return 1;
+		return true;
 
 	} while (0);
 
@@ -582,7 +582,7 @@ static int firebird_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, /* {{{ */
 		efree(S);
 	}
 
-	return 0;
+	return false;
 }
 /* }}} */
 

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -651,7 +651,7 @@ free_statement:
 /* }}} */
 
 /* called by the PDO SQL parser to add quotes to values that are copied into SQL */
-static int firebird_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, /* {{{ */
+static bool firebird_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, /* {{{ */
 	char **quoted, size_t *quotedlen, enum pdo_param_type paramtype)
 {
 	int qcount = 0;
@@ -662,7 +662,7 @@ static int firebird_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t u
 		*quotedlen = 2;
 		*quoted = emalloc(*quotedlen+1);
 		strcpy(*quoted, "''");
-		return 1;
+		return true;
 	}
 
 	/* Firebird only requires single quotes to be doubled if string lengths are used */
@@ -686,7 +686,7 @@ static int firebird_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t u
 	(*quoted)[*quotedlen-1] = '\'';
 	(*quoted)[*quotedlen]   = '\0';
 
-	return 1;
+	return true;
 }
 /* }}} */
 

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -821,7 +821,7 @@ static int firebird_alloc_prepare_stmt(pdo_dbh_t *dbh, const char *sql, size_t s
 /* }}} */
 
 /* called by PDO to set a driver-specific dbh attribute */
-static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /* {{{ */
+static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /* {{{ */
 {
 	pdo_firebird_db_handle *H = (pdo_firebird_db_handle *)dbh->driver_data;
 
@@ -837,7 +837,7 @@ static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 							/* turning on auto_commit with an open transaction is illegal, because
 							   we won't know what to do with it */
 							H->last_app_error = "Cannot enable auto-commit while a transaction is already open";
-							return 0;
+							return false;
 						} else {
 							/* close the transaction */
 							if (!firebird_handle_commit(dbh)) {
@@ -849,17 +849,17 @@ static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 					dbh->auto_commit = bval;
 				}
 			}
-			return 1;
+			return true;
 
 		case PDO_ATTR_FETCH_TABLE_NAMES:
 			H->fetch_table_names = zval_get_long(val)? 1 : 0;
-			return 1;
+			return true;
 
 		case PDO_FB_ATTR_DATE_FORMAT:
 			{
 				zend_string *str = zval_try_get_string(val);
 				if (UNEXPECTED(!str)) {
-					return 0;
+					return false;
 				}
 				if (H->date_format) {
 					efree(H->date_format);
@@ -867,13 +867,13 @@ static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 				spprintf(&H->date_format, 0, "%s", ZSTR_VAL(str));
 				zend_string_release_ex(str, 0);
 			}
-			return 1;
+			return true;
 
 		case PDO_FB_ATTR_TIME_FORMAT:
 			{
 				zend_string *str = zval_try_get_string(val);
 				if (UNEXPECTED(!str)) {
-					return 0;
+					return false;
 				}
 				if (H->time_format) {
 					efree(H->time_format);
@@ -881,13 +881,13 @@ static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 				spprintf(&H->time_format, 0, "%s", ZSTR_VAL(str));
 				zend_string_release_ex(str, 0);
 			}
-			return 1;
+			return true;
 
 		case PDO_FB_ATTR_TIMESTAMP_FORMAT:
 			{
 				zend_string *str = zval_try_get_string(val);
 				if (UNEXPECTED(!str)) {
-					return 0;
+					return false;
 				}
 				if (H->timestamp_format) {
 					efree(H->timestamp_format);
@@ -895,9 +895,9 @@ static int firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 				spprintf(&H->timestamp_format, 0, "%s", ZSTR_VAL(str));
 				zend_string_release_ex(str, 0);
 			}
-			return 1;
+			return true;
 	}
-	return 0;
+	return false;
 }
 /* }}} */
 

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -968,7 +968,7 @@ static int firebird_handle_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 /* }}} */
 
 /* called by PDO to retrieve driver-specific information about an error that has occurred */
-static int pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
+static bool pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
 {
 	pdo_firebird_db_handle *H = (pdo_firebird_db_handle *)dbh->driver_data;
 	const ISC_STATUS *s = H->isc_status;
@@ -983,11 +983,13 @@ static int pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval 
 			strcpy(&buf[i++], " ");
 		}
 		add_next_index_string(info, buf);
+		return true;
 	} else if (H->last_app_error) {
 		add_next_index_long(info, -999);
 		add_next_index_string(info, const_cast(H->last_app_error));
+		return true;
 	}
-	return 1;
+	return false;
 }
 /* }}} */
 

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -968,7 +968,7 @@ static int firebird_handle_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *v
 /* }}} */
 
 /* called by PDO to retrieve driver-specific information about an error that has occurred */
-static bool pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
+static void pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
 {
 	pdo_firebird_db_handle *H = (pdo_firebird_db_handle *)dbh->driver_data;
 	const ISC_STATUS *s = H->isc_status;
@@ -983,13 +983,10 @@ static bool pdo_firebird_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval
 			strcpy(&buf[i++], " ");
 		}
 		add_next_index_string(info, buf);
-		return true;
 	} else if (H->last_app_error) {
 		add_next_index_long(info, -999);
 		add_next_index_string(info, const_cast(H->last_app_error));
-		return true;
 	}
-	return false;
 }
 /* }}} */
 

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -161,7 +161,7 @@ static void mysql_handle_closer(pdo_dbh_t *dbh)
 /* }}} */
 
 /* {{{ mysql_handle_preparer */
-static int mysql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
+static bool mysql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
 {
 	pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 	pdo_mysql_stmt *S = ecalloc(1, sizeof(pdo_mysql_stmt));
@@ -194,7 +194,7 @@ static int mysql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *s
 	} else if (ret == -1) {
 		/* failed to parse */
 		strcpy(dbh->error_code, stmt->error_code);
-		PDO_DBG_RETURN(0);
+		PDO_DBG_RETURN(false);
 	}
 
 	if (!(S->stmt = mysql_stmt_init(H->server))) {
@@ -202,7 +202,7 @@ static int mysql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *s
 		if (nsql) {
 			zend_string_release(nsql);
 		}
-		PDO_DBG_RETURN(0);
+		PDO_DBG_RETURN(false);
 	}
 
 	if (mysql_stmt_prepare(S->stmt, ZSTR_VAL(sql), ZSTR_LEN(sql))) {
@@ -217,7 +217,7 @@ static int mysql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *s
 			goto fallback;
 		}
 		pdo_mysql_error(dbh);
-		PDO_DBG_RETURN(0);
+		PDO_DBG_RETURN(false);
 	}
 	if (nsql) {
 		zend_string_release(nsql);
@@ -238,13 +238,13 @@ static int mysql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *s
 
 	S->max_length = pdo_attr_lval(driver_options, PDO_ATTR_MAX_COLUMN_LEN, 0);
 
-	PDO_DBG_RETURN(1);
+	PDO_DBG_RETURN(true);
 
 fallback:
 end:
 	stmt->supports_placeholders = PDO_PLACEHOLDER_NONE;
 
-	PDO_DBG_RETURN(1);
+	PDO_DBG_RETURN(true);
 }
 /* }}} */
 

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -520,7 +520,7 @@ static int pdo_mysql_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return_
 /* }}} */
 
 /* {{{ pdo_mysql_check_liveness */
-static int pdo_mysql_check_liveness(pdo_dbh_t *dbh)
+static zend_result pdo_mysql_check_liveness(pdo_dbh_t *dbh)
 {
 	pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -390,7 +390,7 @@ static inline int mysql_handle_autocommit(pdo_dbh_t *dbh)
 /* }}} */
 
 /* {{{ pdo_mysql_set_attribute */
-static int pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
+static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	zend_long lval = zval_get_long(val);
 	zend_bool bval = lval ? 1 : 0;
@@ -403,29 +403,29 @@ static int pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			if (dbh->auto_commit ^ bval) {
 				dbh->auto_commit = bval;
 				if (!mysql_handle_autocommit(dbh)) {
-					PDO_DBG_RETURN(0);
+					PDO_DBG_RETURN(false);
 				}
 			}
-			PDO_DBG_RETURN(1);
+			PDO_DBG_RETURN(true);
 
 		case PDO_ATTR_DEFAULT_STR_PARAM:
 			((pdo_mysql_db_handle *)dbh->driver_data)->assume_national_character_set_strings = lval == PDO_PARAM_STR_NATL;
-			PDO_DBG_RETURN(1);
+			PDO_DBG_RETURN(true);
 
 		case PDO_MYSQL_ATTR_USE_BUFFERED_QUERY:
 			/* ignore if the new value equals the old one */
 			((pdo_mysql_db_handle *)dbh->driver_data)->buffered = bval;
-			PDO_DBG_RETURN(1);
+			PDO_DBG_RETURN(true);
 
 		case PDO_MYSQL_ATTR_DIRECT_QUERY:
 		case PDO_ATTR_EMULATE_PREPARES:
 			/* ignore if the new value equals the old one */
 			((pdo_mysql_db_handle *)dbh->driver_data)->emulate_prepare = bval;
-			PDO_DBG_RETURN(1);
+			PDO_DBG_RETURN(true);
 
 		case PDO_ATTR_FETCH_TABLE_NAMES:
 			((pdo_mysql_db_handle *)dbh->driver_data)->fetch_table_names = bval;
-			PDO_DBG_RETURN(1);
+			PDO_DBG_RETURN(true);
 
 #ifndef PDO_USE_MYSQLND
 		case PDO_MYSQL_ATTR_MAX_BUFFER_SIZE:
@@ -436,12 +436,12 @@ static int pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			} else {
 				((pdo_mysql_db_handle *)dbh->driver_data)->max_buffer_size = lval;
 			}
-			PDO_DBG_RETURN(1);
+			PDO_DBG_RETURN(true);
 			break;
 #endif
 
 		default:
-			PDO_DBG_RETURN(0);
+			PDO_DBG_RETURN(false);
 	}
 }
 /* }}} */

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -341,7 +341,7 @@ static int mysql_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unqu
 /* }}} */
 
 /* {{{ mysql_handle_begin */
-static int mysql_handle_begin(pdo_dbh_t *dbh)
+static bool mysql_handle_begin(pdo_dbh_t *dbh)
 {
 	PDO_DBG_ENTER("mysql_handle_quoter");
 	PDO_DBG_INF_FMT("dbh=%p", dbh);
@@ -350,28 +350,28 @@ static int mysql_handle_begin(pdo_dbh_t *dbh)
 /* }}} */
 
 /* {{{ mysql_handle_commit */
-static int mysql_handle_commit(pdo_dbh_t *dbh)
+static bool mysql_handle_commit(pdo_dbh_t *dbh)
 {
 	PDO_DBG_ENTER("mysql_handle_commit");
 	PDO_DBG_INF_FMT("dbh=%p", dbh);
 	if (mysql_commit(((pdo_mysql_db_handle *)dbh->driver_data)->server)) {
 		pdo_mysql_error(dbh);
-		PDO_DBG_RETURN(0);
+		PDO_DBG_RETURN(false);
 	}
-	PDO_DBG_RETURN(1);
+	PDO_DBG_RETURN(true);
 }
 /* }}} */
 
 /* {{{ mysql_handle_rollback */
-static int mysql_handle_rollback(pdo_dbh_t *dbh)
+static bool mysql_handle_rollback(pdo_dbh_t *dbh)
 {
 	PDO_DBG_ENTER("mysql_handle_rollback");
 	PDO_DBG_INF_FMT("dbh=%p", dbh);
 	if (mysql_rollback(((pdo_mysql_db_handle *)dbh->driver_data)->server)) {
 		pdo_mysql_error(dbh);
-		PDO_DBG_RETURN(0);
+		PDO_DBG_RETURN(false);
 	}
-	PDO_DBG_RETURN(1);
+	PDO_DBG_RETURN(true);
 }
 /* }}} */
 
@@ -556,7 +556,7 @@ static void pdo_mysql_request_shutdown(pdo_dbh_t *dbh)
 #endif
 
 /* {{{ pdo_mysql_in_transaction */
-static int pdo_mysql_in_transaction(pdo_dbh_t *dbh)
+static bool pdo_mysql_in_transaction(pdo_dbh_t *dbh)
 {
 	pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 	PDO_DBG_ENTER("pdo_mysql_in_transaction");

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -302,7 +302,7 @@ static char *pdo_mysql_last_insert_id(pdo_dbh_t *dbh, const char *name, size_t *
 #endif
 
 /* {{{ mysql_handle_quoter */
-static int mysql_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype )
+static bool mysql_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype )
 {
 	pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 	zend_bool use_national_character_set = 0;
@@ -336,7 +336,7 @@ static int mysql_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unqu
 	(*quoted)[++*quotedlen] = '\'';
 	(*quoted)[++*quotedlen] = '\0';
 	PDO_DBG_INF_FMT("quoted=%.*s", (int)*quotedlen, *quoted);
-	PDO_DBG_RETURN(1);
+	PDO_DBG_RETURN(true);
 }
 /* }}} */
 

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -141,7 +141,7 @@ static int pdo_mysql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *in
 /* }}} */
 
 /* {{{ mysql_handle_closer */
-static int mysql_handle_closer(pdo_dbh_t *dbh)
+static void mysql_handle_closer(pdo_dbh_t *dbh)
 {
 	pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 
@@ -157,7 +157,6 @@ static int mysql_handle_closer(pdo_dbh_t *dbh)
 		pefree(H, dbh->is_persistent);
 		dbh->driver_data = NULL;
 	}
-	PDO_DBG_RETURN(0);
 }
 /* }}} */
 

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -117,7 +117,7 @@ int _pdo_mysql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int lin
 /* }}} */
 
 /* {{{ pdo_mysql_fetch_error_func */
-static int pdo_mysql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+static bool pdo_mysql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 {
 	pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 	pdo_mysql_error_info *einfo = &H->einfo;
@@ -134,9 +134,10 @@ static int pdo_mysql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *in
 	if (einfo->errcode) {
 		add_next_index_long(info, einfo->errcode);
 		add_next_index_string(info, einfo->errmsg);
+		PDO_DBG_RETURN(true);
 	}
 
-	PDO_DBG_RETURN(1);
+	PDO_DBG_RETURN(false);
 }
 /* }}} */
 

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -117,7 +117,7 @@ int _pdo_mysql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int lin
 /* }}} */
 
 /* {{{ pdo_mysql_fetch_error_func */
-static bool pdo_mysql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+static void pdo_mysql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 {
 	pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 	pdo_mysql_error_info *einfo = &H->einfo;
@@ -134,10 +134,9 @@ static bool pdo_mysql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *i
 	if (einfo->errcode) {
 		add_next_index_long(info, einfo->errcode);
 		add_next_index_string(info, einfo->errmsg);
-		PDO_DBG_RETURN(true);
 	}
 
-	PDO_DBG_RETURN(false);
+	PDO_DBG_VOID_RETURN;
 }
 /* }}} */
 

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -426,7 +426,7 @@ static bool oci_handle_rollback(pdo_dbh_t *dbh) /* {{{ */
 }
 /* }}} */
 
-static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /* {{{ */
+static bool oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /* {{{ */
 {
 	zend_long lval = zval_get_long(val);
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
@@ -440,25 +440,25 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 
 				if (H->last_err) {
 					H->last_err = oci_drv_error("OCITransCommit");
-					return 0;
+					return false;
 				}
 				dbh->in_txn = false;
 			}
 
 			dbh->auto_commit = (unsigned int)lval? 1 : 0;
-			return 1;
+			return true;
 		}
 		case PDO_ATTR_PREFETCH:
 		{
 			H->prefetch = pdo_oci_sanitize_prefetch(lval);
-			return 1;
+			return true;
 		}
 		case PDO_OCI_ATTR_ACTION:
 		{
 #if (OCI_MAJOR_VERSION >= 10)
 			zend_string *action = zval_try_get_string(val);
 			if (UNEXPECTED(!action)) {
-				return 0;
+				return false;
 			}
 
 			H->last_err = OCIAttrSet(H->session, OCI_HTYPE_SESSION,
@@ -466,12 +466,12 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 				OCI_ATTR_ACTION, H->err);
 			if (H->last_err) {
 				oci_drv_error("OCIAttrSet: OCI_ATTR_ACTION");
-				return 0;
+				return false;
 			}
-			return 1;
+			return true;
 #else
 			oci_drv_error("Unsupported attribute type");
-			return 0;
+			return false;
 #endif
 		}
 		case PDO_OCI_ATTR_CLIENT_INFO:
@@ -479,7 +479,7 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 #if (OCI_MAJOR_VERSION >= 10)
 			zend_string *client_info = zval_try_get_string(val);
 			if (UNEXPECTED(!client_info)) {
-				return 0;
+				return false;
 			}
 
 			H->last_err = OCIAttrSet(H->session, OCI_HTYPE_SESSION,
@@ -487,12 +487,12 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 				OCI_ATTR_CLIENT_INFO, H->err);
 			if (H->last_err) {
 				oci_drv_error("OCIAttrSet: OCI_ATTR_CLIENT_INFO");
-				return 0;
+				return false;
 			}
-			return 1;
+			return true;
 #else
 			oci_drv_error("Unsupported attribute type");
-			return 0;
+			return false;
 #endif
 		}
 		case PDO_OCI_ATTR_CLIENT_IDENTIFIER:
@@ -500,7 +500,7 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 #if (OCI_MAJOR_VERSION >= 10)
 			zend_string *identifier = zval_try_get_string(val);
 			if (UNEXPECTED(!identifier)) {
-				return 0;
+				return false;
 			}
 
 			H->last_err = OCIAttrSet(H->session, OCI_HTYPE_SESSION,
@@ -508,12 +508,12 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 				OCI_ATTR_CLIENT_IDENTIFIER, H->err);
 			if (H->last_err) {
 				oci_drv_error("OCIAttrSet: OCI_ATTR_CLIENT_IDENTIFIER");
-				return 0;
+				return false;
 			}
-			return 1;
+			return true;
 #else
 			oci_drv_error("Unsupported attribute type");
-			return 0;
+			return false;
 #endif
 		}
 		case PDO_OCI_ATTR_MODULE:
@@ -521,7 +521,7 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 #if (OCI_MAJOR_VERSION >= 10)
 			zend_string *module = zval_try_get_string(val);
 			if (UNEXPECTED(!module)) {
-				return 0;
+				return false;
 			}
 
 			H->last_err = OCIAttrSet(H->session, OCI_HTYPE_SESSION,
@@ -529,12 +529,12 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 				OCI_ATTR_MODULE, H->err);
 			if (H->last_err) {
 				oci_drv_error("OCIAttrSet: OCI_ATTR_MODULE");
-				return 0;
+				return false;
 			}
-			return 1;
+			return true;
 #else
 			oci_drv_error("Unsupported attribute type");
-			return 0;
+			return false;
 #endif
 		}
 		case PDO_OCI_ATTR_CALL_TIMEOUT:
@@ -547,16 +547,16 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 				OCI_ATTR_CALL_TIMEOUT, H->err);
 			if (H->last_err) {
 				oci_drv_error("OCIAttrSet: OCI_ATTR_CALL_TIMEOUT");
-				return 0;
+				return false;
 			}
-			return 1;
+			return true;
 #else
 			oci_drv_error("Unsupported attribute type");
-			return 0;
+			return false;
 #endif
 		}
 		default:
-			return 0;
+			return false;
 	}
 
 }

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -236,7 +236,7 @@ static void oci_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 }
 /* }}} */
 
-static int oci_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options) /* {{{ */
+static bool oci_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options) /* {{{ */
 {
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
 	pdo_oci_stmt *S = ecalloc(1, sizeof(*S));
@@ -263,7 +263,7 @@ static int oci_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stm
 		/* couldn't grok it */
 		strcpy(dbh->error_code, stmt->error_code);
 		efree(S);
-		return 0;
+		return false;
 	}
 
 	/* create an OCI statement handle */
@@ -283,7 +283,7 @@ static int oci_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stm
 			OCIHandleFree(S->stmt, OCI_HTYPE_STMT);
 			OCIHandleFree(S->err, OCI_HTYPE_ERROR);
 			efree(S);
-			return 0;
+			return false;
 		}
 
 	}
@@ -304,7 +304,7 @@ static int oci_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stm
 		nsql = NULL;
 	}
 
-	return 1;
+	return true;
 }
 /* }}} */
 

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -651,7 +651,7 @@ static int oci_handle_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return
 }
 /* }}} */
 
-static int pdo_oci_check_liveness(pdo_dbh_t *dbh) /* {{{ */
+static zend_result pdo_oci_check_liveness(pdo_dbh_t *dbh) /* {{{ */
 {
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
 	sb4 error_code = 0;

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -391,14 +391,14 @@ static int oci_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquot
 }
 /* }}} */
 
-static int oci_handle_begin(pdo_dbh_t *dbh) /* {{{ */
+static bool oci_handle_begin(pdo_dbh_t *dbh) /* {{{ */
 {
 	/* with Oracle, there is nothing special to be done */
-	return 1;
+	return true;
 }
 /* }}} */
 
-static int oci_handle_commit(pdo_dbh_t *dbh) /* {{{ */
+static bool oci_handle_commit(pdo_dbh_t *dbh) /* {{{ */
 {
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
 
@@ -406,13 +406,13 @@ static int oci_handle_commit(pdo_dbh_t *dbh) /* {{{ */
 
 	if (H->last_err) {
 		H->last_err = oci_drv_error("OCITransCommit");
-		return 0;
+		return false;
 	}
-	return 1;
+	return true;
 }
 /* }}} */
 
-static int oci_handle_rollback(pdo_dbh_t *dbh) /* {{{ */
+static bool oci_handle_rollback(pdo_dbh_t *dbh) /* {{{ */
 {
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
 
@@ -420,9 +420,9 @@ static int oci_handle_rollback(pdo_dbh_t *dbh) /* {{{ */
 
 	if (H->last_err) {
 		H->last_err = oci_drv_error("OCITransRollback");
-		return 0;
+		return false;
 	}
-	return 1;
+	return true;
 }
 /* }}} */
 
@@ -442,7 +442,7 @@ static int oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /
 					H->last_err = oci_drv_error("OCITransCommit");
 					return 0;
 				}
-				dbh->in_txn = 0;
+				dbh->in_txn = false;
 			}
 
 			dbh->auto_commit = (unsigned int)lval? 1 : 0;
@@ -705,7 +705,7 @@ static const struct pdo_dbh_methods oci_methods = {
 	pdo_oci_check_liveness,	/* check_liveness */
 	NULL, /* get_driver_methods */
 	NULL, /* request_shutdown */
-	NULL, /* in_transaction */
+	NULL, /* in transaction, use PDO's internal tracking mechanism */
 	NULL /* get_gc */
 };
 

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -354,7 +354,7 @@ static zend_long oci_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len
 }
 /* }}} */
 
-static int oci_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype ) /* {{{ */
+static bool oci_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype ) /* {{{ */
 {
 	int qcount = 0;
 	char const *cu, *l, *r;
@@ -364,7 +364,7 @@ static int oci_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquot
 		*quotedlen = 2;
 		*quoted = emalloc(*quotedlen+1);
 		strcpy(*quoted, "''");
-		return 1;
+		return true;
 	}
 
 	/* count single quotes */
@@ -387,7 +387,7 @@ static int oci_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquot
 	(*quoted)[*quotedlen-1] = '\'';
 	(*quoted)[*quotedlen]   = '\0';
 
-	return 1;
+	return true;
 }
 /* }}} */
 

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -185,7 +185,7 @@ ub4 _oci_error(OCIError *err, pdo_dbh_t *dbh, pdo_stmt_t *stmt, char *what, swor
 }
 /* }}} */
 
-static int oci_handle_closer(pdo_dbh_t *dbh) /* {{{ */
+static void oci_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 {
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
 
@@ -233,8 +233,6 @@ static int oci_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 	}
 
 	pefree(H, dbh->is_persistent);
-
-	return 0;
 }
 /* }}} */
 

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -29,7 +29,7 @@
 
 static inline ub4 pdo_oci_sanitize_prefetch(long prefetch);
 
-static bool pdo_oci_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
+static void pdo_oci_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
 {
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
 	pdo_oci_error_info *einfo;
@@ -47,10 +47,7 @@ static bool pdo_oci_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *inf
 	if (einfo->errcode) {
 		add_next_index_long(info, einfo->errcode);
 		add_next_index_string(info, einfo->errmsg);
-		return true;
 	}
-
-	return false;
 }
 /* }}} */
 

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -29,7 +29,7 @@
 
 static inline ub4 pdo_oci_sanitize_prefetch(long prefetch);
 
-static int pdo_oci_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
+static bool pdo_oci_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
 {
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
 	pdo_oci_error_info *einfo;
@@ -47,9 +47,10 @@ static int pdo_oci_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info
 	if (einfo->errcode) {
 		add_next_index_long(info, einfo->errcode);
 		add_next_index_string(info, einfo->errmsg);
+		return true;
 	}
 
-	return 1;
+	return false;
 }
 /* }}} */
 

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -136,7 +136,7 @@ static void odbc_handle_closer(pdo_dbh_t *dbh)
 	dbh->driver_data = NULL;
 }
 
-static int odbc_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
+static bool odbc_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
 {
 	RETCODE rc;
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
@@ -160,7 +160,7 @@ static int odbc_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *st
 		/* couldn't grok it */
 		strcpy(dbh->error_code, stmt->error_code);
 		efree(S);
-		return 0;
+		return false;
 	}
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, H->dbc, &S->stmt);
@@ -171,7 +171,7 @@ static int odbc_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *st
 			zend_string_release(nsql);
 		}
 		pdo_odbc_drv_error("SQLAllocStmt");
-		return 0;
+		return false;
 	}
 
 	stmt->driver_data = S;
@@ -185,7 +185,7 @@ static int odbc_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *st
 			if (nsql) {
 				zend_string_release(nsql);
 			}
-			return 0;
+			return false;
 		}
 	}
 
@@ -209,9 +209,9 @@ static int odbc_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *st
 	}
 
 	if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
-		return 0;
+		return false;
 	}
-	return 1;
+	return true;
 }
 
 static zend_long odbc_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len)

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -120,7 +120,7 @@ void pdo_odbc_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, PDO_ODBC_HSTMT statement, 
 }
 /* }}} */
 
-static int odbc_handle_closer(pdo_dbh_t *dbh)
+static void odbc_handle_closer(pdo_dbh_t *dbh)
 {
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle*)dbh->driver_data;
 
@@ -134,8 +134,6 @@ static int odbc_handle_closer(pdo_dbh_t *dbh)
 	H->env = NULL;
 	pefree(H, dbh->is_persistent);
 	dbh->driver_data = NULL;
-
-	return 0;
 }
 
 static int odbc_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -266,7 +266,7 @@ static int odbc_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquo
 }
 */
 
-static int odbc_handle_begin(pdo_dbh_t *dbh)
+static bool odbc_handle_begin(pdo_dbh_t *dbh)
 {
 	if (dbh->auto_commit) {
 		/* we need to disable auto-commit now, to be able to initiate a transaction */
@@ -276,13 +276,13 @@ static int odbc_handle_begin(pdo_dbh_t *dbh)
 		rc = SQLSetConnectAttr(H->dbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_OFF, SQL_IS_INTEGER);
 		if (rc != SQL_SUCCESS) {
 			pdo_odbc_drv_error("SQLSetConnectAttr AUTOCOMMIT = OFF");
-			return 0;
+			return false;
 		}
 	}
-	return 1;
+	return true;
 }
 
-static int odbc_handle_commit(pdo_dbh_t *dbh)
+static bool odbc_handle_commit(pdo_dbh_t *dbh)
 {
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
 	RETCODE rc;
@@ -293,7 +293,7 @@ static int odbc_handle_commit(pdo_dbh_t *dbh)
 		pdo_odbc_drv_error("SQLEndTran: Commit");
 
 		if (rc != SQL_SUCCESS_WITH_INFO) {
-			return 0;
+			return false;
 		}
 	}
 
@@ -302,13 +302,13 @@ static int odbc_handle_commit(pdo_dbh_t *dbh)
 		rc = SQLSetConnectAttr(H->dbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_ON, SQL_IS_INTEGER);
 		if (rc != SQL_SUCCESS) {
 			pdo_odbc_drv_error("SQLSetConnectAttr AUTOCOMMIT = ON");
-			return 0;
+			return false;
 		}
 	}
-	return 1;
+	return true;
 }
 
-static int odbc_handle_rollback(pdo_dbh_t *dbh)
+static bool odbc_handle_rollback(pdo_dbh_t *dbh)
 {
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
 	RETCODE rc;
@@ -319,7 +319,7 @@ static int odbc_handle_rollback(pdo_dbh_t *dbh)
 		pdo_odbc_drv_error("SQLEndTran: Rollback");
 
 		if (rc != SQL_SUCCESS_WITH_INFO) {
-			return 0;
+			return false;
 		}
 	}
 	if (dbh->auto_commit && H->dbc) {
@@ -327,11 +327,11 @@ static int odbc_handle_rollback(pdo_dbh_t *dbh)
 		rc = SQLSetConnectAttr(H->dbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_ON, SQL_IS_INTEGER);
 		if (rc != SQL_SUCCESS) {
 			pdo_odbc_drv_error("SQLSetConnectAttr AUTOCOMMIT = ON");
-			return 0;
+			return false;
 		}
 	}
 
-	return 1;
+	return true;
 }
 
 static int odbc_handle_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
@@ -386,7 +386,7 @@ static const struct pdo_dbh_methods odbc_methods = {
 	NULL, /* check_liveness */
 	NULL, /* get_driver_methods */
 	NULL, /* request_shutdown */
-	NULL, /* in_transaction */
+	NULL, /* in transaction, use PDO's internal tracking mechanism */
 	NULL /* get_gc */
 };
 

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -334,18 +334,18 @@ static bool odbc_handle_rollback(pdo_dbh_t *dbh)
 	return true;
 }
 
-static int odbc_handle_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
+static bool odbc_handle_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
 	switch (attr) {
 		case PDO_ODBC_ATTR_ASSUME_UTF8:
 			H->assume_utf8 = zval_is_true(val);
-			return 1;
+			return true;
 		default:
 			strcpy(H->einfo.last_err_msg, "Unknown Attribute");
 			H->einfo.what = "setAttribute";
 			strcpy(H->einfo.last_state, "IM001");
-			return 0;
+			return false;
 	}
 }
 

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -27,7 +27,7 @@
 #include "php_pdo_odbc_int.h"
 #include "zend_exceptions.h"
 
-static int pdo_odbc_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+static bool pdo_odbc_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 {
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
 	pdo_odbc_errinfo *einfo = &H->einfo;
@@ -48,7 +48,7 @@ static int pdo_odbc_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *inf
 	add_next_index_str(info, message);
 	add_next_index_string(info, einfo->last_state);
 
-	return 1;
+	return true;
 }
 
 

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -27,7 +27,7 @@
 #include "php_pdo_odbc_int.h"
 #include "zend_exceptions.h"
 
-static bool pdo_odbc_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+static void pdo_odbc_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 {
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
 	pdo_odbc_errinfo *einfo = &H->einfo;
@@ -47,8 +47,6 @@ static bool pdo_odbc_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *in
 	add_next_index_long(info, einfo->last_error);
 	add_next_index_str(info, message);
 	add_next_index_string(info, einfo->last_state);
-
-	return true;
 }
 
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -1149,7 +1149,7 @@ static const zend_function_entry *pdo_pgsql_get_driver_methods(pdo_dbh_t *dbh, i
 	}
 }
 
-static int pdo_pgsql_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
+static bool pdo_pgsql_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	zend_bool bval = zval_get_long(val)? 1 : 0;
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
@@ -1157,12 +1157,12 @@ static int pdo_pgsql_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 	switch (attr) {
 		case PDO_ATTR_EMULATE_PREPARES:
 			H->emulate_prepares = bval;
-			return 1;
+			return true;
 		case PDO_PGSQL_ATTR_DISABLE_PREPARES:
 			H->disable_prepares = bval;
-			return 1;
+			return true;
 		default:
-			return 0;
+			return false;
 	}
 }
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -488,7 +488,7 @@ static int pdo_pgsql_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return_
 }
 
 /* {{{ */
-static int pdo_pgsql_check_liveness(pdo_dbh_t *dbh)
+static zend_result pdo_pgsql_check_liveness(pdo_dbh_t *dbh)
 {
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	if (!PQconsumeInput(H->server) || PQstatus(H->server) == CONNECTION_BAD) {

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -221,7 +221,7 @@ static void pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 }
 /* }}} */
 
-static int pgsql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
+static bool pgsql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
 {
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	pdo_pgsql_stmt *S = ecalloc(1, sizeof(pdo_pgsql_stmt));
@@ -272,7 +272,7 @@ static int pgsql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *s
 	if (ret == -1) {
 		/* couldn't grok it */
 		strcpy(dbh->error_code, stmt->error_code);
-		return 0;
+		return false;
 	} else if (ret == 1) {
 		/* query was re-written */
 		S->query = nsql;
@@ -286,7 +286,7 @@ static int pgsql_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *s
 		spprintf(&S->stmt_name, 0, "pdo_stmt_%08x", ++H->stmt_counter);
 	}
 
-	return 1;
+	return true;
 }
 
 static zend_long pgsql_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len)

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -319,7 +319,7 @@ static zend_long pgsql_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_l
 	return ret;
 }
 
-static int pgsql_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype)
+static bool pgsql_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype)
 {
 	unsigned char *escaped;
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
@@ -345,7 +345,7 @@ static int pgsql_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unqu
 			(*quoted)[*quotedlen + 2] = '\0';
 			*quotedlen += 2;
 	}
-	return 1;
+	return true;
 }
 
 static char *pdo_pgsql_last_insert_id(pdo_dbh_t *dbh, const char *name, size_t *len)

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -203,7 +203,7 @@ php_stream *pdo_pgsql_create_lob_stream(zval *dbh, int lfd, Oid oid)
 }
 /* }}} */
 
-static int pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
+static void pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 {
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	if (H) {
@@ -218,7 +218,6 @@ static int pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 		pefree(H, dbh->is_persistent);
 		dbh->driver_data = NULL;
 	}
-	return 0;
 }
 /* }}} */
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -107,21 +107,25 @@ static void _pdo_pgsql_notice(pdo_dbh_t *dbh, const char *message) /* {{{ */
 }
 /* }}} */
 
-static int pdo_pgsql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
+static bool pdo_pgsql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
 {
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	pdo_pgsql_error_info *einfo = &H->einfo;
+	bool return_value = false;
 
 	if (einfo->errcode) {
 		add_next_index_long(info, einfo->errcode);
+		return_value = true;
 	} else {
+		/* Add null to respect expected info array structure */
 		add_next_index_null(info);
 	}
 	if (einfo->errmsg) {
 		add_next_index_string(info, einfo->errmsg);
+		return_value = true;
 	}
 
-	return 1;
+	return return_value;
 }
 /* }}} */
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -107,25 +107,20 @@ static void _pdo_pgsql_notice(pdo_dbh_t *dbh, const char *message) /* {{{ */
 }
 /* }}} */
 
-static bool pdo_pgsql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
+static void pdo_pgsql_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
 {
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	pdo_pgsql_error_info *einfo = &H->einfo;
-	bool return_value = false;
 
 	if (einfo->errcode) {
 		add_next_index_long(info, einfo->errcode);
-		return_value = true;
 	} else {
 		/* Add null to respect expected info array structure */
 		add_next_index_null(info);
 	}
 	if (einfo->errmsg) {
 		add_next_index_string(info, einfo->errmsg);
-		return_value = true;
 	}
-
-	return return_value;
 }
 /* }}} */
 

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -230,12 +230,12 @@ static char *pdo_sqlite_last_insert_id(pdo_dbh_t *dbh, const char *name, size_t 
 }
 
 /* NB: doesn't handle binary strings... use prepared stmts for that */
-static int sqlite_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype )
+static bool sqlite_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unquotedlen, char **quoted, size_t *quotedlen, enum pdo_param_type paramtype )
 {
 	*quoted = safe_emalloc(2, unquotedlen, 3);
 	sqlite3_snprintf(2*unquotedlen + 3, *quoted, "'%q'", unquoted);
 	*quotedlen = strlen(*quoted);
-	return 1;
+	return true;
 }
 
 static bool sqlite_handle_begin(pdo_dbh_t *dbh)

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -174,7 +174,7 @@ static void sqlite_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 }
 /* }}} */
 
-static int sqlite_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
+static bool sqlite_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *stmt, zval *driver_options)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
 	pdo_sqlite_stmt *S = ecalloc(1, sizeof(pdo_sqlite_stmt));
@@ -189,17 +189,17 @@ static int sqlite_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t *
 	if (PDO_CURSOR_FWDONLY != pdo_attr_lval(driver_options, PDO_ATTR_CURSOR, PDO_CURSOR_FWDONLY)) {
 		H->einfo.errcode = SQLITE_ERROR;
 		pdo_sqlite_error(dbh);
-		return 0;
+		return false;
 	}
 
 	i = sqlite3_prepare_v2(H->db, ZSTR_VAL(sql), ZSTR_LEN(sql), &S->stmt, &tail);
 	if (i == SQLITE_OK) {
-		return 1;
+		return true;
 	}
 
 	pdo_sqlite_error(dbh);
 
-	return 0;
+	return false;
 }
 
 static zend_long sqlite_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len)

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -295,19 +295,19 @@ static int pdo_sqlite_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return
 	return 1;
 }
 
-static int pdo_sqlite_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
+static bool pdo_sqlite_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
 
 	switch (attr) {
 		case PDO_ATTR_TIMEOUT:
 			sqlite3_busy_timeout(H->db, zval_get_long(val) * 1000);
-			return 1;
+			return true;
 		case PDO_SQLITE_ATTR_EXTENDED_RESULT_CODES:
 			sqlite3_extended_result_codes(H->db, zval_get_long(val));
-			return 1;
+			return true;
 	}
-	return 0;
+	return false;
 }
 
 typedef struct {

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -238,7 +238,7 @@ static int sqlite_handle_quoter(pdo_dbh_t *dbh, const char *unquoted, size_t unq
 	return 1;
 }
 
-static int sqlite_handle_begin(pdo_dbh_t *dbh)
+static bool sqlite_handle_begin(pdo_dbh_t *dbh)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
 	char *errmsg = NULL;
@@ -247,12 +247,12 @@ static int sqlite_handle_begin(pdo_dbh_t *dbh)
 		pdo_sqlite_error(dbh);
 		if (errmsg)
 			sqlite3_free(errmsg);
-		return 0;
+		return false;
 	}
-	return 1;
+	return true;
 }
 
-static int sqlite_handle_commit(pdo_dbh_t *dbh)
+static bool sqlite_handle_commit(pdo_dbh_t *dbh)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
 	char *errmsg = NULL;
@@ -261,12 +261,12 @@ static int sqlite_handle_commit(pdo_dbh_t *dbh)
 		pdo_sqlite_error(dbh);
 		if (errmsg)
 			sqlite3_free(errmsg);
-		return 0;
+		return false;
 	}
-	return 1;
+	return true;
 }
 
-static int sqlite_handle_rollback(pdo_dbh_t *dbh)
+static bool sqlite_handle_rollback(pdo_dbh_t *dbh)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
 	char *errmsg = NULL;
@@ -275,9 +275,9 @@ static int sqlite_handle_rollback(pdo_dbh_t *dbh)
 		pdo_sqlite_error(dbh);
 		if (errmsg)
 			sqlite3_free(errmsg);
-		return 0;
+		return false;
 	}
-	return 1;
+	return true;
 }
 
 static int pdo_sqlite_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return_value)
@@ -729,7 +729,7 @@ static const struct pdo_dbh_methods sqlite_methods = {
 	NULL,	/* check_liveness: not needed */
 	get_driver_methods,
 	pdo_sqlite_request_shutdown,
-	NULL, /* in_transaction */
+	NULL, /* in transaction, use PDO's internal tracking mechanism */
 	pdo_sqlite_get_gc
 };
 

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -148,7 +148,7 @@ static void pdo_sqlite_cleanup_callbacks(pdo_sqlite_db_handle *H)
 	}
 }
 
-static int sqlite_handle_closer(pdo_dbh_t *dbh) /* {{{ */
+static void sqlite_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
 
@@ -171,7 +171,6 @@ static int sqlite_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 		pefree(H, dbh->is_persistent);
 		dbh->driver_data = NULL;
 	}
-	return 0;
 }
 /* }}} */
 

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -82,7 +82,7 @@ int _pdo_sqlite_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int li
 }
 /* }}} */
 
-static bool pdo_sqlite_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+static void pdo_sqlite_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
 	pdo_sqlite_error_info *einfo = &H->einfo;
@@ -90,10 +90,7 @@ static bool pdo_sqlite_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *
 	if (einfo->errcode) {
 		add_next_index_long(info, einfo->errcode);
 		add_next_index_string(info, einfo->errmsg);
-		return true;
 	}
-
-	return false;
 }
 
 static void pdo_sqlite_cleanup_callbacks(pdo_sqlite_db_handle *H)

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -82,7 +82,7 @@ int _pdo_sqlite_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file, int li
 }
 /* }}} */
 
-static int pdo_sqlite_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
+static bool pdo_sqlite_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
 	pdo_sqlite_error_info *einfo = &H->einfo;
@@ -90,9 +90,10 @@ static int pdo_sqlite_fetch_error_func(pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *i
 	if (einfo->errcode) {
 		add_next_index_long(info, einfo->errcode);
 		add_next_index_string(info, einfo->errmsg);
+		return true;
 	}
 
-	return 1;
+	return false;
 }
 
 static void pdo_sqlite_cleanup_callbacks(pdo_sqlite_db_handle *H)


### PR DESCRIPTION
This is a rather straight forward refactoring which makes the API of PDO handlers clearer, with some drive by nits.

I wonder if it wouldn't make sense to change the liveliness handler from `zend_result` to `bool`

