### PR TITLE
Don't run sapi/fpm tests in parallel with other fpm tests

### DIFF
--- a/sapi/fpm/tests/bug68381-log-level-warning.phpt
+++ b/sapi/fpm/tests/bug68381-log-level-warning.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug68381 - Log messages with warning level only
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/bug68391-conf-include-order.phpt
+++ b/sapi/fpm/tests/bug68391-conf-include-order.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug68391 - Configuration inclusion in alphabetical order
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/bug68420-ipv4-all-addresses.phpt
+++ b/sapi/fpm/tests/bug68420-ipv4-all-addresses.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug68420 - IPv4 all addresses
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/bug68421-ipv6-access-log.phpt
+++ b/sapi/fpm/tests/bug68421-ipv6-access-log.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug68421 - IPv6 all addresses and access_log
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/bug68423-multi-pool-all-pms.phpt
+++ b/sapi/fpm/tests/bug68423-multi-pool-all-pms.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug68423 - Multiple pools with different PMs (dynamic + ondemand + static)
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug68428-ipv6-allowed-clients.phpt
+++ b/sapi/fpm/tests/bug68428-ipv6-allowed-clients.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug68428 - IPv6 allowed client only
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/bug68442-signal-reload.phpt
+++ b/sapi/fpm/tests/bug68442-signal-reload.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug68442 - Signal reload
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug68458-pm-no-start-server.phpt
+++ b/sapi/fpm/tests/bug68458-pm-no-start-server.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug68458 - Missing pm.start_servers should emit notice instead of warning
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/bug69625-no-script-filename.phpt
+++ b/sapi/fpm/tests/bug69625-no-script-filename.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug69625 - 404 should be returned on missing SCRIPT_FILENAME
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug72573-http-proxy.phpt
+++ b/sapi/fpm/tests/bug72573-http-proxy.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug72573 - HTTP_PROXY - CVE-2016-5385
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug73342-nonblocking-stdio.phpt
+++ b/sapi/fpm/tests/bug73342-nonblocking-stdio.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug73342 - Non-blocking stdin
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug74083-concurrent-reload.phpt
+++ b/sapi/fpm/tests/bug74083-concurrent-reload.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Concurrent reload signals should not kill PHP-FPM master process. (Bug: #74083)
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/bug75212-php-value-in-user-ini.phpt
+++ b/sapi/fpm/tests/bug75212-php-value-in-user-ini.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug75212 - php_value acts like php_admin_value
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug76601-reload-child-signals.phpt
+++ b/sapi/fpm/tests/bug76601-reload-child-signals.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug76601 children should not ignore signals during concurrent reloads
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/bug77934-reload-process-control.phpt
+++ b/sapi/fpm/tests/bug77934-reload-process-control.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug77934 - php-fpm kill -USR2 not working
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug78323.phpt
+++ b/sapi/fpm/tests/bug78323.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Bug #78323 Test exit code for invalid parameters
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug78599-path-info-underflow.phpt
+++ b/sapi/fpm/tests/bug78599-path-info-underflow.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug78599 - env_path_info underflow - CVE-2019-11043
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug80024-socket-reduced-inherit.phpt
+++ b/sapi/fpm/tests/bug80024-socket-reduced-inherit.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug80024 - Duplication of info about inherited socket after pool removing
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/bug80849-fpm.phpt
+++ b/sapi/fpm/tests/bug80849-fpm.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #80849 (HTTP Status header truncation)
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/fastcgi_finish_request_basic.phpt
+++ b/sapi/fpm/tests/fastcgi_finish_request_basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Function fastcgi_finish_request basic test
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/fpm_get_status_basic.phpt
+++ b/sapi/fpm/tests/fpm_get_status_basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Function fpm_get_status basic test
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/getallheaders.phpt
+++ b/sapi/fpm/tests/getallheaders.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Function getallheaders basic test
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
+++ b/sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Log message in shutdown function
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt
+++ b/sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered message output log with limit 1024 and msg 80
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bm-limit-2048-msg-4000.phpt
+++ b/sapi/fpm/tests/log-bm-limit-2048-msg-4000.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered message output log with limit 2048 and msg 4000
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwd-limit-1050-msg-2048.phpt
+++ b/sapi/fpm/tests/log-bwd-limit-1050-msg-2048.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output decorated log with limit 1050 with 2048 msg
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwd-limit-1050-msg-2900.phpt
+++ b/sapi/fpm/tests/log-bwd-limit-1050-msg-2900.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output decorated log with limit 1050 with 2900 msg
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwd-limit-64-too-low-error.phpt
+++ b/sapi/fpm/tests/log-bwd-limit-64-too-low-error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output decorated log with limit 64 fails because it is too low
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwd-limit-8000-msg-4096.phpt
+++ b/sapi/fpm/tests/log-bwd-limit-8000-msg-4096.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output decorated log with limit 8000 with 4096 msg
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwd-msg-with-nl.phpt
+++ b/sapi/fpm/tests/log-bwd-msg-with-nl.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output decorated log with msg containing new lines
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwd-multiple-msgs-stdout-stderr.phpt
+++ b/sapi/fpm/tests/log-bwd-multiple-msgs-stdout-stderr.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output decorated log with multiple continuous messages (stdout/stderr mixed)
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --XFAIL--

--- a/sapi/fpm/tests/log-bwd-multiple-msgs.phpt
+++ b/sapi/fpm/tests/log-bwd-multiple-msgs.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output decorated log with multiple continuous messages
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwp-limit-1024-msg-120.phpt
+++ b/sapi/fpm/tests/log-bwp-limit-1024-msg-120.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output plain log with limit 1024 and msg 120
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwp-limit-1500-msg-3300.phpt
+++ b/sapi/fpm/tests/log-bwp-limit-1500-msg-3300.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output plain log with limit 1500 and msg 3300
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwp-msg-flush-split-fallback.phpt
+++ b/sapi/fpm/tests/log-bwp-msg-flush-split-fallback.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output plain log with msg with flush split in buffer
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwp-msg-flush-split-real.phpt
+++ b/sapi/fpm/tests/log-bwp-msg-flush-split-real.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Buffered worker output plain log with msg with flush split in buffer
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-bwp-realloc-buffer.phpt
+++ b/sapi/fpm/tests/log-bwp-realloc-buffer.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: bug81513 - Buffered worker output plain log stream reallocation
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-dwd-limit-1050-msg-2048.phpt
+++ b/sapi/fpm/tests/log-dwd-limit-1050-msg-2048.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Direct worker output decorated log with limit 1050 with 2048 msg
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-dwd-limit-1050-msg-2900.phpt
+++ b/sapi/fpm/tests/log-dwd-limit-1050-msg-2900.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Direct worker output decorated log with limit 1050 with 2900 msg
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-dwd-limit-8000-msg-4096.phpt
+++ b/sapi/fpm/tests/log-dwd-limit-8000-msg-4096.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Direct worker output decorated log with limit 8000 with 4096 msg
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/log-dwp-limit-1000-msg-2000.phpt
+++ b/sapi/fpm/tests/log-dwp-limit-1000-msg-2000.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Direct worker output plain log with limit 1000 and msg 2000
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/main-global-prefix.phpt
+++ b/sapi/fpm/tests/main-global-prefix.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Main invocation with prefix
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/main-version.phpt
+++ b/sapi/fpm/tests/main-version.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: version string
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/php-admin-doc-root.phpt
+++ b/sapi/fpm/tests/php-admin-doc-root.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: php_admin_value doc_root usage
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/pm-max-spawn-rate-config.phpt
+++ b/sapi/fpm/tests/pm-max-spawn-rate-config.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: set pm.max_spawn_rate
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/pm-max-spawn-rate-run.phpt
+++ b/sapi/fpm/tests/pm-max-spawn-rate-run.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: set pm.max_spawn_rate
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/pool-apparmor-basic.phpt
+++ b/sapi/fpm/tests/pool-apparmor-basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: AppArmor basic test
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/pool-prefix.phpt
+++ b/sapi/fpm/tests/pool-prefix.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Pool prefix
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/proc-idle-timeout.phpt
+++ b/sapi/fpm/tests/proc-idle-timeout.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Process manager config pm.process_idle_timeout
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/proc-no-start-server.phpt
+++ b/sapi/fpm/tests/proc-no-start-server.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Process manager config option pm.start_servers missing
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/proc-user-ignored.phpt
+++ b/sapi/fpm/tests/proc-user-ignored.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Process user setting ignored when FPM is not running as root
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/reload-uses-sigkill-as-last-measure.phpt
+++ b/sapi/fpm/tests/reload-uses-sigkill-as-last-measure.phpt
@@ -1,5 +1,7 @@
 --TEST--
 If SIGQUIT and SIGTERM during reloading fail, SIGKILL should be sent
+--CONFLICTS--
+fpm
 --EXTENSIONS--
 pcntl
 --SKIPIF--

--- a/sapi/fpm/tests/socket-invalid-allowed-clients.phpt
+++ b/sapi/fpm/tests/socket-invalid-allowed-clients.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Socket for invalid allowed client only
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/socket-ipv4-allowed-clients.phpt
+++ b/sapi/fpm/tests/socket-ipv4-allowed-clients.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Socket for IPv4 allowed client only
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/socket-ipv4-basic.phpt
+++ b/sapi/fpm/tests/socket-ipv4-basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Socket for IPv4 connection
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/socket-ipv4-fallback.phpt
+++ b/sapi/fpm/tests/socket-ipv4-fallback.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Socket port connection falls back to IPv4
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/socket-ipv6-any.phpt
+++ b/sapi/fpm/tests/socket-ipv6-any.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Socket for IPv6 any address connection
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/socket-ipv6-basic.phpt
+++ b/sapi/fpm/tests/socket-ipv6-basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Socket for IPv6 connection
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/socket-uds-acl.phpt
+++ b/sapi/fpm/tests/socket-uds-acl.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Unix Domain Socket with Posix ACL
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/socket-uds-basic.phpt
+++ b/sapi/fpm/tests/socket-uds-basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Unix Domain Socket connection
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/socket-uds-numeric-ugid-nonroot.phpt
+++ b/sapi/fpm/tests/socket-uds-numeric-ugid-nonroot.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: UNIX socket owner and group settings can be numeric
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/socket-uds-numeric-ugid.phpt
+++ b/sapi/fpm/tests/socket-uds-numeric-ugid.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: UNIX socket owner and group settings can be numeric
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/tests/status-basic.phpt
+++ b/sapi/fpm/tests/status-basic.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Status basic test
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/status-listen.phpt
+++ b/sapi/fpm/tests/status-listen.phpt
@@ -1,5 +1,7 @@
 --TEST--
 FPM: Status listen test
+--CONFLICTS--
+fpm
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--


### PR DESCRIPTION
See discussion on https://github.com/php/php-src/pull/7561

fpm tests have been spuriously failing in CI, with 2 parallel workers
on 2 CPUs.

`make test TESTS='sapi/fpm/tests -j8'` fails locally for me
without this change

They're trying to listen on IPv4 on 127.0.0.1 on the same port as other
tests (e.g. helper getPort()=9008 on 64-bit architecture (PHP_INT_SIZE=8)).

So tests will fail (in the old setup) if

1. php-fpm is still running from another test in parallel.
2. a request is sent to a server for a different test.

