### PR TITLE
Don't truncate subsecond precision in run-tests.php JUNIT output

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -3478,7 +3478,7 @@ function junit_mark_test_as(
     $type,
     string $file_name,
     string $test_name,
-    ?int $time = null,
+    ?float $time = null,
     string $message = '',
     string $details = ''
 ): void {
@@ -3533,7 +3533,7 @@ function junit_mark_test_as(
     $JUNIT['files'][$file_name]['xml'] .= "</testcase>\n";
 }
 
-function junit_suite_record(string $suite, string $param, int $value = 1): void
+function junit_suite_record(string $suite, string $param, float $value = 1): void
 {
     global $JUNIT;
 
@@ -3541,7 +3541,7 @@ function junit_suite_record(string $suite, string $param, int $value = 1): void
     $JUNIT['suites'][$suite][$param] += $value;
 }
 
-function junit_get_timer(string $file_name): int
+function junit_get_timer(string $file_name): float
 {
     global $JUNIT;
     if (!junit_enabled()) {


### PR DESCRIPTION
When run-tests.php has been typed[1], the type of `$time` has been
chosen to be `int`.  This, however, leads to truncation, and the
somewhat relevant subsecond precision is lost.  We fix that by
changing the type to `float`, although `int|string` would be more
appropriate, but requires PHP ≥ 7.4.0.  Another option would be to
move the `number_format()` formatting into `junit_mark_test_as()`.

[1] <https://github.com/php/php-src/commit/11274f53e7fb9d669d74c23aa7883f5f04d92094>

---

I've noticed this due to https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=22476&view=logs&j=0d3730b8-0d59-574b-ab4a-5e189a74d53b&t=492e5677-f211-533f-274d-3a4af39d4cce&l=42.