### PR TITLE
Fix bug #81607: CE_CACHE allocation with concurrent access

### DIFF
--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -710,7 +710,9 @@ static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
 #define OBJ_FLAGS(obj)              GC_FLAGS(obj)
 
 /* Fast class cache */
-#define ZSTR_HAS_CE_CACHE(s)		(GC_FLAGS(s) & IS_STR_CLASS_NAME_MAP_PTR)
+#define ZSTR_HAS_CE_CACHE(s) \
+	((GC_FLAGS(s) & IS_STR_CLASS_NAME_MAP_PTR) \
+		&& ((GC_REFCOUNT(s)-1)/sizeof(void *) < CG(map_ptr_last)))
 #define ZSTR_GET_CE_CACHE(s) \
 	(*(zend_class_entry **)ZEND_MAP_PTR_OFFSET2PTR(GC_REFCOUNT(s)))
 #define ZSTR_SET_CE_CACHE(s, ce) do { \

--- a/ext/opcache/tests/bug81607.inc
+++ b/ext/opcache/tests/bug81607.inc
@@ -1,0 +1,2 @@
+<?php
+class FooBar {}

--- a/ext/opcache/tests/bug81607.phpt
+++ b/ext/opcache/tests/bug81607.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug #81607: CE_CACHE allocation with concurrent access
+--EXTENSIONS--
+opcache
+pcntl
+--INI--
+opcache.enable_cli=1
+--FILE--
+<?php
+
+$pid = pcntl_fork();
+if ($pid == 0) {
+    // Child: Declare class FooBar {} to allocate CE cache slot.
+    require __DIR__ . '/bug81607.inc';
+} else if ($pid > 0) {
+    pcntl_wait($status);
+    var_dump(new FooBar);
+} else {
+    echo "pcntl_fork() failed\n";
+}
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Class "FooBar" not found in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
If one process allocates CE_CACHE on an existing SHM interned
string, then another process may try to access a map ptr slot
that is not allocated in that process. Fix this by checking the
cache slot against map_ptr_last.