### PR TITLE
Add triage label when removing feedback label

### DIFF
--- a/.github/workflows/remove-needs-feedback.yml
+++ b/.github/workflows/remove-needs-feedback.yml
@@ -13,3 +13,6 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: "Status: Needs Feedback"
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: "Status: Needs Triage"


### PR DESCRIPTION
I think this would make sense to indicate that action from our side is needed on the issue again.