### PR TITLE
Make string offset error less specific

### DIFF
--- a/Zend/tests/bug41813.phpt
+++ b/Zend/tests/bug41813.phpt
@@ -9,7 +9,7 @@ $foo[0]->bar = "xyz";
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot use string offset as an object in %s:%d
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug41919.phpt
+++ b/Zend/tests/bug41919.phpt
@@ -8,7 +8,7 @@ $foo[3]->bar[1] = "bang";
 echo "ok\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot use string offset as an object in %sbug41919.php:%d
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sbug41919.php on line %d

--- a/Zend/tests/bug47704.phpt
+++ b/Zend/tests/bug47704.phpt
@@ -6,7 +6,7 @@ $s = "abd";
 $s[0]->a += 1;
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot use string offset as an object in %sbug47704.php:%d
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sbug47704.php on line %d

--- a/Zend/tests/bug49866.phpt
+++ b/Zend/tests/bug49866.phpt
@@ -8,7 +8,7 @@ $b = "f";
 echo $a;
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot create references to/from string offsets in %sbug49866.php:3
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sbug49866.php on line 3

--- a/Zend/tests/bug53432.phpt
+++ b/Zend/tests/bug53432.phpt
@@ -63,5 +63,5 @@ Error: [] operator not supported for strings
 string(0) ""
 Error: Cannot use assign-op operators with string offsets
 string(0) ""
-Error: Cannot use string offset as an array
+Error: Cannot indirectly modify string offset
 string(0) ""

--- a/Zend/tests/bug70089.phpt
+++ b/Zend/tests/bug70089.phpt
@@ -29,7 +29,7 @@ try {
 }
 ?>
 --EXPECT--
-string(36) "Cannot use string offset as an array"
+string(38) "Cannot indirectly modify string offset"
 string(27) "Cannot unset string offsets"
-string(41) "Only variables can be passed by reference"
-string(41) "Cannot increment/decrement string offsets"
+string(38) "Cannot indirectly modify string offset"
+string(38) "Cannot indirectly modify string offset"

--- a/Zend/tests/bug73792.phpt
+++ b/Zend/tests/bug73792.phpt
@@ -14,7 +14,7 @@ echo 'done';
 --EXPECTF--
 Warning: Illegal string offset "2bbb" in %s on line %d
 
-Fatal error: Uncaught Error: Cannot iterate on string offsets by reference in %sbug73792.php:4
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sbug73792.php on line 4

--- a/Zend/tests/bug79779.phpt
+++ b/Zend/tests/bug79779.phpt
@@ -6,7 +6,7 @@ $str = "";
 $str[1]->a = &$b;
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot use string offset as an object in %s:%d
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/list_assign_ref_string_offset_error.phpt
+++ b/Zend/tests/list_assign_ref_string_offset_error.phpt
@@ -10,7 +10,7 @@ list(&$a[$i++]) = $v;
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot create references to/from string offsets in %s:%d
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/offset_assign.phpt
+++ b/Zend/tests/offset_assign.phpt
@@ -10,7 +10,7 @@ echo "Done\n";
 --EXPECTF--
 Warning: Illegal string offset "2x" in %s on line %d
 
-Fatal error: Uncaught Error: Cannot use string offset as an array in %soffset_assign.php:%d
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %soffset_assign.php on line %d

--- a/Zend/tests/str_offset_002.phpt
+++ b/Zend/tests/str_offset_002.phpt
@@ -6,7 +6,7 @@ $a = "aaa";
 $x = array(&$a[1]);
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot create references to/from string offsets in %sstr_offset_002.php:3
+Fatal error: Uncaught Error: Cannot indirectly modify string offset in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sstr_offset_002.php on line 3

--- a/Zend/tests/string_offset_errors.phpt
+++ b/Zend/tests/string_offset_errors.phpt
@@ -23,5 +23,5 @@ try {
 
 ?>
 --EXPECT--
-Cannot return string offsets by reference
-Cannot create references to/from string offsets
+Cannot indirectly modify string offset
+Cannot indirectly modify string offset

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1533,7 +1533,6 @@ ZEND_API ZEND_COLD void zend_wrong_string_offset_error(void)
 	const char *msg = NULL;
 	const zend_execute_data *execute_data = EG(current_execute_data);
 	const zend_op *opline = execute_data->opline;
-	uint32_t var;
 
 	if (UNEXPECTED(EG(exception) != NULL)) {
 		return;
@@ -1546,84 +1545,14 @@ ZEND_API ZEND_COLD void zend_wrong_string_offset_error(void)
 		case ZEND_ASSIGN_STATIC_PROP_OP:
 			msg = "Cannot use assign-op operators with string offsets";
 			break;
+		case ZEND_FETCH_DIM_UNSET:
+			msg = "Cannot unset string offsets";
+			break;
 		case ZEND_FETCH_DIM_W:
 		case ZEND_FETCH_DIM_RW:
 		case ZEND_FETCH_DIM_FUNC_ARG:
-		case ZEND_FETCH_DIM_UNSET:
 		case ZEND_FETCH_LIST_W:
-			/* TODO: Encode the "reason" into opline->extended_value??? */
-			var = opline->result.var;
-			opline++;
-			ZEND_ASSERT(opline < execute_data->func->op_array.opcodes +
-				execute_data->func->op_array.last);
-			if (opline->op1_type == IS_VAR && opline->op1.var == var) {
-				switch (opline->opcode) {
-					case ZEND_FETCH_OBJ_W:
-					case ZEND_FETCH_OBJ_RW:
-					case ZEND_FETCH_OBJ_FUNC_ARG:
-					case ZEND_FETCH_OBJ_UNSET:
-					case ZEND_ASSIGN_OBJ:
-					case ZEND_ASSIGN_OBJ_OP:
-					case ZEND_ASSIGN_OBJ_REF:
-						msg = "Cannot use string offset as an object";
-						break;
-					case ZEND_FETCH_DIM_W:
-					case ZEND_FETCH_DIM_RW:
-					case ZEND_FETCH_DIM_FUNC_ARG:
-					case ZEND_FETCH_DIM_UNSET:
-					case ZEND_FETCH_LIST_W:
-					case ZEND_ASSIGN_DIM:
-					case ZEND_ASSIGN_DIM_OP:
-						msg = "Cannot use string offset as an array";
-						break;
-					case ZEND_ASSIGN_STATIC_PROP_OP:
-					case ZEND_ASSIGN_OP:
-						msg = "Cannot use assign-op operators with string offsets";
-						break;
-					case ZEND_PRE_INC_OBJ:
-					case ZEND_PRE_DEC_OBJ:
-					case ZEND_POST_INC_OBJ:
-					case ZEND_POST_DEC_OBJ:
-					case ZEND_PRE_INC:
-					case ZEND_PRE_DEC:
-					case ZEND_POST_INC:
-					case ZEND_POST_DEC:
-						msg = "Cannot increment/decrement string offsets";
-						break;
-					case ZEND_ASSIGN_REF:
-					case ZEND_ADD_ARRAY_ELEMENT:
-					case ZEND_INIT_ARRAY:
-					case ZEND_MAKE_REF:
-						msg = "Cannot create references to/from string offsets";
-						break;
-					case ZEND_RETURN_BY_REF:
-					case ZEND_VERIFY_RETURN_TYPE:
-						msg = "Cannot return string offsets by reference";
-						break;
-					case ZEND_UNSET_DIM:
-					case ZEND_UNSET_OBJ:
-						msg = "Cannot unset string offsets";
-						break;
-					case ZEND_YIELD:
-						msg = "Cannot yield string offsets by reference";
-						break;
-					case ZEND_SEND_REF:
-					case ZEND_SEND_VAR_EX:
-					case ZEND_SEND_FUNC_ARG:
-						msg = "Only variables can be passed by reference";
-						break;
-					case ZEND_FE_RESET_RW:
-						msg = "Cannot iterate on string offsets by reference";
-						break;
-					EMPTY_SWITCH_DEFAULT_CASE();
-				}
-				break;
-			}
-			if (opline->op2_type == IS_VAR && opline->op2.var == var) {
-				ZEND_ASSERT(opline->opcode == ZEND_ASSIGN_REF);
-				msg = "Cannot create references to/from string offsets";
-				break;
-			}
+			msg = "Cannot indirectly modify string offset";
 			break;
 		EMPTY_SWITCH_DEFAULT_CASE();
 	}


### PR DESCRIPTION
Throw a generic "Cannot indirectly modify string offset" error rather than trying to be more precise about the exact kind of indirect modification that is being attempted.

The motivation here is that we might optimize away the using opcode, in which case we wouldn't be able to preserve the exact message. I don't think the precision here is worth the bother of preventing such optimizations.