### PR TITLE
Fix parsing of semi-reserved tokens at offset > 4GB

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -118,7 +118,9 @@ typedef struct _zend_file_context {
 } zend_file_context;
 
 typedef struct {
-	uint32_t offset;
+	/* Offset in bytes relative to the file start */
+	size_t offset;
+	/* This uses 32-bit integers to avoid doubling the size of the parser stack elements. */
 	uint32_t len;
 } zend_lexer_ident_ref;
 


### PR DESCRIPTION
Possibly related to GH-5668
Also affects php 8.0 but this changes the
datastructures in public(?) header files.
(binary ABI change)
PHP 7.4 wouldn't even parse a class with the below example.

1. Fix parsing semi-reserved tokens such as `namespace`
   with an offset that's larger than 2**32
2. Fix parsing some tokens when their length is larger than 2**32

Offset is relative to yy_start(the start of the file?)

Low priority because 4GB php files and the configured memory limits to support them are extremely rare - this was only noticed when looking into edge cases in the parser - this test case is artificial

Instead of parsing the token 'namespace', the character range from 4GB before is used due to truncation to 32 bits

```php
php > ini_set('memory_limit', '12G');
php > eval(str_repeat(' ' , 2**32) . 'class MyClass{ public static function namespace() {}}');
php > MyClass::namespace();

Warning: Uncaught Error: Call to undefined method MyClass::namespace() in php shell code:1
Stack trace:
  thrown in php shell code on line 1
php > var_export((new ReflectionClass('MyClass'))->getMethods());
array (
  0 =>
  ReflectionMethod::__set_state(array(
     'name' => '         ',
     'class' => 'MyClass',
  )),
)
```