### PR TITLE
Update mysqli tests to work with newer MySQL server

### DIFF
--- a/ext/mysqli/tests/mysqli_pam_sha256.phpt
+++ b/ext/mysqli/tests/mysqli_pam_sha256.phpt
@@ -45,9 +45,8 @@ if (strlen($row['Value']) < 100) {
     die(sprintf("skip Server misconfiguration? RSA pub key is suspicious, [%d] %s\n", $link->errno, $link->error));
 }
 
-if (!$link->query("SET @@session.old_passwords=2")) {
-    die(sprintf("skip Cannot set @@session.old_passwords=2 [%d] %s", $link->errno, $link->error));
-}
+// Ignore errors because this variable exists only in MySQL 5.6 and 5.7
+$link->query("SET @@session.old_passwords=2");
 
 $link->query('DROP USER shatest');
 $link->query("DROP USER shatest@localhost");
@@ -58,8 +57,8 @@ if (!$link->query('CREATE USER shatest@"%" IDENTIFIED WITH sha256_password') ||
     die(sprintf("skip CREATE USER failed [%d] %s", $link->errno, $link->error));
 }
 
-if (!$link->query('SET PASSWORD FOR shatest@"%" = PASSWORD("shatest")') ||
-    !$link->query('SET PASSWORD FOR shatest@"localhost" = PASSWORD("shatest")')) {
+if (!$link->query('SET PASSWORD FOR shatest@"%" = "shatest"') ||
+    !$link->query('SET PASSWORD FOR shatest@"localhost" = "shatest"')) {
     die(sprintf("skip SET PASSWORD failed [%d] %s", $link->errno, $link->error));
 }
 

--- a/ext/mysqli/tests/mysqli_pam_sha256_public_key_ini.phpt
+++ b/ext/mysqli/tests/mysqli_pam_sha256_public_key_ini.phpt
@@ -57,10 +57,8 @@ if (strlen($key) != fwrite($fp, $key)) {
     die(sprintf("skip Failed to create pub key file"));
 }
 
-
-if (!$link->query("SET @@session.old_passwords=2")) {
-    die(sprintf("skip Cannot set @@session.old_passwords=2 [%d] %s", $link->errno, $link->error));
-}
+// Ignore errors because this variable exists only in MySQL 5.6 and 5.7
+$link->query("SET @@session.old_passwords=2");
 
 $link->query('DROP USER shatest');
 $link->query("DROP USER shatest@localhost");
@@ -71,8 +69,8 @@ if (!$link->query('CREATE USER shatest@"%" IDENTIFIED WITH sha256_password') ||
     die(sprintf("skip CREATE USER failed [%d] %s", $link->errno, $link->error));
 }
 
-if (!$link->query('SET PASSWORD FOR shatest@"%" = PASSWORD("shatest")') ||
-    !$link->query('SET PASSWORD FOR shatest@"localhost" = PASSWORD("shatest")')) {
+if (!$link->query('SET PASSWORD FOR shatest@"%" = "shatest"') ||
+    !$link->query('SET PASSWORD FOR shatest@"localhost" = "shatest"')) {
     die(sprintf("skip SET PASSWORD failed [%d] %s", $link->errno, $link->error));
 }
 

--- a/ext/mysqli/tests/mysqli_pam_sha256_public_key_option.phpt
+++ b/ext/mysqli/tests/mysqli_pam_sha256_public_key_option.phpt
@@ -54,10 +54,8 @@ if (strlen($row['Value']) != fwrite($fp, $row['Value'])) {
     die(sprintf("skip Failed to create pub key file"));
 }
 
-
-if (!$link->query("SET @@session.old_passwords=2")) {
-    die(sprintf("skip Cannot set @@session.old_passwords=2 [%d] %s", $link->errno, $link->error));
-}
+// Ignore errors because this variable exists only in MySQL 5.6 and 5.7
+$link->query("SET @@session.old_passwords=2");
 
 $link->query('DROP USER shatest');
 $link->query("DROP USER shatest@localhost");
@@ -68,8 +66,8 @@ if (!$link->query('CREATE USER shatest@"%" IDENTIFIED WITH sha256_password') ||
     die(sprintf("skip CREATE USER failed [%d] %s", $link->errno, $link->error));
 }
 
-if (!$link->query('SET PASSWORD FOR shatest@"%" = PASSWORD("shatest")') ||
-    !$link->query('SET PASSWORD FOR shatest@"localhost" = PASSWORD("shatest")')) {
+if (!$link->query('SET PASSWORD FOR shatest@"%" = "shatest"') ||
+    !$link->query('SET PASSWORD FOR shatest@"localhost" = "shatest"')) {
     die(sprintf("skip SET PASSWORD failed [%d] %s", $link->errno, $link->error));
 }
 

--- a/ext/mysqli/tests/mysqli_pam_sha256_public_key_option_invalid.phpt
+++ b/ext/mysqli/tests/mysqli_pam_sha256_public_key_option_invalid.phpt
@@ -54,10 +54,8 @@ if (strlen($row['Value']) != fwrite($fp, $row['Value'])) {
     die(sprintf("skip Failed to create pub key file"));
 }
 
-
-if (!$link->query("SET @@session.old_passwords=2")) {
-    die(sprintf("skip Cannot set @@session.old_passwords=2 [%d] %s", $link->errno, $link->error));
-}
+// Ignore errors because this variable exists only in MySQL 5.6 and 5.7
+$link->query("SET @@session.old_passwords=2");
 
 $link->query('DROP USER shatest');
 $link->query("DROP USER shatest@localhost");
@@ -68,13 +66,12 @@ if (!$link->query('CREATE USER shatest@"%" IDENTIFIED WITH sha256_password') ||
     die(sprintf("skip CREATE USER failed [%d] %s", $link->errno, $link->error));
 }
 
-if (!$link->query('SET PASSWORD FOR shatest@"%" = PASSWORD("shatest")') ||
-    !$link->query('SET PASSWORD FOR shatest@"localhost" = PASSWORD("shatest")')) {
+if (!$link->query('SET PASSWORD FOR shatest@"%" = "shatest"') ||
+    !$link->query('SET PASSWORD FOR shatest@"localhost" = "shatest"')) {
     die(sprintf("skip SET PASSWORD failed [%d] %s", $link->errno, $link->error));
 }
 
-if (!$link->query("DROP TABLE IF EXISTS test") ||
-    !$link->query("CREATE TABLE test (id INT)") ||
+if (!$link->query("CREATE TABLE test (id INT)") ||
     !$link->query("INSERT INTO test(id) VALUES (1), (2), (3)"))
     die(sprintf("SKIP [%d] %s\n", $link->errno, $link->error));
 


### PR DESCRIPTION
* @@session.old_passwords is present only in 5.6 and 5.7. Newer versions
  already behave as if they have old_passwords=2.
* SET PASSWORD FOR ... = PASSWORD(...) syntax was removed in 8.0.

For all affected tests, versions that don't support newer SQL are
already explicitly excluded with version checks.