### PR TITLE
Fix #81500: Interval serialization regression since 7.3.14 / 7.4.2

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4331,7 +4331,12 @@ static zval *date_interval_write_property(zval *object, zval *member, zval *valu
 		SET_VALUE_FROM_STRUCT(i, "i");
 		SET_VALUE_FROM_STRUCT(s, "s");
 		if (strcmp(Z_STRVAL_P(member), "f") == 0) {
-			obj->diff->us = zval_get_double(value) * 1000000;
+			double val = zval_get_double(value) * 1000000;
+			if (val >= 0 && val < 1000000) {
+				obj->diff->us = val;
+			} else {
+				obj->diff->us = -1000000;
+			}
 			break;
 		}
 		SET_VALUE_FROM_STRUCT(invert, "invert");

--- a/ext/date/tests/bug81500.phpt
+++ b/ext/date/tests/bug81500.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #81500 (Interval serialization regression since 7.3.14 / 7.4.2)
+--FILE--
+<?php
+$interval = new DateInterval('PT1S');
+$interval->f = -0.000001;
+var_dump($interval->s, $interval->f);
+
+$interval = unserialize(serialize($interval));
+var_dump($interval->s, $interval->f);
+?>
+--EXPECT--
+int(1)
+int(-1)
+int(1)
+int(-1)


### PR DESCRIPTION
On unserialization the valid range of `DateInterval::$f` is checked,
and values outside this range are explicitly marked as invalid
(`-1000000`).  To avoid confusion, we should do the same when setting
the property in the first place.