### PR TITLE
Proposal: Allow reserved keywords in more element declaration names(class, function, etc)

### DIFF
--- a/Zend/tests/extended_identifiers.phpt
+++ b/Zend/tests/extended_identifiers.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test allowing semi-reserved identifiers in more contexts
+--FILE--
+<?php
+
+// When php's syntax rules change to allow keywords in more contexts,
+// those keywords will start being forbidden in those specific contexts.
+
+// Previously not allowed
+trait Or {
+}
+
+// Previously not allowed since 8.0
+class Match {
+    use \Or;
+    const OR = 123;
+}
+
+final class Readonly {
+}
+
+// Previously not allowed since 7.4
+function fn() {
+    echo "in fn\n";
+}
+\fn();
+var_dump(\Match::OR);
+var_dump(get_class(new \Match()));
+var_dump(get_class(new \Readonly()));
+?>
+--EXPECT--
+in fn
+int(123)
+string(5) "Match"
+string(8) "Readonly"

--- a/Zend/tests/grammar/callable_class_forbidden.phpt
+++ b/Zend/tests/grammar/callable_class_forbidden.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Callable forbidden as class name since it is also a type hint
+--FILE--
+<?php
+// Previously this was a thrown ParseError - now it's a fatal compilation error.
+class Callable {
+}
+?>
+--EXPECTF--
+Fatal error: Cannot use 'Callable' as class name as it is reserved in %s on line 3

--- a/Zend/tests/grammar/regression_004.phpt
+++ b/Zend/tests/grammar/regression_004.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test possible function naming regression on procedural scope
+Test possible function naming regression on procedural scope now allowed
 --FILE--
 <?php
 
@@ -9,7 +9,10 @@ class Obj
     function return(){} // valid
 }
 
-function echo(){} // not valid
+function echo(){print("test\n");} // valid
+\echo();
+namespace\echo();
 ?>
---EXPECTF--
-Parse error: syntax error, unexpected token "echo", expecting "(" in %s on line %d
+--EXPECT--
+test
+test

--- a/Zend/tests/grammar/regression_005.phpt
+++ b/Zend/tests/grammar/regression_005.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test possible constant naming regression on procedural scope
+Test possible constant naming regression on procedural scope now allowed
 --FILE--
 <?php
 
@@ -9,6 +9,9 @@ class Obj
 }
 
 const return = 'nope';
+var_dump(\return);
+var_dump(Obj::return);
 ?>
---EXPECTF--
-Parse error: syntax error, unexpected token "return", expecting identifier in %s on line %d
+--EXPECT--
+string(4) "nope"
+string(3) "yep"

--- a/Zend/tests/lsb_008.phpt
+++ b/Zend/tests/lsb_008.phpt
@@ -6,4 +6,4 @@ class static {
 }
 ?>
 --EXPECTF--
-Parse error: %s error,%sexpecting %s in %s on line %d
+Fatal error: Cannot use 'static' as class name as it is reserved in %s on line 2

--- a/Zend/tests/lsb_009.phpt
+++ b/Zend/tests/lsb_009.phpt
@@ -6,4 +6,4 @@ interface static {
 }
 ?>
 --EXPECTF--
-Parse error: %s error,%sexpecting %s in %s on line %d
+Fatal error: Cannot use 'static' as class name as it is reserved in %s on line 2

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -176,6 +176,7 @@ static const struct reserved_class_name reserved_class_names[] = {
 	{ZEND_STRL("iterable")},
 	{ZEND_STRL("object")},
 	{ZEND_STRL("mixed")},
+	{ZEND_STRL("callable")},
 	{NULL, 0}
 };
 

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -561,7 +561,7 @@ unset_variable:
 ;
 
 function_declaration_statement:
-	function returns_ref T_STRING backup_doc_comment '(' parameter_list ')' return_type
+	function returns_ref identifier backup_doc_comment '(' parameter_list ')' return_type
 	backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
 		{ $$ = zend_ast_create_decl(ZEND_AST_FUNC_DECL, $2 | $13, $1, $4,
 		      zend_ast_get_str($3), $6, NULL, $11, $8, NULL); CG(extra_fn_flags) = $9; }
@@ -579,10 +579,10 @@ is_variadic:
 
 class_declaration_statement:
 		class_modifiers T_CLASS { $<num>$ = CG(zend_lineno); }
-		T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
+		identifier extends_from implements_list backup_doc_comment '{' class_statement_list '}'
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, $1, $<num>3, $7, zend_ast_get_str($4), $5, $6, $9, NULL, NULL); }
 	|	T_CLASS { $<num>$ = CG(zend_lineno); }
-		T_STRING extends_from implements_list backup_doc_comment '{' class_statement_list '}'
+		identifier extends_from implements_list backup_doc_comment '{' class_statement_list '}'
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, 0, $<num>2, $6, zend_ast_get_str($3), $4, $5, $8, NULL, NULL); }
 ;
 
@@ -599,19 +599,19 @@ class_modifier:
 
 trait_declaration_statement:
 		T_TRAIT { $<num>$ = CG(zend_lineno); }
-		T_STRING backup_doc_comment '{' class_statement_list '}'
+		identifier backup_doc_comment '{' class_statement_list '}'
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_TRAIT, $<num>2, $4, zend_ast_get_str($3), NULL, NULL, $6, NULL, NULL); }
 ;
 
 interface_declaration_statement:
 		T_INTERFACE { $<num>$ = CG(zend_lineno); }
-		T_STRING interface_extends_list backup_doc_comment '{' class_statement_list '}'
+		identifier interface_extends_list backup_doc_comment '{' class_statement_list '}'
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_INTERFACE, $<num>2, $5, zend_ast_get_str($3), NULL, $4, $7, NULL, NULL); }
 ;
 
 enum_declaration_statement:
 		T_ENUM { $<num>$ = CG(zend_lineno); }
-		T_STRING enum_backing_type implements_list backup_doc_comment '{' class_statement_list '}'
+		identifier enum_backing_type implements_list backup_doc_comment '{' class_statement_list '}'
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLASS, ZEND_ACC_ENUM|ZEND_ACC_FINAL, $<num>2, $6, zend_ast_get_str($3), NULL, $5, $8, NULL, $4); }
 ;
 
@@ -1033,7 +1033,7 @@ class_const_decl:
 ;
 
 const_decl:
-	T_STRING '=' expr backup_doc_comment { $$ = zend_ast_create(ZEND_AST_CONST_ELEM, $1, $3, ($4 ? zend_ast_create_zval_from_str($4) : NULL)); }
+	identifier '=' expr backup_doc_comment { $$ = zend_ast_create(ZEND_AST_CONST_ELEM, $1, $3, ($4 ? zend_ast_create_zval_from_str($4) : NULL)); }
 ;
 
 echo_expr_list:


### PR DESCRIPTION
This proposes to allow certain reserved keywords to be allowed as identifiers
in the following places (in PHP 8.2):

- Global function declarations
- Global constant declarations
- Named class declarations
- Trait declarations
- Interface declarations
- Enum declarations

(They were already allowed in class constant declarations, method declarations,
etc.)

For example, if an application was using `Match` as a class/function name
prior to php 8.0, this declaration would have started being a syntax error
in PHP 8.0 due to https://wiki.php.net/rfc/match_expression_v2 .
But with this PR, it would be possible to create element names using those
keywords, or instantiate it or use to it as
`\Match` instead of `Match`,
**thanks to https://wiki.php.net/rfc/namespaced_names_as_token
having already been merged in php 8.0.**

Motivation
----------


- Without https://wiki.php.net/rfc/namespaced_names_as_token it wouldn't have been practical
  to use those symbols even if they were declared until php 8.0. It is now practical.
- Without this change, workarounds such as class_alias would have been required to use
  identifiers such as `Match` as a class/function name when upgrading to php 8.0, for example)
- For applications using libraries such as https://github.com/cweiske/jsonmapper#example
  it would be useful to be able to use reserved keywords as names, e.g. to integrate with applications written in other programming languages and to easily serialize/unserialize data using those symbols

This aims to reduce the backwards compatibility impact of new reserved keyword
additions in new/recent PHP versions, both to aid users in migrating
and reducing objections to new syntax proposals that depend on new keywords.

Details
--------

Using keywords that can already be types (e.g. static, int, float, never)
continues to be a fatal error in class names.

The following keywords would be allowed

```
// reserved_non_modifiers:
  INCLUDE | INCLUDE_ONCE | EVAL | REQUIRE | REQUIRE_ONCE | OR | XOR | AND
| INSTANCEOF | NEW | CLONE | EXIT | IF | ELSEIF | ELSE | ENDIF | ECHO | DO | WHILE | ENDWHILE
| FOR | ENDFOR | FOREACH | ENDFOREACH | DECLARE | ENDDECLARE | AS | TRY | CATCH | FINALLY
| THROW | USE | INSTEADOF | GLOBAL | VAR | UNSET | ISSET | EMPTY | CONTINUE | GOTO
| FUNCTION | CONST | RETURN | PRINT | YIELD | LIST | SWITCH | ENDSWITCH | CASE | DEFAULT | BREAK
| ARRAY | CALLABLE | EXTENDS | IMPLEMENTS | NAMESPACE | TRAIT | INTERFACE | CLASS
| __CLASS__ | __TRAIT__ | __FUNCTION__ | __METHOD__ | __LINE__ | __FILE__ | __DIR__ | __NAMESPACE__
| FN | MATCH | ENUM

// semi_reserved:
| STATIC | ABSTRACT | FINAL | PRIVATE | PROTECTED | PUBLIC | READONLY
```

Additionally, forbid using `callable` as a class name because it is a type hint.
Previously, it would be a ParseError unless using `class_alias`.
This is already done for `never`, `iterable`, `mixed`, etc., so I assume this was an oversight?

Alternatives Considered
-----------------------

1. One possibility was to instead only allow newly introduced keywords
   since some arbitrary php version (e.g. 7.0) but continue forbidding old keywords introduced prior to that version.

   This was rejected because decades from now, the choice of which keywords
   are forbidden would seem arbitrary and hard to remember.
2. Another possibility would be to allow fully qualified names in these declarations.
   (e.g. `class \Match`).

   This was rejected since allowing code in namespaces to declare elements
   in different namespaces was much more drastic than needed (and break current conventions) - the approach taken in this PR would be sufficient.
