### PR TITLE
Fix #80654: file_get_contents() maxlen fails above (2**31)-1 bytes

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -564,10 +564,6 @@ PHP_FUNCTION(file_get_contents)
 		RETURN_FALSE;
 	}
 
-	if (maxlen > INT_MAX) {
-		php_error_docref(NULL, E_WARNING, "maxlen truncated from " ZEND_LONG_FMT " to %d bytes", maxlen, INT_MAX);
-		maxlen = INT_MAX;
-	}
 	if ((contents = php_stream_copy_to_mem(stream, maxlen, 0)) != NULL) {
 		RETVAL_STR(contents);
 	} else {

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -456,10 +456,6 @@ PHP_FUNCTION(stream_get_contents)
 		}
 	}
 
-	if (maxlen > INT_MAX) {
-		php_error_docref(NULL, E_WARNING, "maxlen truncated from " ZEND_LONG_FMT " to %d bytes", maxlen, INT_MAX);
-		maxlen = INT_MAX;
-	}
 	if ((contents = php_stream_copy_to_mem(stream, maxlen, 0))) {
 		RETURN_STR(contents);
 	} else {


### PR DESCRIPTION
We remove the arbitrary restriction to `INT_MAX`; it is superfluous on
32bit systems where `ZEND_LONG_MAX == INT_MAX` anyway, and not useful
on 64bit systems, where larger files should be readable, if the
`memory_limit` is large enough.