### PR TITLE
Speed up ext/dba/tests/bug78808.phpt

### DIFF
--- a/ext/dba/tests/bug78808.phpt
+++ b/ext/dba/tests/bug78808.phpt
@@ -2,7 +2,6 @@
 Bug #78808 ([LMDB] MDB_MAP_FULL: Environment mapsize limit reached)
 --SKIPIF--
 <?php
-if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 $handler = 'lmdb';
 require_once __DIR__ .'/skipif.inc';
 ?>

--- a/ext/dba/tests/bug78808.phpt
+++ b/ext/dba/tests/bug78808.phpt
@@ -10,9 +10,9 @@ require_once __DIR__ .'/skipif.inc';
 <?php
 $handler = 'lmdb';
 require_once __DIR__ .'/test.inc';
-$value = str_repeat('*', 0x10000);
+$value = str_repeat('*', 0x100000);
 $lmdb_h = dba_open($db_filename, 'c', 'lmdb', 0644, 5*1048576);
-for ($i = 0; $i < 50; $i++) {
+for ($i = 0; $i < 3; $i++) {
     dba_insert('key' . $i, $value, $lmdb_h);
 }
 dba_close($lmdb_h);

--- a/ext/dba/tests/bug78808.phpt
+++ b/ext/dba/tests/bug78808.phpt
@@ -10,9 +10,10 @@ require_once __DIR__ .'/skipif.inc';
 <?php
 $handler = 'lmdb';
 require_once __DIR__ .'/test.inc';
+$value = str_repeat('*', 0x10000);
 $lmdb_h = dba_open($db_filename, 'c', 'lmdb', 0644, 5*1048576);
-for ($i = 0; $i < 50000; $i++) {
-    dba_insert('key' . $i, 'value '. $i, $lmdb_h);
+for ($i = 0; $i < 50; $i++) {
+    dba_insert('key' . $i, $value, $lmdb_h);
 }
 dba_close($lmdb_h);
 echo "done\n";


### PR DESCRIPTION
This tests takes about 2 minutes on AppVeyor CI, what is super slow.
The problem is that we're doing 50,000 inserts of small keys and values
instead of only few inserts with large values, what basically has the
same effect regarding the mmap size.