### PR TITLE
Fix #81142: memory leak when unserialize()ing associative array

### DIFF
--- a/ext/standard/tests/serialize/bug81142.phpt
+++ b/ext/standard/tests/serialize/bug81142.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #81142 (memory leak when unserialize()ing associative array)
+--FILE--
+<?php
+$mem0 = memory_get_usage();
+$ctr = 0;
+unserialize(serialize(["foo_$ctr" => 1]));
+$mem1 = memory_get_usage();
+var_dump($mem1 - $mem0);
+?>
+--EXPECT--
+int(0)

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -947,7 +947,13 @@ use_double:
 	} else if (len == 1) {
 		ZVAL_INTERNED_STR(rval, ZSTR_CHAR((zend_uchar)*str));
 	} else if (as_key) {
-		ZVAL_STR(rval, zend_string_init_interned(str, len, 0));
+		zend_string *key = zend_string_init(str, len, 0);
+		zend_string *ikey = zend_interned_string_find_permanent(key);
+		if (ikey) {
+			zend_string_release(key);
+			key = ikey;
+		}
+		ZVAL_STR(rval, key);
 	} else {
 		ZVAL_STRINGL(rval, str, len);
 	}


### PR DESCRIPTION
We should not internalize unserialized array keys, because that easily
wastes a lot of memory for a small gain.  Instead, we check whether the
string is already internalized, and use that; otherwise we use a new
string.

This patch is based on an idea by @nikic.