### PR TITLE
Refactor php_module_startup()

### DIFF
--- a/main/php_main.h
+++ b/main/php_main.h
@@ -25,7 +25,7 @@
 BEGIN_EXTERN_C()
 PHPAPI int php_request_startup(void);
 PHPAPI void php_request_shutdown(void *dummy);
-PHPAPI int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_modules, uint32_t num_additional_modules);
+PHPAPI zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_module);
 PHPAPI void php_module_shutdown(void);
 PHPAPI int php_module_shutdown_wrapper(sapi_module_struct *sapi_globals);
 

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -378,10 +378,7 @@ extern zend_module_entry php_apache_module;
 
 static int php_apache2_startup(sapi_module_struct *sapi_module)
 {
-	if (php_module_startup(sapi_module, &php_apache_module, 1)==FAILURE) {
-		return FAILURE;
-	}
-	return SUCCESS;
+	return php_module_startup(sapi_module, &php_apache_module);
 }
 
 static sapi_module_struct apache2_sapi_module = {

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -966,10 +966,7 @@ static int sapi_cgi_deactivate(void)
 
 static int php_cgi_startup(sapi_module_struct *sapi_module)
 {
-	if (php_module_startup(sapi_module, &cgi_module_entry, 1) == FAILURE) {
-		return FAILURE;
-	}
-	return SUCCESS;
+	return php_module_startup(sapi_module, &cgi_module_entry);
 }
 
 /* {{{ sapi_module_struct cgi_sapi_module */

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -406,10 +406,7 @@ static void sapi_cli_send_header(sapi_header_struct *sapi_header, void *server_c
 
 static int php_cli_startup(sapi_module_struct *sapi_module) /* {{{ */
 {
-	if (php_module_startup(sapi_module, NULL, 0)==FAILURE) {
-		return FAILURE;
-	}
-	return SUCCESS;
+	return php_module_startup(sapi_module, NULL);
 }
 /* }}} */
 

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -498,7 +498,7 @@ const zend_function_entry server_additional_functions[] = {
 
 static int sapi_cli_server_startup(sapi_module_struct *sapi_module) /* {{{ */
 {
-	return php_module_startup(sapi_module, &cli_server_module_entry, 1);
+	return php_module_startup(sapi_module, &cli_server_module_entry);
 } /* }}} */
 
 static size_t sapi_cli_server_ub_write(const char *str, size_t str_length) /* {{{ */

--- a/sapi/embed/php_embed.c
+++ b/sapi/embed/php_embed.c
@@ -119,10 +119,7 @@ static void php_embed_register_variables(zval *track_vars_array)
 /* Module initialization (MINIT) */
 static int php_embed_startup(sapi_module_struct *sapi_module)
 {
-	if (php_module_startup(sapi_module, NULL, 0) == FAILURE) {
-		return FAILURE;
-	}
-	return SUCCESS;
+	return php_module_startup(sapi_module, NULL);
 }
 
 EMBED_SAPI_API sapi_module_struct php_embed_module = {

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -766,10 +766,7 @@ static int sapi_cgi_deactivate(void) /* {{{ */
 
 static int php_cgi_startup(sapi_module_struct *sapi_module) /* {{{ */
 {
-	if (php_module_startup(sapi_module, &cgi_module_entry, 1) == FAILURE) {
-		return FAILURE;
-	}
-	return SUCCESS;
+	return php_module_startup(sapi_module, &cgi_module_entry);
 }
 /* }}} */
 

--- a/sapi/fuzzer/fuzzer-sapi.c
+++ b/sapi/fuzzer/fuzzer-sapi.c
@@ -62,10 +62,7 @@ const char HARDCODED_INI[] =
 
 static int startup(sapi_module_struct *sapi_module)
 {
-	if (php_module_startup(sapi_module, NULL, 0)==FAILURE) {
-		return FAILURE;
-	}
-	return SUCCESS;
+	return php_module_startup(sapi_module, NULL);
 }
 
 static size_t ub_write(const char *str, size_t str_length)

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -97,7 +97,7 @@ static void init_sapi_from_env(sapi_module_struct *sapi_module)
 /* {{{ php_lsapi_startup */
 static int php_lsapi_startup(sapi_module_struct *sapi_module)
 {
-    if (php_module_startup(sapi_module, NULL, 0)==FAILURE) {
+    if (php_module_startup(sapi_module, NULL)==FAILURE) {
         return FAILURE;
     }
     argv0 = sapi_module->executable_location;
@@ -1518,7 +1518,7 @@ int main( int argc, char * argv[] )
 
     lsapi_sapi_module.ini_defaults = sapi_lsapi_ini_defaults;
 
-    if (php_module_startup(&lsapi_sapi_module, &litespeed_module_entry, 1) == FAILURE) {
+    if (php_module_startup(&lsapi_sapi_module, &litespeed_module_entry) == FAILURE) {
 #ifdef ZTS
         tsrm_shutdown();
 #endif

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -705,7 +705,7 @@ static zend_module_entry sapi_phpdbg_module_entry = {
 
 static inline int php_sapi_phpdbg_module_startup(sapi_module_struct *module) /* {{{ */
 {
-	if (php_module_startup(module, &sapi_phpdbg_module_entry, 1) == FAILURE) {
+	if (php_module_startup(module, &sapi_phpdbg_module_entry) == FAILURE) {
 		return FAILURE;
 	}
 


### PR DESCRIPTION
It only ever uses at most 1 additional modules.

Also actually fail startup if registering the module failed for some reason.