### PR TITLE
Remove Z_ARRVAL_P() == &EG(symbol_table) checks

### DIFF
--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -740,11 +740,8 @@ tail_call:
 			goto next;
 		}
 	} else if (GC_TYPE(ref) == IS_ARRAY) {
-		if ((zend_array*)ref != &EG(symbol_table)) {
-			ht = (zend_array*)ref;
-		} else {
-			goto next;
-		}
+		ZEND_ASSERT((zend_array*)ref != &EG(symbol_table));
+		ht = (zend_array*)ref;
 	} else if (GC_TYPE(ref) == IS_REFERENCE) {
 		if (Z_REFCOUNTED(((zend_reference*)ref)->val)) {
 			ref = Z_COUNTED(((zend_reference*)ref)->val);
@@ -861,12 +858,8 @@ static void gc_mark_grey(zend_refcounted *ref, gc_stack *stack)
 				goto next;
 			}
 		} else if (GC_TYPE(ref) == IS_ARRAY) {
-			if (((zend_array*)ref) == &EG(symbol_table)) {
-				GC_REF_SET_BLACK(ref);
-				goto next;
-			} else {
-				ht = (zend_array*)ref;
-			}
+			ZEND_ASSERT(((zend_array*)ref) != &EG(symbol_table));
+			ht = (zend_array*)ref;
 		} else if (GC_TYPE(ref) == IS_REFERENCE) {
 			if (Z_REFCOUNTED(((zend_reference*)ref)->val)) {
 				ref = Z_COUNTED(((zend_reference*)ref)->val);
@@ -1046,12 +1039,8 @@ tail_call:
 					goto next;
 				}
 			} else if (GC_TYPE(ref) == IS_ARRAY) {
-				if ((zend_array*)ref == &EG(symbol_table)) {
-					GC_REF_SET_BLACK(ref);
-					goto next;
-				} else {
-					ht = (zend_array*)ref;
-				}
+				ZEND_ASSERT((zend_array*)ref != &EG(symbol_table));
+				ht = (zend_array*)ref;
 			} else if (GC_TYPE(ref) == IS_REFERENCE) {
 				if (Z_REFCOUNTED(((zend_reference*)ref)->val)) {
 					ref = Z_COUNTED(((zend_reference*)ref)->val);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -6374,11 +6374,8 @@ ZEND_VM_C_LABEL(offset_again):
 					}
 				}
 ZEND_VM_C_LABEL(str_index_dim):
-				if (ht == &EG(symbol_table)) {
-					zend_delete_global_variable(key);
-				} else {
-					zend_hash_del(ht, key);
-				}
+				ZEND_ASSERT(ht != &EG(symbol_table));
+				zend_hash_del(ht, key);
 			} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
 				hval = Z_LVAL_P(offset);
 ZEND_VM_C_LABEL(num_index_dim):

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -24360,11 +24360,8 @@ offset_again:
 					}
 				}
 str_index_dim:
-				if (ht == &EG(symbol_table)) {
-					zend_delete_global_variable(key);
-				} else {
-					zend_hash_del(ht, key);
-				}
+				ZEND_ASSERT(ht != &EG(symbol_table));
+				zend_hash_del(ht, key);
 			} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
 				hval = Z_LVAL_P(offset);
 num_index_dim:
@@ -26513,11 +26510,8 @@ offset_again:
 					}
 				}
 str_index_dim:
-				if (ht == &EG(symbol_table)) {
-					zend_delete_global_variable(key);
-				} else {
-					zend_hash_del(ht, key);
-				}
+				ZEND_ASSERT(ht != &EG(symbol_table));
+				zend_hash_del(ht, key);
 			} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
 				hval = Z_LVAL_P(offset);
 num_index_dim:
@@ -30527,11 +30521,8 @@ offset_again:
 					}
 				}
 str_index_dim:
-				if (ht == &EG(symbol_table)) {
-					zend_delete_global_variable(key);
-				} else {
-					zend_hash_del(ht, key);
-				}
+				ZEND_ASSERT(ht != &EG(symbol_table));
+				zend_hash_del(ht, key);
 			} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
 				hval = Z_LVAL_P(offset);
 num_index_dim:
@@ -41794,11 +41785,8 @@ offset_again:
 					}
 				}
 str_index_dim:
-				if (ht == &EG(symbol_table)) {
-					zend_delete_global_variable(key);
-				} else {
-					zend_hash_del(ht, key);
-				}
+				ZEND_ASSERT(ht != &EG(symbol_table));
+				zend_hash_del(ht, key);
 			} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
 				hval = Z_LVAL_P(offset);
 num_index_dim:
@@ -45240,11 +45228,8 @@ offset_again:
 					}
 				}
 str_index_dim:
-				if (ht == &EG(symbol_table)) {
-					zend_delete_global_variable(key);
-				} else {
-					zend_hash_del(ht, key);
-				}
+				ZEND_ASSERT(ht != &EG(symbol_table));
+				zend_hash_del(ht, key);
 			} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
 				hval = Z_LVAL_P(offset);
 num_index_dim:
@@ -50365,11 +50350,8 @@ offset_again:
 					}
 				}
 str_index_dim:
-				if (ht == &EG(symbol_table)) {
-					zend_delete_global_variable(key);
-				} else {
-					zend_hash_del(ht, key);
-				}
+				ZEND_ASSERT(ht != &EG(symbol_table));
+				zend_hash_del(ht, key);
 			} else if (EXPECTED(Z_TYPE_P(offset) == IS_LONG)) {
 				hval = Z_LVAL_P(offset);
 num_index_dim:


### PR DESCRIPTION
PHP array cannot refer to EG(symbol_table) any more. Replace corresponding checks by ZEND_ASSERT().