### PR TITLE
Fix O(N) performance of DOMNode::replaceChild() 

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1002,7 +1002,7 @@ PHP_METHOD(DOMNode, replaceChild)
 	zval *id, *newnode, *oldnode;
 	xmlNodePtr children, newchild, oldchild, nodep;
 	dom_object *intern, *newchildobj, *oldchildobj;
-	int foundoldchild = 0, stricterror;
+	int stricterror;
 
 	int ret;
 
@@ -1043,42 +1043,32 @@ PHP_METHOD(DOMNode, replaceChild)
 		RETURN_FALSE;
 	}
 
-	/* check for the old child and whether the new child is already a child */
-	while (children) {
-		if (children == oldchild) {
-			foundoldchild = 1;
-			break;
-		}
-		children = children->next;
-	}
-
-	if (foundoldchild) {
-		if (newchild->type == XML_DOCUMENT_FRAG_NODE) {
-			xmlNodePtr prevsib, nextsib;
-			prevsib = oldchild->prev;
-			nextsib = oldchild->next;
-
-			xmlUnlinkNode(oldchild);
-
-			newchild = _php_dom_insert_fragment(nodep, prevsib, nextsib, newchild, intern, newchildobj);
-			if (newchild) {
-				dom_reconcile_ns(nodep->doc, newchild);
-			}
-		} else if (oldchild != newchild) {
-			if (newchild->doc == NULL && nodep->doc != NULL) {
-				xmlSetTreeDoc(newchild, nodep->doc);
-				newchildobj->document = intern->document;
-				php_libxml_increment_doc_ref((php_libxml_node_object *)newchildobj, NULL);
-			}
-			xmlReplaceNode(oldchild, newchild);
-			dom_reconcile_ns(nodep->doc, newchild);
-		}
-		DOM_RET_OBJ(oldchild, &ret, intern);
-		return;
-	} else {
+	if (oldchild->parent != nodep) {
 		php_dom_throw_error(NOT_FOUND_ERR, stricterror);
 		RETURN_FALSE;
 	}
+
+	if (newchild->type == XML_DOCUMENT_FRAG_NODE) {
+		xmlNodePtr prevsib, nextsib;
+		prevsib = oldchild->prev;
+		nextsib = oldchild->next;
+
+		xmlUnlinkNode(oldchild);
+
+		newchild = _php_dom_insert_fragment(nodep, prevsib, nextsib, newchild, intern, newchildobj);
+		if (newchild) {
+			dom_reconcile_ns(nodep->doc, newchild);
+		}
+	} else if (oldchild != newchild) {
+		if (newchild->doc == NULL && nodep->doc != NULL) {
+			xmlSetTreeDoc(newchild, nodep->doc);
+			newchildobj->document = intern->document;
+			php_libxml_increment_doc_ref((php_libxml_node_object *)newchildobj, NULL);
+		}
+		xmlReplaceNode(oldchild, newchild);
+		dom_reconcile_ns(nodep->doc, newchild);
+	}
+	DOM_RET_OBJ(oldchild, &ret, intern);
 }
 /* }}} end dom_node_replace_child */
 

--- a/ext/dom/tests/DOMNode_replaceChild_error1.phpt
+++ b/ext/dom/tests/DOMNode_replaceChild_error1.phpt
@@ -1,0 +1,21 @@
+--TEST--
+replaceChild() where the old node is not a child
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$document = new DOMDocument();
+$real_parent = $document->createElement('real');
+$parent = $document->createElement('p');
+$child1 = $document->createElement('child1');
+$child2 = $document->createElement('child2');
+$child3 = $document->createElement('child3');
+$real_parent->appendChild($child1);
+$parent->appendChild($child2);
+try {
+	$parent->replaceChild($child3, $child1);
+} catch (DOMException $e) {
+	echo "DOMException: " . $e->getMessage();
+}
+--EXPECT--
+DOMException: Not Found Error

--- a/ext/dom/tests/DOMNode_replaceChild_error2.phpt
+++ b/ext/dom/tests/DOMNode_replaceChild_error2.phpt
@@ -1,0 +1,19 @@
+--TEST--
+replaceChild() where the new node is a grandparent of the old node 
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$document = new DOMDocument();
+$a = $document->createElement('a');
+$b = $document->createElement('b');
+$c = $document->createElement('c');
+$a->appendChild($b);
+$b->appendChild($c);
+try {
+	$b->replaceChild($a, $c);
+} catch (DOMException $e) {
+	echo "DOMException: " . $e->getMessage();
+}
+--EXPECT--
+DOMException: Hierarchy Request Error


### PR DESCRIPTION
The patch is motivated by a real-world request which originally took 466s, but with the patch it only takes 76s. In the first commit, I added a test which covers the code I'm changing. In the second commit, I removed the loop over all children and replaced it by a check of the parent pointer.

The early return and indent change improves the readability of the code, but I can omit it for easier backporting if you prefer. The change can be backported to all maintained branches.