### PR TITLE
Support build ext/standard for Windows arm64

### DIFF
--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -20,9 +20,7 @@
 #include "crc32_x86.h"
 
 #ifdef HAVE_AARCH64_CRC32
-#ifdef PHP_WIN32
-# include <intrin.h>
-#else
+#ifndef PHP_WIN32
 # include <arm_acle.h>
 #endif
 # if defined(__linux__)

--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -20,7 +20,11 @@
 #include "crc32_x86.h"
 
 #ifdef HAVE_AARCH64_CRC32
+#ifdef PHP_WIN32
+# include <intrin.h>
+#else
 # include <arm_acle.h>
+#endif
 # if defined(__linux__)
 #  include <sys/auxv.h>
 #  include <asm/hwcap.h>
@@ -34,6 +38,56 @@ static unsigned long getauxval(unsigned long key) {
 	if (elf_aux_info(key, &ret, sizeof(ret)) != 0)
 		return 0;
 	return ret;
+}
+# elif defined(PHP_WIN32)
+/*
+get crc32 support info
+this is undocumented, to be confirmed
+read id_aa64isar0_el1 from registry HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\x\CP 4030
+*/
+int winaa64_support_crc32c() {
+	const WCHAR cpus_key[] = L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\";
+	HKEY cpus_handle;
+	if (ERROR_SUCCESS != RegOpenKeyExW(HKEY_LOCAL_MACHINE, cpus_key, 0, KEY_ENUMERATE_SUB_KEYS, &cpus_handle)) {
+		return 0;
+	}
+	DWORD cpu_index = 0;
+	WCHAR cpu_num[256] = { 0 };
+	uint64_t CP4030 = 0;
+	WCHAR cpu_key[(sizeof(cpus_key) / sizeof(*cpus_key)) + 256] = L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\";
+	while (ERROR_SUCCESS == RegEnumKeyW(cpus_handle, cpu_index++, cpu_num, 255)) {
+		if (0 != wcscpy_s(&cpu_key[sizeof(cpus_key) / sizeof(*cpus_key) - 1], 256, cpu_num)) {
+			break;
+		}
+		HKEY cpu_handle;
+		if (ERROR_SUCCESS != RegOpenKeyExW(HKEY_LOCAL_MACHINE, cpu_key, 0, KEY_READ, &cpu_handle)) {
+			break;
+		}
+		DWORD value_type;
+		uint64_t value;
+		DWORD value_size = sizeof(value);
+		if (ERROR_SUCCESS != RegQueryValueExW(cpu_handle, L"CP 4030", NULL, &value_type, (LPBYTE)&value, &value_size)) {
+			RegCloseKey(cpu_handle);
+			break;
+		}
+
+		if (REG_QWORD != value_type) {
+			RegCloseKey(cpu_handle);
+			break;
+		}
+		//wprintf(L"cp4030 for cpu[%d] \"%s\" is %016zx\n", cpu_index-1, cpu_num, value);
+		// save any bits not set
+		CP4030 |= ~value;
+
+		RegCloseKey(cpu_handle);
+	}
+	//printf("rev CP4030 is %016zx\n", CP4030);
+	RegCloseKey(cpus_handle);
+	if (CP4030 & 0x10000 /* crc32: bit 16-19 (only bit 16 used) */) {
+		//printf("not supported by at least one cpu\n");
+		return 0;
+	}
+	return 1;
 }
 # endif
 
@@ -52,6 +106,9 @@ static inline int has_crc32_insn() {
 	size_t reslen = sizeof(res);
 	if (sysctlbyname("hw.optional.armv8_crc32", &res, &reslen, NULL, 0) < 0)
 		res = 0;
+	return res;
+# elif defined(WIN32)
+	res = winaa64_support_crc32c();
 	return res;
 # else
 	res = 0;

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -648,6 +648,11 @@ void php_get_windows_cpu(char *buf, int bufsize)
 			snprintf(buf, bufsize, "AMD64");
 			break;
 #endif
+#if defined(PROCESSOR_ARCHITECTURE_ARM64)
+		case PROCESSOR_ARCHITECTURE_ARM64 :
+			snprintf(buf, bufsize, "ARM64");
+			break;
+#endif
 		case PROCESSOR_ARCHITECTURE_UNKNOWN :
 		default:
 			snprintf(buf, bufsize, "Unknown");


### PR DESCRIPTION
This is a series of work on building php for windows arm64 (cross compile only yet)

ext/standard/crc32.c try to use arm64 crc32 instructions to calculate crc32

This patch used a dirty, not-confirmed method to check if cpu supports these isa extensions: `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\x\CP 4030` registry seems always hold identical value to ID_AA64ISAR0_EL1 register

Tested in windows 11 arm64 macmini vm, qemu simulator "cortex-a57"/"max" cpu, not sure if this always work

see https://docs.microsoft.com/en-us/answers/questions/645412/get-id-aa64isar0-el1-at-windows-arm64.html