### PR TITLE
Don't expose wchar encoding to users

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
@@ -38,7 +38,6 @@
 #include "mbfl_encoding.h"
 #include "mbfilter_pass.h"
 #include "mbfilter_8bit.h"
-#include "mbfilter_wchar.h"
 
 #include "filters/mbfilter_euc_cn.h"
 #include "filters/mbfilter_hz.h"
@@ -86,7 +85,6 @@
 
 
 static const mbfl_encoding *mbfl_encoding_ptr_list[] = {
-	&mbfl_encoding_wchar,
 	&mbfl_encoding_base64,
 	&mbfl_encoding_uuencode,
 	&mbfl_encoding_html_ent,


### PR DESCRIPTION
The "wchar" encoding isn't really an encoding -- it's what we
internally use as the representation of decoded characters.

In practice, it tends to behave a lot like the 8bit encoding when
used from userland, because input code units end up being treated
as code points.

This patch removes the wchar encoding from the public encoding
list and reserves it for internal use only.