### PR TITLE
Add internal Fiber API

### DIFF
--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -50,15 +50,15 @@ static zend_object_handlers zend_fiber_handlers;
 
 static zend_function zend_fiber_function = { ZEND_INTERNAL_FUNCTION };
 
-typedef void *zend_fcontext_t;
+typedef void *fcontext_t;
 
-typedef struct _zend_transfer_t {
-	zend_fcontext_t context;
+typedef struct _transfer_t {
+	fcontext_t context;
 	void *data;
-} zend_transfer_t;
+} transfer_t;
 
-extern zend_fcontext_t make_fcontext(void *sp, size_t size, void (*fn)(zend_transfer_t));
-extern zend_transfer_t jump_fcontext(zend_fcontext_t to, void *vp);
+extern fcontext_t make_fcontext(void *sp, size_t size, void (*fn)(transfer_t));
+extern transfer_t jump_fcontext(fcontext_t to, void *vp);
 
 #define ZEND_FIBER_DEFAULT_PAGE_SIZE 4096
 
@@ -180,7 +180,7 @@ static void zend_fiber_stack_free(zend_fiber_stack *stack)
 	stack->pointer = NULL;
 }
 
-static ZEND_NORETURN void zend_fiber_trampoline(zend_transfer_t transfer)
+static ZEND_NORETURN void zend_fiber_trampoline(transfer_t transfer)
 {
 	zend_fiber_context *context = transfer.data;
 
@@ -239,7 +239,7 @@ ZEND_API void zend_fiber_switch_context(zend_fiber_context *to)
 	__sanitizer_start_switch_fiber(&fake_stack, to->stack.pointer, to->stack.size);
 #endif
 
-	zend_transfer_t transfer = jump_fcontext(to->self, to);
+	transfer_t transfer = jump_fcontext(to->self, to);
 
 #ifdef __SANITIZE_ADDRESS__
 	__sanitizer_finish_switch_fiber(fake_stack, &to->stack.prior_pointer, &to->stack.prior_size);
@@ -257,7 +257,7 @@ ZEND_API void zend_fiber_suspend_context(zend_fiber_context *current)
 	__sanitizer_start_switch_fiber(&fake_stack, current->stack.prior_pointer, current->stack.prior_size);
 #endif
 
-	zend_transfer_t transfer = jump_fcontext(current->caller, NULL);
+	transfer_t transfer = jump_fcontext(current->caller, NULL);
 
 #ifdef __SANITIZE_ADDRESS__
 	__sanitizer_finish_switch_fiber(fake_stack, &current->stack.prior_pointer, &current->stack.prior_size);

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -92,9 +92,16 @@ static const zend_uchar ZEND_FIBER_STATUS_BAILOUT   = 0x20;
 
 static const zend_uchar ZEND_FIBER_STATUS_FINISHED  = 0x2c;
 
+/* These functions create and manipulate a Fiber object, allowing any internal function to start, resume, or suspend a fiber. */
+ZEND_API zend_fiber *zend_fiber_create(const zend_fcall_info *fci, const zend_fcall_info_cache *fci_cache);
+ZEND_API void zend_fiber_start(zend_fiber *fiber, zval *params, uint32_t param_count, zend_array *named_params, INTERNAL_FUNCTION_PARAMETERS);
+ZEND_API void zend_fiber_suspend(zval *value, INTERNAL_FUNCTION_PARAMETERS);
+ZEND_API void zend_fiber_resume(zend_fiber *fiber, zval *value, INTERNAL_FUNCTION_PARAMETERS);
+ZEND_API void zend_fiber_throw(zend_fiber *fiber, zval *exception, INTERNAL_FUNCTION_PARAMETERS);
+
+/* These functions may be used to create custom fibers (coroutines) using the bundled fiber switching context. */
 ZEND_API zend_bool zend_fiber_init_context(zend_fiber_context *context, zend_fiber_coroutine coroutine, size_t stack_size);
 ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context);
-
 ZEND_API void zend_fiber_switch_context(zend_fiber_context *to);
 ZEND_API void zend_fiber_suspend_context(zend_fiber_context *current);
 

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -94,10 +94,10 @@ static const zend_uchar ZEND_FIBER_STATUS_FINISHED  = 0x2c;
 
 /* These functions create and manipulate a Fiber object, allowing any internal function to start, resume, or suspend a fiber. */
 ZEND_API zend_fiber *zend_fiber_create(const zend_fcall_info *fci, const zend_fcall_info_cache *fci_cache);
-ZEND_API void zend_fiber_start(zend_fiber *fiber, zval *params, uint32_t param_count, zend_array *named_params, INTERNAL_FUNCTION_PARAMETERS);
-ZEND_API void zend_fiber_suspend(zval *value, INTERNAL_FUNCTION_PARAMETERS);
-ZEND_API void zend_fiber_resume(zend_fiber *fiber, zval *value, INTERNAL_FUNCTION_PARAMETERS);
-ZEND_API void zend_fiber_throw(zend_fiber *fiber, zval *exception, INTERNAL_FUNCTION_PARAMETERS);
+ZEND_API void zend_fiber_start(zend_fiber *fiber, zval *params, uint32_t param_count, zend_array *named_params, zval *return_value);
+ZEND_API void zend_fiber_suspend(zval *value, zval *return_value);
+ZEND_API void zend_fiber_resume(zend_fiber *fiber, zval *value, zval *return_value);
+ZEND_API void zend_fiber_throw(zend_fiber *fiber, zval *exception, zval *return_value);
 
 /* These functions may be used to create custom fibers (coroutines) using the bundled fiber switching context. */
 ZEND_API zend_bool zend_fiber_init_context(zend_fiber_context *context, zend_fiber_coroutine coroutine, size_t stack_size);


### PR DESCRIPTION
This additional internal fiber API creates and manipulates a Fiber object, allowing any internal function to start, resume, or suspend a fiber. The existing `zend_fiber_context` API allows custom C-based fiber creation using the bundled switching context, but does not interact with the PHP VM. This API uses `zend_fiber` and behaves the same as calling Fiber object methods from user code, switching EGs, and triggering the fiber switch observer. In general, the Fiber object methods call these new API methods.