### PR TITLE
Restore inadvertently removed imap_header()

### DIFF
--- a/ext/imap/php_imap.stub.php
+++ b/ext/imap/php_imap.stub.php
@@ -29,6 +29,12 @@ function imap_headers($imap): array|false {}
 /** @param resource $imap */
 function imap_headerinfo($imap, int $message_num, int $from_length = 0, int $subject_length = 0): stdClass|false {}
 
+/**
+ * @param resource $imap
+ * @alias imap_headerinfo
+ */
+function imap_header($imap, int $message_num, int $from_length = 0, int $subject_length = 0): stdClass|false {}
+
 function imap_rfc822_parse_headers(string $headers, string $default_hostname = "UNKNOWN"): stdClass {}
 
 function imap_rfc822_write_address(string $mailbox, string $hostname, string $personal): string|false {}

--- a/ext/imap/php_imap_arginfo.h
+++ b/ext/imap/php_imap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 326cb0410034aecc702e9397cd88ef91adaa254c */
+ * Stub hash: f2ae5c4658499d1403a25adba737c570f5e269a9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_imap_open, 0, 0, 3)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
@@ -38,6 +38,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_headerinfo, 0, 2, stdCl
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, from_length, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, subject_length, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
+
+#define arginfo_imap_header arginfo_imap_headerinfo
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_imap_rfc822_parse_headers, 0, 1, stdClass, 0)
 	ZEND_ARG_TYPE_INFO(0, headers, IS_STRING, 0)
@@ -427,6 +429,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(imap_num_recent, arginfo_imap_num_recent)
 	ZEND_FE(imap_headers, arginfo_imap_headers)
 	ZEND_FE(imap_headerinfo, arginfo_imap_headerinfo)
+	ZEND_FALIAS(imap_header, imap_headerinfo, arginfo_imap_header)
 	ZEND_FE(imap_rfc822_parse_headers, arginfo_imap_rfc822_parse_headers)
 	ZEND_FE(imap_rfc822_write_address, arginfo_imap_rfc822_write_address)
 	ZEND_FE(imap_rfc822_parse_adrlist, arginfo_imap_rfc822_parse_adrlist)


### PR DESCRIPTION
`imap_header()` which is an alias of `imap_headerinfo()` has apparently
been removed inadvertently, so we restore it.

Cf. <https://github.com/php/doc-en/pull/292#discussion_r550267916>.

---

This is more for clarification; I'm okay with dropping that alias, but that would need to be documented.

/cc @Girgias, @kocsismate 