### PR TITLE
Fix #80648: Fix for bug 79296 should be based on runtime version

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1473,17 +1473,21 @@ static ZIPARCHIVE_METHOD(open)
 		ze_obj->filename = NULL;
 	}
 
-#if LIBZIP_VERSION_MAJOR > 1 || LIBZIP_VERSION_MAJOR == 1 && LIBZIP_VERSION_MINOR >= 6
-	/* reduce BC break introduce in libzip 1.6.0
-	   "Do not accept empty files as valid zip archives any longer" */
+#ifdef HAVE_LIBZIP_VERSION
+	/* zip_libzip_version() is available as of 1.3.1;
+	   older versions don't need a workaround */
+	if (php_version_compare(zip_libzip_version(), "1.6.0") >= 0) {
+		/* reduce BC break introduced in libzip 1.6.0
+		   "Do not accept empty files as valid zip archives any longer" */
 
-	/* open for write without option to empty the archive */
-	if ((flags & (ZIP_TRUNCATE | ZIP_RDONLY)) == 0) {
-		zend_stat_t st;
+		/* open for write without option to empty the archive */
+		if ((flags & (ZIP_TRUNCATE | ZIP_RDONLY)) == 0) {
+			zend_stat_t st;
 
-		/* exists and is empty */
-		if (VCWD_STAT(resolved_path, &st) == 0 && st.st_size == 0) {
-			flags |= ZIP_TRUNCATE;
+			/* exists and is empty */
+			if (VCWD_STAT(resolved_path, &st) == 0 && st.st_size == 0) {
+				flags |= ZIP_TRUNCATE;
+			}
 		}
 	}
 #endif


### PR DESCRIPTION
This should go into PHP-7.4 *only*, since that fallback is removed as of PHP 8.0.0 altogether.

@remicollet, what do you think?