### PR TITLE
Fix FSF address & update year to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------
                   The PHP License, version 3.01
-Copyright (c) 1999 - 2021 The PHP Group. All rights reserved.
+Copyright (c) 1999 - 2022 The PHP Group. All rights reserved.
 --------------------------------------------------------------------
 
 Redistribution and use in source and binary forms, with or without

--- a/build/pkg.m4
+++ b/build/pkg.m4
@@ -16,8 +16,8 @@ dnl General Public License for more details.
 dnl
 dnl You should have received a copy of the GNU General Public License
 dnl along with this program; if not, write to the Free Software
-dnl Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
-dnl 02111-1307, USA.
+dnl Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+dnl 02110-1301, USA.
 dnl
 dnl As a special exception to the GNU General Public License, if you
 dnl distribute this file as part of a program that contains a

--- a/build/shtool
+++ b/build/shtool
@@ -23,7 +23,7 @@
 ##
 ##  You should have received a copy of the GNU General Public License
 ##  along with this program; if not, write to the Free Software
-##  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+##  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 ##  USA, or contact Ralf S. Engelschall <rse@engelschall.com>.
 ##
 ##  NOTICE: Given that you include this file verbatim into your own

--- a/ext/oci8/LICENSE
+++ b/ext/oci8/LICENSE
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------
                   The PHP License, version 3.01
-Copyright (c) 1999 - 2021 The PHP Group. All rights reserved.
+Copyright (c) 1999 - 2022 The PHP Group. All rights reserved.
 --------------------------------------------------------------------
 
 Redistribution and use in source and binary forms, with or without

--- a/ext/phar/phar.1.in
+++ b/ext/phar/phar.1.in
@@ -1,4 +1,4 @@
-.TH PHAR 1 "2021" "The PHP Group" "User Commands"
+.TH PHAR 1 "2022" "The PHP Group" "User Commands"
 .SH NAME
 phar, phar.phar \- PHAR (PHP archive) command line tool
 .SH SYNOPSIS

--- a/sapi/cli/php.1.in
+++ b/sapi/cli/php.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@php 1 "2021" "The PHP Group" "Scripting Language"
+.TH @program_prefix@php 1 "2022" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@php \- PHP Command Line Interface 'CLI'
 .P

--- a/sapi/fpm/php-fpm.8.in
+++ b/sapi/fpm/php-fpm.8.in
@@ -1,4 +1,4 @@
-.TH PHP-FPM 8 "2021" "The PHP Group" "Scripting Language"
+.TH PHP-FPM 8 "2022" "The PHP Group" "Scripting Language"
 .SH NAME
 .TP 15
 php-fpm \- PHP FastCGI Process Manager 'PHP-FPM'

--- a/sapi/phpdbg/phpdbg.1.in
+++ b/sapi/phpdbg/phpdbg.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@phpdbg 1 "2021" "The PHP Group" "Scripting Language"
+.TH @program_prefix@phpdbg 1 "2022" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@phpdbg \- The interactive PHP debugger
 .SH SYNOPSIS

--- a/scripts/man1/php-config.1.in
+++ b/scripts/man1/php-config.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@php\-config 1 "2021" "The PHP Group" "Scripting Language"
+.TH @program_prefix@php\-config 1 "2022" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@php\-config \- get information about PHP configuration and compile options
 .SH SYNOPSIS

--- a/scripts/man1/phpize.1.in
+++ b/scripts/man1/phpize.1.in
@@ -1,4 +1,4 @@
-.TH @program_prefix@phpize 1 "2021" "The PHP Group" "Scripting Language"
+.TH @program_prefix@phpize 1 "2022" "The PHP Group" "Scripting Language"
 .SH NAME
 @program_prefix@phpize \- prepare a PHP extension for compiling
 .SH SYNOPSIS


### PR DESCRIPTION
FSF mailing address was changed long time ago. This patch updates that address. Also updated year from 2021 to 2022.

rpmlint generated this error after running on a packaged rpm.

`php.x86_64: E: incorrect-fsf-address /usr/lib64/build/pkg.m4
php.x86_64: E: incorrect-fsf-address /usr/lib64/build/shtool`

https://github.com/git/git/commit/703601d6780c32d33dadf19b2b367f2f79e1e34c
https://www.fsf.org/about/contact
www.gnu.org/licenses/old-licenses/gpl-2.0.txt