### PR TITLE
Don't run conflicting bug40228*.phpt in parallel

### DIFF
--- a/ext/zip/tests/bug40228-mb.phpt
+++ b/ext/zip/tests/bug40228-mb.phpt
@@ -2,12 +2,10 @@
 Bug #40228 (extractTo does not create recursive empty path)
 --SKIPIF--
 <?php if (!extension_loaded("zip")) print "skip"; ?>
---CONFLICTS--
-bug40228
 --FILE--
 <?php
-$dest = __DIR__;
-$arc_name = $dest . "/bug40228私はガラスを食べられます.zip";
+$dest = __DIR__ . "/bug40228-mb";
+$arc_name = __DIR__ . "/bug40228私はガラスを食べられます.zip";
 $zip = new ZipArchive;
 $zip->open($arc_name, ZIPARCHIVE::CREATE);
 $zip->extractTo($dest);

--- a/ext/zip/tests/bug40228-mb.phpt
+++ b/ext/zip/tests/bug40228-mb.phpt
@@ -13,6 +13,7 @@ if (is_dir($dest . '/test/empty')) {
     echo "Ok\n";
     rmdir($dest . '/test/empty');
     rmdir($dest . '/test');
+    rmdir($dest);
 } else {
     echo "Failed.\n";
 }

--- a/ext/zip/tests/bug40228-mb.phpt
+++ b/ext/zip/tests/bug40228-mb.phpt
@@ -2,6 +2,8 @@
 Bug #40228 (extractTo does not create recursive empty path)
 --SKIPIF--
 <?php if (!extension_loaded("zip")) print "skip"; ?>
+--CONFLICTS--
+bug40228
 --FILE--
 <?php
 $dest = __DIR__;

--- a/ext/zip/tests/bug40228.phpt
+++ b/ext/zip/tests/bug40228.phpt
@@ -2,12 +2,10 @@
 Bug #40228 (extractTo does not create recursive empty path)
 --SKIPIF--
 <?php if (!extension_loaded("zip")) print "skip"; ?>
---CONFLICTS--
-bug40228
 --FILE--
 <?php
-$dest = __DIR__;
-$arc_name = $dest . "/bug40228.zip";
+$dest = __DIR__ . "/bug40228";
+$arc_name = __DIR__ . "/bug40228.zip";
 $zip = new ZipArchive;
 $zip->open($arc_name, ZIPARCHIVE::CREATE);
 $zip->extractTo($dest);

--- a/ext/zip/tests/bug40228.phpt
+++ b/ext/zip/tests/bug40228.phpt
@@ -13,6 +13,7 @@ if (is_dir($dest . '/test/empty')) {
     echo "Ok\n";
     rmdir($dest . '/test/empty');
     rmdir($dest . '/test');
+    rmdir($dest);
 } else {
     echo "Failed.\n";
 }

--- a/ext/zip/tests/bug40228.phpt
+++ b/ext/zip/tests/bug40228.phpt
@@ -2,6 +2,8 @@
 Bug #40228 (extractTo does not create recursive empty path)
 --SKIPIF--
 <?php if (!extension_loaded("zip")) print "skip"; ?>
+--CONFLICTS--
+bug40228
 --FILE--
 <?php
 $dest = __DIR__;


### PR DESCRIPTION
Both tests use the same directory structure, and as such must not be
run in parallel.  We quick-fix this by explicitly marking the tests as
conflicting.

---

This is supposed to fix https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=22443&view=logs&j=4122fe88-58a7-5c3a-cfc0-c33b79f3deef&t=a0fe5b37-d1c9-5a85-b4d4-025279c03c58&l=2516.
