### PR TITLE
Remove the redefinitions

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -119,7 +119,13 @@ typedef struct _zend_class_dependency {
 } zend_class_dependency;
 
 typedef struct _zend_inheritance_cache_entry zend_inheritance_cache_entry;
-typedef struct _zend_error_info zend_error_info;
+
+typedef struct _zend_error_info {
+	int type;
+	uint32_t lineno;
+	zend_string *filename;
+	zend_string *message;
+} zend_error_info;
 
 struct _zend_inheritance_cache_entry {
 	zend_inheritance_cache_entry *next;
@@ -381,13 +387,6 @@ typedef struct {
 	zend_error_handling_t  handling;
 	zend_class_entry       *exception;
 } zend_error_handling;
-
-typedef struct _zend_error_info {
-	int type;
-	uint32_t lineno;
-	zend_string *filename;
-	zend_string *message;
-} zend_error_info;
 
 BEGIN_EXTERN_C()
 ZEND_API void zend_save_error_handling(zend_error_handling *current);

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -54,8 +54,6 @@ void zend_fiber_shutdown(void);
 
 extern ZEND_API zend_class_entry *zend_ce_fiber;
 
-typedef struct _zend_fiber zend_fiber;
-typedef struct _zend_fiber_context zend_fiber_context;
 typedef struct _zend_fiber_stack zend_fiber_stack;
 
 /* Encapsulates data needed for a context switch. */

--- a/ext/opcache/jit/zend_jit_gdb.c
+++ b/ext/opcache/jit/zend_jit_gdb.c
@@ -284,7 +284,6 @@ static void zend_gdbjit_symtab(zend_gdbjit_ctx *ctx)
 
 typedef ZEND_SET_ALIGNED(1, uint16_t unaligned_uint16_t);
 typedef ZEND_SET_ALIGNED(1, uint32_t unaligned_uint32_t);
-typedef ZEND_SET_ALIGNED(1, uint16_t unaligned_uint16_t);
 typedef ZEND_SET_ALIGNED(1, uintptr_t unaligned_uintptr_t);
 
 #define SECTALIGN(p, a) \

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -3336,7 +3336,6 @@ mrm:
 	}
 }
 
-typedef ZEND_SET_ALIGNED(1, uint16_t unaligned_uint16_t);
 typedef ZEND_SET_ALIGNED(1, int32_t unaligned_int32_t);
 
 static int zend_jit_patch(const void *code, size_t size, uint32_t jmp_table_size, const void *from_addr, const void *to_addr)


### PR DESCRIPTION
# Remove the redefinition of zend_fiber and zend_fiber_context 
```

ZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -c php-8.1.0alpha2/ext/reflection/php_reflection.c -o ext/reflection/php_reflection.lo  -MMD -MF ext/reflection/php_reflection.dep -MT ext/reflection/php_reflection.lo
In file included from php-8.1.0alpha2/ext/reflection/php_reflection.c:47:
php-8.1.0alpha2/Zend/zend_fibers.h:57: error: redefinition of typedef 'zend_fiber'
php-8.1.0alpha2/Zend/zend_globals.h:65: note: previous declaration of 'zend_fiber' was here
php-8.1.0alpha2/Zend/zend_fibers.h:58: error: redefinition of typedef 'zend_fiber_context'
php-8.1.0alpha2/Zend/zend_globals.h:64: note: previous declaration of 'zend_fiber_context' was here
php-8.1.0alpha2/ext/reflection/php_reflection.c: In function '_class_string':
php-8.1.0alpha2/ext/reflection/php_reflection.c:476: warning: missing initializer
```
# redefinition of typedef 'zend_error_info'

```
php-8.1.0alpha2/ext/opcache/ZendAccelerator.c -o ext/opcache/ZendAccelerator.lo  -MMD -MF ext/opcache/ZendAccelerator.dep -MT ext/opcache/ZendAccelerator.lo
In file included from php-8.1.0alpha2/main/php.h:31,
                 from php-8.1.0alpha2/ext/opcache/ZendAccelerator.c:22:
php-8.1.0alpha2/Zend/zend.h:390: error: redefinition of typedef 'zend_error_info'
php-8.1.0alpha2/Zend/zend.h:122: note: previous declaration of 'zend_error_info' was here
cc1: warning: unrecognized command line option "-Wno-implicit-fallthrough"
make: *** [ext/opcache/ZendAccelerator.lo] Error 1
```