### PR TITLE
Simplify SSL_set_mode() calls

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1758,7 +1758,7 @@ int php_openssl_setup_crypto(php_stream *stream,
 	}
 
 #ifdef SSL_MODE_RELEASE_BUFFERS
-	SSL_set_mode(sslsock->ssl_handle, SSL_get_mode(sslsock->ssl_handle) | SSL_MODE_RELEASE_BUFFERS);
+	SSL_set_mode(sslsock->ssl_handle, SSL_MODE_RELEASE_BUFFERS);
 #endif
 
 	if (cparam->inputs.session) {
@@ -1861,14 +1861,7 @@ static int php_openssl_enable_crypto(php_stream *stream,
 			sslsock->s.is_blocked = 0;
 			/* The following mode are added only if we are able to change socket
 			 * to non blocking mode which is also used for read and write */
-			SSL_set_mode(
-				sslsock->ssl_handle,
-				(
-					SSL_get_mode(sslsock->ssl_handle) |
-					SSL_MODE_ENABLE_PARTIAL_WRITE |
-					SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER
-				)
-			);
+			SSL_set_mode(sslsock->ssl_handle, SSL_MODE_ENABLE_PARTIAL_WRITE | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 		}
 
 		timeout = sslsock->is_client ? &sslsock->connect_timeout : &sslsock->s.timeout;


### PR DESCRIPTION
SSL_set_mode() adds the mode set via bitmask in mode to ssl.