### PR TITLE
Fix ODBC tests which may not properly clean up

### DIFF
--- a/ext/odbc/tests/odbc_exec_002.phpt
+++ b/ext/odbc/tests/odbc_exec_002.phpt
@@ -21,11 +21,13 @@ $res = odbc_exec($conn, 'SELECT * FROM FOO');
 var_dump(odbc_fetch_row($res));
 var_dump(odbc_result($res, 'test'));
 var_dump(odbc_fetch_array($res));
-
+?>
+--CLEAN--
+<?php
+require 'config.inc';
+$conn = odbc_connect($dsn, $user, $pass);
 odbc_exec($conn, 'DROP TABLE FOO');
-
 odbc_exec($conn, 'DROP DATABASE odbcTEST');
-
 ?>
 --EXPECT--
 bool(true)

--- a/ext/odbc/tests/odbc_free_result_001.phpt
+++ b/ext/odbc/tests/odbc_free_result_001.phpt
@@ -37,11 +37,13 @@ try {
 } catch (TypeError $e) {
     echo $e->getMessage(), "\n";
 }
-
+?>
+--CLEAN--
+<?php
+require 'config.inc';
+$conn = odbc_connect($dsn, $user, $pass);
 odbc_exec($conn, 'DROP TABLE FOO');
-
 odbc_exec($conn, 'DROP DATABASE odbcTEST');
-
 ?>
 --EXPECT--
 bool(true)


### PR DESCRIPTION
If these tests fail with a fatal error, they won't properly clean up,
which likely causes other tests to fail as (several ODBC tests use the
`odbcTEST` database and tables or stored procedures named `FOO`).  This
is particularly annoying during development, where you would need to
clean up manually.

We fix this by moving the cleanup code to the --CLEAN-- section, so
that this code is executed no matter what.