### PR TITLE
Fixed bug #77561

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@ PHP                                                                        NEWS
   . Fixed bug #67792 (HTTP Authorization schemes are treated as case-sensitive).
     (cmb)
   . Fixed bug #80972 (Memory exhaustion on invalid string offset). (girgias)
+  . Fixed bug #77561 (Shebang line not stripped for non-primary script).
+    (Nikita)
 
 - FTP:
   . Fixed bug #80901 (Info leak in ftp extension). (cmb)

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -560,7 +560,6 @@ ZEND_API int open_file_for_scanning(zend_file_handle *file_handle)
 	}
 
 	if (CG(skip_shebang)) {
-		CG(skip_shebang) = 0;
 		BEGIN(SHEBANG);
 	} else {
 		BEGIN(INITIAL);

--- a/main/main.c
+++ b/main/main.c
@@ -2619,20 +2619,7 @@ PHPAPI int php_execute_script(zend_file_handle *primary_file)
 			zend_set_timeout(INI_INT("max_execution_time"), 0);
 		}
 
-		/*
-		   If cli primary file has shabang line and there is a prepend file,
-		   the `skip_shebang` will be used by prepend file but not primary file,
-		   save it and restore after prepend file been executed.
-		 */
-		if (CG(skip_shebang) && prepend_file_p) {
-			CG(skip_shebang) = 0;
-			if (zend_execute_scripts(ZEND_REQUIRE, NULL, 1, prepend_file_p) == SUCCESS) {
-				CG(skip_shebang) = 1;
-				retval = (zend_execute_scripts(ZEND_REQUIRE, NULL, 2, primary_file, append_file_p) == SUCCESS);
-			}
-		} else {
-			retval = (zend_execute_scripts(ZEND_REQUIRE, NULL, 3, prepend_file_p, primary_file, append_file_p) == SUCCESS);
-		}
+		retval = (zend_execute_scripts(ZEND_REQUIRE, NULL, 3, prepend_file_p, primary_file, append_file_p) == SUCCESS);
 	} zend_end_try();
 
 	if (EG(exception)) {

--- a/sapi/cli/tests/bug77561.inc
+++ b/sapi/cli/tests/bug77561.inc
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+echo "Test\n";

--- a/sapi/cli/tests/bug77561.phpt
+++ b/sapi/cli/tests/bug77561.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #77561: Shebang line not stripped for non-primary script
+--FILE--
+<?php
+
+require __DIR__ . '/bug77561.inc';
+
+?>
+--EXPECT--
+Test


### PR DESCRIPTION
Backports 896dad4c794f7826812bcfdbaaa9f0b3518d9385 to 7.4

Unconditionally strip shebang lines when using the CLI SAPI,
independently of whether they occur in the primary or non-primary
script. It's unlikely that someone intentionally wants to print
that shebang line when including a script, and this regularly
causes issues when scripts are used in multiple contexts, e.g.
for direct invocation and as a phar bootstrap.