### PR TITLE
Removes 'Parallel Edition' output in tests

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1386,10 +1386,6 @@ function run_all_tests_parallel(array $test_files, array $env, $redir_tested): v
     $workerProcs = [];
     $workerSocks = [];
 
-    echo "=====================================================================\n";
-    echo "========= WELCOME TO THE FUTURE: run-tests PARALLEL EDITION =========\n";
-    echo "=====================================================================\n";
-
     // Each test may specify a list of conflict keys. While a test that conflicts with
     // key K is running, no other test that conflicts with K may run. Conflict keys are
     // specified either in the --CONFLICTS-- section, or CONFLICTS file inside a directory.


### PR DESCRIPTION
This pull requests removes the "Parallel Edition" output while running tests.

Before:
<img width="1253" alt="Screenshot 2021-03-25 at 00 01 16" src="https://user-images.githubusercontent.com/5457236/112398966-3b091e80-8cfd-11eb-970c-eda4db4cafb4.png">

After:
<img width="1253" alt="Screenshot 2021-03-25 at 00 00 28" src="https://user-images.githubusercontent.com/5457236/112398933-1e6ce680-8cfd-11eb-8f2e-29d5625ad225.png">
