### PR TITLE
Detect musl libc to not set tls_model attribute on that platform

### DIFF
--- a/TSRM/TSRM.h
+++ b/TSRM/TSRM.h
@@ -147,7 +147,7 @@ TSRM_API const char *tsrm_api_name(void);
 # define __has_attribute(x) 0
 #endif
 
-#if !__has_attribute(tls_model) || defined(__FreeBSD__)
+#if !__has_attribute(tls_model) || defined(__FreeBSD__) || defined(__MUSL__)
 # define TSRM_TLS_MODEL_ATTR
 #elif __PIC__
 # define TSRM_TLS_MODEL_ATTR __attribute__((tls_model("initial-exec")))

--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,17 @@ case $host_alias in
     ;;
 esac
 
+dnl Detect musl libc
+AC_MSG_CHECKING([whether we are using musl libc])
+if command -v ldd >/dev/null && ldd --version 2>&1 | grep -q ^musl
+then
+  AC_MSG_RESULT(yes)
+  CPPFLAGS="$CPPFLAGS -D__MUSL__"
+else
+  AC_MSG_RESULT(no)
+fi
+
+
 dnl Include Zend configurations.
 dnl ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This fixes:
``_tsrm_ls_cache: initial-exec TLS resolves to dynamic definition``
in shared extensions.