### PR TITLE
Fix #71542: disk_total_space does not work with relative paths

### DIFF
--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -183,18 +183,22 @@ static int php_disk_total_space(char *path, double *space) /* {{{ */
 PHP_FUNCTION(disk_total_space)
 {
 	double bytestotal;
-	char *path;
+	char *path, fullpath[MAXPATHLEN];
 	size_t path_len;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_PATH(path, path_len)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (php_check_open_basedir(path)) {
+	if (!expand_filepath(path, fullpath)) {
 		RETURN_FALSE;
 	}
 
-	if (php_disk_total_space(path, &bytestotal) == SUCCESS) {
+	if (php_check_open_basedir(fullpath)) {
+		RETURN_FALSE;
+	}
+
+	if (php_disk_total_space(fullpath, &bytestotal) == SUCCESS) {
 		RETURN_DOUBLE(bytestotal);
 	}
 	RETURN_FALSE;
@@ -278,18 +282,22 @@ static int php_disk_free_space(char *path, double *space) /* {{{ */
 PHP_FUNCTION(disk_free_space)
 {
 	double bytesfree;
-	char *path;
+	char *path, fullpath[MAXPATHLEN];
 	size_t path_len;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_PATH(path, path_len)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (php_check_open_basedir(path)) {
+	if (!expand_filepath(path, fullpath)) {
 		RETURN_FALSE;
 	}
 
-	if (php_disk_free_space(path, &bytesfree) == SUCCESS) {
+	if (php_check_open_basedir(fullpath)) {
+		RETURN_FALSE;
+	}
+
+	if (php_disk_free_space(fullpath, &bytesfree) == SUCCESS) {
 		RETURN_DOUBLE(bytesfree);
 	}
 	RETURN_FALSE;

--- a/ext/standard/tests/dir/bug71542.phpt
+++ b/ext/standard/tests/dir/bug71542.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #71542 (disk_total_space does not work with relative paths)
+--FILE--
+<?php
+$dir = basename(getcwd());
+chdir("..");
+var_dump(
+    disk_total_space($dir) !== false,
+    disk_free_space($dir) !== false
+);
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/tests/security/open_basedir_disk_free_space.phpt
+++ b/tests/security/open_basedir_disk_free_space.phpt
@@ -25,28 +25,28 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: disk_free_space(): open_basedir restriction in effect. File(../bad) is not within the allowed path(s): (.) in %s on line %d
+Warning: disk_free_space(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
 bool(false)
 
-Warning: disk_free_space(): open_basedir restriction in effect. File(../bad/bad.txt) is not within the allowed path(s): (.) in %s on line %d
+Warning: disk_free_space(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
 bool(false)
 
-Warning: disk_free_space(): open_basedir restriction in effect. File(..) is not within the allowed path(s): (.) in %s on line %d
+Warning: disk_free_space(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
 bool(false)
 
-Warning: disk_free_space(): open_basedir restriction in effect. File(../) is not within the allowed path(s): (.) in %s on line %d
+Warning: disk_free_space(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
 bool(false)
 
-Warning: disk_free_space(): open_basedir restriction in effect. File(/) is not within the allowed path(s): (.) in %s on line %d
+Warning: disk_free_space(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
 bool(false)
 
-Warning: disk_free_space(): open_basedir restriction in effect. File(../bad/.) is not within the allowed path(s): (.) in %s on line %d
+Warning: disk_free_space(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
 bool(false)
 
-Warning: disk_free_space(): open_basedir restriction in effect. File(%s/test/bad/bad.txt) is not within the allowed path(s): (.) in %s on line %d
+Warning: disk_free_space(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
 bool(false)
 
-Warning: disk_free_space(): open_basedir restriction in effect. File(%s/test/bad/../bad/bad.txt) is not within the allowed path(s): (.) in %s on line %d
+Warning: disk_free_space(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (.) in %s on line %d
 bool(false)
 float(%s)
 *** Finished testing open_basedir configuration [disk_free_space] ***


### PR DESCRIPTION
For ZTS builds, we need to expand the path given to `disk_free_space()`
and `disk_total_space()` to properly support the VCWD.