### PR TITLE
Fix #80663: Recursive SplFixedArray::setSize() may cause double-free

### DIFF
--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -115,9 +115,7 @@ static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size) /* {{{ 
 			zval_ptr_dtor(&(elements[i]));
 		}
 
-		if (elements) {
-			efree(elements);
-		}
+		efree(elements);
 	} else if (size > array->size) {
 		array->elements = safe_erealloc(array->elements, size, sizeof(zval), 0);
 		memset(array->elements + array->size, '\0', sizeof(zval) * (size - array->size));

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -93,7 +93,7 @@ static void spl_fixedarray_init(spl_fixedarray *array, zend_long size) /* {{{ */
 
 static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size) /* {{{ */
 {
-	if (size == array->size || (size == 0 && array->elements == NULL)) {
+	if (size == array->size) {
 		/* nothing to do */
 		return;
 	}
@@ -106,16 +106,18 @@ static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size) /* {{{ 
 
 	/* clearing the array */
 	if (size == 0) {
-		zend_long i;
-		zval *elements = array->elements;
+		if (array->elements != NULL) {
+			zend_long i;
+			zval *elements = array->elements;
 
-		array->elements = NULL;
+			array->elements = NULL;
 
-		for (i = 0; i < array->size; i++) {
-			zval_ptr_dtor(&(elements[i]));
+			for (i = 0; i < array->size; i++) {
+				zval_ptr_dtor(&(elements[i]));
+			}
+
+			efree(elements);
 		}
-
-		efree(elements);
 	} else if (size > array->size) {
 		array->elements = safe_erealloc(array->elements, size, sizeof(zval), 0);
 		memset(array->elements + array->size, '\0', sizeof(zval) * (size - array->size));

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -111,12 +111,14 @@ static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size) /* {{{ 
 			zval *elements = array->elements;
 
 			array->elements = NULL;
+			array->size = 0;
 
 			for (i = 0; i < array->size; i++) {
 				zval_ptr_dtor(&(elements[i]));
 			}
 
 			efree(elements);
+			return;
 		}
 	} else if (size > array->size) {
 		array->elements = safe_erealloc(array->elements, size, sizeof(zval), 0);

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -109,11 +109,12 @@ static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size) /* {{{ 
 		if (array->elements != NULL) {
 			zend_long i;
 			zval *elements = array->elements;
+			zend_long old_size = array->size;
 
 			array->elements = NULL;
 			array->size = 0;
 
-			for (i = 0; i < array->size; i++) {
+			for (i = 0; i < old_size; i++) {
 				zval_ptr_dtor(&(elements[i]));
 			}
 

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -93,7 +93,7 @@ static void spl_fixedarray_init(spl_fixedarray *array, zend_long size) /* {{{ */
 
 static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size) /* {{{ */
 {
-	if (size == array->size) {
+	if (size == array->size || (size == 0 && array->elements == NULL)) {
 		/* nothing to do */
 		return;
 	}
@@ -107,14 +107,16 @@ static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size) /* {{{ 
 	/* clearing the array */
 	if (size == 0) {
 		zend_long i;
+		zval *elements = array->elements;
+
+		array->elements = NULL;
 
 		for (i = 0; i < array->size; i++) {
-			zval_ptr_dtor(&(array->elements[i]));
+			zval_ptr_dtor(&(elements[i]));
 		}
 
-		if (array->elements) {
-			efree(array->elements);
-			array->elements = NULL;
+		if (elements) {
+			efree(elements);
 		}
 	} else if (size > array->size) {
 		array->elements = safe_erealloc(array->elements, size, sizeof(zval), 0);

--- a/ext/spl/tests/bug80663.phpt
+++ b/ext/spl/tests/bug80663.phpt
@@ -4,11 +4,7 @@ Bug #80663 (Recursive SplFixedArray::setSize() may cause double-free)
 <?php
 class InvalidDestructor {
     public function __destruct() {
-        try {
-            $GLOBALS['obj']->setSize(0);
-        } catch (LogicException $ex) {
-            echo $ex->getMessage();
-        }
+        $GLOBALS['obj']->setSize(0);
     }
 }
 
@@ -16,5 +12,11 @@ $obj = new SplFixedArray(1000);
 $obj[0] = new InvalidDestructor();
 $obj->setSize(0);
 ?>
---EXPECT--
+--EXPECTF--
+Notice: Undefined index: obj in %s on line %d
 
+Fatal error: Uncaught Error: Call to a member function setSize() on null in %s:%d
+Stack trace:
+#0 [internal function]: InvalidDestructor->__destruct()
+#1 {main}
+  thrown in %s on line %d

--- a/ext/spl/tests/bug80663.phpt
+++ b/ext/spl/tests/bug80663.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #80663 (Recursive SplFixedArray::setSize() may cause double-free)
+--FILE--
+<?php
+class InvalidDestructor {
+    public function __destruct() {
+        try {
+            $GLOBALS['obj']->setSize(0);
+        } catch (LogicException $ex) {
+            echo $ex->getMessage();
+        }
+    }
+}
+
+$obj = new SplFixedArray(1000);
+$obj[0] = new InvalidDestructor();
+$obj->setSize(0);
+?>
+--EXPECT--
+

--- a/ext/spl/tests/bug80663.phpt
+++ b/ext/spl/tests/bug80663.phpt
@@ -12,11 +12,4 @@ $obj = new SplFixedArray(1000);
 $obj[0] = new InvalidDestructor();
 $obj->setSize(0);
 ?>
---EXPECTF--
-Notice: Undefined index: obj in %s on line %d
-
-Fatal error: Uncaught Error: Call to a member function setSize() on null in %s:%d
-Stack trace:
-#0 [internal function]: InvalidDestructor->__destruct()
-#1 {main}
-  thrown in %s on line %d
+--EXPECT--


### PR DESCRIPTION
We address the `::setSize(0)` case by setting `array->element = NULL`
before we destroy the elements, and bail in this case out on re-entry
into `spl_fixedarray_resize()`.

This is an alternative solution to PR #7485 based on [@nikic's suggestion](https://github.com/php/php-src/pull/7485#issuecomment-922744179).