### PR TITLE
Add "error_log_mode" setting

### DIFF
--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -165,6 +165,7 @@ struct _php_core_globals {
 	char *syslog_ident;
 	bool have_called_openlog;
 	zend_long syslog_filter;
+	zend_long error_log_mode;
 };
 
 

--- a/tests/basic/errorlog_permission.phpt
+++ b/tests/basic/errorlog_permission.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Check permissions for created errorlog file
+--SKIPIF--
+<?php 
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+    die("skip this test on windows");
+}
+?>
+--INI--
+error_log=error_permissions_test.log
+error_log_mode=0600
+--FILE--
+<?php
+
+const LOG_FILENAME='error_permissions_test.log';
+
+try {
+    if (file_exists(LOG_FILENAME)) {
+        unlink(LOG_FILENAME);
+    }
+    $oldMask = umask(0000);
+
+    error_log("hello world");
+
+    assert(file_exists(LOG_FILENAME));
+
+    printf("got permissions=%o\n", fileperms(LOG_FILENAME) & 0777);
+    printf("errorlog contents\n%s", file_get_contents(LOG_FILENAME));
+    
+    umask($oldMask);
+} finally {
+    unlink(LOG_FILENAME);
+}
+?>
+--EXPECTF--
+got permissions=600
+errorlog contents
+[%d-%s-%d %d:%d:%d %s] hello world


### PR DESCRIPTION
We created this patch some while ago (back in 2011 :D) and decided that it is probably worth sharing with the community. Sometimes we might want to set other permissions for the created logfile (e.g. 0664) but umask only allows us to reduce the permissions, not to increase.

I would appreciate it if you give your opinion and tell me if something might be changed