### PR TITLE
Strip MariaDB 10 prefix

### DIFF
--- a/ext/mysqli/tests/gh7932.phpt
+++ b/ext/mysqli/tests/gh7932.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-7932 (MariaDB version prefix not always stripped)
+--SKIPIF--
+<?php
+require_once 'skipif.inc';
+require_once 'skipifconnectfailure.inc';
+?>
+--FILE--
+<?php
+require_once "connect.inc";
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = new my_mysqli($host, $user, $passwd, $db, $port, $socket);
+
+// It seems we can only test the happy path...
+if (str_starts_with($mysqli->server_info, '5.5.5-')) {
+    print("Expecting stripped prefix. Found: " . $mysqli->server_info . "\n");
+}
+?>
+--EXPECT--

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -1436,14 +1436,6 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_server_version)(const MYSQLND_CONN_DATA * 
 		return 0;
 	}
 
-#define MARIA_DB_VERSION_HACK_PREFIX "5.5.5-"
-
-	if ((conn->server_capabilities & CLIENT_PLUGIN_AUTH)
-		&& !strncmp(p, MARIA_DB_VERSION_HACK_PREFIX, sizeof(MARIA_DB_VERSION_HACK_PREFIX)-1))
-	{
-		p += sizeof(MARIA_DB_VERSION_HACK_PREFIX)-1;
-	}
-
 	major = ZEND_STRTOL(p, &p, 10);
 	p += 1; /* consume the dot */
 	minor = ZEND_STRTOL(p, &p, 10);

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -373,8 +373,9 @@ php_mysqlnd_greet_read(MYSQLND_CONN_DATA * conn, void * _packet)
 
 	/* MariaDB always sends 5.5.5 before version string: 5.5.5 was never released,
 		so just ignore it */
-	if (!strncmp((char *) p, MARIADB_RPL_VERSION_HACK, sizeof(MARIADB_RPL_VERSION_HACK) - 1))
-		p+= sizeof(MARIADB_RPL_VERSION_HACK) - 1;
+	if (!strncmp((char *) p, MARIADB_RPL_VERSION_HACK, sizeof(MARIADB_RPL_VERSION_HACK) - 1)) {
+		p += sizeof(MARIADB_RPL_VERSION_HACK) - 1;
+	}
 
 	packet->server_version = estrdup((char *)p);
 	p+= strlen(packet->server_version) + 1; /* eat the '\0' */

--- a/ext/mysqlnd/mysqlnd_wireprotocol.c
+++ b/ext/mysqlnd/mysqlnd_wireprotocol.c
@@ -41,6 +41,8 @@ const char mysqlnd_read_body_name[]		= "mysqlnd_read_body";
 #define ERROR_MARKER 0xFF
 #define EODATA_MARKER 0xFE
 
+#define MARIADB_RPL_VERSION_HACK "5.5.5-"
+
 /* {{{ mysqlnd_command_to_text */
 const char * const mysqlnd_command_to_text[COM_END] =
 {
@@ -368,6 +370,11 @@ php_mysqlnd_greet_read(MYSQLND_CONN_DATA * conn, void * _packet)
 		}
 		DBG_RETURN(PASS);
 	}
+
+	/* MariaDB always sends 5.5.5 before version string: 5.5.5 was never released,
+		so just ignore it */
+	if (!strncmp((char *) p, MARIADB_RPL_VERSION_HACK, sizeof(MARIADB_RPL_VERSION_HACK) - 1))
+		p+= sizeof(MARIADB_RPL_VERSION_HACK) - 1;
 
 	packet->server_version = estrdup((char *)p);
 	p+= strlen(packet->server_version) + 1; /* eat the '\0' */


### PR DESCRIPTION
I have reconsidered. While I am still uneasy about PHP stripping this value, it seems that [MariaDB does recommend that](https://github.com/mariadb-corporation/mariadb-connector-c/blob/c912a46f786426b34d88a63c9dc38a0be9d54606/libmariadb/mariadb_lib.c#L1554). 

Based on the linked conversation in #7963 and the earlier [PR by Georg Richter from MariaDB](https://github.com/php/php-src/pull/1767) I decided that it's ok to strip the prefix. 

This PR removes the earlier implementation of this hack and also supersedes #7963. A unit test was added in mysqli but not in PDO. The test should succeed in PHP CI jobs no matter what as I don't think we have a CI job connecting to MariaDB. I tested this PR on Windows with MariaDB 10 and the test passed. 

The PR is against PHP 8.0, but if we are worried about BC we can merge it only in Master.