### PR TITLE
Fix GH-7896: Environment vars may be mangled on Windows

### DIFF
--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -571,11 +571,15 @@ void _php_import_environment_variables(zval *array_ptr)
 		import_environment_variable(Z_ARRVAL_P(array_ptr), *env);
 	}
 #else
-	char *environment = GetEnvironmentStringsA();
-	for (char *env = environment; env != NULL && *env; env += strlen(env) + 1) {
-		import_environment_variable(Z_ARRVAL_P(array_ptr), env);
+	wchar_t *environmentw = GetEnvironmentStringsW();
+	for (wchar_t *envw = environmentw; envw != NULL && *envw; envw += wcslen(envw) + 1) {
+		char *env = php_win32_cp_w_to_any(envw);
+		if (env != NULL) {
+			import_environment_variable(Z_ARRVAL_P(array_ptr), env);
+			free(env);
+		}
 	}
-	FreeEnvironmentStringsA(environment);
+	FreeEnvironmentStringsW(environmentw);
 #endif
 
 	tsrm_env_unlock();

--- a/tests/basic/gh7896.phpt
+++ b/tests/basic/gh7896.phpt
@@ -1,5 +1,9 @@
 --TEST--
 GH-7896 (Environment vars may be mangled on Windows)
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY !== "Windows") die("skip for Windows only");
+?>
 --ENV--
 FÖÖ=GüИter传
 --FILE--

--- a/tests/basic/gh7896.phpt
+++ b/tests/basic/gh7896.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-7896 (Environment vars may be mangled on Windows)
+--ENV--
+FÖÖ=GüИter传
+--FILE--
+<?php
+var_dump(
+    $_SERVER['FÖÖ'],
+    $_ENV['FÖÖ'],
+    getenv('FÖÖ')
+);
+?>
+--EXPECT--
+string(11) "GüИter传"
+string(11) "GüИter传"
+string(11) "GüИter传"


### PR DESCRIPTION
When bug 77574[1] has been fixed, the fix only catered to variables
retrieved via `getenv()` with a `$varname` passed, but neither to
`getenv()` without arguments nor to the general import of environment
variables into `$_ENV` and `$_SERVER`.  We catch up on this by using
`GetEnvironmentStringsW()` in `_php_import_environment_variables()` and
converting the encoding to whatever had been chosen by the user.

[1] <https://bugs.php.net/bug.php?id=75574>