### PR TITLE
[SPL] Prevent fclose on underlying SplFileObject file stream.

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -333,6 +333,9 @@ static zend_result spl_filesystem_file_open(spl_filesystem_object *intern, bool 
 		return FAILURE;
 	}
 
+	/* prevent closing the stream outside of SplFileObject */
+	intern->u.file.stream->flags |= PHP_STREAM_FLAG_NO_FCLOSE;
+
 	/*
 	if (intern->u.file.zcontext) {
 		//zend_list_addref(Z_RES_VAL(intern->u.file.zcontext));

--- a/ext/spl/tests/bug81691.phpt
+++ b/ext/spl/tests/bug81691.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Bug #81691 fclose on SplFileObject stream
+--FILE--
+<?php
+$obj = new SplFileObject(__FILE__);
+$resources = get_resources();
+fclose(end($resources));
+
+var_dump($obj->fgets());
+
+?>
+--EXPECTF--
+Warning: fclose(): %d is not a valid stream resource in %s on line %d
+string(6) "<?php
+"


### PR DESCRIPTION
To address https://bugs.php.net/bug.php?id=81691

I'm not sure if this is the correct way to address this issue, hence the draft PR.