### PR TITLE
Create minilua binary with host compiler (fix #80717)

### DIFF
--- a/build/Makefile.global
+++ b/build/Makefile.global
@@ -5,6 +5,8 @@ INSTALL_DATA = $(INSTALL) -m 644
 DEFS = -I$(top_builddir)/include -I$(top_builddir)/main -I$(top_srcdir)
 COMMON_FLAGS = $(DEFS) $(INCLUDES) $(EXTRA_INCLUDES) $(CPPFLAGS) $(PHP_FRAMEWORKPATH)
 
+HOSTCC ?= $(CC)
+
 all: $(all_targets)
 	@echo
 	@echo "Build complete."

--- a/ext/opcache/jit/Makefile.frag
+++ b/ext/opcache/jit/Makefile.frag
@@ -1,6 +1,6 @@
 
 $(builddir)/minilua: $(srcdir)/jit/dynasm/minilua.c
-	$(CC) $(srcdir)/jit/dynasm/minilua.c -lm -o $@
+	$(HOSTCC) $(srcdir)/jit/dynasm/minilua.c -lm -o $@
 
 $(builddir)/jit/zend_jit_x86.c: $(srcdir)/jit/zend_jit_x86.dasc $(srcdir)/jit/dynasm/*.lua $(builddir)/minilua
 	$(builddir)/minilua $(srcdir)/jit/dynasm/dynasm.lua  $(DASM_FLAGS) -o $@ $(srcdir)/jit/zend_jit_x86.dasc


### PR DESCRIPTION
During OpenWrt "cross-compiling" for x86_64, we noticed that during the build
a minilua compiler is generated and finally invoked.

While this is fine when doing a native build, it fails for "cross-compiling"
e.g. due to different used C libraries (e.g. target=musl, host=glibc).

Our solution is to convert the $(CC) to $(HOSTCC) which is then passed via
environment. If not, preset HOSTCC to CC.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>