### PR TITLE
Fix #80931: HTTP stream hangs if server doesn't close connection

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -144,10 +144,12 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 	int header_init = ((flags & HTTP_WRAPPER_HEADER_INIT) != 0);
 	int redirected = ((flags & HTTP_WRAPPER_REDIRECTED) != 0);
 	zend_bool follow_location = 1;
-	php_stream_filter *transfer_encoding = NULL;
+	php_stream_filter *body_filter = NULL;
 	int response_code;
 	smart_str req_buf = {0};
 	zend_bool custom_request_method;
+	zend_bool server_closes_connection = 0;
+	zend_bool chunked_encoding = 0;
 
 	tmp_line[0] = '\0';
 
@@ -664,6 +666,9 @@ finish:
 			php_stream_get_line(stream, tmp_line, sizeof(tmp_line) - 1, &tmp_line_len) != NULL) {
 			zval http_response;
 
+			if (strncasecmp(tmp_line, "HTTP/1.1", sizeof("HTTP/1.1")-1) < 0) {
+				server_closes_connection = 1;
+			}
 			if (tmp_line_len > 9) {
 				response_code = atoi(tmp_line + 9);
 			} else {
@@ -793,6 +798,10 @@ finish:
 			} else if (!strncasecmp(http_header_line, "Content-Length:", sizeof("Content-Length:")-1)) {
 				file_size = atoi(http_header_value);
 				php_stream_notify_file_size(context, file_size, http_header_line, 0);
+			} else if (!strncasecmp(http_header_line, "Connection:", sizeof("Connection:")-1)
+				&& !strncasecmp(http_header_value, "Close", sizeof("Close")-1)
+			) {
+				server_closes_connection = 1;
 			} else if (
 				!strncasecmp(http_header_line, "Transfer-Encoding:", sizeof("Transfer-Encoding:")-1)
 				&& !strncasecmp(http_header_value, "Chunked", sizeof("Chunked")-1)
@@ -806,11 +815,13 @@ finish:
 						decode = zend_is_true(tmpzval);
 					}
 					if (decode) {
-						transfer_encoding = php_stream_filter_create("dechunk", NULL, php_stream_is_persistent(stream));
-						if (transfer_encoding) {
+						body_filter = php_stream_filter_create("dechunk", NULL, php_stream_is_persistent(stream));
+						if (body_filter) {
 							/* don't store transfer-encodeing header */
 							continue;
 						}
+					} else {
+						chunked_encoding = 1;
 					}
 				}
 			}
@@ -949,12 +960,22 @@ out:
 		/* restore mode */
 		strlcpy(stream->mode, mode, sizeof(stream->mode));
 
-		if (transfer_encoding) {
-			php_stream_filter_append(&stream->readfilters, transfer_encoding);
+		if (body_filter == NULL && !server_closes_connection) {
+			zval param;
+			if (chunked_encoding) {
+				ZVAL_FALSE(&param);
+				body_filter = php_stream_filter_create("dechunk", &param, php_stream_is_persistent(stream));
+			} else {
+				ZVAL_LONG(&param, file_size);
+				body_filter = php_stream_filter_create("consumed", &param, php_stream_is_persistent(stream));
+			}
+		}
+		if (body_filter) {
+			php_stream_filter_append(&stream->readfilters, body_filter);
 		}
 	} else {
-		if (transfer_encoding) {
-			php_stream_filter_free(transfer_encoding);
+		if (body_filter) {
+			php_stream_filter_free(body_filter);
 		}
 	}
 

--- a/ext/standard/tests/http/bug80931.phpt
+++ b/ext/standard/tests/http/bug80931.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Bug #80931 (HTTP stream hangs if server doesn't close connection)
+--INI--
+allow_url_fopen=1
+--SKIPIF--
+<?php require 'server.inc'; http_server_skipif('tcp://127.0.0.1:12342'); ?>
+--FILE--
+<?php
+require_once 'server.inc';
+
+$responses = array(
+    "data://text/plain,HTTP/1.1 200\r\nContent-Length: 10\r\n\r\n0123456789",
+    "data://text/plain,HTTP/1.1 200\r\nTransfer-Encoding: chunked\r\n\r\n4\r\n****\r\n0\r\n\r\n",
+    "data://text/plain,HTTP/1.1 200\r\nTransfer-Encoding: chunked\r\n\r\n4\r\n****\r\n0\r\n\r\n",
+);
+$pid = http_server("tcp://127.0.0.1:12342", $responses, $output);
+
+$options = [
+    'http'=> [
+        'protocol_version' => "1.1",
+        'header' => "Connection: keep-alive",
+    ]
+];
+
+$stream = fopen("http://127.0.0.1:12342/", "r", false, stream_context_create($options));
+$t0 = microtime(true);
+var_dump(stream_get_contents($stream));
+$t1 = microtime(true);
+var_dump($t1 - $t0 < 2);
+
+$stream = fopen("http://127.0.0.1:12342/", "r", false, stream_context_create($options));
+$t0 = microtime(true);
+var_dump(stream_get_contents($stream));
+$t1 = microtime(true);
+var_dump($t1 - $t0 < 2);
+
+$options['http']['auto_decode'] = false;
+$stream = fopen("http://127.0.0.1:12342/", "r", false, stream_context_create($options));
+$t0 = microtime(true);
+var_dump(stream_get_contents($stream));
+$t1 = microtime(true);
+var_dump($t1 - $t0 < 2);
+
+http_server_kill($pid);
+?>
+--EXPECT--
+string(10) "0123456789"
+bool(true)
+string(4) "****"
+bool(true)
+string(14) "4
+****
+0
+
+"
+bool(true)

--- a/ext/standard/tests/http/server.inc
+++ b/ext/standard/tests/http/server.inc
@@ -54,6 +54,7 @@ function http_server($socket_string, array $files, &$output = null) {
 		// read headers
 
 		$content_length = 0;
+		$keep_alive = false;
 
 		stream_set_blocking($sock, 0);
 		while (!feof($sock)) {
@@ -70,6 +71,8 @@ function http_server($socket_string, array $files, &$output = null) {
 
 				if (preg_match('#^Content-Length\s*:\s*([[:digit:]]+)\s*$#i', $line, $matches)) {
 					$content_length = (int) $matches[1];
+				} elseif (preg_match('#^Connection\s*:\s*keep-alive\s*$#i', $line, $matches)) {
+					$keep_alive = true;
 				}
 			}
 		}
@@ -85,6 +88,10 @@ function http_server($socket_string, array $files, &$output = null) {
 
 		$fd = fopen($file, 'rb');
 		stream_copy_to_stream($fd, $sock);
+
+		if ($keep_alive) {
+			sleep(2);
+		}
 
 		fclose($sock);
 	}


### PR DESCRIPTION
As is, we read HTTP streams until the server closes the connection,
what is standard behavior prior to HTTP/1.1 anyway.  However, HTTP/1.1
defaults to not closing the connection, and although we are sending a
`Connection: close` header, there is no guarantee that the server heeds
it.  Even worse, if a user passes a `Connection: keep-alive` header via
the stream context, the server is not supposed to close the connection,
so the request hangs (and will only terminated by a timeout).

The proper way to read HTTP responses is to the heed the sent Content-
Length, or in case of `Transfer-encoding: chunked`, to read until after
the final chunk (zero bytes).  To avoid baking this into the general
streams behavior, we use stream filters for this purpose (as suggested
by @IMSoP), and if the end of the stream is detected by those, we set
the `eof` flag.  Since there are already the quite suitable filters for
our purpose (`dechunk` and `consumed`) we attach the desired behavior
to these.

We avoid the filter overhead in cases where the server is going to
close the connection anyway, i.e. prior to HTTP/1.1, or if the server
responds with `Connection: close`.

Currently, the end of content check is enabled for the existing
filters by passing filter parameters.  I kept that simple for now, by
just passing a bool or a long, but that might be to big a BC break;
neither the `dechunk` nor the `consumed` filter are documented, but
easily recognizable via `stream_get_filters()`, so existing code may
already pass parameters, although these are so far unused.  That could
be mitigated by passing an array with respective members instead.
Another option to avoid the BC altogether would be to add the required
info to the stream name (similar to the `convert.iconv.*` filter).

For best BC, it might also be desireable to only set the `eof` flag
from the `dechunk` filter, if `dechunk` is explicitly requested.

---

Any suggestions for improvement are welcome, especially regarding the hackish regression test.