### PR TITLE
Fix #50293: Several openssl functions ignore the VCWD

### DIFF
--- a/ext/openssl/tests/bug50293.phpt
+++ b/ext/openssl/tests/bug50293.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Bug #50293 (Several openssl functions ignore the VCWD)
+--SKIPIF--
+<?php
+if (!extension_loaded("openssl")) die("skip openssl extension not available");
+?>
+--FILE--
+<?php
+$ssl_configargs = [
+    "digest_alg" => "sha1",
+    "encrypt_key" => false,
+    "basicConstraints" => "CA:true",
+    "keyUsage" => "cRLSign, keyCertSign",
+    "nsCertType" => "sslCA, emailCA",
+    "config" => __DIR__ . "/openssl.cnf",
+];
+$dn = [
+    "countryName" => "GB",
+    "stateOrProvinceName" => "Berkshire",
+    "localityName" => "Newbury",
+    "organizationName" => "My Company Ltd",
+    "commonName" => "Demo Cert",
+];
+$numberofdays = '365';
+
+mkdir(__DIR__ . "/bug50293");
+chdir(__DIR__ . "/bug50293");
+
+$privkey = openssl_pkey_new($ssl_configargs);
+$csr = openssl_csr_new($dn, $privkey, $ssl_configargs);
+$sscert = openssl_csr_sign($csr, null, $privkey, $numberofdays);
+openssl_csr_export($csr, $csrout);
+openssl_x509_export($sscert, $certout);
+openssl_x509_export_to_file($sscert , "bug50293.crt", false);
+openssl_pkey_export($privkey, $pkeyout);
+openssl_pkey_export_to_file($privkey, "bug50293.pem");
+
+var_dump(
+    file_exists("bug50293.crt"),
+    file_exists("bug50293.pem")
+);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/bug50293/bug50293.crt");
+@unlink(__DIR__ . "/bug50293/bug50293.pem");
+@rmdir(__DIR__ . "/bug50293");
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/openssl/tests/openssl_pkcs12_export_to_file_error.phpt
+++ b/ext/openssl/tests/openssl_pkcs12_export_to_file_error.phpt
@@ -33,5 +33,5 @@ bool(false)
 Warning: openssl_pkcs12_export_to_file(): private key does not correspond to cert in %s on line %d
 bool(false)
 
-Warning: openssl_pkcs12_export_to_file(): error opening file . in %s on line %d
+Warning: openssl_pkcs12_export_to_file(): error opening file %s in %s on line %d
 bool(false)

--- a/ext/openssl/tests/openssl_pkcs7_decrypt_basic.phpt
+++ b/ext/openssl/tests/openssl_pkcs7_decrypt_basic.phpt
@@ -54,7 +54,11 @@ bool(false)
 Warning: openssl_pkcs7_decrypt(): unable to coerce parameter 3 to x509 cert in %s on line %d
 bool(false)
 bool(false)
+
+Warning: openssl_pkcs7_decrypt(): Path '' not found in %s on line %d
 bool(false)
+
+Warning: openssl_pkcs7_decrypt(): Path '' not found in %s on line %d
 bool(false)
 
 Warning: openssl_pkcs7_decrypt(): unable to coerce parameter 3 to x509 cert in %s on line %d

--- a/ext/openssl/tests/openssl_pkcs7_encrypt_basic.phpt
+++ b/ext/openssl/tests/openssl_pkcs7_encrypt_basic.phpt
@@ -55,7 +55,11 @@ bool(true)
 Warning: openssl_pkcs7_encrypt() expects parameter 4 to be array, string given in %s on line %d
 bool(false)
 bool(false)
+
+Warning: openssl_pkcs7_encrypt(): Path '' not found in %s on line %d
 bool(false)
+
+Warning: openssl_pkcs7_encrypt(): Path '' not found in %s on line %d
 bool(false)
 bool(false)
 bool(false)

--- a/ext/openssl/tests/openssl_pkcs7_sign_basic.phpt
+++ b/ext/openssl/tests/openssl_pkcs7_sign_basic.phpt
@@ -47,11 +47,7 @@ NULL
 
 Warning: openssl_pkcs7_sign(): error opening input file %s in %s on line %d
 bool(false)
-
-Warning: openssl_pkcs7_sign(): error opening input file %s in %s on line %d
 bool(false)
-
-Warning: openssl_pkcs7_sign(): error opening output file %s in %s on line %d
 bool(false)
 
 Warning: openssl_pkcs7_sign(): error getting cert in %s on line %d

--- a/ext/openssl/tests/openssl_pkcs7_sign_basic.phpt
+++ b/ext/openssl/tests/openssl_pkcs7_sign_basic.phpt
@@ -47,7 +47,11 @@ NULL
 
 Warning: openssl_pkcs7_sign(): error opening input file %s in %s on line %d
 bool(false)
+
+Warning: openssl_pkcs7_sign(): Path '' not found in %s on line %d
 bool(false)
+
+Warning: openssl_pkcs7_sign(): Path '' not found in %s on line %d
 bool(false)
 
 Warning: openssl_pkcs7_sign(): error getting cert in %s on line %d

--- a/ext/openssl/tests/openssl_pkcs7_verify_basic.phpt
+++ b/ext/openssl/tests/openssl_pkcs7_verify_basic.phpt
@@ -45,6 +45,8 @@ unlink(__DIR__ . DIRECTORY_SEPARATOR . '/openssl_pkcs7_verify__pkcsfile.tmp');
 ?>
 --EXPECTF--
 int(-1)
+
+Warning: openssl_pkcs7_verify(): Path '' not found in %s on line %d
 int(-1)
 bool(false)
 bool(false)


### PR DESCRIPTION
For ZTS builds, we need to expand the paths given to various openssl
functions to properly support the VCWD.