### PR TITLE
Add tests for function/class declared in a file included repeatedly

### DIFF
--- a/Zend/tests/repeated_include/anonymous_class.inc
+++ b/Zend/tests/repeated_include/anonymous_class.inc
@@ -1,0 +1,7 @@
+<?php
+
+$className = AnonymousClassNameCache::get_class(fn () => new class() {
+    public static function verify() {
+        return 'ok';
+    }
+});

--- a/Zend/tests/repeated_include/anonymous_class.phpt
+++ b/Zend/tests/repeated_include/anonymous_class.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Repeated include must not increase memory - anonymous class
+--SKIPIF--
+<?php
+// TODO test should pass even without opcache, but fixes are needed
+// related bug tracker https://bugs.php.net/bug.php?id=76982
+if (!extension_loaded('Zend OPcache') || !(opcache_get_status() ?: ['opcache_enabled' => false])['opcache_enabled']) {
+    die('xfail test currently requires opcache enabled');
+}
+?>
+--FILE--
+<?php
+
+// new anonymous class declared and included multiple times always has a new class name,
+// this test accounts for that and tests if an anonymous class declared in a closure
+// invoked once does not increase memory consumption
+
+final class AnonymousClassNameCache
+{
+    /** @var array<string, string> */
+    private static $classNameByFxHash = [];
+
+    private function __construct()
+    {
+    }
+
+    public static function get_class(\Closure $createAnonymousClassFx): string
+    {
+        $fxRefl = new \ReflectionFunction($createAnonymousClassFx);
+        $fxHash = $fxRefl->getFileName() . ':' . $fxRefl->getStartLine() . '-' . $fxRefl->getEndLine();
+
+        if (!isset(self::$classNameByFxHash[$fxHash])) {
+            self::$classNameByFxHash[$fxHash] = get_class($createAnonymousClassFx());
+        }
+
+        return self::$classNameByFxHash[$fxHash];
+    }
+}
+
+$classNamePrev = null;
+$m = -1;
+$mDiff = -1;
+$mPrev = 0;
+for ($i = 0; $i < (PHP_OS_FAMILY === 'Windows' ? 1_000 /* include is slow on Windows */ : 20_000); $i++) {
+    require __DIR__ . '/anonymous_class.inc';
+    if ($classNamePrev !== null && $className !== $classNamePrev) {
+        echo 'Class name is different: ' . $className . ' vs ' . $classNamePrev . ' (' . $i . ' iteration)' . "\n";
+        exit(1);
+    }
+    $classNamePrev = $className;
+    assert($className::verify() === 'ok');
+    $m = memory_get_usage();
+    $mDiff = $m - $mPrev;
+    if ($mPrev !== 0 && $mDiff !== 0) {
+        echo 'Increased memory detected: ' . $mDiff . ' B (' . $i . ' iteration)' . "\n";
+        exit(1);
+    }
+    $mPrev = $m;
+}
+echo 'done';
+
+?>
+--EXPECT--
+done

--- a/Zend/tests/repeated_include/anonymous_function.inc
+++ b/Zend/tests/repeated_include/anonymous_function.inc
@@ -1,0 +1,7 @@
+<?php
+
+$funcA = function () {
+    return 'ok';
+};
+
+$funcB = fn () => 'okB';

--- a/Zend/tests/repeated_include/anonymous_function.phpt
+++ b/Zend/tests/repeated_include/anonymous_function.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Repeated include must not increase memory - anonymous function
+--SKIPIF--
+<?php
+// TODO test should pass even without opcache, but fixes are needed
+// related bug tracker https://bugs.php.net/bug.php?id=76982
+if (!extension_loaded('Zend OPcache') || !(opcache_get_status() ?: ['opcache_enabled' => false])['opcache_enabled']) {
+    die('xfail test currently requires opcache enabled');
+}
+?>
+--FILE--
+<?php
+
+$m = -1;
+$mDiff = -1;
+$mPrev = 0;
+for ($i = 0; $i < (PHP_OS_FAMILY === 'Windows' ? 1_000 /* include is slow on Windows */ : 20_000); $i++) {
+    require __DIR__ . '/anonymous_function.inc';
+    assert($funcA() === 'ok');
+    assert($funcB() === 'okB');
+    $m = memory_get_usage();
+    $mDiff = $m - $mPrev;
+    if ($mPrev !== 0 && $mDiff !== 0) {
+        echo 'Increased memory detected: ' . $mDiff . ' B (' . $i . ' iteration)' . "\n";
+        exit(1);
+    }
+    $mPrev = $m;
+}
+echo 'done';
+
+?>
+--EXPECT--
+done

--- a/Zend/tests/repeated_include/class_in_if.inc
+++ b/Zend/tests/repeated_include/class_in_if.inc
@@ -1,0 +1,9 @@
+<?php
+
+if (!class_exists(Test::class)) {
+    class Test {
+        public static function verify() {
+            return 'ok';
+        }
+    }
+}

--- a/Zend/tests/repeated_include/class_in_if.phpt
+++ b/Zend/tests/repeated_include/class_in_if.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Repeated include must not increase memory - class in if condition
+--SKIPIF--
+<?php
+// TODO test should pass even without opcache, but fixes are needed
+// related bug tracker https://bugs.php.net/bug.php?id=76982
+if (!extension_loaded('Zend OPcache') || !(opcache_get_status() ?: ['opcache_enabled' => false])['opcache_enabled']) {
+    die('xfail test currently requires opcache enabled');
+}
+?>
+--FILE--
+<?php
+
+$m = -1;
+$mDiff = -1;
+$mPrev = 0;
+for ($i = 0; $i < (PHP_OS_FAMILY === 'Windows' ? 1_000 /* include is slow on Windows */ : 20_000); $i++) {
+    require __DIR__ . '/class_in_if.inc';
+    assert(Test::verify() === 'ok');
+    $m = memory_get_usage();
+    $mDiff = $m - $mPrev;
+    if ($mPrev !== 0 && $mDiff !== 0) {
+        echo 'Increased memory detected: ' . $mDiff . ' B (' . $i . ' iteration)' . "\n";
+        exit(1);
+    }
+    $mPrev = $m;
+}
+echo 'done';
+
+?>
+--EXPECT--
+done

--- a/Zend/tests/repeated_include/function_in_if.inc
+++ b/Zend/tests/repeated_include/function_in_if.inc
@@ -1,0 +1,7 @@
+<?php
+
+if (!function_exists('test')) {
+    function test() {
+        return 'ok';
+    }
+}

--- a/Zend/tests/repeated_include/function_in_if.phpt
+++ b/Zend/tests/repeated_include/function_in_if.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Repeated include must not increase memory - function in if condition
+--SKIPIF--
+<?php
+// TODO test should pass even without opcache, but fixes are needed
+// related bug tracker https://bugs.php.net/bug.php?id=76982
+if (!extension_loaded('Zend OPcache') || !(opcache_get_status() ?: ['opcache_enabled' => false])['opcache_enabled']) {
+    die('xfail test currently requires opcache enabled');
+}
+?>
+--FILE--
+<?php
+
+$m = -1;
+$mDiff = -1;
+$mPrev = 0;
+for ($i = 0; $i < (PHP_OS_FAMILY === 'Windows' ? 1_000 /* include is slow on Windows */ : 20_000); $i++) {
+    require __DIR__ . '/function_in_if.inc';
+    assert(test() === 'ok');
+    $m = memory_get_usage();
+    $mDiff = $m - $mPrev;
+    if ($mPrev !== 0 && $mDiff !== 0) {
+        echo 'Increased memory detected: ' . $mDiff . ' B (' . $i . ' iteration)' . "\n";
+        exit(1);
+    }
+    $mPrev = $m;
+}
+echo 'done';
+
+?>
+--EXPECT--
+done


### PR DESCRIPTION
Memory leaks are fixed in PHP 8.1 /w opcache.

Add tests to check if memory does not increase on repeated include so code can rely on it.