### PR TITLE
Allow build/gen_stub.php to have extended&non-standard phpdoc types

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1462,9 +1462,17 @@ function parseFunctionLike(
                 } else if ($tag->name === 'tentative-return-type') {
                     $tentativeReturnType = true;
                 } else if ($tag->name === 'return') {
-                    $docReturnType = $tag->getType();
+                    try {
+                        $docReturnType = $tag->getType();
+                    } catch (Exception $e) {
+                        printf("Warning: Invalid return type in phpdoc '%s' of function/method %s: %s\n", $tag->getValue(), $name, $e->getMessage());
+                    }
                 } else if ($tag->name === 'param') {
-                    $docParamTypes[$tag->getVariableName()] = $tag->getType();
+                    try {
+                        $docParamTypes[$tag->getVariableName()] = $tag->getType();
+                    } catch (Exception $e) {
+                        printf("Warning: Invalid param type in phpdoc '%s' of function/method %s: %s\n", $tag->getValue(), $name, $e->getMessage());
+                    }
                 }
             }
         }


### PR DESCRIPTION
(when the real type already exists, because the real type is always used instead)
If there is no real type and no valid phpdoc type, then param/return types of
methods will continue to be errors.

This allows stub authors to write stubs that can also be read as documentation
of what the function is doing. (e.g. `int[]`, `Closure(mixed):bool`, etc)

```php
/**
 * @param iterable $iterable
 * @param Closure(mixed):bool $callback
 * @return bool
 */
public function filter(iterable $iterable, Closure $callback): bool {}
```