### PR TITLE
Make PHP_BUILD_SYSTEM not generate in phpize mode

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -128,18 +128,17 @@ build_dirs = new Array();
 extension_include_code = "";
 extension_module_ptrs = "";
 
-(function () {
-	var wmiservice = GetObject("winmgmts:{impersonationLevel=impersonate}!\\\\.\\root\\cimv2");
-	var oss = wmiservice.ExecQuery("Select * from Win32_OperatingSystem");
-	var os = oss.ItemIndex(0);
-	AC_DEFINE("PHP_BUILD_SYSTEM", os.Caption + " [" + os.Version + "]", "Windows build system version");
-	var build_provider = WshShell.Environment("Process").Item("PHP_BUILD_PROVIDER");
-	if (build_provider) {
-		AC_DEFINE("PHP_BUILD_PROVIDER", build_provider);
-	}
-}());
-
 if (!MODE_PHPIZE) {
+	(function () {
+		var wmiservice = GetObject("winmgmts:{impersonationLevel=impersonate}!\\\\.\\root\\cimv2");
+		var oss = wmiservice.ExecQuery("Select * from Win32_OperatingSystem");
+		var os = oss.ItemIndex(0);
+		AC_DEFINE("PHP_BUILD_SYSTEM", os.Caption + " [" + os.Version + "]", "Windows build system version");
+		var build_provider = WshShell.Environment("Process").Item("PHP_BUILD_PROVIDER");
+		if (build_provider) {
+			AC_DEFINE("PHP_BUILD_PROVIDER", build_provider);
+		}
+	}());
 	get_version_numbers();
 }
 


### PR DESCRIPTION
PHP_BUILD_SYSTEM now will generate unconditionally into config.pickle.h
even in phpize mode, this will cause MSVC warning C4005 when importing php_compact.h.
This commit make it generate only not in phpize mode.

for example: when building phpredis with vs 2019:
```
$ nmake

Microsoft (R) 程序维护实用工具 14.28.29337.0 版
版权所有 (C) Microsoft Corporation。  保留所有权利。

        "cl.exe" /D PHP_SESSION=1 /FI main/config.pickle.h /D COMPILE_DL_REDIS /D REDIS_EXPORTS=1 /nologo /I C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include /I C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main /I C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/Zend /I C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/TSRM /I C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/ext /D _WINDOWS /D WINDOWS=1 /D ZEND_WIN32=1 /D PHP_WIN32=1 /D WIN32 /D _MBCS /D _USE_MATH_DEFINES /FD /wd4996 /Qspectre /guard:cf /Zc:inline /Zc:__cplusplus /d2FuncCache1 /Zc:wchar_t /MP /LD /MD /Ox /D NDebug /D NDEBUG /D ZEND_WIN32_FORCE_INLINE /GF /D ZEND_DEBUG=0 /I "C:\Users\Administrator\Desktop\work\phpredis\no\include" /FoC:\Users\Administrator\Desktop\work\phpredis\x64\Release\\ /FpC:\Users\Administrator\Desktop\work\phpredis\x64\Release\\ /FRC:\Users\Administrator\Desktop\work\phpredis\x64\Release\\ /FdC:\Users\Administrator\Desktop\work\phpredis\x64\Release\\ /c C:\Users\Administrator\Desktop\work\phpredis\cluster_library.c C:\Users\Administrator\Desktop\work\phpredis\library.c C:\Users\Administrator\Desktop\work\phpredis\redis.c C:\Users\Administrator\Desktop\work\phpredis\redis_array.c C:\Users\Administrator\Desktop\work\phpredis\redis_array_impl.c C:\Users\Administrator\Desktop\work\phpredis\redis_cluster.c C:\Users\Administrator\Desktop\work\phpredis\redis_commands.c C:\Users\Administrator\Desktop\work\phpredis\redis_sentinel.c C:\Users\Administrator\Desktop\work\phpredis\redis_session.c C:\Users\Administrator\Desktop\work\phpredis\sentinel_library.c
cluster_library.c
library.c
redis.c
redis_array.c
redis_array_impl.c
redis_cluster.c
redis_commands.c
redis_sentinel.c
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main\../main/config.w32.h(144): warning C4005: “PHP_BUILD_SYSTEM”: 宏重定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\cluster_library.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include\main/config.pickle.h(1): note: 参见“PHP_BUILD_SYSTEM”的前一个定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\cluster_library.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main\../main/config.w32.h(144): warning C4005: “PHP_BUILD_SYSTEM”: 宏重定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include\main/config.pickle.h(1): note: 参见“PHP_BUILD_SYSTEM”的前一个定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main\../main/config.w32.h(144): warning C4005: “PHP_BUILD_SYSTEM”: 宏重定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\library.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include\main/config.pickle.h(1): note: 参见“PHP_BUILD_SYSTEM”的前一个定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\library.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main\../main/config.w32.h(144): warning C4005: “PHP_BUILD_SYSTEM”: 宏重定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_array.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include\main/config.pickle.h(1): note: 参见“PHP_BUILD_SYSTEM”的前一个定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_array.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main\../main/config.w32.h(144): warning C4005: “PHP_BUILD_SYSTEM”: 宏重定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_cluster.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include\main/config.pickle.h(1): note: 参见“PHP_BUILD_SYSTEM”的前一个定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_cluster.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main\../main/config.w32.h(144): warning C4005: “PHP_BUILD_SYSTEM”: 宏重定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_commands.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include\main/config.pickle.h(1): note: 参见“PHP_BUILD_SYSTEM”的前一个定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_commands.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main\../main/config.w32.h(144): warning C4005: “PHP_BUILD_SYSTEM”: 宏重定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_sentinel.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include\main/config.pickle.h(1): note: 参见“PHP_BUILD_SYSTEM”的前一个定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_sentinel.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include/main\../main/config.w32.h(144): warning C4005: “PHP_BUILD_SYSTEM”: 宏重定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_array_impl.c)
C:\Users\Administrator\Desktop\work\php-8.0.2-devel-vs16-x64-orig/include\main/config.pickle.h(1): note: 参见“PHP_BUILD_SYSTEM”的前一个定义 (编译源文件 C:\Users\Administrator\Desktop\work\phpredis\redis_array_impl.c)
C:\Users\Administrator\Desktop\work\phpredis\redis_array.c(271): warning C4133: “函数”: 从“long *”到“zend_long *” 的类型不兼容
C:\Users\Administrator\Desktop\work\phpredis\redis_array_impl.c(239): warning C4133: “函数”: 从“long *”到“zend_long *”的类型不兼容
C:\Users\Administrator\Desktop\work\phpredis\redis_array_impl.c(867): warning C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失
redis_session.c
```

config.pickle.h will be included via /FI, and config.w32.h will be included-in in php_compat.h