### PR TITLE
Send e-mail notifications for new PRs with GitHub Actions

### DIFF
--- a/.github/workflows/new-pull-request-notification.yml
+++ b/.github/workflows/new-pull-request-notification.yml
@@ -1,0 +1,28 @@
+name: New pull request notification
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send e-mail notification for new pull requests
+        uses: dawidd6/action-send-mail@v3.6.0
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          from: php-src notification <phpsrc.notification@gmail.com>
+          to: ${{ secrets.MAIL_TO }}
+          subject: "[${{ github.repository }}] ${{ github.event.pull_request.title }}"
+          body: |
+            Hi
+
+            A new pull request was created on [${{ github.repository }}].
+            ${{ github.event.pull_request.html_url }}
+
+            If you don't wish to receive this e-mail remove your address from the "MAIL_TO" secret in the settings of this repository.


### PR DESCRIPTION
GitHub provides notifications for pull requests. Unfortunately, these notifications are quite noisy as they don't only trigger when a new PR is created but also when anybody comments on any PR or pushes to any associated branch. I often don't feel like I can provide any value on a pull request and yet I'll keep getting notified on every change. This can lead to dozens of e-mails within a few hours. For me, GitHub pull request notifications are currently pretty much unusable.

The approach of this action is to only trigger an initial notification when a new pull request is created. If you review the pull request GitHub will automatically subscribe you to the issue. You also have the option to manually subscribe. If you don't you won't receive any future notifications.

Right now, this feature is intended for maintainers only and thus I'm suggesting to use Gmail as an SMTP as PHPs SMTP doesn't seem to be accessible externally, and to send the e-mails to a limited list of users stored as a secret.

The same issue also actually applies to issues themselves, although I'm focusing on PRs here for now.

Let me know if you're interested in this action.

Ps. I don't have permissions to create GitHub secrets. Somebody would have to do that for me, or grant me the necessary permissions.