### PR TITLE
GD - backport fix for libpng warning when loading interlaced images

### DIFF
--- a/ext/gd/libgd/gd_png.c
+++ b/ext/gd/libgd/gd_png.c
@@ -336,6 +336,11 @@ gdImagePtr gdImageCreateFromPngCtx (gdIOCtx * infile)
 				break;
 	}
 
+	/* enable the interlace transform if supported */
+#ifdef PNG_READ_INTERLACING_SUPPORTED
+	(void)png_set_interlace_handling(png_ptr);
+#endif
+
 	png_read_update_info(png_ptr, info_ptr);
 
 	/* allocate space for the PNG image data */


### PR DESCRIPTION
Currently a warning is being generated when reading interlaced PNGs due to libpng being used incorrectly.

Refer to https://github.com/glennrp/libpng/blob/libpng16/pngread.c#L727 for the source of this warning.

This PR enables the interlacing transform prior to calling `png_read_update_info()` to prevent this warning. There is no change in functionality since libpng automatically does this after emitting the warning anyway.