### PR TITLE
Fix the return result of net_get_interfaces() under windows does not contain wireless network

### DIFF
--- a/ext/standard/net.c
+++ b/ext/standard/net.c
@@ -190,7 +190,7 @@ PHP_FUNCTION(net_get_interfaces) {
 	for (p = pAddresses; p; p = p->Next) {
 		zval iface, unicast;
 
-		if ((IF_TYPE_ETHERNET_CSMACD != p->IfType) && (IF_TYPE_SOFTWARE_LOOPBACK != p->IfType)) {
+		if ((IF_TYPE_ETHERNET_CSMACD != p->IfType) && (IF_TYPE_IEEE80211 != p->IfType) && (IF_TYPE_SOFTWARE_LOOPBACK != p->IfType)) {
 			continue;
 		}
 


### PR DESCRIPTION
Fix the return result of net_get_interfaces() under windows does not contain wireless network

<https://docs.microsoft.com/en-us/windows/win32/api/iptypes/ns-iptypes-ip_interface_name_info_w2ksp1>