### PR TITLE
run-tests: fixed exit code not being set on BORKED tests when no test…

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1015,7 +1015,7 @@ save_or_mail_results();
 junit_save_xml();
 if (getenv('REPORT_EXIT_STATUS') !== '0' &&
 	getenv('REPORT_EXIT_STATUS') !== 'no' &&
-	($sum_results['FAILED'] || $sum_results['LEAKED'])) {
+	($sum_results['FAILED'] || $sum_results['BORKED'] || $sum_results['LEAKED'])) {
 	exit(1);
 }
 exit(0);


### PR DESCRIPTION
… paths are specified

this shows up when 'make test' is used on a PECL extension without specifying tests to run (or in php-src too, I guess...)
It produced a bug which I found unexpectedly difficult to reproduce; it turns out there are actually 2 places where run-tests exits, and the other exit point handles BORKED correctly: https://github.com/php/php-src/blob/06c9633b43a032236b449739a72f4d55cd648fb4/run-tests.php#L879

Side note: I discovered this due to an XLEAK section in one of my tests which wasn't recognized by 7.3's run-tests.php. It would be nice if it was supported, even if it's ignored.