### PR TITLE
Verify exception on ZipArchive::getExternalAttributesName when $name is empty

### DIFF
--- a/ext/zip/tests/oo_getexternalattributesname_error.phpt
+++ b/ext/zip/tests/oo_getexternalattributesname_error.phpt
@@ -1,0 +1,28 @@
+--TEST--
+ZipArchive::getExternalAttributesName() empty name error
+--DESCRIPTION--
+This test verifies that ZipArchive::getExternalAttributesName() will throw Fatal error: Uncaught ValueError if the first parameter is empty
+--CREDITS--
+Meletios Flevarakis php@flevarakis.xyz
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+
+$zip = new ZipArchive();
+$dirname = __DIR__ . '/';
+
+$zip->open($dirname . "test.zip", ZIPARCHIVE::CREATE);
+
+$a = ZipArchive::OPSYS_DEFAULT;
+$b = ZipArchive::OPSYS_DEFAULT;
+
+$out = $zip->getExternalAttributesName("", $a, $b);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught ValueError: ZipArchive::getExternalAttributesName(): Argument #1 ($name) cannot be empty in %s
+Stack trace:
+#0 %s(%d): ZipArchive->getExternalAttributesName('', 3, 3)
+#1 {main}
+  thrown in %s on line %d

--- a/ext/zip/tests/oo_getexternalattributesname_error.phpt
+++ b/ext/zip/tests/oo_getexternalattributesname_error.phpt
@@ -1,9 +1,5 @@
 --TEST--
-ZipArchive::getExternalAttributesName() empty name error
---DESCRIPTION--
-This test verifies that ZipArchive::getExternalAttributesName() will throw Fatal error: Uncaught ValueError if the first parameter is empty
---CREDITS--
-Meletios Flevarakis php@flevarakis.xyz
+ZipArchive::getExternalAttributesName() throws a ValueError when the $name param is empty
 --EXTENSIONS--
 zip
 --FILE--
@@ -17,12 +13,11 @@ $zip->open($dirname . "test.zip", ZIPARCHIVE::CREATE);
 $a = ZipArchive::OPSYS_DEFAULT;
 $b = ZipArchive::OPSYS_DEFAULT;
 
-$out = $zip->getExternalAttributesName("", $a, $b);
-
+try {
+    $zip->getExternalAttributesName("", $a, $b);
+} catch(ValueError $e) {
+    echo $e->getMessage();
+}
 ?>
---EXPECTF--
-Fatal error: Uncaught ValueError: ZipArchive::getExternalAttributesName(): Argument #1 ($name) cannot be empty in %s
-Stack trace:
-#0 %s(%d): ZipArchive->getExternalAttributesName('', 3, 3)
-#1 {main}
-  thrown in %s on line %d
+--EXPECT--
+ZipArchive::getExternalAttributesName(): Argument #1 ($name) cannot be empty


### PR DESCRIPTION
Hello all,

This test verifies that when you pass an empty parameter on ZipArchive::getExternalAttributesName() it will throw a fatal exception (_ValueError_). 

The test also improves the coverage of **etx/zip/php_zip.c** on lines 2223-2224