### PR TITLE
Three stream read optimizations

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -566,6 +566,11 @@ PHP_FUNCTION(file_get_contents)
 		RETURN_FALSE;
 	}
 
+	/* disabling the read buffer allows doing the whole transfer
+	   in just one read() system call */
+	if (php_stream_is(stream, PHP_STREAM_IS_STDIO))
+		php_stream_set_option(stream, PHP_STREAM_OPTION_READ_BUFFER, PHP_STREAM_BUFFER_NONE, NULL);
+
 	if (offset != 0 && php_stream_seek(stream, offset, ((offset > 0) ? SEEK_SET : SEEK_END)) < 0) {
 		php_error_docref(NULL, E_WARNING, "Failed to seek to position " ZEND_LONG_FMT " in the stream", offset);
 		php_stream_close(stream);

--- a/ext/standard/tests/streams/bug54946.phpt
+++ b/ext/standard/tests/streams/bug54946.phpt
@@ -31,11 +31,6 @@ fclose($stream);
 unlink($filename);
 ?>
 --EXPECTF--
-Notice: stream_get_contents(): Read of 8192 bytes failed with errno=9 Bad file descriptor in %s on line %d
 string(0) ""
-
-Notice: stream_get_contents(): Read of 8192 bytes failed with errno=9 Bad file descriptor in %s on line %d
 string(0) ""
-
-Notice: stream_get_contents(): Read of 8192 bytes failed with errno=9 Bad file descriptor in %s on line %d
 string(0) ""

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1517,7 +1517,7 @@ PHPAPI zend_string *_php_stream_copy_to_mem(php_stream *src, size_t maxlen, int 
 	ptr = ZSTR_VAL(result);
 
 	// TODO: Propagate error?
-	while ((ret = php_stream_read(src, ptr, max_len - len)) > 0){
+	while (!php_stream_eof(src) && (ret = php_stream_read(src, ptr, max_len - len)) > 0){
 		len += ret;
 		if (len + min_room >= max_len) {
 			result = zend_string_extend(result, max_len + step, persistent);


### PR DESCRIPTION
These patches optimize large reads by skipping the buffer when appropriate. This saves lots of `read()` system calls and reduces unnecessary memory copies.