### PR TITLE
Remove duplicated SKIP checks to improve performance

### DIFF
--- a/ext/mysqli/tests/014.phpt
+++ b/ext/mysqli/tests/014.phpt
@@ -4,19 +4,18 @@ mysqli autocommit/commit/rollback
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
-    require_once("connect.inc");
+require_once "connect.inc";
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-    $link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
-    if (!$link)
-        die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
-
-    if (!have_innodb($link))
-        die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
+if (!have_innodb($link)) {
+    die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
+}
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
     $link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
 
     if (!mysqli_autocommit($link, TRUE))
@@ -79,7 +78,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 Num_of_rows=1

--- a/ext/mysqli/tests/015.phpt
+++ b/ext/mysqli/tests/015.phpt
@@ -4,18 +4,18 @@ mysqli autocommit/commit/rollback with innodb
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
+require_once "connect.inc";
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-    require_once('connect.inc');
-    if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
-
-    if (!have_innodb($link))
-        die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
+if (!have_innodb($link)) {
+    die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
+}
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     $link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
     if (!$link)
@@ -77,7 +77,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 array(2) {

--- a/ext/mysqli/tests/045.phpt
+++ b/ext/mysqli/tests/045.phpt
@@ -4,9 +4,8 @@ mysqli_stmt_bind_result (SHOW)
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
+    require_once 'skipifconnectfailure.inc';
 
-    require_once("connect.inc");
     $link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
 
     $stmt = mysqli_prepare($link, "SHOW VARIABLES LIKE 'port'");
@@ -20,7 +19,7 @@ mysqli
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     /*** test mysqli_connect 127.0.0.1 ***/
     $link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);

--- a/ext/mysqli/tests/067.phpt
+++ b/ext/mysqli/tests/067.phpt
@@ -4,11 +4,10 @@ function test: nested selects (cursors)
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
-    require_once("connect.inc");
+    require_once "connect.inc";
 
-    if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die("skip Cannot connect to check required version");
+    if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+        die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
     /* skip cursor test for server versions < 50009 */
     if (mysqli_get_server_version($link) < 50009) {
@@ -29,7 +28,7 @@ mysqli
         return $stmt;
     }
 
-    require_once("connect.inc");
+    require_once "connect.inc";
     $mysql = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
 
     if (mysqli_get_server_version($mysql) < 50009) {
@@ -65,7 +64,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/bug42548.phpt
+++ b/ext/mysqli/tests/bug42548.phpt
@@ -4,9 +4,8 @@ Bug #42548 PROCEDURE xxx can't return a result set in the given context (works i
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) <= 50000) {
@@ -15,7 +14,7 @@ if (mysqli_get_server_version($link) <= 50000) {
 ?>
 --FILE--
 <?php
-require_once('connect.inc');
+require_once 'connect.inc';
 
 $mysqli = mysqli_init();
 $mysqli->real_connect($host, $user, $passwd, $db, $port, $socket);
@@ -53,7 +52,7 @@ print "done!";
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/bug44897.phpt
+++ b/ext/mysqli/tests/bug44897.phpt
@@ -4,14 +4,14 @@ Bug #44879 (failed to prepare statement)
 mysqli
 --SKIPIF--
 <?php
-if (!stristr(mysqli_get_client_info(), 'mysqlnd'))
+require_once 'connect.inc';
+
+if (!$IS_MYSQLND) {
     die("skip: only available in mysqlnd");
+}
 
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
-
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) <= 50000) {
     die(sprintf('skip Needs MySQL 5.0+, found version %d.', mysqli_get_server_version($link)));

--- a/ext/mysqli/tests/bug49442.phpt
+++ b/ext/mysqli/tests/bug49442.phpt
@@ -4,14 +4,14 @@ Bug #49422 (mysqlnd: mysqli_real_connect() and LOAD DATA INFILE crash)
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
 $link = mysqli_init();
-if (!my_mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf("skip Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+if (!@my_mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }
 
-include_once("local_infile_tools.inc");
+include_once "local_infile_tools.inc";
 if ($msg = check_local_infile_support($link, $engine))
     die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
 
@@ -23,7 +23,7 @@ mysqli.allow_persistent=1
 mysqli.max_persistent=1
 --FILE--
 <?php
-    include ("connect.inc");
+    include "connect.inc";
 
     $link = mysqli_init();
     if (!my_mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket)) {
@@ -107,7 +107,7 @@ mysqli.max_persistent=1
 ?>
 --CLEAN--
 <?php
-	require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 array(2) {

--- a/ext/mysqli/tests/bug51647.phpt
+++ b/ext/mysqli/tests/bug51647.phpt
@@ -4,8 +4,7 @@ Bug #51647 (Certificate file without private key (pk in another file) doesn't wo
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once "connect.inc";
 
 if (!defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'))
     die("skip Requires MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT");
@@ -43,7 +42,7 @@ $link->close();
 ?>
 --FILE--
 <?php
-    include ("connect.inc");
+    include "connect.inc";
 
     if (!is_object($link = mysqli_init()))
         printf("[001] Cannot create link\n");

--- a/ext/mysqli/tests/bug53503.phpt
+++ b/ext/mysqli/tests/bug53503.phpt
@@ -4,23 +4,23 @@ Bug #53503 (mysqli::query returns false after successful LOAD DATA query)
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die("skip Cannot connect to MySQL");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-include_once("local_infile_tools.inc");
+include_once "local_infile_tools.inc";
 if ($msg = check_local_infile_support($link, $engine))
     die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
 
 mysqli_close($link);
-
 ?>
 --INI--
 mysqli.allow_local_infile=1
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         printf("[001] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
@@ -50,7 +50,7 @@ mysqli.allow_local_infile=1
 ?>
 --CLEAN--
 <?php
-require_once('connect.inc');
+require_once 'connect.inc';
 
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 	printf("[clean] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",

--- a/ext/mysqli/tests/bug55283.phpt
+++ b/ext/mysqli/tests/bug55283.phpt
@@ -4,8 +4,7 @@ Bug #55283 (SSL options set by mysqli_ssl_set ignored for MySQLi persistent conn
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once "connect.inc";
 
 if (!defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'))
     die("skip Requires MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT");

--- a/ext/mysqli/tests/bug55582.phpt
+++ b/ext/mysqli/tests/bug55582.phpt
@@ -4,8 +4,7 @@ Bug #55582 mysqli_num_rows() returns always 0 for unbuffered, when mysqlnd is us
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once 'skipifconnectfailure.inc';
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug63398.phpt
+++ b/ext/mysqli/tests/bug63398.phpt
@@ -4,11 +4,10 @@ Bug #63398 (Segfault when polling closed link)
 mysqli
 --SKIPIF--
 <?php
-require_once("connect.inc");
+require_once "skipifconnectfailure.inc";
 if (!$IS_MYSQLND) {
     die("skip mysqlnd only test");
 }
-require_once('skipifconnectfailure.inc');
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug64726.phpt
+++ b/ext/mysqli/tests/bug64726.phpt
@@ -4,11 +4,10 @@ Bug #63398 (Segfault when calling fetch_object on a use_result and DB pointer ha
 mysqli
 --SKIPIF--
 <?php
-require_once("connect.inc");
+require_once "skipifconnectfailure.inc";
 if (!$IS_MYSQLND) {
     die("skip mysqlnd only test");
 }
-require_once('skipifconnectfailure.inc');
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug68077.phpt
+++ b/ext/mysqli/tests/bug68077.phpt
@@ -4,14 +4,15 @@ Bug #68077 (LOAD DATA LOCAL INFILE / open_basedir restriction)
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 if (!$IS_MYSQLND) {
     die("skip: test applies only to mysqlnd");
 }
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die("skip Cannot connect to MySQL");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-include_once("local_infile_tools.inc");
+include_once "local_infile_tools.inc";
 if ($msg = check_local_infile_support($link, $engine))
     die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
 

--- a/ext/mysqli/tests/bug69899.phpt
+++ b/ext/mysqli/tests/bug69899.phpt
@@ -11,7 +11,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once __DIR__ . '/skipifconnectfailure.inc';
-require_once __DIR__ . '/connect.inc';
 if (!$IS_MYSQLND) {
     die('skip mysqlnd only');
 }

--- a/ext/mysqli/tests/bug70384.phpt
+++ b/ext/mysqli/tests/bug70384.phpt
@@ -4,22 +4,24 @@ mysqli_float_handling - ensure 4 byte float is handled correctly
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
-    if (@$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-        if ($link->server_version < 50709) {
-            die("skip MySQL 5.7.9+ needed. Found [".
-                intval(substr($link->server_version."", -5, 1)).
-                ".".
-                intval(substr($link->server_version."", -4, 2)).
-                ".".
-                intval(substr($link->server_version."", -2, 2)).
-                "]");
-        }
-    }
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
+
+if ($link->server_version < 50709) {
+    die("skip MySQL 5.7.9+ needed. Found [".
+        intval(substr($link->server_version."", -5, 1)).
+        ".".
+        intval(substr($link->server_version."", -4, 2)).
+        ".".
+        intval(substr($link->server_version."", -2, 2)).
+        "]");
+}
 ?>
 --FILE--
 <?php
-    require('connect.inc');
+    require 'connect.inc';
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         printf("[001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
         die();
@@ -56,7 +58,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 OK

--- a/ext/mysqli/tests/bug70949.phpt
+++ b/ext/mysqli/tests/bug70949.phpt
@@ -4,15 +4,14 @@ Bug #70949 (SQL Result Sets With NULL Can Cause Fatal Memory Errors)
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once 'skipifconnectfailure.inc';
 if (!$IS_MYSQLND) {
     die("skip mysqlnd only test");
 }
 ?>
 --FILE--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 $mysql = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
 
 $mysql->query("DROP TABLE IF EXISTS bug70949");
@@ -47,7 +46,7 @@ if ($stmt = $mysql->prepare($sql))
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/bug71863.phpt
+++ b/ext/mysqli/tests/bug71863.phpt
@@ -4,15 +4,14 @@ Bug #71863 Segfault when EXPLAIN with "Unknown Column" Error
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once 'skipifconnectfailure.inc';
 if (!$IS_MYSQLND) {
     die("skip mysqlnd only test");
 }
 ?>
 --FILE--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 
 $req = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
 
@@ -26,7 +25,7 @@ mysqli_query($req, "EXPLAIN SELECT `id` FROM `test_bug_71863` WHERE `owner_id` =
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 if (!mysqli_query($link, "DROP TABLE IF EXISTS test_bug_71863"))

--- a/ext/mysqli/tests/bug72701.phpt
+++ b/ext/mysqli/tests/bug72701.phpt
@@ -4,8 +4,7 @@ Bug #72701 mysqli_get_host_info() wrong output
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once 'skipifconnectfailure.inc';
 
 if ("127.0.0.1" != $host && "localhost" != $host) {
     die("skip require 127.0.0.1 connection");
@@ -15,7 +14,7 @@ if ("127.0.0.1" != $host && "localhost" != $host) {
 --FILE--
 <?php
 
-require_once("connect.inc");
+require_once "connect.inc";
 
 $con = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
 

--- a/ext/mysqli/tests/bug76386.phpt
+++ b/ext/mysqli/tests/bug76386.phpt
@@ -4,11 +4,11 @@ Prepared Statement formatter truncates fractional seconds from date/time column 
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once "connect.inc";
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die("skip Cannot connect to check required version");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
 /* Fractional seconds are supported with servers >= 5.6.4. */
 if (mysqli_get_server_version($link) < 50604) {
@@ -18,7 +18,7 @@ mysqli_close($link);
 ?>
 --FILE--
 <?php
-require_once('connect.inc');
+require_once 'connect.inc';
 // test part 1 - TIMESTAMP(n)
 $link = new mysqli($host, $user, $passwd, $db, $port, $socket);
 $link->query('DROP TABLE IF EXISTS ts_test;');
@@ -96,7 +96,7 @@ string(13) "11:00:00.4444"
 string(15) "11:00:00.006054"
 --CLEAN--
 <?php
-require_once('connect.inc');
+require_once 'connect.inc';
 $link = new mysqli($host, $user, $passwd, $db, $port, $socket);
 $link->query('DROP TABLE ts_test;');
 $link->query('DROP TABLE t_test;');

--- a/ext/mysqli/tests/bug77956.phpt
+++ b/ext/mysqli/tests/bug77956.phpt
@@ -4,17 +4,18 @@ ensure an error is returned when mysqli.allow_local_infile is off
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
 $link = mysqli_init();
-if (!my_mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf("skip Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+if (!@my_mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }
 
-require_once('local_infile_tools.inc');
+include_once "local_infile_tools.inc";
 if ($msg = check_local_infile_support($link, $engine))
     die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
 
+mysqli_close($link);
 ?>
 --INI--
 mysqli.allow_local_infile=0

--- a/ext/mysqli/tests/clean_table.inc
+++ b/ext/mysqli/tests/clean_table.inc
@@ -1,5 +1,5 @@
 <?PHP
-require_once('connect.inc');
+require_once 'connect.inc';
 
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     printf("[clean] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",

--- a/ext/mysqli/tests/gh7746.phpt
+++ b/ext/mysqli/tests/gh7746.phpt
@@ -4,7 +4,6 @@ Bug #GH-7746 mysqli_sql_exception->sqlstate is inaccessible
 mysqli
 --SKIPIF--
 <?php
-require_once "connect.inc";
 require_once 'skipifconnectfailure.inc';
 ?>
 --FILE--

--- a/ext/mysqli/tests/mysqli_allow_local_infile_overrides_local_infile_directory.phpt
+++ b/ext/mysqli/tests/mysqli_allow_local_infile_overrides_local_infile_directory.phpt
@@ -4,17 +4,17 @@ mysqli.allow_local_infile overrides mysqli.local_infile_directory
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-	die("skip Cannot connect to MySQL");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-include_once("local_infile_tools.inc");
+include_once "local_infile_tools.inc";
 if ($msg = check_local_infile_allowed_by_server($link))
-	die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
+    die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
 
 mysqli_close($link);
-
 ?>
 --INI--
 open_basedir={PWD}

--- a/ext/mysqli/tests/mysqli_autocommit.phpt
+++ b/ext/mysqli/tests/mysqli_autocommit.phpt
@@ -4,10 +4,9 @@ mysqli_autocommit()
 mysqli
 --SKIPIF--
 <?php
-    require_once('connect.inc');
-    require_once('skipifconnectfailure.inc');
+    require_once 'connect.inc';
 
-    if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         die(sprintf("skip Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
             $host, $user, $db, $port, $socket));
     }
@@ -17,7 +16,7 @@ mysqli
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         printf("[004] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -129,9 +128,10 @@ mysqli
     }
 
     print "done!";
+?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 mysqli object is already closed

--- a/ext/mysqli/tests/mysqli_autocommit_oo.phpt
+++ b/ext/mysqli/tests/mysqli_autocommit_oo.phpt
@@ -4,13 +4,10 @@ mysqli->autocommit()
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
-    require_once('connect.inc');
+    require_once 'connect.inc';
 
-    if (!$link = new my_mysqli($host, $user, $passwd, $db, $port, $socket)) {
-        printf("skip Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
-            $host, $user, $db, $port, $socket);
-        exit(1);
+    if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+        die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
     }
 
     if (!have_innodb($link))
@@ -18,7 +15,7 @@ mysqli
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     if (!$mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket)) {
         printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -134,7 +131,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 my_mysqli object is already closed

--- a/ext/mysqli/tests/mysqli_change_user_insert_id.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_insert_id.phpt
@@ -4,8 +4,7 @@ mysqli_change_user() - LAST_INSERT_ID() - http://bugs.mysql.com/bug.php?id=45184
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
+require_once 'skipifconnectfailure.inc';
 
 if (!$IS_MYSQLND) {
     die("skip Might hit known and open bugs http://bugs.mysql.com/bug.php?id=30472, http://bugs.mysql.com/bug.php?id=45184");
@@ -13,7 +12,7 @@ if (!$IS_MYSQLND) {
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
+    require_once 'connect.inc';
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
@@ -59,7 +58,7 @@ if (!$IS_MYSQLND) {
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_change_user_new.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_new.phpt
@@ -4,9 +4,9 @@ mysqli_change_user(), MySQL 5.6+
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     die(sprintf("SKIP Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
         $host, $user, $db, $port, $socket));
 
@@ -18,7 +18,7 @@ if (mysqli_get_server_version($link) >= 10_00_00)
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once 'connect.inc';
 
     $tmp	= NULL;
     $link	= NULL;

--- a/ext/mysqli/tests/mysqli_change_user_oo.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_oo.phpt
@@ -4,9 +4,9 @@ mysqli->change_user()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'skipifconnectfailure.inc';
 
-require_once('table.inc');
+require_once 'table.inc';
 if (!$IS_MYSQLND && (mysqli_get_server_version($link) < 50118 && mysqli_get_server_version($link) > 50100)) {
     die("skip Your MySQL Server version has a known bug that will cause a crash");
 }
@@ -16,7 +16,7 @@ if (mysqli_get_server_version($link) >= 50600)
 ?>
 --FILE--
 <?php
-    include_once("connect.inc");
+    require_once "connect.inc";
 
     $link	= NULL;
     $tmp	= NULL;

--- a/ext/mysqli/tests/mysqli_change_user_rollback.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_rollback.phpt
@@ -4,18 +4,16 @@ mysqli_change_user() - ROLLBACK
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (!have_innodb($link))
     die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
-    require_once('table.inc');
+    require_once 'table.inc';
 
     if (!mysqli_query($link, 'ALTER TABLE test ENGINE=InnoDB'))
         printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -64,7 +62,7 @@ if (!have_innodb($link))
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_change_user_set_names.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_set_names.phpt
@@ -4,10 +4,10 @@ mysqli_change_user() - SET NAMES
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (!$res = mysqli_query($link, 'SELECT version() AS server_version'))
     die(sprintf("skip [%d] %s\n", mysqli_errno($link), mysqli_error($link)));
@@ -23,7 +23,7 @@ if ($version[0] <= 4 && $version[1] < 1)
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
+    require_once 'connect.inc';
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());

--- a/ext/mysqli/tests/mysqli_commit.phpt
+++ b/ext/mysqli/tests/mysqli_commit.phpt
@@ -4,18 +4,16 @@ mysqli_commit()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (!have_innodb($link))
     die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[004] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -62,7 +60,7 @@ if (!have_innodb($link))
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 mysqli object is already closed

--- a/ext/mysqli/tests/mysqli_commit_oo.phpt
+++ b/ext/mysqli/tests/mysqli_commit_oo.phpt
@@ -4,18 +4,16 @@ mysqli_commit()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (!have_innodb($link))
     die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once 'connect.inc';
 
     $tmp    = NULL;
     $link   = NULL;
@@ -97,9 +95,10 @@ if (!have_innodb($link))
     }
 
     print "done!";
+?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECTF--
 mysqli object is not fully initialized

--- a/ext/mysqli/tests/mysqli_connect_attr.phpt
+++ b/ext/mysqli/tests/mysqli_connect_attr.phpt
@@ -4,13 +4,13 @@ mysqli check the session_connect_attrs table for connection attributes
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
 if (!$IS_MYSQLND)
     die("skip: test applies only to mysqlnd");
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die("skip Cannot connect to the server");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 /* skip test if the server version does not have session_connect_attrs table yet*/
 if (!$res = mysqli_query($link, "select count(*) as count from information_schema.tables where table_schema='performance_schema' and table_name='session_connect_attrs';"))
@@ -38,7 +38,7 @@ mysqli_close($link);
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once 'connect.inc';
 
     $tmp    = NULL;
     $link   = NULL;

--- a/ext/mysqli/tests/mysqli_connect_oo_warnings.phpt
+++ b/ext/mysqli/tests/mysqli_connect_oo_warnings.phpt
@@ -4,15 +4,15 @@ new mysqli()
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
-    if (!get_current_user())
-        die('skip: get_current_user() not supported');
-    if (stristr(mysqli_get_client_info(), 'mysqlnd'))
-        die("skip: test for libmysql (different error output when using php streams");
+require_once 'skipifconnectfailure.inc';
+if (!get_current_user())
+    die('skip: get_current_user() not supported');
+if ($IS_MYSQLND)
+    die("skip: test for libmysql (different error output when using php streams");
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     $myhost = 'invalidhost';
     $link   = NULL;

--- a/ext/mysqli/tests/mysqli_debug_ini.phpt
+++ b/ext/mysqli/tests/mysqli_debug_ini.phpt
@@ -4,7 +4,7 @@ mysqli_debug() - enabling trace with ini setting
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'skipifconnectfailure.inc';
 
 if (!function_exists('mysqli_debug'))
     die("skip mysqli_debug() not available");
@@ -15,7 +15,6 @@ if (!defined('MYSQLI_DEBUG_TRACE_ENABLED'))
 if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     die("skip: debug functionality not enabled");
 
-require_once('connect.inc');
 if (!$IS_MYSQLND)
     die("skip needs mysqlnd");
 
@@ -29,8 +28,7 @@ else
 mysqlnd.debug="t:O,/tmp/mysqli_debug_phpt.trace"
 --FILE--
 <?php
-    require_once('connect.inc');
-    require_once('table.inc');
+    require_once 'table.inc';
 
     var_dump(ini_get('mysqlnd.debug'));
 
@@ -47,6 +45,10 @@ mysqlnd.debug="t:O,/tmp/mysqli_debug_phpt.trace"
     unlink($trace_file);
 
     print "done!";
+?>
+--CLEAN--
+<?php
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 string(32) "t:O,/tmp/mysqli_debug_phpt.trace"

--- a/ext/mysqli/tests/mysqli_debug_mysqlnd_only.phpt
+++ b/ext/mysqli/tests/mysqli_debug_mysqlnd_only.phpt
@@ -4,8 +4,7 @@ mysqli_debug() - mysqlnd only control strings
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
+require_once 'skipifconnectfailure.inc';
 
 if (!function_exists('mysqli_debug'))
     die("skip mysqli_debug() not available");
@@ -21,8 +20,7 @@ if (!$IS_MYSQLND)
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
-    require_once('table.inc');
+    require_once 'table.inc';
 
     function try_control_string($link, $control_string, $trace_file, $offset) {
 
@@ -126,7 +124,7 @@ if (!$IS_MYSQLND)
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_explain_metadata.phpt
+++ b/ext/mysqli/tests/mysqli_explain_metadata.phpt
@@ -4,15 +4,13 @@ EXPLAIN - metadata
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once 'skipifconnectfailure.inc';
 if (!$IS_MYSQLND)
   die("skip Open libmysql/MySQL issue http://bugs.mysql.com/?id=62350");
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
-    require_once('table.inc');
+    require_once 'table.inc';
 
     if (!$res = mysqli_query($link, 'EXPLAIN SELECT t1.*, t2.* FROM test AS t1, test AS t2'))
         printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -157,7 +155,7 @@ if (!$IS_MYSQLND)
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_fetch_assoc_bit.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_assoc_bit.phpt
@@ -4,17 +4,16 @@ mysqli_fetch_assoc() - BIT
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
+require_once 'skipifconnectfailure.inc';
 
-    require_once('connect.inc');
-    require_once('table.inc');
-    if (mysqli_get_server_version($link) < 50003)
-        // b'001' syntax not supported before 5.0.3
-        die("skip Syntax used for test not supported with MySQL Server before 5.0.3");
+require_once 'table.inc';
+if (mysqli_get_server_version($link) < 50003)
+    // b'001' syntax not supported before 5.0.3
+    die("skip Syntax used for test not supported with MySQL Server before 5.0.3");
 ?>
 --FILE--
 <?php
-    require('connect.inc');
+    require 'connect.inc';
 
     function dec32bin($dec, $bits) {
 
@@ -108,7 +107,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_fetch_assoc_no_alias_utf8.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_assoc_no_alias_utf8.phpt
@@ -4,11 +4,10 @@ mysqli_fetch_assoc() - utf8
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
-    require_once("connect.inc");
+    require_once "connect.inc";
 
-    if (!$link = mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die("skip Cannot connect to server to check charsets");
+    if (!$link = @mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+        die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
     if (!$res = mysqli_query($link, "SHOW CHARACTER SET LIKE 'UTF8'"))
         die("skip Cannot run SHOW CHARACTER SET to check charsets");
@@ -35,7 +34,7 @@ mysqli
 ?>
 --FILE--
 <?php
-    require('table.inc');
+    require 'table.inc';
 
     /* some cyrillic (utf8) comes here */
     if (!$res = mysqli_query($link, "SET NAMES UTF8")) {
@@ -77,6 +76,10 @@ mysqli
 
     mysqli_close($link);
     print "done!";
+?>
+--CLEAN--
+<?php
+require_once "clean_table.inc";
 ?>
 --EXPECTF--
 [003]

--- a/ext/mysqli/tests/mysqli_fetch_field_flags.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_field_flags.phpt
@@ -4,11 +4,9 @@ mysqli_fetch_field() - flags/field->flags
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die(printf("skip: [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (mysqli_get_server_version($link) < 50041)
     die("skip: Due to many MySQL Server differences, the test requires 5.0.41+");
@@ -17,7 +15,7 @@ mysqli_close($link);
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
 /* TODO: mysqli.c needs to export a few more constants - see all the defined() calls! */
 
@@ -220,7 +218,7 @@ mysqli_close($link);
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_fork.phpt
+++ b/ext/mysqli/tests/mysqli_fork.phpt
@@ -4,7 +4,6 @@ Forking a child and using the same connection.
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
 
 if (!function_exists('pcntl_fork'))
     die("skip Process Control Functions not available");
@@ -12,16 +11,16 @@ if (!function_exists('pcntl_fork'))
 if (!function_exists('posix_getpid'))
     die("skip POSIX functions not available");
 
-require_once('connect.inc');
+require_once 'connect.inc';
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (!have_innodb($link))
     die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
 ?>
 --FILE--
 <?php
-    require_once("table.inc");
+    require_once "table.inc";
 
     $res = mysqli_query($link, "SELECT 'dumped by the parent' AS message");
     $pid = pcntl_fork();
@@ -224,7 +223,7 @@ if (!have_innodb($link))
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/mysqli_get_client_info.phpt
+++ b/ext/mysqli/tests/mysqli_get_client_info.phpt
@@ -2,17 +2,12 @@
 mysqli_get_client_info()
 --EXTENSIONS--
 mysqli
---SKIPIF--
-<?php
-require_once('skipifconnectfailure.inc');
-?>
 --FILE--
 <?php
-    require_once("connect.inc");
-    if (!is_string($info = mysqli_get_client_info()) || ('' === $info))
-        printf("[001] Expecting string/any_non_empty, got %s/%s\n", gettype($info), $info);
+if (!is_string($info = mysqli_get_client_info()) || ('' === $info))
+    printf("[001] Expecting string/any_non_empty, got %s/%s\n", gettype($info), $info);
 
-    print "done!";
+print "done!";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_get_warnings.phpt
+++ b/ext/mysqli/tests/mysqli_get_warnings.phpt
@@ -4,14 +4,13 @@ mysqli_get_warnings() - TODO
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
+require_once 'skipifconnectfailure.inc';
 if (!$TEST_EXPERIMENTAL)
     die("skip - experimental (= unsupported) feature");
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     $tmp    = NULL;
     $link   = NULL;
@@ -142,7 +141,7 @@ if (!$TEST_EXPERIMENTAL)
     print "done!";
 ?>
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/mysqli_insert_packet_overflow.phpt
+++ b/ext/mysqli/tests/mysqli_insert_packet_overflow.phpt
@@ -4,9 +4,9 @@ INSERT and packet overflow
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once "connect.inc";
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     die(sprintf("SKIP [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
 
 $max_len = pow(2, 24);
@@ -22,7 +22,7 @@ mysqli_close($link);
 memory_limit=256M
 --FILE--
 <?php
-    require('connect.inc');
+    require_once "connect.inc";
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/mysqli_local_infile_directory_access_allowed.phpt
+++ b/ext/mysqli/tests/mysqli_local_infile_directory_access_allowed.phpt
@@ -4,17 +4,17 @@ mysqli.local_infile_directory vs access allowed
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-	die("skip Cannot connect to MySQL");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-include_once("local_infile_tools.inc");
+include_once "local_infile_tools.inc";
 if ($msg = check_local_infile_allowed_by_server($link))
-	die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
+    die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
 
 mysqli_close($link);
-
 ?>
 --INI--
 open_basedir={PWD}
@@ -22,7 +22,7 @@ mysqli.allow_local_infile=0
 mysqli.local_infile_directory={PWD}/foo
 --FILE--
 <?php
-	require_once("connect.inc");
+	require_once 'connect.inc';
 
 	if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 		printf("[001] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
@@ -64,7 +64,7 @@ mysqli.local_infile_directory={PWD}/foo
 ?>
 --CLEAN--
 <?php
-require_once('connect.inc');
+require_once 'connect.inc';
 
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 	printf("[clean] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",

--- a/ext/mysqli/tests/mysqli_local_infile_directory_access_denied.phpt
+++ b/ext/mysqli/tests/mysqli_local_infile_directory_access_denied.phpt
@@ -4,17 +4,17 @@ mysqli.local_infile_directory access denied
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-	die("skip Cannot connect to MySQL");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-include_once("local_infile_tools.inc");
+include_once "local_infile_tools.inc";
 if ($msg = check_local_infile_allowed_by_server($link))
-	die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
+    die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
 
 mysqli_close($link);
-
 ?>
 --INI--
 open_basedir={PWD}
@@ -22,7 +22,7 @@ mysqli.allow_local_infile=0
 mysqli.local_infile_directory={PWD}/foo/bar
 --FILE--
 <?php
-	require_once("connect.inc");
+	require_once "connect.inc";
 
 	if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 		printf("[001] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
@@ -48,7 +48,7 @@ mysqli.local_infile_directory={PWD}/foo/bar
 ?>
 --CLEAN--
 <?php
-require_once('connect.inc');
+require_once 'connect.inc';
 
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 	printf("[clean] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",

--- a/ext/mysqli/tests/mysqli_local_infile_directory_vs_open_basedir.phpt
+++ b/ext/mysqli/tests/mysqli_local_infile_directory_vs_open_basedir.phpt
@@ -4,17 +4,17 @@ mysqli.local_infile_directory vs open_basedir
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-	die("skip Cannot connect to MySQL");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-include_once("local_infile_tools.inc");
+include_once "local_infile_tools.inc";
 if ($msg = check_local_infile_allowed_by_server($link))
-	die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
+    die(sprintf("skip %s, [%d] %s", $msg, $link->errno, $link->error));
 
 mysqli_close($link);
-
 ?>
 --INI--
 open_basedir={PWD}

--- a/ext/mysqli/tests/mysqli_mysqlnd_read_timeout.phpt
+++ b/ext/mysqli/tests/mysqli_mysqlnd_read_timeout.phpt
@@ -4,8 +4,7 @@ mysqlnd.net_read_timeout limit check
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
+require_once 'skipifconnectfailure.inc';
 if (!$IS_MYSQLND)
     /* The libmysql read_timeout limit default is 365 * 24 * 3600 seconds. It cannot be altered through PHP API calls */
     die("skip mysqlnd only test");
@@ -16,7 +15,7 @@ max_execution_time=60
 mysqlnd.net_read_timeout=1
 --FILE--
 <?php
-    include ("connect.inc");
+    include "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         printf("[001] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());

--- a/ext/mysqli/tests/mysqli_mysqlnd_read_timeout_long.phpt
+++ b/ext/mysqli/tests/mysqli_mysqlnd_read_timeout_long.phpt
@@ -4,13 +4,13 @@ mysqlnd.net_read_timeout > default_socket_timeout
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once "connect.inc";
 
 if (!$IS_MYSQLND) {
     die("skip: test applies only to mysqlnd");
 }
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) <= 50011) {
@@ -24,7 +24,7 @@ max_execution_time=12
 --FILE--
 <?php
     set_time_limit(12);
-    include ("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         printf("[001] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());

--- a/ext/mysqli/tests/mysqli_mysqlnd_read_timeout_zero.phpt
+++ b/ext/mysqli/tests/mysqli_mysqlnd_read_timeout_zero.phpt
@@ -4,13 +4,13 @@ mysqlnd.net_read_timeout = 0
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once "connect.inc";
 
 if (!$IS_MYSQLND) {
     die("skip: test applies only to mysqlnd");
 }
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) <= 50011) {
@@ -23,7 +23,7 @@ max_execution_time=10
 mysqlnd.net_read_timeout=0
 --FILE--
 <?php
-    include ("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         printf("[001] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());

--- a/ext/mysqli/tests/mysqli_options_int_and_float_native.phpt
+++ b/ext/mysqli/tests/mysqli_options_int_and_float_native.phpt
@@ -4,15 +4,14 @@ mysqli_options() - MYSQLI_OPT_INT_AND_FLOAT_NATIVE
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'skipifconnectfailure.inc';
 
-require_once('connect.inc');
 if (!$IS_MYSQLND)
     die("skip mysqlnd only test");
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
 
     $types = array(
@@ -103,7 +102,7 @@ if (!$IS_MYSQLND)
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_pam_sha256.phpt
+++ b/ext/mysqli/tests/mysqli_pam_sha256.phpt
@@ -4,8 +4,6 @@ PAM: SHA-256
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
 ob_start();
 phpinfo(INFO_MODULES);
 $tmp = ob_get_contents();
@@ -13,9 +11,9 @@ ob_end_clean();
 if (!stristr($tmp, "auth_plugin_sha256_password"))
     die("skip SHA256 auth plugin not built-in to mysqlnd");
 
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die(printf("skip: [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (mysqli_get_server_version($link) < 50606)
     die("skip: SHA-256 requires MySQL 5.6.6+");
@@ -79,7 +77,7 @@ echo "nocache";
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, 'shatest', 'shatest', $db, $port, $socket)) {
         printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -105,7 +103,7 @@ echo "nocache";
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+    require_once "clean_table.inc";
     $link->query('DROP USER shatest');
     $link->query('DROP USER shatest@localhost');
 ?>

--- a/ext/mysqli/tests/mysqli_pam_sha256_public_key_ini.phpt
+++ b/ext/mysqli/tests/mysqli_pam_sha256_public_key_ini.phpt
@@ -4,8 +4,6 @@ PAM: SHA-256, mysqlnd.sha256_server_public_key
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
 ob_start();
 phpinfo(INFO_MODULES);
 $tmp = ob_get_contents();
@@ -13,9 +11,9 @@ ob_end_clean();
 if (!stristr($tmp, "auth_plugin_sha256_password"))
     die("skip SHA256 auth plugin not built-in to mysqlnd");
 
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die(printf("skip: [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (mysqli_get_server_version($link) < 50606)
     die("skip: SHA-256 requires MySQL 5.6.6+");
@@ -93,7 +91,7 @@ echo "nocache";
 mysqlnd.sha256_server_public_key="test_sha256_ini"
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
 
     $link = new mysqli($host, 'shatest', 'shatest', $db, $port, $socket);
@@ -115,7 +113,7 @@ mysqlnd.sha256_server_public_key="test_sha256_ini"
 ?>
 --CLEAN--
 <?php
-	require_once("clean_table.inc");
+	require_once "clean_table.inc";
 	$link->query('DROP USER shatest');
 	$link->query('DROP USER shatest@localhost');
 	$file = "test_sha256_ini";

--- a/ext/mysqli/tests/mysqli_pam_sha256_public_key_option.phpt
+++ b/ext/mysqli/tests/mysqli_pam_sha256_public_key_option.phpt
@@ -4,8 +4,6 @@ PAM: SHA-256, option: MYSQLI_SERVER_PUBLIC_KEY
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
 ob_start();
 phpinfo(INFO_MODULES);
 $tmp = ob_get_contents();
@@ -13,9 +11,9 @@ ob_end_clean();
 if (!stristr($tmp, "auth_plugin_sha256_password"))
     die("skip SHA256 auth plugin not built-in to mysqlnd");
 
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die(printf("skip: [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (mysqli_get_server_version($link) < 50606)
     die("skip: SHA-256 requires MySQL 5.6.6+");
@@ -88,7 +86,7 @@ echo "nocache";
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     $file = sprintf("%s%s%s_%s", sys_get_temp_dir(), DIRECTORY_SEPARATOR, "test_sha256_" , @date("Ymd"));
     if (file_exists($file) && is_readable($file)) {
@@ -121,7 +119,7 @@ echo "nocache";
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+    require_once "clean_table.inc";
     $link->query('DROP USER shatest');
     $link->query('DROP USER shatest@localhost');
     $file = sprintf("%s%s%s_%s", sys_get_temp_dir(), DIRECTORY_SEPARATOR, "test_sha256_" , @date("Ymd"));

--- a/ext/mysqli/tests/mysqli_pam_sha256_public_key_option_invalid.phpt
+++ b/ext/mysqli/tests/mysqli_pam_sha256_public_key_option_invalid.phpt
@@ -4,8 +4,6 @@ PAM: SHA-256, option: MYSQLI_SERVER_PUBLIC_KEY (invalid)
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
 ob_start();
 phpinfo(INFO_MODULES);
 $tmp = ob_get_contents();
@@ -13,9 +11,9 @@ ob_end_clean();
 if (!stristr($tmp, "auth_plugin_sha256_password"))
     die("skip SHA256 auth plugin not built-in to mysqlnd");
 
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die(printf("skip: [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (mysqli_get_server_version($link) < 50606)
     die("skip: SHA-256 requires MySQL 5.6.6+");
@@ -88,7 +86,7 @@ echo "nocache";
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     function sha_connect($offset, $host, $db, $port, $socket, $file) {
 
@@ -165,7 +163,7 @@ echo "nocache";
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+    require_once "clean_table.inc";
     $link->query('DROP USER shatest');
     $link->query('DROP USER shatest@localhost');
     $file = sprintf("%s%s%s_%s", sys_get_temp_dir(), DIRECTORY_SEPARATOR, "test_sha256_" , @date("Ymd"));

--- a/ext/mysqli/tests/mysqli_pconn_kill.phpt
+++ b/ext/mysqli/tests/mysqli_pconn_kill.phpt
@@ -4,16 +4,14 @@ Killing a persistent connection.
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once 'skipifconnectfailure.inc';
 ?>
 --INI--
 mysqli.allow_persistent=1
 mysqli.max_persistent=2
 --FILE--
 <?php
-    require_once("connect.inc");
-    require_once("table.inc");
+    require_once "table.inc";
 
     $host = 'p:' . $host;
     if (!$plink = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
@@ -93,7 +91,7 @@ mysqli.max_persistent=2
 ?>
 --CLEAN--
 <?php
-	require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 mysqli object is already closed

--- a/ext/mysqli/tests/mysqli_pconn_limits.phpt
+++ b/ext/mysqli/tests/mysqli_pconn_limits.phpt
@@ -4,8 +4,7 @@ Persistent connections - limits (-1, unlimited)
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once("connect.inc");
+require_once 'skipifconnectfailure.inc';
 ?>
 --INI--
 mysqli.allow_persistent=1
@@ -13,9 +12,7 @@ mysqli.max_persistent=-1
 mysqli.max_links=-1
 --FILE--
 <?php
-    require_once("connect.inc");
-    // opens a regular connection
-    require_once("table.inc");
+    require_once "table.inc";
 
     if (!$res = mysqli_query($link, "SELECT 'works..' as _desc"))
         printf("[001] Cannot run query, [%d] %s\n",
@@ -87,7 +84,7 @@ mysqli.max_links=-1
 ?>
 --CLEAN--
 <?php
-	require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 Regular connection 1 - 'works..'

--- a/ext/mysqli/tests/mysqli_poll_reference.phpt
+++ b/ext/mysqli/tests/mysqli_poll_reference.phpt
@@ -4,13 +4,13 @@ mysqli_poll() & references
 mysqli
 --SKIPIF--
 <?php
-require_once 'skipifconnectfailure.inc';
+require_once 'connect.inc';
 
 if (!$IS_MYSQLND)
     die("skip mysqlnd only feature, compile PHP using --with-mysqli=mysqlnd");
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die("skip cannot connect");
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (mysqli_get_server_version($link) < 50012)
     die("skip Test needs SQL function SLEEP() available as of MySQL 5.0.12");
@@ -18,7 +18,7 @@ if (mysqli_get_server_version($link) < 50012)
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
+    require_once 'connect.inc';
 
     function get_connection() {
         global $host, $user, $passwd, $db, $port, $socket;

--- a/ext/mysqli/tests/mysqli_query_stored_proc.phpt
+++ b/ext/mysqli/tests/mysqli_query_stored_proc.phpt
@@ -4,10 +4,9 @@ mysqli_query() - Stored Procedures
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) <= 50000) {
     die(sprintf('skip Needs MySQL 5.0+, found version %d.', mysqli_get_server_version($link)));
@@ -15,8 +14,7 @@ if (mysqli_get_server_version($link) <= 50000) {
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
-    require_once('table.inc');
+    require_once 'table.inc';
 
     if (!mysqli_query($link, 'DROP PROCEDURE IF EXISTS p'))
         printf("[001] [%d] %s.\n", mysqli_errno($link), mysqli_error($link));
@@ -153,7 +151,7 @@ END;')) {
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/mysqli_query_unicode.phpt
+++ b/ext/mysqli/tests/mysqli_query_unicode.phpt
@@ -4,9 +4,8 @@ mysqli_query() - unicode (cyrillic)
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
-require_once('table.inc');
+require_once 'skipifconnectfailure.inc';
+require_once 'table.inc';
 if (!$res = mysqli_query($link, "SHOW CHARACTER SET LIKE 'utf8'"))
     die("skip UTF8 chatset seems not available");
 mysqli_free_result($res);
@@ -14,9 +13,7 @@ mysqli_close($link);
 ?>
 --FILE--
 <?php
-    include_once("connect.inc");
-
-    require_once('table.inc');
+    require_once 'table.inc';
 
     if (TRUE !== ($tmp = @mysqli_query($link, "set names utf8")))
         printf("[002.5] Expecting TRUE, got %s/%s\n", gettype($tmp), $tmp);

--- a/ext/mysqli/tests/mysqli_real_connect_pconn.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect_pconn.phpt
@@ -4,8 +4,7 @@ mysqli_real_connect() - persistent connections
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
+require_once 'skipifconnectfailure.inc';
 if (!$IS_MYSQLND)
     die("skip mysqlnd only test");
 ?>
@@ -15,7 +14,7 @@ mysqli.allow_persistent=1
 mysqli.max_persistent=10
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
     $host = 'p:' . $host;
 
     if (!$link = mysqli_init())
@@ -149,7 +148,7 @@ mysqli.max_persistent=10
 ?>
 --CLEAN--
 <?php
-	require_once("clean_table.inc");
+	require_once "clean_table.inc";
 ?>
 --EXPECTF--
 Warning: mysqli_real_connect(): (%s/%d): Access denied for user '%s'@'%s' (using password: YES) in %s on line %d

--- a/ext/mysqli/tests/mysqli_reconnect.phpt
+++ b/ext/mysqli/tests/mysqli_reconnect.phpt
@@ -4,16 +4,15 @@ Trying implicit reconnect after wait_timeout and KILL using mysqli_ping()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-if (stristr(mysqli_get_client_info(), 'mysqlnd'))
+require_once 'skipifconnectfailure.inc';
+if ($IS_MYSQLND)
     die("skip: test for libmysql");
 ?>
 --INI--
 mysqli.reconnect=1
 --FILE--
 <?php
-    require_once("connect.inc");
-    require_once("table.inc");
+    require_once "table.inc";
 
     if (!$link2 = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[001] Cannot create second database connection, [%d] %s\n",
@@ -125,6 +124,10 @@ mysqli.reconnect=1
     mysqli_close($link);
     mysqli_close($link2);
     print "done!";
+?>
+--CLEAN--
+<?php
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_release_savepoint.phpt
+++ b/ext/mysqli/tests/mysqli_release_savepoint.phpt
@@ -4,20 +4,16 @@ mysqli_release_savepoint()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (!have_innodb($link))
     die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
-    $tmp    = NULL;
-    $link   = NULL;
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[003] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -62,7 +58,7 @@ if (!have_innodb($link))
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 mysqli_release_savepoint(): Argument #2 ($name) cannot be empty

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -4,12 +4,10 @@ mysqli_report()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'skipifconnectfailure.inc';
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
-
     if (true !== ($tmp = mysqli_report(-1)))
         printf("[002] Expecting boolean/true even for invalid flags, got %s/%s\n", gettype($tmp), $tmp);
 
@@ -28,7 +26,7 @@ require_once('skipifconnectfailure.inc');
     if (true !== ($tmp = mysqli_report(MYSQLI_REPORT_OFF)))
         printf("[008] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
-    require('table.inc');
+    require_once 'table.inc';
 
     /*
     Internal macro MYSQL_REPORT_ERROR
@@ -311,7 +309,7 @@ require_once('skipifconnectfailure.inc');
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECTF--
 Warning: mysqli_multi_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'BAR; FOO' at line 1 in %s on line %d

--- a/ext/mysqli/tests/mysqli_report_new.phpt
+++ b/ext/mysqli/tests/mysqli_report_new.phpt
@@ -4,9 +4,9 @@ mysqli_report(), change user, MySQL 5.6+
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     die(sprintf("SKIP Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
         $host, $user, $db, $port, $socket));
 
@@ -16,12 +16,7 @@ if (mysqli_get_server_version($link) < 50600)
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
-
-    $tmp    = NULL;
-    $link   = NULL;
-
-    require('table.inc');
+    require_once 'table.inc';
 
     /*
     Internal macro MYSQL_REPORT_ERROR
@@ -42,7 +37,7 @@ if (mysqli_get_server_version($link) < 50600)
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECTF--
 Warning: mysqli_change_user(): (%d/%d): Access denied for user '%s'@'%s' (using password: %s) in %s on line %d

--- a/ext/mysqli/tests/mysqli_report_wo_ps.phpt
+++ b/ext/mysqli/tests/mysqli_report_wo_ps.phpt
@@ -4,9 +4,9 @@ mysqli_report(), MySQL < 5.6
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once "connect.inc";
 
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     die(sprintf("SKIP Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
         $host, $user, $db, $port, $socket));
 
@@ -15,11 +15,6 @@ if (mysqli_get_server_version($link) >= 50600)
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
-
-    $tmp    = NULL;
-    $link   = NULL;
-
     if (true !== ($tmp = mysqli_report(-1)))
         printf("[002] Expecting boolean/true even for invalid flags, got %s/%s\n", gettype($tmp), $tmp);
 
@@ -38,7 +33,7 @@ if (mysqli_get_server_version($link) >= 50600)
     if (true !== ($tmp = mysqli_report(MYSQLI_REPORT_OFF)))
         printf("[008] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
-    require('table.inc');
+    require 'table.inc';
 
     /*
     Internal macro MYSQL_REPORT_ERROR
@@ -106,7 +101,7 @@ if (mysqli_get_server_version($link) >= 50600)
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECTF--
 Warning: mysqli_multi_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'BAR; FOO' at line 1 in %s on line %d

--- a/ext/mysqli/tests/mysqli_result_references_mysqlnd.phpt
+++ b/ext/mysqli/tests/mysqli_result_references_mysqlnd.phpt
@@ -4,15 +4,13 @@ References to result sets - mysqlnd (no copies but references)
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
+require_once 'skipifconnectfailure.inc';
 if (!$IS_MYSQLND)
     die("skip Test for mysqlnd only");
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
-    require_once('table.inc');
+    require_once 'table.inc';
 
     $references = array();
 
@@ -50,6 +48,10 @@ if (!$IS_MYSQLND)
 
     debug_zval_dump($references);
     print "done!";
+?>
+--CLEAN--
+<?php
+require_once "clean_table.inc";
 ?>
 --EXPECTF--
 array(1) refcount(%d){

--- a/ext/mysqli/tests/mysqli_rollback.phpt
+++ b/ext/mysqli/tests/mysqli_rollback.phpt
@@ -4,18 +4,16 @@ mysqli_rollback()
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
-    require_once('connect.inc');
-    if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
-
-    if (!have_innodb($link))
-        die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
+if (!have_innodb($link))
+    die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[003] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -59,7 +57,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 mysqli object is already closed

--- a/ext/mysqli/tests/mysqli_savepoint.phpt
+++ b/ext/mysqli/tests/mysqli_savepoint.phpt
@@ -4,18 +4,16 @@ mysqli_savepoint()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (!have_innodb($link))
     die(sprintf("skip Needs InnoDB support, [%d] %s", $link->errno, $link->error));
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[003] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -51,7 +49,7 @@ if (!have_innodb($link))
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 mysqli_savepoint(): Argument #2 ($name) cannot be empty

--- a/ext/mysqli/tests/mysqli_set_charset.phpt
+++ b/ext/mysqli/tests/mysqli_set_charset.phpt
@@ -4,14 +4,12 @@ mysqli_set_charset()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-
 if (!function_exists('mysqli_set_charset'))
     die("skip Function not available");
 
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-    die(sprintf("skip Cannot connect, [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (!($res = mysqli_query($link, 'SELECT version() AS server_version')) ||
         !($tmp = mysqli_fetch_assoc($res))) {
@@ -46,9 +44,7 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
-
-    require('table.inc');
+    require 'table.inc';
 
     if (!$res = mysqli_query($link, 'SELECT @@character_set_connection AS charset, @@collation_connection AS collation'))
         printf("[007] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -128,7 +124,7 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECTF--
 Exception: %s

--- a/ext/mysqli/tests/mysqli_ssl_set.phpt
+++ b/ext/mysqli/tests/mysqli_ssl_set.phpt
@@ -4,13 +4,15 @@ mysqli_ssl_set() - test is a stub!
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+die("skip test is a stub!");
+
+require_once 'skipifconnectfailure.inc';
 if (!function_exists('mysqli_ssl_set'))
     die("skip function not available");
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     /*
     This function always returns TRUE value.

--- a/ext/mysqli/tests/mysqli_stmt_execute.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute.phpt
@@ -4,9 +4,9 @@ mysqli_stmt_execute()
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
+require_once "connect.inc";
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) <= 40100) {
     die(sprintf('skip Needs MySQL 4.1+, found version %d.', mysqli_get_server_version($link)));
@@ -14,9 +14,7 @@ if (mysqli_get_server_version($link) <= 40100) {
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
-
-    require('table.inc');
+    require 'table.inc';
 
     if (!$stmt = mysqli_stmt_init($link))
         printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -134,7 +132,7 @@ if (mysqli_get_server_version($link) <= 40100) {
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 mysqli_stmt object is not fully initialized

--- a/ext/mysqli/tests/mysqli_stmt_execute_stored_proc.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_stored_proc.phpt
@@ -4,10 +4,9 @@ mysqli_stmt_execute() - Stored Procedures
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) <= 50000) {
     die(sprintf('skip Needs MySQL 5.0+, found version %d.', mysqli_get_server_version($link)));
@@ -15,8 +14,12 @@ if (mysqli_get_server_version($link) <= 50000) {
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
-    require_once('table.inc');
+    require_once 'connect.inc';
+
+    if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+        printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
+          $host, $user, $db, $port, $socket);
+    }
 
     if (!mysqli_query($link, 'DROP PROCEDURE IF EXISTS p'))
         printf("[009] [%d] %s.\n", mysqli_errno($link), mysqli_error($link));
@@ -184,7 +187,7 @@ if (mysqli_get_server_version($link) <= 50000) {
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/mysqli_stmt_execute_stored_proc_next_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_stored_proc_next_result.phpt
@@ -4,10 +4,9 @@ mysqli_stmt_execute() - SP, next result
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) < 50503) {
     die(sprintf('skip Needs MySQL 5.5.3+, found version %d.', mysqli_get_server_version($link)));
@@ -15,7 +14,7 @@ if (mysqli_get_server_version($link) < 50503) {
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
+    require_once 'connect.inc';
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -116,7 +115,7 @@ if (mysqli_get_server_version($link) < 50503) {
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/mysqli_stmt_execute_stored_proc_out.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_stored_proc_out.phpt
@@ -4,10 +4,9 @@ mysqli_stmt_execute() - OUT
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-    die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }
 if (mysqli_get_server_version($link) < 50503) {
     die(sprintf('skip Needs MySQL 5.5.3+, found version %d.', mysqli_get_server_version($link)));
@@ -20,7 +19,7 @@ if ($IS_MYSQLND) {
 ?>
 --FILE--
 <?php
-    require_once('connect.inc');
+    require_once 'connect.inc';
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
         printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -70,7 +69,7 @@ if ($IS_MYSQLND) {
 ?>
 --CLEAN--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
    printf("[c001] [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 

--- a/ext/mysqli/tests/mysqli_stmt_fetch_bit.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_fetch_bit.phpt
@@ -4,16 +4,18 @@ Fetching BIT column values using the PS API
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
-    require_once('connect.inc');
-    require_once('table.inc');
-    if (mysqli_get_server_version($link) < 50003)
-        // b'001' syntax not supported before 5.0.3
-        die("skip Syntax used for test not supported with MySQL Server before 5.0.3");
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
+if (mysqli_get_server_version($link) < 50003) {
+    // b'001' syntax not supported before 5.0.3
+    die("skip Syntax used for test not supported with MySQL Server before 5.0.3");
+}
 ?>
 --FILE--
 <?php
-    require('connect.inc');
+    require 'connect.inc';
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -67,7 +69,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_stmt_get_result_bit.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result_bit.phpt
@@ -4,20 +4,23 @@ Fetching BIT column values using the PS API
 mysqli
 --SKIPIF--
 <?php
-    require_once('skipifconnectfailure.inc');
+if (!function_exists('mysqli_stmt_get_result')) {
+    die("skip mysqli_stmt_get_result() not available");
+}
 
-    if (!function_exists('mysqli_stmt_get_result'))
-        die("skip mysqli_stmt_get_result() not available");
+require_once 'connect.inc';
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+    die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+}
 
-    require_once('connect.inc');
-    require_once('table.inc');
-    if (mysqli_get_server_version($link) < 50003)
-        // b'001' syntax not supported before 5.0.3
-        die("skip Syntax used for test not supported with MySQL Server before 5.0.3");
+if (mysqli_get_server_version($link) < 50003) {
+    // b'001' syntax not supported before 5.0.3
+    die("skip Syntax used for test not supported with MySQL Server before 5.0.3");
+}
 ?>
 --FILE--
 <?php
-    require('connect.inc');
+    require_once 'connect.inc';
 
     function dec32bin($dec, $bits) {
 
@@ -124,7 +127,7 @@ mysqli
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 done!

--- a/ext/mysqli/tests/mysqli_stmt_get_warnings.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_warnings.phpt
@@ -4,11 +4,9 @@ mysqli_stmt_get_warnings() - TODO
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
+require_once "connect.inc";
 
-require_once("connect.inc");
-
-if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     die(sprintf("skip Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
         $host, $user, $db, $port, $socket));
 }
@@ -24,9 +22,7 @@ mysqli_query($link, "DROP TABLE IF EXISTS test");
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
-
-    require('table.inc');
+    require 'table.inc';
 
     if (!$stmt = mysqli_stmt_init($link))
         printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
@@ -97,7 +93,7 @@ mysqli_query($link, "DROP TABLE IF EXISTS test");
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECT--
 mysqli_stmt object is not fully initialized

--- a/ext/mysqli/tests/mysqli_stmt_multires.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_multires.phpt
@@ -4,16 +4,14 @@ Multiple result set with PS
 mysqli
 --SKIPIF--
 <?php
-require_once("connect.inc");
+require_once "skipifconnectfailure.inc";
 if (!$IS_MYSQLND) {
     die("skip mysqlnd only test");
 }
-require_once('skipifconnectfailure.inc');
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
-    require('table.inc');
+    require 'table.inc';
 
     $stmt = mysqli_stmt_init($link);
     if (!$link->query('DROP PROCEDURE IF EXISTS p123')) {

--- a/ext/mysqli/tests/mysqli_stmt_send_long_data_packet_size_libmysql.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_send_long_data_packet_size_libmysql.phpt
@@ -6,7 +6,7 @@ mysqli
 <?php
 require_once('skipifconnectfailure.inc');
 
-if (stristr(mysqli_get_client_info(), 'mysqlnd'))
+if ($IS_MYSQLND)
     die("skip: test for libmysql");
 ?>
 --FILE--

--- a/ext/mysqli/tests/mysqli_stmt_send_long_data_packet_size_mysqlnd.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_send_long_data_packet_size_mysqlnd.phpt
@@ -6,7 +6,7 @@ mysqli
 <?php
 require_once('skipifconnectfailure.inc');
 
-if (!stristr(mysqli_get_client_info(), 'mysqlnd'))
+if (!$IS_MYSQLND)
     die("skip: warnings only available in mysqlnd");
 ?>
 --FILE--

--- a/ext/mysqli/tests/mysqli_warning_unclonable.phpt
+++ b/ext/mysqli/tests/mysqli_warning_unclonable.phpt
@@ -4,14 +4,13 @@ Trying to clone mysqli_warning object
 mysqli
 --SKIPIF--
 <?php
-require_once('skipifconnectfailure.inc');
-require_once('connect.inc');
+require_once 'skipifconnectfailure.inc';
 if (!$TEST_EXPERIMENTAL)
     die("skip - experimental (= unsupported) feature");
 ?>
 --FILE--
 <?php
-    require_once("connect.inc");
+    require_once "connect.inc";
 
     if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
         printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",
@@ -35,7 +34,7 @@ if (!$TEST_EXPERIMENTAL)
 ?>
 --CLEAN--
 <?php
-    require_once("clean_table.inc");
+require_once "clean_table.inc";
 ?>
 --EXPECTF--
 Fatal error: Trying to clone an uncloneable object of class mysqli_warning in %s on line %d

--- a/ext/mysqli/tests/skipifconnectfailure.inc
+++ b/ext/mysqli/tests/skipifconnectfailure.inc
@@ -1,7 +1,6 @@
 <?php
 require_once 'connect.inc';
 if ($skip_on_connect_failure) {
-    include_once 'connect.inc';
     $link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
     if (!is_object($link))
         die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));

--- a/ext/mysqli/tests/table.inc
+++ b/ext/mysqli/tests/table.inc
@@ -1,5 +1,5 @@
 <?PHP
-require_once('connect.inc');
+require_once 'connect.inc';
 
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     printf("Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n",


### PR DESCRIPTION
I thought this would speed up some tests, but it doesn't seem to improve it that much. It improves formatting and will prevent confusion in future tests in terms of which file should be included. 