### PR TITLE
Add Backed Enum test case when implementing an interface

### DIFF
--- a/Zend/tests/enum/backed-implements-multiple.phpt
+++ b/Zend/tests/enum/backed-implements-multiple.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Backed Enum with multiple implementing interfaces
+--FILE--
+<?php
+
+interface Colorful {
+    public function color(): string;
+}
+
+interface Shaped {
+    public function shape(): string;
+}
+
+interface ExtendedShaped extends Shaped {
+}
+
+enum Suit: string implements Colorful, ExtendedShaped {
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+
+    public function color(): string {
+        return match ($this) {
+            self::Hearts, self::Diamonds => 'Red',
+            self::Clubs, self::Spades => 'Black',
+        };
+    }
+
+    public function shape(): string {
+        return match ($this) {
+            self::Hearts => 'heart',
+            self::Diamonds => 'diamond',
+            self::Clubs => 'club',
+            self::Spades => 'spade',
+        };
+    }
+}
+
+echo Suit::Hearts->color() . "\n";
+echo Suit::Hearts->shape() . "\n";
+echo Suit::Diamonds->color() . "\n";
+echo Suit::Diamonds->shape() . "\n";
+echo Suit::Clubs->color() . "\n";
+echo Suit::Clubs->shape() . "\n";
+echo Suit::Spades->color() . "\n";
+echo Suit::Spades->shape() . "\n";
+
+?>
+--EXPECT--
+Red
+heart
+Red
+diamond
+Black
+club
+Black
+spade

--- a/Zend/tests/enum/backed-implements.phpt
+++ b/Zend/tests/enum/backed-implements.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Backed Enum implements
+--FILE--
+<?php
+
+interface Colorful {
+    public function color(): string;
+}
+
+enum Suit: string implements Colorful {
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+
+    public function color(): string {
+        return match ($this) {
+            self::Hearts, self::Diamonds => 'Red',
+            self::Clubs, self::Spades => 'Black',
+        };
+    }
+}
+
+echo Suit::Hearts->color() . "\n";
+echo Suit::Diamonds->color() . "\n";
+echo Suit::Clubs->color() . "\n";
+echo Suit::Spades->color() . "\n";
+
+?>
+--EXPECT--
+Red
+Red
+Black
+Black


### PR DESCRIPTION
In the Enumeration RFC, it states Backed Enums can implement
interfaces, but it was not clear where the backed Enum type
would need to be placed in such situation.

This commit adds a test cases for those scenarios.