### PR TITLE
Fix #80460: ODBC doesn't account for SQL_NO_TOTAL indicator

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1814,6 +1814,9 @@ static void php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, int result_type)
 				} else if (result->values[i].vallen == SQL_NULL_DATA) {
 					ZVAL_NULL(&tmp);
 					break;
+				} else if (result->values[i].vallen == SQL_NO_TOTAL) {
+					php_error_docref(NULL, E_WARNING, "Cannot get data of column #%d (driver cannot determine length)", i + 1, rc);
+					ZVAL_FALSE(&tmp);
 				} else {
 					ZVAL_STRINGL(&tmp, buf, result->values[i].vallen);
 				}
@@ -1822,6 +1825,10 @@ static void php_odbc_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, int result_type)
 			default:
 				if (result->values[i].vallen == SQL_NULL_DATA) {
 					ZVAL_NULL(&tmp);
+					break;
+				} else if (result->values[i].vallen == SQL_NO_TOTAL) {
+					php_error_docref(NULL, E_WARNING, "Cannot get data of column #%d (driver cannot determine length)", i + 1, rc);
+					ZVAL_FALSE(&tmp);
 					break;
 				}
 				ZVAL_STRINGL(&tmp, result->values[i].value, result->values[i].vallen);
@@ -1970,6 +1977,9 @@ PHP_FUNCTION(odbc_fetch_into)
 				} else if (result->values[i].vallen == SQL_NULL_DATA) {
 					ZVAL_NULL(&tmp);
 					break;
+				} else if (result->values[i].vallen == SQL_NO_TOTAL) {
+					php_error_docref(NULL, E_WARNING, "Cannot get data of column #%d (driver cannot determine length)", i + 1, rc);
+					ZVAL_FALSE(&tmp);
 				} else {
 					ZVAL_STRINGL(&tmp, buf, result->values[i].vallen);
 				}
@@ -1978,6 +1988,10 @@ PHP_FUNCTION(odbc_fetch_into)
 			default:
 				if (result->values[i].vallen == SQL_NULL_DATA) {
 					ZVAL_NULL(&tmp);
+					break;
+				} else if (result->values[i].vallen == SQL_NO_TOTAL) {
+					php_error_docref(NULL, E_WARNING, "Cannot get data of column #%d (driver cannot determine length)", i + 1, rc);
+					ZVAL_FALSE(&tmp);
 					break;
 				}
 				ZVAL_STRINGL(&tmp, result->values[i].value, result->values[i].vallen);
@@ -2211,6 +2225,10 @@ PHP_FUNCTION(odbc_result)
 			} else if (result->values[field_ind].vallen == SQL_NULL_DATA) {
 				zend_string_efree(field_str);
 				RETURN_NULL();
+			} else if (result->values[field_ind].vallen == SQL_NO_TOTAL) {
+				zend_string_efree(field_str);
+				php_error_docref(NULL, E_WARNING, "Cannot get data of column #%d (driver cannot determine length)", field_ind + 1, rc);
+				RETURN_FALSE;
 			}
 			/* Reduce fieldlen by 1 if we have char data. One day we might
 			   have binary strings... */
@@ -2234,6 +2252,9 @@ PHP_FUNCTION(odbc_result)
 		default:
 			if (result->values[field_ind].vallen == SQL_NULL_DATA) {
 				RETURN_NULL();
+			} else if (result->values[field_ind].vallen == SQL_NO_TOTAL) {
+				php_error_docref(NULL, E_WARNING, "Cannot get data of column #%d (driver cannot determine length)", field_ind + 1, rc);
+				RETURN_FALSE;
 			} else {
 				RETURN_STRINGL(result->values[field_ind].value, result->values[field_ind].vallen);
 			}
@@ -2265,6 +2286,10 @@ PHP_FUNCTION(odbc_result)
 		if (result->values[field_ind].vallen == SQL_NULL_DATA) {
 			efree(field);
 			RETURN_NULL();
+		} else if (result->values[field_ind].vallen == SQL_NO_TOTAL) {
+			php_error_docref(NULL, E_WARNING, "Cannot get data of column #%d (driver cannot determine length)", field_ind + 1, rc);
+			efree(field);
+			RETURN_FALSE;
 		}
 		/* chop the trailing \0 by outputting only 4095 bytes */
 		PHPWRITE(field,(rc == SQL_SUCCESS_WITH_INFO) ? 4095 : result->values[field_ind].vallen);
@@ -2370,7 +2395,14 @@ PHP_FUNCTION(odbc_result_all)
 						RETURN_FALSE;
 					}
 					if (rc == SQL_SUCCESS_WITH_INFO) {
-						PHPWRITE(buf, result->longreadlen);
+						if (result->values[i].vallen == SQL_NO_TOTAL) {
+							php_printf("</td></tr></table>");
+							php_error_docref(NULL, E_WARNING, "Cannot get data of column #%zu (driver cannot determine length)", i + 1, rc);
+							efree(buf);
+							RETURN_FALSE;
+						} else {
+							PHPWRITE(buf, result->longreadlen);
+						}
 					} else if (rc != SQL_SUCCESS) {
 						php_printf("</td></tr></table>");
 						php_error_docref(NULL, E_WARNING, "Cannot get data of column #%zu (retcode %u)", i + 1, rc);
@@ -2387,6 +2419,9 @@ PHP_FUNCTION(odbc_result_all)
 				default:
 					if (result->values[i].vallen == SQL_NULL_DATA) {
 						php_printf("<td>NULL</td>");
+					} else if (result->values[i].vallen == SQL_NO_TOTAL) {
+						php_error_docref(NULL, E_WARNING, "Cannot get data of column #%zu (driver cannot determine length)", i + 1, rc);
+						php_printf("<td>FALSE</td>");
 					} else {
 						php_printf("<td>%s</td>", result->values[i].value);
 					}


### PR DESCRIPTION
The `StrLen_or_IndPtr` parameter usually may be `SQL_NO_TOTAL`; we need
to cater to that possibility to avoid working with negative string
lengths and other issues.  A noteable exemption are calls to
`SQLGetData()` which return `SQL_SUCCESS`; in that case `SQL_NO_TOTAL`
can not occur.

---

Marked as draft, because I'm hoping to get at least a test case for the behavior from the bug reporter.