### PR TITLE
Add support for generating readonly properties via stubs

### DIFF
--- a/Zend/tests/type_declarations/typed_properties_095.phpt
+++ b/Zend/tests/type_declarations/typed_properties_095.phpt
@@ -70,6 +70,8 @@ object(_ZendTestClass)#1 (3) {
   }
   ["classUnionProp"]=>
   NULL
+  ["readonlyProp"]=>
+  uninitialized(int)
 }
 int(123)
 Cannot assign string to property _ZendTestClass::$intProp of type int
@@ -82,6 +84,8 @@ object(Test)#4 (3) {
   }
   ["classUnionProp"]=>
   NULL
+  ["readonlyProp"]=>
+  uninitialized(int)
 }
 int(123)
 Cannot assign string to property _ZendTestClass::$staticIntProp of type int

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1178,6 +1178,10 @@ class PropertyInfo
             $flags .= "|ZEND_ACC_STATIC";
         }
 
+        if ($this->flags & Class_::MODIFIER_READONLY) {
+            $flags .= "|ZEND_ACC_READONLY";
+        }
+
         return $flags;
     }
 }
@@ -2303,7 +2307,7 @@ function initPhpParser() {
     }
 
     $isInitialized = true;
-    $version = "4.9.0";
+    $version = "4.12.0";
     $phpParserDir = __DIR__ . "/PHP-Parser-$version";
     if (!is_dir($phpParserDir)) {
         installPhpParser($version, $phpParserDir);

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1810,9 +1810,7 @@ function handleStatements(FileInfo $fileInfo, array $stmts, PrettyPrinterAbstrac
 }
 
 function parseStubFile(string $code): FileInfo {
-    $minCompatiblePhpVersionId = 80100; // PHP 8.1
-
-    $lexer = PHP_VERSION_ID >= $minCompatiblePhpVersionId ? new PhpParser\Lexer() : new PhpParser\Lexer\Emulative();
+    $lexer = new PhpParser\Lexer\Emulative();
     $parser = new PhpParser\Parser\Php7($lexer);
     $nodeTraverser = new PhpParser\NodeTraverser;
     $nodeTraverser->addVisitor(new PhpParser\NodeVisitor\NameResolver);

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1810,7 +1810,9 @@ function handleStatements(FileInfo $fileInfo, array $stmts, PrettyPrinterAbstrac
 }
 
 function parseStubFile(string $code): FileInfo {
-    $lexer = new PhpParser\Lexer();
+    $minCompatiblePhpVersionId = 80100; // PHP 8.1
+
+    $lexer = PHP_VERSION_ID >= $minCompatiblePhpVersionId ? new PhpParser\Lexer() : new PhpParser\Lexer\Emulative();
     $parser = new PhpParser\Parser\Php7($lexer);
     $nodeTraverser = new PhpParser\NodeTraverser;
     $nodeTraverser->addVisitor(new PhpParser\NodeVisitor\NameResolver);

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -17,6 +17,7 @@ namespace {
         public int $intProp = 123;
         public ?stdClass $classProp = null;
         public stdClass|Iterator|null $classUnionProp = null;
+        public readonly int $readonlyProp;
 
         public static function is_object(): int {}
 

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6efccee97845bb4176d25226cadaedbfc6de961d */
+ * Stub hash: 2a1f8ff8205507259ba19bd379a07b390bc525cd */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -226,6 +226,12 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 	zend_string *property_classUnionProp_name = zend_string_init("classUnionProp", sizeof("classUnionProp") - 1, 1);
 	zend_declare_typed_property(class_entry, property_classUnionProp_name, &property_classUnionProp_default_value, ZEND_ACC_PUBLIC, NULL, property_classUnionProp_type);
 	zend_string_release(property_classUnionProp_name);
+
+	zval property_readonlyProp_default_value;
+	ZVAL_UNDEF(&property_readonlyProp_default_value);
+	zend_string *property_readonlyProp_name = zend_string_init("readonlyProp", sizeof("readonlyProp") - 1, 1);
+	zend_declare_typed_property(class_entry, property_readonlyProp_name, &property_readonlyProp_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_readonlyProp_name);
 
 	return class_entry;
 }


### PR DESCRIPTION
(I realized in the meanwhile that the dynamic "readonly" properties of internal classes are not a good target for migration to `readonly` modifier indeed, since their value changes automatically, while manual modification is not possible. I forgot about this distinction between these "getters" and readonly properties.)