### PR TITLE
Fix #80595: Resetting POSTFIELDS to empty array breaks request

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2969,7 +2969,14 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 
 		case CURLOPT_POSTFIELDS:
 			if (Z_TYPE_P(zvalue) == IS_ARRAY || Z_TYPE_P(zvalue) == IS_OBJECT) {
-				return build_mime_structure_from_hash(ch, zvalue);
+				if (zend_hash_num_elements(HASH_OF(zvalue)) == 0) {
+					/* no need to build the mime structure for empty hashtables;
+					   also works around https://github.com/curl/curl/issues/6455 */
+					curl_easy_setopt(ch->cp, CURLOPT_POSTFIELDS, "");
+					error = curl_easy_setopt(ch->cp, CURLOPT_POSTFIELDSIZE, 0);
+				} else {
+					return build_mime_structure_from_hash(ch, zvalue);
+				}
 			} else {
 #if LIBCURL_VERSION_NUM >= 0x071101
 				zend_string *tmp_str;

--- a/ext/curl/tests/bug79033.phpt
+++ b/ext/curl/tests/bug79033.phpt
@@ -21,9 +21,10 @@ var_dump(curl_getinfo($ch)["request_header"]);
 string(%d) "array(0) {
 }
 "
-string(90) "POST /get.inc?test=post HTTP/1.1
+string(%d) "POST /get.inc?test=post HTTP/1.1
 Host: localhost:%d
 Accept: */*
 Content-Length: 0
+Content-Type: application/x-www-form-urlencoded
 
 "

--- a/ext/curl/tests/bug80595.phpt
+++ b/ext/curl/tests/bug80595.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Bug #80595 (Resetting POSTFIELDS to empty array breaks request)
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+$ch = curl_init();
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST           => true,
+    CURLOPT_URL            => "{$host}/get.inc?test=post",
+]);
+
+curl_setopt($ch, CURLOPT_POSTFIELDS, ['foo' => 'bar']);
+var_dump(curl_exec($ch));
+
+curl_setopt($ch, CURLOPT_POSTFIELDS, []);
+var_dump(curl_exec($ch));
+?>
+--EXPECT--
+string(43) "array(1) {
+  ["foo"]=>
+  string(3) "bar"
+}
+"
+string(13) "array(0) {
+}
+"


### PR DESCRIPTION
This is mainly to work around https://github.com/curl/curl/issues/6455,
but not building the mime structure for empty hashtables is a general
performance optimization, so we do not restrict it to affected cURL
versions (7.56.0 to 7.75.0).

The minor change to bug79033.phpt is unexpected, but should not matter
in practice.