### PR TITLE
Add a case to version compare

### DIFF
--- a/ext/standard/tests/versioning/version_compare.phpt
+++ b/ext/standard/tests/versioning/version_compare.phpt
@@ -17,6 +17,7 @@ test("1", "2");
 test("10", "2");
 test("1.0", "1.1");
 test("1.2", "1.0.1");
+test("1.2(message)", "1.2(message)");
 foreach ($special_forms as $f1) {
     foreach ($special_forms as $f2) {
     test("1.0$f1", "1.0$f2");
@@ -57,6 +58,7 @@ TESTING COMPARE
 10 > 2
 1.0 < 1.1
 1.2 > 1.0.1
+1.2(message) = 1.2(message)
 1.0-dev = 1.0-dev
 1.0-dev < 1.0a1
 1.0-dev < 1.0b1

--- a/ext/standard/versioning.c
+++ b/ext/standard/versioning.c
@@ -179,13 +179,13 @@ php_version_compare(const char *orig_ver1, const char *orig_ver2)
 		}
 	}
 	if (compare == 0) {
-		if (n1 != NULL) {
+		if (n1 != NULL && *p1 != '\0') {
 			if (isdigit(*p1)) {
 				compare = 1;
 			} else {
 				compare = php_version_compare(p1, "#N#");
 			}
-		} else if (n2 != NULL) {
+		} else if (n2 != NULL && *p2 != '\0') {
 			if (isdigit(*p2)) {
 				compare = -1;
 			} else {


### PR DESCRIPTION
OSX have a string at the end of their version which stops the version
comparison working.

The bug was ending in the '#N#' case and comparing to an empty string

If there is nothing left to compare this change prevents that. I have
added the test case in for this.

The closing bracket is what causes the bug in the current PHP version