### PR TITLE
Fix chunk_split_variation*_32bit.phpt for Windows

### DIFF
--- a/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation1_32bit.phpt
@@ -17,4 +17,4 @@ var_dump(chunk_split($a,$b,$c));
 --EXPECTF--
 *** Testing chunk_split() : unexpected large 'end' string argument variation 1 ***
 
-Fatal error: Allowed memory size of %d bytes exhausted%s(tried to allocate %d bytes) in %s on line %d
+Fatal error: %rAllowed memory size of %d bytes exhausted%s\(tried to allocate %d bytes\)|Possible integer overflow in memory allocation \(4294901777 \+ 2097152\)%r in %s on line %d

--- a/ext/standard/tests/strings/chunk_split_variation2_32bit.phpt
+++ b/ext/standard/tests/strings/chunk_split_variation2_32bit.phpt
@@ -16,4 +16,4 @@ var_dump(chunk_split($a,$b,$c));
 --EXPECTF--
 *** Testing chunk_split() : unexpected large 'end' string argument variation 2 ***
 
-Fatal error: Possible integer overflow in memory allocation (65537 * 65537 + 65556) in %s on line %d
+Fatal error: Possible integer overflow in memory allocation (65537 * 65537 + %r65556|65560%r) in %s on line %d


### PR DESCRIPTION
Both tests fail on Windows for slightly different reasons, what appears
to be legit, and as such we fix the test expectations.