### PR TITLE
JIT/AArch64: Fix typo in commit dc0e259

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -1839,7 +1839,7 @@ static int zend_jit_exception_handler_undef_stub(dasm_State **Dst)
 	|	MEM_LOAD_ZTS ldr, REG0, executor_globals, opline_before_exception, REG0
 	|	ldrb TMP1w, OP:REG0->result_type
 	|	TST_32_WITH_CONST TMP1w, (IS_TMP_VAR|IS_VAR), TMP2w
-	|	be >1
+	|	beq >1
 	|	ldr REG0w, OP:REG0->result.var
 	|	add REG0, REG0, FP
 	|	SET_Z_TYPE_INFO REG0, IS_UNDEF, TMP1w


### PR DESCRIPTION
PHP JIT/AArch64 building is broken. Instruction "beq" should be used.

Change-Id: I16c00f87bafb3a565141e1e02c9e15653f39a276