### PR TITLE
Fix #70091: Phar does not mark UTF-8 filenames in ZIP archives

### DIFF
--- a/ext/phar/tests/bug70091.phpt
+++ b/ext/phar/tests/bug70091.phpt
@@ -40,7 +40,7 @@ array(2) {
   ["sig"]=>
   string(8) "504b0304"
   ["flags"]=>
-  int(0)
+  int(8)
 }
 array(2) {
   ["sig"]=>
@@ -52,7 +52,7 @@ array(2) {
   ["sig"]=>
   string(8) "504b0102"
   ["flags"]=>
-  int(0)
+  int(8)
 }
 --CLEAN--
 <?php

--- a/ext/phar/tests/bug70091.phpt
+++ b/ext/phar/tests/bug70091.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Bug #70091 (Phar does not mark UTF-8 filenames in ZIP archives)
+--SKIPIF--
+<?php
+if (!extension_loaded('phar')) die('skip phar extension not available');
+if (!extension_loaded('zlib')) die('skip zlib extension not available');
+?>
+--FILE--
+<?php
+$phar = new PharData(__DIR__ . '/bug70091.zip');
+$phar->addFromString('föö', '');
+$phar->addFromString('foo', '');
+unset($phar);
+
+$stream = fopen(__DIR__ . '/bug70091.zip', 'r');
+
+$data = fread($stream, 8);
+var_dump(unpack('H8sig/@6/nflags', $data));
+
+fseek($stream, 53);
+$data = fread($stream, 8);
+var_dump(unpack('H8sig/@6/nflags', $data));
+
+fseek($stream, 104);
+$data = fread($stream, 10);
+var_dump(unpack('H8sig/@8/nflags', $data));
+
+fseek($stream, 173);
+$data = fread($stream, 10);
+var_dump(unpack('H8sig/@8/nflags', $data));
+?>
+--EXPECT--
+array(2) {
+  ["sig"]=>
+  string(8) "504b0304"
+  ["flags"]=>
+  int(8)
+}
+array(2) {
+  ["sig"]=>
+  string(8) "504b0304"
+  ["flags"]=>
+  int(0)
+}
+array(2) {
+  ["sig"]=>
+  string(8) "504b0102"
+  ["flags"]=>
+  int(8)
+}
+array(2) {
+  ["sig"]=>
+  string(8) "504b0102"
+  ["flags"]=>
+  int(0)
+}
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/bug70091.zip');
+?>

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -810,14 +810,6 @@ int phar_open_or_create_zip(char *fname, size_t fname_len, char *alias, size_t a
 }
 /* }}} */
 
-static zend_bool is_ascii(const unsigned char *str, uint32_t len)
-{
-	while (--len) {
-		if (*str++ >= 0x80) return 0;
-	}
-	return 1;
-}
-
 struct _phar_zip_pass {
 	php_stream *filefp;
 	php_stream *centralfp;
@@ -887,13 +879,11 @@ static int phar_zip_changed_apply_int(phar_entry_info *entry, void *arg) /* {{{ 
 	memcpy(central.datestamp, local.datestamp, sizeof(local.datestamp));
 	PHAR_SET_16(central.filename_len, entry->filename_len + (entry->is_dir ? 1 : 0));
 	PHAR_SET_16(local.filename_len, entry->filename_len + (entry->is_dir ? 1 : 0));
-	if (!is_ascii(entry->filename, entry->filename_len)) {
-		 // set language encoding flag
-		general_purpose_flags = PHAR_GET_16(central.flags);
-		PHAR_SET_16(central.flags, general_purpose_flags | (1 << 11));
-		general_purpose_flags = PHAR_GET_16(local.flags);
-		PHAR_SET_16(local.flags, general_purpose_flags | (1 << 11));
-	}
+	// set language encoding flag (all filenames have to be UTF-8 anyway)
+	general_purpose_flags = PHAR_GET_16(central.flags);
+	PHAR_SET_16(central.flags, general_purpose_flags | (1 << 11));
+	general_purpose_flags = PHAR_GET_16(local.flags);
+	PHAR_SET_16(local.flags, general_purpose_flags | (1 << 11));
 	PHAR_SET_32(central.offset, php_stream_tell(p->filefp));
 
 	/* do extra field for perms later */


### PR DESCRIPTION
The default encoding of filenames in a ZIP archive is IBM Code Page
437.  Phar, however, only supports UTF-8 filenames.  Therefore we have
to mark non ASCII filenames as being stored in UTF-8 by setting the
general purpose bit 11 (the language encoding flag).

The effect of not setting this bit for non ASCII filenames can be seen
in popular tools like 7-Zip and UnZip, but not when extracting the
archives via ext/phar (which is agnostic to the filename encoding), or
via ext/zip (which guesses the encoding).  Thus we add a somewhat
brittle low-level test case.