### PR TITLE
Observer: fake closures

### DIFF
--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -29,7 +29,7 @@
 #define ZEND_OBSERVER_NOT_OBSERVED ((void *) 2)
 
 #define ZEND_OBSERVABLE_FN(fn_flags) \
-	(!(fn_flags & (ZEND_ACC_CALL_VIA_TRAMPOLINE | ZEND_ACC_FAKE_CLOSURE)))
+	(!(fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE))
 
 typedef struct _zend_observer_fcall_data {
 	// points after the last handler

--- a/ext/zend_test/tests/observer_closure_02.phpt
+++ b/ext/zend_test/tests/observer_closure_02.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Observer: Observability of fake closures
+--SKIPIF--
+<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+class Foo
+{
+    public function bar()
+    {
+        echo 'Called as fake closure.' . PHP_EOL;
+    }
+}
+
+$callable = [new Foo(), 'bar'];
+$closure = \Closure::fromCallable($callable);
+$closure();
+
+echo 'DONE' . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s%eobserver_closure_%d.php' -->
+<file '%s%eobserver_closure_%d.php'>
+  <!-- init Foo::bar() -->
+  <Foo::bar>
+Called as fake closure.
+  </Foo::bar>
+DONE
+</file '%s%eobserver_closure_%d.php'>


### PR DESCRIPTION
Methods are not observed from closures created via `Closure::fromCallable()` because it creates a [fake closure](https://heap.space/xref/PHP-8.0/Zend/zend_closures.c?r=78773890#342). The observer API [explicitly cannot observe fake closures](https://github.com/php/php-src/blob/0425a66/Zend/zend_observer.c#L31-L32) because the observer handlers are stored in the runtime cache of op_arrays.

I haven't figured out an obvious solution yet so I thought I'd throw this out there in case anyone has any good ideas. :)

@derickr: @morrisonlevi shared your [use case](https://github.com/derickr/php-observeit) with me and I think this is the root issue as to why `RouterListener->onKernelFinishRequest` isn't being observed. It looks like it's being called after being [converted into a fake closure](https://github.com/symfony/event-dispatcher/blob/5.x/EventDispatcher.php#L270) in the `EventDispatcher`.