### PR TITLE
Fix test in case fallocate(1) is available, but fails

### DIFF
--- a/ext/standard/tests/file/bug81145.phpt
+++ b/ext/standard/tests/file/bug81145.phpt
@@ -6,8 +6,11 @@ if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 if (PHP_INT_SIZE !== 8) die("skip this test is for 64bit platforms only");
 if (disk_free_space(__DIR__) < 0x220000000) die("skip insuffient disk space");
 if (PHP_OS_FAMILY !== "Windows") {
-    exec("fallocate -h", $output, $status);
-    if ($status !== 0) die("skip fallocate(1) not available");
+    $src = __DIR__ . "/bug81145_src.bin";
+    define('SIZE_4G', 0x100000000);
+    exec("fallocate -l " . (SIZE_4G-0x100) . " " . escapeshellarg($src), $output, $status);
+    if ($status !== 0) die("skip fallocate() not supported");
+    @unlink(__DIR__ . "/bug81145_src.bin");
 }
 ?>
 --FILE--


### PR DESCRIPTION
That happens on Travis s390x for whatever reasons.  Thus, instead of
checking for `fallocate -h`, we attempt the real allocation and skip if
that fails.

---

We might want to backport this to PHP-7.4. Targeting master to see whether that resolves the [Travis s390x fail](https://travis-ci.com/github/php/php-src/builds/229516977).