### PR TITLE
macOS 10.14 runners are no longer available via Azure Pipeline

### DIFF
--- a/azure/macos/job.yml
+++ b/azure/macos/job.yml
@@ -5,7 +5,7 @@ parameters:
 jobs:
   - job: ${{ parameters.configurationName }}
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
     steps:
     - template: brew.yml
     - script: |

--- a/azure/macos/job.yml
+++ b/azure/macos/job.yml
@@ -18,7 +18,6 @@ jobs:
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/zlib/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
         ./buildconf --force
-        CFLAGS=-Wno-int-in-bool-context \
         ./configure ${{ parameters.configurationParameters }} \
             --enable-option-checking=fatal \
             --prefix=/usr/local \
@@ -67,7 +66,6 @@ jobs:
             --enable-intl \
             --with-mhash \
             --with-sodium \
-            --enable-werror \
             --with-config-file-path=/etc \
             --with-config-file-scan-dir=/etc/php.d
       displayName: 'Configure Build'

--- a/azure/macos/job.yml
+++ b/azure/macos/job.yml
@@ -18,7 +18,7 @@ jobs:
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/zlib/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
         ./buildconf --force
-        CFLAGS=-Wno-error=int-in-bool-context \
+        CFLAGS=-Wno-int-in-bool-context \
         ./configure ${{ parameters.configurationParameters }} \
             --enable-option-checking=fatal \
             --prefix=/usr/local \

--- a/azure/macos/job.yml
+++ b/azure/macos/job.yml
@@ -18,6 +18,7 @@ jobs:
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/zlib/lib/pkgconfig"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
         ./buildconf --force
+        CFLAGS=-Wno-error=int-in-bool-context \
         ./configure ${{ parameters.configurationParameters }} \
             --enable-option-checking=fatal \
             --prefix=/usr/local \


### PR DESCRIPTION
These images have already been deprecated for two months[1].  Thus,
we upgrade to macOS 10.15.

[1] <https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/>