### PR TITLE
Fix bug #81156 unset() on ArrayObject inside foreach skips next index.

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -617,8 +617,13 @@ ZEND_API void ZEND_FASTCALL _zend_hash_iterators_update(HashTable *ht, HashPosit
 	HashTableIterator *end  = iter + EG(ht_iterators_used);
 
 	while (iter != end) {
-		if (iter->ht == ht && iter->pos == from) {
-			iter->pos = to;
+		if (iter->ht == ht) {
+			if (iter->pos == from) {
+				iter->has_updated_iterator = 1;
+				iter->pos = to;
+			} else {
+				iter->has_updated_iterator = 0;
+			}
 		}
 		iter++;
 	}

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2886,3 +2886,28 @@ convert:
 		return new_ht;
 	}
 }
+
+ZEND_API int ZEND_FASTCALL zend_hash_check_updated_iterator(spl_array_object *object)
+{
+	HashTable *ht = spl_array_get_hash_table(intern);
+	return _zend_hash_check_updated_iterator_ex(ht);
+}
+
+ZEND_API int ZEND_FASTCALL _zend_hash_check_updated_iterator_ex(HashTable *ht)
+{
+	int result = FAILURE;
+	HashTableIterator *iter = EG(ht_iterators);
+	HashTableIterator *end  = iter + EG(ht_iterators_used);
+
+	while (iter != end) {
+		/* The iterator has updated position, so the current position is valid. */
+		if (iter->ht == ht && iter->has_updated_iterator == 1) {
+			result = SUCCESS;
+			iter->has_updated_iterator = 0;
+		}
+		iter++;
+	}
+
+	return result;
+}
+

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2883,7 +2883,7 @@ convert:
 	}
 }
 
-static zend_always_inline void zend_hash_set_is_delete(HashTable *ht, HashPosition from, HashPosition to)
+ZEND_API void ZEND_FASTCALL zend_hash_set_is_delete(HashTable *ht, HashPosition from, HashPosition to)
 {
 	if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
 		HashTableIterator *iter = EG(ht_iterators);
@@ -2913,7 +2913,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_remove_is_delete(HashTable *ht)
 	}
 }
 
-ZEND_API int ZEND_FASTCALL zend_hash_check_if_delete(HashTable *ht) /* {{{ */
+ZEND_API zend_result ZEND_FASTCALL zend_hash_check_if_delete(HashTable *ht) /* {{{ */
 {
 	int result = FAILURE;
 

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2886,28 +2886,3 @@ convert:
 		return new_ht;
 	}
 }
-
-ZEND_API int ZEND_FASTCALL zend_hash_check_updated_iterator(spl_array_object *object)
-{
-	HashTable *ht = spl_array_get_hash_table(intern);
-	return _zend_hash_check_updated_iterator_ex(ht);
-}
-
-ZEND_API int ZEND_FASTCALL _zend_hash_check_updated_iterator_ex(HashTable *ht)
-{
-	int result = FAILURE;
-	HashTableIterator *iter = EG(ht_iterators);
-	HashTableIterator *end  = iter + EG(ht_iterators_used);
-
-	while (iter != end) {
-		/* The iterator has updated position, so the current position is valid. */
-		if (iter->ht == ht && iter->has_updated_iterator == 1) {
-			result = SUCCESS;
-			iter->has_updated_iterator = 0;
-		}
-		iter++;
-	}
-
-	return result;
-}
-

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1336,6 +1336,8 @@ static zend_always_inline void _zend_hash_del_el_ex(HashTable *ht, uint32_t idx,
 		if (ht->nInternalPointer == idx) {
 			ht->nInternalPointer = new_idx;
 		}
+		/* I don't want to use function zend_hash_iterators_update() to set iter->is_delete
+		 * because zend_hash_iterators_update() was used in many place. */
 		zend_hash_set_is_delete(ht, idx, new_idx);
 		zend_hash_iterators_update(ht, idx, new_idx);
 	}
@@ -2915,7 +2917,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_remove_is_delete(HashTable *ht)
 
 ZEND_API zend_result ZEND_FASTCALL zend_hash_check_if_delete(HashTable *ht) /* {{{ */
 {
-	int result = FAILURE;
+	zend_result result = FAILURE;
 
 	if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
 		HashTableIterator *iter = EG(ht_iterators);

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1317,8 +1317,12 @@ static zend_always_inline void zend_hash_set_is_delete(HashTable *ht, HashPositi
 		HashTableIterator *end  = iter + EG(ht_iterators_used);
 
 		while (iter != end) {
-			if (iter->ht == ht && iter->pos == from) {
-				iter->is_delete = 1;
+			if (iter->ht == ht) {
+				if (iter->pos == from) {
+					iter->is_delete = 1;
+				} else {
+					iter->is_delete = 0;
+				}
 			}
 			iter++;
 		}

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2903,18 +2903,3 @@ convert:
 		return new_ht;
 	}
 }
-
-ZEND_API void ZEND_FASTCALL zend_hash_remove_is_delete(HashTable *ht)
-{
-	if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
-		HashTableIterator *iter = EG(ht_iterators);
-		HashTableIterator *end  = iter + EG(ht_iterators_used);
-
-		while (iter != end) {
-			if (iter->ht == ht) {
-				iter->is_delete = 0;
-			}
-			iter++;
-		}
-	}
-}

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2914,24 +2914,3 @@ ZEND_API void ZEND_FASTCALL zend_hash_remove_is_delete(HashTable *ht)
 		}
 	}
 }
-
-ZEND_API zend_result ZEND_FASTCALL zend_hash_check_if_delete(HashTable *ht) /* {{{ */
-{
-	zend_result result = FAILURE;
-
-	if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
-		HashTableIterator *iter = EG(ht_iterators);
-		HashTableIterator *end  = iter + EG(ht_iterators_used);
-
-		while (iter != end) {
-			/* The iterator has updated position, so the current position is valid. */
-			if (iter->ht == ht && iter->is_delete == 1) {
-				result = SUCCESS;
-				iter->is_delete = 0;
-			}
-			iter++;
-		}
-	}
-
-	return result;
-}

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -472,7 +472,7 @@ typedef uint32_t HashPosition;
 typedef struct _HashTableIterator {
 	HashTable    *ht;
 	HashPosition  pos;
-	unsigned has_updated_iterator:1;
+	unsigned      is_delete:1;
 } HashTableIterator;
 
 struct _zend_object {

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -472,6 +472,7 @@ typedef uint32_t HashPosition;
 typedef struct _HashTableIterator {
 	HashTable    *ht;
 	HashPosition  pos;
+	unsigned has_updated_iterator:1;
 } HashTableIterator;
 
 struct _zend_object {

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -957,31 +957,12 @@ static void spl_array_it_get_current_key(zend_object_iterator *iter, zval *key) 
 }
 /* }}} */
 
-static int spl_array_check_updated_iterator(HashTable *ht) /* {{{ */
-{
-	int result = FAILURE;
-	HashTableIterator *iter = EG(ht_iterators);
-	HashTableIterator *end  = iter + EG(ht_iterators_used);
-
-	while (iter != end) {
-		/* The iterator has updated position, so the current position is valid. */
-		if (iter->ht == ht && iter->has_updated_iterator == 1) {
-			result = SUCCESS;
-			iter->has_updated_iterator = 0;
-		}
-		iter++;
-	}
-
-	return result;
-}
-/* }}} */
-
 static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 {
 	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
 	HashTable *aht = spl_array_get_hash_table(object);
 
-	if (spl_array_check_updated_iterator(aht) != SUCCESS) {
+	if (_zend_hash_check_updated_iterator_ex(aht) != SUCCESS) {
 		spl_array_next_ex(object, aht);
 	} else {
 		/* execute the common part */
@@ -1011,6 +992,7 @@ static void spl_array_rewind(spl_array_object *intern) /* {{{ */
 static void spl_array_it_rewind(zend_object_iterator *iter) /* {{{ */
 {
 	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
+	zend_hash_check_updated_iterator(object);
 	spl_array_rewind(object);
 }
 /* }}} */

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -957,12 +957,31 @@ static void spl_array_it_get_current_key(zend_object_iterator *iter, zval *key) 
 }
 /* }}} */
 
+static int spl_array_check_if_delete(HashTable *ht) /* {{{ */
+{
+	int result = FAILURE;
+	HashTableIterator *iter = EG(ht_iterators);
+	HashTableIterator *end  = iter + EG(ht_iterators_used);
+
+	while (iter != end) {
+		/* The iterator has updated position, so the current position is valid. */
+		if (iter->ht == ht && iter->is_delete == 1) {
+			result = SUCCESS;
+			iter->is_delete = 0;
+		}
+		iter++;
+	}
+
+	return result;
+}
+/* }}} */
+
 static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 {
 	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
 	HashTable *aht = spl_array_get_hash_table(object);
 
-	if (zend_hash_check_if_delete(aht) != SUCCESS) {
+	if (spl_array_check_if_delete(aht) != SUCCESS) {
 		spl_array_next_ex(object, aht);
 	} else {
 		/* execute the common part */

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -964,7 +964,7 @@ static int spl_array_check_if_delete(HashTable *ht) /* {{{ */
 	HashTableIterator *end  = iter + EG(ht_iterators_used);
 
 	while (iter != end) {
-		/* The iterator has updated position, so the current position is valid. */
+		/* The iterator has unset value in foreach, so the current position is valid. */
 		if (iter->ht == ht && iter->is_delete == 1) {
 			result = SUCCESS;
 			iter->is_delete = 0;

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -957,11 +957,41 @@ static void spl_array_it_get_current_key(zend_object_iterator *iter, zval *key) 
 }
 /* }}} */
 
+static int spl_array_check_updated_iterator(HashTable *ht) /* {{{ */
+{
+	int result = FAILURE;
+	HashTableIterator *iter = EG(ht_iterators);
+	HashTableIterator *end  = iter + EG(ht_iterators_used);
+
+	while (iter != end) {
+		/* The iterator has updated position, so the current position is valid. */
+		if (iter->ht == ht && iter->has_updated_iterator == 1) {
+			result = SUCCESS;
+			iter->has_updated_iterator = 0;
+		}
+		iter++;
+	}
+
+	return result;
+}
+/* }}} */
+
 static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 {
 	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
 	HashTable *aht = spl_array_get_hash_table(object);
-	spl_array_next_ex(object, aht);
+
+	if (spl_array_check_updated_iterator(aht) != SUCCESS) {
+		spl_array_next_ex(object, aht);
+	} else {
+		/* execute the common part */
+		if (spl_array_is_object(object)) {
+			spl_array_skip_protected(object, aht);
+		} else {
+			uint32_t *pos_ptr = spl_array_get_pos_ptr(aht, object);
+			zend_hash_has_more_elements_ex(aht, pos_ptr);
+		}
+	}
 }
 /* }}} */
 

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -957,12 +957,31 @@ static void spl_array_it_get_current_key(zend_object_iterator *iter, zval *key) 
 }
 /* }}} */
 
+static int spl_array_check_updated_iterator(HashTable *ht) /* {{{ */
+{
+	int result = FAILURE;
+	HashTableIterator *iter = EG(ht_iterators);
+	HashTableIterator *end  = iter + EG(ht_iterators_used);
+
+	while (iter != end) {
+		/* The iterator has updated position, so the current position is valid. */
+		if (iter->ht == ht && iter->has_updated_iterator == 1) {
+			result = SUCCESS;
+			iter->has_updated_iterator = 0;
+		}
+		iter++;
+	}
+
+	return result;
+}
+/* }}} */
+
 static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 {
 	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
 	HashTable *aht = spl_array_get_hash_table(object);
 
-	if (_zend_hash_check_updated_iterator_ex(aht) != SUCCESS) {
+	if (spl_array_check_updated_iterator(aht) != SUCCESS) {
 		spl_array_next_ex(object, aht);
 	} else {
 		/* execute the common part */
@@ -992,7 +1011,6 @@ static void spl_array_rewind(spl_array_object *intern) /* {{{ */
 static void spl_array_it_rewind(zend_object_iterator *iter) /* {{{ */
 {
 	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
-	zend_hash_check_updated_iterator(object);
 	spl_array_rewind(object);
 }
 /* }}} */

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1464,6 +1464,7 @@ PHP_METHOD(ArrayIterator, next)
 		RETURN_THROWS();
 	}
 
+	zend_hash_remove_is_delete(aht);
 	spl_array_next_ex(intern, aht);
 }
 /* }}} */

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -957,31 +957,12 @@ static void spl_array_it_get_current_key(zend_object_iterator *iter, zval *key) 
 }
 /* }}} */
 
-static int spl_array_check_updated_iterator(HashTable *ht) /* {{{ */
-{
-	int result = FAILURE;
-	HashTableIterator *iter = EG(ht_iterators);
-	HashTableIterator *end  = iter + EG(ht_iterators_used);
-
-	while (iter != end) {
-		/* The iterator has updated position, so the current position is valid. */
-		if (iter->ht == ht && iter->has_updated_iterator == 1) {
-			result = SUCCESS;
-			iter->has_updated_iterator = 0;
-		}
-		iter++;
-	}
-
-	return result;
-}
-/* }}} */
-
 static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
 {
 	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
 	HashTable *aht = spl_array_get_hash_table(object);
 
-	if (spl_array_check_updated_iterator(aht) != SUCCESS) {
+	if (zend_hash_check_if_delete(aht) != SUCCESS) {
 		spl_array_next_ex(object, aht);
 	} else {
 		/* execute the common part */

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1464,7 +1464,6 @@ PHP_METHOD(ArrayIterator, next)
 		RETURN_THROWS();
 	}
 
-	zend_hash_remove_is_delete(aht);
 	spl_array_next_ex(intern, aht);
 }
 /* }}} */

--- a/ext/spl/tests/array_015.phpt
+++ b/ext/spl/tests/array_015.phpt
@@ -80,10 +80,9 @@ object(ArrayObject)#%d (1) {
   }
 }
 1=>2
+3=>4
 object(ArrayObject)#%d (1) {
   %s"storage"%s"ArrayObject":private]=>
-  array(1) {
-    [3]=>
-    int(4)
+  array(0) {
   }
 }

--- a/ext/spl/tests/bug81156.phpt
+++ b/ext/spl/tests/bug81156.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #81156 	unset() on ArrayObject inside foreach skips next index
+--FILE--
+<?php
+$ao = new ArrayObject([true, false, false, true]);
+
+foreach ($ao as $key => $value) {
+    echo $key, "\n";
+    if (!$value) {
+        $ao->offsetUnset($key);
+    }
+}
+echo json_encode($ao), "\n";
+
+$ao = new ArrayObject([true, false, false, true]);
+
+foreach ($ao as $key => $value) {
+    echo $key, "\n";
+    if (!$value) {
+        unset($ao[$key]);
+    }
+}
+echo json_encode($ao), "\n";
+?>
+--EXPECT--
+0
+1
+2
+3
+{"0":true,"3":true}
+0
+1
+2
+3
+{"0":true,"3":true}

--- a/ext/spl/tests/bug81156.phpt
+++ b/ext/spl/tests/bug81156.phpt
@@ -2,8 +2,17 @@
 Bug #81156 	unset() on ArrayObject inside foreach skips next index
 --FILE--
 <?php
-$ao = new ArrayObject([true, false, false, true]);
 
+$ao = new ArrayObject([true, false, false, true]);
+foreach ($ao as $key => $value) {
+    echo $key, "\n";
+    if (!$value) {
+        $ao->offsetUnset($key);
+    }
+}
+echo json_encode($ao), "\n";
+
+$ao = new ArrayObject(["a" => true, "b" => false, "c" => false, "d" => true]);
 foreach ($ao as $key => $value) {
     echo $key, "\n";
     if (!$value) {
@@ -13,14 +22,12 @@ foreach ($ao as $key => $value) {
 echo json_encode($ao), "\n";
 
 $ao = new ArrayObject([true, false, false, true]);
-
 foreach ($ao as $key => $value) {
     echo $key, "\n";
-    if (!$value) {
-        unset($ao[$key]);
-    }
+    $ao->offsetUnset($key);
 }
 echo json_encode($ao), "\n";
+
 ?>
 --EXPECT--
 0
@@ -28,8 +35,13 @@ echo json_encode($ao), "\n";
 2
 3
 {"0":true,"3":true}
+a
+b
+c
+d
+{"a":true,"d":true}
 0
 1
 2
 3
-{"0":true,"3":true}
+{}


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=81156

```php
$ao = new ArrayObject([true, false, false, true]);

foreach ($ao as $key => $value) {
    echo $key, "\n";
    if (!$value) {
        unset($ao[$key]); // or $ao->offsetUnset($key);
    }
}
```
The function _zend_hash_iterators_update() and zend_hash_move_forward_ex() will modify the iterator position when unseting value circularly.

For example, _zend_hash_iterators_update() change iterator position 0 to 1 and zend_hash_move_forward_ex() change 1 to 2 when unset $ao[0]. So the program will unset $ao[2] in the next cycle.

I made the following changes to solve such problem.

First, recording iterator position changing by using has_updated_iterator field.
```c
// zend_types.h : 472
typedef struct _HashTableIterator {
	HashTable    *ht;
	HashPosition  pos;
	unsigned       is_delete:1;
} HashTableIterator;

// zend_hash.c : 1313
static zend_always_inline void zend_hash_set_is_delete(HashTable *ht, HashPosition from, HashPosition to)
{
	if (UNEXPECTED(HT_HAS_ITERATORS(ht))) {
		HashTableIterator *iter = EG(ht_iterators);
		HashTableIterator *end  = iter + EG(ht_iterators_used);

		while (iter != end) {
			if (iter->ht == ht) {
				if (iter->pos == from) {
					iter->is_delete = 1;
				} else {
					iter->is_delete = 0;
				}
			}
			iter++;
		}
	}
}
```

Secondly, It means that the iterator position has changed by function _zend_hash_iterators_update() and the current position is valid if the result of function sql_check_update_iterator() is SUCCESS.

The function spl_array_it_move_forward can will execute spl_array_next_ex  if the result of function sql_check_update_iterator() is FAILURE.
```c
// sql_arrar.c : 960
static int spl_array_check_if_delete(HashTable *ht) /* {{{ */
{
	int result = FAILURE;
	HashTableIterator *iter = EG(ht_iterators);
	HashTableIterator *end  = iter + EG(ht_iterators_used);

	while (iter != end) {
		/* The iterator has unset value in foreach, so the current position is valid. */
		if (iter->ht == ht && iter->is_delete == 1) {
			result = SUCCESS;
			iter->is_delete = 0;
		}
		iter++;
	}

	return result;
}

// sql_arrar.c : 979
static void spl_array_it_move_forward(zend_object_iterator *iter) /* {{{ */
{
	spl_array_object *object = Z_SPLARRAY_P(&iter->data);
	HashTable *aht = spl_array_get_hash_table(object);

	if (spl_array_check_if_delete(aht) != SUCCESS) {
		spl_array_next_ex(object, aht);
	} else {
		/* execute the common part */
		if (spl_array_is_object(object)) {
			spl_array_skip_protected(object, aht);
		} else {
			uint32_t *pos_ptr = spl_array_get_pos_ptr(aht, object);
			zend_hash_has_more_elements_ex(aht, pos_ptr);
		}
	}
}
```

To be honest, this pr can not solve the following bug. The results are always weird.
In my branch, the result is {"0":true,"2":true}.
In the main version of php , the result is {"0":true,"2":true,"3":false}.
Can we accept this change? :smiley: 
```php
$ao = new ArrayIterator([true, false, false, true]);

foreach ($ao as $key => $value) {
    $ao->offsetUnset($key);
    $ao->next();
}
echo json_encode($ao), "\n";
```

Welcome to comment the pr if something wrong with my pr and it will help me to perfect it. Thanks.