### PR TITLE
force generated config.w32.h with encoding unicode

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2266,7 +2266,7 @@ function generate_config_h()
 	indata = infile.ReadAll();
 	infile.Close();
 
-	outfile = FSO.CreateTextFile("main/config.w32.h", true);
+	outfile = FSO.CreateTextFile("main/config.w32.h", true, true);
 
 	indata = indata.replace(new RegExp("@PREFIX@", "g"), prefix);
 	outfile.Write(indata);


### PR DESCRIPTION
by default, the encoding of generated file main/config.w32.h associated with the system, which product too many warning C4828 encoding problem.