### PR TITLE
switch phar to use sha256 signature by default

### DIFF
--- a/ext/phar/phar/pharcommand.inc
+++ b/ext/phar/phar/pharcommand.inc
@@ -92,7 +92,7 @@ class PharCommand extends CLICommand
                 'typ' => 'select',
                 'val' => NULL,
                 'inf' => '<method> Selects the hash algorithm.',
-                'select' => array('md5' => 'MD5','sha1' => 'SHA1')
+                'select' => array('md5' => 'MD5','sha1' => 'SHA1', 'sha256' => 'SHA256', 'sha512' => 'SHA512', 'openssl' => 'OPENSSL')
             ),
             'i' => array(
                 'typ' => 'regex',

--- a/ext/phar/tests/create_new_and_modify.phpt
+++ b/ext/phar/tests/create_new_and_modify.phpt
@@ -49,8 +49,8 @@ include $pname . '/b.php';
 <?php unlink(__DIR__ . '/' . basename(__FILE__, '.clean.php') . '.phar.php'); ?>
 --EXPECTF--
 brand new!
-string(40) "%s"
-string(40) "%s"
+string(%d) "%s"
+string(%d) "%s"
 bool(true)
 modified!
 another!

--- a/ext/phar/tests/create_new_phar_c.phpt
+++ b/ext/phar/tests/create_new_phar_c.phpt
@@ -20,7 +20,7 @@ var_dump($phar->getSignature());
 --EXPECTF--
 array(2) {
   ["hash"]=>
-  string(40) "%s"
+  string(64) "%s"
   ["hash_type"]=>
-  string(5) "SHA-1"
+  string(7) "SHA-256"
 }

--- a/ext/phar/tests/phar_setsignaturealgo2.phpt
+++ b/ext/phar/tests/phar_setsignaturealgo2.phpt
@@ -53,7 +53,7 @@ array(2) {
   ["hash"]=>
   string(%d) "%s"
   ["hash_type"]=>
-  string(5) "SHA-1"
+  string(7) "SHA-256"
 }
 array(2) {
   ["hash"]=>

--- a/ext/phar/tests/tar/phar_setsignaturealgo2.phpt
+++ b/ext/phar/tests/tar/phar_setsignaturealgo2.phpt
@@ -52,7 +52,7 @@ array(2) {
   ["hash"]=>
   string(%d) "%s"
   ["hash_type"]=>
-  string(5) "SHA-1"
+  string(7) "SHA-256"
 }
 array(2) {
   ["hash"]=>

--- a/ext/phar/tests/zip/phar_setsignaturealgo2.phpt
+++ b/ext/phar/tests/zip/phar_setsignaturealgo2.phpt
@@ -79,7 +79,7 @@ array(2) {
   ["hash"]=>
   string(%d) "%s"
   ["hash_type"]=>
-  string(5) "SHA-1"
+  string(7) "SHA-256"
 }
 array(2) {
   ["hash"]=>

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1798,6 +1798,9 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 			*signature_length = 64;
 			break;
 		}
+		default:
+			phar->sig_flags = PHAR_SIG_SHA256;
+			ZEND_FALLTHROUGH;
 		case PHAR_SIG_SHA256: {
 			unsigned char digest[32];
 			PHP_SHA256_CTX  context;
@@ -1894,9 +1897,6 @@ int phar_create_signature(phar_archive_data *phar, php_stream *fp, char **signat
 			*signature_length = siglen;
 		}
 		break;
-		default:
-			phar->sig_flags = PHAR_SIG_SHA1;
-			ZEND_FALLTHROUGH;
 		case PHAR_SIG_SHA1: {
 			unsigned char digest[20];
 			PHP_SHA1_CTX  context;

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -1420,7 +1420,7 @@ fperror:
 
 	memcpy(eocd.signature, "PK\5\6", 4);
 	if (!phar->is_data && !phar->sig_flags) {
-		phar->sig_flags = PHAR_SIG_SHA1;
+		phar->sig_flags = PHAR_SIG_SHA256;
 	}
 	if (phar->sig_flags) {
 		PHAR_SET_16(eocd.counthere, zend_hash_num_elements(&phar->manifest) + 1);


### PR DESCRIPTION
To follow security best practices, SHA1 is now very old.

Notice: perhaps we should add an E_DEPRECATED when MD5 and/or SHA1 signatures are generated