### PR TITLE
Fixed bug #81430 Check if runtime cache pointer is NULL before dereferencing

### DIFF
--- a/Zend/zend_observer.c
+++ b/Zend/zend_observer.c
@@ -229,6 +229,7 @@ ZEND_API void ZEND_FASTCALL zend_observer_fcall_end(
 		zend_execute_data *ex = execute_data->prev_execute_data;
 		while (ex && (!ex->func || ex->func->type == ZEND_INTERNAL_FUNCTION
 		          || !ZEND_OBSERVABLE_FN(ex->func->common.fn_flags)
+		          || !&RUN_TIME_CACHE(&ex->func->op_array)
 		          || !ZEND_OBSERVER_DATA(&ex->func->op_array)
 		          || ZEND_OBSERVER_DATA(&ex->func->op_array) == ZEND_OBSERVER_NOT_OBSERVED)) {
 			ex = ex->prev_execute_data;

--- a/ext/zend_test/tests/observer_bug81430_1.phpt
+++ b/ext/zend_test/tests/observer_bug81430_1.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #81430 (Attribute instantiation frame has no run time cache)
+--INI--
+memory_limit=20M
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+
+#[\Attribute]
+class A {
+        public function __construct() {}
+}
+
+#[A]
+function B() {}
+
+$r = new \ReflectionFunction("B");
+call_user_func([$r->getAttributes(A::class)[0], 'newInstance']);
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init A::__construct() -->
+  <A::__construct>
+  </A::__construct>
+</file '%s'>

--- a/ext/zend_test/tests/observer_bug81430_1.phpt
+++ b/ext/zend_test/tests/observer_bug81430_1.phpt
@@ -17,6 +17,7 @@ function B() {}
 
 $r = new \ReflectionFunction("B");
 call_user_func([$r->getAttributes(A::class)[0], 'newInstance']);
+?>
 --EXPECTF--
 <!-- init '%s' -->
 <file '%s'>

--- a/ext/zend_test/tests/observer_bug81430_2.phpt
+++ b/ext/zend_test/tests/observer_bug81430_2.phpt
@@ -21,12 +21,13 @@ function B() {}
 
 $r = new \ReflectionFunction("B");
 call_user_func([$r->getAttributes(A::class)[0], 'newInstance']);
+?>
 --EXPECTF--
 <!-- init '%s' -->
 <file '%s'>
   <!-- init A::__construct() -->
   <A::__construct>
 
-Fatal error: Allowed memory size of 20971520 bytes exhausted %s in %s on line %d
+Fatal error: Allowed memory size of %d bytes exhausted %s in %s on line %d
   </A::__construct>
 </file '%s'>

--- a/ext/zend_test/tests/observer_bug81430_2.phpt
+++ b/ext/zend_test/tests/observer_bug81430_2.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Bug #81430 (Attribute instantiation leaves dangling execute_data pointer)
+--INI--
+memory_limit=20M
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--XFAIL--
+The stack allocated execute_data is invalid in zend_observer_fcall_end_all
+--FILE--
+<?php
+
+#[\Attribute]
+class A {
+        public function __construct() {
+                array_map("str_repeat", ["\xFF"], [100000000]); // cause a bailout
+        }
+}
+
+#[A]
+function B() {}
+
+$r = new \ReflectionFunction("B");
+call_user_func([$r->getAttributes(A::class)[0], 'newInstance']);
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init A::__construct() -->
+  <A::__construct>
+
+Fatal error: Allowed memory size of 20971520 bytes exhausted %s in %s on line %d
+  </A::__construct>
+</file '%s'>


### PR DESCRIPTION
Check if the runtime cache pointer is NULL before dereferencing it.