### PR TITLE
Fix #8232 - always reference classes in `var_export()` via their FQCN

### DIFF
--- a/Zend/tests/bug73350.phpt
+++ b/Zend/tests/bug73350.phpt
@@ -12,7 +12,7 @@ $e = new Exception();
 var_export($e);
 ?>
 --EXPECTF--
-Exception::__set_state(array(
+\Exception::__set_state(array(
    'message' => '',
    'string' => 'Exception in %sbug73350.php:%d
 Stack trace:

--- a/Zend/tests/enum/enum-in-var-export.phpt
+++ b/Zend/tests/enum/enum-in-var-export.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Enum in var_export()
+--FILE--
+<?php
+
+namespace {
+    enum Foo { case BAR; }
+}
+
+namespace A {
+    enum Foo { case BAR; }
+}
+
+namespace A\B {
+    enum Foo { case BAR; }
+}
+
+namespace Test {
+    echo var_export(\Foo::BAR, true) . "\n";
+    echo var_export(\A\Foo::BAR, true) . "\n";
+    echo var_export(\A\B\Foo::BAR, true) . "\n";
+}
+
+?>
+--EXPECT--
+\Foo::BAR
+\A\Foo::BAR
+\A\B\Foo::BAR

--- a/Zend/tests/enum/var_export.phpt
+++ b/Zend/tests/enum/var_export.phpt
@@ -14,8 +14,8 @@ echo str_replace(" \n", "\n", var_export([Foo::Bar], true));
 
 ?>
 --EXPECT--
-Foo::Bar
+\Foo::Bar
 array (
   0 =>
-  Foo::Bar,
+  \Foo::Bar,
 )

--- a/Zend/tests/function_arguments/sensitive_parameter_value.phpt
+++ b/Zend/tests/function_arguments/sensitive_parameter_value.phpt
@@ -33,7 +33,7 @@ object(SensitiveParameterValue)#%d (%d) refcount(%d){
 SensitiveParameterValue Object
 
 # var_export()
-SensitiveParameterValue::__set_state(array(
+\SensitiveParameterValue::__set_state(array(
 ))
 
 # (array) / json_encode()

--- a/ext/date/tests/bug52113.phpt
+++ b/ext/date/tests/bug52113.phpt
@@ -16,7 +16,7 @@ $diff_un = unserialize($diff_s);
 $p = new DatePeriod($start, $diff_un, 2);
 var_dump($diff_un, $p);
 
-$unser = DateInterval::__set_state(array(
+$unser = \DateInterval::__set_state(array(
    'y' => 7,
    'm' => 6,
    'd' => 5,
@@ -68,7 +68,7 @@ object(DateInterval)#%d (16) {
   int(0)
 }
 string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
-DateInterval::__set_state(array(
+\DateInterval::__set_state(array(
    'y' => 0,
    'm' => 0,
    'd' => 0,

--- a/ext/intl/tests/dateformat_format.phpt
+++ b/ext/intl/tests/dateformat_format.phpt
@@ -318,7 +318,7 @@ Formatted localtime_array is : 12/17/95 12:13 AM
 IntlDateFormatter locale= en_US ,datetype = -1 ,timetype =-1 
 Formatted localtime_array is : 18951217 12:13 AM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -326,7 +326,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Thursday, December 31, 2009 3:02:03 PM GMT-10:00
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -334,7 +334,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : December 31, 2009 3:02:03 PM GMT-10:00
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -342,7 +342,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Dec 31, 2009 3:02:03 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -350,7 +350,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 12/31/09 3:02 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -358,7 +358,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 20091231 03:02 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',
@@ -366,7 +366,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Saturday, December 30, 2000 5:04:05 PM GMT-10:00
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',
@@ -374,7 +374,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : December 30, 2000 5:04:05 PM GMT-10:00
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',
@@ -382,7 +382,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Dec 30, 2000 5:04:05 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',
@@ -390,7 +390,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 12/30/00 5:04 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',

--- a/ext/intl/tests/dateformat_format_variant2.phpt
+++ b/ext/intl/tests/dateformat_format_variant2.phpt
@@ -318,7 +318,7 @@ Formatted localtime_array is : 12/17/95, 12:13 AM
 IntlDateFormatter locale= en_US ,datetype = -1 ,timetype =-1 
 Formatted localtime_array is : 18951217 12:13 AM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -326,7 +326,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Thursday, December 31, 2009 at 3:02:03 PM GMT-10:00
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -334,7 +334,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : December 31, 2009 at 3:02:03 PM GMT-10
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -342,7 +342,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Dec 31, 2009, 3:02:03 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -350,7 +350,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 12/31/09, 3:02 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -358,7 +358,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 20091231 03:02 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 3,
    'timezone' => 'America/Los_Angeles',
@@ -366,7 +366,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Saturday, December 30, 2000 at 5:04:05 PM GMT-10:00
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 3,
    'timezone' => 'America/Los_Angeles',
@@ -374,7 +374,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : December 30, 2000 at 5:04:05 PM GMT-10
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 3,
    'timezone' => 'America/Los_Angeles',
@@ -382,7 +382,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Dec 30, 2000, 5:04:05 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 3,
    'timezone' => 'America/Los_Angeles',
@@ -390,7 +390,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 12/30/00, 5:04 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 3,
    'timezone' => 'America/Los_Angeles',

--- a/ext/intl/tests/dateformat_format_variant3.phpt
+++ b/ext/intl/tests/dateformat_format_variant3.phpt
@@ -318,7 +318,7 @@ Formatted localtime_array is : 12/17/95, 12:13 AM
 IntlDateFormatter locale= en_US ,datetype = -1 ,timetype =-1 
 Formatted localtime_array is : 18951217 12:13 AM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -326,7 +326,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Thursday, December 31, 2009 at 3:02:03 PM GMT-10:00
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -334,7 +334,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : December 31, 2009 at 3:02:03 PM GMT-10
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -342,7 +342,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Dec 31, 2009, 3:02:03 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -350,7 +350,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 12/31/09, 3:02 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2010-01-01 01:02:03.000000',
    'timezone_type' => 3,
    'timezone' => 'UTC',
@@ -358,7 +358,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 20091231 03:02 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',
@@ -366,7 +366,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Saturday, December 30, 2000 at 5:04:05 PM GMT-10:00
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',
@@ -374,7 +374,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : December 30, 2000 at 5:04:05 PM GMT-10
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',
@@ -382,7 +382,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : Dec 30, 2000, 5:04:05 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',
@@ -390,7 +390,7 @@ Date is: DateTime::__set_state(array(
 ------------
 Formatted DateTime is : 12/30/00, 5:04 PM
 ------------
-Date is: DateTime::__set_state(array(
+Date is: \DateTime::__set_state(array(
    'date' => '2000-12-30 19:04:05.000000',
    'timezone_type' => 2,
    'timezone' => 'PDT',

--- a/ext/spl/tests/bug65967.phpt
+++ b/ext/spl/tests/bug65967.phpt
@@ -10,5 +10,5 @@ gc_collect_cycles();
 var_export($objstore);
 ?>
 --EXPECT--
-SplObjectStorage::__set_state(array(
+\SplObjectStorage::__set_state(array(
 ))

--- a/ext/spl/tests/fixedarray_022.phpt
+++ b/ext/spl/tests/fixedarray_022.phpt
@@ -11,7 +11,7 @@ call_user_func(function () {
 ?>
 --EXPECTF--
 Warning: var_export does not handle circular references in %s on line 5
-SplFixedArray::__set_state(array(
+\SplFixedArray::__set_state(array(
    0 => NULL,
 ))
 object(SplFixedArray)#2 (1) refcount(4){

--- a/ext/spl/tests/fixedarray_023.phpt
+++ b/ext/spl/tests/fixedarray_023.phpt
@@ -18,7 +18,7 @@ call_user_func(function () {
 Warning: var_export does not handle circular references in %s on line 8
 
 Warning: var_export does not handle circular references in %s on line 8
-SplFixedArray::__set_state(array(
+\SplFixedArray::__set_state(array(
    0 => NAN,
    1 => 0.0,
    2 => NULL,

--- a/ext/standard/tests/array/007.phpt
+++ b/ext/standard/tests/array/007.phpt
@@ -248,54 +248,54 @@ array(9) {
 -=-=-=-=-=-=-=-=- New functionality from 5.0.0 -=-=-=-=-=-=-=-
 $a=array (
   '0.1' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 12,
      'public_member' => 12,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 23,
      'public_member' => 23,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
 );
 $b=array (
   '0.2' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 22,
      'public_member' => 22,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 3,
      'public_member' => 3,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
@@ -326,54 +326,54 @@ array(3) {
 }
 $a=array (
   '0.1' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 12,
      'public_member' => 12,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 23,
      'public_member' => 23,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
 );
 $b=array (
   '0.2' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 22,
      'public_member' => 22,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 3,
      'public_member' => 3,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
@@ -404,54 +404,54 @@ array(3) {
 }
 $a=array (
   '0.1' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 12,
      'public_member' => 12,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 23,
      'public_member' => 23,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
 );
 $b=array (
   '0.2' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 22,
      'public_member' => 22,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 3,
      'public_member' => 3,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
@@ -475,54 +475,54 @@ array(2) {
 }
 $a=array (
   '0.1' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 12,
      'public_member' => 12,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 23,
      'public_member' => 23,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
 );
 $b=array (
   '0.2' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 22,
      'public_member' => 22,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 3,
      'public_member' => 3,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),

--- a/ext/standard/tests/array/array_intersect_1.phpt
+++ b/ext/standard/tests/array/array_intersect_1.phpt
@@ -66,54 +66,54 @@ echo "end   ------------ array_uintersect_uassoc() with method --------\n";
 begin ------------ array_uintersect() ---------------------------
 $a=array (
   '0.1' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 12,
      'public_member' => 12,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 23,
      'public_member' => 23,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
 );
 $b=array (
   '0.2' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 22,
      'public_member' => 22,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 3,
      'public_member' => 3,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
@@ -146,54 +146,54 @@ end   ------------ array_uintersect() ---------------------------
 begin ------------ array_uintersect_assoc() ---------------------
 $a=array (
   '0.1' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 12,
      'public_member' => 12,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 23,
      'public_member' => 23,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
 );
 $b=array (
   '0.2' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 22,
      'public_member' => 22,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 3,
      'public_member' => 3,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
@@ -219,54 +219,54 @@ end   ------------ array_uintersect_assoc() ---------------------
 begin ------------ array_uintersect_uassoc() with ordinary func -
 $a=array (
   '0.1' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 12,
      'public_member' => 12,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 23,
      'public_member' => 23,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
 );
 $b=array (
   '0.2' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 22,
      'public_member' => 22,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 3,
      'public_member' => 3,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
@@ -292,54 +292,54 @@ end   ------------ array_uintersect_uassoc() with ordinary func -
 begin ------------ array_uintersect_uassoc() with method --------
 $a=array (
   '0.1' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 12,
      'public_member' => 12,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 23,
      'public_member' => 23,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),
 );
 $b=array (
   '0.2' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 9,
      'public_member' => 9,
   )),
   '0.5' => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 22,
      'public_member' => 22,
   )),
   0 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 3,
      'public_member' => 3,
   )),
   1 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => 4,
      'public_member' => 4,
   )),
   2 => 
-  cr::__set_state(array(
+  \cr::__set_state(array(
      'priv_member' => -15,
      'public_member' => -15,
   )),

--- a/ext/standard/tests/array/var_export3.phpt
+++ b/ext/standard/tests/array/var_export3.phpt
@@ -18,7 +18,7 @@ $kake = new kake;
 var_export($kake);
 ?>
 --EXPECT--
-kake::__set_state(array(
+\kake::__set_state(array(
    'mann' => 42,
    'kvinne' => 43,
 ))

--- a/ext/standard/tests/general_functions/bug47027.phpt
+++ b/ext/standard/tests/general_functions/bug47027.phpt
@@ -6,7 +6,7 @@ $ao = new ArrayObject(array (2 => "foo", "bar" => "baz"));
 var_export ($ao);
 ?>
 --EXPECT--
-ArrayObject::__set_state(array(
+\ArrayObject::__set_state(array(
    2 => 'foo',
    'bar' => 'baz',
 ))

--- a/ext/standard/tests/general_functions/bug77638_1.phpt
+++ b/ext/standard/tests/general_functions/bug77638_1.phpt
@@ -7,5 +7,5 @@ com_dotnet
 var_export(new COM("Scripting.Dictionary"));
 ?>
 --EXPECT--
-com::__set_state(array(
+\com::__set_state(array(
 ))

--- a/ext/standard/tests/general_functions/bug77638_2.phpt
+++ b/ext/standard/tests/general_functions/bug77638_2.phpt
@@ -7,5 +7,5 @@ ffi
 var_export(FFI::new('int'));
 ?>
 --EXPECT--
-FFI\CData::__set_state(array(
+\FFI\CData::__set_state(array(
 ))

--- a/ext/standard/tests/general_functions/var_export-locale.phpt
+++ b/ext/standard/tests/general_functions/var_export-locale.phpt
@@ -914,35 +914,35 @@ string(17) "(object) array(
 
 
 Iteration 2
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 Iteration 3
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-string(36) "concreteClass::__set_state(array(
+string(37) "\concreteClass::__set_state(array(
 ))"
 
 
 Iteration 4
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-string(57) "Value::__set_state(array(
+string(58) "\Value::__set_state(array(
    'vars' => 
   array (
   ),
@@ -950,140 +950,140 @@ string(57) "Value::__set_state(array(
 
 
 Iteration 5
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-string(266) "myClass::__set_state(array(
+string(271) "\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))"
 
 
 Iteration 6
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-string(266) "myClass::__set_state(array(
+string(271) "\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))"
 
 
 Iteration 7
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 Iteration 8
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 Iteration 9
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 Iteration 10
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-string(57) "Value::__set_state(array(
+string(58) "\Value::__set_state(array(
    'vars' => 
   array (
   ),
@@ -1091,11 +1091,11 @@ string(57) "Value::__set_state(array(
 
 
 Iteration 11
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-string(36) "concreteClass::__set_state(array(
+string(37) "\concreteClass::__set_state(array(
 ))"
 
 *** Testing var_export() with valid null values ***

--- a/ext/standard/tests/general_functions/var_export-locale_32.phpt
+++ b/ext/standard/tests/general_functions/var_export-locale_32.phpt
@@ -914,35 +914,35 @@ string(17) "(object) array(
 
 
 Iteration 2
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 Iteration 3
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-string(36) "concreteClass::__set_state(array(
+string(37) "\concreteClass::__set_state(array(
 ))"
 
 
 Iteration 4
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-string(57) "Value::__set_state(array(
+string(58) "\Value::__set_state(array(
    'vars' => 
   array (
   ),
@@ -950,140 +950,140 @@ string(57) "Value::__set_state(array(
 
 
 Iteration 5
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-string(266) "myClass::__set_state(array(
+string(271) "\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))"
 
 
 Iteration 6
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-string(266) "myClass::__set_state(array(
+string(271) "\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))"
 
 
 Iteration 7
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 Iteration 8
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 Iteration 9
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 Iteration 10
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-string(57) "Value::__set_state(array(
+string(58) "\Value::__set_state(array(
    'vars' => 
   array (
   ),
@@ -1091,11 +1091,11 @@ string(57) "Value::__set_state(array(
 
 
 Iteration 11
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-string(36) "concreteClass::__set_state(array(
+string(37) "\concreteClass::__set_state(array(
 ))"
 
 *** Testing var_export() with valid null values ***

--- a/ext/standard/tests/general_functions/var_export_basic6.phpt
+++ b/ext/standard/tests/general_functions/var_export_basic6.phpt
@@ -110,35 +110,35 @@ string(17) "(object) array(
 
 
 -- Iteration: new foo --
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 -- Iteration: new concreteClass --
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-string(36) "concreteClass::__set_state(array(
+string(37) "\concreteClass::__set_state(array(
 ))"
 
 
 -- Iteration: new Value --
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-string(57) "Value::__set_state(array(
+string(58) "\Value::__set_state(array(
    'vars' => 
   array (
   ),
@@ -146,140 +146,140 @@ string(57) "Value::__set_state(array(
 
 
 -- Iteration: new myClass --
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-string(266) "myClass::__set_state(array(
+string(271) "\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))"
 
 
 -- Iteration: myClass_object --
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-myClass::__set_state(array(
+\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))
-string(266) "myClass::__set_state(array(
+string(271) "\myClass::__set_state(array(
    'foo_object' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'public_var' => 10,
    'public_var1' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'private_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
    'protected_var' => 
-  foo::__set_state(array(
+  \foo::__set_state(array(
   )),
 ))"
 
 
 -- Iteration: myClass_object->foo_object --
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 -- Iteration: myClass_object->public_var1 --
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 -- Iteration: foo_object --
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-foo::__set_state(array(
+\foo::__set_state(array(
 ))
-string(26) "foo::__set_state(array(
+string(27) "\foo::__set_state(array(
 ))"
 
 
 -- Iteration: Value_object --
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-Value::__set_state(array(
+\Value::__set_state(array(
    'vars' => 
   array (
   ),
 ))
-string(57) "Value::__set_state(array(
+string(58) "\Value::__set_state(array(
    'vars' => 
   array (
   ),
@@ -287,9 +287,9 @@ string(57) "Value::__set_state(array(
 
 
 -- Iteration: concreteClass_object --
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-concreteClass::__set_state(array(
+\concreteClass::__set_state(array(
 ))
-string(36) "concreteClass::__set_state(array(
+string(37) "\concreteClass::__set_state(array(
 ))"

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -575,6 +575,7 @@ again:
 			if (ce == zend_standard_class_def) {
 				smart_str_appendl(buf, "(object) array(\n", 16);
 			} else {
+				smart_str_appendc(buf, '\\');
 				smart_str_append(buf, ce->name);
 				if (is_enum) {
 					zend_object *zobj = Z_OBJ_P(struc);


### PR DESCRIPTION
This fix corrects a behavior of `var_export()` that was mostly "hidden" until PHP 8.1 introduced:

 * properties with object initializers
 * constants containing object references
 * default values of class properties containing `enum`s

Since `var_export(..., true)` is mostly used in conjunction with code generation,
and we cannot make assumptions about the generated code being placed in the root
namespace, we must always provide the FQCN of a class in exported code.

For example:

```php
<?php

namespace MyNamespace { class Foo {} }

namespace { echo "<?php\n\nnamespace Example;\n\n" . var_export(new \MyNamespace\Foo(), true) . ';'; }
```

produces:

```php
<?php

namespace Example;

MyNamespace\Foo::__set_state(array(
));
```

This code snippet is invalid, because `Example\MyNamespace\Foo::__set_state()` (which
does not exist) is called.

With this patch applied, the code looks like following (valid):

```php
<?php

namespace Example;

\MyNamespace\Foo::__set_state(array(
));
```

Fixes #8232
Ref: https://github.com/Ocramius/ProxyManager/issues/754