### PR TITLE
Fix #81477: LimitIterator + SplFileObject regression in 8.0.1

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -2738,7 +2738,9 @@ PHP_METHOD(SplFileObject, seek)
 	}
 	if (line_pos > 0) {
 		intern->u.file.current_line_num++;
-		spl_filesystem_file_free_line(intern);
+		if (!SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_READ_AHEAD)) {
+			spl_filesystem_file_free_line(intern);
+		}
 	}
 } /* }}} */
 

--- a/ext/spl/tests/SplFileObject_next_variation002.phpt
+++ b/ext/spl/tests/SplFileObject_next_variation002.phpt
@@ -26,5 +26,5 @@ echo $s->current();
 --EXPECT--
 //line 3
 //line 4
+//line 3
 //line 4
-//line 5

--- a/ext/spl/tests/bug81477.phpt
+++ b/ext/spl/tests/bug81477.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug #81477 (LimitIterator + SplFileObject regression in 8.0.1)
+--FILE--
+<?php
+$filename = __DIR__ . '/bug81477.csv';
+
+$s = fopen($filename, 'w+');
+fwrite($s, "foo,bar\nbaz,bat\nmore,data\n");
+fclose($s);
+
+$sfo = new SplFileObject($filename);
+$sfo->setFlags(SplFileObject::READ_AHEAD);
+$limitIter = new LimitIterator($sfo, 1, -1);
+
+foreach($limitIter as $row) {
+    var_dump($row);
+}
+?>
+--EXPECT--
+string(8) "baz,bat
+"
+string(10) "more,data
+"
+string(0) ""
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/bug81477.csv');
+?>


### PR DESCRIPTION
We must not free the read line, if the `READ_AHEAD` flag is set.  This
also restores the expectations of SplFileObject_next_variation002.phpt.