### PR TITLE
Add ZEND_ATTRIBUTE_WARN_UNUSED_RESULT to C functions

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -277,23 +277,23 @@ zend_result zend_post_startup(void);
 void zend_set_utility_values(zend_utility_values *utility_values);
 
 ZEND_API ZEND_COLD ZEND_NORETURN void _zend_bailout(const char *filename, uint32_t lineno);
-ZEND_API size_t zend_get_page_size(void);
+ZEND_API ZEND_ATTRIBUTE_WARN_UNUSED_RESULT size_t zend_get_page_size(void);
 
 ZEND_API size_t zend_vspprintf(char **pbuf, size_t max_len, const char *format, va_list ap);
 ZEND_API size_t zend_spprintf(char **message, size_t max_len, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 3, 4);
-ZEND_API zend_string *zend_vstrpprintf(size_t max_len, const char *format, va_list ap);
-ZEND_API zend_string *zend_strpprintf(size_t max_len, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
+ZEND_API ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string * zend_vstrpprintf(size_t max_len, const char *format, va_list ap);
+ZEND_API ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string * zend_strpprintf(size_t max_len, const char *format, ...) ZEND_ATTRIBUTE_FORMAT(printf, 2, 3);
 
 /* Same as zend_spprintf and zend_strpprintf, without checking of format validity.
  * For use with custom printf specifiers such as %H. */
 ZEND_API size_t zend_spprintf_unchecked(char **message, size_t max_len, const char *format, ...);
-ZEND_API zend_string *zend_strpprintf_unchecked(size_t max_len, const char *format, ...);
+ZEND_API ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_strpprintf_unchecked(size_t max_len, const char *format, ...);
 
-ZEND_API const char *get_zend_version(void);
+ZEND_API ZEND_ATTRIBUTE_WARN_UNUSED_RESULT const char *get_zend_version(void);
 ZEND_API bool zend_make_printable_zval(zval *expr, zval *expr_copy);
 ZEND_API size_t zend_print_zval(zval *expr, int indent);
 ZEND_API void zend_print_zval_r(zval *expr, int indent);
-ZEND_API zend_string *zend_print_zval_r_to_str(zval *expr, int indent);
+ZEND_API ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_print_zval_r_to_str(zval *expr, int indent);
 ZEND_API void zend_print_flat_zval_r(zval *expr);
 void zend_print_flat_zval_r_to_buf(smart_str *str, zval *expr);
 
@@ -331,8 +331,8 @@ extern ZEND_API void (*zend_on_timeout)(int seconds);
 extern ZEND_API zend_result (*zend_stream_open_function)(zend_file_handle *handle);
 extern void (*zend_printf_to_smart_string)(smart_string *buf, const char *format, va_list ap);
 extern void (*zend_printf_to_smart_str)(smart_str *buf, const char *format, va_list ap);
-extern ZEND_API char *(*zend_getenv)(const char *name, size_t name_len);
-extern ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename);
+extern ZEND_API char *(*zend_getenv)(const char *name, size_t name_len) ZEND_ATTRIBUTE_WARN_UNUSED_RESULT;
+extern ZEND_API zend_string *(*zend_resolve_path)(zend_string *filename) ZEND_ATTRIBUTE_WARN_UNUSED_RESULT;
 
 /* These two callbacks are especially for opcache */
 extern ZEND_API zend_result (*zend_post_startup_cb)(void);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -333,16 +333,16 @@ ZEND_API zend_result zend_copy_parameters_array(uint32_t param_count, zval *argu
 
 #define ZEND_PARSE_PARAMS_THROW 0 /* No longer used, zpp always uses exceptions */
 #define ZEND_PARSE_PARAMS_QUIET (1<<1)
-ZEND_API zend_result zend_parse_parameters(uint32_t num_args, const char *type_spec, ...);
-ZEND_API zend_result zend_parse_parameters_ex(int flags, uint32_t num_args, const char *type_spec, ...);
+ZEND_API zend_result ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_parse_parameters(uint32_t num_args, const char *type_spec, ...);
+ZEND_API zend_result ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_parse_parameters_ex(int flags, uint32_t num_args, const char *type_spec, ...);
 /* NOTE: This must have at least one value in __VA_ARGS__ for the expression to be valid */
 #define zend_parse_parameters_throw(num_args, ...) \
 	zend_parse_parameters(num_args, __VA_ARGS__)
-ZEND_API const char *zend_zval_type_name(const zval *arg);
-ZEND_API zend_string *zend_zval_get_legacy_type(const zval *arg);
+ZEND_API const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_zval_type_name(const zval *arg);
+ZEND_API zend_string * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_zval_get_legacy_type(const zval *arg);
 
-ZEND_API zend_result zend_parse_method_parameters(uint32_t num_args, zval *this_ptr, const char *type_spec, ...);
-ZEND_API zend_result zend_parse_method_parameters_ex(int flags, uint32_t num_args, zval *this_ptr, const char *type_spec, ...);
+ZEND_API zend_result ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_parse_method_parameters(uint32_t num_args, zval *this_ptr, const char *type_spec, ...);
+ZEND_API zend_result ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_parse_method_parameters_ex(int flags, uint32_t num_args, zval *this_ptr, const char *type_spec, ...);
 
 ZEND_API zend_result zend_parse_parameter(int flags, uint32_t arg_num, zval *arg, const char *spec, ...);
 

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -68,20 +68,20 @@ typedef struct _zend_mm_debug_info {
 
 BEGIN_EXTERN_C()
 
-ZEND_API char*  ZEND_FASTCALL zend_strndup(const char *s, size_t length) ZEND_ATTRIBUTE_MALLOC;
+ZEND_API char*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_strndup(const char *s, size_t length) ZEND_ATTRIBUTE_MALLOC;
 
-ZEND_API void*  ZEND_FASTCALL _emalloc(size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE(1);
-ZEND_API void*  ZEND_FASTCALL _safe_emalloc(size_t nmemb, size_t size, size_t offset ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC;
-ZEND_API void*  ZEND_FASTCALL _safe_malloc(size_t nmemb, size_t size, size_t offset) ZEND_ATTRIBUTE_MALLOC;
-ZEND_API void   ZEND_FASTCALL _efree(void *ptr ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
-ZEND_API void*  ZEND_FASTCALL _ecalloc(size_t nmemb, size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE2(1,2);
-ZEND_API void*  ZEND_FASTCALL _erealloc(void *ptr, size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
-ZEND_API void*  ZEND_FASTCALL _erealloc2(void *ptr, size_t size, size_t copy_size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
-ZEND_API void*  ZEND_FASTCALL _safe_erealloc(void *ptr, size_t nmemb, size_t size, size_t offset ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
-ZEND_API void*  ZEND_FASTCALL _safe_realloc(void *ptr, size_t nmemb, size_t size, size_t offset);
-ZEND_API char*  ZEND_FASTCALL _estrdup(const char *s ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC;
-ZEND_API char*  ZEND_FASTCALL _estrndup(const char *s, size_t length ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC;
-ZEND_API size_t ZEND_FASTCALL _zend_mem_block_size(void *ptr ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
+ZEND_API void*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _emalloc(size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE(1);
+ZEND_API void*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _safe_emalloc(size_t nmemb, size_t size, size_t offset ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC;
+ZEND_API void*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _safe_malloc(size_t nmemb, size_t size, size_t offset) ZEND_ATTRIBUTE_MALLOC;
+ZEND_API void   ZEND_FASTCALL                                   _efree(void *ptr ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
+ZEND_API void*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _ecalloc(size_t nmemb, size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE2(1,2);
+ZEND_API void*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _erealloc(void *ptr, size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
+ZEND_API void*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _erealloc2(void *ptr, size_t size, size_t copy_size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
+ZEND_API void*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _safe_erealloc(void *ptr, size_t nmemb, size_t size, size_t offset ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
+ZEND_API void*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _safe_realloc(void *ptr, size_t nmemb, size_t size, size_t offset);
+ZEND_API char*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _estrdup(const char *s ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC;
+ZEND_API char*  ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _estrndup(const char *s, size_t length ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC) ZEND_ATTRIBUTE_MALLOC;
+ZEND_API size_t ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _zend_mem_block_size(void *ptr ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
 
 #include "zend_alloc_sizes.h"
 
@@ -93,8 +93,8 @@ ZEND_API size_t ZEND_FASTCALL _zend_mem_block_size(void *ptr ZEND_FILE_LINE_DC Z
 
 ZEND_MM_BINS_INFO(_ZEND_BIN_ALLOCATOR_DEF, x, y)
 
-ZEND_API void* ZEND_FASTCALL _emalloc_large(size_t size) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE(1);
-ZEND_API void* ZEND_FASTCALL _emalloc_huge(size_t size) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE(1);
+ZEND_API void* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _emalloc_large(size_t size) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE(1);
+ZEND_API void* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _emalloc_huge(size_t size) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE(1);
 
 # define _ZEND_BIN_ALLOCATOR_SELECTOR_START(_num, _size, _elements, _pages, size, y) \
 	((size <= _size) ? _emalloc_ ## _size() :
@@ -185,9 +185,9 @@ ZEND_API void ZEND_FASTCALL _efree_huge(void *, size_t size);
 #define estrndup_rel(s, length)					_estrndup((s), (length) ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_CC)
 #define zend_mem_block_size_rel(ptr)			_zend_mem_block_size((ptr) ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_CC)
 
-ZEND_API void * __zend_malloc(size_t len) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE(1);
-ZEND_API void * __zend_calloc(size_t nmemb, size_t len) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE2(1,2);
-ZEND_API void * __zend_realloc(void *p, size_t len) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
+ZEND_API void * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT __zend_malloc(size_t len) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE(1);
+ZEND_API void * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT __zend_calloc(size_t nmemb, size_t len) ZEND_ATTRIBUTE_MALLOC ZEND_ATTRIBUTE_ALLOC_SIZE2(1,2);
+ZEND_API void * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT __zend_realloc(void *p, size_t len) ZEND_ATTRIBUTE_ALLOC_SIZE(2);
 
 /* Selective persistent/non persistent allocation macros */
 #define pemalloc(size, persistent) ((persistent)?__zend_malloc(size):emalloc(size))

--- a/Zend/zend_constants.h
+++ b/Zend/zend_constants.h
@@ -72,11 +72,11 @@ void free_zend_constant(zval *zv);
 void zend_startup_constants(void);
 void zend_shutdown_constants(void);
 void zend_register_standard_constants(void);
-ZEND_API bool zend_verify_const_access(zend_class_constant *c, zend_class_entry *ce);
-ZEND_API zval *zend_get_constant(zend_string *name);
-ZEND_API zval *zend_get_constant_str(const char *name, size_t name_len);
-ZEND_API zval *zend_get_constant_ex(zend_string *name, zend_class_entry *scope, uint32_t flags);
-ZEND_API zval *zend_get_class_constant_ex(zend_string *class_name, zend_string *constant_name, zend_class_entry *scope, uint32_t flags);
+ZEND_API bool ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_verify_const_access(zend_class_constant *c, zend_class_entry *ce);
+ZEND_API zval * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_constant(zend_string *name);
+ZEND_API zval * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_constant_str(const char *name, size_t name_len);
+ZEND_API zval * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_constant_ex(zend_string *name, zend_class_entry *scope, uint32_t flags);
+ZEND_API zval * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_class_constant_ex(zend_string *class_name, zend_string *constant_name, zend_class_entry *scope, uint32_t flags);
 ZEND_API void zend_register_bool_constant(const char *name, size_t name_len, bool bval, int flags, int module_number);
 ZEND_API void zend_register_null_constant(const char *name, size_t name_len, int flags, int module_number);
 ZEND_API void zend_register_long_constant(const char *name, size_t name_len, zend_long lval, int flags, int module_number);
@@ -90,7 +90,7 @@ void zend_copy_constants(HashTable *target, HashTable *source);
 
 ZEND_API zend_constant *_zend_get_special_const(const char *name, size_t name_len);
 
-static zend_always_inline zend_constant *zend_get_special_const(
+static zend_always_inline zend_constant * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_special_const(
 		const char *name, size_t name_len) {
 	if (name_len == 4 || name_len == 5) {
 		return _zend_get_special_const(name, name_len);

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -45,7 +45,7 @@ ZEND_API void zend_init_code_execute_data(zend_execute_data *execute_data, zend_
 ZEND_API void zend_execute(zend_op_array *op_array, zval *return_value);
 ZEND_API void execute_ex(zend_execute_data *execute_data);
 ZEND_API void execute_internal(zend_execute_data *execute_data, zval *return_value);
-ZEND_API bool zend_is_valid_class_name(zend_string *name);
+ZEND_API bool ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_is_valid_class_name(zend_string *name);
 ZEND_API zend_class_entry *zend_lookup_class(zend_string *name);
 ZEND_API zend_class_entry *zend_lookup_class_ex(zend_string *name, zend_string *lcname, uint32_t flags);
 ZEND_API zend_class_entry *zend_get_called_scope(zend_execute_data *ex);
@@ -332,17 +332,17 @@ static zend_always_inline void zend_vm_stack_extend_call_frame(
 ZEND_API void ZEND_FASTCALL zend_free_extra_named_params(zend_array *extra_named_params);
 
 /* services */
-ZEND_API const char *get_active_class_name(const char **space);
-ZEND_API const char *get_active_function_name(void);
-ZEND_API const char *get_active_function_arg_name(uint32_t arg_num);
-ZEND_API const char *get_function_arg_name(const zend_function *func, uint32_t arg_num);
-ZEND_API zend_string *get_active_function_or_method_name(void);
-ZEND_API zend_string *get_function_or_method_name(const zend_function *func);
-ZEND_API const char *zend_get_executed_filename(void);
-ZEND_API zend_string *zend_get_executed_filename_ex(void);
-ZEND_API uint32_t zend_get_executed_lineno(void);
-ZEND_API zend_class_entry *zend_get_executed_scope(void);
-ZEND_API bool zend_is_executing(void);
+ZEND_API const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT get_active_class_name(const char **space);
+ZEND_API const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT get_active_function_name(void);
+ZEND_API const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT get_active_function_arg_name(uint32_t arg_num);
+ZEND_API const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT get_function_arg_name(const zend_function *func, uint32_t arg_num);
+ZEND_API zend_string * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT get_active_function_or_method_name(void);
+ZEND_API zend_string * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT get_function_or_method_name(const zend_function *func);
+ZEND_API const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_executed_filename(void);
+ZEND_API zend_string * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_executed_filename_ex(void);
+ZEND_API uint32_t  ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_executed_lineno(void);
+ZEND_API zend_class_entry * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_executed_scope(void);
+ZEND_API bool ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_is_executing(void);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_cannot_pass_by_reference(uint32_t arg_num);
 
 ZEND_API void zend_set_timeout(zend_long seconds, bool reset_signals);

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -173,15 +173,15 @@ ZEND_API void ZEND_FASTCALL zend_hash_del_bucket(HashTable *ht, Bucket *p);
 ZEND_API void ZEND_FASTCALL zend_hash_packed_del_val(HashTable *ht, zval *zv);
 
 /* Data retrieval */
-ZEND_API zval* ZEND_FASTCALL zend_hash_find(const HashTable *ht, zend_string *key);
-ZEND_API zval* ZEND_FASTCALL zend_hash_str_find(const HashTable *ht, const char *key, size_t len);
-ZEND_API zval* ZEND_FASTCALL zend_hash_index_find(const HashTable *ht, zend_ulong h);
-ZEND_API zval* ZEND_FASTCALL _zend_hash_index_find(const HashTable *ht, zend_ulong h);
+ZEND_API zval* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_hash_find(const HashTable *ht, zend_string *key);
+ZEND_API zval* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_hash_str_find(const HashTable *ht, const char *key, size_t len);
+ZEND_API zval* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_hash_index_find(const HashTable *ht, zend_ulong h);
+ZEND_API zval* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _zend_hash_index_find(const HashTable *ht, zend_ulong h);
 
 /* The same as zend_hash_find(), but hash value of the key must be already calculated. */
-ZEND_API zval* ZEND_FASTCALL zend_hash_find_known_hash(const HashTable *ht, zend_string *key);
+ZEND_API zval* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_hash_find_known_hash(const HashTable *ht, zend_string *key);
 
-static zend_always_inline zval *zend_hash_find_ex(const HashTable *ht, zend_string *key, bool known_hash)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_hash_find_ex(const HashTable *ht, zend_string *key, bool known_hash)
 {
 	if (known_hash) {
 		return zend_hash_find_known_hash(ht, key);
@@ -210,8 +210,8 @@ static zend_always_inline zval *zend_hash_find_ex(const HashTable *ht, zend_stri
 
 
 /* Find or add NULL, if doesn't exist */
-ZEND_API zval* ZEND_FASTCALL zend_hash_lookup(HashTable *ht, zend_string *key);
-ZEND_API zval* ZEND_FASTCALL zend_hash_index_lookup(HashTable *ht, zend_ulong h);
+ZEND_API zval* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_hash_lookup(HashTable *ht, zend_string *key);
+ZEND_API zval* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_hash_index_lookup(HashTable *ht, zend_ulong h);
 
 #define ZEND_HASH_INDEX_LOOKUP(_ht, _h, _ret) do { \
 		if (EXPECTED(HT_FLAGS(_ht) & HASH_FLAG_PACKED)) { \
@@ -226,23 +226,23 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_index_lookup(HashTable *ht, zend_ulong h)
 	} while (0)
 
 /* Misc */
-static zend_always_inline bool zend_hash_exists(const HashTable *ht, zend_string *key)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_hash_exists(const HashTable *ht, zend_string *key)
 {
 	return zend_hash_find(ht, key) != NULL;
 }
 
-static zend_always_inline bool zend_hash_str_exists(const HashTable *ht, const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_hash_str_exists(const HashTable *ht, const char *str, size_t len)
 {
 	return zend_hash_str_find(ht, str, len) != NULL;
 }
 
-static zend_always_inline bool zend_hash_index_exists(const HashTable *ht, zend_ulong h)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_hash_index_exists(const HashTable *ht, zend_ulong h)
 {
 	return zend_hash_index_find(ht, h) != NULL;
 }
 
 /* traversing */
-ZEND_API HashPosition ZEND_FASTCALL zend_hash_get_current_pos(const HashTable *ht);
+ZEND_API HashPosition ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_hash_get_current_pos(const HashTable *ht);
 
 #define zend_hash_has_more_elements_ex(ht, pos) \
 	(zend_hash_get_current_key_type_ex(ht, pos) == HASH_KEY_NON_EXISTENT ? FAILURE : SUCCESS)
@@ -251,7 +251,7 @@ ZEND_API zend_result   ZEND_FASTCALL zend_hash_move_backwards_ex(HashTable *ht, 
 ZEND_API int   ZEND_FASTCALL zend_hash_get_current_key_ex(const HashTable *ht, zend_string **str_index, zend_ulong *num_index, HashPosition *pos);
 ZEND_API void  ZEND_FASTCALL zend_hash_get_current_key_zval_ex(const HashTable *ht, zval *key, HashPosition *pos);
 ZEND_API int   ZEND_FASTCALL zend_hash_get_current_key_type_ex(HashTable *ht, HashPosition *pos);
-ZEND_API zval* ZEND_FASTCALL zend_hash_get_current_data_ex(HashTable *ht, HashPosition *pos);
+ZEND_API zval* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_hash_get_current_data_ex(HashTable *ht, HashPosition *pos);
 ZEND_API void  ZEND_FASTCALL zend_hash_internal_pointer_reset_ex(HashTable *ht, HashPosition *pos);
 ZEND_API void  ZEND_FASTCALL zend_hash_internal_pointer_end_ex(HashTable *ht, HashPosition *pos);
 
@@ -314,15 +314,18 @@ ZEND_API void ZEND_FASTCALL zend_hash_rehash(HashTable *ht);
 	_zend_new_array(size)
 #endif
 
-ZEND_API HashTable* ZEND_FASTCALL _zend_new_array_0(void);
-ZEND_API HashTable* ZEND_FASTCALL _zend_new_array(uint32_t size);
-ZEND_API HashTable* ZEND_FASTCALL zend_new_pair(zval *val1, zval *val2);
-ZEND_API uint32_t zend_array_count(HashTable *ht);
-ZEND_API HashTable* ZEND_FASTCALL zend_array_dup(HashTable *source);
+/* Methods for allocating new HashTables, used for PHP arrays and property tables of PHP objects.
+ * Note that ZEND_ATTRIBUTE_MALLOC is not used because the returned array arguably contains pointers to other valid objects - https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+ */
+ZEND_API HashTable* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _zend_new_array_0(void);
+ZEND_API HashTable* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _zend_new_array(uint32_t size);
+ZEND_API HashTable* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_new_pair(zval *val1, zval *val2);
+ZEND_API uint32_t ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_array_count(HashTable *ht);
+ZEND_API HashTable* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_array_dup(HashTable *source);
 ZEND_API void ZEND_FASTCALL zend_array_destroy(HashTable *ht);
 ZEND_API void ZEND_FASTCALL zend_symtable_clean(HashTable *ht);
-ZEND_API HashTable* ZEND_FASTCALL zend_symtable_to_proptable(HashTable *ht);
-ZEND_API HashTable* ZEND_FASTCALL zend_proptable_to_symtable(HashTable *ht, bool always_duplicate);
+ZEND_API HashTable* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_symtable_to_proptable(HashTable *ht);
+ZEND_API HashTable* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_proptable_to_symtable(HashTable *ht, bool always_duplicate);
 
 ZEND_API bool ZEND_FASTCALL _zend_handle_numeric_str_ex(const char *key, size_t length, zend_ulong *idx);
 
@@ -395,7 +398,7 @@ static zend_always_inline bool _zend_handle_numeric_str(const char *key, size_t 
 	ZEND_HANDLE_NUMERIC_STR(ZSTR_VAL(key), ZSTR_LEN(key), idx)
 
 
-static zend_always_inline zval *zend_hash_find_ind(const HashTable *ht, zend_string *key)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_hash_find_ind(const HashTable *ht, zend_string *key)
 {
 	zval *zv;
 
@@ -405,7 +408,7 @@ static zend_always_inline zval *zend_hash_find_ind(const HashTable *ht, zend_str
 }
 
 
-static zend_always_inline zval *zend_hash_find_ex_ind(const HashTable *ht, zend_string *key, bool known_hash)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_hash_find_ex_ind(const HashTable *ht, zend_string *key, bool known_hash)
 {
 	zval *zv;
 
@@ -415,7 +418,7 @@ static zend_always_inline zval *zend_hash_find_ex_ind(const HashTable *ht, zend_
 }
 
 
-static zend_always_inline bool zend_hash_exists_ind(const HashTable *ht, zend_string *key)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_hash_exists_ind(const HashTable *ht, zend_string *key)
 {
 	zval *zv;
 
@@ -425,7 +428,7 @@ static zend_always_inline bool zend_hash_exists_ind(const HashTable *ht, zend_st
 }
 
 
-static zend_always_inline zval *zend_hash_str_find_ind(const HashTable *ht, const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_hash_str_find_ind(const HashTable *ht, const char *str, size_t len)
 {
 	zval *zv;
 
@@ -435,7 +438,7 @@ static zend_always_inline zval *zend_hash_str_find_ind(const HashTable *ht, cons
 }
 
 
-static zend_always_inline bool zend_hash_str_exists_ind(const HashTable *ht, const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_hash_str_exists_ind(const HashTable *ht, const char *str, size_t len)
 {
 	zval *zv;
 
@@ -503,7 +506,7 @@ static zend_always_inline zend_result zend_symtable_del_ind(HashTable *ht, zend_
 }
 
 
-static zend_always_inline zval *zend_symtable_find(const HashTable *ht, zend_string *key)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_symtable_find(const HashTable *ht, zend_string *key)
 {
 	zend_ulong idx;
 
@@ -515,7 +518,7 @@ static zend_always_inline zval *zend_symtable_find(const HashTable *ht, zend_str
 }
 
 
-static zend_always_inline zval *zend_symtable_find_ind(const HashTable *ht, zend_string *key)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_symtable_find_ind(const HashTable *ht, zend_string *key)
 {
 	zend_ulong idx;
 
@@ -527,7 +530,7 @@ static zend_always_inline zval *zend_symtable_find_ind(const HashTable *ht, zend
 }
 
 
-static zend_always_inline bool zend_symtable_exists(HashTable *ht, zend_string *key)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_symtable_exists(HashTable *ht, zend_string *key)
 {
 	zend_ulong idx;
 
@@ -539,7 +542,7 @@ static zend_always_inline bool zend_symtable_exists(HashTable *ht, zend_string *
 }
 
 
-static zend_always_inline bool zend_symtable_exists_ind(HashTable *ht, zend_string *key)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_symtable_exists_ind(HashTable *ht, zend_string *key)
 {
 	zend_ulong idx;
 
@@ -599,7 +602,7 @@ static zend_always_inline zend_result zend_symtable_str_del_ind(HashTable *ht, c
 }
 
 
-static zend_always_inline zval *zend_symtable_str_find(HashTable *ht, const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_symtable_str_find(HashTable *ht, const char *str, size_t len)
 {
 	zend_ulong idx;
 
@@ -611,7 +614,7 @@ static zend_always_inline zval *zend_symtable_str_find(HashTable *ht, const char
 }
 
 
-static zend_always_inline bool zend_symtable_str_exists(HashTable *ht, const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_symtable_str_exists(HashTable *ht, const char *str, size_t len)
 {
 	zend_ulong idx;
 
@@ -845,7 +848,7 @@ static zend_always_inline void *zend_hash_next_index_insert_mem(HashTable *ht, v
 	return NULL;
 }
 
-static zend_always_inline void *zend_hash_find_ptr(const HashTable *ht, zend_string *key)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT void *zend_hash_find_ptr(const HashTable *ht, zend_string *key)
 {
 	zval *zv;
 
@@ -858,7 +861,7 @@ static zend_always_inline void *zend_hash_find_ptr(const HashTable *ht, zend_str
 	}
 }
 
-static zend_always_inline void *zend_hash_find_ex_ptr(const HashTable *ht, zend_string *key, bool known_hash)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT void *zend_hash_find_ex_ptr(const HashTable *ht, zend_string *key, bool known_hash)
 {
 	zval *zv;
 
@@ -871,7 +874,7 @@ static zend_always_inline void *zend_hash_find_ex_ptr(const HashTable *ht, zend_
 	}
 }
 
-static zend_always_inline void *zend_hash_str_find_ptr(const HashTable *ht, const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT void *zend_hash_str_find_ptr(const HashTable *ht, const char *str, size_t len)
 {
 	zval *zv;
 
@@ -886,13 +889,13 @@ static zend_always_inline void *zend_hash_str_find_ptr(const HashTable *ht, cons
 
 /* Will lowercase the str; use only if you don't need the lowercased string for
  * anything else. If you have a lowered string, use zend_hash_str_find_ptr. */
-ZEND_API void *zend_hash_str_find_ptr_lc(const HashTable *ht, const char *str, size_t len);
+ZEND_API ZEND_ATTRIBUTE_WARN_UNUSED_RESULT void *zend_hash_str_find_ptr_lc(const HashTable *ht, const char *str, size_t len);
 
 /* Will lowercase the str; use only if you don't need the lowercased string for
  * anything else. If you have a lowered string, use zend_hash_find_ptr. */
-ZEND_API void *zend_hash_find_ptr_lc(const HashTable *ht, zend_string *key);
+ZEND_API ZEND_ATTRIBUTE_WARN_UNUSED_RESULT void *zend_hash_find_ptr_lc(const HashTable *ht, zend_string *key);
 
-static zend_always_inline void *zend_hash_index_find_ptr(const HashTable *ht, zend_ulong h)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT void *zend_hash_index_find_ptr(const HashTable *ht, zend_ulong h)
 {
 	zval *zv;
 
@@ -905,7 +908,7 @@ static zend_always_inline void *zend_hash_index_find_ptr(const HashTable *ht, ze
 	}
 }
 
-static zend_always_inline zval *zend_hash_index_find_deref(HashTable *ht, zend_ulong h)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_hash_index_find_deref(HashTable *ht, zend_ulong h)
 {
 	zval *zv = zend_hash_index_find(ht, h);
 	if (zv) {
@@ -914,7 +917,7 @@ static zend_always_inline zval *zend_hash_index_find_deref(HashTable *ht, zend_u
 	return zv;
 }
 
-static zend_always_inline zval *zend_hash_find_deref(HashTable *ht, zend_string *str)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_hash_find_deref(HashTable *ht, zend_string *str)
 {
 	zval *zv = zend_hash_find(ht, str);
 	if (zv) {
@@ -923,7 +926,7 @@ static zend_always_inline zval *zend_hash_find_deref(HashTable *ht, zend_string 
 	return zv;
 }
 
-static zend_always_inline zval *zend_hash_str_find_deref(HashTable *ht, const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval *zend_hash_str_find_deref(HashTable *ht, const char *str, size_t len)
 {
 	zval *zv = zend_hash_str_find(ht, str, len);
 	if (zv) {
@@ -932,7 +935,7 @@ static zend_always_inline zval *zend_hash_str_find_deref(HashTable *ht, const ch
 	return zv;
 }
 
-static zend_always_inline void *zend_symtable_str_find_ptr(HashTable *ht, const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT void *zend_symtable_str_find_ptr(HashTable *ht, const char *str, size_t len)
 {
 	zend_ulong idx;
 
@@ -943,7 +946,7 @@ static zend_always_inline void *zend_symtable_str_find_ptr(HashTable *ht, const 
 	}
 }
 
-static zend_always_inline void *zend_hash_get_current_data_ptr_ex(HashTable *ht, HashPosition *pos)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT void *zend_hash_get_current_data_ptr_ex(HashTable *ht, HashPosition *pos)
 {
 	zval *zv;
 
@@ -1553,7 +1556,7 @@ static zend_always_inline void *zend_hash_get_current_data_ptr_ex(HashTable *ht,
 	} while (0)
 
 /* Check if an array is a list */
-static zend_always_inline bool zend_array_is_list(zend_array *array)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_array_is_list(zend_array *array)
 {
 	zend_long expected_idx = 0;
 	zend_long num_idx;

--- a/Zend/zend_list.h
+++ b/Zend/zend_list.h
@@ -63,8 +63,8 @@ ZEND_API void *zend_fetch_resource2(zend_resource *res, const char *resource_typ
 ZEND_API void *zend_fetch_resource_ex(zval *res, const char *resource_type_name, int resource_type);
 ZEND_API void *zend_fetch_resource2_ex(zval *res, const char *resource_type_name, int resource_type, int resource_type2);
 
-ZEND_API const char *zend_rsrc_list_get_rsrc_type(zend_resource *res);
-ZEND_API int zend_fetch_list_dtor_id(const char *type_name);
+ZEND_API const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_rsrc_list_get_rsrc_type(zend_resource *res);
+ZEND_API int ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_fetch_list_dtor_id(const char *type_name);
 
 ZEND_API zend_resource* zend_register_persistent_resource(const char *key, size_t key_len, void *rsrc_pointer, int rsrc_type);
 ZEND_API zend_resource* zend_register_persistent_resource_ex(zend_string *key, void *rsrc_pointer, int rsrc_type);

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -78,7 +78,7 @@ static zend_always_inline void zend_object_release(zend_object *obj)
 	}
 }
 
-static zend_always_inline size_t zend_object_properties_size(zend_class_entry *ce)
+static zend_always_inline size_t ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_object_properties_size(zend_class_entry *ce)
 {
 	return sizeof(zval) *
 		(ce->default_properties_count -
@@ -88,13 +88,13 @@ static zend_always_inline size_t zend_object_properties_size(zend_class_entry *c
 /* Allocates object type and zeros it, but not the standard zend_object and properties.
  * Standard object MUST be initialized using zend_object_std_init().
  * Properties MUST be initialized using object_properties_init(). */
-static zend_always_inline void *zend_object_alloc(size_t obj_size, zend_class_entry *ce) {
+static zend_always_inline void * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_object_alloc(size_t obj_size, zend_class_entry *ce) {
 	void *obj = emalloc(obj_size + zend_object_properties_size(ce));
 	memset(obj, 0, obj_size - sizeof(zend_object));
 	return obj;
 }
 
-static inline zend_property_info *zend_get_property_info_for_slot(zend_object *obj, zval *slot)
+static inline zend_property_info * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_property_info_for_slot(zend_object *obj, zval *slot)
 {
 	zend_property_info **table = obj->ce->properties_info_table;
 	intptr_t prop_num = slot - obj->properties_table;
@@ -103,7 +103,7 @@ static inline zend_property_info *zend_get_property_info_for_slot(zend_object *o
 }
 
 /* Helper for cases where we're only interested in property info of typed properties. */
-static inline zend_property_info *zend_get_typed_property_info_for_slot(zend_object *obj, zval *slot)
+static inline zend_property_info * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_get_typed_property_info_for_slot(zend_object *obj, zval *slot)
 {
 	zend_property_info *prop_info = zend_get_property_info_for_slot(obj, slot);
 	if (prop_info && ZEND_TYPE_IS_SET(prop_info->type)) {

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -54,7 +54,7 @@ ZEND_API zend_result ZEND_FASTCALL shift_left_function(zval *result, zval *op1, 
 ZEND_API zend_result ZEND_FASTCALL shift_right_function(zval *result, zval *op1, zval *op2);
 ZEND_API zend_result ZEND_FASTCALL concat_function(zval *result, zval *op1, zval *op2);
 
-ZEND_API bool ZEND_FASTCALL zend_is_identical(zval *op1, zval *op2);
+ZEND_API bool ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_is_identical(zval *op1, zval *op2);
 
 ZEND_API zend_result ZEND_FASTCALL is_equal_function(zval *result, zval *op1, zval *op2);
 ZEND_API zend_result ZEND_FASTCALL is_identical_function(zval *result, zval *op1, zval *op2);
@@ -63,10 +63,10 @@ ZEND_API zend_result ZEND_FASTCALL is_not_equal_function(zval *result, zval *op1
 ZEND_API zend_result ZEND_FASTCALL is_smaller_function(zval *result, zval *op1, zval *op2);
 ZEND_API zend_result ZEND_FASTCALL is_smaller_or_equal_function(zval *result, zval *op1, zval *op2);
 
-ZEND_API bool ZEND_FASTCALL zend_class_implements_interface(const zend_class_entry *class_ce, const zend_class_entry *interface_ce);
-ZEND_API bool ZEND_FASTCALL instanceof_function_slow(const zend_class_entry *instance_ce, const zend_class_entry *ce);
+ZEND_API bool ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_class_implements_interface(const zend_class_entry *class_ce, const zend_class_entry *interface_ce);
+ZEND_API bool ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT instanceof_function_slow(const zend_class_entry *instance_ce, const zend_class_entry *ce);
 
-static zend_always_inline bool instanceof_function(
+static zend_always_inline bool ZEND_ATTRIBUTE_WARN_UNUSED_RESULT instanceof_function(
 		const zend_class_entry *instance_ce, const zend_class_entry *ce) {
 	return instance_ce == ce || instanceof_function_slow(instance_ce, ce);
 }
@@ -86,11 +86,11 @@ static zend_always_inline bool instanceof_function(
  * could not be represented as such due to overflow. It writes 1 to oflow_info
  * if the integer is larger than ZEND_LONG_MAX and -1 if it's smaller than ZEND_LONG_MIN.
  */
-ZEND_API zend_uchar ZEND_FASTCALL _is_numeric_string_ex(const char *str, size_t length, zend_long *lval,
+ZEND_API zend_uchar ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT _is_numeric_string_ex(const char *str, size_t length, zend_long *lval,
 	double *dval, bool allow_errors, int *oflow_info, bool *trailing_data);
 
-ZEND_API const char* ZEND_FASTCALL zend_memnstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
-ZEND_API const char* ZEND_FASTCALL zend_memnrstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
+ZEND_API const char* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_memnstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
+ZEND_API const char* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_memnrstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
 
 #if SIZEOF_ZEND_LONG == 4
 #	define ZEND_DOUBLE_FITS_LONG(d) (!((d) > (double)ZEND_LONG_MAX || (d) < (double)ZEND_LONG_MIN))
@@ -100,7 +100,7 @@ ZEND_API const char* ZEND_FASTCALL zend_memnrstr_ex(const char *haystack, const 
 #endif
 
 #ifdef ZEND_DVAL_TO_LVAL_CAST_OK
-static zend_always_inline zend_long zend_dval_to_lval(double d)
+static zend_always_inline zend_long ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_dval_to_lval(double d)
 {
     if (EXPECTED(zend_finite(d)) && EXPECTED(!zend_isnan(d))) {
         return (zend_long)d;
@@ -109,9 +109,9 @@ static zend_always_inline zend_long zend_dval_to_lval(double d)
     }
 }
 #else
-ZEND_API zend_long ZEND_FASTCALL zend_dval_to_lval_slow(double d);
+ZEND_API zend_long ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_dval_to_lval_slow(double d);
 
-static zend_always_inline zend_long zend_dval_to_lval(double d)
+static zend_always_inline zend_long ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_dval_to_lval(double d)
 {
 	if (UNEXPECTED(!zend_finite(d)) || UNEXPECTED(zend_isnan(d))) {
 		return 0;
@@ -123,7 +123,7 @@ static zend_always_inline zend_long zend_dval_to_lval(double d)
 #endif
 
 /* Used to convert a string float to integer during an (int) cast */
-static zend_always_inline zend_long zend_dval_to_lval_cap(double d)
+static zend_always_inline zend_long ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_dval_to_lval_cap(double d)
 {
 	if (UNEXPECTED(!zend_finite(d)) || UNEXPECTED(zend_isnan(d))) {
 		return 0;
@@ -134,14 +134,14 @@ static zend_always_inline zend_long zend_dval_to_lval_cap(double d)
 }
 /* }}} */
 
-static zend_always_inline bool zend_is_long_compatible(double d, zend_long l) {
+static zend_always_inline bool ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_is_long_compatible(double d, zend_long l) {
 	return (double)l == d;
 }
 
 ZEND_API void zend_incompatible_double_to_long_error(double d);
 ZEND_API void zend_incompatible_string_to_long_error(const zend_string *s);
 
-static zend_always_inline zend_long zend_dval_to_lval_safe(double d)
+static zend_always_inline zend_long ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_dval_to_lval_safe(double d)
 {
 	zend_long l = zend_dval_to_lval(d);
 	if (!zend_is_long_compatible(d, l)) {
@@ -153,7 +153,7 @@ static zend_always_inline zend_long zend_dval_to_lval_safe(double d)
 #define ZEND_IS_DIGIT(c) ((c) >= '0' && (c) <= '9')
 #define ZEND_IS_XDIGIT(c) (((c) >= 'A' && (c) <= 'F') || ((c) >= 'a' && (c) <= 'f'))
 
-static zend_always_inline zend_uchar is_numeric_string_ex(const char *str, size_t length, zend_long *lval,
+static zend_always_inline zend_uchar ZEND_ATTRIBUTE_WARN_UNUSED_RESULT is_numeric_string_ex(const char *str, size_t length, zend_long *lval,
 	double *dval, bool allow_errors, int *oflow_info, bool *trailing_data)
 {
 	if (*str > '9') {
@@ -162,13 +162,13 @@ static zend_always_inline zend_uchar is_numeric_string_ex(const char *str, size_
 	return _is_numeric_string_ex(str, length, lval, dval, allow_errors, oflow_info, trailing_data);
 }
 
-static zend_always_inline zend_uchar is_numeric_string(const char *str, size_t length, zend_long *lval, double *dval, bool allow_errors) {
+static zend_always_inline zend_uchar ZEND_ATTRIBUTE_WARN_UNUSED_RESULT is_numeric_string(const char *str, size_t length, zend_long *lval, double *dval, bool allow_errors) {
     return is_numeric_string_ex(str, length, lval, dval, allow_errors, NULL, NULL);
 }
 
-ZEND_API zend_uchar ZEND_FASTCALL is_numeric_str_function(const zend_string *str, zend_long *lval, double *dval);
+ZEND_API zend_uchar ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT is_numeric_str_function(const zend_string *str, zend_long *lval, double *dval);
 
-static zend_always_inline const char *
+static zend_always_inline const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT
 zend_memnstr(const char *haystack, const char *needle, size_t needle_len, const char *end)
 {
 	const char *p = haystack;
@@ -209,7 +209,7 @@ zend_memnstr(const char *haystack, const char *needle, size_t needle_len, const 
 	}
 }
 
-static zend_always_inline const void *zend_memrchr(const void *s, int c, size_t n)
+static zend_always_inline const void * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_memrchr(const void *s, int c, size_t n)
 {
 #if defined(HAVE_MEMRCHR) && !defined(i386)
 	/* On x86 memrchr() doesn't use SSE/AVX, so inlined version is faster */
@@ -230,7 +230,7 @@ static zend_always_inline const void *zend_memrchr(const void *s, int c, size_t 
 }
 
 
-static zend_always_inline const char *
+static zend_always_inline const char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT
 zend_memnrstr(const char *haystack, const char *needle, size_t needle_len, const char *end)
 {
     const char *p = end;
@@ -284,21 +284,21 @@ ZEND_API void ZEND_FASTCALL convert_to_boolean(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_array(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_object(zval *op);
 
-ZEND_API zend_long    ZEND_FASTCALL zval_get_long_func(zval *op, bool is_strict);
-ZEND_API double       ZEND_FASTCALL zval_get_double_func(zval *op);
-ZEND_API zend_string* ZEND_FASTCALL zval_get_string_func(zval *op);
-ZEND_API zend_string* ZEND_FASTCALL zval_try_get_string_func(zval *op);
+ZEND_API zend_long    ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval_get_long_func(zval *op, bool is_strict);
+ZEND_API double       ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval_get_double_func(zval *op);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval_get_string_func(zval *op);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval_try_get_string_func(zval *op);
 
-static zend_always_inline zend_long zval_get_long(zval *op) {
+static zend_always_inline zend_long ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval_get_long(zval *op) {
 	return EXPECTED(Z_TYPE_P(op) == IS_LONG) ? Z_LVAL_P(op) : zval_get_long_func(op, false);
 }
-static zend_always_inline zend_long zval_get_long_ex(zval *op, bool is_strict) {
+static zend_always_inline zend_long ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval_get_long_ex(zval *op, bool is_strict) {
 	return EXPECTED(Z_TYPE_P(op) == IS_LONG) ? Z_LVAL_P(op) : zval_get_long_func(op, is_strict);
 }
-static zend_always_inline double zval_get_double(zval *op) {
+static zend_always_inline double ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval_get_double(zval *op) {
 	return EXPECTED(Z_TYPE_P(op) == IS_DOUBLE) ? Z_DVAL_P(op) : zval_get_double_func(op);
 }
-static zend_always_inline zend_string *zval_get_string(zval *op) {
+static zend_always_inline zend_string * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zval_get_string(zval *op) {
 	return EXPECTED(Z_TYPE_P(op) == IS_STRING) ? zend_string_copy(Z_STR_P(op)) : zval_get_string_func(op);
 }
 
@@ -360,13 +360,13 @@ static zend_always_inline bool try_convert_to_string(zval *op) {
 #define convert_to_string(op) if (Z_TYPE_P(op) != IS_STRING) { _convert_to_string((op)); }
 
 
-ZEND_API int ZEND_FASTCALL zend_is_true(zval *op);
-ZEND_API bool ZEND_FASTCALL zend_object_is_true(zval *op);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_is_true(zval *op);
+ZEND_API bool ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_object_is_true(zval *op);
 
 #define zval_is_true(op) \
 	zend_is_true(op)
 
-static zend_always_inline bool i_zend_is_true(zval *op)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool i_zend_is_true(zval *op)
 {
 	bool result = 0;
 
@@ -423,15 +423,15 @@ again:
 // TODO: Use a different value to allow an actual distinction here.
 #define ZEND_UNCOMPARABLE 1
 
-ZEND_API int ZEND_FASTCALL zend_compare(zval *op1, zval *op2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_compare(zval *op1, zval *op2);
 
 ZEND_API zend_result ZEND_FASTCALL compare_function(zval *result, zval *op1, zval *op2);
 
-ZEND_API int ZEND_FASTCALL numeric_compare_function(zval *op1, zval *op2);
-ZEND_API int ZEND_FASTCALL string_compare_function_ex(zval *op1, zval *op2, bool case_insensitive);
-ZEND_API int ZEND_FASTCALL string_compare_function(zval *op1, zval *op2);
-ZEND_API int ZEND_FASTCALL string_case_compare_function(zval *op1, zval *op2);
-ZEND_API int ZEND_FASTCALL string_locale_compare_function(zval *op1, zval *op2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT numeric_compare_function(zval *op1, zval *op2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT string_compare_function_ex(zval *op1, zval *op2, bool case_insensitive);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT string_compare_function(zval *op1, zval *op2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT string_case_compare_function(zval *op1, zval *op2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT string_locale_compare_function(zval *op1, zval *op2);
 
 ZEND_API extern const unsigned char zend_tolower_map[256];
 ZEND_API extern const unsigned char zend_toupper_map[256];
@@ -443,33 +443,33 @@ ZEND_API void         ZEND_FASTCALL zend_str_tolower(char *str, size_t length);
 ZEND_API void         ZEND_FASTCALL zend_str_toupper(char *str, size_t length);
 ZEND_API char*        ZEND_FASTCALL zend_str_tolower_copy(char *dest, const char *source, size_t length);
 ZEND_API char*        ZEND_FASTCALL zend_str_toupper_copy(char *dest, const char *source, size_t length);
-ZEND_API char*        ZEND_FASTCALL zend_str_tolower_dup(const char *source, size_t length);
-ZEND_API char*        ZEND_FASTCALL zend_str_toupper_dup(const char *source, size_t length);
-ZEND_API char*        ZEND_FASTCALL zend_str_tolower_dup_ex(const char *source, size_t length);
-ZEND_API char*        ZEND_FASTCALL zend_str_toupper_dup_ex(const char *source, size_t length);
-ZEND_API zend_string* ZEND_FASTCALL zend_string_tolower_ex(zend_string *str, bool persistent);
-ZEND_API zend_string* ZEND_FASTCALL zend_string_toupper_ex(zend_string *str, bool persistent);
+ZEND_API char*        ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_str_tolower_dup(const char *source, size_t length);
+ZEND_API char*        ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_str_toupper_dup(const char *source, size_t length);
+ZEND_API char*        ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_str_tolower_dup_ex(const char *source, size_t length);
+ZEND_API char*        ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_str_toupper_dup_ex(const char *source, size_t length);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string_tolower_ex(zend_string *str, bool persistent);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string_toupper_ex(zend_string *str, bool persistent);
 
 #define zend_string_tolower(str) zend_string_tolower_ex(str, 0)
 #define zend_string_toupper(str) zend_string_toupper_ex(str, 0)
 
-ZEND_API int ZEND_FASTCALL zend_binary_zval_strcmp(zval *s1, zval *s2);
-ZEND_API int ZEND_FASTCALL zend_binary_zval_strncmp(zval *s1, zval *s2, zval *s3);
-ZEND_API int ZEND_FASTCALL zend_binary_strcmp(const char *s1, size_t len1, const char *s2, size_t len2);
-ZEND_API int ZEND_FASTCALL zend_binary_strncmp(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
-ZEND_API int ZEND_FASTCALL zend_binary_strcasecmp(const char *s1, size_t len1, const char *s2, size_t len2);
-ZEND_API int ZEND_FASTCALL zend_binary_strncasecmp(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
-ZEND_API int ZEND_FASTCALL zend_binary_strcasecmp_l(const char *s1, size_t len1, const char *s2, size_t len2);
-ZEND_API int ZEND_FASTCALL zend_binary_strncasecmp_l(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_binary_zval_strcmp(zval *s1, zval *s2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_binary_zval_strncmp(zval *s1, zval *s2, zval *s3);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_binary_strcmp(const char *s1, size_t len1, const char *s2, size_t len2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_binary_strncmp(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_binary_strcasecmp(const char *s1, size_t len1, const char *s2, size_t len2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_binary_strncasecmp(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_binary_strcasecmp_l(const char *s1, size_t len1, const char *s2, size_t len2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_binary_strncasecmp_l(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
 
-ZEND_API bool ZEND_FASTCALL zendi_smart_streq(zend_string *s1, zend_string *s2);
-ZEND_API int ZEND_FASTCALL zendi_smart_strcmp(zend_string *s1, zend_string *s2);
-ZEND_API int ZEND_FASTCALL zend_compare_symbol_tables(HashTable *ht1, HashTable *ht2);
-ZEND_API int ZEND_FASTCALL zend_compare_arrays(zval *a1, zval *a2);
-ZEND_API int ZEND_FASTCALL zend_compare_objects(zval *o1, zval *o2);
+ZEND_API bool ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zendi_smart_streq(zend_string *s1, zend_string *s2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zendi_smart_strcmp(zend_string *s1, zend_string *s2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_compare_symbol_tables(HashTable *ht1, HashTable *ht2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_compare_arrays(zval *a1, zval *a2);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_compare_objects(zval *o1, zval *o2);
 
-ZEND_API int ZEND_FASTCALL zend_atoi(const char *str, size_t str_len);
-ZEND_API zend_long ZEND_FASTCALL zend_atol(const char *str, size_t str_len);
+ZEND_API int ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_atoi(const char *str, size_t str_len);
+ZEND_API zend_long ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_atol(const char *str, size_t str_len);
 
 #define convert_to_null_ex(zv) convert_to_null(zv)
 #define convert_to_boolean_ex(zv) convert_to_boolean(zv)
@@ -810,7 +810,7 @@ overflow: ZEND_ATTRIBUTE_COLD_LABEL
 #endif
 }
 
-static zend_always_inline bool zend_fast_equal_strings(zend_string *s1, zend_string *s2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_fast_equal_strings(zend_string *s1, zend_string *s2)
 {
 	if (s1 == s2) {
 		return 1;
@@ -821,7 +821,7 @@ static zend_always_inline bool zend_fast_equal_strings(zend_string *s1, zend_str
 	}
 }
 
-static zend_always_inline bool fast_equal_check_function(zval *op1, zval *op2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool fast_equal_check_function(zval *op1, zval *op2)
 {
 	if (EXPECTED(Z_TYPE_P(op1) == IS_LONG)) {
 		if (EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
@@ -843,7 +843,7 @@ static zend_always_inline bool fast_equal_check_function(zval *op1, zval *op2)
 	return zend_compare(op1, op2) == 0;
 }
 
-static zend_always_inline bool fast_equal_check_long(zval *op1, zval *op2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool fast_equal_check_long(zval *op1, zval *op2)
 {
 	if (EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
 		return Z_LVAL_P(op1) == Z_LVAL_P(op2);
@@ -851,7 +851,7 @@ static zend_always_inline bool fast_equal_check_long(zval *op1, zval *op2)
 	return zend_compare(op1, op2) == 0;
 }
 
-static zend_always_inline bool fast_equal_check_string(zval *op1, zval *op2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool fast_equal_check_string(zval *op1, zval *op2)
 {
 	if (EXPECTED(Z_TYPE_P(op2) == IS_STRING)) {
 		return zend_fast_equal_strings(Z_STR_P(op1), Z_STR_P(op2));
@@ -859,7 +859,7 @@ static zend_always_inline bool fast_equal_check_string(zval *op1, zval *op2)
 	return zend_compare(op1, op2) == 0;
 }
 
-static zend_always_inline bool fast_is_identical_function(zval *op1, zval *op2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool fast_is_identical_function(zval *op1, zval *op2)
 {
 	if (Z_TYPE_P(op1) != Z_TYPE_P(op2)) {
 		return 0;
@@ -869,7 +869,7 @@ static zend_always_inline bool fast_is_identical_function(zval *op1, zval *op2)
 	return zend_is_identical(op1, op2);
 }
 
-static zend_always_inline bool fast_is_not_identical_function(zval *op1, zval *op2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool fast_is_not_identical_function(zval *op1, zval *op2)
 {
 	if (Z_TYPE_P(op1) != Z_TYPE_P(op2)) {
 		return 1;
@@ -880,7 +880,7 @@ static zend_always_inline bool fast_is_not_identical_function(zval *op1, zval *o
 }
 
 /* buf points to the END of the buffer */
-static zend_always_inline char *zend_print_ulong_to_buf(char *buf, zend_ulong num) {
+static zend_always_inline char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_print_ulong_to_buf(char *buf, zend_ulong num) {
 	*buf = '\0';
 	do {
 		*--buf = (char) (num % 10) + '0';
@@ -890,7 +890,7 @@ static zend_always_inline char *zend_print_ulong_to_buf(char *buf, zend_ulong nu
 }
 
 /* buf points to the END of the buffer */
-static zend_always_inline char *zend_print_long_to_buf(char *buf, zend_long num) {
+static zend_always_inline char * ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_print_long_to_buf(char *buf, zend_long num) {
 	if (num < 0) {
 	    char *result = zend_print_ulong_to_buf(buf, ~((zend_ulong) num) + 1);
 	    *--result = '-';
@@ -900,11 +900,11 @@ static zend_always_inline char *zend_print_long_to_buf(char *buf, zend_long num)
 	}
 }
 
-ZEND_API zend_string* ZEND_FASTCALL zend_long_to_str(zend_long num);
-ZEND_API zend_string* ZEND_FASTCALL zend_ulong_to_str(zend_ulong num);
-ZEND_API zend_string* ZEND_FASTCALL zend_u64_to_str(uint64_t num);
-ZEND_API zend_string* ZEND_FASTCALL zend_i64_to_str(int64_t num);
-ZEND_API zend_string* ZEND_FASTCALL zend_double_to_str(double num);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_long_to_str(zend_long num);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_ulong_to_str(zend_ulong num);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_u64_to_str(uint64_t num);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_i64_to_str(int64_t num);
+ZEND_API zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_double_to_str(double num);
 
 static zend_always_inline void zend_unwrap_reference(zval *op) /* {{{ */
 {

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -228,6 +228,12 @@ char *alloca();
 # define ZEND_ATTRIBUTE_DEPRECATED
 #endif
 
+#if ZEND_GCC_VERSION >= 3003 || __has_attribute(warn_unused_result)
+# define ZEND_ATTRIBUTE_WARN_UNUSED_RESULT  __attribute__((warn_unused_result))
+#else
+# define ZEND_ATTRIBUTE_WARN_UNUSED_RESULT
+#endif
+
 #if ZEND_GCC_VERSION >= 4003 || __has_attribute(unused)
 # define ZEND_ATTRIBUTE_UNUSED __attribute__((unused))
 #else

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -30,9 +30,9 @@ ZEND_API zend_string_init_existing_interned_func_t zend_string_init_existing_int
 static zend_string* ZEND_FASTCALL zend_new_interned_string_permanent(zend_string *str);
 static zend_string* ZEND_FASTCALL zend_new_interned_string_request(zend_string *str);
 static zend_string* ZEND_FASTCALL zend_string_init_interned_permanent(const char *str, size_t size, bool permanent);
-static zend_string* ZEND_FASTCALL zend_string_init_existing_interned_permanent(const char *str, size_t size, bool permanent);
+static zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string_init_existing_interned_permanent(const char *str, size_t size, bool permanent);
 static zend_string* ZEND_FASTCALL zend_string_init_interned_request(const char *str, size_t size, bool permanent);
-static zend_string* ZEND_FASTCALL zend_string_init_existing_interned_request(const char *str, size_t size, bool permanent);
+static zend_string* ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string_init_existing_interned_request(const char *str, size_t size, bool permanent);
 
 /* Any strings interned in the startup phase. Common to all the threads,
    won't be free'd until process exit. If we want an ability to

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -26,7 +26,7 @@ BEGIN_EXTERN_C()
 typedef void (*zend_string_copy_storage_func_t)(void);
 typedef zend_string *(ZEND_FASTCALL *zend_new_interned_string_func_t)(zend_string *str);
 typedef zend_string *(ZEND_FASTCALL *zend_string_init_interned_func_t)(const char *str, size_t size, bool permanent);
-typedef zend_string *(ZEND_FASTCALL *zend_string_init_existing_interned_func_t)(const char *str, size_t size, bool permanent);
+typedef zend_string *(ZEND_FASTCALL ZEND_ATTRIBUTE_WARN_UNUSED_RESULT *zend_string_init_existing_interned_func_t)(const char *str, size_t size, bool permanent);
 
 ZEND_API extern zend_new_interned_string_func_t zend_new_interned_string;
 ZEND_API extern zend_string_init_interned_func_t zend_string_init_interned;
@@ -35,7 +35,7 @@ ZEND_API extern zend_string_init_existing_interned_func_t zend_string_init_exist
 
 ZEND_API zend_ulong ZEND_FASTCALL zend_string_hash_func(zend_string *str);
 ZEND_API zend_ulong ZEND_FASTCALL zend_hash_func(const char *str, size_t len);
-ZEND_API zend_string* ZEND_FASTCALL zend_interned_string_find_permanent(zend_string *str);
+ZEND_API zend_string* ZEND_ATTRIBUTE_WARN_UNUSED_RESULT ZEND_FASTCALL zend_interned_string_find_permanent(zend_string *str);
 
 ZEND_API zend_string *zend_string_concat2(
 	const char *str1, size_t str1_len,
@@ -145,7 +145,7 @@ static zend_always_inline uint32_t zend_string_delref(zend_string *s)
 	return 1;
 }
 
-static zend_always_inline zend_string *zend_string_alloc(size_t len, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_alloc(size_t len, bool persistent)
 {
 	zend_string *ret = (zend_string *)pemalloc(ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(len)), persistent);
 
@@ -156,7 +156,7 @@ static zend_always_inline zend_string *zend_string_alloc(size_t len, bool persis
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_safe_alloc(size_t n, size_t m, size_t l, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_safe_alloc(size_t n, size_t m, size_t l, bool persistent)
 {
 	zend_string *ret = (zend_string *)safe_pemalloc(n, m, ZEND_MM_ALIGNED_SIZE(_ZSTR_STRUCT_SIZE(l)), persistent);
 
@@ -167,7 +167,7 @@ static zend_always_inline zend_string *zend_string_safe_alloc(size_t n, size_t m
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_init(const char *str, size_t len, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_init(const char *str, size_t len, bool persistent)
 {
 	zend_string *ret = zend_string_alloc(len, persistent);
 
@@ -176,7 +176,7 @@ static zend_always_inline zend_string *zend_string_init(const char *str, size_t 
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_init_fast(const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_init_fast(const char *str, size_t len)
 {
 	if (len > 1) {
 		return zend_string_init(str, len, 0);
@@ -187,7 +187,7 @@ static zend_always_inline zend_string *zend_string_init_fast(const char *str, si
 	}
 }
 
-static zend_always_inline zend_string *zend_string_copy(zend_string *s)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_copy(zend_string *s)
 {
 	if (!ZSTR_IS_INTERNED(s)) {
 		GC_ADDREF(s);
@@ -195,7 +195,7 @@ static zend_always_inline zend_string *zend_string_copy(zend_string *s)
 	return s;
 }
 
-static zend_always_inline zend_string *zend_string_dup(zend_string *s, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_dup(zend_string *s, bool persistent)
 {
 	if (ZSTR_IS_INTERNED(s)) {
 		return s;
@@ -204,7 +204,7 @@ static zend_always_inline zend_string *zend_string_dup(zend_string *s, bool pers
 	}
 }
 
-static zend_always_inline zend_string *zend_string_separate(zend_string *s, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_separate(zend_string *s, bool persistent)
 {
 	if (ZSTR_IS_INTERNED(s) || GC_REFCOUNT(s) > 1) {
 		if (!ZSTR_IS_INTERNED(s)) {
@@ -217,7 +217,7 @@ static zend_always_inline zend_string *zend_string_separate(zend_string *s, bool
 	return s;
 }
 
-static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_t len, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_realloc(zend_string *s, size_t len, bool persistent)
 {
 	zend_string *ret;
 
@@ -237,7 +237,7 @@ static zend_always_inline zend_string *zend_string_realloc(zend_string *s, size_
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_extend(zend_string *s, size_t len, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_extend(zend_string *s, size_t len, bool persistent)
 {
 	zend_string *ret;
 
@@ -258,7 +258,7 @@ static zend_always_inline zend_string *zend_string_extend(zend_string *s, size_t
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size_t len, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_truncate(zend_string *s, size_t len, bool persistent)
 {
 	zend_string *ret;
 
@@ -279,7 +279,7 @@ static zend_always_inline zend_string *zend_string_truncate(zend_string *s, size
 	return ret;
 }
 
-static zend_always_inline zend_string *zend_string_safe_realloc(zend_string *s, size_t n, size_t m, size_t l, bool persistent)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string *zend_string_safe_realloc(zend_string *s, size_t n, size_t m, size_t l, bool persistent)
 {
 	zend_string *ret;
 
@@ -341,21 +341,21 @@ static zend_always_inline void zend_string_release_ex(zend_string *s, bool persi
 
 #if defined(__GNUC__) && (defined(__i386__) || (defined(__x86_64__) && !defined(__ILP32__)))
 BEGIN_EXTERN_C()
-ZEND_API bool ZEND_FASTCALL zend_string_equal_val(zend_string *s1, zend_string *s2);
+ZEND_API bool ZEND_FASTCALL  ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_string_equal_val(zend_string *s1, zend_string *s2);
 END_EXTERN_C()
 #else
-static zend_always_inline bool zend_string_equal_val(zend_string *s1, zend_string *s2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_string_equal_val(zend_string *s1, zend_string *s2)
 {
 	return !memcmp(ZSTR_VAL(s1), ZSTR_VAL(s2), ZSTR_LEN(s1));
 }
 #endif
 
-static zend_always_inline bool zend_string_equal_content(zend_string *s1, zend_string *s2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_string_equal_content(zend_string *s1, zend_string *s2)
 {
 	return ZSTR_LEN(s1) == ZSTR_LEN(s2) && zend_string_equal_val(s1, s2);
 }
 
-static zend_always_inline bool zend_string_equals(zend_string *s1, zend_string *s2)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT bool zend_string_equals(zend_string *s1, zend_string *s2)
 {
 	return s1 == s2 || zend_string_equal_content(s1, s2);
 }
@@ -402,7 +402,7 @@ static zend_always_inline bool zend_string_equals(zend_string *s1, zend_string *
  *                  -- Ralf S. Engelschall <rse@engelschall.com>
  */
 
-static zend_always_inline zend_ulong zend_inline_hash_func(const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_ulong zend_inline_hash_func(const char *str, size_t len)
 {
 	zend_ulong hash = Z_UL(5381);
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -564,7 +564,7 @@ struct _zend_ast_ref {
 #define _IS_BOOL					18
 #define _IS_NUMBER					19
 
-static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_uchar zval_get_type(const zval* pz) {
 	return pz->u1.v.type;
 }
 
@@ -633,15 +633,15 @@ static zend_always_inline zend_uchar zval_get_type(const zval* pz) {
 #define GC_FLAGS_SHIFT				0
 #define GC_INFO_SHIFT				10
 
-static zend_always_inline zend_uchar zval_gc_type(uint32_t gc_type_info) {
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_uchar zval_gc_type(uint32_t gc_type_info) {
 	return (gc_type_info & GC_TYPE_MASK);
 }
 
-static zend_always_inline uint32_t zval_gc_flags(uint32_t gc_type_info) {
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT uint32_t zval_gc_flags(uint32_t gc_type_info) {
 	return (gc_type_info >> GC_FLAGS_SHIFT) & (GC_FLAGS_MASK >> GC_FLAGS_SHIFT);
 }
 
-static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT uint32_t zval_gc_info(uint32_t gc_type_info) {
 	return (gc_type_info >> GC_INFO_SHIFT);
 }
 
@@ -1181,7 +1181,7 @@ extern ZEND_API bool zend_rc_debug;
 	do { } while (0)
 #endif
 
-static zend_always_inline uint32_t zend_gc_refcount(const zend_refcounted_h *p) {
+static zend_always_inline uint32_t ZEND_ATTRIBUTE_WARN_UNUSED_RESULT zend_gc_refcount(const zend_refcounted_h *p) {
 	return p->refcount;
 }
 
@@ -1227,7 +1227,7 @@ static zend_always_inline uint32_t zend_gc_delref_ex(zend_refcounted_h *p, uint3
 	return p->refcount;
 }
 
-static zend_always_inline uint32_t zval_refcount_p(const zval* pz) {
+static zend_always_inline ZEND_ATTRIBUTE_WARN_UNUSED_RESULT uint32_t zval_refcount_p(const zval* pz) {
 #if ZEND_DEBUG
 	ZEND_ASSERT(Z_REFCOUNTED_P(pz) || Z_TYPE_P(pz) == IS_ARRAY);
 #endif

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -931,7 +931,7 @@ static size_t tsrm_tls_offset;
 |				SSE_AVX_INS movsd, vmovsd, xmm(dst_reg-ZREG_XMM0), qword [((uint32_t)(uintptr_t)zv)]
 ||			}
 |			DOUBLE_SET_ZVAL_DVAL dst_addr, dst_reg
-||		} else if (Z_TYPE_P(zv) == IS_LONG && dst_def_info == MAY_BE_DOUBLE) {
+||		} else if (dst_def_info == MAY_BE_DOUBLE && Z_TYPE_P(zv) == IS_LONG) {
 ||			zend_reg dst_reg = (Z_MODE(dst_addr) == IS_REG) ? Z_REG(dst_addr) : ZREG_XMM0;
 |			DOUBLE_GET_LONG dst_reg, Z_LVAL_P(zv), ZREG_R0
 |			DOUBLE_SET_ZVAL_DVAL dst_addr, dst_reg
@@ -959,7 +959,7 @@ static size_t tsrm_tls_offset;
 ||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != MAY_BE_DOUBLE) {
 |				SET_ZVAL_TYPE_INFO dst_addr, IS_DOUBLE
 ||			}
-||		} else if (((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != (1<<Z_TYPE_P(zv))) || (dst_info & (MAY_BE_STRING|MAY_BE_ARRAY)) != 0) {
+||		} else if ((dst_info & (MAY_BE_STRING|MAY_BE_ARRAY)) != 0 || ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != (1<<Z_TYPE_P(zv)))) {
 |			SET_ZVAL_TYPE_INFO dst_addr, Z_TYPE_INFO_P(zv)
 ||		}
 ||	}
@@ -986,7 +986,7 @@ static size_t tsrm_tls_offset;
 ||			}
 |			DOUBLE_SET_ZVAL_DVAL dst_addr, ZREG_XMM0
 |			DOUBLE_SET_ZVAL_DVAL res_addr, ZREG_XMM0
-||		} else if (Z_TYPE_P(zv) == IS_LONG && dst_def_info == MAY_BE_DOUBLE) {
+||		} else if (dst_def_info == MAY_BE_DOUBLE && Z_TYPE_P(zv) == IS_LONG) {
 ||			if (Z_MODE(dst_addr) == IS_REG) {
 |				DOUBLE_GET_LONG Z_REG(dst_addr), Z_LVAL_P(zv), ZREG_R0
 |				DOUBLE_SET_ZVAL_DVAL res_addr, Z_REG(dst_addr)
@@ -1049,7 +1049,7 @@ static size_t tsrm_tls_offset;
 ||			if ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != MAY_BE_DOUBLE) {
 |				SET_ZVAL_TYPE_INFO dst_addr, IS_DOUBLE
 ||			}
-||		} else if (((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != (1<<Z_TYPE_P(zv))) || (dst_info & (MAY_BE_STRING|MAY_BE_ARRAY)) != 0) {
+||		} else if ((dst_info & (MAY_BE_STRING|MAY_BE_ARRAY)) != 0 || ((dst_info & (MAY_BE_ANY|MAY_BE_UNDEF|MAY_BE_GUARD)) != (1<<Z_TYPE_P(zv)))) {
 |			SET_ZVAL_TYPE_INFO dst_addr, Z_TYPE_INFO_P(zv)
 ||		}
 ||	}

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -85,7 +85,9 @@ static ZEND_FUNCTION(zend_test_deprecated)
 {
 	zval *arg1;
 
-	zend_parse_parameters(ZEND_NUM_ARGS(), "|z", &arg1);
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|z", &arg1) == FAILURE) {
+		RETURN_THROWS();
+	}
 }
 
 /* Create a string without terminating null byte. Must be terminated with
@@ -127,7 +129,9 @@ static ZEND_FUNCTION(zend_leak_bytes)
 		RETURN_THROWS();
 	}
 
+#pragma GCC diagnostic ignored "-Wunused-result"
 	emalloc(leakbytes);
+#pragma GCC diagnostic warning "-Wunused-result"
 }
 
 /* Leak a refcounted variable */


### PR DESCRIPTION
This has the following benefits:
- Warn about obviously detectable leaks,
  such as the one in ext/zend_test to unit test leak detection.
  Previously, no warning was emitted for not using `emalloc`.
- Act as a weak form of documentation about how the methods are used
  and where return codes should generally be checked.
- Warn about code that is likely to be an obvious mistake,
  e.g. zend_string_tolower will not modify the original string
  (the return value is what the caller should use and release instead)

  (or calling a function from a PECL to compute/create something
  but not putting it into a zval such as `return_value`)
  (or calling `erealloc`-like functions without using the return value)

This commit adds the annotation in the following cases:
- The returned value is newly allocated
- The function effectively has no side effects
- Conventionally, the return value should always be used.

This commit avoids adding the annotation in the following cases:
- There are reasons to call a function just for the side effects,
  e.g. decrementing reference counts, triggering autoloaders, etc.
- There are often callers that know that the return value is constant,
  e.g. decrementing a reference count when the pointer won't be freed.
- The computed value is stored in a pointer argument, e.g. a zval
  for some comparison functions.

Put constant expression before loading type from memory in the jit
- (The compiler may have optimized these out already if it was able to)
- Because the right hand side generated from .dasc was a constant expression,
  gcc was warning about the Z_TYPE_P not having an effect on the if
  condition's final value.