### PR TITLE
Fix FILTER_FLAG_NO_RES_RANGE flag

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -933,7 +933,7 @@ void php_filter_validate_ip(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 						&& ip[4] == 0 && ip[5] == 0 && ip[6] == 0 && (ip[7] == 0 || ip[7] == 1))
 						|| (ip[0] == 0x5f)
 						|| (ip[0] >= 0xfe80 && ip[0] <= 0xfebf)
-						|| ((ip[0] == 0x2001 && ip[1] == 0x0db8) || (ip[1] >= 0x0010 && ip[1] <= 0x001f))
+						|| (ip[0] == 0x2001 && (ip[1] == 0x0db8 || (ip[1] >= 0x0010 && ip[1] <= 0x001f)))
 						|| (ip[0] == 0x3ff3)
 					) {
 						RETURN_VALIDATION_FAILED

--- a/ext/filter/tests/bug47435.phpt
+++ b/ext/filter/tests/bug47435.phpt
@@ -14,6 +14,10 @@ var_dump(filter_var("fe80:5:6::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
 var_dump(filter_var("fe80:5:6::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE));
 var_dump(filter_var("2001:0db8::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
 var_dump(filter_var("2001:0db8::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE));
+var_dump(filter_var("2001:0010::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+var_dump(filter_var("2001:0010::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE));
+var_dump(filter_var("240b:0010::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+var_dump(filter_var("240b:0010::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE));
 var_dump(filter_var("5f::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
 var_dump(filter_var("5f::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE));
 var_dump(filter_var("3ff3::1", FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
@@ -30,6 +34,10 @@ string(11) "fe80:5:6::1"
 bool(false)
 string(12) "2001:0db8::1"
 bool(false)
+string(12) "2001:0010::1"
+bool(false)
+string(12) "240b:0010::1"
+string(12) "240b:0010::1"
 string(5) "5f::1"
 bool(false)
 string(7) "3ff3::1"


### PR DESCRIPTION
`2001:10::/28` is a reversed IPv6 range. But there's a typo in #7476, which caused IPv6 address like `240b:0010::1` will be filtered by the flag `FILTER_FLAG_NO_RES_RANGE`.

http://www.faqs.org/rfcs/rfc6890.html