### PR TITLE
Bug #81458: Add test

### DIFF
--- a/ext/date/tests/bug81458.phpt
+++ b/ext/date/tests/bug81458.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #81458: Incorrect difference after timezone change
+--FILE--
+<?php
+
+$first = (new DateTime('2018-07-01 00:00:00.000000 America/Toronto'))
+    ->setTimezone(new DateTimeZone('UTC'));
+$second = new DateTime('2018-07-02 00:00:00.000000 America/Toronto');
+
+var_dump($first->diff($second)->days);
+var_dump($first->diff($second)->d);
+?>
+--EXPECT--
+int(1)
+int(1)


### PR DESCRIPTION
Add test to reproduce the bug [`81458`](https://bugs.php.net/bug.php?id=81458).

#### Description: 

In PHP 8.0 `diff()->days` returned the total number of days between dates even if one of them were in UTC and not the other.

In PHP 8.1 `diff()->d` is still OK but `diff()->days` is now `0`.

https://3v4l.org/PHsfG
