### PR TITLE
Fix handling of open_basedir that contains cwd

### DIFF
--- a/ext/standard/tests/file/open_basedir_cwd_resolve.phpt
+++ b/ext/standard/tests/file/open_basedir_cwd_resolve.phpt
@@ -1,0 +1,15 @@
+--TEST--
+CWD on open_basedir should not imply that everything is accessible
+--FILE--
+<?php
+
+$cwd = getcwd();
+ini_set('open_basedir', $cwd);
+var_dump(file_get_contents('/some/path/outside/open/basedir'));
+
+?>
+--EXPECTF--
+Warning: file_get_contents(): open_basedir restriction in effect. File(/some/path/outside/open/basedir) is not within the allowed path(s): (%s) in %s on line %d
+
+Warning: file_get_contents(/some/path/outside/open/basedir): Failed to open stream: Operation not permitted in %s on line %d
+bool(false)

--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -198,6 +198,10 @@ PHPAPI int php_check_specific_open_basedir(const char *basedir, const char *path
 			path_tmp[path_len - 1] = '\0';
 #endif
 		}
+		if (*path_tmp == '\0') {
+			/* Do not pass an empty string to realpath(), as this will resolve to CWD. */
+			break;
+		}
 		nesting_level++;
 	}
 


### PR DESCRIPTION
While resolving the path, the last step will reduce it down to ""
(an empty string) and realpath() will resolve this to getcwd().
If open_basedir contains the CWD, then that means open_basedir
will be bypassed for paths that don't have any components that
exist (if one of the components exists, then we abort the realpath
loop at that point).