### PR TITLE
Allow using readonly as function name

### DIFF
--- a/Zend/tests/readonly_function.phpt
+++ b/Zend/tests/readonly_function.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Can use readonly as a function name
+--FILE--
+<?php
+
+function readonly() {
+    echo "Hi!\n";
+}
+
+readonly();
+readonly ();
+
+?>
+--EXPECT--
+Hi!
+Hi!

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1718,6 +1718,12 @@ NEWLINE ("\r"|"\n"|"\r\n")
 	RETURN_TOKEN_WITH_IDENT(T_READONLY);
 }
 
+/* Don't treat "readonly(" as a keyword, to allow using it as a function name. */
+<ST_IN_SCRIPTING>"readonly"[ \n\r\t]*"(" {
+	yyless(strlen("readonly"));
+	RETURN_TOKEN_WITH_STR(T_STRING, 0);
+}
+
 <ST_IN_SCRIPTING>"unset" {
 	RETURN_TOKEN_WITH_IDENT(T_UNSET);
 }


### PR DESCRIPTION
Don't treat "readonly" as a keyword if followed by "(". This
allows using it as a global function name. In particular, this
function has been used by WordPress.

This does not allow other uses of "readonly", in particular it
cannot be used as a class name, unlike "enum". The reason is that
we'd still have to recognize it as a keyword when using in a type
position:

    class Test {
        public ReadOnly $foo;
    }

This should now be interpreted as a readonly property, not as a
read-write property with type `ReadOnly`. As such, a class with
name `ReadOnly`, while unambiguous in most other circumstances,
would not be usable as property or parameter type. For that
reason, we do not support it at all.

Based on the recent Twitter discussion, cc @jrfnl @ramsey @derickr. Unfortunately this is not such a clean case as `enum`, because we can only fully support the function case.