### PR TITLE
Fix gdAlphaMax limit typo

### DIFF
--- a/ext/gd/libgd/gd.c
+++ b/ext/gd/libgd/gd.c
@@ -2625,7 +2625,7 @@ void gdImageCopyResampled (gdImagePtr dst, gdImagePtr src, int dstX, int dstY, i
 			red = red >= 255.5 ? 255 : red+0.5;
 			blue = blue >= 255.5 ? 255 : blue+0.5;
 			green = green >= 255.5 ? 255 : green+0.5;
-			alpha = alpha >= gdAlphaMax+0.5 ? 255 : alpha+0.5;
+			alpha = alpha >= gdAlphaMax+0.5 ? gdAlphaMax : alpha+0.5;
 			gdImageSetPixel(dst, x, y, gdTrueColorAlpha ((int)red, (int)green, (int)blue, (int)alpha));
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/php/php-src/pull/7402, `gdAlphaMax` is 127.

Also ~submitted~ merged to the gd lib as https://github.com/libgd/libgd/pull/741.