### PR TITLE
Allocate zend_class_entry on the heap

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7551,7 +7551,7 @@ static void zend_compile_class_decl(znode *result, zend_ast *ast, bool toplevel)
 	zend_ast *stmt_ast = decl->child[2];
 	zend_ast *enum_backing_type_ast = decl->child[4];
 	zend_string *name, *lcname;
-	zend_class_entry *ce = zend_arena_alloc(&CG(arena), sizeof(zend_class_entry));
+	zend_class_entry *ce = emalloc(sizeof(zend_class_entry));
 	zend_op *opline;
 
 	zend_class_entry *original_ce = CG(active_class_entry);

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2582,7 +2582,7 @@ static zend_class_entry *zend_lazy_class_load(zend_class_entry *pce)
 	zend_class_entry *ce;
 	Bucket *p, *end;
 
-	ce = zend_arena_alloc(&CG(arena), sizeof(zend_class_entry));
+	ce = emalloc(sizeof(zend_class_entry));
 	memcpy(ce, pce, sizeof(zend_class_entry));
 	ce->ce_flags &= ~ZEND_ACC_IMMUTABLE;
 	ce->refcount = 1;

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -395,6 +395,7 @@ ZEND_API void destroy_zend_class(zval *zv)
 			if (ce->num_interfaces > 0 && (ce->ce_flags & ZEND_ACC_RESOLVED_INTERFACES)) {
 				efree(ce->interfaces);
 			}
+			efree(ce);
 			break;
 		case ZEND_INTERNAL_CLASS:
 			if (ce->backed_enum_table) {


### PR DESCRIPTION
I believe that after the immutability changes in PHP-8.1, it's no
longer necessary to allocate zend_class_entry (or anything it
references) on the arena, it should be fine to allocate it on the
heap.

My main motivation here is to make it easier to detect class
use-after-frees after persist, but this also seems reasonable to
avoid leaving behind unused memory in that case.