### PR TITLE
Fix #80259: Bad handling of RFC 2047 in case of folding white space

### DIFF
--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -1764,10 +1764,7 @@ static php_iconv_err_t _php_iconv_mime_decode(smart_str *pretval, const char *st
 					str_left = 1; /* quit_loop */
 					break;
 				}
-				if (encoded_word == NULL) {
-					_php_iconv_appendc(pretval, ' ', cd_pl);
-				}
-				spaces = NULL;
+				spaces = p1;
 				scan_stat = 11;
 				break;
 

--- a/ext/iconv/tests/bug80259.phpt
+++ b/ext/iconv/tests/bug80259.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #80259 (Bad handling of RFC 2047 in case of folding white space)
+--SKIPIF--
+<?php
+if (!extension_loaded("iconv")) die("skip iconv extension not available");
+?>
+--FILE--
+<?php
+var_dump(iconv_mime_decode("=?UTF-8?Q?foo?= bar"));
+var_dump(iconv_mime_decode("=?UTF-8?Q?foo?= =?UTF-8?Q?bar?="));
+?>
+--EXPECT--
+string(7) "foo bar"
+string(6) "foobar"


### PR DESCRIPTION
While it is correct to strip all whitespace (and even FWS) between two
encoded words[1], it is not correct to strip whitespace between an
encoded-word and text.  Fixing this is trivial; we just have to delay
outputting the space, and can then strip as appropriate.

However, that breaks two tests in the suite, because the current
implementation collapses multiple whitespace after CRLF into a single
space.  This violates RFC 5322 which states[2]:

| Unfolding is accomplished by simply removing any CRLF
| that is immediately followed by WSP.

Changing this may break some code, though, and it's especially doubtful
to do it because `mb_decode_mimeheader()` exhibits the same behavior.

Thus, I'm dropping this PR for further discussion.

[1] <https://tools.ietf.org/html/rfc2047#section-8>
[2] <https://tools.ietf.org/html/rfc5322#section-2.2.3>