### PR TITLE
Run GC twice if at least one destructor was called

### DIFF
--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -1479,7 +1479,6 @@ rerun_gc:
 			 * modify any refcounts, so we have no real way to detect this situation
 			 * short of rerunning full GC tracing. What we do instead is to only run
 			 * destructors at this point and automatically re-run GC afterwards. */
-			should_rerun_gc = 1;
 
 			/* Mark all roots for which a dtor will be invoked as DTOR_GARBAGE. Additionally
 			 * color them purple. This serves a double purpose: First, they should be
@@ -1540,6 +1539,8 @@ rerun_gc:
 						GC_ADDREF(obj);
 						obj->handlers->dtor_obj(obj);
 						GC_DELREF(obj);
+
+						should_rerun_gc = 1;
 					}
 				}
 				idx++;


### PR DESCRIPTION
Small improvement of https://github.com/php/php-src/commit/b58d74547f7700526b2d7e632032ed808abab442, I belive there are cases when `gc_flags & GC_HAS_DESTRUCTORS` condition is true, but no destructor is actually called (for example was called in previous GC cycle already). When no destructor was called, 2nd GC run is uselesss.