### PR TITLE
Use camelCase method names in OCICollection and OCILob

### DIFF
--- a/ext/oci8/oci8.stub.php
+++ b/ext/oci8/oci8.stub.php
@@ -699,7 +699,7 @@ class OCICollection {
      * @alias oci_collection_element_assign
      * @return bool
      */
-    public function assignelem(int $index, string $value) {}
+    public function assignElem(int $index, string $value) {}
 
     /**
      * @alias oci_collection_size

--- a/ext/oci8/oci8.stub.php
+++ b/ext/oci8/oci8.stub.php
@@ -559,7 +559,7 @@ class OCILob {
      * @alias oci_lob_import
      * @return bool
      */
-    public function savefile(string $filename) {}
+    public function saveFile(string $filename) {}
 
     /**
      * @alias oci_lob_load
@@ -637,19 +637,19 @@ class OCILob {
      * @alias ocisetbufferinglob
      * @return bool
      */
-    public function setbuffering(bool $mode) {}
+    public function setBuffering(bool $mode) {}
 
     /**
      * @alias ocigetbufferinglob
      * @return bool
      */
-    public function getbuffering() {}
+    public function getBuffering() {}
 
     /**
      * @alias oci_lob_export
      * @return bool
      */
-    public function writetofile(string $filename, ?int $offset = null, ?int $length = null) {}
+    public function writeToFile(string $filename, ?int $offset = null, ?int $length = null) {}
 
     /**
      * @alias oci_lob_export
@@ -658,7 +658,7 @@ class OCILob {
     public function export(string $filename, ?int $offset = null, ?int $length = null) {}
 
     /** @return bool */
-    public function writetemporary(string $data, int $type = OCI_TEMP_CLOB) {}
+    public function writeTemporary(string $data, int $type = OCI_TEMP_CLOB) {}
 
     /** @return bool */
     public function close() {}

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 64f26d6d80e5d5abf5017fb9546c1ee3378731eb */
+ * Stub hash: 4df305f0e3750245ed9f9f9bc10edc339328084a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_define_by_name, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, statement)
@@ -447,7 +447,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_import, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_OCILob_savefile arginfo_class_OCILob_import
+#define arginfo_class_OCILob_saveFile arginfo_class_OCILob_import
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_load, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -491,21 +491,21 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_OCILob_flush, 0, 0, _IS_BO
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flag, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_setbuffering, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_setBuffering, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, mode, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_OCILob_getbuffering arginfo_class_OCILob_load
+#define arginfo_class_OCILob_getBuffering arginfo_class_OCILob_load
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_writetofile, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_writeToFile, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, offset, IS_LONG, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_OCILob_export arginfo_class_OCILob_writetofile
+#define arginfo_class_OCILob_export arginfo_class_OCILob_writeToFile
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_writetemporary, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCILob_writeTemporary, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, type, IS_LONG, 0, "OCI_TEMP_CLOB")
 ZEND_END_ARG_INFO()
@@ -619,7 +619,7 @@ ZEND_FUNCTION(oci_collection_trim);
 ZEND_FUNCTION(oci_new_collection);
 ZEND_FUNCTION(oci_register_taf_callback);
 ZEND_FUNCTION(oci_unregister_taf_callback);
-ZEND_METHOD(OCILob, writetemporary);
+ZEND_METHOD(OCILob, writeTemporary);
 ZEND_METHOD(OCILob, close);
 
 
@@ -754,7 +754,7 @@ static const zend_function_entry ext_functions[] = {
 static const zend_function_entry class_OCILob_methods[] = {
 	ZEND_ME_MAPPING(save, oci_lob_save, arginfo_class_OCILob_save, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(import, oci_lob_import, arginfo_class_OCILob_import, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(savefile, oci_lob_import, arginfo_class_OCILob_savefile, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(saveFile, oci_lob_import, arginfo_class_OCILob_saveFile, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(load, oci_lob_load, arginfo_class_OCILob_load, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(read, oci_lob_read, arginfo_class_OCILob_read, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(eof, oci_lob_eof, arginfo_class_OCILob_eof, ZEND_ACC_PUBLIC)
@@ -767,11 +767,11 @@ static const zend_function_entry class_OCILob_methods[] = {
 	ZEND_ME_MAPPING(truncate, oci_lob_truncate, arginfo_class_OCILob_truncate, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(erase, oci_lob_erase, arginfo_class_OCILob_erase, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(flush, oci_lob_flush, arginfo_class_OCILob_flush, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(setbuffering, ocisetbufferinglob, arginfo_class_OCILob_setbuffering, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(getbuffering, ocigetbufferinglob, arginfo_class_OCILob_getbuffering, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(writetofile, oci_lob_export, arginfo_class_OCILob_writetofile, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(setBuffering, ocisetbufferinglob, arginfo_class_OCILob_setBuffering, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(getBuffering, ocigetbufferinglob, arginfo_class_OCILob_getBuffering, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(writeToFile, oci_lob_export, arginfo_class_OCILob_writeToFile, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(export, oci_lob_export, arginfo_class_OCILob_export, ZEND_ACC_PUBLIC)
-	ZEND_ME(OCILob, writetemporary, arginfo_class_OCILob_writetemporary, ZEND_ACC_PUBLIC)
+	ZEND_ME(OCILob, writeTemporary, arginfo_class_OCILob_writeTemporary, ZEND_ACC_PUBLIC)
 	ZEND_ME(OCILob, close, arginfo_class_OCILob_close, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(free, oci_free_descriptor, arginfo_class_OCILob_free, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dfdfd80652d83f82d9bbe3743cd9137c2ab1668e */
+ * Stub hash: 64f26d6d80e5d5abf5017fb9546c1ee3378731eb */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_define_by_name, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, statement)
@@ -528,7 +528,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCICollection_assign, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, from, OCICollection, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCICollection_assignelem, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_OCICollection_assignElem, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -783,7 +783,7 @@ static const zend_function_entry class_OCICollection_methods[] = {
 	ZEND_ME_MAPPING(append, oci_collection_append, arginfo_class_OCICollection_append, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(getElem, oci_collection_element_get, arginfo_class_OCICollection_getElem, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(assign, oci_collection_assign, arginfo_class_OCICollection_assign, ZEND_ACC_PUBLIC)
-	ZEND_ME_MAPPING(assignelem, oci_collection_element_assign, arginfo_class_OCICollection_assignelem, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(assignElem, oci_collection_element_assign, arginfo_class_OCICollection_assignElem, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(size, oci_collection_size, arginfo_class_OCICollection_size, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(max, oci_collection_max, arginfo_class_OCICollection_max, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(trim, oci_collection_trim, arginfo_class_OCICollection_trim, ZEND_ACC_PUBLIC)

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -916,7 +916,7 @@ PHP_FUNCTION(oci_lob_export)
 /* }}} */
 
 /* {{{ Writes temporary blob */
-PHP_METHOD(OCILob, writetemporary)
+PHP_METHOD(OCILob, writeTemporary)
 {
 	zval *tmp, *z_descriptor;
 	php_oci_descriptor *descriptor;

--- a/ext/oci8/tests/bug37220.phpt
+++ b/ext/oci8/tests/bug37220.phpt
@@ -29,7 +29,7 @@ $query = "UPDATE  bug37220_tab
 $stmt = oci_parse ($c, $query);
 $clob = oci_new_descriptor($c, OCI_D_LOB);
 oci_bind_by_name($stmt, ':data', $clob, -1, OCI_B_CLOB);
-$clob->writetemporary("<MYTAG/>", OCI_TEMP_CLOB);
+$clob->writeTemporary("<MYTAG/>", OCI_TEMP_CLOB);
 $success = oci_execute($stmt, OCI_COMMIT_ON_SUCCESS);
 oci_free_statement($stmt);
 $clob->close();

--- a/ext/oci8/tests/bug43497.phpt
+++ b/ext/oci8/tests/bug43497.phpt
@@ -120,7 +120,7 @@ function fillxmltab($c)
         oci_bind_by_name($stmt, ":id", $id);
         $clob = oci_new_descriptor($c, OCI_D_LOB);
         oci_bind_by_name($stmt, ":xml", $clob, -1, OCI_B_CLOB);
-        $clob->writetemporary($data);
+        $clob->writeTemporary($data);
         oci_execute($stmt);
 
         $clob->close();

--- a/ext/oci8/tests/define3.phpt
+++ b/ext/oci8/tests/define3.phpt
@@ -24,7 +24,7 @@ oci_bind_by_name($stmt,":id",$id);
 oci_bind_by_name($stmt,":fileimage",$fileimage,-1,OCI_B_BLOB);
 $id = 1;
 oci_execute($stmt, OCI_DEFAULT);
-$fileimage->savefile(__DIR__."/test.gif");
+$fileimage->saveFile(__DIR__."/test.gif");
 $data = $fileimage->load();
 var_dump(md5($data));  // original md5
 oci_commit($c);

--- a/ext/oci8/tests/null_byte_1.phpt
+++ b/ext/oci8/tests/null_byte_1.phpt
@@ -23,7 +23,7 @@ echo "Test 1: Import\n";
 
 $lob = oci_new_descriptor($c, OCI_D_LOB);
 try {
-    $lob->savefile("/tmp/abc\0def");
+    $lob->saveFile("/tmp/abc\0def");
 } catch (ValueError $e) {
        echo $e->getMessage(), "\n";
 }


### PR DESCRIPTION
The doc has been using `assignElem()` and there is also a `OCICollection::getElem()` method (which was accidentally renamed from `getelem()` when arginfo got generated from the stubs), so it would be nice to keep using camelCase all over `OCICollection`.