### PR TITLE
Fix #80575: Casting mysqli to array produces null on every field

### DIFF
--- a/ext/mysqli/tests/bug80575.phpt
+++ b/ext/mysqli/tests/bug80575.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #80575 (Casting mysqli to array produces null on every field)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifemb.inc');
+require_once('skipifconnectfailure.inc');
+?>
+--FILE--
+<?php
+require_once('connect.inc');
+$link = new mysqli($host, $user, $passwd, $db, $port, $socket);
+var_dump(((array) $link)["affected_rows"]);
+?>
+--EXPECT--
+int(0)


### PR DESCRIPTION
We implement a `get_properties_for` handler for casting to array, and
also use this instead of the `get_debug_info` handler.