### PR TITLE
Allocate less memory for EG(errors) when recording errors for opcache

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1331,7 +1331,7 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 		/* This is very inefficient for a large number of errors.
 		 * Use pow2 realloc if it becomes a problem. */
 		EG(num_errors)++;
-		EG(errors) = erealloc(EG(errors), sizeof(zend_error_info) * EG(num_errors));
+		EG(errors) = erealloc(EG(errors), sizeof(zend_error_info*) * EG(num_errors));
 		EG(errors)[EG(num_errors)-1] = info;
 	}
 
@@ -1575,7 +1575,7 @@ ZEND_API ZEND_COLD void zend_error_zstr(int type, zend_string *message) {
 
 ZEND_API void zend_begin_record_errors(void)
 {
-	ZEND_ASSERT(!EG(record_errors) && "Error recoreding already enabled");
+	ZEND_ASSERT(!EG(record_errors) && "Error recording already enabled");
 	EG(record_errors) = true;
 	EG(num_errors) = 0;
 	EG(errors) = NULL;


### PR DESCRIPTION
errors is an array of pointers, not an array of values. (could be an array of values instead, but not really performance sensitive enough to investigate)

Low importance since this is freed after opcache compiles a file and there are
typically no or very few errors.