### PR TITLE
gen_stub: Also verify implementation-alias

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1881,7 +1881,7 @@ if ($verify) {
     $errors = [];
 
     foreach ($funcMap as $aliasFunc) {
-        if ($aliasFunc->aliasType !== "alias") {
+        if (!$aliasFunc->alias) {
             continue;
         }
 

--- a/ext/bz2/bz2.stub.php
+++ b/ext/bz2/bz2.stub.php
@@ -14,18 +14,21 @@ function bzread($bz, int $length = 1024): string|false {}
 /**
  * @param resource $bz
  * @implementation-alias fwrite
+ * @no-verify Uses different parameter name
  */
 function bzwrite($bz, string $data, ?int $length = null): int|false {}
 
 /**
  * @param resource $bz
  * @implementation-alias fflush
+ * @no-verify Uses different parameter name
  */
 function bzflush($bz): bool {}
 
 /**
  * @param resource $bz
  * @implementation-alias fclose
+ * @no-verify Uses different parameter name
  */
 function bzclose($bz): bool {}
 

--- a/ext/bz2/bz2_arginfo.h
+++ b/ext/bz2/bz2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0cd7792480671883ebae30ae8358b8f8e3390474 */
+ * Stub hash: 5436fd5a4b0fbfd3b3b3f1caa6a0cf8326c9c5f7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_bzopen, 0, 0, 2)
 	ZEND_ARG_INFO(0, file)

--- a/ext/phar/phar_object.stub.php
+++ b/ext/phar/phar_object.stub.php
@@ -180,7 +180,10 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
 
 class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAccess
 {
-    /** @implementation-alias Phar::__construct */
+    /**
+     * @implementation-alias Phar::__construct
+     * @no-verify PharData constructor accepts extra $format argument
+     */
     public function __construct(string $filename, int $flags = FilesystemIterator::SKIP_DOTS|FilesystemIterator::UNIX_PATHS, ?string $alias = null, int $format = 0) {}
 
     /** @implementation-alias Phar::__destruct */

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3575a0330ff6102461655bc84add44e8b08b585f */
+ * Stub hash: 96900fb403c625ad76b86bac37aed65722472f84 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)

--- a/ext/spl/spl_observer.stub.php
+++ b/ext/spl/spl_observer.stub.php
@@ -74,6 +74,7 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
      * @param object $object
      * @return bool
      * @implementation-alias SplObjectStorage::contains
+     * @no-verify Cannot specify arg type because ArrayAccess does not
      */
     public function offsetExists($object) {}
 
@@ -87,6 +88,7 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
      * @param object $object
      * @return void
      * @implementation-alias SplObjectStorage::attach
+     * @no-verify Cannot specify arg type because ArrayAccess does not
      */
     public function offsetSet($object, mixed $info = null) {}
 
@@ -94,6 +96,7 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
      * @param object $object
      * @return void
      * @implementation-alias SplObjectStorage::detach
+     * @no-verify Cannot specify arg type because ArrayAccess does not
      */
     public function offsetUnset($object) {}
 

--- a/ext/spl/spl_observer_arginfo.h
+++ b/ext/spl/spl_observer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: aaefa4d4ac3b795212191d9fe06982d29948f552 */
+ * Stub hash: fdcb6eb431f6accdb8e44ecc735ae563a5651edf */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplObserver_update, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, subject, SplSubject, 0)

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -4,7 +4,10 @@
 
 class SQLite3
 {
-    /** @implementation-alias SQLite3::open */
+    /**
+     * @implementation-alias SQLite3::open
+     * @no-verify SQLite3::open should really be static
+     */
     public function __construct(string $filename, int $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, string $encryptionKey = "") {}
 
     /** @return void */

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 61a684b6c221a15538a5f8cc32bc4e7d4cf3c8fd */
+ * Stub hash: 2abe77016e7a595f1687be34e52bba6aa477e7ae */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)


### PR DESCRIPTION
This makes `--verify` also check `@implementation-alias`. Failures are ignored using `@no-verify` instead. Some mistakes have been made that would have been caught by this...

There is one remaining failure:
> SplFileObject::__toString() and SplFileObject::fgets() must have the same return type

Another example of ~~great~~ terrible API design in SPL. Converting a file into a string returns ... the current line. Which can return false. Probably the alias here needs to be dropped and we should return "" instead of false.