### PR TITLE
Fix #81475: stream_isatty emits warning with attached stream wrapper

### DIFF
--- a/ext/standard/tests/filters/bug81475.phpt
+++ b/ext/standard/tests/filters/bug81475.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #81475 (stream_isatty emits warning with attached stream wrapper)
+--FILE--
+<?php
+$stdout = fopen('php://stdout', 'wb');
+stream_filter_append($stdout, 'string.toupper');
+var_dump(stream_isatty($stdout));
+?>
+--EXPECT--
+bool(false)

--- a/main/streams/cast.c
+++ b/main/streams/cast.c
@@ -295,7 +295,9 @@ PHPAPI int _php_stream_cast(php_stream *stream, int castas, void **ret, int show
 	}
 
 	if (php_stream_is_filtered(stream)) {
-		php_error_docref(NULL, E_WARNING, "cannot cast a filtered stream on this system");
+		if (show_err) {
+			php_error_docref(NULL, E_WARNING, "cannot cast a filtered stream on this system");
+		}
 		return FAILURE;
 	} else if (stream->ops->cast && stream->ops->cast(stream, castas, ret) == SUCCESS) {
 		goto exit_success;


### PR DESCRIPTION
We must not issue warnings, if `show_err` is false.