### PR TITLE
Fix #78238: BCMath returns "-0"

### DIFF
--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -120,6 +120,8 @@ _PROTOTYPE(int bc_compare, (bc_num n1, bc_num n2));
 
 _PROTOTYPE(char bc_is_zero, (bc_num num));
 
+_PROTOTYPE(char bc_is_zero_for_scale, (bc_num num, int scale));
+
 _PROTOTYPE(char bc_is_near_zero, (bc_num num, int scale));
 
 _PROTOTYPE(char bc_is_neg, (bc_num num));

--- a/ext/bcmath/libbcmath/src/num2str.c
+++ b/ext/bcmath/libbcmath/src/num2str.c
@@ -50,7 +50,7 @@ zend_string
 	int  index, signch;
 
 	/* Allocate the string memory. */
-	signch = num->n_sign != PLUS;  /* Number of sign chars. */
+	signch = num->n_sign != PLUS && !bc_is_zero_for_scale(num, MIN(num->n_scale, scale));  /* Number of sign chars. */
 	if (scale > 0)
 		str = zend_string_alloc(num->n_len + scale + signch + 1, 0);
 	else

--- a/ext/bcmath/libbcmath/src/zero.c
+++ b/ext/bcmath/libbcmath/src/zero.c
@@ -40,7 +40,7 @@
 /* In some places we need to check if the number NUM is zero. */
 
 char
-bc_is_zero (bc_num num)
+bc_is_zero_for_scale (bc_num num, int scale)
 {
   int  count;
   char *nptr;
@@ -49,7 +49,7 @@ bc_is_zero (bc_num num)
   if (num == BCG(_zero_)) return TRUE;
 
   /* Initialize */
-  count = num->n_len + num->n_scale;
+  count = num->n_len + scale;
   nptr = num->n_value;
 
   /* The check */
@@ -59,4 +59,10 @@ bc_is_zero (bc_num num)
     return FALSE;
   else
     return TRUE;
+}
+
+char
+bc_is_zero (bc_num num)
+{
+  return bc_is_zero_for_scale(num, num->n_scale);
 }

--- a/ext/bcmath/tests/bug78238.phpt
+++ b/ext/bcmath/tests/bug78238.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #78238 (BCMath returns "-0")
+--SKIPIF--
+<?php
+if (!extension_loaded('bcmath')) die("sikp bcmath extension not available");
+?>
+--FILE--
+<?php
+var_dump(bcadd("0", "-0.1"));
+
+$a = bcmul("0.9", "-0.1", 1);
+$b = bcmul("0.90", "-0.1", 1);
+var_dump($a, $b);
+?>
+--EXPECT--
+string(1) "0"
+string(3) "0.0"
+string(3) "0.0"


### PR DESCRIPTION
There is no negative zero in the decimal system, so we must suppress
the sign.