### PR TITLE
Add ASan support for MSVC

### DIFF
--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -55,7 +55,7 @@
 # endif
 #endif
 
-#ifdef __SANITIZE_ADDRESS__
+#if defined(__SANITIZE_ADDRESS__) && !defined(_MSC_VER)
 # include <sanitizer/common_interface_defs.h>
 #endif
 

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -48,7 +48,7 @@
 /* needed for ssize_t definition */
 #include <sys/types.h>
 
-#ifdef __SANITIZE_ADDRESS__
+#if defined(__SANITIZE_ADDRESS__) && !defined(_MSC_VER)
 # include <sanitizer/asan_interface.h>
 #endif
 

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3093,7 +3093,7 @@ static int accel_startup(zend_extension *extension)
 #endif
 
 #ifdef ZEND_WIN32
-# if !defined(__has_feature) || !__has_feature(address_sanitizer)
+# ifndef __SANITIZE_ADDRESS__
 	_setmaxstdio(2048); /* The default configuration is limited to 512 stdio files */
 # endif
 #endif

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -1241,6 +1241,8 @@ function SAPI(sapiname, file_list, makefiletarget, cflags, obj_dir)
 	if (PHP_SANITIZER == "yes") {
 		if (CLANG_TOOLSET) {
 			add_asan_opts("CFLAGS_" + SAPI, "LIBS_" + SAPI, (is_lib ? "ARFLAGS_" : "LDFLAGS_") + SAPI);
+		} else if (VS_TOOLSET) {
+			ADD_FLAG("CFLAGS", "/fsanitize=address");
 		}
 	}
 


### PR DESCRIPTION
As of VS 16.9, there is native support for ASan in the MSVC toolchain.
Although it is already possible to enable that by adding the respective
option to `CFLAGS`, we make it available via the configure option
`--enable-sanitizer` which is only used for clang builds on Windows so
far.

We also disable the manual inclusion of ASan headers, since these are
available by default.  We use the more general `__SANITIZE_ADDRESS__`
for detection of ASan, to avoid a bogus warning, when `_setmaxstdio()`
is called.

---

TODO:
- [ ] fix configure help message
- [ ] enable for CI (nightly)?