### PR TITLE
Fix bug #81096: Re-infer ranges if ref type is inferred

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -4291,14 +4291,15 @@ static int zend_infer_types(const zend_op_array *op_array, const zend_script *sc
 	zend_ssa_var_info *ssa_var_info = ssa->var_info;
 	int ssa_vars_count = ssa->vars_count;
 	int j;
+	int worklist_len = zend_bitset_len(ssa_vars_count);
 	zend_bitset worklist, range_worklist;
 	ALLOCA_FLAG(use_heap);
 
-	worklist = do_alloca(sizeof(zend_ulong) * zend_bitset_len(ssa_vars_count), use_heap);
-	memset(worklist, 0, sizeof(zend_ulong) * zend_bitset_len(ssa_vars_count));
+	worklist = do_alloca(sizeof(zend_ulong) * worklist_len * 2, use_heap);
+	memset(worklist, 0, sizeof(zend_ulong) * worklist_len);
 
-	range_worklist = do_alloca(sizeof(zend_ulong) * zend_bitset_len(ssa_vars_count), use_heap);
-	memset(range_worklist, 0, sizeof(zend_ulong) * zend_bitset_len(ssa_vars_count));
+	range_worklist = worklist + worklist_len;
+	memset(range_worklist, 0, sizeof(zend_ulong) * worklist_len);
 
 	/* Type Inference */
 	for (j = op_array->last_var; j < ssa_vars_count; j++) {

--- a/Zend/Optimizer/zend_inference.h
+++ b/Zend/Optimizer/zend_inference.h
@@ -263,8 +263,6 @@ int  zend_inference_narrowing_meet(zend_ssa_var_info *var_info, zend_ssa_range *
 int  zend_inference_widening_meet(zend_ssa_var_info *var_info, zend_ssa_range *r);
 void zend_inference_check_recursive_dependencies(zend_op_array *op_array);
 
-int  zend_infer_types_ex(const zend_op_array *op_array, const zend_script *script, zend_ssa *ssa, zend_bitset worklist, zend_long optimization_level);
-
 ZEND_API uint32_t zend_fetch_arg_info_type(
 	const zend_script *script, zend_arg_info *arg_info, zend_class_entry **pce);
 ZEND_API void zend_init_func_return_info(

--- a/ext/opcache/tests/ref_range_1.phpt
+++ b/ext/opcache/tests/ref_range_1.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Range info for references (1)
+--FILE--
+<?php
+
+function test() {
+    escape_x($x);
+    $x = 0;
+    modify_x();
+    return (int) $x;
+}
+
+function escape_x(&$x) {
+    $GLOBALS['x'] =& $x;
+}
+
+function modify_x() {
+    $GLOBALS['x']++;
+}
+
+var_dump(test());
+
+?>
+--EXPECT--
+int(1)

--- a/ext/opcache/tests/ref_range_2.phpt
+++ b/ext/opcache/tests/ref_range_2.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Range info for references (2)
+--FILE--
+<?php
+
+function test() {
+    escape_x($x);
+    $x = 0;
+    modify_x();
+    return PHP_INT_MAX + (int) $x;
+}
+
+function escape_x(&$x) {
+    $GLOBALS['x'] =& $x;
+}
+
+function modify_x() {
+    $GLOBALS['x']++;
+}
+
+var_dump(test());
+
+?>
+--EXPECTF--
+float(%s)


### PR DESCRIPTION
If a reference type for a variable is inferred, the range
information becomes potentially incorrect, as the variable may
be modified indirectly at any time.

If a reference type is inferred, set the variable to the full
range and recompute dependent ranges. This is done using a separate
range worklist that calculates ranges using a widening meet.

Fix for https://bugs.php.net/bug.php?id=81096.