### PR TITLE
Remove generated zend_jit_x86.c on `make clean`

### DIFF
--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -116,6 +116,7 @@ clean:
 	find . -name \*.so | xargs rm -f
 	find . -name .libs -a -type d|xargs rm -rf
 	rm -f libphp.la $(SAPI_CLI_PATH) $(SAPI_CGI_PATH) $(SAPI_LITESPEED_PATH) $(SAPI_FPM_PATH) $(OVERALL_TARGET) modules/* libs/*
+	rm -f ext/opcache/jit/zend_jit_x86.c
 
 distclean: clean
 	rm -f Makefile config.cache config.log config.status Makefile.objects Makefile.fragments libtool main/php_config.h main/internal_functions_cli.c main/internal_functions.c Zend/zend_dtrace_gen.h Zend/zend_dtrace_gen.h.bak Zend/zend_config.h
@@ -124,7 +125,6 @@ distclean: clean
 	rm -f scripts/man1/phpize.1 scripts/php-config scripts/man1/php-config.1 sapi/cli/php.1 sapi/cgi/php-cgi.1 sapi/phpdbg/phpdbg.1 ext/phar/phar.1 ext/phar/phar.phar.1
 	rm -f sapi/fpm/php-fpm.conf sapi/fpm/init.d.php-fpm sapi/fpm/php-fpm.service sapi/fpm/php-fpm.8 sapi/fpm/status.html
 	rm -f ext/phar/phar.phar ext/phar/phar.php
-	rm -f ext/opcache/jit/zend_jit_x86.c
 	if test "$(srcdir)" != "$(builddir)"; then \
 	  rm -f ext/phar/phar/phar.inc; \
 	fi


### PR DESCRIPTION
Not removing this causes build failure when reconfiguring and rebuilding after a `make clean`, e.g. enabling/disabling ZTS.

This makes https://bugs.php.net/bug.php?id=80561 more bearable. Ideally it would be rebuilt automatically on configuration change if necessary, but I have no idea how to implement this.