### PR TITLE
Fix #81302: Stream position after stream filter removed

### DIFF
--- a/ext/standard/tests/filters/bug81302.phpt
+++ b/ext/standard/tests/filters/bug81302.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #81302 (Stream position after stream filter removed)
+--SKIPIF--
+<?php
+if (!extension_loaded('zlib')) die("skip zlib extension not available");
+?>
+--FILE--
+<?php
+$f = fopen("php://memory", "w+b");
+$z = stream_filter_append($f, "zlib.deflate", STREAM_FILTER_WRITE, 6);
+fwrite($f, "Testing");
+stream_filter_remove($z);
+$pos = ftell($f);
+fseek($f, 0);
+$count = strlen(fread($f, 1024));
+fclose($f);
+var_dump($count === $pos);
+?>
+--EXPECT--
+bool(true)

--- a/main/streams/filter.c
+++ b/main/streams/filter.c
@@ -470,7 +470,10 @@ PHPAPI int _php_stream_filter_flush(php_stream_filter *filter, int finish)
 	} else if (chain == &(stream->writefilters)) {
 		/* Send flushed data to the stream */
 		while ((bucket = inp->head)) {
-			stream->ops->write(stream, bucket->buf, bucket->buflen);
+			ssize_t count = stream->ops->write(stream, bucket->buf, bucket->buflen);
+			if (count > 0) {
+				stream->position += count;
+			}
 			php_stream_bucket_unlink(bucket);
 			php_stream_bucket_delref(bucket);
 		}


### PR DESCRIPTION
When flushing the stream filters actually causes data to be written to
the stream, we need to update its position, because that is not done by
the streams' write methods.