### PR TITLE
Make 'readonly' keyword semi-reserved instead of reserved

### DIFF
--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -305,7 +305,7 @@ reserved_non_modifiers:
 
 semi_reserved:
 	  reserved_non_modifiers
-	| T_STATIC | T_ABSTRACT | T_FINAL | T_PRIVATE | T_PROTECTED | T_PUBLIC
+	| T_STATIC | T_ABSTRACT | T_FINAL | T_PRIVATE | T_PROTECTED | T_PUBLIC | T_READONLY
 ;
 
 ampersand:


### PR DESCRIPTION
E.g. allow using 'readonly' as a method name, etc.
`MyClass::readonly()` was previously a syntax error and this change makes it
stop being a syntax error.