### PR TITLE
Migrate skip checks to --EXTENSIONS--, p1

### DIFF
--- a/ext/bcmath/tests/bcadd.phpt
+++ b/ext/bcmath/tests/bcadd.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcadd() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcadd_error.phpt
+++ b/ext/bcmath/tests/bcadd_error.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcadd() requires well-formed values
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bcadd_variation001.phpt
+++ b/ext/bcmath/tests/bcadd_variation001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcadd() with non-integers
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=5
 --FILE--

--- a/ext/bcmath/tests/bccomp.phpt
+++ b/ext/bcmath/tests/bccomp.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bccomp() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bccomp_error.phpt
+++ b/ext/bcmath/tests/bccomp_error.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bccomp() requires well-formed values
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bccomp_variation001.phpt
+++ b/ext/bcmath/tests/bccomp_variation001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bccomp() with non-integers
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bccomp_variation002.phpt
+++ b/ext/bcmath/tests/bccomp_variation002.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bccomp() with negative value
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcdiv.phpt
+++ b/ext/bcmath/tests/bcdiv.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcdiv() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcdiv_error1.phpt
+++ b/ext/bcmath/tests/bcdiv_error1.phpt
@@ -4,8 +4,8 @@ bcdiv — Divide two arbitrary precision numbers
 TestFest2009
 Antoni Torrents
 antoni@solucionsinternet.com
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bcdiv_error2.phpt
+++ b/ext/bcmath/tests/bcdiv_error2.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcdiv() requires well-formed values
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bcmod.phpt
+++ b/ext/bcmath/tests/bcmod.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcmod() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcmod_error2.phpt
+++ b/ext/bcmath/tests/bcmod_error2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcmod() - mod by 0
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcmod_error3.phpt
+++ b/ext/bcmath/tests/bcmod_error3.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcmod() requires well-formed values
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bcmul.phpt
+++ b/ext/bcmath/tests/bcmul.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcmul() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcmul_error.phpt
+++ b/ext/bcmath/tests/bcmul_error.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcmul() requires well-formed values
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bcpow.phpt
+++ b/ext/bcmath/tests/bcpow.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcpow() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcpow_error1.phpt
+++ b/ext/bcmath/tests/bcpow_error1.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcpow() does not support non-integral exponents
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension is not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bcpow_error2.phpt
+++ b/ext/bcmath/tests/bcpow_error2.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcpow() does not support exponents >= 2**63
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension is not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bcpow_error3.phpt
+++ b/ext/bcmath/tests/bcpow_error3.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcpow() requires well-formed values
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bcpow_variation001.phpt
+++ b/ext/bcmath/tests/bcpow_variation001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcpow() with a negative exponent
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcpowmod.phpt
+++ b/ext/bcmath/tests/bcpowmod.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcpowmod() - Raise an arbitrary precision number to another, reduced by a specified modulus
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcpowmod_error.phpt
+++ b/ext/bcmath/tests/bcpowmod_error.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcpowmod() requires well-formed values
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bcpowmod_negative_exponent.phpt
+++ b/ext/bcmath/tests/bcpowmod_negative_exponent.phpt
@@ -2,8 +2,8 @@
 bc_raisemod's expo can't be negative
 --CREDITS--
 Gabriel Caruso (carusogabriel34@gmail.com)
---SKIPIF--
-<?php if(!extension_loaded('bcmath')) die('skip bcmath extension not loaded'); ?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bcpowmod_zero_modulus.phpt
+++ b/ext/bcmath/tests/bcpowmod_zero_modulus.phpt
@@ -2,8 +2,8 @@
 bc_raisemod's mod can't be zero
 --CREDITS--
 Gabriel Caruso (carusogabriel34@gmail.com)
---SKIPIF--
-<?php if(!extension_loaded('bcmath')) die('skip bcmath extension not loaded'); ?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bcscale.phpt
+++ b/ext/bcmath/tests/bcscale.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcscale() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcscale_variation001.phpt
+++ b/ext/bcmath/tests/bcscale_variation001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcscale() fails with negative argument
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcscale_variation002.phpt
+++ b/ext/bcmath/tests/bcscale_variation002.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcadd() incorrect argument count
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=-2
 --FILE--

--- a/ext/bcmath/tests/bcscale_variation003.phpt
+++ b/ext/bcmath/tests/bcscale_variation003.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcscale() return value
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcsqrt.phpt
+++ b/ext/bcmath/tests/bcsqrt.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcsqrt() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcsqrt_error1.phpt
+++ b/ext/bcmath/tests/bcsqrt_error1.phpt
@@ -3,8 +3,8 @@ bcsqrt — Get the square root of an arbitrary precision number
 --CREDITS--
 Antoni Torrents
 antoni@solucionsinternet.com
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bcsqrt_error2.phpt
+++ b/ext/bcmath/tests/bcsqrt_error2.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcsqrt() requires a well-formed value
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bcsqrt_variation001.phpt
+++ b/ext/bcmath/tests/bcsqrt_variation001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcsqrt() with argument of 0
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcsub.phpt
+++ b/ext/bcmath/tests/bcsub.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bcsub() function
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/bcsub_error.phpt
+++ b/ext/bcmath/tests/bcsub_error.phpt
@@ -1,9 +1,7 @@
 --TEST--
 bcsub() requires well-formed values
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/bug.66364.phpt
+++ b/ext/bcmath/tests/bug.66364.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #66364 (BCMath bcmul ignores scale parameter)
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 var_dump(bcmul('0.3', '0.2', 4));

--- a/ext/bcmath/tests/bug44995.phpt
+++ b/ext/bcmath/tests/bug44995.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #44995 (bcpowmod() fails if scale != 0)
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 var_dump(bcpowmod('4', '4', '3', 1));

--- a/ext/bcmath/tests/bug46781.phpt
+++ b/ext/bcmath/tests/bug46781.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #46781 (BC math handles minus zero incorrectly)
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension is not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 var_dump(bcadd('-0.0', '-0.0', 1));

--- a/ext/bcmath/tests/bug54598.phpt
+++ b/ext/bcmath/tests/bug54598.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #54598 (bcpowmod() may return 1 if modulus is 1)
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension is not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 var_dump(bcpowmod(5, 0, 1));

--- a/ext/bcmath/tests/bug60377.phpt
+++ b/ext/bcmath/tests/bug60377.phpt
@@ -1,7 +1,9 @@
 --TEST--
 bcscale related problem on 64bits platforms
+--EXTENSIONS--
+bcmath
 --SKIPIF--
-<?php if(!extension_loaded("bcmath")) die("skip");
+<?php
 if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
 --FILE--
 <?php

--- a/ext/bcmath/tests/bug72093.phpt
+++ b/ext/bcmath/tests/bug72093.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug 72093: bcpowmod fails on negative scale and corrupts _one_ definition
---SKIPIF--
-<?php
-if(!extension_loaded("bcmath")) print "skip";
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bug75178.phpt
+++ b/ext/bcmath/tests/bug75178.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #75178 (bcpowmod() misbehaves for non-integer base or modulus)
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension is not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bug78878.phpt
+++ b/ext/bcmath/tests/bug78878.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #78878 (Buffer underflow in bc_shift_addsub)
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 try {

--- a/ext/bcmath/tests/bug80545.phpt
+++ b/ext/bcmath/tests/bug80545.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #80545 (bcadd('a', 'a') and bcadd('1', 'a') doesn't throw an exception)
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 

--- a/ext/bcmath/tests/negative_scale.phpt
+++ b/ext/bcmath/tests/negative_scale.phpt
@@ -1,7 +1,7 @@
 --TEST--
 all errors on negative scale
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale=0
 --FILE--

--- a/ext/bcmath/tests/scale.phpt
+++ b/ext/bcmath/tests/scale.phpt
@@ -1,9 +1,7 @@
 --TEST--
 BCMath functions return result with requested scale
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 echo

--- a/ext/bcmath/tests/scale_ini.phpt
+++ b/ext/bcmath/tests/scale_ini.phpt
@@ -1,9 +1,7 @@
 --TEST--
 BCMath functions return result with default scale
---SKIPIF--
-<?php
-if (!extension_loaded('bcmath')) die('skip bcmath extension not available');
-?>
+--EXTENSIONS--
+bcmath
 --INI--
 bcmath.scale = 5
 --FILE--

--- a/ext/bcmath/tests/str2num_formatting.phpt
+++ b/ext/bcmath/tests/str2num_formatting.phpt
@@ -4,8 +4,8 @@ bcmath lib arguments formatting
 1 and 2 argument of bcadd/bcsub/bcmul/bcdiv/bcmod/bcpowmod/bcpow/bccomp (last one works different then others internally);
 1 argument of bcsqrt
 All of the name above must be well-formed
---SKIPIF--
-<?php if(!extension_loaded("bcmath")) print "skip"; ?>
+--EXTENSIONS--
+bcmath
 --FILE--
 <?php
 echo bcadd("1", "2"),"\n";

--- a/ext/bz2/tests/001.phpt
+++ b/ext/bz2/tests/001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzopen() and invalid parameters
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/002.phpt
+++ b/ext/bz2/tests/002.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzopen() using fd opened in wrong mode
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/003-mb.phpt
+++ b/ext/bz2/tests/003-mb.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzread() tests
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/003.phpt
+++ b/ext/bz2/tests/003.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzread() tests
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/004.phpt
+++ b/ext/bz2/tests/004.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzread() tests with invalid files
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/005.phpt
+++ b/ext/bz2/tests/005.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzcompress()/bzdecompress() tests
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/bug51997.phpt
+++ b/ext/bz2/tests/bug51997.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #51997 (SEEK_CUR with 0 value, returns a warning)
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/bug71263.phpt
+++ b/ext/bz2/tests/bug71263.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #71263: fread() does not report bzip2.decompress errors
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip bz2 extension not loaded"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/bug72447.phpt
+++ b/ext/bz2/tests/bug72447.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #72447: Type Confusion in php_bz2_filter_create()
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 $input = "AAAAAAAA";

--- a/ext/bz2/tests/bug72613.phpt
+++ b/ext/bz2/tests/bug72613.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #72613 (Inadequate error handling in bzread())
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 $fp = bzopen(__DIR__.'/72613.bz2', 'r');

--- a/ext/bz2/tests/bug75776.phpt
+++ b/ext/bz2/tests/bug75776.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #75776 (Flushing streams with compression filter is broken)
---SKIPIF--
-<?php
-if (!extension_loaded('bz2')) die('skip bz2 extension not available');
-?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 $text = str_repeat('0123456789abcdef', 1000);

--- a/ext/bz2/tests/bz2_filter_compress.phpt
+++ b/ext/bz2/tests/bz2_filter_compress.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzip2.compress (with convert.base64-encode)
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 $text = 'I am the very model of a modern major general, I\'ve information vegetable, animal, and mineral.';

--- a/ext/bz2/tests/bz2_filter_decompress.phpt
+++ b/ext/bz2/tests/bz2_filter_decompress.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzip2.decompress (with convert.base64-decode)
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 $text = 'QlpoNDFBWSZTWRN6QG0AAAoVgECFACA395UgIABIintI1N6mpowIQ0E1MTTAQGYTNcRyMZm5kgW3ib7hVboE7Tmqj3ToGZ5G3q1ZauD2G58hibSck8KS95EEAbx1Cn+LuSKcKEgJvSA2gA==';

--- a/ext/bz2/tests/bzopen_string_filename_with_null_bytes.phpt
+++ b/ext/bz2/tests/bzopen_string_filename_with_null_bytes.phpt
@@ -1,7 +1,7 @@
 --TEST--
 bzopen(): throw TypeError if filename contains null bytes
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/with_files.phpt
+++ b/ext/bz2/tests/with_files.phpt
@@ -1,7 +1,7 @@
 --TEST--
 BZ2 with files
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/bz2/tests/with_strings.phpt
+++ b/ext/bz2/tests/with_strings.phpt
@@ -1,7 +1,7 @@
 --TEST--
 BZ2 with strings
---SKIPIF--
-<?php if (!extension_loaded("bz2")) print "skip"; ?>
+--EXTENSIONS--
+bz2
 --FILE--
 <?php
 

--- a/ext/calendar/tests/bug52744.phpt
+++ b/ext/calendar/tests/bug52744.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #52744 (cal_days_in_month incorrect for December 1 BCE)
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 var_dump(cal_days_in_month(CAL_GREGORIAN, 12, -1));

--- a/ext/calendar/tests/bug53574_1.phpt
+++ b/ext/calendar/tests/bug53574_1.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #53574 (Integer overflow in SdnToJulian; leads to segfault)
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php
-include 'skipif.inc';
 if (PHP_INT_SIZE != 4) {
         die("skip this test is for 32bit platform only");
 }

--- a/ext/calendar/tests/bug53574_2.phpt
+++ b/ext/calendar/tests/bug53574_2.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #53574 (Integer overflow in SdnToJulian; leads to segfault)
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php
-include 'skipif.inc';
 if (PHP_INT_SIZE == 4) {
         die("skip this test is for 64bit platform only");
 }

--- a/ext/calendar/tests/bug54254.phpt
+++ b/ext/calendar/tests/bug54254.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #54254 (cal_days_in_month incompatible with jdtojewish in non-leap-years)
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 var_dump(cal_days_in_month(CAL_JEWISH, 1, 5771));

--- a/ext/calendar/tests/bug55797_1.phpt
+++ b/ext/calendar/tests/bug55797_1.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #55797: Integer overflow in SdnToGregorian leads to segfault (in optimized builds)
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php
-include 'skipif.inc';
 if (PHP_INT_SIZE != 4) {
         die("skip this test is for 32bit platform only");
 }

--- a/ext/calendar/tests/bug55797_2.phpt
+++ b/ext/calendar/tests/bug55797_2.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #55797: Integer overflow in SdnToGregorian leads to segfault (in optimized builds)
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php
-include 'skipif.inc';
 if (PHP_INT_SIZE == 4) {
         die("skip this test is for 64bit platform only");
 }

--- a/ext/calendar/tests/bug67976.phpt
+++ b/ext/calendar/tests/bug67976.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #67976 (cal_days_month() fails for final month of the French calendar)
---SKIPIF--
-<?php
-if (!extension_loaded('calendar')) die('skip ext/calendar required');
-?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 var_dump(cal_days_in_month(CAL_FRENCH, 13, 14));

--- a/ext/calendar/tests/bug71894.phpt
+++ b/ext/calendar/tests/bug71894.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #71894 (AddressSanitizer: global-buffer-overflow in zif_cal_from_jd)
---SKIPIF--
-<?php
-if (!extension_loaded('calendar')) die('skip ext/calendar required');
-?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 var_dump(cal_from_jd(347997, CAL_JEWISH));

--- a/ext/calendar/tests/bug80185.phpt
+++ b/ext/calendar/tests/bug80185.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #80185 (jdtounix() fails after 2037)
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php
-if (!extension_loaded('calendar')) die('skip ext/calendar required');
 if (PHP_INT_SIZE != 8) die("skip for 64bit platforms only");
 ?>
 --FILE--

--- a/ext/calendar/tests/bug80185_32bit.phpt
+++ b/ext/calendar/tests/bug80185_32bit.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #80185 (jdtounix() fails after 2037)
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php
-if (!extension_loaded('calendar')) die('skip ext/calendar required');
 if (PHP_INT_SIZE != 4) die("skip for 32bit platforms only");
 ?>
 --FILE--

--- a/ext/calendar/tests/cal_days_in_month.phpt
+++ b/ext/calendar/tests/cal_days_in_month.phpt
@@ -1,7 +1,7 @@
 --TEST--
 cal_days_in_month()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 $num = cal_days_in_month(CAL_GREGORIAN, 8, 2003);

--- a/ext/calendar/tests/cal_days_in_month_error1.phpt
+++ b/ext/calendar/tests/cal_days_in_month_error1.phpt
@@ -2,8 +2,8 @@
 Test cal_days_in_month() function : error conditions
 --CREDITS--
 edgarsandi - <edgar.r.sandi@gmail.com>
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 try {

--- a/ext/calendar/tests/cal_from_jd.phpt
+++ b/ext/calendar/tests/cal_from_jd.phpt
@@ -1,7 +1,7 @@
 --TEST--
 cal_from_jd()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 print_r(cal_from_jd(1748326, CAL_GREGORIAN));

--- a/ext/calendar/tests/cal_from_jd_error1.phpt
+++ b/ext/calendar/tests/cal_from_jd_error1.phpt
@@ -2,8 +2,8 @@
 Test cal_from_jd() function : error conditions
 --CREDITS--
 edgarsandi - <edgar.r.sandi@gmail.com>
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 try {

--- a/ext/calendar/tests/cal_info.phpt
+++ b/ext/calendar/tests/cal_info.phpt
@@ -2,8 +2,8 @@
 cal_info()
 --INI--
 date.timezone=UTC
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
   print_r(cal_info());

--- a/ext/calendar/tests/cal_to_jd.phpt
+++ b/ext/calendar/tests/cal_to_jd.phpt
@@ -1,7 +1,7 @@
 --TEST--
 cal_to_jd()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo cal_to_jd(CAL_GREGORIAN, 8, 26, 74), "\n";

--- a/ext/calendar/tests/cal_to_jd_error1.phpt
+++ b/ext/calendar/tests/cal_to_jd_error1.phpt
@@ -2,8 +2,8 @@
 Test cal_to_jd() function : error conditions
 --CREDITS--
 edgarsandi - <edgar.r.sandi@gmail.com>
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 try {

--- a/ext/calendar/tests/easter_date.phpt
+++ b/ext/calendar/tests/easter_date.phpt
@@ -4,8 +4,8 @@ easter_date()
 date.timezone=UTC
 --ENV--
 TZ=UTC
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 putenv('TZ=UTC');

--- a/ext/calendar/tests/easter_days.phpt
+++ b/ext/calendar/tests/easter_days.phpt
@@ -1,7 +1,7 @@
 --TEST--
 easter_days()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo easter_days(1999), "\n";

--- a/ext/calendar/tests/frenchtojd.phpt
+++ b/ext/calendar/tests/frenchtojd.phpt
@@ -1,7 +1,7 @@
 --TEST--
 frenchtojd()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo frenchtojd(-1,-1,-1), "\n";

--- a/ext/calendar/tests/gregoriantojd.phpt
+++ b/ext/calendar/tests/gregoriantojd.phpt
@@ -1,7 +1,7 @@
 --TEST--
 gregoriantojd()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo gregoriantojd( 0, 0,    0). "\n";

--- a/ext/calendar/tests/gregoriantojd_overflow.phpt
+++ b/ext/calendar/tests/gregoriantojd_overflow.phpt
@@ -1,8 +1,9 @@
 --TEST--
 gregoriantojd()
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
-<?php include 'skipif.inc'; ?>
 --FILE--
 <?php
 echo gregoriantojd(5, 5, 6000000) . "\n";

--- a/ext/calendar/tests/jddayofweek.phpt
+++ b/ext/calendar/tests/jddayofweek.phpt
@@ -1,7 +1,7 @@
 --TEST--
 jddayofweek()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 foreach (array(2440588, 2452162, 2453926, -1000) as $jd) {

--- a/ext/calendar/tests/jdmonthname.phpt
+++ b/ext/calendar/tests/jdmonthname.phpt
@@ -1,7 +1,7 @@
 --TEST--
 jdmonthname()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 foreach (array(2440588, 2452162, 2453926) as $jd) {

--- a/ext/calendar/tests/jdtofrench.phpt
+++ b/ext/calendar/tests/jdtofrench.phpt
@@ -1,7 +1,7 @@
 --TEST--
 jdtofrench()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo jdtofrench(0). "\n";

--- a/ext/calendar/tests/jdtogregorian.phpt
+++ b/ext/calendar/tests/jdtogregorian.phpt
@@ -1,7 +1,7 @@
 --TEST--
 jdtogregorian()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo jdtogregorian(0). "\n";

--- a/ext/calendar/tests/jdtogregorian_overflow.phpt
+++ b/ext/calendar/tests/jdtogregorian_overflow.phpt
@@ -2,9 +2,10 @@
 jdtogregorian(): test overflow
 --CREDITS--
 neweracracker@gmail.com
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php
-if (!extension_loaded('calendar')) die('skip ext/calendar required');
 if (PHP_INT_SIZE != 4) die('skip this test is for 32bit platforms only');
 ?>
 --FILE--

--- a/ext/calendar/tests/jdtojewish.phpt
+++ b/ext/calendar/tests/jdtojewish.phpt
@@ -1,7 +1,7 @@
 --TEST--
 jdtojewish() function
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 

--- a/ext/calendar/tests/jdtojewish64.phpt
+++ b/ext/calendar/tests/jdtojewish64.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #64895: Integer overflow in SndToJewish
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php
-include 'skipif.inc';
 if (PHP_INT_SIZE == 4) {
         die("skip this test is for 64bit platform only");
 }

--- a/ext/calendar/tests/jdtojewish_hebrew.phpt
+++ b/ext/calendar/tests/jdtojewish_hebrew.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Test all hebrew month names
---SKIPIF--
-<?php
-if (!extension_loaded('calendar')) die('skip calendar extension not available');
-?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 for ($year = 5000; $year <= 5001; $year++) {

--- a/ext/calendar/tests/jdtojewish_overflow.phpt
+++ b/ext/calendar/tests/jdtojewish_overflow.phpt
@@ -2,10 +2,8 @@
 jdtojewish(): test overflow
 --CREDITS--
 neweracracker@gmail.com
---SKIPIF--
-<?php
-if (!extension_loaded('calendar')) die('skip ext/calendar required');
-?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 for ($i=324542840; $i<324542850; $i++) {

--- a/ext/calendar/tests/jdtojulian.phpt
+++ b/ext/calendar/tests/jdtojulian.phpt
@@ -1,7 +1,7 @@
 --TEST--
 jdtojulian()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo jdtojulian(0). "\n";

--- a/ext/calendar/tests/jdtomonthname.phpt
+++ b/ext/calendar/tests/jdtomonthname.phpt
@@ -1,7 +1,7 @@
 --TEST--
 jdtomonthname() test
---SKIPIF--
-<?php if (!extension_loaded("calendar")) print "skip"; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 

--- a/ext/calendar/tests/jdtounix.phpt
+++ b/ext/calendar/tests/jdtounix.phpt
@@ -2,8 +2,8 @@
 jdtounix()
 --INI--
 date.timezone=UTC
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo date("Y-m-d",jdtounix(2440588)). "\n";

--- a/ext/calendar/tests/jdtounix_error1.phpt
+++ b/ext/calendar/tests/jdtounix_error1.phpt
@@ -4,8 +4,8 @@ Test jdtounix() function : error conditions
 edgarsandi - <edgar.r.sandi@gmail.com>
 --INI--
 date.timezone=UTC
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 try {

--- a/ext/calendar/tests/jewishtojd.phpt
+++ b/ext/calendar/tests/jewishtojd.phpt
@@ -1,7 +1,7 @@
 --TEST--
 jewishtojd()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo jewishtojd(-1,-1,-1). "\n";

--- a/ext/calendar/tests/juliantojd.phpt
+++ b/ext/calendar/tests/juliantojd.phpt
@@ -1,7 +1,7 @@
 --TEST--
 juliantojd()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --FILE--
 <?php
 echo juliantojd( 0, 0,    0). "\n";

--- a/ext/calendar/tests/juliantojd_overflow.phpt
+++ b/ext/calendar/tests/juliantojd_overflow.phpt
@@ -1,8 +1,9 @@
 --TEST--
 juliantojd()
+--EXTENSIONS--
+calendar
 --SKIPIF--
 <?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
-<?php include 'skipif.inc'; ?>
 --FILE--
 <?php
 echo juliantojd(5, 5, 6000000000) . "\n";

--- a/ext/calendar/tests/skipif.inc
+++ b/ext/calendar/tests/skipif.inc
@@ -1,4 +1,0 @@
-<?php
-if(!extension_loaded("calendar"))
-    print "skip - CALENDAR extension not available";
-?>

--- a/ext/calendar/tests/unixtojd.phpt
+++ b/ext/calendar/tests/unixtojd.phpt
@@ -1,7 +1,7 @@
 --TEST--
 unixtojd()
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --ENV--
 TZ=UTC
 --FILE--

--- a/ext/calendar/tests/unixtojd_error1.phpt
+++ b/ext/calendar/tests/unixtojd_error1.phpt
@@ -2,8 +2,8 @@
 Test unixtojd() function : error conditions
 --CREDITS--
 edgarsandi - <edgar.r.sandi@gmail.com>
---SKIPIF--
-<?php include 'skipif.inc'; ?>
+--EXTENSIONS--
+calendar
 --INI--
 date.timezone=UTC
 --FILE--

--- a/ext/com_dotnet/tests/27974.phpt
+++ b/ext/com_dotnet/tests/27974.phpt
@@ -1,8 +1,7 @@
 --TEST--
 COM: mapping a safearray
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present"; ?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 error_reporting(E_ALL);

--- a/ext/com_dotnet/tests/bug33386.phpt
+++ b/ext/com_dotnet/tests/bug33386.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #33386 (ScriptControl only sees last function of class)
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present";
 if (4 != PHP_INT_SIZE)  print "skip MSScriptControl isn't available under x64";
 ?>
 --FILE--

--- a/ext/com_dotnet/tests/bug34272.phpt
+++ b/ext/com_dotnet/tests/bug34272.phpt
@@ -1,8 +1,7 @@
 --TEST--
 Bug #34272 (empty array onto COM object blows up)
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present"; ?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 error_reporting(E_ALL);

--- a/ext/com_dotnet/tests/bug39596.phpt
+++ b/ext/com_dotnet/tests/bug39596.phpt
@@ -1,8 +1,7 @@
 --TEST--
 Bug #39596 (Creating Variant of type VT_ARRAY)
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present"; ?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 error_reporting(E_ALL);

--- a/ext/com_dotnet/tests/bug39606.phpt
+++ b/ext/com_dotnet/tests/bug39606.phpt
@@ -1,8 +1,7 @@
 --TEST--
 COM: Loading typelib corrupts memory
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present"; ?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 error_reporting(E_ALL);

--- a/ext/com_dotnet/tests/bug45280.phpt
+++ b/ext/com_dotnet/tests/bug45280.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #45280 (Reflection of instantiated COM classes causes PHP to crash)
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")){ echo "skip COM/.Net support not present"; }
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 $dict = new COM("Scripting.Dictionary");

--- a/ext/com_dotnet/tests/bug49192.phpt
+++ b/ext/com_dotnet/tests/bug49192.phpt
@@ -1,8 +1,7 @@
 --TEST--
 Bug #49192 (PHP crashes when GC invoked on COM object)
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present"; ?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 

--- a/ext/com_dotnet/tests/bug62474.phpt
+++ b/ext/com_dotnet/tests/bug62474.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #62474 (com_event_sink crashes on certain arguments)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 var_dump(com_event_sink(new variant, function() {}, array()));

--- a/ext/com_dotnet/tests/bug63208.phpt
+++ b/ext/com_dotnet/tests/bug63208.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #63208 (BSTR to PHP string conversion not binary safe)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 $string = "\u{0905}b\0cd";

--- a/ext/com_dotnet/tests/bug64130.phpt
+++ b/ext/com_dotnet/tests/bug64130.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #64130 (COM obj parameters passed by reference are not updated)
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
 if (PHP_INT_SIZE != 4) die('skip for 32bit platforms only');
 try {
     $ie = new com('InternetExplorer.Application');

--- a/ext/com_dotnet/tests/bug66322.phpt
+++ b/ext/com_dotnet/tests/bug66322.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #66322 (COMPersistHelper::SaveToFile can save to wrong location)
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
 try {
     new COM('Word.Application');
 } catch (com_exception $ex) {

--- a/ext/com_dotnet/tests/bug66431_0.phpt
+++ b/ext/com_dotnet/tests/bug66431_0.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #66431 Special Character via COM Interface (CP_UTF8), Scripting.FileSystemObject
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")){ echo "skip COM/.Net support not present"; }
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 

--- a/ext/com_dotnet/tests/bug66431_1.phpt
+++ b/ext/com_dotnet/tests/bug66431_1.phpt
@@ -1,9 +1,9 @@
 --TEST--
 Bug #66431 Special Character via COM Interface (CP_UTF8), Application.Word
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded("com_dotnet")){ echo "skip COM/.Net support not present"; }
-
 try {
     new COM("word.application", NULL, CP_UTF8);
 } catch (Exception $e) {

--- a/ext/com_dotnet/tests/bug69939.phpt
+++ b/ext/com_dotnet/tests/bug69939.phpt
@@ -1,8 +1,7 @@
 --TEST--
 Bug #69939 (Casting object to bool returns false)
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present"; ?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 var_dump((bool) new COM('WScript.Shell'));

--- a/ext/com_dotnet/tests/bug72498.phpt
+++ b/ext/com_dotnet/tests/bug72498.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #72498 variant_date_from_timestamp null dereference
---SKIPIF--
-<?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present";
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 

--- a/ext/com_dotnet/tests/bug73679.phpt
+++ b/ext/com_dotnet/tests/bug73679.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #73679 DOTNET read access violation using invalid codepage
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present";
 if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platforms only");
 ?>
 --FILE--

--- a/ext/com_dotnet/tests/bug77177.phpt
+++ b/ext/com_dotnet/tests/bug77177.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #77177 (Serializing or unserializing COM objects crashes)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 $com = new COM("WScript.Shell");

--- a/ext/com_dotnet/tests/bug77578.phpt
+++ b/ext/com_dotnet/tests/bug77578.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #77578 (Crash when php unload)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 // To actually be able to verify the crash during shutdown on Windows, we have

--- a/ext/com_dotnet/tests/bug77621.phpt
+++ b/ext/com_dotnet/tests/bug77621.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #77621 (Already defined constants are not properly reported)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --INI--
 com.autoregister_verbose=1
 --FILE--

--- a/ext/com_dotnet/tests/bug78650.phpt
+++ b/ext/com_dotnet/tests/bug78650.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #78650 (new COM Crash)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 $fname = __DIR__ . '/bug78650/foo/bar';

--- a/ext/com_dotnet/tests/bug78694.phpt
+++ b/ext/com_dotnet/tests/bug78694.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #78694 (Appending to a variant array causes segfault)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 foreach ([new com('WScript.Shell'), new variant([])] as $var) {

--- a/ext/com_dotnet/tests/bug79242.phpt
+++ b/ext/com_dotnet/tests/bug79242.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug #79242 (COM error constants don't match com_exception codes)
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
 if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");
 ?>
 --FILE--

--- a/ext/com_dotnet/tests/bug79247.phpt
+++ b/ext/com_dotnet/tests/bug79247.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #79247 (Garbage collecting variant objects segfaults)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 $keep = new variant(null);

--- a/ext/com_dotnet/tests/bug79248.phpt
+++ b/ext/com_dotnet/tests/bug79248.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #79248 (Traversing empty VT_ARRAY throws com_exception)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 $v = new variant([], VT_ARRAY);

--- a/ext/com_dotnet/tests/bug79299.phpt
+++ b/ext/com_dotnet/tests/bug79299.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #79299 (com_print_typeinfo prints duplicate variables)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 $dict = new COM("Scripting.Dictionary");

--- a/ext/com_dotnet/tests/bug79332.phpt
+++ b/ext/com_dotnet/tests/bug79332.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #79332 (php_istreams are never freed)
---SKIPIF--
-<?php
-if (!extension_loaded('com_dotnet')) die('skip com_dotnet extension not available');
-?>
+--EXTENSIONS--
+com_dotnet
 --FILE--
 <?php
 $ph = new COMPersistHelper(null);

--- a/ext/com_dotnet/tests/variants.phpt
+++ b/ext/com_dotnet/tests/variants.phpt
@@ -1,8 +1,9 @@
 --TEST--
 COM: General variant tests
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present";
 if (4 != PHP_INT_SIZE) print "skip x86 only"; ?>
 --FILE--
 <?php

--- a/ext/com_dotnet/tests/variants_x64.phpt
+++ b/ext/com_dotnet/tests/variants_x64.phpt
@@ -1,8 +1,9 @@
 --TEST--
 COM: General variant tests
+--EXTENSIONS--
+com_dotnet
 --SKIPIF--
 <?php
-if (!extension_loaded("com_dotnet")) print "skip COM/.Net support not present";
 if (8 != PHP_INT_SIZE) print "skip x64 only";
 if ((string) variant_cat(new VARIANT(false), new VARIANT(0.5)) != 'False0.5')
     print "skip English locale only";

--- a/ext/ctype/tests/001.phpt
+++ b/ext/ctype/tests/001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 ctype on integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
   setlocale(LC_ALL,"C");

--- a/ext/ctype/tests/002.phpt
+++ b/ext/ctype/tests/002.phpt
@@ -1,7 +1,7 @@
 --TEST--
 ctype on strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 

--- a/ext/ctype/tests/bug25745.phpt
+++ b/ext/ctype/tests/bug25745.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #25745 (ctype functions fail with non-ascii characters)
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 $funcs = array(

--- a/ext/ctype/tests/bug34645.phpt
+++ b/ext/ctype/tests/bug34645.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #34645 (ctype corrupts memory when validating large numbers)
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 $id = 394829384;

--- a/ext/ctype/tests/ctype_alnum_basic.phpt
+++ b/ext/ctype/tests/ctype_alnum_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alnum() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_alnum() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_alnum_variation1.phpt
+++ b/ext/ctype/tests/ctype_alnum_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alnum() function : usage variations - Different data types as $c arg
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_alnum_variation2.phpt
+++ b/ext/ctype/tests/ctype_alnum_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alnum() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_alnum_variation3.phpt
+++ b/ext/ctype/tests/ctype_alnum_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alnum() function : usage variations - different string values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_alnum_variation4.phpt
+++ b/ext/ctype/tests/ctype_alnum_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alnum() function : usage variations  - octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_alpha_basic.phpt
+++ b/ext/ctype/tests/ctype_alpha_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alpha() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_alpha() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_alpha_variation1.phpt
+++ b/ext/ctype/tests/ctype_alpha_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alpha() function : usage variations - different data types as $c arg
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_alpha_variation2.phpt
+++ b/ext/ctype/tests/ctype_alpha_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alpha() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_alpha_variation3.phpt
+++ b/ext/ctype/tests/ctype_alpha_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alpha() function : usage variations - different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_alpha_variation4.phpt
+++ b/ext/ctype/tests/ctype_alpha_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_alpha() function : usage variations - Octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_cntrl_basic.phpt
+++ b/ext/ctype/tests/ctype_cntrl_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_cntrl() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_cntrl() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_cntrl_variation1.phpt
+++ b/ext/ctype/tests/ctype_cntrl_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_cntrl() function : usage variations - Different data types as $c arg
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_cntrl_variation2.phpt
+++ b/ext/ctype/tests/ctype_cntrl_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_cntrl() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_cntrl_variation3.phpt
+++ b/ext/ctype/tests/ctype_cntrl_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_cntrl() function : usage variations - Different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_cntrl_variation4.phpt
+++ b/ext/ctype/tests/ctype_cntrl_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_cntrl() function : usage variations - Octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_digit_basic.phpt
+++ b/ext/ctype/tests/ctype_digit_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_digit() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_digit() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_digit_variation1.phpt
+++ b/ext/ctype/tests/ctype_digit_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_digit() function : usage variations - different data types as $c arg
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_digit_variation2.phpt
+++ b/ext/ctype/tests/ctype_digit_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_digit() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_digit_variation3.phpt
+++ b/ext/ctype/tests/ctype_digit_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_digit() function : usage variations - different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_digit_variation4.phpt
+++ b/ext/ctype/tests/ctype_digit_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_digit() function : usage variations - octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_graph_basic.phpt
+++ b/ext/ctype/tests/ctype_graph_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_graph() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_graph() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_graph_variation1.phpt
+++ b/ext/ctype/tests/ctype_graph_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_graph() function : usage variations - different data types as $c arg
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_graph_variation2.phpt
+++ b/ext/ctype/tests/ctype_graph_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_graph() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_graph_variation3.phpt
+++ b/ext/ctype/tests/ctype_graph_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_graph() function : usage variations - different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_graph_variation4.phpt
+++ b/ext/ctype/tests/ctype_graph_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_graph() function : usage variations - octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_lower_basic.phpt
+++ b/ext/ctype/tests/ctype_lower_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_lower() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_lower() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_lower_variation1.phpt
+++ b/ext/ctype/tests/ctype_lower_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_lower() function : usage variations - different data types as $c arg
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_lower_variation2.phpt
+++ b/ext/ctype/tests/ctype_lower_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_lower() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_lower_variation3.phpt
+++ b/ext/ctype/tests/ctype_lower_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_lower() function : usage variations - different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_lower_variation4.phpt
+++ b/ext/ctype/tests/ctype_lower_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_lower() function : usage variations - octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_print_basic.phpt
+++ b/ext/ctype/tests/ctype_print_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_print() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_print() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_print_variation1.phpt
+++ b/ext/ctype/tests/ctype_print_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_print() function : usage variations - different data types as $c arg
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_print_variation2.phpt
+++ b/ext/ctype/tests/ctype_print_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_print() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_print_variation3.phpt
+++ b/ext/ctype/tests/ctype_print_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_print() function : usage variations - different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_print_variation4.phpt
+++ b/ext/ctype/tests/ctype_print_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_print() function : usage variations - octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_punct_basic.phpt
+++ b/ext/ctype/tests/ctype_punct_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_punct() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_punct() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_punct_variation1.phpt
+++ b/ext/ctype/tests/ctype_punct_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_punct() function : usage variations - different data types as $c argument
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_punct_variation2.phpt
+++ b/ext/ctype/tests/ctype_punct_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_punct() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_punct_variation3.phpt
+++ b/ext/ctype/tests/ctype_punct_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_punct() function : usage variations - different punctuation
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_punct_variation4.phpt
+++ b/ext/ctype/tests/ctype_punct_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_punct() function : usage variations - Octal and Hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_space_basic.phpt
+++ b/ext/ctype/tests/ctype_space_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_space() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_space() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_space_variation1.phpt
+++ b/ext/ctype/tests/ctype_space_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_space() function : usage variations - different data types as $c argument
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_space_variation2.phpt
+++ b/ext/ctype/tests/ctype_space_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_space() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_space_variation3.phpt
+++ b/ext/ctype/tests/ctype_space_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_space() function : usage variations - different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_space_variation4.phpt
+++ b/ext/ctype/tests/ctype_space_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_space() function : usage variations - octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_upper_basic.phpt
+++ b/ext/ctype/tests/ctype_upper_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_upper() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_upper() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_upper_variation1.phpt
+++ b/ext/ctype/tests/ctype_upper_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_upper() function : usage variations - different data types
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_upper_variation2.phpt
+++ b/ext/ctype/tests/ctype_upper_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_upper() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_upper_variation3.phpt
+++ b/ext/ctype/tests/ctype_upper_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_upper() function : usage variations - different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_upper_variation4.phpt
+++ b/ext/ctype/tests/ctype_upper_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_upper() function : usage variations - octal and hexadecimal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_xdigit_basic.phpt
+++ b/ext/ctype/tests/ctype_xdigit_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_xdigit() function : basic functionality
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 echo "*** Testing ctype_xdigit() : basic functionality ***\n";

--- a/ext/ctype/tests/ctype_xdigit_variation1.phpt
+++ b/ext/ctype/tests/ctype_xdigit_variation1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_xdigit() function : usage variations - different data typse as $c arg
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_xdigit_variation2.phpt
+++ b/ext/ctype/tests/ctype_xdigit_variation2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_xdigit() function : usage variations - different integers
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_xdigit_variation3.phpt
+++ b/ext/ctype/tests/ctype_xdigit_variation3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_xdigit() function : usage variations - Different strings
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/ctype_xdigit_variation4.phpt
+++ b/ext/ctype/tests/ctype_xdigit_variation4.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test ctype_xdigit() function : usage variations - heaxadecimal and octal values
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+ctype
 --FILE--
 <?php
 /*

--- a/ext/ctype/tests/skipif.inc
+++ b/ext/ctype/tests/skipif.inc
@@ -1,1 +1,0 @@
-<?php	if (!extension_loaded('ctype')) die('skip ctype extension not available');?>


### PR DESCRIPTION
For rationale, see https://github.com/php/php-src/pull/6787

Extensions migrated in part 1:
* bcmath
* bz2
* calendar
* com_dotnet
* ctype