### PR TITLE
JIT/AArch64: [macos] Remove Clang warning due to -Wincompatible-point…

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -14795,7 +14795,7 @@ static int zend_jit_add_veneer(dasm_State *Dst, void *buffer, uint32_t ins, int 
 
 #ifdef HAVE_DISASM
 	    if (JIT_G(debug) & ZEND_JIT_DEBUG_ASM) {
-			const char *name = zend_jit_disasm_find_symbol((ptrdiff_t)cp + offset - 4, &offset);
+			const char *name = zend_jit_disasm_find_symbol((ptrdiff_t)cp + offset - 4, (int64_t *)(&offset));
 
 			if (name && !offset) {
 				if (strstr(name, "@veneer") == NULL) {


### PR DESCRIPTION
…er-types

The following warning message would be produced for macOS on Apple
silicon.

```
php-src/ext/opcache/jit/zend_jit_arm64.dasc:15356:79: warning: incompatible pointer types passing 'ptrdiff_t *' (aka 'long *') to parameter of type 'int64_t *'
      (aka 'long long *') [-Wincompatible-pointer-types]
                        const char *name = zend_jit_disasm_find_symbol((ptrdiff_t)cp + offset - 4, &offset);
                                                                                                   ^~~~~~~
ext/opcache/jit/zend_jit_disasm.c:210:58: note: passing argument to parameter 'offset' here
                                               int64_t  *offset) {

                                                  ^
```

Flag -Wincompatible-pointer-types is enabled by default in Clang [1],
but not in GCC [2].

Adding explicit type conversion would remove this warning.

[1]
https://releases.llvm.org/10.0.0/tools/clang/docs/DiagnosticsReference.html#wincompatible-pointer-types
[2]
https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/Warning-Options.html#Warning-Options

Change-Id: Ia0777a5731ba8f0764e232c0d47aeaab076d13f5