### PR TITLE
Add headers_send_early_and_clear() function for HTTP Early Hints

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -175,7 +175,7 @@ static int phar_file_action(phar_archive_data *phar, phar_entry_info *info, char
 			sapi_header_op(SAPI_HEADER_REPLACE, &ctr);
 			efree((void *) ctr.line);
 
-			if (FAILURE == sapi_send_headers()) {
+			if (FAILURE == sapi_send_headers(/* last_headers */ true)) {
 				zend_bailout();
 			}
 
@@ -300,7 +300,7 @@ static void phar_do_403(char *entry, size_t entry_len) /* {{{ */
 	ctr.line_len = sizeof("HTTP/1.0 403 Access Denied")-1;
 	ctr.line = "HTTP/1.0 403 Access Denied";
 	sapi_header_op(SAPI_HEADER_REPLACE, &ctr);
-	sapi_send_headers();
+	sapi_send_headers(/* last_headers */ true);
 	PHPWRITE("<html>\n <head>\n  <title>Access Denied</title>\n </head>\n <body>\n  <h1>403 - File ", sizeof("<html>\n <head>\n  <title>Access Denied</title>\n </head>\n <body>\n  <h1>403 - File ") - 1);
 	PHPWRITE("Access Denied</h1>\n </body>\n</html>", sizeof("Access Denied</h1>\n </body>\n</html>") - 1);
 }
@@ -324,7 +324,7 @@ static void phar_do_404(phar_archive_data *phar, char *fname, size_t fname_len, 
 	ctr.line_len = sizeof("HTTP/1.0 404 Not Found")-1;
 	ctr.line = "HTTP/1.0 404 Not Found";
 	sapi_header_op(SAPI_HEADER_REPLACE, &ctr);
-	sapi_send_headers();
+	sapi_send_headers(/* last_headers */ true);
 	PHPWRITE("<html>\n <head>\n  <title>File Not Found</title>\n </head>\n <body>\n  <h1>404 - File ", sizeof("<html>\n <head>\n  <title>File Not Found</title>\n </head>\n <body>\n  <h1>404 - File ") - 1);
 	PHPWRITE("Not Found</h1>\n </body>\n</html>",  sizeof("Not Found</h1>\n </body>\n</html>") - 1);
 }
@@ -783,7 +783,7 @@ cleanup_fail:
 			}
 
 			sapi_header_op(SAPI_HEADER_REPLACE, &ctr);
-			sapi_send_headers();
+			sapi_send_headers(/* last_headers */ true);
 			efree((void *) ctr.line);
 			zend_bailout();
 		}

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -520,6 +520,8 @@ function headers_sent(&$filename = null, &$line = null): bool {}
 
 function headers_list(): array {}
 
+function headers_send_early_and_clear(): bool {}
+
 /* {{{ html.c */
 
 function htmlspecialchars(string $string, int $flags = ENT_QUOTES | ENT_SUBSTITUTE, ?string $encoding = null, bool $double_encode = true): string {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 810b8bfbdf037702fcaec2ff81998c2bc2cefae8 */
+ * Stub hash: f09f8df1b2704720615642414ea106471b139e33 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -769,6 +769,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_headers_sent, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_headers_list arginfo_ob_list_handlers
+
+#define arginfo_headers_send_early_and_clear arginfo_ob_flush
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_htmlspecialchars, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
@@ -2445,6 +2447,7 @@ ZEND_FUNCTION(setcookie);
 ZEND_FUNCTION(http_response_code);
 ZEND_FUNCTION(headers_sent);
 ZEND_FUNCTION(headers_list);
+ZEND_FUNCTION(headers_send_early_and_clear);
 ZEND_FUNCTION(htmlspecialchars);
 ZEND_FUNCTION(htmlspecialchars_decode);
 ZEND_FUNCTION(html_entity_decode);
@@ -3080,6 +3083,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(http_response_code, arginfo_http_response_code)
 	ZEND_FE(headers_sent, arginfo_headers_sent)
 	ZEND_FE(headers_list, arginfo_headers_list)
+	ZEND_FE(headers_send_early_and_clear, arginfo_headers_send_early_and_clear)
 	ZEND_FE(htmlspecialchars, arginfo_htmlspecialchars)
 	ZEND_FE(htmlspecialchars_decode, arginfo_htmlspecialchars_decode)
 	ZEND_FE(html_entity_decode, arginfo_html_entity_decode)

--- a/ext/standard/tests/general_functions/headers_send_early_hint.phpt
+++ b/ext/standard/tests/general_functions/headers_send_early_hint.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Using headers_send_early_and_clear() for HTTP early hints (no extra headers)
+--CGI--
+--FILE--
+<?php
+
+header('HTTP/1.1 103 Early Hints');
+header('Link: </style.css>; rel=preload; as=style');
+headers_send_early_and_clear();
+// Headers should be cleared.
+var_dump(headers_list());
+?>
+--EXPECTHEADERS--
+Status: 103 Early Hints
+Link: </style.css>; rel=preload; as=style
+--EXPECT--
+Content-type: text/html; charset=UTF-8
+
+array(0) {
+}

--- a/ext/standard/tests/general_functions/headers_send_early_hint_2.phpt
+++ b/ext/standard/tests/general_functions/headers_send_early_hint_2.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Using headers_send_early_and_clear() for HTTP early hints (extra headers)
+--CGI--
+--FILE--
+<?php
+
+header('HTTP/1.1 103 Early Hints');
+header('Link: </style.css>; rel=preload; as=style');
+headers_send_early_and_clear();
+header('Location: http://example.com/');
+echo "Foo\n";
+?>
+--EXPECTHEADERS--
+Status: 103 Early Hints
+Link: </style.css>; rel=preload; as=style
+--EXPECT--
+Status: 302 Found
+Location: http://example.com/
+Content-type: text/html; charset=UTF-8
+
+Foo

--- a/ext/standard/tests/general_functions/headers_send_early_hint_3.phpt
+++ b/ext/standard/tests/general_functions/headers_send_early_hint_3.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Using headers_send_early_and_clear() for HTTP early hints (after output)
+--CGI--
+--FILE--
+<?php
+
+echo "Foo\n";
+var_dump(headers_send_early_and_clear());
+?>
+--EXPECTF--
+Foo
+
+Warning: headers_send_early_and_clear(): Headers already sent in %s on line %d
+bool(false)

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -821,7 +821,7 @@ SAPI_API int sapi_header_op(sapi_header_op_enum op, void *arg)
 }
 
 
-SAPI_API int sapi_send_headers(void)
+SAPI_API int sapi_send_headers(bool last_headers)
 {
 	int retval;
 	int ret = FAILURE;
@@ -833,7 +833,7 @@ SAPI_API int sapi_send_headers(void)
 	/* Success-oriented.  We set headers_sent to 1 here to avoid an infinite loop
 	 * in case of an error situation.
 	 */
-	if (SG(sapi_headers).send_default_content_type && sapi_module.send_headers) {
+	if (SG(sapi_headers).send_default_content_type && sapi_module.send_headers && last_headers) {
 	    uint32_t len = 0;
 		char *default_mimetype = get_default_content_type(0, &len);
 
@@ -863,7 +863,7 @@ SAPI_API int sapi_send_headers(void)
 		zval_ptr_dtor(&cb);
 	}
 
-	SG(headers_sent) = 1;
+	SG(headers_sent) = last_headers;
 
 	if (sapi_module.send_headers) {
 		retval = sapi_module.send_headers(&SG(sapi_headers));

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -181,7 +181,7 @@ SAPI_API int sapi_add_header_ex(const char *header_line, size_t header_line_len,
 #define sapi_add_header(a, b, c) sapi_add_header_ex((a),(b),(c),1)
 
 
-SAPI_API int sapi_send_headers(void);
+SAPI_API int sapi_send_headers(bool last_headers);
 SAPI_API void sapi_free_header(sapi_header_struct *sapi_header);
 SAPI_API void sapi_handle_post(void *arg);
 SAPI_API size_t sapi_read_post_block(char *buffer, size_t buflen);

--- a/run-tests.php
+++ b/run-tests.php
@@ -2513,7 +2513,7 @@ COMMAND $cmd
     $headers = [];
 
     if (!empty($uses_cgi) && preg_match("/^(.*?)\r?\n\r?\n(.*)/s", $out, $match)) {
-        $output = trim($match[2]);
+        $output = str_replace("\r\n", "\n", trim($match[2]));
         $rh = preg_split("/[\n\r]+/", $match[1]);
 
         foreach ($rh as $line) {

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -524,7 +524,7 @@ static void sapi_cli_server_flush(void *server_context) /* {{{ */
 	}
 
 	if (!SG(headers_sent)) {
-		sapi_send_headers();
+		sapi_send_headers(/* last_headers */ true);
 		SG(headers_sent) = 1;
 	}
 } /* }}} */

--- a/sapi/cli/tests/php_cli_server_early_hints.phpt
+++ b/sapi/cli/tests/php_cli_server_early_hints.phpt
@@ -1,0 +1,47 @@
+--TEST--
+PHP CLI server HTTP early hints
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+include "php_cli_server.inc";
+php_cli_server_start(<<<'PHP'
+    header('HTTP/1.1 103 Early Hints');
+    header('Link: </style.css>; rel=preload; as=style');
+    headers_send_early_and_clear();
+    header('Location: http://example.com/');
+    echo "Foo\n";
+    PHP);
+
+$host = PHP_CLI_SERVER_HOSTNAME;
+$fp = php_cli_server_connect();
+
+if (fwrite($fp, <<<HEADER
+GET / HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+	fpassthru($fp);
+}
+
+?>
+--EXPECTF--
+HTTP/1.1 103 Early Hints
+Host: %s
+Date: %s
+Connection: close
+X-Powered-By: PHP/%s
+Link: </style.css>; rel=preload; as=style
+
+HTTP/1.1 302 Found
+Host: localhost
+Date: Fri, 21 May 2021 13:25:48 GMT
+Connection: close
+Location: http://example.com/
+Content-type: text/html; charset=UTF-8
+
+Foo


### PR DESCRIPTION
This is intended to be used in conjunction with HTTP Early Hints
and other 1xx status codes, which require sending multiple sets
of headers.

Usage:

    header('HTTP/1.1 103 Early Hints');
    header('Link: </style.css>; rel=preload; as=style');
    headers_send_early_and_clear();

    // Normal code goes here. You can send more headers and body
    // here.