### PR TITLE
Fix GH-7902: mb_send_mail may delimit headers with LF only

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3270,6 +3270,8 @@ PHP_FUNCTION(mb_decode_numericentity)
 		continue;											\
 	}
 
+#define CRLF "\r\n"
+
 static int _php_mbstr_parse_mail_headers(HashTable *ht, const char *str, size_t str_len)
 {
 	const char *ps;
@@ -3601,7 +3603,7 @@ PHP_FUNCTION(mb_send_mail)
 			|| orig_str.encoding->no_encoding == mbfl_no_encoding_pass) {
 		orig_str.encoding = mbfl_identify_encoding(&orig_str, MBSTRG(current_detect_order_list), MBSTRG(current_detect_order_list_size), MBSTRG(strict_detection));
 	}
-	pstr = mbfl_mime_header_encode(&orig_str, &conv_str, tran_cs, head_enc, "\r\n", sizeof("Subject: [PHP-jp nnnnnnnn]") + 1);
+	pstr = mbfl_mime_header_encode(&orig_str, &conv_str, tran_cs, head_enc, CRLF, sizeof("Subject: [PHP-jp nnnnnnnn]" CRLF) - 1);
 	if (pstr != NULL) {
 		subject_buf = subject = (char *)pstr->val;
 	}
@@ -3640,14 +3642,14 @@ PHP_FUNCTION(mb_send_mail)
 		n = ZSTR_LEN(str_headers);
 		mbfl_memory_device_strncat(&device, p, n);
 		if (n > 0 && p[n - 1] != '\n') {
-			mbfl_memory_device_strncat(&device, "\r\n", 2);
+			mbfl_memory_device_strncat(&device, CRLF, sizeof(CRLF)-1);
 		}
 		zend_string_release_ex(str_headers, 0);
 	}
 
 	if (!zend_hash_str_exists(&ht_headers, "MIME-VERSION", sizeof("MIME-VERSION") - 1)) {
 		mbfl_memory_device_strncat(&device, PHP_MBSTR_MAIL_MIME_HEADER1, sizeof(PHP_MBSTR_MAIL_MIME_HEADER1) - 1);
-		mbfl_memory_device_strncat(&device, "\r\n", 2);
+		mbfl_memory_device_strncat(&device, CRLF, sizeof(CRLF)-1);
 	}
 
 	if (!suppressed_hdrs.cnt_type) {
@@ -3658,7 +3660,7 @@ PHP_FUNCTION(mb_send_mail)
 			mbfl_memory_device_strncat(&device, PHP_MBSTR_MAIL_MIME_HEADER3, sizeof(PHP_MBSTR_MAIL_MIME_HEADER3) - 1);
 			mbfl_memory_device_strcat(&device, p);
 		}
-		mbfl_memory_device_strncat(&device, "\r\n", 2);
+		mbfl_memory_device_strncat(&device, CRLF, sizeof(CRLF)-1);
 	}
 	if (!suppressed_hdrs.cnt_trans_enc) {
 		mbfl_memory_device_strncat(&device, PHP_MBSTR_MAIL_MIME_HEADER4, sizeof(PHP_MBSTR_MAIL_MIME_HEADER4) - 1);
@@ -3667,7 +3669,7 @@ PHP_FUNCTION(mb_send_mail)
 			p = "7bit";
 		}
 		mbfl_memory_device_strcat(&device, p);
-		mbfl_memory_device_strncat(&device, "\r\n", 2);
+		mbfl_memory_device_strncat(&device, CRLF, sizeof(CRLF)-1);
 	}
 
 	mbfl_memory_device_unput(&device);
@@ -3708,6 +3710,7 @@ PHP_FUNCTION(mb_send_mail)
 }
 
 #undef SKIP_LONG_HEADER_SEP_MBSTRING
+#undef CRLF
 #undef MAIL_ASCIIZ_CHECK_MBSTRING
 #undef PHP_MBSTR_MAIL_MIME_HEADER1
 #undef PHP_MBSTR_MAIL_MIME_HEADER2

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3601,7 +3601,7 @@ PHP_FUNCTION(mb_send_mail)
 			|| orig_str.encoding->no_encoding == mbfl_no_encoding_pass) {
 		orig_str.encoding = mbfl_identify_encoding(&orig_str, MBSTRG(current_detect_order_list), MBSTRG(current_detect_order_list_size), MBSTRG(strict_detection));
 	}
-	pstr = mbfl_mime_header_encode(&orig_str, &conv_str, tran_cs, head_enc, "\n", sizeof("Subject: [PHP-jp nnnnnnnn]"));
+	pstr = mbfl_mime_header_encode(&orig_str, &conv_str, tran_cs, head_enc, "\r\n", sizeof("Subject: [PHP-jp nnnnnnnn]") + 1);
 	if (pstr != NULL) {
 		subject_buf = subject = (char *)pstr->val;
 	}
@@ -3640,14 +3640,14 @@ PHP_FUNCTION(mb_send_mail)
 		n = ZSTR_LEN(str_headers);
 		mbfl_memory_device_strncat(&device, p, n);
 		if (n > 0 && p[n - 1] != '\n') {
-			mbfl_memory_device_strncat(&device, "\n", 1);
+			mbfl_memory_device_strncat(&device, "\r\n", 2);
 		}
 		zend_string_release_ex(str_headers, 0);
 	}
 
 	if (!zend_hash_str_exists(&ht_headers, "MIME-VERSION", sizeof("MIME-VERSION") - 1)) {
 		mbfl_memory_device_strncat(&device, PHP_MBSTR_MAIL_MIME_HEADER1, sizeof(PHP_MBSTR_MAIL_MIME_HEADER1) - 1);
-		mbfl_memory_device_strncat(&device, "\n", 1);
+		mbfl_memory_device_strncat(&device, "\r\n", 2);
 	}
 
 	if (!suppressed_hdrs.cnt_type) {
@@ -3658,7 +3658,7 @@ PHP_FUNCTION(mb_send_mail)
 			mbfl_memory_device_strncat(&device, PHP_MBSTR_MAIL_MIME_HEADER3, sizeof(PHP_MBSTR_MAIL_MIME_HEADER3) - 1);
 			mbfl_memory_device_strcat(&device, p);
 		}
-		mbfl_memory_device_strncat(&device, "\n", 1);
+		mbfl_memory_device_strncat(&device, "\r\n", 2);
 	}
 	if (!suppressed_hdrs.cnt_trans_enc) {
 		mbfl_memory_device_strncat(&device, PHP_MBSTR_MAIL_MIME_HEADER4, sizeof(PHP_MBSTR_MAIL_MIME_HEADER4) - 1);
@@ -3667,9 +3667,10 @@ PHP_FUNCTION(mb_send_mail)
 			p = "7bit";
 		}
 		mbfl_memory_device_strcat(&device, p);
-		mbfl_memory_device_strncat(&device, "\n", 1);
+		mbfl_memory_device_strncat(&device, "\r\n", 2);
 	}
 
+	mbfl_memory_device_unput(&device);
 	mbfl_memory_device_unput(&device);
 	mbfl_memory_device_output('\0', &device);
 	str_headers = zend_string_init((char *)device.buffer, strlen((char *)device.buffer), 0);

--- a/ext/mbstring/tests/gh7902.phpt
+++ b/ext/mbstring/tests/gh7902.phpt
@@ -22,11 +22,11 @@ mb_send_mail($to, $subject, $message, $header);
 $stream = fopen(__DIR__ . "/gh7902.eml", "rb");
 $eml = stream_get_contents($stream);
 fclose($stream);
-var_dump(preg_match('/BASE64\r\n/', $eml));
+var_dump(preg_match_all('/(?<!\r)\n/', $eml));
 ?>
 --CLEAN--
 <?php
 @unlink(__DIR__ . "/gh7902.eml");
 ?>
 --EXPECT--
-int(1)
+int(0)

--- a/ext/mbstring/tests/gh7902.phpt
+++ b/ext/mbstring/tests/gh7902.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-7902 (mb_send_mail may delimit headers with LF only)
+--SKIPIF--
+<?php
+if (!extension_loaded("mbstring")) die("skip mbstring extension not available");
+?>
+--INI--
+sendmail_path={MAIL:{PWD}/gh7902.eml}
+--FILE--
+<?php
+mb_internal_encoding("UTF-8");
+mb_language("uni");
+$to = "omittedvalidaddress@example.com";
+$subject = "test mail";
+$message = "body of testing php mail";
+$header["Mime-Version"] = "1.0";
+$header["Content-Type"] = "text/html; charset=UTF-8";
+$header["From"] = "omittedvalidaddress2@example.com";
+$header["X-Mailer"] = "PHP/" . phpversion();
+mb_send_mail($to, $subject, $message, $header);
+
+$stream = fopen(__DIR__ . "/gh7902.eml", "rb");
+$eml = stream_get_contents($stream);
+fclose($stream);
+var_dump(preg_match('/BASE64\r\n/', $eml));
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/gh7902.eml");
+?>
+--EXPECT--
+int(1)


### PR DESCRIPTION
Email headers are supposed to be separated with CRLF. Period.