### PR TITLE
Restore old PDO::PARAM_* values

### DIFF
--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -35,15 +35,16 @@ struct pdo_bound_param_data;
 
 #define PDO_DRIVER_API	20170320
 
+/* Doctrine hardcodes these constants, avoid changing their values. */
 enum pdo_param_type {
-	PDO_PARAM_NULL,
-	PDO_PARAM_BOOL,
-	PDO_PARAM_INT,
-	PDO_PARAM_STR,
-	PDO_PARAM_LOB,
+	PDO_PARAM_NULL = 0,
+	PDO_PARAM_BOOL = 5,
+	PDO_PARAM_INT = 1,
+	PDO_PARAM_STR = 2,
+	PDO_PARAM_LOB = 3,
 
 	/* get_col: Not supported (yet?) */
-	PDO_PARAM_STMT, /* hierarchical result set */
+	PDO_PARAM_STMT = 4, /* hierarchical result set */
 
 	/* magic flag to denote a parameter as being input/output */
 	PDO_PARAM_INPUT_OUTPUT = 0x80000000,

--- a/ext/pdo/tests/debug_emulated_prepares.phpt
+++ b/ext/pdo/tests/debug_emulated_prepares.phpt
@@ -48,17 +48,17 @@ Key: Name: [5] :bool
 paramno=-1
 name=[5] ":bool"
 is_param=1
-param_type=1
+param_type=5
 Key: Name: [4] :int
 paramno=-1
 name=[4] ":int"
 is_param=1
-param_type=2
+param_type=1
 Key: Name: [7] :string
 paramno=-1
 name=[7] ":string"
 is_param=1
-param_type=3
+param_type=2
 Key: Name: [5] :null
 paramno=-1
 name=[5] ":null"

--- a/ext/pdo_dblib/tests/bug_45876.phpt
+++ b/ext/pdo_dblib/tests/bug_45876.phpt
@@ -32,7 +32,7 @@ array(10) {
   ["native_usertype_id"]=>
   int(%d)
   ["pdo_type"]=>
-  int(3)
+  int(2)
   ["name"]=>
   string(13) "TABLE_CATALOG"
   ["len"]=>

--- a/ext/pdo_dblib/tests/pdo_dblib_param_str_natl.phpt
+++ b/ext/pdo_dblib/tests/pdo_dblib_param_str_natl.phpt
@@ -24,5 +24,5 @@ Key: Name: [6] :value
 paramno=-1
 name=[6] ":value"
 is_param=1
-param_type=1073741827
+param_type=1073741826
 NULL

--- a/ext/pdo_pgsql/tests/bug62498.phpt
+++ b/ext/pdo_pgsql/tests/bug62498.phpt
@@ -59,7 +59,7 @@ array(9) {
     ["native_type"]=>
     string(4) "int2"
     ["pdo_type"]=>
-    int(2)
+    int(1)
     ["name"]=>
     string(7) "int2col"
     ["len"]=>
@@ -78,7 +78,7 @@ array(9) {
     ["native_type"]=>
     string(4) "int4"
     ["pdo_type"]=>
-    int(2)
+    int(1)
     ["name"]=>
     string(7) "int4col"
     ["len"]=>
@@ -97,7 +97,7 @@ array(9) {
     ["native_type"]=>
     string(4) "int8"
     ["pdo_type"]=>
-    int(2)
+    int(1)
     ["name"]=>
     string(7) "int8col"
     ["len"]=>
@@ -116,7 +116,7 @@ array(9) {
     ["native_type"]=>
     string(7) "varchar"
     ["pdo_type"]=>
-    int(3)
+    int(2)
     ["name"]=>
     string(9) "stringcol"
     ["len"]=>
@@ -135,7 +135,7 @@ array(9) {
     ["native_type"]=>
     string(4) "bool"
     ["pdo_type"]=>
-    int(1)
+    int(5)
     ["name"]=>
     string(7) "boolcol"
     ["len"]=>
@@ -154,7 +154,7 @@ array(9) {
     ["native_type"]=>
     string(4) "date"
     ["pdo_type"]=>
-    int(3)
+    int(2)
     ["name"]=>
     string(7) "datecol"
     ["len"]=>
@@ -173,7 +173,7 @@ array(9) {
     ["native_type"]=>
     string(4) "text"
     ["pdo_type"]=>
-    int(3)
+    int(2)
     ["name"]=>
     string(7) "textcol"
     ["len"]=>
@@ -192,7 +192,7 @@ array(9) {
     ["native_type"]=>
     string(9) "timestamp"
     ["pdo_type"]=>
-    int(3)
+    int(2)
     ["name"]=>
     string(5) "tscol"
     ["len"]=>
@@ -211,7 +211,7 @@ array(9) {
     ["native_type"]=>
     string(5) "bytea"
     ["pdo_type"]=>
-    int(4)
+    int(3)
     ["name"]=>
     string(8) "byteacol"
     ["len"]=>

--- a/ext/pdo_pgsql/tests/debug_emulated_prepares.phpt
+++ b/ext/pdo_pgsql/tests/debug_emulated_prepares.phpt
@@ -33,17 +33,17 @@ Key: Name: [5] :bool
 paramno=-1
 name=[5] ":bool"
 is_param=1
-param_type=3
+param_type=2
 Key: Name: [4] :int
 paramno=-1
 name=[4] ":int"
 is_param=1
-param_type=2
+param_type=1
 Key: Name: [7] :string
 paramno=-1
 name=[7] ":string"
 is_param=1
-param_type=3
+param_type=2
 Key: Name: [5] :null
 paramno=-1
 name=[5] ":null"

--- a/ext/pdo_sqlite/tests/debugdumpparams_001.phpt
+++ b/ext/pdo_sqlite/tests/debugdumpparams_001.phpt
@@ -21,15 +21,15 @@ Key: Name: [2] :a
 paramno=-1
 name=[2] ":a"
 is_param=1
-param_type=2
+param_type=1
 Key: Name: [2] :b
 paramno=-1
 name=[2] ":b"
 is_param=1
-param_type=3
+param_type=2
 Key: Position #2:
 paramno=2
 name=[0] ""
 is_param=1
-param_type=3
+param_type=2
 NULL


### PR DESCRIPTION
Doctrine hardcodes the values of these constants, avoid changing
them.

Fixes https://bugs.php.net/bug.php?id=81405.