### PR TITLE
Fix #50713: openssl_pkcs7_verify() may ignore untrusted CAs

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5244,7 +5244,7 @@ PHP_FUNCTION(openssl_pkcs7_verify)
 			certout = BIO_new_file(signersfilename, PHP_OPENSSL_BIO_MODE_W(PKCS7_BINARY));
 			if (certout) {
 				int i;
-				signers = PKCS7_get0_signers(p7, NULL, (int)flags);
+				signers = PKCS7_get0_signers(p7, others, (int)flags);
 				if (signers != NULL) {
 
 					for (i = 0; i < sk_X509_num(signers); i++) {


### PR DESCRIPTION
`openssl_pkcs7_verify()` works fine with untrusted CAs, as long as one
doesn't specify a `$signers_certificates_filename` in which case the
verification fails, because we're not passing along the untrusted CAs
to `PKCS7_get0_signers()`.

---

I would need some help regarding writing a regression test.