### PR TITLE
Export ENV in .sh file generated by run-tests

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2780,9 +2780,14 @@ COMMAND $cmd
 
         // write .sh
         if (strpos($log_format, 'S') !== false) {
+            $env_lines = [];
+            foreach ($env as $env_var => $env_val) {
+                $env_lines[] = "export $env_var=" . escapeshellarg($env_val);
+            }
+            $exported_environment = $env_lines ? "\n" . implode("\n", $env_lines) . "\n" : "";
             $sh_script = <<<SH
 #!/bin/sh
-
+{$exported_environment}
 case "$1" in
 "gdb")
     gdb --args {$cmd}


### PR DESCRIPTION
I think there's no argument against doing that ... As a PR instead of directly pushing, maybe it conflicts with someones workflow?

It just annoyed me a little bit while working with a bunch of tests exporting their own env vars...

Will merge next week unless someone disagrees.