### PR TITLE
PDO cleanup & improvement

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -71,3 +71,6 @@ PHP 8.1 INTERNALS UPGRADE NOTES
     - A new PDO_API pdo_get_long_param(zend_long *lval, zval *value) has been
       introduced to fetch integer values for driver attributes, it will throw
       a type error and return false in case of failure.
+    - A new PDO_API pdo_get_bool_param(zend_long *bool, zval *value) has been
+      introduced to fetch boolean values for driver attributes, it will throw
+      a type error and return false in case of failure.

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -68,3 +68,6 @@ PHP 8.1 INTERNALS UPGRADE NOTES
       of char* for the optional sequence/table name.
     - The php_pdo_str_tolower_dup() PDO_API has been removed use zend_str_tolower_dup()
       or zend_string_tolower_ex().
+    - A new PDO_API pdo_get_long_param(zend_long *lval, zval *value) has been
+      introduced to fetch integer values for driver attributes, it will throw
+      a type error and return false in case of failure.

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -683,6 +683,7 @@ PDO_API void php_pdo_stmt_set_column_count(pdo_stmt_t *stmt, int new_count);
 
 /* Normalization for fetching long param for driver attributes */
 PDO_API bool pdo_get_long_param(zend_long *lval, zval *value);
+PDO_API bool pdo_get_bool_param(bool *bval, zval *value);
 
 PDO_API void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_error_type *pdo_error);
 #endif /* PHP_PDO_DRIVER_H */

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -681,5 +681,8 @@ PDO_API void php_pdo_dbh_delref(pdo_dbh_t *dbh);
 PDO_API void php_pdo_free_statement(pdo_stmt_t *stmt);
 PDO_API void php_pdo_stmt_set_column_count(pdo_stmt_t *stmt, int new_count);
 
+/* Normalization for fetching long param for driver attributes */
+PDO_API bool pdo_get_long_param(zend_long *lval, zval *value);
+
 PDO_API void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_error_type *pdo_error);
 #endif /* PHP_PDO_DRIVER_H */

--- a/ext/pdo/tests/bug_44159.phpt
+++ b/ext/pdo/tests/bug_44159.phpt
@@ -42,6 +42,6 @@ foreach ($attrs as $attr) {
 TypeError: PDO::ATTR_STATEMENT_CLASS value must be of type array, null given
 TypeError: PDO::ATTR_STATEMENT_CLASS value must be of type array, int given
 TypeError: PDO::ATTR_STATEMENT_CLASS value must be of type array, string given
-TypeError: Attribute value must be of type int for selected attribute, null given
+TypeError: Attribute value must be of type bool for selected attribute, null given
 bool(true)
-TypeError: Attribute value must be of type int for selected attribute, string given
+TypeError: Attribute value must be of type bool for selected attribute, string given

--- a/ext/pdo/tests/bug_44159.phpt
+++ b/ext/pdo/tests/bug_44159.phpt
@@ -44,4 +44,4 @@ TypeError: PDO::ATTR_STATEMENT_CLASS value must be of type array, int given
 TypeError: PDO::ATTR_STATEMENT_CLASS value must be of type array, string given
 TypeError: Attribute value must be of type int for selected attribute, null given
 bool(true)
-bool(true)
+TypeError: Attribute value must be of type int for selected attribute, string given

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -273,22 +273,35 @@ zend_string *dblib_handle_last_id(pdo_dbh_t *dbh, const zend_string *name)
 static bool dblib_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
+	zend_long lval;
 
 	switch(attr) {
 		case PDO_ATTR_DEFAULT_STR_PARAM:
-			H->assume_national_character_set_strings = zval_get_long(val) == PDO_PARAM_STR_NATL ? 1 : 0;
+			if (!pdo_get_long_param(&lval, val)) {
+				return false;
+			}
+			H->assume_national_character_set_strings = lval == PDO_PARAM_STR_NATL ? 1 : 0;
 			return true;
 		case PDO_ATTR_TIMEOUT:
 		case PDO_DBLIB_ATTR_QUERY_TIMEOUT:
-			return SUCCEED == dbsettime(zval_get_long(val));
+			if (!pdo_get_long_param(&lval, val)) {
+				return false;
+			}
+			return SUCCEED == dbsettime(lval);
 		case PDO_DBLIB_ATTR_STRINGIFY_UNIQUEIDENTIFIER:
-			H->stringify_uniqueidentifier = zval_get_long(val);
+			if (!pdo_get_long_param(&lval, val)) {
+				return false;
+			}
+			H->stringify_uniqueidentifier = lval;
 			return true;
 		case PDO_DBLIB_ATTR_SKIP_EMPTY_ROWSETS:
 			H->skip_empty_rowsets = zval_is_true(val);
 			return true;
 		case PDO_DBLIB_ATTR_DATETIME_CONVERT:
-			H->datetime_convert = zval_get_long(val);
+			if (!pdo_get_long_param(&lval, val)) {
+				return false;
+			}
+			H->datetime_convert = lval;
 			return true;
 		default:
 			return false;

--- a/ext/pdo_dblib/dblib_driver.c
+++ b/ext/pdo_dblib/dblib_driver.c
@@ -274,6 +274,7 @@ static bool dblib_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_dblib_db_handle *H = (pdo_dblib_db_handle *)dbh->driver_data;
 	zend_long lval;
+	bool bval;
 
 	switch(attr) {
 		case PDO_ATTR_DEFAULT_STR_PARAM:
@@ -295,7 +296,10 @@ static bool dblib_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			H->stringify_uniqueidentifier = lval;
 			return true;
 		case PDO_DBLIB_ATTR_SKIP_EMPTY_ROWSETS:
-			H->skip_empty_rowsets = zval_is_true(val);
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
+			H->skip_empty_rowsets = bval;
 			return true;
 		case PDO_DBLIB_ATTR_DATETIME_CONVERT:
 			if (!pdo_get_long_param(&lval, val)) {

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -820,12 +820,14 @@ static int firebird_alloc_prepare_stmt(pdo_dbh_t *dbh, const zend_string *sql,
 static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /* {{{ */
 {
 	pdo_firebird_db_handle *H = (pdo_firebird_db_handle *)dbh->driver_data;
+	bool bval;
 
 	switch (attr) {
 		case PDO_ATTR_AUTOCOMMIT:
 			{
-				/* Don't use pdo_get_long_param() API as zval_get_long accepts more things */
-				bool bval = zval_get_long(val)? 1 : 0;
+				if (!pdo_get_bool_param(&bval, val)) {
+					return false;
+				}
 
 				/* ignore if the new value equals the old one */
 				if (dbh->auto_commit ^ bval) {
@@ -849,7 +851,10 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 			return true;
 
 		case PDO_ATTR_FETCH_TABLE_NAMES:
-			H->fetch_table_names = zval_get_long(val)? 1 : 0;
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
+			H->fetch_table_names = bval;
 			return true;
 
 		case PDO_FB_ATTR_DATE_FORMAT:

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -824,6 +824,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 	switch (attr) {
 		case PDO_ATTR_AUTOCOMMIT:
 			{
+				/* Don't use pdo_get_long_param() API as zval_get_long accepts more things */
 				bool bval = zval_get_long(val)? 1 : 0;
 
 				/* ignore if the new value equals the old one */

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -402,11 +402,13 @@ static inline int mysql_handle_autocommit(pdo_dbh_t *dbh)
 /* {{{ pdo_mysql_set_attribute */
 static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
-	zend_long lval = zval_get_long(val);
-	bool bval = lval ? 1 : 0;
+	zend_long lval;
+	/* Don't use pdo_get_long_param() API as zval_get_long accepts more things */
+	bool bval = zval_get_long(val) ? 1 : 0;
 	PDO_DBG_ENTER("pdo_mysql_set_attribute");
 	PDO_DBG_INF_FMT("dbh=%p", dbh);
 	PDO_DBG_INF_FMT("attr=%l", attr);
+
 	switch (attr) {
 		case PDO_ATTR_AUTOCOMMIT:
 			/* ignore if the new value equals the old one */
@@ -419,6 +421,9 @@ static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			PDO_DBG_RETURN(true);
 
 		case PDO_ATTR_DEFAULT_STR_PARAM:
+			if (!pdo_get_long_param(&lval, val)) {
+				PDO_DBG_RETURN(false);
+			}
 			((pdo_mysql_db_handle *)dbh->driver_data)->assume_national_character_set_strings = lval == PDO_PARAM_STR_NATL;
 			PDO_DBG_RETURN(true);
 
@@ -439,6 +444,9 @@ static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 
 #ifndef PDO_USE_MYSQLND
 		case PDO_MYSQL_ATTR_MAX_BUFFER_SIZE:
+			if (!pdo_get_long_param(&lval, val)) {
+				PDO_DBG_RETURN(false);
+			}
 			if (lval < 0) {
 				/* TODO: Johannes, can we throw a warning here? */
  				((pdo_mysql_db_handle *)dbh->driver_data)->max_buffer_size = 1024*1024;

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -403,14 +403,16 @@ static inline int mysql_handle_autocommit(pdo_dbh_t *dbh)
 static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	zend_long lval;
-	/* Don't use pdo_get_long_param() API as zval_get_long accepts more things */
-	bool bval = zval_get_long(val) ? 1 : 0;
+	bool bval;
 	PDO_DBG_ENTER("pdo_mysql_set_attribute");
 	PDO_DBG_INF_FMT("dbh=%p", dbh);
 	PDO_DBG_INF_FMT("attr=%l", attr);
 
 	switch (attr) {
 		case PDO_ATTR_AUTOCOMMIT:
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
 			/* ignore if the new value equals the old one */
 			if (dbh->auto_commit ^ bval) {
 				dbh->auto_commit = bval;
@@ -428,17 +430,26 @@ static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			PDO_DBG_RETURN(true);
 
 		case PDO_MYSQL_ATTR_USE_BUFFERED_QUERY:
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
 			/* ignore if the new value equals the old one */
 			((pdo_mysql_db_handle *)dbh->driver_data)->buffered = bval;
 			PDO_DBG_RETURN(true);
 
 		case PDO_MYSQL_ATTR_DIRECT_QUERY:
 		case PDO_ATTR_EMULATE_PREPARES:
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
 			/* ignore if the new value equals the old one */
 			((pdo_mysql_db_handle *)dbh->driver_data)->emulate_prepare = bval;
 			PDO_DBG_RETURN(true);
 
 		case PDO_ATTR_FETCH_TABLE_NAMES:
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
 			((pdo_mysql_db_handle *)dbh->driver_data)->fetch_table_names = bval;
 			PDO_DBG_RETURN(true);
 

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_errmode.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_errmode.phpt
@@ -25,7 +25,6 @@ error_reporting=E_ALL
         echo get_class($e), ': ', $e->getMessage(), \PHP_EOL;
     }
     try {
-        /* This currently passes */
         $db->setAttribute(PDO::ATTR_ERRMODE, 'pdo');
     } catch (\Error $e) {
         echo get_class($e), ': ', $e->getMessage(), \PHP_EOL;
@@ -160,6 +159,7 @@ error_reporting=E_ALL
 --EXPECTF--
 TypeError: Attribute value must be of type int for selected attribute, array given
 TypeError: Attribute value must be of type int for selected attribute, stdClass given
+TypeError: Attribute value must be of type int for selected attribute, string given
 ValueError: Error mode must be one of the PDO::ERRMODE_* constants
 
 Warning: PDO::query(): SQLSTATE[42000]: Syntax error or access violation: %d You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near '%s' at line %d in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_oracle_nulls.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_oracle_nulls.phpt
@@ -23,7 +23,6 @@ MySQLPDOTest::skip();
         echo $e->getMessage(), \PHP_EOL;
     }
     try {
-        /* Currently passes... */
         $db->setAttribute(PDO::ATTR_ORACLE_NULLS, 'pdo');
     } catch (\TypeError $e) {
         echo $e->getMessage(), \PHP_EOL;
@@ -72,6 +71,7 @@ MySQLPDOTest::skip();
 --EXPECTF--
 Attribute value must be of type int for selected attribute, array given
 Attribute value must be of type int for selected attribute, stdClass given
+Attribute value must be of type int for selected attribute, string given
 array(1) {
   [0]=>
   array(6) {

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -431,7 +431,8 @@ static bool oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) 
 	switch (attr) {
 		case PDO_ATTR_AUTOCOMMIT:
 		{
-			if (pdo_get_long_param(&lval, val) == false) {
+			bool bval;
+			if (!pdo_get_bool_param(&bval, val)) {
 				return false;
 			}
 
@@ -446,7 +447,7 @@ static bool oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) 
 				dbh->in_txn = false;
 			}
 
-			dbh->auto_commit = (unsigned int)lval? 1 : 0;
+			dbh->auto_commit = (unsigned int) bval;
 			return true;
 		}
 		case PDO_ATTR_PREFETCH:

--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -425,12 +425,16 @@ static bool oci_handle_rollback(pdo_dbh_t *dbh) /* {{{ */
 
 static bool oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /* {{{ */
 {
-	zend_long lval = zval_get_long(val);
+	zend_long lval;
 	pdo_oci_db_handle *H = (pdo_oci_db_handle *)dbh->driver_data;
 
 	switch (attr) {
 		case PDO_ATTR_AUTOCOMMIT:
 		{
+			if (pdo_get_long_param(&lval, val) == false) {
+				return false;
+			}
+
 			if (dbh->in_txn) {
 				/* Assume they want to commit whatever is outstanding */
 				H->last_err = OCITransCommit(H->svc, H->err, 0);
@@ -447,6 +451,10 @@ static bool oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) 
 		}
 		case PDO_ATTR_PREFETCH:
 		{
+			if (!pdo_get_long_param(&lval, val)) {
+				return false;
+			}
+
 			H->prefetch = pdo_oci_sanitize_prefetch(lval);
 			return true;
 		}
@@ -537,6 +545,9 @@ static bool oci_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) 
 		case PDO_OCI_ATTR_CALL_TIMEOUT:
 		{
 #if (OCI_MAJOR_VERSION >= 18)
+			if (!pdo_get_long_param(&lval, val)) {
+				return false;
+			}
 			ub4 timeout = (ub4) lval;
 
 			H->last_err = OCIAttrSet(H->svc, OCI_HTYPE_SVCCTX,

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -333,9 +333,14 @@ static bool odbc_handle_rollback(pdo_dbh_t *dbh)
 static bool odbc_handle_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
+	bool bval;
+
 	switch (attr) {
 		case PDO_ODBC_ATTR_ASSUME_UTF8:
-			H->assume_utf8 = zval_is_true(val);
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
+			H->assume_utf8 = bval;
 			return true;
 		default:
 			strcpy(H->einfo.last_err_msg, "Unknown Attribute");

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -1154,14 +1154,20 @@ static const zend_function_entry *pdo_pgsql_get_driver_methods(pdo_dbh_t *dbh, i
 
 static bool pdo_pgsql_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
-	bool bval = zval_get_long(val)? 1 : 0;
+	bool bval;
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 
 	switch (attr) {
 		case PDO_ATTR_EMULATE_PREPARES:
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
 			H->emulate_prepares = bval;
 			return true;
 		case PDO_PGSQL_ATTR_DISABLE_PREPARES:
+			if (!pdo_get_bool_param(&bval, val)) {
+				return false;
+			}
 			H->disable_prepares = bval;
 			return true;
 		default:

--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -294,13 +294,20 @@ static int pdo_sqlite_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return
 static bool pdo_sqlite_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
+	zend_long lval;
 
 	switch (attr) {
 		case PDO_ATTR_TIMEOUT:
-			sqlite3_busy_timeout(H->db, zval_get_long(val) * 1000);
+			if (!pdo_get_long_param(&lval, val)) {
+				return false;
+			}
+			sqlite3_busy_timeout(H->db, lval * 1000);
 			return true;
 		case PDO_SQLITE_ATTR_EXTENDED_RESULT_CODES:
-			sqlite3_extended_result_codes(H->db, zval_get_long(val));
+			if (!pdo_get_long_param(&lval, val)) {
+				return false;
+			}
+			sqlite3_extended_result_codes(H->db, lval);
 			return true;
 	}
 	return false;

--- a/ext/pdo_sqlite/tests/bug_44159_sqlite_version.phpt
+++ b/ext/pdo_sqlite/tests/bug_44159_sqlite_version.phpt
@@ -9,14 +9,22 @@ if (!extension_loaded('pdo_sqlite')) die('skip PDO SQLite not available');
 $pdo = new PDO("sqlite:".__DIR__."/foo.db");
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
 
-var_dump($pdo->setAttribute(PDO::NULL_TO_STRING, NULL));
+try {
+    var_dump($pdo->setAttribute(PDO::NULL_TO_STRING, NULL));
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
+}
 var_dump($pdo->setAttribute(PDO::NULL_TO_STRING, 1));
-var_dump($pdo->setAttribute(PDO::NULL_TO_STRING, 'nonsense'));
+try {
+    var_dump($pdo->setAttribute(PDO::NULL_TO_STRING, 'nonsense'));
+} catch (\TypeError $e) {
+    echo $e->getMessage(), \PHP_EOL;
+}
 
 @unlink(__DIR__."/foo.db");
 
 ?>
 --EXPECT--
+Attribute value must be of type int for selected attribute, null given
 bool(true)
-bool(true)
-bool(true)
+Attribute value must be of type int for selected attribute, string given


### PR DESCRIPTION
Some clean up of internal PDO functions.
This also validates PDO integer attribute values such that only integer strings are valid.

However, it seems to me that there is an issue with the `pdo_dbh_set_attr_func()` driver hook, when PDO calls it, it assumes that the driver sets the error conditions such as unkown attribute, etc. but from what I've seen this is not done by most drivers but it is done by some, moreover, just checking for false and assuming this represents an unknown attribute seems to be unsound.
Any ideas?