### PR TITLE
Don't overwrite unwind exception

### DIFF
--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -175,6 +175,12 @@ ZEND_API ZEND_COLD void zend_throw_exception_internal(zend_object *exception) /*
 
 	if (exception != NULL) {
 		zend_object *previous = EG(exception);
+		if (previous && zend_is_unwind_exit(previous)) {
+			/* Don't replace unwinding exception with different exception. */
+			OBJ_RELEASE(exception);
+			return;
+		}
+
 		zend_exception_set_previous(exception, EG(exception));
 		EG(exception) = exception;
 		if (previous) {


### PR DESCRIPTION
This has been suggested by @twose. When killing a coroutine by throwing an unwind exit into it during an I/O operation, the I/O failure may result in an exception being thrown, which will replace the unwind exit exception and the coroutine will ultimately not exit. This patch avoids this by ignoring the newly thrown exception and keeping the unwind exit exception.