### PR TITLE
Move resource-object classes of LDAP to `\LDAP` namespaces

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -64,9 +64,9 @@ PHP                                                                        NEWS
   . Implemented FR #73385 (Add xxHash support). (Anatol)
 
 - LDAP:
-  . Convert resource<ldap link> to object \LDAP. (Máté)
-  . Convert resource<ldap result> to object \LDAPResult. (Máté)
-  . Convert resource<ldap result entry> to object \LDAPResultEntry. (Máté)
+  . Convert resource<ldap link> to object \LDAP\LDAP. (Máté)
+  . Convert resource<ldap result> to object \LDAP\Result. (Máté)
+  . Convert resource<ldap result entry> to object \LDAP\ResultEntry. (Máté)
 
 - MySQLi:
   . Fixed bug #70372 (Emulate mysqli_fetch_all() for libmysqlclient). (Nikita)

--- a/NEWS
+++ b/NEWS
@@ -64,7 +64,7 @@ PHP                                                                        NEWS
   . Implemented FR #73385 (Add xxHash support). (Anatol)
 
 - LDAP:
-  . Convert resource<ldap link> to object \LDAP\LDAP. (Máté)
+  . Convert resource<ldap link> to object \LDAP\Connection. (Máté)
   . Convert resource<ldap result> to object \LDAP\Result. (Máté)
   . Convert resource<ldap result entry> to object \LDAP\ResultEntry. (Máté)
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -71,7 +71,7 @@ PHP 8.1 UPGRADE NOTES
     instead of resources.
 
 - LDAP:
-  . The LDAP functions now accept and return, respectively, LDAP\LDAP objects
+  . The LDAP functions now accept and return, respectively, LDAP\Connection objects
     instead of "ldap link" resources. Return value checks using is_resource()
     should be replaced with checks for `false`.
   . The LDAP functions now accept and return, respectively, LDAP\Result objects

--- a/UPGRADING
+++ b/UPGRADING
@@ -71,13 +71,13 @@ PHP 8.1 UPGRADE NOTES
     instead of resources.
 
 - LDAP:
-  . The LDAP functions now accept and return, respectively, LDAP objects
+  . The LDAP functions now accept and return, respectively, LDAP\LDAP objects
     instead of "ldap link" resources. Return value checks using is_resource()
     should be replaced with checks for `false`.
-  . The LDAP functions now accept and return, respectively, LDAPResult objects
+  . The LDAP functions now accept and return, respectively, LDAP\Result objects
     instead of "ldap result" resources. Return value checks using is_resource()
     should be replaced with checks for `false`.
-  . The LDAP functions now accept and return, respectively, LDAPResultEntry
+  . The LDAP functions now accept and return, respectively, LDAP\ResultEntry
     objects instead of "ldap result entry" resources. Return value checks using
     is_resource() should be replaced with checks for `false`.
 

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -121,7 +121,7 @@ static zend_object *ldap_link_create_object(zend_class_entry *class_type) {
 }
 
 static zend_function *ldap_link_get_constructor(zend_object *object) {
-	zend_throw_error(NULL, "Cannot directly construct LDAP, use ldap_create() instead");
+	zend_throw_error(NULL, "Cannot directly construct LDAP\\LDAP, use ldap_create() instead");
 	return NULL;
 }
 
@@ -167,7 +167,7 @@ static zend_object *ldap_result_create_object(zend_class_entry *class_type) {
 }
 
 static zend_function *ldap_result_get_constructor(zend_object *object) {
-	zend_throw_error(NULL, "Cannot directly construct LDAPResult, use the dedicated functions instead");
+	zend_throw_error(NULL, "Cannot directly construct LDAP\\Result, use the dedicated functions instead");
 	return NULL;
 }
 
@@ -205,7 +205,7 @@ static zend_object *ldap_result_entry_create_object(zend_class_entry *class_type
 }
 
 static zend_function *ldap_result_entry_get_constructor(zend_object *obj) {
-	zend_throw_error(NULL, "Cannot directly construct LDAPResultEntry, use the dedicated functions instead");
+	zend_throw_error(NULL, "Cannot directly construct LDAP\\ResultEntry, use the dedicated functions instead");
 	return NULL;
 }
 
@@ -826,7 +826,7 @@ PHP_MINIT_FUNCTION(ldap)
 {
 	REGISTER_INI_ENTRIES();
 
-	ldap_link_ce = register_class_LDAP();
+	ldap_link_ce = register_class_LDAP_LDAP();
 	ldap_link_ce->create_object = ldap_link_create_object;
 	ldap_link_ce->serialize = zend_class_serialize_deny;
 	ldap_link_ce->unserialize = zend_class_unserialize_deny;
@@ -838,7 +838,7 @@ PHP_MINIT_FUNCTION(ldap)
 	ldap_link_object_handlers.clone_obj = NULL;
 	ldap_link_object_handlers.compare = zend_objects_not_comparable;
 
-	ldap_result_ce = register_class_LDAPResult();
+	ldap_result_ce = register_class_LDAP_Result();
 	ldap_result_ce->create_object = ldap_result_create_object;
 	ldap_result_ce->serialize = zend_class_serialize_deny;
 	ldap_result_ce->unserialize = zend_class_unserialize_deny;
@@ -850,7 +850,7 @@ PHP_MINIT_FUNCTION(ldap)
 	ldap_result_object_handlers.clone_obj = NULL;
 	ldap_result_object_handlers.compare = zend_objects_not_comparable;
 
-	ldap_result_entry_ce = register_class_LDAPResultEntry();
+	ldap_result_entry_ce = register_class_LDAP_ResultEntry();
 	ldap_result_entry_ce->create_object = ldap_result_entry_create_object;
 	ldap_result_entry_ce->serialize = zend_class_serialize_deny;
 	ldap_result_entry_ce->unserialize = zend_class_unserialize_deny;

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -121,7 +121,7 @@ static zend_object *ldap_link_create_object(zend_class_entry *class_type) {
 }
 
 static zend_function *ldap_link_get_constructor(zend_object *object) {
-	zend_throw_error(NULL, "Cannot directly construct LDAP\\LDAP, use ldap_create() instead");
+	zend_throw_error(NULL, "Cannot directly construct LDAP\\Connection, use ldap_create() instead");
 	return NULL;
 }
 
@@ -826,7 +826,7 @@ PHP_MINIT_FUNCTION(ldap)
 {
 	REGISTER_INI_ENTRIES();
 
-	ldap_link_ce = register_class_LDAP_LDAP();
+	ldap_link_ce = register_class_LDAP_Connection();
 	ldap_link_ce->create_object = ldap_link_create_object;
 	ldap_link_ce->serialize = zend_class_serialize_deny;
 	ldap_link_ce->unserialize = zend_class_unserialize_deny;

--- a/ext/ldap/ldap.stub.php
+++ b/ext/ldap/ldap.stub.php
@@ -4,7 +4,7 @@
 
 namespace LDAP {
     /** @strict-properties */
-    final class LDAP
+    final class Connection
     {
     }
 
@@ -22,115 +22,115 @@ namespace LDAP {
 namespace {
 
 #ifdef HAVE_ORALDAP
-function ldap_connect(?string $uri = null, int $port = 389, string $wallet = UNKNOWN, string $password = UNKNOWN, int $auth_mode = GSLC_SSL_NO_AUTH): LDAP\LDAP|false {}
+function ldap_connect(?string $uri = null, int $port = 389, string $wallet = UNKNOWN, string $password = UNKNOWN, int $auth_mode = GSLC_SSL_NO_AUTH): LDAP\Connection|false {}
 #else
-function ldap_connect(?string $uri = null, int $port = 389): LDAP\LDAP|false {}
+function ldap_connect(?string $uri = null, int $port = 389): LDAP\Connection|false {}
 #endif
 
-function ldap_unbind(LDAP\LDAP $ldap): bool {}
+function ldap_unbind(LDAP\Connection $ldap): bool {}
 
 /** @alias ldap_unbind */
-function ldap_close(LDAP\LDAP $ldap): bool {}
+function ldap_close(LDAP\Connection $ldap): bool {}
 
-function ldap_bind(LDAP\LDAP $ldap, ?string $dn = null, ?string $password = null): bool {}
+function ldap_bind(LDAP\Connection $ldap, ?string $dn = null, ?string $password = null): bool {}
 
-function ldap_bind_ext(LDAP\LDAP $ldap, ?string $dn = null, ?string $password = null, ?array $controls = null): LDAP\Result|false {}
+function ldap_bind_ext(LDAP\Connection $ldap, ?string $dn = null, ?string $password = null, ?array $controls = null): LDAP\Result|false {}
 
 #ifdef HAVE_LDAP_SASL
-function ldap_sasl_bind(LDAP\LDAP $ldap, ?string $dn = null, ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authc_id = null, ?string $authz_id = null, ?string $props = null): bool {}
+function ldap_sasl_bind(LDAP\Connection $ldap, ?string $dn = null, ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authc_id = null, ?string $authz_id = null, ?string $props = null): bool {}
 #endif
 
-/** @param LDAP\LDAP|array $ldap */
+/** @param LDAP\Connection|array $ldap */
 function ldap_read($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
 
-/** @param LDAP\LDAP|array $ldap */
+/** @param LDAP\Connection|array $ldap */
 function ldap_list($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
 
-/** @param LDAP\LDAP|array $ldap */
+/** @param LDAP\Connection|array $ldap */
 function ldap_search($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
 
 function ldap_free_result(LDAP\Result $result): bool {}
 
-function ldap_count_entries(LDAP\LDAP $ldap, LDAP\Result $result): int {}
+function ldap_count_entries(LDAP\Connection $ldap, LDAP\Result $result): int {}
 
-function ldap_first_entry(LDAP\LDAP $ldap, LDAP\Result $result): LDAP\ResultEntry|false {}
+function ldap_first_entry(LDAP\Connection $ldap, LDAP\Result $result): LDAP\ResultEntry|false {}
 
-function ldap_next_entry(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): LDAP\ResultEntry|false {}
+function ldap_next_entry(LDAP\Connection $ldap, LDAP\ResultEntry $entry): LDAP\ResultEntry|false {}
 
-function ldap_get_entries(LDAP\LDAP $ldap, LDAP\Result $result): array|false {}
+function ldap_get_entries(LDAP\Connection $ldap, LDAP\Result $result): array|false {}
 
-function ldap_first_attribute(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): string|false {}
+function ldap_first_attribute(LDAP\Connection $ldap, LDAP\ResultEntry $entry): string|false {}
 
-function ldap_next_attribute(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): string|false {}
+function ldap_next_attribute(LDAP\Connection $ldap, LDAP\ResultEntry $entry): string|false {}
 
-function ldap_get_attributes(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): array {}
+function ldap_get_attributes(LDAP\Connection $ldap, LDAP\ResultEntry $entry): array {}
 
-function ldap_get_values_len(LDAP\LDAP $ldap, LDAP\ResultEntry $entry, string $attribute): array|false {}
+function ldap_get_values_len(LDAP\Connection $ldap, LDAP\ResultEntry $entry, string $attribute): array|false {}
 
 /** @alias ldap_get_values_len */
-function ldap_get_values(LDAP\LDAP $ldap, LDAP\ResultEntry $entry, string $attribute): array|false {}
+function ldap_get_values(LDAP\Connection $ldap, LDAP\ResultEntry $entry, string $attribute): array|false {}
 
-function ldap_get_dn(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): string|false {}
+function ldap_get_dn(LDAP\Connection $ldap, LDAP\ResultEntry $entry): string|false {}
 
 function ldap_explode_dn(string $dn, int $with_attrib): array|false {}
 
 function ldap_dn2ufn(string $dn): string|false {}
 
-function ldap_add(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_add(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
-function ldap_add_ext(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
+function ldap_add_ext(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_delete(LDAP\LDAP $ldap, string $dn, ?array $controls = null): bool {}
+function ldap_delete(LDAP\Connection $ldap, string $dn, ?array $controls = null): bool {}
 
-function ldap_delete_ext(LDAP\LDAP $ldap, string $dn, ?array $controls = null): LDAP\Result|false {}
+function ldap_delete_ext(LDAP\Connection $ldap, string $dn, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_modify_batch(LDAP\LDAP $ldap, string $dn, array $modifications_info, ?array $controls = null): bool {}
+function ldap_modify_batch(LDAP\Connection $ldap, string $dn, array $modifications_info, ?array $controls = null): bool {}
 
-function ldap_mod_add(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_mod_add(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
-function ldap_mod_add_ext(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
+function ldap_mod_add_ext(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_mod_replace(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_mod_replace(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
 /** @alias ldap_mod_replace */
-function ldap_modify(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_modify(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
-function ldap_mod_replace_ext(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
+function ldap_mod_replace_ext(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_mod_del(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_mod_del(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
-function ldap_mod_del_ext(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
+function ldap_mod_del_ext(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_errno(LDAP\LDAP $ldap): int {}
+function ldap_errno(LDAP\Connection $ldap): int {}
 
-function ldap_error(LDAP\LDAP $ldap): string {}
+function ldap_error(LDAP\Connection $ldap): string {}
 
 function ldap_err2str(int $errno): string {}
 
-function ldap_compare(LDAP\LDAP $ldap, string $dn, string $attribute, string $value, ?array $controls = null): bool|int {}
+function ldap_compare(LDAP\Connection $ldap, string $dn, string $attribute, string $value, ?array $controls = null): bool|int {}
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
-function ldap_rename(LDAP\LDAP $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): bool {}
+function ldap_rename(LDAP\Connection $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): bool {}
 
-function ldap_rename_ext(LDAP\LDAP $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): LDAP\Result|false {}
+function ldap_rename_ext(LDAP\Connection $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): LDAP\Result|false {}
 
 /**
  * @param array|string|int $value
  */
-function ldap_get_option(LDAP\LDAP $ldap, int $option, &$value = null): bool {}
+function ldap_get_option(LDAP\Connection $ldap, int $option, &$value = null): bool {}
 
 /** @param array|string|int|bool $value */
-function ldap_set_option(?LDAP\LDAP $ldap, int $option, $value): bool {}
+function ldap_set_option(?LDAP\Connection $ldap, int $option, $value): bool {}
 
-function ldap_count_references(LDAP\LDAP $ldap, LDAP\Result $result): int {}
+function ldap_count_references(LDAP\Connection $ldap, LDAP\Result $result): int {}
 
-function ldap_first_reference(LDAP\LDAP $ldap, LDAP\Result $result): LDAP\ResultEntry|false {}
+function ldap_first_reference(LDAP\Connection $ldap, LDAP\Result $result): LDAP\ResultEntry|false {}
 
-function ldap_next_reference(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): LDAP\ResultEntry|false {}
+function ldap_next_reference(LDAP\Connection $ldap, LDAP\ResultEntry $entry): LDAP\ResultEntry|false {}
 
 #ifdef HAVE_LDAP_PARSE_REFERENCE
 /** @param array $referrals */
-function ldap_parse_reference(LDAP\LDAP $ldap, LDAP\ResultEntry $entry, &$referrals): bool {}
+function ldap_parse_reference(LDAP\Connection $ldap, LDAP\ResultEntry $entry, &$referrals): bool {}
 #endif
 
 #ifdef HAVE_LDAP_PARSE_RESULT
@@ -141,16 +141,16 @@ function ldap_parse_reference(LDAP\LDAP $ldap, LDAP\ResultEntry $entry, &$referr
  * @param array $referrals
  * @param array $controls
  */
-function ldap_parse_result(LDAP\LDAP $ldap, LDAP\Result $result, &$error_code, &$matched_dn = null, &$error_message = null, &$referrals = null, &$controls = null): bool {}
+function ldap_parse_result(LDAP\Connection $ldap, LDAP\Result $result, &$error_code, &$matched_dn = null, &$error_message = null, &$referrals = null, &$controls = null): bool {}
 #endif
 #endif
 
 #if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
-function ldap_set_rebind_proc(LDAP\LDAP $ldap, ?callable $callback): bool {}
+function ldap_set_rebind_proc(LDAP\Connection $ldap, ?callable $callback): bool {}
 #endif
 
 #ifdef HAVE_LDAP_START_TLS_S
-function ldap_start_tls(LDAP\LDAP $ldap): bool {}
+function ldap_start_tls(LDAP\Connection $ldap): bool {}
 #endif
 
 function ldap_escape(string $value, string $ignore = "", int $flags = 0): string {}
@@ -167,23 +167,23 @@ function ldap_8859_to_t61(string $value): string|false {}
  * @param string $response_data
  * @param string $response_oid
  */
-function ldap_exop(LDAP\LDAP $ldap, string $request_oid, ?string $request_data = null, ?array $controls = NULL, &$response_data = UNKNOWN, &$response_oid = null): LDAP\Result|bool {}
+function ldap_exop(LDAP\Connection $ldap, string $request_oid, ?string $request_data = null, ?array $controls = NULL, &$response_data = UNKNOWN, &$response_oid = null): LDAP\Result|bool {}
 #endif
 
 #ifdef HAVE_LDAP_PASSWD
 /**
  * @param array $controls
  */
-function ldap_exop_passwd(LDAP\LDAP $ldap, string $user = "", string $old_password = "", string $new_password = "", &$controls = null): string|bool {}
+function ldap_exop_passwd(LDAP\Connection $ldap, string $user = "", string $old_password = "", string $new_password = "", &$controls = null): string|bool {}
 #endif
 
 
 #ifdef HAVE_LDAP_WHOAMI_S
-function ldap_exop_whoami(LDAP\LDAP $ldap): string|false {}
+function ldap_exop_whoami(LDAP\Connection $ldap): string|false {}
 #endif
 
 #ifdef HAVE_LDAP_REFRESH_S
-function ldap_exop_refresh(LDAP\LDAP $ldap, string $dn, int $ttl): int|false {}
+function ldap_exop_refresh(LDAP\Connection $ldap, string $dn, int $ttl): int|false {}
 #endif
 
 #ifdef HAVE_LDAP_PARSE_EXTENDED_RESULT
@@ -191,7 +191,7 @@ function ldap_exop_refresh(LDAP\LDAP $ldap, string $dn, int $ttl): int|false {}
  * @param string $response_data
  * @param string $response_oid
  */
-function ldap_parse_exop(LDAP\LDAP $ldap, LDAP\Result $result, &$response_data = null, &$response_oid = null): bool {}
+function ldap_parse_exop(LDAP\Connection $ldap, LDAP\Result $result, &$response_data = null, &$response_oid = null): bool {}
 #endif
 
 }

--- a/ext/ldap/ldap.stub.php
+++ b/ext/ldap/ldap.stub.php
@@ -2,131 +2,135 @@
 
 /** @generate-class-entries */
 
-/** @strict-properties */
-final class LDAP
-{
+namespace LDAP {
+    /** @strict-properties */
+    final class LDAP
+    {
+    }
+
+    /** @strict-properties */
+    final class Result
+    {
+    }
+
+    /** @strict-properties */
+    final class ResultEntry
+    {
+    }
 }
 
-/** @strict-properties */
-final class LDAPResult
-{
-}
-
-/** @strict-properties */
-final class LDAPResultEntry
-{
-}
+namespace {
 
 #ifdef HAVE_ORALDAP
-function ldap_connect(?string $uri = null, int $port = 389, string $wallet = UNKNOWN, string $password = UNKNOWN, int $auth_mode = GSLC_SSL_NO_AUTH): LDAP|false {}
+function ldap_connect(?string $uri = null, int $port = 389, string $wallet = UNKNOWN, string $password = UNKNOWN, int $auth_mode = GSLC_SSL_NO_AUTH): LDAP\LDAP|false {}
 #else
-function ldap_connect(?string $uri = null, int $port = 389): LDAP|false {}
+function ldap_connect(?string $uri = null, int $port = 389): LDAP\LDAP|false {}
 #endif
 
-function ldap_unbind(LDAP $ldap): bool {}
+function ldap_unbind(LDAP\LDAP $ldap): bool {}
 
 /** @alias ldap_unbind */
-function ldap_close(LDAP $ldap): bool {}
+function ldap_close(LDAP\LDAP $ldap): bool {}
 
-function ldap_bind(LDAP $ldap, ?string $dn = null, ?string $password = null): bool {}
+function ldap_bind(LDAP\LDAP $ldap, ?string $dn = null, ?string $password = null): bool {}
 
-function ldap_bind_ext(LDAP $ldap, ?string $dn = null, ?string $password = null, ?array $controls = null): LDAPResult|false {}
+function ldap_bind_ext(LDAP\LDAP $ldap, ?string $dn = null, ?string $password = null, ?array $controls = null): LDAP\Result|false {}
 
 #ifdef HAVE_LDAP_SASL
-function ldap_sasl_bind(LDAP $ldap, ?string $dn = null, ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authc_id = null, ?string $authz_id = null, ?string $props = null): bool {}
+function ldap_sasl_bind(LDAP\LDAP $ldap, ?string $dn = null, ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authc_id = null, ?string $authz_id = null, ?string $props = null): bool {}
 #endif
 
-/** @param LDAP|array $ldap */
-function ldap_read($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAPResult|array|false {}
+/** @param LDAP\LDAP|array $ldap */
+function ldap_read($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
 
-/** @param LDAP|array $ldap */
-function ldap_list($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAPResult|array|false {}
+/** @param LDAP\LDAP|array $ldap */
+function ldap_list($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
 
-/** @param LDAP|array $ldap */
-function ldap_search($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAPResult|array|false {}
+/** @param LDAP\LDAP|array $ldap */
+function ldap_search($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
 
-function ldap_free_result(LDAPResult $result): bool {}
+function ldap_free_result(LDAP\Result $result): bool {}
 
-function ldap_count_entries(LDAP $ldap, LDAPResult $result): int {}
+function ldap_count_entries(LDAP\LDAP $ldap, LDAP\Result $result): int {}
 
-function ldap_first_entry(LDAP $ldap, LDAPResult $result): LDAPResultEntry|false {}
+function ldap_first_entry(LDAP\LDAP $ldap, LDAP\Result $result): LDAP\ResultEntry|false {}
 
-function ldap_next_entry(LDAP $ldap, LDAPResultEntry $entry): LDAPResultEntry|false {}
+function ldap_next_entry(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): LDAP\ResultEntry|false {}
 
-function ldap_get_entries(LDAP $ldap, LDAPResult $result): array|false {}
+function ldap_get_entries(LDAP\LDAP $ldap, LDAP\Result $result): array|false {}
 
-function ldap_first_attribute(LDAP $ldap, LDAPResultEntry $entry): string|false {}
+function ldap_first_attribute(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): string|false {}
 
-function ldap_next_attribute(LDAP $ldap, LDAPResultEntry $entry): string|false {}
+function ldap_next_attribute(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): string|false {}
 
-function ldap_get_attributes(LDAP $ldap, LDAPResultEntry $entry): array {}
+function ldap_get_attributes(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): array {}
 
-function ldap_get_values_len(LDAP $ldap, LDAPResultEntry $entry, string $attribute): array|false {}
+function ldap_get_values_len(LDAP\LDAP $ldap, LDAP\ResultEntry $entry, string $attribute): array|false {}
 
 /** @alias ldap_get_values_len */
-function ldap_get_values(LDAP $ldap, LDAPResultEntry $entry, string $attribute): array|false {}
+function ldap_get_values(LDAP\LDAP $ldap, LDAP\ResultEntry $entry, string $attribute): array|false {}
 
-function ldap_get_dn(LDAP $ldap, LDAPResultEntry $entry): string|false {}
+function ldap_get_dn(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): string|false {}
 
 function ldap_explode_dn(string $dn, int $with_attrib): array|false {}
 
 function ldap_dn2ufn(string $dn): string|false {}
 
-function ldap_add(LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_add(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
-function ldap_add_ext(LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAPResult|false {}
+function ldap_add_ext(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_delete(LDAP $ldap, string $dn, ?array $controls = null): bool {}
+function ldap_delete(LDAP\LDAP $ldap, string $dn, ?array $controls = null): bool {}
 
-function ldap_delete_ext(LDAP $ldap, string $dn, ?array $controls = null): LDAPResult|false {}
+function ldap_delete_ext(LDAP\LDAP $ldap, string $dn, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_modify_batch(LDAP $ldap, string $dn, array $modifications_info, ?array $controls = null): bool {}
+function ldap_modify_batch(LDAP\LDAP $ldap, string $dn, array $modifications_info, ?array $controls = null): bool {}
 
-function ldap_mod_add(LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_mod_add(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
-function ldap_mod_add_ext(LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAPResult|false {}
+function ldap_mod_add_ext(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_mod_replace(LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_mod_replace(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
 /** @alias ldap_mod_replace */
-function ldap_modify(LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_modify(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
-function ldap_mod_replace_ext(LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAPResult|false {}
+function ldap_mod_replace_ext(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_mod_del(LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+function ldap_mod_del(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): bool {}
 
-function ldap_mod_del_ext(LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAPResult|false {}
+function ldap_mod_del_ext(LDAP\LDAP $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
 
-function ldap_errno(LDAP $ldap): int {}
+function ldap_errno(LDAP\LDAP $ldap): int {}
 
-function ldap_error(LDAP $ldap): string {}
+function ldap_error(LDAP\LDAP $ldap): string {}
 
 function ldap_err2str(int $errno): string {}
 
-function ldap_compare(LDAP $ldap, string $dn, string $attribute, string $value, ?array $controls = null): bool|int {}
+function ldap_compare(LDAP\LDAP $ldap, string $dn, string $attribute, string $value, ?array $controls = null): bool|int {}
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
-function ldap_rename(LDAP $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): bool {}
+function ldap_rename(LDAP\LDAP $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): bool {}
 
-function ldap_rename_ext(LDAP $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): LDAPResult|false {}
+function ldap_rename_ext(LDAP\LDAP $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): LDAP\Result|false {}
 
 /**
  * @param array|string|int $value
  */
-function ldap_get_option(LDAP $ldap, int $option, &$value = null): bool {}
+function ldap_get_option(LDAP\LDAP $ldap, int $option, &$value = null): bool {}
 
 /** @param array|string|int|bool $value */
-function ldap_set_option(?LDAP $ldap, int $option, $value): bool {}
+function ldap_set_option(?LDAP\LDAP $ldap, int $option, $value): bool {}
 
-function ldap_count_references(LDAP $ldap, LDAPResult $result): int {}
+function ldap_count_references(LDAP\LDAP $ldap, LDAP\Result $result): int {}
 
-function ldap_first_reference(LDAP $ldap, LDAPResult $result): LDAPResultEntry|false {}
+function ldap_first_reference(LDAP\LDAP $ldap, LDAP\Result $result): LDAP\ResultEntry|false {}
 
-function ldap_next_reference(LDAP $ldap, LDAPResultEntry $entry): LDAPResultEntry|false {}
+function ldap_next_reference(LDAP\LDAP $ldap, LDAP\ResultEntry $entry): LDAP\ResultEntry|false {}
 
 #ifdef HAVE_LDAP_PARSE_REFERENCE
 /** @param array $referrals */
-function ldap_parse_reference(LDAP $ldap, LDAPResultEntry $entry, &$referrals): bool {}
+function ldap_parse_reference(LDAP\LDAP $ldap, LDAP\ResultEntry $entry, &$referrals): bool {}
 #endif
 
 #ifdef HAVE_LDAP_PARSE_RESULT
@@ -137,16 +141,16 @@ function ldap_parse_reference(LDAP $ldap, LDAPResultEntry $entry, &$referrals): 
  * @param array $referrals
  * @param array $controls
  */
-function ldap_parse_result(LDAP $ldap, LDAPResult $result, &$error_code, &$matched_dn = null, &$error_message = null, &$referrals = null, &$controls = null): bool {}
+function ldap_parse_result(LDAP\LDAP $ldap, LDAP\Result $result, &$error_code, &$matched_dn = null, &$error_message = null, &$referrals = null, &$controls = null): bool {}
 #endif
 #endif
 
 #if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
-function ldap_set_rebind_proc(LDAP $ldap, ?callable $callback): bool {}
+function ldap_set_rebind_proc(LDAP\LDAP $ldap, ?callable $callback): bool {}
 #endif
 
 #ifdef HAVE_LDAP_START_TLS_S
-function ldap_start_tls(LDAP $ldap): bool {}
+function ldap_start_tls(LDAP\LDAP $ldap): bool {}
 #endif
 
 function ldap_escape(string $value, string $ignore = "", int $flags = 0): string {}
@@ -163,23 +167,23 @@ function ldap_8859_to_t61(string $value): string|false {}
  * @param string $response_data
  * @param string $response_oid
  */
-function ldap_exop(LDAP $ldap, string $request_oid, ?string $request_data = null, ?array $controls = NULL, &$response_data = UNKNOWN, &$response_oid = null): LDAPResult|bool {}
+function ldap_exop(LDAP\LDAP $ldap, string $request_oid, ?string $request_data = null, ?array $controls = NULL, &$response_data = UNKNOWN, &$response_oid = null): LDAP\Result|bool {}
 #endif
 
 #ifdef HAVE_LDAP_PASSWD
 /**
  * @param array $controls
  */
-function ldap_exop_passwd(LDAP $ldap, string $user = "", string $old_password = "", string $new_password = "", &$controls = null): string|bool {}
+function ldap_exop_passwd(LDAP\LDAP $ldap, string $user = "", string $old_password = "", string $new_password = "", &$controls = null): string|bool {}
 #endif
 
 
 #ifdef HAVE_LDAP_WHOAMI_S
-function ldap_exop_whoami(LDAP $ldap): string|false {}
+function ldap_exop_whoami(LDAP\LDAP $ldap): string|false {}
 #endif
 
 #ifdef HAVE_LDAP_REFRESH_S
-function ldap_exop_refresh(LDAP $ldap, string $dn, int $ttl): int|false {}
+function ldap_exop_refresh(LDAP\LDAP $ldap, string $dn, int $ttl): int|false {}
 #endif
 
 #ifdef HAVE_LDAP_PARSE_EXTENDED_RESULT
@@ -187,5 +191,7 @@ function ldap_exop_refresh(LDAP $ldap, string $dn, int $ttl): int|false {}
  * @param string $response_data
  * @param string $response_oid
  */
-function ldap_parse_exop(LDAP $ldap, LDAPResult $result, &$response_data = null, &$response_oid = null): bool {}
+function ldap_parse_exop(LDAP\LDAP $ldap, LDAP\Result $result, &$response_data = null, &$response_oid = null): bool {}
 #endif
+
+}

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0e1cee8f1b466ee251ff637ed0fc17f31ca701b9 */
+ * Stub hash: 897c8add020cfc1dec58112de9abfead461b269d */
 
 #if defined(HAVE_ORALDAP)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP\\LDAP, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 0, "389")
 	ZEND_ARG_TYPE_INFO(0, wallet, IS_STRING, 0)
@@ -12,26 +12,26 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if !(defined(HAVE_ORALDAP))
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP\\LDAP, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 0, "389")
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_unbind, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_ldap_close arginfo_ldap_unbind
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_bind, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dn, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_bind_ext, 0, 1, LDAP\\Result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dn, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
@@ -39,7 +39,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_SASL)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_sasl_bind, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dn, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mech, IS_STRING, 1, "null")
@@ -71,39 +71,39 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_free_result, 0, 1, _IS_BOOL
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_count_entries, 0, 2, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_first_entry, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_next_entry, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_get_entries, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_first_attribute, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_ldap_next_attribute arginfo_ldap_first_attribute
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_get_attributes, 0, 2, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_get_values_len, 0, 3, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 	ZEND_ARG_TYPE_INFO(0, attribute, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -122,33 +122,33 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_dn2ufn, 0, 1, MAY_BE_STRING
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_add, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, entry, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_add_ext, 0, 3, LDAP\\Result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, entry, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_delete, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_delete_ext, 0, 2, LDAP\\Result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_modify_batch, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, modifications_info, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
@@ -169,11 +169,11 @@ ZEND_END_ARG_INFO()
 #define arginfo_ldap_mod_del_ext arginfo_ldap_add_ext
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_errno, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_error, 0, 1, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_err2str, 0, 1, IS_STRING, 0)
@@ -181,7 +181,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_err2str, 0, 1, IS_STRING, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_compare, 0, 4, MAY_BE_BOOL|MAY_BE_LONG)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, attribute, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
@@ -190,7 +190,7 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_rename, 0, 5, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, new_rdn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, new_parent, IS_STRING, 0)
@@ -201,7 +201,7 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_rename_ext, 0, 5, LDAP\\Result, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, new_rdn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, new_parent, IS_STRING, 0)
@@ -212,7 +212,7 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_get_option, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, value, "null")
 ZEND_END_ARG_INFO()
@@ -220,7 +220,7 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_set_option, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 1)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 1)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
@@ -228,28 +228,28 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_count_references, 0, 2, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_first_reference, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_next_reference, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP) && defined(HAVE_LDAP_PARSE_REFERENCE)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_parse_reference, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 	ZEND_ARG_INFO(1, referrals)
 ZEND_END_ARG_INFO()
@@ -257,7 +257,7 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP) && defined(HAVE_LDAP_PARSE_RESULT)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_parse_result, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 	ZEND_ARG_INFO(1, error_code)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, matched_dn, "null")
@@ -269,14 +269,14 @@ ZEND_END_ARG_INFO()
 
 #if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_set_rebind_proc, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 1)
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_LDAP_START_TLS_S)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_start_tls, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -298,7 +298,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_EXTENDED_OPERATION_S)
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_exop, 0, 2, LDAP\\Result, MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, request_oid, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, request_data, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "NULL")
@@ -309,7 +309,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_PASSWD)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_exop_passwd, 0, 1, MAY_BE_STRING|MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, user, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, old_password, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, new_password, IS_STRING, 0, "\"\"")
@@ -319,13 +319,13 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_WHOAMI_S)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_exop_whoami, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_LDAP_REFRESH_S)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_exop_refresh, 0, 3, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, ttl, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -333,7 +333,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_PARSE_EXTENDED_RESULT)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_parse_exop, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\Connection, 0)
 	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, response_data, "null")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, response_oid, "null")
@@ -545,7 +545,7 @@ static const zend_function_entry ext_functions[] = {
 };
 
 
-static const zend_function_entry class_LDAP_LDAP_methods[] = {
+static const zend_function_entry class_LDAP_Connection_methods[] = {
 	ZEND_FE_END
 };
 
@@ -559,11 +559,11 @@ static const zend_function_entry class_LDAP_ResultEntry_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_LDAP_LDAP(void)
+static zend_class_entry *register_class_LDAP_Connection(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_NS_CLASS_ENTRY(ce, "LDAP", "LDAP", class_LDAP_LDAP_methods);
+	INIT_NS_CLASS_ENTRY(ce, "LDAP", "Connection", class_LDAP_Connection_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES;
 

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9829bfa03164e646ed81aa6601589409002db960 */
+ * Stub hash: 0e1cee8f1b466ee251ff637ed0fc17f31ca701b9 */
 
 #if defined(HAVE_ORALDAP)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP\\LDAP, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 0, "389")
 	ZEND_ARG_TYPE_INFO(0, wallet, IS_STRING, 0)
@@ -12,26 +12,26 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if !(defined(HAVE_ORALDAP))
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_connect, 0, 0, LDAP\\LDAP, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, uri, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, port, IS_LONG, 0, "389")
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_unbind, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_ldap_close arginfo_ldap_unbind
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_bind, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dn, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_bind_ext, 0, 1, LDAPResult, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_bind_ext, 0, 1, LDAP\\Result, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dn, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
@@ -39,7 +39,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_SASL)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_sasl_bind, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dn, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, password, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mech, IS_STRING, 1, "null")
@@ -50,7 +50,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_sasl_bind, 0, 1, _IS_BOOL, 
 ZEND_END_ARG_INFO()
 #endif
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_read, 0, 3, LDAPResult, MAY_BE_ARRAY|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_read, 0, 3, LDAP\\Result, MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, ldap)
 	ZEND_ARG_TYPE_MASK(0, base, MAY_BE_ARRAY|MAY_BE_STRING, NULL)
 	ZEND_ARG_TYPE_MASK(0, filter, MAY_BE_ARRAY|MAY_BE_STRING, NULL)
@@ -67,44 +67,44 @@ ZEND_END_ARG_INFO()
 #define arginfo_ldap_search arginfo_ldap_read
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_free_result, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, result, LDAPResult, 0)
+	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_count_entries, 0, 2, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, result, LDAPResult, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_first_entry, 0, 2, LDAPResultEntry, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, result, LDAPResult, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_first_entry, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_next_entry, 0, 2, LDAPResultEntry, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, entry, LDAPResultEntry, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_next_entry, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_get_entries, 0, 2, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, result, LDAPResult, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_first_attribute, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, entry, LDAPResultEntry, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_ldap_next_attribute arginfo_ldap_first_attribute
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_get_attributes, 0, 2, IS_ARRAY, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, entry, LDAPResultEntry, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_get_values_len, 0, 3, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, entry, LDAPResultEntry, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 	ZEND_ARG_TYPE_INFO(0, attribute, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -122,33 +122,33 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_dn2ufn, 0, 1, MAY_BE_STRING
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_add, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, entry, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_add_ext, 0, 3, LDAPResult, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_add_ext, 0, 3, LDAP\\Result, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, entry, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_delete, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_delete_ext, 0, 2, LDAPResult, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_delete_ext, 0, 2, LDAP\\Result, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_modify_batch, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, modifications_info, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "null")
@@ -169,11 +169,11 @@ ZEND_END_ARG_INFO()
 #define arginfo_ldap_mod_del_ext arginfo_ldap_add_ext
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_errno, 0, 1, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_error, 0, 1, IS_STRING, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_err2str, 0, 1, IS_STRING, 0)
@@ -181,7 +181,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_err2str, 0, 1, IS_STRING, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_compare, 0, 4, MAY_BE_BOOL|MAY_BE_LONG)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, attribute, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
@@ -190,7 +190,7 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_rename, 0, 5, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, new_rdn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, new_parent, IS_STRING, 0)
@@ -200,8 +200,8 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_rename_ext, 0, 5, LDAPResult, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_rename_ext, 0, 5, LDAP\\Result, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, new_rdn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, new_parent, IS_STRING, 0)
@@ -212,7 +212,7 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_get_option, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, value, "null")
 ZEND_END_ARG_INFO()
@@ -220,7 +220,7 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_set_option, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 1)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 1)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
@@ -228,37 +228,37 @@ ZEND_END_ARG_INFO()
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_count_references, 0, 2, IS_LONG, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, result, LDAPResult, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_first_reference, 0, 2, LDAPResultEntry, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, result, LDAPResult, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_first_reference, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_next_reference, 0, 2, LDAPResultEntry, MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, entry, LDAPResultEntry, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_next_reference, 0, 2, LDAP\\ResultEntry, MAY_BE_FALSE)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP) && defined(HAVE_LDAP_PARSE_REFERENCE)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_parse_reference, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, entry, LDAPResultEntry, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, entry, LDAP\\ResultEntry, 0)
 	ZEND_ARG_INFO(1, referrals)
 ZEND_END_ARG_INFO()
 #endif
 
 #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP) && defined(HAVE_LDAP_PARSE_RESULT)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_parse_result, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, result, LDAPResult, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 	ZEND_ARG_INFO(1, error_code)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, matched_dn, "null")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, error_message, "null")
@@ -269,14 +269,14 @@ ZEND_END_ARG_INFO()
 
 #if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_set_rebind_proc, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 1)
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_LDAP_START_TLS_S)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_start_tls, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -297,8 +297,8 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_LDAP_EXTENDED_OPERATION_S)
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_exop, 0, 2, LDAPResult, MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ldap_exop, 0, 2, LDAP\\Result, MAY_BE_BOOL)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, request_oid, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, request_data, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, controls, IS_ARRAY, 1, "NULL")
@@ -309,7 +309,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_PASSWD)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_exop_passwd, 0, 1, MAY_BE_STRING|MAY_BE_BOOL)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, user, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, old_password, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, new_password, IS_STRING, 0, "\"\"")
@@ -319,13 +319,13 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_WHOAMI_S)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_exop_whoami, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(HAVE_LDAP_REFRESH_S)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ldap_exop_refresh, 0, 3, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
 	ZEND_ARG_TYPE_INFO(0, dn, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, ttl, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -333,8 +333,8 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_LDAP_PARSE_EXTENDED_RESULT)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ldap_parse_exop, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_OBJ_INFO(0, ldap, LDAP, 0)
-	ZEND_ARG_OBJ_INFO(0, result, LDAPResult, 0)
+	ZEND_ARG_OBJ_INFO(0, ldap, LDAP\\LDAP, 0)
+	ZEND_ARG_OBJ_INFO(0, result, LDAP\\Result, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, response_data, "null")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, response_oid, "null")
 ZEND_END_ARG_INFO()
@@ -545,47 +545,47 @@ static const zend_function_entry ext_functions[] = {
 };
 
 
-static const zend_function_entry class_LDAP_methods[] = {
+static const zend_function_entry class_LDAP_LDAP_methods[] = {
 	ZEND_FE_END
 };
 
 
-static const zend_function_entry class_LDAPResult_methods[] = {
+static const zend_function_entry class_LDAP_Result_methods[] = {
 	ZEND_FE_END
 };
 
 
-static const zend_function_entry class_LDAPResultEntry_methods[] = {
+static const zend_function_entry class_LDAP_ResultEntry_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_LDAP(void)
+static zend_class_entry *register_class_LDAP_LDAP(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "LDAP", class_LDAP_methods);
+	INIT_NS_CLASS_ENTRY(ce, "LDAP", "LDAP", class_LDAP_LDAP_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES;
 
 	return class_entry;
 }
 
-static zend_class_entry *register_class_LDAPResult(void)
+static zend_class_entry *register_class_LDAP_Result(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "LDAPResult", class_LDAPResult_methods);
+	INIT_NS_CLASS_ENTRY(ce, "LDAP", "Result", class_LDAP_Result_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES;
 
 	return class_entry;
 }
 
-static zend_class_entry *register_class_LDAPResultEntry(void)
+static zend_class_entry *register_class_LDAP_ResultEntry(void)
 {
 	zend_class_entry ce, *class_entry;
 
-	INIT_CLASS_ENTRY(ce, "LDAPResultEntry", class_LDAPResultEntry_methods);
+	INIT_NS_CLASS_ENTRY(ce, "LDAP", "ResultEntry", class_LDAP_ResultEntry_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES;
 

--- a/ext/ldap/tests/bug48441.phpt
+++ b/ext/ldap/tests/bug48441.phpt
@@ -38,7 +38,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(4) {
   ["count"]=>
@@ -94,7 +94,7 @@ array(4) {
 }
 
 Warning: ldap_search(): Partial search results returned: Sizelimit exceeded in %s on line %d
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>
@@ -114,7 +114,7 @@ array(2) {
     string(%d) "cn=userA,%s"
   }
 }
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(4) {
   ["count"]=>

--- a/ext/ldap/tests/bug77958.phpt
+++ b/ext/ldap/tests/bug77958.phpt
@@ -42,7 +42,7 @@ remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
 bool(true)
-object(LDAPResultEntry)#%d (0) {
+object(LDAP\ResultEntry)#%d (0) {
 }
 array(3) {
   [0]=>

--- a/ext/ldap/tests/ldap_add_ext.phpt
+++ b/ext/ldap/tests/ldap_add_ext.phpt
@@ -41,7 +41,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 ldap_delete($link, "o=test_ldap_add_ext,$base");
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(0)

--- a/ext/ldap/tests/ldap_bind_ext.phpt
+++ b/ext/ldap/tests/ldap_bind_ext.phpt
@@ -44,28 +44,28 @@ var_dump(
 );
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(0)
 string(0) ""
 array(0) {
 }
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(0)
 string(0) ""
 array(0) {
 }
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(49)
 string(0) ""
 array(0) {
 }
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(34)

--- a/ext/ldap/tests/ldap_connect_basic.phpt
+++ b/ext/ldap/tests/ldap_connect_basic.phpt
@@ -13,5 +13,5 @@ $link = ldap_connect($host, $port);
 var_dump($link);
 ?>
 --EXPECTF--
-object(LDAP)#%d (0) {
+object(LDAP\LDAP)#%d (0) {
 }

--- a/ext/ldap/tests/ldap_connect_basic.phpt
+++ b/ext/ldap/tests/ldap_connect_basic.phpt
@@ -13,5 +13,5 @@ $link = ldap_connect($host, $port);
 var_dump($link);
 ?>
 --EXPECTF--
-object(LDAP\LDAP)#%d (0) {
+object(LDAP\Connection)#%d (0) {
 }

--- a/ext/ldap/tests/ldap_connect_variation.phpt
+++ b/ext/ldap/tests/ldap_connect_variation.phpt
@@ -30,13 +30,13 @@ $link = ldap_connect("nonexistent" . $host);
 var_dump($link);
 ?>
 --EXPECTF--
-object(LDAP)#%d (0) {
+object(LDAP\LDAP)#%d (0) {
 }
-object(LDAP)#%d (0) {
+object(LDAP\LDAP)#%d (0) {
 }
-object(LDAP)#%d (0) {
+object(LDAP\LDAP)#%d (0) {
 }
-object(LDAP)#%d (0) {
+object(LDAP\LDAP)#%d (0) {
 }
-object(LDAP)#%d (0) {
+object(LDAP\LDAP)#%d (0) {
 }

--- a/ext/ldap/tests/ldap_connect_variation.phpt
+++ b/ext/ldap/tests/ldap_connect_variation.phpt
@@ -30,13 +30,13 @@ $link = ldap_connect("nonexistent" . $host);
 var_dump($link);
 ?>
 --EXPECTF--
-object(LDAP\LDAP)#%d (0) {
+object(LDAP\Connection)#%d (0) {
 }
-object(LDAP\LDAP)#%d (0) {
+object(LDAP\Connection)#%d (0) {
 }
-object(LDAP\LDAP)#%d (0) {
+object(LDAP\Connection)#%d (0) {
 }
-object(LDAP\LDAP)#%d (0) {
+object(LDAP\Connection)#%d (0) {
 }
-object(LDAP\LDAP)#%d (0) {
+object(LDAP\Connection)#%d (0) {
 }

--- a/ext/ldap/tests/ldap_constructor.phpt
+++ b/ext/ldap/tests/ldap_constructor.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Attempt to instantiate an LDAP\Connection directly
+--EXTENSIONS--
+ldap
+--FILE--
+<?php
+
+try {
+    new LDAP\Connection();
+} catch (Error $ex) {
+    echo "Exception: ", $ex->getMessage(), "\n";
+}
+--EXPECT--
+Exception: Cannot directly construct LDAP\Connection, use ldap_create() instead

--- a/ext/ldap/tests/ldap_controls.phpt
+++ b/ext/ldap/tests/ldap_controls.phpt
@@ -65,7 +65,7 @@ Warning: ldap_modify(): Modify: Assertion Failed in %s on line %d
 Warning: ldap_delete(): Delete: Assertion Failed in %s on line %d
 
 Warning: ldap_compare(): Compare: Assertion Failed in %s on line %d
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>
@@ -89,7 +89,7 @@ array(2) {
 }
 bool(false)
 bool(true)
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>
@@ -112,7 +112,7 @@ array(2) {
   }
 }
 bool(false)
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>
@@ -141,7 +141,7 @@ bool(false)
 bool(true)
 int(-1)
 bool(true)
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(4) {
   ["count"]=>
@@ -153,7 +153,7 @@ array(4) {
   [2]=>
   string(10) "Antarctica"
 }
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(3) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_delete_ext.phpt
+++ b/ext/ldap/tests/ldap_delete_ext.phpt
@@ -43,7 +43,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 ldap_delete($link, "dc=my-domain,$base");
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(0)

--- a/ext/ldap/tests/ldap_exop.phpt
+++ b/ext/ldap/tests/ldap_exop.phpt
@@ -67,12 +67,12 @@ string(%d) "dn:%s"
 string(0) ""
 bool(true)
 string(%d) "dn:cn=user%s"
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 string(%d) "dn:%s"
 bool(true)
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 string(%d) "%s"

--- a/ext/ldap/tests/ldap_first_attribute_error.phpt
+++ b/ext/ldap/tests/ldap_first_attribute_error.phpt
@@ -17,4 +17,4 @@ try {
 }
 ?>
 --EXPECT--
-ldap_first_attribute(): Argument #2 ($entry) must be of type LDAP\ResultEntry, LDAP\LDAP given
+ldap_first_attribute(): Argument #2 ($entry) must be of type LDAP\ResultEntry, LDAP\Connection given

--- a/ext/ldap/tests/ldap_first_attribute_error.phpt
+++ b/ext/ldap/tests/ldap_first_attribute_error.phpt
@@ -17,4 +17,4 @@ try {
 }
 ?>
 --EXPECT--
-ldap_first_attribute(): Argument #2 ($entry) must be of type LDAPResultEntry, LDAP given
+ldap_first_attribute(): Argument #2 ($entry) must be of type LDAP\ResultEntry, LDAP\LDAP given

--- a/ext/ldap/tests/ldap_first_entry_basic.phpt
+++ b/ext/ldap/tests/ldap_first_entry_basic.phpt
@@ -26,7 +26,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResultEntry)#%d (0) {
+object(LDAP\ResultEntry)#%d (0) {
 }
 array(2) {
   [0]=>

--- a/ext/ldap/tests/ldap_first_reference_basic.phpt
+++ b/ext/ldap/tests/ldap_first_reference_basic.phpt
@@ -33,7 +33,7 @@ ldap_delete($link, "cn=userref,$base", [['oid' => LDAP_CONTROL_MANAGEDSAIT, 'isc
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResultEntry)#%d (0) {
+object(LDAP\ResultEntry)#%d (0) {
 }
 array(1) {
   [0]=>

--- a/ext/ldap/tests/ldap_get_option_controls.phpt
+++ b/ext/ldap/tests/ldap_get_option_controls.phpt
@@ -104,7 +104,7 @@ array(1) {
     }
   }
 }
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 int(1)
 bool(true)

--- a/ext/ldap/tests/ldap_list_basic.phpt
+++ b/ext/ldap/tests/ldap_list_basic.phpt
@@ -28,7 +28,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(3) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_mod_ext.phpt
+++ b/ext/ldap/tests/ldap_mod_ext.phpt
@@ -62,7 +62,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(0)
@@ -134,7 +134,7 @@ array(2) {
     string(%d) "o=test,%s"
   }
 }
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(0)

--- a/ext/ldap/tests/ldap_next_entry_basic.phpt
+++ b/ext/ldap/tests/ldap_next_entry_basic.phpt
@@ -28,7 +28,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResultEntry)#%d (0) {
+object(LDAP\ResultEntry)#%d (0) {
 }
 array(2) {
   [0]=>

--- a/ext/ldap/tests/ldap_next_reference_basic.phpt
+++ b/ext/ldap/tests/ldap_next_reference_basic.phpt
@@ -39,7 +39,7 @@ ldap_delete($link, "cn=userref2,$base", [['oid' => LDAP_CONTROL_MANAGEDSAIT, 'is
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResultEntry)#%d (0) {
+object(LDAP\ResultEntry)#%d (0) {
 }
 array(1) {
   [0]=>

--- a/ext/ldap/tests/ldap_parse_result_controls.phpt
+++ b/ext/ldap/tests/ldap_parse_result_controls.phpt
@@ -36,7 +36,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 string(22) "1.2.840.113556.1.4.319"

--- a/ext/ldap/tests/ldap_read_basic.phpt
+++ b/ext/ldap/tests/ldap_read_basic.phpt
@@ -28,7 +28,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_rename_ext.phpt
+++ b/ext/ldap/tests/ldap_rename_ext.phpt
@@ -42,7 +42,7 @@ ldap_rename($link, "cn=userZ,$base", "cn=userA", "$base", true);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 bool(true)
 int(0)

--- a/ext/ldap/tests/ldap_search_basic.phpt
+++ b/ext/ldap/tests/ldap_search_basic.phpt
@@ -29,7 +29,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(4) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_overrides.phpt
+++ b/ext/ldap/tests/ldap_search_overrides.phpt
@@ -42,7 +42,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(4) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_paged_result_controls.phpt
+++ b/ext/ldap/tests/ldap_search_paged_result_controls.phpt
@@ -36,7 +36,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(3) {
   ["count"]=>
@@ -75,7 +75,7 @@ array(3) {
   }
 }
 bool(true)
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_sort_controls.phpt
+++ b/ext/ldap/tests/ldap_search_sort_controls.phpt
@@ -78,7 +78,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(4) {
   ["count"]=>
@@ -147,7 +147,7 @@ array(1) {
     }
   }
 }
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(3) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_variation1.phpt
+++ b/ext/ldap/tests/ldap_search_variation1.phpt
@@ -31,7 +31,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_variation2.phpt
+++ b/ext/ldap/tests/ldap_search_variation2.phpt
@@ -29,7 +29,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(4) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_variation3.phpt
+++ b/ext/ldap/tests/ldap_search_variation3.phpt
@@ -36,7 +36,7 @@ $link = ldap_connect_and_bind($host, $port, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(4) {
   ["count"]=>
@@ -86,7 +86,7 @@ array(4) {
 }
 
 Warning: ldap_search(): Partial search results returned: Sizelimit exceeded in %s on line %d
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_variation4.phpt
+++ b/ext/ldap/tests/ldap_search_variation4.phpt
@@ -32,7 +32,7 @@ remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
 Warning: ldap_search(): Partial search results returned: Sizelimit exceeded in %s on line %d
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_variation5.phpt
+++ b/ext/ldap/tests/ldap_search_variation5.phpt
@@ -40,7 +40,7 @@ remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
 Warning: ldap_search(): Partial search results returned: Sizelimit exceeded in %s on line %d
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>
@@ -62,7 +62,7 @@ array(2) {
 }
 
 Warning: ldap_search(): Partial search results returned: Sizelimit exceeded in %s on line %d
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>
@@ -84,7 +84,7 @@ array(2) {
 }
 
 Warning: ldap_search(): Partial search results returned: Sizelimit exceeded in %s on line %d
-object(LDAPResult)#%d (0) {
+object(LDAP\Result)#%d (0) {
 }
 array(2) {
   ["count"]=>

--- a/ext/ldap/tests/ldap_search_variation6.phpt
+++ b/ext/ldap/tests/ldap_search_variation6.phpt
@@ -45,10 +45,10 @@ remove_dummy_data($link, $base);
 --EXPECTF--
 array(2) {
   [0]=>
-  object(LDAPResult)#%d (0) {
+  object(LDAP\Result)#%d (0) {
   }
   [1]=>
-  object(LDAPResult)#%d (0) {
+  object(LDAP\Result)#%d (0) {
   }
 }
 array(4) {
@@ -214,10 +214,10 @@ array(4) {
 bool(true)
 array(2) {
   [0]=>
-  object(LDAPResult)#%d (0) {
+  object(LDAP\Result)#%d (0) {
   }
   [1]=>
-  object(LDAPResult)#%d (0) {
+  object(LDAP\Result)#%d (0) {
   }
 }
 array(1) {
@@ -230,10 +230,10 @@ array(1) {
 }
 array(2) {
   [0]=>
-  object(LDAPResult)#%d (0) {
+  object(LDAP\Result)#%d (0) {
   }
   [1]=>
-  object(LDAPResult)#%d (0) {
+  object(LDAP\Result)#%d (0) {
   }
 }
 array(1) {


### PR DESCRIPTION
Another change as per accepted [namespaces in bundled extensions RFC](https://wiki.php.net/rfc/namespaces_in_bundled_extensions).

Related: #6925, #5945, #6960