### PR TITLE
Implement GH-7922: print_r should not produce a fatal error

### DIFF
--- a/Zend/tests/gh7922.phpt
+++ b/Zend/tests/gh7922.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-7922 (print_r should not produce a fatal error)
+--FILE--
+<?php
+class A
+{
+    public function __debugInfo(): array
+    {
+        throw new \Error('x');
+    }
+}
+
+try {
+    $a = new A();
+    print_r($a, true);
+} catch (\Throwable $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECT--
+__debuginfo() must return an array

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -160,26 +160,29 @@ ZEND_API HashTable *zend_std_get_debug_info(zend_object *object, int *is_temp) /
 	}
 
 	zend_call_known_instance_method_with_0_params(ce->__debugInfo, object, &retval);
-	if (Z_TYPE(retval) == IS_ARRAY) {
-		if (!Z_REFCOUNTED(retval)) {
-			*is_temp = 1;
-			return zend_array_dup(Z_ARRVAL(retval));
-		} else if (Z_REFCOUNT(retval) <= 1) {
-			*is_temp = 1;
-			ht = Z_ARR(retval);
-			return ht;
-		} else {
-			*is_temp = 0;
+	switch (Z_TYPE(retval)) {
+		case IS_ARRAY:
+			if (!Z_REFCOUNTED(retval)) {
+				*is_temp = 1;
+				return zend_array_dup(Z_ARRVAL(retval));
+			} else if (Z_REFCOUNT(retval) <= 1) {
+				*is_temp = 1;
+				ht = Z_ARR(retval);
+				return ht;
+			} else {
+				*is_temp = 0;
+				zval_ptr_dtor(&retval);
+				return Z_ARRVAL(retval);
+			}
+		default:
+			zend_throw_error(NULL, ZEND_DEBUGINFO_FUNC_NAME "() must return an array");
 			zval_ptr_dtor(&retval);
-			return Z_ARRVAL(retval);
-		}
-	} else if (Z_TYPE(retval) == IS_NULL) {
-		*is_temp = 1;
-		ht = zend_new_array(0);
-		return ht;
+			/* fallthrough */
+		case IS_NULL:
+			*is_temp = 1;
+			ht = zend_new_array(0);
+			return ht;
 	}
-
-	zend_error_noreturn(E_ERROR, ZEND_DEBUGINFO_FUNC_NAME "() must return an array");
 
 	return NULL; /* Compilers are dumb and don't understand that noreturn means that the function does NOT need a return value... */
 }


### PR DESCRIPTION
Fataling if `::__debugInfo()` doesn't return an array appears to be
overly restrictive; we can handle that like returning null, namely by
throwing an `Error` exception and returning an empty array instead.

PS: if null is returned, we don't throw an exception like before. Exception is only thrown if not array|null.