### PR TITLE
use pcre.jit only if enabled

### DIFF
--- a/ext/opcache/zend_accelerator_blacklist.c
+++ b/ext/opcache/zend_accelerator_blacklist.c
@@ -185,10 +185,12 @@ static void zend_accel_blacklist_update_regexp(zend_blacklist *blacklist)
 				return;
 			}
 #ifdef HAVE_PCRE_JIT_SUPPORT
-			if (0 > pcre2_jit_compile(it->re, PCRE2_JIT_COMPLETE)) {
-				/* Don't return here, even JIT could fail to compile, the pattern is still usable. */
-				pcre2_get_error_message(errnumber, pcre_error, sizeof(pcre_error));
-				zend_accel_error(ACCEL_LOG_WARNING, "Blacklist JIT compilation failed, %s\n", pcre_error);
+			if (PCRE_G(jit)) {
+				if (0 > pcre2_jit_compile(it->re, PCRE2_JIT_COMPLETE)) {
+					/* Don't return here, even JIT could fail to compile, the pattern is still usable. */
+					pcre2_get_error_message(errnumber, pcre_error, sizeof(pcre_error));
+					zend_accel_error(ACCEL_LOG_WARNING, "Blacklist JIT compilation failed, %s\n", pcre_error);
+				}
 			}
 #endif
 			/* prepare for the next iteration */


### PR DESCRIPTION
We have a buildtime option `HAVE_PCRE_JIT_SUPPORT` and a runtime option for pcre2 jit usage `PCRE_G(jit)`

This fix check for both in opcache.

Bug: when selinux, jit doesn't work, but even with pcre.jit=0, when opcache is enabled, a AVC is raised

`type=AVC msg=audit(1611840254.138:10844): avc:  denied  { execmem } for  pid=328163 comm="php-fpm" scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:system_r:httpd_t:s0 tclass=process permissive=1`
