### PR TITLE
Fixed parameter type of Phar::setStub()

### DIFF
--- a/ext/phar/phar_object.stub.php
+++ b/ext/phar/phar_object.stub.php
@@ -134,7 +134,7 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
     public function setSignatureAlgorithm(int $algo, ?string $privateKey = null) {}
 
     /**
-     * @param resource $stub
+     * @param resource|string $stub
      * @return bool
      */
     public function setStub($stub, int $length = -1) {}

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e06a2ea3d97778e61aca0f91fda7b72c29ef171d */
+ * Stub hash: fb477cdb092f6bbdd3e70cfb21c72654b4d63654 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)


### PR DESCRIPTION
The docs say string only, but after examining the code it's apparent that both resource _and_ string are accepted.

While this currently doesn't affect anything functionally, these docs are used by static analysers that use these stubs, such as PHPStan.