### PR TITLE
snmp: add SHA256 and SHA512 for security protocol

### DIFF
--- a/ext/snmp/config.m4
+++ b/ext/snmp/config.m4
@@ -30,7 +30,7 @@ if test "$PHP_SNMP" != "no"; then
         AC_MSG_ERROR([Could not find the required paths. Please check your net-snmp installation.])
       fi
     else
-      AC_MSG_ERROR([Net-SNMP version 5.3 or greater reqired (detected $snmp_full_version).])
+      AC_MSG_ERROR([Net-SNMP version 5.3 or greater required (detected $snmp_full_version).])
     fi
   else
     AC_MSG_ERROR([Could not find net-snmp-config binary. Please check your net-snmp installation.])
@@ -50,6 +50,22 @@ if test "$PHP_SNMP" != "no"; then
   PHP_CHECK_LIBRARY($SNMP_LIBNAME, shutdown_snmp_logging,
   [
     AC_DEFINE(HAVE_SHUTDOWN_SNMP_LOGGING, 1, [ ])
+  ], [], [
+    $SNMP_SHARED_LIBADD
+  ])
+
+  dnl Check whether usmHMAC192SHA256AuthProtocol exists.
+  PHP_CHECK_LIBRARY($SNMP_LIBNAME, usmHMAC192SHA256AuthProtocol,
+  [
+    AC_DEFINE(HAVE_SNMP_SHA256, 1, [ ])
+  ], [], [
+    $SNMP_SHARED_LIBADD
+  ])
+
+  dnl Check whether usmHMAC384SHA512AuthProtocol exists.
+  PHP_CHECK_LIBRARY($SNMP_LIBNAME, usmHMAC384SHA512AuthProtocol,
+  [
+    AC_DEFINE(HAVE_SNMP_SHA512, 1, [ ])
   ], [], [
     $SNMP_SHARED_LIBADD
   ])

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -923,8 +923,6 @@ static bool netsnmp_session_set_sec_level(struct snmp_session *s, zend_string *l
 /* {{{ Set the authentication protocol in the snmpv3 session */
 static bool netsnmp_session_set_auth_protocol(struct snmp_session *s, zend_string *prot)
 {
-	smart_string err = {0,0,0};
-
 #ifndef DISABLE_MD5
 	if (zend_string_equals_literal_ci(prot, "MD5")) {
 		s->securityAuthProto = usmHMACMD5AuthProtocol;
@@ -955,18 +953,20 @@ static bool netsnmp_session_set_auth_protocol(struct snmp_session *s, zend_strin
 	}
 #endif
 
-	smart_string_appendl(&err, "Authentication protocol must be \"SHA\"", 37);
+	smart_string err = {0};
+
+	smart_string_appends(&err, "Authentication protocol must be \"SHA\"");
 #ifdef HAVE_SNMP_SHA256
-	smart_string_appendl(&err, " or \"SHA256\"", 12);
+	smart_string_appends(&err, " or \"SHA256\"");
 #endif
 #ifdef HAVE_SNMP_SHA512
-	smart_string_appendl(&err, " or \"SHA512\"", 12);
+	smart_string_appends(&err, " or \"SHA512\"");
 #endif
 #ifndef DISABLE_MD5
-	smart_string_appendl(&err, " or \"MD5\"", 9);
+	smart_string_appends(&err, " or \"MD5\"");
 #endif
 	smart_string_0(&err);
-	zend_value_error("%s", err.c);
+	zend_value_error(err.c);
 	smart_string_free(&err);
 	return false;
 }

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -966,7 +966,7 @@ static bool netsnmp_session_set_auth_protocol(struct snmp_session *s, zend_strin
 	smart_string_appends(&err, " or \"MD5\"");
 #endif
 	smart_string_0(&err);
-	zend_value_error(err.c);
+	zend_value_error("%s", err.c);
 	smart_string_free(&err);
 	return false;
 }

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -29,6 +29,7 @@
 #include "php_snmp.h"
 
 #include "zend_exceptions.h"
+#include "zend_smart_string.h"
 #include "ext/spl/spl_exceptions.h"
 #include "snmp_arginfo.h"
 
@@ -922,6 +923,8 @@ static bool netsnmp_session_set_sec_level(struct snmp_session *s, zend_string *l
 /* {{{ Set the authentication protocol in the snmpv3 session */
 static bool netsnmp_session_set_auth_protocol(struct snmp_session *s, zend_string *prot)
 {
+	smart_string err = {0,0,0};
+
 #ifndef DISABLE_MD5
 	if (zend_string_equals_literal_ci(prot, "MD5")) {
 		s->securityAuthProto = usmHMACMD5AuthProtocol;
@@ -936,7 +939,35 @@ static bool netsnmp_session_set_auth_protocol(struct snmp_session *s, zend_strin
 		return true;
 	}
 
-	zend_value_error("Authentication protocol must be either \"MD5\" or \"SHA\"");
+#ifdef HAVE_SNMP_SHA256
+	if (zend_string_equals_literal_ci(prot, "SHA256")) {
+		s->securityAuthProto = usmHMAC192SHA256AuthProtocol;
+		s->securityAuthProtoLen = sizeof(usmHMAC192SHA256AuthProtocol) / sizeof(oid);
+		return true;
+	}
+#endif
+
+#ifdef HAVE_SNMP_SHA512
+	if (zend_string_equals_literal_ci(prot, "SHA512")) {
+		s->securityAuthProto = usmHMAC384SHA512AuthProtocol;
+		s->securityAuthProtoLen = sizeof(usmHMAC384SHA512AuthProtocol) / sizeof(oid);
+		return true;
+	}
+#endif
+
+	smart_string_appendl(&err, "Authentication protocol must be \"SHA\"", 37);
+#ifdef HAVE_SNMP_SHA256
+	smart_string_appendl(&err, " or \"SHA256\"", 12);
+#endif
+#ifdef HAVE_SNMP_SHA512
+	smart_string_appendl(&err, " or \"SHA512\"", 12);
+#endif
+#ifndef DISABLE_MD5
+	smart_string_appendl(&err, " or \"MD5\"", 9);
+#endif
+	smart_string_0(&err);
+	zend_value_error("%s", err.c);
+	smart_string_free(&err);
 	return false;
 }
 /* }}} */

--- a/ext/snmp/tests/snmp-object-setSecurity_error.phpt
+++ b/ext/snmp/tests/snmp-object-setSecurity_error.phpt
@@ -61,7 +61,7 @@ var_dump($session->close());
 --EXPECTF--
 Security level must be one of "noAuthNoPriv", "authNoPriv", or "authPriv"
 Security level must be one of "noAuthNoPriv", "authNoPriv", or "authPriv"
-Authentication protocol must be either "MD5" or "SHA"
+Authentication protocol must be %s
 
 Warning: SNMP::setSecurity(): Error generating a key for authentication pass phrase '': Generic error (The supplied password length is too short.) in %s on line %d
 bool(false)

--- a/ext/snmp/tests/snmp3-error.phpt
+++ b/ext/snmp/tests/snmp3-error.phpt
@@ -60,7 +60,7 @@ try {
 Checking error handling
 Security level must be one of "noAuthNoPriv", "authNoPriv", or "authPriv"
 Security level must be one of "noAuthNoPriv", "authNoPriv", or "authPriv"
-Authentication protocol must be either "MD5" or "SHA"
+Authentication protocol must be %s
 
 Warning: snmp3_get(): Error generating a key for authentication pass phrase '': Generic error (The supplied password length is too short.) in %s on line %d
 bool(false)


### PR DESCRIPTION
```
#define NETSNMP_USMAUTH_HMAC128SHA224     4 /* RFC 7860; OPTIONAL */
#define NETSNMP_USMAUTH_HMAC192SHA256     5 /* RFC 7860; MUST */
#define NETSNMP_USMAUTH_HMAC256SHA384     6 /* RFC 7860; OPTIONAL */
#define NETSNMP_USMAUTH_HMAC384SHA512     7 /* RFC 7860; SHOULD */

```

This PR only add recommended protocol (not optional ones, don't think it really make sense to add them)