### PR TITLE
Explicitly print reference wrappers in debug_zval_dump()

### DIFF
--- a/ext/mysqli/tests/mysqli_result_references.phpt
+++ b/ext/mysqli/tests/mysqli_result_references.phpt
@@ -87,51 +87,69 @@ array(7) refcount(2){
   [0]=>
   array(2) refcount(1){
     ["id"]=>
-    int(1)
+    reference refcount(1) {
+      int(1)
+    }
     ["label"]=>
     string(1) "a" refcount(%d)
   }
   [1]=>
   array(2) refcount(1){
     ["id"]=>
-    int(2)
+    reference refcount(1) {
+      int(2)
+    }
     ["label"]=>
     string(1) "b" refcount(%d)
   }
   [2]=>
   array(2) refcount(1){
     ["id"]=>
-    int(1)
+    reference refcount(1) {
+      int(1)
+    }
     ["label"]=>
     string(1) "a" refcount(%d)
   }
   [3]=>
   array(2) refcount(1){
     ["id"]=>
-    int(2)
+    reference refcount(1) {
+      int(2)
+    }
     ["label"]=>
     string(1) "b" refcount(%d)
   }
   [4]=>
   array(3) refcount(1){
     ["id"]=>
-    &int(3)
+    reference refcount(2) {
+      int(3)
+    }
     ["label"]=>
     string(1) "a" refcount(%d)
     ["id2"]=>
-    &int(3)
+    reference refcount(2) {
+      int(3)
+    }
   }
   [5]=>
   array(3) refcount(1){
     ["id"]=>
-    &int(4)
+    reference refcount(2) {
+      int(4)
+    }
     ["label"]=>
     string(1) "b" refcount(%d)
     ["id2"]=>
-    &int(4)
+    reference refcount(2) {
+      int(4)
+    }
   }
   [6]=>
-  &object(mysqli_result)#%d (0) refcount(%d){
+  reference refcount(2) {
+    object(mysqli_result)#2 (0) refcount(1){
+    }
   }
 }
 array(1) refcount(2){

--- a/ext/mysqli/tests/mysqli_result_references_mysqlnd.phpt
+++ b/ext/mysqli/tests/mysqli_result_references_mysqlnd.phpt
@@ -55,7 +55,9 @@ array(1) refcount(%d){
   [0]=>
   array(4) refcount(%d){
     ["row_ref"]=>
-    &NULL
+    reference refcount(2) {
+      NULL
+    }
     ["row_copy"]=>
     array(2) refcount(1){
       ["id"]=>
@@ -64,7 +66,9 @@ array(1) refcount(%d){
       string(1) "a" interned
     }
     ["id_ref"]=>
-    string(1) "1" interned
+    reference refcount(1) {
+      string(1) "1" interned
+    }
     ["id_copy"]=>
     string(1) "1" interned
   }
@@ -73,7 +77,9 @@ array(2) refcount(%d){
   [0]=>
   array(4) refcount(%d){
     ["row_ref"]=>
-    &NULL
+    reference refcount(2) {
+      NULL
+    }
     ["row_copy"]=>
     array(2) refcount(%d){
       ["id"]=>
@@ -82,18 +88,24 @@ array(2) refcount(%d){
       string(1) "a" interned
     }
     ["id_ref"]=>
-    string(1) "1" interned
+    reference refcount(1) {
+      string(1) "1" interned
+    }
     ["id_copy"]=>
     string(1) "1" interned
   }
   [1]=>
   array(5) refcount(%d){
     ["row_ref"]=>
-    &array(2) refcount(%d){
-      ["id"]=>
-      &string(1) "2" interned
-      ["label"]=>
-      string(1) "b" interned
+    reference refcount(2) {
+      array(2) refcount(1){
+        ["id"]=>
+        reference refcount(2) {
+          string(1) "2" interned
+        }
+        ["label"]=>
+        string(1) "b" interned
+      }
     }
     ["row_copy"]=>
     array(2) refcount(%d){
@@ -103,7 +115,9 @@ array(2) refcount(%d){
       string(1) "b" interned
     }
     ["id_ref"]=>
-    &string(1) "2" interned
+    reference refcount(2) {
+      string(1) "2" interned
+    }
     ["id_copy"]=>
     string(1) "2" interned
     ["id_copy_mod"]=>

--- a/ext/standard/tests/general_functions/debug_zval_dump_o.phpt
+++ b/ext/standard/tests/general_functions/debug_zval_dump_o.phpt
@@ -345,26 +345,30 @@ object(object_class)#%d (7) refcount(%d){
   ["object_class1"]=>
   *RECURSION*
   ["obj"]=>
-  &object(object_class)#%d (7) refcount(%d){
-    ["value1"]=>
-    int(5)
-    ["value2":"object_class":private]=>
-    int(10)
-    ["value3":protected]=>
-    int(20)
-    ["value4"]=>
-    int(30)
-    ["array_var"]=>
-    array(2) refcount(%d){
-      ["key1"]=>
-      int(1)
-      ["key2 "]=>
-      int(3)
+  reference refcount(2) {
+    object(object_class)#8 (7) refcount(2){
+      ["value1"]=>
+      int(5)
+      ["value2":"object_class":private]=>
+      int(10)
+      ["value3":protected]=>
+      int(20)
+      ["value4"]=>
+      int(30)
+      ["array_var"]=>
+      array(2) refcount(7){
+        ["key1"]=>
+        int(1)
+        ["key2 "]=>
+        int(3)
+      }
+      ["object_class1"]=>
+      *RECURSION*
+      ["obj"]=>
+      reference refcount(2) {
+        *RECURSION*
+      }
     }
-    ["object_class1"]=>
-    *RECURSION*
-    ["obj"]=>
-    *RECURSION*
   }
 }
 Done

--- a/ext/standard/tests/general_functions/debug_zval_dump_refs.phpt
+++ b/ext/standard/tests/general_functions/debug_zval_dump_refs.phpt
@@ -1,0 +1,46 @@
+--TEST--
+References in debug_zval_dump()
+--FILE--
+<?php
+
+$r = 1;
+$a = [&$r];
+debug_zval_dump($a);
+$a[] =& $r;
+debug_zval_dump($a);
+unset($a[1]);
+debug_zval_dump($a);
+unset($r);
+// rc=1 singleton ref remains
+debug_zval_dump($a);
+
+?>
+--EXPECT--
+array(1) refcount(2){
+  [0]=>
+  reference refcount(2) {
+    int(1)
+  }
+}
+array(2) refcount(2){
+  [0]=>
+  reference refcount(3) {
+    int(1)
+  }
+  [1]=>
+  reference refcount(3) {
+    int(1)
+  }
+}
+array(1) refcount(2){
+  [0]=>
+  reference refcount(2) {
+    int(1)
+  }
+}
+array(1) refcount(2){
+  [0]=>
+  reference refcount(1) {
+    int(1)
+  }
+}


### PR DESCRIPTION
Since PHP 7 references are represented using wrapping value that is separately refcounted. Make debug_zval_dump() actually print that, rather than pretending that we still live in PHP 5 times. Also print rc=1 references, which are the worst kind of references.