### PR TITLE
pgsqlSetNoticeCallback

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -102,12 +102,13 @@ int _pdo_pgsql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, int errcode, const char *
 }
 /* }}} */
 
-static void _pdo_pgsql_notice(pdo_dbh_t *dbh, const char *message) /* {{{ */
+static void _pdo_pgsql_notice(void *context, const char *message) /* {{{ */
 {
 	int ret;
 	zval zarg;
 	zval retval;
 	pdo_pgsql_fci * fc;
+	pdo_dbh_t * dbh = (pdo_dbh_t *)context;
 	if ((fc = ((pdo_pgsql_db_handle *)dbh->driver_data)->notice_callback)) {
 		ZVAL_STRINGL(&zarg, (char *) message, strlen(message));
 		fc->fci.param_count = 1;
@@ -1415,7 +1416,7 @@ static int pdo_pgsql_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{
 		goto cleanup;
 	}
 
-	PQsetNoticeProcessor(H->server, (void(*)(void*,const char*))_pdo_pgsql_notice, (void *)dbh);
+	PQsetNoticeProcessor(H->server, _pdo_pgsql_notice, (void *)dbh);
 
 	H->attached = 1;
 	H->pgoid = -1;

--- a/ext/pdo_pgsql/pgsql_driver.stub.php
+++ b/ext/pdo_pgsql/pgsql_driver.stub.php
@@ -33,4 +33,7 @@ class PDO_PGSql_Ext {
 
     /** @tentative-return-type */
     public function pgsqlGetPid(): int {}
+
+    /** @tentative-return-type */
+    public function pgsqlSetNoticeCallback(?callable $callback): bool {}
 }

--- a/ext/pdo_pgsql/pgsql_driver.stub.php
+++ b/ext/pdo_pgsql/pgsql_driver.stub.php
@@ -35,5 +35,5 @@ class PDO_PGSql_Ext {
     public function pgsqlGetPid(): int {}
 
     /** @tentative-return-type */
-    public function pgsqlSetNoticeCallback(?callable $callback): bool {}
+    public function pgsqlSetNoticeCallback(?callable $callback): void {}
 }

--- a/ext/pdo_pgsql/pgsql_driver_arginfo.h
+++ b/ext/pdo_pgsql/pgsql_driver_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9bb79af98dbb7c171fd9533aeabece4937a06cd2 */
+ * Stub hash: f1bbbb97912bd83638aaf6a1d843ead2181894a0 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_PGSql_Ext_pgsqlCopyFromArray, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, tableName, IS_STRING, 0)
@@ -46,6 +46,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_PGSql_Ext_pgsqlGetPid, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_PGSql_Ext_pgsqlSetNoticeCallback, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 1)
+ZEND_END_ARG_INFO()
+
 ZEND_METHOD(PDO_PGSql_Ext, pgsqlCopyFromArray);
 ZEND_METHOD(PDO_PGSql_Ext, pgsqlCopyFromFile);
 ZEND_METHOD(PDO_PGSql_Ext, pgsqlCopyToArray);
@@ -55,6 +59,7 @@ ZEND_METHOD(PDO_PGSql_Ext, pgsqlLOBOpen);
 ZEND_METHOD(PDO_PGSql_Ext, pgsqlLOBUnlink);
 ZEND_METHOD(PDO_PGSql_Ext, pgsqlGetNotify);
 ZEND_METHOD(PDO_PGSql_Ext, pgsqlGetPid);
+ZEND_METHOD(PDO_PGSql_Ext, pgsqlSetNoticeCallback);
 
 static const zend_function_entry class_PDO_PGSql_Ext_methods[] = {
 	ZEND_ME(PDO_PGSql_Ext, pgsqlCopyFromArray, arginfo_class_PDO_PGSql_Ext_pgsqlCopyFromArray, ZEND_ACC_PUBLIC)
@@ -66,5 +71,6 @@ static const zend_function_entry class_PDO_PGSql_Ext_methods[] = {
 	ZEND_ME(PDO_PGSql_Ext, pgsqlLOBUnlink, arginfo_class_PDO_PGSql_Ext_pgsqlLOBUnlink, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDO_PGSql_Ext, pgsqlGetNotify, arginfo_class_PDO_PGSql_Ext_pgsqlGetNotify, ZEND_ACC_PUBLIC)
 	ZEND_ME(PDO_PGSql_Ext, pgsqlGetPid, arginfo_class_PDO_PGSql_Ext_pgsqlGetPid, ZEND_ACC_PUBLIC)
+	ZEND_ME(PDO_PGSql_Ext, pgsqlSetNoticeCallback, arginfo_class_PDO_PGSql_Ext_pgsqlSetNoticeCallback, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/ext/pdo_pgsql/pgsql_driver_arginfo.h
+++ b/ext/pdo_pgsql/pgsql_driver_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f1bbbb97912bd83638aaf6a1d843ead2181894a0 */
+ * Stub hash: 14174ab18f198b9916f83986d10c93b657d8ffb9 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_PGSql_Ext_pgsqlCopyFromArray, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, tableName, IS_STRING, 0)
@@ -46,7 +46,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_PGSql_Ext_pgsqlGetPid, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_PGSql_Ext_pgsqlSetNoticeCallback, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_PDO_PGSql_Ext_pgsqlSetNoticeCallback, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 1)
 ZEND_END_ARG_INFO()
 

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -32,6 +32,11 @@ typedef struct {
 	char *errmsg;
 } pdo_pgsql_error_info;
 
+typedef struct {
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
+} pdo_pgsql_fci;
+
 /* stuff we use in a pgsql database handle */
 typedef struct {
 	PGconn		*server;
@@ -46,6 +51,7 @@ typedef struct {
 	bool		disable_native_prepares; /* deprecated since 5.6 */
 	bool		disable_prepares;
 	HashTable       *lob_streams;
+	pdo_pgsql_fci * notice_callback;
 } pdo_pgsql_db_handle;
 
 typedef struct {

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -32,11 +32,6 @@ typedef struct {
 	char *errmsg;
 } pdo_pgsql_error_info;
 
-typedef struct {
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
-} pdo_pgsql_fci;
-
 /* stuff we use in a pgsql database handle */
 typedef struct {
 	PGconn		*server;
@@ -51,7 +46,7 @@ typedef struct {
 	bool		disable_native_prepares; /* deprecated since 5.6 */
 	bool		disable_prepares;
 	HashTable       *lob_streams;
-	pdo_pgsql_fci * notice_callback;
+	zend_fcall_info_cache *notice_callback;
 } pdo_pgsql_db_handle;
 
 typedef struct {

--- a/ext/pdo_pgsql/tests/issue78621.inc
+++ b/ext/pdo_pgsql/tests/issue78621.inc
@@ -10,6 +10,12 @@ $db->exec("create temporary table t (a varchar(3))");
 $db->exec("create function hey() returns trigger as \$\$ begin new.a := 'oh'; raise notice 'I tampered your data, did you know?'; return new; end; \$\$ language plpgsql");
 $db->exec("create trigger hop before insert on t for each row execute procedure hey()");
 $db->exec("insert into t values ('ah')");
+attach($db, 'Re');
+$db->exec("delete from t");
+$db->exec("insert into t values ('ah')");
+$db->pgsqlSetNoticeCallback(null);
+$db->exec("delete from t");
+$db->exec("insert into t values ('ah')");
 var_dump($db->query("select * from t")->fetchAll(PDO::FETCH_ASSOC));
 echo "Done\n";
 ?>

--- a/ext/pdo_pgsql/tests/issue78621.inc
+++ b/ext/pdo_pgsql/tests/issue78621.inc
@@ -1,0 +1,15 @@
+<?php
+require_once dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+require_once dirname(__FILE__) . '/config.inc';
+$db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+
+attach($db);
+
+$db->beginTransaction();
+$db->exec("create temporary table t (a varchar(3))");
+$db->exec("create function hey() returns trigger as \$\$ begin new.a := 'oh'; raise notice 'I tampered your data, did you know?'; return new; end; \$\$ language plpgsql");
+$db->exec("create trigger hop before insert on t for each row execute procedure hey()");
+$db->exec("insert into t values ('ah')");
+var_dump($db->query("select * from t")->fetchAll(PDO::FETCH_ASSOC));
+echo "Done\n";
+?>

--- a/ext/pdo_pgsql/tests/issue78621.inc
+++ b/ext/pdo_pgsql/tests/issue78621.inc
@@ -19,4 +19,5 @@ $db->exec("delete from t");
 $db->exec("insert into t values ('ah')");
 var_dump($db->query("select * from t")->fetchAll(PDO::FETCH_ASSOC));
 echo "Done\n";
+$db->rollback();
 ?>

--- a/ext/pdo_pgsql/tests/issue78621.inc
+++ b/ext/pdo_pgsql/tests/issue78621.inc
@@ -6,6 +6,7 @@ $db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
 attach($db);
 
 $db->beginTransaction();
+$db->exec("set client_min_messages to notice");
 $db->exec("create temporary table t (a varchar(3))");
 $db->exec("create function hey() returns trigger as \$\$ begin new.a := 'oh'; raise notice 'I tampered your data, did you know?'; return new; end; \$\$ language plpgsql");
 $db->exec("create trigger hop before insert on t for each row execute procedure hey()");

--- a/ext/pdo_pgsql/tests/issue78621.phpt
+++ b/ext/pdo_pgsql/tests/issue78621.phpt
@@ -10,14 +10,16 @@ PDOTest::skip();
 --FILE--
 <?php
 function disp($message) { echo trim($message)."\n"; }
-function attach($db)
+function dispRe($message) { echo "Re".trim($message)."\n"; }
+function attach($db, $prefix = '')
 {
-    $db->pgsqlSetNoticeCallback('disp');
+    $db->pgsqlSetNoticeCallback('disp'.$prefix);
 }
 require dirname(__FILE__) . '/issue78621.inc';
 ?>
 --EXPECT--
 NOTICE:  I tampered your data, did you know?
+ReNOTICE:  I tampered your data, did you know?
 array(1) {
   [0]=>
   array(1) {

--- a/ext/pdo_pgsql/tests/issue78621.phpt
+++ b/ext/pdo_pgsql/tests/issue78621.phpt
@@ -1,0 +1,28 @@
+--TEST--
+pgsqlSetNoticeCallback catches Postgres "raise notice".
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require_once dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+require_once dirname(__FILE__) . '/config.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+function disp($message) { echo trim($message)."\n"; }
+function attach($db)
+{
+    $db->pgsqlSetNoticeCallback('disp');
+}
+require dirname(__FILE__) . '/issue78621.inc';
+?>
+--EXPECT--
+NOTICE:  I tampered your data, did you know?
+array(1) {
+  [0]=>
+  array(1) {
+    ["a"]=>
+    string(2) "oh"
+  }
+}
+Done

--- a/ext/pdo_pgsql/tests/issue78621_closure.phpt
+++ b/ext/pdo_pgsql/tests/issue78621_closure.phpt
@@ -10,9 +10,9 @@ PDOTest::skip();
 --FILE--
 <?php
 function disp($message) { echo trim($message)."\n"; }
-function attach($db)
+function attach($db, $prefix = '')
 {
-    $db->pgsqlSetNoticeCallback(function($message) { echo trim($message)."\n"; });
+    $db->pgsqlSetNoticeCallback(function($message) use($prefix) { echo $prefix.trim($message)."\n"; });
     // https://github.com/php/php-src/pull/4823#pullrequestreview-335623806
     $eraseCallbackMemoryHere = (object)[1];
 }
@@ -20,6 +20,7 @@ require dirname(__FILE__) . '/issue78621.inc';
 ?>
 --EXPECT--
 NOTICE:  I tampered your data, did you know?
+ReNOTICE:  I tampered your data, did you know?
 array(1) {
   [0]=>
   array(1) {

--- a/ext/pdo_pgsql/tests/issue78621_closure.phpt
+++ b/ext/pdo_pgsql/tests/issue78621_closure.phpt
@@ -12,15 +12,42 @@ PDOTest::skip();
 function disp($message) { echo trim($message)."\n"; }
 function attach($db, $prefix = '')
 {
-    $db->pgsqlSetNoticeCallback(function($message) use($prefix) { echo $prefix.trim($message)."\n"; });
-    // https://github.com/php/php-src/pull/4823#pullrequestreview-335623806
-    $eraseCallbackMemoryHere = (object)[1];
+    global $flavor;
+    switch($flavor)
+    {
+        case 0:
+            $db->pgsqlSetNoticeCallback(function($message) use($prefix) { echo $prefix.trim($message)."\n"; });
+            // https://github.com/php/php-src/pull/4823#pullrequestreview-335623806
+            $eraseCallbackMemoryHere = (object)[1];
+            break;
+        case 1:
+            $closure = function($message) use($prefix) { echo $prefix.'('.get_class($this).')'.trim($message)."\n"; };
+            $db->pgsqlSetNoticeCallback($closure->bindTo(new \stdClass));
+            break;
+    }
 }
+echo "Testing with a simple inline closure:\n";
+$flavor = 0;
+require dirname(__FILE__) . '/issue78621.inc';
+echo "Testing with a postbound closure object:\n";
+++$flavor;
 require dirname(__FILE__) . '/issue78621.inc';
 ?>
 --EXPECT--
+Testing with a simple inline closure:
 NOTICE:  I tampered your data, did you know?
 ReNOTICE:  I tampered your data, did you know?
+array(1) {
+  [0]=>
+  array(1) {
+    ["a"]=>
+    string(2) "oh"
+  }
+}
+Done
+Testing with a postbound closure object:
+(stdClass)NOTICE:  I tampered your data, did you know?
+Re(stdClass)NOTICE:  I tampered your data, did you know?
 array(1) {
   [0]=>
   array(1) {

--- a/ext/pdo_pgsql/tests/issue78621_closure.phpt
+++ b/ext/pdo_pgsql/tests/issue78621_closure.phpt
@@ -1,0 +1,30 @@
+--TEST--
+pgsqlSetNoticeCallback catches Postgres "raise notice".
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require_once dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+require_once dirname(__FILE__) . '/config.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+function disp($message) { echo trim($message)."\n"; }
+function attach($db)
+{
+    $db->pgsqlSetNoticeCallback(function($message) { echo trim($message)."\n"; });
+    // https://github.com/php/php-src/pull/4823#pullrequestreview-335623806
+    $eraseCallbackMemoryHere = (object)[1];
+}
+require dirname(__FILE__) . '/issue78621.inc';
+?>
+--EXPECT--
+NOTICE:  I tampered your data, did you know?
+array(1) {
+  [0]=>
+  array(1) {
+    ["a"]=>
+    string(2) "oh"
+  }
+}
+Done

--- a/ext/pdo_pgsql/tests/issue78621_method.phpt
+++ b/ext/pdo_pgsql/tests/issue78621_method.phpt
@@ -13,17 +13,47 @@ class Logger
 {
     public function disp($message) { echo trim($message)."\n"; }
     public function dispRe($message) { echo "Re".trim($message)."\n"; }
+    public function __call(string $method, array $args)
+    {
+        $realMethod = strtr($method, [ 'whatever' => 'disp' ]);
+        echo "$method trampoline for $realMethod\n";
+        return call_user_func_array([ $this, $realMethod ], $args);
+    }
 }
 $logger = new Logger();
 function attach($db, $prefix = '')
 {
     global $logger;
-    $db->pgsqlSetNoticeCallback(array($logger, 'disp'.$prefix));
+    global $flavor;
+    switch($flavor)
+    {
+        case 0: $db->pgsqlSetNoticeCallback([ $logger, 'disp'.$prefix ]); break;
+        case 1: $db->pgsqlSetNoticeCallback([ $logger, 'whatever'.$prefix ]); break;
+    }
 }
+echo "Testing with method explicitely plugged:\n";
+$flavor = 0;
+require dirname(__FILE__) . '/issue78621.inc';
+echo "Testing with a bit of magic:\n";
+++$flavor;
 require dirname(__FILE__) . '/issue78621.inc';
 ?>
 --EXPECT--
+Testing with method explicitely plugged:
 NOTICE:  I tampered your data, did you know?
+ReNOTICE:  I tampered your data, did you know?
+array(1) {
+  [0]=>
+  array(1) {
+    ["a"]=>
+    string(2) "oh"
+  }
+}
+Done
+Testing with a bit of magic:
+whatever trampoline for disp
+NOTICE:  I tampered your data, did you know?
+whateverRe trampoline for dispRe
 ReNOTICE:  I tampered your data, did you know?
 array(1) {
   [0]=>

--- a/ext/pdo_pgsql/tests/issue78621_method.phpt
+++ b/ext/pdo_pgsql/tests/issue78621_method.phpt
@@ -1,0 +1,35 @@
+--TEST--
+pgsqlSetNoticeCallback catches Postgres "raise notice".
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require_once dirname(__FILE__) . '/../../../ext/pdo/tests/pdo_test.inc';
+require_once dirname(__FILE__) . '/config.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+class Logger
+{
+    public function disp($message) { echo trim($message)."\n"; }
+    public function dispRe($message) { echo "Re".trim($message)."\n"; }
+}
+$logger = new Logger();
+function attach($db, $prefix = '')
+{
+    global $logger;
+    $db->pgsqlSetNoticeCallback(array($logger, 'disp'.$prefix));
+}
+require dirname(__FILE__) . '/issue78621.inc';
+?>
+--EXPECT--
+NOTICE:  I tampered your data, did you know?
+ReNOTICE:  I tampered your data, did you know?
+array(1) {
+  [0]=>
+  array(1) {
+    ["a"]=>
+    string(2) "oh"
+  }
+}
+Done


### PR DESCRIPTION
Allows a callback to be triggered on every notice sent by PostgreSQL.

Such notices can be sent with a RAISE NOTICE in PL/pgSQL; in a long running
stored procedure, they prove useful as realtime checkpoint indicators.

Originally proposed at https://bugs.php.net/78621