### PR TITLE
#62906 add support for CURLOPT_*SOCK* options

### DIFF
--- a/ext/curl/curl.stub.php
+++ b/ext/curl/curl.stub.php
@@ -2,6 +2,10 @@
 
 /** @generate-function-entries */
 
+final class CurlSockaddr
+{
+}
+
 final class CurlHandle
 {
 }

--- a/ext/curl/curl_arginfo.h
+++ b/ext/curl/curl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f1d616c644ad366405816cde0384f6f391773ebf */
+ * Stub hash: 90efbdcc7d8dcb5570cdea434261a2a1c85f40ba */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_curl_close, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, handle, CurlHandle, 0)
@@ -224,6 +224,11 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(curl_share_strerror, arginfo_curl_share_strerror)
 	ZEND_FE(curl_strerror, arginfo_curl_strerror)
 	ZEND_FE(curl_version, arginfo_curl_version)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_CurlSockaddr_methods[] = {
 	ZEND_FE_END
 };
 

--- a/ext/curl/curl_private.h
+++ b/ext/curl/curl_private.h
@@ -66,17 +66,19 @@ typedef struct {
 	zval                  func_name;
 	zend_fcall_info_cache fci_cache;
 	int                   method;
-} php_curl_progress, php_curl_fnmatch, php_curlm_server_push;
+} php_curl_progress, php_curl_fnmatch, php_curlm_server_push, php_curl_callback_function;
 
 typedef struct {
-	php_curl_write    *write;
-	php_curl_write    *write_header;
-	php_curl_read     *read;
-	zval               std_err;
-	php_curl_progress *progress;
-#if LIBCURL_VERSION_NUM >= 0x071500 /* Available since 7.21.0 */
-	php_curl_fnmatch  *fnmatch;
-#endif
+	php_curl_write             *write;
+	php_curl_write             *write_header;
+	php_curl_read              *read;
+	zval                       std_err;
+	php_curl_progress          *progress;
+	php_curl_fnmatch           *fnmatch;
+	zval                       fd;
+	php_curl_callback_function *sockopt;
+	php_curl_callback_function *opensocket;
+	php_curl_callback_function *closesocket;
 } php_curl_handlers;
 
 struct _php_curl_error  {

--- a/ext/curl/tests/curl_basic_025.phpt
+++ b/ext/curl/tests/curl_basic_025.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Test CURLOPT_*SOCK
+--SKIPIF--
+<?php
+if (!extension_loaded("curl")) exit("skip curl extension not loaded");
+if (!extension_loaded("sockets")) exit("skip sockets extension not loaded");
+?>
+--FILE--
+<?php
+function opensocket($handler, $purpose, $address) {
+    echo "opensocket", PHP_EOL;
+	return socket_create($address['family'], $address['socktype'], $address['protocol']);
+}
+
+function sockopt($handler, $fd, $purpose) {
+    echo "sockopt", PHP_EOL;
+}
+
+function closesocket($handler, $fd) {
+    echo "closesocket", PHP_EOL;
+	socket_close($fd);
+}
+
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$url = "{$host}/get.php?test=get";
+$ch = curl_init();
+
+ob_start(); // start output buffering
+curl_setopt($ch, CURLOPT_URL, $url); //set the url we want to use
+curl_setopt($ch, CURLOPT_SOCKOPTFUNCTION, 'sockopt');
+curl_setopt($ch, CURLOPT_OPENSOCKETFUNCTION, 'opensocket');
+curl_setopt($ch, CURLOPT_CLOSESOCKETFUNCTION, 'closesocket');
+
+
+$ok = curl_exec($ch);
+curl_close($ch);
+$curl_content = ob_get_contents();
+ob_end_clean();
+
+if($ok) {
+	var_dump( $curl_content );
+} else {
+	echo "curl_exec returned false";
+}
+?>
+===DONE===
+--EXPECTF--
+string(56) "opensocket
+sockopt
+Hello World!
+Hello World!closesocket
+"
+===DONE===

--- a/ext/curl/tests/curl_basic_025.phpt
+++ b/ext/curl/tests/curl_basic_025.phpt
@@ -9,7 +9,7 @@ if (!extension_loaded("sockets")) exit("skip sockets extension not loaded");
 <?php
 function opensocket($handler, $purpose, $address) {
     echo "opensocket", PHP_EOL;
-	return socket_create($address['family'], $address['socktype'], $address['protocol']);
+	return socket_create($address->family, $address->socktype, $address->protocol);
 }
 
 function sockopt($handler, $fd, $purpose) {


### PR DESCRIPTION
This is based on https://github.com/php/php-src/compare/master...adoy:0bd61d907a758ff6eab3afaa714ea275a12dcf8c.

https://curl.se/libcurl/c/CURLOPT_OPENSOCKETFUNCTION.html states you are allowed to modify the address so I made that possible.

I created a php object for the curl_sockaddr. Preferably there would be some kind of php_curl_sockaddr that encapsulates the curl_sockaddr and links the properties somehow. I couldn't find a way to do that. Instead I now have the ugly _curlSockaddrToZval and _zvalToCurlSockaddr.

All feedback is welcome.

Feature request url: https://bugs.php.net/bug.php?id=62906