### PR TITLE
Fix locale dependent parsing of PostgreSQL version number

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1424,9 +1424,9 @@ static void php_pgsql_do_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent)
 			}
 			pgsql = (PGconn *) le->ptr;
 #if HAVE_PQPROTOCOLVERSION && HAVE_PQPARAMETERSTATUS
-			if (PQprotocolVersion(pgsql) >= 3 && atof(PQparameterStatus(pgsql, "server_version")) >= 7.2) {
+			if (PQprotocolVersion(pgsql) >= 3 && zend_strtod(PQparameterStatus(pgsql, "server_version"), NULL) >= 7.2) {
 #else
-			if (atof(PG_VERSION) >= 7.2) {
+			if (zend_strtod(PG_VERSION, NULL) >= 7.2) {
 #endif
 				pg_result = PQexec(pgsql, "RESET ALL;");
 				PQclear(pg_result);
@@ -5326,9 +5326,9 @@ PHP_FUNCTION(pg_get_notify)
 		add_index_string(return_value, 0, pgsql_notify->relname);
 		add_index_long(return_value, 1, pgsql_notify->be_pid);
 #if HAVE_PQPROTOCOLVERSION && HAVE_PQPARAMETERSTATUS
-		if (PQprotocolVersion(pgsql) >= 3 && atof(PQparameterStatus(pgsql, "server_version")) >= 9.0) {
+		if (PQprotocolVersion(pgsql) >= 3 && zend_strtod(PQparameterStatus(pgsql, "server_version"), NULL) >= 9.0) {
 #else
-		if (atof(PG_VERSION) >= 9.0) {
+		if (zend_strtod(PG_VERSION) >= 9.0, NULL) {
 #endif
 #if HAVE_PQPARAMETERSTATUS
 			add_index_string(return_value, 2, pgsql_notify->extra);
@@ -5339,9 +5339,9 @@ PHP_FUNCTION(pg_get_notify)
 		add_assoc_string(return_value, "message", pgsql_notify->relname);
 		add_assoc_long(return_value, "pid", pgsql_notify->be_pid);
 #if HAVE_PQPROTOCOLVERSION && HAVE_PQPARAMETERSTATUS
-		if (PQprotocolVersion(pgsql) >= 3 && atof(PQparameterStatus(pgsql, "server_version")) >= 9.0) {
+		if (PQprotocolVersion(pgsql) >= 3 && zend_strtod(PQparameterStatus(pgsql, "server_version"), NULL) >= 9.0) {
 #else
-		if (atof(PG_VERSION) >= 9.0) {
+		if (zend_strtod(PG_VERSION, NULL) >= 9.0) {
 #endif
 #if HAVE_PQPARAMETERSTATUS
 			add_assoc_string(return_value, "payload", pgsql_notify->extra);


### PR DESCRIPTION
Version numbers are not supposed to be localized, so we must not apply
locale dependent parsing with `atof()`.

---

This has been pointed out in PR #6665.