### PR TITLE
Fix inheritance of class constants if mutable data used

### DIFF
--- a/Zend/tests/class_constant_inheritance_mutable_data.phpt
+++ b/Zend/tests/class_constant_inheritance_mutable_data.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Class constant inheritance with mutable data
+--FILE--
+<?php
+
+// This would previously leak under opcache.
+class A {
+    const X = 'X' . self::Y;
+    const Y = 'Y';
+}
+interface I {
+    const X2 = 'X2' . self::Y2;
+    const Y2 = 'Y2';
+}
+eval('class B extends A implements I {}');
+var_dump(new B);
+var_dump(B::X, B::X2);
+
+// This should only produce one warning, not two.
+class X {
+    const C = 1 % 1.5;
+}
+class Y extends X {
+}
+var_dump(X::C, Y::C);
+?>
+--EXPECTF--
+object(B)#1 (0) {
+}
+string(2) "XY"
+string(4) "X2Y2"
+
+Deprecated: Implicit conversion from float 1.5 to int loses precision in %s on line %d
+int(0)
+int(0)

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1310,6 +1310,22 @@ static zend_class_mutable_data *zend_allocate_mutable_data(zend_class_entry *cla
 }
 /* }}} */
 
+static zend_class_constant *inherit_class_constant(zend_class_entry *ce, zend_string *name) {
+	if (ce->parent) {
+		zend_class_constant *c = zend_hash_find_ptr(CE_CONSTANTS_TABLE(ce->parent), name);
+		if (c) {
+			return c;
+		}
+	}
+	for (uint32_t i = 0; i < ce->num_interfaces; i++) {
+		zend_class_constant *c = zend_hash_find_ptr(CE_CONSTANTS_TABLE(ce->interfaces[i]), name);
+		if (c) {
+			return c;
+		}
+	}
+	ZEND_UNREACHABLE();
+}
+
 ZEND_API HashTable *zend_separate_class_constants_table(zend_class_entry *class_type) /* {{{ */
 {
 	zend_class_mutable_data *mutable_data;
@@ -1323,9 +1339,13 @@ ZEND_API HashTable *zend_separate_class_constants_table(zend_class_entry *class_
 
 	ZEND_HASH_FOREACH_STR_KEY_PTR(&class_type->constants_table, key, c) {
 		if (Z_TYPE(c->value) == IS_CONSTANT_AST) {
-			new_c = zend_arena_alloc(&CG(arena), sizeof(zend_class_constant));
-			memcpy(new_c, c, sizeof(zend_class_constant));
-			c = new_c;
+			if (c->ce == class_type) {
+				new_c = zend_arena_alloc(&CG(arena), sizeof(zend_class_constant));
+				memcpy(new_c, c, sizeof(zend_class_constant));
+				c = new_c;
+			} else {
+				c = inherit_class_constant(class_type, key);
+			}
 		}
 		Z_TRY_ADDREF(c->value);
 		_zend_hash_append_ptr(constants_table, key, c);
@@ -1409,11 +1429,18 @@ ZEND_API zend_result zend_update_class_constants(zend_class_entry *class_type) /
 		} else {
 			constants_table = &class_type->constants_table;
 		}
-		ZEND_HASH_FOREACH_PTR(constants_table, c) {
+
+		zend_string *name;
+		ZEND_HASH_FOREACH_STR_KEY_VAL(constants_table, name, val) {
+			c = Z_PTR_P(val);
 			if (Z_TYPE(c->value) == IS_CONSTANT_AST) {
-				val = &c->value;
-				if (UNEXPECTED(zval_update_constant_ex(val, c->ce) != SUCCESS)) {
-					return FAILURE;
+				if (c->ce == class_type) {
+					val = &c->value;
+					if (UNEXPECTED(zval_update_constant_ex(val, c->ce) != SUCCESS)) {
+						return FAILURE;
+					}
+				} else {
+					Z_PTR_P(val) = inherit_class_constant(class_type, name);
 				}
 			}
 		} ZEND_HASH_FOREACH_END();


### PR DESCRIPTION
Class constants from parent should always be directly reused,
rather than re-evaluated as a separate copy. Previously this used
to happen automatically, as we'd just inherit the class constant
entry from the parent class. With mutable data there may now be
a separate copy of the constant, so we need to use that copy
when updating constants. Otherwise we may evaluate the same
constant multiple times.