### PR TITLE
Retain full path of files for directory uploads

### DIFF
--- a/ext/session/tests/rfc1867.phpt
+++ b/ext/session/tests/rfc1867.phpt
@@ -54,8 +54,10 @@ string(%d) "rfc1867"
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -67,8 +69,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867.phpt
+++ b/ext/session/tests/rfc1867.phpt
@@ -57,7 +57,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -72,7 +72,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_cleanup.phpt
+++ b/ext/session/tests/rfc1867_cleanup.phpt
@@ -54,8 +54,10 @@ string(%d) "rfc1867-cleanup"
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -67,8 +69,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_cleanup.phpt
+++ b/ext/session/tests/rfc1867_cleanup.phpt
@@ -57,7 +57,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -72,7 +72,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_disabled.phpt
+++ b/ext/session/tests/rfc1867_disabled.phpt
@@ -47,8 +47,10 @@ session_destroy();
 string(%d) "rfc1867-disabled"
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -60,8 +62,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_disabled.phpt
+++ b/ext/session/tests/rfc1867_disabled.phpt
@@ -50,7 +50,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -65,7 +65,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_disabled_2.phpt
+++ b/ext/session/tests/rfc1867_disabled_2.phpt
@@ -47,8 +47,10 @@ session_destroy();
 string(%d) "rfc1867-disabled-2"
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -60,8 +62,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_disabled_2.phpt
+++ b/ext/session/tests/rfc1867_disabled_2.phpt
@@ -50,7 +50,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -65,7 +65,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_inter.phpt
+++ b/ext/session/tests/rfc1867_inter.phpt
@@ -57,8 +57,10 @@ session_destroy();
 string(%d) "rfc1867-inter"
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -70,8 +72,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_inter.phpt
+++ b/ext/session/tests/rfc1867_inter.phpt
@@ -60,7 +60,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -75,7 +75,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_no_name.phpt
+++ b/ext/session/tests/rfc1867_no_name.phpt
@@ -47,8 +47,10 @@ session_destroy();
 string(%d) "rfc1867-no-name"
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_no_name.phpt
+++ b/ext/session/tests/rfc1867_no_name.phpt
@@ -50,7 +50,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -65,7 +65,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_no_name.phpt
+++ b/ext/session/tests/rfc1867_no_name.phpt
@@ -62,8 +62,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_cookie.phpt
+++ b/ext/session/tests/rfc1867_sid_cookie.phpt
@@ -53,8 +53,10 @@ string(%d) "rfc1867-sid-cookie"
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -66,8 +68,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_cookie.phpt
+++ b/ext/session/tests/rfc1867_sid_cookie.phpt
@@ -56,7 +56,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -71,7 +71,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_get.phpt
+++ b/ext/session/tests/rfc1867_sid_get.phpt
@@ -51,8 +51,10 @@ string(%d) "rfc1867-sid-get"
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -64,8 +66,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_get.phpt
+++ b/ext/session/tests/rfc1867_sid_get.phpt
@@ -54,7 +54,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -69,7 +69,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_get_2.phpt
+++ b/ext/session/tests/rfc1867_sid_get_2.phpt
@@ -53,8 +53,10 @@ string(%d) "rfc1867-sid-get-2"
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -66,8 +68,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_get_2.phpt
+++ b/ext/session/tests/rfc1867_sid_get_2.phpt
@@ -56,7 +56,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -71,7 +71,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_invalid.phpt
+++ b/ext/session/tests/rfc1867_sid_invalid.phpt
@@ -65,8 +65,10 @@ string(%d) ""
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -78,8 +80,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_invalid.phpt
+++ b/ext/session/tests/rfc1867_sid_invalid.phpt
@@ -68,7 +68,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -83,7 +83,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_only_cookie.phpt
+++ b/ext/session/tests/rfc1867_sid_only_cookie.phpt
@@ -53,8 +53,10 @@ string(%d) "rfc1867-sid-only-cookie"
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -66,8 +68,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_only_cookie.phpt
+++ b/ext/session/tests/rfc1867_sid_only_cookie.phpt
@@ -56,7 +56,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -71,7 +71,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_only_cookie_2.phpt
+++ b/ext/session/tests/rfc1867_sid_only_cookie_2.phpt
@@ -50,8 +50,10 @@ string(%d) "%s"
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -63,8 +65,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_only_cookie_2.phpt
+++ b/ext/session/tests/rfc1867_sid_only_cookie_2.phpt
@@ -53,7 +53,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -68,7 +68,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_post.phpt
+++ b/ext/session/tests/rfc1867_sid_post.phpt
@@ -49,8 +49,10 @@ string(%d) "rfc1867-sid-post"
 bool(true)
 array(2) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -62,8 +64,10 @@ array(2) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/ext/session/tests/rfc1867_sid_post.phpt
+++ b/ext/session/tests/rfc1867_sid_post.phpt
@@ -52,7 +52,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""
@@ -67,7 +67,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""

--- a/main/rfc1867.c
+++ b/main/rfc1867.c
@@ -1144,21 +1144,6 @@ SAPI_API SAPI_POST_HANDLER_FUNC(rfc1867_post_handler) /* {{{ */
 			register_http_post_files_variable(lbuf, s, &PG(http_globals)[TRACK_VARS_FILES], 0);
 			s = NULL;
 
-			/* Add $foo_fullpath */
-			if (llen < strlen(param) + MAX_SIZE_OF_INDEX + 1) {
-				llen = (int)strlen(param);
-				lbuf = (char *) safe_erealloc(lbuf, llen, 1, MAX_SIZE_OF_INDEX + 1);
-				llen += MAX_SIZE_OF_INDEX + 1;
-			}
-
-			if (is_arr_upload) {
-				if (abuf) efree(abuf);
-				abuf = estrndup(param, strlen(param)-array_len);
-				snprintf(lbuf, llen, "%s_fullpath[%s]", abuf, array_index);
-			} else {
-				snprintf(lbuf, llen, "%s_fullpath", param);
-			}
-
 			/* Add full path of supplied file for folder uploads via 
 			 * <input type="file" name="files" multiple webkitdirectory>
 			 */

--- a/main/rfc1867.c
+++ b/main/rfc1867.c
@@ -55,7 +55,7 @@ PHPAPI int (*php_rfc1867_callback)(unsigned int event, void *event_data, void **
 static void safe_php_register_variable(char *var, char *strval, size_t val_len, zval *track_vars_array, bool override_protection);
 
 /* The longest property name we use in an uploaded file array */
-#define MAX_SIZE_OF_INDEX sizeof("[tmp_name]")
+#define MAX_SIZE_OF_INDEX sizeof("[full_path]")
 
 /* The longest anonymous name */
 #define MAX_SIZE_ANONNAME 33
@@ -1147,11 +1147,11 @@ SAPI_API SAPI_POST_HANDLER_FUNC(rfc1867_post_handler) /* {{{ */
 			/* Add full path of supplied file for folder uploads via 
 			 * <input type="file" name="files" multiple webkitdirectory>
 			 */
-			/* Add $foo[fullname] */
+			/* Add $foo[full_path] */
 			if (is_arr_upload) {
-				snprintf(lbuf, llen, "%s[fullpath][%s]", abuf, array_index);
+				snprintf(lbuf, llen, "%s[full_path][%s]", abuf, array_index);
 			} else {
-				snprintf(lbuf, llen, "%s[fullpath]", param);
+				snprintf(lbuf, llen, "%s[full_path]", param);
 			}
 			register_http_post_files_variable(lbuf, filename, &PG(http_globals)[TRACK_VARS_FILES], 0);
 			efree(filename);

--- a/main/rfc1867.c
+++ b/main/rfc1867.c
@@ -1162,10 +1162,6 @@ SAPI_API SAPI_POST_HANDLER_FUNC(rfc1867_post_handler) /* {{{ */
 			/* Add full path of supplied file for folder uploads via 
 			 * <input type="file" name="files" multiple webkitdirectory>
 			 */
-			if (!is_anonymous) {
-				safe_php_register_variable(lbuf, filename, strlen(filename), NULL, 0);
-			}
-
 			/* Add $foo[fullname] */
 			if (is_arr_upload) {
 				snprintf(lbuf, llen, "%s[fullpath][%s]", abuf, array_index);

--- a/sapi/cli/tests/php_cli_server_005.phpt
+++ b/sapi/cli/tests/php_cli_server_005.phpt
@@ -52,8 +52,10 @@ Content-type: text/html; charset=UTF-8
 
 array(1) {
   ["userfile"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(12) "laruence.txt"
+    ["fullpath"]=>
     string(12) "laruence.txt"
     ["type"]=>
     string(10) "text/plain"

--- a/sapi/cli/tests/php_cli_server_005.phpt
+++ b/sapi/cli/tests/php_cli_server_005.phpt
@@ -55,7 +55,7 @@ array(1) {
   array(6) {
     ["name"]=>
     string(12) "laruence.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(12) "laruence.txt"
     ["type"]=>
     string(10) "text/plain"

--- a/tests/basic/021.phpt
+++ b/tests/basic/021.phpt
@@ -24,8 +24,10 @@ var_dump($_POST);
 --EXPECTF--
 array(1) {
   ["pics"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(12) "bug37276.txt"
+    ["fullpath"]=>
     string(12) "bug37276.txt"
     ["type"]=>
     string(10) "text/plain"

--- a/tests/basic/021.phpt
+++ b/tests/basic/021.phpt
@@ -27,7 +27,7 @@ array(1) {
   array(6) {
     ["name"]=>
     string(12) "bug37276.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(12) "bug37276.txt"
     ["type"]=>
     string(10) "text/plain"

--- a/tests/basic/029.phpt
+++ b/tests/basic/029.phpt
@@ -32,8 +32,10 @@ var_dump($_POST);
 --EXPECTF--
 array(1) {
   ["pics"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(10) "text/plain"

--- a/tests/basic/029.phpt
+++ b/tests/basic/029.phpt
@@ -35,7 +35,7 @@ array(1) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(10) "text/plain"

--- a/tests/basic/bug55500.phpt
+++ b/tests/basic/bug55500.phpt
@@ -36,8 +36,13 @@ var_dump($_POST);
 --EXPECTF--
 array(1) {
   ["file"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    array(1) {
+      [0]=>
+      string(9) "file1.txt"
+    }
+    ["fullpath"]=>
     array(1) {
       [0]=>
       string(9) "file1.txt"

--- a/tests/basic/bug55500.phpt
+++ b/tests/basic/bug55500.phpt
@@ -42,7 +42,7 @@ array(1) {
       [0]=>
       string(9) "file1.txt"
     }
-    ["fullpath"]=>
+    ["full_path"]=>
     array(1) {
       [0]=>
       string(9) "file1.txt"

--- a/tests/basic/rfc1867_anonymous_upload.phpt
+++ b/tests/basic/rfc1867_anonymous_upload.phpt
@@ -25,8 +25,10 @@ var_dump($_POST);
 --EXPECTF--
 array(2) {
   [%d]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(16) "text/plain-file1"
@@ -38,8 +40,10 @@ array(2) {
     int(1)
   }
   [%d]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(16) "text/plain-file2"

--- a/tests/basic/rfc1867_anonymous_upload.phpt
+++ b/tests/basic/rfc1867_anonymous_upload.phpt
@@ -28,7 +28,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(16) "text/plain-file1"
@@ -43,7 +43,7 @@ array(2) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(16) "text/plain-file2"

--- a/tests/basic/rfc1867_array_upload.phpt
+++ b/tests/basic/rfc1867_array_upload.phpt
@@ -30,8 +30,17 @@ var_dump($_POST);
 --EXPECTF--
 array(1) {
   ["file"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    array(3) {
+      [0]=>
+      string(9) "file1.txt"
+      [2]=>
+      string(9) "file2.txt"
+      [3]=>
+      string(9) "file3.txt"
+    }
+    ["fullpath"]=>
     array(3) {
       [0]=>
       string(9) "file1.txt"

--- a/tests/basic/rfc1867_array_upload.phpt
+++ b/tests/basic/rfc1867_array_upload.phpt
@@ -40,7 +40,7 @@ array(1) {
       [3]=>
       string(9) "file3.txt"
     }
-    ["fullpath"]=>
+    ["full_path"]=>
     array(3) {
       [0]=>
       string(9) "file1.txt"

--- a/tests/basic/rfc1867_empty_upload.phpt
+++ b/tests/basic/rfc1867_empty_upload.phpt
@@ -40,8 +40,10 @@ if (is_uploaded_file($_FILES["file3"]["tmp_name"])) {
 --EXPECTF--
 array(3) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(16) "text/plain-file1"
@@ -53,8 +55,10 @@ array(3) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(0) ""
+    ["fullpath"]=>
     string(0) ""
     ["type"]=>
     string(0) ""
@@ -66,8 +70,10 @@ array(3) {
     int(0)
   }
   ["file3"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file3.txt"
+    ["fullpath"]=>
     string(9) "file3.txt"
     ["type"]=>
     string(16) "text/plain-file3"

--- a/tests/basic/rfc1867_empty_upload.phpt
+++ b/tests/basic/rfc1867_empty_upload.phpt
@@ -43,7 +43,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(16) "text/plain-file1"
@@ -58,7 +58,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(0) ""
-    ["fullpath"]=>
+    ["full_path"]=>
     string(0) ""
     ["type"]=>
     string(0) ""
@@ -73,7 +73,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(9) "file3.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file3.txt"
     ["type"]=>
     string(16) "text/plain-file3"

--- a/tests/basic/rfc1867_max_file_size.phpt
+++ b/tests/basic/rfc1867_max_file_size.phpt
@@ -40,8 +40,10 @@ if (is_uploaded_file($_FILES["file3"]["tmp_name"])) {
 --EXPECTF--
 array(3) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(16) "text/plain-file1"
@@ -53,8 +55,10 @@ array(3) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""
@@ -66,9 +70,11 @@ array(3) {
     int(0)
   }
   ["file3"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
     string(9) "file3.txt"
+    ["fullpath"]=>
+    string(20) "C:\foo\bar/file3.txt"
     ["type"]=>
     string(16) "text/plain-file3"
     ["tmp_name"]=>

--- a/tests/basic/rfc1867_max_file_size.phpt
+++ b/tests/basic/rfc1867_max_file_size.phpt
@@ -43,7 +43,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(16) "text/plain-file1"
@@ -58,7 +58,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""
@@ -73,7 +73,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(9) "file3.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(20) "C:\foo\bar/file3.txt"
     ["type"]=>
     string(16) "text/plain-file3"

--- a/tests/basic/rfc1867_max_file_uploads_empty_files.phpt
+++ b/tests/basic/rfc1867_max_file_uploads_empty_files.phpt
@@ -40,8 +40,10 @@ if (is_uploaded_file($_FILES["file4"]["tmp_name"])) {
 --EXPECTF--
 array(4) {
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(0) ""
+    ["fullpath"]=>
     string(0) ""
     ["type"]=>
     string(0) ""
@@ -53,8 +55,10 @@ array(4) {
     int(0)
   }
   ["file3"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(0) ""
+    ["fullpath"]=>
     string(0) ""
     ["type"]=>
     string(0) ""
@@ -66,8 +70,10 @@ array(4) {
     int(0)
   }
   ["file4"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file4.txt"
+    ["fullpath"]=>
     string(9) "file4.txt"
     ["type"]=>
     string(15) "text/plain-file"
@@ -79,8 +85,10 @@ array(4) {
     int(0)
   }
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(15) "text/plain-file"

--- a/tests/basic/rfc1867_max_file_uploads_empty_files.phpt
+++ b/tests/basic/rfc1867_max_file_uploads_empty_files.phpt
@@ -43,7 +43,7 @@ array(4) {
   array(6) {
     ["name"]=>
     string(0) ""
-    ["fullpath"]=>
+    ["full_path"]=>
     string(0) ""
     ["type"]=>
     string(0) ""
@@ -58,7 +58,7 @@ array(4) {
   array(6) {
     ["name"]=>
     string(0) ""
-    ["fullpath"]=>
+    ["full_path"]=>
     string(0) ""
     ["type"]=>
     string(0) ""
@@ -73,7 +73,7 @@ array(4) {
   array(6) {
     ["name"]=>
     string(9) "file4.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file4.txt"
     ["type"]=>
     string(15) "text/plain-file"
@@ -88,7 +88,7 @@ array(4) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(15) "text/plain-file"

--- a/tests/basic/rfc1867_missing_boundary_2.phpt
+++ b/tests/basic/rfc1867_missing_boundary_2.phpt
@@ -18,8 +18,10 @@ var_dump($_POST);
 --EXPECT--
 array(1) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""

--- a/tests/basic/rfc1867_missing_boundary_2.phpt
+++ b/tests/basic/rfc1867_missing_boundary_2.phpt
@@ -21,7 +21,7 @@ array(1) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(0) ""

--- a/tests/basic/rfc1867_multiple_webkitdirectory.phpt
+++ b/tests/basic/rfc1867_multiple_webkitdirectory.phpt
@@ -1,0 +1,74 @@
+--TEST--
+Request #77372 (Relative file path is removed from uploaded file)
+--INI--
+file_uploads=1
+upload_max_filesize=1024
+max_file_uploads=10
+--POST_RAW--
+Content-Type: multipart/form-data; boundary=---------------------------64369134225794159231042985467
+-----------------------------64369134225794159231042985467
+Content-Disposition: form-data; name="files[]"; filename="directory/subdirectory/file2.txt"
+Content-Type: text/plain
+
+2
+-----------------------------64369134225794159231042985467
+Content-Disposition: form-data; name="files[]"; filename="directory/file1.txt"
+Content-Type: text/plain
+
+1
+-----------------------------64369134225794159231042985467--
+--FILE--
+<?php
+var_dump($_FILES);
+var_dump($_POST);
+?>
+--EXPECTF--
+array(1) {
+  ["files"]=>
+  array(6) {
+    ["name"]=>
+    array(2) {
+      [0]=>
+      string(9) "file2.txt"
+      [1]=>
+      string(9) "file1.txt"
+    }
+    ["full_path"]=>
+    array(2) {
+      [0]=>
+      string(32) "directory/subdirectory/file2.txt"
+      [1]=>
+      string(19) "directory/file1.txt"
+    }
+    ["type"]=>
+    array(2) {
+      [0]=>
+      string(10) "text/plain"
+      [1]=>
+      string(10) "text/plain"
+    }
+    ["tmp_name"]=>
+    array(2) {
+      [0]=>
+      string(%d) "%s"
+      [1]=>
+      string(%d) "%s"
+    }
+    ["error"]=>
+    array(2) {
+      [0]=>
+      int(0)
+      [1]=>
+      int(0)
+    }
+    ["size"]=>
+    array(2) {
+      [0]=>
+      int(1)
+      [1]=>
+      int(1)
+    }
+  }
+}
+array(0) {
+}

--- a/tests/basic/rfc1867_post_max_filesize.phpt
+++ b/tests/basic/rfc1867_post_max_filesize.phpt
@@ -36,8 +36,10 @@ if (is_uploaded_file($_FILES["file3"]["tmp_name"])) {
 --EXPECTF--
 array(3) {
   ["file1"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file1.txt"
+    ["fullpath"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(16) "text/plain-file1"
@@ -49,8 +51,10 @@ array(3) {
     int(1)
   }
   ["file2"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file2.txt"
+    ["fullpath"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""
@@ -62,8 +66,10 @@ array(3) {
     int(0)
   }
   ["file3"]=>
-  array(5) {
+  array(6) {
     ["name"]=>
+    string(9) "file3.txt"
+    ["fullpath"]=>
     string(9) "file3.txt"
     ["type"]=>
     string(16) "text/plain-file3"

--- a/tests/basic/rfc1867_post_max_filesize.phpt
+++ b/tests/basic/rfc1867_post_max_filesize.phpt
@@ -39,7 +39,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(9) "file1.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file1.txt"
     ["type"]=>
     string(16) "text/plain-file1"
@@ -54,7 +54,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(9) "file2.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file2.txt"
     ["type"]=>
     string(0) ""
@@ -69,7 +69,7 @@ array(3) {
   array(6) {
     ["name"]=>
     string(9) "file3.txt"
-    ["fullpath"]=>
+    ["full_path"]=>
     string(9) "file3.txt"
     ["type"]=>
     string(16) "text/plain-file3"


### PR DESCRIPTION
To fix https://bugs.php.net/bug.php?id=77372 and improve support of `<input type="file" name="files" multiple webkitdirectory>` I introduced another item to the `$_FILES` array called `fullpath`, containing the full filename, as supplied by the user-agent.