### PR TITLE
Refactor DBA to use zend_string*

### DIFF
--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -424,8 +424,7 @@ static void php_dba_update(INTERNAL_FUNCTION_PARAMETERS, int mode)
 		}
 	}
 
-	RETVAL_BOOL(info->hnd->update(info, ZSTR_VAL(key_str), ZSTR_LEN(key_str),
-		ZSTR_VAL(value), ZSTR_LEN(value), mode) == SUCCESS);
+	RETVAL_BOOL(info->hnd->update(info, key_str, value, mode) == SUCCESS);
 	DBA_RELEASE_HT_KEY_CREATION();
 }
 /* }}} */

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -979,15 +979,13 @@ PHP_FUNCTION(dba_fetch)
 		}
 	}
 
-	char *val;
-	size_t len = 0;
-	if ((val = info->hnd->fetch(info, ZSTR_VAL(key_str), ZSTR_LEN(key_str), skip, &len)) == NULL) {
+	zend_string *val;
+	if ((val = info->hnd->fetch(info, key_str, skip)) == NULL) {
 		DBA_RELEASE_HT_KEY_CREATION();
 		RETURN_FALSE;
 	}
 	DBA_RELEASE_HT_KEY_CREATION();
-	RETVAL_STRINGL(val, len);
-	efree(val);
+	RETURN_STR(val);
 }
 /* }}} */
 

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -1020,8 +1020,6 @@ PHP_FUNCTION(dba_key_split)
 /* {{{ Resets the internal key pointer and returns the first key */
 PHP_FUNCTION(dba_firstkey)
 {
-	char *fkey;
-	size_t len;
 	zval *id;
 	dba_info *info = NULL;
 
@@ -1031,12 +1029,10 @@ PHP_FUNCTION(dba_firstkey)
 
 	DBA_FETCH_RESOURCE(info, id);
 
-	fkey = info->hnd->firstkey(info, &len);
+	zend_string *fkey = info->hnd->firstkey(info);
 
 	if (fkey) {
-		RETVAL_STRINGL(fkey, len);
-		efree(fkey);
-		return;
+		RETURN_STR(fkey);
 	}
 
 	RETURN_FALSE;
@@ -1046,8 +1042,6 @@ PHP_FUNCTION(dba_firstkey)
 /* {{{ Returns the next key */
 PHP_FUNCTION(dba_nextkey)
 {
-	char *nkey;
-	size_t len;
 	zval *id;
 	dba_info *info = NULL;
 
@@ -1057,12 +1051,10 @@ PHP_FUNCTION(dba_nextkey)
 
 	DBA_FETCH_RESOURCE(info, id);
 
-	nkey = info->hnd->nextkey(info, &len);
+	zend_string *nkey = info->hnd->nextkey(info);
 
 	if (nkey) {
-		RETVAL_STRINGL(nkey, len);
-		efree(nkey);
-		return;
+		RETURN_STR(nkey);
 	}
 
 	RETURN_FALSE;

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -912,7 +912,7 @@ PHP_FUNCTION(dba_exists)
 		}
 	}
 
-	RETVAL_BOOL(info->hnd->exists(info, ZSTR_VAL(key_str), ZSTR_LEN(key_str)) == SUCCESS);
+	RETVAL_BOOL(info->hnd->exists(info, key_str) == SUCCESS);
 	DBA_RELEASE_HT_KEY_CREATION();
 }
 /* }}} */

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -1094,7 +1094,7 @@ PHP_FUNCTION(dba_delete)
 		}
 	}
 
-	RETVAL_BOOL(info->hnd->delete(info, ZSTR_VAL(key_str), ZSTR_LEN(key_str)) == SUCCESS);
+	RETVAL_BOOL(info->hnd->delete(info, key_str) == SUCCESS);
 	DBA_RELEASE_HT_KEY_CREATION();
 }
 /* }}} */

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -180,7 +180,7 @@ DBA_UPDATE_FUNC(cdb)
 		return FAILURE; /* database was opened readonly */
 	if (!mode)
 		return FAILURE; /* cdb_make doesn't know replace */
-	if (cdb_make_add(&cdb->m, key, keylen, val, vallen) != -1)
+	if (cdb_make_add(&cdb->m, ZSTR_VAL(key), ZSTR_LEN(key), ZSTR_VAL(val), ZSTR_LEN(val)) != -1)
 		return SUCCESS;
 #endif
 	return FAILURE;

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -194,7 +194,7 @@ DBA_EXISTS_FUNC(cdb)
 	if (cdb->make)
 		return FAILURE; /* database was opened writeonly */
 #endif
-	if (php_cdb_find(&cdb->c, key, keylen) == 1)
+	if (php_cdb_find(&cdb->c, ZSTR_VAL(key), ZSTR_LEN(key)) == 1)
 		return SUCCESS;
 	return FAILURE;
 }

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -241,7 +241,7 @@ DBA_FIRSTKEY_FUNC(cdb)
 	CDB_INFO;
 	uint32 klen, dlen;
 	char buf[8];
-	char *key;
+	zend_string *key;
 
 #if DBA_CDB_BUILTIN
 	if (cdb->make)
@@ -262,13 +262,12 @@ DBA_FIRSTKEY_FUNC(cdb)
 	uint32_unpack(buf, &klen);
 	uint32_unpack(buf + 4, &dlen);
 
-	key = safe_emalloc(klen, 1, 1);
-	if (cdb_file_read(cdb->file, key, klen) < klen) {
-		efree(key);
+	key = zend_string_alloc(klen, /* persistent */ false);
+	if (cdb_file_read(cdb->file, ZSTR_VAL(key), klen) < klen) {
+		zend_string_release_ex(key, /* persistent */ false);
 		key = NULL;
 	} else {
-		key[klen] = '\0';
-		if (newlen) *newlen = klen;
+		ZSTR_VAL(key)[klen] = 0;
 	}
 
 	/*       header + klenlen + dlenlen + klen + dlen */
@@ -282,7 +281,7 @@ DBA_NEXTKEY_FUNC(cdb)
 	CDB_INFO;
 	uint32 klen, dlen;
 	char buf[8];
-	char *key;
+	zend_string *key;
 
 #if DBA_CDB_BUILTIN
 	if (cdb->make)
@@ -294,13 +293,12 @@ DBA_NEXTKEY_FUNC(cdb)
 	uint32_unpack(buf, &klen);
 	uint32_unpack(buf + 4, &dlen);
 
-	key = safe_emalloc(klen, 1, 1);
-	if (cdb_file_read(cdb->file, key, klen) < klen) {
-		efree(key);
+	key = zend_string_alloc(klen, /* persistent */ false);
+	if (cdb_file_read(cdb->file, ZSTR_VAL(key), klen) < klen) {
+		zend_string_release_ex(key, /* persistent */ false);
 		key = NULL;
 	} else {
-		key[klen] = '\0';
-		if (newlen) *newlen = klen;
+		ZSTR_VAL(key)[klen] = 0;
 	}
 
 	cdb->pos += 8 + klen + dlen;

--- a/ext/dba/dba_db1.c
+++ b/ext/dba/dba_db1.c
@@ -88,13 +88,12 @@ DBA_FETCH_FUNC(db1)
 	DBT gval;
 	DBT gkey;
 
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	memset(&gval, 0, sizeof(gval));
 	if (dba->dbp->get(dba->dbp, &gkey, &gval, 0) == RET_SUCCESS) {
-		if (newlen) *newlen = gval.size;
-		return estrndup(gval.data, gval.size);
+		return zend_string_init(gval.data, gval.size, /* persistent */ false);
 	}
 	return NULL;
 }

--- a/ext/dba/dba_db1.c
+++ b/ext/dba/dba_db1.c
@@ -146,8 +146,7 @@ DBA_FIRSTKEY_FUNC(db1)
 	memset(&gval, 0, sizeof(gval));
 
 	if (dba->dbp->seq(dba->dbp, &gkey, &gval, R_FIRST) == RET_SUCCESS) {
-		if (newlen) *newlen = gkey.size;
-		return estrndup(gkey.data, gkey.size);
+		return zend_string_init(gkey.data, gkey.size, /* persistent */ false);
 	}
 	return NULL;
 }
@@ -162,8 +161,7 @@ DBA_NEXTKEY_FUNC(db1)
 	memset(&gval, 0, sizeof(gval));
 
 	if (dba->dbp->seq(dba->dbp, &gkey, &gval, R_NEXT) == RET_SUCCESS) {
-		if (newlen) *newlen = gkey.size;
-		return estrndup(gkey.data, gkey.size);
+		return zend_string_init(gkey.data, gkey.size, /* persistent */ false);
 	}
 	return NULL;
 }

--- a/ext/dba/dba_db1.c
+++ b/ext/dba/dba_db1.c
@@ -130,8 +130,8 @@ DBA_DELETE_FUNC(db1)
 	dba_db1_data *dba = info->dbf;
 	DBT gkey;
 
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	return dba->dbp->del(dba->dbp, &gkey, 0) != RET_SUCCESS ? FAILURE : SUCCESS;
 }

--- a/ext/dba/dba_db1.c
+++ b/ext/dba/dba_db1.c
@@ -104,11 +104,11 @@ DBA_UPDATE_FUNC(db1)
 	DBT gval;
 	DBT gkey;
 
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
-	gval.data = (char *) val;
-	gval.size = vallen;
+	gval.data = ZSTR_VAL(val);
+	gval.size = ZSTR_LEN(val);
 
 	return dba->dbp->put(dba->dbp, &gkey, &gval, mode == 1 ? R_NOOVERWRITE : 0) != RET_SUCCESS ? FAILURE : SUCCESS;
 }

--- a/ext/dba/dba_db1.c
+++ b/ext/dba/dba_db1.c
@@ -119,8 +119,8 @@ DBA_EXISTS_FUNC(db1)
 	DBT gval;
 	DBT gkey;
 
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	return dba->dbp->get(dba->dbp, &gkey, &gval, 0) != RET_SUCCESS ? FAILURE : SUCCESS;
 }

--- a/ext/dba/dba_db2.c
+++ b/ext/dba/dba_db2.c
@@ -159,8 +159,7 @@ DBA_FIRSTKEY_FUNC(db2)
 		return NULL;
 	}
 
-	/* we should introduce something like PARAM_PASSTHRU... */
-	return dba_nextkey_db2(info, newlen);
+	return dba_nextkey_db2(info);
 }
 
 DBA_NEXTKEY_FUNC(db2)
@@ -169,11 +168,11 @@ DBA_NEXTKEY_FUNC(db2)
 	DBT gkey = {0}, gval = {0};
 
 	if (dba->cursor->c_get(dba->cursor, &gkey, &gval, DB_NEXT)
-			|| !gkey.data)
+			|| !gkey.data) {
 		return NULL;
+	}
 
-	if (newlen) *newlen = gkey.size;
-	return estrndup(gkey.data, gkey.size);
+	return zend_string_init(gkey.data, gkey.size, /* persistent */ false);
 }
 
 DBA_OPTIMIZE_FUNC(db2)

--- a/ext/dba/dba_db2.c
+++ b/ext/dba/dba_db2.c
@@ -122,8 +122,8 @@ DBA_EXISTS_FUNC(db2)
 	DBT gval = {0};
 	DBT gkey = {0};
 
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	if (dba->dbp->get(dba->dbp, NULL, &gkey, &gval, 0)) {
 		return FAILURE;

--- a/ext/dba/dba_db2.c
+++ b/ext/dba/dba_db2.c
@@ -103,11 +103,11 @@ DBA_UPDATE_FUNC(db2)
 	DBT gval = {0};
 	DBT gkey = {0};
 
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
-	gval.data = (char *) val;
-	gval.size = vallen;
+	gval.data = ZSTR_VAL(val);
+	gval.size = ZSTR_LEN(val);
 
 	if (dba->dbp->put(dba->dbp, NULL, &gkey, &gval,
 				mode == 1 ? DB_NOOVERWRITE : 0)) {

--- a/ext/dba/dba_db2.c
+++ b/ext/dba/dba_db2.c
@@ -136,8 +136,8 @@ DBA_DELETE_FUNC(db2)
 	dba_db2_data *dba = info->dbf;
 	DBT gkey = {0};
 
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	return dba->dbp->del(dba->dbp, NULL, &gkey, 0) ? FAILURE : SUCCESS;
 }

--- a/ext/dba/dba_db2.c
+++ b/ext/dba/dba_db2.c
@@ -87,15 +87,14 @@ DBA_FETCH_FUNC(db2)
 	DBT gval = {0};
 	DBT gkey = {0};
 
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	if (dba->dbp->get(dba->dbp, NULL, &gkey, &gval, 0)) {
 		return NULL;
 	}
 
-	if (newlen) *newlen = gval.size;
-	return estrndup(gval.data, gval.size);
+	return zend_string_init(gval.data, gval.size, /* persistent */ false);
 }
 
 DBA_UPDATE_FUNC(db2)

--- a/ext/dba/dba_db3.c
+++ b/ext/dba/dba_db3.c
@@ -174,7 +174,8 @@ DBA_DELETE_FUNC(db3)
 	DBT gkey;
 
 	memset(&gkey, 0, sizeof(gkey));
-	gkey.data = (char *) key; gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	return dba->dbp->del(dba->dbp, NULL, &gkey, 0) ? FAILURE : SUCCESS;
 }

--- a/ext/dba/dba_db3.c
+++ b/ext/dba/dba_db3.c
@@ -117,18 +117,17 @@ DBA_FETCH_FUNC(db3)
 {
 	dba_db3_data *dba = info->dbf;
 	DBT gval;
-	char *new = NULL;
 	DBT gkey;
 
 	memset(&gkey, 0, sizeof(gkey));
-	gkey.data = (char *) key; gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	memset(&gval, 0, sizeof(gval));
 	if (!dba->dbp->get(dba->dbp, NULL, &gkey, &gval, 0)) {
-		if (newlen) *newlen = gval.size;
-		new = estrndup(gval.data, gval.size);
+		return zend_string_init(gval.data, gval.size, /* persistent */ false);
 	}
-	return new;
+	return NULL;
 }
 
 DBA_UPDATE_FUNC(db3)

--- a/ext/dba/dba_db3.c
+++ b/ext/dba/dba_db3.c
@@ -137,11 +137,12 @@ DBA_UPDATE_FUNC(db3)
 	DBT gkey;
 
 	memset(&gkey, 0, sizeof(gkey));
-	gkey.data = (char *) key; gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	memset(&gval, 0, sizeof(gval));
-	gval.data = (char *) val;
-	gval.size = vallen;
+	gval.data = ZSTR_VAL(val);
+	gval.size = ZSTR_LEN(val);
 
 	if (!dba->dbp->put(dba->dbp, NULL, &gkey, &gval,
 				mode == 1 ? DB_NOOVERWRITE : 0)) {

--- a/ext/dba/dba_db3.c
+++ b/ext/dba/dba_db3.c
@@ -193,27 +193,24 @@ DBA_FIRSTKEY_FUNC(db3)
 		return NULL;
 	}
 
-	/* we should introduce something like PARAM_PASSTHRU... */
-	return dba_nextkey_db3(info, newlen);
+	return dba_nextkey_db3(info);
 }
 
 DBA_NEXTKEY_FUNC(db3)
 {
 	dba_db3_data *dba = info->dbf;
 	DBT gkey, gval;
-	char *nkey = NULL;
 
 	memset(&gkey, 0, sizeof(gkey));
 	memset(&gval, 0, sizeof(gval));
 
 	if (dba->cursor->c_get(dba->cursor, &gkey, &gval, DB_NEXT) == 0) {
 		if (gkey.data) {
-			nkey = estrndup(gkey.data, gkey.size);
-			if (newlen) *newlen = gkey.size;
+			return zend_string_init(gkey.data, gkey.size, /* persistent */ false);
 		}
 	}
 
-	return nkey;
+	return NULL;
 }
 
 DBA_OPTIMIZE_FUNC(db3)

--- a/ext/dba/dba_db3.c
+++ b/ext/dba/dba_db3.c
@@ -158,7 +158,8 @@ DBA_EXISTS_FUNC(db3)
 	DBT gkey;
 
 	memset(&gkey, 0, sizeof(gkey));
-	gkey.data = (char *) key; gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	memset(&gval, 0, sizeof(gval));
 	if (!dba->dbp->get(dba->dbp, NULL, &gkey, &gval, 0)) {

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -237,15 +237,14 @@ DBA_FIRSTKEY_FUNC(db4)
 		return NULL;
 	}
 
-	/* we should introduce something like PARAM_PASSTHRU... */
-	return dba_nextkey_db4(info, newlen);
+	return dba_nextkey_db4(info);
 }
 
 DBA_NEXTKEY_FUNC(db4)
 {
 	dba_db4_data *dba = info->dbf;
 	DBT gkey, gval;
-	char *nkey = NULL;
+	zend_string *key = NULL;
 
 	memset(&gkey, 0, sizeof(gkey));
 	memset(&gval, 0, sizeof(gval));
@@ -256,8 +255,7 @@ DBA_NEXTKEY_FUNC(db4)
 	}
 	if (dba->cursor && dba->cursor->c_get(dba->cursor, &gkey, &gval, DB_NEXT) == 0) {
 		if (gkey.data) {
-			nkey = estrndup(gkey.data, gkey.size);
-			if (newlen) *newlen = gkey.size;
+			key = zend_string_init(gkey.data, gkey.size, /* persistent */ false);
 		}
 		if (info->flags & DBA_PERSISTENT) {
 			if (gkey.data) {
@@ -269,7 +267,7 @@ DBA_NEXTKEY_FUNC(db4)
 		}
 	}
 
-	return nkey;
+	return key;
 }
 
 DBA_OPTIMIZE_FUNC(db4)

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -218,8 +218,8 @@ DBA_DELETE_FUNC(db4)
 	DBT gkey;
 
 	memset(&gkey, 0, sizeof(gkey));
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	return dba->dbp->del(dba->dbp, NULL, &gkey, 0) ? FAILURE : SUCCESS;
 }

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -173,12 +173,12 @@ DBA_UPDATE_FUNC(db4)
 	DBT gkey;
 
 	memset(&gkey, 0, sizeof(gkey));
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	memset(&gval, 0, sizeof(gval));
-	gval.data = (char *) val;
-	gval.size = vallen;
+	gval.data = ZSTR_VAL(val);
+	gval.size = ZSTR_LEN(val);
 
 	if (!dba->dbp->put(dba->dbp, NULL, &gkey, &gval,
 				mode == 1 ? DB_NOOVERWRITE : 0)) {

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -146,25 +146,24 @@ DBA_FETCH_FUNC(db4)
 {
 	dba_db4_data *dba = info->dbf;
 	DBT gval;
-	char *new = NULL;
 	DBT gkey;
+	zend_string *fetched_value = NULL;
 
 	memset(&gkey, 0, sizeof(gkey));
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	memset(&gval, 0, sizeof(gval));
 	if (info->flags & DBA_PERSISTENT) {
 		gval.flags |= DB_DBT_MALLOC;
 	}
 	if (!dba->dbp->get(dba->dbp, NULL, &gkey, &gval, 0)) {
-		if (newlen) *newlen = gval.size;
-		new = estrndup(gval.data, gval.size);
+		fetched_value = zend_string_init(gval.data, gval.size, /* persistent */ false);
 		if (info->flags & DBA_PERSISTENT) {
 			free(gval.data);
 		}
 	}
-	return new;
+	return fetched_value;
 }
 
 DBA_UPDATE_FUNC(db4)

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -194,8 +194,8 @@ DBA_EXISTS_FUNC(db4)
 	DBT gkey;
 
 	memset(&gkey, 0, sizeof(gkey));
-	gkey.data = (char *) key;
-	gkey.size = keylen;
+	gkey.data = ZSTR_VAL(key);
+	gkey.size = ZSTR_LEN(key);
 
 	memset(&gval, 0, sizeof(gval));
 

--- a/ext/dba/dba_dbm.c
+++ b/ext/dba/dba_dbm.c
@@ -145,15 +145,15 @@ DBA_FIRSTKEY_FUNC(dbm)
 {
 	dba_dbm_data *dba = info->dbf;
 	datum gkey;
-	char *key = NULL;
+	zend_string *key = NULL;
 
 	gkey = firstkey();
-	if(gkey.dptr) {
-		if(newlen) *newlen = gkey.dsize;
-		key = estrndup(gkey.dptr, gkey.dsize);
+	if (gkey.dptr) {
+		key = zend_string_init(gkey.dptr, gkey.dsize, /* persistent */ false);
 		dba->nextkey = gkey;
-	} else
+	} else {
 		dba->nextkey.dptr = NULL;
+	}
 	return key;
 }
 
@@ -161,18 +161,18 @@ DBA_NEXTKEY_FUNC(dbm)
 {
 	dba_dbm_data *dba = info->dbf;
 	datum gkey;
-	char *nkey = NULL;
+	zend_string *key = NULL;
 
-	if(!dba->nextkey.dptr) return NULL;
+	if (!dba->nextkey.dptr) { return NULL; }
 
 	gkey = nextkey(dba->nextkey);
-	if(gkey.dptr) {
-		if(newlen) *newlen = gkey.dsize;
-		nkey = estrndup(gkey.dptr, gkey.dsize);
+	if (gkey.dptr) {
+		key = zend_string_init(gkey.dptr, gkey.dsize, /* persistent */ false);
 		dba->nextkey = gkey;
-	} else
+	} else {
 		dba->nextkey.dptr = NULL;
-	return nkey;
+	}
+	return key;
 }
 
 DBA_OPTIMIZE_FUNC(dbm)

--- a/ext/dba/dba_dbm.c
+++ b/ext/dba/dba_dbm.c
@@ -101,18 +101,18 @@ DBA_UPDATE_FUNC(dbm)
 	datum gval;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 
 	if (mode == 1) { /* insert */
 		gval = fetch(gkey);
-		if(gval.dptr) {
+		if (gval.dptr) {
 			return FAILURE;
 		}
 	}
 
-	gval.dptr = (char *) val;
-	gval.dsize = vallen;
+	gval.dptr = ZSTR_VAL(val);
+	gval.dsize = ZSTR_LEN(val);
 
 	return (store(gkey, gval) == -1 ? FAILURE : SUCCESS);
 }

--- a/ext/dba/dba_dbm.c
+++ b/ext/dba/dba_dbm.c
@@ -85,17 +85,15 @@ DBA_CLOSE_FUNC(dbm)
 DBA_FETCH_FUNC(dbm)
 {
 	datum gval;
-	char *new = NULL;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 	gval = fetch(gkey);
-	if(gval.dptr) {
-		if(newlen) *newlen = gval.dsize;
-		new = estrndup(gval.dptr, gval.dsize);
+	if (gval.dptr) {
+		return zend_string_init(gval.dptr, gval.dsize, /* persistent */ false);
 	}
-	return new;
+	return NULL;
 }
 
 DBA_UPDATE_FUNC(dbm)

--- a/ext/dba/dba_dbm.c
+++ b/ext/dba/dba_dbm.c
@@ -136,8 +136,8 @@ DBA_DELETE_FUNC(dbm)
 {
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 	return(delete(gkey) == -1 ? FAILURE : SUCCESS);
 }
 

--- a/ext/dba/dba_dbm.c
+++ b/ext/dba/dba_dbm.c
@@ -122,11 +122,11 @@ DBA_EXISTS_FUNC(dbm)
 	datum gval;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 
 	gval = fetch(gkey);
-	if(gval.dptr) {
+	if (gval.dptr) {
 		return SUCCESS;
 	}
 	return FAILURE;

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -56,21 +56,18 @@ DBA_FETCH_FUNC(flatfile)
 {
 	flatfile *dba = info->dbf;
 	datum gval;
-	char *new = NULL;
 	datum gkey;
+	zend_string *fetched_val = NULL;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 
 	gval = flatfile_fetch(dba, gkey);
 	if (gval.dptr) {
-		if (newlen) {
-			*newlen = gval.dsize;
-		}
-		new = estrndup(gval.dptr, gval.dsize);
+		fetched_val = zend_string_init(gval.dptr, gval.dsize, /* persistent */ false);
 		efree(gval.dptr);
 	}
-	return new;
+	return fetched_val;
 }
 
 DBA_UPDATE_FUNC(flatfile)

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -103,8 +103,8 @@ DBA_EXISTS_FUNC(flatfile)
 	datum gval;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 	gval = flatfile_fetch(dba, gkey);
 	if (gval.dptr) {
 		efree(gval.dptr);

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -118,8 +118,8 @@ DBA_DELETE_FUNC(flatfile)
 	flatfile *dba = info->dbf;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 	return(flatfile_delete(dba, gkey) == -1 ? FAILURE : SUCCESS);
 }
 

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -76,10 +76,10 @@ DBA_UPDATE_FUNC(flatfile)
 	datum gval;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
-	gval.dptr = (char *) val;
-	gval.dsize = vallen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
+	gval.dptr = ZSTR_VAL(val);
+	gval.dsize = ZSTR_LEN(val);
 
 	switch(flatfile_store(dba, gkey, gval, mode==1 ? FLATFILE_INSERT : FLATFILE_REPLACE)) {
 		case 0:
@@ -87,10 +87,12 @@ DBA_UPDATE_FUNC(flatfile)
 		case 1:
 			return FAILURE;
 		case -1:
-			php_error_docref1(NULL, key, E_WARNING, "Operation not possible");
+			// TODO Check when this happens and confirm this can even happen
+			php_error_docref(NULL, E_WARNING, "Operation not possible");
 			return FAILURE;
 		default:
-			php_error_docref2(NULL, key, val, E_WARNING, "Unknown return value");
+			// TODO Convert this to an assertion failure
+			php_error_docref(NULL, E_WARNING, "Unknown return value");
 			return FAILURE;
 	}
 }

--- a/ext/dba/dba_flatfile.c
+++ b/ext/dba/dba_flatfile.c
@@ -132,10 +132,7 @@ DBA_FIRSTKEY_FUNC(flatfile)
 	}
 	dba->nextkey = flatfile_firstkey(dba);
 	if (dba->nextkey.dptr) {
-		if (newlen)  {
-			*newlen = dba->nextkey.dsize;
-		}
-		return estrndup(dba->nextkey.dptr, dba->nextkey.dsize);
+		return zend_string_init(dba->nextkey.dptr, dba->nextkey.dsize, /* persistent */ false);
 	}
 	return NULL;
 }
@@ -153,10 +150,7 @@ DBA_NEXTKEY_FUNC(flatfile)
 	}
 	dba->nextkey = flatfile_nextkey(dba);
 	if (dba->nextkey.dptr) {
-		if (newlen) {
-			*newlen = dba->nextkey.dsize;
-		}
-		return estrndup(dba->nextkey.dptr, dba->nextkey.dsize);
+		return zend_string_init(dba->nextkey.dptr, dba->nextkey.dsize, /* persistent */ false);
 	}
 	return NULL;
 }

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -138,16 +138,15 @@ DBA_FIRSTKEY_FUNC(gdbm)
 {
 	dba_gdbm_data *dba = info->dbf;
 	datum gkey;
-	char *key = NULL;
+	zend_string *key = NULL;
 
-	if(dba->nextkey.dptr) {
+	if (dba->nextkey.dptr) {
 		free(dba->nextkey.dptr);
 	}
 
 	gkey = gdbm_firstkey(dba->dbf);
-	if(gkey.dptr) {
-		key = estrndup(gkey.dptr, gkey.dsize);
-		if(newlen) *newlen = gkey.dsize;
+	if (gkey.dptr) {
+		key = zend_string_init(gkey.dptr, gkey.dsize, /* persistent */ false);
 		dba->nextkey = gkey;
 	} else {
 		dba->nextkey.dptr = NULL;
@@ -158,21 +157,20 @@ DBA_FIRSTKEY_FUNC(gdbm)
 DBA_NEXTKEY_FUNC(gdbm)
 {
 	dba_gdbm_data *dba = info->dbf;
-	char *nkey = NULL;
+	zend_string *key = NULL;
 	datum gkey;
 
-	if(!dba->nextkey.dptr) return NULL;
+	if(!dba->nextkey.dptr) { return NULL; }
 
 	gkey = gdbm_nextkey(dba->dbf, dba->nextkey);
 	free(dba->nextkey.dptr);
-	if(gkey.dptr) {
-		nkey = estrndup(gkey.dptr, gkey.dsize);
-		if(newlen) *newlen = gkey.dsize;
+	if (gkey.dptr) {
+		key = zend_string_init(gkey.dptr, gkey.dsize, /* persistent */ false);
 		dba->nextkey = gkey;
 	} else {
 		dba->nextkey.dptr = NULL;
 	}
-	return nkey;
+	return key;
 }
 
 DBA_OPTIMIZE_FUNC(gdbm)

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -117,8 +117,8 @@ DBA_EXISTS_FUNC(gdbm)
 	dba_gdbm_data *dba = info->dbf;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 
 	return gdbm_exists(dba->dbf, gkey) ? SUCCESS : FAILURE;
 }

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -128,8 +128,8 @@ DBA_DELETE_FUNC(gdbm)
 	dba_gdbm_data *dba = info->dbf;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 
 	return gdbm_delete(dba->dbf, gkey) == -1 ? FAILURE : SUCCESS;
 }

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -71,18 +71,18 @@ DBA_FETCH_FUNC(gdbm)
 {
 	dba_gdbm_data *dba = info->dbf;
 	datum gval;
-	char *new = NULL;
 	datum gkey;
+	zend_string *fetched_val = NULL;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
+
 	gval = gdbm_fetch(dba->dbf, gkey);
-	if(gval.dptr) {
-		if(newlen) *newlen = gval.dsize;
-		new = estrndup(gval.dptr, gval.dsize);
+	if (gval.dptr) {
+		fetched_val = zend_string_init(gval.dptr, gval.dsize, /* persistent */ false);
 		free(gval.dptr);
 	}
-	return new;
+	return fetched_val;
 }
 
 DBA_UPDATE_FUNC(gdbm)

--- a/ext/dba/dba_gdbm.c
+++ b/ext/dba/dba_gdbm.c
@@ -91,10 +91,10 @@ DBA_UPDATE_FUNC(gdbm)
 	datum gval;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
-	gval.dptr = (char *) val;
-	gval.dsize = vallen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
+	gval.dptr = ZSTR_VAL(val);
+	gval.dsize = ZSTR_LEN(val);
 
 	switch (gdbm_store(dba->dbf, gkey, gval, mode == 1 ? GDBM_INSERT : GDBM_REPLACE)) {
 		case 0:
@@ -102,10 +102,12 @@ DBA_UPDATE_FUNC(gdbm)
 		case 1:
 			return FAILURE;
 		case -1:
-			php_error_docref2(NULL, key, val, E_WARNING, "%s", gdbm_strerror(gdbm_errno));
+			// TODO Check when this happens and confirm this can even happen
+			php_error_docref(NULL, E_WARNING, "%s", gdbm_strerror(gdbm_errno));
 			return FAILURE;
 		default:
-			php_error_docref2(NULL, key, val, E_WARNING, "Unknown return value");
+			// TODO Convert this to an assertion failure
+			php_error_docref(NULL, E_WARNING, "Unknown return value");
 			return FAILURE;
 	}
 }

--- a/ext/dba/dba_inifile.c
+++ b/ext/dba/dba_inifile.c
@@ -51,17 +51,21 @@ DBA_FETCH_FUNC(inifile)
 	inifile *dba = info->dbf;
 	val_type ini_val;
 	key_type ini_key;
+	zend_string *fetched_val = NULL;
 
 	if (!key) {
 		php_error_docref(NULL, E_WARNING, "No key specified");
 		return 0;
 	}
-	ini_key = inifile_key_split((char*)key); /* keylen not needed here */
+	ini_key = inifile_key_split(ZSTR_VAL(key)); /* keylen not needed here */
 
 	ini_val = inifile_fetch(dba, &ini_key, skip);
-	*newlen = ini_val.value ? strlen(ini_val.value) : 0;
 	inifile_key_free(&ini_key);
-	return ini_val.value;
+	if (ini_val.value) {
+		fetched_val = zend_string_init(ini_val.value, strlen(ini_val.value), /* persistent */ false);
+		inifile_val_free(&ini_val);
+	}
+	return fetched_val;
 }
 
 DBA_UPDATE_FUNC(inifile)

--- a/ext/dba/dba_inifile.c
+++ b/ext/dba/dba_inifile.c
@@ -112,7 +112,7 @@ DBA_EXISTS_FUNC(inifile)
 		php_error_docref(NULL, E_WARNING, "No key specified");
 		return 0;
 	}
-	ini_key = inifile_key_split((char*)key); /* keylen not needed here */
+	ini_key = inifile_key_split(ZSTR_VAL(key)); /* keylen not needed here */
 
 	ini_val = inifile_fetch(dba, &ini_key, 0);
 	inifile_key_free(&ini_key);

--- a/ext/dba/dba_inifile.c
+++ b/ext/dba/dba_inifile.c
@@ -148,8 +148,9 @@ DBA_FIRSTKEY_FUNC(inifile)
 
 	if (inifile_firstkey(dba)) {
 		char *result = inifile_key_string(&dba->curr.key);
-		*newlen = strlen(result);
-		return result;
+		zend_string *key = zend_string_init(result, strlen(result), /* persistent */ false);
+		efree(result);
+		return key;
 	} else {
 		return NULL;
 	}
@@ -165,8 +166,9 @@ DBA_NEXTKEY_FUNC(inifile)
 
 	if (inifile_nextkey(dba)) {
 		char *result = inifile_key_string(&dba->curr.key);
-		*newlen = strlen(result);
-		return result;
+		zend_string *key = zend_string_init(result, strlen(result), /* persistent */ false);
+		efree(result);
+		return key;
 	} else {
 		return NULL;
 	}

--- a/ext/dba/dba_inifile.c
+++ b/ext/dba/dba_inifile.c
@@ -134,7 +134,7 @@ DBA_DELETE_FUNC(inifile)
 		php_error_docref(NULL, E_WARNING, "No key specified");
 		return 0;
 	}
-	ini_key = inifile_key_split((char*)key); /* keylen not needed here */
+	ini_key = inifile_key_split(ZSTR_VAL(key)); /* keylen not needed here */
 
 	res =  inifile_delete_ex(dba, &ini_key, &found);
 

--- a/ext/dba/dba_inifile.c
+++ b/ext/dba/dba_inifile.c
@@ -79,9 +79,9 @@ DBA_UPDATE_FUNC(inifile)
 		php_error_docref(NULL, E_WARNING, "No key specified");
 		return 0;
 	}
-	ini_key = inifile_key_split((char*)key); /* keylen not needed here */
+	ini_key = inifile_key_split(ZSTR_VAL(key)); /* keylen not needed here */
 
-	ini_val.value = val;
+	ini_val.value = ZSTR_VAL(val);
 
 	if (mode == 1) {
 		res = inifile_append(dba, &ini_key, &ini_val);
@@ -91,7 +91,8 @@ DBA_UPDATE_FUNC(inifile)
 	inifile_key_free(&ini_key);
 	switch(res) {
 	case -1:
-		php_error_docref1(NULL, key, E_WARNING, "Operation not possible");
+		// TODO Check when this happens and confirm this can even happen
+		php_error_docref(NULL, E_WARNING, "Operation not possible");
 		return FAILURE;
 	default:
 	case 0:

--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -223,25 +223,25 @@ DBA_DELETE_FUNC(lmdb)
 
 	rc = mdb_txn_begin(LMDB_IT(env), NULL, 0, &LMDB_IT(txn));
 	if (rc) {
-		php_error_docref1(NULL, key, E_WARNING, "%s", mdb_strerror(rc));
+		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		return FAILURE;
 	}
 
-	k.mv_size = keylen;
-	k.mv_data = key;
+	k.mv_size = ZSTR_LEN(key);
+	k.mv_data = ZSTR_VAL(key);
 
 	rc = mdb_del(LMDB_IT(txn), LMDB_IT(dbi), &k, NULL);
 	if (!rc) {
 		rc = mdb_txn_commit(LMDB_IT(txn));
 		if (rc) {
-			php_error_docref1(NULL, key, E_WARNING, "%s", mdb_strerror(rc));
+			php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 			mdb_txn_abort(LMDB_IT(txn));
 			return FAILURE;
 		}
 		return SUCCESS;
 	}
 
-	php_error_docref1(NULL, key, E_WARNING, "%s", mdb_strerror(rc));
+	php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 
 	return FAILURE;
 }

--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -191,17 +191,17 @@ DBA_EXISTS_FUNC(lmdb)
 		rc = mdb_txn_begin(LMDB_IT(env), NULL, MDB_RDONLY, &LMDB_IT(txn));
 	}
 	if (rc) {
-		php_error_docref1(NULL, key, E_WARNING, "%s", mdb_strerror(rc));
+		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		return FAILURE;
 	}
 
-	k.mv_size = keylen;
-	k.mv_data = key;
+	k.mv_size = ZSTR_LEN(key);
+	k.mv_data = ZSTR_VAL(key);
 
 	rc = mdb_get(LMDB_IT(txn), LMDB_IT(dbi), &k, &v);
 	if (rc) {
 		if (MDB_NOTFOUND != rc) {
-			php_error_docref1(NULL, key, E_WARNING, "%s", mdb_strerror(rc));
+			php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		}
 		mdb_txn_abort(LMDB_IT(txn));
 		return FAILURE;

--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -250,7 +250,7 @@ DBA_FIRSTKEY_FUNC(lmdb)
 {
 	int rc;
 	MDB_val k, v;
-	char *ret = NULL;
+	zend_string *ret = NULL;
 
 	rc = mdb_txn_begin(LMDB_IT(env), NULL, MDB_RDONLY, &LMDB_IT(txn));
 	if (rc) {
@@ -276,9 +276,8 @@ DBA_FIRSTKEY_FUNC(lmdb)
 		return NULL;
 	}
 
-	if(k.mv_data) {
-		if(newlen) *newlen = k.mv_size;
-		ret = estrndup(k.mv_data, k.mv_size);
+	if (k.mv_data) {
+		ret = zend_string_init(k.mv_data, k.mv_size, /* persistent */ false);
 	}
 
 	mdb_txn_reset(LMDB_IT(txn));
@@ -290,7 +289,7 @@ DBA_NEXTKEY_FUNC(lmdb)
 {
 	int rc;
 	MDB_val k, v;
-	char *ret = NULL;
+	zend_string *ret = NULL;
 
 	rc = mdb_txn_renew(LMDB_IT(txn));
 	if (rc) {
@@ -309,9 +308,8 @@ DBA_NEXTKEY_FUNC(lmdb)
 		return NULL;
 	}
 
-	if(k.mv_data) {
-		if(newlen) *newlen = k.mv_size;
-		ret = estrndup(k.mv_data, k.mv_size);
+	if (k.mv_data) {
+		ret = zend_string_init(k.mv_data, k.mv_size, /* persistent */ false);
 	}
 
 	mdb_txn_reset(LMDB_IT(txn));

--- a/ext/dba/dba_lmdb.c
+++ b/ext/dba/dba_lmdb.c
@@ -152,19 +152,19 @@ DBA_UPDATE_FUNC(lmdb)
 
 	rc = mdb_txn_begin(LMDB_IT(env), NULL, 0, &LMDB_IT(txn));
 	if (rc) {
-		php_error_docref2(NULL, key, val, E_WARNING, "%s", mdb_strerror(rc));
+		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		return FAILURE;
 	}
 
-	k.mv_size = keylen;
-	k.mv_data = key;
-	v.mv_size = vallen;
-	v.mv_data = val;
+	k.mv_size = ZSTR_LEN(key);
+	k.mv_data = ZSTR_VAL(key);
+	v.mv_size = ZSTR_LEN(val);
+	v.mv_data = ZSTR_VAL(val);
 
 	rc = mdb_put(LMDB_IT(txn), LMDB_IT(dbi), &k, &v, mode == 1 ? MDB_NOOVERWRITE : 0);
 	if (rc) {
 		if (MDB_KEYEXIST != rc) {
-			php_error_docref2(NULL, key, val, E_WARNING, "%s", mdb_strerror(rc));
+			php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		}
 		mdb_txn_abort(LMDB_IT(txn));
 		return FAILURE;
@@ -172,7 +172,7 @@ DBA_UPDATE_FUNC(lmdb)
 
 	rc = mdb_txn_commit(LMDB_IT(txn));
 	if (rc) {
-		php_error_docref2(NULL, key, val, E_WARNING, "%s", mdb_strerror(rc));
+		php_error_docref(NULL, E_WARNING, "%s", mdb_strerror(rc));
 		mdb_txn_abort(LMDB_IT(txn));
 		return FAILURE;
 	}

--- a/ext/dba/dba_ndbm.c
+++ b/ext/dba/dba_ndbm.c
@@ -82,10 +82,10 @@ DBA_UPDATE_FUNC(ndbm)
 	datum gval;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
-	gval.dptr = (char *) val;
-	gval.dsize = vallen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
+	gval.dptr = ZSTR_VAL(val);
+	gval.dsize = ZSTR_LEN(val);
 
 	if(!dbm_store(info->dbf, gkey, gval, mode == 1 ? DBM_INSERT : DBM_REPLACE))
 		return SUCCESS;

--- a/ext/dba/dba_ndbm.c
+++ b/ext/dba/dba_ndbm.c
@@ -118,27 +118,23 @@ DBA_DELETE_FUNC(ndbm)
 DBA_FIRSTKEY_FUNC(ndbm)
 {
 	datum gkey;
-	char *key = NULL;
 
 	gkey = dbm_firstkey(info->dbf);
-	if(gkey.dptr) {
-		if(newlen) *newlen = gkey.dsize;
-		key = estrndup(gkey.dptr, gkey.dsize);
+	if (gkey.dptr) {
+		return zend_string_init(gkey.dptr, gkey.dsize, /* persistent */ false);
 	}
-	return key;
+	return NULL;
 }
 
 DBA_NEXTKEY_FUNC(ndbm)
 {
 	datum gkey;
-	char *nkey = NULL;
 
 	gkey = dbm_nextkey(info->dbf);
-	if(gkey.dptr) {
-		if(newlen) *newlen = gkey.dsize;
-		nkey = estrndup(gkey.dptr, gkey.dsize);
+	if (gkey.dptr) {
+		return zend_string_init(gkey.dptr, gkey.dsize, /* persistent */ false);
 	}
-	return nkey;
+	return NULL;
 }
 
 DBA_OPTIMIZE_FUNC(ndbm)

--- a/ext/dba/dba_ndbm.c
+++ b/ext/dba/dba_ndbm.c
@@ -66,17 +66,15 @@ DBA_CLOSE_FUNC(ndbm)
 DBA_FETCH_FUNC(ndbm)
 {
 	datum gval;
-	char *new = NULL;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 	gval = dbm_fetch(info->dbf, gkey);
-	if(gval.dptr) {
-		if(newlen) *newlen = gval.dsize;
-		new = estrndup(gval.dptr, gval.dsize);
+	if (gval.dptr) {
+		return zend_string_init(gval.dptr, gval.dsize, /* persistent */ false);
 	}
-	return new;
+	return NULL;
 }
 
 DBA_UPDATE_FUNC(ndbm)

--- a/ext/dba/dba_ndbm.c
+++ b/ext/dba/dba_ndbm.c
@@ -97,10 +97,10 @@ DBA_EXISTS_FUNC(ndbm)
 	datum gval;
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 	gval = dbm_fetch(info->dbf, gkey);
-	if(gval.dptr) {
+	if (gval.dptr) {
 		return SUCCESS;
 	}
 	return FAILURE;

--- a/ext/dba/dba_ndbm.c
+++ b/ext/dba/dba_ndbm.c
@@ -110,8 +110,8 @@ DBA_DELETE_FUNC(ndbm)
 {
 	datum gkey;
 
-	gkey.dptr = (char *) key;
-	gkey.dsize = keylen;
+	gkey.dptr = ZSTR_VAL(key);
+	gkey.dsize = ZSTR_LEN(key);
 	return(dbm_delete(info->dbf, gkey) == -1 ? FAILURE : SUCCESS);
 }
 

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -107,7 +107,7 @@ DBA_EXISTS_FUNC(qdbm)
 	dba_qdbm_data *dba = info->dbf;
 	char *value;
 
-	value = dpget(dba->dbf, key, keylen, 0, -1, NULL);
+	value = dpget(dba->dbf, ZSTR_VAL(key), ZSTR_LEN(key), 0, -1, NULL);
 	if (value) {
 		free(value);
 		return SUCCESS;

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -120,7 +120,7 @@ DBA_DELETE_FUNC(qdbm)
 {
 	dba_qdbm_data *dba = info->dbf;
 
-	return dpout(dba->dbf, key, keylen) ? SUCCESS : FAILURE;
+	return dpout(dba->dbf, ZSTR_VAL(key), ZSTR_LEN(key)) ? SUCCESS : FAILURE;
 }
 
 DBA_FIRSTKEY_FUNC(qdbm)

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -91,12 +91,12 @@ DBA_UPDATE_FUNC(qdbm)
 {
 	dba_qdbm_data *dba = info->dbf;
 
-	if (dpput(dba->dbf, key, keylen, val, vallen, mode == 1 ? DP_DKEEP : DP_DOVER)) {
+	if (dpput(dba->dbf, ZSTR_VAL(key), ZSTR_LEN(key), ZSTR_VAL(val), ZSTR_LEN(val), mode == 1 ? DP_DKEEP : DP_DOVER)) {
 		return SUCCESS;
 	}
 
 	if (dpecode != DP_EKEEP) {
-		php_error_docref2(NULL, key, val, E_WARNING, "%s", dperrmsg(dpecode));
+		php_error_docref(NULL, E_WARNING, "%s", dperrmsg(dpecode));
 	}
 
 	return FAILURE;

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -127,34 +127,34 @@ DBA_FIRSTKEY_FUNC(qdbm)
 {
 	dba_qdbm_data *dba = info->dbf;
 	int value_size;
-	char *value, *new = NULL;
+	char *value;
+	zend_string *key = NULL;
 
 	dpiterinit(dba->dbf);
 
 	value = dpiternext(dba->dbf, &value_size);
 	if (value) {
-		if (newlen) *newlen = value_size;
-		new = estrndup(value, value_size);
+		key = zend_string_init(value, value_size, /* persistent */ false);
 		free(value);
 	}
 
-	return new;
+	return key;
 }
 
 DBA_NEXTKEY_FUNC(qdbm)
 {
 	dba_qdbm_data *dba = info->dbf;
 	int value_size;
-	char *value, *new = NULL;
+	char *value;
+	zend_string *key = NULL;
 
 	value = dpiternext(dba->dbf, &value_size);
 	if (value) {
-		if (newlen) *newlen = value_size;
-		new = estrndup(value, value_size);
+		key = zend_string_init(value, value_size, /* persistent */ false);
 		free(value);
 	}
 
-	return new;
+	return key;
 }
 
 DBA_OPTIMIZE_FUNC(qdbm)

--- a/ext/dba/dba_qdbm.c
+++ b/ext/dba/dba_qdbm.c
@@ -74,17 +74,17 @@ DBA_CLOSE_FUNC(qdbm)
 DBA_FETCH_FUNC(qdbm)
 {
 	dba_qdbm_data *dba = info->dbf;
-	char *value, *new = NULL;
+	char *value;
 	int value_size;
+	zend_string *fetched_val = NULL;
 
-	value = dpget(dba->dbf, key, keylen, 0, -1, &value_size);
+	value = dpget(dba->dbf, ZSTR_VAL(key), ZSTR_LEN(key), 0, -1, &value_size);
 	if (value) {
-		if (newlen) *newlen = value_size;
-		new = estrndup(value, value_size);
+		fetched_val = zend_string_init(value, value_size, /* persistent */ false);
 		free(value);
 	}
 
-	return new;
+	return fetched_val;
 }
 
 DBA_UPDATE_FUNC(qdbm)

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -138,7 +138,7 @@ DBA_DELETE_FUNC(tcadb)
 {
 	dba_tcadb_data *dba = info->dbf;
 
-	return tcadbout(dba->tcadb, key, keylen) ? SUCCESS : FAILURE;
+	return tcadbout(dba->tcadb, ZSTR_VAL(key), ZSTR_LEN(key)) ? SUCCESS : FAILURE;
 }
 
 DBA_FIRSTKEY_FUNC(tcadb)

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -84,19 +84,17 @@ DBA_CLOSE_FUNC(tcadb)
 DBA_FETCH_FUNC(tcadb)
 {
 	dba_tcadb_data *dba = info->dbf;
-	char *value, *new = NULL;
+	char *value;
 	int value_size;
+	zend_string *fetched_val = NULL;
 
-	value = tcadbget(dba->tcadb, key, keylen, &value_size);
+	value = tcadbget(dba->tcadb, ZSTR_VAL(key), ZSTR_LEN(key), &value_size);
 	if (value) {
-		if (newlen) {
-			*newlen = value_size;
-		}
-		new = estrndup(value, value_size);
+		fetched_val = zend_string_init(value, value_size, /* persistent */ false);
 		tcfree(value);
 	}
 
-	return new;
+	return fetched_val;
 }
 
 DBA_UPDATE_FUNC(tcadb)

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -104,18 +104,18 @@ DBA_UPDATE_FUNC(tcadb)
 
 	if (mode == 1) {
 		/* Insert */
-		if (tcadbvsiz(dba->tcadb, key, keylen) > -1) {
+		if (tcadbvsiz(dba->tcadb, ZSTR_VAL(key), ZSTR_LEN(key)) > -1) {
 			return FAILURE;
 		}
 	}
 
-	result = tcadbput(dba->tcadb, key, keylen, val, vallen);
+	result = tcadbput(dba->tcadb, ZSTR_VAL(key), ZSTR_LEN(key), ZSTR_VAL(val), ZSTR_LEN(val));
 
 	if (result) {
 		return SUCCESS;
 	}
 
-	php_error_docref2(NULL, key, val, E_WARNING, "Error updating data");
+	php_error_docref(NULL, E_WARNING, "Error updating data");
 	return FAILURE;
 }
 

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -145,38 +145,34 @@ DBA_FIRSTKEY_FUNC(tcadb)
 {
 	dba_tcadb_data *dba = info->dbf;
 	int value_size;
-	char *value, *new = NULL;
+	char *value;
+	zend_string *key = NULL;
 
 	tcadbiterinit(dba->tcadb);
 
 	value = tcadbiternext(dba->tcadb, &value_size);
 	if (value) {
-		if (newlen) {
-			*newlen = value_size;
-		}
-		new = estrndup(value, value_size);
+		key = zend_string_init(value, value_size, /* persistent */ false);
 		tcfree(value);
 	}
 
-	return new;
+	return key;
 }
 
 DBA_NEXTKEY_FUNC(tcadb)
 {
 	dba_tcadb_data *dba = info->dbf;
 	int value_size;
-	char *value, *new = NULL;
+	char *value;
+	zend_string *key = NULL;
 
 	value = tcadbiternext(dba->tcadb, &value_size);
 	if (value) {
-		if (newlen) {
-			*newlen = value_size;
-		}
-		new = estrndup(value, value_size);
+		key = zend_string_init(value, value_size, /* persistent */ false);
 		tcfree(value);
 	}
 
-	return new;
+	return key;
 }
 
 DBA_OPTIMIZE_FUNC(tcadb)

--- a/ext/dba/dba_tcadb.c
+++ b/ext/dba/dba_tcadb.c
@@ -125,7 +125,7 @@ DBA_EXISTS_FUNC(tcadb)
 	char *value;
 	int value_len;
 
-	value = tcadbget(dba->tcadb, key, keylen, &value_len);
+	value = tcadbget(dba->tcadb, ZSTR_VAL(key), ZSTR_LEN(key), &value_len);
 	if (value) {
 		tcfree(value);
 		return SUCCESS;

--- a/ext/dba/php_dba.h
+++ b/ext/dba/php_dba.h
@@ -76,7 +76,7 @@ typedef struct dba_handler {
 	zend_string* (*fetch)(dba_info *, zend_string *, int);
 	zend_result (*update)(dba_info *, zend_string *, zend_string *, int);
 	zend_result (*exists)(dba_info *, zend_string *);
-	zend_result (*delete)(dba_info *, char *, size_t);
+	zend_result (*delete)(dba_info *, zend_string *);
 	char* (*firstkey)(dba_info *, size_t *);
 	char* (*nextkey)(dba_info *, size_t *);
 	zend_result (*optimize)(dba_info *);
@@ -98,7 +98,7 @@ typedef struct dba_handler {
 #define DBA_EXISTS_FUNC(x) \
 	zend_result dba_exists_##x(dba_info *info, zend_string *key)
 #define DBA_DELETE_FUNC(x) \
-	zend_result dba_delete_##x(dba_info *info, char *key, size_t keylen)
+	zend_result dba_delete_##x(dba_info *info, zend_string *key)
 #define DBA_FIRSTKEY_FUNC(x) \
 	char *dba_firstkey_##x(dba_info *info, size_t *newlen)
 #define DBA_NEXTKEY_FUNC(x) \

--- a/ext/dba/php_dba.h
+++ b/ext/dba/php_dba.h
@@ -73,7 +73,7 @@ typedef struct dba_handler {
 	int flags; /* whether and how dba does locking and other flags*/
 	zend_result (*open)(dba_info *, char **error);
 	void (*close)(dba_info *);
-	char* (*fetch)(dba_info *, char *, size_t, int, size_t *);
+	zend_string* (*fetch)(dba_info *, zend_string *, int);
 	zend_result (*update)(dba_info *, char *, size_t, char *, size_t, int);
 	zend_result (*exists)(dba_info *, char *, size_t);
 	zend_result (*delete)(dba_info *, char *, size_t);
@@ -92,7 +92,7 @@ typedef struct dba_handler {
 #define DBA_CLOSE_FUNC(x) \
 	void dba_close_##x(dba_info *info)
 #define DBA_FETCH_FUNC(x) \
-	char *dba_fetch_##x(dba_info *info, char *key, size_t keylen, int skip, size_t *newlen)
+	zend_string *dba_fetch_##x(dba_info *info, zend_string *key, int skip)
 #define DBA_UPDATE_FUNC(x) \
 	zend_result dba_update_##x(dba_info *info, char *key, size_t keylen, char *val, size_t vallen, int mode)
 #define DBA_EXISTS_FUNC(x) \

--- a/ext/dba/php_dba.h
+++ b/ext/dba/php_dba.h
@@ -32,7 +32,6 @@ typedef enum {
 
 typedef struct dba_lock {
 	php_stream *fp;
-	char *name;
 	int mode; /* LOCK_EX,LOCK_SH */
 } dba_lock;
 

--- a/ext/dba/php_dba.h
+++ b/ext/dba/php_dba.h
@@ -77,8 +77,8 @@ typedef struct dba_handler {
 	zend_result (*update)(dba_info *, zend_string *, zend_string *, int);
 	zend_result (*exists)(dba_info *, zend_string *);
 	zend_result (*delete)(dba_info *, zend_string *);
-	char* (*firstkey)(dba_info *, size_t *);
-	char* (*nextkey)(dba_info *, size_t *);
+	zend_string* (*firstkey)(dba_info *);
+	zend_string* (*nextkey)(dba_info *);
 	zend_result (*optimize)(dba_info *);
 	zend_result (*sync)(dba_info *);
 	char* (*info)(struct dba_handler *hnd, dba_info *);
@@ -100,9 +100,9 @@ typedef struct dba_handler {
 #define DBA_DELETE_FUNC(x) \
 	zend_result dba_delete_##x(dba_info *info, zend_string *key)
 #define DBA_FIRSTKEY_FUNC(x) \
-	char *dba_firstkey_##x(dba_info *info, size_t *newlen)
+	zend_string *dba_firstkey_##x(dba_info *info)
 #define DBA_NEXTKEY_FUNC(x) \
-	char *dba_nextkey_##x(dba_info *info, size_t *newlen)
+	zend_string *dba_nextkey_##x(dba_info *info)
 #define DBA_OPTIMIZE_FUNC(x) \
 	zend_result dba_optimize_##x(dba_info *info)
 #define DBA_SYNC_FUNC(x) \

--- a/ext/dba/php_dba.h
+++ b/ext/dba/php_dba.h
@@ -74,7 +74,7 @@ typedef struct dba_handler {
 	zend_result (*open)(dba_info *, char **error);
 	void (*close)(dba_info *);
 	zend_string* (*fetch)(dba_info *, zend_string *, int);
-	zend_result (*update)(dba_info *, char *, size_t, char *, size_t, int);
+	zend_result (*update)(dba_info *, zend_string *, zend_string *, int);
 	zend_result (*exists)(dba_info *, char *, size_t);
 	zend_result (*delete)(dba_info *, char *, size_t);
 	char* (*firstkey)(dba_info *, size_t *);
@@ -94,7 +94,7 @@ typedef struct dba_handler {
 #define DBA_FETCH_FUNC(x) \
 	zend_string *dba_fetch_##x(dba_info *info, zend_string *key, int skip)
 #define DBA_UPDATE_FUNC(x) \
-	zend_result dba_update_##x(dba_info *info, char *key, size_t keylen, char *val, size_t vallen, int mode)
+	zend_result dba_update_##x(dba_info *info, zend_string *key, zend_string *val, int mode)
 #define DBA_EXISTS_FUNC(x) \
 	zend_result dba_exists_##x(dba_info *info, char *key, size_t keylen)
 #define DBA_DELETE_FUNC(x) \

--- a/ext/dba/php_dba.h
+++ b/ext/dba/php_dba.h
@@ -75,7 +75,7 @@ typedef struct dba_handler {
 	void (*close)(dba_info *);
 	zend_string* (*fetch)(dba_info *, zend_string *, int);
 	zend_result (*update)(dba_info *, zend_string *, zend_string *, int);
-	zend_result (*exists)(dba_info *, char *, size_t);
+	zend_result (*exists)(dba_info *, zend_string *);
 	zend_result (*delete)(dba_info *, char *, size_t);
 	char* (*firstkey)(dba_info *, size_t *);
 	char* (*nextkey)(dba_info *, size_t *);
@@ -96,7 +96,7 @@ typedef struct dba_handler {
 #define DBA_UPDATE_FUNC(x) \
 	zend_result dba_update_##x(dba_info *info, zend_string *key, zend_string *val, int mode)
 #define DBA_EXISTS_FUNC(x) \
-	zend_result dba_exists_##x(dba_info *info, char *key, size_t keylen)
+	zend_result dba_exists_##x(dba_info *info, zend_string *key)
 #define DBA_DELETE_FUNC(x) \
 	zend_result dba_delete_##x(dba_info *info, char *key, size_t keylen)
 #define DBA_FIRSTKEY_FUNC(x) \


### PR DESCRIPTION
This mostly removes the need for out-params for the string length but can also lead to refactoring our custom driver implementations to use zend_strings too instead of a custom struct dedicated for the driver