### PR TITLE
Fix GH-7725: Adjust README instructions on referencing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,8 @@ Extension Community Library - [PECL](https://pecl.php.net).
 ## Contributing
 
 The PHP source code is located in the Git repository at
-[git.php.net](https://git.php.net). Contributions are most welcome by forking
-the [GitHub mirror repository](https://github.com/php/php-src) and sending a
-pull request.
+[github.com/php/php-src](https://github.com/php/php-src). Contributions are most
+welcome by forking the repository and sending a pull request.
 
 Discussions are done on GitHub, but depending on the topic can also be relayed
 to the official PHP developer mailing list internals@lists.php.net.
@@ -111,20 +110,14 @@ New features require an RFC and must be accepted by the developers. See
 [Voting on PHP features](https://wiki.php.net/rfc/voting) for more information
 on the process.
 
-Bug fixes **do not** require an RFC but require a bug tracker ticket. Open a
-ticket at [bugs.php.net](https://bugs.php.net) and reference the bug id using
-`#NNNNNN`.
+Bug fixes don't require an RFC. If the bug has a GitHub issue, reference it in
+the commit message using `GH-NNNNNN`. Use `#NNNNNN` for tickets in the old
+[bugs.php.net](https://bugs.php.net) bug tracker.
 
-    Fix #55371: get_magic_quotes_gpc() throws deprecation warning
+    Fix GH-7815: php_uname doesn't recognise latest Windows versions
 
-    After removing magic quotes, the get_magic_quotes_gpc function caused a
-    deprecated warning. get_magic_quotes_gpc can be used to detect the
-    magic_quotes behavior and therefore should not raise a warning at any time.
-    The patch removes this warning.
-
-Pull requests are not merged directly on GitHub. All PRs will be pulled and
-pushed through [git.php.net](https://git.php.net). See
-[Git workflow](https://wiki.php.net/vcs/gitworkflow) for more details.
+See [Git workflow](https://wiki.php.net/vcs/gitworkflow) for details on how pull
+requests are merged.
 
 ### Guidelines for contributors
 


### PR DESCRIPTION
Also remove some references to git.php.net which is not used anymore.