### PR TITLE
Revert "more fiber notifications"

### DIFF
--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -345,15 +345,11 @@ ZEND_API bool zend_fiber_init_context(zend_fiber_context *context, void *kind, z
 	// Set status in case memory has not been zeroed.
 	context->status = ZEND_FIBER_STATUS_INIT;
 
-	zend_observer_fiber_init_notify(context);
-
 	return true;
 }
 
 ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context)
 {
-	zend_observer_fiber_destroy_notify(context);
-
 	zend_fiber_stack_free(context->stack);
 }
 

--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -40,9 +40,7 @@ typedef struct _zend_observer_fcall_data {
 
 zend_llist zend_observers_fcall_list;
 zend_llist zend_observer_error_callbacks;
-zend_llist zend_observer_fiber_init;
 zend_llist zend_observer_fiber_switch;
-zend_llist zend_observer_fiber_destroy;
 
 int zend_observer_fcall_op_array_extension = -1;
 
@@ -75,9 +73,7 @@ ZEND_API void zend_observer_fcall_register(zend_observer_fcall_init init) {
 ZEND_API void zend_observer_startup(void) {
 	zend_llist_init(&zend_observers_fcall_list, sizeof(zend_observer_fcall_init), NULL, 1);
 	zend_llist_init(&zend_observer_error_callbacks, sizeof(zend_observer_error_cb), NULL, 1);
-	zend_llist_init(&zend_observer_fiber_init, sizeof(zend_observer_fiber_init_handler), NULL, 1);
 	zend_llist_init(&zend_observer_fiber_switch, sizeof(zend_observer_fiber_switch_handler), NULL, 1);
-	zend_llist_init(&zend_observer_fiber_destroy, sizeof(zend_observer_fiber_destroy_handler), NULL, 1);
 }
 
 ZEND_API void zend_observer_activate(void) {
@@ -263,30 +259,9 @@ void zend_observer_error_notify(int type, zend_string *error_filename, uint32_t 
 	}
 }
 
-ZEND_API void zend_observer_fiber_init_register(zend_observer_fiber_init_handler handler)
-{
-	zend_llist_add_element(&zend_observer_fiber_init, &handler);
-}
-
 ZEND_API void zend_observer_fiber_switch_register(zend_observer_fiber_switch_handler handler)
 {
 	zend_llist_add_element(&zend_observer_fiber_switch, &handler);
-}
-
-ZEND_API void zend_observer_fiber_destroy_register(zend_observer_fiber_destroy_handler handler)
-{
-	zend_llist_add_element(&zend_observer_fiber_destroy, &handler);
-}
-
-ZEND_API void ZEND_FASTCALL zend_observer_fiber_init_notify(zend_fiber_context *initializing)
-{
-	zend_llist_element *element;
-	zend_observer_fiber_init_handler callback;
-
-	for (element = zend_observer_fiber_init.head; element; element = element->next) {
-		callback = *(zend_observer_fiber_init_handler *) element->data;
-		callback(initializing);
-	}
 }
 
 ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber_context *from, zend_fiber_context *to)
@@ -297,16 +272,5 @@ ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber_context
 	for (element = zend_observer_fiber_switch.head; element; element = element->next) {
 		callback = *(zend_observer_fiber_switch_handler *) element->data;
 		callback(from, to);
-	}
-}
-
-ZEND_API void ZEND_FASTCALL zend_observer_fiber_destroy_notify(zend_fiber_context *destroying)
-{
-	zend_llist_element *element;
-	zend_observer_fiber_destroy_handler callback;
-
-	for (element = zend_observer_fiber_destroy.head; element; element = element->next) {
-		callback = *(zend_observer_fiber_destroy_handler *) element->data;
-		callback(destroying);
 	}
 }

--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -78,17 +78,10 @@ typedef void (*zend_observer_error_cb)(int type, zend_string *error_filename, ui
 ZEND_API void zend_observer_error_register(zend_observer_error_cb callback);
 void zend_observer_error_notify(int type, zend_string *error_filename, uint32_t error_lineno, zend_string *message);
 
-typedef void (*zend_observer_fiber_init_handler)(zend_fiber_context *initializing);
 typedef void (*zend_observer_fiber_switch_handler)(zend_fiber_context *from, zend_fiber_context *to);
-typedef void (*zend_observer_fiber_destroy_handler)(zend_fiber_context *destroying);
 
-ZEND_API void zend_observer_fiber_init_register(zend_observer_fiber_init_handler handler);
 ZEND_API void zend_observer_fiber_switch_register(zend_observer_fiber_switch_handler handler);
-ZEND_API void zend_observer_fiber_destroy_register(zend_observer_fiber_destroy_handler handler);
-
-ZEND_API void ZEND_FASTCALL zend_observer_fiber_init_notify(zend_fiber_context *initializing);
 ZEND_API void ZEND_FASTCALL zend_observer_fiber_switch_notify(zend_fiber_context *from, zend_fiber_context *to);
-ZEND_API void ZEND_FASTCALL zend_observer_fiber_destroy_notify(zend_fiber_context *destroying);
 
 END_EXTERN_C()
 

--- a/ext/zend_test/observer.c
+++ b/ext/zend_test/observer.c
@@ -189,15 +189,15 @@ static zend_observer_fcall_handlers observer_fcall_init(zend_execute_data *execu
 	return (zend_observer_fcall_handlers){NULL, NULL};
 }
 
-static void fiber_init_observer(zend_fiber_context *initializing) {
-	if (ZT_G(observer_fiber_init)) {
-		php_printf("<!-- alloc: %p -->\n", initializing);
+static void fiber_init_observer(zend_fiber_context *from, zend_fiber_context *to) {
+	if (ZT_G(observer_fiber_init) && to->status == ZEND_FIBER_STATUS_INIT) {
+		php_printf("<!-- alloc: %p -->\n", to);
 	}
 }
 
-static void fiber_destroy_observer(zend_fiber_context *destroying) {
-	if (ZT_G(observer_fiber_destroy)) {
-		php_printf("<!-- destroy: %p -->\n", destroying);
+static void fiber_destroy_observer(zend_fiber_context *from, zend_fiber_context *to) {
+	if (ZT_G(observer_fiber_destroy) && from->status == ZEND_FIBER_STATUS_DEAD) {
+		php_printf("<!-- destroy: %p -->\n", from);
 	}
 }
 
@@ -283,11 +283,11 @@ void zend_test_observer_init(INIT_FUNC_ARGS)
 	}
 
 	if (ZT_G(observer_enabled)) {
-		zend_observer_fiber_init_register(fiber_init_observer);
+		zend_observer_fiber_switch_register(fiber_init_observer);
 		zend_observer_fiber_switch_register(fiber_address_observer);
 		zend_observer_fiber_switch_register(fiber_enter_observer);
 		zend_observer_fiber_switch_register(fiber_suspend_observer);
-		zend_observer_fiber_destroy_register(fiber_destroy_observer);
+		zend_observer_fiber_switch_register(fiber_destroy_observer);
 	}
 }
 


### PR DESCRIPTION
Sorry i just saw this change now, and I have not seen the context of the discussion about it for the time being.
I don’t think we need more notify API, the status should be checked instead.
Correct me if I am wrong.
This revert 848b5458 (#7293)