### PR TITLE
Fix IntlPartsIterator key off-by-one error and first key

### DIFF
--- a/ext/intl/common/common_enum.cpp
+++ b/ext/intl/common/common_enum.cpp
@@ -291,6 +291,7 @@ U_CFUNC void intl_register_IntlIterator_class(void)
 	IntlIterator_ce_ptr = register_class_IntlIterator(zend_ce_iterator);
 	IntlIterator_ce_ptr->create_object = IntlIterator_object_create;
 	IntlIterator_ce_ptr->get_iterator = IntlIterator_get_iterator;
+	IntlIterator_ce_ptr->ce_flags |= ZEND_ACC_REUSE_GET_ITERATOR;
 
 	memcpy(&IntlIterator_handlers, &std_object_handlers,
 		sizeof IntlIterator_handlers);

--- a/ext/intl/tests/breakiter_getPartsIterator_var1.phpt
+++ b/ext/intl/tests/breakiter_getPartsIterator_var1.phpt
@@ -33,24 +33,24 @@ array(5) {
 array(5) {
   [0]=>
   string(3) "foo"
+  [3]=>
+  string(1) " "
   [4]=>
-  string(1) " "
-  [5]=>
   string(3) "bar"
-  [8]=>
+  [7]=>
   string(1) " "
-  [9]=>
+  [8]=>
   string(3) "tao"
 }
 array(5) {
   [3]=>
   string(3) "foo"
-  [5]=>
+  [4]=>
   string(1) " "
-  [8]=>
+  [7]=>
   string(3) "bar"
-  [9]=>
+  [8]=>
   string(1) " "
-  [12]=>
+  [11]=>
   string(3) "tao"
 }

--- a/ext/intl/tests/gh7734.phpt
+++ b/ext/intl/tests/gh7734.phpt
@@ -1,0 +1,42 @@
+--TEST--
+GH-7734 (IntlPartsIterator key is wrong for KEY_LEFT/KEY_RIGHT)
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$iter = \IntlBreakIterator::createCodePointInstance();
+$iter->setText('ABC');
+
+foreach ($iter->getPartsIterator(\IntlPartsIterator::KEY_SEQUENTIAL) as $key => $value) {
+    var_dump($key, $value);
+}
+
+foreach ($iter->getPartsIterator(\IntlPartsIterator::KEY_LEFT) as $key => $value) {
+    var_dump($key, $value);
+}
+
+foreach ($iter->getPartsIterator(\IntlPartsIterator::KEY_RIGHT) as $key => $value) {
+    var_dump($key, $value);
+}
+
+?>
+--EXPECT--
+int(0)
+string(1) "A"
+int(1)
+string(1) "B"
+int(2)
+string(1) "C"
+int(0)
+string(1) "A"
+int(1)
+string(1) "B"
+int(2)
+string(1) "C"
+int(1)
+string(1) "A"
+int(2)
+string(1) "B"
+int(3)
+string(1) "C"


### PR DESCRIPTION
Closes GH-7734

`IntlPartsIterator` with `PARTS_ITERATOR_KEY_RIGHT` relies on advancing the iterator on `rewind` and setting the `index` to the start of the next character sequence. However, the engine resets the `index` to `-1` after rewinding the iterator.

https://github.com/php/php-src/blob/51f750ea463b5677c4ac62d7657802adbc048dd1/Zend/zend_execute.c#L4596

This does not happen in `iterator_to_array`, however.

https://github.com/php/php-src/blob/51f750ea463b5677c4ac62d7657802adbc048dd1/ext/spl/spl_iterators.c#L3040-L3048

Which is why this wasn't caught in https://github.com/php/php-src/commit/0eb5c1a01871c00948610e8d4249b89bf1dce079.

`IntlIterator_ce_ptr->ce_flags |= ZEND_ACC_REUSE_GET_ITERATOR;` will be removed when merging into `master` since the inheritance mechanism of `get_iterator` is different there and this part was already fixed (see https://github.com/php/php-src/commit/0eb5c1a01871c00948610e8d4249b89bf1dce079).