### PR TITLE
Fix ZPP object to numeric type

### DIFF
--- a/Zend/tests/bug999999.phpt
+++ b/Zend/tests/bug999999.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #999999 ZPP int/float/number specifier doesn't accept numeric objets
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+var_dump(abs(gmp_init(-3)));
+var_dump(exp(gmp_init(2)));
+var_dump(base_convert('10', gmp_init(2), 10));
+?>
+--EXPECT--
+int(3)
+float(7.38905609893065)
+string(1) "2"

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -482,6 +482,15 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_long_weak(zval *arg, zend_long *dest)
 		*dest = 0;
 	} else if (EXPECTED(Z_TYPE_P(arg) == IS_TRUE)) {
 		*dest = 1;
+	} else if (Z_TYPE_P(arg) == IS_OBJECT) {
+		zend_object *zobj = Z_OBJ_P(arg);
+		zval obj;
+		if (zobj->handlers->cast_object(zobj, &obj, IS_LONG) == FAILURE) {
+			return 0;
+		}
+		OBJ_RELEASE(zobj);
+		ZVAL_COPY_VALUE(arg, &obj);
+		*dest = Z_LVAL_P(arg);
 	} else {
 		return 0;
 	}
@@ -520,6 +529,15 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_double_weak(zval *arg, double *dest) 
 		*dest = 0.0;
 	} else if (EXPECTED(Z_TYPE_P(arg) == IS_TRUE)) {
 		*dest = 1.0;
+	} else if (UNEXPECTED(Z_TYPE_P(arg) == IS_OBJECT)) {
+		zend_object *zobj = Z_OBJ_P(arg);
+		zval obj;
+		if (zobj->handlers->cast_object(zobj, &obj, IS_DOUBLE) == FAILURE) {
+			return 0;
+		}
+		OBJ_RELEASE(zobj);
+		ZVAL_COPY_VALUE(arg, &obj);
+		*dest = Z_DVAL_P(arg);
 	} else {
 		return 0;
 	}
@@ -561,6 +579,14 @@ ZEND_API bool ZEND_FASTCALL zend_parse_arg_number_slow(zval *arg, zval **dest) /
 		ZVAL_LONG(arg, 0);
 	} else if (Z_TYPE_P(arg) == IS_TRUE) {
 		ZVAL_LONG(arg, 1);
+	} else if (UNEXPECTED(Z_TYPE_P(arg) == IS_OBJECT)) {
+		zend_object *zobj = Z_OBJ_P(arg);
+		zval obj;
+		if (zobj->handlers->cast_object(zobj, &obj, _IS_NUMBER) == FAILURE) {
+			return 0;
+		}
+		OBJ_RELEASE(zobj);
+		ZVAL_COPY_VALUE(arg, &obj);
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
Objects which can be casted to a number should be allowed to pass the ZPP check for it in weak mode.

This does not fix this case: https://3v4l.org/CEA1W but that one already warned so it could be caught, however it fixes this case https://3v4l.org/BerDR which worked prior to PHP 8.0.

@cmb69 what do you think about this, as you found the issue while reviewing the doc PRs.