### PR TITLE
ZEND_INIT_FCALL is only produced when function exists at compile time

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -6,6 +6,8 @@ PHP 8.2 INTERNALS UPGRADE NOTES
 
 3. Module changes
 
+4. OpCode changes
+
 ========================
 1. Internal API changes
 ========================
@@ -23,4 +25,15 @@ PHP 8.2 INTERNALS UPGRADE NOTES
 ========================
 3. Module changes
 ========================
+
+========================
+4. OpCode changes
+========================
+
+* The ZEND_INIT_FCALL opcode now asserts that the function exists in the symbol
+  table as the function's existence is checked at compile time.
+  For extensions modifying the function symbol table, setting
+  CG(compiler_options) |= ZEND_COMPILE_IGNORE_USER_FUNCTIONS | ZEND_COMPILE_IGNORE_INTERNAL_FUNCTIONS;
+  will produce ZEND_INIT_FCALL_BY_NAME opcodes instead which check for the
+  existence of the function at runtime.
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3930,9 +3930,7 @@ ZEND_VM_HOT_HANDLER(61, ZEND_INIT_FCALL, NUM, CONST, NUM|CACHE_SLOT)
 	if (UNEXPECTED(fbc == NULL)) {
 		fname = (zval*)RT_CONSTANT(opline, opline->op2);
 		func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(fname));
-		if (UNEXPECTED(func == NULL)) {
-			ZEND_VM_DISPATCH_TO_HELPER(zend_undefined_function_helper);
-		}
+		ZEND_ASSERT(func != NULL && "Function existence must be checked at compile time");
 		fbc = Z_FUNC_P(func);
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
 			init_func_run_time_cache(&fbc->op_array);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3693,9 +3693,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_FCALL_SPEC_CO
 	if (UNEXPECTED(fbc == NULL)) {
 		fname = (zval*)RT_CONSTANT(opline, opline->op2);
 		func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(fname));
-		if (UNEXPECTED(func == NULL)) {
-			ZEND_VM_TAIL_CALL(zend_undefined_function_helper_SPEC(ZEND_OPCODE_HANDLER_ARGS_PASSTHRU));
-		}
+		ZEND_ASSERT(func != NULL && "Function existence must be checked at compile time");
 		fbc = Z_FUNC_P(func);
 		if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
 			init_func_run_time_cache(&fbc->op_array);


### PR DESCRIPTION
Was a lot of staring and trying to come up with a test case for the undefined function case here while working on function autoloading, but I'm fairly certain this cannot ever happen from me staring at ``zend_compile.c``