### PR TITLE
Fix creating IntlDateFormatter in strict mode with null values for dateType or timeType

### DIFF
--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -52,7 +52,9 @@ static int datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_constructor)
 	size_t		locale_len	= 0;
 	Locale		locale;
 	zend_long	date_type	= 0;
+	zend_bool	date_type_is_null = 1;
 	zend_long	time_type	= 0;
+	zend_bool	time_type_is_null = 1;
 	zval		*calendar_zv	= NULL;
 	Calendar	*calendar	= NULL;
 	zend_long	calendar_type;
@@ -70,8 +72,8 @@ static int datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_bool is_constructor)
 	intl_error_reset(NULL);
 	object = return_value;
 	/* Parse parameters. */
-	if (zend_parse_parameters_ex(zpp_flags, ZEND_NUM_ARGS(), "s!ll|zzs",
-			&locale_str, &locale_len, &date_type, &time_type, &timezone_zv,
+	if (zend_parse_parameters_ex(zpp_flags, ZEND_NUM_ARGS(), "s!l!l!|zzs",
+			&locale_str, &locale_len, &date_type, &date_type_is_null, &time_type, &time_type_is_null, &timezone_zv,
 			&calendar_zv, &pattern_str, &pattern_str_len) == FAILURE) {
 		intl_error_set( NULL, U_ILLEGAL_ARGUMENT_ERROR,	"datefmt_create: "
 				"unable to parse input parameters", 0);

--- a/ext/intl/tests/dateformat_create_strict_types_with_null.phpt
+++ b/ext/intl/tests/dateformat_create_strict_types_with_null.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Creating IntlDateFormatter in strict mode with $locale, $dateType and $timeType set to null
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+var_dump(IntlDateFormatter::create(null, null, null));
+
+?>
+--EXPECT--
+object(IntlDateFormatter)#1 (0) {
+}


### PR DESCRIPTION
According to the [documentation](https://www.php.net/manual/en/intldateformatter.create.php):

> dateType
> Date type to use (none, short, medium, long, full). This is one of the IntlDateFormatter constants. **It can also be null, in which case ICUʼs default date type will be used.**
> 
> timeType
> Time type to use (none, short, medium, long, full). This is one of the IntlDateFormatter constants. **It can also be null, in which case ICUʼs default time type will be used.**

However, passing `null` as the value for either of these two arguments i strict mode will result in a `TypeError`:

> PHP Warning:  Uncaught TypeError: IntlDateFormatter::create() expects parameter 2 to be int, null given in php shell code:1
