### PR TITLE
[Curl] Add `CURLINFO_EFFECTIVE_METHOD`

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -23,6 +23,10 @@ PHP 8.2 UPGRADE NOTES
 2. New Features
 ========================================
 
+- Curl:
+  . Added CURLINFO_EFFECTIVE_METHOD option and returning the effective
+    HTTP method in curl_getinfo() return value.
+
 ========================================
 3. Changes in SAPI modules
 ========================================

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -552,6 +552,9 @@ PHP_MINIT_FUNCTION(curl)
 	REGISTER_CURL_CONSTANT(CURLINFO_SSL_VERIFYRESULT);
 	REGISTER_CURL_CONSTANT(CURLINFO_STARTTRANSFER_TIME);
 	REGISTER_CURL_CONSTANT(CURLINFO_TOTAL_TIME);
+#if LIBCURL_VERSION_NUM >= 0x074800 /* Available since 7.72.0 */
+	REGISTER_CURL_CONSTANT(CURLINFO_EFFECTIVE_METHOD);
+#endif
 
 	/* Other */
 	REGISTER_CURL_CONSTANT(CURLMSG_DONE);
@@ -3257,6 +3260,11 @@ PHP_FUNCTION(curl_getinfo)
 		if (ch->header.str) {
 			CAASTR("request_header", ch->header.str);
 		}
+#if LIBCURL_VERSION_NUM >= 0x074800 /* Available since 7.72.0 */
+		if (curl_easy_getinfo(ch->cp, CURLINFO_EFFECTIVE_METHOD, &s_code) == CURLE_OK) {
+			CAAS("effective_method", s_code);
+		}
+#endif
 	} else {
 		switch (option) {
 			case CURLINFO_HEADER_OUT:

--- a/ext/curl/tests/curl_basic_025.phpt
+++ b/ext/curl/tests/curl_basic_025.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test curl_getinfo() function with CURLINFO_* from curl >= 7.72.0
+--EXTENSIONS--
+curl
+--SKIPIF--
+<?php $curl_version = curl_version();
+if ($curl_version['version_number'] < 0x074800) {
+        exit("skip: test works only with curl >= 7.72.0");
+}
+?>
+--FILE--
+<?php
+
+include 'server.inc';
+
+$ch = curl_init();
+$host = curl_cli_server_start();
+
+$url = "{$host}/get.inc?test=";
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_POSTFIELDS, "data");
+curl_exec($ch);
+var_dump(curl_getinfo($ch, CURLINFO_EFFECTIVE_METHOD));
+curl_close($ch);
+?>
+--EXPECT--
+string(4) "POST"


### PR DESCRIPTION
Since Curl 7.72.0, it supports a new parameter called `CURLINFO_EFFECTIVE_METHOD`, which returns the effect method in HTTP(s) requests. This is similar to `CURLINFO_EFFECTIVE_URL`.

https://curl.se/libcurl/c/CURLINFO_EFFECTIVE_METHOD.html

This adds support for CURLINFO_EFFECTIVE_URL if ext/curl is built with libcurl >= 7.72.0 (`0x074800`).

```php
$url = "https://example.com";
curl_setopt($ch, CURLOPT_URL, $url);
curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
curl_setopt($ch, CURLOPT_POSTFIELDS, "data");
curl_exec($ch);
var_dump(curl_getinfo($ch, CURLINFO_EFFECTIVE_METHOD)); // "POST"
```