### PR TITLE
Fix GH-8267: MySQLi uses unsupported format specifier on Windows

### DIFF
--- a/ext/mysqli/php_mysqli_structs.h
+++ b/ext/mysqli/php_mysqli_structs.h
@@ -134,8 +134,6 @@ typedef struct {
 
 #ifdef PHP_WIN32
 #define PHP_MYSQLI_API __declspec(dllexport)
-#define MYSQLI_LLU_SPEC "%I64u"
-#define MYSQLI_LL_SPEC "%I64d"
 #ifndef L64
 #define L64(x) x##i64
 #endif
@@ -146,15 +144,16 @@ typedef __int64 my_longlong;
 # else
 #  define PHP_MYSQLI_API
 # endif
-/* we need this for PRIu64 and PRId64 */
-#include <inttypes.h>
-#define MYSQLI_LLU_SPEC "%" PRIu64
-#define MYSQLI_LL_SPEC "%" PRId64
 #ifndef L64
 #define L64(x) x##LL
 #endif
 typedef int64_t my_longlong;
 #endif
+
+/* we need this for PRIu64 and PRId64 */
+#include <inttypes.h>
+#define MYSQLI_LLU_SPEC "%" PRIu64
+#define MYSQLI_LL_SPEC "%" PRId64
 
 #ifdef ZTS
 #include "TSRM.h"

--- a/ext/mysqli/tests/gh8267.phpt
+++ b/ext/mysqli/tests/gh8267.phpt
@@ -9,8 +9,7 @@ require_once("skipifconnectfailure.inc");
 <?php
 require_once("connect.inc");
 
-$mysqli = my_mysqli_connect($host, $user, $passwd, "", $port, $socket);
-$mysqli = new mysqli("localhost", "root", "test", "test");
+$mysqli = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket);
 $mysqli->query("DROP TABLE IF EXISTS foo");
 $mysqli->query("CREATE TABLE foo (id BIGINT UNSIGNED AUTO_INCREMENT, PRIMARY KEY (id))");
 $mysqli->query("INSERT INTO foo VALUES (9223372036854775807)");

--- a/ext/mysqli/tests/gh8267.phpt
+++ b/ext/mysqli/tests/gh8267.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug GH-8267 (MySQLi uses unsupported format specifier on Windows)
+--SKIPIF--
+<?php
+require_once("skipif.inc");
+require_once("skipifconnectfailure.inc");
+?>
+--FILE--
+<?php
+require_once("connect.inc");
+
+$mysqli = my_mysqli_connect($host, $user, $passwd, "", $port, $socket);
+$mysqli = new mysqli("localhost", "root", "test", "test");
+$mysqli->query("DROP TABLE IF EXISTS foo");
+$mysqli->query("CREATE TABLE foo (id BIGINT UNSIGNED AUTO_INCREMENT, PRIMARY KEY (id))");
+$mysqli->query("INSERT INTO foo VALUES (9223372036854775807)");
+var_dump($mysqli->insert_id);
+$mysqli->query("INSERT INTO foo VALUES (0)");
+var_dump($mysqli->insert_id);
+?>
+--EXPECT--
+string(19) "9223372036854775807"
+string(19) "9223372036854775808"


### PR DESCRIPTION
Instead of using the unsupported `%I64u` and `%I64d` format specifiers
on Windows, we use the portable `PRIu64` and `PRId64` specifiers.

The `L64()` macro and the `my_longlong` typedef should be adapted as
well, as the `i64` literal suffix is still supported by MSVC, but using
`LL` or `ll` is recommended[1], and the standard `int64_t` is available
there anyway.  This is not urgent, though.

[1] <https://docs.microsoft.com/en-us/cpp/cpp/numeric-boolean-and-pointer-literals-cpp?view=msvc-170#integer-literals>