### PR TITLE
Improve fiber backtraces

### DIFF
--- a/Zend/tests/fibers/backtrace-deep-nesting.phpt
+++ b/Zend/tests/fibers/backtrace-deep-nesting.phpt
@@ -3,7 +3,8 @@ Backtrace in deeply nested function call
 --FILE--
 <?php
 
-function suspend_fiber(int $level): void {
+function suspend_fiber(int $level): void
+{
     if ($level >= 10) {
         $value = \Fiber::suspend($level);
         failing_function($value);
@@ -12,11 +13,13 @@ function suspend_fiber(int $level): void {
     suspend_fiber($level + 1);
 }
 
-function failing_function(string $value): never {
+function failing_function(string $value): never
+{
     throw_exception();
 }
 
-function throw_exception(): never {
+function throw_exception(): never
+{
     throw new Exception;
 }
 
@@ -34,17 +37,17 @@ Fatal error: Uncaught Exception in %sbacktrace-deep-nesting.php:%d
 Stack trace:
 #0 %sbacktrace-deep-nesting.php(%d): throw_exception()
 #1 %sbacktrace-deep-nesting.php(%d): failing_function('test')
-#2 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(10)
-#3 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(9)
-#4 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(8)
-#5 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(7)
-#6 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(6)
-#7 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(5)
-#8 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(4)
-#9 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(3)
-#10 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(2)
-#11 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(1)
-#12 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(0)
+#2 %sbacktrace-deep-nesting.php(%d): suspend_fiber(10)
+#3 %sbacktrace-deep-nesting.php(%d): suspend_fiber(9)
+#4 %sbacktrace-deep-nesting.php(%d): suspend_fiber(8)
+#5 %sbacktrace-deep-nesting.php(%d): suspend_fiber(7)
+#6 %sbacktrace-deep-nesting.php(%d): suspend_fiber(6)
+#7 %sbacktrace-deep-nesting.php(%d): suspend_fiber(5)
+#8 %sbacktrace-deep-nesting.php(%d): suspend_fiber(4)
+#9 %sbacktrace-deep-nesting.php(%d): suspend_fiber(3)
+#10 %sbacktrace-deep-nesting.php(%d): suspend_fiber(2)
+#11 %sbacktrace-deep-nesting.php(%d): suspend_fiber(1)
+#12 %sbacktrace-deep-nesting.php(%d): suspend_fiber(0)
 #13 {fiber}: {closure}()
 #14 %sbacktrace-deep-nesting.php(%d): Fiber->resume('test')
 #15 {main}

--- a/Zend/tests/fibers/backtrace-deep-nesting.phpt
+++ b/Zend/tests/fibers/backtrace-deep-nesting.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Backtrace in deeply nested function call
+--FILE--
+<?php
+
+function suspend_fiber(int $level): void {
+    if ($level >= 10) {
+        $value = \Fiber::suspend($level);
+        failing_function($value);
+    }
+
+    suspend_fiber($level + 1);
+}
+
+function failing_function(string $value): never {
+    throw_exception();
+}
+
+function throw_exception(): never {
+    throw new Exception;
+}
+
+$fiber = new Fiber(function (): void {
+    suspend_fiber(0);
+});
+
+$fiber->start();
+
+$fiber->resume('test');
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception in %sbacktrace-deep-nesting.php:%d
+Stack trace:
+#0 %sbacktrace-deep-nesting.php(%d): throw_exception()
+#1 %sbacktrace-deep-nesting.php(%d): failing_function('test')
+#2 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(10)
+#3 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(9)
+#4 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(8)
+#5 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(7)
+#6 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(6)
+#7 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(5)
+#8 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(4)
+#9 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(3)
+#10 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(2)
+#11 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(1)
+#12 [suspended] %sbacktrace-deep-nesting.php(%d): suspend_fiber(0)
+#13 {fiber}: {closure}()
+#14 %sbacktrace-deep-nesting.php(%d): Fiber->resume('test')
+#15 {main}
+  thrown in %sbacktrace-deep-nesting.php on line %d

--- a/Zend/tests/fibers/backtrace-nested.phpt
+++ b/Zend/tests/fibers/backtrace-nested.phpt
@@ -3,7 +3,8 @@ Backtrace in nested function call
 --FILE--
 <?php
 
-function suspend_fiber(): void {
+function suspend_fiber(): void
+{
     \Fiber::suspend();
     throw new Exception;
 }
@@ -20,7 +21,7 @@ $fiber->resume();
 --EXPECTF--
 Fatal error: Uncaught Exception in %sbacktrace-nested.php:%d
 Stack trace:
-#0 [suspended] %sbacktrace-nested.php(%d): suspend_fiber()
+#0 %sbacktrace-nested.php(%d): suspend_fiber()
 #1 {fiber}: {closure}()
 #2 %sbacktrace-nested.php(%d): Fiber->resume()
 #3 {main}

--- a/Zend/tests/fibers/backtrace-nested.phpt
+++ b/Zend/tests/fibers/backtrace-nested.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Backtrace in nested function call
+--FILE--
+<?php
+
+function suspend_fiber(): void {
+    \Fiber::suspend();
+    throw new Exception;
+}
+
+$fiber = new Fiber(function (): void {
+    suspend_fiber();
+});
+
+$fiber->start();
+
+$fiber->resume();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception in %sbacktrace-nested.php:%d
+Stack trace:
+#0 [suspended] %sbacktrace-nested.php(%d): suspend_fiber()
+#1 {fiber}: {closure}()
+#2 %sbacktrace-nested.php(%d): Fiber->resume()
+#3 {main}
+  thrown in %sbacktrace-nested.php on line %d

--- a/Zend/tests/fibers/backtrace-object.phpt
+++ b/Zend/tests/fibers/backtrace-object.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Backtrace in with object as fiber callback
+--FILE--
+<?php
+
+class Test
+{
+    public function __invoke(string $arg): void
+    {
+        Fiber::suspend();
+        throw new Exception($arg);
+    }
+}
+
+$fiber = new Fiber(new Test);
+
+$fiber->start('test');
+
+$fiber->resume();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: test in %sbacktrace-object.php:%d
+Stack trace:
+#0 {fiber}: Test->__invoke('test')
+#1 %sbacktrace-object.php(%d): Fiber->resume()
+#2 {main}
+  thrown in %sbacktrace-object.php on line %d

--- a/Zend/tests/fibers/debug-backtrace.phpt
+++ b/Zend/tests/fibers/debug-backtrace.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Print backtrace in fiber
+--FILE--
+<?php
+
+function inner_function(): void
+{
+    debug_print_backtrace();
+}
+
+$fiber = new Fiber(function (): void {
+    inner_function();
+});
+
+$fiber->start();
+
+?>
+--EXPECTF--
+#0  inner_function() called at [%sdebug-backtrace.php:9]
+#1  {closure}() started {fiber}
+#2  Fiber->start() called at [%sdebug-backtrace.php:12]

--- a/Zend/tests/fibers/failing-fiber.phpt
+++ b/Zend/tests/fibers/failing-fiber.phpt
@@ -19,6 +19,7 @@ string(4) "test"
 
 Fatal error: Uncaught Exception: test in %sfailing-fiber.php:%d
 Stack trace:
-#0 [internal function]: {closure}()
-#1 {main}
+#0 {fiber}: {closure}()
+#1 %sfailing-fiber.php(%d): Fiber->resume('test')
+#2 {main}
   thrown in %sfailing-fiber.php on line %d

--- a/Zend/tests/fibers/failing-nested-fiber.phpt
+++ b/Zend/tests/fibers/failing-nested-fiber.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test throwing from fiber
+--FILE--
+<?php
+
+$fiber = new Fiber(function (): void {
+    $fiber = new Fiber(function (int $x, int $y): void {
+        Fiber::suspend($x + $y);
+        throw new Exception('test');
+    });
+
+    $value = $fiber->start(1, 2);
+    var_dump($value);
+    $fiber->resume($value);
+});
+
+$fiber->start();
+
+?>
+--EXPECTF--
+int(3)
+
+Fatal error: Uncaught Exception: test in %sfailing-nested-fiber.php:6
+Stack trace:
+#0 {fiber}: {closure}(1, 2)
+#1 %sfailing-nested-fiber.php(%d): Fiber->resume(3)
+#2 {fiber}: {closure}()
+#3 %sfailing-nested-fiber.php(%d): Fiber->start()
+#4 {main}
+  thrown in %sfailing-nested-fiber.php on line %d

--- a/Zend/tests/fibers/fiber-throw-in-destruct.phpt
+++ b/Zend/tests/fibers/fiber-throw-in-destruct.phpt
@@ -22,6 +22,8 @@ int(1)
 
 Fatal error: Uncaught Exception: test in %sfiber-throw-in-destruct.php:%d
 Stack trace:
-#0 [internal function]: class@anonymous::{closure}()
-#1 {main}
+#0 {fiber}: class@anonymous::{closure}()
+#1 %sfiber-throw-in-destruct.php(%d): Fiber->resume()
+#2 [internal function]: class@anonymous->__destruct()
+#3 {main}
   thrown in %sfiber-throw-in-destruct.php on line %d

--- a/Zend/tests/fibers/resume-running-fiber.phpt
+++ b/Zend/tests/fibers/resume-running-fiber.phpt
@@ -15,6 +15,7 @@ $fiber->start();
 Fatal error: Uncaught FiberError: Cannot resume a fiber that is not suspended in %sresume-running-fiber.php:%d
 Stack trace:
 #0 %sresume-running-fiber.php(%d): Fiber->resume()
-#1 [internal function]: {closure}()
-#2 {main}
+#1 {fiber}: {closure}()
+#2 %sresume-running-fiber.php(%d): Fiber->start()
+#3 {main}
   thrown in %sresume-running-fiber.php on line %d

--- a/Zend/tests/fibers/start-arguments.phpt
+++ b/Zend/tests/fibers/start-arguments.phpt
@@ -23,6 +23,7 @@ int(1)
 
 Fatal error: Uncaught TypeError: {closure}(): Argument #1 ($x) must be of type int, string given in %sstart-arguments.php:%d
 Stack trace:
-#0 [internal function]: {closure}('test')
-#1 {main}
+#0 {fiber}: {closure}('test')
+#1 %sstart-arguments.php(%d): Fiber->start('test')
+#2 {main}
   thrown in %sstart-arguments.php on line %d

--- a/Zend/tests/fibers/suspend-in-force-close-fiber-after-shutdown.phpt
+++ b/Zend/tests/fibers/suspend-in-force-close-fiber-after-shutdown.phpt
@@ -22,6 +22,6 @@ done
 Fatal error: Uncaught FiberError: Cannot suspend in a force closed fiber in %ssuspend-in-force-close-fiber-after-shutdown.php:%d
 Stack trace:
 #0 %ssuspend-in-force-close-fiber-after-shutdown.php(%d): Fiber::suspend()
-#1 [internal function]: {closure}()
+#1 {fiber}: {closure}()
 #2 {main}
   thrown in %ssuspend-in-force-close-fiber-after-shutdown.php on line %d

--- a/Zend/tests/fibers/suspend-in-force-close-fiber.phpt
+++ b/Zend/tests/fibers/suspend-in-force-close-fiber.phpt
@@ -20,6 +20,6 @@ unset($fiber);
 Fatal error: Uncaught FiberError: Cannot suspend in a force closed fiber in %ssuspend-in-force-close-fiber.php:%d
 Stack trace:
 #0 %ssuspend-in-force-close-fiber.php(%d): Fiber::suspend()
-#1 [internal function]: {closure}()
+#1 {fiber}: {closure}()
 #2 {main}
   thrown in %ssuspend-in-force-close-fiber.php on line %d

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1902,11 +1902,6 @@ ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int 
 			_zend_hash_append_ex(stack_frame, ZSTR_KNOWN(ZEND_STR_FUNCTION), &tmp, 1);
 		}
 
-		if (!fiber && ZEND_CALL_INFO(call) & ZEND_CALL_SUSPENDED) {
-			ZVAL_TRUE(&tmp);
-			_zend_hash_append_ex(stack_frame, ZSTR_KNOWN(ZEND_STR_SUSPENDED), &tmp, 1);
-		}
-
 		ZVAL_ARR(&tmp, stack_frame);
 		zend_hash_next_index_insert_new(Z_ARRVAL_P(return_value), &tmp);
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1674,6 +1674,7 @@ ZEND_FUNCTION(debug_print_backtrace)
 	ZEND_ASSERT(Z_TYPE(backtrace) == IS_ARRAY);
 	ZEND_HASH_FOREACH_NUM_KEY_VAL(Z_ARR(backtrace), frame_no, frame) {
 		ZEND_ASSERT(Z_TYPE_P(frame) == IS_ARRAY);
+		zval *fiber = zend_hash_find_ex(Z_ARR_P(frame), ZSTR_KNOWN(ZEND_STR_FIBER), 1);
 		zval *function = zend_hash_find_ex(Z_ARR_P(frame), ZSTR_KNOWN(ZEND_STR_FUNCTION), 1);
 		zval *class = zend_hash_find_ex(Z_ARR_P(frame), ZSTR_KNOWN(ZEND_STR_CLASS), 1);
 		zval *type = zend_hash_find_ex(Z_ARR_P(frame), ZSTR_KNOWN(ZEND_STR_TYPE), 1);
@@ -1704,6 +1705,9 @@ ZEND_FUNCTION(debug_print_backtrace)
 			smart_str_appendc(&str, ':');
 			smart_str_append_long(&str, Z_LVAL_P(line));
 			smart_str_appendc(&str, ']');
+		}
+		if (fiber) {
+			smart_str_appends(&str, " started {fiber}");
 		}
 		smart_str_appendc(&str, '\n');
 	} ZEND_HASH_FOREACH_END();

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -1744,6 +1744,7 @@ ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int 
 
 	while (call && (limit == 0 || frameno < limit)) {
 		zend_execute_data *prev = call->prev_execute_data;
+		filename = NULL;
 
 		if (!prev) {
 			/* add frame for a handler call without {main} code */
@@ -1807,7 +1808,6 @@ ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int 
 				}
 				prev_call = prev;
 			}
-			filename = NULL;
 		}
 
 		func = call->func;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -553,7 +553,6 @@ struct _zend_execute_data {
 #define ZEND_CALL_OBSERVED           (1 << 28) /* "fcall_begin" observer handler may set this flag */
                                                /* to prevent optimization in RETURN handler and    */
                                                /* keep all local variables for "fcall_end" handler */
-#define ZEND_CALL_SUSPENDED          (1 << 29)
 #define ZEND_CALL_SEND_ARG_BY_REF    (1u << 31)
 
 #define ZEND_CALL_NESTED_FUNCTION    (ZEND_CALL_FUNCTION | ZEND_CALL_NESTED)

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -553,6 +553,7 @@ struct _zend_execute_data {
 #define ZEND_CALL_OBSERVED           (1 << 28) /* "fcall_begin" observer handler may set this flag */
                                                /* to prevent optimization in RETURN handler and    */
                                                /* keep all local variables for "fcall_end" handler */
+#define ZEND_CALL_SUSPENDED          (1 << 29)
 #define ZEND_CALL_SEND_ARG_BY_REF    (1u << 31)
 
 #define ZEND_CALL_NESTED_FUNCTION    (ZEND_CALL_FUNCTION | ZEND_CALL_NESTED)

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -550,6 +550,11 @@ static void _build_trace_string(smart_str *str, HashTable *ht, uint32_t num) /* 
 	smart_str_append_long(str, num);
 	smart_str_appendc(str, ' ');
 
+	tmp = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_SUSPENDED), 1);
+	if (tmp && Z_TYPE_P(tmp) == IS_TRUE) {
+		smart_str_appends(str, "[suspended] ");
+	}
+
 	file = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_FILE), 1);
 	if (file) {
 		if (Z_TYPE_P(file) != IS_STRING) {
@@ -571,7 +576,12 @@ static void _build_trace_string(smart_str *str, HashTable *ht, uint32_t num) /* 
 			smart_str_appends(str, "): ");
 		}
 	} else {
-		smart_str_appends(str, "[internal function]: ");
+		tmp = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_FIBER), 1);
+		if (tmp) {
+			smart_str_appends(str, "{fiber}: ");
+		} else {
+			smart_str_appends(str, "[internal function]: ");
+		}
 	}
 	TRACE_APPEND_KEY(ZSTR_KNOWN(ZEND_STR_CLASS));
 	TRACE_APPEND_KEY(ZSTR_KNOWN(ZEND_STR_TYPE));

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -550,11 +550,6 @@ static void _build_trace_string(smart_str *str, HashTable *ht, uint32_t num) /* 
 	smart_str_append_long(str, num);
 	smart_str_appendc(str, ' ');
 
-	tmp = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_SUSPENDED), 1);
-	if (tmp && Z_TYPE_P(tmp) == IS_TRUE) {
-		smart_str_appends(str, "[suspended] ");
-	}
-
 	file = zend_hash_find_ex(ht, ZSTR_KNOWN(ZEND_STR_FILE), 1);
 	if (file) {
 		if (Z_TYPE_P(file) != IS_STRING) {

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -481,7 +481,6 @@ ZEND_METHOD(Fiber, suspend)
 {
 	zend_fiber *fiber = EG(current_fiber);
 	zval *exception, *value = NULL;
-	zend_execute_data *frame = execute_data->prev_execute_data;
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
@@ -509,11 +508,6 @@ ZEND_METHOD(Fiber, suspend)
 	fiber->execute_data = execute_data;
 	fiber->status = ZEND_FIBER_STATUS_SUSPENDED;
 	fiber->stack_bottom->prev_execute_data = NULL;
-
-	while (frame) {
-		ZEND_CALL_INFO(frame) |= ZEND_CALL_SUSPENDED;
-		frame = frame->prev_execute_data;
-	}
 
 	zend_fiber_suspend(fiber);
 

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -304,20 +304,6 @@ ZEND_COLD void zend_error_suspend_fiber(
 	abort(); // This fiber should never be resumed.
 }
 
-zend_always_inline bool zend_fiber_is_base_frame(const zend_execute_data *execute_data)
-{
-	return execute_data && execute_data->func == &zend_fiber_function && Z_OBJCE(execute_data->This) == zend_ce_fiber;
-}
-
-zend_fiber *zend_fiber_from_base_frame(const zend_execute_data *execute_data)
-{
-	if (zend_fiber_is_base_frame(execute_data)) {
-		return (zend_fiber *) Z_OBJ(execute_data->This);
-	}
-
-	return NULL;
-}
-
 static zend_always_inline zend_vm_stack zend_fiber_vm_stack_alloc(size_t size)
 {
 	zend_vm_stack page = emalloc(size);

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -67,6 +67,9 @@ typedef struct _zend_fiber {
 	/* Current Zend VM execute data being run by the fiber. */
 	zend_execute_data *execute_data;
 
+	/* Frame on the bottom of the fiber vm stack. */
+	zend_execute_data *stack_bottom;
+
 	/* Exception to be thrown from Fiber::suspend(). */
 	zval *exception;
 
@@ -98,6 +101,9 @@ ZEND_COLD void zend_error_suspend_fiber(
 
 ZEND_API void zend_fiber_switch_context(zend_fiber_context *to);
 ZEND_API void zend_fiber_suspend_context(zend_fiber_context *current);
+
+bool zend_fiber_is_base_frame(const zend_execute_data *execute_data);
+zend_fiber *zend_fiber_from_base_frame(const zend_execute_data *execute_data);
 
 #define ZEND_FIBER_GUARD_PAGES 1
 

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -556,6 +556,8 @@ EMPTY_SWITCH_DEFAULT_CASE()
 	_(ZEND_STR_SLEEP,                  "__sleep") \
 	_(ZEND_STR_WAKEUP,                 "__wakeup") \
 	_(ZEND_STR_CASES,                  "cases") \
+	_(ZEND_STR_FIBER,                  "fiber") \
+	_(ZEND_STR_SUSPENDED,              "suspended") \
 	_(ZEND_STR_FROM,                   "from") \
 	_(ZEND_STR_TRYFROM,                "tryFrom") \
 	_(ZEND_STR_TRYFROM_LOWERCASE,      "tryfrom") \

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -557,7 +557,6 @@ EMPTY_SWITCH_DEFAULT_CASE()
 	_(ZEND_STR_WAKEUP,                 "__wakeup") \
 	_(ZEND_STR_CASES,                  "cases") \
 	_(ZEND_STR_FIBER,                  "fiber") \
-	_(ZEND_STR_SUSPENDED,              "suspended") \
 	_(ZEND_STR_FROM,                   "from") \
 	_(ZEND_STR_TRYFROM,                "tryFrom") \
 	_(ZEND_STR_TRYFROM_LOWERCASE,      "tryfrom") \

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6790,6 +6790,7 @@ ZEND_METHOD(ReflectionFiber, getTrace)
 {
 	zend_fiber *fiber = (zend_fiber *) Z_OBJ(Z_REFLECTION_P(ZEND_THIS)->obj);
 	zend_long options = DEBUG_BACKTRACE_PROVIDE_OBJECT;
+	zend_execute_data *prev_execute_data;
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
@@ -6797,6 +6798,9 @@ ZEND_METHOD(ReflectionFiber, getTrace)
 	ZEND_PARSE_PARAMETERS_END();
 
 	REFLECTION_CHECK_VALID_FIBER(fiber);
+
+	prev_execute_data = fiber->stack_bottom->prev_execute_data;
+	fiber->stack_bottom->prev_execute_data = NULL;
 
 	if (EG(current_fiber) != fiber) {
 		// No need to replace current execute data if within the current fiber.
@@ -6806,6 +6810,7 @@ ZEND_METHOD(ReflectionFiber, getTrace)
 	zend_fetch_debug_backtrace(return_value, 0, options, 0);
 
 	EG(current_execute_data) = execute_data; // Restore original execute data.
+	fiber->stack_bottom->prev_execute_data = prev_execute_data; // Restore prev execute data on fiber stack.
 }
 
 ZEND_METHOD(ReflectionFiber, getExecutingLine)

--- a/ext/reflection/tests/ReflectionFiber_backtrace.phpt
+++ b/ext/reflection/tests/ReflectionFiber_backtrace.phpt
@@ -43,7 +43,7 @@ array(3) {
     }
   }
   [1]=>
-  array(5) {
+  array(4) {
     ["file"]=>
     string(%d) "%sReflectionFiber_backtrace.php"
     ["line"]=>
@@ -53,8 +53,6 @@ array(3) {
     ["args"]=>
     array(0) {
     }
-    ["suspended"]=>
-    bool(true)
   }
   [2]=>
   array(6) {

--- a/ext/reflection/tests/ReflectionFiber_backtrace.phpt
+++ b/ext/reflection/tests/ReflectionFiber_backtrace.phpt
@@ -1,0 +1,79 @@
+--TEST--
+ReflectionFiber backtrace test
+--FILE--
+<?php
+
+function suspend_fiber(): void {
+    Fiber::suspend();
+}
+
+class Test
+{
+    public function __invoke(string $arg): void
+    {
+        suspend_fiber();
+    }
+}
+
+$fiber = new Fiber(new Test);
+
+$fiber->start('test');
+
+$reflection = new ReflectionFiber($fiber);
+
+var_dump($reflection->getTrace(DEBUG_BACKTRACE_PROVIDE_OBJECT));
+
+?>
+--EXPECTF--
+array(3) {
+  [0]=>
+  array(6) {
+    ["file"]=>
+    string(%d) "%sReflectionFiber_backtrace.php"
+    ["line"]=>
+    int(4)
+    ["function"]=>
+    string(7) "suspend"
+    ["class"]=>
+    string(5) "Fiber"
+    ["type"]=>
+    string(2) "::"
+    ["args"]=>
+    array(0) {
+    }
+  }
+  [1]=>
+  array(5) {
+    ["file"]=>
+    string(%d) "%sReflectionFiber_backtrace.php"
+    ["line"]=>
+    int(11)
+    ["function"]=>
+    string(13) "suspend_fiber"
+    ["args"]=>
+    array(0) {
+    }
+    ["suspended"]=>
+    bool(true)
+  }
+  [2]=>
+  array(6) {
+    ["fiber"]=>
+    object(Fiber)#1 (0) {
+    }
+    ["function"]=>
+    string(8) "__invoke"
+    ["class"]=>
+    string(4) "Test"
+    ["object"]=>
+    object(Test)#2 (0) {
+    }
+    ["type"]=>
+    string(2) "->"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      string(4) "test"
+    }
+  }
+}

--- a/ext/reflection/tests/ReflectionFiber_basic.phpt
+++ b/ext/reflection/tests/ReflectionFiber_basic.phpt
@@ -63,7 +63,10 @@ array(2) {
     }
   }
   [1]=>
-  array(2) {
+  array(3) {
+    ["fiber"]=>
+    object(Fiber)#2 (0) {
+    }
     ["function"]=>
     string(9) "{closure}"
     ["args"]=>
@@ -94,7 +97,10 @@ array(2) {
     }
   }
   [1]=>
-  array(2) {
+  array(3) {
+    ["fiber"]=>
+    object(Fiber)#2 (0) {
+    }
     ["function"]=>
     string(9) "{closure}"
     ["args"]=>


### PR DESCRIPTION
This PR adds attaches the trace of the last call to `Fiber::start()`, `Fiber::resume()`, or `Fiber::throw()` to the fiber backtrace, as well as marking the start of the fiber trace with `{fiber}` instead of `[internal function]`.

A new index is added to backtrace arrays, `"fiber"`, which contains the `Fiber` object if the frame is the beginning of the fiber stack trace.

The aim here is to provide as much information to the user as possible while still being performant: The backtrace to the call to resume the fiber well as the entire backtrace within the fiber.