### PR TITLE
Fix zval_refcount_p in debug mode

### DIFF
--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -1188,7 +1188,7 @@ static zend_always_inline uint32_t zend_gc_delref_ex(zend_refcounted_h *p, uint3
 
 static zend_always_inline uint32_t zval_refcount_p(const zval* pz) {
 #if ZEND_DEBUG
-	ZEND_ASSERT(Z_REFCOUNTED_P(pz) || Z_TYPE_P(pz) == IS_ARRAY);
+	ZEND_ASSERT(Z_REFCOUNTED_P(pz) || Z_TYPE_P(pz) == IS_ARRAY || Z_TYPE_P(pz) == IS_STRING);
 #endif
 	return GC_REFCOUNT(Z_COUNTED_P(pz));
 }


### PR DESCRIPTION
zval_refcount_p could not get the refcount for a string