### PR TITLE
Allow user to change SQLITE_DEFENSIVE if needed

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -76,7 +76,7 @@ static void php_sqlite3_error(php_sqlite3_db_object *db_obj, char *format, ...)
 PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("sqlite3.extension_dir",  NULL, PHP_INI_SYSTEM, OnUpdateString, extension_dir, zend_sqlite3_globals, sqlite3_globals)
 #if SQLITE_VERSION_NUMBER >= 3026000
-	STD_PHP_INI_BOOLEAN("sqlite3.defensive",  "1", PHP_INI_SYSTEM, OnUpdateBool, dbconfig_defensive, zend_sqlite3_globals, sqlite3_globals)
+	STD_PHP_INI_BOOLEAN("sqlite3.defensive",  "1", PHP_INI_USER, OnUpdateBool, dbconfig_defensive, zend_sqlite3_globals, sqlite3_globals)
 #endif
 PHP_INI_END()
 /* }}} */


### PR DESCRIPTION
This allows the PHP developer to set the ini setting `sqlite3.defensive` to `false` to be able to manually modify the schema of a SQLite database if needed.

When I introduced this feature I didn't think of the need to manually change a schema (knowing that this may lead to database corruption).

This setting must in fact be available to app developers without having to change the server configuration for all database connections.