### PR TITLE
Use posix_spawn for proc_open when supported by OS

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -376,6 +376,8 @@ dnl
 
 PHP_CHECK_FUNC(res_search, resolv, bind, socket)
 
+PHP_CHECK_FUNC(posix_spawn_file_actions_addchdir_np)
+
 dnl
 dnl Check for strptime()
 dnl


### PR DESCRIPTION
Hello folks: long time no see.. I have some local patches that I wish to get off my sleeve..

- proc_open([""], $descriptorspec, $pipes, $cwd, $env) should result in an error, there must be at least one non-empty element as a program name to execute

- proc_open should use posix_spawn on newish operating system versions where it is significantly fast and uses less memory than the fork/exec path, this is probably going to be a highly noticeable imrpovement on systems where posix_spawn is a syscall.