### PR TITLE
Fix #81223: flock() only locks first byte of file

### DIFF
--- a/ext/standard/flock_compat.c
+++ b/ext/standard/flock_compat.c
@@ -116,7 +116,7 @@ PHPAPI int php_flock(int fd, int operation)
  */
 {
     HANDLE hdl = (HANDLE) _get_osfhandle(fd);
-    DWORD low = 1, high = 0;
+    DWORD low = 0xFFFFFFFF, high = 0xFFFFFFFF;
     OVERLAPPED offset =
     {0, 0, 0, 0, NULL};
 	DWORD err;

--- a/ext/standard/tests/file/bug81223.phpt
+++ b/ext/standard/tests/file/bug81223.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #81223 (flock() only locks first byte of file)
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY !== "Windows") die("skip for Windows only");
+?>
+--FILE--
+<?php
+$filename = __FILE__;
+$stream1 = fopen($filename, "r");
+var_dump(flock($stream1, LOCK_EX));
+$stream2 = fopen($filename, "r");
+var_dump(fread($stream2, 5));
+fseek($stream2, 1);
+var_dump(fread($stream2, 4));
+?>
+--EXPECTF--
+bool(true)
+
+Notice: fread(): read of %d bytes failed with errno=13 Permission denied in %s on line %d
+bool(false)
+
+Notice: fread(): read of %d bytes failed with errno=13 Permission denied in %s on line %d
+bool(false)


### PR DESCRIPTION
`flock()` should lock the whole file, like on other systems which use
mandatory locking.  We cannot use `0` like for `flck.l_len`, so we use
the largest number, what is valid according to the documentation:
<https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex#remarks>.