### PR TITLE
phar: honor SOURCE_DATE_EPOCH for timestamps

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -3002,7 +3002,7 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 			4: metadata-len
 			+: metadata
 		*/
-		mytime = time(NULL);
+		mytime = source_date_epoch_time(NULL);
 		phar_set_32(entry_buffer, entry->uncompressed_filesize);
 		phar_set_32(entry_buffer+4, mytime);
 		phar_set_32(entry_buffer+8, entry->compressed_filesize);

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -429,9 +429,10 @@ static inline enum phar_fp_type phar_get_fp_type(phar_entry_info *entry)
 
 static inline time_t source_date_epoch_time(time_t *tloc)
 {
-	const char *sde = php_getenv(SOURCE_DATE_EPOCH, strlen(SOURCE_DATE_EPOCH));
-	time_t ts = (sde) ? strtol(sde, NULL, 10) : time(0);
+	zend_string *sde = php_getenv(SOURCE_DATE_EPOCH, strlen(SOURCE_DATE_EPOCH));
+	time_t ts = (ZSTR_LEN(sde)) ? strtol(ZSTR_VAL(sde), NULL, 10) : time(0);
 
+	zend_string_release(sde);
 	if (tloc) {
 		*tloc = ts;
 	}

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -425,18 +425,20 @@ static inline enum phar_fp_type phar_get_fp_type(phar_entry_info *entry)
 	return PHAR_G(cached_fp)[entry->phar->phar_pos].manifest[entry->manifest_pos].fp_type;
 }
 
-#define SOURCE_DATE_EPOCH	"SOURCE_DATE_EPOCH"
-
 static inline time_t source_date_epoch_time(time_t *tloc)
 {
-	zend_string *sde = php_getenv(SOURCE_DATE_EPOCH, strlen(SOURCE_DATE_EPOCH));
-	time_t ts = (ZSTR_LEN(sde)) ? strtol(ZSTR_VAL(sde), NULL, 10) : time(0);
+	zend_string *str = php_getenv("SOURCE_DATE_EPOCH", sizeof("SOURCE_DATE_EPOCH")-1);
 
-	zend_string_release(sde);
-	if (tloc) {
-		*tloc = ts;
+	if (str) {
+		time_t t = strtol(ZSTR_VAL(str), NULL, 10);
+
+		zend_string_release(str);
+		if (tloc) {
+			*tloc = t;
+		}
+		return t;
 	}
-	return ts;
+	return time(tloc);
 }
 
 static inline zend_off_t phar_get_fp_offset(phar_entry_info *entry)

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -425,9 +425,11 @@ static inline enum phar_fp_type phar_get_fp_type(phar_entry_info *entry)
 	return PHAR_G(cached_fp)[entry->phar->phar_pos].manifest[entry->manifest_pos].fp_type;
 }
 
+#define SOURCE_DATE_EPOCH	"SOURCE_DATE_EPOCH"
+
 static inline time_t source_date_epoch_time(time_t *tloc)
 {
-	const char *sde = getenv("SOURCE_DATE_EPOCH");
+	const char *sde = php_getenv(SOURCE_DATE_EPOCH, strlen(SOURCE_DATE_EPOCH));
 	time_t ts = (sde) ? strtol(sde, NULL, 10) : time(0);
 
 	if (tloc) {

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -430,7 +430,7 @@ static inline time_t source_date_epoch_time(time_t *tloc)
 	zend_string *str = php_getenv("SOURCE_DATE_EPOCH", sizeof("SOURCE_DATE_EPOCH")-1);
 
 	if (str) {
-		time_t t = strtol(ZSTR_VAL(str), NULL, 10);
+		time_t t = strtoul(ZSTR_VAL(str), NULL, 10);
 
 		zend_string_release(str);
 		if (tloc) {

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -427,11 +427,9 @@ static inline enum phar_fp_type phar_get_fp_type(phar_entry_info *entry)
 
 static inline time_t source_date_epoch_time(time_t *tloc)
 {
-	const char *sde;
-	time_t ts;
+	const char *sde = getenv("SOURCE_DATE_EPOCH");
+	time_t ts = (sde) ? strtol(sde, NULL, 10) : time(0);
 
-	sde = getenv("SOURCE_DATE_EPOCH");
-	ts = (sde) ? strtol(sde, NULL, 10) : time(0);
 	if (tloc) {
 		*tloc = ts;
 	}

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -425,6 +425,19 @@ static inline enum phar_fp_type phar_get_fp_type(phar_entry_info *entry)
 	return PHAR_G(cached_fp)[entry->phar->phar_pos].manifest[entry->manifest_pos].fp_type;
 }
 
+static inline time_t source_date_epoch_time(time_t *tloc)
+{
+	const char *sde;
+	time_t ts;
+
+	sde = getenv("SOURCE_DATE_EPOCH");
+	ts = (sde) ? strtol(sde, NULL, 10) : time(0);
+	if (tloc) {
+		*tloc = ts;
+	}
+	return ts;
+}
+
 static inline zend_off_t phar_get_fp_offset(phar_entry_info *entry)
 {
 	if (!entry->is_persistent) {

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -463,7 +463,7 @@ static int phar_stream_flush(php_stream *stream) /* {{{ */
 	phar_entry_data *data = (phar_entry_data *) stream->abstract;
 
 	if (data->internal_file->is_modified) {
-		data->internal_file->timestamp = time(0);
+		data->internal_file->timestamp = source_date_epoch_time(0);
 		ret = phar_flush(data->phar, 0, 0, 0, &error);
 		if (error) {
 			php_stream_wrapper_log_error(stream->wrapper, REPORT_ERRORS, "%s", error);

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -971,7 +971,7 @@ int phar_tar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int 
 	char halt_stub[] = "__HALT_COMPILER();";
 
 	entry.flags = PHAR_ENT_PERM_DEF_FILE;
-	entry.timestamp = time(NULL);
+	entry.timestamp = source_date_epoch_time(NULL);
 	entry.is_modified = 1;
 	entry.is_crc_checked = 1;
 	entry.is_tar = 1;

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -574,7 +574,7 @@ phar_entry_data *phar_get_or_create_entry_data(char *fname, size_t fname_len, ch
 
 	phar_add_virtual_dirs(phar, path, path_len);
 	etemp.is_modified = 1;
-	etemp.timestamp = time(0);
+	etemp.timestamp = source_date_epoch_time(0);
 	etemp.is_crc_checked = 1;
 	etemp.phar = phar;
 	etemp.filename = estrndup(path, path_len);

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -1185,7 +1185,7 @@ int phar_zip_flush(phar_archive_data *phar, char *user_stub, zend_long len, int 
 
 	pass.error = &temperr;
 	entry.flags = PHAR_ENT_PERM_DEF_FILE;
-	entry.timestamp = time(NULL);
+	entry.timestamp = source_date_epoch_time(NULL);
 	entry.is_modified = 1;
 	entry.is_zip = 1;
 	entry.phar = phar;


### PR DESCRIPTION
In order to build reproducible phars, honor SOURCE_DATE_EPOCH
if set

Signed-off-by: Arjen de Korte <build+github@de-korte.org>