### PR TITLE
Fixed bug #80811

### DIFF
--- a/Zend/tests/bug80811.phpt
+++ b/Zend/tests/bug80811.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #80811: Function exec without $output but with $restult_code parameter crashes
+--FILE--
+<?php
+
+echo 'Executing with all params:' . PHP_EOL;
+exec('echo Something', output: $output, result_code: $resultCode);
+var_dump($resultCode);
+
+echo 'Executing without output param:' . PHP_EOL;
+exec('echo Something', result_code: $resultCode);
+var_dump($resultCode);
+
+?>
+--EXPECT--
+Executing with all params:
+int(0)
+Executing without output param:
+int(0)

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4579,6 +4579,9 @@ ZEND_API zend_result ZEND_FASTCALL zend_handle_undef_args(zend_execute_data *cal
 			}
 
 			ZVAL_COPY_VALUE(arg, &default_value);
+			if (ZEND_ARG_SEND_MODE(arg_info) & ZEND_SEND_BY_REF) {
+				ZVAL_NEW_REF(arg, arg);
+			}
 		}
 	}
 


### PR DESCRIPTION
When filling in defaults for skipped params, make sure that
reference parameters get the expected reference wrapper.

(Testing Windows CI)