### PR TITLE
Fix typo "without-pcre-jit"

### DIFF
--- a/ext/pcre/config0.m4
+++ b/ext/pcre/config0.m4
@@ -7,8 +7,8 @@ PHP_ARG_WITH([external-pcre],,
   [no])
 
 PHP_ARG_WITH([pcre-jit],,
-  [AS_HELP_STRING([--with-pcre-jit],
-    [Enable PCRE JIT functionality])],
+  [AS_HELP_STRING([--without-pcre-jit],
+    [Disable PCRE JIT functionality])],
   [yes],
   [no])
 


### PR DESCRIPTION
PCRE is actually enabled by default, and the option `--with-pcre-jit` was wrongfully called so. This PR is (hopefully the right) fix for that.

Discussed here: https://chat.stackoverflow.com/transcript/message/52568001#52568001