### PR TITLE
Ignore IntelliJ IDEA IDEs from being tracked by Git in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,8 @@ tmp-php.ini
 !/ext/fileinfo/magicdata.patch
 !/ext/pcre/pcre2lib/config.h
 !/win32/build/Makefile
+
+# ------------------------------------------------------------------------------
+# IntelliJ IDEA CLion or related IDEs
+# ------------------------------------------------------------------------------
+.idea/


### PR DESCRIPTION
I'm using CLion for coding which is a product of IntelliJ but git
is tracking this directory. This patch ignores the dir (.idea/).