### PR TITLE
Remove duplicate string APIs

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -33,6 +33,11 @@ PHP 8.2 INTERNALS UPGRADE NOTES
       and php_string_tolower() have been removed.
       Use zend_str_toupper(), zend_string_toupper(), zend_str_tolower(),
       and zend_string_tolower() respectively instead.
+
+    - The PHP APIs string_natural_compare_function_ex(),
+      string_natural_case_compare_function(), and string_natural_compare_function()
+      have been removed. They always returned SUCCESS and were a wrapper around
+      strnatcmp_ex(). Use strnatcmp_ex() directly instead.
 ========================
 4. OpCode changes
 ========================

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -28,7 +28,11 @@ PHP 8.2 INTERNALS UPGRADE NOTES
 ========================
 3. Module changes
 ========================
-
+  a. ext/standard
+    - The PHP APIs php_strtoupper(), php_string_toupper(), php_strtolower(),
+      and php_string_tolower() have been removed.
+      Use zend_str_toupper(), zend_string_toupper(), zend_str_tolower(),
+      and zend_string_tolower() respectively instead.
 ========================
 4. OpCode changes
 ========================

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4529,9 +4529,9 @@ PHP_FUNCTION(array_change_key_case)
 			entry = zend_hash_index_update(Z_ARRVAL_P(return_value), num_key, entry);
 		} else {
 			if (change_to_upper) {
-				new_key = php_string_toupper(string_key);
+				new_key = zend_string_toupper(string_key);
 			} else {
-				new_key = php_string_tolower(string_key);
+				new_key = zend_string_tolower(string_key);
 			}
 			entry = zend_hash_update(Z_ARRVAL_P(return_value), new_key, entry);
 			zend_string_release_ex(new_key, 0);

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -35,10 +35,6 @@ PHP_MINIT_FUNCTION(string_intrin);
 	strnatcmp_ex(a, strlen(a), b, strlen(b), 1)
 PHPAPI int strnatcmp_ex(char const *a, size_t a_len, char const *b, size_t b_len, int fold_case);
 PHPAPI struct lconv *localeconv_r(struct lconv *out);
-PHPAPI char *php_strtoupper(char *s, size_t len);
-PHPAPI char *php_strtolower(char *s, size_t len);
-PHPAPI zend_string *php_string_toupper(zend_string *s);
-PHPAPI zend_string *php_string_tolower(zend_string *s);
 PHPAPI char *php_strtr(char *str, size_t len, const char *str_from, const char *str_to, size_t trlen);
 PHPAPI zend_string *php_addslashes(zend_string *str);
 PHPAPI void php_stripslashes(zend_string *str);

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -55,10 +55,6 @@ PHPAPI void php_explode(const zend_string *delim, zend_string *str, zval *return
 PHPAPI size_t php_strspn(const char *s1, const char *s2, const char *s1_end, const char *s2_end);
 PHPAPI size_t php_strcspn(const char *s1, const char *s2, const char *s1_end, const char *s2_end);
 
-PHPAPI int string_natural_compare_function_ex(zval *result, zval *op1, zval *op2, bool case_insensitive);
-PHPAPI int string_natural_compare_function(zval *result, zval *op1, zval *op2);
-PHPAPI int string_natural_case_compare_function(zval *result, zval *op1, zval *op2);
-
 #if defined(_REENTRANT)
 # ifdef PHP_WIN32
 #  include <wchar.h>

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1343,21 +1343,6 @@ return_false:
 }
 /* }}} */
 
-/* {{{ php_strtoupper */
-PHPAPI char *php_strtoupper(char *s, size_t len)
-{
-	zend_str_toupper(s, len);
-	return s;
-}
-/* }}} */
-
-/* {{{ php_string_toupper */
-PHPAPI zend_string *php_string_toupper(zend_string *s)
-{
-	return zend_string_toupper(s);
-}
-/* }}} */
-
 /* {{{ Makes a string uppercase */
 PHP_FUNCTION(strtoupper)
 {
@@ -1368,21 +1353,6 @@ PHP_FUNCTION(strtoupper)
 	ZEND_PARSE_PARAMETERS_END();
 
 	RETURN_STR(zend_string_toupper(arg));
-}
-/* }}} */
-
-/* {{{ php_strtolower */
-PHPAPI char *php_strtolower(char *s, size_t len)
-{
-	zend_str_tolower(s, len);
-	return s;
-}
-/* }}} */
-
-/* {{{ php_string_tolower */
-PHPAPI zend_string *php_string_tolower(zend_string *s)
-{
-	return zend_string_tolower(s);
 }
 /* }}} */
 
@@ -3120,7 +3090,7 @@ static zend_string *php_str_to_str_i_ex(zend_string *haystack, const char *lc_ha
 		char *e;
 
 		if (ZSTR_LEN(needle) == str_len) {
-			lc_needle = php_string_tolower(needle);
+			lc_needle = zend_string_tolower(needle);
 			end = lc_haystack + ZSTR_LEN(haystack);
 			for (p = lc_haystack; (r = (char*)php_memnstr(p, ZSTR_VAL(lc_needle), ZSTR_LEN(lc_needle), end)); p = r + ZSTR_LEN(lc_needle)) {
 				if (!new_str) {
@@ -3141,7 +3111,7 @@ static zend_string *php_str_to_str_i_ex(zend_string *haystack, const char *lc_ha
 			const char *n;
 			const char *endp = o + ZSTR_LEN(haystack);
 
-			lc_needle = php_string_tolower(needle);
+			lc_needle = zend_string_tolower(needle);
 			n = ZSTR_VAL(lc_needle);
 
 			while ((o = (char*)php_memnstr(o, n, ZSTR_LEN(lc_needle), endp))) {
@@ -3185,7 +3155,7 @@ static zend_string *php_str_to_str_i_ex(zend_string *haystack, const char *lc_ha
 nothing_todo:
 		return zend_string_copy(haystack);
 	} else {
-		lc_needle = php_string_tolower(needle);
+		lc_needle = zend_string_tolower(needle);
 
 		if (memcmp(lc_haystack, ZSTR_VAL(lc_needle), ZSTR_LEN(lc_needle))) {
 			zend_string_release_ex(lc_needle, 0);

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5376,32 +5376,6 @@ static void php_strnatcmp(INTERNAL_FUNCTION_PARAMETERS, int fold_case)
 }
 /* }}} */
 
-PHPAPI int string_natural_compare_function_ex(zval *result, zval *op1, zval *op2, bool case_insensitive) /* {{{ */
-{
-	zend_string *tmp_str1, *tmp_str2;
-	zend_string *str1 = zval_get_tmp_string(op1, &tmp_str1);
-	zend_string *str2 = zval_get_tmp_string(op2, &tmp_str2);
-
-	ZVAL_LONG(result, strnatcmp_ex(ZSTR_VAL(str1), ZSTR_LEN(str1), ZSTR_VAL(str2), ZSTR_LEN(str2), case_insensitive));
-
-	zend_tmp_string_release(tmp_str1);
-	zend_tmp_string_release(tmp_str2);
-	return SUCCESS;
-}
-/* }}} */
-
-PHPAPI int string_natural_case_compare_function(zval *result, zval *op1, zval *op2) /* {{{ */
-{
-	return string_natural_compare_function_ex(result, op1, op2, 1);
-}
-/* }}} */
-
-PHPAPI int string_natural_compare_function(zval *result, zval *op1, zval *op2) /* {{{ */
-{
-	return string_natural_compare_function_ex(result, op1, op2, 0);
-}
-/* }}} */
-
 /* {{{ Returns the result of string comparison using 'natural' algorithm */
 PHP_FUNCTION(strnatcmp)
 {


### PR DESCRIPTION
The to lower/upper functions are wrappers around the ``zend_*`` versions.

The ``natural_compare`` ones are wrappers for ``strnatcmp_ex()`` which always return ``SUCCESS`` and return the result of the comparison via an out argument, something which seems rather pointless.