### PR TITLE
Fix #78719: http wrapper silently ignores long Location headers

### DIFF
--- a/ext/standard/tests/http/bug78719.phpt
+++ b/ext/standard/tests/http/bug78719.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Bug #78719 (http wrapper silently ignores long Location headers)
+--SKIPIF--
+<?php require 'server.inc'; http_server_skipif('tcp://127.0.0.1:12342'); ?>
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+require 'server.inc';
+
+$url = str_repeat('*', 1024);
+$responses = array(
+	"data://text/plain,HTTP/1.0 302 Ok\r\nLocation: $url\r\n\r\nBody",
+	"data://text/plain,HTTP/1.0 302 Ok\r\nLocation: $url$url\r\n\r\nBody",
+);
+
+$pid = http_server("tcp://127.0.0.1:12342", $responses, $output);
+
+function test() {
+    $context = stream_context_create(['http' => ['follow_location' => 0]]);
+    $f = file_get_contents('http://127.0.0.1:12342/', false, $context);
+    var_dump($f);
+}
+test();
+test();
+
+http_server_kill($pid);
+?>
+--EXPECTF--
+string(4) "Body"
+
+Warning: file_get_contents(http://127.0.0.1:12342/): failed to open stream: Location header too long in %s on line %d
+bool(false)


### PR DESCRIPTION
Currently, the HTTP wrapper reads and processes header lines of at most
1024 bytes (including the trailing line break).  This appears to be
overly restrictive, particularly with regard to Location headers, which
may contain long URIs.  There is no standard regarding the maximum
length of an URI, but assuming about 2000 bytes appears to be prudent.
We therefore increase the size of the buffer to 2048.

That still does not properly cater to header lines which are even
longer.  According to RFC 7230, section 3.2.5, it is okay to discard
long header lines, only if that does not change the "message framing or
response semantics".  So, e.g. an overlong Location header must not be
discarded if `follow_location` is set (the default), and probably
should not even if `follow_location` is not set.  We therefore let the
attempt to open the stream fail in this case.