### PR TITLE
socket: ancillary credentials build fix for non linux systems.

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -62,6 +62,34 @@ if test "$PHP_SOCKETS" != "no"; then
     AC_DEFINE(HAVE_AI_IDN,1,[Whether you have AI_IDN])
   fi
 
+  dnl Check for struct ucred
+  dnl checking the header is not enough	(eg DragonFlyBSD)
+  AC_CACHE_CHECK([if ancillary credentials uses ucred],[ac_cv_ucred],
+  [
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <sys/socket.h>
+  ]], [[struct ucred u = {.gid = 0};]])],
+      [ac_cv_ucred=yes], [ac_cv_ucred=no])
+  ])
+
+  if test "$ac_cv_ucred" = yes; then
+    AC_DEFINE(ANC_CREDS_UCRED,1,[Uses ucred struct])
+  fi
+
+  dnl Check for struct cmsgcred
+  AC_CACHE_CHECK([if ancillary credentials uses cmsgcred],[ac_cv_cmsgcred],
+  [
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <sys/socket.h>
+  ]], [[struct cmsgcred c = {0};]])],
+      [ac_cv_cmsgcred=yes], [ac_cv_cmsgcred=no])
+  ])
+
+  if test "$ac_cv_cmsgcred" = yes; then
+    AC_DEFINE(ANC_CREDS_CMSGCRED,1,[Uses cmsgcred struct])
+  fi
+
+
   PHP_SOCKETS_CFLAGS=-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1
   case $host_alias in
   *darwin*) PHP_SOCKETS_CFLAGS="$PHP_SOCKETS_CFLAGS -D__APPLE_USE_RFC_3542"

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -1297,13 +1297,20 @@ void to_zval_read_in6_pktinfo(const char *data, zval *zv, res_context *ctx)
 }
 #endif
 
-/* CONVERSIONS for struct ucred */
+/* CONVERSIONS for struct ucred/cmsgcred */
 #ifdef SO_PASSCRED
 static const field_descriptor descriptors_ucred[] = {
+#if defined(ANC_CREDS_UCRED)
 		{"pid", sizeof("pid"), 1, offsetof(struct ucred, pid), from_zval_write_pid_t, to_zval_read_pid_t},
 		{"uid", sizeof("uid"), 1, offsetof(struct ucred, uid), from_zval_write_uid_t, to_zval_read_uid_t},
 		/* assume the type gid_t is the same as uid_t: */
 		{"gid", sizeof("gid"), 1, offsetof(struct ucred, gid), from_zval_write_uid_t, to_zval_read_uid_t},
+#elif defined(ANC_CREDS_CMSGCRED)
+		{"pid", sizeof("pid"), 1, offsetof(struct cmsgcred, cmcred_pid), from_zval_write_pid_t, to_zval_read_pid_t},
+		{"uid", sizeof("uid"), 1, offsetof(struct cmsgcred, cmcred_uid), from_zval_write_uid_t, to_zval_read_uid_t},
+		/* assume the type gid_t is the same as uid_t: */
+		{"gid", sizeof("gid"), 1, offsetof(struct cmsgcred, cmcred_gid), from_zval_write_uid_t, to_zval_read_uid_t},
+#endif
 		{0}
 };
 void from_zval_write_ucred(const zval *container, char *ucred_c, ser_context *ctx)

--- a/ext/sockets/sendrecvmsg.c
+++ b/ext/sockets/sendrecvmsg.c
@@ -121,8 +121,13 @@ static void init_ancillary_registry(void)
 #endif
 
 #ifdef SO_PASSCRED
+#ifdef ANC_CREDS_UCRED
 	PUT_ENTRY(sizeof(struct ucred), 0, 0, from_zval_write_ucred,
 			to_zval_read_ucred, SOL_SOCKET, SCM_CREDENTIALS);
+#else
+	PUT_ENTRY(sizeof(struct cmsgcred), 0, 0, from_zval_write_ucred,
+			to_zval_read_ucred, SOL_SOCKET, SCM_CREDS);
+#endif
 #endif
 
 #ifdef SCM_RIGHTS
@@ -436,7 +441,11 @@ void php_socket_sendrecvmsg_init(INIT_FUNC_ARGS)
 	REGISTER_LONG_CONSTANT("SCM_RIGHTS",			SCM_RIGHTS,			CONST_CS | CONST_PERSISTENT);
 #endif
 #ifdef SO_PASSCRED
+#ifdef SCM_CREDENTIALS
 	REGISTER_LONG_CONSTANT("SCM_CREDENTIALS",		SCM_CREDENTIALS,	CONST_CS | CONST_PERSISTENT);
+#else
+	REGISTER_LONG_CONSTANT("SCM_CREDS",		SCM_CREDS,	CONST_CS | CONST_PERSISTENT);
+#endif
 	REGISTER_LONG_CONSTANT("SO_PASSCRED",			SO_PASSCRED,		CONST_CS | CONST_PERSISTENT);
 #endif
 


### PR DESCRIPTION
for systems using SO_PASSCRED sockopt flag but not using ucred struct.