### PR TITLE
Fix expected type of IntlDateFormatter::__construct() arguments

### DIFF
--- a/ext/intl/dateformat/dateformat.stub.php
+++ b/ext/intl/dateformat/dateformat.stub.php
@@ -10,8 +10,8 @@ class IntlDateFormatter
      */
     public function __construct(
         ?string $locale,
-        int $dateType = IntlDateFormatter::FULL,
-        int $timeType = IntlDateFormatter::FULL,
+        ?int $dateType = IntlDateFormatter::FULL,
+        ?int $timeType = IntlDateFormatter::FULL,
         $timezone = null,
         $calendar = null,
         ?string $pattern = null
@@ -24,8 +24,8 @@ class IntlDateFormatter
      */
     public static function create(
         ?string $locale,
-        int $dateType = IntlDateFormatter::FULL,
-        int $timeType = IntlDateFormatter::FULL,
+        ?int $dateType = IntlDateFormatter::FULL,
+        ?int $timeType = IntlDateFormatter::FULL,
         $timezone = null,
         IntlCalendar|int|null $calendar = null,
         ?string $pattern = null

--- a/ext/intl/dateformat/dateformat_arginfo.h
+++ b/ext/intl/dateformat/dateformat_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 767e5d064aef6d68f860a79c721eb728436c4eb9 */
+ * Stub hash: 054f57351e4e05b95274db50eb90fd1919990a91 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDateFormatter___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 0, "IntlDateFormatter::FULL")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 0, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 1, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 1, "IntlDateFormatter::FULL")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, calendar, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")
@@ -12,8 +12,8 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_IntlDateFormatter_create, 0, 1, IntlDateFormatter, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 0, "IntlDateFormatter::FULL")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 0, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 1, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 1, "IntlDateFormatter::FULL")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
 	ZEND_ARG_OBJ_TYPE_MASK(0, calendar, IntlCalendar, MAY_BE_LONG|MAY_BE_NULL, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -160,8 +160,8 @@ function intl_error_name(int $errorCode): string {}
 /** @param IntlTimeZone|DateTimeZone|string|null $timezone */
 function datefmt_create(
     ?string $locale,
-    int $dateType = IntlDateFormatter::FULL,
-    int $timeType = IntlDateFormatter::FULL,
+    ?int $dateType = IntlDateFormatter::FULL,
+    ?int $timeType = IntlDateFormatter::FULL,
     $timezone = null,
     IntlCalendar|int|null $calendar = null,
     ?string $pattern = null

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dc9632b2417200deb39cc5cce25aa26a44128707 */
+ * Stub hash: 270a277e595f737019787eafdfc188b206bb6fc4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -278,8 +278,8 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_datefmt_create, 0, 1, IntlDateFormatter, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 0, "IntlDateFormatter::FULL")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 0, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, dateType, IS_LONG, 1, "IntlDateFormatter::FULL")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeType, IS_LONG, 1, "IntlDateFormatter::FULL")
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
 	ZEND_ARG_OBJ_TYPE_MASK(0, calendar, IntlCalendar, MAY_BE_LONG|MAY_BE_NULL, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 1, "null")

--- a/ext/intl/tests/bug81606.phpt
+++ b/ext/intl/tests/bug81606.phpt
@@ -1,0 +1,24 @@
+--TEST--
+IntlDateFormatter::create() with null date and time types
+--EXTENSIONS--
+intl
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$ts = strtotime('2012-01-01 00:00:00 UTC');
+$fmt = IntlDateFormatter::create('en_US', null, null, 'UTC');
+echo $fmt->format($ts), "\n";
+
+$fmt = new IntlDateFormatter('en_US', null, null, 'UTC');
+echo $fmt->format($ts), "\n";
+
+$fmt = datefmt_create('en_US', null, null, 'UTC');
+echo $fmt->format($ts), "\n";
+
+?>
+--EXPECT--
+Sunday, January 1, 2012 at 12:00:00 AM Coordinated Universal Time
+Sunday, January 1, 2012 at 12:00:00 AM Coordinated Universal Time
+Sunday, January 1, 2012 at 12:00:00 AM Coordinated Universal Time


### PR DESCRIPTION
This is a fix for bug #81606.

According to [documentation](https://www.php.net/manual/en/intldateformatter.create.php#refsect1-intldateformatter.create-parameters), `$dateType` and `$timeType` should accept `null values`.

> Date type to use (none, short, medium, long, full). This is one of the IntlDateFormatter constants. It can also be null, in which case ICUʼs default date type will be used.