### PR TITLE
Micro-optimize serializing class names

### DIFF
--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -733,9 +733,10 @@ static inline bool php_var_serialize_class_name(smart_str *buf, zval *struc) /* 
 	PHP_CLASS_ATTRIBUTES;
 
 	PHP_SET_CLASS_ATTRIBUTES(struc);
-	s = zend_print_long_to_buf(b + sizeof(b) - 1, ZSTR_LEN(class_name));
+	size_t class_name_len = ZSTR_LEN(class_name);
+	s = zend_print_long_to_buf(b + sizeof(b) - 1, class_name_len);
 	l = b + sizeof(b) - 1 - s;
-	new_len = smart_str_alloc(buf, 2 + l + 2 + ZSTR_LEN(class_name) + 2, 0);
+	new_len = smart_str_alloc(buf, 2 + l + 2 + class_name_len + 2, 0);
 	res = ZSTR_VAL(buf->s) + ZSTR_LEN(buf->s);
 	ZSTR_LEN(buf->s) = new_len;
 	memcpy(res, "O:", 2);
@@ -744,8 +745,8 @@ static inline bool php_var_serialize_class_name(smart_str *buf, zval *struc) /* 
 	res += l;
 	memcpy(res, ":\"", 2);
 	res += 2;
-	memcpy(res, ZSTR_VAL(class_name), ZSTR_LEN(class_name));
-	res += ZSTR_LEN(class_name);
+	memcpy(res, ZSTR_VAL(class_name), class_name_len);
+	res += class_name_len;
 	memcpy(res, "\":", 2);
 	PHP_CLEANUP_CLASS_ATTRIBUTES();
 	return incomplete_class;


### PR DESCRIPTION
Because of the memcpy, compilers can't infer that ZSTR_LEN (i.e. class_name->len)
did not change, so they copy it out of memory into a register for the last two
accesses. (i.e.  `mov    rdx,QWORD PTR [r15+0x10]` is repeated)
php_var_serialize_string already does something similar.

(register allocation, instructions, etc also changed elsewhere because of the code change)

```asm
# Old
/path/to/php-src/ext/standard/var.c:744
     b2d:	4c 8b 0c 24          	mov    r9,QWORD PTR [rsp]
memcpy():
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
     b31:	41 bb 3a 22 00 00    	mov    r11d,0x223a
     b37:	4c 89 f6             	mov    rsi,r14
     b3a:	48 89 c1             	mov    rcx,rax
php_var_serialize_class_name():
/path/to/php-src/ext/standard/var.c:744
     b3d:	4c 01 c9             	add    rcx,r9
memcpy():
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
     b40:	66 44 89 19          	mov    WORD PTR [rcx],r11w
php_var_serialize_class_name():
/path/to/php-src/ext/standard/var.c:746
     b44:	48 83 c1 02          	add    rcx,0x2
memcpy():
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
     b48:	49 8b 57 10          	mov    rdx,QWORD PTR [r15+0x10]
     b4c:	48 89 cf             	mov    rdi,rcx
     b4f:	e8 00 00 00 00       	call   b54 <php_var_serialize_intern.part.0+0x644>
php_var_serialize_class_name():
/path/to/php-src/ext/standard/var.c:748
     b54:	49 8b 4f 10          	mov    rcx,QWORD PTR [r15+0x10]
     b58:	48 01 c1             	add    rcx,rax
memcpy():
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
     b5b:	66 44 89 29          	mov    WORD PTR [rcx],r13w


#new

php_var_serialize_class_name():
/path/to/php-src/ext/standard/var.c:744
     b2e:	48 8b 14 24          	mov    rdx,QWORD PTR [rsp]
memcpy():
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
     b32:	41 ba 3a 22 00 00    	mov    r10d,0x223a
     b38:	4c 8b 4c 24 08       	mov    r9,QWORD PTR [rsp+0x8]
     b3d:	48 89 c1             	mov    rcx,rax
php_var_serialize_class_name():
/path/to/php-src/ext/standard/var.c:744
     b40:	48 01 d1             	add    rcx,rdx
memcpy():
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
     b43:	4c 89 ce             	mov    rsi,r9
     b46:	4c 89 f2             	mov    rdx,r14
     b49:	66 44 89 11          	mov    WORD PTR [rcx],r10w
php_var_serialize_class_name():
/path/to/php-src/ext/standard/var.c:746
     b4d:	48 83 c1 02          	add    rcx,0x2
memcpy():
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
     b51:	48 89 cf             	mov    rdi,rcx
     b54:	e8 00 00 00 00       	call   b59 <php_var_serialize_intern.part.0+0x649>
     b59:	41 bb 22 3a 00 00    	mov    r11d,0x3a22
     b5f:	66 46 89 1c 30       	mov    WORD PTR [rax+r14*1],r11w
```