### PR TITLE
Fix GH-8074: Wrong type inference of range() result

### DIFF
--- a/ext/opcache/Optimizer/zend_func_info.c
+++ b/ext/opcache/Optimizer/zend_func_info.c
@@ -78,7 +78,7 @@ static uint32_t zend_range_info(const zend_call_info *call_info, const zend_ssa 
 				|| (t3 & (MAY_BE_DOUBLE|MAY_BE_STRING))) {
 			tmp |= MAY_BE_ARRAY_OF_DOUBLE;
 		}
-		if ((t1 & (MAY_BE_ANY-(MAY_BE_STRING|MAY_BE_DOUBLE))) && (t2 & (MAY_BE_ANY-(MAY_BE_STRING|MAY_BE_DOUBLE)))) {
+		if ((t1 & (MAY_BE_ANY-MAY_BE_DOUBLE)) && (t2 & (MAY_BE_ANY-MAY_BE_DOUBLE))) {
 			if ((t3 & MAY_BE_ANY) != MAY_BE_DOUBLE) {
 				tmp |= MAY_BE_ARRAY_OF_LONG;
 			}

--- a/ext/opcache/tests/opt/gh8074.phpt
+++ b/ext/opcache/tests/opt/gh8074.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-8074 (Wrong type inference of range() result)
+--FILE--
+<?php
+function test() {
+    $array = range(1, "2");
+
+    foreach ($array as $i) {
+        var_dump($i + 1);
+    }
+}
+
+test();
+?>
+--EXPECT--
+int(2)
+int(3)


### PR DESCRIPTION
If either the first or second operand of `range()` may be a string, we
must not exclude the possibility that the result may be an array of
longs.