### PR TITLE
Rename ``zip_ent`` parameter to ``zip_entry`` for consistency

### DIFF
--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -29,10 +29,10 @@ function zip_read($zip) {}
 function zip_entry_open($zip_dp, $zip_entry, string $mode = "rb"): bool {}
 
 /**
- * @param resource $zip_ent
+ * @param resource $zip_entry
  * @deprecated
  */
-function zip_entry_close($zip_ent): bool {}
+function zip_entry_close($zip_entry): bool {}
 
 /**
  * @param resource $zip_entry


### PR DESCRIPTION
All other functions use ``zip_entry``