### PR TITLE
client_info is a constant and doesn't need a connection

### DIFF
--- a/ext/mysqli/mysqli_prop.c
+++ b/ext/mysqli/mysqli_prop.c
@@ -119,7 +119,6 @@ static int link_client_version_read(mysqli_object *obj, zval *retval, bool quiet
 /* {{{ property link_client_info_read */
 static int link_client_info_read(mysqli_object *obj, zval *retval, bool quiet)
 {
-	CHECK_STATUS(MYSQLI_STATUS_INITIALIZED, quiet);
 	ZVAL_STRING(retval, MYSQL_SERVER_VERSION);
 
 	return SUCCESS;

--- a/ext/mysqli/tests/mysqli_class_mysqli_properties_no_conn.phpt
+++ b/ext/mysqli/tests/mysqli_class_mysqli_properties_no_conn.phpt
@@ -45,11 +45,7 @@ require_once('skipifconnectfailure.inc');
             echo $exception->getMessage() . "\n";
         }
 
-        try {
-            $mysqli->client_info;
-        } catch (Error $exception) {
-            echo $exception->getMessage() . "\n";
-        }
+        printf("mysqli->client_info = '%s'/%s\n", $mysqli->client_info, gettype($mysqli->client_info));
 
         printf("mysqli->client_version = '%s'/%s\n", $mysqli->client_version, gettype($mysqli->client_version));
 
@@ -242,7 +238,7 @@ Without RS
 
 Class variables:
 Property access is not allowed yet
-Property access is not allowed yet
+client_info = '%s'
 client_version = '%s'
 connect_errno = '%s'
 connect_error = ''%s'
@@ -262,7 +258,7 @@ mysqli object is already closed
 
 Object variables:
 Property access is not allowed yet
-Property access is not allowed yet
+client_info = '%s'
 client_version = '%s'
 connect_errno = '%s'
 connect_error = ''%s'
@@ -283,7 +279,7 @@ mysqli object is already closed
 Magic, magic properties:
 mysqli object is already closed
 Property access is not allowed yet
-Property access is not allowed yet
+mysqli->client_info = '%s'/string
 mysqli->client_version = '%d'/integer
 mysqli object is already closed
 mysqli object is already closed
@@ -324,7 +320,7 @@ mysqli object is already closed
 
 Class variables:
 Property access is not allowed yet
-Property access is not allowed yet
+client_info = '%s'
 client_version = '%s'
 connect_errno = '%s'
 connect_error = '%s'
@@ -344,7 +340,7 @@ mysqli object is already closed
 
 Object variables:
 Property access is not allowed yet
-Property access is not allowed yet
+client_info = '%s'
 client_version = '%s'
 connect_errno = '%s'
 connect_error = '%s'
@@ -365,7 +361,7 @@ mysqli object is already closed
 Magic, magic properties:
 mysqli object is already closed
 Property access is not allowed yet
-Property access is not allowed yet
+mysqli->client_info = '%s'/string
 mysqli->client_version = '%d'/integer
 mysqli object is already closed
 mysqli object is already closed

--- a/ext/mysqli/tests/mysqli_real_connect.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect.phpt
@@ -154,6 +154,8 @@ mysqli.allow_local_infile=1
 --EXPECTF--
 Warning: mysqli_real_connect(): (%s/%d): Access denied for user '%s'@'%s' (using password: YES) in %s on line %d
 object(mysqli)#%d (%d) {
+  ["client_info"]=>
+  string(%d) "%s"
   ["client_version"]=>
   int(%d)
   ["connect_errno"]=>


### PR DESCRIPTION
`$mysqli->client_info` property is just a front for the constant `MYSQL_SERVER_VERSION` and just like `client_version` it should be always accessible. In comparison to `mysqli_get_client_info()` it doesn't go via additional 2 function calls. 