### PR TITLE
Add missing extern "C" in zend.h

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -388,11 +388,13 @@ typedef struct _zend_error_info {
 	zend_string *message;
 } zend_error_info;
 
+BEGIN_EXTERN_C()
 ZEND_API void zend_save_error_handling(zend_error_handling *current);
 ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, zend_class_entry *exception_class, zend_error_handling *current);
 ZEND_API void zend_restore_error_handling(zend_error_handling *saved);
 ZEND_API void zend_begin_record_errors(void);
 ZEND_API void zend_free_recorded_errors(void);
+END_EXTERN_C()
 
 #define DEBUG_BACKTRACE_PROVIDE_OBJECT (1<<0)
 #define DEBUG_BACKTRACE_IGNORE_ARGS    (1<<1)


### PR DESCRIPTION
Although I think we can put all of the code in `extern "C"`, I still keep the current style...
It seems that we often forget to do this when we add new APIs.