### PR TITLE
Ability to do real offset from start of a zend_string for preg_match,

### DIFF
--- a/ext/pcre/tests/preg_start_len_offset.phpt
+++ b/ext/pcre/tests/preg_start_len_offset.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Ability to do real offset from start of a zend_string for preg_match,
+Previously unthinkable or documented as impossible, using front anchor ^ expression.
+--FILE--
+<?php
+$s = "Hello world,Καλημέρα κόσμε,コンニチハ,Привет мир,你好 世界";
+$exp = "/^(?:(\w+\s*\w*),?)/u";
+$len = strlen($s);
+$offset = 0;
+while($offset < $len) {
+	$match = null;
+	$result = preg_match($exp, $s, $match,  PREG_START_LEN_OFFSET, $offset);
+	if (empty($match)) {
+		break;
+	}
+	$capture = $match[1];
+	$offset += strlen($match[0]);
+	echo $capture . PHP_EOL;
+}
+?>
+--EXPECT--
+Hello world
+Καλημέρα κόσμε
+コンニチハ
+Привет мир
+你好 世界


### PR DESCRIPTION
Adjustment to preg_match implementation.
The pcre library , and its preg_match function becomes a little more flexible if the start anchor of an expression, 
could be aligned to anywhere in the internal string without any big fuss. This is currently unthinkable  and documented as impossible, when using front anchor ^ expression. People are advised to use substr, which creates hassles and inefficiency, for large strings.

Alternatives are not easy with PHP, because a zend_string block includes its header.  One possibility would be to have and use internal interator offset inside the string object, with  header memory cost. So the next best thing is to provide an offset from start, to be applied internally.
"preg_match" function already as an offset integer parameter at the end of its function parameters. Its parameter position indicates infrequent usage. It also has a flags field. The offset is passed on to corresponding C library pcre2  API, which says it indicates code unit, not bytes.  The C pcre2 library is fully flexible for C interfaces. Other C applications which can use the external pcre2lib have no problems, they can always offset the subject string start, from high up in the call chain. 

My suggested enhancement here is to have a new flag, to indicate an alternative use for the $offset parameter.
I have labelled it as PREG_START_LEN_OFFSET ( increment the subject start, decrement the subject length, in bytes)
The internal coding of the pcre implementation function, as done here, is intended to only activate when detecting the flag set. PREG_START_LEN_OFFSET, also means that the parameter value passed to the original internal pcre2 API offset must be zero. Why would you need to count units when you control the offset start of the character sequence?
This allows repeated looping through a string with captures using preg_match.

It means the character pointer passed to the pcre2lib may be on an odd aligned boundary, but surely that can't be an issue?

Eample test code (additional test added as ext/pcre/tests/preg_start_len_offset.phpt )
...
$s = "Hello world,Καλημέρα κόσμε,コンニチハ,Привет мир,你好 世界";
$exp = "/^(?:(\w+\s*\w*),?)/u";
$len = strlen($s);
$offset = 0;
while($offset < $len) {
	$match = null;
	$result = preg_match($exp, $s, $match,  PREG_START_LEN_OFFSET, $offset);
	if (empty($match)) {
		break;
	}
	$capture = $match[1];
	$offset += strlen($match[0]);
	echo $capture . PHP_EOL;
}

updated implementation file   -  ext/pcre/php_pcre.c




