### PR TITLE
Throw ValueError instead of TypeError for malformed GMP number

### DIFF
--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -614,7 +614,7 @@ static zend_result convert_to_gmp(mpz_t gmpnumber, zval *val, zend_long base, ui
 					"Cannot convert variable to GMP, it is not an integer string");
 				return FAILURE;
 			}
-			zend_argument_type_error(arg_pos, "is not an integer string");
+			zend_argument_value_error(arg_pos, "is not an integer string");
 			return FAILURE;
 		}
 

--- a/ext/gmp/tests/003.phpt
+++ b/ext/gmp/tests/003.phpt
@@ -25,7 +25,7 @@ Check for number base recognition
         $test[] = gmp_init("0x4d2", 16);
         try {
             $test[] = gmp_init("4d2");
-        } catch (\TypeError $e) {
+        } catch (\ValueError $e) {
             echo $e->getMessage() . \PHP_EOL;
         }
         $test[] = gmp_init("4d2", 16);

--- a/ext/gmp/tests/bug66872.phpt
+++ b/ext/gmp/tests/bug66872.phpt
@@ -7,7 +7,7 @@ Bug #66872: Crash when passing string to gmp_testbit
 
 try {
     var_dump(gmp_testbit("abc", 1));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 

--- a/ext/gmp/tests/bug80560.phpt
+++ b/ext/gmp/tests/bug80560.phpt
@@ -15,9 +15,6 @@ $functions1 = [
     'gmp_fact',
     'gmp_sqrt',
     'gmp_sqrtrem',
-    'gmp_root',
-    'gmp_rootrem',
-    'gmp_pow',
     'gmp_perfect_square',
     'gmp_perfect_power',
     'gmp_prob_prime',
@@ -25,12 +22,16 @@ $functions1 = [
     'gmp_random_seed',
     'gmp_popcount',
     'gmp_com',
+    'gmp_nextprime',
 ];
 $functions1_need_int_2 = [
     'gmp_testbit',
     'gmp_scan0',
     'gmp_scan1',
     'gmp_binomial',
+    'gmp_root',
+    'gmp_rootrem',
+    'gmp_pow',
 ];
 $functions2 = [
     'gmp_add',
@@ -55,7 +56,6 @@ $functions2 = [
     'gmp_or',
     'gmp_xor',
     'gmp_hamdist',
-    'gmp_nextprime',
 ];
 $functions3 = [
     'gmp_powm',
@@ -65,24 +65,24 @@ echo 'Explicit base with gmp_init:', \PHP_EOL;
 echo 'Hexadecimal', \PHP_EOL;
 try {
     var_dump(gmp_init('0X', 16));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 try {
     var_dump(gmp_init('0x', 16));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 
 echo 'Binary', \PHP_EOL;
 try {
     var_dump(gmp_init('0B', 2));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 try {
     var_dump(gmp_init('0b', 2));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 
@@ -91,121 +91,121 @@ foreach ($functions1 as $function) {
     try {
         $function('0B');
         echo $function, ' failed with 0B', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0b');
         echo $function, ' failed with 0b', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0X');
         echo $function, ' failed with 0X', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0x');
         echo $function, ' failed with 0x', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
 }
 foreach ($functions1_need_int_2 as $function) {
     try {
         $function('0B', 1);
         echo $function, ' failed with 0B', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0b', 1);
         echo $function, ' failed with 0b', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0X', 1);
         echo $function, ' failed with 0X', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0x', 1);
         echo $function, ' failed with 0x', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
 }
 foreach ($functions2 as $function) {
     try {
         $function('0B', 1);
         echo $function, ' arg 1 failed with 0B', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0b', 1);
         echo $function, ' arg 1 failed with 0b', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0X', 1);
         echo $function, ' arg 1 failed with 0X', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0x', 1);
         echo $function, ' arg 1 failed with 0x', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, '0B');
         echo $function, ' arg 2 failed with 0B', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, '0b');
         echo $function, ' arg 2 failed with 0b', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, '0X');
         echo $function, ' arg 2 failed with 0X', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, '0x');
         echo $function, ' arg 2 failed with 0x', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
 }
 foreach ($functions3 as $function) {
     try {
         $function('0B', 1, 1);
         echo $function, ' arg 1 failed with 0B', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0b', 1, 1);
         echo $function, ' arg 1 failed with 0b', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0X', 1, 1);
         echo $function, ' arg 1 failed with 0X', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function('0x', 1, 1);
         echo $function, ' arg 1 failed with 0x', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, '0B', 1);
         echo $function, ' arg 2 failed with 0B', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, '0b', 1);
         echo $function, ' arg 2 failed with 0b', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, '0X', 1);
         echo $function, ' arg 2 failed with 0X', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, '0x', 1);
         echo $function, ' arg 2 failed with 0x', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, 1, '0B');
         echo $function, ' arg 3 failed with 0B', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, 1, '0b');
         echo $function, ' arg 3 failed with 0b', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, 1, '0X');
         echo $function, ' arg 3 failed with 0X', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
     try {
         $function(1, 1, '0x');
         echo $function, ' arg 3 failed with 0x', \PHP_EOL;
-    } catch (\TypeError) { }
+    } catch (\ValueError) { }
 }
 
 echo "Done\n";

--- a/ext/gmp/tests/gmp_abs.phpt
+++ b/ext/gmp/tests/gmp_abs.phpt
@@ -7,7 +7,7 @@ gmp_abs() basic tests
 
 try {
     var_dump(gmp_strval(gmp_abs("")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 var_dump(gmp_strval(gmp_abs("0")));
@@ -24,13 +24,13 @@ var_dump(gmp_strval(gmp_abs("0000")));
 try {
     // Base 8
     var_dump(gmp_strval(gmp_abs("09876543")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
     // Base 8
     var_dump(gmp_strval(gmp_abs("-099987654")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 

--- a/ext/gmp/tests/gmp_and.phpt
+++ b/ext/gmp/tests/gmp_and.phpt
@@ -13,7 +13,7 @@ var_dump(gmp_strval(gmp_and(4545, -20)));
 
 try {
     var_dump(gmp_strval(gmp_and("test", "no test")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 

--- a/ext/gmp/tests/gmp_com.phpt
+++ b/ext/gmp/tests/gmp_com.phpt
@@ -9,7 +9,7 @@ var_dump(gmp_strval(gmp_com(0)));
 var_dump(gmp_strval(gmp_com("0")));
 try {
     var_dump(gmp_strval(gmp_com("test")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 var_dump(gmp_strval(gmp_com("2394876545678")));

--- a/ext/gmp/tests/gmp_fact.phpt
+++ b/ext/gmp/tests/gmp_fact.phpt
@@ -8,7 +8,7 @@ gmp_fact() basic tests
 var_dump(gmp_strval(gmp_fact(0)));
 try {
     var_dump(gmp_strval(gmp_fact("")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 var_dump(gmp_strval(gmp_fact("0")));

--- a/ext/gmp/tests/gmp_init.phpt
+++ b/ext/gmp/tests/gmp_init.phpt
@@ -15,17 +15,17 @@ try {
 
 try {
     var_dump(gmp_init("",36));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
     var_dump(gmp_init("foo",3));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
     var_dump(gmp_strval(gmp_init("993247326237679187178",3)));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 

--- a/ext/gmp/tests/gmp_intval.phpt
+++ b/ext/gmp/tests/gmp_intval.phpt
@@ -16,7 +16,7 @@ var_dump(gmp_intval($g));
 
 try {
     var_dump(gmp_intval(""));
-} catch (TypeError $e) {
+} catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
 try {
@@ -31,7 +31,7 @@ try {
 }
 try {
     var_dump(gmp_intval("1.0001"));
-} catch (TypeError $e) {
+} catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
 

--- a/ext/gmp/tests/gmp_mod.phpt
+++ b/ext/gmp/tests/gmp_mod.phpt
@@ -7,7 +7,7 @@ gmp_mod tests()
 
 try {
     var_dump(gmp_mod("",""));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 var_dump(gmp_mod(0,1));

--- a/ext/gmp/tests/gmp_neg.phpt
+++ b/ext/gmp/tests/gmp_neg.phpt
@@ -12,7 +12,7 @@ var_dump(gmp_intval(gmp_neg("-1")));
 
 try {
     var_dump(gmp_intval(gmp_neg("")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 

--- a/ext/gmp/tests/gmp_nextprime.phpt
+++ b/ext/gmp/tests/gmp_nextprime.phpt
@@ -25,7 +25,7 @@ try {
 try {
     $n = gmp_nextprime("");
     var_dump(gmp_strval($n));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {

--- a/ext/gmp/tests/gmp_or.phpt
+++ b/ext/gmp/tests/gmp_or.phpt
@@ -13,7 +13,7 @@ var_dump(gmp_strval(gmp_or(4545, -20)));
 
 try {
     var_dump(gmp_strval(gmp_or("test", "no test")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 

--- a/ext/gmp/tests/gmp_random_seed.phpt
+++ b/ext/gmp/tests/gmp_random_seed.phpt
@@ -108,7 +108,7 @@ var_dump(gmp_strval(gmp_random_range(-10000, 0)));
 // standard non conversion error
 try {
     var_dump(gmp_random_seed('not a number'));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 

--- a/ext/gmp/tests/gmp_sign.phpt
+++ b/ext/gmp/tests/gmp_sign.phpt
@@ -13,13 +13,13 @@ var_dump(gmp_sign("-34535345345"));
 
 try {
     var_dump(gmp_sign("+34534573457345"));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
     $n = gmp_init("098909878976786545");
     var_dump(gmp_sign($n));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {

--- a/ext/gmp/tests/gmp_strval.phpt
+++ b/ext/gmp/tests/gmp_strval.phpt
@@ -7,7 +7,7 @@ gmp_strval() tests
 
 try {
     var_dump(gmp_strval(""));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {

--- a/ext/gmp/tests/gmp_sub.phpt
+++ b/ext/gmp/tests/gmp_sub.phpt
@@ -7,7 +7,7 @@ gmp_sub() tests
 
 try {
     var_dump(gmp_sub("", ""));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {

--- a/ext/gmp/tests/gmp_xor.phpt
+++ b/ext/gmp/tests/gmp_xor.phpt
@@ -13,7 +13,7 @@ var_dump(gmp_strval(gmp_xor(4545, -20)));
 
 try {
     var_dump(gmp_strval(gmp_xor("test", "no test")));
-} catch (\TypeError $e) {
+} catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 


### PR DESCRIPTION
As discussed in #6545, passing an invalid string to GMP should throw a ValueError rather than a TypeError.

cc @Girgias @cmb69 