### PR TITLE
added LibXMLError class definition to stub.

### DIFF
--- a/ext/libxml/libxml.stub.php
+++ b/ext/libxml/libxml.stub.php
@@ -13,6 +13,8 @@ function libxml_get_errors(): array {}
 
 function libxml_clear_errors(): void {}
 
+class LibXMLError {}
+
 /** @deprecated */
 function libxml_disable_entity_loader(bool $disable = true): bool {}
 


### PR DESCRIPTION
LibXMLError class is already implemented, but could not find it in libxml.stub.php.

https://github.com/php/php-src/blob/3e01f5afb1b52fe26a956190296de0192eedeec1/ext/libxml/libxml.c#L790-L818