### PR TITLE
Enable net_get_interfaces on IBM i PASE

### DIFF
--- a/ext/standard/net.c
+++ b/ext/standard/net.c
@@ -27,6 +27,12 @@
 
 #if HAVE_GETIFADDRS
 # include <ifaddrs.h>
+#elif defined(__PASE__)
+/* IBM i implements getifaddrs, but under its own name */
+#include <as400_protos.h>
+#define getifaddrs Qp2getifaddrs
+#define freeifaddrs Qp2freeifaddrs
+#define ifaddrs ifaddrs_pase
 #endif
 
 #ifdef PHP_WIN32
@@ -96,7 +102,7 @@ PHPAPI zend_string* php_inet_ntop(const struct sockaddr *addr) {
 	return NULL;
 }
 
-#if defined(PHP_WIN32) || HAVE_GETIFADDRS
+#if defined(PHP_WIN32) || HAVE_GETIFADDRS || defined(__PASE__)
 static void iface_append_unicast(zval *unicast, zend_long flags,
                                  struct sockaddr *addr, struct sockaddr *netmask,
                                  struct sockaddr *broadcast, struct sockaddr *ptp) {
@@ -259,7 +265,7 @@ PHP_FUNCTION(net_get_interfaces) {
 	FREE(pAddresses);
 #undef MALLOC
 #undef FREE
-#elif HAVE_GETIFADDRS /* !PHP_WIN32 */
+#elif HAVE_GETIFADDRS || defined(__PASE__) /* !PHP_WIN32 */
 	struct ifaddrs *addrs = NULL, *p;
 
 	ZEND_PARSE_PARAMETERS_NONE();


### PR DESCRIPTION
On IBM i, `getifaddrs` is available renamed as `Qp2getifaddrs`; `freeifaddrs` and `struct ifaddr` follow a similar fate. I assume this is in case AIX decides to add it (as if). As such, just use the same implementation, but rename the standard ones to the IBM i definitions and include its header.

On PHP 7.x, an ifdef to `basic_functions.c` is also needed, otherwise the function will not be registered. Technically, the fact PHP 8 always registers this function is a bug, but hasn't been caught, it seems.