### PR TITLE
Fix GH-8310: Registry settings are no longer recognized

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2489,7 +2489,7 @@ PHPAPI int php_execute_script(zend_file_handle *primary_file)
 
 #ifdef PHP_WIN32
 		if(primary_file->filename) {
-			UpdateIniFromRegistry((char*)primary_file->filename);
+			UpdateIniFromRegistry(ZSTR_VAL(primary_file->filename));
 		}
 #endif
 
@@ -2581,7 +2581,7 @@ PHPAPI int php_execute_simple_script(zend_file_handle *primary_file, zval *ret)
 	zend_try {
 #ifdef PHP_WIN32
 		if(primary_file->filename) {
-			UpdateIniFromRegistry((char*)primary_file->filename);
+			UpdateIniFromRegistry(ZSTR_VAL(primary_file->filename));
 		}
 #endif
 


### PR DESCRIPTION
`zend_file_handle->filename` is a `zend_string*` pointer now, so we
must not cast to `char*` but rather pass the underlying `char*`.