### PR TITLE
Fixed GH-8048: Force macOS to use statfs.

### DIFF
--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -42,6 +42,16 @@
 #  include <os2.h>
 #endif
 
+#if defined(__APPLE__)
+  /*
+   Apple statvfs has an interger overflow in libc copying to statvfs.
+   cvt_statfs_to_statvfs(struct statfs *from, struct statvfs *to) {
+   to->f_blocks = (fsblkcnt_t)from->f_blocks;
+   */
+#  undef HAVE_SYS_STATVFS_H
+#  undef HAVE_STATVFS
+#endif
+
 #if defined(HAVE_SYS_STATVFS_H) && defined(HAVE_STATVFS)
 # include <sys/statvfs.h>
 #elif defined(HAVE_SYS_STATFS_H) && defined(HAVE_STATFS)


### PR DESCRIPTION
A macOS bug in libc statvfs(3) call truncates 64 bit elements (e.g. f_blocks) to 32 bits.

Tested in php@7.4, but it is a clean patch against the current.

t.php:
echo "Total: " . disk_total_space("/Volumes/Data/H1/tank"), PHP_EOL;
echo "Free: " . disk_free_space("/Volumes/Data/H1/tank"), PHP_EOL;

Test results:
mbpm1# df -k/Volumes/Data/H1/tank
Filesystem 1024-blocks Used Available Capacity iused ifree %iused Mounted on
h1:/tank 30259027086 21624936060 8634091026 72% 218 17268182053 0% /System/Volumes/Data/H1/tank

mbpm1# php t.php
Total: 30985243736576
Free: 8841309211136

30985243736576 ~ 302590270861024 off by 512.
8841309211136 ~ 86340910261024 also off by 512.