### PR TITLE
Initalize return_value before use

### DIFF
--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -243,6 +243,7 @@ static int firebird_stmt_get_column_meta(pdo_stmt_t *stmt, zend_long colno, zval
 		}
 	}
 
+	array_init(return_value);
 	add_assoc_long(return_value, "pdo_type", param_type);
 	return 1;
 }

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -627,6 +627,7 @@ static int odbc_stmt_describe(pdo_stmt_t *stmt, int colno)
 
 static int odbc_stmt_get_column_meta(pdo_stmt_t *stmt, zend_long colno, zval *return_value)
 {
+	array_init(return_value);
 	add_assoc_long(return_value, "pdo_type", PDO_PARAM_STR);
 	return 1;
 }


### PR DESCRIPTION
Otherwise we likely segfault[1].

[1] <https://ci.appveyor.com/project/php/php-src/builds/38267250/job/6y3ngn1k6ryxx6j3?fullLog=true#L9783>

---

Even with this patch, there is still another issue, because the SELECT COUNT(*) query fails with `General error: [Microsoft][ODBC Driver 17 for SQL Server]Connection is busy with results for another command (SQLExecute[0] at ext\pdo_odbc\odbc_stmt.c:254)`.