### PR TITLE
Fixed parse_url(): can not recognize port without scheme

### DIFF
--- a/ext/standard/tests/url/parse_url_error_003.phpt
+++ b/ext/standard/tests/url/parse_url_error_003.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test parse_url() function: The url is 127.0.0.1:9999?
+--FILE--
+<?php
+echo "*** Testing parse_url() :The url is 127.0.0.1:9999? ***\n";
+$url = '127.0.0.1:9999?';
+
+var_dump(parse_url($url));
+echo "Done"
+?>
+--EXPECT--
+*** Testing parse_url() :The url is 127.0.0.1:9999? ***
+array(3) {
+  ["host"]=>
+  string(9) "127.0.0.1"
+  ["port"]=>
+  int(9999)
+  ["query"]=>
+  string(0) ""
+}
+Done

--- a/ext/standard/tests/url/parse_url_error_003.phpt
+++ b/ext/standard/tests/url/parse_url_error_003.phpt
@@ -1,16 +1,17 @@
 --TEST--
-Test parse_url() function: The url is 127.0.0.1:9999?
+Test parse_url() function: can not recognize port without scheme
 --FILE--
 <?php
-echo "*** Testing parse_url() :The url is 127.0.0.1:9999? ***\n";
-$url = '127.0.0.1:9999?';
-
-var_dump(parse_url($url));
+echo "*** Testing parse_url() :can not recognize port without scheme ***\n";
+echo 'parse 127.0.0.1:9999?';
+var_dump(parse_url('127.0.0.1:9999?'));
+echo 'parse 127.0.0.1:9999#';
+var_dump(parse_url('127.0.0.1:9999#'));
 echo "Done"
 ?>
 --EXPECT--
-*** Testing parse_url() :The url is 127.0.0.1:9999? ***
-array(3) {
+*** Testing parse_url() :can not recognize port without scheme ***
+parse 127.0.0.1:9999?array(3) {
   ["host"]=>
   string(9) "127.0.0.1"
   ["port"]=>
@@ -18,4 +19,15 @@ array(3) {
   ["query"]=>
   string(0) ""
 }
+parse 127.0.0.1:9999#array(3) {
+  ["host"]=>
+  string(9) "127.0.0.1"
+  ["port"]=>
+  int(9999)
+  ["fragment"]=>
+  string(0) ""
+}
 Done
+
+
+

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -324,7 +324,6 @@ parse_host:
 	}
 
 	return ret;
-	
 }
 /* }}} */
 

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -126,7 +126,6 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 			if (!isalpha(*p) && !isdigit(*p) && *p != '+' && *p != '.' && *p != '-') {
 				if (e + 1 < ue && e < binary_strcspn(s, ue, "?#")) {
 					goto parse_port;
-				} else if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
 					s += 2;
 					e = 0;
 					goto parse_host;

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -154,10 +154,6 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 				goto parse_port;
 			}
 
-			// if (*p == '?') {
-			// 	goto parse_port;
-			// }
-
 			ret->scheme = zend_string_init(s, (e-s), 0);
 			php_replace_controlchars_ex(ZSTR_VAL(ret->scheme), ZSTR_LEN(ret->scheme));
 

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -324,6 +324,7 @@ parse_host:
 	}
 
 	return ret;
+	
 }
 /* }}} */
 

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -150,11 +150,7 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 				p++;
 			}
 
-			if ((p == ue || *p == '/') && (p - e) < 7) {
-				goto parse_port;
-			}
-
-			if (*p == '?') {
+			if ((p == ue || *p == '/' || *p == '?') && (p - e) < 7) {
 				goto parse_port;
 			}
 

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -154,6 +154,10 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 				goto parse_port;
 			}
 
+			if (*p == '?') {
+				goto parse_port;
+			}
+
 			ret->scheme = zend_string_init(s, (e-s), 0);
 			php_replace_controlchars_ex(ZSTR_VAL(ret->scheme), ZSTR_LEN(ret->scheme));
 

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -150,7 +150,7 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 				p++;
 			}
 
-			if ((p == ue || *p == '/' || *p == '?') && (p - e) < 7) {
+			if ((p == ue || *p == '/' || *p == '?' || *p == '#') && (p - e) < 7) {
 				goto parse_port;
 			}
 
@@ -190,7 +190,7 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 			pp++;
 		}
 
-		if (pp - p > 0 && pp - p < 6 && (pp == ue || *pp == '/' || *pp == '?')) {
+		if (pp - p > 0 && pp - p < 6 && (pp == ue || *pp == '/' || *pp == '?' || *pp == '#')) {
 			zend_long port;
 			char *end;
 			memcpy(port_buf, p, (pp - p));

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -110,9 +110,15 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 	*has_port = 0;
 	s = str;
 	ue = s + length;
+	char const *ps = memchr(s, '?', length);
+
+	if (! ps) {
+		ps = s;
+	}
 
 	/* parse scheme */
-	if ((e = memchr(s, ':', length)) && e != s) {
+	if ((e = memchr(ps, ':', strlen(ps))) && e != s) {
+		
 		/* validate scheme */
 		p = s;
 		while (p < e) {

--- a/test.php
+++ b/test.php
@@ -1,0 +1,5 @@
+<?php
+
+//var_dump(parse_url("127.0.0.1:9999"));
+//var_dump("==========");
+var_dump(parse_url("127.0.0.1:9999?"));

--- a/test.php
+++ b/test.php
@@ -1,5 +1,0 @@
-<?php
-
-//var_dump(parse_url("127.0.0.1:9999"));
-//var_dump("==========");
-var_dump(parse_url("127.0.0.1:9999?"));

--- a/test.php
+++ b/test.php
@@ -1,5 +1,0 @@
-<?php
-
-var_dump(parse_url("127.0.0.1:9509?"));
-var_dump("=======");
-var_dump(parse_url("127.0.0.1:9509"));

--- a/test.php
+++ b/test.php
@@ -1,0 +1,5 @@
+<?php
+
+var_dump(parse_url("127.0.0.1:9509?"));
+var_dump("=======");
+var_dump(parse_url("127.0.0.1:9509"));


### PR DESCRIPTION
# fixed Before
```php
var_dump(parse_url("127.0.0.1:9999"));
var_dump("==========");
var_dump(parse_url("127.0.0.1:9999?"));
```

output

```
array(2) {
  ["host"]=>
  string(9) "127.0.0.1"
  ["port"]=>
  int(9999)
}
string(10) "=========="
array(3) {
  ["scheme"]=>
  string(9) "127.0.0.1"
  ["path"]=>
  string(4) "9999"
  ["query"]=>
  string(0) ""
}
```

# # fixed After

```
var_dump(parse_url("127.0.0.1:9999?"));
```

output
```
array(2) {
  ["host"]=>
  string(9) "127.0.0.1"
  ["port"]=>
  int(9999)
 ["query"]=>
  string(0) ""
}
```