### PR TITLE
Correct the return types in the `pow()` stub

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1424,7 +1424,7 @@ function intdiv(int $num1, int $num2): int {}
 
 function is_infinite(float $num): bool {}
 
-function pow(mixed $num, mixed $exponent): int|float|object {}
+function pow(mixed $num, mixed $exponent): int|float {}
 
 function exp(float $num): float {}
 


### PR DESCRIPTION
As far as I can tell, the `pow()` function cannot return an object.