### PR TITLE
Remove wrappers for *printf functions

### DIFF
--- a/ext/mysqlnd/mysqlnd_alloc.c
+++ b/ext/mysqlnd/mysqlnd_alloc.c
@@ -360,40 +360,7 @@ static char * _mysqlnd_pestrdup(const char * const ptr, bool persistent MYSQLND_
 /* }}} */
 
 
-
-
-#endif /* MYSQLND_DEBUG_MEMORY */
-
-/* {{{ _mysqlnd_sprintf_free */
-static void _mysqlnd_sprintf_free(char * p)
-{
-	efree(p);
-}
-/* }}} */
-
-
-/* {{{ _mysqlnd_sprintf */
-static int _mysqlnd_sprintf(char ** pbuf, size_t max_len, const char *format, ...)
-{
-	int len;
-	va_list ap;
-	va_start(ap, format);
-	len = vspprintf(pbuf, max_len, format, ap);
-	va_end(ap);
-	return len;
-}
-/* }}} */
-
-/* {{{ _mysqlnd_vsprintf */
-static int _mysqlnd_vsprintf(char ** pbuf, size_t max_len, const char * format, va_list ap)
-{
-	return vspprintf(pbuf, max_len, format, ap);
-}
-/* }}} */
-
-
-
-#if MYSQLND_DEBUG_MEMORY == 0
+#else
 
 /* {{{ mysqlnd_zend_mm_emalloc */
 static void * mysqlnd_zend_mm_emalloc(size_t size MYSQLND_MEM_D)
@@ -486,7 +453,7 @@ static char * mysqlnd_zend_mm_pestrdup(const char * const ptr, bool persistent M
 }
 /* }}} */
 
-#endif
+#endif /* MYSQLND_DEBUG_MEMORY */
 
 
 PHPAPI struct st_mysqlnd_allocator_methods mysqlnd_allocator =
@@ -502,10 +469,7 @@ PHPAPI struct st_mysqlnd_allocator_methods mysqlnd_allocator =
 	_mysqlnd_pefree,
 	_mysqlnd_pememdup,
 	_mysqlnd_pestrndup,
-	_mysqlnd_pestrdup,
-	_mysqlnd_sprintf,
-	_mysqlnd_vsprintf,
-	_mysqlnd_sprintf_free
+	_mysqlnd_pestrdup
 #else
 	mysqlnd_zend_mm_emalloc,
 	mysqlnd_zend_mm_pemalloc,
@@ -517,9 +481,6 @@ PHPAPI struct st_mysqlnd_allocator_methods mysqlnd_allocator =
 	mysqlnd_zend_mm_pefree,
 	mysqlnd_zend_mm_pememdup,
 	mysqlnd_zend_mm_pestrndup,
-	mysqlnd_zend_mm_pestrdup,
-	_mysqlnd_sprintf,
-	_mysqlnd_vsprintf,
-	_mysqlnd_sprintf_free,
+	mysqlnd_zend_mm_pestrdup
 #endif
 };

--- a/ext/mysqlnd/mysqlnd_alloc.h
+++ b/ext/mysqlnd/mysqlnd_alloc.h
@@ -36,9 +36,6 @@ struct st_mysqlnd_allocator_methods
 	char *	(*m_pememdup)(const char * const ptr, size_t size, bool persistent MYSQLND_MEM_D);
 	char *	(*m_pestrndup)(const char * const ptr, size_t size, bool persistent MYSQLND_MEM_D);
 	char *	(*m_pestrdup)(const char * const ptr, bool persistent MYSQLND_MEM_D);
-	int		(*m_sprintf)(char **pbuf, size_t max_len, const char *format, ...);
-	int		(*m_vsprintf)(char **pbuf, size_t max_len, const char *format, va_list ap);
-	void	(*m_sprintf_free)(char * p);
 };
 
 PHPAPI extern struct st_mysqlnd_allocator_methods mysqlnd_allocator;
@@ -54,9 +51,9 @@ PHPAPI extern struct st_mysqlnd_allocator_methods mysqlnd_allocator;
 #define mnd_pememdup(ptr, size, pers)	mysqlnd_allocator.m_pememdup((ptr), (size), (pers) MYSQLND_MEM_C)
 #define mnd_pestrndup(ptr, size, pers)	mysqlnd_allocator.m_pestrndup((ptr), (size), (pers) MYSQLND_MEM_C)
 #define mnd_pestrdup(ptr, pers)			mysqlnd_allocator.m_pestrdup((ptr), (pers) MYSQLND_MEM_C)
-#define mnd_sprintf(p, mx_len, fmt,...) mysqlnd_allocator.m_sprintf((p), (mx_len), (fmt), __VA_ARGS__)
-#define mnd_vsprintf(p, mx_len, fmt,ap) mysqlnd_allocator.m_vsprintf((p), (mx_len), (fmt), (ap))
-#define mnd_sprintf_free(p)				mysqlnd_allocator.m_sprintf_free((p))
+#define mnd_sprintf(p, mx_len, fmt,...) spprintf((p), (mx_len), (fmt), __VA_ARGS__)
+#define mnd_vsprintf(p, mx_len, fmt,ap) vspprintf((p), (mx_len), (fmt), (ap))
+#define mnd_sprintf_free(p)				efree((p))
 
 static inline MYSQLND_STRING mnd_dup_cstring(const MYSQLND_CSTRING str, const bool persistent)
 {


### PR DESCRIPTION
Was there ever a reason for these wrappers? It looks like they are unnecessary and just add double maintenance. 