### PR TITLE
Fix environment variable not work in run-tests.php

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -340,7 +340,7 @@ function main(): void
     if (function_exists('sapi_windows_vt100_support') && !sapi_windows_vt100_support(STDOUT, true)) {
         $colorize = false;
     }
-    if (array_key_exists('NO_COLOR', $_ENV)) {
+    if (array_key_exists('NO_COLOR', $environment)) {
         $colorize = false;
     }
     $selected_tests = false;
@@ -1446,7 +1446,7 @@ function run_all_tests_parallel(array $test_files, array $env, $redir_tested): v
             [], // Inherit our stdin, stdout and stderr
             $pipes,
             null,
-            $_ENV + [
+            $GLOBALS['environment'] + [
                 "TEST_PHP_WORKER" => $i,
                 "TEST_PHP_URI" => $sockUri,
             ],


### PR DESCRIPTION
The comment on line 200 explains why.