### PR TITLE
Don't compare zero exponentials in strings as equal

### DIFF
--- a/Zend/tests/zero_exponential_comparison.phpt
+++ b/Zend/tests/zero_exponential_comparison.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Comparison of zero exponential strings
+--FILE--
+<?php
+
+// One side is not a zero exponential
+var_dump("0" == "0e0");
+var_dump("0.0" == "0e0");
+var_dump(".0" == "0e0");
+// Zero exponentials are exactly identical
+var_dump("0e0" == "0e0");
+var_dump("0e00" == "0e00");
+echo "\n";
+
+// Both sides are zero exponentials, but not identical
+var_dump("0e0" == "0e00");
+var_dump("0e0" == "0e1");
+var_dump("0e10" == "0e2");
+echo "\n";
+
+// Fallback to lexicographical order
+var_dump("0e0" < "0e1");
+var_dump("0e0" > "0e1");
+var_dump("0e10" < "0e2");
+var_dump("0e10" > "0e2");
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+
+bool(false)
+bool(false)
+bool(false)
+
+bool(true)
+bool(false)
+bool(true)
+bool(false)

--- a/Zend/tests/zero_exponential_comparison.phpt
+++ b/Zend/tests/zero_exponential_comparison.phpt
@@ -7,6 +7,7 @@ Comparison of zero exponential strings
 var_dump("0" == "0e0");
 var_dump("0.0" == "0e0");
 var_dump(".0" == "0e0");
+var_dump("0e0" == "-0e0"); // ???
 // Zero exponentials are exactly identical
 var_dump("0e0" == "0e0");
 var_dump("0e00" == "0e00");
@@ -26,6 +27,7 @@ var_dump("0e10" > "0e2");
 
 ?>
 --EXPECT--
+bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1403,7 +1403,7 @@ try_again:
 				bool trailing_data = false;
 				/* For BC reasons we allow errors so that we can warn on leading numeric string */
 				if (IS_LONG == is_numeric_string_ex(Z_STRVAL_P(dim), Z_STRLEN_P(dim), &offset, NULL,
-						/* allow errors */ true, NULL, &trailing_data)) {
+						/* allow errors */ true, NULL, &trailing_data, NULL)) {
 					if (UNEXPECTED(trailing_data) && type != BP_VAR_UNSET) {
 						zend_error(E_WARNING, "Illegal string offset \"%s\"", Z_STRVAL_P(dim));
 					}
@@ -2367,7 +2367,7 @@ try_string_offset:
 					bool trailing_data = false;
 					/* For BC reasons we allow errors so that we can warn on leading numeric string */
 					if (IS_LONG == is_numeric_string_ex(Z_STRVAL_P(dim), Z_STRLEN_P(dim), &offset,
-							NULL, /* allow errors */ true, NULL, &trailing_data)) {
+							NULL, /* allow errors */ true, NULL, &trailing_data, NULL)) {
 						if (UNEXPECTED(trailing_data)) {
 							zend_error(E_WARNING, "Illegal string offset \"%s\"", Z_STRVAL_P(dim));
 						}

--- a/Zend/zend_ini_scanner.l
+++ b/Zend/zend_ini_scanner.l
@@ -158,7 +158,7 @@ static inline zend_result convert_to_number(zval *retval, const char *str, const
 	zend_long lval;
 	double dval;
 
-	if ((type = is_numeric_string_ex(str, str_len, &lval, &dval, 0, &overflow, NULL)) != 0) {
+	if ((type = is_numeric_string_ex(str, str_len, &lval, &dval, 0, &overflow, NULL, NULL)) != 0) {
 		if (type == IS_LONG) {
 			ZVAL_LONG(retval, lval);
 			return SUCCESS;

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -3120,7 +3120,7 @@ check_digits:
 			} else if ((*ptr == 'e' || *ptr == 'E') && dp_or_e < 2) {
 				const char *e = ptr + 1;
 
-				if (is_zero_exponential && tmp_lval == 0) {
+				if (is_zero_exponential && tmp_lval == 0 && !neg) {
 					*is_zero_exponential = true;
 				}
 

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -87,7 +87,7 @@ static zend_always_inline bool instanceof_function(
  * if the integer is larger than ZEND_LONG_MAX and -1 if it's smaller than ZEND_LONG_MIN.
  */
 ZEND_API zend_uchar ZEND_FASTCALL _is_numeric_string_ex(const char *str, size_t length, zend_long *lval,
-	double *dval, bool allow_errors, int *oflow_info, bool *trailing_data);
+	double *dval, bool allow_errors, int *oflow_info, bool *trailing_data, bool *is_zero_exponential);
 
 ZEND_API const char* ZEND_FASTCALL zend_memnstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
 ZEND_API const char* ZEND_FASTCALL zend_memnrstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
@@ -136,17 +136,20 @@ static zend_always_inline zend_long zend_dval_to_lval_cap(double d)
 #define ZEND_IS_DIGIT(c) ((c) >= '0' && (c) <= '9')
 #define ZEND_IS_XDIGIT(c) (((c) >= 'A' && (c) <= 'F') || ((c) >= 'a' && (c) <= 'f'))
 
-static zend_always_inline zend_uchar is_numeric_string_ex(const char *str, size_t length, zend_long *lval,
-	double *dval, bool allow_errors, int *oflow_info, bool *trailing_data)
+static zend_always_inline zend_uchar is_numeric_string_ex(
+	const char *str, size_t length, zend_long *lval,
+	double *dval, bool allow_errors, int *oflow_info,
+	bool *trailing_data, bool *is_zero_exponential)
 {
 	if (*str > '9') {
 		return 0;
 	}
-	return _is_numeric_string_ex(str, length, lval, dval, allow_errors, oflow_info, trailing_data);
+	return _is_numeric_string_ex(
+		str, length, lval, dval, allow_errors, oflow_info, trailing_data, is_zero_exponential);
 }
 
 static zend_always_inline zend_uchar is_numeric_string(const char *str, size_t length, zend_long *lval, double *dval, bool allow_errors) {
-    return is_numeric_string_ex(str, length, lval, dval, allow_errors, NULL, NULL);
+    return is_numeric_string_ex(str, length, lval, dval, allow_errors, NULL, NULL, NULL);
 }
 
 ZEND_API zend_uchar ZEND_FASTCALL is_numeric_str_function(const zend_string *str, zend_long *lval, double *dval);

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -741,7 +741,7 @@ try_again:
 			bool trailing_data = false;
 			/* For BC reasons we allow errors so that we can warn on leading numeric string */
 			if (IS_LONG == is_numeric_string_ex(Z_STRVAL_P(dim), Z_STRLEN_P(dim), &offset, NULL,
-					/* allow errors */ true, NULL, &trailing_data)) {
+					/* allow errors */ true, NULL, &trailing_data, NULL)) {
 				if (UNEXPECTED(trailing_data)
 				 && EG(current_execute_data)->opline->opcode != ZEND_FETCH_DIM_UNSET) {
 					zend_error(E_WARNING, "Illegal string offset \"%s\"", Z_STRVAL_P(dim));


### PR DESCRIPTION
Infamously, `md5('240610708') == md5('QNKCDZO')` returns true in PHP. The reason is that `' 0e462097431906509019562988736854' == '0e830400451993494058024219903391'` interprets the two hashes as floating point numbers in exponential notation, and any numbers of the form `0eNNNN` evaluate to zero. Thus the strings are considered equal. This is usually not desirable.

This patch changes the string comparison rules to treat strings that contain an exponential of the form `0eNNNN` differently: If both sides of the comparison are a zero-exponential, then the strings will be compared lexicographically instead (which means they are only equal if they're exactly equal). If at least one side is not a zero-exponential, then the usual rules apply. We already have a similar special case for integral numbers overflowing the integer space.