### PR TITLE
Fix GH-8080: ReflectionClass::getConstants() depends on def. order

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4454,7 +4454,7 @@ ZEND_METHOD(ReflectionClass, getConstants)
 
 	array_init(return_value);
 	ZEND_HASH_FOREACH_STR_KEY_PTR(&ce->constants_table, key, constant) {
-		if (UNEXPECTED(zval_update_constant_ex(&constant->value, ce) != SUCCESS)) {
+		if (UNEXPECTED(zval_update_constant_ex(&constant->value, constant->ce) != SUCCESS)) {
 			RETURN_THROWS();
 		}
 
@@ -4511,7 +4511,7 @@ ZEND_METHOD(ReflectionClass, getConstant)
 
 	GET_REFLECTION_OBJECT_PTR(ce);
 	ZEND_HASH_FOREACH_PTR(&ce->constants_table, c) {
-		if (UNEXPECTED(zval_update_constant_ex(&c->value, ce) != SUCCESS)) {
+		if (UNEXPECTED(zval_update_constant_ex(&c->value, c->ce) != SUCCESS)) {
 			RETURN_THROWS();
 		}
 	} ZEND_HASH_FOREACH_END();

--- a/ext/reflection/tests/gh8080.phpt
+++ b/ext/reflection/tests/gh8080.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-8080 (ReflectionClass::getConstants() depends on def. order)
+--FILE--
+<?php
+class A {
+    const LIST = [
+        self::TEST => 'Test',
+    ];
+    private const TEST = 'test';
+}
+
+class B extends A {}
+
+$r = new ReflectionClass(B::class);
+var_dump(
+    $r->getConstants(),
+    $r->getConstant("LIST")
+);
+?>
+--EXPECT--
+array(1) {
+  ["LIST"]=>
+  array(1) {
+    ["test"]=>
+    string(4) "Test"
+  }
+}
+array(1) {
+  ["test"]=>
+  string(4) "Test"
+}


### PR DESCRIPTION
When we need to evaluate constant ASTs, we always have to do that in
the scope where the constant has been defined, which may be a parent
of the `ReflectionClass`'s scope.