### PR TITLE
[FFI] Fix #80847 - Resolve struct type for internal struct fields

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -341,7 +341,7 @@ static ffi_type *zend_ffi_make_fake_struct_type(zend_ffi_type *type) /* {{{ */
 				t->elements[i] = &ffi_type_pointer;
 				break;
             case ZEND_FFI_TYPE_STRUCT:
-                t->elements[i] = zend_ffi_get_type(ZEND_FFI_TYPE(field->type));
+                t->elements[i] = &ffi_type_pointer;
                 break;
 			default:
 				efree(t);

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -58,6 +58,7 @@ typedef enum _zend_ffi_tag_kind {
 
 static const char *zend_ffi_tag_kind_name[3] = {"enum", "struct", "union"};
 
+static ffi_type *zend_ffi_get_type(zend_ffi_type *type);
 
 typedef struct _zend_ffi_tag {
 	zend_ffi_tag_kind      kind;
@@ -339,6 +340,9 @@ static ffi_type *zend_ffi_make_fake_struct_type(zend_ffi_type *type) /* {{{ */
 			case ZEND_FFI_TYPE_POINTER:
 				t->elements[i] = &ffi_type_pointer;
 				break;
+            case ZEND_FFI_TYPE_STRUCT:
+                t->elements[i] = zend_ffi_get_type(ZEND_FFI_TYPE(field->type));
+                break;
 			default:
 				efree(t);
 				return NULL;

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -58,8 +58,6 @@ typedef enum _zend_ffi_tag_kind {
 
 static const char *zend_ffi_tag_kind_name[3] = {"enum", "struct", "union"};
 
-static ffi_type *zend_ffi_get_type(zend_ffi_type *type);
-
 typedef struct _zend_ffi_tag {
 	zend_ffi_tag_kind      kind;
 	zend_ffi_type         *type;

--- a/ext/ffi/tests/bug80847.phpt
+++ b/ext/ffi/tests/bug80847.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Bug #80847 (Nested structs)
+--SKIPIF--
+if (!extension_loaded('ffi') die('skip ffi extension not available');
+if (!extension_loaded('zend-test') die('skip zend-test extension not available');
+--FILE--
+<?php
+require_once('utils.inc');
+$header = <<<CDEF
+    typedef struct bug80847_01 {
+        uint64_t a;
+    } bug80847_01;
+
+    typedef struct bug80847_02 {
+        bug80847_01 a;
+    } bug80847_02;
+
+    bug80847_02 bug80847(bug80847_02);
+CDEF;
+
+if (PHP_OS_FAMILY !== 'Windows') {
+    $ffi = FFI::cdef($header);
+} else {
+    try {
+        $ffi = FFI::cdef($header, 'php_zend_test.dll');
+    } catch (FFI\Exception $ex) {
+        $ffi = FFI::cdef($header, ffi_get_php_dll_name());
+    }
+}
+
+$test = $ffi->new('bug80847_02');
+var_dump($ffi->bug80847($test));
+?>
+--EXPECT--
+object(FFI\CData:struct bug80847_02)#3 (1) {
+  ["a"]=>
+  object(FFI\CData:struct bug80847_01)#4 (1) {
+    ["a"]=>
+    int(0)
+  }
+}

--- a/ext/ffi/tests/bug80847.phpt
+++ b/ext/ffi/tests/bug80847.phpt
@@ -15,7 +15,7 @@ $header = <<<CDEF
         bug80847_01 a;
     } bug80847_02;
 
-    bug80847_02 bug80847(bug80847_02);
+    bug80847_02 bug80847(bug80847_02 b);
 CDEF;
 
 if (PHP_OS_FAMILY !== 'Windows') {

--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -37,6 +37,14 @@ struct bug79096 {
 	uint64_t b;
 };
 
+typedef struct bug80847_01 {
+    uint64_t a;
+} bug80847_01;
+
+typedef struct bug80847_02 {
+    bug80847_01 b;
+} bug80847_02;
+
 #ifdef PHP_WIN32
 #	define PHP_ZEND_TEST_API __declspec(dllexport)
 #elif defined(__GNUC__) && __GNUC__ >= 4

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -342,3 +342,8 @@ void bug79177(void)
 {
 	bug79177_cb();
 }
+
+PHP_ZEND_TEST_API bug80847_02 bug80847(bug80847_02 b)
+{
+    return b;
+}


### PR DESCRIPTION
This is an incomplete fix for [BUG #80847](https://bugs.php.net/bug.php?id=80847).

It uses recursion to resolve nested structs.

**This Pull Request currently is incomplete:**
- PHP complains of memory leaks introduced and I can't really understand how to solve this
- I need support for testing this

[This GIST generates a fatal error without this Pull Request](https://gist.github.com/nawarian/319d363dacea2feebc409e5413d03887) with the following message:

```
PHP Fatal error:  Uncaught FFI\Exception: Passing incompatible argument 1 of C function 'BeginMode2D',
expecting 'struct Camera2D', found 'struct Camera2D' in [...]/raylib.php:11
```
