### PR TITLE
tests: Introduce platform checks

### DIFF
--- a/Zend/tests/array_unpack/already_occupied.phpt
+++ b/Zend/tests/array_unpack/already_occupied.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Appending to an array via unpack may fail
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip 64bit only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/binary-32bit.phpt
+++ b/Zend/tests/binary-32bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 testing binary literals
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 var_dump(0b1);

--- a/Zend/tests/binary.phpt
+++ b/Zend/tests/binary.phpt
@@ -2,8 +2,8 @@
 testing binary literals
 --INI--
 precision=32
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 var_dump(0b1);

--- a/Zend/tests/bug46701.phpt
+++ b/Zend/tests/bug46701.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #46701 (Creating associative array with long values in the key fails on 32bit linux)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die('skip this test is for 32bit platforms only'); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/bug54547.phpt
+++ b/Zend/tests/bug54547.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #54547: wrong equality of string numbers near LONG_MAX with 64-bit longs
---SKIPIF--
-<?php
-if (PHP_INT_MAX !== 9223372036854775807)
-    die("skip for 64-bit long systems only");
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 var_dump("9223372036854775807" == "9223372036854775808");

--- a/Zend/tests/bug55509.phpt
+++ b/Zend/tests/bug55509.phpt
@@ -1,11 +1,9 @@
 --TEST--
 Bug #55509 (segfault on x86_64 using more than 2G memory)
+--PLATFORM--
+bits: 64
 --SKIPIF--
 <?php
-if (PHP_INT_SIZE == 4) {
-  die('skip Not for 32-bits OS');
-}
-
 $zend_mm_enabled = getenv("USE_ZEND_ALLOC");
 if ($zend_mm_enabled === "0") {
     die("skip Zend MM disabled");

--- a/Zend/tests/bug62097.phpt
+++ b/Zend/tests/bug62097.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #62097: fix for bug #54547 is wrong for 32-bit machines
---SKIPIF--
-<?php
-if (PHP_INT_MAX !== 2147483647)
-    die('skip for system with 32-bit wide longs only');
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 var_dump("02147483647" == "2147483647",

--- a/Zend/tests/bug69892.phpt
+++ b/Zend/tests/bug69892.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #69892: Different arrays compare identical due to integer key truncation
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platforms only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 var_dump([0 => 0] === [0x100000000 => 0]);

--- a/Zend/tests/bug70173.phpt
+++ b/Zend/tests/bug70173.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #70173 (ZVAL_COPY_VALUE_EX broken for 32bit Solaris Sparc)
---SKIPIF--
-<?php
-if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");
-?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 $var = 2900000000;

--- a/Zend/tests/bug74093.phpt
+++ b/Zend/tests/bug74093.phpt
@@ -1,10 +1,11 @@
 --TEST--
 Bug #74093 (Maximum execution time of n+2 seconds exceed not written in error_log)
+--PLATFORM--
+os: !Windows
+zts: false
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (PHP_ZTS) die("skip only for no-zts build");
-if (substr(PHP_OS, 0, 3) == 'WIN') die("skip not for Windows");
 ?>
 --INI--
 memory_limit=1G

--- a/Zend/tests/bug77660.phpt
+++ b/Zend/tests/bug77660.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #77660 (Segmentation fault on break 2147483648)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 for(;;) break 2147483648;

--- a/Zend/tests/compare_001.phpt
+++ b/Zend/tests/compare_001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables for equality
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/compare_001_64bit.phpt
+++ b/Zend/tests/compare_001_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables for equality
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/compare_002.phpt
+++ b/Zend/tests/compare_002.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables for identity
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/compare_002_64bit.phpt
+++ b/Zend/tests/compare_002_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables for identity
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/compare_003.phpt
+++ b/Zend/tests/compare_003.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables (greater than)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/compare_003_64bit.phpt
+++ b/Zend/tests/compare_003_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables (greater than)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/compare_004.phpt
+++ b/Zend/tests/compare_004.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables (less than)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/compare_004_64bit.phpt
+++ b/Zend/tests/compare_004_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables (less than)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/compare_005.phpt
+++ b/Zend/tests/compare_005.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables (greater or equal than)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/compare_005_64bit.phpt
+++ b/Zend/tests/compare_005_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables (greater or equal than)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/compare_006.phpt
+++ b/Zend/tests/compare_006.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables (smaller or equal than)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/compare_006_64bit.phpt
+++ b/Zend/tests/compare_006_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 comparing different variables (smaller or equal than)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/concat_003.phpt
+++ b/Zend/tests/concat_003.phpt
@@ -1,8 +1,10 @@
 --TEST--
 Concatenating many small strings should not slowdown allocations
+--PLATFORM--
+# debug version is slow
+debug: false
 --SKIPIF--
 <?php
-if (PHP_DEBUG) { die ("skip debug version is slow"); }
 if (getenv('SKIP_PERF_SENSITIVE')) die("skip performance sensitive test");
 ?>
 --FILE--

--- a/Zend/tests/decrement_001.phpt
+++ b/Zend/tests/decrement_001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 decrementing different variables
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --INI--
 precision=14
 --FILE--

--- a/Zend/tests/decrement_001_64bit.phpt
+++ b/Zend/tests/decrement_001_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 decrementing different variables
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --INI--
 precision=14
 --FILE--

--- a/Zend/tests/double_to_string.phpt
+++ b/Zend/tests/double_to_string.phpt
@@ -2,8 +2,8 @@
 double to string conversion tests
 --INI--
 precision=14
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/double_to_string_64bit.phpt
+++ b/Zend/tests/double_to_string_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 double to string conversion tests (64bit)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --INI--
 precision=14
 --FILE--

--- a/Zend/tests/dval_to_lval_32.phpt
+++ b/Zend/tests/dval_to_lval_32.phpt
@@ -1,10 +1,7 @@
 --TEST--
 zend_dval_to_lval preserves low bits  (32 bit long)
---SKIPIF--
-<?php
-if (PHP_INT_SIZE != 4)
-     die("skip for machines with 32-bit longs");
-?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
     /* test doubles around -4e21 */

--- a/Zend/tests/dval_to_lval_64.phpt
+++ b/Zend/tests/dval_to_lval_64.phpt
@@ -1,10 +1,7 @@
 --TEST--
 zend_dval_to_lval preserves low bits  (64 bit long)
---SKIPIF--
-<?php
-if (PHP_INT_SIZE != 8)
-     die("skip for machines with 64-bit longs");
-?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
     /* test doubles around -4e21 */

--- a/Zend/tests/float_to_int/explicit_casts_should_not_warn.phpt
+++ b/Zend/tests/float_to_int/explicit_casts_should_not_warn.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Explicit (int) cast must not warn
---SKIPIF--
-<?php
-if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
-?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/float_to_int/explicit_casts_should_not_warn_32bit.phpt
+++ b/Zend/tests/float_to_int/explicit_casts_should_not_warn_32bit.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Explicit (int) cast must not warn 32bit variation
---SKIPIF--
-<?php
-if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
-?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/float_to_int/warning_float_does_not_fit_zend_long_strings.phpt
+++ b/Zend/tests/float_to_int/warning_float_does_not_fit_zend_long_strings.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Implicit float to int conversions when float too large should warn, string offset variant
---SKIPIF--
-<?php
-if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
-?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/float_to_int/warning_float_does_not_fit_zend_long_strings_32bit.phpt
+++ b/Zend/tests/float_to_int/warning_float_does_not_fit_zend_long_strings_32bit.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Implicit float to int conversions when float too large should warn, string offset variant, 32bit variant
---SKIPIF--
-<?php
-if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
-?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/hex_overflow_32bit.phpt
+++ b/Zend/tests/hex_overflow_32bit.phpt
@@ -2,8 +2,8 @@
 testing integer overflow (32bit)
 --INI--
 serialize_precision=14
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/increment_001.phpt
+++ b/Zend/tests/increment_001.phpt
@@ -1,7 +1,7 @@
 --TEST--
 incrementing different variables
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --INI--
 precision=14
 --FILE--

--- a/Zend/tests/int_overflow_32bit.phpt
+++ b/Zend/tests/int_overflow_32bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 testing integer overflow (32bit)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/int_overflow_64bit.phpt
+++ b/Zend/tests/int_overflow_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 testing integer overflow (64bit)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/int_underflow_32bit.phpt
+++ b/Zend/tests/int_underflow_32bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 testing integer underflow (32bit)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/int_underflow_64bit.phpt
+++ b/Zend/tests/int_underflow_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 testing integer underflow (64bit)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/return_types/internal_functions001.phpt
+++ b/Zend/tests/return_types/internal_functions001.phpt
@@ -2,11 +2,9 @@
 Return type for internal functions
 --EXTENSIONS--
 zend_test
---SKIPIF--
-<?php
-// Internal function return types are only checked in debug builds
-if (!PHP_DEBUG) die('skip requires debug build');
-?>
+--PLATFORM--
+# Internal function return types are only checked in debug builds
+debug: true
 --INI--
 opcache.jit=0
 --FILE--

--- a/Zend/tests/type_declarations/scalar_return_basic.phpt
+++ b/Zend/tests/type_declarations/scalar_return_basic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Return scalar type basics
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 

--- a/Zend/tests/type_declarations/scalar_return_basic_64bit.phpt
+++ b/Zend/tests/type_declarations/scalar_return_basic_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Return scalar type basics
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/type_declarations/scalar_strict.phpt
+++ b/Zend/tests/type_declarations/scalar_strict.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Scalar type strict mode
---SKIPIF--
-<?php if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only"); ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 declare(strict_types=1);

--- a/Zend/tests/type_declarations/scalar_strict_64bit.phpt
+++ b/Zend/tests/type_declarations/scalar_strict_64bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Scalar type strict mode
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 declare(strict_types=1);

--- a/Zend/tests/type_declarations/typed_properties_044.phpt
+++ b/Zend/tests/type_declarations/typed_properties_044.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test increment functions on typed property references
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64 bit platform only"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 $foo = new class {

--- a/Zend/tests/type_declarations/typed_properties_061.phpt
+++ b/Zend/tests/type_declarations/typed_properties_061.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Typed property on overloaded by-ref property
---SKIPIF--
-<?php if (PHP_INT_SIZE == 4) die("SKIP: 64 bit test"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/type_declarations/typed_properties_075.phpt
+++ b/Zend/tests/type_declarations/typed_properties_075.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test typed properties overflowing
---SKIPIF--
-<?php if (PHP_INT_SIZE == 4) die("SKIP: 64 bit test"); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/type_declarations/typed_properties_097.phpt
+++ b/Zend/tests/type_declarations/typed_properties_097.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Incrementing/decrementing past max/min value (additional cases)
---SKIPIF--
-<?php if (PHP_INT_SIZE != 8) die('skip 64 bit test'); ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 

--- a/Zend/tests/zend_signed_multiply-32bit.phpt
+++ b/Zend/tests/zend_signed_multiply-32bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Zend signed multiply 32-bit
---SKIPIF--
-<?php if ((1 << 31) > 0) print "skip Running on 64-bit target"; ?>
+--PLATFORM--
+bits: 32
 --FILE--
 <?php
 var_dump(0x8000 * -0xffff);

--- a/Zend/tests/zend_signed_multiply-64bit-2.phpt
+++ b/Zend/tests/zend_signed_multiply-64bit-2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Zend signed multiply 64-bit, variation 2
---SKIPIF--
-<?php if ((1 << 31) < 0) print "skip Running on 32-bit target"; ?>
+--PLATFORM--
+bits: 64
 --FILE--
 <?php
 for($c = -16; $c < 0; $c++) {


### PR DESCRIPTION
--PLATFORM--
bits: 64
os: !Windows

vs.

--SKIPIF--
&lt;?php
if (PHP_INT_SIZE != 64) die('skip This test is 64bit only');
if (stripos('WIN', PHP_OS) === 0) die('skip This test cannot run on Windows');
?>

This is part of overall work on test speedup by reducing the
number of SKIPIF checks. Additional benefits are the tests getting
more readable and replacing code with metadata.

This change migrates Zend tests to the new system, the rest will be
fixed in subsequent patches.