### PR TITLE
Export gzfwrite()

### DIFF
--- a/ext/zlib/php_zlib.def
+++ b/ext/zlib/php_zlib.def
@@ -34,6 +34,7 @@ EXPORTS
     gzsetparams
     gzread
     gzwrite
+    gzfwrite
     gzprintf
     gzputs
     gzgets


### PR DESCRIPTION
Xdebug recently introduced the possibility to compress profile
information and this uses `gzfwrite()`, what is not yet exported on
Windows.  That would require run-time linking to be worked around.

---

Alternatively, we could fully update to https://github.com/winlibs/zlib/blob/master/win32/zlib.def.

As 7.4 RM and Xdebug maintainer, @derickr might be interested in this.