### PR TITLE
Max spawn child processes rate at once

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -70,6 +70,7 @@ struct fpm_worker_pool_config_s {
 	int pm_start_servers;
 	int pm_min_spare_servers;
 	int pm_max_spare_servers;
+	int pm_max_spawn_rate;
 	int pm_process_idle_timeout;
 	int pm_max_requests;
 	char *pm_status_path;

--- a/sapi/fpm/fpm/fpm_process_ctl.c
+++ b/sapi/fpm/fpm/fpm_process_ctl.c
@@ -431,7 +431,7 @@ static void fpm_pctl_perform_idle_server_maintenance(struct timeval *now) /* {{{
 			zlog(ZLOG_DEBUG, "[pool %s] %d child(ren) have been created dynamically", wp->config->name, children_to_fork);
 
 			/* Double the spawn rate for the next iteration */
-			if (wp->idle_spawn_rate < FPM_MAX_SPAWN_RATE) {
+			if (wp->idle_spawn_rate < wp->config->pm_max_spawn_rate) {
 				wp->idle_spawn_rate *= 2;
 			}
 			continue;

--- a/sapi/fpm/fpm/fpm_process_ctl.h
+++ b/sapi/fpm/fpm/fpm_process_ctl.h
@@ -5,8 +5,6 @@
 
 #include "fpm_events.h"
 
-/* spawn max 32 children at once */
-#define FPM_MAX_SPAWN_RATE (32)
 /* 1s (in ms) heartbeat for idle server maintenance */
 #define FPM_IDLE_SERVER_MAINTENANCE_HEARTBEAT (1000)
 /* a minimum of 130ms heartbeat for pctl */

--- a/sapi/fpm/tests/set-pm-max-spawn-rate.phpt
+++ b/sapi/fpm/tests/set-pm-max-spawn-rate.phpt
@@ -1,0 +1,39 @@
+--TEST--
+FPM: set pm.max_spawn_rate
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+log_level = notice
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+pm.max_spawn_rate = 64
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start(['-t', '-t']);
+$tester->expectLogConfigOptions(['pm.max_spawn_rate' => 64]);
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -1254,6 +1254,48 @@ class Tester
     }
 
     /**
+     * Expect log config options
+     *
+     * @param array $options
+     * @return bool
+     */
+    public function expectLogConfigOptions(array $options)
+    {
+        $configOptions = $this->getConfigOptions();
+        foreach ($options as $name => $value) {
+            if (!isset($configOptions[$name])) {
+                return $this->error("Expected config option: {$name} = {$value} but {$name} is not set");
+            }
+            if ($configOptions[$name] != $value) {
+                return $this->error(
+                    "Expected config option: {$name} = {$value} but got: {$name} = {$configOptions[$name]}"
+                );
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get set config options
+     *
+     * @return array
+     */
+    private function getConfigOptions()
+    {
+        $options = [];
+
+        foreach ($this->getLogLines(-1) as $line) {
+            preg_match('/.+NOTICE:\s+(.+)\s=\s(.+)/', $line, $matches);
+            if ($matches) {
+                $options[$matches[1]] = $matches[2];
+            }
+        }
+
+        return $options;
+    }
+
+    /**
      * Print content of access log.
      */
     public function printAccessLog()

--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -93,6 +93,8 @@ listen = 127.0.0.1:9000
 ;                                    state (waiting to process). If the number
 ;                                    of 'idle' processes is greater than this
 ;                                    number then some children will be killed.
+;             pm.max_spawn_rate    - the maximum number of rate to spawn child
+;                                    processes at once.
 ;  ondemand - no children are created at startup. Children will be forked when
 ;             new requests will connect. The following parameter are used:
 ;             pm.max_children           - the maximum number of children that
@@ -127,6 +129,12 @@ pm.min_spare_servers = 1
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
 pm.max_spare_servers = 3
+
+; The number of rate to spawn child processes at once.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+; Default Value: 32
+;pm.max_spawn_rate = 32
 
 ; The number of seconds after which an idle process will be killed.
 ; Note: Used only when pm is set to 'ondemand'


### PR DESCRIPTION
Problem is when you need spawn very fast a lot of fpm child processes in the dynamic mode (pm = dynamic).
After every spawn it's make 1000ms pause (i think it's HEARTBEAT checker).
Child processes spawn algorithm growth x2 while exceed maximum spawn rate at this moment hardcoded value 32.
When you need spawn a lot of child processes you take a lot of time.

Example we have already spawned 3000 child processes at high load traffic need spawn fast +900 child processes.
```
[00:00:01] spawning 8 children, there are 0 idle, and 3008 total children 
[00:00:02] spawning 16 children, there are 0 idle, and 3024 total children <!-- algorithm growth x2
[00:00:03] spawning 32 children, there are 0 idle, and 3056 total children <!-- algorithm growth x2
[00:00:04] spawning 32 children, there are 0 idle, and 3088 total children <!-- reached maximum from this moment spawn only 32.
[00:00:05] spawning 32 children, there are 0 idle, and 3120 total children
...
...
[00:00:30] spawning 32 children, there are 0 idle, and 3920 total children <!-- Total exceed 30 seconds
```

Result is: we wait 30 seconds to spawn +920 child processes.


Summary: it's good to have this setting in the configuration because spawn new child processes don't have some heavy overhead.
