### PR TITLE
Add tests for FILTER_NULL_ON_FAILURE

### DIFF
--- a/ext/filter/tests/filter_null_on_failure.phpt 
+++ b/ext/filter/tests/filter_null_on_failure.phpt 
@@ -1,0 +1,33 @@
+--TEST--
+FILTER_NULL_ON_FAILURE will give NULL on filters
+--SKIPIF--
+<?php if (!extension_loaded("filter")) die("skip"); ?>
+--FILE--
+<?php
+var_dump(filter_var("invalid", FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE));
+var_dump(filter_var("invalid", FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+var_dump(filter_var("invalid", FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE));
+var_dump(filter_var("invalid", FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE));
+var_dump(filter_var(".invalid", FILTER_VALIDATE_DOMAIN, FILTER_NULL_ON_FAILURE));
+var_dump(filter_var("invalid", FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE));
+var_dump(filter_var("invalid", FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE));
+var_dump(filter_var("invalid", FILTER_VALIDATE_MAC, FILTER_NULL_ON_FAILURE));
+var_dump(filter_var("invalid", FILTER_VALIDATE_REGEXP, [
+    'flags' => FILTER_NULL_ON_FAILURE,
+    'options' => [
+        'regexp' => '/^valid$/'
+    ]
+]));
+var_dump(filter_var("invalid", FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE));
+?>
+--EXPECT--
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL
+NULL


### PR DESCRIPTION
Hey there :vulcan_salute: 

as it turns out, the `FILTER_NULL_ON_FAILURE` does not only work on `bool` filter, but on all validating filters.
This PR adds a test for this.
Documentation update is in https://github.com/php/doc-en/pull/679