### PR TITLE
Proposal: Add debug_backtrace_depth(int $limit=0): int

### DIFF
--- a/Zend/tests/debug_backtrace_depth.phpt
+++ b/Zend/tests/debug_backtrace_depth.phpt
@@ -1,0 +1,24 @@
+--TEST--
+debug_backtrace_depth
+--FILE--
+<?php
+
+function example(int $i, int $max) {
+    printf("i=%d depth=%d depth(limit=5)=%d\n", $i, debug_backtrace_depth(), debug_backtrace_depth(5));
+    if ($i < $max) {
+        example($i + 1, $max);
+    }
+}
+example(0, 7);
+printf("at entry point depth=%d depth(limit=5)=%d\n", debug_backtrace_depth(), debug_backtrace_depth(5));
+?>
+--EXPECT--
+i=0 depth=1 depth(limit=5)=1
+i=1 depth=2 depth(limit=5)=2
+i=2 depth=3 depth(limit=5)=3
+i=3 depth=4 depth(limit=5)=4
+i=4 depth=5 depth(limit=5)=5
+i=5 depth=6 depth(limit=5)=5
+i=6 depth=7 depth(limit=5)=5
+i=7 depth=8 depth(limit=5)=5
+at entry point depth=0 depth(limit=5)=0

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -113,6 +113,8 @@ function debug_backtrace(int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT, int $lim
 
 function debug_print_backtrace(int $options = 0, int $limit = 0): void {}
 
+function debug_backtrace_depth(int $limit = 0): int {}
+
 function extension_loaded(string $extension): bool {}
 
 function get_extension_funcs(string $extension): array|false {}

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 429fc9b22054348101d0b9d6746494e52dc04edf */
+ * Stub hash: b11c04588aee5fc1d64cc34750987ce987befe98 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -185,6 +185,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_debug_print_backtrace, 0, 0, IS_
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_debug_backtrace_depth, 0, 0, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, limit, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_extension_loaded, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, extension, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -258,6 +262,7 @@ ZEND_FUNCTION(get_loaded_extensions);
 ZEND_FUNCTION(get_defined_constants);
 ZEND_FUNCTION(debug_backtrace);
 ZEND_FUNCTION(debug_print_backtrace);
+ZEND_FUNCTION(debug_backtrace_depth);
 ZEND_FUNCTION(extension_loaded);
 ZEND_FUNCTION(get_extension_funcs);
 #if ZEND_DEBUG && defined(ZTS)
@@ -320,6 +325,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(get_defined_constants, arginfo_get_defined_constants)
 	ZEND_FE(debug_backtrace, arginfo_debug_backtrace)
 	ZEND_FE(debug_print_backtrace, arginfo_debug_print_backtrace)
+	ZEND_FE(debug_backtrace_depth, arginfo_debug_backtrace_depth)
 	ZEND_FE(extension_loaded, arginfo_extension_loaded)
 	ZEND_FE(get_extension_funcs, arginfo_get_extension_funcs)
 #if ZEND_DEBUG && defined(ZTS)


### PR DESCRIPTION
This can be polyfilled with
`min($limit, count(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)))`.
or less accurately as `count(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $limit))`

- For debug_backtrace, the limit is to the number of frames scanned,
  not the size of the returned array.
- For debug_backtrace_depth, the limit is on the returned depth)

It's faster just to not read the filenames, lines, create temporary arrays, etc.

This can be useful if you are checking for infinite recursion
to investigate a bug in an application.
E.g. `return debug_backtrace_depth(1000) >= 1000` would check
if php is more than 1000 stack frames of debug_backtrace deep.

This may have other uses, such as more efficiently
computing an indentation level in temporary debug logging statements.

```
Processing Node A
  Processing Node B
    Processing Leaf C
    Processing Leaf D
```

Note that php stack frames are a linked list - the amount of time to compute the
depth is proportional to the depth, and some frames do not show up in backtraces.
This PHP stack is separate from the C stack.

RFC: https://wiki.php.net/rfc/debug_backtrace_depth