### PR TITLE
Implement is_initialized

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1393,6 +1393,8 @@ function boolval(mixed $value): bool {}
 
 function strval(mixed $value): string {}
 
+function is_initialized(object|string $scope, string $property) : bool {}
+
 function is_null(mixed $value): bool {}
 
 function is_resource(mixed $value): bool {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 810b8bfbdf037702fcaec2ff81998c2bc2cefae8 */
+ * Stub hash: 7c42ef97e5b15aa768594897d96eb7c941c486b4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -2062,6 +2062,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_strval arginfo_gettype
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_is_initialized, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_MASK(0, scope, MAY_BE_OBJECT|MAY_BE_STRING, NULL)
+	ZEND_ARG_TYPE_INFO(0, property, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_is_null arginfo_boolval
 
 #define arginfo_is_resource arginfo_boolval
@@ -2786,6 +2791,7 @@ ZEND_FUNCTION(intval);
 ZEND_FUNCTION(floatval);
 ZEND_FUNCTION(boolval);
 ZEND_FUNCTION(strval);
+ZEND_FUNCTION(is_initialized);
 ZEND_FUNCTION(is_null);
 ZEND_FUNCTION(is_resource);
 ZEND_FUNCTION(is_bool);
@@ -3436,6 +3442,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FALIAS(doubleval, floatval, arginfo_doubleval)
 	ZEND_FE(boolval, arginfo_boolval)
 	ZEND_FE(strval, arginfo_strval)
+	ZEND_FE(is_initialized, arginfo_is_initialized)
 	ZEND_FE(is_null, arginfo_is_null)
 	ZEND_FE(is_resource, arginfo_is_resource)
 	ZEND_FE(is_bool, arginfo_is_bool)

--- a/ext/standard/tests/general_functions/is_initialized.phpt
+++ b/ext/standard/tests/general_functions/is_initialized.phpt
@@ -1,0 +1,91 @@
+--TEST--
+Test is_initialized function
+--FILE--
+<?php
+class Foo {
+    public int $bar;
+    public static int $qux;
+    public $baz;
+
+    private static int $boo = 10;
+
+    public function is_private_static_initialized() {
+        return is_initialized(self::class, "boo");
+    }
+}
+
+$foo = new Foo();
+
+try {
+    is_initialized(42, "42"); # string|object
+} catch (Error $ex) {
+    printf("%s\n", $ex->getMessage());
+}
+
+try {
+    is_initialized(Unknown::class, "unknown"); # unknown class
+} catch (Error $ex) {
+    printf("%s\n", $ex->getMessage());
+}
+
+try {
+    is_initialized(Foo::class, "bar"); # instance property without object
+} catch (Error $ex) {
+    printf("%s\n", $ex->getMessage());
+}
+
+try {
+    is_initialized($foo, "baz"); # accessible but untyped
+} catch (Error $ex) {
+    printf("%s\n", $ex->getMessage());
+}
+
+try {
+    is_initialized($foo, "unknown"); # unknown
+} catch (Error $ex) {
+    printf("%s\n", $ex->getMessage());
+}
+
+try {
+    is_initialized($foo, "boo"); # unaccessible
+} catch (Error $ex) {
+    printf("%s\n", $ex->getMessage());
+}
+
+$foo->dynamic = 42;
+
+try {
+    is_initialized($foo, "dynamic"); # dynamic
+} catch (Error $ex) {
+    printf("%s\n", $ex->getMessage());
+}
+
+var_dump(is_initialized($foo, "bar"),         # uninitialized
+         is_initialized(Foo::class, "qux"));  # uninitialized
+         
+$foo->bar = 42;
+Foo::$qux = 42;
+
+var_dump(is_initialized($foo, "bar"),         # initialized
+         is_initialized(Foo::class, "qux"));  # initialized
+
+unset($foo->bar);
+
+var_dump(is_initialized($foo, "bar"));             # uninitialized
+
+var_dump($foo->is_private_static_initialized());   # initialized
+?>
+--EXPECT--
+is_initialized(): Argument #1 ($scope) must be an object or string
+is_initialized(): Argument #1 ($scope) must be the name of a loaded class
+is_initialized(): Argument #1 ($scope) must be an object for instance property
+is_initialized(): Argument #2 ($property) must be the name of an accessible typed property
+is_initialized(): Argument #2 ($property) must be the name of an accessible typed property
+is_initialized(): Argument #2 ($property) must be the name of an accessible typed property
+is_initialized(): Argument #2 ($property) must be the name of an accessible typed property
+bool(false)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(true)


### PR DESCRIPTION
  Determine the state of a typed property without using reflection
    
Fixes #78480
