### PR TITLE
Declare type for Exception::$message and Error::$message

### DIFF
--- a/Zend/zend_exceptions.stub.php
+++ b/Zend/zend_exceptions.stub.php
@@ -22,8 +22,7 @@ interface Throwable extends Stringable
 
 class Exception implements Throwable
 {
-    /** @var string Intentionally left untyped for BC reasons */
-    protected $message = "";
+    protected string $message = "";
     private string $string = "";
     /** @var int Intentionally left untyped for BC reasons */
     protected $code = 0;
@@ -75,8 +74,7 @@ class ErrorException extends Exception
 
 class Error implements Throwable
 {
-    /** @var string Intentionally left untyped for BC reasons */
-    protected $message = "";
+    protected string $message = "";
     private string $string = "";
     /** @var int Intentionally left untyped for BC reasons */
     protected $code = 0;

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9a9ce2975a7449a621d364beca646525fc56b294 */
+ * Stub hash: e47e6e03980e6507ff1890bb5558b028cbe30d03 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Throwable_getMessage, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -272,7 +272,7 @@ static zend_class_entry *register_class_Error(zend_class_entry *class_entry_Thro
 	zval property_message_default_value;
 	ZVAL_EMPTY_STRING(&property_message_default_value);
 	zend_string *property_message_name = zend_string_init("message", sizeof("message") - 1, 1);
-	zend_declare_property_ex(class_entry, property_message_name, &property_message_default_value, ZEND_ACC_PROTECTED, NULL);
+	zend_declare_typed_property(class_entry, property_message_name, &property_message_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_message_name);
 
 	zval property_string_default_value;


### PR DESCRIPTION
Although I proposed not to declare these property types in https://github.com/php/php-src/pull/6891#discussion_r617028046 with respect to BC, I realized afterwards that both the related constructor parameter and the getter's return type is declared as string since PHP 8.0, so I'm wondering if we could yet add these types?