### PR TITLE
[RFC] Autoload Classmap

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4189,9 +4189,8 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_array(zend_ar
 }
 /* }}} */
 
-#define ZEND_FAKE_OP_ARRAY ((zend_op_array*)(zend_intptr_t)-1)
 
-static zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval *inc_filename, int type) /* {{{ */
+zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval *inc_filename, int type) /* {{{ */
 {
 	zend_op_array *new_op_array = NULL;
 	zval tmp_inc_filename;

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -76,6 +76,9 @@ ZEND_API ZEND_COLD void zend_verify_return_error(
 ZEND_API bool zend_verify_ref_array_assignable(zend_reference *ref);
 ZEND_API bool zend_value_instanceof_static(zval *zv);
 
+extern zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval *inc_filename, int type);
+
+#define ZEND_FAKE_OP_ARRAY ((zend_op_array*)(zend_intptr_t)-1)
 
 #define ZEND_REF_TYPE_SOURCES(ref) \
 	(ref)->sources

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -422,7 +422,7 @@ static zend_class_entry *spl_perform_autoload(zend_string *class_name, zend_stri
 				return NULL;
 			}
 			
-			zend_op_array *op_array = zend_include_or_eval(mf, ZEND_REQUIRE_ONCE);
+			zend_op_array *op_array = zend_include_or_eval(mf, ZEND_REQUIRE);
 			if (op_array != NULL && op_array != ZEND_FAKE_OP_ARRAY) {
 				destroy_op_array(op_array);
 				efree_size(op_array, sizeof(zend_op_array));

--- a/ext/spl/php_spl.h
+++ b/ext/spl/php_spl.h
@@ -54,6 +54,7 @@ PHP_MINFO_FUNCTION(spl);
 ZEND_BEGIN_MODULE_GLOBALS(spl)
 	zend_string *autoload_extensions;
 	HashTable   *autoload_functions;
+	HashTable   *autoload_classmap;
 	intptr_t     hash_mask_handle;
 	intptr_t     hash_mask_handlers;
 	int          hash_mask_init;

--- a/ext/spl/php_spl.stub.php
+++ b/ext/spl/php_spl.stub.php
@@ -34,3 +34,7 @@ function iterator_apply(Traversable $iterator, callable $callback, ?array $args 
 function iterator_count(Traversable $iterator): int {}
 
 function iterator_to_array(Traversable $iterator, bool $preserve_keys = true): array {}
+
+function autoload_set_classmap(array $mapping): bool {}
+
+function autoload_get_classmap(array $mapping): array {}

--- a/ext/spl/php_spl.stub.php
+++ b/ext/spl/php_spl.stub.php
@@ -35,6 +35,6 @@ function iterator_count(Traversable $iterator): int {}
 
 function iterator_to_array(Traversable $iterator, bool $preserve_keys = true): array {}
 
-function autoload_set_classmap(array $mapping): bool {}
+function autoload_set_classmap(array $mapping): void {}
 
-function autoload_get_classmap(array $mapping): array {}
+function autoload_get_classmap(): array {}

--- a/ext/spl/php_spl_arginfo.h
+++ b/ext/spl/php_spl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 54d193c03c2652ce40adabd10d88666a86e32728 */
+ * Stub hash: 70ba950885121dee91431621406a8188a5a40a54 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_implements, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, object_or_class)
@@ -61,6 +61,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterator_to_array, 0, 1, IS_ARRA
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, preserve_keys, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_autoload_set_classmap, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, mapping, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_autoload_get_classmap, 0, 1, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, mapping, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(class_implements);
 ZEND_FUNCTION(class_parents);
@@ -77,6 +85,8 @@ ZEND_FUNCTION(spl_object_id);
 ZEND_FUNCTION(iterator_apply);
 ZEND_FUNCTION(iterator_count);
 ZEND_FUNCTION(iterator_to_array);
+ZEND_FUNCTION(autoload_set_classmap);
+ZEND_FUNCTION(autoload_get_classmap);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -95,5 +105,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(iterator_apply, arginfo_iterator_apply)
 	ZEND_FE(iterator_count, arginfo_iterator_count)
 	ZEND_FE(iterator_to_array, arginfo_iterator_to_array)
+	ZEND_FE(autoload_set_classmap, arginfo_autoload_set_classmap)
+	ZEND_FE(autoload_get_classmap, arginfo_autoload_get_classmap)
 	ZEND_FE_END
 };

--- a/ext/spl/php_spl_arginfo.h
+++ b/ext/spl/php_spl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 70ba950885121dee91431621406a8188a5a40a54 */
+ * Stub hash: dc37ffc6559b505fa389a6b0445d00a210e8eddf */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_implements, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, object_or_class)
@@ -61,13 +61,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_iterator_to_array, 0, 1, IS_ARRA
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, preserve_keys, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_autoload_set_classmap, 0, 1, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_autoload_set_classmap, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, mapping, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_autoload_get_classmap, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, mapping, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_autoload_get_classmap arginfo_spl_autoload_functions
 
 
 ZEND_FUNCTION(class_implements);

--- a/ext/spl/tests/autoload_set_classmap_001.phpt
+++ b/ext/spl/tests/autoload_set_classmap_001.phpt
@@ -35,6 +35,6 @@ Example
 Foo\NamespacedExample
 Array
 (
-    [example] => /tmp/example.php
+    [example] => %s/example.php
     [foo\namespacedexample] => %s/namespacedexample.php
 )

--- a/ext/spl/tests/autoload_set_classmap_001.phpt
+++ b/ext/spl/tests/autoload_set_classmap_001.phpt
@@ -1,0 +1,29 @@
+--TEST--
+autoload_set_classmap Basic Operation
+--FILE--
+<?php
+
+    $classes = ['Example', 'Foo\NamespacedExample'];
+    $classes_map = [];
+
+    foreach ($classes as $class) {
+        $p = explode("\\", $class);
+        $class_name = array_pop($p);
+        $namespace = implode('\\', $p);
+
+        $class_str = '<?php ' . ($namespace ? ('namespace ' . $namespace . ';') : '') . ' class ' . $class_name . '{ }';
+        $path = sys_get_temp_dir() . '/' . $class . '.php';
+        file_put_contents($path, $class_str);
+
+        $classes_map[$class] = $path;
+    }
+
+    autoload_set_classmap($classes_map);
+
+    echo get_debug_type(new Example()) . "\n";
+    echo get_debug_type(new Foo\NamespacedExample()) . "\n";
+
+?>
+--EXPECT--
+Example
+Foo\NamespacedExample

--- a/ext/spl/tests/autoload_set_classmap_001.phpt
+++ b/ext/spl/tests/autoload_set_classmap_001.phpt
@@ -3,25 +3,27 @@ autoload_set_classmap Basic Operation
 --FILE--
 <?php
 
-    $classes = ['Example', 'Foo\NamespacedExample'];
-    $classes_map = [];
+$classes = ['Example', 'Foo\NamespacedExample'];
+$classes_map = [];
 
-    foreach ($classes as $class) {
-        $p = explode("\\", $class);
-        $class_name = array_pop($p);
-        $namespace = implode('\\', $p);
+foreach ($classes as $class) {
+    $p = explode("\\", $class);
+    $class_name = array_pop($p);
+    $namespace = implode('\\', $p);
 
-        $class_str = '<?php ' . ($namespace ? ('namespace ' . $namespace . ';') : '') . ' class ' . $class_name . '{ }';
-        $path = sys_get_temp_dir() . '/' . $class . '.php';
-        file_put_contents($path, $class_str);
+    $class = strtolower($class);
 
-        $classes_map[$class] = $path;
-    }
+    $class_str = '<?php ' . ($namespace ? ('namespace ' . $namespace . ';') : '') . ' class ' . $class_name . '{ }';
+    $path = sys_get_temp_dir() . '/' . $class . '.php';
+    file_put_contents($path, $class_str);
 
-    autoload_set_classmap($classes_map);
+    $classes_map[$class] = $path;
+}
 
-    echo get_debug_type(new Example()) . "\n";
-    echo get_debug_type(new Foo\NamespacedExample()) . "\n";
+autoload_set_classmap($classes_map);
+
+echo get_debug_type(new Example()) . "\n";
+echo get_debug_type(new Foo\NamespacedExample()) . "\n";
 
 ?>
 --EXPECT--

--- a/ext/spl/tests/autoload_set_classmap_001.phpt
+++ b/ext/spl/tests/autoload_set_classmap_001.phpt
@@ -6,6 +6,8 @@ autoload_set_classmap Basic Operation
 $classes = ['Example', 'Foo\NamespacedExample'];
 $classes_map = [];
 
+@mkdir(sys_get_temp_dir() . '/foo');
+
 foreach ($classes as $class) {
     $p = explode("\\", $class);
     $class_name = array_pop($p);
@@ -14,7 +16,7 @@ foreach ($classes as $class) {
     $class = strtolower($class);
 
     $class_str = '<?php ' . ($namespace ? ('namespace ' . $namespace . ';') : '') . ' class ' . $class_name . '{ }';
-    $path = sys_get_temp_dir() . '/' . $class . '.php';
+    $path = sys_get_temp_dir() . '/' . str_replace('\\', '/', $class) . '.php';
     file_put_contents($path, $class_str);
 
     $classes_map[$class] = $path;
@@ -25,7 +27,14 @@ autoload_set_classmap($classes_map);
 echo get_debug_type(new Example()) . "\n";
 echo get_debug_type(new Foo\NamespacedExample()) . "\n";
 
+print_r(autoload_get_classmap());
+
 ?>
---EXPECT--
+--EXPECTF--
 Example
 Foo\NamespacedExample
+Array
+(
+    [example] => /tmp/example.php
+    [foo\namespacedexample] => %s/namespacedexample.php
+)

--- a/ext/spl/tests/autoload_set_classmap_002.phpt
+++ b/ext/spl/tests/autoload_set_classmap_002.phpt
@@ -13,4 +13,4 @@ catch (\Throwable $ex) {
 
 ?>
 --EXPECT--
-TypeError - Error during autoloading from classmap. Entry "foo" expected a string value, "int" given.
+TypeError - Error during autoloading from classmap. Entry "foo" expected a string value, int given

--- a/ext/spl/tests/autoload_set_classmap_002.phpt
+++ b/ext/spl/tests/autoload_set_classmap_002.phpt
@@ -1,0 +1,15 @@
+--TEST--
+autoload_set_classmap Reject non-string values
+--FILE--
+<?php
+
+    try {
+        autoload_set_classmap(['Foo' => 123]);
+    }
+    catch (\Throwable $ex) {
+        echo get_class($ex) . ' - ' . $ex->getMessage();
+    }
+
+?>
+--EXPECT--
+ValueError - autoload_set_classmap(): Argument #1 ($mapping) Classmap entry for "Foo" expected string value, found int.

--- a/ext/spl/tests/autoload_set_classmap_002.phpt
+++ b/ext/spl/tests/autoload_set_classmap_002.phpt
@@ -5,6 +5,7 @@ autoload_set_classmap Reject non-string values
 
     try {
         autoload_set_classmap(['Foo' => 123]);
+        new Foo();
     }
     catch (\Throwable $ex) {
         echo get_class($ex) . ' - ' . $ex->getMessage();
@@ -12,4 +13,4 @@ autoload_set_classmap Reject non-string values
 
 ?>
 --EXPECT--
-ValueError - autoload_set_classmap(): Argument #1 ($mapping) Classmap entry for "Foo" expected string value, found int.
+Error - Error during autoloading from classmap. Entry "Foo" expected a string value, "int" given.

--- a/ext/spl/tests/autoload_set_classmap_002.phpt
+++ b/ext/spl/tests/autoload_set_classmap_002.phpt
@@ -3,14 +3,14 @@ autoload_set_classmap Reject non-string values
 --FILE--
 <?php
 
-    try {
-        autoload_set_classmap(['Foo' => 123]);
-        new Foo();
-    }
-    catch (\Throwable $ex) {
-        echo get_class($ex) . ' - ' . $ex->getMessage();
-    }
+try {
+    autoload_set_classmap(['foo' => 123]);
+    new Foo();
+}
+catch (\Throwable $ex) {
+    echo get_class($ex) . ' - ' . $ex->getMessage();
+}
 
 ?>
 --EXPECT--
-Error - Error during autoloading from classmap. Entry "Foo" expected a string value, "int" given.
+TypeError - Error during autoloading from classmap. Entry "foo" expected a string value, "int" given.

--- a/ext/spl/tests/autoload_set_classmap_003.phpt
+++ b/ext/spl/tests/autoload_set_classmap_003.phpt
@@ -3,18 +3,18 @@ autoload_set_classmap Throw error if mapped file did not contain class
 --FILE--
 <?php
 
-    $tmp_file = sys_get_temp_dir() . '/ThisFileIsEmpty.php';
-    file_put_contents($tmp_file, '<?php ');
+$tmp_file = sys_get_temp_dir() . '/ThisFileIsEmpty.php';
+file_put_contents($tmp_file, '<?php ');
 
-    autoload_set_classmap(['Foo' => $tmp_file]);
+autoload_set_classmap(['foo' => $tmp_file]);
 
-    try {
-        new Foo();
-    }
-    catch (\Throwable $ex) {
-        echo get_class($ex) . ' - ' . $ex->getMessage();
-    }
+try {
+    new Foo();
+}
+catch (\Throwable $ex) {
+    echo get_class($ex) . ' - ' . $ex->getMessage();
+}
 
 ?>
 --EXPECTF--
-Error - Error during autoloading from classmap. Entry "Foo" failed to load the class from "%s/ThisFileIsEmpty.php" (Class undefined after file included).
+Error - Error during autoloading from classmap. Entry "foo" failed to load the class from "%s/ThisFileIsEmpty.php" (Class undefined after file included).

--- a/ext/spl/tests/autoload_set_classmap_003.phpt
+++ b/ext/spl/tests/autoload_set_classmap_003.phpt
@@ -17,4 +17,4 @@ autoload_set_classmap Throw error if mapped file did not contain class
 
 ?>
 --EXPECTF--
-Error - Classmap entry "Foo" failed to load the class from "%s/ThisFileIsEmpty.php" (Class undefined after file included).
+Error - Error during autoloading from classmap. Entry "Foo" failed to load the class from "%s/ThisFileIsEmpty.php" (Class undefined after file included).

--- a/ext/spl/tests/autoload_set_classmap_003.phpt
+++ b/ext/spl/tests/autoload_set_classmap_003.phpt
@@ -17,4 +17,4 @@ catch (\Throwable $ex) {
 
 ?>
 --EXPECTF--
-Error - Error during autoloading from classmap. Entry "foo" failed to load the class from "%s/ThisFileIsEmpty.php" (Class undefined after file included).
+Error - Error during autoloading from classmap. Entry "foo" failed to load the class from "%s/ThisFileIsEmpty.php" (Class undefined after file included)

--- a/ext/spl/tests/autoload_set_classmap_003.phpt
+++ b/ext/spl/tests/autoload_set_classmap_003.phpt
@@ -1,0 +1,20 @@
+--TEST--
+autoload_set_classmap Throw error if mapped file did not contain class
+--FILE--
+<?php
+
+    $tmp_file = sys_get_temp_dir() . '/ThisFileIsEmpty.php';
+    file_put_contents($tmp_file, '<?php ');
+
+    autoload_set_classmap(['Foo' => $tmp_file]);
+
+    try {
+        new Foo();
+    }
+    catch (\Throwable $ex) {
+        echo get_class($ex) . ' - ' . $ex->getMessage();
+    }
+
+?>
+--EXPECTF--
+Error - Classmap entry "Foo" failed to load the class from "%s/ThisFileIsEmpty.php" (Class undefined after file included).

--- a/ext/spl/tests/autoload_set_classmap_004.phpt
+++ b/ext/spl/tests/autoload_set_classmap_004.phpt
@@ -1,0 +1,16 @@
+--TEST--
+autoload_set_classmap Map can only be initialized once
+--FILE--
+<?php
+
+    try {
+        autoload_set_classmap(['Foo' => '/Foo']);
+        autoload_set_classmap(['Foo' => '/Foo']);
+    }
+    catch (\Throwable $ex) {
+        echo get_class($ex) . ' - ' . $ex->getMessage();
+    }
+
+?>
+--EXPECT--
+Error - The autoload classmap can only be initialized once per request.

--- a/ext/spl/tests/autoload_set_classmap_004.phpt
+++ b/ext/spl/tests/autoload_set_classmap_004.phpt
@@ -13,4 +13,4 @@ autoload_set_classmap Map can only be initialized once
 
 ?>
 --EXPECT--
-Error - The autoload classmap can only be initialized once per request.
+Error - Classmap Autoloader can only be initialized once per request.

--- a/ext/spl/tests/autoload_set_classmap_004.phpt
+++ b/ext/spl/tests/autoload_set_classmap_004.phpt
@@ -3,13 +3,13 @@ autoload_set_classmap Map can only be initialized once
 --FILE--
 <?php
 
-    try {
-        autoload_set_classmap(['Foo' => '/Foo']);
-        autoload_set_classmap(['Foo' => '/Foo']);
-    }
-    catch (\Throwable $ex) {
-        echo get_class($ex) . ' - ' . $ex->getMessage();
-    }
+try {
+    autoload_set_classmap(['foo' => '/Foo']);
+    autoload_set_classmap(['foo' => '/Foo']);
+}
+catch (\Throwable $ex) {
+    echo get_class($ex) . ' - ' . $ex->getMessage();
+}
 
 ?>
 --EXPECT--


### PR DESCRIPTION
Adds a mechanism to autoload classes based on a static list rather than invoking a userland function.

The classmap is considered authoritative when a key is present. The file must exist, and it must result in the class being loaded. 