### PR TITLE
Remove full stop from error message

### DIFF
--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1402,7 +1402,7 @@ PHP_FUNCTION(xml_parser_free)
 
 	parser = Z_XMLPARSER_P(pind);
 	if (parser->isparsing == 1) {
-		php_error_docref(NULL, E_WARNING, "Parser cannot be freed while it is parsing.");
+		php_error_docref(NULL, E_WARNING, "Parser cannot be freed while it is parsing");
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
Error messages shouldn't have a full stop.  Period.