### PR TITLE
Deprecate internal SplFileInfo::_bad_state_ex() method

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -149,6 +149,8 @@ PHP 8.2 UPGRADE NOTES
     separate, built-in implementations of all of them; for example, UUencoded
     data can be handled using convert_uuencode/convert_uudecode.
 
+- SPL:
+  . The SplFileInfo::_bad_state_ex() internal method has been deprecated.
 ========================================
 5. Changed Functions
 ========================================

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -693,11 +693,8 @@ zend_function *spl_filesystem_object_get_method_check(zend_object **object, zend
 	spl_filesystem_object *fsobj = spl_filesystem_from_obj(*object);
 
 	if (fsobj->u.dir.dirp == NULL && fsobj->orig_path == NULL) {
-		zend_function *func;
-		zend_string *tmp = zend_string_init("_bad_state_ex", sizeof("_bad_state_ex") - 1, 0);
-		func = zend_std_get_method(object, tmp, NULL);
-		zend_string_release_ex(tmp, 0);
-		return func;
+		zend_throw_error(NULL, "The parent constructor was not called: the object is in an invalid state");
+		return NULL;
 	}
 
 	return zend_std_get_method(object, method, key);
@@ -1403,6 +1400,7 @@ PHP_METHOD(SplFileInfo, _bad_state_ex)
 		RETURN_THROWS();
 	}
 	zend_throw_error(NULL, "The parent constructor was not called: the object is in an invalid state");
+	RETURN_THROWS();
 }
 /* }}} */
 

--- a/ext/spl/spl_directory.stub.php
+++ b/ext/spl/spl_directory.stub.php
@@ -97,7 +97,10 @@ class SplFileInfo implements Stringable
     /** @tentative-return-type */
     public function __debugInfo(): array {}
 
-    /** @tentative-return-type */
+    /**
+     * @deprecated
+     * @tentative-return-type
+     */
     final public function _bad_state_ex(): void {}
 }
 

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3ada856cfa2e50708b43125f819706176b1953f7 */
+ * Stub hash: a5789c24c7ba9dd1d266ee3534e6e459bca29630 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFileInfo___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -395,7 +395,7 @@ static const zend_function_entry class_SplFileInfo_methods[] = {
 	ZEND_ME(SplFileInfo, setInfoClass, arginfo_class_SplFileInfo_setInfoClass, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(SplFileInfo, __toString, getPathname, arginfo_class_SplFileInfo___toString, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFileInfo, __debugInfo, arginfo_class_SplFileInfo___debugInfo, ZEND_ACC_PUBLIC)
-	ZEND_ME(SplFileInfo, _bad_state_ex, arginfo_class_SplFileInfo__bad_state_ex, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL)
+	ZEND_ME(SplFileInfo, _bad_state_ex, arginfo_class_SplFileInfo__bad_state_ex, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL|ZEND_ACC_DEPRECATED)
 	ZEND_FE_END
 };
 

--- a/ext/spl/tests/gh8318.phpt
+++ b/ext/spl/tests/gh8318.phpt
@@ -1,0 +1,41 @@
+--TEST--
+GH-8318 (SplFileObject useless call to an internal method for erroring)
+--FILE--
+<?php
+class bug8318 extends \SplFileObject
+{
+    public function __construct()
+    {
+    }
+
+    public function fpassthru(): int
+    {
+        return 0;
+    }
+}
+
+$cl = new bug8318;
+try {
+    $cl->fpassthru();
+} catch (\Error $e) {
+    var_dump($e);
+}
+?>
+--EXPECTF--
+object(Error)#2 (7) {
+  ["message":protected]=>
+  string(72) "The parent constructor was not called: the object is in an invalid state"
+  ["string":"Error":private]=>
+  string(0) ""
+  ["code":protected]=>
+  int(0)
+  ["file":protected]=>
+  string(%d) "%s"
+  ["line":protected]=>
+  int(16)
+  ["trace":"Error":private]=>
+  array(0) {
+  }
+  ["previous":"Error":private]=>
+  NULL
+}


### PR DESCRIPTION
Use standard VM handling instead

Not exactly sure how to write a test for this.