### PR TITLE
Reduce stack depth when parsing repeated string concatenation

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -495,7 +495,7 @@ ZEND_API zend_result ZEND_FASTCALL zend_ast_evaluate(zval *result, zend_ast *ast
 		case ZEND_AST_CONCAT_LIST: {
 			/* Handle `a . b . ...` */
 			zend_ast_list *ast_list = (zend_ast_list *)ast;
-			if (UNEXPECTED(zend_ast_evaluate(&op2, ast_list->child[0], scope) != SUCCESS)) {
+			if (UNEXPECTED(zend_ast_evaluate(&op1, ast_list->child[0], scope) != SUCCESS)) {
 				return FAILURE;
 			}
 			zval tmp;

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -66,6 +66,7 @@ enum _zend_ast_kind {
 	ZEND_AST_ATTRIBUTE_LIST,
 	ZEND_AST_ATTRIBUTE_GROUP,
 	ZEND_AST_MATCH_ARM_LIST,
+	ZEND_AST_CONCAT_LIST,
 
 	/* 0 child nodes */
 	ZEND_AST_MAGIC_CONST = 0 << ZEND_AST_NUM_CHILDREN_SHIFT,
@@ -360,6 +361,13 @@ static zend_always_inline zend_ast *zend_ast_create_assign_op(uint32_t opcode, z
 }
 static zend_always_inline zend_ast *zend_ast_create_cast(uint32_t type, zend_ast *op0) {
 	return zend_ast_create_ex(ZEND_AST_CAST, type, op0);
+}
+static zend_always_inline zend_ast *zend_ast_create_concat_list(zend_ast *op0, zend_ast *op1) {
+	if (op0->kind == ZEND_AST_CONCAT_LIST) {
+		/* Reallocate this list with more elements */
+		return zend_ast_list_add(op0, op1);
+	}
+	return zend_ast_create_list_2(ZEND_AST_CONCAT_LIST, op0, op1);
 }
 static zend_always_inline zend_ast *zend_ast_list_rtrim(zend_ast *ast) {
 	zend_ast_list *list = zend_ast_get_list(ast);

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1129,7 +1129,7 @@ expr:
 	|	expr T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_AND, $1, $3); }
 	|	expr T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_AND, $1, $3); }
 	|	expr '^' expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_XOR, $1, $3); }
-	|	expr '.' expr 	{ $$ = zend_ast_create_binary_op(ZEND_CONCAT, $1, $3); }
+	|	expr '.' expr 	{ $$ = zend_ast_create_concat_list($1, $3); }
 	|	expr '+' expr 	{ $$ = zend_ast_create_binary_op(ZEND_ADD, $1, $3); }
 	|	expr '-' expr 	{ $$ = zend_ast_create_binary_op(ZEND_SUB, $1, $3); }
 	|	expr '*' expr	{ $$ = zend_ast_create_binary_op(ZEND_MUL, $1, $3); }


### PR DESCRIPTION
For example, str_repeat("\0", $n) is represented as
`'' . "\0" . '' . "\0" . ...`, and would previously take ~128 bytes per level of recursion
in zend_eval_const_expr according to another issue.
This would make stack overflows more likely.

```
php > $x = eval('return ' . var_export(str_repeat("\0", 100000), true) . ';');
[1]    16259 segmentation fault (core dumped)  php -a
```

This does the following:
1. Instead of generating a deep tree of ZEND_AST_BINARY_OP,
   (`((a . b) . c) . ...`)
   generate a single node of the new kind ZEND_AST_CONCAT_LIST of size 2 or more.
2. When generating opcodes, generate a balanced tree instead of a linear depth
   tree (e.g. for 1024 concatenations, this would only have depth 11).

Changing the internal representation of the AST may cause issues with third
party extensions or incompatibilities between opcache bytecode in patch
releases, so this targets php 8.2 instead.
(I think opcache can store that ast kind in IS_CONSTANT_AST)
(nikic/php-ast is the only third party extension using ast directly
that I know of)

Closes GH-7946