### PR TITLE
Disable strict pixi requirement for libavif >= 0.9.1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,68 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "PHP aviftest",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/sapi/cli/php",
+      "args": ["../play/php/aviftest.php"],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb"
+    },
+    {
+      "name": "getimagesize",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/sapi/cli/php",
+      "args": ["../play/php/getimagesize.php"],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb"
+    },
+    {
+      "name": "imagecreatefromstring_avif",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/sapi/cli/php",
+      "args": ["ext/gd/tests/imagecreatefromstring_avif.phpt"],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb"
+    },
+    {
+      "name": "Web-Pee",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/sapi/cli/php",
+      "args": ["ext/gd/tests/imagecreatefromstring_webp.phpt"],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb"
+    },
+    {
+      "name": "avif_decode_encode",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/sapi/cli/php",
+      "args": ["ext/gd/tests/avif_decode_encode.phpt"],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "C_Cpp.dimInactiveRegions": false
+}

--- a/ext/gd/libgd/gd_avif.c
+++ b/ext/gd/libgd/gd_avif.c
@@ -342,6 +342,14 @@ gdImagePtr gdImageCreateFromAvifCtx (gdIOCtx *ctx)
 
 	decoder = avifDecoderCreate();
 
+	// Check if libavif version is >= 0.9.1
+#if AVIF_VERSION_MAJOR > 0 || (AVIF_VERSION_MAJOR == 0 && AVIF_VERSION_MINOR > 9) || (AVIF_VERSION_MAJOR == 0 && AVIF_VERSION_MINOR == 9 && AVIF_VERSION_PATCH >= 1)
+	// If so, allow the PixelInformationProperty ('pixi') to be missing in AV1 image
+	// items. libheif v1.11.0 or older does not add the 'pixi' item property to
+	// AV1 image items. (This issue has been corrected in libheif v1.12.0.)
+	decoder->strictFlags &= ~AVIF_STRICT_PIXI_REQUIRED;
+#endif
+
 	io = createAvifIOFromCtx(ctx);
 	if (!io) {
 		gd_error("avif error - Could not allocate memory");

--- a/ext/gd/libgd/gd_avif.c
+++ b/ext/gd/libgd/gd_avif.c
@@ -343,7 +343,7 @@ gdImagePtr gdImageCreateFromAvifCtx (gdIOCtx *ctx)
 	decoder = avifDecoderCreate();
 
 	// Check if libavif version is >= 0.9.1
-#if AVIF_VERSION_MAJOR > 0 || (AVIF_VERSION_MAJOR == 0 && AVIF_VERSION_MINOR > 9) || (AVIF_VERSION_MAJOR == 0 && AVIF_VERSION_MINOR == 9 && AVIF_VERSION_PATCH >= 1)
+#if AVIF_VERSION >= 90100
 	// If so, allow the PixelInformationProperty ('pixi') to be missing in AV1 image
 	// items. libheif v1.11.0 or older does not add the 'pixi' item property to
 	// AV1 image items. (This issue has been corrected in libheif v1.12.0.)

--- a/ext/gd/libgd/gd_avif.c
+++ b/ext/gd/libgd/gd_avif.c
@@ -343,10 +343,10 @@ gdImagePtr gdImageCreateFromAvifCtx (gdIOCtx *ctx)
 	decoder = avifDecoderCreate();
 
 	// Check if libavif version is >= 0.9.1
-#if AVIF_VERSION >= 90100
 	// If so, allow the PixelInformationProperty ('pixi') to be missing in AV1 image
 	// items. libheif v1.11.0 or older does not add the 'pixi' item property to
 	// AV1 image items. (This issue has been corrected in libheif v1.12.0.)
+#if AVIF_VERSION >= 90100
 	decoder->strictFlags &= ~AVIF_STRICT_PIXI_REQUIRED;
 #endif
 

--- a/ext/gd/tests/imagecreatefromstring_avif.phpt
+++ b/ext/gd/tests/imagecreatefromstring_avif.phpt
@@ -7,9 +7,6 @@ gd
 if (!(imagetypes() & IMG_AVIF)) {
     die('skip AVIF support required');
 }
-if (str_contains(PHP_OS, "FreeBSD")) {
-    die("xfail Currently failing on FreeBSD CI");
-}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Some AVIF image generators didn't include the PixelInformationProperty (pixi), even though strictly speaking they should. In v0.9.2, libavif began requiring this. Let's disable it so we can read those images too.