### PR TITLE
Fix #81286: PDO return phantom rowset and no error when MYSQL_ATTR_USE_BUFFERED_QUERY=FALSE

### DIFF
--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -418,10 +418,6 @@ static int pdo_mysql_stmt_next_rowset(pdo_stmt_t *stmt) /* {{{ */
 		S->result = NULL;
 	}
 
-	if (!mysql_more_results(H->server)) {
-		/* No more results */
-		PDO_DBG_RETURN(0);
-	}
 #if PDO_USE_MYSQLND
 	if (mysql_next_result(H->server) == FAIL) {
 		pdo_mysql_error_stmt(stmt);

--- a/ext/pdo_mysql/mysql_statement.c
+++ b/ext/pdo_mysql/mysql_statement.c
@@ -418,6 +418,11 @@ static int pdo_mysql_stmt_next_rowset(pdo_stmt_t *stmt) /* {{{ */
 		S->result = NULL;
 	}
 
+	if (!mysql_more_results(H->server)) {
+		/* No more results */
+		pdo_mysql_error_stmt(stmt);
+		PDO_DBG_RETURN(0);
+	}
 #if PDO_USE_MYSQLND
 	if (mysql_next_result(H->server) == FAIL) {
 		pdo_mysql_error_stmt(stmt);

--- a/ext/pdo_mysql/tests/bug81286.phpt
+++ b/ext/pdo_mysql/tests/bug81286.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Bug #81286: PDO return phantom rowset and no error when MYSQL_ATTR_USE_BUFFERED_QUERY=FALSE
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_mysql')) die('skip not loaded');
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'skipif.inc';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc';
+MySQLPDOTest::skip();
+?>
+--FILE--
+<?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc';
+
+$pdo = MySQLPDOTest::factory();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+$pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+
+$qr = $pdo->query('SELECT IF(1, (SELECT 1 UNION ALL SELECT 2), 0)');
+
+var_dump($pdo->errorInfo());
+
+if ($qr) {
+    var_dump($qr->errorInfo());
+    $qr->nextRowset();
+    var_dump($qr->errorInfo());
+}
+
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  string(5) "00000"
+  [1]=>
+  NULL
+  [2]=>
+  NULL
+}
+array(3) {
+  [0]=>
+  string(5) "00000"
+  [1]=>
+  NULL
+  [2]=>
+  NULL
+}
+array(3) {
+  [0]=>
+  string(5) "21000"
+  [1]=>
+  int(1242)
+  [2]=>
+  string(32) "Subquery returns more than 1 row"
+}


### PR DESCRIPTION
This PR removes the check for `more_results` from PDO_MySQL. This check has been removed in Nikita's refactoring in PHP 8.0.1. This is the smallest necessary change required to fix this bug in PHP 7.4 only, and is the backport of part of the new refactorings. 