### PR TITLE
Update php-parser to 4.13.2 in build/gen_stub.php

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -3287,7 +3287,7 @@ function initPhpParser() {
     }
 
     $isInitialized = true;
-    $version = "4.13.0";
+    $version = "4.13.2";
     $phpParserDir = __DIR__ . "/PHP-Parser-$version";
     if (!is_dir($phpParserDir)) {
         installPhpParser($version, $phpParserDir);


### PR DESCRIPTION
v4.13.2 fixes a deprecation notice in php 8.2 for namespacedName

`php build/gen_stub.php --force-regeneration` works as expected locally.