### PR TITLE
 Fix string method synopsis default values containing "\"

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -458,6 +458,10 @@ class ArgInfo {
                 return "&{$this->defaultValue};";
         }
 
+        if (preg_match("/^\s*['\"].*['\"]\s*$/", $this->defaultValue)) {
+            return str_replace('\\\\', '\\', $this->defaultValue);
+        }
+
         return $this->defaultValue;
     }
 }


### PR DESCRIPTION
As highlighted in https://github.com/php/doc-en/pull/915#discussion_r719380556, we were generating an extra backslash.