### PR TITLE
Remove the redefinition of zend_error_info

### DIFF
--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -62,7 +62,6 @@ END_EXTERN_C()
 typedef struct _zend_vm_stack *zend_vm_stack;
 typedef struct _zend_ini_entry zend_ini_entry;
 typedef struct _zend_fiber zend_fiber;
-typedef struct _zend_error_info zend_error_info;
 
 
 struct _zend_compiler_globals {


### PR DESCRIPTION
It causes -Wtypedef-redefinition warning, introduced by e8e7c04

```
In file included from /usr/local/php/latest/include/php/Zend/zend_API.h:25:
In file included from /usr/local/php/latest/include/php/Zend/zend_modules.h:24:
In file included from /usr/local/php/latest/include/php/Zend/zend_compile.h:745:
/usr/local/php/latest/include/php/Zend/zend_globals.h:65:33: warning: redefinition of typedef 'zend_error_info' is a C11 feature [-Wtypedef-redefinition]
typedef struct _zend_error_info zend_error_info;

/usr/local/php/latest/include/php/Zend/zend.h:389:3: note: previous definition is here
} zend_error_info;
```
