### PR TITLE
Fix #81283: shmop_read(): count is out of range

### DIFF
--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -251,7 +251,7 @@ PHP_FUNCTION(shmop_read)
 		RETURN_FALSE;
 	}
 
-	if (count < 0 || start > (INT_MAX - count) || start + count > shmop->size) {
+	if (count < 0 || start > (ZEND_LONG_MAX - count) || start + count > shmop->size) {
 		php_error_docref(NULL, E_WARNING, "count is out of range");
 		RETURN_FALSE;
 	}


### PR DESCRIPTION
`start`, `count` and `shmop->size` are `zend_long`, so we must not
restrict to `INT_MAX`.