### PR TITLE
Implicitly enable function entry generation when class entry generation is enabled

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1782,12 +1782,14 @@ function parseStubFile(string $code): FileInfo {
                 $fileInfo->generateLegacyArginfo = true;
             } else if ($tag->name === 'generate-class-entries') {
                 $fileInfo->generateClassEntries = true;
+                $fileInfo->declarationPrefix = $tag->value ? $tag->value . " " : "";
             }
         }
     }
 
+    // Generating class entries require generating function/method entries
     if ($fileInfo->generateClassEntries && !$fileInfo->generateFunctionEntries) {
-        throw new Exception("Function entry generation must be enabled when generating class entries");
+        $fileInfo->generateFunctionEntries = true;
     }
 
     handleStatements($fileInfo, $stmts, $prettyPrinter);

--- a/ext/bcmath/bcmath.stub.php
+++ b/ext/bcmath/bcmath.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function bcadd(string $num1, string $num2, ?int $scale = null): string {}
 

--- a/ext/bcmath/bcmath_arginfo.h
+++ b/ext/bcmath/bcmath_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2232d60eb40f382b141ec28fe9542bd88e784333 */
+ * Stub hash: 6a16fed65c0e488e65c43e7df3bd1744e9349cc7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_bcadd, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, num1, IS_STRING, 0)

--- a/ext/bz2/bz2.stub.php
+++ b/ext/bz2/bz2.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 /**
  * @param string|resource $file

--- a/ext/bz2/bz2_arginfo.h
+++ b/ext/bz2/bz2_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 10682cdfc126686cab8497868287459dc574b93d */
+ * Stub hash: 8116780e328f137ca15ae445c9d6b45cf2f41f06 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_bzopen, 0, 0, 2)
 	ZEND_ARG_INFO(0, file)

--- a/ext/calendar/calendar.stub.php
+++ b/ext/calendar/calendar.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function cal_days_in_month(int $calendar, int $month, int $year): int {}
 

--- a/ext/calendar/calendar_arginfo.h
+++ b/ext/calendar/calendar_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4953fb1f36502b399061f5e0ca2f700d09761be3 */
+ * Stub hash: d383ac249ddc88aee4cfaaefd37e85d913281f8e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_cal_days_in_month, 0, 3, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, calendar, IS_LONG, 0)

--- a/ext/ctype/ctype.stub.php
+++ b/ext/ctype/ctype.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function ctype_alnum(mixed $text): bool {}
 

--- a/ext/ctype/ctype_arginfo.h
+++ b/ext/ctype/ctype_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bdf377cc2819bdc625cd2ee1afed2f3e7990eef8 */
+ * Stub hash: 155783e1858a7f24dbc1c3e810d5cffee5468bf7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ctype_alnum, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, text, IS_MIXED, 0)

--- a/ext/curl/curl.stub.php
+++ b/ext/curl/curl.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 /** @strict-properties */
 final class CurlHandle

--- a/ext/curl/curl_arginfo.h
+++ b/ext/curl/curl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0d1b398a10959922a9e12df75fd8465291058fd5 */
+ * Stub hash: b0f2f56d0a38656637190456e5ebd87bf052ee14 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_curl_close, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, handle, CurlHandle, 0)

--- a/ext/curl/curl_file.stub.php
+++ b/ext/curl/curl_file.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 class CURLFile
 {

--- a/ext/curl/curl_file_arginfo.h
+++ b/ext/curl/curl_file_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4cdab686b39e7c4bb03bd5517a637ff25a38b04a */
+ * Stub hash: 2bd78005380fd7f885618c4cb993bb21abe8cea9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_CURLFile___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function strtotime(string $datetime, ?int $baseTimestamp = null): int|false {}
 

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fde1c48b5ad92f574ac049101f421232c6a64252 */
+ * Stub hash: 108136459e578cc699cffcb84d3335a11f8d5c9d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)

--- a/ext/dba/dba.stub.php
+++ b/ext/dba/dba.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 /**
  * @param string $path

--- a/ext/dba/dba_arginfo.h
+++ b/ext/dba/dba_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 847b6feaa62709f1a7a432564e9086e509b86bf7 */
+ * Stub hash: 092664d2d3fa28578e6c8e82160319678c211f0f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_dba_popen, 0, 0, 2)
 	ZEND_ARG_INFO(0, path)

--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 class DOMDocumentType extends DOMNode
 {

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 550deb4b432eb0572b30c220998504047fc556f5 */
+ * Stub hash: 6cc72f07bc62e68dfa1343342b5059e410438e7a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 1)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)

--- a/ext/enchant/enchant.stub.php
+++ b/ext/enchant/enchant.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 /** @strict-properties */
 final class EnchantBroker

--- a/ext/enchant/enchant_arginfo.h
+++ b/ext/enchant/enchant_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ec1ad38320dfec1e567b0f0062dbc032c425945c */
+ * Stub hash: b55b5d39b48d38af9c28bd810c77adcda466f1bd */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_enchant_broker_init, 0, 0, EnchantBroker, MAY_BE_FALSE)
 ZEND_END_ARG_INFO()

--- a/ext/exif/exif.stub.php
+++ b/ext/exif/exif.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function exif_tagname(int $index): string|false {}
 

--- a/ext/exif/exif_arginfo.h
+++ b/ext/exif/exif_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3dde1567a65ab31bd5722ea6d568050420f89439 */
+ * Stub hash: 466379e651a4944e15a0163eabfb29b7d988d747 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_exif_tagname, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)

--- a/ext/ffi/ffi.stub.php
+++ b/ext/ffi/ffi.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 namespace {
 

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f8eb234b7efa2060f54ed300fc6fa697741b0ab6 */
+ * Stub hash: e1d300639ded25533502902180fb76dd5b4d92b2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_cdef, 0, 0, FFI, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, code, IS_STRING, 0, "\"\"")

--- a/ext/fileinfo/fileinfo.stub.php
+++ b/ext/fileinfo/fileinfo.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 class finfo
 {

--- a/ext/fileinfo/fileinfo_arginfo.h
+++ b/ext/fileinfo/fileinfo_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ae5759febdd7ad434c8bf2e23e9da334ff9054dd */
+ * Stub hash: 6b31c20139e3360cb7ff692cc0d5ccfbfd3812bb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_finfo_open, 0, 0, finfo, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "FILEINFO_NONE")

--- a/ext/filter/filter.stub.php
+++ b/ext/filter/filter.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function filter_has_var(int $input_type, string $var_name): bool {}
 

--- a/ext/filter/filter_arginfo.h
+++ b/ext/filter/filter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dc73178b6c82437ae4eec49984613563018d3bde */
+ * Stub hash: 6285ac516fc8972995db91f1c8bf0c171c8fe594 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_filter_has_var, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, input_type, IS_LONG, 0)

--- a/ext/ftp/ftp.stub.php
+++ b/ext/ftp/ftp.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 /** @strict-properties */
 final class FTPConnection

--- a/ext/ftp/ftp_arginfo.h
+++ b/ext/ftp/ftp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d72294d567338c30f627b8247a8cc27148237e41 */
+ * Stub hash: db52e4b33562b93173c41d00f20e313553b173b4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ftp_connect, 0, 1, FTPConnection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)

--- a/ext/gd/gd.stub.php
+++ b/ext/gd/gd.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 /** @strict-properties */
 final class GdImage {}

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 174cec5de1eb55d1fe837648255ee56553cdad6e */
+ * Stub hash: e5688b77ea52f6df10e3335594d9fc1956c10c34 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gd_info, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()

--- a/ext/gettext/gettext.stub.php
+++ b/ext/gettext/gettext.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function textdomain(?string $domain): string {}
 

--- a/ext/gettext/gettext_arginfo.h
+++ b/ext/gettext/gettext_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4a111861e8302c685ba08073dacf9f120307d89a */
+ * Stub hash: bc0c8a6b95afdacad81cc19b5aeb727a58f0cb38 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_textdomain, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, domain, IS_STRING, 1)

--- a/ext/gmp/gmp.stub.php
+++ b/ext/gmp/gmp.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 class GMP
 {

--- a/ext/gmp/gmp_arginfo.h
+++ b/ext/gmp/gmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 97664dc0e71160eacf28f604964df4e9bc97fde5 */
+ * Stub hash: 69215fb94adb4156c974360e5698e842471cb27d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_gmp_init, 0, 1, GMP, 0)
 	ZEND_ARG_TYPE_MASK(0, num, MAY_BE_LONG|MAY_BE_STRING, NULL)

--- a/ext/hash/hash.stub.php
+++ b/ext/hash/hash.stub.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
-
+/** @generate-class-entries */
 function hash(string $algo, string $data, bool $binary = false, array $options = []): string|false {}
 
 function hash_file(string $algo, string $filename, bool $binary = false, array $options = []): string|false {}

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 58f4af6d45c5e69afd2bcee3207397654980f13e */
+ * Stub hash: 3973a03a64b0939de0c3677da55a5104c29b1b99 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_hash, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_STRING, 0)

--- a/ext/iconv/iconv.stub.php
+++ b/ext/iconv/iconv.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function iconv_strlen(string $string, ?string $encoding = null): int|false {}
 

--- a/ext/iconv/iconv_arginfo.h
+++ b/ext/iconv/iconv_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c301856deffe269e4bbf1554d9eba4d5cbbb20e8 */
+ * Stub hash: c7b11a7cd853ede0ca7c5540995d8a7224d00da0 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_iconv_strlen, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)

--- a/ext/imap/php_imap.stub.php
+++ b/ext/imap/php_imap.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 /** @strict-properties */
 final class IMAPConnection {

--- a/ext/imap/php_imap_arginfo.h
+++ b/ext/imap/php_imap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a1e3bdfdd48746db4743e1667d7ba53832160142 */
+ * Stub hash: 4ac7b33357082ac0103b125ec3ce1d389eccf5c7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_open, 0, 3, IMAPConnection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)

--- a/ext/intl/common/common.stub.php
+++ b/ext/intl/common/common.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 class IntlIterator implements Iterator
 {

--- a/ext/intl/common/common_arginfo.h
+++ b/ext/intl/common/common_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 88ed89560edf65b73b27618d3dafa40d54432c2d */
+ * Stub hash: fb470896fab2e63e898a5d49ff8d7f59257be9e3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlIterator_current, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/ext/intl/resourcebundle/resourcebundle.stub.php
+++ b/ext/intl/resourcebundle/resourcebundle.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 class ResourceBundle implements IteratorAggregate, Countable
 {

--- a/ext/intl/resourcebundle/resourcebundle_arginfo.h
+++ b/ext/intl/resourcebundle/resourcebundle_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 474a5f2d63f94aaf68c92839bb343d74179111a7 */
+ * Stub hash: 23040d115ab2c1900fa537313f3a7ff4a57b9715 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ResourceBundle___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)

--- a/ext/intl/transliterator/transliterator.stub.php
+++ b/ext/intl/transliterator/transliterator.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 class Transliterator
 {

--- a/ext/intl/transliterator/transliterator_arginfo.h
+++ b/ext/intl/transliterator/transliterator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 41b9929a370a5f4c0f3ba0dd2c98e766a1941f0d */
+ * Stub hash: 2ea0ba060d9b3cb9a7e8ca4a5932c755bf8df7d0 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Transliterator___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/ext/json/json.stub.php
+++ b/ext/json/json.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function json_encode(mixed $value, int $flags = 0, int $depth = 512): string|false {}
 

--- a/ext/json/json_arginfo.h
+++ b/ext/json/json_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bb9d306951484ce32054dff31dde37638f2841dc */
+ * Stub hash: 6dcef13e46c3dfc2546d3ccc38da07e6c009bbe5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_json_encode, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)

--- a/ext/libxml/libxml.stub.php
+++ b/ext/libxml/libxml.stub.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
-
+/** @generate-class-entries */
 class LibXMLError
 {
     public int $level;

--- a/ext/libxml/libxml_arginfo.h
+++ b/ext/libxml/libxml_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2de903a36e16ddd4ff7ca0ff5be0c2be4697bd7e */
+ * Stub hash: f07180b33955d802c40f3f52f6199605508df87b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_libxml_set_streams_context, 0, 1, IS_VOID, 0)
 	ZEND_ARG_INFO(0, context)

--- a/ext/pdo/pdo_stmt.stub.php
+++ b/ext/pdo/pdo_stmt.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 class PDOStatement implements IteratorAggregate
 {

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 17cecd2e7b3f80314e18bbd44e51b54c9ed061a7 */
+ * Stub hash: d25ba8b84022d6c6208dd45412772d72196c934f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDOStatement_bindColumn, 0, 0, 2)
 	ZEND_ARG_TYPE_MASK(0, column, MAY_BE_STRING|MAY_BE_LONG, NULL)

--- a/ext/simplexml/simplexml.stub.php
+++ b/ext/simplexml/simplexml.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function simplexml_load_file(string $filename, ?string $class_name = SimpleXMLElement::class, int $options = 0, string $namespace_or_prefix = "", bool $is_prefix = false): SimpleXMLElement|false {}
 

--- a/ext/simplexml/simplexml_arginfo.h
+++ b/ext/simplexml/simplexml_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 71a9a5aa5947f254c62889f0a7d1eb5eafc01502 */
+ * Stub hash: 4e4844b9cbac53c3fff061192f7e1ff703ac2f8c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_simplexml_load_file, 0, 1, SimpleXMLElement, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)

--- a/ext/tokenizer/tokenizer.stub.php
+++ b/ext/tokenizer/tokenizer.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function token_get_all(string $code, int $flags = 0): array {}
 

--- a/ext/tokenizer/tokenizer_arginfo.h
+++ b/ext/tokenizer/tokenizer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c84a06c889c19e2a81edbf43e4be53f3491d03be */
+ * Stub hash: 60b4c809624eb4c1ef610e5c5820acfc87f6b07f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_token_get_all, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, code, IS_STRING, 0)

--- a/ext/xml/xml.stub.php
+++ b/ext/xml/xml.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries
- * @generate-class-entries
- */
+/** @generate-class-entries */
 
 function xml_parser_create(?string $encoding = null): XMLParser {}
 

--- a/ext/xml/xml_arginfo.h
+++ b/ext/xml/xml_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fffff15f512d0c99f201d1dd2257fb7bc91cebe2 */
+ * Stub hash: 3c786a3b1d8dc889dd3079bbc7f389d8dc3e11a5 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_xml_parser_create, 0, 0, XMLParser, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_STRING, 1, "null")

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -1,9 +1,6 @@
 <?php
 
-/**
- * @generate-function-entries static
- * @generate-class-entries
- */
+/** @generate-class-entries static */
 
 namespace {
 

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 74e25e800964d6ecc2dfd783e7d738e3776c664c */
+ * Stub hash: cfe2668e6d45a45dafb313cc8b053e2c81ef053a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
The only reason why I opened the PR instead of directly committing it is because the `@generate-function-entries` supports a file-level `declarationPrefix` property. So if both `@generate-function-entries` and `@generate-class-entries` are provided then we can:
- overwrite the `declarationPrefix` with the latter value (I went with this approach for simplicity for now)
- throw an exception to forbid overwriting

Or another possibility is to add support for a `@declaration-prefix` annotation, I think.