### PR TITLE
Always use separate static_members_table

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1873,12 +1873,10 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, bool nullify_hand
 	zend_hash_init(&ce->constants_table, 8, NULL, NULL, persistent_hashes);
 	zend_hash_init(&ce->function_table, 8, NULL, ZEND_FUNCTION_DTOR, persistent_hashes);
 
-	if (ce->type == ZEND_INTERNAL_CLASS) {
-		ZEND_MAP_PTR_INIT(ce->static_members_table, NULL);
-	} else {
-		ZEND_MAP_PTR_INIT(ce->static_members_table, &ce->default_static_members_table);
+	if (ce->type == ZEND_USER_CLASS) {
 		ce->info.user.doc_comment = NULL;
 	}
+	ZEND_MAP_PTR_INIT(ce->static_members_table, NULL);
 	ZEND_MAP_PTR_INIT(ce->mutable_data, NULL);
 
 	ce->default_properties_count = 0;

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -1653,17 +1653,19 @@ static void zend_file_cache_unserialize_class(zval                    *zv,
 	if (!(script->corrupted)) {
 		ce->ce_flags |= ZEND_ACC_IMMUTABLE;
 		ce->ce_flags &= ~ZEND_ACC_FILE_CACHED;
-		if (ce->ce_flags & ZEND_ACC_IMMUTABLE && ce->default_static_members_table) {
-			ZEND_MAP_PTR_NEW(ce->static_members_table);
-		} else {
-			ZEND_MAP_PTR_INIT(ce->static_members_table, &ce->default_static_members_table);
-		}
 		ZEND_MAP_PTR_NEW(ce->mutable_data);
+		if (ce->default_static_members_count) {
+			ZEND_MAP_PTR_NEW(ce->static_members_table);
+		}
 	} else {
 		ce->ce_flags &= ~ZEND_ACC_IMMUTABLE;
 		ce->ce_flags |= ZEND_ACC_FILE_CACHED;
-		ZEND_MAP_PTR_INIT(ce->static_members_table, &ce->default_static_members_table);
 		ZEND_MAP_PTR_INIT(ce->mutable_data, NULL);
+		if (ce->default_static_members_count) {
+			ZEND_MAP_PTR_INIT(ce->static_members_table,
+				zend_arena_alloc(&CG(arena), sizeof(zval *)));
+			ZEND_MAP_PTR_SET(ce->static_members_table, NULL);
+		}
 	}
 }
 

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -926,11 +926,7 @@ zend_class_entry *zend_persist_class_entry(zend_class_entry *orig_ce)
 				} else {
 					ZEND_MAP_PTR_INIT(ce->static_members_table, NULL);
 				}
-			} else {
-				ZEND_MAP_PTR_INIT(ce->static_members_table, &ce->default_static_members_table);
 			}
-		} else {
-			ZEND_MAP_PTR_INIT(ce->static_members_table, &ce->default_static_members_table);
 		}
 
 		zend_hash_persist(&ce->constants_table);

--- a/ext/reflection/tests/bug80821.phpt
+++ b/ext/reflection/tests/bug80821.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #80821: ReflectionProperty::getDefaultValue() returns current value for statics
+--FILE--
+<?php
+
+class Statics {
+	public static $staticVar = 1;
+}
+
+Statics::$staticVar = 2;
+
+$reflect = new \ReflectionClass(Statics::class);
+$prop = $reflect->getProperty("staticVar");
+var_dump($prop->getDefaultValue());
+
+?>
+--EXPECT--
+int(1)


### PR DESCRIPTION
When running without opcache, static_members_table is shared with
default_static_members_table. This is visible in reflection output,
because ReflectionProperty::getDefaultValue() will return the
current value, rather than the default value.

Address this by never sharing the table, which matches the behavior
we already see under opcache.