### PR TITLE
Improve the success rate when use mkdir() in multiprocessing environment

### DIFF
--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1415,8 +1415,9 @@ static int php_plain_files_mkdir(php_stream_wrapper *wrapper, const char *dir, i
 	while (true) {
 		int ret = VCWD_MKDIR(buf, (mode_t) mode);
 		if (ret < 0 && errno != EEXIST) {
-		    /* stop running and issue a warning to client when ret < 0 and errno != EEXIST */
-		    php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+			if (options & REPORT_ERRORS) {
+				php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+			}
 			return 0;
 		}
 
@@ -1431,14 +1432,14 @@ static int php_plain_files_mkdir(php_stream_wrapper *wrapper, const char *dir, i
 			}
 		}
 		if (p == e || !replaced_slash) {
-		    /* No more directories to create */
-		    /* issue a warning to client when the last directory was created failed */
-		    if (ret < 0) {
-		        if (options & REPORT_ERRORS) {
-		            php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
-		        }
-		        return 0;
-		    }
+			/* No more directories to create */
+			/* issue a warning to client when the last directory was created failed */
+			if (ret < 0) {
+				if (options & REPORT_ERRORS) {
+					php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+				}
+				return 0;
+			}
 			return 1;
 		}
 	}

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1437,6 +1437,7 @@ static int php_plain_files_mkdir(php_stream_wrapper *wrapper, const char *dir, i
 		        if (options & REPORT_ERRORS) {
 		            php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
 		        }
+		        return 0;
 		    }
 			return 1;
 		}


### PR DESCRIPTION
A process a want to create /home/test/a directory.
Another process b want to create /home/test/b directory.
But process b will fail rather than creating /home/test/b directory if /home/test/ directory had created by process a.
So I optimize php_plain_files_mkdir function to improve the success rate.

@nikic 
I am so sorry.
I issued a new pr and closed old pr because of my unintentional operation.
I hope it won't cause any inconvenience.

Thanks.