### PR TITLE
Added fallthrough for == operator with objects for extensions

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -118,7 +118,7 @@ ZEND_API const unsigned char zend_toupper_map[256] = {
 0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,
 0xd0,0xd1,0xd2,0xd3,0xd4,0xd5,0xd6,0xd7,0xd8,0xd9,0xda,0xdb,0xdc,0xdd,0xde,0xdf,
 0xe0,0xe1,0xe2,0xe3,0xe4,0xe5,0xe6,0xe7,0xe8,0xe9,0xea,0xeb,0xec,0xed,0xee,0xef,
-0xf0,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff	
+0xf0,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,0xf8,0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff
 };
 
 
@@ -2131,6 +2131,58 @@ static int compare_double_to_string(double dval, zend_string *str) /* {{{ */
 	return ZEND_NORMALIZE_BOOL(cmp_result);
 }
 /* }}} */
+
+ZEND_API int ZEND_FASTCALL zend_equals_object(zval *op1, zval *op2, zend_uchar equals) /* {{{ */
+{
+	zval ret;
+	int retVal;
+	int result;
+	zend_function *op_handler;
+	if (Z_TYPE_P(op1) == IS_OBJECT &&
+		Z_TYPE_P(op2) == IS_OBJECT &&
+		Z_OBJ_P(op1) == Z_OBJ_P(op2)) {
+		return 0;
+	} else if (Z_TYPE_P(op1) == IS_OBJECT) {
+		if (Z_OBJ_HANDLER_P(op1, do_operation)) {
+			result = Z_OBJ_HANDLER_P(op1, do_operation)(equals, &ret, op1, op2);
+			if (result == FAILURE) {
+				goto op2_equals_handler;
+			} else {
+				retVal = (Z_TYPE_INFO(ret) == IS_TRUE ? 0 : ZEND_UNCOMPARABLE);
+			}
+			return retVal;
+		} else {
+			if (Z_TYPE_P(op2) == IS_OBJECT) {
+				goto op2_equals_handler;
+			} else {
+				goto default_equals_handler;
+			}
+		}
+	} else if (Z_TYPE_P(op2) == IS_OBJECT) {
+op2_equals_handler:
+		if (Z_OBJ_HANDLER_P(op2, do_operation)) {
+			result = Z_OBJ_HANDLER_P(op2, do_operation)(equals, &ret, op1, op2);
+			if (result == FAILURE) {
+				goto default_equals_handler;
+			} else {
+				retVal = (Z_TYPE_INFO(ret) == IS_TRUE ? 0 : ZEND_UNCOMPARABLE);
+			}
+			return retVal;
+		} else {
+			if (Z_TYPE_P(op2) == IS_OBJECT) {
+				goto op2_equals_handler;
+			} else {
+				goto default_equals_handler;
+			}
+		}
+	} else {
+default_equals_handler:
+		return zend_compare(op1, op2);
+	}
+}
+/* }}} */
+
+
 
 ZEND_API int ZEND_FASTCALL zend_compare(zval *op1, zval *op2) /* {{{ */
 {

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -423,6 +423,7 @@ again:
 // TODO: Use a different value to allow an actual distinction here.
 #define ZEND_UNCOMPARABLE 1
 
+ZEND_API int ZEND_FASTCALL zend_equals_object(zval *op1, zval *op2, zend_uchar equals);
 ZEND_API int ZEND_FASTCALL zend_compare(zval *op1, zval *op2);
 
 ZEND_API zend_result ZEND_FASTCALL compare_function(zval *result, zval *op1, zval *op2);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -501,7 +501,11 @@ ZEND_VM_HELPER(zend_is_equal_helper, ANY, ANY, zval *op_1, zval *op_2)
 	if (UNEXPECTED(Z_TYPE_INFO_P(op_2) == IS_UNDEF)) {
 		op_2 = ZVAL_UNDEFINED_OP2();
 	}
-	ret = zend_compare(op_1, op_2);
+	if (Z_TYPE_P(op_1) == IS_OBJECT || Z_TYPE_P(op_2) == IS_OBJECT) {
+		ret = zend_equals_object(op_1, op_2, ZEND_IS_EQUAL);
+	} else {
+		ret = zend_compare(op_1, op_2);
+	}
 	if (OP1_TYPE & (IS_TMP_VAR|IS_VAR)) {
 		zval_ptr_dtor_nogc(op_1);
 	}
@@ -581,7 +585,11 @@ ZEND_VM_HELPER(zend_is_not_equal_helper, ANY, ANY, zval *op_1, zval *op_2)
 	if (UNEXPECTED(Z_TYPE_INFO_P(op_2) == IS_UNDEF)) {
 		op_2 = ZVAL_UNDEFINED_OP2();
 	}
-	ret = zend_compare(op_1, op_2);
+	if (Z_TYPE_P(op_1) == IS_OBJECT || Z_TYPE_P(op_2) == IS_OBJECT) {
+		ret = zend_equals_object(op_1, op_2, ZEND_IS_NOT_EQUAL);
+	} else {
+		ret = zend_compare(op_1, op_2);
+	}
 	if (OP1_TYPE & (IS_TMP_VAR|IS_VAR)) {
 		zval_ptr_dtor_nogc(op_1);
 	}


### PR DESCRIPTION
This should allow extensions to handle the == operator differently from the <=> operator. It accomplishes this by allowing the do_operation handler to look at ZEND_IS_EQUAL and ZEND_IS_NOT_EQUAL prior to calling zend_compare.