### PR TITLE
Fix #81070: Integer underflow when memory limit is exceeded

### DIFF
--- a/Zend/tests/bug81070.phpt
+++ b/Zend/tests/bug81070.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug #81070	Setting memory limit to below current usage
+--FILE--
+<?php
+$a = str_repeat("0", 5 * 1024 * 1024);
+ini_set("memory_limit", "3M");
+?>
+--EXPECTF--
+Warning: Failed to set memory limit to 3145728 bytes (Current memory usage is %d bytes) in %s on line %d

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2660,6 +2660,9 @@ ZEND_API char* ZEND_FASTCALL zend_strndup(const char *s, size_t length)
 ZEND_API int zend_set_memory_limit(size_t memory_limit)
 {
 #if ZEND_MM_LIMIT
+	if (UNEXPECTED(memory_limit < AG(mm_heap)->real_size)) {
+		return FAILURE;
+	}
 	AG(mm_heap)->limit = (memory_limit >= ZEND_MM_CHUNK_SIZE) ? memory_limit : ZEND_MM_CHUNK_SIZE;
 #endif
 	return SUCCESS;

--- a/ext/standard/tests/streams/bug78902.phpt
+++ b/ext/standard/tests/streams/bug78902.phpt
@@ -1,14 +1,14 @@
 --TEST--
 Bug #78902: Memory leak when using stream_filter_append
 --INI--
-memory_limit=512k
+memory_limit=2M
 --FILE--
 <?php
 
 /** create temporary file 2mb file */
 $tmp_file_name = tempnam(sys_get_temp_dir(), 'test_');
 $fp = fopen($tmp_file_name, 'w+');
-$size = 1024 * 1024 * 2; // 2mb
+$size = 1024 * 1024 * 4; // 4mb, larger than the memory limit
 $chunk = 1024;
 while ($size > 0) {
     fputs($fp, str_pad('', min($chunk,$size)));

--- a/main/main.c
+++ b/main/main.c
@@ -296,12 +296,18 @@ static PHP_INI_MH(OnSetSerializePrecision)
  */
 static PHP_INI_MH(OnChangeMemoryLimit)
 {
+	size_t value;
 	if (new_value) {
-		PG(memory_limit) = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+		value = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
 	} else {
-		PG(memory_limit) = Z_L(1)<<30;		/* effectively, no limit */
+		value = Z_L(1)<<30;		/* effectively, no limit */
 	}
-	return zend_set_memory_limit(PG(memory_limit));
+	if (zend_set_memory_limit(value) == FAILURE) {
+		zend_error(E_WARNING, "Failed to set memory limit to %zd bytes (Current memory usage is %zd bytes)", value, zend_memory_usage(true));
+		return FAILURE;
+	}
+	PG(memory_limit) = value;
+	return SUCCESS;
 }
 /* }}} */
 

--- a/tests/lang/bug45392.phpt
+++ b/tests/lang/bug45392.phpt
@@ -2,6 +2,8 @@
 Bug #45392 (ob_start()/ob_end_clean() and memory_limit)
 --INI--
 display_errors=stderr
+--XFAIL--
+The issue has not yet been resolved.
 --SKIPIF--
 <?php
 if (getenv("USE_ZEND_ALLOC") === "0") {
@@ -10,7 +12,7 @@ if (getenv("USE_ZEND_ALLOC") === "0") {
 --FILE--
 <?php
 echo __LINE__ . "\n";
-ini_set('memory_limit', 100);
+ini_set('memory_limit', "2M");
 ob_start();
 $i = 0;
 while($i++ < 5000)  {


### PR DESCRIPTION
When the memory limit is reduced using an `ini_set("memory_limit", ..)`
below the currently allocated memory. Further allocations should
cause a memory limit exceeded error.
This fixes the regression introduced in 7.2.23

I have targeted the 7.3 branch as this bug allows for unlimited memory usage in some scenarios.