### PR TITLE
Remove special self/parent handling in get_class_name_map_ptr()

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -750,7 +750,7 @@ static void accel_allocate_ce_cache_slots(void)
 
 		ce = (zend_class_entry*)Z_PTR(p->val);
 		if (ce->name) {
-			zend_accel_get_class_name_map_ptr(ce->name, ce, /* have_xlat */ false);
+			zend_accel_get_class_name_map_ptr(ce->name);
 		}
 	} ZEND_HASH_FOREACH_END();
 }

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -318,7 +318,7 @@ zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type);
 
 zend_string* ZEND_FASTCALL accel_new_interned_string(zend_string *str);
 
-uint32_t zend_accel_get_class_name_map_ptr(zend_string *type_name, zend_class_entry *scope, bool have_xlat);
+uint32_t zend_accel_get_class_name_map_ptr(zend_string *type_name);
 
 /* memory write protection */
 #define SHM_PROTECT() \

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -1231,7 +1231,7 @@ static void zend_file_cache_unserialize_type(
 		UNSERIALIZE_STR(type_name);
 		ZEND_TYPE_SET_PTR(*type, type_name);
 		if (!script->corrupted) {
-			zend_accel_get_class_name_map_ptr(type_name, scope, /* have_xlat */ false);
+			zend_accel_get_class_name_map_ptr(type_name);
 		}
 	} else if (ZEND_TYPE_HAS_CE(*type)) {
 		zend_class_entry *ce = ZEND_TYPE_CE(*type);
@@ -1499,7 +1499,7 @@ static void zend_file_cache_unserialize_class(zval                    *zv,
 	UNSERIALIZE_STR(ce->name);
 	if (!(ce->ce_flags & ZEND_ACC_ANON_CLASS)
 	 && !script->corrupted) {
-		zend_accel_get_class_name_map_ptr(ce->name, ce, /* have_xlat */ false);
+		zend_accel_get_class_name_map_ptr(ce->name);
 	}
 	if (ce->parent) {
 		if (!(ce->ce_flags & ZEND_ACC_LINKED)) {


### PR DESCRIPTION
zend_accel_get_class_name_map_ptr() for "self" and "parent" will
currently try to determine which class these refer to, and then
initialize the CE_CACHE on those strings.

However, this shouldn't be necessary: We already initialize
CE_CACHE on all class declaration names, so it should be covered
through that already.