### PR TITLE
run-tests: revert "EXTENSIONS" section bug introduced in #2673

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2051,7 +2051,7 @@ TEST $file
         settings2array($ini_overwrites, $ext_params);
         $ext_params = settings2params($ext_params);
         $extensions = preg_split("/[\n\r]+/", trim($test->getSection('EXTENSIONS')));
-        [$ext_dir, $loaded] = $skipCache->getExtensions("$php $pass_options $extra_options $ext_params $no_file_cache");
+        [$ext_dir, $loaded] = $skipCache->getExtensions("$php", "$pass_options $extra_options $ext_params $no_file_cache");
         $ext_prefix = IS_WINDOWS ? "php_" : "";
         $missing = [];
         foreach ($extensions as $req_ext) {
@@ -3664,22 +3664,22 @@ class SkipCache
         return $result;
     }
 
-    public function getExtensions(string $php): array
+    public function getExtensions(string $php, string $extensionsOptions): array
     {
-        if (isset($this->extensions[$php])) {
+        if (isset($this->extensions[$php . " " . $extensionsOptions])) {
             $this->extHits++;
-            return $this->extensions[$php];
+            return $this->extensions[$php . " " . $extensionsOptions];
         }
 
         $extDir = `$php -d display_errors=0 -r "echo ini_get('extension_dir');"`;
-        $extensions = explode(",", `$php -d display_errors=0 -r "echo implode(',', get_loaded_extensions());"`);
+        $extensions = explode(",", `$php $extensionsOptions -d display_errors=0 -r "echo implode(',', get_loaded_extensions());"`);
         $extensions = array_map('strtolower', $extensions);
         if (in_array('zend opcache', $extensions)) {
             $extensions[] = 'opcache';
         }
 
         $result = [$extDir, $extensions];
-        $this->extensions[$php] = $result;
+        $this->extensions[$php . " " . $extensionsOptions] = $result;
         $this->extMisses++;
 
         return $result;


### PR DESCRIPTION
documented behaviour of loading extensions from shared modules was
broken some time ago, this patch reintroduces that feature whilst
retaining other changes which allow the skip cache to work

rationale is in https://github.com/php/php-src/pull/2673#issuecomment-826353157

the output of skipcache __destroy is the same before and after this patch, so I am confident it doesn't break anything.