### PR TITLE
Bug #81324	php-fpm will not set syslog ident for children

### DIFF
--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -89,6 +89,7 @@ int fpm_stdio_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 #ifdef HAVE_SYSLOG_H
 	if (fpm_globals.error_log_fd == ZLOG_SYSLOG) {
 		closelog(); /* ensure to close syslog not to interrupt with PHP syslog code */
+		PG(have_called_openlog) = 0;
 	} else
 #endif
 


### PR DESCRIPTION
Description:
------------
When loggning to the syslog from php-fpm. Forked children will inherit the value indicating that openlog already has been run even though closelog() has been called.

Test script:
---------------
```
<?php
brokensyntax
phpinfo();
```

Expected result:
----------------
Aug  2 15:49:22 testserver journal: php[4209]: PHP Parse error:  syntax error, unexpected identifier "phpinfo" in /var/www/html/test.php on line 3

Actual result:
--------------
Aug  2 15:49:22 testserver journal: ool www[4209]: PHP Parse error:  syntax error, unexpected identifier "phpinfo" in /var/www/html/test.php on line 3