### PR TITLE
Allow arbitrary const expressions in backed enums

### DIFF
--- a/Zend/tests/enum/backed-duplicate-int.phpt
+++ b/Zend/tests/enum/backed-duplicate-int.phpt
@@ -8,6 +8,33 @@ enum Foo: int {
     case Baz = 0;
 }
 
+try {
+    var_dump(Foo::Bar);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Foo::Bar);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Foo::from(42));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Foo::tryFrom('bar'));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
 ?>
---EXPECTF--
-Fatal error: Duplicate value in enum Foo for cases Bar and Baz in %s on line %s
+--EXPECT--
+Duplicate value in enum Foo for cases Bar and Baz
+Duplicate value in enum Foo for cases Bar and Baz
+Duplicate value in enum Foo for cases Bar and Baz
+Foo::tryFrom(): Argument #1 ($value) must be of type int, string given

--- a/Zend/tests/enum/backed-duplicate-string.phpt
+++ b/Zend/tests/enum/backed-duplicate-string.phpt
@@ -10,6 +10,33 @@ enum Suit: string {
     case Spades = 'H';
 }
 
+try {
+    var_dump(Suit::Hearts);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Suit::Hearts);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Suit::from(42));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Suit::tryFrom('bar'));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
 ?>
---EXPECTF--
-Fatal error: Duplicate value in enum Suit for cases Hearts and Spades in %s on line %s
+--EXPECT--
+Duplicate value in enum Suit for cases Hearts and Spades
+Duplicate value in enum Suit for cases Hearts and Spades
+Duplicate value in enum Suit for cases Hearts and Spades
+Duplicate value in enum Suit for cases Hearts and Spades

--- a/Zend/tests/enum/backed-int-const-invalid-expr.phpt
+++ b/Zend/tests/enum/backed-int-const-invalid-expr.phpt
@@ -11,4 +11,4 @@ var_dump(Foo::Bar->value);
 
 ?>
 --EXPECTF--
-Fatal error: Enum case value must be compile-time evaluatable in %s on line %d
+Fatal error: Constant expression contains invalid operations in %s on line %d

--- a/Zend/tests/enum/backed-mismatch.phpt
+++ b/Zend/tests/enum/backed-mismatch.phpt
@@ -7,6 +7,33 @@ enum Foo: int {
     case Bar = 'bar';
 }
 
+try {
+    var_dump(Foo::Bar);
+} catch (Error $e) {
+    echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Foo::Bar);
+} catch (Error $e) {
+    echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Foo::from(42));
+} catch (Error $e) {
+    echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(Foo::from('bar'));
+} catch (Error $e) {
+    echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+
 ?>
---EXPECTF--
-Fatal error: Enum case type string does not match enum backing type int in %s on line %d
+--EXPECT--
+TypeError: Enum case type string does not match enum backing type int
+TypeError: Enum case type string does not match enum backing type int
+TypeError: Enum case type string does not match enum backing type int
+TypeError: Foo::from(): Argument #1 ($value) must be of type int, string given

--- a/Zend/tests/enum/gh7821.phpt
+++ b/Zend/tests/enum/gh7821.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-7821: Can't use arbitrary constant expressions in enum cases
+--FILE--
+<?php
+
+interface I {
+    public const A = 'A';
+    public const B = 'B';
+}
+
+enum B: string implements I {
+    case C = I::A;
+    case D = self::B;
+}
+
+var_dump(B::A);
+var_dump(B::B);
+var_dump(B::C->value);
+var_dump(B::D->value);
+
+?>
+--EXPECT--
+string(1) "A"
+string(1) "B"
+string(1) "A"
+string(1) "B"

--- a/Zend/tests/enum/gh8418.phpt
+++ b/Zend/tests/enum/gh8418.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-8418: Enum constant expression evaluation doesn't work with warmed cache
+--FILE--
+<?php
+
+class ExampleClass
+{
+    public const EXAMPLE_CONST = 42;
+}
+
+enum ExampleEnum: int
+{
+    case ENUM_CASE = ExampleClass::EXAMPLE_CONST;
+}
+
+var_dump(ExampleEnum::ENUM_CASE->value);
+
+?>
+--EXPECT--
+int(42)

--- a/Zend/tests/enum/non-backed-enum-with-expr-value.phpt
+++ b/Zend/tests/enum/non-backed-enum-with-expr-value.phpt
@@ -9,4 +9,4 @@ enum Foo {
 
 ?>
 --EXPECTF--
-Fatal error: Case Bar of non-backed enum Foo must not have a value, try adding ": int" to the enum declaration in %s on line %d
+Fatal error: Case Bar of non-backed enum Foo must not have a value in %s on line %d

--- a/Zend/tests/enum/non-backed-enum-with-int-value.phpt
+++ b/Zend/tests/enum/non-backed-enum-with-int-value.phpt
@@ -9,4 +9,4 @@ enum Foo {
 
 ?>
 --EXPECTF--
-Fatal error: Case Bar of non-backed enum Foo must not have a value, try adding ": int" to the enum declaration in %s on line %d
+Fatal error: Case Bar of non-backed enum Foo must not have a value in %s on line %d

--- a/Zend/tests/enum/non-backed-enum-with-string-value.phpt
+++ b/Zend/tests/enum/non-backed-enum-with-string-value.phpt
@@ -9,4 +9,4 @@ enum Foo {
 
 ?>
 --EXPECTF--
-Fatal error: Case Bar of non-backed enum Foo must not have a value, try adding ": string" to the enum declaration in %s on line %d
+Fatal error: Case Bar of non-backed enum Foo must not have a value in %s on line %d

--- a/Zend/tests/enum/update-class-constant-failure.phpt
+++ b/Zend/tests/enum/update-class-constant-failure.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test failure of updating class constants
+--FILE--
+<?php
+
+enum Foo: string {
+    const Bar = NONEXISTENT;
+}
+
+var_dump(Foo::Bar);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Undefined constant "NONEXISTENT" in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -30,6 +30,7 @@
 #include "zend_closures.h"
 #include "zend_inheritance.h"
 #include "zend_ini.h"
+#include "zend_enum.h"
 
 #include <stdarg.h>
 
@@ -1490,6 +1491,12 @@ ZEND_API zend_result zend_update_class_constants(zend_class_entry *class_type) /
 					}
 				}
 			} ZEND_HASH_FOREACH_END();
+		}
+	}
+
+	if (class_type->type == ZEND_USER_CLASS && class_type->ce_flags & ZEND_ACC_ENUM && class_type->enum_backing_type != IS_UNDEF) {
+		if (zend_enum_build_backed_enum_table(class_type) == FAILURE) {
+			return FAILURE;
 		}
 	}
 

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -776,12 +776,18 @@ ZEND_API zend_result ZEND_FASTCALL zend_ast_evaluate(zval *result, zend_ast *ast
 			zend_string *case_name = zend_ast_get_str(case_name_ast);
 
 			zend_ast *case_value_ast = ast->child[2];
-			zval *case_value_zv = case_value_ast != NULL
-				? zend_ast_get_zval(case_value_ast)
-				: NULL;
+
+			zval case_value_zv;
+			ZVAL_UNDEF(&case_value_zv);
+			if (case_value_ast != NULL) {
+				if (UNEXPECTED(zend_ast_evaluate(&case_value_zv, case_value_ast, scope) != SUCCESS)) {
+					return FAILURE;
+				}
+			}
 
 			zend_class_entry *ce = zend_lookup_class(class_name);
-			zend_enum_new(result, ce, case_name, case_value_zv);
+			zend_enum_new(result, ce, case_name, case_value_ast != NULL ? &case_value_zv : NULL);
+			zval_ptr_dtor_nogc(&case_value_zv);
 			break;
 		}
 		case ZEND_AST_CLASS_CONST:

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -21,6 +21,7 @@
 #include "zend_compile.h"
 #include "zend_enum_arginfo.h"
 #include "zend_interfaces.h"
+#include "zend_enum.h"
 
 #define ZEND_ENUM_DISALLOW_MAGIC_METHOD(propertyName, methodName) \
 	do { \
@@ -183,6 +184,72 @@ void zend_enum_add_interfaces(zend_class_entry *ce)
 	}
 }
 
+zend_result zend_enum_build_backed_enum_table(zend_class_entry *ce)
+{
+	ZEND_ASSERT(ce->ce_flags & ZEND_ACC_ENUM);
+	ZEND_ASSERT(ce->type == ZEND_USER_CLASS);
+
+	uint32_t backing_type = ce->enum_backing_type;
+	ZEND_ASSERT(backing_type != IS_UNDEF);
+
+	ce->backed_enum_table = emalloc(sizeof(HashTable));
+	zend_hash_init(ce->backed_enum_table, 0, NULL, ZVAL_PTR_DTOR, 0);
+
+	zend_string *enum_class_name = ce->name;
+
+	zend_string *name;
+	zval *val;
+	ZEND_HASH_MAP_FOREACH_STR_KEY_VAL(&ce->constants_table, name, val) {
+		zend_class_constant *c = Z_PTR_P(val);
+		if ((ZEND_CLASS_CONST_FLAGS(c) & ZEND_CLASS_CONST_IS_CASE) == 0) {
+			continue;
+		}
+
+		zval *c_value = &c->value;
+		zval *case_name = zend_enum_fetch_case_name(Z_OBJ_P(c_value));
+		zval *case_value = zend_enum_fetch_case_value(Z_OBJ_P(c_value));
+
+		if (ce->enum_backing_type != Z_TYPE_P(case_value)) {
+			zend_type_error("Enum case type %s does not match enum backing type %s",
+				zend_get_type_by_const(Z_TYPE_P(case_value)),
+				zend_get_type_by_const(ce->enum_backing_type));
+			goto failure;
+		}
+
+		if (ce->enum_backing_type == IS_LONG) {
+			zend_long long_key = Z_LVAL_P(case_value);
+			zval *existing_case_name = zend_hash_index_find(ce->backed_enum_table, long_key);
+			if (existing_case_name) {
+				zend_throw_error(NULL, "Duplicate value in enum %s for cases %s and %s",
+					ZSTR_VAL(enum_class_name),
+					Z_STRVAL_P(existing_case_name),
+					ZSTR_VAL(name));
+				goto failure;
+			}
+			zend_hash_index_add_new(ce->backed_enum_table, long_key, case_name);
+		} else {
+			ZEND_ASSERT(ce->enum_backing_type == IS_STRING);
+			zend_string *string_key = Z_STR_P(case_value);
+			zval *existing_case_name = zend_hash_find(ce->backed_enum_table, string_key);
+			if (existing_case_name != NULL) {
+				zend_throw_error(NULL, "Duplicate value in enum %s for cases %s and %s",
+					ZSTR_VAL(enum_class_name),
+					Z_STRVAL_P(existing_case_name),
+					ZSTR_VAL(name));
+				goto failure;
+			}
+			zend_hash_add_new(ce->backed_enum_table, string_key, case_name);
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	return SUCCESS;
+
+failure:
+	zend_hash_release(ce->backed_enum_table);
+	ce->backed_enum_table = NULL;
+	return FAILURE;
+}
+
 static ZEND_NAMED_FUNCTION(zend_enum_cases_func)
 {
 	zend_class_entry *ce = execute_data->func->common.scope;
@@ -209,6 +276,12 @@ static ZEND_NAMED_FUNCTION(zend_enum_cases_func)
 
 ZEND_API zend_result zend_enum_get_case_by_value(zend_object **result, zend_class_entry *ce, zend_long long_key, zend_string *string_key, bool try)
 {
+	if (ce->type == ZEND_USER_CLASS && !(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
+		if (zend_update_class_constants(ce) == FAILURE) {
+			return FAILURE;
+		}
+	}
+
 	zval *case_name_zv;
 	if (ce->enum_backing_type == IS_LONG) {
 		case_name_zv = zend_hash_index_find(ce->backed_enum_table, long_key);

--- a/Zend/zend_enum.h
+++ b/Zend/zend_enum.h
@@ -29,6 +29,7 @@ extern ZEND_API zend_class_entry *zend_ce_backed_enum;
 
 void zend_register_enum_ce(void);
 void zend_enum_add_interfaces(zend_class_entry *ce);
+zend_result zend_enum_build_backed_enum_table(zend_class_entry *ce);
 zend_object *zend_enum_new(zval *result, zend_class_entry *ce, zend_string *case_name, zval *backing_value_zv);
 void zend_verify_enum(zend_class_entry *ce);
 void zend_enum_register_funcs(zend_class_entry *ce);

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -330,9 +330,6 @@ ZEND_API void destroy_zend_class(zval *zv)
 				if (ce->attributes) {
 					zend_hash_release(ce->attributes);
 				}
-				if (ce->backed_enum_table) {
-					zend_hash_release(ce->backed_enum_table);
-				}
 
 				if (ce->num_interfaces > 0 && !(ce->ce_flags & ZEND_ACC_RESOLVED_INTERFACES)) {
 					uint32_t i;
@@ -402,6 +399,9 @@ ZEND_API void destroy_zend_class(zval *zv)
 			zend_hash_destroy(&ce->constants_table);
 			if (ce->num_interfaces > 0 && (ce->ce_flags & ZEND_ACC_RESOLVED_INTERFACES)) {
 				efree(ce->interfaces);
+			}
+			if (ce->backed_enum_table) {
+				zend_hash_release(ce->backed_enum_table);
 			}
 			break;
 		case ZEND_INTERNAL_CLASS:

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5896,6 +5896,13 @@ ZEND_VM_HANDLER(181, ZEND_FETCH_CLASS_CONSTANT, VAR|CONST|UNUSED|CLASS_FETCH, CO
 				HANDLE_EXCEPTION();
 			}
 			value = &c->value;
+			// Enums require loading of all class constants to build the backed enum table
+			if (ce->ce_flags & ZEND_ACC_ENUM && ce->enum_backing_type != IS_UNDEF && ce->type == ZEND_USER_CLASS && !(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
+				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
+					ZVAL_UNDEF(EX_VAR(opline->result.var));
+					HANDLE_EXCEPTION();
+				}
+			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				zval_update_constant_ex(value, c->ce);
 				if (UNEXPECTED(EG(exception) != NULL)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -7065,6 +7065,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_CONS
 				HANDLE_EXCEPTION();
 			}
 			value = &c->value;
+			// Enums require loading of all class constants to build the backed enum table
+			if (ce->ce_flags & ZEND_ACC_ENUM && ce->enum_backing_type != IS_UNDEF && ce->type == ZEND_USER_CLASS && !(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
+				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
+					ZVAL_UNDEF(EX_VAR(opline->result.var));
+					HANDLE_EXCEPTION();
+				}
+			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				zval_update_constant_ex(value, c->ce);
 				if (UNEXPECTED(EG(exception) != NULL)) {
@@ -24610,6 +24617,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_VAR_
 				HANDLE_EXCEPTION();
 			}
 			value = &c->value;
+			// Enums require loading of all class constants to build the backed enum table
+			if (ce->ce_flags & ZEND_ACC_ENUM && ce->enum_backing_type != IS_UNDEF && ce->type == ZEND_USER_CLASS && !(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
+				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
+					ZVAL_UNDEF(EX_VAR(opline->result.var));
+					HANDLE_EXCEPTION();
+				}
+			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				zval_update_constant_ex(value, c->ce);
 				if (UNEXPECTED(EG(exception) != NULL)) {
@@ -33448,6 +33462,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_UNUS
 				HANDLE_EXCEPTION();
 			}
 			value = &c->value;
+			// Enums require loading of all class constants to build the backed enum table
+			if (ce->ce_flags & ZEND_ACC_ENUM && ce->enum_backing_type != IS_UNDEF && ce->type == ZEND_USER_CLASS && !(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
+				if (UNEXPECTED(zend_update_class_constants(ce) == FAILURE)) {
+					ZVAL_UNDEF(EX_VAR(opline->result.var));
+					HANDLE_EXCEPTION();
+				}
+			}
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
 				zval_update_constant_ex(value, c->ce);
 				if (UNEXPECTED(EG(exception) != NULL)) {

--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -848,14 +848,6 @@ static void zend_file_cache_serialize_class(zval                     *zv,
 		}
 	}
 
-	if (ce->backed_enum_table) {
-		HashTable *ht;
-		SERIALIZE_PTR(ce->backed_enum_table);
-		ht = ce->backed_enum_table;
-		UNSERIALIZE_PTR(ht);
-		zend_file_cache_serialize_hash(ht, script, info, buf, zend_file_cache_serialize_zval);
-	}
-
 	SERIALIZE_PTR(ce->constructor);
 	SERIALIZE_PTR(ce->destructor);
 	SERIALIZE_PTR(ce->clone);
@@ -1643,12 +1635,6 @@ static void zend_file_cache_unserialize_class(zval                    *zv,
 				p++;
 			}
 		}
-	}
-
-	if (ce->backed_enum_table) {
-		UNSERIALIZE_PTR(ce->backed_enum_table);
-		zend_file_cache_unserialize_hash(
-			ce->backed_enum_table, script, buf, zend_file_cache_unserialize_zval, ZVAL_PTR_DTOR);
 	}
 
 	UNSERIALIZE_PTR(ce->constructor);

--- a/ext/opcache/zend_persist_calc.c
+++ b/ext/opcache/zend_persist_calc.c
@@ -547,27 +547,6 @@ void zend_persist_class_entry_calc(zend_class_entry *ce)
 				ADD_SIZE(sizeof(zend_trait_precedence*) * (i + 1));
 			}
 		}
-
-		if (ce->backed_enum_table) {
-			ADD_SIZE(sizeof(HashTable));
-			zend_hash_persist_calc(ce->backed_enum_table);
-			if (HT_IS_PACKED(ce->backed_enum_table)) {
-				zval *zv;
-
-				ZEND_HASH_PACKED_FOREACH_VAL(ce->backed_enum_table, zv) {
-					zend_persist_zval_calc(zv);
-				} ZEND_HASH_FOREACH_END();
-			} else {
-				Bucket *p;
-
-				ZEND_HASH_MAP_FOREACH_BUCKET(ce->backed_enum_table, p) {
-					if (p->key != NULL) {
-						ADD_INTERNED_STRING(p->key);
-					}
-					zend_persist_zval_calc(&p->val);
-				} ZEND_HASH_FOREACH_END();
-			}
-		}
 	}
 }
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1485,7 +1485,7 @@ static void reflection_enum_case_factory(zend_class_entry *ce, zend_string *name
 {
 	reflection_object *intern;
 
-	zend_class_entry *case_reflection_class = ce->backed_enum_table == IS_UNDEF
+	zend_class_entry *case_reflection_class = ce->enum_backing_type == IS_UNDEF
 		? reflection_enum_unit_case_ptr
 		: reflection_enum_backed_case_ptr;
 	reflection_instantiate(case_reflection_class, object);


### PR DESCRIPTION
Closes GH-7821

Open issues: 

- [x] Every other run or so, `ZSTR_HAS_CE_CACHE(class_name)` returns `true` for `"self"` even though `zend_alloc_ce_cache` specifically guards for that. Sounds like memory corruption but I couldn't figure out where yet
- [x] ~~We probably need more forgiving error handling than `zend_error_noreturn` now that the errors are moved to runtime.~~ All other errors in `zend_do_link_class` seem to be fatal so I think this is consistent.
- [x] I changed the `enum_backing_table` to store the case directly but that might not actually work for internal enums (or we change `zend_enum_add_case` not to modify the backing table anymore and move that to after the constants have been initialized)
- [x] Add tests for https://github.com/php/php-src/issues/7821#issuecomment-1105191090
- [x] ~~Can we add the `backed_enum_table` to the inheritance cache to avoid re-population on every request?~~ That would require tracking dependencies of all classes in all expressions so likely not feasible.