### PR TITLE
Remove randominess from spl_object_hash

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -657,18 +657,7 @@ PHP_FUNCTION(spl_object_id)
 
 PHPAPI zend_string *php_spl_object_hash(zend_object *obj) /* {{{*/
 {
-	intptr_t hash_handle, hash_handlers;
-
-	if (!SPL_G(hash_mask_init)) {
-		SPL_G(hash_mask_handle)   = (intptr_t)(php_mt_rand() >> 1);
-		SPL_G(hash_mask_handlers) = (intptr_t)(php_mt_rand() >> 1);
-		SPL_G(hash_mask_init) = 1;
-	}
-
-	hash_handle   = SPL_G(hash_mask_handle)^(intptr_t)obj->handle;
-	hash_handlers = SPL_G(hash_mask_handlers);
-
-	return strpprintf(32, "%016zx%016zx", hash_handle, hash_handlers);
+	return strpprintf(32, "%016zx0000000000000000", (intptr_t)obj->handle);
 }
 /* }}} */
 
@@ -736,7 +725,6 @@ PHP_RINIT_FUNCTION(spl) /* {{{ */
 {
 	SPL_G(autoload_extensions) = NULL;
 	SPL_G(autoload_functions) = NULL;
-	SPL_G(hash_mask_init) = 0;
 	return SUCCESS;
 } /* }}} */
 
@@ -750,9 +738,6 @@ PHP_RSHUTDOWN_FUNCTION(spl) /* {{{ */
 		zend_hash_destroy(SPL_G(autoload_functions));
 		FREE_HASHTABLE(SPL_G(autoload_functions));
 		SPL_G(autoload_functions) = NULL;
-	}
-	if (SPL_G(hash_mask_init)) {
-		SPL_G(hash_mask_init) = 0;
 	}
 	return SUCCESS;
 } /* }}} */

--- a/ext/spl/php_spl.h
+++ b/ext/spl/php_spl.h
@@ -54,9 +54,6 @@ PHP_MINFO_FUNCTION(spl);
 ZEND_BEGIN_MODULE_GLOBALS(spl)
 	zend_string *autoload_extensions;
 	HashTable   *autoload_functions;
-	intptr_t     hash_mask_handle;
-	intptr_t     hash_mask_handlers;
-	int          hash_mask_init;
 ZEND_END_MODULE_GLOBALS(spl)
 
 ZEND_EXTERN_MODULE_GLOBALS(spl)


### PR DESCRIPTION
see https://3v4l.org/b4Z1G and https://github.com/php/php-src/blob/php-8.0.6/ext/spl/php_spl.c#L644-L670

related with https://github.com/php/php-src/pull/2611

Unneeded randominess is not good as output of repeated runs of php scripts can differ.

I think `spl_object_hash` should be even deprecated in favor of `spl_object_id`.