### PR TITLE
Fix #81400: Unterminated string in dns_get_record() results

### DIFF
--- a/ext/standard/dns_win32.c
+++ b/ext/standard/dns_win32.c
@@ -223,18 +223,18 @@ static void php_parserr(PDNS_RECORD pRec, int type_to_fetch, int store, int raw,
 				array_init(&entries);
 
 				for (i = 0; i < count; i++) {
-					txt_len += strlen(data_txt->pStringArray[i]) + 1;
+					txt_len += strlen(data_txt->pStringArray[i]);
 				}
 
-				txt = zend_string_safe_alloc(txt_len, 2, 0, 0);
-				txt_dst = txt->val;
+				txt = zend_string_alloc(txt_len, 0);
+				txt_dst = ZSTR_VAL(txt);
 				for (i = 0; i < count; i++) {
 					size_t len = strlen(data_txt->pStringArray[i]);
 					memcpy(txt_dst, data_txt->pStringArray[i], len);
 					add_next_index_stringl(&entries, data_txt->pStringArray[i], len);
 					txt_dst += len;
 				}
-				txt->len = txt_dst - txt->val;
+				*txt_dst = '\0';
 				add_assoc_str(subarray, "txt", txt);
 				add_assoc_zval(subarray, "entries", &entries);
 			}


### PR DESCRIPTION
If we assemble a zend_string manually, we need to end it with a NUL
byte ourselves.

We also fix the size calculation for that zend_string; there is no need
for the extra byte for each part, and we don't have to multiply by two,
since we're using DnsQuery_A(), not DnsQuery_W () (in which case we
would have to do the character set conversion, anyway).  This avoids
over-allocation, and the need to explicitly set the string length.

Finally, we use the proper access macro for zend_strings.