### PR TITLE
Deprecate many ArrayIterator methods that are aliases to ArrayObject ones

### DIFF
--- a/ext/spl/spl_array.stub.php
+++ b/ext/spl/spl_array.stub.php
@@ -126,60 +126,70 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
     public function count(): int {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::getFlags
      */
     public function getFlags(): int {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::setFlags
      */
     public function setFlags(int $flags): void {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::asort
      */
     public function asort(int $flags = SORT_REGULAR): bool {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::ksort
      */
     public function ksort(int $flags = SORT_REGULAR): bool {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::uasort
      */
     public function uasort(callable $callback): bool {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::uksort
      */
     public function uksort(callable $callback): bool {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::natsort
      */
     public function natsort(): bool {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::natcasesort
      */
     public function natcasesort(): bool {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::unserialize
      */
     public function unserialize(string $data): void {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @implementation-alias ArrayObject::serialize
      */

--- a/ext/spl/spl_array_arginfo.h
+++ b/ext/spl/spl_array_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e8e9909c2548a2259ba58ecf9f2ad6fe5add70f4 */
+ * Stub hash: aea359465f8fd8c8c5eabc998a36e90628432db9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ArrayObject___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_MASK(0, array, MAY_BE_ARRAY|MAY_BE_OBJECT, "[]")
@@ -228,16 +228,16 @@ static const zend_function_entry class_ArrayIterator_methods[] = {
 	ZEND_MALIAS(ArrayObject, append, append, arginfo_class_ArrayIterator_append, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(ArrayObject, getArrayCopy, getArrayCopy, arginfo_class_ArrayIterator_getArrayCopy, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(ArrayObject, count, count, arginfo_class_ArrayIterator_count, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, getFlags, getFlags, arginfo_class_ArrayIterator_getFlags, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, setFlags, setFlags, arginfo_class_ArrayIterator_setFlags, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, asort, asort, arginfo_class_ArrayIterator_asort, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, ksort, ksort, arginfo_class_ArrayIterator_ksort, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, uasort, uasort, arginfo_class_ArrayIterator_uasort, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, uksort, uksort, arginfo_class_ArrayIterator_uksort, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, natsort, natsort, arginfo_class_ArrayIterator_natsort, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, natcasesort, natcasesort, arginfo_class_ArrayIterator_natcasesort, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, unserialize, unserialize, arginfo_class_ArrayIterator_unserialize, ZEND_ACC_PUBLIC)
-	ZEND_MALIAS(ArrayObject, serialize, serialize, arginfo_class_ArrayIterator_serialize, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(ArrayObject, getFlags, getFlags, arginfo_class_ArrayIterator_getFlags, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, setFlags, setFlags, arginfo_class_ArrayIterator_setFlags, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, asort, asort, arginfo_class_ArrayIterator_asort, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, ksort, ksort, arginfo_class_ArrayIterator_ksort, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, uasort, uasort, arginfo_class_ArrayIterator_uasort, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, uksort, uksort, arginfo_class_ArrayIterator_uksort, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, natsort, natsort, arginfo_class_ArrayIterator_natsort, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, natcasesort, natcasesort, arginfo_class_ArrayIterator_natcasesort, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, unserialize, unserialize, arginfo_class_ArrayIterator_unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
+	ZEND_MALIAS(ArrayObject, serialize, serialize, arginfo_class_ArrayIterator_serialize, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 	ZEND_MALIAS(ArrayObject, __serialize, __serialize, arginfo_class_ArrayIterator___serialize, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(ArrayObject, __unserialize, __unserialize, arginfo_class_ArrayIterator___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(ArrayIterator, rewind, arginfo_class_ArrayIterator_rewind, ZEND_ACC_PUBLIC)

--- a/ext/spl/tests/arrayIterator_ksort_basic1.phpt
+++ b/ext/spl/tests/arrayIterator_ksort_basic1.phpt
@@ -9,9 +9,10 @@ var_dump($arrIter->ksort());
 var_dump($arrIter);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method ArrayIterator::ksort() is deprecated in %s on line %d
 bool(true)
-object(ArrayIterator)#1 (1) {
+object(ArrayIterator)#%d (1) {
   ["storage":"ArrayIterator":private]=>
   array(3) {
     [1]=>

--- a/ext/spl/tests/arrayObject_getFlags_basic2.phpt
+++ b/ext/spl/tests/arrayObject_getFlags_basic2.phpt
@@ -7,10 +7,10 @@ var_dump($ao->getFlags());
 
 $ao2 = new ArrayObject($ao);
 var_dump($ao2->getFlags());
-var_dump($ao2->getIterator()->getFlags());
+@var_dump($ao2->getIterator()->getFlags());
 
 $ai = new ArrayIterator($ao);
-var_dump($ai->getFlags());
+@var_dump($ai->getFlags());
 
 $ao2 = new ArrayObject($ao, 0);
 var_dump($ao2->getFlags());

--- a/ext/spl/tests/array_017.phpt
+++ b/ext/spl/tests/array_017.phpt
@@ -19,15 +19,17 @@ class ArrayIteratorEx extends ArrayIterator
     function dump()
     {
         echo __METHOD__ . "()\n";
-        var_dump(array('Flags'=>$this->getFlags()
-                      ,'OVars'=>get_object_vars($this)
-                      ,'$this'=>$this));
+        var_dump([
+            'Flags' => @$this->getFlags(),
+            'OVars' => get_object_vars($this),
+            '$this' => $this,
+        ]);
     }
 
     function setFlags($flags): void
     {
         echo __METHOD__ . "($flags)\n";
-        ArrayIterator::setFlags($flags);
+        @ArrayIterator::setFlags($flags);
     }
 }
 

--- a/ext/spl/tests/bug46115.phpt
+++ b/ext/spl/tests/bug46115.phpt
@@ -7,5 +7,6 @@ $x = new reflectionmethod('RecursiveArrayIterator', 'asort');
 $z = $x->invoke($h);
 ?>
 DONE
---EXPECT--
+--EXPECTF--
+Deprecated: Method ArrayIterator::asort() is deprecated in %s on line %d
 DONE

--- a/ext/spl/tests/bug67539.phpt
+++ b/ext/spl/tests/bug67539.phpt
@@ -16,5 +16,10 @@ function badsort($a, $b) {
 
 $it->uksort('badsort');
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Method ArrayIterator::uksort() is deprecated in %s on line %d
+
+Deprecated: Method ArrayIterator::serialize() is deprecated in %s on line %d
+
+Deprecated: Method ArrayIterator::unserialize() is deprecated in %s on line %d
 Modification of ArrayObject during sorting is prohibited


### PR DESCRIPTION
This will need an RFC, I think.

These are needless, and cause problems (see some of the bugs lol).
Generally if you want these methods, use an ArrayObject directly.

I intend to _remove_ these and possibly more in PHP 9.0 so that
ArrayIterator can be made efficient.

Of the deprecations included, the only ones I'm not sure about are
the serialize/unserialize ones with the Serializable interface. We
want those to go away eventually, but not sure if we're ready to
add a deprecation notice on this particular usage.