### PR TITLE
Update NEWS for PHP 7.4.26RC1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-?? ??? ????, PHP 7.4.26
+04 Nov 2021, PHP 7.4.26RC1
 
 - Core:
   . Fixed bug #81518 (Header injection via default_mimetype / default_charset).


### PR DESCRIPTION
pm.max_children = 5
Can the default configuration be adjusted higher?
The reason many people think that php doesn't support concurrency is that they simply don't know how to set these configurations.
Over time they think it's because the php language doesn't work