### PR TITLE
Fix #66783: UAF when appending DOMDocument to element

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1302,6 +1302,10 @@ int dom_hierarchy(xmlNodePtr parent, xmlNodePtr child)
 {
 	xmlNodePtr nodep;
 
+	if (child->type == XML_DOCUMENT_NODE) {
+		return FAILURE;
+	}
+
     if (parent == NULL || child == NULL || child->doc != parent->doc) {
         return SUCCESS;
     }

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1302,13 +1302,13 @@ int dom_hierarchy(xmlNodePtr parent, xmlNodePtr child)
 {
 	xmlNodePtr nodep;
 
+	if (parent == NULL || child == NULL || child->doc != parent->doc) {
+		return SUCCESS;
+	}
+
 	if (child->type == XML_DOCUMENT_NODE) {
 		return FAILURE;
 	}
-
-    if (parent == NULL || child == NULL || child->doc != parent->doc) {
-        return SUCCESS;
-    }
 
 	nodep = parent;
 

--- a/ext/dom/tests/bug66783.phpt
+++ b/ext/dom/tests/bug66783.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #66783 (UAF when appending DOMDocument to element)
+--SKIPIF--
+<?php
+if (!extension_loaded('dom')) die('skip dom extension not available');
+?>
+--FILE--
+<?php
+$doc = new DomDocument;
+$doc->loadXML('<root></root>');
+$e = $doc->createElement('e');
+try {
+    $e->appendChild($doc);
+} catch (DOMException $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
+?>
+--EXPECTF--
+Hierarchy Request Error


### PR DESCRIPTION
According to the DOM standard, elements may only contain element, text,
processing instruction and comment nodes[1].  It is also specified that
a HierarchyRequestError should be thrown if a document is to be
inserted[2].  We follow that standard, and prevent the use-after-free
this way.

[1] <https://dom.spec.whatwg.org/#node-trees>
[2] <https://dom.spec.whatwg.org/#mutation-algorithms>