### PR TITLE
Fix #74960: Heap buffer overflow via str_repeat

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -1882,7 +1882,7 @@ ZEND_API int ZEND_FASTCALL concat_function(zval *result, zval *op1, zval *op2) /
 		size_t result_len = op1_len + op2_len;
 		zend_string *result_str;
 
-		if (UNEXPECTED(op1_len > SIZE_MAX - op2_len)) {
+		if (UNEXPECTED(op1_len > ZSTR_MAX_LEN - op2_len)) {
 			zend_throw_error(NULL, "String size overflow");
 			zval_ptr_dtor_str(&op1_copy);
 			zval_ptr_dtor_str(&op2_copy);

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -75,6 +75,8 @@ END_EXTERN_C()
 
 #define _ZSTR_STRUCT_SIZE(len) (_ZSTR_HEADER_SIZE + len + 1)
 
+#define ZSTR_MAX_LEN (SIZE_MAX - ZEND_MM_ALIGNED_SIZE(_ZSTR_HEADER_SIZE + 1))
+
 #define ZSTR_ALLOCA_ALLOC(str, _len, use_heap) do { \
 	(str) = (zend_string *)do_alloca(ZEND_MM_ALIGNED_SIZE_EX(_ZSTR_STRUCT_SIZE(_len), 8), (use_heap)); \
 	GC_SET_REFCOUNT(str, 1); \


### PR DESCRIPTION
Trying to allocate a `zend_string` with a length only slighty smaller
than `SIZE_MAX` causes an integer overflow, so callers may need to
check that explicitly.  To make that easy in a portable way, we
introduce `ZSTR_MAX_LEN`.

---

This PR supersedes #7252.