### PR TITLE
gdbinit: use ____print_str to print htable keys instead of printf

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -340,7 +340,8 @@ define ____print_ht
 			end
 			printf "[%d] ", $i
 			if $p->key
-				printf "%s => ", $p->key->val
+				____print_str $p->key->val $p->key->len
+				printf " => "
 			else
 				printf "%d => ", $p->h
 			end


### PR DESCRIPTION
I noticed this problem while dumping the contents of EG(function_table), where keys for closures start with a null byte. printf interprets this as a zero-length string and emits nothing.
This allows keys containing null bytes to be rendered properly in readable form.