### PR TITLE
Remove mysqli_close that prevented CLEAN from running properly

### DIFF
--- a/ext/mysqli/tests/clean_table.inc
+++ b/ext/mysqli/tests/clean_table.inc
@@ -9,6 +9,3 @@ if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 if (!mysqli_query($link, 'DROP TABLE IF EXISTS test')) {
     printf("[clean] Failed to drop old test table: [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 }
-
-mysqli_close($link);
-?>


### PR DESCRIPTION
It is a bad practice to close mysqli object manually as it leads to bugs like this. The CLEAN section in many files expected the connection to be still open when cleaning up stuff in the database. 