### PR TITLE
JIT/AArch64: Improved code generation for SL/SR and register allocation

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -4580,30 +4580,36 @@ static int zend_jit_long_math_helper(dasm_State    **Dst,
 				|	add Rx(result_reg), Rx(Z_REG(op1_addr)), Rx(Z_REG(op1_addr))
 			} else {
 				|	GET_ZVAL_LVAL result_reg, op1_addr, TMP1
-				|	mov TMP1w, #op2_lval
-				|	lsl Rx(result_reg), Rx(result_reg), TMP1
+				|	// TODO: DynAsm can't encode "lsl/ubfm", use "add+lsl" instead
+				|	//lsl Rx(result_reg), Rx(result_reg), #op2_lval
+				|	add Rx(result_reg), xzr, Rx(result_reg), lsl #op2_lval
 			}
 		} else {
-			if (Z_MODE(op2_addr) != IS_REG || Z_REG(op2_addr) != ZREG_REG1) {
-				|	GET_ZVAL_LVAL ZREG_REG1, op2_addr, TMP1
+			zend_reg op2_reg;
+
+			if (Z_MODE(op2_addr) == IS_REG) {
+				op2_reg = Z_REG(op2_addr);
+			} else {
+				op2_reg = ZREG_TMP2;
+				|	GET_ZVAL_LVAL ZREG_TMP2, op2_addr, TMP2
 			}
 			if (!op2_range ||
 			     op2_range->min < 0 ||
 			     op2_range->max >= SIZEOF_ZEND_LONG * 8) {
 
-				|	cmp REG1, #(SIZEOF_ZEND_LONG*8)
+				|	cmp Rx(op2_reg), #(SIZEOF_ZEND_LONG*8)
 				|	bhs >1
 				|.cold_code
 				|1:
 				|	mov Rx(result_reg), xzr
-				|	cmp REG1, xzr
+				|	cmp Rx(op2_reg), xzr
 				|	bgt >1
 				|	SET_EX_OPLINE opline, REG0
 				|	b ->negative_shift
 				|.code
 			}
 			|	GET_ZVAL_LVAL result_reg, op1_addr, TMP1
-			|	lsl Rx(result_reg), Rx(result_reg), REG1
+			|	lsl Rx(result_reg), Rx(result_reg), Rx(op2_reg)
 			|1:
 		}
 	} else if (opcode == ZEND_SR) {
@@ -4619,29 +4625,33 @@ static int zend_jit_long_math_helper(dasm_State    **Dst,
 					|	b ->negative_shift
 				}
 			} else {
-				|	mov TMP1w, #op2_lval
-				|	asr Rx(result_reg), Rx(result_reg), TMP1
+				|	asr Rx(result_reg), Rx(result_reg), #op2_lval
 			}
 		} else {
-			if (Z_MODE(op2_addr) != IS_REG || Z_REG(op2_addr) != ZREG_REG1) {
-				|	GET_ZVAL_LVAL ZREG_REG1, op2_addr, TMP1
+			zend_reg op2_reg;
+
+			if (Z_MODE(op2_addr) == IS_REG) {
+				op2_reg = Z_REG(op2_addr);
+			} else {
+				op2_reg = ZREG_TMP2;
+				|	GET_ZVAL_LVAL ZREG_TMP2, op2_addr, TMP2
 			}
 			if (!op2_range ||
 			     op2_range->min < 0 ||
 			     op2_range->max >= SIZEOF_ZEND_LONG * 8) {
-				|	cmp REG1, #(SIZEOF_ZEND_LONG*8)
+				|	cmp Rx(op2_reg), #(SIZEOF_ZEND_LONG*8)
 				|	bhs >1
 				|.cold_code
 				|1:
-				|	cmp REG1, xzr
-				|	mov REG1w, #((SIZEOF_ZEND_LONG * 8) - 1)
+				|	cmp Rx(op2_reg), xzr
+				|	mov Rx(op2_reg), #((SIZEOF_ZEND_LONG * 8) - 1)
 				|	bgt >1
 				|	SET_EX_OPLINE opline, REG0
 				|	b ->negative_shift
 				|.code
 			}
 			|1:
-			|	asr Rx(result_reg), Rx(result_reg), REG1
+			|	asr Rx(result_reg), Rx(result_reg), Rx(op2_reg)
 		}
 	} else if (opcode == ZEND_MOD) {
 		// REG0 -> result_reg
@@ -14120,6 +14130,8 @@ static bool zend_jit_may_reuse_reg(const zend_op *opline, const zend_ssa_op *ssa
 		case ZEND_BW_OR:
 		case ZEND_BW_AND:
 		case ZEND_BW_XOR:
+		case ZEND_SL:
+		case ZEND_SR:
 			if (def_var == ssa_op->result_def &&
 			    use_var == ssa_op->op1_use) {
 				return 1;
@@ -14266,19 +14278,6 @@ static bool zend_jit_may_be_in_reg(const zend_op_array *op_array, zend_ssa *ssa,
 	}
 
 	return 1;
-}
-
-static bool zend_needs_extra_reg_for_const(const zend_op *opline, zend_uchar op_type, znode_op op)
-{
-||	if (op_type == IS_CONST) {
-||		zval *zv = RT_CONSTANT(opline, op);
-||		if (Z_TYPE_P(zv) == IS_DOUBLE && Z_DVAL_P(zv) != 0) {
-||			return 1;
-||		} else if (Z_TYPE_P(zv) == IS_LONG) {
-||			return 1;
-||		}
-||	}
-	return 0;
 }
 
 static zend_regset zend_jit_get_def_scratch_regset(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_op_array *op_array, zend_ssa *ssa, int current_var, bool last_use)
@@ -14445,38 +14444,11 @@ static zend_regset zend_jit_get_scratch_regset(const zend_op *opline, const zend
 						ZEND_REGSET_INCL(regset, ZREG_FPR0);
 					}
 				}
-				if (zend_needs_extra_reg_for_const(opline, opline->op1_type, opline->op1) ||
-				    zend_needs_extra_reg_for_const(opline, opline->op2_type, opline->op2)) {
-					if (!ZEND_REGSET_IN(regset, ZREG_REG0)) {
-						ZEND_REGSET_INCL(regset, ZREG_REG0);
-					} else {
-						ZEND_REGSET_INCL(regset, ZREG_REG1);
-					}
-				}
 			}
 			break;
 		case ZEND_BW_OR:
 		case ZEND_BW_AND:
 		case ZEND_BW_XOR:
-			op1_info = OP1_INFO();
-			op2_info = OP2_INFO();
-			if (!(op1_info & ((MAY_BE_ANY|MAY_BE_REF|MAY_BE_UNDEF)-MAY_BE_LONG)) &&
-			    !(op2_info & ((MAY_BE_ANY|MAY_BE_REF|MAY_BE_UNDEF)-MAY_BE_LONG))) {
-				regset = ZEND_REGSET_EMPTY;
-				if (ssa_op->result_def != current_var &&
-				    (ssa_op->op1_use != current_var || !last_use)) {
-					ZEND_REGSET_INCL(regset, ZREG_REG0);
-				}
-				if (zend_needs_extra_reg_for_const(opline, opline->op1_type, opline->op1) ||
-				    zend_needs_extra_reg_for_const(opline, opline->op2_type, opline->op2)) {
-					if (!ZEND_REGSET_IN(regset, ZREG_REG0)) {
-						ZEND_REGSET_INCL(regset, ZREG_REG0);
-					} else {
-						ZEND_REGSET_INCL(regset, ZREG_REG1);
-					}
-				}
-			}
-			break;
 		case ZEND_SL:
 		case ZEND_SR:
 			op1_info = OP1_INFO();
@@ -14487,9 +14459,6 @@ static zend_regset zend_jit_get_scratch_regset(const zend_op *opline, const zend
 				if (ssa_op->result_def != current_var &&
 				    (ssa_op->op1_use != current_var || !last_use)) {
 					ZEND_REGSET_INCL(regset, ZREG_REG0);
-				}
-				if (opline->op2_type != IS_CONST && ssa_op->op2_use != current_var) {
-					ZEND_REGSET_INCL(regset, ZREG_REG1);
 				}
 			}
 			break;
@@ -14558,10 +14527,6 @@ static zend_regset zend_jit_get_scratch_regset(const zend_op *opline, const zend
 					    ssa_op->op2_use != current_var) {
 						ZEND_REGSET_INCL(regset, ZREG_FPR0);
 					}
-				}
-				if (zend_needs_extra_reg_for_const(opline, opline->op1_type, opline->op1) ||
-				    zend_needs_extra_reg_for_const(opline, opline->op2_type, opline->op2)) {
-					ZEND_REGSET_INCL(regset, ZREG_REG0);
 				}
 			}
 			break;


### PR DESCRIPTION
- perform constant shift by single instruction
  TODO: DynAsm: can't encode "lsl x0, x0, #var" !!!
- avoid usage of REG1 for variable shift (it was x86 limitation)
- enable register reuse for SL/SR instructions
- remove special scratch register handling for SL/SR (it was x86
  limitation)
- Remove need for extra scratch registers. AArch64 JIT backend
  don't use extra register for constants. It uses reserved TMP
  registers.