### PR TITLE
pcntl_rfork build fix for DragonFlyBSD.

### DIFF
--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1528,9 +1528,11 @@ PHP_FUNCTION(pcntl_rfork)
 		flags |= RFPROC;
 	}
 
+#ifdef RFTSIGZMB
 	if ((flags & RFTSIGZMB) != 0) {
 		flags |= RFTSIGFLAGS(csignal);
 	}
+#endif
 
 	pid = rfork(flags);
 


### PR DESCRIPTION
RFTSIGZMB flag unsupported, guarding with the said flag instead of system
in case the implementaion catches up with FreeBSD's.