### PR TITLE
Fix GH-7867: FFI::cast() from pointer to array is broken

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -3904,11 +3904,13 @@ ZEND_METHOD(FFI, cast) /* {{{ */
 		/* automatically dereference void* pointers ??? */
 		cdata->ptr = *(void**)ptr;
 	} else if (old_type->kind == ZEND_FFI_TYPE_ARRAY
-	 && type->kind == ZEND_FFI_TYPE_POINTER) {
-		cdata->ptr = &cdata->ptr_holder;
-		cdata->ptr_holder = old_cdata->ptr;
-	} else if (old_type->kind== ZEND_FFI_TYPE_POINTER
-	 && type->kind == ZEND_FFI_TYPE_ARRAY) {
+	 && type->kind == ZEND_FFI_TYPE_POINTER
+	 && zend_ffi_is_compatible_type(ZEND_FFI_TYPE(old_type->array.type), ZEND_FFI_TYPE(type->pointer.type))) {		cdata->ptr = &cdata->ptr_holder;
+ 		cdata->ptr = &cdata->ptr_holder;
+ 		cdata->ptr_holder = old_cdata->ptr;
+	} else if (old_type->kind == ZEND_FFI_TYPE_POINTER
+	 && type->kind == ZEND_FFI_TYPE_ARRAY
+	 && zend_ffi_is_compatible_type(ZEND_FFI_TYPE(old_type->pointer.type), ZEND_FFI_TYPE(type->array.type))) {
 		cdata->ptr = old_cdata->ptr_holder;
 	} else if (type->size > old_type->size) {
 		zend_object_release(&cdata->std);

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -3907,6 +3907,9 @@ ZEND_METHOD(FFI, cast) /* {{{ */
 	 && type->kind == ZEND_FFI_TYPE_POINTER) {
 		cdata->ptr = &cdata->ptr_holder;
 		cdata->ptr_holder = old_cdata->ptr;
+	} else if (old_type->kind== ZEND_FFI_TYPE_POINTER
+	 && type->kind == ZEND_FFI_TYPE_ARRAY) {
+		cdata->ptr = old_cdata->ptr_holder;
 	} else if (type->size > old_type->size) {
 		zend_object_release(&cdata->std);
 		zend_throw_error(zend_ffi_exception_ce, "attempt to cast to larger type");

--- a/ext/ffi/tests/gh7867.phpt
+++ b/ext/ffi/tests/gh7867.phpt
@@ -1,0 +1,75 @@
+--TEST--
+GH-7867 (FFI::cast() from pointer to array is broken)
+--SKIPIF--
+<?php
+if (!extension_loaded("ffi")) die("skip ffi extension not available");
+?>
+--FILE--
+<?php
+$value = FFI::new('char[26]');
+FFI::memcpy($value, implode('', range('a', 'z')), 26);
+
+$slice = FFI::new('char[4]');
+
+echo 'cast from start' . PHP_EOL;
+FFI::memcpy($slice, $value, 4);
+var_dump($value + 0, $slice, FFI::cast('char[4]', $value));
+echo PHP_EOL;
+
+echo 'cast with offset' . PHP_EOL;
+FFI::memcpy($slice, $value + 4, 4);
+var_dump($value + 4, $slice, FFI::cast('char[4]', $value + 4));
+echo PHP_EOL;
+?>
+--EXPECTF--
+cast from start
+object(FFI\CData:char*)#%d (1) {
+  [0]=>
+  string(1) "a"
+}
+object(FFI\CData:char[4])#%d (4) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "b"
+  [2]=>
+  string(1) "c"
+  [3]=>
+  string(1) "d"
+}
+object(FFI\CData:char[4])#%d (4) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "b"
+  [2]=>
+  string(1) "c"
+  [3]=>
+  string(1) "d"
+}
+
+cast with offset
+object(FFI\CData:char*)#%d (1) {
+  [0]=>
+  string(1) "e"
+}
+object(FFI\CData:char[4])#%d (4) {
+  [0]=>
+  string(1) "e"
+  [1]=>
+  string(1) "f"
+  [2]=>
+  string(1) "g"
+  [3]=>
+  string(1) "h"
+}
+object(FFI\CData:char[4])#%d (4) {
+  [0]=>
+  string(1) "e"
+  [1]=>
+  string(1) "f"
+  [2]=>
+  string(1) "g"
+  [3]=>
+  string(1) "h"
+}


### PR DESCRIPTION
Casting from pointer to array is special, so we must not fall back to
the general FFI casting.  There is a particular issue regarding the
size comparison, namely that the pointer size is always 8 for 64bit
architectures, but the size of an array is determined by its
declaration, so as is casting a pointer to an array with more than 8
elements would fail, but casting to an array with less than 9 elements
succeeds, but the internal pointer would point to some arbitrary
memory.

We fix this by properly supporting the cast.  An alternative would be
to deny this kind of cast generally, since it is not necessarily safe.
However, FFI isn't necessarily safe anyway.