### PR TITLE
Fix #80663: Recursive SplFixedArray::setSize() may cause double-free

### DIFF
--- a/ext/spl/tests/bug80663.phpt
+++ b/ext/spl/tests/bug80663.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #80663 (Recursive SplFixedArray::setSize() may cause double-free)
+--FILE--
+<?php
+class InvalidDestructor {
+    public function __destruct() {
+        try {
+            $GLOBALS['obj']->setSize(0);
+        } catch (LogicException $ex) {
+            echo $ex->getMessage();
+        }
+    }
+}
+
+$obj = new SplFixedArray(1000);
+$obj[0] = new InvalidDestructor();
+$obj->setSize(0);
+?>
+--EXPECT--
+recursive resize is not allowed


### PR DESCRIPTION
We disallow recursive calls to SplFixedArray::setSize() to avoid that,
and throw a LogicException instead.

---

If we are concerned about the BC break (at least some recursive resize operations don't appear to be a real issue), we could ignore the operation and raise E_WARNING instead of throwing.