### PR TITLE
Fix GH-8253: pg_insert() fails for references

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -4595,6 +4595,7 @@ PHP_PGSQL_API int php_pgsql_convert(PGconn *pg_link, const char *table_name, con
 
 	ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(values), field, val) {
 		skip_field = 0;
+		ZVAL_DEREF(val);
 		ZVAL_NULL(&new_val);
 
 		/* TODO: Check when meta data can be broken and see if can use assertions instead */

--- a/ext/pgsql/tests/gh8253.phpt
+++ b/ext/pgsql/tests/gh8253.phpt
@@ -1,0 +1,29 @@
+--TEST--
+pg_insert() fails for references
+--SKIPIF--
+<?php
+include("skipif.inc");
+?>
+--FILE--
+<?php
+include "config.inc";
+
+function fee(&$a) {}
+$a = ["bar" => "testing"];
+fee($a["bar"]);
+
+$db = pg_connect($conn_str);
+pg_query($db, "DROP TABLE IF EXISTS gh8253");
+pg_query($db, "CREATE TABLE gh8253 (bar text);");
+pg_insert($db, "gh8253", $a);
+$res = pg_query($db, "SELECT * FROM gh8253");
+var_dump(pg_fetch_all($res));
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(1) {
+    ["bar"]=>
+    string(7) "testing"
+  }
+}


### PR DESCRIPTION
We need to deref the values.