### PR TITLE
Fix #77978: Dirname ending in colon unzips to wrong dir

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -117,8 +117,8 @@ static char * php_zip_make_relative_path(char *path, size_t path_len) /* {{{ */
 			return path;
 		}
 
-		if (i >= 2 && (path[i -1] == '.' || path[i -1] == ':')) {
-			/* i is the position of . or :, add 1 for / */
+		if (i >= 2 && path[i -1] == '.') {
+			/* i is the position of ., add 1 for / */
 			path_begin = path + i + 1;
 			break;
 		}

--- a/ext/zip/tests/bug77978.phpt
+++ b/ext/zip/tests/bug77978.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Bug #77978 (Dirname ending in colon unzips to wrong dir)
+--SKIPIF--
+<?php
+if (!extension_loaded("zip")) die("skip zip extension not available");
+?>
+--FILE--
+<?php
+$file = __DIR__ . "/bug77978.zip";
+$target = __DIR__ . "/bug77978";
+
+mkdir($target);
+
+$zip = new ZipArchive();
+$zip->open($file, ZipArchive::CREATE|ZipArchive::OVERWRITE);
+$zip->addFromString("dir/test:/filename.txt", "contents");
+$zip->close();
+
+$zip->open($file);
+// Windows won't extract filenames with colons; we suppress the warning
+@$zip->extractTo($target, "dir/test:/filename.txt");
+$zip->close();
+
+var_dump(!file_exists("$target/filename.txt"));
+var_dump(PHP_OS_FAMILY === "Windows" || file_exists("$target/dir/test:/filename.txt"));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/bug77978.zip");
+@unlink(__DIR__ . "/bug77978/dir/test:/filename.txt");
+@rmdir(__DIR__ . "/bug77978/dir/test:");
+@rmdir(__DIR__ . "/bug77978/dir");
+@rmdir(__DIR__ . "/bug77978");
+?>


### PR DESCRIPTION
When making the relative path, we must not stop on a `:\` sequence in
the middle of the filename.  This is only significant on Windows as it
may indicate an absolute filename, but this is already checked at the
beginning of the function.

Note that the bug and this patch affects all systems.  However, on
Windows the file is no longer extracted at all, since Windows NTSF does
not allow filenames containing colons; this should likely be tackled
along with other unsupported characters (such as trailing dots) by
replacing these with an underscore (this is what Window's built-in
extractor and 7-zip do).