### PR TITLE
Set log_error_verbosity in pgsql test

### DIFF
--- a/ext/pdo_pgsql/tests/bug_33876.phpt
+++ b/ext/pdo_pgsql/tests/bug_33876.phpt
@@ -47,7 +47,7 @@ else
 # Expected to fail; unless told otherwise, PDO assumes string inputs
 # false -> "" as string, which pgsql doesn't like
 if (!$res->execute(array(false)))
-    print_r($res->errorInfo());
+    print_r(normalizeErrorInfo($res->errorInfo()));
 else
     print_r($res->fetchAll(PDO::FETCH_ASSOC));
 
@@ -83,13 +83,17 @@ else
 # Expected to fail; unless told otherwise, PDO assumes string inputs
 # false -> "" as string, which pgsql doesn't like
 if (!$res->execute(array(false))) {
-    $err = $res->errorInfo();
-    // Strip additional lines outputted by recent PgSQL versions
-    $err[2] = trim(current(explode("\n", $err[2])));
-    print_r($err);
+    print_r(normalizeErrorInfo($res->errorInfo()));
 } else {
     print_r($res->fetchAll(PDO::FETCH_ASSOC));
 }
+
+function normalizeErrorInfo(array $err): array {
+    // Strip additional lines outputted by recent PgSQL versions
+    $err[2] = trim(current(explode("\n", $err[2])));
+    return $err;
+}
+
 ?>
 --EXPECTF--
 Array


### PR DESCRIPTION
This test recently started printing

> CONTEXT:  unnamed portal parameter $1 = ''

into the output.

Maybe this will help?