### PR TITLE
Print error code if CreateMutex() fails

### DIFF
--- a/ext/opcache/shared_alloc_win32.c
+++ b/ext/opcache/shared_alloc_win32.c
@@ -80,7 +80,7 @@ void zend_shared_alloc_create_lock(void)
 {
 	memory_mutex = CreateMutex(NULL, FALSE, create_name_with_username(ACCEL_MUTEX_NAME));
 	if (!memory_mutex) {
-		zend_accel_error(ACCEL_LOG_FATAL, "Cannot create mutex");
+		zend_accel_error(ACCEL_LOG_FATAL, "Cannot create mutex (error %u)", GetLastError());
 		return;
 	}
 	ReleaseMutex(memory_mutex);


### PR DESCRIPTION
This issue came up recently in a bug report[1]; without the error code,
users can barely guess why the function failed.

[1] <https://bugs.php.net/80812>