### PR TITLE
Add mysqli.rollback_on_cached_plink to php.ini-*

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1189,6 +1189,11 @@ mysqli.default_pw =
 ; Allow or prevent reconnect
 mysqli.reconnect = Off
 
+; If this option is enabled, closing a persistent connection will rollback
+; any pending transactions of this connection, before it is put back
+; into the persistent connection pool.
+;mysqli.rollback_on_cached_plink = Off
+
 [mysqlnd]
 ; Enable / Disable collection of general statistics by mysqlnd which can be
 ; used to tune and monitor MySQL operations.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1191,6 +1191,11 @@ mysqli.default_pw =
 ; Allow or prevent reconnect
 mysqli.reconnect = Off
 
+; If this option is enabled, closing a persistent connection will rollback
+; any pending transactions of this connection, before it is put back
+; into the persistent connection pool.
+;mysqli.rollback_on_cached_plink = Off
+
 [mysqlnd]
 ; Enable / Disable collection of general statistics by mysqlnd which can be
 ; used to tune and monitor MySQL operations.


### PR DESCRIPTION
This PR adds the entry of `mysqli.rollback-on-cached-plink`.
https://www.php.net/manual/en/mysqli.configuration.php#ini.mysqli.rollback-on-cached-plink

In the documentation, the default is described as `"TRUE"`, but in reality it is `"0"`. So I'm raising a PR to fix that separately as well.
https://github.com/php/doc-en/pull/610