### PR TITLE
Add "N" and "o" format specifiers to idate()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,9 @@ PHP                                                                        NEWS
 - FPM:
   . Emit error for invalid port setting. (David Carlier)
 
+- Date:
+  . idate() now accepts format specifiers "N" and "o"
+
 - Intl:
   . Update all grandfathered language tags with preferred values
   . Fixed GH-7939 (Cannot unserialize IntlTimeZone objects). (cmb)

--- a/UPGRADING
+++ b/UPGRADING
@@ -40,6 +40,9 @@ PHP 8.2 UPGRADE NOTES
   . Added CURLINFO_EFFECTIVE_METHOD option and returning the effective
     HTTP method in curl_getinfo() return value.
 
+- Date:
+  . idate() now accepts format specifiers "N" and "o".
+
 - OCI8:
   . Added an oci8.prefetch_lob_size directive and oci_set_prefetch_lob()
     function to tune LOB query performance by reducing the number of

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -882,6 +882,7 @@ PHPAPI int php_idate(char format, time_t ts, bool localtime)
 		/* day */
 		case 'd': case 'j': retval = (int) t->d; break;
 
+		case 'N': retval = (int) timelib_iso_day_of_week(t->y, t->m, t->d); break;
 		case 'w': retval = (int) timelib_day_of_week(t->y, t->m, t->d); break;
 		case 'z': retval = (int) timelib_day_of_year(t->y, t->m, t->d); break;
 
@@ -896,6 +897,7 @@ PHPAPI int php_idate(char format, time_t ts, bool localtime)
 		case 'L': retval = (int) timelib_is_leap((int) t->y); break;
 		case 'y': retval = (int) (t->y % 100); break;
 		case 'Y': retval = (int) t->y; break;
+		case 'o': retval = (int) isoyear; break; /* iso year */
 
 		/* Swatch Beat a.k.a. Internet Time */
 		case 'B':

--- a/ext/standard/tests/time/idate.phpt
+++ b/ext/standard/tests/time/idate.phpt
@@ -3,7 +3,7 @@ idate() function
 --FILE--
 <?php
 date_default_timezone_set('GMT0');
-$tmp = "UYzymndjHGhgistwLBIW";
+$tmp = "UYozymndjHGhgistwNLBIW";
 for($a = 0;$a < strlen($tmp); $a++){
     echo $tmp[$a], ': ', idate($tmp[$a], 1043324459)."\n";
 }
@@ -11,6 +11,7 @@ for($a = 0;$a < strlen($tmp); $a++){
 --EXPECT--
 U: 1043324459
 Y: 2003
+o: 2003
 z: 22
 y: 3
 m: 1
@@ -25,6 +26,7 @@ i: 20
 s: 59
 t: 31
 w: 4
+N: 4
 L: 0
 B: 556
 I: 0

--- a/ext/standard/tests/time/idate_iso.phpt
+++ b/ext/standard/tests/time/idate_iso.phpt
@@ -1,0 +1,23 @@
+--TEST--
+idate() function : isoweek
+--FILE--
+<?php
+date_default_timezone_set('GMT0');
+$tmp = "UwNW";
+for($a = 0;$a < strlen($tmp); $a++){
+    echo $tmp[$a], ': ', idate($tmp[$a], 1041808859)."\n";
+}
+$tmp = "UYoW";
+for($a = 0;$a < strlen($tmp); $a++){
+    echo $tmp[$a], ': ', idate($tmp[$a], 1072912859)."\n";
+}
+?>
+--EXPECT--
+U: 1041808859
+w: 0
+N: 7
+W: 1
+U: 1072912859
+Y: 2003
+o: 2004
+W: 1


### PR DESCRIPTION
Moved `timelib_isoweek_from_date` into case where it's actually needed. And changed the timestamp in tests so day of week difference is clear.

With these formatters, it should cover all the ones `date` has (except for the ones that return a string, obviously)