### PR TITLE
Add native_type to pdo_firebird::getColumnMeta() 

### DIFF
--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -218,33 +218,97 @@ static int firebird_stmt_describe(pdo_stmt_t *stmt, int colno) /* {{{ */
 static int firebird_stmt_get_column_meta(pdo_stmt_t *stmt, zend_long colno, zval *return_value)
 {
 	pdo_firebird_stmt *S = (pdo_firebird_stmt *) stmt->driver_data;
-	XSQLVAR *var = &S->out_sqlda.sqlvar[colno];
-
 	enum pdo_param_type param_type;
+	XSQLVAR *var;
+	char* native_type;
+	zval flags;
+
+	if (!stmt->executed) {
+		return FAILURE;
+	}
+	if (colno >= S->out_sqlda.sqld) {
+		/* error invalid column */
+		return FAILURE;
+	}
+
+	array_init(return_value);
+	array_init(&flags);
+
+	var = &S->out_sqlda.sqlvar[colno];
+
+	if (!(var->sqltype & 1)) {
+		add_next_index_string(&flags, "not_null");
+	}
+	add_assoc_zval(return_value, "flags", &flags);
+
 	if (var->sqlscale < 0) {
+		native_type = "decimal";
 		param_type = PDO_PARAM_STR;
 	} else {
 		switch (var->sqltype & ~1) {
+			case SQL_VARYING:
+				native_type = "varchar";
+				param_type = PDO_PARAM_STR;
+				break;
+			case SQL_TEXT:
+				native_type = "char";
+				param_type = PDO_PARAM_STR;
+				break;
 			case SQL_SHORT:
-			case SQL_LONG:
-#if SIZEOF_ZEND_LONG >= 8
-			case SQL_INT64:
-#endif
+				native_type = "smallint";
 				param_type = PDO_PARAM_INT;
+				break;
+			case SQL_LONG:
+				native_type = "integer";
+				param_type = PDO_PARAM_INT;
+				break;
+			case SQL_INT64:
+				native_type = "bigint";
+#if SIZEOF_ZEND_LONG >= 8
+				param_type = PDO_PARAM_INT;
+#else
+				param_type = PDO_PARAM_STR;
+#endif
+				break;
+			case SQL_FLOAT:
+				native_type = "float";
+				param_type = PDO_PARAM_STR;
+				break;
+			case SQL_DOUBLE:
+				native_type = "double";
+				param_type = PDO_PARAM_STR;
 				break;
 #ifdef SQL_BOOLEAN
 			case SQL_BOOLEAN:
+				native_type = "boolean";
 				param_type = PDO_PARAM_BOOL;
 				break;
 #endif
+			case SQL_TYPE_DATE:
+				native_type = "date";
+				param_type = PDO_PARAM_STR;
+				break;
+			case SQL_TYPE_TIME:
+				native_type = "time";
+				param_type = PDO_PARAM_STR;
+				break;
+			case SQL_TIMESTAMP:
+				native_type = "timestamp";
+				param_type = PDO_PARAM_STR;
+				break;
+			case SQL_BLOB:
+				native_type = "blob";
+				param_type = PDO_PARAM_STR;
+				break;
 			default:
+				native_type = "[UNKNOWN]";
 				param_type = PDO_PARAM_STR;
 				break;
 		}
 	}
-
+	add_assoc_string(return_value, "native_type", native_type);
 	add_assoc_long(return_value, "pdo_type", param_type);
-	return 1;
+	return SUCCESS;
 }
 
 /* fetch a blob into a fetch buffer */

--- a/ext/pdo_firebird/tests/getColumnMeta.phpt
+++ b/ext/pdo_firebird/tests/getColumnMeta.phpt
@@ -1,0 +1,261 @@
+--TEST--
+PDO_Firebird: getColumnMeta
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--FILE--
+<?php
+
+require("testdb.inc");
+
+@$dbh->exec('DROP TABLE testcolmeta');
+$dbh->exec('CREATE TABLE testcolmeta (
+    col_notnull         CHAR(30) not null,
+    col_char            CHAR(20),
+    col_varchar         VARCHAR(20),
+    col_smallint        SMALLINT,
+    col_integer         INTEGER,
+    col_bigint          BIGINT,
+    col_decimal_short   DECIMAL(2,1),
+    col_decimal_int     DECIMAL(6,1),
+    col_float           FLOAT,
+    col_date            DATE,
+    col_time            TIME,
+    col_timestamp       TIMESTAMP
+)');
+$dbh->exec("INSERT INTO testcolmeta VALUES (
+    'col_notnull', 'col_char', 'col_varchar',
+    1, 2, 3, 2.1, 6.1, 1234.1234,
+    '2020-01-02', '10:15:30', '2020-03-04 11:16:40')");
+$dbh->commit();
+
+$query = "
+    SELECT
+        col_notnull,
+        col_char,
+        col_varchar,
+        col_smallint,
+        col_integer,
+        col_bigint,
+        col_decimal_short,
+        col_decimal_int,
+        col_float,
+        col_date,
+        col_time,
+        col_timestamp
+    from testcolmeta";
+
+$stmt = $dbh->prepare($query);
+$stmt->execute(array());
+$metas = array();
+for ($i = 0; $i < 13; $i += 1) {
+    $meta = $stmt->getColumnMeta($i);
+    if (is_array($meta)) {
+        ksort($meta);
+    }
+    $metas []= $meta;
+}
+var_dump($metas);
+$dbh->commit();
+
+unset($stmt);
+unset($dbh);
+?>
+--EXPECT--
+array(13) {
+  [0]=>
+  array(6) {
+    ["flags"]=>
+    array(1) {
+      [0]=>
+      string(8) "not_null"
+    }
+    ["len"]=>
+    int(30)
+    ["name"]=>
+    string(11) "COL_NOTNULL"
+    ["native_type"]=>
+    string(4) "char"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(0)
+  }
+  [1]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(20)
+    ["name"]=>
+    string(8) "COL_CHAR"
+    ["native_type"]=>
+    string(4) "char"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(0)
+  }
+  [2]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(20)
+    ["name"]=>
+    string(11) "COL_VARCHAR"
+    ["native_type"]=>
+    string(7) "varchar"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(0)
+  }
+  [3]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(2)
+    ["name"]=>
+    string(12) "COL_SMALLINT"
+    ["native_type"]=>
+    string(8) "smallint"
+    ["pdo_type"]=>
+    int(2)
+    ["precision"]=>
+    int(0)
+  }
+  [4]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(4)
+    ["name"]=>
+    string(11) "COL_INTEGER"
+    ["native_type"]=>
+    string(7) "integer"
+    ["pdo_type"]=>
+    int(2)
+    ["precision"]=>
+    int(0)
+  }
+  [5]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(8)
+    ["name"]=>
+    string(10) "COL_BIGINT"
+    ["native_type"]=>
+    string(6) "bigint"
+    ["pdo_type"]=>
+    int(2)
+    ["precision"]=>
+    int(0)
+  }
+  [6]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(4)
+    ["name"]=>
+    string(17) "COL_DECIMAL_SHORT"
+    ["native_type"]=>
+    string(7) "decimal"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(1)
+  }
+  [7]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(4)
+    ["name"]=>
+    string(15) "COL_DECIMAL_INT"
+    ["native_type"]=>
+    string(7) "decimal"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(1)
+  }
+  [8]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(4)
+    ["name"]=>
+    string(9) "COL_FLOAT"
+    ["native_type"]=>
+    string(5) "float"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(0)
+  }
+  [9]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(4)
+    ["name"]=>
+    string(8) "COL_DATE"
+    ["native_type"]=>
+    string(4) "date"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(0)
+  }
+  [10]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(4)
+    ["name"]=>
+    string(8) "COL_TIME"
+    ["native_type"]=>
+    string(4) "time"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(0)
+  }
+  [11]=>
+  array(6) {
+    ["flags"]=>
+    array(0) {
+    }
+    ["len"]=>
+    int(8)
+    ["name"]=>
+    string(13) "COL_TIMESTAMP"
+    ["native_type"]=>
+    string(9) "timestamp"
+    ["pdo_type"]=>
+    int(3)
+    ["precision"]=>
+    int(0)
+  }
+  [12]=>
+  bool(false)
+}


### PR DESCRIPTION
Work done on pdo_firebird::getColumnMeta():

- Verify column number so a bad column doesn't generate a SIG_SEGV.
- Ensure the statement has been prepared.
- Return native_type.

I was advised no RFC was needed:
https://marc.info/?l=php-internals&m=161305450505181&w=2