### PR TITLE
Fixed failed test in extension skeleton

### DIFF
--- a/ext/skeleton/tests/003.phpt
+++ b/ext/skeleton/tests/003.phpt
@@ -1,11 +1,11 @@
 --TEST--
-%EXTNAME%_test2() Basic test
+test2() Basic test
 --EXTENSIONS--
 %EXTNAME%
 --FILE--
 <?php
-var_dump(%EXTNAME%_test2());
-var_dump(%EXTNAME%_test2('PHP'));
+var_dump(test2());
+var_dump(test2('PHP'));
 ?>
 --EXPECT--
 string(11) "Hello World"


### PR DESCRIPTION
Since https://github.com/php/php-src/pull/5289 `%EXTNAME%_test2` was removed and that leads to failed test on empty extension.