### PR TITLE
Add support for internal enums via stub generation

### DIFF
--- a/Zend/Optimizer/pass1.c
+++ b/Zend/Optimizer/pass1.c
@@ -210,7 +210,7 @@ constant_binary_op:
 						break;
 					}
 				}
-				if (Z_TYPE(c) == IS_CONSTANT_AST) {
+				if (Z_TYPE(c) == IS_CONSTANT_AST || Z_TYPE(c) == IS_OBJECT) {
 					break;
 				}
 				literal_dtor(&ZEND_OP2_LITERAL(opline));
@@ -274,6 +274,8 @@ constant_binary_op:
 							 || Z_TYPE(t) == IS_CONSTANT_AST) {
 								break;
 							}
+						} else if (Z_TYPE_P(c) == IS_OBJECT) {
+							break;
 						} else {
 							ZVAL_COPY_OR_DUP(&t, c);
 						}

--- a/Zend/tests/enum/internal-enum-constant-assignment.phpt
+++ b/Zend/tests/enum/internal-enum-constant-assignment.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Internal enum reassignment to constants preserves identity
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+const E = ZendTestStringBacked::FIRST;
+
+var_dump(E);
+var_dump(E === ZendTestStringBacked::FIRST);
+
+?>
+--EXPECT--
+enum(ZendTestStringBacked::FIRST)
+bool(true)

--- a/Zend/tests/enum/internal-enum-persistent.phpt
+++ b/Zend/tests/enum/internal-enum-persistent.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Internal enums are persistent
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+var_dump(ZendTestStringBacked::FIRST);
+var_dump(ZendTestStringBacked::FIRST == ZendTestStringBacked::getFirst());
+var_dump(ZendTestStringBacked::FIRST === ZendTestStringBacked::getFirst());
+var_dump(ZendTestStringBacked::FIRST !== ZendTestUnbacked::FIRST);
+var_dump(ZendTestStringBacked::FIRST->value);
+var_dump(ZendTestIntBacked::FIRST->value);
+
+var_dump(ZendTestStringBacked::FIRST instanceof UnitEnum, ZendTestStringBacked::FIRST instanceof BackedEnum);
+var_dump(ZendTestUnbacked::FIRST instanceof UnitEnum, ZendTestUnbacked::FIRST instanceof BackedEnum);
+
+var_dump(ZendTestUnbacked::cases());
+var_dump(ZendTestStringBacked::cases());
+var_dump(ZendTestIntBacked::from(42));
+var_dump(ZendTestStringBacked::tryFrom("foo"));
+var_dump(ZendTestStringBacked::tryFrom("a"));
+
+?>
+--EXPECT--
+enum(ZendTestStringBacked::FIRST)
+bool(true)
+bool(true)
+bool(true)
+string(1) "a"
+int(42)
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+array(2) {
+  [0]=>
+  enum(ZendTestUnbacked::FIRST)
+  [1]=>
+  enum(ZendTestUnbacked::SECOND)
+}
+array(2) {
+  [0]=>
+  enum(ZendTestStringBacked::FIRST)
+  [1]=>
+  enum(ZendTestStringBacked::SECOND)
+}
+enum(ZendTestIntBacked::FIRST)
+NULL
+enum(ZendTestStringBacked::FIRST)

--- a/Zend/tests/enum/internal-enum-read-from-reflection.phpt
+++ b/Zend/tests/enum/internal-enum-read-from-reflection.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Internal enums can be safely read from reflection
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$r = new ReflectionEnum("ZendTestStringBacked");
+var_dump($r->getCases());
+var_dump($r->getConstant("FIRST") === ZendTestStringBacked::FIRST);
+var_dump($r->getConstants()["FIRST"] === ZendTestStringBacked::FIRST);
+
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  object(ReflectionEnumBackedCase)#%d (2) {
+    ["name"]=>
+    string(5) "FIRST"
+    ["class"]=>
+    string(20) "ZendTestStringBacked"
+  }
+  [1]=>
+  object(ReflectionEnumBackedCase)#%d (2) {
+    ["name"]=>
+    string(6) "SECOND"
+    ["class"]=>
+    string(20) "ZendTestStringBacked"
+  }
+}
+bool(true)
+bool(true)

--- a/Zend/tests/enum/internal-enum-serialization.phpt
+++ b/Zend/tests/enum/internal-enum-serialization.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Internal enums serialization
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+var_dump(ZendTestStringBacked::FIRST);
+$s = serialize(ZendTestStringBacked::FIRST);
+var_dump($s);
+var_dump(unserialize($s));
+var_dump(unserialize($s) === ZendTestStringBacked::FIRST);
+
+?>
+--EXPECT--
+enum(ZendTestStringBacked::FIRST)
+string(34) "E:26:"ZendTestStringBacked:FIRST";"
+enum(ZendTestStringBacked::FIRST)
+bool(true)

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -40,6 +40,8 @@ typedef struct _zend_function_entry {
 	uint32_t flags;
 } zend_function_entry;
 
+#include "zend_enum.h"
+
 typedef struct _zend_fcall_info {
 	size_t size;
 	zval function_name;

--- a/Zend/zend_enum.h
+++ b/Zend/zend_enum.h
@@ -20,6 +20,7 @@
 #define ZEND_ENUM_H
 
 #include "zend.h"
+#include "zend_API.h"
 #include "zend_types.h"
 
 BEGIN_EXTERN_C()
@@ -46,6 +47,22 @@ static zend_always_inline zval *zend_enum_fetch_case_value(zend_object *zobj)
 	ZEND_ASSERT(zobj->ce->enum_backing_type != IS_UNDEF);
 	return OBJ_PROP_NUM(zobj, 1);
 }
+
+ZEND_API zend_class_entry *zend_register_internal_enum(const char *name);
+ZEND_API zend_class_entry *zend_register_internal_enum_ex(const char *name, const zend_function_entry *functions);
+ZEND_API zend_class_entry *zend_register_internal_backed_enum(const char *name, uint32_t backing_type);
+ZEND_API zend_class_entry *zend_register_internal_backed_enum_ex(const char *name, uint32_t backing_type, const zend_function_entry *functions);
+
+#define zend_add_enum_case(ce, name) zend_add_enum_case_ex(ce, zend_string_init(name, sizeof(name) - 1, 1))
+ZEND_API zend_object *zend_add_enum_case_ex(zend_class_entry *ce, zend_string *name);
+
+#define zend_add_enum_case_long(ce, name, long) zend_add_enum_case_long_ex(ce, zend_string_init(name, sizeof(name) - 1, 1), long)
+ZEND_API zend_object *zend_add_enum_case_long_ex(zend_class_entry *ce, zend_string *name, zend_long value);
+
+#define zend_add_enum_case_string(ce, name, str) zend_add_enum_case_string_ex(ce, zend_string_init(name, sizeof(name) - 1, 1), str)
+#define zend_add_enum_case_str(ce, name, str) zend_add_enum_case_str_ex(ce, zend_string_init(name, sizeof(name) - 1, 1), str)
+#define zend_add_enum_case_string_ex(ce, name, str) zend_add_enum_case_str_ex(ce, name, zend_string_init(str, sizeof(str) - 1, 1))
+ZEND_API zend_object *zend_add_enum_case_str_ex(zend_class_entry *ce, zend_string *name, zend_string *str);
 
 END_EXTERN_C()
 

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -185,6 +185,7 @@ void init_executor(void) /* {{{ */
 	EG(persistent_constants_count) = EG(zend_constants)->nNumUsed;
 	EG(persistent_functions_count) = EG(function_table)->nNumUsed;
 	EG(persistent_classes_count)   = EG(class_table)->nNumUsed;
+	EG(persistent_objects) = (zend_object *) ecalloc(sizeof(zend_object), zend_objects_persistent_handle_counter);
 
 	EG(get_gc_buffer).start = EG(get_gc_buffer).end = EG(get_gc_buffer).cur = NULL;
 
@@ -431,6 +432,7 @@ void shutdown_executor(void) /* {{{ */
 		zend_stack_destroy(&EG(user_error_handlers_error_reporting));
 		zend_stack_destroy(&EG(user_error_handlers));
 		zend_stack_destroy(&EG(user_exception_handlers));
+		efree(EG(persistent_objects));
 		zend_objects_store_destroy(&EG(objects_store));
 		if (EG(in_autoload)) {
 			zend_hash_destroy(EG(in_autoload));

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -79,13 +79,13 @@
 #endif
 
 /* GC_INFO layout */
-#define GC_ADDRESS  0x0fffffu
-#define GC_COLOR    0x300000u
+#define GC_ADDRESS  0x07ffffu
+#define GC_COLOR    0x180000u
 
 #define GC_BLACK    0x000000u /* must be zero */
-#define GC_WHITE    0x100000u
-#define GC_GREY     0x200000u
-#define GC_PURPLE   0x300000u
+#define GC_WHITE    0x080000u
+#define GC_GREY     0x100000u
+#define GC_PURPLE   0x180000u
 
 /* Debug tracing */
 #if ZEND_GC_DEBUG > 1

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -181,6 +181,7 @@ struct _zend_executor_globals {
 	uint32_t persistent_constants_count;
 	uint32_t persistent_functions_count;
 	uint32_t persistent_classes_count;
+	zend_object *persistent_objects;
 
 	HashTable *in_autoload;
 	bool full_tables_cleanup;

--- a/Zend/zend_objects.h
+++ b/Zend/zend_objects.h
@@ -23,9 +23,14 @@
 #include "zend.h"
 
 BEGIN_EXTERN_C()
+extern ZEND_API uint32_t zend_objects_persistent_handle_counter;
+
 ZEND_API void ZEND_FASTCALL zend_object_std_init(zend_object *object, zend_class_entry *ce);
 ZEND_API zend_object* ZEND_FASTCALL zend_objects_new(zend_class_entry *ce);
 ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, zend_object *old_object);
+
+ZEND_API zend_object *zend_objects_new_persistent(zend_class_entry *ce);
+ZEND_API zend_object* ZEND_FASTCALL zend_objects_persistent_copy(zend_object *object);
 
 ZEND_API void zend_object_std_dtor(zend_object *object);
 ZEND_API void zend_objects_destroy_object(zend_object *object);

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -439,6 +439,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 			}
 			break;
 		case ZEND_INTERNAL_CLASS:
+			if (ce->backed_enum_table) {
+				zend_hash_release(ce->backed_enum_table);
+			}
 			if (ce->default_properties_table) {
 				zval *p = ce->default_properties_table;
 				zval *end = p + ce->default_properties_count;

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -614,10 +614,10 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define GC_TRY_DELREF(p)			zend_gc_try_delref(&(p)->gc)
 
 #define GC_TYPE_MASK				0x0000000f
-#define GC_FLAGS_MASK				0x000003f0
-#define GC_INFO_MASK				0xfffffc00
+#define GC_FLAGS_MASK				0x000007f0
+#define GC_INFO_MASK				0xfffff800
 #define GC_FLAGS_SHIFT				0
-#define GC_INFO_SHIFT				10
+#define GC_INFO_SHIFT				11
 
 static zend_always_inline zend_uchar zval_gc_type(uint32_t gc_type_info) {
 	return (gc_type_info & GC_TYPE_MASK);
@@ -704,9 +704,10 @@ static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
 #define IS_ARRAY_PERSISTENT			GC_PERSISTENT
 
 /* object flags (zval.value->gc.u.flags) */
-#define IS_OBJ_WEAKLY_REFERENCED	GC_PERSISTENT
+#define IS_OBJ_PERSISTENT			GC_PERSISTENT /* allocated using malloc */
 #define IS_OBJ_DESTRUCTOR_CALLED	(1<<8)
 #define IS_OBJ_FREE_CALLED			(1<<9)
+#define IS_OBJ_WEAKLY_REFERENCED	(1<<10)
 
 #define OBJ_FLAGS(obj)              GC_FLAGS(obj)
 

--- a/Zend/zend_variables.c
+++ b/Zend/zend_variables.c
@@ -98,8 +98,12 @@ ZEND_API void zval_internal_ptr_dtor(zval *zval_ptr) /* {{{ */
 				ZEND_ASSERT(!ZSTR_IS_INTERNED(str));
 				ZEND_ASSERT((GC_FLAGS(str) & IS_STR_PERSISTENT));
 				free(str);
+			} else if (Z_TYPE_P(zval_ptr) == IS_OBJECT) {
+				zend_object *obj = (zend_object *) ref;
+				ZEND_ASSERT((GC_FLAGS(ref) & IS_OBJ_PERSISTENT));
+				free(obj);
 			} else {
-				zend_error_noreturn(E_CORE_ERROR, "Internal zval's can't be arrays, objects, resources or reference");
+				zend_error_noreturn(E_CORE_ERROR, "Internal zval's can't be arrays, resources or reference");
 			}
 		}
 	}
@@ -129,5 +133,7 @@ ZEND_API void ZEND_FASTCALL zval_copy_ctor_func(zval *zvalue)
 		ZEND_ASSERT(!ZSTR_IS_INTERNED(Z_STR_P(zvalue)));
 		CHECK_ZVAL_STRING(Z_STR_P(zvalue));
 		ZVAL_NEW_STR(zvalue, zend_string_dup(Z_STR_P(zvalue), 0));
+	} else if (EXPECTED(Z_TYPE_P(zvalue) == IS_OBJECT)) {
+		ZVAL_OBJ(zvalue, zend_objects_persistent_copy(Z_OBJ_P(zvalue)));
 	}
 }

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -1388,7 +1388,7 @@ object ":" uiv ":" ["]	{
 		}
 	}
 	ZEND_ASSERT(Z_TYPE_P(value) == IS_OBJECT);
-	ZVAL_COPY(rval, value);
+	ZVAL_COPY_OR_DUP(rval, value);
 
 	return 1;
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -294,6 +294,18 @@ void zend_attribute_validate_zendtestattribute(zend_attribute *attr, uint32_t ta
 	}
 }
 
+static ZEND_METHOD(ZendTestUnbacked, showName)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	RETURN_COPY(zend_enum_fetch_case_name(Z_OBJ_P(getThis())));
+}
+
+static ZEND_METHOD(ZendTestStringBacked, getFirst)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	RETURN_OBJ_COPY(zend_objects_persistent_copy(enum_ZendTestStringBacked_FIRST));
+}
+
 static ZEND_METHOD(_ZendTestClass, __toString)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -383,6 +395,10 @@ PHP_MINIT_FUNCTION(zend_test)
 	zend_test_ns_foo_class = register_class_ZendTestNS_Foo();
 	zend_test_ns2_foo_class = register_class_ZendTestNS2_Foo();
 	zend_test_ns2_ns_foo_class = register_class_ZendTestNS2_ZendSubNS_Foo();
+
+	register_class_ZendTestIntBacked();
+	register_class_ZendTestStringBacked();
+	register_class_ZendTestUnbacked();
 
 	// Loading via dl() not supported with the observer API
 	if (type != MODULE_TEMPORARY) {

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -44,6 +44,25 @@ final class ZendTestAttribute {
 
 }
 
+enum ZendTestUnbacked {
+    case FIRST;
+    case SECOND;
+
+    public function showName(): string {}
+}
+
+enum ZendTestStringBacked: string {
+    case FIRST = "a";
+    case SECOND = "bc";
+
+    public static function getFirst(): ZendTestStringBacked {}
+}
+
+enum ZendTestIntBacked: int {
+    case FIRST = 42;
+    case SECOND = -42;
+}
+
 function zend_test_array_return(): array {}
 
 function zend_test_nullable_array_return(): ?array {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 70374ed7b55604eb98e85148d7ff19e79258ce92 */
+ * Stub hash: 7a76a82242a168597397e7ae7f3533d648a6fefc */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -71,6 +71,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class__ZendTestTrait_testMethod arginfo_ZendTestNS2_ZendSubNS_namespaced_func
 
+#define arginfo_class_ZendTestUnbacked_showName arginfo_class__ZendTestClass___toString
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ZendTestStringBacked_getFirst, 0, 0, ZendTestStringBacked, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_ZendTestNS_Foo_method arginfo_zend_test_void_return
 
 #define arginfo_class_ZendTestNS2_Foo_method arginfo_zend_test_void_return
@@ -98,6 +103,8 @@ static ZEND_METHOD(_ZendTestClass, returnsStatic);
 static ZEND_METHOD(_ZendTestClass, returnsThrowable);
 static ZEND_METHOD(_ZendTestChildClass, returnsThrowable);
 static ZEND_METHOD(_ZendTestTrait, testMethod);
+static ZEND_METHOD(ZendTestUnbacked, showName);
+static ZEND_METHOD(ZendTestStringBacked, getFirst);
 static ZEND_METHOD(ZendTestNS_Foo, method);
 static ZEND_METHOD(ZendTestNS2_Foo, method);
 static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method);
@@ -149,6 +156,23 @@ static const zend_function_entry class__ZendTestTrait_methods[] = {
 
 
 static const zend_function_entry class_ZendTestAttribute_methods[] = {
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ZendTestUnbacked_methods[] = {
+	ZEND_ME(ZendTestUnbacked, showName, arginfo_class_ZendTestUnbacked_showName, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ZendTestStringBacked_methods[] = {
+	ZEND_ME(ZendTestStringBacked, getFirst, arginfo_class_ZendTestStringBacked_getFirst, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ZendTestIntBacked_methods[] = {
 	ZEND_FE_END
 };
 
@@ -264,6 +288,42 @@ static zend_class_entry *register_class_ZendTestAttribute(void)
 	INIT_CLASS_ENTRY(ce, "ZendTestAttribute", class_ZendTestAttribute_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	return class_entry;
+}
+
+static zend_object *enum_ZendTestUnbacked_FIRST;
+static zend_object *enum_ZendTestUnbacked_SECOND;
+
+static zend_class_entry *register_class_ZendTestUnbacked(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_enum_ex("ZendTestUnbacked", class_ZendTestUnbacked_methods);
+	enum_ZendTestUnbacked_FIRST = zend_add_enum_case(class_entry, "FIRST");
+	enum_ZendTestUnbacked_SECOND = zend_add_enum_case(class_entry, "SECOND");
+
+	return class_entry;
+}
+
+static zend_object *enum_ZendTestStringBacked_FIRST;
+static zend_object *enum_ZendTestStringBacked_SECOND;
+
+static zend_class_entry *register_class_ZendTestStringBacked(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_backed_enum_ex("ZendTestStringBacked", IS_STRING, class_ZendTestStringBacked_methods);
+	enum_ZendTestStringBacked_FIRST = zend_add_enum_case_string(class_entry, "FIRST", "a");
+	enum_ZendTestStringBacked_SECOND = zend_add_enum_case_string(class_entry, "SECOND", "bc");
+
+	return class_entry;
+}
+
+static zend_object *enum_ZendTestIntBacked_FIRST;
+static zend_object *enum_ZendTestIntBacked_SECOND;
+
+static zend_class_entry *register_class_ZendTestIntBacked(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_backed_enum_ex("ZendTestIntBacked", IS_LONG, class_ZendTestIntBacked_methods);
+	enum_ZendTestIntBacked_FIRST = zend_add_enum_case_long(class_entry, "FIRST", 42);
+	enum_ZendTestIntBacked_SECOND = zend_add_enum_case_long(class_entry, "SECOND", -42);
 
 	return class_entry;
 }


### PR DESCRIPTION
This uses persistently malloc()'ed objects, which get duplicated to an request-unique object.
Those request-unique objects are supposed to be immutable for the lifetime of the request, i.e. they can be just efree()'d without issues.

~~This patch requires https://github.com/nikic/PHP-Parser/pull/792 (and a subsequent update of the tag) before merging.~~ Done.