### PR TITLE
Fix pdo_oci - declare quotedlen in oci_driver.c

### DIFF
--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -355,6 +355,7 @@ static zend_string* oci_handle_quoter(pdo_dbh_t *dbh, const zend_string *unquote
 	int qcount = 0;
 	char const *cu, *l, *r;
 	char *c, *quoted;
+	size_t quotedlen;
 	zend_string *quoted_str;
 
 	if (ZSTR_LEN(unquoted) == 0) {


### PR DESCRIPTION
This PR fixes `pdo_oci` by declaring `quotedlen` identifier before use in `oci_driver.c`.

Error Fixed: https://github.com/shivammathur/php-builder-windows/runs/1665811167?check_suite_focus=true#step:9:1092
