### PR TITLE
Update bug tracker links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ supported branch of PHP that the bug affects (only green branches on
 [the supported version page](https://www.php.net/supported-versions.php) are
 supported). For example, at the time of writing, the lowest supported version is
 PHP 8.0, which corresponds to the `PHP-8.0` branch in Git. Please also make sure
-you add a link to the PR in the bug on [the bug tracker](https://bugs.php.net/).
+you add a link to the PR in the bug on [the bug tracker](https://github.com/php/php-src/issues)
+or [the old bug tracker](https://bugs.php.net/).
 
 Pull requests implementing RFCs should be submitted against `master`.
 
@@ -49,7 +50,8 @@ them by using `git rebase` instead of `git merge`.
 Fork the official PHP repository and send a pull request. A notification will be
 sent to the pull request mailing list. Sending a note to PHP Internals list
 (internals@lists.php.net) may help getting more feedback and quicker turnaround.
-You can also add pull requests to [bug reports](https://bugs.php.net/).
+You can also add pull requests to [bug reports](https://github.com/php/php-src/issues)
+and [old bug reports](https://bugs.php.net/).
 
 Read [Git access page](https://www.php.net/git.php) for help on using Git to get
 and build PHP source code. We recommend to look at our

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ dnl Basic autoconf initialization, generation of config.nice.
 dnl ----------------------------------------------------------------------------
 
 AC_PREREQ([2.68])
-AC_INIT([PHP],[8.2.0-dev],[https://bugs.php.net],[php],[https://www.php.net])
+AC_INIT([PHP],[8.2.0-dev],[https://github.com/php/php-src/issues],[php],[https://www.php.net])
 AC_CONFIG_SRCDIR([main/php_version.h])
 AC_CONFIG_AUX_DIR([build])
 AC_PRESERVE_HELP_ORDER

--- a/ext/pgsql/tests/README.md
+++ b/ext/pgsql/tests/README.md
@@ -15,4 +15,4 @@ as the same user running the tests you ensure that the user is granted access to
 the database.
 
 If you find problems in PostgreSQL extension, please report a
-[bug](https://bugs.php.net).
+[bug](https://github.com/php/php-src/issues).

--- a/ext/phar/phar.1.in
+++ b/ext/phar/phar.1.in
@@ -497,7 +497,7 @@ You can view the list of known bugs or report any new bug you
 found at:
 .PD 0
 .P
-.B http://bugs.php.net
+.B https://github.com/php/php-src/issues
 .PD 1
 .SH AUTHORS
 The PHP Group: Thies C. Arntzen, Stig Bakken, Andi Gutmans, Rasmus Lerdorf, Sam Ruby, Sascha Schumann, Zeev Suraski, Jim Winstead, Andrei Zmievski.

--- a/main/network.c
+++ b/main/network.c
@@ -1163,7 +1163,7 @@ PHPAPI void _php_emit_fd_setsize_warning(int max_fd)
 	php_error_docref(NULL, E_WARNING,
 		"PHP needs to be recompiled with a larger value of FD_SETSIZE.\n"
 		"If this binary is from an official www.php.net package, file a bug report\n"
-		"at http://bugs.php.net, including the following information:\n"
+		"at https://github.com/php/php-src/issues, including the following information:\n"
 		"FD_SETSIZE=%d, but you are using %d.\n"
 		" --enable-fd-setsize=%d is recommended, but you may want to set it\n"
 		"to match to maximum number of sockets each script will work with at\n"

--- a/sapi/cli/php.1.in
+++ b/sapi/cli/php.1.in
@@ -436,7 +436,7 @@ You can view the list of known bugs or report any new bug you
 found at:
 .PD 0
 .P
-.B http://bugs.php.net
+.B https://github.com/php/php-src/issues
 .PD 1
 .SH AUTHORS
 The PHP Group: Thies C. Arntzen, Stig Bakken, Andi Gutmans, Rasmus Lerdorf, Sam Ruby, Sascha Schumann, Zeev Suraski, Jim Winstead, Andrei Zmievski.

--- a/sapi/fpm/fpm/fpm_atomic.h
+++ b/sapi/fpm/fpm/fpm_atomic.h
@@ -133,7 +133,7 @@ static inline atomic_uint_t atomic_cmp_set(atomic_t *lock, atomic_uint_t old, at
 
 #else
 
-#error Unsupported processor. Please open a bug report (bugs.php.net).
+#error Unsupported processor. Please open a bug report (https://github.com/php/php-src/issues).
 
 #endif
 

--- a/sapi/fpm/php-fpm.8.in
+++ b/sapi/fpm/php-fpm.8.in
@@ -197,7 +197,7 @@ You can view the list of known bugs or report any new bug you
 found at:
 .PD 0
 .P
-.B http://bugs.php.net
+.B https://github.com/php/php-src/issues
 .PD 1
 .SH AUTHORS
 PHP-FPM SAPI was written by Andrei Nigmatulin. The mailing-lists are highload-php-en (English) and highload-php-ru (Russian).

--- a/sapi/phpdbg/phpdbg.1.in
+++ b/sapi/phpdbg/phpdbg.1.in
@@ -105,7 +105,7 @@ You can view the list of known bugs or report any new bug you
 found at
 .PD 0
 .P
-.B http://bugs.php.net/
+.B https://github.com/php/php-src/issues
 .PD 1
 .SH AUTHORS
 Written by Felipe Pena, Joe Watkins and Bob Weinand, formatted by Ondřej Surý for Debian project.

--- a/win32/sendmail.c
+++ b/win32/sendmail.c
@@ -87,7 +87,7 @@ static char *ErrorMessages[] =
 	{"Bad Message File"},
 	{"\"sendmail_from\" not set in php.ini or custom \"From:\" header missing"},
 	{"Mailserver rejected our \"sendmail_from\" setting"}, /* 20 */
-	{"Error while trimming mail header with PCRE, please file a bug report at http://bugs.php.net/"} /* 21 */
+	{"Error while trimming mail header with PCRE, please file a bug report at https://github.com/php/php-src/issues"} /* 21 */
 };
 
 /* This pattern converts all single occurrences of \n (Unix)


### PR DESCRIPTION
The new php-src bugtracker is on Github.