### PR TITLE
Fix param name order for Phar::copy()

### DIFF
--- a/ext/phar/phar_object.stub.php
+++ b/ext/phar/phar_object.stub.php
@@ -46,7 +46,7 @@ class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
     public function convertToData(?int $format = null, ?int $compression = null, ?string $extension = null) {}
 
     /** @return bool */
-    public function copy(string $to, string $from) {}
+    public function copy(string $from, string $to) {}
 
     /** @return int */
     public function count(int $mode = COUNT_NORMAL) {}
@@ -258,7 +258,7 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool
      * @implementation-alias Phar::copy
      */
-    public function copy(string $to, string $from) {}
+    public function copy(string $from, string $to) {}
 
     /**
      * @return int

--- a/ext/phar/phar_object_arginfo.h
+++ b/ext/phar/phar_object_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0973430f90bd972380a9c4434808e9857f703548 */
+ * Stub hash: 32161bce721911d28984bc8198e615d345cb89d7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -58,8 +58,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Phar_convertToData arginfo_class_Phar_convertToExecutable
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar_copy, 0, 0, 2)
-	ZEND_ARG_TYPE_INFO(0, to, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, from, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, to, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Phar_count, 0, 0, 0)


### PR DESCRIPTION
Spotted this while working on the docs, looking at the implementation it seems the order is swapped.