### PR TITLE
Remove SIZEOF_OFF_T undef in PDO PGSQL driver

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -29,7 +29,6 @@
 #include "pdo/php_pdo_driver.h"
 #include "pdo/php_pdo_error.h"
 #include "ext/standard/file.h"
-#undef SIZEOF_OFF_T
 #include "php_pdo_pgsql.h"
 #include "php_pdo_pgsql_int.h"
 #include "zend_exceptions.h"


### PR DESCRIPTION
This looks to be plainly wrong and pointless, and possibly mess with the FFI extension (as it checks for this value)