### PR TITLE
JIT/arm64: fixed unsafe immediate encoding in commit d4ed6b6

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -8460,7 +8460,7 @@ static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t
 	} else {
 		|	// if (CACHED_PTR(opline->result.num))
 		|	ldr REG2, EX->run_time_cache
-		|	ldr REG0, [REG2, #opline->result.num]
+		|	MEM_ACCESS_64_WITH_UOFFSET ldr, REG0, REG2, opline->result.num, TMP1
 		|	cbz REG0, >1
 		|.cold_code
 		|1:
@@ -8469,25 +8469,24 @@ static int zend_jit_init_fcall(dasm_State **Dst, const zend_op *opline, uint32_t
 		 && func->type == ZEND_USER_FUNCTION
 		 && (func->op_array.fn_flags & ZEND_ACC_IMMUTABLE)) {
 			|	LOAD_ADDR FCARG1x, func
-			|	str FCARG1x, [REG2, #opline->result.num]
+			|	MEM_ACCESS_64_WITH_UOFFSET str, FCARG1x, REG2, opline->result.num, TMP1
 			|	EXT_CALL zend_jit_init_func_run_time_cache_helper, REG0
 			|	mov REG0, RETVALx
-			||	ZEND_ASSERT(opline->result.num <= LDR_STR_PIMM64);
 			|	b >3
 		} else {
 			zval *zv = RT_CONSTANT(opline, opline->op2);
 
 			if (opline->opcode == ZEND_INIT_FCALL) {
 				|	LOAD_ADDR FCARG1x, Z_STR_P(zv);
-				|	add FCARG2x, REG2, #opline->result.num
+				|	ADD_SUB_64_WITH_CONST_32 add, FCARG2x, REG2, opline->result.num, TMP1
 				|	EXT_CALL zend_jit_find_func_helper, REG0
 			} else if (opline->opcode == ZEND_INIT_FCALL_BY_NAME) {
 				|	LOAD_ADDR FCARG1x, Z_STR_P(zv + 1);
-				|	add FCARG2x, REG2, #opline->result.num
+				|	ADD_SUB_64_WITH_CONST_32 add, FCARG2x, REG2, opline->result.num, TMP1
 				|	EXT_CALL zend_jit_find_func_helper, REG0
 			} else if (opline->opcode == ZEND_INIT_NS_FCALL_BY_NAME) {
 				|	LOAD_ADDR FCARG1x, zv;
-				|	add FCARG2x, REG2, #opline->result.num
+				|	ADD_SUB_64_WITH_CONST_32 add, FCARG2x, REG2, opline->result.num, TMP1
 				|	EXT_CALL zend_jit_find_ns_func_helper, REG0
 			} else {
 				ZEND_UNREACHABLE();


### PR DESCRIPTION
In my local performance testing, function JIT/arm64 failed for wordpress
benchmark after commit d4ed6b6 (including the follow-up fix commit
487efac).

The root cause lies in that immediate encoding for ADD instruction is
unsafe. In this patch, we use the safe macro ADD_SUB_64_WITH_CONST_32.

Besides, safe macro MEM_ACCESS_64_WITH_UOFFSET is used for the two sites
where `opline->result.num` is used as the offset to access memory.

Tests:
Unit tests: all .phpt test cases under `Zend/tests/, tests/, ext/opcache/tests/jit/` can pass with function JIT, tracing JIT, and tracing JIT with `--repeat 3`.
I further tests with `Symfony` and `wordpress`, and found no failure.

Change-Id: I4704ff27e9527e70061046d634652600e55ccc4f