### PR TITLE
pcntl_rfork: following-up suggestions.

### DIFF
--- a/ext/pcntl/tests/pcntl_rfork.phpt
+++ b/ext/pcntl/tests/pcntl_rfork.phpt
@@ -11,14 +11,11 @@ Test function pcntl_rfork() with no flag.
 echo "*** Test with no flags ***\n";
 
 $pid = pcntl_rfork(0);
-if ($pid > 0) {
-	pcntl_wait($status);
-	var_dump($pid);
-} else {
-	var_dump($pid);
+if ($pid == 0) {
+	echo "child";
+  exit;
 }
 ?>
 --EXPECTF--
 *** Test with no flags ***
-int(0)
-int(%d)
+child

--- a/ext/pcntl/tests/pcntl_rfork_badflags.phpt
+++ b/ext/pcntl/tests/pcntl_rfork_badflags.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test function pcntl_rfork() with wrong flags
+--SKIPIF--
+<?php
+	if (!extension_loaded('pcntl')) die('skip pcntl extension not available');
+	elseif (!extension_loaded('posix')) die('skip posix extension not available');
+  if (!function_exists('pcntl_rfork')) die('skip pcntl_rfork unavailable');
+?>
+--FILE--
+<?php
+echo "\n*** Test with RFMEM ***\n";
+try {
+	$pid = pcntl_rfork(32);
+} catch (ValueError $e) {
+	echo $e;
+}
+echo "\n*** Test with RFSIGSHARE ***\n";
+try {
+	$pid = pcntl_rfork(16384);
+} catch (ValueError $e) {
+	echo $e;
+}
+echo "\n*** Test with RFFDG|RFCFDG ***\n";
+try {
+	$pid = pcntl_rfork(RFFDG|RFCFDG);
+} catch (ValueError $e) {
+	echo $e;
+}
+?>
+--EXPECTF--
+*** Test with RFMEM ***
+ValueError: pcntl_rfork(): Argument #1 ($flags) must not include RFMEM value, not allowed within this context in %s
+Stack trace:
+#0 %s: pcntl_rfork(32)
+#1 {main}
+*** Test with RFSIGSHARE ***
+ValueError: pcntl_rfork(): Argument #1 ($flags) must not include RFSIGSHARE value, not allowed within this context in %s
+Stack trace:
+#0 %s: pcntl_rfork(16384)
+#1 {main}
+*** Test with RFFDG|RFCFDG ***
+ValueError: pcntl_rfork(): Argument #1 ($flags) must not include both RFFDG and RFCFDG, because these flags are mutually exclusive in %s
+Stack trace:
+#0 %s: pcntl_rfork(4100)
+#1 {main}

--- a/ext/pcntl/tests/pcntl_rfork_flags.phpt
+++ b/ext/pcntl/tests/pcntl_rfork_flags.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test function pcntl_rfork() with no wait flag.
+Test function pcntl_rfork() with RFCFDG and RFFDG flags.
 --SKIPIF--
 <?php
 	if (!extension_loaded('pcntl')) die('skip pcntl extension not available');
@@ -8,17 +8,24 @@ Test function pcntl_rfork() with no wait flag.
 ?>
 --FILE--
 <?php
-echo "*** Test by with child not reporting to the parent ***\n";
-
-$pid = pcntl_rfork(RFNOWAIT|RFTSIGZMB,SIGUSR1);
+echo "\n*** Test with RFFDG and RFCFDG flags ***\n";
+$pid = pcntl_rfork(RFFDG);
 if ($pid > 0) {
-	var_dump($pid);
+	pcntl_wait($status);
+  var_dump($pid);
 } else {
 	var_dump($pid);
-  sleep(2); // as the child does not wait so we see its "pid"
+  exit;
+}
+
+$pid = pcntl_rfork(RFCFDG);
+if ($pid > 0) {
+  pcntl_wait($status);
+  var_dump($pid);
 }
 ?>
 --EXPECTF--
-*** Test by with child not reporting to the parent ***
-int(%d)
+*** Test with RFFDG and RFCFDG flags ***
 int(0)
+int(%d)
+int(%d)


### PR DESCRIPTION
removing RFMEM constant.
treating beforehand the only case where rfork would return EINVAL.