### PR TITLE
shell_exec doesn't return false

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -197,7 +197,7 @@ static const func_info_t func_infos[] = {
 	F1("escapeshellcmd",               MAY_BE_STRING),
 	F1("escapeshellarg",               MAY_BE_STRING),
 	F0("passthru",                     MAY_BE_NULL | MAY_BE_FALSE),
-	F1("shell_exec",                   MAY_BE_NULL | MAY_BE_FALSE | MAY_BE_STRING),
+	F1("shell_exec",                   MAY_BE_NULL | MAY_BE_STRING),
 #ifdef PHP_CAN_SUPPORT_PROC_OPEN
 	F1("proc_open",                    MAY_BE_FALSE | MAY_BE_RESOURCE),
 	F1("proc_get_status",              MAY_BE_ARRAY | MAY_BE_ARRAY_KEY_STRING | MAY_BE_ARRAY_OF_FALSE | MAY_BE_ARRAY_OF_TRUE | MAY_BE_ARRAY_OF_LONG | MAY_BE_ARRAY_OF_STRING),

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -742,7 +742,7 @@ function escapeshellcmd(string $command): string {}
 
 function escapeshellarg(string $arg): string {}
 
-function shell_exec(string $command): string|false|null {}
+function shell_exec(string $command): string|null {}
 
 #ifdef HAVE_NICE
 function proc_nice(int $priority): bool {}


### PR DESCRIPTION
In PHP8 I think, some stub were introduced.

For `shell_exec` the return type added is `string|false|null`, but there is no `false` return value according to the php documentation: https://www.php.net/manual/en/function.shell-exec.php

I think it should be only `string|null` then.

I tried to update this, but I don't know if it's the right way to do it.