### PR TITLE
Fix "The Mysterious PHP RFC Process" link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,7 @@ repository. Mailing list subscription is explained on the
 [mailing lists page](https://www.php.net/mailing-lists.php).
 
 You may also want to read
-[The Mysterious PHP RFC Process](https://blogs.oracle.com/opal/entry/the_mysterious_php_rfc_process)
-for additional notes on the best way to approach submitting an RFC.
+[The Mysterious PHP RFC Process](https://blogs.oracle.com/opal/post/the-mysterious-php-rfc-process-and-how-you-can-change-the-web) for additional notes on the best way to approach submitting an RFC.
 
 ## Writing tests
 


### PR DESCRIPTION
The link for "The Mysterious PHP RFC Process" for the current version CONTRIBUTING.md is broken.
This PR fixes that problem by replacing the old broken link with a new one that works.

Note: I've followed the contributors guide for submitting this to the lowest supported branch.
However, since it isn't a code fix I'm not sure if this is the correct procedure for merging this fix.

If any of the maintainers have a preference, please let me know and I'll change where this is aimed.