### PR TITLE
Fix warning in getTraceAsString

### DIFF
--- a/Zend/tests/bug63762.phpt
+++ b/Zend/tests/bug63762.phpt
@@ -39,7 +39,7 @@ string(36) "#0 [internal function]: ()
 
 Array of array of NULL values:
 
-Warning: Function name is not a string in %s on line %d
+Warning: File name is not a string in %s on line %d
 
 Warning: Value for class is not a string in %s on line %d
 
@@ -48,5 +48,5 @@ Warning: Value for type is not a string in %s on line %d
 Warning: Value for function is not a string in %s on line %d
 
 Warning: args element is not an array in %s on line %d
-string(60) "#0 [unknown function][unknown][unknown][unknown]()
+string(58) "#0 [unknown file]: [unknown][unknown][unknown]()
 #1 {main}"

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -550,20 +550,17 @@ static void _build_trace_string(smart_str *str, HashTable *ht, uint32_t num) /* 
 	file = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_FILE), 1);
 	if (file) {
 		if (Z_TYPE_P(file) != IS_STRING) {
-			zend_error(E_WARNING, "Function name is not a string");
-			smart_str_appends(str, "[unknown function]");
+			zend_error(E_WARNING, "File name is not a string");
+			smart_str_appends(str, "[unknown file]: ");
 		} else{
-			zend_long line;
+			zend_long line = 0;
 			tmp = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_LINE), 1);
 			if (tmp) {
 				if (Z_TYPE_P(tmp) == IS_LONG) {
 					line = Z_LVAL_P(tmp);
 				} else {
 					zend_error(E_WARNING, "Line is not an int");
-					line = 0;
 				}
-			} else {
-				line = 0;
 			}
 			smart_str_append(str, Z_STR_P(file));
 			smart_str_appendc(str, '(');


### PR DESCRIPTION
This is a long-standing and harmless bug.

The error says "Function name" is not a string, but it's actually
investigating the "file" field, not "function".

Simplify line number branches as well.