### PR TITLE
Add some const qualifiers in zend_string/hash

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1163,8 +1163,7 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_set_bucket_key(HashTable *ht, Bucket *b, 
 	HT_ASSERT_RC1(ht);
 	ZEND_ASSERT(!HT_IS_PACKED(ht));
 
-	/* Precompute string hash */
-	zend_string_hash_val(key);
+	(void)zend_string_hash_val(key);
 	p = zend_hash_find_bucket(ht, key);
 	if (UNEXPECTED(p)) {
 		return (p == b) ? &p->val : NULL;
@@ -2525,8 +2524,7 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_find(const HashTable *ht, zend_string *ke
 
 	IS_CONSISTENT(ht);
 
-	/* Precompute string hash */
-	zend_string_hash_val(key);
+	(void)zend_string_hash_val(key);
 	p = zend_hash_find_bucket(ht, key);
 	return p ? &p->val : NULL;
 }

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -655,21 +655,18 @@ ZEND_API void ZEND_FASTCALL zend_hash_iterators_advance(HashTable *ht, HashPosit
 	}
 }
 
-static zend_always_inline Bucket *zend_hash_find_bucket(const HashTable *ht, zend_string *key, bool known_hash)
+/* Hash must be known and precomputed before */
+static zend_always_inline Bucket *zend_hash_find_bucket(const HashTable *ht, const zend_string *key)
 {
-	zend_ulong h;
+	zend_ulong key_hash = ZSTR_H(key);
 	uint32_t nIndex;
 	uint32_t idx;
 	Bucket *p, *arData;
 
-	if (known_hash) {
-		h = ZSTR_H(key);
-		ZEND_ASSERT(h != 0 && "Hash must be known");
-	} else {
-		h = zend_string_hash_val(key);
-	}
+	ZEND_ASSERT(key_hash != 0 && "Hash must be known");
+
 	arData = ht->arData;
-	nIndex = h | ht->nTableMask;
+	nIndex = key_hash | ht->nTableMask;
 	idx = HT_HASH_EX(arData, nIndex);
 
 	if (UNEXPECTED(idx == HT_INVALID_IDX)) {
@@ -681,7 +678,7 @@ static zend_always_inline Bucket *zend_hash_find_bucket(const HashTable *ht, zen
 	}
 
 	while (1) {
-		if (p->h == ZSTR_H(key) &&
+		if (p->h == key_hash &&
 		    EXPECTED(p->key) &&
 		    zend_string_equal_content(p->key, key)) {
 			return p;
@@ -758,7 +755,7 @@ static zend_always_inline zval *_zend_hash_add_or_update_i(HashTable *ht, zend_s
 			zend_hash_packed_to_hash(ht);
 		}
 	} else if ((flag & HASH_ADD_NEW) == 0 || ZEND_DEBUG) {
-		p = zend_hash_find_bucket(ht, key, 1);
+		p = zend_hash_find_bucket(ht, key);
 
 		if (p) {
 			zval *data;
@@ -1166,7 +1163,9 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_set_bucket_key(HashTable *ht, Bucket *b, 
 	HT_ASSERT_RC1(ht);
 	ZEND_ASSERT(!HT_IS_PACKED(ht));
 
-	p = zend_hash_find_bucket(ht, key, 0);
+	/* Precompute string hash */
+	zend_string_hash_val(key);
+	p = zend_hash_find_bucket(ht, key);
 	if (UNEXPECTED(p)) {
 		return (p == b) ? &p->val : NULL;
 	}
@@ -2526,17 +2525,19 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_find(const HashTable *ht, zend_string *ke
 
 	IS_CONSISTENT(ht);
 
-	p = zend_hash_find_bucket(ht, key, 0);
+	/* Precompute string hash */
+	zend_string_hash_val(key);
+	p = zend_hash_find_bucket(ht, key);
 	return p ? &p->val : NULL;
 }
 
-ZEND_API zval* ZEND_FASTCALL zend_hash_find_known_hash(const HashTable *ht, zend_string *key)
+ZEND_API zval* ZEND_FASTCALL zend_hash_find_known_hash(const HashTable *ht, const zend_string *key)
 {
 	Bucket *p;
 
 	IS_CONSISTENT(ht);
 
-	p = zend_hash_find_bucket(ht, key, 1);
+	p = zend_hash_find_bucket(ht, key);
 	return p ? &p->val : NULL;
 }
 

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -179,7 +179,7 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_index_find(const HashTable *ht, zend_ulon
 ZEND_API zval* ZEND_FASTCALL _zend_hash_index_find(const HashTable *ht, zend_ulong h);
 
 /* The same as zend_hash_find(), but hash value of the key must be already calculated. */
-ZEND_API zval* ZEND_FASTCALL zend_hash_find_known_hash(const HashTable *ht, zend_string *key);
+ZEND_API zval* ZEND_FASTCALL zend_hash_find_known_hash(const HashTable *ht, const zend_string *key);
 
 static zend_always_inline zval *zend_hash_find_ex(const HashTable *ht, zend_string *key, bool known_hash)
 {

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -370,16 +370,16 @@ ZEND_API void zend_interned_strings_switch_storage(bool request)
 # define I_REPLACE_SONAME_FNNAME_ZU(soname, fnname) _vgr00000ZU_ ## soname ## _ ## fnname
 #endif
 
-ZEND_API bool ZEND_FASTCALL I_REPLACE_SONAME_FNNAME_ZU(NONE,zend_string_equal_val)(zend_string *s1, zend_string *s2)
+ZEND_API bool ZEND_FASTCALL I_REPLACE_SONAME_FNNAME_ZU(NONE,zend_string_equal_val)(const zend_string *s1, const zend_string *s2)
 {
 	return !memcmp(ZSTR_VAL(s1), ZSTR_VAL(s2), ZSTR_LEN(s1));
 }
 
 #if defined(__GNUC__) && defined(__i386__)
-ZEND_API bool ZEND_FASTCALL zend_string_equal_val(zend_string *s1, zend_string *s2)
+ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const zend_string *s2)
 {
-	char *ptr = ZSTR_VAL(s1);
-	size_t delta = (char*)s2 - (char*)s1;
+	const char *ptr = ZSTR_VAL(s1);
+	size_t delta = (const char*)s2 - (const char*)s1;
 	size_t len = ZSTR_LEN(s1);
 	zend_ulong ret;
 
@@ -414,10 +414,10 @@ ZEND_API bool ZEND_FASTCALL zend_string_equal_val(zend_string *s1, zend_string *
 }
 
 #elif defined(__GNUC__) && defined(__x86_64__) && !defined(__ILP32__)
-ZEND_API bool ZEND_FASTCALL zend_string_equal_val(zend_string *s1, zend_string *s2)
+ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const zend_string *s2)
 {
-	char *ptr = ZSTR_VAL(s1);
-	size_t delta = (char*)s2 - (char*)s1;
+	const char *ptr = ZSTR_VAL(s1);
+	size_t delta = (const char*)s2 - (const char*)s1;
 	size_t len = ZSTR_LEN(s1);
 	zend_ulong ret;
 

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -346,21 +346,21 @@ static zend_always_inline bool zend_string_equals_cstr(const zend_string *s1, co
 
 #if defined(__GNUC__) && (defined(__i386__) || (defined(__x86_64__) && !defined(__ILP32__)))
 BEGIN_EXTERN_C()
-ZEND_API bool ZEND_FASTCALL zend_string_equal_val(zend_string *s1, zend_string *s2);
+ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const zend_string *s2);
 END_EXTERN_C()
 #else
-static zend_always_inline bool zend_string_equal_val(zend_string *s1, zend_string *s2)
+static zend_always_inline bool zend_string_equal_val(const zend_string *s1, const zend_string *s2)
 {
 	return !memcmp(ZSTR_VAL(s1), ZSTR_VAL(s2), ZSTR_LEN(s1));
 }
 #endif
 
-static zend_always_inline bool zend_string_equal_content(zend_string *s1, zend_string *s2)
+static zend_always_inline bool zend_string_equal_content(const zend_string *s1, const zend_string *s2)
 {
 	return ZSTR_LEN(s1) == ZSTR_LEN(s2) && zend_string_equal_val(s1, s2);
 }
 
-static zend_always_inline bool zend_string_equals(zend_string *s1, zend_string *s2)
+static zend_always_inline bool zend_string_equals(const zend_string *s1, const zend_string *s2)
 {
 	return s1 == s2 || zend_string_equal_content(s1, s2);
 }


### PR DESCRIPTION
I was confused as to why most of the APIs did not have a const modifier until I actually added them and got reminded that ``zend_string_hash_func()`` needs the ``zend_string`` to be mutable, so not sure how worthwhile these changes actually are.