### PR TITLE
Fix #74779: x() and y() truncating floats to integers

### DIFF
--- a/ext/mysqli/tests/bug74779.phpt
+++ b/ext/mysqli/tests/bug74779.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Bug #74779 (x() and y() truncating floats to integers)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (!setlocale(LC_NUMERIC, "de_DE", "de_DE.UTF-8", "de-DE")) die('skip locale not available');
+?>
+--FILE--
+<?php
+require_once("connect.inc");
+
+if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
+        $host, $user, $db, $port, $socket);
+}
+
+if (!setlocale(LC_NUMERIC, "de_DE", "de_DE.UTF-8", "de-DE")) {
+    echo "[002] Cannot set locale\n";
+}
+
+if (!$link->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true)) {
+    printf("[003] [%d] %s\n", $link->errno, $link->error);
+}
+
+if (!$result = $link->query("SELECT Y(Point(56.7, 53.34))")) {
+    printf("[004] [%d] %s\n", $link->errno, $link->error);
+}
+
+if (!$array = $result->fetch_array(MYSQLI_ASSOC)) {
+    printf("[005] [%d] %s\n", $link->errno, $link->error);
+}
+
+var_dump($array);
+
+mysqli_close($link);
+?>
+--EXPECT--
+array(1) {
+  ["Y(Point(56.7, 53.34))"]=>
+  float(53,34)
+}

--- a/ext/mysqli/tests/bug74779.phpt
+++ b/ext/mysqli/tests/bug74779.phpt
@@ -3,6 +3,7 @@ Bug #74779 (x() and y() truncating floats to integers)
 --SKIPIF--
 <?php
 require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
 if (!setlocale(LC_NUMERIC, "de_DE", "de_DE.UTF-8", "de-DE")) die('skip locale not available');
 ?>
 --FILE--

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -1679,7 +1679,7 @@ php_mysqlnd_rowp_read_text_protocol_aux(MYSQLND_ROW_BUFFER * row_buffer, zval * 
 				zend_uchar save = *(p + len);
 				/* We have to make it ASCIIZ temporarily */
 				*(p + len) = '\0';
-				ZVAL_DOUBLE(current_field, atof((char *) p));
+				ZVAL_DOUBLE(current_field, zend_strtod((char *) p, NULL));
 				*(p + len) = save;
 			}
 #endif /* MYSQLND_STRING_TO_INT_CONVERSION */


### PR DESCRIPTION
We must not use the locale dependent `atof()`, but instead use the
(hopefully) locale independent `zend_strtod()`, when converting string
representations of floating point numbers which are sent by the server.

---

According to [the documentation](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html) there is no way to change `LC_NUMERIC` for the server, so we can expect the server to always sent string representations of floating point numbers with a dot as decimal separator. I'm not sure about that, though, particularly wrt. the MySQL forks.

Also, if `zend_strtod()` is built with `USE_LOCALE` defined, we're back at square one. I think we can ignore that possibility, though, since it likely would break other stuff as well.