### PR TITLE
Fix mysqli stubs

### DIFF
--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -390,7 +390,7 @@ class mysqli_stmt
     public function __construct(mysqli $mysqli, ?string $query = null) {}
 
     /**
-     * @return int|false
+     * @return int
      * @alias mysqli_stmt_attr_get
      */
     public function attr_get(int $attribute) {}

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -36,7 +36,7 @@ class mysqli
     public function change_user(string $username, string $password, ?string $database) {}
 
     /**
-     * @return string|null
+     * @return string
      * @alias mysqli_character_set_name
      */
     public function character_set_name() {}
@@ -101,7 +101,7 @@ class mysqli
 #endif
 
     /**
-     * @return string|null
+     * @return string
      * @alias mysqli_get_server_info
      */
     public function get_server_info() {}
@@ -527,7 +527,7 @@ function mysqli_begin_transaction(mysqli $mysqli, int $flags = 0, ?string $name 
 
 function mysqli_change_user(mysqli $mysqli, string $username, string $password, ?string $database): bool {}
 
-function mysqli_character_set_name(mysqli $mysqli): ?string {}
+function mysqli_character_set_name(mysqli $mysqli): string {}
 
 function mysqli_close(mysqli $mysqli): bool {}
 
@@ -554,7 +554,7 @@ function mysqli_debug(string $options): bool {}
 
 function mysqli_errno(mysqli $mysqli): int {}
 
-function mysqli_error(mysqli $mysqli): ?string {}
+function mysqli_error(mysqli $mysqli): string {}
 
 function mysqli_error_list(mysqli $mysqli): array {}
 
@@ -691,7 +691,7 @@ function mysqli_stmt_data_seek(mysqli_stmt $statement, int $offset): void {}
 
 function mysqli_stmt_errno(mysqli_stmt $statement): int {}
 
-function mysqli_stmt_error(mysqli_stmt $statement): ?string {}
+function mysqli_stmt_error(mysqli_stmt $statement): string {}
 
 function mysqli_stmt_error_list(mysqli_stmt $statement): array {}
 
@@ -731,9 +731,9 @@ function mysqli_stmt_send_long_data(mysqli_stmt $statement, int $param_num, stri
 
 function mysqli_stmt_store_result(mysqli_stmt $statement): bool {}
 
-function mysqli_stmt_sqlstate(mysqli_stmt $statement): ?string {}
+function mysqli_stmt_sqlstate(mysqli_stmt $statement): string {}
 
-function mysqli_sqlstate(mysqli $mysqli): ?string {}
+function mysqli_sqlstate(mysqli $mysqli): string {}
 
 function mysqli_ssl_set(
     mysqli $mysqli,

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -634,6 +634,12 @@ function mysqli_num_rows(mysqli_result $result): int|string {}
 /** @param string|int $value */
 function mysqli_options(mysqli $mysqli, int $option, $value): bool {}
 
+/**
+ * @param string|int $value
+ * @alias mysqli_options
+ */
+function mysqli_set_opt(mysqli $mysqli, int $option, $value): bool {}
+
 function mysqli_ping(mysqli $mysqli): bool {}
 
 #if defined(MYSQLI_USE_MYSQLND)
@@ -658,6 +664,9 @@ function mysqli_real_connect(
 ): bool {}
 
 function mysqli_real_escape_string(mysqli $mysqli, string $string): string {}
+
+/** @alias mysqli_real_escape_string */
+function mysqli_escape_string(mysqli $mysqli, string $string): string {}
 
 function mysqli_real_query(mysqli $mysqli, string $query): bool {}
 
@@ -757,12 +766,3 @@ function mysqli_use_result(mysqli $mysqli): mysqli_result|false {}
 function mysqli_warning_count(mysqli $mysqli): int {}
 
 function mysqli_refresh(mysqli $mysqli, int $flags): bool {}
-
-/** @alias mysqli_real_escape_string */
-function mysqli_escape_string(mysqli $mysqli, string $string): string {}
-
-/**
- * @param string|int $value
- * @alias mysqli_options
- */
-function mysqli_set_opt(mysqli $mysqli, int $option, $value): bool {}

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -152,7 +152,7 @@ class mysqli
      * @return int|false
      * @alias mysqli_poll
      */
-    public static function poll(?array &$read, ?array &$write, array &$error, int $seconds, int $microseconds = 0) {}
+    public static function poll(array &$read, array &$error, array &$reject, int $seconds, int $microseconds = 0) {}
 #endif
 
     /**
@@ -637,7 +637,7 @@ function mysqli_options(mysqli $mysqli, int $option, $value): bool {}
 function mysqli_ping(mysqli $mysqli): bool {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_poll(?array &$read, ?array &$write, array &$error, int $seconds, int $microseconds = 0): int|false {}
+function mysqli_poll(array &$read, array &$error, array &$reject, int $seconds, int $microseconds = 0): int|false {}
 #endif
 
 function mysqli_prepare(mysqli $mysqli, string $query): mysqli_stmt|false {}

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -405,13 +405,13 @@ class mysqli_stmt
      * @return bool
      * @alias mysqli_stmt_bind_param
      */
-    public function bind_param(string $types, mixed &...$vars) {}
+    public function bind_param(string $types, mixed &$var, mixed &...$vars) {}
 
     /**
      * @return bool
      * @alias mysqli_stmt_bind_result
      */
-    public function bind_result(mixed &...$vars) {}
+    public function bind_result( mixed &$var, mixed &...$vars) {}
 
     /**
      * @return bool
@@ -690,9 +690,9 @@ function mysqli_stmt_attr_get(mysqli_stmt $statement, int $attribute): int {}
 
 function mysqli_stmt_attr_set(mysqli_stmt $statement, int $attribute, int $value): bool {}
 
-function mysqli_stmt_bind_param(mysqli_stmt $statement, string $types, mixed &...$vars): bool {}
+function mysqli_stmt_bind_param(mysqli_stmt $statement, string $types, mixed &$var, mixed &...$vars): bool {}
 
-function mysqli_stmt_bind_result(mysqli_stmt $statement, mixed &...$vars): bool {}
+function mysqli_stmt_bind_result(mysqli_stmt $statement, mixed &$var, mixed &...$vars): bool {}
 
 function mysqli_stmt_close(mysqli_stmt $statement): bool {}
 

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -51,7 +51,7 @@ class mysqli
      * @return bool
      * @alias mysqli_commit
      */
-    public function commit(int $flags = -1, ?string $name = null) {}
+    public function commit(int $flags = 0, ?string $name = null) {}
 
     /**
      * @return mysqli|null|false
@@ -531,7 +531,7 @@ function mysqli_character_set_name(mysqli $mysqli): ?string {}
 
 function mysqli_close(mysqli $mysqli): bool {}
 
-function mysqli_commit(mysqli $mysqli, int $flags = -1, ?string $name = null): bool {}
+function mysqli_commit(mysqli $mysqli, int $flags = 0, ?string $name = null): bool {}
 
 function mysqli_connect(
     ?string $hostname = null,

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -302,7 +302,7 @@ class mysqli
 
 class mysqli_result implements IteratorAggregate
 {
-    public function __construct(mysqli $mysql, int $result_mode = MYSQLI_STORE_RESULT) {}
+    public function __construct(mysqli $mysqli, int $result_mode = MYSQLI_STORE_RESULT) {}
 
     /**
      * @return void
@@ -387,7 +387,7 @@ class mysqli_result implements IteratorAggregate
 
 class mysqli_stmt
 {
-    public function __construct(mysqli $mysql, ?string $query = null) {}
+    public function __construct(mysqli $mysqli, ?string $query = null) {}
 
     /**
      * @return int|false
@@ -519,19 +519,19 @@ final class mysqli_sql_exception extends RuntimeException
 {
 }
 
-function mysqli_affected_rows(mysqli $mysql): int|string {}
+function mysqli_affected_rows(mysqli $mysqli): int|string {}
 
-function mysqli_autocommit(mysqli $mysql, bool $enable): bool {}
+function mysqli_autocommit(mysqli $mysqli, bool $enable): bool {}
 
-function mysqli_begin_transaction(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
+function mysqli_begin_transaction(mysqli $mysqli, int $flags = 0, ?string $name = null): bool {}
 
-function mysqli_change_user(mysqli $mysql, string $username, string $password, ?string $database): bool {}
+function mysqli_change_user(mysqli $mysqli, string $username, string $password, ?string $database): bool {}
 
-function mysqli_character_set_name(mysqli $mysql): ?string {}
+function mysqli_character_set_name(mysqli $mysqli): ?string {}
 
-function mysqli_close(mysqli $mysql): bool {}
+function mysqli_close(mysqli $mysqli): bool {}
 
-function mysqli_commit(mysqli $mysql, int $flags = -1, ?string $name = null): bool {}
+function mysqli_commit(mysqli $mysqli, int $flags = -1, ?string $name = null): bool {}
 
 function mysqli_connect(
     ?string $hostname = null,
@@ -548,15 +548,15 @@ function mysqli_connect_error(): ?string {}
 
 function mysqli_data_seek(mysqli_result $result, int $offset): bool {}
 
-function mysqli_dump_debug_info(mysqli $mysql): bool {}
+function mysqli_dump_debug_info(mysqli $mysqli): bool {}
 
 function mysqli_debug(string $options): bool {}
 
-function mysqli_errno(mysqli $mysql): int {}
+function mysqli_errno(mysqli $mysqli): int {}
 
-function mysqli_error(mysqli $mysql): ?string {}
+function mysqli_error(mysqli $mysqli): ?string {}
 
-function mysqli_error_list(mysqli $mysql): array {}
+function mysqli_error_list(mysqli $mysqli): array {}
 
 function mysqli_stmt_execute(mysqli_stmt $statement): bool {}
 
@@ -581,7 +581,7 @@ function mysqli_fetch_object(mysqli_result $result, string $class = "stdClass", 
 
 function mysqli_fetch_row(mysqli_result $result): ?array {}
 
-function mysqli_field_count(mysqli $mysql): int {}
+function mysqli_field_count(mysqli $mysqli): int {}
 
 function mysqli_field_seek(mysqli_result $result, int $index): bool {}
 
@@ -590,64 +590,64 @@ function mysqli_field_tell(mysqli_result $result): int {}
 function mysqli_free_result(mysqli_result $result): void {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_get_connection_stats(mysqli $mysql): array {}
+function mysqli_get_connection_stats(mysqli $mysqli): array {}
 
 function mysqli_get_client_stats(): array {}
 #endif
 
-function mysqli_get_charset(mysqli $mysql): ?object {}
+function mysqli_get_charset(mysqli $mysqli): ?object {}
 
-function mysqli_get_client_info(?mysqli $mysql = null): ?string {}
+function mysqli_get_client_info(?mysqli $mysqli = null): ?string {}
 
 function mysqli_get_client_version(): int {}
 
 function mysqli_get_links_stats(): array {}
 
-function mysqli_get_host_info(mysqli $mysql): string {}
+function mysqli_get_host_info(mysqli $mysqli): string {}
 
-function mysqli_get_proto_info(mysqli $mysql): int {}
+function mysqli_get_proto_info(mysqli $mysqli): int {}
 
-function mysqli_get_server_info(mysqli $mysql): string {}
+function mysqli_get_server_info(mysqli $mysqli): string {}
 
-function mysqli_get_server_version(mysqli $mysql): int {}
+function mysqli_get_server_version(mysqli $mysqli): int {}
 
-function mysqli_get_warnings(mysqli $mysql): mysqli_warning|false {}
+function mysqli_get_warnings(mysqli $mysqli): mysqli_warning|false {}
 
 function mysqli_init(): mysqli|false {}
 
-function mysqli_info(mysqli $mysql): ?string {}
+function mysqli_info(mysqli $mysqli): ?string {}
 
-function mysqli_insert_id(mysqli $mysql): int|string {}
+function mysqli_insert_id(mysqli $mysqli): int|string {}
 
-function mysqli_kill(mysqli $mysql, int $process_id): bool {}
+function mysqli_kill(mysqli $mysqli, int $process_id): bool {}
 
-function mysqli_more_results(mysqli $mysql): bool {}
+function mysqli_more_results(mysqli $mysqli): bool {}
 
-function mysqli_multi_query(mysqli $mysql, string $query): bool {}
+function mysqli_multi_query(mysqli $mysqli, string $query): bool {}
 
-function mysqli_next_result(mysqli $mysql): bool {}
+function mysqli_next_result(mysqli $mysqli): bool {}
 
 function mysqli_num_fields(mysqli_result $result): int {}
 
 function mysqli_num_rows(mysqli_result $result): int|string {}
 
 /** @param string|int $value */
-function mysqli_options(mysqli $mysql, int $option, $value): bool {}
+function mysqli_options(mysqli $mysqli, int $option, $value): bool {}
 
-function mysqli_ping(mysqli $mysql): bool {}
+function mysqli_ping(mysqli $mysqli): bool {}
 
 #if defined(MYSQLI_USE_MYSQLND)
 function mysqli_poll(?array &$read, ?array &$write, array &$error, int $seconds, int $microseconds = 0): int|false {}
 #endif
 
-function mysqli_prepare(mysqli $mysql, string $query): mysqli_stmt|false {}
+function mysqli_prepare(mysqli $mysqli, string $query): mysqli_stmt|false {}
 
 function mysqli_report(int $flags): bool {}
 
-function mysqli_query(mysqli $mysql, string $query, int $result_mode = MYSQLI_STORE_RESULT): mysqli_result|bool {}
+function mysqli_query(mysqli $mysqli, string $query, int $result_mode = MYSQLI_STORE_RESULT): mysqli_result|bool {}
 
 function mysqli_real_connect(
-    mysqli $mysql,
+    mysqli $mysqli,
     ?string $hostname = null,
     ?string $username = null,
     ?string $password = null,
@@ -657,23 +657,23 @@ function mysqli_real_connect(
     int $flags = 0
 ): bool {}
 
-function mysqli_real_escape_string(mysqli $mysql, string $string): string {}
+function mysqli_real_escape_string(mysqli $mysqli, string $string): string {}
 
-function mysqli_real_query(mysqli $mysql, string $query): bool {}
+function mysqli_real_query(mysqli $mysqli, string $query): bool {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_reap_async_query(mysqli $mysql): mysqli_result|bool {}
+function mysqli_reap_async_query(mysqli $mysqli): mysqli_result|bool {}
 #endif
 
-function mysqli_release_savepoint(mysqli $mysql, string $name): bool {}
+function mysqli_release_savepoint(mysqli $mysqli, string $name): bool {}
 
-function mysqli_rollback(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
+function mysqli_rollback(mysqli $mysqli, int $flags = 0, ?string $name = null): bool {}
 
-function mysqli_savepoint(mysqli $mysql, string $name): bool {}
+function mysqli_savepoint(mysqli $mysqli, string $name): bool {}
 
-function mysqli_select_db(mysqli $mysql, string $database): bool {}
+function mysqli_select_db(mysqli $mysqli, string $database): bool {}
 
-function mysqli_set_charset(mysqli $mysql, string $charset): bool {}
+function mysqli_set_charset(mysqli $mysqli, string $charset): bool {}
 
 function mysqli_stmt_affected_rows(mysqli_stmt $statement): int|string {}
 
@@ -707,7 +707,7 @@ function mysqli_stmt_get_result(mysqli_stmt $statement): mysqli_result|false {}
 
 function mysqli_stmt_get_warnings(mysqli_stmt $statement): mysqli_warning|false {}
 
-function mysqli_stmt_init(mysqli $mysql): mysqli_stmt|false {}
+function mysqli_stmt_init(mysqli $mysqli): mysqli_stmt|false {}
 
 function mysqli_stmt_insert_id(mysqli_stmt $statement): int|string {}
 
@@ -733,10 +733,10 @@ function mysqli_stmt_store_result(mysqli_stmt $statement): bool {}
 
 function mysqli_stmt_sqlstate(mysqli_stmt $statement): ?string {}
 
-function mysqli_sqlstate(mysqli $mysql): ?string {}
+function mysqli_sqlstate(mysqli $mysqli): ?string {}
 
 function mysqli_ssl_set(
-    mysqli $mysql,
+    mysqli $mysqli,
     string $key,
     string $certificate,
     string $ca_certificate,
@@ -744,25 +744,25 @@ function mysqli_ssl_set(
     string $cipher_algos
 ): bool {}
 
-function mysqli_stat(mysqli $mysql): string|false {}
+function mysqli_stat(mysqli $mysqli): string|false {}
 
-function mysqli_store_result(mysqli $mysql, int $mode = 0): mysqli_result|false {}
+function mysqli_store_result(mysqli $mysqli, int $mode = 0): mysqli_result|false {}
 
-function mysqli_thread_id(mysqli $mysql): int {}
+function mysqli_thread_id(mysqli $mysqli): int {}
 
 function mysqli_thread_safe(): bool {}
 
-function mysqli_use_result(mysqli $mysql): mysqli_result|false {}
+function mysqli_use_result(mysqli $mysqli): mysqli_result|false {}
 
-function mysqli_warning_count(mysqli $mysql): int {}
+function mysqli_warning_count(mysqli $mysqli): int {}
 
-function mysqli_refresh(mysqli $mysql, int $flags): bool {}
+function mysqli_refresh(mysqli $mysqli, int $flags): bool {}
 
 /** @alias mysqli_real_escape_string */
-function mysqli_escape_string(mysqli $mysql, string $string): string {}
+function mysqli_escape_string(mysqli $mysqli, string $string): string {}
 
 /**
  * @param string|int $value
  * @alias mysqli_options
  */
-function mysqli_set_opt(mysqli $mysql, int $option, $value): bool {}
+function mysqli_set_opt(mysqli $mysqli, int $option, $value): bool {}

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -302,7 +302,7 @@ class mysqli
 
 class mysqli_result implements IteratorAggregate
 {
-    public function __construct(mysqli $mysqli, int $result_mode = MYSQLI_STORE_RESULT) {}
+    public function __construct(mysqli $mysql, int $result_mode = MYSQLI_STORE_RESULT) {}
 
     /**
      * @return void
@@ -387,7 +387,7 @@ class mysqli_result implements IteratorAggregate
 
 class mysqli_stmt
 {
-    public function __construct(mysqli $mysqli, ?string $query = null) {}
+    public function __construct(mysqli $mysql, ?string $query = null) {}
 
     /**
      * @return int
@@ -519,19 +519,19 @@ final class mysqli_sql_exception extends RuntimeException
 {
 }
 
-function mysqli_affected_rows(mysqli $mysqli): int|string {}
+function mysqli_affected_rows(mysqli $mysql): int|string {}
 
-function mysqli_autocommit(mysqli $mysqli, bool $enable): bool {}
+function mysqli_autocommit(mysqli $mysql, bool $enable): bool {}
 
-function mysqli_begin_transaction(mysqli $mysqli, int $flags = 0, ?string $name = null): bool {}
+function mysqli_begin_transaction(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
 
-function mysqli_change_user(mysqli $mysqli, string $username, string $password, ?string $database): bool {}
+function mysqli_change_user(mysqli $mysql, string $username, string $password, ?string $database): bool {}
 
-function mysqli_character_set_name(mysqli $mysqli): string {}
+function mysqli_character_set_name(mysqli $mysql): string {}
 
-function mysqli_close(mysqli $mysqli): bool {}
+function mysqli_close(mysqli $mysql): bool {}
 
-function mysqli_commit(mysqli $mysqli, int $flags = 0, ?string $name = null): bool {}
+function mysqli_commit(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
 
 function mysqli_connect(
     ?string $hostname = null,
@@ -548,15 +548,15 @@ function mysqli_connect_error(): ?string {}
 
 function mysqli_data_seek(mysqli_result $result, int $offset): bool {}
 
-function mysqli_dump_debug_info(mysqli $mysqli): bool {}
+function mysqli_dump_debug_info(mysqli $mysql): bool {}
 
 function mysqli_debug(string $options): bool {}
 
-function mysqli_errno(mysqli $mysqli): int {}
+function mysqli_errno(mysqli $mysql): int {}
 
-function mysqli_error(mysqli $mysqli): string {}
+function mysqli_error(mysqli $mysql): string {}
 
-function mysqli_error_list(mysqli $mysqli): array {}
+function mysqli_error_list(mysqli $mysql): array {}
 
 function mysqli_stmt_execute(mysqli_stmt $statement): bool {}
 
@@ -581,7 +581,7 @@ function mysqli_fetch_object(mysqli_result $result, string $class = "stdClass", 
 
 function mysqli_fetch_row(mysqli_result $result): array|null|false {}
 
-function mysqli_field_count(mysqli $mysqli): int {}
+function mysqli_field_count(mysqli $mysql): int {}
 
 function mysqli_field_seek(mysqli_result $result, int $index): bool {}
 
@@ -590,70 +590,70 @@ function mysqli_field_tell(mysqli_result $result): int {}
 function mysqli_free_result(mysqli_result $result): void {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_get_connection_stats(mysqli $mysqli): array {}
+function mysqli_get_connection_stats(mysqli $mysql): array {}
 
 function mysqli_get_client_stats(): array {}
 #endif
 
-function mysqli_get_charset(mysqli $mysqli): ?object {}
+function mysqli_get_charset(mysqli $mysql): ?object {}
 
-function mysqli_get_client_info(?mysqli $mysqli = null): ?string {}
+function mysqli_get_client_info(?mysqli $mysql = null): ?string {}
 
 function mysqli_get_client_version(): int {}
 
 function mysqli_get_links_stats(): array {}
 
-function mysqli_get_host_info(mysqli $mysqli): string {}
+function mysqli_get_host_info(mysqli $mysql): string {}
 
-function mysqli_get_proto_info(mysqli $mysqli): int {}
+function mysqli_get_proto_info(mysqli $mysql): int {}
 
-function mysqli_get_server_info(mysqli $mysqli): string {}
+function mysqli_get_server_info(mysqli $mysql): string {}
 
-function mysqli_get_server_version(mysqli $mysqli): int {}
+function mysqli_get_server_version(mysqli $mysql): int {}
 
-function mysqli_get_warnings(mysqli $mysqli): mysqli_warning|false {}
+function mysqli_get_warnings(mysqli $mysql): mysqli_warning|false {}
 
 function mysqli_init(): mysqli|false {}
 
-function mysqli_info(mysqli $mysqli): ?string {}
+function mysqli_info(mysqli $mysql): ?string {}
 
-function mysqli_insert_id(mysqli $mysqli): int|string {}
+function mysqli_insert_id(mysqli $mysql): int|string {}
 
-function mysqli_kill(mysqli $mysqli, int $process_id): bool {}
+function mysqli_kill(mysqli $mysql, int $process_id): bool {}
 
-function mysqli_more_results(mysqli $mysqli): bool {}
+function mysqli_more_results(mysqli $mysql): bool {}
 
-function mysqli_multi_query(mysqli $mysqli, string $query): bool {}
+function mysqli_multi_query(mysqli $mysql, string $query): bool {}
 
-function mysqli_next_result(mysqli $mysqli): bool {}
+function mysqli_next_result(mysqli $mysql): bool {}
 
 function mysqli_num_fields(mysqli_result $result): int {}
 
 function mysqli_num_rows(mysqli_result $result): int|string {}
 
 /** @param string|int $value */
-function mysqli_options(mysqli $mysqli, int $option, $value): bool {}
+function mysqli_options(mysqli $mysql, int $option, $value): bool {}
 
 /**
  * @param string|int $value
  * @alias mysqli_options
  */
-function mysqli_set_opt(mysqli $mysqli, int $option, $value): bool {}
+function mysqli_set_opt(mysqli $mysql, int $option, $value): bool {}
 
-function mysqli_ping(mysqli $mysqli): bool {}
+function mysqli_ping(mysqli $mysql): bool {}
 
 #if defined(MYSQLI_USE_MYSQLND)
 function mysqli_poll(array &$read, array &$error, array &$reject, int $seconds, int $microseconds = 0): int|false {}
 #endif
 
-function mysqli_prepare(mysqli $mysqli, string $query): mysqli_stmt|false {}
+function mysqli_prepare(mysqli $mysql, string $query): mysqli_stmt|false {}
 
 function mysqli_report(int $flags): bool {}
 
-function mysqli_query(mysqli $mysqli, string $query, int $result_mode = MYSQLI_STORE_RESULT): mysqli_result|bool {}
+function mysqli_query(mysqli $mysql, string $query, int $result_mode = MYSQLI_STORE_RESULT): mysqli_result|bool {}
 
 function mysqli_real_connect(
-    mysqli $mysqli,
+    mysqli $mysql,
     ?string $hostname = null,
     ?string $username = null,
     ?string $password = null,
@@ -663,26 +663,26 @@ function mysqli_real_connect(
     int $flags = 0
 ): bool {}
 
-function mysqli_real_escape_string(mysqli $mysqli, string $string): string {}
+function mysqli_real_escape_string(mysqli $mysql, string $string): string {}
 
 /** @alias mysqli_real_escape_string */
-function mysqli_escape_string(mysqli $mysqli, string $string): string {}
+function mysqli_escape_string(mysqli $mysql, string $string): string {}
 
-function mysqli_real_query(mysqli $mysqli, string $query): bool {}
+function mysqli_real_query(mysqli $mysql, string $query): bool {}
 
 #if defined(MYSQLI_USE_MYSQLND)
-function mysqli_reap_async_query(mysqli $mysqli): mysqli_result|bool {}
+function mysqli_reap_async_query(mysqli $mysql): mysqli_result|bool {}
 #endif
 
-function mysqli_release_savepoint(mysqli $mysqli, string $name): bool {}
+function mysqli_release_savepoint(mysqli $mysql, string $name): bool {}
 
-function mysqli_rollback(mysqli $mysqli, int $flags = 0, ?string $name = null): bool {}
+function mysqli_rollback(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
 
-function mysqli_savepoint(mysqli $mysqli, string $name): bool {}
+function mysqli_savepoint(mysqli $mysql, string $name): bool {}
 
-function mysqli_select_db(mysqli $mysqli, string $database): bool {}
+function mysqli_select_db(mysqli $mysql, string $database): bool {}
 
-function mysqli_set_charset(mysqli $mysqli, string $charset): bool {}
+function mysqli_set_charset(mysqli $mysql, string $charset): bool {}
 
 function mysqli_stmt_affected_rows(mysqli_stmt $statement): int|string {}
 
@@ -716,7 +716,7 @@ function mysqli_stmt_get_result(mysqli_stmt $statement): mysqli_result|false {}
 
 function mysqli_stmt_get_warnings(mysqli_stmt $statement): mysqli_warning|false {}
 
-function mysqli_stmt_init(mysqli $mysqli): mysqli_stmt|false {}
+function mysqli_stmt_init(mysqli $mysql): mysqli_stmt|false {}
 
 function mysqli_stmt_insert_id(mysqli_stmt $statement): int|string {}
 
@@ -742,10 +742,10 @@ function mysqli_stmt_store_result(mysqli_stmt $statement): bool {}
 
 function mysqli_stmt_sqlstate(mysqli_stmt $statement): string {}
 
-function mysqli_sqlstate(mysqli $mysqli): string {}
+function mysqli_sqlstate(mysqli $mysql): string {}
 
 function mysqli_ssl_set(
-    mysqli $mysqli,
+    mysqli $mysql,
     string $key,
     string $certificate,
     string $ca_certificate,
@@ -753,16 +753,16 @@ function mysqli_ssl_set(
     string $cipher_algos
 ): bool {}
 
-function mysqli_stat(mysqli $mysqli): string|false {}
+function mysqli_stat(mysqli $mysql): string|false {}
 
-function mysqli_store_result(mysqli $mysqli, int $mode = 0): mysqli_result|false {}
+function mysqli_store_result(mysqli $mysql, int $mode = 0): mysqli_result|false {}
 
-function mysqli_thread_id(mysqli $mysqli): int {}
+function mysqli_thread_id(mysqli $mysql): int {}
 
 function mysqli_thread_safe(): bool {}
 
-function mysqli_use_result(mysqli $mysqli): mysqli_result|false {}
+function mysqli_use_result(mysqli $mysql): mysqli_result|false {}
 
-function mysqli_warning_count(mysqli $mysqli): int {}
+function mysqli_warning_count(mysqli $mysql): int {}
 
-function mysqli_refresh(mysqli $mysqli, int $flags): bool {}
+function mysqli_refresh(mysqli $mysql, int $flags): bool {}

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -341,7 +341,7 @@ class mysqli_result implements IteratorAggregate
     public function fetch_field_direct(int $index) {}
 
     /**
-     * @return array|false
+     * @return array
      * @alias mysqli_fetch_all
      */
     public function fetch_all(int $mode = MYSQLI_NUM) {}
@@ -571,15 +571,15 @@ function mysqli_fetch_field_direct(mysqli_result $result, int $index): object|fa
 
 function mysqli_fetch_lengths(mysqli_result $result): array|false {}
 
-function mysqli_fetch_all(mysqli_result $result, int $mode = MYSQLI_NUM): array|false {}
+function mysqli_fetch_all(mysqli_result $result, int $mode = MYSQLI_NUM): array {}
 
 function mysqli_fetch_array(mysqli_result $result, int $mode = MYSQLI_BOTH): array|null|false {}
 
-function mysqli_fetch_assoc(mysqli_result $result): ?array {}
+function mysqli_fetch_assoc(mysqli_result $result): array|null|false {}
 
-function mysqli_fetch_object(mysqli_result $result, string $class = "stdClass", array $constructor_args = []): ?object {}
+function mysqli_fetch_object(mysqli_result $result, string $class = "stdClass", array $constructor_args = []): object|null|false {}
 
-function mysqli_fetch_row(mysqli_result $result): ?array {}
+function mysqli_fetch_row(mysqli_result $result): array|null|false {}
 
 function mysqli_field_count(mysqli $mysqli): int {}
 

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -614,17 +614,13 @@ PHP_FUNCTION(mysqli_character_set_name)
 {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
-	const char	*cs_name;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
 		RETURN_THROWS();
 	}
 
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
-	cs_name = mysql_character_set_name(mysql->mysql);
-	if (cs_name) {
-		RETURN_STRING(cs_name);
-	}
+	RETURN_STRING(mysql_character_set_name(mysql->mysql));
 }
 /* }}} */
 
@@ -801,16 +797,12 @@ PHP_FUNCTION(mysqli_error)
 {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
-	const char	*err;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
-	err = mysql_error(mysql->mysql);
-	if (err) {
-		RETURN_STRING(err);
-	}
+	RETURN_STRING(mysql_error(mysql->mysql));
 }
 /* }}} */
 
@@ -1337,10 +1329,7 @@ PHP_FUNCTION(mysqli_get_client_info)
 		}
 	}
 
-	const char * info = mysql_get_client_info();
-	if (info) {
-		RETURN_STRING(info);
-	}
+	RETURN_STRING(mysql_get_client_info());
 }
 /* }}} */
 
@@ -2149,16 +2138,12 @@ PHP_FUNCTION(mysqli_sqlstate)
 {
 	MY_MYSQL	*mysql;
 	zval		*mysql_link;
-	const char	*state;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_link, mysqli_link_class_entry) == FAILURE) {
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_CONN(mysql, mysql_link, MYSQLI_STATUS_VALID);
-	state = mysql_sqlstate(mysql->mysql);
-	if (state) {
-		RETURN_STRING(state);
-	}
+	RETURN_STRING(mysql_sqlstate(mysql->mysql));
 }
 /* }}} */
 
@@ -2358,17 +2343,13 @@ PHP_FUNCTION(mysqli_stmt_error)
 {
 	MY_STMT	*stmt;
 	zval 	*mysql_stmt;
-	const char * err;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_INITIALIZED);
 
-	err = mysql_stmt_error(stmt->stmt);
-	if (err) {
-		RETURN_STRING(err);
-	}
+	RETURN_STRING(mysql_stmt_error(stmt->stmt));
 }
 /* }}} */
 
@@ -2499,17 +2480,13 @@ PHP_FUNCTION(mysqli_stmt_sqlstate)
 {
 	MY_STMT	*stmt;
 	zval	*mysql_stmt;
-	const char * state;
 
 	if (zend_parse_method_parameters(ZEND_NUM_ARGS(), getThis(), "O", &mysql_stmt, mysqli_stmt_class_entry) == FAILURE) {
 		RETURN_THROWS();
 	}
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
-	state = mysql_stmt_sqlstate(stmt->stmt);
-	if (state) {
-		RETURN_STRING(state);
-	}
+	RETURN_STRING(mysql_stmt_sqlstate(stmt->stmt));
 }
 /* }}} */
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,34 +1,34 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: eb8ca1a6d38ba3f9681fd7a970fe5e847109a0e9 */
+ * Stub hash: 0140fe8228358bcf1822c73f7c185f2e4c8a4218 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_autocommit, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_begin_transaction, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_change_user, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, username, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_character_set_name, 0, 1, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_close, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_commit arginfo_mysqli_begin_transaction
@@ -60,13 +60,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_debug, 0, 1, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_errno, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_error arginfo_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_error_list, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_execute, 0, 1, _IS_BOOL, 0)
@@ -131,7 +131,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_connection_stats, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -141,11 +141,11 @@ ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_charset, 0, 1, IS_OBJECT, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_client_info, 0, 0, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, mysqli, mysqli, 1, "null")
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, mysql, mysqli, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_get_client_version arginfo_mysqli_connect_errno
@@ -162,27 +162,27 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_get_server_version arginfo_mysqli_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_get_warnings, 0, 1, mysqli_warning, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_init, 0, 0, mysqli, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_info, 0, 1, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_insert_id arginfo_mysqli_affected_rows
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_kill, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_more_results arginfo_mysqli_close
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_multi_query, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -195,7 +195,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_num_rows, 0, 1, MAY_BE_LO
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_options, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
@@ -215,7 +215,7 @@ ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_prepare, 0, 2, mysqli_stmt, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -224,13 +224,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_report, 0, 1, _IS_BOOL, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_query, 0, 2, mysqli_result, MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_mode, IS_LONG, 0, "MYSQLI_STORE_RESULT")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_connect, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hostname, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
@@ -241,7 +241,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_connect, 0, 1, _IS_B
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_escape_string, 0, 2, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -251,12 +251,12 @@ ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_reap_async_query, 0, 1, mysqli_result, MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_release_savepoint, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -265,12 +265,12 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_savepoint arginfo_mysqli_release_savepoint
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_select_db, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_set_charset, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, charset, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -342,7 +342,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_get_warnings, 0,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_init, 0, 1, mysqli_stmt, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_insert_id arginfo_mysqli_stmt_affected_rows
@@ -383,7 +383,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_sqlstate arginfo_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_ssl_set, 0, 6, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, certificate, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, ca_certificate, IS_STRING, 0)
@@ -392,11 +392,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_ssl_set, 0, 6, _IS_BOOL, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_stat, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_store_result, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
@@ -406,13 +406,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_thread_safe, 0, 0, _IS_BO
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_use_result, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_warning_count arginfo_mysqli_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_refresh, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -571,7 +571,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_refresh, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_result___construct, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_mode, IS_LONG, 0, "MYSQLI_STORE_RESULT")
 ZEND_END_ARG_INFO()
 
@@ -616,7 +616,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_mysqli_result_getIterator, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt___construct, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, query, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 737d5140625959a8fdf34caf6f745dd9516f695f */
+ * Stub hash: ff5834526717c57caaa2f50747cf7169c3e4db56 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,41 +1,37 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cd300f5106294e193fa85adc9c8a18a68d7d322 */
+ * Stub hash: e5817db470fdc79783b99d299c40e0c38cee8a78 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_autocommit, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_begin_transaction, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_change_user, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, username, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_character_set_name, 0, 1, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_character_set_name, 0, 1, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_close, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_commit, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "-1")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_commit arginfo_mysqli_begin_transaction
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_connect, 0, 0, mysqli, MAY_BE_NULL|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hostname, IS_STRING, 1, "null")
@@ -64,13 +60,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_debug, 0, 1, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_errno, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_error arginfo_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_error_list, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_execute, 0, 1, _IS_BOOL, 0)
@@ -135,7 +131,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_connection_stats, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -145,11 +141,11 @@ ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_charset, 0, 1, IS_OBJECT, 1)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_client_info, 0, 0, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, mysql, mysqli, 1, "null")
+	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, mysqli, mysqli, 1, "null")
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_get_client_version arginfo_mysqli_connect_errno
@@ -157,36 +153,36 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_links_stats, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_host_info, 0, 1, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_mysqli_get_host_info arginfo_mysqli_character_set_name
 
 #define arginfo_mysqli_get_proto_info arginfo_mysqli_errno
 
-#define arginfo_mysqli_get_server_info arginfo_mysqli_get_host_info
+#define arginfo_mysqli_get_server_info arginfo_mysqli_character_set_name
 
 #define arginfo_mysqli_get_server_version arginfo_mysqli_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_get_warnings, 0, 1, mysqli_warning, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_init, 0, 0, mysqli, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 
-#define arginfo_mysqli_info arginfo_mysqli_character_set_name
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_info, 0, 1, IS_STRING, 1)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
+ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_insert_id arginfo_mysqli_affected_rows
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_kill, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_more_results arginfo_mysqli_close
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_multi_query, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -199,7 +195,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_num_rows, 0, 1, MAY_BE_LO
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_options, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
@@ -217,7 +213,7 @@ ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_prepare, 0, 2, mysqli_stmt, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -226,13 +222,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_report, 0, 1, _IS_BOOL, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_query, 0, 2, mysqli_result, MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_mode, IS_LONG, 0, "MYSQLI_STORE_RESULT")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_connect, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hostname, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, username, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
@@ -243,7 +239,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_connect, 0, 1, _IS_B
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_escape_string, 0, 2, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -251,12 +247,12 @@ ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_reap_async_query, 0, 1, mysqli_result, MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_release_savepoint, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -265,12 +261,12 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_savepoint arginfo_mysqli_release_savepoint
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_select_db, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, database, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_set_charset, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, charset, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -311,7 +307,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_errno, 0, 1, IS_LONG
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_error, 0, 1, IS_STRING, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_error, 0, 1, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 ZEND_END_ARG_INFO()
 
@@ -340,7 +336,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_get_warnings, 0,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_stmt_init, 0, 1, mysqli_stmt, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_stmt_insert_id arginfo_mysqli_stmt_affected_rows
@@ -381,7 +377,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_mysqli_sqlstate arginfo_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_ssl_set, 0, 6, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, certificate, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, ca_certificate, IS_STRING, 0)
@@ -390,11 +386,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_ssl_set, 0, 6, _IS_BOOL, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_stat, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_store_result, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
@@ -404,13 +400,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_thread_safe, 0, 0, _IS_BO
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_use_result, 0, 1, mysqli_result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_warning_count arginfo_mysqli_errno
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_refresh, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -447,10 +443,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_mysqli_close arginfo_class_mysqli_character_set_name
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_commit, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "-1")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_class_mysqli_commit arginfo_class_mysqli_begin_transaction
 
 #define arginfo_class_mysqli_connect arginfo_class_mysqli___construct
 
@@ -576,7 +569,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_refresh, 0, 0, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_result___construct, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_mode, IS_LONG, 0, "MYSQLI_STORE_RESULT")
 ZEND_END_ARG_INFO()
 
@@ -621,7 +614,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_mysqli_result_getIterator, 
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt___construct, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, query, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ff5834526717c57caaa2f50747cf7169c3e4db56 */
+ * Stub hash: eb8ca1a6d38ba3f9681fd7a970fe5e847109a0e9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
@@ -289,14 +289,16 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_attr_set, 0, 3, _IS_
 	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_param, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_param, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
 	ZEND_ARG_TYPE_INFO(0, types, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(1, var, IS_MIXED, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_result, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_bind_result, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, statement, mysqli_stmt, 0)
+	ZEND_ARG_TYPE_INFO(1, var, IS_MIXED, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
@@ -627,12 +629,14 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_attr_set, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_bind_param, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_bind_param, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, types, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(1, var, IS_MIXED, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_bind_result, 0, 0, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_stmt_bind_result, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(1, var, IS_MIXED, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(1, vars, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e5817db470fdc79783b99d299c40e0c38cee8a78 */
+ * Stub hash: e0704985c8ce165f984bb189d2104a8f97eaa29e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
@@ -204,9 +204,9 @@ ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_poll, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
-	ZEND_ARG_TYPE_INFO(1, write, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(1, error, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(1, reject, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microseconds, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
@@ -484,9 +484,9 @@ ZEND_END_ARG_INFO()
 
 #if defined(MYSQLI_USE_MYSQLND)
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli_poll, 0, 0, 4)
-	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
-	ZEND_ARG_TYPE_INFO(1, write, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(1, error, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(1, reject, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microseconds, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fd51ccecde65deb48adf0dcbc30a7b19277838e6 */
+ * Stub hash: 737d5140625959a8fdf34caf6f745dd9516f695f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
@@ -92,7 +92,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_lengths, 0, 1, MAY_
 	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_all, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_fetch_all, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "MYSQLI_NUM")
 ZEND_END_ARG_INFO()
@@ -102,11 +102,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_array, 0, 1, MAY_BE
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "MYSQLI_BOTH")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_fetch_assoc, 0, 1, IS_ARRAY, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_assoc, 0, 1, MAY_BE_ARRAY|MAY_BE_NULL|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_fetch_object, 0, 1, IS_OBJECT, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_object, 0, 1, MAY_BE_OBJECT|MAY_BE_NULL|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class, IS_STRING, 0, "\"stdClass\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, constructor_args, IS_ARRAY, 0, "[]")

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e0704985c8ce165f984bb189d2104a8f97eaa29e */
+ * Stub hash: fd51ccecde65deb48adf0dcbc30a7b19277838e6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
@@ -200,6 +200,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_options, 0, 3, _IS_BOOL, 
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
+#define arginfo_mysqli_set_opt arginfo_mysqli_options
+
 #define arginfo_mysqli_ping arginfo_mysqli_close
 
 #if defined(MYSQLI_USE_MYSQLND)
@@ -242,6 +244,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_real_escape_string, 0, 2,
 	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_mysqli_escape_string arginfo_mysqli_real_escape_string
 
 #define arginfo_mysqli_real_query arginfo_mysqli_multi_query
 
@@ -409,10 +413,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_refresh, 0, 2, _IS_BOOL, 
 	ZEND_ARG_OBJ_INFO(0, mysqli, mysqli, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
-
-#define arginfo_mysqli_escape_string arginfo_mysqli_real_escape_string
-
-#define arginfo_mysqli_set_opt arginfo_mysqli_options
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_mysqli___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, hostname, IS_STRING, 1, "null")
@@ -857,6 +857,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mysqli_num_fields, arginfo_mysqli_num_fields)
 	ZEND_FE(mysqli_num_rows, arginfo_mysqli_num_rows)
 	ZEND_FE(mysqli_options, arginfo_mysqli_options)
+	ZEND_FALIAS(mysqli_set_opt, mysqli_options, arginfo_mysqli_set_opt)
 	ZEND_FE(mysqli_ping, arginfo_mysqli_ping)
 #if defined(MYSQLI_USE_MYSQLND)
 	ZEND_FE(mysqli_poll, arginfo_mysqli_poll)
@@ -866,6 +867,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mysqli_query, arginfo_mysqli_query)
 	ZEND_FE(mysqli_real_connect, arginfo_mysqli_real_connect)
 	ZEND_FE(mysqli_real_escape_string, arginfo_mysqli_real_escape_string)
+	ZEND_FALIAS(mysqli_escape_string, mysqli_real_escape_string, arginfo_mysqli_escape_string)
 	ZEND_FE(mysqli_real_query, arginfo_mysqli_real_query)
 #if defined(MYSQLI_USE_MYSQLND)
 	ZEND_FE(mysqli_reap_async_query, arginfo_mysqli_reap_async_query)
@@ -915,8 +917,6 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mysqli_use_result, arginfo_mysqli_use_result)
 	ZEND_FE(mysqli_warning_count, arginfo_mysqli_warning_count)
 	ZEND_FE(mysqli_refresh, arginfo_mysqli_refresh)
-	ZEND_FALIAS(mysqli_escape_string, mysqli_real_escape_string, arginfo_mysqli_escape_string)
-	ZEND_FALIAS(mysqli_set_opt, mysqli_options, arginfo_mysqli_set_opt)
 	ZEND_FE_END
 };
 


### PR DESCRIPTION
There seemed to be a number of problems with the mysqli stubs. 
- The name of the mysqli object instance should be `$mysqli`. This looks like an oversight.
- mysqli::commit has default 0 not -1
- A number of functions/properties are infallible and do not return NULL. The if checks were removed in code and the stubs adjusted
- The names of the parameters in mysqli_poll were accidentally changed. The signature is not the same as socket_select
- `fetch_all()` does not return false. `fetch_assoc()`, `fetch_row` and `fetch_object` are a tri-union. 
- `bind_param` and `bind_result` require at least one variable by reference. The variadics come after. 