### PR TITLE
Fix #52093: openssl_csr_sign silently truncates $serial

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3524,7 +3524,9 @@ PHP_FUNCTION(openssl_csr_sign)
 		goto cleanup;
 	}
 
-
+	if (serial < LONG_MIN || serial > LONG_MAX) {
+		php_error_docref(NULL, E_WARNING, "serial out of range, will be truncated");
+	}
 	ASN1_INTEGER_set(X509_get_serialNumber(new_cert), (long)serial);
 
 	X509_set_subject_name(new_cert, X509_REQ_get_subject_name(csr));

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3524,10 +3524,11 @@ PHP_FUNCTION(openssl_csr_sign)
 		goto cleanup;
 	}
 
-	if (serial < LONG_MIN || serial > LONG_MAX) {
-		php_error_docref(NULL, E_WARNING, "serial out of range, will be truncated");
-	}
-	ASN1_INTEGER_set(X509_get_serialNumber(new_cert), (long)serial);
+#if defined(PHP_WIN32) && defined(ZEND_ENABLE_ZVAL_LONG64)
+	ASN1_INTEGER_set_int64(X509_get_serialNumber(new_cert), serial);
+#else
+	ASN1_INTEGER_set(X509_get_serialNumber(new_cert), serial);
+#endif
 
 	X509_set_subject_name(new_cert, X509_REQ_get_subject_name(csr));
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3524,7 +3524,7 @@ PHP_FUNCTION(openssl_csr_sign)
 		goto cleanup;
 	}
 
-#if defined(PHP_WIN32) && defined(ZEND_ENABLE_ZVAL_LONG64)
+#if PHP_OPENSSL_API_VERSION >= 0x10100
 	ASN1_INTEGER_set_int64(X509_get_serialNumber(new_cert), serial);
 #else
 	ASN1_INTEGER_set(X509_get_serialNumber(new_cert), serial);

--- a/ext/openssl/tests/bug52093.phpt
+++ b/ext/openssl/tests/bug52093.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #52093 (openssl_csr_sign silently truncates $serial)
+--SKIPIF--
+<?php if (!extension_loaded("openssl")) print "skip"; ?>
+--FILE--
+<?php
+$dn = array(
+    "countryName" => "BR",
+    "stateOrProvinceName" => "Rio Grande do Sul",
+    "localityName" => "Porto Alegre",
+    "commonName" => "Henrique do N. Angelo",
+    "emailAddress" => "hnangelo@php.net"
+);
+
+$privkey = openssl_pkey_new();
+$csr = openssl_csr_new($dn, $privkey);
+var_dump(openssl_csr_sign($csr, null, $privkey, 365, [], PHP_INT_MAX));
+?>
+--EXPECTF--
+Warning: openssl_csr_sign(): serial out of range, will be truncated in %s on line %d
+resource(6) of type (OpenSSL X.509)

--- a/ext/openssl/tests/bug52093.phpt
+++ b/ext/openssl/tests/bug52093.phpt
@@ -1,7 +1,10 @@
 --TEST--
-Bug #52093 (openssl_csr_sign silently truncates $serial)
+Bug #52093 (openssl_csr_sign truncates $serial)
 --SKIPIF--
-<?php if (!extension_loaded("openssl")) print "skip"; ?>
+<?php
+if (!extension_loaded("openssl")) print "skip";
+if (PHP_INT_SIZE !== 8) die("skip this test is for 64bit platforms only");
+?>
 --FILE--
 <?php
 $dn = array(
@@ -14,8 +17,8 @@ $dn = array(
 
 $privkey = openssl_pkey_new();
 $csr = openssl_csr_new($dn, $privkey);
-var_dump(openssl_csr_sign($csr, null, $privkey, 365, [], PHP_INT_MAX));
+$cert = openssl_csr_sign($csr, null, $privkey, 365, [], PHP_INT_MAX);
+var_dump(openssl_x509_parse($cert)['serialNumber']);
 ?>
---EXPECTF--
-Warning: openssl_csr_sign(): serial out of range, will be truncated in %s on line %d
-resource(6) of type (OpenSSL X.509)
+--EXPECT--
+string(19) "9223372036854775807"


### PR DESCRIPTION
We must not silently truncate integer arguments passed to a function.
In this case we could use `ASN1_INTEGER_set_int64()` on LLP64
architectures, but that might be regarded a BC break; instead we choose
to raise a warning regarding the truncation for now.