### PR TITLE
Windows: allow GD ext without avif.dll

### DIFF
--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -32,7 +32,11 @@ if (PHP_GD != "no") {
 			}
 		}
 		if (PHP_LIBAVIF != "no") {
-			if (CHECK_LIB("avif.lib", "gd", PHP_GD) &&
+			if (CHECK_LIB("avif_a.lib", "gd", PHP_GD) &&
+				CHECK_LIB("aom_a.lib", "gd", PHP_GD) &&
+				CHECK_HEADER_ADD_INCLUDE("avif.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\avif")) {
+				ADD_FLAG("CFLAGS_GD", "/D HAVE_LIBAVIF /D HAVE_GD_AVIF");
+			} else if (CHECK_LIB("avif.lib", "gd", PHP_GD) &&
 				CHECK_HEADER_ADD_INCLUDE("avif.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\avif")) {
 				ADD_FLAG("CFLAGS_GD", "/D HAVE_LIBAVIF /D HAVE_GD_AVIF");
 			} else {


### PR DESCRIPTION
@cmb69 @morsssss @nikic
Allow building the GD extension on Windows without the dependency on an external avid.dll

This PR aims to improve https://github.com/php/php-src/pull/7026 and https://github.com/php/php-src/commit/81f6d36c90b8626660a6571cdc128265fa00697f

For the changes in building the Windows dependencies see https://github.com/winlibs/libavif/issues/1