### PR TITLE
Fix a NULL pointer dereference bug lead by php_pcre_replace_impl()

### DIFF
--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1880,6 +1880,9 @@ PHP_METHOD(RegexIterator, accept)
 			}
 
 			result = php_pcre_replace_impl(intern->u.regex.pce, subject, ZSTR_VAL(subject), ZSTR_LEN(subject), replacement_str, -1, &count);
+			if (!result) {
+				RETURN_FALSE;
+			}
 
 			if (intern->u.regex.flags & REGIT_USE_KEY) {
 				zval_ptr_dtor(&intern->current.key);


### PR DESCRIPTION
php_pcre_replace_impl() will return NULL on failure. However in the function
zim_RegexIterator_accept(), the return value of php_pcre_replace_impl()
is directly used without any check, which could lead to NULL
pointer dereference.

Fix this by adding a NULL check.

This bug is found by a static analyzer, so it is hard to reproduce it.