### PR TITLE
Fix OOB read due to timezone_open() with 5 digit offset

### DIFF
--- a/ext/date/lib/parse_date.c
+++ b/ext/date/lib/parse_date.c
@@ -766,6 +766,9 @@ static timelib_long timelib_parse_tz_cor(char **ptr)
 				return sHOUR(tmp / 100) + sMIN(tmp % 100);
 			}
 		case 5: /* HH:MM */
+			if (begin[2] != ':') {
+				return 0;
+			}
 			tmp = sHOUR(strtol(begin, NULL, 10)) + sMIN(strtol(begin + 3, NULL, 10));
 			return tmp;
 	}

--- a/ext/date/lib/parse_date.re
+++ b/ext/date/lib/parse_date.re
@@ -764,6 +764,9 @@ static timelib_long timelib_parse_tz_cor(char **ptr)
 				return sHOUR(tmp / 100) + sMIN(tmp % 100);
 			}
 		case 5: /* HH:MM */
+			if (begin[2] != ':') {
+				return 0;
+			}
 			tmp = sHOUR(strtol(begin, NULL, 10)) + sMIN(strtol(begin + 3, NULL, 10));
 			return tmp;
 	}

--- a/ext/date/tests/bug78984.phpt
+++ b/ext/date/tests/bug78984.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #78984 (DateTimeZone accepting invalid UTC timezones)
+--FILE--
+<?php
+$tz = @timezone_open('+30157');
+if ($tz) {
+    // relevant case for quick fix
+    var_dump($tz->getName());
+} else {
+    // dummy case for proper fix
+    var_dump("+00:00");
+}
+?>
+--EXPECT--
+string(6) "+00:00"


### PR DESCRIPTION
This has been reported as bug #78984, and is generally and properly
fixed as of timelib 2020.3 (PHP-8.0).  However, it is not fixed in
PHP-7.4, where the test results in an OOB read, and an unterminated
C string when calling `::getName()`.  Therefore, we apply a minimal
fix which just avoids this dangerous behavior.