### PR TITLE
Use AS_ECHO([]) instead of obsolete $as_echo

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2152,7 +2152,7 @@ EOF
    else
     break
    fi
-   $as_echo "$CURRENT_ARG \\" >>$1
+   AS_ECHO(["$CURRENT_ARG \\"]) >>$1
    CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $CURRENT_ARG"
   done
   echo '"[$]@"' >> $1


### PR DESCRIPTION
When using a newer autoconf, it warns about this. It warns about other
things too, but they aren't as obvious to fix.