### PR TITLE
Drop Windows support for phpdbg_webhelper

### DIFF
--- a/sapi/phpdbg/config.w32
+++ b/sapi/phpdbg/config.w32
@@ -1,6 +1,5 @@
 ARG_ENABLE('phpdbg', 'Build phpdbg', 'no');
 ARG_ENABLE('phpdbgs', 'Build phpdbg shared', 'no');
-ARG_ENABLE('phpdbg-webhelper', 'Build phpdbg webhelper', 'yes');
 
 PHPDBG_SOURCES='phpdbg.c phpdbg_prompt.c phpdbg_cmd.c phpdbg_info.c phpdbg_help.c phpdbg_break.c ' +
 		'phpdbg_print.c phpdbg_bp.c phpdbg_opcode.c phpdbg_list.c phpdbg_utils.c ' +
@@ -12,7 +11,6 @@ PHPDBG_EXE='phpdbg.exe';
 PHPDBG_CFLAGS='/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1';
 
 var PHP_PHPDBG_PGO = false;
-var PHP_PHPDBG_WEBHELPER_PGO = false;
 var PHP_PHPDBGS_PGO = false;
 
 if (PHP_PHPDBG == "yes") {
@@ -20,10 +18,6 @@ if (PHP_PHPDBG == "yes") {
 	ADD_FLAG("LIBS_PHPDBG", "ws2_32.lib user32.lib");
 	ADD_FLAG("CFLAGS_PHPDBG", "/D YY_NO_UNISTD_H");
 	ADD_FLAG("LDFLAGS_PHPDBG", "/stack:8388608");
-
-	if (PHP_PHPDBG_WEBHELPER == "yes") {
-		EXTENSION('phpdbg_webhelper', 'phpdbg_rinit_hook.c phpdbg_webdata_transfer.c');
-	}
 }
 
 if (PHP_PHPDBGS == "yes") {


### PR DESCRIPTION
The relevant functionality of this module is not implemented on
Windows, so it does not make sense to be able to build it for that
platform.

---

cc @bwoebi 