### PR TITLE
JIT/AArch64: [macos] Fix arguments to variadic function

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -1981,6 +1981,10 @@ static int zend_jit_undefined_offset_ex_stub(dasm_State **Dst)
 static int zend_jit_undefined_offset_stub(dasm_State **Dst)
 {
 	|->undefined_offset:
+#ifdef __APPLE__
+	|	stp x29, x30, [sp, # -16]!
+	|	mov x29, sp
+#endif
 	|	//sub r4, 8
 	|	ldr REG0, EX->opline
 	|	ldr REG1w, OP:REG0->result.var
@@ -1999,9 +2003,17 @@ static int zend_jit_undefined_offset_stub(dasm_State **Dst)
 	|	mov CARG1, #E_WARNING
 	|	LOAD_ADDR CARG2, "Undefined array key " ZEND_LONG_FMT
 	|	ldr CARG3, [REG0]
+#ifdef __APPLE__
+	|	str CARG3, [sp, #-16]!
+	|	EXT_CALL zend_error, REG0
+	|	add sp, sp, #16
+	|	ldp x29, x30, [sp], #16
+	|	ret
+#else
 	|	EXT_JMP zend_error, REG0 // tail call
 	|	//add r4, 8 // stack alignment
 	|	//ret
+#endif
 
 	return 1;
 }
@@ -2018,6 +2030,10 @@ static int zend_jit_undefined_index_ex_stub(dasm_State **Dst)
 static int zend_jit_undefined_index_stub(dasm_State **Dst)
 {
 	|->undefined_index:
+#ifdef __APPLE__
+	|	stp x29, x30, [sp, # -16]!
+	|	mov x29, sp
+#endif
 	|	//sub r4, 8
 	|	ldr REG0, EX->opline
 	|	ldr REG1w, OP:REG0->result.var
@@ -2037,9 +2053,17 @@ static int zend_jit_undefined_index_stub(dasm_State **Dst)
 	|	LOAD_ADDR CARG2, "Undefined array key \"%s\""
 	|	ldr CARG3, [REG0]
 	|	add CARG3, CARG3, #offsetof(zend_string, val)
-	|	EXT_JMP zend_error,REG0 // tail call
+#ifdef __APPLE__
+	|	str CARG3, [sp, #-16]!
+	|	EXT_CALL zend_error, REG0
+	|	add sp, sp, #16
+	|	ldp x29, x30, [sp], #16
+	|	ret
+#else
+	|	EXT_JMP zend_error, REG0 // tail call
 	|	//add r4, 8
 	|	//ret
+#endif
 
 	return 1;
 }
@@ -2083,7 +2107,13 @@ static int zend_jit_undefined_function_stub(dasm_State **Dst)
 	|	ldrsw CARG3, [REG0, #offsetof(zend_op, op2.constant)]
 	|	ldr CARG3, [REG0, CARG3]
 	|	add CARG3, CARG3, #offsetof(zend_string, val)
+#ifdef __APPLE__
+	|	str CARG3, [sp, #-16]!
+#endif
 	|	EXT_CALL zend_throw_error, REG0
+#ifdef __APPLE__
+	|	add sp, sp, #16
+#endif
 	|	b ->exception_handler
 	return 1;
 }


### PR DESCRIPTION
zend_throw_error() and zend_error() are variadic functions. In Linux,
arguments are passed in registers, whereas they must be put on stack in
Macos [1][2].

In this patch:
1. preprocessor macro "__APPLE__" is used to distinguish the OS.
2. the third argument "CARG3" is the only variadic argument and put on
stack.
3. the invocation of zend_error() is converted back to regular call in
zend_jit_undefined_offset_stub() and zend_jit_undefined_index_stub().

With this patch, all ~4k test cases can pass for "nonZTS+CALL"
functional/tracing JIT with Macos Apple Silicion.

[1]
https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Overview
[2] https://github.com/below/HelloSilicon#listing-9-1

Change-Id: I49bc3233fc253ad3e77e8664464ff3e830dcd183