### PR TITLE
Prevent mysqli::next_result from reporting errors from previous calls

### DIFF
--- a/ext/mysqli/tests/mysqli_next_result_no_repeat_error.phpt
+++ b/ext/mysqli/tests/mysqli_next_result_no_repeat_error.phpt
@@ -1,0 +1,28 @@
+--TEST--
+next_result reports errors from previous calls
+--EXTENSIONS--
+mysqli
+--SKIPIF--
+<?php
+require_once 'skipifconnectfailure.inc';
+?>
+--FILE--
+<?php
+
+require_once __DIR__ . '/connect.inc';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
+
+try {
+    $mysqli->query("Syntax Error");
+} catch (mysqli_sql_exception) {
+}
+$mysqli->next_result();
+
+print "done!";
+
+?>
+--EXPECTF--
+done!

--- a/ext/mysqli/tests/mysqli_next_result_no_repeat_error.phpt
+++ b/ext/mysqli/tests/mysqli_next_result_no_repeat_error.phpt
@@ -17,7 +17,7 @@ $mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
 
 try {
     $mysqli->query("Syntax Error");
-} catch (mysqli_sql_exception) {
+} catch (mysqli_sql_exception $e) {
 }
 $mysqli->next_result();
 

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -331,13 +331,9 @@ Warning: mysqli_rollback(): (%s/%d): Commands out of sync; you can't run this co
 
 Warning: mysqli_stmt_prepare(): (%s/%d): Commands out of sync; you can't run this command now in %s on line %d
 
-Warning: mysqli_next_result(): (%s/%d): Commands out of sync; you can't run this command now in %s on line %d
-
 Warning: mysqli_next_result(): (%s/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
 Warning: mysqli_store_result(): (%s/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
-
-Warning: mysqli_next_result(): (%s/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
 Warning: mysqli_stmt_attr_set(): (%s/%d): Not implemented in %s on line %d
 

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -1481,13 +1481,14 @@ MYSQLND_METHOD(mysqlnd_conn_data, next_result)(MYSQLND_CONN_DATA * const conn)
 	DBG_ENTER("mysqlnd_conn_data::next_result");
 	DBG_INF_FMT("conn=%llu", conn->thread_id);
 
+	SET_EMPTY_ERROR(conn->error_info);
+
 	if (PASS == conn->m->local_tx_start(conn, this_func)) {
 		do {
 			if (GET_CONNECTION_STATE(&conn->state) != CONN_NEXT_RESULT_PENDING) {
 				break;
 			}
 
-			SET_EMPTY_ERROR(conn->error_info);
 			UPSERT_STATUS_SET_AFFECTED_ROWS_TO_ERROR(conn->upsert_status);
 			/*
 			  We are sure that there is a result set, since conn->state is set accordingly


### PR DESCRIPTION
Regression in PHP 7.4.14.  See https://github.com/php/php-src/commit/eda749260448c2cfbc628592c0943263d03d7119