### PR TITLE
Fix #81585: cached_chunks are not counted to real_size on shutdown

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2303,10 +2303,10 @@ void zend_mm_shutdown(zend_mm_heap *heap, bool full, bool silent)
 #endif
 		memset(heap->free_slot, 0, sizeof(heap->free_slot));
 #if ZEND_MM_STAT || ZEND_MM_LIMIT
-		heap->real_size = ZEND_MM_CHUNK_SIZE;
+		heap->real_size = (heap->cached_chunks_count + 1) * ZEND_MM_CHUNK_SIZE;
 #endif
 #if ZEND_MM_STAT
-		heap->real_peak = ZEND_MM_CHUNK_SIZE;
+		heap->real_peak = (heap->cached_chunks_count + 1) * ZEND_MM_CHUNK_SIZE;
 #endif
 		heap->chunks_count = 1;
 		heap->peak_chunks_count = 1;


### PR DESCRIPTION
The amount of allocated system memory is kept in `real_size`, including
the allocated `cached_chunks`.  Thus, we need to keep the proper count
at the end of the shutdown.