### PR TITLE
Deprecate dynamic property creation

### DIFF
--- a/Zend/tests/anon/003.phpt
+++ b/Zend/tests/anon/003.phpt
@@ -4,7 +4,7 @@ reusing anonymous classes
 <?php
 while (@$i++<10) {
     var_dump(new class($i) {
-
+        public $i;
         public function __construct($i) {
             $this->i = $i;
         }

--- a/Zend/tests/assign_to_obj_001.phpt
+++ b/Zend/tests/assign_to_obj_001.phpt
@@ -20,5 +20,8 @@ $a->test();
 $a->test();
 echo "okey";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property A::$a is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property A::$a is deprecated in %s on line %d
 okey

--- a/Zend/tests/bug24635.phpt
+++ b/Zend/tests/bug24635.phpt
@@ -3,6 +3,7 @@ Bug #24635 (crash on dtor calling other functions)
 --FILE--
 <?php
 class SiteClass {
+    public $page;
     function __construct()	{ $this->page = new PageClass(); }
 }
 class PageClass {
@@ -11,6 +12,7 @@ class PageClass {
     }
 }
 class SectionClass {
+    public $Comment;
     function __construct($comment) {
         $this->Comment = $comment;
     }

--- a/Zend/tests/bug27268.phpt
+++ b/Zend/tests/bug27268.phpt
@@ -17,7 +17,8 @@ $clone = clone $A;
 $clone->a = array();
 print_r($A);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property A::$a is deprecated in %s on line %d
 A Object
 (
     [a] => Array

--- a/Zend/tests/bug30162.phpt
+++ b/Zend/tests/bug30162.phpt
@@ -42,8 +42,16 @@ $db = new hariCow;
 var_dump($db);
 ?>
 --EXPECTF--
+Deprecated: Creation of dynamic property FIIFO::$x is deprecated in %s on line %d
+
 Warning: Undefined variable $db in %s on line %d
 NULL
+
+Deprecated: Creation of dynamic property hariCow::$x is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property hariCow::$y is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property FIIFO::$x is deprecated in %s on line %d
 object(hariCow)#%d (2) {
   ["x"]=>
   string(1) "x"

--- a/Zend/tests/bug38779.phpt
+++ b/Zend/tests/bug38779.phpt
@@ -4,6 +4,7 @@ Bug #38779 (engine crashes when require()'ing file with syntax error through use
 <?php
 
 class Loader {
+    public $context;
     private $position;
     private $data;
     public function stream_open($path, $mode, $options, &$opened_path)  {

--- a/Zend/tests/bug38779_1.phpt
+++ b/Zend/tests/bug38779_1.phpt
@@ -4,6 +4,7 @@ Bug #38779 (engine crashes when require()'ing file with syntax error through use
 <?php
 
 class Loader {
+    public $context;
     private $position;
     private $data;
     public function stream_open($path, $mode, $options, &$opened_path)  {

--- a/Zend/tests/bug41421.phpt
+++ b/Zend/tests/bug41421.phpt
@@ -4,6 +4,7 @@ Bug #41421 (Uncaught exception from a stream wrapper segfaults)
 <?php
 
 class wrapper {
+    public $context;
     function stream_open() {
         return true;
     }

--- a/Zend/tests/bug47343.phpt
+++ b/Zend/tests/bug47343.phpt
@@ -20,6 +20,8 @@ class A
 
 class B
 {
+    public $A;
+
     public function __construct($A)
     {
         $this->A = $A;
@@ -40,5 +42,8 @@ for ($i = 0; $i < 2; $i++)
 
 echo "DONE\n";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property A::$data is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property A::$data is deprecated in %s on line %d
 DONE

--- a/Zend/tests/bug49893.phpt
+++ b/Zend/tests/bug49893.phpt
@@ -12,6 +12,7 @@ class A {
     }
 }
 class B {
+    public $a;
     function __construct() {
         $this->a = new A();
         throw new Exception("1");

--- a/Zend/tests/bug51822.phpt
+++ b/Zend/tests/bug51822.phpt
@@ -34,7 +34,9 @@ if (!isset(Test::$mystatic))
 
 echo "bla\n";
 ?>
---EXPECT--
+--EXPECTF--
 bla
+
+Deprecated: Creation of dynamic property DestructorCreator::$test is deprecated in %s on line %d
 1
 2

--- a/Zend/tests/bug54268.phpt
+++ b/Zend/tests/bug54268.phpt
@@ -20,6 +20,7 @@ class DestructableObject
 }
 class DestructorCreator
 {
+        public $test;
         public function __destruct()
         {
                 $this->test = new DestructableObject;

--- a/Zend/tests/bug55305.phpt
+++ b/Zend/tests/bug55305.phpt
@@ -11,6 +11,7 @@ $f->bar =& $f->foo;
 var_dump($f->foo);
 var_dump($f->bar);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property Foo::$bar is deprecated in %s on line %d
 string(4) "test"
 string(4) "test"

--- a/Zend/tests/bug60536_001.phpt
+++ b/Zend/tests/bug60536_001.phpt
@@ -22,5 +22,7 @@ $a->__construct();
 echo "DONE";
 ?>
 --EXPECTF--
+Deprecated: Creation of dynamic property Z::$x is deprecated in %s on line %d
+
 Warning: Undefined property: Z::$x in %s on line %d
 DONE

--- a/Zend/tests/bug60598.phpt
+++ b/Zend/tests/bug60598.phpt
@@ -7,7 +7,7 @@ define('OBJECT_COUNT', 10000);
 $containers = array();
 
 class ObjectOne {
-    protected $_guid = 0;
+    protected $guid = 0;
     public function __construct() {
         global $containers;
         $this->guid = 1;

--- a/Zend/tests/bug60833.phpt
+++ b/Zend/tests/bug60833.phpt
@@ -5,8 +5,8 @@ Bug #60833 (self, parent, static behave inconsistently case-sensitive)
 class A {
     static $x = "A";
     function testit() {
-        $this->v1 = new sELF;
-        $this->v2 = new SELF;
+        var_dump(new sELF);
+        var_dump(new SELF);
     }
 }
 
@@ -14,26 +14,24 @@ class B extends A {
     static $x = "B";
     function testit() {
         PARENT::testit();
-        $this->v3 = new sELF;
-        $this->v4 = new PARENT;
-        $this->v4 = STATIC::$x;
+        var_dump(new sELF);
+        var_dump(new PARENT);
+        var_dump(STATIC::$x);
     }
 }
 $t = new B();
 $t->testit();
 var_dump($t);
 ?>
---EXPECTF--
-object(B)#%d (4) {
-  ["v1"]=>
-  object(A)#%d (0) {
-  }
-  ["v2"]=>
-  object(A)#%d (0) {
-  }
-  ["v3"]=>
-  object(B)#%d (0) {
-  }
-  ["v4"]=>
-  string(1) "B"
+--EXPECT--
+object(A)#2 (0) {
+}
+object(A)#2 (0) {
+}
+object(B)#2 (0) {
+}
+object(A)#2 (0) {
+}
+string(1) "B"
+object(B)#1 (0) {
 }

--- a/Zend/tests/bug63462.phpt
+++ b/Zend/tests/bug63462.phpt
@@ -67,6 +67,8 @@ __isset publicProperty
 __isset protectedProperty
 __isset privateProperty
 __set nonExisting
+
+Deprecated: Creation of dynamic property Test::$nonExisting is deprecated in %s on line %d
 __set publicProperty
 __set protectedProperty
 __set privateProperty

--- a/Zend/tests/bug64821.1.phpt
+++ b/Zend/tests/bug64821.1.phpt
@@ -16,6 +16,8 @@ throw new a;
 
 ?>
 --EXPECTF--
+Deprecated: Creation of dynamic property a::$string is deprecated in %s on line %d
+
 Fatal error: Uncaught a in %s:0
 Stack trace:
 #0 {main}

--- a/Zend/tests/bug64960.phpt
+++ b/Zend/tests/bug64960.phpt
@@ -31,6 +31,10 @@ $a['waa'];
 --EXPECTF--
 Notice: ob_end_flush(): Failed to delete and flush buffer. No buffer to delete or flush in %sbug64960.php on line 3
 
+Deprecated: Creation of dynamic property Exception::$_trace is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property Exception::$_trace is deprecated in %s on line %d
+
 Fatal error: Uncaught Exception in %sbug64960.php:19
 Stack trace:
 #0 [internal function]: {closure}(8, 'ob_end_clean():...', '%s', 9)

--- a/Zend/tests/bug65911.phpt
+++ b/Zend/tests/bug65911.phpt
@@ -6,6 +6,7 @@ class A {}
 
 class B
 {
+    public $foo;
     public function go()
     {
         $this->foo = 'bar';

--- a/Zend/tests/bug66609.phpt
+++ b/Zend/tests/bug66609.phpt
@@ -25,4 +25,6 @@ echo "okey";
 ?>
 --EXPECTF--
 Warning: Undefined property: Bar::$bar in %s on line %d
+
+Deprecated: Creation of dynamic property Foo::$blah is deprecated in %s on line %d
 okey

--- a/Zend/tests/bug69446.phpt
+++ b/Zend/tests/bug69446.phpt
@@ -22,7 +22,10 @@ unset($foo);
 gc_collect_cycles();
 var_dump($bar);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property bad::$x is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property bad::$y is deprecated in %s on line %d
 object(bad)#2 (2) {
   ["x"]=>
   object(stdClass)#3 (0) {

--- a/Zend/tests/bug70223.phpt
+++ b/Zend/tests/bug70223.phpt
@@ -11,10 +11,13 @@ class A {
 
 }
 
+// Note that this will use __get() for the read, but actually create a new dynamic
+// property A::$f for the write.
 $a = new A;
 echo $a->f++;
 echo $a->f++;
 echo $a->f++;
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property A::$f is deprecated in %s on line %d
 012

--- a/Zend/tests/bug70397.phpt
+++ b/Zend/tests/bug70397.phpt
@@ -8,7 +8,7 @@ $f = function () {
     yield $this->value;
 };
 
-var_dump($f->call(new class {})->current());
+var_dump($f->call(new class { public $value; })->current());
 
 ?>
 --EXPECT--

--- a/Zend/tests/bug70805.phpt
+++ b/Zend/tests/bug70805.phpt
@@ -3,9 +3,11 @@ Bug #70805 (Segmentation faults whilst running Drupal 8 test suite)
 --FILE--
 <?php
 class A {
+    public $b;
 }
 
 class B {
+    public $a;
 }
 
 class C {

--- a/Zend/tests/bug70805_1.phpt
+++ b/Zend/tests/bug70805_1.phpt
@@ -5,9 +5,11 @@ zend.enable_gc = 1
 --FILE--
 <?php
 class A {
+    public $b;
 }
 
 class B {
+    public $a;
 }
 
 class C {

--- a/Zend/tests/bug70805_2.phpt
+++ b/Zend/tests/bug70805_2.phpt
@@ -5,9 +5,11 @@ zend.enable_gc = 1
 --FILE--
 <?php
 class A {
+    public $b;
 }
 
 class B {
+    public $a;
 }
 
 class C {

--- a/Zend/tests/bug71859.phpt
+++ b/Zend/tests/bug71859.phpt
@@ -3,6 +3,7 @@ Bug #71859 (zend_objects_store_call_destructors operates on realloced memory, cr
 --FILE--
 <?php
 class constructs_in_destructor {
+  public $a;
   public function __destruct() {
     //We are now in zend_objects_store_call_destructors
     //This causes a realloc in zend_objects_store_put

--- a/Zend/tests/bug72101.phpt
+++ b/Zend/tests/bug72101.phpt
@@ -26,6 +26,7 @@ class PHPUnit_Framework_MockObject_InvocationMocker {
 
 class PHPUnit_Framework_MockObject_Matcher {
     public $stub = null;
+    public $methodNameMatcher;
     public function invoked($invocation) {
         return $this->stub->invoke($invocation);
     }
@@ -60,7 +61,7 @@ class Mock_MethodCallbackByReference_7b180d26 extends MethodCallbackByReference 
 }
 
 set_error_handler(function() {
-//    var_dump(func_get_args());
+    //var_dump(func_get_args());
     DoesNotExists::$nope = true;
 }, E_ALL);
 
@@ -77,10 +78,10 @@ $foo->bar($a, $b, $c);
 --EXPECTF--
 Fatal error: Uncaught Error: Class "DoesNotExists" not found in %s:%d
 Stack trace:
-#0 %sbug72101.php(8): {closure}(2, 'MethodCallbackB...', '%s', 8)
-#1 %sbug72101.php(27): PHPUnit_Framework_MockObject_Stub_ReturnCallback->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
-#2 %sbug72101.php(19): PHPUnit_Framework_MockObject_Matcher->invoked(Object(PHPUnit_Framework_MockObject_Invocation_Static))
-#3 %sbug72101.php(52): PHPUnit_Framework_MockObject_InvocationMocker->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
-#4 %sbug72101.php(72): Mock_MethodCallbackByReference_7b180d26->bar(0, 0, 0)
+#0 %sbug72101.php(%d): {closure}(2, 'MethodCallbackB...', '%s', 8)
+#1 %sbug72101.php(%d): PHPUnit_Framework_MockObject_Stub_ReturnCallback->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
+#2 %sbug72101.php(%d): PHPUnit_Framework_MockObject_Matcher->invoked(Object(PHPUnit_Framework_MockObject_Invocation_Static))
+#3 %sbug72101.php(%d): PHPUnit_Framework_MockObject_InvocationMocker->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
+#4 %sbug72101.php(%d): Mock_MethodCallbackByReference_7b180d26->bar(0, 0, 0)
 #5 {main}
-  thrown in %sbug72101.php on line 61
+  thrown in %sbug72101.php on line %d

--- a/Zend/tests/bug78010.phpt
+++ b/Zend/tests/bug78010.phpt
@@ -7,6 +7,9 @@ memory_limit=2G
 
 class foo
 {
+    public $x;
+    public $y;
+
     public function __construct()
     {
         $this->x = $this;

--- a/Zend/tests/bug78340.phpt
+++ b/Zend/tests/bug78340.phpt
@@ -4,9 +4,10 @@ Bug #78340: Include of stream wrapper not reading whole file
 <?php
 
 class lib {
+  public $context;
   public static $files= [];
 
-  private $bytes, $pos;
+  private $bytes, $pos, $ino;
 
   function stream_open($path, $mode, $options, $opened_path) {
     $this->bytes= self::$files[$path];

--- a/Zend/tests/bug78379.phpt
+++ b/Zend/tests/bug78379.phpt
@@ -3,11 +3,15 @@ Bug #78379 (Cast to object confuses GC, causes crash)
 --FILE--
 <?php
 class C {
+    public $p;
     public function __construct() {
         $this->p = (object)["x" => [1]];
     }
 }
 class E {
+    public $e;
+    public $f;
+    public $a;
 }
 $e = new E;
 $e->f = new E;

--- a/Zend/tests/bug78379_2.phpt
+++ b/Zend/tests/bug78379_2.phpt
@@ -15,5 +15,10 @@ f();
 gc_collect_cycles();
 echo "End\n";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property E::$a is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property E::$e1 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property E::$a is deprecated in %s on line %d
 End

--- a/Zend/tests/bug78589.phpt
+++ b/Zend/tests/bug78589.phpt
@@ -4,6 +4,7 @@ Bug #78589: Memory leak with GC + __destruct()
 <?php
 
 class Test {
+    public $foo;
     public function __destruct() {}
 }
 

--- a/Zend/tests/bug79477.phpt
+++ b/Zend/tests/bug79477.phpt
@@ -16,5 +16,6 @@ $arr['prop'] = 'new value';
 echo $obj->prop, "\n";
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property Test::$1 is deprecated in %s on line %d
 default value

--- a/Zend/tests/bug79862.phpt
+++ b/Zend/tests/bug79862.phpt
@@ -39,7 +39,11 @@ $c = new c;
 --EXPECTF--
 Notice: Accessing static property c::$prop5 as non static in %s on line %d
 
+Deprecated: Creation of dynamic property c::$prop5 is deprecated in %s on line %d
+
 Notice: Accessing static property c::$prop6 as non static in %s on line %d
+
+Deprecated: Creation of dynamic property c::$prop6 is deprecated in %s on line %d
 NULL
 NULL
 NULL

--- a/Zend/tests/bug81104.phpt
+++ b/Zend/tests/bug81104.phpt
@@ -7,6 +7,7 @@ report_memleaks=0
 <?php
 class X {
     public $x;
+    public $y;
     public function __construct() { $this->x = [$this]; }
 }
 gc_disable();

--- a/Zend/tests/closure_020.phpt
+++ b/Zend/tests/closure_020.phpt
@@ -5,6 +5,7 @@ Closure 020: Trying to access private property outside class
 
 class foo {
     private $test = 3;
+    public $a;
 
     public function x() {
         $a = &$this;

--- a/Zend/tests/closure_026.phpt
+++ b/Zend/tests/closure_026.phpt
@@ -4,6 +4,7 @@ Closure 026: Assigning a closure object to an array in $this
 <?php
 
 class foo {
+    public $a;
     public function __construct() {
         $a =& $this;
 

--- a/Zend/tests/debug_backtrace_with_include_and_this.phpt
+++ b/Zend/tests/debug_backtrace_with_include_and_this.phpt
@@ -3,6 +3,7 @@ debug_backtrace segmentation fault with include and error handler
 --FILE--
 <?php
 class CLWrapper {
+  public $context;
   function stream_open($path, $mode, $options, $opened_path) {
     return false;
   }

--- a/Zend/tests/exception_during_include_stat.phpt
+++ b/Zend/tests/exception_during_include_stat.phpt
@@ -4,6 +4,7 @@ Make sure exceptions during include/require stating are properly propagated
 <?php
 
 class StreamWrapper {
+    public $context;
     public function url_stat($path, $flags) {
         throw new Exception('stat failed');
     }

--- a/Zend/tests/fibers/no-switch-gc.phpt
+++ b/Zend/tests/fibers/no-switch-gc.phpt
@@ -5,9 +5,10 @@ Context switches are prevented during GC collect cycles
 
 $fiber = new Fiber(function () {
     call_user_func(function () {
-        $a = new class () {};
+        $a = new stdClass;
 
         $b = new class () {
+            public $next;
             public function __destruct() {
                 Fiber::suspend();
             }

--- a/Zend/tests/foreach_004.phpt
+++ b/Zend/tests/foreach_004.phpt
@@ -4,6 +4,7 @@ Iterator exceptions in foreach by reference
 <?php
 class IT extends ArrayIterator {
     private $n = 0;
+    private $trap;
 
     function __construct($trap = null) {
         parent::__construct([0, 1]);

--- a/Zend/tests/foreach_shadowed_dyn_property.phpt
+++ b/Zend/tests/foreach_shadowed_dyn_property.phpt
@@ -21,7 +21,8 @@ $test2->prop = "Test2";
 $test2->run();
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property Test2::$prop is deprecated in %s on line %d
 prop => Test
 array(1) {
   ["prop"]=>

--- a/Zend/tests/gc_038.phpt
+++ b/Zend/tests/gc_038.phpt
@@ -126,6 +126,7 @@ function test_pow() {
 test_pow();
 
 class Y {
+    public $x;
     function __toString() {
         return "y";
     }

--- a/Zend/tests/gc_042.phpt
+++ b/Zend/tests/gc_042.phpt
@@ -18,7 +18,8 @@ gc_collect_cycles();
 var_dump($x);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property Test::$x is deprecated in %s on line %d
 object(Test)#1 (1) {
   ["x"]=>
   object(stdClass)#2 (1) {

--- a/Zend/tests/generators/iterator_wrapper_leak.phpt
+++ b/Zend/tests/generators/iterator_wrapper_leak.phpt
@@ -4,6 +4,8 @@ A generator iterator wrapper involved in a cycle should not leak
 <?php
 
 class Test {
+    public $gen1;
+    public $gen2;
     public function method() {
         $this->gen1 = (function () {
             yield 1;

--- a/Zend/tests/get_mangled_object_vars.phpt
+++ b/Zend/tests/get_mangled_object_vars.phpt
@@ -31,7 +31,10 @@ var_export((array) $ao);
 echo "\n";
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property B::$dyn is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property B::$6 is deprecated in %s on line %d
 array (
   'pub' => 1,
   '' . "\0" . '*' . "\0" . 'prot' => 2,
@@ -40,6 +43,8 @@ array (
   'dyn' => 5,
   6 => 6,
 )
+
+Deprecated: Creation of dynamic property AO::$dyn is deprecated in %s on line %d
 array (
   '' . "\0" . 'AO' . "\0" . 'priv' => 1,
   'dyn' => 2,

--- a/Zend/tests/include_stat_is_quiet.phpt
+++ b/Zend/tests/include_stat_is_quiet.phpt
@@ -4,6 +4,7 @@ Stats executed during include path resolution should be silent
 <?php
 
 class StreamWrapper {
+    public $context;
     public function url_stat($path, $flags) {
         $path = str_replace('test://', 'file://', $path);
         if ($flags & STREAM_URL_STAT_QUIET) {

--- a/Zend/tests/nowdoc.inc
+++ b/Zend/tests/nowdoc.inc
@@ -4,7 +4,9 @@
 $a = 1;
 $b = 2;
 $c = array( 'c' => 3, );
-class d { public function __construct() { $this->d = 4; } };
+class d {
+    public $d = 4;
+}
 $d = new d;
 
 ?>

--- a/Zend/tests/temporary_cleaning_013.phpt
+++ b/Zend/tests/temporary_cleaning_013.phpt
@@ -278,14 +278,28 @@ caught Exception 2
 caught Exception 3
 caught Exception 4
 caught Exception 5
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 6
 caught Exception 7
 caught Exception 8
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 9
 caught Exception 10
+
+Deprecated: Creation of dynamic property class@anonymous::$bar is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 11
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 12
 caught Exception 13
+
+Deprecated: Creation of dynamic property class@anonymous::$bar is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 14
 
 Notice: Indirect modification of overloaded element of ArrayAccess@anonymous has no effect in %s on line %d
@@ -293,9 +307,13 @@ caught Exception 15
 
 Notice: Indirect modification of overloaded element of ArrayAccess@anonymous has no effect in %s on line %d
 caught Exception 16
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 17
 caught Exception 18
 caught Exception 19
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 20
 caught Exception 21
 caught Exception 22

--- a/Zend/tests/throwing_overloaded_compound_assign_op.phpt
+++ b/Zend/tests/throwing_overloaded_compound_assign_op.phpt
@@ -28,7 +28,7 @@ try {
 var_dump($test2);
 
 ?>
---EXPECT--
+--EXPECTF--
 Modulo by zero
 object(ArrayObject)#1 (1) {
   ["storage":"ArrayObject":private]=>
@@ -37,6 +37,8 @@ object(ArrayObject)#1 (1) {
     int(42)
   }
 }
+
+Deprecated: Creation of dynamic property Test::$prop is deprecated in %s on line %d
 Modulo by zero
 object(Test)#3 (1) {
   ["prop"]=>

--- a/Zend/tests/type_declarations/typed_properties_086.phpt
+++ b/Zend/tests/type_declarations/typed_properties_086.phpt
@@ -18,7 +18,8 @@ $t->$x--;
 var_dump($t);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property T::$1 is deprecated in %s on line %d
 object(T)#1 (1) {
   ["i"]=>
   uninitialized(int)

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -34,6 +34,7 @@
 
 ZEND_MINIT_FUNCTION(core) { /* {{{ */
 	zend_standard_class_def = register_class_stdClass();
+	zend_standard_class_def->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
 
 	zend_register_default_classes();
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -241,7 +241,7 @@ typedef struct _zend_oparray_context {
 /* or IS_CONSTANT_VISITED_MARK                            |     |     |     */
 #define ZEND_CLASS_CONST_IS_CASE         (1 << 6)  /*     |     |     |  X  */
 /*                                                        |     |     |     */
-/* Class Flags (unused: 15,21,30,31)                      |     |     |     */
+/* Class Flags (unused: 21,30,31)                         |     |     |     */
 /* ===========                                            |     |     |     */
 /*                                                        |     |     |     */
 /* Special class types                                    |     |     |     */
@@ -269,6 +269,10 @@ typedef struct _zend_oparray_context {
 /*                                                        |     |     |     */
 /* User class has methods with static variables           |     |     |     */
 #define ZEND_HAS_STATIC_IN_METHODS       (1 << 14) /*  X  |     |     |     */
+/*                                                        |     |     |     */
+/* Objects of this class may have dynamic properties      |     |     |     */
+/* without triggering a deprecation warning               |     |     |     */
+#define ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES (1 << 15) /* X  |     |     |     */
 /*                                                        |     |     |     */
 /* Children must reuse parent get_iterator()              |     |     |     */
 #define ZEND_ACC_REUSE_GET_ITERATOR      (1 << 16) /*  X  |     |     |     */

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1592,7 +1592,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 			ce->ce_flags |= ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 		}
 	}
-	ce->ce_flags |= parent_ce->ce_flags & (ZEND_HAS_STATIC_IN_METHODS | ZEND_ACC_HAS_TYPE_HINTS | ZEND_ACC_USE_GUARDS | ZEND_ACC_NOT_SERIALIZABLE);
+	ce->ce_flags |= parent_ce->ce_flags & (ZEND_HAS_STATIC_IN_METHODS | ZEND_ACC_HAS_TYPE_HINTS | ZEND_ACC_USE_GUARDS | ZEND_ACC_NOT_SERIALIZABLE | ZEND_ACC_NO_DYNAMIC_PROPERTIES | ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES);
 }
 /* }}} */
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -277,6 +277,12 @@ static ZEND_COLD zend_never_inline void zend_forbidden_dynamic_property(
 		ZSTR_VAL(ce->name), ZSTR_VAL(member));
 }
 
+static ZEND_COLD zend_never_inline void zend_deprecated_dynamic_property(
+		zend_class_entry *ce, zend_string *member) {
+	zend_error(E_DEPRECATED, "Creation of dynamic property %s::$%s is deprecated",
+		ZSTR_VAL(ce->name), ZSTR_VAL(member));
+}
+
 static ZEND_COLD zend_never_inline void zend_readonly_property_modification_scope_error(
 		zend_class_entry *ce, zend_string *member, zend_class_entry *scope, const char *operation) {
 	zend_throw_error(NULL, "Cannot %s readonly property %s::$%s from %s%s",
@@ -874,6 +880,9 @@ write_std_property:
 				variable_ptr = &EG(error_zval);
 				goto exit;
 			}
+			if (EXPECTED(!(zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
+				zend_deprecated_dynamic_property(zobj->ce, name);
+			}
 
 			Z_TRY_ADDREF_P(value);
 			if (!zobj->properties) {
@@ -1046,6 +1055,9 @@ ZEND_API zval *zend_std_get_property_ptr_ptr(zend_object *zobj, zend_string *nam
 			if (UNEXPECTED(zobj->ce->ce_flags & ZEND_ACC_NO_DYNAMIC_PROPERTIES)) {
 				zend_forbidden_dynamic_property(zobj->ce, name);
 				return &EG(error_zval);
+			}
+			if (EXPECTED(!(zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
+				zend_deprecated_dynamic_property(zobj->ce, name);
 			}
 			if (UNEXPECTED(!zobj->properties)) {
 				rebuild_object_properties(zobj);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2411,7 +2411,7 @@ ZEND_VM_C_LABEL(fast_assign_obj):
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -22822,7 +22822,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -22953,7 +22953,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -23084,7 +23084,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -23215,7 +23215,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -25380,7 +25380,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -25511,7 +25511,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -25642,7 +25642,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -25773,7 +25773,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -29305,7 +29305,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -29436,7 +29436,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -29567,7 +29567,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -29698,7 +29698,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -31705,7 +31705,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -31836,7 +31836,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -31967,7 +31967,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -32098,7 +32098,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -33558,7 +33558,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -33689,7 +33689,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -33820,7 +33820,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -33951,7 +33951,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -36028,7 +36028,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -36159,7 +36159,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -36290,7 +36290,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -36421,7 +36421,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -40172,7 +40172,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -40303,7 +40303,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -40434,7 +40434,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -40565,7 +40565,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -43803,7 +43803,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -43934,7 +43934,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -44065,7 +44065,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -44196,7 +44196,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -48834,7 +48834,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -48965,7 +48965,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -49096,7 +49096,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -49227,7 +49227,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}

--- a/ext/soap/tests/bugs/bug46419.phpt
+++ b/ext/soap/tests/bugs/bug46419.phpt
@@ -9,6 +9,7 @@ function bar() {
 }
 
 class LocalSoapClient extends SoapClient {
+  private $server;
 
   function __construct($wsdl, $options) {
     parent::__construct($wsdl, $options);

--- a/ext/spl/tests/ArrayObject_sort_different_backing_storage.phpt
+++ b/ext/spl/tests/ArrayObject_sort_different_backing_storage.phpt
@@ -28,7 +28,7 @@ $ao5->uasort(function($a, $b) { return $a <=> $b; });
 var_dump($ao5);
 
 ?>
---EXPECT--
+--EXPECTF--
 object(ArrayObject)#2 (1) {
   ["storage":"ArrayObject":private]=>
   object(stdClass)#1 (2) {
@@ -50,6 +50,10 @@ object(ArrayObject)#3 (1) {
     }
   }
 }
+
+Deprecated: Creation of dynamic property ArrayObject::$a is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayObject::$b is deprecated in %s on line %d
 object(ArrayObject)#4 (2) {
   ["b"]=>
   int(1)

--- a/ext/spl/tests/ArrayObject_std_props_no_recursion.phpt
+++ b/ext/spl/tests/ArrayObject_std_props_no_recursion.phpt
@@ -13,7 +13,10 @@ $c->prop = 'c';
 var_dump((array) $c);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
 array(3) {
   [0]=>
   int(1)
@@ -22,6 +25,8 @@ array(3) {
   [2]=>
   int(3)
 }
+
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
 array(1) {
   ["prop"]=>
   string(1) "c"

--- a/ext/spl/tests/SplFileObject_fflush_basic_001.phpt
+++ b/ext/spl/tests/SplFileObject_fflush_basic_001.phpt
@@ -13,6 +13,7 @@ var_dump($obj->fflush());
 */
 //create a basic stream class
 class VariableStream {
+    var $context;
     var $position;
     var $varname;
 

--- a/ext/spl/tests/SplFileObject_ftruncate_error_001.phpt
+++ b/ext/spl/tests/SplFileObject_ftruncate_error_001.phpt
@@ -5,6 +5,7 @@ SplFileObject::ftruncate function - truncating with stream that does not support
 
 //create a basic stream class
 class VariableStream {
+    var $context;
     var $position;
     var $varname;
 

--- a/ext/spl/tests/arrayObject___construct_basic2.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic2.phpt
@@ -54,6 +54,8 @@ function testAccess($c, $ao) {
 NULL
 string(12) "C::prop.orig"
   - Write:
+
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
 string(8) "changed1"
 string(8) "changed2"
   - Isset:

--- a/ext/spl/tests/arrayObject___construct_basic3.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic3.phpt
@@ -54,6 +54,8 @@ function testAccess($c, $ao) {
 NULL
 string(12) "C::prop.orig"
   - Write:
+
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
 string(8) "changed1"
 string(8) "changed2"
   - Isset:

--- a/ext/spl/tests/arrayObject___construct_basic6.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic6.phpt
@@ -21,7 +21,8 @@ var_dump($ao);
 $ao = new MyArrayObject(array(1,2,3), ArrayObject::STD_PROP_LIST);
 var_dump($ao);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property ArrayObject::$p is deprecated in %s on line %d
 object(ArrayObject)#1 (2) {
   ["p"]=>
   int(1)
@@ -35,6 +36,8 @@ object(ArrayObject)#1 (2) {
     int(3)
   }
 }
+
+Deprecated: Creation of dynamic property ArrayObject::$p is deprecated in %s on line %d
 object(ArrayObject)#2 (2) {
   ["p"]=>
   int(1)

--- a/ext/spl/tests/arrayObject_clone_basic2.phpt
+++ b/ext/spl/tests/arrayObject_clone_basic2.phpt
@@ -15,7 +15,10 @@ $ao1['new.ao1'] = 'new element added to ao1';
 $ao2['new.ao2'] = 'new element added to ao2';
 var_dump($c, $ao1, $ao2);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property C::$p1 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property C::$p2 is deprecated in %s on line %d
 object(C)#1 (3) {
   ["p1"]=>
   string(32) "new prop added to c before clone"

--- a/ext/spl/tests/arrayObject_clone_basic3.phpt
+++ b/ext/spl/tests/arrayObject_clone_basic3.phpt
@@ -21,7 +21,10 @@ $clonedOuterArrayObject['new.coAO'] = 'new element added to $clonedOuterArrayObj
 
 var_dump($wrappedObject, $innerArrayObject, $outerArrayObject, $clonedOuterArrayObject);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property C::$dynamic1 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property C::$dynamic2 is deprecated in %s on line %d
 object(C)#1 (5) {
   ["p"]=>
   string(9) "C::p.orig"

--- a/ext/spl/tests/arrayObject_exchangeArray_basic3.phpt
+++ b/ext/spl/tests/arrayObject_exchangeArray_basic3.phpt
@@ -51,6 +51,10 @@ var_dump($ao, $original, $copy);
 ?>
 --EXPECTF--
 --> exchangeArray() with objects:
+
+Deprecated: Creation of dynamic property C::$addedToSwapIn is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property C::$addedToOriginal is deprecated in %s on line %d
 object(ArrayObject)#2 (1) {
   ["storage":"ArrayObject":private]=>
   object(C)#3 (2) {
@@ -83,6 +87,8 @@ array(2) {
 --> exchangeArray() with no arg:
 Exception: ArrayObject::exchangeArray() expects exactly 1 argument, 0 given
 
+Deprecated: Creation of dynamic property C::$addedToOriginal is deprecated in %s on line %d
+
 Warning: Undefined variable $copy in %s on line %d
 object(ArrayObject)#2 (1) {
   ["storage":"ArrayObject":private]=>
@@ -104,6 +110,8 @@ NULL
 
 --> exchangeArray() with bad arg type:
 ArrayObject::exchangeArray(): Argument #1 ($array) must be of type array, null given
+
+Deprecated: Creation of dynamic property C::$addedToOriginal is deprecated in %s on line %d
 
 Warning: Undefined variable $copy in %s on line %d
 object(ArrayObject)#3 (1) {

--- a/ext/spl/tests/arrayObject_magicMethods2.phpt
+++ b/ext/spl/tests/arrayObject_magicMethods2.phpt
@@ -69,6 +69,10 @@ var_dump($ao);
 ?>
 --EXPECTF--
 --> Write existent, non-existent and dynamic:
+
+Deprecated: Creation of dynamic property ArrayObject::$a is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayObject::$dynamic is deprecated in %s on line %d
   Original wrapped object:
 object(UsesMagic)#1 (4) {
   ["a"]=>

--- a/ext/spl/tests/array_003.phpt
+++ b/ext/spl/tests/array_003.phpt
@@ -34,7 +34,10 @@ foreach($test as $key => $val)
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property test::$imp is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property test::$dyn is deprecated in %s on line %d
 test Object
 (
     [pub] => public

--- a/ext/spl/tests/array_007.phpt
+++ b/ext/spl/tests/array_007.phpt
@@ -38,7 +38,10 @@ foreach($test as $key => $val)
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property test::$imp is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property test::$dyn is deprecated in %s on line %d
 test Object
 (
     [pub] => public

--- a/ext/spl/tests/array_017.phpt
+++ b/ext/spl/tests/array_017.phpt
@@ -130,6 +130,10 @@ check($obj, 1);
 ?>
 --EXPECTF--
 ArrayObjectEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayObjectEx::$imp1 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayObjectEx::$dyn1 is deprecated in %s on line %d
 ===CHECK===
 ArrayObjectEx::setFlags(0)
 ArrayObjectEx::dump()
@@ -175,6 +179,10 @@ array(3) {
 ArrayObjectEx::show()
 ArrayObjectEx::getIterator()
 ArrayIteratorEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$imp2 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$dyn2 is deprecated in %s on line %d
 ArrayIteratorEx::dump()
 array(3) {
   ["Flags"]=>
@@ -243,6 +251,10 @@ array(1) {
 ===FOREACH===
 ArrayObjectEx::getIterator()
 ArrayIteratorEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$imp2 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$dyn2 is deprecated in %s on line %d
 ArrayIteratorEx::dump()
 array(3) {
   ["Flags"]=>
@@ -364,6 +376,10 @@ array(3) {
 ArrayObjectEx::show()
 ArrayObjectEx::getIterator()
 ArrayIteratorEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$imp2 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$dyn2 is deprecated in %s on line %d
 ArrayIteratorEx::dump()
 array(3) {
   ["Flags"]=>
@@ -432,6 +448,10 @@ array(1) {
 ===FOREACH===
 ArrayObjectEx::getIterator()
 ArrayIteratorEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$imp2 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$dyn2 is deprecated in %s on line %d
 ArrayIteratorEx::dump()
 array(3) {
   ["Flags"]=>
@@ -546,6 +566,10 @@ array(3) {
 ArrayObjectEx::show()
 ArrayObjectEx::getIterator()
 ArrayIteratorEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$imp2 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$dyn2 is deprecated in %s on line %d
 ArrayIteratorEx::dump()
 array(3) {
   ["Flags"]=>
@@ -605,6 +629,10 @@ array(1) {
 ===FOREACH===
 ArrayObjectEx::getIterator()
 ArrayIteratorEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$imp2 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$dyn2 is deprecated in %s on line %d
 ArrayIteratorEx::dump()
 array(3) {
   ["Flags"]=>
@@ -708,6 +736,10 @@ array(3) {
 ArrayObjectEx::show()
 ArrayObjectEx::getIterator()
 ArrayIteratorEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$imp2 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$dyn2 is deprecated in %s on line %d
 ArrayIteratorEx::dump()
 array(3) {
   ["Flags"]=>
@@ -767,6 +799,10 @@ array(1) {
 ===FOREACH===
 ArrayObjectEx::getIterator()
 ArrayIteratorEx::__construct()
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$imp2 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayIteratorEx::$dyn2 is deprecated in %s on line %d
 ArrayIteratorEx::dump()
 array(3) {
   ["Flags"]=>

--- a/ext/spl/tests/bug61326.phpt
+++ b/ext/spl/tests/bug61326.phpt
@@ -12,7 +12,9 @@ var_dump($aobj1 == $aobj3);
 $aobj3->foo = 'bar';
 var_dump($aobj1 == $aobj3);
 ?>
---EXPECT--
+--EXPECTF--
 bool(false)
 bool(true)
+
+Deprecated: Creation of dynamic property ArrayObject::$foo is deprecated in %s on line %d
 bool(false)

--- a/ext/spl/tests/bug65387.phpt
+++ b/ext/spl/tests/bug65387.phpt
@@ -14,6 +14,7 @@ $it2 = new CallbackFilterIterator($it, function($elem) use(&$it2) {
 
 // Callback object
 new class {
+    private $it;
     public function __construct() {
         $it = new ArrayIterator([1, 2, 3]);
         $this->it = new CallbackFilterIterator($it, function($elem) {

--- a/ext/spl/tests/iterator_037.phpt
+++ b/ext/spl/tests/iterator_037.phpt
@@ -27,10 +27,7 @@ function test($ar, $flags)
 
 class MyItem
 {
-    function __construct($value)
-    {
-        $this->value = $value;
-    }
+    function __construct(public $value) {}
 
     function __toString()
     {

--- a/ext/standard/tests/file/userdirstream.phpt
+++ b/ext/standard/tests/file/userdirstream.phpt
@@ -3,6 +3,7 @@ Directory Streams
 --FILE--
 <?php
 class test {
+    public $context;
     public $idx = 0;
 
     function dir_opendir($path, $options) {

--- a/ext/standard/tests/streams/stream_get_line_NUL_delimiter.phpt
+++ b/ext/standard/tests/streams/stream_get_line_NUL_delimiter.phpt
@@ -3,6 +3,7 @@ Bug #60455: stream_get_line and \0 as a delimiter
 --FILE--
 <?php
 class TestStream {
+    public $context;
     private $s = 0;
     function stream_open($path, $mode, $options, &$opened_path) {
             return true;

--- a/tests/classes/dereferencing_001.phpt
+++ b/tests/classes/dereferencing_001.phpt
@@ -4,6 +4,8 @@ ZE2 dereferencing of objects from methods
 <?php
 
 class Name {
+    private $name;
+
     function __construct($_name) {
         $this->name = $_name;
     }

--- a/tests/classes/iterators_006.phpt
+++ b/tests/classes/iterators_006.phpt
@@ -6,6 +6,8 @@ ZE2 iterators and array wrapping
 class ai implements Iterator {
 
     private $array;
+    private $key;
+    private $current;
 
     function __construct() {
         $this->array = array('foo', 'bar', 'baz');

--- a/tests/classes/method_call_variation_001.phpt
+++ b/tests/classes/method_call_variation_001.phpt
@@ -2,7 +2,9 @@
 In $a->$b[Y]() and $a->X[Y]() both $a->$b[Y] and $a->X[Y] represent a global function name
 --FILE--
 <?php
-  class C {}
+  class C {
+    public $functions;
+  }
 
   function foo($a, $b) {
       echo "Called global foo($a, $b)\n";

--- a/tests/classes/property_recreate_private.phpt
+++ b/tests/classes/property_recreate_private.phpt
@@ -58,12 +58,16 @@ object(D)#%d (1) {
 }
 
 Unset superclass's private property, and recreate it as public in subclass:
+
+Deprecated: Creation of dynamic property D::$p is deprecated in %s on line %d
 object(D)#%d (1) {
   ["p"]=>
   string(12) "changed in D"
 }
 
 Unset superclass's private property, and recreate it as public at global scope:
+
+Deprecated: Creation of dynamic property D::$p is deprecated in %s on line %d
 object(D)#%d (1) {
   ["p"]=>
   string(34) "this will create a public property"

--- a/tests/classes/static_properties_003.phpt
+++ b/tests/classes/static_properties_003.phpt
@@ -37,6 +37,8 @@ Warning: Undefined property: C::$x in %s on line %d
 
 Notice: Accessing static property C::$x as non static in %s on line 13
 
+Deprecated: Creation of dynamic property C::$x is deprecated in %s on line %d
+
 Notice: Accessing static property C::$x as non static in %s on line 15
 
 Notice: Accessing static property C::$x as non static in %s on line 16

--- a/tests/classes/visibility_005.phpt
+++ b/tests/classes/visibility_005.phpt
@@ -40,7 +40,8 @@ foreach($o as $k=>$v) {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property base::$d is deprecated in %s on line %d
 ===base::function===
 a=>1
 b=>2
@@ -49,6 +50,8 @@ d=>4
 ===base,foreach===
 a=>1
 d=>4
+
+Deprecated: Creation of dynamic property derived::$d is deprecated in %s on line %d
 ===derived::function===
 a=>1
 b=>2

--- a/tests/lang/030.phpt
+++ b/tests/lang/030.phpt
@@ -3,6 +3,7 @@ $this in constructor test
 --FILE--
 <?php
 class foo {
+    public $Name;
     function __construct($name) {
         $GLOBALS['List']= &$this;
         $this->Name = $name;

--- a/tests/lang/035.phpt
+++ b/tests/lang/035.phpt
@@ -3,6 +3,7 @@ ZE2: set_exception_handler()
 --FILE--
 <?php
 class MyException extends Exception {
+    private $error;
     function __construct($_error) {
         $this->error = $_error;
     }

--- a/tests/lang/bug22510.phpt
+++ b/tests/lang/bug22510.phpt
@@ -29,6 +29,8 @@ class foo
 
 class bar
 {
+    public $instance;
+
     function run1() {
         print __CLASS__."::".__FUNCTION__."\n";
         $this->instance = new foo();
@@ -103,6 +105,8 @@ done!
 ok2
 bar::run2
 foo::method2
+
+Deprecated: Creation of dynamic property foo::$foo is deprecated in %s on line %d
 foo::method2
 foo::finalize
 done!

--- a/tests/lang/bug27439.phpt
+++ b/tests/lang/bug27439.phpt
@@ -12,6 +12,7 @@ class test_props {
 class test {
     public $array = array(1,2,3);
     public $string = "string";
+    public $object;
 
     public function __construct() {
         $this->object = new test_props;

--- a/tests/lang/error_2_exception_001.phpt
+++ b/tests/lang/error_2_exception_001.phpt
@@ -4,6 +4,8 @@ ZE2 errors caught as exceptions
 <?php
 
 class MyException extends Exception {
+    private $errno;
+    private $errmsg;
     function __construct($_errno, $_errmsg) {
         $this->errno = $_errno;
         $this->errmsg = $_errmsg;

--- a/tests/lang/foreachLoopObjects.003.phpt
+++ b/tests/lang/foreachLoopObjects.003.phpt
@@ -130,17 +130,41 @@ object(C)#%d (5) {
 }
 
 Adding properties to an an object.
+
+Deprecated: Creation of dynamic property C::$new0 is deprecated in %s on line %d
 string(10) "Original a"
+
+Deprecated: Creation of dynamic property C::$new1 is deprecated in %s on line %d
 string(10) "Original b"
+
+Deprecated: Creation of dynamic property C::$new2 is deprecated in %s on line %d
 string(10) "Original c"
+
+Deprecated: Creation of dynamic property C::$new3 is deprecated in %s on line %d
 string(16) "Added property 0"
+
+Deprecated: Creation of dynamic property C::$new4 is deprecated in %s on line %d
 string(16) "Added property 1"
+
+Deprecated: Creation of dynamic property C::$new5 is deprecated in %s on line %d
 string(16) "Added property 2"
+
+Deprecated: Creation of dynamic property C::$new6 is deprecated in %s on line %d
 string(16) "Added property 3"
+
+Deprecated: Creation of dynamic property C::$new7 is deprecated in %s on line %d
 string(16) "Added property 4"
+
+Deprecated: Creation of dynamic property C::$new8 is deprecated in %s on line %d
 string(16) "Added property 5"
+
+Deprecated: Creation of dynamic property C::$new9 is deprecated in %s on line %d
 string(16) "Added property 6"
+
+Deprecated: Creation of dynamic property C::$new10 is deprecated in %s on line %d
 string(16) "Added property 7"
+
+Deprecated: Creation of dynamic property C::$new11 is deprecated in %s on line %d
 Loop detected
 object(C)#%d (17) {
   ["a"]=>
@@ -180,17 +204,41 @@ object(C)#%d (17) {
 }
 
 Adding properties to an an object, using &$value.
+
+Deprecated: Creation of dynamic property C::$new0 is deprecated in %s on line %d
 string(10) "Original a"
+
+Deprecated: Creation of dynamic property C::$new1 is deprecated in %s on line %d
 string(10) "Original b"
+
+Deprecated: Creation of dynamic property C::$new2 is deprecated in %s on line %d
 string(10) "Original c"
+
+Deprecated: Creation of dynamic property C::$new3 is deprecated in %s on line %d
 string(16) "Added property 0"
+
+Deprecated: Creation of dynamic property C::$new4 is deprecated in %s on line %d
 string(16) "Added property 1"
+
+Deprecated: Creation of dynamic property C::$new5 is deprecated in %s on line %d
 string(16) "Added property 2"
+
+Deprecated: Creation of dynamic property C::$new6 is deprecated in %s on line %d
 string(16) "Added property 3"
+
+Deprecated: Creation of dynamic property C::$new7 is deprecated in %s on line %d
 string(16) "Added property 4"
+
+Deprecated: Creation of dynamic property C::$new8 is deprecated in %s on line %d
 string(16) "Added property 5"
+
+Deprecated: Creation of dynamic property C::$new9 is deprecated in %s on line %d
 string(16) "Added property 6"
+
+Deprecated: Creation of dynamic property C::$new10 is deprecated in %s on line %d
 string(16) "Added property 7"
+
+Deprecated: Creation of dynamic property C::$new11 is deprecated in %s on line %d
 Loop detected
 object(C)#%d (17) {
   ["a"]=>

--- a/tests/lang/operators/overloaded_property_ref.phpt
+++ b/tests/lang/operators/overloaded_property_ref.phpt
@@ -3,6 +3,7 @@ Operators on overloaded property reference
 --FILE--
 <?php
 class C {
+    private $bar;
     function __construct() { $this->bar = str_repeat("1", 2); }
     function &__get($x) { return $this->bar; }
     function __set($x, $v) { $this->bar = $v; }


### PR DESCRIPTION
What could possibly go wrong?

RFC: https://wiki.php.net/rfc/deprecate_dynamic_properties

TODO:
 * [ ] Finish updating tests.
 * [ ] JIT support.