### PR TITLE
Fix bug #81156 unset() on ArrayObject inside foreach skips next index.

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -594,8 +594,13 @@ ZEND_API void ZEND_FASTCALL _zend_hash_iterators_update(HashTable *ht, HashPosit
 	HashTableIterator *end  = iter + EG(ht_iterators_used);
 
 	while (iter != end) {
-		if (iter->ht == ht && iter->pos == from) {
-			iter->pos = to;
+		if (iter->ht == ht) {
+			if (iter->pos == from) {
+				iter->has_updated_iterator = 1;
+				iter->pos = to;
+			} else {
+				iter->has_updated_iterator = 0;
+			}
 		}
 		iter++;
 	}

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -364,6 +364,7 @@ typedef uint32_t HashPosition;
 typedef struct _HashTableIterator {
 	HashTable    *ht;
 	HashPosition  pos;
+	unsigned has_updated_iterator:1;
 } HashTableIterator;
 
 struct _zend_object {

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1079,6 +1079,17 @@ static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 			zend_user_it_invalidate_current(iter);
 			spl_array_next_ex(object, aht);
 		}
+	} else {
+		zend_user_it_invalidate_current(iter);
+		if (!(object->ar_flags & SPL_ARRAY_OVERLOADED_NEXT)) {
+			uint32_t *pos_ptr = spl_array_get_pos_ptr(aht, object);
+
+			if (spl_array_is_object(object)) {
+				spl_array_skip_protected(object, aht);
+			} else {
+				zend_hash_has_more_elements_ex(aht, pos_ptr);
+			}
+		}
 	}
 }
 /* }}} */

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1048,16 +1048,37 @@ static void spl_array_it_get_current_key(zend_object_iterator *iter, zval *key) 
 }
 /* }}} */
 
+static int spl_array_check_updated_iterator(HashTable *ht) /* {{{ */
+{
+	int result = FAILURE;
+	HashTableIterator *iter = EG(ht_iterators);
+	HashTableIterator *end  = iter + EG(ht_iterators_used);
+
+	while (iter != end) {
+		/* The iterator has updated position, so the current position is valid. */
+		if (iter->ht == ht && iter->has_updated_iterator == 1) {
+			result = SUCCESS;
+			iter->has_updated_iterator = 0;
+		}
+		iter++;
+	}
+
+	return result;
+}
+/* }}} */
+
 static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 {
 	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
 	HashTable *aht = spl_array_get_hash_table(object);
 
-	if (object->ar_flags & SPL_ARRAY_OVERLOADED_NEXT) {
-		zend_user_it_move_forward(iter);
-	} else {
-		zend_user_it_invalidate_current(iter);
-		spl_array_next_ex(object, aht);
+	if (spl_array_check_updated_iterator(aht) != SUCCESS) {
+		if (object->ar_flags & SPL_ARRAY_OVERLOADED_NEXT) {
+			zend_user_it_move_forward(iter);
+		} else {
+			zend_user_it_invalidate_current(iter);
+			spl_array_next_ex(object, aht);
+		}
 	}
 }
 /* }}} */

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1082,11 +1082,10 @@ static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 	} else {
 		zend_user_it_invalidate_current(iter);
 		if (!(object->ar_flags & SPL_ARRAY_OVERLOADED_NEXT)) {
-			uint32_t *pos_ptr = spl_array_get_pos_ptr(aht, object);
-
 			if (spl_array_is_object(object)) {
 				spl_array_skip_protected(object, aht);
 			} else {
+				uint32_t *pos_ptr = spl_array_get_pos_ptr(aht, object);
 				zend_hash_has_more_elements_ex(aht, pos_ptr);
 			}
 		}

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1080,6 +1080,7 @@ static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 			spl_array_next_ex(object, aht);
 		}
 	} else {
+		/* execute the common part. */
 		zend_user_it_invalidate_current(iter);
 		if (!(object->ar_flags & SPL_ARRAY_OVERLOADED_NEXT)) {
 			if (spl_array_is_object(object)) {

--- a/ext/spl/tests/array_015.phpt
+++ b/ext/spl/tests/array_015.phpt
@@ -82,11 +82,10 @@ object(ArrayObject)#%d (1) {
   }
 }
 1=>2
+3=>4
 object(ArrayObject)#%d (1) {
   %s"storage"%s"ArrayObject":private]=>
-  array(1) {
-    [3]=>
-    int(4)
+  array(0) {
   }
 }
 ===DONE===

--- a/ext/spl/tests/bug81156.phpt
+++ b/ext/spl/tests/bug81156.phpt
@@ -11,8 +11,23 @@ foreach ($ao as $key => $value) {
     }
 }
 echo json_encode($ao), "\n";
+
+$ao = new ArrayObject([true, false, false, true]);
+
+foreach ($ao as $key => $value) {
+    echo $key, "\n";
+    if (!$value) {
+        unset($ao[$key]);
+    }
+}
+echo json_encode($ao), "\n";
 ?>
 --EXPECT--
+0
+1
+2
+3
+{"0":true,"3":true}
 0
 1
 2

--- a/ext/spl/tests/bug81156.phpt
+++ b/ext/spl/tests/bug81156.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #81156 	unset() on ArrayObject inside foreach skips next index
+--FILE--
+<?php
+$ao = new ArrayObject([true, false, false, true]);
+
+foreach ($ao as $key => $value) {
+    echo $key, "\n";
+    if (!$value) {
+        $ao->offsetUnset($key);
+    }
+}
+echo json_encode($ao), "\n";
+?>
+--EXPECT--
+0
+1
+2
+3
+{"0":true,"3":true}


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=81156

```php
$ao = new ArrayObject([true, false, false, true]);

foreach ($ao as $key => $value) {
    echo $key, "\n";
    if (!$value) {
        unset($ao[$key]); // or $ao->offsetUnset($key);
    }
}
```
The function _zend_hash_iterators_update() and zend_hash_move_forward_ex() will modify the iterator position when unseting value circularly.

For example, _zend_hash_iterators_update() change iterator position 0 to 1 and zend_hash_move_forward_ex() change 1 to 2 when unset $ao[0]. So the program will unset $ao[2] in the next cycle.

I made the following changes to solve such problem.

First, recording iterator position changing by using has_updated_iterator field.
```c
// zend_types.h : 364
typedef struct _HashTableIterator {
	HashTable    *ht;
	HashPosition  pos;
	unsigned has_updated_iterator:1;
} HashTableIterator;

// zend_hash.c : 591
ZEND_API void ZEND_FASTCALL _zend_hash_iterators_update(HashTable *ht, HashPosition from, HashPosition to)
{
	HashTableIterator *iter = EG(ht_iterators);
	HashTableIterator *end  = iter + EG(ht_iterators_used);

	while (iter != end) {
		if (iter->ht == ht) {
			if (iter->pos == from) {
				iter->has_updated_iterator = 1;
				iter->pos = to;
			} else {
				iter->has_updated_iterator = 0;
			}
		}
		iter++;
	}
}
```

Secondly, It means that the iterator position has changed by function _zend_hash_iterators_update() and the current position is valid if the result of function sql_check_update_iterator() is SUCCESS.

The function spl_array_it_move_forward can will execute spl_array_next_ex  if the result of function sql_check_update_iterator() is FAILURE.
```c
// sql_arrar.c : 1051
static int spl_array_check_updated_iterator(HashTable *ht) /* {{{ */
{
	int result = FAILURE;
	HashTableIterator *iter = EG(ht_iterators);
	HashTableIterator *end  = iter + EG(ht_iterators_used);

	while (iter != end) {
		/* The iterator has updated position, so the current position is valid. */
		if (iter->ht == ht && iter->has_updated_iterator == 1) {
			result = SUCCESS;
			iter->has_updated_iterator = 0;
		}
		iter++;
	}

	return result;
}

// sql_arrar.c : 1070
static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
{
	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
	HashTable *aht = spl_array_get_hash_table(object);

	if (spl_array_check_updated_iterator(aht) != SUCCESS) {
		if (object->ar_flags & SPL_ARRAY_OVERLOADED_NEXT) {
			zend_user_it_move_forward(iter);
		} else {
			zend_user_it_invalidate_current(iter);
			spl_array_next_ex(object, aht);
		}
	} else {
		/* execute the common part. */
		zend_user_it_invalidate_current(iter);
		if (!(object->ar_flags & SPL_ARRAY_OVERLOADED_NEXT)) {
			if (spl_array_is_object(object)) {
				spl_array_skip_protected(object, aht);
			} else {
				uint32_t *pos_ptr = spl_array_get_pos_ptr(aht, object);
				zend_hash_has_more_elements_ex(aht, pos_ptr);
			}
		}
	}
}
```

Welcome to comment the pr if something wrong with my pr and it will help me to perfect it. Thanks.