### PR TITLE
Fix #78819: Heap Overflow in msg_send

### DIFF
--- a/ext/sysvmsg/sysvmsg.c
+++ b/ext/sysvmsg/sysvmsg.c
@@ -414,7 +414,7 @@ PHP_FUNCTION(msg_send)
 	sysvmsg_queue_t * mq = NULL;
 	struct php_msgbuf * messagebuffer = NULL; /* buffer to transmit */
 	int result;
-	int message_len = 0;
+	size_t message_len = 0;
 
 	RETVAL_FALSE;
 


### PR DESCRIPTION
We need to use the proper type.