### PR TITLE
Fix #73630: Built-in Weberver - overwrite $_SERVER['request_uri']

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1629,6 +1629,9 @@ static int php_cli_server_client_read_request_on_path(php_http_parser *parser, c
 	{
 		char *vpath;
 		size_t vpath_len;
+		if (client->request.vpath != NULL) {
+			return 1;
+		}
 		normalize_vpath(&vpath, &vpath_len, at, length, 1);
 		client->request.vpath = vpath;
 		client->request.vpath_len = vpath_len;
@@ -1639,17 +1642,32 @@ static int php_cli_server_client_read_request_on_path(php_http_parser *parser, c
 static int php_cli_server_client_read_request_on_query_string(php_http_parser *parser, const char *at, size_t length)
 {
 	php_cli_server_client *client = parser->data;
-	client->request.query_string = pestrndup(at, length, 1);
-	client->request.query_string_len = length;
+	if (client->request.query_string == NULL) {
+		client->request.query_string = pestrndup(at, length, 1);
+		client->request.query_string_len = length;
+	} else {
+		client->request.query_string = perealloc(client->request.query_string, client->request.query_string_len + length + 1, 1);
+		memcpy(client->request.query_string + client->request.query_string_len, at, length);
+		client->request.query_string_len += length;
+		client->request.query_string[client->request.query_string_len] = '\0';
+	}
 	return 0;
 }
 
 static int php_cli_server_client_read_request_on_url(php_http_parser *parser, const char *at, size_t length)
 {
 	php_cli_server_client *client = parser->data;
-	client->request.request_method = parser->method;
-	client->request.request_uri = pestrndup(at, length, 1);
-	client->request.request_uri_len = length;
+	if (client->request.request_uri == NULL) {
+		client->request.request_method = parser->method;
+		client->request.request_uri = pestrndup(at, length, 1);
+		client->request.request_uri_len = length;
+	} else {
+		ZEND_ASSERT(client->request.request_method == parser->method);
+		client->request.request_uri = perealloc(client->request.request_uri, client->request.request_uri_len + length + 1, 1);
+		memcpy(client->request.request_uri + client->request.request_uri_len, at, length);
+		client->request.request_uri_len += length;
+		client->request.request_uri[client->request.request_uri_len] = '\0';
+	}
 	return 0;
 }
 

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1646,6 +1646,7 @@ static int php_cli_server_client_read_request_on_query_string(php_http_parser *p
 		client->request.query_string = pestrndup(at, length, 1);
 		client->request.query_string_len = length;
 	} else {
+		ZEND_ASSERT(length <= PHP_HTTP_MAX_HEADER_SIZE && PHP_HTTP_MAX_HEADER_SIZE - length >= client->request.query_string_len);
 		client->request.query_string = perealloc(client->request.query_string, client->request.query_string_len + length + 1, 1);
 		memcpy(client->request.query_string + client->request.query_string_len, at, length);
 		client->request.query_string_len += length;
@@ -1663,6 +1664,7 @@ static int php_cli_server_client_read_request_on_url(php_http_parser *parser, co
 		client->request.request_uri_len = length;
 	} else {
 		ZEND_ASSERT(client->request.request_method == parser->method);
+		ZEND_ASSERT(length <= PHP_HTTP_MAX_HEADER_SIZE && PHP_HTTP_MAX_HEADER_SIZE - length >= client->request.query_string_len);
 		client->request.request_uri = perealloc(client->request.request_uri, client->request.request_uri_len + length + 1, 1);
 		memcpy(client->request.request_uri + client->request.request_uri_len, at, length);
 		client->request.request_uri_len += length;

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1629,7 +1629,7 @@ static int php_cli_server_client_read_request_on_path(php_http_parser *parser, c
 	{
 		char *vpath;
 		size_t vpath_len;
-		if (client->request.vpath != NULL) {
+		if (UNEXPECTED(client->request.vpath != NULL)) {
 			return 1;
 		}
 		normalize_vpath(&vpath, &vpath_len, at, length, 1);
@@ -1642,7 +1642,7 @@ static int php_cli_server_client_read_request_on_path(php_http_parser *parser, c
 static int php_cli_server_client_read_request_on_query_string(php_http_parser *parser, const char *at, size_t length)
 {
 	php_cli_server_client *client = parser->data;
-	if (client->request.query_string == NULL) {
+	if (EXPECTED(client->request.query_string == NULL)) {
 		client->request.query_string = pestrndup(at, length, 1);
 		client->request.query_string_len = length;
 	} else {
@@ -1658,7 +1658,7 @@ static int php_cli_server_client_read_request_on_query_string(php_http_parser *p
 static int php_cli_server_client_read_request_on_url(php_http_parser *parser, const char *at, size_t length)
 {
 	php_cli_server_client *client = parser->data;
-	if (client->request.request_uri == NULL) {
+	if (EXPECTED(client->request.request_uri == NULL)) {
 		client->request.request_method = parser->method;
 		client->request.request_uri = pestrndup(at, length, 1);
 		client->request.request_uri_len = length;

--- a/sapi/cli/tests/bug73630.phpt
+++ b/sapi/cli/tests/bug73630.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #73630 (Built-in Weberver - overwrite $_SERVER['request_uri'])
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+$code = <<<'EOF'
+var_dump(strncmp($_SERVER['REQUEST_URI'], "/overflow.php", strlen("/overflow.php")));
+EOF;
+
+include "php_cli_server.inc";
+php_cli_server_start($code);
+
+$host = PHP_CLI_SERVER_HOSTNAME;
+$fp = php_cli_server_connect();
+
+$path = "/overflow.php?" . str_repeat("x", 16400) . "//example.com";
+
+if (fwrite($fp, <<<HEADER
+GET $path HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+	while (!feof($fp)) {
+		echo fgets($fp);
+	}
+}
+
+?>
+--EXPECTF--
+HTTP/1.1 200 OK
+Host: %s
+Date: %s
+Connection: close
+X-Powered-By: PHP/%s
+Content-type: text/html; charset=UTF-8
+
+int(0)

--- a/sapi/cli/tests/bug73630.phpt
+++ b/sapi/cli/tests/bug73630.phpt
@@ -9,6 +9,7 @@ include "skipif.inc";
 
 $code = <<<'EOF'
 var_dump(strncmp($_SERVER['REQUEST_URI'], "/overflow.php", strlen("/overflow.php")));
+var_dump(strlen($_SERVER['QUERY_STRING']));
 EOF;
 
 include "php_cli_server.inc";
@@ -41,3 +42,4 @@ X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8
 
 int(0)
+int(16413)

--- a/sapi/cli/tests/bug73630a.phpt
+++ b/sapi/cli/tests/bug73630a.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug #73630 (Built-in Weberver - overwrite $_SERVER['request_uri'])
+--DESCRIPTION--
+Check that too long paths result in invalid request
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+$code = <<<'EOF'
+echo "won't happen\n";
+EOF;
+
+include "php_cli_server.inc";
+php_cli_server_start($code);
+
+$host = PHP_CLI_SERVER_HOSTNAME;
+$fp = php_cli_server_connect();
+$path = "/" . str_repeat("x", 16400) . "//example.com";
+var_dump(file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "$path"));
+?>
+--EXPECTF--
+Warning: file_get_contents(http://%s//example.com): failed to open stream: HTTP request failed! in %s on line %d
+bool(false)


### PR DESCRIPTION
The built-in Webserver's `on_path`, `on_query_string` and `on_url`
callbacks may be called multiple times from the parser; we must not
simply replace the old values, but need to concatenate the new values
instead.

This appears to be tricky for `on_path` due to the path normalization,
so we fail if the function is called again.