### PR TITLE
switch to libxcrypt implementation when all algo available

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2269,7 +2269,6 @@ struct crypt_data buffer;
 crypt_r("passwd", "hash", &buffer);
 ]])],[php_cv_crypt_r_style=struct_crypt_data],[])
     fi
-    ])
 
   if test "$php_cv_crypt_r_style" = "cryptd"; then
     AC_DEFINE(CRYPT_R_CRYPTD, 1, [Define if crypt_r has uses CRYPTD])

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -53,7 +53,6 @@ fi
 
 PHP_CHECK_FUNC(crypt, crypt)
 PHP_CHECK_FUNC(crypt_r, crypt)
-AC_CHECK_HEADERS(crypt.h)
 if test "$ac_cv_func_crypt_r" = "yes"; then
   PHP_CRYPT_R_STYLE
 fi

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -53,6 +53,7 @@ fi
 
 PHP_CHECK_FUNC(crypt, crypt)
 PHP_CHECK_FUNC(crypt_r, crypt)
+AC_CHECK_HEADERS(crypt.h)
 if test "$ac_cv_func_crypt_r" = "yes"; then
   PHP_CRYPT_R_STYLE
 fi
@@ -270,8 +271,7 @@ int main() {
 dnl
 dnl If one of them is missing, use our own implementation, portable code is then possible
 dnl
-dnl TODO This is currently always enabled
-if test "$ac_cv_crypt_blowfish" = "no" || test "$ac_cv_crypt_des" = "no" || test "$ac_cv_crypt_ext_des" = "no" || test "$ac_cv_crypt_md5" = "no" || test "$ac_cv_crypt_sha512" = "no" || test "$ac_cv_crypt_sha256" = "no" || test "$ac_cv_func_crypt_r" != "yes" || true; then
+if test "$ac_cv_crypt_blowfish" = "no" || test "$ac_cv_crypt_des" = "no" || test "$ac_cv_crypt_ext_des" = "no" || test "$ac_cv_crypt_md5" = "no" || test "$ac_cv_crypt_sha512" = "no" || test "$ac_cv_crypt_sha256" = "no" || test "$ac_cv_func_crypt_r" != "yes"; then
   AC_DEFINE_UNQUOTED(PHP_USE_PHP_CRYPT_R, 1, [Whether PHP has to use its own crypt_r for blowfish, des, ext des and md5])
 
   PHP_ADD_SOURCES(PHP_EXT_DIR(standard), crypt_freesec.c crypt_blowfish.c crypt_sha512.c crypt_sha256.c php_crypt_r.c)


### PR DESCRIPTION
For discussion:

@nikic can you please have a look, some changes coming from you in 7d05bc86307

Using libxcrypt could also allow to add more algo, especially **yescrypt** which mays have interest for password hashing
(also used by pam in some modern linux distro)
