### PR TITLE
Implement $this return type

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -2244,7 +2244,7 @@ static uint32_t zend_convert_type_declaration_mask(uint32_t type_mask) {
 	if (type_mask & MAY_BE_ITERABLE) {
 		result_mask |= MAY_BE_OBJECT|MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_ANY|MAY_BE_ARRAY_OF_ANY|MAY_BE_ARRAY_OF_REF;
 	}
-	if (type_mask & MAY_BE_STATIC) {
+	if (type_mask & (MAY_BE_STATIC|MAY_BE_THIS)) {
 		result_mask |= MAY_BE_OBJECT;
 	}
 	if (type_mask & MAY_BE_ARRAY) {

--- a/Zend/tests/type_declarations/this_type/as_param_type.phpt
+++ b/Zend/tests/type_declarations/this_type/as_param_type.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Cannot use $this as param type
+--FILE--
+<?php
+
+class Test {
+    public function method($this $param) {}
+}
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected variable "$param", expecting ")" in %s on line %d

--- a/Zend/tests/type_declarations/this_type/as_property_type.phpt
+++ b/Zend/tests/type_declarations/this_type/as_property_type.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Cannot use $this as property type
+--FILE--
+<?php
+
+class Test {
+    public $this $prop;
+}
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected variable "$prop", expecting "," or ";" in %s on line %d

--- a/Zend/tests/type_declarations/this_type/basic.phpt
+++ b/Zend/tests/type_declarations/this_type/basic.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Basic usage of $this return type
+--FILE--
+<?php
+
+class Test {
+    public function returnsThis(): $this {
+        return $this;
+    }
+
+    public function returnsStatic(): $this {
+        return new static;
+    }
+}
+
+$test = new Test;
+var_dump($test->returnsThis());
+try {
+    var_dump($test->returnsStatic());
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+object(Test)#1 (0) {
+}
+Test::returnsStatic(): Return value must be of type $this, Test returned

--- a/Zend/tests/type_declarations/this_type/inheritance_this_to_self.phpt
+++ b/Zend/tests/type_declarations/this_type/inheritance_this_to_self.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Cannot replace $this with self
+--FILE--
+<?php
+
+class A {
+    public function method(): $this {}
+}
+class B extends A {
+    public function method(): self {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of B::method(): B must be compatible with A::method(): $this in %s on line %d

--- a/Zend/tests/type_declarations/this_type/inheritance_this_to_static.phpt
+++ b/Zend/tests/type_declarations/this_type/inheritance_this_to_static.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Cannot replace $this with static
+--FILE--
+<?php
+
+class A {
+    public function method(): $this {}
+}
+class B extends A {
+    public function method(): static {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Declaration of B::method(): static must be compatible with A::method(): $this in %s on line %d

--- a/Zend/tests/type_declarations/this_type/inheritance_valid.phpt
+++ b/Zend/tests/type_declarations/this_type/inheritance_valid.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Valid $this inheritance
+--FILE--
+<?php
+
+class A {
+    public function method1(): object {}
+    public function method2(): self {}
+    public function method3(): static {}
+    public function method4(): $this {}
+    public function method5(): int|B {}
+}
+class B extends A {
+    public function method1(): $this {}
+    public function method2(): $this {}
+    public function method3(): $this {}
+    public function method4(): $this {}
+    public function method5(): int|$this {}
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/this_type/interface.phpt
+++ b/Zend/tests/type_declarations/this_type/interface.phpt
@@ -1,0 +1,26 @@
+--TEST--
+$this type in interface
+--FILE--
+<?php
+
+interface FluentInterface {
+    public function doFluentThing(): $this;
+}
+
+class FluentImplementation implements FluentInterface {
+    public function doFluentThing(): $this {
+        echo "Done fluent thing\n";
+        return $this;
+    }
+}
+
+var_dump($fluent = new FluentImplementation);
+var_dump($fluent->doFluentThing());
+
+?>
+--EXPECT--
+object(FluentImplementation)#1 (0) {
+}
+Done fluent thing
+object(FluentImplementation)#1 (0) {
+}

--- a/Zend/tests/type_declarations/this_type/not_this.phpt
+++ b/Zend/tests/type_declarations/this_type/not_this.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Using a variable other than $this as type
+--FILE--
+<?php
+
+function(): $var {}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use $var as type in %s on line %d

--- a/Zend/tests/type_declarations/this_type/on_closure.phpt
+++ b/Zend/tests/type_declarations/this_type/on_closure.phpt
@@ -1,0 +1,29 @@
+--TEST--
+$this on closure
+--FILE--
+<?php
+
+class Test {}
+
+$fn = function(): $this { return $this; };
+var_dump($fn->call(new Test));
+
+$fn2 = function(): $this { return new Test; };
+try {
+    var_dump($fn2->call(new Test));
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump($fn2());
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+object(Test)#2 (0) {
+}
+Test::{closure}(): Return value must be of type $this, Test returned
+{closure}(): Return value must be of type $this, Test returned

--- a/Zend/tests/type_declarations/this_type/on_function.phpt
+++ b/Zend/tests/type_declarations/this_type/on_function.phpt
@@ -1,0 +1,11 @@
+--TEST--
+$this on global function
+--FILE--
+<?php
+
+function test(): $this {
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use "$this" type when no class scope is active in %s on line %d

--- a/Zend/tests/type_declarations/this_type/on_static_closure.phpt
+++ b/Zend/tests/type_declarations/this_type/on_static_closure.phpt
@@ -1,0 +1,14 @@
+--TEST--
+$this on static closure
+--FILE--
+<?php
+
+class Test {
+    public function method() {
+        return static function(): $this {};
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use "$this" type on static closure in %s on line %d

--- a/Zend/tests/type_declarations/this_type/on_static_method.phpt
+++ b/Zend/tests/type_declarations/this_type/on_static_method.phpt
@@ -1,0 +1,13 @@
+--TEST--
+$this on static method
+--FILE--
+<?php
+
+class Test {
+    public static function method(): $this {
+    }
+}
+
+?>
+--EXPECTF--
+Fatal error: Cannot use "$this" type on static method in %s on line %d

--- a/Zend/tests/type_declarations/this_type/redundant_this.phpt
+++ b/Zend/tests/type_declarations/this_type/redundant_this.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Redundant object|$this type
+--FILE--
+<?php
+
+class Test {
+    public function method(): object|$this {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Type $this|object contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/this_type/redundant_this_2.phpt
+++ b/Zend/tests/type_declarations/this_type/redundant_this_2.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Redundant static|$this type
+--FILE--
+<?php
+
+class Test {
+    public function method(): static|$this {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Type $this|static contains both static and $this, which is redundant in %s on line %d

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -786,6 +786,7 @@ zend_ast *zend_negate_num_string(zend_ast *ast);
 uint32_t zend_add_class_modifier(uint32_t flags, uint32_t new_flag);
 uint32_t zend_add_member_modifier(uint32_t flags, uint32_t new_flag);
 bool zend_handle_encoding_declaration(zend_ast *ast);
+bool zend_handle_this_type(zend_ast *ast);
 
 ZEND_API zend_class_entry *zend_bind_class_in_slot(
 		zval *class_table_slot, zval *lcname, zend_string *lc_parent_name);

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -342,9 +342,9 @@ static bool zend_type_contains_traversable(zend_type type) {
 	return 0;
 }
 
-static bool zend_type_permits_self(
+static bool zend_type_permits_static(
 		zend_type type, zend_class_entry *scope, zend_class_entry *self) {
-	if (ZEND_TYPE_FULL_MASK(type) & MAY_BE_OBJECT) {
+	if (ZEND_TYPE_FULL_MASK(type) & (MAY_BE_OBJECT|MAY_BE_STATIC)) {
 		return 1;
 	}
 
@@ -578,10 +578,10 @@ static inheritance_status zend_perform_covariant_type_check(
 			/* Replacing iterable with array is okay */
 			added_types &= ~MAY_BE_ARRAY;
 		}
-		if ((added_types & MAY_BE_STATIC)
-				&& zend_type_permits_self(proto_type, proto_scope, fe_scope)) {
-			/* Replacing type that accepts self with static is okay */
-			added_types &= ~MAY_BE_STATIC;
+		if ((added_types & (MAY_BE_STATIC|MAY_BE_THIS))
+				&& zend_type_permits_static(proto_type, proto_scope, fe_scope)) {
+			/* Replacing type that accepts static with static/$this is okay */
+			added_types &= ~(MAY_BE_STATIC|MAY_BE_THIS);
 		}
 
 		if (added_types == MAY_BE_NEVER) {

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -810,6 +810,11 @@ type_expr:
 type:
 		type_without_static	{ $$ = $1; }
 	|	T_STATIC			{ $$ = zend_ast_create_ex(ZEND_AST_TYPE, IS_STATIC); }
+	|	T_VARIABLE {
+			if (!zend_handle_this_type($1)) { YYERROR; }
+			$$ = zend_ast_create_ex(ZEND_AST_TYPE, IS_THIS);
+			zend_string_release(zend_ast_get_str($1));
+		}
 ;
 
 union_type:

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -523,6 +523,7 @@ EMPTY_SWITCH_DEFAULT_CASE()
 	_(ZEND_STR_ERROR_REPORTING,        "error_reporting") \
 	_(ZEND_STR_STATIC,                 "static") \
 	_(ZEND_STR_THIS,                   "this") \
+	_(ZEND_STR_THIS_VAR,               "$this") \
 	_(ZEND_STR_VALUE,                  "value") \
 	_(ZEND_STR_KEY,                    "key") \
 	_(ZEND_STR_MAGIC_INVOKE,           "__invoke") \

--- a/Zend/zend_type_info.h
+++ b/Zend/zend_type_info.h
@@ -42,6 +42,7 @@
 #define MAY_BE_VOID                 (1 << IS_VOID)
 #define MAY_BE_NEVER                (1 << IS_NEVER)
 #define MAY_BE_STATIC               (1 << IS_STATIC)
+#define MAY_BE_THIS       	        (1 << IS_THIS)
 
 #define MAY_BE_ARRAY_SHIFT          (IS_REFERENCE)
 
@@ -57,9 +58,9 @@
 #define MAY_BE_ARRAY_OF_ANY			(MAY_BE_ANY      << MAY_BE_ARRAY_SHIFT)
 #define MAY_BE_ARRAY_OF_REF			(MAY_BE_REF      << MAY_BE_ARRAY_SHIFT)
 
-#define MAY_BE_ARRAY_PACKED         (1<<21)
-#define MAY_BE_ARRAY_NUMERIC_HASH   (1<<22) /* hash with numeric keys */
-#define MAY_BE_ARRAY_STRING_HASH    (1<<23) /* hash with string keys */
+#define MAY_BE_ARRAY_PACKED         (1<<22)
+#define MAY_BE_ARRAY_NUMERIC_HASH   (1<<23) /* hash with numeric keys */
+#define MAY_BE_ARRAY_STRING_HASH    (1<<24) /* hash with string keys */
 
 #define MAY_BE_ARRAY_KEY_LONG       (MAY_BE_ARRAY_PACKED | MAY_BE_ARRAY_NUMERIC_HASH)
 #define MAY_BE_ARRAY_KEY_STRING     MAY_BE_ARRAY_STRING_HASH
@@ -70,8 +71,8 @@
 #define MAY_BE_PACKED_ONLY(t)       (MAY_BE_PACKED(t) && !MAY_BE_HASH(t))
 #define MAY_BE_HASH_ONLY(t)         (MAY_BE_HASH(t) && !MAY_BE_PACKED(t))
 
-#define MAY_BE_CLASS                (1<<24)
-#define MAY_BE_INDIRECT             (1<<25)
+#define MAY_BE_CLASS                (1<<25)
+#define MAY_BE_INDIRECT             (1<<26)
 
 #define MAY_BE_RC1                  (1<<30) /* may be non-reference with refcount == 1 */
 #define MAY_BE_RCN                  (1u<<31) /* may be non-reference with refcount > 1  */

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -142,17 +142,17 @@ typedef struct {
 #define _ZEND_TYPE_MASK ((1u << 25) - 1)
 /* Only one of these bits may be set. */
 #define _ZEND_TYPE_NAME_BIT (1u << 24)
+/* TODO: bit 23 is not used */
 #define _ZEND_TYPE_LIST_BIT (1u << 22)
 #define _ZEND_TYPE_KIND_MASK (_ZEND_TYPE_LIST_BIT|_ZEND_TYPE_NAME_BIT)
-/* TODO: bit 21 is not used */
 /* Whether the type list is arena allocated */
-#define _ZEND_TYPE_ARENA_BIT (1u << 20)
+#define _ZEND_TYPE_ARENA_BIT (1u << 21)
 /* Whether the type list is an intersection type */
-#define _ZEND_TYPE_INTERSECTION_BIT (1u << 19)
+#define _ZEND_TYPE_INTERSECTION_BIT (1u << 20)
 /* Whether the type is a union type */
-#define _ZEND_TYPE_UNION_BIT (1u << 18)
+#define _ZEND_TYPE_UNION_BIT (1u << 19)
 /* Type mask excluding the flags above. */
-#define _ZEND_TYPE_MAY_BE_MASK ((1u << 18) - 1)
+#define _ZEND_TYPE_MAY_BE_MASK ((1u << 19) - 1)
 /* Must have same value as MAY_BE_NULL */
 #define _ZEND_TYPE_NULLABLE_BIT 0x2u
 
@@ -538,6 +538,7 @@ struct _zend_ast_ref {
 #define IS_STATIC					15
 #define IS_MIXED					16
 #define IS_NEVER					17
+#define IS_THIS						18
 
 /* internal types */
 #define IS_INDIRECT             	12
@@ -546,8 +547,8 @@ struct _zend_ast_ref {
 #define _IS_ERROR					15
 
 /* used for casts */
-#define _IS_BOOL					18
-#define _IS_NUMBER					19
+#define _IS_BOOL					19
+#define _IS_NUMBER					20
 
 static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 	return pz->u1.v.type;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3067,6 +3067,9 @@ ZEND_METHOD(ReflectionUnionType, getTypes)
 	type_mask = ZEND_TYPE_PURE_MASK(param->type);
 	ZEND_ASSERT(!(type_mask & MAY_BE_VOID));
 	ZEND_ASSERT(!(type_mask & MAY_BE_NEVER));
+	if (type_mask & MAY_BE_THIS) {
+		append_type_mask(return_value, MAY_BE_STATIC);
+	}
 	if (type_mask & MAY_BE_STATIC) {
 		append_type_mask(return_value, MAY_BE_STATIC);
 	}

--- a/ext/reflection/tests/this_type.phpt
+++ b/ext/reflection/tests/this_type.phpt
@@ -1,0 +1,46 @@
+--TEST--
+$this type reflection
+--FILE--
+<?php
+
+class Test {
+    public function method1(): $this {}
+    public function method2(): ?$this {}
+    public function method3(): $this|FooBar {}
+}
+
+function printType(ReflectionType $type) {
+    echo (string) $type, "\n";
+    if ($type instanceof ReflectionNamedType) {
+        echo "  isBuiltin: "; var_dump($type->isBuiltin());
+        echo "  getName: "; var_dump($type->getName());
+    } else {
+        foreach ($type->getTypes() as $type) {
+            printType($type);
+        }
+    }
+    echo "\n";
+}
+
+printType((new ReflectionMethod(Test::class, "method1"))->getReturnType());
+printType((new ReflectionMethod(Test::class, "method2"))->getReturnType());
+printType((new ReflectionMethod(Test::class, "method3"))->getReturnType());
+
+?>
+--EXPECT--
+$this
+  isBuiltin: bool(true)
+  getName: string(5) "$this"
+
+?$this
+  isBuiltin: bool(true)
+  getName: string(5) "$this"
+
+FooBar|$this
+FooBar
+  isBuiltin: bool(false)
+  getName: string(6) "FooBar"
+
+static
+  isBuiltin: bool(false)
+  getName: string(6) "static"


### PR DESCRIPTION
The `$this` type is a subtype of `static` that only allows returning `$this`. On an interface, it enforces a fluent implementation, while `static` could also be wither-style API.

This has been suggested by @nicolas-grekas, I'm not completely sure it's a good idea yet :)

RFC: https://wiki.php.net/rfc/this_return_type