### PR TITLE
Add support for arrays with object keys (WIP)

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -339,8 +339,8 @@ define ____print_ht
 				set $n = $n - 1
 			end
 			printf "[%d] ", $i
-			if $p->key
-				____print_str $p->key->val $p->key->len
+			if $p->key.u1.v.type == 6
+				____print_str $p->key.value.str->val $p->key.value.str->len
 				printf " => "
 			else
 				printf "%d => ", $p->h

--- a/Zend/tests/036.phpt
+++ b/Zend/tests/036.phpt
@@ -3,12 +3,12 @@ Trying to use lambda in array offset
 --FILE--
 <?php
 
-try {
-    $test[function(){}] = 1;
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
+$test[function(){}] = 1;
+var_dump($test);
 
 ?>
 --EXPECT--
-Illegal offset type
+array(1) {
+  [Closure#1]=>
+  int(1)
+}

--- a/Zend/tests/038.phpt
+++ b/Zend/tests/038.phpt
@@ -3,12 +3,11 @@ Trying to use lambda as array key
 --FILE--
 <?php
 
-try {
-    var_dump(array(function() { } => 1));
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
+var_dump(array(function() { } => 1));
 
 ?>
 --EXPECT--
-Illegal offset type
+array(1) {
+  [Closure#1]=>
+  int(1)
+}

--- a/Zend/tests/assign_dim_obj_null_return.phpt
+++ b/Zend/tests/assign_dim_obj_null_return.phpt
@@ -20,12 +20,6 @@ function test() {
     }
 
     try {
-        var_dump($array[new stdClass] = 123);
-    } catch (Error $e) {
-        echo $e->getMessage(), "\n";
-    }
-
-    try {
         var_dump($true[123] = 456);
     } catch (Error $e) {
         echo $e->getMessage(), "\n";
@@ -39,12 +33,6 @@ function test() {
 
     try {
         var_dump($array[[]] += 123);
-    } catch (Error $e) {
-        echo $e->getMessage(), "\n";
-    }
-
-    try {
-        var_dump($array[new stdClass] += 123);
     } catch (Error $e) {
         echo $e->getMessage(), "\n";
     }
@@ -73,10 +61,8 @@ test();
 --EXPECT--
 Cannot add element to the array as the next element is already occupied
 Illegal offset type
-Illegal offset type
 Cannot use a scalar value as an array
 Cannot add element to the array as the next element is already occupied
-Illegal offset type
 Illegal offset type
 Cannot use a scalar value as an array
 Attempt to assign property "foo" on bool

--- a/Zend/tests/isset_array.phpt
+++ b/Zend/tests/isset_array.phpt
@@ -3,9 +3,11 @@ Using isset() with arrays
 --FILE--
 <?php
 
+$obj = new stdClass;
 $array = [
     0 => true,
     "a" => true,
+    $obj => true,
 ];
 
 var_dump(isset($array[0]));
@@ -15,6 +17,8 @@ var_dump(isset($array["a"]));
 var_dump(isset($array[false]));
 
 var_dump(isset($array[0.6]));
+
+var_dump(isset($array[$obj]));
 
 var_dump(isset($array[true]));
 
@@ -28,13 +32,9 @@ try {
     echo $exception->getMessage() . "\n";
 }
 
-try {
-    isset($array[new stdClass()]);
-} catch (TypeError $exception) {
-    echo $exception->getMessage() . "\n";
-}
 ?>
 --EXPECTF--
+bool(true)
 bool(true)
 bool(true)
 bool(true)
@@ -44,5 +44,4 @@ bool(false)
 
 Warning: Resource ID#%d used as offset, casting to integer (%d) in %s on line %d
 bool(false)
-Illegal offset type in isset or empty
 Illegal offset type in isset or empty

--- a/Zend/tests/object_keys.phpt
+++ b/Zend/tests/object_keys.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Object keys in arrays
+--FILE--
+<?php
+
+$array = [];
+$obj1 = new stdClass;
+$obj2 = new stdClass;
+
+$array[$obj1] = 1;
+$array[$obj2] = 2;
+var_dump($array[$obj1]);
+var_dump($array[$obj2]);
+
+unset($array[$obj2]);
+var_dump($array[$obj2]);
+
+var_dump(isset($array[$obj1]));
+var_dump(isset($array[$obj2]));
+
+$array[$obj1]++;
+$array[$obj1] += 1;
+var_dump($array[$obj1]);
+
+?>
+--EXPECTF--
+int(1)
+int(2)
+
+Warning: Undefined array key stdClass#2 in %s on line %d
+NULL
+bool(true)
+bool(false)
+int(3)

--- a/Zend/tests/offset_array.phpt
+++ b/Zend/tests/offset_array.phpt
@@ -17,11 +17,7 @@ $fp = fopen(__FILE__, "r");
 var_dump($arr[$fp]);
 
 $obj = new stdClass;
-try {
-    var_dump($arr[$obj]);
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
+var_dump($arr[$obj]);
 
 $arr1 = Array(1,2,3);
 try {
@@ -46,6 +42,8 @@ int(1)
 
 Warning: Resource ID#%d used as offset, casting to integer (%d) in %s on line %d
 int(%d)
-Illegal offset type
+
+Warning: Undefined array key stdClass#1 in %s on line %d
+NULL
 Illegal offset type
 Done

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -324,7 +324,7 @@ static void print_hash(smart_str *buf, HashTable *ht, int indent, zend_bool is_o
 			} else {
 				smart_str_append(buf, Z_STR_P(key));
 			}
-		} else if (Z_TYPE_P(key) == IS_STRING) {
+		} else if (Z_TYPE_P(key) == IS_LONG) {
 			smart_str_append_long(buf, Z_LVAL_P(key));
 		} else {
 			// TODO(OBJ_KEY)

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1342,13 +1342,12 @@ ZEND_API void object_properties_init_ex(zend_object *object, HashTable *properti
 
 ZEND_API void object_properties_load(zend_object *object, HashTable *properties) /* {{{ */
 {
-    zval *prop, tmp;
-   	zend_string *key;
-   	zend_long h;
+    zval *prop, tmp, *zv_key;
    	zend_property_info *property_info;
 
-   	ZEND_HASH_FOREACH_KEY_VAL(properties, h, key, prop) {
-		if (key) {
+   	ZEND_HASH_FOREACH_ZKEY_VAL(properties, zv_key, prop) {
+		if (Z_TYPE_P(zv_key) == IS_STRING) {
+			zend_string *key = Z_STR_P(zv_key);
 			if (ZSTR_VAL(key)[0] == '\0') {
 				const char *class_name, *prop_name;
 				size_t prop_name_len;
@@ -1391,7 +1390,7 @@ ZEND_API void object_properties_load(zend_object *object, HashTable *properties)
 			if (!object->properties) {
 				rebuild_object_properties(object);
 			}
-			prop = zend_hash_index_update(object->properties, h, prop);
+			prop = zend_hash_zkey_update(object->properties, zv_key, prop);
 			zval_add_ref(prop);
 		}
 	} ZEND_HASH_FOREACH_END();

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1276,9 +1276,7 @@ tail_call:
 
 static ZEND_COLD void zend_ast_export_zval(smart_str *str, zval *zv, int priority, int indent)
 {
-	zend_long idx;
-	zend_string *key;
-	zval *val;
+	zval *key, *val;
 	int first;
 
 	ZVAL_DEREF(zv);
@@ -1295,11 +1293,12 @@ static ZEND_COLD void zend_ast_export_zval(smart_str *str, zval *zv, int priorit
 		case IS_LONG:
 			smart_str_append_long(str, Z_LVAL_P(zv));
 			break;
-		case IS_DOUBLE:
-			key = zend_strpprintf(0, "%.*G", (int) EG(precision), Z_DVAL_P(zv));
-			smart_str_appendl(str, ZSTR_VAL(key), ZSTR_LEN(key));
-			zend_string_release_ex(key, 0);
+		case IS_DOUBLE: {
+			zend_string *conv = zend_strpprintf(0, "%.*G", (int) EG(precision), Z_DVAL_P(zv));
+			smart_str_append(str, conv);
+			zend_string_release_ex(conv, 0);
 			break;
+		}
 		case IS_STRING:
 			smart_str_appendc(str, '\'');
 			zend_ast_export_str(str, Z_STR_P(zv));
@@ -1308,18 +1307,19 @@ static ZEND_COLD void zend_ast_export_zval(smart_str *str, zval *zv, int priorit
 		case IS_ARRAY:
 			smart_str_appendc(str, '[');
 			first = 1;
-			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(zv), idx, key, val) {
+			ZEND_HASH_FOREACH_ZKEY_VAL(Z_ARRVAL_P(zv), key, val) {
 				if (first) {
 					first = 0;
 				} else {
 					smart_str_appends(str, ", ");
 				}
-				if (key) {
+				if (Z_TYPE_P(key) == IS_STRING) {
 					smart_str_appendc(str, '\'');
-					zend_ast_export_str(str, key);
+					zend_ast_export_str(str, Z_STR_P(key));
 					smart_str_appends(str, "' => ");
 				} else {
-					smart_str_append_long(str, idx);
+					ZEND_ASSERT(Z_TYPE_P(key) == IS_LONG);
+					smart_str_append_long(str, Z_LVAL_P(key));
 					smart_str_appends(str, " => ");
 				}
 				zend_ast_export_zval(str, val, 0, indent);

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -621,11 +621,7 @@ static zend_result zend_generator_get_next_delegated_value(zend_generator *gener
 		ZVAL_COPY(&generator->value, value);
 
 		zval_ptr_dtor(&generator->key);
-		if (p->key) {
-			ZVAL_STR_COPY(&generator->key, p->key);
-		} else {
-			ZVAL_LONG(&generator->key, p->h);
-		}
+		ZVAL_COPY(&generator->key, &p->key);
 
 		Z_FE_POS(generator->values) = pos;
 	} else {

--- a/Zend/zend_ini.c
+++ b/Zend/zend_ini.c
@@ -168,19 +168,22 @@ ZEND_API void zend_copy_ini_directives(void) /* {{{ */
 
 static int ini_key_compare(Bucket *f, Bucket *s) /* {{{ */
 {
-	if (!f->key && !s->key) { /* both numeric */
-		if (f->h > s->h) {
+	ZEND_ASSERT(Z_TYPE(f->key) == IS_LONG || Z_TYPE(f->key) == IS_STRING);
+	ZEND_ASSERT(Z_TYPE(s->key) == IS_LONG || Z_TYPE(s->key) == IS_STRING);
+
+	if (Z_TYPE(f->key) == IS_LONG && Z_TYPE(s->key) == IS_LONG) { /* both numeric */
+		if (Z_LVAL(f->key) > Z_LVAL(s->key)) {
 			return -1;
-		} else if (f->h < s->h) {
+		} else if (Z_LVAL(f->key) < Z_LVAL(s->key)) {
 			return 1;
 		}
 		return 0;
-	} else if (!f->key) { /* f is numeric, s is not */
+	} else if (Z_TYPE(f->key) == IS_LONG) { /* f is numeric, s is not */
 		return -1;
-	} else if (!s->key) { /* s is numeric, f is not */
+	} else if (Z_TYPE(s->key) == IS_LONG) { /* s is numeric, f is not */
 		return 1;
 	} else { /* both strings */
-		return zend_binary_strcasecmp(ZSTR_VAL(f->key), ZSTR_LEN(f->key), ZSTR_VAL(s->key), ZSTR_LEN(s->key));
+		return zend_binary_strcasecmp(Z_STRVAL(f->key), Z_STRLEN(f->key), Z_STRVAL(s->key), Z_STRLEN(s->key));
 	}
 }
 /* }}} */

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -578,10 +578,10 @@ ZEND_API zval *zend_std_read_property(zend_object *zobj, zend_string *name, int 
 					Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 					if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-				        (EXPECTED(p->key == name) ||
-				         (EXPECTED(p->h == ZSTR_H(name)) &&
-				          EXPECTED(p->key != NULL) &&
-				          EXPECTED(zend_string_equal_content(p->key, name))))) {
+						EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+				        (EXPECTED(Z_STR(p->key) == name) ||
+				         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+				          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 						retval = &p->val;
 						goto exit;
 					}
@@ -1637,10 +1637,10 @@ ZEND_API int zend_std_has_property(zend_object *zobj, zend_string *name, int has
 					Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 					if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-				        (EXPECTED(p->key == name) ||
-				         (EXPECTED(p->h == ZSTR_H(name)) &&
-				          EXPECTED(p->key != NULL) &&
-				          EXPECTED(zend_string_equal_content(p->key, name))))) {
+						EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+				        (EXPECTED(Z_STR(p->key) == name) ||
+				         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+				          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 						value = &p->val;
 						goto found;
 					}

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -216,9 +216,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 
 	if (old_object->properties &&
 	    EXPECTED(zend_hash_num_elements(old_object->properties))) {
-		zval *prop, new_prop;
-		zend_ulong num_key;
-		zend_string *key;
+		zval *key, *prop, new_prop;
 
 		if (!new_object->properties) {
 			new_object->properties = zend_new_array(zend_hash_num_elements(old_object->properties));
@@ -230,18 +228,14 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 		HT_FLAGS(new_object->properties) |=
 			HT_FLAGS(old_object->properties) & HASH_FLAG_HAS_EMPTY_IND;
 
-		ZEND_HASH_FOREACH_KEY_VAL(old_object->properties, num_key, key, prop) {
+		ZEND_HASH_FOREACH_ZKEY_VAL(old_object->properties, key, prop) {
 			if (Z_TYPE_P(prop) == IS_INDIRECT) {
 				ZVAL_INDIRECT(&new_prop, new_object->properties_table + (Z_INDIRECT_P(prop) - old_object->properties_table));
 			} else {
 				ZVAL_COPY_VALUE(&new_prop, prop);
 				zval_add_ref(&new_prop);
 			}
-			if (EXPECTED(key)) {
-				_zend_hash_append(new_object->properties, key, &new_prop);
-			} else {
-				zend_hash_index_add_new(new_object->properties, num_key, &new_prop);
-			}
+			_zend_hash_zkey_append(new_object->properties, key, &new_prop);
 		} ZEND_HASH_FOREACH_END();
 	}
 

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -119,7 +119,7 @@ ZEND_API void zend_interned_strings_dtor(void)
 	zend_known_strings = NULL;
 }
 
-static zend_always_inline zend_string *zend_interned_string_ht_lookup_ex(zend_ulong h, const char *str, size_t size, HashTable *interned_strings)
+static zend_always_inline zend_string *zend_interned_string_ht_lookup_ex(uint32_t h, const char *str, size_t size, HashTable *interned_strings)
 {
 	uint32_t nIndex;
 	uint32_t idx;
@@ -129,9 +129,9 @@ static zend_always_inline zend_string *zend_interned_string_ht_lookup_ex(zend_ul
 	idx = HT_HASH(interned_strings, nIndex);
 	while (idx != HT_INVALID_IDX) {
 		p = HT_HASH_TO_BUCKET(interned_strings, idx);
-		if ((p->h == h) && (ZSTR_LEN(p->key) == size)) {
-			if (!memcmp(ZSTR_VAL(p->key), str, size)) {
-				return p->key;
+		if (Z_HASH(p->key) == h && Z_STRLEN(p->key) == size) {
+			if (!memcmp(Z_STRVAL(p->key), str, size)) {
+				return Z_STR(p->key);
 			}
 		}
 		idx = Z_NEXT(p->val);
@@ -142,7 +142,7 @@ static zend_always_inline zend_string *zend_interned_string_ht_lookup_ex(zend_ul
 
 static zend_always_inline zend_string *zend_interned_string_ht_lookup(zend_string *str, HashTable *interned_strings)
 {
-	zend_ulong h = ZSTR_H(str);
+	uint32_t h = ZSTR_H(str);
 	uint32_t nIndex;
 	uint32_t idx;
 	Bucket *p;
@@ -151,8 +151,8 @@ static zend_always_inline zend_string *zend_interned_string_ht_lookup(zend_strin
 	idx = HT_HASH(interned_strings, nIndex);
 	while (idx != HT_INVALID_IDX) {
 		p = HT_HASH_TO_BUCKET(interned_strings, idx);
-		if ((p->h == h) && zend_string_equal_content(p->key, str)) {
-			return p->key;
+		if (Z_HASH(p->key) == h && zend_string_equal_content(Z_STR(p->key), str)) {
+			return Z_STR(p->key);
 		}
 		idx = Z_NEXT(p->val);
 	}

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -349,9 +349,8 @@ struct _zend_string {
 };
 
 typedef struct _Bucket {
-	zval              val;
-	zend_ulong        h;                /* hash value (or numeric index)   */
-	zend_string      *key;              /* string key or NULL for numerics */
+	zval val; /* Stores Z_NEXT */
+	zval key; /* Stores Z_HASH */
 } Bucket;
 
 typedef struct _zend_array HashTable;
@@ -570,6 +569,9 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 
 #define Z_NEXT(zval)				(zval).u2.next
 #define Z_NEXT_P(zval_p)			Z_NEXT(*(zval_p))
+
+#define Z_HASH(zval)				(zval).u2.extra
+#define Z_HASH_P(zval_p)			Z_HASH(*(zval_p))
 
 #define Z_CACHE_SLOT(zval)			(zval).u2.cache_slot
 #define Z_CACHE_SLOT_P(zval_p)		Z_CACHE_SLOT(*(zval_p))

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5911,6 +5911,9 @@ ZEND_VM_C_LABEL(str_index):
 			hval = Z_LVAL_P(offset);
 ZEND_VM_C_LABEL(num_index):
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((OP2_TYPE & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			ZEND_VM_C_GOTO(add_again);
@@ -5957,6 +5960,7 @@ ZEND_VM_HANDLER(147, ZEND_ADD_ARRAY_UNPACK, ANY, ANY)
 	op1 = GET_OP1_ZVAL_PTR(BP_VAR_R);
 
 ZEND_VM_C_LABEL(add_unpack_again):
+	// TODO(OBJ_KEY)
 	if (EXPECTED(Z_TYPE_P(op1) == IS_ARRAY)) {
 		HashTable *ht = Z_ARRVAL_P(op1);
 		zval *val;
@@ -6383,6 +6387,8 @@ ZEND_VM_C_LABEL(str_index_dim):
 				hval = Z_LVAL_P(offset);
 ZEND_VM_C_LABEL(num_index_dim):
 				zend_hash_index_del(ht, hval);
+			} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+				zend_hash_obj_key_del(ht, Z_OBJ_P(offset));
 			} else if ((OP2_TYPE & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 				offset = Z_REFVAL_P(offset);
 				ZEND_VM_C_GOTO(offset_again);
@@ -7076,6 +7082,8 @@ ZEND_VM_C_LABEL(isset_again):
 			hval = Z_LVAL_P(offset);
 ZEND_VM_C_LABEL(num_index_prop):
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if ((OP2_TYPE & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			ZEND_VM_C_GOTO(isset_again);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2504,6 +2504,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ADD_ARRAY_UNPACK_SPEC_HANDLER(
 	op1 = get_zval_ptr(opline->op1_type, opline->op1, BP_VAR_R);
 
 add_unpack_again:
+	// TODO(OBJ_KEY)
 	if (EXPECTED(Z_TYPE_P(op1) == IS_ARRAY)) {
 		HashTable *ht = Z_ARRVAL_P(op1);
 		zval *val;
@@ -6928,6 +6929,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -7018,6 +7022,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;
@@ -9084,6 +9090,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -9174,6 +9183,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;
@@ -10004,6 +10015,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -11468,6 +11482,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -11558,6 +11575,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;
@@ -15704,6 +15723,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;
@@ -17096,6 +17117,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;
@@ -18408,6 +18431,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;
@@ -19400,6 +19425,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -19803,6 +19831,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -20263,6 +20294,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -20662,6 +20696,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -24262,6 +24299,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -24357,6 +24397,8 @@ str_index_dim:
 				hval = Z_LVAL_P(offset);
 num_index_dim:
 				zend_hash_index_del(ht, hval);
+			} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+				zend_hash_obj_key_del(ht, Z_OBJ_P(offset));
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 				offset = Z_REFVAL_P(offset);
 				goto offset_again;
@@ -26415,6 +26457,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -26510,6 +26555,8 @@ str_index_dim:
 				hval = Z_LVAL_P(offset);
 num_index_dim:
 				zend_hash_index_del(ht, hval);
+			} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+				zend_hash_obj_key_del(ht, Z_OBJ_P(offset));
 			} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 				offset = Z_REFVAL_P(offset);
 				goto offset_again;
@@ -28274,6 +28321,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -30429,6 +30479,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -30524,6 +30577,8 @@ str_index_dim:
 				hval = Z_LVAL_P(offset);
 num_index_dim:
 				zend_hash_index_del(ht, hval);
+			} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+				zend_hash_obj_key_del(ht, Z_OBJ_P(offset));
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 				offset = Z_REFVAL_P(offset);
 				goto offset_again;
@@ -41688,6 +41743,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -41783,6 +41841,8 @@ str_index_dim:
 				hval = Z_LVAL_P(offset);
 num_index_dim:
 				zend_hash_index_del(ht, hval);
+			} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+				zend_hash_obj_key_del(ht, Z_OBJ_P(offset));
 			} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 				offset = Z_REFVAL_P(offset);
 				goto offset_again;
@@ -41911,6 +41971,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if ((IS_CONST & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;
@@ -45134,6 +45196,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -45229,6 +45294,8 @@ str_index_dim:
 				hval = Z_LVAL_P(offset);
 num_index_dim:
 				zend_hash_index_del(ht, hval);
+			} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+				zend_hash_obj_key_del(ht, Z_OBJ_P(offset));
 			} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 				offset = Z_REFVAL_P(offset);
 				goto offset_again;
@@ -45359,6 +45426,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if (((IS_TMP_VAR|IS_VAR) & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;
@@ -46876,6 +46945,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_UNUSED & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -50259,6 +50331,9 @@ str_index:
 			hval = Z_LVAL_P(offset);
 num_index:
 			zend_hash_index_update(Z_ARRVAL_P(EX_VAR(opline->result.var)), hval, expr_ptr);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			zend_hash_obj_key_update(
+				Z_ARRVAL_P(EX_VAR(opline->result.var)), Z_OBJ_P(offset), expr_ptr);
 		} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 			offset = Z_REFVAL_P(offset);
 			goto add_again;
@@ -50354,6 +50429,8 @@ str_index_dim:
 				hval = Z_LVAL_P(offset);
 num_index_dim:
 				zend_hash_index_del(ht, hval);
+			} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+				zend_hash_obj_key_del(ht, Z_OBJ_P(offset));
 			} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_TYPE_P(offset) == IS_REFERENCE)) {
 				offset = Z_REFVAL_P(offset);
 				goto offset_again;
@@ -50482,6 +50559,8 @@ isset_again:
 			hval = Z_LVAL_P(offset);
 num_index_prop:
 			value = zend_hash_index_find(ht, hval);
+		} else if (EXPECTED(Z_TYPE_P(offset) == IS_OBJECT)) {
+			value = zend_hash_obj_key_find(ht, Z_OBJ_P(offset));
 		} else if ((IS_CV & (IS_VAR|IS_CV)) && EXPECTED(Z_ISREF_P(offset))) {
 			offset = Z_REFVAL_P(offset);
 			goto isset_again;

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -6069,10 +6069,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CONST & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -6183,10 +6183,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CONST & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -8359,10 +8359,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CONST & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -8473,10 +8473,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CONST & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -10744,10 +10744,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CONST & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -10858,10 +10858,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CONST & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -15150,10 +15150,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || ((IS_TMP_VAR|IS_VAR) & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -15264,10 +15264,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || ((IS_TMP_VAR|IS_VAR) & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -16570,10 +16570,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || ((IS_TMP_VAR|IS_VAR) & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -16684,10 +16684,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || ((IS_TMP_VAR|IS_VAR) & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -17882,10 +17882,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || ((IS_TMP_VAR|IS_VAR) & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -17996,10 +17996,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || ((IS_TMP_VAR|IS_VAR) & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -21605,11 +21605,7 @@ fe_fetch_r_exit:
 		}
 		Z_FE_POS_P(array) = pos;
 		if (RETURN_VALUE_USED(opline)) {
-			if (!p->key) {
-				ZVAL_LONG(EX_VAR(opline->result.var), p->h);
-			} else {
-				ZVAL_STR_COPY(EX_VAR(opline->result.var), p->key);
-			}
+			ZVAL_COPY(EX_VAR(opline->result.var), &p->key);
 		}
 	} else {
 		zend_object_iterator *iter;
@@ -21634,12 +21630,12 @@ fe_fetch_r_exit:
 						value = Z_INDIRECT_P(value);
 						value_type = Z_TYPE_INFO_P(value);
 						if (EXPECTED(value_type != IS_UNDEF)
-						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key, 0) == SUCCESS)) {
+						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), Z_STR(p->key), 0) == SUCCESS)) {
 							break;
 						}
 					} else if (EXPECTED(Z_OBJCE_P(array)->default_properties_count == 0)
-							|| !p->key
-							|| zend_check_property_access(Z_OBJ_P(array), p->key, 1) == SUCCESS) {
+							|| Z_TYPE(p->key) != IS_STRING
+							|| zend_check_property_access(Z_OBJ_P(array), Z_STR(p->key), 1) == SUCCESS) {
 						break;
 					}
 				}
@@ -21647,16 +21643,14 @@ fe_fetch_r_exit:
 			}
 			EG(ht_iterators)[Z_FE_ITER_P(array)].pos = pos;
 			if (RETURN_VALUE_USED(opline)) {
-				if (UNEXPECTED(!p->key)) {
-					ZVAL_LONG(EX_VAR(opline->result.var), p->h);
-				} else if (ZSTR_VAL(p->key)[0]) {
-					ZVAL_STR_COPY(EX_VAR(opline->result.var), p->key);
-				} else {
+				if (Z_TYPE(p->key) == IS_STRING && Z_STRVAL(p->key)[0] == '\0') {
 					const char *class_name, *prop_name;
 					size_t prop_name_len;
 					zend_unmangle_property_name_ex(
-						p->key, &class_name, &prop_name, &prop_name_len);
+						Z_STR(p->key), &class_name, &prop_name, &prop_name_len);
 					ZVAL_STRINGL(EX_VAR(opline->result.var), prop_name, prop_name_len);
+				} else {
+					ZVAL_COPY(EX_VAR(opline->result.var), &p->key);
 				}
 			}
 		} else {
@@ -21750,11 +21744,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FETCH_RW_SPEC_VAR_HANDLER(Z
 		}
 		EG(ht_iterators)[Z_FE_ITER_P(EX_VAR(opline->op1.var))].pos = pos;
 		if (RETURN_VALUE_USED(opline)) {
-			if (!p->key) {
-				ZVAL_LONG(EX_VAR(opline->result.var), p->h);
-			} else {
-				ZVAL_STR_COPY(EX_VAR(opline->result.var), p->key);
-			}
+			ZVAL_COPY(EX_VAR(opline->result.var), &p->key);
 		}
 	} else if (EXPECTED(Z_TYPE_P(array) == IS_OBJECT)) {
 		zend_object_iterator *iter;
@@ -21778,7 +21768,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FETCH_RW_SPEC_VAR_HANDLER(Z
 						value = Z_INDIRECT_P(value);
 						value_type = Z_TYPE_INFO_P(value);
 						if (EXPECTED(value_type != IS_UNDEF)
-						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), p->key, 0) == SUCCESS)) {
+						 && EXPECTED(zend_check_property_access(Z_OBJ_P(array), Z_STR(p->key), 0) == SUCCESS)) {
 							if ((value_type & Z_TYPE_MASK) != IS_REFERENCE) {
 								zend_property_info *prop_info =
 									zend_get_typed_property_info_for_slot(Z_OBJ_P(array), value);
@@ -21791,8 +21781,8 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FETCH_RW_SPEC_VAR_HANDLER(Z
 							break;
 						}
 					} else if (EXPECTED(Z_OBJCE_P(array)->default_properties_count == 0)
-							|| !p->key
-							|| zend_check_property_access(Z_OBJ_P(array), p->key, 1) == SUCCESS) {
+							|| Z_TYPE(p->key) != IS_STRING
+							|| zend_check_property_access(Z_OBJ_P(array), Z_STR(p->key), 1) == SUCCESS) {
 						break;
 					}
 				}
@@ -21800,16 +21790,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FETCH_RW_SPEC_VAR_HANDLER(Z
 			}
 			EG(ht_iterators)[Z_FE_ITER_P(EX_VAR(opline->op1.var))].pos = pos;
 			if (RETURN_VALUE_USED(opline)) {
-				if (UNEXPECTED(!p->key)) {
-					ZVAL_LONG(EX_VAR(opline->result.var), p->h);
-				} else if (ZSTR_VAL(p->key)[0]) {
-					ZVAL_STR_COPY(EX_VAR(opline->result.var), p->key);
-				} else {
+				if (Z_TYPE(p->key) == IS_STRING && Z_STRVAL(p->key)[0] == '\0') {
 					const char *class_name, *prop_name;
 					size_t prop_name_len;
 					zend_unmangle_property_name_ex(
-						p->key, &class_name, &prop_name, &prop_name_len);
+						Z_STR(p->key), &class_name, &prop_name, &prop_name_len);
 					ZVAL_STRINGL(EX_VAR(opline->result.var), prop_name, prop_name_len);
+				} else {
+					ZVAL_COPY(EX_VAR(opline->result.var), &p->key);
 				}
 			}
 		} else {
@@ -30788,11 +30776,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FETCH_R_SIMPLE_
 	}
 	Z_FE_POS_P(array) = pos;
 	if (0) {
-		if (!p->key) {
-			ZVAL_LONG(EX_VAR(opline->result.var), p->h);
-		} else {
-			ZVAL_STR_COPY(EX_VAR(opline->result.var), p->key);
-		}
+		ZVAL_COPY(EX_VAR(opline->result.var), &p->key);
 	}
 
 	variable_ptr = EX_VAR(opline->op2.var);
@@ -30833,11 +30817,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FETCH_R_SIMPLE_
 	}
 	Z_FE_POS_P(array) = pos;
 	if (1) {
-		if (!p->key) {
-			ZVAL_LONG(EX_VAR(opline->result.var), p->h);
-		} else {
-			ZVAL_STR_COPY(EX_VAR(opline->result.var), p->key);
-		}
+		ZVAL_COPY(EX_VAR(opline->result.var), &p->key);
 	}
 
 	variable_ptr = EX_VAR(opline->op2.var);
@@ -31265,10 +31245,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_UNUSED & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -31422,10 +31402,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_UNUSED & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -33178,10 +33158,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_UNUSED & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -33330,10 +33310,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_UNUSED & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -35677,10 +35657,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_UNUSED & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -35829,10 +35809,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_UNUSED & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -39846,10 +39826,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CV & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -40003,10 +39983,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CV & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -42248,10 +42228,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BIND_GLOBAL_SPEC_C
 		Bucket *p = (Bucket*)((char*)EG(symbol_table).arData + idx);
 
 		if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-	        (EXPECTED(p->key == varname) ||
-	         (EXPECTED(p->h == ZSTR_H(varname)) &&
-	          EXPECTED(p->key != NULL) &&
-	          EXPECTED(zend_string_equal_content(p->key, varname))))) {
+			EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+	        (EXPECTED(Z_STR(p->key) == varname) ||
+	         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(varname)) &&
+	          EXPECTED(zend_string_equal_content(Z_STR(p->key), varname))))) {
 
 			value = (zval*)p; /* value = &p->val; */
 			goto check_indirect;
@@ -43478,10 +43458,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CV & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -43630,10 +43610,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CV & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;
@@ -48529,10 +48509,10 @@ fetch_obj_r_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CV & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_r_copy;
@@ -48681,10 +48661,10 @@ fetch_obj_is_fast_copy:
 							Bucket *p = (Bucket*)((char*)zobj->properties->arData + idx);
 
 							if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF) &&
-						        (EXPECTED(p->key == name) ||
-						         (EXPECTED(p->h == ZSTR_H(name)) &&
-						          EXPECTED(p->key != NULL) &&
-						          EXPECTED(zend_string_equal_content(p->key, name))))) {
+								EXPECTED(Z_TYPE(p->key) == IS_STRING) &&
+						        (EXPECTED(Z_STR(p->key) == name) ||
+						         (EXPECTED(Z_HASH(p->key) == (uint32_t)ZSTR_H(name)) &&
+						          EXPECTED(zend_string_equal_content(Z_STR(p->key), name))))) {
 								retval = &p->val;
 								if (0 || (IS_CV & (IS_TMP_VAR|IS_VAR)) != 0) {
 									goto fetch_obj_is_copy;

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -476,14 +476,10 @@ static void zend_weakmap_iterator_get_current_key(zend_object_iterator *obj_iter
 	zend_weakmap *wm = zend_weakmap_fetch(&iter->it.data);
 	HashPosition *pos = zend_weakmap_iterator_get_pos_ptr(iter);
 
-	zend_string *string_key;
-	zend_ulong num_key;
-	int key_type = zend_hash_get_current_key_ex(&wm->ht, &string_key, &num_key, pos);
-	if (key_type != HASH_KEY_IS_LONG) {
-		ZEND_ASSERT(0 && "Must have integer key");
-	}
+	zval *ht_key = zend_hash_get_current_zkey_ex(&wm->ht, pos);
+	ZEND_ASSERT(Z_TYPE_P(ht_key) == IS_LONG);
 
-	ZVAL_OBJ_COPY(key, (zend_object *) num_key);
+	ZVAL_OBJ_COPY(key, (zend_object *) Z_LVAL_P(ht_key));
 }
 
 static void zend_weakmap_iterator_move_forward(zend_object_iterator *obj_iter)

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -942,6 +942,10 @@ static int spl_array_skip_protected(spl_array_object *intern, HashTable *aht) /*
 
 		do {
 			zval *key = zend_hash_get_current_zkey_ex(aht, pos_ptr);
+			if (!key) {
+				return FAILURE;
+			}
+
 			if (Z_TYPE_P(key) == IS_STRING) {
 				zval *data = zend_hash_get_current_data_ex(aht, pos_ptr);
 				if (data && Z_TYPE_P(data) == IS_INDIRECT &&
@@ -952,9 +956,6 @@ static int spl_array_skip_protected(spl_array_object *intern, HashTable *aht) /*
 				}
 			} else {
 				return SUCCESS;
-			}
-			if (zend_hash_has_more_elements_ex(aht, pos_ptr) != SUCCESS) {
-				return FAILURE;
 			}
 			zend_hash_move_forward_ex(aht, pos_ptr);
 		} while (1);

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -614,19 +614,18 @@ PHP_METHOD(SplFixedArray, fromArray)
 	num = zend_hash_num_elements(Z_ARRVAL_P(data));
 
 	if (num > 0 && save_indexes) {
-		zval *element;
-		zend_string *str_index;
-		zend_ulong num_index, max_index = 0;
+		zval *element, *key;
+		zend_ulong max_index = 0;
 		zend_long tmp;
 
-		ZEND_HASH_FOREACH_KEY(Z_ARRVAL_P(data), num_index, str_index) {
-			if (str_index != NULL || (zend_long)num_index < 0) {
+		ZEND_HASH_FOREACH_ZKEY(Z_ARRVAL_P(data), key) {
+			if (Z_TYPE_P(key) != IS_LONG || Z_LVAL_P(key) < 0) {
 				zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0, "array must contain only positive integer keys");
 				RETURN_THROWS();
 			}
 
-			if (num_index > max_index) {
-				max_index = num_index;
+			if (Z_LVAL_P(key) > max_index) {
+				max_index = Z_LVAL_P(key);
 			}
 		} ZEND_HASH_FOREACH_END();
 
@@ -637,8 +636,8 @@ PHP_METHOD(SplFixedArray, fromArray)
 		}
 		spl_fixedarray_init(&array, tmp);
 
-		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(data), num_index, str_index, element) {
-			ZVAL_COPY_DEREF(&array.elements[num_index], element);
+		ZEND_HASH_FOREACH_ZKEY_VAL(Z_ARRVAL_P(data), key, element) {
+			ZVAL_COPY_DEREF(&array.elements[Z_LVAL_P(key)], element);
 		} ZEND_HASH_FOREACH_END();
 
 	} else if (num > 0 && !save_indexes) {

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1342,7 +1342,7 @@ PHP_FUNCTION(get_current_user)
 static void add_config_entries(HashTable *hash, zval *return_value);
 
 /* {{{ add_config_entry */
-static void add_config_entry(zend_ulong h, zend_string *key, zval *entry, zval *retval)
+static void add_config_entry(zval *key, zval *entry, zval *retval)
 {
 	if (Z_TYPE_P(entry) == IS_STRING) {
 		zend_string *str = Z_STR_P(entry);
@@ -1354,16 +1354,14 @@ static void add_config_entry(zend_ulong h, zend_string *key, zval *entry, zval *
 			}
 		}
 
-		if (key) {
-			add_assoc_str_ex(retval, ZSTR_VAL(key), ZSTR_LEN(key), str);
-		} else {
-			add_index_str(retval, h, str);
-		}
+		zval tmp;
+		ZVAL_STR(&tmp, str);
+		zend_hash_zkey_update(Z_ARRVAL_P(retval), key, &tmp);
 	} else if (Z_TYPE_P(entry) == IS_ARRAY) {
 		zval tmp;
 		array_init(&tmp);
 		add_config_entries(Z_ARRVAL_P(entry), &tmp);
-		zend_hash_update(Z_ARRVAL_P(retval), key, &tmp);
+		zend_hash_zkey_update(Z_ARRVAL_P(retval), key, &tmp);
 	}
 }
 /* }}} */
@@ -1371,12 +1369,10 @@ static void add_config_entry(zend_ulong h, zend_string *key, zval *entry, zval *
 /* {{{ add_config_entries */
 static void add_config_entries(HashTable *hash, zval *return_value) /* {{{ */
 {
-	zend_ulong h;
-	zend_string *key;
-	zval *zv;
+	zval *key, *zv;
 
-	ZEND_HASH_FOREACH_KEY_VAL(hash, h, key, zv)
-		add_config_entry(h, key, zv, return_value);
+	ZEND_HASH_FOREACH_ZKEY_VAL(hash, key, zv)
+		add_config_entry(key, zv, return_value);
 	ZEND_HASH_FOREACH_END();
 }
 /* }}} */

--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -147,14 +147,13 @@ static void php_mail_build_headers_elems(smart_str *s, zend_string *key, zval *v
 
 PHPAPI zend_string *php_mail_build_headers(HashTable *headers)
 {
-	zend_ulong idx;
 	zend_string *key;
 	zval *val;
 	smart_str s = {0};
 
-	ZEND_HASH_FOREACH_KEY_VAL(headers, idx, key, val) {
+	ZEND_HASH_FOREACH_STR_KEY_VAL(headers, key, val) {
 		if (!key) {
-			zend_type_error("Header name cannot be numeric, " ZEND_LONG_FMT " given", idx);
+			zend_type_error("Header name must be a string");
 			break;
 		}
 		/* https://tools.ietf.org/html/rfc2822#section-3.6 */

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -44,8 +44,10 @@ static void php_array_element_dump(zval *zv, zval *key, int level) /* {{{ */
 		PHPWRITE(Z_STRVAL_P(key), Z_STRLEN_P(key));
 		php_printf("\"]=>\n");
 	} else {
-		// TODO(OBJ_KEY)
-		ZEND_ASSERT(0 && "Not implemented");
+		ZEND_ASSERT(Z_TYPE_P(key) == IS_OBJECT);
+		// TODO(OBJ_KEY) Determine desired format.
+		php_printf("%*c[%s#%" PRIu32 "]=>\n",
+			level + 1, ' ', ZSTR_VAL(Z_OBJCE_P(key)->name), Z_OBJ_HANDLE_P(key));
 	}
 	php_var_dump(zv, level + 2);
 }
@@ -410,6 +412,7 @@ PHP_FUNCTION(debug_zval_dump)
 
 static void php_array_element_export(zval *zv, zval *key, int level, smart_str *buf) /* {{{ */
 {
+	buffer_append_spaces(buf, level + 1);
 	php_var_export_ex(key, level + 2, buf);
 	smart_str_appendl(buf, " => ", 4);
 	php_var_export_ex(zv, level + 2, buf);

--- a/tests/classes/tostring_001.phpt
+++ b/tests/classes/tostring_001.phpt
@@ -80,7 +80,7 @@ try {
 
 ?>
 ====DONE====
---EXPECT--
+--EXPECTF--
 ====test1====
 test1 Object
 (
@@ -118,7 +118,8 @@ test2::__toString()
 Converted
 ====test7====
 test2::__toString()
-Illegal offset type
+
+Warning: Undefined array key test2#3 in %s on line %d
 ====test8====
 test2::__toString()
 string(9) "Converted"
@@ -128,7 +129,7 @@ string(9) "Converted"
 test2::__toString()
 Converted
 ====test10====
-object(test3)#2 (0) {
+object(test3)#1 (0) {
 }
 test3::__toString()
 test3::__toString(): Return value must be of type string, array returned


### PR DESCRIPTION
Very much work in progress. A `--disable-all` build mostly works.

RFC: https://wiki.php.net/rfc/object_keys_in_arrays