### PR TITLE
Add pdo_sqlite tests for empty filename and in-memory uri

### DIFF
--- a/ext/pdo_sqlite/tests/pdo_sqlite_empty_filename.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_empty_filename.phpt
@@ -1,0 +1,20 @@
+--TEST--
+PDO_sqlite: Testing empty filename
+--EXTENSIONS--
+pdo_sqlite
+--FILE--
+<?php
+
+// create with empty filename
+$db = new PDO('sqlite:');
+
+var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+
+// create with empty URI
+$db = new PDO('sqlite:file:?cache=shared');
+
+var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+?>
+--EXPECT--
+int(0)
+int(0)

--- a/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
@@ -5,6 +5,11 @@ pdo_sqlite
 --FILE--
 <?php
 
+// create with in-memory database
+$db = new PDO('sqlite:file::memory:?cache=shared');
+
+var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+
 // create with default read-write|create mode
 $filename = "file:" . __DIR__ . DIRECTORY_SEPARATOR . "pdo_sqlite_filename_uri.db";
 
@@ -28,6 +33,7 @@ if (file_exists($filename)) {
 }
 ?>
 --EXPECTF--
+int(0)
 int(0)
 
 Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: 8 attempt to write a readonly database in %s

--- a/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
@@ -5,10 +5,15 @@ pdo_sqlite
 --FILE--
 <?php
 
-// create with in-memory database
+// create with in-memory database using shared cached
 $db = new PDO('sqlite:file::memory:?cache=shared');
 
 var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+
+// create second connection to in-memory database
+$db = new PDO('sqlite:file::memory:?cache=shared');
+
+var_dump($db->exec('SELECT * from test1'));
 
 // create with default read-write|create mode
 $filename = "file:" . __DIR__ . DIRECTORY_SEPARATOR . "pdo_sqlite_filename_uri.db";
@@ -33,6 +38,7 @@ if (file_exists($filename)) {
 }
 ?>
 --EXPECTF--
+int(0)
 int(0)
 int(0)
 

--- a/ext/pdo_sqlite/tests/pdo_sqlite_open_basedir.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_open_basedir.phpt
@@ -1,0 +1,47 @@
+--TEST--
+PDO_sqlite: Testing filenames with open_basedir
+--EXTENSIONS--
+pdo_sqlite
+--INI--
+open_basedir=.
+--FILE--
+<?php
+
+// create in basedir
+$filename = 'pdo_sqlite_filename.db';
+
+$db = new PDO('sqlite:' . $filename);
+
+var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+
+// create outside basedir
+$filename = '..' . DIRECTORY_SEPARATOR . 'pdo_sqlite_filename.db';
+
+new PDO('sqlite:' . $filename);
+?>
+
+--CLEAN--
+<?php
+$filenames = [
+    'pdo_sqlite_filename.db',
+    '..' . DIRECTORY_SEPARATOR . 'pdo_sqlite_filename.db',
+];
+foreach ($filenames as $filename) {
+    if (file_exists($filename)) {
+        unlink($filename);
+    }
+}
+?>
+--EXPECTF--
+int(0)
+
+Fatal error: Uncaught PDOException: PDO::__construct(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (%s) in %s:%d
+Stack trace:
+%s
+#1 {main}
+
+Next PDOException: open_basedir prohibits opening %s in %s:%d
+Stack trace:
+%s
+#1 {main}
+  thrown in %s

--- a/ext/pdo_sqlite/tests/pdo_sqlite_open_basedir_uri.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_open_basedir_uri.phpt
@@ -1,0 +1,32 @@
+--TEST--
+PDO_sqlite: Testing URIs with open_basedir
+--EXTENSIONS--
+pdo_sqlite
+--INI--
+open_basedir={TMP}
+--FILE--
+<?php
+
+// create in basedir
+$filename = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pdo_sqlite_filename.db';
+
+new PDO('sqlite:file:' . $filename);
+?>
+
+--CLEAN--
+<?php
+$filenames = [
+    sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pdo_sqlite_filename.db',
+];
+foreach ($filenames as $filename) {
+    if (file_exists($filename)) {
+        unlink($filename);
+    }
+}
+?>
+--EXPECTF--
+Fatal error: Uncaught PDOException: open_basedir prohibits opening %s in %s:%d
+Stack trace:
+%s
+#1 {main}
+  thrown in %s


### PR DESCRIPTION
Refs #76868.

It would seem that pdo_sqlite supports empty filename and URIs as well as in-memory URIs. This adds tests to support that.

https://bugs.php.net/bug.php?id=76868
 
@cmb69 I was following up on the empty filename commit you referenced in ext/sqlite3.