### PR TITLE
Adjust filename/lineno for constant expressions

### DIFF
--- a/Zend/tests/bug41633_2.phpt
+++ b/Zend/tests/bug41633_2.phpt
@@ -11,4 +11,4 @@ echo Foo::A."\n";
 Fatal error: Uncaught Error: Undefined constant self::B in %s:%d
 Stack trace:
 #0 {main}
-  thrown in %sbug41633_2.php on line 5
+  thrown in %sbug41633_2.php on line 3

--- a/Zend/tests/gh7771_1.phpt
+++ b/Zend/tests/gh7771_1.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-7771 (Incorrect file/line for class constant expression exceptions)
+--FILE--
+<?php
+
+include __DIR__ . '/gh7771_1_definition.inc';
+
+new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Class "NonExistent" not found in %sgh7771_1_definition.inc:4
+Stack trace:
+#0 {main}
+  thrown in %sgh7771_1_definition.inc on line 4

--- a/Zend/tests/gh7771_1_definition.inc
+++ b/Zend/tests/gh7771_1_definition.inc
@@ -1,0 +1,5 @@
+<?php
+
+class Foo {
+	public const BAR = NonExistent::CLASS_CONSTANT;
+}

--- a/Zend/tests/gh7771_2.phpt
+++ b/Zend/tests/gh7771_2.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GH-7771 (Incorrect file/line for class constant expression exceptions)
+--FILE--
+<?php
+
+include __DIR__ . '/gh7771_2_definition.inc';
+
+new Foo();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Class "NonExistent" not found in %sgh7771_2_definition.inc:6
+Stack trace:
+#0 {main}
+  thrown in %sgh7771_2_definition.inc on line 6

--- a/Zend/tests/gh7771_2_definition.inc
+++ b/Zend/tests/gh7771_2_definition.inc
@@ -1,0 +1,8 @@
+<?php
+
+class Foo {
+	public const BAR = 
+		self::BAZ
+		+ NonExistent::CLASS_CONSTANT;
+	public const BAZ = 42;
+}

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -789,7 +789,20 @@ ZEND_API zend_result ZEND_FASTCALL zend_ast_evaluate(zval *result, zend_ast *ast
 		{
 			zend_string *class_name = zend_ast_get_str(ast->child[0]);
 			zend_string *const_name = zend_ast_get_str(ast->child[1]);
+
+			zend_string *previous_filename;
+			zend_long previous_lineno;
+			if (scope) {
+				previous_filename = EG(exception_filename);
+				previous_lineno = EG(exception_lineno);
+				EG(exception_filename) = scope->info.user.filename;
+				EG(exception_lineno) = zend_ast_get_lineno(ast);
+			}
 			zval *zv = zend_get_class_constant_ex(class_name, const_name, scope, ast->attr);
+			if (scope) {
+				EG(exception_filename) = previous_filename;
+				EG(exception_lineno) = previous_lineno;
+			}
 
 			if (UNEXPECTED(zv == NULL)) {
 				ZVAL_UNDEF(result);
@@ -951,6 +964,7 @@ static void* ZEND_FASTCALL zend_ast_tree_copy(zend_ast *ast, void *buf)
 		zend_ast *new = (zend_ast*)buf;
 		new->kind = ast->kind;
 		new->attr = ast->attr;
+		new->lineno = ast->lineno;
 		buf = (void*)((char*)buf + zend_ast_size(children));
 		for (i = 0; i < children; i++) {
 			if (ast->child[i]) {

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -793,15 +793,15 @@ ZEND_API zend_result ZEND_FASTCALL zend_ast_evaluate(zval *result, zend_ast *ast
 			zend_string *previous_filename;
 			zend_long previous_lineno;
 			if (scope) {
-				previous_filename = EG(exception_filename);
-				previous_lineno = EG(exception_lineno);
-				EG(exception_filename) = scope->info.user.filename;
-				EG(exception_lineno) = zend_ast_get_lineno(ast);
+				previous_filename = EG(filename_override);
+				previous_lineno = EG(lineno_override);
+				EG(filename_override) = scope->info.user.filename;
+				EG(lineno_override) = zend_ast_get_lineno(ast);
 			}
 			zval *zv = zend_get_class_constant_ex(class_name, const_name, scope, ast->attr);
 			if (scope) {
-				EG(exception_filename) = previous_filename;
-				EG(exception_lineno) = previous_lineno;
+				EG(filename_override) = previous_filename;
+				EG(lineno_override) = previous_lineno;
 			}
 
 			if (UNEXPECTED(zv == NULL)) {

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -822,6 +822,17 @@ static zend_object *zend_throw_exception_zstr(zend_class_entry *exception_ce, ze
 		zend_update_property_ex(exception_ce, Z_OBJ(ex), ZSTR_KNOWN(ZEND_STR_CODE), &tmp);
 	}
 
+	zend_string *exception_filename = EG(exception_filename);
+	if (exception_filename != NULL) {
+		ZVAL_STR(&tmp, exception_filename);
+		zend_update_property_ex(exception_ce, Z_OBJ(ex), ZSTR_KNOWN(ZEND_STR_FILE), &tmp);
+
+		zend_long exception_filename = EG(exception_lineno);
+		ZEND_ASSERT(exception_filename != -1);
+		ZVAL_LONG(&tmp, exception_filename);
+		zend_update_property_ex(exception_ce, Z_OBJ(ex), ZSTR_KNOWN(ZEND_STR_LINE), &tmp);
+	}
+
 	zend_throw_exception_internal(Z_OBJ(ex));
 
 	return Z_OBJ(ex);

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -822,17 +822,6 @@ static zend_object *zend_throw_exception_zstr(zend_class_entry *exception_ce, ze
 		zend_update_property_ex(exception_ce, Z_OBJ(ex), ZSTR_KNOWN(ZEND_STR_CODE), &tmp);
 	}
 
-	zend_string *exception_filename = EG(exception_filename);
-	if (exception_filename != NULL) {
-		ZVAL_STR(&tmp, exception_filename);
-		zend_update_property_ex(exception_ce, Z_OBJ(ex), ZSTR_KNOWN(ZEND_STR_FILE), &tmp);
-
-		zend_long exception_filename = EG(exception_lineno);
-		ZEND_ASSERT(exception_filename != -1);
-		ZVAL_LONG(&tmp, exception_filename);
-		zend_update_property_ex(exception_ce, Z_OBJ(ex), ZSTR_KNOWN(ZEND_STR_LINE), &tmp);
-	}
-
 	zend_throw_exception_internal(Z_OBJ(ex));
 
 	return Z_OBJ(ex);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -192,8 +192,8 @@ void init_executor(void) /* {{{ */
 	EG(num_errors) = 0;
 	EG(errors) = NULL;
 
-	EG(exception_filename) = NULL;
-	EG(exception_lineno) = -1;
+	EG(filename_override) = NULL;
+	EG(lineno_override) = -1;
 
 	zend_fiber_init();
 	zend_weakrefs_init();
@@ -454,7 +454,7 @@ void shutdown_executor(void) /* {{{ */
 			efree(EG(ht_iterators));
 		}
 
-		ZEND_ASSERT(EG(exception_filename) == NULL);
+		ZEND_ASSERT(EG(filename_override) == NULL);
 	}
 
 #if ZEND_DEBUG
@@ -584,21 +584,18 @@ ZEND_API const char *get_function_arg_name(const zend_function *func, uint32_t a
 
 ZEND_API const char *zend_get_executed_filename(void) /* {{{ */
 {
-	zend_execute_data *ex = EG(current_execute_data);
-
-	while (ex && (!ex->func || !ZEND_USER_CODE(ex->func->type))) {
-		ex = ex->prev_execute_data;
-	}
-	if (ex) {
-		return ZSTR_VAL(ex->func->op_array.filename);
-	} else {
-		return "[no active file]";
-	}
+	zend_string *filename = zend_get_executed_filename_ex();
+	return filename != NULL ? ZSTR_VAL(filename) : "[no active file]";
 }
 /* }}} */
 
 ZEND_API zend_string *zend_get_executed_filename_ex(void) /* {{{ */
 {
+	zend_string *filename_override = EG(filename_override);
+	if (filename_override != NULL) {
+		return filename_override;
+	}
+
 	zend_execute_data *ex = EG(current_execute_data);
 
 	while (ex && (!ex->func || !ZEND_USER_CODE(ex->func->type))) {
@@ -614,6 +611,11 @@ ZEND_API zend_string *zend_get_executed_filename_ex(void) /* {{{ */
 
 ZEND_API uint32_t zend_get_executed_lineno(void) /* {{{ */
 {
+	zend_long lineno_override = EG(lineno_override);
+	if (lineno_override != -1) {
+		return lineno_override;
+	}
+
 	zend_execute_data *ex = EG(current_execute_data);
 
 	while (ex && (!ex->func || !ZEND_USER_CODE(ex->func->type))) {

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -192,6 +192,9 @@ void init_executor(void) /* {{{ */
 	EG(num_errors) = 0;
 	EG(errors) = NULL;
 
+	EG(exception_filename) = NULL;
+	EG(exception_lineno) = -1;
+
 	zend_fiber_init();
 	zend_weakrefs_init();
 
@@ -450,6 +453,8 @@ void shutdown_executor(void) /* {{{ */
 		if (EG(ht_iterators) != EG(ht_iterators_slots)) {
 			efree(EG(ht_iterators));
 		}
+
+		ZEND_ASSERT(EG(exception_filename) == NULL);
 	}
 
 #if ZEND_DEBUG

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -266,6 +266,10 @@ struct _zend_executor_globals {
 	uint32_t num_errors;
 	zend_error_info **errors;
 
+	/* Overwrite filename or line number of thrown exceptions */
+	zend_string *exception_filename;
+	zend_long exception_lineno;
+
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -266,9 +266,9 @@ struct _zend_executor_globals {
 	uint32_t num_errors;
 	zend_error_info **errors;
 
-	/* Overwrite filename or line number of thrown exceptions */
-	zend_string *exception_filename;
-	zend_long exception_lineno;
+	/* Override filename or line number of thrown errors and exceptions */
+	zend_string *filename_override;
+	zend_long lineno_override;
 
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };


### PR DESCRIPTION
Closes GH-7771

The approach in the PR is to simply replace filename/lineno in the exception, similar to ErrorException. Since there are tons paths for throwing errors in constant expressions I avoided passing the name/lineno by storing it in the execution globals.

Unfortunately the lineno in the AST somewhere. Let me know if this approach is ok before I spend too much time on this.