### PR TITLE
Remove zero size special case for copy_to_stream

### DIFF
--- a/ext/standard/tests/file/stream_copy_to_stream_empty.phpt
+++ b/ext/standard/tests/file/stream_copy_to_stream_empty.phpt
@@ -1,0 +1,19 @@
+--TEST--
+stream_copy_to_stream() from empty file
+--FILE--
+<?php
+
+$tmp_empty_file = __FILE__ . ".tmp";
+file_put_contents($tmp_empty_file, "");
+
+$in = fopen($tmp_empty_file, 'r');
+$out = fopen('php://memory', 'w');
+var_dump(stream_copy_to_stream($in, $out));
+
+?>
+--CLEAN--
+<?php
+unlink(__FILE__ . ".tmp");
+?>
+--EXPECT--
+int(0)

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1629,20 +1629,13 @@ PHPAPI int _php_stream_copy_to_stream_ex(php_stream *src, php_stream *dest, size
 			writeptr += didwrite;
 		}
 
-		if (maxlen - haveread == 0) {
+		if (maxlen && maxlen == haveread) {
 			break;
 		}
 	}
 
 	*len = haveread;
-
-	/* we've got at least 1 byte to read.
-	 * less than 1 is an error */
-
-	if (haveread > 0 || src->eof) {
-		return SUCCESS;
-	}
-	return FAILURE;
+	return SUCCESS;
 }
 
 /* Returns the number of bytes moved.

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1539,7 +1539,6 @@ PHPAPI int _php_stream_copy_to_stream_ex(php_stream *src, php_stream *dest, size
 	size_t haveread = 0;
 	size_t towrite;
 	size_t dummy;
-	php_stream_statbuf ssbuf;
 
 	if (!len) {
 		len = &dummy;
@@ -1552,17 +1551,6 @@ PHPAPI int _php_stream_copy_to_stream_ex(php_stream *src, php_stream *dest, size
 
 	if (maxlen == PHP_STREAM_COPY_ALL) {
 		maxlen = 0;
-	}
-
-	if (php_stream_stat(src, &ssbuf) == 0) {
-		if (ssbuf.sb.st_size == 0
-#ifdef S_ISREG
-			&& S_ISREG(ssbuf.sb.st_mode)
-#endif
-		) {
-			*len = 0;
-			return SUCCESS;
-		}
 	}
 
 	if (php_stream_mmap_possible(src)) {


### PR DESCRIPTION
This doesn't seem to serve any purpose. Stats are expensive, so doing an unnecessary stat just to short-circuit the zero size case seems rather dubious. It can also break with stream wrappers that return inaccurate sizes (https://github.com/symfony/symfony/issues/40574) and probably can also break with stream filters. I think we should just drop it...