### PR TITLE
Improved responses to different requests on static resources in built-in web server

### DIFF
--- a/sapi/cli/tests/php_cli_server_013.phpt
+++ b/sapi/cli/tests/php_cli_server_013.phpt
@@ -93,6 +93,3 @@ Date: %s
 Connection: close
 Content-Type: text/html; charset=UTF-8
 Content-Length: %d
-
-<!doctype html><html><head><title>404 Not Found</title><style>AAA</style>
-</head><body><h1>Not Found</h1><p>The requested resource <code class="url">/main/foo/bar</code> was not found on this server.</p></body></html>

--- a/sapi/cli/tests/php_cli_server_013.phpt
+++ b/sapi/cli/tests/php_cli_server_013.phpt
@@ -67,6 +67,60 @@ HEADER
 
 echo preg_replace("/<style>(.*?)<\/style>/s", "<style>AAA</style>", $output), "\n";
 fclose($fp);
+
+$output = '';
+$fp = php_cli_server_connect();
+
+if(fwrite($fp, <<<HEADER
+DELETE / HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+    while (!feof($fp)) {
+        $output .= fgets($fp);
+    }
+}
+
+echo preg_replace("/<style>(.*?)<\/style>/s", "<style>AAA</style>", $output), "\n";
+fclose($fp);
+
+$output = '';
+$fp = php_cli_server_connect();
+
+if(fwrite($fp, <<<HEADER
+PUT / HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+    while (!feof($fp)) {
+        $output .= fgets($fp);
+    }
+}
+
+echo preg_replace("/<style>(.*?)<\/style>/s", "<style>AAA</style>", $output), "\n";
+fclose($fp);
+
+$output = '';
+$fp = php_cli_server_connect();
+
+if(fwrite($fp, <<<HEADER
+PATCH / HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+    while (!feof($fp)) {
+        $output .= fgets($fp);
+    }
+}
+
+echo preg_replace("/<style>(.*?)<\/style>/s", "<style>AAA</style>", $output), "\n";
+fclose($fp);
 ?>
 --EXPECTF--
 HTTP/1.1 404 Not Found
@@ -93,3 +147,35 @@ Date: %s
 Connection: close
 Content-Type: text/html; charset=UTF-8
 Content-Length: %d
+
+
+HTTP/1.1 405 Method Not Allowed
+Host: %s
+Date: %s
+Connection: close
+Content-Type: text/html; charset=UTF-8
+Content-Length: %d
+Allow: GET, HEAD, POST
+
+<!doctype html><html><head><title>405 Method Not Allowed</title><style>AAA</style>
+</head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>
+HTTP/1.1 405 Method Not Allowed
+Host: %s
+Date: %s
+Connection: close
+Content-Type: text/html; charset=UTF-8
+Content-Length: %d
+Allow: GET, HEAD, POST
+
+<!doctype html><html><head><title>405 Method Not Allowed</title><style>AAA</style>
+</head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>
+HTTP/1.1 405 Method Not Allowed
+Host: %s
+Date: %s
+Connection: close
+Content-Type: text/html; charset=UTF-8
+Content-Length: %d
+Allow: GET, HEAD, POST
+
+<!doctype html><html><head><title>405 Method Not Allowed</title><style>AAA</style>
+</head><body><h1>Method Not Allowed</h1><p>Requested method not allowed.</p></body></html>


### PR DESCRIPTION
We use PHP's built-in web server for teaching HTTP requests and responses. These two patches handle some edge cases of interest to us.

- Respond without body to HEAD request on a static resource
- Respond with HTTP status 405 to DELETE/POST/PUT/PATCH request on a static resource