### PR TITLE
Deprecate dynamic property creation with #[AllowDynamicProperties] escape hatch

### DIFF
--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -1101,7 +1101,9 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 
 				/* Don't try to propagate assignments to (potentially) typed properties. We would
 				 * need to deal with errors and type conversions first. */
-				if (!var_info->ce || (var_info->ce->ce_flags & ZEND_ACC_HAS_TYPE_HINTS)) {
+				// TODO: Distinguish dynamic and declared property assignments here?
+				if (!var_info->ce || (var_info->ce->ce_flags & ZEND_ACC_HAS_TYPE_HINTS) ||
+						!(var_info->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					SET_RESULT_BOT(result);
 					SET_RESULT_BOT(op1);
 					return;

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -4842,15 +4842,17 @@ ZEND_API bool zend_may_throw_ex(const zend_op *opline, const zend_ssa_op *ssa_op
 					return 1;
 				}
 
-				if (op_array->scope != ce && ce->default_properties_count) {
-					zend_property_info *prop_info =
-						zend_hash_find_ptr(&ce->properties_info, prop_name);
-					if (prop_info && (!(prop_info->flags & ZEND_ACC_PUBLIC)
-								|| ZEND_TYPE_IS_SET(prop_info->type))) {
+				zend_property_info *prop_info =
+					zend_hash_find_ptr(&ce->properties_info, prop_name);
+				if (prop_info) {
+					if (ZEND_TYPE_IS_SET(prop_info->type)) {
 						return 1;
 					}
+					return !(prop_info->flags & ZEND_ACC_PUBLIC)
+						|| prop_info->ce != op_array->scope;
+				} else {
+					return !(ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES);
 				}
-				return 0;
 			}
 			return 1;
 		case ZEND_ROPE_INIT:

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -4849,7 +4849,7 @@ ZEND_API bool zend_may_throw_ex(const zend_op *opline, const zend_ssa_op *ssa_op
 						return 1;
 					}
 					return !(prop_info->flags & ZEND_ACC_PUBLIC)
-						|| prop_info->ce != op_array->scope;
+						&& prop_info->ce != op_array->scope;
 				} else {
 					return !(ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES);
 				}

--- a/Zend/tests/allow_dynamic_properties_on_interface.phpt
+++ b/Zend/tests/allow_dynamic_properties_on_interface.phpt
@@ -1,0 +1,11 @@
+--TEST--
+#[AllowDynamicProperties] cannot be applied to interface
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+interface Test {}
+
+?>
+--EXPECTF--
+Fatal error: Cannot apply #[AllowDynamicProperties] to interface in %s on line %d

--- a/Zend/tests/allow_dynamic_properties_on_trait.phpt
+++ b/Zend/tests/allow_dynamic_properties_on_trait.phpt
@@ -1,0 +1,11 @@
+--TEST--
+#[AllowDynamicProperties] cannot be applied to trait
+--FILE--
+<?php
+
+#[AllowDynamicProperties]
+trait Test {}
+
+?>
+--EXPECTF--
+Fatal error: Cannot apply #[AllowDynamicProperties] to trait in %s on line %d

--- a/Zend/tests/anon/003.phpt
+++ b/Zend/tests/anon/003.phpt
@@ -4,7 +4,7 @@ reusing anonymous classes
 <?php
 while (@$i++<10) {
     var_dump(new class($i) {
-
+        public $i;
         public function __construct($i) {
             $this->i = $i;
         }

--- a/Zend/tests/assign_to_obj_001.phpt
+++ b/Zend/tests/assign_to_obj_001.phpt
@@ -8,6 +8,7 @@ function &a($i) {
 }
 
 class A {
+    public $a;
     public function test() {
         $this->a = a(1);
         unset($this->a);

--- a/Zend/tests/bug27268.phpt
+++ b/Zend/tests/bug27268.phpt
@@ -2,6 +2,7 @@
 Bug #27268 (Bad references accentuated by clone)
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class A
 {
     public function &getA()

--- a/Zend/tests/bug30162.phpt
+++ b/Zend/tests/bug30162.phpt
@@ -2,6 +2,7 @@
 Bug #30162 (Catching exception in constructor couses lose of $this)
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class FIIFO {
 
     public function __construct() {
@@ -11,6 +12,7 @@ class FIIFO {
 
 }
 
+#[AllowDynamicProperties]
 class hariCow extends FIIFO {
 
     public function __construct() {

--- a/Zend/tests/bug38779_1.phpt
+++ b/Zend/tests/bug38779_1.phpt
@@ -4,6 +4,7 @@ Bug #38779 (engine crashes when require()'ing file with syntax error through use
 <?php
 
 class Loader {
+    public $context;
     private $position;
     private $data;
     public function stream_open($path, $mode, $options, &$opened_path)  {

--- a/Zend/tests/bug47343.phpt
+++ b/Zend/tests/bug47343.phpt
@@ -4,6 +4,7 @@ Bug #47343 (gc_collect_cycles causes a segfault when called within a destructor 
 <?php
 class A
 {
+    public $data = [];
     public function __destruct()
     {
         gc_collect_cycles();
@@ -20,10 +21,7 @@ class A
 
 class B
 {
-    public function __construct($A)
-    {
-        $this->A = $A;
-    }
+    public function __construct(public $A) {}
 
     public function __destruct()
     {

--- a/Zend/tests/bug49893.phpt
+++ b/Zend/tests/bug49893.phpt
@@ -12,6 +12,7 @@ class A {
     }
 }
 class B {
+    public $a;
     function __construct() {
         $this->a = new A();
         throw new Exception("1");

--- a/Zend/tests/bug51822.phpt
+++ b/Zend/tests/bug51822.phpt
@@ -12,6 +12,7 @@ class DestructableObject
 
 class DestructorCreator
 {
+    public $test;
     public function __destruct()
     {
         $this->test = new DestructableObject;

--- a/Zend/tests/bug54268.phpt
+++ b/Zend/tests/bug54268.phpt
@@ -20,6 +20,7 @@ class DestructableObject
 }
 class DestructorCreator
 {
+        public $test;
         public function __destruct()
         {
                 $this->test = new DestructableObject;

--- a/Zend/tests/bug55305.phpt
+++ b/Zend/tests/bug55305.phpt
@@ -2,6 +2,7 @@
 Bug #55305 (ref lost: 1st ref instantiated in class def, 2nd ref made w/o instantiating)
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class Foo {
   var $foo = "test";
 }

--- a/Zend/tests/bug60536_001.phpt
+++ b/Zend/tests/bug60536_001.phpt
@@ -12,6 +12,7 @@ class Y extends X {
           return ++$this->x;
       }
 }
+#[AllowDynamicProperties]
 class Z extends Y {
       function __construct() {
           return ++$this->x;

--- a/Zend/tests/bug60833.phpt
+++ b/Zend/tests/bug60833.phpt
@@ -5,8 +5,8 @@ Bug #60833 (self, parent, static behave inconsistently case-sensitive)
 class A {
     static $x = "A";
     function testit() {
-        $this->v1 = new sELF;
-        $this->v2 = new SELF;
+        var_dump(new sELF);
+        var_dump(new SELF);
     }
 }
 
@@ -14,26 +14,21 @@ class B extends A {
     static $x = "B";
     function testit() {
         PARENT::testit();
-        $this->v3 = new sELF;
-        $this->v4 = new PARENT;
-        $this->v4 = STATIC::$x;
+        var_dump(new sELF);
+        var_dump(new PARENT);
+        var_dump(STATIC::$x);
     }
 }
 $t = new B();
 $t->testit();
-var_dump($t);
 ?>
---EXPECTF--
-object(B)#%d (4) {
-  ["v1"]=>
-  object(A)#%d (0) {
-  }
-  ["v2"]=>
-  object(A)#%d (0) {
-  }
-  ["v3"]=>
-  object(B)#%d (0) {
-  }
-  ["v4"]=>
-  string(1) "B"
+--EXPECT--
+object(A)#2 (0) {
 }
+object(A)#2 (0) {
+}
+object(B)#2 (0) {
+}
+object(A)#2 (0) {
+}
+string(1) "B"

--- a/Zend/tests/bug63462.phpt
+++ b/Zend/tests/bug63462.phpt
@@ -4,6 +4,7 @@ Test script to verify that magic methods should be called only once when accessi
 Marco Pivetta <ocramius@gmail.com>
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class Test {
     public    $publicProperty;
     protected $protectedProperty;

--- a/Zend/tests/bug64821.1.phpt
+++ b/Zend/tests/bug64821.1.phpt
@@ -3,6 +3,7 @@ Bug #64821 Custom Exceptions crash when internal properties overridden (variatio
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class a extends exception {
     public function __construct() {
         $this->message = NULL;

--- a/Zend/tests/bug64960.phpt
+++ b/Zend/tests/bug64960.phpt
@@ -31,6 +31,10 @@ $a['waa'];
 --EXPECTF--
 Notice: ob_end_flush(): Failed to delete and flush buffer. No buffer to delete or flush in %sbug64960.php on line 3
 
+Deprecated: Creation of dynamic property Exception::$_trace is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property Exception::$_trace is deprecated in %s on line %d
+
 Fatal error: Uncaught Exception in %sbug64960.php:19
 Stack trace:
 #0 [internal function]: {closure}(8, 'ob_end_clean():...', '%s', 9)

--- a/Zend/tests/bug65911.phpt
+++ b/Zend/tests/bug65911.phpt
@@ -6,6 +6,7 @@ class A {}
 
 class B
 {
+    public $foo;
     public function go()
     {
         $this->foo = 'bar';

--- a/Zend/tests/bug66609.phpt
+++ b/Zend/tests/bug66609.phpt
@@ -10,6 +10,7 @@ class Bar {
         return $foo->foo;
     }
 }
+#[AllowDynamicProperties]
 class Foo {
     public function __get($x) {
         global $bar;

--- a/Zend/tests/bug69446.phpt
+++ b/Zend/tests/bug69446.phpt
@@ -5,6 +5,7 @@ zend.enable_gc = 1
 --FILE--
 <?php
 $bar = NULL;
+#[AllowDynamicProperties]
 class bad {
     public function __destruct() {
         global $bar;

--- a/Zend/tests/bug70223.phpt
+++ b/Zend/tests/bug70223.phpt
@@ -3,6 +3,9 @@ Bug #70223 (Incrementing value returned by magic getter)
 --FILE--
 <?php
 
+// Note that this actually writes to dynamic property A::$f.
+// Increment goes through __set(), not __get() by reference!
+#[AllowDynamicProperties]
 class A {
 
     private $foo = 0;

--- a/Zend/tests/bug70397.phpt
+++ b/Zend/tests/bug70397.phpt
@@ -8,7 +8,9 @@ $f = function () {
     yield $this->value;
 };
 
-var_dump($f->call(new class {})->current());
+var_dump($f->call(new class {
+    public $value;
+})->current());
 
 ?>
 --EXPECT--

--- a/Zend/tests/bug70805.phpt
+++ b/Zend/tests/bug70805.phpt
@@ -3,9 +3,11 @@ Bug #70805 (Segmentation faults whilst running Drupal 8 test suite)
 --FILE--
 <?php
 class A {
+    public $b;
 }
 
 class B {
+    public $a;
 }
 
 class C {

--- a/Zend/tests/bug70805_1.phpt
+++ b/Zend/tests/bug70805_1.phpt
@@ -5,9 +5,11 @@ zend.enable_gc = 1
 --FILE--
 <?php
 class A {
+    public $b;
 }
 
 class B {
+    public $a;
 }
 
 class C {

--- a/Zend/tests/bug70805_2.phpt
+++ b/Zend/tests/bug70805_2.phpt
@@ -5,9 +5,11 @@ zend.enable_gc = 1
 --FILE--
 <?php
 class A {
+    public $b;
 }
 
 class B {
+    public $a;
 }
 
 class C {

--- a/Zend/tests/bug71859.phpt
+++ b/Zend/tests/bug71859.phpt
@@ -3,6 +3,7 @@ Bug #71859 (zend_objects_store_call_destructors operates on realloced memory, cr
 --FILE--
 <?php
 class constructs_in_destructor {
+  public $a;
   public function __destruct() {
     //We are now in zend_objects_store_call_destructors
     //This causes a realloc in zend_objects_store_put

--- a/Zend/tests/bug72101.phpt
+++ b/Zend/tests/bug72101.phpt
@@ -26,6 +26,7 @@ class PHPUnit_Framework_MockObject_InvocationMocker {
 
 class PHPUnit_Framework_MockObject_Matcher {
     public $stub = null;
+    public $methodNameMatcher;
     public function invoked($invocation) {
         return $this->stub->invoke($invocation);
     }
@@ -77,10 +78,10 @@ $foo->bar($a, $b, $c);
 --EXPECTF--
 Fatal error: Uncaught Error: Class "DoesNotExists" not found in %s:%d
 Stack trace:
-#0 %sbug72101.php(8): {closure}(2, 'MethodCallbackB...', '%s', 8)
-#1 %sbug72101.php(27): PHPUnit_Framework_MockObject_Stub_ReturnCallback->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
-#2 %sbug72101.php(19): PHPUnit_Framework_MockObject_Matcher->invoked(Object(PHPUnit_Framework_MockObject_Invocation_Static))
-#3 %sbug72101.php(52): PHPUnit_Framework_MockObject_InvocationMocker->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
-#4 %sbug72101.php(72): Mock_MethodCallbackByReference_7b180d26->bar(0, 0, 0)
+#0 %sbug72101.php(%d): {closure}(2, 'MethodCallbackB...', '%s', 8)
+#1 %sbug72101.php(%d): PHPUnit_Framework_MockObject_Stub_ReturnCallback->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
+#2 %sbug72101.php(%d): PHPUnit_Framework_MockObject_Matcher->invoked(Object(PHPUnit_Framework_MockObject_Invocation_Static))
+#3 %sbug72101.php(%d): PHPUnit_Framework_MockObject_InvocationMocker->invoke(Object(PHPUnit_Framework_MockObject_Invocation_Static))
+#4 %sbug72101.php(%d): Mock_MethodCallbackByReference_7b180d26->bar(0, 0, 0)
 #5 {main}
-  thrown in %sbug72101.php on line 61
+  thrown in %sbug72101.php on line %d

--- a/Zend/tests/bug78010.phpt
+++ b/Zend/tests/bug78010.phpt
@@ -5,6 +5,7 @@ memory_limit=2G
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class foo
 {
     public function __construct()

--- a/Zend/tests/bug78340.phpt
+++ b/Zend/tests/bug78340.phpt
@@ -4,9 +4,10 @@ Bug #78340: Include of stream wrapper not reading whole file
 <?php
 
 class lib {
+  public $context;
   public static $files= [];
 
-  private $bytes, $pos;
+  private $bytes, $pos, $ino;
 
   function stream_open($path, $mode, $options, $opened_path) {
     $this->bytes= self::$files[$path];

--- a/Zend/tests/bug78379.phpt
+++ b/Zend/tests/bug78379.phpt
@@ -3,10 +3,12 @@ Bug #78379 (Cast to object confuses GC, causes crash)
 --FILE--
 <?php
 class C {
+    public $p;
     public function __construct() {
         $this->p = (object)["x" => [1]];
     }
 }
+#[AllowDynamicProperties]
 class E {
 }
 $e = new E;

--- a/Zend/tests/bug78379_2.phpt
+++ b/Zend/tests/bug78379_2.phpt
@@ -2,6 +2,7 @@
 Bug #78379.2 (Cast to object confuses GC, causes crash)
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class E {}
 function f() {
     $e1 = new E;

--- a/Zend/tests/bug78589.phpt
+++ b/Zend/tests/bug78589.phpt
@@ -4,6 +4,7 @@ Bug #78589: Memory leak with GC + __destruct()
 <?php
 
 class Test {
+    public $foo;
     public function __destruct() {}
 }
 

--- a/Zend/tests/bug79477.phpt
+++ b/Zend/tests/bug79477.phpt
@@ -3,6 +3,7 @@ Bug #79477: casting object into array creates references
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class Test {
     public $prop = 'default value';
 }

--- a/Zend/tests/bug79862.phpt
+++ b/Zend/tests/bug79862.phpt
@@ -3,6 +3,7 @@ Bug #79862: Public non-static property in child should take priority over privat
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class a {
     private static $prop1;
     private static $prop2;

--- a/Zend/tests/bug81104.phpt
+++ b/Zend/tests/bug81104.phpt
@@ -5,6 +5,7 @@ memory_limit=5M
 report_memleaks=0
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class X {
     public $x;
     public function __construct() { $this->x = [$this]; }

--- a/Zend/tests/closure_020.phpt
+++ b/Zend/tests/closure_020.phpt
@@ -5,6 +5,7 @@ Closure 020: Trying to access private property outside class
 
 class foo {
     private $test = 3;
+    public $a;
 
     public function x() {
         $a = &$this;

--- a/Zend/tests/closure_026.phpt
+++ b/Zend/tests/closure_026.phpt
@@ -4,6 +4,7 @@ Closure 026: Assigning a closure object to an array in $this
 <?php
 
 class foo {
+    public $a;
     public function __construct() {
         $a =& $this;
 

--- a/Zend/tests/dynamic_prop_deprecation.phpt
+++ b/Zend/tests/dynamic_prop_deprecation.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Dynamic properties deprecation
+--FILE--
+<?php
+
+class Test {}
+
+$obj = new Test;
+$obj->prop = 1; // Deprecated
+$obj->prop = 1; // Ok
+$obj->prop2 += 1; // Deprecated
+$obj->prop2 += 1; // Ok
+$obj->prop3++; // Deprecated
+$obj->prop3++; // Ok
+$obj->prop4[] = 1; // Deprecated
+$obj->prop4[] = 1; // Ok
+isset($obj->prop5); // Ok
+unset($obj->prop6); // Ok
+
+// stdClass should not throw deprecation.
+$obj = new stdClass;
+$obj->prop = 1;
+
+// Classes with #[AllowDynamicProperties] should not throw deprecation.
+#[AllowDynamicProperties]
+class Test2 {}
+class Test3 extends Test2 {}
+
+$obj = new Test2;
+$obj->prop = 1;
+
+$obj = new Test3;
+$obj->prop = 1;
+
+?>
+--EXPECTF--
+Deprecated: Creation of dynamic property Test::$prop is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property Test::$prop2 is deprecated in %s on line %d
+
+Warning: Undefined property: Test::$prop2 in %s on line %d
+
+Deprecated: Creation of dynamic property Test::$prop3 is deprecated in %s on line %d
+
+Warning: Undefined property: Test::$prop3 in %s on line %d
+
+Deprecated: Creation of dynamic property Test::$prop4 is deprecated in %s on line %d

--- a/Zend/tests/exception_stream_wrapper.phpt
+++ b/Zend/tests/exception_stream_wrapper.phpt
@@ -4,6 +4,7 @@ Exception in stream wrapper + __call
 <?php
 
 class Loader {
+    public $context;
     function stream_open() {
         return true;
     }

--- a/Zend/tests/fibers/no-switch-gc.phpt
+++ b/Zend/tests/fibers/no-switch-gc.phpt
@@ -5,9 +5,10 @@ Context switches are prevented during GC collect cycles
 
 $fiber = new Fiber(function () {
     call_user_func(function () {
-        $a = new class () {};
+        $a = new class { public $next; };
 
-        $b = new class () {
+        $b = new class {
+            public $next;
             public function __destruct() {
                 Fiber::suspend();
             }

--- a/Zend/tests/foreach_shadowed_dyn_property.phpt
+++ b/Zend/tests/foreach_shadowed_dyn_property.phpt
@@ -13,6 +13,8 @@ class Test {
         var_dump(get_object_vars($this));
     }
 }
+
+#[AllowDynamicProperties]
 class Test2 extends Test {
 }
 

--- a/Zend/tests/gc_038.phpt
+++ b/Zend/tests/gc_038.phpt
@@ -126,13 +126,14 @@ function test_pow() {
 test_pow();
 
 class Y {
+    public $x;
     function __toString() {
         return "y";
     }
 }
 function test_concat() {
     $x = new Y;
-    $x->x= $x;
+    $x->x = $x;
     @$x .= "x";
     $n = gc_collect_cycles();
     echo ".=\t$n\n";

--- a/Zend/tests/gc_042.phpt
+++ b/Zend/tests/gc_042.phpt
@@ -3,6 +3,7 @@ Object properties HT may need to be removed from nested data
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class Test {
     public function __destruct() {
         $GLOBALS['x'] = $this;

--- a/Zend/tests/generators/iterator_wrapper_leak.phpt
+++ b/Zend/tests/generators/iterator_wrapper_leak.phpt
@@ -4,6 +4,8 @@ A generator iterator wrapper involved in a cycle should not leak
 <?php
 
 class Test {
+    private $gen1;
+    private $gen2;
     public function method() {
         $this->gen1 = (function () {
             yield 1;

--- a/Zend/tests/get_mangled_object_vars.phpt
+++ b/Zend/tests/get_mangled_object_vars.phpt
@@ -3,6 +3,7 @@ get_mangled_object_vars() function
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class A {
     public $pub = 1;
     protected $prot = 2;
@@ -19,6 +20,7 @@ $obj->{"6"} = 6;
 var_export(get_mangled_object_vars($obj));
 echo "\n";
 
+#[AllowDynamicProperties]
 class AO extends ArrayObject {
     private $priv = 1;
 }

--- a/Zend/tests/nowdoc.inc
+++ b/Zend/tests/nowdoc.inc
@@ -4,7 +4,7 @@
 $a = 1;
 $b = 2;
 $c = array( 'c' => 3, );
-class d { public function __construct() { $this->d = 4; } };
+class d { public $d = 4; };
 $d = new d;
 
 ?>

--- a/Zend/tests/temporary_cleaning_013.phpt
+++ b/Zend/tests/temporary_cleaning_013.phpt
@@ -77,6 +77,7 @@ try {
 
 try {
     var_dump((function() { return new class {
+        public $foo;
         function __construct() { $this->foo = new stdClass; }
         function __destruct() { throw new Exception; }
     }; })()->foo++);
@@ -92,6 +93,7 @@ try {
 
 try {
     var_dump((function() { return new class {
+        public $bar;
         function __construct() { $this->bar = new stdClass; }
         function &__get($x) { return $this->bar; }
         function __destruct() { throw new Exception; }
@@ -115,6 +117,7 @@ try {
 
 try {
     var_dump(++(function() { return new class {
+        public $bar;
         function __construct() { $this->bar = new stdClass; }
         function &__get($x) { return $this->bar; }
         function __destruct() { throw new Exception; }
@@ -143,6 +146,7 @@ try {
 
 try {
     var_dump((new class {
+        public $foo;
         function __construct() { $this->foo = new stdClass; }
         function __destruct() { throw new Exception; }
     })->foo);
@@ -168,6 +172,7 @@ try {
 
 try {
     var_dump(isset((new class {
+        public $foo;
         function __construct() { $this->foo = new stdClass; }
         function __destruct() { throw new Exception; }
     })->foo->bar));
@@ -278,14 +283,22 @@ caught Exception 2
 caught Exception 3
 caught Exception 4
 caught Exception 5
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 6
 caught Exception 7
 caught Exception 8
 caught Exception 9
 caught Exception 10
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 11
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 12
 caught Exception 13
+
+Deprecated: Creation of dynamic property class@anonymous::$foo is deprecated in %s on line %d
 caught Exception 14
 
 Notice: Indirect modification of overloaded element of ArrayAccess@anonymous has no effect in %s on line %d

--- a/Zend/tests/throwing_overloaded_compound_assign_op.phpt
+++ b/Zend/tests/throwing_overloaded_compound_assign_op.phpt
@@ -3,6 +3,7 @@ Exception in compound assign op should prevent call to overloaded object handler
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class Test {
     public function __get($k) {
         $this->$k = 42;

--- a/Zend/tests/type_declarations/typed_properties_086.phpt
+++ b/Zend/tests/type_declarations/typed_properties_086.phpt
@@ -3,6 +3,7 @@ Test typed properties with integer keys
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class T {
     // Class must have at least one property. Property must have a type.
     // Empty class or untyped property removes segfault

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -25,6 +25,7 @@
 
 ZEND_API zend_class_entry *zend_ce_attribute;
 ZEND_API zend_class_entry *zend_ce_return_type_will_change_attribute;
+ZEND_API zend_class_entry *zend_ce_allow_dynamic_properties;
 
 static HashTable internal_attributes;
 
@@ -56,6 +57,12 @@ void validate_attribute(zend_attribute *attr, uint32_t target, zend_class_entry 
 	}
 }
 
+static void validate_allow_dynamic_properties(
+		zend_attribute *attr, uint32_t target, zend_class_entry *scope)
+{
+	scope->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+}
+
 ZEND_METHOD(Attribute, __construct)
 {
 	zend_long flags = ZEND_ATTRIBUTE_TARGET_ALL;
@@ -69,6 +76,11 @@ ZEND_METHOD(Attribute, __construct)
 }
 
 ZEND_METHOD(ReturnTypeWillChange, __construct)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+}
+
+ZEND_METHOD(AllowDynamicProperties, __construct)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 }
@@ -288,6 +300,10 @@ void zend_register_attribute_ce(void)
 
 	zend_ce_return_type_will_change_attribute = register_class_ReturnTypeWillChange();
 	zend_internal_attribute_register(zend_ce_return_type_will_change_attribute, ZEND_ATTRIBUTE_TARGET_METHOD);
+
+	zend_ce_allow_dynamic_properties = register_class_AllowDynamicProperties();
+	attr = zend_internal_attribute_register(zend_ce_allow_dynamic_properties, ZEND_ATTRIBUTE_TARGET_CLASS);
+	attr->validator = validate_allow_dynamic_properties;
 }
 
 void zend_attributes_shutdown(void)

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -60,6 +60,12 @@ void validate_attribute(zend_attribute *attr, uint32_t target, zend_class_entry 
 static void validate_allow_dynamic_properties(
 		zend_attribute *attr, uint32_t target, zend_class_entry *scope)
 {
+	if (scope->ce_flags & ZEND_ACC_TRAIT) {
+		zend_error_noreturn(E_ERROR, "Cannot apply #[AllowDynamicProperties] to trait");
+	}
+	if (scope->ce_flags & ZEND_ACC_INTERFACE) {
+		zend_error_noreturn(E_ERROR, "Cannot apply #[AllowDynamicProperties] to interface");
+	}
 	scope->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
 }
 

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -40,6 +40,7 @@
 BEGIN_EXTERN_C()
 
 extern ZEND_API zend_class_entry *zend_ce_attribute;
+extern ZEND_API zend_class_entry *zend_ce_allow_dynamic_properties;
 
 typedef struct {
 	zend_string *name;

--- a/Zend/zend_attributes.stub.php
+++ b/Zend/zend_attributes.stub.php
@@ -13,3 +13,8 @@ final class ReturnTypeWillChange
 {
     public function __construct() {}
 }
+
+final class AllowDynamicProperties
+{
+    public function __construct() {}
+}

--- a/Zend/zend_attributes_arginfo.h
+++ b/Zend/zend_attributes_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3fd949e1b9f49666bed3081ed1e8e711acd9f49c */
+ * Stub hash: 024e849a9dfa8789f13dd1d2ac222a48e4b017f1 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Attribute___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "Attribute::TARGET_ALL")
@@ -8,9 +8,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ReturnTypeWillChange___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_AllowDynamicProperties___construct arginfo_class_ReturnTypeWillChange___construct
+
 
 ZEND_METHOD(Attribute, __construct);
 ZEND_METHOD(ReturnTypeWillChange, __construct);
+ZEND_METHOD(AllowDynamicProperties, __construct);
 
 
 static const zend_function_entry class_Attribute_methods[] = {
@@ -21,6 +24,12 @@ static const zend_function_entry class_Attribute_methods[] = {
 
 static const zend_function_entry class_ReturnTypeWillChange_methods[] = {
 	ZEND_ME(ReturnTypeWillChange, __construct, arginfo_class_ReturnTypeWillChange___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_AllowDynamicProperties_methods[] = {
+	ZEND_ME(AllowDynamicProperties, __construct, arginfo_class_AllowDynamicProperties___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -46,6 +55,17 @@ static zend_class_entry *register_class_ReturnTypeWillChange(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_CLASS_ENTRY(ce, "ReturnTypeWillChange", class_ReturnTypeWillChange_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_AllowDynamicProperties(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "AllowDynamicProperties", class_AllowDynamicProperties_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -19,6 +19,7 @@
 
 #include "zend.h"
 #include "zend_API.h"
+#include "zend_attributes.h"
 #include "zend_gc.h"
 #include "zend_builtin_functions.h"
 #include "zend_constants.h"
@@ -33,9 +34,11 @@
 /* }}} */
 
 ZEND_MINIT_FUNCTION(core) { /* {{{ */
-	zend_standard_class_def = register_class_stdClass();
-
 	zend_register_default_classes();
+
+	zend_standard_class_def = register_class_stdClass();
+	zend_add_class_attribute(zend_standard_class_def, zend_ce_allow_dynamic_properties->name, 0);
+	zend_standard_class_def->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
 
 	return SUCCESS;
 }

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -240,7 +240,7 @@ typedef struct _zend_oparray_context {
 /* or IS_CONSTANT_VISITED_MARK                            |     |     |     */
 #define ZEND_CLASS_CONST_IS_CASE         (1 << 6)  /*     |     |     |  X  */
 /*                                                        |     |     |     */
-/* Class Flags (unused: 15,16,21,30,31)                   |     |     |     */
+/* Class Flags (unused: 16,21,30,31)                      |     |     |     */
 /* ===========                                            |     |     |     */
 /*                                                        |     |     |     */
 /* Special class types                                    |     |     |     */
@@ -268,6 +268,10 @@ typedef struct _zend_oparray_context {
 /*                                                        |     |     |     */
 /* User class has methods with static variables           |     |     |     */
 #define ZEND_HAS_STATIC_IN_METHODS       (1 << 14) /*  X  |     |     |     */
+/*                                                        |     |     |     */
+/* Objects of this class may have dynamic properties      |     |     |     */
+/* without triggering a deprecation warning               |     |     |     */
+#define ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES (1 << 15) /* X  |     |     |     */
 /*                                                        |     |     |     */
 /* Parent class is resolved (CE).                         |     |     |     */
 #define ZEND_ACC_RESOLVED_PARENT         (1 << 17) /*  X  |     |     |     */

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1588,7 +1588,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 			ce->ce_flags |= ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 		}
 	}
-	ce->ce_flags |= parent_ce->ce_flags & (ZEND_HAS_STATIC_IN_METHODS | ZEND_ACC_HAS_TYPE_HINTS | ZEND_ACC_USE_GUARDS | ZEND_ACC_NOT_SERIALIZABLE);
+	ce->ce_flags |= parent_ce->ce_flags & (ZEND_HAS_STATIC_IN_METHODS | ZEND_ACC_HAS_TYPE_HINTS | ZEND_ACC_USE_GUARDS | ZEND_ACC_NOT_SERIALIZABLE | ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES);
 }
 /* }}} */
 

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -277,6 +277,12 @@ static ZEND_COLD zend_never_inline void zend_forbidden_dynamic_property(
 		ZSTR_VAL(ce->name), ZSTR_VAL(member));
 }
 
+static ZEND_COLD zend_never_inline void zend_deprecated_dynamic_property(
+		zend_class_entry *ce, zend_string *member) {
+	zend_error(E_DEPRECATED, "Creation of dynamic property %s::$%s is deprecated",
+		ZSTR_VAL(ce->name), ZSTR_VAL(member));
+}
+
 static ZEND_COLD zend_never_inline void zend_readonly_property_modification_scope_error(
 		zend_class_entry *ce, zend_string *member, zend_class_entry *scope, const char *operation) {
 	zend_throw_error(NULL, "Cannot %s readonly property %s::$%s from %s%s",
@@ -874,6 +880,9 @@ write_std_property:
 				variable_ptr = &EG(error_zval);
 				goto exit;
 			}
+			if (EXPECTED(!(zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
+				zend_deprecated_dynamic_property(zobj->ce, name);
+			}
 
 			Z_TRY_ADDREF_P(value);
 			if (!zobj->properties) {
@@ -1049,6 +1058,9 @@ ZEND_API zval *zend_std_get_property_ptr_ptr(zend_object *zobj, zend_string *nam
 			if (UNEXPECTED(zobj->ce->ce_flags & ZEND_ACC_NO_DYNAMIC_PROPERTIES)) {
 				zend_forbidden_dynamic_property(zobj->ce, name);
 				return &EG(error_zval);
+			}
+			if (EXPECTED(!(zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
+				zend_deprecated_dynamic_property(zobj->ce, name);
 			}
 			if (UNEXPECTED(!zobj->properties)) {
 				rebuild_object_properties(zobj);

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -880,7 +880,7 @@ write_std_property:
 				variable_ptr = &EG(error_zval);
 				goto exit;
 			}
-			if (EXPECTED(!(zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
+			if (UNEXPECTED(!(zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
 				zend_deprecated_dynamic_property(zobj->ce, name);
 			}
 
@@ -1059,7 +1059,7 @@ ZEND_API zval *zend_std_get_property_ptr_ptr(zend_object *zobj, zend_string *nam
 				zend_forbidden_dynamic_property(zobj->ce, name);
 				return &EG(error_zval);
 			}
-			if (EXPECTED(!(zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
+			if (UNEXPECTED(!(zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES))) {
 				zend_deprecated_dynamic_property(zobj->ce, name);
 			}
 			if (UNEXPECTED(!zobj->properties)) {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2422,7 +2422,7 @@ ZEND_VM_C_LABEL(fast_assign_obj):
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -22924,7 +22924,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -23055,7 +23055,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -23186,7 +23186,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -23317,7 +23317,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -25482,7 +25482,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -25613,7 +25613,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -25744,7 +25744,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -25875,7 +25875,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -29407,7 +29407,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -29538,7 +29538,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -29669,7 +29669,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -29800,7 +29800,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -31862,7 +31862,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -31993,7 +31993,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -32124,7 +32124,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -32255,7 +32255,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -33724,7 +33724,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -33855,7 +33855,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -33986,7 +33986,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -34117,7 +34117,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -36203,7 +36203,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -36334,7 +36334,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -36465,7 +36465,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -36596,7 +36596,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -40346,7 +40346,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -40477,7 +40477,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -40608,7 +40608,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -40739,7 +40739,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -43986,7 +43986,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -44117,7 +44117,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -44248,7 +44248,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -44379,7 +44379,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -49028,7 +49028,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -49159,7 +49159,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -49290,7 +49290,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}
@@ -49421,7 +49421,7 @@ fast_assign_obj:
 					}
 				}
 
-				if (!zobj->ce->__set) {
+				if (!zobj->ce->__set && (zobj->ce->ce_flags & ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES)) {
 					if (EXPECTED(zobj->properties == NULL)) {
 						rebuild_object_properties(zobj);
 					}

--- a/ext/date/tests/DateTimeZone_clone_basic3.phpt
+++ b/ext/date/tests/DateTimeZone_clone_basic3.phpt
@@ -37,6 +37,10 @@ object(DateTimeZone)#%d (2) {
 }
 
 -- Add some properties --
+
+Deprecated: Creation of dynamic property DateTimeZone::$property1 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property DateTimeZone::$property2 is deprecated in %s on line %d
 object(DateTimeZone)#%d (4) {
   ["property1"]=>
   int(99)
@@ -61,6 +65,10 @@ object(DateTimeZone)#%d (4) {
 }
 
 -- Add some more properties --
+
+Deprecated: Creation of dynamic property DateTimeZone::$property3 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property DateTimeZone::$property4 is deprecated in %s on line %d
 object(DateTimeZone)#%d (6) {
   ["property1"]=>
   int(99)

--- a/ext/date/tests/DateTime_clone_basic3.phpt
+++ b/ext/date/tests/DateTime_clone_basic3.phpt
@@ -39,6 +39,10 @@ object(DateTime)#%d (3) {
 }
 
 -- Add some properties --
+
+Deprecated: Creation of dynamic property DateTime::$property1 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property DateTime::$property2 is deprecated in %s on line %d
 object(DateTime)#%d (5) {
   ["property1"]=>
   int(99)
@@ -67,6 +71,10 @@ object(DateTime)#%d (5) {
 }
 
 -- Add some more properties --
+
+Deprecated: Creation of dynamic property DateTime::$property3 is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property DateTime::$property4 is deprecated in %s on line %d
 object(DateTime)#%d (7) {
   ["property1"]=>
   int(99)

--- a/ext/date/tests/bug65672.phpt
+++ b/ext/date/tests/bug65672.phpt
@@ -32,7 +32,7 @@ $period->dynamic3[] = "array";
 var_dump($period->dynamic3);
 
 ?>
---EXPECT--
+--EXPECTF--
 string(5) "stuff"
 string(8) "modified"
 array(1) {
@@ -40,11 +40,17 @@ array(1) {
   string(5) "array"
 }
 bool(false)
+
+Deprecated: Creation of dynamic property DatePeriod@anonymous::$dynamic1 is deprecated in %s on line %d
 string(7) "dynamic"
+
+Deprecated: Creation of dynamic property DatePeriod@anonymous::$dynamic2 is deprecated in %s on line %d
 array(1) {
   [0]=>
   string(5) "array"
 }
+
+Deprecated: Creation of dynamic property DatePeriod@anonymous::$dynamic3 is deprecated in %s on line %d
 array(1) {
   [0]=>
   string(5) "array"

--- a/ext/date/tests/call_function_from_method.phpt
+++ b/ext/date/tests/call_function_from_method.phpt
@@ -6,6 +6,8 @@ date.timezone=UTC
 <?php
 
 class Date {
+    public $date;
+
     public function __construct($in) {
         $this->date = date_create($in);
     }

--- a/ext/date/tests/date_interval_prop_dim.phpt
+++ b/ext/date/tests/date_interval_prop_dim.phpt
@@ -12,5 +12,6 @@ while ($i < 1026) {
 }
 ?>
 ==NOCRASH==
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property Z::$prop is deprecated in %s on line %d
 ==NOCRASH==

--- a/ext/dom/tests/domobject_debug_handler.phpt
+++ b/ext/dom/tests/domobject_debug_handler.phpt
@@ -15,6 +15,7 @@ $d->loadXML($xml);
 print_r($d);
 ?>
 --EXPECTF--
+Deprecated: Creation of dynamic property DOMDocument::$dynamicProperty is deprecated in %s on line %d
 DOMDocument Object
 (
     [config] => 

--- a/ext/exif/tests/bug68799.phpt
+++ b/ext/exif/tests/bug68799.phpt
@@ -8,6 +8,7 @@ exif
 * Pollute the heap. Helps trigger bug. Sometimes not needed.
 */
 class A {
+    public $a;
     function __construct() {
         $a = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAa';
         $this->a = $a . $a . $a . $a . $a . $a;

--- a/ext/gmp/tests/serialize.phpt
+++ b/ext/gmp/tests/serialize.phpt
@@ -51,6 +51,8 @@ object(GMP)#%d (1) {
   ["num"]=>
   string(2) "42"
 }
+
+Deprecated: Creation of dynamic property GMP::$foo is deprecated in %s on line %d
 string(56) "O:3:"GMP":2:{i:0;s:1:"d";i:1;a:1:{s:3:"foo";s:3:"bar";}}"
 object(GMP)#%d (2) {
   ["foo"]=>

--- a/ext/json/tests/bug42785.phpt
+++ b/ext/json/tests/bug42785.phpt
@@ -15,8 +15,7 @@ setlocale(LC_ALL, "de_DE", "de", "german", "ge", "de_DE.ISO8859-1", "ISO8859-1")
 $foo = array(100.10,"bar");
 var_dump(json_encode($foo));
 
-class bar {}
-$bar1 = new bar;
+$bar1 = new stdClass;
 $bar1->a = 100.10;
 $bar1->b = "foo";
 var_dump(json_encode($bar1));

--- a/ext/json/tests/json_encode_basic.phpt
+++ b/ext/json/tests/json_encode_basic.phpt
@@ -12,10 +12,7 @@ unset ($unset_var);
 $fp = fopen(__FILE__, "r");
 
 // get an object
-class sample  {
-}
-
-$obj = new sample();
+$obj = new stdClass();
 $obj->MyInt = 99;
 $obj->MyFloat = 123.45;
 $obj->MyBool = true;

--- a/ext/json/tests/json_encode_pretty_print2.phpt
+++ b/ext/json/tests/json_encode_pretty_print2.phpt
@@ -2,6 +2,7 @@
 json_encode() with JSON_PRETTY_PRINT on declared properties
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class MyClass {
     public $x;
     public $y;

--- a/ext/libxml/tests/bug61367-read.phpt
+++ b/ext/libxml/tests/bug61367-read.phpt
@@ -14,6 +14,7 @@ open_basedir=.
  * Note: Using error_reporting=E_ALL & ~E_NOTICE to suppress "Trying to get property of non-object" notices.
  */
 class StreamExploiter {
+    public $context;
     public function stream_close (  ) {
         $doc = new DOMDocument;
         $doc->resolveExternals = true;

--- a/ext/libxml/tests/bug61367-read_2.phpt
+++ b/ext/libxml/tests/bug61367-read_2.phpt
@@ -14,6 +14,8 @@ open_basedir=.
  * Note: Using error_reporting=E_ALL & ~E_NOTICE to suppress "Trying to get property of non-object" notices.
  */
 class StreamExploiter {
+    public $context;
+
     public function stream_close (  ) {
         $doc = new DOMDocument;
         $doc->resolveExternals = true;

--- a/ext/libxml/tests/bug61367-write.phpt
+++ b/ext/libxml/tests/bug61367-write.phpt
@@ -8,6 +8,8 @@ open_basedir=.
 <?php
 
 class StreamExploiter {
+    public $context;
+
     public function stream_close (  ) {
         $doc = new DOMDocument;
         $doc->appendChild($doc->createTextNode('hello'));

--- a/ext/mysqli/tests/bug46614.phpt
+++ b/ext/mysqli/tests/bug46614.phpt
@@ -13,6 +13,7 @@ if (!defined("MYSQLI_ASYNC")) {
 <?php
 class MySQL_Ext extends mysqli{
     protected $fooData = array();
+    private $extData;
 
     public function isEmpty()
     {

--- a/ext/mysqli/tests/mysqli_fetch_object.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object.phpt
@@ -24,7 +24,8 @@ require_once('skipifconnectfailure.inc');
     }
 
     class mysqli_fetch_object_test {
-
+        public $ID;
+        public $label;
         public $a = null;
         public $b = null;
 

--- a/ext/mysqli/tests/mysqli_fetch_object_no_constructor.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object_no_constructor.phpt
@@ -19,7 +19,8 @@ require_once('skipifconnectfailure.inc');
     }
 
     class mysqli_fetch_object_test {
-
+        public $ID;
+        public $label;
         public $a = null;
         public $b = null;
 
@@ -51,6 +52,10 @@ require_once('skipifconnectfailure.inc');
 --EXPECTF--
 No exception with PHP:
 object(mysqli_fetch_object_test)#%d (%d) {
+  ["ID"]=>
+  NULL
+  ["label"]=>
+  NULL
   ["a"]=>
   NULL
   ["b"]=>

--- a/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_object_oo.phpt
@@ -49,7 +49,8 @@ require_once('skipifconnectfailure.inc');
     }
 
     class mysqli_fetch_object_test {
-
+        public $ID;
+        public $label;
         public $a = null;
         public $b = null;
 

--- a/ext/opcache/tests/jit/fetch_obj_003.phpt
+++ b/ext/opcache/tests/jit/fetch_obj_003.phpt
@@ -9,6 +9,7 @@ opcache.jit_buffer_size=1M
 opcache
 --FILE--
 <?php
+#[ALlowDynamicProperties]
 class C {
     var $a = 0;
 }

--- a/ext/opcache/tests/jit/fetch_obj_004.phpt
+++ b/ext/opcache/tests/jit/fetch_obj_004.phpt
@@ -9,6 +9,7 @@ opcache.jit_buffer_size=1M
 opcache
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class C {
     var $a = 0;
 }

--- a/ext/opcache/tests/jit/inc_obj_002.phpt
+++ b/ext/opcache/tests/jit/inc_obj_002.phpt
@@ -8,6 +8,7 @@ opcache.jit_buffer_size=1M
 opcache.protect_memory=1
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class Test {
     function foo() {
         $this->prop = PHP_INT_MAX - 5;

--- a/ext/opcache/tests/opt/dce_005.phpt
+++ b/ext/opcache/tests/opt/dce_005.phpt
@@ -10,6 +10,7 @@ opcache.preload=
 opcache
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class A {
 }
 function foo(int $x) {
@@ -21,12 +22,12 @@ function foo(int $x) {
 $_main:
      ; (lines=1, args=0, vars=0, tmps=0)
      ; (after optimizer)
-     ; %sdce_005.php:1-9
+     ; %s
 0000 RETURN int(1)
 
 foo:
      ; (lines=2, args=1, vars=1, tmps=0)
      ; (after optimizer)
-     ; %sdce_005.php:4-7
+     ; %s
 0000 CV0($x) = RECV 1
 0001 RETURN null

--- a/ext/pdo/tests/pdo_005.phpt
+++ b/ext/pdo/tests/pdo_005.phpt
@@ -29,6 +29,7 @@ class TestBase
     private $val2;
 }
 
+#[AllowDynamicProperties] // $val2 will be dynamic now.
 class TestDerived extends TestBase
 {
     protected $row;

--- a/ext/pdo/tests/pdo_009.phpt
+++ b/ext/pdo/tests/pdo_009.phpt
@@ -29,6 +29,9 @@ $stmt = $db->prepare('SELECT classtypes.name, test.id AS id, test.val AS val FRO
 
 class Test1
 {
+    public $id;
+    public $val;
+
     public function __construct()
     {
         echo __METHOD__ . "()\n";
@@ -37,6 +40,9 @@ class Test1
 
 class Test2
 {
+    public $id;
+    public $val;
+
     public function __construct()
     {
         echo __METHOD__ . "()\n";
@@ -45,6 +51,9 @@ class Test2
 
 class Test3
 {
+    public $id;
+    public $val;
+
     public function __construct()
     {
         echo __METHOD__ . "()\n";

--- a/ext/pdo/tests/pdo_010.phpt
+++ b/ext/pdo/tests/pdo_010.phpt
@@ -29,6 +29,9 @@ $stmt = $db->prepare('SELECT classtypes.name, test.grp AS grp, test.id AS id, te
 
 class Test1
 {
+    public $id;
+    public $val;
+
     public function __construct()
     {
         echo __METHOD__ . "()\n";
@@ -37,6 +40,9 @@ class Test1
 
 class Test2
 {
+    public $id;
+    public $val;
+
     public function __construct()
     {
         echo __METHOD__ . "()\n";
@@ -45,6 +51,9 @@ class Test2
 
 class Test3
 {
+    public $id;
+    public $val;
+
     public function __construct()
     {
         echo __METHOD__ . "()\n";

--- a/ext/pdo/tests/pdo_011.phpt
+++ b/ext/pdo/tests/pdo_011.phpt
@@ -23,9 +23,8 @@ $db->exec('INSERT INTO test VALUES(4, \'D\', \'Group2\')');
 
 class DerivedStatement extends PDOStatement
 {
-    private function __construct($name, $db)
+    private function __construct(public $name, $db)
     {
-        $this->name = $name;
         echo __METHOD__ . "($name)\n";
     }
 
@@ -41,11 +40,9 @@ $derived = $db->prepare('SELECT id, val FROM test', array(PDO::ATTR_STATEMENT_CL
 
 class Test1
 {
-    public function __construct($id, $val)
+    public function __construct(public $id, public $val)
     {
         echo __METHOD__ . "($id,$val)\n";
-        $this->id = $id;
-        $this->val = $val;
     }
 
     static public function factory($id, $val)

--- a/ext/pdo/tests/pdo_012.phpt
+++ b/ext/pdo/tests/pdo_012.phpt
@@ -26,6 +26,9 @@ var_dump($stmt->fetchAll());
 
 class Test
 {
+    public $val;
+    public $grp;
+
     function __construct($name = 'N/A')
     {
         echo __METHOD__ . "($name)\n";

--- a/ext/pdo/tests/pdo_013.phpt
+++ b/ext/pdo/tests/pdo_013.phpt
@@ -32,6 +32,9 @@ foreach ($stmt as $data)
 
 class Test
 {
+    public $val;
+    public $grp;
+
     function __construct($name = 'N/A')
     {
         echo __METHOD__ . "($name)\n";

--- a/ext/pdo/tests/pdo_014.phpt
+++ b/ext/pdo/tests/pdo_014.phpt
@@ -22,6 +22,9 @@ $SELECT = 'SELECT val, grp FROM test';
 
 class Test
 {
+    public $val;
+    public $grp;
+
     function __construct($name = 'N/A')
     {
         echo __METHOD__ . "($name)\n";

--- a/ext/pdo/tests/pdo_023.phpt
+++ b/ext/pdo/tests/pdo_023.phpt
@@ -14,6 +14,7 @@ PDOTest::skip();
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 
+#[AllowDynamicProperties]
 class PDOStatementX extends PDOStatement
 {
     public $test1 = 1;
@@ -31,6 +32,7 @@ class PDOStatementX extends PDOStatement
     }
 }
 
+#[AllowDynamicProperties]
 class PDODatabaseX extends PDO
 {
     public $test1 = 1;

--- a/ext/pdo_mysql/tests/bug46292.phpt
+++ b/ext/pdo_mysql/tests/bug46292.phpt
@@ -15,6 +15,8 @@ MySQLPDOTest::skip();
 
 
     class myclass {
+        public $value;
+
         public function __construct() {
             printf("%s()\n", __METHOD__);
         }

--- a/ext/pdo_mysql/tests/bug63176.phpt
+++ b/ext/pdo_mysql/tests/bug63176.phpt
@@ -20,6 +20,7 @@ class PDO3 extends PDO {
 
 
 class ModelA {
+    public $db;
     public function __construct($h) {
         var_dump($h);
         if ($h) {

--- a/ext/pdo_mysql/tests/bug70862.phpt
+++ b/ext/pdo_mysql/tests/bug70862.phpt
@@ -19,6 +19,7 @@ MySQLPDOTest::skip();
     $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
     class HelloWrapper {
+        public $context;
         public function stream_open() { return true; }
         public function stream_eof() { return true; }
         public function stream_read() { return NULL; }

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize.phpt
@@ -14,6 +14,7 @@ MySQLPDOTest::skip();
 
     try {
 
+        #[AllowDynamicProperties]
         class myclass implements Serializable {
 
             private static $instance = null;

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetchobject.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetchobject.phpt
@@ -30,6 +30,7 @@ try {
     $query = "SELECT id, '', NULL, \"\" FROM test ORDER BY id ASC LIMIT 3";
     $stmt = $db->prepare($query);
 
+    #[AllowDynamicProperties]
     class myclass {
 
         private $set_calls = 0;

--- a/ext/pdo_pgsql/tests/bug72294.phpt
+++ b/ext/pdo_pgsql/tests/bug72294.phpt
@@ -70,6 +70,8 @@ class PHPUnit_Framework_TestFailure
 
 class PHPUnit_Framework_TestResult
 {
+    private $errors;
+
     public function run( $test)
     {
         $error      = false;

--- a/ext/pdo_sqlite/tests/bug46139.phpt
+++ b/ext/pdo_sqlite/tests/bug46139.phpt
@@ -8,6 +8,7 @@ pdo_sqlite
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 
+#[AllowDynamicProperties]
 class Person {
     public $test = NULL;
     public function __construct() {

--- a/ext/pdo_sqlite/tests/bug70862.phpt
+++ b/ext/pdo_sqlite/tests/bug70862.phpt
@@ -14,6 +14,7 @@ $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
 class HelloWrapper {
+    public $context;
     public function stream_open() { return true; }
     public function stream_eof() { return true; }
     public function stream_read() { return NULL; }

--- a/ext/reflection/tests/002.phpt
+++ b/ext/reflection/tests/002.phpt
@@ -3,6 +3,7 @@ Reflection properties are read only
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class ReflectionMethodEx extends ReflectionMethod
 {
     public $foo = "xyz";

--- a/ext/reflection/tests/024.phpt
+++ b/ext/reflection/tests/024.phpt
@@ -2,6 +2,7 @@
 ReflectionObject::__toString (filtering privates/protected dynamic properties)
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class C1 {
     private   $p1 = 1;
     protected $p2 = 2;
@@ -17,7 +18,7 @@ echo $obj;
 ?>
 --EXPECTF--
 Object of class [ <user> class C1 ] {
-  @@ %s024.php 2-6
+  @@ %s
 
   - Constants [0] {
   }

--- a/ext/reflection/tests/ReflectionClass_getInterfaces_003.phpt
+++ b/ext/reflection/tests/ReflectionClass_getInterfaces_003.phpt
@@ -58,6 +58,8 @@ array(1) {
   }
 }
 Modify the object, and it is apparently no longer referenced.
+
+Deprecated: Creation of dynamic property ReflectionClass::$x is deprecated in %s on line %d
 array(1) {
   ["I"]=>
   object(ReflectionClass)#%d (2) {

--- a/ext/reflection/tests/ReflectionObject___toString_basic2.phpt
+++ b/ext/reflection/tests/ReflectionObject___toString_basic2.phpt
@@ -3,6 +3,7 @@ ReflectionObject::__toString() : very basic test with dynamic properties
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class Foo  {
     public $bar = 1;
 }
@@ -14,7 +15,7 @@ echo new ReflectionObject($f);
 ?>
 --EXPECTF--
 Object of class [ <user> class Foo ] {
-  @@ %s 3-5
+  @@ %s
 
   - Constants [0] {
   }

--- a/ext/reflection/tests/ReflectionObject_export_basic3.phpt
+++ b/ext/reflection/tests/ReflectionObject_export_basic3.phpt
@@ -6,6 +6,7 @@ class C {
     private $p = 1;
 }
 
+#[AllowDynamicProperties]
 class D extends C{
 }
 
@@ -15,7 +16,7 @@ echo new ReflectionObject($Obj);
 ?>
 --EXPECTF--
 Object of class [ <user> class D extends C ] {
-  @@ %s 6-7
+  @@ %s
 
   - Constants [0] {
   }

--- a/ext/reflection/tests/ReflectionParameter_isDefault.phpt
+++ b/ext/reflection/tests/ReflectionParameter_isDefault.phpt
@@ -2,6 +2,7 @@
 ReflectionParameter::isDefault()
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class A {
 public $defprop;
 }

--- a/ext/reflection/tests/ReflectionProperty_getDefaultValue.phpt
+++ b/ext/reflection/tests/ReflectionProperty_getDefaultValue.phpt
@@ -5,6 +5,7 @@ reflection: ReflectionProperty::getDefaultValue
 
 define('FOO', 42);
 
+#[AllowDynamicProperties]
 class TestClass
 {
     public $foo;

--- a/ext/reflection/tests/ReflectionProperty_hasDefaultValue.phpt
+++ b/ext/reflection/tests/ReflectionProperty_hasDefaultValue.phpt
@@ -3,6 +3,7 @@ reflection: ReflectionProperty::hasDefaultValue
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class TestClass
 {
     public $foo;

--- a/ext/reflection/tests/ReflectionProperty_isInitialized.phpt
+++ b/ext/reflection/tests/ReflectionProperty_isInitialized.phpt
@@ -3,6 +3,7 @@ Test ReflectionProperty::isInitialized()
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class A {
     public static ?string $ssv = null;
     public static ?string $ss;

--- a/ext/reflection/tests/ReflectionProperty_setValue_error.phpt
+++ b/ext/reflection/tests/ReflectionProperty_setValue_error.phpt
@@ -11,6 +11,7 @@ class TestClass {
     private $priv = "keepOut";
 }
 
+#[AllowDynamicProperties]
 class AnotherClass {
 }
 

--- a/ext/reflection/tests/bug40431.phpt
+++ b/ext/reflection/tests/bug40431.phpt
@@ -21,6 +21,7 @@ echo "=== 2nd test ===\n";
 class test1 {
 }
 
+#[AllowDynamicProperties]
 class test2 extends test1{
 }
 
@@ -38,6 +39,7 @@ var_dump($props[0]->isProtected());
 
 echo "=== 3rd test ===\n";
 
+#[AllowDynamicProperties]
 class test3 {
 }
 
@@ -59,6 +61,7 @@ class test5 {
     private $value = 1;
 }
 
+#[AllowDynamicProperties]
 class test4 extends test5{
 }
 

--- a/ext/reflection/tests/bug46064.phpt
+++ b/ext/reflection/tests/bug46064.phpt
@@ -3,6 +3,7 @@ Bug #46064 (Exception when creating ReflectionProperty object on dynamicly creat
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class x {
     public $zzz = 2;
 }
@@ -32,6 +33,7 @@ class test {
     protected $a = 1;
 }
 
+#[AllowDynamicProperties]
 class bar extends test {
     public function __construct() {
         $this->foobar = 2;

--- a/ext/reflection/tests/bug46064_2.phpt
+++ b/ext/reflection/tests/bug46064_2.phpt
@@ -3,6 +3,7 @@ Bug #46064.2 (Exception when creating ReflectionProperty object on dynamicly cre
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class foo {
 }
 
@@ -14,6 +15,7 @@ $p = new ReflectionObject($x);
 var_dump($p->getProperty('test'));
 
 
+#[AllowDynamicProperties]
 class bar {
     public function __construct() {
         $this->a = 1;

--- a/ext/reflection/tests/bug53366.phpt
+++ b/ext/reflection/tests/bug53366.phpt
@@ -3,6 +3,7 @@ Bug #53366 (Reflection doesn't get dynamic property value from getProperty())
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class UserClass {
 }
 

--- a/ext/reflection/tests/bug79820.phpt
+++ b/ext/reflection/tests/bug79820.phpt
@@ -3,6 +3,7 @@ Bug #79820: Use after free when type duplicated into ReflectionProperty gets res
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class Test {
     public stdClass $prop;
 }

--- a/ext/reflection/tests/bug80370.phpt
+++ b/ext/reflection/tests/bug80370.phpt
@@ -2,6 +2,7 @@
 Bug #80370: Segfault on ReflectionProperty::getAttributes of dynamic property
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class Foobar {
 
 }

--- a/ext/reflection/tests/property_exists.phpt
+++ b/ext/reflection/tests/property_exists.phpt
@@ -3,6 +3,7 @@ Reflection and property_exists()
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class A
 {
     public    $a = 1;

--- a/ext/session/tests/001.phpt
+++ b/ext/session/tests/001.phpt
@@ -13,6 +13,7 @@ session.save_handler=files
 <?php
 error_reporting(E_ALL);
 
+#[AllowDynamicProperties]
 class foo {
     public $bar = "ok";
 

--- a/ext/snmp/tests/snmp-object-properties.phpt
+++ b/ext/snmp/tests/snmp-object-properties.phpt
@@ -158,6 +158,8 @@ object(SNMP)#%d (%d) {
 bool(true)
 bool(true)
 bool(false)
+
+Deprecated: Creation of dynamic property SNMP::$123 is deprecated in %s on line %d
 object(SNMP)#%d (%d) {
   ["info"]=>
   array(3) {

--- a/ext/soap/tests/bugs/bug39815.phpt
+++ b/ext/soap/tests/bugs/bug39815.phpt
@@ -4,8 +4,7 @@ Bug #39815 (to_zval_double() in ext/soap/php_encoding.c is not locale-independen
 soap
 --SKIPIF--
 <?php
-if (!@setlocale(LC_ALL, 'sv_SE', 'sv_SE.ISO8859-1')) die('skip sv_SE locale not available');
-if (!@setlocale(LC_ALL, 'en_US', 'en_US.ISO8859-1')) die('skip en_US locale not available');
+if (!@setlocale(LC_ALL, 'de_DE', 'de_DE.ISO8859-1')) die('skip de_DE locale not available');
 ?>
 --INI--
 precision=14
@@ -16,6 +15,7 @@ function test(){
   return 123.456;
 }
 class LocalSoapClient extends SoapClient {
+  private $server;
 
   function __construct($wsdl, $options) {
     parent::__construct($wsdl, $options);
@@ -35,10 +35,10 @@ class LocalSoapClient extends SoapClient {
 $x = new LocalSoapClient(NULL,array('location'=>'test://',
                                    'uri'=>'http://testuri.org',
                                    "trace"=>1));
-setlocale(LC_ALL,"sv_SE","sv_SE.ISO8859-1");
+setlocale(LC_ALL,"de_DE","de_DE.ISO8859-1");
 var_dump($x->test());
 echo $x->__getLastResponse();
-setlocale(LC_ALL,"en_US","en_US.ISO8859-1");
+setlocale(LC_ALL, "C");
 var_dump($x->test());
 echo $x->__getLastResponse();
 ?>

--- a/ext/spl/tests/ArrayObject_sort_different_backing_storage.phpt
+++ b/ext/spl/tests/ArrayObject_sort_different_backing_storage.phpt
@@ -28,7 +28,7 @@ $ao5->uasort(function($a, $b) { return $a <=> $b; });
 var_dump($ao5);
 
 ?>
---EXPECT--
+--EXPECTF--
 object(ArrayObject)#2 (1) {
   ["storage":"ArrayObject":private]=>
   object(stdClass)#1 (2) {
@@ -50,6 +50,10 @@ object(ArrayObject)#3 (1) {
     }
   }
 }
+
+Deprecated: Creation of dynamic property ArrayObject::$a is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayObject::$b is deprecated in %s on line %d
 object(ArrayObject)#4 (2) {
   ["b"]=>
   int(1)

--- a/ext/spl/tests/ArrayObject_std_props_no_recursion.phpt
+++ b/ext/spl/tests/ArrayObject_std_props_no_recursion.phpt
@@ -13,7 +13,10 @@ $c->prop = 'c';
 var_dump((array) $c);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
 array(3) {
   [0]=>
   int(1)
@@ -22,6 +25,8 @@ array(3) {
   [2]=>
   int(3)
 }
+
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
 array(1) {
   ["prop"]=>
   string(1) "c"

--- a/ext/spl/tests/SplFileObject_fflush_basic_001.phpt
+++ b/ext/spl/tests/SplFileObject_fflush_basic_001.phpt
@@ -13,8 +13,9 @@ var_dump($obj->fflush());
 */
 //create a basic stream class
 class VariableStream {
-    var $position;
-    var $varname;
+    public $position;
+    public $varname;
+    public $context;
 
     function stream_open($path, $mode, $options, &$opened_path)
     {

--- a/ext/spl/tests/SplFileObject_ftruncate_error_001.phpt
+++ b/ext/spl/tests/SplFileObject_ftruncate_error_001.phpt
@@ -5,8 +5,9 @@ SplFileObject::ftruncate function - truncating with stream that does not support
 
 //create a basic stream class
 class VariableStream {
-    var $position;
-    var $varname;
+    public $position;
+    public $varname;
+    public $context;
 
     function stream_open($path, $mode, $options, &$opened_path)
     {

--- a/ext/spl/tests/arrayObject___construct_basic2.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic2.phpt
@@ -54,6 +54,8 @@ function testAccess($c, $ao) {
 NULL
 string(12) "C::prop.orig"
   - Write:
+
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
 string(8) "changed1"
 string(8) "changed2"
   - Isset:

--- a/ext/spl/tests/arrayObject___construct_basic3.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic3.phpt
@@ -54,6 +54,8 @@ function testAccess($c, $ao) {
 NULL
 string(12) "C::prop.orig"
   - Write:
+
+Deprecated: Creation of dynamic property ArrayObject::$prop is deprecated in %s on line %d
 string(8) "changed1"
 string(8) "changed2"
   - Isset:

--- a/ext/spl/tests/arrayObject___construct_basic6.phpt
+++ b/ext/spl/tests/arrayObject___construct_basic6.phpt
@@ -21,7 +21,8 @@ var_dump($ao);
 $ao = new MyArrayObject(array(1,2,3), ArrayObject::STD_PROP_LIST);
 var_dump($ao);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Creation of dynamic property ArrayObject::$p is deprecated in %s on line %d
 object(ArrayObject)#1 (2) {
   ["p"]=>
   int(1)
@@ -35,6 +36,8 @@ object(ArrayObject)#1 (2) {
     int(3)
   }
 }
+
+Deprecated: Creation of dynamic property ArrayObject::$p is deprecated in %s on line %d
 object(ArrayObject)#2 (2) {
   ["p"]=>
   int(1)

--- a/ext/spl/tests/arrayObject_clone_basic2.phpt
+++ b/ext/spl/tests/arrayObject_clone_basic2.phpt
@@ -2,6 +2,8 @@
 SPL: Cloning an instance of ArrayObject which wraps an object.
 --FILE--
 <?php
+
+#[AllowDynamicProperties]
 class C { }
 
 $c = new C;

--- a/ext/spl/tests/arrayObject_clone_basic3.phpt
+++ b/ext/spl/tests/arrayObject_clone_basic3.phpt
@@ -2,6 +2,8 @@
 SPL: Cloning nested ArrayObjects.
 --FILE--
 <?php
+
+#[AllowDynamicProperties]
 class C {
     public $p = 'C::p.orig';
 }

--- a/ext/spl/tests/arrayObject_exchangeArray_basic3.phpt
+++ b/ext/spl/tests/arrayObject_exchangeArray_basic3.phpt
@@ -3,6 +3,7 @@ SPL: ArrayObject::exchangeArray() basic usage with object as underlying data sto
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class C {
     public $pub1 = 'public1';
 }

--- a/ext/spl/tests/arrayObject_magicMethods2.phpt
+++ b/ext/spl/tests/arrayObject_magicMethods2.phpt
@@ -69,6 +69,10 @@ var_dump($ao);
 ?>
 --EXPECTF--
 --> Write existent, non-existent and dynamic:
+
+Deprecated: Creation of dynamic property ArrayObject::$a is deprecated in %s on line %d
+
+Deprecated: Creation of dynamic property ArrayObject::$dynamic is deprecated in %s on line %d
   Original wrapped object:
 object(UsesMagic)#1 (4) {
   ["a"]=>

--- a/ext/spl/tests/array_003.phpt
+++ b/ext/spl/tests/array_003.phpt
@@ -7,6 +7,7 @@ SPL: ArrayObject from object
 // since they cannot be accessed from the external object which iterates
 // them.
 
+#[AllowDynamicProperties]
 class test
 {
     public    $pub = "public";

--- a/ext/spl/tests/array_007.phpt
+++ b/ext/spl/tests/array_007.phpt
@@ -7,6 +7,7 @@ SPL: ArrayObject/Iterator from IteratorAggregate
 // since they cannot be accessed from the external object which iterates
 // them.
 
+#[AllowDynamicProperties]
 class test implements IteratorAggregate
 {
     public    $pub = "public";

--- a/ext/spl/tests/array_017.phpt
+++ b/ext/spl/tests/array_017.phpt
@@ -3,6 +3,7 @@ SPL: ArrayObject::exchangeArray($this)
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class ArrayIteratorEx extends ArrayIterator
 {
     public    $pub2 = 1;
@@ -31,6 +32,7 @@ class ArrayIteratorEx extends ArrayIterator
     }
 }
 
+#[AllowDynamicProperties]
 class ArrayObjectEx extends ArrayObject
 {
     public    $pub1 = 1;

--- a/ext/spl/tests/bug61326.phpt
+++ b/ext/spl/tests/bug61326.phpt
@@ -12,7 +12,9 @@ var_dump($aobj1 == $aobj3);
 $aobj3->foo = 'bar';
 var_dump($aobj1 == $aobj3);
 ?>
---EXPECT--
+--EXPECTF--
 bool(false)
 bool(true)
+
+Deprecated: Creation of dynamic property ArrayObject::$foo is deprecated in %s on line %d
 bool(false)

--- a/ext/spl/tests/bug65387.phpt
+++ b/ext/spl/tests/bug65387.phpt
@@ -14,6 +14,7 @@ $it2 = new CallbackFilterIterator($it, function($elem) use(&$it2) {
 
 // Callback object
 new class {
+    private $it;
     public function __construct() {
         $it = new ArrayIterator([1, 2, 3]);
         $this->it = new CallbackFilterIterator($it, function($elem) {

--- a/ext/spl/tests/iterator_037.phpt
+++ b/ext/spl/tests/iterator_037.phpt
@@ -27,10 +27,7 @@ function test($ar, $flags)
 
 class MyItem
 {
-    function __construct($value)
-    {
-        $this->value = $value;
-    }
+    function __construct(public $value) {}
 
     function __toString()
     {

--- a/ext/sqlite3/tests/sqlite3_blob_bind_resource.phpt
+++ b/ext/sqlite3/tests/sqlite3_blob_bind_resource.phpt
@@ -13,6 +13,7 @@ $insert_stmt = $db->prepare("INSERT INTO test (id, data) VALUES (1, ?)");
 
 
 class HelloWrapper {
+    public $context;
     public function stream_open() { return true; }
     public function stream_eof() { return true; }
     public function stream_read() { return NULL; }

--- a/ext/sqlite3/tests/stream_test.inc
+++ b/ext/sqlite3/tests/stream_test.inc
@@ -2,6 +2,7 @@
 
 class SQLite3_Test_Stream
 {
+    public $context;
     private $position;
     public static $string_length = 10;
     public static $string = "abcdefg\0hi";

--- a/ext/standard/tests/array/bug39576.phpt
+++ b/ext/standard/tests/array/bug39576.phpt
@@ -4,10 +4,10 @@ Bug #39576 (array_walk() doesn't separate userdata zval)
 <?php
 
 class Test {
-
     public $_table = '';
     public $_columns = array ();
     public $_primary = array ();
+    public $name;
 
 }
 

--- a/ext/standard/tests/file/bug27508.phpt
+++ b/ext/standard/tests/file/bug27508.phpt
@@ -4,6 +4,7 @@ Bug #27508 (userspace wrappers have bogus eof indicator)
 <?php
 class FileStream {
     public $fp;
+    public $context;
 
     function stream_open($path, $mode, $options, &$opened_path)
     {

--- a/ext/standard/tests/file/bug38450.phpt
+++ b/ext/standard/tests/file/bug38450.phpt
@@ -4,6 +4,7 @@ Bug #38450 (constructor is not called for classes used in userspace stream wrapp
 <?php
 
 class VariableStream {
+    var $context;
     var $position;
     var $varname;
 

--- a/ext/standard/tests/file/bug38450_1.phpt
+++ b/ext/standard/tests/file/bug38450_1.phpt
@@ -4,6 +4,7 @@ Bug #38450 (constructor is not called for classes used in userspace stream wrapp
 <?php
 
 class VariableStream {
+    var $context;
     var $position;
     var $varname;
 

--- a/ext/standard/tests/file/bug38450_2.phpt
+++ b/ext/standard/tests/file/bug38450_2.phpt
@@ -4,6 +4,7 @@ Bug #38450 (constructor is not called for classes used in userspace stream wrapp
 <?php
 
 class VariableStream {
+    var $context;
     var $position;
     var $varname;
 

--- a/ext/standard/tests/file/bug38450_3.phpt
+++ b/ext/standard/tests/file/bug38450_3.phpt
@@ -4,6 +4,7 @@ Bug #38450 (constructor is not called for classes used in userspace stream wrapp
 <?php
 
 class VariableStream {
+    var $context;
     var $position;
     var $varname;
 
@@ -102,7 +103,7 @@ var_dump($myvar);
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught ArgumentCountError: Too few arguments to function VariableStream::__construct(), 0 passed and exactly 1 expected in %sbug38450_3.php:7
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function VariableStream::__construct(), 0 passed and exactly 1 expected in %sbug38450_3.php:%d
 Stack trace:
 #0 [internal function]: VariableStream->__construct()
 #1 %s(%d): fopen('var://myvar', 'r+')

--- a/ext/standard/tests/file/bug39551.phpt
+++ b/ext/standard/tests/file/bug39551.phpt
@@ -5,7 +5,7 @@ Bug #39551 (Segfault with stream_bucket_new in user filter)
 
 $bucket = stream_bucket_new(fopen('php://temp', 'w+'), '');
 
-class bucketFilter {
+class bucketFilter extends php_user_filter {
     public function filter($in, $out, &$consumed, $closing ): int {
 
         $bucket = stream_bucket_new(fopen('php://temp', 'w+'), '');

--- a/ext/standard/tests/file/bug71287.phpt
+++ b/ext/standard/tests/file/bug71287.phpt
@@ -3,6 +3,8 @@ Bug #71287 (Error message contains hexadecimal instead of decimal number)
 --FILE--
 <?php
 class Stream {
+    public $context;
+
     public function stream_open($path, $mode, $options, $opened_path) {
         return true;
     }

--- a/ext/standard/tests/file/fopencookie.phpt
+++ b/ext/standard/tests/file/fopencookie.phpt
@@ -17,6 +17,7 @@ fopencookie detected and working (or cast mechanism works)
  */
 
 class userstream {
+    public $context;
     public $position = 0;
     public $data = "If you can read this, it worked";
 

--- a/ext/standard/tests/file/include_streams.phpt
+++ b/ext/standard/tests/file/include_streams.phpt
@@ -10,6 +10,7 @@ EOD;
 
 class mystream
 {
+    public $context;
     public $path;
     public $mode;
     public $options;

--- a/ext/standard/tests/file/include_userstream_002.phpt
+++ b/ext/standard/tests/file/include_userstream_002.phpt
@@ -6,6 +6,7 @@ allow_url_include=0
 --FILE--
 <?php
 class test {
+    public $context;
     private $data = '<?php echo "Hello World\n";?>';
     private $pos;
     private $stream = null;
@@ -98,10 +99,10 @@ include "test2://hello";
 <?php echo "Hello World\n";?>
 <?php echo "Hello World\n";?>
 
-Warning: fopen(): test1:// wrapper is disabled in the server configuration by allow_url_include=0 in %sinclude_userstream_002.php on line 10
+Warning: fopen(): test1:// wrapper is disabled in the server configuration by allow_url_include=0 in %sinclude_userstream_002.php on line 11
 
-Warning: fopen(test1://hello): Failed to open stream: no suitable wrapper could be found in %sinclude_userstream_002.php on line 10
+Warning: fopen(test1://hello): Failed to open stream: no suitable wrapper could be found in %sinclude_userstream_002.php on line 11
 
-Warning: include(test2://hello): Failed to open stream: "test::stream_open" call failed in %sinclude_userstream_002.php on line 89
+Warning: include(test2://hello): Failed to open stream: "test::stream_open" call failed in %sinclude_userstream_002.php on line 90
 
-Warning: include(): Failed opening 'test2://hello' for inclusion (include_path='%s') in %sinclude_userstream_002.php on line 89
+Warning: include(): Failed opening 'test2://hello' for inclusion (include_path='%s') in %sinclude_userstream_002.php on line 90

--- a/ext/standard/tests/file/include_userstream_003.phpt
+++ b/ext/standard/tests/file/include_userstream_003.phpt
@@ -6,6 +6,7 @@ allow_url_include=1
 --FILE--
 <?php
 class test {
+    public $context;
     private $data = '<?php echo "Hello World\n";?>';
     private $pos;
     private $stream = null;
@@ -97,28 +98,28 @@ include "test2://hello";
 --EXPECTF--
 Deprecated: Directive 'allow_url_include' is deprecated in Unknown on line 0
 
-Warning: file_get_contents(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %sinclude_userstream_003.php on line 86
+Warning: file_get_contents(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %s on line %d
 
-Warning: file_get_contents(test1://hello): Failed to open stream: no suitable wrapper could be found in %sinclude_userstream_003.php on line 86
-
-
-Warning: include(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %sinclude_userstream_003.php on line 87
-
-Warning: include(test1://hello): Failed to open stream: no suitable wrapper could be found in %sinclude_userstream_003.php on line 87
-
-Warning: include(): Failed opening 'test1://hello' for inclusion (include_path='%s') in %sinclude_userstream_003.php on line 87
-
-Warning: fopen(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %sinclude_userstream_003.php on line 10
-
-Warning: fopen(test1://hello): Failed to open stream: no suitable wrapper could be found in %sinclude_userstream_003.php on line 10
-
-Warning: file_get_contents(test2://hello): Failed to open stream: "test::stream_open" call failed in %sinclude_userstream_003.php on line 88
+Warning: file_get_contents(test1://hello): Failed to open stream: no suitable wrapper could be found in %s on line %d
 
 
-Warning: fopen(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %sinclude_userstream_003.php on line 10
+Warning: include(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %s on line %d
 
-Warning: fopen(test1://hello): Failed to open stream: no suitable wrapper could be found in %sinclude_userstream_003.php on line 10
+Warning: include(test1://hello): Failed to open stream: no suitable wrapper could be found in %s on line %d
 
-Warning: include(test2://hello): Failed to open stream: "test::stream_open" call failed in %sinclude_userstream_003.php on line 89
+Warning: include(): Failed opening 'test1://hello' for inclusion (include_path='.:/home/nikic/php/php-src-install/lib/php') in %s on line %d
 
-Warning: include(): Failed opening 'test2://hello' for inclusion (include_path='%s') in %sinclude_userstream_003.php on line 89
+Warning: fopen(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %s on line %d
+
+Warning: fopen(test1://hello): Failed to open stream: no suitable wrapper could be found in %s on line %d
+
+Warning: file_get_contents(test2://hello): Failed to open stream: "test::stream_open" call failed in %s on line %d
+
+
+Warning: fopen(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %s on line %d
+
+Warning: fopen(test1://hello): Failed to open stream: no suitable wrapper could be found in %s on line %d
+
+Warning: include(test2://hello): Failed to open stream: "test::stream_open" call failed in %s on line %d
+
+Warning: include(): Failed opening 'test2://hello' for inclusion (include_path='.:/home/nikic/php/php-src-install/lib/php') in %s on line %d

--- a/ext/standard/tests/file/include_userstream_003.phpt
+++ b/ext/standard/tests/file/include_userstream_003.phpt
@@ -107,7 +107,7 @@ Warning: include(): test1:// wrapper is disabled in the server configuration by 
 
 Warning: include(test1://hello): Failed to open stream: no suitable wrapper could be found in %s on line %d
 
-Warning: include(): Failed opening 'test1://hello' for inclusion (include_path='.:/home/nikic/php/php-src-install/lib/php') in %s on line %d
+Warning: include(): Failed opening 'test1://hello' for inclusion (include_path='%s') in %s on line %d
 
 Warning: fopen(): test1:// wrapper is disabled in the server configuration by allow_url_fopen=0 in %s on line %d
 
@@ -122,4 +122,4 @@ Warning: fopen(test1://hello): Failed to open stream: no suitable wrapper could 
 
 Warning: include(test2://hello): Failed to open stream: "test::stream_open" call failed in %s on line %d
 
-Warning: include(): Failed opening 'test2://hello' for inclusion (include_path='.:/home/nikic/php/php-src-install/lib/php') in %s on line %d
+Warning: include(): Failed opening 'test2://hello' for inclusion (include_path='%s') in %s on line %d

--- a/ext/standard/tests/file/userdirstream.phpt
+++ b/ext/standard/tests/file/userdirstream.phpt
@@ -4,6 +4,7 @@ Directory Streams
 <?php
 class test {
     public $idx = 0;
+    public $context;
 
     function dir_opendir($path, $options) {
         print "Opening\n";

--- a/ext/standard/tests/file/userstreams.phpt
+++ b/ext/standard/tests/file/userstreams.phpt
@@ -81,6 +81,7 @@ class uselessstream
 
 class mystream
 {
+    public $context;
     public $path;
     public $mode;
     public $options;

--- a/ext/standard/tests/file/userstreams_002.phpt
+++ b/ext/standard/tests/file/userstreams_002.phpt
@@ -3,6 +3,7 @@ User-space streams: stream_cast()
 --FILE--
 <?php
 class test_wrapper_base {
+    public $context;
     public $return_value;
     function stream_open($path, $mode, $openedpath) {
         return true;

--- a/ext/standard/tests/file/userstreams_003.phpt
+++ b/ext/standard/tests/file/userstreams_003.phpt
@@ -3,6 +3,7 @@ User-space streams: stream_set_option()
 --FILE--
 <?php
 class test_wrapper_base {
+    public $context;
     public $return_value;
     public $expected_option;
     public $expected_value;

--- a/ext/standard/tests/file/userstreams_004.phpt
+++ b/ext/standard/tests/file/userstreams_004.phpt
@@ -3,6 +3,7 @@ User-space streams: stream_lock()
 --FILE--
 <?php
 class test_wrapper_base {
+    public $context;
     public $mode;
     function stream_open($path, $mode, $openedpath) {
         return true;

--- a/ext/standard/tests/file/userstreams_005.phpt
+++ b/ext/standard/tests/file/userstreams_005.phpt
@@ -3,6 +3,7 @@ User-space streams: stream_truncate()
 --FILE--
 <?php
 class test_wrapper_base {
+    public $context;
     public $mode;
     function stream_open($path, $mode, $openedpath) {
         return true;

--- a/ext/standard/tests/file/userstreams_006.phpt
+++ b/ext/standard/tests/file/userstreams_006.phpt
@@ -3,6 +3,7 @@ User-space streams: set_options returns "not implemented" for unhandled option t
 --FILE--
 <?php
 class test_wrapper {
+    public $context;
     function stream_open($path, $mode, $openedpath) {
         return true;
     }

--- a/ext/standard/tests/file/userstreams_007.phpt
+++ b/ext/standard/tests/file/userstreams_007.phpt
@@ -3,6 +3,7 @@ User-space streams: test metadata option
 --FILE--
 <?php
 class test_wrapper {
+    public $context;
     function stream_open($path, $mode, $openedpath) {
         return true;
     }

--- a/ext/standard/tests/file/userwrapper.phpt
+++ b/ext/standard/tests/file/userwrapper.phpt
@@ -3,6 +3,8 @@ Userstream unlink, rename, mkdir, rmdir, and url_stat.
 --FILE--
 <?php
 class test {
+    public $context;
+
     function unlink($file) {
         print "Unlinking file: $file\n";
     }

--- a/ext/standard/tests/general_functions/bug72306.phpt
+++ b/ext/standard/tests/general_functions/bug72306.phpt
@@ -3,6 +3,7 @@ Bug #72306 (Heap overflow through proc_open and $env parameter)
 --FILE--
 <?php
 class moo {
+    public $a;
     function __construct() { $this->a = 0; }
     function __toString() { return $this->a++ ? str_repeat("a", 0x8000) : "a"; }
 }

--- a/ext/standard/tests/general_functions/debug_zval_dump_o.phpt
+++ b/ext/standard/tests/general_functions/debug_zval_dump_o.phpt
@@ -17,6 +17,7 @@ function zval_dump( $values ) {
 
 /* checking on objects type */
 echo "*** Testing debug_zval_dump() on objects ***\n";
+#[AllowDynamicProperties]
 class object_class {
   var $value1 = 1;
   private $value2 = 10;
@@ -45,6 +46,7 @@ class no_member_class{
 }
 
 /* class with member as object of other class */
+#[AllowDynamicProperties]
 class contains_object_class
 {
    var       $p = 30;

--- a/ext/standard/tests/general_functions/is_object.phpt
+++ b/ext/standard/tests/general_functions/is_object.phpt
@@ -62,7 +62,7 @@ class myClass
     $this->public_var = 10;
     $this->public_var1 = new foo();
     $this->private_var = new foo();
-    $this->proected_var = new foo();
+    $this->protected_var = new foo();
   }
 }
 

--- a/ext/standard/tests/general_functions/print_r.phpt
+++ b/ext/standard/tests/general_functions/print_r.phpt
@@ -136,6 +136,7 @@ $arrays = array (
 check_printr($arrays);
 
 echo "\n*** Testing print_r() on object variables ***\n";
+#[AllowDynamicProperties]
 class object_class
 {
   var       $value;
@@ -168,6 +169,7 @@ class no_member_class {
 }
 
 /* class with member as object of other class */
+#[AllowDynamicProperties]
 class contains_object_class
 {
    var       $p = 30;

--- a/ext/standard/tests/general_functions/print_r_64bit.phpt
+++ b/ext/standard/tests/general_functions/print_r_64bit.phpt
@@ -140,6 +140,7 @@ $arrays = array (
 check_printr($arrays);
 
 echo "\n*** Testing print_r() on object variables ***\n";
+#[AllowDynamicProperties]
 class object_class
 {
   var       $value;
@@ -172,6 +173,7 @@ class no_member_class {
 }
 
 /* class with member as object of other class */
+#[AllowDynamicProperties]
 class contains_object_class
 {
    var       $p = 30;

--- a/ext/standard/tests/general_functions/var_dump.phpt
+++ b/ext/standard/tests/general_functions/var_dump.phpt
@@ -134,6 +134,7 @@ $arrays = array (
 check_vardump($arrays);
 
 echo "\n*** Testing var_dump() on object variables ***\n";
+#[AllowDynamicProperties]
 class object_class
 {
   var       $value;
@@ -166,6 +167,7 @@ class no_member_class {
 }
 
 /* class with member as object of other class */
+#[AllowDynamicProperties]
 class contains_object_class
 {
    var       $p = 30;

--- a/ext/standard/tests/general_functions/var_dump_64bit.phpt
+++ b/ext/standard/tests/general_functions/var_dump_64bit.phpt
@@ -134,6 +134,7 @@ $arrays = array (
 check_vardump($arrays);
 
 echo "\n*** Testing var_dump() on object variables ***\n";
+#[AllowDynamicProperties]
 class object_class
 {
   var       $value;
@@ -166,6 +167,7 @@ class no_member_class {
 }
 
 /* class with member as object of other class */
+#[AllowDynamicProperties]
 class contains_object_class
 {
    var       $p = 30;

--- a/ext/standard/tests/general_functions/var_export-locale_32.phpt
+++ b/ext/standard/tests/general_functions/var_export-locale_32.phpt
@@ -236,7 +236,7 @@ class myClass
     $this->public_var = 10;
     $this->public_var1 = new foo();
     $this->private_var = new foo();
-    $this->proected_var = new foo();
+    $this->protected_var = new foo();
   }
 }
 
@@ -961,8 +961,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
-   'proected_var' => 
+   'protected_var' =>
   foo::__set_state(array(
   )),
 ))
@@ -977,8 +976,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
-   'proected_var' => 
+   'protected_var' =>
   foo::__set_state(array(
   )),
 ))
@@ -993,8 +991,7 @@ string(293) "myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
-   'proected_var' => 
+   'protected_var' =>
   foo::__set_state(array(
   )),
 ))"
@@ -1012,8 +1009,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
-   'proected_var' => 
+   'protected_var' =>
   foo::__set_state(array(
   )),
 ))
@@ -1028,8 +1024,7 @@ myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
-   'proected_var' => 
+   'protected_var' =>
   foo::__set_state(array(
   )),
 ))
@@ -1044,8 +1039,7 @@ string(293) "myClass::__set_state(array(
    'private_var' => 
   foo::__set_state(array(
   )),
-   'protected_var' => NULL,
-   'proected_var' => 
+   'protected_var' =>
   foo::__set_state(array(
   )),
 ))"

--- a/ext/standard/tests/serialize/001.phpt
+++ b/ext/standard/tests/serialize/001.phpt
@@ -4,6 +4,7 @@ serialize()/unserialize()/var_dump()
 serialize_precision=100
 --FILE--
 <?php
+#[AllowDynamicProperties]
 class t
 {
     function __construct()
@@ -12,6 +13,7 @@ class t
     }
 }
 
+#[AllowDynamicProperties]
 class s
 {
     public $a;

--- a/ext/standard/tests/serialize/__serialize_004.phpt
+++ b/ext/standard/tests/serialize/__serialize_004.phpt
@@ -3,6 +3,7 @@ __serialize() mechanism (004): Delayed __unserialize() calls
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class Wakeup {
     public $data;
     public function __construct(array $data) {
@@ -15,6 +16,7 @@ class Wakeup {
     }
 }
 
+#[AllowDynamicProperties]
 class Unserialize {
     public $data;
     public function __construct(array $data) {

--- a/ext/standard/tests/serialize/bug14293.phpt
+++ b/ext/standard/tests/serialize/bug14293.phpt
@@ -4,6 +4,8 @@ Bug #14293 (serialize() and __sleep())
 <?php
 class t
 {
+    public $a;
+
     function __construct()
     {
         $this->a = 'hello';

--- a/ext/standard/tests/serialize/bug36424.phpt
+++ b/ext/standard/tests/serialize/bug36424.phpt
@@ -3,6 +3,7 @@ Bug #36424 - Serializable interface breaks object references
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class a implements Serializable {
     function serialize() {
         return serialize(get_object_vars($this));

--- a/ext/standard/tests/serialize/serialization_objects_005.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_005.phpt
@@ -5,7 +5,7 @@ Check behaviour of incomplete class
 $serialized = 'O:1:"C":1:{s:1:"p";i:1;}';
 
 $incomplete = unserialize($serialized);
-eval('Class C {}');
+eval('#[AllowDynamicProperties] Class C {}');
 $complete   = unserialize($serialized);
 
 

--- a/ext/standard/tests/streams/bug40459.phpt
+++ b/ext/standard/tests/streams/bug40459.phpt
@@ -6,6 +6,7 @@ allow_url_fopen=1
 <?php
 // Test whether the constructor of the user-space stream wrapper is called when stream functions are called
 class testwrapper {
+    public $context;
     private $constructorCalled = false;
     function __construct() {
         $this->constructorCalled = true;

--- a/ext/standard/tests/streams/bug53903.phpt
+++ b/ext/standard/tests/streams/bug53903.phpt
@@ -4,6 +4,7 @@ Bug #53903 streamwrapper/stream_stat causes problems
 <?php
 
 class sw {
+    public $context;
 
     public function stream_open($path, $mode, $options, &$opened_path) {
         return true;

--- a/ext/standard/tests/streams/bug60455_02.phpt
+++ b/ext/standard/tests/streams/bug60455_02.phpt
@@ -3,6 +3,7 @@ Bug #60455: stream_get_line and 1-line followed by eol input
 --FILE--
 <?php
 class TestStream {
+    public $context;
     private $s = 0;
     function stream_open($path, $mode, $options, &$opened_path) {
             return true;

--- a/ext/standard/tests/streams/bug60455_03.phpt
+++ b/ext/standard/tests/streams/bug60455_03.phpt
@@ -3,6 +3,7 @@ Bug #60455: stream_get_line and 2 lines, one possibly empty
 --FILE--
 <?php
 class TestStream {
+    public $context;
     private $lines = array();
     private $s = 0;
     private $eofth = 3;

--- a/ext/standard/tests/streams/bug60455_04.phpt
+++ b/ext/standard/tests/streams/bug60455_04.phpt
@@ -4,6 +4,7 @@ read with EOL indication
 --FILE--
 <?php
 class TestStream {
+    public $context;
     private $s = 0;
     function stream_open($path, $mode, $options, &$opened_path) {
             return true;

--- a/ext/standard/tests/streams/bug60817.phpt
+++ b/ext/standard/tests/streams/bug60817.phpt
@@ -3,6 +3,7 @@ Bug #60817: stream_get_line() reads from stream even when there is already suffi
 --FILE--
 <?php
 class TestStream { //data, empty data, empty data + eof
+    public $context;
     private $s = 0;
     function stream_open($path, $mode, $options, &$opened_path) {
             return true;

--- a/ext/standard/tests/streams/bug67626.phpt
+++ b/ext/standard/tests/streams/bug67626.phpt
@@ -4,6 +4,8 @@ Bug #67626: Exceptions not properly handled in user stream handlers
 <?php
 class MyStream
 {
+    public $context;
+
     public function stream_open() { return true; }
 
     public function stream_read()

--- a/ext/standard/tests/streams/bug78662.phpt
+++ b/ext/standard/tests/streams/bug78662.phpt
@@ -3,6 +3,7 @@ Bug #78662 (stream_write bad error detection)
 --FILE--
 <?php
 class FailedStream {
+    public $context;
     function stream_open($path, $mode, $options, &$opened_path)
     {
         return true;

--- a/ext/standard/tests/streams/set_file_buffer.phpt
+++ b/ext/standard/tests/streams/set_file_buffer.phpt
@@ -6,6 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br> - #phparty7 - @phpsp - novatec/2015 - sao p
 <?php
 
 class test_wrapper {
+  public $context;
 
   function stream_open($path, $mode, $openedpath) {
     return true;

--- a/ext/standard/tests/streams/stream_get_line_NUL_delimiter.phpt
+++ b/ext/standard/tests/streams/stream_get_line_NUL_delimiter.phpt
@@ -3,6 +3,7 @@ Bug #60455: stream_get_line and \0 as a delimiter
 --FILE--
 <?php
 class TestStream {
+    public $context;
     private $s = 0;
     function stream_open($path, $mode, $options, &$opened_path) {
             return true;

--- a/ext/standard/tests/streams/stream_read_object_return.phpt
+++ b/ext/standard/tests/streams/stream_read_object_return.phpt
@@ -3,6 +3,7 @@ Returning an object from stream_read() is invalid, but should not leak
 --FILE--
 <?php
 class MyStream {
+    public $context;
     function stream_open() {
         return true;
     }

--- a/ext/standard/tests/streams/stream_set_chunk_size.phpt
+++ b/ext/standard/tests/streams/stream_set_chunk_size.phpt
@@ -3,6 +3,7 @@ stream_set_chunk_size basic tests
 --FILE--
 <?php
 class test_wrapper {
+    public $context;
     function stream_open($path, $mode, $openedpath) {
         return true;
     }

--- a/ext/standard/tests/streams/user-stream-error.phpt
+++ b/ext/standard/tests/streams/user-stream-error.phpt
@@ -4,6 +4,7 @@ E_ERROR during UserStream Open
 <?php
 
 class FailStream {
+  public $context;
   public function stream_open($path, $mode, $options, &$opened_path) {
     _some_undefined_function();
   }

--- a/ext/zip/tests/bug53603.phpt
+++ b/ext/zip/tests/bug53603.phpt
@@ -6,6 +6,7 @@ zip
 <?php
 
 class TestStream {
+    public $context;
     function url_stat($path, $flags) {
         if (!($flags & STREAM_URL_STAT_QUIET))
             trigger_error("not quiet");

--- a/sapi/phpdbg/tests/phpdbg_get_executable_stream_wrapper.phpt
+++ b/sapi/phpdbg/tests/phpdbg_get_executable_stream_wrapper.phpt
@@ -25,6 +25,7 @@ prompt>
  */
 final class StreamWrapper
 {
+    public $context;
     public function stream_open(
         string $path,
         string $mode,

--- a/tests/classes/dereferencing_001.phpt
+++ b/tests/classes/dereferencing_001.phpt
@@ -4,9 +4,7 @@ ZE2 dereferencing of objects from methods
 <?php
 
 class Name {
-    function __construct($_name) {
-        $this->name = $_name;
-    }
+    function __construct(public $name) {}
 
     function display() {
         echo $this->name . "\n";

--- a/tests/classes/iterators_006.phpt
+++ b/tests/classes/iterators_006.phpt
@@ -6,6 +6,8 @@ ZE2 iterators and array wrapping
 class ai implements Iterator {
 
     private $array;
+    private $key;
+    private $current;
 
     function __construct() {
         $this->array = array('foo', 'bar', 'baz');

--- a/tests/classes/method_call_variation_001.phpt
+++ b/tests/classes/method_call_variation_001.phpt
@@ -2,7 +2,9 @@
 In $a->$b[Y]() and $a->X[Y]() both $a->$b[Y] and $a->X[Y] represent a global function name
 --FILE--
 <?php
-  class C {}
+  class C {
+    public $functions;
+  }
 
   function foo($a, $b) {
       echo "Called global foo($a, $b)\n";

--- a/tests/classes/property_recreate_private.phpt
+++ b/tests/classes/property_recreate_private.phpt
@@ -12,6 +12,7 @@ class C {
     }
 }
 
+#[AllowDynamicProperties]
 class D extends C {
     function setP() {
         $this->p = 'changed in D';
@@ -78,7 +79,7 @@ object(C)#%d (1) {
 
 Unset a private property, and attempt to recreate at global scope (expecting failure):
 
-Fatal error: Uncaught Error: Cannot access private property C::$p in %s:46
+Fatal error: Uncaught Error: Cannot access private property C::$p in %s:%d
 Stack trace:
 #0 {main}
-  thrown in %s on line 46
+  thrown in %s on line %d

--- a/tests/classes/static_properties_003.phpt
+++ b/tests/classes/static_properties_003.phpt
@@ -2,7 +2,7 @@
 Attempting to access static properties using instance property syntax
 --FILE--
 <?php
-class C {
+#[AllowDynamicProperties] class C {
     public static $x = 'C::$x';
     protected static $y = 'C::$y';
 }

--- a/tests/classes/static_properties_003.phpt
+++ b/tests/classes/static_properties_003.phpt
@@ -2,7 +2,8 @@
 Attempting to access static properties using instance property syntax
 --FILE--
 <?php
-#[AllowDynamicProperties] class C {
+#[AllowDynamicProperties]
+class C {
     public static $x = 'C::$x';
     protected static $y = 'C::$y';
 }
@@ -29,17 +30,17 @@ var_dump(isset($c->y));
 --> Access visible static prop like instance prop:
 bool(false)
 
-Notice: Accessing static property C::$x as non static in %s on line 11
-
 Notice: Accessing static property C::$x as non static in %s on line 12
-
-Warning: Undefined property: C::$x in %s on line %d
 
 Notice: Accessing static property C::$x as non static in %s on line 13
 
-Notice: Accessing static property C::$x as non static in %s on line 15
+Warning: Undefined property: C::$x in %s on line %d
+
+Notice: Accessing static property C::$x as non static in %s on line 14
 
 Notice: Accessing static property C::$x as non static in %s on line 16
+
+Notice: Accessing static property C::$x as non static in %s on line 17
 string(3) "ref"
 string(5) "C::$x"
 

--- a/tests/classes/visibility_005.phpt
+++ b/tests/classes/visibility_005.phpt
@@ -3,6 +3,7 @@ ZE2 foreach and property visibility
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class base
 {
     public $a=1;

--- a/tests/lang/030.phpt
+++ b/tests/lang/030.phpt
@@ -3,6 +3,7 @@ $this in constructor test
 --FILE--
 <?php
 class foo {
+    public $Name;
     function __construct($name) {
         $GLOBALS['List']= &$this;
         $this->Name = $name;

--- a/tests/lang/035.phpt
+++ b/tests/lang/035.phpt
@@ -3,9 +3,7 @@ ZE2: set_exception_handler()
 --FILE--
 <?php
 class MyException extends Exception {
-    function __construct($_error) {
-        $this->error = $_error;
-    }
+    function __construct(public $error) {}
 
     function getException()
     {

--- a/tests/lang/bug22510.phpt
+++ b/tests/lang/bug22510.phpt
@@ -2,6 +2,8 @@
 Bug #22510 (segfault among complex references)
 --FILE--
 <?php
+
+#[AllowDynamicProperties]
 class foo
 {
     public $list = array();
@@ -29,6 +31,8 @@ class foo
 
 class bar
 {
+    public $instance;
+
     function run1() {
         print __CLASS__."::".__FUNCTION__."\n";
         $this->instance = new foo();

--- a/tests/lang/bug27439.phpt
+++ b/tests/lang/bug27439.phpt
@@ -12,6 +12,7 @@ class test_props {
 class test {
     public $array = array(1,2,3);
     public $string = "string";
+    public $object;
 
     public function __construct() {
         $this->object = new test_props;

--- a/tests/lang/error_2_exception_001.phpt
+++ b/tests/lang/error_2_exception_001.phpt
@@ -4,10 +4,7 @@ ZE2 errors caught as exceptions
 <?php
 
 class MyException extends Exception {
-    function __construct($_errno, $_errmsg) {
-        $this->errno = $_errno;
-        $this->errmsg = $_errmsg;
-    }
+    function __construct(public $errno, public $errmsg) {}
 
     function getErrno() {
         return $this->errno;

--- a/tests/lang/foreachLoopObjects.003.phpt
+++ b/tests/lang/foreachLoopObjects.003.phpt
@@ -3,6 +3,7 @@ Foreach loop tests - modifying the object during the loop.
 --FILE--
 <?php
 
+#[AllowDynamicProperties]
 class C {
     public $a = "Original a";
     public $b = "Original b";

--- a/tests/lang/operators/overloaded_property_ref.phpt
+++ b/tests/lang/operators/overloaded_property_ref.phpt
@@ -3,6 +3,7 @@ Operators on overloaded property reference
 --FILE--
 <?php
 class C {
+    private $bar;
     function __construct() { $this->bar = str_repeat("1", 2); }
     function &__get($x) { return $this->bar; }
     function __set($x, $v) { $this->bar = $v; }


### PR DESCRIPTION
This is a variant of #7390 that adds an `#[AllowDynamicProperties]` escape hatch, to explicitly allow using dynamic properties on a class without deprecation.

RFC: https://wiki.php.net/rfc/deprecate_dynamic_properties

TODO: Plaster `#[AllowDynamicProperties]` over large swathes of tests.