### PR TITLE
DateTime*::getOffset() no longer returns false as of PHP 8.0.0

### DIFF
--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -125,7 +125,7 @@ interface DateTimeInterface
     /** @return DateTimeZone|false */
     public function getTimezone();
 
-    /** @return int|false */
+    /** @return int */
     public function getOffset();
 
     /** @return int|false */
@@ -202,7 +202,7 @@ class DateTime implements DateTimeInterface
     public function setTimezone(DateTimeZone $timezone) {}
 
     /**
-     * @return int|false
+     * @return int
      * @alias date_offset_get
      */
     public function getOffset() {}
@@ -279,7 +279,7 @@ class DateTimeImmutable implements DateTimeInterface
     public function getTimezone() {}
 
     /**
-     * @return int|false
+     * @return int
      * @alias date_offset_get
      */
     public function getOffset() {}

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 65e429036ef2ee45f31688bc2af94dc26a1b973a */
+ * Stub hash: 7b23a03d3c4941fb9a614de62d80fa5b0e11d14b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)


### PR DESCRIPTION
Cf. <https://github.com/php/doc-en/pull/282>.