### PR TITLE
skip test with libpcre2 10.38

### DIFF
--- a/ext/pcre/tests/bug70345.phpt
+++ b/ext/pcre/tests/bug70345.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Bug #70345 (Multiple vulnerabilities related to PCRE functions)
+--SKIPIF--
+<?php
+if (version_compare(PCRE_VERSION, '10.38', '>=')) {
+    die("skip only for libpcre2 < 10.38");
+}
+?>
 --FILE--
 <?php
 $regex = '/(?=xyz\K)/';


### PR DESCRIPTION
With libpcre2 10.38
```
TEST FAILURE: ../ext/pcre/tests/bug70345.diff --
001+ Warning: preg_split(): Compilation failed: \K is not allowed in lookarounds (but see PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK) at offset 9 in /builddir/build/BUILD/php-8.0.12RC1/ext/pcre/tests/bug70345.php on line 5
     bool(false)
     
004+ Warning: preg_match(): Compilation failed: \K is not allowed in lookarounds (but see PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK) at offset 12 in /builddir/build/BUILD/php-8.0.12RC1/ext/pcre/tests/bug70345.php on line 9
005+ NULL
003- Warning: preg_match(): Get subpatterns list failed in %s on line %d
004- array(0) {
005- }

```

This is for 7.4
Probably a better fix is possible in 8.1+ defined some new constant to manage this `\K` modifier using `PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK`