### PR TITLE
Delete an outdated comment for read_property and read_dimension

### DIFF
--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -36,10 +36,6 @@ struct _zend_property_info;
 #define ZEND_ENCODE_DYN_PROP_OFFSET(offset)        ((uintptr_t)(-((intptr_t)(offset) + 2)))
 
 
-/* The following rule applies to read_property() and read_dimension() implementations:
-   If you return a zval which is not otherwise referenced by the extension or the engine's
-   symbol table, its reference count should be 0.
-*/
 /* Used to fetch property from the object, read-only */
 typedef zval *(*zend_object_read_property_t)(zval *object, zval *member, int type, void **cache_slot, zval *rv);
 


### PR DESCRIPTION
The comment is outdated as of PHP7.
For example, in the current code, zend_assign_op_overloaded property() expects the refcount of the returned value from read_property to be greater than 0 when the returned value is a refcounted, to call zval_ptr_dtor() later.

This is a follow-up of https://github.com/php/php-src/pull/6597.

# History
- The same description was originally written in a commit in 2004 alongside the write side. https://github.com/php/php-src/commit/c8c0e979826b677de5f786920289056242ea5c54
- One requested to put the description in somewhere. https://externals.io/message/7789
- Then it was added as a comment in zend_object_handler.h . https://github.com/php/php-src/commit/7d3215d33321173c58db4d86b7398e16c5c55d13
- At the time the comment was written, there were at least three places where the code actually set the reference count to 0 in read_properties.
	- https://github.com/php/php-src/blob/7d3215d33321173c58db4d86b7398e16c5c55d13/ext/dom/php_dom.c#L229
	- https://github.com/php/php-src/blob/7d3215d33321173c58db4d86b7398e16c5c55d13/ext/mysqli/mysqli.c#L190
	- https://github.com/php/php-src/blob/7d3215d33321173c58db4d86b7398e16c5c55d13/ext/simplexml/simplexml.c#L245
- All three of the above were removed during the development of PHP 7.
	- https://github.com/php/php-src/commit/2f0a758fbbf39ff8684d167f86c708cc361db782
	- https://github.com/php/php-src/commit/2402d6cbbc5e04362b23b183f9129a8db230bcce
	- https://github.com/php/php-src/commit/a975c7e0fe95a94c119eb1c8e519b2357aa50dcc
- In the current code, even when they generate and return a refcounted value, its refcount would be 1.