### PR TITLE
Avoid overflow in zend_list_insert

### DIFF
--- a/Zend/zend_list.c
+++ b/Zend/zend_list.c
@@ -31,7 +31,7 @@ static HashTable list_destructors;
 
 ZEND_API zval* ZEND_FASTCALL zend_list_insert(void *ptr, int type)
 {
-	int index;
+	zend_long index;
 	zval zv;
 
 	index = zend_hash_next_free_element(&EG(regular_list));


### PR DESCRIPTION
As described in https://bugs.php.net/bug.php?id=81399 declaring `index` as `int` may lead to overflow and later in segfault. Let's declare it as `zend_long`, because function `zend_hash_index_add_new` accepts `zend_ulong`.