### PR TITLE
Add PDOStatement::lastInsertId method

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1524,6 +1524,16 @@ PHP_METHOD(PDOStatement, rowCount)
 }
 /* }}} */
 
+/* {{{ Returns the number of AUTO_INCREMENT by the last execute().  It is not always meaningful. */
+PHP_METHOD(PDOStatement, lastInsertId)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	PHP_STMT_GET_OBJ;
+	RETURN_LONG(stmt->last_insert_id);
+}
+/* }}} */
+
 /* {{{ Fetch the error code associated with the last operation on the statement handle */
 PHP_METHOD(PDOStatement, errorCode)
 {

--- a/ext/pdo/pdo_stmt.stub.php
+++ b/ext/pdo/pdo_stmt.stub.php
@@ -55,6 +55,9 @@ class PDOStatement implements IteratorAggregate
     /** @return int */
     public function rowCount() {}
 
+    /** @return int */
+    public function lastInsertId() {}
+
     /** @return bool */
     public function setAttribute(int $attribute, mixed $value) {}
 

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -70,6 +70,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_PDOStatement_rowCount arginfo_class_PDOStatement_closeCursor
 
+#define arginfo_class_PDOStatement_lastInsertId arginfo_class_PDOStatement_closeCursor
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_setAttribute, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, attribute, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
@@ -101,6 +103,7 @@ ZEND_METHOD(PDOStatement, getAttribute);
 ZEND_METHOD(PDOStatement, getColumnMeta);
 ZEND_METHOD(PDOStatement, nextRowset);
 ZEND_METHOD(PDOStatement, rowCount);
+ZEND_METHOD(PDOStatement, lastInsertId);
 ZEND_METHOD(PDOStatement, setAttribute);
 ZEND_METHOD(PDOStatement, setFetchMode);
 ZEND_METHOD(PDOStatement, getIterator);
@@ -124,6 +127,7 @@ static const zend_function_entry class_PDOStatement_methods[] = {
 	ZEND_ME(PDOStatement, getColumnMeta, arginfo_class_PDOStatement_getColumnMeta, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDOStatement, nextRowset, arginfo_class_PDOStatement_nextRowset, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDOStatement, rowCount, arginfo_class_PDOStatement_rowCount, ZEND_ACC_PUBLIC)
+	ZEND_ME(PDOStatement, lastInsertId, arginfo_class_PDOStatement_lastInsertId, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDOStatement, setAttribute, arginfo_class_PDOStatement_setAttribute, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDOStatement, setFetchMode, arginfo_class_PDOStatement_setFetchMode, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDOStatement, getIterator, arginfo_class_PDOStatement_getIterator, ZEND_ACC_PUBLIC)

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -584,6 +584,9 @@ struct _pdo_stmt_t {
 	/* not always meaningful */
 	zend_long row_count;
 
+	/* not always meaningful */
+	zend_long last_insert_id;
+
 	/* used to hold the statement's current query */
 	zend_string *query_string;
 

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -584,7 +584,7 @@ struct _pdo_stmt_t {
 	/* not always meaningful */
 	zend_long row_count;
 
-	/* not always meaningful */
+	/* last insert id */
 	zend_long last_insert_id;
 
 	/* used to hold the statement's current query */

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -126,6 +126,16 @@ static void pdo_mysql_stmt_set_row_count(pdo_stmt_t *stmt) /* {{{ */
 }
 /* }}} */
 
+static void pdo_mysql_stmt_set_last_insert_id(pdo_stmt_t *stmt) /* {{{ */
+{
+	pdo_mysql_stmt *S = stmt->driver_data;
+	zend_long last_insert_id = (zend_long) mysql_stmt_insert_id(S->stmt);
+	if (last_insert_id != (zend_long)-1) {
+		stmt->last_insert_id = last_insert_id;
+	}
+}
+/* }}} */
+
 static int pdo_mysql_fill_stmt_from_result(pdo_stmt_t *stmt) /* {{{ */
 {
 	pdo_mysql_stmt *S = (pdo_mysql_stmt*)stmt->driver_data;

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -268,6 +268,7 @@ static bool pdo_mysql_stmt_after_execute_prepared(pdo_stmt_t *stmt) {
 #endif
 
 	pdo_mysql_stmt_set_row_count(stmt);
+	pdo_mysql_stmt_set_last_insert_id(stmt);
 	return true;
 }
 


### PR DESCRIPTION
The PDOStatement::lastInsertId method is added because when ATTR_PERSISTENT is turned on, a concurrency error will occur in multithreading. Code like:

```
thread1: $pdo = new PDO(...);
thread2: $pdo = new PDO(...);
thread1: $pdo->exec("INSERT INTO foo (name) VALUES ('foo')");
thread2: $pdo->exec("INSERT INTO foo (name) VALUES ('bar')");
thread1: $pdo->lastInsertId(); // 2
thread2: $pdo->lastInsertId(); // 2
```

The reason is that PDO uses the same database connection at the bottom, and thread1 gets the wrong lastInsertId.

[MySQL: Client/Server Protocol OK_Packet](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_ok_packet.html) supports last_insert_id, and mysqlnd also supports it.

Use PDOStatement::lastInsertId method, code like:

```
thread1: $pdo = new PDO(...);
thread2: $pdo = new PDO(...);
thread1: $stmt = $pdo->prepare("INSERT INTO foo (name) VALUES ('foo')");
thread2: $stmt = $pdo->prepare("INSERT INTO foo (name) VALUES ('bar')");
thread1: $stmt->execute();
thread2: $stmt->execute();
thread1: $stmt->lastInsertId(); // 1
thread2: $stmt->lastInsertId(); // 2
```

perfect!
