### PR TITLE
Remove unnecessary inline define

### DIFF
--- a/Zend/zend_config.w32.h
+++ b/Zend/zend_config.w32.h
@@ -48,16 +48,6 @@
 #define strcasecmp(s1, s2) _stricmp(s1, s2)
 #define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
 
-#ifndef __cplusplus
-/* This will cause the compilation process to be MUCH longer, but will generate
- * a much quicker PHP binary
- */
-#ifdef ZEND_WIN32_FORCE_INLINE
-# undef inline
-# define inline __forceinline
-#endif
-#endif
-
 #ifdef LIBZEND_EXPORTS
 #	define ZEND_API __declspec(dllexport)
 #else

--- a/main/php.h
+++ b/main/php.h
@@ -95,13 +95,6 @@ typedef int gid_t;
 typedef char * caddr_t;
 typedef int pid_t;
 
-# ifndef PHP_DEBUG
-#  ifdef inline
-#   undef inline
-#  endif
-#  define inline		__inline
-# endif
-
 # define M_TWOPI        (M_PI * 2.0)
 # define off_t			_off_t
 

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3439,7 +3439,7 @@ function toolset_setup_build_mode()
 			ADD_FLAG("CFLAGS", "/Od /D NDebug /D NDEBUG /D ZEND_WIN32_NEVER_INLINE /D ZEND_DEBUG=0");
 		} else {
 			// Equivalent to Release_TSInline build -> best optimization
-			ADD_FLAG("CFLAGS", "/Ox /D NDebug /D NDEBUG /D ZEND_WIN32_FORCE_INLINE /GF /D ZEND_DEBUG=0");
+			ADD_FLAG("CFLAGS", "/Ox /D NDebug /D NDEBUG /GF /D ZEND_DEBUG=0");
 		}
 
 		// if you have VS.Net /GS hardens the binary against buffer overruns


### PR DESCRIPTION
This is a standard keyword in C99, which is what we use.