### PR TITLE
Change Zend Stream API to use zend_string* instead of char*.

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -2,6 +2,7 @@ PHP 8.1 INTERNALS UPGRADE NOTES
 
 1. Internal API changes
   a. Removed Zend APIs
+  b. Zend Stream API
 
 2. Build system changes
 
@@ -16,6 +17,19 @@ PHP 8.1 INTERNALS UPGRADE NOTES
        spl_ce_Stringable, spl_ce_Traversable alias class entries have been removed in favor of zend_ce_aggregate,
        zend_ce_arrayaccess, zend_ce_countable, zend_ce_iterator, zend_ce_serializable, zend_ce_stringable,
        zend_ce_traversable.
+  b. Zend Stream API has been changed to use "zend_string*" instead of "char*"
+      - zend_file_handle.filename now is zend_string*
+      - zend_file_handle.free_filename is removed. Now zend_file_handle.filename is always released.
+      - added zend_file_handle.primary_script flag. SAPIs should set it for main executed script.
+      - added zend_file_handle.in_list flag, that is set when file_handle added into CG(open_files)
+      - added zend_stream_init_filename_ex() function, that takes filename as zend_string*
+      - in functions zend_stream_open(), php_stream_open_for_zend_ex() and zend_stream_open_function()
+        callback "filename" argument is removed (it's passed as a field of file_handle)
+      - in zend_fopen() and zend_resolve_path() callbacks filename now passed as zend_string*
+      - file_handles should be destroyed by zend_destroy_file_handle() function (usually in the same function
+        the same function where they were created by zend_stream_init_*()). Previously there were two different
+        destructors zend_destroy_file_handle() and zend_file_handle_dtor().
+      - zend_ini_scanner_globals.filename now is zend_string*
 
 ========================
 2. Build system changes

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -21,10 +21,11 @@ PHP 8.1 INTERNALS UPGRADE NOTES
       - zend_file_handle.filename now is zend_string*
       - zend_file_handle.free_filename is removed. Now zend_file_handle.filename is always released.
       - added zend_file_handle.primary_script flag. SAPIs should set it for main executed script.
-      - added zend_file_handle.in_list flag, that is set when file_handle added into CG(open_files)
+      - added zend_file_handle.in_list flag, which is set when a file_handle is added into CG(open_files)
       - added zend_stream_init_filename_ex() function, that takes filename as zend_string*
-      - in functions zend_stream_open(), php_stream_open_for_zend_ex() and zend_stream_open_function()
-        callback "filename" argument is removed (it's passed as a field of file_handle)
+      - the "filename" parameter of functons zend_stream_open(), php_stream_open_for_zend_ex() and
+        callback zend_stream_open_function() has been removed (it's now passed as a "filename" field of the
+        file_handle parameter)
       - in zend_fopen() and zend_resolve_path() callbacks filename now passed as zend_string*
       - file_handles should be destroyed by zend_destroy_file_handle() function (usually in the same function
         the same function where they were created by zend_stream_init_*()). Previously there were two different

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -215,16 +215,16 @@ typedef struct _zend_utility_functions {
 	void (*error_function)(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
 	size_t (*printf_function)(const char *format, ...) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 1, 2);
 	size_t (*write_function)(const char *str, size_t str_length);
-	FILE *(*fopen_function)(const char *filename, zend_string **opened_path);
+	FILE *(*fopen_function)(zend_string *filename, zend_string **opened_path);
 	void (*message_handler)(zend_long message, const void *data);
 	zval *(*get_configuration_directive)(zend_string *name);
 	void (*ticks_function)(int ticks);
 	void (*on_timeout)(int seconds);
-	zend_result (*stream_open_function)(const char *filename, zend_file_handle *handle);
+	zend_result (*stream_open_function)(zend_file_handle *handle);
 	void (*printf_to_smart_string_function)(smart_string *buf, const char *format, va_list ap);
 	void (*printf_to_smart_str_function)(smart_str *buf, const char *format, va_list ap);
 	char *(*getenv_function)(const char *name, size_t name_len);
-	zend_string *(*resolve_path_function)(const char *filename, size_t filename_len);
+	zend_string *(*resolve_path_function)(zend_string *filename);
 } zend_utility_functions;
 
 typedef struct _zend_utility_values {
@@ -303,16 +303,16 @@ END_EXTERN_C()
 BEGIN_EXTERN_C()
 extern ZEND_API size_t (*zend_printf)(const char *format, ...) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 1, 2);
 extern ZEND_API zend_write_func_t zend_write;
-extern ZEND_API FILE *(*zend_fopen)(const char *filename, zend_string **opened_path);
+extern ZEND_API FILE *(*zend_fopen)(zend_string *filename, zend_string **opened_path);
 extern ZEND_API void (*zend_ticks_function)(int ticks);
 extern ZEND_API void (*zend_interrupt_function)(zend_execute_data *execute_data);
 extern ZEND_API void (*zend_error_cb)(int type, const char *error_filename, const uint32_t error_lineno, zend_string *message);
 extern ZEND_API void (*zend_on_timeout)(int seconds);
-extern ZEND_API zend_result (*zend_stream_open_function)(const char *filename, zend_file_handle *handle);
+extern ZEND_API zend_result (*zend_stream_open_function)(zend_file_handle *handle);
 extern void (*zend_printf_to_smart_string)(smart_string *buf, const char *format, va_list ap);
 extern void (*zend_printf_to_smart_str)(smart_str *buf, const char *format, va_list ap);
 extern ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
-extern ZEND_API zend_string *(*zend_resolve_path)(const char *filename, size_t filename_len);
+extern ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
 
 /* These two callbacks are especially for opcache */
 extern ZEND_API zend_result (*zend_post_startup_cb)(void);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -398,13 +398,6 @@ static bool zend_have_seen_symbol(zend_string *name, uint32_t kind) {
 	return zv && (Z_LVAL_P(zv) & kind) != 0;
 }
 
-ZEND_API void file_handle_dtor(zend_file_handle *fh) /* {{{ */
-{
-
-	zend_file_handle_dtor(fh);
-}
-/* }}} */
-
 void init_compiler(void) /* {{{ */
 {
 	CG(arena) = zend_arena_create(64 * 1024);
@@ -412,7 +405,7 @@ void init_compiler(void) /* {{{ */
 	memset(&CG(context), 0, sizeof(CG(context)));
 	zend_init_compiler_data_structures();
 	zend_init_rsrc_list();
-	zend_llist_init(&CG(open_files), sizeof(zend_file_handle), (void (*)(void *)) file_handle_dtor, 0);
+	zend_stream_init();
 	CG(unclean_shutdown) = 0;
 
 	CG(delayed_variance_obligations) = NULL;

--- a/Zend/zend_dtrace.c
+++ b/Zend/zend_dtrace.c
@@ -44,9 +44,9 @@ static inline const char *dtrace_get_executed_filename(void)
 ZEND_API zend_op_array *dtrace_compile_file(zend_file_handle *file_handle, int type)
 {
 	zend_op_array *res;
-	DTRACE_COMPILE_FILE_ENTRY(ZSTR_VAL(file_handle->opened_path), (char *)file_handle->filename);
+	DTRACE_COMPILE_FILE_ENTRY(ZSTR_VAL(file_handle->opened_path), ZSTR_VAL(file_handle->filename));
 	res = compile_file(file_handle, type);
-	DTRACE_COMPILE_FILE_RETURN(ZSTR_VAL(file_handle->opened_path), (char *)file_handle->filename);
+	DTRACE_COMPILE_FILE_RETURN(ZSTR_VAL(file_handle->opened_path), ZSTR_VAL(file_handle->filename));
 
 	return res;
 }

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -264,7 +264,7 @@ void shutdown_executor(void) /* {{{ */
 #endif
 
 	zend_try {
-		zend_llist_destroy(&CG(open_files));
+		zend_stream_shutdown();
 	} zend_end_try();
 
 	EG(flags) |= EG_FLAGS_IN_RESOURCE_SHUTDOWN;

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -270,7 +270,7 @@ struct _zend_ini_scanner_globals {
 	int yy_state;
 	zend_stack state_stack;
 
-	char *filename;
+	zend_string *filename;
 	int lineno;
 
 	/* Modes are: ZEND_INI_SCANNER_NORMAL, ZEND_INI_SCANNER_RAW, ZEND_INI_SCANNER_TYPED */

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -227,7 +227,6 @@ ZEND_API zend_result zend_parse_ini_file(zend_file_handle *fh, bool unbuffered_e
 
 	CG(ini_parser_unbuffered_errors) = unbuffered_errors;
 	retval = ini_parse();
-	zend_file_handle_dtor(fh);
 
 	shutdown_ini_scanner();
 

--- a/Zend/zend_ini_scanner.l
+++ b/Zend/zend_ini_scanner.l
@@ -231,7 +231,7 @@ static zend_result init_ini_scanner(int scanner_mode, zend_file_handle *fh)
 	SCNG(yy_in) = fh;
 
 	if (fh != NULL) {
-		ini_filename = zend_strndup(fh->filename, strlen(fh->filename));
+		ini_filename = zend_string_copy(fh->filename);
 	} else {
 		ini_filename = NULL;
 	}
@@ -248,7 +248,7 @@ void shutdown_ini_scanner(void)
 {
 	zend_stack_destroy(&SCNG(state_stack));
 	if (ini_filename) {
-		free(ini_filename);
+		zend_string_release(ini_filename);
 	}
 }
 /* }}} */
@@ -263,7 +263,7 @@ ZEND_COLD int zend_ini_scanner_get_lineno(void)
 /* {{{ zend_ini_scanner_get_filename() */
 ZEND_COLD char *zend_ini_scanner_get_filename(void)
 {
-	return ini_filename ? ini_filename : "Unknown";
+	return ini_filename ? ZSTR_VAL(ini_filename) : "Unknown";
 }
 /* }}} */
 
@@ -278,7 +278,6 @@ zend_result zend_ini_open_file_for_scanning(zend_file_handle *fh, int scanner_mo
 	}
 
 	if (init_ini_scanner(scanner_mode, fh) == FAILURE) {
-		zend_file_handle_dtor(fh);
 		return FAILURE;
 	}
 

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -297,16 +297,6 @@ ZEND_API void zend_restore_lexical_state(zend_lex_state *lex_state)
 	RESET_DOC_COMMENT();
 }
 
-ZEND_API void zend_destroy_file_handle(zend_file_handle *file_handle)
-{
-	zend_llist_del_element(&CG(open_files), file_handle, (int (*)(void *, void *)) zend_compare_file_handles);
-	/* zend_file_handle_dtor() operates on the copy, so we have to NULLify the original here */
-	file_handle->opened_path = NULL;
-	if (file_handle->free_filename) {
-		file_handle->filename = NULL;
-	}
-}
-
 ZEND_API zend_result zend_lex_tstring(zval *zv, unsigned char *ident)
 {
 	unsigned char *end = ident;
@@ -542,11 +532,13 @@ ZEND_API zend_result open_file_for_scanning(zend_file_handle *file_handle)
 	if (zend_stream_fixup(file_handle, &buf, &size) == FAILURE) {
 		/* Still add it to open_files to make destroy_file_handle work */
 		zend_llist_add_element(&CG(open_files), file_handle);
+		file_handle->in_list = 1;
 		return FAILURE;
 	}
 
 	ZEND_ASSERT(!EG(exception) && "stream_fixup() should have failed");
 	zend_llist_add_element(&CG(open_files), file_handle);
+	file_handle->in_list = 1;
 
 	/* Reset the scanner for scanning the new file */
 	SCNG(yy_in) = file_handle;
@@ -584,7 +576,7 @@ ZEND_API zend_result open_file_for_scanning(zend_file_handle *file_handle)
 	if (file_handle->opened_path) {
 		compiled_filename = zend_string_copy(file_handle->opened_path);
 	} else {
-		compiled_filename = zend_string_init(file_handle->filename, strlen(file_handle->filename), 0);
+		compiled_filename = zend_string_copy(file_handle->filename);
 	}
 
 	zend_set_compiled_filename(compiled_filename);
@@ -655,9 +647,9 @@ ZEND_API zend_op_array *compile_file(zend_file_handle *file_handle, int type)
 	if (open_file_for_scanning(file_handle)==FAILURE) {
 		if (!EG(exception)) {
 			if (type==ZEND_REQUIRE) {
-				zend_message_dispatcher(ZMSG_FAILED_REQUIRE_FOPEN, file_handle->filename);
+				zend_message_dispatcher(ZMSG_FAILED_REQUIRE_FOPEN, ZSTR_VAL(file_handle->filename));
 			} else {
-				zend_message_dispatcher(ZMSG_FAILED_INCLUDE_FOPEN, file_handle->filename);
+				zend_message_dispatcher(ZMSG_FAILED_INCLUDE_FOPEN, ZSTR_VAL(file_handle->filename));
 			}
 		}
 	} else {
@@ -715,7 +707,7 @@ zend_op_array *compile_filename(int type, zval *filename)
 		ZVAL_STR(&tmp, zval_get_string(filename));
 		filename = &tmp;
 	}
-	zend_stream_init_filename(&file_handle, Z_STRVAL_P(filename));
+	zend_stream_init_filename_ex(&file_handle, Z_STR_P(filename));
 
 	retval = zend_compile_file(&file_handle, type);
 	if (retval && file_handle.handle.stream.handle) {
@@ -837,6 +829,7 @@ zend_result highlight_file(const char *filename, zend_syntax_highlighter_ini *sy
 	zend_save_lexical_state(&original_lex_state);
 	if (open_file_for_scanning(&file_handle)==FAILURE) {
 		zend_message_dispatcher(ZMSG_FAILED_HIGHLIGHT_FOPEN, filename);
+		zend_destroy_file_handle(&file_handle);
 		zend_restore_lexical_state(&original_lex_state);
 		return FAILURE;
 	}

--- a/Zend/zend_llist.c
+++ b/Zend/zend_llist.c
@@ -112,6 +112,8 @@ ZEND_API void zend_llist_destroy(zend_llist *l)
 		current = next;
 	}
 
+	l->head  = NULL;
+	l->tail  = NULL;
 	l->count = 0;
 }
 

--- a/Zend/zend_stream.c
+++ b/Zend/zend_stream.c
@@ -64,25 +64,36 @@ ZEND_API void zend_stream_init_fp(zend_file_handle *handle, FILE *fp, const char
 	memset(handle, 0, sizeof(zend_file_handle));
 	handle->type = ZEND_HANDLE_FP;
 	handle->handle.fp = fp;
-	handle->filename = filename;
+	handle->filename = filename ? zend_string_init(filename, strlen(filename), 0) : NULL;
 }
 
 ZEND_API void zend_stream_init_filename(zend_file_handle *handle, const char *filename) {
 	memset(handle, 0, sizeof(zend_file_handle));
 	handle->type = ZEND_HANDLE_FILENAME;
-	handle->filename = filename;
+	handle->filename = filename ? zend_string_init(filename, strlen(filename), 0) : NULL;
 }
 
-ZEND_API zend_result zend_stream_open(const char *filename, zend_file_handle *handle) /* {{{ */
+ZEND_API void zend_stream_init_filename_ex(zend_file_handle *handle, zend_string *filename) {
+	memset(handle, 0, sizeof(zend_file_handle));
+	handle->type = ZEND_HANDLE_FILENAME;
+	handle->filename = zend_string_copy(filename);
+}
+
+ZEND_API zend_result zend_stream_open(zend_file_handle *handle) /* {{{ */
 {
 	zend_string *opened_path;
+
+	ZEND_ASSERT(handle->type == ZEND_HANDLE_FILENAME);
 	if (zend_stream_open_function) {
-		return zend_stream_open_function(filename, handle);
+		return zend_stream_open_function(handle);
 	}
 
-	zend_stream_init_fp(handle, zend_fopen(filename, &opened_path), filename);
-	handle->opened_path = opened_path;
-	return handle->handle.fp ? SUCCESS : FAILURE;
+	handle->handle.fp = zend_fopen(handle->filename, &opened_path);
+	if (!handle->handle.fp) {
+		return FAILURE;
+	}
+	handle->type = ZEND_HANDLE_FP;
+	return SUCCESS;
 } /* }}} */
 
 static int zend_stream_getc(zend_file_handle *file_handle) /* {{{ */
@@ -124,7 +135,7 @@ ZEND_API zend_result zend_stream_fixup(zend_file_handle *file_handle, char **buf
 	}
 
 	if (file_handle->type == ZEND_HANDLE_FILENAME) {
-		if (zend_stream_open(file_handle->filename, file_handle) == FAILURE) {
+		if (zend_stream_open(file_handle) == FAILURE) {
 			return FAILURE;
 		}
 	}
@@ -199,7 +210,7 @@ ZEND_API zend_result zend_stream_fixup(zend_file_handle *file_handle, char **buf
 	return SUCCESS;
 } /* }}} */
 
-ZEND_API void zend_file_handle_dtor(zend_file_handle *fh) /* {{{ */
+static void zend_file_handle_dtor(zend_file_handle *fh) /* {{{ */
 {
 	switch (fh->type) {
 		case ZEND_HANDLE_FP:
@@ -225,22 +236,22 @@ ZEND_API void zend_file_handle_dtor(zend_file_handle *fh) /* {{{ */
 		efree(fh->buf);
 		fh->buf = NULL;
 	}
-	if (fh->free_filename && fh->filename) {
-		efree((char*)fh->filename);
+	if (fh->filename) {
+		zend_string_release(fh->filename);
 		fh->filename = NULL;
 	}
 }
 /* }}} */
 
 /* return int to be compatible with Zend linked list API */
-ZEND_API int zend_compare_file_handles(zend_file_handle *fh1, zend_file_handle *fh2) /* {{{ */
+static int zend_compare_file_handles(zend_file_handle *fh1, zend_file_handle *fh2) /* {{{ */
 {
 	if (fh1->type != fh2->type) {
 		return 0;
 	}
 	switch (fh1->type) {
 		case ZEND_HANDLE_FILENAME:
-			return strcmp(fh1->filename, fh2->filename) == 0;
+			return zend_string_equals(fh1->filename, fh2->filename);
 		case ZEND_HANDLE_FP:
 			return fh1->handle.fp == fh2->handle.fp;
 		case ZEND_HANDLE_STREAM:
@@ -249,4 +260,26 @@ ZEND_API int zend_compare_file_handles(zend_file_handle *fh1, zend_file_handle *
 			return 0;
 	}
 	return 0;
+} /* }}} */
+
+ZEND_API void zend_destroy_file_handle(zend_file_handle *file_handle) /* {{{ */
+{
+	if (file_handle->in_list) {
+		zend_llist_del_element(&CG(open_files), file_handle, (int (*)(void *, void *)) zend_compare_file_handles);
+		/* zend_file_handle_dtor() operates on the copy, so we have to NULLify the original here */
+		file_handle->opened_path = NULL;
+		file_handle->filename = NULL;
+	} else {
+		zend_file_handle_dtor(file_handle);
+	}
+} /* }}} */
+
+void zend_stream_init(void) /* {{{ */
+{
+	zend_llist_init(&CG(open_files), sizeof(zend_file_handle), (void (*)(void *)) zend_file_handle_dtor, 0);
+} /* }}} */
+
+void zend_stream_shutdown(void) /* {{{ */
+{
+	zend_llist_destroy(&CG(open_files));
 } /* }}} */

--- a/Zend/zend_stream.h
+++ b/Zend/zend_stream.h
@@ -53,12 +53,11 @@ typedef struct _zend_file_handle {
 		FILE          *fp;
 		zend_stream   stream;
 	} handle;
-	const char        *filename;
+	zend_string       *filename;
 	zend_string       *opened_path;
-	zend_stream_type  type;
-	/* free_filename is used by wincache */
-	/* TODO: Clean up filename vs opened_path mess */
-	bool         free_filename;
+	zend_uchar        type; /* packed zend_stream_type */
+	bool              primary_script;
+	bool              in_list; /* added into CG(open_file) */
 	char              *buf;
 	size_t            len;
 } zend_file_handle;
@@ -66,10 +65,13 @@ typedef struct _zend_file_handle {
 BEGIN_EXTERN_C()
 ZEND_API void zend_stream_init_fp(zend_file_handle *handle, FILE *fp, const char *filename);
 ZEND_API void zend_stream_init_filename(zend_file_handle *handle, const char *filename);
-ZEND_API zend_result zend_stream_open(const char *filename, zend_file_handle *handle);
+ZEND_API void zend_stream_init_filename_ex(zend_file_handle *handle, zend_string *filename);
+ZEND_API zend_result zend_stream_open(zend_file_handle *handle);
 ZEND_API zend_result zend_stream_fixup(zend_file_handle *file_handle, char **buf, size_t *len);
-ZEND_API void zend_file_handle_dtor(zend_file_handle *fh);
-ZEND_API int zend_compare_file_handles(zend_file_handle *fh1, zend_file_handle *fh2);
+ZEND_API void zend_destroy_file_handle(zend_file_handle *file_handle);
+
+void zend_stream_init(void);
+void zend_stream_shutdown(void);
 END_EXTERN_C()
 
 #ifdef ZEND_WIN32

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -234,8 +234,8 @@ typedef struct _zend_accel_globals {
 	const zend_op          *cache_opline;
 	zend_persistent_script *cache_persistent_script;
 	/* preallocated buffer for keys */
-	int                     key_len;
-	char                    key[MAXPATHLEN * 8];
+	zend_string             key;
+	char                    _key[MAXPATHLEN * 8];
 } zend_accel_globals;
 
 typedef struct _zend_string_table {
@@ -317,11 +317,11 @@ void zend_accel_schedule_restart_if_necessary(zend_accel_restart_reason reason);
 accel_time_t zend_get_file_handle_timestamp(zend_file_handle *file_handle, size_t *size);
 int  validate_timestamp_and_record(zend_persistent_script *persistent_script, zend_file_handle *file_handle);
 int  validate_timestamp_and_record_ex(zend_persistent_script *persistent_script, zend_file_handle *file_handle);
-int  zend_accel_invalidate(const char *filename, size_t filename_len, bool force);
+int  zend_accel_invalidate(zend_string *filename, bool force);
 int  accelerator_shm_read_lock(void);
 void accelerator_shm_read_unlock(void);
 
-char *accel_make_persistent_key(const char *path, size_t path_length, int *key_len);
+zend_string *accel_make_persistent_key(zend_string *path);
 zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type);
 
 #define IS_ACCEL_INTERNED(str) \

--- a/ext/opcache/zend_accelerator_hash.c
+++ b/ext/opcache/zend_accelerator_hash.c
@@ -200,32 +200,6 @@ zend_accel_hash_entry* zend_accel_hash_find_entry(zend_accel_hash *accel_hash, z
 		0);
 }
 
-/* Returns the data associated with key on success
- * Returns NULL if data doesn't exist
- */
-void* zend_accel_hash_str_find(zend_accel_hash *accel_hash, const char *key, uint32_t key_length)
-{
-	return zend_accel_hash_find_ex(
-		accel_hash,
-		key,
-		key_length,
-		zend_inline_hash_func(key, key_length),
-		1);
-}
-
-/* Returns the hash entry associated with key on success
- * Returns NULL if it doesn't exist
- */
-zend_accel_hash_entry* zend_accel_hash_str_find_entry(zend_accel_hash *accel_hash, const char *key, uint32_t key_length)
-{
-	return (zend_accel_hash_entry *)zend_accel_hash_find_ex(
-		accel_hash,
-		key,
-		key_length,
-		zend_inline_hash_func(key, key_length),
-		0);
-}
-
 int zend_accel_hash_unlink(zend_accel_hash *accel_hash, const char *key, uint32_t key_length)
 {
     zend_ulong hash_value;

--- a/ext/opcache/zend_accelerator_hash.h
+++ b/ext/opcache/zend_accelerator_hash.h
@@ -79,16 +79,6 @@ zend_accel_hash_entry* zend_accel_hash_find_entry(
 		zend_accel_hash        *accel_hash,
 		zend_string            *key);
 
-void* zend_accel_hash_str_find(
-		zend_accel_hash        *accel_hash,
-		const char             *key,
-		uint32_t               key_length);
-
-zend_accel_hash_entry* zend_accel_hash_str_find_entry(
-		zend_accel_hash        *accel_hash,
-		const char             *key,
-		uint32_t               key_length);
-
 int zend_accel_hash_unlink(
 		zend_accel_hash        *accel_hash,
 		const char             *key,

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -310,17 +310,21 @@ ZEND_INI_END()
 
 static int filename_is_in_cache(zend_string *filename)
 {
-	char *key;
-	int key_length;
+	zend_string *key;
 
-	key = accel_make_persistent_key(ZSTR_VAL(filename), ZSTR_LEN(filename), &key_length);
+	key = accel_make_persistent_key(filename);
 	if (key != NULL) {
-		zend_persistent_script *persistent_script = zend_accel_hash_str_find(&ZCSG(hash), key, key_length);
+		zend_persistent_script *persistent_script = zend_accel_hash_find(&ZCSG(hash), key);
 		if (persistent_script && !persistent_script->corrupted) {
 			if (ZCG(accel_directives).validate_timestamps) {
 				zend_file_handle handle;
-				zend_stream_init_filename(&handle, ZSTR_VAL(filename));
-				return validate_timestamp_and_record_ex(persistent_script, &handle) == SUCCESS;
+				int ret;
+
+				zend_stream_init_filename_ex(&handle, filename);
+				ret = validate_timestamp_and_record_ex(persistent_script, &handle) == SUCCESS
+					? 1 : 0;
+				zend_destroy_file_handle(&handle);
+				return ret;
 			}
 
 			return 1;
@@ -836,11 +840,10 @@ ZEND_FUNCTION(opcache_reset)
 /* {{{ Invalidates cached script (in necessary or forced) */
 ZEND_FUNCTION(opcache_invalidate)
 {
-	char *script_name;
-	size_t script_name_len;
+	zend_string *script_name;
 	bool force = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|b", &script_name, &script_name_len, &force) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|b", &script_name, &force) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -848,7 +851,7 @@ ZEND_FUNCTION(opcache_invalidate)
 		RETURN_FALSE;
 	}
 
-	if (zend_accel_invalidate(script_name, script_name_len, force) == SUCCESS) {
+	if (zend_accel_invalidate(script_name, force) == SUCCESS) {
 		RETURN_TRUE;
 	} else {
 		RETURN_FALSE;
@@ -857,14 +860,13 @@ ZEND_FUNCTION(opcache_invalidate)
 
 ZEND_FUNCTION(opcache_compile_file)
 {
-	char *script_name;
-	size_t script_name_len;
+	zend_string *script_name;
 	zend_file_handle handle;
 	zend_op_array *op_array = NULL;
 	zend_execute_data *orig_execute_data = NULL;
 	uint32_t orig_compiler_options;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &script_name, &script_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &script_name) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -873,7 +875,7 @@ ZEND_FUNCTION(opcache_compile_file)
 		RETURN_FALSE;
 	}
 
-	zend_stream_init_filename(&handle, script_name);
+	zend_stream_init_filename_ex(&handle, script_name);
 
 	orig_execute_data = EG(current_execute_data);
 	orig_compiler_options = CG(compiler_options);
@@ -889,7 +891,7 @@ ZEND_FUNCTION(opcache_compile_file)
 			op_array = persistent_compile_file(&handle, ZEND_INCLUDE);
 		} zend_catch {
 			EG(current_execute_data) = orig_execute_data;
-			zend_error(E_WARNING, ACCELERATOR_PRODUCT_NAME " could not compile file %s", handle.filename);
+			zend_error(E_WARNING, ACCELERATOR_PRODUCT_NAME " could not compile file %s", ZSTR_VAL(handle.filename));
 		} zend_end_try();
 	}
 

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1247,7 +1247,7 @@ static void zend_persist_warnings(zend_persistent_script *script) {
 	}
 }
 
-zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script, const char **key, unsigned int key_length, int for_shm)
+zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script, int for_shm)
 {
 	Bucket *p;
 
@@ -1256,10 +1256,6 @@ zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script
 	ZEND_ASSERT(((zend_uintptr_t)ZCG(mem) & 0x7) == 0); /* should be 8 byte aligned */
 
 	script = zend_shared_memdup_free(script, sizeof(zend_persistent_script));
-	if (key && *key) {
-		*key = zend_shared_memdup_put((void*)*key, key_length + 1);
-	}
-
 	script->corrupted = 0;
 	ZCG(current_persistent_script) = script;
 

--- a/ext/opcache/zend_persist.h
+++ b/ext/opcache/zend_persist.h
@@ -22,8 +22,8 @@
 #ifndef ZEND_PERSIST_H
 #define ZEND_PERSIST_H
 
-uint32_t zend_accel_script_persist_calc(zend_persistent_script *script, const char *key, unsigned int key_length, int for_shm);
-zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script, const char **key, unsigned int key_length, int for_shm);
+uint32_t zend_accel_script_persist_calc(zend_persistent_script *script, int for_shm);
+zend_persistent_script *zend_accel_script_persist(zend_persistent_script *script, int for_shm);
 
 void zend_persist_class_entry_calc(zend_class_entry *ce);
 zend_class_entry *zend_persist_class_entry(zend_class_entry *ce);

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -558,7 +558,7 @@ static void zend_persist_warnings_calc(zend_persistent_script *script) {
 	}
 }
 
-uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_script, const char *key, unsigned int key_length, int for_shm)
+uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_script, int for_shm)
 {
 	Bucket *p;
 
@@ -573,10 +573,6 @@ uint32_t zend_accel_script_persist_calc(zend_persistent_script *new_persistent_s
 	}
 
 	ADD_SIZE(sizeof(zend_persistent_script));
-	if (key) {
-		ADD_SIZE(key_length + 1);
-		zend_shared_alloc_register_xlat_entry(key, key);
-	}
 	ADD_STRING(new_persistent_script->script.filename);
 
 #if defined(__AVX__) || defined(__SSE2__)

--- a/ext/phar/phar_internal.h
+++ b/ext/phar/phar_internal.h
@@ -475,10 +475,6 @@ union _phar_entry_object {
 	phar_entry_info          *entry;
 };
 
-#ifndef PHAR_MAIN
-extern zend_string *(*phar_save_resolve_path)(const char *filename, size_t filename_len);
-#endif
-
 BEGIN_EXTERN_C()
 
 #ifdef PHP_WIN32

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -247,13 +247,12 @@ static int phar_file_action(phar_archive_data *phar, phar_entry_info *info, char
 				if (!new_op_array) {
 					zend_hash_str_del(&EG(included_files), name, name_len);
 				}
-
-				zend_destroy_file_handle(&file_handle);
-
 			} else {
 				efree(name);
 				new_op_array = NULL;
 			}
+
+			zend_destroy_file_handle(&file_handle);
 #ifdef PHP_WIN32
 			efree(arch);
 #endif

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -253,7 +253,7 @@ zend_string *phar_find_in_include_path(char *filename, size_t filename_len, phar
 	}
 
 	if (!zend_is_executing() || !PHAR_G(cwd)) {
-		return phar_save_resolve_path(filename, filename_len);
+		return NULL;
 	}
 
 	fname = (char*)zend_get_executed_filename();
@@ -267,7 +267,7 @@ zend_string *phar_find_in_include_path(char *filename, size_t filename_len, phar
 	}
 
 	if (fname_len < 7 || memcmp(fname, "phar://", 7) || SUCCESS != phar_split_fname(fname, strlen(fname), &arch, &arch_len, &entry, &entry_len, 1, 0)) {
-		return phar_save_resolve_path(filename, filename_len);
+		return NULL;
 	}
 
 	efree(entry);
@@ -277,7 +277,7 @@ zend_string *phar_find_in_include_path(char *filename, size_t filename_len, phar
 
 		if (FAILURE == phar_get_archive(&phar, arch, arch_len, NULL, 0, NULL)) {
 			efree(arch);
-			return phar_save_resolve_path(filename, filename_len);
+			return NULL;
 		}
 splitted:
 		if (pphar) {

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -598,8 +598,10 @@ static int readline_shell_run(void) /* {{{ */
 
 	if (PG(auto_prepend_file) && PG(auto_prepend_file)[0]) {
 		zend_file_handle prepend_file;
+
 		zend_stream_init_filename(&prepend_file, PG(auto_prepend_file));
 		zend_execute_scripts(ZEND_REQUIRE, NULL, 1, &prepend_file);
+		zend_destroy_file_handle(&prepend_file);
 	}
 
 #ifndef PHP_WIN32

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -239,20 +239,19 @@ PHP_FUNCTION(spl_classes)
 
 static int spl_autoload(zend_string *class_name, zend_string *lc_name, const char *ext, int ext_len) /* {{{ */
 {
-	char *class_file;
-	int class_file_len;
+	zend_string *class_file;
 	zval dummy;
 	zend_file_handle file_handle;
 	zend_op_array *new_op_array;
 	zval result;
 	int ret;
 
-	class_file_len = (int)spprintf(&class_file, 0, "%s%.*s", ZSTR_VAL(lc_name), ext_len, ext);
+	class_file = zend_strpprintf(0, "%s%.*s", ZSTR_VAL(lc_name), ext_len, ext);
 
 #if DEFAULT_SLASH != '\\'
 	{
-		char *ptr = class_file;
-		char *end = ptr + class_file_len;
+		char *ptr = ZSTR_VAL(class_file);
+		char *end = ptr + ZSTR_LEN(class_file);
 
 		while ((ptr = memchr(ptr, '\\', (end - ptr))) != NULL) {
 			*ptr = DEFAULT_SLASH;
@@ -260,21 +259,20 @@ static int spl_autoload(zend_string *class_name, zend_string *lc_name, const cha
 	}
 #endif
 
-	ret = php_stream_open_for_zend_ex(class_file, &file_handle, USE_PATH|STREAM_OPEN_FOR_INCLUDE);
+	zend_stream_init_filename_ex(&file_handle, class_file);
+	ret = php_stream_open_for_zend_ex(&file_handle, USE_PATH|STREAM_OPEN_FOR_INCLUDE);
 
 	if (ret == SUCCESS) {
 		zend_string *opened_path;
 		if (!file_handle.opened_path) {
-			file_handle.opened_path = zend_string_init(class_file, class_file_len, 0);
+			file_handle.opened_path = zend_string_copy(class_file);
 		}
 		opened_path = zend_string_copy(file_handle.opened_path);
 		ZVAL_NULL(&dummy);
 		if (zend_hash_add(&EG(included_files), opened_path, &dummy)) {
 			new_op_array = zend_compile_file(&file_handle, ZEND_REQUIRE);
-			zend_destroy_file_handle(&file_handle);
 		} else {
 			new_op_array = NULL;
-			zend_file_handle_dtor(&file_handle);
 		}
 		zend_string_release_ex(opened_path, 0);
 		if (new_op_array) {
@@ -287,11 +285,13 @@ static int spl_autoload(zend_string *class_name, zend_string *lc_name, const cha
 				zval_ptr_dtor(&result);
 			}
 
-			efree(class_file);
+			zend_destroy_file_handle(&file_handle);
+			zend_string_release(class_file);
 			return zend_hash_exists(EG(class_table), lc_name);
 		}
 	}
-	efree(class_file);
+	zend_destroy_file_handle(&file_handle);
+	zend_string_release(class_file);
 	return 0;
 } /* }}} */
 

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -406,16 +406,18 @@ static int browscap_read_file(char *filename, browser_data *browdata, int persis
 {
 	zend_file_handle fh;
 	browscap_parser_ctx ctx = {0};
+	FILE *fp;
 
 	if (filename == NULL || filename[0] == '\0') {
 		return FAILURE;
 	}
 
-	zend_stream_init_fp(&fh, VCWD_FOPEN(filename, "r"), filename);
-	if (!fh.handle.fp) {
+	fp = VCWD_FOPEN(filename, "r");
+	if (!fp) {
 		zend_error(E_CORE_WARNING, "Cannot open \"%s\" for reading", filename);
 		return FAILURE;
 	}
+	zend_stream_init_fp(&fh, fp, filename);
 
 	browdata->htab = pemalloc(sizeof *browdata->htab, persistent);
 	zend_hash_init(browdata->htab, 0, NULL,
@@ -439,6 +441,7 @@ static int browscap_read_file(char *filename, browser_data *browdata, int persis
 		zend_string_release(ctx.current_section_name);
 	}
 	zend_hash_destroy(&ctx.str_interned);
+	zend_destroy_file_handle(&fh);
 
 	return SUCCESS;
 }

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1525,15 +1525,14 @@ PHP_FUNCTION(stream_socket_enable_crypto)
 /* {{{ Determine what file will be opened by calls to fopen() with a relative path */
 PHP_FUNCTION(stream_resolve_include_path)
 {
-	char *filename;
-	size_t filename_len;
+	zend_string *filename;
 	zend_string *resolved_path;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_PATH(filename, filename_len)
+		Z_PARAM_PATH_STR(filename)
 	ZEND_PARSE_PARAMETERS_END();
 
-	resolved_path = zend_resolve_path(filename, filename_len);
+	resolved_path = zend_resolve_path(filename);
 
 	if (resolved_path) {
 		RETURN_STR(resolved_path);

--- a/main/main.c
+++ b/main/main.c
@@ -1442,9 +1442,10 @@ PHP_FUNCTION(set_time_limit)
 /* }}} */
 
 /* {{{ php_fopen_wrapper_for_zend */
-static FILE *php_fopen_wrapper_for_zend(const char *filename, zend_string **opened_path)
+static FILE *php_fopen_wrapper_for_zend(zend_string *filename, zend_string **opened_path)
 {
-	return php_stream_open_wrapper_as_file((char *)filename, "rb", USE_PATH|REPORT_ERRORS|STREAM_OPEN_FOR_INCLUDE, opened_path);
+	*opened_path = filename;
+	return php_stream_open_wrapper_as_file(ZSTR_VAL(filename), "rb", USE_PATH|REPORT_ERRORS|STREAM_OPEN_FOR_INCLUDE|STREAM_OPEN_FOR_ZEND_STREAM, opened_path);
 }
 /* }}} */
 
@@ -1472,20 +1473,25 @@ static size_t php_zend_stream_fsizer(void *handle) /* {{{ */
 }
 /* }}} */
 
-static zend_result php_stream_open_for_zend(const char *filename, zend_file_handle *handle) /* {{{ */
+static zend_result php_stream_open_for_zend(zend_file_handle *handle) /* {{{ */
 {
-	return php_stream_open_for_zend_ex(filename, handle, USE_PATH|REPORT_ERRORS|STREAM_OPEN_FOR_INCLUDE);
+	return php_stream_open_for_zend_ex(handle, USE_PATH|REPORT_ERRORS|STREAM_OPEN_FOR_INCLUDE);
 }
 /* }}} */
 
-PHPAPI zend_result php_stream_open_for_zend_ex(const char *filename, zend_file_handle *handle, int mode) /* {{{ */
+PHPAPI zend_result php_stream_open_for_zend_ex(zend_file_handle *handle, int mode) /* {{{ */
 {
 	zend_string *opened_path;
-	php_stream *stream = php_stream_open_wrapper((char *)filename, "rb", mode, &opened_path);
+	zend_string *filename;
+	php_stream *stream;
+
+	ZEND_ASSERT(handle->type == ZEND_HANDLE_FILENAME);
+	opened_path = filename = handle->filename;
+	stream = php_stream_open_wrapper((char *)ZSTR_VAL(filename), "rb", mode | STREAM_OPEN_FOR_ZEND_STREAM, &opened_path);
 	if (stream) {
 		memset(handle, 0, sizeof(zend_file_handle));
 		handle->type = ZEND_HANDLE_STREAM;
-		handle->filename = (char*)filename;
+		handle->filename = filename;
 		handle->opened_path = opened_path;
 		handle->handle.stream.handle  = stream;
 		handle->handle.stream.reader  = (zend_stream_reader_t)_php_stream_read;
@@ -1503,9 +1509,9 @@ PHPAPI zend_result php_stream_open_for_zend_ex(const char *filename, zend_file_h
 }
 /* }}} */
 
-static zend_string *php_resolve_path_for_zend(const char *filename, size_t filename_len) /* {{{ */
+static zend_string *php_resolve_path_for_zend(zend_string *filename) /* {{{ */
 {
-	return php_resolve_path(filename, filename_len, PG(include_path));
+	return php_resolve_path(ZSTR_VAL(filename), ZSTR_LEN(filename), PG(include_path));
 }
 /* }}} */
 
@@ -2142,9 +2148,11 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	/* this will read in php.ini, set up the configuration parameters,
 	   load zend extensions and register php function extensions
 	   to be loaded later */
+	zend_stream_init();
 	if (php_init_config() == FAILURE) {
 		return FAILURE;
 	}
+	zend_stream_shutdown();
 
 	/* Register PHP core ini entries */
 	REGISTER_INI_ENTRIES();
@@ -2450,18 +2458,18 @@ PHPAPI int php_execute_script(zend_file_handle *primary_file)
 #else
 			php_ignore_value(VCWD_GETCWD(old_cwd, OLD_CWD_SIZE-1));
 #endif
-			VCWD_CHDIR_FILE(primary_file->filename);
+			VCWD_CHDIR_FILE(ZSTR_VAL(primary_file->filename));
 		}
 
  		/* Only lookup the real file path and add it to the included_files list if already opened
 		 *   otherwise it will get opened and added to the included_files list in zend_execute_scripts
 		 */
- 		if (primary_file->filename &&
- 		    strcmp("Standard input code", primary_file->filename) &&
+		if (primary_file->filename &&
+		    strcmp("Standard input code", ZSTR_VAL(primary_file->filename)) &&
  			primary_file->opened_path == NULL &&
  			primary_file->type != ZEND_HANDLE_FILENAME
 		) {
-			if (expand_filepath(primary_file->filename, realfile)) {
+			if (expand_filepath(ZSTR_VAL(primary_file->filename), realfile)) {
 				primary_file->opened_path = zend_string_init(realfile, strlen(realfile), 0);
 				zend_hash_add_empty_element(&EG(included_files), primary_file->opened_path);
 			}
@@ -2489,6 +2497,14 @@ PHPAPI int php_execute_script(zend_file_handle *primary_file)
 
 		retval = (zend_execute_scripts(ZEND_REQUIRE, NULL, 3, prepend_file_p, primary_file, append_file_p) == SUCCESS);
 	} zend_end_try();
+
+	if (prepend_file_p) {
+		zend_destroy_file_handle(prepend_file_p);
+	}
+
+	if (append_file_p) {
+		zend_destroy_file_handle(append_file_p);
+	}
 
 	if (EG(exception)) {
 		zend_try {
@@ -2533,7 +2549,7 @@ PHPAPI int php_execute_simple_script(zend_file_handle *primary_file, zval *ret)
 
 		if (primary_file->filename && !(SG(options) & SAPI_OPTION_NO_CHDIR)) {
 			php_ignore_value(VCWD_GETCWD(old_cwd, OLD_CWD_SIZE-1));
-			VCWD_CHDIR_FILE(primary_file->filename);
+			VCWD_CHDIR_FILE(ZSTR_VAL(primary_file->filename));
 		}
 		zend_execute_scripts(ZEND_REQUIRE, ret, 1, primary_file);
 	} zend_end_try();
@@ -2609,7 +2625,6 @@ PHPAPI int php_lint_script(zend_file_handle *file)
 
 	zend_try {
 		op_array = zend_compile_file(file, ZEND_INCLUDE);
-		zend_destroy_file_handle(file);
 
 		if (op_array) {
 			destroy_op_array(op_array);

--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -771,7 +771,7 @@ PHPAPI int php_parse_user_ini_file(const char *dirname, const char *ini_filename
 	if (VCWD_STAT(ini_file, &sb) == 0) {
 		if (S_ISREG(sb.st_mode)) {
 			zend_file_handle fh;
-			int ret;
+			int ret = FAILURE;
 
 			zend_stream_init_fp(&fh, VCWD_FOPEN(ini_file, "r"), ini_file);
 			if (fh.handle.fp) {

--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -616,15 +616,14 @@ int php_init_config(void)
 		{
 			zval tmp;
 
-			ZVAL_NEW_STR(&tmp, zend_string_init(fh.filename, strlen(fh.filename), 1));
+			ZVAL_NEW_STR(&tmp, zend_string_init(filename, strlen(filename), 1));
 			zend_hash_str_update(&configuration_hash, "cfg_file_path", sizeof("cfg_file_path")-1, &tmp);
 			if (opened_path) {
 				zend_string_release_ex(opened_path, 0);
-			} else {
-				efree((char *)fh.filename);
 			}
 			php_ini_opened_path = zend_strndup(Z_STRVAL(tmp), Z_STRLEN(tmp));
 		}
+		zend_destroy_file_handle(&fh);
 	}
 
 	/* Check for PHP_INI_SCAN_DIR environment variable to override/set config file scan directory */
@@ -693,6 +692,7 @@ int php_init_config(void)
 									zend_llist_add_element(&scanned_ini_list, &p);
 								}
 							}
+							zend_destroy_file_handle(&fh);
 						}
 					}
 					free(namelist[i]);
@@ -771,17 +771,20 @@ PHPAPI int php_parse_user_ini_file(const char *dirname, const char *ini_filename
 	if (VCWD_STAT(ini_file, &sb) == 0) {
 		if (S_ISREG(sb.st_mode)) {
 			zend_file_handle fh;
+			int ret;
+
 			zend_stream_init_fp(&fh, VCWD_FOPEN(ini_file, "r"), ini_file);
 			if (fh.handle.fp) {
 				/* Reset active ini section */
 				RESET_ACTIVE_INI_HASH();
 
-				if (zend_parse_ini_file(&fh, 1, ZEND_INI_SCANNER_NORMAL, (zend_ini_parser_cb_t) php_ini_parser_cb, target_hash) == SUCCESS) {
+				ret = zend_parse_ini_file(&fh, 1, ZEND_INI_SCANNER_NORMAL, (zend_ini_parser_cb_t) php_ini_parser_cb, target_hash);
+				if (ret == SUCCESS) {
 					/* FIXME: Add parsed file to the list of user files read? */
-					return SUCCESS;
 				}
-				return FAILURE;
 			}
+			zend_destroy_file_handle(&fh);
+			return ret;
 		}
 	}
 	return FAILURE;

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -40,7 +40,7 @@ PHPAPI void php_handle_aborted_connection(void);
 PHPAPI int php_handle_auth_data(const char *auth);
 
 PHPAPI void php_html_puts(const char *str, size_t siz);
-PHPAPI int php_stream_open_for_zend_ex(const char *filename, zend_file_handle *handle, int mode);
+PHPAPI int php_stream_open_for_zend_ex(zend_file_handle *handle, int mode);
 
 /* environment module */
 extern int php_init_environ(void);

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -554,6 +554,9 @@ END_EXTERN_C()
 /* Allow blocking reads on anonymous pipes on Windows. */
 #define STREAM_USE_BLOCKING_PIPE        0x00008000
 
+/* this flag is only used by include/require functions */
+#define STREAM_OPEN_FOR_ZEND_STREAM     0x00010000
+
 int php_init_stream_wrappers(int module_number);
 int php_shutdown_stream_wrappers(int module_number);
 void php_shutdown_stream_hashes(void);

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2043,10 +2043,14 @@ PHPAPI php_stream *_php_stream_open_wrapper_ex(const char *path, const char *mod
 	php_stream_wrapper *wrapper = NULL;
 	const char *path_to_open;
 	int persistent = options & STREAM_OPEN_PERSISTENT;
+	zend_string *path_str = NULL;
 	zend_string *resolved_path = NULL;
 	char *copy_of_path = NULL;
 
 	if (opened_path) {
+		if (options & STREAM_OPEN_FOR_ZEND_STREAM) {
+			path_str = *opened_path;
+		}
 		*opened_path = NULL;
 	}
 
@@ -2056,7 +2060,11 @@ PHPAPI php_stream *_php_stream_open_wrapper_ex(const char *path, const char *mod
 	}
 
 	if (options & USE_PATH) {
-		resolved_path = zend_resolve_path(path, strlen(path));
+		if (path_str) {
+			resolved_path = zend_resolve_path(path_str);
+		} else {
+			resolved_path = php_resolve_path(path, strlen(path), PG(include_path));
+		}
 		if (resolved_path) {
 			path = ZSTR_VAL(resolved_path);
 			/* we've found this file, don't re-check include_path or run realpath */

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -699,12 +699,14 @@ zend_first_try {
 	} else {
 		zend_file_handle zfd;
 		zend_stream_init_filename(&zfd, (char *) r->filename);
+		zfd.primary_script = 1;
 
 		if (!parent_req) {
 			php_execute_script(&zfd);
 		} else {
 			zend_execute_scripts(ZEND_INCLUDE, NULL, 1, &zfd);
 		}
+		zend_destroy_file_handle(&zfd);
 
 		apr_table_set(r->notes, "mod_php_memory_usage",
 			apr_psprintf(ctx->r->pool, "%" APR_SIZE_T_FMT, zend_memory_peak_usage(1)));

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2015,9 +2015,11 @@ static int php_cli_server_dispatch_script(php_cli_server *server, php_cli_server
 	{
 		zend_file_handle zfd;
 		zend_stream_init_filename(&zfd, SG(request_info).path_translated);
+		zfd.primary_script = 1;
 		zend_try {
 			php_execute_script(&zfd);
 		} zend_end_try();
+		zend_destroy_file_handle(&zfd);
 	}
 
 	php_cli_server_log_response(client, SG(sapi_headers).http_response_code, NULL);
@@ -2136,6 +2138,7 @@ static int php_cli_server_dispatch_router(php_cli_server *server, php_cli_server
 	php_ignore_value(VCWD_GETCWD(old_cwd, MAXPATHLEN - 1));
 
 	zend_stream_init_filename(&zfd, server->router);
+	zfd.primary_script = 1;
 
 	zend_try {
 		zval retval;
@@ -2148,6 +2151,8 @@ static int php_cli_server_dispatch_router(php_cli_server *server, php_cli_server
 			}
 		}
 	} zend_end_try();
+
+	zend_destroy_file_handle(&zfd);
 
 	if (old_cwd[0] != '\0') {
 		php_ignore_value(VCWD_CHDIR(old_cwd));

--- a/sapi/fuzzer/fuzzer-sapi.c
+++ b/sapi/fuzzer/fuzzer-sapi.c
@@ -250,6 +250,7 @@ int fuzzer_do_request_from_buffer(
 	zend_first_try {
 		zend_file_handle file_handle;
 		zend_stream_init_filename(&file_handle, filename);
+		file_handle.primary_script = 1;
 		file_handle.buf = estrndup(data, data_len);
 		file_handle.len = data_len;
 
@@ -261,6 +262,7 @@ int fuzzer_do_request_from_buffer(
 			destroy_op_array(op_array);
 			efree(op_array);
 		}
+		zend_destroy_file_handle(&file_handle);
 	} zend_end_try();
 
 	CG(compiled_filename) = NULL; /* ??? */

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -1309,7 +1309,7 @@ static int cli_main( int argc, char * argv[] )
         }
         if ( ret == -1 ) {
             if ( *p ) {
-                zend_file_handle file_handle;
+				zend_file_handle file_handle;
 				zend_stream_init_fp(&file_handle, VCWD_FOPEN(*p, "rb"), NULL);
 				file_handle.primary_script = 1;
 

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -643,11 +643,13 @@ static void init_request_info( void )
     php_handle_auth_data(pAuth);
 }
 
-static int lsapi_execute_script( zend_file_handle * file_handle)
+static int lsapi_execute_script(void)
 {
+	zend_file_handle file_handle;
     char *p;
     int len;
-	zend_stream_init_filename(file_handle, SG(request_info).path_translated);
+	zend_stream_init_filename(&file_handle, SG(request_info).path_translated);
+	file_handle->primary_script = 1;
 
     p = argv0;
     *p++ = ':';
@@ -658,7 +660,8 @@ static int lsapi_execute_script( zend_file_handle * file_handle)
         len = 0;
     memccpy( p, SG(request_info).path_translated + len, 0, 46 );
 
-    php_execute_script(file_handle);
+    php_execute_script(&file_handle);
+    zend_destroy_file_handle(&file_handle);
     return 0;
 
 }
@@ -740,8 +743,6 @@ static int lsapi_module_main(int show_source)
 {
     struct sigaction act;
     int sa_rc;
-    zend_file_handle file_handle;
-    memset(&file_handle, 0, sizeof(file_handle));
     if (php_request_startup() == FAILURE ) {
         return -1;
     }
@@ -767,7 +768,7 @@ static int lsapi_module_main(int show_source)
         php_get_highlight_struct(&syntax_highlighter_ini);
         highlight_file(SG(request_info).path_translated, &syntax_highlighter_ini);
     } else {
-        lsapi_execute_script( &file_handle);
+        lsapi_execute_script();
     }
     zend_try {
         php_request_shutdown(NULL);
@@ -1310,6 +1311,7 @@ static int cli_main( int argc, char * argv[] )
             if ( *p ) {
                 zend_file_handle file_handle;
 				zend_stream_init_fp(&file_handle, VCWD_FOPEN(*p, "rb"), NULL);
+				file_handle.primary_script = 1;
 
                 if ( file_handle.handle.fp ) {
                     script_filename = *p;
@@ -1329,8 +1331,7 @@ static int cli_main( int argc, char * argv[] )
                             php_get_highlight_struct(&syntax_highlighter_ini);
                             highlight_file(SG(request_info).path_translated, &syntax_highlighter_ini);
                         } else if (source_highlight == 2) {
-                            file_handle.filename = *p;
-                            file_handle.free_filename = 0;
+                            file_handle.filename = zend_string_init(*p, strlen(*p), 0);
                             file_handle.opened_path = NULL;
                             ret = php_lint_script(&file_handle);
                             if (ret==SUCCESS) {
@@ -1340,8 +1341,7 @@ static int cli_main( int argc, char * argv[] )
                             }
 
                         } else {
-                            file_handle.filename = *p;
-                            file_handle.free_filename = 0;
+                            file_handle.filename = zend_string_init(*p, strlen(*p), 0);
                             file_handle.opened_path = NULL;
 
                             php_execute_script(&file_handle);

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -566,7 +566,8 @@ int phpdbg_compile(void) /* {{{ */
 		return FAILURE;
 	}
 
-	if (php_stream_open_for_zend_ex(PHPDBG_G(exec), &fh, USE_PATH|STREAM_OPEN_FOR_INCLUDE) == SUCCESS && zend_stream_fixup(&fh, &buf, &len) == SUCCESS) {
+	zend_stream_init_filename(&fh, PHPDBG_G(exec));
+	if (php_stream_open_for_zend_ex(&fh, USE_PATH|STREAM_OPEN_FOR_INCLUDE) == SUCCESS && zend_stream_fixup(&fh, &buf, &len) == SUCCESS) {
 		CG(skip_shebang) = 1;
 		PHPDBG_G(ops) = zend_compile_file(&fh, ZEND_INCLUDE);
 		zend_destroy_file_handle(&fh);
@@ -581,7 +582,7 @@ int phpdbg_compile(void) /* {{{ */
 	} else {
 		phpdbg_error("compile", "type=\"openfailure\" context=\"%s\"", "Could not open file %s", PHPDBG_G(exec));
 	}
-
+	zend_destroy_file_handle(&fh);
 	return FAILURE;
 } /* }}} */
 


### PR DESCRIPTION
This allows to eliminate re-calculation of string lenght and hash value.
The detailed list of changes:

- zend_file_handle.filename now is zend_string*
- zend_file_handle.free_filename is removed. Now zend_file_handle.filename is always released.
- added zend_file_handle.primary_script flag. SAPIs should set it for main executed script.
- added zend_file_handle.in_list flag, that is set when file_handle added into CG(open_files)
- added zend_stream_init_filename_ex() function, that takes filename as zend_string*
- in functions zend_stream_open(), php_stream_open_for_zend_ex() and zend_stream_open_function() callback "filename" argument is removed (it's passed as a field of file_handle)
- in zend_fopen() and zend_resolve_path() callbacks filename now passed as zend_string*
- file_handles should be destroyed by zend_destroy_file_handle() function (usually in the same function the same function where they were created by zend_stream_init_*()). Previously there were two different destructors zend_destroy_file_handle() and zend_file_handle_dtor().
- zend_ini_scanner_globals.filename now is zend_string*
