### PR TITLE
Remove (ZEND_)WRONG_PARAM_COUNT_WITH_RETVAL macros

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -14,6 +14,7 @@ PHP 8.2 INTERNALS UPGRADE NOTES
   around zend_binary_str(n)casecmp_l() -- rather than
   zend_binary_str(n)casecmp() as one would expect. Call the appropriate
   wrapped function directly instead.
+* Removed the (ZEND_)WRONG_PARAM_COUNT_WITH_RETVAL() macros.
 
 ========================
 2. Build system changes

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -472,10 +472,8 @@ ZEND_API const char *zend_get_type_by_const(int type);
 #define ZEND_IS_METHOD_CALL()				(EX(func)->common.scope != NULL)
 
 #define WRONG_PARAM_COUNT					ZEND_WRONG_PARAM_COUNT()
-#define WRONG_PARAM_COUNT_WITH_RETVAL(ret)	ZEND_WRONG_PARAM_COUNT_WITH_RETVAL(ret)
 #define ZEND_NUM_ARGS()						EX_NUM_ARGS()
 #define ZEND_WRONG_PARAM_COUNT()					{ zend_wrong_param_count(); return; }
-#define ZEND_WRONG_PARAM_COUNT_WITH_RETVAL(ret)		{ zend_wrong_param_count(); return ret; }
 
 #ifndef ZEND_WIN32
 #define DLEXPORT


### PR DESCRIPTION
A TypeError is always emitted therefore assigning a retval is pointless and incorrect.