### PR TITLE
Mysqlnd refactoring (remove mysqlnd_field_type_name, get_parameter_metadata, and mysqlnd stat triggers)

### DIFF
--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -177,8 +177,6 @@ PHPAPI void mysqlnd_free_param_bind_dtor(MYSQLND_PARAM_BIND * param_bind);
 PHPAPI void mysqlnd_free_result_bind_dtor(MYSQLND_RESULT_BIND * result_bind);
 
 
-PHPAPI const char * mysqlnd_field_type_name(const enum mysqlnd_field_types field_type);
-
 /* LOAD DATA LOCAL */
 PHPAPI void mysqlnd_local_infile_default(MYSQLND_CONN_DATA * conn);
 

--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -230,7 +230,6 @@ PHPAPI zend_ulong mysqlnd_old_escape_string(char * newstr, const char * escapest
 #define mysqlnd_stmt_free_result_bind(stmt,bind)	(stmt)->m->free_result_bind((stmt), (bind))
 #define mysqlnd_stmt_bind_result(stmt,bind)			(stmt)->m->bind_result((stmt), (bind))
 #define mysqlnd_stmt_bind_one_result(s,no)			(s)->m->bind_one_result((s), (no))
-#define mysqlnd_stmt_param_metadata(stmt)			(stmt)->m->get_parameter_metadata((stmt))
 #define mysqlnd_stmt_result_metadata(stmt)			(stmt)->m->get_result_metadata((stmt))
 
 #define	mysqlnd_stmt_free_result(stmt)				(stmt)->m->free_result((stmt))

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -1505,59 +1505,6 @@ MYSQLND_METHOD(mysqlnd_conn_data, next_result)(MYSQLND_CONN_DATA * const conn)
 /* }}} */
 
 
-/* {{{ mysqlnd_field_type_name */
-PHPAPI const char * mysqlnd_field_type_name(const enum mysqlnd_field_types field_type)
-{
-	switch(field_type) {
-		case FIELD_TYPE_JSON:
-			return "json";
-		case FIELD_TYPE_STRING:
-		case FIELD_TYPE_VAR_STRING:
-			return "string";
-		case FIELD_TYPE_TINY:
-		case FIELD_TYPE_SHORT:
-		case FIELD_TYPE_LONG:
-		case FIELD_TYPE_LONGLONG:
-		case FIELD_TYPE_INT24:
-			return "int";
-		case FIELD_TYPE_FLOAT:
-		case FIELD_TYPE_DOUBLE:
-		case FIELD_TYPE_DECIMAL:
-		case FIELD_TYPE_NEWDECIMAL:
-			return "real";
-		case FIELD_TYPE_TIMESTAMP:
-			return "timestamp";
-		case FIELD_TYPE_YEAR:
-			return "year";
-		case FIELD_TYPE_DATE:
-		case FIELD_TYPE_NEWDATE:
-			return "date";
-		case FIELD_TYPE_TIME:
-			return "time";
-		case FIELD_TYPE_SET:
-			return "set";
-		case FIELD_TYPE_ENUM:
-			return "enum";
-		case FIELD_TYPE_GEOMETRY:
-			return "geometry";
-		case FIELD_TYPE_DATETIME:
-			return "datetime";
-		case FIELD_TYPE_TINY_BLOB:
-		case FIELD_TYPE_MEDIUM_BLOB:
-		case FIELD_TYPE_LONG_BLOB:
-		case FIELD_TYPE_BLOB:
-			return "blob";
-		case FIELD_TYPE_NULL:
-			return "null";
-		case FIELD_TYPE_BIT:
-			return "bit";
-		default:
-			return "unknown";
-	}
-}
-/* }}} */
-
-
 /* {{{ mysqlnd_conn_data::change_user */
 static enum_func_status
 MYSQLND_METHOD(mysqlnd_conn_data, change_user)(MYSQLND_CONN_DATA * const conn,

--- a/ext/mysqlnd/mysqlnd_libmysql_compat.h
+++ b/ext/mysqlnd/mysqlnd_libmysql_compat.h
@@ -95,7 +95,6 @@
 #define mysql_stmt_send_long_data(s,p,d,l) mysqlnd_stmt_send_long_data((s), (p), (d), (l))
 #define mysql_stmt_attr_get(s,a,v)		mysqlnd_stmt_attr_get((s), (a), (v))
 #define mysql_stmt_attr_set(s,a,v)		mysqlnd_stmt_attr_set((s), (a), (v))
-#define mysql_stmt_param_metadata(s)	mysqlnd_stmt_param_metadata((s))
 #define mysql_stmt_result_metadata(s)	mysqlnd_stmt_result_metadata((s))
 #define mysql_stmt_next_result(s)		mysqlnd_stmt_next_result((s))
 #define mysql_stmt_more_results(s)		mysqlnd_stmt_more_results((s))

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -1481,19 +1481,6 @@ MYSQLND_METHOD(mysqlnd_stmt, data_seek)(const MYSQLND_STMT * const s, uint64_t r
 /* }}} */
 
 
-/* {{{ mysqlnd_stmt::param_metadata */
-static MYSQLND_RES *
-MYSQLND_METHOD(mysqlnd_stmt, param_metadata)(MYSQLND_STMT * const s)
-{
-	MYSQLND_STMT_DATA * stmt = s? s->data : NULL;
-	if (!stmt || !stmt->param_count) {
-		return NULL;
-	}
-	return NULL;
-}
-/* }}} */
-
-
 /* {{{ mysqlnd_stmt::result_metadata */
 static MYSQLND_RES *
 MYSQLND_METHOD(mysqlnd_stmt, result_metadata)(MYSQLND_STMT * const s)
@@ -1977,7 +1964,7 @@ MYSQLND_CLASS_METHODS_START(mysqlnd_stmt)
 	MYSQLND_METHOD(mysqlnd_stmt, bind_result),
 	MYSQLND_METHOD(mysqlnd_stmt, bind_one_result),
 	MYSQLND_METHOD(mysqlnd_stmt, send_long_data),
-	MYSQLND_METHOD(mysqlnd_stmt, param_metadata),
+
 	MYSQLND_METHOD(mysqlnd_stmt, result_metadata),
 
 	MYSQLND_METHOD(mysqlnd_stmt, insert_id),

--- a/ext/mysqlnd/mysqlnd_statistics.c
+++ b/ext/mysqlnd/mysqlnd_statistics.c
@@ -216,8 +216,6 @@ mysqlnd_stats_init(MYSQLND_STATS ** stats, const size_t statistic_count, const b
 {
 	*stats = pecalloc(1, sizeof(MYSQLND_STATS), persistent);
 	(*stats)->values = pecalloc(statistic_count, sizeof(uint64_t), persistent);
-	(*stats)->triggers = pecalloc(statistic_count, sizeof(mysqlnd_stat_trigger), persistent);
-	(*stats)->in_trigger = FALSE;
 	(*stats)->count = statistic_count;
 #ifdef ZTS
 	(*stats)->LOCK_access = tsrm_mutex_alloc();
@@ -233,43 +231,9 @@ mysqlnd_stats_end(MYSQLND_STATS * stats, const bool persistent)
 #ifdef ZTS
 	tsrm_mutex_free(stats->LOCK_access);
 #endif
-	pefree(stats->triggers, persistent);
 	pefree(stats->values, persistent);
 	/* mnd_free will reference LOCK_access and crash...*/
 	pefree(stats, persistent);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_stats_set_trigger */
-PHPAPI mysqlnd_stat_trigger
-mysqlnd_stats_set_trigger(MYSQLND_STATS * const stats, enum_mysqlnd_collected_stats statistic, mysqlnd_stat_trigger trigger)
-{
-	mysqlnd_stat_trigger ret = NULL;
-	DBG_ENTER("mysqlnd_stats_set_trigger");
-	if (stats) {
-		MYSQLND_STATS_LOCK(stats);
-		ret = stats->triggers[statistic];
-		stats->triggers[statistic] = trigger;
-		MYSQLND_STATS_UNLOCK(stats);
-	}
-	DBG_RETURN(ret);
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_stats_set_handler */
-PHPAPI mysqlnd_stat_trigger
-mysqlnd_stats_reset_triggers(MYSQLND_STATS * const stats)
-{
-	mysqlnd_stat_trigger ret = NULL;
-	DBG_ENTER("mysqlnd_stats_reset_trigger");
-	if (stats) {
-		MYSQLND_STATS_LOCK(stats);
-		memset(stats->triggers, 0, stats->count * sizeof(mysqlnd_stat_trigger));
-		MYSQLND_STATS_UNLOCK(stats);
-	}
-	DBG_RETURN(ret);
 }
 /* }}} */
 

--- a/ext/mysqlnd/mysqlnd_statistics.h
+++ b/ext/mysqlnd/mysqlnd_statistics.h
@@ -26,26 +26,10 @@
 #define MYSQLND_STATS_UNLOCK(stats)
 #endif
 
-#ifndef MYSQLND_CORE_STATISTICS_TRIGGERS_DISABLED
-#define MYSQLND_STAT_CALL_TRIGGER(s_array, statistic, val) \
-			if ((s_array)->triggers[(statistic)] && (s_array)->in_trigger == FALSE) { \
-				(s_array)->in_trigger = TRUE; \
-				MYSQLND_STATS_UNLOCK((s_array)); \
-																						\
-				(s_array)->triggers[(statistic)]((s_array), (statistic), (val)); \
-																						\
-				MYSQLND_STATS_LOCK((s_array)); \
-				(s_array)->in_trigger = FALSE; \
-			}
-#else
-#define MYSQLND_STAT_CALL_TRIGGER(s_array, statistic, val)
-#endif /* MYSQLND_CORE_STATISTICS_TRIGGERS_DISABLED */
-
-#define MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(stats, statistic, value) \
+#define MYSQLND_STATS_UPDATE_VALUE(stats, statistic, value) \
 	{ \
 			MYSQLND_STATS_LOCK(stats); \
 			(stats)->values[(statistic)] += (value); \
-			MYSQLND_STAT_CALL_TRIGGER((stats), (statistic), (value)); \
 			MYSQLND_STATS_UNLOCK(_p_s); \
 	}
 
@@ -54,7 +38,7 @@
 	enum_mysqlnd_collected_stats _s = (statistic);\
 	MYSQLND_STATS * _p_s = (MYSQLND_STATS *) (stats); \
 	if ((enabler) && _p_s && _s != _p_s->count) { \
-		MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(_p_s, _s, -1); \
+		MYSQLND_STATS_UPDATE_VALUE(_p_s, _s, -1); \
 	}\
  }
 
@@ -63,7 +47,7 @@
 	enum_mysqlnd_collected_stats _s = (statistic);\
 	MYSQLND_STATS * _p_s = (MYSQLND_STATS *) (stats); \
 	if ((enabler) && _p_s && _s != _p_s->count) { \
-		MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(_p_s, _s, 1); \
+		MYSQLND_STATS_UPDATE_VALUE(_p_s, _s, 1); \
 	}\
  }
 
@@ -73,7 +57,7 @@
 	MYSQLND_STATS * _p_s = (MYSQLND_STATS *) (stats); \
 	if ((enabler) && _p_s && _s != _p_s->count) { \
 		uint64_t v = (uint64_t) (value); \
-		MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(_p_s, _s, v); \
+		MYSQLND_STATS_UPDATE_VALUE(_p_s, _s, v); \
 	}\
  }
 
@@ -85,8 +69,8 @@
 		uint64_t v2 = (uint64_t) (value2); \
 		enum_mysqlnd_collected_stats _s1 = (statistic1);\
 		enum_mysqlnd_collected_stats _s2 = (statistic2);\
-		if (_s1 != _p_s->count) MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(_p_s, _s1, v1); \
-		if (_s2 != _p_s->count) MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(_p_s, _s2, v2); \
+		if (_s1 != _p_s->count) MYSQLND_STATS_UPDATE_VALUE(_p_s, _s1, v1); \
+		if (_s2 != _p_s->count) MYSQLND_STATS_UPDATE_VALUE(_p_s, _s2, v2); \
 	}\
  }
 
@@ -100,9 +84,9 @@
 		enum_mysqlnd_collected_stats _s1 = (statistic1);\
 		enum_mysqlnd_collected_stats _s2 = (statistic2);\
 		enum_mysqlnd_collected_stats _s3 = (statistic3);\
-		if (_s1 != _p_s->count) MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(_p_s, _s1, v1); \
-		if (_s2 != _p_s->count) MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(_p_s, _s2, v2); \
-		if (_s3 != _p_s->count) MYSQLND_UPDATE_VALUE_AND_CALL_TRIGGER(_p_s, _s3, v3); \
+		if (_s1 != _p_s->count) MYSQLND_STATS_UPDATE_VALUE(_p_s, _s1, v1); \
+		if (_s2 != _p_s->count) MYSQLND_STATS_UPDATE_VALUE(_p_s, _s2, v2); \
+		if (_s3 != _p_s->count) MYSQLND_STATS_UPDATE_VALUE(_p_s, _s3, v3); \
 	}\
  }
 
@@ -112,8 +96,5 @@ PHPAPI void mysqlnd_stats_init(MYSQLND_STATS ** stats, const size_t statistic_co
 PHPAPI void mysqlnd_stats_end(MYSQLND_STATS * stats, const bool persistent);
 
 PHPAPI void mysqlnd_fill_stats_hash(const MYSQLND_STATS * const stats, const MYSQLND_STRING * names, zval *return_value ZEND_FILE_LINE_DC);
-
-PHPAPI mysqlnd_stat_trigger mysqlnd_stats_set_trigger(MYSQLND_STATS * const stats, enum_mysqlnd_collected_stats stat, mysqlnd_stat_trigger trigger);
-PHPAPI mysqlnd_stat_trigger mysqlnd_stats_reset_triggers(MYSQLND_STATS * const stats);
 
 #endif	/* MYSQLND_STATISTICS_H */

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -813,7 +813,6 @@ MYSQLND_CLASS_METHODS_TYPE(mysqlnd_stmt)
 	func_mysqlnd_stmt__bind_result bind_result;
 	func_mysqlnd_stmt__bind_one_result bind_one_result;
 	func_mysqlnd_stmt__send_long_data send_long_data;
-	func_mysqlnd_stmt__get_parameter_metadata get_parameter_metadata;
 	func_mysqlnd_stmt__get_result_metadata get_result_metadata;
 
 	func_mysqlnd_stmt__get_last_insert_id get_last_insert_id;

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -294,14 +294,10 @@ typedef enum_func_status  (*mysqlnd_fetch_row_func)(MYSQLND_RES *result,
 
 typedef struct st_mysqlnd_stats MYSQLND_STATS;
 
-typedef void (*mysqlnd_stat_trigger)(MYSQLND_STATS * stats, enum_mysqlnd_collected_stats stat, int64_t change);
-
 struct st_mysqlnd_stats
 {
 	uint64_t				*values;
-	mysqlnd_stat_trigger	*triggers;
 	size_t					count;
-	bool				in_trigger;
 #ifdef ZTS
 	MUTEX_T	LOCK_access;
 #endif


### PR DESCRIPTION
`mysqlnd_field_type_name` is not used anywhere. My research turned up nothing. It looks like a leftover from some previous functionality. 

Either I am too dumb to understand or `get_parameter_metadata` is just dead code. I can't see any references to this method anywhere.

Stat triggers is a functionality that doesn't seem to be used anywhere. It doesn't look like it harms performance, but if nobody uses it then it might be prudent to just drop this functionality and have cleaner code. 