### PR TITLE
Prevent double-free of Phar ZIP stream

### DIFF
--- a/ext/phar/tests/zip/require_hash.phpt
+++ b/ext/phar/tests/zip/require_hash.phpt
@@ -45,7 +45,7 @@ try {
 @unlink(__DIR__ . '/require_hash.zip');
 ?>
 --EXPECTF--
-zip-based phar "%srequire_hash.phar.zip" does not have a signature
+phar error: signature is missing in zip-based phar "%srequire_hash.phar.zip"
 bool(false)
 array(2) {
   ["hash"]=>

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -673,12 +673,7 @@ foundit:
 
 	/* ensure signature set */
 	if (!mydata->is_data && PHAR_G(require_hash) && !mydata->signature) {
-		php_stream_close(fp);
-		phar_destroy_phar_data(mydata);
-		if (error) {
-			spprintf(error, 0, "zip-based phar \"%s\" does not have a signature", fname);
-		}
-		return FAILURE;
+		PHAR_ZIP_FAIL("signature is missing");
 	}
 
 	mydata->fp = fp;

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -665,8 +665,6 @@ foundit:
 		zend_hash_str_add_mem(&mydata->manifest, entry.filename, entry.filename_len, (void *)&entry, sizeof(phar_entry_info));
 	}
 
-	mydata->fp = fp;
-
 	if (zend_hash_str_exists(&(mydata->manifest), ".phar/stub.php", sizeof(".phar/stub.php")-1)) {
 		mydata->is_data = 0;
 	} else {
@@ -682,6 +680,8 @@ foundit:
 		}
 		return FAILURE;
 	}
+
+	mydata->fp = fp;
 
 	zend_hash_str_add_ptr(&(PHAR_G(phar_fname_map)), mydata->fname, fname_len, mydata);
 


### PR DESCRIPTION
We must not alias the closed stream to `phar_archive_data.fp`.