### PR TITLE
Make date/time type arguments of IntlDateFormatter ctor optional

### DIFF
--- a/ext/intl/dateformat/dateformat.stub.php
+++ b/ext/intl/dateformat/dateformat.stub.php
@@ -8,14 +8,28 @@ class IntlDateFormatter
      * @param IntlTimeZone|DateTimeZone|string|null $timezone
      * @param IntlCalendar|int|null $calendar
      */
-    public function __construct(?string $locale, int $dateType, int $timeType, $timezone = null, $calendar = null, ?string $pattern = null) {}
+    public function __construct(
+        ?string $locale,
+        int $dateType = IntlDateFormatter::FULL,
+        int $timeType = IntlDateFormatter::FULL,
+        $timezone = null,
+        $calendar = null,
+        ?string $pattern = null
+    ) {}
 
     /**
      * @param IntlTimeZone|DateTimeZone|string|null $timezone
      * @return IntlDateFormatter|null
      * @alias datefmt_create
      */
-    public static function create(?string $locale, int $dateType, int $timeType, $timezone = null, IntlCalendar|int|null $calendar = null, ?string $pattern = null) {}
+    public static function create(
+        ?string $locale,
+        int $dateType = IntlDateFormatter::FULL,
+        int $timeType = IntlDateFormatter::FULL,
+        $timezone = null,
+        IntlCalendar|int|null $calendar = null,
+        ?string $pattern = null
+    ) {}
 
     /**
      * @return int|false

--- a/ext/intl/dateformat/dateformat_arginfo.h
+++ b/ext/intl/dateformat/dateformat_arginfo.h
@@ -1,19 +1,19 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a83ee23ab33293a878280f137260da9f8914218a */
+ * Stub hash: 5fd68ae153d18374d33a5c3848a88abc1ab67d38 */
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDateFormatter___construct, 0, 0, 3)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDateFormatter___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, dateType, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, timeType, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 0, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 0, "IntlDateFormatter::FULL")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, calendar, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDateFormatter_create, 0, 0, 3)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDateFormatter_create, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, dateType, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, timeType, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 0, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 0, "IntlDateFormatter::FULL")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
 	ZEND_ARG_OBJ_TYPE_MASK(0, calendar, IntlCalendar, MAY_BE_LONG|MAY_BE_NULL, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")

--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -51,8 +51,8 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 	char	*locale_str;
 	size_t		locale_len	= 0;
 	Locale		locale;
-	zend_long	date_type	= 0;
-	zend_long	time_type	= 0;
+	zend_long	date_type = UDAT_FULL;
+	zend_long	time_type = UDAT_FULL;
 	zend_object *calendar_obj = NULL;
 	zend_long calendar_long = 0;
 	bool calendar_is_null = 1;
@@ -71,11 +71,11 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 	intl_error_reset(NULL);
 	object = return_value;
 
-	ZEND_PARSE_PARAMETERS_START(3, 6)
+	ZEND_PARSE_PARAMETERS_START(1, 6)
 		Z_PARAM_STRING_OR_NULL(locale_str, locale_len)
+		Z_PARAM_OPTIONAL
 		Z_PARAM_LONG(date_type)
 		Z_PARAM_LONG(time_type)
-		Z_PARAM_OPTIONAL
 		Z_PARAM_ZVAL(timezone_zv)
 		Z_PARAM_OBJ_OF_CLASS_OR_LONG_OR_NULL(calendar_obj, Calendar_ce_ptr, calendar_long, calendar_is_null)
 		Z_PARAM_STRING_OR_NULL(pattern_str, pattern_str_len)

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -158,7 +158,14 @@ function intl_error_name(int $errorCode): string {}
 /* dateformat */
 
 /** @param IntlTimeZone|DateTimeZone|string|null $timezone */
-function datefmt_create(?string $locale, int $dateType, int $timeType, $timezone = null, IntlCalendar|int|null $calendar = null, ?string $pattern = null): ?IntlDateFormatter {}
+function datefmt_create(
+    ?string $locale,
+    int $dateType = IntlDateFormatter::FULL,
+    int $timeType = IntlDateFormatter::FULL,
+    $timezone = null,
+    IntlCalendar|int|null $calendar = null,
+    ?string $pattern = null
+): ?IntlDateFormatter {}
 
 function datefmt_get_datetype(IntlDateFormatter $formatter): int|false {}
 

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9d6b4d36a39e4bb346ea0d45d4be8c941070bd67 */
+ * Stub hash: 0d3e65fea1fbb8f38c3268b4048cb91972a94a1b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -276,10 +276,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_intl_error_name, 0, 1, IS_STRING
 	ZEND_ARG_TYPE_INFO(0, errorCode, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_datefmt_create, 0, 3, IntlDateFormatter, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_datefmt_create, 0, 1, IntlDateFormatter, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, dateType, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, timeType, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 0, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 0, "IntlDateFormatter::FULL")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
 	ZEND_ARG_OBJ_TYPE_MASK(0, calendar, IntlCalendar, MAY_BE_LONG|MAY_BE_NULL, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")

--- a/ext/intl/tests/dateformat_create_default.phpt
+++ b/ext/intl/tests/dateformat_create_default.phpt
@@ -1,0 +1,22 @@
+--TEST--
+IntlDateFormatter::create() with default date and time types
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$ts = strtotime('2012-01-01 00:00:00 UTC');
+$fmt = IntlDateFormatter::create('en_US');
+echo $fmt->format($ts), "\n";
+
+$fmt = new IntlDateFormatter('en_US');
+echo $fmt->format($ts), "\n";
+
+$fmt = datefmt_create('en_US');
+echo $fmt->format($ts), "\n";
+
+?>
+--EXPECT--
+Sunday, January 1, 2012 at 12:00:00 AM Coordinated Universal Time
+Sunday, January 1, 2012 at 12:00:00 AM Coordinated Universal Time
+Sunday, January 1, 2012 at 12:00:00 AM Coordinated Universal Time


### PR DESCRIPTION
Default them to IntlDateFormatter:FULL, which has value 0, which
was what you would get if you passed null to these arguments in
weak typing mode. The documentation called this ICU's default
date/time type.