### PR TITLE
Reduce threshold further in ext/date/tests/bug73837.phpt

### DIFF
--- a/ext/date/tests/bug73837.phpt
+++ b/ext/date/tests/bug73837.phpt
@@ -13,7 +13,7 @@ for ( $i = 0; $i < 1000; $i++ )
 
 // For low-resolution clocks, we may construct many objects in the same tick.
 var_dump($n = count( $collect ));
-echo $n > 400 ? "microseconds differ\n" : "microseconds do not differ enough ($n)\n";
+echo $n > 200 ? "microseconds differ\n" : "microseconds do not differ enough ($n)\n";
 ?>
 --EXPECTF--
 int(%d)


### PR DESCRIPTION
The threshold in test case ext/date/tests/bug73837.phpt has been reduced
several times, from the original 990 to current 400. However, this case
still failed on my local test with Mac Mini machine(macOS on Apple
silicon). Here is the diff result:

```
  $ cat ext/date/tests/bug73837.diff
     int(%d)
  002+ microseconds do not differ enough (268)
  002- microseconds differ
```

Hence this patch reduces the threshold further.

Note that this patch should be backported to PHP 8.1 branch as well.