### PR TITLE
Fix GH-7910: rename fails on Windows if the target is being executed

### DIFF
--- a/Zend/tests/gh7910.phpt
+++ b/Zend/tests/gh7910.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-7910 (rename fails on Windows if the target is being executed)
+--FILE--
+<?php
+$content = file_get_contents(__FILE__);
+file_put_contents(__DIR__ . "/gh7910.php.bak", $content);
+var_dump(rename(__DIR__ . "/gh7910.php.bak", __FILE__));
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/gh7910.php.bak");
+?>
+--EXPECT--
+bool(true)

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1750,6 +1750,9 @@ ZEND_API zend_result zend_execute_scripts(int type, zval *retval, int file_count
 		}
 
 		if (ret == FAILURE) {
+			/* If a failure occurred in one of the earlier files,
+			 * only destroy the following file handles. */
+			zend_destroy_file_handle(file_handle);
 			continue;
 		}
 

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1757,6 +1757,7 @@ ZEND_API zend_result zend_execute_scripts(int type, zval *retval, int file_count
 		if (file_handle->opened_path) {
 			zend_hash_add_empty_element(&EG(included_files), file_handle->opened_path);
 		}
+		zend_destroy_file_handle(file_handle);
 		if (op_array) {
 			zend_execute(op_array, retval);
 			zend_exception_restore();

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -613,7 +613,6 @@ static int readline_shell_run(void) /* {{{ */
 
 		zend_stream_init_filename(&prepend_file, PG(auto_prepend_file));
 		zend_execute_scripts(ZEND_REQUIRE, NULL, 1, &prepend_file);
-		zend_destroy_file_handle(&prepend_file);
 	}
 
 #ifndef PHP_WIN32

--- a/main/main.c
+++ b/main/main.c
@@ -2535,14 +2535,6 @@ PHPAPI int php_execute_script(zend_file_handle *primary_file)
 		retval = (zend_execute_scripts(ZEND_REQUIRE, NULL, 3, prepend_file_p, primary_file, append_file_p) == SUCCESS);
 	} zend_end_try();
 
-	if (prepend_file_p) {
-		zend_destroy_file_handle(prepend_file_p);
-	}
-
-	if (append_file_p) {
-		zend_destroy_file_handle(append_file_p);
-	}
-
 	if (EG(exception)) {
 		zend_try {
 			zend_exception_error(EG(exception), E_ERROR);

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -706,7 +706,6 @@ zend_first_try {
 		} else {
 			zend_execute_scripts(ZEND_INCLUDE, NULL, 1, &zfd);
 		}
-		zend_destroy_file_handle(&zfd);
 
 		apr_table_set(r->notes, "mod_php_memory_usage",
 			apr_psprintf(ctx->r->pool, "%" APR_SIZE_T_FMT, zend_memory_peak_usage(1)));


### PR DESCRIPTION
Prior to commit c732ab4[1], the script file was closed immediately
after compilation, what made it possible to replace that file with
another one on Windows (e.g. for hot patching).  This is no longer
possible, since even opening the file with `FILE_SHARE_DELETE`
semantics does not allow to have it as target of `rename()`.

Thus, we revert this part of the `zend_string` refactoring of the Zend
stream API.

[1] <https://github.com/php/php-src/commit/c732ab400af92c54eee47c487a56009f1d79dd5d>

---

So far this patch is incomplete, because it may cause double closing of the file, but before fixing this, I want to make sure that the new close behavior is not something that has been done deliberately for some particular reason. @dstogov?