### PR TITLE
Fix signedness confusion

### DIFF
--- a/ext/filter/logical_filters.c
+++ b/ext/filter/logical_filters.c
@@ -496,7 +496,7 @@ void php_filter_validate_regexp(PHP_INPUT_FILTER_PARAM_DECL) /* {{{ */
 	}
 }
 
-static int _php_filter_validate_domain(char * domain, int len, zend_long flags) /* {{{ */
+static int _php_filter_validate_domain(char * domain, size_t len, zend_long flags) /* {{{ */
 {
 	char *e, *s, *t;
 	size_t l;


### PR DESCRIPTION
As is, there is the possibility that integer underflow occurs, making
`_php_filter_validate_domain()` succeed for very long domain names.

Cf. <https://pwning.systems/posts/php_filter_var_shenanigans/>.