### PR TITLE
Fix #53580: During resize gdImageCopyResampled cause colors change

### DIFF
--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -2612,7 +2612,6 @@ void gdImageCopyResampled (gdImagePtr dst, gdImagePtr src, int dstX, int dstY, i
 				green /= spixels;
 				blue /= spixels;
 				alpha /= spixels;
-				alpha += 0.5;
 			}
 			if ( alpha_sum != 0.0f) {
 				if( contrib_sum != 0.0f) {
@@ -2622,20 +2621,12 @@ void gdImageCopyResampled (gdImagePtr dst, gdImagePtr src, int dstX, int dstY, i
 				green /= alpha_sum;
 				blue /= alpha_sum;
 			}
-			/* Clamping to allow for rounding errors above */
-			if (red > 255.0f) {
-				red = 255.0f;
-			}
-			if (green > 255.0f) {
-				green = 255.0f;
-			}
-			if (blue > 255.0f) {
-				blue = 255.0f;
-			}
-			if (alpha > gdAlphaMax) {
-				alpha = gdAlphaMax;
-			}
-			gdImageSetPixel(dst, x, y, gdTrueColorAlpha ((int) red, (int) green, (int) blue, (int) alpha));
+			/* Round up closest next channel value and clamp to max channel value */
+			red = red >= 255.5 ? 255 : red+0.5;
+			blue = blue >= 255.5 ? 255 : blue+0.5;
+			green = green >= 255.5 ? 255 : green+0.5;
+			alpha = alpha >= gdAlphaMax+0.5 ? 255 : alpha+0.5;
+			gdImageSetPixel(dst, x, y, gdTrueColorAlpha ((int)red, (int)green, (int)blue, (int)alpha));
 		}
 	}
 }

--- a/ext/gd/libgd/gd_png.c
+++ b/ext/gd/libgd/gd_png.c
@@ -728,12 +728,7 @@ void gdImagePngCtxEx (gdImagePtr im, gdIOCtx * outfile, int level, int basefilte
 					 */
 					a = gdTrueColorGetAlpha(thisPixel);
 					/* Andrew Hull: >> 6, not >> 7! (gd 2.0.5) */
-					if (a == 127) {
-						*pOutputRow++ = 0;
-					} else {
-						*pOutputRow++ = 255 - ((a << 1) + (a >> 6));
-					}
-
+					*pOutputRow++ = 255 - ((a << 1) + (a >> 6));
 				}
 			}
 		}

--- a/ext/gd/tests/bug53580.phpt
+++ b/ext/gd/tests/bug53580.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #53580 (During resize gdImageCopyResampled cause colors change)
+--SKIPIF--
+<?php
+if (!extension_loaded('gd')) die("skip gd extension not available");
+if (!GD_BUNDLED && version_compare(GD_VERSION, "2.3.2") <= 0) {
+    die("skip test requires GD > 2.3.2");
+}
+?>
+--FILE--
+<?php
+$w0 = 100;
+$h0 = 100;
+$w1 = 150;
+$h1 = 150;
+$c0 = 0xffffff;
+
+$im0 = imagecreatetruecolor($w0, $h0);
+imagefilledrectangle($im0, 0, 0, $w0 - 1, $h0 - 1, $c0);
+
+$im1 = imagecreatetruecolor($w1, $h1);
+imagecopyresampled($im1, $im0, 0, 0, 0, 0, $w1, $h1, $w0, $h0);
+
+for ($i = 0; $i < $w1; $i++) {
+    for ($j = 0; $j < $h1; $j++) {
+        if (($c1 = imagecolorat($im1, $i, $j)) !== $c0) {
+            printf("%d,%d = %d\n", $i, $j, $c1);
+        }
+    }
+}
+?>
+--EXPECT--


### PR DESCRIPTION
We port the upstream fix[1], and also revert commit a3383ac3d7[2] which
is now obsolete, and also not part of libgd.  Especially the change to
gd.png.c was at best a half-baked optimization.

[1] <https://github.com/libgd/libgd/commit/a24e96f01989bf9ca05a08d33862a08d6f4c4ed6>
[2] <https://github.com/php/php-src/commit/a3383ac3d7e21e54b1d7d89f308088d0692abc9f>