### PR TITLE
Fix #81518: Header injection via default_mimetype / default_charset

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -614,6 +614,10 @@ PHPAPI void (*php_internal_encoding_changed)(void) = NULL;
  */
 static PHP_INI_MH(OnUpdateDefaultCharset)
 {
+	if (memchr(ZSTR_VAL(new_value), '\0', ZSTR_LEN(new_value))
+		|| strpbrk(ZSTR_VAL(new_value), "\r\n")) {
+		return FAILURE;
+	}
 	OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 	if (php_internal_encoding_changed) {
 		php_internal_encoding_changed();
@@ -624,6 +628,19 @@ static PHP_INI_MH(OnUpdateDefaultCharset)
 #endif
 	}
 	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_INI_MH
+ */
+static PHP_INI_MH(OnUpdateDefaultMimeTye)
+{
+	char *s = ZSTR_VAL(new_value), *e = s + ZSTR_LEN(new_value);
+	if (memchr(ZSTR_VAL(new_value), '\0', ZSTR_LEN(new_value))
+		|| strpbrk(ZSTR_VAL(new_value), "\r\n")) {
+		return FAILURE;
+	}
+	return OnUpdateString(entry, new_value, mh_arg1, mh_arg2, mh_arg3, stage);
 }
 /* }}} */
 
@@ -782,7 +799,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("auto_prepend_file",		NULL,		PHP_INI_SYSTEM|PHP_INI_PERDIR,		OnUpdateString,			auto_prepend_file,		php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("doc_root",				NULL,		PHP_INI_SYSTEM,		OnUpdateStringUnempty,	doc_root,				php_core_globals,	core_globals)
 	STD_PHP_INI_ENTRY("default_charset",		PHP_DEFAULT_CHARSET,	PHP_INI_ALL,	OnUpdateDefaultCharset,			default_charset,		sapi_globals_struct, sapi_globals)
-	STD_PHP_INI_ENTRY("default_mimetype",		SAPI_DEFAULT_MIMETYPE,	PHP_INI_ALL,	OnUpdateString,			default_mimetype,		sapi_globals_struct, sapi_globals)
+	STD_PHP_INI_ENTRY("default_mimetype",		SAPI_DEFAULT_MIMETYPE,	PHP_INI_ALL,	OnUpdateDefaultMimeTye,			default_mimetype,		sapi_globals_struct, sapi_globals)
 	STD_PHP_INI_ENTRY("internal_encoding",		NULL,			PHP_INI_ALL,	OnUpdateInternalEncoding,	internal_encoding,	php_core_globals, core_globals)
 	STD_PHP_INI_ENTRY("input_encoding",			NULL,			PHP_INI_ALL,	OnUpdateInputEncoding,				input_encoding,		php_core_globals, core_globals)
 	STD_PHP_INI_ENTRY("output_encoding",		NULL,			PHP_INI_ALL,	OnUpdateOutputEncoding,				output_encoding,	php_core_globals, core_globals)

--- a/main/main.c
+++ b/main/main.c
@@ -635,7 +635,6 @@ static PHP_INI_MH(OnUpdateDefaultCharset)
  */
 static PHP_INI_MH(OnUpdateDefaultMimeTye)
 {
-	char *s = ZSTR_VAL(new_value), *e = s + ZSTR_LEN(new_value);
 	if (memchr(ZSTR_VAL(new_value), '\0', ZSTR_LEN(new_value))
 		|| strpbrk(ZSTR_VAL(new_value), "\r\n")) {
 		return FAILURE;

--- a/sapi/cgi/tests/bug81518a.phpt
+++ b/sapi/cgi/tests/bug81518a.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #81518 (Header injection via default_mimetype / default_charset)
+--CGI--
+--FILE--
+<?php
+ini_set(
+    "default_mimetype",
+    "text/html;charset=ISO-8859-1\r\nContent-Length: 31\r\n\r\n" .
+    "Lets smuggle a HTTP response.\r\n"
+);
+?>
+--EXPECTHEADERS--
+Content-type: text/html; charset=UTF-8
+--EXPECT--

--- a/sapi/cgi/tests/bug81518b.phpt
+++ b/sapi/cgi/tests/bug81518b.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #81518 (Header injection via default_mimetype / default_charset)
+--CGI--
+--FILE--
+<?php
+ini_set('default_charset', 'ISO-8859-1' . "\r\nHeader-Injection: Works!");
+header('Content-Type: text/html');
+?>
+--EXPECTHEADERS--
+Content-type: text/html;charset=UTF-8
+--EXPECT--


### PR DESCRIPTION
We forbid setting these INI options to values containing NUL bytes, CR
or LF.

---

Not sure where to put the tests. php-Would src/tests be more appropriate?
