### PR TITLE
Fix GH-7939: Cannot unserialize IntlTimeZone objects

### DIFF
--- a/ext/intl/breakiterator/breakiterator.stub.php
+++ b/ext/intl/breakiterator/breakiterator.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class IntlBreakIterator implements IteratorAggregate
 {
     /** @tentative-return-type */
@@ -69,6 +70,7 @@ class IntlBreakIterator implements IteratorAggregate
     public function getIterator(): Iterator {}
 }
 
+/** @not-serializable */
 class IntlRuleBasedBreakIterator extends IntlBreakIterator
 {
     public function __construct(string $rules, bool $compiled = false) {}
@@ -86,6 +88,7 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator
     public function getRuleStatusVec(): array|false {}
 }
 
+/** @not-serializable */
 class IntlCodePointBreakIterator extends IntlBreakIterator
 {
     /** @tentative-return-type */

--- a/ext/intl/breakiterator/breakiterator_arginfo.h
+++ b/ext/intl/breakiterator/breakiterator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1979da7ee2fa55b27f1c91bb4e0ddc37e8505b08 */
+ * Stub hash: 724e0c36ee113b67906cc9a8cea23781f0a961bf */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_IntlBreakIterator_createCharacterInstance, 0, 0, IntlBreakIterator, 1)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, locale, IS_STRING, 1, "null")
@@ -161,6 +161,7 @@ static zend_class_entry *register_class_IntlBreakIterator(zend_class_entry *clas
 
 	INIT_CLASS_ENTRY(ce, "IntlBreakIterator", class_IntlBreakIterator_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 	zend_class_implements(class_entry, 1, class_entry_IteratorAggregate);
 
 	return class_entry;
@@ -172,6 +173,7 @@ static zend_class_entry *register_class_IntlRuleBasedBreakIterator(zend_class_en
 
 	INIT_CLASS_ENTRY(ce, "IntlRuleBasedBreakIterator", class_IntlRuleBasedBreakIterator_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_IntlBreakIterator);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }
@@ -182,6 +184,7 @@ static zend_class_entry *register_class_IntlCodePointBreakIterator(zend_class_en
 
 	INIT_CLASS_ENTRY(ce, "IntlCodePointBreakIterator", class_IntlCodePointBreakIterator_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_IntlBreakIterator);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/breakiterator/breakiterator_iterators.stub.php
+++ b/ext/intl/breakiterator/breakiterator_iterators.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class IntlPartsIterator extends IntlIterator
 {
     /** @tentative-return-type */

--- a/ext/intl/breakiterator/breakiterator_iterators_arginfo.h
+++ b/ext/intl/breakiterator/breakiterator_iterators_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 267199a0a3532b5acf1d700f14329cdb2f2db0e1 */
+ * Stub hash: f72f108e37541ac042bb25249ef226211c344189 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_IntlPartsIterator_getBreakIterator, 0, 0, IntlBreakIterator, 0)
 ZEND_END_ARG_INFO()
@@ -24,6 +24,7 @@ static zend_class_entry *register_class_IntlPartsIterator(zend_class_entry *clas
 
 	INIT_CLASS_ENTRY(ce, "IntlPartsIterator", class_IntlPartsIterator_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_IntlIterator);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/calendar/calendar.stub.php
+++ b/ext/intl/calendar/calendar.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class IntlCalendar
 {
     private function __construct() {}
@@ -281,6 +282,7 @@ class IntlCalendar
     public function toDateTime(): DateTime|false {}
 }
 
+/** @not-serializable */
 class IntlGregorianCalendar extends IntlCalendar
 {
     /**

--- a/ext/intl/calendar/calendar_arginfo.h
+++ b/ext/intl/calendar/calendar_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7be0e49d2b898587c4bbefaaf613932ae4786c52 */
+ * Stub hash: 0096dc9e60e2256054d23344e024df1d6527a5fa */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -291,6 +291,7 @@ static zend_class_entry *register_class_IntlCalendar(void)
 
 	INIT_CLASS_ENTRY(ce, "IntlCalendar", class_IntlCalendar_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }
@@ -301,6 +302,7 @@ static zend_class_entry *register_class_IntlGregorianCalendar(zend_class_entry *
 
 	INIT_CLASS_ENTRY(ce, "IntlGregorianCalendar", class_IntlGregorianCalendar_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_IntlCalendar);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/collator/collator.stub.php
+++ b/ext/intl/collator/collator.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class Collator
 {
     public function __construct(string $locale) {}

--- a/ext/intl/collator/collator_arginfo.h
+++ b/ext/intl/collator/collator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4baf9586ab91f37facc865cf1b3aa6a87e5d732d */
+ * Stub hash: c2e08f16cdc3d64e82fc277b4a59250d4b19c84e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Collator___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -96,6 +96,7 @@ static zend_class_entry *register_class_Collator(void)
 
 	INIT_CLASS_ENTRY(ce, "Collator", class_Collator_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/common/common.stub.php
+++ b/ext/intl/common/common.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class IntlIterator implements Iterator
 {
     /** @tentative-return-type */

--- a/ext/intl/common/common_arginfo.h
+++ b/ext/intl/common/common_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c4698dbe96a069a63265052e9a105f074e3dda0a */
+ * Stub hash: 976f2d1417928226d6c04ff444c4feda152d91df */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_IntlIterator_current, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
@@ -37,6 +37,7 @@ static zend_class_entry *register_class_IntlIterator(zend_class_entry *class_ent
 
 	INIT_CLASS_ENTRY(ce, "IntlIterator", class_IntlIterator_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 	zend_class_implements(class_entry, 1, class_entry_Iterator);
 
 	return class_entry;

--- a/ext/intl/converter/converter.stub.php
+++ b/ext/intl/converter/converter.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class UConverter
 {
     public function __construct(?string $destination_encoding = null, ?string $source_encoding = null) {}

--- a/ext/intl/converter/converter_arginfo.h
+++ b/ext/intl/converter/converter_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2a6d8499e1a2d414130e366783a1c084f47a3293 */
+ * Stub hash: 0ab2d741996611bbfcfb07462bc184a02f353585 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_UConverter___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, destination_encoding, IS_STRING, 1, "null")
@@ -125,6 +125,7 @@ static zend_class_entry *register_class_UConverter(void)
 
 	INIT_CLASS_ENTRY(ce, "UConverter", class_UConverter_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/dateformat/dateformat.stub.php
+++ b/ext/intl/dateformat/dateformat.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class IntlDateFormatter
 {
     /**

--- a/ext/intl/dateformat/dateformat_arginfo.h
+++ b/ext/intl/dateformat/dateformat_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 82f90e7b0528b2b3515c086763dba4de0f92dfa7 */
+ * Stub hash: c7c0d08433ab9dbf59777072550895d85294aad4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDateFormatter___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
@@ -141,6 +141,7 @@ static zend_class_entry *register_class_IntlDateFormatter(void)
 
 	INIT_CLASS_ENTRY(ce, "IntlDateFormatter", class_IntlDateFormatter_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/dateformat/datepatterngenerator.stub.php
+++ b/ext/intl/dateformat/datepatterngenerator.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class IntlDatePatternGenerator
 {
     public function __construct(?string $locale = null) {}

--- a/ext/intl/dateformat/datepatterngenerator_arginfo.h
+++ b/ext/intl/dateformat/datepatterngenerator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 74026c524046787844da9f8132029735243176c6 */
+ * Stub hash: 4456b13f7ed59847bbf129cd45b0d1f63ce70108 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlDatePatternGenerator___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, locale, IS_STRING, 1, "null")
@@ -32,6 +32,7 @@ static zend_class_entry *register_class_IntlDatePatternGenerator(void)
 
 	INIT_CLASS_ENTRY(ce, "IntlDatePatternGenerator", class_IntlDatePatternGenerator_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/msgformat/msgformat.stub.php
+++ b/ext/intl/msgformat/msgformat.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class MessageFormatter
 {
     public function __construct(string $locale, string $pattern) {}

--- a/ext/intl/msgformat/msgformat_arginfo.h
+++ b/ext/intl/msgformat/msgformat_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 44bc7b87c0b6c674bf94764b3f036006e3933713 */
+ * Stub hash: d595f5c582996ebb96ab39df8cb56c4cf6c8dfcf */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_MessageFormatter___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 0)
@@ -81,6 +81,7 @@ static zend_class_entry *register_class_MessageFormatter(void)
 
 	INIT_CLASS_ENTRY(ce, "MessageFormatter", class_MessageFormatter_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/resourcebundle/resourcebundle.stub.php
+++ b/ext/intl/resourcebundle/resourcebundle.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class ResourceBundle implements IteratorAggregate, Countable
 {
     public function __construct(?string $locale, ?string $bundle, bool $fallback = true) {}

--- a/ext/intl/resourcebundle/resourcebundle_arginfo.h
+++ b/ext/intl/resourcebundle/resourcebundle_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d27fa5a4dc092b94e48fc876070f440c247fa6c2 */
+ * Stub hash: 7816536650d8513ef6998233096b0bf6a29d7af4 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ResourceBundle___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, locale, IS_STRING, 1)
@@ -62,6 +62,7 @@ static zend_class_entry *register_class_ResourceBundle(zend_class_entry *class_e
 
 	INIT_CLASS_ENTRY(ce, "ResourceBundle", class_ResourceBundle_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 	zend_class_implements(class_entry, 2, class_entry_IteratorAggregate, class_entry_Countable);
 
 	return class_entry;

--- a/ext/intl/spoofchecker/spoofchecker.stub.php
+++ b/ext/intl/spoofchecker/spoofchecker.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class Spoofchecker
 {
     public function __construct() {}

--- a/ext/intl/spoofchecker/spoofchecker_arginfo.h
+++ b/ext/intl/spoofchecker/spoofchecker_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d915fb3698e0bde4af2a1175fff882cae1f55668 */
+ * Stub hash: f1c86958a39aa8f89ee468a0753f6a5b232c3e1f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Spoofchecker___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -58,6 +58,7 @@ static zend_class_entry *register_class_Spoofchecker(void)
 
 	INIT_CLASS_ENTRY(ce, "Spoofchecker", class_Spoofchecker_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/timezone/timezone.stub.php
+++ b/ext/intl/timezone/timezone.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class IntlTimeZone
 {
     private function __construct() {}

--- a/ext/intl/timezone/timezone_arginfo.h
+++ b/ext/intl/timezone/timezone_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3f945431687a2f45b0ec8c3a6435ef68008c75ad */
+ * Stub hash: 2ec7a46ca205dfeb9ef0dc3c8e8d78bce1cf43be */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlTimeZone___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -169,6 +169,7 @@ static zend_class_entry *register_class_IntlTimeZone(void)
 
 	INIT_CLASS_ENTRY(ce, "IntlTimeZone", class_IntlTimeZone_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	return class_entry;
 }

--- a/ext/intl/transliterator/transliterator.stub.php
+++ b/ext/intl/transliterator/transliterator.stub.php
@@ -2,6 +2,7 @@
 
 /** @generate-class-entries */
 
+/** @not-serializable */
 class Transliterator
 {
     public string $id;

--- a/ext/intl/transliterator/transliterator_arginfo.h
+++ b/ext/intl/transliterator/transliterator_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8a6aaab7dd89a014726bd1fdf1f40f7b6fa98ea5 */
+ * Stub hash: 8ef1f285c6138fbc58c1e4cef04d4ac09dfc3fef */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Transliterator___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -61,6 +61,7 @@ static zend_class_entry *register_class_Transliterator(void)
 
 	INIT_CLASS_ENTRY(ce, "Transliterator", class_Transliterator_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);


### PR DESCRIPTION
As it is now, `IntlTimeZone`, `IntlCalendar` and `IntlDateFormatter`
instances can be serialized, but the representation is meaningless, and
unserialization yields uninitialized/unusable objects.  To prevent
users from noticing this too late, we deny serialization of such
objects in the first place.

---

Note that I targetted PHP-8.1 for convenience, and that I didn't check other Intl classes for now which may have the same issue. For now, I'm interested whether we want to go this route (note that any serialization attempt will throw an Error now), or whether we actually want to implement proper (un)serialization for these classes.