### PR TITLE
Fix false positive recursion warning for var_export of enums

### DIFF
--- a/Zend/tests/enum/var_export.phpt
+++ b/Zend/tests/enum/var_export.phpt
@@ -8,7 +8,14 @@ enum Foo {
 }
 
 var_export(Foo::Bar);
+// Should not warn about recursion
+echo "\n";
+echo str_replace(" \n", "\n", var_export([Foo::Bar], true));
 
 ?>
 --EXPECT--
 Foo::Bar
+array (
+  0 =>
+  Foo::Bar,
+)

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -595,13 +595,13 @@ again:
 				}
 			}
 
-			if (myht && !is_enum) {
-				ZEND_HASH_FOREACH_KEY_VAL_IND(myht, index, key, val) {
-					php_object_element_export(val, index, key, level, buf);
-				} ZEND_HASH_FOREACH_END();
-				GC_TRY_UNPROTECT_RECURSION(myht);
-			}
 			if (myht) {
+				if (!is_enum) {
+					ZEND_HASH_FOREACH_KEY_VAL_IND(myht, index, key, val) {
+						php_object_element_export(val, index, key, level, buf);
+					} ZEND_HASH_FOREACH_END();
+				}
+				GC_TRY_UNPROTECT_RECURSION(myht);
 				zend_release_properties(myht);
 			}
 			if (level > 1 && !is_enum) {


### PR DESCRIPTION
Because TRY_UNPROTECT_RECURSION was never called for enums after calling TRY_PROTECT_RECURSION, subsequent calls to var_export would emit a warning.

This fixes that.