### PR TITLE
Don't throw undefined array key warning in ArrayObject unset()

### DIFF
--- a/Zend/tests/unset_cv10.phpt
+++ b/Zend/tests/unset_cv10.phpt
@@ -10,9 +10,7 @@ $a->offsetUnset('x');
 echo $x;
 echo "ok\n";
 ?>
---EXPECTF--
+--EXPECT--
 ok
-
-Warning: Undefined array key "x" in %s on line %d
 ok
 ok

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -554,9 +554,7 @@ static void spl_array_unset_dimension_ex(int check_inherited, zend_object *objec
 		if (data) {
 			if (Z_TYPE_P(data) == IS_INDIRECT) {
 				data = Z_INDIRECT_P(data);
-				if (Z_TYPE_P(data) == IS_UNDEF) {
-					zend_error(E_WARNING,"Undefined array key \"%s\"", ZSTR_VAL(key.key));
-				} else {
+				if (Z_TYPE_P(data) != IS_UNDEF) {
 					zval_ptr_dtor(data);
 					ZVAL_UNDEF(data);
 					HT_FLAGS(ht) |= HASH_FLAG_HAS_EMPTY_IND;
@@ -565,17 +563,13 @@ static void spl_array_unset_dimension_ex(int check_inherited, zend_object *objec
 						spl_array_skip_protected(intern, ht);
 					}
 				}
-			} else if (zend_hash_del(ht, key.key) == FAILURE) {
-				zend_error(E_WARNING,"Undefined array key \"%s\"", ZSTR_VAL(key.key));
+			} else {
+				zend_hash_del(ht, key.key);
 			}
-		} else {
-			zend_error(E_WARNING,"Undefined array key \"%s\"", ZSTR_VAL(key.key));
 		}
 		spl_hash_key_release(&key);
 	} else {
-		if (zend_hash_index_del(ht, key.h) == FAILURE) {
-			zend_error(E_WARNING, "Undefined array key " ZEND_LONG_FMT, key.h);
-		}
+		zend_hash_index_del(ht, key.h);
 	}
 } /* }}} */
 

--- a/ext/spl/tests/arrayObject___construct_basic4.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic4.phpt
@@ -64,8 +64,6 @@ bool(true)
 Warning: Undefined array key "prop" in %s on line %d
 
 Warning: Undefined array key "prop" in %s on line %d
-
-Warning: Undefined array key "prop" in %s on line %d
 NULL
 NULL
   - After:

--- a/ext/spl/tests/arrayObject___construct_basic5.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic5.phpt
@@ -64,8 +64,6 @@ bool(true)
 Warning: Undefined array key "prop" in %s on line %d
 
 Warning: Undefined array key "prop" in %s on line %d
-
-Warning: Undefined array key "prop" in %s on line %d
 NULL
 NULL
   - After:

--- a/ext/spl/tests/arrayObject_magicMethods1.phpt
+++ b/ext/spl/tests/arrayObject_magicMethods1.phpt
@@ -170,8 +170,6 @@ object(ArrayObject)#2 (1) {
 }
 
 --> Unset existent, non-existent and dynamic:
-
-Warning: Undefined array key "nonexistent" in %s on line %d
   Original wrapped object:
 object(UsesMagic)#1 (3) {
   ["b"]=>

--- a/ext/spl/tests/arrayObject_magicMethods3.phpt
+++ b/ext/spl/tests/arrayObject_magicMethods3.phpt
@@ -170,8 +170,6 @@ object(ArrayObject)#2 (1) {
 }
 
 --> Unset existent, non-existent and dynamic:
-
-Warning: Undefined array key "nonexistent" in %s on line %d
   Original wrapped object:
 object(UsesMagic)#1 (3) {
   ["b"]=>

--- a/ext/spl/tests/arrayObject_magicMethods4.phpt
+++ b/ext/spl/tests/arrayObject_magicMethods4.phpt
@@ -179,8 +179,6 @@ object(UsesMagic)#2 (2) {
 }
 
 --> Unset existent, non-existent and dynamic:
-
-Warning: Undefined array key "nonexistent" in %s on line %d
   Original wrapped object:
 object(C)#1 (3) {
   ["b"]=>

--- a/ext/spl/tests/arrayObject_magicMethods6.phpt
+++ b/ext/spl/tests/arrayObject_magicMethods6.phpt
@@ -179,8 +179,6 @@ object(UsesMagic)#2 (2) {
 }
 
 --> Unset existent, non-existent and dynamic:
-
-Warning: Undefined array key "nonexistent" in %s on line %d
   Original wrapped object:
 object(C)#1 (3) {
   ["b"]=>

--- a/ext/spl/tests/array_001.phpt
+++ b/ext/spl/tests/array_001.phpt
@@ -82,10 +82,6 @@ NULL
 
 Warning: Undefined array key "b" in %s on line %d
 NULL
-
-Warning: Undefined array key 7 in %s on line %d
-
-Warning: Undefined array key "c" in %s on line %d
 object(ArrayObject)#%d (1) {
   ["storage":"ArrayObject":private]=>
   array(2) {

--- a/ext/spl/tests/array_010.phpt
+++ b/ext/spl/tests/array_010.phpt
@@ -125,10 +125,6 @@ array(6) {
   [6]=>
   string(9) "changed 6"
 }
-
-Warning: Undefined array key 7 in %s on line %d
-
-Warning: Undefined array key "8th" in %s on line %d
 array(4) {
   [0]=>
   string(3) "1st"

--- a/ext/spl/tests/bug45622b.phpt
+++ b/ext/spl/tests/bug45622b.phpt
@@ -28,6 +28,4 @@ Doesn't trigger __get.
 Warning: Undefined array key "prop1" in %s on line %d
 Doesn't trigger __set.
 Doesn't trigger __unset.
-
-Warning: Undefined array key "prop3" in %s on line %d
 Shouldn't trigger __isset.

--- a/ext/spl/tests/bug66127.phpt
+++ b/ext/spl/tests/bug66127.phpt
@@ -21,6 +21,5 @@ unset($items[0][0]);
 crash();
 echo "Worked!\n";
 ?>
---EXPECTF--
-Warning: Undefined array key 0 in %s on line %d
+--EXPECT--
 Worked!


### PR DESCRIPTION
This makes the behavior of ArrayObject the same as for plain
arrays, which don't throw a warning when unsetting a key that
already doesn't exit.

Fixes https://bugs.php.net/bug.php?id=80945.