### PR TITLE
Fix #80771: phpinfo(INFO_CREDITS) displays nothing in CLI

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -1000,7 +1000,7 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 	}
 
 
-	if ((flag & PHP_INFO_CREDITS) && !sapi_module.phpinfo_as_text) {
+	if ((flag & PHP_INFO_CREDITS)) {
 		php_info_print_hr();
 		php_print_credits(PHP_CREDITS_ALL & ~PHP_CREDITS_FULLPAGE);
 	}

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -1000,7 +1000,7 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 	}
 
 
-	if ((flag & PHP_INFO_CREDITS)) {
+	if (flag & PHP_INFO_CREDITS) {
 		php_info_print_hr();
 		php_print_credits(PHP_CREDITS_ALL & ~PHP_CREDITS_FULLPAGE);
 	}

--- a/ext/standard/tests/general_functions/bug80771.phpt
+++ b/ext/standard/tests/general_functions/bug80771.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #80771 (phpinfo(INFO_CREDITS) displays nothing in CLI)
+--FILE--
+<?php
+ob_start();
+phpinfo(INFO_CREDITS);
+$info = ob_get_clean();
+
+ob_start();
+phpcredits();
+$credits = ob_get_clean();
+
+var_dump(strpos($info, $credits) !== false);
+?>
+--EXPECT--
+bool(true)

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -642,7 +642,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 					goto err;
 				}
 				request_started = 1;
-				php_print_info(0xFFFFFFFF);
+				php_print_info(PHP_INFO_ALL & ~PHP_INFO_CREDITS);
 				php_output_end_all();
 				exit_status = (c == '?' && argc > 1 && !strchr(argv[1],  c));
 				goto out;


### PR DESCRIPTION
There is no good reason not to show the credits in text based SAPIs.