### PR TITLE
Fully qualify ReturnTypeWillChange in deprecation message

### DIFF
--- a/Zend/tests/deprecation_to_exception_during_inheritance.phpt
+++ b/Zend/tests/deprecation_to_exception_during_inheritance.phpt
@@ -17,7 +17,7 @@ $class = new class extends DateTime {
 
 ?>
 --EXPECTF--
-Fatal error: During inheritance of DateTime: Uncaught Exception: Return type of DateTime@anonymous::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s:%d
+Fatal error: During inheritance of DateTime: Uncaught Exception: Return type of DateTime@anonymous::getTimezone() should either be compatible with DateTime::getTimezone(): DateTimeZone|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s:%d
 Stack trace:
 #0 %s(%d): {closure}(8192, 'Return type of ...', '%s', 8)
 #1 {main} in %s on line %d

--- a/Zend/tests/tentative_type_early_binding.phpt
+++ b/Zend/tests/tentative_type_early_binding.phpt
@@ -8,6 +8,6 @@ class Test extends SplObjectStorage {
 }
 ?>
 --EXPECTF--
-Deprecated: Return type of Test::valid() should either be compatible with SplObjectStorage::valid(): bool, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s on line %d
+Deprecated: Return type of Test::valid() should either be compatible with SplObjectStorage::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s on line %d
 
 Fatal error: Could not check compatibility between Test::current(): Unknown and SplObjectStorage::current(): object, because class Unknown is not available in %s on line %d

--- a/Zend/tests/type_declarations/variance/internal_parent/incompatible_return_type.phpt
+++ b/Zend/tests/type_declarations/variance/internal_parent/incompatible_return_type.phpt
@@ -13,5 +13,5 @@ class MyDateTimeZone extends DateTimeZone
 var_dump(MyDateTimeZone::listIdentifiers());
 ?>
 --EXPECTF--
-Deprecated: Return type of MyDateTimeZone::listIdentifiers(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null): string should either be compatible with DateTimeZone::listIdentifiers(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null): array, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s on line %d
+Deprecated: Return type of MyDateTimeZone::listIdentifiers(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null): string should either be compatible with DateTimeZone::listIdentifiers(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null): array, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s on line %d
 string(0) ""

--- a/Zend/tests/type_declarations/variance/internal_parent/missing_return_type.phpt
+++ b/Zend/tests/type_declarations/variance/internal_parent/missing_return_type.phpt
@@ -10,4 +10,4 @@ class MyDateTimeZone extends DateTimeZone
 }
 ?>
 --EXPECTF--
-Deprecated: Return type of MyDateTimeZone::listIdentifiers(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null) should either be compatible with DateTimeZone::listIdentifiers(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null): array, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s on line %d
+Deprecated: Return type of MyDateTimeZone::listIdentifiers(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null) should either be compatible with DateTimeZone::listIdentifiers(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null): array, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -997,7 +997,7 @@ static void ZEND_COLD emit_incompatible_method_error(
 		if (!return_type_will_change_attribute) {
 			zend_error_at(E_DEPRECATED, func_filename(child), func_lineno(child),
 				"Return type of %s should either be compatible with %s, "
-				"or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice",
+				"or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice",
 				ZSTR_VAL(child_prototype), ZSTR_VAL(parent_prototype));
 			if (EG(exception)) {
 				zend_exception_uncaught_error(


### PR DESCRIPTION
When adding the `#[ReturnTypeWillChange]` attribute in namespaced code, you also need to `use ReturnTypeWillChange`, otherwise it will be silently ignored and may result in confusion. Change the deprecation message to suggest `#[\ReturnTypeWillChange]`, which will always work.