### PR TITLE
Add dependency tracking for header files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@
 # Standard object files generated during build process
 *.o
 
+# Dependency files generated during build process
+*.dep
+
 # Cache directories created by Autoconf tools
 autom4te.cache/
 

--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -111,7 +111,7 @@ test: all
 
 clean:
 	find . -name \*.gcno -o -name \*.gcda | xargs rm -f
-	find . -name \*.lo -o -name \*.o | xargs rm -f
+	find . -name \*.lo -o -name \*.o -o -name \*.dep | xargs rm -f
 	find . -name \*.la -o -name \*.a | xargs rm -f
 	find . -name \*.so | xargs rm -f
 	find . -name .libs -a -type d|xargs rm -rf
@@ -155,10 +155,6 @@ prof-use:
 			fi; \
 		fi; \
 	fi;
-
-# As we don't track includes, this is just a heuristic
-%.c: %_arginfo.h
-	@touch $@
 
 .PHONY: all clean install distclean test prof-gen prof-clean prof-use
 .NOEXPORT:

--- a/build/php.m4
+++ b/build/php.m4
@@ -257,8 +257,12 @@ dnl Choose the right compiler/flags/etc. for the source-file.
         *.cpp|*.cc|*.cxx[)] ac_comp="$b_cxx_pre $ac_inc $b_cxx_meta $3 -c $ac_srcdir$ac_src -o $ac_bdir$ac_obj.$b_lo $b_cxx_post" ;;
       esac
 
+dnl Generate Makefiles with dependencies
+      ac_comp="$ac_comp -MMD -MF $ac_bdir$ac_obj.dep -MT $ac_bdir[$]ac_obj.lo"
+
 dnl Create a rule for the object/source combo.
     cat >>Makefile.objects<<EOF
+-include $ac_bdir[$]ac_obj.dep
 $ac_bdir[$]ac_obj.lo: $ac_srcdir[$]ac_src
 	$ac_comp
 EOF


### PR DESCRIPTION
This ensures all .c files which include a header file directly or indirectly are rebuilt whenever the header file is changed.

By adding the flags to `PHP_ADD_SOURCES_X` this change should also work for out of tree extensions, though this was not tested.

I used the `.dep` extension instead of the default extension `.d` since there are already some dtrace files with extension `.d` which would clash with the dependency files.

At least the change to the `.gitignore` should probably be ported to the other branches as well. Otherwise there will be a lot of untracked files after building master and changing to a different branch.