### PR TITLE
Fix #77686: Immediately remove ID from DOMDocument when removing child element

### DIFF
--- a/ext/dom/tests/bug77686.phpt
+++ b/ext/dom/tests/bug77686.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #77686 Removed elements are still returned by getElementById
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadHTML('<html><body id="x"><div id="y"><span id="z"></span></div></body></html>');
+$body = $doc->getElementById('x');
+$div = $doc->getElementById('y');
+$span = $doc->getElementById('z');
+$body->removeChild($div);
+var_dump($doc->getElementById('y'));
+var_dump($doc->getElementById('z'));
+?>
+--EXPECT--
+NULL
+NULL


### PR DESCRIPTION
In the code below, the current behavior of the last two calls to `DOMDocument::getElementById()` is returning the `DOMElement` objects that have been removed from the document unless the `DOMElement` object is destroyed.

With this patch, `null` is returned from `getElementById()` immediately after an element is removed from the document even if a reference remains to the removed `DOMElement` object.

```php
$doc = new DOMDocument;
$doc->loadHTML('<html><body id="x"><div id="y"><span id="z"></span></div></body></html>');
$body = $doc->getElementById('x');
$div = $doc->getElementById('y');
$span = $doc->getElementById('z');
$body->removeChild($div);

// DOMElement now, NULL after patch
var_dump($doc->getElementById('y'));
var_dump($doc->getElementById('z'));
```

This similar code below demonstrates the current inconsistency, where `null` is returned for the last two calls to `DOMDocument::getElementById()` because no reference is kept to the removed `DOMElement`.

```php
$doc = new DOMDocument;
$doc->loadHTML('<html><body id="x"><div id="y"><span id="z"></span></div></body></html>');
$body = $doc->getElementById('x');
$body->removeChild($doc->getElementById('y'));

// NULL
var_dump($doc->getElementById('y'));
var_dump($doc->getElementById('z'));
```