### PR TITLE
Add test for case that should fail

### DIFF
--- a/Zend/tests/type_declarations/default_typed_function_argument_null_value.phpt
+++ b/Zend/tests/type_declarations/default_typed_function_argument_null_value.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Default null for non nullable function arguments
+--FILE--
+<?php
+
+function anotherTest(DateTimeImmutable $datetime = null): DateTimeImmutable
+{
+    return $datetime ?? new DateTimeImmutable();
+}
+
+$test = anotherTest();
+
+echo "Succeeded!";
+?>
+--EXPECT--
+The operation should fail since $datetime is holding a different value than it's signature allows.

--- a/Zend/tests/type_declarations/default_typed_function_argument_null_value_strict.phpt
+++ b/Zend/tests/type_declarations/default_typed_function_argument_null_value_strict.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Default null for non nullable function arguments using strict types
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+function anotherTest(DateTimeImmutable $datetime = null): DateTimeImmutable
+{
+    return $datetime ?? new DateTimeImmutable();
+}
+
+$test = anotherTest();
+
+echo "Succeeded!";
+?>
+--EXPECT--
+The operation should fail since $datetime is holding a different value than it's signature allows.

--- a/Zend/tests/type_declarations/default_typed_method_argument_null_value.phpt
+++ b/Zend/tests/type_declarations/default_typed_method_argument_null_value.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Default null for non nullable method arguments
+--FILE--
+<?php
+
+final class Test
+{
+    private DateTimeImmutable $datetime;
+
+    public function __construct(DateTimeImmutable $datetime = null)
+    {
+        $this->datetime = $datetime ?? new DateTimeImmutable();
+    }
+}
+
+$test = new Test();
+
+echo "Succeeded!";
+?>
+--EXPECT--
+The operation should fail since $datetime is holding a different value than it's signature allows.

--- a/Zend/tests/type_declarations/default_typed_method_argument_null_value_strict.phpt
+++ b/Zend/tests/type_declarations/default_typed_method_argument_null_value_strict.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Default null for non nullable method arguments using strict types
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+final class Test
+{
+    private DateTimeImmutable $datetime;
+
+    public function __construct(DateTimeImmutable $datetime = null)
+    {
+        $this->datetime = $datetime ?? new DateTimeImmutable();
+    }
+}
+
+$test = new Test();
+
+echo "Succeeded!";
+?>
+--EXPECT--
+The operation should fail since $datetime is holding a different value than it's signature allows.


### PR DESCRIPTION
I found an occurrence of a code snippet as added in the tests, and
was surprised it worked. I wonder if this is something that is
known, since I would expect the examples in the commit to fail
because of the type signature not allowing null.

I wonder what the next steps could be.