### PR TITLE
Run mb_send_mail tests on Windows, too

### DIFF
--- a/ext/mbstring/tests/bug52681.phpt
+++ b/ext/mbstring/tests/bug52681.phpt
@@ -4,15 +4,12 @@ Bug #52681 (mb_send_mail() appends an extra MIME-Version header)
 mbstring
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 if (!function_exists("mb_send_mail") || !mb_language("neutral")) {
     die("skip mb_send_mail() not available");
 }
 ?>
 --INI--
-sendmail_path=/bin/cat
+sendmail_path={MAIL:{PWD}/bug52681.eml}
 mail.add_x_header=off
 --FILE--
 <?php
@@ -20,6 +17,12 @@ $to = 'example@example.com';
 $headers = 'MIME-Version: 2.0';
 
 mb_send_mail($to, mb_language(), "test", $headers);
+
+readfile(__DIR__ . "/bug52681.eml");
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/bug52681.eml");
 ?>
 --EXPECTF--
 To: example@example.com

--- a/ext/mbstring/tests/mb_send_mail01.phpt
+++ b/ext/mbstring/tests/mb_send_mail01.phpt
@@ -4,15 +4,12 @@ mb_send_mail() test 1 (lang=neutral)
 mbstring
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 if (!function_exists("mb_send_mail") || !mb_language("neutral")) {
     die("skip mb_send_mail() not available");
 }
 ?>
 --INI--
-sendmail_path=/bin/cat
+sendmail_path={MAIL:{PWD}/mb_send_mail01.eml}
 mail.add_x_header=off
 --FILE--
 <?php
@@ -20,12 +17,18 @@ $to = 'example@example.com';
 
 /* default setting */
 mb_send_mail($to, mb_language(), "test");
+readfile(__DIR__ . "/mb_send_mail01.eml");
 
 /* neutral (UTF-8) */
 if (mb_language("neutral")) {
     mb_internal_encoding("UTF-8");
     mb_send_mail($to, "test ".mb_language(), "test");
+    readfile(__DIR__ . "/mb_send_mail01.eml");
 }
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/mb_send_mail01.eml");
 ?>
 --EXPECTF--
 To: example@example.com

--- a/ext/mbstring/tests/mb_send_mail02.phpt
+++ b/ext/mbstring/tests/mb_send_mail02.phpt
@@ -4,15 +4,12 @@ mb_send_mail() test 2 (lang=Japanese)
 mbstring
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 if (!function_exists("mb_send_mail") || !mb_language("japanese")) {
     die("skip mb_send_mail() not available");
 }
 ?>
 --INI--
-sendmail_path=/bin/cat
+sendmail_path={MAIL:{PWD}/mb_send_mail02.eml}
 mail.add_x_header=off
 --FILE--
 <?php
@@ -20,12 +17,18 @@ $to = 'example@example.com';
 
 /* default setting */
 mb_send_mail($to, mb_language(), "test");
+readfile(__DIR__ . "/mb_send_mail02.eml");
 
 /* Japanese (EUC-JP) */
 if (mb_language("japanese")) {
     mb_internal_encoding('EUC-JP');
     mb_send_mail($to, "テスト ".mb_language(), "テスト");
+    readfile(__DIR__ . "/mb_send_mail02.eml");
 }
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/mb_send_mail02.eml");
 ?>
 --EXPECTF--
 To: example@example.com

--- a/ext/mbstring/tests/mb_send_mail03.phpt
+++ b/ext/mbstring/tests/mb_send_mail03.phpt
@@ -4,15 +4,12 @@ mb_send_mail() test 3 (lang=English)
 mbstring
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 if (!function_exists("mb_send_mail") || !mb_language("english")) {
     die("skip mb_send_mail() not available");
 }
 ?>
 --INI--
-sendmail_path=/bin/cat
+sendmail_path={MAIL:{PWD}/mb_send_mail03.eml}
 mail.add_x_header=off
 --FILE--
 <?php
@@ -20,12 +17,18 @@ $to = 'example@example.com';
 
 /* default setting */
 mb_send_mail($to, mb_language(), "test");
+readfile(__DIR__ . "/mb_send_mail03.eml");
 
 /* English (iso-8859-1) */
 if (mb_language("english")) {
     mb_internal_encoding("ISO-8859-1");
     mb_send_mail($to, "test ".mb_language(), "test");
+    readfile(__DIR__ . "/mb_send_mail03.eml");
 }
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/mb_send_mail03.eml");
 ?>
 --EXPECTF--
 To: example@example.com

--- a/ext/mbstring/tests/mb_send_mail04.phpt
+++ b/ext/mbstring/tests/mb_send_mail04.phpt
@@ -4,15 +4,12 @@ mb_send_mail() test 4 (lang=German)
 mbstring
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 if (!function_exists("mb_send_mail") || !mb_language("german")) {
     die("skip mb_send_mail() not available");
 }
 ?>
 --INI--
-sendmail_path=/bin/cat
+sendmail_path={MAIL:{PWD}/mb_send_mail04.eml}
 mail.add_x_header=off
 --FILE--
 <?php
@@ -20,12 +17,18 @@ $to = 'example@example.com';
 
 /* default setting */
 mb_send_mail($to, mb_language(), "test");
+readfile(__DIR__ . "/mb_send_mail04.eml");
 
 /* German (iso-8859-15) */
 if (mb_language("german")) {
     mb_internal_encoding("ISO-8859-15");
     mb_send_mail($to, "Pr"."\xfc"."fung ".mb_language(), "Pr"."\xfc"."fung");
+    readfile(__DIR__ . "/mb_send_mail04.eml");
 }
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/mb_send_mail04.eml");
 ?>
 --EXPECTF--
 To: example@example.com

--- a/ext/mbstring/tests/mb_send_mail05.phpt
+++ b/ext/mbstring/tests/mb_send_mail05.phpt
@@ -4,9 +4,6 @@ mb_send_mail() test 5 (lang=Simplified Chinese)
 mbstring
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 if (!function_exists("mb_send_mail") || !mb_language("Simplified Chinese")) {
     die("skip mb_send_mail() not available");
 }
@@ -15,7 +12,7 @@ if (!@mb_internal_encoding('GB2312')) {
 }
 ?>
 --INI--
-sendmail_path=/bin/cat
+sendmail_path={MAIL:{PWD}/mb_send_mail05.eml}
 mail.add_x_header=off
 --FILE--
 <?php
@@ -23,12 +20,18 @@ $to = 'example@example.com';
 
 /* default setting */
 mb_send_mail($to, mb_language(), "test");
+readfile(__DIR__ . "/mb_send_mail05.eml");
 
 /* Simplified Chinese (HK-GB-2312) */
 if (mb_language("simplified chinese")) {
     mb_internal_encoding('GB2312');
     mb_send_mail($to, "Втбщ ".mb_language(), "Втбщ");
+    readfile(__DIR__ . "/mb_send_mail05.eml");
 }
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/mb_send_mail05.eml");
 ?>
 --EXPECTF--
 To: example@example.com

--- a/ext/mbstring/tests/mb_send_mail06.phpt
+++ b/ext/mbstring/tests/mb_send_mail06.phpt
@@ -4,9 +4,6 @@ mb_send_mail() test 6 (lang=Traditional Chinese)
 mbstring
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 if (!function_exists("mb_send_mail") || !mb_language("Traditional Chinese")) {
     die("skip mb_send_mail() not available");
 }
@@ -15,7 +12,7 @@ if (!@mb_internal_encoding('BIG5')) {
 }
 ?>
 --INI--
-sendmail_path=/bin/cat
+sendmail_path={MAIL:{PWD}/mb_send_mail06.eml}
 mail.add_x_header=off
 --FILE--
 <?php
@@ -23,12 +20,18 @@ $to = 'example@example.com';
 
 /* default setting */
 mb_send_mail($to, mb_language(), "test");
+readfile(__DIR__ . "/mb_send_mail06.eml");
 
 /* Traditional Chinese () */
 if (mb_language("traditional chinese")) {
     mb_internal_encoding('BIG5');
     mb_send_mail($to, "´úÅç ".mb_language(), "´úÅç");
+    readfile(__DIR__ . "/mb_send_mail06.eml");
 }
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/mb_send_mail06.eml");
 ?>
 --EXPECTF--
 To: example@example.com

--- a/ext/mbstring/tests/mb_send_mail07.phpt
+++ b/ext/mbstring/tests/mb_send_mail07.phpt
@@ -4,9 +4,6 @@ mb_send_mail() test 7 (lang=Korean)
 mbstring
 --SKIPIF--
 <?php
-if (substr(PHP_OS, 0, 3) == 'WIN') {
-    die('skip.. Not valid for Windows');
-}
 if (!function_exists("mb_send_mail") || !mb_language("Korean")) {
     die("skip mb_send_mail() not available");
 }
@@ -15,7 +12,7 @@ if (!@mb_internal_encoding('ISO-2022-KR')) {
 }
 ?>
 --INI--
-sendmail_path=/bin/cat
+sendmail_path={MAIL:{PWD}/mb_send_mail07.eml}
 mail.add_x_header=off
 --FILE--
 <?php
@@ -23,12 +20,18 @@ $to = 'example@example.com';
 
 /* default setting */
 mb_send_mail($to, mb_language(), "test");
+readfile(__DIR__ . "/mb_send_mail07.eml");
 
 /* Korean */
 if (mb_language("korean")) {
     mb_internal_encoding('EUC-KR');
     mb_send_mail($to, "테스트 ".mb_language(), "테스트");
+    readfile(__DIR__ . "/mb_send_mail07.eml");
 }
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/mb_send_mail07.eml");
 ?>
 --EXPECTF--
 To: example@example.com


### PR DESCRIPTION
We use the run-tests.php `{MAIL}` abstraction instead of `cat`.