### PR TITLE
Update year to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------
                   The PHP License, version 3.01
-Copyright (c) 1999 - 2019 The PHP Group. All rights reserved.
+Copyright (c) 1999 - 2021 The PHP Group. All rights reserved.
 --------------------------------------------------------------------
 
 Redistribution and use in source and binary forms, with or without

--- a/ext/oci8/LICENSE
+++ b/ext/oci8/LICENSE
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------
                   The PHP License, version 3.01
-Copyright (c) 1999 - 2019 The PHP Group. All rights reserved.
+Copyright (c) 1999 - 2021 The PHP Group. All rights reserved.
 --------------------------------------------------------------------
 
 Redistribution and use in source and binary forms, with or without

--- a/ext/phar/phar.1.in
+++ b/ext/phar/phar.1.in
@@ -1,4 +1,4 @@
-.TH PHAR 1 "2019" "The PHP Group" "User Commands"
+.TH PHAR 1 "2021" "The PHP Group" "User Commands"
 .SH NAME
 phar, phar.phar \- PHAR (PHP archive) command line tool
 .SH SYNOPSIS

--- a/sapi/cli/php.1.in
+++ b/sapi/cli/php.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@php 1 "2019" "The PHP Group" "Scripting Language"
+.TH @program_prefix@php 1 "2021" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@php \- PHP Command Line Interface 'CLI'
 .P

--- a/sapi/fpm/php-fpm.8.in
+++ b/sapi/fpm/php-fpm.8.in
@@ -1,4 +1,4 @@
-.TH PHP-FPM 8 "2019" "The PHP Group" "Scripting Language"
+.TH PHP-FPM 8 "2021" "The PHP Group" "Scripting Language"
 .SH NAME
 .TP 15
 php-fpm \- PHP FastCGI Process Manager 'PHP-FPM'

--- a/sapi/phpdbg/phpdbg.1.in
+++ b/sapi/phpdbg/phpdbg.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@phpdbg 1 "2019" "The PHP Group" "Scripting Language"
+.TH @program_prefix@phpdbg 1 "2021" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@phpdbg \- The interactive PHP debugger
 .SH SYNOPSIS

--- a/scripts/man1/php-config.1.in
+++ b/scripts/man1/php-config.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@php\-config 1 "2019" "The PHP Group" "Scripting Language"
+.TH @program_prefix@php\-config 1 "2021" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@php\-config \- get information about PHP configuration and compile options
 .SH SYNOPSIS

--- a/scripts/man1/phpize.1.in
+++ b/scripts/man1/phpize.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@phpize 1 "2019" "The PHP Group" "Scripting Language"
+.TH @program_prefix@phpize 1 "2021" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@phpize \- prepare a PHP extension for compiling
 .SH SYNOPSIS


### PR DESCRIPTION
Hello, the year 2020 was skipped since it wasn't such a good year and now it is probably time to bump the year to 2021.

I've skipped PHP 7.3 branch.