### PR TITLE
fdatasync disable warning on macOS.

### DIFF
--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -60,6 +60,9 @@ extern int php_get_gid_by_name(const char *name, gid_t *gid);
 # define PLAIN_WRAP_BUF_SIZE(st) (st)
 # if !defined(HAVE_FDATASYNC)
 #  define fdatasync fsync
+# elif defined(__APPLE__)
+  // The symbol is present, however not in the headers
+  extern int fdatasync(int);
 # endif
 #endif
 


### PR DESCRIPTION
The symbol exists and picked up but nowhere to be found on the headers.
tested on gcc/clang from homebrew and clang/Xcode.