### PR TITLE
Use zend_throw_unwind_exit() for assert.bail

### DIFF
--- a/Zend/tests/exception_011.phpt
+++ b/Zend/tests/exception_011.phpt
@@ -7,7 +7,11 @@ assert.exception=1
 <?php
 
 define ("XXXXX", 1);
-assert(false);
+try {
+    assert(false);
+} catch (AssertionError $error) {
+    echo "Caught\n";
+}
 
 ?>
 --EXPECTHEADERS--

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -186,15 +186,20 @@ PHP_FUNCTION(assert)
 
 	if (ASSERTG(exception)) {
 		zend_throw_exception(assertion_error_ce, description_str ? ZSTR_VAL(description_str) : NULL, E_ERROR);
+		if (ASSERTG(bail)) {
+			/* When bail is turned on, the exception will not be caught. */
+			zend_exception_error(EG(exception), E_ERROR);
+		}
 	} else if (ASSERTG(warning)) {
 		php_error_docref(NULL, E_WARNING, "%s failed", description_str ? ZSTR_VAL(description_str) : "Assertion failed");
 	}
 
 	if (ASSERTG(bail)) {
-		zend_bailout();
+		zend_throw_unwind_exit();
+		RETURN_THROWS();
+	} else {
+		RETURN_FALSE;
 	}
-
-	RETURN_FALSE;
 }
 /* }}} */
 


### PR DESCRIPTION
I may understand why unwind_exit is not used here, but I noticed that we can use unwind_exit instead of the evil zend_bailout without breaking the original behavior by this way because the original zend_bailout will longjmp out of the executor, so the exception will never be caught and it always triggers the E_ERROR here.

But I also noticed the problem of API design, if we pass an exception to param description_obj, option bail will be ignored... Its behavior is not so satisfactory but the document does not specify the specific behavior of these configurations (and it seems some content of the document is already out of date, maybe I will fix them).

Still, it's always best to break nothing...