### PR TITLE
Fix GH-7826: Inconsistent argument name in hash_hmac_file and hash_file

### DIFF
--- a/ext/hash/hash.stub.php
+++ b/ext/hash/hash.stub.php
@@ -8,7 +8,7 @@ function hash_file(string $algo, string $filename, bool $binary = false): string
 
 function hash_hmac(string $algo, string $data, string $key, bool $binary = false): string {}
 
-function hash_hmac_file(string $algo, string $data, string $key, bool $binary = false): string|false {}
+function hash_hmac_file(string $algo, string $filename, string $key, bool $binary = false): string|false {}
 
 function hash_init(string $algo, int $flags = 0, string $key = ""): HashContext {}
 

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f73c6fa1a4ac1ca93f87775bbe69fbdb2deb5746 */
+ * Stub hash: ae4f5ceba77eee7062cbd2fadb112aac33d198ce */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hash, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_STRING, 0)
@@ -22,7 +22,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_hash_hmac_file, 0, 3, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, binary, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()

--- a/ext/hash/tests/hash_hmac_file_error.phpt
+++ b/ext/hash/tests/hash_hmac_file_error.phpt
@@ -43,4 +43,4 @@ hash_hmac_file(): Argument #1 ($algo) must be a valid cryptographic hashing algo
 hash_hmac_file(): Argument #1 ($algo) must be a valid cryptographic hashing algorithm
 
 -- Testing hash_hmac_file() function with bad path --
-hash_hmac_file(): Argument #2 ($data) must not contain any null bytes
+hash_hmac_file(): Argument #2 ($filename) must not contain any null bytes


### PR DESCRIPTION
Like `hash_file()`, `hash_hmac_file()` expects a filename, and not some
string data.  Fixing this now, constitutes a (hopefully small) BC break
though.