### PR TITLE
Fix zend_register_internal_class_ex alias generation

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1748,7 +1748,7 @@ class ClassInfo {
         }
 
         if ($this->alias) {
-            $code .= "\tzend_register_class_alias(\"" . str_replace("\\", "_", $this->alias) . "\", class_entry);\n";
+            $code .= "\tzend_register_class_alias(\"" . str_replace("\\", "\\\\", $this->alias) . "\", class_entry);\n";
         }
 
         foreach ($this->enumCaseInfos as $enumCase) {


### PR DESCRIPTION
This wouldn't work for creating aliases in a namespace.

It would create the class alias "MyNS_ClassName" instead of
"MyNS\\ClassName" for `@alias MyNS\ClassName`

This was probably copied from nearby code which created a C identifier, where `_` was the proper separator,
but `\\` is what should be used within a double quoted C string passed to zend_register_internal_class_ex

This has no impact in `php build/gen_stub.php --force-regeneration` for php-src itself