### PR TITLE
NetBSD build warning fixes.

### DIFF
--- a/Zend/zend_cpuinfo.c
+++ b/Zend/zend_cpuinfo.c
@@ -75,7 +75,7 @@ static void __zend_cpuid(uint32_t func, uint32_t subfunc, zend_cpu_info *cpuinfo
 
 #if defined(__i386__) || defined(__x86_64__)
 /* Function based on compiler-rt implementation. */
-static unsigned get_xcr0_eax() {
+static unsigned get_xcr0_eax(void) {
 # if defined(__GNUC__) || defined(__clang__)
 	// Check xgetbv; this uses a .byte sequence instead of the instruction
 	// directly because older assemblers do not include support for xgetbv and
@@ -90,7 +90,7 @@ static unsigned get_xcr0_eax() {
 # endif
 }
 
-static zend_bool is_avx_supported() {
+static zend_bool is_avx_supported(void) {
 	if (!(cpuinfo.ecx & ZEND_CPU_FEATURE_AVX)) {
 		/* No support for AVX */
 		return 0;
@@ -106,7 +106,7 @@ static zend_bool is_avx_supported() {
 	return 1;
 }
 #else
-static zend_bool is_avx_supported() {
+static zend_bool is_avx_supported(void) {
 	return 0;
 }
 #endif

--- a/ext/sockets/multicast.c
+++ b/ext/sockets/multicast.c
@@ -784,7 +784,7 @@ int php_add4_to_if_index(struct in_addr *addr, php_socket *php_sock, unsigned *i
 	}
 
 	for (p = if_conf.ifc_buf;
-		 p < if_conf.ifc_buf + if_conf.ifc_len;
+		 p < ((char *)if_conf.ifc_buf) + if_conf.ifc_len;
 		 p += entry_len) {
 		/* p may be misaligned on macos. */
 		struct ifreq cur_req;


### PR DESCRIPTION
sockets/multicast, ifconf.ifc_buf member, unlike most of platforms,
 is a void ptr also fixing cpuinfo declarations with strict compiler flags.