### PR TITLE
Fix typos in the error message

### DIFF
--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -449,8 +449,7 @@ PHP_FUNCTION(mysqli_fetch_all)
 	MYSQLI_FETCH_RESOURCE(result, MYSQL_RES *, mysql_result, "mysqli_result", MYSQLI_STATUS_VALID);
 
 	if (!mode || (mode & ~MYSQLI_BOTH)) {
-		zend_argument_value_error(ERROR_ARG_POS(2), "must be one of MYSQLI_FETCH_NUM, "
-		                 "MYSQLI_FETCH_ASSOC, or MYSQLI_FETCH_BOTH");
+		zend_argument_value_error(ERROR_ARG_POS(2), "must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH");
 		RETURN_THROWS();
 	}
 

--- a/ext/mysqli/tests/mysqli_fetch_all.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_all.phpt
@@ -440,6 +440,6 @@ array(1) {
     string(1) "1"
   }
 }
-mysqli_fetch_all(): Argument #2 ($mode) must be one of MYSQLI_FETCH_NUM, MYSQLI_FETCH_ASSOC, or MYSQLI_FETCH_BOTH
+mysqli_fetch_all(): Argument #2 ($mode) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
 mysqli_result object is already closed
 done!

--- a/ext/mysqli/tests/mysqli_fetch_all_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_all_oo.phpt
@@ -432,6 +432,6 @@ array(1) {
     string(1) "1"
   }
 }
-mysqli_result::fetch_all(): Argument #1 ($mode) must be one of MYSQLI_FETCH_NUM, MYSQLI_FETCH_ASSOC, or MYSQLI_FETCH_BOTH
+mysqli_result::fetch_all(): Argument #1 ($mode) must be one of MYSQLI_NUM, MYSQLI_ASSOC, or MYSQLI_BOTH
 mysqli_result object is already closed
 done!


### PR DESCRIPTION
The error message was referring to invalid constant names. 