### PR TITLE
Fix #81500: Interval serialization regression since 7.3.14 / 7.4.2

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4331,7 +4331,12 @@ static zval *date_interval_write_property(zval *object, zval *member, zval *valu
 		SET_VALUE_FROM_STRUCT(i, "i");
 		SET_VALUE_FROM_STRUCT(s, "s");
 		if (strcmp(Z_STRVAL_P(member), "f") == 0) {
-			obj->diff->us = zval_get_double(value) * 1000000;
+			double val = zval_get_double(value) * 1000000;
+			if (val > -1000000 && val < 1000000) {
+				obj->diff->us = val;
+			} else {
+				obj->diff->us = -1000000;
+			}
 			break;
 		}
 		SET_VALUE_FROM_STRUCT(invert, "invert");
@@ -4471,7 +4476,7 @@ static int php_date_interval_initialize_from_hash(zval **return_value, php_inter
 		(*intobj)->diff->us = -1000000;
 		if (z_arg) {
 			double val = zval_get_double(z_arg) * 1000000;
-			if (val >= 0 && val < 1000000) {
+			if (val > -1000000 && val < 1000000) {
 				(*intobj)->diff->us = val;
 			}
 		}

--- a/ext/date/tests/bug81500.phpt
+++ b/ext/date/tests/bug81500.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #81500 (Interval serialization regression since 7.3.14 / 7.4.2)
+--FILE--
+<?php
+$interval = new DateInterval('PT1S');
+$interval->f = -0.000001;
+var_dump($interval->s, $interval->f);
+
+$interval = unserialize(serialize($interval));
+var_dump($interval->s, $interval->f);
+?>
+--EXPECT--
+int(1)
+float(-1.0E-6)
+int(1)
+float(-1.0E-6)


### PR DESCRIPTION
While it may not be desired, `DateInterval::$f` supports negative
values, at least with regard to calculations.  We still need to guard
from assigning double values which are out of range for signed 64bit
integers (which would be undefined behavior).  While we could restrict
this only to values which are actually out of range, the marker for
invalid µs is `-1000000`, so we cannot accept smaller numbers.  To
retain symmetry, we also reject values greater than `1000000`.  We must
not do that only for unserialization, but also when the property is set
in the first place.