### PR TITLE
Perform precise unresolved class check for preloading

### DIFF
--- a/Zend/zend_inheritance.h
+++ b/Zend/zend_inheritance.h
@@ -39,6 +39,11 @@ zend_class_entry *zend_try_early_bind(zend_class_entry *ce, zend_class_entry *pa
 ZEND_API extern zend_class_entry* (*zend_inheritance_cache_get)(zend_class_entry *ce, zend_class_entry *parent, zend_class_entry **traits_and_interfaces);
 ZEND_API extern zend_class_entry* (*zend_inheritance_cache_add)(zend_class_entry *ce, zend_class_entry *proto, zend_class_entry *parent, zend_class_entry **traits_and_interfaces, HashTable *dependencies);
 
+/* Returns NULL on success, or an unresolved class name on failure. */
+ZEND_API zend_string *zend_can_preload(
+	zend_class_entry *ce, zend_class_entry *parent,
+	zend_class_entry **interfaces, zend_class_entry **traits);
+
 END_EXTERN_C()
 
 #endif

--- a/ext/opcache/tests/preload_011.phpt
+++ b/ext/opcache/tests/preload_011.phpt
@@ -25,8 +25,4 @@ $g = new G;
 
 ?>
 --EXPECTF--
-Warning: Can't preload unlinked class H: Unknown type dependencies in %s on line %d
-
-Warning: Can't preload unlinked class B: Unknown type dependencies in %s on line %d
-
-Warning: Can't preload unlinked class A: Unknown type dependencies in %s on line %d
+Warning: Can't preload unlinked class H: Unknown type dependency L in %s on line %d

--- a/ext/opcache/tests/preload_variance.inc
+++ b/ext/opcache/tests/preload_variance.inc
@@ -1,7 +1,6 @@
 <?php
 
-// Requires X, delay to runtime.
-// TODO: It is not actually required, because we don't need X to check inheritance in this case.
+// Works, because X does not need to be known to check inheritance in this case.
 class A extends Z {
     public function method(X $a) {}
 }


### PR DESCRIPTION
opcache_compile_file() based preloading needs to ensure that all inheritance dependencies are available in advance. This is easy for parent/interfaces/traits, but hard for type variance checks. Currently, preloading checks that types on the current class are available if there is a parent/interface/trait method against which a variance check may need to be performed. Unfortuantely, this is insufficient: The prototype method may have a missing type as well, in which case we currently get a crash.

This PR takes an approach similar to what we do for early binding, which is to perform a "check only" method inheritance check. It's more complicated than early binding, because we need to consider traits and interfaces and need to keep track which methods would actually get inherited. To keep complexity manageable, preloading of classes using complex trait conflict resolution is not supported.