### PR TITLE
mbstring: Fix invalid config reference

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1679,8 +1679,8 @@ zend.assertions = 1
 
 ; This directive specifies the regex pattern of content types for which mb_output_handler()
 ; is activated.
-; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
-;mbstring.http_output_conv_mimetype=
+; Default: mbstring.http_output_conv_mimetypes=^(text/|application/xhtml\+xml)
+;mbstring.http_output_conv_mimetypes=
 
 ; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
 ; to the pcre.recursion_limit for PCRE.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1681,8 +1681,8 @@ zend.assertions = -1
 
 ; This directive specifies the regex pattern of content types for which mb_output_handler()
 ; is activated.
-; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
-;mbstring.http_output_conv_mimetype=
+; Default: mbstring.http_output_conv_mimetypes=^(text/|application/xhtml\+xml)
+;mbstring.http_output_conv_mimetypes=
 
 ; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
 ; to the pcre.recursion_limit for PCRE.


### PR DESCRIPTION
Just noticed it as I was debugging a system configuration issue I had. The correct reference can be found here:

* https://github.com/php/php-src/blob/php-8.0.12/ext/mbstring/mbstring.c#L939