### PR TITLE
Make var_export/debug_zval_dump check for infinite recursion on the *object*

### DIFF
--- a/ext/spl/tests/gh8044.phpt
+++ b/ext/spl/tests/gh8044.phpt
@@ -11,7 +11,7 @@ call_user_func(function () {
 ?>
 --EXPECTF--
 Warning: var_export does not handle circular references in %s on line 5
-SplFixedArray::__set_state(array(
+\SplFixedArray::__set_state(array(
    0 => NULL,
 ))
 object(SplFixedArray)#2 (1) refcount(4){

--- a/ext/spl/tests/gh8044.phpt
+++ b/ext/spl/tests/gh8044.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug GH-8044 (var_export/debug_zval_dump HT_ASSERT_RC1 debug failure for SplFixedArray)
+--FILE--
+<?php
+call_user_func(function () {
+    $x = new SplFixedArray(1);
+    $x[0] = $x;
+    var_export($x); echo "\n";
+    debug_zval_dump($x); echo "\n";
+});
+?>
+--EXPECTF--
+Warning: var_export does not handle circular references in %s on line 5
+SplFixedArray::__set_state(array(
+   0 => NULL,
+))
+object(SplFixedArray)#2 (1) refcount(4){
+  [0]=>
+  *RECURSION*
+}


### PR DESCRIPTION
Switch the check from the result of `get_properties_for` (the returned hash table of properties) to just checking for
infinite recursion on the object.

- In order for a native datastructure to correctly implement
  `*get_properties_for` for var_export's cycle detection,
  it would need to return the exact same array every time prior to this PR.

  Prior to this commit, the requirements for cycle detection
  would prevent SplFixedArray or similar classes from returning a
  temporary array that:

  1. Wouldn't be affected by unexpected mutations from error handlers
  2. Could be garbage collected instead.


Note that SplFixedArray continues to need to return `object->properties`
~~until php 9.0, when dynamic properties are forbidden.~~
(even after php 9.0, because `#[\AllowDynamicProperties]` can be used in subclasses?)

------

Thankfully, [those](https://github.com/php/php-src/pull/8046#issuecomment-1229259497) are the only remaining issues I'm aware of after the last fix https://github.com/php/php-src/pull/8105/files
(delayed __destruct of elements after a var_export call on a collection followed by change such as remove()/pop(), extra memory usage on internal data structures such as SPL after a var_export call, poor worst-case performance for cycle detection in var_export and related functions)