### PR TITLE
Remove a redundant expression

### DIFF
--- a/ext/gd/libgd/gdkanji.c
+++ b/ext/gd/libgd/gdkanji.c
@@ -143,7 +143,7 @@ DetectKanjiCode (unsigned char *str)
 	      else if (c >= 224 && c <= 239)
 		{
 		  whatcode = EUCORSJIS;
-		  while (c >= 64 && c != '\0' && whatcode == EUCORSJIS)
+		  while (c >= 64 && whatcode == EUCORSJIS)
 		    {
 		      if (c >= 129)
 			{


### PR DESCRIPTION
If I'm right, `c != '\0'` is equivalent to `c != 0` ... so it could be redundant because of the `c >= 64` expression.