### PR TITLE
Fix #75850: Unclear error message wrt. __halt_compiler() w/o semicolon

### DIFF
--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -2602,7 +2602,7 @@ int phar_flush(phar_archive_data *phar, char *user_stub, zend_long len, int conv
 			}
 			php_stream_close(newfile);
 			if (error) {
-				spprintf(error, 0, "illegal stub for phar \"%s\"", phar->fname);
+				spprintf(error, 0, "illegal stub for phar \"%s\" (__HALT_COMPILER(); is missing)", phar->fname);
 			}
 			if (free_user_stub) {
 				zend_string_free(suser_stub);

--- a/ext/phar/tests/phar_stub_error.phpt
+++ b/ext/phar/tests/phar_stub_error.phpt
@@ -48,7 +48,7 @@ __HALT_COMPILER();
 string(48) "<?php echo "first stub\n"; __HALT_COMPILER(); ?>"
 string(48) "<?php echo "first stub\n"; __HALT_COMPILER(); ?>"
 bool(true)
-Exception: illegal stub for phar "%sphar_stub_error.phar.php"
+Exception: illegal stub for phar "%sphar_stub_error.phar.php" (__HALT_COMPILER(); is missing)
 string(48) "<?php echo "first stub\n"; __HALT_COMPILER(); ?>"
 bool(true)
 string(48) "<?php echo "first stub\n"; __HALT_COMPILER(); ?>"


### PR DESCRIPTION
We add the failure reason to the error message.