### PR TITLE
Fix GH-7757: Multi-inherited final constant causes fatal error

### DIFF
--- a/Zend/tests/constants/final_constants/final_const13.phpt
+++ b/Zend/tests/constants/final_constants/final_const13.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug GH-7757 (Multi-inherited final constant causes fatal error)
+--FILE--
+<?php
+interface EntityInterface {
+    final public const TEST = 'this';
+}
+
+interface KeyInterface extends EntityInterface {
+}
+
+interface StringableInterface extends EntityInterface {
+}
+
+class SomeTestClass implements KeyInterface, StringableInterface {
+}
+?>
+--EXPECT--

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1605,7 +1605,7 @@ static bool do_inherit_constant_check(
 	}
 
 	zend_class_constant *old_constant = Z_PTR_P(zv);
-	if ((ZEND_CLASS_CONST_FLAGS(parent_constant) & ZEND_ACC_FINAL)) {
+	if (parent_constant->ce != old_constant->ce && (ZEND_CLASS_CONST_FLAGS(parent_constant) & ZEND_ACC_FINAL)) {
 		zend_error_noreturn(E_COMPILE_ERROR, "%s::%s cannot override final constant %s::%s",
 			ZSTR_VAL(old_constant->ce->name), ZSTR_VAL(name),
 			ZSTR_VAL(parent_constant->ce->name), ZSTR_VAL(name)


### PR DESCRIPTION
"Diamond" inheritance of final constants is supposed to be supported.