### PR TITLE
Fix #71868: Environment variables with no value are filtered out by proc_open()

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -164,11 +164,6 @@ static php_process_env _php_array_to_envp(zval *environment)
 	ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(environment), key, element) {
 		str = zval_get_string(element);
 
-		if (ZSTR_LEN(str) == 0) {
-			zend_string_release_ex(str, 0);
-			continue;
-		}
-
 		sizeenv += ZSTR_LEN(str) + 1;
 
 		if (key && ZSTR_LEN(key)) {

--- a/ext/standard/tests/general_functions/bug71868.inc
+++ b/ext/standard/tests/general_functions/bug71868.inc
@@ -1,0 +1,4 @@
+<?php
+var_dump(isset($_SERVER['FOO']));
+var_dump($_SERVER['FOO']);
+?>

--- a/ext/standard/tests/general_functions/bug71868.phpt
+++ b/ext/standard/tests/general_functions/bug71868.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug #71868: Environment variables with no value are filtered out by proc_open()
+--SKIPIF--
+<?php
+if (!function_exists('proc_open')) die('skip proc_open() not available');
+?>
+--FILE--
+<?php
+$callee = __DIR__ . DIRECTORY_SEPARATOR . "bug71868.inc";
+$php = getenv('TEST_PHP_EXECUTABLE');
+$cmd = "$php -n $callee";
+
+$descriptors = array();
+$pipes = array();
+
+$cwd = __DIR__;
+$env = array('FOO' => '');
+
+$process = proc_open($cmd, $descriptors, $pipes, $cwd, $env);
+proc_close($process);
+?>
+--EXPECT--
+bool(true)
+string(0) ""


### PR DESCRIPTION
Remove empty value check from _php_array_to_envp (introduced in 7e92f63)