### PR TITLE
Implement properties for DateTime object

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2115,9 +2115,7 @@ static HashTable *date_object_get_properties(zend_object *object) /* {{{ */
 	PHP_DATE_OBJECT_ADD_PROPERTY("hour", h);
 	PHP_DATE_OBJECT_ADD_PROPERTY("minute", i);
 	PHP_DATE_OBJECT_ADD_PROPERTY("second", s);
-	
-	ZVAL_STR(&zv, date_format("P", sizeof("P")-1, obj->time, 1));
-	zend_hash_str_update(props, "timezone", sizeof("timezone") - 1, &zv);
+	PHP_DATE_OBJECT_ADD_PROPERTY("microsecond", us);
 
 	return props;
 } /* }}} */
@@ -3823,9 +3821,6 @@ static zval *date_object_read_property(zend_object *object, zend_string *name, i
 {
 	php_date_obj *obj;
 	zval *retval;
-	// timelib_sll value = -1;
-
-	// ZVAL_NULL(retval);
 
 	obj = php_date_obj_from_obj(object);
 
@@ -3843,9 +3838,8 @@ static zval *date_object_read_property(zend_object *object, zend_string *name, i
 		ZVAL_LONG(retval, obj->time->i);
 	} else if (zend_string_equals_literal(name, "second")) {
 		ZVAL_LONG(retval, obj->time->s);
-	} else if (zend_string_equals_literal(name, "timezone")) {
-		zend_string *buf = date_format("P", sizeof("P")-1, obj->time, 1);
-		ZVAL_STR(retval, buf);
+	} else if (zend_string_equals_literal(name, "microsecond")) {
+		ZVAL_LONG(retval, obj->time->us);
 	} else {
 		retval = zend_std_read_property(object, name, type, cache_slot, rv);
 		return retval;

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -215,7 +215,7 @@ class DateTime implements DateTimeInterface
     public int $hour;
     public int $minute;
     public int $second;
-    public string $timezone;
+    public int $microsecond;
 
     public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null) {}
 

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -209,6 +209,14 @@ interface DateTimeInterface
 
 class DateTime implements DateTimeInterface
 {
+    public int $year;
+    public int $month;
+    public int $day;
+    public int $hour;
+    public int $minute;
+    public int $second;
+    public string $timezone;
+
     public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null) {}
 
     /** @tentative-return-type */

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 309c82089d655b81b8ed186ee080b32170a46892 */
+ * Stub hash: c3c07b41e9c9919e8d1e99cb75b1785fc3378ee6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -755,11 +755,11 @@ static zend_class_entry *register_class_DateTime(zend_class_entry *class_entry_D
 	zend_declare_typed_property(class_entry, property_second_name, &property_second_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_second_name);
 
-	zval property_timezone_default_value;
-	ZVAL_UNDEF(&property_timezone_default_value);
-	zend_string *property_timezone_name = zend_string_init("timezone", sizeof("timezone") - 1, 1);
-	zend_declare_typed_property(class_entry, property_timezone_name, &property_timezone_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_timezone_name);
+	zval property_microsecond_default_value;
+	ZVAL_UNDEF(&property_microsecond_default_value);
+	zend_string *property_microsecond_name = zend_string_init("microsecond", sizeof("microsecond") - 1, 1);
+	zend_declare_typed_property(class_entry, property_microsecond_name, &property_microsecond_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_microsecond_name);
 
 	return class_entry;
 }

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e4585948a8767182f38b553b603e06555e92c372 */
+ * Stub hash: 309c82089d655b81b8ed186ee080b32170a46892 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -718,6 +718,48 @@ static zend_class_entry *register_class_DateTime(zend_class_entry *class_entry_D
 	INIT_CLASS_ENTRY(ce, "DateTime", class_DateTime_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	zend_class_implements(class_entry, 1, class_entry_DateTimeInterface);
+
+	zval property_year_default_value;
+	ZVAL_UNDEF(&property_year_default_value);
+	zend_string *property_year_name = zend_string_init("year", sizeof("year") - 1, 1);
+	zend_declare_typed_property(class_entry, property_year_name, &property_year_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_year_name);
+
+	zval property_month_default_value;
+	ZVAL_UNDEF(&property_month_default_value);
+	zend_string *property_month_name = zend_string_init("month", sizeof("month") - 1, 1);
+	zend_declare_typed_property(class_entry, property_month_name, &property_month_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_month_name);
+
+	zval property_day_default_value;
+	ZVAL_UNDEF(&property_day_default_value);
+	zend_string *property_day_name = zend_string_init("day", sizeof("day") - 1, 1);
+	zend_declare_typed_property(class_entry, property_day_name, &property_day_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_day_name);
+
+	zval property_hour_default_value;
+	ZVAL_UNDEF(&property_hour_default_value);
+	zend_string *property_hour_name = zend_string_init("hour", sizeof("hour") - 1, 1);
+	zend_declare_typed_property(class_entry, property_hour_name, &property_hour_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_hour_name);
+
+	zval property_minute_default_value;
+	ZVAL_UNDEF(&property_minute_default_value);
+	zend_string *property_minute_name = zend_string_init("minute", sizeof("minute") - 1, 1);
+	zend_declare_typed_property(class_entry, property_minute_name, &property_minute_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_minute_name);
+
+	zval property_second_default_value;
+	ZVAL_UNDEF(&property_second_default_value);
+	zend_string *property_second_name = zend_string_init("second", sizeof("second") - 1, 1);
+	zend_declare_typed_property(class_entry, property_second_name, &property_second_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_second_name);
+
+	zval property_timezone_default_value;
+	ZVAL_UNDEF(&property_timezone_default_value);
+	zend_string *property_timezone_name = zend_string_init("timezone", sizeof("timezone") - 1, 1);
+	zend_declare_typed_property(class_entry, property_timezone_name, &property_timezone_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_timezone_name);
 
 	return class_entry;
 }

--- a/ext/date/tests/DateTime_properties.phpt
+++ b/ext/date/tests/DateTime_properties.phpt
@@ -5,7 +5,7 @@ Properties of DateTime class
 
 var_dump(get_class_vars(DateTime::class));
 
-$datetime = new DateTime('2000-01-02 03:04:05Z');
+$datetime = new DateTime('2000-01-02 03:04:05.100000Z');
 var_dump(get_object_vars($datetime));
 
 assert(isset(
@@ -15,8 +15,12 @@ assert(isset(
     $datetime->hour,
     $datetime->minute,
     $datetime->second,
-    $datetime->timezone,
+    $datetime->microsecond,
 ));
+
+
+$neg_datetime = new DateTime('-2000-01-02 03:04:05.100000Z');
+var_dump($neg_datetime->year);
 
 ?>
 --EXPECT--
@@ -33,7 +37,7 @@ array(7) {
   NULL
   ["second"]=>
   NULL
-  ["timezone"]=>
+  ["microsecond"]=>
   NULL
 }
 array(7) {
@@ -49,6 +53,7 @@ array(7) {
   int(4)
   ["second"]=>
   int(5)
-  ["timezone"]=>
-  string(3) "+00:00"
+  ["microsecond"]=>
+  int(100000)
 }
+int(-2000)

--- a/ext/date/tests/DateTime_properties.phpt
+++ b/ext/date/tests/DateTime_properties.phpt
@@ -8,6 +8,18 @@ var_dump(get_class_vars(DateTime::class));
 $datetime = new DateTime('2000-01-02 03:04:05.100000Z');
 var_dump(get_object_vars($datetime));
 
+echo "\nvar_dump\n";
+var_dump($datetime);
+
+echo "\nprint_r\n";
+print_r($datetime);
+
+echo "\nvar_export\n";
+var_export($datetime);
+
+echo "\nArray Cast\n";
+var_dump((array) $datetime);
+
 assert(isset(
     $datetime->year,
     $datetime->month,
@@ -55,5 +67,74 @@ array(7) {
   int(5)
   ["microsecond"]=>
   int(100000)
+}
+
+var_dump
+object(DateTime)#1 (10) {
+  ["year"]=>
+  int(2000)
+  ["month"]=>
+  int(1)
+  ["day"]=>
+  int(2)
+  ["hour"]=>
+  int(3)
+  ["minute"]=>
+  int(4)
+  ["second"]=>
+  int(5)
+  ["microsecond"]=>
+  int(100000)
+  ["date"]=>
+  string(26) "2000-01-02 03:04:05.100000"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(1) "Z"
+}
+
+print_r
+DateTime Object
+(
+    [year] => 2000
+    [month] => 1
+    [day] => 2
+    [hour] => 3
+    [minute] => 4
+    [second] => 5
+    [microsecond] => 100000
+    [date] => 2000-01-02 03:04:05.100000
+    [timezone_type] => 2
+    [timezone] => Z
+)
+
+var_export
+DateTime::__set_state(array(
+   'date' => '2000-01-02 03:04:05.100000',
+   'timezone_type' => 2,
+   'timezone' => 'Z',
+))
+Array Cast
+array(10) {
+  ["year"]=>
+  int(2000)
+  ["month"]=>
+  int(1)
+  ["day"]=>
+  int(2)
+  ["hour"]=>
+  int(3)
+  ["minute"]=>
+  int(4)
+  ["second"]=>
+  int(5)
+  ["microsecond"]=>
+  int(100000)
+  ["date"]=>
+  string(26) "2000-01-02 03:04:05.100000"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(1) "Z"
 }
 int(-2000)

--- a/ext/date/tests/DateTime_properties.phpt
+++ b/ext/date/tests/DateTime_properties.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Properties of DateTime class
+--FILE--
+<?php
+
+var_dump(get_class_vars(DateTime::class));
+
+$datetime = new DateTime('2000-01-02 03:04:05Z');
+var_dump(get_object_vars($datetime));
+
+assert(isset(
+    $datetime->year,
+    $datetime->month,
+    $datetime->day,
+    $datetime->hour,
+    $datetime->minute,
+    $datetime->second,
+    $datetime->timezone,
+));
+
+?>
+--EXPECT--
+array(7) {
+  ["year"]=>
+  NULL
+  ["month"]=>
+  NULL
+  ["day"]=>
+  NULL
+  ["hour"]=>
+  NULL
+  ["minute"]=>
+  NULL
+  ["second"]=>
+  NULL
+  ["timezone"]=>
+  NULL
+}
+array(7) {
+  ["year"]=>
+  int(2000)
+  ["month"]=>
+  int(1)
+  ["day"]=>
+  int(2)
+  ["hour"]=>
+  int(3)
+  ["minute"]=>
+  int(4)
+  ["second"]=>
+  int(5)
+  ["timezone"]=>
+  string(3) "+00:00"
+}

--- a/ext/date/tests/DateTime_properties2.phpt
+++ b/ext/date/tests/DateTime_properties2.phpt
@@ -28,6 +28,12 @@ assert($datetime->microsecond === 7);
 
 var_dump($datetime);
 
+$datetime->second = 61;
+assert($datetime->second === 1 && $datetime->minute === 6);
+
+$datetime->second = '61'; // will cast to integer
+assert($datetime->second === 1 && $datetime->minute === 7);
+
 ?>
 --EXPECT--
 object(DateTime)#1 (10) {

--- a/ext/date/tests/DateTime_properties2.phpt
+++ b/ext/date/tests/DateTime_properties2.phpt
@@ -1,0 +1,47 @@
+--TEST--
+DateTime: Test cannot modify read only properties
+--FILE--
+<?php
+
+$period = new DateTime();
+
+$properties = [
+    "year",
+    "month",
+    "day",
+    "hour",
+    "minute",
+    "second",
+    "microsecond",
+];
+
+foreach ($properties as $property) {
+    try {
+        $period->$property = "new";
+    } catch (Error $e) {
+        echo $e->getMessage() . "\n";
+    }
+
+    try {
+        $period->$property[] = "extra";
+    } catch (Error $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+?>
+--EXPECT--
+Writing to DateTime->year is unsupported
+Retrieval of DateTime->year for modification is unsupported
+Writing to DateTime->month is unsupported
+Retrieval of DateTime->month for modification is unsupported
+Writing to DateTime->day is unsupported
+Retrieval of DateTime->day for modification is unsupported
+Writing to DateTime->hour is unsupported
+Retrieval of DateTime->hour for modification is unsupported
+Writing to DateTime->minute is unsupported
+Retrieval of DateTime->minute for modification is unsupported
+Writing to DateTime->second is unsupported
+Retrieval of DateTime->second for modification is unsupported
+Writing to DateTime->microsecond is unsupported
+Retrieval of DateTime->microsecond for modification is unsupported

--- a/ext/date/tests/DateTime_properties2.phpt
+++ b/ext/date/tests/DateTime_properties2.phpt
@@ -1,47 +1,54 @@
 --TEST--
-DateTime: Test cannot modify read only properties
+DateTime: Test modify properties
 --FILE--
 <?php
 
-$period = new DateTime();
+$datetime = new DateTime('2000-01-02 03:04:05.100000Z');
 
-$properties = [
-    "year",
-    "month",
-    "day",
-    "hour",
-    "minute",
-    "second",
-    "microsecond",
-];
+$datetime->year = 2001;
+assert($datetime->year === 2001);
 
-foreach ($properties as $property) {
-    try {
-        $period->$property = "new";
-    } catch (Error $e) {
-        echo $e->getMessage() . "\n";
-    }
+$datetime->month = 2;
+assert($datetime->month === 2);
 
-    try {
-        $period->$property[] = "extra";
-    } catch (Error $e) {
-        echo $e->getMessage() . "\n";
-    }
-}
+$datetime->day = 3;
+assert($datetime->day === 3);
+
+$datetime->hour = 4;
+assert($datetime->hour === 4);
+
+$datetime->minute = 5;
+assert($datetime->minute === 5);
+
+$datetime->second = 6;
+assert($datetime->second === 6);
+
+$datetime->microsecond = 7;
+assert($datetime->microsecond === 7);
+
+var_dump($datetime);
 
 ?>
 --EXPECT--
-Writing to DateTime->year is unsupported
-Retrieval of DateTime->year for modification is unsupported
-Writing to DateTime->month is unsupported
-Retrieval of DateTime->month for modification is unsupported
-Writing to DateTime->day is unsupported
-Retrieval of DateTime->day for modification is unsupported
-Writing to DateTime->hour is unsupported
-Retrieval of DateTime->hour for modification is unsupported
-Writing to DateTime->minute is unsupported
-Retrieval of DateTime->minute for modification is unsupported
-Writing to DateTime->second is unsupported
-Retrieval of DateTime->second for modification is unsupported
-Writing to DateTime->microsecond is unsupported
-Retrieval of DateTime->microsecond for modification is unsupported
+object(DateTime)#1 (10) {
+  ["year"]=>
+  int(2001)
+  ["month"]=>
+  int(2)
+  ["day"]=>
+  int(3)
+  ["hour"]=>
+  int(4)
+  ["minute"]=>
+  int(5)
+  ["second"]=>
+  int(6)
+  ["microsecond"]=>
+  int(7)
+  ["date"]=>
+  string(26) "2001-02-03 04:05:06.000007"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(1) "Z"
+}


### PR DESCRIPTION
PHP is becoming a type safe object more and more. However, there is no way to get separate components of `DateTime` class in a type safe manner. The only viable way is to use `format()` method and then type cast the result. To get the hour, one would have to do:
```
$dt = new DateTime();
$hour = (int) $dt->format('H');
```
I am proposing to add typed properties to `DateTime`, `DateTimeImmutable` and `DateTimeInterface` classes. They will allow users to get the separate components without type casting. 

To Do:

- [ ] Finish implementation
- [x] Add microseconds
- [x] Improve test case