### PR TITLE
Support compile_string passing parsing state

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -80,7 +80,7 @@ static inline uint32_t zend_alloc_cache_slot(void) {
 }
 
 ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, bool skip_initial);
+ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, bool begin_initial);
 
 #ifndef ZTS
 ZEND_API zend_compiler_globals compiler_globals;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -80,7 +80,7 @@ static inline uint32_t zend_alloc_cache_slot(void) {
 }
 
 ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, bool begin_initial);
+ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state);
 
 #ifndef ZTS
 ZEND_API zend_compiler_globals compiler_globals;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -80,7 +80,7 @@ static inline uint32_t zend_alloc_cache_slot(void) {
 }
 
 ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename);
+ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, bool skip_initial);
 
 #ifndef ZTS
 ZEND_API zend_compiler_globals compiler_globals;
@@ -375,7 +375,6 @@ void zend_init_compiler_data_structures(void) /* {{{ */
 	CG(active_class_entry) = NULL;
 	CG(in_compilation) = 0;
 	CG(skip_shebang) = 0;
-	CG(skip_initial) = 0;
 
 	CG(encoding_declared) = 0;
 	CG(memoized_exprs) = NULL;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -80,7 +80,7 @@ static inline uint32_t zend_alloc_cache_slot(void) {
 }
 
 ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state);
+ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, zend_compile_position position);
 
 #ifndef ZTS
 ZEND_API zend_compiler_globals compiler_globals;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -375,6 +375,7 @@ void zend_init_compiler_data_structures(void) /* {{{ */
 	CG(active_class_entry) = NULL;
 	CG(in_compilation) = 0;
 	CG(skip_shebang) = 0;
+	CG(skip_initial) = 0;
 
 	CG(encoding_declared) = 0;
 	CG(memoized_exprs) = NULL;

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -755,7 +755,7 @@ void zend_file_context_begin(zend_file_context *prev_context);
 void zend_file_context_end(zend_file_context *prev_context);
 
 extern ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, bool skip_initial);
+extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, bool begin_initial);
 
 ZEND_API int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem);
 void startup_scanner(void);
@@ -810,7 +810,7 @@ zend_string *zval_make_interned_string(zval *zv);
 struct _zend_arena;
 
 ZEND_API zend_op_array *compile_file(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, bool skip_initial);
+ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, bool begin_initial);
 ZEND_API zend_op_array *compile_filename(int type, zend_string *filename);
 ZEND_API zend_ast *zend_compile_string_to_ast(
 		zend_string *code, struct _zend_arena **ast_arena, zend_string *filename);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -743,11 +743,11 @@ struct _zend_execute_data {
 
 #include "zend_globals.h"
 
-typedef enum _zend_lex_begin_state {
-	ZEND_LEX_BEGIN_STATE_SHEBANG = 0,
-	ZEND_LEX_BEGIN_STATE_INITIAL,
-	ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING
-} zend_lex_begin_state;
+typedef enum _zend_compile_position {
+	ZEND_COMPILE_POSITION_AT_SHEBANG = 0,
+	ZEND_COMPILE_POSITION_AT_OPEN_TAG,
+	ZEND_COMPILE_POSITION_AFTER_OPEN_TAG
+} zend_compile_position;
 
 BEGIN_EXTERN_C()
 
@@ -761,7 +761,7 @@ void zend_file_context_begin(zend_file_context *prev_context);
 void zend_file_context_end(zend_file_context *prev_context);
 
 extern ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state);
+extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, zend_compile_position begin_state);
 
 ZEND_API int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem);
 void startup_scanner(void);
@@ -816,7 +816,7 @@ zend_string *zval_make_interned_string(zval *zv);
 struct _zend_arena;
 
 ZEND_API zend_op_array *compile_file(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state);
+ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, zend_compile_position begin_state);
 ZEND_API zend_op_array *compile_filename(int type, zend_string *filename);
 ZEND_API zend_ast *zend_compile_string_to_ast(
 		zend_string *code, struct _zend_arena **ast_arena, zend_string *filename);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -743,6 +743,12 @@ struct _zend_execute_data {
 
 #include "zend_globals.h"
 
+typedef enum _zend_lex_begin_state {
+	ZEND_LEX_BEGIN_STATE_SHEBANG = 0,
+	ZEND_LEX_BEGIN_STATE_INITIAL,
+	ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING
+} zend_lex_begin_state;
+
 BEGIN_EXTERN_C()
 
 void init_compiler(void);
@@ -755,7 +761,7 @@ void zend_file_context_begin(zend_file_context *prev_context);
 void zend_file_context_end(zend_file_context *prev_context);
 
 extern ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, bool begin_initial);
+extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state);
 
 ZEND_API int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem);
 void startup_scanner(void);
@@ -810,7 +816,7 @@ zend_string *zval_make_interned_string(zval *zv);
 struct _zend_arena;
 
 ZEND_API zend_op_array *compile_file(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, bool begin_initial);
+ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state);
 ZEND_API zend_op_array *compile_filename(int type, zend_string *filename);
 ZEND_API zend_ast *zend_compile_string_to_ast(
 		zend_string *code, struct _zend_arena **ast_arena, zend_string *filename);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -761,7 +761,7 @@ void zend_file_context_begin(zend_file_context *prev_context);
 void zend_file_context_end(zend_file_context *prev_context);
 
 extern ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, zend_compile_position begin_state);
+extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, zend_compile_position position);
 
 ZEND_API int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem);
 void startup_scanner(void);
@@ -816,7 +816,7 @@ zend_string *zval_make_interned_string(zval *zv);
 struct _zend_arena;
 
 ZEND_API zend_op_array *compile_file(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, zend_compile_position begin_state);
+ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, zend_compile_position position);
 ZEND_API zend_op_array *compile_filename(int type, zend_string *filename);
 ZEND_API zend_ast *zend_compile_string_to_ast(
 		zend_string *code, struct _zend_arena **ast_arena, zend_string *filename);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -755,7 +755,7 @@ void zend_file_context_begin(zend_file_context *prev_context);
 void zend_file_context_end(zend_file_context *prev_context);
 
 extern ZEND_API zend_op_array *(*zend_compile_file)(zend_file_handle *file_handle, int type);
-extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename);
+extern ZEND_API zend_op_array *(*zend_compile_string)(zend_string *source_string, const char *filename, bool skip_initial);
 
 ZEND_API int ZEND_FASTCALL lex_scan(zval *zendlval, zend_parser_stack_elem *elem);
 void startup_scanner(void);
@@ -810,7 +810,7 @@ zend_string *zval_make_interned_string(zval *zv);
 struct _zend_arena;
 
 ZEND_API zend_op_array *compile_file(zend_file_handle *file_handle, int type);
-ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename);
+ZEND_API zend_op_array *compile_string(zend_string *source_string, const char *filename, bool skip_initial);
 ZEND_API zend_op_array *compile_filename(int type, zend_string *filename);
 ZEND_API zend_ast *zend_compile_string_to_ast(
 		zend_string *code, struct _zend_arena **ast_arena, zend_string *filename);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4394,7 +4394,7 @@ static zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval 
 			break;
 		case ZEND_EVAL: {
 				char *eval_desc = zend_make_compiled_string_description("eval()'d code");
-				new_op_array = zend_compile_string(inc_filename, eval_desc);
+				new_op_array = zend_compile_string(inc_filename, eval_desc, 0);
 				efree(eval_desc);
 			}
 			break;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4394,7 +4394,7 @@ static zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval 
 			break;
 		case ZEND_EVAL: {
 				char *eval_desc = zend_make_compiled_string_description("eval()'d code");
-				new_op_array = zend_compile_string(inc_filename, eval_desc, 0);
+				new_op_array = zend_compile_string(inc_filename, eval_desc, ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
 				efree(eval_desc);
 			}
 			break;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -4394,7 +4394,7 @@ static zend_never_inline zend_op_array* ZEND_FASTCALL zend_include_or_eval(zval 
 			break;
 		case ZEND_EVAL: {
 				char *eval_desc = zend_make_compiled_string_description("eval()'d code");
-				new_op_array = zend_compile_string(inc_filename, eval_desc, ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
+				new_op_array = zend_compile_string(inc_filename, eval_desc, ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 				efree(eval_desc);
 			}
 			break;

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1223,7 +1223,7 @@ ZEND_API zend_result zend_eval_stringl(const char *str, size_t str_len, zval *re
 
 	original_compiler_options = CG(compiler_options);
 	CG(compiler_options) = ZEND_COMPILE_DEFAULT_FOR_EVAL;
-	new_op_array = zend_compile_string(code_str, string_name);
+	new_op_array = zend_compile_string(code_str, string_name, 0);
 	CG(compiler_options) = original_compiler_options;
 
 	if (new_op_array) {

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1223,7 +1223,7 @@ ZEND_API zend_result zend_eval_stringl(const char *str, size_t str_len, zval *re
 
 	original_compiler_options = CG(compiler_options);
 	CG(compiler_options) = ZEND_COMPILE_DEFAULT_FOR_EVAL;
-	new_op_array = zend_compile_string(code_str, string_name, ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
+	new_op_array = zend_compile_string(code_str, string_name, ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 	CG(compiler_options) = original_compiler_options;
 
 	if (new_op_array) {

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1223,7 +1223,7 @@ ZEND_API zend_result zend_eval_stringl(const char *str, size_t str_len, zval *re
 
 	original_compiler_options = CG(compiler_options);
 	CG(compiler_options) = ZEND_COMPILE_DEFAULT_FOR_EVAL;
-	new_op_array = zend_compile_string(code_str, string_name, 0);
+	new_op_array = zend_compile_string(code_str, string_name, ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
 	CG(compiler_options) = original_compiler_options;
 
 	if (new_op_array) {

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -94,7 +94,6 @@ struct _zend_compiler_globals {
 	struct _zend_ini_parser_param *ini_parser_param;
 
 	bool skip_shebang;
-	bool skip_initial;
 	bool increment_lineno;
 
 	bool variable_width_locale;   /* UTF-8, Shift-JIS, Big5, ISO 2022, EUC, etc */

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -94,6 +94,7 @@ struct _zend_compiler_globals {
 	struct _zend_ini_parser_param *ini_parser_param;
 
 	bool skip_shebang;
+	bool skip_initial;
 	bool increment_lineno;
 
 	bool variable_width_locale;   /* UTF-8, Shift-JIS, Big5, ISO 2022, EUC, etc */

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -782,7 +782,7 @@ ZEND_API size_t zend_get_scanned_file_offset(void)
 	return offset;
 }
 
-zend_op_array *compile_string(zend_string *source_string, const char *filename, bool begin_initial)
+zend_op_array *compile_string(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state)
 {
 	zend_lex_state original_lex_state;
 	zend_op_array *op_array = NULL;
@@ -799,11 +799,19 @@ zend_op_array *compile_string(zend_string *source_string, const char *filename, 
 	filename_str = zend_string_init(filename, strlen(filename), 0);
 	zend_prepare_string_for_scanning(&tmp, filename_str);
 	zend_string_release(filename_str);
-	if (begin_initial) {
-		BEGIN(INITIAL);
-	} else {
-		BEGIN(ST_IN_SCRIPTING);
+
+	switch (begin_state) {
+		case ZEND_LEX_BEGIN_STATE_SHEBANG:
+			BEGIN(SHEBANG);
+			break;
+		case ZEND_LEX_BEGIN_STATE_INITIAL:
+			BEGIN(INITIAL);
+			break;
+		case ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING:
+			BEGIN(ST_IN_SCRIPTING);
+			break;
 	}
+
 	op_array = zend_compile(ZEND_EVAL_CODE);
 
 	zend_restore_lexical_state(&original_lex_state);

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -782,7 +782,7 @@ ZEND_API size_t zend_get_scanned_file_offset(void)
 	return offset;
 }
 
-zend_op_array *compile_string(zend_string *source_string, const char *filename, bool skip_initial)
+zend_op_array *compile_string(zend_string *source_string, const char *filename, bool begin_initial)
 {
 	zend_lex_state original_lex_state;
 	zend_op_array *op_array = NULL;
@@ -799,7 +799,7 @@ zend_op_array *compile_string(zend_string *source_string, const char *filename, 
 	filename_str = zend_string_init(filename, strlen(filename), 0);
 	zend_prepare_string_for_scanning(&tmp, filename_str);
 	zend_string_release(filename_str);
-	if (skip_initial) {
+	if (begin_initial) {
 		BEGIN(INITIAL);
 	} else {
 		BEGIN(ST_IN_SCRIPTING);

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -799,7 +799,11 @@ zend_op_array *compile_string(zend_string *source_string, const char *filename)
 	filename_str = zend_string_init(filename, strlen(filename), 0);
 	zend_prepare_string_for_scanning(&tmp, filename_str);
 	zend_string_release(filename_str);
-	BEGIN(ST_IN_SCRIPTING);
+	if (CG(skip_initial)) {
+		BEGIN(INITIAL);
+	} else {
+		BEGIN(ST_IN_SCRIPTING);
+	}
 	op_array = zend_compile(ZEND_EVAL_CODE);
 
 	zend_restore_lexical_state(&original_lex_state);

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -782,7 +782,7 @@ ZEND_API size_t zend_get_scanned_file_offset(void)
 	return offset;
 }
 
-zend_op_array *compile_string(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state)
+zend_op_array *compile_string(zend_string *source_string, const char *filename, zend_compile_position position)
 {
 	zend_lex_state original_lex_state;
 	zend_op_array *op_array = NULL;
@@ -800,14 +800,14 @@ zend_op_array *compile_string(zend_string *source_string, const char *filename, 
 	zend_prepare_string_for_scanning(&tmp, filename_str);
 	zend_string_release(filename_str);
 
-	switch (begin_state) {
-		case ZEND_LEX_BEGIN_STATE_SHEBANG:
+	switch (position) {
+		case ZEND_COMPILE_POSITION_AT_SHEBANG:
 			BEGIN(SHEBANG);
 			break;
-		case ZEND_LEX_BEGIN_STATE_INITIAL:
+		case ZEND_COMPILE_POSITION_AT_OPEN_TAG:
 			BEGIN(INITIAL);
 			break;
-		case ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING:
+		case ZEND_COMPILE_POSITION_AFTER_OPEN_TAG:
 			BEGIN(ST_IN_SCRIPTING);
 			break;
 	}

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -782,7 +782,7 @@ ZEND_API size_t zend_get_scanned_file_offset(void)
 	return offset;
 }
 
-zend_op_array *compile_string(zend_string *source_string, const char *filename)
+zend_op_array *compile_string(zend_string *source_string, const char *filename, bool skip_initial)
 {
 	zend_lex_state original_lex_state;
 	zend_op_array *op_array = NULL;
@@ -799,7 +799,7 @@ zend_op_array *compile_string(zend_string *source_string, const char *filename)
 	filename_str = zend_string_init(filename, strlen(filename), 0);
 	zend_prepare_string_for_scanning(&tmp, filename_str);
 	zend_string_release(filename_str);
-	if (CG(skip_initial)) {
+	if (skip_initial) {
 		BEGIN(INITIAL);
 	} else {
 		BEGIN(ST_IN_SCRIPTING);

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -203,7 +203,7 @@ static ZEND_FUNCTION(zend_test_compile_string)
 {
 	zend_string *source_string = NULL;
 	zend_string *filename = NULL;
-	zend_long begin_state = ZEND_LEX_BEGIN_STATE_INITIAL;
+	zend_long begin_state = ZEND_COMPILE_POSITION_AT_OPEN_TAG;
 
 	ZEND_PARSE_PARAMETERS_START(3, 3)
 		Z_PARAM_STR(source_string)

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -199,6 +199,41 @@ static ZEND_FUNCTION(zend_string_or_stdclass)
 	}
 }
 
+static ZEND_FUNCTION(zend_test_compile_string)
+{
+	zend_string *source_string = NULL;
+	zend_string *filename = NULL;
+	bool skip_initial = 0;
+
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_STR(source_string)
+		Z_PARAM_STR(filename)
+		Z_PARAM_BOOL(skip_initial)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_op_array *op_array = NULL;
+
+	op_array = compile_string(source_string, ZSTR_VAL(filename), skip_initial);
+
+	if (op_array) {
+		zval retval;
+
+		zend_try {
+			ZVAL_UNDEF(&retval);
+			zend_execute(op_array, &retval);
+		} zend_catch {
+			destroy_op_array(op_array);
+			efree_size(op_array, sizeof(zend_op_array));
+			zend_bailout();
+		} zend_end_try();
+
+		destroy_op_array(op_array);
+		efree_size(op_array, sizeof(zend_op_array));
+	}
+
+	return;
+}
+
 /* Tests Z_PARAM_OBJ_OF_CLASS_OR_STR_OR_NULL */
 static ZEND_FUNCTION(zend_string_or_stdclass_or_null)
 {

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -203,17 +203,17 @@ static ZEND_FUNCTION(zend_test_compile_string)
 {
 	zend_string *source_string = NULL;
 	zend_string *filename = NULL;
-	zend_long begin_state = ZEND_COMPILE_POSITION_AT_OPEN_TAG;
+	zend_long position = ZEND_COMPILE_POSITION_AT_OPEN_TAG;
 
 	ZEND_PARSE_PARAMETERS_START(3, 3)
 		Z_PARAM_STR(source_string)
 		Z_PARAM_STR(filename)
-		Z_PARAM_LONG(begin_state)
+		Z_PARAM_LONG(position)
 	ZEND_PARSE_PARAMETERS_END();
 
 	zend_op_array *op_array = NULL;
 
-	op_array = compile_string(source_string, ZSTR_VAL(filename), begin_state);
+	op_array = compile_string(source_string, ZSTR_VAL(filename), position);
 
 	if (op_array) {
 		zval retval;

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -203,17 +203,17 @@ static ZEND_FUNCTION(zend_test_compile_string)
 {
 	zend_string *source_string = NULL;
 	zend_string *filename = NULL;
-	bool begin_initial = 0;
+	zend_long begin_state = ZEND_LEX_BEGIN_STATE_INITIAL;
 
 	ZEND_PARSE_PARAMETERS_START(3, 3)
 		Z_PARAM_STR(source_string)
 		Z_PARAM_STR(filename)
-		Z_PARAM_BOOL(begin_initial)
+		Z_PARAM_LONG(begin_state)
 	ZEND_PARSE_PARAMETERS_END();
 
 	zend_op_array *op_array = NULL;
 
-	op_array = compile_string(source_string, ZSTR_VAL(filename), begin_initial);
+	op_array = compile_string(source_string, ZSTR_VAL(filename), begin_state);
 
 	if (op_array) {
 		zval retval;

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -203,17 +203,17 @@ static ZEND_FUNCTION(zend_test_compile_string)
 {
 	zend_string *source_string = NULL;
 	zend_string *filename = NULL;
-	bool skip_initial = 0;
+	bool begin_initial = 0;
 
 	ZEND_PARSE_PARAMETERS_START(3, 3)
 		Z_PARAM_STR(source_string)
 		Z_PARAM_STR(filename)
-		Z_PARAM_BOOL(skip_initial)
+		Z_PARAM_BOOL(begin_initial)
 	ZEND_PARSE_PARAMETERS_END();
 
 	zend_op_array *op_array = NULL;
 
-	op_array = compile_string(source_string, ZSTR_VAL(filename), skip_initial);
+	op_array = compile_string(source_string, ZSTR_VAL(filename), begin_initial);
 
 	if (op_array) {
 		zval retval;

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -62,7 +62,7 @@ namespace {
 
     function zend_test_void_return(): void {}
 
-    function zend_test_compile_string(string $source_string, string $filename, int $begin_state): void {}
+    function zend_test_compile_string(string $source_string, string $filename, int $position): void {}
 
     /** @deprecated */
     function zend_test_deprecated(mixed $arg = null): void {}

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -62,6 +62,8 @@ namespace {
 
     function zend_test_void_return(): void {}
 
+    function zend_test_compile_string(string $source_string, string $filename, bool $skip_initial): void {}
+
     /** @deprecated */
     function zend_test_deprecated(mixed $arg = null): void {}
 

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -62,7 +62,7 @@ namespace {
 
     function zend_test_void_return(): void {}
 
-    function zend_test_compile_string(string $source_string, string $filename, bool $skip_initial): void {}
+    function zend_test_compile_string(string $source_string, string $filename, bool $begin_initial): void {}
 
     /** @deprecated */
     function zend_test_deprecated(mixed $arg = null): void {}

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -62,7 +62,7 @@ namespace {
 
     function zend_test_void_return(): void {}
 
-    function zend_test_compile_string(string $source_string, string $filename, bool $begin_initial): void {}
+    function zend_test_compile_string(string $source_string, string $filename, int $begin_state): void {}
 
     /** @deprecated */
     function zend_test_deprecated(mixed $arg = null): void {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 53832c784e59195e8ef41710c1e4e778f396c99b */
+ * Stub hash: 7432f512564a359ecac72fb2cfc9718f5728166a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -8,6 +8,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_nullable_array_return,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_void_return, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_compile_string, 0, 3, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, source_string, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, skip_initial, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_deprecated, 0, 0, IS_VOID, 0)
@@ -84,6 +90,7 @@ ZEND_END_ARG_INFO()
 static ZEND_FUNCTION(zend_test_array_return);
 static ZEND_FUNCTION(zend_test_nullable_array_return);
 static ZEND_FUNCTION(zend_test_void_return);
+static ZEND_FUNCTION(zend_test_compile_string);
 static ZEND_FUNCTION(zend_test_deprecated);
 static ZEND_FUNCTION(zend_create_unterminated_string);
 static ZEND_FUNCTION(zend_terminate_string);
@@ -111,6 +118,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_test_array_return, arginfo_zend_test_array_return)
 	ZEND_FE(zend_test_nullable_array_return, arginfo_zend_test_nullable_array_return)
 	ZEND_FE(zend_test_void_return, arginfo_zend_test_void_return)
+	ZEND_FE(zend_test_compile_string, arginfo_zend_test_compile_string)
 	ZEND_DEP_FE(zend_test_deprecated, arginfo_zend_test_deprecated)
 	ZEND_FE(zend_create_unterminated_string, arginfo_zend_create_unterminated_string)
 	ZEND_FE(zend_terminate_string, arginfo_zend_terminate_string)

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -13,7 +13,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_compile_string, 0, 3, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, source_string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, begin_state, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, position, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_deprecated, 0, 0, IS_VOID, 0)

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -13,7 +13,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_compile_string, 0, 3, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, source_string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, skip_initial, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, begin_initial, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_deprecated, 0, 0, IS_VOID, 0)

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7432f512564a359ecac72fb2cfc9718f5728166a */
+ * Stub hash: 91ffc3205c6ac7b07953c9446e9cb9988d893dd4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -13,7 +13,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_compile_string, 0, 3, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, source_string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, begin_initial, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, begin_state, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_deprecated, 0, 0, IS_VOID, 0)

--- a/ext/zend_test/tests/zend_test_compile_string.phpt
+++ b/ext/zend_test/tests/zend_test_compile_string.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Zend: Test compile string
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+$source_string = <<<EOF
+<?php
+var_dump('php');
+EOF;
+
+zend_test_compile_string($source_string, 'Source string', 1);
+
+$source_string = <<<EOF
+var_dump('php');
+EOF;
+
+zend_test_compile_string($source_string, 'Source string', 0);
+
+$source_string = <<<EOF
+<?php
+var_dump('php');
+EOF;
+
+zend_test_compile_string($source_string, 'Source string', 0);
+?>
+--EXPECT--
+string(3) "php"
+string(3) "php"
+
+Parse error: syntax error, unexpected token "<", expecting end of file in Source string on line 1

--- a/ext/zend_test/tests/zend_test_compile_string.phpt
+++ b/ext/zend_test/tests/zend_test_compile_string.phpt
@@ -5,9 +5,9 @@ zend_test
 --FILE--
 <?php
 
-define('ZEND_LEX_BEGIN_STATE_SHEBANG', 0);
-define('ZEND_LEX_BEGIN_STATE_INITIAL', 1);
-define('ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING', 2);
+define('ZEND_COMPILE_POSITION_AT_SHEBANG', 0);
+define('ZEND_COMPILE_POSITION_AT_OPEN_TAG', 1);
+define('ZEND_COMPILE_POSITION_AFTER_OPEN_TAG', 2);
 
 $source_string = <<<EOF
 #!/path/to/php
@@ -15,7 +15,7 @@ $source_string = <<<EOF
 var_dump('php');
 EOF;
 
-zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_SHEBANG);
+zend_test_compile_string($source_string, 'Source string', ZEND_COMPILE_POSITION_AT_SHEBANG);
 
 $source_string = <<<EOF
 #!/path/to/php
@@ -23,27 +23,27 @@ $source_string = <<<EOF
 var_dump('php');
 EOF;
 
-zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_INITIAL);
+zend_test_compile_string($source_string, 'Source string', ZEND_COMPILE_POSITION_AT_OPEN_TAG);
 
 $source_string = <<<EOF
 <?php
 var_dump('php');
 EOF;
 
-zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_INITIAL);
+zend_test_compile_string($source_string, 'Source string', ZEND_COMPILE_POSITION_AT_OPEN_TAG);
 
 $source_string = <<<EOF
 var_dump('php');
 EOF;
 
-zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
+zend_test_compile_string($source_string, 'Source string', ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 
 $source_string = <<<EOF
 <?php
 var_dump('php');
 EOF;
 
-zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
+zend_test_compile_string($source_string, 'Source string', ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 ?>
 --EXPECT--
 string(3) "php"

--- a/ext/zend_test/tests/zend_test_compile_string.phpt
+++ b/ext/zend_test/tests/zend_test_compile_string.phpt
@@ -4,27 +4,51 @@ Zend: Test compile string
 zend_test
 --FILE--
 <?php
+
+define('ZEND_LEX_BEGIN_STATE_SHEBANG', 0);
+define('ZEND_LEX_BEGIN_STATE_INITIAL', 1);
+define('ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING', 2);
+
+$source_string = <<<EOF
+#!/path/to/php
+<?php
+var_dump('php');
+EOF;
+
+zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_SHEBANG);
+
+$source_string = <<<EOF
+#!/path/to/php
+<?php
+var_dump('php');
+EOF;
+
+zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_INITIAL);
+
 $source_string = <<<EOF
 <?php
 var_dump('php');
 EOF;
 
-zend_test_compile_string($source_string, 'Source string', 1);
+zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_INITIAL);
 
 $source_string = <<<EOF
 var_dump('php');
 EOF;
 
-zend_test_compile_string($source_string, 'Source string', 0);
+zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
 
 $source_string = <<<EOF
 <?php
 var_dump('php');
 EOF;
 
-zend_test_compile_string($source_string, 'Source string', 0);
+zend_test_compile_string($source_string, 'Source string', ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
 ?>
 --EXPECT--
+string(3) "php"
+#!/path/to/php
+string(3) "php"
 string(3) "php"
 string(3) "php"
 

--- a/sapi/phpdbg/phpdbg.h
+++ b/sapi/phpdbg/phpdbg.h
@@ -270,7 +270,7 @@ ZEND_BEGIN_MODULE_GLOBALS(phpdbg)
 
 	zend_op_array *(*compile_file)(zend_file_handle *file_handle, int type);
 	zend_op_array *(*init_compile_file)(zend_file_handle *file_handle, int type);
-	zend_op_array *(*compile_string)(zend_string *source_string, const char *filename, bool skip_initial);
+	zend_op_array *(*compile_string)(zend_string *source_string, const char *filename, bool begin_initial);
 	HashTable file_sources;
 
 	zend_arena *oplog_arena;                     /* arena for storing oplog */

--- a/sapi/phpdbg/phpdbg.h
+++ b/sapi/phpdbg/phpdbg.h
@@ -270,7 +270,7 @@ ZEND_BEGIN_MODULE_GLOBALS(phpdbg)
 
 	zend_op_array *(*compile_file)(zend_file_handle *file_handle, int type);
 	zend_op_array *(*init_compile_file)(zend_file_handle *file_handle, int type);
-	zend_op_array *(*compile_string)(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state);
+	zend_op_array *(*compile_string)(zend_string *source_string, const char *filename, zend_compile_position position);
 	HashTable file_sources;
 
 	zend_arena *oplog_arena;                     /* arena for storing oplog */

--- a/sapi/phpdbg/phpdbg.h
+++ b/sapi/phpdbg/phpdbg.h
@@ -270,7 +270,7 @@ ZEND_BEGIN_MODULE_GLOBALS(phpdbg)
 
 	zend_op_array *(*compile_file)(zend_file_handle *file_handle, int type);
 	zend_op_array *(*init_compile_file)(zend_file_handle *file_handle, int type);
-	zend_op_array *(*compile_string)(zend_string *source_string, const char *filename, bool begin_initial);
+	zend_op_array *(*compile_string)(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state);
 	HashTable file_sources;
 
 	zend_arena *oplog_arena;                     /* arena for storing oplog */

--- a/sapi/phpdbg/phpdbg.h
+++ b/sapi/phpdbg/phpdbg.h
@@ -270,7 +270,7 @@ ZEND_BEGIN_MODULE_GLOBALS(phpdbg)
 
 	zend_op_array *(*compile_file)(zend_file_handle *file_handle, int type);
 	zend_op_array *(*init_compile_file)(zend_file_handle *file_handle, int type);
-	zend_op_array *(*compile_string)(zend_string *source_string, const char *filename);
+	zend_op_array *(*compile_string)(zend_string *source_string, const char *filename, bool skip_initial);
 	HashTable file_sources;
 
 	zend_arena *oplog_arena;                     /* arena for storing oplog */

--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -878,7 +878,7 @@ static inline void phpdbg_create_conditional_break(phpdbg_breakcond_t *brake, co
 
 	bp_code = zend_string_concat3(
 		"return ", sizeof("return ")-1, expr, expr_len, ";", sizeof(";")-1);
-	new_break.ops = zend_compile_string(bp_code, "Conditional Breakpoint Code");
+	new_break.ops = zend_compile_string(bp_code, "Conditional Breakpoint Code", 0);
 	zend_string_release(bp_code);
 
 	if (new_break.ops) {

--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -878,7 +878,7 @@ static inline void phpdbg_create_conditional_break(phpdbg_breakcond_t *brake, co
 
 	bp_code = zend_string_concat3(
 		"return ", sizeof("return ")-1, expr, expr_len, ";", sizeof(";")-1);
-	new_break.ops = zend_compile_string(bp_code, "Conditional Breakpoint Code", ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
+	new_break.ops = zend_compile_string(bp_code, "Conditional Breakpoint Code", ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 	zend_string_release(bp_code);
 
 	if (new_break.ops) {

--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -878,7 +878,7 @@ static inline void phpdbg_create_conditional_break(phpdbg_breakcond_t *brake, co
 
 	bp_code = zend_string_concat3(
 		"return ", sizeof("return ")-1, expr, expr_len, ";", sizeof(";")-1);
-	new_break.ops = zend_compile_string(bp_code, "Conditional Breakpoint Code", 0);
+	new_break.ops = zend_compile_string(bp_code, "Conditional Breakpoint Code", ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
 	zend_string_release(bp_code);
 
 	if (new_break.ops) {

--- a/sapi/phpdbg/phpdbg_list.c
+++ b/sapi/phpdbg/phpdbg_list.c
@@ -309,7 +309,7 @@ zend_op_array *phpdbg_init_compile_file(zend_file_handle *file, int type) {
 	return op_array;
 }
 
-zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *filename, bool begin_initial) {
+zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state) {
 	zend_string *fake_name;
 	zend_op_array *op_array;
 	phpdbg_file_source *dataptr;
@@ -317,7 +317,7 @@ zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *fil
 	char *bufptr, *endptr;
 
 	if (PHPDBG_G(flags) & PHPDBG_IN_EVAL) {
-		return PHPDBG_G(compile_string)(source_string, filename, begin_initial);
+		return PHPDBG_G(compile_string)(source_string, filename, begin_state);
 	}
 
 	dataptr = emalloc(sizeof(phpdbg_file_source) + sizeof(uint32_t) * ZSTR_LEN(source_string));
@@ -332,7 +332,7 @@ zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *fil
 	dataptr->lines = ++line;
 	dataptr->line[line] = endptr - dataptr->buf;
 
-	op_array = PHPDBG_G(compile_string)(source_string, filename, begin_initial);
+	op_array = PHPDBG_G(compile_string)(source_string, filename, begin_state);
 
 	if (op_array == NULL) {
 		efree(dataptr->buf);

--- a/sapi/phpdbg/phpdbg_list.c
+++ b/sapi/phpdbg/phpdbg_list.c
@@ -309,7 +309,7 @@ zend_op_array *phpdbg_init_compile_file(zend_file_handle *file, int type) {
 	return op_array;
 }
 
-zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *filename, bool skip_initial) {
+zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *filename, bool begin_initial) {
 	zend_string *fake_name;
 	zend_op_array *op_array;
 	phpdbg_file_source *dataptr;
@@ -317,7 +317,7 @@ zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *fil
 	char *bufptr, *endptr;
 
 	if (PHPDBG_G(flags) & PHPDBG_IN_EVAL) {
-		return PHPDBG_G(compile_string)(source_string, filename, skip_initial);
+		return PHPDBG_G(compile_string)(source_string, filename, begin_initial);
 	}
 
 	dataptr = emalloc(sizeof(phpdbg_file_source) + sizeof(uint32_t) * ZSTR_LEN(source_string));
@@ -332,7 +332,7 @@ zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *fil
 	dataptr->lines = ++line;
 	dataptr->line[line] = endptr - dataptr->buf;
 
-	op_array = PHPDBG_G(compile_string)(source_string, filename, skip_initial);
+	op_array = PHPDBG_G(compile_string)(source_string, filename, begin_initial);
 
 	if (op_array == NULL) {
 		efree(dataptr->buf);

--- a/sapi/phpdbg/phpdbg_list.c
+++ b/sapi/phpdbg/phpdbg_list.c
@@ -309,7 +309,7 @@ zend_op_array *phpdbg_init_compile_file(zend_file_handle *file, int type) {
 	return op_array;
 }
 
-zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *filename) {
+zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *filename, bool skip_initial) {
 	zend_string *fake_name;
 	zend_op_array *op_array;
 	phpdbg_file_source *dataptr;
@@ -317,7 +317,7 @@ zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *fil
 	char *bufptr, *endptr;
 
 	if (PHPDBG_G(flags) & PHPDBG_IN_EVAL) {
-		return PHPDBG_G(compile_string)(source_string, filename);
+		return PHPDBG_G(compile_string)(source_string, filename, skip_initial);
 	}
 
 	dataptr = emalloc(sizeof(phpdbg_file_source) + sizeof(uint32_t) * ZSTR_LEN(source_string));
@@ -332,7 +332,7 @@ zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *fil
 	dataptr->lines = ++line;
 	dataptr->line[line] = endptr - dataptr->buf;
 
-	op_array = PHPDBG_G(compile_string)(source_string, filename);
+	op_array = PHPDBG_G(compile_string)(source_string, filename, skip_initial);
 
 	if (op_array == NULL) {
 		efree(dataptr->buf);

--- a/sapi/phpdbg/phpdbg_list.c
+++ b/sapi/phpdbg/phpdbg_list.c
@@ -309,7 +309,7 @@ zend_op_array *phpdbg_init_compile_file(zend_file_handle *file, int type) {
 	return op_array;
 }
 
-zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *filename, zend_lex_begin_state begin_state) {
+zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *filename, zend_compile_position position) {
 	zend_string *fake_name;
 	zend_op_array *op_array;
 	phpdbg_file_source *dataptr;
@@ -317,7 +317,7 @@ zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *fil
 	char *bufptr, *endptr;
 
 	if (PHPDBG_G(flags) & PHPDBG_IN_EVAL) {
-		return PHPDBG_G(compile_string)(source_string, filename, begin_state);
+		return PHPDBG_G(compile_string)(source_string, filename, position);
 	}
 
 	dataptr = emalloc(sizeof(phpdbg_file_source) + sizeof(uint32_t) * ZSTR_LEN(source_string));
@@ -332,7 +332,7 @@ zend_op_array *phpdbg_compile_string(zend_string *source_string, const char *fil
 	dataptr->lines = ++line;
 	dataptr->line[line] = endptr - dataptr->buf;
 
-	op_array = PHPDBG_G(compile_string)(source_string, filename, begin_state);
+	op_array = PHPDBG_G(compile_string)(source_string, filename, position);
 
 	if (op_array == NULL) {
 		efree(dataptr->buf);

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -514,7 +514,7 @@ exec_code:
 } /* }}} */
 
 int phpdbg_compile_stdin(zend_string *code) {
-	PHPDBG_G(ops) = zend_compile_string(code, "Standard input code");
+	PHPDBG_G(ops) = zend_compile_string(code, "Standard input code", 0);
 	zend_string_release(code);
 
 	if (EG(exception)) {

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -514,7 +514,7 @@ exec_code:
 } /* }}} */
 
 int phpdbg_compile_stdin(zend_string *code) {
-	PHPDBG_G(ops) = zend_compile_string(code, "Standard input code", 0);
+	PHPDBG_G(ops) = zend_compile_string(code, "Standard input code", ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
 	zend_string_release(code);
 
 	if (EG(exception)) {

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -514,7 +514,7 @@ exec_code:
 } /* }}} */
 
 int phpdbg_compile_stdin(zend_string *code) {
-	PHPDBG_G(ops) = zend_compile_string(code, "Standard input code", ZEND_LEX_BEGIN_STATE_ST_IN_SCRIPTING);
+	PHPDBG_G(ops) = zend_compile_string(code, "Standard input code", ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 	zend_string_release(code);
 
 	if (EG(exception)) {


### PR DESCRIPTION
I'm not sure if this revision is good.

I have a requirement to execute encrypted PHP code.

Currently, I read the encrypted code into memory, then decrypt it, and write the decrypted content to a temporary file. Then call compile_file to fetch op_array.

Perhaps we can fetch op_array directly from compile_string. But it will report the problem:

```bash
Parse error: syntax error, unexpected token "<", expecting end of file
```

So, I need to remove T_OPEN_TAG myself. So I think it's fine if compile_string can skip T_OPEN_TAG.