### PR TITLE
Fix #73246: XMLReader: encoding length not checked

### DIFF
--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -873,6 +873,11 @@ PHP_METHOD(xmlreader, open)
 		RETURN_FALSE;
 	}
 
+	if (encoding && CHECK_NULL_PATH(encoding, encoding_len)) {
+		php_error_docref(NULL, E_WARNING, "Encoding must not contain NUL bytes");
+		RETURN_FALSE;
+	}
+
 	valid_file = _xmlreader_get_valid_file_path(source, resolved_path, MAXPATHLEN );
 
 	if (valid_file) {
@@ -1052,6 +1057,11 @@ PHP_METHOD(xmlreader, XML)
 
 	if (!source_len) {
 		php_error_docref(NULL, E_WARNING, "Empty string supplied as input");
+		RETURN_FALSE;
+	}
+
+	if (encoding && CHECK_NULL_PATH(encoding, encoding_len)) {
+		php_error_docref(NULL, E_WARNING, "Encoding must not contain NUL bytes");
 		RETURN_FALSE;
 	}
 

--- a/ext/xmlreader/tests/bug73246.phpt
+++ b/ext/xmlreader/tests/bug73246.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #73246 (XMLReader: encoding length not checked)
+--SKIPIF--
+<?php
+if (!extension_loaded("xmlreader")) die("skip xmlreader extension not available");
+?>
+--FILE--
+<?php
+$reader = new XMLReader();
+$reader->open(__FILE__, "UTF\0-8");
+$reader->XML('<?xml version="1.0"?><root/>', "UTF\0-8");
+?>
+--EXPECTF--
+Warning: XMLReader::open(): Encoding must not contain NUL bytes in %s on line %d
+
+Warning: XMLReader::XML(): Encoding must not contain NUL bytes in %s on line %d


### PR DESCRIPTION
libxml2 expects the passed encoding to be NUL terminated, so we reject
strings with NUL bytes right away.