### PR TITLE
Deprecate implicit default PGSQL connection

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -143,6 +143,9 @@ PHP 8.1 UPGRADE NOTES
   . The PgSQL functions now accept and return, respectively, \PgSql\Lob
     objects instead of "pgsql large object" resources. Return value checks
     using is_resource() should be replaced with checks for `false`.
+  . Not passing the connection argument to PgSQL functions and using the
+    default connection is deprecated.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_1
 
 - PSpell:
   . The PSpell functions now accept and return, respectively, PSpell\Dictionary objects

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -78,8 +78,15 @@
 		zend_throw_error(NULL, "No PostgreSQL connection opened yet"); \
 		RETURN_THROWS(); \
 	}
+
+/* This is a bit hacky as the macro usage is "link = FETCH_DEFAULT_LINK();" */
 #define FETCH_DEFAULT_LINK() \
-	(PGG(default_link) ? pgsql_link_from_obj(PGG(default_link)) : NULL)
+		(PGG(default_link) ? pgsql_link_from_obj(PGG(default_link)) : NULL); \
+		php_error_docref(NULL, E_DEPRECATED, "Automatic fetching of PostgreSQL connection is deprecated")
+
+/* Used only when creating a connection */
+#define FETCH_DEFAULT_LINK_NO_WARNING() \
+		(PGG(default_link) ? pgsql_link_from_obj(PGG(default_link)) : NULL)
 
 #define CHECK_PGSQL_LINK(link_handle) \
 	if (link_handle->conn == NULL) { \
@@ -850,7 +857,7 @@ PHP_FUNCTION(pg_close)
 	link = Z_PGSQL_LINK_P(pgsql_link);
 	CHECK_PGSQL_LINK(link);
 
-	if (link == FETCH_DEFAULT_LINK()) {
+	if (link == FETCH_DEFAULT_LINK_NO_WARNING()) {
 		GC_DELREF(PGG(default_link));
 		PGG(default_link) = NULL;
 	}

--- a/ext/pgsql/tests/01createdb.phpt
+++ b/ext/pgsql/tests/01createdb.phpt
@@ -22,7 +22,7 @@ else {
     echo pg_last_error()."\n";
 }
 
-$v = pg_version();
+$v = pg_version($db);
 if (version_compare($v['server'], '9.2', '>=') && (!($q = @pg_query($db, "SELECT * FROM ".$table_name_92)) || !@pg_num_rows($q)))
 {
     pg_query($db,$table_def_92); // Create table here

--- a/ext/pgsql/tests/05large_object.phpt
+++ b/ext/pgsql/tests/05large_object.phpt
@@ -43,7 +43,7 @@ $handle = pg_lo_open ($db, $oid, "w");
 $bytesWritten = pg_lo_read_all($handle);
 echo "\n";
 var_dump($bytesWritten);
-if (pg_last_error()) echo "pg_lo_read_all() error\n".pg_last_error();
+if (pg_last_error($db)) echo "pg_lo_read_all() error\n".pg_last_error();
 pg_lo_close($handle);
 pg_exec ($db, "commit");
 
@@ -103,7 +103,7 @@ try {
 
 echo "OK";
 ?>
---EXPECT--
+--EXPECTF--
 create/write/close LO
 open/read/tell/seek/close LO
 string(5) "large"
@@ -120,10 +120,16 @@ large object data
 int(17)
 unlink LO
 Test without connection
+
+Deprecated: pg_lo_unlink(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 Test with string oid value
 import/export LO
+
+Deprecated: pg_lo_create(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 Invalid OID value passed
 Invalid OID value passed
+
+Deprecated: pg_lo_create(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 Invalid OID value passed
 Invalid OID value passed
 OK

--- a/ext/pgsql/tests/07optional.phpt
+++ b/ext/pgsql/tests/07optional.phpt
@@ -16,9 +16,9 @@ $enc = pg_client_encoding($db);
 pg_set_client_encoding($db, $enc);
 
 if (function_exists('pg_set_error_verbosity')) {
-    pg_set_error_verbosity(PGSQL_ERRORS_TERSE);
-    pg_set_error_verbosity(PGSQL_ERRORS_DEFAULT);
-    pg_set_error_verbosity(PGSQL_ERRORS_VERBOSE);
+    pg_set_error_verbosity($db, PGSQL_ERRORS_TERSE);
+    pg_set_error_verbosity($db, PGSQL_ERRORS_DEFAULT);
+    pg_set_error_verbosity($db, PGSQL_ERRORS_VERBOSE);
 }
 echo "OK";
 ?>

--- a/ext/pgsql/tests/08escape.phpt
+++ b/ext/pgsql/tests/08escape.phpt
@@ -44,8 +44,8 @@ $data = file_get_contents(FILE_NAME);
 $db   = pg_connect($conn_str);
 
 // Insert binary to DB
-$escaped_data = pg_escape_bytea($data);
-pg_query("DELETE FROM ".$table_name." WHERE num = 10000;");
+$escaped_data = pg_escape_bytea($db, $data);
+pg_query($db, "DELETE FROM ".$table_name." WHERE num = 10000;");
 $sql = "INSERT INTO ".$table_name." (num, bin) VALUES (10000, CAST ('".$escaped_data."' AS BYTEA));";
 pg_query($db, $sql);
 
@@ -73,7 +73,7 @@ for ($i = 0; $i < 2; $i++) {
 // pg_escape_literal/pg_escape_identifier
 $before = "ABC\\ABC\'";
 $expect	 = " E'ABC\\\\ABC\\\\'''";
-$after = pg_escape_literal($before);
+$after = pg_escape_literal($db, $before);
 if ($expect === $after) {
     echo "pg_escape_literal() is Ok\n";
 }
@@ -86,7 +86,7 @@ else {
 
 $before = "ABC\\ABC\'";
 $expect	 = "\"ABC\ABC\'\"";
-$after = pg_escape_identifier($before);
+$after = pg_escape_identifier($db, $before);
 if ($expect === $after) {
     echo "pg_escape_identifier() is Ok\n";
 }
@@ -98,8 +98,11 @@ else {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: pg_escape_string(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 pg_escape_string() is Ok
+
+Deprecated: pg_escape_bytea(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 pg_escape_bytea() is Ok
 pg_escape_bytea() actually works with database
 pg_escape_literal() is Ok

--- a/ext/pgsql/tests/09notice.phpt
+++ b/ext/pgsql/tests/09notice.phpt
@@ -7,7 +7,7 @@ pgsql
 
 include("skipif.inc");
 
-_skip_lc_messages();
+_skip_lc_messages($conn);
 
 ?>
 --FILE--
@@ -20,7 +20,7 @@ ini_set('pgsql.ignore_notice', FALSE);
 
 $db = pg_connect($conn_str);
 
-_set_lc_messages();
+_set_lc_messages($db);
 
 $res = pg_query($db, 'SET client_min_messages TO NOTICE;');
 var_dump($res);

--- a/ext/pgsql/tests/13pg_select_9.phpt
+++ b/ext/pgsql/tests/13pg_select_9.phpt
@@ -14,7 +14,7 @@ error_reporting(E_ALL);
 include 'config.inc';
 
 $db = pg_connect($conn_str);
-pg_query("SET bytea_output = 'hex'");
+pg_query($db, "SET bytea_output = 'hex'");
 
 $fields = array('num'=>'1234', 'str'=>'ABC', 'bin'=>'XYZ');
 $ids = array('num'=>'1234');

--- a/ext/pgsql/tests/18pg_escape_bytea_before.phpt
+++ b/ext/pgsql/tests/18pg_escape_bytea_before.phpt
@@ -28,5 +28,6 @@ else {
     echo "OK";
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: pg_escape_bytea(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 OK

--- a/ext/pgsql/tests/18pg_escape_bytea_esc.phpt
+++ b/ext/pgsql/tests/18pg_escape_bytea_esc.phpt
@@ -14,7 +14,7 @@ $db = pg_connect($conn_str);
 @pg_query($db, "SET bytea_output = 'escape'");
 
 $image = file_get_contents(__DIR__ . '/php.gif');
-$esc_image = pg_escape_bytea($image);
+$esc_image = pg_escape_bytea($db, $image);
 
 pg_query($db, 'INSERT INTO '.$table_name.' (num, bin) VALUES (9876, \''.$esc_image.'\');');
 $result = pg_query($db, 'SELECT * FROM '.$table_name.' WHERE num = 9876');

--- a/ext/pgsql/tests/18pg_escape_bytea_hex.phpt
+++ b/ext/pgsql/tests/18pg_escape_bytea_hex.phpt
@@ -17,7 +17,7 @@ $db = pg_connect($conn_str);
 @pg_query($db, "SET bytea_output = 'hex'");
 
 $image = file_get_contents(__DIR__ . '/php.gif');
-$esc_image = pg_escape_bytea($image);
+$esc_image = pg_escape_bytea($db, $image);
 
 pg_query($db, 'INSERT INTO '.$table_name.' (num, bin) VALUES (9876, \''.$esc_image.'\');');
 $result = pg_query($db, 'SELECT * FROM '.$table_name.' WHERE num = 9876');

--- a/ext/pgsql/tests/27large_object_oid.phpt
+++ b/ext/pgsql/tests/27large_object_oid.phpt
@@ -42,8 +42,16 @@ pg_exec ("commit");
 
 echo "OK";
 ?>
---EXPECT--
+--EXPECTF--
 create LO from int
 create LO from string
 create LO using default connection
+
+Deprecated: pg_exec(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_create(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_unlink(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_exec(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 OK

--- a/ext/pgsql/tests/28large_object_import_oid.phpt
+++ b/ext/pgsql/tests/28large_object_import_oid.phpt
@@ -84,14 +84,26 @@ try {
 
 echo "OK";
 ?>
---EXPECT--
+--EXPECTF--
 import LO from int
 import LO from string
 import LO using default connection
+
+Deprecated: pg_exec(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_unlink(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_exec(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_import(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 Invalid OID value passed
 Invalid OID value passed
+
+Deprecated: pg_lo_import(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 Invalid OID value passed
 Invalid OID value passed
+
+Deprecated: pg_lo_import(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 OID value must be of type string|int, bool given
 OID value must be of type string|int, array given
 OID value must be of type string|int, stdClass given

--- a/ext/pgsql/tests/80_bug24499.phpt
+++ b/ext/pgsql/tests/80_bug24499.phpt
@@ -16,12 +16,12 @@ if (!$dbh) {
     die ("Could not connect to the server");
 }
 
-@pg_query("DROP SEQUENCE id_id_seq");
-@pg_query("DROP TABLE id");
-pg_query("CREATE TABLE id (id SERIAL, t INT)");
+@pg_query($dbh, "DROP SEQUENCE id_id_seq");
+@pg_query($dbh, "DROP TABLE id");
+pg_query($dbh, "CREATE TABLE id (id SERIAL, t INT)");
 
 for ($i=0; $i<4; $i++) {
-    pg_query("INSERT INTO id (t) VALUES ($i)");
+    pg_query($dbh, "INSERT INTO id (t) VALUES ($i)");
 }
 
 class Id

--- a/ext/pgsql/tests/80_bug27597.phpt
+++ b/ext/pgsql/tests/80_bug27597.phpt
@@ -16,11 +16,11 @@ if (!$dbh) {
     die ("Could not connect to the server");
 }
 
-@pg_query("DROP TABLE id");
-pg_query("CREATE TABLE id (id INT)");
+@pg_query($dbh, "DROP TABLE id");
+pg_query($dbh, "CREATE TABLE id (id INT)");
 
 for ($i=0; $i<4; $i++) {
-    pg_query("INSERT INTO id (id) VALUES ($i)");
+    pg_query($dbh, "INSERT INTO id (id) VALUES ($i)");
 }
 
 function xi_fetch_array($res, $type = PGSQL_ASSOC) {
@@ -28,7 +28,7 @@ function xi_fetch_array($res, $type = PGSQL_ASSOC) {
     return $a ;
 }
 
-$res = pg_query("SELECT * FROM id");
+$res = pg_query($dbh, "SELECT * FROM id");
 $i = 0; // endless-loop protection
 while($row = xi_fetch_array($res)) {
     print_r($row);

--- a/ext/pgsql/tests/80_bug32223.phpt
+++ b/ext/pgsql/tests/80_bug32223.phpt
@@ -6,7 +6,7 @@ pgsql
 <?php
 require_once('skipif.inc');
 
-_skip_lc_messages();
+_skip_lc_messages($conn);
 
 @pg_query($conn, "CREATE LANGUAGE 'plpgsql' HANDLER plpgsql_call_handler LANCOMPILER 'PL/pgSQL'");
 $res = @pg_query($conn, "CREATE OR REPLACE FUNCTION test_notice() RETURNS boolean AS '
@@ -30,7 +30,7 @@ if (!$dbh) {
     die ("Could not connect to the server");
 }
 
-_set_lc_messages();
+_set_lc_messages($dbh);
 
 $res = pg_query($dbh, "CREATE OR REPLACE FUNCTION test_notice() RETURNS boolean AS '
 begin

--- a/ext/pgsql/tests/80_bug32223b.phpt
+++ b/ext/pgsql/tests/80_bug32223b.phpt
@@ -6,7 +6,7 @@ pgsql
 <?php
 require_once('skipif.inc');
 
-_skip_lc_messages();
+_skip_lc_messages($conn);
 
 @pg_query($conn, "CREATE LANGUAGE 'plpgsql' HANDLER plpgsql_call_handler LANCOMPILER 'PL/pgSQL'");
 $res = @pg_query($conn, "CREATE OR REPLACE FUNCTION test_notice() RETURNS boolean AS '
@@ -30,7 +30,7 @@ if (!$dbh) {
     die ("Could not connect to the server");
 }
 
-_set_lc_messages();
+_set_lc_messages($dbh);
 
 $res = pg_query($dbh, "CREATE OR REPLACE FUNCTION test_notice() RETURNS boolean AS '
 begin

--- a/ext/pgsql/tests/80_bug39971.phpt
+++ b/ext/pgsql/tests/80_bug39971.phpt
@@ -16,7 +16,7 @@ if (!$dbh) {
     die ("Could not connect to the server");
 }
 
-pg_query("CREATE TABLE php_test (id SERIAL, tm timestamp NOT NULL)");
+pg_query($dbh, "CREATE TABLE php_test (id SERIAL, tm timestamp NOT NULL)");
 
 $values = array('tm' => 'now()');
 pg_insert($dbh, 'php_test', $values);

--- a/ext/pgsql/tests/80_bug42783.phpt
+++ b/ext/pgsql/tests/80_bug42783.phpt
@@ -16,11 +16,11 @@ if (!$dbh) {
     die ("Could not connect to the server");
 }
 
-pg_query("CREATE TABLE php_test (id SERIAL PRIMARY KEY, time TIMESTAMP NOT NULL DEFAULT now())");
+pg_query($dbh, "CREATE TABLE php_test (id SERIAL PRIMARY KEY, time TIMESTAMP NOT NULL DEFAULT now())");
 
 pg_insert($dbh, 'php_test', array());
 
-var_dump(pg_fetch_assoc(pg_query("SELECT * FROM php_test")));
+var_dump(pg_fetch_assoc(pg_query($dbh, "SELECT * FROM php_test")));
 
 pg_query($dbh, "DROP TABLE php_test");
 pg_close($dbh);

--- a/ext/pgsql/tests/98old_api.phpt
+++ b/ext/pgsql/tests/98old_api.phpt
@@ -10,7 +10,7 @@ pgsql
 include('config.inc');
 
 $db = pg_connect($conn_str);
-$result = pg_exec("SELECT * FROM ".$table_name);
+$result = pg_exec($db, "SELECT * FROM ".$table_name);
 pg_numrows($result);
 pg_numfields($result);
 pg_fieldname($result, 0);
@@ -20,11 +20,11 @@ pg_fieldprtlen($result, 0);
 pg_fieldisnull($result, 0);
 
 pg_result($result,0,0);
-$result = pg_exec("INSERT INTO ".$table_name." VALUES (7777, 'KKK')");
+$result = pg_exec($db, "INSERT INTO ".$table_name." VALUES (7777, 'KKK')");
 $oid = pg_getlastoid($result);
 pg_freeresult($result);
-pg_errormessage();
-$result = pg_exec("UPDATE ".$table_name." SET str = 'QQQ' WHERE str like 'RGD';");
+pg_errormessage($db);
+$result = pg_exec($db, "UPDATE ".$table_name." SET str = 'QQQ' WHERE str like 'RGD';");
 pg_cmdtuples($result);
 
 

--- a/ext/pgsql/tests/bug37100_9.phpt
+++ b/ext/pgsql/tests/bug37100_9.phpt
@@ -14,20 +14,20 @@ include 'config.inc';
 
 $db = pg_connect($conn_str);
 
-@pg_query('DROP TABLE test_bug');
+@pg_query($db, 'DROP TABLE test_bug');
 
-pg_query('CREATE TABLE test_bug (binfield byteA) ;');
-pg_query("INSERT INTO test_bug VALUES (decode('0103AA000812','hex'))");
+pg_query($db, 'CREATE TABLE test_bug (binfield byteA) ;');
+pg_query($db, "INSERT INTO test_bug VALUES (decode('0103AA000812','hex'))");
 
 
-$data = pg_query("SELECT binfield FROM test_bug");
+$data = pg_query($db, "SELECT binfield FROM test_bug");
 $res = pg_fetch_result($data,0);
 var_dump($res);
 var_dump(bin2hex(pg_unescape_bytea($res)));
 
 $sql = "BEGIN; DECLARE mycursor BINARY CURSOR FOR SELECT binfield FROM test_bug; FETCH ALL IN mycursor;";
 
-$data = pg_query($sql);
+$data = pg_query($db, $sql);
 $res = pg_fetch_result($data,0);
 
 var_dump(strlen($res));
@@ -36,7 +36,7 @@ var_dump(bin2hex($res));
 pg_close($db);
 
 $db = pg_connect($conn_str);
-pg_query('DROP TABLE test_bug');
+pg_query($db, 'DROP TABLE test_bug');
 pg_close($db);
 
 

--- a/ext/pgsql/tests/bug46408.phpt
+++ b/ext/pgsql/tests/bug46408.phpt
@@ -17,7 +17,7 @@ require_once('config.inc');
 $dbh = pg_connect($conn_str);
 setlocale(LC_ALL, "de", "de_DE", "de_DE.ISO8859-1", "de_DE.ISO_8859-1", "de_DE.UTF-8");
 echo 3.5 , "\n";
-pg_query_params("SELECT $1::numeric", array(3.5));
+pg_query_params($dbh, "SELECT $1::numeric", array(3.5));
 pg_close($dbh);
 
 echo "Done".PHP_EOL;

--- a/ext/pgsql/tests/bug47199.phpt
+++ b/ext/pgsql/tests/bug47199.phpt
@@ -13,13 +13,13 @@ require_once('config.inc');
 
 $dbh = pg_connect($conn_str);
 $tbl_name = 'test_47199';
-@pg_query("DROP TABLE $tbl_name");
-pg_query("CREATE TABLE $tbl_name (null_field INT, not_null_field INT NOT NULL)");
+@pg_query($dbh, "DROP TABLE $tbl_name");
+pg_query($dbh, "CREATE TABLE $tbl_name (null_field INT, not_null_field INT NOT NULL)");
 
 pg_insert($dbh, $tbl_name, array('null_field' => null, 'not_null_field' => 1));
 pg_insert($dbh, $tbl_name, array('null_field' => null, 'not_null_field' => 2));
 
-var_dump(pg_fetch_all(pg_query('SELECT * FROM '. $tbl_name)));
+var_dump(pg_fetch_all(pg_query($dbh, 'SELECT * FROM '. $tbl_name)));
 
 $query = pg_delete($dbh, $tbl_name, array('null_field' => NULL,'not_null_field' => 2), PGSQL_DML_STRING|PGSQL_DML_EXEC);
 
@@ -29,9 +29,9 @@ $query = pg_update($dbh, $tbl_name, array('null_field' => NULL, 'not_null_field'
 
 echo $query, "\n";
 
-var_dump(pg_fetch_all(pg_query('SELECT * FROM '. $tbl_name)));
+var_dump(pg_fetch_all(pg_query($dbh, 'SELECT * FROM '. $tbl_name)));
 
-@pg_query("DROP TABLE $tbl_name");
+@pg_query($dbh, "DROP TABLE $tbl_name");
 pg_close($dbh);
 
 echo PHP_EOL."Done".PHP_EOL;

--- a/ext/pgsql/tests/bug60244.phpt
+++ b/ext/pgsql/tests/bug60244.phpt
@@ -12,7 +12,7 @@ include("skipif.inc");
 include 'config.inc';
 
 $db = pg_connect($conn_str);
-$result = pg_query("select 'a' union select 'b'");
+$result = pg_query($db, "select 'a' union select 'b'");
 
 try {
     var_dump(pg_fetch_array($result, -1));

--- a/ext/pgsql/tests/bug64609.phpt
+++ b/ext/pgsql/tests/bug64609.phpt
@@ -14,14 +14,14 @@ error_reporting(E_ALL);
 include 'config.inc';
 
 $db = pg_connect($conn_str);
-pg_query("BEGIN");
-pg_query("CREATE TYPE t_enum AS ENUM ('ok', 'ko')");
-pg_query("CREATE TABLE test_enum (a t_enum)");
+pg_query($db, "BEGIN");
+pg_query($db, "CREATE TYPE t_enum AS ENUM ('ok', 'ko')");
+pg_query($db, "CREATE TABLE test_enum (a t_enum)");
 
 $fields = array('a' => 'ok');
 $converted = pg_convert($db, 'test_enum', $fields);
 
-pg_query("ROLLBACK");
+pg_query($db, "ROLLBACK");
 
 var_dump($converted);
 ?>

--- a/ext/pgsql/tests/bug65119.phpt
+++ b/ext/pgsql/tests/bug65119.phpt
@@ -12,10 +12,10 @@ include 'config.inc';
 
 function test(Array $values, $conn_str) {
   $connection = pg_pconnect($conn_str, PGSQL_CONNECT_FORCE_NEW);
-  pg_query("begin");
-  pg_query("CREATE TABLE bug65119 (i INTEGER)");
+  pg_query($connection, "begin");
+  pg_query($connection, "CREATE TABLE bug65119 (i INTEGER)");
   pg_copy_from($connection, "bug65119", $values, "\t", "NULL");
-  pg_query("rollback");
+  pg_query($connection, "rollback");
 }
 
 $values = Array(1,2,3);

--- a/ext/pgsql/tests/bug68638.phpt
+++ b/ext/pgsql/tests/bug68638.phpt
@@ -13,7 +13,7 @@ $conn = pg_connect($conn_str);
 
 $table='test_68638';
 
-pg_query("CREATE TABLE $table (id INT, value FLOAT)");
+pg_query($conn, "CREATE TABLE $table (id INT, value FLOAT)");
 
 pg_insert($conn,$table, array('id' => 1, 'value' => 1.2));
 pg_insert($conn,$table, array('id' => 2, 'value' => 10));
@@ -25,12 +25,12 @@ pg_update($conn,$table, array('value' => 'inf'), array('id' => 1));
 pg_update($conn,$table, array('value' => '-inf'), array('id' => 2));
 pg_update($conn,$table, array('value' => '+inf'), array('id' => 3));
 
-$rs = pg_query("SELECT * FROM $table");
+$rs = pg_query($conn, "SELECT * FROM $table");
 while ($row = pg_fetch_assoc($rs)) {
         var_dump($row);
 }
 
-pg_query("DROP TABLE $table");
+pg_query($conn, "DROP TABLE $table");
 
 ?>
 --EXPECT--

--- a/ext/pgsql/tests/bug71998.phpt
+++ b/ext/pgsql/tests/bug71998.phpt
@@ -13,7 +13,7 @@ include('config.inc');
 
 $db = pg_connect($conn_str);
 
-pg_query("CREATE TABLE tmp_statistics (id integer NOT NULL, remote_addr inet);");
+pg_query($db, "CREATE TABLE tmp_statistics (id integer NOT NULL, remote_addr inet);");
 
 $ips = array(
     /* IPv4*/

--- a/ext/pgsql/tests/bug72028.phpt
+++ b/ext/pgsql/tests/bug72028.phpt
@@ -14,7 +14,7 @@ $conn = pg_connect($conn_str);
 
 $table = "bug72028_" . md5(uniqid(time()));
 
-pg_query("CREATE TABLE $table (value TEXT, details TEXT);");
+pg_query($conn, "CREATE TABLE $table (value TEXT, details TEXT);");
 
 $sql = "INSERT INTO $table (value, details) VALUES ($1, $2)";
 
@@ -29,12 +29,12 @@ unset($p);
 
 $result = pg_query_params($conn, $sql, $params2);
 
-$r = pg_query("SELECT * FROM $table");
+$r = pg_query($conn, "SELECT * FROM $table");
 while (false !== ($i = pg_fetch_assoc($r))) {
     var_dump($i);
 }
 
-pg_query("DROP TABLE $table");
+pg_query($conn, "DROP TABLE $table");
 
 ?>
 --EXPECT--

--- a/ext/pgsql/tests/bug72197.phpt
+++ b/ext/pgsql/tests/bug72197.phpt
@@ -35,4 +35,6 @@ pg_close($conn);
 --EXPECTF--
 pg_lo_create(): Argument #1 ($connection) must be of type PgSql\Connection when the connection is provided%w
 int(%d)
+
+Deprecated: pg_lo_create(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 int(%d)

--- a/ext/pgsql/tests/bug75419.phpt
+++ b/ext/pgsql/tests/bug75419.phpt
@@ -13,5 +13,6 @@ $db2 = pg_connect($conn_str, PGSQL_CONNECT_FORCE_NEW);
 pg_close($db1);
 var_dump(pg_ping());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: pg_ping(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 bool(true)

--- a/ext/pgsql/tests/close_default_link.phpt
+++ b/ext/pgsql/tests/close_default_link.phpt
@@ -13,5 +13,6 @@ $db1 = pg_connect($conn_str);
 unset($db1);
 var_dump(pg_close());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: pg_close(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 bool(true)

--- a/ext/pgsql/tests/connect_after_close.phpt
+++ b/ext/pgsql/tests/connect_after_close.phpt
@@ -17,6 +17,9 @@ $db2 = pg_connect($conn_str);
 unset($db2);
 var_dump(pg_close());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: pg_close(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 bool(true)
+
+Deprecated: pg_close(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 bool(true)

--- a/ext/pgsql/tests/deprecated_implicit_default_link.phpt
+++ b/ext/pgsql/tests/deprecated_implicit_default_link.phpt
@@ -1,0 +1,144 @@
+--TEST--
+PostgreSQL fetching default link automatically is deprecated
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+include('config.inc');
+$db = pg_connect($conn_str);
+
+// We don't care about warnings
+ini_set('error_reporting', E_ALL&~E_WARNING);
+
+// Special cases
+pg_set_error_verbosity(PGSQL_ERRORS_TERSE);
+pg_query_params('str', []);
+pg_execute('str', []);
+
+pg_lo_unlink(1);
+// deprecated alias 'pg_lounlink',
+pg_lo_open(1, 'r');
+// deprecated alias 'pg_loopen',
+pg_lo_export(1, '');
+// deprecated alias 'pg_loexport',
+
+$functions = [
+'pg_dbname',
+'pg_last_error',
+// deprecated alias 'pg_errormessage',
+'pg_options',
+'pg_port',
+'pg_tty',
+'pg_host',
+'pg_version',
+'pg_parameter_status',
+'pg_ping',
+'pg_query',
+'pg_exec',
+'pg_prepare',
+'pg_untrace',
+'pg_lo_create',
+// deprecated alias 'pg_locreate',
+'pg_lo_import',
+// deprecated alias 'pg_loimport',
+'pg_set_client_encoding',
+// deprecated alias 'pg_setclientencoding',
+'pg_client_encoding',
+// deprecated alias 'pg_clientencoding',
+'pg_end_copy',
+'pg_put_line',
+'pg_escape_string',
+'pg_escape_bytea',
+'pg_escape_literal',
+'pg_escape_identifier',
+'pg_close',
+];
+
+foreach ($functions as $function) {
+    $args = [];
+    $argNum = 0;
+    retry:
+    try {
+        $function(...$args);
+        continue;
+    } catch (ArgumentCountError) {
+        $args[] = 'str';
+        ++$argNum;
+        goto retry;
+    } catch (TypeError $e) {
+        if (str_contains($e->getMessage(), 'type array')) {
+            $args[$argNum] = [];
+            goto retry;
+        }
+        var_dump($e->getMessage());
+    } catch (\Error $e) {
+        echo $e->getMessage();
+    }
+}
+
+echo "END";
+?>
+--EXPECTF--
+Deprecated: pg_set_error_verbosity(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_query_params(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_execute(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_unlink(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_open(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_export(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_dbname(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_last_error(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_options(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_port(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_tty(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_host(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_version(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_parameter_status(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_ping(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_query(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_exec(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_prepare(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_untrace(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_create(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_lo_import(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_set_client_encoding(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_client_encoding(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_end_copy(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_put_line(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_escape_string(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_escape_bytea(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_escape_literal(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_escape_identifier(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+
+Deprecated: pg_close(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
+END

--- a/ext/pgsql/tests/lcmess.inc
+++ b/ext/pgsql/tests/lcmess.inc
@@ -1,16 +1,16 @@
 <?php
 
-function _skip_lc_messages($lc_messages = 'C')
+function _skip_lc_messages($conn, $lc_messages = 'C')
 {
-    if (!_set_lc_messages($lc_messages)) {
+    if (!_set_lc_messages($conn, $lc_messages)) {
         die("skip Cannot set LC_MESSAGES to '{$lc_messages}'\n");
     }
 }
 
-function _set_lc_messages($lc_messages = 'C')
+function _set_lc_messages($conn, $lc_messages = 'C')
 {
-    if (pg_fetch_result(pg_query("SHOW LC_MESSAGES"), 0, 0) != $lc_messages) {
-        if (!@pg_exec("SET LC_MESSAGES='{$lc_messages}'")) {
+    if (pg_fetch_result(pg_query($conn, "SHOW LC_MESSAGES"), 0, 0) != $lc_messages) {
+        if (!@pg_exec($conn, "SET LC_MESSAGES='{$lc_messages}'")) {
             return false;
         }
     }

--- a/ext/pgsql/tests/no_link_open.phpt
+++ b/ext/pgsql/tests/no_link_open.phpt
@@ -12,5 +12,6 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: pg_dbname(): Automatic fetching of PostgreSQL connection is deprecated in %s on line %d
 No PostgreSQL connection opened yet

--- a/ext/pgsql/tests/pg_delete_001.phpt
+++ b/ext/pgsql/tests/pg_delete_001.phpt
@@ -11,10 +11,10 @@ include('config.inc');
 
 $conn = pg_connect($conn_str);
 
-pg_query('CREATE SCHEMA phptests');
+pg_query($conn, 'CREATE SCHEMA phptests');
 
-pg_query('CREATE TABLE foo (id INT, id2 INT)');
-pg_query('CREATE TABLE phptests.foo (id INT, id2 INT)');
+pg_query($conn, 'CREATE TABLE foo (id INT, id2 INT)');
+pg_query($conn, 'CREATE TABLE phptests.foo (id INT, id2 INT)');
 
 pg_insert($conn, 'foo', array('id' => 1, 'id2' => 1));
 pg_insert($conn, 'foo', array('id' => 1, 'id2' => 2));
@@ -34,16 +34,16 @@ pg_delete($conn, 'phptests.foo', array('id' => 2, 'id2' => 1));
 pg_delete($conn, 'phptests.foo', array('id' => 2, 'id2' => 3));
 var_dump(pg_delete($conn, 'phptests.foo', array('id' => 2, 'id2' => 3), PGSQL_DML_STRING));
 
-var_dump(pg_fetch_all(pg_query('SELECT * FROM foo')));
-var_dump(pg_fetch_all(pg_query('SELECT * FROM phptests.foo')));
+var_dump(pg_fetch_all(pg_query($conn, 'SELECT * FROM foo')));
+var_dump(pg_fetch_all(pg_query($conn, 'SELECT * FROM phptests.foo')));
 
 /* Inexistent */
 pg_delete($conn, 'bar', array('id' => 1, 'id2' => 2));
 var_dump(pg_delete($conn, 'bar', array('id' => 1, 'id2' => 2), PGSQL_DML_STRING));
 
-pg_query('DROP TABLE foo');
-pg_query('DROP TABLE phptests.foo');
-pg_query('DROP SCHEMA phptests');
+pg_query($conn, 'DROP TABLE foo');
+pg_query($conn, 'DROP TABLE phptests.foo');
+pg_query($conn, 'DROP SCHEMA phptests');
 
 ?>
 --EXPECTF--

--- a/ext/pgsql/tests/pg_insert_001.phpt
+++ b/ext/pgsql/tests/pg_insert_001.phpt
@@ -11,8 +11,8 @@ include('config.inc');
 
 $conn = pg_connect($conn_str);
 
-pg_query('CREATE SCHEMA phptests');
-pg_query('CREATE TABLE phptests.foo (id INT, id2 INT)');
+pg_query($conn, 'CREATE SCHEMA phptests');
+pg_query($conn, 'CREATE TABLE phptests.foo (id INT, id2 INT)');
 
 
 pg_insert($conn, 'foo', array('id' => 1, 'id2' => 1));
@@ -23,8 +23,8 @@ var_dump(pg_insert($conn, 'phptests.foo', array('id' => 1, 'id2' => 2), PGSQL_DM
 
 var_dump(pg_select($conn, 'phptests.foo', array('id' => 1)));
 
-pg_query('DROP TABLE phptests.foo');
-pg_query('DROP SCHEMA phptests');
+pg_query($conn, 'DROP TABLE phptests.foo');
+pg_query($conn, 'DROP SCHEMA phptests');
 
 ?>
 --EXPECTF--

--- a/ext/pgsql/tests/pg_meta_data_001.phpt
+++ b/ext/pgsql/tests/pg_meta_data_001.phpt
@@ -11,11 +11,11 @@ include('config.inc');
 
 $conn = pg_connect($conn_str);
 
-pg_query('CREATE SCHEMA phptests');
+pg_query($conn, 'CREATE SCHEMA phptests');
 
-pg_query('CREATE TABLE phptests.foo (id INT, id2 INT)');
+pg_query($conn, 'CREATE TABLE phptests.foo (id INT, id2 INT)');
 
-pg_query('CREATE TABLE foo (id INT, id3 INT)');
+pg_query($conn, 'CREATE TABLE foo (id INT, id3 INT)');
 
 
 var_dump(pg_meta_data($conn, 'foo'));
@@ -23,9 +23,9 @@ var_dump(pg_meta_data($conn, 'phptests.foo'));
 var_dump(pg_meta_data($conn, 'phptests.foo', TRUE));
 
 
-pg_query('DROP TABLE foo');
-pg_query('DROP TABLE phptests.foo');
-pg_query('DROP SCHEMA phptests');
+pg_query($conn, 'DROP TABLE foo');
+pg_query($conn, 'DROP TABLE phptests.foo');
+pg_query($conn, 'DROP SCHEMA phptests');
 
 ?>
 --EXPECT--

--- a/ext/pgsql/tests/pg_select_001.phpt
+++ b/ext/pgsql/tests/pg_select_001.phpt
@@ -11,17 +11,17 @@ include('config.inc');
 
 $conn = pg_connect($conn_str);
 
-pg_query('CREATE SCHEMA phptests');
+pg_query($conn, 'CREATE SCHEMA phptests');
 
-pg_query('CREATE TABLE phptests.foo (id INT, id2 INT)');
-pg_query('INSERT INTO phptests.foo VALUES (1,2)');
-pg_query('INSERT INTO phptests.foo VALUES (2,3)');
+pg_query($conn, 'CREATE TABLE phptests.foo (id INT, id2 INT)');
+pg_query($conn, 'INSERT INTO phptests.foo VALUES (1,2)');
+pg_query($conn, 'INSERT INTO phptests.foo VALUES (2,3)');
 
-pg_query('CREATE TABLE phptests.bar (id4 INT, id3 INT)');
-pg_query('INSERT INTO phptests.bar VALUES (4,5)');
-pg_query('INSERT INTO phptests.bar VALUES (6,7)');
+pg_query($conn, 'CREATE TABLE phptests.bar (id4 INT, id3 INT)');
+pg_query($conn, 'INSERT INTO phptests.bar VALUES (4,5)');
+pg_query($conn, 'INSERT INTO phptests.bar VALUES (6,7)');
 
-/* Inexistent table */
+/* Nonexistent table */
 var_dump(pg_select($conn, 'foo', array('id' => 1)));
 
 /* Existent column */
@@ -36,9 +36,9 @@ var_dump(pg_select($conn, 'phptests.bar', array('id4' => 4)));
 /* Use a different result type */
 var_dump(pg_select($conn, 'phptests.bar', array('id4' => 4), 0, PGSQL_NUM));
 
-pg_query('DROP TABLE phptests.foo');
-pg_query('DROP TABLE phptests.bar');
-pg_query('DROP SCHEMA phptests');
+pg_query($conn, 'DROP TABLE phptests.foo');
+pg_query($conn, 'DROP TABLE phptests.bar');
+pg_query($conn, 'DROP SCHEMA phptests');
 
 ?>
 --EXPECTF--

--- a/ext/pgsql/tests/pg_update_001.phpt
+++ b/ext/pgsql/tests/pg_update_001.phpt
@@ -11,10 +11,10 @@ include('config.inc');
 
 $conn = pg_connect($conn_str);
 
-pg_query('CREATE SCHEMA phptests');
+pg_query($conn, 'CREATE SCHEMA phptests');
 
-pg_query('CREATE TABLE foo (id INT, id2 INT)');
-pg_query('CREATE TABLE phptests.foo (id INT, id2 INT)');
+pg_query($conn, 'CREATE TABLE foo (id INT, id2 INT)');
+pg_query($conn, 'CREATE TABLE phptests.foo (id INT, id2 INT)');
 
 
 pg_insert($conn, 'foo', array('id' => 1, 'id2' => 1));
@@ -26,14 +26,14 @@ var_dump(pg_update($conn, 'foo', array('id' => 10), array('id' => 1), PGSQL_DML_
 pg_update($conn, 'phptests.foo', array('id' => 100), array('id2' => 2));
 var_dump(pg_update($conn, 'phptests.foo', array('id' => 100), array('id2' => 2), PGSQL_DML_STRING));
 
-$rs = pg_query('SELECT * FROM foo UNION SELECT * FROM phptests.foo ORDER BY id');
+$rs = pg_query($conn, 'SELECT * FROM foo UNION SELECT * FROM phptests.foo ORDER BY id');
 while ($row = pg_fetch_assoc($rs)) {
     var_dump($row);
 }
 
-pg_query('DROP TABLE foo');
-pg_query('DROP TABLE phptests.foo');
-pg_query('DROP SCHEMA phptests');
+pg_query($conn, 'DROP TABLE foo');
+pg_query($conn, 'DROP TABLE phptests.foo');
+pg_query($conn, 'DROP SCHEMA phptests');
 
 ?>
 --EXPECT--

--- a/ext/pgsql/tests/skipif.inc
+++ b/ext/pgsql/tests/skipif.inc
@@ -1,3 +1,4 @@
+
 <?php
 // This script prints "skip" unless:
 // * the pgsql extension is built-in or loadable, AND
@@ -21,7 +22,8 @@ if (!$conn) {
 
 function skip_server_version($version, $op = '<')
 {
-    $pg = pg_parameter_status('server_version');
+    global $conn;
+    $pg = pg_parameter_status($conn,'server_version');
     if (version_compare($pg, $version, $op)) {
         die("skip Server version {$pg} is {$op} {$version}\n");
     }
@@ -30,7 +32,8 @@ function skip_server_version($version, $op = '<')
 
 function skip_bytea_not_hex()
 {
-    $out = pg_escape_bytea("\xFF");
+    global $conn;
+    $out = pg_escape_bytea($conn, "\xFF");
     if (strpos($out, '377') !== false) {
         die("skip libpq or backend < 9.0\n");
     }
@@ -38,7 +41,8 @@ function skip_bytea_not_hex()
 
 function skip_bytea_not_escape()
 {
-    $out = pg_escape_bytea("\xFF");
+    global $conn;
+    $out = pg_escape_bytea($conn, "\xFF");
     if (strpos($out, '377') === false) {
         die("skip libpq or backend >= 9.0\n");
     }


### PR DESCRIPTION
Possible implementation for https://wiki.php.net/rfc/deprecations_php_8_1#calling_overloaded_pgsql_functions_without_the_connection_argument