### PR TITLE
fix: make throws an exception: Allocation of JIT memory failed, PCRE JIT will be disabled

### DIFF
--- a/ext/phar/phar/pharcommand.inc
+++ b/ext/phar/phar/pharcommand.inc
@@ -642,6 +642,8 @@ class PharCommand extends CLICommand
             $dir = new InvertedRegexIterator($dir, $invregex);
         }
 
+        ini_set('pcre.jit', '0');
+
         try {
             foreach($dir as $file) {
                 if ((empty($stub) || $file->getRealPath() != $stub->getRealPath()) && !is_dir($file)) {


### PR DESCRIPTION
fix: make throws an exception: Allocation of JIT memory failed, PCRE JIT will be disabled. This is likely caused by security restrictions. Either grant PHP permission to allocate executable memory, or set pcre.jit=0 in /Users/***/Downloads/php-8.0.7/ext/phar/phar.php:1136