### PR TITLE
Sync the FPM openmetrics status with php-fpm_exporter

### DIFF
--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -140,7 +140,7 @@ int fpm_status_handle_request(void) /* {{{ */
 	struct fpm_scoreboard_proc_s proc;
 	char *buffer, *time_format, time_buffer[64];
 	time_t now_epoch;
-	int full, encode, is_start_time_str;
+	int full, encode, has_start_time;
 	char *short_syntax, *short_post;
 	char *full_pre, *full_syntax, *full_post, *full_separator;
 	zend_string *_GET_str;
@@ -223,7 +223,7 @@ int fpm_status_handle_request(void) /* {{{ */
 		short_syntax = short_post = NULL;
 		full_separator = full_pre = full_syntax = full_post = NULL;
 		encode = 0;
-		is_start_time_str = 1;
+		has_start_time = 1;
 
 		/* HTML */
 		if (fpm_php_get_string_from_table(_GET_str, "html")) {
@@ -398,21 +398,18 @@ int fpm_status_handle_request(void) /* {{{ */
 				"# HELP phpfpm_up Could pool %s using a %s PM on PHP-FPM be reached?\n"
 				"# TYPE phpfpm_up gauge\n"
 				"phpfpm_up 1\n"
-				"# HELP phpfpm_start_time When FPM has started.\n"
-				"# TYPE phpfpm_start_time gauge\n"
-				"phpfpm_start_time %lld\n"
-				"# HELP phpfpm_start_since_total The number of seconds since FPM has started.\n"
-				"# TYPE phpfpm_start_since_total counter\n"
-				"phpfpm_start_since_total %lu\n"
-				"# HELP phpfpm_accepted_connections_total The number of requests accepted by the pool.\n"
-				"# TYPE phpfpm_accepted_connections_total counter\n"
-				"phpfpm_accepted_connections_total %lu\n"
+				"# HELP phpfpm_start_since The number of seconds since FPM has started.\n"
+				"# TYPE phpfpm_start_since counter\n"
+				"phpfpm_start_since %lu\n"
+				"# HELP phpfpm_accepted_connections The number of requests accepted by the pool.\n"
+				"# TYPE phpfpm_accepted_connections counter\n"
+				"phpfpm_accepted_connections %lu\n"
 				"# HELP phpfpm_listen_queue The number of requests in the queue of pending connections.\n"
 				"# TYPE phpfpm_listen_queue gauge\n"
 				"phpfpm_listen_queue %d\n"
-				"# HELP phpfpm_max_listen_queue_total The maximum number of requests in the queue of pending connections since FPM has started.\n"
-				"# TYPE phpfpm_max_listen_queue_total counter\n"
-				"phpfpm_max_listen_queue_total %d\n"
+				"# HELP phpfpm_max_listen_queue The maximum number of requests in the queue of pending connections since FPM has started.\n"
+				"# TYPE phpfpm_max_listen_queue counter\n"
+				"phpfpm_max_listen_queue %d\n"
 				"# TYPE phpfpm_listen_queue_length gauge\n"
 				"# HELP phpfpm_listen_queue_length The size of the socket queue of pending connections.\n"
 				"phpfpm_listen_queue_length %u\n"
@@ -425,17 +422,17 @@ int fpm_status_handle_request(void) /* {{{ */
 				"# HELP phpfpm_total_processes The number of idle + active processes.\n"
 				"# TYPE phpfpm_total_processes gauge\n"
 				"phpfpm_total_processes %d\n"
-				"# HELP phpfpm_max_active_processes_total The maximum number of active processes since FPM has started.\n"
-				"# TYPE phpfpm_max_active_processes_total counter\n"
-				"phpfpm_max_active_processes_total %d\n"
-				"# HELP phpfpm_max_children_reached_total The number of times, the process limit has been reached, when pm tries to start more children (works only for pm 'dynamic' and 'ondemand').\n"
-				"# TYPE phpfpm_max_children_reached_total counter\n"
-				"phpfpm_max_children_reached_total %u\n"
-				"# HELP phpfpm_slow_requests_total The number of requests that exceeded your 'request_slowlog_timeout' value.\n"
-				"# TYPE phpfpm_slow_requests_total counter\n"
-				"phpfpm_slow_requests_total %lu\n";
+				"# HELP phpfpm_max_active_processes The maximum number of active processes since FPM has started.\n"
+				"# TYPE phpfpm_max_active_processes counter\n"
+				"phpfpm_max_active_processes %d\n"
+				"# HELP phpfpm_max_children_reached The number of times, the process limit has been reached, when pm tries to start more children (works only for pm 'dynamic' and 'ondemand').\n"
+				"# TYPE phpfpm_max_children_reached counter\n"
+				"phpfpm_max_children_reached %u\n"
+				"# HELP phpfpm_slow_requests The number of requests that exceeded your 'request_slowlog_timeout' value.\n"
+				"# TYPE phpfpm_slow_requests counter\n"
+				"phpfpm_slow_requests %lu\n";
 
-			is_start_time_str = 0;
+			has_start_time = 0;
 			if (!full) {
 				short_post = "";
 			} else {
@@ -487,7 +484,7 @@ int fpm_status_handle_request(void) /* {{{ */
 		}
 
 		now_epoch = time(NULL);
-		if (is_start_time_str) {
+		if (has_start_time) {
 			strftime(time_buffer, sizeof(time_buffer) - 1, time_format, localtime(&scoreboard.start_epoch));
 			spprintf(&buffer, 0, short_syntax,
 					scoreboard.pool,
@@ -508,7 +505,6 @@ int fpm_status_handle_request(void) /* {{{ */
 			spprintf(&buffer, 0, short_syntax,
 					scoreboard.pool,
 					PM2STR(scoreboard.pm),
-					(unsigned long long) scoreboard.start_epoch,
 					(unsigned long) (now_epoch - scoreboard.start_epoch),
 					scoreboard.requests,
 					scoreboard.lq,

--- a/sapi/fpm/tests/status.inc
+++ b/sapi/fpm/tests/status.inc
@@ -209,21 +209,18 @@ class Status
         $pattern = "|# HELP phpfpm_up Could pool " . $fields['pool'] . " using a " . $fields['process manager'] . " PM on PHP-FPM be reached\?\n" .
             "# TYPE phpfpm_up gauge\n" .
             "phpfpm_up 1\n" .
-            "# HELP phpfpm_start_time When FPM has started\.\n" .
-            "# TYPE phpfpm_start_time gauge\n" .
-            "phpfpm_start_time \d+\n" .
-            "# HELP phpfpm_start_since_total The number of seconds since FPM has started\.\n" .
-            "# TYPE phpfpm_start_since_total counter\n" .
-            "phpfpm_start_since_total " . $fields['start since'] . "\n" .
-            "# HELP phpfpm_accepted_connections_total The number of requests accepted by the pool\.\n" .
-            "# TYPE phpfpm_accepted_connections_total counter\n" .
-            "phpfpm_accepted_connections_total " . $fields['accepted conn'] . "\n" .
+            "# HELP phpfpm_start_since The number of seconds since FPM has started\.\n" .
+            "# TYPE phpfpm_start_since counter\n" .
+            "phpfpm_start_since " . $fields['start since'] . "\n" .
+            "# HELP phpfpm_accepted_connections The number of requests accepted by the pool\.\n" .
+            "# TYPE phpfpm_accepted_connections counter\n" .
+            "phpfpm_accepted_connections " . $fields['accepted conn'] . "\n" .
             "# HELP phpfpm_listen_queue The number of requests in the queue of pending connections\.\n" .
             "# TYPE phpfpm_listen_queue gauge\n" .
             "phpfpm_listen_queue " . $fields['listen queue'] . "\n" .
-            "# HELP phpfpm_max_listen_queue_total The maximum number of requests in the queue of pending connections since FPM has started\.\n" .
-            "# TYPE phpfpm_max_listen_queue_total counter\n" .
-            "phpfpm_max_listen_queue_total " . $fields['max listen queue'] . "\n" .
+            "# HELP phpfpm_max_listen_queue The maximum number of requests in the queue of pending connections since FPM has started\.\n" .
+            "# TYPE phpfpm_max_listen_queue counter\n" .
+            "phpfpm_max_listen_queue " . $fields['max listen queue'] . "\n" .
             "# TYPE phpfpm_listen_queue_length gauge\n" .
             "# HELP phpfpm_listen_queue_length The size of the socket queue of pending connections\.\n" .
             "phpfpm_listen_queue_length " . $fields['listen queue len'] . "\n" .
@@ -236,15 +233,15 @@ class Status
             "# HELP phpfpm_total_processes The number of idle \+ active processes\.\n" .
             "# TYPE phpfpm_total_processes gauge\n" .
             "phpfpm_total_processes " . $fields['total processes'] . "\n" .
-            "# HELP phpfpm_max_active_processes_total The maximum number of active processes since FPM has started\.\n" .
-            "# TYPE phpfpm_max_active_processes_total counter\n" .
-            "phpfpm_max_active_processes_total " . $fields['max active processes'] . "\n" .
-            "# HELP phpfpm_max_children_reached_total The number of times, the process limit has been reached, when pm tries to start more children \(works only for pm 'dynamic' and 'ondemand'\)\.\n" .
-            "# TYPE phpfpm_max_children_reached_total counter\n" .
-            "phpfpm_max_children_reached_total " . $fields['max children reached'] . "\n" .
-            "# HELP phpfpm_slow_requests_total The number of requests that exceeded your 'request_slowlog_timeout' value\.\n" .
-            "# TYPE phpfpm_slow_requests_total counter\n" .
-            "phpfpm_slow_requests_total " . $fields['slow requests'] . "|";
+            "# HELP phpfpm_max_active_processes The maximum number of active processes since FPM has started\.\n" .
+            "# TYPE phpfpm_max_active_processes counter\n" .
+            "phpfpm_max_active_processes " . $fields['max active processes'] . "\n" .
+            "# HELP phpfpm_max_children_reached The number of times, the process limit has been reached, when pm tries to start more children \(works only for pm 'dynamic' and 'ondemand'\)\.\n" .
+            "# TYPE phpfpm_max_children_reached counter\n" .
+            "phpfpm_max_children_reached " . $fields['max children reached'] . "\n" .
+            "# HELP phpfpm_slow_requests The number of requests that exceeded your 'request_slowlog_timeout' value\.\n" .
+            "# TYPE phpfpm_slow_requests counter\n" .
+            "phpfpm_slow_requests " . $fields['slow requests'] . "|";
 
         if (!preg_match($pattern, $body)) {
             echo "ERROR: Expected body does not match pattern\n";


### PR DESCRIPTION
This PR removes start time which didn't really makes sense and renames some metrics for openmetrics status format to be inline with https://github.com/hipages/php-fpm_exporter#metrics-collected . 