### PR TITLE
Fix #68471: IntlDateFormatter fails for "GMT+00:00" timezone

### DIFF
--- a/ext/intl/tests/bug68471.phpt
+++ b/ext/intl/tests/bug68471.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug #68471 (IntlDateFormatter fails for "GMT+00:00" timezone)
+--SKIPIF--
+<?php
+if (!extension_loaded('intl')) die("sikp intl extension not available");
+?>
+--FILE--
+<?php
+$formatter = new IntlDateFormatter(
+    'fr_FR',
+    IntlDateFormatter::NONE,
+    IntlDateFormatter::NONE,
+    "GMT+00:00"
+);
+var_dump($formatter);
+?>
+--EXPECT--
+object(IntlDateFormatter)#1 (0) {
+}

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -176,8 +176,7 @@ U_CFUNC TimeZone *timezone_process_timezone_argument(zval *zv_timezone,
 		return timezone_convert_datetimezone(tzobj->type, tzobj, 0,
 			outside_error, func);
 	} else {
-		UnicodeString	id,
-						gottenId;
+		UnicodeString	id;
 		UErrorCode		status = U_ZERO_ERROR; /* outside_error may be NULL */
 		if (!try_convert_to_string(zv_timezone)) {
 			zval_ptr_dtor_str(&local_zv_tz);
@@ -204,7 +203,7 @@ U_CFUNC TimeZone *timezone_process_timezone_argument(zval *zv_timezone,
 			zval_ptr_dtor_str(&local_zv_tz);
 			return NULL;
 		}
-		if (timeZone->getID(gottenId) != id) {
+		if (*timeZone == TimeZone::getUnknown()) {
 			spprintf(&message, 0, "%s: no such time zone: '%s'",
 				func, Z_STRVAL_P(zv_timezone));
 			if (message) {


### PR DESCRIPTION
GMT+00:00 is recognized by ICU, and is normalized to GMT.  There are no
issues when GMT+00:00 is passed to `IntlTimeZone::createTimeZone()`,
but passing it to IntlDateFormatter::__construct() causes a failure,
since there is an additional check regarding the validity.  While
checking the validity of the result of `TimeZone::createTimeZone()`[1]
is a good idea, comparing the IDs is overly restrictive.  Instead we
just check that the timezone is supported by ICU.

[1] <https://unicode-org.github.io/icu-docs/apidoc/dev/icu4c/classicu_1_1TimeZone.html#a35da0507b62754ffe5d8d59c19775cdb>

---

It might be a good idea to also add this check to `intltz_create_time_zone()`, or to drop it from `IntlDateFormatter::__construct()` altogether. Note that https://github.com/php/php-src/blob/2590051a4f801e24c197ffdc402dd7833e4158c8/ext/intl/timezone/timezone_methods.cpp#L71
is wrong; if the timezone is not recognized, it is Etc\Unknown.