### PR TITLE
Bug #80545: Converted some type warnings to type errors in the "bcmath" extension.

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -135,13 +135,13 @@ static void php_str2num(bc_num *num, char *str)
 
 	if (!(p = strchr(str, '.'))) {
 		if (!bc_str2num(num, str, 0)) {
-			php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+		    zend_type_error("bcmath function argument is not well-formed");
 		}
 		return;
 	}
 
 	if (!bc_str2num(num, str, strlen(p+1))) {
-		php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+	    zend_type_error("bcmath function argument is not well-formed");
 	}
 }
 /* }}} */
@@ -509,12 +509,10 @@ PHP_FUNCTION(bccomp)
 	bc_init_num(&first);
 	bc_init_num(&second);
 
-	if (!bc_str2num(&first, ZSTR_VAL(left), scale)) {
-		php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+	if (!bc_str2num(&first, ZSTR_VAL(left), scale) || !bc_str2num(&second, ZSTR_VAL(right), scale)) {
+	    zend_type_error("bcmath function argument is not well-formed");
 	}
-	if (!bc_str2num(&second, ZSTR_VAL(right), scale)) {
-		php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
-	}
+
 	RETVAL_LONG(bc_compare(first, second));
 
 	bc_free_num(&first);

--- a/ext/bcmath/tests/bug80545.phpt
+++ b/ext/bcmath/tests/bug80545.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #80545 (bcadd('a', 'a') doesn't throw an exception)
+--SKIPIF--
+<?php
+if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
+?>
+--FILE--
+<?php
+try {
+    bcadd('a', 'a');
+} catch (\TypeError $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECT--
+bcmath function argument is not well-formed

--- a/ext/bcmath/tests/str2num_formatting.phpt
+++ b/ext/bcmath/tests/str2num_formatting.phpt
@@ -14,12 +14,39 @@ echo bcadd("", "2", 2),"\n";
 echo bcadd("+0", "2"), "\n";
 echo bcadd("-0", "2"), "\n";
 
-echo bcadd(" 0", "2");
-echo bcadd("1e1", "2");
-echo bcadd("1,1", "2");
-echo bcadd("Hello", "2");
-echo bcadd("1 1", "2");
-echo "\n", "\n";
+echo "\n";
+
+try {
+    echo bcadd(" 0", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bcadd("1e1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bcadd("1,1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bcadd("Hello", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bcadd("1 1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+echo "\n";
 
 echo bccomp("1", "2"),"\n";
 echo bccomp("1.1", "2", 2),"\n";
@@ -27,11 +54,38 @@ echo bccomp("", "2"),"\n";
 echo bccomp("+0", "2"), "\n";
 echo bccomp("-0", "2"), "\n";
 
-echo bccomp(" 0", "2");
-echo bccomp("1e1", "2");
-echo bccomp("1,1", "2");
-echo bccomp("Hello", "2");
-echo bccomp("1 1", "2");
+echo "\n";
+
+try {
+    echo bccomp(" 0", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bccomp("1e1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bccomp("1,1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bccomp("Hello", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bccomp("1 1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 3
@@ -40,16 +94,11 @@ echo bccomp("1 1", "2");
 2
 2
 
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
 
 -1
 -1
@@ -57,13 +106,8 @@ Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
 -1
 -1
 
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed


### PR DESCRIPTION
Hi,

This my first attempt to solve one of the bugs from the PHP bug tracker (#80545). I targeted this to the PHP 8.0 branch because the warning promotion didn't take place yet in PHP 7.4 (please correct me if I'm wrong).

If there's anything I did wrong or needs to change, please let me know! :) 