### PR TITLE
Fix GH-7953: ob_clean() only does not set Content-Encoding

### DIFF
--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -311,7 +311,7 @@ static int php_iconv_output_handler(void **nothing, php_output_context *output_c
 			mimetype = SG(default_mimetype) ? SG(default_mimetype) : SAPI_DEFAULT_MIMETYPE;
 		}
 
-		if (mimetype != NULL && !(output_context->op & PHP_OUTPUT_HANDLER_CLEAN) || (output_context->op & PHP_OUTPUT_HANDLER_START)) {
+		if (mimetype != NULL && (!(output_context->op & PHP_OUTPUT_HANDLER_CLEAN) || (output_context->op & PHP_OUTPUT_HANDLER_START))) {
 			size_t len;
 			char *p = strstr(get_output_encoding(), "//");
 

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -311,7 +311,7 @@ static int php_iconv_output_handler(void **nothing, php_output_context *output_c
 			mimetype = SG(default_mimetype) ? SG(default_mimetype) : SAPI_DEFAULT_MIMETYPE;
 		}
 
-		if (mimetype != NULL && !(output_context->op & PHP_OUTPUT_HANDLER_CLEAN)) {
+		if (mimetype != NULL && !(output_context->op & PHP_OUTPUT_HANDLER_CLEAN) || (output_context->op & PHP_OUTPUT_HANDLER_START)) {
 			size_t len;
 			char *p = strstr(get_output_encoding(), "//");
 

--- a/ext/iconv/tests/gh7953.phpt
+++ b/ext/iconv/tests/gh7953.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-7953 (ob_clean() only may not set Content-* header)
+--SKIPIF--
+<?php
+if (!extension_loaded("iconv")) die("skip iconv extension not available");
+?>
+--INI--
+input_encoding=UTF-8
+output_encoding=ISO-8859-1
+--CGI--
+--FILE--
+<?php
+ob_start('ob_iconv_handler');
+ob_clean();
+
+echo 'Hello World';
+?>
+--EXPECTF--
+%a
+--EXPECTHEADERS--
+Content-Type: text/html; charset=ISO-8859-1

--- a/ext/zlib/tests/gh7953.phpt
+++ b/ext/zlib/tests/gh7953.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-7953 (ob_clean() only does not set Content-Encoding)
+GH-7953 (ob_clean() only may not set Content-* header)
 --SKIPIF--
 <?php
 if (!extension_loaded("zlib")) die("skip zlib extension not available");

--- a/ext/zlib/tests/gh7953.phpt
+++ b/ext/zlib/tests/gh7953.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-7953 (ob_clean() only does not set Content-Encoding)
+--SKIPIF--
+<?php
+if (!extension_loaded("zlib")) die("skip zlib extension not available");
+?>
+--CGI--
+--ENV--
+HTTP_ACCEPT_ENCODING=gzip
+--FILE--
+<?php
+ob_start('ob_gzhandler');
+ob_clean();
+
+echo 'Hello World';
+?>
+--EXPECTF--
+%a
+--EXPECTHEADERS--
+Content-Encoding: gzip
+Vary: Accept-Encoding

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -281,7 +281,7 @@ static int php_zlib_output_handler(void **handler_context, php_output_context *o
 		return FAILURE;
 	}
 
-	if (!(output_context->op & PHP_OUTPUT_HANDLER_CLEAN)) {
+	if (!(output_context->op & PHP_OUTPUT_HANDLER_CLEAN) || (output_context->op & PHP_OUTPUT_HANDLER_START)) {
 		int flags;
 
 		if (SUCCESS == php_output_handler_hook(PHP_OUTPUT_HANDLER_HOOK_GET_FLAGS, &flags)) {


### PR DESCRIPTION
If an output handler has not yet been started, calling `ob_clean()`
causes it to start.  If that happens, we must not forget to set the
`Content-Encoding` and `Vary` headers.