### PR TITLE
Fix #81407: shmop_open won't attach and causes php to crash

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -611,16 +611,19 @@ TSRM_API int pclose(FILE *stream)
 	return termstat;
 }/*}}}*/
 
+#define SEGMENT_PREFIX "TSRM_SHM_SEGMENT:"
+#define DESCRIPTOR_PREFIX "TSRM_SHM_DESCRIPTOR:"
+
 TSRM_API int shmget(key_t key, size_t size, int flags)
 {/*{{{*/
 	shm_pair *shm;
-	char shm_segment[26], shm_info[29];
+	char shm_segment[sizeof(SEGMENT_PREFIX "4294967295")], shm_info[sizeof(DESCRIPTOR_PREFIX "4294967295")];
 	HANDLE shm_handle = NULL, info_handle = NULL;
 	BOOL created = FALSE;
 
 	if (key != IPC_PRIVATE) {
-		snprintf(shm_segment, sizeof(shm_segment), "TSRM_SHM_SEGMENT:%d", key);
-		snprintf(shm_info, sizeof(shm_info), "TSRM_SHM_DESCRIPTOR:%d", key);
+		snprintf(shm_segment, sizeof(shm_segment), SEGMENT_PREFIX "%d", key);
+		snprintf(shm_info, sizeof(shm_info), DESCRIPTOR_PREFIX "%d", key);
 
 		shm_handle  = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, shm_segment);
 		info_handle = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, shm_info);

--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -613,11 +613,12 @@ TSRM_API int pclose(FILE *stream)
 
 #define SEGMENT_PREFIX "TSRM_SHM_SEGMENT:"
 #define DESCRIPTOR_PREFIX "TSRM_SHM_DESCRIPTOR:"
+#define INT_MIN_AS_STRING "-2147483648"
 
 TSRM_API int shmget(key_t key, size_t size, int flags)
 {/*{{{*/
 	shm_pair *shm;
-	char shm_segment[sizeof(SEGMENT_PREFIX "4294967295")], shm_info[sizeof(DESCRIPTOR_PREFIX "4294967295")];
+	char shm_segment[sizeof(SEGMENT_PREFIX INT_MIN_AS_STRING)], shm_info[sizeof(DESCRIPTOR_PREFIX INT_MIN_AS_STRING)];
 	HANDLE shm_handle = NULL, info_handle = NULL;
 	BOOL created = FALSE;
 

--- a/ext/shmop/tests/bug81407.phpt
+++ b/ext/shmop/tests/bug81407.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #81407 (shmop_open won't attach and causes php to crash)
+--SKIPIF--
+<?php
+if (!extension_loaded("shmop")) die("skip shmop extension not available");
+?>
+--FILE--
+<?php
+$a = shmop_open(367504384, 'n', 0664, 262144);
+$b = shmop_open(367504385, 'n', 0664, 65536);
+if ($b == false) {
+	$b = shmop_open(367504385, 'w', 0664, 65536);
+}
+var_dump($a !== false, $b !== false);
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/shmop/tests/bug81407.phpt
+++ b/ext/shmop/tests/bug81407.phpt
@@ -2,6 +2,7 @@
 Bug #81407 (shmop_open won't attach and causes php to crash)
 --SKIPIF--
 <?php
+if (PHP_OS_FAMILY !== "Windows") die("skip for Windows only");
 if (!extension_loaded("shmop")) die("skip shmop extension not available");
 ?>
 --FILE--


### PR DESCRIPTION
We need to allocate buffers for the file mapping names which are large
enough for all potential keys (`key_t` is defined as `int` on Windows).

---

A cleaner solution would be to print the keys as hexadecimal numbers, and to use `2*sizeof(key_t)` to get its size. Not sure if anybody relies on the decimal keys; maybe better change that for "master" only?

And we may want to avoid the (likely harmless) integer overflow which currently may happen.