### PR TITLE
Fix #76359: open_basedir bypass through adding ".."

### DIFF
--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -110,6 +110,11 @@ PHPAPI ZEND_INI_MH(OnUpdateBaseDir)
 			*end = '\0';
 			end++;
 		}
+		if (ptr[0] == '.' && ptr[1] == '.' && ptr[2] == '\0') {
+			/* Don't allow .. to be set at runtime */
+			efree(pathbuf);
+			return FAILURE;
+		}
 		if (php_check_open_basedir_ex(ptr, 0) != 0) {
 			/* At least one portion of this open_basedir is less restrictive than the prior one, FAIL */
 			efree(pathbuf);

--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -110,8 +110,12 @@ PHPAPI ZEND_INI_MH(OnUpdateBaseDir)
 			*end = '\0';
 			end++;
 		}
-		if (ptr[0] == '.' && ptr[1] == '.' && ptr[2] == '\0') {
-			/* Don't allow .. to be set at runtime */
+#ifndef PHP_WIN32
+		if (ptr[0] == '.' && ptr[1] == '.' && (ptr[2] == '\0' || ptr[2] == DEFAULT_SLASH)) {
+#else
+		if (ptr[0] == '.' && ptr[1] == '.' && (ptr[2] == '\0' || ptr[2] == DEFAULT_SLASH || ptr[2] == '/')) {
+#endif
+			/* Don't allow paths with a leading .. path component to be set at runtime */
 			efree(pathbuf);
 			return FAILURE;
 		}

--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -110,11 +110,7 @@ PHPAPI ZEND_INI_MH(OnUpdateBaseDir)
 			*end = '\0';
 			end++;
 		}
-#ifndef PHP_WIN32
-		if (ptr[0] == '.' && ptr[1] == '.' && (ptr[2] == '\0' || ptr[2] == DEFAULT_SLASH)) {
-#else
-		if (ptr[0] == '.' && ptr[1] == '.' && (ptr[2] == '\0' || ptr[2] == DEFAULT_SLASH || ptr[2] == '/')) {
-#endif
+		if (ptr[0] == '.' && ptr[1] == '.' && (ptr[2] == '\0' || IS_SLASH(ptr[2]))) {
 			/* Don't allow paths with a leading .. path component to be set at runtime */
 			efree(pathbuf);
 			return FAILURE;

--- a/tests/security/bug76359.phpt
+++ b/tests/security/bug76359.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #76359 (open_basedir bypass through adding "..")
+--FILE--
+<?php
+ini_set('open_basedir', __DIR__);
+mkdir(__DIR__ . "/bug76359");
+chdir(__DIR__ . "/bug76359");
+var_dump(ini_set('open_basedir', ini_get('open_basedir') . PATH_SEPARATOR . ".."));
+chdir("..");
+chdir("..");
+?>
+--EXPECTF--
+bool(false)
+
+Warning: chdir(): open_basedir restriction in effect. File(..) is not within the allowed path(s): (%s) in %s on line %d
+--CLEAN--
+<?php
+@rmdir(__DIR__ . "/bug76359");
+?>


### PR DESCRIPTION
We explicitly forbid adding `..` to `open_basedir`at runtime.

---

Note this is only a minimal fix for the reported issue. There are still problems with `..` somewhere in the path, e.g. consider:
````
+---foo
|       oh.no
|
\---wwwroot
    |   index.php
    |
    \---foo
            no.problem
````
with index.php:
````.php
<?php
chdir(__DIR__);
ini_set('open_basedir', __DIR__);
chdir("./foo");
ini_set('open_basedir', ini_get('open_basedir') . PATH_SEPARATOR . "../foo");
chdir("..");
chdir("../foo");
var_dump(scandir(".")[2]);
````
outputs:
````
string(5) "oh.no"
````
Generally disallowing `..` in the path might by too much of a BC break, though.
