### PR TITLE
Fix #54176: locale_compose accepts more than 3 extlang

### DIFF
--- a/ext/intl/locale/locale_methods.c
+++ b/ext/intl/locale/locale_methods.c
@@ -830,6 +830,18 @@ static int append_multiple_key_values(smart_str* loc_name, HashTable* hash_arr, 
 		} else if(Z_TYPE_P(ele_value) == IS_ARRAY ) {
 			HashTable *arr = Z_ARRVAL_P(ele_value);
 			zval *data;
+			int max_value = 0;
+
+			/* Decide the max_value: the max. no. of elements allowed */
+			if( strcmp(key_name , LOC_VARIANT_TAG) ==0 ){
+				max_value  = MAX_NO_VARIANT;
+			}
+			if( strcmp(key_name , LOC_EXTLANG_TAG) ==0 ){
+				max_value  = MAX_NO_EXTLANG;
+			}
+			if( strcmp(key_name , LOC_PRIVATE_TAG) ==0 ){
+				max_value  = MAX_NO_PRIVATE;
+			}
 
 			ZEND_HASH_FOREACH_VAL(arr, data) {
 				if(Z_TYPE_P(data) != IS_STRING) {
@@ -840,6 +852,9 @@ static int append_multiple_key_values(smart_str* loc_name, HashTable* hash_arr, 
 				}
 				smart_str_appendl(loc_name, SEPARATOR , sizeof(SEPARATOR)-1);
 				smart_str_appendl(loc_name, Z_STRVAL_P(data) , Z_STRLEN_P(data));
+				if (max_value > 0 && isFirstSubtag >= max_value) {
+					break;
+				}
 			} ZEND_HASH_FOREACH_END();
 			return SUCCESS;
 		} else {

--- a/ext/intl/tests/locale/bug54176.phpt
+++ b/ext/intl/tests/locale/bug54176.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug #54176 (locale_compose accepts more than 3 extlang)
+--SKIPIF--
+<?php
+if (!extension_loaded('intl')) die("skip intl extension not available");
+?>
+--FILE--
+<?php
+$arr = [
+    'language'=>'en',
+    'script'  =>'Hans',
+    'region'  =>'CN',
+    'extlang' => ['a','b','c','d','e','f'],
+];
+var_dump(locale_compose($arr));
+$arr = [
+    'language'=>'en',
+    'script'  =>'Hans',
+    'region'  =>'CN',
+    'extlang0' => 'a',
+    'extlang1' => 'b',
+    'extlang2' => 'c',
+    'extlang3' => 'd',
+];
+var_dump(locale_compose($arr));
+?>
+--EXPECT--
+string(16) "en_a_b_c_Hans_CN"
+string(16) "en_a_b_c_Hans_CN"


### PR DESCRIPTION
`locale_compose()` accepts at most 15 'variant' and 'private' subtags
each, and at most 3 'extlang' subtags.  This is currently only enforced
if the subtags are given as specific key (e.g. 'variant0'); for
consistency we enforce this for generic keys (e.g. 'variant'), too.

---

This patch matches the [documentation](https://www.php.net/manual/en/locale.composelocale.php), but it seems to me that the documentation is wrong. I assume the limitations have been introduced to avoid "infinite" hash table lookups (although that could have been solved differently), but that is not an issue when the generic keys are used with arrays.

Maybe @smalyshev can clarify?