### PR TITLE
Curl: Add CURLOPT_DOH_URL option

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1141,6 +1141,10 @@ PHP_MINIT_FUNCTION(curl)
 	REGISTER_CURL_CONSTANT(CURLOPT_TLS13_CIPHERS);
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x073E00 /* Available since 7.62.0 */
+	REGISTER_CURL_CONSTANT(CURLOPT_DOH_URL);
+#endif
+
 #if LIBCURL_VERSION_NUM >= 0x074000 /* Available since 7.64.0 */
 	REGISTER_CURL_CONSTANT(CURLOPT_HTTP09_ALLOWED);
 #endif
@@ -2449,6 +2453,9 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 #endif
 #if LIBCURL_VERSION_NUM >= 0x072800 /* Available since 7.40.0 */
 		case CURLOPT_UNIX_SOCKET_PATH:
+#endif
+#if LIBCURL_VERSION_NUM >= 0x073E00 /* Available since 7.62.0 */
+		case CURLOPT_DOH_URL:
 #endif
 		case CURLOPT_KRBLEVEL:
 		{


### PR DESCRIPTION
From libcurl version 7.62.0 and later, it supports DNS-over-HTTPS with [`CURLOPT_DOH_URL`](https://curl.se/libcurl/c/CURLOPT_DOH_URL.html) option.
This adds integration with the `CURLOPT_DOH_URL` option if libcurl version is >= 7.62.0 (0x073E00).

For reference, Ubuntu 20.04+ `libcurl4-openssl-dev`-based PHP builds use Curl 7.68.