### PR TITLE
Fix #74264: grapheme_sttrpos() broken for negative offsets

### DIFF
--- a/ext/intl/grapheme/grapheme_util.c
+++ b/ext/intl/grapheme/grapheme_util.c
@@ -133,7 +133,7 @@ void grapheme_substr_ascii(char *str, size_t str_len, int32_t f, int32_t l, char
 int32_t grapheme_strpos_utf16(char *haystack, size_t haystack_len, char *needle, size_t needle_len, int32_t offset, int32_t *puchar_pos, int f_ignore_case, int last)
 {
 	UChar *uhaystack = NULL, *uneedle = NULL;
-	int32_t uhaystack_len = 0, uneedle_len = 0, char_pos, ret_pos, offset_pos = 0, prev_pos = USEARCH_DONE;
+	int32_t uhaystack_len = 0, uneedle_len = 0, char_pos, ret_pos, offset_pos = 0;
 	unsigned char u_break_iterator_buffer[U_BRK_SAFECLONE_BUFFERSIZE];
 	UBreakIterator* bi = NULL;
 	UErrorCode status;
@@ -193,6 +193,7 @@ int32_t grapheme_strpos_utf16(char *haystack, size_t haystack_len, char *needle,
 			}			
 		} else {
 			/* searching backwards is broken, so we search forwards, albeit it's less efficient */
+			int32_t prev_pos = USEARCH_DONE;
 			do {
 				char_pos = usearch_next(src, &status);
 				if (char_pos == USEARCH_DONE || char_pos > offset_pos) {

--- a/ext/intl/grapheme/grapheme_util.c
+++ b/ext/intl/grapheme/grapheme_util.c
@@ -179,7 +179,7 @@ int32_t grapheme_strpos_utf16(char *haystack, size_t haystack_len, char *needle,
 			STRPOS_CHECK_STATUS(status, "Invalid search offset");
 		}
 		status = U_ZERO_ERROR;
-		usearch_setOffset(src, last ? 0 : offset_pos, &status);
+		usearch_setOffset(src, offset_pos + (last && offset < 0), &status);
 		STRPOS_CHECK_STATUS(status, "Invalid search offset");
 	}
 
@@ -192,15 +192,9 @@ int32_t grapheme_strpos_utf16(char *haystack, size_t haystack_len, char *needle,
 				char_pos = USEARCH_DONE;
 			}			
 		} else {
-			/* searching backwards is broken, so we search forwards, albeit it's less efficient */
-			do {
-				char_pos = usearch_next(src, &status);
-				if (char_pos == USEARCH_DONE || char_pos > offset_pos) {
-					char_pos = prev_pos;
-					break;
-				}
-				prev_pos = char_pos;
-			} while(1);
+			usearch_setAttribute(src, USEARCH_OVERLAP, USEARCH_ON, &status);
+			STRPOS_CHECK_STATUS(status, "Error setting overlap flag");
+			char_pos = usearch_previous(src, &status);
 		}
 	} else {
 		char_pos = usearch_next(src, &status);

--- a/ext/intl/tests/bug74264.phpt
+++ b/ext/intl/tests/bug74264.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #74264 (grapheme_sttrpos() broken for negative offsets)
+--SKIPIF--
+<?php
+if (!extension_loaded('intl')) die("skip intl extension not available");
+?>
+--FILE--
+<?php
+foreach (range(-5, -1) as $offset) {
+    var_dump(
+        grapheme_strrpos('déjàààà', 'à', $offset),
+        grapheme_strripos('DÉJÀÀÀÀ', 'à', $offset)
+    );        
+}
+?>
+--EXPECT--
+bool(false)
+bool(false)
+int(3)
+int(3)
+int(4)
+int(4)
+int(5)
+int(5)
+int(6)
+int(6)


### PR DESCRIPTION
We must not assume that `usearch_last()` gives the proper result for
negative offsets.  Instead we'd need to continue to search backwards
(`usearch_previous`) until we find a proper match.  However, apparently
searching backwards is broken, so we work around by searching forward
from the start of the string until we pass the `offset_pos`, and then
use the previous result.