### PR TITLE
Allow ``null`` and ``false`` as standalone types

### DIFF
--- a/Zend/tests/type_declarations/standalone_null.phpt
+++ b/Zend/tests/type_declarations/standalone_null.phpt
@@ -3,9 +3,14 @@ Null can be used as a standalone type
 --FILE--
 <?php
 
-function test(): null {}
+function test(null $v): null {
+    return $v;
+}
+
+var_dump(test(null));
 
 ?>
 ===DONE===
 --EXPECT--
+NULL
 ===DONE===

--- a/Zend/tests/type_declarations/standalone_null.phpt
+++ b/Zend/tests/type_declarations/standalone_null.phpt
@@ -10,7 +10,5 @@ function test(null $v): null {
 var_dump(test(null));
 
 ?>
-===DONE===
 --EXPECT--
 NULL
-===DONE===

--- a/Zend/tests/type_declarations/typed_properties_110.phpt
+++ b/Zend/tests/type_declarations/typed_properties_110.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test typed properties allow null
+--FILE--
+<?php
+class Foo {
+    public null $value;
+}
+
+$foo = new Foo();
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/typed_properties_110.phpt
+++ b/Zend/tests/type_declarations/typed_properties_110.phpt
@@ -7,7 +7,14 @@ class Foo {
 }
 
 $foo = new Foo();
+$foo->value = null;
+
+try {
+    $foo->value = 1;
+} catch (\TypeError $e) {
+    echo $e->getMessage();
+}
+
 ?>
-===DONE===
 --EXPECT--
-===DONE===
+Cannot assign int to property Foo::$value of type null

--- a/Zend/tests/type_declarations/typed_properties_111.phpt
+++ b/Zend/tests/type_declarations/typed_properties_111.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test typed properties allow false
+--FILE--
+<?php
+class Foo {
+    public false $value;
+}
+
+$foo = new Foo();
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/typed_properties_111.phpt
+++ b/Zend/tests/type_declarations/typed_properties_111.phpt
@@ -7,7 +7,14 @@ class Foo {
 }
 
 $foo = new Foo();
+$foo->value = false;
+
+try {
+    $foo->value = true;
+} catch (\TypeError $e) {
+    echo $e->getMessage();
+}
+
 ?>
-===DONE===
 --EXPECT--
-===DONE===
+Cannot assign bool to property Foo::$value of type false

--- a/Zend/tests/type_declarations/typed_return_null_false_without_value.phpt
+++ b/Zend/tests/type_declarations/typed_return_null_false_without_value.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Typed null|false return without value generates compile-time error
+--FILE--
+<?php
+
+function test() : null|false {
+    return;
+}
+
+test();
+
+?>
+--EXPECTF--
+Fatal error: A function with return type must return a value (did you mean "return null;" instead of "return;"?) in %s on line %d

--- a/Zend/tests/type_declarations/typed_return_null_without_value.phpt
+++ b/Zend/tests/type_declarations/typed_return_null_without_value.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Typed null return without value generates compile-time error
+--FILE--
+<?php
+
+function test() : null {
+    return;
+}
+
+test();
+
+?>
+--EXPECTF--
+Fatal error: A function with return type must return a value (did you mean "return null;" instead of "return;"?) in %s on line %d

--- a/Zend/tests/type_declarations/union_types/null_false_union.phpt
+++ b/Zend/tests/type_declarations/union_types/null_false_union.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Null and false can be used in a union type
+--FILE--
+<?php
+
+function test1(): null|false {}
+function test2(): false|null {}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/union_types/redundant_types/nullable_null.phpt
+++ b/Zend/tests/type_declarations/union_types/redundant_types/nullable_null.phpt
@@ -8,4 +8,4 @@ function test(): ?null {
 
 ?>
 --EXPECTF--
-Fatal error: Null cannot be used as a standalone type in %s on line %d
+Fatal error: null cannot be marked as nullable in %s on line %d

--- a/Zend/tests/type_declarations/union_types/standalone_false.phpt
+++ b/Zend/tests/type_declarations/union_types/standalone_false.phpt
@@ -1,10 +1,11 @@
 --TEST--
-False cannot be used as a standalone type
+False can be used as a standalone type
 --FILE--
 <?php
 
 function test(): false {}
 
 ?>
---EXPECTF--
-Fatal error: false cannot be used as a standalone type in %s on line %d
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/union_types/standalone_false_implicit_nullability.phpt
+++ b/Zend/tests/type_declarations/union_types/standalone_false_implicit_nullability.phpt
@@ -1,9 +1,9 @@
 --TEST--
-False cannot be used as a standalone type
+False cannot be used as a standalone type even with implicit nullability
 --FILE--
 <?php
 
-function test(): false {}
+function test(false $v = null) {}
 
 ?>
 --EXPECTF--

--- a/Zend/tests/type_declarations/union_types/standalone_false_implicit_nullability.phpt
+++ b/Zend/tests/type_declarations/union_types/standalone_false_implicit_nullability.phpt
@@ -1,10 +1,11 @@
 --TEST--
-False cannot be used as a standalone type even with implicit nullability
+False can be used as a standalone type even with implicit nullability
 --FILE--
 <?php
 
 function test(false $v = null) {}
 
 ?>
---EXPECTF--
-Fatal error: false cannot be used as a standalone type in %s on line %d
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/union_types/standalone_nullable_false.phpt
+++ b/Zend/tests/type_declarations/union_types/standalone_nullable_false.phpt
@@ -1,10 +1,11 @@
 --TEST--
-Nullable false cannot be used as a standalone type
+Nullable false can be used as a standalone type
 --FILE--
 <?php
 
 function test(): ?false {}
 
 ?>
---EXPECTF--
-Fatal error: false cannot be marked as nullable since false is not a standalone type in %s on line %d
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/union_types/standalone_nullable_false.phpt
+++ b/Zend/tests/type_declarations/union_types/standalone_nullable_false.phpt
@@ -7,4 +7,4 @@ function test(): ?false {}
 
 ?>
 --EXPECTF--
-Fatal error: False cannot be used as a standalone type in %s on line %d
+Fatal error: false cannot be marked as nullable since false is not a standalone type in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6343,14 +6343,6 @@ static zend_type zend_compile_typename(
 		zend_error_noreturn(E_COMPILE_ERROR, "null cannot be marked as nullable");
 	}
 
-	if ((type_mask & MAY_BE_FALSE) && !ZEND_TYPE_IS_COMPLEX(type) && !(type_mask & ~MAY_BE_FALSE)) {
-		if (is_marked_nullable) {
-			zend_error_noreturn(E_COMPILE_ERROR, "false cannot be marked as nullable since false is not a standalone type");
-		} else {
-			zend_error_noreturn(E_COMPILE_ERROR, "false cannot be used as a standalone type");
-		}
-	}
-
 	if (is_marked_nullable || force_allow_null) {
 		ZEND_TYPE_FULL_MASK(type) |= MAY_BE_NULL;
 		type_mask = ZEND_TYPE_PURE_MASK(type);

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1255,7 +1255,7 @@ zend_string *zend_type_to_string_resolved(zend_type type, zend_class_entry *scop
 
 	if (type_mask & MAY_BE_NULL) {
 		bool is_union = !str || memchr(ZSTR_VAL(str), '|', ZSTR_LEN(str)) != NULL;
-		if (!is_union) {
+		if (!is_union && !zend_string_equals_literal(str, "false")) {
 			zend_string *nullable_str = zend_string_concat2("?", 1, ZSTR_VAL(str), ZSTR_LEN(str));
 			zend_string_release(str);
 			return nullable_str;
@@ -6186,11 +6186,11 @@ static bool zend_type_contains_traversable(zend_type type) {
 static zend_type zend_compile_typename(
 		zend_ast *ast, bool force_allow_null) /* {{{ */
 {
-	bool allow_null = force_allow_null;
+	bool is_marked_nullable = false;
 	zend_ast_attr orig_ast_attr = ast->attr;
 	zend_type type = ZEND_TYPE_INIT_NONE(0);
 	if (ast->attr & ZEND_TYPE_NULLABLE) {
-		allow_null = 1;
+		is_marked_nullable = true;
 		ast->attr &= ~ZEND_TYPE_NULLABLE;
 	}
 
@@ -6314,10 +6314,6 @@ static zend_type zend_compile_typename(
 		type = zend_compile_single_typename(ast);
 	}
 
-	if (allow_null) {
-		ZEND_TYPE_FULL_MASK(type) |= MAY_BE_NULL;
-	}
-
 	uint32_t type_mask = ZEND_TYPE_PURE_MASK(type);
 	if ((type_mask & (MAY_BE_ARRAY|MAY_BE_ITERABLE)) == (MAY_BE_ARRAY|MAY_BE_ITERABLE)) {
 		zend_string *type_str = zend_type_to_string(type);
@@ -6332,7 +6328,7 @@ static zend_type zend_compile_typename(
 			ZSTR_VAL(type_str));
 	}
 
-	if (type_mask == MAY_BE_ANY && (orig_ast_attr & ZEND_TYPE_NULLABLE)) {
+	if (type_mask == MAY_BE_ANY && is_marked_nullable) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Type mixed cannot be marked as nullable since mixed already includes null");
 	}
 
@@ -6343,21 +6339,29 @@ static zend_type zend_compile_typename(
 			ZSTR_VAL(type_str));
 	}
 
+	if ((type_mask & MAY_BE_NULL) && is_marked_nullable) {
+		zend_error_noreturn(E_COMPILE_ERROR, "null cannot be marked as nullable");
+	}
+
+	if ((type_mask & MAY_BE_FALSE) && !ZEND_TYPE_IS_COMPLEX(type) && !(type_mask & ~MAY_BE_FALSE)) {
+		if (is_marked_nullable) {
+			zend_error_noreturn(E_COMPILE_ERROR, "false cannot be marked as nullable since false is not a standalone type");
+		} else {
+			zend_error_noreturn(E_COMPILE_ERROR, "false cannot be used as a standalone type");
+		}
+	}
+
+	if (is_marked_nullable || force_allow_null) {
+		ZEND_TYPE_FULL_MASK(type) |= MAY_BE_NULL;
+		type_mask = ZEND_TYPE_PURE_MASK(type);
+	}
+
 	if ((type_mask & MAY_BE_VOID) && (ZEND_TYPE_IS_COMPLEX(type) || type_mask != MAY_BE_VOID)) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Void can only be used as a standalone type");
 	}
 
 	if ((type_mask & MAY_BE_NEVER) && (ZEND_TYPE_IS_COMPLEX(type) || type_mask != MAY_BE_NEVER)) {
 		zend_error_noreturn(E_COMPILE_ERROR, "never can only be used as a standalone type");
-	}
-
-	if ((type_mask & (MAY_BE_NULL|MAY_BE_FALSE))
-			&& !ZEND_TYPE_IS_COMPLEX(type) && !(type_mask & ~(MAY_BE_NULL|MAY_BE_FALSE))) {
-		if (type_mask == MAY_BE_NULL) {
-			zend_error_noreturn(E_COMPILE_ERROR, "Null cannot be used as a standalone type");
-		} else {
-			zend_error_noreturn(E_COMPILE_ERROR, "False cannot be used as a standalone type");
-		}
 	}
 
 	ast->attr = orig_ast_attr;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1255,7 +1255,7 @@ zend_string *zend_type_to_string_resolved(zend_type type, zend_class_entry *scop
 
 	if (type_mask & MAY_BE_NULL) {
 		bool is_union = !str || memchr(ZSTR_VAL(str), '|', ZSTR_LEN(str)) != NULL;
-		if (!is_union && !zend_string_equals_literal(str, "false")) {
+		if (!is_union) {
 			zend_string *nullable_str = zend_string_concat2("?", 1, ZSTR_VAL(str), ZSTR_LEN(str));
 			zend_string_release(str);
 			return nullable_str;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6186,11 +6186,11 @@ static bool zend_type_contains_traversable(zend_type type) {
 static zend_type zend_compile_typename(
 		zend_ast *ast, bool force_allow_null) /* {{{ */
 {
-	bool is_marked_nullable = false;
+	bool is_marked_nullable = ast->attr & ZEND_TYPE_NULLABLE;
 	zend_ast_attr orig_ast_attr = ast->attr;
 	zend_type type = ZEND_TYPE_INIT_NONE(0);
-	if (ast->attr & ZEND_TYPE_NULLABLE) {
-		is_marked_nullable = true;
+
+	if (is_marked_nullable) {
 		ast->attr &= ~ZEND_TYPE_NULLABLE;
 	}
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1342,6 +1342,10 @@ static reflection_type_kind get_type_kind(zend_type type) {
 	if (type_mask_without_null == MAY_BE_BOOL || ZEND_TYPE_PURE_MASK(type) == MAY_BE_ANY) {
 		return NAMED_TYPE;
 	}
+	/* null|false must be a union type */
+	if (ZEND_TYPE_PURE_MASK(type) == (MAY_BE_NULL|MAY_BE_FALSE)) {
+		return UNION_TYPE;
+	}
 	/* Check that only one bit is set. */
 	if ((type_mask_without_null & (type_mask_without_null - 1)) != 0) {
 		return UNION_TYPE;
@@ -1356,6 +1360,7 @@ static void reflection_type_factory(zend_type type, zval *object, bool legacy_be
 	type_reference *reference;
 	reflection_type_kind type_kind = get_type_kind(type);
 	bool is_mixed = ZEND_TYPE_PURE_MASK(type) == MAY_BE_ANY;
+	bool is_only_null = (ZEND_TYPE_PURE_MASK(type) == MAY_BE_NULL && !ZEND_TYPE_IS_COMPLEX(type));
 
 	switch (type_kind) {
 		case INTERSECTION_TYPE:
@@ -1373,7 +1378,7 @@ static void reflection_type_factory(zend_type type, zval *object, bool legacy_be
 	intern = Z_REFLECTION_P(object);
 	reference = (type_reference*) emalloc(sizeof(type_reference));
 	reference->type = type;
-	reference->legacy_behavior = legacy_behavior && type_kind == NAMED_TYPE && !is_mixed;
+	reference->legacy_behavior = legacy_behavior && type_kind == NAMED_TYPE && !is_mixed && !is_only_null;
 	intern->ptr = reference;
 	intern->ref_type = REF_TYPE_TYPE;
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1342,10 +1342,6 @@ static reflection_type_kind get_type_kind(zend_type type) {
 	if (type_mask_without_null == MAY_BE_BOOL || ZEND_TYPE_PURE_MASK(type) == MAY_BE_ANY) {
 		return NAMED_TYPE;
 	}
-	/* null|false must be a union type */
-	if (ZEND_TYPE_PURE_MASK(type) == (MAY_BE_NULL|MAY_BE_FALSE)) {
-		return UNION_TYPE;
-	}
 	/* Check that only one bit is set. */
 	if ((type_mask_without_null & (type_mask_without_null - 1)) != 0) {
 		return UNION_TYPE;

--- a/ext/reflection/tests/ReflectionType_possible_types.phpt
+++ b/ext/reflection/tests/ReflectionType_possible_types.phpt
@@ -13,6 +13,7 @@ $functions = [
     function(): callable {},
     function(): iterable {},
     function(): null {},
+    function(): false {},
     function(): StdClass {}
 ];
 
@@ -32,4 +33,5 @@ string(5) "array"
 string(8) "callable"
 string(8) "iterable"
 string(4) "null"
+string(5) "false"
 string(8) "StdClass"

--- a/ext/reflection/tests/ReflectionType_possible_types.phpt
+++ b/ext/reflection/tests/ReflectionType_possible_types.phpt
@@ -12,6 +12,7 @@ $functions = [
     function(): array {},
     function(): callable {},
     function(): iterable {},
+    function(): null {},
     function(): StdClass {}
 ];
 
@@ -30,4 +31,5 @@ string(4) "bool"
 string(5) "array"
 string(8) "callable"
 string(8) "iterable"
+string(4) "null"
 string(8) "StdClass"

--- a/ext/reflection/tests/union_types.phpt
+++ b/ext/reflection/tests/union_types.phpt
@@ -13,6 +13,13 @@ function dumpType(ReflectionUnionType $rt) {
     }
 }
 
+function dumpBCType(ReflectionNamedType $rt) {
+    echo "Type $rt:\n";
+    echo "  Name: " . $rt->getName() . "\n";
+    echo "  String: " . (string) $rt . "\n";
+    echo "  Allows Null: " . ($rt->allowsNull() ? "true" : "false") . "\n";
+}
+
 function test1(): X|Y|int|float|false|null { }
 function test2(): X|iterable|bool { }
 function test3(): null|false { }
@@ -24,8 +31,8 @@ class Test {
 
 dumpType((new ReflectionFunction('test1'))->getReturnType());
 dumpType((new ReflectionFunction('test2'))->getReturnType());
-dumpType((new ReflectionFunction('test3'))->getReturnType());
-dumpType((new ReflectionFunction('test4'))->getReturnType());
+dumpBCType((new ReflectionFunction('test3'))->getReturnType());
+dumpBCType((new ReflectionFunction('test4'))->getReturnType());
 
 $rc = new ReflectionClass(Test::class);
 $rp = $rc->getProperty('prop');
@@ -79,21 +86,13 @@ Allows null: false
   Name: bool
   String: bool
   Allows Null: false
-Type false|null:
-Allows null: true
+Type ?false:
   Name: false
-  String: false
-  Allows Null: false
-  Name: null
-  String: null
+  String: ?false
   Allows Null: true
-Type false|null:
-Allows null: true
+Type ?false:
   Name: false
-  String: false
-  Allows Null: false
-  Name: null
-  String: null
+  String: ?false
   Allows Null: true
 Type X|Y|int:
 Allows null: false

--- a/ext/reflection/tests/union_types.phpt
+++ b/ext/reflection/tests/union_types.phpt
@@ -16,6 +16,7 @@ function dumpType(ReflectionUnionType $rt) {
 function test1(): X|Y|int|float|false|null { }
 function test2(): X|iterable|bool { }
 function test3(): null|false { }
+function test4(): ?false { }
 
 class Test {
     public X|Y|int $prop;
@@ -24,6 +25,7 @@ class Test {
 dumpType((new ReflectionFunction('test1'))->getReturnType());
 dumpType((new ReflectionFunction('test2'))->getReturnType());
 dumpType((new ReflectionFunction('test3'))->getReturnType());
+dumpType((new ReflectionFunction('test4'))->getReturnType());
 
 $rc = new ReflectionClass(Test::class);
 $rp = $rc->getProperty('prop');
@@ -77,6 +79,14 @@ Allows null: false
   Name: bool
   String: bool
   Allows Null: false
+Type false|null:
+Allows null: true
+  Name: false
+  String: false
+  Allows Null: false
+  Name: null
+  String: null
+  Allows Null: true
 Type false|null:
 Allows null: true
   Name: false

--- a/ext/reflection/tests/union_types.phpt
+++ b/ext/reflection/tests/union_types.phpt
@@ -15,6 +15,7 @@ function dumpType(ReflectionUnionType $rt) {
 
 function test1(): X|Y|int|float|false|null { }
 function test2(): X|iterable|bool { }
+function test3(): null|false { }
 
 class Test {
     public X|Y|int $prop;
@@ -22,6 +23,7 @@ class Test {
 
 dumpType((new ReflectionFunction('test1'))->getReturnType());
 dumpType((new ReflectionFunction('test2'))->getReturnType());
+dumpType((new ReflectionFunction('test3'))->getReturnType());
 
 $rc = new ReflectionClass(Test::class);
 $rp = $rc->getProperty('prop');
@@ -75,6 +77,14 @@ Allows null: false
   Name: bool
   String: bool
   Allows Null: false
+Type false|null:
+Allows null: true
+  Name: false
+  String: false
+  Allows Null: false
+  Name: null
+  String: null
+  Allows Null: true
 Type X|Y|int:
 Allows null: false
   Name: X


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/null-standalone-type

Also a drive-by consistency fix for error messages.