### PR TITLE
Alternative Fiber Internals Refactoring

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -380,6 +380,7 @@ void shutdown_executor(void) /* {{{ */
 	zend_objects_store_free_object_storage(&EG(objects_store), fast_shutdown);
 
 	zend_weakrefs_shutdown();
+	zend_fiber_shutdown();
 
 	zend_try {
 		zend_llist_apply(&zend_extensions, (llist_apply_func_t) zend_extension_deactivator);

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -67,7 +67,7 @@ typedef struct _zend_fiber_stack {
 typedef struct _zend_fiber zend_fiber;
 typedef struct _zend_fiber_context zend_fiber_context;
 
-/* Fiber function is passed the fiber context and must return another context to switch to after it ran to completion. */
+/* Coroutine functions must return a fiber context to switch to after they are finished. */
 typedef zend_fiber_context *(*zend_fiber_coroutine)(zend_fiber_context *context);
 
 /* Defined as a macro to allow anonymous embedding. */
@@ -83,7 +83,7 @@ struct _zend_fiber_context {
 	ZEND_FIBER_CONTEXT_FIELDS;
 };
 
-/* Zend VM that needs to be captured / restored during context switch. */
+/* Zend VM state that needs to be captured / restored during fiber context switch. */
 typedef struct _zend_fiber_vm_state {
 	zend_vm_stack vm_stack;
 	size_t vm_stack_page_size;

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -61,8 +61,7 @@ END_EXTERN_C()
 
 typedef struct _zend_vm_stack *zend_vm_stack;
 typedef struct _zend_ini_entry zend_ini_entry;
-typedef struct _zend_fiber zend_fiber;
-
+typedef struct _zend_fiber_context zend_fiber_context;
 
 struct _zend_compiler_globals {
 	zend_stack loop_var_stack;
@@ -250,8 +249,8 @@ struct _zend_executor_globals {
 
 	zend_get_gc_buffer get_gc_buffer;
 
-	/* Active fiber, NULL when in main thread. */
-	zend_fiber *current_fiber;
+	zend_fiber_context *main_fiber;
+	zend_fiber_context *current_fiber;
 
 	/* Default fiber C stack size. */
 	zend_long fiber_stack_size;

--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -264,7 +264,7 @@ ZEND_API void zend_observer_fiber_switch_register(zend_observer_fiber_switch_han
 	zend_llist_add_element(&zend_observer_fiber_switch, &handler);
 }
 
-void zend_observer_fiber_switch_notify(zend_fiber *from, zend_fiber *to)
+ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber *from, zend_fiber *to)
 {
 	zend_llist_element *element;
 	zend_observer_fiber_switch_handler callback;

--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -264,7 +264,7 @@ ZEND_API void zend_observer_fiber_switch_register(zend_observer_fiber_switch_han
 	zend_llist_add_element(&zend_observer_fiber_switch, &handler);
 }
 
-ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber *from, zend_fiber *to)
+ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber_context *from, zend_fiber_context *to)
 {
 	zend_llist_element *element;
 	zend_observer_fiber_switch_handler callback;

--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -78,10 +78,10 @@ typedef void (*zend_observer_error_cb)(int type, zend_string *error_filename, ui
 ZEND_API void zend_observer_error_register(zend_observer_error_cb callback);
 void zend_observer_error_notify(int type, zend_string *error_filename, uint32_t error_lineno, zend_string *message);
 
-typedef void (*zend_observer_fiber_switch_handler)(zend_fiber *from, zend_fiber *to);
+typedef void (*zend_observer_fiber_switch_handler)(zend_fiber_context *from, zend_fiber_context *to);
 
 ZEND_API void zend_observer_fiber_switch_register(zend_observer_fiber_switch_handler handler);
-ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber *from, zend_fiber *to);
+ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber_context *from, zend_fiber_context *to);
 
 END_EXTERN_C()
 

--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -81,7 +81,7 @@ void zend_observer_error_notify(int type, zend_string *error_filename, uint32_t 
 typedef void (*zend_observer_fiber_switch_handler)(zend_fiber *from, zend_fiber *to);
 
 ZEND_API void zend_observer_fiber_switch_register(zend_observer_fiber_switch_handler handler);
-void zend_observer_fiber_switch_notify(zend_fiber *from, zend_fiber *to);
+ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber *from, zend_fiber *to);
 
 END_EXTERN_C()
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6895,7 +6895,7 @@ ZEND_METHOD(ReflectionFiber, getTrace)
 	prev_execute_data = fiber->stack_bottom->prev_execute_data;
 	fiber->stack_bottom->prev_execute_data = NULL;
 
-	if (EG(current_fiber) != fiber) {
+	if (EG(current_fiber) != zend_fiber_get_context(fiber)) {
 		// No need to replace current execute data if within the current fiber.
 		EG(current_execute_data) = fiber->execute_data;
 	}
@@ -6915,7 +6915,7 @@ ZEND_METHOD(ReflectionFiber, getExecutingLine)
 
 	REFLECTION_CHECK_VALID_FIBER(fiber);
 
-	if (EG(current_fiber) == fiber) {
+	if (EG(current_fiber) == zend_fiber_get_context(fiber)) {
 		prev_execute_data = execute_data->prev_execute_data;
 	} else {
 		prev_execute_data = fiber->execute_data->prev_execute_data;
@@ -6933,7 +6933,7 @@ ZEND_METHOD(ReflectionFiber, getExecutingFile)
 
 	REFLECTION_CHECK_VALID_FIBER(fiber);
 
-	if (EG(current_fiber) == fiber) {
+	if (EG(current_fiber) == zend_fiber_get_context(fiber)) {
 		prev_execute_data = execute_data->prev_execute_data;
 	} else {
 		prev_execute_data = fiber->execute_data->prev_execute_data;

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -411,44 +411,40 @@ static void observer_set_user_opcode_handler(const char *opcode_names, user_opco
 	}
 }
 
-static void fiber_address_observer(zend_fiber *from, zend_fiber *to)
+static void fiber_address_observer(zend_fiber_context *from, zend_fiber_context *to)
 {
 	if (ZT_G(observer_fiber_switch)) {
 		php_printf("<!-- switching from fiber %p to %p -->\n", from, to);
 	}
 }
 
-static void fiber_enter_observer(zend_fiber *from, zend_fiber *to)
+static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *to)
 {
 	if (ZT_G(observer_fiber_switch)) {
-		if (to) {
-			if (to->status == ZEND_FIBER_STATUS_INIT) {
-				php_printf("<init '%p'>\n", to);
-			} else if (to->status == ZEND_FIBER_STATUS_RUNNING && (!from || from->status == ZEND_FIBER_STATUS_RUNNING)) {
-				if (to->flags & ZEND_FIBER_FLAG_DESTROYED) {
-					php_printf("<destroying '%p'>\n", to);
-				} else if (to->status != ZEND_FIBER_STATUS_DEAD) {
-					php_printf("<resume '%p'>\n", to);
-				}
+		if (to->status == ZEND_FIBER_STATUS_INIT) {
+			php_printf("<init '%p'>\n", to);
+		} else if (to->status == ZEND_FIBER_STATUS_RUNNING && from->status == ZEND_FIBER_STATUS_RUNNING) {
+			if (to->flags & ZEND_FIBER_FLAG_DESTROYED) {
+				php_printf("<destroying '%p'>\n", to);
+			} else if (to->status != ZEND_FIBER_STATUS_DEAD) {
+				php_printf("<resume '%p'>\n", to);
 			}
 		}
 	}
 }
 
-static void fiber_suspend_observer(zend_fiber *from, zend_fiber *to)
+static void fiber_suspend_observer(zend_fiber_context *from, zend_fiber_context *to)
 {
 	if (ZT_G(observer_fiber_switch)) {
-		if (from) {
-			if (from->status == ZEND_FIBER_STATUS_SUSPENDED) {
-				php_printf("<suspend '%p'>\n", from);
-			} else if (from->status == ZEND_FIBER_STATUS_DEAD) {
-				if (from->flags & ZEND_FIBER_FLAG_THREW) {
-					php_printf("<threw '%p'>\n", from);
-				} else if (from->flags & ZEND_FIBER_FLAG_DESTROYED) {
-					php_printf("<destroyed '%p'>\n", from);
-				} else {
-					php_printf("<returned '%p'>\n", from);
-				}
+		if (from->status == ZEND_FIBER_STATUS_SUSPENDED) {
+			php_printf("<suspend '%p'>\n", from);
+		} else if (from->status == ZEND_FIBER_STATUS_DEAD) {
+			if (from->flags & ZEND_FIBER_FLAG_THREW) {
+				php_printf("<threw '%p'>\n", from);
+			} else if (from->flags & ZEND_FIBER_FLAG_DESTROYED) {
+				php_printf("<destroyed '%p'>\n", from);
+			} else {
+				php_printf("<returned '%p'>\n", from);
 			}
 		}
 	}

--- a/ext/zend_test/tests/observer_fiber_01.phpt
+++ b/ext/zend_test/tests/observer_fiber_01.phpt
@@ -18,12 +18,12 @@ $fiber->resume();
 ?>
 --EXPECTF--
 <!-- init '%sobserver_fiber_01.php' -->
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <init '%s'>
 <!-- init {closure}() -->
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <resume '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <returned '%s'>

--- a/ext/zend_test/tests/observer_fiber_02.phpt
+++ b/ext/zend_test/tests/observer_fiber_02.phpt
@@ -17,12 +17,12 @@ $fiber->start();
 ?>
 --EXPECTF--
 <!-- init '%sobserver_fiber_02.php' -->
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <init '%s'>
 <!-- init {closure}() -->
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <destroying '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <destroyed '%s'>

--- a/ext/zend_test/tests/observer_fiber_03.phpt
+++ b/ext/zend_test/tests/observer_fiber_03.phpt
@@ -40,12 +40,12 @@ $fiber->resume();
 ?>
 --EXPECTF--
 <!-- init '%sobserver_fiber_03.php' -->
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <init '%s'>
 <!-- init {closure}() -->
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <resume '%s'>
 int(1)
 <!-- switching from fiber %s to %s -->
@@ -53,9 +53,9 @@ int(1)
 <!-- init {closure}() -->
 <!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <resume '%s'>
 int(2)
 <!-- switching from fiber %s to %s -->
@@ -63,9 +63,9 @@ int(2)
 int(3)
 <!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <resume '%s'>
 int(4)
 <!-- switching from fiber %s to %s -->
@@ -73,5 +73,5 @@ int(4)
 int(5)
 <!-- switching from fiber %s to %s -->
 <returned '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <returned '%s'>

--- a/ext/zend_test/tests/observer_fiber_04.phpt
+++ b/ext/zend_test/tests/observer_fiber_04.phpt
@@ -27,25 +27,25 @@ $fiber->resume();
 ?>
 --EXPECTF--
 <!-- init '%sobserver_fiber_04.php' -->
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <init '%s'>
 <!-- init {closure}() -->
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <resume '%s'>
 <!-- switching from fiber %s to %s -->
 <init '%s'>
 <!-- init {closure}() -->
 <!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <resume '%s'>
 <!-- switching from fiber %s to %s -->
 <destroying '%s'>
 <!-- switching from fiber %s to %s -->
 <destroyed '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <returned '%s'>

--- a/ext/zend_test/tests/observer_fiber_05.phpt
+++ b/ext/zend_test/tests/observer_fiber_05.phpt
@@ -26,25 +26,25 @@ $fiber->resume();
 ?>
 --EXPECTF--
 <!-- init '%sobserver_fiber_05.php' -->
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <init '%s'>
 <!-- init {closure}() -->
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <resume '%s'>
 <!-- switching from fiber %s to %s -->
 <init '%s'>
 <!-- init {closure}() -->
 <!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <destroying '%s'>
 <!-- switching from fiber %s to %s -->
 <destroying '%s'>
 <!-- switching from fiber %s to %s -->
 <destroyed '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <destroyed '%s'>

--- a/ext/zend_test/tests/observer_fiber_06.phpt
+++ b/ext/zend_test/tests/observer_fiber_06.phpt
@@ -23,12 +23,12 @@ try {
 ?>
 --EXPECTF--
 <!-- init '%sobserver_fiber_06.php' -->
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <init '%s'>
 <!-- init {closure}() -->
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <suspend '%s'>
-<!-- switching from fiber 0 to %s -->
+<!-- switching from fiber %s to %s -->
 <resume '%s'>
-<!-- switching from fiber %s to 0 -->
+<!-- switching from fiber %s to %s -->
 <threw '%s'>


### PR DESCRIPTION
@trowski This is an alternative (and a lot simpler refactoring) to #7085 that achieves some of the goals (1 and 3) stated by @twose without a complete rewrite of the code. I kept everything really simple to make it easily comprehensible. It also allows for pure C fibers and arbitrary context switching for different scheduling models. The C fiber is basically represented by `zend_fiber_context` while the PHP fiber object is using `zend_fiber`. I am pretty sure that it is a good starting point for further improvements. I have used similiar in production for more than a year now and it works really well.

I did not remove the `ZEND_API` for `zend_fiber`, however it would make sense to come up with a new implementation based on `zend_fiber_context` that might be more suited for internal use. I have used an API like that for some time and it was really nice for suspending from within PHP streams and function calls. Let me know if you are intereseted in another PR for this and I will try to come up with another PR.

Let's make this work in a way that allows everyone to collaborate and benefit.