### PR TITLE
Sync gzgets signature with fgets

### DIFF
--- a/ext/zlib/zlib.stub.php
+++ b/ext/zlib/zlib.stub.php
@@ -99,9 +99,9 @@ function gzread($stream, int $length): string|false {}
 
 /**
  * @param resource $stream
- * @implementation-alias fgets
+ * @alias fgets
  */
-function gzgets($stream, int $length = 1024): string|false {}
+function gzgets($stream, ?int $length = null): string|false {}
 
 function deflate_init(int $encoding, array $options = []): DeflateContext|false {}
 

--- a/ext/zlib/zlib_arginfo.h
+++ b/ext/zlib/zlib_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 940858ddc4ddc7edb1e00960334ffa473224fd85 */
+ * Stub hash: 5862b97739c885589779f8ba3d13b4e390d72811 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ob_gzhandler, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
@@ -101,7 +101,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_gzgets, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, stream)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "1024")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_deflate_init, 0, 1, DeflateContext, MAY_BE_FALSE)


### PR DESCRIPTION
@kocsismate This got marked as implementation-alias as part of #6335, but I'm not sure why. All the other gz functions use normal aliases.