### PR TITLE
Update deprecation message for incompatible float to int conversion

### DIFF
--- a/Zend/tests/array_offset.phpt
+++ b/Zend/tests/array_offset.phpt
@@ -13,13 +13,13 @@ echo "Done\n";
 --EXPECTF--
 Warning: Undefined array key -1 in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float -1.1 to int in %s on line %d
+Deprecated: Implicit conversion from float -1.1 to int loses precision in %s on line %d
 
 Warning: Undefined array key -1 in %s on line %d
 
 Warning: Undefined array key -1 in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float -1.1 to int in %s on line %d
+Deprecated: Implicit conversion from float -1.1 to int loses precision in %s on line %d
 
 Warning: Undefined array key -1 in %s on line %d
 Done

--- a/Zend/tests/bug46701.phpt
+++ b/Zend/tests/bug46701.phpt
@@ -27,11 +27,11 @@ new foo;
 
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from non-compatible float 3428599296 to int in %s on line %d
+Deprecated: Implicit conversion from float 3428599296 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 3459455488 to int in %s on line %d
+Deprecated: Implicit conversion from float 3459455488 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 3459616768 to int in %s on line %d
+Deprecated: Implicit conversion from float 3459616768 to int loses precision in %s on line %d
 array(3) {
   [-866368000]=>
   int(1)
@@ -41,10 +41,10 @@ array(3) {
   int(3)
 }
 
-Deprecated: Implicit conversion from non-compatible float 3459455488 to int in %s on line %d
+Deprecated: Implicit conversion from float 3459455488 to int loses precision in %s on line %d
 int(2)
 
-Deprecated: Implicit conversion from non-compatible float 3459616768 to int in %s on line %d
+Deprecated: Implicit conversion from float 3459616768 to int loses precision in %s on line %d
 array(1) {
   [-835350528]=>
   int(3)

--- a/Zend/tests/bug72347.phpt
+++ b/Zend/tests/bug72347.phpt
@@ -13,6 +13,6 @@ function test() : int {
 var_dump(test());
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 float(1.5)
 int(1)

--- a/Zend/tests/constant_expressions_dynamic.phpt
+++ b/Zend/tests/constant_expressions_dynamic.phpt
@@ -47,7 +47,7 @@ var_dump(
 --EXPECTF--
 Warning: A non-numeric value encountered in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 3.14 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.14 to int loses precision in %s on line %d
 int(3)
 string(4) "1foo"
 bool(false)

--- a/Zend/tests/empty_str_offset.phpt
+++ b/Zend/tests/empty_str_offset.phpt
@@ -99,31 +99,31 @@ bool(true)
 bool(false)
 - double ---
 
-Deprecated: Implicit conversion from non-compatible float -1.1 to int in %s on line %d
+Deprecated: Implicit conversion from float -1.1 to int loses precision in %s on line %d
 bool(false)
 
-Deprecated: Implicit conversion from non-compatible float -10.5 to int in %s on line %d
+Deprecated: Implicit conversion from float -10.5 to int loses precision in %s on line %d
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float -4.1 to int in %s on line %d
+Deprecated: Implicit conversion from float -4.1 to int loses precision in %s on line %d
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float -0.8 to int in %s on line %d
+Deprecated: Implicit conversion from float -0.8 to int loses precision in %s on line %d
 bool(false)
 
-Deprecated: Implicit conversion from non-compatible float -0.1 to int in %s on line %d
+Deprecated: Implicit conversion from float -0.1 to int loses precision in %s on line %d
 bool(false)
 
-Deprecated: Implicit conversion from non-compatible float 0.2 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.2 to int loses precision in %s on line %d
 bool(false)
 
-Deprecated: Implicit conversion from non-compatible float 0.9 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.9 to int loses precision in %s on line %d
 bool(false)
 
-Deprecated: Implicit conversion from non-compatible float 3.141592653589793 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.141592653589793 to int loses precision in %s on line %d
 bool(false)
 
-Deprecated: Implicit conversion from non-compatible float 100.5001 to int in %s on line %d
+Deprecated: Implicit conversion from float 100.5001 to int loses precision in %s on line %d
 bool(true)
 - array ---
 bool(true)

--- a/Zend/tests/float_to_int/union_int_string_type_arg.phpt
+++ b/Zend/tests/float_to_int/union_int_string_type_arg.phpt
@@ -21,7 +21,7 @@ foo(10e500); // Infinity
 --EXPECTF--
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 string(3) "NAN"
 string(8) "1.0E+121"

--- a/Zend/tests/float_to_int/warning_float_does_not_fit_zend_long_arrays.phpt
+++ b/Zend/tests/float_to_int/warning_float_does_not_fit_zend_long_arrays.phpt
@@ -26,9 +26,9 @@ var_dump($array[$string_float]);
 int(0)
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float 1.0E+121 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.0E+121 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 1.0E+121 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.0E+121 to int loses precision in %s on line %d
 array(2) {
   [0]=>
   string(11) "Large float"
@@ -42,13 +42,13 @@ array(2) {
   string(18) "String large float"
 }
 
-Deprecated: Implicit conversion from non-compatible float 1.0E+121 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.0E+121 to int loses precision in %s on line %d
 string(1) "0"
 
 Warning: Undefined array key "1.0E+121" in %s on line %d
 NULL
 
-Deprecated: Implicit conversion from non-compatible float 1.0E+121 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.0E+121 to int loses precision in %s on line %d
 string(1) "0"
 
 Warning: Undefined array key "1.0E+121" in %s on line %d

--- a/Zend/tests/float_to_int/warnings_float_literals.phpt
+++ b/Zend/tests/float_to_int/warnings_float_literals.phpt
@@ -71,43 +71,43 @@ var_dump($instance->a);
 --EXPECTF--
 Bitwise ops:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(-2)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(3)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(2)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(8)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(6)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 Modulo:
 
-Deprecated: Implicit conversion from non-compatible float 6.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 6.5 to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float 2.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 2.5 to int loses precision in %s on line %d
 int(1)
 Offset access:
 Arrays:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 string(1) "b"
 
-Deprecated: Implicit conversion from non-compatible float 2.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 2.5 to int loses precision in %s on line %d
 array(3) {
   [0]=>
   string(1) "a"
@@ -125,16 +125,16 @@ Warning: String offset cast occurred in %s on line %d
 string(3) "phz"
 Function calls:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float 60.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 60.5 to int loses precision in %s on line %d
 string(1) "<"
 Function returns:
 
-Deprecated: Implicit conversion from non-compatible float 3.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.5 to int loses precision in %s on line %d
 int(3)
 Typed property assignment:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)

--- a/Zend/tests/float_to_int/warnings_float_literals_assignment_ops.phpt
+++ b/Zend/tests/float_to_int/warnings_float_literals_assignment_ops.phpt
@@ -34,21 +34,21 @@ var_dump($var);
 --EXPECTF--
 Bitwise ops:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(3)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(2)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(6)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 Modulo:
 
-Deprecated: Implicit conversion from non-compatible float 2.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 2.5 to int loses precision in %s on line %d
 int(1)

--- a/Zend/tests/float_to_int/warnings_float_vars.phpt
+++ b/Zend/tests/float_to_int/warnings_float_vars.phpt
@@ -93,49 +93,49 @@ var_dump($instance->a);
 --EXPECTF--
 Bitwise ops:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(-2)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(3)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(2)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(8)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(8)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(6)
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 Modulo:
 
-Deprecated: Implicit conversion from non-compatible float 6.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 6.5 to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float 2.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 2.5 to int loses precision in %s on line %d
 int(1)
 Offset access:
 Arrays:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 string(1) "b"
 
-Deprecated: Implicit conversion from non-compatible float 2.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 2.5 to int loses precision in %s on line %d
 array(3) {
   [0]=>
   string(1) "a"
@@ -153,16 +153,16 @@ Warning: String offset cast occurred in %s on line %d
 string(3) "phz"
 Function calls:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float 60.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 60.5 to int loses precision in %s on line %d
 string(1) "<"
 Function returns:
 
-Deprecated: Implicit conversion from non-compatible float 3.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.5 to int loses precision in %s on line %d
 int(3)
 Typed property assignment:
 
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 int(1)

--- a/Zend/tests/float_to_int/warnings_string_float_literals.phpt
+++ b/Zend/tests/float_to_int/warnings_string_float_literals.phpt
@@ -54,45 +54,45 @@ var_dump($instance->a);
 --EXPECTF--
 Bitwise ops:
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(3)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(2)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(8)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(6)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)
 Modulo:
 
-Deprecated: Implicit conversion from non-compatible float-string "6.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "6.5" to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float-string "2.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "2.5" to int loses precision in %s on line %d
 int(1)
 Function calls:
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float-string "60.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "60.5" to int loses precision in %s on line %d
 string(1) "<"
 Function returns:
 
-Deprecated: Implicit conversion from non-compatible float-string "3.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.5" to int loses precision in %s on line %d
 int(3)
 Typed property assignment:
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)

--- a/Zend/tests/float_to_int/warnings_string_float_literals_assignment_ops.phpt
+++ b/Zend/tests/float_to_int/warnings_string_float_literals_assignment_ops.phpt
@@ -34,21 +34,21 @@ var_dump($var);
 --EXPECTF--
 Bitwise ops:
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(3)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(2)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(6)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)
 Modulo:
 
-Deprecated: Implicit conversion from non-compatible float-string "2.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "2.5" to int loses precision in %s on line %d
 int(1)

--- a/Zend/tests/float_to_int/warnings_string_float_vars.phpt
+++ b/Zend/tests/float_to_int/warnings_string_float_vars.phpt
@@ -74,51 +74,51 @@ var_dump($instance->a);
 --EXPECTF--
 Bitwise ops:
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(3)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(2)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(8)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(8)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(6)
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)
 Modulo:
 
-Deprecated: Implicit conversion from non-compatible float-string "6.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "6.5" to int loses precision in %s on line %d
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float-string "2.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "2.5" to int loses precision in %s on line %d
 int(1)
 Function calls:
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)
 
-Deprecated: Implicit conversion from non-compatible float-string "60.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "60.5" to int loses precision in %s on line %d
 string(1) "<"
 Function returns:
 
-Deprecated: Implicit conversion from non-compatible float-string "3.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.5" to int loses precision in %s on line %d
 int(3)
 Typed property assignment:
 
-Deprecated: Implicit conversion from non-compatible float-string "1.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "1.5" to int loses precision in %s on line %d
 int(1)

--- a/Zend/tests/isset_array.phpt
+++ b/Zend/tests/isset_array.phpt
@@ -39,7 +39,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float 0.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.6 to int loses precision in %s on line %d
 bool(true)
 bool(false)
 bool(false)

--- a/Zend/tests/isset_str_offset.phpt
+++ b/Zend/tests/isset_str_offset.phpt
@@ -96,28 +96,28 @@ bool(false)
 bool(true)
 - double ---
 
-Deprecated: Implicit conversion from non-compatible float -1.1 to int in %s on line %d
+Deprecated: Implicit conversion from float -1.1 to int loses precision in %s on line %d
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float -10.5 to int in %s on line %d
+Deprecated: Implicit conversion from float -10.5 to int loses precision in %s on line %d
 bool(false)
 
-Deprecated: Implicit conversion from non-compatible float -0.8 to int in %s on line %d
+Deprecated: Implicit conversion from float -0.8 to int loses precision in %s on line %d
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float -0.1 to int in %s on line %d
+Deprecated: Implicit conversion from float -0.1 to int loses precision in %s on line %d
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float 0.2 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.2 to int loses precision in %s on line %d
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float 0.9 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.9 to int loses precision in %s on line %d
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float 3.141592653589793 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.141592653589793 to int loses precision in %s on line %d
 bool(true)
 
-Deprecated: Implicit conversion from non-compatible float 100.5001 to int in %s on line %d
+Deprecated: Implicit conversion from float 100.5001 to int loses precision in %s on line %d
 bool(false)
 - array ---
 bool(false)

--- a/Zend/tests/list_keyed_conversions.phpt
+++ b/Zend/tests/list_keyed_conversions.phpt
@@ -21,7 +21,7 @@ list(STDIN => $resource) = [];
 
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from non-compatible float 1.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
 string(0) ""
 int(1)
 int(0)

--- a/Zend/tests/not_001.phpt
+++ b/Zend/tests/not_001.phpt
@@ -17,7 +17,7 @@ var_dump(bin2hex($s1));
 echo "Done\n";
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from non-compatible float 23.67 to int in %s on line %d
+Deprecated: Implicit conversion from float 23.67 to int loses precision in %s on line %d
 int(-24)
 string(8) "8c90929a"
 Done

--- a/Zend/tests/offset_array.phpt
+++ b/Zend/tests/offset_array.phpt
@@ -35,7 +35,7 @@ echo "Done\n";
 --EXPECTF--
 int(2)
 
-Deprecated: Implicit conversion from non-compatible float 0.0836 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.0836 to int loses precision in %s on line %d
 int(1)
 
 Warning: Undefined array key "" in %s on line %d

--- a/Zend/tests/operator_unsupported_types.phpt
+++ b/Zend/tests/operator_unsupported_types.phpt
@@ -453,7 +453,7 @@ Unsupported operand types: bool % array
 Unsupported operand types: array % int
 Unsupported operand types: int % array
 Unsupported operand types: array % float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float % array
 Unsupported operand types: array % string
 Unsupported operand types: string % array
@@ -469,7 +469,7 @@ Unsupported operand types: bool % stdClass
 Unsupported operand types: stdClass % int
 Unsupported operand types: int % stdClass
 Unsupported operand types: stdClass % float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float % stdClass
 Unsupported operand types: stdClass % string
 Unsupported operand types: string % stdClass
@@ -485,7 +485,7 @@ Unsupported operand types: bool % resource
 Unsupported operand types: resource % int
 Unsupported operand types: int % resource
 Unsupported operand types: resource % float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float % resource
 Unsupported operand types: resource % string
 Unsupported operand types: string % resource
@@ -501,7 +501,7 @@ Unsupported operand types: bool % string
 Unsupported operand types: string % int
 Unsupported operand types: int % string
 Unsupported operand types: string % float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float % string
 Unsupported operand types: string % string
 Unsupported operand types: string % string
@@ -609,7 +609,7 @@ Unsupported operand types: bool << array
 Unsupported operand types: array << int
 Unsupported operand types: int << array
 Unsupported operand types: array << float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float << array
 Unsupported operand types: array << string
 Unsupported operand types: string << array
@@ -625,7 +625,7 @@ Unsupported operand types: bool << stdClass
 Unsupported operand types: stdClass << int
 Unsupported operand types: int << stdClass
 Unsupported operand types: stdClass << float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float << stdClass
 Unsupported operand types: stdClass << string
 Unsupported operand types: string << stdClass
@@ -641,7 +641,7 @@ Unsupported operand types: bool << resource
 Unsupported operand types: resource << int
 Unsupported operand types: int << resource
 Unsupported operand types: resource << float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float << resource
 Unsupported operand types: resource << string
 Unsupported operand types: string << resource
@@ -657,7 +657,7 @@ Unsupported operand types: bool << string
 Unsupported operand types: string << int
 Unsupported operand types: int << string
 Unsupported operand types: string << float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float << string
 Unsupported operand types: string << string
 Unsupported operand types: string << string
@@ -689,7 +689,7 @@ Unsupported operand types: bool >> array
 Unsupported operand types: array >> int
 Unsupported operand types: int >> array
 Unsupported operand types: array >> float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float >> array
 Unsupported operand types: array >> string
 Unsupported operand types: string >> array
@@ -705,7 +705,7 @@ Unsupported operand types: bool >> stdClass
 Unsupported operand types: stdClass >> int
 Unsupported operand types: int >> stdClass
 Unsupported operand types: stdClass >> float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float >> stdClass
 Unsupported operand types: stdClass >> string
 Unsupported operand types: string >> stdClass
@@ -721,7 +721,7 @@ Unsupported operand types: bool >> resource
 Unsupported operand types: resource >> int
 Unsupported operand types: int >> resource
 Unsupported operand types: resource >> float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float >> resource
 Unsupported operand types: resource >> string
 Unsupported operand types: string >> resource
@@ -737,7 +737,7 @@ Unsupported operand types: bool >> string
 Unsupported operand types: string >> int
 Unsupported operand types: int >> string
 Unsupported operand types: string >> float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float >> string
 Unsupported operand types: string >> string
 Unsupported operand types: string >> string
@@ -769,7 +769,7 @@ Unsupported operand types: bool & array
 Unsupported operand types: array & int
 Unsupported operand types: int & array
 Unsupported operand types: array & float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float & array
 Unsupported operand types: array & string
 Unsupported operand types: string & array
@@ -813,7 +813,7 @@ Unsupported operand types: bool & string
 Unsupported operand types: string & int
 Unsupported operand types: int & string
 Unsupported operand types: string & float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float & string
 No error for "foo" & "123"
 No error for "123" & "foo"
@@ -844,7 +844,7 @@ Unsupported operand types: bool | array
 Unsupported operand types: array | int
 Unsupported operand types: int | array
 Unsupported operand types: array | float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float | array
 Unsupported operand types: array | string
 Unsupported operand types: string | array
@@ -888,7 +888,7 @@ Unsupported operand types: bool | string
 Unsupported operand types: string | int
 Unsupported operand types: int | string
 Unsupported operand types: string | float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float | string
 No error for "foo" | "123"
 No error for "123" | "foo"
@@ -919,7 +919,7 @@ Unsupported operand types: bool ^ array
 Unsupported operand types: array ^ int
 Unsupported operand types: int ^ array
 Unsupported operand types: array ^ float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float ^ array
 Unsupported operand types: array ^ string
 Unsupported operand types: string ^ array
@@ -963,7 +963,7 @@ Unsupported operand types: bool ^ string
 Unsupported operand types: string ^ int
 Unsupported operand types: int ^ string
 Unsupported operand types: string ^ float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float ^ string
 No error for "foo" ^ "123"
 No error for "123" ^ "foo"
@@ -1467,7 +1467,7 @@ Unsupported operand types: bool % array
 Unsupported operand types: array % int
 Unsupported operand types: int % array
 Unsupported operand types: array % float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float % array
 Unsupported operand types: array % string
 Unsupported operand types: string % array
@@ -1483,7 +1483,7 @@ Unsupported operand types: bool % stdClass
 Unsupported operand types: stdClass % int
 Unsupported operand types: int % stdClass
 Unsupported operand types: stdClass % float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float % stdClass
 Unsupported operand types: stdClass % string
 Unsupported operand types: string % stdClass
@@ -1499,7 +1499,7 @@ Unsupported operand types: bool % resource
 Unsupported operand types: resource % int
 Unsupported operand types: int % resource
 Unsupported operand types: resource % float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float % resource
 Unsupported operand types: resource % string
 Unsupported operand types: string % resource
@@ -1515,7 +1515,7 @@ Unsupported operand types: bool % string
 Unsupported operand types: string % int
 Unsupported operand types: int % string
 Unsupported operand types: string % float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float % string
 Unsupported operand types: string % string
 Unsupported operand types: string % string
@@ -1623,7 +1623,7 @@ Unsupported operand types: bool << array
 Unsupported operand types: array << int
 Unsupported operand types: int << array
 Unsupported operand types: array << float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float << array
 Unsupported operand types: array << string
 Unsupported operand types: string << array
@@ -1639,7 +1639,7 @@ Unsupported operand types: bool << stdClass
 Unsupported operand types: stdClass << int
 Unsupported operand types: int << stdClass
 Unsupported operand types: stdClass << float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float << stdClass
 Unsupported operand types: stdClass << string
 Unsupported operand types: string << stdClass
@@ -1655,7 +1655,7 @@ Unsupported operand types: bool << resource
 Unsupported operand types: resource << int
 Unsupported operand types: int << resource
 Unsupported operand types: resource << float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float << resource
 Unsupported operand types: resource << string
 Unsupported operand types: string << resource
@@ -1671,7 +1671,7 @@ Unsupported operand types: bool << string
 Unsupported operand types: string << int
 Unsupported operand types: int << string
 Unsupported operand types: string << float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float << string
 Unsupported operand types: string << string
 Unsupported operand types: string << string
@@ -1703,7 +1703,7 @@ Unsupported operand types: bool >> array
 Unsupported operand types: array >> int
 Unsupported operand types: int >> array
 Unsupported operand types: array >> float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float >> array
 Unsupported operand types: array >> string
 Unsupported operand types: string >> array
@@ -1719,7 +1719,7 @@ Unsupported operand types: bool >> stdClass
 Unsupported operand types: stdClass >> int
 Unsupported operand types: int >> stdClass
 Unsupported operand types: stdClass >> float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float >> stdClass
 Unsupported operand types: stdClass >> string
 Unsupported operand types: string >> stdClass
@@ -1735,7 +1735,7 @@ Unsupported operand types: bool >> resource
 Unsupported operand types: resource >> int
 Unsupported operand types: int >> resource
 Unsupported operand types: resource >> float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float >> resource
 Unsupported operand types: resource >> string
 Unsupported operand types: string >> resource
@@ -1751,7 +1751,7 @@ Unsupported operand types: bool >> string
 Unsupported operand types: string >> int
 Unsupported operand types: int >> string
 Unsupported operand types: string >> float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float >> string
 Unsupported operand types: string >> string
 Unsupported operand types: string >> string
@@ -1783,7 +1783,7 @@ Unsupported operand types: bool & array
 Unsupported operand types: array & int
 Unsupported operand types: int & array
 Unsupported operand types: array & float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float & array
 Unsupported operand types: array & string
 Unsupported operand types: string & array
@@ -1799,7 +1799,7 @@ Unsupported operand types: bool & stdClass
 Unsupported operand types: stdClass & int
 Unsupported operand types: int & stdClass
 Unsupported operand types: stdClass & float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float & stdClass
 Unsupported operand types: stdClass & string
 Unsupported operand types: string & stdClass
@@ -1815,7 +1815,7 @@ Unsupported operand types: bool & resource
 Unsupported operand types: resource & int
 Unsupported operand types: int & resource
 Unsupported operand types: resource & float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float & resource
 Unsupported operand types: resource & string
 Unsupported operand types: string & resource
@@ -1831,7 +1831,7 @@ Unsupported operand types: bool & string
 Unsupported operand types: string & int
 Unsupported operand types: int & string
 Unsupported operand types: string & float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float & string
 No error for "foo" &= "123"
 No error for "123" &= "foo"
@@ -1862,7 +1862,7 @@ Unsupported operand types: bool | array
 Unsupported operand types: array | int
 Unsupported operand types: int | array
 Unsupported operand types: array | float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float | array
 Unsupported operand types: array | string
 Unsupported operand types: string | array
@@ -1878,7 +1878,7 @@ Unsupported operand types: bool | stdClass
 Unsupported operand types: stdClass | int
 Unsupported operand types: int | stdClass
 Unsupported operand types: stdClass | float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float | stdClass
 Unsupported operand types: stdClass | string
 Unsupported operand types: string | stdClass
@@ -1894,7 +1894,7 @@ Unsupported operand types: bool | resource
 Unsupported operand types: resource | int
 Unsupported operand types: int | resource
 Unsupported operand types: resource | float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float | resource
 Unsupported operand types: resource | string
 Unsupported operand types: string | resource
@@ -1910,7 +1910,7 @@ Unsupported operand types: bool | string
 Unsupported operand types: string | int
 Unsupported operand types: int | string
 Unsupported operand types: string | float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float | string
 No error for "foo" |= "123"
 No error for "123" |= "foo"
@@ -1941,7 +1941,7 @@ Unsupported operand types: bool ^ array
 Unsupported operand types: array ^ int
 Unsupported operand types: int ^ array
 Unsupported operand types: array ^ float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float ^ array
 Unsupported operand types: array ^ string
 Unsupported operand types: string ^ array
@@ -1957,7 +1957,7 @@ Unsupported operand types: bool ^ stdClass
 Unsupported operand types: stdClass ^ int
 Unsupported operand types: int ^ stdClass
 Unsupported operand types: stdClass ^ float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float ^ stdClass
 Unsupported operand types: stdClass ^ string
 Unsupported operand types: string ^ stdClass
@@ -1973,7 +1973,7 @@ Unsupported operand types: bool ^ resource
 Unsupported operand types: resource ^ int
 Unsupported operand types: int ^ resource
 Unsupported operand types: resource ^ float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float ^ resource
 Unsupported operand types: resource ^ string
 Unsupported operand types: string ^ resource
@@ -1989,7 +1989,7 @@ Unsupported operand types: bool ^ string
 Unsupported operand types: string ^ int
 Unsupported operand types: int ^ string
 Unsupported operand types: string ^ float
-Warning: Implicit conversion from non-compatible float 3.5 to int
+Warning: Implicit conversion from float 3.5 to int loses precision
 Unsupported operand types: float ^ string
 No error for "foo" ^= "123"
 No error for "123" ^= "foo"

--- a/Zend/tests/type_declarations/scalar_basic.phpt
+++ b/Zend/tests/type_declarations/scalar_basic.phpt
@@ -72,7 +72,7 @@ int(1)
 int(1)
 
 *** Trying float(1.5)
-E_DEPRECATED: Implicit conversion from non-compatible float 1.5 to int on line 14
+E_DEPRECATED: Implicit conversion from float 1.5 to int loses precision on line 14
 int(1)
 
 *** Trying string(2) "1a"

--- a/Zend/tests/type_declarations/scalar_return_basic.phpt
+++ b/Zend/tests/type_declarations/scalar_return_basic.phpt
@@ -71,7 +71,7 @@ int(1)
 *** Trying float(1)
 int(1)
 *** Trying float(1.5)
-E_DEPRECATED: Implicit conversion from non-compatible float 1.5 to int on line %d
+E_DEPRECATED: Implicit conversion from float 1.5 to int loses precision on line %d
 int(1)
 *** Trying string(2) "1a"
 *** Caught {closure}(): Return value must be of type int, string returned in %s on line %d

--- a/Zend/tests/type_declarations/scalar_return_basic_64bit.phpt
+++ b/Zend/tests/type_declarations/scalar_return_basic_64bit.phpt
@@ -71,7 +71,7 @@ int(1)
 *** Trying float(1)
 int(1)
 *** Trying float(1.5)
-E_DEPRECATED: Implicit conversion from non-compatible float 1.5 to int on line %d
+E_DEPRECATED: Implicit conversion from float 1.5 to int loses precision on line %d
 int(1)
 *** Trying string(2) "1a"
 *** Caught {closure}(): Return value must be of type int, string returned in %s on line %d

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -810,11 +810,11 @@ try_again:
 
 ZEND_API void ZEND_COLD zend_incompatible_double_to_long_error(double d)
 {
-	zend_error_unchecked(E_DEPRECATED, "Implicit conversion from non-compatible float %.*H to int", -1, d);
+	zend_error_unchecked(E_DEPRECATED, "Implicit conversion from float %.*H to int loses precision", -1, d);
 }
 ZEND_API void ZEND_COLD zend_incompatible_string_to_long_error(const zend_string *s)
 {
-	zend_error(E_DEPRECATED, "Implicit conversion from non-compatible float-string \"%s\" to int", ZSTR_VAL(s));
+	zend_error(E_DEPRECATED, "Implicit conversion from float-string \"%s\" to int loses precision", ZSTR_VAL(s));
 }
 
 ZEND_API zend_long ZEND_FASTCALL zval_get_long_func(zval *op, bool is_strict) /* {{{ */

--- a/ext/mbstring/tests/mb_substitute_character_variation_weak_types.phpt
+++ b/ext/mbstring/tests/mb_substitute_character_variation_weak_types.phpt
@@ -118,11 +118,11 @@ bool(true)
 ValueError: mb_substitute_character(): Argument #1 ($substitute_character) is not a valid codepoint
 --float 10.5--
 
-Deprecated: Implicit conversion from non-compatible float 10.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 10.5 to int loses precision in %s on line %d
 bool(true)
 --float -10.5--
 
-Deprecated: Implicit conversion from non-compatible float -10.5 to int in %s on line %d
+Deprecated: Implicit conversion from float -10.5 to int loses precision in %s on line %d
 ValueError: mb_substitute_character(): Argument #1 ($substitute_character) is not a valid codepoint
 --float 10.0e19--
 ValueError: mb_substitute_character(): Argument #1 ($substitute_character) must be "none", "long", "entity" or a valid codepoint
@@ -130,7 +130,7 @@ ValueError: mb_substitute_character(): Argument #1 ($substitute_character) must 
 ValueError: mb_substitute_character(): Argument #1 ($substitute_character) must be "none", "long", "entity" or a valid codepoint
 --float .5--
 
-Deprecated: Implicit conversion from non-compatible float 0.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.5 to int loses precision in %s on line %d
 bool(true)
 --empty array--
 TypeError: mb_substitute_character(): Argument #1 ($substitute_character) must be of type string|int|null, array given

--- a/ext/opcache/tests/jit/reg_alloc_003_32bits.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_003_32bits.phpt
@@ -24,5 +24,5 @@ function test($char_code) {
 echo test(65), "\n";
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from non-compatible float 4294967168 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294967168 to int loses precision in %s on line %d
 correct

--- a/ext/spl/tests/iterator_to_array_nonscalar_keys.phpt
+++ b/ext/spl/tests/iterator_to_array_nonscalar_keys.phpt
@@ -20,5 +20,5 @@ try {
 
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from non-compatible float 2.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 2.5 to int loses precision in %s on line %d
 Illegal offset type

--- a/ext/standard/tests/array/array_column_basic.phpt
+++ b/ext/standard/tests/array/array_column_basic.phpt
@@ -227,7 +227,7 @@ array(3) {
   string(3) "333"
 }
 
-Deprecated: Implicit conversion from non-compatible float 0.123 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.123 to int loses precision in %s on line %d
 array(3) {
   ["aaa"]=>
   string(3) "111"
@@ -259,7 +259,7 @@ array(3) {
   string(3) "ccc"
 }
 
-Deprecated: Implicit conversion from non-compatible float 3.14 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.14 to int loses precision in %s on line %d
 array(0) {
 }
 

--- a/ext/standard/tests/array/array_key_exists_variation3.phpt
+++ b/ext/standard/tests/array/array_key_exists_variation3.phpt
@@ -34,7 +34,7 @@ echo "Done";
 -- Iteration 1 --
 Pass float as $key:
 
-Deprecated: Implicit conversion from non-compatible float 1.23456789E-10 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.23456789E-10 to int loses precision in %s on line %d
 bool(true)
 Cast float to int:
 bool(true)
@@ -42,7 +42,7 @@ bool(true)
 -- Iteration 1 --
 Pass float as $key:
 
-Deprecated: Implicit conversion from non-compatible float 1.00000000000001 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.00000000000001 to int loses precision in %s on line %d
 bool(true)
 Cast float to int:
 bool(true)
@@ -50,7 +50,7 @@ bool(true)
 -- Iteration 1 --
 Pass float as $key:
 
-Deprecated: Implicit conversion from non-compatible float 1.99999999999999 to int in %s on line %d
+Deprecated: Implicit conversion from float 1.99999999999999 to int loses precision in %s on line %d
 bool(true)
 Cast float to int:
 bool(true)

--- a/ext/standard/tests/array/bug68553.phpt
+++ b/ext/standard/tests/array/bug68553.phpt
@@ -36,7 +36,7 @@ try {
 --EXPECTF--
 Warning: Resource ID#%d used as offset, casting to integer (%d) in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 7.38 to int in %s on line %d
+Deprecated: Implicit conversion from float 7.38 to int loses precision in %s on line %d
 array(8) {
   [10]=>
   array(1) {

--- a/ext/standard/tests/math/bug30695.phpt
+++ b/ext/standard/tests/math/bug30695.phpt
@@ -53,22 +53,22 @@ if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
     echo "\n", toUTF8(65), "\n", toUTF8(233), "\n", toUTF8(1252), "\n", toUTF8(20095), "\n";
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from non-compatible float 4294967168 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294967168 to int loses precision in %s on line %d
 A
 
-Deprecated: Implicit conversion from non-compatible float 4294967168 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294967168 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 4294965248 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294965248 to int loses precision in %s on line %d
 é
 
-Deprecated: Implicit conversion from non-compatible float 4294967168 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294967168 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 4294965248 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294965248 to int loses precision in %s on line %d
 Ӥ
 
-Deprecated: Implicit conversion from non-compatible float 4294967168 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294967168 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 4294965248 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294965248 to int loses precision in %s on line %d
 
-Deprecated: Implicit conversion from non-compatible float 4294901760 to int in %s on line %d
+Deprecated: Implicit conversion from float 4294901760 to int loses precision in %s on line %d
 乿

--- a/ext/standard/tests/math/decbin_basic.phpt
+++ b/ext/standard/tests/math/decbin_basic.phpt
@@ -28,19 +28,19 @@ foreach ($values as $value) {
 --EXPECTF--
 string(4) "1010"
 
-Deprecated: Implicit conversion from non-compatible float 3950.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 3950.5 to int loses precision in %s on line %d
 string(12) "111101101110"
 
-Deprecated: Implicit conversion from non-compatible float 3950.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 3950.5 to int loses precision in %s on line %d
 string(12) "111101101110"
 string(2) "11"
 string(7) "1011111"
 string(4) "1010"
 
-Deprecated: Implicit conversion from non-compatible float-string "3950.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3950.5" to int loses precision in %s on line %d
 string(12) "111101101110"
 
-Deprecated: Implicit conversion from non-compatible float-string "3.9505e3" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.9505e3" to int loses precision in %s on line %d
 string(12) "111101101110"
 string(6) "100111"
 decbin(): Argument #1 ($num) must be of type int, string given

--- a/ext/standard/tests/math/dechex_basic.phpt
+++ b/ext/standard/tests/math/dechex_basic.phpt
@@ -28,19 +28,19 @@ foreach ($values as $value) {
 --EXPECTF--
 string(1) "a"
 
-Deprecated: Implicit conversion from non-compatible float 3950.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 3950.5 to int loses precision in %s on line %d
 string(3) "f6e"
 
-Deprecated: Implicit conversion from non-compatible float 3950.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 3950.5 to int loses precision in %s on line %d
 string(3) "f6e"
 string(1) "3"
 string(2) "5f"
 string(1) "a"
 
-Deprecated: Implicit conversion from non-compatible float-string "3950.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3950.5" to int loses precision in %s on line %d
 string(3) "f6e"
 
-Deprecated: Implicit conversion from non-compatible float-string "3.9505e3" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.9505e3" to int loses precision in %s on line %d
 string(3) "f6e"
 string(2) "27"
 dechex(): Argument #1 ($num) must be of type int, string given

--- a/ext/standard/tests/math/decoct_basic.phpt
+++ b/ext/standard/tests/math/decoct_basic.phpt
@@ -28,19 +28,19 @@ foreach ($values as $value) {
 --EXPECTF--
 string(2) "12"
 
-Deprecated: Implicit conversion from non-compatible float 3950.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 3950.5 to int loses precision in %s on line %d
 string(4) "7556"
 
-Deprecated: Implicit conversion from non-compatible float 3950.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 3950.5 to int loses precision in %s on line %d
 string(4) "7556"
 string(1) "3"
 string(3) "137"
 string(2) "12"
 
-Deprecated: Implicit conversion from non-compatible float-string "3950.5" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3950.5" to int loses precision in %s on line %d
 string(4) "7556"
 
-Deprecated: Implicit conversion from non-compatible float-string "3.9505e3" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.9505e3" to int loses precision in %s on line %d
 string(4) "7556"
 string(2) "47"
 decoct(): Argument #1 ($num) must be of type int, string given

--- a/ext/standard/tests/math/mt_srand_basic.phpt
+++ b/ext/standard/tests/math/mt_srand_basic.phpt
@@ -16,7 +16,7 @@ var_dump(mt_srand(false));
 NULL
 NULL
 
-Deprecated: Implicit conversion from non-compatible float 500.1 to int in %s on line %d
+Deprecated: Implicit conversion from float 500.1 to int loses precision in %s on line %d
 NULL
 NULL
 NULL

--- a/ext/standard/tests/math/round_basic.phpt
+++ b/ext/standard/tests/math/round_basic.phpt
@@ -45,12 +45,12 @@ round: 123456789
 ...with precision 3-> float(123456789)
 ...with precision 4-> float(123456789)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(123456789)
 ...with precision 2-> float(123456789)
 ...with precision 04-> float(123456789)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(123456789)
 ...with precision 2.1e1-> float(123456789)
 ...with precision 1-> float(123456789)
@@ -61,12 +61,12 @@ round: 123.456789
 ...with precision 3-> float(123.457)
 ...with precision 4-> float(123.4568)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(123.457)
 ...with precision 2-> float(123.46)
 ...with precision 04-> float(123.4568)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(123.457)
 ...with precision 2.1e1-> float(123.456789)
 ...with precision 1-> float(123.5)
@@ -77,12 +77,12 @@ round: -4.5679123
 ...with precision 3-> float(-4.568)
 ...with precision 4-> float(-4.5679)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(-4.568)
 ...with precision 2-> float(-4.57)
 ...with precision 04-> float(-4.5679)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(-4.568)
 ...with precision 2.1e1-> float(-4.5679123)
 ...with precision 1-> float(-4.6)
@@ -93,12 +93,12 @@ round: 12300
 ...with precision 3-> float(12300)
 ...with precision 4-> float(12300)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(12300)
 ...with precision 2-> float(12300)
 ...with precision 04-> float(12300)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(12300)
 ...with precision 2.1e1-> float(12300)
 ...with precision 1-> float(12300)
@@ -109,12 +109,12 @@ round: -4567
 ...with precision 3-> float(-4567)
 ...with precision 4-> float(-4567)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(-4567)
 ...with precision 2-> float(-4567)
 ...with precision 04-> float(-4567)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(-4567)
 ...with precision 2.1e1-> float(-4567)
 ...with precision 1-> float(-4567)
@@ -125,12 +125,12 @@ round: 2311527
 ...with precision 3-> float(2311527)
 ...with precision 4-> float(2311527)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(2311527)
 ...with precision 2-> float(2311527)
 ...with precision 04-> float(2311527)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(2311527)
 ...with precision 2.1e1-> float(2311527)
 ...with precision 1-> float(2311527)
@@ -141,12 +141,12 @@ round: 14680063
 ...with precision 3-> float(14680063)
 ...with precision 4-> float(14680063)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(14680063)
 ...with precision 2-> float(14680063)
 ...with precision 04-> float(14680063)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(14680063)
 ...with precision 2.1e1-> float(14680063)
 ...with precision 1-> float(14680063)
@@ -157,12 +157,12 @@ round: 1.234567
 ...with precision 3-> float(1.235)
 ...with precision 4-> float(1.2346)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(1.235)
 ...with precision 2-> float(1.23)
 ...with precision 04-> float(1.2346)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(1.235)
 ...with precision 2.1e1-> float(1.234567)
 ...with precision 1-> float(1.2)
@@ -173,12 +173,12 @@ round: 2.3456789e8
 ...with precision 3-> float(234567890)
 ...with precision 4-> float(234567890)
 
-Deprecated: Implicit conversion from non-compatible float 3.6 to int in %s on line %d
+Deprecated: Implicit conversion from float 3.6 to int loses precision in %s on line %d
 ...with precision 3.6-> float(234567890)
 ...with precision 2-> float(234567890)
 ...with precision 04-> float(234567890)
 
-Deprecated: Implicit conversion from non-compatible float-string "3.6" to int in %s on line %d
+Deprecated: Implicit conversion from float-string "3.6" to int loses precision in %s on line %d
 ...with precision 3.6-> float(234567890)
 ...with precision 2.1e1-> float(234567890)
 ...with precision 1-> float(234567890)

--- a/ext/standard/tests/math/srand_basic.phpt
+++ b/ext/standard/tests/math/srand_basic.phpt
@@ -19,7 +19,7 @@ var_dump(srand(false));
 NULL
 NULL
 
-Deprecated: Implicit conversion from non-compatible float 500.1 to int in %s on line %d
+Deprecated: Implicit conversion from float 500.1 to int loses precision in %s on line %d
 NULL
 NULL
 NULL

--- a/ext/standard/tests/streams/bug72075.phpt
+++ b/ext/standard/tests/streams/bug72075.phpt
@@ -12,5 +12,5 @@ $dummy =& $r[0];
 print stream_select($r, $w, $e, 0.5);
 ?>
 --EXPECTF--
-Deprecated: Implicit conversion from non-compatible float 0.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 0.5 to int loses precision in %s on line %d
 0

--- a/ext/standard/tests/strings/chr_variation1.phpt
+++ b/ext/standard/tests/strings/chr_variation1.phpt
@@ -59,11 +59,11 @@ string(2) "ff"
 string(2) "00"
 -- Iteration 5 --
 
-Deprecated: Implicit conversion from non-compatible float 10.5 to int in %s on line %d
+Deprecated: Implicit conversion from float 10.5 to int loses precision in %s on line %d
 string(2) "0a"
 -- Iteration 6 --
 
-Deprecated: Implicit conversion from non-compatible float -20.5 to int in %s on line %d
+Deprecated: Implicit conversion from float -20.5 to int loses precision in %s on line %d
 string(2) "ec"
 -- Iteration 7 --
 string(2) "48"

--- a/tests/lang/bug27354.phpt
+++ b/tests/lang/bug27354.phpt
@@ -10,7 +10,7 @@ var_dump(-2147483648 % -2);
 --EXPECTF--
 int(0)
 
-Deprecated: Implicit conversion from non-compatible float -9.223372036860776E+18 to int in %s on line %d
+Deprecated: Implicit conversion from float -9.223372036860776E+18 to int loses precision in %s on line %d
 int(0)
 int(0)
 int(0)

--- a/tests/lang/operators/bitwiseNot_basiclong_64bit.phpt
+++ b/tests/lang/operators/bitwiseNot_basiclong_64bit.phpt
@@ -52,7 +52,7 @@ int(-4294967294)
 int(-9223372036854775807)
 --- testing: 9.2233720368548E+18 ---
 
-Deprecated: Implicit conversion from non-compatible float 9.223372036854776E+18 to int in %s on line %d
+Deprecated: Implicit conversion from float 9.223372036854776E+18 to int loses precision in %s on line %d
 int(9223372036854775807)
 --- testing: -9223372036854775807 ---
 int(9223372036854775806)


### PR DESCRIPTION
Updates the deprecation message for implicit incompatible float to int conversion from:

```
Implicit conversion from non-compatible
```

to

```
Implicit conversion from incompatible
```

Related: #6661