### PR TITLE
Add host for php_network_getaddresses getaddrinfo failed error message.

### DIFF
--- a/ext/ftp/tests/ftp_ssl_connect_error.phpt
+++ b/ext/ftp/tests/ftp_ssl_connect_error.phpt
@@ -27,7 +27,7 @@ echo "===DONE===\n";
 
 -- Testing ftp_ssl_connect() function on failure --
 
-Warning: ftp_ssl_connect(): php_network_getaddresses: getaddrinfo failed: %s in %s on line %d
+Warning: ftp_ssl_connect(): php_network_getaddresses: getaddrinfo for %s failed: %s in %s on line %d
 bool(false)
 
 -- Testing ftp_ssl_connect() function timeout exception for value 0 --

--- a/ext/standard/tests/network/bindto.phpt
+++ b/ext/standard/tests/network/bindto.phpt
@@ -13,6 +13,6 @@ $fp = stream_socket_client(
 );
 ?>
 --EXPECTF--
-Warning: stream_socket_client(): php_network_getaddresses: getaddrinfo failed: %s in %s on line %d
+Warning: stream_socket_client(): php_network_getaddresses: getaddrinfo for www.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.com failed: %s in %s on line %d
 
-Warning: stream_socket_client(): Unable to connect to tcp://www.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.com:80 (php_network_getaddresses: getaddrinfo failed: %s) in %s on line %d
+Warning: stream_socket_client(): Unable to connect to tcp://www.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.com:80 (php_network_getaddresses: getaddrinfo for %s failed: %s) in %s on line %d

--- a/main/network.c
+++ b/main/network.c
@@ -201,10 +201,10 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
 			if (*error_string) {
 				zend_string_release_ex(*error_string, 0);
 			}
-			*error_string = strpprintf(0, "php_network_getaddresses: getaddrinfo failed: %s", PHP_GAI_STRERROR(n));
+			*error_string = strpprintf(0, "php_network_getaddresses: getaddrinfo for %s failed: %s", host, PHP_GAI_STRERROR(n));
 			php_error_docref(NULL, E_WARNING, "%s", ZSTR_VAL(*error_string));
 		} else {
-			php_error_docref(NULL, E_WARNING, "php_network_getaddresses: getaddrinfo failed: %s", PHP_GAI_STRERROR(n));
+			php_error_docref(NULL, E_WARNING, "php_network_getaddresses: getaddrinfo for %s failed: %s", host, PHP_GAI_STRERROR(n));
 		}
 		return 0;
 	} else if (res == NULL) {
@@ -213,10 +213,10 @@ PHPAPI int php_network_getaddresses(const char *host, int socktype, struct socka
 			if (*error_string) {
 				zend_string_release_ex(*error_string, 0);
 			}
-			*error_string = strpprintf(0, "php_network_getaddresses: getaddrinfo failed (null result pointer) errno=%d", errno);
+			*error_string = strpprintf(0, "php_network_getaddresses: getaddrinfo for %s failed (null result pointer) errno=%d", host, errno);
 			php_error_docref(NULL, E_WARNING, "%s", ZSTR_VAL(*error_string));
 		} else {
-			php_error_docref(NULL, E_WARNING, "php_network_getaddresses: getaddrinfo failed (null result pointer)");
+			php_error_docref(NULL, E_WARNING, "php_network_getaddresses: getaddrinfo for %s failed (null result pointer)", host);
 		}
 		return 0;
 	}


### PR DESCRIPTION
Based on https://twitter.com/greg0ire/status/1407039981328216067 I was thinking we could change this error message to include the failed host.

The modified tests with the 100 char length hostname might be an indicator for why its not the greatest idea, but on average hostnames are probably much shorter.

Is there a reason why its not included in the message? Security does not seem to be a problem, as host would not contain anything security related and displaying errors is already a security problem.

I checked a bit back in the commit history, the message has been this way forever (got back to 2003).