### PR TITLE
Fix GH-8068: mysqli_fetch_object creates inaccessible properties

### DIFF
--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -1198,11 +1198,13 @@ void php_mysqli_fetch_into_hash(INTERNAL_FUNCTION_PARAMETERS, int override_flags
 		ZVAL_COPY_VALUE(&dataset, return_value);
 
 		object_init_ex(return_value, ce);
+		HashTable *prop_table = zend_symtable_to_proptable(Z_ARR(dataset));
+		zval_ptr_dtor(&dataset);
 		if (!ce->default_properties_count && !ce->__set) {
-			Z_OBJ_P(return_value)->properties = Z_ARR(dataset);
+			Z_OBJ_P(return_value)->properties = prop_table;
 		} else {
-			zend_merge_properties(return_value, Z_ARRVAL(dataset));
-			zval_ptr_dtor(&dataset);
+			zend_merge_properties(return_value, prop_table);
+			zend_array_release(prop_table);
 		}
 
 		if (ce->constructor) {

--- a/ext/mysqli/tests/gh8068.phpt
+++ b/ext/mysqli/tests/gh8068.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-8068 (mysqli_fetch_object creates inaccessible properties)
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+require_once('skipifconnectfailure.inc');
+?>
+--FILE--
+<?php
+require_once("connect.inc");
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysqli = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
+$res = $mysqli->query('SELECT 42');
+$obj = $res->fetch_object();
+var_dump(
+    $obj,
+    $obj->{42}
+);
+?>
+--EXPECT--
+object(stdClass)#4 (1) {
+  ["42"]=>
+  string(2) "42"
+}
+string(2) "42"

--- a/ext/mysqli/tests/gh8068.phpt
+++ b/ext/mysqli/tests/gh8068.phpt
@@ -7,7 +7,7 @@ require_once('skipifconnectfailure.inc');
 ?>
 --FILE--
 <?php
-require_once("connect.inc");
+require_once "connect.inc";
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 $mysqli = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
 $res = $mysqli->query('SELECT 42');

--- a/ext/mysqli/tests/gh8068.phpt
+++ b/ext/mysqli/tests/gh8068.phpt
@@ -2,8 +2,8 @@
 GH-8068 (mysqli_fetch_object creates inaccessible properties)
 --SKIPIF--
 <?php
-require_once('skipif.inc');
-require_once('skipifconnectfailure.inc');
+require_once 'skipif.inc';
+require_once 'skipifconnectfailure.inc';
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
When fetching into objects, we need to create object style hash tables,
i.e. where numeric column names are stored as string keys instead of
integer keys.  Instead of the slightly more efficient alternative to
create the desired hash table in the first place, we go for the more
readable implementation and convert the array style hash table using
`zend_symtable_to_proptable()`.