### PR TITLE
Fix #81076

### DIFF
--- a/Zend/tests/bug81076.phpt
+++ b/Zend/tests/bug81076.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug #81076 Invalid implicit binds cause incorrect static var count in closure debug info
+--FILE--
+<?php
+var_dump(fn() => [$why, $do, $we, $count]);
+?>
+--EXPECT--
+object(Closure)#1 (0) {
+}

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -515,16 +515,30 @@ static HashTable *zend_closure_get_debug_info(zend_object *object, int *is_temp)
 
 	if (closure->func.type == ZEND_USER_FUNCTION && closure->func.op_array.static_variables) {
 		zval *var;
+		zend_string *key;
 		HashTable *static_variables =
-			ZEND_MAP_PTR_GET(closure->func.op_array.static_variables_ptr);
-		ZVAL_ARR(&val, zend_array_dup(static_variables));
-		zend_hash_update(debug_info, ZSTR_KNOWN(ZEND_STR_STATIC), &val);
-		ZEND_HASH_FOREACH_VAL(Z_ARRVAL(val), var) {
+			zend_array_dup(ZEND_MAP_PTR_GET(closure->func.op_array.static_variables_ptr));
+
+		array_init(&val);
+
+		ZEND_HASH_FOREACH_STR_KEY_VAL(static_variables, key, var) {
+			zval copy;
+
 			if (Z_TYPE_P(var) == IS_CONSTANT_AST) {
-				zval_ptr_dtor(var);
-				ZVAL_STRING(var, "<constant ast>");
+				ZVAL_STRING(&copy, "<constant ast>");
+			} else {
+				ZVAL_COPY(&copy, var);
 			}
+
+			zend_hash_add_new(Z_ARRVAL(val), key, &copy);
 		} ZEND_HASH_FOREACH_END();
+
+		if (zend_hash_num_elements(Z_ARRVAL(val))) {
+			zend_hash_update(debug_info, ZSTR_KNOWN(ZEND_STR_STATIC), &val);
+		} else {
+			zval_ptr_dtor(&val);
+		}
+		zend_array_release(static_variables);
 	}
 
 	if (Z_TYPE(closure->this_ptr) != IS_UNDEF) {

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -516,8 +516,7 @@ static HashTable *zend_closure_get_debug_info(zend_object *object, int *is_temp)
 	if (closure->func.type == ZEND_USER_FUNCTION && closure->func.op_array.static_variables) {
 		zval *var;
 		zend_string *key;
-		HashTable *static_variables =
-			zend_array_dup(ZEND_MAP_PTR_GET(closure->func.op_array.static_variables_ptr));
+		HashTable *static_variables = ZEND_MAP_PTR_GET(closure->func.op_array.static_variables_ptr);
 
 		array_init(&val);
 
@@ -527,6 +526,11 @@ static HashTable *zend_closure_get_debug_info(zend_object *object, int *is_temp)
 			if (Z_TYPE_P(var) == IS_CONSTANT_AST) {
 				ZVAL_STRING(&copy, "<constant ast>");
 			} else {
+				if (Z_OPT_REFCOUNTED_P(var)) {
+					if (Z_ISREF_P(var) && Z_REFCOUNT_P(var) == 1) {
+						var = Z_REFVAL_P(var);
+					}
+				}
 				ZVAL_COPY(&copy, var);
 			}
 
@@ -538,7 +542,6 @@ static HashTable *zend_closure_get_debug_info(zend_object *object, int *is_temp)
 		} else {
 			zval_ptr_dtor(&val);
 		}
-		zend_array_release(static_variables);
 	}
 
 	if (Z_TYPE(closure->this_ptr) != IS_UNDEF) {

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -526,10 +526,8 @@ static HashTable *zend_closure_get_debug_info(zend_object *object, int *is_temp)
 			if (Z_TYPE_P(var) == IS_CONSTANT_AST) {
 				ZVAL_STRING(&copy, "<constant ast>");
 			} else {
-				if (Z_OPT_REFCOUNTED_P(var)) {
-					if (Z_ISREF_P(var) && Z_REFCOUNT_P(var) == 1) {
-						var = Z_REFVAL_P(var);
-					}
+				if (Z_ISREF_P(var) && Z_REFCOUNT_P(var) == 1) {
+					var = Z_REFVAL_P(var);
 				}
 				ZVAL_COPY(&copy, var);
 			}


### PR DESCRIPTION
  Invalid implicit binds cause incorrect count in static vars of closure debug info