### PR TITLE
Fix #81206: Multiple PHP processes crash with JIT enabled

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3008,8 +3008,10 @@ static zend_result accel_post_startup(void)
 				zend_accel_error(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - probably not enough shared memory.");
 				return SUCCESS;
 			case SUCCESSFULLY_REATTACHED:
-#if defined(HAVE_JIT) && !defined(ZEND_WIN32)
-				reattached = 1;
+#ifdef HAVE_JIT
+				if (sapi_module.name && strcmp(sapi_module.name, "apache2handler") == 0) {
+					reattached = 1;
+				}
 #endif
 				zend_shared_alloc_lock();
 				accel_shared_globals = (zend_accel_shared_globals *) ZSMMG(app_shared_globals);

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3009,9 +3009,7 @@ static zend_result accel_post_startup(void)
 				return SUCCESS;
 			case SUCCESSFULLY_REATTACHED:
 #ifdef HAVE_JIT
-				if (sapi_module.name && strcmp(sapi_module.name, "apache2handler") == 0) {
-					reattached = 1;
-				}
+				reattached = 1;
 #endif
 				zend_shared_alloc_lock();
 				accel_shared_globals = (zend_accel_shared_globals *) ZSMMG(app_shared_globals);

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4044,6 +4044,17 @@ ZEND_EXT_API void zend_jit_protect(void)
 #endif
 }
 
+static void zend_jit_init_non_hybrid_handlers(void)
+{
+	zend_jit_runtime_jit_handler = (const void*)zend_runtime_jit;
+	zend_jit_profile_jit_handler = (const void*)zend_jit_profile_helper;
+	zend_jit_func_hot_counter_handler = (const void*)zend_jit_func_counter_helper;
+	zend_jit_loop_hot_counter_handler = (const void*)zend_jit_loop_counter_helper;
+	zend_jit_func_trace_counter_handler = (const void*)zend_jit_func_trace_helper;
+	zend_jit_ret_trace_counter_handler = (const void*)zend_jit_ret_trace_helper;
+	zend_jit_loop_trace_counter_handler = (const void*)zend_jit_loop_trace_helper;
+}
+
 static int zend_jit_make_stubs(void)
 {
 	dasm_State* dasm_state = NULL;
@@ -4071,13 +4082,7 @@ static int zend_jit_make_stubs(void)
 		zend_jit_ret_trace_counter_handler = dasm_labels[zend_lbhybrid_ret_trace_counter];
 		zend_jit_loop_trace_counter_handler = dasm_labels[zend_lbhybrid_loop_trace_counter];
 	} else {
-		zend_jit_runtime_jit_handler = (const void*)zend_runtime_jit;
-		zend_jit_profile_jit_handler = (const void*)zend_jit_profile_helper;
-		zend_jit_func_hot_counter_handler = (const void*)zend_jit_func_counter_helper;
-		zend_jit_loop_hot_counter_handler = (const void*)zend_jit_loop_counter_helper;
-		zend_jit_func_trace_counter_handler = (const void*)zend_jit_func_trace_helper;
-		zend_jit_ret_trace_counter_handler = (const void*)zend_jit_ret_trace_helper;
-		zend_jit_loop_trace_counter_handler = (const void*)zend_jit_loop_trace_helper;
+		zend_jit_init_non_hybrid_handlers();
 	}
 
 	dasm_free(&dasm_state);
@@ -4353,6 +4358,7 @@ ZEND_EXT_API int zend_jit_startup(void *buf, size_t size, zend_bool reattached)
 #if _WIN32
 		/* restore global labels */
 		memcpy(dasm_labels, dasm_buf, sizeof(void*) * zend_lb_MAX);
+		zend_jit_init_non_hybrid_handlers();
 #endif
 	}
 

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4044,15 +4044,25 @@ ZEND_EXT_API void zend_jit_protect(void)
 #endif
 }
 
-static void zend_jit_init_non_hybrid_handlers(void)
+static void zend_jit_init_handlers(void)
 {
-	zend_jit_runtime_jit_handler = (const void*)zend_runtime_jit;
-	zend_jit_profile_jit_handler = (const void*)zend_jit_profile_helper;
-	zend_jit_func_hot_counter_handler = (const void*)zend_jit_func_counter_helper;
-	zend_jit_loop_hot_counter_handler = (const void*)zend_jit_loop_counter_helper;
-	zend_jit_func_trace_counter_handler = (const void*)zend_jit_func_trace_helper;
-	zend_jit_ret_trace_counter_handler = (const void*)zend_jit_ret_trace_helper;
-	zend_jit_loop_trace_counter_handler = (const void*)zend_jit_loop_trace_helper;
+	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
+		zend_jit_runtime_jit_handler = dasm_labels[zend_lbhybrid_runtime_jit];
+		zend_jit_profile_jit_handler = dasm_labels[zend_lbhybrid_profile_jit];
+		zend_jit_func_hot_counter_handler = dasm_labels[zend_lbhybrid_func_hot_counter];
+		zend_jit_loop_hot_counter_handler = dasm_labels[zend_lbhybrid_loop_hot_counter];
+		zend_jit_func_trace_counter_handler = dasm_labels[zend_lbhybrid_func_trace_counter];
+		zend_jit_ret_trace_counter_handler = dasm_labels[zend_lbhybrid_ret_trace_counter];
+		zend_jit_loop_trace_counter_handler = dasm_labels[zend_lbhybrid_loop_trace_counter];
+	} else {
+		zend_jit_runtime_jit_handler = (const void*)zend_runtime_jit;
+		zend_jit_profile_jit_handler = (const void*)zend_jit_profile_helper;
+		zend_jit_func_hot_counter_handler = (const void*)zend_jit_func_counter_helper;
+		zend_jit_loop_hot_counter_handler = (const void*)zend_jit_loop_counter_helper;
+		zend_jit_func_trace_counter_handler = (const void*)zend_jit_func_trace_helper;
+		zend_jit_ret_trace_counter_handler = (const void*)zend_jit_ret_trace_helper;
+		zend_jit_loop_trace_counter_handler = (const void*)zend_jit_loop_trace_helper;
+	}
 }
 
 static int zend_jit_make_stubs(void)
@@ -4073,17 +4083,7 @@ static int zend_jit_make_stubs(void)
 		}
 	}
 
-	if (zend_jit_vm_kind == ZEND_VM_KIND_HYBRID) {
-		zend_jit_runtime_jit_handler = dasm_labels[zend_lbhybrid_runtime_jit];
-		zend_jit_profile_jit_handler = dasm_labels[zend_lbhybrid_profile_jit];
-		zend_jit_func_hot_counter_handler = dasm_labels[zend_lbhybrid_func_hot_counter];
-		zend_jit_loop_hot_counter_handler = dasm_labels[zend_lbhybrid_loop_hot_counter];
-		zend_jit_func_trace_counter_handler = dasm_labels[zend_lbhybrid_func_trace_counter];
-		zend_jit_ret_trace_counter_handler = dasm_labels[zend_lbhybrid_ret_trace_counter];
-		zend_jit_loop_trace_counter_handler = dasm_labels[zend_lbhybrid_loop_trace_counter];
-	} else {
-		zend_jit_init_non_hybrid_handlers();
-	}
+	zend_jit_init_handlers();
 
 	dasm_free(&dasm_state);
 	return 1;
@@ -4358,7 +4358,7 @@ ZEND_EXT_API int zend_jit_startup(void *buf, size_t size, zend_bool reattached)
 #if _WIN32
 		/* restore global labels */
 		memcpy(dasm_labels, dasm_buf, sizeof(void*) * zend_lb_MAX);
-		zend_jit_init_non_hybrid_handlers();
+		zend_jit_init_handlers();
 #endif
 	}
 


### PR DESCRIPTION
The fix for bug 80175 (PR #6268) broke most SAPIs wrt. JIT, most
notably cgi-fcgi, because for these SAPIs `SUCCESSFULLY_REATTACHED`
actually has to set the `reattached` flag.

---

I'm not sure whether some other APIs might need to be handled as well:
https://github.com/php/php-src/blob/65bd8d281fc7bbe70a58ff1fae11bc737ea39073/ext/opcache/ZendAccelerator.c#L2601-L2612
What is "uwsgi"?

