### PR TITLE
Convert IMAPConnection to IMAP\Connection

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -171,7 +171,7 @@ static zend_object* imap_object_create(zend_class_entry* ce) {
 }
 
 static zend_function *imap_object_get_constructor(zend_object *zobj) {
-	zend_throw_error(NULL, "Cannot directly construct IMAPConnection, use imap_open() instead");
+	zend_throw_error(NULL, "Cannot directly construct IMAP\\Connection, use imap_open() instead");
 	return NULL;
 }
 
@@ -198,7 +198,7 @@ static void imap_object_destroy(zend_object *zobj) {
 #define GET_IMAP_STREAM(imap_conn_struct, zval_imap_obj) \
 	imap_conn_struct = imap_object_from_zend_object(Z_OBJ_P(zval_imap_obj)); \
 	if (!imap_conn_struct) { \
-		zend_throw_exception(zend_ce_value_error, "IMAPConnection is already closed", 0); \
+		zend_throw_exception(zend_ce_value_error, "IMAP\\Connection is already closed", 0); \
 		RETURN_THROWS(); \
 	}
 
@@ -477,7 +477,7 @@ PHP_MINIT_FUNCTION(imap)
 	ssl_onceonlyinit ();
 #endif
 
-	php_imap_ce = register_class_IMAPConnection();
+	php_imap_ce = register_class_IMAP_Connection();
 	php_imap_ce->create_object = imap_object_create;
 	php_imap_ce->serialize = zend_class_serialize_deny;
 	php_imap_ce->unserialize = zend_class_unserialize_deny;
@@ -785,7 +785,7 @@ PHP_FUNCTION(imap_open)
 	/* Check for PHP_EXPUNGE and not CL_EXPUNGE as the user land facing CL_EXPUNGE constant is defined
 	 * to something different to prevent clashes between CL_EXPUNGE and an OP_* constant allowing setting
 	 * the CL_EXPUNGE flag which will expunge when the mailbox is closed (be that manually, or via the
-	 * IMAPConnection object being destroyed naturally at the end of the PHP script */
+	 * IMAP\Connection object being destroyed naturally at the end of the PHP script */
 	if (flags && ((flags & ~(OP_READONLY | OP_ANONYMOUS | OP_HALFOPEN | PHP_EXPUNGE | OP_DEBUG | OP_SHORTCACHE
 	 		| OP_SILENT | OP_PROTOTYPE | OP_SECURE)) != 0)) {
 		zend_argument_value_error(4, "must be a bitmask of the OP_* constants, and CL_EXPUNGE");
@@ -908,7 +908,7 @@ PHP_FUNCTION(imap_reopen)
 	/* Check for PHP_EXPUNGE and not CL_EXPUNGE as the user land facing CL_EXPUNGE constant is defined
      * to something different to prevent clashes between CL_EXPUNGE and an OP_* constant allowing setting
      * the CL_EXPUNGE flag which will expunge when the mailbox is closed (be that manually, or via the
-     * IMAPConnection object being destroyed naturally at the end of the PHP script */
+     * IMAP\Connection object being destroyed naturally at the end of the PHP script */
 	if (options && ((options & ~(OP_READONLY | OP_ANONYMOUS | OP_HALFOPEN | OP_EXPUNGE | PHP_EXPUNGE)) != 0)) {
 		zend_argument_value_error(3, "must be a bitmask of OP_READONLY, OP_ANONYMOUS, OP_HALFOPEN, "
 			"OP_EXPUNGE, and CL_EXPUNGE");
@@ -940,7 +940,7 @@ PHP_FUNCTION(imap_reopen)
 
 	imap_conn_struct->imap_stream = mail_open(imap_conn_struct->imap_stream, ZSTR_VAL(mailbox), flags);
 	if (imap_conn_struct->imap_stream == NIL) {
-		/* IMAPConnection object will release it self. */
+		/* IMAP\Connection object will release it self. */
 		php_error_docref(NULL, E_WARNING, "Couldn't re-open stream");
 		RETURN_FALSE;
 	}

--- a/ext/imap/php_imap.stub.php
+++ b/ext/imap/php_imap.stub.php
@@ -2,111 +2,115 @@
 
 /** @generate-class-entries */
 
-/** @strict-properties */
-final class IMAPConnection {
+namespace IMAP {
+    /** @strict-properties */
+    final class Connection {
+    }
 }
 
-function imap_open(string $mailbox, string $user, string $password, int $flags = 0, int $retries = 0, array $options = []): IMAPConnection|false {}
+namespace {
 
-function imap_reopen(IMAPConnection $imap, string $mailbox, int $flags = 0, int $retries = 0): bool {}
+function imap_open(string $mailbox, string $user, string $password, int $flags = 0, int $retries = 0, array $options = []): IMAP\Connection|false {}
 
-function imap_close(IMAPConnection $imap, int $flags = 0): bool {}
+function imap_reopen(IMAP\Connection $imap, string $mailbox, int $flags = 0, int $retries = 0): bool {}
 
-function imap_num_msg(IMAPConnection $imap): int|false {}
+function imap_close(IMAP\Connection $imap, int $flags = 0): bool {}
 
-function imap_num_recent(IMAPConnection $imap): int {}
+function imap_num_msg(IMAP\Connection $imap): int|false {}
 
-function imap_headers(IMAPConnection $imap): array|false {}
+function imap_num_recent(IMAP\Connection $imap): int {}
 
-function imap_headerinfo(IMAPConnection $imap, int $message_num, int $from_length = 0, int $subject_length = 0): stdClass|false {}
+function imap_headers(IMAP\Connection $imap): array|false {}
 
-function imap_rfc822_parse_headers(string $headers, string $default_hostname = "UNKNOWN"): stdClass {}
+function imap_headerinfo(IMAP\Connection $imap, int $message_num, int $from_length = 0, int $subject_length = 0): \stdClass|false {}
+
+function imap_rfc822_parse_headers(string $headers, string $default_hostname = "UNKNOWN"): \stdClass {}
 
 function imap_rfc822_write_address(string $mailbox, string $hostname, string $personal): string|false {}
 
 function imap_rfc822_parse_adrlist(string $string, string $default_hostname): array {}
 
-function imap_body(IMAPConnection $imap, int $message_num, int $flags = 0): string|false {}
+function imap_body(IMAP\Connection $imap, int $message_num, int $flags = 0): string|false {}
 
 /**
  * @alias imap_body
  */
-function imap_fetchtext(IMAPConnection $imap, int $message_num, int $flags = 0): string|false {}
+function imap_fetchtext(IMAP\Connection $imap, int $message_num, int $flags = 0): string|false {}
 
-function imap_bodystruct(IMAPConnection $imap, int $message_num, string $section): stdClass|false {}
+function imap_bodystruct(IMAP\Connection $imap, int $message_num, string $section): \stdClass|false {}
 
-function imap_fetchbody(IMAPConnection $imap, int $message_num, string $section, int $flags = 0): string|false {}
+function imap_fetchbody(IMAP\Connection $imap, int $message_num, string $section, int $flags = 0): string|false {}
 
-function imap_fetchmime(IMAPConnection $imap, int $message_num, string $section, int $flags = 0): string|false {}
+function imap_fetchmime(IMAP\Connection $imap, int $message_num, string $section, int $flags = 0): string|false {}
 
 /**
  * @param resource|string|int $file
  */
-function imap_savebody(IMAPConnection $imap, $file, int $message_num, string $section = "", int $flags = 0): bool {}
+function imap_savebody(IMAP\Connection $imap, $file, int $message_num, string $section = "", int $flags = 0): bool {}
 
-function imap_fetchheader(IMAPConnection $imap, int $message_num, int $flags = 0): string|false {}
+function imap_fetchheader(IMAP\Connection $imap, int $message_num, int $flags = 0): string|false {}
 
-function imap_fetchstructure(IMAPConnection $imap, int $message_num, int $flags = 0): stdClass|false {}
-
-/**
- */
-function imap_gc(IMAPConnection $imap, int $flags): bool {}
+function imap_fetchstructure(IMAP\Connection $imap, int $message_num, int $flags = 0): \stdClass|false {}
 
 /**
  */
-function imap_expunge(IMAPConnection $imap): bool {}
+function imap_gc(IMAP\Connection $imap, int $flags): bool {}
 
 /**
  */
-function imap_delete(IMAPConnection $imap, string $message_num, int $flags = 0): bool {}
+function imap_expunge(IMAP\Connection $imap): bool {}
 
 /**
  */
-function imap_undelete(IMAPConnection $imap, string $message_num, int $flags = 0): bool {}
-
-function imap_check(IMAPConnection $imap): stdClass|false {}
-
-function imap_listscan(IMAPConnection $imap, string $reference, string $pattern, string $content): array|false {}
+function imap_delete(IMAP\Connection $imap, string $message_num, int $flags = 0): bool {}
 
 /**
- * @alias imap_listscan
  */
-function imap_scan(IMAPConnection $imap, string $reference, string $pattern, string $content): array|false {}
+function imap_undelete(IMAP\Connection $imap, string $message_num, int $flags = 0): bool {}
+
+function imap_check(IMAP\Connection $imap): \stdClass|false {}
+
+function imap_listscan(IMAP\Connection $imap, string $reference, string $pattern, string $content): array|false {}
 
 /**
  * @alias imap_listscan
  */
-function imap_scanmailbox(IMAPConnection $imap, string $reference, string $pattern, string $content): array|false {}
+function imap_scan(IMAP\Connection $imap, string $reference, string $pattern, string $content): array|false {}
 
-function imap_mail_copy(IMAPConnection $imap, string $message_nums, string $mailbox, int $flags = 0): bool {}
+/**
+ * @alias imap_listscan
+ */
+function imap_scanmailbox(IMAP\Connection $imap, string $reference, string $pattern, string $content): array|false {}
 
-function imap_mail_move(IMAPConnection $imap, string $message_nums, string $mailbox, int $flags = 0): bool {}
+function imap_mail_copy(IMAP\Connection $imap, string $message_nums, string $mailbox, int $flags = 0): bool {}
+
+function imap_mail_move(IMAP\Connection $imap, string $message_nums, string $mailbox, int $flags = 0): bool {}
 
 function imap_mail_compose(array $envelope, array $bodies): string|false {}
 
-function imap_createmailbox(IMAPConnection $imap, string $mailbox): bool {}
+function imap_createmailbox(IMAP\Connection $imap, string $mailbox): bool {}
 
 /**
  * @alias imap_createmailbox
  */
-function imap_create(IMAPConnection $imap, string $mailbox): bool {}
+function imap_create(IMAP\Connection $imap, string $mailbox): bool {}
 
-function imap_renamemailbox(IMAPConnection $imap, string $from, string $to): bool {}
+function imap_renamemailbox(IMAP\Connection $imap, string $from, string $to): bool {}
 
 /**
  * @alias imap_renamemailbox
  */
-function imap_rename(IMAPConnection $imap, string $from, string $to): bool {}
+function imap_rename(IMAP\Connection $imap, string $from, string $to): bool {}
 
-function imap_deletemailbox(IMAPConnection $imap, string $mailbox): bool {}
+function imap_deletemailbox(IMAP\Connection $imap, string $mailbox): bool {}
 
-function imap_subscribe(IMAPConnection $imap, string $mailbox): bool {}
+function imap_subscribe(IMAP\Connection $imap, string $mailbox): bool {}
 
-function imap_unsubscribe(IMAPConnection $imap, string $mailbox): bool {}
+function imap_unsubscribe(IMAP\Connection $imap, string $mailbox): bool {}
 
-function imap_append(IMAPConnection $imap, string $folder, string $message, ?string $options = null, ?string $internal_date = null): bool {}
+function imap_append(IMAP\Connection $imap, string $folder, string $message, ?string $options = null, ?string $internal_date = null): bool {}
 
-function imap_ping(IMAPConnection $imap): bool {}
+function imap_ping(IMAP\Connection $imap): bool {}
 
 function imap_base64(string $string): string|false {}
 
@@ -118,39 +122,39 @@ function imap_binary(string $string): string|false {}
 
 function imap_utf8(string $mime_encoded_text): string {}
 
-function imap_status(IMAPConnection $imap, string $mailbox, int $flags): stdClass|false {}
+function imap_status(IMAP\Connection $imap, string $mailbox, int $flags): \stdClass|false {}
 
-function imap_mailboxmsginfo(IMAPConnection $imap): stdClass {}
+function imap_mailboxmsginfo(IMAP\Connection $imap): \stdClass {}
 
-function imap_setflag_full(IMAPConnection $imap, string $sequence, string $flag, int $options = 0): bool {}
+function imap_setflag_full(IMAP\Connection $imap, string $sequence, string $flag, int $options = 0): bool {}
 
-function imap_clearflag_full(IMAPConnection $imap, string $sequence, string $flag, int $options = 0): bool {}
+function imap_clearflag_full(IMAP\Connection $imap, string $sequence, string $flag, int $options = 0): bool {}
 
-function imap_sort(IMAPConnection $imap, int $criteria, bool $reverse, int $flags = 0, ?string $search_criteria = null, ?string $charset = null): array|false {}
+function imap_sort(IMAP\Connection $imap, int $criteria, bool $reverse, int $flags = 0, ?string $search_criteria = null, ?string $charset = null): array|false {}
 
-function imap_uid(IMAPConnection $imap, int $message_num): int|false {}
+function imap_uid(IMAP\Connection $imap, int $message_num): int|false {}
 
-function imap_msgno(IMAPConnection $imap, int $message_uid): int {}
+function imap_msgno(IMAP\Connection $imap, int $message_uid): int {}
 
-function imap_list(IMAPConnection $imap, string $reference, string $pattern): array|false {}
+function imap_list(IMAP\Connection $imap, string $reference, string $pattern): array|false {}
 
 /**
  * @alias imap_list
  */
-function imap_listmailbox(IMAPConnection $imap, string $reference, string $pattern): array|false {}
+function imap_listmailbox(IMAP\Connection $imap, string $reference, string $pattern): array|false {}
 
-function imap_lsub(IMAPConnection $imap, string $reference, string $pattern): array|false {}
+function imap_lsub(IMAP\Connection $imap, string $reference, string $pattern): array|false {}
 
 /**
  * @alias imap_lsub
  */
-function imap_listsubscribed(IMAPConnection $imap, string $reference, string $pattern): array|false {}
+function imap_listsubscribed(IMAP\Connection $imap, string $reference, string $pattern): array|false {}
 
-function imap_getsubscribed(IMAPConnection $imap, string $reference, string $pattern): array|false {}
+function imap_getsubscribed(IMAP\Connection $imap, string $reference, string $pattern): array|false {}
 
-function imap_getmailboxes(IMAPConnection $imap, string $reference, string $pattern): array|false {}
+function imap_getmailboxes(IMAP\Connection $imap, string $reference, string $pattern): array|false {}
 
-function imap_fetch_overview(IMAPConnection $imap, string $sequence, int $flags = 0): array|false {}
+function imap_fetch_overview(IMAP\Connection $imap, string $sequence, int $flags = 0): array|false {}
 
 function imap_alerts(): array|false {}
 
@@ -158,7 +162,7 @@ function imap_errors(): array|false {}
 
 function imap_last_error(): string|false {}
 
-function imap_search(IMAPConnection $imap, string $criteria, int $flags = SE_FREE, string $charset = ""): array|false {}
+function imap_search(IMAP\Connection $imap, string $criteria, int $flags = SE_FREE, string $charset = ""): array|false {}
 
 function imap_utf7_decode(string $string): string|false {}
 
@@ -172,20 +176,21 @@ function imap_mutf7_to_utf8(string $string): string|false {}
 
 function imap_mime_header_decode(string $string): array|false {}
 
-function imap_thread(IMAPConnection $imap, int $flags = SE_FREE): array|false {}
+function imap_thread(IMAP\Connection $imap, int $flags = SE_FREE): array|false {}
 
 function imap_timeout(int $timeout_type, int $timeout = -1): int|bool {}
 
 #if defined(HAVE_IMAP2000) || defined(HAVE_IMAP2001)
-function imap_get_quota(IMAPConnection $imap, string $quota_root): array|false {}
+function imap_get_quota(IMAP\Connection $imap, string $quota_root): array|false {}
 
-function imap_get_quotaroot(IMAPConnection $imap, string $mailbox): array|false {}
+function imap_get_quotaroot(IMAP\Connection $imap, string $mailbox): array|false {}
 
-function imap_set_quota(IMAPConnection $imap, string $quota_root, int $mailbox_size): bool {}
+function imap_set_quota(IMAP\Connection $imap, string $quota_root, int $mailbox_size): bool {}
 
-function imap_setacl(IMAPConnection $imap, string $mailbox, string $user_id, string $rights): bool {}
+function imap_setacl(IMAP\Connection $imap, string $mailbox, string $user_id, string $rights): bool {}
 
-function imap_getacl(IMAPConnection $imap, string $mailbox): array|false {}
+function imap_getacl(IMAP\Connection $imap, string $mailbox): array|false {}
 #endif
 
 function imap_mail(string $to, string $subject, string $message, ?string $additional_headers = null, ?string $cc = null, ?string $bcc = null, ?string $return_path = null): bool {}
+}

--- a/ext/imap/php_imap_arginfo.h
+++ b/ext/imap/php_imap_arginfo.h
@@ -1,7 +1,7 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4ac7b33357082ac0103b125ec3ce1d389eccf5c7 */
+ * Stub hash: 39a8d1ff3f13e3c0263d7c56e5d42ab3a2314c88 */
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_open, 0, 3, IMAPConnection, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_open, 0, 3, IMAP\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, user, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, password, IS_STRING, 0)
@@ -11,31 +11,31 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_open, 0, 3, IMAPConnect
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_reopen, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, retries, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_close, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_num_msg, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_num_recent, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_headers, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_headerinfo, 0, 2, stdClass, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, from_length, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, subject_length, IS_LONG, 0, "0")
@@ -58,7 +58,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_rfc822_parse_adrlist, 0, 2,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_body, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
@@ -66,13 +66,13 @@ ZEND_END_ARG_INFO()
 #define arginfo_imap_fetchtext arginfo_imap_body
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_bodystruct, 0, 3, stdClass, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, section, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_fetchbody, 0, 3, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, section, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
@@ -81,7 +81,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_imap_fetchmime arginfo_imap_fetchbody
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_savebody, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_INFO(0, file)
 	ZEND_ARG_TYPE_INFO(0, message_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, section, IS_STRING, 0, "\"\"")
@@ -91,22 +91,22 @@ ZEND_END_ARG_INFO()
 #define arginfo_imap_fetchheader arginfo_imap_body
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_fetchstructure, 0, 2, stdClass, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_num, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_gc, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_expunge, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_delete, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_num, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
@@ -114,11 +114,11 @@ ZEND_END_ARG_INFO()
 #define arginfo_imap_undelete arginfo_imap_delete
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_check, 0, 1, stdClass, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_listscan, 0, 4, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, reference, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, content, IS_STRING, 0)
@@ -129,7 +129,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_imap_scanmailbox arginfo_imap_listscan
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_mail_copy, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_nums, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
@@ -143,14 +143,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_mail_compose, 0, 2, MAY_BE_
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_createmailbox, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_imap_create arginfo_imap_createmailbox
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_renamemailbox, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, from, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, to, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -164,7 +164,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_imap_unsubscribe arginfo_imap_createmailbox
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_append, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, folder, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_STRING, 1, "null")
@@ -188,17 +188,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_utf8, 0, 1, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imap_status, 0, 3, stdClass, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_imap_mailboxmsginfo, 0, 1, stdClass, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_setflag_full, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, sequence, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, flag, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
@@ -207,7 +207,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_imap_clearflag_full arginfo_imap_setflag_full
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_sort, 0, 3, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, criteria, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, reverse, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
@@ -216,17 +216,17 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_sort, 0, 3, MAY_BE_ARRAY|MA
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_uid, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_num, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_msgno, 0, 2, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, message_uid, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_list, 0, 3, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, reference, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, pattern, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -242,7 +242,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_imap_getmailboxes arginfo_imap_list
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_fetch_overview, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, sequence, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
@@ -256,7 +256,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_last_error, 0, 0, MAY_BE_ST
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_search, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, criteria, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "SE_FREE")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, charset, IS_STRING, 0, "\"\"")
@@ -283,7 +283,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_mime_header_decode, 0, 1, M
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_thread, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "SE_FREE")
 ZEND_END_ARG_INFO()
 
@@ -294,21 +294,21 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_IMAP2000) || defined(HAVE_IMAP2001)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_get_quota, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, quota_root, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_IMAP2000) || defined(HAVE_IMAP2001)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imap_get_quotaroot, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_IMAP2000) || defined(HAVE_IMAP2001)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_set_quota, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, quota_root, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, mailbox_size, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -316,7 +316,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_IMAP2000) || defined(HAVE_IMAP2001)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imap_setacl, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, imap, IMAPConnection, 0)
+	ZEND_ARG_OBJ_INFO(0, imap, IMAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, mailbox, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, user_id, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, rights, IS_STRING, 0)
@@ -514,15 +514,15 @@ static const zend_function_entry ext_functions[] = {
 };
 
 
-static const zend_function_entry class_IMAPConnection_methods[] = {
+static const zend_function_entry class_IMAP_Connection_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_IMAPConnection(void)
+static zend_class_entry *register_class_IMAP_Connection(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "IMAPConnection", class_IMAPConnection_methods);
+	INIT_NS_CLASS_ENTRY(ce, "IMAP", "Connection", class_IMAP_Connection_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES;
 

--- a/ext/imap/tests/bug75774.phpt
+++ b/ext/imap/tests/bug75774.phpt
@@ -21,4 +21,4 @@ unlink($fn);
 
 ?>
 --EXPECT--
-imap_append(): Argument #1 ($imap) must be of type IMAPConnection, resource given
+imap_append(): Argument #1 ($imap) must be of type IMAP\Connection, resource given

--- a/ext/imap/tests/imap_constructor.phpt
+++ b/ext/imap/tests/imap_constructor.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Attempt to instantiate an IMAPConnection directly
+Attempt to instantiate an IMAP\Connection directly
 --SKIPIF--
 <?php
 extension_loaded('imap') or die('skip imap extension not available in this build');
@@ -7,9 +7,9 @@ extension_loaded('imap') or die('skip imap extension not available in this build
 <?php
 
 try {
-    new IMAPConnection();
+    new IMAP\Connection();
 } catch (Error $ex) {
     echo "Exception: ", $ex->getMessage(), "\n";
 }
 --EXPECT--
-Exception: Cannot directly construct IMAPConnection, use imap_open() instead
+Exception: Cannot directly construct IMAP\Connection, use imap_open() instead

--- a/ext/imap/tests/imap_final.phpt
+++ b/ext/imap/tests/imap_final.phpt
@@ -1,11 +1,11 @@
 --TEST--
-Check that IMAPConnection is declared final
+Check that IMAP\Connection is declared final
 --SKIPIF--
 <?php
 extension_loaded('imap') or die('skip imap extension not available in this build');
 --FILE--
 <?php
 
-class T extends IMAPConnection {}
+class T extends IMAP\Connection {}
 --EXPECTF--
-Fatal error: Class T may not inherit from final class (IMAPConnection) in %s on line %d
+Fatal error: Class T may not inherit from final class (IMAP\Connection) in %s on line %d


### PR DESCRIPTION
As this a newly introduced class in PHP 8.1 and the "Namespaces in bundled PHP extensions" RFC is passing, it makes sense to introduce the IMAP namespace for it.