### PR TITLE
Use HT for recursion protection in JSON encode

### DIFF
--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -152,6 +152,7 @@ PHP_JSON_API int php_json_encode_ex(smart_str *buf, zval *val, int options, zend
 	return_code = php_json_encode_zval(buf, val, options, &encoder);
 	JSON_G(error_code) = encoder.error_code;
 
+	php_json_encode_destroy(&encoder);
 	return return_code;
 }
 /* }}} */
@@ -235,6 +236,7 @@ PHP_FUNCTION(json_encode)
 	php_json_encode_init(&encoder);
 	encoder.max_depth = (int)depth;
 	php_json_encode_zval(&buf, parameter, (int)options, &encoder);
+	php_json_encode_destroy(&encoder);
 
 	if (!(options & PHP_JSON_THROW_ON_ERROR) || (options & PHP_JSON_PARTIAL_OUTPUT_ON_ERROR)) {
 		JSON_G(error_code) = encoder.error_code;

--- a/ext/json/php_json_encoder.h
+++ b/ext/json/php_json_encoder.h
@@ -26,11 +26,20 @@ struct _php_json_encoder {
 	int depth;
 	int max_depth;
 	php_json_error_code error_code;
+	HashTable recursive;
 };
 
 static inline void php_json_encode_init(php_json_encoder *encoder)
 {
-	memset(encoder, 0, sizeof(php_json_encoder));
+	encoder->depth = 0;
+	encoder->max_depth = 0;
+	encoder->error_code = 0;
+	zend_hash_init(&encoder->recursive, 0, NULL, NULL, 0);
+}
+
+static inline void php_json_encode_destroy(php_json_encoder *encoder)
+{
+	zend_hash_destroy(&encoder->recursive);
 }
 
 int php_json_encode_zval(smart_str *buf, zval *val, int options, php_json_encoder *encoder);


### PR DESCRIPTION
The jsonSerialize() method might access recursion-protected objects/arrays, in which case other operations like var_dump() may break. This also fixes https://bugs.php.net/bug.php?id=81524.

@tstarling Thoughts?