### PR TITLE
fix(php_set_attribute_id): fix incorrect ID removal, when is_id == 1

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1157,11 +1157,9 @@ static void php_set_attribute_id(xmlAttrPtr attrp, zend_bool is_id) /* {{{ */
 			xmlAddID(NULL, attrp->doc, id_val, attrp);
 			xmlFree(id_val);
 		}
-	} else {
-		if (attrp->atype == XML_ATTRIBUTE_ID) {
-			xmlRemoveID(attrp->doc, attrp);
-			attrp->atype = 0;
-		}
+	} else if (is_id == 0 && attrp->atype == XML_ATTRIBUTE_ID) {
+		xmlRemoveID(attrp->doc, attrp);
+		attrp->atype = 0;
 	}
 }
 /* }}} */

--- a/ext/dom/tests/bug81433.phpt
+++ b/ext/dom/tests/bug81433.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Bug #81433 (DOMElement::setIdAttribute(attr, true) called twice removes ID)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+if (LIBXML_VERSION >= 20912) die('skip For libxml2 < 2.9.12 only');
+?>
+--FILE--
+<?php
+$dom = new DOMDocument('1.0', 'utf-8');
+
+$element = $dom->createElement('test', 'root');
+
+$dom->appendChild($element);
+
+$element->setAttribute("id", 123);
+$element->setIdAttribute("id", true);
+
+$node = $element->getAttributeNode("id");
+var_dump($node->isId());
+
+$element->setIdAttribute("id", true);
+var_dump($node->isId());
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/81433.html');
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/dom/tests/bug81433.phpt
+++ b/ext/dom/tests/bug81433.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Bug #81433 (DOMElement::setIdAttribute(attr, true) called twice removes ID)
---SKIPIF--
-<?php
-require_once('skipif.inc');
-if (LIBXML_VERSION >= 20912) die('skip For libxml2 < 2.9.12 only');
-?>
 --FILE--
 <?php
 $dom = new DOMDocument('1.0', 'utf-8');
@@ -21,10 +16,6 @@ var_dump($node->isId());
 
 $element->setIdAttribute("id", true);
 var_dump($node->isId());
-?>
---CLEAN--
-<?php
-unlink(__DIR__ . '/81433.html');
 ?>
 --EXPECT--
 bool(true)


### PR DESCRIPTION
This is how we can reproduce the bug:

  ```
$dom = new DOMDocument('1.0', 'utf-8');

$element = $dom->createElement('test', 'root');

$dom->appendChild($element);

$element->setAttribute("id", 123);
$element->setIdAttribute("id", true);

$node = $element->getAttributeNode("id");
echo $node->isId(), "\n";

$element->setIdAttribute("id", true);
echo $node->isId(), "\n";
  ```

And we get printed just

```
1
```

So, the second call to setIdAttribute, even with `is_id` set to `true`, revokes the identity from the attribute. The problem is with `else` branch of the source code:

```
	if (is_id == 1 && attrp->atype != XML_ATTRIBUTE_ID) {
		xmlChar *id_val;

		id_val = xmlNodeListGetString(attrp->doc, attrp->children, 1);
		if (id_val != NULL) {
			xmlAddID(NULL, attrp->doc, id_val, attrp);
			xmlFree(id_val);
		}
	} else {
		if (attrp->atype == XML_ATTRIBUTE_ID) {
			xmlRemoveID(attrp->doc, attrp);
			attrp->atype = 0;
		}
	}
```
It removes identity, but does not check if `is_id` is `0`.

