### PR TITLE
Merge concatenated literal strings while compiling.

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -424,18 +424,12 @@ zend_ast *zend_ast_create_concat_op(zend_ast *op0, zend_ast *op1) {
 	if (op0->kind == ZEND_AST_ZVAL && op1->kind == ZEND_AST_ZVAL) {
 		zval *zv0 = zend_ast_get_zval(op0);
 		zval *zv1 = zend_ast_get_zval(op1);
-		if (zend_binary_op_produces_error(ZEND_CONCAT, zv0, zv1)) {
-			goto create_binary_op;
+		if (!zend_binary_op_produces_error(ZEND_CONCAT, zv0, zv1) &&
+				concat_function(zv0, zv0, zv1) == SUCCESS) {
+			zval_ptr_dtor_nogc(zv1);
+			return zend_ast_create_zval(zv0);
 		}
-
-		/* concat_function is optimized for result == op1 and will extend the already created string. */
-		if (concat_function(zv0, zv0, zv1) == FAILURE) {
-			goto create_binary_op;
-		}
-		zval_ptr_dtor_nogc(zv1);
-		return zend_ast_create_zval(zv0);
 	}
-create_binary_op:
 	return zend_ast_create_binary_op(ZEND_CONCAT, op0, op1);
 }
 

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -421,22 +421,22 @@ ZEND_API zend_ast *zend_ast_create_list(uint32_t init_children, zend_ast_kind ki
 #endif
 
 zend_ast *zend_ast_create_concat_op(zend_ast *op0, zend_ast *op1) {
-	zend_ast *result = zend_ast_create_binary_op(ZEND_CONCAT, op0, op1);
 	if (op0->kind == ZEND_AST_ZVAL && op1->kind == ZEND_AST_ZVAL) {
 		zval *zv0 = zend_ast_get_zval(op0);
 		zval *zv1 = zend_ast_get_zval(op1);
 		if (zend_binary_op_produces_error(ZEND_CONCAT, zv0, zv1)) {
-			return result;
+			goto create_binary_op;
 		}
 
 		/* concat_function is optimized for result == op1 and will extend the already created string. */
 		if (concat_function(zv0, zv0, zv1) == FAILURE) {
-			return result;
+			goto create_binary_op;
 		}
 		zval_ptr_dtor_nogc(zv1);
 		return zend_ast_create_zval(zv0);
 	}
-	return result;
+create_binary_op:
+	return zend_ast_create_binary_op(ZEND_CONCAT, op0, op1);
 }
 
 static inline bool is_power_of_two(uint32_t n) {

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -420,6 +420,25 @@ ZEND_API zend_ast *zend_ast_create_list(uint32_t init_children, zend_ast_kind ki
 }
 #endif
 
+zend_ast *zend_ast_create_concat_op(zend_ast *op0, zend_ast *op1) {
+	zend_ast *result = zend_ast_create_binary_op(ZEND_CONCAT, op0, op1);
+	if (op0->kind == ZEND_AST_ZVAL && op1->kind == ZEND_AST_ZVAL) {
+		zval *zv0 = zend_ast_get_zval(op0);
+		zval *zv1 = zend_ast_get_zval(op1);
+		if (zend_binary_op_produces_error(ZEND_CONCAT, zv0, zv1)) {
+			return result;
+		}
+
+		/* concat_function is optimized for result == op1 and will extend the already created string. */
+		if (concat_function(zv0, zv0, zv1) == FAILURE) {
+			return result;
+		}
+		zval_ptr_dtor_nogc(zv1);
+		return zend_ast_create_zval(zv0);
+	}
+	return result;
+}
+
 static inline bool is_power_of_two(uint32_t n) {
 	return ((n != 0) && (n == (n & (~n + 1))));
 }

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -355,6 +355,9 @@ static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 static zend_always_inline zend_ast *zend_ast_create_binary_op(uint32_t opcode, zend_ast *op0, zend_ast *op1) {
 	return zend_ast_create_ex(ZEND_AST_BINARY_OP, opcode, op0, op1);
 }
+
+zend_ast *zend_ast_create_concat_op(zend_ast *op0, zend_ast *op1);
+
 static zend_always_inline zend_ast *zend_ast_create_assign_op(uint32_t opcode, zend_ast *op0, zend_ast *op1) {
 	return zend_ast_create_ex(ZEND_AST_ASSIGN_OP, opcode, op0, op1);
 }

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1129,7 +1129,7 @@ expr:
 	|	expr T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_AND, $1, $3); }
 	|	expr T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_AND, $1, $3); }
 	|	expr '^' expr	{ $$ = zend_ast_create_binary_op(ZEND_BW_XOR, $1, $3); }
-	|	expr '.' expr 	{ $$ = zend_ast_create_binary_op(ZEND_CONCAT, $1, $3); }
+	|	expr '.' expr 	{ $$ = zend_ast_create_concat_op($1, $3); }
 	|	expr '+' expr 	{ $$ = zend_ast_create_binary_op(ZEND_ADD, $1, $3); }
 	|	expr '-' expr 	{ $$ = zend_ast_create_binary_op(ZEND_SUB, $1, $3); }
 	|	expr '*' expr	{ $$ = zend_ast_create_binary_op(ZEND_MUL, $1, $3); }


### PR DESCRIPTION
The output of token_get_all is unaffected, so projects such as the userland
nikic/php-parser are unaffected.

However, the output of `assert` would be affected. https://github.com/php/php-src/issues/7946#issuecomment-1013742459

Extensions such as nikic/php-ast which expose the internal php ast would see
literals be flattened, though.

This makes php significantly faster at parsing edge cases such as
`$x = eval('return ' . var_export(str_repeat("\0", 100), true) . ';');`
and avoids the stack overflow from recursing 100000 times in
zend_eval_const_expr to process `'' . "\0" . '' . "\0" . ...`

Closes GH-7946

Alternative to GH-7947