### PR TITLE
microptimization of SQLite3Result::fetchArray

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1946,8 +1946,10 @@ PHP_METHOD(SQLite3Result, fetchArray)
 			}
 
 			array_init(return_value);
+			
+			int column_count = sqlite3_data_count(result_obj->stmt_obj->stmt);
 
-			for (i = 0; i < sqlite3_data_count(result_obj->stmt_obj->stmt); i++) {
+			for (i = 0; i < column_count; i++) {
 				zval data;
 
 				sqlite_value_to_zval(result_obj->stmt_obj->stmt, i, &data);


### PR DESCRIPTION
Store the result of sqlite3_data_count() into a variable and check that inside a loop instead calling it directly all the time. GCC is not brave enough to figure out the function produces the same result every time and call it repeatedly. This change produces fairly small but measurable and consistent speedup.