### PR TITLE
Fix bug #80894: properly free debuginfo

### DIFF
--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -164,8 +164,7 @@ again:
 					php_object_property_dump(val, num, key, level);
 				} ZEND_HASH_FOREACH_END();
 				if (is_temp) {
-					zend_hash_destroy(myht);
-					efree(myht);
+					zend_array_destroy(myht);
 				}
 			}
 			if (level > 1) {


### PR DESCRIPTION
Call zend_array_destroy() on the return value of the __debugInfo() method, so that it is removed from the GC root buffer.

More details at https://bugs.php.net/bug.php?id=80894