### PR TITLE
Use __atomic_test_and_set() instead of __sync_test_and_set() for lsapi

### DIFF
--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -443,7 +443,7 @@ static void lsapi_close_connection(LSAPI_Request *pReq)
     if (s_busy_workers)
         __sync_fetch_and_sub(s_busy_workers, 1);
     if (s_worker_status)
-        __sync_lock_test_and_set(&s_worker_status->m_state, LSAPI_STATE_IDLE);
+        __atomic_test_and_set(&s_worker_status->m_state, LSAPI_STATE_IDLE);
 }
 
 
@@ -1587,7 +1587,7 @@ int LSAPI_Accept_r( LSAPI_Request * pReq )
                 else
                 {
                     if (s_worker_status)
-                        __sync_lock_test_and_set(&s_worker_status->m_state,
+                        __atomic_test_and_set(&s_worker_status->m_state,
                                                  LSAPI_STATE_CONNECTED);
                     if (s_busy_workers)
                         __sync_fetch_and_add(s_busy_workers, 1);
@@ -3315,7 +3315,7 @@ static int lsapi_prefork_server_accept( lsapi_prefork_server * pServer,
                 if (pthread_atfork_func)
                     (*pthread_atfork_func)(NULL, NULL, set_skip_write);
 
-                __sync_lock_test_and_set(&s_worker_status->m_state,
+                __atomic_test_and_set(&s_worker_status->m_state,
                                          LSAPI_STATE_CONNECTED);
                 if (s_busy_workers)
                     __sync_add_and_fetch(s_busy_workers, 1);
@@ -3390,7 +3390,7 @@ int LSAPI_Postfork_Child(LSAPI_Request * pReq)
 {
     int max_children = g_prefork_server->m_iMaxChildren;
     s_pid = getpid();
-    __sync_lock_test_and_set(&pReq->child_status->m_pid, s_pid);
+    __atomic_test_and_set(&pReq->child_status->m_pid, s_pid);
     s_worker_status = pReq->child_status;
 
     setsid();
@@ -3402,7 +3402,7 @@ int LSAPI_Postfork_Child(LSAPI_Request * pReq)
     if (pthread_atfork_func)
         (*pthread_atfork_func)(NULL, NULL, set_skip_write);
 
-    __sync_lock_test_and_set(&s_worker_status->m_state,
+    __atomic_test_and_set(&s_worker_status->m_state,
                                 LSAPI_STATE_CONNECTED);
     if (s_busy_workers)
         __sync_add_and_fetch(s_busy_workers, 1);
@@ -3651,7 +3651,7 @@ int LSAPI_Prefork_Accept_r( LSAPI_Request * pReq )
             if (fd == pReq->m_fdListen)
             {
                 if (s_worker_status)
-                    __sync_lock_test_and_set(&s_worker_status->m_state,
+                    __atomic_test_and_set(&s_worker_status->m_state,
                                              LSAPI_STATE_ACCEPTING);
                 if (s_accepting_workers)
                     __sync_fetch_and_add(s_accepting_workers, 1);
@@ -3662,7 +3662,7 @@ int LSAPI_Prefork_Accept_r( LSAPI_Request * pReq )
                 if (s_accepting_workers)
                     __sync_fetch_and_sub(s_accepting_workers, 1);
                 if (s_worker_status)
-                    __sync_lock_test_and_set(&s_worker_status->m_state,
+                    __atomic_test_and_set(&s_worker_status->m_state,
                                              LSAPI_STATE_IDLE);
             }
 
@@ -3711,7 +3711,7 @@ int LSAPI_Prefork_Accept_r( LSAPI_Request * pReq )
                     if ( pReq->m_fd != -1 )
                     {
                         if (s_worker_status)
-                            __sync_lock_test_and_set(&s_worker_status->m_state,
+                            __atomic_test_and_set(&s_worker_status->m_state,
                                                      LSAPI_STATE_CONNECTED);
                         if (s_busy_workers)
                             __sync_fetch_and_add(s_busy_workers, 1);


### PR DESCRIPTION
Related to #7914

Usage of `__atomics_` is preferred according to https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html#g_t_005f_005fatomic-Builtins

There's more usage found in the same file and 4 wrappers in fpm-atomics.h