### PR TITLE
[Bug #77120] Handle OCI_SUCCESS_WITH_INFO returned from OCISessionBegin

### DIFF
--- a/ext/pdo_oci/oci_driver.c
+++ b/ext/pdo_oci/oci_driver.c
@@ -336,9 +336,13 @@ static zend_long oci_handle_doer(pdo_dbh_t *dbh, const zend_string *sql) /* {{{ 
 	H->last_err = OCIStmtExecute(H->svc, stmt, H->err, 1, 0, NULL, NULL,
 			(dbh->auto_commit && !dbh->in_txn) ? OCI_COMMIT_ON_SUCCESS : OCI_DEFAULT);
 
-	if (H->last_err) {
+	sword last_err = H->last_err;
+
+	if (last_err) {
 		H->last_err = oci_drv_error("OCIStmtExecute");
-	} else {
+	}
+
+	if (!last_err || last_err == OCI_SUCCESS_WITH_INFO) {
 		/* return the number of affected rows */
 		H->last_err = OCIAttrGet(stmt, OCI_HTYPE_STMT, &rowcount, 0, OCI_ATTR_ROW_COUNT, H->err);
 		ret = rowcount;

--- a/ext/pdo_oci/tests/oci_success_with_info.phpt
+++ b/ext/pdo_oci/tests/oci_success_with_info.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Handling OCI_SUCCESS_WITH_INFO
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_oci')) die('skip not loaded');
+?>
+--FILE--
+<?php
+
+function connectAsAdmin(): PDO {
+    return PDOTest::test_factory(__DIR__ . '/../../pdo_oci/tests/common.phpt');
+}
+
+function connectAsUser(string $username, string $password): PDO {
+    return new PDO(getenv('PDOTEST_DSN'), $username, $password);
+}
+
+function dropProfile(PDO $conn): void {
+    $conn->exec(<<<'SQL'
+BEGIN
+    EXECUTE IMMEDIATE 'DROP PROFILE BUG77120_PROFILE CASCADE';
+EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLCODE != -2380 THEN
+            RAISE;
+        END IF;
+END;
+SQL
+    );
+}
+
+function dropUser(PDO $conn): void {
+    $conn->exec(<<<'SQL'
+BEGIN
+    EXECUTE IMMEDIATE 'DROP USER BUG77120_USER CASCADE';
+EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLCODE != -1918 THEN
+            RAISE;
+        END IF;
+END;
+SQL
+    );
+}
+
+require __DIR__ . '/../../pdo/tests/pdo_test.inc';
+
+$conn = connectAsAdmin();
+
+dropUser($conn);
+dropProfile($conn);
+
+$password = bin2hex(random_bytes(8));
+
+$conn->exec('CREATE PROFILE BUG77120_PROFILE LIMIT PASSWORD_LIFE_TIME 1/86400 PASSWORD_GRACE_TIME 1');
+$conn->exec('CREATE USER BUG77120_USER IDENTIFIED BY "' . $password . '" PROFILE BUG77120_PROFILE');
+$conn->exec('GRANT CREATE SESSION TO BUG77120_USER');
+
+// let the password expire
+sleep(2);
+
+$conn = connectAsUser('BUG77120_USER', $password);
+var_dump($conn->errorInfo());
+
+$conn = connectAsAdmin();
+dropUser($conn);
+dropProfile($conn);
+
+?>
+--EXPECTF--
+array(3) {
+  [0]=>
+  string(5) "HY000"
+  [1]=>
+  int(28002)
+  [2]=>
+  string(%d) "OCISessionBegin: OCI_SUCCESS_WITH_INFO: ORA-28002: %s
+ (%s:%d)"
+}


### PR DESCRIPTION
Create a test user:
```sql
CREATE PROFILE test_profile LIMIT PASSWORD_LIFE_TIME 1/86400 PASSWORD_GRACE_TIME 7;
CREATE USER bob IDENTIFIED BY password PROFILE test_profile;
GRANT CREATE SESSION TO bob;
```

Run the script:
```php
$conn = new PDO('oci:dbname=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SID=XE)))', 'bob', 'password');
```

**Expected result**:
The connection is successfully established. The details of the informational message are available via `PDO::errorInfo()`.

**Actual result**:
```
PDOException: SQLSTATE[HY000]: OCISessionBegin: OCI_SUCCESS_WITH_INFO: ORA-28002: the password will expire within 7 days
 (ext/pdo_oci/oci_driver.c:685) in test.php on line 3
```

**Change summary**:
1. Proceed with connection initialization if `OCI_SUCCESS_WITH_INFO` is returned.
2. Do not throw an exception upon `OCI_SUCCESS_WITH_INFO`.