### PR TITLE
Fix GH-7980: Unexpected result for iconv_mime_decode

### DIFF
--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -1576,6 +1576,9 @@ static php_iconv_err_t _php_iconv_mime_decode(smart_str *pretval, const char *st
 						}
 
 						err = _php_iconv_appendl(pretval, ZSTR_VAL(decoded_text), ZSTR_LEN(decoded_text), cd);
+						if (err == PHP_ICONV_ERR_SUCCESS) {
+							err = _php_iconv_appendl(pretval, NULL, 0, cd);
+						}
 						zend_string_release_ex(decoded_text, 0);
 
 						if (err != PHP_ICONV_ERR_SUCCESS) {
@@ -1714,13 +1717,6 @@ static php_iconv_err_t _php_iconv_mime_decode(smart_str *pretval, const char *st
 
 	if (next_pos != NULL) {
 		*next_pos = p1;
-	}
-
-	if (cd != (iconv_t)(-1)) {
-		_php_iconv_appendl(pretval, NULL, 0, cd);
-	}
-	if (cd_pl != (iconv_t)(-1)) {
-		_php_iconv_appendl(pretval, NULL, 0, cd_pl);
 	}
 
 	smart_str_0(pretval);

--- a/ext/iconv/tests/gh7980.phpt
+++ b/ext/iconv/tests/gh7980.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug GH-7980 (Unexpected result for iconv_mime_decode)
+--SKIPIF--
+<?php
+if (!extension_loaded("iconv")) die("skip iconv extension not available");
+?>
+--FILE--
+<?php
+$subject = '=?windows-1258?Q?DSI_Charg=E9_de_Formation_Jean_Dupont?= <jdupont@example.fr>';
+var_dump(iconv_mime_decode($subject, ICONV_MIME_DECODE_STRICT, 'UTF-8'));
+?>
+--EXPECT--
+string(57) "DSI Chargé de Formation Jean Dupont <jdupont@example.fr>"


### PR DESCRIPTION
We need to reset the shift state right after conversion, to cater to
potenially following plain encodings.  Also, there is no need to reset
the shift for plain encodings, because these are not state-dependent.