### PR TITLE
Bug #80545: Converted some type warnings to type errors in the "bcmath" extension.

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -129,20 +129,23 @@ PHP_MINFO_FUNCTION(bcmath)
 
 /* {{{ php_str2num
    Convert to bc_num detecting scale */
-static void php_str2num(bc_num *num, char *str, uint32_t arg_num)
+static zend_result php_str2num(bc_num *num, char *str)
 {
 	char *p;
 
 	if (!(p = strchr(str, '.'))) {
 		if (!bc_str2num(num, str, 0)) {
-			zend_argument_value_error(arg_num, "bcmath function argument is not well-formed");
+			return FAILURE;
 		}
-		return;
+
+		return SUCCESS;
 	}
 
 	if (!bc_str2num(num, str, strlen(p+1))) {
-		zend_argument_value_error(arg_num, "bcmath function argument is not well-formed");
+		return FAILURE;
 	}
+
+	return SUCCESS;
 }
 /* }}} */
 
@@ -174,15 +177,23 @@ PHP_FUNCTION(bcadd)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left), 1);
-	php_str2num(&second, ZSTR_VAL(right), 2);
+
+	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
+	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
+		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
 	bc_add (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
 	bc_free_num(&first);
 	bc_free_num(&second);
 	bc_free_num(&result);
-	return;
 }
 /* }}} */
 
@@ -214,15 +225,23 @@ PHP_FUNCTION(bcsub)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left), 1);
-	php_str2num(&second, ZSTR_VAL(right), 2);
+
+	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
+	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
+		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
 	bc_sub (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
 	bc_free_num(&first);
 	bc_free_num(&second);
 	bc_free_num(&result);
-	return;
 }
 /* }}} */
 
@@ -254,15 +273,23 @@ PHP_FUNCTION(bcmul)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left), 1);
-	php_str2num(&second, ZSTR_VAL(right), 2);
+
+	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
+	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
+		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
 	bc_multiply (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
 	bc_free_num(&first);
 	bc_free_num(&second);
 	bc_free_num(&result);
-	return;
 }
 /* }}} */
 
@@ -294,8 +321,16 @@ PHP_FUNCTION(bcdiv)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left), 1);
-	php_str2num(&second, ZSTR_VAL(right), 2);
+
+	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
+	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
+		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
 
 	switch (bc_divide(first, second, &result, scale)) {
 		case 0: /* OK */
@@ -309,7 +344,6 @@ PHP_FUNCTION(bcdiv)
 	bc_free_num(&first);
 	bc_free_num(&second);
 	bc_free_num(&result);
-	return;
 }
 /* }}} */
 
@@ -341,8 +375,16 @@ PHP_FUNCTION(bcmod)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left), 1);
-	php_str2num(&second, ZSTR_VAL(right), 2);
+
+	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
+	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
+		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
 
 	switch (bc_modulo(first, second, &result, scale)) {
 		case 0:
@@ -389,9 +431,21 @@ PHP_FUNCTION(bcpowmod)
 	bc_init_num(&second);
 	bc_init_num(&mod);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left), 1);
-	php_str2num(&second, ZSTR_VAL(right), 2);
-	php_str2num(&mod, ZSTR_VAL(modulus), 3);
+
+	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
+	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
+		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
+	if (php_str2num(&mod, ZSTR_VAL(modulus)) == FAILURE) {
+		zend_argument_value_error(3, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
 
 	if (bc_raisemod(first, second, mod, &result, scale) == SUCCESS) {
 		RETVAL_STR(bc_num2str_ex(result, scale));
@@ -432,8 +486,17 @@ PHP_FUNCTION(bcpow)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left), 1);
-	php_str2num(&second, ZSTR_VAL(right), 2);
+
+	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
+	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
+		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
+
 	bc_raise (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
@@ -468,7 +531,11 @@ PHP_FUNCTION(bcsqrt)
 	}
 
 	bc_init_num(&result);
-	php_str2num(&result, ZSTR_VAL(left), 1);
+
+	if (php_str2num(&result, ZSTR_VAL(left)) == FAILURE) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
+	}
 
 	if (bc_sqrt (&result, scale) != 0) {
 		RETVAL_STR(bc_num2str_ex(result, scale));
@@ -477,7 +544,6 @@ PHP_FUNCTION(bcsqrt)
 	}
 
 	bc_free_num(&result);
-	return;
 }
 /* }}} */
 
@@ -521,7 +587,6 @@ PHP_FUNCTION(bccomp)
 
 	bc_free_num(&first);
 	bc_free_num(&second);
-	return;
 }
 /* }}} */
 

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -577,10 +577,12 @@ PHP_FUNCTION(bccomp)
 
 	if (!bc_str2num(&first, ZSTR_VAL(left), scale)) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
 	}
 
 	if (!bc_str2num(&second, ZSTR_VAL(right), scale)) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		RETURN_THROWS();
 	}
 
 	RETVAL_LONG(bc_compare(first, second));

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -180,20 +180,23 @@ PHP_FUNCTION(bcadd)
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	bc_add (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
-	bc_free_num(&first);
-	bc_free_num(&second);
-	bc_free_num(&result);
+
+	cleanup: {
+		bc_free_num(&first);
+		bc_free_num(&second);
+		bc_free_num(&result);
+	};
 }
 /* }}} */
 
@@ -228,20 +231,23 @@ PHP_FUNCTION(bcsub)
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	bc_sub (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
-	bc_free_num(&first);
-	bc_free_num(&second);
-	bc_free_num(&result);
+
+	cleanup: {
+		bc_free_num(&first);
+		bc_free_num(&second);
+		bc_free_num(&result);
+	};
 }
 /* }}} */
 
@@ -276,20 +282,23 @@ PHP_FUNCTION(bcmul)
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	bc_multiply (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
-	bc_free_num(&first);
-	bc_free_num(&second);
-	bc_free_num(&result);
+
+	cleanup: {
+		bc_free_num(&first);
+		bc_free_num(&second);
+		bc_free_num(&result);
+	};
 }
 /* }}} */
 
@@ -324,12 +333,12 @@ PHP_FUNCTION(bcdiv)
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	switch (bc_divide(first, second, &result, scale)) {
@@ -341,9 +350,11 @@ PHP_FUNCTION(bcdiv)
 			break;
 	}
 
-	bc_free_num(&first);
-	bc_free_num(&second);
-	bc_free_num(&result);
+	cleanup: {
+		bc_free_num(&first);
+		bc_free_num(&second);
+		bc_free_num(&result);
+	};
 }
 /* }}} */
 
@@ -378,12 +389,12 @@ PHP_FUNCTION(bcmod)
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	switch (bc_modulo(first, second, &result, scale)) {
@@ -395,9 +406,11 @@ PHP_FUNCTION(bcmod)
 			break;
 	}
 
-	bc_free_num(&first);
-	bc_free_num(&second);
-	bc_free_num(&result);
+	cleanup: {
+		bc_free_num(&first);
+		bc_free_num(&second);
+		bc_free_num(&result);
+	};
 }
 /* }}} */
 
@@ -434,27 +447,29 @@ PHP_FUNCTION(bcpowmod)
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (php_str2num(&mod, ZSTR_VAL(modulus)) == FAILURE) {
 		zend_argument_value_error(3, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (bc_raisemod(first, second, mod, &result, scale) == SUCCESS) {
 		RETVAL_STR(bc_num2str_ex(result, scale));
 	}
 
-	bc_free_num(&first);
-	bc_free_num(&second);
-	bc_free_num(&mod);
-	bc_free_num(&result);
+	cleanup: {
+		bc_free_num(&first);
+		bc_free_num(&second);
+		bc_free_num(&mod);
+		bc_free_num(&result);
+	};
 }
 /* }}} */
 
@@ -489,20 +504,23 @@ PHP_FUNCTION(bcpow)
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	bc_raise (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
-	bc_free_num(&first);
-	bc_free_num(&second);
-	bc_free_num(&result);
+
+	cleanup: {
+		bc_free_num(&first);
+		bc_free_num(&second);
+		bc_free_num(&result);
+	};
 }
 /* }}} */
 
@@ -534,7 +552,7 @@ PHP_FUNCTION(bcsqrt)
 
 	if (php_str2num(&result, ZSTR_VAL(left)) == FAILURE) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (bc_sqrt (&result, scale) != 0) {
@@ -543,7 +561,9 @@ PHP_FUNCTION(bcsqrt)
 		zend_argument_value_error(1, "must be greater than or equal to 0");
 	}
 
-	bc_free_num(&result);
+	cleanup: {
+		bc_free_num(&result);
+	};
 }
 /* }}} */
 
@@ -577,18 +597,20 @@ PHP_FUNCTION(bccomp)
 
 	if (!bc_str2num(&first, ZSTR_VAL(left), scale)) {
 		zend_argument_value_error(1, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	if (!bc_str2num(&second, ZSTR_VAL(right), scale)) {
 		zend_argument_value_error(2, "bcmath function argument is not well-formed");
-		RETURN_THROWS();
+		goto cleanup;
 	}
 
 	RETVAL_LONG(bc_compare(first, second));
 
-	bc_free_num(&first);
-	bc_free_num(&second);
+	cleanup: {
+		bc_free_num(&first);
+		bc_free_num(&second);
+	};
 }
 /* }}} */
 

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -179,12 +179,12 @@ PHP_FUNCTION(bcadd)
 	bc_init_num(&result);
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
-		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
@@ -230,12 +230,12 @@ PHP_FUNCTION(bcsub)
 	bc_init_num(&result);
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
-		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
@@ -281,12 +281,12 @@ PHP_FUNCTION(bcmul)
 	bc_init_num(&result);
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
-		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
@@ -332,12 +332,12 @@ PHP_FUNCTION(bcdiv)
 	bc_init_num(&result);
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
-		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
@@ -388,12 +388,12 @@ PHP_FUNCTION(bcmod)
 	bc_init_num(&result);
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
-		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
@@ -446,17 +446,17 @@ PHP_FUNCTION(bcpowmod)
 	bc_init_num(&result);
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
-		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (php_str2num(&mod, ZSTR_VAL(modulus)) == FAILURE) {
-		zend_argument_value_error(3, "bcmath function argument is not well-formed");
+		zend_argument_value_error(3, "is not well-formed");
 		goto cleanup;
 	}
 
@@ -503,12 +503,12 @@ PHP_FUNCTION(bcpow)
 	bc_init_num(&result);
 
 	if (php_str2num(&first, ZSTR_VAL(left)) == FAILURE) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (php_str2num(&second, ZSTR_VAL(right)) == FAILURE) {
-		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 
@@ -551,7 +551,7 @@ PHP_FUNCTION(bcsqrt)
 	bc_init_num(&result);
 
 	if (php_str2num(&result, ZSTR_VAL(left)) == FAILURE) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
@@ -596,12 +596,12 @@ PHP_FUNCTION(bccomp)
 	bc_init_num(&second);
 
 	if (!bc_str2num(&first, ZSTR_VAL(left), scale)) {
-		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+		zend_argument_value_error(1, "is not well-formed");
 		goto cleanup;
 	}
 
 	if (!bc_str2num(&second, ZSTR_VAL(right), scale)) {
-		zend_argument_value_error(2, "bcmath function argument is not well-formed");
+		zend_argument_value_error(2, "is not well-formed");
 		goto cleanup;
 	}
 

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -129,19 +129,19 @@ PHP_MINFO_FUNCTION(bcmath)
 
 /* {{{ php_str2num
    Convert to bc_num detecting scale */
-static void php_str2num(bc_num *num, char *str)
+static void php_str2num(bc_num *num, char *str, uint32_t arg_num)
 {
 	char *p;
 
 	if (!(p = strchr(str, '.'))) {
 		if (!bc_str2num(num, str, 0)) {
-			zend_type_error("bcmath function argument is not well-formed");
+			zend_argument_value_error(arg_num, "bcmath function argument is not well-formed");
 		}
 		return;
 	}
 
 	if (!bc_str2num(num, str, strlen(p+1))) {
-		zend_type_error("bcmath function argument is not well-formed");
+		zend_argument_value_error(arg_num, "bcmath function argument is not well-formed");
 	}
 }
 /* }}} */
@@ -174,8 +174,8 @@ PHP_FUNCTION(bcadd)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left));
-	php_str2num(&second, ZSTR_VAL(right));
+	php_str2num(&first, ZSTR_VAL(left), 1);
+	php_str2num(&second, ZSTR_VAL(right), 2);
 	bc_add (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
@@ -214,8 +214,8 @@ PHP_FUNCTION(bcsub)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left));
-	php_str2num(&second, ZSTR_VAL(right));
+	php_str2num(&first, ZSTR_VAL(left), 1);
+	php_str2num(&second, ZSTR_VAL(right), 2);
 	bc_sub (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
@@ -254,8 +254,8 @@ PHP_FUNCTION(bcmul)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left));
-	php_str2num(&second, ZSTR_VAL(right));
+	php_str2num(&first, ZSTR_VAL(left), 1);
+	php_str2num(&second, ZSTR_VAL(right), 2);
 	bc_multiply (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
@@ -294,8 +294,8 @@ PHP_FUNCTION(bcdiv)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left));
-	php_str2num(&second, ZSTR_VAL(right));
+	php_str2num(&first, ZSTR_VAL(left), 1);
+	php_str2num(&second, ZSTR_VAL(right), 2);
 
 	switch (bc_divide(first, second, &result, scale)) {
 		case 0: /* OK */
@@ -341,8 +341,8 @@ PHP_FUNCTION(bcmod)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left));
-	php_str2num(&second, ZSTR_VAL(right));
+	php_str2num(&first, ZSTR_VAL(left), 1);
+	php_str2num(&second, ZSTR_VAL(right), 2);
 
 	switch (bc_modulo(first, second, &result, scale)) {
 		case 0:
@@ -389,9 +389,9 @@ PHP_FUNCTION(bcpowmod)
 	bc_init_num(&second);
 	bc_init_num(&mod);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left));
-	php_str2num(&second, ZSTR_VAL(right));
-	php_str2num(&mod, ZSTR_VAL(modulus));
+	php_str2num(&first, ZSTR_VAL(left), 1);
+	php_str2num(&second, ZSTR_VAL(right), 2);
+	php_str2num(&mod, ZSTR_VAL(modulus), 3);
 
 	if (bc_raisemod(first, second, mod, &result, scale) == SUCCESS) {
 		RETVAL_STR(bc_num2str_ex(result, scale));
@@ -432,8 +432,8 @@ PHP_FUNCTION(bcpow)
 	bc_init_num(&first);
 	bc_init_num(&second);
 	bc_init_num(&result);
-	php_str2num(&first, ZSTR_VAL(left));
-	php_str2num(&second, ZSTR_VAL(right));
+	php_str2num(&first, ZSTR_VAL(left), 1);
+	php_str2num(&second, ZSTR_VAL(right), 2);
 	bc_raise (first, second, &result, scale);
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
@@ -468,7 +468,7 @@ PHP_FUNCTION(bcsqrt)
 	}
 
 	bc_init_num(&result);
-	php_str2num(&result, ZSTR_VAL(left));
+	php_str2num(&result, ZSTR_VAL(left), 1);
 
 	if (bc_sqrt (&result, scale) != 0) {
 		RETVAL_STR(bc_num2str_ex(result, scale));
@@ -509,8 +509,12 @@ PHP_FUNCTION(bccomp)
 	bc_init_num(&first);
 	bc_init_num(&second);
 
-	if (!bc_str2num(&first, ZSTR_VAL(left), scale) || !bc_str2num(&second, ZSTR_VAL(right), scale)) {
-		zend_type_error("bcmath function argument is not well-formed");
+	if (!bc_str2num(&first, ZSTR_VAL(left), scale)) {
+		zend_argument_value_error(1, "bcmath function argument is not well-formed");
+	}
+
+	if (!bc_str2num(&second, ZSTR_VAL(right), scale)) {
+		zend_argument_value_error(2, "bcmath function argument is not well-formed");
 	}
 
 	RETVAL_LONG(bc_compare(first, second));

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -135,13 +135,13 @@ static void php_str2num(bc_num *num, char *str)
 
 	if (!(p = strchr(str, '.'))) {
 		if (!bc_str2num(num, str, 0)) {
-            zend_type_error("bcmath function argument is not well-formed");
+			zend_type_error("bcmath function argument is not well-formed");
 		}
 		return;
 	}
 
 	if (!bc_str2num(num, str, strlen(p+1))) {
-        zend_type_error("bcmath function argument is not well-formed");
+		zend_type_error("bcmath function argument is not well-formed");
 	}
 }
 /* }}} */
@@ -509,9 +509,9 @@ PHP_FUNCTION(bccomp)
 	bc_init_num(&first);
 	bc_init_num(&second);
 
-    if (!bc_str2num(&first, ZSTR_VAL(left), scale) || !bc_str2num(&second, ZSTR_VAL(right), scale)) {
-        zend_type_error("bcmath function argument is not well-formed");
-    }
+	if (!bc_str2num(&first, ZSTR_VAL(left), scale) || !bc_str2num(&second, ZSTR_VAL(right), scale)) {
+		zend_type_error("bcmath function argument is not well-formed");
+	}
 
 	RETVAL_LONG(bc_compare(first, second));
 

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -135,13 +135,13 @@ static void php_str2num(bc_num *num, char *str)
 
 	if (!(p = strchr(str, '.'))) {
 		if (!bc_str2num(num, str, 0)) {
-			php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+            zend_type_error("bcmath function argument is not well-formed");
 		}
 		return;
 	}
 
 	if (!bc_str2num(num, str, strlen(p+1))) {
-		php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
+        zend_type_error("bcmath function argument is not well-formed");
 	}
 }
 /* }}} */
@@ -509,12 +509,10 @@ PHP_FUNCTION(bccomp)
 	bc_init_num(&first);
 	bc_init_num(&second);
 
-	if (!bc_str2num(&first, ZSTR_VAL(left), scale)) {
-		php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
-	}
-	if (!bc_str2num(&second, ZSTR_VAL(right), scale)) {
-		php_error_docref(NULL, E_WARNING, "bcmath function argument is not well-formed");
-	}
+    if (!bc_str2num(&first, ZSTR_VAL(left), scale) || !bc_str2num(&second, ZSTR_VAL(right), scale)) {
+        zend_type_error("bcmath function argument is not well-formed");
+    }
+
 	RETVAL_LONG(bc_compare(first, second));
 
 	bc_free_num(&first);

--- a/ext/bcmath/tests/bug80545.phpt
+++ b/ext/bcmath/tests/bug80545.phpt
@@ -1,16 +1,25 @@
 --TEST--
-Bug #80545 (bcadd('a', 'a') doesn't throw an exception)
+Bug #80545 (bcadd('a', 'a') and bcadd('1', 'a') doesn't throw an exception)
 --SKIPIF--
 <?php
 if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
 ?>
 --FILE--
 <?php
+
 try {
     bcadd('a', 'a');
 } catch (\ValueError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    bcadd('1', 'a');
+} catch (\ValueError $e) {
     echo $e->getMessage();
 }
+
 ?>
 --EXPECT--
 bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
+bcadd(): Argument #2 ($num2) bcmath function argument is not well-formed

--- a/ext/bcmath/tests/bug80545.phpt
+++ b/ext/bcmath/tests/bug80545.phpt
@@ -21,5 +21,5 @@ try {
 
 ?>
 --EXPECT--
-bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
-bcadd(): Argument #2 ($num2) bcmath function argument is not well-formed
+bcadd(): Argument #1 ($num1) is not well-formed
+bcadd(): Argument #2 ($num2) is not well-formed

--- a/ext/bcmath/tests/bug80545.phpt
+++ b/ext/bcmath/tests/bug80545.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #80545 (bcadd('a', 'a') doesn't throw an exception)
+--SKIPIF--
+<?php
+if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
+?>
+--FILE--
+<?php
+try {
+    bcadd('a', 'a');
+} catch (\TypeError $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECT--
+bcmath function argument is not well-formed

--- a/ext/bcmath/tests/bug80545.phpt
+++ b/ext/bcmath/tests/bug80545.phpt
@@ -8,9 +8,9 @@ if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
 <?php
 try {
     bcadd('a', 'a');
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage();
 }
 ?>
 --EXPECT--
-bcmath function argument is not well-formed
+bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed

--- a/ext/bcmath/tests/str2num_formatting.phpt
+++ b/ext/bcmath/tests/str2num_formatting.phpt
@@ -94,11 +94,11 @@ try {
 2
 2
 
-bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
-bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
-bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
-bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
-bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
+bcadd(): Argument #1 ($num1) is not well-formed
+bcadd(): Argument #1 ($num1) is not well-formed
+bcadd(): Argument #1 ($num1) is not well-formed
+bcadd(): Argument #1 ($num1) is not well-formed
+bcadd(): Argument #1 ($num1) is not well-formed
 
 -1
 -1
@@ -106,8 +106,8 @@ bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
 -1
 -1
 
-bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
-bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
-bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
-bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
-bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
+bccomp(): Argument #1 ($num1) is not well-formed
+bccomp(): Argument #1 ($num1) is not well-formed
+bccomp(): Argument #1 ($num1) is not well-formed
+bccomp(): Argument #1 ($num1) is not well-formed
+bccomp(): Argument #1 ($num1) is not well-formed

--- a/ext/bcmath/tests/str2num_formatting.phpt
+++ b/ext/bcmath/tests/str2num_formatting.phpt
@@ -14,12 +14,39 @@ echo bcadd("", "2", 2),"\n";
 echo bcadd("+0", "2"), "\n";
 echo bcadd("-0", "2"), "\n";
 
-echo bcadd(" 0", "2");
-echo bcadd("1e1", "2");
-echo bcadd("1,1", "2");
-echo bcadd("Hello", "2");
-echo bcadd("1 1", "2");
-echo "\n", "\n";
+echo "\n";
+
+try {
+    echo bcadd(" 0", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bcadd("1e1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bcadd("1,1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bcadd("Hello", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bcadd("1 1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+echo "\n";
 
 echo bccomp("1", "2"),"\n";
 echo bccomp("1.1", "2", 2),"\n";
@@ -27,11 +54,38 @@ echo bccomp("", "2"),"\n";
 echo bccomp("+0", "2"), "\n";
 echo bccomp("-0", "2"), "\n";
 
-echo bccomp(" 0", "2");
-echo bccomp("1e1", "2");
-echo bccomp("1,1", "2");
-echo bccomp("Hello", "2");
-echo bccomp("1 1", "2");
+echo "\n";
+
+try {
+    echo bccomp(" 0", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bccomp("1e1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bccomp("1,1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bccomp("Hello", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+try {
+    echo bccomp("1 1", "2");
+} catch (\TypeError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
 ?>
 --EXPECTF--
 3
@@ -40,16 +94,11 @@ echo bccomp("1 1", "2");
 2
 2
 
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
-Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
-2
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
 
 -1
 -1
@@ -57,13 +106,8 @@ Warning: bcadd(): bcmath function argument is not well-formed in %s on line %d
 -1
 -1
 
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
-Warning: bccomp(): bcmath function argument is not well-formed in %s on line %d
--1
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed
+bcmath function argument is not well-formed

--- a/ext/bcmath/tests/str2num_formatting.phpt
+++ b/ext/bcmath/tests/str2num_formatting.phpt
@@ -18,31 +18,31 @@ echo "\n";
 
 try {
     echo bcadd(" 0", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     echo bcadd("1e1", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     echo bcadd("1,1", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     echo bcadd("Hello", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     echo bcadd("1 1", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
@@ -58,31 +58,31 @@ echo "\n";
 
 try {
     echo bccomp(" 0", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     echo bccomp("1e1", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     echo bccomp("1,1", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     echo bccomp("Hello", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     echo bccomp("1 1", "2");
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
@@ -94,11 +94,11 @@ try {
 2
 2
 
-bcmath function argument is not well-formed
-bcmath function argument is not well-formed
-bcmath function argument is not well-formed
-bcmath function argument is not well-formed
-bcmath function argument is not well-formed
+bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
+bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
+bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
+bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
+bcadd(): Argument #1 ($num1) bcmath function argument is not well-formed
 
 -1
 -1
@@ -106,8 +106,8 @@ bcmath function argument is not well-formed
 -1
 -1
 
-bcmath function argument is not well-formed
-bcmath function argument is not well-formed
-bcmath function argument is not well-formed
-bcmath function argument is not well-formed
-bcmath function argument is not well-formed
+bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
+bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
+bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
+bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed
+bccomp(): Argument #1 ($num1) bcmath function argument is not well-formed


### PR DESCRIPTION
Hi,

This my first attempt to solve one of the bugs from the PHP bug tracker (#80545). I targeted this to the PHP 8.0 branch because the warning promotion didn't take place yet in PHP 7.4 (please correct me if I'm wrong).

Bccomp had the same issue, so I changed it there too.

If there's anything I did wrong or needs to change, please let me know! :)