### PR TITLE
Fix #44643: bound parameters ignore explicit type definitions

### DIFF
--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -323,9 +323,16 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 				if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
 					/* MS Access, for instance, doesn't support SQLDescribeParam,
 					 * so we need to guess */
-					sqltype = PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_LOB ?
-									SQL_LONGVARBINARY :
-									SQL_LONGVARCHAR;
+					switch (PDO_PARAM_TYPE(param->param_type)) {
+						case PDO_PARAM_INT:
+							sqltype = SQL_INTEGER;
+							break;
+						case PDO_PARAM_LOB:
+							sqltype = SQL_LONGVARBINARY;
+							break;
+						default:
+							sqltype = SQL_LONGVARCHAR;
+					}
 					precision = 4000;
 					scale = 5;
 					nullable = 1;

--- a/ext/pdo_odbc/tests/bug44643.phpt
+++ b/ext/pdo_odbc/tests/bug44643.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug #44643 (bound parameters ignore explicit type definitions)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_odbc')) die('skip pdo_odbc extension not available');
+require 'ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require 'ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+$sql = "SELECT * FROM (SELECT 'test' = :id1) a WHERE a.test = :id2";
+$stmt = $db->prepare($sql);
+$id1 = 1;
+$stmt->bindParam(':id1', $id1, PDO::PARAM_INT);
+$id2 = 1;
+$stmt->bindParam(':id2', $id2, PDO::PARAM_INT);
+var_dump($stmt->execute());
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
If `SQLDescribeParam()` fails for a parameter, we must not assume
`SQL_LONGVARCHAR` for any param which is not `PDO_PARAM_LOB`.  At least
mapping `PDO_PARAM_INT` to `SQL_INTEGER` should be safe, and not
introduce a BC break.