### PR TITLE
Bugfix: Ensure previous fiber context can be destroyed in fiber trampoline

### DIFF
--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -218,6 +218,11 @@ static ZEND_NORETURN void zend_fiber_trampoline(boost_context_data data)
 	/* Initialize transfer struct with a copy of passed data. */
 	zend_fiber_transfer transfer = *data.transfer;
 
+	/* Ensure that previous fiber will be cleaned up (needed by symmetric coroutines). */
+	if (from->status == ZEND_FIBER_STATUS_DEAD) {
+		zend_fiber_destroy_context(from);
+	}
+
 	zend_fiber_context *context = EG(current_fiber_context);
 
 	context->function(&transfer);


### PR DESCRIPTION
This fixes a memory leak that occurs when symmetric coroutines ares used like this:

```php
await([
	async(fn() => 1),
	async(fn() => 2)
]);
```
In this case control will be transfered from `main` to `fiber 1` to `fiber 2` and back to `main`. Without this PR this code will result in a memory leak (`fiber 1` cannot be released). The fiber context of `fiber 1` has to be destroyed immediately after switching to `fiber 2` because it is already marked as dead and will never be resumed. The context of `fiber 2` is destroyed when `main` is resumed. Adding additional fibers in the example will fail to destroy every fiber context except for the last one.

@trowski I discovered this bug due to `zend_fiber_stack` being a tracked allocation after your last commit. 😉