### PR TITLE
Add support for ::class to constant()

### DIFF
--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -25,7 +25,6 @@
 #include "zend_operators.h"
 #include "zend_globals.h"
 #include "zend_API.h"
-#include <string.h>
 
 /* Protection from recursive self-referencing class constants */
 #define IS_CONSTANT_VISITED_MARK    0x80
@@ -377,7 +376,7 @@ ZEND_API zval *zend_get_constant_ex(zend_string *cname, zend_class_entry *scope,
 		if (ce) {
 			c = zend_hash_find_ptr(CE_CONSTANTS_TABLE(ce), constant_name);
 			if (c == NULL) {
-				if (!strcasecmp(ZSTR_VAL(constant_name), "class")) {
+				if (zend_string_equals_literal_ci(constant_name, "class")) {
 					zval tmp;
 					ZVAL_NEW_STR(&tmp, class_name);
 					ret_constant = &tmp;

--- a/ext/standard/tests/general_functions/constant_001.phpt
+++ b/ext/standard/tests/general_functions/constant_001.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test constant() function: test access to class constant
+--FILE--
+<?php
+namespace Foo;
+
+class Bar {}
+
+var_dump(constant('Foo\Bar::class'));
+?>
+--EXPECT--
+string(7) "Foo\Bar"

--- a/ext/standard/tests/general_functions/constant_001.phpt
+++ b/ext/standard/tests/general_functions/constant_001.phpt
@@ -4,9 +4,42 @@ Test constant() function: test access to class constant
 <?php
 namespace Foo;
 
-class Bar {}
+class Bar
+{
+    function dump()
+    {
+        var_dump(constant('static::class'));
+    }
+}
 
+class Baz extends Bar
+{
+    function dump()
+    {
+        parent::dump();
+        var_dump(constant('self::clAsS'));
+        var_dump(constant('parent::class'));
+    }
+}
+
+var_dump(constant('Not\Exists::class'));
 var_dump(constant('Foo\Bar::class'));
+var_dump(constant('\\Foo\Bar::class'));
+(new Bar)->dump();
+(new Baz)->dump();
+
+var_dump(defined('Not\Exists::clASs'));
+var_dump(defined('Foo\Bar::class'));
+var_dump(defined('\\Foo\Bar::class'));
 ?>
 --EXPECT--
+string(10) "Not\Exists"
 string(7) "Foo\Bar"
+string(7) "Foo\Bar"
+string(7) "Foo\Bar"
+string(7) "Foo\Baz"
+string(7) "Foo\Baz"
+string(7) "Foo\Bar"
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
This change allows retrieving the value of the `::class` special constant using the `constant()` function:

```php
var_dump(
  constant('\DateTime::class')
);
```

For instance, Twig's `constant()` helper internally uses this function. This patch allows writing code like that: 
```twig
`myObject` contains a random object, retrieve its class:
{{ constant('class', myObject) }}
```

TODO: write an RFC?