### PR TITLE
JIT/AArch64: [macos][ZTS] Support fast path for tlv_get_addr

### DIFF
--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -745,11 +745,10 @@ TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void)
 	size_t ret;
 
 # ifdef __APPLE__
-	// In macOS, "ret" holds the address of one TLVDecriptor, where the first
-	// member is the address of function tlv_get_addr().
+	// Points to struct TLVDecriptor for _tsrm_ls_cache in macOS.
 	asm("adrp %0, #__tsrm_ls_cache@TLVPPAGE\n\t"
 	    "ldr %0, [%0, #__tsrm_ls_cache@TLVPPAGEOFF]"
-	    : "=r" (ret));
+	     : "=r" (ret));
 # else
 	asm("mov %0, xzr\n\t"
 	    "add %0, %0, #:tprel_hi12:_tsrm_ls_cache, lsl #12\n\t"

--- a/TSRM/TSRM.c
+++ b/TSRM/TSRM.c
@@ -744,10 +744,18 @@ TSRM_API size_t tsrm_get_ls_cache_tcb_offset(void)
 #elif defined(__aarch64__)
 	size_t ret;
 
+# ifdef __APPLE__
+	// In macOS, "ret" holds the address of one TLVDecriptor, where the first
+	// member is the address of function tlv_get_addr().
+	asm("adrp %0, #__tsrm_ls_cache@TLVPPAGE\n\t"
+	    "ldr %0, [%0, #__tsrm_ls_cache@TLVPPAGEOFF]"
+	    : "=r" (ret));
+# else
 	asm("mov %0, xzr\n\t"
 	    "add %0, %0, #:tprel_hi12:_tsrm_ls_cache, lsl #12\n\t"
 	    "add %0, %0, #:tprel_lo12_nc:_tsrm_ls_cache"
 	     : "=r" (ret));
+# endif
 	return ret;
 #else
 	return 0;

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4055,8 +4055,10 @@ ZEND_EXT_API void zend_jit_unprotect(void)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 		int opts = PROT_READ | PROT_WRITE;
 #ifdef ZTS
+# ifndef __APPLE__
 		/* Another thread may be executing JITed code. */
 		opts |= PROT_EXEC;
+# endif
 #endif
 		if (mprotect(dasm_buf, dasm_size, opts) != 0) {
 			fprintf(stderr, "mprotect() failed [%d] %s\n", errno, strerror(errno));

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4055,6 +4055,8 @@ ZEND_EXT_API void zend_jit_unprotect(void)
 	if (!(JIT_G(debug) & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
 		int opts = PROT_READ | PROT_WRITE;
 #ifdef ZTS
+  /* TODO: EXEC+WRITE is not supported in macOS. Removing EXEC is still buggy as
+   * other threads, which are executing the JITed code, would crash anyway. */
 # ifndef __APPLE__
 		/* Another thread may be executing JITed code. */
 		opts |= PROT_EXEC;

--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -483,10 +483,100 @@ static int logical_immediate_p (uint64_t value, uint32_t reg_size)
 ||	}
 |.endmacro
 
+#ifdef __APPLE__
+|.macro SAVE_REGS
+|	sub sp, sp, #(16*21)
+|
+|	stp d30, d31, [sp]
+|	stp d28, d29, [sp, #16]
+|	stp d26, d27, [sp, #(16*2)]
+|	stp d24, d25, [sp, #(16*3)]
+|	stp d22, d23, [sp, #(16*4)]
+|	stp d20, d21, [sp, #(16*5)]
+|	stp d18, d19, [sp, #(16*6)]
+|	stp d16, d17, [sp, #(16*7)]
+|	// Callee-saved registers, d8 to d15, can be omitted.
+|	stp d6, d7, [sp, #(16*8)]
+|	stp d4, d5, [sp, #(16*9)]
+|	stp d2, d3, [sp, #(16*10)]
+|	stp d0, d1, [sp, #(16*11)]
+|
+|	stp x29, x30, [sp, #(16*12)]
+|	// Callee-saved registers, x19 to x28, can be omitted.
+|	// Temporary registers TMP1 to TMP3, i.e. x15 to 17, can be omitted.
+|	stp x14, x18, [sp, #(16*13)]
+|	stp x12, x13, [sp, #(16*14)]
+|	stp x10, x11, [sp, #(16*15)]
+|	stp x8, x9, [sp, #(16*16)]
+|	stp x6, x7, [sp, #(16*17)]
+|	stp x4, x5, [sp, #(16*18)]
+|	stp x2, x3, [sp, #(16*19)]
+|	stp x0, x1, [sp, #(16*20)]
+|.endmacro
+
+|.macro RESTORE_REGS
+|	ldp d30, d31, [sp]
+|	ldp d28, d29, [sp, #16]
+|	ldp d26, d27, [sp, #(16*2)]
+|	ldp d24, d25, [sp, #(16*3)]
+|	ldp d22, d23, [sp, #(16*4)]
+|	ldp d20, d21, [sp, #(16*5)]
+|	ldp d18, d19, [sp, #(16*6)]
+|	ldp d16, d17, [sp, #(16*7)]
+|	// Callee-saved registers, d8 to d15, can be omitted.
+|	ldp d6, d7, [sp, #(16*8)]
+|	ldp d4, d5, [sp, #(16*9)]
+|	ldp d2, d3, [sp, #(16*10)]
+|	ldp d0, d1, [sp, #(16*11)]
+|
+|	ldp x29, x30, [sp, #(16*12)]
+|	// Callee-saved registers, x19 to x28, can be omitted.
+|	// Temporary registers TMP1 to TMP3, i.e. x15 to 17, can be omitted.
+|	ldp x14, x18, [sp, #(16*13)]
+|	ldp x12, x13, [sp, #(16*14)]
+|	ldp x10, x11, [sp, #(16*15)]
+|	ldp x8, x9, [sp, #(16*16)]
+|	ldp x6, x7, [sp, #(16*17)]
+|	ldp x4, x5, [sp, #(16*18)]
+|	ldp x2, x3, [sp, #(16*19)]
+|	ldp x0, x1, [sp, #(16*20)]
+|
+|	add sp, sp, #(16*21)
+|.endmacro
+#endif
+
 |.macro LOAD_TSRM_CACHE, reg
+||#ifdef __APPLE__
+|	// TODO: Get a better name for "tsrm_ls_cache_tcb_offset"?
+|	// TODO: In Linux only TMP3 is used particularly for ZTS, whereas TMP1 and TMP2 are also used in macOS.
+|	LOAD_ADDR TMP3, tsrm_ls_cache_tcb_offset
+|	.long 0xd53bd06f // TODO: hard-coded: mrs TMP1, tpidrro_el0
+|	and TMP1, TMP1, #0xfffffffffffffff8
+|	ldr TMP2, [TMP3, #0x8]
+|	ldr TMP1, [TMP1, TMP2, lsl #3]
+|	cbz TMP1, >4     // TODO: There is conflict for local labels. A number of test cases would fail.
+|	ldr TMP2, [TMP3, #0x10]
+|	ldr reg, [TMP1, TMP2]
+|	b >7
+|4:
+|	// Slow path. Invoke tlv_get_addr(). TODO: Put it in cold code or global stub?
+|	stp x29, x30, [sp, #-16]!
+|	mov x29, sp
+|	SAVE_REGS
+|	mov x0, TMP3
+|	ldr TMP1, [TMP3]
+|	blr TMP1
+|	mov TMP3, x0
+|	RESTORE_REGS     // TMP3 is not in this list
+|	ldr reg, [TMP3]
+|	mov sp, x29
+|	ldp, x29, x30, [sp], #16
+|7:
+||#else
 |	.long 0xd53bd051 // TODO: hard-coded: mrs TMP3, tpidr_el0
 ||	ZEND_ASSERT(tsrm_ls_cache_tcb_offset <= LDR_STR_PIMM64);
 |	ldr reg, [TMP3, #tsrm_ls_cache_tcb_offset]
+||#endif
 |.endmacro
 
 |.macro LOAD_ADDR_ZTS, reg, struct, field

--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -184,6 +184,14 @@ const char* zend_reg_name[] = {
 
 #if ZTS
 static size_t tsrm_ls_cache_tcb_offset = 0;
+# ifdef __APPLE__
+struct TLVDescriptor {
+	void*       (*thunk)(struct TLVDescriptor*);
+	uint64_t    key;
+	uint64_t    offset;
+};
+typedef struct TLVDescriptor TLVDescriptor;
+# endif
 #endif
 
 /* By default avoid JITing inline handlers if it does not seem profitable due to lack of
@@ -483,95 +491,22 @@ static int logical_immediate_p (uint64_t value, uint32_t reg_size)
 ||	}
 |.endmacro
 
-#ifdef __APPLE__
-|.macro SAVE_REGS
-|	sub sp, sp, #(16*21)
-|
-|	stp d30, d31, [sp]
-|	stp d28, d29, [sp, #16]
-|	stp d26, d27, [sp, #(16*2)]
-|	stp d24, d25, [sp, #(16*3)]
-|	stp d22, d23, [sp, #(16*4)]
-|	stp d20, d21, [sp, #(16*5)]
-|	stp d18, d19, [sp, #(16*6)]
-|	stp d16, d17, [sp, #(16*7)]
-|	// Callee-saved registers, d8 to d15, can be omitted.
-|	stp d6, d7, [sp, #(16*8)]
-|	stp d4, d5, [sp, #(16*9)]
-|	stp d2, d3, [sp, #(16*10)]
-|	stp d0, d1, [sp, #(16*11)]
-|
-|	stp x29, x30, [sp, #(16*12)]
-|	// Callee-saved registers, x19 to x28, can be omitted.
-|	// Temporary registers TMP1 to TMP3, i.e. x15 to 17, can be omitted.
-|	stp x14, x18, [sp, #(16*13)]
-|	stp x12, x13, [sp, #(16*14)]
-|	stp x10, x11, [sp, #(16*15)]
-|	stp x8, x9, [sp, #(16*16)]
-|	stp x6, x7, [sp, #(16*17)]
-|	stp x4, x5, [sp, #(16*18)]
-|	stp x2, x3, [sp, #(16*19)]
-|	stp x0, x1, [sp, #(16*20)]
+// Safe memory load/store with an unsigned 64-bit offset.
+|.macro SAFE_MEM_ACC_WITH_64_UOFFSET, ldr_str_ins, op, base_reg, offset, tmp_reg
+||	if (((uintptr_t)(offset)) > LDR_STR_PIMM64) {
+|		LOAD_64BIT_VAL tmp_reg, offset
+|		ldr_str_ins op, [base_reg, tmp_reg]
+||	} else {
+|		ldr_str_ins op, [base_reg, #(offset)]
+||	}
 |.endmacro
-
-|.macro RESTORE_REGS
-|	ldp d30, d31, [sp]
-|	ldp d28, d29, [sp, #16]
-|	ldp d26, d27, [sp, #(16*2)]
-|	ldp d24, d25, [sp, #(16*3)]
-|	ldp d22, d23, [sp, #(16*4)]
-|	ldp d20, d21, [sp, #(16*5)]
-|	ldp d18, d19, [sp, #(16*6)]
-|	ldp d16, d17, [sp, #(16*7)]
-|	// Callee-saved registers, d8 to d15, can be omitted.
-|	ldp d6, d7, [sp, #(16*8)]
-|	ldp d4, d5, [sp, #(16*9)]
-|	ldp d2, d3, [sp, #(16*10)]
-|	ldp d0, d1, [sp, #(16*11)]
-|
-|	ldp x29, x30, [sp, #(16*12)]
-|	// Callee-saved registers, x19 to x28, can be omitted.
-|	// Temporary registers TMP1 to TMP3, i.e. x15 to 17, can be omitted.
-|	ldp x14, x18, [sp, #(16*13)]
-|	ldp x12, x13, [sp, #(16*14)]
-|	ldp x10, x11, [sp, #(16*15)]
-|	ldp x8, x9, [sp, #(16*16)]
-|	ldp x6, x7, [sp, #(16*17)]
-|	ldp x4, x5, [sp, #(16*18)]
-|	ldp x2, x3, [sp, #(16*19)]
-|	ldp x0, x1, [sp, #(16*20)]
-|
-|	add sp, sp, #(16*21)
-|.endmacro
-#endif
 
 |.macro LOAD_TSRM_CACHE, reg
 ||#ifdef __APPLE__
-|	// TODO: Get a better name for "tsrm_ls_cache_tcb_offset"?
-|	// TODO: In Linux only TMP3 is used particularly for ZTS, whereas TMP1 and TMP2 are also used in macOS.
-|	LOAD_ADDR TMP3, tsrm_ls_cache_tcb_offset
-|	.long 0xd53bd06f // TODO: hard-coded: mrs TMP1, tpidrro_el0
-|	and TMP1, TMP1, #0xfffffffffffffff8
-|	ldr TMP2, [TMP3, #0x8]
-|	ldr TMP1, [TMP1, TMP2, lsl #3]
-|	cbz TMP1, >4     // TODO: There is conflict for local labels. A number of test cases would fail.
-|	ldr TMP2, [TMP3, #0x10]
-|	ldr reg, [TMP1, TMP2]
-|	b >7
-|4:
-|	// Slow path. Invoke tlv_get_addr(). TODO: Put it in cold code or global stub?
-|	stp x29, x30, [sp, #-16]!
-|	mov x29, sp
-|	SAVE_REGS
-|	mov x0, TMP3
-|	ldr TMP1, [TMP3]
-|	blr TMP1
-|	mov TMP3, x0
-|	RESTORE_REGS     // TMP3 is not in this list
-|	ldr reg, [TMP3]
-|	mov sp, x29
-|	ldp, x29, x30, [sp], #16
-|7:
+|	.long 0xd53bd071 // TODO: hard-coded: mrs TMP3, tpidrro_el0
+|	and TMP3, TMP3, #0xfffffffffffffff8
+|	SAFE_MEM_ACC_WITH_64_UOFFSET ldr, TMP3, TMP3, (((TLVDescriptor*)tsrm_ls_cache_tcb_offset)->key << 3), TMP1
+|	SAFE_MEM_ACC_WITH_64_UOFFSET ldr, reg, TMP3, (((TLVDescriptor*)tsrm_ls_cache_tcb_offset)->offset), TMP1
 ||#else
 |	.long 0xd53bd051 // TODO: hard-coded: mrs TMP3, tpidr_el0
 ||	ZEND_ASSERT(tsrm_ls_cache_tcb_offset <= LDR_STR_PIMM64);


### PR DESCRIPTION
As updated in file TSRM.c, function tsrm_get_ls_cache_tcb_offset() would
return an address, which stores the address of function tlv_get_addr(),
and this return value would be further used as the first argument of
function tlv_get_addr().

Note that 1) the address of thread local variable "_tsrm_ls_cache" is
obtained by invoking tlv_get_addr() in macOS, and 2) 'ldr' instruction
would be patched to "add" by the linker. See the example in [1].

The disassembly code for function tlv_get_addr() is shown in [2].

In this patch, we implement one fast path for tlv_get_addr in macro
LOAD_TSRM_CACHE and will fall back to slow path if needed.

Based on the comment for function tlv_allocate_and_initialize_for_key()
from [3], the slow path is supposed to be executed only once for each
thread.

Even though a number of test cases failed due to the potential conflicts
of local labels, this patch can be submitted for internal/upstream
reviews.

[1] https://gist.github.com/shqking/4aab67e0105f7c1f2c549d57d5799f94
[2] https://gist.github.com/shqking/329d7712c26bad49786ab0a544a4af43
[3]
https://opensource.apple.com/source/dyld/dyld-195.6/src/threadLocalVariables.c.auto.html

Change-Id: I613e9c37e3ff2ecc3fab0f53f1e48a0246e12ee3