### PR TITLE
Fix #78374: Warning when closing FTPS connection after FTP_PUT

### DIFF
--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1582,7 +1582,7 @@ my_recv(ftpbuf_t *ftp, php_socket_t s, void *buf, size_t len)
 /* {{{ data_available
  */
 int
-data_available(ftpbuf_t *ftp, php_socket_t s)
+data_available(ftpbuf_t *ftp, php_socket_t s, zend_bool ignore_timeout)
 {
 	int		n;
 
@@ -1590,6 +1590,7 @@ data_available(ftpbuf_t *ftp, php_socket_t s)
 	if (n < 1) {
 		char buf[256];
 		if (n == 0) {
+			if (ignore_timeout) return 0;
 #ifdef PHP_WIN32
 			_set_errno(ETIMEDOUT);
 #else
@@ -1919,7 +1920,7 @@ static void ftp_ssl_shutdown(ftpbuf_t *ftp, php_socket_t fd, SSL *ssl_handle) {
 		done = 0;
 	}
 
-	while (!done && data_available(ftp, fd)) {
+	while (!done && data_available(ftp, fd, 1)) {
 		ERR_clear_error();
 		nread = SSL_read(ssl_handle, buf, sizeof(buf));
 		if (nread <= 0) {
@@ -2174,7 +2175,7 @@ ftp_nb_continue_read(ftpbuf_t *ftp)
 	data = ftp->data;
 
 	/* check if there is already more data */
-	if (!data_available(ftp, data->fd)) {
+	if (!data_available(ftp, data->fd, 0)) {
 		return PHP_FTP_MOREDATA;
 	}
 

--- a/ext/ftp/tests/bug78374.phpt
+++ b/ext/ftp/tests/bug78374.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #78374 (Warning when closing FTPS connection after FTP_PUT)
+--SKIPIF--
+<?php
+$ssl = 1;
+require 'skipif.inc';
+if (!function_exists("ftp_ssl_connect")) die("skip ftp_ssl is disabled");
+?>
+--FILE--
+<?php
+$ssl = 1;
+require 'server.inc';
+
+$ftp = ftp_ssl_connect('127.0.0.1', $port);
+if (!$ftp) die("Couldn't connect to the server");
+
+var_dump(ftp_login($ftp, 'user', 'pass'));
+var_dump(ftp_put($ftp, basename(__FILE__), __FILE__, FTP_ASCII));
+var_dump(ftp_close($ftp));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)

--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -236,6 +236,10 @@ if ($pid) {
 					continue;
 				}
 
+				if ((!empty($ssl)) && (!stream_socket_enable_crypto($fs, true, STREAM_CRYPTO_METHOD_SSLv23_SERVER, $s))) {
+					die("SSLv23 handshake failed.\n");
+				}
+
 				$data = stream_get_contents($fs);
 				$orig = file_get_contents(dirname(__FILE__).'/'.$m[1]);
 

--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -236,7 +236,7 @@ if ($pid) {
 					continue;
 				}
 
-				if ((!empty($ssl)) && (!stream_socket_enable_crypto($fs, true, STREAM_CRYPTO_METHOD_SSLv23_SERVER, $s))) {
+				if ((!empty($ssl)) && (!stream_socket_enable_crypto($fs, true, STREAM_CRYPTO_METHOD_TLS_SERVER, $s))) {
 					die("SSLv23 handshake failed.\n");
 				}
 


### PR DESCRIPTION
`ftp_ssl_shutdown()` attempts a bidirectional shutdown handshake, i.e.
we're sending a close_notify alert, and then wait for the peer to send
its close_notify alert.  If the peer doesn't sent it, typically because
it already closed the connection, we should not raise a warning, but
rather ignore this condition.

---

Note that the test case is somewhat bogus as it wouldn't fail without the changes to ftp.c; I wouldn't know how to accomplish that. Still, the test case makes some sense on its own, since it tests uploading via FTPS.