### PR TITLE
Fix #81346: Non-seekable streams don't update position after write

### DIFF
--- a/ext/standard/tests/streams/bug81346.phpt
+++ b/ext/standard/tests/streams/bug81346.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #81346 (Non-seekable streams don't update position after write)
+--DESCRIPTION--
+The test expectation is due to bug #81345.
+--SKIPIF--
+<?php
+if (!extension_loaded('bz2')) die("bz2 extension not available");
+?>
+--FILE--
+<?php
+$s = fopen("compress.bzip2://" . __DIR__ . "/bug81346.bz2", "w");
+fwrite($s, str_repeat("hello world", 100));
+fflush($s);
+var_dump(ftell($s));
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/bug81346.bz2");
+?>
+--EXPECT--
+int(1100)

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1151,12 +1151,7 @@ static ssize_t _php_stream_write_buffer(php_stream *stream, const char *buf, siz
 		buf += justwrote;
 		count -= justwrote;
 		didwrite += justwrote;
-
-		/* Only screw with the buffer if we can seek, otherwise we lose data
-		 * buffered from fifos and sockets */
-		if (stream->ops->seek && (stream->flags & PHP_STREAM_FLAG_NO_SEEK) == 0) {
-			stream->position += justwrote;
-		}
+		stream->position += justwrote;
 	}
 
 	return didwrite;


### PR DESCRIPTION
The stream position is not related to the buffer, and needs to be
updated for non-seekable streams as well.  The erroneous condition
around the position update is a relict of an old commit[1].

The unexpected test expectation is due to bug #81345.

[1] <https://github.com/php/php-src/commit/088e2692c3d1e680fd3d9306c4adb417e761acff>