### PR TITLE
Fix ./makedist wrt. to GH move

### DIFF
--- a/makedist
+++ b/makedist
@@ -40,8 +40,8 @@ if test "${2}" -lt "13" -o "${2}" -eq "13" -a "${3}" -lt "5"; then
 fi
 IFS="$old_IFS"
 
-if test "x$PHPROOT" = "x"; then
-    PHPROOT=git@git.php.net:php-src.git;
+if test "x$PHPROOT" -ne "x"; then
+    PHPROOT=--remote=$PHPROOT
 fi
 
 LT_TARGETS='ltconfig ltmain.sh config.guess config.sub'
@@ -72,7 +72,7 @@ fi
 
 # Export PHP
 $ECHO_N "makedist: exporting tag 'php-$VER' from '$PHPROOT'...$ECHO_C"
-git archive --format=tar --remote=$PHPROOT refs/tags/php-$VER --prefix=php-$VER/ | (cd $MY_OLDPWD; tar xvf -) || exit 4
+git archive --format=tar $PHPROOT refs/tags/php-$VER --prefix=php-$VER/ | (cd $MY_OLDPWD; tar xvf -) || exit 4
 echo ""
 
 cd $DIR || exit 5

--- a/makedist
+++ b/makedist
@@ -41,7 +41,9 @@ fi
 IFS="$old_IFS"
 
 if test "x$PHPROOT" != "x"; then
-    PHPROOT=--remote=$PHPROOT
+    remote_option=--remote=$PHPROOT
+else
+    remote_option=
 fi
 
 LT_TARGETS='ltconfig ltmain.sh config.guess config.sub'
@@ -72,7 +74,7 @@ fi
 
 # Export PHP
 $ECHO_N "makedist: exporting tag 'php-$VER' from '$PHPROOT'...$ECHO_C"
-git archive --format=tar $PHPROOT refs/tags/php-$VER --prefix=php-$VER/ | (cd $MY_OLDPWD; tar xvf -) || exit 4
+git archive --format=tar $remote_option refs/tags/php-$VER --prefix=php-$VER/ | (cd $MY_OLDPWD; tar xvf -) || exit 4
 echo ""
 
 cd $DIR || exit 5

--- a/makedist
+++ b/makedist
@@ -40,7 +40,7 @@ if test "${2}" -lt "13" -o "${2}" -eq "13" -a "${3}" -lt "5"; then
 fi
 IFS="$old_IFS"
 
-if test "x$PHPROOT" -ne "x"; then
+if test "x$PHPROOT" != "x"; then
     PHPROOT=--remote=$PHPROOT
 fi
 


### PR DESCRIPTION
We can no longer export from git.php.net, and apparently exporting from
Github is not supported.  We apply a quick fix to export from the local
clone by default, still leaving an option to export from some other
repo.  This is, unfortunately, a minor BC break in a security release.