### PR TITLE
Fix php_pgsql_fd_cast() wrt. php_stream_can_cast()

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -5419,15 +5419,15 @@ static int php_pgsql_fd_cast(php_stream *stream, int cast_as, void **ret) /* {{{
 		case PHP_STREAM_AS_FD_FOR_SELECT:
 		case PHP_STREAM_AS_FD:
 		case PHP_STREAM_AS_SOCKETD:
-			if (ret) {
-				int fd_number = PQsocket(pgsql);
-				if (fd_number == -1) {
-					return FAILURE;
-				}
-
-				*(php_socket_t *)ret = fd_number;
-				return SUCCESS;
+			int fd_number = PQsocket(pgsql);
+			if (fd_number == -1) {
+				return FAILURE;
 			}
+
+			if (ret) {
+				*(php_socket_t *)ret = fd_number;
+			}
+			return SUCCESS;
 		default:
 			return FAILURE;
 	}

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -5418,14 +5418,15 @@ static int php_pgsql_fd_cast(php_stream *stream, int cast_as, void **ret) /* {{{
 	switch (cast_as)	{
 		case PHP_STREAM_AS_FD_FOR_SELECT:
 		case PHP_STREAM_AS_FD:
-		case PHP_STREAM_AS_SOCKETD:
-			int fd_number = PQsocket(pgsql);
-			if (fd_number == -1) {
-				return FAILURE;
-			}
+		case PHP_STREAM_AS_SOCKETD: {
+				int fd_number = PQsocket(pgsql);
+				if (fd_number == -1) {
+					return FAILURE;
+				}
 
-			if (ret) {
-				*(php_socket_t *)ret = fd_number;
+				if (ret) {
+					*(php_socket_t *)ret = fd_number;
+				}
 			}
 			return SUCCESS;
 		default:


### PR DESCRIPTION
`php_stream_can_cast()` forwards to `_php_stream_cast()` with `ret` set
to `NULL`.  `php_pgsql_fd_cast()` needs to cater to that, because
otherwise the stream would report that it is not castable.

This *might* fix https://bugs.php.net/73903.

---

It seems not possible to write a meaningful regression test for this behavior, since the core and bundled extensions only use `php_stream_can_cast()` when checking for a TTY. It would, of course, be possible to use ext/zend_test, but that might be overkill.