### PR TITLE
Fix bug #80584: 0x and 0X are considered valid hex numbers by filter_var()

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -233,6 +233,9 @@ void php_filter_int(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 		p++; len--;
 		if (allow_hex && (*p == 'x' || *p == 'X')) {
 			p++; len--;
+			if (len == 0) {
+				RETURN_VALIDATION_FAILED
+			}
 			if (php_filter_parse_hex(p, len, &ctx_value) < 0) {
 				error = 1;
 			}

--- a/ext/filter/tests/bug80584.phpt
+++ b/ext/filter/tests/bug80584.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #80584: "0x" and "0X" are considered valid hex numbers by filter_var()
+--SKIPIF--
+<?php
+if (!extension_loaded('filter')) die('skip filter extension not available');
+?>
+--FILE--
+<?php
+var_dump(filter_var('0x', FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX));
+var_dump(filter_var('0X', FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX));
+var_dump(filter_var('', FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX));
+var_dump(filter_var('0', FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX));
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+int(0)


### PR DESCRIPTION
Similarly to #6549 for GMP but for the filter extension.

This issue exists in PHP 7 and is long standing behaviour therefore I'm only targetting PHP 8.0 for this.