### PR TITLE
[JIT] Print out more meaningful warning message

### DIFF
--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -182,7 +182,7 @@ static ZEND_INI_MH(OnUpdateCounter)
 		*p = val;
 		return SUCCESS;
 	}
-	zend_error(E_WARNING, "Invalid \"%s\" setting; use default value instead. Should be between 0 and 256 (not included)", ZSTR_VAL(entry->name));
+	zend_error(E_WARNING, "Invalid \"%s\" setting; use default value instead. Should be between 0 and 255", ZSTR_VAL(entry->name));
 	return FAILURE;
 }
 

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -182,7 +182,7 @@ static ZEND_INI_MH(OnUpdateCounter)
 		*p = val;
 		return SUCCESS;
 	}
-	zend_error(E_WARNING, "Invalid \"%s\" setting. Should be between 0 and 256", ZSTR_VAL(entry->name));
+	zend_error(E_WARNING, "Invalid \"%s\" setting; use default value instead. Should be between 0 and 256 (not included)", ZSTR_VAL(entry->name));
 	return FAILURE;
 }
 

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -182,7 +182,7 @@ static ZEND_INI_MH(OnUpdateCounter)
 		*p = val;
 		return SUCCESS;
 	}
-	zend_error(E_WARNING, "Invalid \"%s\" setting; use default value instead. Should be between 0 and 255", ZSTR_VAL(entry->name));
+	zend_error(E_WARNING, "Invalid \"%s\" setting; using default value instead. Should be between 0 and 255", ZSTR_VAL(entry->name));
 	return FAILURE;
 }
 


### PR DESCRIPTION
When the setting value is out of range for jit_hot_loop, jit_hot_func,
jit_hot_return, and jit_hot_side_exit, current PHP only prints out
warning message like:
    Warning: Invalid "opcache.jit_hot_loop" setting.
    Should be between 0 and 256 in Unknown on line 0

With this small patch, PHP can print out more meaningful information,
and tell user default value will be used and correct value range, like
    Warning: Invalid "opcache.jit_hot_loop" setting; use default value instead.
    Should be between 0 and 256 (not included) in Unknown on line 0

This patch has been verified on my local machine.

Signed-off-by: Su, Tao <tao.su@intel.com>