### PR TITLE
Fix result_type related stack corruption on LLP64 architectures

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -2000,7 +2000,7 @@ PHP_FUNCTION(pg_fetch_object)
 PHP_FUNCTION(pg_fetch_all)
 {
 	zval *result;
-	long result_type = PGSQL_ASSOC;
+	zend_long result_type = PGSQL_ASSOC;
 	PGresult *pgsql_result;
 	pgsql_result_handle *pg_result;
 
@@ -5896,7 +5896,7 @@ PHP_FUNCTION(pg_select)
 	char *table;
 	size_t table_len;
 	zend_ulong option = PGSQL_DML_EXEC;
-	long result_type = PGSQL_ASSOC;
+	zend_long result_type = PGSQL_ASSOC;
 	PGconn *pg_link;
 	zend_string *sql = NULL;
 


### PR DESCRIPTION
Integer parameters are stored in `zend_long` values, which have 64 bits
on LLP64, but `long` has only 32 bits there.

Adding a test might be overkill, because the broken behavior could
already be observed when running pg_select_001.phpt on Windows debug
builds, which report the stack corruption.