### PR TITLE
Fix #81011: mb_convert_encoding removes references from arrays

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3286,6 +3286,7 @@ MBSTRING_API HashTable *php_mb_convert_encoding_recursive(HashTable *input, cons
 		}
 		/* convert value */
 		ZEND_ASSERT(entry);
+try_again:
 		switch(Z_TYPE_P(entry)) {
 			case IS_STRING:
 				cval = php_mb_convert_encoding(Z_STRVAL_P(entry), Z_STRLEN_P(entry), _to_encoding, _from_encodings, &cval_len);
@@ -3307,6 +3308,9 @@ MBSTRING_API HashTable *php_mb_convert_encoding_recursive(HashTable *input, cons
 					ZVAL_EMPTY_ARRAY(&entry_tmp);
 				}
 				break;
+			case IS_REFERENCE:
+				entry = Z_REFVAL_P(entry);
+				goto try_again;
 			case IS_OBJECT:
 			default:
 				if (key) {

--- a/ext/mbstring/tests/bug81011.phpt
+++ b/ext/mbstring/tests/bug81011.phpt
@@ -1,0 +1,85 @@
+--TEST--
+Bug #81011 (mb_convert_encoding removes references from arrays)
+--SKIPIF--
+<?php
+if (!extension_loaded('mbstring')) die("skip mbstring extension not available");
+?>
+--FILE--
+<?php
+$array = [
+    'ads' => [
+        123 => ['name' => 'this', 'id' => 444],
+        234 => ['name' => 'that', 'id' => 555],
+    ],
+    'other' => ['one', 'two']
+    ];
+         
+// we modify array elements using reference     
+foreach( $array['ads'] as &$ad ){
+    $ad['premium'] = (int)($ad['id'] == 555);
+}
+
+var_dump($array);
+var_dump(mb_convert_encoding($array, 'UTF-8', 'UTF-8'));
+?>
+--EXPECT--
+array(2) {
+  ["ads"]=>
+  array(2) {
+    [123]=>
+    array(3) {
+      ["name"]=>
+      string(4) "this"
+      ["id"]=>
+      int(444)
+      ["premium"]=>
+      int(0)
+    }
+    [234]=>
+    &array(3) {
+      ["name"]=>
+      string(4) "that"
+      ["id"]=>
+      int(555)
+      ["premium"]=>
+      int(1)
+    }
+  }
+  ["other"]=>
+  array(2) {
+    [0]=>
+    string(3) "one"
+    [1]=>
+    string(3) "two"
+  }
+}
+array(2) {
+  ["ads"]=>
+  array(2) {
+    [123]=>
+    array(3) {
+      ["name"]=>
+      string(4) "this"
+      ["id"]=>
+      int(444)
+      ["premium"]=>
+      int(0)
+    }
+    [234]=>
+    array(3) {
+      ["name"]=>
+      string(4) "that"
+      ["id"]=>
+      int(555)
+      ["premium"]=>
+      int(1)
+    }
+  }
+  ["other"]=>
+  array(2) {
+    [0]=>
+    string(3) "one"
+    [1]=>
+    string(3) "two"
+  }
+}


### PR DESCRIPTION
We need to dereference references.