### PR TITLE
run-tests: capture Windows-specific error exit codes

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1188,7 +1188,7 @@ function system_with_timeout($commandline, $env = null, $stdin = null, $captureS
 	}
 	if ($stat["exitcode"] > 128 && $stat["exitcode"] < 160) {
 		$data .= "\nTermsig=" . ($stat["exitcode"] - 128) . "\n";
-	} else if (defined('PHP_WINDOWS_VERSION_MAJOR') && (($stat["exitcode"] >> 30) & 0b11) === 0x3) {
+	} else if (defined('PHP_WINDOWS_VERSION_MAJOR') && (($stat["exitcode"] >> 28) & 0b1111) === 0b1100) {
 		// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/87fba13e-bf06-450e-83b1-9241dc81e781
 		$data .= "\nTermsig=" . $stat["exitcode"] . "\n";
 	}

--- a/run-tests.php
+++ b/run-tests.php
@@ -1188,6 +1188,9 @@ function system_with_timeout($commandline, $env = null, $stdin = null, $captureS
 	}
 	if ($stat["exitcode"] > 128 && $stat["exitcode"] < 160) {
 		$data .= "\nTermsig=" . ($stat["exitcode"] - 128) . "\n";
+	} else if (defined('PHP_WINDOWS_VERSION_MAJOR') && (($stat["exitcode"] >> 30) & 0b11) === 0x3) {
+		// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/87fba13e-bf06-450e-83b1-9241dc81e781
+		$data .= "\nTermsig=" . $stat["exitcode"] . "\n";
 	}
 
 	proc_close($proc);


### PR DESCRIPTION
the lack of such a check leads to false-passes of tests on Windows, because if a segfault occurs, there's no indication from run-tests. This means that a test which crashed after emitting all of its expected output (or not producing any output) would still be seen as passed, even though it actually crashed.

I discovered this problem because of bad tests in an extension I maintain which had empty --EXPECT-- sections, which led to segfaulting tests passing.

This PR makes run-tests capture ERROR severity statuses, as described here: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/87fba13e-bf06-450e-83b1-9241dc81e781