### PR TITLE
"Export" relevant GD macros

### DIFF
--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -25,7 +25,8 @@ if (PHP_GD != "no") {
 			if ((CHECK_LIB("libwebp_a.lib", "gd", PHP_GD) || CHECK_LIB("libwebp.lib", "gd", PHP_GD)) &&
 				CHECK_HEADER_ADD_INCLUDE("decode.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\webp") &&
 				CHECK_HEADER_ADD_INCLUDE("encode.h", "CFLAGS_GD", PHP_GD + ";" + PHP_PHP_BUILD + "\\include\\webp")) {
-				ADD_FLAG("CFLAGS_GD", "/D HAVE_LIBWEBP /D HAVE_GD_WEBP");
+				AC_DEFINE("HAVE_LIBWEBP", 1, "WebP support");
+				AC_DEFINE("HAVE_GD_WEBP", 1, "WebP support");
 			} else {
 				WARNING("libwebp not enabled; libraries and headers not found");
 			}
@@ -42,10 +43,20 @@ if (PHP_GD != "no") {
 			gd_filter.c gd_pixelate.c gd_rotate.c gd_color_match.c gd_webp.c \
 			gd_crop.c gd_interpolation.c gd_matrix.c gd_bmp.c gd_tga.c", "gd");
 		AC_DEFINE('HAVE_LIBGD', 1, 'GD support');
+		AC_DEFINE('HAVE_GD_BUNDLED', 1, "Bundled GD");
+		AC_DEFINE('HAVE_GD_PNG', 1, "PNG support");
+		AC_DEFINE('HAVE_GD_BMP', 1, "BMP support");
+		AC_DEFINE('HAVE_GD_TGA', 1, "TGA support");
+		AC_DEFINE('HAVE_LIBPNG', 1, "PNG support");
+		AC_DEFINE('HAVE_LIBJPEG', 1, "JPEG support");
+		AC_DEFINE('HAVE_GD_JPG', 1, "JPEG support");
+		AC_DEFINE('HAVE_XPM', 1, "XPM support");
+		AC_DEFINE('HAVE_GD_XPM', 1, "XPM support");
+		AC_DEFINE('HAVE_LIBFREETYPE', 1, "Freetype support");
+		AC_DEFINE('HAVE_GD_FREETYPE', 1, "Freetype support");
 		ADD_FLAG("CFLAGS_GD", " \
 /D PHP_GD_EXPORTS=1 \
 /D HAVE_GD_DYNAMIC_CTX_EX=1 \
-/D HAVE_GD_BUNDLED=1  \
 /D HAVE_GD_GD2  \
 /D HAVE_GD_GIF_READ=1  \
 /D HAVE_GD_GIF_CREATE=1  \
@@ -54,24 +65,14 @@ if (PHP_GD != "no") {
 /D HAVE_GD_IMAGESETTILE=1 \
 /D HAVE_GD_FONTCACHESHUTDOWN=1 \
 /D HAVE_GD_FONTMUTEX=1 \
-/D HAVE_LIBFREETYPE=1 \
-/D HAVE_GD_JPG  \
-/D HAVE_GD_PNG  \
 /D HAVE_GD_STRINGFTEX=1  \
 /D HAVE_GD_STRINGTTF=1  \
 /D HAVE_GD_WBMP  \
 /D HAVE_GD_XBM  \
-/D HAVE_GD_XPM  \
-/D HAVE_GD_FREETYPE=1  \
-/D HAVE_GD_BMP \
-/D HAVE_GD_TGA \
 /D HAVE_LIBGD13=1  \
 /D HAVE_LIBGD15=1  \
 /D HAVE_LIBGD20=1  \
 /D HAVE_LIBGD204=1 \
-/D HAVE_LIBJPEG  \
-/D HAVE_LIBPNG  \
-/D HAVE_XPM  \
 /D HAVE_COLORCLOSESTHWB  \
 /D HAVE_GD_GET_INTERPOLATION \
 /D USE_GD_IOCTX \


### PR DESCRIPTION
For parity with non Windows systems, we should `AC_DEFINE` these macros
so that they are defined in config.w32.h instead of directly passed to
the compiler.  This allows extensions which have ext/gd as dependency
to check for these macros.  E.g. ext/ps does this[1], and fails to
build on Windows, because `HAVE_GD_BUNDLED` isn't defined.

[1] <https://github.com/steinm/ps/blob/RELEASE_1_4_4/ps.c#L34>

---

Note that I targeted PHP-8.0 which is a compromise. Fixing this for PHP-7.4 might make sense as well, although ext/pd can't be build for that version with GD support anyway (https://bugs.php.net/81639).