### PR TITLE
Updated README.md with information on how to get help

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ contribute:
 - [Mailing list rules](/docs/mailinglist-rules.md)
 - [PHP release process](/docs/release-process.md)
 
+## Help and support
+
+If you're looking for help with using PHP the [Help page](https://www.php.net/support)
+is a good place to start.
+
 ## Credits
 
 For the list of people who've put work into PHP, please see the


### PR DESCRIPTION
Added a section to the README linking to the help pages on the php.net website (https://www.php.net/support) to try and minimise PHP issues being raised from users looking for help with their code, rather than language-level issues. Similarly to try and reduce erroneous bugs being filed on bugs.php.net.