### PR TITLE
Accept null for microseconds argument in stream_select()

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1209,7 +1209,7 @@ function soundex(string $string): string {}
 
 /* streamsfuncs.c */
 
-function stream_select(?array &$read, ?array &$write, ?array &$except, ?int $seconds, int $microseconds = 0): int|false {}
+function stream_select(?array &$read, ?array &$write, ?array &$except, ?int $seconds, ?int $microseconds = null): int|false {}
 
 /** @return resource */
 function stream_context_create(?array $options = null, ?array $params = null) {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2d92e992837a61a052eea6d0257837aaccc54be6 */
+ * Stub hash: 55f11c2d6cc7ba342b1062104f3838866ad9135d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1847,7 +1847,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_stream_select, 0, 4, MAY_BE_LONG
 	ZEND_ARG_TYPE_INFO(1, write, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO(1, except, IS_ARRAY, 1)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 1)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microseconds, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, microseconds, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_stream_context_create, 0, 0, 0)

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -793,7 +793,7 @@ PHP_FUNCTION(stream_select)
 		if (usec == 0) {
 			php_error_docref(NULL, E_DEPRECATED, "Argument #5 ($microseconds) should be null instead of 0 when argument #4 ($seconds) is null");
 		} else {
-			zend_argument_value_error(4, "cannot be null when argument #5 ($microseconds) is specified and non-null");
+			zend_argument_value_error(5, "must be null when argument #4 ($seconds) is null");
 			RETURN_THROWS();
 		}
 	}

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -745,6 +745,7 @@ PHP_FUNCTION(stream_select)
 	int retval, sets = 0;
 	zend_long sec, usec = 0;
 	bool secnull;
+	bool usecnull = 1;
 	int set_count, max_set_count = 0;
 
 	ZEND_PARSE_PARAMETERS_START(4, 5)
@@ -753,7 +754,7 @@ PHP_FUNCTION(stream_select)
 		Z_PARAM_ARRAY_EX2(e_array, 1, 1, 0)
 		Z_PARAM_LONG_OR_NULL(sec, secnull)
 		Z_PARAM_OPTIONAL
-		Z_PARAM_LONG(usec)
+		Z_PARAM_LONG_OR_NULL(usec, usecnull)
 	ZEND_PARSE_PARAMETERS_END();
 
 	FD_ZERO(&rfds);
@@ -787,6 +788,11 @@ PHP_FUNCTION(stream_select)
 	}
 
 	PHP_SAFE_MAX_FD(max_fd, max_set_count);
+
+	if (secnull && !usecnull) {
+		zend_argument_value_error(4, "must not be null if argument #5 ($microseconds) is specified and non-null");
+		RETURN_THROWS();
+	}
 
 	/* If seconds is not set to null, build the timeval, else we wait indefinitely */
 	if (!secnull) {

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -790,8 +790,12 @@ PHP_FUNCTION(stream_select)
 	PHP_SAFE_MAX_FD(max_fd, max_set_count);
 
 	if (secnull && !usecnull) {
-		zend_argument_value_error(4, "must not be null if argument #5 ($microseconds) is specified and non-null");
-		RETURN_THROWS();
+		if (usec == 0) {
+			php_error_docref(NULL, E_DEPRECATED, "Argument #5 ($microseconds) should be null instead of 0 when argument #4 ($seconds) is null");
+		} else {
+			zend_argument_value_error(4, "cannot be null when argument #5 ($microseconds) is specified and non-null");
+			RETURN_THROWS();
+		}
 	}
 
 	/* If seconds is not set to null, build the timeval, else we wait indefinitely */

--- a/ext/standard/tests/general_functions/proc_open_sockets1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets1.phpt
@@ -25,7 +25,7 @@ while ($pipes) {
     $w = null;
     $e = null;
 
-    if (!stream_select($r, $w, $e, null, 0)) {
+    if (!stream_select($r, $w, $e, null)) {
         throw new Error("Select failed");
     }
 

--- a/ext/standard/tests/general_functions/proc_open_sockets2.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets2.phpt
@@ -9,7 +9,7 @@ function poll($pipe, $read = true)
     $w = ($read == false) ? [$pipe] : null;
     $e = null;
 
-    if (!stream_select($r, $w, $e, null, 0)) {
+    if (!stream_select($r, $w, $e, null)) {
         throw new \Error("Select failed");
     }
 }

--- a/ext/standard/tests/general_functions/proc_open_sockets3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets3.phpt
@@ -9,7 +9,7 @@ function poll($pipe, $read = true)
     $w = ($read == false) ? [$pipe] : null;
     $e = null;
 
-    if (!stream_select($r, $w, $e, null, 0)) {
+    if (!stream_select($r, $w, $e, null)) {
         throw new \Error("Select failed");
     }
 }

--- a/ext/standard/tests/streams/stream_select_null_usec.phpt
+++ b/ext/standard/tests/streams/stream_select_null_usec.phpt
@@ -9,13 +9,17 @@ $except = null;
 
 error_reporting(-1);
 set_error_handler(function ($errno, $errstr) {
-    throw new \Exception($errstr);
+    print $errno . " " . $errstr . "\n";
 });
 
 stream_select($read, $write, $except, null, null);
 var_dump($read);
 
+print "\n";
+
 stream_select($read, $write, $except, null, 0);
+
+stream_select($read, $write, $except, null, 1);
 ?>
 --EXPECTF--
 array(1) {
@@ -23,8 +27,10 @@ array(1) {
   resource(%d) of type (stream)
 }
 
-Fatal error: Uncaught ValueError: stream_select(): Argument #4 ($seconds) must not be null if argument #5 ($microseconds) is specified and non-null in %s
+8192 stream_select(): Argument #5 ($microseconds) should be null instead of 0 when argument #4 ($seconds) is null
+
+Fatal error: Uncaught ValueError: stream_select(): Argument #4 ($seconds) cannot be null when argument #5 ($microseconds) is specified and non-null in %s
 Stack trace:
-#0 %s stream_select(Array, NULL, NULL, NULL, 0)
+#0 %s stream_select(Array, NULL, NULL, NULL, 1)
 #1 {main}
 %s

--- a/ext/standard/tests/streams/stream_select_null_usec.phpt
+++ b/ext/standard/tests/streams/stream_select_null_usec.phpt
@@ -1,0 +1,30 @@
+--TEST--
+stream_select allows null for microsecond timeout if timeout is null
+--FILE--
+<?php
+
+$read = [fopen(__FILE__, 'r')];
+$write = null;
+$except = null;
+
+error_reporting(-1);
+set_error_handler(function ($errno, $errstr) {
+    throw new \Exception($errstr);
+});
+
+stream_select($read, $write, $except, null, null);
+var_dump($read);
+
+stream_select($read, $write, $except, null, 0);
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  resource(%d) of type (stream)
+}
+
+Fatal error: Uncaught ValueError: stream_select(): Argument #4 ($seconds) must not be null if argument #5 ($microseconds) is specified and non-null in %s
+Stack trace:
+#0 %s stream_select(Array, NULL, NULL, NULL, 0)
+#1 {main}
+%s

--- a/ext/standard/tests/streams/stream_select_null_usec.phpt
+++ b/ext/standard/tests/streams/stream_select_null_usec.phpt
@@ -29,7 +29,7 @@ array(1) {
 
 8192 stream_select(): Argument #5 ($microseconds) should be null instead of 0 when argument #4 ($seconds) is null
 
-Fatal error: Uncaught ValueError: stream_select(): Argument #4 ($seconds) cannot be null when argument #5 ($microseconds) is specified and non-null in %s
+Fatal error: Uncaught ValueError: stream_select(): Argument #5 ($microseconds) must be null when argument #4 ($seconds) is null in %s
 Stack trace:
 #0 %s stream_select(Array, NULL, NULL, NULL, 1)
 #1 {main}


### PR DESCRIPTION
The deprecation of passing null is thrown otherwise.

If the timeout is calculated conditionally before calling stream_select(), passing 0 to avoid the deprecation seems unreasonable, example:

https://github.com/amphp/amp/blob/7d4bbc6e0b47c6bb39b6cce1a4b5942e0c5125fb/lib/Loop/NativeDriver.php#L286