### PR TITLE
Include FQCN in the Serializable deprecation message (ref #6494)

### DIFF
--- a/Zend/tests/bug64354.phpt
+++ b/Zend/tests/bug64354.phpt
@@ -21,5 +21,5 @@ try {
 }
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in B instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(9) "serialize"

--- a/Zend/tests/enum/no-implement-serializable-indirect.phpt
+++ b/Zend/tests/enum/no-implement-serializable-indirect.phpt
@@ -21,6 +21,6 @@ var_dump(unserialize(serialize(Foo::Bar)));
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in Foo instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
 Fatal error: Enums may not implement the Serializable interface in %s on line %d

--- a/Zend/tests/enum/no-implement-serializable.phpt
+++ b/Zend/tests/enum/no-implement-serializable.phpt
@@ -19,6 +19,6 @@ var_dump(unserialize(serialize(Foo::Bar)));
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in Foo instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
 Fatal error: Enums may not implement the Serializable interface in %s on line %d

--- a/Zend/tests/serializable_deprecation.phpt
+++ b/Zend/tests/serializable_deprecation.phpt
@@ -20,4 +20,4 @@ class D extends A implements I {
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in C instead (or in addition, if support for old PHP versions is necessary) in %s on line %d

--- a/Zend/tests/traits/interface_003.phpt
+++ b/Zend/tests/traits/interface_003.phpt
@@ -21,7 +21,7 @@ var_dump(unserialize($o));
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in bar instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(20) "C:3:"bar":6:{foobar}"
 string(6) "foobar"
 object(bar)#%d (0) {

--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -419,7 +419,7 @@ static int zend_implement_serializable(zend_class_entry *interface, zend_class_e
 	}
 	if (!(class_type->ce_flags & ZEND_ACC_EXPLICIT_ABSTRACT_CLASS)
 			&& (!class_type->__serialize || !class_type->__unserialize)) {
-		zend_error(E_DEPRECATED, "The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)");
+		zend_error(E_DEPRECATED, "The Serializable interface is deprecated. Implement __serialize() and __unserialize() in %s instead (or in addition, if support for old PHP versions is necessary)", ZSTR_VAL(class_type->name));
 	}
 	return SUCCESS;
 }

--- a/ext/pdo/tests/bug_44409.phpt
+++ b/ext/pdo/tests/bug_44409.phpt
@@ -42,7 +42,7 @@ print_r($stmt->fetchAll(PDO::FETCH_CLASS|PDO::FETCH_SERIALIZE, "bug44409"));
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in bug44409 instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
 Deprecated: PDOStatement::fetchAll(): The PDO::FETCH_SERIALIZE mode is deprecated in %s on line %d
 Method called: bug44409::unserialize('Data from DB')

--- a/ext/pdo/tests/pdo_018.phpt
+++ b/ext/pdo/tests/pdo_018.phpt
@@ -184,11 +184,11 @@ var_dump($stmt->fetchAll(PDO::FETCH_CLASS|PDO::FETCH_CLASSTYPE|PDO::FETCH_SERIAL
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in TestBase instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in TestDerived instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in TestLeaf instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(1) "3"
 array(3) {
   [0]=>

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize.phpt
@@ -121,7 +121,7 @@ $db = MySQLPDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test');
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in myclass instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Creating an object, serializing it and writing it to DB...
 myclass::singleton(Creating object)
 myclass::__construct(Creating object)

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_simple.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_simple.phpt
@@ -70,7 +70,7 @@ MySQLPDOTest::skip();
     print "done!\n";
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in myclass instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Lets see what the Serializeable interface makes our object behave like...
 myclass::__construct('Called by script') - note that it must not be called when unserializing
 myclass::serialize()

--- a/ext/standard/tests/serialize/005.phpt
+++ b/ext/standard/tests/serialize/005.phpt
@@ -128,7 +128,7 @@ echo "===AutoNA===\n";
 var_dump(unserialize('O:22:"autoload_not_available":0:{}'));
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in TestNew instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 ===O1===
 TestOld::__sleep()
 string(18) "O:7:"TestOld":0:{}"
@@ -153,7 +153,7 @@ object(TestNAOld)#%d (0) {
 ===NANew===
 unserializer(TestNANew)
 
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in TestNANew instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
 Warning: Erroneous data format for unserializing 'TestNANew' in %s005.php on line %d
 
@@ -162,7 +162,7 @@ bool(false)
 ===NANew2===
 unserializer(TestNANew2)
 
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in TestNANew2 instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 TestNew::unserialize()
 object(TestNANew2)#%d (0) {
 }

--- a/ext/standard/tests/serialize/bug36424.phpt
+++ b/ext/standard/tests/serialize/bug36424.phpt
@@ -42,11 +42,11 @@ echo "Done\n";
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in a instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in b instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in c instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 C:1:"c":108:{a:1:{s:1:"a";C:1:"a":81:{a:3:{s:1:"b";C:1:"b":30:{a:2:{s:1:"c";r:1;s:1:"a";r:3;}}s:1:"c";r:1;s:1:"a";r:3;}}}}
 bool(true)
 bool(true)

--- a/ext/standard/tests/serialize/bug64146.phpt
+++ b/ext/standard/tests/serialize/bug64146.phpt
@@ -52,7 +52,7 @@ print $a->a[1]->b->c . "\n";
 ?>
 Done
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in B instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 1
 2
 Done

--- a/ext/standard/tests/serialize/bug64354_3.phpt
+++ b/ext/standard/tests/serialize/bug64354_3.phpt
@@ -26,5 +26,5 @@ try {
 }
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in B instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(6) "Failed"

--- a/ext/standard/tests/serialize/bug65481.phpt
+++ b/ext/standard/tests/serialize/bug65481.phpt
@@ -35,5 +35,5 @@ $token = serialize($token);
 ?>
 Done
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in Token instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Done

--- a/ext/standard/tests/serialize/bug70172.phpt
+++ b/ext/standard/tests/serialize/bug70172.phpt
@@ -41,7 +41,7 @@ function ptr2str($ptr)
 }
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in obj instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 array(2) {
   [0]=>
   int(1)

--- a/ext/standard/tests/serialize/bug70172_2.phpt
+++ b/ext/standard/tests/serialize/bug70172_2.phpt
@@ -48,7 +48,7 @@ function ptr2str($ptr)
 }
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in obj instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 array(2) {
   [0]=>
   object(obj2)#%d (1) {

--- a/ext/standard/tests/serialize/bug70219_1.phpt
+++ b/ext/standard/tests/serialize/bug70219_1.phpt
@@ -30,7 +30,7 @@ var_dump($data);
 var_dump($_SESSION);
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in obj instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 array(2) {
   [0]=>
   object(obj)#%d (1) {

--- a/ext/standard/tests/serialize/bug70436.phpt
+++ b/ext/standard/tests/serialize/bug70436.phpt
@@ -46,7 +46,7 @@ function ptr2str($ptr)
 ?>
 DONE
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in obj instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
 Notice: unserialize(): Error at offset 0 of 3 bytes in %sbug70436.php on line %d
 

--- a/ext/standard/tests/serialize/bug71940.phpt
+++ b/ext/standard/tests/serialize/bug71940.phpt
@@ -44,7 +44,7 @@ print_r(unserialize($serialized));
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in Entry instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Array
 (
     [0] => Entry Object

--- a/ext/standard/tests/serialize/bug72663_2.phpt
+++ b/ext/standard/tests/serialize/bug72663_2.phpt
@@ -19,7 +19,7 @@ var_dump(unserialize($exploit));
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in obj instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
 Notice: unserialize(): Unexpected end of serialized data in %s on line %d
 

--- a/ext/standard/tests/serialize/bug80411.phpt
+++ b/ext/standard/tests/serialize/bug80411.phpt
@@ -22,7 +22,7 @@ var_export($recovered);
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in UnSerializable instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 a:4:{i:0;N;i:1;N;i:2;s:6:"endcap";i:3;R:4;}
 array (
   0 => NULL,

--- a/ext/standard/tests/serialize/max_depth.phpt
+++ b/ext/standard/tests/serialize/max_depth.phpt
@@ -139,7 +139,7 @@ Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be ch
 Notice: unserialize(): Error at offset 2309 of 2574 bytes in %s on line %d
 bool(false)
 
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in Test instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Nested unserialize combined depth limit:
 
 Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d
@@ -149,7 +149,7 @@ bool(false)
 bool(true)
 bool(true)
 
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in Test2 instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 Nested unserialize overridden depth limit:
 
 Warning: unserialize(): Maximum depth of 256 exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting in %s on line %d

--- a/ext/standard/tests/serialize/ref_to_failed_serialize.phpt
+++ b/ext/standard/tests/serialize/ref_to_failed_serialize.phpt
@@ -19,7 +19,7 @@ var_dump(unserialize($s));
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in NotSerializable instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 string(18) "a:2:{i:0;N;i:1;N;}"
 array(2) {
   [0]=>

--- a/ext/standard/tests/serialize/serialization_objects_010.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_010.phpt
@@ -20,6 +20,6 @@ try {
 echo "Done";
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in C instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 C::serialize() must return a string or NULL
 Done

--- a/ext/standard/tests/strings/bug72663.phpt
+++ b/ext/standard/tests/strings/bug72663.phpt
@@ -19,7 +19,7 @@ var_dump(unserialize($exploit));
 ?>
 DONE
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in obj instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 
 Notice: unserialize(): Unexpected end of serialized data in %sbug72663.php on line %d
 

--- a/tests/classes/serialize_001.phpt
+++ b/tests/classes/serialize_001.phpt
@@ -46,7 +46,7 @@ foreach($tests as $data)
 
 ?>
 --EXPECTF--
-Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
+Deprecated: The Serializable interface is deprecated. Implement __serialize() and __unserialize() in Test instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
 ==========
 string(6) "String"
 Test::__construct(String)


### PR DESCRIPTION
While running some of my test suites on PHP 8.1.0-beta2, I (rightfully) received the deprecation introduced by #6494: "The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)"

The message is very clear on the course of action, but it didn't provide any information to which class was affected by this change. This PR proposes a very small change by adding the affected FQCN in the message.