### PR TITLE
Clarify error description for SQLSTATE 22007

### DIFF
--- a/ext/pdo/pdo_sqlstate.c
+++ b/ext/pdo/pdo_sqlstate.c
@@ -83,7 +83,7 @@ static const struct pdo_sqlstate_info err_initializer[] = {
 	{ "22003",	"Numeric value out of range" },
 	{ "22004",	"Null value not allowed" },
 	{ "22005",	"Error in assignment" },
-	{ "22007",	"Invalid datetime format" },
+	{ "22007",	"Invalid or truncated value" },
 	{ "22008",	"Datetime field overflow" },
 	{ "22009",	"Invalid time zone displacement value" },
 	{ "2200B",	"Escape character conflict" },


### PR DESCRIPTION
In MySQL and MariaDB (not in Postgres) SQLSTATE `22007` is used for invalid values, not necessarily wrong dates.

In MySQL 5.7 [0] and 8.0 [1] and MariaDB [2], the two reasons for getting a 22007 state is:
|state|error no.|error|message|
|-----|-----|-----|-----|
|22007|1292|`ER_TRUNCATED_WRONG_VALUE`|Truncated incorrect %s value: '%s'|
|22007|1367|`ER_ILLEGAL_VALUE_FOR_TYPE`|Illegal %s '%s' value found during parsing|

Note: SQLSTATE codes are not to be confused with error numbers.

Currently, if you write a string >255 chars to a VARCHAR(255) column, PDO will report _'Invalid datetime format'_, which is _very_ confusing to see in your logs, since the column is clearly not a date type column.

That said, it looks like _'Invalid datetime format'_ is conforming with SQL:2011, as confirmed by Wikipedia [3] and the PostgreSQL manual [4]. Though I don't have access to SQL:2011, so I can't confirm.

Anyway, although the description of 22007 is technically correct confirming the SQL:2011, I believe that _'Invalid or truncated value'_ as proposed in this PR will prevent confusion, especially for MySQL/MariaDB users.

[0] https://dev.mysql.com/doc/mysql-errors/5.7/en/server-error-reference.html
[1] https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
[2] https://mariadb.com/kb/en/mariadb-error-codes/
[3] https://en.wikipedia.org/wiki/SQLSTATE
[4] https://www.postgresql.org/docs/9.4/errcodes-appendix.html