### PR TITLE
Don't use separate static variables in inherited methods

### DIFF
--- a/Zend/tests/anon/015.phpt
+++ b/Zend/tests/anon/015.phpt
@@ -19,12 +19,15 @@ var_dump($d->foo(24));
 var_dump($c->foo());
 ?>
 --EXPECT--
-NULL
+array(1) {
+  [0]=>
+  int(42)
+}
 array(1) {
   [0]=>
   int(24)
 }
 array(1) {
   [0]=>
-  int(42)
+  int(24)
 }

--- a/Zend/tests/anon/016.phpt
+++ b/Zend/tests/anon/016.phpt
@@ -19,13 +19,16 @@ var_dump($d->foo(24));
 var_dump($c->foo());
 ?>
 --EXPECT--
-NULL
+array(1) {
+  [0]=>
+  object(stdClass)#2 (0) {
+  }
+}
 array(1) {
   [0]=>
   int(24)
 }
 array(1) {
   [0]=>
-  object(stdClass)#2 (0) {
-  }
+  int(24)
 }

--- a/Zend/tests/method_static_var.phpt
+++ b/Zend/tests/method_static_var.phpt
@@ -20,5 +20,5 @@ Bar::test();
 --EXPECT--
 int(1)
 int(2)
-int(1)
-int(2)
+int(3)
+int(4)

--- a/Zend/tests/static_variables_traits.phpt
+++ b/Zend/tests/static_variables_traits.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Behavior of static variables in trait methods
+--FILE--
+<?php
+
+trait T {
+    public static function counter() {
+        static $i = 0;
+        var_dump(++$i);
+    }
+}
+
+class C1 {
+    use T {
+        T::counter as counter1;
+        T::counter as counter2;
+    }
+}
+
+class C2 {
+    use T;
+}
+
+C1::counter();
+C1::counter1();
+C1::counter2();
+C2::counter();
+
+C1::counter();
+C1::counter1();
+C1::counter2();
+C2::counter();
+
+?>
+--EXPECT--
+int(1)
+int(1)
+int(1)
+int(1)
+int(2)
+int(2)
+int(2)
+int(2)

--- a/ext/opcache/tests/preload_method_static_vars.phpt
+++ b/ext/opcache/tests/preload_method_static_vars.phpt
@@ -19,8 +19,8 @@ Bar::test();
 --EXPECT--
 int(1)
 int(2)
-int(1)
-int(2)
+int(3)
+int(4)
 
 int(1)
-int(1)
+int(2)

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -763,7 +763,6 @@ static void zend_persist_class_method(zval *zv, zend_class_entry *ce)
 	}
 
 	if ((op_array->fn_flags & ZEND_ACC_IMMUTABLE)
-	 && !op_array->static_variables
 	 && !ZCG(current_persistent_script)->corrupted
 	 && zend_accel_in_shm(op_array)) {
 		zend_shared_alloc_register_xlat_entry(op_array, op_array);


### PR DESCRIPTION
Implementation for RFC: https://wiki.php.net/rfc/static_variable_inheritance