### PR TITLE
Allowing catching arg type deprecations in intl classes

### DIFF
--- a/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
+++ b/ext/intl/breakiterator/rulebasedbreakiterator_methods.cpp
@@ -31,7 +31,7 @@ static inline RuleBasedBreakIterator *fetch_rbbi(BreakIterator_object *bio) {
 	return (RuleBasedBreakIterator*)bio->biter;
 }
 
-static void _php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAMETERS)
+static void _php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
 {
 	char		*rules;
 	size_t		rules_len;
@@ -50,6 +50,9 @@ static void _php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAMETERS)
 		zend_throw_error(NULL, "IntlRuleBasedBreakIterator object is already constructed");
 		RETURN_THROWS();
 	}
+
+	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
+	*error_handling_replaced = 1;
 
 	// instantiation of ICU object
 	RuleBasedBreakIterator *rbbi;
@@ -95,11 +98,13 @@ static void _php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAMETERS)
 U_CFUNC PHP_METHOD(IntlRuleBasedBreakIterator, __construct)
 {
 	zend_error_handling error_handling;
+	bool error_handling_replaced = 0;
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
 	return_value = ZEND_THIS;
-	_php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-	zend_restore_error_handling(&error_handling);
+	_php_intlrbbi_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced);
+	if (error_handling_replaced) {
+		zend_restore_error_handling(&error_handling);
+	}
 }
 
 U_CFUNC PHP_METHOD(IntlRuleBasedBreakIterator, getRules)

--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -44,7 +44,7 @@ static inline GregorianCalendar *fetch_greg(Calendar_object *co) {
 }
 
 static void _php_intlgregcal_constructor_body(
-    INTERNAL_FUNCTION_PARAMETERS, bool is_constructor)
+    INTERNAL_FUNCTION_PARAMETERS, bool is_constructor, zend_error_handling *error_handling, bool *error_handling_replaced)
 {
 	zval		*tz_object	= NULL;
 	zval		args_a[6],
@@ -82,6 +82,11 @@ static void _php_intlgregcal_constructor_body(
 			"lll|lll", &largs[0], &largs[1], &largs[2], &largs[3], &largs[4],
 			&largs[5]) == FAILURE) {
 		RETURN_THROWS();
+	}
+
+	if (error_handling != NULL) {
+		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
+		*error_handling_replaced = 1;
 	}
 
 	// instantion of ICU object
@@ -188,17 +193,19 @@ U_CFUNC PHP_FUNCTION(intlgregcal_create_instance)
 	intl_error_reset(NULL);
 
 	object_init_ex(return_value, GregorianCalendar_ce_ptr);
-	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, 0);
+	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, /* is_constructor */ 0, NULL, NULL);
 }
 
 U_CFUNC PHP_METHOD(IntlGregorianCalendar, __construct)
 {
 	zend_error_handling error_handling;
+	bool error_handling_replaced = 0;
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
 	return_value = ZEND_THIS;
-	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1);
-	zend_restore_error_handling(&error_handling);
+	_php_intlgregcal_constructor_body(INTERNAL_FUNCTION_PARAM_PASSTHRU, /* is_constructor */ 1, &error_handling, &error_handling_replaced);
+	if (error_handling_replaced) {
+		zend_restore_error_handling(&error_handling);
+	}
 }
 
 U_CFUNC PHP_FUNCTION(intlgregcal_set_gregorian_change)

--- a/ext/intl/collator/collator_create.c
+++ b/ext/intl/collator/collator_create.c
@@ -22,7 +22,7 @@
 #include "intl_data.h"
 
 /* {{{ */
-static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS)
+static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
 {
 	const char*      locale;
 	size_t           locale_len = 0;
@@ -36,6 +36,11 @@ static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS)
 		&locale, &locale_len ) == FAILURE )
 	{
 		return FAILURE;
+	}
+
+	if (error_handling != NULL) {
+		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
+		*error_handling_replaced = 1;
 	}
 
 	INTL_CHECK_LOCALE_LEN_OR_FAILURE(locale_len);
@@ -56,7 +61,7 @@ static int collator_ctor(INTERNAL_FUNCTION_PARAMETERS)
 PHP_FUNCTION( collator_create )
 {
 	object_init_ex( return_value, Collator_ce_ptr );
-	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}
@@ -67,14 +72,16 @@ PHP_FUNCTION( collator_create )
 PHP_METHOD( Collator, __construct )
 {
 	zend_error_handling error_handling;
+	bool error_handling_replaced = 0;
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
 	return_value = ZEND_THIS;
-	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+	if (collator_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced) == FAILURE) {
 		if (!EG(exception)) {
 			zend_throw_exception(IntlException_ce_ptr, "Constructor failed", 0);
 		}
 	}
-	zend_restore_error_handling(&error_handling);
+	if (error_handling_replaced) {
+		zend_restore_error_handling(&error_handling);
+	}
 }
 /* }}} */

--- a/ext/intl/msgformat/msgformat.c
+++ b/ext/intl/msgformat/msgformat.c
@@ -25,7 +25,7 @@
 #include "intl_convert.h"
 
 /* {{{ */
-static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
+static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
 {
 	const char* locale;
 	char*       pattern;
@@ -43,6 +43,11 @@ static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 		&locale, &locale_len, &pattern, &pattern_len ) == FAILURE )
 	{
 		return FAILURE;
+	}
+
+	if (error_handling != NULL) {
+		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
+		*error_handling_replaced = 1;
 	}
 
 	INTL_CHECK_LOCALE_LEN_OR_FAILURE(locale_len);
@@ -104,7 +109,7 @@ static int msgfmt_ctor(INTERNAL_FUNCTION_PARAMETERS)
 PHP_FUNCTION( msgfmt_create )
 {
 	object_init_ex( return_value, MessageFormatter_ce_ptr );
-	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}
@@ -115,17 +120,19 @@ PHP_FUNCTION( msgfmt_create )
 PHP_METHOD( MessageFormatter, __construct )
 {
 	zend_error_handling error_handling;
+	bool error_handling_replaced = 0;
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
 	return_value = ZEND_THIS;
-	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+	if (msgfmt_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU,  &error_handling, &error_handling_replaced) == FAILURE) {
 		if (!EG(exception)) {
 			zend_string *err = intl_error_get_message(NULL);
 			zend_throw_exception(IntlException_ce_ptr, ZSTR_VAL(err), intl_error_get_code(NULL));
 			zend_string_release_ex(err, 0);
 		}
 	}
-	zend_restore_error_handling(&error_handling);
+	if (error_handling_replaced) {
+		zend_restore_error_handling(&error_handling);
+	}
 }
 /* }}} */
 

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -74,7 +74,7 @@ static zend_object *ResourceBundle_object_create( zend_class_entry *ce )
 /* }}} */
 
 /* {{{ ResourceBundle_ctor */
-static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS)
+static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_handling, bool *error_handling_replaced)
 {
 	const char *bundlename;
 	size_t		bundlename_len = 0;
@@ -91,6 +91,11 @@ static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS)
 		&locale, &locale_len, &bundlename, &bundlename_len, &fallback ) == FAILURE )
 	{
 		return FAILURE;
+	}
+
+	if (error_handling != NULL) {
+		zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, error_handling);
+		*error_handling_replaced = 1;
 	}
 
 	if (rb->me) {
@@ -139,15 +144,17 @@ static int resourcebundle_ctor(INTERNAL_FUNCTION_PARAMETERS)
 PHP_METHOD( ResourceBundle, __construct )
 {
 	zend_error_handling error_handling;
+	bool error_handling_replaced = 0;
 
-	zend_replace_error_handling(EH_THROW, IntlException_ce_ptr, &error_handling);
 	return_value = ZEND_THIS;
-	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, &error_handling, &error_handling_replaced) == FAILURE) {
 		if (!EG(exception)) {
 			zend_throw_exception(IntlException_ce_ptr, "Constructor failed", 0);
 		}
 	}
-	zend_restore_error_handling(&error_handling);
+	if (error_handling_replaced) {
+		zend_restore_error_handling(&error_handling);
+	}
 }
 /* }}} */
 
@@ -155,7 +162,7 @@ PHP_METHOD( ResourceBundle, __construct )
 PHP_FUNCTION( resourcebundle_create )
 {
 	object_init_ex( return_value, ResourceBundle_ce_ptr );
-	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU) == FAILURE) {
+	if (resourcebundle_ctor(INTERNAL_FUNCTION_PARAM_PASSTHRU, NULL, NULL) == FAILURE) {
 		zval_ptr_dtor(return_value);
 		RETURN_NULL();
 	}

--- a/ext/intl/tests/gh8115.phpt
+++ b/ext/intl/tests/gh8115.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-8115 (Can't catch deprecation in IntlDateFormatter)
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+error_reporting(E_ALL);
+set_error_handler(function ($errNo, $errStr) {
+    echo "Caught ($errNo): $errStr\n";
+});
+try {
+    new \IntlDateFormatter(null, null, null);
+} catch (\IntlException) {}
+try {
+    new \IntlRuleBasedBreakIterator(null, null);
+} catch (\IntlException) {}
+// Can't be tested since all params are optional
+new \IntlGregorianCalendar(null, null);
+new \Collator(null);
+// Can't be tested since all params are optional
+new \IntlDatePatternGenerator(null);
+new \NumberFormatter(null, null);
+try {
+    new \MessageFormatter(null, null);
+} catch (\IntlException) {}
+new \ResourceBundle(null, null, null);
+
+?>
+--EXPECT--
+Caught (8192): IntlDateFormatter::__construct(): Passing null to parameter #2 ($dateType) of type int is deprecated
+Caught (8192): IntlDateFormatter::__construct(): Passing null to parameter #3 ($timeType) of type int is deprecated
+Caught (8192): IntlRuleBasedBreakIterator::__construct(): Passing null to parameter #1 ($rules) of type string is deprecated
+Caught (8192): IntlRuleBasedBreakIterator::__construct(): Passing null to parameter #2 ($compiled) of type bool is deprecated
+Caught (8192): Collator::__construct(): Passing null to parameter #1 ($locale) of type string is deprecated
+Caught (8192): NumberFormatter::__construct(): Passing null to parameter #1 ($locale) of type string is deprecated
+Caught (8192): NumberFormatter::__construct(): Passing null to parameter #2 ($style) of type int is deprecated
+Caught (8192): MessageFormatter::__construct(): Passing null to parameter #1 ($locale) of type string is deprecated
+Caught (8192): MessageFormatter::__construct(): Passing null to parameter #2 ($pattern) of type string is deprecated
+Caught (8192): ResourceBundle::__construct(): Passing null to parameter #3 ($fallback) of type bool is deprecated


### PR DESCRIPTION
Closes GH-8115

Doesn't affect PHP-8.0 since the "Passing null to parameter" deprecation was introduced in PHP 8.1.

It's somewhat sub-optimal that `zend_replace_error_handling` and `zend_restore_error_handling` are now called in different places but moving them into the given function was not trivially possible because the inner functions usually have multiple exit points.