### PR TITLE
run-tests.php - Added support for %o and %MAX_LENs|s specifiers for optional parts and length limited strings in EXPECTF blocks.

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2647,7 +2647,9 @@ COMMAND $cmd
             // Stick to basics
             $wanted_re = str_replace('%e', '\\' . DIRECTORY_SEPARATOR, $wanted_re);
             $wanted_re = str_replace('%s', '[^\r\n]+', $wanted_re);
+            $wanted_re = preg_replace('/%([1-9]\d{0,14})s/', '[^\r\n]{1,\\1}', $wanted_re);
             $wanted_re = str_replace('%S', '[^\r\n]*', $wanted_re);
+            $wanted_re = preg_replace('/%([1-9]\d{0,14})S/', '?([^\r\n]{1,\\1})', $wanted_re);
             $wanted_re = str_replace('%a', '.+', $wanted_re);
             $wanted_re = str_replace('%A', '.*', $wanted_re);
             $wanted_re = str_replace('%w', '\s*', $wanted_re);
@@ -2657,6 +2659,7 @@ COMMAND $cmd
             $wanted_re = str_replace('%f', '[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?', $wanted_re);
             $wanted_re = str_replace('%c', '.', $wanted_re);
             $wanted_re = str_replace('%0', '\x00', $wanted_re);
+            $wanted_re = str_replace('%o', '?', $wanted_re); // Allow optional parts
             // %f allows two points "-.0.0" but that is the best *simple* expression
         }
 


### PR DESCRIPTION
The current EXPECTF implementation misses some very useful features, which this PR us about to address.
1) Support for 'optional' data  using %o modifier. It ads the regexp '?' modifier.
2) Support for length limited strings. Currently %s and %S are supported for strings. This change adds support for, for example %15s - String of 1-15 characters long, or %15S -Optional string of up to 15 characters.

Real life examples, there it can be useful:
Let's look on currently failing test ext/xsl/tests/bug71540.phpt on latest PHP 8.0-STABLE.

It has the folowing expected line:
Warning: XSLTProcessor::transformToXml(): Stack usage error in %sbug71540.php on line %d

On CentOS/RHEL 7 libxslt 1.1.28-6.el7 the library has cosmetic error and outputs the word 'error' as 'errror'(Three r's)
and PHP's comparison fail.

With current system we can change it to:
Warning: XSLTProcessor::transformToXml(): Stack usage errror in %sbug71540.php on line %d
but then newer versions of libxlst will cause the test to fail.
As workaround we can use:
Warning: XSLTProcessor::transformToXml(): Stack usage err%Sor in %sbug71540.php on line %d
but it allows too much difference in the strings.

With new update we can just write:
Warning: XSLTProcessor::transformToXml(): Stack usage err%oror in %sbug71540.php on line %d
and it will match exactly our two cases(It makes third 'r' optional).

We can also use:
Warning: XSLTProcessor::transformToXml(): Stack usage err%1Sor in %sbug71540.php on line %d
to allow any additional single character(optionally).