### PR TITLE
Fix DATE_FORMAT_COOKIE definition

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -368,7 +368,7 @@ PHP_RSHUTDOWN_FUNCTION(date)
  * http://msdn.microsoft.com/en-us/library/windows/desktop/aa384321%28v=vs.85%29.aspx
  * and http://curl.haxx.se/rfc/cookie_spec.html
  */
-#define DATE_FORMAT_COOKIE   "l, d-M-Y H:i:s T"
+#define DATE_FORMAT_COOKIE   "D, d-M-Y H:i:s T"
 
 #define SUNFUNCS_RET_TIMESTAMP 0
 #define SUNFUNCS_RET_STRING    1

--- a/ext/date/tests/DateTime_format_basic2.phpt
+++ b/ext/date/tests/DateTime_format_basic2.phpt
@@ -24,7 +24,7 @@ var_dump( $date->format( DateTime::W3C) ) ;
 --EXPECT--
 *** Testing date_format() : basic functionality - formatting coinstants ***
 string(25) "2005-07-14T22:30:41+01:00"
-string(34) "Thursday, 14-Jul-2005 22:30:41 BST"
+string(29) "Thu, 14-Jul-2005 22:30:41 BST"
 string(24) "2005-07-14T22:30:41+0100"
 string(29) "Thu, 14 Jul 05 22:30:41 +0100"
 string(32) "Thursday, 14-Jul-05 22:30:41 BST"

--- a/ext/date/tests/bug52063.phpt
+++ b/ext/date/tests/bug52063.phpt
@@ -11,5 +11,5 @@ echo $a->format(DateTime::COOKIE);
 echo "\n";
 ?>
 --EXPECT--
-Thursday, 01-Jan-2009 00:00:00 WET
-Thursday, 01-Jan-2009 00:00:00 WET
+Thu, 01-Jan-2009 00:00:00 WET
+Thu, 01-Jan-2009 00:00:00 WET

--- a/ext/date/tests/date_constants.phpt
+++ b/ext/date/tests/date_constants.phpt
@@ -41,8 +41,8 @@ Date constants
 --EXPECT--
 string(25) "2006-07-01T14:27:30+02:00"
 string(25) "2006-05-30T14:32:13+02:00"
-string(35) "Saturday, 01-Jul-2006 14:27:30 CEST"
-string(34) "Tuesday, 30-May-2006 14:32:13 CEST"
+string(30) "Sat, 01-Jul-2006 14:27:30 CEST"
+string(30) "Tue, 30-May-2006 14:32:13 CEST"
 string(24) "2006-07-01T14:27:30+0200"
 string(24) "2006-05-30T14:32:13+0200"
 string(29) "Sat, 01 Jul 06 14:27:30 +0200"

--- a/ext/date/tests/gmdate_variation13.phpt
+++ b/ext/date/tests/gmdate_variation13.phpt
@@ -39,7 +39,7 @@ string(25) "2008-08-08T08:08:08+00:00"
 string(%d) "%s"
 
 --DATE_COOKIE Constant--
-string(32) "Friday, 08-Aug-2008 08:08:08 GMT"
+string(29) "Fri, 08-Aug-2008 08:08:08 GMT"
 string(%d) "%s"
 
 --DATE_RFC822 Constant--

--- a/ext/date/tests/test-parse-from-format.phpt
+++ b/ext/date/tests/test-parse-from-format.phpt
@@ -32,8 +32,8 @@ object(DateTime)#2 (3) {
   string(6) "+02:00"
 }
 
-string(16) "l, d-M-Y H:i:s T"
-string(38) "Tuesday, 08-Jul-2008 22:14:12 GMT+0200"
+string(16) "D, d-M-Y H:i:s T"
+string(34) "Tue, 08-Jul-2008 22:14:12 GMT+0200"
 object(DateTime)#1 (3) {
   ["date"]=>
   string(26) "2008-07-08 22:14:12.000000"


### PR DESCRIPTION
In both http://curl.haxx.se/rfc/cookie_spec.html , https://docs.microsoft.com/de-de/windows/win32/wininet/http-cookies?redirectedfrom=MSDN and https://tools.ietf.org/html/rfc7234#section-5.3 the cookie datetime is specified as Mon, DD-Mon-YYYY HH:MM:SS GMT. However, the current definition returns Monday, DD-Mon-YYY HH:MM:SS GMT. Therefore, the "l" in "l, d-M-Y H:i:s T" must be changed to "D".