### PR TITLE
php://temp does not preserve file-position when switched to temporary file

### DIFF
--- a/ext/standard/tests/streams/temp_stream_seek.phpt
+++ b/ext/standard/tests/streams/temp_stream_seek.phpt
@@ -1,0 +1,20 @@
+--TEST--
+BUG: php://temp does not preserve file-pointer once it switches from memory to temporary file
+--FILE--
+<?php
+
+$f = fopen('php://temp/maxmemory:1024', 'r+');
+fwrite($f, str_repeat("1", 738));
+fseek($f, 0, SEEK_SET);
+fwrite($f, str_repeat("2", 512));
+
+fseek($f, 0, SEEK_SET);
+var_dump(fread($f, 16));
+
+fseek($f, 0, SEEK_END);
+var_dump(ftell($f));
+
+?>
+--EXPECT--
+string(16) "2222222222222222"
+int(738)

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -375,10 +375,11 @@ static ssize_t php_stream_temp_write(php_stream *stream, const char *buf, size_t
 		return -1;
 	}
 	if (php_stream_is(ts->innerstream, PHP_STREAM_IS_MEMORY)) {
-		size_t memsize;
-		char *membuf = php_stream_memory_get_buffer(ts->innerstream, &memsize);
-
-		if (memsize + count >= ts->smax) {
+		zend_off_t pos = php_stream_tell(ts->innerstream);
+		
+		if (pos + count >= ts->smax) {
+			size_t memsize;
+			char *membuf = php_stream_memory_get_buffer(ts->innerstream, &memsize);
 			php_stream *file = php_stream_fopen_temporary_file(ts->tmpdir, "php", NULL);
 			if (file == NULL) {
 				php_error_docref(NULL, E_WARNING, "Unable to create temporary file, Check permissions in temporary files directory.");
@@ -388,6 +389,7 @@ static ssize_t php_stream_temp_write(php_stream *stream, const char *buf, size_t
 			php_stream_free_enclosed(ts->innerstream, PHP_STREAM_FREE_CLOSE);
 			ts->innerstream = file;
 			php_stream_encloses(stream, ts->innerstream);
+			php_stream_seek(ts->innerstream, pos, SEEK_SET);
 		}
 	}
 	return php_stream_write(ts->innerstream, buf, count);


### PR DESCRIPTION
This is my first PR for PHP. Please forgive me if I violated some rules that I didn't know so far or understood wrong while reading your guidelines.

I discovered a small flaw in PHP's php://temp stream-wrapper:
The stream is kept in memory until a given amount of data was written to it. Once this limit is reached during `fwrite()` PHP will offload the stream to a temporary file.

PHP detects whether the limit is reached by adding the length to be written to the length of the actual stream. This is right as long as the file-position is at the end of the stream. If the pointer is somewhere else, there might be no need to switch to a temporary file at all. Plus: The file-position is not preserved during the switch so contents will be written to the end of the file regardless of the previous file-position.

I wrote a very small test for this bug that may explain the issue better than my words. I also included a fix for the issue itself.

Thank you in advance!