### PR TITLE
Speed up test case

### DIFF
--- a/Zend/tests/bug79514.phpt
+++ b/Zend/tests/bug79514.phpt
@@ -3,14 +3,12 @@ Bug #79514 (Memory leaks while including unexistent file)
 --FILE--
 <?php
 $filename = __DIR__ . '/bug79514.doesnotexist';
-// approximate size of the zend_string
-$size = 8 + 3 * PHP_INT_SIZE + strlen($filename) & ~(PHP_INT_SIZE - 1);
+@include $filename;
+// Further include should not increase memory usage.
 $mem1 = memory_get_usage();
-for ($i = 0; $i < 100; $i++) {
-    @include $filename;
-}
+@include $filename;
 $mem2 = memory_get_usage();
-var_dump($mem2 - $mem1 < 100 * $size);
+var_dump($mem1 == $mem2);
 ?>
 --EXPECT--
 bool(true)

--- a/Zend/tests/bug79514.phpt
+++ b/Zend/tests/bug79514.phpt
@@ -2,12 +2,15 @@
 Bug #79514 (Memory leaks while including unexistent file)
 --FILE--
 <?php
-$mem1 = memory_get_usage(true);
-for ($i = 0; $i < 100000; $i++) {
-    @include __DIR__ . '/bug79514.doesnotexist';
+$filename = __DIR__ . '/bug79514.doesnotexist';
+// approximate size of the zend_string
+$size = 8 + 3 * PHP_INT_SIZE + strlen($filename) & ~(PHP_INT_SIZE - 1);
+$mem1 = memory_get_usage();
+for ($i = 0; $i < 100; $i++) {
+    @include $filename;
 }
-$mem2 = memory_get_usage(true);
-var_dump($mem2 - $mem1 < 100000);
+$mem2 = memory_get_usage();
+var_dump($mem2 - $mem1 < 100 * $size);
 ?>
 --EXPECT--
 bool(true)


### PR DESCRIPTION
This test case did 100,000 includes of a non existing file to show the
memory leak; this is not necessary, if we (approximately) calculate the
actual size of the zend_string, and rely on the actual memory allocated
by ZendMM.