### PR TITLE
Use ASCII lower case for misc case folding

### DIFF
--- a/ext/intl/grapheme/grapheme_string.c
+++ b/ext/intl/grapheme/grapheme_string.c
@@ -27,8 +27,6 @@
 #include <unicode/ustring.h>
 #include <unicode/ubrk.h>
 
-#include "ext/standard/php_string.h"
-
 /* }}} */
 
 #define GRAPHEME_EXTRACT_TYPE_COUNT		0
@@ -179,9 +177,9 @@ PHP_FUNCTION(grapheme_stripos)
 		char *haystack_dup, *needle_dup;
 		int32_t noffset = offset >= 0 ? offset : (int32_t)haystack_len + offset;
 		needle_dup = estrndup(needle, needle_len);
-		php_strtolower(needle_dup, needle_len);
+		zend_str_tolower(needle_dup, needle_len);
 		haystack_dup = estrndup(haystack, haystack_len);
-		php_strtolower(haystack_dup, haystack_len);
+		zend_str_tolower(haystack_dup, haystack_len);
 
 		found = php_memnstr(haystack_dup + noffset, needle_dup, needle_len, haystack_dup + haystack_len);
 
@@ -295,9 +293,9 @@ PHP_FUNCTION(grapheme_strripos)
 		char *needle_dup, *haystack_dup;
 
 		needle_dup = estrndup(needle, needle_len);
-		php_strtolower(needle_dup, needle_len);
+		zend_str_tolower(needle_dup, needle_len);
 		haystack_dup = estrndup(haystack, haystack_len);
-		php_strtolower(haystack_dup, haystack_len);
+		zend_str_tolower(haystack_dup, haystack_len);
 
 		ret_pos = grapheme_strrpos_ascii(haystack_dup, haystack_len, needle_dup, needle_len, offset);
 

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -45,7 +45,6 @@
 #define __STDC__ 1
 #endif
 
-#include "ext/standard/php_string.h"
 #include "ext/standard/info.h"
 
 #ifdef HAVE_LDAP_SASL
@@ -2012,7 +2011,8 @@ PHP_FUNCTION(ldap_get_entries)
 			ldap_value_free_len(ldap_value);
 
 			attr_len = strlen(attribute);
-			zend_hash_str_update(Z_ARRVAL(tmp1), php_strtolower(attribute, attr_len), attr_len, &tmp2);
+			zend_str_tolower(attribute, attr_len);
+			zend_hash_str_update(Z_ARRVAL(tmp1), attribute, attr_len, &tmp2);
 			add_index_string(&tmp1, num_attrib, attribute);
 
 			num_attrib++;

--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -1045,7 +1045,7 @@ php_oci_connection *php_oci_do_connect_ex(char *username, int username_len, char
 	smart_str_0(&hashed_details);
 
 	/* make it lowercase */
-	php_strtolower(ZSTR_VAL(hashed_details.s), ZSTR_LEN(hashed_details.s));
+	zend_str_tolower(ZSTR_VAL(hashed_details.s), ZSTR_LEN(hashed_details.s));
 
 	if (!exclusive && !new_password) {
 		bool found = 0;
@@ -2163,7 +2163,7 @@ static php_oci_spool *php_oci_get_spool(char *username, int username_len, char *
 	/* Session Pool Hash Key : oci8spool***username**edition**hashedpassword**dbname**charset */
 
 	smart_str_0(&spool_hashed_details);
-	php_strtolower(ZSTR_VAL(spool_hashed_details.s), ZSTR_LEN(spool_hashed_details.s));
+	zend_str_tolower(ZSTR_VAL(spool_hashed_details.s), ZSTR_LEN(spool_hashed_details.s));
 	/* }}} */
 
 	spool_out_zv = zend_hash_find(&EG(persistent_list), spool_hashed_details.s);

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -1128,7 +1128,8 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 						char *tmp = estrdup(function->functionName);
 						int  len = strlen(tmp);
 
-						if (zend_hash_str_add_ptr(&ctx.sdl->functions, php_strtolower(tmp, len), len, function) == NULL) {
+						zend_str_tolower(tmp, len);
+						if (zend_hash_str_add_ptr(&ctx.sdl->functions, tmp, len, function) == NULL) {
 							zend_hash_next_index_insert_ptr(&ctx.sdl->functions, function);
 						}
 						efree(tmp);
@@ -1139,7 +1140,8 @@ static sdlPtr load_wsdl(zval *this_ptr, char *struri)
 							}
 							tmp = estrdup(function->requestName);
 							len = strlen(tmp);
-							zend_hash_str_add_ptr(ctx.sdl->requests, php_strtolower(tmp, len), len, function);
+							zend_str_tolower(tmp, len);
+							zend_hash_str_add_ptr(ctx.sdl->requests, tmp, len, function);
 							efree(tmp);
 						}
 					}

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -4070,7 +4070,7 @@ static sdlFunctionPtr get_function(sdlPtr sdl, const char *function_name) /* {{{
 
 	int len = strlen(function_name);
 	char *str = estrndup(function_name,len);
-	php_strtolower(str,len);
+	zend_str_tolower(str,len);
 	if (sdl != NULL) {
 		if ((tmp = zend_hash_str_find_ptr(&sdl->functions, str, len)) != NULL) {
 			efree(str);

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -490,7 +490,7 @@ PHP_FUNCTION(get_meta_tags)
 		} else if (tok == TOK_CLOSETAG) {
 			if (have_name) {
 				/* For BC */
-				php_strtolower(name, strlen(name));
+				zend_str_tolower(name, strlen(name));
 				if (have_content) {
 					add_assoc_string(return_value, name, value);
 				} else {

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -455,7 +455,7 @@ finish:
 			}
 
 			/* Make lowercase for easy comparison against 'standard' headers */
-			php_strtolower(ZSTR_VAL(tmp), ZSTR_LEN(tmp));
+			zend_str_tolower(ZSTR_VAL(tmp), ZSTR_LEN(tmp));
 			t = ZSTR_VAL(tmp);
 
 			if (!header_init) {

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -34,7 +34,6 @@
 #include <sys/utsname.h>
 #endif
 #include "url.h"
-#include "php_string.h"
 
 #ifdef PHP_WIN32
 # include "winver.h"
@@ -135,7 +134,7 @@ PHPAPI ZEND_COLD void php_info_print_module(zend_module_entry *zend_module) /* {
 		if (!sapi_module.phpinfo_as_text) {
 			zend_string *url_name = php_url_encode(zend_module->name, strlen(zend_module->name));
 
-			php_strtolower(ZSTR_VAL(url_name), ZSTR_LEN(url_name));
+			zend_str_tolower(ZSTR_VAL(url_name), ZSTR_LEN(url_name));
 			php_info_printf("<h2><a name=\"module_%s\">%s</a></h2>\n", ZSTR_VAL(url_name), zend_module->name);
 
 			efree(url_name);

--- a/main/main.c
+++ b/main/main.c
@@ -48,7 +48,6 @@
 #include "php_syslog.h"
 #include "fopen_wrappers.h"
 #include "ext/standard/php_standard.h"
-#include "ext/standard/php_string.h"
 #include "ext/date/php_date.h"
 #include "php_variables.h"
 #include "ext/standard/credits.h"
@@ -1013,7 +1012,8 @@ PHPAPI ZEND_COLD void php_verror(const char *docref, const char *params, int typ
 		while((p = strchr(docref_buf, '_')) != NULL) {
 			*p = '-';
 		}
-		docref = php_strtolower(docref_buf, doclen);
+		zend_str_tolower(docref_buf, doclen);
+		docref = docref_buf;
 	}
 
 	/* we have a docref for a function AND

--- a/main/rfc1867.c
+++ b/main/rfc1867.c
@@ -28,7 +28,6 @@
 #include "php_globals.h"
 #include "php_variables.h"
 #include "rfc1867.h"
-#include "ext/standard/php_string.h"
 #include "zend_smart_string.h"
 
 #ifndef DEBUG_FILE_UPLOAD
@@ -714,7 +713,7 @@ SAPI_API SAPI_POST_HANDLER_FUNC(rfc1867_post_handler) /* {{{ */
 		int content_type_len = (int)strlen(content_type_dup);
 		char *content_type_lcase = estrndup(content_type_dup, content_type_len);
 
-		php_strtolower(content_type_lcase, content_type_len);
+		zend_str_tolower(content_type_lcase, content_type_len);
 		boundary = strstr(content_type_lcase, "boundary");
 		if (boundary) {
 			boundary = content_type_dup + (boundary - content_type_lcase);

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1824,7 +1824,7 @@ PHPAPI php_stream_wrapper *php_stream_locate_url_wrapper(const char *path, const
 		if (NULL == (wrapper = zend_hash_str_find_ptr(wrapper_hash, protocol, n))) {
 			char *tmp = estrndup(protocol, n);
 
-			php_strtolower(tmp, n);
+			zend_str_tolower(tmp, n);
 			if (NULL == (wrapper = zend_hash_str_find_ptr(wrapper_hash, tmp, n))) {
 				char wrapper_name[32];
 


### PR DESCRIPTION
Use ASCII case conversion instead of locale-dependent case conversion in
the following places:

* grapheme_stripos() and grapheme_strripos() in the "fast" path
* ldap_get_entries()
* oci_pconnect() for case folding of parameters when constructing a key into the connection or session pool
* SoapClient: case folding of function names
* get_meta_tags(): case conversion of property names
* http stream wrapper: header names
* phpinfo(): anchor names
* php_verror(): docref URLs
* rfc1867.c: Content-Type boundary parameter name
* streams.c: stream protocol names

Bug fixes split out from https://wiki.php.net/rfc/strtolower-ascii