### PR TITLE
Zend, ext/opcache: use PR_SET_VMA_ANON_NAME (Linux 5.17)

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -57,6 +57,7 @@
 #include "zend_operators.h"
 #include "zend_multiply.h"
 #include "zend_bitset.h"
+#include "zend_mmap.h"
 #include <signal.h>
 
 #ifdef HAVE_UNISTD_H
@@ -475,6 +476,7 @@ static void *zend_mm_mmap(size_t size)
 #endif
 		ptr = mmap(NULL, size, PROT_READ | PROT_WRITE, mflags, fd, 0);
 		if (ptr != MAP_FAILED) {
+			zend_mmap_set_name(ptr, size, "zend_alloc");
 			return ptr;
 		}
 	}
@@ -488,6 +490,7 @@ static void *zend_mm_mmap(size_t size)
 #endif
 		return NULL;
 	}
+	zend_mmap_set_name(ptr, size, "zend_alloc");
 	return ptr;
 #endif
 }

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -24,6 +24,7 @@
 #include "zend_exceptions.h"
 #include "zend_builtin_functions.h"
 #include "zend_observer.h"
+#include "zend_mmap.h"
 
 #include "zend_fibers.h"
 #include "zend_fibers_arginfo.h"
@@ -210,6 +211,8 @@ static zend_fiber_stack *zend_fiber_stack_allocate(size_t size)
 		zend_throw_exception_ex(NULL, 0, "Fiber stack allocate failed: mmap failed: %s (%d)", strerror(errno), errno);
 		return NULL;
 	}
+
+	zend_mmap_set_name(pointer, alloc_size, "zend_fiber_stack");
 
 # if ZEND_FIBER_GUARD_PAGES
 	if (mprotect(pointer, ZEND_FIBER_GUARD_PAGES * page_size, PROT_NONE) < 0) {

--- a/Zend/zend_mmap.h
+++ b/Zend/zend_mmap.h
@@ -1,0 +1,44 @@
+/*
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 2.00 of the Zend license,     |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | http://www.zend.com/license/2_00.txt.                                |
+   | If you did not receive a copy of the Zend license and are unable to  |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@zend.com so we can mail you a copy immediately.              |
+   +----------------------------------------------------------------------+
+   | Authors: Max Kellermann <max.kellermann@ionos.com>                   |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef ZEND_MMAP_H
+#define ZEND_MMAP_H
+
+#include "zend_portability.h"
+
+#ifdef __linux__
+# include <sys/prctl.h>
+
+/* fallback definitions if our libc is older than the kernel */
+# ifndef PR_SET_VMA
+#  define PR_SET_VMA 0x53564d41
+# endif
+# ifndef PR_SET_VMA_ANON_NAME
+#  define PR_SET_VMA_ANON_NAME 0
+# endif
+#endif // __linux__
+
+/**
+ * Set a name for the specified memory area.
+ *
+ * This feature requires Linux 5.17.
+ */
+static zend_always_inline void zend_mmap_set_name(const void *start, size_t len, const char *name)
+{
+#ifdef __linux__
+	prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, (unsigned long)start, len, (unsigned long)name);
+#endif
+}
+
+#endif /* ZEND_MMAP_H */

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -34,6 +34,7 @@
 #include "zend_vm.h"
 #include "zend_inheritance.h"
 #include "zend_exceptions.h"
+#include "zend_mmap.h"
 #include "main/php_main.h"
 #include "main/SAPI.h"
 #include "main/php_streams.h"
@@ -2986,6 +2987,8 @@ static int accel_remap_huge_pages(void *start, size_t size, size_t real_size, co
 		return -1;
 #  endif
 	}
+
+	zend_mmap_set_name(start, size, "zend_huge_code_pages");
 
 	if (ret == start) {
 		memcpy(start, mem, real_size);

--- a/ext/opcache/jit/zend_jit_perf_dump.c
+++ b/ext/opcache/jit/zend_jit_perf_dump.c
@@ -46,6 +46,7 @@ extern unsigned int thr_self(void);
 #endif
 
 #include "zend_elf.h"
+#include "zend_mmap.h"
 
 /*
  * 1) Profile using perf-<pid>.map
@@ -171,8 +172,9 @@ static void zend_jit_perf_jitdump_open(void)
 		return;
 	}
 
+	const size_t page_size = sysconf(_SC_PAGESIZE);
 	jitdump_mem = mmap(NULL,
-			sysconf(_SC_PAGESIZE),
+			page_size,
 			PROT_READ|PROT_EXEC,
 			MAP_PRIVATE, jitdump_fd, 0);
 
@@ -181,6 +183,8 @@ static void zend_jit_perf_jitdump_open(void)
 		jitdump_fd = -1;
 		return;
 	}
+
+	zend_mmap_set_name(jitdump_mem, page_size, "zend_jitdump");
 
 	memset(&jit_hdr, 0, sizeof(jit_hdr));
 	jit_hdr.magic           = ZEND_PERF_JITDUMP_HEADER_MAGIC;


### PR DESCRIPTION
The new Linux 5.17 feature PR_SET_VMA_ANON_NAME can give names to
anonymous private memory, see:

 https://lwn.net/Articles/867818/

It can be useful while debugging, to identify which portion of the
process's memory belongs to which subsystem.

This is how /proc/PID/maps can look like:

 555ccd400000-555ccdc00000 r-xp 00000000 00:00 0                          [anon:huge_code_pages]
 7f6ec6600000-7f6ec6800000 rw-p 00000000 00:00 0                          [anon:zend_alloc]

The first mapping is the PHP executable copied to anonymous memory by
option "opcache.huge_code_pages".  The second one is a memory area for
the "zend_alloc.h" memory allocator library.

Unfortunately, it is not possible to give names to shared memory
(MAP_SHARED),  because Linux MAP_SHARED really maps /dev/zero (see
shmem_zero_setup()), which makes madvise_vma_anon_name() believe this
is a file mapping, failing the prctl() with EBADF.