### PR TITLE
Fix GH-7854: Segfault on one-arm match statement

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -150,6 +150,7 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 	while (opline < end) {
 		/* Constant Propagation: strip X = QM_ASSIGN(const) */
 		if (opline->op1_type == IS_TMP_VAR &&
+		    opline->opcode != ZEND_FETCH_LIST_R &&
 		    opline->opcode != ZEND_FREE) {
 			src = VAR_SOURCE(opline->op1);
 			if (src &&

--- a/Zend/tests/gh7854.phpt
+++ b/Zend/tests/gh7854.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Bug GH-7854 (Segfault on one-arm match statement)
+--FILE--
+<?php
+[$a, $b] = match (true) {
+    true => ['three', 'whatever'],
+};
+var_dump($a, $b);
+?>
+--EXPECT--
+string(5) "three"
+string(8) "whatever"


### PR DESCRIPTION
We cannot trivially strip X = QM_ASSIGN(const) for `ZEND_FETCH_LIST_R`
opcodes during block optimization, since following `ZEND_FETCH_LIST_R`s
reuse the first operand, and it is finally `ZEND_FREE`d.  Instead we
leave this optimization to the SCCP pass (if it is enabled).