### PR TITLE
Close stale PRs with GitHub actions

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,20 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-close: 7
+          days-before-stale: 60
+          # Temporary, avoid closing PRs until this action merged
+          debug-only: true
+          # Hack to skip issues, unfortunately there's no option to disable issues
+          only-issue-labels: inexistent-label
+          only-pr-labels: Waiting on Author
+          stale-pr-message: There has not been any recent activity in this PR. It will automatically be closed in 7 days if no further action is taken.


### PR DESCRIPTION
As discussed in r11. Open question:

[operations-per-run](https://github.com/actions/stale#operations-per-run) is currently configured to `30`.

> This option aims to limit the number of operations made with the GitHub API to avoid reaching the rate limit.

I'm not sure if we're subject to rate limiting. Leaving it as is would probably mean that stale PRs would only get closed over time instead of at once.

`debug-only` is enabled since I'm not sure if GitHub will run actions that are not merged yet. We might even leave it enabled after merging for a few days to see if it behaves correctly.