### PR TITLE
Split fiber status and flags

### DIFF
--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -25,6 +25,19 @@
 
 BEGIN_EXTERN_C()
 
+typedef enum {
+	ZEND_FIBER_STATUS_INIT,
+	ZEND_FIBER_STATUS_RUNNING,
+	ZEND_FIBER_STATUS_SUSPENDED,
+	ZEND_FIBER_STATUS_DEAD,
+} zend_fiber_status;
+
+typedef enum {
+	ZEND_FIBER_FLAG_THREW     = 1 << 0,
+	ZEND_FIBER_FLAG_BAILOUT   = 1 << 1,
+	ZEND_FIBER_FLAG_DESTROYED = 1 << 2,
+} zend_fiber_flag;
+
 void zend_register_fiber_ce(void);
 void zend_fiber_init(void);
 
@@ -59,8 +72,11 @@ typedef struct _zend_fiber {
 	/* Fiber PHP object handle. */
 	zend_object std;
 
-	/* Status of the fiber, one of the ZEND_FIBER_STATUS_* constants. */
-	zend_uchar status;
+	/* Status of the fiber, one of the zend_fiber_status values. */
+	zend_fiber_status status;
+
+	/* Flags of the fiber, bit field of the zend_fiber_flag values. */
+	zend_uchar flags;
 
 	/* Callback and info / cache to be used when fiber is started. */
 	zend_fcall_info fci;
@@ -81,16 +97,6 @@ typedef struct _zend_fiber {
 	/* Storage for temporaries and fiber return value. */
 	zval value;
 } zend_fiber;
-
-static const zend_uchar ZEND_FIBER_STATUS_INIT      = 0x0;
-static const zend_uchar ZEND_FIBER_STATUS_SUSPENDED = 0x1;
-static const zend_uchar ZEND_FIBER_STATUS_RUNNING   = 0x2;
-static const zend_uchar ZEND_FIBER_STATUS_RETURNED  = 0x4;
-static const zend_uchar ZEND_FIBER_STATUS_THREW     = 0x8;
-static const zend_uchar ZEND_FIBER_STATUS_SHUTDOWN  = 0x10;
-static const zend_uchar ZEND_FIBER_STATUS_BAILOUT   = 0x20;
-
-static const zend_uchar ZEND_FIBER_STATUS_FINISHED  = 0x2c;
 
 /* These functions create and manipulate a Fiber object, allowing any internal function to start, resume, or suspend a fiber. */
 ZEND_API zend_fiber *zend_fiber_create(const zend_fcall_info *fci, const zend_fcall_info_cache *fci_cache);

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6873,7 +6873,7 @@ ZEND_METHOD(ReflectionFiber, getFiber)
 }
 
 #define REFLECTION_CHECK_VALID_FIBER(fiber) do { \
-		if (fiber == NULL || fiber->status == ZEND_FIBER_STATUS_INIT || fiber->status & ZEND_FIBER_STATUS_FINISHED) { \
+		if (fiber == NULL || fiber->status == ZEND_FIBER_STATUS_INIT || fiber->status == ZEND_FIBER_STATUS_DEAD) { \
 			zend_throw_error(NULL, "Cannot fetch information from a fiber that has not been started or is terminated"); \
 			RETURN_THROWS(); \
 		} \
@@ -6948,7 +6948,7 @@ ZEND_METHOD(ReflectionFiber, getCallable)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	if (fiber == NULL || fiber->status & ZEND_FIBER_STATUS_FINISHED) {
+	if (fiber == NULL || fiber->status == ZEND_FIBER_STATUS_DEAD) {
 		zend_throw_error(NULL, "Cannot fetch the callable from a fiber that has terminated"); \
 		RETURN_THROWS();
 	}

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -425,9 +425,11 @@ static void fiber_enter_observer(zend_fiber *from, zend_fiber *to)
 			if (to->status == ZEND_FIBER_STATUS_INIT) {
 				php_printf("<init '%p'>\n", to);
 			} else if (to->status == ZEND_FIBER_STATUS_RUNNING && (!from || from->status == ZEND_FIBER_STATUS_RUNNING)) {
-				php_printf("<resume '%p'>\n", to);
-			} else if (to->status == ZEND_FIBER_STATUS_SHUTDOWN) {
-				php_printf("<destroying '%p'>\n", to);
+				if (to->flags & ZEND_FIBER_FLAG_DESTROYED) {
+					php_printf("<destroying '%p'>\n", to);
+				} else if (to->status != ZEND_FIBER_STATUS_DEAD) {
+					php_printf("<resume '%p'>\n", to);
+				}
 			}
 		}
 	}
@@ -439,12 +441,14 @@ static void fiber_suspend_observer(zend_fiber *from, zend_fiber *to)
 		if (from) {
 			if (from->status == ZEND_FIBER_STATUS_SUSPENDED) {
 				php_printf("<suspend '%p'>\n", from);
-			} else if (from->status == ZEND_FIBER_STATUS_RETURNED) {
-				php_printf("<returned '%p'>\n", from);
-			} else if (from->status == ZEND_FIBER_STATUS_THREW) {
-				php_printf("<threw '%p'>\n", from);
-			} else if (from->status == ZEND_FIBER_STATUS_SHUTDOWN) {
-				php_printf("<destroyed '%p'>\n", from);
+			} else if (from->status == ZEND_FIBER_STATUS_DEAD) {
+				if (from->flags & ZEND_FIBER_FLAG_THREW) {
+					php_printf("<threw '%p'>\n", from);
+				} else if (from->flags & ZEND_FIBER_FLAG_DESTROYED) {
+					php_printf("<destroyed '%p'>\n", from);
+				} else {
+					php_printf("<returned '%p'>\n", from);
+				}
 			}
 		}
 	}

--- a/ext/zend_test/tests/observer_fiber_05.phpt
+++ b/ext/zend_test/tests/observer_fiber_05.phpt
@@ -44,9 +44,7 @@ $fiber->resume();
 <destroying '%s'>
 <!-- switching from fiber %s to %s -->
 <destroying '%s'>
-<destroyed '%s'>
 <!-- switching from fiber %s to %s -->
-<destroying '%s'>
 <destroyed '%s'>
 <!-- switching from fiber %s to 0 -->
 <destroyed '%s'>


### PR DESCRIPTION
This splits the fiber running status from flags about how the fiber exited: normally, with an exception, bailout, or forced destroyed.

Observers are better able to differentiate running status from exiting (e.g., a fiber is running because it is being destroyed vs. a fiber is dead and was destroyed), which is why the dubious output of `ext/zend_test/tests/observer_fiber_05.phpt` is now improved with this change.