### PR TITLE
Fix GH-7932: MariaDB version prefix not always stripped

### DIFF
--- a/ext/mysqli/tests/gh7932.phpt
+++ b/ext/mysqli/tests/gh7932.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-7932 (MariaDB version prefix not always stripped)
+--SKIPIF--
+<?php
+require_once 'skipif.inc';
+require_once 'skipifconnectfailure.inc';
+?>
+--FILE--
+<?php
+require_once "connect.inc";
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
+$result = $mysqli->query("select version()");
+$version = $result->fetch_array()[0];
+var_dump($mysqli->server_info === $version);
+?>
+--EXPECT--
+bool(true)

--- a/ext/mysqlnd/mysqlnd_commands.c
+++ b/ext/mysqlnd/mysqlnd_commands.c
@@ -647,7 +647,14 @@ MYSQLND_METHOD(mysqlnd_command, handshake)(MYSQLND_CONN_DATA * const conn, const
 
 	conn->thread_id			= greet_packet.thread_id;
 	conn->protocol_version	= greet_packet.protocol_version;
-	conn->server_version	= mnd_pestrdup(greet_packet.server_version, conn->persistent);
+
+#define MARIA_DB_VERSION_HACK_PREFIX "5.5.5-"
+	char *p = greet_packet.server_version;
+	if (!strncmp(p, MARIA_DB_VERSION_HACK_PREFIX, sizeof(MARIA_DB_VERSION_HACK_PREFIX)-1)) {
+		p += sizeof(MARIA_DB_VERSION_HACK_PREFIX)-1;
+	}
+	conn->server_version	= mnd_pestrdup(p, conn->persistent);
+#undef MARIA_DB_VERSION_HACK_PREFIX
 
 	conn->greet_charset = mysqlnd_find_charset_nr(greet_packet.charset_no);
 	if (!conn->greet_charset) {


### PR DESCRIPTION
For consistency with `mysqlnd_conn_data#get_server_version`, we strip
the MariaDB version prefix also in `mysqlnd_command#handshake`.

---

The definition of `MARIA_DB_VERSION_HACK_PREFIX` should better go into a header (maybe mysqlnd_portability.h), but since *all* mysqlnd headers are installed, we better delay that for master to avoid compatibility issues.

@kamil-tekiela, what do you think? The alternative would be to remove the stripping in `mysqlnd_conn_data#get_server_version`, but that would bring back https://bugs.php.net/78179.