### PR TITLE
Ignore ZEND_EXIT, ZEND_BEGIN_SILENCE, ZEND_END_SILENCE in JIT check

### DIFF
--- a/Zend/zend_vm_opcodes.c
+++ b/Zend/zend_vm_opcodes.c
@@ -442,3 +442,13 @@ ZEND_API uint32_t ZEND_FASTCALL zend_get_opcode_flags(zend_uchar opcode) {
 	}
 	return zend_vm_opcodes_flags[opcode];
 }
+ZEND_API zend_uchar zend_get_opcode_id(const char *name, size_t length) {
+	zend_uchar opcode;
+	for (opcode = 0; opcode < (sizeof(zend_vm_opcodes_names) / sizeof(zend_vm_opcodes_names[0])) - 1; opcode++) {
+		if (strncmp(zend_vm_opcodes_names[opcode], name, length) == 0) {
+			return opcode;
+		}
+	}
+	return ZEND_VM_LAST_OPCODE + 1;
+}
+

--- a/Zend/zend_vm_opcodes.h
+++ b/Zend/zend_vm_opcodes.h
@@ -79,6 +79,7 @@ BEGIN_EXTERN_C()
 
 ZEND_API const char* ZEND_FASTCALL zend_get_opcode_name(zend_uchar opcode);
 ZEND_API uint32_t ZEND_FASTCALL zend_get_opcode_flags(zend_uchar opcode);
+ZEND_API zend_uchar zend_get_opcode_id(const char *name, size_t length);
 
 END_EXTERN_C()
 

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4234,11 +4234,19 @@ ZEND_EXT_API int zend_jit_check_support(void)
 	}
 
 	for (i = 0; i <= 256; i++) {
-		if (zend_get_user_opcode_handler(i) != NULL) {
-			zend_error(E_WARNING, "JIT is incompatible with third party extensions that setup user opcode handlers. JIT disabled.");
-			JIT_G(enabled) = 0;
-			JIT_G(on) = 0;
-			return FAILURE;
+		switch (i) {
+			/* JIT has no effect on these opcodes */
+			case ZEND_BEGIN_SILENCE:
+			case ZEND_END_SILENCE:
+			case ZEND_EXIT:
+				break;
+			default:
+				if (zend_get_user_opcode_handler(i) != NULL) {
+					zend_error(E_WARNING, "JIT is incompatible with third party extensions that setup user opcode handlers. JIT disabled.");
+					JIT_G(enabled) = 0;
+					JIT_G(on) = 0;
+					return FAILURE;
+				}
 		}
 	}
 

--- a/ext/opcache/tests/jit/ignored_opcodes.phpt
+++ b/ext/opcache/tests/jit/ignored_opcodes.phpt
@@ -1,0 +1,32 @@
+--TEST--
+JIT: ignored opcodes
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+opcache.jit=function
+;opcache.jit_debug=257
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_opcode_in_user_handler=ZEND_EXIT, ZEND_BEGIN_SILENCE, ZEND_END_SILENCE
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--FILE--
+<?php
+function test(): int
+{
+    return 0;
+}
+
+exit(@test());
+?>
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- opcode: 'ZEND_BEGIN_SILENCE' in user handler -->
+  <!-- opcode: 'ZEND_END_SILENCE' in user handler -->
+  <!-- opcode: 'ZEND_EXIT' in user handler -->
+  <!-- Exception: UnwindExit -->
+</file '%s'>

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -38,6 +38,7 @@ ZEND_BEGIN_MODULE_GLOBALS(zend_test)
 	int observer_show_return_value;
 	int observer_show_init_backtrace;
 	int observer_show_opcode;
+	char *observer_show_opcode_in_user_handler;
 	int observer_nesting_depth;
 	int replace_zend_execute_ex;
 ZEND_END_MODULE_GLOBALS(zend_test)
@@ -346,6 +347,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("zend_test.observer.show_return_value", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_return_value, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.observer.show_init_backtrace", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_init_backtrace, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.observer.show_opcode", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_opcode, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_ENTRY("zend_test.observer.show_opcode_in_user_handler", "", PHP_INI_SYSTEM, OnUpdateString, observer_show_opcode_in_user_handler, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.replace_zend_execute_ex", "0", PHP_INI_SYSTEM, OnUpdateBool, replace_zend_execute_ex, zend_zend_test_globals, zend_test_globals)
 PHP_INI_END()
 
@@ -355,6 +357,42 @@ void (*old_zend_execute_ex)(zend_execute_data *execute_data);
 static void custom_zend_execute_ex(zend_execute_data *execute_data)
 {
 	old_zend_execute_ex(execute_data);
+}
+
+static int observer_show_opcode_in_user_handler(zend_execute_data *execute_data)
+{
+	if (ZT_G(observer_show_output)) {
+		php_printf("%*s<!-- opcode: '%s' in user handler -->\n", 2 * ZT_G(observer_nesting_depth), "", zend_get_opcode_name(EX(opline)->opcode));
+	}
+
+	return ZEND_USER_OPCODE_DISPATCH;
+}
+
+static void observer_set_user_opcode_handler(const char *opcode_names, user_opcode_handler_t handler)
+{
+	const char *s = NULL, *e = opcode_names;
+
+	while (1) {
+		if (*e == ' ' || *e == ',' || *e == '\0') {
+			if (s) {
+				zend_uchar opcode = zend_get_opcode_id(s, e - s);
+				if (opcode <= ZEND_VM_LAST_OPCODE) {
+					zend_set_user_opcode_handler(opcode, handler);
+				} else {
+					zend_error(E_WARNING, "Invalid opcode name %.*s", (int) (e - s), e);
+				}
+				s = NULL;
+			}
+		} else {
+			if (!s) {
+				s = e;
+			}
+		}
+		if (*e == '\0') {
+			break;
+		}
+		e++;
+	}
 }
 
 PHP_MINIT_FUNCTION(zend_test)
@@ -398,6 +436,10 @@ PHP_MINIT_FUNCTION(zend_test)
 	if (ZT_G(replace_zend_execute_ex)) {
 		old_zend_execute_ex = zend_execute_ex;
 		zend_execute_ex = custom_zend_execute_ex;
+	}
+
+	if (ZT_G(observer_enabled) && ZT_G(observer_show_opcode_in_user_handler)) {
+		observer_set_user_opcode_handler(ZT_G(observer_show_opcode_in_user_handler), observer_show_opcode_in_user_handler);
 	}
 
 	return SUCCESS;


### PR DESCRIPTION
ref: https://bugs.php.net/bug.php?id=80621

Swoole only replaced `ZEND_EXIT`, `ZEND_BEGIN_SILENCE`, `ZEND_END_SILENCE` opcode handlers.
`ZEND_EXIT` can help Swoole to detect exit/die operation and exit from the current coroutine correctly.
`ZEND_*_SILENCE` can help Swoole to switch `EG(error_reporting)` to keep the right behavior when using the error control operator.

I don't know much about JIT, but I think that JIT should not break the compatibility of all user opcodes...
And sometimes it is acceptable even if the compatibility was broken, these user opcode handlers are not very important, especially when developers want to enable JIT anyway.
