### PR TITLE
ext/opcache: check mkstemp() return value right after the call

### DIFF
--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -83,11 +83,12 @@ void zend_shared_alloc_create_lock(char *lockfile_path)
 
 	snprintf(lockfile_name, sizeof(lockfile_name), "%s/%sXXXXXX", lockfile_path, SEM_FILENAME_PREFIX);
 	lock_file = mkstemp(lockfile_name);
-	fchmod(lock_file, 0666);
-
 	if (lock_file == -1) {
 		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Unable to create lock file: %s (%d)", strerror(errno), errno);
 	}
+
+	fchmod(lock_file, 0666);
+
 	val = fcntl(lock_file, F_GETFD, 0);
 	val |= FD_CLOEXEC;
 	fcntl(lock_file, F_SETFD, val);


### PR DESCRIPTION
Don't call fchmod(-1), which is not only wrong, but also clobbers
errno and sets it to EBADF, breaking the following errno access for
the log message.