### PR TITLE
Improve interface non-public method error message

### DIFF
--- a/Zend/tests/bug71871.phpt
+++ b/Zend/tests/bug71871.phpt
@@ -9,4 +9,4 @@ interface test {
 
 ?>
 --EXPECTF--
-Fatal error: Access type for interface method test::test() must be omitted in %s on line %d
+Fatal error: Access type for interface method test::test() must be public in %s on line %d

--- a/Zend/tests/bug71871_2.phpt
+++ b/Zend/tests/bug71871_2.phpt
@@ -9,4 +9,4 @@ interface test {
 
 ?>
 --EXPECTF--
-Fatal error: Access type for interface method test::test() must be omitted in %s on line %d
+Fatal error: Access type for interface method test::test() must be public in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6945,7 +6945,7 @@ zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string *name, 
 	if (in_interface) {
 		if (!(fn_flags & ZEND_ACC_PUBLIC) || (fn_flags & (ZEND_ACC_FINAL|ZEND_ACC_ABSTRACT))) {
 			zend_error_noreturn(E_COMPILE_ERROR, "Access type for interface method "
-				"%s::%s() must be omitted", ZSTR_VAL(ce->name), ZSTR_VAL(name));
+				"%s::%s() must be public", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		}
 		op_array->fn_flags |= ZEND_ACC_ABSTRACT;
 	}

--- a/tests/classes/interface_method_private.phpt
+++ b/tests/classes/interface_method_private.phpt
@@ -9,4 +9,4 @@ interface if_a {
 
 ?>
 --EXPECTF--
-Fatal error: Access type for interface method if_a::err() must be omitted in %s on line %d
+Fatal error: Access type for interface method if_a::err() must be public in %s on line %d


### PR DESCRIPTION
Currently interface methods with visibility `private` or `protected` fail with an error message:
```
Access type for interface method A::b() must be omitted
```
However, explicitly setting visibility `public` is allowed and often desired. This commit updates the error message to:
```
Access type for interface method A::b() must be omitted or declared public
```