### PR TITLE
Refactor definition of ZEND_MM_ALIGNMENT

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -256,7 +256,7 @@ typedef union _mm_align_test {
 
 int main()
 {
-  int i = ZEND_MM_ALIGNMENT;
+  size_t i = ZEND_MM_ALIGNMENT;
   int zeros = 0;
   FILE *fp;
 
@@ -266,7 +266,7 @@ int main()
   }
 
   fp = fopen("conftest.zend", "w");
-  fprintf(fp, "%d %d\n", ZEND_MM_ALIGNMENT, zeros);
+  fprintf(fp, "(size_t)%zu (size_t)%d %d\n", ZEND_MM_ALIGNMENT, zeros, ZEND_MM_ALIGNMENT < 4);
   fclose(fp);
 
   return 0;
@@ -274,12 +274,15 @@ int main()
 ]])], [
   LIBZEND_MM_ALIGN=`cat conftest.zend | cut -d ' ' -f 1`
   LIBZEND_MM_ALIGN_LOG2=`cat conftest.zend | cut -d ' ' -f 2`
+  LIBZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT=`cat conftest.zend | cut -d ' ' -f 3`
   AC_DEFINE_UNQUOTED(ZEND_MM_ALIGNMENT, $LIBZEND_MM_ALIGN, [ ])
   AC_DEFINE_UNQUOTED(ZEND_MM_ALIGNMENT_LOG2, $LIBZEND_MM_ALIGN_LOG2, [ ])
+  AC_DEFINE_UNQUOTED(ZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT, $LIBZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT, [ ])
 ], [], [
   dnl Cross compilation needs something here.
-  AC_DEFINE_UNQUOTED(ZEND_MM_ALIGNMENT, 8, [ ])
-  AC_DEFINE_UNQUOTED(ZEND_MM_ALIGNMENT_LOG2, 3, [ ])
+  AC_DEFINE(ZEND_MM_ALIGNMENT, 8, [ ])
+  AC_DEFINE(ZEND_MM_ALIGNMENT_LOG2, 3, [ ])
+  AC_DEFINE(ZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT, 0, [ ])
 ])
 
 AC_MSG_RESULT(done)

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -27,13 +27,7 @@
 #include "zend.h"
 
 #ifndef ZEND_MM_ALIGNMENT
-# define ZEND_MM_ALIGNMENT Z_UL(8)
-# define ZEND_MM_ALIGNMENT_LOG2 Z_L(3)
-#elif ZEND_MM_ALIGNMENT < 4
-# undef ZEND_MM_ALIGNMENT
-# undef ZEND_MM_ALIGNMENT_LOG2
-# define ZEND_MM_ALIGNMENT Z_UL(4)
-# define ZEND_MM_ALIGNMENT_LOG2 Z_L(2)
+# error "ZENF_MM_ALIGNMENT was not defined during configure"
 #endif
 
 #define ZEND_MM_ALIGNMENT_MASK ~(ZEND_MM_ALIGNMENT - 1)

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -27,7 +27,7 @@
 #include "zend.h"
 
 #ifndef ZEND_MM_ALIGNMENT
-# error "ZENF_MM_ALIGNMENT was not defined during configure"
+# error "ZEND_MM_ALIGNMENT was not defined during configure"
 #endif
 
 #define ZEND_MM_ALIGNMENT_MASK ~(ZEND_MM_ALIGNMENT - 1)

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1484,7 +1484,7 @@ static zend_persistent_script *store_script_in_file_cache(zend_persistent_script
 	/* Align to 64-byte boundary */
 	ZCG(mem) = zend_arena_alloc(&CG(arena), memory_used + 64);
 	ZCG(mem) = (void*)(((zend_uintptr_t)ZCG(mem) + 63L) & ~63L);
-#elif ZEND_MM_ALIGNMENT < 8
+#elif ZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT
 	/* Align to 8-byte boundary */
 	ZCG(mem) = zend_arena_alloc(&CG(arena), memory_used + 8);
 	ZCG(mem) = (void*)(((zend_uintptr_t)ZCG(mem) + 7L) & ~7L);
@@ -2365,7 +2365,7 @@ static zend_class_entry* zend_accel_inheritance_cache_add(zend_class_entry *ce, 
 
 	zend_shared_alloc_clear_xlat_table();
 
-#if ZEND_MM_ALIGNMENT < 8
+#if ZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT
 	/* Align to 8-byte boundary */
 	ZCG(mem) = zend_shared_alloc(size + 8);
 #else
@@ -2381,7 +2381,7 @@ static zend_class_entry* zend_accel_inheritance_cache_add(zend_class_entry *ce, 
 
 	zend_map_ptr_extend(ZCSG(map_ptr_last));
 
-#if ZEND_MM_ALIGNMENT < 8
+#if ZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT
 	/* Align to 8-byte boundary */
 	ZCG(mem) = (void*)(((zend_uintptr_t)ZCG(mem) + 7L) & ~7L);
 #endif

--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -27,6 +27,10 @@
 #define DEFAULT_SHORT_OPEN_TAG "1"
 
 /* Platform-Specific Configuration. Should not be changed. */
+/* Alignment for Zend memory allocator */
+#define ZEND_MM_ALIGNMENT (size_t)8
+#define ZEND_MM_ALIGNMENT_LOG2 (size_t)3
+#define ZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT 0
 #define PHP_SIGCHILD 0
 #define HAVE_GETSERVBYNAME 1
 #define HAVE_GETSERVBYPORT 1


### PR DESCRIPTION
Currently ZEND_MM_ALIGNMENT might get defined during config,
in which case it is an 'int' and not a 'zend_ulong'.

This fixes many [-Wsign-conversion] warnings.

Co-authored-by: Guillaume Charifi <guillaume.charifi@sfr.fr>