### PR TITLE
fix [-Wstrict-prototypes] buid warnings

### DIFF
--- a/Zend/zend_cpuinfo.c
+++ b/Zend/zend_cpuinfo.c
@@ -106,7 +106,7 @@ static bool is_avx_supported() {
 	return 1;
 }
 #else
-static bool is_avx_supported() {
+static bool is_avx_supported(void) {
 	return 0;
 }
 #endif

--- a/Zend/zend_cpuinfo.h
+++ b/Zend/zend_cpuinfo.h
@@ -215,7 +215,7 @@ static inline int zend_cpu_supports_pclmul() {
 	return __builtin_cpu_supports("pclmul");
 }
 #else
-static inline int zend_cpu_supports_pclmul() {
+static inline int zend_cpu_supports_pclmul(void) {
 	return zend_cpu_supports(ZEND_CPU_FEATURE_PCLMULQDQ);
 }
 #endif

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -154,7 +154,7 @@ void zend_exception_restore(void) /* {{{ */
 }
 /* }}} */
 
-static zend_always_inline bool is_handle_exception_set() {
+static zend_always_inline bool is_handle_exception_set(void) {
 	zend_execute_data *execute_data = EG(current_execute_data);
 	return !execute_data->func
 		|| !ZEND_USER_CODE(execute_data->func->common.type)

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -727,7 +727,7 @@ exit:
 }
 /* }}} */
 
-static zend_always_inline bool property_uses_strict_types() {
+static zend_always_inline bool property_uses_strict_types(void) {
 	zend_execute_data *execute_data = EG(current_execute_data);
 	return execute_data
 		&& execute_data->func

--- a/ext/hash/murmur/endianness.h
+++ b/ext/hash/murmur/endianness.h
@@ -2,7 +2,7 @@ static const union {
   uint8_t u8[2];
   uint16_t u16;
 } EndianMix = {{ 1, 0 }};
-FORCE_INLINE int IsBigEndian()
+FORCE_INLINE int IsBigEndian(void)
 {
   // Constant-folded by the compiler.
   return EndianMix.u16 != 1;

--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -104,7 +104,7 @@ static inline spl_dllist_object *spl_dllist_from_obj(zend_object *obj) /* {{{ */
 
 #define Z_SPLDLLIST_P(zv)  spl_dllist_from_obj(Z_OBJ_P((zv)))
 
-static spl_ptr_llist *spl_ptr_llist_init() /* {{{ */
+static spl_ptr_llist *spl_ptr_llist_init(void) /* {{{ */
 {
 	spl_ptr_llist *llist = emalloc(sizeof(spl_ptr_llist));
 

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -2371,7 +2371,7 @@ static char *php_cli_server_parse_addr(const char *addr, int *pport) {
 	return pestrndup(addr, end - addr, 1);
 }
 
-static void php_cli_server_startup_workers() {
+static void php_cli_server_startup_workers(void) {
 	char *workers = getenv("PHP_CLI_SERVER_WORKERS");
 	if (!workers) {
 		return;


### PR DESCRIPTION
These warnings appear with recent GCC 11.2

Notice some other still present in ext/gd, but terrible to fix, especially because of https://github.com/php/php-src/blob/master/ext/gd/gd.c#L1699