### PR TITLE
Don't leak changes to textdomain and friends across requests

### DIFF
--- a/ext/gettext/php_gettext.h
+++ b/ext/gettext/php_gettext.h
@@ -47,6 +47,17 @@ PHP_NAMED_FUNCTION(zif_dcngettext);
 PHP_NAMED_FUNCTION(zif_bind_textdomain_codeset);
 #endif
 
+ZEND_BEGIN_MODULE_GLOBALS(php_gettext)
+	HashTable *dirs;
+ZEND_END_MODULE_GLOBALS(php_gettext)
+
+#if defined(ZTS) && defined(COMPILE_DL_GETTEXT)
+ZEND_TSRMLS_CACHE_EXTERN()
+#endif
+
+ZEND_EXTERN_MODULE_GLOBALS(php_gettext)
+#define PHPGETTEXTG(v) ZEND_MODULE_GLOBALS_ACCESSOR(php_gettext, v)
+
 #else
 #define gettext_module_ptr NULL
 #endif /* HAVE_LIBINTL */


### PR DESCRIPTION
For `textdomain()`, this is trivial; we just retrieve the default value in MINIT, and store it in a true global, and set it in RINIT.

For `bind_textdomain()` it is not quite as trivial; we need a module global HashTable where we store all changed domains with their original directory, and reset everything in RINIT.

For `bind_textdomain_codeset()`, however, there seems to be no solution, since the default value of the codeset is `NULL`, but when passing NULL as codeset to `bind_textdomain_codeset(3)`, the function returns the current codeset.

I'm not sure how to proceed with this. Any ideas?

Also we should probably document that ext/gettext is not thread safe …