### PR TITLE
Add ZipArchive::clearError, getStreamIndex and getStreamName methods

### DIFF
--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -31,7 +31,7 @@ extern zend_module_entry zip_module_entry;
 #define ZIP_OVERWRITE ZIP_TRUNCATE
 #endif
 
-#define PHP_ZIP_VERSION "1.19.4"
+#define PHP_ZIP_VERSION "1.20.0-dev"
 
 #define ZIP_OPENBASEDIR_CHECKPATH(filename) php_check_open_basedir(filename)
 
@@ -75,7 +75,7 @@ static inline ze_zip_object *php_zip_fetch_object(zend_object *obj) {
 #define Z_ZIP_P(zv) php_zip_fetch_object(Z_OBJ_P((zv)))
 
 php_stream *php_stream_zip_opener(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC);
-php_stream *php_stream_zip_open(struct zip *arch, const char *path, const char *mode STREAMS_DC);
+php_stream *php_stream_zip_open(struct zip *arch, struct zip_stat *sb, const char *mode, zip_flags_t flags STREAMS_DC);
 
 extern const php_stream_wrapper php_stream_zip_wrapper;
 

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 93db1517143e903f01e4726a6b6c9bcbe0510f5b */
+ * Stub hash: 214a5d606d5535032251a41d4fa18f47d93ec42e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -56,6 +56,9 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_count
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_getStatusString, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_clearError, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_addEmptyDir, 0, 1, _IS_BOOL, 0)
@@ -201,6 +204,16 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_ZipArchive_getFr
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZipArchive_getStreamIndex, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZipArchive_getStreamName, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZipArchive_getStream, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -309,6 +322,7 @@ ZEND_METHOD(ZipArchive, setPassword);
 ZEND_METHOD(ZipArchive, close);
 ZEND_METHOD(ZipArchive, count);
 ZEND_METHOD(ZipArchive, getStatusString);
+ZEND_METHOD(ZipArchive, clearError);
 ZEND_METHOD(ZipArchive, addEmptyDir);
 ZEND_METHOD(ZipArchive, addFromString);
 ZEND_METHOD(ZipArchive, addFile);
@@ -342,7 +356,8 @@ ZEND_METHOD(ZipArchive, unchangeName);
 ZEND_METHOD(ZipArchive, extractTo);
 ZEND_METHOD(ZipArchive, getFromName);
 ZEND_METHOD(ZipArchive, getFromIndex);
-ZEND_METHOD(ZipArchive, getStream);
+ZEND_METHOD(ZipArchive, getStreamIndex);
+ZEND_METHOD(ZipArchive, getStreamName);
 #if defined(ZIP_OPSYS_DEFAULT)
 ZEND_METHOD(ZipArchive, setExternalAttributesName);
 #endif
@@ -398,6 +413,7 @@ static const zend_function_entry class_ZipArchive_methods[] = {
 	ZEND_ME(ZipArchive, close, arginfo_class_ZipArchive_close, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZipArchive, count, arginfo_class_ZipArchive_count, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZipArchive, getStatusString, arginfo_class_ZipArchive_getStatusString, ZEND_ACC_PUBLIC)
+	ZEND_ME(ZipArchive, clearError, arginfo_class_ZipArchive_clearError, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZipArchive, addEmptyDir, arginfo_class_ZipArchive_addEmptyDir, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZipArchive, addFromString, arginfo_class_ZipArchive_addFromString, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZipArchive, addFile, arginfo_class_ZipArchive_addFile, ZEND_ACC_PUBLIC)
@@ -431,7 +447,9 @@ static const zend_function_entry class_ZipArchive_methods[] = {
 	ZEND_ME(ZipArchive, extractTo, arginfo_class_ZipArchive_extractTo, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZipArchive, getFromName, arginfo_class_ZipArchive_getFromName, ZEND_ACC_PUBLIC)
 	ZEND_ME(ZipArchive, getFromIndex, arginfo_class_ZipArchive_getFromIndex, ZEND_ACC_PUBLIC)
-	ZEND_ME(ZipArchive, getStream, arginfo_class_ZipArchive_getStream, ZEND_ACC_PUBLIC)
+	ZEND_ME(ZipArchive, getStreamIndex, arginfo_class_ZipArchive_getStreamIndex, ZEND_ACC_PUBLIC)
+	ZEND_ME(ZipArchive, getStreamName, arginfo_class_ZipArchive_getStreamName, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(ZipArchive, getStream, getStreamName, arginfo_class_ZipArchive_getStream, ZEND_ACC_PUBLIC)
 #if defined(ZIP_OPSYS_DEFAULT)
 	ZEND_ME(ZipArchive, setExternalAttributesName, arginfo_class_ZipArchive_setExternalAttributesName, ZEND_ACC_PUBLIC)
 #endif

--- a/ext/zip/tests/oo_getstreamindex.phpt
+++ b/ext/zip/tests/oo_getstreamindex.phpt
@@ -1,0 +1,67 @@
+--TEST--
+ZipArchive::getStreamIndex / ZipArchive::getName
+--EXTENSIONS--
+zip
+--FILE--
+<?php
+
+$name = __DIR__ . '/getstream.zip';
+
+$zip = new ZipArchive;
+$r = $zip->open($name, ZIPARCHIVE::CREATE);
+$zip->addFromString('foo.txt', 'foo');
+$zip->addFromString('bar.txt', 'bar');
+$zip->close();
+
+$r = $zip->open($name);
+
+$zip->addFromString('bar.txt', 'baz', ZipArchive::FL_OVERWRITE);
+
+
+echo "== Name\n";
+$fp = $zip->getStreamName('foo.txt');
+var_dump($zip->status);
+var_dump(stream_get_contents($fp));
+$zip->clearError();
+fclose($fp);
+
+echo "== Index\n";
+$fp = $zip->getStreamIndex(0);
+var_dump($zip->status);
+var_dump(stream_get_contents($fp));
+$zip->clearError();
+fclose($fp);
+
+echo "== Index, changed\n";
+$fp = $zip->getStreamIndex(1);
+var_dump($zip->status);
+$zip->clearError();
+
+echo "== Index, unchanged\n";
+$fp = $zip->getStreamIndex(1, ZipArchive::FL_UNCHANGED);
+var_dump($zip->status);
+var_dump(stream_get_contents($fp));
+$zip->clearError();
+fclose($fp);
+
+$zip->close();
+?>
+== Done
+--CLEAN--
+<?php
+$name = __DIR__ . '/getstream.zip';
+@unlink($name);
+?>
+--EXPECTF--
+== Name
+int(0)
+string(3) "foo"
+== Index
+int(0)
+string(3) "foo"
+== Index, changed
+int(15)
+== Index, unchanged
+int(0)
+string(3) "bar"
+== Done

--- a/ext/zip/zip_stream.c
+++ b/ext/zip/zip_stream.c
@@ -208,7 +208,7 @@ const php_stream_ops php_stream_zipio_ops = {
 };
 
 /* {{{ php_stream_zip_open */
-php_stream *php_stream_zip_open(struct zip *arch, const char *path, const char *mode STREAMS_DC)
+php_stream *php_stream_zip_open(struct zip *arch, struct zip_stat *sb, const char *mode, zip_flags_t flags STREAMS_DC)
 {
 	struct zip_file *zf = NULL;
 
@@ -220,7 +220,7 @@ php_stream *php_stream_zip_open(struct zip *arch, const char *path, const char *
 	}
 
 	if (arch) {
-		zf = zip_fopen(arch, path, 0);
+		zf = zip_fopen_index(arch, sb->index, flags);
 		if (zf) {
 			self = emalloc(sizeof(*self));
 
@@ -229,7 +229,7 @@ php_stream *php_stream_zip_open(struct zip *arch, const char *path, const char *
 			self->stream = NULL;
 			self->cursor = 0;
 			stream = php_stream_alloc(&php_stream_zipio_ops, self, NULL, mode);
-			stream->orig_path = estrdup(path);
+			stream->orig_path = estrdup(sb->name);
 		}
 	}
 


### PR DESCRIPTION
    public function clearError(): void {}
    public function getStreamIndex(int $index, int $flags = 0) {}
    public function getStreamName(string $name, int $flags = 0) {}

ZipArchive::getStream is kept for BC

See https://github.com/pierrejoye/php_zip/issues/20