### PR TITLE
Fix ReflectionFunction stub signature

### DIFF
--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -113,7 +113,7 @@ abstract class ReflectionFunctionAbstract implements Reflector
 
 class ReflectionFunction extends ReflectionFunctionAbstract
 {
-    public function __construct(Closure|string $function) {}
+    public function __construct(callable $function) {}
 
     public function __toString(): string {}
 


### PR DESCRIPTION
Constructing a new `ReflectionFunction` with a `callable` argument should be valid:

```php
function reflection(callable $callable): ReflectionFunction {
    return new ReflectionFunction($callable);
}

reflection('strpos');
reflection(Closure::fromCallable('strpos'));
reflection(strpos(...));
reflection(fn () => 42);
reflection(function () { return 42; });
```

FYI I run into this issue using PHPStan, which raises an error with this code: https://phpstan.org/r/a6942c0f-0362-4868-b30c-f805139ebf24 (see phpstan/php-8-stubs#8)