### PR TITLE
make new API public

### DIFF
--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -89,7 +89,7 @@ static uint32_t crc32_aarch64(uint32_t crc, char *p, size_t nr) {
 # endif
 #endif
 
-uint32_t crc32_bulk_update(uint32_t crc, const char *p, size_t nr)
+PHPAPI uint32_t crc32_bulk_update(uint32_t crc, const char *p, size_t nr)
 {
 #if HAVE_AARCH64_CRC32
 	if (has_crc32_insn()) {
@@ -112,7 +112,7 @@ uint32_t crc32_bulk_update(uint32_t crc, const char *p, size_t nr)
 	return crc;
 }
 
-int crc32_stream_bulk_update(uint32_t *crc, php_stream *fp, size_t nr)
+PHPAPI int crc32_stream_bulk_update(uint32_t *crc, php_stream *fp, size_t nr)
 {
 	size_t handled = 0, n;
 	char buf[1024];

--- a/ext/standard/crc32.h
+++ b/ext/standard/crc32.h
@@ -23,10 +23,10 @@
 
 #define CRC32(crc, ch)	 (crc = (crc >> 8) ^ crc32tab[(crc ^ (ch)) & 0xff])
 
-uint32_t crc32_bulk_update(uint32_t crc, const char *p, size_t nr);
+PHPAPI uint32_t crc32_bulk_update(uint32_t crc, const char *p, size_t nr);
 
 /* Return FAILURE if stream reading fail */
-int crc32_stream_bulk_update(uint32_t *crc, php_stream *fp, size_t nr);
+PHPAPI int crc32_stream_bulk_update(uint32_t *crc, php_stream *fp, size_t nr);
 
 /* generated using the AUTODIN II polynomial
  *	x^32 + x^26 + x^23 + x^22 + x^16 +


### PR DESCRIPTION
As used in some extension, need to be public.
`
Warning: PHP Startup: Unable to load dynamic library 'phar.so' (tried: /builddir/build/BUILD/php-8.1.0alpha2/build-cgi/modules/phar.so (/builddir/build/BUILD/php-8.1.0alpha2/build-cgi/modules/phar.so: undefined symbol: crc32_stream_bulk_update), /builddir/build/BUILD/php-8.1.0alpha2/build-cgi/modules/phar.so.so (/builddir/build/BUILD/php-8.1.0alpha2/build-cgi/modules/phar.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
`