### PR TITLE
Properly render 2+ namespaces functions in build/gen_stub.php

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -818,9 +818,10 @@ class FuncInfo {
             }
 
             if ($namespace) {
+                // Render A\B as "A\\B" in C strings for namespaces
                 return sprintf(
                     "\tZEND_NS_FE(\"%s\", %s, %s)\n",
-                    $namespace, $declarationName, $this->getArgInfoName());
+                    addslashes($namespace), $declarationName, $this->getArgInfoName());
             } else {
                 return sprintf("\tZEND_FE(%s, %s)\n", $declarationName, $this->getArgInfoName());
             }
@@ -1222,7 +1223,7 @@ class ClassInfo {
         $code .= "\tzend_class_entry ce, *class_entry;\n\n";
         if (count($this->name->parts) > 1) {
             $className = $this->name->getLast();
-            $namespace = $this->name->slice(0, -1);
+            $namespace = addslashes((string) $this->name->slice(0, -1));
 
             $code .= "\tINIT_NS_CLASS_ENTRY(ce, \"$namespace\", \"$className\", class_{$escapedName}_methods);\n";
         } else {

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -236,6 +236,12 @@ static ZEND_FUNCTION(zend_iterable)
 	ZEND_PARSE_PARAMETERS_END();
 }
 
+static ZEND_FUNCTION(namespaced_func)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	RETURN_TRUE;
+}
+
 static zend_object *zend_test_class_new(zend_class_entry *class_type) /* {{{ */ {
 	zend_object *obj = zend_objects_new(class_type);
 	object_properties_init(obj, class_type);
@@ -320,6 +326,10 @@ static ZEND_METHOD(ZendTestNS_Foo, method) {
 }
 
 static ZEND_METHOD(ZendTestNS2_Foo, method) {
+	ZEND_PARSE_PARAMETERS_NONE();
+}
+
+static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method) {
 	ZEND_PARSE_PARAMETERS_NONE();
 }
 

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -90,3 +90,13 @@ class Foo {
 }
 
 }
+
+namespace ZendTestNS2\ZendSubNS {
+
+class Foo {
+    public function method(): void {}
+}
+
+function namespaced_func(): bool {}
+
+}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 950679cde15789a9060d4798dc35dc5a590fd8b2 */
+ * Stub hash: 74e25e800964d6ecc2dfd783e7d738e3776c664c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -51,6 +51,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_iterable, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, arg2, IS_ITERABLE, 1, "null")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_ZendSubNS_namespaced_func, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestClass_is_object, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -60,12 +63,13 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestClass_returnsStatic, 0, 0, IS_STATIC, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestTrait_testMethod, 0, 0, _IS_BOOL, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class__ZendTestTrait_testMethod arginfo_ZendTestNS2_ZendSubNS_namespaced_func
 
 #define arginfo_class_ZendTestNS_Foo_method arginfo_zend_test_void_return
 
 #define arginfo_class_ZendTestNS2_Foo_method arginfo_zend_test_void_return
+
+#define arginfo_class_ZendTestNS2_ZendSubNS_Foo_method arginfo_zend_test_void_return
 
 
 static ZEND_FUNCTION(zend_test_array_return);
@@ -81,12 +85,14 @@ static ZEND_FUNCTION(zend_string_or_object_or_null);
 static ZEND_FUNCTION(zend_string_or_stdclass);
 static ZEND_FUNCTION(zend_string_or_stdclass_or_null);
 static ZEND_FUNCTION(zend_iterable);
+static ZEND_FUNCTION(namespaced_func);
 static ZEND_METHOD(_ZendTestClass, is_object);
 static ZEND_METHOD(_ZendTestClass, __toString);
 static ZEND_METHOD(_ZendTestClass, returnsStatic);
 static ZEND_METHOD(_ZendTestTrait, testMethod);
 static ZEND_METHOD(ZendTestNS_Foo, method);
 static ZEND_METHOD(ZendTestNS2_Foo, method);
+static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -103,6 +109,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_string_or_stdclass, arginfo_zend_string_or_stdclass)
 	ZEND_FE(zend_string_or_stdclass_or_null, arginfo_zend_string_or_stdclass_or_null)
 	ZEND_FE(zend_iterable, arginfo_zend_iterable)
+	ZEND_NS_FE("ZendTestNS2\\ZendSubNS", namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)
 	ZEND_FE_END
 };
 
@@ -144,6 +151,12 @@ static const zend_function_entry class_ZendTestNS_Foo_methods[] = {
 
 static const zend_function_entry class_ZendTestNS2_Foo_methods[] = {
 	ZEND_ME(ZendTestNS2_Foo, method, arginfo_class_ZendTestNS2_Foo_method, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ZendTestNS2_ZendSubNS_Foo_methods[] = {
+	ZEND_ME(ZendTestNS2_ZendSubNS_Foo, method, arginfo_class_ZendTestNS2_ZendSubNS_Foo_method, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -247,6 +260,16 @@ zend_class_entry *register_class_ZendTestNS2_Foo()
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS2", "Foo", class_ZendTestNS2_Foo_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	return class_entry;
+}
+
+zend_class_entry *register_class_ZendTestNS2_ZendSubNS_Foo()
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS2\\ZendSubNS", "Foo", class_ZendTestNS2_ZendSubNS_Foo_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 
 	return class_entry;


### PR DESCRIPTION
Affects both INIT_NS_CLASS_ENTRY and ZEND_NS_FE

@nikic FYI - This seems to work for a name such as `PHP\iterable\any` and a class. Previously, `INIT_NS_CLASS_ENTRY(ce, "Foo\Bar", "X", class_Foo_Bar_X_methods);` would be generated instead of `"Foo\\Bar"`

Should this be backported to PHP-8.0 for global functions?