### PR TITLE
Fix #73533: Invalid memory access in php_libxml_xmlCheckUTF8

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -1182,7 +1182,7 @@ static PHP_FUNCTION(libxml_set_external_entity_loader)
 /* {{{ Common functions shared by extensions */
 int php_libxml_xmlCheckUTF8(const unsigned char *s)
 {
-	int i;
+	size_t i;
 	unsigned char c;
 
 	for (i = 0; (c = s[i++]);) {


### PR DESCRIPTION
A string passed to `php_libxml_xmlCheckUTF8()` may be longer than
1<<31-1 bytes, so we're better using a `size_t`.