### PR TITLE
$context parameter of get_headers() is nullable

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1433,7 +1433,7 @@ function rawurlencode(string $string): string {}
 
 function rawurldecode(string $string): string {}
 
-/** @param resource $context */
+/** @param resource|null $context */
 function get_headers(string $url, bool $associative = false, $context = null): array|false {}
 
 /* user_filters.c */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2da40c5fd9726f98ff96cf9fb5e0c41521e1e6ae */
+ * Stub hash: ff0ec0005317a22c41e61e9c58f67e968d1243c4 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)


### PR DESCRIPTION
I've noticed this while reviewing https://github.com/php/doc-en/pull/1014.