### PR TITLE
Stop including php_pcre.h from spl_iterators.h

### DIFF
--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -23,6 +23,7 @@
 #include "ext/standard/info.h"
 #include "zend_exceptions.h"
 #include "zend_interfaces.h"
+#include "ext/pcre/php_pcre.h"
 
 #include "php_spl.h"
 #include "spl_functions.h"
@@ -113,6 +114,53 @@ typedef struct _spl_recursive_it_iterator {
 	zend_object_iterator   intern;
 } spl_recursive_it_iterator;
 
+typedef struct _spl_cbfilter_it_intern {
+	zend_fcall_info       fci;
+	zend_fcall_info_cache fcc;
+	zend_object           *object;
+} _spl_cbfilter_it_intern;
+
+typedef struct _spl_dual_it_object {
+	struct {
+		zval                 zobject;
+		zend_class_entry     *ce;
+		zend_object          *object;
+		zend_object_iterator *iterator;
+	} inner;
+	struct {
+		zval                 data;
+		zval                 key;
+		zend_long            pos;
+	} current;
+	dual_it_type             dit_type;
+	union {
+		struct {
+			zend_long             offset;
+			zend_long             count;
+		} limit;
+		struct {
+			zend_long             flags; /* CIT_* */
+			zend_string          *zstr;
+			zval             zchildren;
+			zval             zcache;
+		} caching;
+		struct {
+			zval                  zarrayit;
+			zend_object_iterator *iterator;
+		} append;
+		struct {
+			zend_long        flags;
+			zend_long        preg_flags;
+			pcre_cache_entry *pce;
+			zend_string      *regex;
+			regex_mode       mode;
+			int              use_flags;
+		} regex;
+		_spl_cbfilter_it_intern *cbfilter;
+	} u;
+	zend_object              std;
+} spl_dual_it_object;
+
 static zend_object_handlers spl_handlers_rec_it_it;
 static zend_object_handlers spl_handlers_dual_it;
 
@@ -122,6 +170,12 @@ static inline spl_recursive_it_object *spl_recursive_it_from_obj(zend_object *ob
 /* }}} */
 
 #define Z_SPLRECURSIVE_IT_P(zv)  spl_recursive_it_from_obj(Z_OBJ_P((zv)))
+
+static inline spl_dual_it_object *spl_dual_it_from_obj(zend_object *obj) /* {{{ */ {
+	return (spl_dual_it_object*)((char*)(obj) - XtOffsetOf(spl_dual_it_object, std));
+} /* }}} */
+
+#define Z_SPLDUAL_IT_P(zv)  spl_dual_it_from_obj(Z_OBJ_P((zv)))
 
 #define SPL_FETCH_AND_CHECK_DUAL_IT(var, objzval) 												\
 	do { 																						\

--- a/ext/spl/spl_iterators.h
+++ b/ext/spl/spl_iterators.h
@@ -19,7 +19,6 @@
 
 #include "php.h"
 #include "php_spl.h"
-#include "ext/pcre/php_pcre.h"
 
 extern PHPAPI zend_class_entry *spl_ce_AppendIterator;
 extern PHPAPI zend_class_entry *spl_ce_CachingIterator;
@@ -98,59 +97,6 @@ typedef enum {
 	REGIT_MODE_REPLACE,
 	REGIT_MODE_MAX
 } regex_mode;
-
-typedef struct _spl_cbfilter_it_intern {
-	zend_fcall_info       fci;
-	zend_fcall_info_cache fcc;
-	zend_object           *object;
-} _spl_cbfilter_it_intern;
-
-typedef struct _spl_dual_it_object {
-	struct {
-		zval                 zobject;
-		zend_class_entry     *ce;
-		zend_object          *object;
-		zend_object_iterator *iterator;
-	} inner;
-	struct {
-		zval                 data;
-		zval                 key;
-		zend_long            pos;
-	} current;
-	dual_it_type             dit_type;
-	union {
-		struct {
-			zend_long             offset;
-			zend_long             count;
-		} limit;
-		struct {
-			zend_long             flags; /* CIT_* */
-			zend_string          *zstr;
-			zval             zchildren;
-			zval             zcache;
-		} caching;
-		struct {
-			zval                  zarrayit;
-			zend_object_iterator *iterator;
-		} append;
-		struct {
-			zend_long        flags;
-			zend_long        preg_flags;
-			pcre_cache_entry *pce;
-			zend_string      *regex;
-			regex_mode       mode;
-			int              use_flags;
-		} regex;
-		_spl_cbfilter_it_intern *cbfilter;
-	} u;
-	zend_object              std;
-} spl_dual_it_object;
-
-static inline spl_dual_it_object *spl_dual_it_from_obj(zend_object *obj) /* {{{ */ {
-	return (spl_dual_it_object*)((char*)(obj) - XtOffsetOf(spl_dual_it_object, std));
-} /* }}} */
-
-#define Z_SPLDUAL_IT_P(zv)  spl_dual_it_from_obj(Z_OBJ_P((zv)))
 
 typedef int (*spl_iterator_apply_func_t)(zend_object_iterator *iter, void *puser);
 


### PR DESCRIPTION
This fixes GH-7774.

spl_iterators.h was including php_pcre.h so that one object intern struct could reference a pcre_cache_entry. These object interns should not be public, so they can be moved out of the header file.

This change moves the object interns ouf of spl_iterators.h so that php_pcre.h doesn't need to be included from there.