### PR TITLE
opcache_is_script_cached() honors preloaded scripts

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -68,6 +68,8 @@ PHP                                                                        NEWS
   . Fixed Bug #81255 (Memory leak in PHPUnit with functional JIT)
   . Fixed Bug #80959 (infinite loop in building cfg during JIT compilation)
     (Nikita, Dmitry)
+  . Changed opcache_is_script_cached() to return true for preloaded scripts.
+    (Mike)
 
 - Reflection:
   . Fixed bug #80821 (ReflectionProperty::getDefaultValue() returns current

--- a/UPGRADING
+++ b/UPGRADING
@@ -489,6 +489,9 @@ PHP 8.1 UPGRADE NOTES
   . All GMP function now accept octal string with the leading octal prefix ("0o"/"0O")
     RFC: https://wiki.php.net/rfc/explicit_octal_notation
 
+- Opcache:
+  . opcache_is_script_cached() now returns true for preloaded scripts.
+
 - PDO ODBC:
   . PDO::getAttributes() with PDO::ATTR_SERVER_INFO and PDO::ATTR_SERVER_VERSION
     now return values instead of throwing PDOException.

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4580,6 +4580,24 @@ finish:
 	return ret;
 }
 
+bool accel_is_script_preloaded(zend_string *script_name)
+{
+	if (preload_scripts) {
+		if (zend_hash_exists(preload_scripts, script_name)) {
+			return true;
+		}
+	}
+	if (ZCSG(saved_scripts)) {
+		zend_persistent_script **p;
+		for (p = ZCSG(saved_scripts); *p; ++p) {
+			if (zend_string_equals((*p)->script.filename, script_name)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 static size_t preload_ub_write(const char *str, size_t str_length)
 {
 	return fwrite(str, 1, str_length, stdout);

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -313,6 +313,8 @@ void accelerator_shm_read_unlock(void);
 zend_string *accel_make_persistent_key(zend_string *path);
 zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type);
 
+bool accel_is_script_preloaded(zend_string *script_name);
+
 #define IS_ACCEL_INTERNED(str) \
 	((char*)(str) >= (char*)ZCSG(interned_strings).start && (char*)(str) < (char*)ZCSG(interned_strings).top)
 

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -917,6 +917,10 @@ ZEND_FUNCTION(opcache_is_script_cached)
 		RETURN_FALSE;
 	}
 
+	if (accel_is_script_preloaded(script_name)) {
+		RETURN_TRUE;
+	}
+
 	if (!ZCG(accelerator_enabled)) {
 		RETURN_FALSE;
 	}


### PR DESCRIPTION

`opcache_is_script_cached` currently ignores preloaded scripts.