### PR TITLE
Migrate CI to GitHub actions

### DIFF
--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -1,0 +1,66 @@
+name: apt
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        sudo apt install bison \
+          re2c \
+          locales \
+          ldap-utils \
+          openssl \
+          slapd \
+          language-pack-de \
+          libgmp-dev \
+          libicu-dev \
+          libtidy-dev \
+          libenchant-dev \
+          libaspell-dev \
+          libpspell-dev \
+          libsasl2-dev \
+          libxpm-dev \
+          libzip-dev \
+          libsqlite3-dev \
+          libwebp-dev \
+          libonig-dev \
+          libkrb5-dev \
+          libgssapi-krb5-2 \
+          libcurl4-openssl-dev \
+          libxml2-dev \
+          libxslt1-dev \
+          libpq-dev \
+          libreadline-dev \
+          libldap2-dev \
+          libsodium-dev \
+          libargon2-0-dev \
+          libmm-dev \
+          libsnmp-dev \
+          postgresql \
+          postgresql-contrib \
+          snmpd \
+          snmp-mibs-downloader \
+          freetds-dev \
+          unixodbc-dev \
+          llvm \
+          libc-client-dev \
+          dovecot-core \
+          dovecot-pop3d \
+          dovecot-imapd \
+          sendmail \
+          firebird-dev \
+          liblmdb-dev \
+          libtokyocabinet-dev \
+          libdb-dev \
+          libqdbm-dev \
+          libjpeg-dev \
+          libpng-dev \
+          libfreetype6-dev
+        mkdir /opt/oracle
+        wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip
+        unzip instantclient-basiclite-linuxx64.zip
+        wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+        unzip instantclient-sdk-linuxx64.zip
+        mv instantclient_*_* /opt/oracle/instantclient
+        # Interferes with libldap2 headers.
+        rm /opt/oracle/instantclient/sdk/include/ldap.h

--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -1,0 +1,32 @@
+name: brew
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        brew install pkg-config \
+          autoconf \
+          bison \
+          re2c
+        brew install openssl@1.1 \
+          krb5 \
+          bzip2 \
+          enchant \
+          libffi \
+          libpng \
+          webp \
+          freetype \
+          intltool \
+          icu4c \
+          libiconv \
+          zlib \
+          t1lib \
+          gd \
+          libzip \
+          gmp \
+          tidyp \
+          libxml2 \
+          libxslt \
+          postgresql
+        brew link icu4c gettext --force

--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -1,0 +1,71 @@
+name: ./configure
+inputs:
+  configurationParameters:
+    default: ''
+    required: false
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        export PATH="/usr/local/opt/bison/bin:$PATH"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/krb5/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libffi/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxml2/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/libxslt/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/zlib/lib/pkgconfig"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig"
+        ./buildconf --force
+        ./configure \
+          --enable-option-checking=fatal \
+          --prefix=/usr/local \
+          --enable-fpm \
+          --with-pdo-mysql=mysqlnd \
+          --with-mysqli=mysqlnd \
+          --with-pgsql=/usr/local/opt/libpq \
+          --with-pdo-pgsql=/usr/local/opt/libpq \
+          --with-pdo-sqlite \
+          --without-pear \
+          --enable-gd \
+          --with-jpeg \
+          --with-webp \
+          --with-freetype \
+          --enable-exif \
+          --with-zip \
+          --with-zlib \
+          --enable-soap \
+          --enable-xmlreader \
+          --with-xsl \
+          --with-tidy=/usr/local/opt/tidyp \
+          --with-libxml \
+          --enable-sysvsem \
+          --enable-sysvshm \
+          --enable-shmop \
+          --enable-pcntl \
+          --with-readline=/usr/local/opt/readline \
+          --enable-mbstring \
+          --with-curl \
+          --with-gettext=/usr/local/opt/gettext \
+          --enable-sockets \
+          --with-bz2=/usr/local/opt/bzip2 \
+          --with-openssl \
+          --with-gmp=/usr/local/opt/gmp \
+          --with-iconv=/usr/local/opt/libiconv \
+          --enable-bcmath \
+          --enable-calendar \
+          --enable-ftp \
+          --with-pspell=/usr/local/opt/aspell \
+          --with-kerberos \
+          --enable-sysvmsg \
+          --with-ffi \
+          --enable-zend-test \
+          --enable-intl \
+          --with-mhash \
+          --with-sodium \
+          --enable-dba \
+          --enable-werror \
+          --with-config-file-path=/etc \
+          --with-config-file-scan-dir=/etc/php.d \
+          ${{ inputs.configurationParameters }}

--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -1,0 +1,84 @@
+name: ./configure
+inputs:
+  configurationParameters:
+    default: ''
+    required: false
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        ./buildconf --force
+        ./configure \
+          --enable-option-checking=fatal \
+          --prefix=/usr \
+          --enable-phpdbg \
+          --enable-fpm \
+          --with-pdo-mysql=mysqlnd \
+          --with-mysqli=mysqlnd \
+          --with-pgsql \
+          --with-pdo-pgsql \
+          --with-pdo-sqlite \
+          --enable-intl \
+          --without-pear \
+          --enable-gd \
+          --with-jpeg \
+          --with-webp \
+          --with-freetype \
+          --with-xpm \
+          --enable-exif \
+          --with-zip \
+          --with-zlib \
+          --with-zlib-dir=/usr \
+          --enable-soap \
+          --enable-xmlreader \
+          --with-xsl \
+          --with-tidy \
+          --enable-sysvsem \
+          --enable-sysvshm \
+          --enable-shmop \
+          --enable-pcntl \
+          --with-readline \
+          --enable-mbstring \
+          --with-curl \
+          --with-gettext \
+          --enable-sockets \
+          --with-bz2 \
+          --with-openssl \
+          --with-gmp \
+          --enable-bcmath \
+          --enable-calendar \
+          --enable-ftp \
+          --with-pspell=/usr \
+          --with-enchant=/usr \
+          --with-kerberos \
+          --enable-sysvmsg \
+          --with-ffi \
+          --enable-zend-test \
+          --with-ldap \
+          --with-ldap-sasl \
+          --with-password-argon2 \
+          --with-mhash \
+          --with-sodium \
+          --enable-dba \
+          --with-cdb \
+          --enable-flatfile \
+          --enable-inifile \
+          --with-tcadb \
+          --with-lmdb \
+          --with-qdbm \
+          --with-snmp \
+          --with-unixODBC \
+          --with-imap \
+          --with-kerberos \
+          --with-imap-ssl \
+          --with-pdo-odbc=unixODBC,/usr \
+          --with-pdo-firebird \
+          --with-pdo-dblib \
+          --with-pdo-oci=shared,instantclient,/opt/oracle/instantclient \
+          --with-oci8=shared,instantclient,/opt/oracle/instantclient \
+          --enable-werror \
+          --with-config-file-path=/etc \
+          --with-config-file-scan-dir=/etc/php.d \
+          ${{ inputs.configurationParameters }}

--- a/.github/actions/install-linux/action.yml
+++ b/.github/actions/install-linux/action.yml
@@ -1,0 +1,14 @@
+name: Install
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        sudo make install
+        sudo mkdir     /etc/php.d
+        sudo chmod 777 /etc/php.d
+        echo mysqli.default_socket=/var/run/mysqld/mysqld.sock    > /etc/php.d/mysqli.ini
+        echo pdo_mysql.default_socket=/var/run/mysqld/mysqld.sock > /etc/php.d/pdo_mysql.ini
+        echo opcache.enable_cli=1 >> /etc/php.d/opcache.ini
+        echo opcache.protect_memory=1 >> /etc/php.d/opcache.ini

--- a/.github/actions/mssql/action.yml
+++ b/.github/actions/mssql/action.yml
@@ -1,0 +1,14 @@
+name: Create mssql container
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        docker run \
+          -e "ACCEPT_EULA=Y" \
+          -e "SA_PASSWORD=<YourStrong@Passw0rd>" \
+          -p 1433:1433 \
+          --name sql1 \
+          -h sql1 \
+          -d mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04

--- a/.github/actions/setup-x64/action.yml
+++ b/.github/actions/setup-x64/action.yml
@@ -1,0 +1,30 @@
+name: Setup
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+
+        sudo service mysql start
+        sudo service postgresql start
+        sudo service slapd start
+        mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS test"
+        # Ensure local_infile tests can run.
+        mysql -uroot -proot -e "SET GLOBAL local_infile = true"
+        sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+        sudo -u postgres psql -c "CREATE DATABASE test;"
+        docker exec sql1 /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U SA -P "<YourStrong@Passw0rd>" -Q "create login pdo_test with password='password', check_policy=off; create user pdo_test for login pdo_test; grant alter, control to pdo_test;"
+        sudo locale-gen de_DE
+
+        ./.github/scripts/setup-slapd.sh
+
+        sudo cp ext/snmp/tests/snmpd.conf /etc/snmp
+        sudo cp ext/snmp/tests/bigtest /etc/snmp
+        sudo service snmpd restart
+
+        sudo groupadd -g 5000 vmail
+        sudo useradd -m -d /var/vmail -s /bin/false -u 5000 -g vmail vmail
+        sudo cp ext/imap/tests/setup/dovecot.conf /etc/dovecot/dovecot.conf
+        sudo cp ext/imap/tests/setup/dovecotpass /etc/dovecot/dovecotpass
+        sudo service dovecot restart

--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -1,0 +1,27 @@
+name: Test
+inputs:
+  runTestsParameters:
+    default: ''
+    required: false
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        export MYSQL_TEST_USER=root
+        export MYSQL_TEST_PASSWD=root
+        export PDO_MYSQL_TEST_DSN="mysql:host=localhost;dbname=test"
+        export PDO_MYSQL_TEST_USER=root
+        export PDO_MYSQL_TEST_PASS=root
+        export PDO_DBLIB_TEST_DSN="dblib:host=127.0.0.1;dbname=master;version=7.0"
+        export PDO_DBLIB_TEST_USER="pdo_test"
+        export PDO_DBLIB_TEST_PASS="password"
+        export SKIP_IO_CAPTURE_TESTS=1
+        sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
+          -j$(/usr/bin/nproc) \
+          -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP \
+          --offline \
+          --show-diff \
+          --show-slow 1000 \
+          --set-timeout 120

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -1,0 +1,20 @@
+name: Test
+inputs:
+  runTestsParameters:
+    default: ''
+    required: false
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        export SKIP_IO_CAPTURE_TESTS=1
+        export CI_NO_IPV6=1
+        sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
+          -j$(sysctl -n hw.ncpu) \
+          -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP \
+          --offline \
+          --show-diff \
+          --show-slow 1000 \
+          --set-timeout 120

--- a/.github/scripts/setup-slapd.sh
+++ b/.github/scripts/setup-slapd.sh
@@ -1,0 +1,185 @@
+#!/bin/sh
+set -ev
+
+# Create TLS certificate
+sudo mkdir -p /etc/ldap/ssl
+
+alt_names() {
+  (
+      (
+        (hostname && hostname -a && hostname -A && hostname -f) |
+        xargs -n 1 |
+        sort -u |
+        sed -e 's/\(\S\+\)/DNS:\1/g'
+      ) && (
+        (hostname -i && hostname -I && echo "127.0.0.1 ::1") |
+        xargs -n 1 |
+        sort -u |
+        sed -e 's/\(\S\+\)/IP:\1/g'
+      )
+  ) | paste -d, -s
+}
+
+sudo openssl req -newkey rsa:4096 -x509 -nodes -days 3650 \
+  -out /etc/ldap/ssl/server.crt -keyout /etc/ldap/ssl/server.key \
+  -subj "/C=US/ST=Arizona/L=Localhost/O=localhost/CN=localhost" \
+  -addext "subjectAltName = `alt_names`"
+
+sudo chown -R openldap:openldap /etc/ldap/ssl
+
+# Display the TLS certificate (should be world readable)
+openssl x509 -noout -text -in /etc/ldap/ssl/server.crt
+
+# Point to the certificate generated
+if ! grep -q 'TLS_CACERT \/etc\/ldap\/ssl\/server.crt' /etc/ldap/ldap.conf; then
+  sudo sed -e 's|^\s*TLS_CACERT|# TLS_CACERT|' -i /etc/ldap/ldap.conf
+  echo 'TLS_CACERT /etc/ldap/ssl/server.crt' | sudo tee -a /etc/ldap/ldap.conf
+fi
+
+# Configure LDAP protocols to serve.
+sudo sed -e 's|^\s*SLAPD_SERVICES\s*=.*$|SLAPD_SERVICES="ldap:/// ldaps:/// ldapi:///"|' -i /etc/default/slapd
+
+# Configure LDAP database.
+DBDN=`sudo ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b cn=config '(&(olcRootDN=*)(olcSuffix=*))' dn | grep -i '^dn:' | sed -e 's/^dn:\s*//'`;
+
+sudo ldapadd -Q -Y EXTERNAL -H ldapi:/// -f /etc/ldap/schema/ppolicy.ldif
+
+sudo service slapd restart
+
+sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: $DBDN
+changetype: modify
+replace: olcSuffix
+olcSuffix: dc=my-domain,dc=com
+-
+replace: olcRootDN
+olcRootDN: cn=Manager,dc=my-domain,dc=com
+-
+replace: olcRootPW
+olcRootPW: secret
+
+dn: cn=config
+changetype: modify
+add: olcTLSCACertificateFile
+olcTLSCACertificateFile: /etc/ldap/ssl/server.crt
+-
+add: olcTLSCertificateFile
+olcTLSCertificateFile: /etc/ldap/ssl/server.crt
+-
+add: olcTLSCertificateKeyFile
+olcTLSCertificateKeyFile: /etc/ldap/ssl/server.key
+-
+add: olcTLSVerifyClient
+olcTLSVerifyClient: never
+-
+add: olcAuthzRegexp
+olcAuthzRegexp: uid=usera,cn=digest-md5,cn=auth cn=usera,dc=my-domain,dc=com
+-
+replace: olcLogLevel
+olcLogLevel: -1
+
+dn: cn=module{0},cn=config
+changetype: modify
+add: olcModuleLoad
+olcModuleLoad: sssvlv
+-
+add: olcModuleLoad
+olcModuleLoad: ppolicy
+-
+add: olcModuleLoad
+olcModuleLoad: dds
+EOF
+
+sudo service slapd restart
+
+sudo ldapadd -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: olcOverlay=sssvlv,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcSssVlvConfig
+olcOverlay: sssvlv
+olcSssVlvMax: 10
+olcSssVlvMaxKeys: 5
+
+dn: olcOverlay=ppolicy,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcPPolicyConfig
+olcOverlay: ppolicy
+### This would clutter our DIT and make tests to fail, while ppolicy does not
+### seem to work as we expect (it does not seem to provide expected controls)
+## olcPPolicyDefault: cn=default,ou=pwpolicies,dc=my-domain,dc=com
+## olcPPolicyHashCleartext: FALSE
+## olcPPolicyUseLockout: TRUE
+
+dn: olcOverlay=dds,$DBDN
+objectClass: olcOverlayConfig
+objectClass: olcDdsConfig
+olcOverlay: dds
+EOF
+
+sudo service slapd restart
+
+sudo ldapmodify -Q -Y EXTERNAL -H ldapi:/// << EOF
+dn: $DBDN
+changetype: modify
+add: olcDbIndex
+olcDbIndex: entryExpireTimestamp eq
+EOF
+
+sudo service slapd restart
+
+ldapadd -H ldapi:/// -D cn=Manager,dc=my-domain,dc=com -w secret <<EOF
+dn: dc=my-domain,dc=com
+objectClass: top
+objectClass: organization
+objectClass: dcObject
+dc: my-domain
+o: php ldap tests
+
+### This would clutter our DIT and make tests to fail, while ppolicy does not
+### seem to work as we expect (it does not seem to provide expected controls)
+## dn: ou=pwpolicies,dc=my-domain,dc=com
+## objectClass: top
+## objectClass: organizationalUnit
+## ou: pwpolicies
+##
+## dn: cn=default,ou=pwpolicies,dc=my-domain,dc=com
+## objectClass: top
+## objectClass: person
+## objectClass: pwdPolicy
+## cn: default
+## sn: default
+## pwdAttribute: userPassword
+## pwdMaxAge: 2592000
+## pwdExpireWarning: 3600
+## #pwdInHistory: 0
+## pwdCheckQuality: 0
+## pwdMaxFailure: 5
+## pwdLockout: TRUE
+## #pwdLockoutDuration: 0
+## #pwdGraceAuthNLimit: 0
+## #pwdFailureCountInterval: 0
+## pwdMustChange: FALSE
+## pwdMinLength: 3
+## pwdAllowUserChange: TRUE
+## pwdSafeModify: FALSE
+EOF
+
+# Verify TLS connection
+tries=0
+while : ; do
+	ldapsearch -d 255 -H ldaps://localhost -D cn=Manager,dc=my-domain,dc=com -w secret -s base -b dc=my-domain,dc=com 'objectclass=*'
+	rt=$?
+	if [ $rt -eq 0 ]; then
+		echo "OK"
+		exit 0
+	else
+		tries=$((tries+1))
+		if [ $((tries)) -gt 3 ]; then
+			echo "exit failure $rt"
+			exit $rt
+		else
+			echo "trying again"
+			sleep 3
+		fi
+	fi
+done

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,81 @@
+name: Push
+on:
+  push:
+    paths-ignore:
+      - docs/*
+      - NEWS
+      - UPGRADING
+      - UPGRADING.INTERNALS
+      - README.md
+      - CONTRIBUTING.md
+      - CODING_STANDARDS.md
+    branches:
+      - PHP-7.4
+      - PHP-8.0
+      - PHP-8.1
+      - master
+  pull_request:
+    branches:
+      - '**'
+jobs:
+  LINUX_X64:
+    strategy:
+      matrix:
+        include:
+          - debug: true
+            zts: false
+          - debug: false
+            zts: true
+    name: "LINUX_X64_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+      - name: Create mssql container
+        uses: ./.github/actions/mssql
+      - name: apt
+        uses: ./.github/actions/apt-x64
+      - name: ./configure
+        uses: ./.github/actions/configure-x64
+        with:
+          configurationParameters: >-
+            --${{ matrix.debug && 'enable' || 'disable' }}-debug
+            --${{ matrix.zts && 'enable' || 'disable' }}-zts
+      - name: make
+        run: make -j$(/usr/bin/nproc) >/dev/null
+      - name: make install
+        uses: ./.github/actions/install-linux
+      - name: Setup
+        uses: ./.github/actions/setup-x64
+      - name: Test
+        uses: ./.github/actions/test-linux
+      - name: Test Tracing JIT
+        uses: ./.github/actions/test-linux
+        with:
+          runTestsParameters: -d zend_extension=opcache.so -d opcache.jit_buffer_size=16M
+  MACOS_DEBUG_NTS:
+    runs-on: macos-10.15
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+      - name: brew
+        uses: ./.github/actions/brew
+      - name: ./configure
+        uses: ./.github/actions/configure-macos
+        with:
+          configurationParameters: --enable-debug --disable-zts
+      - name: make
+        run: |-
+          export PATH="/usr/local/opt/bison/bin:$PATH"
+          make -j$(sysctl -n hw.logicalcpu) >/dev/null
+      - name: make install
+        run: sudo make install
+      - name: Test
+        uses: ./.github/actions/test-macos
+      - name: Test Tracing JIT
+        uses: ./.github/actions/test-macos
+        with:
+          runTestsParameters: >-
+            -d zend_extension=opcache.so
+            -d opcache.protect_memory=1
+            -d opcache.jit_buffer_size=16M

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,22 +27,11 @@ schedules:
         - master
 
 jobs:
-  - template: azure/job.yml
-    parameters:
-      configurationName: DEBUG_NTS
-      configurationParameters: '--enable-debug --disable-zts'
-  - template: azure/job.yml
-    parameters:
-      configurationName: RELEASE_ZTS
-      configurationParameters: '--disable-debug --enable-zts'
-  - template: azure/i386/job.yml
-    parameters:
-      configurationName: I386_DEBUG_ZTS
-      configurationParameters: '--enable-debug --enable-zts'
-  - template: azure/macos/job.yml
-    parameters:
-      configurationName: MACOS_DEBUG_NTS
-      configurationParameters: '--enable-debug --disable-zts'
+  # Azure pipelines don't work atm
+  # - template: azure/i386/job.yml
+  #   parameters:
+  #     configurationName: I386_DEBUG_ZTS
+  #     configurationParameters: '--enable-debug --enable-zts'
   - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
     - template: azure/job.yml
       parameters:


### PR DESCRIPTION
This is only a minimal migration of Azure DevOps to GitHub actions. The entire nightly build is missing, as well as `i386`.

Should we target PHP 8.0 or 7.4 for this? PHP 7.4 should only receive minimal changes, although testing is also arguably more important for patches.

/cc @cmb69