### PR TITLE
Check liveness in PDO_ODBC

### DIFF
--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -372,6 +372,26 @@ static int odbc_handle_get_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 	return 0;
 }
 
+static zend_result odbc_handle_check_liveness(pdo_dbh_t *dbh)
+{
+	RETCODE ret;
+	UCHAR d_name[32];
+	SQLSMALLINT len;
+	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
+
+	/*
+	 *  XXX: Should we be using SQL_ATTR_CONNECTION_DEAD? Procedural ODBC
+	 *  uses this check, but it might be problematic per #20298
+	 */
+	ret = SQLGetInfo(H->dbc, SQL_DATA_SOURCE_READ_ONLY, d_name,
+		sizeof(d_name), &len);
+
+	if(ret != SQL_SUCCESS || len == 0) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
 static const struct pdo_dbh_methods odbc_methods = {
 	odbc_handle_closer,
 	odbc_handle_preparer,
@@ -384,7 +404,7 @@ static const struct pdo_dbh_methods odbc_methods = {
 	NULL,	/* last id */
 	pdo_odbc_fetch_error_func,
 	odbc_handle_get_attr,	/* get attr */
-	NULL, /* check_liveness */
+	odbc_handle_check_liveness, /* check_liveness */
 	NULL, /* get_driver_methods */
 	NULL, /* request_shutdown */
 	NULL, /* in transaction, use PDO's internal tracking mechanism */

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -375,18 +375,13 @@ static int odbc_handle_get_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 static zend_result odbc_handle_check_liveness(pdo_dbh_t *dbh)
 {
 	RETCODE ret;
-	UCHAR d_name[32];
-	SQLSMALLINT len;
+	SQLUINTEGER dead;
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
 
-	/*
-	 *  XXX: Should we be using SQL_ATTR_CONNECTION_DEAD? Procedural ODBC
-	 *  uses this check, but it might be problematic per #20298
-	 */
-	ret = SQLGetInfo(H->dbc, SQL_DATA_SOURCE_READ_ONLY, d_name,
-		sizeof(d_name), &len);
+	/* ODBC 3.5; procedural ODBC uses SQLGetInfo read only instead */
+	ret = SQLGetConnectAttr(H->dbc, SQL_ATTR_CONNECTION_DEAD, &dead, 0, NULL);
 
-	if (ret != SQL_SUCCESS || len == 0) {
+	if (ret != SQL_SUCCESS || dead == SQL_CD_TRUE) {
 		return FAILURE;
 	}
 	return SUCCESS;

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -386,7 +386,7 @@ static zend_result odbc_handle_check_liveness(pdo_dbh_t *dbh)
 	ret = SQLGetInfo(H->dbc, SQL_DATA_SOURCE_READ_ONLY, d_name,
 		sizeof(d_name), &len);
 
-	if(ret != SQL_SUCCESS || len == 0) {
+	if (ret != SQL_SUCCESS || len == 0) {
 		return FAILURE;
 	}
 	return SUCCESS;


### PR DESCRIPTION
PDO drivers allow for it, and procedural ODBC has its own facility for it, but PDO_ODBC doesn't. If a connection is severed (for example, on IBM i, ending a database job, or killing the network connection elsewhere), a persistent connection could get stuck. This adapts the procedural ODBC code to PDO for handling connection liveness, so PDO can reconnect if needed.

A discussion about the method to check liveness is linked; this might not be the best method, but it's what procedural ODBC uses, so it's consistent.