### PR TITLE
Fix edge case serializing __PHP_Incomplete_Class properties.

### DIFF
--- a/ext/standard/tests/serialize/incomplete_class_magic.phpt
+++ b/ext/standard/tests/serialize/incomplete_class_magic.phpt
@@ -1,0 +1,32 @@
+--TEST--
+(un)serializing __PHP_Incomplete_Class instance edge case
+--FILE--
+<?php
+
+$serialized = 'O:8:"Missing_":1:{s:33:"__PHP_Incomplete_Class_Name' . "\0" . 'other";i:123;}';
+ob_start();
+$o = unserialize($serialized);
+var_dump($o);
+$reserialized = serialize($o);
+var_dump(unserialize($reserialized));
+// Pretty print null bytes
+echo str_replace("\0", "\\0", ob_get_clean());
+
+// The serialization should have a property count of 1 and a property set with 1 element.
+var_export($reserialized);
+echo "\n";
+?>
+--EXPECT--
+object(__PHP_Incomplete_Class)#1 (2) {
+  ["__PHP_Incomplete_Class_Name"]=>
+  string(8) "Missing_"
+  ["__PHP_Incomplete_Class_Name\0other"]=>
+  int(123)
+}
+object(__PHP_Incomplete_Class)#2 (2) {
+  ["__PHP_Incomplete_Class_Name"]=>
+  string(8) "Missing_"
+  ["__PHP_Incomplete_Class_Name\0other"]=>
+  int(123)
+}
+'O:8:"Missing_":1:{s:33:"__PHP_Incomplete_Class_Name' . "\0" . 'other";i:123;}'

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -878,7 +878,7 @@ static void php_var_serialize_nested_data(smart_str *buf, zval *struc, HashTable
 		zend_ulong index;
 
 		ZEND_HASH_FOREACH_KEY_VAL_IND(ht, index, key, data) {
-			if (incomplete_class && strcmp(ZSTR_VAL(key), MAGIC_MEMBER) == 0) {
+			if (incomplete_class && zend_string_equals_literal(key, MAGIC_MEMBER)) {
 				continue;
 			}
 


### PR DESCRIPTION
This was using strcmp instead of zend_string_equals_literal.
As a result, the property count didn't match the number of properties
being serialized if properties started with
"__PHP_Incomplete_Class\0" (unlikely)

(before, `'O:8:"Missing_":1:{}'` would be serialized, which failed to
unserialize because it expected 1 property but reached the end of the set)

Everywhere else expects the MAGIC_MEMBER to match exactly,
and this should use zend_string_equals_literal as an example for other code.

This has used strcmp since 2004 in deb84befae4bbc3686a4f2ed82b04e2cabae5dc0