### PR TITLE
Fix docs: Improve documentation for better clarity to readers

### DIFF
--- a/docs/mailinglist-rules.md
+++ b/docs/mailinglist-rules.md
@@ -1,14 +1,14 @@
-# Mailinglist rules
+# Mailing list rules
 
 This is the first file you should be reading before doing any posts on PHP
-mailinglists. Following these rules is considered imperative to the success of
-the PHP project. Therefore expect your contributions to be of much less positive
+mailing lists. Following these rules is considered imperative to the success of
+the PHP project. Therefore, expect your contributions to be of much less positive
 impact if you do not follow these rules. More importantly you can actually
 assume that not following these rules will hurt the PHP project.
 
 PHP is developed through the efforts of a large number of people.
-Collaboration is a Good Thing(tm), and mailinglists lets us do this. Thus,
-following some basic rules with regards to mailinglist usage will:
+Collaboration is a Good Thing(tm), and mailing lists lets us do this. Thus,
+following some basic rules with regards to mailing list usage will:
 
    a. Make everybody happier, especially those responsible for developing PHP
       itself.
@@ -24,11 +24,11 @@ Having said that, here are the organizational rules:
    1. Respect other people working on the project.
 
    2. Do not post when you are angry. Any post can wait a few hours. Review
-      your post after a good breather or a good nights sleep.
+      your post after a good breather, or a good nights sleep.
 
-   3. Make sure you pick the right mailinglist for your posting. Please review
+   3. Make sure you pick the right mailing list for your posting. Please review
       the descriptions on the
-      [mailinglist overview page](https://www.php.net/mailing-lists.php). When
+      [mailing list overview page](https://www.php.net/mailing-lists.php). When
       in doubt ask a friend or someone you trust on IRC.
 
    4. Make sure you know what you are talking about. PHP is a very large project
@@ -37,8 +37,8 @@ Having said that, here are the organizational rules:
       research before posting to the entire developer community.
 
    5. Patches have a much greater chance of acceptance than just asking the
-      PHP developers to implement a feature for you. For one it makes the
-      discussion more concrete and it shows that the poster put thought and time
+      PHP developers to implement a feature for you. For one, it makes the
+      discussion more concrete, and it shows that the poster put thought and time
       into the request.
 
    6. If you are posting to an existing thread, make sure that you know what
@@ -51,7 +51,7 @@ Having said that, here are the organizational rules:
 The next few rules are more some general hints:
 
    1. If you notice that your posting ratio is much higher than that of other
-      people, double check the above rules. Try to wait a bit longer before
+      people, double-check the above rules. Try to wait a bit longer before
       sending your replies to give other people more time to digest your answers
       and more importantly give you the opportunity to make sure that you
       aggregate your current position into a single mail instead of multiple

--- a/docs/output-api.md
+++ b/docs/output-api.md
@@ -108,7 +108,7 @@ for every output handler op.
 
 ## Output handler hooks
 
-The output handler can change its abilities at runtime. Eg. the gz handler can
+The output handler can change its abilities at runtime. For example, the gz handler can
 remove the CLEANABLE and REMOVABLE bits when the first output has passed through it;
 or handlers implemented in C to be used with ob_start() can contain a non-global
 context:

--- a/docs/parameter-parsing-api.md
+++ b/docs/parameter-parsing-api.md
@@ -58,9 +58,9 @@ See also
 
 ## Type specifiers
 
-The following list shows the type specifier, its meaning and the parameter types
+The following list shows the type specifier, its meaning, and the parameter types
 that need to be passed by address. All passed parameters are set if the PHP
-parameter is non optional and untouched if optional and the parameter is not
+parameter is non-optional and untouched if optional and the parameter is not
 present. The only exception is O where the zend_class_entry* has to be provided
 on input and is used to verify the PHP parameter is an instance of that class.
 
@@ -95,7 +95,7 @@ The following characters also have a meaning in the specifier string:
   by the parsing function if they are not passed to it.
 * `/` - use SEPARATE_ZVAL() on the parameter it follows
 * `!` - the parameter it follows can be of specified type or NULL. If NULL is
-  passed and the output for such type is a pointer, then the output pointer is
+  passed, and the output for such type is a pointer, then the output pointer is
   set to a native NULL pointer. For 'b', 'l' and 'd', an extra argument of type
   zend_bool* must be passed after the corresponding bool*, zend_long* or
   double* arguments, respectively. A non-zero value will be written to the

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -143,7 +143,7 @@ explained at the end of this document in
 
     Note: Remember to update the sha256 checksum information.
 
- 2. Skip this step for non stable releases after GA of minor or major versions
+ 2. Skip this step for non-stable releases after GA of minor or major versions
     (e.g. announce 7.4.0RC1, but not 7.4.1RC1):
 
     Add a short notice to web-php stating that there is a new release, and
@@ -433,7 +433,7 @@ branch:
  1. Email systems@php.net to get setup for access to downloads.php.net and to be added
     to the release-managers@ distribution list.
     
- 2. Request membership to the Release Managers group on github.
+ 2. Request membership to the Release Managers group on GitHub.
 
  3. Create a GPG key for your @php.net address and publish it by editing
     `include/gpg-keys.inc` in the `web-php` repository, adding the output of

--- a/docs/self-contained-extensions.md
+++ b/docs/self-contained-extensions.md
@@ -169,5 +169,5 @@ points to be regarded.
 #define PHP_FOO_VERSION "1.2.3"
 ```
 
-This macros has to be used within your foo_module_entry to indicate the
+This macro has to be used within your foo_module_entry to indicate the
 extension version.

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -169,7 +169,7 @@ PHPAPI int php_stream_supports_lock(php_stream * stream);
 ```
 
 This function will return either 1 (success) or 0 (failure) indicating whether
-or not a lock can be set on this stream. Typically you can only set locks on
+or not a lock can be set on this stream. Typically, you can only set locks on
 stdio streams.
 
 ## Casting streams
@@ -209,7 +209,7 @@ if you mix ANSI stdio calls on the FILE* with php stream calls on the stream.
 
 If your system has the fopencookie function, php streams can synthesize a
 `FILE*` on top of any stream, which is useful for SSL sockets, memory based
-streams, data base streams etc. etc.
+streams, database streams etc. etc.
 
 In situations where this is not desirable, you should query the stream to see if
 it naturally supports `FILE *`. You can use this code snippet for this purpose:
@@ -353,7 +353,7 @@ stream = php_stream_alloc(&my_ops, state, 0, persistent, "r");
 ```
 
 Once you have that part figured out, you can write your implementation and
-define the your own php_stream_ops struct (we called it my_ops in the above
+define your own php_stream_ops struct (we called it my_ops in the above
 example).
 
 For example, for reading from this weird MySQL stream:


### PR DESCRIPTION
While reading the docs in the repo, I found & made a few improvements to the
documentation so it's clearer to its readers.

These improvements are around: typos, general punctuations, and grammar.