### PR TITLE
Fix #81327: Error build openssl extension on php 7.4.22

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -3524,7 +3524,7 @@ PHP_FUNCTION(openssl_csr_sign)
 		goto cleanup;
 	}
 
-#if PHP_OPENSSL_API_VERSION >= 0x10100
+#if PHP_OPENSSL_API_VERSION >= 0x10100 && !defined (LIBRESSL_VERSION_NUMBER)
 	ASN1_INTEGER_set_int64(X509_get_serialNumber(new_cert), serial);
 #else
 	ASN1_INTEGER_set(X509_get_serialNumber(new_cert), serial);


### PR DESCRIPTION
The recent fix for bug 52093 is not compatible with LibreSSL ≥ 2.7.0,
which we recognize as mostly OpenSSL 1.1.0 compatible, but they still
do not support `ASN1_INTEGER_set_int64()`.