### PR TITLE
Fix #80933: SplFileObject::fgets() stops at NUL byte for DROP_NEW_LINE

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2046,7 +2046,6 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent) /
 		intern->u.file.current_line_len = 0;
 	} else {
 		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
-			char breaks[] = "\r\n";
 			const char *eol = memchr(buf, '\n', line_len);
 			if (eol != NULL) {
 				line_len = (eol > buf && *(eol - 1) == '\r') ? eol - buf - 1 : eol - buf;

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2046,13 +2046,12 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent) /
 		intern->u.file.current_line_len = 0;
 	} else {
 		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
-			zend_string *zbuf = zend_string_init(buf, line_len, 0);
-			const char *eol = php_stream_locate_eol(intern->u.file.stream, zbuf);
+			char breaks[] = "\r\n";
+			const char *eol = memchr(buf, '\n', line_len);
 			if (eol != NULL) {
-				line_len = eol - ZSTR_VAL(zbuf);
+				line_len = (eol > buf && *(eol - 1) == '\r') ? eol - buf - 1 : eol - buf;
 				buf[line_len] = '\0';
 			}
-			zend_string_release(zbuf);
 		}
 
 		intern->u.file.current_line = buf;

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2046,9 +2046,11 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent) /
 		intern->u.file.current_line_len = 0;
 	} else {
 		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
-			const char *eol = memchr(buf, '\n', line_len);
-			if (eol != NULL) {
-				line_len = (eol > buf && *(eol - 1) == '\r') ? eol - buf - 1 : eol - buf;
+			if (line_len > 0 && buf[line_len - 1] == '\n') {
+				line_len--;
+				if (line_len > 0 && buf[line_len - 1] == '\r') {
+					line_len--;
+				}
 				buf[line_len] = '\0';
 			}
 		}

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2046,9 +2046,13 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent) /
 		intern->u.file.current_line_len = 0;
 	} else {
 		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
-			char breaks[] = "\r\n";
-			line_len = php_strcspn(buf, breaks, buf + line_len, breaks + sizeof(breaks)-1);
-			buf[line_len] = '\0';
+			zend_string *zbuf = zend_string_init(buf, line_len, 0);
+			const char *eol = php_stream_locate_eol(intern->u.file.stream, zbuf);
+			if (eol != NULL) {
+				line_len = eol - ZSTR_VAL(zbuf);
+				buf[line_len] = '\0';
+			}
+			zend_string_release(zbuf);
 		}
 
 		intern->u.file.current_line = buf;

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2046,7 +2046,7 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent) /
 		intern->u.file.current_line_len = 0;
 	} else {
 		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
-			const char breaks[] = "\r\n";
+			char breaks[] = "\r\n";
 			line_len = php_strcspn(buf, breaks, buf + line_len, breaks + sizeof(breaks)-1);
 			buf[line_len] = '\0';
 		}

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2046,7 +2046,8 @@ static int spl_filesystem_file_read(spl_filesystem_object *intern, int silent) /
 		intern->u.file.current_line_len = 0;
 	} else {
 		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
-			line_len = strcspn(buf, "\r\n");
+			const char breaks[] = "\r\n";
+			line_len = php_strcspn(buf, breaks, buf + line_len, breaks + sizeof(breaks)-1);
 			buf[line_len] = '\0';
 		}
 

--- a/ext/spl/tests/bug80933.phpt
+++ b/ext/spl/tests/bug80933.phpt
@@ -1,22 +1,27 @@
 --TEST--
-Bug #80933 (SplFileObject::fgets() stops at NUL byte for DROP_NEW_LINE)
+Bug #80933 (SplFileObject::DROP_NEW_LINE is broken for NUL and CR)
 --FILE--
 <?php
-// string with a NULL char
-$line = "Lorem ipsum \0 dolor sit amet";
+$lines = [
+    "Lorem ipsum \0 dolor sit amet", // string with NUL
+    "Lorem ipsum \r dolor sit amet", // string with CR
+];
+foreach ($lines as $line) {
+    $temp = new SplTempFileObject();
+    $temp->fwrite($line);
 
-$temp = new SplTempFileObject();
-$temp->fwrite($line);
+    $temp->rewind();
+    $read = $temp->fgets();
+    var_dump($line === $read); 
 
-$temp->rewind();
-$read = $temp->fgets();
-var_dump($line === $read); 
-
-$temp->rewind();
-$temp->setFlags(SplFileObject::DROP_NEW_LINE);
-$read = $temp->fgets();
-var_dump($line === $read);
+    $temp->rewind();
+    $temp->setFlags(SplFileObject::DROP_NEW_LINE);
+    $read = $temp->fgets();
+    var_dump($line === $read);
+}
 ?>
 --EXPECT--
+bool(true)
+bool(true)
 bool(true)
 bool(true)

--- a/ext/spl/tests/bug80933.phpt
+++ b/ext/spl/tests/bug80933.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #80933 (SplFileObject::fgets() stops at NUL byte for DROP_NEW_LINE)
+--FILE--
+<?php
+// string with a NULL char
+$line = "Lorem ipsum \0 dolor sit amet";
+
+$temp = new SplTempFileObject();
+$temp->fwrite($line);
+
+$temp->rewind();
+$read = $temp->fgets();
+var_dump($line === $read); 
+
+$temp->rewind();
+$temp->setFlags(SplFileObject::DROP_NEW_LINE);
+$read = $temp->fgets();
+var_dump($line === $read);
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/spl/tests/bug80933.phpt
+++ b/ext/spl/tests/bug80933.phpt
@@ -12,7 +12,7 @@ foreach ($lines as $line) {
 
     $temp->rewind();
     $read = $temp->fgets();
-    var_dump($line === $read); 
+    var_dump($line === $read);
 
     $temp->rewind();
     $temp->setFlags(SplFileObject::DROP_NEW_LINE);


### PR DESCRIPTION
`buf` may contain NUL bytes, so we must not use `strcspn()` but rather
the binary safe `php_strcspn()`.

Signed-off-by: Christoph M. Becker <cmbecker69@gmx.de>