### PR TITLE
Fix null static_variable_ptr for uncalled fake closures

### DIFF
--- a/Zend/tests/gh8083.phpt
+++ b/Zend/tests/gh8083.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-8083 (var_dump() on closure with static variable segfaults)
+--FILE--
+<?php
+
+function func() {
+    static $i;
+}
+
+$x = func(...);
+
+var_dump($x);
+
+?>
+--EXPECT--
+object(Closure)#1 (1) {
+  ["static"]=>
+  array(1) {
+    ["i"]=>
+    NULL
+  }
+}

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -697,6 +697,13 @@ static void zend_create_closure_ex(zval *res, zend_function *func, zend_class_en
 			}
 			ZEND_MAP_PTR_INIT(closure->func.op_array.static_variables_ptr,
 				&closure->func.op_array.static_variables);
+		} else if (func->op_array.static_variables) {
+			HashTable *ht = ZEND_MAP_PTR_GET(func->op_array.static_variables_ptr);
+
+			if (!ht) {
+				ht = zend_array_dup(func->op_array.static_variables);
+				ZEND_MAP_PTR_SET(closure->func.op_array.static_variables_ptr, ht);
+			}
 		}
 
 		/* Runtime cache is scope-dependent, so we cannot reuse it if the scope changed */


### PR DESCRIPTION
Closes GH-8083

This is already fixed on `master`.

https://github.com/php/php-src/blob/06de112d327ec10419890ce2d4af7b78eb106073/Zend/zend_closures.c#L700-L708

@dstogov I'm unsure if this fix is correct. Can you check? You made changes to `map_ptr` in the same commit (https://github.com/php/php-src/commit/ddaf64b56c88f0ae223b1aca25293dd7fec77fc0). I don't understand the details of how this works.