### PR TITLE
Properly initialize PS(mod) on RINIT

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2856,7 +2856,8 @@ static int php_rinit_session(zend_bool auto_start) /* {{{ */
 {
 	php_rinit_session_globals();
 
-	if (PS(mod) == NULL) {
+	PS(mod) = NULL;
+	{
 		char *value;
 
 		value = zend_ini_string("session.save_handler", sizeof("session.save_handler") - 1, 0);


### PR DESCRIPTION
We can't do that in `php_rinit_session_globals()` since that function
is called by PHP function `session_destroy()` too, but in that case we
don't want to reset PS(mod).

---

This fixes the failing `--repeat 2 ext/session/tests/bug80889.phpt` and similar issues.