### PR TITLE
Fix #72146: Integer overflow on substr_replace

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2664,7 +2664,9 @@ PHP_FUNCTION(substr_replace)
 				}
 			}
 
-			if ((f + l) > (zend_long)ZSTR_LEN(orig_str)) {
+			ZEND_ASSERT(0 <= f && f <= ZEND_LONG_MAX);
+			ZEND_ASSERT(0 <= l && l <= ZEND_LONG_MAX);
+			if (((size_t) f + l) > ZSTR_LEN(orig_str)) {
 				l = ZSTR_LEN(orig_str) - f;
 			}
 

--- a/ext/standard/tests/strings/bug72146.phpt
+++ b/ext/standard/tests/strings/bug72146.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #72146 (Integer overflow on substr_replace)
+--FILE--
+<?php 
+var_dump(substr_replace(["ABCDE"], "123", 3, PHP_INT_MAX));
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(6) "ABC123"
+}


### PR DESCRIPTION
Adding two `zend_long`s may overflow, and casting `size_t` to
`zend_long` may truncate; we can avoid this here by enforcing unsigned
arithmetic.