### PR TITLE
Export AST for default value strings in reflection

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1947,7 +1947,20 @@ simple_list:
 			zend_ast_export_name(str, ast->child[1], 0, indent);
 			break;
 		case ZEND_AST_CLASS_NAME:
-			zend_ast_export_ns_name(str, ast->child[0], 0, indent);
+			if (ast->child[0] == NULL) {
+				/* The const expr representation stores the fetch type instead. */
+				switch (ast->attr) {
+					case ZEND_FETCH_CLASS_SELF:
+						smart_str_appends(str, "self");
+						break;
+					case ZEND_FETCH_CLASS_PARENT:
+						smart_str_appends(str, "parent");
+						break;
+					EMPTY_SWITCH_DEFAULT_CASE()
+				}
+			} else {
+				zend_ast_export_ns_name(str, ast->child[0], 0, indent);
+			}
 			smart_str_appends(str, "::class");
 			break;
 		case ZEND_AST_ASSIGN:            BINARY_OP(" = ",   90, 91, 90);

--- a/ext/reflection/tests/ReflectionAttribute_toString.phpt
+++ b/ext/reflection/tests/ReflectionAttribute_toString.phpt
@@ -3,18 +3,15 @@ ReflectionAttribute::__toString
 --FILE--
 <?php
 
-#[Foo, Bar(a: "foo", b: 1234), Baz("foo", 1234), XXX(ERROR)]
+#[Foo, Bar(a: "foo", b: 1234), Baz("foo", 1234), X(NO_ERROR), Y(new stdClass)]
 function foo() {}
 
 $refl = new ReflectionFunction('foo');
 echo $refl->getAttributes()[0];
 echo $refl->getAttributes()[1];
 echo $refl->getAttributes()[2];
-try {
-    echo $refl->getAttributes()[3];
-} catch (Error $e) {
-    echo $e->getMessage(), "\n";
-}
+echo $refl->getAttributes()[3];
+echo $refl->getAttributes()[4];
 
 ?>
 --EXPECT--
@@ -31,4 +28,13 @@ Attribute [ Baz ] {
     Argument #1 [ 1234 ]
   }
 }
-Undefined constant "ERROR"
+Attribute [ X ] {
+  - Arguments [1] {
+    Argument #0 [ NO_ERROR ]
+  }
+}
+Attribute [ Y ] {
+  - Arguments [1] {
+    Argument #0 [ new \stdClass() ]
+  }
+}

--- a/ext/reflection/tests/ReflectionClass_export_basic1.phpt
+++ b/ext/reflection/tests/ReflectionClass_export_basic1.phpt
@@ -51,7 +51,7 @@ Class [ <user> class C extends A ] {
         Parameter #0 [ <required> A $a ]
         Parameter #1 [ <required> $b ]
         Parameter #2 [ <optional> ?C $c = NULL ]
-        Parameter #3 [ <optional> $d = '16 chars long -...' ]
+        Parameter #3 [ <optional> $d = K ]
         Parameter #4 [ <optional> $e = '15 chars long -' ]
         Parameter #5 [ <optional> $f = NULL ]
         Parameter #6 [ <optional> $g = false ]

--- a/ext/reflection/tests/ReflectionMethod_defaultArg.phpt
+++ b/ext/reflection/tests/ReflectionMethod_defaultArg.phpt
@@ -32,13 +32,13 @@ Method [ <user> private method bar ] {
   @@ %s
 
   - Parameters [1] {
-    Parameter #0 [ <optional> $a = 'T' ]
+    Parameter #0 [ <optional> $a = self::class ]
   }
 }
 Method [ <user> private method bar ] {
   @@ %s
 
   - Parameters [1] {
-    Parameter #0 [ <optional> $a = 'B' ]
+    Parameter #0 [ <optional> $a = self::class ]
   }
 }

--- a/ext/reflection/tests/ReflectionMethod_tentative_return_type.phpt
+++ b/ext/reflection/tests/ReflectionMethod_tentative_return_type.phpt
@@ -49,7 +49,7 @@ string(%d) "Method [ <user, overwrites DateTimeZone, prototype DateTimeZone> sta
   @@ %s
 
   - Parameters [2] {
-    Parameter #0 [ <optional> int $timezoneGroup = %d ]
+    Parameter #0 [ <optional> int $timezoneGroup = DateTimeZone::ALL ]
     Parameter #1 [ <optional> ?string $countryCode = NULL ]
   }
   - Return [ string ]

--- a/ext/reflection/tests/ReflectionParameter_new_initializer.phpt
+++ b/ext/reflection/tests/ReflectionParameter_new_initializer.phpt
@@ -1,0 +1,17 @@
+--TEST--
+ReflectionParameter::__toString() with new initializer
+--FILE--
+<?php
+
+function test(
+    $p1 = new stdClass,
+    $p2 = new SomeClass(new With, some: new Parameters)
+) {}
+
+echo new ReflectionParameter('test', 'p1'), "\n";
+echo new ReflectionParameter('test', 'p2'), "\n";
+
+?>
+--EXPECT--
+Parameter #0 [ <optional> $p1 = new \stdClass() ]
+Parameter #1 [ <optional> $p2 = new \SomeClass(new \With(), some: new \Parameters()) ]

--- a/ext/reflection/tests/bug33389.phpt
+++ b/ext/reflection/tests/bug33389.phpt
@@ -42,7 +42,7 @@ Class [ <user> class Test ] {
       @@ %sbug33389.php 4 - 5
 
       - Parameters [1] {
-        Parameter #0 [ <optional> $arg = 1 ]
+        Parameter #0 [ <optional> $arg = foobar ]
       }
     }
 

--- a/ext/reflection/tests/bug45765.phpt
+++ b/ext/reflection/tests/bug45765.phpt
@@ -51,7 +51,7 @@ Object of class [ <user> class foo extends foo2 ] {
       @@ %s 10 - 11
 
       - Parameters [1] {
-        Parameter #0 [ <optional> $a = 'foo's bar' ]
+        Parameter #0 [ <optional> $a = self::BAR ]
       }
     }
 
@@ -59,7 +59,7 @@ Object of class [ <user> class foo extends foo2 ] {
       @@ %s 13 - 14
 
       - Parameters [1] {
-        Parameter #0 [ <optional> $a = 'foobar' ]
+        Parameter #0 [ <optional> $a = parent::BAR ]
       }
     }
 
@@ -67,7 +67,7 @@ Object of class [ <user> class foo extends foo2 ] {
       @@ %s 16 - 17
 
       - Parameters [1] {
-        Parameter #0 [ <optional> $a = 'foo's bar' ]
+        Parameter #0 [ <optional> $a = foo::BAR ]
       }
     }
 
@@ -75,7 +75,7 @@ Object of class [ <user> class foo extends foo2 ] {
       @@ %s 19 - 20
 
       - Parameters [1] {
-        Parameter #0 [ <optional> $a = 'foobar' ]
+        Parameter #0 [ <optional> $a = foo2::BAR ]
       }
     }
   }

--- a/ext/reflection/tests/bug74673.phpt
+++ b/ext/reflection/tests/bug74673.phpt
@@ -15,8 +15,28 @@ $class = new ReflectionClass('A');
 echo $class;
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Undefined constant "PHP_SELF" in %s:%d
-Stack trace:
-#0 %s(%d): ReflectionClass->__toString()
-#1 {main}
-  thrown in %s on line %d
+Class [ <user> class A ] {
+  @@ %s
+
+  - Constants [0] {
+  }
+
+  - Static properties [0] {
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [0] {
+  }
+
+  - Methods [1] {
+    Method [ <user> public method method ] {
+      @@ %s
+
+      - Parameters [1] {
+        Parameter #0 [ <optional> $test = PHP_SELF + 1 ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
When dumping default values in ReflectionXXX::__toString(), for
expression initializers print the AST export instead of trying to
evaluate the expression. With the introduction of "new in
initializers" the result of the evaluation will commonly not be
printable at all, and "__toString" will throw an exception, which
is not particularly useful. Using the AST export also provides more
information on how the parameter was originally declared, e.g. it
preserves the fact that a certain constant was used.