### PR TITLE
Fix #81225: Incorrect immediate encoding when using LEA optimization

### DIFF
--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -4274,17 +4274,20 @@ static int zend_jit_math_long_long(dasm_State    **Dst,
 	} else if (opcode == ZEND_ADD &&
 			!may_overflow &&
 			Z_MODE(op1_addr) == IS_REG &&
-			Z_MODE(op2_addr) == IS_CONST_ZVAL) {
+			Z_MODE(op2_addr) == IS_CONST_ZVAL &&
+			IS_SIGNED_32BIT(Z_LVAL_P(Z_ZV(op2_addr)))) {
 		|	lea Ra(result_reg), [Ra(Z_REG(op1_addr))+Z_LVAL_P(Z_ZV(op2_addr))]
 	} else if (opcode == ZEND_ADD &&
 			!may_overflow &&
 			Z_MODE(op2_addr) == IS_REG &&
-			Z_MODE(op1_addr) == IS_CONST_ZVAL) {
+			Z_MODE(op1_addr) == IS_CONST_ZVAL &&
+			IS_SIGNED_32BIT(Z_LVAL_P(Z_ZV(op1_addr)))) {
 		|	lea Ra(result_reg), [Ra(Z_REG(op2_addr))+Z_LVAL_P(Z_ZV(op1_addr))]
 	} else if (opcode == ZEND_SUB &&
 			!may_overflow &&
 			Z_MODE(op1_addr) == IS_REG &&
-			Z_MODE(op2_addr) == IS_CONST_ZVAL) {
+			Z_MODE(op2_addr) == IS_CONST_ZVAL &&
+			IS_SIGNED_32BIT(-Z_LVAL_P(Z_ZV(op2_addr)))) {
 		|	lea Ra(result_reg), [Ra(Z_REG(op1_addr))-Z_LVAL_P(Z_ZV(op2_addr))]
 	} else {
 		|	GET_ZVAL_LVAL result_reg, op1_addr

--- a/ext/opcache/tests/jit/bug81225.phpt
+++ b/ext/opcache/tests/jit/bug81225.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Bug #81225 (Incorrect immediate encoding when using LEA optimization)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+;opcache.jit_debug=257
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE != 8) die("skip: 64-bit only"); ?>
+--FILE--
+<?php
+function add_with_positive(int $a) {
+    $a = $a % 10;
+    $b = $a + 1;
+    $c = $a + 100;
+    $d = $a + 2147483647;          // 0x7fff,ffff
+    $e = $a + 2147483648;          // 0x8000,0000     cannot encoded as imm field of lea r1, [r2 + imm]
+    $f = $a + 78187493394;         // 0x12,1234,5678  cannot encoded as imm field of lea r1, [r2 + imm]
+    var_dump($b, $c, $d, $e, $f);
+}
+
+function add_with_negative(int $a) {
+    $a = $a % 10;
+    $b = $a + (-1);
+    $c = $a + (-100);
+    $d = $a + (-2147483648);       // 0xFFFF,FFFF,8000,0000
+    $e = $a + (-2147483649);       // 0xFFFF,FFFF,7FFF,FFFF  cannot encoded as imm field of lea r1, [r2 + imm]
+    $f = $a + (-261458978401740);  // 0xFFFF,1234,5678,1234  cannot encoded as imm field of lea r1, [r2 + imm]
+    var_dump($b, $c, $d, $e, $f);
+}
+
+function sub_with_positive(int $a) {
+    $a = $a % 10;
+    $b = $a - 1;
+    $c = $a - 100;
+    $d = $a - 2147483647;          // 0x7fff,ffff
+    $e = $a - 2147483648;          // 0x8000,0000
+    $f = $a - 2147483649;          // 0x8000,0001     cannot encoded as imm field of lea r1, [r2 + imm]
+    $g = $a - 78187493394;         // 0x12,1234,5678  cannot encoded as imm field of lea r1, [r2 + imm]
+    var_dump($b, $c, $d, $e, $f, $g);
+}
+
+function sub_with_negative(int $a) {
+    $a = $a % 10;
+    $b = $a - (-1);
+    $c = $a - (-100);
+    $d = $a - (-2147483647);       // 0xFFFF,FFFF,8000,0001
+    $e = $a - (-2147483648);       // 0xFFFF,FFFF,8000,0000  cannot encoded as imm field of lea r1, [r2 + imm]
+    $f = $a - (-2147483649);       // 0xFFFF,FFFF,7FFF,FFFF  cannot encoded as imm field of lea r1, [r2 + imm]
+    $g = $a - (-261458978401740);  // 0xFFFF,1234,5678,1234  cannot encoded as imm field of lea r1, [r2 + imm]
+    var_dump($b, $c, $d, $e, $f, $g);
+}
+
+add_with_positive(2);
+add_with_negative(2);
+sub_with_positive(2);
+sub_with_negative(2);
+
+?>
+--EXPECT--
+int(3)
+int(102)
+int(2147483649)
+int(2147483650)
+int(78187493396)
+int(1)
+int(-98)
+int(-2147483646)
+int(-2147483647)
+int(-261458978401738)
+int(1)
+int(-98)
+int(-2147483645)
+int(-2147483646)
+int(-2147483647)
+int(-78187493392)
+int(3)
+int(102)
+int(2147483649)
+int(2147483650)
+int(2147483651)
+int(261458978401742)


### PR DESCRIPTION
In JIT/x86, adding with constants would be optimized to LEA instruction.
One premise is that this addition would not overflow. This applys for
subtraction with constants as well.

In the addressing model of x86_64, the "displacement" field in "base +
dispalcement" mode is 32-bit long and would be sign-extended to 64 bits.
However, in JIT/x86, such range check is missing.

In this patch, we add these range checks and one unit test case.

Note: this bug doesn't affect JIT/arm64 in master branch as such "LEA"
optimization is not conducted in JIT/arm64.

Note: this patch should be merged to master branch as well.

[1] https://bugs.php.net/bug.php?id=81225

Change-Id: I6e5cba0958e888d0bcf44db50b1f148094a241f8