### PR TITLE
Fix GH-7809: Cloning a faked SplFileInfo object may segfault

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -385,8 +385,12 @@ static zend_object *spl_filesystem_object_clone(zend_object *old_object)
 
 	switch (source->type) {
 		case SPL_FS_INFO:
-			intern->path = zend_string_copy(source->path);
-			intern->file_name = zend_string_copy(source->file_name);
+			if (source->path != NULL) {
+				intern->path = zend_string_copy(source->path);
+			}
+			if (source->file_name != NULL) {
+				intern->file_name = zend_string_copy(source->file_name);
+			}
 			break;
 		case SPL_FS_DIR:
 			spl_filesystem_dir_open(intern, source->path);

--- a/ext/spl/tests/gh7809.phpt
+++ b/ext/spl/tests/gh7809.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug GH-7809 (Cloning a faked SplFileInfo object may segfault)
+--FILE--
+<?php
+class MySplFileInfo extends SplFileInfo {
+    public function __construct(string $filename) {}
+}
+
+$sfi = new MySplFileInfo("foo");
+clone $sfi;
+?>
+--EXPECT--


### PR DESCRIPTION
While the `path` is not supposed to be `NULL` for normal operation, it
is possible to create `SplFileInfo` objects where that is the case, and
we must not follow the null pointer.