### PR TITLE
Fix outdated comment about refcounting in array.c [ci skip]

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3085,7 +3085,7 @@ static void php_splice(HashTable *in_hash, zend_long offset, zend_long length, H
 	for (pos = 0, idx = 0; pos < offset && idx < in_hash->nNumUsed; idx++) {
 		p = in_hash->arData + idx;
 		if (Z_TYPE(p->val) == IS_UNDEF) continue;
-		/* Get entry and increase reference count */
+		/* Get entry */
 		entry = &p->val;
 
 		/* Update output hash depending on key type */


### PR DESCRIPTION
- Originally the reference count was incremented in here.
- PHP7 removed the refcounting. https://github.com/php/php-src/commit/aa8ecbedcb94e9e22e8fd7ffd539377e747153f7#diff-9c1967d7282ea72ecea9d5dae0dab7349a34d48cc7a10ca38ff49a616f628e40L1954