### PR TITLE
Fix #73226: --r[fcez] always return zero exit code

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1086,6 +1086,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 						zend_printf("Exception: %s\n", Z_STRVAL_P(msg));
 						zval_ptr_dtor(&tmp);
 						EG(exception) = NULL;
+						exit_status = 1;
 					} else {
 						zend_print_zval(&ref, 0);
 						zend_write("\n", 1);


### PR DESCRIPTION
This makes the behavior consistent with `--ri`, and is likely useful
for scripting.

---

Might be better to target the "master" branch only.