### PR TITLE
Add support for class union types for internal functions

### DIFF
--- a/ext/ffi/ffi.stub.php
+++ b/ext/ffi/ffi.stub.php
@@ -33,17 +33,11 @@ final class FFI
     /** @prefer-ref $ptr */
     public static function addr(FFI\CData $ptr): FFI\CData {}
 
-    /**
-     * @param FFI\CData|FFI\CType $ptr
-     * @prefer-ref $ptr
-     */
-    public static function sizeof($ptr): int {}
+    /** @prefer-ref $ptr */
+    public static function sizeof(FFI\CData|FFI\CType $ptr): int {}
 
-    /**
-     * @param FFI\CData|FFI\CType $ptr
-     * @prefer-ref $ptr
-     */
-    public static function alignof($ptr): int {}
+    /** @prefer-ref $ptr */
+    public static function alignof(FFI\CData|FFI\CType $ptr): int {}
 
     /**
      * @param FFI\CData|string $from

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0b4215e4686f4184b2eef0de7d60e01855725924 */
+ * Stub hash: 5aeec68fea7a94cd643464acfb10bf4cfcc863da */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_cdef, 0, 0, FFI, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, code, IS_STRING, 0, "\"\"")
@@ -47,7 +47,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_addr, 0, 1, FFI\\CData,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_FFI_sizeof, 0, 1, IS_LONG, 0)
-	ZEND_ARG_INFO(ZEND_SEND_PREFER_REF, ptr)
+	ZEND_ARG_OBJ_TYPE_MASK(ZEND_SEND_PREFER_REF, ptr, FFI\\CData|FFI\\CType, 0, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_FFI_alignof arginfo_class_FFI_sizeof


### PR DESCRIPTION
This closes the last hole in the supported types for internal function arginfo types. It's now possible to represent unions of multiple classes. This is done by storing them as `TypeA|TypeB` and PHP will then convert this into an appropriate union type list.

cc @kocsismate 

@trowski I think you were asking about this.