### PR TITLE
Align fiber C stack size

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -177,11 +177,25 @@ static ZEND_INI_MH(OnSetExceptionStringParamMaxLen) /* {{{ */
 
 static ZEND_INI_MH(OnUpdateFiberStackSize) /* {{{ */
 {
+	zend_long size;
+
 	if (new_value) {
-		EG(fiber_stack_size) = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+		size = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+		if (size == 0) {
+			size = ZEND_FIBER_DEFAULT_C_STACK_SIZE;
+		} else if (size < ZEND_FIBER_MIN_C_STACK_SIZE) {
+			size = ZEND_FIBER_MIN_C_STACK_SIZE;
+		} else if (size > ZEND_FIBER_MAX_C_STACK_SIZE) {
+			size = ZEND_FIBER_MAX_C_STACK_SIZE;
+		} else {
+			size = ZEND_MM_ALIGNED_SIZE_EX(size, ZEND_FIBER_C_STACK_ALIGNMENT);
+		}
 	} else {
-		EG(fiber_stack_size) = ZEND_FIBER_DEFAULT_C_STACK_SIZE;
+		size = ZEND_FIBER_DEFAULT_C_STACK_SIZE;
 	}
+
+	EG(fiber_stack_size) = size;
+
 	return SUCCESS;
 }
 /* }}} */

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -76,8 +76,6 @@ typedef struct _transfer_t {
 extern fcontext_t make_fcontext(void *sp, size_t size, void (*fn)(transfer_t));
 extern transfer_t jump_fcontext(fcontext_t to, void *vp);
 
-#define ZEND_FIBER_DEFAULT_PAGE_SIZE 4096
-
 #define ZEND_FIBER_BACKUP_EG(stack, stack_page_size, execute_data, error_reporting, trace_num, bailout) do { \
 	stack = EG(vm_stack); \
 	stack->top = EG(vm_stack_top); \
@@ -108,7 +106,7 @@ static size_t zend_fiber_get_page_size(void)
 		page_size = zend_get_page_size();
 		if (!page_size || (page_size & (page_size - 1))) {
 			/* anyway, we have to return a valid result */
-			page_size = ZEND_FIBER_DEFAULT_PAGE_SIZE;
+			page_size = ZEND_FIBER_C_STACK_ALIGNMENT;
 		}
 	}
 
@@ -352,11 +350,11 @@ static void ZEND_STACK_ALIGNED zend_fiber_execute(zend_fiber_context *context)
 	EG(vm_stack) = NULL;
 
 	zend_first_try {
-		zend_vm_stack stack = zend_fiber_vm_stack_alloc(ZEND_FIBER_VM_STACK_SIZE);
+		zend_vm_stack stack = zend_fiber_vm_stack_alloc(ZEND_FIBER_DEFAULT_VM_STACK_SIZE);
 		EG(vm_stack) = stack;
 		EG(vm_stack_top) = stack->top + ZEND_CALL_FRAME_SLOT;
 		EG(vm_stack_end) = stack->end;
-		EG(vm_stack_page_size) = ZEND_FIBER_VM_STACK_SIZE;
+		EG(vm_stack_page_size) = ZEND_FIBER_DEFAULT_VM_STACK_SIZE;
 
 		fiber->execute_data = (zend_execute_data *) stack->top;
 		fiber->stack_bottom = fiber->execute_data;

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -25,6 +25,15 @@
 
 BEGIN_EXTERN_C()
 
+#define ZEND_FIBER_C_STACK_ALIGNMENT (4 * 1024)
+#define ZEND_FIBER_DEFAULT_C_STACK_SIZE (ZEND_FIBER_C_STACK_ALIGNMENT * (sizeof(void *) * 64))
+#define ZEND_FIBER_MIN_C_STACK_SIZE (128 * 1024)
+#define ZEND_FIBER_MAX_C_STACK_SIZE (16 * 1024 * 1024)
+
+#define ZEND_FIBER_DEFAULT_VM_STACK_SIZE (sizeof(zval) * 1024)
+
+#define ZEND_FIBER_GUARD_PAGES 1
+
 void zend_register_fiber_ce(void);
 void zend_fiber_init(void);
 
@@ -104,12 +113,6 @@ ZEND_API zend_bool zend_fiber_init_context(zend_fiber_context *context, zend_fib
 ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context);
 ZEND_API void zend_fiber_switch_context(zend_fiber_context *to);
 ZEND_API void zend_fiber_suspend_context(zend_fiber_context *current);
-
-#define ZEND_FIBER_GUARD_PAGES 1
-
-#define ZEND_FIBER_DEFAULT_C_STACK_SIZE (4096 * (((sizeof(void *)) < 8) ? 256 : 512))
-
-#define ZEND_FIBER_VM_STACK_SIZE (1024 * sizeof(zval))
 
 END_EXTERN_C()
 


### PR DESCRIPTION
Also, align the macro names.
Generally, macro definitions are always at the top of the file, it's easier to edit.