### PR TITLE
Fixed bug #80900

### DIFF
--- a/ext/opcache/Optimizer/sccp.c
+++ b/ext/opcache/Optimizer/sccp.c
@@ -2006,7 +2006,7 @@ static void sccp_mark_feasible_successors(
 				scdf_mark_edge_feasible(scdf, block_num, target);
 				return;
 			}
-			s = 0;
+			s = block->successors_count - 1;
 			break;
 		case ZEND_SWITCH_STRING:
 			if (Z_TYPE_P(op1) == IS_STRING) {
@@ -2024,7 +2024,7 @@ static void sccp_mark_feasible_successors(
 				scdf_mark_edge_feasible(scdf, block_num, target);
 				return;
 			}
-			s = 0;
+			s = block->successors_count - 1;
 			break;
 		default:
 			for (s = 0; s < block->successors_count; s++) {

--- a/ext/opcache/tests/bug80900.phpt
+++ b/ext/opcache/tests/bug80900.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Bug 80900: Switch constant with incorrect type
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+function switchLong() {
+    $var = 'foo';
+    /* The number of case clauses needs to be greater than 5,
+     * otherwise it will not be compiled into SWITCH_LONG. */
+    switch ($var) {
+        case 1:
+            echo 'no1';
+            break;
+        case 2:
+            echo 'no2';
+            break;
+        case 3:
+            echo 'no3';
+            break;
+        case 4:
+            echo 'no4';
+            break;
+        case 5:
+            echo 'no5';
+            break;
+        default:
+            echo 'yes';
+            break;
+    }
+    echo PHP_EOL;
+}
+
+function switchString() {
+    $var = false;
+    switch ($var) {
+        case 'string':
+            echo 'no';
+            break;
+        default:
+            echo 'yes';
+            break;
+    }
+    echo PHP_EOL;
+}
+
+switchLong();
+switchString();
+?>
+--EXPECT--
+yes
+yes


### PR DESCRIPTION
SCCP optimization marks the wrong target feasible when the constant is of the incorrect type.

I am just curious about this bug and have a try...
And this bug was introduced by db2ffcf so we need to fix it on PHP-7.4 instead of master.
