### PR TITLE
Fix bug #80024: prevent duplication of inherited sockets on reload

### DIFF
--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -89,6 +89,8 @@ static void fpm_sockets_cleanup(int which, void *arg) /* {{{ */
 			}
 			setenv(envname, env_value + socket_set[i], 1);
 		}
+		sprintf(envname, "FPM_SOCKETS_%d", socket_set_count);
+		unsetenv(envname);
 		free(env_value);
 	}
 


### PR DESCRIPTION
"FPM_SOCKETS_X" env variable isn't cleaned when it's become unused.
The issue appears if count of sockets is changed from "FPM_ENV_SOCKET_SET_SIZE * n + 1" to "FPM_ENV_SOCKET_SET_SIZE * n"
In such cases the same socket presents in "FPM_SOCKETS_[socket_set_count - 1]" and "FPM_SOCKETS_[socket_set_count]"