### PR TITLE
Implement server type/version for PDO_ODBC getAttr

### DIFF
--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -350,6 +350,20 @@ static bool odbc_handle_set_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 	}
 }
 
+static int pdo_odbc_get_info_string(pdo_dbh_t *dbh, SQLUSMALLINT type, zval *val)
+{
+	RETCODE rc;
+	SQLSMALLINT out_len;
+	char buf[256];
+	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
+	rc = SQLGetInfo(H->dbc, type, (SQLPOINTER)buf, 256, &out_len);
+	/* returning -1 is treated as an error, not as unsupported */
+	if (rc == -1)
+		return -1;
+	ZVAL_STRING(val, buf);
+	return 1;
+}
+
 static int odbc_handle_get_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 {
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
@@ -359,9 +373,11 @@ static int odbc_handle_get_attr(pdo_dbh_t *dbh, zend_long attr, zval *val)
 			return 1;
 
 		case PDO_ATTR_SERVER_VERSION:
+			return pdo_odbc_get_info_string(dbh, SQL_DBMS_VER, val);
+		case PDO_ATTR_SERVER_INFO:
+			return pdo_odbc_get_info_string(dbh, SQL_DBMS_NAME, val);
 		case PDO_ATTR_PREFETCH:
 		case PDO_ATTR_TIMEOUT:
-		case PDO_ATTR_SERVER_INFO:
 		case PDO_ATTR_CONNECTION_STATUS:
 			break;
 		case PDO_ODBC_ATTR_ASSUME_UTF8:

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -356,11 +356,12 @@ static int pdo_odbc_get_info_string(pdo_dbh_t *dbh, SQLUSMALLINT type, zval *val
 	SQLSMALLINT out_len;
 	char buf[256];
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
-	rc = SQLGetInfo(H->dbc, type, (SQLPOINTER)buf, 256, &out_len);
+	rc = SQLGetInfo(H->dbc, type, (SQLPOINTER)buf, sizeof(buf), &out_len);
 	/* returning -1 is treated as an error, not as unsupported */
-	if (rc == -1)
+	if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
 		return -1;
-	ZVAL_STRING(val, buf);
+	}
+	ZVAL_STRINGL(val, buf, out_len);
 	return 1;
 }
 

--- a/ext/pdo_odbc/tests/get_attribute_server.phpt
+++ b/ext/pdo_odbc/tests/get_attribute_server.phpt
@@ -1,0 +1,24 @@
+--TEST--
+PDO ODBC getAttribute SERVER_INFO and SERVER_VERSION
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_odbc')) print 'skip not loaded';
+require 'ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require 'ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory('ext/pdo_odbc/tests/common.phpt');
+// Obviously, we can't assume what driver is being used, so just check strings
+// Example driver output (MariaDB ODBC):
+// PDO::ATTR_SERVER_INFO: MariaDB
+// PDO::ATTR_SERVER_VERSION: 10.04.000018
+// As well as IBM i ODBC:
+// PDO::ATTR_SERVER_INFO: DB2/400 SQL
+// PDO::ATTR_SERVER_VERSION: 07.02.0015
+var_dump($db->getAttribute(PDO::ATTR_SERVER_INFO));
+var_dump($db->getAttribute(PDO::ATTR_SERVER_VERSION));
+--EXPECTF--
+string(%d) "%s"
+string(%d) "%s"


### PR DESCRIPTION
As an example using the IBM Db2i ODBC driver:

```
PDO::ATTR_SERVER_INFO: DB2/400 SQL
PDO::ATTR_SERVER_VERSION: 07.02.0015
```

Sidebar (probably for @cmb69):

Other attribute types seem to be sporadically implemented across PDO drivers, so I haven't implemented them yet. For example, about half of the drivers implement the autocommit attribute by just returning it from the PDO state, others don't. Makes me curious what should be missing. After this patch, I do know autocommit, connection status, prefetch, and timeout are missing gettings, and some of that probably doesn't map to ODBC anyways. (Setters I haven't even gotten into.)