### PR TITLE
[skip-ci] Update UPGRADING file with new `IMAP` namespace

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -63,7 +63,7 @@ PHP 8.1 UPGRADE NOTES
     instead of resources.
 
 - IMAP:
-  . The IMAP functions now accept and return, respectively, IMAPConnection objects
+  . The IMAP functions now accept and return, respectively, IMAP\Connection objects
     instead of resources.
 
 - LDAP:


### PR DESCRIPTION
Followed by the bundled extension namespace RFC, #6925 updated the `IMAPConnection` class to `IMAP\Connection`.

This updates the UPGRADING file to reflect that change.