### PR TITLE
Use more appropriate types in JSON extension

### DIFF
--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -141,10 +141,10 @@ static PHP_MINFO_FUNCTION(json)
 }
 /* }}} */
 
-PHP_JSON_API int php_json_encode_ex(smart_str *buf, zval *val, int options, zend_long depth) /* {{{ */
+PHP_JSON_API zend_result php_json_encode_ex(smart_str *buf, zval *val, int options, zend_long depth) /* {{{ */
 {
 	php_json_encoder encoder;
-	int return_code;
+	zend_result return_code;
 
 	php_json_encode_init(&encoder);
 	encoder.max_depth = depth;
@@ -156,7 +156,7 @@ PHP_JSON_API int php_json_encode_ex(smart_str *buf, zval *val, int options, zend
 }
 /* }}} */
 
-PHP_JSON_API int php_json_encode(smart_str *buf, zval *val, int options) /* {{{ */
+PHP_JSON_API zend_result php_json_encode(smart_str *buf, zval *val, int options) /* {{{ */
 {
 	return php_json_encode_ex(buf, val, options, JSON_G(encode_max_depth));
 }
@@ -195,7 +195,7 @@ static const char *php_json_get_error_msg(php_json_error_code error_code) /* {{{
 }
 /* }}} */
 
-PHP_JSON_API int php_json_decode_ex(zval *return_value, const char *str, size_t str_len, zend_long options, zend_long depth) /* {{{ */
+PHP_JSON_API zend_result php_json_decode_ex(zval *return_value, const char *str, size_t str_len, zend_long options, zend_long depth) /* {{{ */
 {
 	php_json_parser parser;
 

--- a/ext/json/json_encoder.c
+++ b/ext/json/json_encoder.c
@@ -31,7 +31,7 @@
 
 static const char digits[] = "0123456789abcdef";
 
-static int php_json_escape_string(
+static zend_result php_json_escape_string(
 		smart_str *buf,	const char *s, size_t len,
 		int options, php_json_encoder *encoder);
 
@@ -71,7 +71,7 @@ static inline void php_json_pretty_print_indent(smart_str *buf, int options, php
 
 /* }}} */
 
-static inline int php_json_is_valid_double(double d) /* {{{ */
+static inline bool php_json_is_valid_double(double d) /* {{{ */
 {
 	return !zend_isinf(d) && !zend_isnan(d);
 }
@@ -107,7 +107,7 @@ static inline void php_json_encode_double(smart_str *buf, double d, int options)
 		} \
 	} while (0)
 
-static int php_json_encode_array(smart_str *buf, zval *val, int options, php_json_encoder *encoder) /* {{{ */
+static zend_result php_json_encode_array(smart_str *buf, zval *val, int options, php_json_encoder *encoder) /* {{{ */
 {
 	int i, r, need_comma = 0;
 	HashTable *myht, *prop_ht;
@@ -312,7 +312,7 @@ static int php_json_encode_array(smart_str *buf, zval *val, int options, php_jso
 }
 /* }}} */
 
-static int php_json_escape_string(
+static zend_result php_json_escape_string(
 		smart_str *buf, const char *s, size_t len,
 		int options, php_json_encoder *encoder) /* {{{ */
 {
@@ -526,12 +526,12 @@ static int php_json_escape_string(
 }
 /* }}} */
 
-static int php_json_encode_serializable_object(smart_str *buf, zval *val, int options, php_json_encoder *encoder) /* {{{ */
+static zend_result php_json_encode_serializable_object(smart_str *buf, zval *val, int options, php_json_encoder *encoder) /* {{{ */
 {
 	zend_class_entry *ce = Z_OBJCE_P(val);
 	HashTable* myht = Z_OBJPROP_P(val);
 	zval retval, fname;
-	int return_code;
+	zend_result return_code;
 
 	if (myht && GC_IS_RECURSIVE(myht)) {
 		encoder->error_code = PHP_JSON_ERROR_RECURSION;
@@ -588,7 +588,7 @@ static int php_json_encode_serializable_object(smart_str *buf, zval *val, int op
 }
 /* }}} */
 
-static int php_json_encode_serializable_enum(smart_str *buf, zval *val, int options, php_json_encoder *encoder)
+static zend_result php_json_encode_serializable_enum(smart_str *buf, zval *val, int options, php_json_encoder *encoder)
 {
 	zend_class_entry *ce = Z_OBJCE_P(val);
 	if (ce->enum_backing_type == IS_UNDEF) {
@@ -601,7 +601,7 @@ static int php_json_encode_serializable_enum(smart_str *buf, zval *val, int opti
 	return php_json_encode_zval(buf, value_zv, options, encoder);
 }
 
-int php_json_encode_zval(smart_str *buf, zval *val, int options, php_json_encoder *encoder) /* {{{ */
+zend_result php_json_encode_zval(smart_str *buf, zval *val, int options, php_json_encoder *encoder) /* {{{ */
 {
 again:
 	switch (Z_TYPE_P(val))

--- a/ext/json/php_json.h
+++ b/ext/json/php_json.h
@@ -97,11 +97,11 @@ PHP_JSON_API ZEND_EXTERN_MODULE_GLOBALS(json)
 ZEND_TSRMLS_CACHE_EXTERN()
 #endif
 
-PHP_JSON_API int php_json_encode_ex(smart_str *buf, zval *val, int options, zend_long depth);
-PHP_JSON_API int php_json_encode(smart_str *buf, zval *val, int options);
-PHP_JSON_API int php_json_decode_ex(zval *return_value, const char *str, size_t str_len, zend_long options, zend_long depth);
+PHP_JSON_API zend_result php_json_encode_ex(smart_str *buf, zval *val, int options, zend_long depth);
+PHP_JSON_API zend_result php_json_encode(smart_str *buf, zval *val, int options);
+PHP_JSON_API zend_result php_json_decode_ex(zval *return_value, const char *str, size_t str_len, zend_long options, zend_long depth);
 
-static inline int php_json_decode(zval *return_value, const char *str, int str_len, bool assoc, zend_long depth)
+static inline zend_result php_json_decode(zval *return_value, const char *str, size_t str_len, bool assoc, zend_long depth)
 {
 	return php_json_decode_ex(return_value, str, str_len, assoc ? PHP_JSON_OBJECT_AS_ARRAY : 0, depth);
 }

--- a/ext/json/php_json_encoder.h
+++ b/ext/json/php_json_encoder.h
@@ -33,6 +33,6 @@ static inline void php_json_encode_init(php_json_encoder *encoder)
 	memset(encoder, 0, sizeof(php_json_encoder));
 }
 
-int php_json_encode_zval(smart_str *buf, zval *val, int options, php_json_encoder *encoder);
+zend_result php_json_encode_zval(smart_str *buf, zval *val, int options, php_json_encoder *encoder);
 
 #endif	/* PHP_JSON_ENCODER_H */


### PR DESCRIPTION
Mainly converting usage of ``int`` to ``zend_result`` but also a couple ``bool`` and ``size_t``.