### PR TITLE
[gen_stub] fix nested namespaced typed property in gen_stub.php

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -382,6 +382,11 @@ class SimpleType {
         return str_replace('\\', '\\\\', $this->name);
     }
 
+    public function toCVarEscapedName(): string {
+        $name = str_replace('_', '__', $this->name);
+        return str_replace('\\', '_', $this->name);
+    }
+
     public function equals(SimpleType $other): bool {
         return $this->name === $other->name && $this->isBuiltin === $other->isBuiltin;
     }
@@ -1351,8 +1356,8 @@ class PropertyInfo
                 if (count($arginfoType->classTypes) >= 2) {
                     foreach ($arginfoType->classTypes as $classType) {
                         $className = $classType->name;
-                        $escapedClassName = str_replace('\\', '\\\\', $className);
-                        $varEscapedClassName = str_replace('\\', '_', $className);
+                        $escapedClassName = $classType->toEscapedName();
+                        $varEscapedClassName = $classType->toCVarEscapedName();
                         $code .= "\tzend_string *property_{$propertyName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", sizeof(\"{$escapedClassName}\") - 1, 1);\n";
                     }
 
@@ -1362,7 +1367,7 @@ class PropertyInfo
 
                     foreach ($arginfoType->classTypes as $k => $classType) {
                         $className = $classType->name;
-                        $escapedClassName = str_replace('\\', '\\\\', $className);
+                        $escapedClassName = $classType->toEscapedName();
                         $code .= "\tproperty_{$propertyName}_type_list->types[$k] = (zend_type) ZEND_TYPE_INIT_CLASS(property_{$propertyName}_class_{$escapedClassName}, 0, 0);\n";
                     }
 
@@ -1372,8 +1377,8 @@ class PropertyInfo
                     $typeCode = "property_{$propertyName}_type";
                 } else {
                     $className = $arginfoType->classTypes[0]->name;
-                    $escapedClassName = str_replace('\\', '\\\\', $className);
-                    $varEscapedClassName = str_replace('\\', '_', $className);
+                    $escapedClassName = $arginfoType->classTypes[0]->toEscapedName();
+                    $varEscapedClassName = $arginfoType->classTypes[0]->toCVarEscapedName();
                     $code .= "\tzend_string *property_{$propertyName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", sizeof(\"${escapedClassName}\")-1, 1);\n";
 
                     $typeCode = "(zend_type) ZEND_TYPE_INIT_CLASS(property_{$propertyName}_class_{$varEscapedClassName}, 0, " . $arginfoType->toTypeMask() . ")";

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1351,7 +1351,9 @@ class PropertyInfo
                 if (count($arginfoType->classTypes) >= 2) {
                     foreach ($arginfoType->classTypes as $classType) {
                         $className = $classType->name;
-                        $code .= "\tzend_string *property_{$propertyName}_class_{$className} = zend_string_init(\"$className\", sizeof(\"$className\") - 1, 1);\n";
+                        $escapedClassName = str_replace('\\', '\\\\', $className);
+                        $varEscapedClassName = str_replace('\\', '_', $className);
+                        $code .= "\tzend_string *property_{$propertyName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", sizeof(\"{$escapedClassName}\") - 1, 1);\n";
                     }
 
                     $classTypeCount = count($arginfoType->classTypes);
@@ -1360,7 +1362,8 @@ class PropertyInfo
 
                     foreach ($arginfoType->classTypes as $k => $classType) {
                         $className = $classType->name;
-                        $code .= "\tproperty_{$propertyName}_type_list->types[$k] = (zend_type) ZEND_TYPE_INIT_CLASS(property_{$propertyName}_class_{$className}, 0, 0);\n";
+                        $escapedClassName = str_replace('\\', '\\\\', $className);
+                        $code .= "\tproperty_{$propertyName}_type_list->types[$k] = (zend_type) ZEND_TYPE_INIT_CLASS(property_{$propertyName}_class_{$escapedClassName}, 0, 0);\n";
                     }
 
                     $typeMaskCode = $this->type->toArginfoType()->toTypeMask();
@@ -1369,9 +1372,11 @@ class PropertyInfo
                     $typeCode = "property_{$propertyName}_type";
                 } else {
                     $className = $arginfoType->classTypes[0]->name;
-                    $code .= "\tzend_string *property_{$propertyName}_class_{$className} = zend_string_init(\"$className\", sizeof(\"$className\")-1, 1);\n";
+                    $escapedClassName = str_replace('\\', '\\\\', $className);
+                    $varEscapedClassName = str_replace('\\', '_', $className);
+                    $code .= "\tzend_string *property_{$propertyName}_class_{$varEscapedClassName} = zend_string_init(\"{$escapedClassName}\", sizeof(\"${escapedClassName}\")-1, 1);\n";
 
-                    $typeCode = "(zend_type) ZEND_TYPE_INIT_CLASS(property_{$propertyName}_class_{$className}, 0, " . $arginfoType->toTypeMask() . ")";
+                    $typeCode = "(zend_type) ZEND_TYPE_INIT_CLASS(property_{$propertyName}_class_{$varEscapedClassName}, 0, " . $arginfoType->toTypeMask() . ")";
                 }
             } else {
                 $typeCode = "(zend_type) ZEND_TYPE_INIT_MASK(" . $arginfoType->toTypeMask() . ")";

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -39,8 +39,6 @@ static zend_class_entry *zend_test_attribute;
 static zend_class_entry *zend_test_ns_foo_class;
 static zend_class_entry *zend_test_ns2_foo_class;
 static zend_class_entry *zend_test_ns2_ns_foo_class;
-static zend_class_entry *zend_test_ns3_ns_foo_class;
-static zend_class_entry *zend_test_ns3_foo_class;
 static zend_class_entry *zend_test_unit_enum;
 static zend_class_entry *zend_test_string_enum;
 static zend_object_handlers zend_test_class_handlers;
@@ -357,41 +355,6 @@ static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method)
 	ZEND_PARSE_PARAMETERS_NONE();
 }
 
-static ZEND_METHOD(ZendTestNS3_Foo, __construct)
-{
-	zend_object *foo;
-	zval zfoo;
-	zend_string *pname;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJ_OF_CLASS(foo, zend_test_ns3_ns_foo_class);
-	ZEND_PARSE_PARAMETERS_END();
-
-	ZVAL_OBJ(&zfoo, foo);
-
-	pname = zend_string_init("foo", sizeof("foo") - 1, 0);
-	zend_std_write_property(Z_OBJ_P(ZEND_THIS), pname, &zfoo, NULL);
-	zend_string_release(pname);
-}
-
-static ZEND_METHOD(ZendTestNS3_Foo, method1)
-{
-	zend_object *foo;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJ_OF_CLASS(foo, zend_test_ns3_ns_foo_class);
-	ZEND_PARSE_PARAMETERS_END();
-}
-
-static ZEND_METHOD(ZendTestNS3_Foo, method2)
-{
-	zend_object *foo;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_OBJ_OF_CLASS(foo, zend_test_ns3_ns_foo_class);
-	ZEND_PARSE_PARAMETERS_END();
-}
-
 PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("zend_test.replace_zend_execute_ex", "0", PHP_INI_SYSTEM, OnUpdateBool, replace_zend_execute_ex, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.register_passes", "0", PHP_INI_SYSTEM, OnUpdateBool, register_passes, zend_zend_test_globals, zend_test_globals)
@@ -429,8 +392,6 @@ PHP_MINIT_FUNCTION(zend_test)
 
 	zend_test_ns_foo_class = register_class_ZendTestNS_Foo();
 	zend_test_ns2_foo_class = register_class_ZendTestNS2_Foo();
-	zend_test_ns3_ns_foo_class = register_class_ZendTestNS3_ZendSubNS_Foo();
-	zend_test_ns3_foo_class = register_class_ZendTestNS3_Foo();
 	zend_test_ns2_ns_foo_class = register_class_ZendTestNS2_ZendSubNS_Foo();
 
 	zend_test_unit_enum = zend_register_internal_enum("ZendTestUnitEnum", IS_UNDEF, NULL);

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -39,6 +39,8 @@ static zend_class_entry *zend_test_attribute;
 static zend_class_entry *zend_test_ns_foo_class;
 static zend_class_entry *zend_test_ns2_foo_class;
 static zend_class_entry *zend_test_ns2_ns_foo_class;
+static zend_class_entry *zend_test_ns3_ns_foo_class;
+static zend_class_entry *zend_test_ns3_foo_class;
 static zend_class_entry *zend_test_unit_enum;
 static zend_class_entry *zend_test_string_enum;
 static zend_object_handlers zend_test_class_handlers;
@@ -355,6 +357,41 @@ static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method)
 	ZEND_PARSE_PARAMETERS_NONE();
 }
 
+static ZEND_METHOD(ZendTestNS3_Foo, __construct)
+{
+	zend_object *foo;
+	zval zfoo;
+	zend_string *pname;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJ_OF_CLASS(foo, zend_test_ns3_ns_foo_class);
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_OBJ(&zfoo, foo);
+
+	pname = zend_string_init("foo", sizeof("foo") - 1, 0);
+	zend_std_write_property(Z_OBJ_P(ZEND_THIS), pname, &zfoo, NULL);
+	zend_string_release(pname);
+}
+
+static ZEND_METHOD(ZendTestNS3_Foo, method1)
+{
+	zend_object *foo;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJ_OF_CLASS(foo, zend_test_ns3_ns_foo_class);
+	ZEND_PARSE_PARAMETERS_END();
+}
+
+static ZEND_METHOD(ZendTestNS3_Foo, method2)
+{
+	zend_object *foo;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJ_OF_CLASS(foo, zend_test_ns3_ns_foo_class);
+	ZEND_PARSE_PARAMETERS_END();
+}
+
 PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("zend_test.replace_zend_execute_ex", "0", PHP_INI_SYSTEM, OnUpdateBool, replace_zend_execute_ex, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.register_passes", "0", PHP_INI_SYSTEM, OnUpdateBool, register_passes, zend_zend_test_globals, zend_test_globals)
@@ -392,6 +429,8 @@ PHP_MINIT_FUNCTION(zend_test)
 
 	zend_test_ns_foo_class = register_class_ZendTestNS_Foo();
 	zend_test_ns2_foo_class = register_class_ZendTestNS2_Foo();
+	zend_test_ns3_ns_foo_class = register_class_ZendTestNS3_ZendSubNS_Foo();
+	zend_test_ns3_foo_class = register_class_ZendTestNS3_Foo();
 	zend_test_ns2_ns_foo_class = register_class_ZendTestNS2_ZendSubNS_Foo();
 
 	zend_test_unit_enum = zend_register_internal_enum("ZendTestUnitEnum", IS_UNDEF, NULL);

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -102,3 +102,23 @@ namespace ZendTestNS2\ZendSubNS {
     function namespaced_func(): bool {}
 
 }
+
+namespace ZendTestNS3\ZendSubNS {
+
+    class Foo {
+    }
+
+}
+
+namespace ZendTestNS3 {
+
+    class Foo {
+        public ZendSubNS\Foo $foo;
+
+        public function __construct(ZendSubNS\Foo $foo) {}
+
+        public function method1(ZendSubNS\Foo $foo): void {}
+        public function method2(\ZendTestNS3\ZendSubNS\Foo $foo): void {}
+    }
+
+}

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -88,6 +88,8 @@ namespace ZendTestNS {
 namespace ZendTestNS2 {
 
     class Foo {
+        public ZendSubNS\Foo $foo;
+
         public function method(): void {}
     }
 
@@ -100,25 +102,5 @@ namespace ZendTestNS2\ZendSubNS {
     }
 
     function namespaced_func(): bool {}
-
-}
-
-namespace ZendTestNS3\ZendSubNS {
-
-    class Foo {
-    }
-
-}
-
-namespace ZendTestNS3 {
-
-    class Foo {
-        public ZendSubNS\Foo $foo;
-
-        public function __construct(ZendSubNS\Foo $foo) {}
-
-        public function method1(ZendSubNS\Foo $foo): void {}
-        public function method2(\ZendTestNS3\ZendSubNS\Foo $foo): void {}
-    }
 
 }

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 93bb8b9120e510e8c3afc29dc0a5d47cb6b5f10e */
+ * Stub hash: 77e4782af9c6994f233ba6535b53179da318b223 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -80,6 +80,16 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ZendTestNS2_ZendSubNS_Foo_method arginfo_zend_test_void_return
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZendTestNS3_Foo___construct, 0, 0, 1)
+	ZEND_ARG_OBJ_INFO(0, foo, ZendTestNS3\\ZendSubNS\\Foo, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ZendTestNS3_Foo_method1, 0, 1, IS_VOID, 0)
+	ZEND_ARG_OBJ_INFO(0, foo, ZendTestNS3\\ZendSubNS\\Foo, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_ZendTestNS3_Foo_method2 arginfo_class_ZendTestNS3_Foo_method1
+
 
 static ZEND_FUNCTION(zend_test_array_return);
 static ZEND_FUNCTION(zend_test_nullable_array_return);
@@ -105,6 +115,9 @@ static ZEND_METHOD(_ZendTestTrait, testMethod);
 static ZEND_METHOD(ZendTestNS_Foo, method);
 static ZEND_METHOD(ZendTestNS2_Foo, method);
 static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method);
+static ZEND_METHOD(ZendTestNS3_Foo, __construct);
+static ZEND_METHOD(ZendTestNS3_Foo, method1);
+static ZEND_METHOD(ZendTestNS3_Foo, method2);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -172,6 +185,19 @@ static const zend_function_entry class_ZendTestNS2_Foo_methods[] = {
 
 static const zend_function_entry class_ZendTestNS2_ZendSubNS_Foo_methods[] = {
 	ZEND_ME(ZendTestNS2_ZendSubNS_Foo, method, arginfo_class_ZendTestNS2_ZendSubNS_Foo_method, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ZendTestNS3_ZendSubNS_Foo_methods[] = {
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ZendTestNS3_Foo_methods[] = {
+	ZEND_ME(ZendTestNS3_Foo, __construct, arginfo_class_ZendTestNS3_Foo___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(ZendTestNS3_Foo, method1, arginfo_class_ZendTestNS3_Foo_method1, ZEND_ACC_PUBLIC)
+	ZEND_ME(ZendTestNS3_Foo, method2, arginfo_class_ZendTestNS3_Foo_method2, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -305,6 +331,33 @@ static zend_class_entry *register_class_ZendTestNS2_ZendSubNS_Foo(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS2\\ZendSubNS", "Foo", class_ZendTestNS2_ZendSubNS_Foo_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ZendTestNS3_ZendSubNS_Foo(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS3\\ZendSubNS", "Foo", class_ZendTestNS3_ZendSubNS_Foo_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ZendTestNS3_Foo(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS3", "Foo", class_ZendTestNS3_Foo_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	zend_string *property_foo_class_ZendTestNS3_ZendSubNS_Foo = zend_string_init("ZendTestNS3\\ZendSubNS\\Foo", sizeof("ZendTestNS3\\ZendSubNS\\Foo")-1, 1);
+	zval property_foo_default_value;
+	ZVAL_UNDEF(&property_foo_default_value);
+	zend_string *property_foo_name = zend_string_init("foo", sizeof("foo") - 1, 1);
+	zend_declare_typed_property(class_entry, property_foo_name, &property_foo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_foo_class_ZendTestNS3_ZendSubNS_Foo, 0, 0));
+	zend_string_release(property_foo_name);
 
 	return class_entry;
 }

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 77e4782af9c6994f233ba6535b53179da318b223 */
+ * Stub hash: 04d48fa64594bacba57210dcb94381f83951116c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -80,16 +80,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ZendTestNS2_ZendSubNS_Foo_method arginfo_zend_test_void_return
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZendTestNS3_Foo___construct, 0, 0, 1)
-	ZEND_ARG_OBJ_INFO(0, foo, ZendTestNS3\\ZendSubNS\\Foo, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ZendTestNS3_Foo_method1, 0, 1, IS_VOID, 0)
-	ZEND_ARG_OBJ_INFO(0, foo, ZendTestNS3\\ZendSubNS\\Foo, 0)
-ZEND_END_ARG_INFO()
-
-#define arginfo_class_ZendTestNS3_Foo_method2 arginfo_class_ZendTestNS3_Foo_method1
-
 
 static ZEND_FUNCTION(zend_test_array_return);
 static ZEND_FUNCTION(zend_test_nullable_array_return);
@@ -115,9 +105,6 @@ static ZEND_METHOD(_ZendTestTrait, testMethod);
 static ZEND_METHOD(ZendTestNS_Foo, method);
 static ZEND_METHOD(ZendTestNS2_Foo, method);
 static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method);
-static ZEND_METHOD(ZendTestNS3_Foo, __construct);
-static ZEND_METHOD(ZendTestNS3_Foo, method1);
-static ZEND_METHOD(ZendTestNS3_Foo, method2);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -185,19 +172,6 @@ static const zend_function_entry class_ZendTestNS2_Foo_methods[] = {
 
 static const zend_function_entry class_ZendTestNS2_ZendSubNS_Foo_methods[] = {
 	ZEND_ME(ZendTestNS2_ZendSubNS_Foo, method, arginfo_class_ZendTestNS2_ZendSubNS_Foo_method, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-
-static const zend_function_entry class_ZendTestNS3_ZendSubNS_Foo_methods[] = {
-	ZEND_FE_END
-};
-
-
-static const zend_function_entry class_ZendTestNS3_Foo_methods[] = {
-	ZEND_ME(ZendTestNS3_Foo, __construct, arginfo_class_ZendTestNS3_Foo___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME(ZendTestNS3_Foo, method1, arginfo_class_ZendTestNS3_Foo_method1, ZEND_ACC_PUBLIC)
-	ZEND_ME(ZendTestNS3_Foo, method2, arginfo_class_ZendTestNS3_Foo_method2, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -322,6 +296,13 @@ static zend_class_entry *register_class_ZendTestNS2_Foo(void)
 	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS2", "Foo", class_ZendTestNS2_Foo_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 
+	zend_string *property_foo_class_ZendTestNS2_ZendSubNS_Foo = zend_string_init("ZendTestNS2\\ZendSubNS\\Foo", sizeof("ZendTestNS2\\ZendSubNS\\Foo")-1, 1);
+	zval property_foo_default_value;
+	ZVAL_UNDEF(&property_foo_default_value);
+	zend_string *property_foo_name = zend_string_init("foo", sizeof("foo") - 1, 1);
+	zend_declare_typed_property(class_entry, property_foo_name, &property_foo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_foo_class_ZendTestNS2_ZendSubNS_Foo, 0, 0));
+	zend_string_release(property_foo_name);
+
 	return class_entry;
 }
 
@@ -331,33 +312,6 @@ static zend_class_entry *register_class_ZendTestNS2_ZendSubNS_Foo(void)
 
 	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS2\\ZendSubNS", "Foo", class_ZendTestNS2_ZendSubNS_Foo_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
-
-	return class_entry;
-}
-
-static zend_class_entry *register_class_ZendTestNS3_ZendSubNS_Foo(void)
-{
-	zend_class_entry ce, *class_entry;
-
-	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS3\\ZendSubNS", "Foo", class_ZendTestNS3_ZendSubNS_Foo_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
-
-	return class_entry;
-}
-
-static zend_class_entry *register_class_ZendTestNS3_Foo(void)
-{
-	zend_class_entry ce, *class_entry;
-
-	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS3", "Foo", class_ZendTestNS3_Foo_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
-
-	zend_string *property_foo_class_ZendTestNS3_ZendSubNS_Foo = zend_string_init("ZendTestNS3\\ZendSubNS\\Foo", sizeof("ZendTestNS3\\ZendSubNS\\Foo")-1, 1);
-	zval property_foo_default_value;
-	ZVAL_UNDEF(&property_foo_default_value);
-	zend_string *property_foo_name = zend_string_init("foo", sizeof("foo") - 1, 1);
-	zend_declare_typed_property(class_entry, property_foo_name, &property_foo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_foo_class_ZendTestNS3_ZendSubNS_Foo, 0, 0));
-	zend_string_release(property_foo_name);
 
 	return class_entry;
 }

--- a/ext/zend_test/tests/gen_stub_test_01.phpt
+++ b/ext/zend_test/tests/gen_stub_test_01.phpt
@@ -5,14 +5,13 @@ zend_test
 --FILE--
 <?php
 
-$foo = new \ZendTestNS3\Foo(new \ZendTestNS3\ZendSubNS\Foo());
+$foo = new \ZendTestNS2\Foo();
+$foo->foo = new \ZendTestNS2\ZendSubNS\Foo();
 var_dump($foo);
-$foo->method1(new \ZendTestNS3\ZendSubNS\foo());
-$foo->method2(new \ZendTestNS3\ZendSubNS\foo());
 ?>
 --EXPECT--
-object(ZendTestNS3\Foo)#1 (1) {
+object(ZendTestNS2\Foo)#1 (1) {
   ["foo"]=>
-  object(ZendTestNS3\ZendSubNS\Foo)#2 (0) {
+  object(ZendTestNS2\ZendSubNS\Foo)#2 (0) {
   }
 }

--- a/ext/zend_test/tests/gen_stub_test_01.phpt
+++ b/ext/zend_test/tests/gen_stub_test_01.phpt
@@ -6,12 +6,17 @@ zend_test
 <?php
 
 $foo = new \ZendTestNS2\Foo();
+var_dump($foo);
 $foo->foo = new \ZendTestNS2\ZendSubNS\Foo();
 var_dump($foo);
 ?>
---EXPECT--
-object(ZendTestNS2\Foo)#1 (1) {
+--EXPECTF--
+object(ZendTestNS2\Foo)#%d (%d) {
   ["foo"]=>
-  object(ZendTestNS2\ZendSubNS\Foo)#2 (0) {
+  uninitialized(ZendTestNS2\ZendSubNS\Foo)
+}
+object(ZendTestNS2\Foo)#%d (%d) {
+  ["foo"]=>
+  object(ZendTestNS2\ZendSubNS\Foo)#%d (%d) {
   }
 }

--- a/ext/zend_test/tests/gen_stub_test_01.phpt
+++ b/ext/zend_test/tests/gen_stub_test_01.phpt
@@ -1,0 +1,18 @@
+--TEST--
+gen_stub.php: nested namespaced typed properties test.
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$foo = new \ZendTestNS3\Foo(new \ZendTestNS3\ZendSubNS\Foo());
+var_dump($foo);
+$foo->method1(new \ZendTestNS3\ZendSubNS\foo());
+$foo->method2(new \ZendTestNS3\ZendSubNS\foo());
+?>
+--EXPECT--
+object(ZendTestNS3\Foo)#1 (1) {
+  ["foo"]=>
+  object(ZendTestNS3\ZendSubNS\Foo)#2 (0) {
+  }
+}


### PR DESCRIPTION
gen_stub.php fails to auto-generate typed properties with nested namespaces.

There is nothing broken in php-src with this at the moment, but we will try to fix it as it is difficult to create an extension.