### PR TITLE
Fix GH-7875: mails are sent even if failure to log throws exception

### DIFF
--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -473,6 +473,10 @@ PHPAPI int php_mail(const char *to, const char *subject, const char *message, co
 		efree(logline);
 	}
 
+	if (EG(exception)) {
+		MAIL_RET(0);
+	}
+
 	if (PG(mail_x_header)) {
 		const char *tmp = zend_get_executed_filename();
 		zend_string *f;

--- a/ext/standard/tests/mail/gh7875.phpt
+++ b/ext/standard/tests/mail/gh7875.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-7875 (mails are sent even if failure to log throws exception)
+--INI--
+sendmail_path={MAIL:{PWD}/gh7875.mail.out}
+mail.log={PWD}/gh7875.mail.log
+--FILE--
+<?php
+function exception_error_handler($severity, $message, $file, $line) {
+    if (!(error_reporting() & $severity)) {
+        return;
+    }
+    throw new ErrorException($message, 0, $severity, $file, $line);
+}
+set_error_handler("exception_error_handler");
+
+touch(__DIR__ . "/gh7875.mail.log");
+chmod(__DIR__ . "/gh7875.mail.log", 0444);
+
+try {
+	$return = mail('recipient@example.com', 'Subject', 'Body', []);
+	var_dump($return);
+} catch (\Exception $e) {
+	echo $e->getMessage(), PHP_EOL;
+    var_dump(file_exists(__DIR__ . "/gh7875.mail.out"));
+}
+?>
+--CLEAN--
+<?php
+@chmod(__DIR__ . "/gh7875.mail.log", 0644);
+@unlink(__DIR__ . "/gh7875.mail.log");
+@unlink(__DIR__ . "/gh7875.mail.out");
+?>
+--EXPECTF--
+mail(%s): Failed to open stream: Permission denied
+bool(false)

--- a/ext/standard/tests/mail/gh7875.phpt
+++ b/ext/standard/tests/mail/gh7875.phpt
@@ -17,8 +17,8 @@ touch(__DIR__ . "/gh7875.mail.log");
 chmod(__DIR__ . "/gh7875.mail.log", 0444);
 
 try {
-	$return = mail('recipient@example.com', 'Subject', 'Body', []);
-	var_dump($return);
+	mail('recipient@example.com', 'Subject', 'Body', []);
+	echo 'Not Reached';
 } catch (\Exception $e) {
 	echo $e->getMessage(), PHP_EOL;
     var_dump(file_exists(__DIR__ . "/gh7875.mail.out"));


### PR DESCRIPTION
We explicitly check for an exception after the logging attempt, and
bail out in that case.