### PR TITLE
Fix GH-8208: mb_encode_mimeheader: $indent functionality broken

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -1803,7 +1803,7 @@ mime_header_encoder_result(struct mime_header_encoder_data *pe, mbfl_string *res
 		mbfl_memory_device_strncat(&pe->outdev, "\x3f\x3d", 2);		/* ?= */
 	} else if (pe->tmpdev.pos > 0) {
 		if (pe->outdev.pos > 0) {
-			if ((pe->outdev.pos - pe->linehead + pe->tmpdev.pos) > 74) {
+			if ((pe->outdev.pos - pe->linehead + pe->tmpdev.pos + pe->firstindent) > 74) {
 				mbfl_memory_device_strncat(&pe->outdev, pe->lwsp, pe->lwsplen);
 			} else {
 				mbfl_memory_device_output(0x20, &pe->outdev);

--- a/ext/mbstring/tests/gh8208.phpt
+++ b/ext/mbstring/tests/gh8208.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-8208 (mb_encode_mimeheader: $indent functionality broken)
+--SKIPIF--
+<?php
+if (!extension_loaded("mbstring")) die("skip mbstring extension not available");
+?>
+--FILE--
+<?php
+$s = "[service-Aufgaben S&W-Team][#19415] VM''s aufsetzen mit unterschiedlichen";
+$p = 'Subject: ';
+var_dump(
+    $p . mb_encode_mimeheader($s, 'UTF-8', 'Q', "\015\012", strlen($p)),
+    mb_encode_mimeheader($p . $s, 'UTF-8', 'Q', "\015\012", 0)
+);
+?>
+--EXPECT--
+string(84) "Subject: [service-Aufgaben S&W-Team][#19415] VM''s aufsetzen mit
+ unterschiedlichen"
+string(84) "Subject: [service-Aufgaben S&W-Team][#19415] VM''s aufsetzen mit
+ unterschiedlichen"


### PR DESCRIPTION
We also need to factor in the indent, when getting the encoder result.