### PR TITLE
Fix typos in ksort_basic test

### DIFF
--- a/ext/standard/tests/array/ksort_basic.phpt
+++ b/ext/standard/tests/array/ksort_basic.phpt
@@ -48,17 +48,17 @@ var_dump( $temp_array);
 
 echo "\n-- Testing ksort() by supplying string array (case insensitive), 'flag' = SORT_STRING|SORT_FLAG_CASE --\n";
 $temp_array = $unsorted_strings;
-var_dump( sort($temp_array, SORT_STRING|SORT_FLAG_CASE) ); // expecting : bool(true)
+var_dump( ksort($temp_array, SORT_STRING|SORT_FLAG_CASE) ); // expecting : bool(true)
 var_dump( $temp_array);
 
 echo "\n-- Testing ksort() by supplying string array (natural), 'flag' = SORT_NATURAL --\n";
 $temp_array = $unsorted_strings;
-var_dump( sort($temp_array, SORT_NATURAL) ); // expecting : bool(true)
+var_dump( ksort($temp_array, SORT_NATURAL) ); // expecting : bool(true)
 var_dump( $temp_array);
 
 echo "\n-- Testing ksort() by supplying string array (natural, case insensitive), 'flag' = SORT_NATURAL|SORT_FLAG_CASE --\n";
 $temp_array = $unsorted_strings;
-var_dump( sort($temp_array, SORT_NATURAL|SORT_FLAG_CASE) ); // expecting : bool(true)
+var_dump( ksort($temp_array, SORT_NATURAL|SORT_FLAG_CASE) ); // expecting : bool(true)
 var_dump( $temp_array);
 
 echo "\n-- Testing ksort() by supplying numeric array, 'flag' = SORT_NUMERIC --\n";

--- a/ext/standard/tests/array/ksort_basic.phpt
+++ b/ext/standard/tests/array/ksort_basic.phpt
@@ -163,63 +163,63 @@ array(8) {
 -- Testing ksort() by supplying string array (case insensitive), 'flag' = SORT_STRING|SORT_FLAG_CASE --
 bool(true)
 array(8) {
-  [0]=>
+  ["b"]=>
   string(6) "banana"
-  [1]=>
+  ["l"]=>
   string(5) "lemon"
-  [2]=>
+  ["o"]=>
   string(6) "orange"
-  [3]=>
+  ["O"]=>
   string(6) "Orange"
-  [4]=>
+  ["O1"]=>
   string(7) "Orange1"
-  [5]=>
+  ["o2"]=>
   string(7) "orange2"
-  [6]=>
+  ["o20"]=>
   string(8) "orange20"
-  [7]=>
+  ["O3"]=>
   string(7) "Orange3"
 }
 
 -- Testing ksort() by supplying string array (natural), 'flag' = SORT_NATURAL --
 bool(true)
 array(8) {
-  [0]=>
+  ["O"]=>
   string(6) "Orange"
-  [1]=>
+  ["O1"]=>
   string(7) "Orange1"
-  [2]=>
+  ["O3"]=>
   string(7) "Orange3"
-  [3]=>
+  ["b"]=>
   string(6) "banana"
-  [4]=>
+  ["l"]=>
   string(5) "lemon"
-  [5]=>
+  ["o"]=>
   string(6) "orange"
-  [6]=>
+  ["o2"]=>
   string(7) "orange2"
-  [7]=>
+  ["o20"]=>
   string(8) "orange20"
 }
 
 -- Testing ksort() by supplying string array (natural, case insensitive), 'flag' = SORT_NATURAL|SORT_FLAG_CASE --
 bool(true)
 array(8) {
-  [0]=>
+  ["b"]=>
   string(6) "banana"
-  [1]=>
+  ["l"]=>
   string(5) "lemon"
-  [2]=>
+  ["o"]=>
   string(6) "orange"
-  [3]=>
+  ["O"]=>
   string(6) "Orange"
-  [4]=>
+  ["O1"]=>
   string(7) "Orange1"
-  [5]=>
+  ["o2"]=>
   string(7) "orange2"
-  [6]=>
+  ["O3"]=>
   string(7) "Orange3"
-  [7]=>
+  ["o20"]=>
   string(8) "orange20"
 }
 


### PR DESCRIPTION
Typos calling sort() instead of ksort() function fixed in ksort_basic test