### PR TITLE
fix TypeError: Unsupported operand types: string * int

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -97,12 +97,12 @@ Options:
                 Do not delete 'all' files, 'php' test file, 'skip' or 'clean'
                 file.
 
-    --set-timeout [n]
+    --set-timeout <n>
                 Set timeout for individual tests, where [n] is the number of
                 seconds. The default value is 60 seconds, or 300 seconds when
                 testing for memory leaks.
 
-    --context [n]
+    --context <n>
                 Sets the number of lines of surrounding context to print for diffs.
                 The default value is 3.
 
@@ -113,7 +113,7 @@ Options:
                 'mem'. The result types get written independent of the log format,
                 however 'diff' only exists when a test fails.
 
-    --show-slow [n]
+    --show-slow <n>
                 Show all tests that took longer than [n] milliseconds to run.
 
     --no-clean  Do not execute clean section if any.
@@ -571,7 +571,11 @@ function main(): void
                     $just_save_results = true;
                     break;
                 case '--set-timeout':
-                    $environment['TEST_TIMEOUT'] = $argv[++$i];
+                    $timeout = $argv[++$i] ?? '';
+                    if (!preg_match('/^\d+$/', $timeout)) {
+                        error("'$timeout' is not a valid number of seconds, try e.g. --set-timeout 60 for 1 minute");
+                    }
+                    $environment['TEST_TIMEOUT'] = intval($timeout, 10);
                     break;
                 case '--context':
                     $context_line_count = $argv[++$i] ?? '';
@@ -586,7 +590,11 @@ function main(): void
                     }
                     break;
                 case '--show-slow':
-                    $slow_min_ms = $argv[++$i];
+                    $slow_min_ms = $argv[++$i] ?? '';
+                    if (!preg_match('/^\d+$/', $slow_min_ms)) {
+                        error("'$slow_min_ms' is not a valid number of milliseconds, try e.g. --show-slow 1000 for 1 second");
+                    }
+                    $slow_min_ms = intval($slow_min_ms, 10);
                     break;
                 case '--temp-source':
                     $temp_source = $argv[++$i];


### PR DESCRIPTION
```
$ php run-tests.php --show-slow 
=====================================================================
PHP         : /usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.0.17
ZEND_VERSION: 4.0.17
PHP_OS      : Linux - Linux builder.remirepo.net 5.16.15-201.fc35.x86_64 #1 SMP PREEMPT Thu Mar 17 05:45:13 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/memcached
More .INIs  :   
---------------------------------------------------------------------
PHP         : /usr/bin/phpdbg 
PHP_SAPI    : phpdbg
PHP_VERSION : 8.0.17
ZEND_VERSION: 4.0.17
PHP_OS      : Linux - Linux builder.remirepo.net 5.16.15-201.fc35.x86_64 #1 SMP PREEMPT Thu Mar 17 05:45:13 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/memcached
More .INIs  : 
---------------------------------------------------------------------
CWD         : /work/GIT/pecl-and-ext/memcached
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
Running selected tests.
Fatal error: Uncaught TypeError: Unsupported operand types: string * int in /work/GIT/pecl-and-ext/memcached/run-tests.php:2524
Stack trace:
#0 /work/GIT/pecl-and-ext/memcached/run-tests.php(1348): run_test('/usr/bin/php', '/work/GIT/pecl-...', Array)
#1 /work/GIT/pecl-and-ext/memcached/run-tests.php(718): run_all_tests(Array, Array)
#2 /work/GIT/pecl-and-ext/memcached/run-tests.php(3772): main()
#3 {main}

```