### PR TITLE
remove closing bracket in bad place

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2219,7 +2219,6 @@ struct crypt_data buffer;
 crypt_r("passwd", "hash", &buffer);
 ]])],[php_cv_crypt_r_style=struct_crypt_data_gnu_source],[])
     fi
-    ])
 
     if test "$php_cv_crypt_r_style" = "none"; then
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[


### PR DESCRIPTION
Discovered during work for pr #7580
Issue introduced in 6ca6e9f

Effects:  `CRYPT_R_STRUCT_CRYPT_DATA` is never set in `main/php_config.h`