### PR TITLE
password_hash: don't fail on unsupported threads value

### DIFF
--- a/ext/sodium/sodium_pwhash.c
+++ b/ext/sodium/sodium_pwhash.c
@@ -65,8 +65,7 @@ static inline int get_options(zend_array *options, size_t *memlimit, size_t *ops
 		}
 	}
 	if ((opt = zend_hash_str_find(options, "threads", strlen("threads"))) && (zval_get_long(opt) != 1)) {
-		php_error_docref(NULL, E_WARNING, "A thread value other than 1 is not supported by this implementation");
-		return FAILURE;
+		php_error_docref(NULL, E_NOTICE, "A thread value other than 1 is not supported by this implementation");
 	}
 	return SUCCESS;
 }


### PR DESCRIPTION
As this is only about how hash is computed (in other implementation)
and have no effect on result.

This will improve code compatibility for the various implementations