### PR TITLE
Add support for defining object constants via define()

### DIFF
--- a/Zend/tests/constexpr/new_allowed.phpt
+++ b/Zend/tests/constexpr/new_allowed.phpt
@@ -17,19 +17,32 @@ function test($param = new stdClass) {
     var_dump($param, $var);
 }
 
+class Test3 implements Stringable {
+    public function __toString(): string {
+        return "hello";
+    }
+}
+
 const TEST = new stdClass;
+define("TEST2", new stdClass);
+define("TEST3", new Test3);
 
 new Test;
 test();
 var_dump(TEST);
+var_dump(TEST2);
+var_dump(TEST3);
 
 ?>
 --EXPECT--
-object(stdClass)#3 (0) {
-}
-object(stdClass)#2 (0) {
+object(stdClass)#4 (0) {
 }
 object(stdClass)#3 (0) {
+}
+object(stdClass)#4 (0) {
 }
 object(stdClass)#1 (0) {
 }
+object(stdClass)#2 (0) {
+}
+string(5) "hello"

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -432,10 +432,6 @@ static bool validate_constant_array_argument(HashTable *ht, int argument_number)
 						break;
 					}
 				}
-			} else if (Z_TYPE_P(val) != IS_STRING && Z_TYPE_P(val) != IS_RESOURCE) {
-				zend_argument_type_error(argument_number, "cannot be an object, %s given", zend_zval_type_name(val));
-				ret = 0;
-				break;
 			}
 		}
 	} ZEND_HASH_FOREACH_END();
@@ -443,6 +439,13 @@ static bool validate_constant_array_argument(HashTable *ht, int argument_number)
 	return ret;
 }
 /* }}} */
+
+static bool validate_constant_obj_argument(zend_object *obj)
+{
+	bool ret = 1;
+
+	return ret;
+}
 
 static void copy_constant_array(zval *dst, zval *src) /* {{{ */
 {
@@ -520,11 +523,10 @@ ZEND_FUNCTION(define)
 				val = &val_free;
 				break;
 			}
-			ZEND_FALLTHROUGH;
-		default:
-			zval_ptr_dtor(&val_free);
-			zend_argument_type_error(2, "cannot be an object, %s given", zend_zval_type_name(val));
-			RETURN_THROWS();
+
+			if (!validate_constant_obj_argument(Z_OBJ_P(val))) {
+				RETURN_THROWS();
+			}
 	}
 
 	ZVAL_COPY(&c.value, val);

--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -26,8 +26,7 @@ function strncasecmp(string $string1, string $string2, int $length): int {}
 
 function error_reporting(?int $error_level = null): int {}
 
-/** @param mixed $value */
-function define(string $constant_name, $value, bool $case_insensitive = false): bool {}
+function define(string $constant_name, mixed $value, bool $case_insensitive = false): bool {}
 
 function defined(string $constant_name): bool {}
 

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c333499e3ea100d976f0fa8bb8800ed21b04f1c6 */
+ * Stub hash: 38936b472d60d9eeb2cc8e35c1276e9f707837bf */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_version, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -39,7 +39,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_define, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, constant_name, IS_STRING, 0)
-	ZEND_ARG_INFO(0, value)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, case_insensitive, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
Hopefully, I'm not missing any conceptual problem why the original RFC left this use-case out.