### PR TITLE
Fix #51758: delete an outdated comment from zend_object_handler.h [ci skip]

### DIFF
--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -47,13 +47,9 @@ typedef zval *(*zend_object_read_property_t)(zval *object, zval *member, int typ
 typedef zval *(*zend_object_read_dimension_t)(zval *object, zval *offset, int type, zval *rv);
 
 
-/* The following rule applies to write_property() and write_dimension() implementations:
-   If you receive a value zval in write_property/write_dimension, you may only modify it if
-   its reference count is 1.  Otherwise, you must create a copy of that zval before making
-   any changes.  You should NOT modify the reference count of the value passed to you.
+/* Used to set property of the object
    You must return the final value of the assigned property.
 */
-/* Used to set property of the object */
 typedef zval *(*zend_object_write_property_t)(zval *object, zval *member, zval *value, void **cache_slot);
 
 /* Used to set dimension of the object */


### PR DESCRIPTION
Fix https://bugs.php.net/bug.php?id=51758

It seems that the original intent of this prescription was preventing unintended modification to the RHS and values which share the memory location with the RHS in assignments.

In the first place, it is not usual trying to change the RHS in a write handler, IMHO. I don't think the description makes sense in the current situation about handling of refcount, so I simply delete the whole sentences.

# History
- The same description was originally written in a commit in 2004 which fixes a bug in the pre-released simplexml. https://github.com/php/php-src/commit/c8c0e979826b677de5f786920289056242ea5c54
- One requested to put the description in somewhere. https://externals.io/message/7789
-  Then it was added as a comment in zend_object_handler.h . https://github.com/php/php-src/commit/7d3215d33321173c58db4d86b7398e16c5c55d13
-  At the time of the comment written, the refcount of RHS was simply incremented before calling the write handler in the process of ZEND_ASSIGN_OBJ. https://github.com/php/php-src/blob/c8c0e979826b677de5f786920289056242ea5c54/Zend/zend_execute.c#L407
-  The refcount of a zval may be 0 or 1 if the write handler is called from zend_API in that era. https://github.com/php/php-src/blob/c8c0e979826b677de5f786920289056242ea5c54/Zend/zend_API.c#L1058-L1170
-  The original fix in simplexml was removed in 2018, because scalar types don't have reference counter anymore as of PHP7. 
 https://github.com/php/php-src/commit/f7f790fcc9d57bcd0b6d356994c67ec746a5ac23 https://github.com/php/php-src/commit/4a475a4976db92e71949786cdf5990c61514261e
