### PR TITLE
Remove bogus type of $object param in SplObjectStorage::offsetSet()

### DIFF
--- a/ext/spl/spl_observer.stub.php
+++ b/ext/spl/spl_observer.stub.php
@@ -90,7 +90,7 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
      * @implementation-alias SplObjectStorage::attach
      * @no-verify Cannot specify arg type because ArrayAccess does not
      */
-    public function offsetSet(mixed $object, mixed $info = null): void {}
+    public function offsetSet($object, mixed $info = null): void {}
 
     /**
      * @param object $object

--- a/ext/spl/spl_observer_arginfo.h
+++ b/ext/spl/spl_observer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a3c87f5b7edd257e25d6651628dd9896e14f5715 */
+ * Stub hash: 63dde3294f600164805befd79b1f670fbfb23571 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplObserver_update, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, subject, SplSubject, 0)
@@ -75,7 +75,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplObjectStorage
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplObjectStorage_offsetSet, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, object, IS_MIXED, 0)
+	ZEND_ARG_INFO(0, object)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, info, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
The parameter definitely only accepts objects, so we shouldn't explicitly mark it as `mixed`. Looks like I (accidentally (?)) added this type in https://github.com/php/php-src/pull/7235/files#diff-01509803e11a18aa23ee35cf1243406221d39a275722504d435a33b08add0fa1R93

This will fix the generated method synopsis of `SplObjectStorage::offsetSet()`.