### PR TITLE
Allow all scalar types in ini_set()

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -318,7 +318,7 @@ function ini_get(string $option): string|false {}
 
 function ini_get_all(?string $extension = null, bool $details = true): array|false {}
 
-function ini_set(string $option, string $value): string|false {}
+function ini_set(string $option, string|int|float|bool|null $value): string|false {}
 
 /** @alias ini_set */
 function ini_alter(string $option, string $value): string|false {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4f4ed195a688735d48aeb3b7cd390d8463a07c26 */
+ * Stub hash: e9f39cbc595f0f2cdd84e58d4857f9fdb03ff7b7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -491,10 +491,13 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ini_set, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, option, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+	ZEND_ARG_TYPE_MASK(0, value, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_BOOL|MAY_BE_NULL, NULL)
 ZEND_END_ARG_INFO()
 
-#define arginfo_ini_alter arginfo_ini_set
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ini_alter, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, option, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ini_restore, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_STRING, 0)

--- a/ext/standard/tests/general_functions/ini_set_types.phpt
+++ b/ext/standard/tests/general_functions/ini_set_types.phpt
@@ -1,0 +1,29 @@
+--TEST--
+ini_set() accepts non-strings under strict_types
+--FILE--
+<?php
+declare(strict_types=1);
+
+ini_set('docref_root', null);
+var_dump(ini_get('docref_root'));
+ini_set('html_errors', true);
+var_dump(ini_get('html_errors'));
+ini_set('html_errors', false);
+var_dump(ini_get('html_errors'));
+ini_set('precision', 6);
+var_dump(ini_get('precision'));
+// Are there any float options?
+
+try {
+    ini_set('foo', []);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+string(0) ""
+string(1) "1"
+string(0) ""
+string(1) "6"
+ini_set(): Argument #2 ($value) must be of type string|int|float|bool|null


### PR DESCRIPTION
This changes `ini_set()` to accept all scalar types (`string|int|float|bool|null`) for the new value. The idea here is that while the INI system ultimately works with strings, its value interpretation is designed to be consistent with PHP's casting rules, e.g. `"1"` and `""` are interpreted as boolean true and false respectively.

I personally believe that writing `ini_set('precision', 10)` makes more sense than `ini_set('precision', '10')`, and find `strict_types` to be unnecessarily pedantic here.