### PR TITLE
Oci8 problem on 64-bit bigendian platforms, bug#73002

### DIFF
--- a/ext/oci8/tests/bigendian64_1.phpt
+++ b/ext/oci8/tests/bigendian64_1.phpt
@@ -1,0 +1,28 @@
+--TEST--
+64-bit bigendian platform, PL/SQL, assign to bind-variable, string type
+--SKIPIF--
+<?php
+if (!extension_loaded('oci8')) die ("skip no oci8 extension");
+require(__DIR__.'/connect.inc');
+?>
+--FILE--
+<?php
+
+require(__DIR__.'/connect.inc');
+
+// Run Test
+
+echo "64-bit bigendian platform, PL/SQL, assign to bind-variable, string type\n";
+
+$sql = "begin
+          :output1 := 'Teststr';
+        end;";
+
+$s = oci_parse($c, $sql);
+oci_bind_by_name($s, ':output1', $output1, 64);
+oci_execute($s);
+print $output1."\n"
+?>
+--EXPECT--
+64-bit bigendian platform, PL/SQL, assign to bind-variable, string type
+Teststr


### PR DESCRIPTION
On 64-bit big-endian platforms pointers to 8-bytes field cannot be
trivially converted into pointers to 4-bytes field.

Explained in details here: https://bugs.php.net/bug.php?id=73002

This affects strings' length-fields, booleans, and integer values for Oracle client 10 (and older).