### PR TITLE
Fix GH-8273: SplFileObject: key() returns wrong value

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1862,11 +1862,10 @@ static int spl_filesystem_object_cast(zend_object *readobj, zval *writeobj, int 
 }
 /* }}} */
 
-static zend_result spl_filesystem_file_read(spl_filesystem_object *intern, bool silent) /* {{{ */
+static zend_result spl_filesystem_file_read_ex(spl_filesystem_object *intern, bool silent, zend_long line_add) /* {{{ */
 {
 	char *buf;
 	size_t line_len = 0;
-	zend_long line_add = (intern->u.file.current_line || !Z_ISUNDEF(intern->u.file.current_zval)) ? 1 : 0;
 
 	spl_filesystem_file_free_line(intern);
 
@@ -1910,6 +1909,12 @@ static zend_result spl_filesystem_file_read(spl_filesystem_object *intern, bool 
 
 	return SUCCESS;
 } /* }}} */
+
+static inline zend_result spl_filesystem_file_read(spl_filesystem_object *intern, bool silent)
+{
+	zend_long line_add = (intern->u.file.current_line) ? 1 : 0;
+	return spl_filesystem_file_read_ex(intern, silent, line_add);
+}
 
 static zend_result spl_filesystem_file_read_csv(spl_filesystem_object *intern, char delimiter, char enclosure, int escape, zval *return_value) /* {{{ */
 {
@@ -2180,7 +2185,7 @@ PHP_METHOD(SplFileObject, fgets)
 
 	CHECK_SPL_FILE_OBJECT_IS_INITIALIZED(intern);
 
-	if (spl_filesystem_file_read(intern, 0) == FAILURE) {
+	if (spl_filesystem_file_read_ex(intern, /* silent */ false, /* line_add */ 1) == FAILURE) {
 		RETURN_THROWS();
 	}
 	RETURN_STRINGL(intern->u.file.current_line, intern->u.file.current_line_len);
@@ -2218,8 +2223,8 @@ PHP_METHOD(SplFileObject, key)
 		RETURN_THROWS();
 	}
 
-/*	Do not read the next line to support correct counting with fgetc()
-	if (!intern->current_line) {
+	/* Do not read the next line to support correct counting with fgetc()
+	if (!intern->u.file.current_line) {
 		spl_filesystem_file_read_line(ZEND_THIS, intern, 1);
 	} */
 	RETURN_LONG(intern->u.file.current_line_num);

--- a/ext/spl/tests/gh8273.phpt
+++ b/ext/spl/tests/gh8273.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-8273 (SplFileObject: key() returns wrong value)
+--FILE--
+<?php
+
+$file = new SplTempFileObject();
+
+// write to file
+for ($i = 0; $i < 5; $i++) {
+    $file->fwrite("line {$i}" . PHP_EOL);
+}
+
+// read from file
+$file->rewind();
+while ($file->valid()) {
+    echo $file->key(), ': ', $file->fgets();
+}
+?>
+--EXPECT--
+0: line 0
+1: line 1
+2: line 2
+3: line 3
+4: line 4


### PR DESCRIPTION
Not sure this is the best approach but it fixes the bug