### PR TITLE
Fixed bug #80958

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4637,9 +4637,13 @@ static zend_string *try_setlocale_str(zend_long cat, zend_string *loc) {
 }
 
 static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv) {
-	zend_string *loc_str = zval_try_get_string(loc_zv);
-	zend_string *result = try_setlocale_str(cat, loc_str);
-	zend_string_release_ex(loc_str, 0);
+	zend_string *loc_str, *tmp_loc_str, *result;
+	loc_str = zval_try_get_tmp_string(loc_zv, &tmp_loc_str);
+	if (UNEXPECTED(loc_str == NULL)) {
+		return NULL;
+	}
+	result = try_setlocale_str(cat, loc_str);
+	zend_tmp_string_release(tmp_loc_str);
 	return result;
 }
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4637,12 +4637,12 @@ static zend_string *try_setlocale_str(zend_long cat, zend_string *loc) {
 }
 
 static zend_string *try_setlocale_zval(zend_long cat, zval *loc_zv) {
-	zend_string *loc_str, *tmp_loc_str, *result;
-	loc_str = zval_try_get_tmp_string(loc_zv, &tmp_loc_str);
+	zend_string *tmp_loc_str;
+	zend_string *loc_str = zval_try_get_tmp_string(loc_zv, &tmp_loc_str);
 	if (UNEXPECTED(loc_str == NULL)) {
 		return NULL;
 	}
-	result = try_setlocale_str(cat, loc_str);
+	zend_string *result = try_setlocale_str(cat, loc_str);
 	zend_tmp_string_release(tmp_loc_str);
 	return result;
 }


### PR DESCRIPTION
Missing check after zval_try_get_string().

I have checked all references to `zval_try_get*_string()` but I didn’t find any more problems.