### PR TITLE
Allow objects in define()

### DIFF
--- a/Zend/tests/008.phpt
+++ b/Zend/tests/008.phpt
@@ -16,12 +16,7 @@ var_dump(define("test const", 3));
 var_dump(define("test const", 3));
 var_dump(define("test", array(1)));
 var_dump(define("test1", fopen(__FILE__, 'r')));
-
-try {
 var_dump(define("test2", new stdclass));
-} catch (TypeError $exception) {
-    echo $exception->getMessage() . "\n";
-}
 
 var_dump(constant(" "));
 var_dump(constant("[[["));
@@ -42,7 +37,7 @@ Warning: Constant test const already defined in %s on line %d
 bool(false)
 bool(true)
 bool(true)
-define(): Argument #2 ($value) cannot be an object, stdClass given
+bool(true)
 int(1)
 int(2)
 int(3)

--- a/Zend/tests/bug37811.phpt
+++ b/Zend/tests/bug37811.phpt
@@ -13,21 +13,21 @@ class TestClass
 
 define("Bar", new TestClass);
 var_dump(Bar);
+var_dump((string) Bar);
 
+define("Baz", new stdClass);
+var_dump(Baz);
 try {
-    define("Baz", new stdClass);
-} catch (TypeError $exception) {
-    echo $exception->getMessage() . "\n";
-}
-
-try {
-    var_dump(Baz);
-} catch (Error $exception) {
-    echo $exception->getMessage() . "\n";
+    var_dump((string) Baz);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
 }
 
 ?>
 --EXPECT--
+object(TestClass)#1 (0) {
+}
 string(3) "Foo"
-define(): Argument #2 ($value) cannot be an object, stdClass given
-Undefined constant "Baz"
+object(stdClass)#2 (0) {
+}
+Object of class stdClass could not be converted to string

--- a/Zend/tests/constant_arrays.phpt
+++ b/Zend/tests/constant_arrays.phpt
@@ -23,12 +23,9 @@ define('QUX', $y);
 $y[0] = 3;
 var_dump($x, $y, QUX);
 
-// ensure objects not allowed in arrays
-try {
-    define('ELEPHPANT', [new StdClass]);
-} catch (TypeError $exception) {
-    echo $exception->getMessage() . "\n";
-}
+// objects are allowed in arrays
+define('ELEPHPANT', [new StdClass]);
+var_dump(ELEPHPANT);
 
 // ensure recursion doesn't crash
 $recursive = [];
@@ -40,7 +37,7 @@ try {
     echo $exception->getMessage() . "\n";
 }
 ?>
---EXPECTF--
+--EXPECT--
 array(4) {
   [0]=>
   int(7)
@@ -102,5 +99,9 @@ array(1) {
   [0]=>
   int(7)
 }
-define(): Argument #2 ($value) cannot be an object, stdClass given
+array(1) {
+  [0]=>
+  object(stdClass)#1 (0) {
+  }
+}
 define(): Argument #2 ($value) cannot be a recursive array

--- a/Zend/tests/constants_002.phpt
+++ b/Zend/tests/constants_002.phpt
@@ -3,23 +3,14 @@ Defining constants with non-scalar values
 --FILE--
 <?php
 
-try {
-    define('foo', new stdClass);
-} catch (TypeError $exception) {
-    echo $exception->getMessage() . "\n";
-}
-
-try {
-    var_dump(foo);
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
-
-define('foo', fopen(__FILE__, 'r'));
+define('foo', new stdClass);
 var_dump(foo);
 
+define('bar', fopen(__FILE__, 'r'));
+var_dump(bar);
+
 ?>
---EXPECT--
-define(): Argument #2 ($value) cannot be an object, stdClass given
-Undefined constant "foo"
-resource(5) of type (stream)
+--EXPECTF--
+object(stdClass)#1 (0) {
+}
+resource(%d) of type (stream)


### PR DESCRIPTION
With the introduction of enums, constants using the `const X = Y` syntax can now contain objects. However, `define()` still prohibits use of objects. This relaxes the restriction.

The `const X = Y` syntax currently only allows assigning enum objects in particular, simply because there is no syntactically supported way to create a different object. I don't see a point in restricting `define()` to allow only enum objects in particular though.