### PR TITLE
use AVX2 in zend_hash_real_init_mixed_ex()

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -31,6 +31,10 @@
 # include <emmintrin.h>
 #endif
 
+#ifdef __AVX2__
+# include <immintrin.h>
+#endif
+
 #if ZEND_DEBUG
 # define HT_ASSERT(ht, expr) \
 	ZEND_ASSERT((expr) || (HT_FLAGS(ht) & HASH_FLAG_ALLOW_COW_VIOLATION))
@@ -174,7 +178,14 @@ static zend_always_inline void zend_hash_real_init_mixed_ex(HashTable *ht)
 		HT_SET_DATA_ADDR(ht, data);
 		/* Don't overwrite iterator count. */
 		ht->u.v.flags = HASH_FLAG_STATIC_KEYS;
-#ifdef __SSE2__
+#if defined(__AVX2__)
+		do {
+			__m256i ymm0 = _mm256_setzero_si256();
+			ymm0 = _mm256_cmpeq_epi8(ymm0, ymm0);
+			_mm256_storeu_si256((__m256i*)&HT_HASH_EX(data,  0), ymm0);
+			_mm256_storeu_si256((__m256i*)&HT_HASH_EX(data,  8), ymm0);
+		} while (0);
+#elif defined(__SSE2__)
 		do {
 			__m128i xmm0 = _mm_setzero_si128();
 			xmm0 = _mm_cmpeq_epi8(xmm0, xmm0);


### PR DESCRIPTION
Whether to make this kind of improvement is debatable, and we will send a PR to make sure of it.
Need `-mavx2` compile options.