### PR TITLE
Update futcsv and fgetcsv stubs

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -851,10 +851,10 @@ function unlink(string $filename, $context = null): bool {}
 function file_put_contents(string $filename, mixed $data, int $flags = 0, $context = null): int|false {}
 
 /** @param resource $stream */
-function fputcsv($stream, array $fields, string $separator = ",", string $enclosure = "\"", string $escape = "\\"): int|false {}
+function fputcsv($stream, array $fields, string $delimiter = ",", string $enclosure = "\"", string $escape = "\\"): int|false {}
 
 /** @param resource $stream */
-function fgetcsv($stream, ?int $length = null, string $separator = ",", string $enclosure = "\"", string $escape = "\\"): array|false {}
+function fgetcsv($stream, ?int $length = null, string $delimiter = ",", string $enclosure = "\"", string $escape = "\\"): array|false {}
 
 function realpath(string $path): string|false {}
 


### PR DESCRIPTION
@cmb69 pointed me here: https://github.com/php/doc-en/pull/606#issuecomment-843089325

If I interpret https://github.com/php/php-src/blob/ac47162add6fa529836467929e7bcf20025638b7/ext/standard/file.c#L1985 correctly the name is delimiter not seperator. 

See also: https://github.com/php/doc-en/pull/606#issuecomment-843092007

Update:

https://3v4l.org/64Kch