### PR TITLE
run-tests: Fix warning when specifying xdebug as a required extension

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2056,7 +2056,7 @@ TEST $file
         $missing = [];
         foreach ($extensions as $req_ext) {
             if (!in_array(strtolower($req_ext), $loaded)) {
-                if ($req_ext == 'opcache') {
+                if ($req_ext == 'opcache' || $req_ext == 'xdebug') {
                     $ext_file = $ext_dir . DIRECTORY_SEPARATOR . $ext_prefix . $req_ext . '.' . PHP_SHLIB_SUFFIX;
                     $ini_settings['zend_extension'][] = $ext_file;
                 } else {


### PR DESCRIPTION
xdebug should go in the zend_extensions array rather than the extensions array