### PR TITLE
Sort DOM properties alphabetically

### DIFF
--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -5,10 +5,13 @@
 class DOMDocumentType extends DOMNode
 {
     /** @readonly */
-    public string $name;
+    public DOMNamedNodeMap $entities;
 
     /** @readonly */
-    public DOMNamedNodeMap $entities;
+    public ?string $internalSubset;
+
+    /** @readonly */
+    public string $name;
 
     /** @readonly */
     public DOMNamedNodeMap $notations;
@@ -18,9 +21,6 @@ class DOMDocumentType extends DOMNode
 
     /** @readonly */
     public string $systemId;
-
-    /** @readonly */
-    public ?string $internalSubset;
 }
 
 class DOMCdataSection extends DOMText
@@ -60,15 +60,10 @@ interface DOMChildNode
 class DOMNode
 {
     /** @readonly */
-    public string $nodeName;
-
-    public ?string $nodeValue;
+    public ?DOMNamedNodeMap $attributes;
 
     /** @readonly */
-    public int $nodeType;
-
-    /** @readonly */
-    public ?DOMNode $parentNode;
+    public ?string $baseURI;
 
     /** @readonly */
     public DOMNodeList $childNodes;
@@ -80,27 +75,32 @@ class DOMNode
     public ?DOMNode $lastChild;
 
     /** @readonly */
-    public ?DOMNode $previousSibling;
+    public ?string $localName;
+
+    /** @readonly */
+    public ?string $namespaceURI;
 
     /** @readonly */
     public ?DOMNode $nextSibling;
 
     /** @readonly */
-    public ?DOMNamedNodeMap $attributes;
+    public string $nodeName;
+
+    /** @readonly */
+    public int $nodeType;
+
+    public ?string $nodeValue;
 
     /** @readonly */
     public ?DOMDocument $ownerDocument;
 
     /** @readonly */
-    public ?string $namespaceURI;
+    public ?DOMNode $parentNode;
 
     public string $prefix;
 
     /** @readonly */
-    public ?string $localName;
-
-    /** @readonly */
-    public ?string $baseURI;
+    public ?DOMNode $previousSibling;
 
     public string $textContent;
 
@@ -282,15 +282,15 @@ class DOMAttr extends DOMNode
     public string $name;
 
     /** @readonly */
-    public bool $specified = true;
-
-    public string $value;
-
-    /** @readonly */
     public ?DOMElement $ownerElement;
 
     /** @readonly */
     public mixed $schemaTypeInfo = null;
+
+    /** @readonly */
+    public bool $specified = true;
+
+    public string $value;
 
     public function __construct(string $name, string $value = "") {}
 
@@ -301,10 +301,7 @@ class DOMAttr extends DOMNode
 class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
 {
     /** @readonly */
-    public string $tagName;
-
-    /** @readonly */
-    public mixed $schemaTypeInfo = null;
+    public int $childElementCount;
 
     /** @readonly */
     public ?DOMElement $firstElementChild;
@@ -313,13 +310,16 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
     public ?DOMElement $lastElementChild;
 
     /** @readonly */
-    public int $childElementCount;
+    public ?DOMElement $nextElementSibling;
 
     /** @readonly */
     public ?DOMElement $previousElementSibling;
 
     /** @readonly */
-    public ?DOMElement $nextElementSibling;
+    public mixed $schemaTypeInfo = null;
+
+    /** @readonly */
+    public string $tagName;
 
     public function __construct(string $qualifiedName, ?string $value = null, string $namespace = "") {}
 
@@ -397,37 +397,11 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
 
 class DOMDocument extends DOMNode implements DOMParentNode
 {
-    /** @readonly */
-    public ?DOMDocumentType $doctype;
-
-    /** @readonly */
-    public DOMImplementation $implementation;
-
-    /** @readonly */
-    public ?DOMElement $documentElement;
-
     /**
      * @readonly
      * @deprecated
      */
     public ?string $actualEncoding;
-
-    public ?string $encoding;
-
-    /** @readonly */
-    public ?string $xmlEncoding;
-
-    public bool $standalone;
-
-    public bool $xmlStandalone;
-
-    public ?string $version;
-
-    public ?string $xmlVersion;
-
-    public bool $strictErrorChecking;
-
-    public ?string $documentURI;
 
     /**
      * @readonly
@@ -435,17 +409,43 @@ class DOMDocument extends DOMNode implements DOMParentNode
      */
     public mixed $config = null;
 
+    /** @readonly */
+    public ?DOMDocumentType $doctype;
+
+    /** @readonly */
+    public ?DOMElement $documentElement;
+
+    public ?string $documentURI;
+
+    public ?string $encoding;
+
     public bool $formatOutput;
 
-    public bool $validateOnParse;
-
-    public bool $resolveExternals;
+    /** @readonly */
+    public DOMImplementation $implementation;
 
     public bool $preserveWhiteSpace;
 
     public bool $recover;
 
+    public bool $resolveExternals;
+
+    public bool $standalone;
+
+    public bool $strictErrorChecking;
+
     public bool $substituteEntities;
+
+    public bool $validateOnParse;
+
+    public ?string $version;
+
+    /** @readonly */
+    public ?string $xmlEncoding;
+
+    public bool $xmlStandalone;
+
+    public ?string $xmlVersion;
 
     /** @readonly */
     public ?DOMElement $firstElementChild;
@@ -613,15 +613,6 @@ class DOMNamedNodeMap implements IteratorAggregate, Countable
 
 class DOMEntity extends DOMNode
 {
-    /** @readonly */
-    public ?string $publicId;
-
-    /** @readonly */
-    public ?string $systemId;
-
-    /** @readonly */
-    public ?string $notationName;
-
     /**
      * @readonly
      * @deprecated
@@ -633,6 +624,15 @@ class DOMEntity extends DOMNode
      * @deprecated
      */
     public ?string $encoding = null;
+
+    /** @readonly */
+    public ?string $notationName;
+
+    /** @readonly */
+    public ?string $publicId;
+
+    /** @readonly */
+    public ?string $systemId;
 
     /**
      * @readonly
@@ -657,10 +657,10 @@ class DOMNotation extends DOMNode
 
 class DOMProcessingInstruction extends DOMNode
 {
+    public string $data;
+
     /** @readonly */
     public string $target;
-
-    public string $data;
 
     public function __construct(string $name, string $value = "") {}
 }

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 74698bea9c5e0635cf91345e8512b9677489510c */
+ * Stub hash: 5cd10d4e78802853f97be372e3d3cc68179642cf */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
@@ -902,18 +902,24 @@ static zend_class_entry *register_class_DOMDocumentType(zend_class_entry *class_
 	INIT_CLASS_ENTRY(ce, "DOMDocumentType", class_DOMDocumentType_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DOMNode);
 
-	zval property_name_default_value;
-	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
-	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_name_name);
-
 	zend_string *property_entities_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
 	zval property_entities_default_value;
 	ZVAL_UNDEF(&property_entities_default_value);
 	zend_string *property_entities_name = zend_string_init("entities", sizeof("entities") - 1, 1);
 	zend_declare_typed_property(class_entry, property_entities_name, &property_entities_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_entities_class_DOMNamedNodeMap, 0, 0));
 	zend_string_release(property_entities_name);
+
+	zval property_internalSubset_default_value;
+	ZVAL_UNDEF(&property_internalSubset_default_value);
+	zend_string *property_internalSubset_name = zend_string_init("internalSubset", sizeof("internalSubset") - 1, 1);
+	zend_declare_typed_property(class_entry, property_internalSubset_name, &property_internalSubset_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_internalSubset_name);
+
+	zval property_name_default_value;
+	ZVAL_UNDEF(&property_name_default_value);
+	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_name_name);
 
 	zend_string *property_notations_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
 	zval property_notations_default_value;
@@ -933,12 +939,6 @@ static zend_class_entry *register_class_DOMDocumentType(zend_class_entry *class_
 	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_systemId_name);
-
-	zval property_internalSubset_default_value;
-	ZVAL_UNDEF(&property_internalSubset_default_value);
-	zend_string *property_internalSubset_name = zend_string_init("internalSubset", sizeof("internalSubset") - 1, 1);
-	zend_declare_typed_property(class_entry, property_internalSubset_name, &property_internalSubset_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_internalSubset_name);
 
 	return class_entry;
 }
@@ -991,30 +991,18 @@ static zend_class_entry *register_class_DOMNode(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
-	zval property_nodeName_default_value;
-	ZVAL_UNDEF(&property_nodeName_default_value);
-	zend_string *property_nodeName_name = zend_string_init("nodeName", sizeof("nodeName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_nodeName_name, &property_nodeName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_nodeName_name);
+	zend_string *property_attributes_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
+	zval property_attributes_default_value;
+	ZVAL_UNDEF(&property_attributes_default_value);
+	zend_string *property_attributes_name = zend_string_init("attributes", sizeof("attributes") - 1, 1);
+	zend_declare_typed_property(class_entry, property_attributes_name, &property_attributes_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_attributes_class_DOMNamedNodeMap, 0, MAY_BE_NULL));
+	zend_string_release(property_attributes_name);
 
-	zval property_nodeValue_default_value;
-	ZVAL_UNDEF(&property_nodeValue_default_value);
-	zend_string *property_nodeValue_name = zend_string_init("nodeValue", sizeof("nodeValue") - 1, 1);
-	zend_declare_typed_property(class_entry, property_nodeValue_name, &property_nodeValue_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_nodeValue_name);
-
-	zval property_nodeType_default_value;
-	ZVAL_UNDEF(&property_nodeType_default_value);
-	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
-	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_nodeType_name);
-
-	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
-	zval property_parentNode_default_value;
-	ZVAL_UNDEF(&property_parentNode_default_value);
-	zend_string *property_parentNode_name = zend_string_init("parentNode", sizeof("parentNode") - 1, 1);
-	zend_declare_typed_property(class_entry, property_parentNode_name, &property_parentNode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentNode_class_DOMNode, 0, MAY_BE_NULL));
-	zend_string_release(property_parentNode_name);
+	zval property_baseURI_default_value;
+	ZVAL_UNDEF(&property_baseURI_default_value);
+	zend_string *property_baseURI_name = zend_string_init("baseURI", sizeof("baseURI") - 1, 1);
+	zend_declare_typed_property(class_entry, property_baseURI_name, &property_baseURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_baseURI_name);
 
 	zend_string *property_childNodes_class_DOMNodeList = zend_string_init("DOMNodeList", sizeof("DOMNodeList")-1, 1);
 	zval property_childNodes_default_value;
@@ -1037,12 +1025,17 @@ static zend_class_entry *register_class_DOMNode(void)
 	zend_declare_typed_property(class_entry, property_lastChild_name, &property_lastChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastChild_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_lastChild_name);
 
-	zend_string *property_previousSibling_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
-	zval property_previousSibling_default_value;
-	ZVAL_UNDEF(&property_previousSibling_default_value);
-	zend_string *property_previousSibling_name = zend_string_init("previousSibling", sizeof("previousSibling") - 1, 1);
-	zend_declare_typed_property(class_entry, property_previousSibling_name, &property_previousSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousSibling_class_DOMNode, 0, MAY_BE_NULL));
-	zend_string_release(property_previousSibling_name);
+	zval property_localName_default_value;
+	ZVAL_UNDEF(&property_localName_default_value);
+	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_localName_name);
+
+	zval property_namespaceURI_default_value;
+	ZVAL_UNDEF(&property_namespaceURI_default_value);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_namespaceURI_name);
 
 	zend_string *property_nextSibling_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
 	zval property_nextSibling_default_value;
@@ -1051,12 +1044,23 @@ static zend_class_entry *register_class_DOMNode(void)
 	zend_declare_typed_property(class_entry, property_nextSibling_name, &property_nextSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextSibling_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_nextSibling_name);
 
-	zend_string *property_attributes_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
-	zval property_attributes_default_value;
-	ZVAL_UNDEF(&property_attributes_default_value);
-	zend_string *property_attributes_name = zend_string_init("attributes", sizeof("attributes") - 1, 1);
-	zend_declare_typed_property(class_entry, property_attributes_name, &property_attributes_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_attributes_class_DOMNamedNodeMap, 0, MAY_BE_NULL));
-	zend_string_release(property_attributes_name);
+	zval property_nodeName_default_value;
+	ZVAL_UNDEF(&property_nodeName_default_value);
+	zend_string *property_nodeName_name = zend_string_init("nodeName", sizeof("nodeName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_nodeName_name, &property_nodeName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_nodeName_name);
+
+	zval property_nodeType_default_value;
+	ZVAL_UNDEF(&property_nodeType_default_value);
+	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
+	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_nodeType_name);
+
+	zval property_nodeValue_default_value;
+	ZVAL_UNDEF(&property_nodeValue_default_value);
+	zend_string *property_nodeValue_name = zend_string_init("nodeValue", sizeof("nodeValue") - 1, 1);
+	zend_declare_typed_property(class_entry, property_nodeValue_name, &property_nodeValue_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_nodeValue_name);
 
 	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", sizeof("DOMDocument")-1, 1);
 	zval property_ownerDocument_default_value;
@@ -1065,11 +1069,12 @@ static zend_class_entry *register_class_DOMNode(void)
 	zend_declare_typed_property(class_entry, property_ownerDocument_name, &property_ownerDocument_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerDocument_class_DOMDocument, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerDocument_name);
 
-	zval property_namespaceURI_default_value;
-	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
-	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_namespaceURI_name);
+	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zval property_parentNode_default_value;
+	ZVAL_UNDEF(&property_parentNode_default_value);
+	zend_string *property_parentNode_name = zend_string_init("parentNode", sizeof("parentNode") - 1, 1);
+	zend_declare_typed_property(class_entry, property_parentNode_name, &property_parentNode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentNode_class_DOMNode, 0, MAY_BE_NULL));
+	zend_string_release(property_parentNode_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
@@ -1077,17 +1082,12 @@ static zend_class_entry *register_class_DOMNode(void)
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_prefix_name);
 
-	zval property_localName_default_value;
-	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_localName_name);
-
-	zval property_baseURI_default_value;
-	ZVAL_UNDEF(&property_baseURI_default_value);
-	zend_string *property_baseURI_name = zend_string_init("baseURI", sizeof("baseURI") - 1, 1);
-	zend_declare_typed_property(class_entry, property_baseURI_name, &property_baseURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_baseURI_name);
+	zend_string *property_previousSibling_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zval property_previousSibling_default_value;
+	ZVAL_UNDEF(&property_previousSibling_default_value);
+	zend_string *property_previousSibling_name = zend_string_init("previousSibling", sizeof("previousSibling") - 1, 1);
+	zend_declare_typed_property(class_entry, property_previousSibling_name, &property_previousSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousSibling_class_DOMNode, 0, MAY_BE_NULL));
+	zend_string_release(property_previousSibling_name);
 
 	zval property_textContent_default_value;
 	ZVAL_UNDEF(&property_textContent_default_value);
@@ -1267,18 +1267,6 @@ static zend_class_entry *register_class_DOMAttr(zend_class_entry *class_entry_DO
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
-	zval property_specified_default_value;
-	ZVAL_BOOL(&property_specified_default_value, 1);
-	zend_string *property_specified_name = zend_string_init("specified", sizeof("specified") - 1, 1);
-	zend_declare_typed_property(class_entry, property_specified_name, &property_specified_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_specified_name);
-
-	zval property_value_default_value;
-	ZVAL_UNDEF(&property_value_default_value);
-	zend_string *property_value_name = zend_string_init("value", sizeof("value") - 1, 1);
-	zend_declare_typed_property(class_entry, property_value_name, &property_value_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_value_name);
-
 	zend_string *property_ownerElement_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
 	zval property_ownerElement_default_value;
 	ZVAL_UNDEF(&property_ownerElement_default_value);
@@ -1292,6 +1280,18 @@ static zend_class_entry *register_class_DOMAttr(zend_class_entry *class_entry_DO
 	zend_declare_typed_property(class_entry, property_schemaTypeInfo_name, &property_schemaTypeInfo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_schemaTypeInfo_name);
 
+	zval property_specified_default_value;
+	ZVAL_BOOL(&property_specified_default_value, 1);
+	zend_string *property_specified_name = zend_string_init("specified", sizeof("specified") - 1, 1);
+	zend_declare_typed_property(class_entry, property_specified_name, &property_specified_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_specified_name);
+
+	zval property_value_default_value;
+	ZVAL_UNDEF(&property_value_default_value);
+	zend_string *property_value_name = zend_string_init("value", sizeof("value") - 1, 1);
+	zend_declare_typed_property(class_entry, property_value_name, &property_value_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_value_name);
+
 	return class_entry;
 }
 
@@ -1303,17 +1303,11 @@ static zend_class_entry *register_class_DOMElement(zend_class_entry *class_entry
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DOMNode);
 	zend_class_implements(class_entry, 2, class_entry_DOMParentNode, class_entry_DOMChildNode);
 
-	zval property_tagName_default_value;
-	ZVAL_UNDEF(&property_tagName_default_value);
-	zend_string *property_tagName_name = zend_string_init("tagName", sizeof("tagName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_tagName_name, &property_tagName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_tagName_name);
-
-	zval property_schemaTypeInfo_default_value;
-	ZVAL_NULL(&property_schemaTypeInfo_default_value);
-	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", sizeof("schemaTypeInfo") - 1, 1);
-	zend_declare_typed_property(class_entry, property_schemaTypeInfo_name, &property_schemaTypeInfo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
-	zend_string_release(property_schemaTypeInfo_name);
+	zval property_childElementCount_default_value;
+	ZVAL_UNDEF(&property_childElementCount_default_value);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_childElementCount_name);
 
 	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
 	zval property_firstElementChild_default_value;
@@ -1329,11 +1323,12 @@ static zend_class_entry *register_class_DOMElement(zend_class_entry *class_entry
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
-	zval property_childElementCount_default_value;
-	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
-	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_childElementCount_name);
+	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zval property_nextElementSibling_default_value;
+	ZVAL_UNDEF(&property_nextElementSibling_default_value);
+	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", sizeof("nextElementSibling") - 1, 1);
+	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_DOMElement, 0, MAY_BE_NULL));
+	zend_string_release(property_nextElementSibling_name);
 
 	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
 	zval property_previousElementSibling_default_value;
@@ -1342,12 +1337,17 @@ static zend_class_entry *register_class_DOMElement(zend_class_entry *class_entry
 	zend_declare_typed_property(class_entry, property_previousElementSibling_name, &property_previousElementSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_previousElementSibling_name);
 
-	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
-	zval property_nextElementSibling_default_value;
-	ZVAL_UNDEF(&property_nextElementSibling_default_value);
-	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", sizeof("nextElementSibling") - 1, 1);
-	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_DOMElement, 0, MAY_BE_NULL));
-	zend_string_release(property_nextElementSibling_name);
+	zval property_schemaTypeInfo_default_value;
+	ZVAL_NULL(&property_schemaTypeInfo_default_value);
+	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", sizeof("schemaTypeInfo") - 1, 1);
+	zend_declare_typed_property(class_entry, property_schemaTypeInfo_name, &property_schemaTypeInfo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
+	zend_string_release(property_schemaTypeInfo_name);
+
+	zval property_tagName_default_value;
+	ZVAL_UNDEF(&property_tagName_default_value);
+	zend_string *property_tagName_name = zend_string_init("tagName", sizeof("tagName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_tagName_name, &property_tagName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_tagName_name);
 
 	return class_entry;
 }
@@ -1360,19 +1360,24 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DOMNode);
 	zend_class_implements(class_entry, 1, class_entry_DOMParentNode);
 
+	zval property_actualEncoding_default_value;
+	ZVAL_UNDEF(&property_actualEncoding_default_value);
+	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", sizeof("actualEncoding") - 1, 1);
+	zend_declare_typed_property(class_entry, property_actualEncoding_name, &property_actualEncoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_actualEncoding_name);
+
+	zval property_config_default_value;
+	ZVAL_NULL(&property_config_default_value);
+	zend_string *property_config_name = zend_string_init("config", sizeof("config") - 1, 1);
+	zend_declare_typed_property(class_entry, property_config_name, &property_config_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
+	zend_string_release(property_config_name);
+
 	zend_string *property_doctype_class_DOMDocumentType = zend_string_init("DOMDocumentType", sizeof("DOMDocumentType")-1, 1);
 	zval property_doctype_default_value;
 	ZVAL_UNDEF(&property_doctype_default_value);
 	zend_string *property_doctype_name = zend_string_init("doctype", sizeof("doctype") - 1, 1);
 	zend_declare_typed_property(class_entry, property_doctype_name, &property_doctype_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_doctype_class_DOMDocumentType, 0, MAY_BE_NULL));
 	zend_string_release(property_doctype_name);
-
-	zend_string *property_implementation_class_DOMImplementation = zend_string_init("DOMImplementation", sizeof("DOMImplementation")-1, 1);
-	zval property_implementation_default_value;
-	ZVAL_UNDEF(&property_implementation_default_value);
-	zend_string *property_implementation_name = zend_string_init("implementation", sizeof("implementation") - 1, 1);
-	zend_declare_typed_property(class_entry, property_implementation_name, &property_implementation_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_implementation_class_DOMImplementation, 0, 0));
-	zend_string_release(property_implementation_name);
 
 	zend_string *property_documentElement_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
 	zval property_documentElement_default_value;
@@ -1381,11 +1386,11 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 	zend_declare_typed_property(class_entry, property_documentElement_name, &property_documentElement_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_documentElement_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_documentElement_name);
 
-	zval property_actualEncoding_default_value;
-	ZVAL_UNDEF(&property_actualEncoding_default_value);
-	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", sizeof("actualEncoding") - 1, 1);
-	zend_declare_typed_property(class_entry, property_actualEncoding_name, &property_actualEncoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_actualEncoding_name);
+	zval property_documentURI_default_value;
+	ZVAL_UNDEF(&property_documentURI_default_value);
+	zend_string *property_documentURI_name = zend_string_init("documentURI", sizeof("documentURI") - 1, 1);
+	zend_declare_typed_property(class_entry, property_documentURI_name, &property_documentURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_documentURI_name);
 
 	zval property_encoding_default_value;
 	ZVAL_UNDEF(&property_encoding_default_value);
@@ -1393,71 +1398,18 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 	zend_declare_typed_property(class_entry, property_encoding_name, &property_encoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_encoding_name);
 
-	zval property_xmlEncoding_default_value;
-	ZVAL_UNDEF(&property_xmlEncoding_default_value);
-	zend_string *property_xmlEncoding_name = zend_string_init("xmlEncoding", sizeof("xmlEncoding") - 1, 1);
-	zend_declare_typed_property(class_entry, property_xmlEncoding_name, &property_xmlEncoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_xmlEncoding_name);
-
-	zval property_standalone_default_value;
-	ZVAL_UNDEF(&property_standalone_default_value);
-	zend_string *property_standalone_name = zend_string_init("standalone", sizeof("standalone") - 1, 1);
-	zend_declare_typed_property(class_entry, property_standalone_name, &property_standalone_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_standalone_name);
-
-	zval property_xmlStandalone_default_value;
-	ZVAL_UNDEF(&property_xmlStandalone_default_value);
-	zend_string *property_xmlStandalone_name = zend_string_init("xmlStandalone", sizeof("xmlStandalone") - 1, 1);
-	zend_declare_typed_property(class_entry, property_xmlStandalone_name, &property_xmlStandalone_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_xmlStandalone_name);
-
-	zval property_version_default_value;
-	ZVAL_UNDEF(&property_version_default_value);
-	zend_string *property_version_name = zend_string_init("version", sizeof("version") - 1, 1);
-	zend_declare_typed_property(class_entry, property_version_name, &property_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_version_name);
-
-	zval property_xmlVersion_default_value;
-	ZVAL_UNDEF(&property_xmlVersion_default_value);
-	zend_string *property_xmlVersion_name = zend_string_init("xmlVersion", sizeof("xmlVersion") - 1, 1);
-	zend_declare_typed_property(class_entry, property_xmlVersion_name, &property_xmlVersion_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_xmlVersion_name);
-
-	zval property_strictErrorChecking_default_value;
-	ZVAL_UNDEF(&property_strictErrorChecking_default_value);
-	zend_string *property_strictErrorChecking_name = zend_string_init("strictErrorChecking", sizeof("strictErrorChecking") - 1, 1);
-	zend_declare_typed_property(class_entry, property_strictErrorChecking_name, &property_strictErrorChecking_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_strictErrorChecking_name);
-
-	zval property_documentURI_default_value;
-	ZVAL_UNDEF(&property_documentURI_default_value);
-	zend_string *property_documentURI_name = zend_string_init("documentURI", sizeof("documentURI") - 1, 1);
-	zend_declare_typed_property(class_entry, property_documentURI_name, &property_documentURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_documentURI_name);
-
-	zval property_config_default_value;
-	ZVAL_NULL(&property_config_default_value);
-	zend_string *property_config_name = zend_string_init("config", sizeof("config") - 1, 1);
-	zend_declare_typed_property(class_entry, property_config_name, &property_config_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
-	zend_string_release(property_config_name);
-
 	zval property_formatOutput_default_value;
 	ZVAL_UNDEF(&property_formatOutput_default_value);
 	zend_string *property_formatOutput_name = zend_string_init("formatOutput", sizeof("formatOutput") - 1, 1);
 	zend_declare_typed_property(class_entry, property_formatOutput_name, &property_formatOutput_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_formatOutput_name);
 
-	zval property_validateOnParse_default_value;
-	ZVAL_UNDEF(&property_validateOnParse_default_value);
-	zend_string *property_validateOnParse_name = zend_string_init("validateOnParse", sizeof("validateOnParse") - 1, 1);
-	zend_declare_typed_property(class_entry, property_validateOnParse_name, &property_validateOnParse_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_validateOnParse_name);
-
-	zval property_resolveExternals_default_value;
-	ZVAL_UNDEF(&property_resolveExternals_default_value);
-	zend_string *property_resolveExternals_name = zend_string_init("resolveExternals", sizeof("resolveExternals") - 1, 1);
-	zend_declare_typed_property(class_entry, property_resolveExternals_name, &property_resolveExternals_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
-	zend_string_release(property_resolveExternals_name);
+	zend_string *property_implementation_class_DOMImplementation = zend_string_init("DOMImplementation", sizeof("DOMImplementation")-1, 1);
+	zval property_implementation_default_value;
+	ZVAL_UNDEF(&property_implementation_default_value);
+	zend_string *property_implementation_name = zend_string_init("implementation", sizeof("implementation") - 1, 1);
+	zend_declare_typed_property(class_entry, property_implementation_name, &property_implementation_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_implementation_class_DOMImplementation, 0, 0));
+	zend_string_release(property_implementation_name);
 
 	zval property_preserveWhiteSpace_default_value;
 	ZVAL_UNDEF(&property_preserveWhiteSpace_default_value);
@@ -1471,11 +1423,59 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 	zend_declare_typed_property(class_entry, property_recover_name, &property_recover_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_recover_name);
 
+	zval property_resolveExternals_default_value;
+	ZVAL_UNDEF(&property_resolveExternals_default_value);
+	zend_string *property_resolveExternals_name = zend_string_init("resolveExternals", sizeof("resolveExternals") - 1, 1);
+	zend_declare_typed_property(class_entry, property_resolveExternals_name, &property_resolveExternals_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_resolveExternals_name);
+
+	zval property_standalone_default_value;
+	ZVAL_UNDEF(&property_standalone_default_value);
+	zend_string *property_standalone_name = zend_string_init("standalone", sizeof("standalone") - 1, 1);
+	zend_declare_typed_property(class_entry, property_standalone_name, &property_standalone_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_standalone_name);
+
+	zval property_strictErrorChecking_default_value;
+	ZVAL_UNDEF(&property_strictErrorChecking_default_value);
+	zend_string *property_strictErrorChecking_name = zend_string_init("strictErrorChecking", sizeof("strictErrorChecking") - 1, 1);
+	zend_declare_typed_property(class_entry, property_strictErrorChecking_name, &property_strictErrorChecking_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_strictErrorChecking_name);
+
 	zval property_substituteEntities_default_value;
 	ZVAL_UNDEF(&property_substituteEntities_default_value);
 	zend_string *property_substituteEntities_name = zend_string_init("substituteEntities", sizeof("substituteEntities") - 1, 1);
 	zend_declare_typed_property(class_entry, property_substituteEntities_name, &property_substituteEntities_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_substituteEntities_name);
+
+	zval property_validateOnParse_default_value;
+	ZVAL_UNDEF(&property_validateOnParse_default_value);
+	zend_string *property_validateOnParse_name = zend_string_init("validateOnParse", sizeof("validateOnParse") - 1, 1);
+	zend_declare_typed_property(class_entry, property_validateOnParse_name, &property_validateOnParse_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_validateOnParse_name);
+
+	zval property_version_default_value;
+	ZVAL_UNDEF(&property_version_default_value);
+	zend_string *property_version_name = zend_string_init("version", sizeof("version") - 1, 1);
+	zend_declare_typed_property(class_entry, property_version_name, &property_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_version_name);
+
+	zval property_xmlEncoding_default_value;
+	ZVAL_UNDEF(&property_xmlEncoding_default_value);
+	zend_string *property_xmlEncoding_name = zend_string_init("xmlEncoding", sizeof("xmlEncoding") - 1, 1);
+	zend_declare_typed_property(class_entry, property_xmlEncoding_name, &property_xmlEncoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_xmlEncoding_name);
+
+	zval property_xmlStandalone_default_value;
+	ZVAL_UNDEF(&property_xmlStandalone_default_value);
+	zend_string *property_xmlStandalone_name = zend_string_init("xmlStandalone", sizeof("xmlStandalone") - 1, 1);
+	zend_declare_typed_property(class_entry, property_xmlStandalone_name, &property_xmlStandalone_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
+	zend_string_release(property_xmlStandalone_name);
+
+	zval property_xmlVersion_default_value;
+	ZVAL_UNDEF(&property_xmlVersion_default_value);
+	zend_string *property_xmlVersion_name = zend_string_init("xmlVersion", sizeof("xmlVersion") - 1, 1);
+	zend_declare_typed_property(class_entry, property_xmlVersion_name, &property_xmlVersion_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_xmlVersion_name);
 
 	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
 	zval property_firstElementChild_default_value;
@@ -1557,24 +1557,6 @@ static zend_class_entry *register_class_DOMEntity(zend_class_entry *class_entry_
 	INIT_CLASS_ENTRY(ce, "DOMEntity", class_DOMEntity_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DOMNode);
 
-	zval property_publicId_default_value;
-	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_publicId_name);
-
-	zval property_systemId_default_value;
-	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
-	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_systemId_name);
-
-	zval property_notationName_default_value;
-	ZVAL_UNDEF(&property_notationName_default_value);
-	zend_string *property_notationName_name = zend_string_init("notationName", sizeof("notationName") - 1, 1);
-	zend_declare_typed_property(class_entry, property_notationName_name, &property_notationName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_notationName_name);
-
 	zval property_actualEncoding_default_value;
 	ZVAL_NULL(&property_actualEncoding_default_value);
 	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", sizeof("actualEncoding") - 1, 1);
@@ -1586,6 +1568,24 @@ static zend_class_entry *register_class_DOMEntity(zend_class_entry *class_entry_
 	zend_string *property_encoding_name = zend_string_init("encoding", sizeof("encoding") - 1, 1);
 	zend_declare_typed_property(class_entry, property_encoding_name, &property_encoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_encoding_name);
+
+	zval property_notationName_default_value;
+	ZVAL_UNDEF(&property_notationName_default_value);
+	zend_string *property_notationName_name = zend_string_init("notationName", sizeof("notationName") - 1, 1);
+	zend_declare_typed_property(class_entry, property_notationName_name, &property_notationName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_notationName_name);
+
+	zval property_publicId_default_value;
+	ZVAL_UNDEF(&property_publicId_default_value);
+	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_publicId_name);
+
+	zval property_systemId_default_value;
+	ZVAL_UNDEF(&property_systemId_default_value);
+	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
+	zend_string_release(property_systemId_name);
 
 	zval property_version_default_value;
 	ZVAL_NULL(&property_version_default_value);
@@ -1635,17 +1635,17 @@ static zend_class_entry *register_class_DOMProcessingInstruction(zend_class_entr
 	INIT_CLASS_ENTRY(ce, "DOMProcessingInstruction", class_DOMProcessingInstruction_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DOMNode);
 
-	zval property_target_default_value;
-	ZVAL_UNDEF(&property_target_default_value);
-	zend_string *property_target_name = zend_string_init("target", sizeof("target") - 1, 1);
-	zend_declare_typed_property(class_entry, property_target_name, &property_target_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_target_name);
-
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
 	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
+
+	zval property_target_default_value;
+	ZVAL_UNDEF(&property_target_default_value);
+	zend_string *property_target_name = zend_string_init("target", sizeof("target") - 1, 1);
+	zend_declare_typed_property(class_entry, property_target_name, &property_target_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_target_name);
 
 	return class_entry;
 }


### PR DESCRIPTION
The PHP manual has listed them alphabetically most of the time. It is easier to find the property you are looking for. Since the manual class synopsis is build based on stubs, let's align properties in stubs to be in alphabetical order so that we can easily generate PHP manual. See https://github.com/php/doc-en/pull/839