### PR TITLE
Allow to specify SQLite URI filenames to PDO DSN

### DIFF
--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -735,7 +735,17 @@ static const struct pdo_dbh_methods sqlite_methods = {
 static char *make_filename_safe(const char *filename)
 {
 	if (*filename && strncasecmp(filename, "file:", 5) == 0) {
-		char *fullpath = expand_filepath(filename+5, NULL);
+		char *fullpath;
+		if (strncasecmp(filename+5, "///", 3) == 0) {
+			fullpath = expand_filepath(filename+7, NULL);
+		} else if (strncasecmp(filename+5, "//localhost/", 12) == 0) {
+			fullpath = expand_filepath(filename+16, NULL);
+		} else if (strncasecmp(filename+5, "//", 2) == 0) {
+			// authority error on sqlite3_open_v2
+			return filename;
+		} else {
+			fullpath = expand_filepath(filename+5, NULL);
+		}
 
 		if (!fullpath) {
 			return NULL;

--- a/ext/pdo_sqlite/tests/open_basedir.phpt
+++ b/ext/pdo_sqlite/tests/open_basedir.phpt
@@ -1,0 +1,31 @@
+--TEST--
+PDO SQLite open_basedir check
+--SKIPIF--
+<?php if (!extension_loaded('pdo_sqlite')) print 'skip not loaded'; ?>
+--INI--
+open_basedir=.
+--FILE--
+<?php
+chdir(__DIR__);
+
+try {
+    $db = new PDO('sqlite:../not_in_open_basedir.sqlite');
+} catch (Exception $e) {
+    echo $e->getMessage() . "\n";
+}
+try {
+    $db = new PDO('sqlite:file:../not_in_open_basedir.sqlite');
+} catch (Exception $e) {
+    echo $e->getMessage() . "\n";
+}
+try {
+    $db = new PDO('sqlite:file:../not_in_open_basedir.sqlite?mode=ro');
+} catch (Exception $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+open_basedir prohibits opening ../not_in_open_basedir.sqlite
+open_basedir prohibits opening file:../not_in_open_basedir.sqlite
+open_basedir prohibits opening file:../not_in_open_basedir.sqlite?mode=ro

--- a/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
@@ -1,0 +1,37 @@
+--TEST--
+PDO_sqlite: Testing filename uri
+--SKIPIF--
+<?php if (!extension_loaded('pdo_sqlite')) print 'skip not loaded'; ?>
+--FILE--
+<?php
+
+// create with default read-write|create mode
+$filename = "file:" . __DIR__ . DIRECTORY_SEPARATOR . "pdo_sqlite_filename_uri.db";
+
+$db = new PDO('sqlite:' . $filename);
+
+var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+
+// create with readonly mode
+$filename = "file:" . __DIR__ . DIRECTORY_SEPARATOR . "pdo_sqlite_filename_uri.db?mode=ro";
+
+$db = new PDO('sqlite:' . $filename);
+
+var_dump($db->exec('CREATE TABLE test2 (id INT);'));
+
+?>
+--CLEAN--
+<?php
+$filename = __DIR__ . DIRECTORY_SEPARATOR . "pdo_sqlite_filename_uri.db";
+if (file_exists($filename)) {
+    unlink($filename);
+}
+?>
+--EXPECTF--
+int(0)
+
+Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: 8 attempt to write a readonly database in %s
+Stack trace:
+%s
+#1 {main}
+  thrown in %s


### PR DESCRIPTION
SQLite allows to URI filenames to setup database configuration.
https://www.sqlite.org/uri.html
https://www.sqlite.org/c3ref/open.html#urifilenameexamples

With URI filename, we can specify query parameters to setup SQLite configuration, for example `mode=ro` disables write access, `nolock=1` disables file locking. 

In current PHP implementation, we cannot specify URI filenames because of expanding filename process, so this PR resolve it.

Example usage:
```
$pdo = new PDO('sqlite3:file:/tmp/db.sqlite?mode=ro');
```