### PR TITLE
Update the min curl version in the sync-constants.php script

### DIFF
--- a/ext/curl/sync-constants.php
+++ b/ext/curl/sync-constants.php
@@ -12,7 +12,7 @@ const CURL_DOC_FILE = 'https://curl.haxx.se/libcurl/c/symbols-in-versions.html';
 
 const SOURCE_FILE = __DIR__ . '/interface.c';
 
-const MIN_SUPPORTED_CURL_VERSION = '7.15.5';
+const MIN_SUPPORTED_CURL_VERSION = '7.29.0';
 
 const IGNORED_CONSTANTS = [
     'CURLOPT_PROGRESSDATA'


### PR DESCRIPTION
PHP 8.0 bumped the min curl version to 7.29.0