### PR TITLE
Smal cURL refactoring

### DIFF
--- a/ext/curl/curl_file.c
+++ b/ext/curl/curl_file.c
@@ -38,14 +38,14 @@ static void curlfile_ctor(INTERNAL_FUNCTION_PARAMETERS)
 		Z_PARAM_STR_OR_NULL(postname)
 	ZEND_PARSE_PARAMETERS_END();
 
-	zend_update_property_string(curl_CURLFile_class, Z_OBJ_P(cf), "name", sizeof("name")-1, ZSTR_VAL(fname));
+	zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "name", sizeof("name")-1, fname);
 
 	if (mime) {
-		zend_update_property_string(curl_CURLFile_class, Z_OBJ_P(cf), "mime", sizeof("mime")-1, ZSTR_VAL(mime));
+		zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "mime", sizeof("mime")-1, mime);
 	}
 
 	if (postname) {
-		zend_update_property_string(curl_CURLFile_class, Z_OBJ_P(cf), "postname", sizeof("postname")-1, ZSTR_VAL(postname));
+		zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "postname", sizeof("postname")-1, postname);
 	}
 }
 
@@ -82,7 +82,7 @@ static void curlfile_set_property(char *name, size_t name_len, INTERNAL_FUNCTION
 		Z_PARAM_STR(arg)
 	ZEND_PARSE_PARAMETERS_END();
 
-	zend_update_property_string(curl_CURLFile_class, Z_OBJ_P(ZEND_THIS), name, name_len, ZSTR_VAL(arg));
+	zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(ZEND_THIS), name, name_len, arg);
 }
 
 /* {{{ Get file name */

--- a/ext/curl/curl_private.h
+++ b/ext/curl/curl_private.h
@@ -140,7 +140,7 @@ php_curl *init_curl_handle_into_zval(zval *curl);
 void init_curl_handle(php_curl *ch);
 void _php_curl_cleanup_handle(php_curl *);
 void _php_curl_multi_cleanup_list(void *data);
-void _php_curl_verify_handlers(php_curl *ch, int reporterror);
+void _php_curl_verify_handlers(php_curl *ch, bool reporterror);
 void _php_setup_easy_copy_handlers(php_curl *ch, php_curl *source);
 
 static inline php_curl *curl_from_obj(zend_object *obj) {

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -96,7 +96,7 @@ static ZEND_ATTRIBUTE_UNUSED unsigned long php_curl_ssl_id(void)
 # define php_curl_ret(__ret) RETVAL_FALSE; return;
 #endif
 
-static int php_curl_option_str(php_curl *ch, zend_long option, const char *str, const size_t len)
+static zend_result php_curl_option_str(php_curl *ch, zend_long option, const char *str, const size_t len)
 {
 	if (strlen(str) != len) {
 		zend_value_error("%s(): cURL option must not contain any null bytes", get_active_function_name());
@@ -109,7 +109,7 @@ static int php_curl_option_str(php_curl *ch, zend_long option, const char *str, 
 	return error == CURLE_OK ? SUCCESS : FAILURE;
 }
 
-static int php_curl_option_url(php_curl *ch, const char *url, const size_t len) /* {{{ */
+static zend_result php_curl_option_url(php_curl *ch, const char *url, const size_t len) /* {{{ */
 {
 	/* Disable file:// if open_basedir are used */
 	if (PG(open_basedir) && *PG(open_basedir)) {
@@ -131,7 +131,7 @@ static int php_curl_option_url(php_curl *ch, const char *url, const size_t len) 
 }
 /* }}} */
 
-void _php_curl_verify_handlers(php_curl *ch, int reporterror) /* {{{ */
+void _php_curl_verify_handlers(php_curl *ch, bool reporterror) /* {{{ */
 {
 	php_stream *stream;
 
@@ -226,7 +226,7 @@ static HashTable *curl_get_gc(zend_object *object, zval **table, int *n);
 static zend_function *curl_get_constructor(zend_object *object);
 static zend_object *curl_clone_obj(zend_object *object);
 php_curl *init_curl_handle_into_zval(zval *curl);
-static inline int build_mime_structure_from_hash(php_curl *ch, zval *zpostfields);
+static inline zend_result build_mime_structure_from_hash(php_curl *ch, zval *zpostfields);
 
 /* {{{ PHP_INI_BEGIN */
 PHP_INI_BEGIN()
@@ -1249,7 +1249,7 @@ static zend_object *curl_clone_obj(zend_object *object) {
 
 	postfields = &clone_ch->postfields;
 	if (Z_TYPE_P(postfields) != IS_UNDEF) {
-		if (build_mime_structure_from_hash(clone_ch, postfields) != SUCCESS) {
+		if (build_mime_structure_from_hash(clone_ch, postfields) == FAILURE) {
 			zend_throw_exception(NULL, "Failed to clone CurlHandle", 0);
 			return &clone_ch->std;
 		}
@@ -1391,7 +1391,7 @@ static size_t curl_write(char *data, size_t size, size_t nmemb, void *ctx)
 				php_error_docref(NULL, E_WARNING, "Could not call the CURLOPT_WRITEFUNCTION");
 				length = -1;
 			} else if (!Z_ISUNDEF(retval)) {
-				_php_curl_verify_handlers(ch, 1);
+				_php_curl_verify_handlers(ch, /* reporterror */ true);
 				length = zval_get_long(&retval);
 			}
 
@@ -1413,7 +1413,7 @@ static int curl_fnmatch(void *ctx, const char *pattern, const char *string)
 	int rval = CURL_FNMATCHFUNC_FAIL;
 	zval argv[3];
 	zval retval;
-	int  error;
+	zend_result error;
 	zend_fcall_info fci;
 
 	GC_ADDREF(&ch->std);
@@ -1435,7 +1435,7 @@ static int curl_fnmatch(void *ctx, const char *pattern, const char *string)
 	if (error == FAILURE) {
 		php_error_docref(NULL, E_WARNING, "Cannot call the CURLOPT_FNMATCH_FUNCTION");
 	} else if (!Z_ISUNDEF(retval)) {
-		_php_curl_verify_handlers(ch, 1);
+		_php_curl_verify_handlers(ch, /* reporterror */ true);
 		rval = zval_get_long(&retval);
 	}
 	zval_ptr_dtor(&argv[0]);
@@ -1459,7 +1459,7 @@ static size_t curl_progress(void *clientp, double dltotal, double dlnow, double 
 
 	zval argv[5];
 	zval retval;
-	int  error;
+	zend_result error;
 	zend_fcall_info fci;
 
 	GC_ADDREF(&ch->std);
@@ -1483,7 +1483,7 @@ static size_t curl_progress(void *clientp, double dltotal, double dlnow, double 
 	if (error == FAILURE) {
 		php_error_docref(NULL, E_WARNING, "Cannot call the CURLOPT_PROGRESSFUNCTION");
 	} else if (!Z_ISUNDEF(retval)) {
-		_php_curl_verify_handlers(ch, 1);
+		_php_curl_verify_handlers(ch, /* reporterror */ true);
 		if (0 != zval_get_long(&retval)) {
 			rval = 1;
 		}
@@ -1509,7 +1509,7 @@ static size_t curl_read(char *data, size_t size, size_t nmemb, void *ctx)
 		case PHP_CURL_USER: {
 			zval argv[3];
 			zval retval;
-			int  error;
+			zend_result error;
 			zend_fcall_info fci;
 
 			GC_ADDREF(&ch->std);
@@ -1537,7 +1537,7 @@ static size_t curl_read(char *data, size_t size, size_t nmemb, void *ctx)
 				php_error_docref(NULL, E_WARNING, "Cannot call the CURLOPT_READFUNCTION");
 				length = CURL_READFUNC_ABORT;
 			} else if (!Z_ISUNDEF(retval)) {
-				_php_curl_verify_handlers(ch, 1);
+				_php_curl_verify_handlers(ch, /* reporterror */ true);
 				if (Z_TYPE(retval) == IS_STRING) {
 					length = MIN((int) (size * nmemb), Z_STRLEN(retval));
 					memcpy(data, Z_STRVAL(retval), length);
@@ -1577,7 +1577,7 @@ static size_t curl_write_header(char *data, size_t size, size_t nmemb, void *ctx
 		case PHP_CURL_USER: {
 			zval argv[2];
 			zval retval;
-			int  error;
+			zend_result error;
 			zend_fcall_info fci;
 
 			GC_ADDREF(&ch->std);
@@ -1599,7 +1599,7 @@ static size_t curl_write_header(char *data, size_t size, size_t nmemb, void *ctx
 				php_error_docref(NULL, E_WARNING, "Could not call the CURLOPT_HEADERFUNCTION");
 				length = -1;
 			} else if (!Z_ISUNDEF(retval)) {
-				_php_curl_verify_handlers(ch, 1);
+				_php_curl_verify_handlers(ch, /* reporterror */ true);
 				length = zval_get_long(&retval);
 			}
 			zval_ptr_dtor(&argv[0]);
@@ -1988,7 +1988,7 @@ static void free_cb(void *arg) /* {{{ */
 /* }}} */
 #endif
 
-static inline int build_mime_structure_from_hash(php_curl *ch, zval *zpostfields) /* {{{ */
+static inline zend_result build_mime_structure_from_hash(php_curl *ch, zval *zpostfields) /* {{{ */
 {
 	HashTable *postfields = Z_ARRVAL_P(zpostfields);
 	CURLcode error = CURLE_OK;
@@ -2260,7 +2260,7 @@ PHP_FUNCTION(curl_copy_handle)
 
 	postfields = &ch->postfields;
 	if (Z_TYPE_P(postfields) != IS_UNDEF) {
-		if (build_mime_structure_from_hash(dupch, postfields) != SUCCESS) {
+		if (build_mime_structure_from_hash(dupch, postfields) == FAILURE) {
 			zval_ptr_dtor(return_value);
 			php_error_docref(NULL, E_WARNING, "Cannot rebuild mime structure");
 			RETURN_FALSE;
@@ -2269,7 +2269,7 @@ PHP_FUNCTION(curl_copy_handle)
 }
 /* }}} */
 
-static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool is_array_config) /* {{{ */
+static zend_result _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool is_array_config) /* {{{ */
 {
 	CURLcode error = CURLE_OK;
 	zend_long lval;
@@ -2435,12 +2435,12 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 			if ((option == CURLOPT_PROTOCOLS || option == CURLOPT_REDIR_PROTOCOLS) &&
 				(PG(open_basedir) && *PG(open_basedir)) && (lval & CURLPROTO_FILE)) {
 					php_error_docref(NULL, E_WARNING, "CURLPROTO_FILE cannot be activated when an open_basedir is set");
-					return 1;
+					return FAILURE;
 			}
 # if defined(ZTS)
 			if (option == CURLOPT_DNS_USE_GLOBAL_CACHE && lval) {
 				php_error_docref(NULL, E_WARNING, "CURLOPT_DNS_USE_GLOBAL_CACHE cannot be activated when thread safety is enabled");
-				return 1;
+				return FAILURE;
 			}
 # endif
 			error = curl_easy_setopt(ch->cp, option, lval);
@@ -2533,7 +2533,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 		{
 			zend_string *tmp_str;
 			zend_string *str = zval_get_tmp_string(zvalue, &tmp_str);
-			int ret = php_curl_option_str(ch, option, ZSTR_VAL(str), ZSTR_LEN(str));
+			zend_result ret = php_curl_option_str(ch, option, ZSTR_VAL(str), ZSTR_LEN(str));
 			zend_tmp_string_release(tmp_str);
 			return ret;
 		}
@@ -2563,7 +2563,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 			} else {
 				zend_string *tmp_str;
 				zend_string *str = zval_get_tmp_string(zvalue, &tmp_str);
-				int ret = php_curl_option_str(ch, option, ZSTR_VAL(str), ZSTR_LEN(str));
+				zend_result ret = php_curl_option_str(ch, option, ZSTR_VAL(str), ZSTR_LEN(str));
 				zend_tmp_string_release(tmp_str);
 				return ret;
 			}
@@ -2583,7 +2583,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 		{
 			zend_string *tmp_str;
 			zend_string *str = zval_get_tmp_string(zvalue, &tmp_str);
-			int ret = php_curl_option_url(ch, ZSTR_VAL(str), ZSTR_LEN(str));
+			zend_result ret = php_curl_option_url(ch, ZSTR_VAL(str), ZSTR_LEN(str));
 			zend_tmp_string_release(tmp_str);
 			return ret;
 		}
@@ -2757,7 +2757,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 				zend_tmp_string_release(tmp_val);
 				if (!slist) {
 					php_error_docref(NULL, E_WARNING, "Could not build curl_slist");
-					return 1;
+					return FAILURE;
 				}
 			} ZEND_HASH_FOREACH_END();
 
@@ -2881,7 +2881,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 		{
 		    zend_string *tmp_str;
 			zend_string *str = zval_get_tmp_string(zvalue, &tmp_str);
-			int ret;
+			zend_result ret;
 
 			if (ZSTR_LEN(str) && php_check_open_basedir(ZSTR_VAL(str))) {
 				zend_tmp_string_release(tmp_str);
@@ -3056,7 +3056,7 @@ PHP_FUNCTION(curl_exec)
 
 	ch = Z_CURL_P(zid);
 
-	_php_curl_verify_handlers(ch, 1);
+	_php_curl_verify_handlers(ch, /* reporterror */ true);
 
 	_php_curl_cleanup_handle(ch);
 
@@ -3427,7 +3427,7 @@ static void curl_free_obj(zend_object *object)
 		return;
 	}
 
-	_php_curl_verify_handlers(ch, 0);
+	_php_curl_verify_handlers(ch, /* reporterror */ false);
 
 	/*
 	 * Libcurl is doing connection caching. When easy handle is cleaned up,

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -88,7 +88,7 @@ PHP_FUNCTION(curl_multi_add_handle)
 	mh = Z_CURL_MULTI_P(z_mh);
 	ch = Z_CURL_P(z_ch);
 
-	_php_curl_verify_handlers(ch, 1);
+	_php_curl_verify_handlers(ch, /* reporterror */ true);
 
 	_php_curl_cleanup_handle(ch);
 
@@ -217,7 +217,7 @@ PHP_FUNCTION(curl_multi_exec)
 			pz_ch = (zval *)zend_llist_get_next_ex(&mh->easyh, &pos)) {
 			ch = Z_CURL_P(pz_ch);
 
-			_php_curl_verify_handlers(ch, 1);
+			_php_curl_verify_handlers(ch, /* reporterror */ true);
 		}
 	}
 
@@ -318,7 +318,7 @@ PHP_FUNCTION(curl_multi_close)
 	for (pz_ch = (zval *)zend_llist_get_first_ex(&mh->easyh, &pos); pz_ch;
 		pz_ch = (zval *)zend_llist_get_next_ex(&mh->easyh, &pos)) {
 		php_curl *ch = Z_CURL_P(pz_ch);
-		_php_curl_verify_handlers(ch, 1);
+		_php_curl_verify_handlers(ch, /* reporterror */ true);
 		curl_multi_remove_handle(mh->multi, ch->cp);
 	}
 	zend_llist_clean(&mh->easyh);
@@ -374,7 +374,7 @@ static int _php_server_push_callback(CURL *parent_ch, CURL *easy, size_t num_hea
 	zval 					headers;
 	zval 					retval;
 	char 					*header;
-	int  					error;
+	zend_result				error;
 	zend_fcall_info 		fci 			= empty_fcall_info;
 
 	pz_parent_ch = _php_curl_multi_find_easy_handle(mh, parent_ch);
@@ -428,7 +428,8 @@ static int _php_server_push_callback(CURL *parent_ch, CURL *easy, size_t num_hea
 
 #endif
 
-static int _php_curl_multi_setopt(php_curlm *mh, zend_long option, zval *zvalue, zval *return_value) /* {{{ */
+/* Returns true on failure, false on success */
+static bool _php_curl_multi_setopt(php_curlm *mh, zend_long option, zval *zvalue, zval *return_value) /* {{{ */
 {
 	CURLMcode error = CURLM_OK;
 
@@ -544,7 +545,7 @@ void curl_multi_free_obj(zend_object *object)
 		pz_ch = (zval *)zend_llist_get_next_ex(&mh->easyh, &pos)) {
 		if (!(OBJ_FLAGS(Z_OBJ_P(pz_ch)) & IS_OBJ_FREE_CALLED)) {
 			ch = Z_CURL_P(pz_ch);
-			_php_curl_verify_handlers(ch, 0);
+			_php_curl_verify_handlers(ch, /* reporterror */ false);
 		}
 	}
 

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -428,7 +428,6 @@ static int _php_server_push_callback(CURL *parent_ch, CURL *easy, size_t num_hea
 
 #endif
 
-/* Returns true on failure, false on success */
 static bool _php_curl_multi_setopt(php_curlm *mh, zend_long option, zval *zvalue, zval *return_value) /* {{{ */
 {
 	CURLMcode error = CURLM_OK;
@@ -466,9 +465,9 @@ static bool _php_curl_multi_setopt(php_curlm *mh, zend_long option, zval *zvalue
 			}
 
 			ZVAL_COPY(&mh->handlers.server_push->func_name, zvalue);
-			error = curl_multi_setopt(mh->multi, option, _php_server_push_callback);
+			error = curl_multi_setopt(mh->multi, CURLMOPT_PUSHFUNCTION, _php_server_push_callback);
 			if (error != CURLM_OK) {
-				return 0;
+				return false;
 			}
 			error = curl_multi_setopt(mh->multi, CURLMOPT_PUSHDATA, mh);
 			break;
@@ -481,7 +480,7 @@ static bool _php_curl_multi_setopt(php_curlm *mh, zend_long option, zval *zvalue
 
 	SAVE_CURLM_ERROR(mh, error);
 
-	return error != CURLM_OK;
+	return error == CURLM_OK;
 }
 /* }}} */
 
@@ -500,7 +499,7 @@ PHP_FUNCTION(curl_multi_setopt)
 
 	mh = Z_CURL_MULTI_P(z_mh);
 
-	if (!_php_curl_multi_setopt(mh, options, zvalue, return_value)) {
+	if (_php_curl_multi_setopt(mh, options, zvalue, return_value)) {
 		RETURN_TRUE;
 	} else {
 		RETURN_FALSE;

--- a/ext/curl/share.c
+++ b/ext/curl/share.c
@@ -53,7 +53,8 @@ PHP_FUNCTION(curl_share_close)
 }
 /* }}} */
 
-static int _php_curl_share_setopt(php_curlsh *sh, zend_long option, zval *zvalue, zval *return_value) /* {{{ */
+/* Returns true on failure, false on success */
+static bool _php_curl_share_setopt(php_curlsh *sh, zend_long option, zval *zvalue, zval *return_value) /* {{{ */
 {
 	CURLSHcode error = CURLSHE_OK;
 

--- a/ext/curl/share.c
+++ b/ext/curl/share.c
@@ -53,7 +53,6 @@ PHP_FUNCTION(curl_share_close)
 }
 /* }}} */
 
-/* Returns true on failure, false on success */
 static bool _php_curl_share_setopt(php_curlsh *sh, zend_long option, zval *zvalue, zval *return_value) /* {{{ */
 {
 	CURLSHcode error = CURLSHE_OK;
@@ -72,7 +71,7 @@ static bool _php_curl_share_setopt(php_curlsh *sh, zend_long option, zval *zvalu
 
 	SAVE_CURLSH_ERROR(sh, error);
 
-	return error != CURLSHE_OK;
+	return error == CURLSHE_OK;
 }
 /* }}} */
 
@@ -91,7 +90,7 @@ PHP_FUNCTION(curl_share_setopt)
 
 	sh = Z_CURL_SHARE_P(z_sh);
 
-	if (!_php_curl_share_setopt(sh, options, zvalue, return_value)) {
+	if (_php_curl_share_setopt(sh, options, zvalue, return_value)) {
 		RETURN_TRUE;
 	} else {
 		RETURN_FALSE;


### PR DESCRIPTION
Use of ``zend_update_property_str()`` where appropriate prevent a re-computation of the string length.

Use ``bool``/``zend_result`` instead of ``int`` where appropriate.

And the final commit is I think a correct bug fix because for some reason the PHP cURL helper functions return ``true`` on failure and ``false`` on succes