### PR TITLE
Prevent strict interpretation of tentative definition

### DIFF
--- a/ext/com_dotnet/php_com_dotnet_internal.h
+++ b/ext/com_dotnet/php_com_dotnet_internal.h
@@ -72,7 +72,7 @@ zend_class_entry *php_com_variant_class_entry, *php_com_exception_class_entry, *
 zend_object* php_com_object_new(zend_class_entry *ce);
 zend_object* php_com_object_clone(zend_object *object);
 void php_com_object_free_storage(zend_object *object);
-zend_object_handlers php_com_object_handlers;
+extern zend_object_handlers php_com_object_handlers;
 void php_com_object_enable_event_sink(php_com_dotnet_object *obj, int enable);
 
 /* com_saproxy.c */


### PR DESCRIPTION
This header declaration is never supposed to be interpreted as
definition; otherwise, the handlers are not properly initialized, what
happens, for instance, with ASan instrumented MSVC builds.