### PR TITLE
Don't involve PHP in Apache mpm_winnt control process

### DIFF
--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -459,6 +459,25 @@ static int php_pre_config(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp
 	return OK;
 }
 
+static int php_apache_startup_php()
+{
+#ifdef ZTS
+	php_tsrm_startup();
+# ifdef PHP_WIN32
+	ZEND_TSRMLS_CACHE_UPDATE();
+# endif
+#endif
+
+	zend_signal_startup();
+
+	sapi_startup(&apache2_sapi_module);
+	if (apache2_sapi_module.startup(&apache2_sapi_module) != SUCCESS) {
+		return DONE;
+	}
+
+	return OK;
+}
+
 static int
 php_apache_server_startup(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
 {
@@ -482,21 +501,14 @@ php_apache_server_startup(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp
 	if (apache2_php_ini_path_override) {
 		apache2_sapi_module.php_ini_path_override = apache2_php_ini_path_override;
 	}
-#ifdef ZTS
-	php_tsrm_startup();
-# ifdef PHP_WIN32
-	ZEND_TSRMLS_CACHE_UPDATE();
-# endif
-#endif
-
-	zend_signal_startup();
-
-	sapi_startup(&apache2_sapi_module);
-	if (apache2_sapi_module.startup(&apache2_sapi_module) != SUCCESS) {
+#ifndef PHP_WIN32
+	int res = php_apache_startup_php();
+	if (res != OK) {
 		return DONE;
 	}
 	apr_pool_cleanup_register(pconf, NULL, php_apache_server_shutdown, apr_pool_cleanup_null);
 	php_apache_add_version(pconf);
+#endif
 
 	return OK;
 }
@@ -743,7 +755,13 @@ zend_first_try {
 
 static void php_apache_child_init(apr_pool_t *pchild, server_rec *s)
 {
+#ifndef PHP_WIN32
 	apr_pool_cleanup_register(pchild, NULL, php_apache_child_shutdown, apr_pool_cleanup_null);
+#else
+	php_apache_startup_php();
+	php_apache_add_version(pchild);
+	apr_pool_cleanup_register(pchild, NULL, php_apache_server_shutdown, apr_pool_cleanup_null);
+#endif
 }
 
 #ifdef ZEND_SIGNALS


### PR DESCRIPTION
Apache mpm_winnt uses a single control process which launches a single
child process which in turn creates threads to handle requests.  Since
the child process is not forked, but rather spawned, and the control
process is never involved in request handling, there is no need to
power up PHP for the control process.  Besides not doing this saves
some resources, we no longer have to deal with potential re-attaching
to OPcache shared memory which avoids issues due to ASLR, and paves the
way to further improvements (such as preloading support for Apache
mpm_winnt).

---

Possibly, a problem with that exact implementation is that it assumes that mpm_winnt is always used on Windows, what might be wrong. Maybe someone knowlegable with Apache on Windows can clarify whether alternative MPMs might be used there, and if so, suggest a better way to detect that (i.e. is there a respective macro we could use in favor of `PHP_WIN32`)?

cc @Jan-E 