### PR TITLE
:bug: Fixed Bug #80908 PDO::lastInsertId() return wrong.

### DIFF
--- a/ext/pdo/pdo.c
+++ b/ext/pdo/pdo.c
@@ -281,6 +281,40 @@ PDO_API zend_string *php_pdo_int64_to_str(int64_t i64) /* {{{ */
 }
 /* }}} */
 
+/* Convert uint64 to zend_string */
+PDO_API zend_string *php_pdo_uint64_to_str(uint64_t i64) /* {{{ */
+{
+	char buffer[65];
+	char outbuf[65] = "";
+	register char *p;
+	zend_long long_val;
+	char *dst = outbuf;
+
+	if (i64 == 0) {
+		return ZSTR_CHAR('0');
+	}
+
+	p = &buffer[sizeof(buffer)-1];
+	*p = '\0';
+
+	while ((uint64_t)i64 > (uint64_t)ZEND_LONG_MAX) {
+		uint64_t quo = (uint64_t)i64 / (unsigned int)10;
+		unsigned int rem = (unsigned int)(i64 - quo*10U);
+		*--p = digit_vec[rem];
+		i64 = (int64_t)quo;
+	}
+	long_val = (zend_long)i64;
+	while (long_val != 0) {
+		zend_long quo = long_val / 10;
+		*--p = digit_vec[(unsigned int)(long_val - quo * 10)];
+		long_val = quo;
+	}
+	while ((*dst++ = *p++) != 0)
+		;
+	*dst = '\0';
+	return zend_string_init(outbuf, strlen(outbuf), 0);
+}
+
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(pdo)
 {

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -27,6 +27,7 @@ typedef struct _pdo_row_t		 pdo_row_t;
 struct pdo_bound_param_data;
 
 PDO_API zend_string *php_pdo_int64_to_str(int64_t i64);
+PDO_API zend_string *php_pdo_uint64_to_str(uint64_t ui64);
 
 #ifndef TRUE
 # define TRUE 1

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -289,7 +289,7 @@ static zend_string *pdo_mysql_last_insert_id(pdo_dbh_t *dbh, const zend_string *
 {
 	pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 	PDO_DBG_ENTER("pdo_mysql_last_insert_id");
-	PDO_DBG_RETURN(php_pdo_int64_to_str(mysql_insert_id(H->server)));
+	PDO_DBG_RETURN(php_pdo_uint64_to_str(mysql_insert_id(H->server)));
 }
 /* }}} */
 

--- a/ext/pdo_mysql/tests/bug80908.phpt
+++ b/ext/pdo_mysql/tests/bug80908.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Bug #80908: pdo_mysql lastInsertId() return wrong, when table id bigger than the maximum value of int64
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_mysql')) die('skip not loaded');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'skipif.inc');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+MySQLPDOTest::skip();
+?>
+--FILE--
+<?php
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+
+function createDB(): PDO {
+    $db = MySQLPDOTest::factory();
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+    return $db;
+}
+
+$db = createDB();
+$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('CREATE TABLE test (`id` bigint(20) unsigned AUTO_INCREMENT, `name` varchar(5), primary key (`id`)) ENGINE = InnoDB AUTO_INCREMENT=10376293541461622799');
+
+function testLastInsertId(PDO $db) {
+    echo "Running test lastInsertId\n";
+    $db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+    try {
+        $db->exec("insert into test (`name`) values ('bar')");
+        $id = $db->lastInsertId();
+        echo "Last insert id is " . $id . "\n";
+    } catch (PDOException $e) {
+        echo $e->getMessage()."\n";
+    }
+}
+
+testLastInsertId($db);
+unset($db);
+echo "\n";
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+MySQLPDOTest::dropTestTable();
+?>
+--EXPECT--
+Running test lastInsertId
+Last insert id is 10376293541461622799


### PR DESCRIPTION
Fixed Bug #80908 
  
MySQL api function `last_insert_id()` always return unsigned interger,
but in `ext.pdo_mysql` we use `int64` to receive the `uint64` return value.
When MySQL table `auto_increment id` bigger than the maximum value of
int64, `ext.pdo_mysql` will treat as `int64`.