### PR TITLE
Fix GH-8170: --enable-debug configure option on Windows.

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -120,6 +120,7 @@ function get_version_numbers()
 }
 
 configure_args = new Array();
+configure_args_declared = {};
 configure_subst = WScript.CreateObject("Scripting.Dictionary");
 
 configure_hdr = WScript.CreateObject("Scripting.Dictionary");
@@ -228,6 +229,8 @@ function ConfigureArg(type, optname, helptext, defval)
 		this.arg = "--" + type + "-" + optname;
 		this.imparg = "--" + opptype + "-" + optname;
 	}
+	check_arg_uniqueness(this.arg);
+	check_arg_uniqueness(this.imparg);
 
 	this.optname = optname;
 	this.helptext = helptext;
@@ -235,6 +238,14 @@ function ConfigureArg(type, optname, helptext, defval)
 	this.symval = optname.toUpperCase().replace(new RegExp("-", "g"), "_");
 	this.seen = false;
 	this.argval = defval;
+}
+
+function check_arg_uniqueness(argname)
+{
+	if (configure_args_declared[argname]) {
+		ERROR('Option ' + argname + ' is already declared.');
+	}
+	configure_args_declared[argname] = true;
 }
 
 function ARG_WITH(optname, helptext, defval)

--- a/win32/build/phpize.js.in
+++ b/win32/build/phpize.js.in
@@ -232,7 +232,6 @@ C.Write(file_get_contents(PHP_DIR + "/script/config.phpize.js"));
 // Pull in code for the base detection
 modules = file_get_contents(PHP_DIR + "/script/config.w32.phpize.in");
 
-C.WriteLine("ARG_ENABLE('debug', 'Compile with debugging symbols', PHP_DEBUG);");
 find_config_w32(".");
 
 // Now generate contents of module based on MODULES, chasing dependencies


### PR DESCRIPTION
#8170
Remove `ARG_ENABLE('debug', ...)` in `phpize.js.in`.
Also make an dictionary object to keep track of the declared `--option` to detect duplicates.