### PR TITLE
Fix #80863: ZipArchive::extractTo() ignores references

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -2616,7 +2616,6 @@ static ZIPARCHIVE_METHOD(extractTo)
 
 	zval *self = ZEND_THIS;
 	zval *zval_files = NULL;
-	zval *zval_file = NULL;
 	php_stream_statbuf ssb;
 	char *pathto;
 	size_t pathto_len;
@@ -2653,7 +2652,9 @@ static ZIPARCHIVE_METHOD(extractTo)
 					RETURN_FALSE;
 				}
 				for (i = 0; i < nelems; i++) {
+					zval *zval_file;
 					if ((zval_file = zend_hash_index_find(Z_ARRVAL_P(zval_files), i)) != NULL) {
+try_again:
 						switch (Z_TYPE_P(zval_file)) {
 							case IS_LONG:
 								break;
@@ -2662,6 +2663,10 @@ static ZIPARCHIVE_METHOD(extractTo)
 									RETURN_FALSE;
 								}
 								break;
+							case IS_REFERENCE:
+								zval_file = Z_REFVAL_P(zval_file);
+								goto try_again;
+							EMPTY_SWITCH_DEFAULT_CASE();
 						}
 					}
 				}

--- a/ext/zip/tests/bug80863.phpt
+++ b/ext/zip/tests/bug80863.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #80863 (ZipArchive::extractTo() ignores references)
+--SKIPIF--
+<?php
+if (!extension_loaded('zip')) die("skip zip extension not available");
+?>
+--FILE--
+<?php
+$archive = __DIR__ . "/bug80863.zip";
+
+$zip = new ZipArchive();
+$zip->open($archive, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+$zip->addFromString("file1.txt", "contents");
+$zip->addFromString("file2.txt", "contents");
+$zip->close();
+
+$target = __DIR__ . "/bug80683";
+mkdir($target);
+
+$files = [
+    "file1.txt",
+    "file2.txt",
+];
+// turn into references
+foreach ($files as &$file);
+
+$zip = new ZipArchive();
+$zip->open($archive);
+$zip->extractTo($target, $files);
+var_dump(is_file("$target/file1.txt"));
+var_dump(is_file("$target/file2.txt"));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/bug80863.zip");
+$target = __DIR__ .  "/bug80683";
+@unlink("$target/file1.txt");
+@unlink("$target/file2.txt");
+@rmdir($target);
+?>


### PR DESCRIPTION
We need to cater to references, when traversing the files to extract.
While we're at it, we add an empty default clause, which would have
caught this issue.  We also move the `zval_file` declaration into a
narrower scope, which makes it easier to reason about the value
modification.