### PR TITLE
Deprecate $num_points parameter of image(open|filled)polygon

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -2673,6 +2673,8 @@ static void php_imagepolygon(INTERNAL_FUNCTION_PARAMETERS, int filled)
 			RETURN_THROWS();
 		}
 		NPOINTS /= 2;
+	} else {
+		php_error_docref(NULL, E_DEPRECATED, "using the $num_points parameter is deprecated");
 	}
 
 	im = php_gd_libgdimageptr_from_zval_p(IM);

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -2674,7 +2674,7 @@ static void php_imagepolygon(INTERNAL_FUNCTION_PARAMETERS, int filled)
 		}
 		NPOINTS /= 2;
 	} else {
-		php_error_docref(NULL, E_DEPRECATED, "using the $num_points parameter is deprecated");
+		php_error_docref(NULL, E_DEPRECATED, "Using the $num_points parameter is deprecated");
 	}
 
 	im = php_gd_libgdimageptr_from_zval_p(IM);

--- a/ext/gd/tests/bug55005.phpt
+++ b/ext/gd/tests/bug55005.phpt
@@ -16,6 +16,9 @@ trycatch_dump(
     fn () => imagepolygon($g, array(200,10, 200,100, 280,100), 2, $fgnd)
 );
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: imagefilledpolygon(): using the $num_points parameter is deprecated in %s on line %d
 !! [ValueError] imagefilledpolygon(): Argument #3 ($num_points_or_color) must be greater than or equal to 3
+
+Deprecated: imagepolygon(): using the $num_points parameter is deprecated in %s on line %d
 !! [ValueError] imagepolygon(): Argument #3 ($num_points_or_color) must be greater than or equal to 3

--- a/ext/gd/tests/bug55005.phpt
+++ b/ext/gd/tests/bug55005.phpt
@@ -17,8 +17,8 @@ trycatch_dump(
 );
 ?>
 --EXPECTF--
-Deprecated: imagefilledpolygon(): using the $num_points parameter is deprecated in %s on line %d
+Deprecated: imagefilledpolygon(): Using the $num_points parameter is deprecated in %s on line %d
 !! [ValueError] imagefilledpolygon(): Argument #3 ($num_points_or_color) must be greater than or equal to 3
 
-Deprecated: imagepolygon(): using the $num_points parameter is deprecated in %s on line %d
+Deprecated: imagepolygon(): Using the $num_points parameter is deprecated in %s on line %d
 !! [ValueError] imagepolygon(): Argument #3 ($num_points_or_color) must be greater than or equal to 3


### PR DESCRIPTION
Cf. <https://wiki.php.net/rfc/deprecations_php_8_1#num_points_parameter_of_image_open_filled_polygon>.