### PR TITLE
Add FPM prod idle timeout test

### DIFF
--- a/sapi/fpm/tests/proc-idle-timeout.phpt
+++ b/sapi/fpm/tests/proc-idle-timeout.phpt
@@ -1,0 +1,53 @@
+--TEST--
+FPM: Process manager config pm.process_idle_timeout
+--SKIPIF--
+<?php
+include "skipif.inc";
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = ondemand
+pm.max_children = 3
+pm.process_idle_timeout = 1
+pm.status_path = /status
+EOT;
+
+$code = <<<EOT
+<?php
+usleep(200);
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->multiRequest(2);
+$tester->status([
+    'total processes' => 2,
+]);
+// wait for process idle timeout
+sleep(4);
+$tester->status([
+    'total processes' => 1,
+]);
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/status.inc
+++ b/sapi/fpm/tests/status.inc
@@ -87,7 +87,7 @@ class Status
         if ($startTimeTimestamp && $fields['start time'][0] === '\\') {
             $fields['start time'] = '\d+';
         }
-        $pattern = '|' . $header;
+        $pattern = '(' . $header;
         foreach ($fields as $name => $value) {
             if ($nameTransformer) {
                 $name = call_user_func($nameTransformer, $name);
@@ -102,7 +102,7 @@ class Status
             }
         }
         $pattern = rtrim($pattern, $rowPattern[strlen($rowPattern) - 1]);
-        $pattern .= $footer . '|';
+        $pattern .= $footer . ')';
 
         if (!preg_match($pattern, $body)) {
             echo "ERROR: Expected body does not match pattern\n";

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -522,7 +522,7 @@ class Tester
     }
 
     /**
-     * Execute request.
+     * Get request params array.
      *
      * @param string $query
      * @param array $headers
@@ -531,20 +531,13 @@ class Tester
      * @param string|null $successMessage
      * @param string|null $errorMessage
      * @param bool $connKeepAlive
-     * @return Response
+     * @return array
      */
-    public function request(
+    private function getRequestParams(
         string $query = '',
         array $headers = [],
-        string $uri = null,
-        string $address = null,
-        string $successMessage = null,
-        string $errorMessage = null,
-        bool $connKeepAlive = false
+        string $uri = null
     ) {
-        if ($this->hasError()) {
-            return new Response(null, true);
-        }
         if (is_null($uri)) {
             $uri = $this->makeSourceFile();
         }
@@ -571,9 +564,38 @@ class Tester
             ],
             $headers
         );
-        $params = array_filter($params, function($value) {
+
+        return array_filter($params, function($value) {
             return !is_null($value);
         });
+    }
+
+    /**
+     * Execute request.
+     *
+     * @param string $query
+     * @param array $headers
+     * @param string|null $uri
+     * @param string|null $address
+     * @param string|null $successMessage
+     * @param string|null $errorMessage
+     * @param bool $connKeepAlive
+     * @return Response
+     */
+    public function request(
+        string $query = '',
+        array $headers = [],
+        string $uri = null,
+        string $address = null,
+        string $successMessage = null,
+        string $errorMessage = null,
+        bool $connKeepAlive = false
+    ) {
+        if ($this->hasError()) {
+            return new Response(null, true);
+        }
+
+        $params = $this->getRequestParams($query, $headers, $uri);
 
         try {
             $this->response = new Response(
@@ -592,6 +614,66 @@ class Tester
             $this->response->debugOutput();
         }
         return $this->response;
+    }
+
+    /**
+     * Execute multiple requests in parallel.
+     *
+     * @param array|int $requests
+     * @param string|null $address
+     * @param string|null $successMessage
+     * @param string|null $errorMessage
+     * @param bool $connKeepAlive
+     * @return Response[]
+     * @throws \Exception
+     */
+    public function multiRequest(
+        $requests,
+        string $address = null,
+        string $successMessage = null,
+        string $errorMessage = null,
+        bool $connKeepAlive = false
+    ) {
+        if ($this->hasError()) {
+            return new Response(null, true);
+        }
+
+        if (is_numeric($requests)) {
+            $requests = array_fill(0, $requests, []);
+        } elseif (!is_array($requests)) {
+            throw new \Exception('Requests can be either numeric or array');
+        }
+
+        try {
+            $connections = array_map(function ($requestData) use ($address, $connKeepAlive) {
+                $client = $this->getClient($address, $connKeepAlive);
+                $params = $this->getRequestParams(
+                    $requestData['query'] ?? '',
+                    $requestData['headers'] ?? [],
+                    $requestData['uri'] ?? null
+                );
+                return [
+                    'client' => $client,
+                    'requestId' => $client->async_request($params, false),
+                ];
+            }, $requests);
+
+            $responses = array_map(function ($conn) {
+                $response = new Response($conn['client']->wait_for_response_data($conn['requestId']));
+                if ($this->debug) {
+                    $response->debugOutput();
+                }
+                return $response;
+            }, $connections);
+            $this->message($successMessage);
+            return $responses;
+        } catch (\Exception $exception) {
+            if ($errorMessage === null) {
+                $this->error("Request failed", $exception);
+            } else {
+                $this->message($errorMessage);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This tests FPM `pm.process_idle_timeout` functionality. To be able to do that multi request (using multiple clients) support has been added to FPM tester. This will be helpful for some other cases as well.