### PR TITLE
Add support for testing with Graviton2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,12 @@ jobs:
         - env: ENABLE_ZTS=1 ENABLE_DEBUG=1 SKIP_IO_CAPTURE_TESTS=1 ARM64=1
           arch: arm64
           if: type = cron
+        - env: ENABLE_ZTS=1 ENABLE_DEBUG=1 SKIP_IO_CAPTURE_TESTS=1 ARM64=1
+          arch: arm64-graviton2
+          dist: bionic
+          virt: lxd
+          group: edge
+          if: type = cron
         - env: ENABLE_ZTS=1 ENABLE_DEBUG=1 SKIP_IO_CAPTURE_TESTS=1 S390X=1
           arch: s390x
           if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,6 @@ env:
 jobs:
     include:
         - env: ENABLE_ZTS=1 ENABLE_DEBUG=1 SKIP_IO_CAPTURE_TESTS=1 ARM64=1
-          arch: arm64
-          if: type = cron
-        - env: ENABLE_ZTS=1 ENABLE_DEBUG=1 SKIP_IO_CAPTURE_TESTS=1 ARM64=1
           arch: arm64-graviton2
           dist: bionic
           virt: lxd


### PR DESCRIPTION
Travis CI supports running on AWS Graviton2 instances. For more information please see: https://blog.travis-ci.com/2020-09-11-arm-on-aws

Travis CI build logs for arm64 and arm64-graviton2: https://travis-ci.com/github/janaknat/php-src/builds/226356460