### PR TITLE
Fix invalid FPM status page response content when using the OpenMetrics format

### DIFF
--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -430,7 +430,8 @@ int fpm_status_handle_request(void) /* {{{ */
 				"phpfpm_max_children_reached %u\n"
 				"# HELP phpfpm_slow_requests The number of requests that exceeded your 'request_slowlog_timeout' value.\n"
 				"# TYPE phpfpm_slow_requests counter\n"
-				"phpfpm_slow_requests %lu\n";
+				"phpfpm_slow_requests %lu\n"
+				"# EOF\n";
 
 			has_start_time = 0;
 			if (!full) {

--- a/sapi/fpm/tests/status.inc
+++ b/sapi/fpm/tests/status.inc
@@ -241,7 +241,8 @@ class Status
             "phpfpm_max_children_reached " . $fields['max children reached'] . "\n" .
             "# HELP phpfpm_slow_requests The number of requests that exceeded your 'request_slowlog_timeout' value\.\n" .
             "# TYPE phpfpm_slow_requests counter\n" .
-            "phpfpm_slow_requests " . $fields['slow requests'] . ")";
+            "phpfpm_slow_requests " . $fields['slow requests'] . "\n" .
+            "# EOF)\n";
 
         if (!preg_match($pattern, $body)) {
             echo "ERROR: Expected body does not match pattern\n";


### PR DESCRIPTION
This little change fixes #7842 by adding the missing `# EOF\n` line required by the OpenMetrics format specs when using the `openmetrics` query parameter