### PR TITLE
Fix #49270: configure fails if PHP source folder path contains spaces

### DIFF
--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -13,10 +13,10 @@ $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
 # Tweak zendparse to be exported through ZEND_API. This has to be revisited once
 # bison supports foreign skeletons and that bison version is used. Read
 # https://git.savannah.gnu.org/cgit/bison.git/tree/data/README.md for more.
-	@$(YACC) -p zend -v -d $(srcdir)/zend_language_parser.y -o $@
-	@$(SED) -e 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' < $@ \
-	> $@.tmp && \
-	mv $@.tmp $@
+	@$(YACC) -p zend -v -d $(srcdir)/zend_language_parser.y -o "$@"
+	@$(SED) -e 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' < "$@" \
+	> "$@".tmp && \
+	mv "$@".tmp "$@"
 	@$(SED) -e 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' < $(srcdir)/zend_language_parser.h \
 	> $(srcdir)/zend_language_parser.h.tmp && \
 	mv $(srcdir)/zend_language_parser.h.tmp $(srcdir)/zend_language_parser.h
@@ -27,7 +27,7 @@ $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
 
 $(srcdir)/zend_ini_parser.h: $(srcdir)/zend_ini_parser.c
 $(srcdir)/zend_ini_parser.c: $(srcdir)/zend_ini_parser.y
-	@$(YACC) -p ini_ -v -d $(srcdir)/zend_ini_parser.y -o $@
+	@$(YACC) -p ini_ -v -d $(srcdir)/zend_ini_parser.y -o "$@"
 
 $(srcdir)/zend_ini_scanner.c: $(srcdir)/zend_ini_scanner.l
 	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l)

--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -16,8 +16,8 @@ build-modules: $(PHP_MODULES) $(PHP_ZEND_EX)
 build-binaries: $(PHP_BINARIES)
 
 libphp$(PHP_MAJOR_VERSION).la: $(PHP_GLOBAL_OBJS) $(PHP_SAPI_OBJS)
-	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) $(EXTRA_CFLAGS) -rpath $(phptempdir) $(EXTRA_LDFLAGS) $(LDFLAGS) $(PHP_RPATHS) $(PHP_GLOBAL_OBJS) $(PHP_SAPI_OBJS) $(EXTRA_LIBS) $(ZEND_EXTRA_LIBS) -o $@
-	-@$(LIBTOOL) --silent --mode=install cp $@ $(phptempdir)/$@ >/dev/null 2>&1
+	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) $(EXTRA_CFLAGS) -rpath "$(phptempdir)" $(EXTRA_LDFLAGS) $(LDFLAGS) $(PHP_RPATHS) $(PHP_GLOBAL_OBJS) $(PHP_SAPI_OBJS) $(EXTRA_LIBS) $(ZEND_EXTRA_LIBS) -o $@
+	-@$(LIBTOOL) --silent --mode=install cp $@ "$(phptempdir)/$@" >/dev/null 2>&1
 
 libs/libphp$(PHP_MAJOR_VERSION).bundle: $(PHP_GLOBAL_OBJS) $(PHP_SAPI_OBJS)
 	$(CC) $(MH_BUNDLE_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) $(PHP_GLOBAL_OBJS:.lo=.o) $(PHP_SAPI_OBJS:.lo=.o) $(PHP_FRAMEWORKS) $(EXTRA_LIBS) $(ZEND_EXTRA_LIBS) -o $@ && cp $@ libs/libphp$(PHP_MAJOR_VERSION).so
@@ -27,10 +27,10 @@ install: $(all_targets) $(install_targets)
 install-sapi: $(OVERALL_TARGET)
 	@echo "Installing PHP SAPI module:       $(PHP_SAPI)"
 	-@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
-	-@if test ! -r $(phptempdir)/libphp$(PHP_MAJOR_VERSION).$(SHLIB_DL_SUFFIX_NAME); then \
+	-@if test ! -r "$(phptempdir)/libphp$(PHP_MAJOR_VERSION).$(SHLIB_DL_SUFFIX_NAME)"; then \
 		for i in 0.0.0 0.0 0; do \
-			if test -r $(phptempdir)/libphp$(PHP_MAJOR_VERSION).$(SHLIB_DL_SUFFIX_NAME).$$i; then \
-				$(LN_S) $(phptempdir)/libphp$(PHP_MAJOR_VERSION).$(SHLIB_DL_SUFFIX_NAME).$$i $(phptempdir)/libphp$(PHP_MAJOR_VERSION).$(SHLIB_DL_SUFFIX_NAME); \
+			if test -r "$(phptempdir)/libphp$(PHP_MAJOR_VERSION).$(SHLIB_DL_SUFFIX_NAME).$$i"; then \
+				$(LN_S) "$(phptempdir)/libphp$(PHP_MAJOR_VERSION).$(SHLIB_DL_SUFFIX_NAME).$$i" "$(phptempdir)/libphp$(PHP_MAJOR_VERSION).$(SHLIB_DL_SUFFIX_NAME)"; \
 				break; \
 			fi; \
 		done; \

--- a/build/genif.sh
+++ b/build/genif.sh
@@ -32,7 +32,7 @@ header_list=
 olddir=$(pwd)
 
 # Go to project root.
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../" && pwd -P)
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../" && pwd -P)"
 
 module_ptrs="$(echo $extensions | $AWK -f ./build/order_by_dep.awk)"
 
@@ -43,7 +43,7 @@ done
 
 includes=$($AWK -f ./build/print_include.awk $header_list)
 
-cd $olddir
+cd "$olddir"
 
 cat $template | \
   sed \

--- a/buildconf
+++ b/buildconf
@@ -8,7 +8,7 @@ force=0
 debug=0
 
 # Go to project root.
-cd $(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+cd "$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
 
 php_extra_version=$(grep '^AC_INIT(' configure.ac)
 case "$php_extra_version" in
@@ -81,7 +81,7 @@ echo "buildconf: Checking installation"
 min_version=$(sed -n 's/AC_PREREQ(\[\(.*\)\])/\1/p' configure.ac)
 
 # Check if autoconf exists.
-ac_version=$($PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//')
+ac_version=$("$PHP_AUTOCONF" --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//')
 
 if test -z "$ac_version"; then
   echo "buildconf: autoconf not found." >&2
@@ -129,9 +129,9 @@ else
 fi
 
 echo "buildconf: Rebuilding configure"
-$PHP_AUTOCONF $autoconf_flags
+"$PHP_AUTOCONF" $autoconf_flags
 
 echo "buildconf: Rebuilding main/php_config.h.in"
-$PHP_AUTOHEADER $autoheader_flags
+"$PHP_AUTOHEADER" $autoheader_flags
 
 echo "buildconf: Run ./configure to proceed with customizing the PHP build."

--- a/configure.ac
+++ b/configure.ac
@@ -141,9 +141,9 @@ echo "#define PHP_RELEASE_VERSION $PHP_RELEASE_VERSION" >> php_version.h.new
 echo "#define PHP_EXTRA_VERSION \"$PHP_EXTRA_VERSION\"" >> php_version.h.new
 echo "#define PHP_VERSION \"$PHP_VERSION\"" >> php_version.h.new
 echo "#define PHP_VERSION_ID $PHP_VERSION_ID" >> php_version.h.new
-cmp php_version.h.new $srcdir/main/php_version.h >/dev/null 2>&1
+cmp php_version.h.new "$srcdir/main/php_version.h" >/dev/null 2>&1
 if test $? -ne 0 ; then
-  rm -f $srcdir/main/php_version.h && mv php_version.h.new $srcdir/main/php_version.h && \
+  rm -f "$srcdir/main/php_version.h" && mv php_version.h.new "$srcdir/main/php_version.h" && \
   echo 'Updated main/php_version.h'
 else
   rm -f php_version.h.new
@@ -153,22 +153,23 @@ dnl Settings we want to make before the checks.
 dnl ----------------------------------------------------------------------------
 
 php_shtool=$srcdir/build/shtool
-T_MD=`$php_shtool echo -n -e %B`
-T_ME=`$php_shtool echo -n -e %b`
+T_MD=`"$php_shtool" echo -n -e %B`
+T_ME=`"$php_shtool" echo -n -e %b`
 
 PHP_INIT_BUILD_SYSTEM
 
 dnl We want this one before the checks, so the checks can modify CFLAGS.
 test -z "$CFLAGS" && auto_cflags=1
 
-abs_srcdir=`(cd $srcdir; pwd)`
+abs_srcdir=`(cd "$srcdir"; pwd)`
+abs_srcdir_escaped="$(echo "$abs_srcdir" | "$SED" 's/ /\\ /g')"
 abs_builddir=`pwd`
 
 dnl Because `make install` is often performed by the superuser, we create the
 dnl libs subdirectory as the user who configures PHP. Otherwise, the current
 dnl user will not be able to delete libs or the contents of libs.
 
-$php_shtool mkdir -p libs
+"$php_shtool" mkdir -p libs
 rm -f libs/*
 
 dnl Checks for programs.
@@ -786,7 +787,7 @@ if test "$PHP_GCOV" = "yes"; then
   fi
 
   dnl Check if ccache is being used.
-  case `$php_shtool path $CC` in
+  case `"$php_shtool" path $CC` in
     *ccache*[)] gcc_ccache=yes;;
     *[)] gcc_ccache=no;;
   esac
@@ -1222,7 +1223,8 @@ case `eval echo $datadir` in
 esac
 
 phplibdir=`pwd`/modules
-$php_shtool mkdir -p $phplibdir
+phplibdir=$(echo "$phplibdir" | "$SED" 's/ /\\ /g')
+"$php_shtool" mkdir -p "$phplibdir"
 phptempdir=`pwd`/libs
 
 old_exec_prefix=$exec_prefix
@@ -1233,7 +1235,7 @@ libdir=`eval echo $libdir`
 datadir=`eval eval echo $datadir`
 
 dnl Build extension directory path.
-ZEND_MODULE_API_NO=`$EGREP '#define ZEND_MODULE_API_NO ' $srcdir/Zend/zend_modules.h|"${SED}" 's/#define ZEND_MODULE_API_NO //'`
+ZEND_MODULE_API_NO=`$EGREP '#define ZEND_MODULE_API_NO ' "$srcdir/Zend/zend_modules.h"|"${SED}" 's/#define ZEND_MODULE_API_NO //'`
 
 if test -z "$EXTENSION_DIR"; then
   extbasedir=$ZEND_MODULE_API_NO
@@ -1527,9 +1529,9 @@ PHP_GEN_GLOBAL_MAKEFILE
 AC_DEFINE([HAVE_BUILD_DEFS_H], 1, [ ])
 
 dnl Make directories when building in a separate build directory.
-$php_shtool mkdir -p pear
-$php_shtool mkdir -p scripts
-$php_shtool mkdir -p scripts/man1
+"$php_shtool" mkdir -p pear
+"$php_shtool" mkdir -p scripts
+"$php_shtool" mkdir -p scripts/man1
 
 ALL_OUTPUT_FILES="main/build-defs.h \
 scripts/phpize scripts/man1/phpize.1 \
@@ -1564,7 +1566,7 @@ fi
 
 dnl Create configuration headers.
 dnl ----------------------------------------------------------------------------
-test -d Zend || $php_shtool mkdir Zend
+test -d Zend || "$php_shtool" mkdir Zend
 
 cat >Zend/zend_config.h <<FEO
 #include <../main/php_config.h>
@@ -1573,10 +1575,10 @@ FEO
 dnl Run this only when generating all the files.
 if test -n "\$REDO_ALL"; then
   echo "creating main/internal_functions.c"
-  AWK="$AWK" sh $srcdir/build/genif.sh $srcdir/main/internal_functions.c.in "$EXT_STATIC" > main/internal_functions.c
+  AWK="$AWK" sh "$srcdir/build/genif.sh" "$srcdir/main/internal_functions.c.in" "$EXT_STATIC" > main/internal_functions.c
 
   echo "creating main/internal_functions_cli.c"
-  AWK="$AWK" sh $srcdir/build/genif.sh $srcdir/main/internal_functions.c.in "$EXT_CLI_STATIC" > main/internal_functions_cli.c
+  AWK="$AWK" sh "$srcdir/build/genif.sh" "$srcdir/main/internal_functions.c.in" "$EXT_CLI_STATIC" > main/internal_functions_cli.c
 
     if test "$PHP_SAPI" = "apache2handler"; then
       if test "$APACHE_VERSION" -ge 2004001; then

--- a/ext/bcmath/config.m4
+++ b/ext/bcmath/config.m4
@@ -9,7 +9,7 @@ libbcmath/src/add.c libbcmath/src/div.c libbcmath/src/init.c libbcmath/src/neg.c
 libbcmath/src/compare.c libbcmath/src/divmod.c libbcmath/src/int2num.c libbcmath/src/num2long.c libbcmath/src/output.c libbcmath/src/recmul.c \
 libbcmath/src/sqrt.c libbcmath/src/zero.c libbcmath/src/debug.c libbcmath/src/doaddsub.c libbcmath/src/nearzero.c libbcmath/src/num2str.c libbcmath/src/raise.c \
 libbcmath/src/rmzero.c libbcmath/src/str2num.c,
-          $ext_shared,,-I@ext_srcdir@/libbcmath/src -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+          $ext_shared,,-I\"@ext_srcdir@/libbcmath/src\" -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_ADD_BUILD_DIR($ext_builddir/libbcmath/src)
   AC_DEFINE(HAVE_BCMATH, 1, [Whether you have bcmath])
 fi

--- a/ext/date/config0.m4
+++ b/ext/date/config0.m4
@@ -4,7 +4,7 @@ AC_CHECK_HEADERS([io.h])
 dnl Check for strtoll, atoll
 AC_CHECK_FUNCS(strtoll atoll)
 
-PHP_DATE_CFLAGS="-I@ext_builddir@/lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
+PHP_DATE_CFLAGS="-I\"@ext_builddir@/lib\" -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -DHAVE_TIMELIB_CONFIG_H=1"
 timelib_sources="lib/astro.c lib/dow.c lib/parse_date.c lib/parse_tz.c
                  lib/timelib.c lib/tm2unixtime.c lib/unixtime2tm.c lib/parse_iso_intervals.c lib/interval.c"
 

--- a/ext/fileinfo/config.m4
+++ b/ext/fileinfo/config.m4
@@ -49,7 +49,7 @@ int main(void)
     libmagic_sources="$libmagic_sources libmagic/strcasestr.c"
   ],[AC_MSG_RESULT([skipped, cross-compiling])])
 
-  PHP_NEW_EXTENSION(fileinfo, fileinfo.c $libmagic_sources, $ext_shared,,-I@ext_srcdir@/libmagic)
+  PHP_NEW_EXTENSION(fileinfo, fileinfo.c $libmagic_sources, $ext_shared,,[-I\"@ext_srcdir@/libmagic\"])
   PHP_ADD_BUILD_DIR($ext_builddir/libmagic)
 
   AC_CHECK_FUNCS([utimes strndup])

--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -168,7 +168,7 @@ dnl Various checks for GD features
 
     PHP_NEW_EXTENSION(gd, gd.c $extra_sources, $ext_shared,, \\$(GD_CFLAGS))
     PHP_ADD_BUILD_DIR($ext_builddir/libgd)
-    GD_CFLAGS="-I$ext_srcdir/libgd $GD_CFLAGS"
+    GD_CFLAGS="-I\"$ext_srcdir/libgd\" $GD_CFLAGS"
     GD_HEADER_DIRS="ext/gd/ ext/gd/libgd/"
 
     PHP_TEST_BUILD(foobar, [], [

--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -31,7 +31,7 @@ else
     SHA3_OPT_SRC="$SHA3_DIR/KeccakP-1600-opt64.c"
   ])
   EXT_HASH_SHA3_SOURCES="$SHA3_OPT_SRC $SHA3_DIR/KeccakHash.c $SHA3_DIR/KeccakSponge.c hash_sha3.c"
-  PHP_HASH_CFLAGS="-I@ext_srcdir@/$SHA3_DIR -DKeccakP200_excluded -DKeccakP400_excluded -DKeccakP800_excluded -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  PHP_HASH_CFLAGS="-I\"@ext_srcdir@/$SHA3_DIR\" -DKeccakP200_excluded -DKeccakP400_excluded -DKeccakP800_excluded -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
 
   PHP_ADD_BUILD_DIR(ext/hash/$SHA3_DIR, 1)
 fi

--- a/ext/iconv/config.m4
+++ b/ext/iconv/config.m4
@@ -150,7 +150,7 @@ int main() {
       PHP_DEFINE([ICONV_SUPPORTS_ERRNO],0,[ext/iconv])
       AC_DEFINE([ICONV_SUPPORTS_ERRNO],0,[Whether iconv supports error no or not])
     ],[
-      AC_MSG_RESULT(no, cross-compiling)
+      AC_MSG_RESULT([no, cross-compiling])
       PHP_DEFINE([ICONV_SUPPORTS_ERRNO],0,[ext/iconv])
       AC_DEFINE([ICONV_SUPPORTS_ERRNO],0,[Whether iconv supports error no or not])
     ])

--- a/ext/json/Makefile.frag
+++ b/ext/json/Makefile.frag
@@ -1,5 +1,5 @@
 $(srcdir)/json_scanner.c: $(srcdir)/json_scanner.re
-	@$(RE2C) $(RE2C_FLAGS) -t $(srcdir)/php_json_scanner_defs.h --no-generation-date -bci -o $@ $(srcdir)/json_scanner.re
+	@$(RE2C) $(RE2C_FLAGS) -t $(srcdir)/php_json_scanner_defs.h --no-generation-date -bci -o "$@" $(srcdir)/json_scanner.re
 
 $(srcdir)/json_parser.tab.c: $(srcdir)/json_parser.y
-	@$(YACC) --defines -l $(srcdir)/json_parser.y -o $@
+	@$(YACC) --defines -l $(srcdir)/json_parser.y -o "$@"

--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -67,7 +67,7 @@ else
   pcre2lib/pcre2_string_utils.c pcre2lib/pcre2_study.c pcre2lib/pcre2_substitute.c  pcre2lib/pcre2_substring.c \
   pcre2lib/pcre2_tables.c pcre2lib/pcre2_ucd.c pcre2lib/pcre2_valid_utf.c pcre2lib/pcre2_xclass.c \
   pcre2lib/pcre2_find_bracket.c pcre2lib/pcre2_convert.c pcre2lib/pcre2_extuni.c pcre2lib/pcre2_script_run.c"
-  PHP_PCRE_CFLAGS="-DHAVE_CONFIG_H -I@ext_srcdir@/pcre2lib -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
+  PHP_PCRE_CFLAGS="-DHAVE_CONFIG_H -I\"@ext_srcdir@/pcre2lib\" -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1"
   AC_DEFINE(HAVE_BUNDLED_PCRE, 1, [ ])
   AC_DEFINE(PCRE2_CODE_UNIT_WIDTH, 8, [ ])
 

--- a/ext/pdo_sqlite/config.m4
+++ b/ext/pdo_sqlite/config.m4
@@ -28,7 +28,7 @@ if test "$PHP_PDO_SQLITE" != "no"; then
 
   PHP_SUBST(PDO_SQLITE_SHARED_LIBADD)
   PHP_NEW_EXTENSION(pdo_sqlite, pdo_sqlite.c sqlite_driver.c sqlite_statement.c,
-    $ext_shared,,-I$pdo_cv_inc_path)
+    $ext_shared,,-I\"$pdo_cv_inc_path\")
 
   PHP_ADD_EXTENSION_DEP(pdo_sqlite, pdo)
 fi

--- a/ext/tokenizer/tokenizer_data_gen.sh
+++ b/ext/tokenizer/tokenizer_data_gen.sh
@@ -3,7 +3,7 @@
 # Generate the tokenizer extension data file from the parser header file.
 
 # Go to project root directory.
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)"
 
 infile="Zend/zend_language_parser.h"
 outfile="ext/tokenizer/tokenizer_data.c"

--- a/main/php_version.h
+++ b/main/php_version.h
@@ -2,7 +2,7 @@
 /* edit configure.ac to change version number */
 #define PHP_MAJOR_VERSION 7
 #define PHP_MINOR_VERSION 4
-#define PHP_RELEASE_VERSION 17
+#define PHP_RELEASE_VERSION 18
 #define PHP_EXTRA_VERSION "-dev"
-#define PHP_VERSION "7.4.17-dev"
-#define PHP_VERSION_ID 70417
+#define PHP_VERSION "7.4.18-dev"
+#define PHP_VERSION_ID 70418

--- a/sapi/phpdbg/Makefile.frag
+++ b/sapi/phpdbg/Makefile.frag
@@ -18,7 +18,7 @@ $(srcdir)/phpdbg_lexer.c: $(srcdir)/phpdbg_lexer.l
 
 $(srcdir)/phpdbg_parser.h: $(srcdir)/phpdbg_parser.c
 $(srcdir)/phpdbg_parser.c: $(srcdir)/phpdbg_parser.y
-	@$(YACC) -p phpdbg_ -v -d $(srcdir)/phpdbg_parser.y -o $@
+	@$(YACC) -p phpdbg_ -v -d $(srcdir)/phpdbg_parser.y -o "$@"
 
 install-phpdbg: $(BUILD_BINARY)
 	@echo "Installing phpdbg binary:         $(INSTALL_ROOT)$(bindir)/"

--- a/scripts/Makefile.frag
+++ b/scripts/Makefile.frag
@@ -47,7 +47,7 @@ install-programs: $(builddir)/phpize $(builddir)/php-config
 	done
 
 $(builddir)/phpize: $(srcdir)/phpize.in $(top_builddir)/config.status
-	(CONFIG_FILES=$@ CONFIG_HEADERS= $(top_builddir)/config.status)
+	(CONFIG_FILES="$@" CONFIG_HEADERS= $(top_builddir)/config.status)
 
 $(builddir)/php-config: $(srcdir)/php-config.in $(top_builddir)/config.status
-	(CONFIG_FILES=$@ CONFIG_HEADERS= $(top_builddir)/config.status)
+	(CONFIG_FILES="$@" CONFIG_HEADERS= $(top_builddir)/config.status)

--- a/scripts/dev/credits
+++ b/scripts/dev/credits
@@ -2,8 +2,8 @@
 #
 # Generate credits_*.h headers from the ext/*/CREDITS and sapi/*/CREDITS files.
 
-# Go to project root directory
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)
+# Go to project root directory.
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)"
 
 awkprog='
 BEGIN { FS = "\n|\r\n|\r"; RS = "" }

--- a/scripts/dev/genfiles
+++ b/scripts/dev/genfiles
@@ -43,10 +43,10 @@ SED=${SED:-sed}
 MAKE=${MAKE:-make}
 
 # Go to project root.
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)"
 
 # Check required bison version from the configure.ac file.
-required_bison_version=$($SED -n 's/PHP_PROG_BISON(\[\([0-9\.]*\)\].*/\1/p' configure.ac)
+required_bison_version=$("$SED" -n 's/PHP_PROG_BISON(\[\([0-9\.]*\)\].*/\1/p' configure.ac)
 set -f; IFS='.'; set -- $required_bison_version; set +f; IFS=' '
 required_bison_num="$(expr ${1:-0} \* 10000 + ${2:-0} \* 100 + ${3:-0})"
 
@@ -71,7 +71,7 @@ else
 fi
 
 # Check required re2c version from the configure.ac file.
-required_re2c_version=$($SED -n 's/PHP_PROG_RE2C(\[\(.*\)\])/\1/p' configure.ac)
+required_re2c_version=$("$SED" -n 's/PHP_PROG_RE2C(\[\(.*\)\])/\1/p' configure.ac)
 set -f; IFS='.'; set -- $required_re2c_version; set +f; IFS=' '
 required_re2c_num="$(expr ${1:-0} \* 10000 + ${2:-0} \* 100 + ${3:-0})"
 
@@ -96,13 +96,13 @@ else
 fi
 
 # Check if make exists.
-if ! test -x "$(command -v $MAKE)"; then
+if ! test -x "$(command -v "$MAKE")"; then
   echo "genfiles: make not found. Please install make to generate files." >&2
   exit 1
 fi
 
 echo "genfiles: Generating Zend parser and lexer files"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" SED="$SED" srcdir=Zend builddir=Zend top_srcdir=. \
+"$MAKE" RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" SED="$SED" srcdir=Zend builddir=Zend top_srcdir=. \
   -f Zend/Makefile.frag \
   Zend/zend_language_parser.c \
   Zend/zend_language_scanner.c \
@@ -110,29 +110,29 @@ $MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" SED="$SED" srcdir=Zend 
   Zend/zend_ini_scanner.c
 
 echo "genfiles: Generating phpdbg parser and lexer files"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" srcdir=sapi/phpdbg builddir=sapi/phpdbg top_srcdir=. \
+"$MAKE" RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" srcdir=sapi/phpdbg builddir=sapi/phpdbg top_srcdir=. \
   -f sapi/phpdbg/Makefile.frag \
   sapi/phpdbg/phpdbg_parser.c \
   sapi/phpdbg/phpdbg_lexer.c
 
 echo "genfiles: enerating json extension parser and lexer files"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" srcdir=ext/json builddir=ext/json top_srcdir=. \
+"$MAKE" RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" srcdir=ext/json builddir=ext/json top_srcdir=. \
   -f ext/json/Makefile.frag \
   ext/json/json_parser.tab.c \
   ext/json/json_scanner.c
 
 echo "genfiles: Generating PDO lexer file"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" srcdir=ext/pdo builddir=ext/pdo top_srcdir=. \
+"$MAKE" RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" srcdir=ext/pdo builddir=ext/pdo top_srcdir=. \
   -f ext/pdo/Makefile.frag \
   ext/pdo/pdo_sql_parser.c
 
 echo "genfiles: Generating standard extension lexer files"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" srcdir=ext/standard builddir=ext/standard top_srcdir=. \
+"$MAKE" RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" srcdir=ext/standard builddir=ext/standard top_srcdir=. \
   -f ext/standard/Makefile.frag \
   ext/standard/var_unserializer.c \
   ext/standard/url_scanner_ex.c
 
 echo "genfiles: Generating phar extension lexer file"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" srcdir=ext/phar builddir=ext/phar top_srcdir=. \
+"$MAKE" RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" srcdir=ext/phar builddir=ext/phar top_srcdir=. \
   -f ext/phar/Makefile.frag \
   ext/phar/phar_path_check.c

--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -6,7 +6,7 @@
 # Adapted to Git by Stanislav Malyshev <stas@php.net>.
 
 # Go to project root directory.
-cd $(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../../" && pwd -P)"
 
 # Process options and arguments.
 while :; do

--- a/scripts/phpize.in
+++ b/scripts/phpize.in
@@ -122,7 +122,7 @@ phpize_check_autotools()
   test -z "$PHP_AUTOCONF" && PHP_AUTOCONF=autoconf
   test -z "$PHP_AUTOHEADER" && PHP_AUTOHEADER=autoheader
 
-  if test ! -x "$PHP_AUTOCONF" && test ! -x "`$php_shtool path $PHP_AUTOCONF`"; then
+  if test ! -x "$PHP_AUTOCONF" && test ! -x "`"$php_shtool" path "$PHP_AUTOCONF"`"; then
     cat <<EOF
 Cannot find autoconf. Please check your autoconf installation and the
 \$PHP_AUTOCONF environment variable. Then, rerun this script.
@@ -130,7 +130,7 @@ Cannot find autoconf. Please check your autoconf installation and the
 EOF
     exit 1
   fi
-  if test ! -x "$PHP_AUTOHEADER" && test ! -x "`$php_shtool path $PHP_AUTOHEADER`"; then
+  if test ! -x "$PHP_AUTOHEADER" && test ! -x "`"$php_shtool" path "$PHP_AUTOHEADER"`"; then
     cat <<EOF
 Cannot find autoheader. Please check your autoconf installation and the
 \$PHP_AUTOHEADER environment variable. Then, rerun this script.

--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -163,6 +163,7 @@ AC_PROG_LIBTOOL
 all_targets='$(PHP_MODULES) $(PHP_ZEND_EX)'
 install_targets="install-modules install-headers"
 phplibdir="`pwd`/modules"
+phplibdir=$(echo "$phplibdir" | "$SED" 's/ /\\ /g')
 CPPFLAGS="$CPPFLAGS -DHAVE_CONFIG_H"
 CFLAGS_CLEAN='$(CFLAGS)'
 CXXFLAGS_CLEAN='$(CXXFLAGS)'
@@ -206,7 +207,7 @@ PHP_SUBST(INSTALL_HEADERS)
 PHP_GEN_BUILD_DIRS
 PHP_GEN_GLOBAL_MAKEFILE
 
-test -d modules || $php_shtool mkdir modules
+test -d modules || "$php_shtool" mkdir modules
 
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Hello, this is a draft pull request that might fix this long existing bug where PHP can't be built in directories containing spaces:
https://bugs.php.net/bug.php?id=49270

I'm still rechecking this if if it goes through ok.