### PR TITLE
Update #81645 : header() checks the validity of HTTP status code

### DIFF
--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -555,8 +555,8 @@ static int sapi_extract_response_code(const char *header_line)
 	for (ptr = header_line; *ptr; ptr++) {
 		if (*ptr == ' ' && *(ptr + 1) != ' ') {
 			/* beginning of the response code */
-			char* status_description = estrdup(ptr + 1);
-			char* response_code = strtok(status_description, " ");
+			char *status_description = estrdup(ptr + 1);
+			char *response_code = strtok(status_description, " ");
 
 			code = atoi(response_code);
 


### PR DESCRIPTION
## Reference
[Original Reference: header() allows arbitrary status codes (which may overflow) #81645](https://bugs.php.net/bug.php?id=81645)

### Description
To follow RFC 7230, now `header()` only accepts response code in the closed interval [100, 999]. However, `atoi` also allows a positive or negative sign in front of decimal representation which can lead invalid HTTP status line, an additional check logic using `strlen` is added. This patch also can prevent integer overflow which I raised initially.


#### Test1
```php
<?php
header("HTTP/1.1 200 OK");
```
#### Expect
Nothing wrong
#### Result
```
HTTP/1.1 200 OK
Date: Tue, 23 Nov 2021 08:28:00 GMT
Connection: close
X-Powered-By: PHP/8.2.0-dev
Content-type: text/html; charset=UTF-8
```

#### Test2
```php
<?php
header("HTTP/1.1 777 LUCKY");
```
#### Expect
It's not a standard status code, but it's acceptable.
#### Result
```
HTTP/1.1 777 LUCKY
Date: Tue, 23 Nov 2021 08:28:17 GMT
Connection: close
X-Powered-By: PHP/8.2.0-dev
Content-type: text/html; charset=UTF-8
```

#### Test3
```php
<?php
header("HTTP/1.1 11 ELEVEN");
```
#### Expect
It's an invalid HTTP status line because it's not 3 digit
#### Result
```
HTTP/1.1 200 OK
Date: Tue, 23 Nov 2021 08:28:40 GMT
Connection: close
X-Powered-By: PHP/8.2.0-dev
Content-type: text/html; charset=UTF-8

<br />
<b>Warning</b>:  Cannot set HTTP status line - status code is malformed in <b>/home/ubuntu/mytester/ser.php</b> on line <b>5</b><br />
```

#### Test4
```php
<?php
header("HTTP/1.1 1111 LONG");
```
#### Expect
It's an invalid HTTP status line because it's not 3 digit
#### Result
```
HTTP/1.1 200 OK
Date: Tue, 23 Nov 2021 08:29:25 GMT
Connection: close
X-Powered-By: PHP/8.2.0-dev
Content-type: text/html; charset=UTF-8

<br />
<b>Warning</b>:  Cannot set HTTP status line - status code is malformed in <b>/home/ubuntu/mytester/ser.php</b> on line <b>6</b><br />
```

#### Test5
```php
<?php
header("HTTP/1.1 007 IMPOSSIBLE");
```
#### Expect
It's lower than 100, but it's valid 3 digit
#### Result
```
HTTP/1.1 007 IMPOSSIBLE
Date: Tue, 23 Nov 2021 08:30:37 GMT
Connection: close
X-Powered-By: PHP/8.2.0-dev
Content-type: text/html; charset=UTF-8
```

#### Test6
```php
<?php
header("HTTP/1.1 000 ZERO");
```
#### Expect
It's totally zero, but 3 digit zero.
#### Result
```
HTTP/1.1 000 ZERO
Date: Tue, 23 Nov 2021 08:30:50 GMT
Connection: close
X-Powered-By: PHP/8.2.0-dev
Content-type: text/html; charset=UTF-8
```

#### Test7
```php
<?php
header("HTTP/1.1 4294967496 OVERFLOW");
```
#### Expect
It occurs overflow and parsed as 200 in atoi, but must be failed.
#### Result
```
HTTP/1.1 200 OK
Date: Tue, 23 Nov 2021 08:32:08 GMT
Connection: close
X-Powered-By: PHP/8.2.0-dev
Content-type: text/html; charset=UTF-8

<br />
<b>Warning</b>:  Cannot set HTTP status line - status code is malformed in <b>/home/ubuntu/mytester/ser.php</b> on line <b>9</b><br />
```