### PR TITLE
Mark curl tests using http2.golang.org as XFAIL

### DIFF
--- a/ext/curl/tests/bug76675.phpt
+++ b/ext/curl/tests/bug76675.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #76675 (Segfault with H2 server push write/writeheader handlers)
+--XFAIL--
+http2.golang.org/serverpush is gone
 --SKIPIF--
 <?php
 include 'skipif.inc';

--- a/ext/curl/tests/bug76675.phpt
+++ b/ext/curl/tests/bug76675.phpt
@@ -12,6 +12,7 @@ $curl_version = curl_version();
 if ($curl_version['version_number'] < 0x073d00) {
     exit("skip: test may crash with curl < 7.61.0");
 }
+die("skip test is slow due to timeout, and XFAILs anyway");
 ?>
 --FILE--
 <?php

--- a/ext/curl/tests/bug77535.phpt
+++ b/ext/curl/tests/bug77535.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #77535 (Invalid callback, h2 server push)
+--XFAIL--
+http2.golang.org/serverpush is gone
 --SKIPIF--
 <?php
 include 'skipif.inc';

--- a/ext/curl/tests/bug77535.phpt
+++ b/ext/curl/tests/bug77535.phpt
@@ -12,6 +12,7 @@ $curl_version = curl_version();
 if ($curl_version['version_number'] < 0x073d00) {
     exit("skip: test may crash with curl < 7.61.0");
 }
+die("skip test is slow due to timeout, and XFAILs anyway");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
http2.golang.org/serverpush has been retired[1], so we need to come up
with an alternative.  Until then, we mark the relevant tests as XFAIL
(although bug77535.phpt passes, what might be an indication that the
test needs further revision).

[1] <https://github.com/golang/go/issues/49301>

---

/cc @patrickallaert 