### PR TITLE
SimpleXMLElement::children() has a non-nullable return type

### DIFF
--- a/ext/simplexml/simplexml.stub.php
+++ b/ext/simplexml/simplexml.stub.php
@@ -33,7 +33,7 @@ class SimpleXMLElement implements Stringable, Countable, RecursiveIterator
     public function getDocNamespaces(bool $recursive = false, bool $fromRoot = true): array|false {}
 
     /** @tentative-return-type */
-    public function children(?string $namespaceOrPrefix = null, bool $isPrefix = false): ?SimpleXMLElement {}
+    public function children(?string $namespaceOrPrefix = null, bool $isPrefix = false): SimpleXMLElement {}
 
     /** @tentative-return-type */
     public function attributes(?string $namespaceOrPrefix = null, bool $isPrefix = false): ?SimpleXMLElement {}


### PR DESCRIPTION
I hope this is the right place to suggest this update...?

https://www.php.net/manual/en/simplexmlelement.children.php says that this method

> Returns a SimpleXMLElement element, whether the node has children or not.

This is confirmed by:

`php8.1 -r '$x = new SimpleXMLElement("<foo></foo>"); var_dump($x->children());'`