### PR TITLE
Fix bug 81111: Prevent serialization of anonymous classes

### DIFF
--- a/ext/standard/tests/serialize/bug81111.phpt
+++ b/ext/standard/tests/serialize/bug81111.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Bug #81111 ()
+--FILE--
+<?php
+
+function check_serialize_throws($obj) {
+    try {
+        var_dump(serialize($obj));
+    } catch (Throwable $e) {
+        echo "Caught: " . get_class($e) . "\n";
+        echo "Message: " . $e->getMessage() . "\n";
+    }
+}
+
+function make_alias($obj) {
+    class_alias(get_class($obj), 'SomeAlias');
+    return new SomeAlias();
+}
+
+echo "Case 1: anonymous class\n";
+check_serialize_throws(new class () {});
+
+echo "\n";
+echo "Case 2: anonymous class with __serialize\n";
+check_serialize_throws(new class () {
+    public function __serialize() { return []; }
+    public function __unserialize($value) { }
+});
+
+echo "\n";
+echo "Case 3: anonymous class with Serializable\n";
+check_serialize_throws(new class () implements Serializable {
+    public function serialize() { return ''; }
+    public function unserialize(string $ser) { return new self(); }
+});
+
+echo "\n";
+echo "Case 4: aliased anonymous class with __serialize\n";
+$alias = make_alias(new class() {
+    public function __serialize() { return []; }
+});
+check_serialize_throws($alias);
+
+?>
+--EXPECTF--
+Case 1: anonymous class
+Caught: Exception
+Message: Serialization of 'class@anonymous' is not allowed
+
+Case 2: anonymous class with __serialize
+Caught: Exception
+Message: Serialization of 'class@anonymous' is not allowed
+
+Case 3: anonymous class with Serializable
+
+Deprecated: The Serializable interface is deprecated. %s
+Caught: Exception
+Message: Serialization of 'Serializable@anonymous' is not allowed
+
+Case 4: aliased anonymous class with __serialize
+Caught: Exception
+Message: Serialization of 'class@anonymous' is not allowed

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -23,6 +23,7 @@
 #include "php.h"
 #include "php_string.h"
 #include "php_var.h"
+#include "zend_interfaces.h"
 #include "zend_smart_str.h"
 #include "basic_functions.h"
 #include "php_incomplete_class.h"
@@ -1075,7 +1076,7 @@ again:
 					return;
 				}
 
-				if (ce->__serialize) {
+				if (ce->__serialize && ce->serialize != zend_class_serialize_deny) {
 					zval retval, obj;
 					zend_string *key;
 					zval *data;


### PR DESCRIPTION
This is a pretty basic solution for preventing `__serialize` on anonymous classes for [bug 81111](https://bugs.php.net/bug.php?id=81111).

It's probably not very elegant though...

This has the side effect of ignoring `__serialize` for classes that extend internal classes that use `zend_class_serialize_deny`. For example,
```php
class Something extends CURLFile {
    public function __serialize() { return []; }
    public function __unserialize($value) { return new self('file'); }
}
var_dump(serialize(new Something('file')));
// Fatal error: Uncaught Exception: Serialization of 'Something' is not allowed
```

That seems like its better than allowing serialization. However, using `__unserialize` for a class that extends an internal class is still possible:
```php
var_dump(unserialize('O:9:"Something":0:{}'));
// object(Something)#2 (3) {
//  ["name"]=>
//  string(0) ""
//  ["mime"]=>
//  string(0) ""
//  ["postname"]=>
//  string(0) ""
//}
```