### PR TITLE
fix bug 81343: inconsistent type conversion after closeCursor

### DIFF
--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -674,12 +674,6 @@ static int pgsql_stmt_get_column_meta(pdo_stmt_t *stmt, zend_long colno, zval *r
 
 static int pdo_pgsql_stmt_cursor_closer(pdo_stmt_t *stmt)
 {
-	pdo_pgsql_stmt *S = (pdo_pgsql_stmt*)stmt->driver_data;
-
-	if (S->cols != NULL){
-		efree(S->cols);
-		S->cols = NULL;
-	}
 	return 1;
 }
 

--- a/ext/pdo_pgsql/tests/bug81343.phpt
+++ b/ext/pdo_pgsql/tests/bug81343.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #81343 pdo_pgsql: Inconsitent boolean conversion after calling closeCursor()
+--EXTENSIONS--
+pdo
+pdo_pgsql
+--SKIPIF--
+<?php
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+$sth = $pdo->prepare("select false where 2=?");
+
+for ($i = 0; $i < 2; $i++) {
+    $sth->execute([2]);
+    var_dump($sth->fetchColumn(0));
+    $sth->closeCursor();
+}
+?>
+--EXPECT--
+bool(false)
+bool(false)


### PR DESCRIPTION
`S->cols` is already freed in the statement destructor and since  caa710037e663fd78f67533b29611183090068b2 the column data is only populated on the first `execute()` which means that on subsequent execute()s after `closeCursor` was called, all meta-data for column types was removed and never restored, so any possible data type conversion was not happening any more.