### PR TITLE
Fix a NULL pointer dereference of spl_ptr_llist_offset()

### DIFF
--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -1257,6 +1257,7 @@ PHP_METHOD(SplDoublyLinkedList, add)
 
 		/* Get the element we want to insert before */
 		element = spl_ptr_llist_offset(intern->llist, index, intern->flags & SPL_DLLIST_IT_LIFO);
+		ZEND_ASSERT(element != NULL);
 
 		ZVAL_COPY_VALUE(&elem->data, value);
 		SPL_LLIST_RC(elem) = 1;


### PR DESCRIPTION
spl_ptr_llist_offset() will return NULL when offset is invalid. However
in the function zim_SplDoublyLinkedList_add(), the return value of
spl_ptr_llist_offset() is directly used without check, which could
lead to possible NULL pointer dereference.

Fix this bug by adding the check of spl_ptr_llist_offset() like others.

This bug is found by a static analyzer, making it hard to reproduce.