### PR TITLE
Add factory methods for DatePeriod and ReflectionMethod

### DIFF
--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -398,6 +398,12 @@ class DateInterval
 
 class DatePeriod implements IteratorAggregate
 {
+    public static function createFromRecurrences(DateTimeInterface $start, DateInterval $interval, int $recurrences, int $options = 0): static {}
+
+    public static function createFromDates(DateTimeInterface $start, DateInterval $interval, DateTimeInterface $end, int $options = 0): static {}
+
+    public static function createFromIso8601(string $specification, int $options = 0): static {}
+
     /**
      * @param DateTimeInterface|string $start
      * @param DateInterval|int $interval

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 108136459e578cc699cffcb84d3335a11f8d5c9d */
+ * Stub hash: 0affb8dcab45c4067e2dfd30b34d0aa240de746e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -403,6 +403,25 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateInterval___set_state arginfo_class_DateTime___set_state
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DatePeriod_createFromRecurrences, 0, 3, IS_STATIC, 0)
+	ZEND_ARG_OBJ_INFO(0, start, DateTimeInterface, 0)
+	ZEND_ARG_OBJ_INFO(0, interval, DateInterval, 0)
+	ZEND_ARG_TYPE_INFO(0, recurrences, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DatePeriod_createFromDates, 0, 3, IS_STATIC, 0)
+	ZEND_ARG_OBJ_INFO(0, start, DateTimeInterface, 0)
+	ZEND_ARG_OBJ_INFO(0, interval, DateInterval, 0)
+	ZEND_ARG_OBJ_INFO(0, end, DateTimeInterface, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_DatePeriod_createFromIso8601, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, specification, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DatePeriod___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, start)
 	ZEND_ARG_INFO(0, interval)
@@ -498,6 +517,9 @@ ZEND_METHOD(DateTimeZone, __set_state);
 ZEND_METHOD(DateInterval, __construct);
 ZEND_METHOD(DateInterval, __wakeup);
 ZEND_METHOD(DateInterval, __set_state);
+ZEND_METHOD(DatePeriod, createFromRecurrences);
+ZEND_METHOD(DatePeriod, createFromDates);
+ZEND_METHOD(DatePeriod, createFromIso8601);
 ZEND_METHOD(DatePeriod, __construct);
 ZEND_METHOD(DatePeriod, getStartDate);
 ZEND_METHOD(DatePeriod, getEndDate);
@@ -647,6 +669,9 @@ static const zend_function_entry class_DateInterval_methods[] = {
 
 
 static const zend_function_entry class_DatePeriod_methods[] = {
+	ZEND_ME(DatePeriod, createFromRecurrences, arginfo_class_DatePeriod_createFromRecurrences, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(DatePeriod, createFromDates, arginfo_class_DatePeriod_createFromDates, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(DatePeriod, createFromIso8601, arginfo_class_DatePeriod_createFromIso8601, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(DatePeriod, __construct, arginfo_class_DatePeriod___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(DatePeriod, getStartDate, arginfo_class_DatePeriod_getStartDate, ZEND_ACC_PUBLIC)
 	ZEND_ME(DatePeriod, getEndDate, arginfo_class_DatePeriod_getEndDate, ZEND_ACC_PUBLIC)

--- a/ext/date/tests/DatePeriod_createFromDates.phpt
+++ b/ext/date/tests/DatePeriod_createFromDates.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test DatePeriod::createFromDates()
+--FILE--
+<?php
+
+class MyDatePeriod extends DatePeriod
+{
+}
+
+$start = new DateTime();
+$end = new DateTime("+2 days");
+$interval = new DateInterval("P1D");
+
+$p1 = MyDatePeriod::createFromDates($start, $interval, $end);
+$p2 = new MyDatePeriod($start, $interval, $end);
+
+var_dump($p1::class);
+var_dump($p1 == $p2);
+
+?>
+--EXPECT--
+string(12) "MyDatePeriod"
+bool(true)

--- a/ext/date/tests/DatePeriod_createFromIso8601.phpt
+++ b/ext/date/tests/DatePeriod_createFromIso8601.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test DatePeriod::createFromIso8601()
+--FILE--
+<?php
+
+class MyDatePeriod extends DatePeriod
+{
+}
+
+$p1 = MyDatePeriod::createFromIso8601("R4/2012-07-01T00:00:00Z/P7D");
+$p2 = new MyDatePeriod("R4/2012-07-01T00:00:00Z/P7D");
+
+var_dump($p1::class);
+var_dump($p1 == $p2);
+
+try {
+    MyDatePeriod::createFromIso8601("");
+} catch (Exception $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+string(12) "MyDatePeriod"
+bool(true)
+DatePeriod::createFromIso8601(): Unknown or bad format ()

--- a/ext/date/tests/DatePeriod_createFromRecurrences.phpt
+++ b/ext/date/tests/DatePeriod_createFromRecurrences.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test DatePeriod::createFromRecurrences()
+--FILE--
+<?php
+
+class MyDatePeriod extends DatePeriod
+{
+}
+
+$start = new DateTime();
+$interval = new DateInterval("P1D");
+
+$p1 = MyDatePeriod::createFromRecurrences($start, $interval, 2);
+$p2 = new MyDatePeriod($start, $interval, 2);
+
+var_dump($p1::class);
+var_dump($p1 == $p2);
+
+try {
+    MyDatePeriod::createFromRecurrences($start, $interval, 0);
+} catch (Exception $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+string(12) "MyDatePeriod"
+bool(true)
+DatePeriod::createFromRecurrences(): Recurrence count must be greater than 0

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -151,6 +151,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
 {
     public string $class;
 
+    public static function createFromMethodName(string $method): static {}
+
     public function __construct(object|string $objectOrMethod, ?string $method = null) {}
 
     public function __toString(): string {}

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3594ec0b0c3ed7266223be9c6b426aac56e3aabe */
+ * Stub hash: eed674aa76185f0f66c6dcc6d2da96d8388dd873 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -100,6 +100,10 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_ReflectionGenerator_getThis arginfo_class_ReflectionFunctionAbstract_inNamespace
 
 #define arginfo_class_ReflectionGenerator_getExecutingGenerator arginfo_class_ReflectionFunctionAbstract_inNamespace
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionMethod_createFromMethodName, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, method, IS_STRING, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReflectionMethod___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_MASK(0, objectOrMethod, MAY_BE_OBJECT|MAY_BE_STRING, NULL)
@@ -565,6 +569,7 @@ ZEND_METHOD(ReflectionGenerator, getTrace);
 ZEND_METHOD(ReflectionGenerator, getFunction);
 ZEND_METHOD(ReflectionGenerator, getThis);
 ZEND_METHOD(ReflectionGenerator, getExecutingGenerator);
+ZEND_METHOD(ReflectionMethod, createFromMethodName);
 ZEND_METHOD(ReflectionMethod, __construct);
 ZEND_METHOD(ReflectionMethod, __toString);
 ZEND_METHOD(ReflectionMethod, isPublic);
@@ -810,6 +815,7 @@ static const zend_function_entry class_ReflectionGenerator_methods[] = {
 
 
 static const zend_function_entry class_ReflectionMethod_methods[] = {
+	ZEND_ME(ReflectionMethod, createFromMethodName, arginfo_class_ReflectionMethod_createFromMethodName, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(ReflectionMethod, __construct, arginfo_class_ReflectionMethod___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionMethod, __toString, arginfo_class_ReflectionMethod___toString, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionMethod, isPublic, arginfo_class_ReflectionMethod_isPublic, ZEND_ACC_PUBLIC)

--- a/ext/reflection/tests/ReflectionMethod_createFromMethodName.phpt
+++ b/ext/reflection/tests/ReflectionMethod_createFromMethodName.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test ReflectionMethod::createFromMethodName()
+--FILE--
+<?php
+
+class Foo
+{
+    public function bar()
+    {
+    }
+}
+
+class MyReflectionMethod extends ReflectionMethod
+{
+}
+
+$m1 = MyReflectionMethod::createFromMethodName("Foo::bar");
+$m2 = new MyReflectionMethod("Foo::bar");
+
+var_dump($m1::class);
+var_dump($m1 == $m2);
+
+try {
+    MyReflectionMethod::createFromMethodName("Foo::baz");
+} catch (ReflectionException $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+string(18) "MyReflectionMethod"
+bool(true)
+Method Foo::baz() does not exist


### PR DESCRIPTION
This PR proposes to add the following factory methods:

```php
class DatePeriod
{
    public static function createFromRecurrences(DateTimeInterface $start, DateInterval $interval, int $recurrences, int $options = 0): static {}

    public static function createFromDates(DateTimeInterface $start, DateInterval $interval, DateTimeInterface $end, int $options = 0): static {}

    public static function createFromIso8601(string $specification, int $options = 0): static {}
}

class ReflectionMethod
{
    public static function createFromMethodName(string $method): static {}
}
```

The longer-term advantage of these added methods is that we could get rid of the overloaded signatures of `DatePeriod::__construct()` and `ReflectionMethod::__construct()` in PHP 9 after a deprecation phase in PHP 8.x (https://wiki.php.net/rfc/deprecations_php_8_1#dateperiodconstruct and https://wiki.php.net/rfc/deprecations_php_8_1#passing_a_method_name_as_the_first_parameter_to_reflectionmethodconstruct).

P.S. I don't have any strong preference about the method names, and the current ones should be considered as WIP ones. :)