### PR TITLE
Fix #81488: ext/zip doesn't extract files with special names

### DIFF
--- a/ext/zip/tests/bug81488.phpt
+++ b/ext/zip/tests/bug81488.phpt
@@ -3,6 +3,7 @@ Bug #81488 (ext/zip doesn't extract files with special names)
 --SKIPIF--
 <?php
 if (!extension_loaded("zip")) die("skip zip extension not available");
+if (PHP_OS_FAMILY !== "Windows") die("skip for Windows only");
 ?>
 --FILE--
 <?php

--- a/ext/zip/tests/bug81488.phpt
+++ b/ext/zip/tests/bug81488.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Bug #81488 (ext/zip doesn't extract files with special names)
+--SKIPIF--
+<?php
+if (!extension_loaded("zip")) die("skip zip extension not available");
+?>
+--FILE--
+<?php
+$filenames = ["foo<bar1", "foo>bar2", "foo|bar3", "foo*bar4", "foo?bar5", "foo\"bar6", "foo:bar7"];
+$archive = __DIR__ . "/bug81488.zip";
+$dir = __DIR__ . "/bug81488";
+mkdir($dir);
+
+$zip = new ZipArchive();
+$zip->open($archive, ZipArchive::CREATE|ZipArchive::OVERWRITE);
+foreach ($filenames as $i => $filename) {
+    $zip->addFromString($filename, "yada yada");
+}
+$zip->close();
+
+$zip->open($archive);
+foreach ($filenames as $filename) {
+    var_dump($zip->extractTo($dir, $filename));
+}
+var_dump(scandir($dir));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+array(9) {
+  [0]=>
+  string(1) "."
+  [1]=>
+  string(2) ".."
+  [2]=>
+  string(8) "foo_bar1"
+  [3]=>
+  string(8) "foo_bar2"
+  [4]=>
+  string(8) "foo_bar3"
+  [5]=>
+  string(8) "foo_bar4"
+  [6]=>
+  string(8) "foo_bar5"
+  [7]=>
+  string(8) "foo_bar6"
+  [8]=>
+  string(8) "foo_bar7"
+}
+--CLEAN--
+<?php
+$dir = __DIR__ . "/bug81488";
+foreach (scandir($dir) as $filename) {
+    if ($filename[0] !== ".") {
+        @unlink("$dir/$filename");
+    }
+}
+@rmdir($dir);
+@unlink(__DIR__ . "/bug81488.zip");
+?>


### PR DESCRIPTION
We replace characters which are not supported by NTFS with underscores,
like 7-zip (and to some extend the Windows extractor) does it.

---

Note that this patch is not yet complete, because it lacks mangling of trailing dots. I'm submitting this PR to have some discussion about whether we want to do this name mangling, or merely treat this as doc issue. If the latter, we may consider to still replace colons, because these designate [NTFS streams](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/c54dec26-1551-4d3a-a0ea-4fa40f848eb3), and as such a file "foo:bar" will be extracted as "foo" with the attached stream "foo:bar".

In case we do the name mangling, it should be pointed out that the name mangling can lead to identical names, so later extractions may overwrite prior, but that is already the case with "/foobar", "./foobar", "foobar", for instance.

Also noteworthy: Phar(Data) has the same issue.

cc @remicollet 