### PR TITLE
Proposal: var_representation($value, int $flags=0): string as alternative for var_export

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1475,6 +1475,8 @@ function var_export(mixed $value, bool $return = false): ?string {}
 
 function debug_zval_dump(mixed $value, mixed ...$values): void {}
 
+function var_representation(mixed $value, int $flags = 0): string {}
+
 function serialize(mixed $value): string {}
 
 function unserialize(string $data, array $options = []): mixed {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7540039937587f05584660bc1a1a8a80aa5ccbd1 */
+ * Stub hash: 533808ec59e5d4713134fe8c76a5a4df2ee872cb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2157,6 +2157,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_debug_zval_dump arginfo_var_dump
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_var_representation, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
 #define arginfo_serialize arginfo_gettype
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_unserialize, 0, 1, IS_MIXED, 0)
@@ -2811,6 +2816,7 @@ ZEND_FUNCTION(convert_uudecode);
 ZEND_FUNCTION(var_dump);
 ZEND_FUNCTION(var_export);
 ZEND_FUNCTION(debug_zval_dump);
+ZEND_FUNCTION(var_representation);
 ZEND_FUNCTION(serialize);
 ZEND_FUNCTION(unserialize);
 ZEND_FUNCTION(memory_get_usage);
@@ -3463,6 +3469,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(var_dump, arginfo_var_dump)
 	ZEND_FE(var_export, arginfo_var_export)
 	ZEND_FE(debug_zval_dump, arginfo_debug_zval_dump)
+	ZEND_FE(var_representation, arginfo_var_representation)
 	ZEND_FE(serialize, arginfo_serialize)
 	ZEND_FE(unserialize, arginfo_unserialize)
 	ZEND_FE(memory_get_usage, arginfo_memory_get_usage)

--- a/ext/standard/php_var.h
+++ b/ext/standard/php_var.h
@@ -25,6 +25,7 @@ PHP_MINIT_FUNCTION(var);
 PHPAPI void php_var_dump(zval *struc, int level);
 PHPAPI void php_var_export(zval *struc, int level);
 PHPAPI void php_var_export_ex(zval *struc, int level, smart_str *buf);
+PHPAPI void php_var_representation_ex(zval *struc, int level, smart_str *buf);
 
 PHPAPI void php_debug_zval_dump(zval *struc, int level);
 

--- a/ext/standard/tests/general_functions/var_representation1.phpt
+++ b/ext/standard/tests/general_functions/var_representation1.phpt
@@ -1,0 +1,150 @@
+--TEST--
+Test var_representation() function
+--FILE--
+<?php
+function dump($value): void {
+    echo var_representation($value), "\n";
+    $output = var_representation($value, VAR_REPRESENTATION_SINGLE_LINE);
+    echo "oneline: $output\n";
+}
+dump(null);
+dump(false);
+dump(true);
+dump(0);
+dump(0.0);
+dump(new stdClass());
+dump((object)['key' => "\$value\tsecond"]);
+dump([]);
+dump([1,2,3]);
+dump(new ArrayObject(['a', ['b']]));
+dump("Content-Length: 42\r\n");
+// use octal
+dump(["Foo\0\r\n\r\001\x19test quotes and special characters\$b'\"\\" => "\0"]);
+// does not escape or check validity of bytes "\80-\ff" (e.g. utf-8 data)
+dump("▜");
+dump((object)["Foo\0\r\n\r\001" => true]);
+echo "STDIN is dumped as null, like var_export\n";
+dump(STDIN);
+echo "The ascii range is encoded as follows:\n";
+echo var_representation(implode('', array_map('chr', range(0, 0x7f)))), "\n";
+echo "Recursive objects cause a warning, like var_export\n";
+$x = new stdClass();
+$x->x = $x;
+dump($x);
+echo "Recursive arrays cause a warning, like var_export\n";
+
+$a = [];
+$a[0] = &$a;
+$a[1] = 'other';
+dump($a);
+$ref = 'ref shown as value like var_export';
+dump([(object)['key' => (object)['inner' => [1.0]], 'other' => &$ref]]);
+class Example {
+    public $untyped1;
+    public $untyped2 = null;
+    public $untyped3 = 3;
+    public int $typed1;
+    public array $typed2 = [];
+    // rendering does not depend on existence of public function __set_state(), like var_export.
+}
+$x = new Example();
+unset($x->untyped1);  // unset properties/uninitialized typed properties are not shown, like var_export
+$x->typed2 = [new Example()];
+dump($x);
+?>
+--EXPECTF--
+null
+oneline: null
+false
+oneline: false
+true
+oneline: true
+0
+oneline: 0
+0.0
+oneline: 0.0
+(object) []
+oneline: (object) []
+(object) [
+  'key' => "\$value\tsecond",
+]
+oneline: (object) ['key' => "\$value\tsecond"]
+[]
+oneline: []
+[
+  1,
+  2,
+  3,
+]
+oneline: [1, 2, 3]
+\ArrayObject::__set_state([
+  'a',
+  [
+    'b',
+  ],
+])
+oneline: \ArrayObject::__set_state(['a', ['b']])
+"Content-Length: 42\r\n"
+oneline: "Content-Length: 42\r\n"
+[
+  "Foo\x00\r\n\r\x01\x19test quotes and special characters\$b'\"\\" => "\x00",
+]
+oneline: ["Foo\x00\r\n\r\x01\x19test quotes and special characters\$b'\"\\" => "\x00"]
+'▜'
+oneline: '▜'
+(object) [
+  "Foo\x00\r\n\r\x01" => true,
+]
+oneline: (object) ["Foo\x00\r\n\r\x01" => true]
+STDIN is dumped as null, like var_export
+
+Warning: var_representation does not handle resources in %s on line 3
+null
+
+Warning: var_representation does not handle resources in %s on line 4
+oneline: null
+The ascii range is encoded as follows:
+"\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#\$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f"
+Recursive objects cause a warning, like var_export
+
+Warning: var_representation does not handle circular references in %s on line 3
+(object) [
+  'x' => null,
+]
+
+Warning: var_representation does not handle circular references in %s on line 4
+oneline: (object) ['x' => null]
+Recursive arrays cause a warning, like var_export
+
+Warning: var_representation does not handle circular references in %s on line 3
+[
+  null,
+  'other',
+]
+
+Warning: var_representation does not handle circular references in %s on line 4
+oneline: [null, 'other']
+[
+  (object) [
+    'key' => (object) [
+      'inner' => [
+        1.0,
+      ],
+    ],
+    'other' => 'ref shown as value like var_export',
+  ],
+]
+oneline: [(object) ['key' => (object) ['inner' => [1.0]], 'other' => 'ref shown as value like var_export']]
+\Example::__set_state([
+  'untyped2' => null,
+  'untyped3' => 3,
+  'typed2' => [
+    \Example::__set_state([
+      'untyped1' => null,
+      'untyped2' => null,
+      'untyped3' => 3,
+      'typed2' => [],
+    ]),
+  ],
+])
+oneline: \Example::__set_state(['untyped2' => null, 'untyped3' => 3, 'typed2' => [\Example::__set_state(['untyped1' => null, 'untyped2' => null, 'untyped3' => 3, 'typed2' => []])]])


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/readable_var_representation

Prior RFCs have proposed adding to the option list of var_export and been
rejected or had development stop:

- A lot of code (php-src tests, PECL tests, and applications written in PHP) is already using var_export, and may be relying on the old
  behaviors for unit tests (asserting exact representation), etc.

  ~~(Changing var_export would result in thousands of failures in php-src alone)~~ (haven't counted yet)
- Code compatibility with PHP 5 has also been brought up as a reason to keep
  var_export output the same.
- See GH-2699 and linked PRs.
- Extending `var_export` by adding a third argument is impossible to polyfill in
  older php versions, and would result in a ArgumentCountError in php 8.0
- See https://externals.io/message/109415

This has the following differences from var_export:

1. var_representation() unconditionally returns a string
2. Use `null` instead of `NULL` - the former is recommended by more coding
   guidelines (https://www.php-fig.org/psr/psr-2/).
3. Change the way indentation is done for arrays/objects.
   See ext/standard/tests/general_functions/short_var_export1.phpt
   (e.g. always add 2 spaces, never 3 in objects, and put the array start on the
   same line as the key)
4. Render lists as `"[\n  'item1',\n]"` (or `"['item1']"` in single-line mode) rather than `"array(\n  0 => 'item1',\n)"`

   Always render empty lists on a single line, render multiline by default when there are 1 or more elements
5. Prepend `\` to class names so that generated code snippets can be used in
   namespaces without any issues.
6. Support `VAR_REPRESENTATION_SINGLE_LINE` in $flags.
   This will use a single-line representation for arrays/objects.
7. Escape control characters("\x00"-"\x1f" and "\x7f"(backspace)) inside of double quoted strings
   instead of single quoted strings with unescaped control characters mixed with ` . "\0" . `.

Having this available in php-src is useful for the following reasons:
1. It's convenient to be able to dump a snippet
   and use that in your source code with less reformatting, updating
   namespaces, etc. (or to dump values to see in utilities)
2. This often saves a few bytes (except for some binary strings) if the output of var_export() for an object/array
   is saved to disk, used as an array key, etc.
3. This is possibly more readable for list-like arrays
4. This can start being used in short, self-contained scripts if available.
5. The checks for infinite recursion are possible to polyfill with
   ReflectionReference or other approaches,
   but error prone to implement from scratch.

Example short_var_export output (see ext/standard/tests/general_functions/var_representation1.phpt for more examples):

```php
\ArrayObject::__set_state([
  'a',
  [
    "x\r\ny",
  ],
  [],
])
oneline: \ArrayObject::__set_state(['a', ["x\r\ny"], []])
```

Double quoted strings are used if the string contains \x00-\x1f or \x7f (control characters including `\r`, `\n`, `\t`, and backspace)

The ascii range 0x00-0x7f is encoded as follows if double quoted strings are used (`\r`, `\n`, `\t`, `\$`, `\\`, `\"`, in addition to other control characters and backspace encoded as hex escaped characters)

```php
// 0x00-0x1f
"\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f"
// 0x20-0x7f
" !\"#\$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f"
```