### PR TITLE
Revert "Fix #81424: PCRE2 10.35 JIT performance regression"

### DIFF
--- a/ext/pcre/pcre2lib/pcre2_jit_compile.c
+++ b/ext/pcre/pcre2lib/pcre2_jit_compile.c
@@ -11152,7 +11152,7 @@ early_fail_type = (early_fail_ptr & 0x7);
 early_fail_ptr >>= 3;
 
 /* During recursion, these optimizations are disabled. */
-if (common->early_fail_start_ptr == 0 && common->fast_forward_bc_ptr == NULL)
+if (common->early_fail_start_ptr == 0)
   {
   early_fail_ptr = 0;
   early_fail_type = type_skip;


### PR DESCRIPTION
This reverts commit a2471383fec332ae30827c7e3f4f9451420f1f0b.

Fixing the performance regression, apparently fixes a functional
regression[1], so we revert for now.

[1] <https://github.com/PhilipHazel/pcre2/issues/21>