### PR TITLE
Fix error message allocation of PDO PgSQL.

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -87,7 +87,7 @@ int _pdo_pgsql_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, int errcode, const char *
 	}
 
 	if (msg) {
-		einfo->errmsg = estrdup(msg);
+		einfo->errmsg = pestrdup(msg, dbh->is_persistent);
 	}
 	else if (errmsg) {
 		einfo->errmsg = _pdo_pgsql_trim_message(errmsg, dbh->is_persistent);

--- a/ext/pdo_pgsql/tests/gh7723.phpt
+++ b/ext/pdo_pgsql/tests/gh7723.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GitHub #7723 (Fix error message allocation of PDO PgSQL)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+require __DIR__ . '/config.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+require __DIR__ . '/config.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->setAttribute(PDO::ATTR_PERSISTENT, true);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+$st = $db->prepare('select 1');
+for ($i = 0; ++$i <= 2;) {
+    try {
+        $st->bindValue(':invalid', $i);
+    } catch (PDOException $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+?>
+--EXPECT--
+SQLSTATE[HY093]: Invalid parameter number: :invalid
+SQLSTATE[HY093]: Invalid parameter number: :invalid


### PR DESCRIPTION
In PDO PgSQL driver, some error messages are allocated using estrdup() instead of pestrdup().
This cause crash if persistent connection is used and the last error message is freed (with pefree().)
```php
<?php
$db = new PDO(
    'pgsql:dbname=' . DB_NAME,
    USER_NAME,
    PASSWORD,
    [
        PDO::ATTR_PERSISTENT => true,
        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
        PDO::ATTR_EMULATE_PREPARES => false,
    ],
);

$st = $db->prepare('select 1');
for ($i = 0; ++$i <= 2;) {
    try {
        $st->bindValue(':invalid', $i);
    } catch (PDOException $e) {
        echo "$i\n";
    }
}
```

Expected result:
```
1
2
```
Actual result:
```
1
*** Error in `php': free(): invalid pointer: 0x... ***
======= Backtrace: =========
/lib64/libc.so.6(+0x81329)[0x...]
/usr/lib64/php/modules/pdo_pgsql.so(+0x3c11)[0x...]
```