### PR TITLE
Handle reference zvals when outputting superglobals in phpinfo()

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -176,7 +176,7 @@ static ZEND_COLD void php_print_gpcse_array(char *name, uint32_t name_length)
 	key = zend_string_init(name, name_length, 0);
 	zend_is_auto_global(key);
 
-	if ((data = zend_hash_find(&EG(symbol_table), key)) != NULL && (Z_TYPE_P(data) == IS_ARRAY)) {
+	if ((data = zend_hash_find_deref(&EG(symbol_table), key)) != NULL && (Z_TYPE_P(data) == IS_ARRAY)) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(data), num_key, string_key, tmp) {
 			if (!sapi_module.phpinfo_as_text) {
 				php_info_print("<tr>");

--- a/ext/standard/tests/bug80915.phpt
+++ b/ext/standard/tests/bug80915.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #80915: Taking a reference to $_SERVER hides its values from phpinfo()
+--FILE--
+<?php
+
+$_ENV = [];
+$_SERVER = [ 'test' => 'test' ];
+
+$reference =& $_SERVER;
+
+phpinfo(INFO_VARIABLES);
+
+?>
+--EXPECT--
+phpinfo()
+
+PHP Variables
+
+Variable => Value
+$_SERVER['test'] => test


### PR DESCRIPTION
Fixes Bug #80915