### PR TITLE
Implement debug_print_backtrace() on top of zend_fetch_backtrace()

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -342,8 +342,6 @@ static void print_hash(smart_str *buf, HashTable *ht, int indent, bool is_object
 }
 /* }}} */
 
-static void zend_print_flat_zval_r_to_buf(smart_str *buf, zval *expr);
-
 static void print_flat_hash(smart_str *buf, HashTable *ht) /* {{{ */
 {
 	zval *tmp;
@@ -393,7 +391,7 @@ ZEND_API size_t zend_print_zval(zval *expr, int indent) /* {{{ */
 }
 /* }}} */
 
-static void zend_print_flat_zval_r_to_buf(smart_str *buf, zval *expr) /* {{{ */
+void zend_print_flat_zval_r_to_buf(smart_str *buf, zval *expr) /* {{{ */
 {
 	switch (Z_TYPE_P(expr)) {
 		case IS_ARRAY:

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -279,6 +279,7 @@ ZEND_API size_t zend_print_zval(zval *expr, int indent);
 ZEND_API void zend_print_zval_r(zval *expr, int indent);
 ZEND_API zend_string *zend_print_zval_r_to_str(zval *expr, int indent);
 ZEND_API void zend_print_flat_zval_r(zval *expr);
+ZEND_API void zend_print_flat_zval_r_to_buf(smart_str *str, zval *expr);
 
 #define zend_print_variable(var) \
 	zend_print_zval((var), 0)


### PR DESCRIPTION
As debug_print_backtrace() is not performance-critical, this implements it by formatting the zend_fetch_backtrace() result. This means there is only one place implementing the backtrace construction logic, and they cannot go out of sync. zend_fetch_backtrace() has much better test coverage, because it is used by exceptions.