### PR TITLE
Add zend_getpagesize() and reuse it in accelerator and fiber

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1207,7 +1207,7 @@ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32
 /* }}} */
 END_EXTERN_C()
 
-ZEND_API size_t zend_getpagesize(void)
+ZEND_API size_t zend_get_page_size(void)
 {
 #ifdef _WIN32
 	SYSTEM_INFO system_info;

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1207,6 +1207,21 @@ ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32
 /* }}} */
 END_EXTERN_C()
 
+ZEND_API size_t zend_getpagesize(void)
+{
+#ifdef _WIN32
+	SYSTEM_INFO system_info;
+	GetSystemInfo(&system_info);
+	return system_info.dwPageSize;
+#elif defined(__FreeBSD__)
+	/* This returns the value obtained from
+	 * the auxv vector, avoiding a syscall. */
+	return getpagesize();
+#else
+	return (size_t) sysconf(_SC_PAGESIZE);
+#endif
+}
+
 ZEND_API void zend_append_version_info(const zend_extension *extension) /* {{{ */
 {
 	char *new_info;

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -265,7 +265,7 @@ zend_result zend_post_startup(void);
 void zend_set_utility_values(zend_utility_values *utility_values);
 
 ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32_t lineno);
-ZEND_API size_t zend_getpagesize(void);
+ZEND_API size_t zend_get_page_size(void);
 
 ZEND_API size_t zend_vspprintf(char **pbuf, size_t max_len, const char *format, va_list ap);
 ZEND_API size_t zend_spprintf(char **message, size_t max_len, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 3, 4);

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -265,6 +265,7 @@ zend_result zend_post_startup(void);
 void zend_set_utility_values(zend_utility_values *utility_values);
 
 ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32_t lineno);
+ZEND_API size_t zend_getpagesize(void);
 
 ZEND_API size_t zend_vspprintf(char **pbuf, size_t max_len, const char *format, va_list ap);
 ZEND_API size_t zend_spprintf(char **message, size_t max_len, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 3, 4);

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -90,12 +90,12 @@ extern transfer_t jump_fcontext(fcontext_t to, void *vp);
 # define ZEND_FIBER_STACK_FLAGS (MAP_PRIVATE | MAP_ANON)
 #endif
 
-static size_t zend_fiber_getpagesize(void)
+static size_t zend_fiber_get_page_size(void)
 {
 	static size_t page_size = 0;
 
 	if (!page_size) {
-		page_size = zend_getpagesize();
+		page_size = zend_get_page_size();
 		if (!page_size || (page_size & (page_size - 1))) {
 			/* anyway, we have to return a valid result */
 			page_size = ZEND_FIBER_DEFAULT_PAGE_SIZE;
@@ -108,7 +108,7 @@ static size_t zend_fiber_getpagesize(void)
 static bool zend_fiber_stack_allocate(zend_fiber_stack *stack, size_t size)
 {
 	void *pointer;
-	const size_t page_size = zend_fiber_getpagesize();
+	const size_t page_size = zend_fiber_get_page_size();
 
 	ZEND_ASSERT(size >= page_size + ZEND_FIBER_GUARD_PAGES * page_size);
 
@@ -165,7 +165,7 @@ static void zend_fiber_stack_free(zend_fiber_stack *stack)
 	VALGRIND_STACK_DEREGISTER(stack->valgrind);
 #endif
 
-	const size_t page_size = zend_fiber_getpagesize();
+	const size_t page_size = zend_fiber_get_page_size();
 
 	void *pointer = (void *) ((uintptr_t) stack->pointer - ZEND_FIBER_GUARD_PAGES * page_size);
 

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -90,27 +90,25 @@ extern transfer_t jump_fcontext(fcontext_t to, void *vp);
 # define ZEND_FIBER_STACK_FLAGS (MAP_PRIVATE | MAP_ANON)
 #endif
 
-
-
-static size_t zend_fiber_page_size()
+static size_t zend_fiber_getpagesize(void)
 {
-#if _POSIX_MAPPED_FILES
-	static size_t page_size;
+	static size_t page_size = 0;
 
 	if (!page_size) {
-		page_size = sysconf(_SC_PAGESIZE);
+		page_size = zend_getpagesize();
+		if (!page_size || (page_size & (page_size - 1))) {
+			/* anyway, we have to return a valid result */
+			page_size = ZEND_FIBER_DEFAULT_PAGE_SIZE;
+		}
 	}
 
 	return page_size;
-#else
-	return ZEND_FIBER_DEFAULT_PAGE_SIZE;
-#endif
 }
 
 static bool zend_fiber_stack_allocate(zend_fiber_stack *stack, size_t size)
 {
 	void *pointer;
-	const size_t page_size = zend_fiber_page_size();
+	const size_t page_size = zend_fiber_getpagesize();
 
 	ZEND_ASSERT(size >= page_size + ZEND_FIBER_GUARD_PAGES * page_size);
 
@@ -167,7 +165,7 @@ static void zend_fiber_stack_free(zend_fiber_stack *stack)
 	VALGRIND_STACK_DEREGISTER(stack->valgrind);
 #endif
 
-	const size_t page_size = zend_fiber_page_size();
+	const size_t page_size = zend_fiber_getpagesize();
 
 	void *pointer = (void *) ((uintptr_t) stack->pointer - ZEND_FIBER_GUARD_PAGES * page_size);
 

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3171,14 +3171,8 @@ static zend_result accel_post_startup(void)
 		 && zend_jit_check_support() == SUCCESS) {
 			size_t page_size;
 
-# ifdef _WIN32
-			SYSTEM_INFO system_info;
-			GetSystemInfo(&system_info);
-			page_size = system_info.dwPageSize;
-# else
-			page_size = getpagesize();
-# endif
-			if (!page_size || (page_size & (page_size - 1))) {
+			page_size = zend_getpagesize();
+			if (!page_size && (page_size & (page_size - 1))) {
 				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - can't get page size.");
 				abort();
 			}

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3171,7 +3171,7 @@ static zend_result accel_post_startup(void)
 		 && zend_jit_check_support() == SUCCESS) {
 			size_t page_size;
 
-			page_size = zend_getpagesize();
+			page_size = zend_get_page_size();
 			if (!page_size && (page_size & (page_size - 1))) {
 				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - can't get page size.");
 				abort();


### PR DESCRIPTION
The code is referenced from https://github.com/jemalloc/jemalloc/blob/master/src/pages.c#L417 .
A small change, just for code reuse.