### PR TITLE
Allow passing false to the $length parameter of substr

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -603,7 +603,7 @@ function str_ends_with(string $haystack, string $needle): bool {}
 
 function chunk_split(string $string, int $length = 76, string $separator = "\r\n"): string {}
 
-function substr(string $string, int $offset, ?int $length = null): string {}
+function substr(string $string, int $offset, int|false|null $length = null): string {}
 
 function substr_replace(array|string $string, array|string $replace, array|int $offset, array|int|null $length = null): string|array {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 963bd7624ec5f981ac9074eef94f9da740aa5108 */
+ * Stub hash: 453ac1d55fb43fbb4fbc89942a10fc26e5a94383 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -927,7 +927,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_substr, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 1, "null")
+	ZEND_ARG_TYPE_MASK(0, length, MAY_BE_LONG|MAY_BE_BOOL|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_substr_replace, 0, 3, MAY_BE_STRING|MAY_BE_ARRAY)

--- a/ext/standard/tests/strings/substr_strict.phpt
+++ b/ext/standard/tests/strings/substr_strict.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Testing substr() with strict types
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+echo substr('foo', 1, false);
+--EXPECT--


### PR DESCRIPTION
According to the documentation, it's possible to pass `false` as a value for the length parameter of the `substr()` function:

>  If length is given and is 0, **false** or null, an empty string will be returned. 

However, when strict types are enabled, passing false currently throws the following error:

> Fatal error: Uncaught TypeError: substr(): Argument #3 ($length) must be of type ?int, bool given

This causes a break in the dev version of Doctrine: https://github.com/doctrine/orm/issues/8878

I wonder if we should fix the documentation or fix the code.
In this PR, I tried to fix the code, but as the test failure shows, changing the stub file isn't enough. We also have to add a slightly more heavy parameter parsing logic and I wonder if it is worth it.

What do you think?