### PR TITLE
Proposal: Rename FFI `getFuncArg*` to `getFuncParameter*`, $arg_index->$index

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4730,7 +4730,7 @@ ZEND_METHOD(FFI_CType, getFuncReturnType) /* {{{ */
 }
 /* }}} */
 
-ZEND_METHOD(FFI_CType, getFuncArgCount) /* {{{ */
+ZEND_METHOD(FFI_CType, getFuncParameterCount) /* {{{ */
 {
 	zend_ffi_ctype *ctype = (zend_ffi_ctype*)(Z_OBJ_P(ZEND_THIS));
 	zend_ffi_type *type;
@@ -4748,7 +4748,7 @@ ZEND_METHOD(FFI_CType, getFuncArgCount) /* {{{ */
 }
 /* }}} */
 
-ZEND_METHOD(FFI_CType, getFuncArgType) /* {{{ */
+ZEND_METHOD(FFI_CType, getFuncParameterType) /* {{{ */
 {
 	zend_ffi_ctype *ctype = (zend_ffi_ctype*)(Z_OBJ_P(ZEND_THIS));
 	zend_ffi_type *type, *ptr;

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4653,7 +4653,7 @@ ZEND_METHOD(FFI_CType, getStructFieldOffset) /* {{{ */
 
 	ptr = zend_hash_find_ptr(&type->record.fields, name);
 	if (!ptr) {
-		zend_throw_error(zend_ffi_exception_ce, "Wrong fileld name");
+		zend_throw_error(zend_ffi_exception_ce, "Wrong field name");
 		RETURN_THROWS();
 	}
 	RETURN_LONG(ptr->offset);
@@ -4680,7 +4680,7 @@ ZEND_METHOD(FFI_CType, getStructFieldType) /* {{{ */
 
 	ptr = zend_hash_find_ptr(&type->record.fields, name);
 	if (!ptr) {
-		zend_throw_error(zend_ffi_exception_ce, "Wrong fileld name");
+		zend_throw_error(zend_ffi_exception_ce, "Wrong field name");
 		RETURN_THROWS();
 	}
 

--- a/ext/ffi/ffi.stub.php
+++ b/ext/ffi/ffi.stub.php
@@ -92,8 +92,8 @@ final class CType {
 
     public function getFuncABI(): int {}
     public function getFuncReturnType(): CType {}
-    public function getFuncArgCount(): int {}
-    public function getFuncArgType(int $arg_index): CType {}
+    public function getFuncParameterCount(): int {}
+    public function getFuncParameterType(int $arg_index): CType {}
 }
 
 class Exception extends \Error {

--- a/ext/ffi/ffi.stub.php
+++ b/ext/ffi/ffi.stub.php
@@ -93,7 +93,7 @@ final class CType {
     public function getFuncABI(): int {}
     public function getFuncReturnType(): CType {}
     public function getFuncParameterCount(): int {}
-    public function getFuncParameterType(int $arg_index): CType {}
+    public function getFuncParameterType(int $index): CType {}
 }
 
 class Exception extends \Error {

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e1141661e96f6fcf67b7dc79b345cfb50c246ac2 */
+ * Stub hash: 2675462a253edd2a0ea6106b9640f0d1a5a09489 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_cdef, 0, 0, FFI, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, code, IS_STRING, 0, "\"\"")
@@ -118,7 +118,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_FFI_CType_getFuncParameterCount arginfo_class_FFI_CType_getKind
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_CType_getFuncParameterType, 0, 1, FFI\\CType, 0)
-	ZEND_ARG_TYPE_INFO(0, arg_index, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bdfc4211d30630290aaf5046dd4ae72936982703 */
+ * Stub hash: e1141661e96f6fcf67b7dc79b345cfb50c246ac2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_cdef, 0, 0, FFI, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, code, IS_STRING, 0, "\"\"")
@@ -115,9 +115,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_FFI_CType_getFuncReturnType arginfo_class_FFI_CType_getArrayElementType
 
-#define arginfo_class_FFI_CType_getFuncArgCount arginfo_class_FFI_CType_getKind
+#define arginfo_class_FFI_CType_getFuncParameterCount arginfo_class_FFI_CType_getKind
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_CType_getFuncArgType, 0, 1, FFI\\CType, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_CType_getFuncParameterType, 0, 1, FFI\\CType, 0)
 	ZEND_ARG_TYPE_INFO(0, arg_index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -153,8 +153,8 @@ ZEND_METHOD(FFI_CType, getStructFieldOffset);
 ZEND_METHOD(FFI_CType, getStructFieldType);
 ZEND_METHOD(FFI_CType, getFuncABI);
 ZEND_METHOD(FFI_CType, getFuncReturnType);
-ZEND_METHOD(FFI_CType, getFuncArgCount);
-ZEND_METHOD(FFI_CType, getFuncArgType);
+ZEND_METHOD(FFI_CType, getFuncParameterCount);
+ZEND_METHOD(FFI_CType, getFuncParameterType);
 
 
 static const zend_function_entry class_FFI_methods[] = {
@@ -199,8 +199,8 @@ static const zend_function_entry class_FFI_CType_methods[] = {
 	ZEND_ME(FFI_CType, getStructFieldType, arginfo_class_FFI_CType_getStructFieldType, ZEND_ACC_PUBLIC)
 	ZEND_ME(FFI_CType, getFuncABI, arginfo_class_FFI_CType_getFuncABI, ZEND_ACC_PUBLIC)
 	ZEND_ME(FFI_CType, getFuncReturnType, arginfo_class_FFI_CType_getFuncReturnType, ZEND_ACC_PUBLIC)
-	ZEND_ME(FFI_CType, getFuncArgCount, arginfo_class_FFI_CType_getFuncArgCount, ZEND_ACC_PUBLIC)
-	ZEND_ME(FFI_CType, getFuncArgType, arginfo_class_FFI_CType_getFuncArgType, ZEND_ACC_PUBLIC)
+	ZEND_ME(FFI_CType, getFuncParameterCount, arginfo_class_FFI_CType_getFuncParameterCount, ZEND_ACC_PUBLIC)
+	ZEND_ME(FFI_CType, getFuncParameterType, arginfo_class_FFI_CType_getFuncParameterType, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/ext/ffi/tests/046.phpt
+++ b/ext/ffi/tests/046.phpt
@@ -47,9 +47,9 @@ $x = FFI::type("void (*)(double,int32_t)");
 var_dump($x->getKind() === $x::TYPE_POINTER);
 var_dump($x->getPointerType()->getKind() === $x::TYPE_FUNC);
 var_dump($x->getPointerType()->getFuncReturnType()->getKind() === $x::TYPE_VOID);
-var_dump($x->getPointerType()->getFuncArgCount());
-var_dump($x->getPointerType()->getFuncArgType(0)->getKind() === $x::TYPE_DOUBLE);
-var_dump($x->getPointerType()->getFuncArgType(1)->getKind() === $x::TYPE_SINT32);
+var_dump($x->getPointerType()->getFuncParameterCount());
+var_dump($x->getPointerType()->getFuncParameterType(0)->getKind() === $x::TYPE_DOUBLE);
+var_dump($x->getPointerType()->getFuncParameterType(1)->getKind() === $x::TYPE_SINT32);
 ?>
 --EXPECT--
 bool(true)

--- a/ext/ffi/tests/bug80847.phpt
+++ b/ext/ffi/tests/bug80847.phpt
@@ -4,7 +4,7 @@ Bug #80847 (Nested structs)
 ffi
 --SKIPIF--
 <?php
-if (PHP_OS_FAMILY == 'Windows' && ((1 << 31) > 0)) die('xfail libffi doesn\'t properly support passing big strctures by value on Windows/64');
+if (PHP_OS_FAMILY == 'Windows' && ((1 << 31) > 0)) die('xfail libffi doesn\'t properly support passing big structures by value on Windows/64');
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
PHP is already already using "Parameter" instead of "Argument" for reflection on types elsewhere.

Parameter is used to refer to the function declarations
(AST_PARAM internally in the AST, ReflectionFunctionAbstract->getParameters(),
etc.)
Argument is used to refer to expressions passed to the functions by the caller
(ArgumentCountError, etc.).
(Error messages were also changed in php 8.x to refer to passing too many arguments to a
function)

Other languages use similar definitions,
e.g. https://developer.mozilla.org/en-US/docs/Glossary/Parameter

Followup to https://github.com/php/php-src/pull/7217#pullrequestreview-700990479 

-----

Looking at this again, I don't see a need to drop the "Func" - there's already getFuncABI.

If you look at the current implementation, there's getStruct*, getArray*, getPointer*, meaning `getFunc*` sort of makes sense for a naming scheme to make it easier to find functionality associated with a given function.