### PR TITLE
Fix #81351: xml_parse may fail, but has no error code

### DIFF
--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -565,16 +565,8 @@ XML_Parse(XML_Parser parser, const XML_Char *data, int data_len, int is_final)
 {
 	int error;
 
-	if (parser->parser->lastError.level >= XML_ERR_WARNING) {
-		return 0;
-	}
-
 	error = xmlParseChunk(parser->parser, (char *) data, data_len, is_final);
-	if (error) {
-		return 0;
-	} else {
-		return 1;
-	}
+	return !error && parser->parser->lastError.level <= XML_ERR_WARNING;
 }
 
 PHP_XML_API int

--- a/ext/xml/tests/bug73135.phpt
+++ b/ext/xml/tests/bug73135.phpt
@@ -21,6 +21,10 @@ HERE;
     xml_parse($parser, $xml);
 ?>
 --EXPECTF--
+Warning: xml_parse(): Parser must not be called recursively. in %s%ebug73135.php on line %d
+
+Warning: xml_parse(): Parser must not be called recursively. in %s%ebug73135.php on line %d
+
 Warning: xml_parse(): Unable to call handler ahihi() in %s%ebug73135.php on line %d
 
 Warning: xml_parse(): Unable to call handler ahihi() in %s%ebug73135.php on line %d

--- a/ext/xml/tests/bug73135.phpt
+++ b/ext/xml/tests/bug73135.phpt
@@ -21,9 +21,9 @@ HERE;
     xml_parse($parser, $xml);
 ?>
 --EXPECTF--
-Warning: xml_parse(): Parser must not be called recursively. in %s%ebug73135.php on line %d
+Warning: xml_parse(): Parser must not be called recursively in %s%ebug73135.php on line %d
 
-Warning: xml_parse(): Parser must not be called recursively. in %s%ebug73135.php on line %d
+Warning: xml_parse(): Parser must not be called recursively in %s%ebug73135.php on line %d
 
 Warning: xml_parse(): Unable to call handler ahihi() in %s%ebug73135.php on line %d
 

--- a/ext/xml/tests/bug81351.phpt
+++ b/ext/xml/tests/bug81351.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #81351 (xml_parse may fail, but has no error code)
+--SKIPIF--
+<?php
+if (!extension_loaded('xml')) die("skip xml extension not available");
+?>
+--FILE--
+<?php
+$xml = <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+ <soap:Body>
+  <X xmlns="example.org">
+XML;
+
+$parser = xml_parser_create_ns('UTF-8');
+$success = xml_parse($parser, $xml, false);
+$code = xml_get_error_code($parser);
+$error = xml_error_string($code);
+echo "xml_parse returned $success, xml_get_error_code = $code, xml_error_string = $error\r\n";
+$success = xml_parse($parser, 'Y>', true);
+$code = xml_get_error_code($parser);
+$error = xml_error_string($code);
+echo "xml_parse returned $success, xml_get_error_code = $code, xml_error_string = $error\r\n";
+?>
+--EXPECT--
+xml_parse returned 1, xml_get_error_code = 0, xml_error_string = No error
+xml_parse returned 0, xml_get_error_code = 5, xml_error_string = Invalid document end

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1416,6 +1416,10 @@ PHP_FUNCTION(xml_parse)
 		RETURN_FALSE;
 	}
 
+	if (parser->isparsing) {
+		php_error_docref(NULL, E_WARNING, "Parser must not be called recursively.");
+		RETURN_FALSE;
+	}
 	parser->isparsing = 1;
 	ret = XML_Parse(parser->parser, (XML_Char*)data, data_len, isFinal);
 	parser->isparsing = 0;
@@ -1467,6 +1471,10 @@ PHP_FUNCTION(xml_parse_into_struct)
 	XML_SetElementHandler(parser->parser, _xml_startElementHandler, _xml_endElementHandler);
 	XML_SetCharacterDataHandler(parser->parser, _xml_characterDataHandler);
 
+	if (parser->isparsing) {
+		php_error_docref(NULL, E_WARNING, "Parser must not be called recursively.");
+		RETURN_FALSE;
+	}
 	parser->isparsing = 1;
 	ret = XML_Parse(parser->parser, (XML_Char*)data, data_len, 1);
 	parser->isparsing = 0;

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1417,7 +1417,7 @@ PHP_FUNCTION(xml_parse)
 	}
 
 	if (parser->isparsing) {
-		php_error_docref(NULL, E_WARNING, "Parser must not be called recursively.");
+		php_error_docref(NULL, E_WARNING, "Parser must not be called recursively");
 		RETURN_FALSE;
 	}
 	parser->isparsing = 1;
@@ -1472,7 +1472,7 @@ PHP_FUNCTION(xml_parse_into_struct)
 	XML_SetCharacterDataHandler(parser->parser, _xml_characterDataHandler);
 
 	if (parser->isparsing) {
-		php_error_docref(NULL, E_WARNING, "Parser must not be called recursively.");
+		php_error_docref(NULL, E_WARNING, "Parser must not be called recursively");
 		RETURN_FALSE;
 	}
 	parser->isparsing = 1;


### PR DESCRIPTION
The fix for bug #73135[1] cured the symptoms, but not the root cause,
namely xmlParse() must not be called recursively.  Since that bugfix
also messed up the error handling, we basically revert it (but also
simplify the return), and then prevent calling the parser recursively.

[1] <https://github.com/php/php-src/pull/2166/commits/f2a8a8c068995a5d780882c556cedd53bce3827d>