### PR TITLE
Optimize SplObjectStorage native read/write/isset dimension handlers

### DIFF
--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -44,10 +44,17 @@ PHPAPI zend_class_entry     *spl_ce_MultipleIterator;
 
 PHPAPI zend_object_handlers spl_handler_SplObjectStorage;
 
+/* Bit flags for marking internal functionality overridden by SplObjectStorage subclasses. */
+#define SOS_OVERRIDDEN_READ_DIMENSION  1
+#define SOS_OVERRIDDEN_WRITE_DIMENSION 2
+#define SOS_OVERRIDDEN_UNSET_DIMENSION 4
+
 typedef struct _spl_SplObjectStorage { /* {{{ */
 	HashTable         storage;
 	zend_long         index;
 	HashPosition      pos;
+	/* In SplObjectStorage, flags is a hidden implementation detail to optimize ArrayAccess handlers.
+	 * In MultipleIterator on a different class hierarchy, flags is a user settable value controlling iteration behavior. */
 	zend_long         flags;
 	zend_function    *fptr_get_hash;
 	zend_object       std;
@@ -76,7 +83,7 @@ void spl_SplObjectStorage_free_storage(zend_object *object) /* {{{ */
 } /* }}} */
 
 static int spl_object_storage_get_hash(zend_hash_key *key, spl_SplObjectStorage *intern, zend_object *obj) {
-	if (intern->fptr_get_hash) {
+	if (UNEXPECTED(intern->fptr_get_hash)) {
 		zval param;
 		zval rv;
 		ZVAL_OBJ(&param, obj);
@@ -125,8 +132,55 @@ static spl_SplObjectStorageElement* spl_object_storage_get(spl_SplObjectStorage 
 	}
 } /* }}} */
 
+static spl_SplObjectStorageElement *spl_object_storage_create_element(zend_object *obj, zval *inf) /* {{{ */
+{
+	spl_SplObjectStorageElement *pelement = emalloc(sizeof(spl_SplObjectStorageElement));
+	pelement->obj = obj;
+	GC_ADDREF(obj);
+	if (inf) {
+		ZVAL_COPY(&pelement->inf, inf);
+	} else {
+		ZVAL_NULL(&pelement->inf);
+	}
+	return pelement;
+} /* }}} */
+
+/* A faster version of spl_object_storage_attach used when neither SplObjectStorage->getHash nor SplObjectStorage->offsetSet is overridden. */
+static spl_SplObjectStorageElement *spl_object_storage_attach_handle(spl_SplObjectStorage *intern, zend_object *obj, zval *inf) /* {{{ */
+{
+	uint32_t handle = obj->handle;
+	zval *entry_zv = zend_hash_index_lookup(&intern->storage, handle);
+	spl_SplObjectStorageElement *pelement;
+	ZEND_ASSERT(!(intern->flags & SOS_OVERRIDDEN_WRITE_DIMENSION));
+
+	if (Z_TYPE_P(entry_zv) != IS_NULL) {
+		zval zv_inf;
+		ZEND_ASSERT(Z_TYPE_P(entry_zv) == IS_PTR);
+		pelement = Z_PTR_P(entry_zv);
+		ZVAL_COPY_VALUE(&zv_inf, &pelement->inf);
+		ZEND_ASSERT(Z_TYPE(zv_inf) != IS_REFERENCE);
+		if (inf) {
+			ZVAL_COPY(&pelement->inf, inf);
+		} else {
+			ZVAL_NULL(&pelement->inf);
+		}
+		/* Call the old value's destructor last, in case it moves the entry */
+		zval_ptr_dtor(&zv_inf);
+		return pelement;
+	}
+
+	pelement = spl_object_storage_create_element(obj, inf);
+	ZVAL_PTR(entry_zv, pelement);
+	return pelement;
+} /* }}} */
+
 spl_SplObjectStorageElement *spl_object_storage_attach(spl_SplObjectStorage *intern, zend_object *obj, zval *inf) /* {{{ */
 {
+	if (EXPECTED(!(intern->flags & SOS_OVERRIDDEN_WRITE_DIMENSION))) {
+		return spl_object_storage_attach_handle(intern, obj, inf);
+	}
+	/* getHash or offsetSet is overridden. */
+
 	spl_SplObjectStorageElement *pelement, element;
 	zend_hash_key key;
 	if (spl_object_storage_get_hash(&key, intern, obj) == FAILURE) {
@@ -136,13 +190,17 @@ spl_SplObjectStorageElement *spl_object_storage_attach(spl_SplObjectStorage *int
 	pelement = spl_object_storage_get(intern, &key);
 
 	if (pelement) {
-		zval_ptr_dtor(&pelement->inf);
+		zval zv_inf;
+		ZVAL_COPY_VALUE(&zv_inf, &pelement->inf);
+		ZEND_ASSERT(Z_TYPE(zv_inf) != IS_REFERENCE);
 		if (inf) {
 			ZVAL_COPY(&pelement->inf, inf);
 		} else {
 			ZVAL_NULL(&pelement->inf);
 		}
 		spl_object_storage_free_hash(intern, &key);
+		/* Call the old value's destructor last, in case it moves the entry */
+		zval_ptr_dtor(&zv_inf);
 		return pelement;
 	}
 
@@ -164,6 +222,9 @@ spl_SplObjectStorageElement *spl_object_storage_attach(spl_SplObjectStorage *int
 
 static int spl_object_storage_detach(spl_SplObjectStorage *intern, zend_object *obj) /* {{{ */
 {
+	if (EXPECTED(!(intern->flags & SOS_OVERRIDDEN_UNSET_DIMENSION))) {
+		return zend_hash_index_del(&intern->storage, obj->handle);
+	}
 	int ret = FAILURE;
 	zend_hash_key key;
 	if (spl_object_storage_get_hash(&key, intern, obj) == FAILURE) {
@@ -189,6 +250,9 @@ void spl_object_storage_addall(spl_SplObjectStorage *intern, spl_SplObjectStorag
 	intern->index = 0;
 } /* }}} */
 
+#define SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, zstr_method) \
+	(((zend_function *)zend_hash_find_ptr(&(class_type)->function_table, ZSTR_KNOWN(zstr_method)))->common.scope != spl_ce_SplObjectStorage)
+
 static zend_object *spl_object_storage_new_ex(zend_class_entry *class_type, zend_object *orig) /* {{{ */
 {
 	spl_SplObjectStorage *intern;
@@ -207,10 +271,27 @@ static zend_object *spl_object_storage_new_ex(zend_class_entry *class_type, zend
 
 	while (parent) {
 		if (parent == spl_ce_SplObjectStorage) {
+			/* Possible optimization: Cache these results with a map from class entry to IS_NULL/IS_PTR.
+			 * Or maybe just a single item with the result for the most recently loaded subclass. */
 			if (class_type != spl_ce_SplObjectStorage) {
-				intern->fptr_get_hash = zend_hash_str_find_ptr(&class_type->function_table, "gethash", sizeof("gethash") - 1);
-				if (intern->fptr_get_hash->common.scope == spl_ce_SplObjectStorage) {
-					intern->fptr_get_hash = NULL;
+				zend_function *get_hash = zend_hash_str_find_ptr(&class_type->function_table, "gethash", sizeof("gethash") - 1);
+				if (get_hash->common.scope != spl_ce_SplObjectStorage) {
+					intern->fptr_get_hash = get_hash;
+				}
+				if (intern->fptr_get_hash != NULL ||
+					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, ZEND_STR_OFFSETGET) ||
+					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, ZEND_STR_OFFSETEXISTS)) {
+					intern->flags |= SOS_OVERRIDDEN_READ_DIMENSION;
+				}
+
+				if (intern->fptr_get_hash != NULL ||
+					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, ZEND_STR_OFFSETSET)) {
+					intern->flags |= SOS_OVERRIDDEN_WRITE_DIMENSION;
+				}
+
+				if (intern->fptr_get_hash != NULL ||
+					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, ZEND_STR_OFFSETUNSET)) {
+					intern->flags |= SOS_OVERRIDDEN_UNSET_DIMENSION;
 				}
 			}
 			break;
@@ -328,20 +409,21 @@ static zend_object *spl_SplObjectStorage_new(zend_class_entry *class_type)
 }
 /* }}} */
 
-int spl_object_storage_contains(spl_SplObjectStorage *intern, zend_object *obj) /* {{{ */
+/* Returns true if the SplObjectStorage contains an entry for getHash(obj), even if the corresponding value is null. */
+bool spl_object_storage_contains(spl_SplObjectStorage *intern, zend_object *obj) /* {{{ */
 {
-	int found;
+	if (EXPECTED(!intern->fptr_get_hash)) {
+		return zend_hash_index_find(&intern->storage, obj->handle) != NULL;
+	}
 	zend_hash_key key;
 	if (spl_object_storage_get_hash(&key, intern, obj) == FAILURE) {
-		return 0;
+		return true;
 	}
 
-	if (key.key) {
-		found = zend_hash_exists(&intern->storage, key.key);
-	} else {
-		found = zend_hash_index_exists(&intern->storage, key.h);
-	}
-	spl_object_storage_free_hash(intern, &key);
+	ZEND_ASSERT(key.key);
+	bool found = zend_hash_exists(&intern->storage, key.key);
+	zend_string_release_ex(key.key, 0);
+
 	return found;
 } /* }}} */
 
@@ -360,6 +442,69 @@ PHP_METHOD(SplObjectStorage, attach)
 	ZEND_PARSE_PARAMETERS_END();
 	spl_object_storage_attach(intern, obj, inf);
 } /* }}} */
+
+static int spl_object_storage_has_dimension(zend_object *object, zval *offset, int check_empty)
+{
+	spl_SplObjectStorage *intern = spl_object_storage_from_obj(object);
+	if (UNEXPECTED(offset == NULL || Z_TYPE_P(offset) != IS_OBJECT || (intern->flags & SOS_OVERRIDDEN_READ_DIMENSION))) {
+		/* Can't optimize empty()/isset() check if getHash, offsetExists, or offsetGet is overridden */
+		return zend_std_has_dimension(object, offset, check_empty);
+	}
+	spl_SplObjectStorageElement *element = zend_hash_index_find_ptr(&intern->storage, Z_OBJ_HANDLE_P(offset));
+	if (!element) {
+		return 0;
+	}
+
+	if (check_empty) {
+		return i_zend_is_true(&element->inf);
+	}
+	/* NOTE: SplObjectStorage->offsetExists() is an alias of SplObjectStorage->contains(), so this returns true even if the value is null. */
+	return 1;
+}
+
+static zval *spl_object_storage_read_dimension(zend_object *object, zval *offset, int type, zval *rv)
+{
+	spl_SplObjectStorage *intern = spl_object_storage_from_obj(object);
+	if (UNEXPECTED(offset == NULL || Z_TYPE_P(offset) != IS_OBJECT || (intern->flags & SOS_OVERRIDDEN_READ_DIMENSION))) {
+		/* Can't optimize it if getHash, offsetExists, or offsetGet is overridden */
+		return zend_std_read_dimension(object, offset, type, rv);
+	}
+	spl_SplObjectStorageElement *element = zend_hash_index_find_ptr(&intern->storage, Z_OBJ_HANDLE_P(offset));
+
+	if (!element) {
+		if (type == BP_VAR_IS) {
+			return &EG(uninitialized_zval);
+		}
+		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "Object not found");
+		return NULL;
+	} else {
+		/* This deliberately returns a non-reference, even for BP_VAR_W and BP_VAR_RW, to behave the same way as SplObjectStorage did when using the default zend_std_read_dimension behavior.
+		 * i.e. This prevents taking a reference to an entry of SplObjectStorage because offsetGet would return a non-reference. */
+		ZEND_ASSERT(Z_TYPE(element->inf) != IS_REFERENCE);
+		ZVAL_COPY(rv, &element->inf);
+		return rv;
+	}
+}
+
+static void spl_object_storage_write_dimension(zend_object *object, zval *offset, zval *inf)
+{
+	spl_SplObjectStorage *intern = spl_object_storage_from_obj(object);
+	if (UNEXPECTED(offset == NULL || Z_TYPE_P(offset) != IS_OBJECT || (intern->flags & SOS_OVERRIDDEN_WRITE_DIMENSION))) {
+		zend_std_write_dimension(object, offset, inf);
+		return;
+	}
+	spl_object_storage_attach_handle(intern, Z_OBJ_P(offset), inf);
+}
+
+static void spl_object_storage_unset_dimension(zend_object *object, zval *offset)
+{
+	spl_SplObjectStorage *intern = spl_object_storage_from_obj(object);
+	if (UNEXPECTED(Z_TYPE_P(offset) != IS_OBJECT || (intern->flags & SOS_OVERRIDDEN_UNSET_DIMENSION))) {
+		zend_std_unset_dimension(object, offset);
+		return;
+	}
+	zend_hash_index_del(&intern->storage, Z_OBJ_HANDLE_P(offset));
+}
 
 /* {{{ Detaches an object from the storage */
 PHP_METHOD(SplObjectStorage, detach)
@@ -411,7 +556,7 @@ PHP_METHOD(SplObjectStorage, offsetGet)
 	if (!element) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "Object not found");
 	} else {
-		RETURN_COPY_DEREF(&element->inf);
+		RETURN_COPY(&element->inf);
 	}
 } /* }}} */
 
@@ -1201,6 +1346,10 @@ PHP_MINIT_FUNCTION(spl_observer)
 	spl_handler_SplObjectStorage.clone_obj       = spl_object_storage_clone;
 	spl_handler_SplObjectStorage.get_gc          = spl_object_storage_get_gc;
 	spl_handler_SplObjectStorage.free_obj        = spl_SplObjectStorage_free_storage;
+	spl_handler_SplObjectStorage.read_dimension  = spl_object_storage_read_dimension;
+	spl_handler_SplObjectStorage.write_dimension = spl_object_storage_write_dimension;
+	spl_handler_SplObjectStorage.has_dimension   = spl_object_storage_has_dimension;
+	spl_handler_SplObjectStorage.unset_dimension = spl_object_storage_unset_dimension;
 
 	spl_ce_MultipleIterator = register_class_MultipleIterator(zend_ce_iterator);
 	spl_ce_MultipleIterator->create_object = spl_SplObjectStorage_new;

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -158,7 +158,6 @@ static spl_SplObjectStorageElement *spl_object_storage_attach_handle(spl_SplObje
 		ZEND_ASSERT(Z_TYPE_P(entry_zv) == IS_PTR);
 		pelement = Z_PTR_P(entry_zv);
 		ZVAL_COPY_VALUE(&zv_inf, &pelement->inf);
-		ZEND_ASSERT(Z_TYPE(zv_inf) != IS_REFERENCE);
 		if (inf) {
 			ZVAL_COPY(&pelement->inf, inf);
 		} else {
@@ -192,7 +191,6 @@ spl_SplObjectStorageElement *spl_object_storage_attach(spl_SplObjectStorage *int
 	if (pelement) {
 		zval zv_inf;
 		ZVAL_COPY_VALUE(&zv_inf, &pelement->inf);
-		ZEND_ASSERT(Z_TYPE(zv_inf) != IS_REFERENCE);
 		if (inf) {
 			ZVAL_COPY(&pelement->inf, inf);
 		} else {
@@ -481,7 +479,7 @@ static zval *spl_object_storage_read_dimension(zend_object *object, zval *offset
 		/* This deliberately returns a non-reference, even for BP_VAR_W and BP_VAR_RW, to behave the same way as SplObjectStorage did when using the default zend_std_read_dimension behavior.
 		 * i.e. This prevents taking a reference to an entry of SplObjectStorage because offsetGet would return a non-reference. */
 		ZEND_ASSERT(Z_TYPE(element->inf) != IS_REFERENCE);
-		ZVAL_COPY(rv, &element->inf);
+		ZVAL_COPY_DEREF(rv, &element->inf);
 		return rv;
 	}
 }
@@ -556,7 +554,7 @@ PHP_METHOD(SplObjectStorage, offsetGet)
 	if (!element) {
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0, "Object not found");
 	} else {
-		RETURN_COPY(&element->inf);
+		RETURN_COPY_DEREF(&element->inf);
 	}
 } /* }}} */
 
@@ -996,6 +994,7 @@ PHP_METHOD(SplObjectStorage, __unserialize)
 				RETURN_THROWS();
 			}
 
+			ZVAL_DEREF(val);
 			spl_object_storage_attach(intern, Z_OBJ_P(key), val);
 			key = NULL;
 		} else {

--- a/ext/spl/tests/SplObjectStorage_coalesce.phpt
+++ b/ext/spl/tests/SplObjectStorage_coalesce.phpt
@@ -1,0 +1,91 @@
+--TEST--
+SplObjectStorage magic operators
+--FILE--
+<?php
+$i = 'dynamic';
+$v = $i . '_';
+$s = new SplObjectStorage();
+$o1 = new Stdclass;
+$o2 = new Stdclass;
+var_dump($s[$o1] ?? 'default');
+var_dump($s[$o1] ??= $i);
+var_dump($s[$o1] ??= null);
+var_dump($s[$o1] ??= false);
+var_dump($s[$o1] ?? $i);
+var_dump(isset($s[$o1]));
+var_dump(empty($s[$o1]));
+echo "o2\n";
+var_dump(isset($s[$o2]));
+var_dump(empty($s[$o2]));
+$s[$o2] = null;
+var_dump($s[$o2] ?? new stdClass());
+echo "check isset/empty/contains for null. offsetExists returns true as long as the entry is there.\n";
+var_dump(isset($s[$o2]));
+var_dump(empty($s[$o2]));
+var_dump($s->contains($o2));
+echo "check isset/empty/contains for false.\n";
+$s[$o2] = false;
+var_dump(isset($s[$o2]));
+var_dump(empty($s[$o2]));
+var_dump($s->contains($o2));
+try {
+    $s['invalid'] = 123;
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+try {
+    var_dump(isset($s['invalid']));
+} catch (Error $e) {
+    printf("%s: %s\n", $e::class, $e->getMessage());
+}
+$a = &$s[$o1];
+
+var_dump($s);
+
+?>
+--EXPECTF--
+string(7) "default"
+string(7) "dynamic"
+string(7) "dynamic"
+string(7) "dynamic"
+string(7) "dynamic"
+bool(true)
+bool(false)
+o2
+bool(false)
+bool(true)
+object(stdClass)#4 (0) {
+}
+check isset/empty/contains for null. offsetExists returns true as long as the entry is there.
+bool(true)
+bool(true)
+bool(true)
+check isset/empty/contains for false.
+bool(true)
+bool(true)
+bool(true)
+TypeError: SplObjectStorage::offsetSet(): Argument #1 ($object) must be of type object, string given
+TypeError: SplObjectStorage::offsetExists(): Argument #1 ($object) must be of type object, string given
+
+Notice: Indirect modification of overloaded element of SplObjectStorage has no effect in %s on line 38
+object(SplObjectStorage)#1 (1) {
+  ["storage":"SplObjectStorage":private]=>
+  array(2) {
+    [0]=>
+    array(2) {
+      ["obj"]=>
+      object(stdClass)#2 (0) {
+      }
+      ["inf"]=>
+      string(7) "dynamic"
+    }
+    [1]=>
+    array(2) {
+      ["obj"]=>
+      object(stdClass)#3 (0) {
+      }
+      ["inf"]=>
+      bool(false)
+    }
+  }
+}

--- a/ext/spl/tests/SplObjectStorage_unserialize_reference.phpt
+++ b/ext/spl/tests/SplObjectStorage_unserialize_reference.phpt
@@ -1,0 +1,42 @@
+--TEST--
+SPL: Test that __unserialize converts references to non-references
+--FILE--
+<?php
+
+$s = new SplObjectStorage();
+$y = 1;
+$o = new stdClass();
+$x = [$o, &$y];
+$s->__unserialize([$x, []]);
+var_dump($s);
+$val = $s[$o];
+$val = 123;
+var_dump($s);
+?>
+--EXPECT--
+object(SplObjectStorage)#1 (1) {
+  ["storage":"SplObjectStorage":private]=>
+  array(1) {
+    [0]=>
+    array(2) {
+      ["obj"]=>
+      object(stdClass)#2 (0) {
+      }
+      ["inf"]=>
+      int(1)
+    }
+  }
+}
+object(SplObjectStorage)#1 (1) {
+  ["storage":"SplObjectStorage":private]=>
+  array(1) {
+    [0]=>
+    array(2) {
+      ["obj"]=>
+      object(stdClass)#2 (0) {
+      }
+      ["inf"]=>
+      int(1)
+    }
+  }
+}

--- a/ext/spl/tests/SplObjectStorage_unset.phpt
+++ b/ext/spl/tests/SplObjectStorage_unset.phpt
@@ -1,0 +1,55 @@
+--TEST--
+SplObjectStorage unset and destructor edge cases
+--FILE--
+<?php
+class HasDestructor {
+    public function __destruct() {
+        echo "In destructor. Should no longer be accessible in \$s:\n";
+        var_dump($GLOBALS['s']);
+
+        throw new RuntimeException("thrown from destructor");
+    }
+}
+$o = new stdClass();
+$s = new SplObjectStorage();
+$s[$o] = new HasDestructor();
+try {
+    unset($s[$o]);
+} catch (Exception $e) {
+    echo "Caught: {$e->getMessage()}\n";
+}
+var_dump($s);
+$s[$o] = new HasDestructor();
+try {
+    $s->offsetUnset($o);
+} catch (Exception $e) {
+    echo "Caught: {$e->getMessage()}\n";
+}
+
+var_dump($s);
+?>
+--EXPECT--
+In destructor. Should no longer be accessible in $s:
+object(SplObjectStorage)#2 (1) {
+  ["storage":"SplObjectStorage":private]=>
+  array(0) {
+  }
+}
+Caught: thrown from destructor
+object(SplObjectStorage)#2 (1) {
+  ["storage":"SplObjectStorage":private]=>
+  array(0) {
+  }
+}
+In destructor. Should no longer be accessible in $s:
+object(SplObjectStorage)#2 (1) {
+  ["storage":"SplObjectStorage":private]=>
+  array(0) {
+  }
+}
+Caught: thrown from destructor
+object(SplObjectStorage)#2 (1) {
+  ["storage":"SplObjectStorage":private]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
This makes reading/writing with `$splObjectStorage[$offset]` shorthand twice as
fast as it was previously, and a bit faster than offsetGet/offsetSet instead of
(previously) much slower.

There have been no attempts at adding these read/write handlers in the commit history of this file.

The shorthand syntax is also more concise than calling offsetGet/offsetSet directly.

Related to GH-7690

A synthetic benchmark that sequentially writes then sequentially reads data in a SplObjectStorage with 100000 entries:

- Time to construct a SplObjectStorage instance instead of a subclass - I expect that to be unaffected
- Reads/writes to SplObjectStorage (or subclasses that don't override offsetGet/offsetSet/offsetExists/getHash)  - I expect that to be faster, like the benchmarks
- Magic array dimension read/write shorthand syntax is much faster
- Subclasses that do override those ArrayAccess methods may be slightly slower than before, but are uncommon overall (and were already slow) 

```php
<?php

class Example {
}

function bench_spl_object_storage_short(int $n) {
    $m = new SplObjectStorage();
    $values = [];
    for ($i = 0; $i < $n; $i++) {
        $x = new Example();
        $m[$x] = $i;
        $values[] = $x;
    }
    $total = 0;
    foreach ($values as $x) {
        $total += $m[$x];
    }
    return $total;
}

function bench_spl_object_storage(int $n) {
    $m = new SplObjectStorage();
    $values = [];
    for ($i = 0; $i < $n; $i++) {
        $x = new Example();
        $m->offsetSet($x, $i);
        $values[] = $x;
    }
    $total = 0;
    foreach ($values as $x) {
        $total += $m->offsetGet($x);
    }
    return $total;
}

function bench_weak_map(int $n) {
    $m = new WeakMap();
    $values = [];
    for ($i = 0; $i < $n; $i++) {
        $x = new Example();
        $m[$x] = $i;
        $values[] = $x;
    }
    $total = 0;
    foreach ($values as $x) {
        $total += $m[$x];
    }
    return $total;
}

function main(int $n, int $iterations) {
    error_reporting(E_ALL & ~E_DEPRECATED);
    ini_set('memory_limit', '1G');
    foreach (['bench_spl_object_storage', 'bench_spl_object_storage_short', 'bench_weak_map'] as $f) {
        gc_collect_cycles();
        $t1 = hrtime(true);
        for ($i = 0; $i < $iterations; $i++) {
            $total = $f($n);
        }
        $t2 = hrtime(true);
        printf("%30s: n=%d iterations=%d create+read time=%.6f result=%d\n", $f, $n, $iterations, ($t2 - $t1)/1e9, $total);
    }
    echo "\n";
}

for ($i = 0; $i < 10; $i++) {
    main(100000, 10);
}
```

Before work on WeakMap

```
      bench_spl_object_storage: n=100000 iterations=10 create+read time=0.137906 result=4999950000
bench_spl_object_storage_short: n=100000 iterations=10 create+read time=0.231022 result=4999950000
                bench_weak_map: n=100000 iterations=10 create+read time=0.360986 result=4999950000
```

With this PR, bench_spl_object_storage_short is much faster than before:

```
      bench_spl_object_storage: n=100000 iterations=10 create+read time=0.135253 result=4999950000
bench_spl_object_storage_short: n=100000 iterations=10 create+read time=0.113202 result=4999950000
```

With GH-7690 and related work on WeakMap, create+read for WeakMap is faster than before

```
                bench_weak_map: n=100000 iterations=10 create+read time=0.150795 result=4999950000
```

It's safer to call `zval_ptr_dtor` on a copy of the zval (ZVAL_COPY_VALUE) AFTER updating the SplObjectStorage entry in case the entry is moved or updated by the destructor (e.g. `__destruct` deletes the entry while it's being updated, causing that pointer to be invalidated) - this is a bug unrelated to this change that is unlikely in typical code.