### PR TITLE
Simplify zend_forbid_dynamic_call()

### DIFF
--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -689,13 +689,13 @@ ZEND_API void zend_detach_symbol_table(zend_execute_data *execute_data);
 ZEND_API zend_result zend_set_local_var(zend_string *name, zval *value, bool force);
 ZEND_API zend_result zend_set_local_var_str(const char *name, size_t len, zval *value, bool force);
 
-static zend_always_inline zend_result zend_forbid_dynamic_call(const char *func_name)
+static zend_always_inline zend_result zend_forbid_dynamic_call(void)
 {
 	zend_execute_data *ex = EG(current_execute_data);
 	ZEND_ASSERT(ex != NULL && ex->func != NULL);
 
 	if (ZEND_CALL_INFO(ex) & ZEND_CALL_DYNAMIC) {
-		zend_throw_error(NULL, "Cannot call %s dynamically", func_name);
+		zend_throw_error(NULL, "Cannot call %s() dynamically", get_active_function_name());
 		return FAILURE;
 	}
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -157,7 +157,7 @@ ZEND_FUNCTION(func_num_args)
 		RETURN_THROWS();
 	}
 
-	if (zend_forbid_dynamic_call("func_num_args()") == FAILURE) {
+	if (zend_forbid_dynamic_call() == FAILURE) {
 		RETURN_LONG(-1);
 	}
 
@@ -188,7 +188,7 @@ ZEND_FUNCTION(func_get_arg)
 		RETURN_THROWS();
 	}
 
-	if (zend_forbid_dynamic_call("func_get_arg()") == FAILURE) {
+	if (zend_forbid_dynamic_call() == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -226,7 +226,7 @@ ZEND_FUNCTION(func_get_args)
 		RETURN_THROWS();
 	}
 
-	if (zend_forbid_dynamic_call("func_get_args()") == FAILURE) {
+	if (zend_forbid_dynamic_call() == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -1331,7 +1331,7 @@ ZEND_FUNCTION(get_defined_vars)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	if (zend_forbid_dynamic_call("get_defined_vars()") == FAILURE) {
+	if (zend_forbid_dynamic_call() == FAILURE) {
 		return;
 	}
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2407,7 +2407,7 @@ PHP_FUNCTION(extract)
 		}
 	}
 
-	if (zend_forbid_dynamic_call("extract()") == FAILURE) {
+	if (zend_forbid_dynamic_call() == FAILURE) {
 		return;
 	}
 
@@ -2523,7 +2523,7 @@ PHP_FUNCTION(compact)
 		Z_PARAM_VARIADIC('+', args, num_args)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (zend_forbid_dynamic_call("compact()") == FAILURE) {
+	if (zend_forbid_dynamic_call() == FAILURE) {
 		return;
 	}
 


### PR DESCRIPTION
When I encountered a related problem and git blame it, I caught this one...
The special case has been completely removed, I think we can simplify it now.