### PR TITLE
Fix inconsistency in true/false/null constant resolution when opcache is not used

### DIFF
--- a/Zend/tests/eval_constant_resolution.phpt
+++ b/Zend/tests/eval_constant_resolution.phpt
@@ -1,0 +1,23 @@
+--TEST--
+eval() constant resolution
+--FILE--
+<?php
+namespace foo {
+define('foo\true', 'test');
+echo "In eval\n";
+eval('namespace foo { var_dump(true); var_dump(TrUe); var_dump(namespace\true); var_dump(\true); }');
+echo "Outside eval\n";
+var_dump(true); var_dump(TrUe); var_dump(namespace\true); var_dump(\true);
+}
+?>
+--EXPECT--
+In eval
+bool(true)
+bool(true)
+string(4) "test"
+bool(true)
+Outside eval
+bool(true)
+bool(true)
+string(4) "test"
+bool(true)

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1475,28 +1475,26 @@ static bool can_ct_eval_const(zend_constant *c) {
 
 static bool zend_try_ct_eval_const(zval *zv, zend_string *name, bool is_fully_qualified) /* {{{ */
 {
-	zend_constant *c = zend_hash_find_ptr(EG(zend_constants), name);
+	/* Substitute true, false and null (including unqualified usage in namespaces)
+	 * before looking up the possibly namespaced name. */
+	const char *lookup_name = ZSTR_VAL(name);
+	size_t lookup_len = ZSTR_LEN(name);
+
+	if (!is_fully_qualified) {
+		zend_get_unqualified_name(name, &lookup_name, &lookup_len);
+	}
+
+	zend_constant *c;
+	if ((c = zend_get_special_const(lookup_name, lookup_len))) {
+		ZVAL_COPY_VALUE(zv, &c->value);
+		return 1;
+	}
+	c = zend_hash_find_ptr(EG(zend_constants), name);
 	if (c && can_ct_eval_const(c)) {
 		ZVAL_COPY_OR_DUP(zv, &c->value);
 		return 1;
 	}
-
-	{
-		/* Substitute true, false and null (including unqualified usage in namespaces) */
-		const char *lookup_name = ZSTR_VAL(name);
-		size_t lookup_len = ZSTR_LEN(name);
-
-		if (!is_fully_qualified) {
-			zend_get_unqualified_name(name, &lookup_name, &lookup_len);
-		}
-
-		if ((c = zend_get_special_const(lookup_name, lookup_len))) {
-			ZVAL_COPY_VALUE(zv, &c->value);
-			return 1;
-		}
-
-		return 0;
-	}
+	return 0;
 }
 /* }}} */
 


### PR DESCRIPTION
~~Strangely, uses of eval and 'php -a' will not treat non-FQ true/false/null as magic
keywords, while compiled php required from a file would do that.~~

Currently, opcache assumes that the non-FQ true/false/null constant reference is safe to convert to the literal, even though it may also be defined in the same namespace. See https://github.com/php/php-src/blob/php-8.1.0beta3/Zend/Optimizer/block_pass.c#L32-L52

This may confuse people learning the language, and result in code loaded with
eval() behaving differently from the same snippet in a file loaded by require.

```
Interactive shell

php > define('foo\true', 'test');
php > namespace foo { var_dump(true); }
string(4) "test"
```

This PR will make the same session instead properly emit `bool(true);` like it already would if running those statements in files. (Interactive shell internally uses the same APIs eval uses)

- https://3v4l.org/ppBdV reproduces this (expected all lines to be `bool(true)`). I couldn't find related bugs in a quick search on bugs.php.net
- Earlier, I thought it was due to eval. But that doesn't seem to be the case (it also happens when there are multiple files), it's probably related to the constant not existing when the file is loaded.

zend_resolve_non_class_name is a static C function where case_sensitive is only true for global constants (and false for global functions).

This targets php 8.1 - I'm not certain if it makes sense to fix this in earlier versions as well, if anything using eval() somehow relies on this.

