### PR TITLE
7.4: configure.ac: add build/ as macro-dir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,7 @@ AC_PREREQ([2.68])
 AC_INIT([PHP],[7.4.27-dev],[https://bugs.php.net],[php],[https://www.php.net])
 AC_CONFIG_SRCDIR([main/php_version.h])
 AC_CONFIG_AUX_DIR([build])
+AC_CONFIG_MACRO_DIRS([build])
 AC_PRESERVE_HELP_ORDER
 
 PHP_CONFIG_NICE(config.nice)


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=81637

Moved from https://github.com/php/php-src/pull/7666.