### PR TITLE
Fix #81048: phpinfo(INFO_VARIABLES) "Array to string conversion"

### DIFF
--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -202,6 +202,9 @@ static ZEND_COLD void php_print_gpcse_array(char *name, uint32_t name_length)
 			} else {
 				php_info_print(" => ");
 			}
+			if (Z_TYPE_P(tmp) == IS_REFERENCE) {
+				ZVAL_DEREF(tmp);
+			}
 			if (Z_TYPE_P(tmp) == IS_ARRAY) {
 				if (!sapi_module.phpinfo_as_text) {
 					zend_string *str = zend_print_zval_r_to_str(tmp, 0);

--- a/ext/standard/tests/bug81048.phpt
+++ b/ext/standard/tests/bug81048.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #81048 (phpinfo(INFO_VARIABLES) "Array to string conversion")
+--FILE--
+<?php
+
+$_ENV = [];
+$_SERVER = ['foo' => ['bar' => ['baz' => 'qux']]];
+
+array_walk_recursive($_SERVER, function($value, $key) {
+    // NOP
+});
+
+phpinfo(INFO_VARIABLES);
+?>
+--EXPECT--
+phpinfo()
+
+PHP Variables
+
+Variable => Value
+$_SERVER['foo'] => Array
+(
+    [bar] => Array
+        (
+            [baz] => qux
+        )
+
+)


### PR DESCRIPTION
Now that we properly dereference references of the superglobals. we
also need to dereference contained references to avoid to string
conversion.