### PR TITLE
Cache method overrides of ArrayAccess in zend_class_entry

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -183,6 +183,8 @@ struct _zend_class_entry {
 
 	/* allocated only if class implements Iterator or IteratorAggregate interface */
 	zend_class_iterator_funcs *iterator_funcs_ptr;
+	/* allocated only if class implements ArrayAccess interface */
+	zend_class_arrayaccess_funcs *arrayaccess_funcs_ptr;
 
 	/* handlers */
 	union {

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -292,6 +292,7 @@ typedef struct _zend_fcall_info_cache {
 		class_container.interfaces = NULL;						\
 		class_container.get_iterator = NULL;					\
 		class_container.iterator_funcs_ptr = NULL;				\
+		class_container.arrayaccess_funcs_ptr = NULL;			\
 		class_container.info.internal.module = NULL;			\
 		class_container.info.internal.builtin_functions = functions;	\
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1802,6 +1802,7 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, bool nullify_hand
 		ce->create_object = NULL;
 		ce->get_iterator = NULL;
 		ce->iterator_funcs_ptr = NULL;
+		ce->arrayaccess_funcs_ptr = NULL;
 		ce->get_static_method = NULL;
 		ce->parent = NULL;
 		ce->parent_name = NULL;

--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -359,6 +359,28 @@ static int zend_implement_iterator(zend_class_entry *interface, zend_class_entry
 }
 /* }}} */
 
+/* {{{ zend_implement_arrayaccess */
+static int zend_implement_arrayaccess(zend_class_entry *interface, zend_class_entry *class_type)
+{
+	ZEND_ASSERT(!class_type->arrayaccess_funcs_ptr && "ArrayAccess funcs already set?");
+	zend_class_arrayaccess_funcs *funcs_ptr = class_type->type == ZEND_INTERNAL_CLASS
+		? pemalloc(sizeof(zend_class_arrayaccess_funcs), 1)
+		: zend_arena_alloc(&CG(arena), sizeof(zend_class_arrayaccess_funcs));
+	class_type->arrayaccess_funcs_ptr = funcs_ptr;
+
+	funcs_ptr->zf_offsetget = zend_hash_str_find_ptr(
+		&class_type->function_table, "offsetget", sizeof("offsetget") - 1);
+	funcs_ptr->zf_offsetexists = zend_hash_str_find_ptr(
+		&class_type->function_table, "offsetexists", sizeof("offsetexists") - 1);
+	funcs_ptr->zf_offsetset = zend_hash_str_find_ptr(
+		&class_type->function_table, "offsetset", sizeof("offsetset") - 1);
+	funcs_ptr->zf_offsetunset = zend_hash_str_find_ptr(
+		&class_type->function_table, "offsetunset", sizeof("offsetunset") - 1);
+
+	return SUCCESS;
+}
+/* }}} */
+
 /* {{{ zend_user_serialize */
 ZEND_API int zend_user_serialize(zval *object, unsigned char **buffer, size_t *buf_len, zend_serialize_data *data)
 {
@@ -616,6 +638,7 @@ ZEND_API void zend_register_interfaces(void)
 	zend_ce_serializable->interface_gets_implemented = zend_implement_serializable;
 
 	zend_ce_arrayaccess = register_class_ArrayAccess();
+	zend_ce_arrayaccess->interface_gets_implemented = zend_implement_arrayaccess;
 
 	zend_ce_countable = register_class_Countable();
 

--- a/Zend/zend_iterators.h
+++ b/Zend/zend_iterators.h
@@ -72,6 +72,13 @@ typedef struct _zend_class_iterator_funcs {
 	zend_function *zf_rewind;
 } zend_class_iterator_funcs;
 
+typedef struct _zend_class_arrayaccess_funcs {
+	zend_function *zf_offsetget;
+	zend_function *zf_offsetexists;
+	zend_function *zf_offsetset;
+	zend_function *zf_offsetunset;
+} zend_class_arrayaccess_funcs;
+
 BEGIN_EXTERN_C()
 /* given a zval, returns stuff that can be used to iterate it. */
 ZEND_API zend_object_iterator* zend_iterator_unwrap(zval *array_ptr);

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -469,6 +469,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 			if (ce->iterator_funcs_ptr) {
 				free(ce->iterator_funcs_ptr);
 			}
+			if (ce->arrayaccess_funcs_ptr) {
+				free(ce->arrayaccess_funcs_ptr);
+			}
 			if (ce->num_interfaces > 0) {
 				free(ce->interfaces);
 			}

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -571,10 +571,6 @@ EMPTY_SWITCH_DEFAULT_CASE()
 	_(ZEND_STR_AUTOGLOBAL_SERVER,      "_SERVER") \
 	_(ZEND_STR_AUTOGLOBAL_ENV,         "_ENV") \
 	_(ZEND_STR_AUTOGLOBAL_REQUEST,     "_REQUEST") \
-	_(ZEND_STR_OFFSETGET,              "offsetget") \
-	_(ZEND_STR_OFFSETSET,              "offsetset") \
-	_(ZEND_STR_OFFSETEXISTS,           "offsetexists") \
-	_(ZEND_STR_OFFSETUNSET,            "offsetunset") \
 	_(ZEND_STR_COUNT,                  "count") \
 
 

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -880,6 +880,14 @@ static void zend_file_cache_serialize_class(zval                     *zv,
 		SERIALIZE_PTR(ce->iterator_funcs_ptr);
 	}
 
+	if (ce->arrayaccess_funcs_ptr) {
+		SERIALIZE_PTR(ce->arrayaccess_funcs_ptr->zf_offsetget);
+		SERIALIZE_PTR(ce->arrayaccess_funcs_ptr->zf_offsetexists);
+		SERIALIZE_PTR(ce->arrayaccess_funcs_ptr->zf_offsetset);
+		SERIALIZE_PTR(ce->arrayaccess_funcs_ptr->zf_offsetunset);
+		SERIALIZE_PTR(ce->arrayaccess_funcs_ptr);
+	}
+
 	ZEND_MAP_PTR_INIT(ce->static_members_table, NULL);
 	ZEND_MAP_PTR_INIT(ce->mutable_data, NULL);
 }
@@ -1669,6 +1677,13 @@ static void zend_file_cache_unserialize_class(zval                    *zv,
 		UNSERIALIZE_PTR(ce->iterator_funcs_ptr->zf_key);
 		UNSERIALIZE_PTR(ce->iterator_funcs_ptr->zf_current);
 		UNSERIALIZE_PTR(ce->iterator_funcs_ptr->zf_next);
+	}
+	if (ce->arrayaccess_funcs_ptr) {
+		UNSERIALIZE_PTR(ce->arrayaccess_funcs_ptr);
+		UNSERIALIZE_PTR(ce->arrayaccess_funcs_ptr->zf_offsetget);
+		UNSERIALIZE_PTR(ce->arrayaccess_funcs_ptr->zf_offsetexists);
+		UNSERIALIZE_PTR(ce->arrayaccess_funcs_ptr->zf_offsetset);
+		UNSERIALIZE_PTR(ce->arrayaccess_funcs_ptr->zf_offsetunset);
 	}
 
 	if (!(script->corrupted)) {

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -985,6 +985,9 @@ zend_class_entry *zend_persist_class_entry(zend_class_entry *orig_ce)
 		if (ce->iterator_funcs_ptr) {
 			ce->iterator_funcs_ptr = zend_shared_memdup(ce->iterator_funcs_ptr, sizeof(zend_class_iterator_funcs));
 		}
+		if (ce->arrayaccess_funcs_ptr) {
+			ce->arrayaccess_funcs_ptr = zend_shared_memdup(ce->arrayaccess_funcs_ptr, sizeof(zend_class_arrayaccess_funcs));
+		}
 
 		if (ce->ce_flags & ZEND_ACC_CACHED) {
 			return ce;
@@ -1134,6 +1137,14 @@ void zend_update_parent_ce(zend_class_entry *ce)
 				ce->iterator_funcs_ptr->zf_current = zend_hash_str_find_ptr(&ce->function_table, "current", sizeof("current") - 1);
 				ce->iterator_funcs_ptr->zf_next = zend_hash_str_find_ptr(&ce->function_table, "next", sizeof("next") - 1);
 			}
+		}
+
+		if (ce->arrayaccess_funcs_ptr) {
+			ZEND_ASSERT(zend_class_implements_interface(ce, zend_ce_arrayaccess));
+			ce->arrayaccess_funcs_ptr->zf_offsetget = zend_hash_str_find_ptr(&ce->function_table, "offsetget", sizeof("offsetget") - 1);
+			ce->arrayaccess_funcs_ptr->zf_offsetexists = zend_hash_str_find_ptr(&ce->function_table, "offsetexists", sizeof("offsetexists") - 1);
+			ce->arrayaccess_funcs_ptr->zf_offsetset = zend_hash_str_find_ptr(&ce->function_table, "offsetset", sizeof("offsetset") - 1);
+			ce->arrayaccess_funcs_ptr->zf_offsetunset = zend_hash_str_find_ptr(&ce->function_table, "offsetunset", sizeof("offsetunset") - 1);
 		}
 	}
 

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -470,6 +470,9 @@ void zend_persist_class_entry_calc(zend_class_entry *ce)
 		if (ce->iterator_funcs_ptr) {
 			ADD_SIZE(sizeof(zend_class_iterator_funcs));
 		}
+		if (ce->arrayaccess_funcs_ptr) {
+			ADD_SIZE(sizeof(zend_class_arrayaccess_funcs));
+		}
 
 		if (ce->ce_flags & ZEND_ACC_CACHED) {
 			return;

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -249,7 +249,7 @@ void spl_object_storage_addall(spl_SplObjectStorage *intern, spl_SplObjectStorag
 } /* }}} */
 
 #define SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, zstr_method) \
-	(((zend_function *)zend_hash_find_ptr(&(class_type)->function_table, ZSTR_KNOWN(zstr_method)))->common.scope != spl_ce_SplObjectStorage)
+	(class_type->arrayaccess_funcs_ptr && class_type->arrayaccess_funcs_ptr->zstr_method)
 
 static zend_object *spl_object_storage_new_ex(zend_class_entry *class_type, zend_object *orig) /* {{{ */
 {
@@ -277,18 +277,18 @@ static zend_object *spl_object_storage_new_ex(zend_class_entry *class_type, zend
 					intern->fptr_get_hash = get_hash;
 				}
 				if (intern->fptr_get_hash != NULL ||
-					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, ZEND_STR_OFFSETGET) ||
-					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, ZEND_STR_OFFSETEXISTS)) {
+					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, zf_offsetget) ||
+					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, zf_offsetexists)) {
 					intern->flags |= SOS_OVERRIDDEN_READ_DIMENSION;
 				}
 
 				if (intern->fptr_get_hash != NULL ||
-					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, ZEND_STR_OFFSETSET)) {
+					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, zf_offsetset)) {
 					intern->flags |= SOS_OVERRIDDEN_WRITE_DIMENSION;
 				}
 
 				if (intern->fptr_get_hash != NULL ||
-					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, ZEND_STR_OFFSETUNSET)) {
+					SPL_OBJECT_STORAGE_CLASS_HAS_OVERRIDE(class_type, zf_offsetunset)) {
 					intern->flags |= SOS_OVERRIDDEN_UNSET_DIMENSION;
 				}
 			}


### PR DESCRIPTION
Previously, code such as subclasses of SplFixedArray would check for method
overrides when instantiating the objects.

This optimization was mentioned as a followup to GH-6552