### PR TITLE
line break before --prefix in php-fpm man page

### DIFF
--- a/sapi/fpm/php-fpm.8.in
+++ b/sapi/fpm/php-fpm.8.in
@@ -77,6 +77,8 @@ Show compiled in modules
 .PD 1
 .B \-v
 Version number
+.TP
+.PD 0
 .B \-\-prefix \fIpath\fP
 .TP
 .PD 1


### PR DESCRIPTION
Fix missing line break that should be before --prefix in the php-fpm man page