### PR TITLE
Fix bug #81618: dns_get_record failure on FreeBSD

### DIFF
--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -946,8 +946,15 @@ PHP_FUNCTION(dns_get_record)
 			n = php_dns_search(handle, hostname, C_IN, type_to_fetch, answer.qb2, sizeof answer);
 
 			if (n < 0) {
+#if defined(HAVE_RES_NSEARCH)
+				int r_h_errno = handle->res_h_errno;
+#endif
 				php_dns_free_handle(handle);
+#if defined(HAVE_RES_NSEARCH)
+				switch (r_h_errno) {
+#else
 				switch (h_errno) {
+#endif
 					case NO_DATA:
 					case HOST_NOT_FOUND:
 						continue;

--- a/ext/standard/tests/bug81618.phpt
+++ b/ext/standard/tests/bug81618.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #81618: dns_get_record failure on FreeBSD
+--FILE--
+<?php
+$ret = dns_get_record('www.google.com', DNS_A + DNS_CNAME);
+
+echo ($ret !== false && count($ret) > 0);
+
+?>
+
+--EXPECT--
+1


### PR DESCRIPTION
when query for a record type fails.

from fsbruva's insights.