### PR TITLE
Fix #80889: amendment

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2066,7 +2066,7 @@ static PHP_FUNCTION(session_set_save_handler)
 		}
 	}
 
-	if (PS(mod) && PS(mod) != &ps_mod_user) {
+	if (!PS(mod) || PS(mod) != &ps_mod_user) {
 		ini_name = zend_string_init("session.save_handler", sizeof("session.save_handler") - 1, 0);
 		ini_val = zend_string_init("user", sizeof("user") - 1, 0);
 		PS(set_handler) = 1;

--- a/ext/session/tests/bug80889a.phpt
+++ b/ext/session/tests/bug80889a.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #80889 (Cannot set save handler when save_handler is invalid)
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--INI--
+session.save_handler=whatever
+--FILE--
+<?php
+$initHandler = ini_get('session.save_handler');
+session_set_save_handler(
+    function ($savePath, $sessionName) {
+        return true;
+    },
+    function () {
+        return true;
+    },
+    function ($id) {
+        return '';
+    },
+    function ($id, $data) {
+        return true;
+    },
+    function ($id) {
+        return true;
+    },
+    function ($maxlifetime) {
+        return true;
+    }
+);
+$setHandler = ini_get('session.save_handler');
+var_dump($initHandler, $setHandler);
+?>
+--EXPECT--
+string(8) "whatever"
+string(4) "user"


### PR DESCRIPTION
`session_set_save_handler()` may be called with callables instead of an
object; we need to cater to that as well.