### PR TITLE
Refactoring mysqlnd: removing unused properties

### DIFF
--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -487,10 +487,6 @@ mysqlnd_auth_change_user(MYSQLND_CONN_DATA * const conn,
 		}
 	}
 	if (ret == PASS) {
-		ZEND_ASSERT(conn->username.s != user && conn->password.s != passwd);
-		mysqlnd_set_persistent_string(&conn->username, user, user_len, conn->persistent);
-		mysqlnd_set_persistent_string(&conn->password, passwd, passwd_len, conn->persistent);
-
 		mysqlnd_set_string(&conn->last_message, NULL, 0);
 		UPSERT_STATUS_RESET(conn->upsert_status);
 		/* set charset for old servers */

--- a/ext/mysqlnd/mysqlnd_commands.c
+++ b/ext/mysqlnd/mysqlnd_commands.c
@@ -637,8 +637,7 @@ MYSQLND_METHOD(mysqlnd_command, handshake)(MYSQLND_CONN_DATA * const conn, const
 	conn->protocol_version	= greet_packet.protocol_version;
 	conn->server_version	= mnd_pestrdup(greet_packet.server_version, conn->persistent);
 
-	conn->greet_charset = mysqlnd_find_charset_nr(greet_packet.charset_no);
-	if (!conn->greet_charset) {
+	if (!mysqlnd_find_charset_nr(greet_packet.charset_no)) {
 		char * msg;
 		mnd_sprintf(&msg, 0, "Server sent charset (%d) unknown to the client. Please, report to the developers", greet_packet.charset_no);
 		SET_CLIENT_ERROR(conn->error_info, CR_NOT_IMPLEMENTED, UNKNOWN_SQLSTATE, msg);

--- a/ext/mysqlnd/mysqlnd_commands.c
+++ b/ext/mysqlnd/mysqlnd_commands.c
@@ -106,9 +106,6 @@ MYSQLND_METHOD(mysqlnd_command, init_db)(MYSQLND_CONN_DATA * const conn, const M
 	  a protocol of giving back -1. Thus we have to follow it :(
 	*/
 	UPSERT_STATUS_SET_AFFECTED_ROWS_TO_ERROR(conn->upsert_status);
-	if (ret == PASS) {
-		mysqlnd_set_persistent_string(&conn->connect_or_select_db, db.s, db.l, conn->persistent);
-	}
 
 	DBG_RETURN(ret);
 }

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -661,7 +661,6 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect)(MYSQLND_CONN_DATA * conn,
 			goto err; /* OOM */
 		}
 
-		conn->port				= port;
 		mysqlnd_set_persistent_string(&conn->connect_or_select_db, database.s, database.l, conn->persistent);
 
 		if (!unix_socket && !named_pipe) {

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -282,7 +282,6 @@ MYSQLND_METHOD(mysqlnd_conn_data, free_contents)(MYSQLND_CONN_DATA * conn)
 
 	DBG_INF("Freeing memory of members");
 
-	mysqlnd_set_persistent_string(&conn->connect_or_select_db, NULL, 0, pers);
 	DBG_INF_FMT("scheme=%s", conn->scheme.s);
 	mysqlnd_set_persistent_string(&conn->scheme, NULL, 0, pers);
 	
@@ -660,8 +659,6 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect)(MYSQLND_CONN_DATA * conn,
 		if (!conn->scheme.s) {
 			goto err; /* OOM */
 		}
-
-		mysqlnd_set_persistent_string(&conn->connect_or_select_db, database.s, database.l, conn->persistent);
 
 		if (!unix_socket && !named_pipe) {
 			char *p;

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -297,7 +297,6 @@ MYSQLND_METHOD(mysqlnd_conn_data, free_contents)(MYSQLND_CONN_DATA * conn)
 	mysqlnd_set_string(&conn->last_message, NULL, 0);
 
 	conn->charset = NULL;
-	conn->greet_charset = NULL;
 
 	DBG_VOID_RETURN;
 }

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -902,7 +902,6 @@ struct st_mysqlnd_connection_data
 	MYSQLND_STRING	connect_or_select_db;
 	MYSQLND_INFILE	infile;
 	unsigned int	protocol_version;
-	unsigned int	port;
 	zend_ulong		server_capabilities;
 
 	/* For UPSERT queries */

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -899,7 +899,6 @@ struct st_mysqlnd_connection_data
 	MYSQLND_STRING	authentication_plugin_data;
 	const MYSQLND_CHARSET *charset;
 	const MYSQLND_CHARSET *greet_charset;
-	MYSQLND_STRING	connect_or_select_db;
 	MYSQLND_INFILE	infile;
 	unsigned int	protocol_version;
 	zend_ulong		server_capabilities;

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -892,10 +892,6 @@ struct st_mysqlnd_connection_data
 	MYSQLND_PROTOCOL_PAYLOAD_DECODER_FACTORY * payload_decoder_factory;
 
 /* Information related */
-	MYSQLND_STRING	hostname;
-	MYSQLND_STRING	unix_socket;
-	MYSQLND_STRING	username;
-	MYSQLND_STRING	password;
 	MYSQLND_STRING	scheme;
 	uint64_t		thread_id;
 	char			*server_version;

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -898,7 +898,6 @@ struct st_mysqlnd_connection_data
 	char			*host_info;
 	MYSQLND_STRING	authentication_plugin_data;
 	const MYSQLND_CHARSET *charset;
-	const MYSQLND_CHARSET *greet_charset;
 	MYSQLND_INFILE	infile;
 	unsigned int	protocol_version;
 	zend_ulong		server_capabilities;


### PR DESCRIPTION
I am creating this PR but I have no hopes that it will be merged.

This PR aims to remove mysqlnd properties from `conn` object that are not used in mysqlnd source code. However, this doesn't mean they are not used elsewhere. In particular, plugins might use them for whatever purpose they want. I checked mysqlnd_ms which is the only one I know that is maintained at least a little bit. The property connect_or_select_db is used there. 

The only one of these which might be relatively uncontroversial is `greet_charset`. I see no way how this information could be used by plugins. 

I have not touched `scheme` as it is used in mysqlnd for debugging purposes. 

Even if this PR is not merged, it can serve as documentation of why this code can't be touched. 