### PR TITLE
Fixed bug #81096: Inconsistent range inferece for variables passed by reference

### DIFF
--- a/ext/opcache/tests/ref_range_1.phpt
+++ b/ext/opcache/tests/ref_range_1.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Range info for references (1)
+--FILE--
+<?php
+
+function test() {
+    escape_x($x);
+    $x = 0;
+    modify_x();
+    return (int) $x;
+}
+
+function escape_x(&$x) {
+    $GLOBALS['x'] =& $x;
+}
+
+function modify_x() {
+    $GLOBALS['x']++;
+}
+
+var_dump(test());
+
+?>
+--EXPECT--
+int(1)

--- a/ext/opcache/tests/ref_range_2.phpt
+++ b/ext/opcache/tests/ref_range_2.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Range info for references (2)
+--FILE--
+<?php
+
+function test() {
+    escape_x($x);
+    $x = 0;
+    modify_x();
+    return PHP_INT_MAX + (int) $x;
+}
+
+function escape_x(&$x) {
+    $GLOBALS['x'] =& $x;
+}
+
+function modify_x() {
+    $GLOBALS['x']++;
+}
+
+var_dump(test());
+
+?>
+--EXPECTF--
+float(%s)


### PR DESCRIPTION
Detect references before range inference and exclude them from range inference.