### PR TITLE
Merge fiber switching functions

### DIFF
--- a/Zend/tests/fibers/fiber-status.phpt
+++ b/Zend/tests/fibers/fiber-status.phpt
@@ -10,6 +10,18 @@ $fiber = new Fiber(function (): void {
     var_dump($fiber->isRunning());
     var_dump($fiber->isSuspended());
     var_dump($fiber->isTerminated());
+
+    $nested = new Fiber(function () use ($fiber): void {
+        echo "\nWithin Nested Fiber:\n";
+        var_dump($fiber->isStarted());
+        var_dump($fiber->isRunning());
+        var_dump($fiber->isSuspended());
+        var_dump($fiber->isTerminated());
+        Fiber::suspend();
+    });
+
+    $nested->start();
+
     Fiber::suspend();
 });
 
@@ -44,6 +56,12 @@ bool(false)
 bool(false)
 
 Within Fiber:
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+
+Within Nested Fiber:
 bool(true)
 bool(true)
 bool(false)

--- a/Zend/tests/fibers/resume-previous-fiber.phpt
+++ b/Zend/tests/fibers/resume-previous-fiber.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Resume previous fiber
+--FILE--
+<?php
+
+$fiber = new Fiber(function (): void {
+    $fiber1 = Fiber::this();
+
+    $fiber2 = new Fiber(function () use ($fiber1): void {
+        $fiber1->resume();
+    });
+
+    $fiber2->start();
+});
+
+$fiber->start();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught FiberError: Cannot resume a fiber that is not suspended in %sresume-previous-fiber.php:%d
+Stack trace:
+#0 %sresume-previous-fiber.php(%d): Fiber->resume()
+#1 [internal function]: {closure}()
+#2 %sresume-previous-fiber.php(%d): Fiber->start()
+#3 [internal function]: {closure}()
+#4 %sresume-previous-fiber.php(%d): Fiber->start()
+#5 {main}
+  thrown in %sresume-previous-fiber.php on line %d

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -281,7 +281,7 @@ ZEND_API zend_fiber_context *zend_fiber_switch_context(zend_fiber_context *to)
 	}
 
 	if (previous->status == ZEND_FIBER_STATUS_DEAD) {
-		zend_fiber_destroy_context(to);
+		zend_fiber_destroy_context(previous);
 	}
 
 	return previous;

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -226,7 +226,7 @@ ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context)
 	zend_fiber_stack_free(&context->stack);
 }
 
-ZEND_API void zend_fiber_switch_context(zend_fiber_context *to)
+ZEND_API zend_fiber_context *zend_fiber_switch_context(zend_fiber_context *to)
 {
 	zend_fiber_context *from = EG(current_fiber);
 	zend_fiber_vm_state state;
@@ -283,6 +283,8 @@ ZEND_API void zend_fiber_switch_context(zend_fiber_context *to)
 	if (previous->status == ZEND_FIBER_STATUS_DEAD) {
 		zend_fiber_destroy_context(to);
 	}
+
+	return previous;
 }
 
 

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -133,7 +133,7 @@ ZEND_API void zend_fiber_throw(zend_fiber *fiber, zval *exception, zval *return_
 /* These functions may be used to create custom fibers (coroutines) using the bundled fiber switching context. */
 ZEND_API bool zend_fiber_init_context(zend_fiber_context *context, void *kind, zend_fiber_coroutine coroutine, size_t stack_size);
 ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context);
-ZEND_API void zend_fiber_switch_context(zend_fiber_context *to);
+ZEND_API zend_fiber_context *zend_fiber_switch_context(zend_fiber_context *to);
 
 END_EXTERN_C()
 

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -90,8 +90,8 @@ struct _zend_fiber_context {
 /* Zend VM state that needs to be captured / restored during fiber context switch. */
 typedef struct _zend_fiber_vm_state {
 	zend_vm_stack vm_stack;
-	zval* vm_stack_top;
-	zval* vm_stack_end;
+	zval *vm_stack_top;
+	zval *vm_stack_end;
 	size_t vm_stack_page_size;
 	zend_execute_data *current_execute_data;
 	int error_reporting;

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -76,7 +76,6 @@ typedef zend_fiber_context *(*zend_fiber_coroutine)(zend_fiber_context *context)
 	void *handle; \
 	/* Pointer that identifies the fiber type. */ \
 	void *kind; \
-	zend_fiber_context *caller; \
 	zend_fiber_coroutine function; \
 	zend_fiber_stack stack; \
 	zend_fiber_status status; \
@@ -105,6 +104,9 @@ struct _zend_fiber {
 
 	/* Fiber context fields (embedded to avoid memory allocation). */
 	ZEND_FIBER_CONTEXT_FIELDS;
+
+	/* Fiber that resumed us. */
+	zend_fiber_context *caller;
 
 	/* Callback and info / cache to be used when fiber is started. */
 	zend_fcall_info fci;

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -123,14 +123,7 @@ struct _zend_fiber {
 	zval value;
 };
 
-/* These functions create and manipulate a Fiber object, allowing any internal function to start, resume, or suspend a fiber. */
-ZEND_API zend_fiber *zend_fiber_create(const zend_fcall_info *fci, const zend_fcall_info_cache *fci_cache);
-ZEND_API void zend_fiber_start(zend_fiber *fiber, zval *params, uint32_t param_count, zend_array *named_params, zval *return_value);
-ZEND_API void zend_fiber_suspend(zval *value, zval *return_value);
-ZEND_API void zend_fiber_resume(zend_fiber *fiber, zval *value, zval *return_value);
-ZEND_API void zend_fiber_throw(zend_fiber *fiber, zval *exception, zval *return_value);
-
-/* These functions may be used to create custom fibers (coroutines) using the bundled fiber switching context. */
+/* These functions may be used to create custom fiber objects using the bundled fiber switching context. */
 ZEND_API bool zend_fiber_init_context(zend_fiber_context *context, void *kind, zend_fiber_coroutine coroutine, size_t stack_size);
 ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context);
 ZEND_API zend_fiber_context *zend_fiber_switch_context(zend_fiber_context *to);

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -436,7 +436,7 @@ static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *t
 	if (ZT_G(observer_fiber_switch)) {
 		if (to->status == ZEND_FIBER_STATUS_INIT) {
 			php_printf("<init '%p'>\n", to);
-		} else if (to->status == ZEND_FIBER_STATUS_RUNNING && from->status == ZEND_FIBER_STATUS_RUNNING) {
+		} else if (from->status == ZEND_FIBER_STATUS_RUNNING && to->status == ZEND_FIBER_STATUS_SUSPENDED) {
 			if (to->flags & ZEND_FIBER_FLAG_DESTROYED) {
 				php_printf("<destroying '%p'>\n", to);
 			} else if (to->status != ZEND_FIBER_STATUS_DEAD) {
@@ -449,7 +449,7 @@ static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *t
 static void fiber_suspend_observer(zend_fiber_context *from, zend_fiber_context *to)
 {
 	if (ZT_G(observer_fiber_switch)) {
-		if (from->status == ZEND_FIBER_STATUS_SUSPENDED) {
+		if (from->status == ZEND_FIBER_STATUS_RUNNING && to->status == ZEND_FIBER_STATUS_RUNNING) {
 			php_printf("<suspend '%p'>\n", from);
 		} else if (from->status == ZEND_FIBER_STATUS_DEAD) {
 			if (from->flags & ZEND_FIBER_FLAG_THREW) {

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -436,7 +436,7 @@ static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *t
 	if (ZT_G(observer_fiber_switch)) {
 		if (to->status == ZEND_FIBER_STATUS_INIT) {
 			php_printf("<init '%p'>\n", to);
-		} else if (from->status == ZEND_FIBER_STATUS_RUNNING && to->status == ZEND_FIBER_STATUS_SUSPENDED) {
+		} else if (to->caller == NULL) {
 			if (to->flags & ZEND_FIBER_FLAG_DESTROYED) {
 				php_printf("<destroying '%p'>\n", to);
 			} else if (to->status != ZEND_FIBER_STATUS_DEAD) {
@@ -449,7 +449,7 @@ static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *t
 static void fiber_suspend_observer(zend_fiber_context *from, zend_fiber_context *to)
 {
 	if (ZT_G(observer_fiber_switch)) {
-		if (from->status == ZEND_FIBER_STATUS_RUNNING && to->status == ZEND_FIBER_STATUS_RUNNING) {
+		if (from->caller == to && from->status == ZEND_FIBER_STATUS_RUNNING) {
 			php_printf("<suspend '%p'>\n", from);
 		} else if (from->status == ZEND_FIBER_STATUS_DEAD) {
 			if (from->flags & ZEND_FIBER_FLAG_THREW) {

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -436,7 +436,12 @@ static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *t
 	if (ZT_G(observer_fiber_switch)) {
 		if (to->status == ZEND_FIBER_STATUS_INIT) {
 			php_printf("<init '%p'>\n", to);
-		} else if (to->caller == NULL) {
+		} else if (to != EG(main_fiber)) {
+			zend_fiber *fiber = zend_fiber_from_context(to);
+			if (fiber->caller != from) {
+				return;
+			}
+
 			if (to->flags & ZEND_FIBER_FLAG_DESTROYED) {
 				php_printf("<destroying '%p'>\n", to);
 			} else if (to->status != ZEND_FIBER_STATUS_DEAD) {
@@ -449,15 +454,18 @@ static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *t
 static void fiber_suspend_observer(zend_fiber_context *from, zend_fiber_context *to)
 {
 	if (ZT_G(observer_fiber_switch)) {
-		if (from->caller == to && from->status == ZEND_FIBER_STATUS_RUNNING) {
-			php_printf("<suspend '%p'>\n", from);
-		} else if (from->status == ZEND_FIBER_STATUS_DEAD) {
+		if (from->status == ZEND_FIBER_STATUS_DEAD) {
 			if (from->flags & ZEND_FIBER_FLAG_THREW) {
 				php_printf("<threw '%p'>\n", from);
 			} else if (from->flags & ZEND_FIBER_FLAG_DESTROYED) {
 				php_printf("<destroyed '%p'>\n", from);
 			} else {
 				php_printf("<returned '%p'>\n", from);
+			}
+		} else if (from != EG(main_fiber)) {
+			zend_fiber *fiber = zend_fiber_from_context(from);
+			if (fiber->caller == NULL) {
+				php_printf("<suspend '%p'>\n", from);
 			}
 		}
 	}

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -436,7 +436,7 @@ static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *t
 	if (ZT_G(observer_fiber_switch)) {
 		if (to->status == ZEND_FIBER_STATUS_INIT) {
 			php_printf("<init '%p'>\n", to);
-		} else if (to != EG(main_fiber)) {
+		} else if (to->kind == zend_ce_fiber) {
 			zend_fiber *fiber = zend_fiber_from_context(to);
 			if (fiber->caller != from) {
 				return;
@@ -462,7 +462,7 @@ static void fiber_suspend_observer(zend_fiber_context *from, zend_fiber_context 
 			} else {
 				php_printf("<returned '%p'>\n", from);
 			}
-		} else if (from != EG(main_fiber)) {
+		} else if (from->kind == zend_ce_fiber) {
 			zend_fiber *fiber = zend_fiber_from_context(from);
 			if (fiber->caller == NULL) {
 				php_printf("<suspend '%p'>\n", from);


### PR DESCRIPTION
Provides a single function for switching arbitrary between fiber contexts (including `{main}`), `zend_fiber_switch_context`.

`zend_fiber_context` may be used to create and switch between custom fibers while still triggering the switch observer and swapping the necessary VM globals. An extension or a future implementation of async/await then may create fiber contexts which are independently scheduled and cannot be controlled with the `Fiber` API. This avoids a call to `Fiber::suspend()` potentially interfering with custom scheduling in an extension or event-loop.