### PR TITLE
array_is_list will return false when array is empty.

### DIFF
--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -1222,9 +1222,9 @@ static zend_always_inline zend_bool zend_array_is_list(zend_array *array)
 	zend_long expected_idx = 0;
 	zend_long num_idx;
 	zend_string* str_idx;
-	/* Empty arrays are lists */
+	/* Empty arrays are not lists */
 	if (zend_hash_num_elements(array) == 0) {
-		return 1;
+		return 0;
 	}
 
 	/* Packed arrays are lists */

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -1227,7 +1227,7 @@ static zend_always_inline zend_bool zend_array_is_list(zend_array *array)
 		return 0;
 	}
 
-	/* Packed arrays are lists */
+	/* Packed arrays are lists, because empty array without any key */
 	if (HT_IS_PACKED(array) && HT_IS_WITHOUT_HOLES(array)) {
 		return 1;
 	}

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -1222,12 +1222,12 @@ static zend_always_inline zend_bool zend_array_is_list(zend_array *array)
 	zend_long expected_idx = 0;
 	zend_long num_idx;
 	zend_string* str_idx;
-	/* Empty arrays are not lists */
+	/* Empty arrays are not lists, because empty array without any key. */
 	if (zend_hash_num_elements(array) == 0) {
 		return 0;
 	}
 
-	/* Packed arrays are lists, because empty array without any key */
+	/* Packed arrays are lists */
 	if (HT_IS_PACKED(array) && HT_IS_WITHOUT_HOLES(array)) {
 		return 1;
 	}

--- a/ext/standard/tests/general_functions/array_is_list.phpt
+++ b/ext/standard/tests/general_functions/array_is_list.phpt
@@ -92,7 +92,7 @@ unset middle: false
 unset end: true
 unset string key: true
 unset into order: true
-unset to empty: true
+unset to empty: false
 append implicit: true
 append explicit: true
 append with gap: false

--- a/ext/standard/tests/general_functions/array_is_list.phpt
+++ b/ext/standard/tests/general_functions/array_is_list.phpt
@@ -69,7 +69,7 @@ $arr[4] = 5;
 test_is_list("append with gap", $arr);
 
 --EXPECT--
-empty: true
+empty: false
 one: true
 two: true
 three: true
@@ -92,7 +92,7 @@ unset middle: false
 unset end: true
 unset string key: true
 unset into order: true
-unset to empty: true
+unset to empty: false
 append implicit: true
 append explicit: true
 append with gap: false

--- a/ext/standard/tests/general_functions/array_is_list.phpt
+++ b/ext/standard/tests/general_functions/array_is_list.phpt
@@ -92,7 +92,7 @@ unset middle: false
 unset end: true
 unset string key: true
 unset into order: true
-unset to empty: false
+unset to empty: true
 append implicit: true
 append explicit: true
 append with gap: false


### PR DESCRIPTION
Hi.

I think array_is_list() will return false when array is empty, because empty array without any keys.

The definition of array_is_list:

Add a new function `array_is_list(array $array): bool` that will return true if the array keys are `0 .. count($array)-1` in that order. 

But

```php
<?php
$test = [];
var_dump($test[0]);

//Warning: Undefined array key 0 in /home/test/array_is_list.php on line 3
```

Thanks