### PR TITLE
mysqli_get_client_info doesn't take any parameters

### DIFF
--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -87,7 +87,7 @@ class mysqli
     public function get_charset() {}
 
     /**
-     * @return string|null
+     * @return string
      * @alias mysqli_get_client_info
      */
     public function get_client_info() {}
@@ -597,7 +597,7 @@ function mysqli_get_client_stats(): array {}
 
 function mysqli_get_charset(mysqli $mysql): ?object {}
 
-function mysqli_get_client_info(?mysqli $mysql = null): ?string {}
+function mysqli_get_client_info(): string {}
 
 function mysqli_get_client_version(): int {}
 

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1325,16 +1325,8 @@ PHP_FUNCTION(mysqli_free_result)
 /* {{{ Get MySQL client info */
 PHP_FUNCTION(mysqli_get_client_info)
 {
-	if (getThis()) {
-		if (zend_parse_parameters_none() == FAILURE) {
-			RETURN_THROWS();
-		}
-	} else {
-		zval *mysql_link;
-
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "|O!", &mysql_link, mysqli_link_class_entry) == FAILURE) {
-			RETURN_THROWS();
-		}
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_THROWS();
 	}
 
 	const char * info = mysql_get_client_info();

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1329,10 +1329,7 @@ PHP_FUNCTION(mysqli_get_client_info)
 		RETURN_THROWS();
 	}
 
-	const char * info = mysql_get_client_info();
-	if (info) {
-		RETURN_STRING(info);
-	}
+	RETURN_STRING(mysql_get_client_info());
 }
 /* }}} */
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cd300f5106294e193fa85adc9c8a18a68d7d322 */
+ * Stub hash: 32f9d7786a8e782a18523f1a3ad8636000d40897 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -148,8 +148,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_charset, 0, 1, IS_OBJ
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_client_info, 0, 0, IS_STRING, 1)
-	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, mysql, mysqli, 1, "null")
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_get_client_info, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_get_client_version arginfo_mysqli_connect_errno

--- a/ext/mysqli/tests/bug74737.phpt
+++ b/ext/mysqli/tests/bug74737.phpt
@@ -13,5 +13,5 @@ echo PHP_EOL;
 echo $rf->getNumberOfRequiredParameters();
 ?>
 --EXPECT--
-1
+0
 0


### PR DESCRIPTION
`mysqli_get_client_info()` doesn't take any parameters and it never did. This seems to have been a regression in PHP 8.0. 

As documented in PHP manual `mysqli_get_client_info` doesn't need the connection link. Prior to PHP 8.0 the function didn't take any arguments, so it makes no sense to add it now. This function is just a wrapper around a constant in the client library. Mysqlnd always has this constant set (duh) but I am unable to test against libmysql. However, if it is not set in libmysql then that would have been noticed ages ago since we have a test case for this already https://github.com/php/php-src/blob/master/ext/mysqli/tests/068.phpt

This PR reverts the previous commit and adjusts the stub file. 