### PR TITLE
Remove all *_EXTERN_C() in C source files

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1189,7 +1189,6 @@ ZEND_COLD void zenderror(const char *error) /* {{{ */
 }
 /* }}} */
 
-BEGIN_EXTERN_C()
 ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32_t lineno) /* {{{ */
 {
 
@@ -1205,7 +1204,6 @@ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32
 	LONGJMP(*EG(bailout), FAILURE);
 }
 /* }}} */
-END_EXTERN_C()
 
 ZEND_API void zend_append_version_info(const zend_extension *extension) /* {{{ */
 {
@@ -1298,7 +1296,6 @@ ZEND_API void zend_deactivate(void) /* {{{ */
 }
 /* }}} */
 
-BEGIN_EXTERN_C()
 ZEND_API void zend_message_dispatcher(zend_long message, const void *data) /* {{{ */
 {
 	if (zend_message_dispatcher_p) {
@@ -1306,7 +1303,6 @@ ZEND_API void zend_message_dispatcher(zend_long message, const void *data) /* {{
 	}
 }
 /* }}} */
-END_EXTERN_C()
 
 ZEND_API zval *zend_get_configuration_directive(zend_string *name) /* {{{ */
 {

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -118,7 +118,6 @@ do {																			\
 #define ZEND_IS_OCT(c)  ((c)>='0' && (c)<='7')
 #define ZEND_IS_HEX(c)  (((c)>='0' && (c)<='9') || ((c)>='a' && (c)<='f') || ((c)>='A' && (c)<='F'))
 
-BEGIN_EXTERN_C()
 
 static void strip_underscores(char *str, size_t *len)
 {
@@ -587,7 +586,6 @@ ZEND_API zend_result open_file_for_scanning(zend_file_handle *file_handle)
 	CG(increment_lineno) = 0;
 	return SUCCESS;
 }
-END_EXTERN_C()
 
 static zend_op_array *zend_compile(int type)
 {
@@ -811,7 +809,6 @@ zend_op_array *compile_string(zend_string *source_string, const char *filename)
 }
 
 
-BEGIN_EXTERN_C()
 zend_result highlight_file(const char *filename, zend_syntax_highlighter_ini *syntax_highlighter_ini)
 {
 	zend_lex_state original_lex_state;

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -292,10 +292,6 @@ static double private_mem[PRIVATE_mem], *pmem_next = private_mem;
 #include "math.h"
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef CONST
 #ifdef KR_headers
 #define CONST /* blank */
@@ -527,12 +523,6 @@ BCinfo { int dp0, dp1, dplen, dsign, e0, inexact, nd, nd0, rounding, scale, uflc
 #endif
 
 #define Kmax 7
-
-#ifdef __cplusplus
-extern "C" double strtod(const char *s00, char **se);
-extern "C" char *dtoa(double d, int mode, int ndigits,
-			int *decpt, int *sign, char **rve);
-#endif
 
  struct
 Bigint {
@@ -4553,7 +4543,3 @@ static void free_p5s(void)
 	}
 	FREE_DTOA_LOCK(1)
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/ext/phar/dirstream.c
+++ b/ext/phar/dirstream.c
@@ -21,9 +21,7 @@
 #include "phar_internal.h"
 #include "dirstream.h"
 
-BEGIN_EXTERN_C()
 void phar_dostat(phar_archive_data *phar, phar_entry_info *data, php_stream_statbuf *ssb, bool is_dir);
-END_EXTERN_C()
 
 const php_stream_ops phar_dir_ops = {
 	phar_dir_write, /* write */

--- a/win32/readdir.c
+++ b/win32/readdir.c
@@ -21,10 +21,6 @@
  * The DIR typedef is not compatible with Unix.
  **********************************************************************/
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 DIR *opendir(const char *dir)
 {/*{{{*/
 	DIR *dp;
@@ -196,7 +192,3 @@ int rewinddir(DIR *dp)
 
 	return 0;
 }/*}}}*/
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
I think they are useless and maybe someone just copied the content from the header file at the time?
We even lost `END_EXTERN_C()` in `Zend/zend_language_scanner.l`.