### PR TITLE
Make var_export/debug_zval_dump first check for infinite recursion on the object before properties

### DIFF
--- a/ext/spl/tests/gh8044.phpt
+++ b/ext/spl/tests/gh8044.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug GH-8044 (var_export HT_ASSERT_RC1 debug failure for SplFixedArray)
+--FILE--
+<?php
+set_error_handler(function ($errno, $errmsg) {
+    echo "errmsg=$errmsg\n";
+});
+$x = new SplFixedArray(2);
+$x[0] = $x;
+$x[1] = $x;
+var_export($x);
+?>
+--EXPECT--
+errmsg=var_export does not handle circular references
+errmsg=var_export does not handle circular references
+SplFixedArray::__set_state(array(
+   0 => NULL,
+   1 => NULL,
+))

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -552,9 +552,16 @@ again:
 			break;
 
 		case IS_OBJECT:
+			if (Z_IS_RECURSIVE_P(struc)) {
+				smart_str_appendl(buf, "NULL", 4);
+				zend_error(E_WARNING, "var_export does not handle circular references");
+				return;
+			}
+			Z_PROTECT_RECURSION_P(struc);
 			myht = zend_get_properties_for(struc, ZEND_PROP_PURPOSE_VAR_EXPORT);
 			if (myht) {
 				if (GC_IS_RECURSIVE(myht)) {
+					Z_UNPROTECT_RECURSION_P(struc);
 					smart_str_appendl(buf, "NULL", 4);
 					zend_error(E_WARNING, "var_export does not handle circular references");
 					zend_release_properties(myht);
@@ -595,6 +602,7 @@ again:
 				GC_TRY_UNPROTECT_RECURSION(myht);
 				zend_release_properties(myht);
 			}
+			Z_UNPROTECT_RECURSION_P(struc);
 			if (level > 1 && !is_enum) {
 				buffer_append_spaces(buf, level - 1);
 			}


### PR DESCRIPTION
This test case previously failed with an assertion error in debug builds
(for updating an index of the array to set it to the same value it already had)

After the new check on recursion on the object, repeat the existing check on the return value of `get_properties_for`
in case there was a reason for doing it that way.

1. `HT_ASSERT_RC1(ht);` would fail for SplFixedArray and related
   datastructures.
2. In order for a native datastructure to correctly implement
   `*get_properties_for` for var_export's cycle detection,
   it would need to return the exact same array every time prior to this PR.

   This would prevent SplFixedArray or similar classes from returning a
   temporary array that

   1. Wouldn't be affected by unexpected mutations from error handlers
   2. Could be garbage collected instead.


Note that SplFixedArray continues to need to return `object->properties`
until php 9.0, when dynamic properties are forbidden.
(to display dynamic properties when debugging, until then)


Closes GH-8044