### PR TITLE
Generate &Properties; entity in xpointer for inherited properties in class synopses

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1779,7 +1779,7 @@ class ClassInfo {
                 $parentClassName = self::getClassSynopsisFilename($parent);
                 $includeElement = $this->createIncludeElement(
                     $doc,
-                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.$parentClassName')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='Properties']]))"
+                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.$parentClassName')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"
                 );
                 $classSynopsis->appendChild($includeElement);
             }
@@ -1949,7 +1949,9 @@ class ClassInfo {
     private function createIncludeElement(DOMDocument $doc, string $query): DOMElement
     {
         $includeElement = $doc->createElement("xi:include");
-        $includeElement->setAttribute("xpointer", $query);
+        $attr = $doc->createAttribute("xpointer");
+        $attr->value = $query;
+        $includeElement->appendChild($attr);
         $fallbackElement = $doc->createElement("xi:fallback");
         $includeElement->appendChild(new DOMText("\n     "));
         $includeElement->appendChild($fallbackElement);


### PR DESCRIPTION
This changes `ClassInfo::createIncludeElement()` such that it takes the `$query` argument as-is for the `xpointer` attribute value. Special characters, like `"` and `&`, are used as-is so be careful not to break the resulting XML.

Refs: 
* https://github.com/php/php-src/pull/7340#discussion_r682800971
* https://github.com/php/doc-en/pull/839#discussion_r695465040