### PR TITLE
Improve fix for #80783

### DIFF
--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -665,13 +665,13 @@ static int odbc_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr, zend_ulong
  			256, &C->fetched_len);
 		orig_fetched_len = C->fetched_len;
 
-		if (rc == SQL_SUCCESS) {
+		if (rc == SQL_SUCCESS && C->fetched_len < 256) {
 			/* all the data fit into our little buffer;
 			 * jump down to the generic bound data case */
 			goto in_data;
 		}
 
-		if (rc == SQL_SUCCESS_WITH_INFO) {
+		if (rc == SQL_SUCCESS_WITH_INFO || rc == SQL_SUCCESS) {
 			/* this is a 'long column'
 
 			 read the column in 255 byte blocks until the end of the column is reached, reassembling those blocks
@@ -700,7 +700,7 @@ static int odbc_stmt_get_col(pdo_stmt_t *stmt, int colno, char **ptr, zend_ulong
 				}
 
 				/* resize output buffer and reassemble block */
-				if (rc==SQL_SUCCESS_WITH_INFO) {
+				if (rc==SQL_SUCCESS_WITH_INFO || (rc==SQL_SUCCESS && C->fetched_len > 255)) {
 					/* point 5, in section "Retrieving Data with SQLGetData" in http://msdn.microsoft.com/en-us/library/windows/desktop/ms715441(v=vs.85).aspx
 					 states that if SQL_SUCCESS_WITH_INFO, fetched_len will be > 255 (greater than buf2's size)
 					 (if a driver fails to follow that and wrote less than 255 bytes to buf2, this will AV or read garbage into buf) */


### PR DESCRIPTION
Working on new tests introduced in previous fix bccca0b53aa60a62e2988c750fc73c02d109e642
I notice some driver may return SQL_SUCCESS instead of SQL_SUCCESS_WITH_INFO, but with fetch len > 255 

Tried with unixODBC 2.3.9 and [MySQL][ODBC 8.0(w) Driver][mysqld-5.5.5-10.4.18-MariaDB]  

P.S. issue only affects binary columuns, not char ones, so bug80783.phpt, not bug80783a.phpt