### PR TITLE
Implement JsonSerializable for SplFixedArray

### DIFF
--- a/ext/spl/config.m4
+++ b/ext/spl/config.m4
@@ -2,3 +2,4 @@ PHP_NEW_EXTENSION(spl, php_spl.c spl_functions.c spl_engine.c spl_iterators.c sp
 PHP_INSTALL_HEADERS([ext/spl], [php_spl.h spl_array.h spl_directory.h spl_engine.h spl_exceptions.h spl_functions.h spl_iterators.h spl_observer.h spl_dllist.h spl_heap.h spl_fixedarray.h])
 PHP_ADD_EXTENSION_DEP(spl, pcre, true)
 PHP_ADD_EXTENSION_DEP(spl, standard, true)
+PHP_ADD_EXTENSION_DEP(spl, json)

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -735,9 +735,14 @@ PHP_RSHUTDOWN_FUNCTION(spl) /* {{{ */
 	return SUCCESS;
 } /* }}} */
 
-/* {{{ spl_module_entry */
+static const zend_module_dep spl_deps[] = {
+	ZEND_MOD_REQUIRED("json")
+	ZEND_MOD_END
+};
+
 zend_module_entry spl_module_entry = {
-	STANDARD_MODULE_HEADER,
+	STANDARD_MODULE_HEADER_EX, NULL,
+	spl_deps,
 	"SPL",
 	ext_functions,
 	PHP_MINIT(spl),
@@ -748,4 +753,3 @@ zend_module_entry spl_module_entry = {
 	PHP_SPL_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
-/* }}} */

--- a/ext/spl/spl_fixedarray.stub.php
+++ b/ext/spl/spl_fixedarray.stub.php
@@ -2,7 +2,7 @@
 
 /** @generate-class-entries */
 
-class SplFixedArray implements IteratorAggregate, ArrayAccess, Countable
+class SplFixedArray implements IteratorAggregate, ArrayAccess, Countable, JsonSerializable
 {
     public function __construct(int $size = 0) {}
 
@@ -49,4 +49,6 @@ class SplFixedArray implements IteratorAggregate, ArrayAccess, Countable
     public function offsetUnset($index) {}
 
     public function getIterator(): Iterator {}
+
+    public function jsonSerialize(): array {}
 }

--- a/ext/spl/spl_fixedarray_arginfo.h
+++ b/ext/spl/spl_fixedarray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: aeac254f38638c19a11f7d79ac2e5c2d40924e58 */
+ * Stub hash: 115b2d974b18287654be925c4fdc2236674423eb */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFixedArray___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size, IS_LONG, 0, "0")
@@ -39,6 +39,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_SplFixedArray_getIterator, 0, 0, Iterator, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_SplFixedArray_jsonSerialize, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 
 ZEND_METHOD(SplFixedArray, __construct);
 ZEND_METHOD(SplFixedArray, __wakeup);
@@ -52,6 +55,7 @@ ZEND_METHOD(SplFixedArray, offsetGet);
 ZEND_METHOD(SplFixedArray, offsetSet);
 ZEND_METHOD(SplFixedArray, offsetUnset);
 ZEND_METHOD(SplFixedArray, getIterator);
+ZEND_METHOD(SplFixedArray, jsonSerialize);
 
 
 static const zend_function_entry class_SplFixedArray_methods[] = {
@@ -67,16 +71,17 @@ static const zend_function_entry class_SplFixedArray_methods[] = {
 	ZEND_ME(SplFixedArray, offsetSet, arginfo_class_SplFixedArray_offsetSet, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFixedArray, offsetUnset, arginfo_class_SplFixedArray_offsetUnset, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFixedArray, getIterator, arginfo_class_SplFixedArray_getIterator, ZEND_ACC_PUBLIC)
+	ZEND_ME(SplFixedArray, jsonSerialize, arginfo_class_SplFixedArray_jsonSerialize, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_SplFixedArray(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_ArrayAccess, zend_class_entry *class_entry_Countable)
+static zend_class_entry *register_class_SplFixedArray(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_ArrayAccess, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "SplFixedArray", class_SplFixedArray_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
-	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_Countable);
+	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_ArrayAccess, class_entry_Countable, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/ext/spl/tests/splfixedarray_json_encode.phpt
+++ b/ext/spl/tests/splfixedarray_json_encode.phpt
@@ -1,0 +1,18 @@
+--TEST--
+json_encode() on SplFixedArray
+--FILE--
+<?php
+
+echo json_encode(new SplFixedArray()) . "\n";
+echo json_encode(new SplFixedArray(1)) . "\n";
+
+$a = new SplFixedArray(3);
+$a[0] = 0;
+$a[2] = 2;
+echo json_encode($a) . "\n";
+
+?>
+--EXPECT--
+[]
+[null]
+[0,null,2]


### PR DESCRIPTION
This returns an array for SplFixedArray JSON encoding, which
is more appropriate than an object with integer string keys.

Implements request https://bugs.php.net/bug.php?id=81112.