### PR TITLE
Fix #51903: simplexml_load_file() doesn't use HTTP headers

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -417,7 +417,7 @@ php_libxml_input_buffer_create_filename(const char *URI, xmlCharEncoding enc)
 			zval *header;
 
 			ZEND_HASH_FOREACH_VAL_IND(Z_ARRVAL(s->wrapperdata), header) {
-				char *buf = "Content-Type:";
+				char buf[] = "Content-Type:";
 				if (Z_TYPE_P(header) == IS_STRING &&
 						!zend_binary_strncasecmp(Z_STRVAL_P(header), Z_STRLEN_P(header), buf, sizeof(buf)-1, sizeof(buf)-1)) {
 					char *needle = estrdup("charset=");

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -409,6 +409,35 @@ php_libxml_input_buffer_create_filename(const char *URI, xmlCharEncoding enc)
 		return(NULL);
 	}
 
+	/* Check if there's been an external transport protocol with an encoding information */
+	if (enc == XML_CHAR_ENCODING_NONE) {
+		php_stream *s  = (php_stream *) context;
+
+		if (Z_TYPE(s->wrapperdata) == IS_ARRAY) {
+			zval *header;
+
+			ZEND_HASH_FOREACH_VAL_IND(Z_ARRVAL(s->wrapperdata), header) {
+				char *buf = "Content-Type:";
+				if (Z_TYPE_P(header) == IS_STRING &&
+						!zend_binary_strncasecmp(Z_STRVAL_P(header), Z_STRLEN_P(header), buf, sizeof(buf)-1, sizeof(buf)-1)) {
+					char *needle = estrdup("charset=");
+					char *haystack = estrndup(Z_STRVAL_P(header), Z_STRLEN_P(header));
+					char *encoding = php_stristr(haystack, needle, Z_STRLEN_P(header), sizeof("charset=")-1);
+
+					if (encoding) {
+						enc = xmlParseCharEncoding(encoding + sizeof("charset=")-1);
+						if (enc <= XML_CHAR_ENCODING_NONE) {
+							enc = XML_CHAR_ENCODING_NONE;
+						}
+					}
+					efree(haystack);
+					efree(needle);
+					break; /* found content-type */
+				}
+			} ZEND_HASH_FOREACH_END();
+		}
+	}
+
 	/* Allocate the Input buffer front-end. */
 	ret = xmlAllocParserInputBuffer(enc);
 	if (ret != NULL) {

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -425,7 +425,26 @@ php_libxml_input_buffer_create_filename(const char *URI, xmlCharEncoding enc)
 					char *encoding = php_stristr(haystack, needle, Z_STRLEN_P(header), sizeof("charset=")-1);
 
 					if (encoding) {
-						enc = xmlParseCharEncoding(encoding + sizeof("charset=")-1);
+						char *end;
+						
+						encoding += sizeof("charset=")-1;
+						if (*encoding == '"') {
+							encoding++;
+						}
+						end = strchr(encoding, ';');
+						if (end == NULL) {
+							end = encoding + strlen(encoding);
+						}
+						end--; /* end == encoding-1 isn't a buffer underrun */
+						while (*end == ' ' || *end == '\t') {
+							end--;
+						}
+						if (*end == '"') {
+							end--;
+						}
+						if (encoding >= end) continue;
+						*(end+1) = '\0';
+						enc = xmlParseCharEncoding(encoding);
 						if (enc <= XML_CHAR_ENCODING_NONE) {
 							enc = XML_CHAR_ENCODING_NONE;
 						}

--- a/ext/libxml/tests/bug51903.phpt
+++ b/ext/libxml/tests/bug51903.phpt
@@ -11,16 +11,28 @@ http_server_skipif('tcp://127.0.0.1:12342');
 require "./ext/standard/tests/http/server.inc";
 $responses = [
     "data://text/plain,HTTP/1.1 200 OK\r\n"
-      . "Content-Type: text/xml; charset=ISO-8859-1\r\n\r\n"
-      . "<?xml version=\"1.0\"?>\n"
-      . "<root>\xE4\xF6\xFC</root>\n",
+    . "Content-Type: text/xml; charset=ISO-8859-1\r\n\r\n"
+    . "<?xml version=\"1.0\"?>\n"
+    . "<root>\xE4\xF6\xFC</root>\n",
+    "data://text/plain,HTTP/1.1 200 OK\r\n"
+    . "Content-Type: text/xml; charset=ISO-8859-1; foo=bar\r\n\r\n"
+    . "<?xml version=\"1.0\"?>\n"
+    . "<root>\xE4\xF6\xFC</root>\n",
+    "data://text/plain,HTTP/1.1 200 OK\r\n"
+    . "Content-Type: text/xml; charset=\"ISO-8859-1\" ; foo=bar\r\n\r\n"
+    . "<?xml version=\"1.0\"?>\n"
+    . "<root>\xE4\xF6\xFC</root>\n",
 ];
 $pid = http_server('tcp://127.0.0.1:12342', $responses);
 
-$sxe = simplexml_load_file('http://127.0.0.1:12342/');
-echo "$sxe\n";
+for ($i = 0; $i < count($responses); $i++) {
+    $sxe = simplexml_load_file('http://127.0.0.1:12342/');
+    echo "$sxe\n";
+}
 
 http_server_kill($pid);
 ?>
 --EXPECT--
+äöü
+äöü
 äöü

--- a/ext/libxml/tests/bug51903.phpt
+++ b/ext/libxml/tests/bug51903.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #51903 (simplexml_load_file() doesn't use HTTP headers)
+--SKIPIF--
+<?php
+if (!extension_loaded('simplexml')) die('skip simplexml extension not available');
+if (@!include "./ext/standard/tests/http/server.inc") die('skip server.inc not available');
+http_server_skipif('tcp://127.0.0.1:12342');
+?>
+--FILE--
+<?php
+require "./ext/standard/tests/http/server.inc";
+$responses = [
+    "data://text/plain,HTTP/1.1 200 OK\r\n"
+      . "Content-Type: text/xml; charset=ISO-8859-1\r\n\r\n"
+      . "<?xml version=\"1.0\"?>\n"
+      . "<root>\xE4\xF6\xFC</root>\n",
+];
+$pid = http_server('tcp://127.0.0.1:12342', $responses);
+
+$sxe = simplexml_load_file('http://127.0.0.1:12342/');
+echo "$sxe\n";
+
+http_server_kill($pid);
+?>
+--EXPECT--
+äöü


### PR DESCRIPTION
The `encoding` attribute of the XML declaration is optional; it is good
practice to use external encoding information where available if it is
missing.  Thus, we check for `charset` info of `Content-Type` headers,
and see whether the encoding is supported.

This is just a PHP 7.4+ compatible update of Mike's patch.

Co-authored-by: Michael Wallner <mike@php.net>