### PR TITLE
Fix for bug in file handling refactor.

### DIFF
--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -402,7 +402,7 @@ PHPAPI int php_fopen_primary_script(zend_file_handle *file_handle)
 		IS_ABSOLUTE_PATH(PG(doc_root), length)) {
 		size_t path_len = strlen(path_info);
 		filename = zend_string_alloc(length + path_len + 2, 0);
-		memcpy(filename, PG(doc_root), length);
+		memcpy(ZSTR_VAL(filename), PG(doc_root), length);
 		if (!IS_SLASH(ZSTR_VAL(filename)[length - 1])) {	/* length is never 0 */
 			ZSTR_VAL(filename)[length++] = PHP_DIR_SEPARATOR;
 		}


### PR DESCRIPTION
While testing the cPanel usage of PHP-FPM, we stumbled on this bug.
Without the fix, the zend_string is corrupted and getting odd filenames

When using FPM we kept getting "No input file specified".

I work for cPanel and we use PHP extensively.