### PR TITLE
ARM64: range.phpt failed under RELEASE mode

### DIFF
--- a/ext/standard/tests/array/range.phpt
+++ b/ext/standard/tests/array/range.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test range() function
 --INI--
-precision=14
+serialize_precision=14
 --FILE--
 <?php
 
@@ -347,7 +347,7 @@ array(11) {
   [6]=>
   float(1.6)
   [7]=>
-  float(1.7000000000000002)
+  float(1.7)
   [8]=>
   float(1.8)
   [9]=>
@@ -371,7 +371,7 @@ array(11) {
   [6]=>
   float(1.4)
   [7]=>
-  float(1.2999999999999998)
+  float(1.3)
   [8]=>
   float(1.2)
   [9]=>
@@ -395,7 +395,7 @@ array(11) {
   [6]=>
   float(1.6)
   [7]=>
-  float(1.7000000000000002)
+  float(1.7)
   [8]=>
   float(1.8)
   [9]=>
@@ -419,7 +419,7 @@ array(11) {
   [6]=>
   float(1.6)
   [7]=>
-  float(1.7000000000000002)
+  float(1.7)
   [8]=>
   float(1.8)
   [9]=>


### PR DESCRIPTION
Test case "ext/standard/tests/array/range.phpt" failed on ARM64 machine
only under RELEASE mode.

How to reproduce it:
```
./buildconf -f; ./configure; make -j 128
make test TESTS="-d opcache.enable=1 -d opcache.enable_cli=1 ext/standard/tests/array/range.phpt"
```

Root cause:
I suspect the root cause is that on ARM64 machine, PHP RELEASE mode
produces different values for internal function range() compared to
DEBUG mode.

Take the downsized test case downsize-range.php [1] as an example. We
applied the check-element.diff patch to check the original values. Note
that we print out the floating point numbers with precision 16.

From the outputs in file output.md, we can see the 7-th and 9-th
elements are different between RELEASE and DEBUG.

To be honest, I didn't get where such difference comes from and probably
this is due to different compilation options used by RELEASED and DEBUG.

Fix:
After commit [2], serialize_precision is used for var_dump(). As a
result, the pre-set "precision=14" didn't work actually.

In this patch, we turn to set serialize_precision as 14 and therefore
the difference between RELEASE and DEBUG can be eliminated.

Note-1: this failue didn't occur on x86 machine.
Note-2: in my local test, this is the only test case which behaves
differently on ARM64 machine under RELEASE and DEBUG mode.

[1] https://gist.github.com/shqking/0d55abf8dbaafde4a00ea9304e71f06b
[2] https://github.com/php/php-src/commit/a939805

Change-Id: Ia9b86cea332b39b324b0bc326d93f44770a543c2