### PR TITLE
7.4 — curl/interface.c: avoid crashing, when PHP is compiled without IPv6 support, and CURL has IPv6 support

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1974,6 +1974,9 @@ static void _php_curl_set_default_options(php_curl *ch)
 #endif
 	curl_easy_setopt(ch->cp, CURLOPT_DNS_CACHE_TIMEOUT, 120);
 	curl_easy_setopt(ch->cp, CURLOPT_MAXREDIRS, 20); /* prevent infinite redirects */
+#if !ENABLE_IPV6
+	curl_easy_setopt(ch->cp, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+#endif
 
 	cainfo = INI_STR("openssl.cafile");
 	if (!(cainfo && cainfo[0] != '\0')) {
@@ -2574,6 +2577,12 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue) /* {{{
 		case CURLOPT_HTTP09_ALLOWED:
 #endif
 			lval = zval_get_long(zvalue);
+#if !ENABLE_IPV6
+			if (option == CURLOPT_IPRESOLVE && lval == CURL_IPRESOLVE_V6) {
+					php_error_docref(NULL, E_WARNING, "CURL_IPRESOLVE_V6 cannot be activated as PHP is compiled without IPv6 support");
+					return 1;
+			}
+#endif
 #if LIBCURL_VERSION_NUM >= 0x071304
 			if ((option == CURLOPT_PROTOCOLS || option == CURLOPT_REDIR_PROTOCOLS) &&
 				(PG(open_basedir) && *PG(open_basedir)) && (lval & CURLPROTO_FILE)) {


### PR DESCRIPTION
I have this patch since 2018, PHP-7.1.  My kernel knows about IPv6, but the system has no IPv6 routing configured and PHP is configured without IPv6 support.

Fixes https://bugs.php.net/bug.php?id=75862 .