### PR TITLE
Fix #80974: Wrong diff between 2 dates in different timezones

### DIFF
--- a/ext/date/lib/interval.c
+++ b/ext/date/lib/interval.c
@@ -127,6 +127,12 @@ timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two)
 				rt->d--;
 				rt->h = 24;
 			}
+		} else {
+			/* Then for all the others */
+			rt->h -= dst_h_corr + (two->dst - one->dst);
+			rt->i -= dst_m_corr;
+
+			timelib_do_rel_normalize(rt->invert ? one : two, rt);
 		}
 	} else {
 		/* Then for all the others */

--- a/ext/date/lib/interval.c
+++ b/ext/date/lib/interval.c
@@ -32,6 +32,7 @@ timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two)
 	timelib_time *swp;
 	timelib_sll dst_corr = 0, dst_h_corr = 0, dst_m_corr = 0;
 	timelib_time_offset *trans = NULL;
+	bool normalize = 0;
 
 
 	rt = timelib_rel_time_ctor();
@@ -128,13 +129,13 @@ timelib_rel_time *timelib_diff(timelib_time *one, timelib_time *two)
 				rt->h = 24;
 			}
 		} else {
-			/* Then for all the others */
-			rt->h -= dst_h_corr + (two->dst - one->dst);
-			rt->i -= dst_m_corr;
-
-			timelib_do_rel_normalize(rt->invert ? one : two, rt);
+			normalize = 1;
 		}
 	} else {
+		normalize = 1;
+	}
+
+	if (normalize) {
 		/* Then for all the others */
 		rt->h -= dst_h_corr + (two->dst - one->dst);
 		rt->i -= dst_m_corr;

--- a/ext/date/tests/bug80974.phpt
+++ b/ext/date/tests/bug80974.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #80974 (Wrong diff between 2 dates in different timezones)
+--FILE--
+<?php
+date_default_timezone_set('UTC');
+echo date_diff(
+    new DateTime('2012-01-01 00:00 America/Toronto'),
+    new DateTime('2012-01-01 00:00 America/Vancouver'),
+)->format('%h'), "\n";
+?>
+--EXPECT--
+3


### PR DESCRIPTION
Here is first the test case to show the failure. Note that this passed with PHP < 8.1

See: https://bugs.php.net/bug.php?id=80974