### PR TITLE
Fix #81424: PCRE2 10.35 JIT performance regression

### DIFF
--- a/ext/pcre/pcre2lib/pcre2_jit_compile.c
+++ b/ext/pcre/pcre2lib/pcre2_jit_compile.c
@@ -11152,7 +11152,7 @@ early_fail_type = (early_fail_ptr & 0x7);
 early_fail_ptr >>= 3;
 
 /* During recursion, these optimizations are disabled. */
-if (common->early_fail_start_ptr == 0)
+if (common->early_fail_start_ptr == 0 && common->fast_forward_bc_ptr == NULL)
   {
   early_fail_ptr = 0;
   early_fail_type = type_skip;


### PR DESCRIPTION
We backport the respective upstream fix[1] to our bundled pcre2lib.

[1] <https://github.com/PhilipHazel/pcre2/commit/dc5f96663597572f694147aeec3525003c351123>

---

Background: we updated from PCRE2 10.34 to PCRE2 10.35 (which introduced this performance regression in PHP 7.4.12; this is why it might be reasonable to backport the fix to PHP-7.4. If we don't want to touch the stable branches, we should at least backport to PHP-8.1, which has PCRE2 10.37; or we see if we can update to PCRE2 10.38, which is not yet released, though.