### PR TITLE
Fix bug #80600 DOMChildNode::remove does not work on DOMCharacterData.

### DIFF
--- a/ext/dom/characterdata.c
+++ b/ext/dom/characterdata.c
@@ -349,9 +349,8 @@ PHP_METHOD(DOMCharacterData, replaceData)
 PHP_METHOD(DOMCharacterData, remove)
 {
 	zval *id = ZEND_THIS;
-	xmlNodePtr children, child;
+	xmlNodePtr child;
 	dom_object *intern;
-	int stricterror;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		RETURN_THROWS();
@@ -359,38 +358,7 @@ PHP_METHOD(DOMCharacterData, remove)
 
 	DOM_GET_OBJ(child, id, xmlNodePtr, intern);
 
-	if (dom_node_children_valid(child) == FAILURE) {
-		RETURN_NULL();
-	}
-
-	stricterror = dom_get_strict_error(intern->document);
-
-	if (dom_node_is_read_only(child) == SUCCESS ||
-		(child->parent != NULL && dom_node_is_read_only(child->parent) == SUCCESS)) {
-		php_dom_throw_error(NO_MODIFICATION_ALLOWED_ERR, stricterror);
-		RETURN_NULL();
-	}
-
-	if (!child->parent) {
-		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
-		RETURN_NULL();
-	}
-
-	children = child->parent->children;
-	if (!children) {
-		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
-		RETURN_NULL();
-	}
-
-	while (children) {
-		if (children == child) {
-			xmlUnlinkNode(child);
-			RETURN_NULL();
-		}
-		children = children->next;
-	}
-
-	php_dom_throw_error(NOT_FOUND_ERR, stricterror);
+	dom_child_node_remove(intern);
 	RETURN_NULL();
 }
 

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -374,10 +374,6 @@ void dom_child_node_remove(dom_object *context)
 	xmlNodePtr children;
 	int stricterror;
 
-	if (dom_node_children_valid(child) == FAILURE) {
-		return;
-	}
-
 	stricterror = dom_get_strict_error(context->document);
 
 	if (dom_node_is_read_only(child) == SUCCESS ||
@@ -388,6 +384,10 @@ void dom_child_node_remove(dom_object *context)
 
 	if (!child->parent) {
 		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
+		return;
+	}
+
+	if (dom_node_children_valid(child->parent) == FAILURE) {
 		return;
 	}
 

--- a/ext/dom/tests/bug80600.phpt
+++ b/ext/dom/tests/bug80600.phpt
@@ -1,0 +1,11 @@
+--TEST--
+dom: DOMChildNode::remove does not work on character data
+--FILE--
+<?php
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a><!-- foo --></a>');
+$doc->documentElement->firstChild->remove();
+echo $doc->saveXML($doc->documentElement);
+--EXPECTF--
+<a/>


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=80600

Problem was an erroreous check if `child` was valid to have child nodes, but the check must be made for the parents. Also cleans up code duplication between `PHP_METHOD(DOMCharacterData, remove)` and `dom_child_node_remove`.