### PR TITLE
Accept null and 0 for microseconds argument in stream_select()

### DIFF
--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -790,9 +790,7 @@ PHP_FUNCTION(stream_select)
 	PHP_SAFE_MAX_FD(max_fd, max_set_count);
 
 	if (secnull && !usecnull) {
-		if (usec == 0) {
-			php_error_docref(NULL, E_DEPRECATED, "Argument #5 ($microseconds) should be null instead of 0 when argument #4 ($seconds) is null");
-		} else {
+		if (usec != 0) {
 			zend_argument_value_error(5, "must be null when argument #4 ($seconds) is null");
 			RETURN_THROWS();
 		}

--- a/ext/standard/tests/streams/stream_select_null_usec.phpt
+++ b/ext/standard/tests/streams/stream_select_null_usec.phpt
@@ -27,7 +27,6 @@ array(1) {
   resource(%d) of type (stream)
 }
 
-8192 stream_select(): Argument #5 ($microseconds) should be null instead of 0 when argument #4 ($seconds) is null
 
 Fatal error: Uncaught ValueError: stream_select(): Argument #5 ($microseconds) must be null when argument #4 ($seconds) is null in %s
 Stack trace:


### PR DESCRIPTION
The previously merged change #6879 makes it impossible to write code that will run on pre PHP8.1 and post PHP8.1 without (at least) a deprecation warning.

Old implementation (https://github.com/php/php-src/blob/PHP-7.4.25/ext/standard/streamsfuncs.c#L764):
`$tv_sec` is NULL-able INT
`$tv_usec` is OPTIONAL INT (can't be null)

New implementation (https://github.com/php/php-src/pull/6879/files#diff-4294bfe38876196fc83b34d3b3a8d16919acbc8aaa68ce2fc77859f0ef46b787R757)
`$tv_sec` is NULL-able INT
`$tv_usec` is NULL-able INT 

However the code also adds rules in case `$tv_sec` is NULL and `$tv_usec` is not NULL (https://github.com/php/php-src/pull/6879/files#diff-4294bfe38876196fc83b34d3b3a8d16919acbc8aaa68ce2fc77859f0ef46b787R792)
1. if it's 0 - a deprecation error emitted
2. if it's not 0 an exception is thrown

Here should be noted that the first argument `$tv_sec` acts as a gate-keeper to the `php_select` argument `tv_p` making the value of `$tv_usec` irrelevant in case `$tv_sec` is NULL.

While the second rule makes sense, as passing any number to `$tv_usec` effectively gets ignored and is logically incorrect, I have a problem with the first rule.

In pre PHP8.1 code if you passed both arguments to `stream_select` the the second HAD TO BE an integer.
Where in the current implementation - if we are talking the case where `$tv_sec` is NULL - it MUST NOT be, to avoid a deprecation warning. 

Here is a great example of what I am talking about: https://github.com/sabre-io/event/pull/88/files

This Pull-Request proposes to allow (without warnings) `$tv_usec` to be 0 even if `$tv_sec` is NULL as this keeps the behavior of pre and post PHP8.1 the same.