### PR TITLE
Remove the "getdir" function which was introduced accidentally

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -45,6 +45,8 @@ PHP                                                                        NEWS
 - Standard:
   . Fixed bug #80915 (Taking a reference to $_SERVER hides its values from
     phpinfo()). (Rowan Tommins)
+  . Fixed bug #80914 ('getdir' accidentally defined as an alias of 'dir').
+    (Rowan Tommins)
 
 01 Apr 2021, PHP 8.0.4
 

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -695,13 +695,7 @@ function utf8_decode(string $string): string {}
  */
 function opendir(string $directory, $context = null) {}
 
-/** @param resource $context */
-function getdir(string $directory, $context = null): Directory|false {}
-
-/**
- * @param resource|null $context
- * @alias getdir
- */
+/** @param resource|null $context */
 function dir(string $directory, $context = null): Directory|false {}
 
 /** @param resource|null $dir_handle */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 39cd1ddd82efd6b62605218faff8b720d8b97170 */
+ * Stub hash: b1d68b2f2dcc7a078257c65569f2eec284dcd804 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1094,12 +1094,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_opendir, 0, 0, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, context, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_getdir, 0, 1, Directory, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_dir, 0, 1, Directory, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, directory, IS_STRING, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, context, "null")
 ZEND_END_ARG_INFO()
-
-#define arginfo_dir arginfo_getdir
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_closedir, 0, 0, IS_VOID, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, dir_handle, "null")
@@ -2512,7 +2510,7 @@ ZEND_FUNCTION(substr_compare);
 ZEND_FUNCTION(utf8_encode);
 ZEND_FUNCTION(utf8_decode);
 ZEND_FUNCTION(opendir);
-ZEND_FUNCTION(getdir);
+ZEND_FUNCTION(dir);
 ZEND_FUNCTION(closedir);
 ZEND_FUNCTION(chdir);
 #if defined(HAVE_CHROOT) && !defined(ZTS) && ENABLE_CHROOT_FUNC
@@ -3147,8 +3145,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(utf8_encode, arginfo_utf8_encode)
 	ZEND_FE(utf8_decode, arginfo_utf8_decode)
 	ZEND_FE(opendir, arginfo_opendir)
-	ZEND_FE(getdir, arginfo_getdir)
-	ZEND_FALIAS(dir, getdir, arginfo_dir)
+	ZEND_FE(dir, arginfo_dir)
 	ZEND_FE(closedir, arginfo_closedir)
 	ZEND_FE(chdir, arginfo_chdir)
 #if defined(HAVE_CHROOT) && !defined(ZTS) && ENABLE_CHROOT_FUNC

--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -237,7 +237,7 @@ PHP_FUNCTION(opendir)
 /* }}} */
 
 /* {{{ Directory class with properties, handle and class and methods read, rewind and close */
-PHP_FUNCTION(getdir)
+PHP_FUNCTION(dir)
 {
 	_php_do_opendir(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1);
 }


### PR DESCRIPTION
The actual name of this function is dir(), but ever since it was
introduced in PHP 3, its internal name was "getdir", leading to it
being mistaken for an alias. This went unnoticed until the switch
to stubs for generating arginfo, at which point getdir() became a
real but undocumented function.