### PR TITLE
Fix #80833 ZipArchive::getStream doesn't use setPassword

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -2887,7 +2887,6 @@ PHP_METHOD(ZipArchive, getStream)
 	char *mode = "rb";
 	zend_string *filename;
 	php_stream *stream;
-	ze_zip_object *obj;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "P", &filename) == FAILURE) {
 		RETURN_THROWS();
@@ -2899,9 +2898,7 @@ PHP_METHOD(ZipArchive, getStream)
 		RETURN_FALSE;
 	}
 
-	obj = Z_ZIP_P(self);
-
-	stream = php_stream_zip_open(obj->filename, ZSTR_VAL(filename), mode STREAMS_CC);
+	stream = php_stream_zip_open(intern, ZSTR_VAL(filename), mode STREAMS_CC);
 	if (stream) {
 		php_stream_to_zval(stream, return_value);
 	} else {

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -75,7 +75,7 @@ static inline ze_zip_object *php_zip_fetch_object(zend_object *obj) {
 #define Z_ZIP_P(zv) php_zip_fetch_object(Z_OBJ_P((zv)))
 
 php_stream *php_stream_zip_opener(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC);
-php_stream *php_stream_zip_open(const char *filename, const char *path, const char *mode STREAMS_DC);
+php_stream *php_stream_zip_open(struct zip *arch, const char *path, const char *mode STREAMS_DC);
 
 extern const php_stream_wrapper php_stream_zip_wrapper;
 

--- a/ext/zip/tests/bug80833.phpt
+++ b/ext/zip/tests/bug80833.phpt
@@ -36,13 +36,22 @@ $extract_zip->setPassword("second_password");
 $file_stream = $extract_zip->getStream("test2.txt");
 var_dump(stream_get_contents($file_stream));
 fclose($file_stream);
+
+// Archive close before the stream
+$extract_zip->setPassword("first_password");
+$file_stream = $extract_zip->getStream("test.txt");
 $extract_zip->close();
+var_dump(stream_get_contents($file_stream));
+fclose($file_stream);
 ?>
 --CLEAN--
 <?php
 @unlink(__DIR__ . "/80833.zip");
 ?>
---EXPECT--
+--EXPECTF--
 string(22) "This is a test string."
 string(22) "This is a test string."
 string(28) "This is another test string."
+
+Warning: stream_get_contents(): Zip stream error: Containing zip archive was closed in %s
+string(0) ""

--- a/ext/zip/tests/bug80833.phpt
+++ b/ext/zip/tests/bug80833.phpt
@@ -15,6 +15,16 @@ $create_zip->addFromString("test2.txt", "This is another test string.");
 $create_zip->setEncryptionName("test2.txt", ZipArchive::EM_AES_256, "second_password");
 $create_zip->close();
 
+// Stream API
+$o = [
+	'zip' => [
+		'password' => "first_password",
+	],
+];
+$c = stream_context_create($o);
+var_dump(file_get_contents("zip://" . __DIR__ . "/80833.zip#test.txt", false, $c));
+
+// getStream method
 $extract_zip = new ZipArchive();
 $extract_zip->open(__DIR__ . "/80833.zip", ZipArchive::RDONLY);
 $extract_zip->setPassword("first_password");
@@ -32,5 +42,6 @@ $extract_zip->close();
 @unlink(__DIR__ . "/80833.zip");
 ?>
 --EXPECT--
+string(22) "This is a test string."
 string(22) "This is a test string."
 string(28) "This is another test string."

--- a/ext/zip/tests/bug80833.phpt
+++ b/ext/zip/tests/bug80833.phpt
@@ -3,6 +3,7 @@ Bug #80833 (ZipArchive::getStream doesn't use setPassword)
 --SKIPIF--
 <?php
 if (!extension_loaded('zip')) die("skip zip extension not available");
+if (!method_exists('ZipArchive', 'setEncryptionName')) die('skip encryption not supported');
 ?>
 --FILE--
 <?php

--- a/ext/zip/tests/bug80833.phpt
+++ b/ext/zip/tests/bug80833.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Bug #80833 (ZipArchive::getStream doesn't use setPassword)
+--SKIPIF--
+<?php
+if (!extension_loaded('zip')) die("skip zip extension not available");
+?>
+--FILE--
+<?php
+$create_zip = new ZipArchive();
+$create_zip->open(__DIR__ . "/80833.zip", ZipArchive::CREATE);
+$create_zip->setPassword("default_password");
+$create_zip->addFromString("test.txt", "This is a test string.");
+$create_zip->setEncryptionName("test.txt", ZipArchive::EM_AES_256, "first_password");
+$create_zip->addFromString("test2.txt", "This is another test string.");
+$create_zip->setEncryptionName("test2.txt", ZipArchive::EM_AES_256, "second_password");
+$create_zip->close();
+
+$extract_zip = new ZipArchive();
+$extract_zip->open(__DIR__ . "/80833.zip", ZipArchive::RDONLY);
+$extract_zip->setPassword("first_password");
+$file_stream = $extract_zip->getStream("test.txt");
+var_dump(stream_get_contents($file_stream));
+fclose($file_stream);
+$extract_zip->setPassword("second_password");
+$file_stream = $extract_zip->getStream("test2.txt");
+var_dump(stream_get_contents($file_stream));
+fclose($file_stream);
+$extract_zip->close();
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/80833.zip");
+?>
+--EXPECT--
+string(22) "This is a test string."
+string(28) "This is another test string."

--- a/ext/zip/zip_stream.c
+++ b/ext/zip/zip_stream.c
@@ -48,7 +48,7 @@ static ssize_t php_zip_ops_read(php_stream *stream, char *buf, size_t count)
 	ssize_t n = 0;
 	STREAM_DATA_FROM_STREAM();
 
-	if (self->za && self->zf) {
+	if (self->zf) {
 		n = zip_fread(self->zf, buf, count);
 		if (n < 0) {
 #if LIBZIP_VERSION_MAJOR < 1
@@ -208,51 +208,32 @@ const php_stream_ops php_stream_zipio_ops = {
 };
 
 /* {{{ php_stream_zip_open */
-php_stream *php_stream_zip_open(const char *filename, const char *path, const char *mode STREAMS_DC)
+php_stream *php_stream_zip_open(struct zip *arch, const char *path, const char *mode STREAMS_DC)
 {
 	struct zip_file *zf = NULL;
-	int err = 0;
 
 	php_stream *stream = NULL;
 	struct php_zip_stream_data_t *self;
-	struct zip *stream_za;
 
 	if (strncmp(mode,"r", strlen("r")) != 0) {
 		return NULL;
 	}
 
-	if (filename) {
-		if (ZIP_OPENBASEDIR_CHECKPATH(filename)) {
-			return NULL;
-		}
-
-		/* duplicate to make the stream za independent (esp. for MSHUTDOWN) */
-		stream_za = zip_open(filename, ZIP_CREATE, &err);
-		if (!stream_za) {
-			return NULL;
-		}
-
-		zf = zip_fopen(stream_za, path, 0);
+	if (arch) {
+		zf = zip_fopen(arch, path, 0);
 		if (zf) {
 			self = emalloc(sizeof(*self));
 
-			self->za = stream_za;
+			self->za = NULL; /* to keep it open on stream close */
 			self->zf = zf;
 			self->stream = NULL;
 			self->cursor = 0;
 			stream = php_stream_alloc(&php_stream_zipio_ops, self, NULL, mode);
 			stream->orig_path = estrdup(path);
-		} else {
-			zip_close(stream_za);
 		}
 	}
 
-	if (!stream) {
-		return NULL;
-	} else {
-		return stream;
-	}
-
+	return stream;
 }
 /* }}} */
 


### PR DESCRIPTION
Could apply in 7.4+

Previously,  `php_stream_zip_open` reopen the same archive, bad for perf, and also explain why password is lost.
