### PR TITLE
fpm dumpable process setting extra check for SElinux based systems.

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -563,6 +563,12 @@ if test "$PHP_FPM" != "no"; then
     [no],
     [no])
 
+  PHP_ARG_WITH([fpm-selinux],,
+    [AS_HELP_STRING([--with-fpm-selinux],
+      [Support SELinux policy library])],
+    [no],
+    [no])
+
   if test "$PHP_FPM_SYSTEMD" != "no" ; then
     PKG_CHECK_MODULES([SYSTEMD], [libsystemd >= 209])
 
@@ -605,11 +611,13 @@ if test "$PHP_FPM" != "no"; then
     ])
   fi
 
-  AC_CHECK_HEADERS([selinux/selinux.h])
-  AC_CHECK_LIB(selinux, security_setenforce, [
-    PHP_ADD_LIBRARY(selinux)
-    AC_DEFINE(HAVE_SELINUX, 1, [ SElinux available ])
-  ],[])
+  if test "x$PHP_FPM_SELINUX" != "xno" ; then
+    AC_CHECK_HEADERS([selinux/selinux.h])
+    AC_CHECK_LIB(selinux, security_setenforce, [
+      PHP_ADD_LIBRARY(selinux)
+      AC_DEFINE(HAVE_SELINUX, 1, [ SElinux available ])
+    ],[])
+  fi
 
   PHP_SUBST_OLD(php_fpm_systemd)
   AC_DEFINE_UNQUOTED(PHP_FPM_SYSTEMD, "$php_fpm_systemd", [fpm systemd service type])

--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -605,6 +605,12 @@ if test "$PHP_FPM" != "no"; then
     ])
   fi
 
+  AC_CHECK_HEADERS([selinux/selinux.h])
+  AC_CHECK_LIB(selinux, security_setenforce, [
+    PHP_ADD_LIBRARY(selinux)
+    AC_DEFINE(HAVE_SELINUX, 1, [ SElinux available ])
+  ],[])
+
   PHP_SUBST_OLD(php_fpm_systemd)
   AC_DEFINE_UNQUOTED(PHP_FPM_SYSTEMD, "$php_fpm_systemd", [fpm systemd service type])
 

--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -416,15 +416,17 @@ int fpm_unix_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 	}
 
 #ifdef HAVE_PRCTL
-	int dumpable = 1;
+	if (wp->config->process_dumpable) {
+		int dumpable = 1;
 #ifdef HAVE_SELINUX
-	if (security_get_boolean_active("deny_ptrace") == 1) {
-		zlog(ZLOG_SYSERROR, "[pool %s] ptrace is denied", wp->config->name);
-		dumpable = 0;
-	}
+		if (security_get_boolean_active("deny_ptrace") == 1) {
+			zlog(ZLOG_SYSERROR, "[pool %s] ptrace is denied", wp->config->name);
+			dumpable = 0;
+		}
 #endif
-	if (dumpable && wp->config->process_dumpable && 0 > prctl(PR_SET_DUMPABLE, 1, 0, 0, 0)) {
-		zlog(ZLOG_SYSERROR, "[pool %s] failed to prctl(PR_SET_DUMPABLE)", wp->config->name);
+		if (dumpable && 0 > prctl(PR_SET_DUMPABLE, 1, 0, 0, 0)) {
+			zlog(ZLOG_SYSERROR, "[pool %s] failed to prctl(PR_SET_DUMPABLE)", wp->config->name);
+		}
 	}
 #endif
 

--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -31,6 +31,10 @@
 #include <sys/acl.h>
 #endif
 
+#ifdef HAVE_SELINUX
+#include <selinux/selinux.h>
+#endif
+
 #include "fpm.h"
 #include "fpm_conf.h"
 #include "fpm_cleanup.h"
@@ -412,7 +416,14 @@ int fpm_unix_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 	}
 
 #ifdef HAVE_PRCTL
-	if (wp->config->process_dumpable && 0 > prctl(PR_SET_DUMPABLE, 1, 0, 0, 0)) {
+	int dumpable = 1;
+#ifdef HAVE_SELINUX
+	if (security_get_boolean_active("deny_ptrace") == 1) {
+		zlog(ZLOG_SYSERROR, "[pool %s] ptrace is denied", wp->config->name);
+		dumpable = 0;
+	}
+#endif
+	if (dumpable && wp->config->process_dumpable && 0 > prctl(PR_SET_DUMPABLE, 1, 0, 0, 0)) {
 		zlog(ZLOG_SYSERROR, "[pool %s] failed to prctl(PR_SET_DUMPABLE)", wp->config->name);
 	}
 #endif


### PR DESCRIPTION
deny_ptrace is a os runtime setting and is off by default,
at least on workstations flavors (fedora) however might be different on production servers.