### PR TITLE
Fix #80880: SSL_read on shutdown, ftp/proc_open

### DIFF
--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1932,8 +1932,9 @@ static void ftp_ssl_shutdown(ftpbuf_t *ftp, php_socket_t fd, SSL *ssl_handle) {
 					done = 1;
 					break;
 				case SSL_ERROR_SYSCALL:
-					/* Something went totally wrong; bail out to avoid raising
-					   a spurious warning. */
+					/* most likely the peer closed the connection without
+					   sending a close_notify shutdown alert;
+					   bail out to avoid raising a spurious warning */
 					done = 1;
 					break;
 				default:

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1931,6 +1931,14 @@ static void ftp_ssl_shutdown(ftpbuf_t *ftp, php_socket_t fd, SSL *ssl_handle) {
 					/* SSL wants a write. Really odd. Let's bail out. */
 					done = 1;
 					break;
+# ifdef PHP_WIN32
+				case SSL_ERROR_SYSCALL:
+					if (WSAGetLastError() == WSAECONNABORTED) {
+						/* suppress spurious warning if connection is aborted */
+						done = 1;
+					}
+					break;
+# endif
 				default:
 					if ((sslerror = ERR_get_error())) {
 						ERR_error_string_n(sslerror, buf, sizeof(buf));

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1931,15 +1931,11 @@ static void ftp_ssl_shutdown(ftpbuf_t *ftp, php_socket_t fd, SSL *ssl_handle) {
 					/* SSL wants a write. Really odd. Let's bail out. */
 					done = 1;
 					break;
-# ifdef PHP_WIN32
 				case SSL_ERROR_SYSCALL:
-					if (WSAGetLastError() == WSAECONNABORTED) {
-						/* suppress spurious warning if connection is aborted */
-						done = 1;
-						break;
-					}
-					/* fallthrough */
-# endif
+					/* Something went totally wrong; bail out to avoid raising
+					   a spurious warning. */
+					done = 1;
+					break;
 				default:
 					if ((sslerror = ERR_get_error())) {
 						ERR_error_string_n(sslerror, buf, sizeof(buf));

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1936,8 +1936,9 @@ static void ftp_ssl_shutdown(ftpbuf_t *ftp, php_socket_t fd, SSL *ssl_handle) {
 					if (WSAGetLastError() == WSAECONNABORTED) {
 						/* suppress spurious warning if connection is aborted */
 						done = 1;
+						break;
 					}
-					break;
+					/* fallthrough */
 # endif
 				default:
 					if ((sslerror = ERR_get_error())) {


### PR DESCRIPTION
When `SSL_read()` after `SSL_shutdown()` fails with `SSL_ERROR_SYSCALL`,
we should not warn about this on Windows for `WSAECONNABORTED`.

---
I'm not sure whether this is a Windows specific issue, or whether `SSL_ERROR_SYSCALL` may happen on other systems as well, so I went with a Windows specific patch. @manuelm, since you've implemented the proper SSL shutdown, maybe you want to have a look.