### PR TITLE
Don't reset the timeout on deactivate when the timeout was changed

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -395,7 +395,15 @@ static PHP_INI_MH(OnUpdateTimeout)
 	}
 	zend_unset_timeout();
 	ZEND_ATOL(EG(timeout_seconds), ZSTR_VAL(new_value));
-	zend_set_timeout(EG(timeout_seconds), 0);
+	if (stage != PHP_INI_STAGE_DEACTIVATE) {
+		/*
+		 * If we're restoring INI values, we shouldn't reset the timer.
+		 * Otherwise, the timer is active when PHP is idle, such as the
+		 * the CLI web server or CGI. Running a script will re-activate
+		 * the timeout, so it's not needed to do so at script end.
+		 */
+		zend_set_timeout(EG(timeout_seconds), 0);
+	}
 	return SUCCESS;
 }
 /* }}} */


### PR DESCRIPTION
When the time limit for a script is changed, when the script ends, its INI value will be reset. This calls the event handler for the
timeout change, which will unset then reset the timeout. However, this is done even if the script is done executing, and say, the CGI or CLI web server process is idle.

This is probably incorrect, but isn't a problem on most platforms, because PHP uses a timer that only ticks when the process is active (that is, executing code). Since when it's idle, it's blocking on listen/read, it won't tick because nothing executes. However, on platforms where only the real-time timer is supported, (Cygwin/PASE) it ticks regardless of if PHP is even executing. This means that the idle processes are subject to timeouts from the INI reset on script end.

This makes it so the timer is never set if the state is deactivating. Testing with the CLI web server indicates the timer no longer
spuriously activates under PASE.

Fixes PHP bug #80728