### PR TITLE
Normalize PHP CS to enforce PSR-2 standard and normalized indentation, part 1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  php-cs-fixer:
+    name: PHP CS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl, xml, dom, json, iconv
+      - uses: actions/checkout@v2
+
+      -   name: Install
+          run: curl -s -L https://cs.symfony.com/download/php-cs-fixer-v2.phar -o php-cs-fixer.phar
+
+      -   name: Run fixer
+          run: php php-cs-fixer.phar fix --config=.github/workflows/lint/.php_cs.dist --dry-run --using-cache=no --diff --diff-format=udiff --verbose --show-progress=dots

--- a/.github/workflows/lint/.gitignore
+++ b/.github/workflows/lint/.gitignore
@@ -1,0 +1,1 @@
+/.php_cs.cache

--- a/.github/workflows/lint/.php_cs.dist
+++ b/.github/workflows/lint/.php_cs.dist
@@ -1,0 +1,33 @@
+<?php
+
+$phpRoot = dirname(__DIR__, 3);
+
+$finder = PhpCsFixer\Finder::create()
+    ->name('*.phpt')
+    ->in([
+        // $phpRoot . '/main',
+        // $phpRoot . '/ext',
+        $phpRoot . '/ext/bcmath',
+        $phpRoot . '/build',
+        $phpRoot . '/pear',
+        // $phpRoot . '/sapi',
+        $phpRoot . '/scripts',
+        $phpRoot . '/win32',
+        // $phpRoot . '/Zend',
+    ])
+    ->append([
+        $phpRoot . '/run-tests.php',
+    ])
+    ->notName('*.stub.php');
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        'concat_space' => [
+            'spacing' => 'one',
+        ],
+        'binary_operator_spaces' => true,
+        'whitespace_after_comma_in_array' => true,
+    ])
+    ->setFinder($finder)
+    ->setCacheFile(__DIR__ . '/.php_cs.cache');

--- a/ext/bcmath/tests/bcadd_variation001.phpt
+++ b/ext/bcmath/tests/bcadd_variation001.phpt
@@ -6,8 +6,8 @@ bcmath
 bcmath.scale=5
 --FILE--
 <?php
-echo bcadd("2.2", "4.3", "2")."\n";
-echo bcadd("2.2", "-7.3", "1")."\n";
+echo bcadd("2.2", "4.3", "2") . "\n";
+echo bcadd("2.2", "-7.3", "1") . "\n";
 echo bcadd("-4.27", "7.3");
 ?>
 --EXPECT--

--- a/ext/bcmath/tests/bccomp_variation001.phpt
+++ b/ext/bcmath/tests/bccomp_variation001.phpt
@@ -6,8 +6,8 @@ bcmath
 bcmath.scale=0
 --FILE--
 <?php
-echo bccomp("2.2", "2.2", "2")."\n";
-echo bccomp("2.32", "2.2", "2")."\n";
+echo bccomp("2.2", "2.2", "2") . "\n";
+echo bccomp("2.32", "2.2", "2") . "\n";
 echo bccomp("2.29", "2.3", "2");
 ?>
 --EXPECT--

--- a/ext/bcmath/tests/bccomp_variation002.phpt
+++ b/ext/bcmath/tests/bccomp_variation002.phpt
@@ -6,8 +6,8 @@ bcmath
 bcmath.scale=0
 --FILE--
 <?php
-echo bccomp("-2", "-2")."\n";
-echo bccomp("-2", "2", "1")."\n";
+echo bccomp("-2", "-2") . "\n";
+echo bccomp("-2", "2", "1") . "\n";
 echo bccomp("-2.29", "-2.3", "2");
 ?>
 --EXPECT--

--- a/ext/bcmath/tests/bug60377.phpt
+++ b/ext/bcmath/tests/bug60377.phpt
@@ -4,7 +4,9 @@ bcscale related problem on 64bits platforms
 bcmath
 --SKIPIF--
 <?php
-if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
+if (PHP_INT_SIZE != 8) {
+    die("skip: 64-bit only");
+} ?>
 --FILE--
 <?php
 try {
@@ -13,7 +15,7 @@ try {
     echo $e->getMessage() . \PHP_EOL;
 }
 $var67 = bcsqrt(0);
-$var414 = bcadd(0,-1,10);
+$var414 = bcadd(0, -1, 10);
 ?>
 --EXPECT--
 bcscale(): Argument #1 ($scale) must be between 0 and 2147483647

--- a/ext/bcmath/tests/negative_scale.phpt
+++ b/ext/bcmath/tests/negative_scale.phpt
@@ -7,27 +7,27 @@ bcmath.scale=0
 --FILE--
 <?php
 try {
-    bcadd('1','2',-1);
+    bcadd('1', '2', -1);
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
-    bcsub('1','2',-1);
+    bcsub('1', '2', -1);
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
-    bcmul('1','2',-1);
+    bcmul('1', '2', -1);
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
-    bcdiv('1','2',-1);
+    bcdiv('1', '2', -1);
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }
 try {
-    bcmod('1','2',-1);
+    bcmod('1', '2', -1);
 } catch (\ValueError $e) {
     echo $e->getMessage() . \PHP_EOL;
 }

--- a/pear/fetch.php
+++ b/pear/fetch.php
@@ -1,15 +1,17 @@
 <?php
 
-function usage($argv) {
+function usage($argv)
+{
     echo "Usage:\n";
     printf("\tphp %s <http://example.com/file> <localfile>\n", $argv[0]);
     exit(1);
 }
 
-function stream_notification_callback($notification_code, $severity, $message, $message_code, $bytes_transferred, $bytes_max) {
+function stream_notification_callback($notification_code, $severity, $message, $message_code, $bytes_transferred, $bytes_max)
+{
     static $filesize = null;
 
-    switch($notification_code) {
+    switch ($notification_code) {
     case STREAM_NOTIFY_RESOLVE:
     case STREAM_NOTIFY_AUTH_REQUIRED:
     case STREAM_NOTIFY_COMPLETED:
@@ -38,10 +40,10 @@ function stream_notification_callback($notification_code, $severity, $message, $
     case STREAM_NOTIFY_PROGRESS:
         if ($bytes_transferred > 0) {
             if (!isset($filesize)) {
-                printf("\rUnknown filesize.. %2d kb done..", $bytes_transferred/1024);
+                printf("\rUnknown filesize.. %2d kb done..", $bytes_transferred / 1024);
             } else {
-                $length = (int)(($bytes_transferred/$filesize)*100);
-                printf("\r[%-100s] %d%% (%2d/%2d kb)", str_repeat("=", $length). ">", $length, ($bytes_transferred/1024), $filesize/1024);
+                $length = (int)(($bytes_transferred / $filesize) * 100);
+                printf("\r[%-100s] %d%% (%2d/%2d kb)", str_repeat("=", $length) . ">", $length, ($bytes_transferred / 1024), $filesize / 1024);
             }
         }
         break;

--- a/run-tests.php
+++ b/run-tests.php
@@ -862,8 +862,10 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
     @unlink($info_file);
 
     // load list of enabled extensions
-    save_text($info_file,
-        '<?php echo str_replace("Zend OPcache", "opcache", implode(",", get_loaded_extensions())); ?>');
+    save_text(
+        $info_file,
+        '<?php echo str_replace("Zend OPcache", "opcache", implode(",", get_loaded_extensions())); ?>'
+    );
     $exts_to_test = explode(',', `$php $pass_options $info_params $no_file_cache "$info_file"`);
     // check for extensions that need special handling and regenerate
     $info_params_ex = [
@@ -1099,10 +1101,14 @@ function test_sort($a, $b): int
     $a = test_name($a);
     $b = test_name($b);
 
-    $ta = strpos($a, TEST_PHP_SRCDIR . "/tests") === 0 ? 1 + (strpos($a,
-            TEST_PHP_SRCDIR . "/tests/run-test") === 0 ? 1 : 0) : 0;
-    $tb = strpos($b, TEST_PHP_SRCDIR . "/tests") === 0 ? 1 + (strpos($b,
-            TEST_PHP_SRCDIR . "/tests/run-test") === 0 ? 1 : 0) : 0;
+    $ta = strpos($a, TEST_PHP_SRCDIR . "/tests") === 0 ? 1 + (strpos(
+        $a,
+        TEST_PHP_SRCDIR . "/tests/run-test"
+    ) === 0 ? 1 : 0) : 0;
+    $tb = strpos($b, TEST_PHP_SRCDIR . "/tests") === 0 ? 1 + (strpos(
+        $b,
+        TEST_PHP_SRCDIR . "/tests/run-test"
+    ) === 0 ? 1 : 0) : 0;
 
     if ($ta == $tb) {
         return strcmp($a, $b);
@@ -1289,7 +1295,7 @@ function system_with_timeout(
     }
     if ($stat["exitcode"] > 128 && $stat["exitcode"] < 160) {
         $data .= "\nTermsig=" . ($stat["exitcode"] - 128) . "\n";
-    } else if (defined('PHP_WINDOWS_VERSION_MAJOR') && (($stat["exitcode"] >> 28) & 0b1111) === 0b1100) {
+    } elseif (defined('PHP_WINDOWS_VERSION_MAJOR') && (($stat["exitcode"] >> 28) & 0b1111) === 0b1100) {
         // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/87fba13e-bf06-450e-83b1-9241dc81e781
         $data .= "\nTermsig=" . $stat["exitcode"] . "\n";
     }
@@ -1310,7 +1316,7 @@ function run_all_tests(array $test_files, array $env, $redir_tested = null): voi
     if ($file_cache !== null) {
         /* Automatically skip opcache tests in --file-cache mode,
          * because opcache generally doesn't expect those to run under file cache */
-        $test_files = array_filter($test_files, function($test) {
+        $test_files = array_filter($test_files, function ($test) {
             return !is_string($test) || false === strpos($test, 'ext/opcache');
         });
     }
@@ -1528,7 +1534,7 @@ function run_all_tests_parallel(array $test_files, array $env, $redir_tested): v
     // Tests waiting due to conflicts. Map from conflict key to array.
     $waitingTests = [];
 
-escape:
+    escape:
     while ($test_files || $sequentialTests || $testsInProgress > 0) {
         $toRead = array_values($workerSocks);
         $toWrite = null;
@@ -1798,7 +1804,8 @@ function show_file_block(string $file, string $block, ?string $section = null): 
     }
 }
 
-function skip_test(string $tested, string $tested_file, string $shortname, string $reason) {
+function skip_test(string $tested, string $tested_file, string $shortname, string $reason)
+{
     global $junit;
 
     show_result('SKIP', $tested, $tested_file, "reason: $reason");
@@ -2092,7 +2099,7 @@ TEST $file
             // even though all the files are re-created.
             $ini_settings['opcache.validate_timestamps'] = '0';
         }
-    } else if ($num_repeats > 1) {
+    } elseif ($num_repeats > 1) {
         // Make sure warnings still show up on the second run.
         $ini_settings['opcache.record_warnings'] = '1';
     }
@@ -3305,7 +3312,7 @@ function show_result(
     if (!$SHOW_ONLY_GROUPS || in_array($result, $SHOW_ONLY_GROUPS)) {
         if ($colorize) {
             /* Use ANSI escape codes for coloring test result */
-            switch ( $result ) {
+            switch ($result) {
                 case 'PASS': // Light Green
                     $color = "\e[1;32m{$result}\e[0m"; break;
                 case 'FAIL':
@@ -3325,7 +3332,6 @@ function show_result(
     } elseif (!$SHOW_ONLY_GROUPS) {
         clear_show_test();
     }
-
 }
 
 class BorkageException extends Exception
@@ -3606,11 +3612,11 @@ class JUnit
     private function mergeSuites(array &$dest, array $source): void
     {
         $dest['test_total'] += $source['test_total'];
-        $dest['test_pass']  += $source['test_pass'];
-        $dest['test_fail']  += $source['test_fail'];
+        $dest['test_pass'] += $source['test_pass'];
+        $dest['test_fail'] += $source['test_fail'];
         $dest['test_error'] += $source['test_error'];
-        $dest['test_skip']  += $source['test_skip'];
-        $dest['test_warn']  += $source['test_warn'];
+        $dest['test_skip'] += $source['test_skip'];
+        $dest['test_warn'] += $source['test_warn'];
         $dest['execution_time'] += $source['execution_time'];
         $dest['files'] += $source['files'];
     }
@@ -3719,7 +3725,7 @@ class RuntestsValgrind
         $this->tool = $tool;
         $header = system_with_timeout("valgrind --tool={$this->tool} --version", $environment);
         if (!$header) {
-            error("Valgrind returned no version info for {$this->tool}, cannot proceed.\n".
+            error("Valgrind returned no version info for {$this->tool}, cannot proceed.\n" .
                   "Please check if Valgrind is installed and the tool is named correctly.");
         }
         $count = 0;
@@ -3729,7 +3735,10 @@ class RuntestsValgrind
         }
         $this->version = $version;
         $this->header = sprintf(
-            "%s (%s)", trim($header), $this->tool);
+            "%s (%s)",
+            trim($header),
+            $this->tool
+        );
         $this->version_3_8_0 = version_compare($version, '3.8.0', '>=');
     }
 

--- a/scripts/dev/check_parameters.php
+++ b/scripts/dev/check_parameters.php
@@ -54,8 +54,8 @@ function error($str, $level = 0)
     global $current_file, $current_function, $line;
 
     if ($level <= REPORT_LEVEL) {
-        if (strpos($current_file,PHPDIR) === 0) {
-            $filename = substr($current_file, strlen(PHPDIR)+1);
+        if (strpos($current_file, PHPDIR) === 0) {
+            $filename = substr($current_file, strlen(PHPDIR) + 1);
         } else {
             $filename = $current_file;
         }
@@ -69,12 +69,12 @@ function update_lineno($offset)
 {
     global $lines_offset, $line;
 
-    $left  = 0;
-    $right = $count = count($lines_offset)-1;
+    $left = 0;
+    $right = $count = count($lines_offset) - 1;
 
     // a nice binary search :)
     do {
-        $mid = intval(($left + $right)/2);
+        $mid = intval(($left + $right) / 2);
         $val = $lines_offset[$mid];
 
         if ($val < $offset) {
@@ -84,15 +84,15 @@ function update_lineno($offset)
             } else {
                 $left = $mid;
             }
-        } else if ($val > $offset) {
+        } elseif ($val > $offset) {
             if ($lines_offset[--$mid] < $offset) {
-                $line = $mid+1;
+                $line = $mid + 1;
                 return;
             } else {
                 $right = $mid;
             }
         } else {
-            $line = $mid+1;
+            $line = $mid + 1;
             return;
         }
     } while (true);
@@ -102,13 +102,14 @@ function update_lineno($offset)
 /** parses the sources and fetches its vars name, type and if they are initialized or not */
 function get_vars($txt)
 {
-    $ret =  array();
+    $ret = array();
     preg_match_all('/((?:(?:unsigned|struct)\s+)?\w+)(?:\s*(\*+)\s+|\s+(\**))(\w+(?:\[\s*\w*\s*\])?)\s*(?:(=)[^,;]+)?((?:\s*,\s*\**\s*\w+(?:\[\s*\w*\s*\])?\s*(?:=[^,;]+)?)*)\s*;/S', $txt, $m, PREG_SET_ORDER);
 
     foreach ($m as $x) {
         // the first parameter is special
-        if (!in_array($x[1], array('else', 'endif', 'return'))) // hack to skip reserved words
+        if (!in_array($x[1], array('else', 'endif', 'return'))) { // hack to skip reserved words
             $ret[$x[4]] = array($x[1] . $x[2] . $x[3], $x[5]);
+        }
 
         // are there more vars?
         if ($x[6]) {
@@ -119,7 +120,7 @@ function get_vars($txt)
         }
     }
 
-//	if ($GLOBALS['current_function'] == 'for_debugging') { print_r($m);print_r($ret); }
+    //	if ($GLOBALS['current_function'] == 'for_debugging') { print_r($m);print_r($ret); }
     return $ret;
 }
 
@@ -140,14 +141,14 @@ function check_param($db, $idx, $exp, $optional, $allow_uninit = false)
     }
 
     if ($db[$idx][1] != $exp) {
-        error("{$db[$idx][0]}: expected '$exp' but got '{$db[$idx][1]}' [".($idx+1).']');
+        error("{$db[$idx][0]}: expected '$exp' but got '{$db[$idx][1]}' [" . ($idx + 1) . ']');
     }
 
     if (!$optional && $db[$idx][2]) {
-        error("not optional var is initialized: {$db[$idx][0]} [".($idx+1).']', 2);
+        error("not optional var is initialized: {$db[$idx][0]} [" . ($idx + 1) . ']', 2);
     }
     if (!$allow_uninit && $optional && !$db[$idx][2]) {
-        error("optional var not initialized: {$db[$idx][0]} [".($idx+1).']', 1);
+        error("optional var not initialized: {$db[$idx][0]} [" . ($idx + 1) . ']', 1);
     }
 }
 
@@ -168,7 +169,6 @@ function get_params($vars, $str)
         if (empty($vars[$name][0])) {
             error("variable not found: '$name'", 3);
             $ret[][] = '**dummy**';
-
         } else {
             $ret[] = array($name, $vars[$name][0] . ($x[1] ? '*' : ''), $vars[$name][1]);
         }
@@ -179,7 +179,7 @@ function get_params($vars, $str)
         }
     }
 
-//	if ($GLOBALS['current_function'] == 'for_debugging') { var_dump($m); var_dump($ret); }
+    //	if ($GLOBALS['current_function'] == 'for_debugging') { var_dump($m); var_dump($ret); }
     return $ret;
 }
 
@@ -198,7 +198,6 @@ function check_function($name, $txt, $offset)
         ,\s*([^{;]*)
     /Sx';
     if (preg_match_all($regex, $txt, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
-
         $GLOBALS['current_function'] = $name;
 
         foreach ($matches as $m) {
@@ -222,7 +221,7 @@ function check_function($name, $txt, $offset)
                             error("more than one optional separator at char #$i");
                         } else {
                             $optional = true;
-                            if ($i == $len-1) {
+                            if ($i == $len - 1) {
                                 error("unnecessary optional separator");
                             }
                         }
@@ -256,11 +255,11 @@ function check_function($name, $txt, $offset)
 
                     case 's':
                     case 'p':
-                        check_param($params, ++$j, 'char**', $optional, $allow_uninit=true);
-                        check_param($params, ++$j, 'size_t*', $optional, $allow_uninit=true);
-                        if ($optional && !$params[$j-1][2] && !$params[$j][2]
-                                && $params[$j-1][0] !== '**dummy**' && $params[$j][0] !== '**dummy**') {
-                            error("one of optional vars {$params[$j-1][0]} or {$params[$j][0]} must be initialized", 1);
+                        check_param($params, ++$j, 'char**', $optional, $allow_uninit = true);
+                        check_param($params, ++$j, 'size_t*', $optional, $allow_uninit = true);
+                        if ($optional && !$params[$j - 1][2] && !$params[$j][2]
+                                && $params[$j - 1][0] !== '**dummy**' && $params[$j][0] !== '**dummy**') {
+                            error("one of optional vars {$params[$j - 1][0]} or {$params[$j][0]} must be initialized", 1);
                         }
                     break;
 
@@ -276,7 +275,7 @@ function check_function($name, $txt, $offset)
 
                         // If an is_null flag is in use, only that flag is required to be
                         // initialized
-                        $allow_uninit = $i+1 < $len && $spec[$i+1] === '!'
+                        $allow_uninit = $i + 1 < $len && $spec[$i + 1] === '!'
                                 && in_array($char, array('l', 'L', 'd', 'b'));
 
                         foreach ($API_params[$char] as $exp) {
@@ -295,7 +294,9 @@ function check_function($name, $txt, $offset)
 function recurse($path)
 {
     foreach (scandir($path) as $file) {
-        if ($file == '.' || $file == '..' || $file == 'CVS') continue;
+        if ($file == '.' || $file == '..' || $file == 'CVS') {
+            continue;
+        }
 
         $file = "$path/$file";
         if (is_dir($file)) {
@@ -304,18 +305,22 @@ function recurse($path)
         }
 
         // parse only .c and .cpp files
-        if (substr_compare($file, '.c', -2) && substr_compare($file, '.cpp', -4)) continue;
+        if (substr_compare($file, '.c', -2) && substr_compare($file, '.cpp', -4)) {
+            continue;
+        }
 
         $txt = file_get_contents($file);
         // remove comments (but preserve the number of lines)
         $txt = preg_replace('@//.*@S', '', $txt);
-        $txt = preg_replace_callback('@/\*.*\*/@SsU', function($matches) {
+        $txt = preg_replace_callback('@/\*.*\*/@SsU', function ($matches) {
             return preg_replace("/[^\r\n]+/S", "", $matches[0]);
         }, $txt);
 
         $split = preg_split('/PHP_(?:NAMED_)?(?:FUNCTION|METHOD)\s*\((\w+(?:,\s*\w+)?)\)/S', $txt, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE);
 
-        if (count($split) < 2) continue; // no functions defined on this file
+        if (count($split) < 2) {
+            continue;
+        } // no functions defined on this file
         array_shift($split); // the first part isn't relevant
 
 
@@ -333,10 +338,10 @@ function recurse($path)
         $GLOBALS['current_file'] = $file;
 
 
-        for ($i = 0; $i < count($split); $i+=2) {
+        for ($i = 0; $i < count($split); $i += 2) {
             // if the /* }}} */ comment is found use it to reduce false positives
             // TODO: check the other indexes
-            list($f) = preg_split('@/\*\s*}}}\s*\*/@S', $split[$i+1][0]);
+            list($f) = preg_split('@/\*\s*}}}\s*\*/@S', $split[$i + 1][0]);
             check_function(preg_replace('/\s*,\s*/S', '::', $split[$i][0]), $f, $split[$i][1]);
         }
     }
@@ -360,7 +365,7 @@ HELP;
     $dirs[] = PHPDIR;
 }
 
-foreach($dirs as $dir) {
+foreach ($dirs as $dir) {
     if (is_dir($dir)) {
         if (!is_readable($dir)) {
             echo "ERROR: directory '", $dir ,"' is not readable\n";

--- a/scripts/dev/find_tested.php
+++ b/scripts/dev/find_tested.php
@@ -41,7 +41,7 @@ if ($num_params == 3) {
     $extensions = get_loaded_extensions();
     if (!in_array($extension_name, $extensions)) {
         echo "Error: extension $extension_name is not loaded. Loaded extensions:\n";
-        foreach($extensions as $extension) {
+        foreach ($extensions as $extension) {
             echo "$extension\n";
         }
         die();
@@ -56,7 +56,7 @@ $method_info = populate_method_info();
 if ($extension_name != false) {
     // get only the methods from the extension we are querying
     $extension_method_info = array();
-    foreach($method_info as $method_record) {
+    foreach ($method_info as $method_record) {
         if (strcasecmp($extension_name, $method_record[EXTENSION_NAME]) == 0) {
             $extension_method_info[] = $method_record;
         }
@@ -73,7 +73,7 @@ $extension_method_info = mark_methods_as_tested($extension_method_info, $phpt_fi
  * The loop to output the test coverage info
  * Should output: Extension, Class Name, Method/Function Name, Test Status, Test Files
  */
-foreach($extension_method_info as $record) {
+foreach ($extension_method_info as $record) {
     echo $record[EXTENSION_NAME] . ",";
     echo $record[CLASS_NAME] . ",";
     echo $record[METHOD_NAME] . ",";
@@ -85,15 +85,15 @@ foreach($extension_method_info as $record) {
  * Marks the "tested" status of methods in $method_info according
  * to whether they are tested in $phpt_files
  */
-function mark_methods_as_tested($method_info, $phpt_files) {
-
-    foreach($phpt_files as $phpt_file) {
+function mark_methods_as_tested($method_info, $phpt_files)
+{
+    foreach ($phpt_files as $phpt_file) {
         $tested_functions = extract_tests($phpt_file);
 
-        foreach($tested_functions as $tested_function) {
+        foreach ($tested_functions as $tested_function) {
 
             // go through method info array marking this function as tested
-            foreach($method_info as &$current_method_record) {
+            foreach ($method_info as &$current_method_record) {
                 if (strcasecmp($tested_function, $current_method_record[METHOD_NAME]) == 0) {
                     // matched the method name
                     if ($current_method_record[IS_DUPLICATE] == true) {
@@ -114,8 +114,8 @@ function mark_methods_as_tested($method_info, $phpt_files) {
 /**
  * returns an array containing a record for each defined method.
  */
-function populate_method_info() {
-
+function populate_method_info()
+{
     $method_info = array();
 
     // get functions
@@ -181,12 +181,12 @@ function populate_method_info() {
 
 function get_phpt_files($dir, &$phpt_file_count, &$all_phpt)
 {
-    $thisdir = dir($dir.'/'); //include the trailing slash
-    while(($file = $thisdir->read()) !== false) {
+    $thisdir = dir($dir . '/'); //include the trailing slash
+    while (($file = $thisdir->read()) !== false) {
         if ($file != '.' && $file != '..') {
-            $path = $thisdir->path.$file;
-            if(is_dir($path) == true) {
-                get_phpt_files($path , $phpt_file_count , $all_phpt);
+            $path = $thisdir->path . $file;
+            if (is_dir($path) == true) {
+                get_phpt_files($path, $phpt_file_count, $all_phpt);
             } else {
                 if (preg_match("/\w+\.phpt$/", $file)) {
                     $all_phpt[$phpt_file_count] = $path;
@@ -200,7 +200,8 @@ function get_phpt_files($dir, &$phpt_file_count, &$all_phpt)
 /**
  * Extract tests from a specified file, returns an array of tested function tokens
  */
-function extract_tests($file) {
+function extract_tests($file)
+{
     $code = file_get_contents($file);
 
     if (!preg_match('/--FILE--\s*(.*)\s*--(EXPECTF|EXPECTREGEX|EXPECT)?--/is', $code, $r)) {
@@ -210,17 +211,19 @@ function extract_tests($file) {
 
     $tokens = token_get_all($r[1]);
     $functions = array_filter($tokens, 'filter_functions');
-    $functions = array_map( 'map_token_value',$functions);
+    $functions = array_map('map_token_value', $functions);
     $functions = array_unique($functions);
 
     return $functions;
 }
 
-function filter_functions($x) {
+function filter_functions($x)
+{
     return $x[0] == 307;
 }
 
-function map_token_value($x) {
+function map_token_value($x)
+{
     return $x[1];
 }
 

--- a/scripts/dev/search_underscores.php
+++ b/scripts/dev/search_underscores.php
@@ -31,7 +31,7 @@ $classes = array_merge(get_declared_classes(), get_declared_interfaces());
 
 $extensions = array();
 
-foreach(get_loaded_extensions() as $ext) {
+foreach (get_loaded_extensions() as $ext) {
     $cnt_modules++;
     if (strpos($ext, "_") !== false) {
         $err++;
@@ -41,27 +41,26 @@ foreach(get_loaded_extensions() as $ext) {
 
 $cnt_classes = count($classes);
 
-foreach($classes as $c) {
+foreach ($classes as $c) {
     if (strpos($c, "_") !== false) {
         $err++;
         $ref = new ReflectionClass($c);
-        if (!($ext = $ref->getExtensionName())) {;
+        if (!($ext = $ref->getExtensionName())) {
+            ;
             $ext = $ref->isInternal() ? "<internal>" : "<user>";
         }
         if (!array_key_exists($ext, $extensions)) {
             $extensions[$ext] = array();
         }
         $extensions[$ext][$c] = array();
-        foreach(get_class_methods($c) as $method) {
+        foreach (get_class_methods($c) as $method) {
             $cnt_methods++;
             if (strpos(substr($method, substr($method, 0, 2) != "__"  ? 0 : 2), "_") !== false) {
                 $err++;
                 $extensions[$ext][$c][] = $method;
             }
         }
-    }
-    else
-    {
+    } else {
         $cnt_methods += count(get_class_methods($c));
     }
 }
@@ -78,13 +77,13 @@ printf("Errors:  %5d (%.1f%%)\n", $err, round($err * 100 / $cnt, 1));
 printf("\n");
 
 ksort($extensions);
-foreach($extensions as $ext => &$classes) {
+foreach ($extensions as $ext => &$classes) {
     echo "Extension: $ext\n";
     ksort($classes);
-    foreach($classes as $classname => &$methods) {
+    foreach ($classes as $classname => &$methods) {
         echo "  Class: $classname\n";
         ksort($methods);
-        foreach($methods as $method) {
+        foreach ($methods as $method) {
             echo "    Method: $method\n";
         }
     }

--- a/scripts/dev/tidy.php
+++ b/scripts/dev/tidy.php
@@ -1,6 +1,6 @@
 <?php
 
-set_error_handler(function($_, $msg) {
+set_error_handler(function ($_, $msg) {
     throw new Exception($msg);
 });
 
@@ -67,13 +67,13 @@ foreach ($it as $file) {
 
     if ($lang === 'c') {
         $code = stripTrailingWhitespace($code);
-        // TODO: Avoid this for now.
+    // TODO: Avoid this for now.
         // $code = reindentToTabs($code);
-    } else if ($lang === 'php') {
+    } elseif ($lang === 'php') {
         $code = stripTrailingWhitespace($code);
         $code = reindentToSpaces($code);
-    } else if ($lang === 'phpt') {
-        $code = transformTestCode($code, function(string $code) {
+    } elseif ($lang === 'phpt') {
+        $code = transformTestCode($code, function (string $code) {
             $code = stripTrailingWhitespace($code);
             $code = reindentToSpaces($code);
             return $code;
@@ -85,12 +85,14 @@ foreach ($it as $file) {
     }
 }
 
-function stripTrailingWhitespace(string $code): string {
+function stripTrailingWhitespace(string $code): string
+{
     return preg_replace('/\h+$/m', '', $code);
 }
 
-function reindentToTabs(string $code): string {
-    return preg_replace_callback('/^ +/m', function(array $matches) {
+function reindentToTabs(string $code): string
+{
+    return preg_replace_callback('/^ +/m', function (array $matches) {
         $tabSize = 4;
         $spaces = strlen($matches[0]);
         $tabs = intdiv($spaces, $tabSize);
@@ -99,8 +101,9 @@ function reindentToTabs(string $code): string {
     }, $code);
 }
 
-function reindentToSpaces(string $code): string {
-    return preg_replace_callback('/^[ \t]+/m', function(array $matches) {
+function reindentToSpaces(string $code): string
+{
+    return preg_replace_callback('/^[ \t]+/m', function (array $matches) {
         $tabSize = 4;
         $indent = 0;
         foreach (str_split($matches[0]) as $char) {
@@ -119,7 +122,8 @@ function reindentToSpaces(string $code): string {
     }, $code);
 }
 
-function transformTestCode(string $code, callable $transformer): string {
+function transformTestCode(string $code, callable $transformer): string
+{
     // Don't transform whitespace-sensitive tests.
     if (strpos($code, '--WHITESPACE_SENSITIVE--') !== false) {
         return $code;
@@ -127,14 +131,15 @@ function transformTestCode(string $code, callable $transformer): string {
 
     return preg_replace_callback(
         '/(--(?:FILE|SKIPIF|CLEAN)--)(.+?)(?=--[A-Z_]+--)/s',
-        function(array $matches) use($transformer) {
+        function (array $matches) use ($transformer) {
             return $matches[1] . $transformer($matches[2]);
         },
         $code
     );
 }
 
-function getLanguageFromExtension(string $ext): ?string {
+function getLanguageFromExtension(string $ext): ?string
+{
     switch ($ext) {
     case 'c':
     case 'h':

--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -44,7 +44,7 @@ function get_depends($module)
         'apachecore.dll',
 
         /* apache 2 */
-        'libhttpd.dll', 'libapr.dll', 'libaprutil.dll','libapr-1.dll', 'libaprutil-1.dll',
+        'libhttpd.dll', 'libapr.dll', 'libaprutil.dll', 'libapr-1.dll', 'libaprutil-1.dll',
 
         /* oracle */
         'oci.dll', 'ociw32.dll',
@@ -74,9 +74,11 @@ function get_depends($module)
     $is_pecl = in_array($module, $pecl_targets);
 
     $cmd = "$GLOBALS[build_dir]\\deplister.exe \"$module\" \"$GLOBALS[build_dir]\"";
-    $proc = proc_open($cmd,
-            array(1 => array("pipe", "w")),
-            $pipes);
+    $proc = proc_open(
+        $cmd,
+        array(1 => array("pipe", "w")),
+        $pipes
+    );
 
     $n = 0;
     while (($line = fgetcsv($pipes[1]))) {
@@ -125,7 +127,7 @@ function get_depends($module)
     }
     fclose($pipes[1]);
     proc_close($proc);
-//echo "Module $module [$n lines]\n";
+    //echo "Module $module [$n lines]\n";
 }
 
 function copy_file_list($source_dir, $dest_dir, $list)
@@ -181,15 +183,19 @@ function extract_file_from_tarball($pkg, $filename, $dest_dir) /* {{{ */
     do {
         /* read the header */
         $hdr_data = gzread($fp, 512);
-        if (strlen($hdr_data) == 0)
+        if (strlen($hdr_data) == 0) {
             break;
+        }
         $checksum = 0;
-        for ($i = 0; $i < 148; $i++)
+        for ($i = 0; $i < 148; $i++) {
             $checksum += ord($hdr_data[$i]);
-        for ($i = 148; $i < 156; $i++)
+        }
+        for ($i = 148; $i < 156; $i++) {
             $checksum += 32;
-        for ($i = 156; $i < 512; $i++)
+        }
+        for ($i = 156; $i < 512; $i++) {
             $checksum += ord($hdr_data[$i]);
+        }
 
         $hdr = unpack("a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/a1typeflag/a100link/a6magic/a2version/a32uname/a32gname/a8devmajor/a8devminor", $hdr_data);
 
@@ -217,9 +223,7 @@ function extract_file_from_tarball($pkg, $filename, $dest_dir) /* {{{ */
         $size = 512 * ceil((int)$hdr['size'] / 512);
         echo "Skipping $size bytes\n";
         gzseek($fp, gztell($fp) + $size);
-
     } while (!$done);
-
 } /* }}} */
 
 
@@ -243,7 +247,7 @@ copy_file_list($build_dir, "$dist_dir", $sapi_targets);
 copy_file_list($build_dir, "$dist_dir/ext", $ext_targets);
 
 /* pecl sapi and extensions */
-if(sizeof($pecl_targets)) {
+if (sizeof($pecl_targets)) {
     copy_file_list($build_dir, $pecl_dir, $pecl_targets);
 }
 
@@ -263,7 +267,7 @@ foreach ($text_files as $src => $dest) {
 
 /* general other files */
 $general_files = array(
-    "$GLOBALS[build_dir]\\deplister.exe"	=>	"deplister.exe",
+    "$GLOBALS[build_dir]\\deplister.exe" => "deplister.exe",
 );
 
 foreach ($general_files as $src => $dest) {
@@ -274,7 +278,9 @@ foreach ($general_files as $src => $dest) {
 $branch = "HEAD"; // TODO - determine this from SVN branche name
 $fp = fopen("$dist_dir/snapshot.txt", "w");
 $now = date("r");
-fwrite($fp, <<<EOT
+fwrite(
+    $fp,
+    <<<EOT
 This snapshot was automatically generated on
 $now
 
@@ -296,8 +302,9 @@ fwrite($fp, "\r\n\r\n");
 /* list dependencies */
 fprintf($fp, "Dependency information:\r\n");
 foreach ($per_module_deps as $modulename => $deps) {
-    if (in_array($modulename, $pecl_targets))
+    if (in_array($modulename, $pecl_targets)) {
         continue;
+    }
 
     fprintf($fp, "Module: %s\r\n", $modulename);
     fwrite($fp, "===========================\r\n");
@@ -343,7 +350,7 @@ if (file_exists("$php_build_dir/bin/libenchant2.dll")) {
     $ENCHANT_DLLS[] = array('lib/enchant', 'libenchant_ispell.dll');
 }
 foreach ($ENCHANT_DLLS as $dll) {
-    $dest  = "$dist_dir/$dll[0]";
+    $dest = "$dist_dir/$dll[0]";
     $filename = $dll[1];
 
     if (!file_exists("$dest") || !is_dir("$dest")) {
@@ -353,7 +360,7 @@ foreach ($ENCHANT_DLLS as $dll) {
     }
 
     if (!copy($php_build_dir . '/bin/' . $filename, "$dest/" . basename($filename))) {
-            echo "WARNING: couldn't copy $filename into the dist dir";
+        echo "WARNING: couldn't copy $filename into the dist dir";
     }
 }
 
@@ -419,8 +426,8 @@ function copy_dir($source, $dest)
 
 function copy_test_dir($directory, $dest)
 {
-    if(substr($directory,-1) == '/') {
-        $directory = substr($directory,0,-1);
+    if (substr($directory, -1) == '/') {
+        $directory = substr($directory, 0, -1);
     }
 
     if ($directory == 'tests' || $directory == 'examples') {
@@ -432,19 +439,19 @@ function copy_test_dir($directory, $dest)
         return false;
     }
 
-    if(!file_exists($directory) || !is_dir($directory)) {
+    if (!file_exists($directory) || !is_dir($directory)) {
         echo "failed... $directory\n";
-        return FALSE;
+        return false;
     }
 
     $directory_list = opendir($directory);
 
-    while (FALSE !== ($file = readdir($directory_list))) {
+    while (false !== ($file = readdir($directory_list))) {
         $full_path = $directory . '/' . $file;
-        if($file != '.' && $file != '..' && $file != '.svn' && is_dir($full_path)) {
+        if ($file != '.' && $file != '..' && $file != '.svn' && is_dir($full_path)) {
             if ($file == 'tests' || $file == 'examples') {
                 if (!is_dir($dest . '/' . $full_path)) {
-                    mkdir($dest . '/' . $full_path , 0775, true);
+                    mkdir($dest . '/' . $full_path, 0775, true);
                 }
                 copy_dir($full_path, $dest . '/' . $full_path . '/');
                 continue;
@@ -474,7 +481,7 @@ function make_phar_dot_phar($dist_dir)
         }
 
         echo 'adding ', $file, "\n";
-        $phar[(string) $file] = file_get_contents($path_to_phar.  '/phar/' . $file);
+        $phar[(string) $file] = file_get_contents($path_to_phar . '/phar/' . $file);
     }
 
     $phar->setSignatureAlgorithm(Phar::SHA1);
@@ -524,8 +531,9 @@ if (!$use_pear_template) {
     foreach ($packages as $name => $version) {
         $filename = "$name-$version.tgz";
         $destfilename = "$dist_dir/PEAR/go-pear-bundle/$filename";
-        if (file_exists($destfilename))
+        if (file_exists($destfilename)) {
             continue;
+        }
         $url = "http://pear.php.net/get/$filename";
         echo "Downloading $name from $url\n";
         flush();
@@ -551,7 +559,7 @@ if (file_exists($snapshot_template)) {
         if (is_dir($item)) {
             if ($bi == 'dlls' || $bi == 'symbols') {
                 continue;
-            } else if ($bi == 'PEAR') {
+            } elseif ($bi == 'PEAR') {
                 if ($use_pear_template) {
                     /* copy to top level */
                     copy_dir($item, "$dist_dir/$bi");
@@ -586,4 +594,3 @@ if (file_exists($snapshot_template)) {
 }
 
 make_phar_dot_phar($dist_dir);
-?>

--- a/win32/build/registersyslog.php
+++ b/win32/build/registersyslog.php
@@ -7,7 +7,9 @@ $PATH = "SYSTEM\\CurrentControlSet\\Services\\Eventlog\\Application\\PHP-" . php
 $dll = $argv[1];
 $dll = addslashes($dll);
 
-file_put_contents("win32/syslog.reg", <<<REG
+file_put_contents(
+    "win32/syslog.reg",
+    <<<REG
 REGEDIT4
 
 [HKEY_LOCAL_MACHINE\\$PATH]
@@ -16,5 +18,3 @@ REGEDIT4
 
 REG
 );
-
-?>


### PR DESCRIPTION
Part 1, apply on `ext/bcmath` directory and scripts.

Another parts will update more `ext/*` files.

Please advise which directories contains files intended to have obscure formating to test PHP lexer.