### PR TITLE
Change 'can not' to 'cannot' in places where it was a typo

### DIFF
--- a/Zend/tests/bug47516.phpt
+++ b/Zend/tests/bug47516.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #47516 (nowdoc can not be embed in heredoc but can be embed in double quote)
+Bug #47516 (nowdoc cannot be embedded in heredoc but can be embedded in double quote)
 --FILE--
 <?php
 $s='substr';

--- a/Zend/tests/bug70805.phpt
+++ b/Zend/tests/bug70805.phpt
@@ -37,9 +37,9 @@ $t[] = &$t;
 unset($t); // This is used to trigger C::__destruct while doing gc_colloct_roots
 
 $e = $a;
-unset($a); // This one can not be putted into roots buf because it's full, thus gc_colloct_roots will be called,
+unset($a); // This one cannot be put into roots buf because it's full, thus gc_colloct_roots will be called,
            // but C::__destructor which is called in gc_colloct_roots will put $a into buf
-           // which will make $a be putted into gc roots buf twice
+           // which will make $a be put into gc roots buf twice
 var_dump(gc_collect_cycles());
 ?>
 --EXPECT--

--- a/Zend/tests/bug70957.phpt
+++ b/Zend/tests/bug70957.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #70957 (self::class can not be resolved with reflection for abstract class)
+Bug #70957 (self::class cannot be resolved with reflection for abstract class)
 --FILE--
 <?php
 

--- a/Zend/tests/type_declarations/union_types/redundant_types/nullable_null.phpt
+++ b/Zend/tests/type_declarations/union_types/redundant_types/nullable_null.phpt
@@ -8,4 +8,4 @@ function test(): ?null {
 
 ?>
 --EXPECTF--
-Fatal error: Null can not be used as a standalone type in %s on line %d
+Fatal error: Null cannot be used as a standalone type in %s on line %d

--- a/Zend/tests/type_declarations/union_types/standalone_false.phpt
+++ b/Zend/tests/type_declarations/union_types/standalone_false.phpt
@@ -7,4 +7,4 @@ function test(): false {}
 
 ?>
 --EXPECTF--
-Fatal error: False can not be used as a standalone type in %s on line %d
+Fatal error: False cannot be used as a standalone type in %s on line %d

--- a/Zend/tests/type_declarations/union_types/standalone_null.phpt
+++ b/Zend/tests/type_declarations/union_types/standalone_null.phpt
@@ -7,4 +7,4 @@ function test(): null {}
 
 ?>
 --EXPECTF--
-Fatal error: Null can not be used as a standalone type in %s on line %d
+Fatal error: Null cannot be used as a standalone type in %s on line %d

--- a/Zend/tests/type_declarations/union_types/standalone_nullable_false.phpt
+++ b/Zend/tests/type_declarations/union_types/standalone_nullable_false.phpt
@@ -7,4 +7,4 @@ function test(): ?false {}
 
 ?>
 --EXPECTF--
-Fatal error: False can not be used as a standalone type in %s on line %d
+Fatal error: False cannot be used as a standalone type in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6328,9 +6328,9 @@ static zend_type zend_compile_typename(
 	if ((type_mask & (MAY_BE_NULL|MAY_BE_FALSE))
 			&& !ZEND_TYPE_IS_COMPLEX(type) && !(type_mask & ~(MAY_BE_NULL|MAY_BE_FALSE))) {
 		if (type_mask == MAY_BE_NULL) {
-			zend_error_noreturn(E_COMPILE_ERROR, "Null can not be used as a standalone type");
+			zend_error_noreturn(E_COMPILE_ERROR, "Null cannot be used as a standalone type");
 		} else {
-			zend_error_noreturn(E_COMPILE_ERROR, "False can not be used as a standalone type");
+			zend_error_noreturn(E_COMPILE_ERROR, "False cannot be used as a standalone type");
 		}
 	}
 

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -2403,7 +2403,7 @@ function gen_vm($def, $skel) {
     // Load definition file
     $in = @file($def);
     if (!$in) {
-        die("ERROR: Can not open definition file '$def'\n");
+        die("ERROR: Cannot open definition file '$def'\n");
     }
     // We need absolute path to definition file to use it in #line directives
     $definition_file = realpath($def);
@@ -2411,7 +2411,7 @@ function gen_vm($def, $skel) {
     // Load skeleton file
     $skl = @file($skel);
     if (!$skl) {
-        die("ERROR: Can not open skeleton file '$skel'\n");
+        die("ERROR: Cannot open skeleton file '$skel'\n");
     }
     // We need absolute path to skeleton file to use it in #line directives
     $skeleton_file = realpath($skel);

--- a/ext/curl/tests/curl_copy_handle_basic_006.phpt
+++ b/ext/curl/tests/curl_copy_handle_basic_006.phpt
@@ -26,7 +26,7 @@ curl
   var_dump( curl_exec($ch) );
   var_dump( curl_exec($copy) );
 
-  curl_close($ch); // can not close original handle before curl_exec($copy) since it causes char * inputs to be invalid (see also: http://curl.haxx.se/libcurl/c/curl_easy_duphandle.html)
+  curl_close($ch); // cannot close original handle before curl_exec($copy) since it causes char * inputs to be invalid (see also: http://curl.haxx.se/libcurl/c/curl_easy_duphandle.html)
   curl_close($copy);
 
 ?>

--- a/ext/date/tests/bug45543.phpt
+++ b/ext/date/tests/bug45543.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test for bug #45543: DateTime::setTimezone can not set timezones without ID.
+Test for bug #45543: DateTime::setTimezone cannot set timezones without ID.
 --INI--
 date.timezone=UTC
 --FILE--

--- a/ext/intl/grapheme/grapheme_util.c
+++ b/ext/intl/grapheme/grapheme_util.c
@@ -53,7 +53,7 @@ void grapheme_substr_ascii(char *str, size_t str_len, int32_t f, int32_t l, char
 	*sub_str = NULL;
 
 	if(str_len > INT32_MAX) {
-		/* We can not return long strings from ICU functions, so we won't here too */
+		/* We cannot return long strings from ICU functions, so we won't here too */
 		return;
 	}
 

--- a/ext/intl/intl_convert.c
+++ b/ext/intl/intl_convert.c
@@ -60,7 +60,7 @@ void intl_convert_utf8_to_utf16(
 	*status = U_ZERO_ERROR;
 
 	if(src_len > INT32_MAX) {
-		/* we can not fit this string */
+		/* we cannot fit this string */
 		*status = U_BUFFER_OVERFLOW_ERROR;
 		return;
 	}

--- a/ext/mysqli/tests/bug34785.phpt
+++ b/ext/mysqli/tests/bug34785.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #34785 (Can not properly subclass mysqli_stmt)
+Bug #34785 (Cannot properly subclass mysqli_stmt)
 --EXTENSIONS--
 mysqli
 --SKIPIF--

--- a/ext/mysqli/tests/mysqli_options_openbasedir.phpt
+++ b/ext/mysqli/tests/mysqli_options_openbasedir.phpt
@@ -15,7 +15,7 @@ if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
 
 if ($IS_MYSQLND) {
     if (true !== mysqli_options($link, MYSQLI_OPT_LOCAL_INFILE, 1))
-        printf("[002] Can not set MYSQLI_OPT_LOCAL_INFILE although open_basedir is set!\n");
+        printf("[002] Cannot set MYSQLI_OPT_LOCAL_INFILE although open_basedir is set!\n");
 
 } else {
     if (false !== mysqli_options($link, MYSQLI_OPT_LOCAL_INFILE, 1))

--- a/ext/mysqli/tests/mysqli_select_db.phpt
+++ b/ext/mysqli/tests/mysqli_select_db.phpt
@@ -56,11 +56,11 @@ require_once('skipifconnectfailure.inc');
     $current_db = $row['dbname'];
 
     mysqli_report(MYSQLI_REPORT_OFF);
-    mysqli_select_db($link, 'I can not imagine that this database exists');
+    mysqli_select_db($link, 'I cannot imagine that this database exists');
     mysqli_report(MYSQLI_REPORT_ERROR);
 
     ob_start();
-    mysqli_select_db($link, 'I can not imagine that this database exists');
+    mysqli_select_db($link, 'I cannot imagine that this database exists');
     $output = ob_get_contents();
     ob_end_clean();
     if (!stristr($output, "1049") && !stristr($output, "1044") && !stristr($output, "1045")) {

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3214,7 +3214,7 @@ static zend_result accel_post_startup(void)
 				break;
 			case FAILED_REATTACHED:
 				accel_startup_ok = 0;
-				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - can not reattach to exiting shared memory.");
+				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - cannot reattach to exiting shared memory.");
 				return SUCCESS;
 				break;
 #if ENABLE_FILE_CACHE_FALLBACK

--- a/ext/pcntl/tests/pcntl_fork_variation.phpt
+++ b/ext/pcntl/tests/pcntl_fork_variation.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test function pcntl_fork() by testing the process isolation in the forking hierarchy father -> son -> grandson where father can not knows his grandson
+Test function pcntl_fork() by testing the process isolation in the forking hierarchy father -> son -> grandson where father cannot know his grandson
 --CREDITS--
 Marco Fabbri mrfabbri@gmail.com
 Francesco Fullone ff@ideato.it

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -497,7 +497,7 @@ bail:
 
 		entry.link = NULL;
 		/* link field is null-terminated unless it has 100 non-null chars.
-		 * Thus we can not use strlen. */
+		 * Thus we cannot use strlen. */
 		linkname_len = strnlen(hdr->linkname, 100);
 		if (entry.tar_type == TAR_LINK) {
 			if (!zend_hash_str_exists(&myphar->manifest, hdr->linkname, linkname_len)) {

--- a/ext/reflection/tests/ReflectionClass_CannotClone_basic.phpt
+++ b/ext/reflection/tests/ReflectionClass_CannotClone_basic.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Reflection class can not be cloned
+Reflection class cannot be cloned
 --CREDITS--
 Stefan Koopmanschap <stefan@phpgg.nl>
 TestFest PHP|Tek

--- a/ext/simplexml/tests/bug26976.phpt
+++ b/ext/simplexml/tests/bug26976.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #26976 (Can not access array elements using array indices)
+Bug #26976 (Cannot access array elements using array indices)
 --EXTENSIONS--
 simplexml
 --FILE--

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -432,7 +432,7 @@ static void php_snmp_internal(INTERNAL_FUNCTION_PARAMETERS, int st,
 	}
 
 	if ((st & SNMP_CMD_SET) && objid_query->count > objid_query->step) {
-		php_snmp_error(getThis(), PHP_SNMP_ERRNO_MULTIPLE_SET_QUERIES, "Can not fit all OIDs for SET query into one packet, using multiple queries");
+		php_snmp_error(getThis(), PHP_SNMP_ERRNO_MULTIPLE_SET_QUERIES, "Cannot fit all OIDs for SET query into one packet, using multiple queries");
 	}
 
 	while (keepwalking) {

--- a/ext/snmp/tests/snmp-object-errno-errstr.phpt
+++ b/ext/snmp/tests/snmp-object-errno-errstr.phpt
@@ -138,12 +138,12 @@ string(129) "Could not add variable: OID='.iso.org.dod.internet.mgmt.mib-2.syste
 SNMP::ERRNO_MULTIPLE_SET_QUERIES
 bool(true)
 bool(true)
-string(74) "Can not fit all OIDs for SET query into one packet, using multiple queries"
+string(74) "Cannot fit all OIDs for SET query into one packet, using multiple queries"
 bool(true)
 bool(true)
 bool(true)
 bool(true)
-string(74) "Can not fit all OIDs for SET query into one packet, using multiple queries"
+string(74) "Cannot fit all OIDs for SET query into one packet, using multiple queries"
 bool(true)
 bool(true)
 bool(true)

--- a/ext/snmp/tests/snmp-object-errno-errstr.phpt
+++ b/ext/snmp/tests/snmp-object-errno-errstr.phpt
@@ -138,12 +138,12 @@ string(129) "Could not add variable: OID='.iso.org.dod.internet.mgmt.mib-2.syste
 SNMP::ERRNO_MULTIPLE_SET_QUERIES
 bool(true)
 bool(true)
-string(74) "Cannot fit all OIDs for SET query into one packet, using multiple queries"
+string(73) "Cannot fit all OIDs for SET query into one packet, using multiple queries"
 bool(true)
 bool(true)
 bool(true)
 bool(true)
-string(74) "Cannot fit all OIDs for SET query into one packet, using multiple queries"
+string(73) "Cannot fit all OIDs for SET query into one packet, using multiple queries"
 bool(true)
 bool(true)
 bool(true)

--- a/ext/snmp/tests/snmp-object.phpt
+++ b/ext/snmp/tests/snmp-object.phpt
@@ -232,12 +232,12 @@ bool(true)
 bool(true)
 Multiple OID with max_oids = 1
 
-Warning: SNMP::set(): Can not fit all OIDs for SET query into one packet, using multiple queries in %s on line %d
+Warning: SNMP::set(): Cannot fit all OIDs for SET query into one packet, using multiple queries in %s on line %d
 bool(true)
 bool(true)
 bool(true)
 
-Warning: SNMP::set(): Can not fit all OIDs for SET query into one packet, using multiple queries in %s on line %d
+Warning: SNMP::set(): Cannot fit all OIDs for SET query into one packet, using multiple queries in %s on line %d
 bool(true)
 bool(true)
 bool(true)

--- a/ext/sockets/tests/mcast_ipv6_send.phpt
+++ b/ext/sockets/tests/mcast_ipv6_send.phpt
@@ -9,10 +9,11 @@ if (getenv('CI_NO_IPV6') || !defined('IPPROTO_IPV6')) {
     die('skip IPv6 not available.');
 }
 $level = IPPROTO_IPV6;
-$s = socket_create(AF_INET6, SOCK_DGRAM, SOL_UDP) or die("skip Can not create socket");
+$s = socket_create(AF_INET6, SOCK_DGRAM, SOL_UDP) or die("skip Cannot create socket");
 if (socket_set_option($s, $level, IPV6_MULTICAST_IF, 1) === false) {
     die("skip interface 1 either doesn't exist or has no ipv6 address");
 }
+?>
 --FILE--
 <?php
 $domain = AF_INET6;

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -329,7 +329,7 @@ static void php_browscap_parser_cb(zval *arg1, zval *arg2, zval *arg3, int callb
 				}
 
 				if (zend_string_equals_literal_ci(Z_STR_P(arg1), "parent")) {
-					/* parent entry can not be same as current section -> causes infinite loop! */
+					/* parent entry cannot be same as current section -> causes infinite loop! */
 					if (ctx->current_section_name != NULL &&
 						zend_string_equals_ci(ctx->current_section_name, Z_STR_P(arg2))
 					) {

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -365,7 +365,7 @@ static void php_do_chgrp(INTERNAL_FUNCTION_PARAMETERS, int do_lchgrp) /* {{{ */
 		} else {
 #if !defined(WINDOWS)
 /* On Windows, we expect regular chgrp to fail silently by default */
-			php_error_docref(NULL, E_WARNING, "Can not call chgrp() for a non-standard stream");
+			php_error_docref(NULL, E_WARNING, "Cannot call chgrp() for a non-standard stream");
 #endif
 			RETURN_FALSE;
 		}
@@ -491,7 +491,7 @@ static void php_do_chown(INTERNAL_FUNCTION_PARAMETERS, int do_lchown) /* {{{ */
 		} else {
 #if !defined(WINDOWS)
 /* On Windows, we expect regular chown to fail silently by default */
-			php_error_docref(NULL, E_WARNING, "Can not call chown() for a non-standard stream");
+			php_error_docref(NULL, E_WARNING, "Cannot call chown() for a non-standard stream");
 #endif
 			RETURN_FALSE;
 		}
@@ -574,7 +574,7 @@ PHP_FUNCTION(chmod)
 				RETURN_FALSE;
 			}
 		} else {
-			php_error_docref(NULL, E_WARNING, "Can not call chmod() for a non-standard stream");
+			php_error_docref(NULL, E_WARNING, "Cannot call chmod() for a non-standard stream");
 			RETURN_FALSE;
 		}
 	}
@@ -643,7 +643,7 @@ PHP_FUNCTION(touch)
 		} else {
 			php_stream *stream;
 			if(!filetime_is_null || !fileatime_is_null) {
-				php_error_docref(NULL, E_WARNING, "Can not call touch() for a non-standard stream");
+				php_error_docref(NULL, E_WARNING, "Cannot call touch() for a non-standard stream");
 				RETURN_FALSE;
 			}
 			stream = php_stream_open_wrapper_ex(filename, "c", REPORT_ERRORS, NULL, NULL);

--- a/ext/standard/hrtime.c
+++ b/ext/standard/hrtime.c
@@ -159,7 +159,7 @@ static zend_always_inline php_hrtime_t _timer_current(void)
 	from an arbitrary point in time. If an optional boolean argument is
 	passed, returns an integer on 64-bit platforms or float on 32-bit
 	containing the current high-resolution time in nanoseconds. The
-	delivered timestamp is monotonic and can not be adjusted. */
+	delivered timestamp is monotonic and cannot be adjusted. */
 PHP_FUNCTION(hrtime)
 {
 #if HRTIME_AVAILABLE

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1190,7 +1190,7 @@ PHPAPI void php_implode(const zend_string *glue, HashTable *pieces, zval *return
 		}
 	} ZEND_HASH_FOREACH_END();
 
-	/* numelems can not be 0, we checked above */
+	/* numelems cannot be 0, we checked above */
 	str = zend_string_safe_alloc(numelems - 1, ZSTR_LEN(glue), len, 0);
 	cptr = ZSTR_VAL(str) + ZSTR_LEN(str);
 	*cptr = 0;

--- a/ext/standard/tests/array/array_filter_object.phpt
+++ b/ext/standard/tests/array/array_filter_object.phpt
@@ -47,7 +47,7 @@ class FinalClass
 {
   private $var4;
   final function finalMethod() {
-    echo 'This can not be overloaded';
+    echo 'This cannot be overloaded';
   }
 }
 

--- a/ext/standard/tests/filters/bug22538.phpt
+++ b/ext/standard/tests/filters/bug22538.phpt
@@ -15,7 +15,7 @@ do {
     $path2 = sprintf("%s/%s%db", __DIR__, uniqid(), time());
 } while ($path1 == $path2);
 
-$fp = fopen($path1, "w") or die("Can not open $path1\n");
+$fp = fopen($path1, "w") or die("Cannot open $path1\n");
 $str = "abcdefghijklmnopqrstuvwxyz\n";
 $str_len = strlen($str);
 $cnt = $size;
@@ -24,8 +24,8 @@ while (($cnt -= $str_len) > 0) {
 }
 $cnt = $size - ($str_len + $cnt);
 fclose($fp);
-$fin = fopen($path1, "r") or die("Can not open $path1\n");
-$fout = fopen($path2, "w") or die("Can not open $path2\n");
+$fin = fopen($path1, "r") or die("Cannot open $path1\n");
+$fout = fopen($path2, "w") or die("Cannot open $path2\n");
 stream_filter_append($fout, "string.rot13");
 my_stream_copy_to_stream($fin, $fout);
 fclose($fout);

--- a/ext/xmlreader/tests/014.phpt
+++ b/ext/xmlreader/tests/014.phpt
@@ -1,5 +1,5 @@
 --TEST--
-XMLReader: libxml2 XML Reader, read-only element values can not be modified
+XMLReader: libxml2 XML Reader, read-only element values cannot be modified
 --CREDITS--
 Mark Baker mark@lange.demon.co.uk at the PHPNW2017 Conference for PHP Testfest 2017
 --EXTENSIONS--

--- a/main/network.c
+++ b/main/network.c
@@ -836,7 +836,7 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
 				((struct sockaddr_in *)sa)->sin_port = htons(port);
 				socklen = sizeof(struct sockaddr_in);
 				if (bindto && strchr(bindto, ':')) {
-					/* IPV4 sock can not bind to IPV6 address */
+					/* IPV4 sock cannot bind to IPV6 address */
 					bindto = NULL;
 				}
 				break;

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -598,7 +598,7 @@ PHP_FUNCTION(phpdbg_end_oplog)
 	}
 
 	if (!PHPDBG_G(oplog_list)) {
-		zend_error(E_WARNING, "Can not end an oplog without starting it");
+		zend_error(E_WARNING, "Cannot end an oplog without starting it");
 		return;
 	}
 

--- a/sapi/phpdbg/tests/phpdbg_oplog_002.phpt
+++ b/sapi/phpdbg/tests/phpdbg_oplog_002.phpt
@@ -6,7 +6,7 @@ q
 --EXPECTF--
 [Successful compilation of %s]
 prompt> 
-Warning: Can not end an oplog without starting it in %s on line 3
+Warning: Cannot end an oplog without starting it in %s on line 3
 NULL
 [Script ended normally]
 prompt> 

--- a/tests/classes/interface_constant_inheritance_006.phpt
+++ b/tests/classes/interface_constant_inheritance_006.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Ensure a interface can not have protected constants
+Ensure an interface cannot have protected constants
 --FILE--
 <?php
 interface A {

--- a/tests/classes/interface_constant_inheritance_007.phpt
+++ b/tests/classes/interface_constant_inheritance_007.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Ensure a interface can not have private constants
+Ensure an interface cannot have private constants
 --FILE--
 <?php
 interface A {

--- a/tests/lang/bug24908.phpt
+++ b/tests/lang/bug24908.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #24908 (super-globals can not be used in __destruct())
+Bug #24908 (super-globals cannot be used in __destruct())
 --INI--
 variables_order=GPS
 --FILE--


### PR DESCRIPTION
Phrases "can not" and "cannot" have different meanings. Most of the time usage of "can not" is a typo. "Cannot" means the opposite of "can". "Can not ..." should only be used when "not" describes the word following it. 

This PR contains two commits:
1. Changing all "can not" to "cannot" in comments and in test files. I tried to avoid places where it was not clear which one the author meant. Some of them involved fixing related typos.
2. Changing PHP error messages to fix the typos. There is one I didn't change in timelib. 