### PR TITLE
Fix readdir_r() config check

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1362,10 +1362,10 @@ int main() {
   if (!dir)
     return 1;
   if (readdir_r(dir, (struct dirent *) entry, &pentry) == 0) {
-    close(dir);
+    closedir(dir);
     return 0;
   }
-  close(dir);
+  closedir(dir);
   return 1;
 }
     ]])],[


### PR DESCRIPTION
The handle created by opendir() should be freed by closedir(). The code is instead incorrectly using close(), i.e. implicitly converting the DIR* pointer to an integer and ignoring the EBADF error which results. The close() was added in 1bdffee820d92f558d883bd1aa41bebc739e2980 in an attempt to fix compilation with AddressSanitizer, and my motivation is the same -- AddressSanitizer compilation still fails before this patch due to a detected memory leak.

Affects PHP 7.3 only.