### PR TITLE
Re-enable observer fatal error test

### DIFF
--- a/ext/zend_test/tests/observer_error_05.phpt
+++ b/ext/zend_test/tests/observer_error_05.phpt
@@ -6,8 +6,6 @@ Observer: End handlers fire after a userland fatal error
 zend_test.observer.enabled=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
---XFAIL--
-This is unsafe and fails on macos
 --FILE--
 <?php
 set_error_handler(function ($errno, $errstr, $errfile, $errline) {


### PR DESCRIPTION
Now that zend_call_function() no longer inserts dummy frames,
this should be safe and no longer fail on some platforms.