### PR TITLE
Fix bug #76003: FPM /status reports wrong number of active processe

### DIFF
--- a/sapi/fpm/fpm/fpm_process_ctl.c
+++ b/sapi/fpm/fpm/fpm_process_ctl.c
@@ -324,21 +324,6 @@ static void fpm_pctl_perform_idle_server_maintenance(struct timeval *now) /* {{{
 
 		if (wp->config == NULL) continue;
 
-		for (child = wp->children; child; child = child->next) {
-			if (fpm_request_is_idle(child)) {
-				if (last_idle_child == NULL) {
-					last_idle_child = child;
-				} else {
-					if (timercmp(&child->started, &last_idle_child->started, <)) {
-						last_idle_child = child;
-					}
-				}
-				idle++;
-			} else {
-				active++;
-			}
-		}
-
 		/* update status structure for all PMs */
 		if (wp->listen_address_domain == FPM_AF_INET) {
 			if (0 > fpm_socket_get_listening_queue(wp->listening_socket, &cur_lq, NULL)) {
@@ -356,7 +341,25 @@ static void fpm_pctl_perform_idle_server_maintenance(struct timeval *now) /* {{{
 #endif
 			}
 		}
-		fpm_scoreboard_update(idle, active, cur_lq, -1, -1, -1, 0, FPM_SCOREBOARD_ACTION_SET, wp->scoreboard);
+
+		fpm_scoreboard_update_begin(wp->scoreboard);
+
+		for (child = wp->children; child; child = child->next) {
+			if (fpm_request_is_idle(child)) {
+				if (last_idle_child == NULL) {
+					last_idle_child = child;
+				} else {
+					if (timercmp(&child->started, &last_idle_child->started, <)) {
+						last_idle_child = child;
+					}
+				}
+				idle++;
+			} else {
+				active++;
+			}
+		}
+
+		fpm_scoreboard_update_commit(idle, active, cur_lq, -1, -1, -1, 0, FPM_SCOREBOARD_ACTION_SET, wp->scoreboard);
 
 		/* this is specific to PM_STYLE_ONDEMAND */
 		if (wp->config->pm == PM_STYLE_ONDEMAND) {

--- a/sapi/fpm/fpm/fpm_request.c
+++ b/sapi/fpm/fpm/fpm_request.c
@@ -41,6 +41,8 @@ void fpm_request_accepting() /* {{{ */
 
 	fpm_clock_get(&now);
 
+	fpm_scoreboard_update_begin(NULL);
+
 	proc = fpm_scoreboard_proc_acquire(NULL, -1, 0);
 	if (proc == NULL) {
 		zlog(ZLOG_WARNING, "failed to acquire proc scoreboard");
@@ -52,7 +54,7 @@ void fpm_request_accepting() /* {{{ */
 	fpm_scoreboard_proc_release(proc);
 
 	/* idle++, active-- */
-	fpm_scoreboard_update(1, -1, 0, 0, 0, 0, 0, FPM_SCOREBOARD_ACTION_INC, NULL);
+	fpm_scoreboard_update_commit(1, -1, 0, 0, 0, 0, 0, FPM_SCOREBOARD_ACTION_INC, NULL);
 }
 /* }}} */
 
@@ -71,6 +73,8 @@ void fpm_request_reading_headers() /* {{{ */
 #ifdef HAVE_TIMES
 	times(&cpu);
 #endif
+
+	fpm_scoreboard_update_begin(NULL);
 
 	proc = fpm_scoreboard_proc_acquire(NULL, -1, 0);
 	if (proc == NULL) {
@@ -95,7 +99,7 @@ void fpm_request_reading_headers() /* {{{ */
 	fpm_scoreboard_proc_release(proc);
 
 	/* idle--, active++, request++ */
-	fpm_scoreboard_update(-1, 1, 0, 0, 1, 0, 0, FPM_SCOREBOARD_ACTION_INC, NULL);
+	fpm_scoreboard_update_commit(-1, 1, 0, 0, 1, 0, 0, FPM_SCOREBOARD_ACTION_INC, NULL);
 }
 /* }}} */
 

--- a/sapi/fpm/fpm/fpm_scoreboard.h
+++ b/sapi/fpm/fpm/fpm_scoreboard.h
@@ -73,7 +73,10 @@ struct fpm_scoreboard_s {
 int fpm_scoreboard_init_main();
 int fpm_scoreboard_init_child(struct fpm_worker_pool_s *wp);
 
+void fpm_scoreboard_update_begin(struct fpm_scoreboard_s *scoreboard);
+void fpm_scoreboard_update_commit(int idle, int active, int lq, int lq_len, int requests, int max_children_reached, int slow_rq, int action, struct fpm_scoreboard_s *scoreboard);
 void fpm_scoreboard_update(int idle, int active, int lq, int lq_len, int requests, int max_children_reached, int slow_rq, int action, struct fpm_scoreboard_s *scoreboard);
+
 struct fpm_scoreboard_s *fpm_scoreboard_get();
 struct fpm_scoreboard_proc_s *fpm_scoreboard_proc_get(struct fpm_scoreboard_s *scoreboard, int child_index);
 struct fpm_scoreboard_proc_s *fpm_scoreboard_proc_get_from_child(struct fpm_child_s *child);


### PR DESCRIPTION
The fix introduces early locking of scoreboard when it is updated which prevents the race condition causing an incorrect number of active processes being set.

This is unfortunately not easily repeatable in the test environment so this was tested manually using following setup: https://github.com/bukka/php-util/tree/92a02d92914821bd194867360d563ed5a462a80f/tests/fpm/status-wrong-active-procs . It allows to load test FPM using wrk which triggers around 15k requests in 30s and then polls the status pages to check if the active process are above the set maximum of 5. This was quickly achievable before the fix (often 6 active processes were visible) but it no longer happens after this fix. The load test also didn't show any visible perf regression.