### PR TITLE
Fix some imagecolor*() return types

### DIFF
--- a/ext/gd/gd.stub.php
+++ b/ext/gd/gd.stub.php
@@ -36,9 +36,9 @@ function imagelayereffect(GdImage $image, int $effect): bool {}
 
 function imagecolorallocatealpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
 
-function imagecolorresolvealpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
+function imagecolorresolvealpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int {}
 
-function imagecolorclosestalpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
+function imagecolorclosestalpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int {}
 
 function imagecolorexactalpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
 
@@ -141,15 +141,15 @@ function imagepalettecopy(GdImage $dst, GdImage $src): void {}
 
 function imagecolorat(GdImage $image, int $x, int $y): int|false {}
 
-function imagecolorclosest(GdImage $image, int $red, int $green, int $blue): int|false {}
+function imagecolorclosest(GdImage $image, int $red, int $green, int $blue): int {}
 
-function imagecolorclosesthwb(GdImage $image, int $red, int $green, int $blue): int|false {}
+function imagecolorclosesthwb(GdImage $image, int $red, int $green, int $blue): int {}
 
 function imagecolordeallocate(GdImage $image, int $color): bool {}
 
-function imagecolorresolve(GdImage $image, int $red, int $green, int $blue): int|false {}
+function imagecolorresolve(GdImage $image, int $red, int $green, int $blue): int {}
 
-function imagecolorexact(GdImage $image, int $red, int $green, int $blue): int|false {}
+function imagecolorexact(GdImage $image, int $red, int $green, int $blue): int {}
 
 function imagecolorset(GdImage $image, int $color, int $red, int $green, int $blue, int $alpha = 0): ?bool {}
 

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ef2df95a30077f088ccfa9b02341385f77caaa64 */
+ * Stub hash: 4efa17e2238f259e359b8f64967677c0ac2abfdb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gd_info, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -81,9 +81,15 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imagecolorallocatealpha, 0, 5, M
 	ZEND_ARG_TYPE_INFO(0, alpha, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_imagecolorresolvealpha arginfo_imagecolorallocatealpha
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagecolorresolvealpha, 0, 5, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
+	ZEND_ARG_TYPE_INFO(0, red, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, green, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, blue, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, alpha, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
-#define arginfo_imagecolorclosestalpha arginfo_imagecolorallocatealpha
+#define arginfo_imagecolorclosestalpha arginfo_imagecolorresolvealpha
 
 #define arginfo_imagecolorexactalpha arginfo_imagecolorallocatealpha
 
@@ -276,18 +282,23 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_imagecolorat, 0, 3, MAY_BE_LONG|
 	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_imagecolorclosest arginfo_imagecolorallocate
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagecolorclosest, 0, 4, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
+	ZEND_ARG_TYPE_INFO(0, red, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, green, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, blue, IS_LONG, 0)
+ZEND_END_ARG_INFO()
 
-#define arginfo_imagecolorclosesthwb arginfo_imagecolorallocate
+#define arginfo_imagecolorclosesthwb arginfo_imagecolorclosest
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagecolordeallocate, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
 	ZEND_ARG_TYPE_INFO(0, color, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_imagecolorresolve arginfo_imagecolorallocate
+#define arginfo_imagecolorresolve arginfo_imagecolorclosest
 
-#define arginfo_imagecolorexact arginfo_imagecolorallocate
+#define arginfo_imagecolorexact arginfo_imagecolorclosest
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagecolorset, 0, 5, _IS_BOOL, 1)
 	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)


### PR DESCRIPTION
These functions either return always a valid color, or `-1` on failure,
but never `false`.