### PR TITLE
Style fix for zend_vm_gen.php

### DIFF
--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -138,10 +138,10 @@ $vm_ext_decode = array(
 );
 
 $vm_kind_name = array(
-    ZEND_VM_KIND_CALL => "ZEND_VM_KIND_CALL",
-    ZEND_VM_KIND_SWITCH => "ZEND_VM_KIND_SWITCH",
-    ZEND_VM_KIND_GOTO => "ZEND_VM_KIND_GOTO",
-    ZEND_VM_KIND_HYBRID => "ZEND_VM_KIND_HYBRID",
+    ZEND_VM_KIND_CALL      => "ZEND_VM_KIND_CALL",
+    ZEND_VM_KIND_SWITCH    => "ZEND_VM_KIND_SWITCH",
+    ZEND_VM_KIND_GOTO      => "ZEND_VM_KIND_GOTO",
+    ZEND_VM_KIND_HYBRID    => "ZEND_VM_KIND_HYBRID",
 );
 
 $op_types = array(
@@ -150,7 +150,7 @@ $op_types = array(
     "TMP",
     "VAR",
     "UNUSED",
-    "CV"
+    "CV",
 );
 
 $op_types_ex = array(
@@ -590,9 +590,9 @@ function is_hot_helper($name) {
 
     if (isset($helpers[$name]["hot"])) {
         return $helpers[$name]["hot"];
-    } else {
-        return false;
     }
+
+    return false;
 }
 
 // Returns name of specialized helper
@@ -637,7 +637,8 @@ function helper_name($name, $spec, $op1, $op2, $extra_spec) {
             $extra = extra_spec_name(array_intersect_key($extra_spec, $helpers[$name]["spec"]));
         }
     }
-    return $name.($spec?"_SPEC":"").$prefix[$op1].$prefix[$op2].$extra;
+
+    return $name . ($spec ? "_SPEC" : "") . $prefix[$op1] . $prefix[$op2] . $extra;
 }
 
 function opcode_name($name, $spec, $op1, $op2, $extra_spec) {
@@ -688,7 +689,8 @@ function opcode_name($name, $spec, $op1, $op2, $extra_spec) {
             $extra = extra_spec_name(array_intersect_key($extra_spec, $opcode["spec"]));
         }
     }
-    return $name.($spec?"_SPEC":"").$prefix[$op1].$prefix[$op2].$extra;
+
+    return $name . ($spec ? "_SPEC" : "") . $prefix[$op1] . $prefix[$op2] . $extra;
 }
 
 // Formats condition, protecting it by parentheses when needed.
@@ -701,7 +703,7 @@ function format_condition($condition) {
         return $condition;
     }
 
-    return "(".$condition.")";
+    return "(" . $condition . ")";
 }
 
 // Generates code for opcode handler or helper
@@ -811,7 +813,7 @@ function gen_code($f, $spec, $kind, $code, $op1, $op2, $name, $extra_spec=null) 
         $code = "{\n\tfprintf(stderr, \"$name\\n\");\n" . substr($code, 1);
     }
     // Updating code according to selected threading model
-    switch($kind) {
+    switch ($kind) {
         case ZEND_VM_KIND_HYBRID:
             $code = preg_replace_callback(
                 array(
@@ -1071,7 +1073,7 @@ function gen_handler($f, $spec, $kind, $name, $op1, $op2, $use, $code, $lineno, 
     // Generate opcode handler's entry point according to selected threading model
     $additional_func = false;
     $spec_name = $name.($spec?"_SPEC":"").$prefix[$op1].$prefix[$op2].($spec?extra_spec_name($extra_spec):"");
-    switch($kind) {
+    switch ($kind) {
         case ZEND_VM_KIND_HYBRID:
             if (is_inline_hybrid_handler($name, $opcode["hot"], $op1, $op2, $extra_spec)) {
                 $out = fopen('php://memory', 'w+');
@@ -1164,7 +1166,7 @@ function gen_helper($f, $spec, $kind, $name, $op1, $op2, $param, $code, $lineno,
     $spec_name = $name.($spec?"_SPEC":"").$prefix[$op1].$prefix[$op2].($spec?extra_spec_name($extra_spec):"");
 
     // Generate helper's entry point according to selected threading model
-    switch($kind) {
+    switch ($kind) {
         case ZEND_VM_KIND_HYBRID:
             out($f, $spec_name . "_LABEL:\n");
             break;
@@ -1226,7 +1228,7 @@ function gen_labels($f, $spec, $kind, $prolog, &$specs, $switch_labels = array()
       // Emit labels for specialized executor
 
       // For each opcode in opcode number order
-        foreach($opcodes as $num => $dsc) {
+        foreach ($opcodes as $num => $dsc) {
             if (isset($dsc['alias'])) {
                 $specs[$num] = $specs[$opnames[$dsc['alias']]];
                 continue;
@@ -1276,7 +1278,7 @@ function gen_labels($f, $spec, $kind, $prolog, &$specs, $switch_labels = array()
             $foreach_op1 = function($do) use ($dsc, $op_types) {
                 return function($_, $op2) use ($do, $dsc, $op_types) {
                     // For each op1.op_type except ANY
-                    foreach($op_types as $op1) {
+                    foreach ($op_types as $op1) {
                         if ($op1 != "ANY") {
                             if (!isset($dsc["op1"][$op1])) {
                                 if ($op1 == "TMP" || $op1 == "VAR") {
@@ -1302,7 +1304,7 @@ function gen_labels($f, $spec, $kind, $prolog, &$specs, $switch_labels = array()
             $foreach_op2 = function($do) use ($dsc, $op_types) {
                 return function($op1, $_) use ($do, $dsc, $op_types) {
                     // For each op2.op_type except ANY
-                    foreach($op_types as $op2) {
+                    foreach ($op_types as $op2) {
                         if ($op2 != "ANY") {
                             if (!isset($dsc["op2"][$op2])) {
                                 if ($op2 == "TMP" || $op2 == "VAR") {
@@ -1328,7 +1330,7 @@ function gen_labels($f, $spec, $kind, $prolog, &$specs, $switch_labels = array()
             $foreach_op_data = function($do) use ($dsc, $op_types) {
                 return function($op1, $op2, $extra_spec = array()) use ($do, $dsc, $op_types) {
                     // For each op_data.op_type except ANY
-                    foreach($op_types as $op_data) {
+                    foreach ($op_types as $op_data) {
                         if ($op_data != "ANY") {
                             if (!isset($dsc["spec"]["OP_DATA"][$op_data])) {
                                 if ($op_data == "TMP" || $op_data == "VAR") {
@@ -1448,7 +1450,7 @@ function gen_labels($f, $spec, $kind, $prolog, &$specs, $switch_labels = array()
       // Emit labels for unspecialized executor
 
       // For each opcode in opcode number order
-        foreach($opcodes as $num => $dsc) {
+        foreach ($opcodes as $num => $dsc) {
             while ($next != $num) {
               // If some opcode numbers are not used then fill hole with pointers
               // to handler of undefined opcode
@@ -1529,7 +1531,7 @@ function gen_labels($f, $spec, $kind, $prolog, &$specs, $switch_labels = array()
     $l = fopen(__DIR__ . "/zend_vm_handlers.h", "w+") or die("ERROR: Cannot create zend_vm_handlers.h\n");
     out($l, "#define VM_HANDLERS(_) \\\n");
     foreach ($list as $n => $name) {
-        if (!is_null($name)) {
+        if (null !== $name) {
             out($l, "\t_($n, $name) \\\n");
         }
     }
@@ -1644,7 +1646,7 @@ function extra_spec_handler($dsc) {
     if (isset($specs["OP_DATA"])) {
         $op_data_specs = $specs["OP_DATA"];
         $specs["OP_DATA"] = array();
-        foreach($op_types_ex as $op_data) {
+        foreach ($op_types_ex as $op_data) {
             if (isset($dsc["spec"]["OP_DATA"][$op_data])) {
                 $specs["OP_DATA"][] = $op_data;
             }
@@ -1694,10 +1696,10 @@ function gen_executor_code($f, $spec, $kind, $prolog, &$switch_labels = array())
         // Produce specialized executor
         $op1t = $op_types_ex;
         // for each op1.op_type
-        foreach($op1t as $op1) {
+        foreach ($op1t as $op1) {
             $op2t = $op_types_ex;
             // for each op2.op_type
-            foreach($op2t as $op2) {
+            foreach ($op2t as $op2) {
                 // for each handlers in helpers in original order
                 foreach ($list as $lineno => $dsc) {
                     if (isset($dsc["handler"])) {
@@ -2255,7 +2257,7 @@ function parse_operand_spec($def, $lineno, $str, &$flags) {
 
     $flags = 0;
     $a = explode("|",$str);
-    foreach($a as $val) {
+    foreach ($a as $val) {
         if (isset($vm_op_decode[$val])) {
             $flags |= $vm_op_decode[$val];
         } else {
@@ -2276,7 +2278,7 @@ function parse_ext_spec($def, $lineno, $str) {
 
     $flags = 0;
     $a = explode("|",$str);
-    foreach($a as $val) {
+    foreach ($a as $val) {
         if (isset($vm_ext_decode[$val])) {
             $flags |= $vm_ext_decode[$val];
         } else {
@@ -2291,7 +2293,7 @@ function parse_spec_rules($def, $lineno, $str) {
 
     $ret = array();
     $a = explode(",", $str);
-    foreach($a as $rule) {
+    foreach ($a as $rule) {
         $n = strpos($rule, "=");
         if ($n !== false) {
             $id = trim(substr($rule, 0, $n));
@@ -2446,8 +2448,8 @@ function gen_vm($def, $skel) {
                 $opcodes[$orig_code]['type_spec'][$code] = $condition;
             }
             $op = $m[4];
-            $op1  = parse_operand_spec($def, $lineno, $m[5], $flags1);
-            $op2  = parse_operand_spec($def, $lineno, $m[6], $flags2);
+            $op1 = parse_operand_spec($def, $lineno, $m[5], $flags1);
+            $op2 = parse_operand_spec($def, $lineno, $m[6], $flags2);
             $flags = $flags1 | ($flags2 << 8);
             if (!empty($m[8])) {
                 $flags |= parse_ext_spec($def, $lineno, $m[8]);
@@ -2603,7 +2605,7 @@ function gen_vm($def, $skel) {
     fputs($f, "# endif\n");
     fputs($f, "#endif\n");
     fputs($f, "\n");
-    foreach($vm_op_flags as $name => $val) {
+    foreach ($vm_op_flags as $name => $val) {
         fprintf($f, "#define %-24s 0x%08x\n", $name, $val);
     }
     fputs($f, "#define ZEND_VM_OP1_FLAGS(flags) (flags & 0xff)\n");
@@ -2847,7 +2849,7 @@ function gen_vm($def, $skel) {
         out($f, "\tuint32_t spec = zend_spec_handlers[opcode];\n");
         if (isset($used_extra_spec["TYPE"])) {
             out($f, "\tswitch (opcode) {\n");
-            foreach($opcodes as $code => $dsc) {
+            foreach ($opcodes as $code => $dsc) {
                 if (isset($dsc['type_spec'])) {
                     $orig_op = $dsc['op'];
                     out($f, "\t\tcase $orig_op:\n");
@@ -2857,7 +2859,7 @@ function gen_vm($def, $skel) {
                         out($f, "\t\t\t}\n");
                     }
                     $first = true;
-                    foreach($dsc['type_spec'] as $code => $condition) {
+                    foreach ($dsc['type_spec'] as $code => $condition) {
                         $condition = format_condition($condition);
                         if ($first) {
                             out($f, "\t\t\tif $condition {\n");
@@ -2885,7 +2887,7 @@ function gen_vm($def, $skel) {
                 }
             }
             $has_commutative = false;
-            foreach($opcodes as $code => $dsc) {
+            foreach ($opcodes as $code => $dsc) {
                 if (!isset($dsc['is_type_spec']) &&
                     !isset($dsc['type_spec']) &&
                     isset($dsc["spec"]["COMMUTATIVE"])) {


### PR DESCRIPTION
- fixed array style for $vm_kind_name and $op_types
- deleted unnecessary else statement for is_hot_helper function
- fixed concatenation style
- fixed style of using whitespace between "(" and switch/foreach
- replaced !is_null with "!=="

It is done for uniformity and increased readability