### PR TITLE
Fix #81714: segfault when serializing finalized HashContext

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -227,6 +227,9 @@ PHP_HASH_API int php_hash_serialize_spec(const php_hashcontext_object *hash, zva
 	size_t pos = 0, max_alignment = 1;
 	unsigned char *buf = (unsigned char *) hash->context;
 	zval tmp;
+	if (buf == NULL) {
+		return FAILURE;
+	}
 	array_init(zv);
 	while (*spec != '\0' && *spec != '.') {
 		char spec_ch = *spec;

--- a/ext/hash/tests/bug81714.phpt
+++ b/ext/hash/tests/bug81714.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #81714 (segfault when serializing finalized HashContext)
+--FILE--
+<?php
+$h = hash_init('md5');
+hash_final($h);
+try {
+    serialize($h);
+} catch (Exception $ex) {
+    var_dump($ex->getMessage());
+}
+?>
+--EXPECTF--
+string(52) "HashContext for algorithm "md5" cannot be serialized"


### PR DESCRIPTION
We must not allow to serialize already finalized `HashContext`s, since
the internal context is already freed.  Since there is not much point
in serializing finalized `HashContext`s, we just bail out in that case.