### PR TITLE
Fix zend_observer_fcall_end_all() accessing dangling pointers

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6315,6 +6315,7 @@ static int call_attribute_constructor(
 		dummy_func.type = ZEND_USER_FUNCTION;
 		dummy_func.common.fn_flags =
 			attr->flags & ZEND_ATTRIBUTE_STRICT_TYPES ? ZEND_ACC_STRICT_TYPES : 0;
+		dummy_func.common.fn_flags |= ZEND_ACC_CALL_VIA_TRAMPOLINE;
 		dummy_func.op_array.filename = filename;
 
 		dummy_opline.opcode = ZEND_DO_FCALL;

--- a/ext/zend_test/tests/observer_bug81430_1.phpt
+++ b/ext/zend_test/tests/observer_bug81430_1.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Bug #81430 (Attribute instantiation frame accessing invalid frame pointer)
+--EXTENSIONS--
+zend_test
+--INI--
+memory_limit=20M
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+
+#[\Attribute]
+class A {
+    private $a;
+    public function __construct() {
+    }
+}
+
+#[A]
+function B() {}
+
+$r = new \ReflectionFunction("B");
+call_user_func([$r->getAttributes(A::class)[0], 'newInstance']);
+?>
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init A::__construct() -->
+  <A::__construct>
+  </A::__construct>
+</file '%s'>

--- a/ext/zend_test/tests/observer_bug81430_2.phpt
+++ b/ext/zend_test/tests/observer_bug81430_2.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Bug #81430 (Attribute instantiation leaves dangling execute_data pointer)
+--EXTENSIONS--
+zend_test
+--INI--
+memory_limit=20M
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+
+#[\Attribute]
+class A {
+    public function __construct() {
+        array_map("str_repeat", ["\xFF"], [100000000]); // cause a bailout
+    }
+}
+
+#[A]
+function B() {}
+
+$r = new \ReflectionFunction("B");
+call_user_func([$r->getAttributes(A::class)[0], 'newInstance']);
+?>
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init A::__construct() -->
+  <A::__construct>
+
+Fatal error: Allowed memory size of %d bytes exhausted %s in %s on line %d
+  </A::__construct>
+</file '%s'>


### PR DESCRIPTION
By switching attribute constructor stackframe to be called via trampoline the stack allocation is not causing dangling pointers in the zend_observer API anymore that lead to crashes.

Follow up to https://github.com/php/php-src/pull/7665 and https://github.com/php/php-src/commit/76e2a8380e5e030412e9d565955d011972af8418