### PR TITLE
Fix phpize build of the opcache extension (jit/zend_jit.lo not found)

### DIFF
--- a/ext/opcache/jit/Makefile.frag
+++ b/ext/opcache/jit/Makefile.frag
@@ -5,7 +5,7 @@ $(builddir)/minilua: $(srcdir)/jit/dynasm/minilua.c
 $(builddir)/jit/zend_jit_x86.c: $(srcdir)/jit/zend_jit_x86.dasc $(srcdir)/jit/dynasm/*.lua $(builddir)/minilua
 	$(builddir)/minilua $(srcdir)/jit/dynasm/dynasm.lua  $(DASM_FLAGS) -o $@ $(srcdir)/jit/zend_jit_x86.dasc
 
-jit/zend_jit.lo: \
+$(builddir)jit/zend_jit.lo: \
 	$(builddir)/jit/zend_jit_x86.c \
 	$(srcdir)/jit/zend_jit_helpers.c \
 	$(srcdir)/jit/zend_jit_disasm_x86.c \
@@ -16,3 +16,4 @@ jit/zend_jit.lo: \
 	$(srcdir)/jit/zend_jit_trace.c \
 	$(srcdir)/jit/zend_elf.c
 
+jit/zend_jit.lo: $(builddir)/jit/zend_jit.lo

--- a/ext/opcache/jit/Makefile.frag
+++ b/ext/opcache/jit/Makefile.frag
@@ -5,7 +5,7 @@ $(builddir)/minilua: $(srcdir)/jit/dynasm/minilua.c
 $(builddir)/jit/zend_jit_x86.c: $(srcdir)/jit/zend_jit_x86.dasc $(srcdir)/jit/dynasm/*.lua $(builddir)/minilua
 	$(builddir)/minilua $(srcdir)/jit/dynasm/dynasm.lua  $(DASM_FLAGS) -o $@ $(srcdir)/jit/zend_jit_x86.dasc
 
-$(builddir)/jit/zend_jit.lo: \
+jit/zend_jit.lo: \
 	$(builddir)/jit/zend_jit_x86.c \
 	$(srcdir)/jit/zend_jit_helpers.c \
 	$(srcdir)/jit/zend_jit_disasm_x86.c \

--- a/ext/opcache/jit/Makefile.frag
+++ b/ext/opcache/jit/Makefile.frag
@@ -5,7 +5,7 @@ $(builddir)/minilua: $(srcdir)/jit/dynasm/minilua.c
 $(builddir)/jit/zend_jit_x86.c: $(srcdir)/jit/zend_jit_x86.dasc $(srcdir)/jit/dynasm/*.lua $(builddir)/minilua
 	$(builddir)/minilua $(srcdir)/jit/dynasm/dynasm.lua  $(DASM_FLAGS) -o $@ $(srcdir)/jit/zend_jit_x86.dasc
 
-$(builddir)jit/zend_jit.lo: \
+$(builddir)/jit/zend_jit.lo: \
 	$(builddir)/jit/zend_jit_x86.c \
 	$(srcdir)/jit/zend_jit_helpers.c \
 	$(srcdir)/jit/zend_jit_disasm_x86.c \


### PR DESCRIPTION
I found that jit is not build correctly on my FreeBSD machine using `phpize` command in the extension directory.

Reason is that in the Makefile i have referenced `jit/zend_jit.lo` as dependency, but target was mentioned  as `./jit/zend_jit.lo`. This fix adds additional target w/o path which is used on local builds with `phpize`