### PR TITLE
mb_check_encoding($str, '7bit') rejects strings with bytes over 0x7F

### DIFF
--- a/ext/mbstring/libmbfl/filters/mbfilter_7bit.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_7bit.c
@@ -69,7 +69,7 @@ const struct mbfl_convert_vtbl vtbl_7bit_8bit = {
 
 int mbfl_filt_conv_7bit_any(int c, mbfl_convert_filter *filter)
 {
-	return (*filter->output_function)(c, filter->data);
+	return (*filter->output_function)(c < 0x80 ? c : MBFL_BAD_INPUT, filter->data);
 }
 
 

--- a/ext/mbstring/tests/other_encodings.phpt
+++ b/ext/mbstring/tests/other_encodings.phpt
@@ -14,10 +14,11 @@ mb_substitute_character(0x25);
 var_dump(mb_convert_encoding("ABC", "7bit", "ASCII"));
 var_dump(mb_convert_encoding("\x80", "7bit", "ASCII"));
 var_dump(mb_convert_encoding("ABC", "8bit", "7bit"));
+var_dump(mb_check_encoding(chr(255), '7bit'));
 echo "7bit done\n";
 
 // "8bit"
-var_dump(mb_convert_encoding("\x01\x00", "8bit", "UTF-16BE")); // codepoints over 0xFF are illegal or '8-bit'
+var_dump(mb_convert_encoding("\x01\x00", "8bit", "UTF-16BE")); // codepoints over 0xFF are illegal for '8-bit'
 echo "8bit done\n";
 
 ?>
@@ -25,6 +26,7 @@ echo "8bit done\n";
 string(3) "ABC"
 string(1) "%"
 string(3) "ABC"
+bool(false)
 7bit done
 string(1) "%"
 8bit done


### PR DESCRIPTION
This was the old behavior of mb_check_encoding() before 3e7acf901d, but yours truly broke it. If only we had more thorough tests at that time, this might not have slipped through the cracks.

Thanks to @divinity76 for the report.

FYA @cmb69 
Maybe @nikic might also want to have a look, if he's not too busy.