### PR TITLE
(bugfix) dns.c: Correct dns_get_record on FreeBSD - Fix #81618

### DIFF
--- a/ext/standard/dns.c
+++ b/ext/standard/dns.c
@@ -827,6 +827,7 @@ PHP_FUNCTION(dns_get_record)
 	zend_long type_param = PHP_DNS_ANY;
 	zval *authns = NULL, *addtl = NULL;
 	int type_to_fetch;
+	int dns_errno;
 #if defined(HAVE_DNS_SEARCH)
 	struct sockaddr_storage from;
 	uint32_t fromsize = sizeof(from);
@@ -975,8 +976,9 @@ PHP_FUNCTION(dns_get_record)
 			n = php_dns_search(handle, hostname, C_IN, type_to_fetch, answer.qb2, sizeof answer);
 
 			if (n < 0) {
+				dns_errno = php_dns_errno(handle);
 				php_dns_free_handle(handle);
-				switch (h_errno) {
+				switch (dns_errno) {
 					case NO_DATA:
 					case HOST_NOT_FOUND:
 						continue;

--- a/ext/standard/php_dns.h
+++ b/ext/standard/php_dns.h
@@ -24,6 +24,7 @@
     	((int)dns_search(res, dname, class, type, (char *) answer, anslen, (struct sockaddr *)&from, &fromsize))
 #define php_dns_free_handle(res) \
 		dns_free(res)
+#define php_dns_errno(handle) h_errno
 
 #elif defined(HAVE_RES_NSEARCH)
 #define php_dns_search(res, dname, class, type, answer, anslen) \
@@ -37,11 +38,13 @@
 			res_nclose(res); \
 			php_dns_free_res(res)
 #endif
+#define php_dns_errno(handle) handle->res_h_errno
 
 #elif defined(HAVE_RES_SEARCH)
 #define php_dns_search(res, dname, class, type, answer, anslen) \
 			res_search(dname, class, type, answer, anslen)
 #define php_dns_free_handle(res) /* noop */
+#define php_dns_errno(handle) h_errno
 
 #endif
 

--- a/ext/standard/tests/bug81618.phpt
+++ b/ext/standard/tests/bug81618.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug #81618: dns_get_record failure on FreeBSD
+--FILE--
+<?php
+$ret = dns_get_record('www.google.com', DNS_A + DNS_CNAME);
+
+echo ($ret !== false && count($ret) > 0);
+
+?>
+
+--EXPECT--
+1


### PR DESCRIPTION
Modify dns_get_record to test for query result based on dns_errno to
accommodate modern FreeBSD, for which res_nsearch() does not update
h_errno directly. Add new php_dns_errno macro, and have it consult
statp->res_h_errno when OS has res_nsearch().

Fixes #81618

This approach is more complete than #7650, because it deals with the
general case for any subsequent or future calls to php_dns_errno().

Test borrowed from #7650.

Will need to be backported to 8.1, 7.3 and 7.4 branches.