### PR TITLE
Removed mentions of git.php.net from the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -398,9 +398,6 @@ Example:
 When you change the NEWS file for a bug fix, then please keep the bugs sorted in
 decreasing order under the fixed version.
 
-You can use [gitweb](https://git.php.net/) to look at PHP Git repository in
-various ways.
-
 ## Copyright and license headers
 
 New source code files should include the following header block:

--- a/README.md
+++ b/README.md
@@ -103,10 +103,8 @@ Extension Community Library - [PECL](https://pecl.php.net).
 
 ## Contributing
 
-The PHP source code is located in the Git repository at
-[git.php.net](https://git.php.net). Contributions are most welcome by forking
-the [GitHub mirror repository](https://github.com/php/php-src) and sending a
-pull request.
+Contributions are most welcome by forking the
+[GitHub repository](https://github.com/php/php-src) and sending a pull request.
 
 Discussions are done on GitHub, but depending on the topic can also be relayed
 to the official PHP developer mailing list internals@lists.php.net.
@@ -127,9 +125,8 @@ ticket at [bugs.php.net](https://bugs.php.net) and reference the bug id using
     magic_quotes behavior and therefore should not raise a warning at any time.
     The patch removes this warning.
 
-Pull requests are not merged directly on GitHub. All PRs will be pulled and
-pushed through [git.php.net](https://git.php.net). See
-[Git workflow](https://wiki.php.net/vcs/gitworkflow) for more details.
+See [Git workflow](https://wiki.php.net/vcs/gitworkflow) for more details on the
+pull request workflow.
 
 ### Guidelines for contributors
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -37,14 +37,13 @@
 
     Moving extensions from php-src to PECL:
 
-    * Ask someone with Git admin access to create a new empty repository on
-      https://git.php.net under the PECL projects and a belonging GitHub mirror.
+    * Ask someone with Git admin access to create a new empty repository GitHub.
 
     * Clone a new copy of the php-src repository (it will rewrite history, keep
       contributors commits and include only the extension folder):
 
         ```sh
-        git clone https://git.php.net/repository/php-src.git ext-name
+        git clone git@github.com:php/php-src.git ext-name
         cd ext-name
         git filter-branch --prune-empty --subdirectory-filter ext/ext-name master
         ```
@@ -52,7 +51,7 @@
     * Set remote Git push URL for the PECL extension:
 
         ```sh
-        git remote set-url origin git@git.php.net:pecl/category/ext-name
+        git remote set-url origin git@github.com:php/pecl-ext-name.git
         ```
 
     * Create branch and tags structure appropriate for the extension and push:
@@ -204,7 +203,7 @@
     sudo -u ezmlm ezmlm-sub ~ezmlm/primary-qa-tester/mod moderator-email-address
     ```
  6. For RCs, post tweet with release announcement (and link to news article on
-    php.net) ([@official_php](https://twitter.com/official_php))  
+    php.net) ([@official_php](https://twitter.com/official_php))
 
 ## Rolling a stable release
 
@@ -347,9 +346,9 @@
     php-announce@ is its own completely separate email. This is to make sure
     that replies to the announcement on php-general@ or internals@ will not
     accidentally hit the php-announce@ mailinglist.
-    
-11. Post tweet with release announcement and link to news article on php.net 
-    ([@official_php](https://twitter.com/official_php))  
+
+11. Post tweet with release announcement and link to news article on php.net
+    ([@official_php](https://twitter.com/official_php))
 
 ## Re-releasing the same version (or -pl)
 
@@ -403,7 +402,9 @@
     Bump API version numbers in `Zend/zend_extensions.h`, `Zend/zend_modules.h`,
     and `main/php.h`.
 
-    Example: https://git.php.net/?p=php-src.git;a=commit;h=a63c99b
+    Example:
+    https://github.com/php/php-src/commit/a63c99ba624cff86292ffde97089428e68c6fc10
+
     Push the new branch and the commit just added to master.
 
  3. Immediately notify internals@ of the branch cut and advise the new merging

--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -57,7 +57,7 @@ EXAMPLES:
     scripts/dev/makedist php-7.4.0RC1
 
   Create release packages from a remote Git repository for the tag php-7.4.0:
-    scripts/dev/makedist --remote=git@git.php.net:php-src.git php-7.4.0
+    scripts/dev/makedist --remote=git@github.com:php/php-src.git php-7.4.0
 HELP
       exit
       ;;


### PR DESCRIPTION
According to yesterday's "Changes to Git commit workflow" announcement (https://news-web.php.net/php.internals/113838), git.php.net server will become discontinued and GitHub repositories won't be only mirrors anymore. 
Some documentation in this repository has to be adjusted to reflect that change.