### PR TITLE
Refactor Fiber internal implementation

### DIFF
--- a/Zend/tests/fibers/fiber-this.phpt
+++ b/Zend/tests/fibers/fiber-this.phpt
@@ -13,6 +13,7 @@ $fiber->start();
 
 ?>
 --EXPECTF--
-NULL
+object(Fiber)#%d (0) {
+}
 object(Fiber)#%d (0) {
 }

--- a/Zend/tests/fibers/fiber-this.phpt
+++ b/Zend/tests/fibers/fiber-this.phpt
@@ -13,7 +13,6 @@ $fiber->start();
 
 ?>
 --EXPECTF--
-object(Fiber)#%d (0) {
-}
+NULL
 object(Fiber)#%d (0) {
 }

--- a/Zend/tests/fibers/resume-non-running-fiber.phpt
+++ b/Zend/tests/fibers/resume-non-running-fiber.phpt
@@ -9,7 +9,7 @@ $fiber->resume();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught FiberError: Cannot resume a fiber that is not suspended in %sresume-non-running-fiber.php:%d
+Fatal error: Uncaught FiberError: Fiber has not started in %sresume-non-running-fiber.php:%d
 Stack trace:
 #0 %sresume-non-running-fiber.php(%d): Fiber->resume()
 #1 {main}

--- a/Zend/tests/fibers/resume-running-fiber.phpt
+++ b/Zend/tests/fibers/resume-running-fiber.phpt
@@ -12,7 +12,7 @@ $fiber->start();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught FiberError: Cannot resume a fiber that is not suspended in %sresume-running-fiber.php:%d
+Fatal error: Uncaught FiberError: Fiber is running in %sresume-running-fiber.php:%d
 Stack trace:
 #0 %sresume-running-fiber.php(%d): Fiber->resume()
 #1 [internal function]: {closure}()

--- a/Zend/tests/fibers/resume-terminated-fiber.phpt
+++ b/Zend/tests/fibers/resume-terminated-fiber.phpt
@@ -11,7 +11,7 @@ $fiber->resume();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught FiberError: Cannot resume a fiber that is not suspended in %sresume-terminated-fiber.php:%d
+Fatal error: Uncaught FiberError: Fiber is dead in %sresume-terminated-fiber.php:%d
 Stack trace:
 #0 %sresume-terminated-fiber.php(%d): Fiber->resume()
 #1 {main}

--- a/Zend/tests/fibers/suspend-outside-fiber.phpt
+++ b/Zend/tests/fibers/suspend-outside-fiber.phpt
@@ -7,7 +7,7 @@ $value = Fiber::suspend(1);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught FiberError: Cannot suspend outside of a fiber in %ssuspend-outside-fiber.php:%d
+Fatal error: Uncaught FiberError: Fiber has nowhere to go in %ssuspend-outside-fiber.php:%d
 Stack trace:
 #0 %ssuspend-outside-fiber.php(%d): Fiber::suspend(1)
 #1 {main}

--- a/Zend/tests/fibers/throw-into-non-running-fiber.phpt
+++ b/Zend/tests/fibers/throw-into-non-running-fiber.phpt
@@ -9,7 +9,7 @@ $fiber->throw(new Exception('test'));
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught FiberError: Cannot resume a fiber that is not suspended in %sthrow-into-non-running-fiber.php:%d
+Fatal error: Uncaught FiberError: Fiber has not started in %sthrow-into-non-running-fiber.php:%d
 Stack trace:
 #0 %sthrow-into-non-running-fiber.php(%d): Fiber->throw(Object(Exception))
 #1 {main}

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -177,11 +177,25 @@ static ZEND_INI_MH(OnSetExceptionStringParamMaxLen) /* {{{ */
 
 static ZEND_INI_MH(OnUpdateFiberStackSize) /* {{{ */
 {
+	zend_long size;
+
 	if (new_value) {
-		EG(fiber_stack_size) = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+		size = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+		if (size == 0) {
+			size = ZEND_FIBER_DEFAULT_C_STACK_SIZE;
+		} else if (size < ZEND_FIBER_MIN_C_STACK_SIZE) {
+			size = ZEND_FIBER_MIN_C_STACK_SIZE;
+		} else if (size > ZEND_FIBER_MAX_C_STACK_SIZE) {
+			size = ZEND_FIBER_MAX_C_STACK_SIZE;
+		} else {
+			size = ZEND_MM_ALIGNED_SIZE_EX(size, ZEND_FIBER_C_STACK_ALIGNMENT);
+		}
 	} else {
-		EG(fiber_stack_size) = ZEND_FIBER_DEFAULT_C_STACK_SIZE;
+		size = ZEND_FIBER_DEFAULT_C_STACK_SIZE;
 	}
+
+	EG(fiber_stack_size) = size;
+
 	return SUCCESS;
 }
 /* }}} */

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -379,6 +379,7 @@ void shutdown_executor(void) /* {{{ */
 
 	zend_objects_store_free_object_storage(&EG(objects_store), fast_shutdown);
 
+	zend_fiber_shutdown();
 	zend_weakrefs_shutdown();
 
 	zend_try {

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -76,8 +76,6 @@ typedef struct _transfer_t {
 extern fcontext_t make_fcontext(void *sp, size_t size, void (*fn)(transfer_t));
 extern transfer_t jump_fcontext(fcontext_t to, void *vp);
 
-#define ZEND_FIBER_DEFAULT_PAGE_SIZE 4096
-
 #define ZEND_FIBER_BACKUP_EG(stack, stack_page_size, execute_data, error_reporting, trace_num, bailout) do { \
 	stack = EG(vm_stack); \
 	stack->top = EG(vm_stack_top); \
@@ -108,7 +106,7 @@ static size_t zend_fiber_get_page_size(void)
 		page_size = zend_get_page_size();
 		if (!page_size || (page_size & (page_size - 1))) {
 			/* anyway, we have to return a valid result */
-			page_size = ZEND_FIBER_DEFAULT_PAGE_SIZE;
+			page_size = ZEND_FIBER_C_STACK_ALIGNMENT;
 		}
 	}
 
@@ -352,11 +350,11 @@ static void ZEND_STACK_ALIGNED zend_fiber_execute(zend_fiber_context *context)
 	EG(vm_stack) = NULL;
 
 	zend_first_try {
-		zend_vm_stack stack = zend_fiber_vm_stack_alloc(ZEND_FIBER_VM_STACK_SIZE);
+		zend_vm_stack stack = zend_fiber_vm_stack_alloc(ZEND_FIBER_DEFAULT_VM_STACK_SIZE);
 		EG(vm_stack) = stack;
 		EG(vm_stack_top) = stack->top + ZEND_CALL_FRAME_SLOT;
 		EG(vm_stack_end) = stack->end;
-		EG(vm_stack_page_size) = ZEND_FIBER_VM_STACK_SIZE;
+		EG(vm_stack_page_size) = ZEND_FIBER_DEFAULT_VM_STACK_SIZE;
 
 		fiber->execute_data = (zend_execute_data *) stack->top;
 		fiber->stack_bottom = fiber->execute_data;

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -622,6 +622,11 @@ ZEND_METHOD(Fiber, this)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
+	/* Follow RFC for now */
+	if (EG(current_fiber) == EG(main_fiber)) {
+		RETURN_NULL();
+	}
+
 	RETURN_OBJ_COPY(&EG(current_fiber)->std);
 }
 

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -34,85 +34,107 @@ BEGIN_EXTERN_C()
 
 #define ZEND_FIBER_GUARD_PAGES 1
 
-void zend_register_fiber_ce(void);
-void zend_fiber_init(void);
-
 extern ZEND_API zend_class_entry *zend_ce_fiber;
 
+typedef struct _zend_fiber zend_fiber;
 typedef struct _zend_fiber_context zend_fiber_context;
+typedef struct _zend_fiber_executor zend_fiber_executor;
 
-typedef void (*zend_fiber_coroutine)(zend_fiber_context *context);
+#define ZEND_FIBER_STATUS_MAP(XX) \
+	XX(INIT,      0) \
+	XX(RUNNING,   1) \
+	XX(SUSPENDED, 2) \
+	XX(DEAD,      3) \
 
-typedef struct _zend_fiber_stack {
-	void *pointer;
-	size_t size;
+typedef enum {
+#define ZEND_FIBER_STATUS_GEN(name, value) ZEND_FIBER_STATUS_##name = (value),
+	ZEND_FIBER_STATUS_MAP(ZEND_FIBER_STATUS_GEN)
+#undef ZEND_FIBER_STATUS_GEN
+} zend_fiber_status;
 
+#define ZEND_FIBER_FLAG_MAP(XX) \
+	XX(THREW,     1 << 0) \
+	XX(BAILOUT,   1 << 1) \
+	XX(DESTROYED, 1 << 2) \
+
+typedef enum {
+#define ZEND_FIBER_FLAG_GEN(name, value) ZEND_FIBER_FLAG_##name = (value),
+	ZEND_FIBER_FLAG_MAP(ZEND_FIBER_FLAG_GEN)
+#undef ZEND_FIBER_FLAG_GEN
+} zend_fiber_flag;
+
+struct _zend_fiber_context {
+	void *ptr;
+	void *stack;
+	size_t stack_size;
 #ifdef HAVE_VALGRIND
-	int valgrind;
+	unsigned int valgrind_stack_id;
 #endif
-
 #ifdef __SANITIZE_ADDRESS__
-	const void *prior_pointer;
-	size_t prior_size;
+	void *asan_fake_stack;
+	const void *asan_stack_bottom;
+	size_t asan_stack_size;
 #endif
-} zend_fiber_stack;
+};
 
-typedef struct _zend_fiber_context {
-	void *self;
-	void *caller;
-	zend_fiber_coroutine function;
-	zend_fiber_stack stack;
-} zend_fiber_context;
+struct _zend_fiber_executor
+{
+	JMP_BUF *bailout;
+	int error_reporting;
+	int exit_status;
+	zval *vm_stack_top;
+	zval *vm_stack_end;
+	zend_vm_stack vm_stack;
+	size_t vm_stack_page_size;
+	zend_execute_data *current_execute_data;
+	uint32_t jit_trace_num;
+};
 
-typedef struct _zend_fiber {
+/* unrelated fields on executor_globals may be overwritten
+ * if the we use aligned size, so we define unaligned size here. */
+#define ZEND_FIBER_EXECUTOR_UNALIGNED_SIZE (XtOffsetOf(zend_fiber_executor, jit_trace_num) + sizeof(uint32_t))
+
+ZEND_STATIC_ASSERT(ZEND_FIBER_EXECUTOR_UNALIGNED_SIZE ==
+	XtOffsetOf(zend_executor_globals, jit_trace_num) -
+	XtOffsetOf(zend_executor_globals, bailout) + sizeof(uint32_t)
+);
+
+struct _zend_fiber {
 	/* Fiber PHP object handle. */
 	zend_object std;
-
+	/* The one who resumed this fiber */
+	zend_fiber *from;
+	/* Previous one, the target when we suspend. */
+	zend_fiber *previous;
 	/* Status of the fiber, one of the ZEND_FIBER_STATUS_* constants. */
 	zend_uchar status;
-
+	/* Flags of the fiber, collection of the ZEND_FIBER_FLAG_* constants. */
+	zend_uchar flags;
 	/* Callback and info / cache to be used when fiber is started. */
 	zend_fcall_info fci;
 	zend_fcall_info_cache fci_cache;
-
 	/* Context of this fiber, will be initialized during call to Fiber::start(). */
 	zend_fiber_context context;
-
-	/* Current Zend VM execute data being run by the fiber. */
+	/* Executor globals. */
+	zend_fiber_executor *executor;
+	/* Root execute data. */
 	zend_execute_data *execute_data;
+	/* Storage for fiber return value. */
+	zval retval;
+};
 
-	/* Frame on the bottom of the fiber vm stack. */
-	zend_execute_data *stack_bottom;
+void zend_register_fiber_ce(void);
 
-	/* Exception to be thrown from Fiber::suspend(). */
-	zval *exception;
-
-	/* Storage for temporaries and fiber return value. */
-	zval value;
-} zend_fiber;
-
-static const zend_uchar ZEND_FIBER_STATUS_INIT      = 0x0;
-static const zend_uchar ZEND_FIBER_STATUS_SUSPENDED = 0x1;
-static const zend_uchar ZEND_FIBER_STATUS_RUNNING   = 0x2;
-static const zend_uchar ZEND_FIBER_STATUS_RETURNED  = 0x4;
-static const zend_uchar ZEND_FIBER_STATUS_THREW     = 0x8;
-static const zend_uchar ZEND_FIBER_STATUS_SHUTDOWN  = 0x10;
-static const zend_uchar ZEND_FIBER_STATUS_BAILOUT   = 0x20;
-
-static const zend_uchar ZEND_FIBER_STATUS_FINISHED  = 0x2c;
+void zend_fiber_init(void);
+void zend_fiber_shutdown(void);
 
 /* These functions create and manipulate a Fiber object, allowing any internal function to start, resume, or suspend a fiber. */
 ZEND_API zend_fiber *zend_fiber_create(const zend_fcall_info *fci, const zend_fcall_info_cache *fci_cache);
-ZEND_API void zend_fiber_start(zend_fiber *fiber, zval *params, uint32_t param_count, zend_array *named_params, zval *return_value);
-ZEND_API void zend_fiber_suspend(zval *value, zval *return_value);
-ZEND_API void zend_fiber_resume(zend_fiber *fiber, zval *value, zval *return_value);
-ZEND_API void zend_fiber_throw(zend_fiber *fiber, zval *exception, zval *return_value);
-
-/* These functions may be used to create custom fibers (coroutines) using the bundled fiber switching context. */
-ZEND_API zend_bool zend_fiber_init_context(zend_fiber_context *context, zend_fiber_coroutine coroutine, size_t stack_size);
-ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context);
-ZEND_API void zend_fiber_switch_context(zend_fiber_context *to);
-ZEND_API void zend_fiber_suspend_context(zend_fiber_context *current);
+ZEND_API bool zend_fiber_start(zend_fiber *fiber, zval *data, zval *retval);
+ZEND_API void zend_fiber_jump(zend_fiber *fiber, zval *data, zval *retval);
+ZEND_API bool zend_fiber_resume(zend_fiber *fiber, zval *data, zval *retval);
+ZEND_API bool zend_fiber_suspend(zval *data, zval *retval);
+ZEND_API bool zend_fiber_throw(zend_fiber *fiber, zend_object *exception, zval *retval);
 
 END_EXTERN_C()
 

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -25,6 +25,15 @@
 
 BEGIN_EXTERN_C()
 
+#define ZEND_FIBER_C_STACK_ALIGNMENT (4 * 1024)
+#define ZEND_FIBER_DEFAULT_C_STACK_SIZE (ZEND_FIBER_C_STACK_ALIGNMENT * (sizeof(void *) * 64))
+#define ZEND_FIBER_MIN_C_STACK_SIZE (128 * 1024)
+#define ZEND_FIBER_MAX_C_STACK_SIZE (16 * 1024 * 1024)
+
+#define ZEND_FIBER_DEFAULT_VM_STACK_SIZE (sizeof(zval) * 1024)
+
+#define ZEND_FIBER_GUARD_PAGES 1
+
 void zend_register_fiber_ce(void);
 void zend_fiber_init(void);
 
@@ -104,12 +113,6 @@ ZEND_API zend_bool zend_fiber_init_context(zend_fiber_context *context, zend_fib
 ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context);
 ZEND_API void zend_fiber_switch_context(zend_fiber_context *to);
 ZEND_API void zend_fiber_suspend_context(zend_fiber_context *current);
-
-#define ZEND_FIBER_GUARD_PAGES 1
-
-#define ZEND_FIBER_DEFAULT_C_STACK_SIZE (4096 * (((sizeof(void *)) < 8) ? 256 : 512))
-
-#define ZEND_FIBER_VM_STACK_SIZE (1024 * sizeof(zval))
 
 END_EXTERN_C()
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -155,14 +155,14 @@ struct _zend_executor_globals {
 
 	HashTable included_files;	/* files already included */
 
+	HashTable *function_table;	/* function symbol table */
+	HashTable *class_table;		/* class table */
+	HashTable *zend_constants;	/* constants table */
+
 	JMP_BUF *bailout;
 
 	int error_reporting;
 	int exit_status;
-
-	HashTable *function_table;	/* function symbol table */
-	HashTable *class_table;		/* class table */
-	HashTable *zend_constants;	/* constants table */
 
 	zval          *vm_stack_top;
 	zval          *vm_stack_end;
@@ -170,9 +170,10 @@ struct _zend_executor_globals {
 	size_t         vm_stack_page_size;
 
 	struct _zend_execute_data *current_execute_data;
-	zend_class_entry *fake_scope; /* used to avoid checks accessing properties */
 
 	uint32_t jit_trace_num; /* Used by tracing JIT to reference the currently running trace */
+
+	zend_class_entry *fake_scope; /* used to avoid checks accessing properties */
 
 	zend_long precision;
 
@@ -250,11 +251,14 @@ struct _zend_executor_globals {
 
 	zend_get_gc_buffer get_gc_buffer;
 
+	/* Main fiber. */
+	zend_fiber *main_fiber;
 	/* Active fiber, NULL when in main thread. */
 	zend_fiber *current_fiber;
-
 	/* Default fiber C stack size. */
 	zend_long fiber_stack_size;
+	/* Exception thrown from the other fiber */
+	zend_object *fiber_exception;
 
 	/* If record_errors is enabled, all emitted diagnostics will be recorded,
 	 * in addition to being processed as usual. */

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -107,6 +107,8 @@
 # define ZEND_ASSERT(c) ZEND_ASSUME(c)
 #endif
 
+#define ZEND_STATIC_ASSERT(c) void zend_static_assert(int static_assert_failed[1 - 2 * !(c)])
+
 #if ZEND_DEBUG
 # define ZEND_UNREACHABLE() do {ZEND_ASSERT(0); ZEND_ASSUME(0);} while (0)
 #else

--- a/ext/zend_test/tests/observer_fiber_05.phpt
+++ b/ext/zend_test/tests/observer_fiber_05.phpt
@@ -44,9 +44,7 @@ $fiber->resume();
 <destroying '%s'>
 <!-- switching from fiber %s to %s -->
 <destroying '%s'>
-<destroyed '%s'>
 <!-- switching from fiber %s to %s -->
-<destroying '%s'>
 <destroyed '%s'>
 <!-- switching from fiber %s to 0 -->
 <destroyed '%s'>


### PR DESCRIPTION
No BC breaks at the user level.

I tried to divide them into multiple PRs but I failed, changes depend on each other to a certain extent.

1. Introduced main fiber. It's one of the most important parts of this PR. Any C stack can be abstracted as fiber, the main fiber in fibers is like the main thread in threads.

2. Put the fiber object and its context on its own C stack. This is the same trick as the zend_vm_stack does. It also works on the main fiber, we can put the main fiber on the main PHP VM stack without emalloc.

3. Add `zend_fiber_jump` and merge code of `resume`/`suspend`, this is the biggest problem in the previous implementation. The same code appears repeatedly in various places before. I believe the logic of fiber switching is clearer now.
  
  > (expected output of [observer_fiber_05.phpt](https://github.com/php/php-src/blob/master/ext/zend_test/tests/observer_fiber_05.phpt) looks incorrect, we have 2 fibers but there are 3 `destroying` &&  `destroyed`, it's correct after refactor).
  
4. Change the order of executor_globals members, so that we can switch context through a memcpy instead of multiple assignments, this simplifies the code, and for better performance.

5. boost context provided the transfer structure to let users can transfer ptr data between fibers, so we can transfer zval ptr to fiber and use ZVAL_COPY on the peer side without an extra field to store zval. But we still need a zval to store the return value of fiber because we provided `getReturn`

6. Remove the `exception` field from `zend_fiber`, we can use one thread-safe global var instead.

7. About the ASan part (https://github.com/php/php-src/commit/af2905968cdf623bfd80f7d69b8fbc80d6d00c9e ), the code makes me confused, I believe the correct/clearer example is https://github.com/boostorg/context/blob/master/include/boost/context/continuation_ucontext.hpp

8. Rename `value` to `data`, as boost called it `transfer.data ` I believe it's more clear to named it `data` than  `value`

9. Rename `caller` to `from`, as boost called it `transfer.from` (also in boost.fiber), which means where the switch came from.

10. Nested fibers are maintained by linked list structure, we usually use `prev` to represent the previous one, I named it `previous` here.

11. We only need four statuses, `INIT`/`SUSPENDED`/`RUNNING`/`DEAD` (same with Lua coroutine), and it's better to make it be an enum, any other internal status information is expressed in `fiber->flags`

12. Remove zend_fiber_context APIs, they are meaningless

Also, since we do not want to break the RFC, there are many optimizations or enhancements that can not be implemented for now. It is still the beginning.
