### PR TITLE
Add configure option --enable-sanitizer=a,b,c

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,10 +74,7 @@ jobs:
     - template: azure/job.yml
       parameters:
         configurationName: DEBUG_ZTS_ASAN_UBSAN
-        configurationParameters: >-
-            --enable-debug --enable-zts
-            CFLAGS='-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC'
-            LDFLAGS='-fsanitize=undefined,address'
+        configurationParameters: '--enable-debug --enable-zts --enable-sanitizer=address,undefined'
         runTestsParameters: --asan
         timeoutInMinutes: 360
     - template: azure/msan_job.yml
@@ -90,9 +87,8 @@ jobs:
       parameters:
         configurationName: COMMUNITY
         configurationParameters: >-
-            --enable-debug --enable-zts
-            CFLAGS='-fsanitize=undefined,address -fno-sanitize-recover -DZEND_TRACK_ARENA_ALLOC'
-            LDFLAGS='-fsanitize=undefined,address'
+            --enable-debug --enable-zts  --enable-sanitizer=address
+            CFLAGS='-fno-sanitize-recover'
     - template: azure/coverage_job.yml
       parameters:
         configurationName: COVERAGE_DEBUG_ZTS

--- a/configure.ac
+++ b/configure.ac
@@ -982,6 +982,11 @@ PHP_ARG_ENABLE([memory-sanitizer],,
     [Enable memory sanitizer (clang only)])],
   [no],
   [no])
+PHP_ARG_ENABLE([sanitizer],,
+  [AS_HELP_STRING([--enable-sanitizer],
+    [Enable sanitizers, like --enable-sanitizer=address,undefined for ASan and UBSan, Asan and UBSan is enabled in default."])],
+  [no],
+  [no])
 
 dnl Extension configuration.
 dnl ----------------------------------------------------------------------------
@@ -1374,8 +1379,38 @@ fi
 
 dnl Enable -fsanitize=memory late, because interceptors may break linking detection.
 if test "$PHP_MEMORY_SANITIZER" = "yes"; then
-  CFLAGS="$CFLAGS -fsanitize=memory -fsanitize-memory-track-origins"
-  CXXFLAGS="$CXXFLAGS -fsanitize=memory -fsanitize-memory-track-origins"
+  AX_CHECK_COMPILE_FLAG([-fsanitize=memory -fsanitize-memory-track-origins], [
+    CFLAGS="$CFLAGS -fsanitize=memory -fsanitize-memory-track-origins"
+    CXXFLAGS="$CXXFLAGS -fsanitize=memory -fsanitize-memory-track-origins"
+  ], [AC_MSG_ERROR([MemorySanitizer is not available])])
+fi
+
+dnl --enable-sanitizer=[[yes,]a,b,c,...]
+if test "$PHP_SANITIZER" != "no"; then
+  sanitizers="$PHP_SANITIZER"
+  if test "$PHP_SANITIZER" = "yes"; then
+    dnl same as windows' default
+    sanitizers="address,undefined"
+  fi
+  sanitizer_cflags="-fsanitize="
+  _IFS=$IFS
+  IFS=','
+  for sanitizer in "$sanitizers"; do
+    if test x"$sanitizer" = x"yes" || test x"$sanitizer" = x"" ; then
+      continue
+    fi
+    if test x"$sanitizer" = x"memory" || test x"$memory-track-origins" = x"" ; then
+      if test "$PHP_MEMORY_SANITIZER" = "yes"; then
+        continue
+      fi
+    fi
+    sanitizer_cflags=",${sanitizer}"
+  done
+  IFS=$_IFS
+  AX_CHECK_COMPILE_FLAG([-fsanitize=${sanitizer}], [
+    CFLAGS="$CFLAGS -fsanitize=${sanitizer}"
+    CXXFLAGS="$CXXFLAGS -fsanitize=${sanitizer}"
+  ], [AC_MSG_ERROR([Sanitizer "${sanitizer}" is not available])])
 fi
 
 dnl

--- a/win32/build/config.w32
+++ b/win32/build/config.w32
@@ -62,6 +62,8 @@ DEFINE("BASE_INCLUDES", "/I . /I main /I Zend /I TSRM /I ext ");
 
 toolset_setup_common_cflags();
 
+toolset_setup_sanitizer_cflags();
+
 if (VS_TOOLSET) {
 	ARG_WITH('mp', 'Tell Visual Studio use up to [n,auto,disable] processes for compilation', 'auto');
 	var PHP_MP_DISABLED = true;


### PR DESCRIPTION
As described in #6825

Tested at Linux with {bash,dash,zsh,mksh}, {clang,gcc}

Tested at macOS with {bash,zsh}, clang

Tested at Windows 10 20H2 with VS 2019 16.9 release with php-sdk-binary-tools in master branch

Maybe need more tests?