### PR TITLE
ext/opcache: fix configure output while checking mmap MAP_ANON support

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -220,7 +220,7 @@ int main() {
 ]])],[dnl
     AC_DEFINE(HAVE_SHM_MMAP_ANON, 1, [Define if you have mmap(MAP_ANON) SHM support])
     have_shm_mmap_anon=yes],[have_shm_mmap_anon=no],[have_shm_mmap_anon=no])
-  AC_MSG_RESULT([$have_shm_mmap_anon=yes])
+  AC_MSG_RESULT([$have_shm_mmap_anon])
 
   PHP_CHECK_FUNC_LIB(shm_open, rt, root)
   AC_MSG_CHECKING(for mmap() using shm_open() shared memory support)


### PR DESCRIPTION
It seems that f3efb9e3fb introduced a "typo" which may result
in the following confusing message:

checking for mmap() using MAP_ANON shared memory support... no=yes

Let's fix this.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>