### PR TITLE
Support empty POSIX string in older TZif2

### DIFF
--- a/ext/date/lib/timelib.c
+++ b/ext/date/lib/timelib.c
@@ -35,7 +35,7 @@
 
 #define TIMELIB_LLABS(y) (y < 0 ? (y * -1) : y)
 
-const char *timelib_error_messages[9] = {
+const char *timelib_error_messages[10] = {
 	"No error",
 	"Can not allocate buffer for parsing",
 	"Corrupt tzfile: The transitions in the file don't always increase",
@@ -44,6 +44,8 @@ const char *timelib_error_messages[9] = {
 	"The version used in this timezone identifier is unsupported",
 	"No timezone with this name could be found",
 	"A 'slim' timezone file has been detected",
+	"The embedded POSIX string is not valid",
+	"The embedded POSIX string is empty"
 };
 
 const char *timelib_get_error_message(int error_code)

--- a/ext/date/lib/timelib.h
+++ b/ext/date/lib/timelib.h
@@ -370,7 +370,8 @@ typedef struct _timelib_tzdb {
 #define TIMELIB_UNSET   -99999
 
 /* An entry for each of these error codes is also in the
- * timelib_error_messages array in timelib.c */
+ * timelib_error_messages array in timelib.c.
+ * Codes 0x00, 0x07, and 0x09 are warnings only. */
 #define TIMELIB_ERROR_NO_ERROR                            0x00
 #define TIMELIB_ERROR_CANNOT_ALLOCATE                     0x01
 #define TIMELIB_ERROR_CORRUPT_TRANSITIONS_DONT_INCREASE   0x02
@@ -378,8 +379,9 @@ typedef struct _timelib_tzdb {
 #define TIMELIB_ERROR_CORRUPT_NO_ABBREVIATION             0x04
 #define TIMELIB_ERROR_UNSUPPORTED_VERSION                 0x05
 #define TIMELIB_ERROR_NO_SUCH_TIMEZONE                    0x06
-#define TIMELIB_ERROR_SLIM_FILE                           0x07
-#define TIMELIB_ERROR_POSIX_MISSING_TTINFO                0x08
+#define TIMELIB_ERROR_SLIM_FILE                           0x07 /* Warns if the file is SLIM, but we can't read it */
+#define TIMELIB_ERROR_CORRUPT_POSIX_STRING                0x08
+#define TIMELIB_ERROR_EMPTY_POSIX_STRING                  0x09 /* Warns if the POSIX string is empty, but still produces results */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
From https://github.com/derickr/timelib/commit/f2903432bf8779f32237cc2e620e2fb0ca161ffa

Also see https://github.com/derickr/timelib/issues/112


php still have timelib version 2021.03 while this fix is part of 2021.06

Probably only affects downstream distributions using system tzdata and having old data