### PR TITLE
Fix #69477 ext/zip: Allow extracting to paths with dirs ending with dot

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -117,11 +117,21 @@ static char * php_zip_make_relative_path(char *path, size_t path_len) /* {{{ */
 			return path;
 		}
 
-		if (i >= 2 && (path[i -1] == '.' || path[i -1] == ':')) {
-			/* i is the position of . or :, add 1 for / */
+		if (i >= 1 && path[i - 1] == ':') {
 			path_begin = path + i + 1;
 			break;
 		}
+
+		if (i == 2 && path[i - 2] == '.' && path[i - 1] == '.') {
+			path_begin = path + 3;
+			break;
+		}
+
+		if (i >= 3 && IS_SLASH(path[i - 3]) && path[i - 2] == '.' && path[i - 1] == '.') {
+			path_begin = path + i + 1;
+			break;
+		}
+
 		i--;
 	}
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -102,23 +102,28 @@ static char * php_zip_make_relative_path(char *path, size_t path_len) /* {{{ */
 		return NULL;
 	}
 
-	if (path_len == 1 && (path[0] == '.' || IS_SLASH(path[0]))) {
+	if (path_len == 1 && (path[0] == '.' || IS_SLASH(path[0]) || path[0] == ':')) {
 		return NULL;
 	}
 
 	i = path_len;
 
 	while (1) {
-		while (i > 0 && !IS_SLASH(path[i])) {
+		while (i > 0 && !(IS_SLASH(path[i]) || path[i] == ':')) {
 			i--;
 		}
 
 		if (!i) {
-			if (IS_SLASH(path[0])) {
+			if (IS_SLASH(path[0]) || path[0] == ':') {
 				path_begin = path + 1;
 			} else {
 				path_begin = path;
 			}
+			break;
+		}
+
+		if (i == 1 && path[i] == ':') {
+			path_begin = path + i + 1;
 			break;
 		}
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -102,8 +102,8 @@ static char * php_zip_make_relative_path(char *path, size_t path_len) /* {{{ */
 		return NULL;
 	}
 
-	if (IS_SLASH(path[0])) {
-		return path + 1;
+	if (path_len == 1 && (path[0] == '.' || IS_SLASH(path[0]))) {
+		return NULL;
 	}
 
 	i = path_len;
@@ -114,7 +114,12 @@ static char * php_zip_make_relative_path(char *path, size_t path_len) /* {{{ */
 		}
 
 		if (!i) {
-			return path;
+			if (IS_SLASH(path[0])) {
+				path_begin = path + 1;
+			} else {
+				path_begin = path;
+			}
+			break;
 		}
 
 		if (i >= 1 && path[i - 1] == ':') {
@@ -134,6 +139,18 @@ static char * php_zip_make_relative_path(char *path, size_t path_len) /* {{{ */
 
 		i--;
 	}
+
+#ifdef PHP_WIN32
+	if (path[path_len - 1] == '.') {
+		path[path_len - 1] = '_';
+	}
+
+	for (i = 1; i < path_len; i++) {
+		if (IS_SLASH(path[i]) && path[i - 1] == '.') {
+			 path[i - 1] = '_';
+		}
+	}
+#endif
 
 	return path_begin;
 }

--- a/ext/zip/tests/bug69477.phpt
+++ b/ext/zip/tests/bug69477.phpt
@@ -19,21 +19,41 @@ if (!$archive->open($zipfile, ZipArchive::CREATE)) {
 }
 
 // (string) Entry path in the ZIP => (string) Expected actual target path
-$paths = [
-    '.a/b/c/file01.txt' => '.a/b/c/file01.txt',
-    'a./b/c/file02.txt' => 'a./b/c/file02.txt',
-    'a/.b/c/file03.txt' => 'a/.b/c/file03.txt',
-    'a/b./c/file04.txt' => 'a/b./c/file04.txt',
-    'a/b../c/file05.txt' => 'a/b../c/file05.txt',
-    'a/b.../c/file06.txt' => 'a/b.../c/file06.txt',
-    'a/..b/c/file07.txt' => 'a/..b/c/file07.txt',
-    'a/...b/c/file08.txt' => 'a/...b/c/file08.txt',
-    'a/../b./c./file09.txt' => 'b./c./file09.txt',
-    '//../b./c./file10.txt' => 'b./c./file10.txt',
-    '/../b./c./file11.txt' => 'b./c./file11.txt',
-    'C:/a./b./file12.txt' => 'a./b./file12.txt',
-    'a/b:/c/file13.txt' => 'c/file13.txt',
-];
+if (PHP_OS_FAMILY === 'Windows') {
+    $paths = [
+        '.a/b/c/file01.txt' => '.a/b/c/file01.txt',
+        'a./b/c/file02.txt' => 'a_/b/c/file02.txt',
+        'a/.b/c/file03.txt' => 'a/.b/c/file03.txt',
+        'a/b./c/file04.txt' => 'a/b_/c/file04.txt',
+        'a/b../c/file05.txt' => 'a/b._/c/file05.txt',
+        'a/b.../c/file06.txt' => 'a/b.._/c/file06.txt',
+        'a/..b/c/file07.txt' => 'a/..b/c/file07.txt',
+        'a/...b/c/file08.txt' => 'a/...b/c/file08.txt',
+        'a/../b./c./file09.txt' => 'b_/c_/file09.txt',
+        '//../b./c./file10.txt' => 'b_/c_/file10.txt',
+        '/../b./c./file11.txt' => 'b_/c_/file11.txt',
+        'C:/a./b./file12.txt' => 'a_/b_/file12.txt',
+        'a/b:/c/file13.txt' => 'c/file13.txt',
+        'a/b/c/file14.' => 'a/b/c/file14_',
+    ];
+} else {
+    $paths = [
+        '.a/b/c/file01.txt' => '.a/b/c/file01.txt',
+        'a./b/c/file02.txt' => 'a./b/c/file02.txt',
+        'a/.b/c/file03.txt' => 'a/.b/c/file03.txt',
+        'a/b./c/file04.txt' => 'a/b./c/file04.txt',
+        'a/b../c/file05.txt' => 'a/b../c/file05.txt',
+        'a/b.../c/file06.txt' => 'a/b.../c/file06.txt',
+        'a/..b/c/file07.txt' => 'a/..b/c/file07.txt',
+        'a/...b/c/file08.txt' => 'a/...b/c/file08.txt',
+        'a/../b./c./file09.txt' => 'b./c./file09.txt',
+        '//../b./c./file10.txt' => 'b./c./file10.txt',
+        '/../b./c./file11.txt' => 'b./c./file11.txt',
+        'C:/a./b./file12.txt' => 'a./b./file12.txt',
+        'a/b:/c/file13.txt' => 'c/file13.txt',
+        'a/b/c/file14.' => 'a/b/c/file14.',
+    ];
+}
 
 foreach ($paths as $zippath => $realpath) {
     $archive->addFromString($zippath, $zippath . ' => ' . $realpath);

--- a/ext/zip/tests/bug69477.phpt
+++ b/ext/zip/tests/bug69477.phpt
@@ -35,6 +35,7 @@ if (PHP_OS_FAMILY === 'Windows') {
         'C:/a./b./file12.txt' => 'a_/b_/file12.txt',
         'a/b:/c/file13.txt' => 'c/file13.txt',
         'a/b/c/file14.' => 'a/b/c/file14_',
+        'C:a./b./file15.txt' => 'a_/b_/file15.txt',
     ];
 } else {
     $paths = [
@@ -52,6 +53,7 @@ if (PHP_OS_FAMILY === 'Windows') {
         'C:/a./b./file12.txt' => 'a./b./file12.txt',
         'a/b:/c/file13.txt' => 'c/file13.txt',
         'a/b/c/file14.' => 'a/b/c/file14.',
+        'C:a./b./file15.txt' => 'a./b./file15.txt',
     ];
 }
 

--- a/ext/zip/tests/bug69477.phpt
+++ b/ext/zip/tests/bug69477.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Bug #69477 (ZipArchive::extractTo() truncates path segments ending with dot)
+--SKIPIF--
+<?php
+if(!extension_loaded('zip')) die('skip');
+?>
+--FILE--
+<?php
+include __DIR__ . '/utils.inc';
+$dir = __DIR__ . '/bug69477';
+if (file_exists($dir)) rmdir_rf($dir);
+mkdir($dir);
+$zipfile = $dir . '/abc.zip';
+
+$archive = new ZipArchive();
+
+if (!$archive->open($zipfile, ZipArchive::CREATE)) {
+    exit('failed: unable to create archive');
+}
+
+// (string) Entry path in the ZIP => (string) Expected actual target path
+$paths = [
+    '.a/b/c/file01.txt' => '.a/b/c/file01.txt',
+    'a./b/c/file02.txt' => 'a./b/c/file02.txt',
+    'a/.b/c/file03.txt' => 'a/.b/c/file03.txt',
+    'a/b./c/file04.txt' => 'a/b./c/file04.txt',
+    'a/b../c/file05.txt' => 'a/b../c/file05.txt',
+    'a/b.../c/file06.txt' => 'a/b.../c/file06.txt',
+    'a/..b/c/file07.txt' => 'a/..b/c/file07.txt',
+    'a/...b/c/file08.txt' => 'a/...b/c/file08.txt',
+    'a/../b./c./file09.txt' => 'b./c./file09.txt',
+    '//../b./c./file10.txt' => 'b./c./file10.txt',
+    '/../b./c./file11.txt' => 'b./c./file11.txt',
+    'C:/a./b./file12.txt' => 'a./b./file12.txt',
+    'a/b:/c/file13.txt' => 'c/file13.txt',
+];
+
+foreach ($paths as $zippath => $realpath) {
+    $archive->addFromString($zippath, $zippath . ' => ' . $realpath);
+}
+
+$archive->close();
+
+$archive2 = new ZipArchive();
+
+if (!$archive2->open($zipfile)) {
+    exit('failed: unable to open archive2');
+}
+
+$archive2->extractTo($dir);
+$archive2->close();
+
+foreach ($paths as $zippath => $realpath) {
+    if (!is_readable($dir . '/' . $realpath) || file_get_contents($dir . '/' . $realpath) !== $zippath . ' => ' . $realpath) {
+        exit('failed: ' . $zippath);
+    }
+}
+
+echo 'ok';
+?>
+--CLEAN--
+<?php
+include __DIR__ . '/utils.inc';
+$dir = __DIR__ . '/bug69477';
+rmdir_rf($dir);
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
The function `php_zip_make_relative_path()` used to stop on the first
right-most occurrence of './' in the ZIP entry path. As a result, the
`extractTo()` method didn't extract entries like `foo/bar./baz/file.txt`
into correct location.