### PR TITLE
Export php_getenv() API

### DIFF
--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -137,6 +137,8 @@ typedef struct {
 } putenv_entry;
 #endif
 
+PHPAPI zend_string *php_getenv(const char *str, size_t str_len);
+
 PHPAPI double php_get_nan(void);
 PHPAPI double php_get_inf(void);
 


### PR DESCRIPTION
This exports a php_getenv() API which will fetch an environment
variable in a thread-safe manner (assuming all other environment
manipulations are thread-safe ... ha ha ha).