### PR TITLE
[Zend] Enhance Zend header files protection

### DIFF
--- a/Zend/zend_gdb.h
+++ b/Zend/zend_gdb.h
@@ -20,8 +20,12 @@
 #ifndef ZEND_GDB
 #define ZEND_GDB
 
+BEGIN_EXTERN_C()
+
 ZEND_API bool zend_gdb_register_code(const void *object, size_t size);
 ZEND_API void zend_gdb_unregister_all(void);
 ZEND_API bool zend_gdb_present(void);
+
+END_EXTERN_C()
 
 #endif


### PR DESCRIPTION
Keep unified coding style and reduce potential macro definition
conflictions in future.

ZEND_GDB_H should be safer than ZEND_GDB which might be used inside
source code files.

Signed-off-by: Su, Tao <tao.su@intel.com>