### PR TITLE
Fix #79812: Potential integer overflow in pcntl_exec()

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -955,7 +955,7 @@ PHP_FUNCTION(pcntl_exec)
 	int envc = 0, envi = 0;
 	char **argv = NULL, **envp = NULL;
 	char **current_arg, **pair;
-	int pair_length;
+	size_t pair_length;
 	zend_string *key;
 	char *path;
 	size_t path_len;

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1015,8 +1015,9 @@ PHP_FUNCTION(pcntl_exec)
 			}
 
 			/* Length of element + equal sign + length of key + null */
+			ZEND_ASSERT(Z_STRLEN_P(element) < SIZE_MAX && ZSTR_LEN(key) < SIZE_MAX);
+			*pair = safe_emalloc(Z_STRLEN_P(element) + 1, sizeof(char) + ZSTR_LEN(key) + 1);
 			pair_length = Z_STRLEN_P(element) + ZSTR_LEN(key) + 2;
-			*pair = emalloc(pair_length);
 			strlcpy(*pair, ZSTR_VAL(key), ZSTR_LEN(key) + 1);
 			strlcat(*pair, "=", pair_length);
 			strlcat(*pair, Z_STRVAL_P(element), pair_length);

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1016,7 +1016,7 @@ PHP_FUNCTION(pcntl_exec)
 
 			/* Length of element + equal sign + length of key + null */
 			ZEND_ASSERT(Z_STRLEN_P(element) < SIZE_MAX && ZSTR_LEN(key) < SIZE_MAX);
-			*pair = safe_emalloc(Z_STRLEN_P(element) + 1, sizeof(char) + ZSTR_LEN(key) + 1);
+			*pair = safe_emalloc(Z_STRLEN_P(element) + 1, sizeof(char), ZSTR_LEN(key) + 1);
 			pair_length = Z_STRLEN_P(element) + ZSTR_LEN(key) + 2;
 			strlcpy(*pair, ZSTR_VAL(key), ZSTR_LEN(key) + 1);
 			strlcat(*pair, "=", pair_length);


### PR DESCRIPTION
We use the proper type.