### PR TITLE
Use 16 instead of 15 bytes of random data in ReflectionReference->getId

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6370,7 +6370,7 @@ ZEND_METHOD(ReflectionReference, getId)
 	}
 
 	if (!REFLECTION_G(key_initialized)) {
-		if (php_random_bytes_throw(&REFLECTION_G(key_initialized), 16) == FAILURE) {
+		if (php_random_bytes_throw(&REFLECTION_G(key), 16) == FAILURE) {
 			RETURN_THROWS();
 		}
 


### PR DESCRIPTION
```
ZEND_BEGIN_MODULE_GLOBALS(reflection)
	bool key_initialized;
	unsigned char key[REFLECTION_KEY_LEN];
ZEND_END_MODULE_GLOBALS(reflection)
```

This was previously also overwriting key_initialized, which didn't matter at all (I think?)
because C struct layout is always in order of declaration and the value of
key_initialized was subsequently set to 1.

Amends 6347f0b937cc3fb3edb38003a41f3f9e8608831d added in php 7.4