### PR TITLE
Use Z_PARAM_OBJ macros when zval isn't needed

### DIFF
--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -769,7 +769,6 @@ ZEND_FUNCTION(get_class_vars)
 /* {{{ Returns an array of object properties */
 ZEND_FUNCTION(get_object_vars)
 {
-	zval *obj;
 	zval *value;
 	HashTable *properties;
 	zend_string *key;
@@ -777,10 +776,9 @@ ZEND_FUNCTION(get_object_vars)
 	zend_ulong num_key;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJECT(obj)
+		Z_PARAM_OBJ(zobj)
 	ZEND_PARSE_PARAMETERS_END();
 
-	zobj = Z_OBJ_P(obj);
 	properties = zobj->handlers->get_properties(zobj);
 	if (properties == NULL) {
 		RETURN_EMPTY_ARRAY();
@@ -839,22 +837,22 @@ ZEND_FUNCTION(get_object_vars)
 /* {{{ Returns an array of mangled object properties. Does not respect property visibility. */
 ZEND_FUNCTION(get_mangled_object_vars)
 {
-	zval *obj;
+	zend_object *obj;
 	HashTable *properties;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJECT(obj)
+		Z_PARAM_OBJ(obj)
 	ZEND_PARSE_PARAMETERS_END();
 
-	properties = Z_OBJ_HT_P(obj)->get_properties(Z_OBJ_P(obj));
+	properties = obj->handlers->get_properties(obj);
 	if (!properties) {
 		ZVAL_EMPTY_ARRAY(return_value);
 		return;
 	}
 
 	properties = zend_proptable_to_symtable(properties,
-		(Z_OBJCE_P(obj)->default_properties_count ||
-		 Z_OBJ_P(obj)->handlers != &std_object_handlers ||
+		(obj->ce->default_properties_count ||
+		 obj->handlers != &std_object_handlers ||
 		 GC_IS_RECURSIVE(properties)));
 	RETURN_ARR(properties);
 }

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -128,6 +128,7 @@ ZEND_METHOD(Closure, call)
 	zend_fcall_info_cache fci_cache;
 	zend_function my_function;
 	zend_object *newobj;
+	zend_class_entry *newclass;
 
 	fci.param_count = 0;
 	fci.params = NULL;
@@ -140,26 +141,27 @@ ZEND_METHOD(Closure, call)
 	closure = (zend_closure *) Z_OBJ_P(ZEND_THIS);
 
 	newobj = Z_OBJ_P(newthis);
+	newclass = newobj->ce;
 
-	if (!zend_valid_closure_binding(closure, newthis, Z_OBJCE_P(newthis))) {
+	if (!zend_valid_closure_binding(closure, newthis, newclass)) {
 		return;
 	}
 
 	if (closure->func.common.fn_flags & ZEND_ACC_GENERATOR) {
 		zval new_closure;
-		zend_create_closure(&new_closure, &closure->func, Z_OBJCE_P(newthis), closure->called_scope, newthis);
+		zend_create_closure(&new_closure, &closure->func, newclass, closure->called_scope, newthis);
 		closure = (zend_closure *) Z_OBJ(new_closure);
 		fci_cache.function_handler = &closure->func;
 	} else {
 		memcpy(&my_function, &closure->func, closure->func.type == ZEND_USER_FUNCTION ? sizeof(zend_op_array) : sizeof(zend_internal_function));
 		my_function.common.fn_flags &= ~ZEND_ACC_CLOSURE;
 		/* use scope of passed object */
-		my_function.common.scope = Z_OBJCE_P(newthis);
+		my_function.common.scope = newclass;
 		fci_cache.function_handler = &my_function;
 
 		/* Runtime cache relies on bound scope to be immutable, hence we need a separate rt cache in case scope changed */
 		if (ZEND_USER_CODE(my_function.type)
-		 && (closure->func.common.scope != Z_OBJCE_P(newthis)
+		 && (closure->func.common.scope != newclass
 		  || (closure->func.common.fn_flags & ZEND_ACC_HEAP_RT_CACHE))) {
 			void *ptr;
 
@@ -172,7 +174,7 @@ ZEND_METHOD(Closure, call)
 		}
 	}
 
-	fci_cache.called_scope = newobj->ce;
+	fci_cache.called_scope = newclass;
 	fci_cache.object = fci.object = newobj;
 
 	fci.size = sizeof(fci);

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -181,8 +181,8 @@ static zend_object* zend_weakref_new(zend_class_entry *ce) {
 	return &wr->std;
 }
 
-static zend_always_inline zend_bool zend_weakref_find(zval *referent, zval *return_value) {
-	void *tagged_ptr = zend_hash_index_find_ptr(&EG(weakrefs), (zend_ulong) Z_OBJ_P(referent));
+static zend_always_inline zend_bool zend_weakref_find(zend_object *referent, zval *return_value) {
+	void *tagged_ptr = zend_hash_index_find_ptr(&EG(weakrefs), (zend_ulong) referent);
 	if (!tagged_ptr) {
 		return 0;
 	}
@@ -209,13 +209,13 @@ found_weakref:
 	return 0;
 }
 
-static zend_always_inline void zend_weakref_create(zval *referent, zval *return_value) {
+static zend_always_inline void zend_weakref_create(zend_object *referent, zval *return_value) {
 	zend_weakref *wr;
 
 	object_init_ex(return_value, zend_ce_weakref);
 
 	wr = zend_weakref_fetch(return_value);
-	wr->referent = Z_OBJ_P(referent);
+	wr->referent = referent;
 
 	zend_weakref_register(wr->referent, ZEND_WEAKREF_ENCODE(wr, ZEND_WEAKREF_TAG_REF));
 }
@@ -245,10 +245,10 @@ ZEND_COLD ZEND_METHOD(WeakReference, __construct)
 
 ZEND_METHOD(WeakReference, create)
 {
-	zval *referent;
+	zend_object *referent;
 
 	ZEND_PARSE_PARAMETERS_START(1,1)
-		Z_PARAM_OBJECT(referent)
+		Z_PARAM_OBJ(referent)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (zend_weakref_find(referent, return_value)) {

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -641,13 +641,13 @@ PHP_FUNCTION(spl_object_hash)
 /* {{{ Returns the integer object handle for the given object */
 PHP_FUNCTION(spl_object_id)
 {
-	zval *obj;
+	zend_object *obj;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJECT(obj)
+		Z_PARAM_OBJ(obj)
 	ZEND_PARSE_PARAMETERS_END();
 
-	RETURN_LONG((zend_long)Z_OBJ_HANDLE_P(obj));
+	RETURN_LONG((zend_long)obj->handle);
 }
 /* }}} */
 


### PR DESCRIPTION
In some cases, like spl_object_id, the code is simpler but equally efficient
after optimizations.

In other cases, like get_mangled_object_vars(), the compiler can't infer that
the object in the zval won't change.