### PR TITLE
remove specialized printing from phpdbg

### DIFF
--- a/sapi/phpdbg/phpdbg.h
+++ b/sapi/phpdbg/phpdbg.h
@@ -272,7 +272,6 @@ ZEND_BEGIN_MODULE_GLOBALS(phpdbg)
 	phpdbg_oplog_entry *oplog_cur;               /* current oplog entry */
 
 	struct {
-		FILE *ptr;
 		int fd;
 	} io[PHPDBG_IO_FDS];                         /* io */
 	ssize_t (*php_stdiop_write)(php_stream *, const char *, size_t);
@@ -302,7 +301,7 @@ ZEND_BEGIN_MODULE_GLOBALS(phpdbg)
 	uint64_t flags;                              /* phpdbg flags */
 
 	char *sapi_name_ptr;                         /* store sapi name to free it if necessary to not leak memory */
-	long lines;                                  /* max number of lines to display */
+	zend_ulong lines;                                  /* max number of lines to display */
 ZEND_END_MODULE_GLOBALS(phpdbg) /* }}} */
 
 #endif

--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -137,7 +137,7 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 						case PHPDBG_BREAK_FILE: {
 							zend_string *filename = php_addcslashes_str(((phpdbg_breakfile_t*)brake)->filename, strlen(((phpdbg_breakfile_t*)brake)->filename), "\\\"\n", 3);
 							phpdbg_asprintf(&new_str,
-								"%sbreak \"%s\":%lu\n", *str,
+								"%sbreak \"%s\":"ZEND_ULONG_FMT"\n", *str,
 								ZSTR_VAL(filename),
 								((phpdbg_breakfile_t*)brake)->line);
 							zend_string_release(filename);
@@ -158,7 +158,7 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 
 						case PHPDBG_BREAK_METHOD_OPLINE: {
 							phpdbg_asprintf(&new_str,
-								"%sbreak %s::%s#%llu\n", *str,
+								"%sbreak %s::%s#"ZEND_ULONG_FMT"\n", *str,
 								((phpdbg_breakopline_t*)brake)->class_name,
 								((phpdbg_breakopline_t*)brake)->func_name,
 								((phpdbg_breakopline_t*)brake)->opline_num);
@@ -166,7 +166,7 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 
 						case PHPDBG_BREAK_FUNCTION_OPLINE: {
 							phpdbg_asprintf(&new_str,
-								"%sbreak %s#%llu\n", *str,
+								"%sbreak %s#"ZEND_ULONG_FMT"\n", *str,
 								((phpdbg_breakopline_t*)brake)->func_name,
 								((phpdbg_breakopline_t*)brake)->opline_num);
 						} break;
@@ -174,7 +174,7 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 						case PHPDBG_BREAK_FILE_OPLINE: {
 							zend_string *filename = php_addcslashes_str(((phpdbg_breakopline_t*)brake)->class_name, strlen(((phpdbg_breakopline_t*)brake)->class_name), "\\\"\n", 3);
 							phpdbg_asprintf(&new_str,
-								"%sbreak \"%s\":#%llu\n", *str,
+								"%sbreak \"%s\":#"ZEND_ULONG_FMT"\n", *str,
 								ZSTR_VAL(filename),
 								((phpdbg_breakopline_t*)brake)->opline_num);
 							zend_string_release(filename);
@@ -193,19 +193,19 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 								switch (conditional->param.type) {
 		                            case NUMERIC_FUNCTION_PARAM:
 		                                phpdbg_asprintf(&new_str,
-		                                    "%sbreak at %s#%ld if %s\n",
+		                                    "%sbreak at %s#"ZEND_ULONG_FMT" if %s\n",
 		                                    *str, conditional->param.str, conditional->param.num, conditional->code);
 		                            break;
 
 		                            case NUMERIC_METHOD_PARAM:
 		                                phpdbg_asprintf(&new_str,
-		                                    "%sbreak at %s::%s#%ld if %s\n",
+		                                    "%sbreak at %s::%s#"ZEND_ULONG_FMT" if %s\n",
 		                                    *str, conditional->param.method.class, conditional->param.method.name, conditional->param.num, conditional->code);
 		                            break;
 
 		                            case ADDR_PARAM:
 		                                phpdbg_asprintf(&new_str,
-		                                    "%sbreak at 0X%lx if %s\n",
+		                                    "%sbreak at 0X"ZEND_ULONG_FMT" if %s\n",
 		                                    *str, conditional->param.addr, conditional->code);
 		                            break;
 
@@ -224,7 +224,7 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 									case FILE_PARAM: {
 										zend_string *filename = php_addcslashes_str(conditional->param.file.name, strlen(conditional->param.file.name), "\\\"\n", 3);
 										phpdbg_asprintf(&new_str,
-											"%sbreak at \"%s\":%lu if %s\n", *str,
+											"%sbreak at \"%s\":"ZEND_ULONG_FMT" if %s\n", *str,
 											ZSTR_VAL(filename), conditional->param.file.line,
 											conditional->code);
 										zend_string_release(filename);
@@ -241,7 +241,7 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 					}
 
 					if ((*str)[0]) {
-						efree(*str);
+						free(*str);
 					}
 					*str = new_str;
 				}
@@ -254,7 +254,7 @@ PHPDBG_API void phpdbg_export_breakpoints_to_string(char **str) /* {{{ */
 	}
 } /* }}} */
 
-PHPDBG_API void phpdbg_set_breakpoint_file(const char *path, size_t path_len, long line_num) /* {{{ */
+PHPDBG_API void phpdbg_set_breakpoint_file(const char *path, size_t path_len, zend_ulong line_num) /* {{{ */
 {
 	php_stream_statbuf ssb;
 	char realpath[MAXPATHLEN];
@@ -328,14 +328,14 @@ PHPDBG_API void phpdbg_set_breakpoint_file(const char *path, size_t path_len, lo
 		if (pending) {
 			PHPDBG_G(flags) |= PHPDBG_HAS_PENDING_FILE_BP;
 
-			phpdbg_notice("Pending breakpoint #%d added at %s:%ld", new_break.id, new_break.filename, new_break.line);
+			phpdbg_notice("Pending breakpoint #%d added at %s:"ZEND_ULONG_FMT"", new_break.id, new_break.filename, new_break.line);
 		} else {
 			PHPDBG_G(flags) |= PHPDBG_HAS_FILE_BP;
 
-			phpdbg_notice("Breakpoint #%d added at %s:%ld", new_break.id, new_break.filename, new_break.line);
+			phpdbg_notice("Breakpoint #%d added at %s:"ZEND_ULONG_FMT"", new_break.id, new_break.filename, new_break.line);
 		}
 	} else {
-		phpdbg_error("Breakpoint at %s:%ld exists", path, line_num);
+		phpdbg_error("Breakpoint at %s:"ZEND_ULONG_FMT" exists", path, line_num);
 	}
 
 	zend_string_release(path_str);
@@ -491,10 +491,10 @@ PHPDBG_API void phpdbg_set_breakpoint_opline(zend_ulong opline) /* {{{ */
 
 		zend_hash_index_update_mem(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], opline, &new_break, sizeof(phpdbg_breakline_t));
 
-		phpdbg_notice("Breakpoint #%d added at %#lx", new_break.id, new_break.opline);
+		phpdbg_notice("Breakpoint #%d added at #"ZEND_ULONG_FMT, new_break.id, new_break.opline);
 		PHPDBG_BREAK_MAPPING(new_break.id, &PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE]);
 	} else {
-		phpdbg_error("Breakpoint exists at %#lx", opline);
+		phpdbg_error("Breakpoint exists at #"ZEND_ULONG_FMT, opline);
 	}
 } /* }}} */
 
@@ -503,11 +503,11 @@ PHPDBG_API int phpdbg_resolve_op_array_break(phpdbg_breakopline_t *brake, zend_o
 	phpdbg_breakline_t opline_break;
 	if (op_array->last <= brake->opline_num) {
 		if (brake->class_name == NULL) {
-			phpdbg_error("There are only %d oplines in function %s (breaking at opline %ld impossible)", op_array->last, brake->func_name, brake->opline_num);
+			phpdbg_error("There are only %d oplines in function %s (breaking at opline "ZEND_ULONG_FMT" impossible)", op_array->last, brake->func_name, brake->opline_num);
 		} else if (brake->func_name == NULL) {
-			phpdbg_error("There are only %d oplines in file %s (breaking at opline %ld impossible)", op_array->last, brake->class_name, brake->opline_num);
+			phpdbg_error("There are only %d oplines in file %s (breaking at opline "ZEND_ULONG_FMT" impossible)", op_array->last, brake->class_name, brake->opline_num);
 		} else {
-			phpdbg_error("There are only %d oplines in method %s::%s (breaking at opline %ld impossible)", op_array->last, brake->class_name, brake->func_name, brake->opline_num);
+			phpdbg_error("There are only %d oplines in method %s::%s (breaking at opline "ZEND_ULONG_FMT" impossible)", op_array->last, brake->class_name, brake->func_name, brake->opline_num);
 		}
 
 		return FAILURE;
@@ -559,7 +559,7 @@ PHPDBG_API void phpdbg_resolve_op_array_breaks(zend_op_array *op_array) /* {{{ *
 			zend_hash_internal_pointer_end(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE]);
 			opline_break = zend_hash_get_current_data_ptr(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE]);
 
-			phpdbg_notice("Breakpoint #%d resolved at %s%s%s#%ld (opline %#lx)",
+			phpdbg_notice("Breakpoint #%d resolved at %s%s%s#"ZEND_ULONG_FMT" (opline #"ZEND_ULONG_FMT")",
 				opline_break->id,
 				brake->class_name ? brake->class_name : "",
 				brake->class_name && brake->func_name ? "::" : "",
@@ -653,11 +653,11 @@ PHPDBG_API void phpdbg_set_breakpoint_method_opline(const char *class, const cha
 
 	switch (phpdbg_resolve_opline_break(&new_break)) {
 		case FAILURE:
-			phpdbg_notice("Pending breakpoint #%d at %s::%s#%ld", new_break.id, new_break.class_name, new_break.func_name, opline);
+			phpdbg_notice("Pending breakpoint #%d at %s::%s#"ZEND_ULONG_FMT, new_break.id, new_break.class_name, new_break.func_name, opline);
 			break;
 
 		case SUCCESS:
-			phpdbg_notice("Breakpoint #%d added at %s::%s#%ld", new_break.id, new_break.class_name, new_break.func_name, opline);
+			phpdbg_notice("Breakpoint #%d added at %s::%s#"ZEND_ULONG_FMT, new_break.id, new_break.class_name, new_break.func_name, opline);
 			break;
 
 		case 2:
@@ -675,7 +675,7 @@ PHPDBG_API void phpdbg_set_breakpoint_method_opline(const char *class, const cha
 	}
 
 	if (zend_hash_index_exists(method_table, opline)) {
-		phpdbg_error("Breakpoint already exists for %s::%s#%ld", new_break.class_name, new_break.func_name, opline);
+		phpdbg_error("Breakpoint already exists for %s::%s#"ZEND_ULONG_FMT, new_break.class_name, new_break.func_name, opline);
 		efree((char*)new_break.func_name);
 		efree((char*)new_break.class_name);
 		PHPDBG_G(bp_count)--;
@@ -705,11 +705,11 @@ PHPDBG_API void phpdbg_set_breakpoint_function_opline(const char *function, zend
 
 	switch (phpdbg_resolve_opline_break(&new_break)) {
 		case FAILURE:
-			phpdbg_notice("Pending breakpoint #%d at %s#%ld", new_break.id, new_break.func_name, opline);
+			phpdbg_notice("Pending breakpoint #%d at %s#"ZEND_ULONG_FMT, new_break.id, new_break.func_name, opline);
 			break;
 
 		case SUCCESS:
-			phpdbg_notice("Breakpoint #%d added at %s#%ld", new_break.id, new_break.func_name, opline);
+			phpdbg_notice("Breakpoint #%d added at %s#"ZEND_ULONG_FMT, new_break.id, new_break.func_name, opline);
 			break;
 
 		case 2:
@@ -722,7 +722,7 @@ PHPDBG_API void phpdbg_set_breakpoint_function_opline(const char *function, zend
 	}
 
 	if (zend_hash_index_exists(func_table, opline)) {
-		phpdbg_error("Breakpoint already exists for %s#%ld", new_break.func_name, opline);
+		phpdbg_error("Breakpoint already exists for %s#"ZEND_ULONG_FMT, new_break.func_name, opline);
 		efree((char*)new_break.func_name);
 		PHPDBG_G(bp_count)--;
 		return;
@@ -751,11 +751,11 @@ PHPDBG_API void phpdbg_set_breakpoint_file_opline(const char *file, zend_ulong o
 
 	switch (phpdbg_resolve_opline_break(&new_break)) {
 		case FAILURE:
-			phpdbg_notice("Pending breakpoint #%d at %s:%ld", new_break.id, new_break.class_name, opline);
+			phpdbg_notice("Pending breakpoint #%d at %s:"ZEND_ULONG_FMT, new_break.id, new_break.class_name, opline);
 			break;
 
 		case SUCCESS:
-			phpdbg_notice("Breakpoint #%d added at %s:%ld", new_break.id, new_break.class_name, opline);
+			phpdbg_notice("Breakpoint #%d added at %s:"ZEND_ULONG_FMT, new_break.id, new_break.class_name, opline);
 			break;
 
 		case 2:
@@ -768,7 +768,7 @@ PHPDBG_API void phpdbg_set_breakpoint_file_opline(const char *file, zend_ulong o
 	}
 
 	if (zend_hash_index_exists(file_table, opline)) {
-		phpdbg_error("Breakpoint already exists for %s:%ld", new_break.class_name, opline);
+		phpdbg_error("Breakpoint already exists for %s:"ZEND_ULONG_FMT, new_break.class_name, opline);
 		efree((char*)new_break.class_name);
 		PHPDBG_G(bp_count)--;
 		return;
@@ -817,10 +817,10 @@ PHPDBG_API void phpdbg_set_breakpoint_opline_ex(phpdbg_opline_ptr_t opline) /* {
 
 		zend_hash_index_update_mem(&PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE], (zend_ulong) opline, &new_break, sizeof(phpdbg_breakline_t));
 
-		phpdbg_notice("Breakpoint #%d added at %#lx", new_break.id, new_break.opline);
+		phpdbg_notice("Breakpoint #%d added at #"ZEND_ULONG_FMT, new_break.id, new_break.opline);
 		PHPDBG_BREAK_MAPPING(new_break.id, &PHPDBG_G(bp)[PHPDBG_BREAK_OPLINE]);
 	} else {
-		phpdbg_error("Breakpoint exists for opline %#lx", (zend_ulong) opline);
+		phpdbg_error("Breakpoint exists for opline #"ZEND_ULONG_FMT, (zend_ulong) opline);
 	}
 } /* }}} */
 
@@ -1243,10 +1243,10 @@ PHPDBG_API void phpdbg_delete_breakpoint(zend_ulong num) /* {{{ */
 			break;
 		}
 
-		phpdbg_notice("Deleted breakpoint #%ld", num);
+		phpdbg_notice("Deleted breakpoint #"ZEND_ULONG_FMT, num);
 		PHPDBG_BREAK_UNMAPPING(num);
 	} else {
-		phpdbg_error("Failed to find breakpoint #%ld", num);
+		phpdbg_error("Failed to find breakpoint #"ZEND_ULONG_FMT, num);
 	}
 } /* }}} */
 
@@ -1285,7 +1285,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 
 	switch (brake->type) {
 		case PHPDBG_BREAK_FILE: {
-			phpdbg_notice("Breakpoint #%d at %s:%ld, hits: %lu",
+			phpdbg_notice("Breakpoint #%d at %s:"ZEND_ULONG_FMT", hits: "ZEND_ULONG_FMT"",
 				((phpdbg_breakfile_t*)brake)->id,
 				((phpdbg_breakfile_t*)brake)->filename,
 				((phpdbg_breakfile_t*)brake)->line,
@@ -1293,7 +1293,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 		} break;
 
 		case PHPDBG_BREAK_SYM: {
-			phpdbg_notice("Breakpoint #%d in %s() at %s:%u, hits: %lu",
+			phpdbg_notice("Breakpoint #%d in %s() at %s:%u, hits: "ZEND_ULONG_FMT"",
 				((phpdbg_breaksymbol_t*)brake)->id,
 				((phpdbg_breaksymbol_t*)brake)->symbol,
 				zend_get_executed_filename(),
@@ -1302,7 +1302,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 		} break;
 
 		case PHPDBG_BREAK_OPLINE: {
-			phpdbg_notice("Breakpoint #%d in %#lx at %s:%u, hits: %lu",
+			phpdbg_notice("Breakpoint #%d in #"ZEND_ULONG_FMT" at %s:%u, hits: "ZEND_ULONG_FMT"",
 				((phpdbg_breakline_t*)brake)->id,
 				((phpdbg_breakline_t*)brake)->opline,
 				zend_get_executed_filename(),
@@ -1311,7 +1311,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 		} break;
 
 		case PHPDBG_BREAK_METHOD_OPLINE: {
-			 phpdbg_notice("Breakpoint #%d in %s::%s()#%lu at %s:%u, hits: %lu",
+			 phpdbg_notice("Breakpoint #%d in %s::%s()#"ZEND_ULONG_FMT" at %s:%u, hits: "ZEND_ULONG_FMT"",
 				((phpdbg_breakopline_t*)brake)->id,
 				((phpdbg_breakopline_t*)brake)->class_name,
 				((phpdbg_breakopline_t*)brake)->func_name,
@@ -1322,7 +1322,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 		} break;
 
 		case PHPDBG_BREAK_FUNCTION_OPLINE: {
-			 phpdbg_notice("Breakpoint #%d in %s()#%lu at %s:%u, hits: %lu",
+			 phpdbg_notice("Breakpoint #%d in %s()#"ZEND_ULONG_FMT" at %s:%u, hits: "ZEND_ULONG_FMT"",
 				((phpdbg_breakopline_t*)brake)->id,
 				((phpdbg_breakopline_t*)brake)->func_name,
 				((phpdbg_breakopline_t*)brake)->opline_num,
@@ -1332,7 +1332,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 		} break;
 
 		case PHPDBG_BREAK_FILE_OPLINE: {
-			 phpdbg_notice("Breakpoint #%d in #%lu at %s:%u, hits: %lu",
+			 phpdbg_notice("Breakpoint #%d in #"ZEND_ULONG_FMT" at %s:%u, hits: "ZEND_ULONG_FMT"",
 				((phpdbg_breakopline_t*)brake)->id,
 				((phpdbg_breakopline_t*)brake)->opline_num,
 				zend_get_executed_filename(),
@@ -1341,7 +1341,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 		} break;
 
 		case PHPDBG_BREAK_OPCODE: {
-			 phpdbg_notice("Breakpoint #%d in %s at %s:%u, hits: %lu",
+			 phpdbg_notice("Breakpoint #%d in %s at %s:%u, hits: "ZEND_ULONG_FMT"",
 				((phpdbg_breakop_t*)brake)->id,
 				((phpdbg_breakop_t*)brake)->name,
 				zend_get_executed_filename(),
@@ -1350,7 +1350,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 		} break;
 
 		case PHPDBG_BREAK_METHOD: {
-			 phpdbg_notice("Breakpoint #%d in %s::%s() at %s:%u, hits: %lu",
+			 phpdbg_notice("Breakpoint #%d in %s::%s() at %s:%u, hits: "ZEND_ULONG_FMT"",
 				((phpdbg_breakmethod_t*)brake)->id,
 				((phpdbg_breakmethod_t*)brake)->class_name,
 				((phpdbg_breakmethod_t*)brake)->func_name,
@@ -1362,7 +1362,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 		case PHPDBG_BREAK_COND: {
 			if (((phpdbg_breakcond_t*)brake)->paramed) {
 				char *param;
-				phpdbg_notice("Conditional breakpoint #%d: at %s if %s at %s:%u, hits: %lu",
+				phpdbg_notice("Conditional breakpoint #%d: at %s if %s at %s:%u, hits: "ZEND_ULONG_FMT"",
 					((phpdbg_breakcond_t*)brake)->id,
 					phpdbg_param_tostring(&((phpdbg_breakcond_t*)brake)->param, &param),
 					((phpdbg_breakcond_t*)brake)->code,
@@ -1372,7 +1372,7 @@ PHPDBG_API void phpdbg_print_breakpoint(phpdbg_breakbase_t *brake) /* {{{ */
 				if (param)
 					free(param);
 			} else {
-				phpdbg_notice("Conditional breakpoint #%d: on %s == true at %s:%u, hits: %lu",
+				phpdbg_notice("Conditional breakpoint #%d: on %s == true at %s:%u, hits: "ZEND_ULONG_FMT"",
 					((phpdbg_breakcond_t*)brake)->id,
 					((phpdbg_breakcond_t*)brake)->code,
 					zend_get_executed_filename(),
@@ -1482,7 +1482,7 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 				phpdbg_breakfile_t *brake;
 
 				ZEND_HASH_FOREACH_PTR(points, brake) {
-					phpdbg_writeln("#%d\t\t%s:%lu%s",
+					phpdbg_writeln("#%d\t\t%s:"ZEND_ULONG_FMT"%s",
 						brake->id, brake->filename, brake->line,
 						((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 				} ZEND_HASH_FOREACH_END();
@@ -1496,7 +1496,7 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 				phpdbg_breakfile_t *brake;
 
 				ZEND_HASH_FOREACH_PTR(points, brake) {
-					phpdbg_writeln("#%d\t\t%s:%lu%s",
+					phpdbg_writeln("#%d\t\t%s:"ZEND_ULONG_FMT"%s",
 						brake->id, brake->filename, brake->line,
 						((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 				} ZEND_HASH_FOREACH_END();
@@ -1529,13 +1529,13 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 							type = "file";
 						}
 
-						phpdbg_writeln("#%d\t\t%#lx\t\t(%s breakpoint)%s",
+						phpdbg_writeln("#%d\t\t#"ZEND_ULONG_FMT"\t\t(%s breakpoint)%s",
 							brake->id, brake->opline, type,
 							((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 					} break;
 
 					default:
-						phpdbg_writeln("#%d\t\t%#lx%s",
+						phpdbg_writeln("#%d\t\t#"ZEND_ULONG_FMT"%s",
 							brake->id, brake->opline,
 							((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 						break;
@@ -1553,7 +1553,7 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 					phpdbg_breakopline_t *brake;
 
 					ZEND_HASH_FOREACH_PTR(method_table, brake) {
-						phpdbg_writeln("#%d\t\t%s::%s opline %ld%s",
+						phpdbg_writeln("#%d\t\t%s::%s opline "ZEND_ULONG_FMT"%s",
 							brake->id, brake->class_name, brake->func_name, brake->opline_num,
 							((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 					} ZEND_HASH_FOREACH_END();
@@ -1570,7 +1570,7 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 				phpdbg_breakopline_t *brake;
 
 				ZEND_HASH_FOREACH_PTR(function_table, brake) {
-					phpdbg_writeln("#%d\t\t%s opline %ld%s",
+					phpdbg_writeln("#%d\t\t%s opline "ZEND_ULONG_FMT"%s",
 						brake->id, brake->func_name, brake->opline_num,
 						((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 				} ZEND_HASH_FOREACH_END();
@@ -1586,7 +1586,7 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 				phpdbg_breakopline_t *brake;
 
 				ZEND_HASH_FOREACH_PTR(file_table, brake) {
-					phpdbg_writeln("#%d\t\t%s opline %ld%s",
+					phpdbg_writeln("#%d\t\t%s opline "ZEND_ULONG_FMT"%s",
 						brake->id, brake->class_name, brake->opline_num,
 						((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 				} ZEND_HASH_FOREACH_END();
@@ -1608,7 +1608,7 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 						break;
 
 						case NUMERIC_FUNCTION_PARAM:
-							phpdbg_writeln("#%d\t\tat %s#%ld if %s%s",
+							phpdbg_writeln("#%d\t\tat %s#"ZEND_ULONG_FMT" if %s%s",
 				 				brake->id, brake->param.str, brake->param.num, brake->code,
 				 				((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 						break;
@@ -1620,19 +1620,19 @@ PHPDBG_API void phpdbg_print_breakpoints(zend_ulong type) /* {{{ */
 						break;
 
 						case NUMERIC_METHOD_PARAM:
-							phpdbg_writeln("#%d\t\tat %s::%s#%ld if %s%s",
+							phpdbg_writeln("#%d\t\tat %s::%s#"ZEND_ULONG_FMT" if %s%s",
 				 				brake->id, brake->param.method.class, brake->param.method.name, brake->param.num, brake->code,
 				 				((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 						break;
 
 						case FILE_PARAM:
-							phpdbg_writeln("#%d\t\tat %s:%lu if %s%s",
+							phpdbg_writeln("#%d\t\tat %s:"ZEND_ULONG_FMT" if %s%s",
 				 				brake->id, brake->param.file.name, brake->param.file.line, brake->code,
 				 				((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 						break;
 
 						case ADDR_PARAM:
-							phpdbg_writeln("#%d\t\tat #%lx if %s%s",
+							phpdbg_writeln("#%d\t\tat #"ZEND_ULONG_FMT" if %s%s",
 				 				brake->id, brake->param.addr, brake->code,
 				 				((phpdbg_breakbase_t *) brake)->disabled ? " [disabled]" : "");
 						break;

--- a/sapi/phpdbg/phpdbg_bp.h
+++ b/sapi/phpdbg/phpdbg_bp.h
@@ -54,7 +54,7 @@ typedef struct _phpdbg_breakbase_t {
  */
 typedef struct _phpdbg_breakfile_t {
 	phpdbg_breakbase(filename);
-	long        line;
+	zend_ulong line;
 } phpdbg_breakfile_t;
 
 /**
@@ -123,7 +123,7 @@ PHPDBG_API HashTable *phpdbg_resolve_pending_file_break_ex(const char *file, uin
 PHPDBG_API void phpdbg_resolve_pending_file_break(const char *file); /* }}} */
 
 /* {{{ Breakpoint Creation API */
-PHPDBG_API void phpdbg_set_breakpoint_file(const char* filename, size_t path_len, long lineno);
+PHPDBG_API void phpdbg_set_breakpoint_file(const char* filename, size_t path_len, zend_ulong lineno);
 PHPDBG_API void phpdbg_set_breakpoint_symbol(const char* func_name, size_t func_name_len);
 PHPDBG_API void phpdbg_set_breakpoint_method(const char* class_name, const char* func_name);
 PHPDBG_API void phpdbg_set_breakpoint_opcode(const char* opname, size_t opname_len);

--- a/sapi/phpdbg/phpdbg_cmd.c
+++ b/sapi/phpdbg/phpdbg_cmd.c
@@ -101,7 +101,7 @@ PHPDBG_API char* phpdbg_param_tostring(const phpdbg_param_t *param, char **point
 		break;
 
 		case NUMERIC_PARAM:
-			ZEND_IGNORE_VALUE(asprintf(pointer, "%li", param->num));
+			ZEND_IGNORE_VALUE(asprintf(pointer, ZEND_LONG_FMT, param->num));
 		break;
 
 		case METHOD_PARAM:
@@ -110,18 +110,18 @@ PHPDBG_API char* phpdbg_param_tostring(const phpdbg_param_t *param, char **point
 
 		case FILE_PARAM:
 			if (param->num) {
-				ZEND_IGNORE_VALUE(asprintf(pointer, "%s:%lu#%lu", param->file.name, param->file.line, param->num));
+				ZEND_IGNORE_VALUE(asprintf(pointer, "%s:"ZEND_ULONG_FMT"#"ZEND_ULONG_FMT, param->file.name, param->file.line, param->num));
 			} else {
-				ZEND_IGNORE_VALUE(asprintf(pointer, "%s:%lu", param->file.name, param->file.line));
+				ZEND_IGNORE_VALUE(asprintf(pointer, "%s:"ZEND_ULONG_FMT, param->file.name, param->file.line));
 			}
 		break;
 
 		case NUMERIC_FUNCTION_PARAM:
-			ZEND_IGNORE_VALUE(asprintf(pointer, "%s#%lu", param->str, param->num));
+			ZEND_IGNORE_VALUE(asprintf(pointer, "%s#"ZEND_ULONG_FMT, param->str, param->num));
 		break;
 
 		case NUMERIC_METHOD_PARAM:
-			ZEND_IGNORE_VALUE(asprintf(pointer, "%s::%s#%lu", param->method.class, param->method.name, param->num));
+			ZEND_IGNORE_VALUE(asprintf(pointer, "%s::%s#"ZEND_ULONG_FMT, param->method.class, param->method.name, param->num));
 		break;
 
 		default:
@@ -331,11 +331,11 @@ PHPDBG_API void phpdbg_param_debug(const phpdbg_param_t *param, const char *msg)
 			break;
 
 			case NUMERIC_FILE_PARAM:
-				fprintf(stderr, "%s NUMERIC_FILE_PARAM(%s:#%lu)\n", msg, param->file.name, param->file.line);
+				fprintf(stderr, "%s NUMERIC_FILE_PARAM(%s:#"ZEND_ULONG_FMT")\n", msg, param->file.name, param->file.line);
 			break;
 
 			case FILE_PARAM:
-				fprintf(stderr, "%s FILE_PARAM(%s:%lu)\n", msg, param->file.name, param->file.line);
+				fprintf(stderr, "%s FILE_PARAM(%s:"ZEND_ULONG_FMT")\n", msg, param->file.name, param->file.line);
 			break;
 
 			case METHOD_PARAM:
@@ -347,11 +347,11 @@ PHPDBG_API void phpdbg_param_debug(const phpdbg_param_t *param, const char *msg)
 			break;
 
 			case NUMERIC_FUNCTION_PARAM:
-				fprintf(stderr, "%s NUMERIC_FUNCTION_PARAM(%s::%ld)\n", msg, param->str, param->num);
+				fprintf(stderr, "%s NUMERIC_FUNCTION_PARAM(%s::"ZEND_LONG_FMT")\n", msg, param->str, param->num);
 			break;
 
 			case NUMERIC_PARAM:
-				fprintf(stderr, "%s NUMERIC_PARAM(%ld)\n", msg, param->num);
+				fprintf(stderr, "%s NUMERIC_PARAM("ZEND_LONG_FMT")\n", msg, param->num);
 			break;
 
 			case COND_PARAM:
@@ -468,9 +468,9 @@ PHPDBG_API int phpdbg_stack_verify(const phpdbg_command_t *command, phpdbg_param
 		char buffer[128] = {0,};
 		const phpdbg_param_t *top = (stack != NULL) ? *stack : NULL;
 		const char *arg = command->args;
-		size_t least = 0L,
-		       received = 0L,
-		       current = 0L;
+		zend_ulong least = 0L,
+		           received = 0L,
+		           current = 0L;
 		bool optional = 0;
 
 		/* check for arg spec */
@@ -499,14 +499,14 @@ PHPDBG_API int phpdbg_stack_verify(const phpdbg_command_t *command, phpdbg_param
 
 #define verify_arg(e, a, t) if (!(a)) { \
 	if (!optional) { \
-		phpdbg_error("The command \"%s\" expected %s and got nothing at parameter %lu", \
+		phpdbg_error("The command \"%s\" expected %s and got nothing at parameter "ZEND_ULONG_FMT, \
 			phpdbg_command_name(command, buffer), \
 			(e), \
 			current); \
 		return FAILURE;\
 	} \
 } else if ((a)->type != (t)) { \
-	phpdbg_error("The command \"%s\" expected %s and got %s at parameter %lu", \
+	phpdbg_error("The command \"%s\" expected %s and got %s at parameter "ZEND_ULONG_FMT, \
 		phpdbg_command_name(command, buffer), \
 		(e),\
 		phpdbg_get_param_type((a)), \
@@ -554,7 +554,7 @@ PHPDBG_API int phpdbg_stack_verify(const phpdbg_command_t *command, phpdbg_param
 #undef verify_arg
 
 		if ((received < least)) {
-			phpdbg_error("The command \"%s\" expected at least %lu arguments (%s) and received %lu",
+			phpdbg_error("The command \"%s\" expected at least "ZEND_ULONG_FMT" arguments (%s) and received "ZEND_ULONG_FMT,
 				phpdbg_command_name(command, buffer),
 				least,
 				command->args,
@@ -643,7 +643,7 @@ PHPDBG_API const phpdbg_command_t *phpdbg_stack_resolve(const phpdbg_command_t *
 			}
 
 			/* ", " separated matches */
-			phpdbg_error("The command \"%s\" is ambiguous, matching %lu commands (%s)", name->str, matches, list);
+			phpdbg_error("The command \"%s\" is ambiguous, matching "ZEND_ULONG_FMT" commands (%s)", name->str, matches, list);
 			efree(list);
 
 			return NULL;

--- a/sapi/phpdbg/phpdbg_cmd.h
+++ b/sapi/phpdbg/phpdbg_cmd.h
@@ -51,11 +51,11 @@ typedef enum {
 typedef struct _phpdbg_param phpdbg_param_t;
 struct _phpdbg_param {
 	phpdbg_param_type type;
-	long num;
+	zend_long num;
 	zend_ulong addr;
 	struct {
 		char *name;
-		long line;
+		zend_ulong line;
 	} file;
 	struct {
 		char *class;
@@ -175,7 +175,7 @@ PHPDBG_API void phpdbg_param_debug(const phpdbg_param_t *param, const char *msg)
 */
 #define phpdbg_default_switch_case() \
 	default: \
-		phpdbg_error("command", "type=\"wrongarg\" got=\"%s\"", "Unsupported parameter type (%s) for command", phpdbg_get_param_type(param)); \
+		phpdbg_error("Unsupported parameter type (%s) for command", phpdbg_get_param_type(param)); \
 	break
 
 #endif /* PHPDBG_CMD_H */

--- a/sapi/phpdbg/phpdbg_frame.c
+++ b/sapi/phpdbg/phpdbg_frame.c
@@ -279,7 +279,7 @@ void phpdbg_dump_backtrace(size_t num) /* {{{ */
 		if (file) { /* userland */
 			phpdbg_out("frame #%d: ", i);
 			phpdbg_dump_prototype(tmp);
-			phpdbg_out(" at %s:%ld\n", Z_STRVAL_P(file), Z_LVAL_P(line));
+			phpdbg_out(" at %s:"ZEND_LONG_FMT"\n", Z_STRVAL_P(file), Z_LVAL_P(line));
 			i++;
 		} else {
 			phpdbg_out(" => ");
@@ -292,7 +292,7 @@ void phpdbg_dump_backtrace(size_t num) /* {{{ */
 		zend_hash_move_forward_ex(Z_ARRVAL(zbacktrace), &position);
 	}
 
-	phpdbg_writeln("frame #%d: {main} at %s:%ld", i, Z_STRVAL_P(file), Z_LVAL_P(line));
+	phpdbg_writeln("frame #%d: {main} at %s:"ZEND_LONG_FMT, i, Z_STRVAL_P(file), Z_LVAL_P(line));
 
 	zval_ptr_dtor_nogc(&zbacktrace);
 	zend_string_release(Z_STR(startfile));

--- a/sapi/phpdbg/phpdbg_help.c
+++ b/sapi/phpdbg/phpdbg_help.c
@@ -43,21 +43,21 @@ void pretty_print(char *text)
 	char *new, *p, *q;
 
 	const char  *prompt_escape = phpdbg_get_prompt();
-	unsigned int prompt_escape_len = strlen(prompt_escape);
-	unsigned int prompt_len = strlen(PHPDBG_G(prompt)[0]);
+	size_t prompt_escape_len = strlen(prompt_escape);
+	size_t prompt_len = strlen(PHPDBG_G(prompt)[0]);
 
 	const char  *bold_on_escape  = PHPDBG_G(flags) & PHPDBG_IS_COLOURED ? "\033[1m" : "";
 	const char  *bold_off_escape = PHPDBG_G(flags) & PHPDBG_IS_COLOURED ? "\033[0m" : "";
-	unsigned int bold_escape_len = strlen(bold_on_escape);
+	size_t bold_escape_len = strlen(bold_on_escape);
 
-	unsigned int term_width = phpdbg_get_terminal_width();
-	unsigned int size = 0;
+	uint32_t term_width = phpdbg_get_terminal_width();
+	uint32_t size = 0;
 
 	int in_bold = 0;
 
-	char *last_new_blank = NULL;          /* position in new buffer of last blank char */
-	unsigned int last_blank_count = 0;    /* printable char offset of last blank char */
-	unsigned int line_count = 0;          /* number printable chars on current line */
+	char *last_new_blank = NULL;  /* position in new buffer of last blank char */
+	uint32_t last_blank_count = 0;    /* printable char offset of last blank char */
+	uint32_t line_count = 0;          /* number printable chars on current line */
 
 	/* First pass calculates a safe size for the pretty print version */
 	for (p = text; *p; p++) {
@@ -126,7 +126,7 @@ void pretty_print(char *text)
 	*q++ = '\0';
 
 	if ((q-new)>size) {
-		phpdbg_error("Output overrun of %lu bytes", ((q - new) - size));
+		phpdbg_error("Output overrun of %" PRIu32 " bytes", (uint32_t) ((q - new) - size));
 	}
 
 	phpdbg_out("%s\n", new);
@@ -279,7 +279,7 @@ PHPDBG_HELP(aliases) /* {{{ */
 	int len;
 
 	/* Print out aliases for all commands except help as this one comes last */
-	phpdbg_writeln("help", "", "Below are the aliased, short versions of all supported commands");
+	phpdbg_writeln("Below are the aliased, short versions of all supported commands");
 
 	for(c = phpdbg_prompt_commands; c->name; c++) {
 		if (c->alias && c->alias != 'h') {

--- a/sapi/phpdbg/phpdbg_info.c
+++ b/sapi/phpdbg/phpdbg_info.c
@@ -83,7 +83,10 @@ PHPDBG_INFO(error) /* {{{ */
 {
 	if (PG(last_error_message)) {
 		phpdbg_try_access {
-			phpdbg_writeln("Last error: %s at %s line %d", PG(last_error_message), ZSTR_VAL(PG(last_error_file)), PG(last_error_lineno));
+			phpdbg_writeln("Last error: %s at %s line %d",
+			    ZSTR_VAL(PG(last_error_message)),
+			    ZSTR_VAL(PG(last_error_file)),
+			    PG(last_error_lineno));
 		} phpdbg_catch_access {
 			phpdbg_notice("No error found!");
 		} phpdbg_end_try_access();
@@ -140,7 +143,7 @@ PHPDBG_INFO(constants) /* {{{ */
 					VARIABLEINFO("\nbool (false)");
 					break;
 				case IS_LONG:
-					VARIABLEINFO("\nint (%ld)", Z_LVAL(data->value));
+					VARIABLEINFO("\nint ("ZEND_LONG_FMT")", Z_LVAL(data->value));
 					break;
 				case IS_DOUBLE:
 					VARIABLEINFO("\ndouble (%lf)", Z_DVAL(data->value));
@@ -261,7 +264,7 @@ retry_switch:
 						VARIABLEINFO("\nbool (false)");
 						break;
 					case IS_LONG:
-						VARIABLEINFO("\nint (%ld)", Z_LVAL_P(data));
+						VARIABLEINFO("\nint ("ZEND_LONG_FMT")", Z_LVAL_P(data));
 						break;
 					case IS_DOUBLE:
 						VARIABLEINFO("\ndouble (%lf)", Z_DVAL_P(data));

--- a/sapi/phpdbg/phpdbg_opcode.c
+++ b/sapi/phpdbg/phpdbg_opcode.c
@@ -162,7 +162,7 @@ void phpdbg_print_opline_ex(zend_execute_data *execute_data, bool ignore_flags) 
 		}
 
 		if (!ignore_flags && PHPDBG_G(oplog)) {
-			phpdbg_log_ex(fileno(PHPDBG_G(oplog)), "L%-5u %16p %s %s\n",
+			phpdbg_log_internal(fileno(PHPDBG_G(oplog)), "L%-5u %16p %s %s\n",
 				opline->lineno,
 				opline,
 				decode,

--- a/sapi/phpdbg/phpdbg_out.c
+++ b/sapi/phpdbg/phpdbg_out.c
@@ -81,7 +81,7 @@ static int phpdbg_process_print(int fd, int type, const char *msg, int msglen) {
 
 		case P_WRITE:
 			if (msg) {
-				msgout = strndup(msg, msglen);
+				msgout = pestrndup(msg, msglen, 1);
 				msgoutlen = msglen;
 				PHPDBG_G(last_was_newline) = msg[msglen - 1] == '\n';
 			} else {

--- a/sapi/phpdbg/phpdbg_out.c
+++ b/sapi/phpdbg/phpdbg_out.c
@@ -29,795 +29,12 @@
 
 ZEND_EXTERN_MODULE_GLOBALS(phpdbg)
 
-/* copied from php-src/main/snprintf.c and slightly modified */
-/*
- * NUM_BUF_SIZE is the size of the buffer used for arithmetic conversions
- *
- * XXX: this is a magic number; do not decrease it
- * Emax = 1023
- * NDIG = 320
- * NUM_BUF_SIZE >= strlen("-") + Emax + strlen(".") + NDIG + strlen("E+1023") + 1;
- */
-#define NUM_BUF_SIZE        2048
-
-/*
- * Descriptor for buffer area
- */
-struct buf_area {
-	char *buf_end;
-	char *nextb; /* pointer to next byte to read/write   */
-};
-
-typedef struct buf_area buffy;
-
-/*
- * The INS_CHAR macro inserts a character in the buffer and writes
- * the buffer back to disk if necessary
- * It uses the char pointers sp and bep:
- *      sp points to the next available character in the buffer
- *      bep points to the end-of-buffer+1
- * While using this macro, note that the nextb pointer is NOT updated.
- *
- * NOTE: Evaluation of the c argument should not have any side-effects
- */
-#define INS_CHAR(c, sp, bep, cc) \
-	{                            \
-		if (sp < bep)            \
-		{                        \
-			*sp++ = c;           \
-		}                        \
-		cc++;                    \
-	}
-
-#define NUM( c )			( c - '0' )
-
-#define STR_TO_DEC( str, num )		\
-    num = NUM( *str++ ) ;		\
-    while ( isdigit((int)*str ) )		\
-    {					\
-	num *= 10 ;			\
-	num += NUM( *str++ ) ;		\
-    }
-
-/*
- * This macro does zero padding so that the precision
- * requirement is satisfied. The padding is done by
- * adding '0's to the left of the string that is going
- * to be printed.
- */
-#define FIX_PRECISION( adjust, precision, s, s_len )	\
-    if ( adjust )					\
-	while ( s_len < precision )			\
-	{						\
-	    *--s = '0' ;				\
-	    s_len++ ;					\
-	}
-
-/*
- * Macro that does padding. The padding is done by printing
- * the character ch.
- */
-#define PAD( width, len, ch )	do		\
-	{					\
-	    INS_CHAR( ch, sp, bep, cc ) ;	\
-	    width-- ;				\
-	}					\
-	while ( width > len )
-
-/*
- * Prefix the character ch to the string str
- * Increase length
- * Set the has_prefix flag
- */
-#define PREFIX( str, length, ch )	 *--str = ch ; length++ ; has_prefix = YES
-
-#include <locale.h>
-#define LCONV_DECIMAL_POINT (*lconv->decimal_point)
-#define NUL '\0'
-#define S_NULL "(null)"
-#define S_NULL_LEN 6
-#define FLOAT_DIGITS 6
-
-/*
- * Do format conversion placing the output in buffer
- */
-static int format_converter(register buffy *odp, const char *fmt, va_list ap) {
-	char *sp;
-	char *bep;
-	int cc = 0;
-	int i;
-
-	char *s = NULL, *free_s = NULL;
-	size_t s_len;
-
-	int min_width = 0;
-	int precision = 0;
-	enum {
-		LEFT, RIGHT
-	} adjust;
-	char pad_char;
-	char prefix_char;
-
-	double fp_num;
-	wide_int i_num = (wide_int) 0;
-	u_wide_int ui_num;
-
-	char num_buf[NUM_BUF_SIZE];
-	char char_buf[2];			/* for printing %% and %<unknown> */
-
-	struct lconv *lconv = NULL;
-
-	/*
-	 * Flag variables
-	 */
-	length_modifier_e modifier;
-	boolean_e alternate_form;
-	boolean_e print_sign;
-	boolean_e print_blank;
-	boolean_e adjust_precision;
-	boolean_e adjust_width;
-	bool_int is_negative;
-
-	sp = odp->nextb;
-	bep = odp->buf_end;
-
-	while (*fmt) {
-		if (*fmt != '%') {
-			INS_CHAR(*fmt, sp, bep, cc);
-		} else {
-			/*
-			 * Default variable settings
-			 */
-			zend_string *tmp_str = NULL;
-			adjust = RIGHT;
-			alternate_form = print_sign = print_blank = NO;
-			pad_char = ' ';
-			prefix_char = NUL;
-
-			fmt++;
-
-			/*
-			 * Try to avoid checking for flags, width or precision
-			 */
-			if (isascii((int)*fmt) && !islower((int)*fmt)) {
-				/*
-				 * Recognize flags: -, #, BLANK, +
-				 */
-				for (;; fmt++) {
-					if (*fmt == '-')
-						adjust = LEFT;
-					else if (*fmt == '+')
-						print_sign = YES;
-					else if (*fmt == '#')
-						alternate_form = YES;
-					else if (*fmt == ' ')
-						print_blank = YES;
-					else if (*fmt == '0')
-						pad_char = '0';
-					else
-						break;
-				}
-
-				/*
-				 * Check if a width was specified
-				 */
-				if (isdigit((int)*fmt)) {
-					STR_TO_DEC(fmt, min_width);
-					adjust_width = YES;
-				} else if (*fmt == '*') {
-					min_width = va_arg(ap, int);
-					fmt++;
-					adjust_width = YES;
-					if (min_width < 0) {
-						adjust = LEFT;
-						min_width = -min_width;
-					}
-				} else
-					adjust_width = NO;
-
-				/*
-				 * Check if a precision was specified
-				 */
-				if (*fmt == '.') {
-					adjust_precision = YES;
-					fmt++;
-					if (isdigit((int)*fmt)) {
-						STR_TO_DEC(fmt, precision);
-					} else if (*fmt == '*') {
-						precision = va_arg(ap, int);
-						fmt++;
-						if (precision < 0)
-							precision = 0;
-					} else
-						precision = 0;
-
-					if (precision > FORMAT_CONV_MAX_PRECISION && *fmt != 's' && *fmt != 'v' && *fmt != 'b') {
-						precision = FORMAT_CONV_MAX_PRECISION;
-					}
-				} else
-					adjust_precision = NO;
-			} else
-				adjust_precision = adjust_width = NO;
-
-			/*
-			 * Modifier check
-			 */
-			switch (*fmt) {
-				case 'L':
-					fmt++;
-					modifier = LM_LONG_DOUBLE;
-					break;
-				case 'I':
-					fmt++;
-#if SIZEOF_LONG_LONG
-					if (*fmt == '6' && *(fmt+1) == '4') {
-						fmt += 2;
-						modifier = LM_LONG_LONG;
-					} else
-#endif
-						if (*fmt == '3' && *(fmt+1) == '2') {
-							fmt += 2;
-							modifier = LM_LONG;
-						} else {
-#ifdef _WIN64
-							modifier = LM_LONG_LONG;
-#else
-							modifier = LM_LONG;
-#endif
-						}
-					break;
-				case 'l':
-					fmt++;
-#if SIZEOF_LONG_LONG
-					if (*fmt == 'l') {
-						fmt++;
-						modifier = LM_LONG_LONG;
-					} else
-#endif
-						modifier = LM_LONG;
-					break;
-					case 'z':
-					fmt++;
-					modifier = LM_SIZE_T;
-					break;
-				case 'j':
-					fmt++;
-#if SIZEOF_INTMAX_T
-					modifier = LM_INTMAX_T;
-#else
-					modifier = LM_SIZE_T;
-#endif
-					break;
-				case 't':
-					fmt++;
-#if SIZEOF_PTRDIFF_T
-					modifier = LM_PTRDIFF_T;
-#else
-					modifier = LM_SIZE_T;
-#endif
-					break;
-				case 'h':
-					fmt++;
-					if (*fmt == 'h') {
-						fmt++;
-					}
-					/* these are promoted to int, so no break */
-					ZEND_FALLTHROUGH;
-				default:
-					modifier = LM_STD;
-					break;
-			}
-
-			/*
-			 * Argument extraction and printing.
-			 * First we determine the argument type.
-			 * Then, we convert the argument to a string.
-			 * On exit from the switch, s points to the string that
-			 * must be printed, s_len has the length of the string
-			 * The precision requirements, if any, are reflected in s_len.
-			 *
-			 * NOTE: pad_char may be set to '0' because of the 0 flag.
-			 *   It is reset to ' ' by non-numeric formats
-			 */
-			switch (*fmt) {
-				case 'Z': {
-					zval *zvp = va_arg(ap, zval *);
-					zend_string *str = zval_get_tmp_string(zvp, &tmp_str);
-					s_len = ZSTR_LEN(str);
-					s = ZSTR_VAL(str);
-					if (adjust_precision && precision < s_len) {
-						s_len = precision;
-					}
-					break;
-				}
-				case 'u':
-					switch(modifier) {
-						default:
-							i_num = (wide_int) va_arg(ap, unsigned int);
-							break;
-						case LM_LONG_DOUBLE:
-							goto fmt_error;
-						case LM_LONG:
-							i_num = (wide_int) va_arg(ap, unsigned long int);
-							break;
-						case LM_SIZE_T:
-							i_num = (wide_int) va_arg(ap, size_t);
-							break;
-#if SIZEOF_LONG_LONG
-						case LM_LONG_LONG:
-							i_num = (wide_int) va_arg(ap, u_wide_int);
-							break;
-#endif
-#if SIZEOF_INTMAX_T
-						case LM_INTMAX_T:
-							i_num = (wide_int) va_arg(ap, uintmax_t);
-							break;
-#endif
-#if SIZEOF_PTRDIFF_T
-						case LM_PTRDIFF_T:
-							i_num = (wide_int) va_arg(ap, ptrdiff_t);
-							break;
-#endif
-					}
-					/*
-					 * The rest also applies to other integer formats, so fall
-					 * into that case.
-					 */
-					ZEND_FALLTHROUGH;
-				case 'd':
-				case 'i':
-					/*
-					 * Get the arg if we haven't already.
-					 */
-					if ((*fmt) != 'u') {
-						switch(modifier) {
-							default:
-								i_num = (wide_int) va_arg(ap, int);
-								break;
-							case LM_LONG_DOUBLE:
-								goto fmt_error;
-							case LM_LONG:
-								i_num = (wide_int) va_arg(ap, long int);
-								break;
-							case LM_SIZE_T:
-#if SIZEOF_SSIZE_T
-								i_num = (wide_int) va_arg(ap, ssize_t);
-#else
-								i_num = (wide_int) va_arg(ap, size_t);
-#endif
-								break;
-#if SIZEOF_LONG_LONG
-							case LM_LONG_LONG:
-								i_num = (wide_int) va_arg(ap, wide_int);
-								break;
-#endif
-#if SIZEOF_INTMAX_T
-							case LM_INTMAX_T:
-								i_num = (wide_int) va_arg(ap, intmax_t);
-								break;
-#endif
-#if SIZEOF_PTRDIFF_T
-							case LM_PTRDIFF_T:
-								i_num = (wide_int) va_arg(ap, ptrdiff_t);
-								break;
-#endif
-						}
-					}
-					s = ap_php_conv_10(i_num, (*fmt) == 'u', &is_negative,
-								&num_buf[NUM_BUF_SIZE], &s_len);
-					FIX_PRECISION(adjust_precision, precision, s, s_len);
-
-					if (*fmt != 'u') {
-						if (is_negative) {
-							prefix_char = '-';
-						} else if (print_sign) {
-							prefix_char = '+';
-						} else if (print_blank) {
-							prefix_char = ' ';
-						}
-					}
-					break;
-
-
-				case 'o':
-					switch(modifier) {
-						default:
-							ui_num = (u_wide_int) va_arg(ap, unsigned int);
-							break;
-						case LM_LONG_DOUBLE:
-							goto fmt_error;
-						case LM_LONG:
-							ui_num = (u_wide_int) va_arg(ap, unsigned long int);
-							break;
-						case LM_SIZE_T:
-							ui_num = (u_wide_int) va_arg(ap, size_t);
-							break;
-#if SIZEOF_LONG_LONG
-						case LM_LONG_LONG:
-							ui_num = (u_wide_int) va_arg(ap, u_wide_int);
-							break;
-#endif
-#if SIZEOF_INTMAX_T
-						case LM_INTMAX_T:
-							ui_num = (u_wide_int) va_arg(ap, uintmax_t);
-							break;
-#endif
-#if SIZEOF_PTRDIFF_T
-						case LM_PTRDIFF_T:
-							ui_num = (u_wide_int) va_arg(ap, ptrdiff_t);
-							break;
-#endif
-					}
-					s = ap_php_conv_p2(ui_num, 3, *fmt, &num_buf[NUM_BUF_SIZE], &s_len);
-					FIX_PRECISION(adjust_precision, precision, s, s_len);
-					if (alternate_form && *s != '0') {
-						*--s = '0';
-						s_len++;
-					}
-					break;
-
-
-				case 'x':
-				case 'X':
-					switch(modifier) {
-						default:
-							ui_num = (u_wide_int) va_arg(ap, unsigned int);
-							break;
-						case LM_LONG_DOUBLE:
-							goto fmt_error;
-						case LM_LONG:
-							ui_num = (u_wide_int) va_arg(ap, unsigned long int);
-							break;
-						case LM_SIZE_T:
-							ui_num = (u_wide_int) va_arg(ap, size_t);
-							break;
-#if SIZEOF_LONG_LONG
-						case LM_LONG_LONG:
-							ui_num = (u_wide_int) va_arg(ap, u_wide_int);
-							break;
-#endif
-#if SIZEOF_INTMAX_T
-						case LM_INTMAX_T:
-							ui_num = (u_wide_int) va_arg(ap, uintmax_t);
-							break;
-#endif
-#if SIZEOF_PTRDIFF_T
-						case LM_PTRDIFF_T:
-							ui_num = (u_wide_int) va_arg(ap, ptrdiff_t);
-							break;
-#endif
-					}
-					s = ap_php_conv_p2(ui_num, 4, *fmt, &num_buf[NUM_BUF_SIZE], &s_len);
-					FIX_PRECISION(adjust_precision, precision, s, s_len);
-					if (alternate_form && i_num != 0) {
-						*--s = *fmt;	/* 'x' or 'X' */
-						*--s = '0';
-						s_len += 2;
-					}
-					break;
-
-
-				case 's':
-				case 'v':
-					s = va_arg(ap, char *);
-					if (s != NULL) {
-						if (adjust_precision) {
-							s_len = precision;
-						} else {
-							s_len = strlen(s);
-						}
-					} else {
-						s = S_NULL;
-						s_len = S_NULL_LEN;
-					}
-					pad_char = ' ';
-					break;
-
-
-				case 'b':
-				    s = PHPDBG_G(err_buf).msg;
-					if (s != NULL) {
-						s_len = PHPDBG_G(err_buf).msglen;
-
-						if (adjust_precision && precision != s_len) {
-							s_len = precision;
-						}
-					} else {
-						s = "";
-						s_len = 0;
-					}
-					pad_char = ' ';
-					break;
-
-
-				case 'r':
-					if (PHPDBG_G(req_id)) {
-						s_len = spprintf(&s, 0, "req=\"" ZEND_ULONG_FMT "\"", PHPDBG_G(req_id));
-						free_s = s;
-					} else {
-						s = "";
-						s_len = 0;
-					}
-					break;
-
-
-				case 'f':
-				case 'F':
-				case 'e':
-				case 'E':
-
-					switch(modifier) {
-						case LM_LONG_DOUBLE:
-							fp_num = (double) va_arg(ap, long double);
-							break;
-						case LM_STD:
-							fp_num = va_arg(ap, double);
-							break;
-						default:
-							goto fmt_error;
-					}
-
-					if (zend_isnan(fp_num)) {
-						s = "NAN";
-						s_len = 3;
-					} else if (zend_isinf(fp_num)) {
-						s = "INF";
-						s_len = 3;
-					} else {
-						if (!lconv) {
-							lconv = localeconv();
-						}
-
-						s = php_conv_fp((*fmt == 'f')?'F':*fmt, fp_num, alternate_form,
-						 (adjust_precision == NO) ? FLOAT_DIGITS : precision,
-						 (*fmt == 'f')?LCONV_DECIMAL_POINT:'.',
-									&is_negative, &num_buf[1], &s_len);
-						if (is_negative)
-							prefix_char = '-';
-						else if (print_sign)
-							prefix_char = '+';
-						else if (print_blank)
-							prefix_char = ' ';
-					}
-					break;
-
-
-				case 'g':
-				case 'k':
-				case 'G':
-				case 'H':
-					switch(modifier) {
-						case LM_LONG_DOUBLE:
-							fp_num = (double) va_arg(ap, long double);
-							break;
-						case LM_STD:
-							fp_num = va_arg(ap, double);
-							break;
-						default:
-							goto fmt_error;
-					}
-
-					if (zend_isnan(fp_num)) {
-						s = "NAN";
-						s_len = 3;
-						break;
-					} else if (zend_isinf(fp_num)) {
-						if (fp_num > 0) {
-							s = "INF";
-							s_len = 3;
-						} else {
-							s = "-INF";
-							s_len = 4;
-						}
-						break;
-					}
-
-					if (adjust_precision == NO) {
-						precision = FLOAT_DIGITS;
-					} else if (precision == 0) {
-						precision = 1;
-					}
-					/*
-					 * * We use &num_buf[ 1 ], so that we have room for the sign
-					 */
-					if (!lconv) {
-						lconv = localeconv();
-					}
-
-					s = php_gcvt(fp_num, precision, (*fmt=='H' || *fmt == 'k') ? '.' : LCONV_DECIMAL_POINT, (*fmt == 'G' || *fmt == 'H')?'E':'e', &num_buf[1]);
-					if (*s == '-') {
-						prefix_char = *s++;
-					} else if (print_sign) {
-						prefix_char = '+';
-					} else if (print_blank) {
-						prefix_char = ' ';
-					}
-
-					s_len = strlen(s);
-
-					if (alternate_form && (strchr(s, '.')) == NULL) {
-						s[s_len++] = '.';
-					}
-					break;
-
-
-				case 'c':
-					char_buf[0] = (char) (va_arg(ap, int));
-					s = &char_buf[0];
-					s_len = 1;
-					pad_char = ' ';
-					break;
-
-
-				case '%':
-					char_buf[0] = '%';
-					s = &char_buf[0];
-					s_len = 1;
-					pad_char = ' ';
-					break;
-
-
-				case 'n':
-					*(va_arg(ap, int *)) = cc;
-					goto skip_output;
-
-					/*
-					 * Always extract the argument as a "char *" pointer. We
-					 * should be using "void *" but there are still machines
-					 * that don't understand it.
-					 * If the pointer size is equal to the size of an unsigned
-					 * integer we convert the pointer to a hex number, otherwise
-					 * we print "%p" to indicate that we don't handle "%p".
-					 */
-				case 'p':
-					if (sizeof(char *) <= sizeof(u_wide_int)) {
-						ui_num = (u_wide_int)((size_t) va_arg(ap, char *));
-						s = ap_php_conv_p2(ui_num, 4, 'x',
-								&num_buf[NUM_BUF_SIZE], &s_len);
-						if (ui_num != 0) {
-							*--s = 'x';
-							*--s = '0';
-							s_len += 2;
-						}
-					} else {
-						s = "%p";
-						s_len = 2;
-					}
-					pad_char = ' ';
-					break;
-
-
-				case NUL:
-					/*
-					 * The last character of the format string was %.
-					 * We ignore it.
-					 */
-					continue;
-
-
-fmt_error:
-				php_error(E_ERROR, "Illegal length modifier specified '%c' in s[np]printf call", *fmt);
-					/*
-					 * The default case is for unrecognized %'s.
-					 * We print %<char> to help the user identify what
-					 * option is not understood.
-					 * This is also useful in case the user wants to pass
-					 * the output of format_converter to another function
-					 * that understands some other %<char> (like syslog).
-					 * Note that we can't point s inside fmt because the
-					 * unknown <char> could be preceded by width etc.
-					 */
-					ZEND_FALLTHROUGH;
-				default:
-					char_buf[0] = '%';
-					char_buf[1] = *fmt;
-					s = char_buf;
-					s_len = 2;
-					pad_char = ' ';
-					break;
-			}
-
-			if (prefix_char != NUL) {
-				*--s = prefix_char;
-				s_len++;
-			}
-			if (adjust_width && adjust == RIGHT && min_width > s_len) {
-				if (pad_char == '0' && prefix_char != NUL) {
-					INS_CHAR(*s, sp, bep, cc)
-						s++;
-					s_len--;
-					min_width--;
-				}
-				PAD(min_width, s_len, pad_char);
-			}
-			/*
-			 * Print the string s.
-			 */
-			for (i = s_len; i != 0; i--) {
-				INS_CHAR(*s, sp, bep, cc);
-				s++;
-			}
-
-			if (adjust_width && adjust == LEFT && min_width > s_len)
-				PAD(min_width, s_len, pad_char);
-			zend_tmp_string_release(tmp_str);
-		}
-skip_output:
-		if (free_s) {
-			efree(free_s);
-			free_s = NULL;
-		}
-
-		fmt++;
-	}
-	odp->nextb = sp;
-	return (cc);
-}
-
-static void strx_printv(int *ccp, char *buf, size_t len, const char *format, va_list ap) {
-	buffy od;
-	int cc;
-
-	/*
-	 * First initialize the descriptor
-	 * Notice that if no length is given, we initialize buf_end to the
-	 * highest possible address.
-	 */
-	if (len == 0) {
-		od.buf_end = (char *) ~0;
-		od.nextb   = (char *) ~0;
-	} else {
-		od.buf_end = &buf[len-1];
-		od.nextb   = buf;
-	}
-
-	/*
-	 * Do the conversion
-	 */
-	cc = format_converter(&od, format, ap);
-	if (len != 0 && od.nextb <= od.buf_end) {
-		*(od.nextb) = '\0';
-	}
-	if (ccp) {
-		*ccp = cc;
-	}
-}
-
-static int phpdbg_vsnprintf(char *buf, size_t len, const char *format, va_list ap) {
-	int cc;
-
-	strx_printv(&cc, buf, len, format, ap);
-	return (cc);
-}
-
-PHPDBG_API int phpdbg_vasprintf(char **buf, const char *format, va_list ap) {
-	va_list ap2;
-	int cc;
-
-	va_copy(ap2, ap);
-	cc = phpdbg_vsnprintf(NULL, 0, format, ap2);
-	va_end(ap2);
-
-	*buf = NULL;
-
-	if (cc >= 0) {
-		*buf = emalloc(++cc);
-		if ((cc = phpdbg_vsnprintf(*buf, cc, format, ap)) < 0) {
-			efree(*buf);
-			*buf = NULL;
-		}
-	}
-
-	return cc;
-}
-/* copy end */
-
 PHPDBG_API int _phpdbg_asprintf(char **buf, const char *format, ...) {
 	int ret;
 	va_list va;
 
 	va_start(va, format);
-	ret = phpdbg_vasprintf(buf, format, va);
+	ret = vasprintf(buf, format, va);
 	va_end(va);
 
 	return ret;
@@ -825,7 +42,7 @@ PHPDBG_API int _phpdbg_asprintf(char **buf, const char *format, ...) {
 
 static int phpdbg_process_print(int fd, int type, const char *msg, int msglen) {
 	char *msgout = NULL;
-	int msgoutlen;
+	int msgoutlen = FAILURE;
 
 	switch (type) {
 		case P_ERROR:
@@ -857,19 +74,19 @@ static int phpdbg_process_print(int fd, int type, const char *msg, int msglen) {
 				msgoutlen = phpdbg_asprintf(&msgout, "%.*s\n", msglen, msg);
 			} else {
 				msgoutlen = 1;
-				msgout = estrdup("\n");
+				msgout = strdup("\n");
 			}
 			PHPDBG_G(last_was_newline) = 1;
 			break;
 
 		case P_WRITE:
 			if (msg) {
-				msgout = estrndup(msg, msglen);
+				msgout = strndup(msg, msglen);
 				msgoutlen = msglen;
 				PHPDBG_G(last_was_newline) = msg[msglen - 1] == '\n';
 			} else {
 				msgoutlen = 0;
-				msgout = estrdup("");
+				msgout = strdup("");
 			}
 			break;
 
@@ -895,15 +112,12 @@ static int phpdbg_process_print(int fd, int type, const char *msg, int msglen) {
 		EMPTY_SWITCH_DEFAULT_CASE()
 	}
 
-	if (msgout) {
+	if (msgoutlen != FAILURE) {
 		phpdbg_mixed_write(fd, msgout, msgoutlen);
-	}
 
-	if (msgout) {
-		efree(msgout);
+		free(msgout);
 	}
-
-	return msgout ? msgoutlen : 0;
+	return msgoutlen;
 } /* }}} */
 
 PHPDBG_API int phpdbg_vprint(int type, int fd, const char *strfmt, va_list args) {
@@ -914,7 +128,7 @@ PHPDBG_API int phpdbg_vprint(int type, int fd, const char *strfmt, va_list args)
 
 	if (strfmt != NULL && strlen(strfmt) > 0L) {
 		va_copy(argcpy, args);
-		msglen = phpdbg_vasprintf(&msg, strfmt, argcpy);
+		msglen = vasprintf(&msg, strfmt, argcpy);
 		va_end(argcpy);
 	}
 
@@ -932,7 +146,7 @@ PHPDBG_API int phpdbg_vprint(int type, int fd, const char *strfmt, va_list args)
 	len = phpdbg_process_print(fd, type, msg, msglen);
 
 	if (msg) {
-		efree(msg);
+		free(msg);
 	}
 
 	return len;
@@ -943,7 +157,7 @@ PHPDBG_API void phpdbg_free_err_buf(void) {
 		return;
 	}
 
-	efree(PHPDBG_G(err_buf).msg);
+	free(PHPDBG_G(err_buf).msg);
 
 	PHPDBG_G(err_buf).type = 0;
 }
@@ -995,11 +209,11 @@ PHPDBG_API int phpdbg_log_internal(int fd, const char *fmt, ...) {
 	int len = 0;
 
 	va_start(args, fmt);
-	buflen = phpdbg_vasprintf(&buffer, fmt, args);
+	buflen = vasprintf(&buffer, fmt, args);
 	va_end(args);
 
 	len = phpdbg_mixed_write(fd, buffer, buflen);
-	efree(buffer);
+	free(buffer);
 
 	return len;
 }
@@ -1015,11 +229,11 @@ PHPDBG_API int phpdbg_out_internal(int fd, const char *fmt, ...) {
 	}
 
 	va_start(args, fmt);
-	buflen = phpdbg_vasprintf(&buffer, fmt, args);
+	buflen = vasprintf(&buffer, fmt, args);
 	va_end(args);
 
 	len = phpdbg_mixed_write(fd, buffer, buflen);
 
-	efree(buffer);
+	free(buffer);
 	return len;
 }

--- a/sapi/phpdbg/phpdbg_out.h
+++ b/sapi/phpdbg/phpdbg_out.h
@@ -32,38 +32,25 @@ enum {
 	P_LOG
 };
 
-/* phpdbg uses lots of custom format specifiers, so we disable format checks by default. */
-#if defined(PHPDBG_CHECK_FORMAT_STRINGS)
-# define PHPDBG_ATTRIBUTE_FORMAT(type, idx, first) PHP_ATTRIBUTE_FORMAT(type, idx, first)
-#else
-# define PHPDBG_ATTRIBUTE_FORMAT(type, idx, first)
-#endif
-
-PHPDBG_API int phpdbg_print(int severity, int fd, const char *strfmt, ...) PHPDBG_ATTRIBUTE_FORMAT(printf, 3, 4);
-PHPDBG_API int phpdbg_log_internal(int fd, const char *fmt, ...) PHPDBG_ATTRIBUTE_FORMAT(printf, 2, 3);
-PHPDBG_API int phpdbg_out_internal(int fd, const char *fmt, ...) PHPDBG_ATTRIBUTE_FORMAT(printf, 2, 3);
+PHPDBG_API int phpdbg_print(int severity, int fd, const char *strfmt, ...) PHP_ATTRIBUTE_FORMAT(printf, 3, 4);
+PHPDBG_API int phpdbg_log_internal(int fd, const char *fmt, ...) PHP_ATTRIBUTE_FORMAT(printf, 2, 3);
+PHPDBG_API int phpdbg_out_internal(int fd, const char *fmt, ...) PHP_ATTRIBUTE_FORMAT(printf, 2, 3);
 
 #define phpdbg_error(strfmt, ...)              phpdbg_print(P_ERROR  , PHPDBG_G(io)[PHPDBG_STDOUT].fd, strfmt, ##__VA_ARGS__)
 #define phpdbg_notice(strfmt, ...)             phpdbg_print(P_NOTICE , PHPDBG_G(io)[PHPDBG_STDOUT].fd, strfmt, ##__VA_ARGS__)
 #define phpdbg_writeln(strfmt, ...)            phpdbg_print(P_WRITELN, PHPDBG_G(io)[PHPDBG_STDOUT].fd, strfmt, ##__VA_ARGS__)
 #define phpdbg_write(strfmt, ...)              phpdbg_print(P_WRITE  , PHPDBG_G(io)[PHPDBG_STDOUT].fd, strfmt, ##__VA_ARGS__)
-#define phpdbg_script(type, strfmt, ...)       phpdbg_print(type     , PHPDBG_G(io)[PHPDBG_STDOUT].fd, strfmt, ##__VA_ARGS__)
-#define phpdbg_log(fmt, ...) phpdbg_log_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt, ##__VA_ARGS__)
-#define phpdbg_out(fmt, ...) phpdbg_out_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt, ##__VA_ARGS__)
 
-#define phpdbg_error_ex(out, strfmt, ...)         phpdbg_print(P_ERROR  , out, strfmt, ##__VA_ARGS__)
-#define phpdbg_notice_ex(out, trfmt, ...)         phpdbg_print(P_NOTICE , out, strfmt, ##__VA_ARGS__)
-#define phpdbg_writeln_ex(out, strfmt, ...)       phpdbg_print(P_WRITELN, out, strfmt, ##__VA_ARGS__)
-#define phpdbg_write_ex(out, strfmt, ...)         phpdbg_print(P_WRITE  , out, strfmt, ##__VA_ARGS__)
-#define phpdbg_script_ex(out, type, strfmt, ...)  phpdbg_print(type,      out, strfmt, ##__VA_ARGS__)
-#define phpdbg_log_ex(out, strfmt, ...) phpdbg_log_internal(out, strfmt, ##__VA_ARGS__)
-#define phpdbg_out_ex(out, strfmt, ...) phpdbg_out_internal(out, strfmt, ##__VA_ARGS__)
+#define phpdbg_log(fmt, ...)                   phpdbg_log_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt, ##__VA_ARGS__)
+#define phpdbg_out(fmt, ...)                   phpdbg_out_internal(PHPDBG_G(io)[PHPDBG_STDOUT].fd, fmt, ##__VA_ARGS__)
+
+#define phpdbg_script(type, strfmt, ...)       phpdbg_print(type,      PHPDBG_G(io)[PHPDBG_STDOUT].fd, strfmt, ##__VA_ARGS__)
 
 #define phpdbg_asprintf(buf, ...) _phpdbg_asprintf(buf, ##__VA_ARGS__)
 PHPDBG_API int _phpdbg_asprintf(char **buf, const char *format, ...);
 
 #if PHPDBG_DEBUG
-#	define phpdbg_debug(strfmt, ...) phpdbg_log_ex(PHPDBG_G(io)[PHPDBG_STDERR].fd, strfmt, ##__VA_ARGS__)
+#	define phpdbg_debug(strfmt, ...) phpdbg_log_internal(PHPDBG_G(io)[PHPDBG_STDERR].fd, strfmt, ##__VA_ARGS__)
 #else
 #	define phpdbg_debug(strfmt, ...)
 #endif

--- a/sapi/phpdbg/phpdbg_set.c
+++ b/sapi/phpdbg/phpdbg_set.c
@@ -79,7 +79,7 @@ PHPDBG_SET(pagination) /* {{{ */
 PHPDBG_SET(lines) /* {{{ */
 {
 	if (!param || param->type == EMPTY_PARAM) {
-		phpdbg_writeln("Lines %ld", PHPDBG_G(lines));
+		phpdbg_writeln("Lines "ZEND_ULONG_FMT, PHPDBG_G(lines));
 	} else switch (param->type) {
 		case NUMERIC_PARAM: {
 			PHPDBG_G(lines) = param->num;
@@ -105,9 +105,9 @@ PHPDBG_SET(break) /* {{{ */
 			} else {
 				phpdbg_breakbase_t *brake = phpdbg_find_breakbase(param->num);
 				if (brake) {
-					phpdbg_writeln("Breakpoint #%ld %s", param->num, brake->disabled ? "off" : "on");
+					phpdbg_writeln("Breakpoint #"ZEND_LONG_FMT" %s", param->num, brake->disabled ? "off" : "on");
 				} else {
-					phpdbg_error("Failed to find breakpoint #%ld", param->num);
+					phpdbg_error("Failed to find breakpoint #"ZEND_LONG_FMT, param->num);
 				}
 			}
 		} break;

--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -331,39 +331,39 @@ int phpdbg_rebuild_symtable(void) {
 	return SUCCESS;
 }
 
-PHPDBG_API int phpdbg_get_terminal_width(void) /* {{{ */
+PHPDBG_API uint32_t phpdbg_get_terminal_width(void) /* {{{ */
 {
-	int columns;
+	uint32_t columns;
 #ifdef _WIN32
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 
 	GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-	columns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+	columns = (uint32_t) csbi.srWindow.Right - csbi.srWindow.Left + 1;
 #elif defined(HAVE_SYS_IOCTL_H) && defined(TIOCGWINSZ)
 	struct winsize w;
 
-	columns = ioctl(fileno(stdout), TIOCGWINSZ, &w) == 0 ? w.ws_col : 80;
+	columns = (uint32_t) ioctl(fileno(stdout), TIOCGWINSZ, &w) == 0 ? w.ws_col : 80;
 #else
 	columns = 80;
 #endif
 	return columns;
 } /* }}} */
 
-PHPDBG_API int phpdbg_get_terminal_height(void) /* {{{ */
+PHPDBG_API uint32_t phpdbg_get_terminal_height(void) /* {{{ */
 {
-	int lines;
+	uint32_t lines;
 #ifdef _WIN32
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 
 	if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
-		lines = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+		lines = (uint32_t) csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
 	} else {
 		lines = 40;
 	}
 #elif defined(HAVE_SYS_IOCTL_H) && defined(TIOCGWINSZ)
 	struct winsize w;
 
-	lines = ioctl(fileno(stdout), TIOCGWINSZ, &w) == 0 ? w.ws_row : 40;
+	lines = (uint32_t) ioctl(fileno(stdout), TIOCGWINSZ, &w) == 0 ? w.ws_row : 40;
 #else
 	lines = 40;
 #endif
@@ -529,7 +529,7 @@ PHPDBG_API int phpdbg_parse_variable_with_arg(char *input, size_t len, HashTable
 			last_index[index_len] = 0;
 			if (!(zv = zend_symtable_str_find(parent, last_index, index_len))) {
 				if (!silent) {
-					phpdbg_error("%.*s is undefined", (int) input[i] == ']' ? i + 1 : i, input);
+					phpdbg_error("%.*s is undefined", (int) (input[i] == ']' ? i + 1 : i), input);
 				}
 				return FAILURE;
 			}

--- a/sapi/phpdbg/phpdbg_utils.h
+++ b/sapi/phpdbg/phpdbg_utils.h
@@ -72,8 +72,8 @@ PHPDBG_API void phpdbg_set_prompt(const char*);
 PHPDBG_API const char *phpdbg_get_prompt(void); /* }}} */
 
 /* {{{ Console size */
-PHPDBG_API int phpdbg_get_terminal_width(void);
-PHPDBG_API int phpdbg_get_terminal_height(void); /* }}} */
+PHPDBG_API uint32_t phpdbg_get_terminal_width(void);
+PHPDBG_API uint32_t phpdbg_get_terminal_height(void); /* }}} */
 
 PHPDBG_API void phpdbg_set_async_io(int fd);
 


### PR DESCRIPTION
This quickly turned into a nightmare ... phpdbg is using bad format specifiers everywhere, and we got no warnings about it because they were disabled because of special format specifiers that phpdbg implemented ....