### PR TITLE
Error in substr_count() if offset == haystack length

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5416,7 +5416,7 @@ PHP_FUNCTION(substr_count)
 	if (offset < 0) {
 		offset += (zend_long)haystack_len;
 	}
-	if ((offset < 0) || ((size_t)offset > haystack_len)) {
+	if ((offset < 0) || ((size_t)offset >= haystack_len)) {
 		zend_argument_value_error(3, "must be contained in argument #1 ($haystack)");
 		RETURN_THROWS();
 	}

--- a/ext/standard/tests/strings/substr_count_error.phpt
+++ b/ext/standard/tests/strings/substr_count_error.phpt
@@ -13,6 +13,13 @@ try {
     echo $exception->getMessage() . "\n";
 }
 
+/* offset = size of the string */
+try {
+    substr_count($str, "t", 10);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
 /* offset > size of the string */
 try {
     substr_count($str, "t", 25);
@@ -40,6 +47,7 @@ echo "Done\n";
 ?>
 --EXPECT--
 *** Testing error conditions ***
+substr_count(): Argument #3 ($offset) must be contained in argument #1 ($haystack)
 substr_count(): Argument #3 ($offset) must be contained in argument #1 ($haystack)
 substr_count(): Argument #3 ($offset) must be contained in argument #1 ($haystack)
 substr_count(): Argument #4 ($length) must be contained in argument #1 ($haystack)


### PR DESCRIPTION
Since the offset starts with 0 an offset that is the same as the length
of the haystack should lead to the same error as any greater value does.