### PR TITLE
Fix Bug #80972: Memory exhaustion on invalid string offset (PHP7)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ PHP                                                                        NEWS
     (cmb)
   . Fixed bug #67792 (HTTP Authorization schemes are treated as case-sensitive).
     (cmb)
+  . Fixed bug Bug #80972 (Memory exhaustion on invalid string offset). (girgias)
 
 - pgsql:
   . Fixed php_pgsql_fd_cast() wrt. php_stream_can_cast(). (cmb)
@@ -210,7 +211,7 @@ PHP                                                                        NEWS
     PROCEDURE resultset SIGNAL). (Nikita)
 
 - Standard:
-  . Fixed bug #77423 (FILTER_VALIDATE_URL accepts URLs with invalid userinfo). 
+  . Fixed bug #77423 (FILTER_VALIDATE_URL accepts URLs with invalid userinfo).
     (CVE-2020-7071) (cmb)
   . Fixed bug #80366 (Return Value of zend_fstat() not Checked). (sagpant, cmb)
   . Fixed bug #80411 (References to null-serialized object break serialize()).
@@ -349,7 +350,7 @@ PHP                                                                        NEWS
   . Fixed bug #80048 (Bug #69100 has not been fixed for Windows). (cmb)
   . Fixed bug #80049 (Memleak when coercing integers to string via variadic
     argument). (Nikita)
-  . Fixed bug #79699 (PHP parses encoded cookie names so malicious `__Host-` 
+  . Fixed bug #79699 (PHP parses encoded cookie names so malicious `__Host-`
     cookies can be sent). (CVE-2020-7070) (Stas)
 
 - Calendar:
@@ -368,7 +369,7 @@ PHP                                                                        NEWS
     handlers changed). (SammyK)
 
 - OpenSSL:
-  . Fixed bug #79601 (Wrong ciphertext/tag in AES-CCM encryption for a 12 
+  . Fixed bug #79601 (Wrong ciphertext/tag in AES-CCM encryption for a 12
     bytes IV). (CVE-2020-7069) (Jakub Zelenka)
 
 - PDO:
@@ -450,7 +451,7 @@ PHP                                                                        NEWS
     (cmb)
 
 - Core:
-  . Fixed bug #79877 (getimagesize function silently truncates after a null 
+  . Fixed bug #79877 (getimagesize function silently truncates after a null
     byte) (cmb)
   . Fixed bug #79740 (serialize() and unserialize() methods can not be called
     statically). (Nikita)
@@ -511,7 +512,7 @@ PHP                                                                        NEWS
   . Fixed possibly unsupported timercmp() usage. (cmb)
 
 - Exif:
-  . Fixed bug #79687 (Sony picture - PHP Warning - Make, Model, MakerNotes). 
+  . Fixed bug #79687 (Sony picture - PHP Warning - Make, Model, MakerNotes).
     (cmb)
 
 - Fileinfo:
@@ -727,7 +728,7 @@ PHP                                                                        NEWS
   . Fixed bug #79014 (PHP-FPM & Primary script unknown). (Jakub Zelenka)
 
 - MBstring:
-  . Fixed bug #79371 (mb_strtolower (UTF-32LE): stack-buffer-overflow at 
+  . Fixed bug #79371 (mb_strtolower (UTF-32LE): stack-buffer-overflow at
     php_unicode_tolower_full). (CVE-2020-7065) (cmb)
 
 - MySQLi:

--- a/Zend/tests/bug80972.phpt
+++ b/Zend/tests/bug80972.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Bug #80972: Memory exhaustion on invalid string offset
+--FILE--
+<?php
+
+function exceptions_error_handler($severity, $message, $filename, $lineno) {
+    if (error_reporting() & $severity) {
+        throw new ErrorException($message, 0, $severity, $filename, $lineno);
+    }
+}
+set_error_handler('exceptions_error_handler');
+
+$float = 10e120;
+$string_float = (string) $float;
+
+$string = 'Here is some text for good measure';
+
+try {
+    echo 'Float casted to string compile', \PHP_EOL;
+    $string[(string) 10e120] = 'E';
+    var_dump($string);
+} catch (\Throwable $e) {
+    echo $e->getMessage(), \PHP_EOL;
+}
+
+/* This same bug also permits to modify the first byte of a string even if
+ * the offset is invalid */
+try {
+    /* This must not affect the string value */
+    $string["wrong"] = "f";
+} catch (\Throwable $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+var_dump($string);
+
+?>
+--EXPECT--
+Float casted to string compile
+Illegal string offset '1.0E+121'
+Illegal string offset 'wrong'
+string(34) "Here is some text for good measure"

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1550,6 +1550,12 @@ static zend_never_inline void zend_assign_to_string_offset(zval *str, zval *dim,
 	zend_long offset;
 
 	offset = zend_check_string_offset(dim, BP_VAR_W EXECUTE_DATA_CC);
+	if (UNEXPECTED(EG(exception) != NULL)) {
+		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			ZVAL_UNDEF(EX_VAR(opline->result.var));
+		}
+		return;
+	}
 	if (offset < -(zend_long)Z_STRLEN_P(str)) {
 		/* Error on negative offset */
 		zend_error(E_WARNING, "Illegal string offset:  " ZEND_LONG_FMT, offset);


### PR DESCRIPTION
Equivalent of #6890 but for PHP 7 (due to merge conflicts)