### PR TITLE
add php.ini entry to set default user_agent for curl

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -232,6 +232,7 @@ static inline int build_mime_structure_from_hash(php_curl *ch, zval *zpostfields
 /* {{{ PHP_INI_BEGIN */
 PHP_INI_BEGIN()
 	PHP_INI_ENTRY("curl.cainfo", "", PHP_INI_SYSTEM, NULL)
+	PHP_INI_ENTRY("curl.user_agent", "", PHP_INI_SYSTEM, NULL)
 PHP_INI_END()
 /* }}} */
 
@@ -1802,7 +1803,7 @@ static void create_certinfo(struct curl_certinfo *ci, zval *listcode)
    Set default options for a handle */
 static void _php_curl_set_default_options(php_curl *ch)
 {
-	char *cainfo;
+	char *cainfo, *user_agent;
 
 	curl_easy_setopt(ch->cp, CURLOPT_NOPROGRESS,        1);
 	curl_easy_setopt(ch->cp, CURLOPT_VERBOSE,           0);
@@ -1825,6 +1826,11 @@ static void _php_curl_set_default_options(php_curl *ch)
 	}
 	if (cainfo && cainfo[0] != '\0') {
 		curl_easy_setopt(ch->cp, CURLOPT_CAINFO, cainfo);
+	}
+
+	user_agent = INI_STR("curl.user_agent");
+	if (user_agent && user_agent[0] != '\0') {
+		curl_easy_setopt(ch->cp, CURLOPT_USERAGENT, user_agent);
 	}
 
 #ifdef ZTS

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -232,7 +232,7 @@ static inline int build_mime_structure_from_hash(php_curl *ch, zval *zpostfields
 /* {{{ PHP_INI_BEGIN */
 PHP_INI_BEGIN()
 	PHP_INI_ENTRY("curl.cainfo", "", PHP_INI_SYSTEM, NULL)
-	PHP_INI_ENTRY("curl.user_agent", "", PHP_INI_SYSTEM, NULL)
+	PHP_INI_ENTRY("curl.user_agent", "", PHP_INI_ALL, NULL)
 PHP_INI_END()
 /* }}} */
 

--- a/ext/curl/tests/curl_user_agent.phpt
+++ b/ext/curl/tests/curl_user_agent.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Test curl.user_agent ini entry
+--INI--
+curl.user_agent=test/1.0
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch = curl_init($host);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+curl_exec($ch);
+$info = curl_getinfo($ch);
+echo $info['request_header'];
+curl_close($ch);
+
+ini_set('curl.user_agent', 'ini/1.0');
+
+//Override with ini_set
+$ch = curl_init($host);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+curl_exec($ch);
+$info = curl_getinfo($ch);
+echo $info['request_header'];
+curl_close($ch);
+
+//Override with CURLOPT
+$ch = curl_init($host);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_USERAGENT, 'override/1.0');
+curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+curl_exec($ch);
+$info = curl_getinfo($ch);
+echo $info['request_header'];
+curl_close($ch);
+?>
+--EXPECTREGEX--
+GET \/ HTTP\/1\.1
+Host: localhost:[0-9]*
+User-Agent: test\/1.0
+Accept: \*\/\*
+
+GET \/ HTTP\/1\.1
+Host: localhost:[0-9]*
+User-Agent: ini\/1.0
+Accept: \*\/\*
+
+GET \/ HTTP\/1\.1
+Host: localhost:[0-9]*
+User-Agent: override\/1.0
+Accept: \*\/\*


### PR DESCRIPTION
> https://www.php.net/manual/en/filesystem.configuration.php#ini.user-agent
> Define the user agent for PHP to send.
> 
> https://www.php.net/manual/en/soapclient.construct.php
> The user_agent option specifies string to use in User-Agent header.

In the same spirit i'd like to propose a php.ini entry to set a default user agent for all cURL requests.

The patch seems very straightforward and i am not sure if it requires a full RFC process.
If everything is fine i would also send a PR to update the docs respectively.

PS: This was my first test to write for PHP and the experience was good 👍 