### PR TITLE
Don't populate CE_CACHE during compilation

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1101,7 +1101,8 @@ ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *
 			}
 			return NULL;
 		}
-		if (ZSTR_HAS_CE_CACHE(name)) {
+		/* Don't populate CE_CACHE during compilation. The class may be freed while persisting. */
+		if (ZSTR_HAS_CE_CACHE(name) && !CG(in_compilation)) {
 			ZSTR_SET_CE_CACHE(name, ce);
 		}
 		return ce;
@@ -1157,7 +1158,8 @@ ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *
 		zend_string_release_ex(lc_name, 0);
 	}
 	if (ce) {
-		if (ZSTR_HAS_CE_CACHE(name)) {
+		/* Don't populate CE_CACHE during compilation. The class may be freed while persisting. */
+		if (ZSTR_HAS_CE_CACHE(name) && !CG(in_compilation)) {
 			ZSTR_SET_CE_CACHE(name, ce);
 		}
 	}

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -868,9 +868,6 @@ zend_class_entry *zend_persist_class_entry(zend_class_entry *orig_ce)
 		ce->inheritance_cache = NULL;
 
 		if (!(ce->ce_flags & ZEND_ACC_CACHED)) {
-			if (ZSTR_HAS_CE_CACHE(ce->name)) {
-				ZSTR_SET_CE_CACHE(ce->name, NULL);
-			}
 			zend_accel_store_interned_string(ce->name);
 			if (!(ce->ce_flags & ZEND_ACC_ANON_CLASS)
 			 && !ZCG(current_persistent_script)->corrupted) {


### PR DESCRIPTION
It's possible for CE_CACHE slots to be populated during compilation
(e.g. due to an early binding attempt). When opcache then persists
the class, it clears the CE_CACHE slot for the class name as declared,
but not for different spellings (that only differ in case). As such,
a pointer to the old, non-persistent class entry may be retained.

Fix this by not populating CE_CACHE if in_compilation is set.