### PR TITLE
Reorganize zend_test and add custom fiber implementation tests

### DIFF
--- a/ext/zend_test/config.m4
+++ b/ext/zend_test/config.m4
@@ -4,5 +4,5 @@ PHP_ARG_ENABLE([zend-test],
     [Enable zend_test extension])])
 
 if test "$PHP_ZEND_TEST" != "no"; then
-  PHP_NEW_EXTENSION(zend_test, test.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+  PHP_NEW_EXTENSION(zend_test, test.c fiber.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 fi

--- a/ext/zend_test/config.m4
+++ b/ext/zend_test/config.m4
@@ -4,5 +4,5 @@ PHP_ARG_ENABLE([zend-test],
     [Enable zend_test extension])])
 
 if test "$PHP_ZEND_TEST" != "no"; then
-  PHP_NEW_EXTENSION(zend_test, test.c fiber.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+  PHP_NEW_EXTENSION(zend_test, test.c observer.c fiber.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 fi

--- a/ext/zend_test/config.w32
+++ b/ext/zend_test/config.w32
@@ -3,6 +3,6 @@
 ARG_ENABLE("zend-test", "enable zend_test extension", "no");
 
 if (PHP_ZEND_TEST != "no") {
-	EXTENSION("zend_test", "test.c fiber.c", PHP_ZEND_TEST_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	EXTENSION("zend_test", "test.c observer.c fiber.c", PHP_ZEND_TEST_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 	ADD_FLAG("CFLAGS_ZEND_TEST", "/D PHP_ZEND_TEST_EXPORTS ");
 }

--- a/ext/zend_test/config.w32
+++ b/ext/zend_test/config.w32
@@ -3,6 +3,6 @@
 ARG_ENABLE("zend-test", "enable zend_test extension", "no");
 
 if (PHP_ZEND_TEST != "no") {
-	EXTENSION("zend_test", "test.c", PHP_ZEND_TEST_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	EXTENSION("zend_test", "test.c fiber.c", PHP_ZEND_TEST_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 	ADD_FLAG("CFLAGS_ZEND_TEST", "/D PHP_ZEND_TEST_EXPORTS ");
 }

--- a/ext/zend_test/fiber.c
+++ b/ext/zend_test/fiber.c
@@ -1,0 +1,298 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) The PHP Group                                          |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://www.php.net/license/3_01.txt                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Aaron Piotrowski <aaron@trowski.com>                         |
+  +----------------------------------------------------------------------+
+*/
+
+#include "php_test.h"
+#include "fiber.h"
+#include "fiber_arginfo.h"
+#include "zend_fibers.h"
+#include "zend_exceptions.h"
+
+static zend_class_entry *zend_test_fiber_class;
+static zend_object_handlers zend_test_fiber_handlers;
+
+static zend_always_inline zend_fiber_context *zend_test_fiber_get_context(zend_test_fiber *fiber)
+{
+	return (zend_fiber_context *) &fiber->handle;
+}
+
+static zend_fiber_transfer zend_test_fiber_switch_to(zend_fiber_context *context, zval *value, bool exception)
+{
+	zend_fiber_transfer transfer = {
+			.context = context,
+			.flags = exception ? ZEND_FIBER_TRANSFER_FLAG_ERROR : 0,
+	};
+
+	if (value) {
+		ZVAL_COPY(&transfer.value, value);
+	} else {
+		ZVAL_NULL(&transfer.value);
+	}
+
+	zend_fiber_switch_context(&transfer);
+
+	return transfer;
+}
+
+static zend_fiber_transfer zend_test_fiber_resume(zend_test_fiber *fiber, zval *value, bool exception)
+{
+	zend_test_fiber *previous = ZT_G(active_fiber);
+
+	fiber->caller = EG(current_fiber_context);
+	ZT_G(active_fiber) = fiber;
+
+	zend_fiber_transfer transfer = zend_test_fiber_switch_to(fiber->previous, value, exception);
+
+	ZT_G(active_fiber) = previous;
+
+	return transfer;
+}
+
+static zend_fiber_transfer zend_test_fiber_suspend(zend_test_fiber *fiber, zval *value)
+{
+	ZEND_ASSERT(fiber->caller != NULL);
+
+	zend_fiber_context *caller = fiber->caller;
+	fiber->previous = EG(current_fiber_context);
+	fiber->caller = NULL;
+
+	return zend_test_fiber_switch_to(caller, value, false);
+}
+
+static ZEND_STACK_ALIGNED void zend_test_fiber_execute(zend_fiber_transfer *transfer)
+{
+	zend_test_fiber *fiber = ZT_G(active_fiber);
+
+	zend_execute_data *execute_data;
+
+	EG(vm_stack) = NULL;
+
+	zend_first_try {
+		zend_vm_stack stack = zend_vm_stack_new_page(ZEND_FIBER_VM_STACK_SIZE, NULL);
+		EG(vm_stack) = stack;
+		EG(vm_stack_top) = stack->top + ZEND_CALL_FRAME_SLOT;
+		EG(vm_stack_end) = stack->end;
+		EG(vm_stack_page_size) = ZEND_FIBER_VM_STACK_SIZE;
+
+		execute_data = (zend_execute_data *) stack->top;
+
+		memset(execute_data, 0, sizeof(zend_execute_data));
+
+		EG(current_execute_data) = execute_data;
+		EG(jit_trace_num) = 0;
+
+		fiber->fci.retval = &fiber->result;
+
+		zend_call_function(&fiber->fci, &fiber->fci_cache);
+
+		zval_ptr_dtor(&fiber->fci.function_name);
+
+		if (EG(exception)) {
+			if (!(fiber->flags & ZEND_FIBER_FLAG_DESTROYED)
+				|| !(zend_is_graceful_exit(EG(exception)) || zend_is_unwind_exit(EG(exception)))
+			) {
+				fiber->flags |= ZEND_FIBER_FLAG_THREW;
+				transfer->flags = ZEND_FIBER_TRANSFER_FLAG_ERROR;
+
+				ZVAL_OBJ_COPY(&transfer->value, EG(exception));
+			}
+
+			zend_clear_exception();
+		} else {
+			ZVAL_COPY(&transfer->value, &fiber->result);
+		}
+	} zend_catch {
+		fiber->flags |= ZEND_FIBER_FLAG_BAILOUT;
+	} zend_end_try();
+
+	transfer->context = fiber->caller;
+
+	zend_vm_stack_destroy();
+	fiber->caller = NULL;
+}
+
+static zend_object *zend_test_fiber_object_create(zend_class_entry *ce)
+{
+	zend_fiber *fiber;
+
+	fiber = emalloc(sizeof(zend_test_fiber));
+	memset(fiber, 0, sizeof(zend_test_fiber));
+
+	zend_object_std_init(&fiber->std, ce);
+	fiber->std.handlers = &zend_test_fiber_handlers;
+
+	return &fiber->std;
+}
+
+static void zend_test_fiber_object_destroy(zend_object *object)
+{
+	zend_test_fiber *fiber = (zend_test_fiber *) object;
+
+	if (fiber->status != ZEND_FIBER_STATUS_SUSPENDED) {
+		return;
+	}
+
+	zend_object *exception = EG(exception);
+	EG(exception) = NULL;
+
+	fiber->flags |= ZEND_FIBER_FLAG_DESTROYED;
+
+	zend_fiber_transfer transfer = zend_test_fiber_resume(fiber, NULL, false);
+
+	if (transfer.flags & ZEND_FIBER_TRANSFER_FLAG_ERROR) {
+		EG(exception) = Z_OBJ(transfer.value);
+
+		if (!exception && EG(current_execute_data) && EG(current_execute_data)->func
+			&& ZEND_USER_CODE(EG(current_execute_data)->func->common.type)) {
+			zend_rethrow_exception(EG(current_execute_data));
+		}
+
+		zend_exception_set_previous(EG(exception), exception);
+
+		if (!EG(current_execute_data)) {
+			zend_exception_error(EG(exception), E_ERROR);
+		}
+	} else {
+		zval_ptr_dtor(&transfer.value);
+		EG(exception) = exception;
+	}
+}
+
+static void zend_test_fiber_object_free(zend_object *object)
+{
+	zend_test_fiber *fiber = (zend_test_fiber *) object;
+
+	if (fiber->status == ZEND_FIBER_STATUS_INIT) {
+		// Fiber was never started, so we need to release the reference to the callback.
+		zval_ptr_dtor(&fiber->fci.function_name);
+	}
+
+	zval_ptr_dtor(&fiber->result);
+
+	zend_object_std_dtor(&fiber->std);
+}
+
+static zend_always_inline void delegate_transfer_result(
+	zend_test_fiber *fiber, zend_fiber_transfer *transfer, INTERNAL_FUNCTION_PARAMETERS
+) {
+	if (transfer->flags & ZEND_FIBER_TRANSFER_FLAG_ERROR) {
+		zend_throw_exception_internal(Z_OBJ(transfer->value));
+		RETURN_THROWS();
+	}
+
+	if (fiber->status == ZEND_FIBER_STATUS_DEAD) {
+		zval_ptr_dtor(&transfer->value);
+		RETURN_NULL();
+	}
+
+	RETURN_COPY_VALUE(&transfer->value);
+}
+
+static ZEND_METHOD(_ZendTestFiber, __construct)
+{
+	zend_test_fiber *fiber = (zend_test_fiber *) Z_OBJ_P(getThis());
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_FUNC(fiber->fci, fiber->fci_cache)
+	ZEND_PARSE_PARAMETERS_END();
+
+	// Keep a reference to closures or callable objects while the fiber is running.
+	Z_TRY_ADDREF(fiber->fci.function_name);
+}
+
+static ZEND_METHOD(_ZendTestFiber, start)
+{
+	zend_test_fiber *fiber = (zend_test_fiber *) Z_OBJ_P(getThis());
+	zval *params;
+	uint32_t param_count;
+	zend_array *named_params;
+
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC_WITH_NAMED(params, param_count, named_params);
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZEND_ASSERT(fiber->status == ZEND_FIBER_STATUS_INIT);
+
+	fiber->fci.params = params;
+	fiber->fci.param_count = param_count;
+	fiber->fci.named_params = named_params;
+
+	zend_fiber_context *context = zend_test_fiber_get_context(fiber);
+
+	zend_fiber_init_context(context, zend_test_fiber_class, zend_test_fiber_execute, EG(fiber_stack_size));
+
+	fiber->previous = context;
+
+	zend_fiber_transfer transfer = zend_test_fiber_resume(fiber, NULL, false);
+
+	delegate_transfer_result(fiber, &transfer, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+static ZEND_METHOD(_ZendTestFiber, suspend)
+{
+	zval *value = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(value);
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_test_fiber *fiber = ZT_G(active_fiber);
+
+	ZEND_ASSERT(fiber);
+
+	zend_fiber_transfer transfer = zend_test_fiber_suspend(fiber, value);
+
+	if (fiber->flags & ZEND_FIBER_FLAG_DESTROYED) {
+		// This occurs when the test fiber is GC'ed while suspended.
+		zval_ptr_dtor(&transfer.value);
+		zend_throw_graceful_exit();
+		RETURN_THROWS();
+	}
+
+	delegate_transfer_result(fiber, &transfer, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+static ZEND_METHOD(_ZendTestFiber, resume)
+{
+	zend_test_fiber *fiber;
+	zval *value = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(value);
+	ZEND_PARSE_PARAMETERS_END();
+
+	fiber = (zend_test_fiber *) Z_OBJ_P(getThis());
+
+	if (UNEXPECTED(fiber->status != ZEND_FIBER_STATUS_SUSPENDED || fiber->caller != NULL)) {
+		zend_throw_error(NULL, "Cannot resume a fiber that is not suspended");
+		RETURN_THROWS();
+	}
+
+	zend_fiber_transfer transfer = zend_test_fiber_resume(fiber, value, false);
+
+	delegate_transfer_result(fiber, &transfer, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+void zend_test_fiber_init(void)
+{
+	zend_test_fiber_class = register_class__ZendTestFiber();
+	zend_test_fiber_class->create_object = zend_test_fiber_object_create;
+
+	zend_test_fiber_handlers = std_object_handlers;
+	zend_test_fiber_handlers.dtor_obj = zend_test_fiber_object_destroy;
+	zend_test_fiber_handlers.free_obj = zend_test_fiber_object_free;
+}

--- a/ext/zend_test/fiber.c
+++ b/ext/zend_test/fiber.c
@@ -125,7 +125,7 @@ static ZEND_STACK_ALIGNED void zend_test_fiber_execute(zend_fiber_transfer *tran
 
 static zend_object *zend_test_fiber_object_create(zend_class_entry *ce)
 {
-	zend_fiber *fiber;
+	zend_test_fiber *fiber;
 
 	fiber = emalloc(sizeof(zend_test_fiber));
 	memset(fiber, 0, sizeof(zend_test_fiber));

--- a/ext/zend_test/fiber.h
+++ b/ext/zend_test/fiber.h
@@ -1,0 +1,34 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) The PHP Group                                          |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://www.php.net/license/3_01.txt                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Aaron Piotrowski <aaron@trowski.com>                        |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef ZEND_TEST_FIBER_H
+#define ZEND_TEST_FIBER_H
+
+#include "zend_fibers.h"
+
+typedef struct _zend_test_fiber {
+	zend_object std;
+	ZEND_FIBER_CONTEXT_FIELDS;
+	zend_fiber_context *caller;
+	zend_fiber_context *previous;
+	zend_fcall_info fci;
+	zend_fcall_info_cache fci_cache;
+	zval result;
+} zend_test_fiber;
+
+void zend_test_fiber_init(void);
+
+#endif

--- a/ext/zend_test/fiber.stub.php
+++ b/ext/zend_test/fiber.stub.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @generate-class-entries static */
+
+final class _ZendTestFiber
+{
+    public function __construct(callable $callback) {}
+
+    public function start(mixed ...$args): mixed {}
+
+    public function resume(mixed $value = null): mixed {}
+
+    public static function suspend(mixed $value = null): mixed {}
+}

--- a/ext/zend_test/fiber_arginfo.h
+++ b/ext/zend_test/fiber_arginfo.h
@@ -1,0 +1,42 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 12481d4bfa2981f886a2efabc82c29cfaf14b2f0 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class__ZendTestFiber___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestFiber_start, 0, 0, IS_MIXED, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, args, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestFiber_resume, 0, 0, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_MIXED, 0, "null")
+ZEND_END_ARG_INFO()
+
+#define arginfo_class__ZendTestFiber_suspend arginfo_class__ZendTestFiber_resume
+
+
+static ZEND_METHOD(_ZendTestFiber, __construct);
+static ZEND_METHOD(_ZendTestFiber, start);
+static ZEND_METHOD(_ZendTestFiber, resume);
+static ZEND_METHOD(_ZendTestFiber, suspend);
+
+
+static const zend_function_entry class__ZendTestFiber_methods[] = {
+	ZEND_ME(_ZendTestFiber, __construct, arginfo_class__ZendTestFiber___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(_ZendTestFiber, start, arginfo_class__ZendTestFiber_start, ZEND_ACC_PUBLIC)
+	ZEND_ME(_ZendTestFiber, resume, arginfo_class__ZendTestFiber_resume, ZEND_ACC_PUBLIC)
+	ZEND_ME(_ZendTestFiber, suspend, arginfo_class__ZendTestFiber_suspend, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class__ZendTestFiber(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "_ZendTestFiber", class__ZendTestFiber_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	return class_entry;
+}

--- a/ext/zend_test/observer.c
+++ b/ext/zend_test/observer.c
@@ -1,0 +1,281 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) The PHP Group                                          |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://www.php.net/license/3_01.txt                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author:                                                              |
+  +----------------------------------------------------------------------+
+*/
+
+#include "php.h"
+#include "php_test.h"
+#include "observer.h"
+#include "zend_observer.h"
+#include "zend_smart_str.h"
+#include "ext/standard/php_var.h"
+
+static zend_observer_fcall_handlers observer_fcall_init(zend_execute_data *execute_data);
+
+static int observer_show_opcode_in_user_handler(zend_execute_data *execute_data)
+{
+	if (ZT_G(observer_show_output)) {
+		php_printf("%*s<!-- opcode: '%s' in user handler -->\n", 2 * ZT_G(observer_nesting_depth), "", zend_get_opcode_name(EX(opline)->opcode));
+	}
+
+	return ZEND_USER_OPCODE_DISPATCH;
+}
+
+static void observer_set_user_opcode_handler(const char *opcode_names, user_opcode_handler_t handler)
+{
+	const char *s = NULL, *e = opcode_names;
+
+	while (1) {
+		if (*e == ' ' || *e == ',' || *e == '\0') {
+			if (s) {
+				zend_uchar opcode = zend_get_opcode_id(s, e - s);
+				if (opcode <= ZEND_VM_LAST_OPCODE) {
+					zend_set_user_opcode_handler(opcode, handler);
+				} else {
+					zend_error(E_WARNING, "Invalid opcode name %.*s", (int) (e - s), e);
+				}
+				s = NULL;
+			}
+		} else {
+			if (!s) {
+				s = e;
+			}
+		}
+		if (*e == '\0') {
+			break;
+		}
+		e++;
+	}
+}
+
+static void observer_show_opcode(zend_execute_data *execute_data)
+{
+	if (!ZT_G(observer_show_opcode)) {
+		return;
+	}
+	php_printf("%*s<!-- opcode: '%s' -->\n", 2 * ZT_G(observer_nesting_depth), "", zend_get_opcode_name(EX(opline)->opcode));
+}
+
+static void observer_begin(zend_execute_data *execute_data)
+{
+	if (!ZT_G(observer_show_output)) {
+		return;
+	}
+
+	if (execute_data->func && execute_data->func->common.function_name) {
+		if (execute_data->func->common.scope) {
+			php_printf("%*s<%s::%s>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->common.scope->name), ZSTR_VAL(execute_data->func->common.function_name));
+		} else {
+			php_printf("%*s<%s>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->common.function_name));
+		}
+	} else {
+		php_printf("%*s<file '%s'>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->op_array.filename));
+	}
+	ZT_G(observer_nesting_depth)++;
+	observer_show_opcode(execute_data);
+}
+
+static void get_retval_info(zval *retval, smart_str *buf)
+{
+	if (!ZT_G(observer_show_return_type) && !ZT_G(observer_show_return_value)) {
+		return;
+	}
+
+	smart_str_appendc(buf, ':');
+	if (retval == NULL) {
+		smart_str_appendl(buf, "NULL", 4);
+	} else if (ZT_G(observer_show_return_value)) {
+		if (Z_TYPE_P(retval) == IS_OBJECT) {
+			smart_str_appendl(buf, "object(", 7);
+			smart_str_append(buf, Z_OBJCE_P(retval)->name);
+			smart_str_appendl(buf, ")#", 2);
+			smart_str_append_long(buf, Z_OBJ_HANDLE_P(retval));
+		} else {
+			php_var_export_ex(retval, 2 * ZT_G(observer_nesting_depth) + 3, buf);
+		}
+	} else if (ZT_G(observer_show_return_type)) {
+		smart_str_appends(buf, zend_zval_type_name(retval));
+	}
+	smart_str_0(buf);
+}
+
+static void observer_end(zend_execute_data *execute_data, zval *retval)
+{
+	if (!ZT_G(observer_show_output)) {
+		return;
+	}
+
+	if (EG(exception)) {
+		php_printf("%*s<!-- Exception: %s -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(EG(exception)->ce->name));
+	}
+	observer_show_opcode(execute_data);
+	ZT_G(observer_nesting_depth)--;
+	if (execute_data->func && execute_data->func->common.function_name) {
+		smart_str retval_info = {0};
+		get_retval_info(retval, &retval_info);
+		if (execute_data->func->common.scope) {
+			php_printf("%*s</%s::%s%s>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->common.scope->name), ZSTR_VAL(execute_data->func->common.function_name), retval_info.s ? ZSTR_VAL(retval_info.s) : "");
+		} else {
+			php_printf("%*s</%s%s>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->common.function_name), retval_info.s ? ZSTR_VAL(retval_info.s) : "");
+		}
+		smart_str_free(&retval_info);
+	} else {
+		php_printf("%*s</file '%s'>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->op_array.filename));
+	}
+}
+
+static void observer_show_init(zend_function *fbc)
+{
+	if (fbc->common.function_name) {
+		if (fbc->common.scope) {
+			php_printf("%*s<!-- init %s::%s() -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
+		} else {
+			php_printf("%*s<!-- init %s() -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->common.function_name));
+		}
+	} else {
+		php_printf("%*s<!-- init '%s' -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->op_array.filename));
+	}
+}
+
+static void observer_show_init_backtrace(zend_execute_data *execute_data)
+{
+	zend_execute_data *ex = execute_data;
+	php_printf("%*s<!--\n", 2 * ZT_G(observer_nesting_depth), "");
+	do {
+		zend_function *fbc = ex->func;
+		int indent = 2 * ZT_G(observer_nesting_depth) + 4;
+		if (fbc->common.function_name) {
+			if (fbc->common.scope) {
+				php_printf("%*s%s::%s()\n", indent, "", ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
+			} else {
+				php_printf("%*s%s()\n", indent, "", ZSTR_VAL(fbc->common.function_name));
+			}
+		} else {
+			php_printf("%*s{main} %s\n", indent, "", ZSTR_VAL(fbc->op_array.filename));
+		}
+	} while ((ex = ex->prev_execute_data) != NULL);
+	php_printf("%*s-->\n", 2 * ZT_G(observer_nesting_depth), "");
+}
+
+static zend_observer_fcall_handlers observer_fcall_init(zend_execute_data *execute_data)
+{
+	zend_function *fbc = execute_data->func;
+	if (ZT_G(observer_show_output)) {
+		observer_show_init(fbc);
+		if (ZT_G(observer_show_init_backtrace)) {
+			observer_show_init_backtrace(execute_data);
+		}
+		observer_show_opcode(execute_data);
+	}
+
+	if (ZT_G(observer_observe_all)) {
+		return (zend_observer_fcall_handlers){observer_begin, observer_end};
+	} else if (ZT_G(observer_observe_includes) && !fbc->common.function_name) {
+		return (zend_observer_fcall_handlers){observer_begin, observer_end};
+	} else if (ZT_G(observer_observe_functions) && fbc->common.function_name) {
+		return (zend_observer_fcall_handlers){observer_begin, observer_end};
+	}
+	return (zend_observer_fcall_handlers){NULL, NULL};
+}
+
+static void fiber_address_observer(zend_fiber_context *from, zend_fiber_context *to)
+{
+	if (ZT_G(observer_fiber_switch)) {
+		php_printf("<!-- switching from fiber %p to %p -->\n", from, to);
+	}
+}
+
+static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *to)
+{
+	if (ZT_G(observer_fiber_switch)) {
+		if (to->status == ZEND_FIBER_STATUS_INIT) {
+			php_printf("<init '%p'>\n", to);
+		} else if (to->kind == zend_ce_fiber) {
+			zend_fiber *fiber = zend_fiber_from_context(to);
+			if (fiber->caller != from) {
+				return;
+			}
+
+			if (to->flags & ZEND_FIBER_FLAG_DESTROYED) {
+				php_printf("<destroying '%p'>\n", to);
+			} else if (to->status != ZEND_FIBER_STATUS_DEAD) {
+				php_printf("<resume '%p'>\n", to);
+			}
+		}
+	}
+}
+
+static void fiber_suspend_observer(zend_fiber_context *from, zend_fiber_context *to)
+{
+	if (ZT_G(observer_fiber_switch)) {
+		if (from->status == ZEND_FIBER_STATUS_DEAD) {
+			if (from->flags & ZEND_FIBER_FLAG_THREW) {
+				php_printf("<threw '%p'>\n", from);
+			} else if (from->flags & ZEND_FIBER_FLAG_DESTROYED) {
+				php_printf("<destroyed '%p'>\n", from);
+			} else {
+				php_printf("<returned '%p'>\n", from);
+			}
+		} else if (from->kind == zend_ce_fiber) {
+			zend_fiber *fiber = zend_fiber_from_context(from);
+			if (fiber->caller == NULL) {
+				php_printf("<suspend '%p'>\n", from);
+			}
+		}
+	}
+}
+
+PHP_INI_BEGIN()
+	STD_PHP_INI_BOOLEAN("zend_test.observer.enabled", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_enabled, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.show_output", "1", PHP_INI_SYSTEM, OnUpdateBool, observer_show_output, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.observe_all", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_observe_all, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.observe_includes", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_observe_includes, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.observe_functions", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_observe_functions, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.show_return_type", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_return_type, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.show_return_value", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_return_value, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.show_init_backtrace", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_init_backtrace, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.show_opcode", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_opcode, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_ENTRY("zend_test.observer.show_opcode_in_user_handler", "", PHP_INI_SYSTEM, OnUpdateString, observer_show_opcode_in_user_handler, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.fiber_switch", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_fiber_switch, zend_zend_test_globals, zend_test_globals)
+PHP_INI_END()
+
+void zend_test_observer_init(INIT_FUNC_ARGS)
+{
+	// Loading via dl() not supported with the observer API
+	if (type != MODULE_TEMPORARY) {
+		REGISTER_INI_ENTRIES();
+		if (ZT_G(observer_enabled)) {
+			zend_observer_fcall_register(observer_fcall_init);
+		}
+	} else {
+		(void)ini_entries;
+	}
+
+	if (ZT_G(observer_enabled) && ZT_G(observer_show_opcode_in_user_handler)) {
+		observer_set_user_opcode_handler(ZT_G(observer_show_opcode_in_user_handler), observer_show_opcode_in_user_handler);
+	}
+
+	if (ZT_G(observer_enabled)) {
+		zend_observer_fiber_switch_register(fiber_address_observer);
+		zend_observer_fiber_switch_register(fiber_enter_observer);
+		zend_observer_fiber_switch_register(fiber_suspend_observer);
+	}
+}
+
+void zend_test_observer_shutdown(SHUTDOWN_FUNC_ARGS)
+{
+	if (type != MODULE_TEMPORARY) {
+		UNREGISTER_INI_ENTRIES();
+	}
+}

--- a/ext/zend_test/observer.h
+++ b/ext/zend_test/observer.h
@@ -1,0 +1,23 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) The PHP Group                                          |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://www.php.net/license/3_01.txt                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author:                                                              |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef ZEND_TEST_OBSERVER_H
+#define ZEND_TEST_OBSERVER_H
+
+void zend_test_observer_init(INIT_FUNC_ARGS);
+void zend_test_observer_shutdown(SHUTDOWN_FUNC_ARGS);
+
+#endif

--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -17,6 +17,8 @@
 #ifndef PHP_TEST_H
 #define PHP_TEST_H
 
+#include "fiber.h"
+
 extern zend_module_entry zend_test_module_entry;
 #define phpext_zend_test_ptr &zend_test_module_entry
 
@@ -29,6 +31,28 @@ extern zend_module_entry zend_test_module_entry;
 #if defined(ZTS) && defined(COMPILE_DL_ZEND_TEST)
 ZEND_TSRMLS_CACHE_EXTERN()
 #endif
+
+ZEND_BEGIN_MODULE_GLOBALS(zend_test)
+	int observer_enabled;
+	int observer_show_output;
+	int observer_observe_all;
+	int observer_observe_includes;
+	int observer_observe_functions;
+	int observer_show_return_type;
+	int observer_show_return_value;
+	int observer_show_init_backtrace;
+	int observer_show_opcode;
+	char *observer_show_opcode_in_user_handler;
+	int observer_nesting_depth;
+	int observer_fiber_switch;
+	int replace_zend_execute_ex;
+	int register_passes;
+	zend_test_fiber *active_fiber;
+ZEND_END_MODULE_GLOBALS(zend_test)
+
+extern ZEND_DECLARE_MODULE_GLOBALS(zend_test)
+
+#define ZT_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(zend_test, v)
 
 struct bug79096 {
 	uint64_t a;

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -24,32 +24,13 @@
 #include "ext/standard/php_var.h"
 #include "php_test.h"
 #include "test_arginfo.h"
+#include "fiber.h"
 #include "zend_attributes.h"
 #include "zend_observer.h"
 #include "zend_smart_str.h"
-#include "zend_fibers.h"
 #include "Zend/Optimizer/zend_optimizer.h"
 
-ZEND_BEGIN_MODULE_GLOBALS(zend_test)
-	int observer_enabled;
-	int observer_show_output;
-	int observer_observe_all;
-	int observer_observe_includes;
-	int observer_observe_functions;
-	int observer_show_return_type;
-	int observer_show_return_value;
-	int observer_show_init_backtrace;
-	int observer_show_opcode;
-	char *observer_show_opcode_in_user_handler;
-	int observer_nesting_depth;
-	int observer_fiber_switch;
-	int replace_zend_execute_ex;
-	int register_passes;
-ZEND_END_MODULE_GLOBALS(zend_test)
-
 ZEND_DECLARE_MODULE_GLOBALS(zend_test)
-
-#define ZT_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(zend_test, v)
 
 static zend_class_entry *zend_test_interface;
 static zend_class_entry *zend_test_class;
@@ -528,6 +509,8 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_optimizer_register_pass(pass1);
 		zend_optimizer_register_pass(pass2);
 	}
+
+	zend_test_fiber_init();
 
 	return SUCCESS;
 }

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -15,7 +15,7 @@
 */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+# include "config.h"
 #endif
 
 #include "php.h"
@@ -114,7 +114,7 @@ static ZEND_FUNCTION(zend_terminate_string)
 	ZSTR_VAL(str)[ZSTR_LEN(str)] = '\0';
 }
 
-/* {{{ Cause an intentional memory leak, for testing/debugging purposes */
+/* Cause an intentional memory leak, for testing/debugging purposes */
 static ZEND_FUNCTION(zend_leak_bytes)
 {
 	zend_long leakbytes = 3;
@@ -125,9 +125,8 @@ static ZEND_FUNCTION(zend_leak_bytes)
 
 	emalloc(leakbytes);
 }
-/* }}} */
 
-/* {{{ Leak a refcounted variable */
+/* Leak a refcounted variable */
 static ZEND_FUNCTION(zend_leak_variable)
 {
 	zval *zv;
@@ -143,7 +142,6 @@ static ZEND_FUNCTION(zend_leak_variable)
 
 	Z_ADDREF_P(zv);
 }
-/* }}} */
 
 /* Tests Z_PARAM_OBJ_OR_STR */
 static ZEND_FUNCTION(zend_string_or_object)
@@ -161,7 +159,6 @@ static ZEND_FUNCTION(zend_string_or_object)
 		RETURN_OBJ_COPY(object);
 	}
 }
-/* }}} */
 
 /* Tests Z_PARAM_OBJ_OR_STR_OR_NULL */
 static ZEND_FUNCTION(zend_string_or_object_or_null)
@@ -181,7 +178,6 @@ static ZEND_FUNCTION(zend_string_or_object_or_null)
 		RETURN_NULL();
 	}
 }
-/* }}} */
 
 /* Tests Z_PARAM_OBJ_OF_CLASS_OR_STR */
 static ZEND_FUNCTION(zend_string_or_stdclass)
@@ -199,7 +195,6 @@ static ZEND_FUNCTION(zend_string_or_stdclass)
 		RETURN_OBJ_COPY(object);
 	}
 }
-/* }}} */
 
 /* Tests Z_PARAM_OBJ_OF_CLASS_OR_STR_OR_NULL */
 static ZEND_FUNCTION(zend_string_or_stdclass_or_null)
@@ -219,7 +214,6 @@ static ZEND_FUNCTION(zend_string_or_stdclass_or_null)
 		RETURN_NULL();
 	}
 }
-/* }}} */
 
 /* TESTS Z_PARAM_ITERABLE and Z_PARAM_ITERABLE_OR_NULL */
 static ZEND_FUNCTION(zend_iterable)
@@ -239,15 +233,16 @@ static ZEND_FUNCTION(namespaced_func)
 	RETURN_TRUE;
 }
 
-static zend_object *zend_test_class_new(zend_class_entry *class_type) /* {{{ */ {
+static zend_object *zend_test_class_new(zend_class_entry *class_type)
+{
 	zend_object *obj = zend_objects_new(class_type);
 	object_properties_init(obj, class_type);
 	obj->handlers = &zend_test_class_handlers;
 	return obj;
 }
-/* }}} */
 
-static zend_function *zend_test_class_method_get(zend_object **object, zend_string *name, const zval *key) /* {{{ */ {
+static zend_function *zend_test_class_method_get(zend_object **object, zend_string *name, const zval *key)
+{
     if (zend_string_equals_literal_ci(name, "test")) {
 	    zend_internal_function *fptr;
 
@@ -268,9 +263,9 @@ static zend_function *zend_test_class_method_get(zend_object **object, zend_stri
     }
 	return zend_std_get_method(object, name, key);
 }
-/* }}} */
 
-static zend_function *zend_test_class_static_method_get(zend_class_entry *ce, zend_string *name) /* {{{ */ {
+static zend_function *zend_test_class_static_method_get(zend_class_entry *ce, zend_string *name)
+{
 	if (zend_string_equals_literal_ci(name, "test")) {
 		zend_internal_function *fptr;
 
@@ -291,7 +286,6 @@ static zend_function *zend_test_class_static_method_get(zend_class_entry *ce, ze
 	}
 	return zend_std_get_static_method(ce, name, NULL);
 }
-/* }}} */
 
 void zend_attribute_validate_zendtestattribute(zend_attribute *attr, uint32_t target, zend_class_entry *scope)
 {
@@ -300,13 +294,15 @@ void zend_attribute_validate_zendtestattribute(zend_attribute *attr, uint32_t ta
 	}
 }
 
-static ZEND_METHOD(_ZendTestClass, __toString) {
+static ZEND_METHOD(_ZendTestClass, __toString)
+{
 	ZEND_PARSE_PARAMETERS_NONE();
 	RETURN_EMPTY_STRING();
 }
 
 /* Internal function returns bool, we return int. */
-static ZEND_METHOD(_ZendTestClass, is_object) {
+static ZEND_METHOD(_ZendTestClass, is_object)
+{
 	ZEND_PARSE_PARAMETERS_NONE();
 	RETURN_LONG(42);
 }
@@ -316,30 +312,36 @@ static ZEND_METHOD(_ZendTestClass, returnsStatic) {
 	object_init_ex(return_value, zend_get_called_scope(execute_data));
 }
 
-static ZEND_METHOD(_ZendTestClass, returnsThrowable) {
+static ZEND_METHOD(_ZendTestClass, returnsThrowable)
+{
 	ZEND_PARSE_PARAMETERS_NONE();
 	zend_throw_error(NULL, "Dummy");
 }
 
-static ZEND_METHOD(_ZendTestChildClass, returnsThrowable) {
+static ZEND_METHOD(_ZendTestChildClass, returnsThrowable)
+{
 	ZEND_PARSE_PARAMETERS_NONE();
 	zend_throw_error(NULL, "Dummy");
 }
 
-static ZEND_METHOD(_ZendTestTrait, testMethod) {
+static ZEND_METHOD(_ZendTestTrait, testMethod)
+{
 	ZEND_PARSE_PARAMETERS_NONE();
 	RETURN_TRUE;
 }
 
-static ZEND_METHOD(ZendTestNS_Foo, method) {
+static ZEND_METHOD(ZendTestNS_Foo, method)
+{
 	ZEND_PARSE_PARAMETERS_NONE();
 }
 
-static ZEND_METHOD(ZendTestNS2_Foo, method) {
+static ZEND_METHOD(ZendTestNS2_Foo, method)
+{
 	ZEND_PARSE_PARAMETERS_NONE();
 }
 
-static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method) {
+static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method)
+{
 	ZEND_PARSE_PARAMETERS_NONE();
 }
 
@@ -461,9 +463,9 @@ zend_module_entry zend_test_module_entry = {
 };
 
 #ifdef COMPILE_DL_ZEND_TEST
-#ifdef ZTS
+# ifdef ZTS
 ZEND_TSRMLS_CACHE_DEFINE()
-#endif
+# endif
 ZEND_GET_MODULE(zend_test)
 #endif
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -21,13 +21,11 @@
 #include "php.h"
 #include "php_ini.h"
 #include "ext/standard/info.h"
-#include "ext/standard/php_var.h"
 #include "php_test.h"
 #include "test_arginfo.h"
+#include "observer.h"
 #include "fiber.h"
 #include "zend_attributes.h"
-#include "zend_observer.h"
-#include "zend_smart_str.h"
 #include "Zend/Optimizer/zend_optimizer.h"
 
 ZEND_DECLARE_MODULE_GLOBALS(zend_test)
@@ -346,110 +344,14 @@ static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method) {
 }
 
 PHP_INI_BEGIN()
-	STD_PHP_INI_BOOLEAN("zend_test.observer.enabled", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_enabled, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.show_output", "1", PHP_INI_SYSTEM, OnUpdateBool, observer_show_output, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.observe_all", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_observe_all, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.observe_includes", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_observe_includes, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.observe_functions", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_observe_functions, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.show_return_type", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_return_type, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.show_return_value", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_return_value, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.show_init_backtrace", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_init_backtrace, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.show_opcode", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_show_opcode, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_ENTRY("zend_test.observer.show_opcode_in_user_handler", "", PHP_INI_SYSTEM, OnUpdateString, observer_show_opcode_in_user_handler, zend_zend_test_globals, zend_test_globals)
-	STD_PHP_INI_BOOLEAN("zend_test.observer.fiber_switch", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_fiber_switch, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.replace_zend_execute_ex", "0", PHP_INI_SYSTEM, OnUpdateBool, replace_zend_execute_ex, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.register_passes", "0", PHP_INI_SYSTEM, OnUpdateBool, register_passes, zend_zend_test_globals, zend_test_globals)
 PHP_INI_END()
-
-static zend_observer_fcall_handlers observer_fcall_init(zend_execute_data *execute_data);
 
 void (*old_zend_execute_ex)(zend_execute_data *execute_data);
 static void custom_zend_execute_ex(zend_execute_data *execute_data)
 {
 	old_zend_execute_ex(execute_data);
-}
-
-static int observer_show_opcode_in_user_handler(zend_execute_data *execute_data)
-{
-	if (ZT_G(observer_show_output)) {
-		php_printf("%*s<!-- opcode: '%s' in user handler -->\n", 2 * ZT_G(observer_nesting_depth), "", zend_get_opcode_name(EX(opline)->opcode));
-	}
-
-	return ZEND_USER_OPCODE_DISPATCH;
-}
-
-static void observer_set_user_opcode_handler(const char *opcode_names, user_opcode_handler_t handler)
-{
-	const char *s = NULL, *e = opcode_names;
-
-	while (1) {
-		if (*e == ' ' || *e == ',' || *e == '\0') {
-			if (s) {
-				zend_uchar opcode = zend_get_opcode_id(s, e - s);
-				if (opcode <= ZEND_VM_LAST_OPCODE) {
-					zend_set_user_opcode_handler(opcode, handler);
-				} else {
-					zend_error(E_WARNING, "Invalid opcode name %.*s", (int) (e - s), e);
-				}
-				s = NULL;
-			}
-		} else {
-			if (!s) {
-				s = e;
-			}
-		}
-		if (*e == '\0') {
-			break;
-		}
-		e++;
-	}
-}
-
-static void fiber_address_observer(zend_fiber_context *from, zend_fiber_context *to)
-{
-	if (ZT_G(observer_fiber_switch)) {
-		php_printf("<!-- switching from fiber %p to %p -->\n", from, to);
-	}
-}
-
-static void fiber_enter_observer(zend_fiber_context *from, zend_fiber_context *to)
-{
-	if (ZT_G(observer_fiber_switch)) {
-		if (to->status == ZEND_FIBER_STATUS_INIT) {
-			php_printf("<init '%p'>\n", to);
-		} else if (to->kind == zend_ce_fiber) {
-			zend_fiber *fiber = zend_fiber_from_context(to);
-			if (fiber->caller != from) {
-				return;
-			}
-
-			if (to->flags & ZEND_FIBER_FLAG_DESTROYED) {
-				php_printf("<destroying '%p'>\n", to);
-			} else if (to->status != ZEND_FIBER_STATUS_DEAD) {
-				php_printf("<resume '%p'>\n", to);
-			}
-		}
-	}
-}
-
-static void fiber_suspend_observer(zend_fiber_context *from, zend_fiber_context *to)
-{
-	if (ZT_G(observer_fiber_switch)) {
-		if (from->status == ZEND_FIBER_STATUS_DEAD) {
-			if (from->flags & ZEND_FIBER_FLAG_THREW) {
-				php_printf("<threw '%p'>\n", from);
-			} else if (from->flags & ZEND_FIBER_FLAG_DESTROYED) {
-				php_printf("<destroyed '%p'>\n", from);
-			} else {
-				php_printf("<returned '%p'>\n", from);
-			}
-		} else if (from->kind == zend_ce_fiber) {
-			zend_fiber *fiber = zend_fiber_from_context(from);
-			if (fiber->caller == NULL) {
-				php_printf("<suspend '%p'>\n", from);
-			}
-		}
-	}
 }
 
 PHP_MINIT_FUNCTION(zend_test)
@@ -483,9 +385,6 @@ PHP_MINIT_FUNCTION(zend_test)
 	// Loading via dl() not supported with the observer API
 	if (type != MODULE_TEMPORARY) {
 		REGISTER_INI_ENTRIES();
-		if (ZT_G(observer_enabled)) {
-			zend_observer_fcall_register(observer_fcall_init);
-		}
 	} else {
 		(void)ini_entries;
 	}
@@ -495,21 +394,12 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_execute_ex = custom_zend_execute_ex;
 	}
 
-	if (ZT_G(observer_enabled) && ZT_G(observer_show_opcode_in_user_handler)) {
-		observer_set_user_opcode_handler(ZT_G(observer_show_opcode_in_user_handler), observer_show_opcode_in_user_handler);
-	}
-
-	if (ZT_G(observer_enabled)) {
-		zend_observer_fiber_switch_register(fiber_address_observer);
-		zend_observer_fiber_switch_register(fiber_enter_observer);
-		zend_observer_fiber_switch_register(fiber_suspend_observer);
-	}
-
 	if (ZT_G(register_passes)) {
 		zend_optimizer_register_pass(pass1);
 		zend_optimizer_register_pass(pass2);
 	}
 
+	zend_test_observer_init(INIT_FUNC_ARGS_PASSTHRU);
 	zend_test_fiber_init();
 
 	return SUCCESS;
@@ -521,137 +411,9 @@ PHP_MSHUTDOWN_FUNCTION(zend_test)
 		UNREGISTER_INI_ENTRIES();
 	}
 
+	zend_test_observer_shutdown(SHUTDOWN_FUNC_ARGS_PASSTHRU);
+
 	return SUCCESS;
-}
-
-static void observer_show_opcode(zend_execute_data *execute_data)
-{
-	if (!ZT_G(observer_show_opcode)) {
-		return;
-	}
-	php_printf("%*s<!-- opcode: '%s' -->\n", 2 * ZT_G(observer_nesting_depth), "", zend_get_opcode_name(EX(opline)->opcode));
-}
-
-static void observer_begin(zend_execute_data *execute_data)
-{
-	if (!ZT_G(observer_show_output)) {
-		return;
-	}
-
-	if (execute_data->func && execute_data->func->common.function_name) {
-		if (execute_data->func->common.scope) {
-			php_printf("%*s<%s::%s>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->common.scope->name), ZSTR_VAL(execute_data->func->common.function_name));
-		} else {
-			php_printf("%*s<%s>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->common.function_name));
-		}
-	} else {
-		php_printf("%*s<file '%s'>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->op_array.filename));
-	}
-	ZT_G(observer_nesting_depth)++;
-	observer_show_opcode(execute_data);
-}
-
-static void get_retval_info(zval *retval, smart_str *buf)
-{
-	if (!ZT_G(observer_show_return_type) && !ZT_G(observer_show_return_value)) {
-		return;
-	}
-
-	smart_str_appendc(buf, ':');
-	if (retval == NULL) {
-		smart_str_appendl(buf, "NULL", 4);
-	} else if (ZT_G(observer_show_return_value)) {
-		if (Z_TYPE_P(retval) == IS_OBJECT) {
-			smart_str_appendl(buf, "object(", 7);
-			smart_str_append(buf, Z_OBJCE_P(retval)->name);
-			smart_str_appendl(buf, ")#", 2);
-			smart_str_append_long(buf, Z_OBJ_HANDLE_P(retval));
-		} else {
-			php_var_export_ex(retval, 2 * ZT_G(observer_nesting_depth) + 3, buf);
-		}
-	} else if (ZT_G(observer_show_return_type)) {
-		smart_str_appends(buf, zend_zval_type_name(retval));
-	}
-	smart_str_0(buf);
-}
-
-static void observer_end(zend_execute_data *execute_data, zval *retval)
-{
-	if (!ZT_G(observer_show_output)) {
-		return;
-	}
-
-	if (EG(exception)) {
-		php_printf("%*s<!-- Exception: %s -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(EG(exception)->ce->name));
-	}
-	observer_show_opcode(execute_data);
-	ZT_G(observer_nesting_depth)--;
-	if (execute_data->func && execute_data->func->common.function_name) {
-		smart_str retval_info = {0};
-		get_retval_info(retval, &retval_info);
-		if (execute_data->func->common.scope) {
-			php_printf("%*s</%s::%s%s>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->common.scope->name), ZSTR_VAL(execute_data->func->common.function_name), retval_info.s ? ZSTR_VAL(retval_info.s) : "");
-		} else {
-			php_printf("%*s</%s%s>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->common.function_name), retval_info.s ? ZSTR_VAL(retval_info.s) : "");
-		}
-		smart_str_free(&retval_info);
-	} else {
-		php_printf("%*s</file '%s'>\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(execute_data->func->op_array.filename));
-	}
-}
-
-static void observer_show_init(zend_function *fbc)
-{
-	if (fbc->common.function_name) {
-		if (fbc->common.scope) {
-			php_printf("%*s<!-- init %s::%s() -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
-		} else {
-			php_printf("%*s<!-- init %s() -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->common.function_name));
-		}
-	} else {
-		php_printf("%*s<!-- init '%s' -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->op_array.filename));
-	}
-}
-
-static void observer_show_init_backtrace(zend_execute_data *execute_data)
-{
-	zend_execute_data *ex = execute_data;
-	php_printf("%*s<!--\n", 2 * ZT_G(observer_nesting_depth), "");
-	do {
-		zend_function *fbc = ex->func;
-		int indent = 2 * ZT_G(observer_nesting_depth) + 4;
-		if (fbc->common.function_name) {
-			if (fbc->common.scope) {
-				php_printf("%*s%s::%s()\n", indent, "", ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
-			} else {
-				php_printf("%*s%s()\n", indent, "", ZSTR_VAL(fbc->common.function_name));
-			}
-		} else {
-			php_printf("%*s{main} %s\n", indent, "", ZSTR_VAL(fbc->op_array.filename));
-		}
-	} while ((ex = ex->prev_execute_data) != NULL);
-	php_printf("%*s-->\n", 2 * ZT_G(observer_nesting_depth), "");
-}
-
-static zend_observer_fcall_handlers observer_fcall_init(zend_execute_data *execute_data)
-{
-	zend_function *fbc = execute_data->func;
-	if (ZT_G(observer_show_output)) {
-		observer_show_init(fbc);
-		if (ZT_G(observer_show_init_backtrace)) {
-			observer_show_init_backtrace(execute_data);
-		}
-		observer_show_opcode(execute_data);
-	}
-
-	if (ZT_G(observer_observe_all)) {
-		return (zend_observer_fcall_handlers){observer_begin, observer_end};
-	} else if (ZT_G(observer_observe_includes) && !fbc->common.function_name) {
-		return (zend_observer_fcall_handlers){observer_begin, observer_end};
-	} else if (ZT_G(observer_observe_functions) && fbc->common.function_name) {
-		return (zend_observer_fcall_handlers){observer_begin, observer_end};
-	}
-	return (zend_observer_fcall_handlers){NULL, NULL};
 }
 
 PHP_RINIT_FUNCTION(zend_test)

--- a/ext/zend_test/tests/fiber_test_01.phpt
+++ b/ext/zend_test/tests/fiber_test_01.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Fiber interaction with custom fiber implementation 1
+--SKIPIF--
+<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--FILE--
+<?php
+$fiber = new Fiber(function (): int {
+    $test = new _ZendTestFiber(function (): int {
+        $value = Fiber::suspend(123);
+        var_dump($value); // int(246)
+        return $value;
+    });
+    var_dump($test->start()); // NULL
+    return 1;
+});
+$value = $fiber->start();
+var_dump($value); // int(123)
+$value = $fiber->resume(2 * $value);
+var_dump($value); // NULL
+var_dump($fiber->getReturn()); // int(1)
+
+?>
+--EXPECTF--
+int(123)
+int(246)
+NULL
+NULL
+int(1)

--- a/ext/zend_test/tests/fiber_test_01.phpt
+++ b/ext/zend_test/tests/fiber_test_01.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Fiber interaction with custom fiber implementation 1
---SKIPIF--
-<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--EXTENSIONS--
+zend_test
 --FILE--
 <?php
 $fiber = new Fiber(function (): int {

--- a/ext/zend_test/tests/fiber_test_02.phpt
+++ b/ext/zend_test/tests/fiber_test_02.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Fiber interaction with custom fiber implementation 2
+--SKIPIF--
+<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--FILE--
+<?php
+$test = new _ZendTestFiber(function (): void {
+    $fiber = new Fiber(function (): int {
+        $value = _ZendTestFiber::suspend(1);
+        var_dump($value); // int(2)
+        return $value;
+    });
+    $fiber->start();
+});
+var_dump($test->start()); // int(1)
+var_dump($test->resume(2)); // NULL
+
+?>
+--EXPECTF--
+int(1)
+int(2)
+NULL

--- a/ext/zend_test/tests/fiber_test_02.phpt
+++ b/ext/zend_test/tests/fiber_test_02.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Fiber interaction with custom fiber implementation 2
---SKIPIF--
-<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--EXTENSIONS--
+zend_test
 --FILE--
 <?php
 $test = new _ZendTestFiber(function (): void {

--- a/ext/zend_test/tests/fiber_test_03.phpt
+++ b/ext/zend_test/tests/fiber_test_03.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Fiber interaction with custom fiber implementation 3
---SKIPIF--
-<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--EXTENSIONS--
+zend_test
 --FILE--
 <?php
 $fiber = new Fiber(function (): int {

--- a/ext/zend_test/tests/fiber_test_03.phpt
+++ b/ext/zend_test/tests/fiber_test_03.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Fiber interaction with custom fiber implementation 3
+--SKIPIF--
+<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--FILE--
+<?php
+$fiber = new Fiber(function (): int {
+    $test = new _ZendTestFiber(function (): void {
+        $value = Fiber::suspend(1);
+        var_dump($value); // int(2)
+        Fiber::suspend(3);
+    });
+    var_dump($test->start()); // NULL
+    echo "unreachable\n"; // Test fiber throws.
+    return 1;
+});
+$value = $fiber->start();
+var_dump($value); // int(1)
+$value = $fiber->resume(2 * $value);
+var_dump($value); // int(3)
+$value = $fiber->throw(new Exception('test'));
+
+?>
+--EXPECTF--
+int(1)
+int(2)
+int(3)
+
+Fatal error: Uncaught Exception: test in %sfiber_test_03.php:%d
+Stack trace:
+#0 {main}
+  thrown in %sfiber_test_03.php on line %d

--- a/ext/zend_test/tests/fiber_test_04.phpt
+++ b/ext/zend_test/tests/fiber_test_04.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Fiber interaction with custom fiber implementation 4
+--SKIPIF--
+<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--FILE--
+<?php
+$fiber = new Fiber(function (): int {
+    $test = new _ZendTestFiber(function (): void {
+        $value = Fiber::suspend(1);
+        var_dump($value); // int(2)
+        $value = _ZendTestFiber::suspend(3);
+        var_dump($value); // int(6)
+        $value = Fiber::suspend(4);
+        var_dump($value); // int(8)
+        _ZendTestFiber::suspend(5);
+        echo "unreachable\n"; // Test fiber is not resumed.
+    });
+    $value = $test->start();
+    var_dump($value); // int(3)
+    var_dump($test->resume(2 * $value)); // int(5)
+    return -1;
+});
+$value = $fiber->start();
+var_dump($value); // int(1)
+$value = $fiber->resume(2 * $value);
+var_dump($value); // int(4)
+$value = $fiber->resume(2 * $value);
+var_dump($value); // NULL
+var_dump($fiber->getReturn()); // int(-1)
+
+?>
+--EXPECTF--
+int(1)
+int(2)
+int(3)
+int(6)
+int(4)
+int(8)
+int(5)
+NULL
+int(-1)

--- a/ext/zend_test/tests/fiber_test_04.phpt
+++ b/ext/zend_test/tests/fiber_test_04.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Fiber interaction with custom fiber implementation 4
---SKIPIF--
-<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--EXTENSIONS--
+zend_test
 --FILE--
 <?php
 $fiber = new Fiber(function (): int {

--- a/ext/zend_test/tests/fiber_test_05.phpt
+++ b/ext/zend_test/tests/fiber_test_05.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Fiber interaction with custom fiber implementation 5
---SKIPIF--
-<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--EXTENSIONS--
+zend_test
 --FILE--
 <?php
 $test = new _ZendTestFiber(function (): void {

--- a/ext/zend_test/tests/fiber_test_05.phpt
+++ b/ext/zend_test/tests/fiber_test_05.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Fiber interaction with custom fiber implementation 5
+--SKIPIF--
+<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--FILE--
+<?php
+$test = new _ZendTestFiber(function (): void {
+    $fiber = new Fiber(function (): int {
+        $value = Fiber::suspend(1);
+        var_dump($value); // int(2)
+        $value = _ZendTestFiber::suspend(3);
+        var_dump($value); // int(6)
+        $value = Fiber::suspend(4);
+        var_dump($value); // int(8)
+        return 2 * $value;
+    });
+    $value = $fiber->start();
+    var_dump($value); // int(1)
+    $value = $fiber->resume(2 * $value);
+    var_dump($value); // int(4)
+    $value = $fiber->resume(2 * $value);
+    var_dump($value); // NULL
+    var_dump($fiber->getReturn()); // int(16)
+});
+$value = $test->start();
+var_dump($value); // int(3)
+$value = $test->resume(2 * $value);
+
+?>
+--EXPECTF--
+int(1)
+int(2)
+int(3)
+int(6)
+int(4)
+int(8)
+NULL
+int(16)

--- a/ext/zend_test/tests/fiber_test_06.phpt
+++ b/ext/zend_test/tests/fiber_test_06.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Fiber interaction with custom fiber implementation 6
+--SKIPIF--
+<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--FILE--
+<?php
+$test = new _ZendTestFiber(function (): void {
+    $fiber = new Fiber(function (): void {
+        var_dump(_ZendTestFiber::suspend(10)); // string(2) "10"
+        Fiber::suspend(20);
+        echo "unreachable\n"; // Fiber is not resumed.
+    });
+    var_dump($fiber->start()); // int(20)
+});
+
+$fiber = new Fiber(function (): void {
+    var_dump(Fiber::suspend(1)); // string(1) "1"
+    var_dump(Fiber::suspend(2)); // string(1) "2"
+});
+
+var_dump($test->start()); // int(10)
+
+var_dump($fiber->start()); // int(1)
+var_dump($fiber->resume('1')); // int(2)
+
+var_dump($test->resume('10')); // NULL
+
+var_dump($fiber->resume('2')); // NULL
+
+?>
+--EXPECTF--
+int(10)
+int(1)
+string(1) "1"
+int(2)
+string(2) "10"
+int(20)
+NULL
+string(1) "2"
+NULL

--- a/ext/zend_test/tests/fiber_test_06.phpt
+++ b/ext/zend_test/tests/fiber_test_06.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Fiber interaction with custom fiber implementation 6
---SKIPIF--
-<?php if (!extension_loaded('zend_test')) die('skip: zend_test extension required'); ?>
+--EXTENSIONS--
+zend_test
 --FILE--
 <?php
 $test = new _ZendTestFiber(function (): void {


### PR DESCRIPTION
@krakjoe As requested, here is `zend_test` broken up into separate files. I made separate commits to keep things cleaner, but would you rather I kept this PR to just the first commit? Should I separate test.c further?