### PR TITLE
zend_atol() cleanup

### DIFF
--- a/Zend/tests/zend_atol.phpt
+++ b/Zend/tests/zend_atol.phpt
@@ -1,0 +1,360 @@
+--TEST--
+Test parsing of INI "size" values (e.g. "16M")
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+// This test checks valid formats do not throw any warnings.
+foreach (['', ' '] as $leadingWS) {
+  foreach (['', '+', '-'] as $sign) {
+    foreach (['', ' '] as $midWS) {
+      foreach (['', 'K', 'k', 'M', 'm', 'G', 'g'] as $exp) {
+        foreach (['', ' '] as $trailingWS) {
+          $setting = sprintf('%s%s1%s%s%s',
+                             $leadingWS, $sign, $midWS, $exp, $trailingWS);
+          var_dump($setting);
+          var_dump(zend_test_zend_atol($setting));
+        }
+      }
+    }
+  }
+}
+
+--EXPECT--
+string(1) "1"
+int(1)
+string(2) "1 "
+int(1)
+string(2) "1K"
+int(1024)
+string(3) "1K "
+int(1024)
+string(2) "1k"
+int(1024)
+string(3) "1k "
+int(1024)
+string(2) "1M"
+int(1048576)
+string(3) "1M "
+int(1048576)
+string(2) "1m"
+int(1048576)
+string(3) "1m "
+int(1048576)
+string(2) "1G"
+int(1073741824)
+string(3) "1G "
+int(1073741824)
+string(2) "1g"
+int(1073741824)
+string(3) "1g "
+int(1073741824)
+string(2) "1 "
+int(1)
+string(3) "1  "
+int(1)
+string(3) "1 K"
+int(1024)
+string(4) "1 K "
+int(1024)
+string(3) "1 k"
+int(1024)
+string(4) "1 k "
+int(1024)
+string(3) "1 M"
+int(1048576)
+string(4) "1 M "
+int(1048576)
+string(3) "1 m"
+int(1048576)
+string(4) "1 m "
+int(1048576)
+string(3) "1 G"
+int(1073741824)
+string(4) "1 G "
+int(1073741824)
+string(3) "1 g"
+int(1073741824)
+string(4) "1 g "
+int(1073741824)
+string(2) "+1"
+int(1)
+string(3) "+1 "
+int(1)
+string(3) "+1K"
+int(1024)
+string(4) "+1K "
+int(1024)
+string(3) "+1k"
+int(1024)
+string(4) "+1k "
+int(1024)
+string(3) "+1M"
+int(1048576)
+string(4) "+1M "
+int(1048576)
+string(3) "+1m"
+int(1048576)
+string(4) "+1m "
+int(1048576)
+string(3) "+1G"
+int(1073741824)
+string(4) "+1G "
+int(1073741824)
+string(3) "+1g"
+int(1073741824)
+string(4) "+1g "
+int(1073741824)
+string(3) "+1 "
+int(1)
+string(4) "+1  "
+int(1)
+string(4) "+1 K"
+int(1024)
+string(5) "+1 K "
+int(1024)
+string(4) "+1 k"
+int(1024)
+string(5) "+1 k "
+int(1024)
+string(4) "+1 M"
+int(1048576)
+string(5) "+1 M "
+int(1048576)
+string(4) "+1 m"
+int(1048576)
+string(5) "+1 m "
+int(1048576)
+string(4) "+1 G"
+int(1073741824)
+string(5) "+1 G "
+int(1073741824)
+string(4) "+1 g"
+int(1073741824)
+string(5) "+1 g "
+int(1073741824)
+string(2) "-1"
+int(-1)
+string(3) "-1 "
+int(-1)
+string(3) "-1K"
+int(-1024)
+string(4) "-1K "
+int(-1024)
+string(3) "-1k"
+int(-1024)
+string(4) "-1k "
+int(-1024)
+string(3) "-1M"
+int(-1048576)
+string(4) "-1M "
+int(-1048576)
+string(3) "-1m"
+int(-1048576)
+string(4) "-1m "
+int(-1048576)
+string(3) "-1G"
+int(-1073741824)
+string(4) "-1G "
+int(-1073741824)
+string(3) "-1g"
+int(-1073741824)
+string(4) "-1g "
+int(-1073741824)
+string(3) "-1 "
+int(-1)
+string(4) "-1  "
+int(-1)
+string(4) "-1 K"
+int(-1024)
+string(5) "-1 K "
+int(-1024)
+string(4) "-1 k"
+int(-1024)
+string(5) "-1 k "
+int(-1024)
+string(4) "-1 M"
+int(-1048576)
+string(5) "-1 M "
+int(-1048576)
+string(4) "-1 m"
+int(-1048576)
+string(5) "-1 m "
+int(-1048576)
+string(4) "-1 G"
+int(-1073741824)
+string(5) "-1 G "
+int(-1073741824)
+string(4) "-1 g"
+int(-1073741824)
+string(5) "-1 g "
+int(-1073741824)
+string(2) " 1"
+int(1)
+string(3) " 1 "
+int(1)
+string(3) " 1K"
+int(1024)
+string(4) " 1K "
+int(1024)
+string(3) " 1k"
+int(1024)
+string(4) " 1k "
+int(1024)
+string(3) " 1M"
+int(1048576)
+string(4) " 1M "
+int(1048576)
+string(3) " 1m"
+int(1048576)
+string(4) " 1m "
+int(1048576)
+string(3) " 1G"
+int(1073741824)
+string(4) " 1G "
+int(1073741824)
+string(3) " 1g"
+int(1073741824)
+string(4) " 1g "
+int(1073741824)
+string(3) " 1 "
+int(1)
+string(4) " 1  "
+int(1)
+string(4) " 1 K"
+int(1024)
+string(5) " 1 K "
+int(1024)
+string(4) " 1 k"
+int(1024)
+string(5) " 1 k "
+int(1024)
+string(4) " 1 M"
+int(1048576)
+string(5) " 1 M "
+int(1048576)
+string(4) " 1 m"
+int(1048576)
+string(5) " 1 m "
+int(1048576)
+string(4) " 1 G"
+int(1073741824)
+string(5) " 1 G "
+int(1073741824)
+string(4) " 1 g"
+int(1073741824)
+string(5) " 1 g "
+int(1073741824)
+string(3) " +1"
+int(1)
+string(4) " +1 "
+int(1)
+string(4) " +1K"
+int(1024)
+string(5) " +1K "
+int(1024)
+string(4) " +1k"
+int(1024)
+string(5) " +1k "
+int(1024)
+string(4) " +1M"
+int(1048576)
+string(5) " +1M "
+int(1048576)
+string(4) " +1m"
+int(1048576)
+string(5) " +1m "
+int(1048576)
+string(4) " +1G"
+int(1073741824)
+string(5) " +1G "
+int(1073741824)
+string(4) " +1g"
+int(1073741824)
+string(5) " +1g "
+int(1073741824)
+string(4) " +1 "
+int(1)
+string(5) " +1  "
+int(1)
+string(5) " +1 K"
+int(1024)
+string(6) " +1 K "
+int(1024)
+string(5) " +1 k"
+int(1024)
+string(6) " +1 k "
+int(1024)
+string(5) " +1 M"
+int(1048576)
+string(6) " +1 M "
+int(1048576)
+string(5) " +1 m"
+int(1048576)
+string(6) " +1 m "
+int(1048576)
+string(5) " +1 G"
+int(1073741824)
+string(6) " +1 G "
+int(1073741824)
+string(5) " +1 g"
+int(1073741824)
+string(6) " +1 g "
+int(1073741824)
+string(3) " -1"
+int(-1)
+string(4) " -1 "
+int(-1)
+string(4) " -1K"
+int(-1024)
+string(5) " -1K "
+int(-1024)
+string(4) " -1k"
+int(-1024)
+string(5) " -1k "
+int(-1024)
+string(4) " -1M"
+int(-1048576)
+string(5) " -1M "
+int(-1048576)
+string(4) " -1m"
+int(-1048576)
+string(5) " -1m "
+int(-1048576)
+string(4) " -1G"
+int(-1073741824)
+string(5) " -1G "
+int(-1073741824)
+string(4) " -1g"
+int(-1073741824)
+string(5) " -1g "
+int(-1073741824)
+string(4) " -1 "
+int(-1)
+string(5) " -1  "
+int(-1)
+string(5) " -1 K"
+int(-1024)
+string(6) " -1 K "
+int(-1024)
+string(5) " -1 k"
+int(-1024)
+string(6) " -1 k "
+int(-1024)
+string(5) " -1 M"
+int(-1048576)
+string(6) " -1 M "
+int(-1048576)
+string(5) " -1 m"
+int(-1048576)
+string(6) " -1 m "
+int(-1048576)
+string(5) " -1 G"
+int(-1073741824)
+string(6) " -1 G "
+int(-1073741824)
+string(5) " -1 g"
+int(-1073741824)
+string(6) " -1 g "
+int(-1073741824)

--- a/Zend/tests/zend_atol_error.phpt
+++ b/Zend/tests/zend_atol_error.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test parsing failures of INI "size" values (e.g. "16M")
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+// This test checks invalid formats do throw warnings.
+
+$tests = [
+  'K',     # No digits
+  '1KM',   # Multiple multipliers.
+  '1X',    # Unknown multiplier.
+  '1.0K',  # Non integral digits.
+];
+
+foreach ($tests as $setting) {
+  var_dump(zend_test_zend_atol($setting));
+}
+
+--EXPECTF--
+Warning: Invalid numeric string 'K', no valid leading digits, interpreting as '0' for backwards compatibility in %s%ezend_atol_error.php on line %d
+int(0)
+
+Warning: Invalid numeric string '1KM', interpreting as '1M' for backwards compatibility in %s%ezend_atol_error.php on line %d
+int(1048576)
+
+Warning: Invalid numeric string '1X', interpreting as '1' for backwards compatibility in %s%ezend_atol_error.php on line %d
+int(1)
+
+Warning: Invalid numeric string '1.0K', interpreting as '1K' for backwards compatibility in %s%ezend_atol_error.php on line %d
+int(1024)

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -146,7 +146,7 @@ static ZEND_INI_MH(OnUpdateAssertions) /* {{{ */
 {
 	zend_long *p = (zend_long *) ZEND_INI_GET_ADDR();
 
-	zend_long val = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+	zend_long val = ZEND_ATOL(ZSTR_VAL(new_value));
 
 	if (stage != ZEND_INI_STAGE_STARTUP &&
 	    stage != ZEND_INI_STAGE_SHUTDOWN &&

--- a/ext/ffi/tests/bug78270_1.phpt
+++ b/ext/ffi/tests/bug78270_1.phpt
@@ -27,7 +27,7 @@ require_once('utils.inc');
 $ffi = FFI::cdef(<<<EOC
     __vectorcall int bug78270(const char *str, size_t str_len);
 EOC, "php_zend_test.dll");
-var_dump($ffi->bug78270("17.4", 4));
+var_dump($ffi->bug78270("17", 2));
 ?>
 --EXPECT--
 int(17)

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -165,7 +165,7 @@ static ZEND_INI_MH(OnUpdateJit)
 static ZEND_INI_MH(OnUpdateJitDebug)
 {
 	zend_long *p = (zend_long *) ZEND_INI_GET_ADDR();
-	zend_long val = zend_atol(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+	zend_long val = ZEND_ATOL(ZSTR_VAL(new_value));
 
 	if (zend_jit_debug_config(*p, val, stage) == SUCCESS) {
 		*p = val;

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2505,7 +2505,7 @@ static void php_simple_ini_parser_cb(zval *arg1, zval *arg2, zval *arg3, int cal
 			}
 
 			if (!(Z_STRLEN_P(arg1) > 1 && Z_STRVAL_P(arg1)[0] == '0') && is_numeric_string(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1), NULL, NULL, 0) == IS_LONG) {
-				zend_ulong key = (zend_ulong) zend_atol(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1));
+				zend_ulong key = (zend_ulong) ZEND_STRTOUL(Z_STRVAL_P(arg1), NULL, 0);
 				if ((find_hash = zend_hash_index_find(Z_ARRVAL_P(arr), key)) == NULL) {
 					array_init(&hash);
 					find_hash = zend_hash_index_add_new(Z_ARRVAL_P(arr), key, &hash);

--- a/ext/standard/tests/general_functions/parse_ini_numeric_entry_name.phpt
+++ b/ext/standard/tests/general_functions/parse_ini_numeric_entry_name.phpt
@@ -1,0 +1,23 @@
+--TEST--
+parse_ini_string with numeric entry name
+--FILE--
+<?php
+
+var_dump(parse_ini_string("
+1[]=1
+2M[]=2
+"));
+
+--EXPECT--
+array(2) {
+  [1]=>
+  array(1) {
+    [0]=>
+    string(1) "1"
+  }
+  ["2M"]=>
+  array(1) {
+    [0]=>
+    string(1) "2"
+  }
+}

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -307,6 +307,17 @@ static ZEND_FUNCTION(zend_get_unit_enum)
 	RETURN_OBJ_COPY(zend_enum_get_case_cstr(zend_test_unit_enum, "Foo"));
 }
 
+static ZEND_FUNCTION(zend_test_zend_atol)
+{
+	zend_string *str;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_LONG(zend_atol(ZSTR_VAL(str), ZSTR_LEN(str)));
+}
+
 static ZEND_FUNCTION(namespaced_func)
 {
 	ZEND_PARSE_PARAMETERS_NONE();

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -92,6 +92,8 @@ namespace {
     function zend_weakmap_dump(): array {}
 
     function zend_get_unit_enum(): ZendTestUnitEnum {}
+
+    function zend_test_zend_atol(string $str): int {}
 }
 
 namespace ZendTestNS {

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7326163f8ce5340c12e74af72d47a8926eb39786 */
+ * Stub hash: 6ab822237eacd3831c1d8dea23b7d5e4c88e4a88 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -71,6 +71,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_zend_get_unit_enum, 0, 0, ZendTestUnitEnum, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_zend_atol, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, str, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_ZendSubNS_namespaced_func, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -116,6 +120,7 @@ static ZEND_FUNCTION(zend_weakmap_attach);
 static ZEND_FUNCTION(zend_weakmap_remove);
 static ZEND_FUNCTION(zend_weakmap_dump);
 static ZEND_FUNCTION(zend_get_unit_enum);
+static ZEND_FUNCTION(zend_test_zend_atol);
 static ZEND_FUNCTION(namespaced_func);
 static ZEND_METHOD(_ZendTestClass, is_object);
 static ZEND_METHOD(_ZendTestClass, __toString);
@@ -147,6 +152,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_weakmap_remove, arginfo_zend_weakmap_remove)
 	ZEND_FE(zend_weakmap_dump, arginfo_zend_weakmap_dump)
 	ZEND_FE(zend_get_unit_enum, arginfo_zend_get_unit_enum)
+	ZEND_FE(zend_test_zend_atol, arginfo_zend_test_zend_atol)
 	ZEND_NS_FE("ZendTestNS2\\ZendSubNS", namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)
 	ZEND_FE_END
 };


### PR DESCRIPTION
This PR is mostly a rebase of #4132 and continuation of 989205e9.

#4132 primarily changes the zend_atol() function, which is used to parse sizes/quantity values in ini settings, so that a warning is triggered if a value has an invalid format. This warning is helpful as it makes it easier to notice configuration errors.

A warning or a deprecation is the right solution here, since alternatives introduce breaking changes and/or have security implications.

There are little changes compared to the original PR:
- The warning messages specify that the fallback behavior is for backwards compatibility
- The changes around zend_atoi() was handled already in 989205e9
- Switched the tests to a ext/zend-test function, and added expectations about the return value of zend_atol()

There are a few things we could consider after this change:

* Deprecating zend_atoi() and removing it at some point in the future
* Renaming zend_atol() to something reflecting its behavior. This would make it less surprising and would reduce the chances of accidentally using zend_atol() at a place where the intent is not to parse a size or quantity. Since the function is only used for parsing ini values now, we could move it to Zend/zend_ini and chose a name like zend_ini_parse_quantity(). We could keep a deprecated wrapper/alias for some time.
* Ultimately removing the fallback and turning the warning to an error, although it may have security implication preventing us from doing that