### PR TITLE
Add const to zend_extension_version_info.build_id

### DIFF
--- a/Zend/zend_extensions.h
+++ b/Zend/zend_extensions.h
@@ -48,7 +48,7 @@ You can use the following macro to check the extension API version for compatibi
 
 typedef struct _zend_extension_version_info {
 	int zend_extension_api_no;
-	char *build_id;
+	const char *build_id;
 } zend_extension_version_info;
 
 #define ZEND_EXTENSION_BUILD_ID "API" ZEND_TOSTR(ZEND_EXTENSION_API_NO) ZEND_BUILD_TS ZEND_BUILD_DEBUG ZEND_BUILD_SYSTEM ZEND_BUILD_EXTRA


### PR DESCRIPTION
This is a follow-up to:
https://github.com/php/php-src/commit/3c6ab4b3ea5854fd44a2945bb65bf027a6c94890

Made change in GitHub UI -- waiting on test results (did it spawn new warnings anywhere?)