### PR TITLE
Fix bundled libgd includes

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -57,13 +57,13 @@
 
 #include "gd_compat.h"
 
-#include <gd.h>
-#include <gd_errors.h>
-#include <gdfontt.h>  /* 1 Tiny font */
-#include <gdfonts.h>  /* 2 Small font */
-#include <gdfontmb.h> /* 3 Medium bold font */
-#include <gdfontl.h>  /* 4 Large font */
-#include <gdfontg.h>  /* 5 Giant font */
+#include "libgd/gd.h"
+#include "libgd/gd_errors.h"
+#include "libgd/gdfontt.h"  /* 1 Tiny font */
+#include "libgd/gdfonts.h"  /* 2 Small font */
+#include "libgd/gdfontmb.h" /* 3 Medium bold font */
+#include "libgd/gdfontl.h"  /* 4 Large font */
+#include "libgd/gdfontg.h"  /* 5 Giant font */
 
 #if defined(HAVE_GD_FREETYPE) && defined(HAVE_GD_BUNDLED)
 # include <ft2build.h>

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -57,13 +57,23 @@
 
 #include "gd_compat.h"
 
-#include "libgd/gd.h"
-#include "libgd/gd_errors.h"
-#include "libgd/gdfontt.h"  /* 1 Tiny font */
-#include "libgd/gdfonts.h"  /* 2 Small font */
-#include "libgd/gdfontmb.h" /* 3 Medium bold font */
-#include "libgd/gdfontl.h"  /* 4 Large font */
-#include "libgd/gdfontg.h"  /* 5 Giant font */
+#ifdef HAVE_GD_BUNDLED
+# include "libgd/gd.h"
+# include "libgd/gd_errors.h"
+# include "libgd/gdfontt.h"  /* 1 Tiny font */
+# include "libgd/gdfonts.h"  /* 2 Small font */
+# include "libgd/gdfontmb.h" /* 3 Medium bold font */
+# include "libgd/gdfontl.h"  /* 4 Large font */
+# include "libgd/gdfontg.h"  /* 5 Giant font */
+#else
+# include <gd.h>
+# include <gd_errors.h>
+# include <gdfontt.h>  /* 1 Tiny font */
+# include <gdfonts.h>  /* 2 Small font */
+# include <gdfontmb.h> /* 3 Medium bold font */
+# include <gdfontl.h>  /* 4 Large font */
+# include <gdfontg.h>  /* 5 Giant font */
+#endif
 
 #if defined(HAVE_GD_FREETYPE) && defined(HAVE_GD_BUNDLED)
 # include <ft2build.h>

--- a/ext/gd/libgd/gd_crop.c
+++ b/ext/gd/libgd/gd_crop.c
@@ -19,10 +19,11 @@
  *  (end code)
  **/
 
-#include <gd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+
+#include "gd.h"
 
 static int gdGuessBackgroundColorFromCorners(gdImagePtr im, int *color);
 static int gdColorMatch(gdImagePtr im, int col1, int col2, float threshold);

--- a/ext/gd/libgd/gd_interpolation.c
+++ b/ext/gd/libgd/gd_interpolation.c
@@ -58,7 +58,7 @@ TODO:
 #include <string.h>
 #include <math.h>
 
-#include <gd.h>
+#include "gd.h"
 #include "gdhelpers.h"
 
 #ifdef _MSC_VER

--- a/ext/gd/libgd/gd_wbmp.c
+++ b/ext/gd/libgd/gd_wbmp.c
@@ -51,13 +51,13 @@
    ----------------------------------------------------------------------------
  */
 
-#include <gd.h>
-#include <gdfonts.h>
-#include <gd_errors.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
 
+#include "gd.h"
+#include "gdfonts.h"
+#include "gd_errors.h"
 #include "wbmp.h"
 
 


### PR DESCRIPTION
This PR replaces the bundled libgd includes from `#include <foo.h>` with `#include "foo.h"` for gd-related headers to avoid including headers that may be available in system directories instead of the expected local headers.

Fixes https://bugs.php.net/bug.php?id=81032