### PR TITLE
socket module add SO_ATTACH_REUSEPORT_CPBF for Linux.

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -5,7 +5,7 @@ PHP_ARG_ENABLE([sockets],
 
 if test "$PHP_SOCKETS" != "no"; then
   AC_CHECK_FUNCS([hstrerror if_nametoindex if_indextoname])
-  AC_CHECK_HEADERS([netinet/tcp.h sys/un.h sys/sockio.h])
+  AC_CHECK_HEADERS([netinet/tcp.h sys/un.h sys/sockio.h linux/filter.h])
   AC_DEFINE([HAVE_SOCKETS], 1, [ ])
 
   dnl Check for fied ss_family in sockaddr_storage (missing in AIX until 5.3)

--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -1678,6 +1678,27 @@ const SCM_CREDS = UNKNOWN;
  */
 const LOCAL_CREDS = UNKNOWN;
 #endif
+#if defined(SO_ATTACH_REUSEPORT_CBPF)
+/**
+ * @var int
+ * @cvalue SO_ATTACH_REUSEPORT_CBPF
+ */
+const SO_ATTACH_REUSEPORT_CBPF = UNKNOWN;
+#endif
+#if defined(SO_DETACH_FILTER)
+/**
+ * @var int
+ * @cvalue SO_DETACH_FILTER
+ */
+const SO_DETACH_FILTER = UNKNOWN;
+#endif
+#if defined(SO_DETACH_BPF)
+/**
+ * @var int
+ * @cvalue SO_DETACH_BPF
+ */
+const SO_DETACH_BPF = UNKNOWN;
+#endif
 
 /**
  * @strict-properties

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d28c6b566f4739b1eaefb82032e620aeb59728dc */
+ * Stub hash: 546bd6fd43a68c8b6a95b4145afa94c04e36364a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -966,6 +966,15 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if (!defined(LOCAL_CREDS_PERSISTENT) && defined(LOCAL_CREDS))
 	REGISTER_LONG_CONSTANT("LOCAL_CREDS", LOCAL_CREDS, CONST_PERSISTENT);
+#endif
+#if defined(SO_ATTACH_REUSEPORT_CBPF)
+	REGISTER_LONG_CONSTANT("SO_ATTACH_REUSEPORT_CBPF", SO_ATTACH_REUSEPORT_CBPF, CONST_PERSISTENT);
+#endif
+#if defined(SO_DETACH_FILTER)
+	REGISTER_LONG_CONSTANT("SO_DETACH_FILTER", SO_DETACH_FILTER, CONST_PERSISTENT);
+#endif
+#if defined(SO_DETACH_BPF)
+	REGISTER_LONG_CONSTANT("SO_DETACH_BPF", SO_DETACH_BPF, CONST_PERSISTENT);
 #endif
 }
 

--- a/ext/sockets/tests/socket_reuseport_cbpf.phpt
+++ b/ext/sockets/tests/socket_reuseport_cbpf.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test if socket_set_option() works, option:SO_ATTACH_REUSEPORT_CBPF
+--EXTENSIONS--
+sockets
+--SKIPIF--
+<?php
+
+if (!defined("SO_ATTACH_REUSEPORT_CBPF")) {
+	die('SKIP on platforms not supporting SO_ATTACH_REUSEPORT_CBPF');
+}
+?>
+--FILE--
+<?php
+$socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+
+if (!$socket) {
+        die('Unable to create AF_INET socket [socket]');
+}
+var_dump(socket_set_option( $socket, SOL_SOCKET, SO_REUSEADDR, true));
+var_dump(socket_set_option( $socket, SOL_SOCKET, SO_REUSEPORT, true));
+var_dump(socket_set_option( $socket, SOL_SOCKET, SO_ATTACH_REUSEPORT_CBPF, SKF_AD_CPU));
+var_dump(socket_bind($socket, '0.0.0.0'));
+socket_listen($socket);
+socket_close($socket);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
to be used in conjunction with SO_REUSPORT, giving a greater control
over how we bind a socket instead of the round robin workflow, we do
 instead attach to the processor id as :
- we assign the processor_id to A in the BPF filter.
- then returns A.

in other words, a more modern version of SO_INCOMING_CPU (ie can have a per
 worker notion we do not use here).