### PR TITLE
Fix #78680: mysqlnd pam plugin missing terminating null

### DIFF
--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -652,7 +652,11 @@ mysqlnd_pam_auth_get_auth_data(struct st_mysqlnd_authentication_plugin * self,
 	if (passwd && passwd_len) {
 		ret = (zend_uchar*) zend_strndup(passwd, passwd_len);
 	}
-	*auth_data_len = passwd_len;
+	/*
+	  Trailing null required. bug#78680
+	  https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_authentication_methods_clear_text_password.html
+	*/
+	*auth_data_len = passwd_len + 1;
 
 	return ret;
 }


### PR DESCRIPTION
The PAM service requires the terminating null to be part
of the communication.

Tested with MariaDB-10.4(pam) and Percona Server 5.7.32(auth_pam_compat).

Test result should actually succeed. Add additional check for pamtest user.

Thanks Geoff Montee for bug report.