### PR TITLE
Fix #76167: mbstring may use pointer from some previous request

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -5208,10 +5208,6 @@ static void php_mb_populate_current_detect_order_list(void)
 	const mbfl_encoding **entry = 0;
 	size_t nentries;
 
-	if (MBSTRG(current_detect_order_list)) {
-		return;
-	}
-
 	if (MBSTRG(detect_order_list) && MBSTRG(detect_order_list_size)) {
 		nentries = MBSTRG(detect_order_list_size);
 		entry = (const mbfl_encoding **)safe_emalloc(nentries, sizeof(mbfl_encoding*), 0);


### PR DESCRIPTION
We must not reuse per-request memory across multiple requests, so this
check triggered during RINIT makes no sense.  As explained in the bug
report[1], it can be even harmful, if some request startup fails, and
the pointers refer to already freed memory in the next request.

[1] <https://bugs.php.net/76167>