### PR TITLE
Dom namespacenode improvement

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -608,7 +608,7 @@ PHP_MINIT_FUNCTION(dom)
 	dom_register_prop_handler(&dom_node_prop_handlers, "textContent", sizeof("textContent")-1, dom_node_text_content_read, dom_node_text_content_write);
 	zend_hash_add_ptr(&classes, dom_node_class_entry->name, &dom_node_prop_handlers);
 
-	dom_namespace_node_class_entry = register_class_DOMNameSpaceNode();
+	dom_namespace_node_class_entry = register_class_DOMNameSpaceNode(dom_node_class_entry);
 	dom_namespace_node_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_namespace_node_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);

--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -93,7 +93,7 @@ class DOMNode
     public function replaceChild(DOMNode $node, DOMNode $child) {}
 }
 
-class DOMNameSpaceNode
+class DOMNameSpaceNode extends DOMNode
 {
 }
 

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c41e6d58eb8b0bbdb07401c4f1eb92c6ba3d324c */
+ * Stub hash: 9913983970c7a26ce1e6d71dc290d5eaab894643 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 1)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
@@ -908,12 +908,12 @@ static zend_class_entry *register_class_DOMNode(void)
 	return class_entry;
 }
 
-static zend_class_entry *register_class_DOMNameSpaceNode(void)
+static zend_class_entry *register_class_DOMNameSpaceNode(zend_class_entry *class_entry_DOMNode)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "DOMNameSpaceNode", class_DOMNameSpaceNode_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_DOMNode);
 
 	return class_entry;
 }

--- a/ext/dom/tests/domnamespacenodes.phpt
+++ b/ext/dom/tests/domnamespacenodes.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Namespace nodes: DOMNamespaceNode functionality
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$xmlStr = <<<EOXML
+<hello xmlns="http://www.hello.com" xmlns:foo="http://foo">
+    <item xmlns:bar="http://bar">A</item>
+</hello>
+EOXML;
+
+$dom = new DOMDocument;
+$dom->loadXML($xmlStr);
+if(!$dom) {
+    echo "Error while parsing the document\n";
+    exit;
+}
+
+$node = $dom->documentElement;
+$checkInstance = fn ($node): string =>
+	($node instanceof DOMNode && $node instanceof DOMNameSpaceNode) ? 'YES' : 'NO';
+
+
+$xmlns = $node->getAttributeNode('xmlns');
+echo "Root XMLNS uri: ".$xmlns->namespaceURI."\n";
+echo "Root XMLNS prefix: ".$xmlns->prefix."\n";
+echo "This is a node: " . $checkInstance($xmlns) . "\n";
+
+$foo = $node->getAttributeNode('xmlns:foo');
+echo "Root XMLNS:foo uri: ".$foo->namespaceURI."\n";
+echo "Root XMLNS:foo prefix: ".$foo->prefix."\n";
+echo "This is a node: " . $checkInstance($foo) . "\n";
+
+$bar = $node->firstElementChild->getAttributeNode('xmlns:bar');
+echo "Item XMLNS:bar uri: ".$bar->namespaceURI."\n";
+echo "Item XMLNS:bar prefix: ".$bar->prefix."\n";
+echo "This is a node: " . $checkInstance($bar) . "\n";
+
+$node->firstElementChild->removeAttributeNS($bar->namespaceURI, $bar->prefix);
+
+print $dom->saveXML($node);
+
+?>
+--EXPECT--
+Root XMLNS uri: http://www.hello.com
+Root XMLNS prefix: 
+This is a node: YES
+Root XMLNS:foo uri: http://foo
+Root XMLNS:foo prefix: foo
+This is a node: YES
+Item XMLNS:bar uri: http://bar
+Item XMLNS:bar prefix: bar
+This is a node: YES
+<hello xmlns="http://www.hello.com" xmlns:foo="http://foo">
+    <item>A</item>
+</hello>


### PR DESCRIPTION
This PR makes  `DOMNamespaceNode` extend from `DOMNode`.
This allows for easier data access without having to worry about all possible types all the times:

```xml
<hello xmlns="http://www.hello.com" xmlns:foo="http://foo">
    <item xmlns:bar="http://bar">A</item>
</hello>
```

Given following example, 
The result can either be `DOMAttr|DOMNamespaceNode|false`:

```php
$xmlns = $hello->getAttributeNode('xmlns');
$foo = $hello->getAttributeNode('xmlns:foo');
```

(Since the xmlns attributes are very hidden away in the dom extension, you'll need to directly fetch it based on exact attribute name.)

Meaning that if you want to use the result of a the `getAttributeNode()`,
you might always have to keep in mind the possibility of it being a `DOMNameSpaceNode`:

```php
function doSomethingWithAttribute(DOMAttr | DOMNamespaceNode $node)
{
    // do something
}
```

If you are dealing with only one function, this might be OK.
But if you were to build a library around DOM, this becomes quite messy and it works clumsy.

A better solution is to - *at least* - make `DOMNamespaceNode extends DOMNode`.
This way you can at least use the base type:

```php
function doSomethingWithAttribute(DOMNode $node)
{
    return match(true) {
        $node instanceof DOMAttr => 'attr',
        $node instanceof DOMNameSpaceNode => 'xmlns attribute',
    };
}
```

This PR is in line with the java jaxon implementation:
http://www.cafeconleche.org/jaxen/apidocs/org/jaxen/dom/NamespaceNode.html

An alternative solution might to make it extend DOMAttr. However, I don't think this is the way to go, since you can also fetch the namespaces through xpath. In this case it would make less sense for it to be an attribute:

```php
$namespaces = $xpath->query('./namespace::*', $node);
```




