### PR TITLE
Fix #81243: Too much memory is allocated for preg_replace()

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -1805,14 +1805,12 @@ not_matched:
 				result = zend_string_copy(subject_str);
 				break;
 			}
-			new_len = result_len + subject_len - last_end_offset;
-			if (new_len >= alloc_len) {
-				alloc_len = new_len; /* now we know exactly how long it is */
-				if (NULL != result) {
-					result = zend_string_realloc(result, alloc_len, 0);
-				} else {
-					result = zend_string_alloc(alloc_len, 0);
-				}
+			/* now we know exactly how long it is */
+			alloc_len = result_len + subject_len - last_end_offset;
+			if (NULL != result) {
+				result = zend_string_realloc(result, alloc_len, 0);
+			} else {
+				result = zend_string_alloc(alloc_len, 0);
 			}
 			/* stick that last bit of string on our output */
 			memcpy(ZSTR_VAL(result) + result_len, piece, subject_len - last_end_offset);

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -1719,7 +1719,7 @@ matched:
 			}
 
 			if (new_len >= alloc_len) {
-				alloc_len = zend_safe_address_guarded(2, new_len, alloc_len);
+				alloc_len = zend_safe_address_guarded(2, new_len, 0);
 				if (result == NULL) {
 					result = zend_string_alloc(alloc_len, 0);
 				} else {
@@ -1957,7 +1957,7 @@ matched:
 			ZEND_ASSERT(eval_result);
 			new_len = zend_safe_address_guarded(1, ZSTR_LEN(eval_result), new_len);
 			if (new_len >= alloc_len) {
-				alloc_len = zend_safe_address_guarded(2, new_len, alloc_len);
+				alloc_len = zend_safe_address_guarded(2, new_len, 0);
 				if (result == NULL) {
 					result = zend_string_alloc(alloc_len, 0);
 				} else {

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -2014,14 +2014,12 @@ not_matched:
 				result = zend_string_copy(subject_str);
 				break;
 			}
-			new_len = result_len + subject_len - last_end_offset;
-			if (new_len >= alloc_len) {
-				alloc_len = new_len; /* now we know exactly how long it is */
-				if (NULL != result) {
-					result = zend_string_realloc(result, alloc_len, 0);
-				} else {
-					result = zend_string_alloc(alloc_len, 0);
-				}
+			/* now we know exactly how long it is */
+			alloc_len = result_len + subject_len - last_end_offset;
+			if (NULL != result) {
+				result = zend_string_realloc(result, alloc_len, 0);
+			} else {
+				result = zend_string_alloc(alloc_len, 0);
 			}
 			/* stick that last bit of string on our output */
 			memcpy(ZSTR_VAL(result) + result_len, piece, subject_len - last_end_offset);

--- a/ext/pcre/tests/bug81243.phpt
+++ b/ext/pcre/tests/bug81243.phpt
@@ -1,5 +1,5 @@
 --TEST--
-
+Bug #81243 (Too much memory is allocated for preg_replace())
 --FILE--
 <?php
 $test_string = str_repeat('Eins zwei drei', 2000);

--- a/ext/pcre/tests/bug81243.phpt
+++ b/ext/pcre/tests/bug81243.phpt
@@ -1,0 +1,13 @@
+--TEST--
+
+--FILE--
+<?php
+$test_string = str_repeat('Eins zwei drei', 2000);
+$replaced = preg_replace('/\s/', '-', $test_string);
+$mem0 = memory_get_usage();
+$replaced = str_repeat($replaced, 1);
+$mem1 = memory_get_usage();
+var_dump($mem0 == $mem1);
+?>
+--EXPECT--
+bool(true)

--- a/ext/pcre/tests/bug81243.phpt
+++ b/ext/pcre/tests/bug81243.phpt
@@ -3,11 +3,19 @@
 --FILE--
 <?php
 $test_string = str_repeat('Eins zwei drei', 2000);
+
 $replaced = preg_replace('/\s/', '-', $test_string);
+$mem0 = memory_get_usage();
+$replaced = str_repeat($replaced, 1);
+$mem1 = memory_get_usage();
+var_dump($mem0 == $mem1);
+
+$replaced = preg_replace_callback('/\s/', function ($_) {return '-';}, $test_string);
 $mem0 = memory_get_usage();
 $replaced = str_repeat($replaced, 1);
 $mem1 = memory_get_usage();
 var_dump($mem0 == $mem1);
 ?>
 --EXPECT--
+bool(true)
 bool(true)


### PR DESCRIPTION
If `new_len > alloc_len`, we had a serious issue anyway.  The
comparison only makes some sense if `new_len == alloc_len`, but in that
case we don't need to *re*-allocate.  Only if `new_len == 0` we need to
allocate an empty zend_string.  However, trimming a potentially over-
allocated string appears to be reasonable, so we drop the condition
altogether.
