### PR TITLE
Fix GH-8140: Wrong first class callable by name optimization

### DIFF
--- a/Zend/Optimizer/optimize_func_calls.c
+++ b/Zend/Optimizer/optimize_func_calls.c
@@ -200,14 +200,18 @@ void zend_optimize_func_calls(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 						fcall->op1.num = zend_vm_calc_used_stack(fcall->extended_value, call_stack[call].func);
 						literal_dtor(&ZEND_OP2_LITERAL(fcall));
 						fcall->op2.constant = fcall->op2.constant + 1;
-						opline->opcode = zend_get_call_op(fcall, call_stack[call].func);
+						if (opline->opcode != ZEND_CALLABLE_CONVERT) {
+							opline->opcode = zend_get_call_op(fcall, call_stack[call].func);
+						}
 					} else if (fcall->opcode == ZEND_INIT_NS_FCALL_BY_NAME) {
 						fcall->opcode = ZEND_INIT_FCALL;
 						fcall->op1.num = zend_vm_calc_used_stack(fcall->extended_value, call_stack[call].func);
 						literal_dtor(&op_array->literals[fcall->op2.constant]);
 						literal_dtor(&op_array->literals[fcall->op2.constant + 2]);
 						fcall->op2.constant = fcall->op2.constant + 1;
-						opline->opcode = zend_get_call_op(fcall, call_stack[call].func);
+						if (opline->opcode != ZEND_CALLABLE_CONVERT) {
+							opline->opcode = zend_get_call_op(fcall, call_stack[call].func);
+						}
 					} else if (fcall->opcode == ZEND_INIT_STATIC_METHOD_CALL
 							|| fcall->opcode == ZEND_INIT_METHOD_CALL
 							|| fcall->opcode == ZEND_NEW) {

--- a/ext/opcache/tests/opt/gh8140a.phpt
+++ b/ext/opcache/tests/opt/gh8140a.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-8140 (Wrong first class callable by name optimization)
+--FILE--
+<?php
+namespace Test;
+
+function greeter(string $name) {
+  echo "Hello, ${name}!";
+}
+
+$mycallable = greeter(...);
+
+$mycallable("world");
+?>
+--EXPECT--
+Hello, world!

--- a/ext/opcache/tests/opt/gh8140b.phpt
+++ b/ext/opcache/tests/opt/gh8140b.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-8140 (Wrong first class callable by name optimization)
+--FILE--
+<?php
+$mycallable = greeter(...);
+
+function greeter(string $name) {
+    echo "Hello, ${name}!";
+}
+  
+$mycallable("world");
+?>
+--EXPECT--
+Hello, world!


### PR DESCRIPTION
When optimizing by name function calls, we must not replace
`CALLABLE_CONVERT` opcodes, but have to keep them.