### PR TITLE
Fix #81693: mb_check_encoding(7bit) segfaults

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
@@ -316,7 +316,7 @@ const struct mbfl_convert_vtbl* mbfl_convert_filter_get_vtbl(const mbfl_encoding
 		return &vtbl_pass;
 	}
 
-	if (to->no_encoding == mbfl_no_encoding_wchar && from->input_filter != NULL) {
+	if (to->no_encoding == mbfl_no_encoding_wchar) {
 		return from->input_filter;
 	} else if (from->no_encoding == mbfl_no_encoding_wchar) {
 		return to->output_filter;

--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
@@ -307,7 +307,8 @@ const struct mbfl_convert_vtbl* mbfl_convert_filter_get_vtbl(const mbfl_encoding
 		from = &mbfl_encoding_8bit;
 	} else if (from->no_encoding == mbfl_no_encoding_base64 ||
 			   from->no_encoding == mbfl_no_encoding_qprint ||
-			   from->no_encoding == mbfl_no_encoding_uuencode) {
+			   from->no_encoding == mbfl_no_encoding_uuencode ||
+			   from->no_encoding == mbfl_no_encoding_7bit) {
 		to = &mbfl_encoding_8bit;
 	}
 
@@ -315,7 +316,7 @@ const struct mbfl_convert_vtbl* mbfl_convert_filter_get_vtbl(const mbfl_encoding
 		return &vtbl_pass;
 	}
 
-	if (to->no_encoding == mbfl_no_encoding_wchar) {
+	if (to->no_encoding == mbfl_no_encoding_wchar && from->input_filter != NULL) {
 		return from->input_filter;
 	} else if (from->no_encoding == mbfl_no_encoding_wchar) {
 		return to->output_filter;

--- a/ext/mbstring/tests/bug81693.phpt
+++ b/ext/mbstring/tests/bug81693.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #81693 (mb_check_encoding(7bit) segfaults)
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+var_dump(mb_check_encoding('Hello world', '7bit'));
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
`php_mb_check_encoding()` now uses conversion to `mbfl_encoding_wchar`.
Since `mbfl_encoding_7bit` has no `input_filter`, no filter can be
found.  Since we don't actually need to convert to wchar, we encode to
8bit.