### PR TITLE
Fix `-Werror=sign-compare` warning in `zend_memnistr` when compiling with `-Werror`

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -939,7 +939,7 @@ zend_memnistr(const char *haystack, const char *needle, size_t needle_len, const
 		return haystack;
 	}
 
-	if (UNEXPECTED(needle_len > (end - haystack))) {
+	if (UNEXPECTED(needle_len > (size_t)(end - haystack))) {
 		return NULL;
 	}
 
@@ -947,7 +947,7 @@ zend_memnistr(const char *haystack, const char *needle, size_t needle_len, const
 	const char first_upper = zend_toupper_ascii(*needle);
 	const char *p_lower = (const char *)memchr(haystack, first_lower, end - haystack);
 	const char *p_upper = NULL;
-	if (first_lower != first_upper) { 
+	if (first_lower != first_upper) {
 		// If the needle length is 1 we don't need to look beyond p_lower as it is a guaranteed match
 		size_t upper_search_length = end - (needle_len == 1 && p_lower != NULL ? p_lower : haystack);
 		p_upper = (const char *)memchr(haystack, first_upper, upper_search_length);


### PR DESCRIPTION
`comparison of integer expressions of different signedness: ‘size_t’ {aka
‘long unsigned int’} and ‘long int’ [-Werror=sign-compare]`

This is asserting `end >= haystack` as a precondition for callers (in debug
builds) and existing callers are correct.

An alternate option is to cast the left side to `int64_t`, but that may be
slightly inefficient for 32-bit builds (to account for >=2GB strings).

Noticed when locally developing with `-Werror`