### PR TITLE
Add Locale::getLanguage() and make getPrimaryLanguage() its alias

### DIFF
--- a/ext/intl/locale/locale.stub.php
+++ b/ext/intl/locale/locale.stub.php
@@ -18,7 +18,13 @@ class Locale
 
     /**
      * @tentative-return-type
-     * @alias locale_get_primary_language
+     * @alias locale_get_language
+     */
+    public static function getLanguage(string $locale): ?string{}
+
+    /**
+     * @tentative-return-type
+     * @alias locale_get_language
      */
     public static function getPrimaryLanguage(string $locale): ?string{}
 

--- a/ext/intl/locale/locale_arginfo.h
+++ b/ext/intl/locale/locale_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 539e559bc038e18358540b3b3f4db7b09e532dae */
+ * Stub hash: 3635a4069505cc9e9c22deddf7cb68c396990cd1 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Locale_getDefault, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -8,13 +8,15 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Locale_setDefault, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Locale_getPrimaryLanguage, 0, 1, IS_STRING, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Locale_getLanguage, 0, 1, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Locale_getScript arginfo_class_Locale_getPrimaryLanguage
+#define arginfo_class_Locale_getPrimaryLanguage arginfo_class_Locale_getLanguage
 
-#define arginfo_class_Locale_getRegion arginfo_class_Locale_getPrimaryLanguage
+#define arginfo_class_Locale_getScript arginfo_class_Locale_getLanguage
+
+#define arginfo_class_Locale_getRegion arginfo_class_Locale_getLanguage
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_Locale_getKeywords, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE|MAY_BE_NULL)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -56,7 +58,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Locale_lookup, 0
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, defaultLocale, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Locale_canonicalize arginfo_class_Locale_getPrimaryLanguage
+#define arginfo_class_Locale_canonicalize arginfo_class_Locale_getLanguage
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_Locale_acceptFromHttp, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, header, IS_STRING, 0)
@@ -65,7 +67,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_FUNCTION(locale_get_default);
 ZEND_FUNCTION(locale_set_default);
-ZEND_FUNCTION(locale_get_primary_language);
+ZEND_FUNCTION(locale_get_language);
 ZEND_FUNCTION(locale_get_script);
 ZEND_FUNCTION(locale_get_region);
 ZEND_FUNCTION(locale_get_keywords);
@@ -86,7 +88,8 @@ ZEND_FUNCTION(locale_accept_from_http);
 static const zend_function_entry class_Locale_methods[] = {
 	ZEND_ME_MAPPING(getDefault, locale_get_default, arginfo_class_Locale_getDefault, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(setDefault, locale_set_default, arginfo_class_Locale_setDefault, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	ZEND_ME_MAPPING(getPrimaryLanguage, locale_get_primary_language, arginfo_class_Locale_getPrimaryLanguage, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME_MAPPING(getLanguage, locale_get_language, arginfo_class_Locale_getLanguage, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME_MAPPING(getPrimaryLanguage, locale_get_language, arginfo_class_Locale_getPrimaryLanguage, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(getScript, locale_get_script, arginfo_class_Locale_getScript, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(getRegion, locale_get_region, arginfo_class_Locale_getRegion, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(getKeywords, locale_get_keywords, arginfo_class_Locale_getKeywords, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)

--- a/ext/intl/locale/locale_methods.c
+++ b/ext/intl/locale/locale_methods.c
@@ -368,27 +368,27 @@ static zend_string* get_icu_value_internal( const char* loc_name , char* tag_nam
 			}
 		}
 
-	if( fromParseLocale==1 ){
-		zend_off_t singletonPos = 0;
+		if( fromParseLocale==1 ){
+			zend_off_t singletonPos = 0;
 
-		/* Handle singletons */
-		if( strcmp(tag_name , LOC_LANG_TAG)==0 ){
-			if( strlen(loc_name)>1 && (isIDPrefix(loc_name) == 1) ){
-				return zend_string_init(loc_name, strlen(loc_name), 0);
+			/* Handle singletons */
+			if( strcmp(tag_name , LOC_LANG_TAG)==0 ){
+				 if( strlen(loc_name)>1 && (isIDPrefix(loc_name) == 1) ){
+					 return zend_string_init(loc_name, strlen(loc_name), 0);
+				 }
 			}
-		}
 
-		singletonPos = getSingletonPos( loc_name );
-		if( singletonPos == 0){
-			/* singleton at start of script, region , variant etc.
-			 * or invalid singleton at start of language */
-			return NULL;
-		} else if( singletonPos > 0 ){
-			/* singleton at some position except at start
-			 * strip off the singleton and rest of the loc_name */
-			mod_loc_name = estrndup ( loc_name , singletonPos-1);
-		}
-	} /* end of if fromParse */
+			singletonPos = getSingletonPos( loc_name );
+			if( singletonPos == 0){
+				 /* singleton at start of script, region , variant etc.
+				  * or invalid singleton at start of language */
+				 return NULL;
+			} else if( singletonPos > 0 ){
+				 /* singleton at some position except at start
+				  * strip off the singleton and rest of the loc_name */
+				 mod_loc_name = estrndup ( loc_name , singletonPos-1);
+			}
+		} /* end of if fromParse */
 
 	} /* end of if != LOC_CANONICAL_TAG */
 
@@ -537,8 +537,8 @@ PHP_FUNCTION( locale_get_region )
 }
 /* }}} */
 
-/* {{{ gets the primary language for the $locale */
-PHP_FUNCTION(locale_get_primary_language )
+/* {{{ gets the language for the $locale */
+PHP_FUNCTION( locale_get_language )
 {
 	get_icu_value_src_php( LOC_LANG_TAG , INTERNAL_FUNCTION_PARAM_PASSTHRU );
 }

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -296,6 +296,11 @@ function locale_get_default(): string {}
 
 function locale_set_default(string $locale): bool {}
 
+function locale_get_language(string $locale): ?string {}
+
+/**
+ * @alias locale_get_language
+ */
 function locale_get_primary_language(string $locale): ?string {}
 
 function locale_get_script(string $locale): ?string {}

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 09aa0aa66c78b86c0e6e0e554c3ebe205a0e5f59 */
+ * Stub hash: 0374661db01144e54cfca6f0ac751aa3b1d5ffe0 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -507,13 +507,15 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_locale_set_default, 0, 1, _IS_BO
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_locale_get_primary_language, 0, 1, IS_STRING, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_locale_get_language, 0, 1, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_locale_get_script arginfo_locale_get_primary_language
+#define arginfo_locale_get_primary_language arginfo_locale_get_language
 
-#define arginfo_locale_get_region arginfo_locale_get_primary_language
+#define arginfo_locale_get_script arginfo_locale_get_language
+
+#define arginfo_locale_get_region arginfo_locale_get_language
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_locale_get_keywords, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE|MAY_BE_NULL)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -548,7 +550,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_locale_filter_matches, 0, 2, _IS
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, canonicalize, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
-#define arginfo_locale_canonicalize arginfo_locale_get_primary_language
+#define arginfo_locale_canonicalize arginfo_locale_get_language
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_locale_lookup, 0, 2, IS_STRING, 1)
 	ZEND_ARG_TYPE_INFO(0, languageTag, IS_ARRAY, 0)
@@ -901,7 +903,7 @@ ZEND_FUNCTION(idn_to_ascii);
 ZEND_FUNCTION(idn_to_utf8);
 ZEND_FUNCTION(locale_get_default);
 ZEND_FUNCTION(locale_set_default);
-ZEND_FUNCTION(locale_get_primary_language);
+ZEND_FUNCTION(locale_get_language);
 ZEND_FUNCTION(locale_get_script);
 ZEND_FUNCTION(locale_get_region);
 ZEND_FUNCTION(locale_get_keywords);
@@ -1091,7 +1093,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(idn_to_utf8, arginfo_idn_to_utf8)
 	ZEND_FE(locale_get_default, arginfo_locale_get_default)
 	ZEND_FE(locale_set_default, arginfo_locale_set_default)
-	ZEND_FE(locale_get_primary_language, arginfo_locale_get_primary_language)
+	ZEND_FE(locale_get_language, arginfo_locale_get_language)
+	ZEND_FALIAS(locale_get_primary_language, locale_get_language, arginfo_locale_get_primary_language)
 	ZEND_FE(locale_get_script, arginfo_locale_get_script)
 	ZEND_FE(locale_get_region, arginfo_locale_get_region)
 	ZEND_FE(locale_get_keywords, arginfo_locale_get_keywords)

--- a/ext/intl/tests/bug72241.phpt
+++ b/ext/intl/tests/bug72241.phpt
@@ -5,8 +5,11 @@ intl
 --FILE--
 <?php
 $var1=str_repeat("A", 1000);
+$out = locale_get_language($var1);
+var_dump($out);
 $out = locale_get_primary_language($var1);
 var_dump($out);
 ?>
 --EXPECT--
+NULL
 NULL

--- a/ext/intl/tests/locale_bug74439.phpt
+++ b/ext/intl/tests/locale_bug74439.phpt
@@ -12,6 +12,7 @@ $methods = [
 'composeLocale',
 'getAllVariants',
 'getKeywords',
+'getLanguage',
 'getPrimaryLanguage',
 'getRegion',
 'getScript',
@@ -38,6 +39,7 @@ canonicalize: 1, 1
 composeLocale: 1, 1
 getAllVariants: 1, 1
 getKeywords: 1, 1
+getLanguage: 1, 1
 getPrimaryLanguage: 1, 1
 getRegion: 1, 1
 getScript: 1, 1

--- a/ext/intl/tests/locale_get_language.phpt
+++ b/ext/intl/tests/locale_get_language.phpt
@@ -1,12 +1,12 @@
 --TEST--
-locale_get_primary_language()
+locale_get_language()
 --EXTENSIONS--
 intl
 --FILE--
 <?php
 
 /*
- * Try getting the prmary language for different locales
+ * Try getting the language for different locales
  * with Procedural and Object methods.
  */
 
@@ -70,6 +70,11 @@ function ut_main()
 
     foreach( $locales as $locale )
     {
+        $lang = ut_loc_get_language( $locale);
+        $res_str .= "$locale:  language='$lang'";
+        $res_str .= "\n";
+
+        // Also test the alias Locale::getPrimaryLanguage().
         $lang = ut_loc_get_primary_language( $locale);
         $res_str .= "$locale:  primary_language='$lang'";
         $res_str .= "\n";
@@ -84,38 +89,73 @@ ut_run();
 
 ?>
 --EXPECTF--
+uk-ua_CALIFORNIA@currency=;currency=GRN:  language='uk'
 uk-ua_CALIFORNIA@currency=;currency=GRN:  primary_language='uk'
+root:  language='%S'
 root:  primary_language='%S'
+uk@currency=EURO:  language='uk'
 uk@currency=EURO:  primary_language='uk'
+Hindi:  language='hindi'
 Hindi:  primary_language='hindi'
+de:  language='de'
 de:  primary_language='de'
+fr:  language='fr'
 fr:  primary_language='fr'
+ja:  language='ja'
 ja:  primary_language='ja'
+i-enochian:  language='i-enochian'
 i-enochian:  primary_language='i-enochian'
+zh-Hant:  language='zh'
 zh-Hant:  primary_language='zh'
+zh-Hans:  language='zh'
 zh-Hans:  primary_language='zh'
+sr-Cyrl:  language='sr'
 sr-Cyrl:  primary_language='sr'
+sr-Latn:  language='sr'
 sr-Latn:  primary_language='sr'
+zh-Hans-CN:  language='zh'
 zh-Hans-CN:  primary_language='zh'
+sr-Latn-CS:  language='sr'
 sr-Latn-CS:  primary_language='sr'
+sl-rozaj:  language='sl'
 sl-rozaj:  primary_language='sl'
+sl-nedis:  language='sl'
 sl-nedis:  primary_language='sl'
+de-CH-1901:  language='de'
 de-CH-1901:  primary_language='de'
+sl-IT-nedis:  language='sl'
 sl-IT-nedis:  primary_language='sl'
+sl-Latn-IT-nedis:  language='sl'
 sl-Latn-IT-nedis:  primary_language='sl'
+de-DE:  language='de'
 de-DE:  primary_language='de'
+en-US:  language='en'
 en-US:  primary_language='en'
+es-419:  language='es'
 es-419:  primary_language='es'
+de-CH-x-phonebk:  language='de'
 de-CH-x-phonebk:  primary_language='de'
+az-Arab-x-AZE-derbend:  language='az'
 az-Arab-x-AZE-derbend:  primary_language='az'
+zh-min:  language='zh-min'
 zh-min:  primary_language='zh-min'
+zh-min-nan-Hant-CN:  language='zh'
 zh-min-nan-Hant-CN:  primary_language='zh'
+qaa-Qaaa-QM-x-southern:  language='qaa'
 qaa-Qaaa-QM-x-southern:  primary_language='qaa'
+sr-Latn-QM:  language='sr'
 sr-Latn-QM:  primary_language='sr'
+sr-Qaaa-CS:  language='sr'
 sr-Qaaa-CS:  primary_language='sr'
+en-US-u-islamCal:  language='en'
 en-US-u-islamCal:  primary_language='en'
+zh-CN-a-myExt-x-private:  language='zh'
 zh-CN-a-myExt-x-private:  primary_language='zh'
+en-a-myExt-b-another:  language='en'
 en-a-myExt-b-another:  primary_language='en'
+de-419-DE:  language='de'
 de-419-DE:  primary_language='de'
+a-DE:  language='a'
 a-DE:  primary_language='a'
+ar-a-aaa-b-bbb-a-ccc:  language='ar'
 ar-a-aaa-b-bbb-a-ccc:  primary_language='ar'

--- a/ext/intl/tests/ut_common.inc
+++ b/ext/intl/tests/ut_common.inc
@@ -236,6 +236,10 @@ function ut_loc_set_default( $locale  )
 {
     return $GLOBALS['oo-mode'] ? Locale::setDefault( $locale  ) : locale_set_default( $locale );
 }
+function ut_loc_get_language( $locale )
+{
+    return $GLOBALS['oo-mode'] ? Locale::getLanguage( $locale ) : locale_get_language( $locale );
+}
 function ut_loc_get_primary_language( $locale )
 {
     return $GLOBALS['oo-mode'] ? Locale::getPrimaryLanguage( $locale ) : locale_get_primary_language( $locale );


### PR DESCRIPTION
I'm going through the ICU code and updating ext-intl so that it has feature parity with libicu. While doing so, I came across this oddity. PHP uses `Locale::getPrimaryLanguage()`, but ICU has no concept of a "primary" language in a language tag. A well-formed language tag has only one language.

ICU's code refers to this function as `uloc_getLanguage()`. See here: https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/uloc_8h.html#a59ff0bdaf316e095b1a10e7ecf63feb3

Indeed, this is the same function we use behind `getPrimaryLanguage()`.

This PR adds `Locale::getLanguage()` and `locale_get_language()`, turning `Locale::getPrimaryLanguage()` and `locale_get_primary_language()` into aliases. We can choose to deprecate them in a future release, if we like (i.e., 8.3?, 9.0?).