### PR TITLE
Use the standard _WIN32 instead of the custom MSWIN32 in libgd

### DIFF
--- a/ext/gd/config.w32
+++ b/ext/gd/config.w32
@@ -88,7 +88,6 @@ if (PHP_GD != "no") {
 /D HAVE_COLORCLOSESTHWB  \
 /D HAVE_GD_GET_INTERPOLATION \
 /D USE_GD_IOCTX \
-/D MSWIN32 \
 		");
 		if (ICC_TOOLSET) {
 			ADD_FLAG("LDFLAGS_GD", "/nodefaultlib:libcmt");

--- a/ext/gd/libgd/gdft.c
+++ b/ext/gd/libgd/gdft.c
@@ -12,7 +12,7 @@
 #include "gd.h"
 #include "gdhelpers.h"
 
-#ifndef MSWIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <io.h>


### PR DESCRIPTION
We're already checking `_WIN32` elsewhere in our bundled libgd, so it
makes no sense to also have a custom `MSWIN32`.