### PR TITLE
Use strlen(str) instead of sizeof(str)-1 for directly declared strings

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -334,8 +334,8 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 				zval *arg = &OPLINE_OP1_LITERAL(sv);
 				char *fname = FUNCTION_CACHE->funcs[Z_LVAL(ZEND_OP1_LITERAL(fcall))].function_name;
 				size_t flen = FUNCTION_CACHE->funcs[Z_LVAL(ZEND_OP1_LITERAL(fcall))].name_len;
-				if((flen == sizeof("function_exists")-1 && zend_binary_strcasecmp(fname, flen, "function_exists", sizeof("function_exists")-1) == 0) ||
-						  (flen == sizeof("is_callable")-1 && zend_binary_strcasecmp(fname, flen, "is_callable", sizeof("is_callable")-1) == 0)
+				if((flen == strlen("function_exists") && zend_binary_strcasecmp(fname, flen, "function_exists", strlen("function_exists")) == 0) ||
+						  (flen == strlen("is_callable") && zend_binary_strcasecmp(fname, flen, "is_callable", strlen("is_callable")) == 0)
 						  ) {
 					zend_function *function;
 					if((function = zend_hash_find_ptr(EG(function_table), Z_STR_P(arg))) != NULL) {
@@ -345,7 +345,7 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 						LITERAL_BOOL(opline->op1, 1);
 						opline->op1_type = IS_CONST;
 					}
-				} else if(flen == sizeof("constant")-1 && zend_binary_strcasecmp(fname, flen, "constant", sizeof("constant")-1) == 0) {
+				} else if(flen == strlen("constant") && zend_binary_strcasecmp(fname, flen, "constant", strlen("constant")) == 0) {
 					zval c;
 					if (zend_optimizer_get_persistent_constant(Z_STR_P(arg), &c, 1 ELS_CC)) {
 						literal_dtor(arg);
@@ -355,7 +355,7 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 						/* no copy ctor - get already copied it */
 						opline->op1_type = IS_CONST;
 					}
-				} else if(flen == sizeof("extension_loaded")-1 && zend_binary_strcasecmp(fname, flen, "extension_loaded", sizeof("extension_loaded")-1) == 0) {
+				} else if(flen == strlen("extension_loaded") && zend_binary_strcasecmp(fname, flen, "extension_loaded", strlen("extension_loaded")) == 0) {
 					if(zend_hash_exists(&module_registry, Z_STR_P(arg))) {
 						literal_dtor(arg);
 						MAKE_NOP(sv);

--- a/Zend/Optimizer/pass1.c
+++ b/Zend/Optimizer/pass1.c
@@ -131,7 +131,7 @@ void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 				memset(&fake_execute_data, 0, sizeof(zend_execute_data));
 				fake_execute_data.func = (zend_function*)op_array;
 				EG(current_execute_data) = &fake_execute_data;
-				if ((offset = zend_get_constant_str("__COMPILER_HALT_OFFSET__", sizeof("__COMPILER_HALT_OFFSET__") - 1)) != NULL) {
+				if ((offset = zend_get_constant_str("__COMPILER_HALT_OFFSET__", strlen("__COMPILER_HALT_OFFSET__"))) != NULL) {
 
 					literal_dtor(&ZEND_OP2_LITERAL(opline));
 					replace_by_const_or_qm_assign(op_array, opline, offset);
@@ -232,7 +232,7 @@ void zend_optimizer_pass1(zend_op_array *op_array, zend_optimizer_ctx *ctx)
 					}
 
 					if (RESULT_UNUSED(opline) &&
-					    !zend_memnstr(Z_STRVAL(ZEND_OP1_LITERAL(send1_opline)), "::", sizeof("::") - 1, Z_STRVAL(ZEND_OP1_LITERAL(send1_opline)) + Z_STRLEN(ZEND_OP1_LITERAL(send1_opline)))) {
+					    !zend_memnstr(Z_STRVAL(ZEND_OP1_LITERAL(send1_opline)), "::", strlen("::"), Z_STRVAL(ZEND_OP1_LITERAL(send1_opline)) + Z_STRLEN(ZEND_OP1_LITERAL(send1_opline)))) {
 
 						opline->opcode = ZEND_DECLARE_CONST;
 						opline->op1_type = IS_CONST;

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -990,7 +990,7 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	zend_interned_strings_init();
 	zend_startup_builtin_functions();
 	zend_register_standard_constants();
-	zend_register_auto_global(zend_string_init_interned("GLOBALS", sizeof("GLOBALS") - 1, 1), 1, php_auto_globals_create_globals);
+	zend_register_auto_global(zend_string_init_interned("GLOBALS", strlen("GLOBALS"), 1), 1, php_auto_globals_create_globals);
 
 #ifndef ZTS
 	zend_init_rsrc_plist();

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3738,7 +3738,7 @@ try_again:
 			zend_class_entry *ce = Z_OBJCE_P(callable);
 			return zend_string_concat2(
 				ZSTR_VAL(ce->name), ZSTR_LEN(ce->name),
-				"::__invoke", sizeof("::__invoke") - 1);
+				"::__invoke", strlen("::__invoke"));
 		}
 		case IS_REFERENCE:
 			callable = Z_REFVAL_P(callable);
@@ -4832,7 +4832,7 @@ static zend_result get_default_via_ast(zval *default_value_zval, const char *def
 	zend_arena *ast_arena;
 
 	zend_string *code = zend_string_concat3(
-		"<?php ", sizeof("<?php ") - 1, default_value, strlen(default_value), ";", 1);
+		"<?php ", strlen("<?php "), default_value, strlen(default_value), ";", 1);
 
 	ast = zend_compile_string_to_ast(code, &ast_arena, ZSTR_EMPTY_ALLOC());
 	zend_string_release(code);
@@ -4886,16 +4886,16 @@ ZEND_API zend_result zend_get_default_from_internal_arg_info(
 	/* Avoid going through the full AST machinery for some simple and common cases. */
 	size_t default_value_len = strlen(default_value);
 	zend_ulong lval;
-	if (default_value_len == sizeof("null")-1
-			&& !memcmp(default_value, "null", sizeof("null")-1)) {
+	if (default_value_len == strlen("null")
+			&& !memcmp(default_value, "null", strlen("null"))) {
 		ZVAL_NULL(default_value_zval);
 		return SUCCESS;
-	} else if (default_value_len == sizeof("true")-1
-			&& !memcmp(default_value, "true", sizeof("true")-1)) {
+	} else if (default_value_len == strlen("true")
+			&& !memcmp(default_value, "true", strlen("true"))) {
 		ZVAL_TRUE(default_value_zval);
 		return SUCCESS;
-	} else if (default_value_len == sizeof("false")-1
-			&& !memcmp(default_value, "false", sizeof("false")-1)) {
+	} else if (default_value_len == strlen("false")
+			&& !memcmp(default_value, "false", strlen("false"))) {
 		ZVAL_FALSE(default_value_zval);
 		return SUCCESS;
 	} else if (default_value_len >= 2
@@ -4907,8 +4907,8 @@ ZEND_API zend_result zend_get_default_from_internal_arg_info(
 			ZVAL_STR(default_value_zval, str);
 			return SUCCESS;
 		}
-	} else if (default_value_len == sizeof("[]")-1
-			&& !memcmp(default_value, "[]", sizeof("[]")-1)) {
+	} else if (default_value_len == strlen("[]")
+			&& !memcmp(default_value, "[]", strlen("[]"))) {
 		ZVAL_EMPTY_ARRAY(default_value_zval);
 		return SUCCESS;
 	} else if (ZEND_HANDLE_NUMERIC_STR(default_value, default_value_len, lval)) {

--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -1631,7 +1631,7 @@ tail_call:
 			break;
 		}
 		case ZEND_AST_CONSTANT_CLASS:
-			smart_str_appendl(str, "__CLASS__", sizeof("__CLASS__")-1);
+			smart_str_appendl(str, "__CLASS__", strlen("__CLASS__"));
 			break;
 		case ZEND_AST_ZNODE:
 			/* This AST kind is only used for temporary nodes during compilation */

--- a/Zend/zend_attributes_arginfo.h
+++ b/Zend/zend_attributes_arginfo.h
@@ -73,7 +73,7 @@ static zend_class_entry *register_class_Attribute(void)
 
 	zval property_flags_default_value;
 	ZVAL_UNDEF(&property_flags_default_value);
-	zend_string *property_flags_name = zend_string_init("flags", sizeof("flags") - 1, 1);
+	zend_string *property_flags_name = zend_string_init("flags", strlen("flags"), 1);
 	zend_declare_typed_property(class_entry, property_flags_name, &property_flags_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_flags_name);
 
@@ -123,7 +123,7 @@ static zend_class_entry *register_class_SensitiveParameterValue(void)
 
 	zval property_value_default_value;
 	ZVAL_UNDEF(&property_value_default_value);
-	zend_string *property_value_name = zend_string_init("value", sizeof("value") - 1, 1);
+	zend_string *property_value_name = zend_string_init("value", strlen("value"), 1);
 	zend_declare_typed_property(class_entry, property_value_name, &property_value_default_value, ZEND_ACC_PRIVATE|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_value_name);
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -112,8 +112,8 @@ ZEND_FUNCTION(gc_enable)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	key = zend_string_init("zend.enable_gc", sizeof("zend.enable_gc")-1, 0);
-	zend_alter_ini_entry_chars(key, "1", sizeof("1")-1, ZEND_INI_USER, ZEND_INI_STAGE_RUNTIME);
+	key = zend_string_init("zend.enable_gc", strlen("zend.enable_gc"), 0);
+	zend_alter_ini_entry_chars(key, "1", strlen("1"), ZEND_INI_USER, ZEND_INI_STAGE_RUNTIME);
 	zend_string_release_ex(key, 0);
 }
 /* }}} */
@@ -125,8 +125,8 @@ ZEND_FUNCTION(gc_disable)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	key = zend_string_init("zend.enable_gc", sizeof("zend.enable_gc")-1, 0);
-	zend_alter_ini_entry_chars(key, "0", sizeof("0")-1, ZEND_INI_USER, ZEND_INI_STAGE_RUNTIME);
+	key = zend_string_init("zend.enable_gc", strlen("zend.enable_gc"), 0);
+	zend_alter_ini_entry_chars(key, "0", strlen("0"), ZEND_INI_USER, ZEND_INI_STAGE_RUNTIME);
 	zend_string_release_ex(key, 0);
 }
 /* }}} */
@@ -142,10 +142,10 @@ ZEND_FUNCTION(gc_status)
 
 	array_init_size(return_value, 3);
 
-	add_assoc_long_ex(return_value, "runs", sizeof("runs")-1, (long)status.runs);
-	add_assoc_long_ex(return_value, "collected", sizeof("collected")-1, (long)status.collected);
-	add_assoc_long_ex(return_value, "threshold", sizeof("threshold")-1, (long)status.threshold);
-	add_assoc_long_ex(return_value, "roots", sizeof("roots")-1, (long)status.num_roots);
+	add_assoc_long_ex(return_value, "runs", strlen("runs"), (long)status.runs);
+	add_assoc_long_ex(return_value, "collected", strlen("collected"), (long)status.collected);
+	add_assoc_long_ex(return_value, "threshold", strlen("threshold"), (long)status.threshold);
+	add_assoc_long_ex(return_value, "roots", strlen("roots"), (long)status.num_roots);
 }
 /* }}} */
 
@@ -481,7 +481,7 @@ ZEND_FUNCTION(define)
 		Z_PARAM_BOOL(non_cs)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (zend_memnstr(ZSTR_VAL(name), "::", sizeof("::") - 1, ZSTR_VAL(name) + ZSTR_LEN(name))) {
+	if (zend_memnstr(ZSTR_VAL(name), "::", strlen("::"), ZSTR_VAL(name) + ZSTR_LEN(name))) {
 		zend_argument_value_error(1, "cannot be a class constant");
 		RETURN_THROWS();
 	}
@@ -1323,8 +1323,8 @@ ZEND_FUNCTION(get_defined_functions)
 		}
 	} ZEND_HASH_FOREACH_END();
 
-	zend_hash_str_add_new(Z_ARRVAL_P(return_value), "internal", sizeof("internal")-1, &internal);
-	zend_hash_str_add_new(Z_ARRVAL_P(return_value), "user", sizeof("user")-1, &user);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), "internal", strlen("internal"), &internal);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), "user", strlen("user"), &user);
 }
 /* }}} */
 
@@ -1563,7 +1563,7 @@ static void debug_backtrace_get_args(zend_execute_data *call, zval *arg_array) /
 						zend_attribute *attribute = zend_get_parameter_attribute_str(
 							call->func->common.attributes,
 							"sensitiveparameter",
-							sizeof("sensitiveparameter") - 1,
+							strlen("sensitiveparameter"),
 							i
 						);
 
@@ -1595,7 +1595,7 @@ static void debug_backtrace_get_args(zend_execute_data *call, zval *arg_array) /
 						zend_attribute *attribute = zend_get_parameter_attribute_str(
 							call->func->common.attributes,
 							"sensitiveparameter",
-							sizeof("sensitiveparameter") - 1,
+							strlen("sensitiveparameter"),
 							i
 						);
 						bool is_sensitive = attribute != NULL;
@@ -1634,7 +1634,7 @@ static void debug_backtrace_get_args(zend_execute_data *call, zval *arg_array) /
 					zend_attribute *attribute = zend_get_parameter_attribute_str(
 						call->func->common.attributes,
 						"sensitiveparameter",
-						sizeof("sensitiveparameter") - 1,
+						strlen("sensitiveparameter"),
 						MIN(i, call->func->common.num_args)
 					);
 					is_sensitive = attribute != NULL;
@@ -1953,7 +1953,7 @@ ZEND_FUNCTION(get_extension_funcs)
 		module = zend_hash_find_ptr(&module_registry, lcname);
 		zend_string_release_ex(lcname, 0);
 	} else {
-		module = zend_hash_str_find_ptr(&module_registry, "core", sizeof("core") - 1);
+		module = zend_hash_str_find_ptr(&module_registry, "core", strlen("core"));
 	}
 
 	if (!module) {

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -616,7 +616,7 @@ static HashTable *zend_closure_get_debug_info(zend_object *object, int *is_temp)
 			zend_string_release_ex(name, 0);
 			arg_info++;
 		}
-		zend_hash_str_update(debug_info, "parameter", sizeof("parameter")-1, &val);
+		zend_hash_str_update(debug_info, "parameter", strlen("parameter"), &val);
 	}
 
 	return debug_info;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -843,7 +843,7 @@ uint32_t zend_add_member_modifier(uint32_t flags, uint32_t new_flag) /* {{{ */
 ZEND_API zend_string *zend_create_member_string(zend_string *class_name, zend_string *member_name) {
 	return zend_string_concat3(
 		ZSTR_VAL(class_name), ZSTR_LEN(class_name),
-		"::", sizeof("::") - 1,
+		"::", strlen("::"),
 		ZSTR_VAL(member_name), ZSTR_LEN(member_name));
 }
 
@@ -1852,7 +1852,7 @@ zend_ast *zend_negate_num_string(zend_ast *ast) /* {{{ */
 	zval *zv = zend_ast_get_zval(ast);
 	if (Z_TYPE_P(zv) == IS_LONG) {
 		if (Z_LVAL_P(zv) == 0) {
-			ZVAL_NEW_STR(zv, zend_string_init("-0", sizeof("-0")-1, 0));
+			ZVAL_NEW_STR(zv, zend_string_init("-0", strlen("-0"), 0));
 		} else {
 			ZEND_ASSERT(Z_LVAL_P(zv) > 0);
 			Z_LVAL_P(zv) *= -1;
@@ -4033,7 +4033,7 @@ static void zend_compile_assert(znode *result, zend_ast_list *args, zend_string 
 				/* If the original argument was named, add the new argument as named as well,
 				 * as mixing named and positional is not allowed. */
 				zend_ast *name = zend_ast_create_zval_from_str(
-					zend_string_init("description", sizeof("description") - 1, 0));
+					zend_string_init("description", strlen("description"), 0));
 				arg = zend_ast_create(ZEND_AST_NAMED_ARG, name, arg);
 			}
 			zend_ast_list_add((zend_ast *) args, arg);
@@ -6963,9 +6963,9 @@ static void add_stringable_interface(zend_class_entry *ce) {
 		erealloc(ce->interface_names, sizeof(zend_class_name) * ce->num_interfaces);
 	// TODO: Add known interned strings instead?
 	ce->interface_names[ce->num_interfaces - 1].name =
-		zend_string_init("Stringable", sizeof("Stringable") - 1, 0);
+		zend_string_init("Stringable", strlen("Stringable"), 0);
 	ce->interface_names[ce->num_interfaces - 1].lc_name =
-		zend_string_init("stringable", sizeof("stringable") - 1, 0);
+		zend_string_init("stringable", strlen("stringable"), 0);
 }
 
 static zend_string *zend_begin_method_decl(zend_op_array *op_array, zend_string *name, bool has_body) /* {{{ */

--- a/Zend/zend_constants.c
+++ b/Zend/zend_constants.c
@@ -136,9 +136,9 @@ void zend_register_standard_constants(void)
 	REGISTER_MAIN_BOOL_CONSTANT("FALSE", 0, CONST_PERSISTENT);
 	REGISTER_MAIN_NULL_CONSTANT("NULL", CONST_PERSISTENT);
 
-	true_const = zend_hash_str_find_ptr(EG(zend_constants), "TRUE", sizeof("TRUE")-1);
-	false_const = zend_hash_str_find_ptr(EG(zend_constants), "FALSE", sizeof("FALSE")-1);
-	null_const = zend_hash_str_find_ptr(EG(zend_constants), "NULL", sizeof("NULL")-1);
+	true_const = zend_hash_str_find_ptr(EG(zend_constants), "TRUE", strlen("TRUE"));
+	false_const = zend_hash_str_find_ptr(EG(zend_constants), "FALSE", strlen("FALSE"));
+	null_const = zend_hash_str_find_ptr(EG(zend_constants), "NULL", strlen("NULL"));
 }
 
 
@@ -213,8 +213,8 @@ static zend_constant *zend_get_halt_offset_constant(const char *name, size_t nam
 
 	if (!EG(current_execute_data)) {
 		return NULL;
-	} else if (name_len == sizeof("__COMPILER_HALT_OFFSET__")-1 &&
-	          !memcmp(name, "__COMPILER_HALT_OFFSET__", sizeof("__COMPILER_HALT_OFFSET__")-1)) {
+	} else if (name_len == strlen("__COMPILER_HALT_OFFSET__") &&
+	          !memcmp(name, "__COMPILER_HALT_OFFSET__", strlen("__COMPILER_HALT_OFFSET__"))) {
 		const char *cfilename;
 		zend_string *haltname;
 		size_t clen;
@@ -223,7 +223,7 @@ static zend_constant *zend_get_halt_offset_constant(const char *name, size_t nam
 		clen = strlen(cfilename);
 		/* check for __COMPILER_HALT_OFFSET__ */
 		haltname = zend_mangle_property_name(haltoff,
-			sizeof("__COMPILER_HALT_OFFSET__") - 1, cfilename, clen, 0);
+			strlen("__COMPILER_HALT_OFFSET__"), cfilename, clen, 0);
 		c = zend_hash_find_ptr(EG(zend_constants), haltname);
 		zend_string_efree(haltname);
 		return c;

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -175,11 +175,11 @@ void zend_enum_add_interfaces(zend_class_entry *ce)
 	ce->interface_names = erealloc(ce->interface_names, sizeof(zend_class_name) * ce->num_interfaces);
 
 	ce->interface_names[num_interfaces_before].name = zend_string_copy(zend_ce_unit_enum->name);
-	ce->interface_names[num_interfaces_before].lc_name = zend_string_init("unitenum", sizeof("unitenum") - 1, 0);
+	ce->interface_names[num_interfaces_before].lc_name = zend_string_init("unitenum", strlen("unitenum"), 0);
 
 	if (ce->enum_backing_type != IS_UNDEF) {
 		ce->interface_names[num_interfaces_before + 1].name = zend_string_copy(zend_ce_backed_enum->name);
-		ce->interface_names[num_interfaces_before + 1].lc_name = zend_string_init("backedenum", sizeof("backedenum") - 1, 0);	
+		ce->interface_names[num_interfaces_before + 1].lc_name = zend_string_init("backedenum", strlen("backedenum"), 0);	
 	}
 }
 

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -660,7 +660,7 @@ ZEND_METHOD(Exception, __toString)
 	str = ZSTR_EMPTY_ALLOC();
 
 	exception = ZEND_THIS;
-	fname = zend_string_init("gettraceasstring", sizeof("gettraceasstring")-1, 0);
+	fname = zend_string_init("gettraceasstring", strlen("gettraceasstring"), 0);
 
 	while (exception && Z_TYPE_P(exception) == IS_OBJECT && instanceof_function(Z_OBJCE_P(exception), zend_ce_throwable)) {
 		zend_string *prev_str = str;

--- a/Zend/zend_exceptions_arginfo.h
+++ b/Zend/zend_exceptions_arginfo.h
@@ -208,44 +208,44 @@ static zend_class_entry *register_class_Exception(zend_class_entry *class_entry_
 
 	zval property_message_default_value;
 	ZVAL_EMPTY_STRING(&property_message_default_value);
-	zend_string *property_message_name = zend_string_init("message", sizeof("message") - 1, 1);
+	zend_string *property_message_name = zend_string_init("message", strlen("message"), 1);
 	zend_declare_property_ex(class_entry, property_message_name, &property_message_default_value, ZEND_ACC_PROTECTED, NULL);
 	zend_string_release(property_message_name);
 
 	zval property_string_default_value;
 	ZVAL_EMPTY_STRING(&property_string_default_value);
-	zend_string *property_string_name = zend_string_init("string", sizeof("string") - 1, 1);
+	zend_string *property_string_name = zend_string_init("string", strlen("string"), 1);
 	zend_declare_typed_property(class_entry, property_string_name, &property_string_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_string_name);
 
 	zval property_code_default_value;
 	ZVAL_LONG(&property_code_default_value, 0);
-	zend_string *property_code_name = zend_string_init("code", sizeof("code") - 1, 1);
+	zend_string *property_code_name = zend_string_init("code", strlen("code"), 1);
 	zend_declare_property_ex(class_entry, property_code_name, &property_code_default_value, ZEND_ACC_PROTECTED, NULL);
 	zend_string_release(property_code_name);
 
 	zval property_file_default_value;
 	ZVAL_EMPTY_STRING(&property_file_default_value);
-	zend_string *property_file_name = zend_string_init("file", sizeof("file") - 1, 1);
+	zend_string *property_file_name = zend_string_init("file", strlen("file"), 1);
 	zend_declare_typed_property(class_entry, property_file_name, &property_file_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_file_name);
 
 	zval property_line_default_value;
 	ZVAL_LONG(&property_line_default_value, 0);
-	zend_string *property_line_name = zend_string_init("line", sizeof("line") - 1, 1);
+	zend_string *property_line_name = zend_string_init("line", strlen("line"), 1);
 	zend_declare_typed_property(class_entry, property_line_name, &property_line_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_line_name);
 
 	zval property_trace_default_value;
 	ZVAL_EMPTY_ARRAY(&property_trace_default_value);
-	zend_string *property_trace_name = zend_string_init("trace", sizeof("trace") - 1, 1);
+	zend_string *property_trace_name = zend_string_init("trace", strlen("trace"), 1);
 	zend_declare_typed_property(class_entry, property_trace_name, &property_trace_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_trace_name);
 
-	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", sizeof("Throwable")-1, 1);
+	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", strlen("Throwable"), 1);
 	zval property_previous_default_value;
 	ZVAL_NULL(&property_previous_default_value);
-	zend_string *property_previous_name = zend_string_init("previous", sizeof("previous") - 1, 1);
+	zend_string *property_previous_name = zend_string_init("previous", strlen("previous"), 1);
 	zend_declare_typed_property(class_entry, property_previous_name, &property_previous_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previous_class_Throwable, 0, MAY_BE_NULL));
 	zend_string_release(property_previous_name);
 
@@ -272,44 +272,44 @@ static zend_class_entry *register_class_Error(zend_class_entry *class_entry_Thro
 
 	zval property_message_default_value;
 	ZVAL_EMPTY_STRING(&property_message_default_value);
-	zend_string *property_message_name = zend_string_init("message", sizeof("message") - 1, 1);
+	zend_string *property_message_name = zend_string_init("message", strlen("message"), 1);
 	zend_declare_property_ex(class_entry, property_message_name, &property_message_default_value, ZEND_ACC_PROTECTED, NULL);
 	zend_string_release(property_message_name);
 
 	zval property_string_default_value;
 	ZVAL_EMPTY_STRING(&property_string_default_value);
-	zend_string *property_string_name = zend_string_init("string", sizeof("string") - 1, 1);
+	zend_string *property_string_name = zend_string_init("string", strlen("string"), 1);
 	zend_declare_typed_property(class_entry, property_string_name, &property_string_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_string_name);
 
 	zval property_code_default_value;
 	ZVAL_LONG(&property_code_default_value, 0);
-	zend_string *property_code_name = zend_string_init("code", sizeof("code") - 1, 1);
+	zend_string *property_code_name = zend_string_init("code", strlen("code"), 1);
 	zend_declare_property_ex(class_entry, property_code_name, &property_code_default_value, ZEND_ACC_PROTECTED, NULL);
 	zend_string_release(property_code_name);
 
 	zval property_file_default_value;
 	ZVAL_EMPTY_STRING(&property_file_default_value);
-	zend_string *property_file_name = zend_string_init("file", sizeof("file") - 1, 1);
+	zend_string *property_file_name = zend_string_init("file", strlen("file"), 1);
 	zend_declare_typed_property(class_entry, property_file_name, &property_file_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_file_name);
 
 	zval property_line_default_value;
 	ZVAL_UNDEF(&property_line_default_value);
-	zend_string *property_line_name = zend_string_init("line", sizeof("line") - 1, 1);
+	zend_string *property_line_name = zend_string_init("line", strlen("line"), 1);
 	zend_declare_typed_property(class_entry, property_line_name, &property_line_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_line_name);
 
 	zval property_trace_default_value;
 	ZVAL_EMPTY_ARRAY(&property_trace_default_value);
-	zend_string *property_trace_name = zend_string_init("trace", sizeof("trace") - 1, 1);
+	zend_string *property_trace_name = zend_string_init("trace", strlen("trace"), 1);
 	zend_declare_typed_property(class_entry, property_trace_name, &property_trace_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_trace_name);
 
-	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", sizeof("Throwable")-1, 1);
+	zend_string *property_previous_class_Throwable = zend_string_init("Throwable", strlen("Throwable"), 1);
 	zval property_previous_default_value;
 	ZVAL_NULL(&property_previous_default_value);
-	zend_string *property_previous_name = zend_string_init("previous", sizeof("previous") - 1, 1);
+	zend_string *property_previous_name = zend_string_init("previous", strlen("previous"), 1);
 	zend_declare_typed_property(class_entry, property_previous_name, &property_previous_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previous_class_Throwable, 0, MAY_BE_NULL));
 	zend_string_release(property_previous_name);
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -826,7 +826,7 @@ ZEND_COLD void zend_match_unhandled_error(zval *value)
 	if (Z_TYPE_P(value) <= IS_STRING) {
 		smart_str_append_scalar(&msg, value, EG(exception_string_param_max_len));
 	} else {
-		smart_str_appendl(&msg, "of type ", sizeof("of type ")-1);
+		smart_str_appendl(&msg, "of type ", strlen("of type "));
 		smart_str_appends(&msg, zend_zval_type_name(value));
 	}
 
@@ -4273,7 +4273,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 	) {
 		zend_string *mname;
 		size_t cname_length = colon - ZSTR_VAL(function) - 1;
-		size_t mname_length = ZSTR_LEN(function) - cname_length - (sizeof("::") - 1);
+		size_t mname_length = ZSTR_LEN(function) - cname_length - (strlen("::"));
 
 		lcname = zend_string_init(ZSTR_VAL(function), cname_length, 0);
 
@@ -4283,7 +4283,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 			return NULL;
 		}
 
-		mname = zend_string_init(ZSTR_VAL(function) + (cname_length + sizeof("::") - 1), mname_length, 0);
+		mname = zend_string_init(ZSTR_VAL(function) + (cname_length + strlen("::")), mname_length, 0);
 
 		if (called_scope->get_static_method) {
 			fbc = called_scope->get_static_method(called_scope, mname);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -562,7 +562,7 @@ ZEND_API zend_string *get_function_or_method_name(const zend_function *func) /* 
 		return zend_create_member_string(func->common.scope->name, func->common.function_name);
 	}
 
-	return func->common.function_name ? zend_string_copy(func->common.function_name) : zend_string_init("main", sizeof("main") - 1, 0);
+	return func->common.function_name ? zend_string_copy(func->common.function_name) : zend_string_init("main", strlen("main"), 0);
 }
 /* }}} */
 
@@ -1242,7 +1242,7 @@ ZEND_API zend_result zend_eval_stringl(const char *str, size_t str_len, zval *re
 
 	if (retval_ptr) {
 		code_str = zend_string_concat3(
-			"return ", sizeof("return ")-1, str, str_len, ";", sizeof(";")-1);
+			"return ", strlen("return "), str, str_len, ";", strlen(";"));
 	} else {
 		code_str = zend_string_init(str, str_len, 0);
 	}

--- a/Zend/zend_gdb.c
+++ b/Zend/zend_gdb.c
@@ -123,7 +123,7 @@ ZEND_API bool zend_gdb_present(void)
 			buf[n] = 0;
 			s = strstr(buf, "TracerPid:");
 			if (s) {
-				s += sizeof("TracerPid:") - 1;
+				s += strlen("TracerPid:");
 				while (*s == ' ' || *s == '\t') {
 					s++;
 				}

--- a/Zend/zend_highlight.c
+++ b/Zend/zend_highlight.c
@@ -181,7 +181,7 @@ ZEND_API void zend_strip(void)
 		switch (token_type) {
 			case T_WHITESPACE:
 				if (!prev_space) {
-					zend_write(" ", sizeof(" ") - 1);
+					zend_write(" ", strlen(" "));
 					prev_space = 1;
 				}
 				ZEND_FALLTHROUGH;
@@ -196,7 +196,7 @@ ZEND_API void zend_strip(void)
 				if (lex_scan(&token, NULL) != T_WHITESPACE) {
 					zend_write((char*)LANG_SCNG(yy_text), LANG_SCNG(yy_leng));
 				}
-				zend_write("\n", sizeof("\n") - 1);
+				zend_write("\n", strlen("\n"));
 				prev_space = 1;
 				ZVAL_UNDEF(&token);
 				continue;

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -991,7 +991,7 @@ static void ZEND_COLD emit_incompatible_method_error(
 		zend_attribute *return_type_will_change_attribute = zend_get_attribute_str(
 			child->common.attributes,
 			"returntypewillchange",
-			sizeof("returntypewillchange")-1
+			strlen("returntypewillchange")
 		);
 
 		if (!return_type_will_change_attribute) {

--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -294,7 +294,7 @@ static int zend_implement_aggregate(zend_class_entry *interface, zend_class_entr
 
 	memset(funcs_ptr, 0, sizeof(zend_class_iterator_funcs));
 	funcs_ptr->zf_new_iterator = zend_hash_str_find_ptr(
-		&class_type->function_table, "getiterator", sizeof("getiterator") - 1);
+		&class_type->function_table, "getiterator", strlen("getiterator"));
 
 	if (class_type->get_iterator && class_type->get_iterator != zend_user_it_get_new_iterator) {
 		/* get_iterator was explicitly assigned for an internal class. */
@@ -333,15 +333,15 @@ static int zend_implement_iterator(zend_class_entry *interface, zend_class_entry
 
 	memset(funcs_ptr, 0, sizeof(zend_class_iterator_funcs));
 	funcs_ptr->zf_rewind = zend_hash_str_find_ptr(
-		&class_type->function_table, "rewind", sizeof("rewind") - 1);
+		&class_type->function_table, "rewind", strlen("rewind"));
 	funcs_ptr->zf_valid = zend_hash_str_find_ptr(
-		&class_type->function_table, "valid", sizeof("valid") - 1);
+		&class_type->function_table, "valid", strlen("valid"));
 	funcs_ptr->zf_key = zend_hash_str_find_ptr(
-		&class_type->function_table, "key", sizeof("key") - 1);
+		&class_type->function_table, "key", strlen("key"));
 	funcs_ptr->zf_current = zend_hash_str_find_ptr(
-		&class_type->function_table, "current", sizeof("current") - 1);
+		&class_type->function_table, "current", strlen("current"));
 	funcs_ptr->zf_next = zend_hash_str_find_ptr(
-		&class_type->function_table, "next", sizeof("next") - 1);
+		&class_type->function_table, "next", strlen("next"));
 
 	if (class_type->get_iterator && class_type->get_iterator != zend_user_it_get_iterator) {
 		if (!class_type->parent || class_type->parent->get_iterator != class_type->get_iterator) {
@@ -378,13 +378,13 @@ static int zend_implement_arrayaccess(zend_class_entry *interface, zend_class_en
 	class_type->arrayaccess_funcs_ptr = funcs_ptr;
 
 	funcs_ptr->zf_offsetget = zend_hash_str_find_ptr(
-		&class_type->function_table, "offsetget", sizeof("offsetget") - 1);
+		&class_type->function_table, "offsetget", strlen("offsetget"));
 	funcs_ptr->zf_offsetexists = zend_hash_str_find_ptr(
-		&class_type->function_table, "offsetexists", sizeof("offsetexists") - 1);
+		&class_type->function_table, "offsetexists", strlen("offsetexists"));
 	funcs_ptr->zf_offsetset = zend_hash_str_find_ptr(
-		&class_type->function_table, "offsetset", sizeof("offsetset") - 1);
+		&class_type->function_table, "offsetset", strlen("offsetset"));
 	funcs_ptr->zf_offsetunset = zend_hash_str_find_ptr(
-		&class_type->function_table, "offsetunset", sizeof("offsetunset") - 1);
+		&class_type->function_table, "offsetunset", strlen("offsetunset"));
 
 	return SUCCESS;
 }

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1204,12 +1204,12 @@ inline_function:
 		function returns_ref backup_doc_comment '(' parameter_list ')' lexical_vars return_type
 		backup_fn_flags '{' inner_statement_list '}' backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_CLOSURE, $2 | $13, $1, $3,
-				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0),
+				  zend_string_init("{closure}", strlen("{closure}"), 0),
 				  $5, $7, $11, $8, NULL); CG(extra_fn_flags) = $9; }
 	|	fn returns_ref backup_doc_comment '(' parameter_list ')' return_type
 		T_DOUBLE_ARROW backup_fn_flags backup_lex_pos expr backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_ARROW_FUNC, $2 | $12, $1, $3,
-				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0), $5, NULL,
+				  zend_string_init("{closure}", strlen("{closure}"), 0), $5, NULL,
 				  zend_ast_create(ZEND_AST_RETURN, $11), $7, NULL);
 				  ((zend_ast_decl *) $$)->lex_pos = $10;
 				  CG(extra_fn_flags) = $9; }
@@ -1568,7 +1568,7 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 			if (yyres) {
 				yystpcpy(yyres, "end of file");
 			}
-			return sizeof("end of file")-1;
+			return strlen("end of file");
 		}
 
 		/* Prevent the backslash getting doubled in the output (eugh) */
@@ -1576,7 +1576,7 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 			if (yyres) {
 				yystpcpy(yyres, "token \"\\\"");
 			}
-			return sizeof("token \"\\\"")-1;
+			return strlen("token \"\\\"");
 		}
 
 		/* We used "amp" as a dummy label to avoid a duplicate token literal warning. */
@@ -1584,7 +1584,7 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 			if (yyres) {
 				yystpcpy(yyres, "token \"&\"");
 			}
-			return sizeof("token \"&\"")-1;
+			return strlen("token \"&\"");
 		}
 
 		/* Avoid unreadable """ */
@@ -1593,7 +1593,7 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 			if (yyres) {
 				yystpcpy(yyres, "double-quote mark");
 			}
-			return sizeof("double-quote mark")-1;
+			return strlen("double-quote mark");
 		}
 
 		/* Strip off the outer quote marks */
@@ -1610,7 +1610,7 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 				snprintf(buffer, sizeof(buffer), "token \"%.*s\"", (int)toktype_len-2, toktype+1);
 				yystpcpy(yyres, buffer);
 			}
-			return toktype_len + sizeof("token ")-1;
+			return toktype_len + strlen("token ");
 		}
 
 		/* Fetch the content of the last seen token from global lexer state */
@@ -1624,7 +1624,7 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 				snprintf(buffer, sizeof(buffer), "character 0x%02hhX", *tokcontent);
 				yystpcpy(yyres, buffer);
 			}
-			return sizeof("character 0x00")-1;
+			return strlen("character 0x00");
 		}
 
 		/* Truncate at line end to avoid messing up log formats */
@@ -1637,11 +1637,11 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 		if (tokcontent_len > 0 && strcmp(yystr, "\"quoted string\"") == 0) {
 			if (*tokcontent == '"') {
 				toktype = "double-quoted string";
-				toktype_len = sizeof("double-quoted string")-1;
+				toktype_len = strlen("double-quoted string");
 			}
 			else if (*tokcontent == '\'') {
 				toktype = "single-quoted string";
-				toktype_len = sizeof("single-quoted string")-1;
+				toktype_len = strlen("single-quoted string");
 			}
 		}
 
@@ -1655,19 +1655,19 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 		}
 
 		/* Truncate to 30 characters and add a ... */
-		if (tokcontent_len > 30 + sizeof("...")-1) {
+		if (tokcontent_len > 30 + strlen("...")) {
 			if (yyres) {
 				snprintf(buffer, sizeof(buffer), "%.*s \"%.*s...\"", (int)toktype_len, toktype, 30, tokcontent);
 				yystpcpy(yyres, buffer);
 			}
-			return toktype_len + 30 + sizeof(" \"...\"")-1;
+			return toktype_len + 30 + strlen(" \"...\"");
 		}
 
 		if (yyres) {
 			snprintf(buffer, sizeof(buffer), "%.*s \"%.*s\"", (int)toktype_len, toktype, (int)tokcontent_len, tokcontent);
 			yystpcpy(yyres, buffer);
 		}
-		return toktype_len + tokcontent_len + sizeof(" \"\"")-1;
+		return toktype_len + tokcontent_len + strlen(" \"\"");
 	}
 
 	/* One of the expected tokens */
@@ -1677,7 +1677,7 @@ static YYSIZE_T zend_yytnamerr(char *yyres, const char *yystr)
 		if (yyres) {
 			yystpcpy(yyres, "\"\\\"");
 		}
-		return sizeof("\"\\\"")-1;
+		return strlen("\"\\\"");
 	}
 
 	/* Strip off the outer quote marks */

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -413,12 +413,12 @@ static const zend_encoding* zend_multibyte_detect_unicode(void)
 		/* check if the NULL byte is after the __HALT_COMPILER(); */
 		pos2 = LANG_SCNG(script_org);
 
-		while ((size_t)(pos1 - pos2) >= sizeof("__HALT_COMPILER();")-1) {
+		while ((size_t)(pos1 - pos2) >= strlen("__HALT_COMPILER();")) {
 			pos2 = memchr(pos2, '_', pos1 - pos2);
 			if (!pos2) break;
 			pos2++;
-			if (strncasecmp((char*)pos2, "_HALT_COMPILER", sizeof("_HALT_COMPILER")-1) == 0) {
-				pos2 += sizeof("_HALT_COMPILER")-1;
+			if (strncasecmp((char*)pos2, "_HALT_COMPILER", strlen("_HALT_COMPILER")) == 0) {
+				pos2 += strlen("_HALT_COMPILER");
 				while (*pos2 == ' '  ||
 					   *pos2 == '\t' ||
 					   *pos2 == '\r' ||
@@ -2361,7 +2361,7 @@ inline_char_handler:
 }
 
 <ST_IN_SCRIPTING>"namespace"("\\"{LABEL})+ {
-	RETURN_TOKEN_WITH_STR(T_NAME_RELATIVE, sizeof("namespace\\") - 1);
+	RETURN_TOKEN_WITH_STR(T_NAME_RELATIVE, strlen("namespace\\"));
 }
 
 <ST_IN_SCRIPTING>{LABEL}("\\"{LABEL})+ {

--- a/Zend/zend_multibyte.c
+++ b/Zend/zend_multibyte.c
@@ -114,7 +114,7 @@ ZEND_API zend_result zend_multibyte_set_functions(const zend_multibyte_functions
 	 * populated, we need to reinitialize script_encoding here.
 	 */
 	{
-		const char *value = zend_ini_string("zend.script_encoding", sizeof("zend.script_encoding") - 1, 0);
+		const char *value = zend_ini_string("zend.script_encoding", strlen("zend.script_encoding"), 0);
 		zend_multibyte_set_script_encoding_by_string(value, strlen(value));
 	}
 	return SUCCESS;

--- a/Zend/zend_smart_str.c
+++ b/Zend/zend_smart_str.c
@@ -186,7 +186,7 @@ ZEND_API void ZEND_FASTCALL smart_str_append_escaped_truncated(smart_str *str, z
 	smart_str_append_escaped(str, ZSTR_VAL(value), MIN(length, ZSTR_LEN(value)));
 
 	if (ZSTR_LEN(value) > length) {
-		smart_str_appendl(str, "...", sizeof("...")-1);
+		smart_str_appendl(str, "...", strlen("..."));
 	}
 }
 
@@ -196,7 +196,7 @@ ZEND_API void ZEND_FASTCALL smart_str_append_scalar(smart_str *dest, zval *value
 	switch (Z_TYPE_P(value)) {
 		case IS_UNDEF:
 		case IS_NULL:
-			smart_str_appendl(dest, "NULL", sizeof("NULL")-1);
+			smart_str_appendl(dest, "NULL", strlen("NULL"));
 		break;
 
 		case IS_TRUE:

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -99,7 +99,7 @@ ZEND_API void zend_interned_strings_init(void)
 	zend_string_init_existing_interned = zend_string_init_existing_interned_permanent;
 
 	/* interned empty string */
-	str = zend_string_alloc(sizeof("")-1, 1);
+	str = zend_string_alloc(strlen(""), 1);
 	ZSTR_VAL(str)[0] = '\000';
 	zend_empty_string = zend_new_interned_string_permanent(str);
 

--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -1671,8 +1671,8 @@ CWD_API FILE *virtual_popen(const char *command, const char *type) /* {{{ */
 	dir = CWDG(cwd).cwd;
 
 	ptr = command_line = (char *) emalloc(command_length + sizeof("cd '' ; ") + dir_length + extra+1+1);
-	memcpy(ptr, "cd ", sizeof("cd ")-1);
-	ptr += sizeof("cd ")-1;
+	memcpy(ptr, "cd ", strlen("cd "));
+	ptr += strlen("cd ");
 
 	if (CWDG(cwd).cwd_length == 0) {
 		*ptr++ = DEFAULT_SLASH;

--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -633,7 +633,7 @@ PHP_FUNCTION(bcscale)
 			RETURN_THROWS();
 		}
 
-		zend_string *ini_name = zend_string_init("bcmath.scale", sizeof("bcmath.scale") - 1, 0);
+		zend_string *ini_name = zend_string_init("bcmath.scale", strlen("bcmath.scale"), 0);
 		zend_string *new_scale_str = zend_long_to_str(new_scale);
 		zend_alter_ini_entry(ini_name, new_scale_str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release(new_scale_str);

--- a/ext/bz2/bz2_filter.c
+++ b/ext/bz2/bz2_filter.c
@@ -337,12 +337,12 @@ static php_stream_filter *php_bz2_filter_create(const char *filtername, zval *fi
 			zval *tmpzval = NULL;
 
 			if (Z_TYPE_P(filterparams) == IS_ARRAY || Z_TYPE_P(filterparams) == IS_OBJECT) {
-				if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "concatenated", sizeof("concatenated")-1))) {
+				if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "concatenated", strlen("concatenated")))) {
 					data->expect_concatenated = zend_is_true(tmpzval);
 					tmpzval = NULL;
 				}
 
-				tmpzval = zend_hash_str_find(HASH_OF(filterparams), "small", sizeof("small")-1);
+				tmpzval = zend_hash_str_find(HASH_OF(filterparams), "small", strlen("small"));
 			} else {
 				tmpzval = filterparams;
 			}
@@ -362,7 +362,7 @@ static php_stream_filter *php_bz2_filter_create(const char *filtername, zval *fi
 			zval *tmpzval;
 
 			if (Z_TYPE_P(filterparams) == IS_ARRAY || Z_TYPE_P(filterparams) == IS_OBJECT) {
-				if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "blocks", sizeof("blocks")-1))) {
+				if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "blocks", strlen("blocks")))) {
 					/* How much memory to allocate (1 - 9) x 100kb */
 					zend_long blocks = zval_get_long(tmpzval);
 					if (blocks < 1 || blocks > 9) {
@@ -372,7 +372,7 @@ static php_stream_filter *php_bz2_filter_create(const char *filtername, zval *fi
 					}
 				}
 
-				if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "work", sizeof("work")-1))) {
+				if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "work", strlen("work")))) {
 					/* Work Factor (0 - 250) */
 					zend_long work = zval_get_long(tmpzval);
 					if (work < 0 || work > 250) {

--- a/ext/com_dotnet/com_com.c
+++ b/ext/com_dotnet/com_com.c
@@ -77,28 +77,28 @@ PHP_METHOD(com, __construct)
 		/* decode the data from the array */
 
 		if (NULL != (tmp = zend_hash_str_find(server_params,
-				"Server", sizeof("Server")-1))) {
+				"Server", strlen("Server")))) {
 			server_name = zval_get_string(tmp);
 			ctx = CLSCTX_REMOTE_SERVER;
 		}
 
 		if (NULL != (tmp = zend_hash_str_find(server_params,
-				"Username", sizeof("Username")-1))) {
+				"Username", strlen("Username")))) {
 			user_name = zval_get_string(tmp);
 		}
 
 		if (NULL != (tmp = zend_hash_str_find(server_params,
-				"Password", sizeof("Password")-1))) {
+				"Password", strlen("Password")))) {
 			password = zval_get_string(tmp);
 		}
 
 		if (NULL != (tmp = zend_hash_str_find(server_params,
-				"Domain", sizeof("Domain")-1))) {
+				"Domain", strlen("Domain")))) {
 			domain_name = zval_get_string(tmp);
 		}
 
 		if (NULL != (tmp = zend_hash_str_find(server_params,
-				"Flags", sizeof("Flags")-1))) {
+				"Flags", strlen("Flags")))) {
 			ctx = (CLSCTX)zval_get_long(tmp);
 		}
 	}

--- a/ext/curl/config.m4
+++ b/ext/curl/config.m4
@@ -39,11 +39,11 @@ int main(int argc, char *argv[])
     const char *ptr = data->ssl_version;
 
     while(*ptr == ' ') ++ptr;
-    if (strncasecmp(ptr, "OpenSSL/1.1", sizeof("OpenSSL/1.1")-1) == 0) {
+    if (strncasecmp(ptr, "OpenSSL/1.1", strlen("OpenSSL/1.1")) == 0) {
       /* New OpenSSL version */
       return 3;
     }
-    if (strncasecmp(ptr, "OpenSSL", sizeof("OpenSSL")-1) == 0) {
+    if (strncasecmp(ptr, "OpenSSL", strlen("OpenSSL")) == 0) {
       /* Old OpenSSL version */
       return 0;
     }

--- a/ext/curl/curl_file.c
+++ b/ext/curl/curl_file.c
@@ -38,14 +38,14 @@ static void curlfile_ctor(INTERNAL_FUNCTION_PARAMETERS)
 		Z_PARAM_STR_OR_NULL(postname)
 	ZEND_PARSE_PARAMETERS_END();
 
-	zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "name", sizeof("name")-1, fname);
+	zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "name", strlen("name"), fname);
 
 	if (mime) {
-		zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "mime", sizeof("mime")-1, mime);
+		zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "mime", strlen("mime"), mime);
 	}
 
 	if (postname) {
-		zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "postname", sizeof("postname")-1, postname);
+		zend_update_property_str(curl_CURLFile_class, Z_OBJ_P(cf), "postname", strlen("postname"), postname);
 	}
 }
 
@@ -88,35 +88,35 @@ static void curlfile_set_property(char *name, size_t name_len, INTERNAL_FUNCTION
 /* {{{ Get file name */
 ZEND_METHOD(CURLFile, getFilename)
 {
-	curlfile_get_property("name", sizeof("name")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+	curlfile_get_property("name", strlen("name"), INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
 /* {{{ Get MIME type */
 ZEND_METHOD(CURLFile, getMimeType)
 {
-	curlfile_get_property("mime", sizeof("mime")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+	curlfile_get_property("mime", strlen("mime"), INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
 /* {{{ Get file name for POST */
 ZEND_METHOD(CURLFile, getPostFilename)
 {
-	curlfile_get_property("postname", sizeof("postname")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+	curlfile_get_property("postname", strlen("postname"), INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
 /* {{{ Set MIME type */
 ZEND_METHOD(CURLFile, setMimeType)
 {
-	curlfile_set_property("mime", sizeof("mime")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+	curlfile_set_property("mime", strlen("mime"), INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
 /* {{{ Set file name for POST */
 ZEND_METHOD(CURLFile, setPostFilename)
 {
-	curlfile_set_property("postname", sizeof("postname")-1, INTERNAL_FUNCTION_PARAM_PASSTHRU);
+	curlfile_set_property("postname", strlen("postname"), INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
@@ -134,12 +134,12 @@ ZEND_METHOD(CURLStringFile, __construct)
 		Z_PARAM_STR(mime)
 	ZEND_PARSE_PARAMETERS_END();
 
-	zend_update_property_str(curl_CURLStringFile_class, Z_OBJ_P(object), "data", sizeof("data") - 1, data);
-	zend_update_property_str(curl_CURLStringFile_class, Z_OBJ_P(object), "postname", sizeof("postname")-1, postname);
+	zend_update_property_str(curl_CURLStringFile_class, Z_OBJ_P(object), "data", strlen("data"), data);
+	zend_update_property_str(curl_CURLStringFile_class, Z_OBJ_P(object), "postname", strlen("postname"), postname);
 	if (mime) {
-		zend_update_property_str(curl_CURLStringFile_class, Z_OBJ_P(object), "mime", sizeof("mime")-1, mime);
+		zend_update_property_str(curl_CURLStringFile_class, Z_OBJ_P(object), "mime", strlen("mime"), mime);
 	} else {
-		zend_update_property_string(curl_CURLStringFile_class, Z_OBJ_P(object), "mime", sizeof("mime")-1, "application/octet-stream");
+		zend_update_property_string(curl_CURLStringFile_class, Z_OBJ_P(object), "mime", strlen("mime"), "application/octet-stream");
 	}
 }
 

--- a/ext/curl/curl_file_arginfo.h
+++ b/ext/curl/curl_file_arginfo.h
@@ -64,19 +64,19 @@ static zend_class_entry *register_class_CURLFile(void)
 
 	zval property_name_default_value;
 	ZVAL_EMPTY_STRING(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
 	zval property_mime_default_value;
 	ZVAL_EMPTY_STRING(&property_mime_default_value);
-	zend_string *property_mime_name = zend_string_init("mime", sizeof("mime") - 1, 1);
+	zend_string *property_mime_name = zend_string_init("mime", strlen("mime"), 1);
 	zend_declare_typed_property(class_entry, property_mime_name, &property_mime_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_mime_name);
 
 	zval property_postname_default_value;
 	ZVAL_EMPTY_STRING(&property_postname_default_value);
-	zend_string *property_postname_name = zend_string_init("postname", sizeof("postname") - 1, 1);
+	zend_string *property_postname_name = zend_string_init("postname", strlen("postname"), 1);
 	zend_declare_typed_property(class_entry, property_postname_name, &property_postname_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_postname_name);
 
@@ -92,19 +92,19 @@ static zend_class_entry *register_class_CURLStringFile(void)
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
 
 	zval property_postname_default_value;
 	ZVAL_UNDEF(&property_postname_default_value);
-	zend_string *property_postname_name = zend_string_init("postname", sizeof("postname") - 1, 1);
+	zend_string *property_postname_name = zend_string_init("postname", strlen("postname"), 1);
 	zend_declare_typed_property(class_entry, property_postname_name, &property_postname_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_postname_name);
 
 	zval property_mime_default_value;
 	ZVAL_UNDEF(&property_mime_default_value);
-	zend_string *property_mime_name = zend_string_init("mime", sizeof("mime") - 1, 1);
+	zend_string *property_mime_name = zend_string_init("mime", strlen("mime"), 1);
 	zend_declare_typed_property(class_entry, property_mime_name, &property_mime_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_mime_name);
 

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -117,11 +117,11 @@ static zend_result php_curl_option_url(php_curl *ch, const char *url, const size
 	}
 
 #if LIBCURL_VERSION_NUM > 0x073800 && defined(PHP_WIN32)
-	if (len > sizeof("file://") - 1 && '/' != url[sizeof("file://") - 1] && !strncmp("file://", url, sizeof("file://") - 1) && len < MAXPATHLEN - 2) {
+	if (len > strlen("file://") && '/' != url[strlen("file://")] && !strncmp("file://", url, strlen("file://")) && len < MAXPATHLEN - 2) {
 		char _tmp[MAXPATHLEN] = {0};
 
-		memmove(_tmp, "file:///", sizeof("file:///") - 1);
-		memmove(_tmp + sizeof("file:///") - 1, url + sizeof("file://") - 1, len - sizeof("file://") + 1);
+		memmove(_tmp, "file:///", strlen("file:///"));
+		memmove(_tmp + strlen("file:///"), url + strlen("file://"), len - sizeof("file://") + 1);
 
 		return php_curl_option_str(ch, CURLOPT_URL, _tmp, len + 1);
 	}
@@ -2088,7 +2088,7 @@ static inline zend_result build_mime_structure_from_hash(php_curl *ch, zval *zpo
 			curl_seek_callback seekfunc = seek_cb;
 #endif
 
-			prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "name", sizeof("name")-1, 0, &rv);
+			prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "name", strlen("name"), 0, &rv);
 			ZVAL_DEREF(prop);
 			if (Z_TYPE_P(prop) != IS_STRING) {
 				php_error_docref(NULL, E_WARNING, "Invalid filename for key %s", ZSTR_VAL(string_key));
@@ -2099,12 +2099,12 @@ static inline zend_result build_mime_structure_from_hash(php_curl *ch, zval *zpo
 					return 1;
 				}
 
-				prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "mime", sizeof("mime")-1, 0, &rv);
+				prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "mime", strlen("mime"), 0, &rv);
 				ZVAL_DEREF(prop);
 				if (Z_TYPE_P(prop) == IS_STRING && Z_STRLEN_P(prop) > 0) {
 					type = Z_STRVAL_P(prop);
 				}
-				prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "postname", sizeof("postname")-1, 0, &rv);
+				prop = zend_read_property(curl_CURLFile_class, Z_OBJ_P(current), "postname", strlen("postname"), 0, &rv);
 				ZVAL_DEREF(prop);
 				if (Z_TYPE_P(prop) == IS_STRING && Z_STRLEN_P(prop) > 0) {
 					filename = Z_STRVAL_P(prop);
@@ -2162,7 +2162,7 @@ static inline zend_result build_mime_structure_from_hash(php_curl *ch, zval *zpo
 			zval *prop, rv;
 			char *type = NULL, *filename = NULL;
 
-			prop = zend_read_property(curl_CURLStringFile_class, Z_OBJ_P(current), "postname", sizeof("postname")-1, 0, &rv);
+			prop = zend_read_property(curl_CURLStringFile_class, Z_OBJ_P(current), "postname", strlen("postname"), 0, &rv);
 			if (EG(exception)) {
 				zend_string_release_ex(string_key, 0);
 				return FAILURE;
@@ -2172,7 +2172,7 @@ static inline zend_result build_mime_structure_from_hash(php_curl *ch, zval *zpo
 
 			filename = Z_STRVAL_P(prop);
 
-			prop = zend_read_property(curl_CURLStringFile_class, Z_OBJ_P(current), "mime", sizeof("mime")-1, 0, &rv);
+			prop = zend_read_property(curl_CURLStringFile_class, Z_OBJ_P(current), "mime", strlen("mime"), 0, &rv);
 			if (EG(exception)) {
 				zend_string_release_ex(string_key, 0);
 				return FAILURE;
@@ -2182,7 +2182,7 @@ static inline zend_result build_mime_structure_from_hash(php_curl *ch, zval *zpo
 
 			type = Z_STRVAL_P(prop);
 
-			prop = zend_read_property(curl_CURLStringFile_class, Z_OBJ_P(current), "data", sizeof("data")-1, 0, &rv);
+			prop = zend_read_property(curl_CURLStringFile_class, Z_OBJ_P(current), "data", strlen("data"), 0, &rv);
 			if (EG(exception)) {
 				zend_string_release_ex(string_key, 0);
 				return FAILURE;

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1811,20 +1811,20 @@ static HashTable *date_object_get_properties_for(zend_object *object, zend_prop_
 	}
 
 	/* first we add the date and time in ISO format */
-	ZVAL_STR(&zv, date_format("Y-m-d H:i:s.u", sizeof("Y-m-d H:i:s.u")-1, dateobj->time, 1));
-	zend_hash_str_update(props, "date", sizeof("date")-1, &zv);
+	ZVAL_STR(&zv, date_format("Y-m-d H:i:s.u", strlen("Y-m-d H:i:s.u"), dateobj->time, 1));
+	zend_hash_str_update(props, "date", strlen("date"), &zv);
 
 	/* then we add the timezone name (or similar) */
 	if (dateobj->time->is_localtime) {
 		ZVAL_LONG(&zv, dateobj->time->zone_type);
-		zend_hash_str_update(props, "timezone_type", sizeof("timezone_type")-1, &zv);
+		zend_hash_str_update(props, "timezone_type", strlen("timezone_type"), &zv);
 
 		switch (dateobj->time->zone_type) {
 			case TIMELIB_ZONETYPE_ID:
 				ZVAL_STRING(&zv, dateobj->time->tz_info->name);
 				break;
 			case TIMELIB_ZONETYPE_OFFSET: {
-				zend_string *tmpstr = zend_string_alloc(sizeof("UTC+05:00")-1, 0);
+				zend_string *tmpstr = zend_string_alloc(strlen("UTC+05:00"), 0);
 				int utc_offset = dateobj->time->z;
 
 				ZSTR_LEN(tmpstr) = snprintf(ZSTR_VAL(tmpstr), sizeof("+05:00"), "%c%02d:%02d",
@@ -1839,7 +1839,7 @@ static HashTable *date_object_get_properties_for(zend_object *object, zend_prop_
 				ZVAL_STRING(&zv, dateobj->time->tz_abbr);
 				break;
 		}
-		zend_hash_str_update(props, "timezone", sizeof("timezone")-1, &zv);
+		zend_hash_str_update(props, "timezone", strlen("timezone"), &zv);
 	}
 
 	return props;
@@ -1922,7 +1922,7 @@ static void php_timezone_to_string(php_timezone_obj *tzobj, zval *zv)
 			ZVAL_STRING(zv, tzobj->tzi.tz->name);
 			break;
 		case TIMELIB_ZONETYPE_OFFSET: {
-			zend_string *tmpstr = zend_string_alloc(sizeof("UTC+05:00")-1, 0);
+			zend_string *tmpstr = zend_string_alloc(strlen("UTC+05:00"), 0);
 			timelib_sll utc_offset = tzobj->tzi.utc_offset;
 
 			ZSTR_LEN(tmpstr) = snprintf(ZSTR_VAL(tmpstr), sizeof("+05:00"), "%c%02d:%02d",
@@ -1963,10 +1963,10 @@ static HashTable *date_object_get_properties_for_timezone(zend_object *object, z
 	}
 
 	ZVAL_LONG(&zv, tzobj->type);
-	zend_hash_str_update(props, "timezone_type", sizeof("timezone_type")-1, &zv);
+	zend_hash_str_update(props, "timezone_type", strlen("timezone_type"), &zv);
 
 	php_timezone_to_string(tzobj, &zv);
-	zend_hash_str_update(props, "timezone", sizeof("timezone")-1, &zv);
+	zend_hash_str_update(props, "timezone", strlen("timezone"), &zv);
 
 	return props;
 } /* }}} */
@@ -1984,10 +1984,10 @@ static HashTable *date_object_get_debug_info_timezone(zend_object *object, int *
 	ht = zend_array_dup(props);
 
 	ZVAL_LONG(&zv, tzobj->type);
-	zend_hash_str_update(ht, "timezone_type", sizeof("timezone_type")-1, &zv);
+	zend_hash_str_update(ht, "timezone_type", strlen("timezone_type"), &zv);
 
 	php_timezone_to_string(tzobj, &zv);
-	zend_hash_str_update(ht, "timezone", sizeof("timezone")-1, &zv);
+	zend_hash_str_update(ht, "timezone", strlen("timezone"), &zv);
 
 	return ht;
 } /* }}} */
@@ -2048,7 +2048,7 @@ static HashTable *date_object_get_properties_interval(zend_object *object) /* {{
 	PHP_DATE_INTERVAL_ADD_PROPERTY("i", i);
 	PHP_DATE_INTERVAL_ADD_PROPERTY("s", s);
 	ZVAL_DOUBLE(&zv, (double)intervalobj->diff->us / 1000000.0);
-	zend_hash_str_update(props, "f", sizeof("f") - 1, &zv);
+	zend_hash_str_update(props, "f", strlen("f"), &zv);
 	PHP_DATE_INTERVAL_ADD_PROPERTY("weekday", weekday);
 	PHP_DATE_INTERVAL_ADD_PROPERTY("weekday_behavior", weekday_behavior);
 	PHP_DATE_INTERVAL_ADD_PROPERTY("first_last_day_of", first_last_day_of);
@@ -2057,7 +2057,7 @@ static HashTable *date_object_get_properties_interval(zend_object *object) /* {{
 		PHP_DATE_INTERVAL_ADD_PROPERTY("days", days);
 	} else {
 		ZVAL_FALSE(&zv);
-		zend_hash_str_update(props, "days", sizeof("days")-1, &zv);
+		zend_hash_str_update(props, "days", strlen("days"), &zv);
 	}
 	PHP_DATE_INTERVAL_ADD_PROPERTY("special_type", special.type);
 	PHP_DATE_INTERVAL_ADD_PROPERTY("special_amount", special.amount);
@@ -2214,7 +2214,7 @@ PHPAPI bool php_date_initialize(php_date_obj *dateobj, const char *time_str, siz
 	} else {
 		if (time_str_len == 0) {
 			time_str = "now";
-			time_str_len = sizeof("now") - 1;
+			time_str_len = strlen("now");
 		}
 		dateobj->time = timelib_strtotime(time_str, time_str_len, &err, DATE_TIMEZONEDB, php_date_parse_tzfile_wrapper);
 	}
@@ -2278,8 +2278,8 @@ PHPAPI bool php_date_initialize(php_date_obj *dateobj, const char *time_str, siz
 	php_date_set_time_fraction(now, usec);
 
 	if (!format
-	 && time_str_len == sizeof("now") - 1
-	 && memcmp(time_str, "now", sizeof("now") - 1) == 0) {
+	 && time_str_len == strlen("now")
+	 && memcmp(time_str, "now", strlen("now")) == 0) {
 		timelib_time_dtor(dateobj->time);
 		dateobj->time = now;
 		return 1;
@@ -2505,17 +2505,17 @@ static bool php_date_initialize_from_hash(php_date_obj **dateobj, HashTable *myh
 	zval              tmp_obj;
 	timelib_tzinfo   *tzi;
 
-	z_date = zend_hash_str_find(myht, "date", sizeof("date")-1);
+	z_date = zend_hash_str_find(myht, "date", strlen("date"));
 	if (!z_date || Z_TYPE_P(z_date) != IS_STRING) {
 		return false;
 	}
 
-	z_timezone_type = zend_hash_str_find(myht, "timezone_type", sizeof("timezone_type")-1);
+	z_timezone_type = zend_hash_str_find(myht, "timezone_type", strlen("timezone_type"));
 	if (!z_timezone_type || Z_TYPE_P(z_timezone_type) != IS_LONG) {
 		return false;
 	}
 
-	z_timezone = zend_hash_str_find(myht, "timezone", sizeof("timezone")-1);
+	z_timezone = zend_hash_str_find(myht, "timezone", strlen("timezone"));
 	if (!z_timezone || Z_TYPE_P(z_timezone) != IS_STRING) {
 		return false;
 	}
@@ -3454,13 +3454,13 @@ static zend_result php_date_timezone_initialize_from_hash(zval **return_value, p
 {
 	zval            *z_timezone_type;
 
-	if ((z_timezone_type = zend_hash_str_find(myht, "timezone_type", sizeof("timezone_type") - 1)) == NULL) {
+	if ((z_timezone_type = zend_hash_str_find(myht, "timezone_type", strlen("timezone_type"))) == NULL) {
 		return FAILURE;
 	}
 
 	zval *z_timezone;
 
-	if ((z_timezone = zend_hash_str_find(myht, "timezone", sizeof("timezone") - 1)) == NULL) {
+	if ((z_timezone = zend_hash_str_find(myht, "timezone", strlen("timezone"))) == NULL) {
 		return FAILURE;
 	}
 
@@ -3957,7 +3957,7 @@ static void php_date_interval_initialize_from_hash(zval **return_value, php_inte
 
 #define PHP_DATE_INTERVAL_READ_PROPERTY_DAYS(member) \
 	do { \
-		zval *z_arg = zend_hash_str_find(myht, "days", sizeof("days") - 1); \
+		zval *z_arg = zend_hash_str_find(myht, "days", strlen("days")); \
 		if (z_arg && Z_TYPE_P(z_arg) == IS_FALSE) { \
 			(*intobj)->diff->member = -99999; \
 		} else if (z_arg && Z_TYPE_P(z_arg) <= IS_STRING) { \
@@ -3986,7 +3986,7 @@ static void php_date_interval_initialize_from_hash(zval **return_value, php_inte
 	PHP_DATE_INTERVAL_READ_PROPERTY("i", i, timelib_sll, -1)
 	PHP_DATE_INTERVAL_READ_PROPERTY("s", s, timelib_sll, -1)
 	{
-		zval *z_arg = zend_hash_str_find(myht, "f", sizeof("f") - 1);
+		zval *z_arg = zend_hash_str_find(myht, "f", strlen("f"));
 		if (z_arg) {
 			(*intobj)->diff->us = zend_dval_to_lval(zval_get_double(z_arg) * 1000000.0);
 		}
@@ -4001,7 +4001,7 @@ static void php_date_interval_initialize_from_hash(zval **return_value, php_inte
 	PHP_DATE_INTERVAL_READ_PROPERTY("have_weekday_relative", have_weekday_relative, unsigned int, 0);
 	PHP_DATE_INTERVAL_READ_PROPERTY("have_special_relative", have_special_relative, unsigned int, 0);
 	{
-		zval *z_arg = zend_hash_str_find(myht, "civil_or_wall", sizeof("civil_or_wall") - 1);
+		zval *z_arg = zend_hash_str_find(myht, "civil_or_wall", strlen("civil_or_wall"));
 		(*intobj)->civil_or_wall = PHP_DATE_CIVIL;
 		if (z_arg) {
 			zend_long val = zval_get_long(z_arg);
@@ -4475,12 +4475,12 @@ PHP_FUNCTION(timezone_abbreviations_list)
 
 	do {
 		array_init(&element);
-		add_assoc_bool_ex(&element, "dst", sizeof("dst") -1, entry->type);
-		add_assoc_long_ex(&element, "offset", sizeof("offset") - 1, entry->gmtoffset);
+		add_assoc_bool_ex(&element, "dst", strlen("dst"), entry->type);
+		add_assoc_long_ex(&element, "offset", strlen("offset"), entry->gmtoffset);
 		if (entry->full_tz_name) {
-			add_assoc_string_ex(&element, "timezone_id", sizeof("timezone_id") - 1, entry->full_tz_name);
+			add_assoc_string_ex(&element, "timezone_id", strlen("timezone_id"), entry->full_tz_name);
 		} else {
-			add_assoc_null_ex(&element, "timezone_id", sizeof("timezone_id") - 1);
+			add_assoc_null_ex(&element, "timezone_id", strlen("timezone_id"));
 		}
 
 		abbr_array_p = zend_hash_str_find(Z_ARRVAL_P(return_value), entry->name, strlen(entry->name));
@@ -4767,7 +4767,7 @@ static HashTable *date_object_get_properties_period(zend_object *object) /* {{{ 
 	} else {
 		ZVAL_NULL(&zv);
 	}
-	zend_hash_str_update(props, "start", sizeof("start")-1, &zv);
+	zend_hash_str_update(props, "start", strlen("start"), &zv);
 
 	if (period_obj->current) {
 		php_date_obj *date_obj;
@@ -4777,7 +4777,7 @@ static HashTable *date_object_get_properties_period(zend_object *object) /* {{{ 
 	} else {
 		ZVAL_NULL(&zv);
 	}
-	zend_hash_str_update(props, "current", sizeof("current")-1, &zv);
+	zend_hash_str_update(props, "current", strlen("current"), &zv);
 
 	if (period_obj->end) {
 		php_date_obj *date_obj;
@@ -4787,7 +4787,7 @@ static HashTable *date_object_get_properties_period(zend_object *object) /* {{{ 
 	} else {
 		ZVAL_NULL(&zv);
 	}
-	zend_hash_str_update(props, "end", sizeof("end")-1, &zv);
+	zend_hash_str_update(props, "end", strlen("end"), &zv);
 
 	if (period_obj->interval) {
 		php_interval_obj *interval_obj;
@@ -4798,14 +4798,14 @@ static HashTable *date_object_get_properties_period(zend_object *object) /* {{{ 
 	} else {
 		ZVAL_NULL(&zv);
 	}
-	zend_hash_str_update(props, "interval", sizeof("interval")-1, &zv);
+	zend_hash_str_update(props, "interval", strlen("interval"), &zv);
 
 	/* converted to larger type (int->long); must check when unserializing */
 	ZVAL_LONG(&zv, (zend_long) period_obj->recurrences);
-	zend_hash_str_update(props, "recurrences", sizeof("recurrences")-1, &zv);
+	zend_hash_str_update(props, "recurrences", strlen("recurrences"), &zv);
 
 	ZVAL_BOOL(&zv, period_obj->include_start_date);
-	zend_hash_str_update(props, "include_start_date", sizeof("include_start_date")-1, &zv);
+	zend_hash_str_update(props, "include_start_date", strlen("include_start_date"), &zv);
 
 	return props;
 } /* }}} */
@@ -4816,7 +4816,7 @@ static bool php_date_period_initialize_from_hash(php_period_obj *period_obj, Has
 
 	/* this function does no rollback on error */
 
-	ht_entry = zend_hash_str_find(myht, "start", sizeof("start")-1);
+	ht_entry = zend_hash_str_find(myht, "start", strlen("start"));
 	if (ht_entry) {
 		if (Z_TYPE_P(ht_entry) == IS_OBJECT && instanceof_function(Z_OBJCE_P(ht_entry), date_ce_interface)) {
 			php_date_obj *date_obj;
@@ -4830,7 +4830,7 @@ static bool php_date_period_initialize_from_hash(php_period_obj *period_obj, Has
 		return 0;
 	}
 
-	ht_entry = zend_hash_str_find(myht, "end", sizeof("end")-1);
+	ht_entry = zend_hash_str_find(myht, "end", strlen("end"));
 	if (ht_entry) {
 		if (Z_TYPE_P(ht_entry) == IS_OBJECT && instanceof_function(Z_OBJCE_P(ht_entry), date_ce_interface)) {
 			php_date_obj *date_obj;
@@ -4843,7 +4843,7 @@ static bool php_date_period_initialize_from_hash(php_period_obj *period_obj, Has
 		return 0;
 	}
 
-	ht_entry = zend_hash_str_find(myht, "current", sizeof("current")-1);
+	ht_entry = zend_hash_str_find(myht, "current", strlen("current"));
 	if (ht_entry) {
 		if (Z_TYPE_P(ht_entry) == IS_OBJECT && instanceof_function(Z_OBJCE_P(ht_entry), date_ce_interface)) {
 			php_date_obj *date_obj;
@@ -4856,7 +4856,7 @@ static bool php_date_period_initialize_from_hash(php_period_obj *period_obj, Has
 		return 0;
 	}
 
-	ht_entry = zend_hash_str_find(myht, "interval", sizeof("interval")-1);
+	ht_entry = zend_hash_str_find(myht, "interval", strlen("interval"));
 	if (ht_entry) {
 		if (Z_TYPE_P(ht_entry) == IS_OBJECT && Z_OBJCE_P(ht_entry) == date_ce_interval) {
 			php_interval_obj *interval_obj;
@@ -4869,7 +4869,7 @@ static bool php_date_period_initialize_from_hash(php_period_obj *period_obj, Has
 		return 0;
 	}
 
-	ht_entry = zend_hash_str_find(myht, "recurrences", sizeof("recurrences")-1);
+	ht_entry = zend_hash_str_find(myht, "recurrences", strlen("recurrences"));
 	if (ht_entry &&
 			Z_TYPE_P(ht_entry) == IS_LONG && Z_LVAL_P(ht_entry) >= 0 && Z_LVAL_P(ht_entry) <= INT_MAX) {
 		period_obj->recurrences = Z_LVAL_P(ht_entry);
@@ -4877,7 +4877,7 @@ static bool php_date_period_initialize_from_hash(php_period_obj *period_obj, Has
 		return 0;
 	}
 
-	ht_entry = zend_hash_str_find(myht, "include_start_date", sizeof("include_start_date")-1);
+	ht_entry = zend_hash_str_find(myht, "include_start_date", strlen("include_start_date"));
 	if (ht_entry &&
 			(Z_TYPE_P(ht_entry) == IS_FALSE || Z_TYPE_P(ht_entry) == IS_TRUE)) {
 		period_obj->include_start_date = (Z_TYPE_P(ht_entry) == IS_TRUE);

--- a/ext/dba/dba_db4.c
+++ b/ext/dba/dba_db4.c
@@ -45,8 +45,8 @@ static void php_dba_db4_errcall_fcn(
 	{
 		const char *function = get_active_function_name();
 		if (function && (!strcmp(function,"dba_popen") || !strcmp(function,"dba_open"))
-			&& (!strncmp(msg, "fop_read_meta", sizeof("fop_read_meta")-1)
-				|| !strncmp(msg, "BDB0004 fop_read_meta", sizeof("BDB0004 fop_read_meta")-1))) {
+			&& (!strncmp(msg, "fop_read_meta", strlen("fop_read_meta"))
+				|| !strncmp(msg, "BDB0004 fop_read_meta", strlen("BDB0004 fop_read_meta")))) {
 			return;
 		}
 	}

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1575,7 +1575,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 		zval *tmp;
 		char *xquery;
 
-		tmp = zend_hash_str_find(ht, "query", sizeof("query")-1);
+		tmp = zend_hash_str_find(ht, "query", strlen("query"));
 		if (!tmp) {
 			/* if mode == 0 then $xpath arg is 3, if mode == 1 then $xpath is 4 */
 			zend_argument_value_error(3 + mode, "must have a \"query\" key");
@@ -1591,7 +1591,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 		ctxp = xmlXPathNewContext(docp);
 		ctxp->node = nodep;
 
-		tmp = zend_hash_str_find(ht, "namespaces", sizeof("namespaces")-1);
+		tmp = zend_hash_str_find(ht, "namespaces", strlen("namespaces"));
 		if (tmp && Z_TYPE_P(tmp) == IS_ARRAY && !HT_IS_PACKED(Z_ARRVAL_P(tmp))) {
 			zval *tmpns;
 			zend_string *prefix;

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -403,7 +403,7 @@ static HashTable* dom_get_debug_info_helper(zend_object *object, int *is_temp) /
 		return debug_info;
 	}
 
-	object_str = zend_string_init("(object value omitted)", sizeof("(object value omitted)")-1, 0);
+	object_str = zend_string_init("(object value omitted)", strlen("(object value omitted)"), 0);
 
 	ZEND_HASH_MAP_FOREACH_STR_KEY_PTR(prop_handlers, string_key, entry) {
 		zval value;
@@ -585,45 +585,45 @@ PHP_MINIT_FUNCTION(dom)
 	dom_node_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_node_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_node_prop_handlers, "nodeName", sizeof("nodeName")-1, dom_node_node_name_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "nodeValue", sizeof("nodeValue")-1, dom_node_node_value_read, dom_node_node_value_write);
-	dom_register_prop_handler(&dom_node_prop_handlers, "nodeType", sizeof("nodeType")-1, dom_node_node_type_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "parentNode", sizeof("parentNode")-1, dom_node_parent_node_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "childNodes", sizeof("childNodes")-1, dom_node_child_nodes_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "firstChild", sizeof("firstChild")-1, dom_node_first_child_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "lastChild", sizeof("lastChild")-1, dom_node_last_child_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "previousSibling", sizeof("previousSibling")-1, dom_node_previous_sibling_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "nextSibling", sizeof("nextSibling")-1, dom_node_next_sibling_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "attributes", sizeof("attributes")-1, dom_node_attributes_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "ownerDocument", sizeof("ownerDocument")-1, dom_node_owner_document_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "namespaceURI", sizeof("namespaceURI")-1, dom_node_namespace_uri_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "prefix", sizeof("prefix")-1, dom_node_prefix_read, dom_node_prefix_write);
-	dom_register_prop_handler(&dom_node_prop_handlers, "localName", sizeof("localName")-1, dom_node_local_name_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "baseURI", sizeof("baseURI")-1, dom_node_base_uri_read, NULL);
-	dom_register_prop_handler(&dom_node_prop_handlers, "textContent", sizeof("textContent")-1, dom_node_text_content_read, dom_node_text_content_write);
+	dom_register_prop_handler(&dom_node_prop_handlers, "nodeName", strlen("nodeName"), dom_node_node_name_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "nodeValue", strlen("nodeValue"), dom_node_node_value_read, dom_node_node_value_write);
+	dom_register_prop_handler(&dom_node_prop_handlers, "nodeType", strlen("nodeType"), dom_node_node_type_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "parentNode", strlen("parentNode"), dom_node_parent_node_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "childNodes", strlen("childNodes"), dom_node_child_nodes_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "firstChild", strlen("firstChild"), dom_node_first_child_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "lastChild", strlen("lastChild"), dom_node_last_child_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "previousSibling", strlen("previousSibling"), dom_node_previous_sibling_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "nextSibling", strlen("nextSibling"), dom_node_next_sibling_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "attributes", strlen("attributes"), dom_node_attributes_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "ownerDocument", strlen("ownerDocument"), dom_node_owner_document_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "namespaceURI", strlen("namespaceURI"), dom_node_namespace_uri_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "prefix", strlen("prefix"), dom_node_prefix_read, dom_node_prefix_write);
+	dom_register_prop_handler(&dom_node_prop_handlers, "localName", strlen("localName"), dom_node_local_name_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "baseURI", strlen("baseURI"), dom_node_base_uri_read, NULL);
+	dom_register_prop_handler(&dom_node_prop_handlers, "textContent", strlen("textContent"), dom_node_text_content_read, dom_node_text_content_write);
 	zend_hash_add_ptr(&classes, dom_node_class_entry->name, &dom_node_prop_handlers);
 
 	dom_namespace_node_class_entry = register_class_DOMNameSpaceNode();
 	dom_namespace_node_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_namespace_node_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "nodeName", sizeof("nodeName")-1, dom_node_node_name_read, NULL);
-	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "nodeValue", sizeof("nodeValue")-1, dom_node_node_value_read, NULL);
-	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "nodeType", sizeof("nodeType")-1, dom_node_node_type_read, NULL);
-	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "prefix", sizeof("prefix")-1, dom_node_prefix_read, NULL);
-	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "localName", sizeof("localName")-1, dom_node_local_name_read, NULL);
-	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "namespaceURI", sizeof("namespaceURI")-1, dom_node_namespace_uri_read, NULL);
-	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "ownerDocument", sizeof("ownerDocument")-1, dom_node_owner_document_read, NULL);
-	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "parentNode", sizeof("parentNode")-1, dom_node_parent_node_read, NULL);
+	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "nodeName", strlen("nodeName"), dom_node_node_name_read, NULL);
+	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "nodeValue", strlen("nodeValue"), dom_node_node_value_read, NULL);
+	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "nodeType", strlen("nodeType"), dom_node_node_type_read, NULL);
+	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "prefix", strlen("prefix"), dom_node_prefix_read, NULL);
+	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "localName", strlen("localName"), dom_node_local_name_read, NULL);
+	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "namespaceURI", strlen("namespaceURI"), dom_node_namespace_uri_read, NULL);
+	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "ownerDocument", strlen("ownerDocument"), dom_node_owner_document_read, NULL);
+	dom_register_prop_handler(&dom_namespace_node_prop_handlers, "parentNode", strlen("parentNode"), dom_node_parent_node_read, NULL);
 	zend_hash_add_ptr(&classes, dom_namespace_node_class_entry->name, &dom_namespace_node_prop_handlers);
 
 	dom_documentfragment_class_entry = register_class_DOMDocumentFragment(dom_node_class_entry, dom_parentnode_class_entry);
 	dom_documentfragment_class_entry->create_object = dom_objects_new;
 	zend_hash_init(&dom_documentfragment_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 
-	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "firstElementChild", sizeof("firstElementChild")-1, dom_parent_node_first_element_child_read, NULL);
-	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "lastElementChild", sizeof("lastElementChild")-1, dom_parent_node_last_element_child_read, NULL);
-	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "childElementCount", sizeof("childElementCount")-1, dom_parent_node_child_element_count, NULL);
+	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "firstElementChild", strlen("firstElementChild"), dom_parent_node_first_element_child_read, NULL);
+	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "lastElementChild", strlen("lastElementChild"), dom_parent_node_last_element_child_read, NULL);
+	dom_register_prop_handler(&dom_documentfragment_prop_handlers, "childElementCount", strlen("childElementCount"), dom_parent_node_child_element_count, NULL);
 
 	zend_hash_merge(&dom_documentfragment_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_documentfragment_class_entry->name, &dom_documentfragment_prop_handlers);
@@ -631,29 +631,29 @@ PHP_MINIT_FUNCTION(dom)
 	dom_document_class_entry = register_class_DOMDocument(dom_node_class_entry, dom_parentnode_class_entry);
 	dom_document_class_entry->create_object = dom_objects_new;
 	zend_hash_init(&dom_document_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_document_prop_handlers, "doctype", sizeof("doctype")-1, dom_document_doctype_read, NULL);
-	dom_register_prop_handler(&dom_document_prop_handlers, "implementation", sizeof("implementation")-1, dom_document_implementation_read, NULL);
-	dom_register_prop_handler(&dom_document_prop_handlers, "documentElement", sizeof("documentElement")-1, dom_document_document_element_read, NULL);
-	dom_register_prop_handler(&dom_document_prop_handlers, "actualEncoding", sizeof("actualEncoding")-1, dom_document_encoding_read, NULL);
-	dom_register_prop_handler(&dom_document_prop_handlers, "encoding", sizeof("encoding")-1, dom_document_encoding_read, dom_document_encoding_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "xmlEncoding", sizeof("xmlEncoding")-1, dom_document_encoding_read, NULL);
-	dom_register_prop_handler(&dom_document_prop_handlers, "standalone", sizeof("standalone")-1, dom_document_standalone_read, dom_document_standalone_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "xmlStandalone", sizeof("xmlStandalone")-1, dom_document_standalone_read, dom_document_standalone_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "version", sizeof("version")-1, dom_document_version_read, dom_document_version_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "xmlVersion", sizeof("xmlVersion")-1, dom_document_version_read, dom_document_version_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "strictErrorChecking", sizeof("strictErrorChecking")-1, dom_document_strict_error_checking_read, dom_document_strict_error_checking_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "documentURI", sizeof("documentURI")-1, dom_document_document_uri_read, dom_document_document_uri_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "config", sizeof("config")-1, dom_document_config_read, NULL);
-	dom_register_prop_handler(&dom_document_prop_handlers, "formatOutput", sizeof("formatOutput")-1, dom_document_format_output_read, dom_document_format_output_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "validateOnParse", sizeof("validateOnParse")-1, dom_document_validate_on_parse_read, dom_document_validate_on_parse_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "resolveExternals", sizeof("resolveExternals")-1, dom_document_resolve_externals_read, dom_document_resolve_externals_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "preserveWhiteSpace", sizeof("preserveWhitespace")-1, dom_document_preserve_whitespace_read, dom_document_preserve_whitespace_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "recover", sizeof("recover")-1, dom_document_recover_read, dom_document_recover_write);
-	dom_register_prop_handler(&dom_document_prop_handlers, "substituteEntities", sizeof("substituteEntities")-1, dom_document_substitue_entities_read, dom_document_substitue_entities_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "doctype", strlen("doctype"), dom_document_doctype_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "implementation", strlen("implementation"), dom_document_implementation_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "documentElement", strlen("documentElement"), dom_document_document_element_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "actualEncoding", strlen("actualEncoding"), dom_document_encoding_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "encoding", strlen("encoding"), dom_document_encoding_read, dom_document_encoding_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "xmlEncoding", strlen("xmlEncoding"), dom_document_encoding_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "standalone", strlen("standalone"), dom_document_standalone_read, dom_document_standalone_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "xmlStandalone", strlen("xmlStandalone"), dom_document_standalone_read, dom_document_standalone_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "version", strlen("version"), dom_document_version_read, dom_document_version_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "xmlVersion", strlen("xmlVersion"), dom_document_version_read, dom_document_version_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "strictErrorChecking", strlen("strictErrorChecking"), dom_document_strict_error_checking_read, dom_document_strict_error_checking_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "documentURI", strlen("documentURI"), dom_document_document_uri_read, dom_document_document_uri_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "config", strlen("config"), dom_document_config_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "formatOutput", strlen("formatOutput"), dom_document_format_output_read, dom_document_format_output_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "validateOnParse", strlen("validateOnParse"), dom_document_validate_on_parse_read, dom_document_validate_on_parse_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "resolveExternals", strlen("resolveExternals"), dom_document_resolve_externals_read, dom_document_resolve_externals_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "preserveWhiteSpace", strlen("preserveWhitespace"), dom_document_preserve_whitespace_read, dom_document_preserve_whitespace_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "recover", strlen("recover"), dom_document_recover_read, dom_document_recover_write);
+	dom_register_prop_handler(&dom_document_prop_handlers, "substituteEntities", strlen("substituteEntities"), dom_document_substitue_entities_read, dom_document_substitue_entities_write);
 
-	dom_register_prop_handler(&dom_document_prop_handlers, "firstElementChild", sizeof("firstElementChild")-1, dom_parent_node_first_element_child_read, NULL);
-	dom_register_prop_handler(&dom_document_prop_handlers, "lastElementChild", sizeof("lastElementChild")-1, dom_parent_node_last_element_child_read, NULL);
-	dom_register_prop_handler(&dom_document_prop_handlers, "childElementCount", sizeof("childElementCount")-1, dom_parent_node_child_element_count, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "firstElementChild", strlen("firstElementChild"), dom_parent_node_first_element_child_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "lastElementChild", strlen("lastElementChild"), dom_parent_node_last_element_child_read, NULL);
+	dom_register_prop_handler(&dom_document_prop_handlers, "childElementCount", strlen("childElementCount"), dom_parent_node_child_element_count, NULL);
 
 	zend_hash_merge(&dom_document_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_document_class_entry->name, &dom_document_prop_handlers);
@@ -663,7 +663,7 @@ PHP_MINIT_FUNCTION(dom)
 	dom_nodelist_class_entry->get_iterator = php_dom_get_iterator;
 
 	zend_hash_init(&dom_nodelist_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_nodelist_prop_handlers, "length", sizeof("length")-1, dom_nodelist_length_read, NULL);
+	dom_register_prop_handler(&dom_nodelist_prop_handlers, "length", strlen("length"), dom_nodelist_length_read, NULL);
 	zend_hash_add_ptr(&classes, dom_nodelist_class_entry->name, &dom_nodelist_prop_handlers);
 
 	dom_namednodemap_class_entry = register_class_DOMNamedNodeMap(zend_ce_aggregate, zend_ce_countable);
@@ -671,17 +671,17 @@ PHP_MINIT_FUNCTION(dom)
 	dom_namednodemap_class_entry->get_iterator = php_dom_get_iterator;
 
 	zend_hash_init(&dom_namednodemap_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_namednodemap_prop_handlers, "length", sizeof("length")-1, dom_namednodemap_length_read, NULL);
+	dom_register_prop_handler(&dom_namednodemap_prop_handlers, "length", strlen("length"), dom_namednodemap_length_read, NULL);
 	zend_hash_add_ptr(&classes, dom_namednodemap_class_entry->name, &dom_namednodemap_prop_handlers);
 
 	dom_characterdata_class_entry = register_class_DOMCharacterData(dom_node_class_entry, dom_childnode_class_entry);
 	dom_characterdata_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_characterdata_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_characterdata_prop_handlers, "data", sizeof("data")-1, dom_characterdata_data_read, dom_characterdata_data_write);
-	dom_register_prop_handler(&dom_characterdata_prop_handlers, "length", sizeof("length")-1, dom_characterdata_length_read, NULL);
-	dom_register_prop_handler(&dom_characterdata_prop_handlers, "previousElementSibling", sizeof("previousElementSibling")-1, dom_node_previous_element_sibling_read, NULL);
-	dom_register_prop_handler(&dom_characterdata_prop_handlers, "nextElementSibling", sizeof("nextElementSibling")-1, dom_node_next_element_sibling_read, NULL);
+	dom_register_prop_handler(&dom_characterdata_prop_handlers, "data", strlen("data"), dom_characterdata_data_read, dom_characterdata_data_write);
+	dom_register_prop_handler(&dom_characterdata_prop_handlers, "length", strlen("length"), dom_characterdata_length_read, NULL);
+	dom_register_prop_handler(&dom_characterdata_prop_handlers, "previousElementSibling", strlen("previousElementSibling"), dom_node_previous_element_sibling_read, NULL);
+	dom_register_prop_handler(&dom_characterdata_prop_handlers, "nextElementSibling", strlen("nextElementSibling"), dom_node_next_element_sibling_read, NULL);
 	zend_hash_merge(&dom_characterdata_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_characterdata_class_entry->name, &dom_characterdata_prop_handlers);
 
@@ -689,11 +689,11 @@ PHP_MINIT_FUNCTION(dom)
 	dom_attr_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_attr_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_attr_prop_handlers, "name", sizeof("name")-1, dom_attr_name_read, NULL);
-	dom_register_prop_handler(&dom_attr_prop_handlers, "specified", sizeof("specified")-1, dom_attr_specified_read, NULL);
-	dom_register_prop_handler(&dom_attr_prop_handlers, "value", sizeof("value")-1, dom_attr_value_read, dom_attr_value_write);
-	dom_register_prop_handler(&dom_attr_prop_handlers, "ownerElement", sizeof("ownerElement")-1, dom_attr_owner_element_read, NULL);
-	dom_register_prop_handler(&dom_attr_prop_handlers, "schemaTypeInfo", sizeof("schemaTypeInfo")-1, dom_attr_schema_type_info_read, NULL);
+	dom_register_prop_handler(&dom_attr_prop_handlers, "name", strlen("name"), dom_attr_name_read, NULL);
+	dom_register_prop_handler(&dom_attr_prop_handlers, "specified", strlen("specified"), dom_attr_specified_read, NULL);
+	dom_register_prop_handler(&dom_attr_prop_handlers, "value", strlen("value"), dom_attr_value_read, dom_attr_value_write);
+	dom_register_prop_handler(&dom_attr_prop_handlers, "ownerElement", strlen("ownerElement"), dom_attr_owner_element_read, NULL);
+	dom_register_prop_handler(&dom_attr_prop_handlers, "schemaTypeInfo", strlen("schemaTypeInfo"), dom_attr_schema_type_info_read, NULL);
 	zend_hash_merge(&dom_attr_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_attr_class_entry->name, &dom_attr_prop_handlers);
 
@@ -701,13 +701,13 @@ PHP_MINIT_FUNCTION(dom)
 	dom_element_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_element_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_element_prop_handlers, "tagName", sizeof("tagName")-1, dom_element_tag_name_read, NULL);
-	dom_register_prop_handler(&dom_element_prop_handlers, "schemaTypeInfo", sizeof("schemaTypeInfo")-1, dom_element_schema_type_info_read, NULL);
-	dom_register_prop_handler(&dom_element_prop_handlers, "firstElementChild", sizeof("firstElementChild")-1, dom_parent_node_first_element_child_read, NULL);
-	dom_register_prop_handler(&dom_element_prop_handlers, "lastElementChild", sizeof("lastElementChild")-1, dom_parent_node_last_element_child_read, NULL);
-	dom_register_prop_handler(&dom_element_prop_handlers, "childElementCount", sizeof("childElementCount")-1, dom_parent_node_child_element_count, NULL);
-	dom_register_prop_handler(&dom_element_prop_handlers, "previousElementSibling", sizeof("previousElementSibling")-1, dom_node_previous_element_sibling_read, NULL);
-	dom_register_prop_handler(&dom_element_prop_handlers, "nextElementSibling", sizeof("nextElementSibling")-1, dom_node_next_element_sibling_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "tagName", strlen("tagName"), dom_element_tag_name_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "schemaTypeInfo", strlen("schemaTypeInfo"), dom_element_schema_type_info_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "firstElementChild", strlen("firstElementChild"), dom_parent_node_first_element_child_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "lastElementChild", strlen("lastElementChild"), dom_parent_node_last_element_child_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "childElementCount", strlen("childElementCount"), dom_parent_node_child_element_count, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "previousElementSibling", strlen("previousElementSibling"), dom_node_previous_element_sibling_read, NULL);
+	dom_register_prop_handler(&dom_element_prop_handlers, "nextElementSibling", strlen("nextElementSibling"), dom_node_next_element_sibling_read, NULL);
 	zend_hash_merge(&dom_element_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_element_class_entry->name, &dom_element_prop_handlers);
 
@@ -715,7 +715,7 @@ PHP_MINIT_FUNCTION(dom)
 	dom_text_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_text_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_text_prop_handlers, "wholeText", sizeof("wholeText")-1, dom_text_whole_text_read, NULL);
+	dom_register_prop_handler(&dom_text_prop_handlers, "wholeText", strlen("wholeText"), dom_text_whole_text_read, NULL);
 	zend_hash_merge(&dom_text_prop_handlers, &dom_characterdata_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_text_class_entry->name, &dom_text_prop_handlers);
 
@@ -731,12 +731,12 @@ PHP_MINIT_FUNCTION(dom)
 	dom_documenttype_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_documenttype_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_documenttype_prop_handlers, "name", sizeof("name")-1, dom_documenttype_name_read, NULL);
-	dom_register_prop_handler(&dom_documenttype_prop_handlers, "entities", sizeof("entities")-1, dom_documenttype_entities_read, NULL);
-	dom_register_prop_handler(&dom_documenttype_prop_handlers, "notations", sizeof("notations")-1, dom_documenttype_notations_read, NULL);
-	dom_register_prop_handler(&dom_documenttype_prop_handlers, "publicId", sizeof("publicId")-1, dom_documenttype_public_id_read, NULL);
-	dom_register_prop_handler(&dom_documenttype_prop_handlers, "systemId", sizeof("systemId")-1, dom_documenttype_system_id_read, NULL);
-	dom_register_prop_handler(&dom_documenttype_prop_handlers, "internalSubset", sizeof("internalSubset")-1, dom_documenttype_internal_subset_read, NULL);
+	dom_register_prop_handler(&dom_documenttype_prop_handlers, "name", strlen("name"), dom_documenttype_name_read, NULL);
+	dom_register_prop_handler(&dom_documenttype_prop_handlers, "entities", strlen("entities"), dom_documenttype_entities_read, NULL);
+	dom_register_prop_handler(&dom_documenttype_prop_handlers, "notations", strlen("notations"), dom_documenttype_notations_read, NULL);
+	dom_register_prop_handler(&dom_documenttype_prop_handlers, "publicId", strlen("publicId"), dom_documenttype_public_id_read, NULL);
+	dom_register_prop_handler(&dom_documenttype_prop_handlers, "systemId", strlen("systemId"), dom_documenttype_system_id_read, NULL);
+	dom_register_prop_handler(&dom_documenttype_prop_handlers, "internalSubset", strlen("internalSubset"), dom_documenttype_internal_subset_read, NULL);
 	zend_hash_merge(&dom_documenttype_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_documenttype_class_entry->name, &dom_documenttype_prop_handlers);
 
@@ -744,8 +744,8 @@ PHP_MINIT_FUNCTION(dom)
 	dom_notation_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_notation_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_notation_prop_handlers, "publicId", sizeof("publicId")-1, dom_notation_public_id_read, NULL);
-	dom_register_prop_handler(&dom_notation_prop_handlers, "systemId", sizeof("systemId")-1, dom_notation_system_id_read, NULL);
+	dom_register_prop_handler(&dom_notation_prop_handlers, "publicId", strlen("publicId"), dom_notation_public_id_read, NULL);
+	dom_register_prop_handler(&dom_notation_prop_handlers, "systemId", strlen("systemId"), dom_notation_system_id_read, NULL);
 	zend_hash_merge(&dom_notation_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_notation_class_entry->name, &dom_notation_prop_handlers);
 
@@ -753,12 +753,12 @@ PHP_MINIT_FUNCTION(dom)
 	dom_entity_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_entity_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_entity_prop_handlers, "publicId", sizeof("publicId")-1, dom_entity_public_id_read, NULL);
-	dom_register_prop_handler(&dom_entity_prop_handlers, "systemId", sizeof("systemId")-1, dom_entity_system_id_read, NULL);
-	dom_register_prop_handler(&dom_entity_prop_handlers, "notationName", sizeof("notationName")-1, dom_entity_notation_name_read, NULL);
-	dom_register_prop_handler(&dom_entity_prop_handlers, "actualEncoding", sizeof("actualEncoding")-1, dom_entity_actual_encoding_read, NULL);
-	dom_register_prop_handler(&dom_entity_prop_handlers, "encoding", sizeof("encoding")-1, dom_entity_encoding_read, NULL);
-	dom_register_prop_handler(&dom_entity_prop_handlers, "version", sizeof("version")-1, dom_entity_version_read, NULL);
+	dom_register_prop_handler(&dom_entity_prop_handlers, "publicId", strlen("publicId"), dom_entity_public_id_read, NULL);
+	dom_register_prop_handler(&dom_entity_prop_handlers, "systemId", strlen("systemId"), dom_entity_system_id_read, NULL);
+	dom_register_prop_handler(&dom_entity_prop_handlers, "notationName", strlen("notationName"), dom_entity_notation_name_read, NULL);
+	dom_register_prop_handler(&dom_entity_prop_handlers, "actualEncoding", strlen("actualEncoding"), dom_entity_actual_encoding_read, NULL);
+	dom_register_prop_handler(&dom_entity_prop_handlers, "encoding", strlen("encoding"), dom_entity_encoding_read, NULL);
+	dom_register_prop_handler(&dom_entity_prop_handlers, "version", strlen("version"), dom_entity_version_read, NULL);
 	zend_hash_merge(&dom_entity_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_entity_class_entry->name, &dom_entity_prop_handlers);
 
@@ -770,8 +770,8 @@ PHP_MINIT_FUNCTION(dom)
 	dom_processinginstruction_class_entry->create_object = dom_objects_new;
 
 	zend_hash_init(&dom_processinginstruction_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_processinginstruction_prop_handlers, "target", sizeof("target")-1, dom_processinginstruction_target_read, NULL);
-	dom_register_prop_handler(&dom_processinginstruction_prop_handlers, "data", sizeof("data")-1, dom_processinginstruction_data_read, dom_processinginstruction_data_write);
+	dom_register_prop_handler(&dom_processinginstruction_prop_handlers, "target", strlen("target"), dom_processinginstruction_target_read, NULL);
+	dom_register_prop_handler(&dom_processinginstruction_prop_handlers, "data", strlen("data"), dom_processinginstruction_data_read, dom_processinginstruction_data_write);
 	zend_hash_merge(&dom_processinginstruction_prop_handlers, &dom_node_prop_handlers, dom_copy_prop_handler, 0);
 	zend_hash_add_ptr(&classes, dom_processinginstruction_class_entry->name, &dom_processinginstruction_prop_handlers);
 
@@ -784,8 +784,8 @@ PHP_MINIT_FUNCTION(dom)
 	dom_xpath_class_entry->create_object = dom_xpath_objects_new;
 
 	zend_hash_init(&dom_xpath_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
-	dom_register_prop_handler(&dom_xpath_prop_handlers, "document", sizeof("document")-1, dom_xpath_document_read, NULL);
-	dom_register_prop_handler(&dom_xpath_prop_handlers, "registerNodeNamespaces", sizeof("registerNodeNamespaces")-1, dom_xpath_register_node_ns_read, dom_xpath_register_node_ns_write);
+	dom_register_prop_handler(&dom_xpath_prop_handlers, "document", strlen("document"), dom_xpath_document_read, NULL);
+	dom_register_prop_handler(&dom_xpath_prop_handlers, "registerNodeNamespaces", strlen("registerNodeNamespaces"), dom_xpath_register_node_ns_read, dom_xpath_register_node_ns_write);
 	zend_hash_add_ptr(&classes, dom_xpath_class_entry->name, &dom_xpath_prop_handlers);
 #endif
 
@@ -1535,7 +1535,7 @@ static int dom_nodelist_has_dimension(zend_object *object, zval *member, int che
 		return 0;
 	} else {
 		zval *length = zend_read_property(
-			object->ce, object, "length", sizeof("length") - 1, 0, &rv);
+			object->ce, object, "length", strlen("length"), 0, &rv);
 		return length && offset < Z_LVAL_P(length);
 	}
 } /* }}} end dom_nodelist_has_dimension */

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -904,39 +904,39 @@ static zend_class_entry *register_class_DOMDocumentType(zend_class_entry *class_
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
-	zend_string *property_entities_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
+	zend_string *property_entities_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", strlen("DOMNamedNodeMap"), 1);
 	zval property_entities_default_value;
 	ZVAL_UNDEF(&property_entities_default_value);
-	zend_string *property_entities_name = zend_string_init("entities", sizeof("entities") - 1, 1);
+	zend_string *property_entities_name = zend_string_init("entities", strlen("entities"), 1);
 	zend_declare_typed_property(class_entry, property_entities_name, &property_entities_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_entities_class_DOMNamedNodeMap, 0, 0));
 	zend_string_release(property_entities_name);
 
-	zend_string *property_notations_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
+	zend_string *property_notations_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", strlen("DOMNamedNodeMap"), 1);
 	zval property_notations_default_value;
 	ZVAL_UNDEF(&property_notations_default_value);
-	zend_string *property_notations_name = zend_string_init("notations", sizeof("notations") - 1, 1);
+	zend_string *property_notations_name = zend_string_init("notations", strlen("notations"), 1);
 	zend_declare_typed_property(class_entry, property_notations_name, &property_notations_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_notations_class_DOMNamedNodeMap, 0, 0));
 	zend_string_release(property_notations_name);
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_systemId_name);
 
 	zval property_internalSubset_default_value;
 	ZVAL_UNDEF(&property_internalSubset_default_value);
-	zend_string *property_internalSubset_name = zend_string_init("internalSubset", sizeof("internalSubset") - 1, 1);
+	zend_string *property_internalSubset_name = zend_string_init("internalSubset", strlen("internalSubset"), 1);
 	zend_declare_typed_property(class_entry, property_internalSubset_name, &property_internalSubset_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_internalSubset_name);
 
@@ -993,105 +993,105 @@ static zend_class_entry *register_class_DOMNode(void)
 
 	zval property_nodeName_default_value;
 	ZVAL_UNDEF(&property_nodeName_default_value);
-	zend_string *property_nodeName_name = zend_string_init("nodeName", sizeof("nodeName") - 1, 1);
+	zend_string *property_nodeName_name = zend_string_init("nodeName", strlen("nodeName"), 1);
 	zend_declare_typed_property(class_entry, property_nodeName_name, &property_nodeName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_nodeName_name);
 
 	zval property_nodeValue_default_value;
 	ZVAL_UNDEF(&property_nodeValue_default_value);
-	zend_string *property_nodeValue_name = zend_string_init("nodeValue", sizeof("nodeValue") - 1, 1);
+	zend_string *property_nodeValue_name = zend_string_init("nodeValue", strlen("nodeValue"), 1);
 	zend_declare_typed_property(class_entry, property_nodeValue_name, &property_nodeValue_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_nodeValue_name);
 
 	zval property_nodeType_default_value;
 	ZVAL_UNDEF(&property_nodeType_default_value);
-	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
+	zend_string *property_nodeType_name = zend_string_init("nodeType", strlen("nodeType"), 1);
 	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_nodeType_name);
 
-	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zval property_parentNode_default_value;
 	ZVAL_UNDEF(&property_parentNode_default_value);
-	zend_string *property_parentNode_name = zend_string_init("parentNode", sizeof("parentNode") - 1, 1);
+	zend_string *property_parentNode_name = zend_string_init("parentNode", strlen("parentNode"), 1);
 	zend_declare_typed_property(class_entry, property_parentNode_name, &property_parentNode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentNode_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_parentNode_name);
 
-	zend_string *property_childNodes_class_DOMNodeList = zend_string_init("DOMNodeList", sizeof("DOMNodeList")-1, 1);
+	zend_string *property_childNodes_class_DOMNodeList = zend_string_init("DOMNodeList", strlen("DOMNodeList"), 1);
 	zval property_childNodes_default_value;
 	ZVAL_UNDEF(&property_childNodes_default_value);
-	zend_string *property_childNodes_name = zend_string_init("childNodes", sizeof("childNodes") - 1, 1);
+	zend_string *property_childNodes_name = zend_string_init("childNodes", strlen("childNodes"), 1);
 	zend_declare_typed_property(class_entry, property_childNodes_name, &property_childNodes_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_childNodes_class_DOMNodeList, 0, 0));
 	zend_string_release(property_childNodes_name);
 
-	zend_string *property_firstChild_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_firstChild_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zval property_firstChild_default_value;
 	ZVAL_UNDEF(&property_firstChild_default_value);
-	zend_string *property_firstChild_name = zend_string_init("firstChild", sizeof("firstChild") - 1, 1);
+	zend_string *property_firstChild_name = zend_string_init("firstChild", strlen("firstChild"), 1);
 	zend_declare_typed_property(class_entry, property_firstChild_name, &property_firstChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstChild_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_firstChild_name);
 
-	zend_string *property_lastChild_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_lastChild_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zval property_lastChild_default_value;
 	ZVAL_UNDEF(&property_lastChild_default_value);
-	zend_string *property_lastChild_name = zend_string_init("lastChild", sizeof("lastChild") - 1, 1);
+	zend_string *property_lastChild_name = zend_string_init("lastChild", strlen("lastChild"), 1);
 	zend_declare_typed_property(class_entry, property_lastChild_name, &property_lastChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastChild_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_lastChild_name);
 
-	zend_string *property_previousSibling_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_previousSibling_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zval property_previousSibling_default_value;
 	ZVAL_UNDEF(&property_previousSibling_default_value);
-	zend_string *property_previousSibling_name = zend_string_init("previousSibling", sizeof("previousSibling") - 1, 1);
+	zend_string *property_previousSibling_name = zend_string_init("previousSibling", strlen("previousSibling"), 1);
 	zend_declare_typed_property(class_entry, property_previousSibling_name, &property_previousSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousSibling_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_previousSibling_name);
 
-	zend_string *property_nextSibling_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_nextSibling_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zval property_nextSibling_default_value;
 	ZVAL_UNDEF(&property_nextSibling_default_value);
-	zend_string *property_nextSibling_name = zend_string_init("nextSibling", sizeof("nextSibling") - 1, 1);
+	zend_string *property_nextSibling_name = zend_string_init("nextSibling", strlen("nextSibling"), 1);
 	zend_declare_typed_property(class_entry, property_nextSibling_name, &property_nextSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextSibling_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_nextSibling_name);
 
-	zend_string *property_attributes_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", sizeof("DOMNamedNodeMap")-1, 1);
+	zend_string *property_attributes_class_DOMNamedNodeMap = zend_string_init("DOMNamedNodeMap", strlen("DOMNamedNodeMap"), 1);
 	zval property_attributes_default_value;
 	ZVAL_UNDEF(&property_attributes_default_value);
-	zend_string *property_attributes_name = zend_string_init("attributes", sizeof("attributes") - 1, 1);
+	zend_string *property_attributes_name = zend_string_init("attributes", strlen("attributes"), 1);
 	zend_declare_typed_property(class_entry, property_attributes_name, &property_attributes_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_attributes_class_DOMNamedNodeMap, 0, MAY_BE_NULL));
 	zend_string_release(property_attributes_name);
 
-	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", sizeof("DOMDocument")-1, 1);
+	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", strlen("DOMDocument"), 1);
 	zval property_ownerDocument_default_value;
 	ZVAL_UNDEF(&property_ownerDocument_default_value);
-	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", sizeof("ownerDocument") - 1, 1);
+	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", strlen("ownerDocument"), 1);
 	zend_declare_typed_property(class_entry, property_ownerDocument_name, &property_ownerDocument_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerDocument_class_DOMDocument, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerDocument_name);
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_namespaceURI_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_prefix_name);
 
 	zval property_localName_default_value;
 	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_string *property_localName_name = zend_string_init("localName", strlen("localName"), 1);
 	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_localName_name);
 
 	zval property_baseURI_default_value;
 	ZVAL_UNDEF(&property_baseURI_default_value);
-	zend_string *property_baseURI_name = zend_string_init("baseURI", sizeof("baseURI") - 1, 1);
+	zend_string *property_baseURI_name = zend_string_init("baseURI", strlen("baseURI"), 1);
 	zend_declare_typed_property(class_entry, property_baseURI_name, &property_baseURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_baseURI_name);
 
 	zval property_textContent_default_value;
 	ZVAL_UNDEF(&property_textContent_default_value);
-	zend_string *property_textContent_name = zend_string_init("textContent", sizeof("textContent") - 1, 1);
+	zend_string *property_textContent_name = zend_string_init("textContent", strlen("textContent"), 1);
 	zend_declare_typed_property(class_entry, property_textContent_name, &property_textContent_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_textContent_name);
 
@@ -1108,51 +1108,51 @@ static zend_class_entry *register_class_DOMNameSpaceNode(void)
 
 	zval property_nodeName_default_value;
 	ZVAL_UNDEF(&property_nodeName_default_value);
-	zend_string *property_nodeName_name = zend_string_init("nodeName", sizeof("nodeName") - 1, 1);
+	zend_string *property_nodeName_name = zend_string_init("nodeName", strlen("nodeName"), 1);
 	zend_declare_typed_property(class_entry, property_nodeName_name, &property_nodeName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_nodeName_name);
 
 	zval property_nodeValue_default_value;
 	ZVAL_UNDEF(&property_nodeValue_default_value);
-	zend_string *property_nodeValue_name = zend_string_init("nodeValue", sizeof("nodeValue") - 1, 1);
+	zend_string *property_nodeValue_name = zend_string_init("nodeValue", strlen("nodeValue"), 1);
 	zend_declare_typed_property(class_entry, property_nodeValue_name, &property_nodeValue_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_nodeValue_name);
 
 	zval property_nodeType_default_value;
 	ZVAL_UNDEF(&property_nodeType_default_value);
-	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
+	zend_string *property_nodeType_name = zend_string_init("nodeType", strlen("nodeType"), 1);
 	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_nodeType_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_prefix_name);
 
 	zval property_localName_default_value;
 	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_string *property_localName_name = zend_string_init("localName", strlen("localName"), 1);
 	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_localName_name);
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_namespaceURI_name);
 
-	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", sizeof("DOMDocument")-1, 1);
+	zend_string *property_ownerDocument_class_DOMDocument = zend_string_init("DOMDocument", strlen("DOMDocument"), 1);
 	zval property_ownerDocument_default_value;
 	ZVAL_UNDEF(&property_ownerDocument_default_value);
-	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", sizeof("ownerDocument") - 1, 1);
+	zend_string *property_ownerDocument_name = zend_string_init("ownerDocument", strlen("ownerDocument"), 1);
 	zend_declare_typed_property(class_entry, property_ownerDocument_name, &property_ownerDocument_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerDocument_class_DOMDocument, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerDocument_name);
 
-	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", sizeof("DOMNode")-1, 1);
+	zend_string *property_parentNode_class_DOMNode = zend_string_init("DOMNode", strlen("DOMNode"), 1);
 	zval property_parentNode_default_value;
 	ZVAL_UNDEF(&property_parentNode_default_value);
-	zend_string *property_parentNode_name = zend_string_init("parentNode", sizeof("parentNode") - 1, 1);
+	zend_string *property_parentNode_name = zend_string_init("parentNode", strlen("parentNode"), 1);
 	zend_declare_typed_property(class_entry, property_parentNode_name, &property_parentNode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parentNode_class_DOMNode, 0, MAY_BE_NULL));
 	zend_string_release(property_parentNode_name);
 
@@ -1177,23 +1177,23 @@ static zend_class_entry *register_class_DOMDocumentFragment(zend_class_entry *cl
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DOMNode);
 	zend_class_implements(class_entry, 1, class_entry_DOMParentNode);
 
-	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
-	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
@@ -1210,7 +1210,7 @@ static zend_class_entry *register_class_DOMNodeList(zend_class_entry *class_entr
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -1227,27 +1227,27 @@ static zend_class_entry *register_class_DOMCharacterData(zend_class_entry *class
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
-	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_previousElementSibling_default_value;
 	ZVAL_UNDEF(&property_previousElementSibling_default_value);
-	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", sizeof("previousElementSibling") - 1, 1);
+	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", strlen("previousElementSibling"), 1);
 	zend_declare_typed_property(class_entry, property_previousElementSibling_name, &property_previousElementSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_previousElementSibling_name);
 
-	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_nextElementSibling_default_value;
 	ZVAL_UNDEF(&property_nextElementSibling_default_value);
-	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", sizeof("nextElementSibling") - 1, 1);
+	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", strlen("nextElementSibling"), 1);
 	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_nextElementSibling_name);
 
@@ -1263,32 +1263,32 @@ static zend_class_entry *register_class_DOMAttr(zend_class_entry *class_entry_DO
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
 	zval property_specified_default_value;
 	ZVAL_BOOL(&property_specified_default_value, 1);
-	zend_string *property_specified_name = zend_string_init("specified", sizeof("specified") - 1, 1);
+	zend_string *property_specified_name = zend_string_init("specified", strlen("specified"), 1);
 	zend_declare_typed_property(class_entry, property_specified_name, &property_specified_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_specified_name);
 
 	zval property_value_default_value;
 	ZVAL_UNDEF(&property_value_default_value);
-	zend_string *property_value_name = zend_string_init("value", sizeof("value") - 1, 1);
+	zend_string *property_value_name = zend_string_init("value", strlen("value"), 1);
 	zend_declare_typed_property(class_entry, property_value_name, &property_value_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_value_name);
 
-	zend_string *property_ownerElement_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_ownerElement_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_ownerElement_default_value;
 	ZVAL_UNDEF(&property_ownerElement_default_value);
-	zend_string *property_ownerElement_name = zend_string_init("ownerElement", sizeof("ownerElement") - 1, 1);
+	zend_string *property_ownerElement_name = zend_string_init("ownerElement", strlen("ownerElement"), 1);
 	zend_declare_typed_property(class_entry, property_ownerElement_name, &property_ownerElement_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_ownerElement_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_ownerElement_name);
 
 	zval property_schemaTypeInfo_default_value;
 	ZVAL_NULL(&property_schemaTypeInfo_default_value);
-	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", sizeof("schemaTypeInfo") - 1, 1);
+	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", strlen("schemaTypeInfo"), 1);
 	zend_declare_typed_property(class_entry, property_schemaTypeInfo_name, &property_schemaTypeInfo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_schemaTypeInfo_name);
 
@@ -1305,47 +1305,47 @@ static zend_class_entry *register_class_DOMElement(zend_class_entry *class_entry
 
 	zval property_tagName_default_value;
 	ZVAL_UNDEF(&property_tagName_default_value);
-	zend_string *property_tagName_name = zend_string_init("tagName", sizeof("tagName") - 1, 1);
+	zend_string *property_tagName_name = zend_string_init("tagName", strlen("tagName"), 1);
 	zend_declare_typed_property(class_entry, property_tagName_name, &property_tagName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_tagName_name);
 
 	zval property_schemaTypeInfo_default_value;
 	ZVAL_NULL(&property_schemaTypeInfo_default_value);
-	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", sizeof("schemaTypeInfo") - 1, 1);
+	zend_string *property_schemaTypeInfo_name = zend_string_init("schemaTypeInfo", strlen("schemaTypeInfo"), 1);
 	zend_declare_typed_property(class_entry, property_schemaTypeInfo_name, &property_schemaTypeInfo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_schemaTypeInfo_name);
 
-	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
-	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
-	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_previousElementSibling_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_previousElementSibling_default_value;
 	ZVAL_UNDEF(&property_previousElementSibling_default_value);
-	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", sizeof("previousElementSibling") - 1, 1);
+	zend_string *property_previousElementSibling_name = zend_string_init("previousElementSibling", strlen("previousElementSibling"), 1);
 	zend_declare_typed_property(class_entry, property_previousElementSibling_name, &property_previousElementSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_previousElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_previousElementSibling_name);
 
-	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_nextElementSibling_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_nextElementSibling_default_value;
 	ZVAL_UNDEF(&property_nextElementSibling_default_value);
-	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", sizeof("nextElementSibling") - 1, 1);
+	zend_string *property_nextElementSibling_name = zend_string_init("nextElementSibling", strlen("nextElementSibling"), 1);
 	zend_declare_typed_property(class_entry, property_nextElementSibling_name, &property_nextElementSibling_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_nextElementSibling_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_nextElementSibling_name);
 
@@ -1360,140 +1360,140 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_DOMNode);
 	zend_class_implements(class_entry, 1, class_entry_DOMParentNode);
 
-	zend_string *property_doctype_class_DOMDocumentType = zend_string_init("DOMDocumentType", sizeof("DOMDocumentType")-1, 1);
+	zend_string *property_doctype_class_DOMDocumentType = zend_string_init("DOMDocumentType", strlen("DOMDocumentType"), 1);
 	zval property_doctype_default_value;
 	ZVAL_UNDEF(&property_doctype_default_value);
-	zend_string *property_doctype_name = zend_string_init("doctype", sizeof("doctype") - 1, 1);
+	zend_string *property_doctype_name = zend_string_init("doctype", strlen("doctype"), 1);
 	zend_declare_typed_property(class_entry, property_doctype_name, &property_doctype_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_doctype_class_DOMDocumentType, 0, MAY_BE_NULL));
 	zend_string_release(property_doctype_name);
 
-	zend_string *property_implementation_class_DOMImplementation = zend_string_init("DOMImplementation", sizeof("DOMImplementation")-1, 1);
+	zend_string *property_implementation_class_DOMImplementation = zend_string_init("DOMImplementation", strlen("DOMImplementation"), 1);
 	zval property_implementation_default_value;
 	ZVAL_UNDEF(&property_implementation_default_value);
-	zend_string *property_implementation_name = zend_string_init("implementation", sizeof("implementation") - 1, 1);
+	zend_string *property_implementation_name = zend_string_init("implementation", strlen("implementation"), 1);
 	zend_declare_typed_property(class_entry, property_implementation_name, &property_implementation_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_implementation_class_DOMImplementation, 0, 0));
 	zend_string_release(property_implementation_name);
 
-	zend_string *property_documentElement_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_documentElement_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_documentElement_default_value;
 	ZVAL_UNDEF(&property_documentElement_default_value);
-	zend_string *property_documentElement_name = zend_string_init("documentElement", sizeof("documentElement") - 1, 1);
+	zend_string *property_documentElement_name = zend_string_init("documentElement", strlen("documentElement"), 1);
 	zend_declare_typed_property(class_entry, property_documentElement_name, &property_documentElement_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_documentElement_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_documentElement_name);
 
 	zval property_actualEncoding_default_value;
 	ZVAL_UNDEF(&property_actualEncoding_default_value);
-	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", sizeof("actualEncoding") - 1, 1);
+	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", strlen("actualEncoding"), 1);
 	zend_declare_typed_property(class_entry, property_actualEncoding_name, &property_actualEncoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_actualEncoding_name);
 
 	zval property_encoding_default_value;
 	ZVAL_UNDEF(&property_encoding_default_value);
-	zend_string *property_encoding_name = zend_string_init("encoding", sizeof("encoding") - 1, 1);
+	zend_string *property_encoding_name = zend_string_init("encoding", strlen("encoding"), 1);
 	zend_declare_typed_property(class_entry, property_encoding_name, &property_encoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_encoding_name);
 
 	zval property_xmlEncoding_default_value;
 	ZVAL_UNDEF(&property_xmlEncoding_default_value);
-	zend_string *property_xmlEncoding_name = zend_string_init("xmlEncoding", sizeof("xmlEncoding") - 1, 1);
+	zend_string *property_xmlEncoding_name = zend_string_init("xmlEncoding", strlen("xmlEncoding"), 1);
 	zend_declare_typed_property(class_entry, property_xmlEncoding_name, &property_xmlEncoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_xmlEncoding_name);
 
 	zval property_standalone_default_value;
 	ZVAL_UNDEF(&property_standalone_default_value);
-	zend_string *property_standalone_name = zend_string_init("standalone", sizeof("standalone") - 1, 1);
+	zend_string *property_standalone_name = zend_string_init("standalone", strlen("standalone"), 1);
 	zend_declare_typed_property(class_entry, property_standalone_name, &property_standalone_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_standalone_name);
 
 	zval property_xmlStandalone_default_value;
 	ZVAL_UNDEF(&property_xmlStandalone_default_value);
-	zend_string *property_xmlStandalone_name = zend_string_init("xmlStandalone", sizeof("xmlStandalone") - 1, 1);
+	zend_string *property_xmlStandalone_name = zend_string_init("xmlStandalone", strlen("xmlStandalone"), 1);
 	zend_declare_typed_property(class_entry, property_xmlStandalone_name, &property_xmlStandalone_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_xmlStandalone_name);
 
 	zval property_version_default_value;
 	ZVAL_UNDEF(&property_version_default_value);
-	zend_string *property_version_name = zend_string_init("version", sizeof("version") - 1, 1);
+	zend_string *property_version_name = zend_string_init("version", strlen("version"), 1);
 	zend_declare_typed_property(class_entry, property_version_name, &property_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_version_name);
 
 	zval property_xmlVersion_default_value;
 	ZVAL_UNDEF(&property_xmlVersion_default_value);
-	zend_string *property_xmlVersion_name = zend_string_init("xmlVersion", sizeof("xmlVersion") - 1, 1);
+	zend_string *property_xmlVersion_name = zend_string_init("xmlVersion", strlen("xmlVersion"), 1);
 	zend_declare_typed_property(class_entry, property_xmlVersion_name, &property_xmlVersion_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_xmlVersion_name);
 
 	zval property_strictErrorChecking_default_value;
 	ZVAL_UNDEF(&property_strictErrorChecking_default_value);
-	zend_string *property_strictErrorChecking_name = zend_string_init("strictErrorChecking", sizeof("strictErrorChecking") - 1, 1);
+	zend_string *property_strictErrorChecking_name = zend_string_init("strictErrorChecking", strlen("strictErrorChecking"), 1);
 	zend_declare_typed_property(class_entry, property_strictErrorChecking_name, &property_strictErrorChecking_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_strictErrorChecking_name);
 
 	zval property_documentURI_default_value;
 	ZVAL_UNDEF(&property_documentURI_default_value);
-	zend_string *property_documentURI_name = zend_string_init("documentURI", sizeof("documentURI") - 1, 1);
+	zend_string *property_documentURI_name = zend_string_init("documentURI", strlen("documentURI"), 1);
 	zend_declare_typed_property(class_entry, property_documentURI_name, &property_documentURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_documentURI_name);
 
 	zval property_config_default_value;
 	ZVAL_NULL(&property_config_default_value);
-	zend_string *property_config_name = zend_string_init("config", sizeof("config") - 1, 1);
+	zend_string *property_config_name = zend_string_init("config", strlen("config"), 1);
 	zend_declare_typed_property(class_entry, property_config_name, &property_config_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_config_name);
 
 	zval property_formatOutput_default_value;
 	ZVAL_UNDEF(&property_formatOutput_default_value);
-	zend_string *property_formatOutput_name = zend_string_init("formatOutput", sizeof("formatOutput") - 1, 1);
+	zend_string *property_formatOutput_name = zend_string_init("formatOutput", strlen("formatOutput"), 1);
 	zend_declare_typed_property(class_entry, property_formatOutput_name, &property_formatOutput_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_formatOutput_name);
 
 	zval property_validateOnParse_default_value;
 	ZVAL_UNDEF(&property_validateOnParse_default_value);
-	zend_string *property_validateOnParse_name = zend_string_init("validateOnParse", sizeof("validateOnParse") - 1, 1);
+	zend_string *property_validateOnParse_name = zend_string_init("validateOnParse", strlen("validateOnParse"), 1);
 	zend_declare_typed_property(class_entry, property_validateOnParse_name, &property_validateOnParse_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_validateOnParse_name);
 
 	zval property_resolveExternals_default_value;
 	ZVAL_UNDEF(&property_resolveExternals_default_value);
-	zend_string *property_resolveExternals_name = zend_string_init("resolveExternals", sizeof("resolveExternals") - 1, 1);
+	zend_string *property_resolveExternals_name = zend_string_init("resolveExternals", strlen("resolveExternals"), 1);
 	zend_declare_typed_property(class_entry, property_resolveExternals_name, &property_resolveExternals_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_resolveExternals_name);
 
 	zval property_preserveWhiteSpace_default_value;
 	ZVAL_UNDEF(&property_preserveWhiteSpace_default_value);
-	zend_string *property_preserveWhiteSpace_name = zend_string_init("preserveWhiteSpace", sizeof("preserveWhiteSpace") - 1, 1);
+	zend_string *property_preserveWhiteSpace_name = zend_string_init("preserveWhiteSpace", strlen("preserveWhiteSpace"), 1);
 	zend_declare_typed_property(class_entry, property_preserveWhiteSpace_name, &property_preserveWhiteSpace_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_preserveWhiteSpace_name);
 
 	zval property_recover_default_value;
 	ZVAL_UNDEF(&property_recover_default_value);
-	zend_string *property_recover_name = zend_string_init("recover", sizeof("recover") - 1, 1);
+	zend_string *property_recover_name = zend_string_init("recover", strlen("recover"), 1);
 	zend_declare_typed_property(class_entry, property_recover_name, &property_recover_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_recover_name);
 
 	zval property_substituteEntities_default_value;
 	ZVAL_UNDEF(&property_substituteEntities_default_value);
-	zend_string *property_substituteEntities_name = zend_string_init("substituteEntities", sizeof("substituteEntities") - 1, 1);
+	zend_string *property_substituteEntities_name = zend_string_init("substituteEntities", strlen("substituteEntities"), 1);
 	zend_declare_typed_property(class_entry, property_substituteEntities_name, &property_substituteEntities_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_substituteEntities_name);
 
-	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_firstElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_firstElementChild_default_value;
 	ZVAL_UNDEF(&property_firstElementChild_default_value);
-	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", sizeof("firstElementChild") - 1, 1);
+	zend_string *property_firstElementChild_name = zend_string_init("firstElementChild", strlen("firstElementChild"), 1);
 	zend_declare_typed_property(class_entry, property_firstElementChild_name, &property_firstElementChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_firstElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_firstElementChild_name);
 
-	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", sizeof("DOMElement")-1, 1);
+	zend_string *property_lastElementChild_class_DOMElement = zend_string_init("DOMElement", strlen("DOMElement"), 1);
 	zval property_lastElementChild_default_value;
 	ZVAL_UNDEF(&property_lastElementChild_default_value);
-	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", sizeof("lastElementChild") - 1, 1);
+	zend_string *property_lastElementChild_name = zend_string_init("lastElementChild", strlen("lastElementChild"), 1);
 	zend_declare_typed_property(class_entry, property_lastElementChild_name, &property_lastElementChild_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_lastElementChild_class_DOMElement, 0, MAY_BE_NULL));
 	zend_string_release(property_lastElementChild_name);
 
 	zval property_childElementCount_default_value;
 	ZVAL_UNDEF(&property_childElementCount_default_value);
-	zend_string *property_childElementCount_name = zend_string_init("childElementCount", sizeof("childElementCount") - 1, 1);
+	zend_string *property_childElementCount_name = zend_string_init("childElementCount", strlen("childElementCount"), 1);
 	zend_declare_typed_property(class_entry, property_childElementCount_name, &property_childElementCount_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_childElementCount_name);
 
@@ -1510,7 +1510,7 @@ static zend_class_entry *register_class_DOMException(zend_class_entry *class_ent
 
 	zval property_code_default_value;
 	ZVAL_LONG(&property_code_default_value, 0);
-	zend_string *property_code_name = zend_string_init("code", sizeof("code") - 1, 1);
+	zend_string *property_code_name = zend_string_init("code", strlen("code"), 1);
 	zend_declare_property_ex(class_entry, property_code_name, &property_code_default_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(property_code_name);
 
@@ -1526,7 +1526,7 @@ static zend_class_entry *register_class_DOMText(zend_class_entry *class_entry_DO
 
 	zval property_wholeText_default_value;
 	ZVAL_UNDEF(&property_wholeText_default_value);
-	zend_string *property_wholeText_name = zend_string_init("wholeText", sizeof("wholeText") - 1, 1);
+	zend_string *property_wholeText_name = zend_string_init("wholeText", strlen("wholeText"), 1);
 	zend_declare_typed_property(class_entry, property_wholeText_name, &property_wholeText_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_wholeText_name);
 
@@ -1543,7 +1543,7 @@ static zend_class_entry *register_class_DOMNamedNodeMap(zend_class_entry *class_
 
 	zval property_length_default_value;
 	ZVAL_UNDEF(&property_length_default_value);
-	zend_string *property_length_name = zend_string_init("length", sizeof("length") - 1, 1);
+	zend_string *property_length_name = zend_string_init("length", strlen("length"), 1);
 	zend_declare_typed_property(class_entry, property_length_name, &property_length_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_length_name);
 
@@ -1559,37 +1559,37 @@ static zend_class_entry *register_class_DOMEntity(zend_class_entry *class_entry_
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_systemId_name);
 
 	zval property_notationName_default_value;
 	ZVAL_UNDEF(&property_notationName_default_value);
-	zend_string *property_notationName_name = zend_string_init("notationName", sizeof("notationName") - 1, 1);
+	zend_string *property_notationName_name = zend_string_init("notationName", strlen("notationName"), 1);
 	zend_declare_typed_property(class_entry, property_notationName_name, &property_notationName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_notationName_name);
 
 	zval property_actualEncoding_default_value;
 	ZVAL_NULL(&property_actualEncoding_default_value);
-	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", sizeof("actualEncoding") - 1, 1);
+	zend_string *property_actualEncoding_name = zend_string_init("actualEncoding", strlen("actualEncoding"), 1);
 	zend_declare_typed_property(class_entry, property_actualEncoding_name, &property_actualEncoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_actualEncoding_name);
 
 	zval property_encoding_default_value;
 	ZVAL_NULL(&property_encoding_default_value);
-	zend_string *property_encoding_name = zend_string_init("encoding", sizeof("encoding") - 1, 1);
+	zend_string *property_encoding_name = zend_string_init("encoding", strlen("encoding"), 1);
 	zend_declare_typed_property(class_entry, property_encoding_name, &property_encoding_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_encoding_name);
 
 	zval property_version_default_value;
 	ZVAL_NULL(&property_version_default_value);
-	zend_string *property_version_name = zend_string_init("version", sizeof("version") - 1, 1);
+	zend_string *property_version_name = zend_string_init("version", strlen("version"), 1);
 	zend_declare_typed_property(class_entry, property_version_name, &property_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_version_name);
 
@@ -1615,13 +1615,13 @@ static zend_class_entry *register_class_DOMNotation(zend_class_entry *class_entr
 
 	zval property_publicId_default_value;
 	ZVAL_UNDEF(&property_publicId_default_value);
-	zend_string *property_publicId_name = zend_string_init("publicId", sizeof("publicId") - 1, 1);
+	zend_string *property_publicId_name = zend_string_init("publicId", strlen("publicId"), 1);
 	zend_declare_typed_property(class_entry, property_publicId_name, &property_publicId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_publicId_name);
 
 	zval property_systemId_default_value;
 	ZVAL_UNDEF(&property_systemId_default_value);
-	zend_string *property_systemId_name = zend_string_init("systemId", sizeof("systemId") - 1, 1);
+	zend_string *property_systemId_name = zend_string_init("systemId", strlen("systemId"), 1);
 	zend_declare_typed_property(class_entry, property_systemId_name, &property_systemId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_systemId_name);
 
@@ -1637,13 +1637,13 @@ static zend_class_entry *register_class_DOMProcessingInstruction(zend_class_entr
 
 	zval property_target_default_value;
 	ZVAL_UNDEF(&property_target_default_value);
-	zend_string *property_target_name = zend_string_init("target", sizeof("target") - 1, 1);
+	zend_string *property_target_name = zend_string_init("target", strlen("target"), 1);
 	zend_declare_typed_property(class_entry, property_target_name, &property_target_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_target_name);
 
 	zval property_data_default_value;
 	ZVAL_UNDEF(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_data_name);
 
@@ -1658,16 +1658,16 @@ static zend_class_entry *register_class_DOMXPath(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
-	zend_string *property_document_class_DOMDocument = zend_string_init("DOMDocument", sizeof("DOMDocument")-1, 1);
+	zend_string *property_document_class_DOMDocument = zend_string_init("DOMDocument", strlen("DOMDocument"), 1);
 	zval property_document_default_value;
 	ZVAL_UNDEF(&property_document_default_value);
-	zend_string *property_document_name = zend_string_init("document", sizeof("document") - 1, 1);
+	zend_string *property_document_name = zend_string_init("document", strlen("document"), 1);
 	zend_declare_typed_property(class_entry, property_document_name, &property_document_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_document_class_DOMDocument, 0, 0));
 	zend_string_release(property_document_name);
 
 	zval property_registerNodeNamespaces_default_value;
 	ZVAL_UNDEF(&property_registerNodeNamespaces_default_value);
-	zend_string *property_registerNodeNamespaces_name = zend_string_init("registerNodeNamespaces", sizeof("registerNodeNamespaces") - 1, 1);
+	zend_string *property_registerNodeNamespaces_name = zend_string_init("registerNodeNamespaces", strlen("registerNodeNamespaces"), 1);
 	zend_declare_typed_property(class_entry, property_registerNodeNamespaces_name, &property_registerNodeNamespaces_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_registerNodeNamespaces_name);
 

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -71,7 +71,7 @@ PHP_MINFO_FUNCTION(exif)
 	php_info_print_table_row(2, "Supported EXIF Version", "0220");
 	php_info_print_table_row(2, "Supported filetypes", "JPEG, TIFF");
 
-	if (zend_hash_str_exists(&module_registry, "mbstring", sizeof("mbstring")-1)) {
+	if (zend_hash_str_exists(&module_registry, "mbstring", strlen("mbstring"))) {
 		php_info_print_table_row(2, "Multibyte decoding support using mbstring", "enabled");
 	} else {
 		php_info_print_table_row(2, "Multibyte decoding support using mbstring", "disabled");
@@ -163,7 +163,7 @@ static PHP_GINIT_FUNCTION(exif)
 PHP_MINIT_FUNCTION(exif)
 {
 	REGISTER_INI_ENTRIES();
-	if (zend_hash_str_exists(&module_registry, "mbstring", sizeof("mbstring")-1)) {
+	if (zend_hash_str_exists(&module_registry, "mbstring", strlen("mbstring"))) {
 		REGISTER_LONG_CONSTANT("EXIF_USE_MBSTRING", 1, CONST_CS | CONST_PERSISTENT);
 	} else {
 		REGISTER_LONG_CONSTANT("EXIF_USE_MBSTRING", 0, CONST_CS | CONST_PERSISTENT);

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -1455,7 +1455,7 @@ static bool zend_ffi_ctype_name(zend_ffi_ctype_name_buf *buf, const zend_ffi_typ
 				if (type->enumeration.tag_name) {
 					zend_ffi_ctype_name_prepend(buf, ZSTR_VAL(type->enumeration.tag_name), ZSTR_LEN(type->enumeration.tag_name));
 				} else {
-					zend_ffi_ctype_name_prepend(buf, "<anonymous>", sizeof("<anonymous>")-1);
+					zend_ffi_ctype_name_prepend(buf, "<anonymous>", strlen("<anonymous>"));
 				}
 				name = "enum ";
 				break;
@@ -1519,14 +1519,14 @@ static bool zend_ffi_ctype_name(zend_ffi_ctype_name_buf *buf, const zend_ffi_typ
 					if (type->record.tag_name) {
 						zend_ffi_ctype_name_prepend(buf, ZSTR_VAL(type->record.tag_name), ZSTR_LEN(type->record.tag_name));
 					} else {
-						zend_ffi_ctype_name_prepend(buf, "<anonymous>", sizeof("<anonymous>")-1);
+						zend_ffi_ctype_name_prepend(buf, "<anonymous>", strlen("<anonymous>"));
 					}
 					name = "union ";
 				} else {
 					if (type->record.tag_name) {
 						zend_ffi_ctype_name_prepend(buf, ZSTR_VAL(type->record.tag_name), ZSTR_LEN(type->record.tag_name));
 					} else {
-						zend_ffi_ctype_name_prepend(buf, "<anonymous>", sizeof("<anonymous>")-1);
+						zend_ffi_ctype_name_prepend(buf, "<anonymous>", strlen("<anonymous>"));
 					}
 					name = "struct ";
 				}
@@ -1964,7 +1964,7 @@ static HashTable *zend_ffi_cdata_get_debug_info(zend_object *obj, int *is_temp) 
 		case ZEND_FFI_TYPE_SINT64:
 			zend_ffi_cdata_to_zval(cdata, ptr, type, BP_VAR_R, &tmp, ZEND_FFI_FLAG_CONST, 0, 0);
 			ht = zend_new_array(1);
-			zend_hash_str_add(ht, "cdata", sizeof("cdata")-1, &tmp);
+			zend_hash_str_add(ht, "cdata", strlen("cdata"), &tmp);
 			*is_temp = 1;
 			return ht;
 			break;
@@ -2760,18 +2760,18 @@ static zend_function *zend_ffi_get_func(zend_object **obj, zend_string *name, co
 	zend_function   *func;
 	zend_ffi_type   *type;
 
-	if (ZSTR_LEN(name) == sizeof("new") -1
+	if (ZSTR_LEN(name) == strlen("new")
 	 && (ZSTR_VAL(name)[0] == 'n' || ZSTR_VAL(name)[0] == 'N')
 	 && (ZSTR_VAL(name)[1] == 'e' || ZSTR_VAL(name)[1] == 'E')
 	 && (ZSTR_VAL(name)[2] == 'w' || ZSTR_VAL(name)[2] == 'W')) {
 		return (zend_function*)&zend_ffi_new_fn;
-	} else if (ZSTR_LEN(name) == sizeof("cast") -1
+	} else if (ZSTR_LEN(name) == strlen("cast")
 	 && (ZSTR_VAL(name)[0] == 'c' || ZSTR_VAL(name)[0] == 'C')
 	 && (ZSTR_VAL(name)[1] == 'a' || ZSTR_VAL(name)[1] == 'A')
 	 && (ZSTR_VAL(name)[2] == 's' || ZSTR_VAL(name)[2] == 'S')
 	 && (ZSTR_VAL(name)[3] == 't' || ZSTR_VAL(name)[3] == 'T')) {
 		return (zend_function*)&zend_ffi_cast_fn;
-	} else if (ZSTR_LEN(name) == sizeof("type") -1
+	} else if (ZSTR_LEN(name) == strlen("type")
 	 && (ZSTR_VAL(name)[0] == 't' || ZSTR_VAL(name)[0] == 'T')
 	 && (ZSTR_VAL(name)[1] == 'y' || ZSTR_VAL(name)[1] == 'Y')
 	 && (ZSTR_VAL(name)[2] == 'p' || ZSTR_VAL(name)[2] == 'P')
@@ -4791,9 +4791,9 @@ static char *zend_ffi_parse_directives(const char *filename, char *code_pos, cha
 	*scope_name = NULL;
 	*lib = NULL;
 	while (*code_pos == '#') {
-		if (strncmp(code_pos, "#define FFI_SCOPE", sizeof("#define FFI_SCOPE") - 1) == 0
-		 && (code_pos[sizeof("#define FFI_SCOPE") - 1] == ' '
-		  || code_pos[sizeof("#define FFI_SCOPE") - 1] == '\t')) {
+		if (strncmp(code_pos, "#define FFI_SCOPE", strlen("#define FFI_SCOPE")) == 0
+		 && (code_pos[strlen("#define FFI_SCOPE")] == ' '
+		  || code_pos[strlen("#define FFI_SCOPE")] == '\t')) {
 			p = code_pos + sizeof("#define FFI_SCOPE");
 			while (*p == ' ' || *p == '\t') {
 				p++;
@@ -4838,9 +4838,9 @@ static char *zend_ffi_parse_directives(const char *filename, char *code_pos, cha
 				p++;
 			}
 			code_pos = p;
-		} else if (strncmp(code_pos, "#define FFI_LIB", sizeof("#define FFI_LIB") - 1) == 0
-		 && (code_pos[sizeof("#define FFI_LIB") - 1] == ' '
-		  || code_pos[sizeof("#define FFI_LIB") - 1] == '\t')) {
+		} else if (strncmp(code_pos, "#define FFI_LIB", strlen("#define FFI_LIB")) == 0
+		 && (code_pos[strlen("#define FFI_LIB")] == ' '
+		  || code_pos[strlen("#define FFI_LIB")] == '\t')) {
 			p = code_pos + sizeof("#define FFI_LIB");
 			while (*p == ' ' || *p == '\t') {
 				p++;
@@ -5227,11 +5227,11 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_ce = register_class_FFI();
 	zend_ffi_ce->create_object = zend_ffi_new;
 
-	memcpy(&zend_ffi_new_fn, zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "new", sizeof("new")-1), sizeof(zend_internal_function));
+	memcpy(&zend_ffi_new_fn, zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "new", strlen("new")), sizeof(zend_internal_function));
 	zend_ffi_new_fn.fn_flags &= ~ZEND_ACC_STATIC;
-	memcpy(&zend_ffi_cast_fn, zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "cast", sizeof("cast")-1), sizeof(zend_internal_function));
+	memcpy(&zend_ffi_cast_fn, zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "cast", strlen("cast")), sizeof(zend_internal_function));
 	zend_ffi_cast_fn.fn_flags &= ~ZEND_ACC_STATIC;
-	memcpy(&zend_ffi_type_fn, zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "type", sizeof("type")-1), sizeof(zend_internal_function));
+	memcpy(&zend_ffi_type_fn, zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "type", strlen("type")), sizeof(zend_internal_function));
 	zend_ffi_type_fn.fn_flags &= ~ZEND_ACC_STATIC;
 
 	memcpy(&zend_ffi_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
@@ -5255,7 +5255,7 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_handlers.get_properties       = zend_fake_get_properties;
 	zend_ffi_handlers.get_gc               = zend_fake_get_gc;
 
-	zend_declare_class_constant_long(zend_ffi_ce, "__BIGGEST_ALIGNMENT__", sizeof("__BIGGEST_ALIGNMENT__")-1, __BIGGEST_ALIGNMENT__);
+	zend_declare_class_constant_long(zend_ffi_ce, "__BIGGEST_ALIGNMENT__", strlen("__BIGGEST_ALIGNMENT__"), __BIGGEST_ALIGNMENT__);
 
 	zend_ffi_cdata_ce = register_class_FFI_CData();
 	zend_ffi_cdata_ce->create_object = zend_ffi_cdata_new;
@@ -6063,37 +6063,37 @@ void zend_ffi_add_bit_field(zend_ffi_dcl *struct_dcl, const char *name, size_t n
 
 	if (field_type->kind < ZEND_FFI_TYPE_UINT8 || field_type->kind > ZEND_FFI_TYPE_BOOL) {
 		zend_ffi_cleanup_dcl(field_dcl);
-		zend_ffi_parser_error("Wrong type of bit field \"%.*s\" at line %d", name ? name_len : sizeof("<anonymous>")-1, name ? name : "<anonymous>", FFI_G(line));
+		zend_ffi_parser_error("Wrong type of bit field \"%.*s\" at line %d", name ? name_len : strlen("<anonymous>"), name ? name : "<anonymous>", FFI_G(line));
 	}
 
 	if (bits->kind == ZEND_FFI_VAL_INT32 || bits->kind == ZEND_FFI_VAL_INT64) {
 		if (bits->i64 < 0) {
 			zend_ffi_cleanup_dcl(field_dcl);
-			zend_ffi_parser_error("Negative width in bit-field \"%.*s\" at line %d", name ? name_len : sizeof("<anonymous>")-1, name ? name : "<anonymous>", FFI_G(line));
+			zend_ffi_parser_error("Negative width in bit-field \"%.*s\" at line %d", name ? name_len : strlen("<anonymous>"), name ? name : "<anonymous>", FFI_G(line));
 		} else if (bits->i64 == 0) {
 			zend_ffi_cleanup_dcl(field_dcl);
 			if (name) {
-				zend_ffi_parser_error("Zero width in bit-field \"%.*s\" at line %d", name ? name_len : sizeof("<anonymous>")-1, name ? name : "<anonymous>", FFI_G(line));
+				zend_ffi_parser_error("Zero width in bit-field \"%.*s\" at line %d", name ? name_len : strlen("<anonymous>"), name ? name : "<anonymous>", FFI_G(line));
 			}
 			return;
 		} else if (bits->i64 > field_type->size * 8) {
 			zend_ffi_cleanup_dcl(field_dcl);
-			zend_ffi_parser_error("Width of \"%.*s\" exceeds its type at line %d", name ? name_len : sizeof("<anonymous>")-1, name ? name : "<anonymous>", FFI_G(line));
+			zend_ffi_parser_error("Width of \"%.*s\" exceeds its type at line %d", name ? name_len : strlen("<anonymous>"), name ? name : "<anonymous>", FFI_G(line));
 		}
 	} else if (bits->kind == ZEND_FFI_VAL_UINT32 || bits->kind == ZEND_FFI_VAL_UINT64) {
 		if (bits->u64 == 0) {
 			zend_ffi_cleanup_dcl(field_dcl);
 			if (name) {
-				zend_ffi_parser_error("Zero width in bit-field \"%.*s\" at line %d", name ? name_len : sizeof("<anonymous>")-1, name ? name : "<anonymous>", FFI_G(line));
+				zend_ffi_parser_error("Zero width in bit-field \"%.*s\" at line %d", name ? name_len : strlen("<anonymous>"), name ? name : "<anonymous>", FFI_G(line));
 			}
 			return;
 		} else if (bits->u64 > field_type->size * 8) {
 			zend_ffi_cleanup_dcl(field_dcl);
-			zend_ffi_parser_error("Width of \"%.*s\" exceeds its type at line %d", name ? name_len : sizeof("<anonymous>")-1, name ? name : "<anonymous>", FFI_G(line));
+			zend_ffi_parser_error("Width of \"%.*s\" exceeds its type at line %d", name ? name_len : strlen("<anonymous>"), name ? name : "<anonymous>", FFI_G(line));
 		}
 	} else {
 		zend_ffi_cleanup_dcl(field_dcl);
-		zend_ffi_parser_error("Bit field \"%.*s\" width not an integer constant at line %d", name ? name_len : sizeof("<anonymous>")-1, name ? name : "<anonymous>", FFI_G(line));
+		zend_ffi_parser_error("Bit field \"%.*s\" width not an integer constant at line %d", name ? name_len : strlen("<anonymous>"), name ? name : "<anonymous>", FFI_G(line));
 	}
 
 	field = pemalloc(sizeof(zend_ffi_field), FFI_G(persistent));
@@ -6839,7 +6839,7 @@ void zend_ffi_add_attribute_value(zend_ffi_dcl *dcl, const char *name, size_t na
 
 void zend_ffi_add_msvc_attribute_value(zend_ffi_dcl *dcl, const char *name, size_t name_len, zend_ffi_val *val) /* {{{ */
 {
-	if (name_len == sizeof("align")-1 && memcmp(name, "align", sizeof("align")-1) == 0) {
+	if (name_len == strlen("align") && memcmp(name, "align", strlen("align")) == 0) {
 		if ((val->kind == ZEND_FFI_VAL_INT32 || val->kind == ZEND_FFI_VAL_UINT32 || val->kind == ZEND_FFI_VAL_INT64 || val->kind == ZEND_FFI_VAL_UINT64)
 		 && val->i64 > 0 && val->i64 <= 0x80000000 && (val->i64 & (val->i64 - 1)) == 0) {
 			dcl->align = val->i64;

--- a/ext/fileinfo/libmagic.patch
+++ b/ext/fileinfo/libmagic.patch
@@ -3229,7 +3229,7 @@ diff -ur libmagic.orig/softmagic.c libmagic/softmagic.c
 -	rc = file_regcomp(&rx, "%[-0-9\\.]*s", REG_EXTENDED|REG_NOSUB);
 -	if (rc) {
 -		file_regerror(&rx, rc, ms);
-+	pattern = zend_string_init("~%[-0-9\\.]*s~", sizeof("~%[-0-9\\.]*s~") - 1, 0);
++	pattern = zend_string_init("~%[-0-9\\.]*s~", strlen("~%[-0-9\\.]*s~"), 0);
 +	if ((pce = pcre_get_compiled_regex_cache_ex(pattern, 0)) == NULL) {
 +		rv = -1;
  	} else {

--- a/ext/fileinfo/libmagic/softmagic.c
+++ b/ext/fileinfo/libmagic/softmagic.c
@@ -485,7 +485,7 @@ check_fmt(struct magic_set *ms, const char *fmt)
 	if (strchr(fmt, '%') == NULL)
 		return 0;
 
-	pattern = zend_string_init("~%[-0-9\\.]*s~", sizeof("~%[-0-9\\.]*s~") - 1, 0);
+	pattern = zend_string_init("~%[-0-9\\.]*s~", strlen("~%[-0-9\\.]*s~"), 0);
 	if ((pce = pcre_get_compiled_regex_cache_ex(pattern, 0)) == NULL) {
 		rv = -1;
 	} else {

--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -350,7 +350,7 @@ handle_default:
 		((flags & FILTER_NULL_ON_FAILURE && Z_TYPE_P(value) == IS_NULL) ||
 		(!(flags & FILTER_NULL_ON_FAILURE) && Z_TYPE_P(value) == IS_FALSE))) {
 		zval *tmp;
-		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(options), "default", sizeof("default") - 1)) != NULL) {
+		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(options), "default", strlen("default"))) != NULL) {
 			ZVAL_COPY(value, tmp);
 		}
 	}
@@ -547,11 +547,11 @@ static void php_filter_call(
 			filter = filter_args_long;
 		}
 	} else {
-		if ((option = zend_hash_str_find(filter_args_ht, "filter", sizeof("filter") - 1)) != NULL) {
+		if ((option = zend_hash_str_find(filter_args_ht, "filter", strlen("filter"))) != NULL) {
 			filter = zval_get_long(option);
 		}
 
-		if ((option = zend_hash_str_find(filter_args_ht, "flags", sizeof("flags") - 1)) != NULL) {
+		if ((option = zend_hash_str_find(filter_args_ht, "flags", strlen("flags"))) != NULL) {
 			filter_flags = zval_get_long(option);
 
 			if (!(filter_flags & FILTER_REQUIRE_ARRAY ||  filter_flags & FILTER_FORCE_ARRAY)) {
@@ -559,7 +559,7 @@ static void php_filter_call(
 			}
 		}
 
-		if ((option = zend_hash_str_find_deref(filter_args_ht, "options", sizeof("options") - 1)) != NULL) {
+		if ((option = zend_hash_str_find_deref(filter_args_ht, "options", strlen("options"))) != NULL) {
 			if (filter != FILTER_CALLBACK) {
 				if (Z_TYPE_P(option) == IS_ARRAY) {
 					options = option;
@@ -678,13 +678,13 @@ PHP_FUNCTION(filter_input)
 		if (!filter_args_ht) {
 			filter_flags = filter_args_long;
 		} else {
-			if ((option = zend_hash_str_find(filter_args_ht, "flags", sizeof("flags") - 1)) != NULL) {
+			if ((option = zend_hash_str_find(filter_args_ht, "flags", strlen("flags"))) != NULL) {
 				filter_flags = zval_get_long(option);
 			}
 
-			if ((opt = zend_hash_str_find_deref(filter_args_ht, "options", sizeof("options") - 1)) != NULL &&
+			if ((opt = zend_hash_str_find_deref(filter_args_ht, "options", strlen("options"))) != NULL &&
 				Z_TYPE_P(opt) == IS_ARRAY &&
-				(def = zend_hash_str_find_deref(Z_ARRVAL_P(opt), "default", sizeof("default") - 1)) != NULL
+				(def = zend_hash_str_find_deref(Z_ARRVAL_P(opt), "default", strlen("default"))) != NULL
 			) {
 				ZVAL_COPY(return_value, def);
 				return;
@@ -766,7 +766,7 @@ PHP_FUNCTION(filter_input_array)
 		zval *option;
 		if (op_long) {
 			filter_flags = op_long;
-		} else if (op_ht && (option = zend_hash_str_find(op_ht, "flags", sizeof("flags") - 1)) != NULL) {
+		} else if (op_ht && (option = zend_hash_str_find(op_ht, "flags", strlen("flags"))) != NULL) {
 			filter_flags = zval_get_long(option);
 		}
 

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -213,7 +213,7 @@ ftp_quit(ftpbuf_t *ftp)
 		return 0;
 	}
 
-	if (!ftp_putcmd(ftp, "QUIT", sizeof("QUIT")-1, NULL, (size_t) 0)) {
+	if (!ftp_putcmd(ftp, "QUIT", strlen("QUIT"), NULL, (size_t) 0)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 221) {
@@ -245,7 +245,7 @@ ftp_login(ftpbuf_t *ftp, const char *user, const size_t user_len, const char *pa
 
 #ifdef HAVE_FTP_SSL
 	if (ftp->use_ssl && !ftp->ssl_active) {
-		if (!ftp_putcmd(ftp, "AUTH", sizeof("AUTH")-1, "TLS", sizeof("TLS")-1)) {
+		if (!ftp_putcmd(ftp, "AUTH", strlen("AUTH"), "TLS", strlen("TLS"))) {
 			return 0;
 		}
 		if (!ftp_getresp(ftp)) {
@@ -253,7 +253,7 @@ ftp_login(ftpbuf_t *ftp, const char *user, const size_t user_len, const char *pa
 		}
 
 		if (ftp->resp != 234) {
-			if (!ftp_putcmd(ftp, "AUTH", sizeof("AUTH")-1, "SSL", sizeof("SSL")-1)) {
+			if (!ftp_putcmd(ftp, "AUTH", strlen("AUTH"), "SSL", strlen("SSL"))) {
 				return 0;
 			}
 			if (!ftp_getresp(ftp)) {
@@ -335,7 +335,7 @@ ftp_login(ftpbuf_t *ftp, const char *user, const size_t user_len, const char *pa
 		if (!ftp->old_ssl) {
 
 			/* set protection buffersize to zero */
-			if (!ftp_putcmd(ftp, "PBSZ", sizeof("PBSZ")-1, "0", sizeof("0")-1)) {
+			if (!ftp_putcmd(ftp, "PBSZ", strlen("PBSZ"), "0", strlen("0"))) {
 				return 0;
 			}
 			if (!ftp_getresp(ftp)) {
@@ -343,7 +343,7 @@ ftp_login(ftpbuf_t *ftp, const char *user, const size_t user_len, const char *pa
 			}
 
 			/* enable data conn encryption */
-			if (!ftp_putcmd(ftp, "PROT", sizeof("PROT")-1, "P", sizeof("P")-1)) {
+			if (!ftp_putcmd(ftp, "PROT", strlen("PROT"), "P", strlen("P"))) {
 				return 0;
 			}
 			if (!ftp_getresp(ftp)) {
@@ -355,7 +355,7 @@ ftp_login(ftpbuf_t *ftp, const char *user, const size_t user_len, const char *pa
 	}
 #endif
 
-	if (!ftp_putcmd(ftp, "USER", sizeof("USER")-1, user, user_len)) {
+	if (!ftp_putcmd(ftp, "USER", strlen("USER"), user, user_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp)) {
@@ -367,7 +367,7 @@ ftp_login(ftpbuf_t *ftp, const char *user, const size_t user_len, const char *pa
 	if (ftp->resp != 331) {
 		return 0;
 	}
-	if (!ftp_putcmd(ftp, "PASS", sizeof("PASS")-1, pass, pass_len)) {
+	if (!ftp_putcmd(ftp, "PASS", strlen("PASS"), pass, pass_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp)) {
@@ -389,7 +389,7 @@ ftp_reinit(ftpbuf_t *ftp)
 
 	ftp->nb = 0;
 
-	if (!ftp_putcmd(ftp, "REIN", sizeof("REIN")-1, NULL, (size_t) 0)) {
+	if (!ftp_putcmd(ftp, "REIN", strlen("REIN"), NULL, (size_t) 0)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 220) {
@@ -414,7 +414,7 @@ ftp_syst(ftpbuf_t *ftp)
 	if (ftp->syst) {
 		return ftp->syst;
 	}
-	if (!ftp_putcmd(ftp, "SYST", sizeof("SYST")-1, NULL, (size_t) 0)) {
+	if (!ftp_putcmd(ftp, "SYST", strlen("SYST"), NULL, (size_t) 0)) {
 		return NULL;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 215) {
@@ -449,7 +449,7 @@ ftp_pwd(ftpbuf_t *ftp)
 	if (ftp->pwd) {
 		return ftp->pwd;
 	}
-	if (!ftp_putcmd(ftp, "PWD", sizeof("PWD")-1, NULL, (size_t) 0)) {
+	if (!ftp_putcmd(ftp, "PWD", strlen("PWD"), NULL, (size_t) 0)) {
 		return NULL;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 257) {
@@ -475,7 +475,7 @@ ftp_exec(ftpbuf_t *ftp, const char *cmd, const size_t cmd_len)
 	if (ftp == NULL) {
 		return 0;
 	}
-	if (!ftp_putcmd(ftp, "SITE EXEC", sizeof("SITE EXEC")-1, cmd, cmd_len)) {
+	if (!ftp_putcmd(ftp, "SITE EXEC", strlen("SITE EXEC"), cmd, cmd_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 200) {
@@ -519,7 +519,7 @@ ftp_chdir(ftpbuf_t *ftp, const char *dir, const size_t dir_len)
 		ftp->pwd = NULL;
 	}
 
-	if (!ftp_putcmd(ftp, "CWD", sizeof("CWD")-1, dir, dir_len)) {
+	if (!ftp_putcmd(ftp, "CWD", strlen("CWD"), dir, dir_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 250) {
@@ -542,7 +542,7 @@ ftp_cdup(ftpbuf_t *ftp)
 		ftp->pwd = NULL;
 	}
 
-	if (!ftp_putcmd(ftp, "CDUP", sizeof("CDUP")-1, NULL, (size_t) 0)) {
+	if (!ftp_putcmd(ftp, "CDUP", strlen("CDUP"), NULL, (size_t) 0)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 250) {
@@ -562,7 +562,7 @@ ftp_mkdir(ftpbuf_t *ftp, const char *dir, const size_t dir_len)
 	if (ftp == NULL) {
 		return NULL;
 	}
-	if (!ftp_putcmd(ftp, "MKD", sizeof("MKD")-1, dir, dir_len)) {
+	if (!ftp_putcmd(ftp, "MKD", strlen("MKD"), dir, dir_len)) {
 		return NULL;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 257) {
@@ -590,7 +590,7 @@ ftp_rmdir(ftpbuf_t *ftp, const char *dir, const size_t dir_len)
 	if (ftp == NULL) {
 		return 0;
 	}
-	if (!ftp_putcmd(ftp, "RMD", sizeof("RMD")-1, dir, dir_len)) {
+	if (!ftp_putcmd(ftp, "RMD", strlen("RMD"), dir, dir_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 250) {
@@ -617,7 +617,7 @@ ftp_chmod(ftpbuf_t *ftp, const int mode, const char *filename, const int filenam
 		return 0;
 	}
 
-	if (!ftp_putcmd(ftp, "SITE", sizeof("SITE")-1, buffer, buffer_len)) {
+	if (!ftp_putcmd(ftp, "SITE", strlen("SITE"), buffer, buffer_len)) {
 		efree(buffer);
 		return 0;
 	}
@@ -649,7 +649,7 @@ ftp_alloc(ftpbuf_t *ftp, const zend_long size, zend_string **response)
 		return 0;
 	}
 
-	if (!ftp_putcmd(ftp, "ALLO", sizeof("ALLO")-1, buffer, buffer_len)) {
+	if (!ftp_putcmd(ftp, "ALLO", strlen("ALLO"), buffer, buffer_len)) {
 		return 0;
 	}
 
@@ -673,7 +673,7 @@ ftp_alloc(ftpbuf_t *ftp, const zend_long size, zend_string **response)
 char**
 ftp_nlist(ftpbuf_t *ftp, const char *path, const size_t path_len)
 {
-	return ftp_genlist(ftp, "NLST", sizeof("NLST")-1, path, path_len);
+	return ftp_genlist(ftp, "NLST", strlen("NLST"), path, path_len);
 }
 /* }}} */
 
@@ -681,7 +681,7 @@ ftp_nlist(ftpbuf_t *ftp, const char *path, const size_t path_len)
 char**
 ftp_list(ftpbuf_t *ftp, const char *path, const size_t path_len, int recursive)
 {
-	return ftp_genlist(ftp, ((recursive) ? "LIST -R" : "LIST"), ((recursive) ? sizeof("LIST -R")-1 : sizeof("LIST")-1), path, path_len);
+	return ftp_genlist(ftp, ((recursive) ? "LIST -R" : "LIST"), ((recursive) ? strlen("LIST -R") : strlen("LIST")), path, path_len);
 }
 /* }}} */
 
@@ -689,7 +689,7 @@ ftp_list(ftpbuf_t *ftp, const char *path, const size_t path_len, int recursive)
 char**
 ftp_mlsd(ftpbuf_t *ftp, const char *path, const size_t path_len)
 {
-	return ftp_genlist(ftp, "MLSD", sizeof("MLSD")-1, path, path_len);
+	return ftp_genlist(ftp, "MLSD", strlen("MLSD"), path, path_len);
 }
 /* }}} */
 
@@ -708,7 +708,7 @@ ftp_mlsd_parse_line(HashTable *ht, const char *input) {
 
 	/* Extract pathname */
 	ZVAL_STRINGL(&zstr, sp + 1, end - sp - 1);
-	zend_hash_str_update(ht, "name", sizeof("name")-1, &zstr);
+	zend_hash_str_update(ht, "name", strlen("name"), &zstr);
 	end = sp;
 
 	while (input < end) {
@@ -756,7 +756,7 @@ ftp_type(ftpbuf_t *ftp, ftptype_t type)
 	} else {
 		return 0;
 	}
-	if (!ftp_putcmd(ftp, "TYPE", sizeof("TYPE")-1, typechar, 1)) {
+	if (!ftp_putcmd(ftp, "TYPE", strlen("TYPE"), typechar, 1)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 200) {
@@ -803,7 +803,7 @@ ftp_pasv(ftpbuf_t *ftp, int pasv)
 		char *endptr, delimiter;
 
 		/* try EPSV first */
-		if (!ftp_putcmd(ftp, "EPSV", sizeof("EPSV")-1, NULL, (size_t) 0)) {
+		if (!ftp_putcmd(ftp, "EPSV", strlen("EPSV"), NULL, (size_t) 0)) {
 			return 0;
 		}
 		if (!ftp_getresp(ftp)) {
@@ -834,7 +834,7 @@ ftp_pasv(ftpbuf_t *ftp, int pasv)
 	/* fall back to PASV */
 #endif
 
-	if (!ftp_putcmd(ftp, "PASV",  sizeof("PASV")-1, NULL, (size_t) 0)) {
+	if (!ftp_putcmd(ftp, "PASV",  strlen("PASV"), NULL, (size_t) 0)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 227) {
@@ -888,7 +888,7 @@ ftp_get(ftpbuf_t *ftp, php_stream *outstream, const char *path, const size_t pat
 		if (arg_len < 0) {
 			goto bail;
 		}
-		if (!ftp_putcmd(ftp, "REST", sizeof("REST")-1, arg, arg_len)) {
+		if (!ftp_putcmd(ftp, "REST", strlen("REST"), arg, arg_len)) {
 			goto bail;
 		}
 		if (!ftp_getresp(ftp) || (ftp->resp != 350)) {
@@ -896,7 +896,7 @@ ftp_get(ftpbuf_t *ftp, php_stream *outstream, const char *path, const size_t pat
 		}
 	}
 
-	if (!ftp_putcmd(ftp, "RETR", sizeof("RETR")-1, path, path_len)) {
+	if (!ftp_putcmd(ftp, "RETR", strlen("RETR"), path, path_len)) {
 		goto bail;
 	}
 	if (!ftp_getresp(ftp) || (ftp->resp != 150 && ftp->resp != 125)) {
@@ -983,7 +983,7 @@ ftp_put(ftpbuf_t *ftp, const char *path, const size_t path_len, php_stream *inst
 		if (arg_len < 0) {
 			goto bail;
 		}
-		if (!ftp_putcmd(ftp, "REST", sizeof("REST")-1, arg, arg_len)) {
+		if (!ftp_putcmd(ftp, "REST", strlen("REST"), arg, arg_len)) {
 			goto bail;
 		}
 		if (!ftp_getresp(ftp) || (ftp->resp != 350)) {
@@ -991,7 +991,7 @@ ftp_put(ftpbuf_t *ftp, const char *path, const size_t path_len, php_stream *inst
 		}
 	}
 
-	if (!ftp_putcmd(ftp, "STOR", sizeof("STOR")-1, path, path_len)) {
+	if (!ftp_putcmd(ftp, "STOR", strlen("STOR"), path, path_len)) {
 		goto bail;
 	}
 	if (!ftp_getresp(ftp) || (ftp->resp != 150 && ftp->resp != 125)) {
@@ -1058,7 +1058,7 @@ ftp_append(ftpbuf_t *ftp, const char *path, const size_t path_len, php_stream *i
 	}
 	ftp->data = data;
 
-	if (!ftp_putcmd(ftp, "APPE", sizeof("APPE")-1, path, path_len)) {
+	if (!ftp_putcmd(ftp, "APPE", strlen("APPE"), path, path_len)) {
 		goto bail;
 	}
 	if (!ftp_getresp(ftp) || (ftp->resp != 150 && ftp->resp != 125)) {
@@ -1114,7 +1114,7 @@ ftp_size(ftpbuf_t *ftp, const char *path, const size_t path_len)
 	if (!ftp_type(ftp, FTPTYPE_IMAGE)) {
 		return -1;
 	}
-	if (!ftp_putcmd(ftp, "SIZE", sizeof("SIZE")-1, path, path_len)) {
+	if (!ftp_putcmd(ftp, "SIZE", strlen("SIZE"), path, path_len)) {
 		return -1;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 213) {
@@ -1137,7 +1137,7 @@ ftp_mdtm(ftpbuf_t *ftp, const char *path, const size_t path_len)
 	if (ftp == NULL) {
 		return -1;
 	}
-	if (!ftp_putcmd(ftp, "MDTM", sizeof("MDTM")-1, path, path_len)) {
+	if (!ftp_putcmd(ftp, "MDTM", strlen("MDTM"), path, path_len)) {
 		return -1;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 213) {
@@ -1178,7 +1178,7 @@ ftp_delete(ftpbuf_t *ftp, const char *path, const size_t path_len)
 	if (ftp == NULL) {
 		return 0;
 	}
-	if (!ftp_putcmd(ftp, "DELE", sizeof("DELE")-1, path, path_len)) {
+	if (!ftp_putcmd(ftp, "DELE", strlen("DELE"), path, path_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 250) {
@@ -1196,13 +1196,13 @@ ftp_rename(ftpbuf_t *ftp, const char *src, const size_t src_len, const char *des
 	if (ftp == NULL) {
 		return 0;
 	}
-	if (!ftp_putcmd(ftp, "RNFR", sizeof("RNFR")-1, src, src_len)) {
+	if (!ftp_putcmd(ftp, "RNFR", strlen("RNFR"), src, src_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 350) {
 		return 0;
 	}
-	if (!ftp_putcmd(ftp, "RNTO", sizeof("RNTO")-1, dest, dest_len)) {
+	if (!ftp_putcmd(ftp, "RNTO", strlen("RNTO"), dest, dest_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 250) {
@@ -1219,7 +1219,7 @@ ftp_site(ftpbuf_t *ftp, const char *cmd, const size_t cmd_len)
 	if (ftp == NULL) {
 		return 0;
 	}
-	if (!ftp_putcmd(ftp, "SITE", sizeof("SITE")-1, cmd, cmd_len)) {
+	if (!ftp_putcmd(ftp, "SITE", strlen("SITE"), cmd, cmd_len)) {
 		return 0;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp < 200 || ftp->resp >= 300) {
@@ -1698,7 +1698,7 @@ ftp_getdata(ftpbuf_t *ftp)
 			goto bail;
 		}
 
-		if (!ftp_putcmd(ftp, "EPRT", sizeof("EPRT")-1, eprtarg, eprtarg_len)) {
+		if (!ftp_putcmd(ftp, "EPRT", strlen("EPRT"), eprtarg, eprtarg_len)) {
 			goto bail;
 		}
 
@@ -1719,7 +1719,7 @@ ftp_getdata(ftpbuf_t *ftp)
 	if (arg_len < 0) {
 		goto bail;
 	}
-	if (!ftp_putcmd(ftp, "PORT", sizeof("PORT")-1, arg, arg_len)) {
+	if (!ftp_putcmd(ftp, "PORT", strlen("PORT"), arg, arg_len)) {
 		goto bail;
 	}
 	if (!ftp_getresp(ftp) || ftp->resp != 200) {
@@ -2077,7 +2077,7 @@ ftp_nb_get(ftpbuf_t *ftp, php_stream *outstream, const char *path, const size_t 
 		if (arg_len < 0) {
 			goto bail;
 		}
-		if (!ftp_putcmd(ftp, "REST", sizeof("REST")-1, arg, arg_len)) {
+		if (!ftp_putcmd(ftp, "REST", strlen("REST"), arg, arg_len)) {
 			goto bail;
 		}
 		if (!ftp_getresp(ftp) || (ftp->resp != 350)) {
@@ -2085,7 +2085,7 @@ ftp_nb_get(ftpbuf_t *ftp, php_stream *outstream, const char *path, const size_t 
 		}
 	}
 
-	if (!ftp_putcmd(ftp, "RETR", sizeof("RETR")-1, path, path_len)) {
+	if (!ftp_putcmd(ftp, "RETR", strlen("RETR"), path, path_len)) {
 		goto bail;
 	}
 	if (!ftp_getresp(ftp) || (ftp->resp != 150 && ftp->resp != 125)) {
@@ -2193,7 +2193,7 @@ ftp_nb_put(ftpbuf_t *ftp, const char *path, const size_t path_len, php_stream *i
 		if (arg_len < 0) {
 			goto bail;
 		}
-		if (!ftp_putcmd(ftp, "REST", sizeof("REST")-1, arg, arg_len)) {
+		if (!ftp_putcmd(ftp, "REST", strlen("REST"), arg, arg_len)) {
 			goto bail;
 		}
 		if (!ftp_getresp(ftp) || (ftp->resp != 350)) {
@@ -2201,7 +2201,7 @@ ftp_nb_put(ftpbuf_t *ftp, const char *path, const size_t path_len, php_stream *i
 		}
 	}
 
-	if (!ftp_putcmd(ftp, "STOR", sizeof("STOR")-1, path, path_len)) {
+	if (!ftp_putcmd(ftp, "STOR", strlen("STOR"), path, path_len)) {
 		goto bail;
 	}
 	if (!ftp_getresp(ftp) || (ftp->resp != 150 && ftp->resp != 125)) {

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -3658,28 +3658,28 @@ PHP_FUNCTION(imagecrop)
 
 	im = php_gd_libgdimageptr_from_zval_p(IM);
 
-	if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "x", sizeof("x") -1)) != NULL) {
+	if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "x", strlen("x"))) != NULL) {
 		rect.x = zval_get_long(tmp);
 	} else {
 		zend_argument_value_error(2, "must have an \"x\" key");
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "y", sizeof("y") - 1)) != NULL) {
+	if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "y", strlen("y"))) != NULL) {
 		rect.y = zval_get_long(tmp);
 	} else {
 		zend_argument_value_error(2, "must have a \"y\" key");
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "width", sizeof("width") - 1)) != NULL) {
+	if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "width", strlen("width"))) != NULL) {
 		rect.width = zval_get_long(tmp);
 	} else {
 		zend_argument_value_error(2, "must have a \"width\" key");
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "height", sizeof("height") - 1)) != NULL) {
+	if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "height", strlen("height"))) != NULL) {
 		rect.height = zval_get_long(tmp);
 	} else {
 		zend_argument_value_error(2, "must have a \"height\" key");
@@ -3842,28 +3842,28 @@ PHP_FUNCTION(imageaffine)
 	}
 
 	if (z_rect != NULL) {
-		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "x", sizeof("x") - 1)) != NULL) {
+		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "x", strlen("x"))) != NULL) {
 			rect.x = zval_get_long(tmp);
 		} else {
 			zend_argument_value_error(3, "must have an \"x\" key");
 			RETURN_THROWS();
 		}
 
-		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "y", sizeof("y") - 1)) != NULL) {
+		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "y", strlen("y"))) != NULL) {
 			rect.y = zval_get_long(tmp);
 		} else {
 			zend_argument_value_error(3, "must have a \"y\" key");
 			RETURN_THROWS();
 		}
 
-		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "width", sizeof("width") - 1)) != NULL) {
+		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "width", strlen("width"))) != NULL) {
 			rect.width = zval_get_long(tmp);
 		} else {
 			zend_argument_value_error(3, "must have a \"width\" key");
 			RETURN_THROWS();
 		}
 
-		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "height", sizeof("height") - 1)) != NULL) {
+		if ((tmp = zend_hash_str_find(Z_ARRVAL_P(z_rect), "height", strlen("height"))) != NULL) {
 			rect.height = zval_get_long(tmp);
 		} else {
 			zend_argument_value_error(3, "must have a \"height\" key");
@@ -3906,14 +3906,14 @@ PHP_FUNCTION(imageaffinematrixget)
 				RETURN_THROWS();
 			}
 
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(options), "x", sizeof("x") - 1)) != NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(options), "x", strlen("x"))) != NULL) {
 				x = zval_get_double(tmp);
 			} else {
 				zend_argument_value_error(2, "must have an \"x\" key");
 				RETURN_THROWS();
 			}
 
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(options), "y", sizeof("y") - 1)) != NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(options), "y", strlen("y"))) != NULL) {
 				y = zval_get_double(tmp);
 			} else {
 				zend_argument_value_error(2, "must have a \"y\" key");

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -310,7 +310,7 @@ static HashTable *gmp_get_debug_info(zend_object *obj, int *is_temp) /* {{{ */
 	ht = zend_array_dup(props);
 
 	gmp_strval(&zv, gmpnum, 10);
-	zend_hash_str_update(ht, "num", sizeof("num")-1, &zv);
+	zend_hash_str_update(ht, "num", strlen("num"), &zv);
 
 	return ht;
 }

--- a/ext/hash/hash_murmur.c
+++ b/ext/hash/hash_murmur.c
@@ -39,7 +39,7 @@ const php_hash_ops php_hash_murmur3a_ops = {
 PHP_HASH_API void PHP_MURMUR3AInit(PHP_MURMUR3A_CTX *ctx, HashTable *args)
 {
 	if (args) {
-		zval *seed = zend_hash_str_find_deref(args, "seed", sizeof("seed") - 1);
+		zval *seed = zend_hash_str_find_deref(args, "seed", strlen("seed"));
 		/* This might be a bit too restrictive, but thinking that a seed might be set
 			once and for all, it should be done a clean way. */
 		if (seed && IS_LONG == Z_TYPE_P(seed)) {
@@ -96,7 +96,7 @@ const php_hash_ops php_hash_murmur3c_ops = {
 PHP_HASH_API void PHP_MURMUR3CInit(PHP_MURMUR3C_CTX *ctx, HashTable *args)
 {
 	if (args) {
-		zval *seed = zend_hash_str_find_deref(args, "seed", sizeof("seed") - 1);
+		zval *seed = zend_hash_str_find_deref(args, "seed", strlen("seed"));
 		/* This might be a bit too restrictive, but thinking that a seed might be set
 			once and for all, it should be done a clean way. */
 		if (seed && IS_LONG == Z_TYPE_P(seed)) {
@@ -170,7 +170,7 @@ const php_hash_ops php_hash_murmur3f_ops = {
 PHP_HASH_API void PHP_MURMUR3FInit(PHP_MURMUR3F_CTX *ctx, HashTable *args)
 {
 	if (args) {
-		zval *seed = zend_hash_str_find_deref(args, "seed", sizeof("seed") - 1);
+		zval *seed = zend_hash_str_find_deref(args, "seed", strlen("seed"));
 		/* This might be a bit too restrictive, but thinking that a seed might be set
 			once and for all, it should be done a clean way. */
 		if (seed && IS_LONG == Z_TYPE_P(seed)) {

--- a/ext/hash/hash_xxhash.c
+++ b/ext/hash/hash_xxhash.c
@@ -43,7 +43,7 @@ PHP_HASH_API void PHP_XXH32Init(PHP_XXH32_CTX *ctx, HashTable *args)
 	memset(&ctx->s, 0, sizeof ctx->s);
 
 	if (args) {
-		zval *seed = zend_hash_str_find_deref(args, "seed", sizeof("seed") - 1);
+		zval *seed = zend_hash_str_find_deref(args, "seed", strlen("seed"));
 		/* This might be a bit too restrictive, but thinking that a seed might be set
 			once and for all, it should be done a clean way. */
 		if (seed && IS_LONG == Z_TYPE_P(seed)) {
@@ -107,7 +107,7 @@ PHP_HASH_API void PHP_XXH64Init(PHP_XXH64_CTX *ctx, HashTable *args)
 	memset(&ctx->s, 0, sizeof ctx->s);
 
 	if (args) {
-		zval *seed = zend_hash_str_find_deref(args, "seed", sizeof("seed") - 1);
+		zval *seed = zend_hash_str_find_deref(args, "seed", strlen("seed"));
 		/* This might be a bit too restrictive, but thinking that a seed might be set
 			once and for all, it should be done a clean way. */
 		if (seed && IS_LONG == Z_TYPE_P(seed)) {
@@ -160,8 +160,8 @@ zend_always_inline static void _PHP_XXH3_Init(PHP_XXH3_64_CTX *ctx, HashTable *a
 	memset(&ctx->s, 0, sizeof ctx->s);
 
 	if (args) {
-		zval *_seed = zend_hash_str_find_deref(args, "seed", sizeof("seed") - 1);
-		zval *_secret = zend_hash_str_find_deref(args, "secret", sizeof("secret") - 1);
+		zval *_seed = zend_hash_str_find_deref(args, "seed", strlen("seed"));
+		zval *_secret = zend_hash_str_find_deref(args, "secret", strlen("secret"));
 
 		if (_seed && _secret) {
 			zend_throw_error(NULL, "%s: Only one of seed or secret is to be passed for initialization", algo_name);

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -238,8 +238,8 @@ PHP_MINFO_FUNCTION(miconv)
 {
 	zval *iconv_impl, *iconv_ver;
 
-	iconv_impl = zend_get_constant_str("ICONV_IMPL", sizeof("ICONV_IMPL")-1);
-	iconv_ver = zend_get_constant_str("ICONV_VERSION", sizeof("ICONV_VERSION")-1);
+	iconv_impl = zend_get_constant_str("ICONV_IMPL", strlen("ICONV_IMPL"));
+	iconv_ver = zend_get_constant_str("ICONV_VERSION", strlen("ICONV_VERSION"));
 
 	php_info_print_table_start();
 	php_info_print_table_row(2, "iconv support", "enabled");
@@ -961,7 +961,7 @@ static php_iconv_err_t _php_iconv_mime_encode(smart_str *pretval, const char *fn
 
 	_php_iconv_appendl(pretval, fname, fname_nbytes, cd_pl);
 	char_cnt -= fname_nbytes;
-	smart_str_appendl(pretval, ": ", sizeof(": ") - 1);
+	smart_str_appendl(pretval, ": ", strlen(": "));
 	char_cnt -= 2;
 
 	in_p = fval;
@@ -970,7 +970,7 @@ static php_iconv_err_t _php_iconv_mime_encode(smart_str *pretval, const char *fn
 	do {
 		size_t prev_in_left;
 		size_t out_size;
-		size_t encoded_word_min_len = sizeof("=\?\?X\?\?=")-1 + out_charset_len + (enc_scheme == PHP_ICONV_ENC_SCHEME_BASE64 ? 4 : 3);
+		size_t encoded_word_min_len = strlen("=\?\?X\?\?=") + out_charset_len + (enc_scheme == PHP_ICONV_ENC_SCHEME_BASE64 ? 4 : 3);
 
 		if (char_cnt < encoded_word_min_len + lfchars_len + 1) {
 			/* lfchars must be encoded in ASCII here*/
@@ -979,7 +979,7 @@ static php_iconv_err_t _php_iconv_mime_encode(smart_str *pretval, const char *fn
 			char_cnt = max_line_len - 1;
 		}
 
-		smart_str_appendl(pretval, "=?", sizeof("=?") - 1);
+		smart_str_appendl(pretval, "=?", strlen("=?"));
 		char_cnt -= 2;
 		smart_str_appendl(pretval, out_charset, out_charset_len);
 		char_cnt -= out_charset_len;
@@ -1068,7 +1068,7 @@ static php_iconv_err_t _php_iconv_mime_encode(smart_str *pretval, const char *fn
 
 				smart_str_appendl(pretval, ZSTR_VAL(encoded), ZSTR_LEN(encoded));
 				char_cnt -= ZSTR_LEN(encoded);
-				smart_str_appendl(pretval, "?=", sizeof("?=") - 1);
+				smart_str_appendl(pretval, "?=", strlen("?="));
 				char_cnt -= 2;
 
 				zend_string_release_ex(encoded, 0);
@@ -1151,7 +1151,7 @@ static php_iconv_err_t _php_iconv_mime_encode(smart_str *pretval, const char *fn
 					}
 				}
 
-				smart_str_appendl(pretval, "?=", sizeof("?=") - 1);
+				smart_str_appendl(pretval, "?=", strlen("?="));
 				char_cnt -= 2;
 
 				if (iconv(cd, NULL, NULL, NULL, NULL) == (size_t)-1) {
@@ -1978,7 +1978,7 @@ PHP_FUNCTION(iconv_mime_encode)
 	if (pref != NULL) {
 		zval *pzval;
 
-		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "scheme", sizeof("scheme") - 1)) != NULL) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "scheme", strlen("scheme"))) != NULL) {
 			if (Z_TYPE_P(pzval) == IS_STRING && Z_STRLEN_P(pzval) > 0) {
 				switch (Z_STRVAL_P(pzval)[0]) {
 					case 'B': case 'b':
@@ -1992,7 +1992,7 @@ PHP_FUNCTION(iconv_mime_encode)
 			}
 		}
 
-		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "input-charset", sizeof("input-charset") - 1)) != NULL && Z_TYPE_P(pzval) == IS_STRING) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "input-charset", strlen("input-charset"))) != NULL && Z_TYPE_P(pzval) == IS_STRING) {
 			if (Z_STRLEN_P(pzval) >= ICONV_CSNMAXLEN) {
 				php_error_docref(NULL, E_WARNING, "Encoding parameter exceeds the maximum allowed length of %d characters", ICONV_CSNMAXLEN);
 				RETURN_FALSE;
@@ -2004,7 +2004,7 @@ PHP_FUNCTION(iconv_mime_encode)
 		}
 
 
-		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "output-charset", sizeof("output-charset") - 1)) != NULL && Z_TYPE_P(pzval) == IS_STRING) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "output-charset", strlen("output-charset"))) != NULL && Z_TYPE_P(pzval) == IS_STRING) {
 			if (Z_STRLEN_P(pzval) >= ICONV_CSNMAXLEN) {
 				php_error_docref(NULL, E_WARNING, "Encoding parameter exceeds the maximum allowed length of %d characters", ICONV_CSNMAXLEN);
 				RETURN_FALSE;
@@ -2015,11 +2015,11 @@ PHP_FUNCTION(iconv_mime_encode)
 			}
 		}
 
-		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "line-length", sizeof("line-length") - 1)) != NULL) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "line-length", strlen("line-length"))) != NULL) {
 			line_len = zval_get_long(pzval);
 		}
 
-		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "line-break-chars", sizeof("line-break-chars") - 1)) != NULL) {
+		if ((pzval = zend_hash_str_find_deref(Z_ARRVAL_P(pref), "line-break-chars", strlen("line-break-chars"))) != NULL) {
 			if (Z_TYPE_P(pzval) != IS_STRING) {
 				tmp_str = zval_try_get_string_func(pzval);
 				if (UNEXPECTED(!tmp_str)) {
@@ -2244,11 +2244,11 @@ PHP_FUNCTION(iconv_set_encoding)
 	}
 
 	if(zend_string_equals_literal_ci(type, "input_encoding")) {
-		name = zend_string_init("iconv.input_encoding", sizeof("iconv.input_encoding") - 1, 0);
+		name = zend_string_init("iconv.input_encoding", strlen("iconv.input_encoding"), 0);
 	} else if(zend_string_equals_literal_ci(type, "output_encoding")) {
-		name = zend_string_init("iconv.output_encoding", sizeof("iconv.output_encoding") - 1, 0);
+		name = zend_string_init("iconv.output_encoding", strlen("iconv.output_encoding"), 0);
 	} else if(zend_string_equals_literal_ci(type, "internal_encoding")) {
-		name = zend_string_init("iconv.internal_encoding", sizeof("iconv.internal_encoding") - 1, 0);
+		name = zend_string_init("iconv.internal_encoding", strlen("iconv.internal_encoding"), 0);
 	} else {
 		RETURN_FALSE;
 	}

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -60,7 +60,7 @@ MAILSTREAM DEFAULTPROTO;
 #endif
 
 #define CRLF	"\015\012"
-#define CRLF_LEN sizeof("\015\012") - 1
+#define CRLF_LEN strlen("\015\012")
 #define PHP_EXPUNGE 32768
 #define PHP_IMAP_ADDRESS_SIZE_BUF 10
 #ifndef SENDBUFLEN
@@ -383,12 +383,12 @@ void mail_getquota(MAILSTREAM *stream, char *qroot, QUOTALIST *qlist)
 		if (strncmp(qlist->name, "STORAGE", 7) == 0)
 		{
 			/* this is to add backwards compatibility */
-			add_assoc_long_ex(return_value, "usage", sizeof("usage") - 1, qlist->usage);
-			add_assoc_long_ex(return_value, "limit", sizeof("limit") - 1, qlist->limit);
+			add_assoc_long_ex(return_value, "usage", strlen("usage"), qlist->usage);
+			add_assoc_long_ex(return_value, "limit", strlen("limit"), qlist->limit);
 		}
 
-		add_assoc_long_ex(&t_map, "usage", sizeof("usage") - 1, qlist->usage);
-		add_assoc_long_ex(&t_map, "limit", sizeof("limit") - 1, qlist->limit);
+		add_assoc_long_ex(&t_map, "usage", strlen("usage"), qlist->usage);
+		add_assoc_long_ex(&t_map, "limit", strlen("limit"), qlist->limit);
 		add_assoc_zval_ex(return_value, qlist->name, strlen(qlist->name), &t_map);
 	}
 }
@@ -813,7 +813,7 @@ PHP_FUNCTION(imap_open)
 	if (params) {
 		zval *disabled_auth_method;
 
-		if ((disabled_auth_method = zend_hash_str_find(params, "DISABLE_AUTHENTICATOR", sizeof("DISABLE_AUTHENTICATOR") - 1)) != NULL) {
+		if ((disabled_auth_method = zend_hash_str_find(params, "DISABLE_AUTHENTICATOR", strlen("DISABLE_AUTHENTICATOR"))) != NULL) {
 			switch (Z_TYPE_P(disabled_auth_method)) {
 				case IS_STRING:
 					if (Z_STRLEN_P(disabled_auth_method) > 1) {
@@ -964,7 +964,7 @@ PHP_FUNCTION(imap_append)
 	}
 
 	if (internal_date) {
-		zend_string *regex  = zend_string_init("/[0-3][0-9]-((Jan)|(Feb)|(Mar)|(Apr)|(May)|(Jun)|(Jul)|(Aug)|(Sep)|(Oct)|(Nov)|(Dec))-[0-9]{4} [0-2][0-9]:[0-5][0-9]:[0-5][0-9] [+-][0-9]{4}/", sizeof("/[0-3][0-9]-((Jan)|(Feb)|(Mar)|(Apr)|(May)|(Jun)|(Jul)|(Aug)|(Sep)|(Oct)|(Nov)|(Dec))-[0-9]{4} [0-2][0-9]:[0-5][0-9]:[0-5][0-9] [+-][0-9]{4}/") - 1, 0);
+		zend_string *regex  = zend_string_init("/[0-3][0-9]-((Jan)|(Feb)|(Mar)|(Apr)|(May)|(Jun)|(Jul)|(Aug)|(Sep)|(Oct)|(Nov)|(Dec))-[0-9]{4} [0-2][0-9]:[0-5][0-9]:[0-5][0-9] [+-][0-9]{4}/", strlen("/[0-3][0-9]-((Jan)|(Feb)|(Mar)|(Apr)|(May)|(Jun)|(Jul)|(Aug)|(Sep)|(Oct)|(Nov)|(Dec))-[0-9]{4} [0-2][0-9]:[0-5][0-9]:[0-5][0-9] [+-][0-9]{4}/"), 0);
 		pcre_cache_entry *pce;				/* Compiled regex */
 		zval *subpats = NULL;				/* Parts (not used) */
 		int global = 0;
@@ -3079,63 +3079,63 @@ PHP_FUNCTION(imap_mail_compose)
 	efree(str_copy);
 
 	env = mail_newenvelope();
-	if ((pvalue = zend_hash_str_find(envelope, "remail", sizeof("remail") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "remail", strlen("remail"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "remail");
 		env->remail = cpystr(Z_STRVAL_P(pvalue));
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "return_path", sizeof("return_path") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "return_path", strlen("return_path"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 1, "return_path");
 		PHP_RFC822_PARSE_ADRLIST(&env->return_path, pvalue);
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "date", sizeof("date") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "date", strlen("date"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "date");
 		env->date = (unsigned char*)cpystr(Z_STRVAL_P(pvalue));
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "from", sizeof("from") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "from", strlen("from"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 1, "from");
 		PHP_RFC822_PARSE_ADRLIST(&env->from, pvalue);
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "reply_to", sizeof("reply_to") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "reply_to", strlen("reply_to"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 1, "reply_to");
 		PHP_RFC822_PARSE_ADRLIST(&env->reply_to, pvalue);
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "in_reply_to", sizeof("in_reply_to") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "in_reply_to", strlen("in_reply_to"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "in_reply_to");
 		env->in_reply_to = cpystr(Z_STRVAL_P(pvalue));
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "subject", sizeof("subject") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "subject", strlen("subject"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "subject");
 		env->subject = cpystr(Z_STRVAL_P(pvalue));
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "to", sizeof("to") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "to", strlen("to"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 1, "to");
 		PHP_RFC822_PARSE_ADRLIST(&env->to, pvalue);
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "cc", sizeof("cc") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "cc", strlen("cc"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 1, "cc");
 		PHP_RFC822_PARSE_ADRLIST(&env->cc, pvalue);
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "bcc", sizeof("bcc") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "bcc", strlen("bcc"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 1, "bcc");
 		PHP_RFC822_PARSE_ADRLIST(&env->bcc, pvalue);
 	}
-	if ((pvalue = zend_hash_str_find(envelope, "message_id", sizeof("message_id") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "message_id", strlen("message_id"))) != NULL) {
 		convert_to_string(pvalue);
 		CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "message_id");
 		env->message_id=cpystr(Z_STRVAL_P(pvalue));
 	}
 
-	if ((pvalue = zend_hash_str_find(envelope, "custom_headers", sizeof("custom_headers") - 1)) != NULL) {
+	if ((pvalue = zend_hash_str_find(envelope, "custom_headers", strlen("custom_headers"))) != NULL) {
 		if (Z_TYPE_P(pvalue) == IS_ARRAY) {
 			custom_headers_param = tmp_param = NULL;
 			SEPARATE_ARRAY(pvalue);
@@ -3171,19 +3171,19 @@ PHP_FUNCTION(imap_mail_compose)
 			bod = mail_newbody();
 			topbod = bod;
 
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type", sizeof("type") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type", strlen("type"))) != NULL) {
 				zend_long type = zval_get_long(pvalue);
 				if (type >= 0 && type <= TYPEMAX && body_types[type] != NULL) {
 					bod->type = (short) type;
 				}
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "encoding", sizeof("encoding") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "encoding", strlen("encoding"))) != NULL) {
 				zend_long encoding = zval_get_long(pvalue);
 				if (encoding >= 0 && encoding <= ENCMAX && body_encodings[encoding] != NULL) {
 					bod->encoding = (short) encoding;
 				}
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "charset", sizeof("charset") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "charset", strlen("charset"))) != NULL) {
 				convert_to_string(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body charset");
 				tmp_param = mail_newbody_parameter();
@@ -3192,7 +3192,7 @@ PHP_FUNCTION(imap_mail_compose)
 				tmp_param->next = bod->parameter;
 				bod->parameter = tmp_param;
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type.parameters", sizeof("type.parameters") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type.parameters", strlen("type.parameters"))) != NULL) {
 				if(Z_TYPE_P(pvalue) == IS_ARRAY && !HT_IS_PACKED(Z_ARRVAL_P(pvalue))) {
 					disp_param = tmp_param = NULL;
 					SEPARATE_ARRAY(pvalue);
@@ -3211,28 +3211,28 @@ PHP_FUNCTION(imap_mail_compose)
 					bod->parameter = disp_param;
 				}
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "subtype", sizeof("subtype") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "subtype", strlen("subtype"))) != NULL) {
 				convert_to_string_ex(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body subtype");
 				bod->subtype = cpystr(Z_STRVAL_P(pvalue));
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "id", sizeof("id") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "id", strlen("id"))) != NULL) {
 				convert_to_string(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body id");
 				bod->id = cpystr(Z_STRVAL_P(pvalue));
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "description", sizeof("description") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "description", strlen("description"))) != NULL) {
 				convert_to_string(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body description");
 				bod->description = cpystr(Z_STRVAL_P(pvalue));
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition.type", sizeof("disposition.type") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition.type", strlen("disposition.type"))) != NULL) {
 				convert_to_string(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body disposition.type");
 				bod->disposition.type = (char *) fs_get(Z_STRLEN_P(pvalue) + 1);
 				memcpy(bod->disposition.type, Z_STRVAL_P(pvalue), Z_STRLEN_P(pvalue)+1);
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition", sizeof("disposition") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition", strlen("disposition"))) != NULL) {
 				if (Z_TYPE_P(pvalue) == IS_ARRAY && !HT_IS_PACKED(Z_ARRVAL_P(pvalue))) {
 					disp_param = tmp_param = NULL;
 					SEPARATE_ARRAY(pvalue);
@@ -3254,7 +3254,7 @@ PHP_FUNCTION(imap_mail_compose)
 			if (bod->type == TYPEMESSAGE && bod->subtype && !strcmp(bod->subtype, "RFC822")) {
 				bod->nested.msg = mail_newmsg();
 			} else {
-				if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "contents.data", sizeof("contents.data") - 1)) != NULL) {
+				if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "contents.data", strlen("contents.data"))) != NULL) {
 					convert_to_string(pvalue);
 					bod->contents.text.data = fs_get(Z_STRLEN_P(pvalue) + 1);
 					memcpy(bod->contents.text.data, Z_STRVAL_P(pvalue), Z_STRLEN_P(pvalue)+1);
@@ -3265,13 +3265,13 @@ PHP_FUNCTION(imap_mail_compose)
 					bod->contents.text.size = 0;
 				}
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "lines", sizeof("lines") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "lines", strlen("lines"))) != NULL) {
 				bod->size.lines = zval_get_long(pvalue);
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "bytes", sizeof("bytes") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "bytes", strlen("bytes"))) != NULL) {
 				bod->size.bytes = zval_get_long(pvalue);
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "md5", sizeof("md5") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "md5", strlen("md5"))) != NULL) {
 				convert_to_string(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body md5");
 				bod->md5 = cpystr(Z_STRVAL_P(pvalue));
@@ -3279,7 +3279,7 @@ PHP_FUNCTION(imap_mail_compose)
 		} else if (Z_TYPE_P(data) == IS_ARRAY && topbod->type == TYPEMULTIPART) {
 			short type = 0;
 			SEPARATE_ARRAY(data);
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type", sizeof("type") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type", strlen("type"))) != NULL) {
 				zend_long tmp_type = zval_get_long(pvalue);
 				if (tmp_type >= 0 && tmp_type <= TYPEMAX && tmp_type != TYPEMULTIPART && body_types[tmp_type] != NULL) {
 					type = (short) tmp_type;
@@ -3298,13 +3298,13 @@ PHP_FUNCTION(imap_mail_compose)
 			bod = &mypart->body;
 			bod->type = type;
 
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "encoding", sizeof("encoding") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "encoding", strlen("encoding"))) != NULL) {
 				zend_long encoding = zval_get_long(pvalue);
 				if (encoding >= 0 && encoding <= ENCMAX && body_encodings[encoding] != NULL) {
 					bod->encoding = (short) encoding;
 				}
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "charset", sizeof("charset") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "charset", strlen("charset"))) != NULL) {
 				convert_to_string_ex(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body charset");
 				tmp_param = mail_newbody_parameter();
@@ -3314,7 +3314,7 @@ PHP_FUNCTION(imap_mail_compose)
 				tmp_param->next = bod->parameter;
 				bod->parameter = tmp_param;
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type.parameters", sizeof("type.parameters") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "type.parameters", strlen("type.parameters"))) != NULL) {
 				if (Z_TYPE_P(pvalue) == IS_ARRAY && !HT_IS_PACKED(Z_ARRVAL_P(pvalue))) {
 					disp_param = tmp_param = NULL;
 					SEPARATE_ARRAY(pvalue);
@@ -3333,28 +3333,28 @@ PHP_FUNCTION(imap_mail_compose)
 					bod->parameter = disp_param;
 				}
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "subtype", sizeof("subtype") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "subtype", strlen("subtype"))) != NULL) {
 				convert_to_string_ex(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body subtype");
 				bod->subtype = cpystr(Z_STRVAL_P(pvalue));
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "id", sizeof("id") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "id", strlen("id"))) != NULL) {
 				convert_to_string_ex(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body id");
 				bod->id = cpystr(Z_STRVAL_P(pvalue));
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "description", sizeof("description") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "description", strlen("description"))) != NULL) {
 				convert_to_string_ex(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body description");
 				bod->description = cpystr(Z_STRVAL_P(pvalue));
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition.type", sizeof("disposition.type") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition.type", strlen("disposition.type"))) != NULL) {
 				convert_to_string_ex(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body disposition.type");
 				bod->disposition.type = (char *) fs_get(Z_STRLEN_P(pvalue) + 1);
 				memcpy(bod->disposition.type, Z_STRVAL_P(pvalue), Z_STRLEN_P(pvalue)+1);
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition", sizeof("disposition") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "disposition", strlen("disposition"))) != NULL) {
 				if (Z_TYPE_P(pvalue) == IS_ARRAY && !HT_IS_PACKED(Z_ARRVAL_P(pvalue))) {
 					disp_param = tmp_param = NULL;
 					SEPARATE_ARRAY(pvalue);
@@ -3376,7 +3376,7 @@ PHP_FUNCTION(imap_mail_compose)
 			if (bod->type == TYPEMESSAGE && bod->subtype && !strcmp(bod->subtype, "RFC822")) {
 				bod->nested.msg = mail_newmsg();
 			} else {
-				if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "contents.data", sizeof("contents.data") - 1)) != NULL) {
+				if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "contents.data", strlen("contents.data"))) != NULL) {
 					convert_to_string(pvalue);
 					bod->contents.text.data = fs_get(Z_STRLEN_P(pvalue) + 1);
 					memcpy(bod->contents.text.data, Z_STRVAL_P(pvalue), Z_STRLEN_P(pvalue) + 1);
@@ -3387,13 +3387,13 @@ PHP_FUNCTION(imap_mail_compose)
 					bod->contents.text.size = 0;
 				}
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "lines", sizeof("lines") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "lines", strlen("lines"))) != NULL) {
 				bod->size.lines = zval_get_long(pvalue);
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "bytes", sizeof("bytes") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "bytes", strlen("bytes"))) != NULL) {
 				bod->size.bytes = zval_get_long(pvalue);
 			}
-			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "md5", sizeof("md5") - 1)) != NULL) {
+			if ((pvalue = zend_hash_str_find(Z_ARRVAL_P(data), "md5", strlen("md5"))) != NULL) {
 				convert_to_string_ex(pvalue);
 				CHECK_HEADER_INJECTION(Z_STR_P(pvalue), 0, "body md5");
 				bod->md5 = cpystr(Z_STRVAL_P(pvalue));

--- a/ext/intl/breakiterator/breakiterator_class.cpp
+++ b/ext/intl/breakiterator/breakiterator_class.cpp
@@ -150,22 +150,22 @@ static HashTable *BreakIterator_get_debug_info(zend_object *object, int *is_temp
 
 	if (biter == NULL) {
 		ZVAL_FALSE(&val);
-		zend_hash_str_update(debug_info, "valid", sizeof("valid") - 1, &val);
+		zend_hash_str_update(debug_info, "valid", strlen("valid"), &val);
 		return debug_info;
 	}
 	ZVAL_TRUE(&val);
-	zend_hash_str_update(debug_info, "valid", sizeof("valid") - 1, &val);
+	zend_hash_str_update(debug_info, "valid", strlen("valid"), &val);
 
 	if (Z_ISUNDEF(bio->text)) {
 		ZVAL_NULL(&val);
-		zend_hash_str_update(debug_info, "text", sizeof("text") - 1, &val);
+		zend_hash_str_update(debug_info, "text", strlen("text"), &val);
 	} else {
 		Z_TRY_ADDREF(bio->text);
-		zend_hash_str_update(debug_info, "text", sizeof("text") - 1, &bio->text);
+		zend_hash_str_update(debug_info, "text", strlen("text"), &bio->text);
 	}
 
 	ZVAL_STRING(&val, const_cast<char*>(typeid(*biter).name()));
-	zend_hash_str_update(debug_info, "type", sizeof("type") - 1, &val);
+	zend_hash_str_update(debug_info, "type", strlen("type"), &val);
 
 	return debug_info;
 }
@@ -235,7 +235,7 @@ U_CFUNC void breakiterator_register_BreakIterator_class(void)
 	BreakIterator_handlers.free_obj = BreakIterator_objects_free;
 
 	zend_declare_class_constant_long(BreakIterator_ce_ptr,
-		"DONE", sizeof("DONE") - 1, BreakIterator::DONE );
+		"DONE", strlen("DONE"), BreakIterator::DONE );
 
 	/* Declare constants that are defined in the C header */
 #define BREAKITER_DECL_LONG_CONST(name) \

--- a/ext/intl/calendar/calendar_class.cpp
+++ b/ext/intl/calendar/calendar_class.cpp
@@ -161,14 +161,14 @@ static HashTable *Calendar_get_debug_info(zend_object *object, int *is_temp)
 
 	if (cal == NULL) {
 		ZVAL_FALSE(&zv);
-		zend_hash_str_update(debug_info, "valid", sizeof("valid") - 1, &zv);
+		zend_hash_str_update(debug_info, "valid", strlen("valid"), &zv);
 		return debug_info;
 	}
 	ZVAL_TRUE(&zv);
-	zend_hash_str_update(debug_info, "valid", sizeof("valid") - 1, &zv);
+	zend_hash_str_update(debug_info, "valid", strlen("valid"), &zv);
 
 	ZVAL_STRING(&zv, const_cast<char*>(cal->getType()));
-	zend_hash_str_update(debug_info, "type", sizeof("type") - 1, &zv);
+	zend_hash_str_update(debug_info, "type", strlen("type"), &zv);
 	{
 		zval		   ztz,
 					   ztz_debug;
@@ -184,7 +184,7 @@ static HashTable *Calendar_get_debug_info(zend_object *object, int *is_temp)
 		zend_hash_destroy(debug_info_tz);
 		FREE_HASHTABLE(debug_info_tz);
 
-		zend_hash_str_update(debug_info, "timeZone", sizeof("timeZone") - 1, &ztz_debug);
+		zend_hash_str_update(debug_info, "timeZone", strlen("timeZone"), &ztz_debug);
 	}
 
 	{
@@ -192,10 +192,10 @@ static HashTable *Calendar_get_debug_info(zend_object *object, int *is_temp)
 		Locale		locale	= cal->getLocale(ULOC_VALID_LOCALE, uec);
 		if (U_SUCCESS(uec)) {
 			ZVAL_STRING(&zv, const_cast<char*>(locale.getName()));
-			zend_hash_str_update(debug_info, "locale", sizeof("locale") - 1, &zv);
+			zend_hash_str_update(debug_info, "locale", strlen("locale"), &zv);
 		} else {
 			ZVAL_STRING(&zv, const_cast<char*>(u_errorName(uec)));
-			zend_hash_str_update(debug_info, "locale", sizeof("locale") - 1, &zv);
+			zend_hash_str_update(debug_info, "locale", strlen("locale"), &zv);
 		}
 	}
 
@@ -214,7 +214,7 @@ static HashTable *Calendar_get_debug_info(zend_object *object, int *is_temp)
 		}
 	}
 
-	zend_hash_str_update(debug_info, "fields", sizeof("fields") - 1, &zfields);
+	zend_hash_str_update(debug_info, "fields", strlen("fields"), &zfields);
 
 	return debug_info;
 }

--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -530,7 +530,7 @@ static void php_converter_resolve_callback(zval *zobj,
 PHP_METHOD(UConverter, __construct) {
 	php_converter_object *objval = CONV_GET(ZEND_THIS);
 	char *src = "utf-8";
-	size_t src_len = sizeof("utf-8") - 1;
+	size_t src_len = strlen("utf-8");
 	char *dest = src;
 	size_t dest_len = src_len;
 
@@ -746,13 +746,13 @@ PHP_METHOD(UConverter, transcode) {
 			zval *tmpzval;
 
 			if (U_SUCCESS(error) &&
-				(tmpzval = zend_hash_str_find(Z_ARRVAL_P(options), "from_subst", sizeof("from_subst") - 1)) != NULL &&
+				(tmpzval = zend_hash_str_find(Z_ARRVAL_P(options), "from_subst", strlen("from_subst"))) != NULL &&
 				Z_TYPE_P(tmpzval) == IS_STRING) {
 				error = U_ZERO_ERROR;
 				ucnv_setSubstChars(src_cnv, Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval) & 0x7F, &error);
 			}
 			if (U_SUCCESS(error) &&
-				(tmpzval = zend_hash_str_find(Z_ARRVAL_P(options), "to_subst", sizeof("to_subst") - 1)) != NULL &&
+				(tmpzval = zend_hash_str_find(Z_ARRVAL_P(options), "to_subst", strlen("to_subst"))) != NULL &&
 				Z_TYPE_P(tmpzval) == IS_STRING) {
 				error = U_ZERO_ERROR;
 				ucnv_setSubstChars(dest_cnv, Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval) & 0x7F, &error);

--- a/ext/intl/idn/idn.c
+++ b/ext/intl/idn/idn.c
@@ -162,10 +162,10 @@ static void php_intl_idn_to_46(INTERNAL_FUNCTION_PARAMETERS,
 	}
 
 	if (idna_info) {
-		add_assoc_str_ex(idna_info, "result", sizeof("result")-1, zend_string_copy(buffer));
+		add_assoc_str_ex(idna_info, "result", strlen("result"), zend_string_copy(buffer));
 		add_assoc_bool_ex(idna_info, "isTransitionalDifferent",
-				sizeof("isTransitionalDifferent")-1, info.isTransitionalDifferent);
-		add_assoc_long_ex(idna_info, "errors", sizeof("errors")-1, (zend_long)info.errors);
+				strlen("isTransitionalDifferent"), info.isTransitionalDifferent);
+		add_assoc_long_ex(idna_info, "errors", strlen("errors"), (zend_long)info.errors);
 	}
 
 	zend_string_release(buffer);

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -78,7 +78,7 @@ U_CFUNC zval *timezone_convert_to_datetimezone(const TimeZone *timeZone,
 	object_init_ex(ret, php_date_get_timezone_ce());
 	tzobj = Z_PHPTIMEZONE_P(ret);
 
-	if (id.compare(0, 3, UnicodeString("GMT", sizeof("GMT")-1, US_INV)) == 0) {
+	if (id.compare(0, 3, UnicodeString("GMT", strlen("GMT"), US_INV)) == 0) {
 		/* The DateTimeZone constructor doesn't support offset time zones,
 		 * so we must mess with DateTimeZone structure ourselves */
 		tzobj->initialized	  = 1;
@@ -308,12 +308,12 @@ static HashTable *TimeZone_get_debug_info(zend_object *object, int *is_temp)
 
 	if (tz == NULL) {
 		ZVAL_FALSE(&zv);
-		zend_hash_str_update(debug_info, "valid", sizeof("valid") - 1, &zv);
+		zend_hash_str_update(debug_info, "valid", strlen("valid"), &zv);
 		return debug_info;
 	}
 
 	ZVAL_TRUE(&zv);
-	zend_hash_str_update(debug_info, "valid", sizeof("valid") - 1, &zv);
+	zend_hash_str_update(debug_info, "valid", strlen("valid"), &zv);
 
 	tz->getID(ustr);
 	u8str = intl_convert_utf16_to_utf8(
@@ -322,7 +322,7 @@ static HashTable *TimeZone_get_debug_info(zend_object *object, int *is_temp)
 		return debug_info;
 	}
 	ZVAL_NEW_STR(&zv, u8str);
-	zend_hash_str_update(debug_info, "id", sizeof("id") - 1, &zv);
+	zend_hash_str_update(debug_info, "id", strlen("id"), &zv);
 
 	int32_t rawOffset, dstOffset;
 	UDate now = Calendar::getNow();
@@ -332,9 +332,9 @@ static HashTable *TimeZone_get_debug_info(zend_object *object, int *is_temp)
 	}
 
 	ZVAL_LONG(&zv, (zend_long)rawOffset);
-	zend_hash_str_update(debug_info,"rawOffset", sizeof("rawOffset") - 1, &zv);
+	zend_hash_str_update(debug_info,"rawOffset", strlen("rawOffset"), &zv);
 	ZVAL_LONG(&zv, (zend_long)(rawOffset + dstOffset));
-	zend_hash_str_update(debug_info,"currentOffset", sizeof("currentOffset") - 1, &zv);
+	zend_hash_str_update(debug_info,"currentOffset", strlen("currentOffset"), &zv);
 
 	return debug_info;
 }

--- a/ext/intl/transliterator/transliterator_arginfo.h
+++ b/ext/intl/transliterator/transliterator_arginfo.h
@@ -65,7 +65,7 @@ static zend_class_entry *register_class_Transliterator(void)
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_id_name);
 

--- a/ext/intl/transliterator/transliterator_class.c
+++ b/ext/intl/transliterator/transliterator_class.c
@@ -55,7 +55,7 @@ int transliterator_object_construct( zval *object,
 
 	ZVAL_NEW_STR(&tmp, u8str);
 	zend_update_property(Transliterator_ce_ptr, Z_OBJ_P(object),
-		"id", sizeof( "id" ) - 1, &tmp );
+		"id", strlen( "id" ), &tmp );
 	GC_DELREF(u8str);
 	return SUCCESS;
 }

--- a/ext/intl/uchar/uchar.c
+++ b/ext/intl/uchar/uchar.c
@@ -619,10 +619,10 @@ int php_uchar_minit(INIT_FUNC_ARGS) {
 #define IC_CONSTL(name, val) \
 	zend_declare_class_constant_long(ce, name, strlen(name), val);
 
-	zend_declare_class_constant_string(ce, "UNICODE_VERSION", sizeof("UNICODE_VERISON")-1, U_UNICODE_VERSION);
+	zend_declare_class_constant_string(ce, "UNICODE_VERSION", strlen("UNICODE_VERISON"), U_UNICODE_VERSION);
 	IC_CONSTL("CODEPOINT_MIN", UCHAR_MIN_VALUE)
 	IC_CONSTL("CODEPOINT_MAX", UCHAR_MAX_VALUE)
-	zend_declare_class_constant_double(ce, "NO_NUMERIC_VALUE", sizeof("NO_NUMERIC_VALUE")-1, U_NO_NUMERIC_VALUE);
+	zend_declare_class_constant_double(ce, "NO_NUMERIC_VALUE", strlen("NO_NUMERIC_VALUE"), U_NO_NUMERIC_VALUE);
 
 	/* All enums used by the uchar APIs.  There are a LOT of them,
 	 * so they're separated out into include files,

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -393,7 +393,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 	zend_string *tmpstring = NULL, **tmpstrings1 = NULL, **tmpstrings2 = NULL;
 	size_t num_tmpstrings1 = 0, num_tmpstrings2 = 0;
 
-	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "oid", sizeof("oid") - 1)) == NULL) {
+	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "oid", strlen("oid"))) == NULL) {
 		zend_value_error("%s(): Control must have an \"oid\" key", get_active_function_name());
 		return -1;
 	}
@@ -403,7 +403,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 		return -1;
 	}
 
-	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "iscritical", sizeof("iscritical") - 1)) != NULL) {
+	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "iscritical", strlen("iscritical"))) != NULL) {
 		control_iscritical = zend_is_true(val);
 	} else {
 		control_iscritical = 0;
@@ -413,7 +413,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 	struct berval control_value = { 0L, NULL };
 	int control_value_alloc = 0;
 
-	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "value", sizeof("value") - 1)) != NULL) {
+	if ((val = zend_hash_str_find(Z_ARRVAL_P(array), "value", strlen("value"))) != NULL) {
 		if (Z_TYPE_P(val) != IS_ARRAY) {
 			tmpstring = zval_get_string(val);
 			if (EG(exception)) {
@@ -426,10 +426,10 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 			zval* tmp;
 			int pagesize = 1;
 			struct berval cookie = { 0L, NULL };
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "size", sizeof("size") - 1)) != NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "size", strlen("size"))) != NULL) {
 				pagesize = zval_get_long(tmp);
 			}
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "cookie", sizeof("cookie") - 1)) != NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "cookie", strlen("cookie"))) != NULL) {
 				tmpstring = zval_get_string(tmp);
 				if (EG(exception)) {
 					rc = -1;
@@ -447,7 +447,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 		} else if (strcmp(ZSTR_VAL(control_oid), LDAP_CONTROL_ASSERT) == 0) {
 			zval* tmp;
 			zend_string* assert;
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "filter", sizeof("filter") - 1)) == NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "filter", strlen("filter"))) == NULL) {
 				rc = -1;
 				zend_value_error("%s(): Control must have a \"filter\" key", get_active_function_name());
 			} else {
@@ -470,7 +470,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 			}
 		} else if (strcmp(ZSTR_VAL(control_oid), LDAP_CONTROL_VALUESRETURNFILTER) == 0) {
 			zval* tmp;
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "filter", sizeof("filter") - 1)) == NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "filter", strlen("filter"))) == NULL) {
 				rc = -1;
 				zend_value_error("%s(): Control must have a \"filter\" key", get_active_function_name());
 			} else {
@@ -494,7 +494,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 			}
 		} else if ((strcmp(ZSTR_VAL(control_oid), LDAP_CONTROL_PRE_READ) == 0) || (strcmp(ZSTR_VAL(control_oid), LDAP_CONTROL_POST_READ) == 0)) {
 			zval* tmp;
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "attrs", sizeof("attrs") - 1)) == NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "attrs", strlen("attrs"))) == NULL) {
 				rc = -1;
 				zend_value_error("%s(): Control must have an \"attrs\" key", get_active_function_name());
 			} else {
@@ -562,7 +562,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 					goto failure;
 				}
 
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(sortkey), "attr", sizeof("attr") - 1)) == NULL) {
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(sortkey), "attr", strlen("attr"))) == NULL) {
 					rc = -1;
 					zend_value_error("%s(): Sort key list must have an \"attr\" key", get_active_function_name());
 					goto failure;
@@ -576,7 +576,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				sort_keys[i]->attributeType = ZSTR_VAL(tmpstrings1[num_tmpstrings1]);
 				++num_tmpstrings1;
 
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(sortkey), "oid", sizeof("oid") - 1)) != NULL) {
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(sortkey), "oid", strlen("oid"))) != NULL) {
 					tmpstrings2[num_tmpstrings2] = zval_get_string(tmp);
 					if (EG(exception)) {
 						rc = -1;
@@ -588,7 +588,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 					sort_keys[i]->orderingRule = NULL;
 				}
 
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(sortkey), "reverse", sizeof("reverse") - 1)) != NULL) {
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(sortkey), "reverse", strlen("reverse"))) != NULL) {
 					sort_keys[i]->reverseOrder = zend_is_true(tmp);
 				} else {
 					sort_keys[i]->reverseOrder = 0;
@@ -607,7 +607,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 			struct berval attrValue;
 			struct berval context;
 
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "before", sizeof("before") - 1)) != NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "before", strlen("before"))) != NULL) {
 				vlvInfo.ldvlv_before_count = zval_get_long(tmp);
 			} else {
 				rc = -1;
@@ -615,7 +615,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				goto failure;
 			}
 
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "after", sizeof("after") - 1)) != NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "after", strlen("after"))) != NULL) {
 				vlvInfo.ldvlv_after_count = zval_get_long(tmp);
 			} else {
 				rc = -1;
@@ -623,7 +623,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				goto failure;
 			}
 
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "attrvalue", sizeof("attrvalue") - 1)) != NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "attrvalue", strlen("attrvalue"))) != NULL) {
 				tmpstring = zval_get_string(tmp);
 				if (EG(exception)) {
 					rc = -1;
@@ -632,10 +632,10 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				attrValue.bv_val = ZSTR_VAL(tmpstring);
 				attrValue.bv_len = ZSTR_LEN(tmpstring);
 				vlvInfo.ldvlv_attrvalue = &attrValue;
-			} else if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "offset", sizeof("offset") - 1)) != NULL) {
+			} else if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "offset", strlen("offset"))) != NULL) {
 				vlvInfo.ldvlv_attrvalue = NULL;
 				vlvInfo.ldvlv_offset = zval_get_long(tmp);
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "count", sizeof("count") - 1)) != NULL) {
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "count", strlen("count"))) != NULL) {
 					vlvInfo.ldvlv_count = zval_get_long(tmp);
 				} else {
 					rc = -1;
@@ -648,7 +648,7 @@ static int _php_ldap_control_from_array(LDAP *ld, LDAPControl** ctrl, zval* arra
 				goto failure;
 			}
 
-			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "context", sizeof("context") - 1)) != NULL) {
+			if ((tmp = zend_hash_str_find(Z_ARRVAL_P(val), "context", strlen("context"))) != NULL) {
 				tmpstring = zval_get_string(tmp);
 				if (EG(exception)) {
 					rc = -1;
@@ -3945,7 +3945,7 @@ PHP_FUNCTION(ldap_escape)
 
 	if (flags & PHP_LDAP_ESCAPE_DN) {
 		havecharlist = 1;
-		php_ldap_escape_map_set_chars(map, "\\,=+<>;\"#\r", sizeof("\\,=+<>;\"#\r") - 1, 1);
+		php_ldap_escape_map_set_chars(map, "\\,=+<>;\"#\r", strlen("\\,=+<>;\"#\r"), 1);
 	}
 
 	if (!havecharlist) {

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -272,7 +272,7 @@ static void *php_libxml_streams_IO_open_wrapper(const char *filename, const char
 			thus the php stream wrapper will fail on a valid case. For this
 			reason the prefix is rather better cut off. */
 		{
-			size_t pre_len = sizeof("file:/") - 1;
+			size_t pre_len = strlen("file:/");
 
 			if (strncasecmp(resolved_path, "file:/", pre_len) == 0
 				&& '/' != resolved_path[pre_len]) {
@@ -385,7 +385,7 @@ php_libxml_input_buffer_create_filename(const char *URI, xmlCharEncoding enc)
 					if (encoding) {
 						char *end;
 
-						encoding += sizeof("charset=")-1;
+						encoding += strlen("charset=");
 						if (*encoding == '"') {
 							encoding++;
 						}
@@ -1051,20 +1051,20 @@ PHP_FUNCTION(libxml_get_errors)
 			zval z_error;
 
 			object_init_ex(&z_error, libxmlerror_class_entry);
-			add_property_long_ex(&z_error, "level", sizeof("level") - 1, error->level);
-			add_property_long_ex(&z_error, "code", sizeof("code") - 1, error->code);
-			add_property_long_ex(&z_error, "column", sizeof("column") - 1, error->int2 );
+			add_property_long_ex(&z_error, "level", strlen("level"), error->level);
+			add_property_long_ex(&z_error, "code", strlen("code"), error->code);
+			add_property_long_ex(&z_error, "column", strlen("column"), error->int2 );
 			if (error->message) {
-				add_property_string_ex(&z_error, "message", sizeof("message") - 1, error->message);
+				add_property_string_ex(&z_error, "message", strlen("message"), error->message);
 			} else {
-				add_property_stringl_ex(&z_error, "message", sizeof("message") - 1, "", 0);
+				add_property_stringl_ex(&z_error, "message", strlen("message"), "", 0);
 			}
 			if (error->file) {
-				add_property_string_ex(&z_error, "file", sizeof("file") - 1, error->file);
+				add_property_string_ex(&z_error, "file", strlen("file"), error->file);
 			} else {
-				add_property_stringl_ex(&z_error, "file", sizeof("file") - 1, "", 0);
+				add_property_stringl_ex(&z_error, "file", strlen("file"), "", 0);
 			}
-			add_property_long_ex(&z_error, "line", sizeof("line") - 1, error->line);
+			add_property_long_ex(&z_error, "line", strlen("line"), error->line);
 			add_next_index_zval(return_value, &z_error);
 
 			error = zend_llist_get_next(LIBXML(error_list));

--- a/ext/libxml/libxml_arginfo.h
+++ b/ext/libxml/libxml_arginfo.h
@@ -61,37 +61,37 @@ static zend_class_entry *register_class_LibXMLError(void)
 
 	zval property_level_default_value;
 	ZVAL_UNDEF(&property_level_default_value);
-	zend_string *property_level_name = zend_string_init("level", sizeof("level") - 1, 1);
+	zend_string *property_level_name = zend_string_init("level", strlen("level"), 1);
 	zend_declare_typed_property(class_entry, property_level_name, &property_level_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_level_name);
 
 	zval property_code_default_value;
 	ZVAL_UNDEF(&property_code_default_value);
-	zend_string *property_code_name = zend_string_init("code", sizeof("code") - 1, 1);
+	zend_string *property_code_name = zend_string_init("code", strlen("code"), 1);
 	zend_declare_typed_property(class_entry, property_code_name, &property_code_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_code_name);
 
 	zval property_column_default_value;
 	ZVAL_UNDEF(&property_column_default_value);
-	zend_string *property_column_name = zend_string_init("column", sizeof("column") - 1, 1);
+	zend_string *property_column_name = zend_string_init("column", strlen("column"), 1);
 	zend_declare_typed_property(class_entry, property_column_name, &property_column_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_column_name);
 
 	zval property_message_default_value;
 	ZVAL_UNDEF(&property_message_default_value);
-	zend_string *property_message_name = zend_string_init("message", sizeof("message") - 1, 1);
+	zend_string *property_message_name = zend_string_init("message", strlen("message"), 1);
 	zend_declare_typed_property(class_entry, property_message_name, &property_message_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_message_name);
 
 	zval property_file_default_value;
 	ZVAL_UNDEF(&property_file_default_value);
-	zend_string *property_file_name = zend_string_init("file", sizeof("file") - 1, 1);
+	zend_string *property_file_name = zend_string_init("file", strlen("file"), 1);
 	zend_declare_typed_property(class_entry, property_file_name, &property_file_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_file_name);
 
 	zval property_line_default_value;
 	ZVAL_UNDEF(&property_line_default_value);
-	zend_string *property_line_name = zend_string_init("line", sizeof("line") - 1, 1);
+	zend_string *property_line_name = zend_string_init("line", strlen("line"), 1);
 	zend_declare_typed_property(class_entry, property_line_name, &property_line_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_line_name);
 

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1205,7 +1205,7 @@ PHP_FUNCTION(mb_language)
 	if (name == NULL) {
 		RETVAL_STRING((char *)mbfl_no_language2name(MBSTRG(language)));
 	} else {
-		zend_string *ini_name = zend_string_init("mbstring.language", sizeof("mbstring.language") - 1, 0);
+		zend_string *ini_name = zend_string_init("mbstring.language", strlen("mbstring.language"), 0);
 		if (FAILURE == zend_alter_ini_entry(ini_name, name, PHP_INI_USER, PHP_INI_STAGE_RUNTIME)) {
 			zend_argument_value_error(1, "must be a valid language, \"%s\" given", ZSTR_VAL(name));
 			zend_string_release_ex(ini_name, 0);
@@ -3558,7 +3558,7 @@ PHP_FUNCTION(mb_send_mail)
 		_php_mbstr_parse_mail_headers(&ht_headers, ZSTR_VAL(str_headers), ZSTR_LEN(str_headers));
 	}
 
-	if ((s = zend_hash_str_find(&ht_headers, "content-type", sizeof("content-type") - 1))) {
+	if ((s = zend_hash_str_find(&ht_headers, "content-type", strlen("content-type")))) {
 		char *tmp;
 		char *param_name;
 		char *charset = NULL;
@@ -3594,7 +3594,7 @@ PHP_FUNCTION(mb_send_mail)
 		suppressed_hdrs.cnt_type = 1;
 	}
 
-	if ((s = zend_hash_str_find(&ht_headers, "content-transfer-encoding", sizeof("content-transfer-encoding") - 1))) {
+	if ((s = zend_hash_str_find(&ht_headers, "content-transfer-encoding", strlen("content-transfer-encoding")))) {
 		const mbfl_encoding *_body_enc;
 
 		ZEND_ASSERT(Z_TYPE_P(s) == IS_STRING);
@@ -3695,7 +3695,7 @@ PHP_FUNCTION(mb_send_mail)
 		zend_string_release_ex(str_headers, 0);
 	}
 
-	if (!zend_hash_str_exists(&ht_headers, "mime-version", sizeof("mime-version") - 1)) {
+	if (!zend_hash_str_exists(&ht_headers, "mime-version", strlen("mime-version"))) {
 		mbfl_memory_device_strncat(&device, PHP_MBSTR_MAIL_MIME_HEADER1, sizeof(PHP_MBSTR_MAIL_MIME_HEADER1) - 1);
 		mbfl_memory_device_strncat(&device, CRLF, sizeof(CRLF)-1);
 	}
@@ -3791,7 +3791,7 @@ PHP_FUNCTION(mb_get_info)
 		if (MBSTRG(current_http_output_encoding)) {
 			add_assoc_string(return_value, "http_output", (char *)MBSTRG(current_http_output_encoding)->name);
 		}
-		if ((name = (char *)zend_ini_string("mbstring.http_output_conv_mimetypes", sizeof("mbstring.http_output_conv_mimetypes") - 1, 0)) != NULL) {
+		if ((name = (char *)zend_ini_string("mbstring.http_output_conv_mimetypes", strlen("mbstring.http_output_conv_mimetypes"), 0)) != NULL) {
 			add_assoc_string(return_value, "http_output_conv_mimetypes", name);
 		}
 		if (lang != NULL) {
@@ -3852,7 +3852,7 @@ PHP_FUNCTION(mb_get_info)
 			RETVAL_STRING((char *)MBSTRG(current_http_output_encoding)->name);
 		}
 	} else if (zend_string_equals_literal_ci(type, "http_output_conv_mimetypes")) {
-		if ((name = (char *)zend_ini_string("mbstring.http_output_conv_mimetypes", sizeof("mbstring.http_output_conv_mimetypes") - 1, 0)) != NULL) {
+		if ((name = (char *)zend_ini_string("mbstring.http_output_conv_mimetypes", strlen("mbstring.http_output_conv_mimetypes"), 0)) != NULL) {
 			RETVAL_STRING(name);
 		}
 	} else if (zend_string_equals_literal_ci(type, "mail_charset")) {

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -40,26 +40,26 @@ static void mysqli_tx_cor_options_to_string(const MYSQL * const conn, smart_str 
 {
 	if (mode & TRANS_COR_AND_CHAIN && !(mode & TRANS_COR_AND_NO_CHAIN)) {
 		if (str->s && ZSTR_LEN(str->s)) {
-			smart_str_appendl(str, " ", sizeof(" ") - 1);
+			smart_str_appendl(str, " ", strlen(" "));
 		}
-		smart_str_appendl(str, "AND CHAIN", sizeof("AND CHAIN") - 1);
+		smart_str_appendl(str, "AND CHAIN", strlen("AND CHAIN"));
 	} else if (mode & TRANS_COR_AND_NO_CHAIN && !(mode & TRANS_COR_AND_CHAIN)) {
 		if (str->s && ZSTR_LEN(str->s)) {
-			smart_str_appendl(str, " ", sizeof(" ") - 1);
+			smart_str_appendl(str, " ", strlen(" "));
 		}
-		smart_str_appendl(str, "AND NO CHAIN", sizeof("AND NO CHAIN") - 1);
+		smart_str_appendl(str, "AND NO CHAIN", strlen("AND NO CHAIN"));
 	}
 
 	if (mode & TRANS_COR_RELEASE && !(mode & TRANS_COR_NO_RELEASE)) {
 		if (str->s && ZSTR_LEN(str->s)) {
-			smart_str_appendl(str, " ", sizeof(" ") - 1);
+			smart_str_appendl(str, " ", strlen(" "));
 		}
-		smart_str_appendl(str, "RELEASE", sizeof("RELEASE") - 1);
+		smart_str_appendl(str, "RELEASE", strlen("RELEASE"));
 	} else if (mode & TRANS_COR_NO_RELEASE && !(mode & TRANS_COR_RELEASE)) {
 		if (str->s && ZSTR_LEN(str->s)) {
-			smart_str_appendl(str, " ", sizeof(" ") - 1);
+			smart_str_appendl(str, " ", strlen(" "));
 		}
-		smart_str_appendl(str, "NO RELEASE", sizeof("NO RELEASE") - 1);
+		smart_str_appendl(str, "NO RELEASE", strlen("NO RELEASE"));
 	}
 	smart_str_0(str);
 }

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1101,31 +1101,31 @@ static zend_class_entry *register_class_mysqli_driver(void)
 
 	zval property_client_info_default_value;
 	ZVAL_UNDEF(&property_client_info_default_value);
-	zend_string *property_client_info_name = zend_string_init("client_info", sizeof("client_info") - 1, 1);
+	zend_string *property_client_info_name = zend_string_init("client_info", strlen("client_info"), 1);
 	zend_declare_typed_property(class_entry, property_client_info_name, &property_client_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_client_info_name);
 
 	zval property_client_version_default_value;
 	ZVAL_UNDEF(&property_client_version_default_value);
-	zend_string *property_client_version_name = zend_string_init("client_version", sizeof("client_version") - 1, 1);
+	zend_string *property_client_version_name = zend_string_init("client_version", strlen("client_version"), 1);
 	zend_declare_typed_property(class_entry, property_client_version_name, &property_client_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_client_version_name);
 
 	zval property_driver_version_default_value;
 	ZVAL_UNDEF(&property_driver_version_default_value);
-	zend_string *property_driver_version_name = zend_string_init("driver_version", sizeof("driver_version") - 1, 1);
+	zend_string *property_driver_version_name = zend_string_init("driver_version", strlen("driver_version"), 1);
 	zend_declare_typed_property(class_entry, property_driver_version_name, &property_driver_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_driver_version_name);
 
 	zval property_reconnect_default_value;
 	ZVAL_BOOL(&property_reconnect_default_value, 0);
-	zend_string *property_reconnect_name = zend_string_init("reconnect", sizeof("reconnect") - 1, 1);
+	zend_string *property_reconnect_name = zend_string_init("reconnect", strlen("reconnect"), 1);
 	zend_declare_typed_property(class_entry, property_reconnect_name, &property_reconnect_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_reconnect_name);
 
 	zval property_report_mode_default_value;
 	ZVAL_LONG(&property_report_mode_default_value, 0);
-	zend_string *property_report_mode_name = zend_string_init("report_mode", sizeof("report_mode") - 1, 1);
+	zend_string *property_report_mode_name = zend_string_init("report_mode", strlen("report_mode"), 1);
 	zend_declare_typed_property(class_entry, property_report_mode_name, &property_report_mode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_report_mode_name);
 
@@ -1141,109 +1141,109 @@ static zend_class_entry *register_class_mysqli(void)
 
 	zval property_affected_rows_default_value;
 	ZVAL_UNDEF(&property_affected_rows_default_value);
-	zend_string *property_affected_rows_name = zend_string_init("affected_rows", sizeof("affected_rows") - 1, 1);
+	zend_string *property_affected_rows_name = zend_string_init("affected_rows", strlen("affected_rows"), 1);
 	zend_declare_typed_property(class_entry, property_affected_rows_name, &property_affected_rows_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_affected_rows_name);
 
 	zval property_client_info_default_value;
 	ZVAL_UNDEF(&property_client_info_default_value);
-	zend_string *property_client_info_name = zend_string_init("client_info", sizeof("client_info") - 1, 1);
+	zend_string *property_client_info_name = zend_string_init("client_info", strlen("client_info"), 1);
 	zend_declare_typed_property(class_entry, property_client_info_name, &property_client_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_client_info_name);
 
 	zval property_client_version_default_value;
 	ZVAL_UNDEF(&property_client_version_default_value);
-	zend_string *property_client_version_name = zend_string_init("client_version", sizeof("client_version") - 1, 1);
+	zend_string *property_client_version_name = zend_string_init("client_version", strlen("client_version"), 1);
 	zend_declare_typed_property(class_entry, property_client_version_name, &property_client_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_client_version_name);
 
 	zval property_connect_errno_default_value;
 	ZVAL_UNDEF(&property_connect_errno_default_value);
-	zend_string *property_connect_errno_name = zend_string_init("connect_errno", sizeof("connect_errno") - 1, 1);
+	zend_string *property_connect_errno_name = zend_string_init("connect_errno", strlen("connect_errno"), 1);
 	zend_declare_typed_property(class_entry, property_connect_errno_name, &property_connect_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_connect_errno_name);
 
 	zval property_connect_error_default_value;
 	ZVAL_UNDEF(&property_connect_error_default_value);
-	zend_string *property_connect_error_name = zend_string_init("connect_error", sizeof("connect_error") - 1, 1);
+	zend_string *property_connect_error_name = zend_string_init("connect_error", strlen("connect_error"), 1);
 	zend_declare_typed_property(class_entry, property_connect_error_name, &property_connect_error_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_connect_error_name);
 
 	zval property_errno_default_value;
 	ZVAL_UNDEF(&property_errno_default_value);
-	zend_string *property_errno_name = zend_string_init("errno", sizeof("errno") - 1, 1);
+	zend_string *property_errno_name = zend_string_init("errno", strlen("errno"), 1);
 	zend_declare_typed_property(class_entry, property_errno_name, &property_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_errno_name);
 
 	zval property_error_default_value;
 	ZVAL_UNDEF(&property_error_default_value);
-	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
+	zend_string *property_error_name = zend_string_init("error", strlen("error"), 1);
 	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_error_name);
 
 	zval property_error_list_default_value;
 	ZVAL_UNDEF(&property_error_list_default_value);
-	zend_string *property_error_list_name = zend_string_init("error_list", sizeof("error_list") - 1, 1);
+	zend_string *property_error_list_name = zend_string_init("error_list", strlen("error_list"), 1);
 	zend_declare_typed_property(class_entry, property_error_list_name, &property_error_list_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_error_list_name);
 
 	zval property_field_count_default_value;
 	ZVAL_UNDEF(&property_field_count_default_value);
-	zend_string *property_field_count_name = zend_string_init("field_count", sizeof("field_count") - 1, 1);
+	zend_string *property_field_count_name = zend_string_init("field_count", strlen("field_count"), 1);
 	zend_declare_typed_property(class_entry, property_field_count_name, &property_field_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_field_count_name);
 
 	zval property_host_info_default_value;
 	ZVAL_UNDEF(&property_host_info_default_value);
-	zend_string *property_host_info_name = zend_string_init("host_info", sizeof("host_info") - 1, 1);
+	zend_string *property_host_info_name = zend_string_init("host_info", strlen("host_info"), 1);
 	zend_declare_typed_property(class_entry, property_host_info_name, &property_host_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_host_info_name);
 
 	zval property_info_default_value;
 	ZVAL_UNDEF(&property_info_default_value);
-	zend_string *property_info_name = zend_string_init("info", sizeof("info") - 1, 1);
+	zend_string *property_info_name = zend_string_init("info", strlen("info"), 1);
 	zend_declare_typed_property(class_entry, property_info_name, &property_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_info_name);
 
 	zval property_insert_id_default_value;
 	ZVAL_UNDEF(&property_insert_id_default_value);
-	zend_string *property_insert_id_name = zend_string_init("insert_id", sizeof("insert_id") - 1, 1);
+	zend_string *property_insert_id_name = zend_string_init("insert_id", strlen("insert_id"), 1);
 	zend_declare_typed_property(class_entry, property_insert_id_name, &property_insert_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_insert_id_name);
 
 	zval property_server_info_default_value;
 	ZVAL_UNDEF(&property_server_info_default_value);
-	zend_string *property_server_info_name = zend_string_init("server_info", sizeof("server_info") - 1, 1);
+	zend_string *property_server_info_name = zend_string_init("server_info", strlen("server_info"), 1);
 	zend_declare_typed_property(class_entry, property_server_info_name, &property_server_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_server_info_name);
 
 	zval property_server_version_default_value;
 	ZVAL_UNDEF(&property_server_version_default_value);
-	zend_string *property_server_version_name = zend_string_init("server_version", sizeof("server_version") - 1, 1);
+	zend_string *property_server_version_name = zend_string_init("server_version", strlen("server_version"), 1);
 	zend_declare_typed_property(class_entry, property_server_version_name, &property_server_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_server_version_name);
 
 	zval property_sqlstate_default_value;
 	ZVAL_UNDEF(&property_sqlstate_default_value);
-	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
+	zend_string *property_sqlstate_name = zend_string_init("sqlstate", strlen("sqlstate"), 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_sqlstate_name);
 
 	zval property_protocol_version_default_value;
 	ZVAL_UNDEF(&property_protocol_version_default_value);
-	zend_string *property_protocol_version_name = zend_string_init("protocol_version", sizeof("protocol_version") - 1, 1);
+	zend_string *property_protocol_version_name = zend_string_init("protocol_version", strlen("protocol_version"), 1);
 	zend_declare_typed_property(class_entry, property_protocol_version_name, &property_protocol_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_protocol_version_name);
 
 	zval property_thread_id_default_value;
 	ZVAL_UNDEF(&property_thread_id_default_value);
-	zend_string *property_thread_id_name = zend_string_init("thread_id", sizeof("thread_id") - 1, 1);
+	zend_string *property_thread_id_name = zend_string_init("thread_id", strlen("thread_id"), 1);
 	zend_declare_typed_property(class_entry, property_thread_id_name, &property_thread_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_thread_id_name);
 
 	zval property_warning_count_default_value;
 	ZVAL_UNDEF(&property_warning_count_default_value);
-	zend_string *property_warning_count_name = zend_string_init("warning_count", sizeof("warning_count") - 1, 1);
+	zend_string *property_warning_count_name = zend_string_init("warning_count", strlen("warning_count"), 1);
 	zend_declare_typed_property(class_entry, property_warning_count_name, &property_warning_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_warning_count_name);
 
@@ -1260,31 +1260,31 @@ static zend_class_entry *register_class_mysqli_result(zend_class_entry *class_en
 
 	zval property_current_field_default_value;
 	ZVAL_UNDEF(&property_current_field_default_value);
-	zend_string *property_current_field_name = zend_string_init("current_field", sizeof("current_field") - 1, 1);
+	zend_string *property_current_field_name = zend_string_init("current_field", strlen("current_field"), 1);
 	zend_declare_typed_property(class_entry, property_current_field_name, &property_current_field_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_current_field_name);
 
 	zval property_field_count_default_value;
 	ZVAL_UNDEF(&property_field_count_default_value);
-	zend_string *property_field_count_name = zend_string_init("field_count", sizeof("field_count") - 1, 1);
+	zend_string *property_field_count_name = zend_string_init("field_count", strlen("field_count"), 1);
 	zend_declare_typed_property(class_entry, property_field_count_name, &property_field_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_field_count_name);
 
 	zval property_lengths_default_value;
 	ZVAL_UNDEF(&property_lengths_default_value);
-	zend_string *property_lengths_name = zend_string_init("lengths", sizeof("lengths") - 1, 1);
+	zend_string *property_lengths_name = zend_string_init("lengths", strlen("lengths"), 1);
 	zend_declare_typed_property(class_entry, property_lengths_name, &property_lengths_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property_lengths_name);
 
 	zval property_num_rows_default_value;
 	ZVAL_UNDEF(&property_num_rows_default_value);
-	zend_string *property_num_rows_name = zend_string_init("num_rows", sizeof("num_rows") - 1, 1);
+	zend_string *property_num_rows_name = zend_string_init("num_rows", strlen("num_rows"), 1);
 	zend_declare_typed_property(class_entry, property_num_rows_name, &property_num_rows_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_num_rows_name);
 
 	zval property_type_default_value;
 	ZVAL_UNDEF(&property_type_default_value);
-	zend_string *property_type_name = zend_string_init("type", sizeof("type") - 1, 1);
+	zend_string *property_type_name = zend_string_init("type", strlen("type"), 1);
 	zend_declare_typed_property(class_entry, property_type_name, &property_type_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_type_name);
 
@@ -1300,61 +1300,61 @@ static zend_class_entry *register_class_mysqli_stmt(void)
 
 	zval property_affected_rows_default_value;
 	ZVAL_UNDEF(&property_affected_rows_default_value);
-	zend_string *property_affected_rows_name = zend_string_init("affected_rows", sizeof("affected_rows") - 1, 1);
+	zend_string *property_affected_rows_name = zend_string_init("affected_rows", strlen("affected_rows"), 1);
 	zend_declare_typed_property(class_entry, property_affected_rows_name, &property_affected_rows_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_affected_rows_name);
 
 	zval property_insert_id_default_value;
 	ZVAL_UNDEF(&property_insert_id_default_value);
-	zend_string *property_insert_id_name = zend_string_init("insert_id", sizeof("insert_id") - 1, 1);
+	zend_string *property_insert_id_name = zend_string_init("insert_id", strlen("insert_id"), 1);
 	zend_declare_typed_property(class_entry, property_insert_id_name, &property_insert_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_insert_id_name);
 
 	zval property_num_rows_default_value;
 	ZVAL_UNDEF(&property_num_rows_default_value);
-	zend_string *property_num_rows_name = zend_string_init("num_rows", sizeof("num_rows") - 1, 1);
+	zend_string *property_num_rows_name = zend_string_init("num_rows", strlen("num_rows"), 1);
 	zend_declare_typed_property(class_entry, property_num_rows_name, &property_num_rows_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_STRING));
 	zend_string_release(property_num_rows_name);
 
 	zval property_param_count_default_value;
 	ZVAL_UNDEF(&property_param_count_default_value);
-	zend_string *property_param_count_name = zend_string_init("param_count", sizeof("param_count") - 1, 1);
+	zend_string *property_param_count_name = zend_string_init("param_count", strlen("param_count"), 1);
 	zend_declare_typed_property(class_entry, property_param_count_name, &property_param_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_param_count_name);
 
 	zval property_field_count_default_value;
 	ZVAL_UNDEF(&property_field_count_default_value);
-	zend_string *property_field_count_name = zend_string_init("field_count", sizeof("field_count") - 1, 1);
+	zend_string *property_field_count_name = zend_string_init("field_count", strlen("field_count"), 1);
 	zend_declare_typed_property(class_entry, property_field_count_name, &property_field_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_field_count_name);
 
 	zval property_errno_default_value;
 	ZVAL_UNDEF(&property_errno_default_value);
-	zend_string *property_errno_name = zend_string_init("errno", sizeof("errno") - 1, 1);
+	zend_string *property_errno_name = zend_string_init("errno", strlen("errno"), 1);
 	zend_declare_typed_property(class_entry, property_errno_name, &property_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_errno_name);
 
 	zval property_error_default_value;
 	ZVAL_UNDEF(&property_error_default_value);
-	zend_string *property_error_name = zend_string_init("error", sizeof("error") - 1, 1);
+	zend_string *property_error_name = zend_string_init("error", strlen("error"), 1);
 	zend_declare_typed_property(class_entry, property_error_name, &property_error_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_error_name);
 
 	zval property_error_list_default_value;
 	ZVAL_UNDEF(&property_error_list_default_value);
-	zend_string *property_error_list_name = zend_string_init("error_list", sizeof("error_list") - 1, 1);
+	zend_string *property_error_list_name = zend_string_init("error_list", strlen("error_list"), 1);
 	zend_declare_typed_property(class_entry, property_error_list_name, &property_error_list_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_error_list_name);
 
 	zval property_sqlstate_default_value;
 	ZVAL_UNDEF(&property_sqlstate_default_value);
-	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
+	zend_string *property_sqlstate_name = zend_string_init("sqlstate", strlen("sqlstate"), 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_sqlstate_name);
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_id_name);
 
@@ -1371,19 +1371,19 @@ static zend_class_entry *register_class_mysqli_warning(void)
 
 	zval property_message_default_value;
 	ZVAL_UNDEF(&property_message_default_value);
-	zend_string *property_message_name = zend_string_init("message", sizeof("message") - 1, 1);
+	zend_string *property_message_name = zend_string_init("message", strlen("message"), 1);
 	zend_declare_typed_property(class_entry, property_message_name, &property_message_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_message_name);
 
 	zval property_sqlstate_default_value;
 	ZVAL_UNDEF(&property_sqlstate_default_value);
-	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
+	zend_string *property_sqlstate_name = zend_string_init("sqlstate", strlen("sqlstate"), 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_sqlstate_name);
 
 	zval property_errno_default_value;
 	ZVAL_UNDEF(&property_errno_default_value);
-	zend_string *property_errno_name = zend_string_init("errno", sizeof("errno") - 1, 1);
+	zend_string *property_errno_name = zend_string_init("errno", strlen("errno"), 1);
 	zend_declare_typed_property(class_entry, property_errno_name, &property_errno_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_errno_name);
 
@@ -1399,9 +1399,9 @@ static zend_class_entry *register_class_mysqli_sql_exception(zend_class_entry *c
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 
 	zval property_sqlstate_default_value;
-	zend_string *property_sqlstate_default_value_str = zend_string_init("00000", sizeof("00000") - 1, 1);
+	zend_string *property_sqlstate_default_value_str = zend_string_init("00000", strlen("00000"), 1);
 	ZVAL_STR(&property_sqlstate_default_value, property_sqlstate_default_value_str);
-	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
+	zend_string *property_sqlstate_name = zend_string_init("sqlstate", strlen("sqlstate"), 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_sqlstate_name);
 

--- a/ext/mysqli/mysqli_exception.c
+++ b/ext/mysqli/mysqli_exception.c
@@ -47,19 +47,19 @@ void php_mysqli_throw_sql_exception(char *sqlstate, int errorno, char *format, .
 
 	if (message) {
 		zend_update_property_string(
-			mysqli_exception_class_entry, Z_OBJ(sql_ex), "message", sizeof("message") - 1, message);
+			mysqli_exception_class_entry, Z_OBJ(sql_ex), "message", strlen("message"), message);
 	}
 
 	if (sqlstate) {
 		zend_update_property_string(
-			mysqli_exception_class_entry, Z_OBJ(sql_ex), "sqlstate", sizeof("sqlstate") - 1, sqlstate);
+			mysqli_exception_class_entry, Z_OBJ(sql_ex), "sqlstate", strlen("sqlstate"), sqlstate);
 	} else {
 		zend_update_property_string(
-			mysqli_exception_class_entry, Z_OBJ(sql_ex), "sqlstate", sizeof("sqlstate") - 1, "00000");
+			mysqli_exception_class_entry, Z_OBJ(sql_ex), "sqlstate", strlen("sqlstate"), "00000");
 	}
 
 	efree(message);
-	zend_update_property_long(mysqli_exception_class_entry, Z_OBJ(sql_ex), "code", sizeof("code") - 1, errorno);
+	zend_update_property_long(mysqli_exception_class_entry, Z_OBJ(sql_ex), "code", strlen("code"), errorno);
 
 	zend_throw_exception_object(&sql_ex);
 }
@@ -71,7 +71,7 @@ PHP_METHOD(mysqli_sql_exception, getSqlState)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	prop = zend_read_property(mysqli_exception_class_entry, Z_OBJ_P(ZEND_THIS), "sqlstate", sizeof("sqlstate")-1, 1, &rv);
+	prop = zend_read_property(mysqli_exception_class_entry, Z_OBJ_P(ZEND_THIS), "sqlstate", strlen("sqlstate"), 1, &rv);
 	ZVAL_DEREF(prop);
 	zend_string *str = zval_get_string(prop);
 	

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -549,9 +549,9 @@ PHP_FUNCTION(mysqli_error_list)
 		{
 			zval single_error;
 			array_init(&single_error);
-			add_assoc_long_ex(&single_error, "errno", sizeof("errno") - 1, message->error_no);
-			add_assoc_string_ex(&single_error, "sqlstate", sizeof("sqlstate") - 1, message->sqlstate);
-			add_assoc_string_ex(&single_error, "error", sizeof("error") - 1, message->error);
+			add_assoc_long_ex(&single_error, "errno", strlen("errno"), message->error_no);
+			add_assoc_string_ex(&single_error, "sqlstate", strlen("sqlstate"), message->sqlstate);
+			add_assoc_string_ex(&single_error, "error", strlen("error"), message->error);
 			add_next_index_zval(return_value, &single_error);
 		}
 	} else {
@@ -562,9 +562,9 @@ PHP_FUNCTION(mysqli_error_list)
 		zval single_error;
 		array_init(return_value);
 		array_init(&single_error);
-		add_assoc_long_ex(&single_error, "errno", sizeof("errno") - 1, mysql_errno(mysql->mysql));
-		add_assoc_string_ex(&single_error, "sqlstate", sizeof("sqlstate") - 1, mysql_sqlstate(mysql->mysql));
-		add_assoc_string_ex(&single_error, "error", sizeof("error") - 1, mysql_error(mysql->mysql));
+		add_assoc_long_ex(&single_error, "errno", strlen("errno"), mysql_errno(mysql->mysql));
+		add_assoc_string_ex(&single_error, "sqlstate", strlen("sqlstate"), mysql_sqlstate(mysql->mysql));
+		add_assoc_string_ex(&single_error, "error", strlen("error"), mysql_error(mysql->mysql));
 		add_next_index_zval(return_value, &single_error);
 	} else {
 		RETURN_EMPTY_ARRAY();
@@ -594,9 +594,9 @@ PHP_FUNCTION(mysqli_stmt_error_list)
 		{
 			zval single_error;
 			array_init(&single_error);
-			add_assoc_long_ex(&single_error, "errno", sizeof("errno") - 1, message->error_no);
-			add_assoc_string_ex(&single_error, "sqlstate", sizeof("sqlstate") - 1, message->sqlstate);
-			add_assoc_string_ex(&single_error, "error", sizeof("error") - 1, message->error);
+			add_assoc_long_ex(&single_error, "errno", strlen("errno"), message->error_no);
+			add_assoc_string_ex(&single_error, "sqlstate", strlen("sqlstate"), message->sqlstate);
+			add_assoc_string_ex(&single_error, "error", strlen("error"), message->error);
 			add_next_index_zval(return_value, &single_error);
 		}
 	} else {
@@ -607,9 +607,9 @@ PHP_FUNCTION(mysqli_stmt_error_list)
 		zval single_error;
 		array_init(return_value);
 		array_init(&single_error);
-		add_assoc_long_ex(&single_error, "errno", sizeof("errno") - 1, mysql_stmt_errno(stmt->stmt));
-		add_assoc_string_ex(&single_error, "sqlstate", sizeof("sqlstate") - 1, mysql_stmt_sqlstate(stmt->stmt));
-		add_assoc_string_ex(&single_error, "error", sizeof("error") - 1, mysql_stmt_error(stmt->stmt));
+		add_assoc_long_ex(&single_error, "errno", strlen("errno"), mysql_stmt_errno(stmt->stmt));
+		add_assoc_string_ex(&single_error, "sqlstate", strlen("sqlstate"), mysql_stmt_sqlstate(stmt->stmt));
+		add_assoc_string_ex(&single_error, "error", strlen("error"), mysql_stmt_error(stmt->stmt));
 		add_next_index_zval(return_value, &single_error);
 	} else {
 		RETURN_EMPTY_ARRAY();
@@ -1166,20 +1166,20 @@ static int mysqli_begin_transaction_libmysql(MYSQL * conn, const unsigned int mo
 	unsigned int query_len;
 	if (mode & TRANS_START_WITH_CONSISTENT_SNAPSHOT) {
 		if (tmp_str.s) {
-			smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
+			smart_str_appendl(&tmp_str, ", ", strlen(", "));
 		}
-		smart_str_appendl(&tmp_str, "WITH CONSISTENT SNAPSHOT", sizeof("WITH CONSISTENT SNAPSHOT") - 1);
+		smart_str_appendl(&tmp_str, "WITH CONSISTENT SNAPSHOT", strlen("WITH CONSISTENT SNAPSHOT"));
 	}
 	if (mode & TRANS_START_READ_WRITE) {
 		if (tmp_str.s) {
-			smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
+			smart_str_appendl(&tmp_str, ", ", strlen(", "));
 		}
-		smart_str_appendl(&tmp_str, "READ WRITE", sizeof("READ WRITE") - 1);
+		smart_str_appendl(&tmp_str, "READ WRITE", strlen("READ WRITE"));
 	} else if (mode & TRANS_START_READ_ONLY) {
 		if (tmp_str.s) {
-			smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
+			smart_str_appendl(&tmp_str, ", ", strlen(", "));
 		}
-		smart_str_appendl(&tmp_str, "READ ONLY", sizeof("READ ONLY") - 1);
+		smart_str_appendl(&tmp_str, "READ ONLY", strlen("READ ONLY"));
 	}
 	smart_str_0(&tmp_str);
 
@@ -1315,8 +1315,8 @@ PHP_FUNCTION(mysqli_get_links_stats)
 	}
 
 	array_init(return_value);
-	add_assoc_long_ex(return_value, "total", sizeof("total") - 1, MyG(num_links));
-	add_assoc_long_ex(return_value, "active_plinks", sizeof("active_plinks") - 1, MyG(num_active_persistent));
-	add_assoc_long_ex(return_value, "cached_plinks", sizeof("cached_plinks") - 1, MyG(num_inactive_persistent));
+	add_assoc_long_ex(return_value, "total", strlen("total"), MyG(num_links));
+	add_assoc_long_ex(return_value, "active_plinks", strlen("active_plinks"), MyG(num_active_persistent));
+	add_assoc_long_ex(return_value, "cached_plinks", strlen("cached_plinks"), MyG(num_inactive_persistent));
 }
 /* }}} */

--- a/ext/mysqli/mysqli_prop.c
+++ b/ext/mysqli/mysqli_prop.c
@@ -214,9 +214,9 @@ static int link_error_list_read(mysqli_object *obj, zval *retval, bool quiet)
 			{
 				zval single_error;
 				array_init(&single_error);
-				add_assoc_long_ex(&single_error, "errno", sizeof("errno") - 1, message->error_no);
-				add_assoc_string_ex(&single_error, "sqlstate", sizeof("sqlstate") - 1, message->sqlstate);
-				add_assoc_string_ex(&single_error, "error", sizeof("error") - 1, message->error);
+				add_assoc_long_ex(&single_error, "errno", strlen("errno"), message->error_no);
+				add_assoc_string_ex(&single_error, "sqlstate", strlen("sqlstate"), message->sqlstate);
+				add_assoc_string_ex(&single_error, "error", strlen("error"), message->error);
 				add_next_index_zval(retval, &single_error);
 			}
 		}
@@ -224,9 +224,9 @@ static int link_error_list_read(mysqli_object *obj, zval *retval, bool quiet)
 		if (mysql_errno(mysql->mysql)) {
 			zval single_error;
 			array_init(&single_error);
-			add_assoc_long_ex(&single_error, "errno", sizeof("errno") - 1, mysql_errno(mysql->mysql));
-			add_assoc_string_ex(&single_error, "sqlstate", sizeof("sqlstate") - 1, mysql_sqlstate(mysql->mysql));
-			add_assoc_string_ex(&single_error, "error", sizeof("error") - 1, mysql_error(mysql->mysql));
+			add_assoc_long_ex(&single_error, "errno", strlen("errno"), mysql_errno(mysql->mysql));
+			add_assoc_string_ex(&single_error, "sqlstate", strlen("sqlstate"), mysql_sqlstate(mysql->mysql));
+			add_assoc_string_ex(&single_error, "error", strlen("error"), mysql_error(mysql->mysql));
 			add_next_index_zval(retval, &single_error);
 		}
 #endif
@@ -369,9 +369,9 @@ static int stmt_error_list_read(mysqli_object *obj, zval *retval, bool quiet)
 			{
 				zval single_error;
 				array_init(&single_error);
-				add_assoc_long_ex(&single_error, "errno", sizeof("errno") - 1, message->error_no);
-				add_assoc_string_ex(&single_error, "sqlstate", sizeof("sqlstate") - 1, message->sqlstate);
-				add_assoc_string_ex(&single_error, "error", sizeof("error") - 1, message->error);
+				add_assoc_long_ex(&single_error, "errno", strlen("errno"), message->error_no);
+				add_assoc_string_ex(&single_error, "sqlstate", strlen("sqlstate"), message->sqlstate);
+				add_assoc_string_ex(&single_error, "error", strlen("error"), message->error);
 				add_next_index_zval(retval, &single_error);
 			}
 		}
@@ -379,9 +379,9 @@ static int stmt_error_list_read(mysqli_object *obj, zval *retval, bool quiet)
 		if (mysql_stmt_errno(stmt->stmt)) {
 			zval single_error;
 			array_init(&single_error);
-			add_assoc_long_ex(&single_error, "errno", sizeof("errno") - 1, mysql_stmt_errno(stmt->stmt));
-			add_assoc_string_ex(&single_error, "sqlstate", sizeof("sqlstate") - 1, mysql_stmt_sqlstate(stmt->stmt));
-			add_assoc_string_ex(&single_error, "error", sizeof("error") - 1, mysql_stmt_error(stmt->stmt));
+			add_assoc_long_ex(&single_error, "errno", strlen("errno"), mysql_stmt_errno(stmt->stmt));
+			add_assoc_string_ex(&single_error, "sqlstate", strlen("sqlstate"), mysql_stmt_sqlstate(stmt->stmt));
+			add_assoc_string_ex(&single_error, "error", strlen("error"), mysql_stmt_error(stmt->stmt));
 			add_next_index_zval(retval, &single_error);
 		}
 #endif

--- a/ext/mysqli/mysqli_warning.c
+++ b/ext/mysqli/mysqli_warning.c
@@ -59,7 +59,7 @@ MYSQLI_WARNING *php_new_warning(const char *reason, int errorno)
 
 	ZVAL_UTF8_STRING(&(w->reason), reason, ZSTR_DUPLICATE);
 
-	ZVAL_UTF8_STRINGL(&(w->sqlstate), "HY000", sizeof("HY000") - 1,  ZSTR_DUPLICATE);
+	ZVAL_UTF8_STRINGL(&(w->sqlstate), "HY000", strlen("HY000"),  ZSTR_DUPLICATE);
 
 	w->errorno = errorno;
 
@@ -106,7 +106,7 @@ MYSQLI_WARNING *php_new_warning(zval * reason, int errorno)
 	ZVAL_COPY(&w->reason, reason);
 	convert_to_string(&w->reason);
 
-	ZVAL_UTF8_STRINGL(&(w->sqlstate), "HY000", sizeof("HY000") - 1,  ZSTR_DUPLICATE);
+	ZVAL_UTF8_STRINGL(&(w->sqlstate), "HY000", strlen("HY000"),  ZSTR_DUPLICATE);
 
 	w->errorno = errorno;
 

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -520,7 +520,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_scheme)(MYSQLND_CONN_DATA * conn, MYSQLND_
 	MYSQLND_STRING transport;
 	DBG_ENTER("mysqlnd_conn_data::get_scheme");
 #ifndef PHP_WIN32
-	if (hostname.l == sizeof("localhost") - 1 && !strncasecmp(hostname.s, "localhost", hostname.l)) {
+	if (hostname.l == strlen("localhost") && !strncasecmp(hostname.s, "localhost", hostname.l)) {
 		DBG_INF_FMT("socket=%s", socket_or_pipe->s? socket_or_pipe->s:"n/a");
 		if (!socket_or_pipe->s) {
 			socket_or_pipe->s = "/tmp/mysql.sock";
@@ -529,7 +529,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, get_scheme)(MYSQLND_CONN_DATA * conn, MYSQLND_
 		transport.l = mnd_sprintf(&transport.s, 0, "unix://%s", socket_or_pipe->s);
 		*unix_socket = TRUE;
 #else
-	if (hostname.l == sizeof(".") - 1 && hostname.s[0] == '.') {
+	if (hostname.l == strlen(".") && hostname.s[0] == '.') {
 		/* named pipe in socket */
 		if (!socket_or_pipe->s) {
 			socket_or_pipe->s = "\\\\.\\pipe\\MySQL";
@@ -1669,7 +1669,7 @@ static enum_func_status
 MYSQLND_METHOD(mysqlnd_conn_data, set_autocommit)(MYSQLND_CONN_DATA * conn, unsigned int mode)
 {
 	DBG_ENTER("mysqlnd_conn_data::set_autocommit");
-	DBG_RETURN(conn->m->query(conn, (mode) ? "SET AUTOCOMMIT=1":"SET AUTOCOMMIT=0", sizeof("SET AUTOCOMMIT=1") - 1));
+	DBG_RETURN(conn->m->query(conn, (mode) ? "SET AUTOCOMMIT=1":"SET AUTOCOMMIT=0", strlen("SET AUTOCOMMIT=1")));
 }
 /* }}} */
 
@@ -1698,26 +1698,26 @@ MYSQLND_METHOD(mysqlnd_conn_data, tx_cor_options_to_string)(const MYSQLND_CONN_D
 {
 	if ((mode & TRANS_COR_AND_CHAIN) && !(mode & TRANS_COR_AND_NO_CHAIN)) {
 		if (str->s && ZSTR_LEN(str->s)) {
-			smart_str_appendl(str, " ", sizeof(" ") - 1);
+			smart_str_appendl(str, " ", strlen(" "));
 		}
-		smart_str_appendl(str, "AND CHAIN", sizeof("AND CHAIN") - 1);
+		smart_str_appendl(str, "AND CHAIN", strlen("AND CHAIN"));
 	} else if ((mode & TRANS_COR_AND_NO_CHAIN) && !(mode & TRANS_COR_AND_CHAIN)) {
 		if (str->s && ZSTR_LEN(str->s)) {
-			smart_str_appendl(str, " ", sizeof(" ") - 1);
+			smart_str_appendl(str, " ", strlen(" "));
 		}
-		smart_str_appendl(str, "AND NO CHAIN", sizeof("AND NO CHAIN") - 1);
+		smart_str_appendl(str, "AND NO CHAIN", strlen("AND NO CHAIN"));
 	}
 
 	if ((mode & TRANS_COR_RELEASE) && !(mode & TRANS_COR_NO_RELEASE)) {
 		if (str->s && ZSTR_LEN(str->s)) {
-			smart_str_appendl(str, " ", sizeof(" ") - 1);
+			smart_str_appendl(str, " ", strlen(" "));
 		}
-		smart_str_appendl(str, "RELEASE", sizeof("RELEASE") - 1);
+		smart_str_appendl(str, "RELEASE", strlen("RELEASE"));
 	} else if ((mode & TRANS_COR_NO_RELEASE) && !(mode & TRANS_COR_RELEASE)) {
 		if (str->s && ZSTR_LEN(str->s)) {
-			smart_str_appendl(str, " ", sizeof(" ") - 1);
+			smart_str_appendl(str, " ", strlen(" "));
 		}
-		smart_str_appendl(str, "NO RELEASE", sizeof("NO RELEASE") - 1);
+		smart_str_appendl(str, "NO RELEASE", strlen("NO RELEASE"));
 	}
 	smart_str_0(str);
 }
@@ -1809,20 +1809,20 @@ MYSQLND_METHOD(mysqlnd_conn_data, tx_begin)(MYSQLND_CONN_DATA * conn, const unsi
 	smart_str tmp_str = {0, 0};
 	if (mode & TRANS_START_WITH_CONSISTENT_SNAPSHOT) {
 		if (tmp_str.s) {
-			smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
+			smart_str_appendl(&tmp_str, ", ", strlen(", "));
 		}
-		smart_str_appendl(&tmp_str, "WITH CONSISTENT SNAPSHOT", sizeof("WITH CONSISTENT SNAPSHOT") - 1);
+		smart_str_appendl(&tmp_str, "WITH CONSISTENT SNAPSHOT", strlen("WITH CONSISTENT SNAPSHOT"));
 	}
 	if (mode & TRANS_START_READ_WRITE) {
 		if (tmp_str.s && ZSTR_LEN(tmp_str.s)) {
-			smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
+			smart_str_appendl(&tmp_str, ", ", strlen(", "));
 		}
-		smart_str_appendl(&tmp_str, "READ WRITE", sizeof("READ WRITE") - 1);
+		smart_str_appendl(&tmp_str, "READ WRITE", strlen("READ WRITE"));
 	} else if (mode & TRANS_START_READ_ONLY) {
 		if (tmp_str.s && ZSTR_LEN(tmp_str.s)) {
-			smart_str_appendl(&tmp_str, ", ", sizeof(", ") - 1);
+			smart_str_appendl(&tmp_str, ", ", strlen(", "));
 		}
-		smart_str_appendl(&tmp_str, "READ ONLY", sizeof("READ ONLY") - 1);
+		smart_str_appendl(&tmp_str, "READ ONLY", strlen("READ ONLY"));
 	}
 	smart_str_0(&tmp_str);
 

--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -127,7 +127,7 @@ MYSQLND_METHOD(mysqlnd_vio, open_pipe)(MYSQLND_VIO * const vio, const MYSQLND_CS
 		streams_options |= STREAM_OPEN_PERSISTENT;
 	}
 	streams_options |= IGNORE_URL;
-	net_stream = php_stream_open_wrapper(scheme.s + sizeof("pipe://") - 1, "r+", streams_options, NULL);
+	net_stream = php_stream_open_wrapper(scheme.s + strlen("pipe://"), "r+", streams_options, NULL);
 	if (!net_stream) {
 		SET_CLIENT_ERROR(error_info, CR_CONNECTION_ERROR, UNKNOWN_SQLSTATE, "Unknown error while connecting");
 		DBG_RETURN(NULL);
@@ -255,7 +255,7 @@ MYSQLND_METHOD(mysqlnd_vio, post_connect_set_opt)(MYSQLND_VIO * const vio, const
 			php_stream_set_option(net_stream, PHP_STREAM_OPTION_READ_TIMEOUT, 0, &tv);
 		}
 
-		if (!memcmp(scheme.s, "tcp://", sizeof("tcp://") - 1)) {
+		if (!memcmp(scheme.s, "tcp://", strlen("tcp://"))) {
 			/* TCP -> Set TCP_NODELAY */
 			mysqlnd_set_sock_no_delay(net_stream);
 			/* TCP -> Set SO_KEEPALIVE */
@@ -278,11 +278,11 @@ MYSQLND_METHOD(mysqlnd_vio, get_open_stream)(MYSQLND_VIO * const vio, const MYSQ
 {
 	func_mysqlnd_vio__open_stream ret = NULL;
 	DBG_ENTER("mysqlnd_vio::get_open_stream");
-	if (scheme.l > (sizeof("pipe://") - 1) && !memcmp(scheme.s, "pipe://", sizeof("pipe://") - 1)) {
+	if (scheme.l > (strlen("pipe://")) && !memcmp(scheme.s, "pipe://", strlen("pipe://"))) {
 		ret = vio->data->m.open_pipe;
-	} else if ((scheme.l > (sizeof("tcp://") - 1) && !memcmp(scheme.s, "tcp://", sizeof("tcp://") - 1))
+	} else if ((scheme.l > (strlen("tcp://")) && !memcmp(scheme.s, "tcp://", strlen("tcp://")))
 				||
-				(scheme.l > (sizeof("unix://") - 1) && !memcmp(scheme.s, "unix://", sizeof("unix://") - 1)))
+				(scheme.l > (strlen("unix://")) && !memcmp(scheme.s, "unix://", strlen("unix://"))))
 	{
 		ret = vio->data->m.open_tcp_or_unix;
 	}

--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -954,33 +954,33 @@ php_oci_connection *php_oci_do_connect_ex(char *username, int username_len, char
 		use_spool = 0;
 	}
 
-	smart_str_appendl_ex(&hashed_details, "oci8***", sizeof("oci8***") - 1, 0);
+	smart_str_appendl_ex(&hashed_details, "oci8***", strlen("oci8***"), 0);
 	smart_str_appendl_ex(&hashed_details, username, username_len, 0);
-	smart_str_appendl_ex(&hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&hashed_details, "**", strlen("**"), 0);
 
 	/* DRCP: connection_class is an attribute of a connection */
 	if (OCI_G(connection_class)){
 		smart_str_appendl_ex(&hashed_details, OCI_G(connection_class), strlen(OCI_G(connection_class)), 0);
 	}
-	smart_str_appendl_ex(&hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&hashed_details, "**", strlen("**"), 0);
 
 	/* Add edition attribute to the hash */
 	if (OCI_G(edition)){
 		smart_str_appendl_ex(&hashed_details, OCI_G(edition), strlen(OCI_G(edition)), 0);
 	}
-	smart_str_appendl_ex(&hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&hashed_details, "**", strlen("**"), 0);
 
 	if (password_len) {
 		zend_ulong password_hash;
 		password_hash = zend_hash_func(password, password_len);
 		smart_str_append_unsigned_ex(&hashed_details, password_hash, 0);
 	}
-	smart_str_appendl_ex(&hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&hashed_details, "**", strlen("**"), 0);
 
 	if (dbname) {
 		smart_str_appendl_ex(&hashed_details, dbname, dbname_len, 0);
 	}
-	smart_str_appendl_ex(&hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&hashed_details, "**", strlen("**"), 0);
 
 	if (charset && *charset) {
 		PHP_OCI_CALL_RETURN(charsetid, OCINlsCharSetNameToId, (OCI_G(env), (CONST oratext *)charset));
@@ -1007,7 +1007,7 @@ php_oci_connection *php_oci_do_connect_ex(char *username, int username_len, char
 
 	smart_str_append_unsigned_ex(&hashed_details, session_mode, 0);
 	if (persistent) {
-		smart_str_appendl_ex(&hashed_details, "pc", sizeof("pc") - 1, 0);
+		smart_str_appendl_ex(&hashed_details, "pc", strlen("pc"), 0);
 	}
 
 	smart_str_0(&hashed_details);
@@ -2075,25 +2075,25 @@ static php_oci_spool *php_oci_get_spool(char *username, int username_len, char *
 	zval *spool_out_zv = NULL;
 
 	/* {{{ Create the spool hash key */
-	smart_str_appendl_ex(&spool_hashed_details, "oci8spool***", sizeof("oci8spool***") - 1, 0);
+	smart_str_appendl_ex(&spool_hashed_details, "oci8spool***", strlen("oci8spool***"), 0);
 	smart_str_appendl_ex(&spool_hashed_details, username, username_len, 0);
-	smart_str_appendl_ex(&spool_hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&spool_hashed_details, "**", strlen("**"), 0);
 	/* Add edition attribute to the hash */
 	if (OCI_G(edition)){
 		smart_str_appendl_ex(&spool_hashed_details, OCI_G(edition), strlen(OCI_G(edition)), 0);
 	}
-	smart_str_appendl_ex(&spool_hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&spool_hashed_details, "**", strlen("**"), 0);
 	if (password_len) {
 		zend_ulong password_hash;
 		password_hash = zend_hash_func(password, password_len);
 		smart_str_append_unsigned_ex(&spool_hashed_details, password_hash, 0);
 	}
-	smart_str_appendl_ex(&spool_hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&spool_hashed_details, "**", strlen("**"), 0);
 
 	if (dbname_len) {
 		smart_str_appendl_ex(&spool_hashed_details, dbname, dbname_len, 0);
 	}
-	smart_str_appendl_ex(&spool_hashed_details, "**", sizeof("**") - 1, 0);
+	smart_str_appendl_ex(&spool_hashed_details, "**", strlen("**"), 0);
 
 	smart_str_append_unsigned_ex(&spool_hashed_details, charsetid, 0);
 

--- a/ext/oci8/oci8_interface.c
+++ b/ext/oci8/oci8_interface.c
@@ -233,7 +233,7 @@ PHP_FUNCTION(oci_free_descriptor)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -264,7 +264,7 @@ PHP_FUNCTION(oci_lob_save)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -290,7 +290,7 @@ PHP_FUNCTION(oci_lob_import)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -316,7 +316,7 @@ PHP_FUNCTION(oci_lob_load)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -356,7 +356,7 @@ PHP_FUNCTION(oci_lob_read)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -388,7 +388,7 @@ PHP_FUNCTION(oci_lob_eof)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -414,7 +414,7 @@ PHP_FUNCTION(oci_lob_tell)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -435,7 +435,7 @@ PHP_FUNCTION(oci_lob_rewind)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -460,7 +460,7 @@ PHP_FUNCTION(oci_lob_seek)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -507,7 +507,7 @@ PHP_FUNCTION(oci_lob_size)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -540,7 +540,7 @@ PHP_FUNCTION(oci_lob_write)
 		data_len = MIN((zend_long) data_len, write_len);
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -568,12 +568,12 @@ PHP_FUNCTION(oci_lob_append)
 		RETURN_THROWS();
 	}
 
-	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_dest), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_dest), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property. The first argument should be valid descriptor object");
 		RETURN_FALSE;
 	}
 
-	if ((tmp_from = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_from), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp_from = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_from), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property. The second argument should be valid descriptor object");
 		RETURN_FALSE;
 	}
@@ -606,7 +606,7 @@ PHP_FUNCTION(oci_lob_truncate)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -648,7 +648,7 @@ PHP_FUNCTION(oci_lob_erase)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -673,7 +673,7 @@ PHP_FUNCTION(oci_lob_flush)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -703,7 +703,7 @@ PHP_FUNCTION(ocisetbufferinglob)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -727,7 +727,7 @@ PHP_FUNCTION(ocigetbufferinglob)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -760,12 +760,12 @@ PHP_FUNCTION(oci_lob_copy)
 		RETURN_THROWS();
 	}
 
-	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_dest), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_dest), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property. The first argument should be valid descriptor object");
 		RETURN_FALSE;
 	}
 
-	if ((tmp_from = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_from), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp_from = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_from), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property. The second argument should be valid descriptor object");
 		RETURN_FALSE;
 	}
@@ -791,12 +791,12 @@ PHP_FUNCTION(oci_lob_is_equal)
 		RETURN_THROWS();
 	}
 
-	if ((tmp_first = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_first), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp_first = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_first), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property. The first argument should be valid descriptor object");
 		RETURN_FALSE;
 	}
 
-	if ((tmp_second = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_second), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp_second = zend_hash_str_find(Z_OBJPROP_P(z_descriptor_second), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property. The second argument should be valid descriptor object");
 		RETURN_FALSE;
 	}
@@ -846,7 +846,7 @@ PHP_FUNCTION(oci_lob_export)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -928,7 +928,7 @@ PHP_METHOD(OCILob, writeTemporary)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -952,7 +952,7 @@ PHP_METHOD(OCILob, close)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", sizeof("descriptor")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_descriptor), "descriptor", strlen("descriptor"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 		RETURN_FALSE;
 	}
@@ -2097,7 +2097,7 @@ PHP_FUNCTION(oci_free_collection)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
 		RETURN_FALSE;
 	}
@@ -2121,7 +2121,7 @@ PHP_FUNCTION(oci_collection_append)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
 		RETURN_FALSE;
 	}
@@ -2146,7 +2146,7 @@ PHP_FUNCTION(oci_collection_element_get)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
 		RETURN_FALSE;
 	}
@@ -2169,12 +2169,12 @@ PHP_FUNCTION(oci_collection_assign)
 		RETURN_THROWS();
 	}
 
-	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_collection_dest), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp_dest = zend_hash_str_find(Z_OBJPROP_P(z_collection_dest), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property. The first argument should be valid collection object");
 		RETURN_FALSE;
 	}
 
-	if ((tmp_from = zend_hash_str_find(Z_OBJPROP_P(z_collection_from), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp_from = zend_hash_str_find(Z_OBJPROP_P(z_collection_from), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property. The second argument should be valid collection object");
 		RETURN_FALSE;
 	}
@@ -2202,7 +2202,7 @@ PHP_FUNCTION(oci_collection_element_assign)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
 		RETURN_FALSE;
 	}
@@ -2227,7 +2227,7 @@ PHP_FUNCTION(oci_collection_size)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
 		RETURN_FALSE;
 	}
@@ -2252,7 +2252,7 @@ PHP_FUNCTION(oci_collection_max)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
 		RETURN_FALSE;
 	}
@@ -2277,7 +2277,7 @@ PHP_FUNCTION(oci_collection_trim)
 		RETURN_THROWS();
 	}
 
-	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", sizeof("collection")-1)) == NULL) {
+	if ((tmp = zend_hash_str_find(Z_OBJPROP_P(z_collection), "collection", strlen("collection"))) == NULL) {
 		php_error_docref(NULL, E_WARNING, "Unable to find collection property");
 		RETURN_FALSE;
 	}

--- a/ext/oci8/oci8_statement.c
+++ b/ext/oci8/oci8_statement.c
@@ -1139,7 +1139,7 @@ int php_oci_bind_by_name(php_oci_statement *statement, char *name, size_t name_l
 		{
 			zval *tmp;
 
-			if (Z_TYPE_P(param) != IS_OBJECT || (tmp = zend_hash_str_find(Z_OBJPROP_P(param), "collection", sizeof("collection")-1)) == NULL) {
+			if (Z_TYPE_P(param) != IS_OBJECT || (tmp = zend_hash_str_find(Z_OBJPROP_P(param), "collection", strlen("collection"))) == NULL) {
 				php_error_docref(NULL, E_WARNING, "Unable to find collection property");
 				return 1;
 			}
@@ -1161,7 +1161,7 @@ int php_oci_bind_by_name(php_oci_statement *statement, char *name, size_t name_l
 		{
 			zval *tmp;
 
-			if (Z_TYPE_P(param) != IS_OBJECT || (tmp = zend_hash_str_find(Z_OBJPROP_P(param), "descriptor", sizeof("descriptor")-1)) == NULL) {
+			if (Z_TYPE_P(param) != IS_OBJECT || (tmp = zend_hash_str_find(Z_OBJPROP_P(param), "descriptor", strlen("descriptor"))) == NULL) {
 				php_error_docref(NULL, E_WARNING, "Unable to find descriptor property");
 				return 1;
 			}
@@ -1480,7 +1480,7 @@ sb4 php_oci_bind_out_callback(
 		 * out-bind as the contents would have been changed for in/out
 		 * binds (Bug #46994).
 		 */
-		if ((tmp = zend_hash_str_find(Z_OBJPROP_P(val), "descriptor", sizeof("descriptor")-1)) == NULL) {
+		if ((tmp = zend_hash_str_find(Z_OBJPROP_P(val), "descriptor", strlen("descriptor"))) == NULL) {
 			php_error_docref(NULL, E_WARNING, "Unable to find object outbind descriptor property");
 			return OCI_ERROR;
 		}
@@ -1952,7 +1952,7 @@ php_oci_bind *php_oci_bind_array_helper_date(zval *var, zend_long max_table_leng
 			((OCIDate *)bind->array.elements)[i] = oci_date;
 			zend_hash_move_forward(hash);
 		} else {
-			PHP_OCI_CALL_RETURN(errstatus, OCIDateFromText, (connection->err, (CONST text *)"01-JAN-00", sizeof("01-JAN-00")-1, NULL, 0, NULL, 0, &oci_date));
+			PHP_OCI_CALL_RETURN(errstatus, OCIDateFromText, (connection->err, (CONST text *)"01-JAN-00", strlen("01-JAN-00"), NULL, 0, NULL, 0, &oci_date));
 
 			if (errstatus != OCI_SUCCESS) {
 				/* failed to convert string to date */

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -1253,8 +1253,8 @@ PHP_FUNCTION(odbc_data_source)
 
 	array_init(return_value);
 
-	add_assoc_string_ex(return_value, "server", sizeof("server")-1, (char *) server_name);
-	add_assoc_string_ex(return_value, "description", sizeof("description")-1, (char *) desc);
+	add_assoc_string_ex(return_value, "server", strlen("server"), (char *) server_name);
+	add_assoc_string_ex(return_value, "description", strlen("description"), (char *) desc);
 
 }
 /* }}} */

--- a/ext/opcache/jit/dynasm/minilua.c
+++ b/ext/opcache/jit/dynasm/minilua.c
@@ -7575,7 +7575,7 @@ size_t l=strlen(form);
 char spec=form[l-1];
 strcpy(form+l-1,"l");
 form[l+sizeof("l")-2]=spec;
-form[l+sizeof("l")-1]='\0';
+form[l+strlen("l")]='\0';
 }
 static int str_format(lua_State*L){
 int top=lua_gettop(L);

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -388,15 +388,15 @@ void zend_accel_override_file_functions(void)
 			return;
 		}
 		/* override file_exists */
-		if ((old_function = zend_hash_str_find_ptr(CG(function_table), "file_exists", sizeof("file_exists")-1)) != NULL) {
+		if ((old_function = zend_hash_str_find_ptr(CG(function_table), "file_exists", strlen("file_exists"))) != NULL) {
 			orig_file_exists = old_function->internal_function.handler;
 			old_function->internal_function.handler = accel_file_exists;
 		}
-		if ((old_function = zend_hash_str_find_ptr(CG(function_table), "is_file", sizeof("is_file")-1)) != NULL) {
+		if ((old_function = zend_hash_str_find_ptr(CG(function_table), "is_file", strlen("is_file"))) != NULL) {
 			orig_is_file = old_function->internal_function.handler;
 			old_function->internal_function.handler = accel_is_file;
 		}
-		if ((old_function = zend_hash_str_find_ptr(CG(function_table), "is_readable", sizeof("is_readable")-1)) != NULL) {
+		if ((old_function = zend_hash_str_find_ptr(CG(function_table), "is_readable", strlen("is_readable"))) != NULL) {
 			orig_is_readable = old_function->internal_function.handler;
 			old_function->internal_function.handler = accel_is_readable;
 		}

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -408,7 +408,7 @@ static void zend_persist_op_array_ex(zend_op_array *op_array, zend_persistent_sc
 		memset(&fake_execute_data, 0, sizeof(fake_execute_data));
 		fake_execute_data.func = (zend_function*)op_array;
 		EG(current_execute_data) = &fake_execute_data;
-		if ((offset = zend_get_constant_str("__COMPILER_HALT_OFFSET__", sizeof("__COMPILER_HALT_OFFSET__") - 1)) != NULL) {
+		if ((offset = zend_get_constant_str("__COMPILER_HALT_OFFSET__", strlen("__COMPILER_HALT_OFFSET__"))) != NULL) {
 			main_persistent_script->compiler_halt_offset = Z_LVAL_P(offset);
 		}
 		EG(current_execute_data) = orig_execute_data;
@@ -1125,23 +1125,23 @@ void zend_update_parent_ce(zend_class_entry *ce)
 		if (ce->iterator_funcs_ptr) {
 			memset(ce->iterator_funcs_ptr, 0, sizeof(zend_class_iterator_funcs));
 			if (zend_class_implements_interface(ce, zend_ce_aggregate)) {
-				ce->iterator_funcs_ptr->zf_new_iterator = zend_hash_str_find_ptr(&ce->function_table, "getiterator", sizeof("getiterator") - 1);
+				ce->iterator_funcs_ptr->zf_new_iterator = zend_hash_str_find_ptr(&ce->function_table, "getiterator", strlen("getiterator"));
 			}
 			if (zend_class_implements_interface(ce, zend_ce_iterator)) {
-				ce->iterator_funcs_ptr->zf_rewind = zend_hash_str_find_ptr(&ce->function_table, "rewind", sizeof("rewind") - 1);
-				ce->iterator_funcs_ptr->zf_valid = zend_hash_str_find_ptr(&ce->function_table, "valid", sizeof("valid") - 1);
-				ce->iterator_funcs_ptr->zf_key = zend_hash_str_find_ptr(&ce->function_table, "key", sizeof("key") - 1);
-				ce->iterator_funcs_ptr->zf_current = zend_hash_str_find_ptr(&ce->function_table, "current", sizeof("current") - 1);
-				ce->iterator_funcs_ptr->zf_next = zend_hash_str_find_ptr(&ce->function_table, "next", sizeof("next") - 1);
+				ce->iterator_funcs_ptr->zf_rewind = zend_hash_str_find_ptr(&ce->function_table, "rewind", strlen("rewind"));
+				ce->iterator_funcs_ptr->zf_valid = zend_hash_str_find_ptr(&ce->function_table, "valid", strlen("valid"));
+				ce->iterator_funcs_ptr->zf_key = zend_hash_str_find_ptr(&ce->function_table, "key", strlen("key"));
+				ce->iterator_funcs_ptr->zf_current = zend_hash_str_find_ptr(&ce->function_table, "current", strlen("current"));
+				ce->iterator_funcs_ptr->zf_next = zend_hash_str_find_ptr(&ce->function_table, "next", strlen("next"));
 			}
 		}
 
 		if (ce->arrayaccess_funcs_ptr) {
 			ZEND_ASSERT(zend_class_implements_interface(ce, zend_ce_arrayaccess));
-			ce->arrayaccess_funcs_ptr->zf_offsetget = zend_hash_str_find_ptr(&ce->function_table, "offsetget", sizeof("offsetget") - 1);
-			ce->arrayaccess_funcs_ptr->zf_offsetexists = zend_hash_str_find_ptr(&ce->function_table, "offsetexists", sizeof("offsetexists") - 1);
-			ce->arrayaccess_funcs_ptr->zf_offsetset = zend_hash_str_find_ptr(&ce->function_table, "offsetset", sizeof("offsetset") - 1);
-			ce->arrayaccess_funcs_ptr->zf_offsetunset = zend_hash_str_find_ptr(&ce->function_table, "offsetunset", sizeof("offsetunset") - 1);
+			ce->arrayaccess_funcs_ptr->zf_offsetget = zend_hash_str_find_ptr(&ce->function_table, "offsetget", strlen("offsetget"));
+			ce->arrayaccess_funcs_ptr->zf_offsetexists = zend_hash_str_find_ptr(&ce->function_table, "offsetexists", strlen("offsetexists"));
+			ce->arrayaccess_funcs_ptr->zf_offsetset = zend_hash_str_find_ptr(&ce->function_table, "offsetset", strlen("offsetset"));
+			ce->arrayaccess_funcs_ptr->zf_offsetunset = zend_hash_str_find_ptr(&ce->function_table, "offsetunset", strlen("offsetunset"));
 		}
 	}
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -863,7 +863,7 @@ static int php_openssl_parse_config(struct php_x509_request * req, zval * option
 		php_openssl_conf_get_number(req->req_config, req->section_name, "default_bits"));
 	SET_OPTIONAL_LONG_ARG("private_key_type", req->priv_key_type, OPENSSL_KEYTYPE_DEFAULT);
 
-	if (optional_args && (item = zend_hash_str_find(Z_ARRVAL_P(optional_args), "encrypt_key", sizeof("encrypt_key")-1)) != NULL) {
+	if (optional_args && (item = zend_hash_str_find(Z_ARRVAL_P(optional_args), "encrypt_key", strlen("encrypt_key"))) != NULL) {
 		req->priv_key_encrypt = Z_TYPE_P(item) == IS_TRUE ? 1 : 0;
 	} else {
 		str = php_openssl_conf_get_string(req->req_config, req->section_name, "encrypt_rsa_key");
@@ -879,7 +879,7 @@ static int php_openssl_parse_config(struct php_x509_request * req, zval * option
 
 	if (req->priv_key_encrypt &&
 		optional_args &&
-		(item = zend_hash_str_find(Z_ARRVAL_P(optional_args), "encrypt_key_cipher", sizeof("encrypt_key_cipher")-1)) != NULL &&
+		(item = zend_hash_str_find(Z_ARRVAL_P(optional_args), "encrypt_key_cipher", strlen("encrypt_key_cipher"))) != NULL &&
 		Z_TYPE_P(item) == IS_LONG
 	) {
 		zend_long cipher_algo = Z_LVAL_P(item);
@@ -910,7 +910,7 @@ static int php_openssl_parse_config(struct php_x509_request * req, zval * option
 #ifdef HAVE_EVP_PKEY_EC
 	/* set the ec group curve name */
 	req->curve_name = NID_undef;
-	if (optional_args && (item = zend_hash_str_find(Z_ARRVAL_P(optional_args), "curve_name", sizeof("curve_name")-1)) != NULL
+	if (optional_args && (item = zend_hash_str_find(Z_ARRVAL_P(optional_args), "curve_name", strlen("curve_name"))) != NULL
 		&& Z_TYPE_P(item) == IS_STRING) {
 		req->curve_name = OBJ_sn2nid(Z_STRVAL_P(item));
 		if (req->curve_name == NID_undef) {
@@ -1391,9 +1391,9 @@ PHP_FUNCTION(openssl_get_cert_locations)
 	add_assoc_string(return_value, "default_private_dir", (char *) X509_get_default_private_dir());
 	add_assoc_string(return_value, "default_default_cert_area", (char *) X509_get_default_cert_area());
 	add_assoc_string(return_value, "ini_cafile",
-		zend_ini_string("openssl.cafile", sizeof("openssl.cafile")-1, 0));
+		zend_ini_string("openssl.cafile", strlen("openssl.cafile"), 0));
 	add_assoc_string(return_value, "ini_capath",
-		zend_ini_string("openssl.capath", sizeof("openssl.capath")-1, 0));
+		zend_ini_string("openssl.capath", strlen("openssl.capath"), 0));
 }
 /* }}} */
 
@@ -1401,12 +1401,12 @@ static X509 *php_openssl_x509_from_str(zend_string *cert_str) {
 	X509 *cert = NULL;
 	BIO *in;
 
-	if (ZSTR_LEN(cert_str) > 7 && memcmp(ZSTR_VAL(cert_str), "file://", sizeof("file://") - 1) == 0) {
-		if (php_openssl_open_base_dir_chk(ZSTR_VAL(cert_str) + (sizeof("file://") - 1))) {
+	if (ZSTR_LEN(cert_str) > 7 && memcmp(ZSTR_VAL(cert_str), "file://", strlen("file://")) == 0) {
+		if (php_openssl_open_base_dir_chk(ZSTR_VAL(cert_str) + (strlen("file://")))) {
 			return NULL;
 		}
 
-		in = BIO_new_file(ZSTR_VAL(cert_str) + (sizeof("file://") - 1), PHP_OPENSSL_BIO_MODE_R(PKCS7_BINARY));
+		in = BIO_new_file(ZSTR_VAL(cert_str) + (strlen("file://")), PHP_OPENSSL_BIO_MODE_R(PKCS7_BINARY));
 		if (in == NULL) {
 			php_openssl_store_errors();
 			return NULL;
@@ -2579,7 +2579,7 @@ PHP_FUNCTION(openssl_pkcs12_export_to_file)
 
 	/* parse extra config from args array, promote this to an extra function */
 	if (args &&
-		(item = zend_hash_str_find(Z_ARRVAL_P(args), "friendly_name", sizeof("friendly_name")-1)) != NULL &&
+		(item = zend_hash_str_find(Z_ARRVAL_P(args), "friendly_name", strlen("friendly_name"))) != NULL &&
 		Z_TYPE_P(item) == IS_STRING
 	) {
 		friendly_name = Z_STRVAL_P(item);
@@ -2589,7 +2589,7 @@ PHP_FUNCTION(openssl_pkcs12_export_to_file)
 	   friendly_caname
 	*/
 
-	if (args && (item = zend_hash_str_find(Z_ARRVAL_P(args), "extracerts", sizeof("extracerts")-1)) != NULL) {
+	if (args && (item = zend_hash_str_find(Z_ARRVAL_P(args), "extracerts", strlen("extracerts"))) != NULL) {
 		ca = php_array_to_X509_sk(item);
 	}
 	/* end parse extra config */
@@ -2674,13 +2674,13 @@ PHP_FUNCTION(openssl_pkcs12_export)
 
 	/* parse extra config from args array, promote this to an extra function */
 	if (args &&
-		(item = zend_hash_str_find(Z_ARRVAL_P(args), "friendly_name", sizeof("friendly_name")-1)) != NULL &&
+		(item = zend_hash_str_find(Z_ARRVAL_P(args), "friendly_name", strlen("friendly_name"))) != NULL &&
 		Z_TYPE_P(item) == IS_STRING
 	) {
 		friendly_name = Z_STRVAL_P(item);
 	}
 
-	if (args && (item = zend_hash_str_find(Z_ARRVAL_P(args), "extracerts", sizeof("extracerts")-1)) != NULL) {
+	if (args && (item = zend_hash_str_find(Z_ARRVAL_P(args), "extracerts", strlen("extracerts"))) != NULL) {
 		ca = php_array_to_X509_sk(item);
 	}
 	/* end parse extra config */
@@ -2898,7 +2898,7 @@ static int php_openssl_make_REQ(struct php_x509_request * req, X509_REQ * csr, z
 			if (len < sizeof("_default")) {
 				continue;
 			}
-			len -= sizeof("_default") - 1;
+			len -= strlen("_default");
 			if (strcmp("_default", type + len) != 0) {
 				continue;
 			}
@@ -2997,8 +2997,8 @@ static X509_REQ *php_openssl_csr_from_str(zend_string *csr_str)
 	char * filename = NULL;
 	BIO * in;
 
-	if (ZSTR_LEN(csr_str) > 7 && memcmp(ZSTR_VAL(csr_str), "file://", sizeof("file://") - 1) == 0) {
-		filename = ZSTR_VAL(csr_str) + (sizeof("file://") - 1);
+	if (ZSTR_LEN(csr_str) > 7 && memcmp(ZSTR_VAL(csr_str), "file://", strlen("file://")) == 0) {
+		filename = ZSTR_VAL(csr_str) + (strlen("file://"));
 	}
 
 	if (filename) {
@@ -3566,8 +3566,8 @@ static EVP_PKEY *php_openssl_pkey_from_zval(zval *val, int public_key, char *pas
 			TMP_CLEAN;
 		}
 
-		if (Z_STRLEN_P(val) > 7 && memcmp(Z_STRVAL_P(val), "file://", sizeof("file://") - 1) == 0) {
-			filename = Z_STRVAL_P(val) + (sizeof("file://") - 1);
+		if (Z_STRLEN_P(val) > 7 && memcmp(Z_STRVAL_P(val), "file://", strlen("file://")) == 0) {
+			filename = Z_STRVAL_P(val) + (strlen("file://"));
 			if (php_openssl_open_base_dir_chk(filename)) {
 				TMP_CLEAN;
 			}
@@ -4239,7 +4239,7 @@ static bool php_openssl_pkey_init_legacy_ec(EC_KEY *eckey, zval *data, bool *is_
 
 	*is_private = false;
 
-	if ((bn = zend_hash_str_find(Z_ARRVAL_P(data), "curve_name", sizeof("curve_name") - 1)) != NULL &&
+	if ((bn = zend_hash_str_find(Z_ARRVAL_P(data), "curve_name", strlen("curve_name"))) != NULL &&
 			Z_TYPE_P(bn) == IS_STRING) {
 		int nid = OBJ_sn2nid(Z_STRVAL_P(bn));
 		if (nid != NID_undef) {
@@ -4263,7 +4263,7 @@ static bool php_openssl_pkey_init_legacy_ec(EC_KEY *eckey, zval *data, bool *is_
 	}
 
 	// The public key 'pnt' can be calculated from 'd' or is defined by 'x' and 'y'
-	if ((bn = zend_hash_str_find(Z_ARRVAL_P(data), "d", sizeof("d") - 1)) != NULL &&
+	if ((bn = zend_hash_str_find(Z_ARRVAL_P(data), "d", strlen("d"))) != NULL &&
 			Z_TYPE_P(bn) == IS_STRING) {
 		*is_private = true;
 		d = BN_bin2bn((unsigned char*) Z_STRVAL_P(bn), Z_STRLEN_P(bn), NULL);
@@ -4280,9 +4280,9 @@ static bool php_openssl_pkey_init_legacy_ec(EC_KEY *eckey, zval *data, bool *is_
 		}
 
 		BN_free(d);
-	} else if ((x = zend_hash_str_find(Z_ARRVAL_P(data), "x", sizeof("x") - 1)) != NULL &&
+	} else if ((x = zend_hash_str_find(Z_ARRVAL_P(data), "x", strlen("x"))) != NULL &&
 			Z_TYPE_P(x) == IS_STRING &&
-			(y = zend_hash_str_find(Z_ARRVAL_P(data), "y", sizeof("y") - 1)) != NULL &&
+			(y = zend_hash_str_find(Z_ARRVAL_P(data), "y", strlen("y"))) != NULL &&
 			Z_TYPE_P(y) == IS_STRING) {
 		pnt = EC_POINT_new(group);
 		if (pnt == NULL) {
@@ -4337,7 +4337,7 @@ static EVP_PKEY *php_openssl_pkey_init_ec(zval *data, bool *is_private) {
 	EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
 	OSSL_PARAM *params = NULL;
 	OSSL_PARAM_BLD *bld = OSSL_PARAM_BLD_new();
-	zval *curve_name_zv = zend_hash_str_find(Z_ARRVAL_P(data), "curve_name", sizeof("curve_name") - 1);
+	zval *curve_name_zv = zend_hash_str_find(Z_ARRVAL_P(data), "curve_name", strlen("curve_name"));
 
 	OPENSSL_PKEY_SET_BN(data, d);
 	OPENSSL_PKEY_SET_BN(data, x);
@@ -4462,7 +4462,7 @@ PHP_FUNCTION(openssl_pkey_new)
 	if (args && Z_TYPE_P(args) == IS_ARRAY) {
 		EVP_PKEY *pkey;
 
-		if ((data = zend_hash_str_find(Z_ARRVAL_P(args), "rsa", sizeof("rsa")-1)) != NULL &&
+		if ((data = zend_hash_str_find(Z_ARRVAL_P(args), "rsa", strlen("rsa"))) != NULL &&
 			Z_TYPE_P(data) == IS_ARRAY) {
 			pkey = php_openssl_pkey_init_rsa(data);
 			if (!pkey) {
@@ -4470,7 +4470,7 @@ PHP_FUNCTION(openssl_pkey_new)
 			}
 			php_openssl_pkey_object_init(return_value, pkey, /* is_private */ true);
 			return;
-		} else if ((data = zend_hash_str_find(Z_ARRVAL_P(args), "dsa", sizeof("dsa") - 1)) != NULL &&
+		} else if ((data = zend_hash_str_find(Z_ARRVAL_P(args), "dsa", strlen("dsa"))) != NULL &&
 			Z_TYPE_P(data) == IS_ARRAY) {
 			bool is_private;
 			pkey = php_openssl_pkey_init_dsa(data, &is_private);
@@ -4479,7 +4479,7 @@ PHP_FUNCTION(openssl_pkey_new)
 			}
 			php_openssl_pkey_object_init(return_value, pkey, is_private);
 			return;
-		} else if ((data = zend_hash_str_find(Z_ARRVAL_P(args), "dh", sizeof("dh") - 1)) != NULL &&
+		} else if ((data = zend_hash_str_find(Z_ARRVAL_P(args), "dh", strlen("dh"))) != NULL &&
 			Z_TYPE_P(data) == IS_ARRAY) {
 			bool is_private;
 			pkey = php_openssl_pkey_init_dh(data, &is_private);
@@ -4489,7 +4489,7 @@ PHP_FUNCTION(openssl_pkey_new)
 			php_openssl_pkey_object_init(return_value, pkey, is_private);
 			return;
 #ifdef HAVE_EVP_PKEY_EC
-		} else if ((data = zend_hash_str_find(Z_ARRVAL_P(args), "ec", sizeof("ec") - 1)) != NULL &&
+		} else if ((data = zend_hash_str_find(Z_ARRVAL_P(args), "ec", strlen("ec"))) != NULL &&
 			Z_TYPE_P(data) == IS_ARRAY) {
 			bool is_private;
 			pkey = php_openssl_pkey_init_ec(data, &is_private);
@@ -4686,7 +4686,7 @@ PHP_FUNCTION(openssl_pkey_get_private)
 	zval *cert;
 	EVP_PKEY *pkey;
 	char * passphrase = "";
-	size_t passphrase_len = sizeof("")-1;
+	size_t passphrase_len = strlen("");
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|s!", &cert, &passphrase, &passphrase_len) == FAILURE) {
 		RETURN_THROWS();

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -837,7 +837,7 @@ static int php_openssl_enable_peer_verification(SSL_CTX *ctx, php_stream *stream
 	GET_VER_OPT_STRING("capath", capath);
 
 	if (cafile == NULL) {
-		cafile = zend_ini_string("openssl.cafile", sizeof("openssl.cafile")-1, 0);
+		cafile = zend_ini_string("openssl.cafile", strlen("openssl.cafile"), 0);
 		cafile = strlen(cafile) ? cafile : NULL;
 	} else if (!sslsock->is_client) {
 		/* Servers need to load and assign CA names from the cafile */
@@ -851,7 +851,7 @@ static int php_openssl_enable_peer_verification(SSL_CTX *ctx, php_stream *stream
 	}
 
 	if (capath == NULL) {
-		capath = zend_ini_string("openssl.capath", sizeof("openssl.capath")-1, 0);
+		capath = zend_ini_string("openssl.capath", strlen("openssl.capath"), 0);
 		capath = strlen(capath) ? capath : NULL;
 	}
 
@@ -1432,7 +1432,7 @@ static int php_openssl_enable_server_sni(php_stream *stream, php_openssl_netstre
 			zend_string *local_pk_str, *local_cert_str;
 			char resolved_cert_path_buff[MAXPATHLEN], resolved_pk_path_buff[MAXPATHLEN];
 
-			local_cert = zend_hash_str_find(Z_ARRVAL_P(current), "local_cert", sizeof("local_cert")-1);
+			local_cert = zend_hash_str_find(Z_ARRVAL_P(current), "local_cert", strlen("local_cert"));
 			if (local_cert == NULL) {
 				php_error_docref(NULL, E_WARNING,
 					"local_cert not present in the array"
@@ -1454,7 +1454,7 @@ static int php_openssl_enable_server_sni(php_stream *stream, php_openssl_netstre
 			}
 			zend_string_release(local_cert_str);
 
-			local_pk = zend_hash_str_find(Z_ARRVAL_P(current), "local_pk", sizeof("local_pk")-1);
+			local_pk = zend_hash_str_find(Z_ARRVAL_P(current), "local_pk", strlen("local_pk"));
 			if (local_pk == NULL) {
 				php_error_docref(NULL, E_WARNING,
 					"local_pk not present in the array"

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -1196,47 +1196,47 @@ static void pcntl_siginfo_to_zval(int signo, siginfo_t *siginfo, zval *user_sigi
 			return;
 		}
 
-		add_assoc_long_ex(user_siginfo, "signo", sizeof("signo")-1, siginfo->si_signo);
-		add_assoc_long_ex(user_siginfo, "errno", sizeof("errno")-1, siginfo->si_errno);
-		add_assoc_long_ex(user_siginfo, "code",  sizeof("code")-1,  siginfo->si_code);
+		add_assoc_long_ex(user_siginfo, "signo", strlen("signo"), siginfo->si_signo);
+		add_assoc_long_ex(user_siginfo, "errno", strlen("errno"), siginfo->si_errno);
+		add_assoc_long_ex(user_siginfo, "code",  strlen("code"),  siginfo->si_code);
 		switch(signo) {
 #ifdef SIGCHLD
 			case SIGCHLD:
-				add_assoc_long_ex(user_siginfo,   "status", sizeof("status")-1, siginfo->si_status);
+				add_assoc_long_ex(user_siginfo,   "status", strlen("status"), siginfo->si_status);
 # ifdef si_utime
-				add_assoc_double_ex(user_siginfo, "utime",  sizeof("utime")-1,  siginfo->si_utime);
+				add_assoc_double_ex(user_siginfo, "utime",  strlen("utime"),  siginfo->si_utime);
 # endif
 # ifdef si_stime
-				add_assoc_double_ex(user_siginfo, "stime",  sizeof("stime")-1,  siginfo->si_stime);
+				add_assoc_double_ex(user_siginfo, "stime",  strlen("stime"),  siginfo->si_stime);
 # endif
-				add_assoc_long_ex(user_siginfo,   "pid",    sizeof("pid")-1,    siginfo->si_pid);
-				add_assoc_long_ex(user_siginfo,   "uid",    sizeof("uid")-1,    siginfo->si_uid);
+				add_assoc_long_ex(user_siginfo,   "pid",    strlen("pid"),    siginfo->si_pid);
+				add_assoc_long_ex(user_siginfo,   "uid",    strlen("uid"),    siginfo->si_uid);
 				break;
 			case SIGUSR1:
 			case SIGUSR2:
-				add_assoc_long_ex(user_siginfo,   "pid",    sizeof("pid")-1,    siginfo->si_pid);
-				add_assoc_long_ex(user_siginfo,   "uid",    sizeof("uid")-1,    siginfo->si_uid);
+				add_assoc_long_ex(user_siginfo,   "pid",    strlen("pid"),    siginfo->si_pid);
+				add_assoc_long_ex(user_siginfo,   "uid",    strlen("uid"),    siginfo->si_uid);
 				break;
 #endif
 			case SIGILL:
 			case SIGFPE:
 			case SIGSEGV:
 			case SIGBUS:
-				add_assoc_double_ex(user_siginfo, "addr", sizeof("addr")-1, (zend_long)siginfo->si_addr);
+				add_assoc_double_ex(user_siginfo, "addr", strlen("addr"), (zend_long)siginfo->si_addr);
 				break;
 #if defined(SIGPOLL) && !defined(__CYGWIN__)
 			case SIGPOLL:
-				add_assoc_long_ex(user_siginfo, "band", sizeof("band")-1, siginfo->si_band);
+				add_assoc_long_ex(user_siginfo, "band", strlen("band"), siginfo->si_band);
 # ifdef si_fd
-				add_assoc_long_ex(user_siginfo, "fd",   sizeof("fd")-1,   siginfo->si_fd);
+				add_assoc_long_ex(user_siginfo, "fd",   strlen("fd"),   siginfo->si_fd);
 # endif
 				break;
 #endif
 		}
 #if defined(SIGRTMIN) && defined(SIGRTMAX)
 		if (SIGRTMIN <= signo && signo <= SIGRTMAX) {
-			add_assoc_long_ex(user_siginfo, "pid", sizeof("pid")-1, siginfo->si_pid);
-			add_assoc_long_ex(user_siginfo, "uid", sizeof("uid")-1, siginfo->si_uid);
+			add_assoc_long_ex(user_siginfo, "pid", strlen("pid"), siginfo->si_pid);
+			add_assoc_long_ex(user_siginfo, "uid", strlen("uid"), siginfo->si_uid);
 		}
 #endif
 	}

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -1124,7 +1124,7 @@ static void populate_subpat_array(
 	}
 	/* Add MARK, if available */
 	if (mark) {
-		add_assoc_string_ex(subpats, "MARK", sizeof("MARK") - 1, (char *)mark);
+		add_assoc_string_ex(subpats, "MARK", strlen("MARK"), (char *)mark);
 	}
 }
 

--- a/ext/pdo/pdo.c
+++ b/ext/pdo/pdo.c
@@ -114,7 +114,7 @@ PDO_API zend_result php_pdo_register_driver(const pdo_driver_t *driver) /* {{{ *
 			driver->driver_name, driver->api_version, PDO_DRIVER_API);
 		return FAILURE;
 	}
-	if (!zend_hash_str_exists(&module_registry, "pdo", sizeof("pdo") - 1)) {
+	if (!zend_hash_str_exists(&module_registry, "pdo", strlen("pdo"))) {
 		zend_error(E_ERROR, "You MUST load PDO before loading any PDO drivers");
 		return FAILURE;	/* NOTREACHED */
 	}
@@ -125,7 +125,7 @@ PDO_API zend_result php_pdo_register_driver(const pdo_driver_t *driver) /* {{{ *
 
 PDO_API void php_pdo_unregister_driver(const pdo_driver_t *driver) /* {{{ */
 {
-	if (!zend_hash_str_exists(&module_registry, "pdo", sizeof("pdo") - 1)) {
+	if (!zend_hash_str_exists(&module_registry, "pdo", strlen("pdo"))) {
 		return;
 	}
 

--- a/ext/pdo/pdo_arginfo.h
+++ b/ext/pdo/pdo_arginfo.h
@@ -27,13 +27,13 @@ static zend_class_entry *register_class_PDOException(zend_class_entry *class_ent
 
 	zval property_code_default_value;
 	ZVAL_LONG(&property_code_default_value, 0);
-	zend_string *property_code_name = zend_string_init("code", sizeof("code") - 1, 1);
+	zend_string *property_code_name = zend_string_init("code", strlen("code"), 1);
 	zend_declare_property_ex(class_entry, property_code_name, &property_code_default_value, ZEND_ACC_PROTECTED, NULL);
 	zend_string_release(property_code_name);
 
 	zval property_errorInfo_default_value;
 	ZVAL_NULL(&property_errorInfo_default_value);
-	zend_string *property_errorInfo_name = zend_string_init("errorInfo", sizeof("errorInfo") - 1, 1);
+	zend_string *property_errorInfo_name = zend_string_init("errorInfo", strlen("errorInfo"), 1);
 	zend_declare_typed_property(class_entry, property_errorInfo_name, &property_errorInfo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property_errorInfo_name);
 

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -48,13 +48,13 @@ void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_e
 		add_next_index_string(&error_info, driver_errmsg);
 
 		spprintf(&pdo_exception_message, 0,"SQLSTATE[%s] [%d] %s",*pdo_error, driver_errcode, driver_errmsg);
-		zend_update_property(php_pdo_get_exception(), Z_OBJ(pdo_exception), "errorInfo", sizeof("errorInfo")-1, &error_info);
-		zend_update_property_long(php_pdo_get_exception(), Z_OBJ(pdo_exception), "code", sizeof("code")-1, driver_errcode);
+		zend_update_property(php_pdo_get_exception(), Z_OBJ(pdo_exception), "errorInfo", strlen("errorInfo"), &error_info);
+		zend_update_property_long(php_pdo_get_exception(), Z_OBJ(pdo_exception), "code", strlen("code"), driver_errcode);
 		zend_update_property_string(
 			php_pdo_get_exception(),
 			Z_OBJ(pdo_exception),
 			"message",
-			sizeof("message")-1,
+			strlen("message"),
 			pdo_exception_message
 		);
 		efree(pdo_exception_message);
@@ -103,14 +103,14 @@ void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *sqlstate
 
 		object_init_ex(&ex, pdo_ex);
 
-		zend_update_property_string(zend_ce_exception, Z_OBJ(ex), "message", sizeof("message")-1, message);
-		zend_update_property_string(zend_ce_exception, Z_OBJ(ex), "code", sizeof("code")-1, *pdo_err);
+		zend_update_property_string(zend_ce_exception, Z_OBJ(ex), "message", strlen("message"), message);
+		zend_update_property_string(zend_ce_exception, Z_OBJ(ex), "code", strlen("code"), *pdo_err);
 
 		array_init(&info);
 
 		add_next_index_string(&info, *pdo_err);
 		add_next_index_long(&info, 0);
-		zend_update_property(pdo_ex, Z_OBJ(ex), "errorInfo", sizeof("errorInfo")-1, &info);
+		zend_update_property(pdo_ex, Z_OBJ(ex), "errorInfo", strlen("errorInfo"), &info);
 		zval_ptr_dtor(&info);
 
 		zend_throw_exception_object(&ex);
@@ -180,11 +180,11 @@ PDO_API void pdo_handle_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt) /* {{{ */
 
 		object_init_ex(&ex, pdo_ex);
 
-		zend_update_property_str(zend_ce_exception, Z_OBJ(ex), "message", sizeof("message") - 1, message);
-		zend_update_property_string(zend_ce_exception, Z_OBJ(ex), "code", sizeof("code") - 1, *pdo_err);
+		zend_update_property_str(zend_ce_exception, Z_OBJ(ex), "message", strlen("message"), message);
+		zend_update_property_string(zend_ce_exception, Z_OBJ(ex), "code", strlen("code"), *pdo_err);
 
 		if (!Z_ISUNDEF(info)) {
-			zend_update_property(pdo_ex, Z_OBJ(ex), "errorInfo", sizeof("errorInfo") - 1, &info);
+			zend_update_property(pdo_ex, Z_OBJ(ex), "errorInfo", strlen("errorInfo"), &info);
 		}
 
 		zend_throw_exception_object(&ex);
@@ -265,9 +265,9 @@ PHP_METHOD(PDO, __construct)
 		}
 	}
 
-	if (!strncmp(data_source, "uri:", sizeof("uri:")-1)) {
+	if (!strncmp(data_source, "uri:", strlen("uri:"))) {
 		/* the specified URI holds connection details */
-		data_source = dsn_from_uri(data_source + sizeof("uri:")-1, alt_dsn, sizeof(alt_dsn));
+		data_source = dsn_from_uri(data_source + strlen("uri:"), alt_dsn, sizeof(alt_dsn));
 		if (!data_source) {
 			zend_argument_error(php_pdo_get_exception(), 1, "must be a valid data source URI");
 			RETURN_THROWS();
@@ -458,7 +458,7 @@ static void pdo_stmt_construct(zend_execute_data *execute_data, pdo_stmt_t *stmt
 	zend_string *key;
 
 	ZVAL_STR(&query_string, stmt->query_string);
-	key = zend_string_init("queryString", sizeof("queryString") - 1, 0);
+	key = zend_string_init("queryString", strlen("queryString"), 0);
 	zend_std_write_property(Z_OBJ_P(object), key, &query_string, NULL);
 	zend_string_release_ex(key, 0);
 

--- a/ext/pdo/pdo_stmt_arginfo.h
+++ b/ext/pdo/pdo_stmt_arginfo.h
@@ -150,7 +150,7 @@ static zend_class_entry *register_class_PDOStatement(zend_class_entry *class_ent
 
 	zval property_queryString_default_value;
 	ZVAL_UNDEF(&property_queryString_default_value);
-	zend_string *property_queryString_name = zend_string_init("queryString", sizeof("queryString") - 1, 1);
+	zend_string *property_queryString_name = zend_string_init("queryString", strlen("queryString"), 1);
 	zend_declare_typed_property(class_entry, property_queryString_name, &property_queryString_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_queryString_name);
 
@@ -167,7 +167,7 @@ static zend_class_entry *register_class_PDORow(void)
 
 	zval property_queryString_default_value;
 	ZVAL_UNDEF(&property_queryString_default_value);
-	zend_string *property_queryString_name = zend_string_init("queryString", sizeof("queryString") - 1, 1);
+	zend_string *property_queryString_name = zend_string_init("queryString", strlen("queryString"), 1);
 	zend_declare_typed_property(class_entry, property_queryString_name, &property_queryString_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_queryString_name);
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -435,33 +435,33 @@ static int pdo_pgsql_get_attribute(pdo_dbh_t *dbh, zend_long attr, zval *return_
 		case PDO_ATTR_CONNECTION_STATUS:
 			switch (PQstatus(H->server)) {
 				case CONNECTION_STARTED:
-					ZVAL_STRINGL(return_value, "Waiting for connection to be made.", sizeof("Waiting for connection to be made.")-1);
+					ZVAL_STRINGL(return_value, "Waiting for connection to be made.", strlen("Waiting for connection to be made."));
 					break;
 
 				case CONNECTION_MADE:
 				case CONNECTION_OK:
-					ZVAL_STRINGL(return_value, "Connection OK; waiting to send.", sizeof("Connection OK; waiting to send.")-1);
+					ZVAL_STRINGL(return_value, "Connection OK; waiting to send.", strlen("Connection OK; waiting to send."));
 					break;
 
 				case CONNECTION_AWAITING_RESPONSE:
-					ZVAL_STRINGL(return_value, "Waiting for a response from the server.", sizeof("Waiting for a response from the server.")-1);
+					ZVAL_STRINGL(return_value, "Waiting for a response from the server.", strlen("Waiting for a response from the server."));
 					break;
 
 				case CONNECTION_AUTH_OK:
-					ZVAL_STRINGL(return_value, "Received authentication; waiting for backend start-up to finish.", sizeof("Received authentication; waiting for backend start-up to finish.")-1);
+					ZVAL_STRINGL(return_value, "Received authentication; waiting for backend start-up to finish.", strlen("Received authentication; waiting for backend start-up to finish."));
 					break;
 #ifdef CONNECTION_SSL_STARTUP
 				case CONNECTION_SSL_STARTUP:
-					ZVAL_STRINGL(return_value, "Negotiating SSL encryption.", sizeof("Negotiating SSL encryption.")-1);
+					ZVAL_STRINGL(return_value, "Negotiating SSL encryption.", strlen("Negotiating SSL encryption."));
 					break;
 #endif
 				case CONNECTION_SETENV:
-					ZVAL_STRINGL(return_value, "Negotiating environment-driven parameter settings.", sizeof("Negotiating environment-driven parameter settings.")-1);
+					ZVAL_STRINGL(return_value, "Negotiating environment-driven parameter settings.", strlen("Negotiating environment-driven parameter settings."));
 					break;
 
 				case CONNECTION_BAD:
 				default:
-					ZVAL_STRINGL(return_value, "Bad connection.", sizeof("Bad connection.")-1);
+					ZVAL_STRINGL(return_value, "Bad connection.", strlen("Bad connection."));
 					break;
 			}
 			break;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -4326,26 +4326,26 @@ PHP_PGSQL_API zend_result php_pgsql_meta_data(PGconn *pg_link, const zend_string
 		char *name;
 		array_init(&elem);
 		/* pg_attribute.attnum */
-		add_assoc_long_ex(&elem, "num", sizeof("num") - 1, atoi(PQgetvalue(pg_result, i, 1)));
+		add_assoc_long_ex(&elem, "num", strlen("num"), atoi(PQgetvalue(pg_result, i, 1)));
 		/* pg_type.typname */
-		add_assoc_string_ex(&elem, "type", sizeof("type") - 1, PQgetvalue(pg_result, i, 2));
+		add_assoc_string_ex(&elem, "type", strlen("type"), PQgetvalue(pg_result, i, 2));
 		/* pg_attribute.attlen */
-		add_assoc_long_ex(&elem, "len", sizeof("len") - 1, atoi(PQgetvalue(pg_result,i,3)));
+		add_assoc_long_ex(&elem, "len", strlen("len"), atoi(PQgetvalue(pg_result,i,3)));
 		/* pg_attribute.attnonull */
-		add_assoc_bool_ex(&elem, "not null", sizeof("not null") - 1, !strcmp(PQgetvalue(pg_result, i, 4), "t"));
+		add_assoc_bool_ex(&elem, "not null", strlen("not null"), !strcmp(PQgetvalue(pg_result, i, 4), "t"));
 		/* pg_attribute.atthasdef */
-		add_assoc_bool_ex(&elem, "has default", sizeof("has default") - 1, !strcmp(PQgetvalue(pg_result,i,5), "t"));
+		add_assoc_bool_ex(&elem, "has default", strlen("has default"), !strcmp(PQgetvalue(pg_result,i,5), "t"));
 		/* pg_attribute.attndims */
-		add_assoc_long_ex(&elem, "array dims", sizeof("array dims") - 1, atoi(PQgetvalue(pg_result, i, 6)));
+		add_assoc_long_ex(&elem, "array dims", strlen("array dims"), atoi(PQgetvalue(pg_result, i, 6)));
 		/* pg_type.typtype */
-		add_assoc_bool_ex(&elem, "is enum", sizeof("is enum") - 1, !strcmp(PQgetvalue(pg_result, i, 7), "e"));
+		add_assoc_bool_ex(&elem, "is enum", strlen("is enum"), !strcmp(PQgetvalue(pg_result, i, 7), "e"));
 		if (extended) {
 			/* pg_type.typtype */
-			add_assoc_bool_ex(&elem, "is base", sizeof("is base") - 1, !strcmp(PQgetvalue(pg_result, i, 7), "b"));
-			add_assoc_bool_ex(&elem, "is composite", sizeof("is composite") - 1, !strcmp(PQgetvalue(pg_result, i, 7), "c"));
-			add_assoc_bool_ex(&elem, "is pesudo", sizeof("is pesudo") - 1, !strcmp(PQgetvalue(pg_result, i, 7), "p"));
+			add_assoc_bool_ex(&elem, "is base", strlen("is base"), !strcmp(PQgetvalue(pg_result, i, 7), "b"));
+			add_assoc_bool_ex(&elem, "is composite", strlen("is composite"), !strcmp(PQgetvalue(pg_result, i, 7), "c"));
+			add_assoc_bool_ex(&elem, "is pesudo", strlen("is pesudo"), !strcmp(PQgetvalue(pg_result, i, 7), "p"));
 			/* pg_description.description */
-			add_assoc_string_ex(&elem, "description", sizeof("description") - 1, PQgetvalue(pg_result, i, 8));
+			add_assoc_string_ex(&elem, "description", strlen("description"), PQgetvalue(pg_result, i, 8));
 		}
 		/* pg_attribute.attname */
 		name = PQgetvalue(pg_result,i,0);
@@ -4598,19 +4598,19 @@ PHP_PGSQL_API zend_result php_pgsql_convert(PGconn *pg_link, const zend_string *
 			php_error_docref(NULL, E_NOTICE, "Invalid field name (%s) in values", ZSTR_VAL(field));
 			err = 1;
 		}
-		if (!err && (type = zend_hash_str_find(Z_ARRVAL_P(def), "type", sizeof("type") - 1)) == NULL) {
+		if (!err && (type = zend_hash_str_find(Z_ARRVAL_P(def), "type", strlen("type"))) == NULL) {
 			php_error_docref(NULL, E_NOTICE, "Detected broken meta data. Missing 'type'");
 			err = 1;
 		}
-		if (!err && (not_null = zend_hash_str_find(Z_ARRVAL_P(def), "not null", sizeof("not null") - 1)) == NULL) {
+		if (!err && (not_null = zend_hash_str_find(Z_ARRVAL_P(def), "not null", strlen("not null"))) == NULL) {
 			php_error_docref(NULL, E_NOTICE, "Detected broken meta data. Missing 'not null'");
 			err = 1;
 		}
-		if (!err && (has_default = zend_hash_str_find(Z_ARRVAL_P(def), "has default", sizeof("has default") - 1)) == NULL) {
+		if (!err && (has_default = zend_hash_str_find(Z_ARRVAL_P(def), "has default", strlen("has default"))) == NULL) {
 			php_error_docref(NULL, E_NOTICE, "Detected broken meta data. Missing 'has default'");
 			err = 1;
 		}
-		if (!err && (is_enum = zend_hash_str_find(Z_ARRVAL_P(def), "is enum", sizeof("is enum") - 1)) == NULL) {
+		if (!err && (is_enum = zend_hash_str_find(Z_ARRVAL_P(def), "is enum", strlen("is enum"))) == NULL) {
 			php_error_docref(NULL, E_NOTICE, "Detected broken meta data. Missing 'is enum'");
 			err = 1;
 		}
@@ -4645,14 +4645,14 @@ PHP_PGSQL_API zend_result php_pgsql_convert(PGconn *pg_link, const zend_string *
 								zend_string_equals_literal(Z_STR_P(val), "true") || zend_string_equals_literal(Z_STR_P(val), "True") ||
 								zend_string_equals_literal(Z_STR_P(val), "yes") || zend_string_equals_literal(Z_STR_P(val), "Yes") ||
 								zend_string_equals_literal(Z_STR_P(val), "1")) {
-								ZVAL_STRINGL(&new_val, "'t'", sizeof("'t'")-1);
+								ZVAL_STRINGL(&new_val, "'t'", strlen("'t'"));
 							}
 							else if (zend_string_equals_literal(Z_STR_P(val), "f") || zend_string_equals_literal(Z_STR_P(val), "F") ||
 									 zend_string_equals_literal(Z_STR_P(val), "n") || zend_string_equals_literal(Z_STR_P(val), "N") ||
 									 zend_string_equals_literal(Z_STR_P(val), "false") ||  zend_string_equals_literal(Z_STR_P(val), "False") ||
 									 zend_string_equals_literal(Z_STR_P(val), "no") ||  zend_string_equals_literal(Z_STR_P(val), "No") ||
 									 zend_string_equals_literal(Z_STR_P(val), "0")) {
-								ZVAL_STRINGL(&new_val, "'f'", sizeof("'f'")-1);
+								ZVAL_STRINGL(&new_val, "'f'", strlen("'f'"));
 							}
 							else {
 								php_error_docref(NULL, E_NOTICE, "Detected invalid value (%s) for PostgreSQL %s field (%s)", Z_STRVAL_P(val), Z_STRVAL_P(type), ZSTR_VAL(field));
@@ -4663,19 +4663,19 @@ PHP_PGSQL_API zend_result php_pgsql_convert(PGconn *pg_link, const zend_string *
 
 					case IS_LONG:
 						if (Z_LVAL_P(val)) {
-							ZVAL_STRINGL(&new_val, "'t'", sizeof("'t'")-1);
+							ZVAL_STRINGL(&new_val, "'t'", strlen("'t'"));
 						}
 						else {
-							ZVAL_STRINGL(&new_val, "'f'", sizeof("'f'")-1);
+							ZVAL_STRINGL(&new_val, "'f'", strlen("'f'"));
 						}
 						break;
 
 					case IS_TRUE:
-						ZVAL_STRINGL(&new_val, "'t'", sizeof("'t'")-1);
+						ZVAL_STRINGL(&new_val, "'t'", strlen("'t'"));
 						break;
 
 					case IS_FALSE:
-						ZVAL_STRINGL(&new_val, "'f'", sizeof("'f'")-1);
+						ZVAL_STRINGL(&new_val, "'f'", strlen("'f'"));
 						break;
 
 					case IS_NULL:
@@ -4809,7 +4809,7 @@ PHP_PGSQL_API zend_result php_pgsql_convert(PGconn *pg_link, const zend_string *
 							if (opt & PGSQL_CONV_FORCE_NULL) {
 								ZVAL_STR(&new_val, ZSTR_KNOWN(ZEND_STR_NULL));
 							} else {
-								ZVAL_STRINGL(&new_val, "''", sizeof("''")-1);
+								ZVAL_STRINGL(&new_val, "''", strlen("''"));
 							}
 						}
 						else {
@@ -4855,7 +4855,7 @@ PHP_PGSQL_API zend_result php_pgsql_convert(PGconn *pg_link, const zend_string *
 						}
 						else {
 							/* better regex? */
-							if (php_pgsql_convert_match(Z_STR_P(val), "^[0-9]+$", sizeof("^[0-9]+$")-1, 0) == FAILURE) {
+							if (php_pgsql_convert_match(Z_STR_P(val), "^[0-9]+$", strlen("^[0-9]+$"), 0) == FAILURE) {
 								err = 1;
 							}
 							else {
@@ -4933,7 +4933,7 @@ PHP_PGSQL_API zend_result php_pgsql_convert(PGconn *pg_link, const zend_string *
 						if (Z_STRLEN_P(val) == 0) {
 							ZVAL_STR(&new_val, ZSTR_KNOWN(ZEND_STR_NULL));
 						} else if (zend_string_equals_literal_ci(Z_STR_P(val), "now()")) {
-							ZVAL_STRINGL(&new_val, "NOW()", sizeof("NOW()")-1);
+							ZVAL_STRINGL(&new_val, "NOW()", strlen("NOW()"));
 						} else {
 #define REGEX0 "^([0-9]{4}[/-][0-9]{1,2}[/-][0-9]{1,2})(([ \\t]+|T)(([0-9]{1,2}:[0-9]{1,2}){1}(:[0-9]{1,2}){0,1}(\\.[0-9]+){0,1}([ \\t]*([+-][0-9]{1,4}(:[0-9]{1,2}){0,1}|[-a-zA-Z_/+]{1,50})){0,1})){0,1}$"
 							/* better regex? */
@@ -5376,7 +5376,7 @@ PHP_PGSQL_API zend_result php_pgsql_insert(PGconn *pg_link, const zend_string *t
 				smart_str_appendl(&querystr, buf, snprintf(buf, sizeof(buf), "%F", Z_DVAL_P(val)));
 				break;
 			case IS_NULL:
-				smart_str_appendl(&querystr, "NULL", sizeof("NULL")-1);
+				smart_str_appendl(&querystr, "NULL", strlen("NULL"));
 				break;
 			default:
 				zend_type_error("Value must be of type string|int|float|null, %s given", zend_zval_type_name(val));
@@ -5550,7 +5550,7 @@ static inline int build_assignment_string(PGconn *pg_link, smart_str *querystr, 
 				}
 				break;
 			case IS_NULL:
-				smart_str_appendl(querystr, "NULL", sizeof("NULL")-1);
+				smart_str_appendl(querystr, "NULL", strlen("NULL"));
 				break;
 			default:
 				zend_type_error("Value must be of type string|int|float|null, %s given", zend_zval_type_name(val));
@@ -5608,7 +5608,7 @@ PHP_PGSQL_API zend_result php_pgsql_update(PGconn *pg_link, const zend_string *t
 
 	smart_str_appends(&querystr, " WHERE ");
 
-	if (build_assignment_string(pg_link, &querystr, Z_ARRVAL_P(ids_array), 1, " AND ", sizeof(" AND ")-1, opt))
+	if (build_assignment_string(pg_link, &querystr, Z_ARRVAL_P(ids_array), 1, " AND ", strlen(" AND "), opt))
 		goto cleanup;
 
 	smart_str_appendc(&querystr, ';');
@@ -5706,7 +5706,7 @@ PHP_PGSQL_API zend_result php_pgsql_delete(PGconn *pg_link, const zend_string *t
 	build_tablename(&querystr, pg_link, table);
 	smart_str_appends(&querystr, " WHERE ");
 
-	if (build_assignment_string(pg_link, &querystr, Z_ARRVAL_P(ids_array), 1, " AND ", sizeof(" AND ")-1, opt))
+	if (build_assignment_string(pg_link, &querystr, Z_ARRVAL_P(ids_array), 1, " AND ", strlen(" AND "), opt))
 		goto cleanup;
 
 	smart_str_appendc(&querystr, ';');
@@ -5846,7 +5846,7 @@ PHP_PGSQL_API zend_result php_pgsql_select(PGconn *pg_link, const zend_string *t
 	build_tablename(&querystr, pg_link, table);
 	smart_str_appends(&querystr, " WHERE ");
 
-	if (build_assignment_string(pg_link, &querystr, Z_ARRVAL_P(ids_array), 1, " AND ", sizeof(" AND ")-1, opt))
+	if (build_assignment_string(pg_link, &querystr, Z_ARRVAL_P(ids_array), 1, " AND ", strlen(" AND "), opt))
 		goto cleanup;
 
 	smart_str_appendc(&querystr, ';');

--- a/ext/phar/dirstream.c
+++ b/ext/phar/dirstream.c
@@ -175,7 +175,7 @@ static php_stream *phar_make_dirstream(char *dir, HashTable *manifest) /* {{{ */
 	ALLOC_HASHTABLE(data);
 	zend_hash_init(data, 64, NULL, NULL, 0);
 
-	if ((*dir == '/' && dirlen == 1 && (manifest->nNumOfElements == 0)) || (dirlen >= sizeof(".phar")-1 && !memcmp(dir, ".phar", sizeof(".phar")-1))) {
+	if ((*dir == '/' && dirlen == 1 && (manifest->nNumOfElements == 0)) || (dirlen >= strlen(".phar") && !memcmp(dir, ".phar", strlen(".phar")))) {
 		/* make empty root directory for empty phar */
 		/* make empty directory for .phar magic directory */
 		efree(dir);
@@ -201,7 +201,7 @@ static php_stream *phar_make_dirstream(char *dir, HashTable *manifest) /* {{{ */
 
 		if (*dir == '/') {
 			/* root directory */
-			if (keylen >= sizeof(".phar")-1 && !memcmp(ZSTR_VAL(str_key), ".phar", sizeof(".phar")-1)) {
+			if (keylen >= strlen(".phar") && !memcmp(ZSTR_VAL(str_key), ".phar", strlen(".phar"))) {
 				/* do not add any magic entries to this directory */
 				if (SUCCESS != zend_hash_move_forward(manifest)) {
 					break;

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -49,7 +49,7 @@ ZEND_INI_MH(phar_ini_modify_handler) /* {{{ */
 {
 	bool old, ini;
 
-	if (ZSTR_LEN(entry->name) == sizeof("phar.readonly")-1) {
+	if (ZSTR_LEN(entry->name) == strlen("phar.readonly")) {
 		old = PHAR_G(readonly_orig);
 	} else {
 		old = PHAR_G(require_hash_orig);
@@ -59,7 +59,7 @@ ZEND_INI_MH(phar_ini_modify_handler) /* {{{ */
 
 	/* do not allow unsetting in runtime */
 	if (stage == ZEND_INI_STAGE_STARTUP) {
-		if (ZSTR_LEN(entry->name) == sizeof("phar.readonly")-1) {
+		if (ZSTR_LEN(entry->name) == strlen("phar.readonly")) {
 			PHAR_G(readonly_orig) = ini;
 		} else {
 			PHAR_G(require_hash_orig) = ini;
@@ -68,7 +68,7 @@ ZEND_INI_MH(phar_ini_modify_handler) /* {{{ */
 		return FAILURE;
 	}
 
-	if (ZSTR_LEN(entry->name) == sizeof("phar.readonly")-1) {
+	if (ZSTR_LEN(entry->name) == strlen("phar.readonly")) {
 		PHAR_G(readonly) = ini;
 		if (PHAR_G(request_init) && HT_IS_INITIALIZED(&PHAR_G(phar_fname_map))) {
 			zend_hash_apply_with_argument(&(PHAR_G(phar_fname_map)), phar_set_writeable_bit, (void *)&ini);
@@ -106,8 +106,8 @@ static void phar_split_cache_list(void) /* {{{ */
 	zend_init_rsrc_list();
 	EG(regular_list).nNextFreeElement=1;	/* we don't want resource id 0 */
 
-	PHAR_G(has_bz2) = zend_hash_str_exists(&module_registry, "bz2", sizeof("bz2")-1);
-	PHAR_G(has_zlib) = zend_hash_str_exists(&module_registry, "zlib", sizeof("zlib")-1);
+	PHAR_G(has_bz2) = zend_hash_str_exists(&module_registry, "bz2", strlen("bz2"));
+	PHAR_G(has_zlib) = zend_hash_str_exists(&module_registry, "zlib", strlen("zlib"));
 	/* these two are dummies and will be destroyed later */
 	zend_hash_init(&cached_phars, sizeof(phar_archive_data*), zend_get_hash_value, destroy_phar_data,  1);
 	zend_hash_init(&cached_alias, sizeof(phar_archive_data*), zend_get_hash_value, NULL, 1);
@@ -524,7 +524,7 @@ int phar_open_parsed_phar(char *fname, size_t fname_len, char *alias, size_t ali
 		if (!is_data) {
 			/* prevent any ".phar" without a stub getting through */
 			if (!phar->halt_offset && !phar->is_brandnew && (phar->is_tar || phar->is_zip)) {
-				if (PHAR_G(readonly) && NULL == (stub = zend_hash_str_find_ptr(&(phar->manifest), ".phar/stub.php", sizeof(".phar/stub.php")-1))) {
+				if (PHAR_G(readonly) && NULL == (stub = zend_hash_str_find_ptr(&(phar->manifest), ".phar/stub.php", strlen(".phar/stub.php")))) {
 					if (error) {
 						spprintf(error, 0, "'%s' is not a phar archive. Use PharData::__construct() for a standard zip or tar archive", fname);
 					}
@@ -1347,7 +1347,7 @@ check_file:
 
 		if (PHAR_G(readonly) && !(*test)->is_data && ((*test)->is_tar || (*test)->is_zip)) {
 			phar_entry_info *stub;
-			if (NULL == (stub = zend_hash_str_find_ptr(&((*test)->manifest), ".phar/stub.php", sizeof(".phar/stub.php")-1))) {
+			if (NULL == (stub = zend_hash_str_find_ptr(&((*test)->manifest), ".phar/stub.php", strlen(".phar/stub.php")))) {
 				spprintf(error, 0, "'%s' is not a phar archive. Use PharData::__construct() for a standard zip or tar archive", fname);
 				return FAILURE;
 			}
@@ -1672,7 +1672,7 @@ static int phar_open_from_fp(php_stream* fp, char *fname, size_t fname_len, char
 #ifndef MAX_WBITS
 #define MAX_WBITS 15
 #endif
-				add_assoc_long_ex(&filterparams, "window", sizeof("window") - 1, MAX_WBITS + 32);
+				add_assoc_long_ex(&filterparams, "window", strlen("window"), MAX_WBITS + 32);
 
 				/* entire file is gzip-compressed, uncompress to temporary file */
 				if (!(temp = php_stream_fopen_tmpfile())) {
@@ -1684,7 +1684,7 @@ static int phar_open_from_fp(php_stream* fp, char *fname, size_t fname_len, char
 
 				if (!filter) {
 					err = 1;
-					add_assoc_long_ex(&filterparams, "window", sizeof("window") - 1, MAX_WBITS);
+					add_assoc_long_ex(&filterparams, "window", strlen("window"), MAX_WBITS);
 					filter = php_stream_filter_create("zlib.inflate", &filterparams, php_stream_is_persistent(fp));
 					zend_array_destroy(Z_ARR(filterparams));
 
@@ -2333,7 +2333,7 @@ int phar_open_executed_filename(char *alias, size_t alias_len, char **error) /* 
 		return FAILURE;
 	}
 
-	if (0 == zend_get_constant_str("__COMPILER_HALT_OFFSET__", sizeof("__COMPILER_HALT_OFFSET__")-1)) {
+	if (0 == zend_get_constant_str("__COMPILER_HALT_OFFSET__", strlen("__COMPILER_HALT_OFFSET__"))) {
 		if (error) {
 			spprintf(error, 0, "__HALT_COMPILER(); must be declared in a phar");
 		}
@@ -3486,8 +3486,8 @@ void phar_request_initialize(void) /* {{{ */
 	{
 		PHAR_G(last_phar) = NULL;
 		PHAR_G(last_phar_name) = PHAR_G(last_alias) = NULL;
-		PHAR_G(has_bz2) = zend_hash_str_exists(&module_registry, "bz2", sizeof("bz2")-1);
-		PHAR_G(has_zlib) = zend_hash_str_exists(&module_registry, "zlib", sizeof("zlib")-1);
+		PHAR_G(has_bz2) = zend_hash_str_exists(&module_registry, "bz2", strlen("bz2"));
+		PHAR_G(has_zlib) = zend_hash_str_exists(&module_registry, "zlib", strlen("zlib"));
 		PHAR_G(request_init) = 1;
 		PHAR_G(request_ends) = 0;
 		PHAR_G(request_done) = 0;
@@ -3585,7 +3585,7 @@ PHP_MINFO_FUNCTION(phar) /* {{{ */
 #ifdef PHAR_HAVE_OPENSSL
 	php_info_print_table_row(2, "Native OpenSSL support", "enabled");
 #else
-	if (zend_hash_str_exists(&module_registry, "openssl", sizeof("openssl")-1)) {
+	if (zend_hash_str_exists(&module_registry, "openssl", strlen("openssl"))) {
 		php_info_print_table_row(2, "OpenSSL support", "enabled");
 	} else {
 		php_info_print_table_row(2, "OpenSSL support", "disabled (install ext/openssl)");

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -63,23 +63,23 @@ static void phar_mung_server_vars(char *fname, char *entry, size_t entry_len, ch
 	_SERVER = Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]);
 
 	/* PATH_INFO and PATH_TRANSLATED should always be munged */
-	if (NULL != (stuff = zend_hash_str_find(_SERVER, "PATH_INFO", sizeof("PATH_INFO")-1))) {
+	if (NULL != (stuff = zend_hash_str_find(_SERVER, "PATH_INFO", strlen("PATH_INFO")))) {
 		path_info = Z_STRVAL_P(stuff);
 		code = Z_STRLEN_P(stuff);
 		if (code > (size_t)entry_len && !memcmp(path_info, entry, entry_len)) {
 			ZVAL_STR(&temp, Z_STR_P(stuff));
 			ZVAL_STRINGL(stuff, path_info + entry_len, request_uri_len);
-			zend_hash_str_update(_SERVER, "PHAR_PATH_INFO", sizeof("PHAR_PATH_INFO")-1, &temp);
+			zend_hash_str_update(_SERVER, "PHAR_PATH_INFO", strlen("PHAR_PATH_INFO"), &temp);
 		}
 	}
 
-	if (NULL != (stuff = zend_hash_str_find(_SERVER, "PATH_TRANSLATED", sizeof("PATH_TRANSLATED")-1))) {
+	if (NULL != (stuff = zend_hash_str_find(_SERVER, "PATH_TRANSLATED", strlen("PATH_TRANSLATED")))) {
 		zend_string *str = strpprintf(4096, "phar://%s%s", fname, entry);
 
 		ZVAL_STR(&temp, Z_STR_P(stuff));
 		ZVAL_NEW_STR(stuff, str);
 
-		zend_hash_str_update(_SERVER, "PHAR_PATH_TRANSLATED", sizeof("PHAR_PATH_TRANSLATED")-1, &temp);
+		zend_hash_str_update(_SERVER, "PHAR_PATH_TRANSLATED", strlen("PHAR_PATH_TRANSLATED"), &temp);
 	}
 
 	if (!PHAR_G(phar_SERVER_mung_list)) {
@@ -87,46 +87,46 @@ static void phar_mung_server_vars(char *fname, char *entry, size_t entry_len, ch
 	}
 
 	if (PHAR_G(phar_SERVER_mung_list) & PHAR_MUNG_REQUEST_URI) {
-		if (NULL != (stuff = zend_hash_str_find(_SERVER, "REQUEST_URI", sizeof("REQUEST_URI")-1))) {
+		if (NULL != (stuff = zend_hash_str_find(_SERVER, "REQUEST_URI", strlen("REQUEST_URI")))) {
 			path_info = Z_STRVAL_P(stuff);
 			code = Z_STRLEN_P(stuff);
 			if (code > basename_len && !memcmp(path_info, basename, basename_len)) {
 				ZVAL_STR(&temp, Z_STR_P(stuff));
 				ZVAL_STRINGL(stuff, path_info + basename_len, code - basename_len);
-				zend_hash_str_update(_SERVER, "PHAR_REQUEST_URI", sizeof("PHAR_REQUEST_URI")-1, &temp);
+				zend_hash_str_update(_SERVER, "PHAR_REQUEST_URI", strlen("PHAR_REQUEST_URI"), &temp);
 			}
 		}
 	}
 
 	if (PHAR_G(phar_SERVER_mung_list) & PHAR_MUNG_PHP_SELF) {
-		if (NULL != (stuff = zend_hash_str_find(_SERVER, "PHP_SELF", sizeof("PHP_SELF")-1))) {
+		if (NULL != (stuff = zend_hash_str_find(_SERVER, "PHP_SELF", strlen("PHP_SELF")))) {
 			path_info = Z_STRVAL_P(stuff);
 			code = Z_STRLEN_P(stuff);
 
 			if (code > basename_len && !memcmp(path_info, basename, basename_len)) {
 				ZVAL_STR(&temp, Z_STR_P(stuff));
 				ZVAL_STRINGL(stuff, path_info + basename_len, code - basename_len);
-				zend_hash_str_update(_SERVER, "PHAR_PHP_SELF", sizeof("PHAR_PHP_SELF")-1, &temp);
+				zend_hash_str_update(_SERVER, "PHAR_PHP_SELF", strlen("PHAR_PHP_SELF"), &temp);
 			}
 		}
 	}
 
 	if (PHAR_G(phar_SERVER_mung_list) & PHAR_MUNG_SCRIPT_NAME) {
-		if (NULL != (stuff = zend_hash_str_find(_SERVER, "SCRIPT_NAME", sizeof("SCRIPT_NAME")-1))) {
+		if (NULL != (stuff = zend_hash_str_find(_SERVER, "SCRIPT_NAME", strlen("SCRIPT_NAME")))) {
 			ZVAL_STR(&temp, Z_STR_P(stuff));
 			ZVAL_STRINGL(stuff, entry, entry_len);
-			zend_hash_str_update(_SERVER, "PHAR_SCRIPT_NAME", sizeof("PHAR_SCRIPT_NAME")-1, &temp);
+			zend_hash_str_update(_SERVER, "PHAR_SCRIPT_NAME", strlen("PHAR_SCRIPT_NAME"), &temp);
 		}
 	}
 
 	if (PHAR_G(phar_SERVER_mung_list) & PHAR_MUNG_SCRIPT_FILENAME) {
-		if (NULL != (stuff = zend_hash_str_find(_SERVER, "SCRIPT_FILENAME", sizeof("SCRIPT_FILENAME")-1))) {
+		if (NULL != (stuff = zend_hash_str_find(_SERVER, "SCRIPT_FILENAME", strlen("SCRIPT_FILENAME")))) {
 			zend_string *str = strpprintf(4096, "phar://%s%s", fname, entry);
 
 			ZVAL_STR(&temp, Z_STR_P(stuff));
 			ZVAL_NEW_STR(stuff, str);
 
-			zend_hash_str_update(_SERVER, "PHAR_SCRIPT_FILENAME", sizeof("PHAR_SCRIPT_FILENAME")-1, &temp);
+			zend_hash_str_update(_SERVER, "PHAR_SCRIPT_FILENAME", strlen("PHAR_SCRIPT_FILENAME"), &temp);
 		}
 	}
 }
@@ -297,12 +297,12 @@ static void phar_do_403(char *entry, size_t entry_len) /* {{{ */
 	sapi_header_line ctr = {0};
 
 	ctr.response_code = 403;
-	ctr.line_len = sizeof("HTTP/1.0 403 Access Denied")-1;
+	ctr.line_len = strlen("HTTP/1.0 403 Access Denied");
 	ctr.line = "HTTP/1.0 403 Access Denied";
 	sapi_header_op(SAPI_HEADER_REPLACE, &ctr);
 	sapi_send_headers();
-	PHPWRITE("<html>\n <head>\n  <title>Access Denied</title>\n </head>\n <body>\n  <h1>403 - File ", sizeof("<html>\n <head>\n  <title>Access Denied</title>\n </head>\n <body>\n  <h1>403 - File ") - 1);
-	PHPWRITE("Access Denied</h1>\n </body>\n</html>", sizeof("Access Denied</h1>\n </body>\n</html>") - 1);
+	PHPWRITE("<html>\n <head>\n  <title>Access Denied</title>\n </head>\n <body>\n  <h1>403 - File ", strlen("<html>\n <head>\n  <title>Access Denied</title>\n </head>\n <body>\n  <h1>403 - File "));
+	PHPWRITE("Access Denied</h1>\n </body>\n</html>", strlen("Access Denied</h1>\n </body>\n</html>"));
 }
 /* }}} */
 
@@ -321,12 +321,12 @@ static void phar_do_404(phar_archive_data *phar, char *fname, size_t fname_len, 
 	}
 
 	ctr.response_code = 404;
-	ctr.line_len = sizeof("HTTP/1.0 404 Not Found")-1;
+	ctr.line_len = strlen("HTTP/1.0 404 Not Found");
 	ctr.line = "HTTP/1.0 404 Not Found";
 	sapi_header_op(SAPI_HEADER_REPLACE, &ctr);
 	sapi_send_headers();
-	PHPWRITE("<html>\n <head>\n  <title>File Not Found</title>\n </head>\n <body>\n  <h1>404 - File ", sizeof("<html>\n <head>\n  <title>File Not Found</title>\n </head>\n <body>\n  <h1>404 - File ") - 1);
-	PHPWRITE("Not Found</h1>\n </body>\n</html>",  sizeof("Not Found</h1>\n </body>\n</html>") - 1);
+	PHPWRITE("<html>\n <head>\n  <title>File Not Found</title>\n </head>\n <body>\n  <h1>404 - File ", strlen("<html>\n <head>\n  <title>File Not Found</title>\n </head>\n <body>\n  <h1>404 - File "));
+	PHPWRITE("Not Found</h1>\n </body>\n</html>",  strlen("Not Found</h1>\n </body>\n</html>"));
 }
 /* }}} */
 
@@ -597,21 +597,21 @@ PHP_METHOD(Phar, webPhar)
 		++basename;
 	}
 
-	if ((sapi_mod_name_len == sizeof("cgi-fcgi") - 1 && !strncmp(sapi_module.name, "cgi-fcgi", sizeof("cgi-fcgi") - 1))
-		|| (sapi_mod_name_len == sizeof("fpm-fcgi") - 1 && !strncmp(sapi_module.name, "fpm-fcgi", sizeof("fpm-fcgi") - 1))
-		|| (sapi_mod_name_len == sizeof("cgi") - 1 && !strncmp(sapi_module.name, "cgi", sizeof("cgi") - 1))) {
+	if ((sapi_mod_name_len == strlen("cgi-fcgi") && !strncmp(sapi_module.name, "cgi-fcgi", strlen("cgi-fcgi")))
+		|| (sapi_mod_name_len == strlen("fpm-fcgi") && !strncmp(sapi_module.name, "fpm-fcgi", strlen("fpm-fcgi")))
+		|| (sapi_mod_name_len == strlen("cgi") && !strncmp(sapi_module.name, "cgi", strlen("cgi")))) {
 
 		if (Z_TYPE(PG(http_globals)[TRACK_VARS_SERVER]) != IS_UNDEF) {
 			HashTable *_server = Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]);
 			zval *z_script_name, *z_path_info;
 
-			if (NULL == (z_script_name = zend_hash_str_find(_server, "SCRIPT_NAME", sizeof("SCRIPT_NAME")-1)) ||
+			if (NULL == (z_script_name = zend_hash_str_find(_server, "SCRIPT_NAME", strlen("SCRIPT_NAME"))) ||
 				IS_STRING != Z_TYPE_P(z_script_name) ||
 				!strstr(Z_STRVAL_P(z_script_name), basename)) {
 				goto finish;
 			}
 
-			if (NULL != (z_path_info = zend_hash_str_find(_server, "PATH_INFO", sizeof("PATH_INFO")-1)) &&
+			if (NULL != (z_path_info = zend_hash_str_find(_server, "PATH_INFO", strlen("PATH_INFO"))) &&
 				IS_STRING == Z_TYPE_P(z_path_info)) {
 				entry_len = Z_STRLEN_P(z_path_info);
 				entry = estrndup(Z_STRVAL_P(z_path_info), entry_len);
@@ -630,13 +630,13 @@ PHP_METHOD(Phar, webPhar)
 		} else {
 			char *testit;
 
-			testit = sapi_getenv("SCRIPT_NAME", sizeof("SCRIPT_NAME")-1);
+			testit = sapi_getenv("SCRIPT_NAME", strlen("SCRIPT_NAME"));
 			if (!(pt = strstr(testit, basename))) {
 				efree(testit);
 				goto finish;
 			}
 
-			path_info = sapi_getenv("PATH_INFO", sizeof("PATH_INFO")-1);
+			path_info = sapi_getenv("PATH_INFO", strlen("PATH_INFO"));
 
 			if (path_info) {
 				entry = path_info;
@@ -740,7 +740,7 @@ cleanup_fail:
 		} else {
 			/* assume "index.php" is starting point */
 			entry = estrndup("/index.php", sizeof("/index.php"));
-			entry_len = sizeof("/index.php")-1;
+			entry_len = strlen("/index.php");
 		}
 
 		if (FAILURE == phar_get_archive(&phar, fname, fname_len, NULL, 0, NULL) ||
@@ -756,7 +756,7 @@ cleanup_fail:
 			char *tmp = NULL, sa = '\0';
 			sapi_header_line ctr = {0};
 			ctr.response_code = 301;
-			ctr.line_len = sizeof("HTTP/1.1 301 Moved Permanently")-1;
+			ctr.line_len = strlen("HTTP/1.1 301 Moved Permanently");
 			ctr.line = "HTTP/1.1 301 Moved Permanently";
 			sapi_header_op(SAPI_HEADER_REPLACE, &ctr);
 
@@ -1242,7 +1242,7 @@ PHP_METHOD(Phar, getSupportedSignatures)
 	add_next_index_stringl(return_value, "OpenSSL_SHA256", 14);
 	add_next_index_stringl(return_value, "OpenSSL_SHA512", 14);
 #else
-	if (zend_hash_str_exists(&module_registry, "openssl", sizeof("openssl")-1)) {
+	if (zend_hash_str_exists(&module_registry, "openssl", strlen("openssl"))) {
 		add_next_index_stringl(return_value, "OpenSSL", 7);
 		add_next_index_stringl(return_value, "OpenSSL_SHA256", 14);
 		add_next_index_stringl(return_value, "OpenSSL_SHA512", 14);
@@ -1435,7 +1435,7 @@ static int phar_build(zend_object_iterator *iter, void *puser) /* {{{ */
 			}
 
 			close_fp = 0;
-			opened = zend_string_init("[stream]", sizeof("[stream]") - 1, 0);
+			opened = zend_string_init("[stream]", strlen("[stream]"), 0);
 			goto after_open_fp;
 		case IS_OBJECT:
 			if (instanceof_function(Z_OBJCE_P(value), spl_ce_SplFileInfo)) {
@@ -1591,7 +1591,7 @@ phar_spl_fileinfo:
 		return ZEND_HASH_APPLY_STOP;
 	}
 after_open_fp:
-	if (str_key_len >= sizeof(".phar")-1 && !memcmp(str_key, ".phar", sizeof(".phar")-1)) {
+	if (str_key_len >= strlen(".phar") && !memcmp(str_key, ".phar", strlen(".phar"))) {
 		/* silently skip any files that would be added to the magic .phar directory */
 		if (save) {
 			efree(save);
@@ -3404,14 +3404,14 @@ PHP_METHOD(Phar, copy)
 		RETURN_THROWS();
 	}
 
-	if (oldfile_len >= sizeof(".phar")-1 && !memcmp(oldfile, ".phar", sizeof(".phar")-1)) {
+	if (oldfile_len >= strlen(".phar") && !memcmp(oldfile, ".phar", strlen(".phar"))) {
 		/* can't copy a meta file */
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
 			"file \"%s\" cannot be copied to file \"%s\", cannot copy Phar meta-file in %s", oldfile, newfile, phar_obj->archive->fname);
 		RETURN_THROWS();
 	}
 
-	if (newfile_len >= sizeof(".phar")-1 && !memcmp(newfile, ".phar", sizeof(".phar")-1)) {
+	if (newfile_len >= strlen(".phar") && !memcmp(newfile, ".phar", strlen(".phar"))) {
 		/* can't copy a meta file */
 		zend_throw_exception_ex(spl_ce_UnexpectedValueException, 0,
 			"file \"%s\" cannot be copied to file \"%s\", cannot copy to Phar meta-file in %s", oldfile, newfile, phar_obj->archive->fname);
@@ -3501,7 +3501,7 @@ PHP_METHOD(Phar, offsetExists)
 			}
 		}
 
-		if (fname_len >= sizeof(".phar")-1 && !memcmp(fname, ".phar", sizeof(".phar")-1)) {
+		if (fname_len >= strlen(".phar") && !memcmp(fname, ".phar", strlen(".phar"))) {
 			/* none of these are real files, so they don't exist */
 			RETURN_FALSE;
 		}
@@ -3534,17 +3534,17 @@ PHP_METHOD(Phar, offsetGet)
 	if (!(entry = phar_get_entry_info_dir(phar_obj->archive, fname, fname_len, 1, &error, 0))) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Entry %s does not exist%s%s", fname, error?", ":"", error?error:"");
 	} else {
-		if (fname_len == sizeof(".phar/stub.php")-1 && !memcmp(fname, ".phar/stub.php", sizeof(".phar/stub.php")-1)) {
+		if (fname_len == strlen(".phar/stub.php") && !memcmp(fname, ".phar/stub.php", strlen(".phar/stub.php"))) {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot get stub \".phar/stub.php\" directly in phar \"%s\", use getStub", phar_obj->archive->fname);
 			RETURN_THROWS();
 		}
 
-		if (fname_len == sizeof(".phar/alias.txt")-1 && !memcmp(fname, ".phar/alias.txt", sizeof(".phar/alias.txt")-1)) {
+		if (fname_len == strlen(".phar/alias.txt") && !memcmp(fname, ".phar/alias.txt", strlen(".phar/alias.txt"))) {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot get alias \".phar/alias.txt\" directly in phar \"%s\", use getAlias", phar_obj->archive->fname);
 			RETURN_THROWS();
 		}
 
-		if (fname_len >= sizeof(".phar")-1 && !memcmp(fname, ".phar", sizeof(".phar")-1)) {
+		if (fname_len >= strlen(".phar") && !memcmp(fname, ".phar", strlen(".phar"))) {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot directly get any files or directories in magic \".phar\" directory");
 			RETURN_THROWS();
 		}
@@ -3576,9 +3576,9 @@ static void phar_add_file(phar_archive_data **pphar, char *filename, size_t file
 	ALLOCA_FLAG(filename_use_heap)
 #endif
 
-	if (filename_len >= sizeof(".phar")-1) {
+	if (filename_len >= strlen(".phar")) {
 		start_pos = '/' == filename[0]; /* account for any leading slash: multiple-leads handled elsewhere */
-		if (!memcmp(&filename[start_pos], ".phar", sizeof(".phar")-1) && (filename[start_pos+5] == '/' || filename[start_pos+5] == '\\' || filename[start_pos+5] == '\0')) {
+		if (!memcmp(&filename[start_pos], ".phar", strlen(".phar")) && (filename[start_pos+5] == '/' || filename[start_pos+5] == '\\' || filename[start_pos+5] == '\0')) {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot create any files in magic \".phar\" directory");
 			return;
 		}
@@ -3711,17 +3711,17 @@ PHP_METHOD(Phar, offsetSet)
 		RETURN_THROWS();
 	}
 
-	if (fname_len == sizeof(".phar/stub.php")-1 && !memcmp(fname, ".phar/stub.php", sizeof(".phar/stub.php")-1)) {
+	if (fname_len == strlen(".phar/stub.php") && !memcmp(fname, ".phar/stub.php", strlen(".phar/stub.php"))) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot set stub \".phar/stub.php\" directly in phar \"%s\", use setStub", phar_obj->archive->fname);
 		RETURN_THROWS();
 	}
 
-	if (fname_len == sizeof(".phar/alias.txt")-1 && !memcmp(fname, ".phar/alias.txt", sizeof(".phar/alias.txt")-1)) {
+	if (fname_len == strlen(".phar/alias.txt") && !memcmp(fname, ".phar/alias.txt", strlen(".phar/alias.txt"))) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot set alias \".phar/alias.txt\" directly in phar \"%s\", use setAlias", phar_obj->archive->fname);
 		RETURN_THROWS();
 	}
 
-	if (fname_len >= sizeof(".phar")-1 && !memcmp(fname, ".phar", sizeof(".phar")-1)) {
+	if (fname_len >= strlen(".phar") && !memcmp(fname, ".phar", strlen(".phar"))) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot set any files or directories in magic \".phar\" directory");
 		RETURN_THROWS();
 	}
@@ -3789,7 +3789,7 @@ PHP_METHOD(Phar, addEmptyDir)
 
 	PHAR_ARCHIVE_OBJECT();
 
-	if (dirname_len >= sizeof(".phar")-1 && !memcmp(dirname, ".phar", sizeof(".phar")-1)) {
+	if (dirname_len >= strlen(".phar") && !memcmp(dirname, ".phar", strlen(".phar"))) {
 		zend_throw_exception_ex(spl_ce_BadMethodCallException, 0, "Cannot create a directory in magic \".phar\" directory");
 		RETURN_THROWS();
 	}
@@ -3866,7 +3866,7 @@ PHP_METHOD(Phar, getStub)
 
 	if (phar_obj->archive->is_tar || phar_obj->archive->is_zip) {
 
-		if (NULL != (stub = zend_hash_str_find_ptr(&(phar_obj->archive->manifest), ".phar/stub.php", sizeof(".phar/stub.php")-1))) {
+		if (NULL != (stub = zend_hash_str_find_ptr(&(phar_obj->archive->manifest), ".phar/stub.php", strlen(".phar/stub.php")))) {
 			if (phar_obj->archive->fp && !phar_obj->archive->is_brandnew && !(stub->flags & PHAR_ENT_COMPRESSION_MASK)) {
 				fp = phar_obj->archive->fp;
 			} else {
@@ -4098,7 +4098,7 @@ static int phar_extract_file(bool overwrite, phar_entry_info *entry, char *dest,
 		return SUCCESS;
 	}
 
-	if (entry->filename_len >= sizeof(".phar")-1 && !memcmp(entry->filename, ".phar", sizeof(".phar")-1)) {
+	if (entry->filename_len >= strlen(".phar") && !memcmp(entry->filename, ".phar", strlen(".phar"))) {
 		return SUCCESS;
 	}
 	/* strip .. from path and restrict it to be under dest directory */

--- a/ext/phar/stream.c
+++ b/ext/phar/stream.c
@@ -211,18 +211,18 @@ static php_stream * phar_wrapper_open_url(php_stream_wrapper *wrapper, const cha
 		php_url_free(resource);
 		efree(internal_file);
 
-		if (context && Z_TYPE(context->options) != IS_UNDEF && (pzoption = zend_hash_str_find(HASH_OF(&context->options), "phar", sizeof("phar")-1)) != NULL) {
+		if (context && Z_TYPE(context->options) != IS_UNDEF && (pzoption = zend_hash_str_find(HASH_OF(&context->options), "phar", strlen("phar"))) != NULL) {
 			pharcontext = HASH_OF(pzoption);
 			if (idata->internal_file->uncompressed_filesize == 0
 				&& idata->internal_file->compressed_filesize == 0
-				&& (pzoption = zend_hash_str_find(pharcontext, "compress", sizeof("compress")-1)) != NULL
+				&& (pzoption = zend_hash_str_find(pharcontext, "compress", strlen("compress"))) != NULL
 				&& Z_TYPE_P(pzoption) == IS_LONG
 				&& (Z_LVAL_P(pzoption) & ~PHAR_ENT_COMPRESSION_MASK) == 0
 			) {
 				idata->internal_file->flags &= ~PHAR_ENT_COMPRESSION_MASK;
 				idata->internal_file->flags |= Z_LVAL_P(pzoption);
 			}
-			if ((pzoption = zend_hash_str_find(pharcontext, "metadata", sizeof("metadata")-1)) != NULL) {
+			if ((pzoption = zend_hash_str_find(pharcontext, "metadata", strlen("metadata"))) != NULL) {
 				phar_metadata_tracker_free(&idata->internal_file->metadata_tracker, idata->internal_file->is_persistent);
 
 				metadata = pzoption;
@@ -244,7 +244,7 @@ static php_stream * phar_wrapper_open_url(php_stream_wrapper *wrapper, const cha
 				return NULL;
 			}
 			if (phar->is_tar || phar->is_zip) {
-				if ((FAILURE == phar_get_entry_data(&idata, ZSTR_VAL(resource->host), host_len, ".phar/stub.php", sizeof(".phar/stub.php")-1, "r", 0, &error, 0)) || !idata) {
+				if ((FAILURE == phar_get_entry_data(&idata, ZSTR_VAL(resource->host), host_len, ".phar/stub.php", strlen(".phar/stub.php"), "r", 0, &error, 0)) || !idata) {
 					goto idata_error;
 				}
 				efree(internal_file);
@@ -319,7 +319,7 @@ idata_error:
 		char *entry = idata->internal_file->filename, *cwd;
 
 		PHAR_G(cwd_init) = 1;
-		if ((idata->phar->is_tar || idata->phar->is_zip) && idata->internal_file->filename_len == sizeof(".phar/stub.php")-1 && !strncmp(idata->internal_file->filename, ".phar/stub.php", sizeof(".phar/stub.php")-1)) {
+		if ((idata->phar->is_tar || idata->phar->is_zip) && idata->internal_file->filename_len == strlen(".phar/stub.php") && !strncmp(idata->internal_file->filename, ".phar/stub.php", strlen(".phar/stub.php"))) {
 			/* we're executing the stub, which doesn't count as a file */
 			PHAR_G(cwd_init) = 0;
 		} else if ((cwd = strrchr(entry, '/'))) {

--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -174,7 +174,7 @@ int phar_mount_entry(phar_archive_data *phar, char *filename, size_t filename_le
 		return FAILURE;
 	}
 
-	if (path_len >= sizeof(".phar")-1 && !memcmp(path, ".phar", sizeof(".phar")-1)) {
+	if (path_len >= strlen(".phar") && !memcmp(path, ".phar", strlen(".phar"))) {
 		/* no creating magic phar files by mounting them */
 		return FAILURE;
 	}
@@ -1221,7 +1221,7 @@ phar_entry_info *phar_get_entry_info_dir(phar_archive_data *phar, char *path, si
 		*error = NULL;
 	}
 
-	if (security && path_len >= sizeof(".phar")-1 && !memcmp(path, ".phar", sizeof(".phar")-1)) {
+	if (security && path_len >= strlen(".phar") && !memcmp(path, ".phar", strlen(".phar"))) {
 		if (error) {
 			spprintf(error, 4096, "phar error: cannot directly access magic \".phar\" directory or files within it");
 		}
@@ -1388,7 +1388,7 @@ static int phar_call_openssl_signverify(int is_sign, php_stream *fp, zend_off_t 
 	zval retval, zp[4], openssl;
 	zend_string *str;
 
-	ZVAL_STRINGL(&openssl, is_sign ? "openssl_sign" : "openssl_verify", is_sign ? sizeof("openssl_sign")-1 : sizeof("openssl_verify")-1);
+	ZVAL_STRINGL(&openssl, is_sign ? "openssl_sign" : "openssl_verify", is_sign ? strlen("openssl_sign") : strlen("openssl_verify"));
 	if (*signature_len) {
 		ZVAL_STRINGL(&zp[1], *signature, *signature_len);
 	} else {
@@ -1513,7 +1513,7 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t sig_type,
 			char *pfile;
 			php_stream *pfp;
 #ifndef PHAR_HAVE_OPENSSL
-			if (!zend_hash_str_exists(&module_registry, "openssl", sizeof("openssl")-1)) {
+			if (!zend_hash_str_exists(&module_registry, "openssl", strlen("openssl"))) {
 				if (error) {
 					spprintf(error, 0, "openssl not loaded");
 				}

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -163,12 +163,12 @@ static void phar_zip_u2d_time(time_t time, char *dtime, char *ddate) /* {{{ */
 
 static char *phar_find_eocd(const char *s, size_t n)
 {
-	const char *end = s + n + sizeof("PK\5\6") - 1 - sizeof(phar_zip_dir_end);
+	const char *end = s + n + strlen("PK\5\6") - sizeof(phar_zip_dir_end);
 
 	/* search backwards for end of central directory signatures */
 	do {
 		uint16_t comment_len;
-		const char *eocd_start = zend_memnrstr(s, "PK\5\6", sizeof("PK\5\6") - 1, end);
+		const char *eocd_start = zend_memnrstr(s, "PK\5\6", strlen("PK\5\6"), end);
 
 		if (eocd_start == NULL) {
 			return NULL;
@@ -416,7 +416,7 @@ foundit:
 			entry.is_dir = 0;
 		}
 
-		if (entry.filename_len == sizeof(".phar/signature.bin")-1 && !strncmp(entry.filename, ".phar/signature.bin", sizeof(".phar/signature.bin")-1)) {
+		if (entry.filename_len == strlen(".phar/signature.bin") && !strncmp(entry.filename, ".phar/signature.bin", strlen(".phar/signature.bin"))) {
 			size_t read;
 			php_stream *sigfile;
 			char *sig;
@@ -560,7 +560,7 @@ foundit:
 			ZVAL_UNDEF(&entry.metadata_tracker.val);
 		}
 
-		if (!actual_alias && entry.filename_len == sizeof(".phar/alias.txt")-1 && !strncmp(entry.filename, ".phar/alias.txt", sizeof(".phar/alias.txt")-1)) {
+		if (!actual_alias && entry.filename_len == strlen(".phar/alias.txt") && !strncmp(entry.filename, ".phar/alias.txt", strlen(".phar/alias.txt"))) {
 			php_stream_filter *filter;
 			zend_off_t saveloc;
 			/* verify local file header */
@@ -686,7 +686,7 @@ foundit:
 		zend_hash_str_add_mem(&mydata->manifest, entry.filename, entry.filename_len, (void *)&entry, sizeof(phar_entry_info));
 	}
 
-	if (zend_hash_str_exists(&(mydata->manifest), ".phar/stub.php", sizeof(".phar/stub.php")-1)) {
+	if (zend_hash_str_exists(&(mydata->manifest), ".phar/stub.php", strlen(".phar/stub.php"))) {
 		mydata->is_data = 0;
 	} else {
 		mydata->is_data = 1;
@@ -1159,7 +1159,7 @@ static int phar_zip_applysignature(phar_archive_data *phar, struct _phar_zip_pas
 		}
 
 		entry.filename = ".phar/signature.bin";
-		entry.filename_len = sizeof(".phar/signature.bin")-1;
+		entry.filename_len = strlen(".phar/signature.bin");
 		entry.fp = php_stream_fopen_tmpfile();
 		entry.fp_type = PHAR_MOD;
 		entry.is_modified = 1;
@@ -1245,12 +1245,12 @@ int phar_zip_flush(phar_archive_data *phar, char *user_stub, zend_long len, int 
 		}
 
 		entry.uncompressed_filesize = entry.compressed_filesize = phar->alias_len;
-		entry.filename = estrndup(".phar/alias.txt", sizeof(".phar/alias.txt")-1);
-		entry.filename_len = sizeof(".phar/alias.txt")-1;
+		entry.filename = estrndup(".phar/alias.txt", strlen(".phar/alias.txt"));
+		entry.filename_len = strlen(".phar/alias.txt");
 
 		zend_hash_str_update_mem(&phar->manifest, entry.filename, entry.filename_len, (void*)&entry, sizeof(phar_entry_info));
 	} else {
-		zend_hash_str_del(&phar->manifest, ".phar/alias.txt", sizeof(".phar/alias.txt")-1);
+		zend_hash_str_del(&phar->manifest, ".phar/alias.txt", strlen(".phar/alias.txt"));
 	}
 
 	/* register alias */
@@ -1334,8 +1334,8 @@ int phar_zip_flush(phar_archive_data *phar, char *user_stub, zend_long len, int 
 			return EOF;
 		}
 
-		entry.filename = estrndup(".phar/stub.php", sizeof(".phar/stub.php")-1);
-		entry.filename_len = sizeof(".phar/stub.php")-1;
+		entry.filename = estrndup(".phar/stub.php", strlen(".phar/stub.php"));
+		entry.filename_len = strlen(".phar/stub.php");
 
 		zend_hash_str_update_mem(&phar->manifest, entry.filename, entry.filename_len, (void*)&entry, sizeof(phar_entry_info));
 
@@ -1358,11 +1358,11 @@ int phar_zip_flush(phar_archive_data *phar, char *user_stub, zend_long len, int 
 		}
 
 		entry.uncompressed_filesize = entry.compressed_filesize = sizeof(newstub) - 1;
-		entry.filename = estrndup(".phar/stub.php", sizeof(".phar/stub.php")-1);
-		entry.filename_len = sizeof(".phar/stub.php")-1;
+		entry.filename = estrndup(".phar/stub.php", strlen(".phar/stub.php"));
+		entry.filename_len = strlen(".phar/stub.php");
 
 		if (!defaultstub) {
-			if (!zend_hash_str_exists(&phar->manifest, ".phar/stub.php", sizeof(".phar/stub.php")-1)) {
+			if (!zend_hash_str_exists(&phar->manifest, ".phar/stub.php", strlen(".phar/stub.php"))) {
 				if (NULL == zend_hash_str_add_mem(&phar->manifest, entry.filename, entry.filename_len, (void*)&entry, sizeof(phar_entry_info))) {
 					php_stream_close(entry.fp);
 					efree(entry.filename);

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -725,7 +725,7 @@ int php_posix_group_to_array(struct group *g, zval *array_group) /* {{{ */
 
 		add_next_index_string(&array_members, gr_mem);
 	}
-	zend_hash_str_update(Z_ARRVAL_P(array_group), "members", sizeof("members")-1, &array_members);
+	zend_hash_str_update(Z_ARRVAL_P(array_group), "members", strlen("members"), &array_members);
 	add_assoc_long(array_group, "gid", g->gr_gid);
 	return 1;
 }

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1522,27 +1522,27 @@ ZEND_METHOD(Reflection, getModifierNames)
 	array_init(return_value);
 
 	if (modifiers & (ZEND_ACC_ABSTRACT | ZEND_ACC_EXPLICIT_ABSTRACT_CLASS)) {
-		add_next_index_stringl(return_value, "abstract", sizeof("abstract")-1);
+		add_next_index_stringl(return_value, "abstract", strlen("abstract"));
 	}
 	if (modifiers & ZEND_ACC_FINAL) {
-		add_next_index_stringl(return_value, "final", sizeof("final")-1);
+		add_next_index_stringl(return_value, "final", strlen("final"));
 	}
 
 	/* These are mutually exclusive */
 	switch (modifiers & ZEND_ACC_PPP_MASK) {
 		case ZEND_ACC_PUBLIC:
-			add_next_index_stringl(return_value, "public", sizeof("public")-1);
+			add_next_index_stringl(return_value, "public", strlen("public"));
 			break;
 		case ZEND_ACC_PRIVATE:
-			add_next_index_stringl(return_value, "private", sizeof("private")-1);
+			add_next_index_stringl(return_value, "private", strlen("private"));
 			break;
 		case ZEND_ACC_PROTECTED:
-			add_next_index_stringl(return_value, "protected", sizeof("protected")-1);
+			add_next_index_stringl(return_value, "protected", strlen("protected"));
 			break;
 	}
 
 	if (modifiers & ZEND_ACC_STATIC) {
-		add_next_index_stringl(return_value, "static", sizeof("static")-1);
+		add_next_index_stringl(return_value, "static", strlen("static"));
 	}
 }
 /* }}} */
@@ -2924,13 +2924,13 @@ ZEND_METHOD(ReflectionParameter, getDefaultValueConstantName)
 	if (ast->kind == ZEND_AST_CONSTANT) {
 		RETVAL_STR_COPY(zend_ast_get_constant_name(ast));
 	} else if (ast->kind == ZEND_AST_CONSTANT_CLASS) {
-		RETVAL_STRINGL("__CLASS__", sizeof("__CLASS__")-1);
+		RETVAL_STRINGL("__CLASS__", strlen("__CLASS__"));
 	} else if (ast->kind == ZEND_AST_CLASS_CONST) {
 		zend_string *class_name = zend_ast_get_str(ast->child[0]);
 		zend_string *const_name = zend_ast_get_str(ast->child[1]);
 		RETVAL_NEW_STR(zend_string_concat3(
 			ZSTR_VAL(class_name), ZSTR_LEN(class_name),
-			"::", sizeof("::")-1,
+			"::", strlen("::"),
 			ZSTR_VAL(const_name), ZSTR_LEN(const_name)));
 	} else {
 		RETVAL_NULL();
@@ -6076,19 +6076,19 @@ ZEND_METHOD(ReflectionExtension, getDependencies)
 		switch(dep->type) {
 			case MODULE_DEP_REQUIRED:
 				rel_type = "Required";
-				len += sizeof("Required") - 1;
+				len += strlen("Required");
 				break;
 			case MODULE_DEP_CONFLICTS:
 				rel_type = "Conflicts";
-				len += sizeof("Conflicts") - 1;
+				len += strlen("Conflicts");
 				break;
 			case MODULE_DEP_OPTIONAL:
 				rel_type = "Optional";
-				len += sizeof("Optional") - 1;
+				len += strlen("Optional");
 				break;
 			default:
 				rel_type = "Error"; /* shouldn't happen */
-				len += sizeof("Error") - 1;
+				len += strlen("Error");
 				break;
 		}
 

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1219,7 +1219,7 @@ static zend_class_entry *register_class_ReflectionFunctionAbstract(zend_class_en
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
@@ -1256,7 +1256,7 @@ static zend_class_entry *register_class_ReflectionMethod(zend_class_entry *class
 
 	zval property_class_default_value;
 	ZVAL_UNDEF(&property_class_default_value);
-	zend_string *property_class_name = zend_string_init("class", sizeof("class") - 1, 1);
+	zend_string *property_class_name = zend_string_init("class", strlen("class"), 1);
 	zend_declare_typed_property(class_entry, property_class_name, &property_class_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_class_name);
 
@@ -1274,7 +1274,7 @@ static zend_class_entry *register_class_ReflectionClass(zend_class_entry *class_
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
@@ -1302,13 +1302,13 @@ static zend_class_entry *register_class_ReflectionProperty(zend_class_entry *cla
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
 	zval property_class_default_value;
 	ZVAL_UNDEF(&property_class_default_value);
-	zend_string *property_class_name = zend_string_init("class", sizeof("class") - 1, 1);
+	zend_string *property_class_name = zend_string_init("class", strlen("class"), 1);
 	zend_declare_typed_property(class_entry, property_class_name, &property_class_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_class_name);
 
@@ -1326,13 +1326,13 @@ static zend_class_entry *register_class_ReflectionClassConstant(zend_class_entry
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
 	zval property_class_default_value;
 	ZVAL_UNDEF(&property_class_default_value);
-	zend_string *property_class_name = zend_string_init("class", sizeof("class") - 1, 1);
+	zend_string *property_class_name = zend_string_init("class", strlen("class"), 1);
 	zend_declare_typed_property(class_entry, property_class_name, &property_class_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_class_name);
 
@@ -1350,7 +1350,7 @@ static zend_class_entry *register_class_ReflectionParameter(zend_class_entry *cl
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
@@ -1410,7 +1410,7 @@ static zend_class_entry *register_class_ReflectionExtension(zend_class_entry *cl
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
@@ -1428,7 +1428,7 @@ static zend_class_entry *register_class_ReflectionZendExtension(zend_class_entry
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -209,7 +209,7 @@ PHPAPI zval* php_get_session_var(zend_string *name) /* {{{ */
 static void php_session_track_init(void) /* {{{ */
 {
 	zval session_vars;
-	zend_string *var_name = zend_string_init("_SESSION", sizeof("_SESSION") - 1, 0);
+	zend_string *var_name = zend_string_init("_SESSION", strlen("_SESSION"), 0);
 	/* Unconditionally destroy existing array -- possible dirty data */
 	zend_delete_global_variable(var_name);
 
@@ -865,7 +865,7 @@ PS_SERIALIZER_DECODE_FUNC(php_serialize) /* {{{ */
 	zval session_vars;
 	php_unserialize_data_t var_hash;
 	int result;
-	zend_string *var_name = zend_string_init("_SESSION", sizeof("_SESSION") - 1, 0);
+	zend_string *var_name = zend_string_init("_SESSION", strlen("_SESSION"), 0);
 
 	ZVAL_NULL(&session_vars);
 	PHP_VAR_UNSERIALIZE_INIT(var_hash);
@@ -1275,7 +1275,7 @@ static void php_session_remove_cookie(void) {
 	zend_llist_element *current;
 	char *session_cookie;
 	size_t session_cookie_len;
-	size_t len = sizeof("Set-Cookie")-1;
+	size_t len = strlen("Set-Cookie");
 
 	ZEND_ASSERT(strpbrk(PS(session_name), "=,; \t\r\n\013\014") == NULL);
 	spprintf(&session_cookie, 0, "Set-Cookie: %s=", PS(session_name));
@@ -1333,7 +1333,7 @@ static int php_session_send_cookie(void) /* {{{ */
 	/* URL encode id because it might be user supplied */
 	e_id = php_url_encode(ZSTR_VAL(PS(id)), ZSTR_LEN(PS(id)));
 
-	smart_str_appendl(&ncookie, "Set-Cookie: ", sizeof("Set-Cookie: ")-1);
+	smart_str_appendl(&ncookie, "Set-Cookie: ", strlen("Set-Cookie: "));
 	smart_str_appendl(&ncookie, PS(session_name), strlen(PS(session_name)));
 	smart_str_appendc(&ncookie, '=');
 	smart_str_appendl(&ncookie, ZSTR_VAL(e_id), ZSTR_LEN(e_id));
@@ -1348,7 +1348,7 @@ static int php_session_send_cookie(void) /* {{{ */
 		t = tv.tv_sec + PS(cookie_lifetime);
 
 		if (t > 0) {
-			date_fmt = php_format_date("D, d-M-Y H:i:s T", sizeof("D, d-M-Y H:i:s T")-1, t, 0);
+			date_fmt = php_format_date("D, d-M-Y H:i:s T", strlen("D, d-M-Y H:i:s T"), t, 0);
 			smart_str_appends(&ncookie, COOKIE_EXPIRES);
 			smart_str_appendl(&ncookie, ZSTR_VAL(date_fmt), ZSTR_LEN(date_fmt));
 			zend_string_release_ex(date_fmt, 0);
@@ -1454,8 +1454,8 @@ PHPAPI int php_session_reset_id(void) /* {{{ */
 
 	/* If the SID constant exists, destroy it. */
 	/* We must not delete any items in EG(zend_constants) */
-	/* zend_hash_str_del(EG(zend_constants), "sid", sizeof("sid") - 1); */
-	sid = zend_get_constant_str("SID", sizeof("SID") - 1);
+	/* zend_hash_str_del(EG(zend_constants), "sid", strlen("sid")); */
+	sid = zend_get_constant_str("SID", strlen("SID"));
 
 	if (PS(define_sid)) {
 		smart_str var = {0};
@@ -1485,7 +1485,7 @@ PHPAPI int php_session_reset_id(void) /* {{{ */
 	if (APPLY_TRANS_SID) {
 		apply_trans_sid = 1;
 		if (PS(use_cookies) &&
-			(data = zend_hash_str_find(&EG(symbol_table), "_COOKIE", sizeof("_COOKIE") - 1))) {
+			(data = zend_hash_str_find(&EG(symbol_table), "_COOKIE", strlen("_COOKIE")))) {
 			ZVAL_DEREF(data);
 			if (Z_TYPE_P(data) == IS_ARRAY &&
 				(ppid = zend_hash_str_find(Z_ARRVAL_P(data), PS(session_name), strlen(PS(session_name))))) {
@@ -1520,7 +1520,7 @@ PHPAPI int php_session_start(void) /* {{{ */
 			break;
 
 		case php_session_disabled:
-			value = zend_ini_string("session.save_handler", sizeof("session.save_handler") - 1, 0);
+			value = zend_ini_string("session.save_handler", strlen("session.save_handler"), 0);
 			if (!PS(mod) && value) {
 				PS(mod) = _php_find_ps_module(value);
 				if (!PS(mod)) {
@@ -1528,7 +1528,7 @@ PHPAPI int php_session_start(void) /* {{{ */
 					return FAILURE;
 				}
 			}
-			value = zend_ini_string("session.serialize_handler", sizeof("session.serialize_handler") - 1, 0);
+			value = zend_ini_string("session.serialize_handler", strlen("session.serialize_handler"), 0);
 			if (!PS(serializer) && value) {
 				PS(serializer) = _php_find_ps_serializer(value);
 				if (!PS(serializer)) {
@@ -1557,7 +1557,7 @@ PHPAPI int php_session_start(void) /* {{{ */
 	 */
 
 	if (!PS(id)) {
-		if (PS(use_cookies) && (data = zend_hash_str_find(&EG(symbol_table), "_COOKIE", sizeof("_COOKIE") - 1))) {
+		if (PS(use_cookies) && (data = zend_hash_str_find(&EG(symbol_table), "_COOKIE", strlen("_COOKIE")))) {
 			ZVAL_DEREF(data);
 			if (Z_TYPE_P(data) == IS_ARRAY && (ppid = zend_hash_str_find(Z_ARRVAL_P(data), PS(session_name), lensess))) {
 				ppid2sid(ppid);
@@ -1567,13 +1567,13 @@ PHPAPI int php_session_start(void) /* {{{ */
 		}
 		/* Initialize session ID from non cookie values */
 		if (!PS(use_only_cookies)) {
-			if (!PS(id) && (data = zend_hash_str_find(&EG(symbol_table), "_GET", sizeof("_GET") - 1))) {
+			if (!PS(id) && (data = zend_hash_str_find(&EG(symbol_table), "_GET", strlen("_GET")))) {
 				ZVAL_DEREF(data);
 				if (Z_TYPE_P(data) == IS_ARRAY && (ppid = zend_hash_str_find(Z_ARRVAL_P(data), PS(session_name), lensess))) {
 					ppid2sid(ppid);
 				}
 			}
-			if (!PS(id) && (data = zend_hash_str_find(&EG(symbol_table), "_POST", sizeof("_POST") - 1))) {
+			if (!PS(id) && (data = zend_hash_str_find(&EG(symbol_table), "_POST", strlen("_POST")))) {
 				ZVAL_DEREF(data);
 				if (Z_TYPE_P(data) == IS_ARRAY && (ppid = zend_hash_str_find(Z_ARRVAL_P(data), PS(session_name), lensess))) {
 					ppid2sid(ppid);
@@ -1583,7 +1583,7 @@ PHPAPI int php_session_start(void) /* {{{ */
 			 * '<session-name>=<session-id>' to allow URLs of the form
 			 * http://yoursite/<session-name>=<session-id>/script.php */
 			if (!PS(id) && zend_is_auto_global(ZSTR_KNOWN(ZEND_STR_AUTOGLOBAL_SERVER)) == SUCCESS &&
-				(data = zend_hash_str_find(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]), "REQUEST_URI", sizeof("REQUEST_URI") - 1)) &&
+				(data = zend_hash_str_find(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]), "REQUEST_URI", strlen("REQUEST_URI"))) &&
 				Z_TYPE_P(data) == IS_STRING &&
 				(p = strstr(Z_STRVAL_P(data), PS(session_name))) &&
 				p[lensess] == '='
@@ -1598,7 +1598,7 @@ PHPAPI int php_session_start(void) /* {{{ */
 			 * an external site which invalidates the previously found id. */
 			if (PS(id) && PS(extern_referer_chk)[0] != '\0' &&
 				!Z_ISUNDEF(PG(http_globals)[TRACK_VARS_SERVER]) &&
-				(data = zend_hash_str_find(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_REFERER", sizeof("HTTP_REFERER") - 1)) &&
+				(data = zend_hash_str_find(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_REFERER", strlen("HTTP_REFERER"))) &&
 				Z_TYPE_P(data) == IS_STRING &&
 				Z_STRLEN_P(data) != 0 &&
 				strstr(Z_STRVAL_P(data), PS(extern_referer_chk)) == NULL
@@ -1783,7 +1783,7 @@ PHP_FUNCTION(session_set_cookie_params)
 	}
 
 	if (lifetime) {
-		ini_name = zend_string_init("session.cookie_lifetime", sizeof("session.cookie_lifetime") - 1, 0);
+		ini_name = zend_string_init("session.cookie_lifetime", strlen("session.cookie_lifetime"), 0);
 		result = zend_alter_ini_entry(ini_name, lifetime, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
@@ -1792,7 +1792,7 @@ PHP_FUNCTION(session_set_cookie_params)
 		}
 	}
 	if (path) {
-		ini_name = zend_string_init("session.cookie_path", sizeof("session.cookie_path") - 1, 0);
+		ini_name = zend_string_init("session.cookie_path", strlen("session.cookie_path"), 0);
 		result = zend_alter_ini_entry(ini_name, path, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
@@ -1801,7 +1801,7 @@ PHP_FUNCTION(session_set_cookie_params)
 		}
 	}
 	if (domain) {
-		ini_name = zend_string_init("session.cookie_domain", sizeof("session.cookie_domain") - 1, 0);
+		ini_name = zend_string_init("session.cookie_domain", strlen("session.cookie_domain"), 0);
 		result = zend_alter_ini_entry(ini_name, domain, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
@@ -1810,7 +1810,7 @@ PHP_FUNCTION(session_set_cookie_params)
 		}
 	}
 	if (!secure_null) {
-		ini_name = zend_string_init("session.cookie_secure", sizeof("session.cookie_secure") - 1, 0);
+		ini_name = zend_string_init("session.cookie_secure", strlen("session.cookie_secure"), 0);
 		result = zend_alter_ini_entry_chars(ini_name, secure ? "1" : "0", 1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
@@ -1819,7 +1819,7 @@ PHP_FUNCTION(session_set_cookie_params)
 		}
 	}
 	if (!httponly_null) {
-		ini_name = zend_string_init("session.cookie_httponly", sizeof("session.cookie_httponly") - 1, 0);
+		ini_name = zend_string_init("session.cookie_httponly", strlen("session.cookie_httponly"), 0);
 		result = zend_alter_ini_entry_chars(ini_name, httponly ? "1" : "0", 1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
@@ -1828,7 +1828,7 @@ PHP_FUNCTION(session_set_cookie_params)
 		}
 	}
 	if (samesite) {
-		ini_name = zend_string_init("session.cookie_samesite", sizeof("session.cookie_samesite") - 1, 0);
+		ini_name = zend_string_init("session.cookie_samesite", strlen("session.cookie_samesite"), 0);
 		result = zend_alter_ini_entry(ini_name, samesite, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 		if (result == FAILURE) {
@@ -1890,7 +1890,7 @@ PHP_FUNCTION(session_name)
 	RETVAL_STRING(PS(session_name));
 
 	if (name) {
-		ini_name = zend_string_init("session.name", sizeof("session.name") - 1, 0);
+		ini_name = zend_string_init("session.name", strlen("session.name"), 0);
 		zend_alter_ini_entry(ini_name, name, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 	}
@@ -1940,7 +1940,7 @@ PHP_FUNCTION(session_module_name)
 		}
 		PS(mod_data) = NULL;
 
-		ini_name = zend_string_init("session.save_handler", sizeof("session.save_handler") - 1, 0);
+		ini_name = zend_string_init("session.save_handler", strlen("session.save_handler"), 0);
 		zend_alter_ini_entry(ini_name, name, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 	}
@@ -1964,8 +1964,8 @@ static int save_handler_check_session(void) {
 static inline void set_user_save_handler_ini(void) {
 	zend_string *ini_name, *ini_val;
 
-	ini_name = zend_string_init("session.save_handler", sizeof("session.save_handler") - 1, 0);
-	ini_val = zend_string_init("user", sizeof("user") - 1, 0);
+	ini_name = zend_string_init("session.save_handler", strlen("session.save_handler"), 0);
+	ini_val = zend_string_init("user", strlen("user"), 0);
 	PS(set_handler) = 1;
 	zend_alter_ini_entry(ini_name, ini_val, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 	PS(set_handler) = 0;
@@ -2072,14 +2072,14 @@ PHP_FUNCTION(session_set_save_handler)
 			ZEND_ASSERT(result == SUCCESS);
 
 			/* add shutdown function, removing the old one if it exists */
-			if (!register_user_shutdown_function("session_shutdown", sizeof("session_shutdown") - 1, &shutdown_function_entry)) {
+			if (!register_user_shutdown_function("session_shutdown", strlen("session_shutdown"), &shutdown_function_entry)) {
 				zval_ptr_dtor(&callable);
 				php_error_docref(NULL, E_WARNING, "Unable to register session shutdown function");
 				RETURN_FALSE;
 			}
 		} else {
 			/* remove shutdown function */
-			remove_user_shutdown_function("session_shutdown", sizeof("session_shutdown") - 1);
+			remove_user_shutdown_function("session_shutdown", strlen("session_shutdown"));
 		}
 
 		if (PS(session_status) != php_session_active && (!PS(mod) || PS(mod) != &ps_mod_user)) {
@@ -2118,7 +2118,7 @@ PHP_FUNCTION(session_set_save_handler)
 	}
 
 	/* remove shutdown function */
-	remove_user_shutdown_function("session_shutdown", sizeof("session_shutdown") - 1);
+	remove_user_shutdown_function("session_shutdown", strlen("session_shutdown"));
 
 	if (!PS(mod) || PS(mod) != &ps_mod_user) {
 		set_user_save_handler_ini();
@@ -2158,7 +2158,7 @@ PHP_FUNCTION(session_save_path)
 	RETVAL_STRING(PS(save_path));
 
 	if (name) {
-		ini_name = zend_string_init("session.save_path", sizeof("session.save_path") - 1, 0);
+		ini_name = zend_string_init("session.save_path", strlen("session.save_path"), 0);
 		zend_alter_ini_entry(ini_name, name, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 	}
@@ -2393,7 +2393,7 @@ PHP_FUNCTION(session_cache_limiter)
 	RETVAL_STRING(PS(cache_limiter));
 
 	if (limiter) {
-		ini_name = zend_string_init("session.cache_limiter", sizeof("session.cache_limiter") - 1, 0);
+		ini_name = zend_string_init("session.cache_limiter", strlen("session.cache_limiter"), 0);
 		zend_alter_ini_entry(ini_name, limiter, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
 	}
@@ -2423,7 +2423,7 @@ PHP_FUNCTION(session_cache_expire)
 	RETVAL_LONG(PS(cache_expire));
 
 	if (!expires_is_null) {
-		zend_string *ini_name = zend_string_init("session.cache_expire", sizeof("session.cache_expire") - 1, 0);
+		zend_string *ini_name = zend_string_init("session.cache_expire", strlen("session.cache_expire"), 0);
 		zend_string *ini_value = zend_long_to_str(expires);
 		zend_alter_ini_entry(ini_name, ini_value, ZEND_INI_USER, ZEND_INI_STAGE_RUNTIME);
 		zend_string_release_ex(ini_name, 0);
@@ -2723,7 +2723,7 @@ static int php_rinit_session(bool auto_start) /* {{{ */
 	{
 		char *value;
 
-		value = zend_ini_string("session.save_handler", sizeof("session.save_handler") - 1, 0);
+		value = zend_ini_string("session.save_handler", strlen("session.save_handler"), 0);
 		if (value) {
 			PS(mod) = _php_find_ps_module(value);
 		}
@@ -2732,7 +2732,7 @@ static int php_rinit_session(bool auto_start) /* {{{ */
 	if (PS(serializer) == NULL) {
 		char *value;
 
-		value = zend_ini_string("session.serialize_handler", sizeof("session.serialize_handler") - 1, 0);
+		value = zend_ini_string("session.serialize_handler", strlen("session.serialize_handler"), 0);
 		if (value) {
 			PS(serializer) = _php_find_ps_serializer(value);
 		}
@@ -2810,7 +2810,7 @@ static PHP_GINIT_FUNCTION(ps) /* {{{ */
 
 static PHP_MINIT_FUNCTION(session) /* {{{ */
 {
-	zend_register_auto_global(zend_string_init_interned("_SESSION", sizeof("_SESSION") - 1, 1), 0, NULL);
+	zend_register_auto_global(zend_string_init_interned("_SESSION", strlen("_SESSION"), 1), 0, NULL);
 
 	my_module_number = module_number;
 	PS(module_number) = module_number;
@@ -2968,7 +2968,7 @@ static bool php_check_cancel_upload(php_session_rfc1867_progress *progress) /* {
 	if (Z_TYPE_P(progress_ary) != IS_ARRAY) {
 		return 0;
 	}
-	if ((cancel_upload = zend_hash_str_find(Z_ARRVAL_P(progress_ary), "cancel_upload", sizeof("cancel_upload") - 1)) == NULL) {
+	if ((cancel_upload = zend_hash_str_find(Z_ARRVAL_P(progress_ary), "cancel_upload", strlen("cancel_upload"))) == NULL) {
 		return 0;
 	}
 	return Z_TYPE_P(cancel_upload) == IS_TRUE;
@@ -3099,13 +3099,13 @@ static int php_session_rfc1867_callback(unsigned int event, void *event_data, vo
 				array_init(&progress->data);
 				array_init(&progress->files);
 
-				add_assoc_long_ex(&progress->data, "start_time", sizeof("start_time") - 1, (zend_long)sapi_get_request_time());
-				add_assoc_long_ex(&progress->data, "content_length",  sizeof("content_length") - 1, progress->content_length);
-				add_assoc_long_ex(&progress->data, "bytes_processed", sizeof("bytes_processed") - 1, data->post_bytes_processed);
-				add_assoc_bool_ex(&progress->data, "done", sizeof("done") - 1, 0);
-				add_assoc_zval_ex(&progress->data, "files", sizeof("files") - 1, &progress->files);
+				add_assoc_long_ex(&progress->data, "start_time", strlen("start_time"), (zend_long)sapi_get_request_time());
+				add_assoc_long_ex(&progress->data, "content_length",  strlen("content_length"), progress->content_length);
+				add_assoc_long_ex(&progress->data, "bytes_processed", strlen("bytes_processed"), data->post_bytes_processed);
+				add_assoc_bool_ex(&progress->data, "done", strlen("done"), 0);
+				add_assoc_zval_ex(&progress->data, "files", strlen("files"), &progress->files);
 
-				progress->post_bytes_processed = zend_hash_str_find(Z_ARRVAL(progress->data), "bytes_processed", sizeof("bytes_processed") - 1);
+				progress->post_bytes_processed = zend_hash_str_find(Z_ARRVAL(progress->data), "bytes_processed", strlen("bytes_processed"));
 
 				php_rinit_session(0);
 				PS(id) = zend_string_init(Z_STRVAL(progress->sid), Z_STRLEN(progress->sid), 0);
@@ -3120,18 +3120,18 @@ static int php_session_rfc1867_callback(unsigned int event, void *event_data, vo
 			array_init(&progress->current_file);
 
 			/* Each uploaded file has its own array. Trying to make it close to $_FILES entries. */
-			add_assoc_string_ex(&progress->current_file, "field_name", sizeof("field_name") - 1, data->name);
-			add_assoc_string_ex(&progress->current_file, "name", sizeof("name") - 1, *data->filename);
-			add_assoc_null_ex(&progress->current_file, "tmp_name", sizeof("tmp_name") - 1);
-			add_assoc_long_ex(&progress->current_file, "error", sizeof("error") - 1, 0);
+			add_assoc_string_ex(&progress->current_file, "field_name", strlen("field_name"), data->name);
+			add_assoc_string_ex(&progress->current_file, "name", strlen("name"), *data->filename);
+			add_assoc_null_ex(&progress->current_file, "tmp_name", strlen("tmp_name"));
+			add_assoc_long_ex(&progress->current_file, "error", strlen("error"), 0);
 
-			add_assoc_bool_ex(&progress->current_file, "done", sizeof("done") - 1, 0);
-			add_assoc_long_ex(&progress->current_file, "start_time", sizeof("start_time") - 1, (zend_long)time(NULL));
-			add_assoc_long_ex(&progress->current_file, "bytes_processed", sizeof("bytes_processed") - 1, 0);
+			add_assoc_bool_ex(&progress->current_file, "done", strlen("done"), 0);
+			add_assoc_long_ex(&progress->current_file, "start_time", strlen("start_time"), (zend_long)time(NULL));
+			add_assoc_long_ex(&progress->current_file, "bytes_processed", strlen("bytes_processed"), 0);
 
 			add_next_index_zval(&progress->files, &progress->current_file);
 
-			progress->current_file_bytes_processed = zend_hash_str_find(Z_ARRVAL(progress->current_file), "bytes_processed", sizeof("bytes_processed") - 1);
+			progress->current_file_bytes_processed = zend_hash_str_find(Z_ARRVAL(progress->current_file), "bytes_processed", strlen("bytes_processed"));
 
 			Z_LVAL_P(progress->current_file_bytes_processed) =  data->post_bytes_processed;
 			php_session_rfc1867_update(progress, 0);
@@ -3158,11 +3158,11 @@ static int php_session_rfc1867_callback(unsigned int event, void *event_data, vo
 			}
 
 			if (data->temp_filename) {
-				add_assoc_string_ex(&progress->current_file, "tmp_name",  sizeof("tmp_name") - 1, data->temp_filename);
+				add_assoc_string_ex(&progress->current_file, "tmp_name",  strlen("tmp_name"), data->temp_filename);
 			}
 
-			add_assoc_long_ex(&progress->current_file, "error", sizeof("error") - 1, data->cancel_upload);
-			add_assoc_bool_ex(&progress->current_file, "done", sizeof("done") - 1,  1);
+			add_assoc_long_ex(&progress->current_file, "error", strlen("error"), data->cancel_upload);
+			add_assoc_bool_ex(&progress->current_file, "done", strlen("done"),  1);
 
 			Z_LVAL_P(progress->post_bytes_processed) = data->post_bytes_processed;
 
@@ -3178,7 +3178,7 @@ static int php_session_rfc1867_callback(unsigned int event, void *event_data, vo
 				} else {
 					if (!Z_ISUNDEF(progress->data)) {
 						SEPARATE_ARRAY(&progress->data);
-						add_assoc_bool_ex(&progress->data, "done", sizeof("done") - 1, 1);
+						add_assoc_bool_ex(&progress->data, "done", strlen("done"), 1);
 						Z_LVAL_P(progress->post_bytes_processed) = data->post_bytes_processed;
 						php_session_rfc1867_update(progress, 1);
 					}

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -1121,7 +1121,7 @@ static HashTable *sxe_get_prop_hash(zend_object *object, int is_debug) /* {{{ */
 					namelen = xmlStrlen(attr->name);
 					if (Z_ISUNDEF(zattr)) {
 						array_init(&zattr);
-						sxe_properties_add(rv, "@attributes", sizeof("@attributes") - 1, &zattr);
+						sxe_properties_add(rv, "@attributes", strlen("@attributes"), &zattr);
 					}
 					add_assoc_zval_ex(&zattr, (char*)attr->name, namelen, &value);
 				}
@@ -2198,7 +2198,7 @@ static zend_function* php_sxe_find_fptr_count(zend_class_entry *ce)
 	}
 
 	if (inherited) {
-		fptr_count = zend_hash_str_find_ptr(&ce->function_table, "count", sizeof("count") - 1);
+		fptr_count = zend_hash_str_find_ptr(&ce->function_table, "count", strlen("count"));
 		if (fptr_count->common.scope == parent) {
 			fptr_count = NULL;
 		}

--- a/ext/skeleton/skeleton.c
+++ b/ext/skeleton/skeleton.c
@@ -29,7 +29,7 @@ PHP_FUNCTION(test1)
 PHP_FUNCTION(test2)
 {
 	char *var = "World";
-	size_t var_len = sizeof("World") - 1;
+	size_t var_len = strlen("World");
 	zend_string *retval;
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -253,49 +253,49 @@ static zend_class_entry *register_class_SNMP(void)
 
 	zval property_info_default_value;
 	ZVAL_UNDEF(&property_info_default_value);
-	zend_string *property_info_name = zend_string_init("info", sizeof("info") - 1, 1);
+	zend_string *property_info_name = zend_string_init("info", strlen("info"), 1);
 	zend_declare_typed_property(class_entry, property_info_name, &property_info_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property_info_name);
 
 	zval property_max_oids_default_value;
 	ZVAL_UNDEF(&property_max_oids_default_value);
-	zend_string *property_max_oids_name = zend_string_init("max_oids", sizeof("max_oids") - 1, 1);
+	zend_string *property_max_oids_name = zend_string_init("max_oids", strlen("max_oids"), 1);
 	zend_declare_typed_property(class_entry, property_max_oids_name, &property_max_oids_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_max_oids_name);
 
 	zval property_valueretrieval_default_value;
 	ZVAL_UNDEF(&property_valueretrieval_default_value);
-	zend_string *property_valueretrieval_name = zend_string_init("valueretrieval", sizeof("valueretrieval") - 1, 1);
+	zend_string *property_valueretrieval_name = zend_string_init("valueretrieval", strlen("valueretrieval"), 1);
 	zend_declare_typed_property(class_entry, property_valueretrieval_name, &property_valueretrieval_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_valueretrieval_name);
 
 	zval property_quick_print_default_value;
 	ZVAL_UNDEF(&property_quick_print_default_value);
-	zend_string *property_quick_print_name = zend_string_init("quick_print", sizeof("quick_print") - 1, 1);
+	zend_string *property_quick_print_name = zend_string_init("quick_print", strlen("quick_print"), 1);
 	zend_declare_typed_property(class_entry, property_quick_print_name, &property_quick_print_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_quick_print_name);
 
 	zval property_enum_print_default_value;
 	ZVAL_UNDEF(&property_enum_print_default_value);
-	zend_string *property_enum_print_name = zend_string_init("enum_print", sizeof("enum_print") - 1, 1);
+	zend_string *property_enum_print_name = zend_string_init("enum_print", strlen("enum_print"), 1);
 	zend_declare_typed_property(class_entry, property_enum_print_name, &property_enum_print_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_enum_print_name);
 
 	zval property_oid_output_format_default_value;
 	ZVAL_UNDEF(&property_oid_output_format_default_value);
-	zend_string *property_oid_output_format_name = zend_string_init("oid_output_format", sizeof("oid_output_format") - 1, 1);
+	zend_string *property_oid_output_format_name = zend_string_init("oid_output_format", strlen("oid_output_format"), 1);
 	zend_declare_typed_property(class_entry, property_oid_output_format_name, &property_oid_output_format_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_oid_output_format_name);
 
 	zval property_oid_increasing_check_default_value;
 	ZVAL_UNDEF(&property_oid_increasing_check_default_value);
-	zend_string *property_oid_increasing_check_name = zend_string_init("oid_increasing_check", sizeof("oid_increasing_check") - 1, 1);
+	zend_string *property_oid_increasing_check_name = zend_string_init("oid_increasing_check", strlen("oid_increasing_check"), 1);
 	zend_declare_typed_property(class_entry, property_oid_increasing_check_name, &property_oid_increasing_check_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_oid_increasing_check_name);
 
 	zval property_exceptions_enabled_default_value;
 	ZVAL_UNDEF(&property_exceptions_enabled_default_value);
-	zend_string *property_exceptions_enabled_name = zend_string_init("exceptions_enabled", sizeof("exceptions_enabled") - 1, 1);
+	zend_string *property_exceptions_enabled_name = zend_string_init("exceptions_enabled", strlen("exceptions_enabled"), 1);
 	zend_declare_typed_property(class_entry, property_exceptions_enabled_name, &property_exceptions_enabled_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_exceptions_enabled_name);
 

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -990,11 +990,11 @@ static zval *to_zval_double(zval *ret, encodeTypePtr type, xmlNodePtr data)
 					ZVAL_DOUBLE(ret, dval);
 					break;
 				default:
-					if (strncasecmp((char*)data->children->content, "NaN", sizeof("NaN")-1) == 0) {
+					if (strncasecmp((char*)data->children->content, "NaN", strlen("NaN")) == 0) {
 						ZVAL_DOUBLE(ret, php_get_nan());
-					} else if (strncasecmp((char*)data->children->content, "INF", sizeof("INF")-1) == 0) {
+					} else if (strncasecmp((char*)data->children->content, "INF", strlen("INF")) == 0) {
 						ZVAL_DOUBLE(ret, php_get_inf());
-					} else if (strncasecmp((char*)data->children->content, "-INF", sizeof("-INF")-1) == 0) {
+					} else if (strncasecmp((char*)data->children->content, "-INF", strlen("-INF")) == 0) {
 						ZVAL_DOUBLE(ret, -php_get_inf());
 					} else {
 						soap_error0(E_ERROR, "Encoding: Violation of encoding rules");
@@ -2388,7 +2388,7 @@ iterator_done:
 				smart_str_0(&array_type);
 				if (strcmp(ZSTR_VAL(array_type.s),"xsd:anyType") == 0) {
 					smart_str_free(&array_type);
-					smart_str_appendl(&array_type,"xsd:ur-type",sizeof("xsd:ur-type")-1);
+					smart_str_appendl(&array_type,"xsd:ur-type",strlen("xsd:ur-type"));
 				}
 				smart_str_appendc(&array_type, '[');
 				smart_str_append_smart_str(&array_type, &array_size);
@@ -3476,7 +3476,7 @@ static encodePtr get_array_type(xmlNodePtr node, zval *array, smart_str *type)
 	char *prev_stype = NULL, *cur_stype = NULL, *prev_ns = NULL, *cur_ns = NULL;
 
 	if (!array || Z_TYPE_P(array) != IS_ARRAY) {
-		smart_str_appendl(type, "xsd:anyType", sizeof("xsd:anyType")-1);
+		smart_str_appendl(type, "xsd:anyType", strlen("xsd:anyType"));
 		return get_conversion(XSD_ANYTYPE);
 	}
 
@@ -3537,7 +3537,7 @@ static encodePtr get_array_type(xmlNodePtr node, zval *array, smart_str *type)
 	} ZEND_HASH_FOREACH_END();
 
 	if (different || i == 0) {
-		smart_str_appendl(type, "xsd:anyType", sizeof("xsd:anyType")-1);
+		smart_str_appendl(type, "xsd:anyType", strlen("xsd:anyType"));
 		return get_conversion(XSD_ANYTYPE);
 	} else {
 		encodePtr enc;

--- a/ext/soap/php_http.c
+++ b/ext/soap/php_http.c
@@ -121,25 +121,25 @@ void http_context_headers(php_stream_context* context,
 					p++;
 				}
 				/* skip some predefined headers */
-				if ((name_len != sizeof("host")-1 ||
-				     strncasecmp(s, "host", sizeof("host")-1) != 0) &&
-				    (name_len != sizeof("connection")-1 ||
-				     strncasecmp(s, "connection", sizeof("connection")-1) != 0) &&
-				    (name_len != sizeof("user-agent")-1 ||
-				     strncasecmp(s, "user-agent", sizeof("user-agent")-1) != 0) &&
-				    (name_len != sizeof("content-length")-1 ||
-				     strncasecmp(s, "content-length", sizeof("content-length")-1) != 0) &&
-				    (name_len != sizeof("content-type")-1 ||
-				     strncasecmp(s, "content-type", sizeof("content-type")-1) != 0) &&
+				if ((name_len != strlen("host") ||
+				     strncasecmp(s, "host", strlen("host")) != 0) &&
+				    (name_len != strlen("connection") ||
+				     strncasecmp(s, "connection", strlen("connection")) != 0) &&
+				    (name_len != strlen("user-agent") ||
+				     strncasecmp(s, "user-agent", strlen("user-agent")) != 0) &&
+				    (name_len != strlen("content-length") ||
+				     strncasecmp(s, "content-length", strlen("content-length")) != 0) &&
+				    (name_len != strlen("content-type") ||
+				     strncasecmp(s, "content-type", strlen("content-type")) != 0) &&
 				    (!has_cookies ||
-				     name_len != sizeof("cookie")-1 ||
-				     strncasecmp(s, "cookie", sizeof("cookie")-1) != 0) &&
+				     name_len != strlen("cookie") ||
+				     strncasecmp(s, "cookie", strlen("cookie")) != 0) &&
 				    (!has_authorization ||
-				     name_len != sizeof("authorization")-1 ||
-				     strncasecmp(s, "authorization", sizeof("authorization")-1) != 0) &&
+				     name_len != strlen("authorization") ||
+				     strncasecmp(s, "authorization", strlen("authorization")) != 0) &&
 				    (!has_proxy_authorization ||
-				     name_len != sizeof("proxy-authorization")-1 ||
-				     strncasecmp(s, "proxy-authorization", sizeof("proxy-authorization")-1) != 0)) {
+				     name_len != strlen("proxy-authorization") ||
+				     strncasecmp(s, "proxy-authorization", strlen("proxy-authorization")) != 0)) {
 				    /* add header */
 					smart_str_appendl(soap_headers, s, p-s);
 					smart_str_append_const(soap_headers, "\r\n");
@@ -670,7 +670,7 @@ try_again:
 				PHP_MD5Final(hash, &md5ctx);
 				make_digest(cnonce, hash);
 
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nc", sizeof("nc")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nc", strlen("nc"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_LONG) {
 					Z_LVAL_P(tmp)++;
 					snprintf(nc, sizeof(nc), "%08" ZEND_LONG_FMT_SPEC, Z_LVAL_P(tmp));
@@ -682,7 +682,7 @@ try_again:
 				PHP_MD5Init(&md5ctx);
 				PHP_MD5Update(&md5ctx, (unsigned char*)Z_STRVAL_P(login), Z_STRLEN_P(login));
 				PHP_MD5Update(&md5ctx, (unsigned char*)":", 1);
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "realm", sizeof("realm")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "realm", strlen("realm"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING) {
 					PHP_MD5Update(&md5ctx, (unsigned char*)Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
 				}
@@ -693,14 +693,14 @@ try_again:
 				}
 				PHP_MD5Final(hash, &md5ctx);
 				make_digest(HA1, hash);
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "algorithm", sizeof("algorithm")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "algorithm", strlen("algorithm"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING &&
-					Z_STRLEN_P(tmp) == sizeof("md5-sess")-1 &&
+					Z_STRLEN_P(tmp) == strlen("md5-sess") &&
 					stricmp(Z_STRVAL_P(tmp), "md5-sess") == 0) {
 					PHP_MD5Init(&md5ctx);
 					PHP_MD5Update(&md5ctx, (unsigned char*)HA1, 32);
 					PHP_MD5Update(&md5ctx, (unsigned char*)":", 1);
-					if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nonce", sizeof("nonce")-1)) != NULL &&
+					if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nonce", strlen("nonce"))) != NULL &&
 						Z_TYPE_P(tmp) == IS_STRING) {
 						PHP_MD5Update(&md5ctx, (unsigned char*)Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
 					}
@@ -711,7 +711,7 @@ try_again:
 				}
 
 				PHP_MD5Init(&md5ctx);
-				PHP_MD5Update(&md5ctx, (unsigned char*)"POST:", sizeof("POST:")-1);
+				PHP_MD5Update(&md5ctx, (unsigned char*)"POST:", strlen("POST:"));
 				if (phpurl->path) {
 					PHP_MD5Update(&md5ctx, (unsigned char*)ZSTR_VAL(phpurl->path), ZSTR_LEN(phpurl->path));
 				} else {
@@ -728,19 +728,19 @@ try_again:
 				PHP_MD5Init(&md5ctx);
 				PHP_MD5Update(&md5ctx, (unsigned char*)HA1, 32);
 				PHP_MD5Update(&md5ctx, (unsigned char*)":", 1);
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nonce", sizeof("nonce")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nonce", strlen("nonce"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING) {
 					PHP_MD5Update(&md5ctx, (unsigned char*)Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
 				}
 				PHP_MD5Update(&md5ctx, (unsigned char*)":", 1);
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "qop", sizeof("qop")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "qop", strlen("qop"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING) {
 					PHP_MD5Update(&md5ctx, (unsigned char*)nc, 8);
 					PHP_MD5Update(&md5ctx, (unsigned char*)":", 1);
 					PHP_MD5Update(&md5ctx, (unsigned char*)cnonce, 8);
 					PHP_MD5Update(&md5ctx, (unsigned char*)":", 1);
 					/* TODO: Support for qop="auth-int" */
-					PHP_MD5Update(&md5ctx, (unsigned char*)"auth", sizeof("auth")-1);
+					PHP_MD5Update(&md5ctx, (unsigned char*)"auth", strlen("auth"));
 					PHP_MD5Update(&md5ctx, (unsigned char*)":", 1);
 				}
 				PHP_MD5Update(&md5ctx, (unsigned char*)HA2, 32);
@@ -749,12 +749,12 @@ try_again:
 
 				smart_str_append_const(&soap_headers, "Authorization: Digest username=\"");
 				smart_str_appendl(&soap_headers, Z_STRVAL_P(login), Z_STRLEN_P(login));
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "realm", sizeof("realm")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "realm", strlen("realm"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING) {
 					smart_str_append_const(&soap_headers, "\", realm=\"");
 					smart_str_appendl(&soap_headers, Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
 				}
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nonce", sizeof("nonce")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "nonce", strlen("nonce"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING) {
 					smart_str_append_const(&soap_headers, "\", nonce=\"");
 					smart_str_appendl(&soap_headers, Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
@@ -773,7 +773,7 @@ try_again:
 					smart_str_appendc(&soap_headers, '#');
 					smart_str_appends(&soap_headers, ZSTR_VAL(phpurl->fragment));
 				}
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "qop", sizeof("qop")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "qop", strlen("qop"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING) {
 				/* TODO: Support for qop="auth-int" */
 					smart_str_append_const(&soap_headers, "\", qop=\"auth");
@@ -784,12 +784,12 @@ try_again:
 				}
 				smart_str_append_const(&soap_headers, "\", response=\"");
 				smart_str_appendl(&soap_headers, response, 32);
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "opaque", sizeof("opaque")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "opaque", strlen("opaque"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING) {
 					smart_str_append_const(&soap_headers, "\", opaque=\"");
 					smart_str_appendl(&soap_headers, Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
 				}
-				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "algorithm", sizeof("algorithm")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(Z_ARRVAL_P(digest), "algorithm", strlen("algorithm"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_STRING) {
 					smart_str_append_const(&soap_headers, "\", algorithm=\"");
 					smart_str_appendl(&soap_headers, Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
@@ -984,10 +984,10 @@ try_again:
 					while (*options == ' ') {options++;}
 					sempos = strstr(options, ";");
 					if (strstr(options,"path=") == options) {
-						eqpos = options + sizeof("path=")-1;
+						eqpos = options + strlen("path=");
 						add_index_stringl(&zcookie, 1, eqpos, sempos?(size_t)(sempos-eqpos):strlen(eqpos));
 					} else if (strstr(options,"domain=") == options) {
-						eqpos = options + sizeof("domain=")-1;
+						eqpos = options + strlen("domain=");
 						add_index_stringl(&zcookie, 2, eqpos, sempos?(size_t)(sempos-eqpos):strlen(eqpos));
 					} else if (strstr(options,"secure") == options) {
 						add_index_bool(&zcookie, 3, 1);
@@ -1025,7 +1025,7 @@ try_again:
 		if (use_proxy && !use_ssl) {
 			connection = get_http_header_value(ZSTR_VAL(http_headers), "Proxy-Connection: ");
 			if (connection) {
-				if (strncasecmp(connection, "close", sizeof("close")-1) == 0) {
+				if (strncasecmp(connection, "close", strlen("close")) == 0) {
 					http_close = TRUE;
 				}
 				efree(connection);
@@ -1034,7 +1034,7 @@ try_again:
 		if (http_close == FALSE) {
 			connection = get_http_header_value(ZSTR_VAL(http_headers), "Connection: ");
 			if (connection) {
-				if (strncasecmp(connection, "close", sizeof("close")-1) == 0) {
+				if (strncasecmp(connection, "close", strlen("close")) == 0) {
 					http_close = TRUE;
 				}
 				efree(connection);
@@ -1045,7 +1045,7 @@ try_again:
 		if (use_proxy && !use_ssl) {
 			connection = get_http_header_value(ZSTR_VAL(http_headers), "Proxy-Connection: ");
 			if (connection) {
-				if (strncasecmp(connection, "Keep-Alive", sizeof("Keep-Alive")-1) == 0) {
+				if (strncasecmp(connection, "Keep-Alive", strlen("Keep-Alive")) == 0) {
 					http_close = FALSE;
 				}
 				efree(connection);
@@ -1054,7 +1054,7 @@ try_again:
 		if (http_close == TRUE) {
 			connection = get_http_header_value(ZSTR_VAL(http_headers), "Connection: ");
 			if (connection) {
-				if (strncasecmp(connection, "Keep-Alive", sizeof("Keep-Alive")-1) == 0) {
+				if (strncasecmp(connection, "Keep-Alive", strlen("Keep-Alive")) == 0) {
 					http_close = FALSE;
 				}
 				efree(connection);
@@ -1151,7 +1151,7 @@ try_again:
 			zval digest;
 
 			ZVAL_UNDEF(&digest);
-			s = auth + sizeof("Digest")-1;
+			s = auth + strlen("Digest");
 			while (*s != '\0') {
 				char *name, *val;
 				while (*s == ' ') ++s;
@@ -1252,11 +1252,11 @@ try_again:
 
 		if ((strcmp(content_encoding,"gzip") == 0 ||
 		     strcmp(content_encoding,"x-gzip") == 0) &&
-		     zend_hash_str_exists(EG(function_table), "gzinflate", sizeof("gzinflate")-1)) {
+		     zend_hash_str_exists(EG(function_table), "gzinflate", strlen("gzinflate"))) {
 			ZVAL_STRING(&func, "gzinflate");
 			ZVAL_STRINGL(&params[0], http_body->val+10, http_body->len-10);
 		} else if (strcmp(content_encoding,"deflate") == 0 &&
-		           zend_hash_str_exists(EG(function_table), "gzuncompress", sizeof("gzuncompress")-1)) {
+		           zend_hash_str_exists(EG(function_table), "gzuncompress", strlen("gzuncompress"))) {
 			ZVAL_STRING(&func, "gzuncompress");
 			ZVAL_STR_COPY(&params[0], http_body);
 		} else {
@@ -1404,13 +1404,13 @@ static zend_string* get_http_body(php_stream *stream, int close, char *headers)
 	if (!close) {
 		header = get_http_header_value(headers, "Connection: ");
 		if (header) {
-			if(!strncasecmp(header, "close", sizeof("close")-1)) header_close = 1;
+			if(!strncasecmp(header, "close", strlen("close"))) header_close = 1;
 			efree(header);
 		}
 	}
 	header = get_http_header_value(headers, "Transfer-Encoding: ");
 	if (header) {
-		if(!strncasecmp(header, "chunked", sizeof("chunked")-1)) header_chunked = 1;
+		if(!strncasecmp(header, "chunked", strlen("chunked"))) header_chunked = 1;
 		efree(header);
 	}
 	header = get_http_header_value(headers, "Content-Length: ");

--- a/ext/soap/php_schema.c
+++ b/ext/soap/php_schema.c
@@ -456,10 +456,10 @@ static int schema_list(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr listType, sdlTypeP
 		{
 			char buf[MAX_LENGTH_OF_LONG + 1];
 			char *res = zend_print_long_to_buf(buf + sizeof(buf) - 1, zend_hash_num_elements(sdl->types));
-			char *str = emalloc(sizeof("anonymous")-1 + (buf + sizeof(buf) - res));
+			char *str = emalloc(strlen("anonymous") + (buf + sizeof(buf) - res));
 
-			memcpy(str, "anonymous", sizeof("anonymous")-1);
-			memcpy(str + sizeof("anonymous")-1, res, buf + sizeof(buf) - res);
+			memcpy(str, "anonymous", strlen("anonymous"));
+			memcpy(str + strlen("anonymous"), res, buf + sizeof(buf) - res);
 			newType->name = str;
 		}
 		newType->namens = estrdup((char*)tns->children->content);
@@ -553,10 +553,10 @@ static int schema_union(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr unionType, sdlTyp
 			{
 				char buf[MAX_LENGTH_OF_LONG + 1];
 				char *res = zend_print_long_to_buf(buf + sizeof(buf) - 1, zend_hash_num_elements(sdl->types));
-				char *str = emalloc(sizeof("anonymous")-1 + (buf + sizeof(buf) - res));
+				char *str = emalloc(strlen("anonymous") + (buf + sizeof(buf) - res));
 
-				memcpy(str, "anonymous", sizeof("anonymous")-1);
-				memcpy(str + sizeof("anonymous")-1, res, buf + sizeof(buf) - res);
+				memcpy(str, "anonymous", strlen("anonymous"));
+				memcpy(str + strlen("anonymous"), res, buf + sizeof(buf) - res);
 				newType->name = str;
 			}
 			newType->namens = estrdup((char*)tns->children->content);
@@ -1924,10 +1924,10 @@ static int schema_attribute(sdlPtr sdl, xmlAttrPtr tns, xmlNodePtr attrType, sdl
 			{
 				char buf[MAX_LENGTH_OF_LONG + 1];
 				char *res = zend_print_long_to_buf(buf + sizeof(buf) - 1, zend_hash_num_elements(sdl->types));
-				char *str = emalloc(sizeof("anonymous")-1 + (buf + sizeof(buf) - res));
+				char *str = emalloc(strlen("anonymous") + (buf + sizeof(buf) - res));
 
-				memcpy(str, "anonymous", sizeof("anonymous")-1);
-				memcpy(str + sizeof("anonymous")-1, res, buf + sizeof(buf) - res);
+				memcpy(str, "anonymous", strlen("anonymous"));
+				memcpy(str + strlen("anonymous"), res, buf + sizeof(buf) - res);
 				dummy_type->name = str;
 			}
 			dummy_type->namens = estrdup((char*)tns->children->content);

--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -3211,10 +3211,10 @@ sdlPtr get_sdl(zval *this_ptr, char *uri, zend_long cache_wsdl)
 		PHP_MD5Update(&context, (unsigned char*)uri, uri_len);
 		PHP_MD5Final(digest, &context);
 		make_digest(md5str, digest);
-		key = emalloc(len+sizeof("/wsdl-")-1+user_len+2+sizeof(md5str));
+		key = emalloc(len+strlen("/wsdl-")+user_len+2+sizeof(md5str));
 		memcpy(key,SOAP_GLOBAL(cache_dir),len);
-		memcpy(key+len,"/wsdl-",sizeof("/wsdl-")-1);
-		len += sizeof("/wsdl-")-1;
+		memcpy(key+len,"/wsdl-",strlen("/wsdl-"));
+		len += strlen("/wsdl-");
 		if (user_len) {
 			memcpy(key+len, user, user_len-1);
 			len += user_len-1;
@@ -3270,8 +3270,8 @@ sdlPtr get_sdl(zval *this_ptr, char *uri, zend_long cache_wsdl)
 			php_stream_context_set_option(context, "http", "proxy", &str_proxy);
 			zval_ptr_dtor(&str_proxy);
 
-			if (uri_len < sizeof("https://")-1 ||
-				strncasecmp(uri, "https://", sizeof("https://")-1) != 0) {
+			if (uri_len < strlen("https://") ||
+				strncasecmp(uri, "https://", strlen("https://")) != 0) {
 				ZVAL_TRUE(&str_proxy);
 				php_stream_context_set_option(context, "http", "request_fulluri", &str_proxy);
 			}
@@ -3292,7 +3292,7 @@ sdlPtr get_sdl(zval *this_ptr, char *uri, zend_long cache_wsdl)
 
 		ZVAL_DOUBLE(&http_version, 1.1);
 		php_stream_context_set_option(context, "http", "protocol_version", &http_version);
-		smart_str_appendl(&headers, "Connection: close\r\n", sizeof("Connection: close\r\n")-1);
+		smart_str_appendl(&headers, "Connection: close\r\n", strlen("Connection: close\r\n"));
 	}
 
 	if (headers.s && ZSTR_LEN(headers.s) > 0) {

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -678,10 +678,10 @@ PHP_METHOD(SoapFault, __toString)
 	}
 
 	this_ptr = ZEND_THIS;
-	faultcode = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "faultcode", sizeof("faultcode")-1, 1, &rv1);
-	faultstring = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "faultstring", sizeof("faultstring")-1, 1, &rv2);
-	file = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "file", sizeof("file")-1, 1, &rv3);
-	line = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "line", sizeof("line")-1, 1, &rv4);
+	faultcode = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "faultcode", strlen("faultcode"), 1, &rv1);
+	faultstring = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "faultstring", strlen("faultstring"), 1, &rv2);
+	file = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "file", strlen("file"), 1, &rv3);
+	line = zend_read_property(soap_fault_class_entry, Z_OBJ_P(this_ptr), "line", strlen("line"), 1, &rv4);
 
 	zend_call_method_with_0_params(
 		Z_OBJ_P(ZEND_THIS), Z_OBJCE_P(ZEND_THIS), NULL, "gettraceasstring", &trace);
@@ -876,7 +876,7 @@ PHP_METHOD(SoapServer, __construct)
 		HashTable *ht = Z_ARRVAL_P(options);
 		zval *tmp;
 
-		if ((tmp = zend_hash_str_find(ht, "soap_version", sizeof("soap_version")-1)) != NULL) {
+		if ((tmp = zend_hash_str_find(ht, "soap_version", strlen("soap_version"))) != NULL) {
 			if (Z_TYPE_P(tmp) == IS_LONG &&
 			    (Z_LVAL_P(tmp) == SOAP_1_1 || Z_LVAL_P(tmp) == SOAP_1_2)) {
 				version = Z_LVAL_P(tmp);
@@ -885,19 +885,19 @@ PHP_METHOD(SoapServer, __construct)
 			}
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "uri", sizeof("uri")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "uri", strlen("uri"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			service->uri = estrndup(Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
 		} else if (!wsdl) {
 			php_error_docref(NULL, E_ERROR, "'uri' option is required in nonWSDL mode");
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "actor", sizeof("actor")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "actor", strlen("actor"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			service->actor = estrndup(Z_STRVAL_P(tmp), Z_STRLEN_P(tmp));
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "encoding", sizeof("encoding")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "encoding", strlen("encoding"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			xmlCharEncodingHandlerPtr encoding;
 
@@ -909,28 +909,28 @@ PHP_METHOD(SoapServer, __construct)
 			}
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "classmap", strlen("classmap"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY) {
 			service->class_map = zend_array_dup(Z_ARRVAL_P(tmp));
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "typemap", sizeof("typemap")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "typemap", strlen("typemap"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY &&
 			zend_hash_num_elements(Z_ARRVAL_P(tmp)) > 0) {
 			typemap_ht = Z_ARRVAL_P(tmp);
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "features", sizeof("features")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "features", strlen("features"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_LONG) {
 			service->features = Z_LVAL_P(tmp);
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "cache_wsdl", sizeof("cache_wsdl")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "cache_wsdl", strlen("cache_wsdl"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_LONG) {
 			cache_wsdl = Z_LVAL_P(tmp);
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "send_errors", sizeof("send_errors")-1)) != NULL) {
+		if ((tmp = zend_hash_str_find(ht, "send_errors", strlen("send_errors"))) != NULL) {
 			if (Z_TYPE_P(tmp) == IS_FALSE) {
 				service->send_errors = 0;
 			} else if (Z_TYPE_P(tmp) == IS_TRUE) {
@@ -1203,7 +1203,7 @@ static void _soap_server_exception(soapServicePtr service, sdlFunctionPtr functi
 	} else if (instanceof_function(Z_OBJCE(exception_object), zend_ce_error)) {
 		if (service->send_errors) {
 			zval rv;
-			zend_string *msg = zval_get_string(zend_read_property(zend_ce_error, Z_OBJ(exception_object), "message", sizeof("message")-1, 0, &rv));
+			zend_string *msg = zval_get_string(zend_read_property(zend_ce_error, Z_OBJ(exception_object), "message", strlen("message"), 0, &rv));
 			add_soap_fault_ex(&exception_object, this_ptr, "Server", ZSTR_VAL(msg), NULL, NULL);
 			zend_string_release_ex(msg, 0);
 		} else {
@@ -1264,7 +1264,7 @@ PHP_METHOD(SoapServer, handle)
 */
 			zval readfile, readfile_ret, param;
 
-			sapi_add_header("Content-Type: text/xml; charset=utf-8", sizeof("Content-Type: text/xml; charset=utf-8")-1, 1);
+			sapi_add_header("Content-Type: text/xml; charset=utf-8", strlen("Content-Type: text/xml; charset=utf-8"), 1);
 			ZVAL_STRING(&param, service->sdl->source);
 			ZVAL_STRING(&readfile, "readfile");
 			if (call_user_function(EG(function_table), NULL, &readfile, &readfile_ret, 1, &param ) == FAILURE) {
@@ -1308,7 +1308,7 @@ PHP_METHOD(SoapServer, handle)
 			zend_is_auto_global(server);
 			if ((server_vars = zend_hash_find(&EG(symbol_table), server)) != NULL &&
 			    Z_TYPE_P(server_vars) == IS_ARRAY &&
-			    (encoding = zend_hash_str_find(Z_ARRVAL_P(server_vars), "HTTP_CONTENT_ENCODING", sizeof("HTTP_CONTENT_ENCODING")-1)) != NULL &&
+			    (encoding = zend_hash_str_find(Z_ARRVAL_P(server_vars), "HTTP_CONTENT_ENCODING", strlen("HTTP_CONTENT_ENCODING"))) != NULL &&
 			    Z_TYPE_P(encoding) == IS_STRING) {
 
 				if (zend_string_equals_literal(Z_STR_P(encoding), "gzip")
@@ -1318,7 +1318,7 @@ PHP_METHOD(SoapServer, handle)
 					zval filter_params;
 
 					array_init_size(&filter_params, 1);
-					add_assoc_long_ex(&filter_params, "window", sizeof("window")-1, 0x2f); /* ANY WBITS */
+					add_assoc_long_ex(&filter_params, "window", strlen("window"), 0x2f); /* ANY WBITS */
 
 					zf = php_stream_filter_create("zlib.inflate", &filter_params, 0);
 					zend_array_destroy(Z_ARR(filter_params));
@@ -1415,7 +1415,7 @@ PHP_METHOD(SoapServer, handle)
 			session_vars = &PS(http_session_vars);
 			ZVAL_DEREF(session_vars);
 			if (Z_TYPE_P(session_vars) == IS_ARRAY &&
-			    (tmp_soap_p = zend_hash_str_find(Z_ARRVAL_P(session_vars), "_bogus_session_name", sizeof("_bogus_session_name")-1)) != NULL &&
+			    (tmp_soap_p = zend_hash_str_find(Z_ARRVAL_P(session_vars), "_bogus_session_name", strlen("_bogus_session_name"))) != NULL &&
 			    Z_TYPE_P(tmp_soap_p) == IS_OBJECT &&
 			    Z_OBJCE_P(tmp_soap_p) == service->soap_class.ce) {
 				soap_obj = tmp_soap_p;
@@ -1446,7 +1446,7 @@ PHP_METHOD(SoapServer, handle)
 
 				ZVAL_DEREF(session_vars);
 				if (Z_TYPE_P(session_vars) == IS_ARRAY &&
-				    (tmp_soap_p = zend_hash_str_update(Z_ARRVAL_P(session_vars), "_bogus_session_name", sizeof("_bogus_session_name")-1, &tmp_soap)) != NULL) {
+				    (tmp_soap_p = zend_hash_str_update(Z_ARRVAL_P(session_vars), "_bogus_session_name", strlen("_bogus_session_name"), &tmp_soap)) != NULL) {
 					soap_obj = tmp_soap_p;
 				} else {
 					soap_obj = &tmp_soap;
@@ -1611,13 +1611,13 @@ PHP_METHOD(SoapServer, handle)
 		}
 
 		if (soap_version == SOAP_1_2) {
-			sapi_add_header("Content-Type: application/soap+xml; charset=utf-8", sizeof("Content-Type: application/soap+xml; charset=utf-8")-1, 1);
+			sapi_add_header("Content-Type: application/soap+xml; charset=utf-8", strlen("Content-Type: application/soap+xml; charset=utf-8"), 1);
 		} else {
-			sapi_add_header("Content-Type: text/xml; charset=utf-8", sizeof("Content-Type: text/xml; charset=utf-8")-1, 1);
+			sapi_add_header("Content-Type: text/xml; charset=utf-8", strlen("Content-Type: text/xml; charset=utf-8"), 1);
 		}
 
 		if (zend_ini_long("zlib.output_compression", sizeof("zlib.output_compression"), 0)) {
-			sapi_add_header("Connection: close", sizeof("Connection: close")-1, 1);
+			sapi_add_header("Connection: close", strlen("Connection: close"), 1);
 		} else {
 			snprintf(cont_len, sizeof(cont_len), "Content-Length: %d", size);
 			sapi_add_header(cont_len, strlen(cont_len), 1);
@@ -1625,8 +1625,8 @@ PHP_METHOD(SoapServer, handle)
 		php_write(buf, size);
 		xmlFree(buf);
 	} else {
-		sapi_add_header("HTTP/1.1 202 Accepted", sizeof("HTTP/1.1 202 Accepted")-1, 1);
-		sapi_add_header("Content-Length: 0", sizeof("Content-Length: 0")-1, 1);
+		sapi_add_header("HTTP/1.1 202 Accepted", strlen("HTTP/1.1 202 Accepted"), 1);
+		sapi_add_header("Content-Length: 0", strlen("Content-Length: 0"), 1);
 	}
 
 fail:
@@ -1751,7 +1751,7 @@ static void soap_server_fault_ex(sdlFunctionPtr function, zval* fault, soapHeade
 	xmlDocDumpMemory(doc_return, &buf, &size);
 
 	if ((Z_TYPE(PG(http_globals)[TRACK_VARS_SERVER]) == IS_ARRAY || zend_is_auto_global(ZSTR_KNOWN(ZEND_STR_AUTOGLOBAL_SERVER))) &&
-		(agent_name = zend_hash_str_find(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_USER_AGENT", sizeof("HTTP_USER_AGENT")-1)) != NULL &&
+		(agent_name = zend_hash_str_find(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_USER_AGENT", strlen("HTTP_USER_AGENT"))) != NULL &&
 		Z_TYPE_P(agent_name) == IS_STRING) {
 		if (zend_string_equals_literal(Z_STR_P(agent_name), "Shockwave Flash")) {
 			use_http_error_status = 0;
@@ -1762,18 +1762,18 @@ static void soap_server_fault_ex(sdlFunctionPtr function, zval* fault, soapHeade
 	   our fault code with their own handling... Figure this out later
 	*/
 	if (use_http_error_status) {
-		sapi_add_header("HTTP/1.1 500 Internal Server Error", sizeof("HTTP/1.1 500 Internal Server Error")-1, 1);
+		sapi_add_header("HTTP/1.1 500 Internal Server Error", strlen("HTTP/1.1 500 Internal Server Error"), 1);
 	}
 	if (zend_ini_long("zlib.output_compression", sizeof("zlib.output_compression"), 0)) {
-		sapi_add_header("Connection: close", sizeof("Connection: close")-1, 1);
+		sapi_add_header("Connection: close", strlen("Connection: close"), 1);
 	} else {
 		snprintf(cont_len, sizeof(cont_len), "Content-Length: %d", size);
 		sapi_add_header(cont_len, strlen(cont_len), 1);
 	}
 	if (soap_version == SOAP_1_2) {
-		sapi_add_header("Content-Type: application/soap+xml; charset=utf-8", sizeof("Content-Type: application/soap+xml; charset=utf-8")-1, 1);
+		sapi_add_header("Content-Type: application/soap+xml; charset=utf-8", strlen("Content-Type: application/soap+xml; charset=utf-8"), 1);
 	} else {
-		sapi_add_header("Content-Type: text/xml; charset=utf-8", sizeof("Content-Type: text/xml; charset=utf-8")-1, 1);
+		sapi_add_header("Content-Type: text/xml; charset=utf-8", strlen("Content-Type: text/xml; charset=utf-8"), 1);
 	}
 
 	php_write(buf, size);
@@ -1849,7 +1849,7 @@ static zend_never_inline ZEND_COLD void soap_real_error_handler(int error_num, z
 			    instanceof_function(Z_OBJCE_P(error_object), soap_server_class_entry) &&
 				(service = soap_server_object_fetch(Z_OBJ_P(error_object))->service) &&
 				!service->send_errors) {
-				buffer = zend_string_init("Internal Error", sizeof("Internal Error")-1, 0);
+				buffer = zend_string_init("Internal Error", strlen("Internal Error"), 0);
 			} else {
 				buffer = zend_string_copy(message);
 
@@ -1955,27 +1955,27 @@ PHP_METHOD(SoapClient, __construct)
 
 		if (!wsdl) {
 			/* Fetching non-WSDL mode options */
-			if ((tmp = zend_hash_str_find(ht, "uri", sizeof("uri")-1)) != NULL &&
+			if ((tmp = zend_hash_str_find(ht, "uri", strlen("uri"))) != NULL &&
 			    Z_TYPE_P(tmp) == IS_STRING) {
 				ZVAL_STR_COPY(Z_CLIENT_URI_P(this_ptr), Z_STR_P(tmp));
 			} else {
 				php_error_docref(NULL, E_ERROR, "'uri' option is required in nonWSDL mode");
 			}
 
-			if ((tmp = zend_hash_str_find(ht, "style", sizeof("style")-1)) != NULL &&
+			if ((tmp = zend_hash_str_find(ht, "style", strlen("style"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_LONG &&
 					(Z_LVAL_P(tmp) == SOAP_RPC || Z_LVAL_P(tmp) == SOAP_DOCUMENT)) {
 				ZVAL_LONG(Z_CLIENT_STYLE_P(this_ptr), Z_LVAL_P(tmp));
 			}
 
-			if ((tmp = zend_hash_str_find(ht, "use", sizeof("use")-1)) != NULL &&
+			if ((tmp = zend_hash_str_find(ht, "use", strlen("use"))) != NULL &&
 					Z_TYPE_P(tmp) == IS_LONG &&
 					(Z_LVAL_P(tmp) == SOAP_LITERAL || Z_LVAL_P(tmp) == SOAP_ENCODED)) {
 				ZVAL_LONG(Z_CLIENT_USE_P(this_ptr), Z_LVAL_P(tmp));
 			}
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "stream_context", sizeof("stream_context")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "stream_context", strlen("stream_context"))) != NULL &&
 				Z_TYPE_P(tmp) == IS_RESOURCE) {
 			context = php_stream_context_from_zval(tmp, 1);
 			Z_ADDREF_P(tmp);
@@ -1983,84 +1983,84 @@ PHP_METHOD(SoapClient, __construct)
 			context = php_stream_context_alloc();
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "location", sizeof("location")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "location", strlen("location"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			ZVAL_STR_COPY(Z_CLIENT_LOCATION_P(this_ptr), Z_STR_P(tmp));
 		} else if (!wsdl) {
 			php_error_docref(NULL, E_ERROR, "'location' option is required in nonWSDL mode");
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "soap_version", sizeof("soap_version")-1)) != NULL) {
+		if ((tmp = zend_hash_str_find(ht, "soap_version", strlen("soap_version"))) != NULL) {
 			if (Z_TYPE_P(tmp) == IS_LONG &&
 			    (Z_LVAL_P(tmp) == SOAP_1_1 || Z_LVAL_P(tmp) == SOAP_1_2)) {
 				soap_version = Z_LVAL_P(tmp);
 			}
 		}
-		if ((tmp = zend_hash_str_find(ht, "login", sizeof("login")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "login", strlen("login"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			ZVAL_STR_COPY(Z_CLIENT_LOGIN_P(this_ptr), Z_STR_P(tmp));
-			if ((tmp = zend_hash_str_find(ht, "password", sizeof("password")-1)) != NULL &&
+			if ((tmp = zend_hash_str_find(ht, "password", strlen("password"))) != NULL &&
 			    Z_TYPE_P(tmp) == IS_STRING) {
 				ZVAL_STR_COPY(Z_CLIENT_PASSWORD_P(this_ptr), Z_STR_P(tmp));
 			}
-			if ((tmp = zend_hash_str_find(ht, "authentication", sizeof("authentication")-1)) != NULL &&
+			if ((tmp = zend_hash_str_find(ht, "authentication", strlen("authentication"))) != NULL &&
 			    Z_TYPE_P(tmp) == IS_LONG &&
 			    Z_LVAL_P(tmp) == SOAP_AUTHENTICATION_DIGEST) {
 				ZVAL_TRUE(Z_CLIENT_USE_DIGEST_P(this_ptr));
 			}
 		}
-		if ((tmp = zend_hash_str_find(ht, "proxy_host", sizeof("proxy_host")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "proxy_host", strlen("proxy_host"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			ZVAL_STR_COPY(Z_CLIENT_PROXY_HOST_P(this_ptr), Z_STR_P(tmp));
-			if ((tmp = zend_hash_str_find(ht, "proxy_port", sizeof("proxy_port")-1)) != NULL) {
+			if ((tmp = zend_hash_str_find(ht, "proxy_port", strlen("proxy_port"))) != NULL) {
 				if (Z_TYPE_P(tmp) != IS_LONG) {
 					ZVAL_LONG(&tmp2, zval_get_long(tmp));
 					tmp = &tmp2;
 				}
 				ZVAL_LONG(Z_CLIENT_PROXY_PORT_P(this_ptr), Z_LVAL_P(tmp));
 			}
-			if ((tmp = zend_hash_str_find(ht, "proxy_login", sizeof("proxy_login")-1)) != NULL &&
+			if ((tmp = zend_hash_str_find(ht, "proxy_login", strlen("proxy_login"))) != NULL &&
 			    Z_TYPE_P(tmp) == IS_STRING) {
 				ZVAL_STR_COPY(Z_CLIENT_PROXY_LOGIN_P(this_ptr), Z_STR_P(tmp));
-				if ((tmp = zend_hash_str_find(ht, "proxy_password", sizeof("proxy_password")-1)) != NULL &&
+				if ((tmp = zend_hash_str_find(ht, "proxy_password", strlen("proxy_password"))) != NULL &&
 				    Z_TYPE_P(tmp) == IS_STRING) {
 					ZVAL_STR_COPY(Z_CLIENT_PROXY_PASSWORD_P(this_ptr), Z_STR_P(tmp));
 				}
 			}
 		}
-		if ((tmp = zend_hash_str_find(ht, "local_cert", sizeof("local_cert")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "local_cert", strlen("local_cert"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			if (!context) {
 				context = php_stream_context_alloc();
 			}
 			php_stream_context_set_option(context, "ssl", "local_cert", tmp);
-			if ((tmp = zend_hash_str_find(ht, "passphrase", sizeof("passphrase")-1)) != NULL &&
+			if ((tmp = zend_hash_str_find(ht, "passphrase", strlen("passphrase"))) != NULL &&
 			    Z_TYPE_P(tmp) == IS_STRING) {
 				php_stream_context_set_option(context, "ssl", "passphrase", tmp);
 			}
 		}
-		if ((tmp = zend_hash_str_find(ht, "trace", sizeof("trace")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "trace", strlen("trace"))) != NULL &&
 		    (Z_TYPE_P(tmp) == IS_TRUE ||
 		     (Z_TYPE_P(tmp) == IS_LONG && Z_LVAL_P(tmp) == 1))) {
 			ZVAL_TRUE(Z_CLIENT_TRACE_P(this_ptr));
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "exceptions", sizeof("exceptions")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "exceptions", strlen("exceptions"))) != NULL &&
 		    (Z_TYPE_P(tmp) == IS_FALSE ||
 		     (Z_TYPE_P(tmp) == IS_LONG && Z_LVAL_P(tmp) == 0))) {
 			ZVAL_FALSE(Z_CLIENT_EXCEPTIONS_P(this_ptr));
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "compression", sizeof("compression")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "compression", strlen("compression"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_LONG &&
-	      zend_hash_str_exists(EG(function_table), "gzinflate", sizeof("gzinflate")-1) &&
-	      zend_hash_str_exists(EG(function_table), "gzdeflate", sizeof("gzdeflate")-1) &&
-	      zend_hash_str_exists(EG(function_table), "gzuncompress", sizeof("gzuncompress")-1) &&
-	      zend_hash_str_exists(EG(function_table), "gzcompress", sizeof("gzcompress")-1) &&
-	      zend_hash_str_exists(EG(function_table), "gzencode", sizeof("gzencode")-1)) {
+	      zend_hash_str_exists(EG(function_table), "gzinflate", strlen("gzinflate")) &&
+	      zend_hash_str_exists(EG(function_table), "gzdeflate", strlen("gzdeflate")) &&
+	      zend_hash_str_exists(EG(function_table), "gzuncompress", strlen("gzuncompress")) &&
+	      zend_hash_str_exists(EG(function_table), "gzcompress", strlen("gzcompress")) &&
+	      zend_hash_str_exists(EG(function_table), "gzencode", strlen("gzencode"))) {
 			ZVAL_LONG(Z_CLIENT_COMPRESSION_P(this_ptr), Z_LVAL_P(tmp));
 		}
-		if ((tmp = zend_hash_str_find(ht, "encoding", sizeof("encoding")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "encoding", strlen("encoding"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			xmlCharEncodingHandlerPtr encoding;
 
@@ -2072,23 +2072,23 @@ PHP_METHOD(SoapClient, __construct)
 				ZVAL_STR_COPY(Z_CLIENT_ENCODING_P(this_ptr), Z_STR_P(tmp));
 			}
 		}
-		if ((tmp = zend_hash_str_find(ht, "classmap", sizeof("classmap")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "classmap", strlen("classmap"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY) {
 			ZVAL_COPY(Z_CLIENT_CLASSMAP_P(this_ptr), tmp);
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "typemap", sizeof("typemap")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "typemap", strlen("typemap"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_ARRAY &&
 			zend_hash_num_elements(Z_ARRVAL_P(tmp)) > 0) {
 			typemap_ht = Z_ARRVAL_P(tmp);
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "features", sizeof("features")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "features", strlen("features"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_LONG) {
 			ZVAL_LONG(Z_CLIENT_FEATURES_P(this_ptr), Z_LVAL_P(tmp));
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "connection_timeout", sizeof("connection_timeout")-1)) != NULL) {
+		if ((tmp = zend_hash_str_find(ht, "connection_timeout", strlen("connection_timeout"))) != NULL) {
 			zend_long lval = zval_get_long(tmp);
 			if (lval > 0) {
 				ZVAL_LONG(Z_CLIENT_CONNECTION_TIMEOUT_P(this_ptr), lval);
@@ -2099,23 +2099,23 @@ PHP_METHOD(SoapClient, __construct)
 			ZVAL_RES(Z_CLIENT_STREAM_CONTEXT_P(this_ptr), context->res);
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "cache_wsdl", sizeof("cache_wsdl")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "cache_wsdl", strlen("cache_wsdl"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_LONG) {
 			cache_wsdl = Z_LVAL_P(tmp);
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "user_agent", sizeof("user_agent")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "user_agent", strlen("user_agent"))) != NULL &&
 		    Z_TYPE_P(tmp) == IS_STRING) {
 			ZVAL_STR_COPY(Z_CLIENT_USER_AGENT_P(this_ptr), Z_STR_P(tmp));
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "keep_alive", sizeof("keep_alive")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "keep_alive", strlen("keep_alive"))) != NULL &&
 				(Z_TYPE_P(tmp) == IS_FALSE ||
 				 (Z_TYPE_P(tmp) == IS_LONG && Z_LVAL_P(tmp) == 0))) {
 			ZVAL_FALSE(Z_CLIENT_KEEP_ALIVE_P(this_ptr));
 		}
 
-		if ((tmp = zend_hash_str_find(ht, "ssl_method", sizeof("ssl_method")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(ht, "ssl_method", strlen("ssl_method"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_LONG) {
 			ZVAL_LONG(Z_CLIENT_SSL_METHOD_P(this_ptr), Z_LVAL_P(tmp));
 			php_error_docref(NULL, E_DEPRECATED,
@@ -2178,7 +2178,7 @@ static int do_request(zval *this_ptr, xmlDoc *request, char *location, char *act
 			ZVAL_STRINGL(Z_CLIENT_LAST_REQUEST_P(this_ptr), buf, buf_size);
 		}
 
-		ZVAL_STRINGL(&func,"__doRequest",sizeof("__doRequest")-1);
+		ZVAL_STRINGL(&func,"__doRequest",strlen("__doRequest"));
 		ZVAL_STRINGL(&params[0], buf, buf_size);
 		ZVAL_STRING(&params[1], location);
 		if (action == NULL) {
@@ -2482,17 +2482,17 @@ void soap_client_call_impl(INTERNAL_FUNCTION_PARAMETERS, bool is_soap_call)
 
 	if (options) {
 		HashTable *hto = Z_ARRVAL_P(options);
-		if ((tmp = zend_hash_str_find(hto, "location", sizeof("location")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(hto, "location", strlen("location"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_STRING) {
 			location = Z_STRVAL_P(tmp);
 		}
 
-		if ((tmp = zend_hash_str_find(hto, "soapaction", sizeof("soapaction")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(hto, "soapaction", strlen("soapaction"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_STRING) {
 			soap_action = Z_STRVAL_P(tmp);
 		}
 
-		if ((tmp = zend_hash_str_find(hto, "uri", sizeof("uri")-1)) != NULL &&
+		if ((tmp = zend_hash_str_find(hto, "uri", strlen("uri"))) != NULL &&
 			Z_TYPE_P(tmp) == IS_STRING) {
 			uri = Z_STRVAL_P(tmp);
 		}
@@ -2843,7 +2843,7 @@ static void set_soap_fault(zval *obj, char *fault_code_ns, char *fault_code, cha
 	}
 
 	ZVAL_STRING(Z_FAULT_STRING_P(obj), fault_string ? fault_string : "");
-	zend_update_property_string(zend_ce_exception, Z_OBJ_P(obj), "message", sizeof("message")-1, (fault_string ? fault_string : ""));
+	zend_update_property_string(zend_ce_exception, Z_OBJ_P(obj), "message", strlen("message"), (fault_string ? fault_string : ""));
 
 	if (fault_code != NULL) {
 		int soap_version = SOAP_GLOBAL(soap_version);
@@ -4238,7 +4238,7 @@ static void model_to_string(sdlContentModelPtr model, smart_str *buf, int level)
 			for (i = 0;i < level;i++) {
 				smart_str_appendc(buf, ' ');
 			}
-			smart_str_appendl(buf, "<anyXML> any;\n", sizeof("<anyXML> any;\n")-1);
+			smart_str_appendl(buf, "<anyXML> any;\n", strlen("<anyXML> any;\n"));
 			break;
 		case XSD_CONTENT_SEQUENCE:
 		case XSD_CONTENT_ALL:
@@ -4275,7 +4275,7 @@ static void type_to_string(sdlTypePtr type, smart_str *buf, int level) /* {{{ */
 				smart_str_appendl(buf, type->encode->details.type_str, strlen(type->encode->details.type_str));
 				smart_str_appendc(buf, ' ');
 			} else {
-				smart_str_appendl(buf, "anyType ", sizeof("anyType ")-1);
+				smart_str_appendl(buf, "anyType ", strlen("anyType "));
 			}
 			smart_str_appendl(buf, type->name, strlen(type->name));
 			break;
@@ -4332,7 +4332,7 @@ static void type_to_string(sdlTypePtr type, smart_str *buf, int level) /* {{{ */
 						len = end - ext->val;
 					}
 					if (len == 0) {
-						smart_str_appendl(buf, "anyType", sizeof("anyType")-1);
+						smart_str_appendl(buf, "anyType", strlen("anyType"));
 					} else {
 						smart_str_appendl(buf, ext->val, len);
 					}

--- a/ext/soap/soap_arginfo.h
+++ b/ext/soap/soap_arginfo.h
@@ -242,13 +242,13 @@ static zend_class_entry *register_class_SoapParam(void)
 
 	zval property_param_name_default_value;
 	ZVAL_UNDEF(&property_param_name_default_value);
-	zend_string *property_param_name_name = zend_string_init("param_name", sizeof("param_name") - 1, 1);
+	zend_string *property_param_name_name = zend_string_init("param_name", strlen("param_name"), 1);
 	zend_declare_typed_property(class_entry, property_param_name_name, &property_param_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_param_name_name);
 
 	zval property_param_data_default_value;
 	ZVAL_UNDEF(&property_param_data_default_value);
-	zend_string *property_param_data_name = zend_string_init("param_data", sizeof("param_data") - 1, 1);
+	zend_string *property_param_data_name = zend_string_init("param_data", strlen("param_data"), 1);
 	zend_declare_typed_property(class_entry, property_param_data_name, &property_param_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_param_data_name);
 
@@ -264,31 +264,31 @@ static zend_class_entry *register_class_SoapHeader(void)
 
 	zval property_namespace_default_value;
 	ZVAL_UNDEF(&property_namespace_default_value);
-	zend_string *property_namespace_name = zend_string_init("namespace", sizeof("namespace") - 1, 1);
+	zend_string *property_namespace_name = zend_string_init("namespace", strlen("namespace"), 1);
 	zend_declare_typed_property(class_entry, property_namespace_name, &property_namespace_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_namespace_name);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
 	zval property_data_default_value;
 	ZVAL_NULL(&property_data_default_value);
-	zend_string *property_data_name = zend_string_init("data", sizeof("data") - 1, 1);
+	zend_string *property_data_name = zend_string_init("data", strlen("data"), 1);
 	zend_declare_typed_property(class_entry, property_data_name, &property_data_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_data_name);
 
 	zval property_mustUnderstand_default_value;
 	ZVAL_UNDEF(&property_mustUnderstand_default_value);
-	zend_string *property_mustUnderstand_name = zend_string_init("mustUnderstand", sizeof("mustUnderstand") - 1, 1);
+	zend_string *property_mustUnderstand_name = zend_string_init("mustUnderstand", strlen("mustUnderstand"), 1);
 	zend_declare_typed_property(class_entry, property_mustUnderstand_name, &property_mustUnderstand_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_mustUnderstand_name);
 
 	zval property_actor_default_value;
 	ZVAL_UNDEF(&property_actor_default_value);
-	zend_string *property_actor_name = zend_string_init("actor", sizeof("actor") - 1, 1);
+	zend_string *property_actor_name = zend_string_init("actor", strlen("actor"), 1);
 	zend_declare_typed_property(class_entry, property_actor_name, &property_actor_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_actor_name);
 
@@ -304,43 +304,43 @@ static zend_class_entry *register_class_SoapFault(zend_class_entry *class_entry_
 
 	zval property_faultstring_default_value;
 	ZVAL_UNDEF(&property_faultstring_default_value);
-	zend_string *property_faultstring_name = zend_string_init("faultstring", sizeof("faultstring") - 1, 1);
+	zend_string *property_faultstring_name = zend_string_init("faultstring", strlen("faultstring"), 1);
 	zend_declare_typed_property(class_entry, property_faultstring_name, &property_faultstring_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_faultstring_name);
 
 	zval property_faultcode_default_value;
 	ZVAL_NULL(&property_faultcode_default_value);
-	zend_string *property_faultcode_name = zend_string_init("faultcode", sizeof("faultcode") - 1, 1);
+	zend_string *property_faultcode_name = zend_string_init("faultcode", strlen("faultcode"), 1);
 	zend_declare_typed_property(class_entry, property_faultcode_name, &property_faultcode_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_faultcode_name);
 
 	zval property_faultcodens_default_value;
 	ZVAL_NULL(&property_faultcodens_default_value);
-	zend_string *property_faultcodens_name = zend_string_init("faultcodens", sizeof("faultcodens") - 1, 1);
+	zend_string *property_faultcodens_name = zend_string_init("faultcodens", strlen("faultcodens"), 1);
 	zend_declare_typed_property(class_entry, property_faultcodens_name, &property_faultcodens_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_faultcodens_name);
 
 	zval property_faultactor_default_value;
 	ZVAL_NULL(&property_faultactor_default_value);
-	zend_string *property_faultactor_name = zend_string_init("faultactor", sizeof("faultactor") - 1, 1);
+	zend_string *property_faultactor_name = zend_string_init("faultactor", strlen("faultactor"), 1);
 	zend_declare_typed_property(class_entry, property_faultactor_name, &property_faultactor_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_faultactor_name);
 
 	zval property_detail_default_value;
 	ZVAL_NULL(&property_detail_default_value);
-	zend_string *property_detail_name = zend_string_init("detail", sizeof("detail") - 1, 1);
+	zend_string *property_detail_name = zend_string_init("detail", strlen("detail"), 1);
 	zend_declare_typed_property(class_entry, property_detail_name, &property_detail_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_detail_name);
 
 	zval property__name_default_value;
 	ZVAL_NULL(&property__name_default_value);
-	zend_string *property__name_name = zend_string_init("_name", sizeof("_name") - 1, 1);
+	zend_string *property__name_name = zend_string_init("_name", strlen("_name"), 1);
 	zend_declare_typed_property(class_entry, property__name_name, &property__name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__name_name);
 
 	zval property_headerfault_default_value;
 	ZVAL_NULL(&property_headerfault_default_value);
-	zend_string *property_headerfault_name = zend_string_init("headerfault", sizeof("headerfault") - 1, 1);
+	zend_string *property_headerfault_name = zend_string_init("headerfault", strlen("headerfault"), 1);
 	zend_declare_typed_property(class_entry, property_headerfault_name, &property_headerfault_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_headerfault_name);
 
@@ -356,37 +356,37 @@ static zend_class_entry *register_class_SoapVar(void)
 
 	zval property_enc_type_default_value;
 	ZVAL_UNDEF(&property_enc_type_default_value);
-	zend_string *property_enc_type_name = zend_string_init("enc_type", sizeof("enc_type") - 1, 1);
+	zend_string *property_enc_type_name = zend_string_init("enc_type", strlen("enc_type"), 1);
 	zend_declare_typed_property(class_entry, property_enc_type_name, &property_enc_type_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_enc_type_name);
 
 	zval property_enc_value_default_value;
 	ZVAL_NULL(&property_enc_value_default_value);
-	zend_string *property_enc_value_name = zend_string_init("enc_value", sizeof("enc_value") - 1, 1);
+	zend_string *property_enc_value_name = zend_string_init("enc_value", strlen("enc_value"), 1);
 	zend_declare_typed_property(class_entry, property_enc_value_name, &property_enc_value_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_enc_value_name);
 
 	zval property_enc_stype_default_value;
 	ZVAL_NULL(&property_enc_stype_default_value);
-	zend_string *property_enc_stype_name = zend_string_init("enc_stype", sizeof("enc_stype") - 1, 1);
+	zend_string *property_enc_stype_name = zend_string_init("enc_stype", strlen("enc_stype"), 1);
 	zend_declare_typed_property(class_entry, property_enc_stype_name, &property_enc_stype_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_enc_stype_name);
 
 	zval property_enc_ns_default_value;
 	ZVAL_NULL(&property_enc_ns_default_value);
-	zend_string *property_enc_ns_name = zend_string_init("enc_ns", sizeof("enc_ns") - 1, 1);
+	zend_string *property_enc_ns_name = zend_string_init("enc_ns", strlen("enc_ns"), 1);
 	zend_declare_typed_property(class_entry, property_enc_ns_name, &property_enc_ns_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_enc_ns_name);
 
 	zval property_enc_name_default_value;
 	ZVAL_NULL(&property_enc_name_default_value);
-	zend_string *property_enc_name_name = zend_string_init("enc_name", sizeof("enc_name") - 1, 1);
+	zend_string *property_enc_name_name = zend_string_init("enc_name", strlen("enc_name"), 1);
 	zend_declare_typed_property(class_entry, property_enc_name_name, &property_enc_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_enc_name_name);
 
 	zval property_enc_namens_default_value;
 	ZVAL_NULL(&property_enc_namens_default_value);
-	zend_string *property_enc_namens_name = zend_string_init("enc_namens", sizeof("enc_namens") - 1, 1);
+	zend_string *property_enc_namens_name = zend_string_init("enc_namens", strlen("enc_namens"), 1);
 	zend_declare_typed_property(class_entry, property_enc_namens_name, &property_enc_namens_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_enc_namens_name);
 
@@ -400,10 +400,10 @@ static zend_class_entry *register_class_SoapServer(void)
 	INIT_CLASS_ENTRY(ce, "SoapServer", class_SoapServer_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 
-	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", sizeof("SoapFault")-1, 1);
+	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", strlen("SoapFault"), 1);
 	zval property___soap_fault_default_value;
 	ZVAL_NULL(&property___soap_fault_default_value);
-	zend_string *property___soap_fault_name = zend_string_init("__soap_fault", sizeof("__soap_fault") - 1, 1);
+	zend_string *property___soap_fault_name = zend_string_init("__soap_fault", strlen("__soap_fault"), 1);
 	zend_declare_typed_property(class_entry, property___soap_fault_name, &property___soap_fault_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property___soap_fault_class_SoapFault, 0, MAY_BE_NULL));
 	zend_string_release(property___soap_fault_name);
 
@@ -419,218 +419,218 @@ static zend_class_entry *register_class_SoapClient(void)
 
 	zval property_uri_default_value;
 	ZVAL_NULL(&property_uri_default_value);
-	zend_string *property_uri_name = zend_string_init("uri", sizeof("uri") - 1, 1);
+	zend_string *property_uri_name = zend_string_init("uri", strlen("uri"), 1);
 	zend_declare_typed_property(class_entry, property_uri_name, &property_uri_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_uri_name);
 
 	zval property_style_default_value;
 	ZVAL_NULL(&property_style_default_value);
-	zend_string *property_style_name = zend_string_init("style", sizeof("style") - 1, 1);
+	zend_string *property_style_name = zend_string_init("style", strlen("style"), 1);
 	zend_declare_typed_property(class_entry, property_style_name, &property_style_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_style_name);
 
 	zval property_use_default_value;
 	ZVAL_NULL(&property_use_default_value);
-	zend_string *property_use_name = zend_string_init("use", sizeof("use") - 1, 1);
+	zend_string *property_use_name = zend_string_init("use", strlen("use"), 1);
 	zend_declare_typed_property(class_entry, property_use_name, &property_use_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_use_name);
 
 	zval property_location_default_value;
 	ZVAL_NULL(&property_location_default_value);
-	zend_string *property_location_name = zend_string_init("location", sizeof("location") - 1, 1);
+	zend_string *property_location_name = zend_string_init("location", strlen("location"), 1);
 	zend_declare_typed_property(class_entry, property_location_name, &property_location_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_location_name);
 
 	zval property_trace_default_value;
 	ZVAL_BOOL(&property_trace_default_value, 0);
-	zend_string *property_trace_name = zend_string_init("trace", sizeof("trace") - 1, 1);
+	zend_string *property_trace_name = zend_string_init("trace", strlen("trace"), 1);
 	zend_declare_typed_property(class_entry, property_trace_name, &property_trace_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_trace_name);
 
 	zval property_compression_default_value;
 	ZVAL_NULL(&property_compression_default_value);
-	zend_string *property_compression_name = zend_string_init("compression", sizeof("compression") - 1, 1);
+	zend_string *property_compression_name = zend_string_init("compression", strlen("compression"), 1);
 	zend_declare_typed_property(class_entry, property_compression_name, &property_compression_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property_compression_name);
 
 	zval property_sdl_default_value;
 	ZVAL_NULL(&property_sdl_default_value);
-	zend_string *property_sdl_name = zend_string_init("sdl", sizeof("sdl") - 1, 1);
+	zend_string *property_sdl_name = zend_string_init("sdl", strlen("sdl"), 1);
 	zend_declare_property_ex(class_entry, property_sdl_name, &property_sdl_default_value, ZEND_ACC_PRIVATE, NULL);
 	zend_string_release(property_sdl_name);
 
 	zval property_typemap_default_value;
 	ZVAL_NULL(&property_typemap_default_value);
-	zend_string *property_typemap_name = zend_string_init("typemap", sizeof("typemap") - 1, 1);
+	zend_string *property_typemap_name = zend_string_init("typemap", strlen("typemap"), 1);
 	zend_declare_property_ex(class_entry, property_typemap_name, &property_typemap_default_value, ZEND_ACC_PRIVATE, NULL);
 	zend_string_release(property_typemap_name);
 
 	zval property_httpsocket_default_value;
 	ZVAL_NULL(&property_httpsocket_default_value);
-	zend_string *property_httpsocket_name = zend_string_init("httpsocket", sizeof("httpsocket") - 1, 1);
+	zend_string *property_httpsocket_name = zend_string_init("httpsocket", strlen("httpsocket"), 1);
 	zend_declare_property_ex(class_entry, property_httpsocket_name, &property_httpsocket_default_value, ZEND_ACC_PRIVATE, NULL);
 	zend_string_release(property_httpsocket_name);
 
 	zval property_httpurl_default_value;
 	ZVAL_NULL(&property_httpurl_default_value);
-	zend_string *property_httpurl_name = zend_string_init("httpurl", sizeof("httpurl") - 1, 1);
+	zend_string *property_httpurl_name = zend_string_init("httpurl", strlen("httpurl"), 1);
 	zend_declare_property_ex(class_entry, property_httpurl_name, &property_httpurl_default_value, ZEND_ACC_PRIVATE, NULL);
 	zend_string_release(property_httpurl_name);
 
 	zval property__login_default_value;
 	ZVAL_NULL(&property__login_default_value);
-	zend_string *property__login_name = zend_string_init("_login", sizeof("_login") - 1, 1);
+	zend_string *property__login_name = zend_string_init("_login", strlen("_login"), 1);
 	zend_declare_typed_property(class_entry, property__login_name, &property__login_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__login_name);
 
 	zval property__password_default_value;
 	ZVAL_NULL(&property__password_default_value);
-	zend_string *property__password_name = zend_string_init("_password", sizeof("_password") - 1, 1);
+	zend_string *property__password_name = zend_string_init("_password", strlen("_password"), 1);
 	zend_declare_typed_property(class_entry, property__password_name, &property__password_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__password_name);
 
 	zval property__use_digest_default_value;
 	ZVAL_BOOL(&property__use_digest_default_value, 0);
-	zend_string *property__use_digest_name = zend_string_init("_use_digest", sizeof("_use_digest") - 1, 1);
+	zend_string *property__use_digest_name = zend_string_init("_use_digest", strlen("_use_digest"), 1);
 	zend_declare_typed_property(class_entry, property__use_digest_name, &property__use_digest_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property__use_digest_name);
 
 	zval property__digest_default_value;
 	ZVAL_NULL(&property__digest_default_value);
-	zend_string *property__digest_name = zend_string_init("_digest", sizeof("_digest") - 1, 1);
+	zend_string *property__digest_name = zend_string_init("_digest", strlen("_digest"), 1);
 	zend_declare_typed_property(class_entry, property__digest_name, &property__digest_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__digest_name);
 
 	zval property__proxy_host_default_value;
 	ZVAL_NULL(&property__proxy_host_default_value);
-	zend_string *property__proxy_host_name = zend_string_init("_proxy_host", sizeof("_proxy_host") - 1, 1);
+	zend_string *property__proxy_host_name = zend_string_init("_proxy_host", strlen("_proxy_host"), 1);
 	zend_declare_typed_property(class_entry, property__proxy_host_name, &property__proxy_host_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__proxy_host_name);
 
 	zval property__proxy_port_default_value;
 	ZVAL_NULL(&property__proxy_port_default_value);
-	zend_string *property__proxy_port_name = zend_string_init("_proxy_port", sizeof("_proxy_port") - 1, 1);
+	zend_string *property__proxy_port_name = zend_string_init("_proxy_port", strlen("_proxy_port"), 1);
 	zend_declare_typed_property(class_entry, property__proxy_port_name, &property__proxy_port_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property__proxy_port_name);
 
 	zval property__proxy_login_default_value;
 	ZVAL_NULL(&property__proxy_login_default_value);
-	zend_string *property__proxy_login_name = zend_string_init("_proxy_login", sizeof("_proxy_login") - 1, 1);
+	zend_string *property__proxy_login_name = zend_string_init("_proxy_login", strlen("_proxy_login"), 1);
 	zend_declare_typed_property(class_entry, property__proxy_login_name, &property__proxy_login_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__proxy_login_name);
 
 	zval property__proxy_password_default_value;
 	ZVAL_NULL(&property__proxy_password_default_value);
-	zend_string *property__proxy_password_name = zend_string_init("_proxy_password", sizeof("_proxy_password") - 1, 1);
+	zend_string *property__proxy_password_name = zend_string_init("_proxy_password", strlen("_proxy_password"), 1);
 	zend_declare_typed_property(class_entry, property__proxy_password_name, &property__proxy_password_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__proxy_password_name);
 
 	zval property__exceptions_default_value;
 	ZVAL_BOOL(&property__exceptions_default_value, 1);
-	zend_string *property__exceptions_name = zend_string_init("_exceptions", sizeof("_exceptions") - 1, 1);
+	zend_string *property__exceptions_name = zend_string_init("_exceptions", strlen("_exceptions"), 1);
 	zend_declare_typed_property(class_entry, property__exceptions_name, &property__exceptions_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property__exceptions_name);
 
 	zval property__encoding_default_value;
 	ZVAL_NULL(&property__encoding_default_value);
-	zend_string *property__encoding_name = zend_string_init("_encoding", sizeof("_encoding") - 1, 1);
+	zend_string *property__encoding_name = zend_string_init("_encoding", strlen("_encoding"), 1);
 	zend_declare_typed_property(class_entry, property__encoding_name, &property__encoding_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__encoding_name);
 
 	zval property__classmap_default_value;
 	ZVAL_NULL(&property__classmap_default_value);
-	zend_string *property__classmap_name = zend_string_init("_classmap", sizeof("_classmap") - 1, 1);
+	zend_string *property__classmap_name = zend_string_init("_classmap", strlen("_classmap"), 1);
 	zend_declare_typed_property(class_entry, property__classmap_name, &property__classmap_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property__classmap_name);
 
 	zval property__features_default_value;
 	ZVAL_NULL(&property__features_default_value);
-	zend_string *property__features_name = zend_string_init("_features", sizeof("_features") - 1, 1);
+	zend_string *property__features_name = zend_string_init("_features", strlen("_features"), 1);
 	zend_declare_typed_property(class_entry, property__features_name, &property__features_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property__features_name);
 
 	zval property__connection_timeout_default_value;
 	ZVAL_LONG(&property__connection_timeout_default_value, 0);
-	zend_string *property__connection_timeout_name = zend_string_init("_connection_timeout", sizeof("_connection_timeout") - 1, 1);
+	zend_string *property__connection_timeout_name = zend_string_init("_connection_timeout", strlen("_connection_timeout"), 1);
 	zend_declare_typed_property(class_entry, property__connection_timeout_name, &property__connection_timeout_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property__connection_timeout_name);
 
 	zval property__stream_context_default_value;
 	ZVAL_NULL(&property__stream_context_default_value);
-	zend_string *property__stream_context_name = zend_string_init("_stream_context", sizeof("_stream_context") - 1, 1);
+	zend_string *property__stream_context_name = zend_string_init("_stream_context", strlen("_stream_context"), 1);
 	zend_declare_property_ex(class_entry, property__stream_context_name, &property__stream_context_default_value, ZEND_ACC_PRIVATE, NULL);
 	zend_string_release(property__stream_context_name);
 
 	zval property__user_agent_default_value;
 	ZVAL_NULL(&property__user_agent_default_value);
-	zend_string *property__user_agent_name = zend_string_init("_user_agent", sizeof("_user_agent") - 1, 1);
+	zend_string *property__user_agent_name = zend_string_init("_user_agent", strlen("_user_agent"), 1);
 	zend_declare_typed_property(class_entry, property__user_agent_name, &property__user_agent_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property__user_agent_name);
 
 	zval property__keep_alive_default_value;
 	ZVAL_BOOL(&property__keep_alive_default_value, 1);
-	zend_string *property__keep_alive_name = zend_string_init("_keep_alive", sizeof("_keep_alive") - 1, 1);
+	zend_string *property__keep_alive_name = zend_string_init("_keep_alive", strlen("_keep_alive"), 1);
 	zend_declare_typed_property(class_entry, property__keep_alive_name, &property__keep_alive_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property__keep_alive_name);
 
 	zval property__ssl_method_default_value;
 	ZVAL_NULL(&property__ssl_method_default_value);
-	zend_string *property__ssl_method_name = zend_string_init("_ssl_method", sizeof("_ssl_method") - 1, 1);
+	zend_string *property__ssl_method_name = zend_string_init("_ssl_method", strlen("_ssl_method"), 1);
 	zend_declare_typed_property(class_entry, property__ssl_method_name, &property__ssl_method_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property__ssl_method_name);
 
 	zval property__soap_version_default_value;
 	ZVAL_UNDEF(&property__soap_version_default_value);
-	zend_string *property__soap_version_name = zend_string_init("_soap_version", sizeof("_soap_version") - 1, 1);
+	zend_string *property__soap_version_name = zend_string_init("_soap_version", strlen("_soap_version"), 1);
 	zend_declare_typed_property(class_entry, property__soap_version_name, &property__soap_version_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property__soap_version_name);
 
 	zval property__use_proxy_default_value;
 	ZVAL_NULL(&property__use_proxy_default_value);
-	zend_string *property__use_proxy_name = zend_string_init("_use_proxy", sizeof("_use_proxy") - 1, 1);
+	zend_string *property__use_proxy_name = zend_string_init("_use_proxy", strlen("_use_proxy"), 1);
 	zend_declare_typed_property(class_entry, property__use_proxy_name, &property__use_proxy_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_NULL));
 	zend_string_release(property__use_proxy_name);
 
 	zval property__cookies_default_value;
 	ZVAL_EMPTY_ARRAY(&property__cookies_default_value);
-	zend_string *property__cookies_name = zend_string_init("_cookies", sizeof("_cookies") - 1, 1);
+	zend_string *property__cookies_name = zend_string_init("_cookies", strlen("_cookies"), 1);
 	zend_declare_typed_property(class_entry, property__cookies_name, &property__cookies_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
 	zend_string_release(property__cookies_name);
 
 	zval property___default_headers_default_value;
 	ZVAL_NULL(&property___default_headers_default_value);
-	zend_string *property___default_headers_name = zend_string_init("__default_headers", sizeof("__default_headers") - 1, 1);
+	zend_string *property___default_headers_name = zend_string_init("__default_headers", strlen("__default_headers"), 1);
 	zend_declare_typed_property(class_entry, property___default_headers_name, &property___default_headers_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY|MAY_BE_NULL));
 	zend_string_release(property___default_headers_name);
 
-	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", sizeof("SoapFault")-1, 1);
+	zend_string *property___soap_fault_class_SoapFault = zend_string_init("SoapFault", strlen("SoapFault"), 1);
 	zval property___soap_fault_default_value;
 	ZVAL_NULL(&property___soap_fault_default_value);
-	zend_string *property___soap_fault_name = zend_string_init("__soap_fault", sizeof("__soap_fault") - 1, 1);
+	zend_string *property___soap_fault_name = zend_string_init("__soap_fault", strlen("__soap_fault"), 1);
 	zend_declare_typed_property(class_entry, property___soap_fault_name, &property___soap_fault_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property___soap_fault_class_SoapFault, 0, MAY_BE_NULL));
 	zend_string_release(property___soap_fault_name);
 
 	zval property___last_request_default_value;
 	ZVAL_NULL(&property___last_request_default_value);
-	zend_string *property___last_request_name = zend_string_init("__last_request", sizeof("__last_request") - 1, 1);
+	zend_string *property___last_request_name = zend_string_init("__last_request", strlen("__last_request"), 1);
 	zend_declare_typed_property(class_entry, property___last_request_name, &property___last_request_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property___last_request_name);
 
 	zval property___last_response_default_value;
 	ZVAL_NULL(&property___last_response_default_value);
-	zend_string *property___last_response_name = zend_string_init("__last_response", sizeof("__last_response") - 1, 1);
+	zend_string *property___last_response_name = zend_string_init("__last_response", strlen("__last_response"), 1);
 	zend_declare_typed_property(class_entry, property___last_response_name, &property___last_response_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property___last_response_name);
 
 	zval property___last_request_headers_default_value;
 	ZVAL_NULL(&property___last_request_headers_default_value);
-	zend_string *property___last_request_headers_name = zend_string_init("__last_request_headers", sizeof("__last_request_headers") - 1, 1);
+	zend_string *property___last_request_headers_name = zend_string_init("__last_request_headers", strlen("__last_request_headers"), 1);
 	zend_declare_typed_property(class_entry, property___last_request_headers_name, &property___last_request_headers_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property___last_request_headers_name);
 
 	zval property___last_response_headers_default_value;
 	ZVAL_NULL(&property___last_response_headers_default_value);
-	zend_string *property___last_response_headers_name = zend_string_init("__last_response_headers", sizeof("__last_response_headers") - 1, 1);
+	zend_string *property___last_response_headers_name = zend_string_init("__last_response_headers", strlen("__last_response_headers"), 1);
 	zend_declare_typed_property(class_entry, property___last_response_headers_name, &property___last_response_headers_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property___last_response_headers_name);
 

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -714,7 +714,7 @@ static void from_zval_write_sockaddr_aux(const zval *container,
 
 	fill_sockaddr = param_get_bool(ctx, KEY_FILL_SOCKADDR, 1);
 
-	if ((elem = zend_hash_str_find(Z_ARRVAL_P(container), "family", sizeof("family") - 1)) != NULL
+	if ((elem = zend_hash_str_find(Z_ARRVAL_P(container), "family", strlen("family"))) != NULL
 			&& Z_TYPE_P(elem) != IS_NULL) {
 		const char *node = "family";
 		zend_llist_add_element(&ctx->keys, &node);
@@ -879,7 +879,7 @@ static void from_zval_write_control(const zval			*arr,
 	if (entry->calc_space) {
 		zval *data_elem;
 		/* arr must be an array at this point */
-		if ((data_elem = zend_hash_str_find(Z_ARRVAL_P(arr), "data", sizeof("data") - 1)) == NULL) {
+		if ((data_elem = zend_hash_str_find(Z_ARRVAL_P(arr), "data", strlen("data"))) == NULL) {
 			do_from_zval_err(ctx, "cmsghdr should have a 'data' element here");
 			return;
 		}

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -110,12 +110,12 @@ ZEND_GET_MODULE(sodium)
 /* Remove argument information from backtrace to prevent information leaks */
 static void sodium_remove_param_values_from_backtrace(zend_object *obj) {
 	zval rv;
-	zval *trace = zend_read_property(zend_get_exception_base(obj), obj, "trace", sizeof("trace")-1, 0, &rv);
+	zval *trace = zend_read_property(zend_get_exception_base(obj), obj, "trace", strlen("trace"), 0, &rv);
 	if (trace && Z_TYPE_P(trace) == IS_ARRAY) {
 		zval *frame;
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(trace), frame) {
 			if (Z_TYPE_P(frame) == IS_ARRAY) {
-				zval *args = zend_hash_str_find(Z_ARRVAL_P(frame), "args", sizeof("args")-1);
+				zval *args = zend_hash_str_find(Z_ARRVAL_P(frame), "args", strlen("args"));
 				if (args) {
 					zval_ptr_dtor(args);
 					ZVAL_EMPTY_ARRAY(args);

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -541,7 +541,7 @@ PHP_FUNCTION(spl_autoload_register)
 	} else {
 		alfi = emalloc(sizeof(autoload_func_info));
 		alfi->func_ptr = zend_hash_str_find_ptr(
-			CG(function_table), "spl_autoload", sizeof("spl_autoload") - 1);
+			CG(function_table), "spl_autoload", strlen("spl_autoload"));
 		alfi->obj = NULL;
 		alfi->ce = NULL;
 		alfi->closure = NULL;

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -203,23 +203,23 @@ static zend_object *spl_array_object_new_ex(zend_class_entry *class_type, zend_o
 	ZEND_ASSERT(parent);
 
 	if (inherited) {
-		intern->fptr_offset_get = zend_hash_str_find_ptr(&class_type->function_table, "offsetget", sizeof("offsetget") - 1);
+		intern->fptr_offset_get = zend_hash_str_find_ptr(&class_type->function_table, "offsetget", strlen("offsetget"));
 		if (intern->fptr_offset_get->common.scope == parent) {
 			intern->fptr_offset_get = NULL;
 		}
-		intern->fptr_offset_set = zend_hash_str_find_ptr(&class_type->function_table, "offsetset", sizeof("offsetset") - 1);
+		intern->fptr_offset_set = zend_hash_str_find_ptr(&class_type->function_table, "offsetset", strlen("offsetset"));
 		if (intern->fptr_offset_set->common.scope == parent) {
 			intern->fptr_offset_set = NULL;
 		}
-		intern->fptr_offset_has = zend_hash_str_find_ptr(&class_type->function_table, "offsetexists", sizeof("offsetexists") - 1);
+		intern->fptr_offset_has = zend_hash_str_find_ptr(&class_type->function_table, "offsetexists", strlen("offsetexists"));
 		if (intern->fptr_offset_has->common.scope == parent) {
 			intern->fptr_offset_has = NULL;
 		}
-		intern->fptr_offset_del = zend_hash_str_find_ptr(&class_type->function_table, "offsetunset",  sizeof("offsetunset") - 1);
+		intern->fptr_offset_del = zend_hash_str_find_ptr(&class_type->function_table, "offsetunset",  strlen("offsetunset"));
 		if (intern->fptr_offset_del->common.scope == parent) {
 			intern->fptr_offset_del = NULL;
 		}
-		intern->fptr_count = zend_hash_str_find_ptr(&class_type->function_table, "count", sizeof("count") - 1);
+		intern->fptr_count = zend_hash_str_find_ptr(&class_type->function_table, "count", strlen("count"));
 		if (intern->fptr_count->common.scope == parent) {
 			intern->fptr_count = NULL;
 		}
@@ -762,7 +762,7 @@ static inline HashTable* spl_array_get_debug_info(zend_object *obj) /* {{{ */
 
 		base = obj->handlers == &spl_handler_ArrayIterator
 			? spl_ce_ArrayIterator : spl_ce_ArrayObject;
-		zname = spl_gen_private_prop_name(base, "storage", sizeof("storage")-1);
+		zname = spl_gen_private_prop_name(base, "storage", strlen("storage"));
 		zend_symtable_update(debug_info, zname, storage);
 		zend_string_release_ex(zname, 0);
 

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -359,7 +359,7 @@ static zend_result spl_filesystem_file_open(spl_filesystem_object *intern, bool 
 	intern->u.file.enclosure = '"';
 	intern->u.file.escape = (unsigned char) '\\';
 
-	intern->u.file.func_getCurr = zend_hash_str_find_ptr(&intern->std.ce->function_table, "getcurrentline", sizeof("getcurrentline") - 1);
+	intern->u.file.func_getCurr = zend_hash_str_find_ptr(&intern->std.ce->function_table, "getcurrentline", strlen("getcurrentline"));
 
 	return SUCCESS;
 } /* }}} */
@@ -622,7 +622,7 @@ static inline HashTable *spl_filesystem_object_get_debug_info(zend_object *objec
 
 	rv = zend_array_dup(intern->std.properties);
 
-	pnstr = spl_gen_private_prop_name(spl_ce_SplFileInfo, "pathName", sizeof("pathName")-1);
+	pnstr = spl_gen_private_prop_name(spl_ce_SplFileInfo, "pathName", strlen("pathName"));
 	path = spl_filesystem_object_get_pathname(intern);
 	if (path) {
 		ZVAL_STR_COPY(&tmp, path);
@@ -635,7 +635,7 @@ static inline HashTable *spl_filesystem_object_get_debug_info(zend_object *objec
 	if (intern->file_name) {
 		size_t path_len;
 
-		pnstr = spl_gen_private_prop_name(spl_ce_SplFileInfo, "fileName", sizeof("fileName")-1);
+		pnstr = spl_gen_private_prop_name(spl_ce_SplFileInfo, "fileName", strlen("fileName"));
 		spl_filesystem_object_get_path(intern, &path_len);
 
 		if (path_len && path_len < ZSTR_LEN(intern->file_name)) {
@@ -648,7 +648,7 @@ static inline HashTable *spl_filesystem_object_get_debug_info(zend_object *objec
 	}
 	if (intern->type == SPL_FS_DIR) {
 #ifdef HAVE_GLOB
-		pnstr = spl_gen_private_prop_name(spl_ce_DirectoryIterator, "glob", sizeof("glob")-1);
+		pnstr = spl_gen_private_prop_name(spl_ce_DirectoryIterator, "glob", strlen("glob"));
 		if (php_stream_is(intern->u.dir.dirp ,&php_glob_stream_ops)) {
 			ZVAL_STR_COPY(&tmp, intern->path);
 		} else {
@@ -657,7 +657,7 @@ static inline HashTable *spl_filesystem_object_get_debug_info(zend_object *objec
 		zend_symtable_update(rv, pnstr, &tmp);
 		zend_string_release_ex(pnstr, 0);
 #endif
-		pnstr = spl_gen_private_prop_name(spl_ce_RecursiveDirectoryIterator, "subPathName", sizeof("subPathName")-1);
+		pnstr = spl_gen_private_prop_name(spl_ce_RecursiveDirectoryIterator, "subPathName", strlen("subPathName"));
 		if (intern->u.dir.sub_path) {
 			ZVAL_STR_COPY(&tmp, intern->u.dir.sub_path);
 		} else {
@@ -667,18 +667,18 @@ static inline HashTable *spl_filesystem_object_get_debug_info(zend_object *objec
 		zend_string_release_ex(pnstr, 0);
 	}
 	if (intern->type == SPL_FS_FILE) {
-		pnstr = spl_gen_private_prop_name(spl_ce_SplFileObject, "openMode", sizeof("openMode")-1);
+		pnstr = spl_gen_private_prop_name(spl_ce_SplFileObject, "openMode", strlen("openMode"));
 		ZVAL_STR_COPY(&tmp, intern->u.file.open_mode);
 		zend_symtable_update(rv, pnstr, &tmp);
 		zend_string_release_ex(pnstr, 0);
 		stmp[1] = '\0';
 		stmp[0] = intern->u.file.delimiter;
-		pnstr = spl_gen_private_prop_name(spl_ce_SplFileObject, "delimiter", sizeof("delimiter")-1);
+		pnstr = spl_gen_private_prop_name(spl_ce_SplFileObject, "delimiter", strlen("delimiter"));
 		ZVAL_STRINGL(&tmp, stmp, 1);
 		zend_symtable_update(rv, pnstr, &tmp);
 		zend_string_release_ex(pnstr, 0);
 		stmp[0] = intern->u.file.enclosure;
-		pnstr = spl_gen_private_prop_name(spl_ce_SplFileObject, "enclosure", sizeof("enclosure")-1);
+		pnstr = spl_gen_private_prop_name(spl_ce_SplFileObject, "enclosure", strlen("enclosure"));
 		ZVAL_STRINGL(&tmp, stmp, 1);
 		zend_symtable_update(rv, pnstr, &tmp);
 		zend_string_release_ex(pnstr, 0);
@@ -694,7 +694,7 @@ zend_function *spl_filesystem_object_get_method_check(zend_object **object, zend
 
 	if (fsobj->u.dir.dirp == NULL && fsobj->orig_path == NULL) {
 		zend_function *func;
-		zend_string *tmp = zend_string_init("_bad_state_ex", sizeof("_bad_state_ex") - 1, 0);
+		zend_string *tmp = zend_string_init("_bad_state_ex", strlen("_bad_state_ex"), 0);
 		func = zend_std_get_method(object, tmp, NULL);
 		zend_string_release_ex(tmp, 0);
 		return func;
@@ -2110,14 +2110,14 @@ PHP_METHOD(SplTempFileObject, __construct)
 	}
 
 	if (max_memory < 0) {
-		file_name = zend_string_init("php://memory", sizeof("php://memory")-1, 0);
+		file_name = zend_string_init("php://memory", strlen("php://memory"), 0);
 	} else if (ZEND_NUM_ARGS()) {
 		file_name = zend_strpprintf(0, "php://temp/maxmemory:" ZEND_LONG_FMT, max_memory);
 	} else {
-		file_name = zend_string_init("php://temp", sizeof("php://temp")-1, 0);
+		file_name = zend_string_init("php://temp", strlen("php://temp"), 0);
 	}
 	intern->file_name = file_name;
-	intern->u.file.open_mode = zend_string_init("wb", sizeof("wb")-1, 0);
+	intern->u.file.open_mode = zend_string_init("wb", strlen("wb"), 0);
 
 	/* spl_filesystem_file_open() can generate E_WARNINGs which we want to promote to exceptions */
 	zend_replace_error_handling(EH_THROW, spl_ce_RuntimeException, &error_handling);

--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -367,23 +367,23 @@ static zend_object *spl_dllist_object_new_ex(zend_class_entry *class_type, zend_
 	ZEND_ASSERT(parent);
 
 	if (inherited) {
-		intern->fptr_offset_get = zend_hash_str_find_ptr(&class_type->function_table, "offsetget", sizeof("offsetget") - 1);
+		intern->fptr_offset_get = zend_hash_str_find_ptr(&class_type->function_table, "offsetget", strlen("offsetget"));
 		if (intern->fptr_offset_get->common.scope == parent) {
 			intern->fptr_offset_get = NULL;
 		}
-		intern->fptr_offset_set = zend_hash_str_find_ptr(&class_type->function_table, "offsetset", sizeof("offsetset") - 1);
+		intern->fptr_offset_set = zend_hash_str_find_ptr(&class_type->function_table, "offsetset", strlen("offsetset"));
 		if (intern->fptr_offset_set->common.scope == parent) {
 			intern->fptr_offset_set = NULL;
 		}
-		intern->fptr_offset_has = zend_hash_str_find_ptr(&class_type->function_table, "offsetexists", sizeof("offsetexists") - 1);
+		intern->fptr_offset_has = zend_hash_str_find_ptr(&class_type->function_table, "offsetexists", strlen("offsetexists"));
 		if (intern->fptr_offset_has->common.scope == parent) {
 			intern->fptr_offset_has = NULL;
 		}
-		intern->fptr_offset_del = zend_hash_str_find_ptr(&class_type->function_table, "offsetunset", sizeof("offsetunset") - 1);
+		intern->fptr_offset_del = zend_hash_str_find_ptr(&class_type->function_table, "offsetunset", strlen("offsetunset"));
 		if (intern->fptr_offset_del->common.scope == parent) {
 			intern->fptr_offset_del = NULL;
 		}
-		intern->fptr_count = zend_hash_str_find_ptr(&class_type->function_table, "count", sizeof("count") - 1);
+		intern->fptr_count = zend_hash_str_find_ptr(&class_type->function_table, "count", strlen("count"));
 		if (intern->fptr_count->common.scope == parent) {
 			intern->fptr_count = NULL;
 		}
@@ -446,7 +446,7 @@ static inline HashTable* spl_dllist_object_get_debug_info(zend_object *obj) /* {
 	debug_info = zend_new_array(1);
 	zend_hash_copy(debug_info, intern->std.properties, (copy_ctor_func_t) zval_add_ref);
 
-	pnstr = spl_gen_private_prop_name(spl_ce_SplDoublyLinkedList, "flags", sizeof("flags")-1);
+	pnstr = spl_gen_private_prop_name(spl_ce_SplDoublyLinkedList, "flags", strlen("flags"));
 	ZVAL_LONG(&tmp, intern->flags);
 	zend_hash_add(debug_info, pnstr, &tmp);
 	zend_string_release_ex(pnstr, 0);
@@ -465,7 +465,7 @@ static inline HashTable* spl_dllist_object_get_debug_info(zend_object *obj) /* {
 		current = next;
 	}
 
-	pnstr = spl_gen_private_prop_name(spl_ce_SplDoublyLinkedList, "dllist", sizeof("dllist")-1);
+	pnstr = spl_gen_private_prop_name(spl_ce_SplDoublyLinkedList, "dllist", strlen("dllist"));
 	zend_hash_add(debug_info, pnstr, &dllist_array);
 	zend_string_release_ex(pnstr, 0);
 

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -288,7 +288,7 @@ static zend_object *spl_fixedarray_object_new_ex(zend_class_entry *class_type, z
 	ZEND_ASSERT(parent);
 
 	if (UNEXPECTED(inherited)) {
-		zend_function *fptr_count = zend_hash_str_find_ptr(&class_type->function_table, "count", sizeof("count") - 1);
+		zend_function *fptr_count = zend_hash_str_find_ptr(&class_type->function_table, "count", strlen("count"));
 		if (fptr_count->common.scope == parent) {
 			fptr_count = NULL;
 		}

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -147,9 +147,9 @@ static void spl_pqueue_extract_helper(zval *result, spl_pqueue_elem *elem, int f
 	if ((flags & SPL_PQUEUE_EXTR_BOTH) == SPL_PQUEUE_EXTR_BOTH) {
 		array_init(result);
 		Z_TRY_ADDREF(elem->data);
-		add_assoc_zval_ex(result, "data", sizeof("data") - 1, &elem->data);
+		add_assoc_zval_ex(result, "data", strlen("data"), &elem->data);
 		Z_TRY_ADDREF(elem->priority);
-		add_assoc_zval_ex(result, "priority", sizeof("priority") - 1, &elem->priority);
+		add_assoc_zval_ex(result, "priority", strlen("priority"), &elem->priority);
 		return;
 	}
 
@@ -454,11 +454,11 @@ static zend_object *spl_heap_object_new_ex(zend_class_entry *class_type, zend_ob
 	ZEND_ASSERT(parent);
 
 	if (inherited) {
-		intern->fptr_cmp = zend_hash_str_find_ptr(&class_type->function_table, "compare", sizeof("compare") - 1);
+		intern->fptr_cmp = zend_hash_str_find_ptr(&class_type->function_table, "compare", strlen("compare"));
 		if (intern->fptr_cmp->common.scope == parent) {
 			intern->fptr_cmp = NULL;
 		}
-		intern->fptr_count = zend_hash_str_find_ptr(&class_type->function_table, "count", sizeof("count") - 1);
+		intern->fptr_count = zend_hash_str_find_ptr(&class_type->function_table, "count", strlen("count"));
 		if (intern->fptr_count->common.scope == parent) {
 			intern->fptr_count = NULL;
 		}
@@ -520,12 +520,12 @@ static inline HashTable* spl_heap_object_get_debug_info(zend_class_entry *ce, ze
 	debug_info = zend_new_array(zend_hash_num_elements(intern->std.properties) + 1);
 	zend_hash_copy(debug_info, intern->std.properties, (copy_ctor_func_t) zval_add_ref);
 
-	pnstr = spl_gen_private_prop_name(ce, "flags", sizeof("flags")-1);
+	pnstr = spl_gen_private_prop_name(ce, "flags", strlen("flags"));
 	ZVAL_LONG(&tmp, intern->flags);
 	zend_hash_update(debug_info, pnstr, &tmp);
 	zend_string_release_ex(pnstr, 0);
 
-	pnstr = spl_gen_private_prop_name(ce, "isCorrupted", sizeof("isCorrupted")-1);
+	pnstr = spl_gen_private_prop_name(ce, "isCorrupted", strlen("isCorrupted"));
 	ZVAL_BOOL(&tmp, intern->heap->flags&SPL_HEAP_CORRUPTED);
 	zend_hash_update(debug_info, pnstr, &tmp);
 	zend_string_release_ex(pnstr, 0);
@@ -545,7 +545,7 @@ static inline HashTable* spl_heap_object_get_debug_info(zend_class_entry *ce, ze
 		}
 	}
 
-	pnstr = spl_gen_private_prop_name(ce, "heap", sizeof("heap")-1);
+	pnstr = spl_gen_private_prop_name(ce, "heap", strlen("heap"));
 	zend_hash_update(debug_info, pnstr, &heap_array);
 	zend_string_release_ex(pnstr, 0);
 

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -625,31 +625,31 @@ static void spl_recursive_it_it_construct(INTERNAL_FUNCTION_PARAMETERS, zend_cla
 	intern->in_iteration = 0;
 	intern->ce = Z_OBJCE_P(object);
 
-	intern->beginIteration = zend_hash_str_find_ptr(&intern->ce->function_table, "beginiteration", sizeof("beginiteration") - 1);
+	intern->beginIteration = zend_hash_str_find_ptr(&intern->ce->function_table, "beginiteration", strlen("beginiteration"));
 	if (intern->beginIteration->common.scope == ce_base) {
 		intern->beginIteration = NULL;
 	}
-	intern->endIteration = zend_hash_str_find_ptr(&intern->ce->function_table, "enditeration", sizeof("enditeration") - 1);
+	intern->endIteration = zend_hash_str_find_ptr(&intern->ce->function_table, "enditeration", strlen("enditeration"));
 	if (intern->endIteration->common.scope == ce_base) {
 		intern->endIteration = NULL;
 	}
-	intern->callHasChildren = zend_hash_str_find_ptr(&intern->ce->function_table, "callhaschildren", sizeof("callHasChildren") - 1);
+	intern->callHasChildren = zend_hash_str_find_ptr(&intern->ce->function_table, "callhaschildren", strlen("callHasChildren"));
 	if (intern->callHasChildren->common.scope == ce_base) {
 		intern->callHasChildren = NULL;
 	}
-	intern->callGetChildren = zend_hash_str_find_ptr(&intern->ce->function_table, "callgetchildren", sizeof("callGetChildren") - 1);
+	intern->callGetChildren = zend_hash_str_find_ptr(&intern->ce->function_table, "callgetchildren", strlen("callGetChildren"));
 	if (intern->callGetChildren->common.scope == ce_base) {
 		intern->callGetChildren = NULL;
 	}
-	intern->beginChildren = zend_hash_str_find_ptr(&intern->ce->function_table, "beginchildren", sizeof("beginchildren") - 1);
+	intern->beginChildren = zend_hash_str_find_ptr(&intern->ce->function_table, "beginchildren", strlen("beginchildren"));
 	if (intern->beginChildren->common.scope == ce_base) {
 		intern->beginChildren = NULL;
 	}
-	intern->endChildren = zend_hash_str_find_ptr(&intern->ce->function_table, "endchildren", sizeof("endchildren") - 1);
+	intern->endChildren = zend_hash_str_find_ptr(&intern->ce->function_table, "endchildren", strlen("endchildren"));
 	if (intern->endChildren->common.scope == ce_base) {
 		intern->endChildren = NULL;
 	}
-	intern->nextElement = zend_hash_str_find_ptr(&intern->ce->function_table, "nextelement", sizeof("nextElement") - 1);
+	intern->nextElement = zend_hash_str_find_ptr(&intern->ce->function_table, "nextelement", strlen("nextElement"));
 	if (intern->nextElement->common.scope == ce_base) {
 		intern->nextElement = NULL;
 	}
@@ -1912,7 +1912,7 @@ PHP_METHOD(RegexIterator, accept)
 			break;
 
 		case REGIT_MODE_REPLACE: {
-			zval *replacement = zend_read_property(intern->std.ce, Z_OBJ_P(ZEND_THIS), "replacement", sizeof("replacement")-1, 1, &rv);
+			zval *replacement = zend_read_property(intern->std.ce, Z_OBJ_P(ZEND_THIS), "replacement", strlen("replacement"), 1, &rv);
 			zend_string *replacement_str = zval_try_get_string(replacement);
 
 			if (UNEXPECTED(!replacement_str)) {

--- a/ext/spl/spl_iterators_arginfo.h
+++ b/ext/spl/spl_iterators_arginfo.h
@@ -811,7 +811,7 @@ static zend_class_entry *register_class_RegexIterator(zend_class_entry *class_en
 
 	zval property_replacement_default_value;
 	ZVAL_NULL(&property_replacement_default_value);
-	zend_string *property_replacement_name = zend_string_init("replacement", sizeof("replacement") - 1, 1);
+	zend_string *property_replacement_name = zend_string_init("replacement", strlen("replacement"), 1);
 	zend_declare_typed_property(class_entry, property_replacement_name, &property_replacement_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_replacement_name);
 

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -272,7 +272,7 @@ static zend_object *spl_object_storage_new_ex(zend_class_entry *class_type, zend
 			/* Possible optimization: Cache these results with a map from class entry to IS_NULL/IS_PTR.
 			 * Or maybe just a single item with the result for the most recently loaded subclass. */
 			if (class_type != spl_ce_SplObjectStorage) {
-				zend_function *get_hash = zend_hash_str_find_ptr(&class_type->function_table, "gethash", sizeof("gethash") - 1);
+				zend_function *get_hash = zend_hash_str_find_ptr(&class_type->function_table, "gethash", strlen("gethash"));
 				if (get_hash->common.scope != spl_ce_SplObjectStorage) {
 					intern->fptr_get_hash = get_hash;
 				}
@@ -343,12 +343,12 @@ static inline HashTable* spl_object_storage_debug_info(zend_object *obj) /* {{{ 
 		Z_ARRVAL_P(&tmp)->pDestructor = NULL;
 		zval obj;
 		ZVAL_OBJ(&obj, element->obj);
-		add_assoc_zval_ex(&tmp, "obj", sizeof("obj") - 1, &obj);
-		add_assoc_zval_ex(&tmp, "inf", sizeof("inf") - 1, &element->inf);
+		add_assoc_zval_ex(&tmp, "obj", strlen("obj"), &obj);
+		add_assoc_zval_ex(&tmp, "inf", strlen("inf"), &element->inf);
 		zend_hash_next_index_insert(Z_ARRVAL(storage), &tmp);
 	} ZEND_HASH_FOREACH_END();
 
-	zname = spl_gen_private_prop_name(spl_ce_SplObjectStorage, "storage", sizeof("storage")-1);
+	zname = spl_gen_private_prop_name(spl_ce_SplObjectStorage, "storage", strlen("storage"));
 	zend_symtable_update(debug_info, zname, &storage);
 	zend_string_release_ex(zname, 0);
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -112,8 +112,8 @@ PHP_METHOD(SQLite3, open)
 		RETURN_THROWS();
 	}
 
-	if (filename_len != 0 && (filename_len != sizeof(":memory:")-1 ||
-			memcmp(filename, ":memory:", sizeof(":memory:")-1) != 0)) {
+	if (filename_len != 0 && (filename_len != strlen(":memory:") ||
+			memcmp(filename, ":memory:", strlen(":memory:")) != 0)) {
 		if (!(fullpath = expand_filepath(filename, NULL))) {
 			zend_throw_exception(zend_ce_exception, "Unable to expand filepath", 0);
 			RETURN_THROWS();
@@ -2402,48 +2402,48 @@ PHP_MINIT_FUNCTION(sqlite3)
 	REGISTER_LONG_CONSTANT("SQLITE3_OPEN_CREATE", SQLITE_OPEN_CREATE, CONST_CS | CONST_PERSISTENT);
 
 	/* Class constants */
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "OK", sizeof("OK") - 1, SQLITE_OK);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "OK", strlen("OK"), SQLITE_OK);
 
 	/* Constants for authorizer return */
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DENY", sizeof("DENY") - 1, SQLITE_DENY);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "IGNORE", sizeof("IGNORE") - 1, SQLITE_IGNORE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DENY", strlen("DENY"), SQLITE_DENY);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "IGNORE", strlen("IGNORE"), SQLITE_IGNORE);
 
 	/* Constants for authorizer actions */
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_INDEX", sizeof("CREATE_INDEX") - 1, SQLITE_CREATE_INDEX);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TABLE", sizeof("CREATE_TABLE") - 1, SQLITE_CREATE_TABLE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TEMP_INDEX", sizeof("CREATE_TEMP_INDEX") - 1, SQLITE_CREATE_TEMP_INDEX);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TEMP_TABLE", sizeof("CREATE_TEMP_TABLE") - 1, SQLITE_CREATE_TEMP_TABLE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TEMP_TRIGGER", sizeof("CREATE_TEMP_TRIGGER") - 1, SQLITE_CREATE_TEMP_TRIGGER);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TEMP_VIEW", sizeof("CREATE_TEMP_VIEW") - 1, SQLITE_CREATE_TEMP_VIEW);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TRIGGER", sizeof("CREATE_TRIGGER") - 1, SQLITE_CREATE_TRIGGER);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_VIEW", sizeof("CREATE_VIEW") - 1, SQLITE_CREATE_VIEW);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DELETE", sizeof("DELETE") - 1, SQLITE_DELETE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_INDEX", sizeof("DROP_INDEX") - 1, SQLITE_DROP_INDEX);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TABLE", sizeof("DROP_TABLE") - 1, SQLITE_DROP_TABLE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TEMP_INDEX", sizeof("DROP_TEMP_INDEX") - 1, SQLITE_DROP_TEMP_INDEX);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TEMP_TABLE", sizeof("DROP_TEMP_TABLE") - 1, SQLITE_DROP_TEMP_TABLE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TEMP_TRIGGER", sizeof("DROP_TEMP_TRIGGER") - 1, SQLITE_DROP_TEMP_TRIGGER);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TEMP_VIEW", sizeof("DROP_TEMP_VIEW") - 1, SQLITE_DROP_TEMP_VIEW);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TRIGGER", sizeof("DROP_TRIGGER") - 1, SQLITE_DROP_TRIGGER);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_VIEW", sizeof("DROP_VIEW") - 1, SQLITE_DROP_VIEW);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "INSERT", sizeof("INSERT") - 1, SQLITE_INSERT);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "PRAGMA", sizeof("PRAGMA") - 1, SQLITE_PRAGMA);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "READ", sizeof("READ") - 1, SQLITE_READ);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "SELECT", sizeof("SELECT") - 1, SQLITE_SELECT);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "TRANSACTION", sizeof("TRANSACTION") - 1, SQLITE_TRANSACTION);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "UPDATE", sizeof("UPDATE") - 1, SQLITE_UPDATE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "ATTACH", sizeof("ATTACH") - 1, SQLITE_ATTACH);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DETACH", sizeof("DETACH") - 1, SQLITE_DETACH);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "ALTER_TABLE", sizeof("ALTER_TABLE") - 1, SQLITE_ALTER_TABLE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "REINDEX", sizeof("REINDEX") - 1, SQLITE_REINDEX);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "ANALYZE", sizeof("ANALYZE") - 1, SQLITE_ANALYZE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_VTABLE", sizeof("CREATE_VTABLE") - 1, SQLITE_CREATE_VTABLE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_VTABLE", sizeof("DROP_VTABLE") - 1, SQLITE_DROP_VTABLE);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "FUNCTION", sizeof("FUNCTION") - 1, SQLITE_FUNCTION);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "SAVEPOINT", sizeof("SAVEPOINT") - 1, SQLITE_SAVEPOINT);
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "COPY", sizeof("COPY") - 1, SQLITE_COPY);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_INDEX", strlen("CREATE_INDEX"), SQLITE_CREATE_INDEX);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TABLE", strlen("CREATE_TABLE"), SQLITE_CREATE_TABLE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TEMP_INDEX", strlen("CREATE_TEMP_INDEX"), SQLITE_CREATE_TEMP_INDEX);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TEMP_TABLE", strlen("CREATE_TEMP_TABLE"), SQLITE_CREATE_TEMP_TABLE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TEMP_TRIGGER", strlen("CREATE_TEMP_TRIGGER"), SQLITE_CREATE_TEMP_TRIGGER);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TEMP_VIEW", strlen("CREATE_TEMP_VIEW"), SQLITE_CREATE_TEMP_VIEW);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_TRIGGER", strlen("CREATE_TRIGGER"), SQLITE_CREATE_TRIGGER);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_VIEW", strlen("CREATE_VIEW"), SQLITE_CREATE_VIEW);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DELETE", strlen("DELETE"), SQLITE_DELETE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_INDEX", strlen("DROP_INDEX"), SQLITE_DROP_INDEX);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TABLE", strlen("DROP_TABLE"), SQLITE_DROP_TABLE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TEMP_INDEX", strlen("DROP_TEMP_INDEX"), SQLITE_DROP_TEMP_INDEX);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TEMP_TABLE", strlen("DROP_TEMP_TABLE"), SQLITE_DROP_TEMP_TABLE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TEMP_TRIGGER", strlen("DROP_TEMP_TRIGGER"), SQLITE_DROP_TEMP_TRIGGER);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TEMP_VIEW", strlen("DROP_TEMP_VIEW"), SQLITE_DROP_TEMP_VIEW);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_TRIGGER", strlen("DROP_TRIGGER"), SQLITE_DROP_TRIGGER);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_VIEW", strlen("DROP_VIEW"), SQLITE_DROP_VIEW);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "INSERT", strlen("INSERT"), SQLITE_INSERT);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "PRAGMA", strlen("PRAGMA"), SQLITE_PRAGMA);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "READ", strlen("READ"), SQLITE_READ);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "SELECT", strlen("SELECT"), SQLITE_SELECT);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "TRANSACTION", strlen("TRANSACTION"), SQLITE_TRANSACTION);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "UPDATE", strlen("UPDATE"), SQLITE_UPDATE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "ATTACH", strlen("ATTACH"), SQLITE_ATTACH);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DETACH", strlen("DETACH"), SQLITE_DETACH);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "ALTER_TABLE", strlen("ALTER_TABLE"), SQLITE_ALTER_TABLE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "REINDEX", strlen("REINDEX"), SQLITE_REINDEX);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "ANALYZE", strlen("ANALYZE"), SQLITE_ANALYZE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "CREATE_VTABLE", strlen("CREATE_VTABLE"), SQLITE_CREATE_VTABLE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "DROP_VTABLE", strlen("DROP_VTABLE"), SQLITE_DROP_VTABLE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "FUNCTION", strlen("FUNCTION"), SQLITE_FUNCTION);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "SAVEPOINT", strlen("SAVEPOINT"), SQLITE_SAVEPOINT);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "COPY", strlen("COPY"), SQLITE_COPY);
 #ifdef SQLITE_RECURSIVE
-	zend_declare_class_constant_long(php_sqlite3_sc_entry, "RECURSIVE", sizeof("RECURSIVE") - 1, SQLITE_RECURSIVE);
+	zend_declare_class_constant_long(php_sqlite3_sc_entry, "RECURSIVE", strlen("RECURSIVE"), SQLITE_RECURSIVE);
 #endif
 
 #ifdef SQLITE_DETERMINISTIC

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -227,7 +227,7 @@ PHP_FUNCTION(assert_options)
 				RETURN_THROWS();
 			}
 
-			key = zend_string_init("assert.active", sizeof("assert.active")-1, 0);
+			key = zend_string_init("assert.active", strlen("assert.active"), 0);
 			zend_alter_ini_entry_ex(key, value_str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(key, 0);
 			zend_string_release_ex(value_str, 0);
@@ -243,7 +243,7 @@ PHP_FUNCTION(assert_options)
 				RETURN_THROWS();
 			}
 
-			key = zend_string_init("assert.bail", sizeof("assert.bail")-1, 0);
+			key = zend_string_init("assert.bail", strlen("assert.bail"), 0);
 			zend_alter_ini_entry_ex(key, value_str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(key, 0);
 			zend_string_release_ex(value_str, 0);
@@ -259,7 +259,7 @@ PHP_FUNCTION(assert_options)
 				RETURN_THROWS();
 			}
 
-			key = zend_string_init("assert.warning", sizeof("assert.warning")-1, 0);
+			key = zend_string_init("assert.warning", strlen("assert.warning"), 0);
 			zend_alter_ini_entry_ex(key, value_str, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(key, 0);
 			zend_string_release_ex(value_str, 0);
@@ -294,7 +294,7 @@ PHP_FUNCTION(assert_options)
 				RETURN_THROWS();
 			}
 
-			key = zend_string_init("assert.exception", sizeof("assert.exception")-1, 0);
+			key = zend_string_init("assert.exception", strlen("assert.exception"), 0);
 			zend_alter_ini_entry_ex(key, val, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0);
 			zend_string_release_ex(val, 0);
 			zend_string_release_ex(key, 0);

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -694,8 +694,8 @@ PHP_FUNCTION(ip2long)
 		/* The only special case when we should return -1 ourselves,
 		 * because inet_addr() considers it wrong. We return 0xFFFFFFFF and
 		 * not -1 or ~0 because of 32/64bit issues. */
-		if (addr_len == sizeof("255.255.255.255") - 1 &&
-			!memcmp(addr, "255.255.255.255", sizeof("255.255.255.255") - 1)
+		if (addr_len == strlen("255.255.255.255") &&
+			!memcmp(addr, "255.255.255.255", strlen("255.255.255.255"))
 		) {
 			RETURN_LONG(0xFFFFFFFF);
 		}
@@ -1278,8 +1278,8 @@ PHP_FUNCTION(time_nanosleep)
 		RETURN_TRUE;
 	} else if (errno == EINTR) {
 		array_init(return_value);
-		add_assoc_long_ex(return_value, "seconds", sizeof("seconds")-1, php_rem.tv_sec);
-		add_assoc_long_ex(return_value, "nanoseconds", sizeof("nanoseconds")-1, php_rem.tv_nsec);
+		add_assoc_long_ex(return_value, "seconds", strlen("seconds"), php_rem.tv_sec);
+		add_assoc_long_ex(return_value, "nanoseconds", strlen("nanoseconds"), php_rem.tv_nsec);
 		return;
 	} else if (errno == EINVAL) {
 		zend_value_error("Nanoseconds was not in the range 0 to 999 999 999 or seconds was negative");
@@ -2147,7 +2147,7 @@ PHP_FUNCTION(set_include_path)
 		Z_PARAM_PATH_STR(new_value)
 	ZEND_PARSE_PARAMETERS_END();
 
-	old_value = zend_ini_string("include_path", sizeof("include_path") - 1, 0);
+	old_value = zend_ini_string("include_path", strlen("include_path"), 0);
 	/* copy to return here, because alter might free it! */
 	if (old_value) {
 		RETVAL_STRING(old_value);
@@ -2155,7 +2155,7 @@ PHP_FUNCTION(set_include_path)
 		RETVAL_FALSE;
 	}
 
-	key = zend_string_init("include_path", sizeof("include_path") - 1, 0);
+	key = zend_string_init("include_path", strlen("include_path"), 0);
 	if (zend_alter_ini_entry_ex(key, new_value, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0) == FAILURE) {
 		zend_string_release_ex(key, 0);
 		zval_ptr_dtor_str(return_value);
@@ -2172,7 +2172,7 @@ PHP_FUNCTION(get_include_path)
 
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	str = zend_ini_string("include_path", sizeof("include_path") - 1, 0);
+	str = zend_ini_string("include_path", strlen("include_path"), 0);
 
 	if (str == NULL) {
 		RETURN_FALSE;
@@ -2236,7 +2236,7 @@ PHP_FUNCTION(ignore_user_abort)
 	old_setting = (unsigned short)PG(ignore_user_abort);
 
 	if (!arg_is_null) {
-		zend_string *key = zend_string_init("ignore_user_abort", sizeof("ignore_user_abort") - 1, 0);
+		zend_string *key = zend_string_init("ignore_user_abort", strlen("ignore_user_abort"), 0);
 		zend_alter_ini_entry_chars(key, arg ? "1" : "0", 1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_string_release_ex(key, 0);
 	}

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -144,7 +144,7 @@ static size_t browscap_compute_regex_len(zend_string *pattern) {
 		}
 	}
 
-	return len + sizeof("~^$~")-1;
+	return len + strlen("~^$~");
 }
 
 static zend_string *browscap_convert_pattern(zend_string *pattern, int persistent) /* {{{ */
@@ -279,14 +279,14 @@ static HashTable *browscap_entry_to_array(browser_data *bdata, browscap_entry *e
 	HashTable *ht = zend_new_array(8);
 
 	ZVAL_STR(&tmp, browscap_convert_pattern(entry->pattern, 0));
-	zend_hash_str_add(ht, "browser_name_regex", sizeof("browser_name_regex")-1, &tmp);
+	zend_hash_str_add(ht, "browser_name_regex", strlen("browser_name_regex"), &tmp);
 
 	ZVAL_STR_COPY(&tmp, entry->pattern);
-	zend_hash_str_add(ht, "browser_name_pattern", sizeof("browser_name_pattern")-1, &tmp);
+	zend_hash_str_add(ht, "browser_name_pattern", strlen("browser_name_pattern"), &tmp);
 
 	if (entry->parent) {
 		ZVAL_STR_COPY(&tmp, entry->parent);
-		zend_hash_str_add(ht, "parent", sizeof("parent")-1, &tmp);
+		zend_hash_str_add(ht, "parent", strlen("parent"), &tmp);
 	}
 
 	for (i = entry->kv_start; i < entry->kv_end; i++) {
@@ -713,7 +713,7 @@ PHP_FUNCTION(get_browser)
 				|| zend_is_auto_global(ZSTR_KNOWN(ZEND_STR_AUTOGLOBAL_SERVER))) {
 			http_user_agent = zend_hash_str_find(
 				Z_ARRVAL_P(&PG(http_globals)[TRACK_VARS_SERVER]),
-				"HTTP_USER_AGENT", sizeof("HTTP_USER_AGENT")-1);
+				"HTTP_USER_AGENT", strlen("HTTP_USER_AGENT"));
 		}
 		if (http_user_agent == NULL) {
 			php_error_docref(NULL, E_WARNING, "HTTP_USER_AGENT variable is not set, cannot determine user agent name");

--- a/ext/standard/dir_arginfo.h
+++ b/ext/standard/dir_arginfo.h
@@ -31,13 +31,13 @@ static zend_class_entry *register_class_Directory(void)
 
 	zval property_path_default_value;
 	ZVAL_UNDEF(&property_path_default_value);
-	zend_string *property_path_name = zend_string_init("path", sizeof("path") - 1, 1);
+	zend_string *property_path_name = zend_string_init("path", strlen("path"), 1);
 	zend_declare_typed_property(class_entry, property_path_name, &property_path_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_path_name);
 
 	zval property_handle_default_value;
 	ZVAL_UNDEF(&property_handle_default_value);
-	zend_string *property_handle_name = zend_string_init("handle", sizeof("handle") - 1, 1);
+	zend_string *property_handle_name = zend_string_init("handle", strlen("handle"), 1);
 	zend_declare_typed_property(class_entry, property_handle_name, &property_handle_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_handle_name);
 

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -614,8 +614,8 @@ PHP_FUNCTION(file_put_contents)
 		mode[0] = 'a';
 	} else if (flags & LOCK_EX) {
 		/* check to make sure we are dealing with a regular file */
-		if (php_memnstr(filename, "://", sizeof("://") - 1, filename + filename_len)) {
-			if (strncasecmp(filename, "file://", sizeof("file://") - 1)) {
+		if (php_memnstr(filename, "://", strlen("://"), filename + filename_len)) {
+			if (strncasecmp(filename, "file://", strlen("file://"))) {
 				php_error_docref(NULL, E_WARNING, "Exclusive locks may only be set for regular files");
 				RETURN_FALSE;
 			}

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -1115,18 +1115,18 @@ PHP_FUNCTION(realpath_cache_get)
 
 			/* bucket->key is unsigned long */
 			if (ZEND_LONG_MAX >= bucket->key) {
-				add_assoc_long_ex(&entry, "key", sizeof("key") - 1, bucket->key);
+				add_assoc_long_ex(&entry, "key", strlen("key"), bucket->key);
 			} else {
-				add_assoc_double_ex(&entry, "key", sizeof("key") - 1, (double)bucket->key);
+				add_assoc_double_ex(&entry, "key", strlen("key"), (double)bucket->key);
 			}
-			add_assoc_bool_ex(&entry, "is_dir", sizeof("is_dir") - 1, bucket->is_dir);
-			add_assoc_stringl_ex(&entry, "realpath", sizeof("realpath") - 1, bucket->realpath, bucket->realpath_len);
-			add_assoc_long_ex(&entry, "expires", sizeof("expires") - 1, bucket->expires);
+			add_assoc_bool_ex(&entry, "is_dir", strlen("is_dir"), bucket->is_dir);
+			add_assoc_stringl_ex(&entry, "realpath", strlen("realpath"), bucket->realpath, bucket->realpath_len);
+			add_assoc_long_ex(&entry, "expires", strlen("expires"), bucket->expires);
 #ifdef PHP_WIN32
-			add_assoc_bool_ex(&entry, "is_rvalid", sizeof("is_rvalid") - 1, bucket->is_rvalid);
-			add_assoc_bool_ex(&entry, "is_wvalid", sizeof("is_wvalid") - 1, bucket->is_wvalid);
-			add_assoc_bool_ex(&entry, "is_readable", sizeof("is_readable") - 1, bucket->is_readable);
-			add_assoc_bool_ex(&entry, "is_writable", sizeof("is_writable") - 1, bucket->is_writable);
+			add_assoc_bool_ex(&entry, "is_rvalid", strlen("is_rvalid"), bucket->is_rvalid);
+			add_assoc_bool_ex(&entry, "is_wvalid", strlen("is_wvalid"), bucket->is_wvalid);
+			add_assoc_bool_ex(&entry, "is_readable", strlen("is_readable"), bucket->is_readable);
+			add_assoc_bool_ex(&entry, "is_writable", strlen("is_writable"), bucket->is_writable);
 #endif
 			zend_hash_str_update(Z_ARRVAL_P(return_value), bucket->path, bucket->path_len, &entry);
 			bucket = bucket->next;

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -118,7 +118,7 @@ PHPAPI zend_result php_setcookie(zend_string *name, zend_string *value, time_t e
 		 * so in order to force cookies to be deleted, even on MSIE, we
 		 * pick an expiry date in the past
 		 */
-		dt = php_format_date("D, d-M-Y H:i:s T", sizeof("D, d-M-Y H:i:s T")-1, 1, 0);
+		dt = php_format_date("D, d-M-Y H:i:s T", strlen("D, d-M-Y H:i:s T"), 1, 0);
 		smart_str_appends(&buf, "Set-Cookie: ");
 		smart_str_append(&buf, name);
 		smart_str_appends(&buf, "=deleted; expires=");
@@ -141,7 +141,7 @@ PHPAPI zend_result php_setcookie(zend_string *name, zend_string *value, time_t e
 			double diff;
 
 			smart_str_appends(&buf, COOKIE_EXPIRES);
-			dt = php_format_date("D, d-M-Y H:i:s T", sizeof("D, d-M-Y H:i:s T")-1, expires, 0);
+			dt = php_format_date("D, d-M-Y H:i:s T", strlen("D, d-M-Y H:i:s T"), expires, 0);
 			/* check to make sure that the year does not exceed 4 digits in length */
 			p = zend_memrchr(ZSTR_VAL(dt), '-', ZSTR_LEN(dt));
 			if (!p || *(p + 5) != ' ') {

--- a/ext/standard/html.c
+++ b/ext/standard/html.c
@@ -1135,10 +1135,10 @@ PHPAPI zend_string *php_escape_html_entities_ex(const unsigned char *old, size_t
 	if (flags & (ENT_HTML_SUBSTITUTE_ERRORS | ENT_HTML_SUBSTITUTE_DISALLOWED_CHARS)) {
 		if (charset == cs_utf_8) {
 			replacement = (const unsigned char*)"\xEF\xBF\xBD";
-			replacement_len = sizeof("\xEF\xBF\xBD") - 1;
+			replacement_len = strlen("\xEF\xBF\xBD");
 		} else {
 			replacement = (const unsigned char*)"&#xFFFD;";
-			replacement_len = sizeof("&#xFFFD;") - 1;
+			replacement_len = strlen("&#xFFFD;");
 		}
 	}
 
@@ -1254,8 +1254,8 @@ pass_char_through:
 		} else { /* this_char == '&' */
 			if (double_encode) {
 encode_amp:
-				memcpy(&ZSTR_VAL(replaced)[len], "&amp;", sizeof("&amp;") - 1);
-				len += sizeof("&amp;") - 1;
+				memcpy(&ZSTR_VAL(replaced)[len], "&amp;", strlen("&amp;"));
+				len += strlen("&amp;");
 			} else { /* no double encode */
 				/* check if entity is valid */
 				size_t ent_len; /* not counting & or ; */

--- a/ext/standard/http.c
+++ b/ext/standard/http.c
@@ -194,10 +194,10 @@ PHPAPI void php_url_encode_hash_ex(HashTable *ht, smart_str *formstr,
 					smart_str_append_long(formstr, Z_LVAL_P(zdata));
 					break;
 				case IS_FALSE:
-					smart_str_appendl(formstr, "0", sizeof("0")-1);
+					smart_str_appendl(formstr, "0", strlen("0"));
 					break;
 				case IS_TRUE:
-					smart_str_appendl(formstr, "1", sizeof("1")-1);
+					smart_str_appendl(formstr, "1", strlen("1"));
 					break;
 				default:
 					{

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -243,11 +243,11 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 			zval_ptr_dtor(&ssl_proxy_peer_name);
 		}
 
-		smart_str_appendl(&header, "CONNECT ", sizeof("CONNECT ")-1);
+		smart_str_appendl(&header, "CONNECT ", strlen("CONNECT "));
 		smart_str_appends(&header, ZSTR_VAL(resource->host));
 		smart_str_appendc(&header, ':');
 		smart_str_append_unsigned(&header, resource->port);
-		smart_str_appendl(&header, " HTTP/1.0\r\n", sizeof(" HTTP/1.0\r\n")-1);
+		smart_str_appendl(&header, " HTTP/1.0\r\n", strlen(" HTTP/1.0\r\n"));
 
 	    /* check if we have Proxy-Authorization header */
 		if (context && (tmpzval = php_stream_context_get_option(context, "http", "header")) != NULL) {
@@ -265,12 +265,12 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 							while (*p != 0 && *p != ':' && *p != '\r' && *p !='\n') p++;
 							if (*p == ':') {
 								p++;
-								if (p - s == sizeof("Proxy-Authorization:") - 1 &&
-								    zend_binary_strcasecmp(s, sizeof("Proxy-Authorization:") - 1,
-								        "Proxy-Authorization:", sizeof("Proxy-Authorization:") - 1) == 0) {
+								if (p - s == strlen("Proxy-Authorization:") &&
+								    zend_binary_strcasecmp(s, strlen("Proxy-Authorization:"),
+								        "Proxy-Authorization:", strlen("Proxy-Authorization:")) == 0) {
 									while (*p != 0 && *p != '\r' && *p !='\n') p++;
 									smart_str_appendl(&header, s, p - s);
-									smart_str_appendl(&header, "\r\n", sizeof("\r\n")-1);
+									smart_str_appendl(&header, "\r\n", strlen("\r\n"));
 									goto finish;
 								} else {
 									while (*p != 0 && *p != '\r' && *p !='\n') p++;
@@ -289,12 +289,12 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 					while (*p != 0 && *p != ':' && *p != '\r' && *p !='\n') p++;
 					if (*p == ':') {
 						p++;
-						if (p - s == sizeof("Proxy-Authorization:") - 1 &&
-						    zend_binary_strcasecmp(s, sizeof("Proxy-Authorization:") - 1,
-						        "Proxy-Authorization:", sizeof("Proxy-Authorization:") - 1) == 0) {
+						if (p - s == strlen("Proxy-Authorization:") &&
+						    zend_binary_strcasecmp(s, strlen("Proxy-Authorization:"),
+						        "Proxy-Authorization:", strlen("Proxy-Authorization:")) == 0) {
 							while (*p != 0 && *p != '\r' && *p !='\n') p++;
 							smart_str_appendl(&header, s, p - s);
-							smart_str_appendl(&header, "\r\n", sizeof("\r\n")-1);
+							smart_str_appendl(&header, "\r\n", strlen("\r\n"));
 							goto finish;
 						} else {
 							while (*p != 0 && *p != '\r' && *p !='\n') p++;
@@ -306,7 +306,7 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 			}
 		}
 finish:
-		smart_str_appendl(&header, "\r\n", sizeof("\r\n")-1);
+		smart_str_appendl(&header, "\r\n", strlen("\r\n"));
 
 		if (php_stream_write(stream, ZSTR_VAL(header.s), ZSTR_LEN(header.s)) != ZSTR_LEN(header.s)) {
 			php_stream_wrapper_log_error(wrapper, options, "Cannot connect to HTTPS server through proxy");
@@ -428,7 +428,7 @@ finish:
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(tmpzval), tmpheader) {
 				if (Z_TYPE_P(tmpheader) == IS_STRING) {
 					smart_str_append(&tmpstr, Z_STR_P(tmpheader));
-					smart_str_appendl(&tmpstr, "\r\n", sizeof("\r\n") - 1);
+					smart_str_appendl(&tmpstr, "\r\n", strlen("\r\n"));
 				}
 			} ZEND_HASH_FOREACH_END();
 			smart_str_0(&tmpstr);
@@ -489,7 +489,7 @@ finish:
 			/* remove Proxy-Authorization header */
 			if (use_proxy && use_ssl && (s = strstr(t, "proxy-authorization:")) &&
 			    (s == t || *(s-1) == '\n')) {
-				char *p = s + sizeof("proxy-authorization:") - 1;
+				char *p = s + strlen("proxy-authorization:");
 
 				while (s > t && (*(s-1) == ' ' || *(s-1) == '\t')) s--;
 				while (*p != 0 && *p != '\r' && *p != '\n') p++;
@@ -679,7 +679,7 @@ finish:
 				while (
 					!php_stream_eof(stream)
 					&& php_stream_get_line(stream, tmp_line, sizeof(tmp_line) - 1, &tmp_line_len) != NULL
-					&& ( tmp_line_len < sizeof("HTTP/1") - 1 || strncasecmp(tmp_line, "HTTP/1", sizeof("HTTP/1") - 1) )
+					&& ( tmp_line_len < strlen("HTTP/1") || strncasecmp(tmp_line, "HTTP/1", strlen("HTTP/1")) )
 				);
 
 				if (tmp_line_len > 9) {
@@ -770,7 +770,7 @@ finish:
 				http_header_value = e;
 			}
 
-			if (!strncasecmp(http_header_line, "Location:", sizeof("Location:")-1)) {
+			if (!strncasecmp(http_header_line, "Location:", strlen("Location:"))) {
 				if (context && (tmpzval = php_stream_context_get_option(context, "http", "follow_location")) != NULL) {
 					follow_location = zval_is_true(tmpzval);
 				} else if (!((response_code >= 300 && response_code < 304)
@@ -782,14 +782,14 @@ finish:
 					follow_location = 0;
 				}
 				strlcpy(location, http_header_value, sizeof(location));
-			} else if (!strncasecmp(http_header_line, "Content-Type:", sizeof("Content-Type:")-1)) {
+			} else if (!strncasecmp(http_header_line, "Content-Type:", strlen("Content-Type:"))) {
 				php_stream_notify_info(context, PHP_STREAM_NOTIFY_MIME_TYPE_IS, http_header_value, 0);
-			} else if (!strncasecmp(http_header_line, "Content-Length:", sizeof("Content-Length:")-1)) {
+			} else if (!strncasecmp(http_header_line, "Content-Length:", strlen("Content-Length:"))) {
 				file_size = atoi(http_header_value);
 				php_stream_notify_file_size(context, file_size, http_header_line, 0);
 			} else if (
-				!strncasecmp(http_header_line, "Transfer-Encoding:", sizeof("Transfer-Encoding:")-1)
-				&& !strncasecmp(http_header_value, "Chunked", sizeof("Chunked")-1)
+				!strncasecmp(http_header_line, "Transfer-Encoding:", strlen("Transfer-Encoding:"))
+				&& !strncasecmp(http_header_value, "Chunked", strlen("Chunked"))
 			) {
 
 				/* create filter to decode response body */
@@ -841,10 +841,10 @@ finish:
 			char loc_path[HTTP_HEADER_BLOCK_SIZE];
 
 			*new_path='\0';
-			if (strlen(location)<8 || (strncasecmp(location, "http://", sizeof("http://")-1) &&
-							strncasecmp(location, "https://", sizeof("https://")-1) &&
-							strncasecmp(location, "ftp://", sizeof("ftp://")-1) &&
-							strncasecmp(location, "ftps://", sizeof("ftps://")-1)))
+			if (strlen(location)<8 || (strncasecmp(location, "http://", strlen("http://")) &&
+							strncasecmp(location, "https://", strlen("https://")) &&
+							strncasecmp(location, "ftp://", strlen("ftp://")) &&
+							strncasecmp(location, "ftps://", strlen("ftps://"))))
 			{
 				if (*location != '/') {
 					if (*(location+1) != '\0' && resource->path) {
@@ -904,7 +904,7 @@ finish:
 	} \
 }
 			/* check for control characters in login, password & path */
-			if (strncasecmp(new_path, "http://", sizeof("http://") - 1) || strncasecmp(new_path, "https://", sizeof("https://") - 1)) {
+			if (strncasecmp(new_path, "http://", strlen("http://")) || strncasecmp(new_path, "https://", strlen("https://"))) {
 				CHECK_FOR_CNTRL_CHARS(resource->user);
 				CHECK_FOR_CNTRL_CHARS(resource->pass);
 				CHECK_FOR_CNTRL_CHARS(resource->path);
@@ -969,7 +969,7 @@ php_stream *php_stream_url_wrap_http(php_stream_wrapper *wrapper, const char *pa
 
 	if (!Z_ISUNDEF(headers)) {
 		if (FAILURE == zend_set_local_var_str(
-				"http_response_header", sizeof("http_response_header")-1, &headers, 0)) {
+				"http_response_header", strlen("http_response_header"), &headers, 0)) {
 			zval_ptr_dtor(&headers);
 		}
 	}

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -997,16 +997,16 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 
 		php_info_print_table_start();
 		php_info_print_table_header(2, "Variable", "Value");
-		if ((data = zend_hash_str_find(&EG(symbol_table), "PHP_SELF", sizeof("PHP_SELF")-1)) != NULL && Z_TYPE_P(data) == IS_STRING) {
+		if ((data = zend_hash_str_find(&EG(symbol_table), "PHP_SELF", strlen("PHP_SELF"))) != NULL && Z_TYPE_P(data) == IS_STRING) {
 			php_info_print_table_row(2, "PHP_SELF", Z_STRVAL_P(data));
 		}
-		if ((data = zend_hash_str_find(&EG(symbol_table), "PHP_AUTH_TYPE", sizeof("PHP_AUTH_TYPE")-1)) != NULL && Z_TYPE_P(data) == IS_STRING) {
+		if ((data = zend_hash_str_find(&EG(symbol_table), "PHP_AUTH_TYPE", strlen("PHP_AUTH_TYPE"))) != NULL && Z_TYPE_P(data) == IS_STRING) {
 			php_info_print_table_row(2, "PHP_AUTH_TYPE", Z_STRVAL_P(data));
 		}
-		if ((data = zend_hash_str_find(&EG(symbol_table), "PHP_AUTH_USER", sizeof("PHP_AUTH_USER")-1)) != NULL && Z_TYPE_P(data) == IS_STRING) {
+		if ((data = zend_hash_str_find(&EG(symbol_table), "PHP_AUTH_USER", strlen("PHP_AUTH_USER"))) != NULL && Z_TYPE_P(data) == IS_STRING) {
 			php_info_print_table_row(2, "PHP_AUTH_USER", Z_STRVAL_P(data));
 		}
-		if ((data = zend_hash_str_find(&EG(symbol_table), "PHP_AUTH_PW", sizeof("PHP_AUTH_PW")-1)) != NULL && Z_TYPE_P(data) == IS_STRING) {
+		if ((data = zend_hash_str_find(&EG(symbol_table), "PHP_AUTH_PW", strlen("PHP_AUTH_PW"))) != NULL && Z_TYPE_P(data) == IS_STRING) {
 			php_info_print_table_row(2, "PHP_AUTH_PW", Z_STRVAL_P(data));
 		}
 		php_print_gpcse_array(ZEND_STRL("_REQUEST"));
@@ -1337,7 +1337,7 @@ PHP_FUNCTION(php_sapi_name)
 PHP_FUNCTION(php_uname)
 {
 	char *mode = "a";
-	size_t modelen = sizeof("a")-1;
+	size_t modelen = strlen("a");
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL

--- a/ext/standard/net.c
+++ b/ext/standard/net.c
@@ -285,11 +285,11 @@ PHP_FUNCTION(net_get_interfaces) {
 			iface = zend_hash_str_add(Z_ARR_P(return_value), p->ifa_name, strlen(p->ifa_name), &newif);
 		}
 
-		unicast = zend_hash_str_find(Z_ARR_P(iface), "unicast", sizeof("unicast") - 1);
+		unicast = zend_hash_str_find(Z_ARR_P(iface), "unicast", strlen("unicast"));
 		if (!unicast) {
 			zval newuni;
 			array_init(&newuni);
-			unicast = zend_hash_str_add(Z_ARR_P(iface), "unicast", sizeof("unicast") - 1, &newuni);
+			unicast = zend_hash_str_add(Z_ARR_P(iface), "unicast", strlen("unicast"), &newuni);
 		}
 
 		iface_append_unicast(unicast,
@@ -297,7 +297,7 @@ PHP_FUNCTION(net_get_interfaces) {
 		                     p->ifa_addr, p->ifa_netmask,
 		                     (p->ifa_flags & IFF_BROADCAST) ? p->ifa_broadaddr : NULL,
 					         (p->ifa_flags & IFF_POINTOPOINT) ? p->ifa_dstaddr : NULL);
-		status = zend_hash_str_find(Z_ARR_P(iface), "up", sizeof("up") - 1);
+		status = zend_hash_str_find(Z_ARR_P(iface), "up", strlen("up"));
 		if (!status) {
 			add_assoc_bool(iface, "up", ((p->ifa_flags & IFF_UP) != 0));
 		}

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -104,7 +104,7 @@ static zend_string* php_password_make_salt(size_t length) /* {{{ */
 /* }}} */
 
 static zend_string* php_password_get_salt(zval *unused_, size_t required_salt_len, HashTable *options) {
-	if (options && zend_hash_str_exists(options, "salt", sizeof("salt") - 1)) {
+	if (options && zend_hash_str_exists(options, "salt", strlen("salt"))) {
 		php_error_docref(NULL, E_WARNING, "The \"salt\" option has been ignored, since providing a custom salt is no longer supported");
 	}
 
@@ -144,7 +144,7 @@ static bool php_password_bcrypt_needs_rehash(const zend_string *hash, zend_array
 	}
 
 	sscanf(ZSTR_VAL(hash), "$2y$" ZEND_LONG_FMT "$", &old_cost);
-	if (options && (znew_cost = zend_hash_str_find(options, "cost", sizeof("cost")-1)) != NULL) {
+	if (options && (znew_cost = zend_hash_str_find(options, "cost", strlen("cost"))) != NULL) {
 		new_cost = zval_get_long(znew_cost);
 	}
 
@@ -184,7 +184,7 @@ static zend_string* php_password_bcrypt_hash(const zend_string *password, zend_a
 	zval *zcost;
 	zend_long cost = PHP_PASSWORD_BCRYPT_COST;
 
-	if (options && (zcost = zend_hash_str_find(options, "cost", sizeof("cost")-1)) != NULL) {
+	if (options && (zcost = zend_hash_str_find(options, "cost", strlen("cost"))) != NULL) {
 		cost = zval_get_long(zcost);
 	}
 
@@ -242,10 +242,10 @@ static int extract_argon2_parameters(const zend_string *hash,
 	if (!hash || (ZSTR_LEN(hash) < sizeof("$argon2id$"))) {
 		return FAILURE;
 	}
-	if (!memcmp(p, "$argon2i$", sizeof("$argon2i$") - 1)) {
-		p += sizeof("$argon2i$") - 1;
-	} else if (!memcmp(p, "$argon2id$", sizeof("$argon2id$") - 1)) {
-		p += sizeof("$argon2id$") - 1;
+	if (!memcmp(p, "$argon2i$", strlen("$argon2i$"))) {
+		p += strlen("$argon2i$");
+	} else if (!memcmp(p, "$argon2id$", strlen("$argon2id$"))) {
+		p += strlen("$argon2id$");
 	} else {
 		return FAILURE;
 	}
@@ -279,15 +279,15 @@ static bool php_password_argon2_needs_rehash(const zend_string *hash, zend_array
 	zend_long new_threads = PHP_PASSWORD_ARGON2_THREADS, threads = 0;
 	zval *option_buffer;
 
-	if (options && (option_buffer = zend_hash_str_find(options, "memory_cost", sizeof("memory_cost")-1)) != NULL) {
+	if (options && (option_buffer = zend_hash_str_find(options, "memory_cost", strlen("memory_cost"))) != NULL) {
 		new_memory_cost = zval_get_long(option_buffer);
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, "time_cost", sizeof("time_cost")-1)) != NULL) {
+	if (options && (option_buffer = zend_hash_str_find(options, "time_cost", strlen("time_cost"))) != NULL) {
 		new_time_cost = zval_get_long(option_buffer);
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, "threads", sizeof("threads")-1)) != NULL) {
+	if (options && (option_buffer = zend_hash_str_find(options, "threads", strlen("threads"))) != NULL) {
 		new_threads = zval_get_long(option_buffer);
 	}
 
@@ -307,7 +307,7 @@ static zend_string *php_password_argon2_hash(const zend_string *password, zend_a
 	size_t encoded_len;
 	int status = 0;
 
-	if (options && (option_buffer = zend_hash_str_find(options, "memory_cost", sizeof("memory_cost")-1)) != NULL) {
+	if (options && (option_buffer = zend_hash_str_find(options, "memory_cost", strlen("memory_cost"))) != NULL) {
 		memory_cost = zval_get_long(option_buffer);
 	}
 
@@ -316,7 +316,7 @@ static zend_string *php_password_argon2_hash(const zend_string *password, zend_a
 		return NULL;
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, "time_cost", sizeof("time_cost")-1)) != NULL) {
+	if (options && (option_buffer = zend_hash_str_find(options, "time_cost", strlen("time_cost"))) != NULL) {
 		time_cost = zval_get_long(option_buffer);
 	}
 
@@ -325,7 +325,7 @@ static zend_string *php_password_argon2_hash(const zend_string *password, zend_a
 		return NULL;
 	}
 
-	if (options && (option_buffer = zend_hash_str_find(options, "threads", sizeof("threads")-1)) != NULL) {
+	if (options && (option_buffer = zend_hash_str_find(options, "threads", strlen("threads"))) != NULL) {
 		threads = zval_get_long(option_buffer);
 	}
 
@@ -501,14 +501,14 @@ static const php_password_algo* php_password_algo_find_zval(zend_string *arg_str
 #else
 		case 2:
 			{
-			zend_string *n = zend_string_init("argon2i", sizeof("argon2i")-1, 0);
+			zend_string *n = zend_string_init("argon2i", strlen("argon2i"), 0);
 			const php_password_algo* ret = php_password_algo_find(n);
 			zend_string_release(n);
 			return ret;
 			}
 		case 3:
 			{
-			zend_string *n = zend_string_init("argon2id", sizeof("argon2id")-1, 0);
+			zend_string *n = zend_string_init("argon2id", strlen("argon2id"), 0);
 			const php_password_algo* ret = php_password_algo_find(n);
 			zend_string_release(n);
 			return ret;

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -913,7 +913,7 @@ static int parse_context_params(php_stream_context *context, HashTable *params)
 	int ret = SUCCESS;
 	zval *tmp;
 
-	if (NULL != (tmp = zend_hash_str_find(params, "notification", sizeof("notification")-1))) {
+	if (NULL != (tmp = zend_hash_str_find(params, "notification", strlen("notification")))) {
 
 		if (context->notifier) {
 			php_stream_notification_free(context->notifier);
@@ -925,7 +925,7 @@ static int parse_context_params(php_stream_context *context, HashTable *params)
 		ZVAL_COPY(&context->notifier->ptr, tmp);
 		context->notifier->dtor = user_space_stream_notifier_dtor;
 	}
-	if (NULL != (tmp = zend_hash_str_find(params, "options", sizeof("options")-1))) {
+	if (NULL != (tmp = zend_hash_str_find(params, "options", strlen("options")))) {
 		if (Z_TYPE_P(tmp) == IS_ARRAY) {
 			return parse_context_options(context, Z_ARRVAL_P(tmp));
 		} else {
@@ -1080,10 +1080,10 @@ PHP_FUNCTION(stream_context_get_params)
 	array_init(return_value);
 	if (context->notifier && Z_TYPE(context->notifier->ptr) != IS_UNDEF && context->notifier->func == user_space_stream_notifier) {
 		Z_TRY_ADDREF(context->notifier->ptr);
-		add_assoc_zval_ex(return_value, "notification", sizeof("notification")-1, &context->notifier->ptr);
+		add_assoc_zval_ex(return_value, "notification", strlen("notification"), &context->notifier->ptr);
 	}
 	Z_TRY_ADDREF(context->options);
-	add_assoc_zval_ex(return_value, "options", sizeof("options")-1, &context->options);
+	add_assoc_zval_ex(return_value, "options", strlen("options"), &context->options);
 }
 /* }}} */
 

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -4598,7 +4598,7 @@ PHP_FUNCTION(nl2br)
 	}
 
 	{
-		size_t repl_len = is_xhtml ? (sizeof("<br />") - 1) : (sizeof("<br>") - 1);
+		size_t repl_len = is_xhtml ? (strlen("<br />")) : (strlen("<br>"));
 
 		result = zend_string_safe_alloc(repl_cnt, repl_len, ZSTR_LEN(str), 0);
 		target = ZSTR_VAL(result);
@@ -5458,8 +5458,8 @@ PHP_FUNCTION(localeconv)
 		add_assoc_long(  return_value, "n_sign_posn",       currlocdata.n_sign_posn);
 	}
 
-	zend_hash_str_update(Z_ARRVAL_P(return_value), "grouping", sizeof("grouping")-1, &grouping);
-	zend_hash_str_update(Z_ARRVAL_P(return_value), "mon_grouping", sizeof("mon_grouping")-1, &mon_grouping);
+	zend_hash_str_update(Z_ARRVAL_P(return_value), "grouping", strlen("grouping"), &grouping);
+	zend_hash_str_update(Z_ARRVAL_P(return_value), "mon_grouping", strlen("mon_grouping"), &mon_grouping);
 }
 /* }}} */
 

--- a/ext/standard/url_scanner_ex.re
+++ b/ext/standard/url_scanner_ex.re
@@ -458,7 +458,7 @@ static inline void handle_tag(STD_PARA)
     /* intentionally using str_find here, in case the hash value is set, but the string val is changed later */
 	if ((ctx->lookup_data = zend_hash_str_find_ptr(ctx->tags, ZSTR_VAL(ctx->tag.s), ZSTR_LEN(ctx->tag.s))) != NULL) {
 		ok = 1;
-		if (ZSTR_LEN(ctx->tag.s) == sizeof("form")-1
+		if (ZSTR_LEN(ctx->tag.s) == strlen("form")
 			&& !strncasecmp(ZSTR_VAL(ctx->tag.s), "form", ZSTR_LEN(ctx->tag.s))) {
 			ctx->tag_type = TAG_FORM;
 		} else {

--- a/ext/standard/user_filters.c
+++ b/ext/standard/user_filters.c
@@ -118,7 +118,7 @@ static void userfilter_dtor(php_stream_filter *thisfilter)
 		return;
 	}
 
-	zend_string *func_name = zend_string_init("onclose", sizeof("onclose")-1, 0);
+	zend_string *func_name = zend_string_init("onclose", strlen("onclose"), 0);
 	zend_call_method_if_exists(Z_OBJ_P(obj), func_name, &retval, 0, NULL);
 	zend_string_release(func_name);
 
@@ -153,7 +153,7 @@ php_stream_filter_status_t userfilter_filter(
 	uint32_t orig_no_fclose = stream->flags & PHP_STREAM_FLAG_NO_FCLOSE;
 	stream->flags |= PHP_STREAM_FLAG_NO_FCLOSE;
 
-	zval *stream_prop = zend_hash_str_find_ind(Z_OBJPROP_P(obj), "stream", sizeof("stream")-1);
+	zval *stream_prop = zend_hash_str_find_ind(Z_OBJPROP_P(obj), "stream", strlen("stream"));
 	if (stream_prop) {
 		/* Give the userfilter class a hook back to the stream */
 		zval_ptr_dtor(stream_prop);
@@ -161,7 +161,7 @@ php_stream_filter_status_t userfilter_filter(
 		Z_ADDREF_P(stream_prop);
 	}
 
-	ZVAL_STRINGL(&func_name, "filter", sizeof("filter")-1);
+	ZVAL_STRINGL(&func_name, "filter", strlen("filter"));
 
 	/* Setup calling arguments */
 	ZVAL_RES(&args[0], zend_register_resource(buckets_in, le_bucket_brigade));
@@ -319,7 +319,7 @@ static php_stream_filter *user_filter_factory_create(const char *filtername,
 	}
 
 	/* invoke the constructor */
-	zend_string *func_name = zend_string_init("oncreate", sizeof("oncreate")-1, 0);
+	zend_string *func_name = zend_string_init("oncreate", strlen("oncreate"), 0);
 	zend_call_method_if_exists(Z_OBJ(obj), func_name, &retval, 0, NULL);
 	zend_string_release(func_name);
 
@@ -400,7 +400,7 @@ static void php_stream_bucket_attach(int append, INTERNAL_FUNCTION_PARAMETERS)
 		Z_PARAM_OBJECT(zobject)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (NULL == (pzbucket = zend_hash_str_find_deref(Z_OBJPROP_P(zobject), "bucket", sizeof("bucket")-1))) {
+	if (NULL == (pzbucket = zend_hash_str_find_deref(Z_OBJPROP_P(zobject), "bucket", strlen("bucket")))) {
 		zend_argument_value_error(2, "must be an object that has a \"bucket\" property");
 		RETURN_THROWS();
 	}
@@ -414,7 +414,7 @@ static void php_stream_bucket_attach(int append, INTERNAL_FUNCTION_PARAMETERS)
 		RETURN_THROWS();
 	}
 
-	if (NULL != (pzdata = zend_hash_str_find_deref(Z_OBJPROP_P(zobject), "data", sizeof("data")-1)) && Z_TYPE_P(pzdata) == IS_STRING) {
+	if (NULL != (pzdata = zend_hash_str_find_deref(Z_OBJPROP_P(zobject), "data", strlen("data"))) && Z_TYPE_P(pzdata) == IS_STRING) {
 		if (!bucket->own_buf) {
 			bucket = php_stream_bucket_make_writeable(bucket);
 		}

--- a/ext/standard/user_filters_arginfo.h
+++ b/ext/standard/user_filters_arginfo.h
@@ -36,19 +36,19 @@ static zend_class_entry *register_class_php_user_filter(void)
 
 	zval property_filtername_default_value;
 	ZVAL_EMPTY_STRING(&property_filtername_default_value);
-	zend_string *property_filtername_name = zend_string_init("filtername", sizeof("filtername") - 1, 1);
+	zend_string *property_filtername_name = zend_string_init("filtername", strlen("filtername"), 1);
 	zend_declare_typed_property(class_entry, property_filtername_name, &property_filtername_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_filtername_name);
 
 	zval property_params_default_value;
 	ZVAL_EMPTY_STRING(&property_params_default_value);
-	zend_string *property_params_name = zend_string_init("params", sizeof("params") - 1, 1);
+	zend_string *property_params_name = zend_string_init("params", strlen("params"), 1);
 	zend_declare_typed_property(class_entry, property_params_name, &property_params_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_params_name);
 
 	zval property_stream_default_value;
 	ZVAL_NULL(&property_stream_default_value);
-	zend_string *property_stream_name = zend_string_init("stream", sizeof("stream") - 1, 1);
+	zend_string *property_stream_name = zend_string_init("stream", strlen("stream"), 1);
 	zend_declare_property_ex(class_entry, property_stream_name, &property_stream_default_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(property_stream_name);
 

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -1347,7 +1347,7 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 	if (options != NULL) {
 		zval *classes, *max_depth;
 
-		classes = zend_hash_str_find_deref(options, "allowed_classes", sizeof("allowed_classes")-1);
+		classes = zend_hash_str_find_deref(options, "allowed_classes", strlen("allowed_classes"));
 		if (classes && Z_TYPE_P(classes) != IS_ARRAY && Z_TYPE_P(classes) != IS_TRUE && Z_TYPE_P(classes) != IS_FALSE) {
 			zend_type_error("%s(): Option \"allowed_classes\" must be of type array|bool, %s given", function_name, zend_zval_type_name(classes));
 			goto cleanup;
@@ -1375,7 +1375,7 @@ PHPAPI void php_unserialize_with_options(zval *return_value, const char *buf, co
 		}
 		php_var_unserialize_set_allowed_classes(var_hash, class_hash);
 
-		max_depth = zend_hash_str_find_deref(options, "max_depth", sizeof("max_depth") - 1);
+		max_depth = zend_hash_str_find_deref(options, "max_depth", strlen("max_depth"));
 		if (max_depth) {
 			if (Z_TYPE_P(max_depth) != IS_LONG) {
 				zend_type_error("%s(): Option \"max_depth\" must be of type int, %s given", function_name, zend_zval_type_name(max_depth));

--- a/ext/sysvmsg/sysvmsg.c
+++ b/ext/sysvmsg/sysvmsg.c
@@ -154,16 +154,16 @@ PHP_FUNCTION(msg_set_queue)
 		zval *item;
 
 		/* now pull out members of data and set them in the stat buffer */
-		if ((item = zend_hash_str_find(Z_ARRVAL_P(data), "msg_perm.uid", sizeof("msg_perm.uid") - 1)) != NULL) {
+		if ((item = zend_hash_str_find(Z_ARRVAL_P(data), "msg_perm.uid", strlen("msg_perm.uid"))) != NULL) {
 			stat.msg_perm.uid = zval_get_long(item);
 		}
-		if ((item = zend_hash_str_find(Z_ARRVAL_P(data), "msg_perm.gid", sizeof("msg_perm.gid") - 1)) != NULL) {
+		if ((item = zend_hash_str_find(Z_ARRVAL_P(data), "msg_perm.gid", strlen("msg_perm.gid"))) != NULL) {
 			stat.msg_perm.gid = zval_get_long(item);
 		}
-		if ((item = zend_hash_str_find(Z_ARRVAL_P(data), "msg_perm.mode", sizeof("msg_perm.mode") - 1)) != NULL) {
+		if ((item = zend_hash_str_find(Z_ARRVAL_P(data), "msg_perm.mode", strlen("msg_perm.mode"))) != NULL) {
 			stat.msg_perm.mode = zval_get_long(item);
 		}
-		if ((item = zend_hash_str_find(Z_ARRVAL_P(data), "msg_qbytes", sizeof("msg_qbytes") - 1)) != NULL) {
+		if ((item = zend_hash_str_find(Z_ARRVAL_P(data), "msg_qbytes", strlen("msg_qbytes"))) != NULL) {
 			stat.msg_qbytes = zval_get_long(item);
 		}
 		if (msgctl(mq->id, IPC_SET, &stat) == 0) {

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -597,7 +597,7 @@ static void tidy_doc_update_properties(PHPTidyObj *obj)
 			rebuild_object_properties(&obj->std);
 		}
 		ZVAL_STRINGL(&temp, (char*)output.bp, output.size-1);
-		zend_hash_str_update(obj->std.properties, "value", sizeof("value") - 1, &temp);
+		zend_hash_str_update(obj->std.properties, "value", strlen("value"), &temp);
 	}
 
 	tidyBufFree(&output);
@@ -607,7 +607,7 @@ static void tidy_doc_update_properties(PHPTidyObj *obj)
 			rebuild_object_properties(&obj->std);
 		}
 		ZVAL_STRINGL(&temp, (char*)obj->ptdoc->errbuf->bp, obj->ptdoc->errbuf->size-1);
-		zend_hash_str_update(obj->std.properties, "errorBuffer", sizeof("errorBuffer") - 1, &temp);
+		zend_hash_str_update(obj->std.properties, "errorBuffer", strlen("errorBuffer"), &temp);
 	}
 }
 
@@ -664,7 +664,7 @@ static void tidy_add_default_properties(PHPTidyObj *obj, tidy_obj_type type)
 			} else {
 				ZVAL_NULL(&attribute);
 			}
-			zend_hash_str_update(obj->std.properties, "attribute", sizeof("attribute") - 1, &attribute);
+			zend_hash_str_update(obj->std.properties, "attribute", strlen("attribute"), &attribute);
 
 			tempnode = tidyGetChild(obj->node);
 
@@ -687,7 +687,7 @@ static void tidy_add_default_properties(PHPTidyObj *obj, tidy_obj_type type)
 				ZVAL_NULL(&children);
 			}
 
-			zend_hash_str_update(obj->std.properties, "child", sizeof("child") - 1, &children);
+			zend_hash_str_update(obj->std.properties, "child", strlen("child"), &children);
 
 			break;
 

--- a/ext/tokenizer/tokenizer.c
+++ b/ext/tokenizer/tokenizer.c
@@ -426,7 +426,7 @@ void on_event(
 			/* Special cases */
 			if (token == ';' && LANG_SCNG(yy_leng) > 1) { /* ?> or ?>\n or ?>\r\n */
 				token = T_CLOSE_TAG;
-			} else if (token == T_ECHO && LANG_SCNG(yy_leng) == sizeof("<?=") - 1) {
+			} else if (token == T_ECHO && LANG_SCNG(yy_leng) == strlen("<?=")) {
 				token = T_OPEN_TAG_WITH_ECHO;
 			}
 			add_token(

--- a/ext/tokenizer/tokenizer_arginfo.h
+++ b/ext/tokenizer/tokenizer_arginfo.h
@@ -70,25 +70,25 @@ static zend_class_entry *register_class_PhpToken(zend_class_entry *class_entry_S
 
 	zval property_id_default_value;
 	ZVAL_UNDEF(&property_id_default_value);
-	zend_string *property_id_name = zend_string_init("id", sizeof("id") - 1, 1);
+	zend_string *property_id_name = zend_string_init("id", strlen("id"), 1);
 	zend_declare_typed_property(class_entry, property_id_name, &property_id_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_id_name);
 
 	zval property_text_default_value;
 	ZVAL_UNDEF(&property_text_default_value);
-	zend_string *property_text_name = zend_string_init("text", sizeof("text") - 1, 1);
+	zend_string *property_text_name = zend_string_init("text", strlen("text"), 1);
 	zend_declare_typed_property(class_entry, property_text_name, &property_text_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_text_name);
 
 	zval property_line_default_value;
 	ZVAL_UNDEF(&property_line_default_value);
-	zend_string *property_line_name = zend_string_init("line", sizeof("line") - 1, 1);
+	zend_string *property_line_name = zend_string_init("line", strlen("line"), 1);
 	zend_declare_typed_property(class_entry, property_line_name, &property_line_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_line_name);
 
 	zval property_pos_default_value;
 	ZVAL_UNDEF(&property_pos_default_value);
-	zend_string *property_pos_name = zend_string_init("pos", sizeof("pos") - 1, 1);
+	zend_string *property_pos_name = zend_string_init("pos", strlen("pos"), 1);
 	zend_declare_typed_property(class_entry, property_pos_name, &property_pos_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_pos_name);
 

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -688,7 +688,7 @@ void _xml_startElementHandler(void *userData, const XML_Char *name, const XML_Ch
 				}
 
 				if (atcnt) {
-					zend_hash_str_add(Z_ARRVAL(tag), "attributes", sizeof("attributes") - 1, &atr);
+					zend_hash_str_add(Z_ARRVAL(tag), "attributes", strlen("attributes"), &atr);
 				} else {
 					zval_ptr_dtor(&atr);
 				}
@@ -795,7 +795,7 @@ void _xml_characterDataHandler(void *userData, const XML_Char *s, int len)
 				zval *myval;
 
 				/* check if the current tag already has a value - if yes append to that! */
-				if ((myval = zend_hash_str_find(Z_ARRVAL_P(parser->ctag), "value", sizeof("value") - 1))) {
+				if ((myval = zend_hash_str_find(Z_ARRVAL_P(parser->ctag), "value", strlen("value")))) {
 					size_t newlen = Z_STRLEN_P(myval) + ZSTR_LEN(decoded_value);
 					Z_STR_P(myval) = zend_string_extend(Z_STR_P(myval), newlen, 0);
 					strncpy(Z_STRVAL_P(myval) + Z_STRLEN_P(myval) - ZSTR_LEN(decoded_value),
@@ -814,9 +814,9 @@ void _xml_characterDataHandler(void *userData, const XML_Char *s, int len)
 				zval *curtag, *mytype, *myval;
 
 				ZEND_HASH_REVERSE_FOREACH_VAL(Z_ARRVAL(parser->data), curtag) {
-					if ((mytype = zend_hash_str_find(Z_ARRVAL_P(curtag),"type", sizeof("type") - 1))) {
+					if ((mytype = zend_hash_str_find(Z_ARRVAL_P(curtag),"type", strlen("type")))) {
 						if (zend_string_equals_literal(Z_STR_P(mytype), "cdata")) {
-							if ((myval = zend_hash_str_find(Z_ARRVAL_P(curtag), "value", sizeof("value") - 1))) {
+							if ((myval = zend_hash_str_find(Z_ARRVAL_P(curtag), "value", strlen("value")))) {
 								size_t newlen = Z_STRLEN_P(myval) + ZSTR_LEN(decoded_value);
 								Z_STR_P(myval) = zend_string_extend(Z_STR_P(myval), newlen, 0);
 								strncpy(Z_STRVAL_P(myval) + Z_STRLEN_P(myval) - ZSTR_LEN(decoded_value),

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -185,13 +185,13 @@ zval *xmlreader_write_property(zend_object *object, zend_string *name, zval *val
 /* {{{ */
 static zend_function *xmlreader_get_method(zend_object **obj, zend_string *name, const zval *key)
 {
-	if (ZSTR_LEN(name) == sizeof("open") - 1
+	if (ZSTR_LEN(name) == strlen("open")
 			&& (ZSTR_VAL(name)[0] == 'o' || ZSTR_VAL(name)[0] == 'O')
 			&& (ZSTR_VAL(name)[1] == 'p' || ZSTR_VAL(name)[1] == 'P')
 			&& (ZSTR_VAL(name)[2] == 'e' || ZSTR_VAL(name)[2] == 'E')
 			&& (ZSTR_VAL(name)[3] == 'n' || ZSTR_VAL(name)[3] == 'N')) {
 		return (zend_function*)&xmlreader_open_fn;
-	} else if (ZSTR_LEN(name) == sizeof("xml") - 1
+	} else if (ZSTR_LEN(name) == strlen("xml")
 			&& (ZSTR_VAL(name)[0] == 'x' || ZSTR_VAL(name)[0] == 'X')
 			&& (ZSTR_VAL(name)[1] == 'm' || ZSTR_VAL(name)[1] == 'M')
 			&& (ZSTR_VAL(name)[2] == 'l' || ZSTR_VAL(name)[2] == 'L')) {
@@ -1164,9 +1164,9 @@ PHP_MINIT_FUNCTION(xmlreader)
 	xmlreader_class_entry = register_class_XMLReader();
 	xmlreader_class_entry->create_object = xmlreader_objects_new;
 
-	memcpy(&xmlreader_open_fn, zend_hash_str_find_ptr(&xmlreader_class_entry->function_table, "open", sizeof("open")-1), sizeof(zend_internal_function));
+	memcpy(&xmlreader_open_fn, zend_hash_str_find_ptr(&xmlreader_class_entry->function_table, "open", strlen("open")), sizeof(zend_internal_function));
 	xmlreader_open_fn.fn_flags &= ~ZEND_ACC_STATIC;
-	memcpy(&xmlreader_xml_fn, zend_hash_str_find_ptr(&xmlreader_class_entry->function_table, "xml", sizeof("xml")-1), sizeof(zend_internal_function));
+	memcpy(&xmlreader_xml_fn, zend_hash_str_find_ptr(&xmlreader_class_entry->function_table, "xml", strlen("xml")), sizeof(zend_internal_function));
 	xmlreader_xml_fn.fn_flags &= ~ZEND_ACC_STATIC;
 
 	zend_hash_init(&xmlreader_prop_handlers, 0, NULL, php_xmlreader_free_prop_handler, 1);

--- a/ext/xmlreader/php_xmlreader_arginfo.h
+++ b/ext/xmlreader/php_xmlreader_arginfo.h
@@ -157,85 +157,85 @@ static zend_class_entry *register_class_XMLReader(void)
 
 	zval property_attributeCount_default_value;
 	ZVAL_UNDEF(&property_attributeCount_default_value);
-	zend_string *property_attributeCount_name = zend_string_init("attributeCount", sizeof("attributeCount") - 1, 1);
+	zend_string *property_attributeCount_name = zend_string_init("attributeCount", strlen("attributeCount"), 1);
 	zend_declare_typed_property(class_entry, property_attributeCount_name, &property_attributeCount_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_attributeCount_name);
 
 	zval property_baseURI_default_value;
 	ZVAL_UNDEF(&property_baseURI_default_value);
-	zend_string *property_baseURI_name = zend_string_init("baseURI", sizeof("baseURI") - 1, 1);
+	zend_string *property_baseURI_name = zend_string_init("baseURI", strlen("baseURI"), 1);
 	zend_declare_typed_property(class_entry, property_baseURI_name, &property_baseURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_baseURI_name);
 
 	zval property_depth_default_value;
 	ZVAL_UNDEF(&property_depth_default_value);
-	zend_string *property_depth_name = zend_string_init("depth", sizeof("depth") - 1, 1);
+	zend_string *property_depth_name = zend_string_init("depth", strlen("depth"), 1);
 	zend_declare_typed_property(class_entry, property_depth_name, &property_depth_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_depth_name);
 
 	zval property_hasAttributes_default_value;
 	ZVAL_UNDEF(&property_hasAttributes_default_value);
-	zend_string *property_hasAttributes_name = zend_string_init("hasAttributes", sizeof("hasAttributes") - 1, 1);
+	zend_string *property_hasAttributes_name = zend_string_init("hasAttributes", strlen("hasAttributes"), 1);
 	zend_declare_typed_property(class_entry, property_hasAttributes_name, &property_hasAttributes_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_hasAttributes_name);
 
 	zval property_hasValue_default_value;
 	ZVAL_UNDEF(&property_hasValue_default_value);
-	zend_string *property_hasValue_name = zend_string_init("hasValue", sizeof("hasValue") - 1, 1);
+	zend_string *property_hasValue_name = zend_string_init("hasValue", strlen("hasValue"), 1);
 	zend_declare_typed_property(class_entry, property_hasValue_name, &property_hasValue_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_hasValue_name);
 
 	zval property_isDefault_default_value;
 	ZVAL_UNDEF(&property_isDefault_default_value);
-	zend_string *property_isDefault_name = zend_string_init("isDefault", sizeof("isDefault") - 1, 1);
+	zend_string *property_isDefault_name = zend_string_init("isDefault", strlen("isDefault"), 1);
 	zend_declare_typed_property(class_entry, property_isDefault_name, &property_isDefault_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_isDefault_name);
 
 	zval property_isEmptyElement_default_value;
 	ZVAL_UNDEF(&property_isEmptyElement_default_value);
-	zend_string *property_isEmptyElement_name = zend_string_init("isEmptyElement", sizeof("isEmptyElement") - 1, 1);
+	zend_string *property_isEmptyElement_name = zend_string_init("isEmptyElement", strlen("isEmptyElement"), 1);
 	zend_declare_typed_property(class_entry, property_isEmptyElement_name, &property_isEmptyElement_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_BOOL));
 	zend_string_release(property_isEmptyElement_name);
 
 	zval property_localName_default_value;
 	ZVAL_UNDEF(&property_localName_default_value);
-	zend_string *property_localName_name = zend_string_init("localName", sizeof("localName") - 1, 1);
+	zend_string *property_localName_name = zend_string_init("localName", strlen("localName"), 1);
 	zend_declare_typed_property(class_entry, property_localName_name, &property_localName_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_localName_name);
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
+	zend_string *property_name_name = zend_string_init("name", strlen("name"), 1);
 	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_name_name);
 
 	zval property_namespaceURI_default_value;
 	ZVAL_UNDEF(&property_namespaceURI_default_value);
-	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", sizeof("namespaceURI") - 1, 1);
+	zend_string *property_namespaceURI_name = zend_string_init("namespaceURI", strlen("namespaceURI"), 1);
 	zend_declare_typed_property(class_entry, property_namespaceURI_name, &property_namespaceURI_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_namespaceURI_name);
 
 	zval property_nodeType_default_value;
 	ZVAL_UNDEF(&property_nodeType_default_value);
-	zend_string *property_nodeType_name = zend_string_init("nodeType", sizeof("nodeType") - 1, 1);
+	zend_string *property_nodeType_name = zend_string_init("nodeType", strlen("nodeType"), 1);
 	zend_declare_typed_property(class_entry, property_nodeType_name, &property_nodeType_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_nodeType_name);
 
 	zval property_prefix_default_value;
 	ZVAL_UNDEF(&property_prefix_default_value);
-	zend_string *property_prefix_name = zend_string_init("prefix", sizeof("prefix") - 1, 1);
+	zend_string *property_prefix_name = zend_string_init("prefix", strlen("prefix"), 1);
 	zend_declare_typed_property(class_entry, property_prefix_name, &property_prefix_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_prefix_name);
 
 	zval property_value_default_value;
 	ZVAL_UNDEF(&property_value_default_value);
-	zend_string *property_value_name = zend_string_init("value", sizeof("value") - 1, 1);
+	zend_string *property_value_name = zend_string_init("value", strlen("value"), 1);
 	zend_declare_typed_property(class_entry, property_value_name, &property_value_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_value_name);
 
 	zval property_xmlLang_default_value;
 	ZVAL_UNDEF(&property_xmlLang_default_value);
-	zend_string *property_xmlLang_name = zend_string_init("xmlLang", sizeof("xmlLang") - 1, 1);
+	zend_string *property_xmlLang_name = zend_string_init("xmlLang", strlen("xmlLang"), 1);
 	zend_declare_typed_property(class_entry, property_xmlLang_name, &property_xmlLang_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_xmlLang_name);
 

--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -117,7 +117,7 @@ static char *_xmlwriter_get_valid_file_path(char *source, char *resolved_path, i
 	if (uri->scheme != NULL) {
 		/* absolute file uris - libxml only supports localhost or empty host */
 		if (strncasecmp(source, "file:///", 8) == 0) {
-			if (source[sizeof("file:///") - 1] == '\0') {
+			if (source[strlen("file:///")] == '\0') {
 				xmlFreeURI(uri);
 				return NULL;
 			}
@@ -128,7 +128,7 @@ static char *_xmlwriter_get_valid_file_path(char *source, char *resolved_path, i
 			source += 7;
 #endif
 		} else if (strncasecmp(source, "file://localhost/",17) == 0) {
-			if (source[sizeof("file://localhost/") - 1] == '\0') {
+			if (source[strlen("file://localhost/")] == '\0') {
 				xmlFreeURI(uri);
 				return NULL;
 			}

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -347,7 +347,7 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 
 	intern = Z_XSL_P(id);
 
-	member = zend_string_init("cloneDocument", sizeof("cloneDocument")-1, 0);
+	member = zend_string_init("cloneDocument", strlen("cloneDocument"), 0);
 	cloneDocu = zend_std_read_property(Z_OBJ_P(id), member, BP_VAR_IS, NULL, &rv);
 	if (Z_TYPE_P(cloneDocu) != IS_NULL) {
 		convert_to_long(cloneDocu);
@@ -448,7 +448,7 @@ static xmlDocPtr php_xsl_apply_stylesheet(zval *id, xsl_object *intern, xsltStyl
 	ctxt = xsltNewTransformContext(style, doc);
 	ctxt->_private = (void *) intern;
 
-	member = zend_string_init("doXInclude", sizeof("doXInclude")-1, 0);
+	member = zend_string_init("doXInclude", strlen("doXInclude"), 0);
 	doXInclude = zend_std_read_property(Z_OBJ_P(id), member, BP_VAR_IS, NULL, &rv);
 	if (Z_TYPE_P(doXInclude) != IS_NULL) {
 		convert_to_long(doXInclude);

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -525,7 +525,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_attribute *attr;
 
 		attr = zend_add_parameter_attribute(
-			zend_hash_str_find_ptr(CG(function_table), "zend_test_parameter_with_attribute", sizeof("zend_test_parameter_with_attribute") - 1),
+			zend_hash_str_find_ptr(CG(function_table), "zend_test_parameter_with_attribute", strlen("zend_test_parameter_with_attribute")),
 			0,
 			zend_test_parameter_attribute->name,
 			1
@@ -540,7 +540,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_attribute *attr;
 
 		attr = zend_add_parameter_attribute(
-			zend_hash_str_find_ptr(&zend_test_class_with_method_with_parameter_attribute->function_table, "no_override", sizeof("no_override") - 1),
+			zend_hash_str_find_ptr(&zend_test_class_with_method_with_parameter_attribute->function_table, "no_override", strlen("no_override")),
 			0,
 			zend_test_parameter_attribute->name,
 			1
@@ -549,7 +549,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		ZVAL_PSTRING(&attr->args[0].value, "value2");
 
 		attr = zend_add_parameter_attribute(
-			zend_hash_str_find_ptr(&zend_test_class_with_method_with_parameter_attribute->function_table, "override", sizeof("override") - 1),
+			zend_hash_str_find_ptr(&zend_test_class_with_method_with_parameter_attribute->function_table, "override", strlen("override")),
 			0,
 			zend_test_parameter_attribute->name,
 			1
@@ -564,7 +564,7 @@ PHP_MINIT_FUNCTION(zend_test)
 		zend_attribute *attr;
 
 		attr = zend_add_parameter_attribute(
-			zend_hash_str_find_ptr(&zend_test_child_class_with_method_with_parameter_attribute->function_table, "override", sizeof("override") - 1),
+			zend_hash_str_find_ptr(&zend_test_child_class_with_method_with_parameter_attribute->function_table, "override", strlen("override")),
 			0,
 			zend_test_parameter_attribute->name,
 			1

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -270,31 +270,31 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 
 	zval property__StaticProp_default_value;
 	ZVAL_NULL(&property__StaticProp_default_value);
-	zend_string *property__StaticProp_name = zend_string_init("_StaticProp", sizeof("_StaticProp") - 1, 1);
+	zend_string *property__StaticProp_name = zend_string_init("_StaticProp", strlen("_StaticProp"), 1);
 	zend_declare_property_ex(class_entry, property__StaticProp_name, &property__StaticProp_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL);
 	zend_string_release(property__StaticProp_name);
 
 	zval property_staticIntProp_default_value;
 	ZVAL_LONG(&property_staticIntProp_default_value, 123);
-	zend_string *property_staticIntProp_name = zend_string_init("staticIntProp", sizeof("staticIntProp") - 1, 1);
+	zend_string *property_staticIntProp_name = zend_string_init("staticIntProp", strlen("staticIntProp"), 1);
 	zend_declare_typed_property(class_entry, property_staticIntProp_name, &property_staticIntProp_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_staticIntProp_name);
 
 	zval property_intProp_default_value;
 	ZVAL_LONG(&property_intProp_default_value, 123);
-	zend_string *property_intProp_name = zend_string_init("intProp", sizeof("intProp") - 1, 1);
+	zend_string *property_intProp_name = zend_string_init("intProp", strlen("intProp"), 1);
 	zend_declare_typed_property(class_entry, property_intProp_name, &property_intProp_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_intProp_name);
 
-	zend_string *property_classProp_class_stdClass = zend_string_init("stdClass", sizeof("stdClass")-1, 1);
+	zend_string *property_classProp_class_stdClass = zend_string_init("stdClass", strlen("stdClass"), 1);
 	zval property_classProp_default_value;
 	ZVAL_NULL(&property_classProp_default_value);
-	zend_string *property_classProp_name = zend_string_init("classProp", sizeof("classProp") - 1, 1);
+	zend_string *property_classProp_name = zend_string_init("classProp", strlen("classProp"), 1);
 	zend_declare_typed_property(class_entry, property_classProp_name, &property_classProp_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_classProp_class_stdClass, 0, MAY_BE_NULL));
 	zend_string_release(property_classProp_name);
 
-	zend_string *property_classUnionProp_class_stdClass = zend_string_init("stdClass", sizeof("stdClass") - 1, 1);
-	zend_string *property_classUnionProp_class_Iterator = zend_string_init("Iterator", sizeof("Iterator") - 1, 1);
+	zend_string *property_classUnionProp_class_stdClass = zend_string_init("stdClass", strlen("stdClass"), 1);
+	zend_string *property_classUnionProp_class_Iterator = zend_string_init("Iterator", strlen("Iterator"), 1);
 	zend_type_list *property_classUnionProp_type_list = malloc(ZEND_TYPE_LIST_SIZE(2));
 	property_classUnionProp_type_list->num_types = 2;
 	property_classUnionProp_type_list->types[0] = (zend_type) ZEND_TYPE_INIT_CLASS(property_classUnionProp_class_stdClass, 0, 0);
@@ -302,13 +302,13 @@ static zend_class_entry *register_class__ZendTestClass(zend_class_entry *class_e
 	zend_type property_classUnionProp_type = ZEND_TYPE_INIT_UNION(property_classUnionProp_type_list, MAY_BE_NULL);
 	zval property_classUnionProp_default_value;
 	ZVAL_NULL(&property_classUnionProp_default_value);
-	zend_string *property_classUnionProp_name = zend_string_init("classUnionProp", sizeof("classUnionProp") - 1, 1);
+	zend_string *property_classUnionProp_name = zend_string_init("classUnionProp", strlen("classUnionProp"), 1);
 	zend_declare_typed_property(class_entry, property_classUnionProp_name, &property_classUnionProp_default_value, ZEND_ACC_PUBLIC, NULL, property_classUnionProp_type);
 	zend_string_release(property_classUnionProp_name);
 
 	zval property_readonlyProp_default_value;
 	ZVAL_UNDEF(&property_readonlyProp_default_value);
-	zend_string *property_readonlyProp_name = zend_string_init("readonlyProp", sizeof("readonlyProp") - 1, 1);
+	zend_string *property_readonlyProp_name = zend_string_init("readonlyProp", strlen("readonlyProp"), 1);
 	zend_declare_typed_property(class_entry, property_readonlyProp_name, &property_readonlyProp_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_readonlyProp_name);
 
@@ -335,7 +335,7 @@ static zend_class_entry *register_class__ZendTestTrait(void)
 
 	zval property_testProp_default_value;
 	ZVAL_NULL(&property_testProp_default_value);
-	zend_string *property_testProp_name = zend_string_init("testProp", sizeof("testProp") - 1, 1);
+	zend_string *property_testProp_name = zend_string_init("testProp", strlen("testProp"), 1);
 	zend_declare_property_ex(class_entry, property_testProp_name, &property_testProp_default_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(property_testProp_name);
 
@@ -363,7 +363,7 @@ static zend_class_entry *register_class_ZendTestParameterAttribute(void)
 
 	zval property_parameter_default_value;
 	ZVAL_UNDEF(&property_parameter_default_value);
-	zend_string *property_parameter_name = zend_string_init("parameter", sizeof("parameter") - 1, 1);
+	zend_string *property_parameter_name = zend_string_init("parameter", strlen("parameter"), 1);
 	zend_declare_typed_property(class_entry, property_parameter_name, &property_parameter_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_parameter_name);
 
@@ -406,17 +406,17 @@ static zend_class_entry *register_class_ZendTestStringEnum(void)
 	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestStringEnum", IS_STRING, class_ZendTestStringEnum_methods);
 
 	zval enum_case_Foo_value;
-	zend_string *enum_case_Foo_value_str = zend_string_init("Test1", sizeof("Test1") - 1, 1);
+	zend_string *enum_case_Foo_value_str = zend_string_init("Test1", strlen("Test1"), 1);
 	ZVAL_STR(&enum_case_Foo_value, enum_case_Foo_value_str);
 	zend_enum_add_case_cstr(class_entry, "Foo", &enum_case_Foo_value);
 
 	zval enum_case_Bar_value;
-	zend_string *enum_case_Bar_value_str = zend_string_init("Test2", sizeof("Test2") - 1, 1);
+	zend_string *enum_case_Bar_value_str = zend_string_init("Test2", strlen("Test2"), 1);
 	ZVAL_STR(&enum_case_Bar_value, enum_case_Bar_value_str);
 	zend_enum_add_case_cstr(class_entry, "Bar", &enum_case_Bar_value);
 
 	zval enum_case_Baz_value;
-	zend_string *enum_case_Baz_value_str = zend_string_init("Test2\\a", sizeof("Test2\\a") - 1, 1);
+	zend_string *enum_case_Baz_value_str = zend_string_init("Test2\\a", strlen("Test2\\a"), 1);
 	ZVAL_STR(&enum_case_Baz_value, enum_case_Baz_value_str);
 	zend_enum_add_case_cstr(class_entry, "Baz", &enum_case_Baz_value);
 
@@ -440,10 +440,10 @@ static zend_class_entry *register_class_ZendTestNS2_Foo(void)
 	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS2", "Foo", class_ZendTestNS2_Foo_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 
-	zend_string *property_foo_class_ZendTestNS2_ZendSubNS_Foo = zend_string_init("ZendTestNS2\\ZendSubNS\\Foo", sizeof("ZendTestNS2\\ZendSubNS\\Foo")-1, 1);
+	zend_string *property_foo_class_ZendTestNS2_ZendSubNS_Foo = zend_string_init("ZendTestNS2\\ZendSubNS\\Foo", strlen("ZendTestNS2\\ZendSubNS\\Foo"), 1);
 	zval property_foo_default_value;
 	ZVAL_UNDEF(&property_foo_default_value);
-	zend_string *property_foo_name = zend_string_init("foo", sizeof("foo") - 1, 1);
+	zend_string *property_foo_name = zend_string_init("foo", strlen("foo"), 1);
 	zend_declare_typed_property(class_entry, property_foo_name, &property_foo_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_foo_class_ZendTestNS2_ZendSubNS_Foo, 0, 0));
 	zend_string_release(property_foo_name);
 

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -350,7 +350,7 @@ static int php_zip_parse_options(HashTable *options, zip_options *opts)
 	opts->enc_method = -1;  /* -1 to not change default */
 #endif
 
-	if ((option = zend_hash_str_find(options, "remove_all_path", sizeof("remove_all_path") - 1)) != NULL) {
+	if ((option = zend_hash_str_find(options, "remove_all_path", strlen("remove_all_path"))) != NULL) {
 		if (Z_TYPE_P(option) != IS_FALSE && Z_TYPE_P(option) != IS_TRUE) {
 			php_error_docref(NULL, E_WARNING, "Option \"remove_all_path\" must be of type bool, %s given",
 				zend_zval_type_name(option));
@@ -358,14 +358,14 @@ static int php_zip_parse_options(HashTable *options, zip_options *opts)
 		opts->remove_all_path = zval_get_long(option);
 	}
 
-	if ((option = zend_hash_str_find(options, "comp_method", sizeof("comp_method") - 1)) != NULL) {
+	if ((option = zend_hash_str_find(options, "comp_method", strlen("comp_method"))) != NULL) {
 		if (Z_TYPE_P(option) != IS_LONG) {
 			php_error_docref(NULL, E_WARNING, "Option \"comp_method\" must be of type int, %s given",
 				zend_zval_type_name(option));
 		}
 		opts->comp_method = zval_get_long(option);
 
-		if ((option = zend_hash_str_find(options, "comp_flags", sizeof("comp_flags") - 1)) != NULL) {
+		if ((option = zend_hash_str_find(options, "comp_flags", strlen("comp_flags"))) != NULL) {
 			if (Z_TYPE_P(option) != IS_LONG) {
 				php_error_docref(NULL, E_WARNING, "Option \"comp_flags\" must be of type int, %s given",
 					zend_zval_type_name(option));
@@ -375,14 +375,14 @@ static int php_zip_parse_options(HashTable *options, zip_options *opts)
 	}
 
 #ifdef HAVE_ENCRYPTION
-	if ((option = zend_hash_str_find(options, "enc_method", sizeof("enc_method") - 1)) != NULL) {
+	if ((option = zend_hash_str_find(options, "enc_method", strlen("enc_method"))) != NULL) {
 		if (Z_TYPE_P(option) != IS_LONG) {
 			php_error_docref(NULL, E_WARNING, "Option \"enc_method\" must be of type int, %s given",
 				zend_zval_type_name(option));
 		}
 		opts->enc_method = zval_get_long(option);
 
-		if ((option = zend_hash_str_find(options, "enc_password", sizeof("enc_password") - 1)) != NULL) {
+		if ((option = zend_hash_str_find(options, "enc_password", strlen("enc_password"))) != NULL) {
 			if (Z_TYPE_P(option) != IS_STRING) {
 				zend_type_error("Option \"enc_password\" must be of type string, %s given",
 					zend_zval_type_name(option));
@@ -393,7 +393,7 @@ static int php_zip_parse_options(HashTable *options, zip_options *opts)
 	}
 #endif
 
-	if ((option = zend_hash_str_find(options, "remove_path", sizeof("remove_path") - 1)) != NULL) {
+	if ((option = zend_hash_str_find(options, "remove_path", strlen("remove_path"))) != NULL) {
 		if (Z_TYPE_P(option) != IS_STRING) {
 			zend_type_error("Option \"remove_path\" must be of type string, %s given",
 				zend_zval_type_name(option));
@@ -413,7 +413,7 @@ static int php_zip_parse_options(HashTable *options, zip_options *opts)
 		opts->remove_path = Z_STRVAL_P(option);
 	}
 
-	if ((option = zend_hash_str_find(options, "add_path", sizeof("add_path") - 1)) != NULL) {
+	if ((option = zend_hash_str_find(options, "add_path", strlen("add_path"))) != NULL) {
 		if (Z_TYPE_P(option) != IS_STRING) {
 			zend_type_error("Option \"add_path\" must be of type string, %s given",
 				zend_zval_type_name(option));
@@ -433,7 +433,7 @@ static int php_zip_parse_options(HashTable *options, zip_options *opts)
 		opts->add_path = Z_STRVAL_P(option);
 	}
 
-	if ((option = zend_hash_str_find(options, "flags", sizeof("flags") - 1)) != NULL) {
+	if ((option = zend_hash_str_find(options, "flags", strlen("flags"))) != NULL) {
 		if (Z_TYPE_P(option) != IS_LONG) {
 			zend_type_error("Option \"flags\" must be of type int, %s given",
 				zend_zval_type_name(option));
@@ -3245,9 +3245,9 @@ static PHP_MINIT_FUNCTION(zip)
 	REGISTER_ZIP_CLASS_CONST_LONG("EM_UNKNOWN",				ZIP_EM_UNKNOWN);
 
 #ifdef HAVE_LIBZIP_VERSION
-	zend_declare_class_constant_string(zip_class_entry, "LIBZIP_VERSION", sizeof("LIBZIP_VERSION")-1, zip_libzip_version());
+	zend_declare_class_constant_string(zip_class_entry, "LIBZIP_VERSION", strlen("LIBZIP_VERSION"), zip_libzip_version());
 #else
-	zend_declare_class_constant_string(zip_class_entry, "LIBZIP_VERSION", sizeof("LIBZIP_VERSION")-1, LIBZIP_VERSION);
+	zend_declare_class_constant_string(zip_class_entry, "LIBZIP_VERSION", strlen("LIBZIP_VERSION"), LIBZIP_VERSION);
 #endif
 
 	php_register_url_stream_wrapper("zip", &php_stream_zip_wrapper);

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -496,37 +496,37 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 
 	zval property_lastId_default_value;
 	ZVAL_UNDEF(&property_lastId_default_value);
-	zend_string *property_lastId_name = zend_string_init("lastId", sizeof("lastId") - 1, 1);
+	zend_string *property_lastId_name = zend_string_init("lastId", strlen("lastId"), 1);
 	zend_declare_typed_property(class_entry, property_lastId_name, &property_lastId_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_lastId_name);
 
 	zval property_status_default_value;
 	ZVAL_UNDEF(&property_status_default_value);
-	zend_string *property_status_name = zend_string_init("status", sizeof("status") - 1, 1);
+	zend_string *property_status_name = zend_string_init("status", strlen("status"), 1);
 	zend_declare_typed_property(class_entry, property_status_name, &property_status_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_status_name);
 
 	zval property_statusSys_default_value;
 	ZVAL_UNDEF(&property_statusSys_default_value);
-	zend_string *property_statusSys_name = zend_string_init("statusSys", sizeof("statusSys") - 1, 1);
+	zend_string *property_statusSys_name = zend_string_init("statusSys", strlen("statusSys"), 1);
 	zend_declare_typed_property(class_entry, property_statusSys_name, &property_statusSys_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_statusSys_name);
 
 	zval property_numFiles_default_value;
 	ZVAL_UNDEF(&property_numFiles_default_value);
-	zend_string *property_numFiles_name = zend_string_init("numFiles", sizeof("numFiles") - 1, 1);
+	zend_string *property_numFiles_name = zend_string_init("numFiles", strlen("numFiles"), 1);
 	zend_declare_typed_property(class_entry, property_numFiles_name, &property_numFiles_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_numFiles_name);
 
 	zval property_filename_default_value;
 	ZVAL_UNDEF(&property_filename_default_value);
-	zend_string *property_filename_name = zend_string_init("filename", sizeof("filename") - 1, 1);
+	zend_string *property_filename_name = zend_string_init("filename", strlen("filename"), 1);
 	zend_declare_typed_property(class_entry, property_filename_name, &property_filename_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_filename_name);
 
 	zval property_comment_default_value;
 	ZVAL_UNDEF(&property_comment_default_value);
-	zend_string *property_comment_name = zend_string_init("comment", sizeof("comment") - 1, 1);
+	zend_string *property_comment_name = zend_string_init("comment", strlen("comment"), 1);
 	zend_declare_typed_property(class_entry, property_comment_name, &property_comment_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_comment_name);
 

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -154,7 +154,7 @@ static int php_zlib_output_encoding(void)
 
 	if (!ZLIBG(compression_coding)) {
 		if ((Z_TYPE(PG(http_globals)[TRACK_VARS_SERVER]) == IS_ARRAY || zend_is_auto_global(ZSTR_KNOWN(ZEND_STR_AUTOGLOBAL_SERVER))) &&
-			(enc = zend_hash_str_find(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_ACCEPT_ENCODING", sizeof("HTTP_ACCEPT_ENCODING") - 1))) {
+			(enc = zend_hash_str_find(Z_ARRVAL(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_ACCEPT_ENCODING", strlen("HTTP_ACCEPT_ENCODING")))) {
 			convert_to_string(enc);
 			if (strstr(Z_STRVAL_P(enc), "gzip")) {
 				ZLIBG(compression_coding) = PHP_ZLIB_ENCODING_GZIP;
@@ -595,9 +595,9 @@ PHP_FUNCTION(zlib_get_coding_type)
 	}
 	switch (ZLIBG(compression_coding)) {
 		case PHP_ZLIB_ENCODING_GZIP:
-			RETURN_STRINGL("gzip", sizeof("gzip") - 1);
+			RETURN_STRINGL("gzip", strlen("gzip"));
 		case PHP_ZLIB_ENCODING_DEFLATE:
-			RETURN_STRINGL("deflate", sizeof("deflate") - 1);
+			RETURN_STRINGL("deflate", strlen("deflate"));
 		default:
 			RETURN_FALSE;
 	}

--- a/ext/zlib/zlib_filter.c
+++ b/ext/zlib/zlib_filter.c
@@ -323,7 +323,7 @@ static php_stream_filter *php_zlib_filter_create(const char *filtername, zval *f
 			zval *tmpzval;
 
 			if ((Z_TYPE_P(filterparams) == IS_ARRAY || Z_TYPE_P(filterparams) == IS_OBJECT) &&
-				(tmpzval = zend_hash_str_find(HASH_OF(filterparams), "window", sizeof("window") - 1))) {
+				(tmpzval = zend_hash_str_find(HASH_OF(filterparams), "window", strlen("window")))) {
 				/* log-2 base of history window (9 - 15) */
 				zend_long tmp = zval_get_long(tmpzval);
 				if (tmp < -MAX_WBITS || tmp > MAX_WBITS + 32) {
@@ -355,7 +355,7 @@ static php_stream_filter *php_zlib_filter_create(const char *filtername, zval *f
 			switch (Z_TYPE_P(filterparams)) {
 				case IS_ARRAY:
 				case IS_OBJECT:
-					if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "memory", sizeof("memory") -1))) {
+					if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "memory", strlen("memory")))) {
 						/* Memory Level (1 - 9) */
 						tmp = zval_get_long(tmpzval);
 						if (tmp < 1 || tmp > MAX_MEM_LEVEL) {
@@ -365,7 +365,7 @@ static php_stream_filter *php_zlib_filter_create(const char *filtername, zval *f
 						}
 					}
 
-					if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "window", sizeof("window") - 1))) {
+					if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "window", strlen("window")))) {
 						/* log-2 base of history window (9 - 15) */
 						tmp = zval_get_long(tmpzval);
 						if (tmp < -MAX_WBITS || tmp > MAX_WBITS + 16) {
@@ -375,7 +375,7 @@ static php_stream_filter *php_zlib_filter_create(const char *filtername, zval *f
 						}
 					}
 
-					if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "level", sizeof("level") - 1))) {
+					if ((tmpzval = zend_hash_str_find(HASH_OF(filterparams), "level", strlen("level")))) {
 						tmp = zval_get_long(tmpzval);
 
 						/* Pseudo pass through to catch level validating code */

--- a/main/SAPI.c
+++ b/main/SAPI.c
@@ -317,13 +317,13 @@ static inline char *get_default_content_type(uint32_t prefix_len, uint32_t *len)
 	if (*charset && strncasecmp(mimetype, "text/", 5) == 0) {
 		char *p;
 
-		*len = prefix_len + mimetype_len + sizeof("; charset=") - 1 + charset_len;
+		*len = prefix_len + mimetype_len + strlen("; charset=") + charset_len;
 		content_type = (char*)emalloc(*len + 1);
 		p = content_type + prefix_len;
 		memcpy(p, mimetype, mimetype_len);
 		p += mimetype_len;
-		memcpy(p, "; charset=", sizeof("; charset=") - 1);
-		p += sizeof("; charset=") - 1;
+		memcpy(p, "; charset=", strlen("; charset="));
+		p += strlen("; charset=");
 		memcpy(p, charset, charset_len + 1);
 	} else {
 		*len = prefix_len + mimetype_len;
@@ -346,9 +346,9 @@ SAPI_API void sapi_get_default_content_type_header(sapi_header_struct *default_h
 {
 	uint32_t len;
 
-	default_header->header = get_default_content_type(sizeof("Content-type: ")-1, &len);
+	default_header->header = get_default_content_type(strlen("Content-type: "), &len);
 	default_header->header_len = len;
-	memcpy(default_header->header, "Content-type: ", sizeof("Content-type: ") - 1);
+	memcpy(default_header->header, "Content-type: ", strlen("Content-type: "));
 }
 
 /*
@@ -370,7 +370,7 @@ SAPI_API size_t sapi_apply_default_charset(char **mimetype, size_t len)
 
 	if (*mimetype != NULL) {
 		if (*charset && strncmp(*mimetype, "text/", 5) == 0 && strstr(*mimetype, "charset=") == NULL) {
-			newlen = len + (sizeof(";charset=")-1) + strlen(charset);
+			newlen = len + (strlen(";charset=")) + strlen(charset);
 			newtype = emalloc(newlen + 1);
 	 		PHP_STRLCPY(newtype, *mimetype, newlen + 1, len);
 			strlcat(newtype, ";charset=", newlen + 1);
@@ -775,7 +775,7 @@ SAPI_API int sapi_header_op(sapi_header_op_enum op, void *arg)
 				if (newlen != 0) {
 					newlen += sizeof("Content-type: ");
 					newheader = emalloc(newlen);
-					PHP_STRLCPY(newheader, "Content-type: ", newlen, sizeof("Content-type: ")-1);
+					PHP_STRLCPY(newheader, "Content-type: ", newlen, strlen("Content-type: "));
 					strlcat(newheader, mimetype, newlen);
 					sapi_header.header = newheader;
 					sapi_header.header_len = (uint32_t)(newlen - 1);
@@ -789,9 +789,9 @@ SAPI_API int sapi_header_op(sapi_header_op_enum op, void *arg)
 				 * do disable compression altogether. This contributes to making scripts
 				 * portable between setups that have and don't have zlib compression
 				 * enabled globally. See req #44164 */
-				zend_string *key = zend_string_init("zlib.output_compression", sizeof("zlib.output_compression")-1, 0);
+				zend_string *key = zend_string_init("zlib.output_compression", strlen("zlib.output_compression"), 0);
 				zend_alter_ini_entry_chars(key,
-					"0", sizeof("0") - 1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
+					"0", strlen("0"), PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 				zend_string_release_ex(key, 0);
 			} else if (!strcasecmp(header_line, "Location")) {
 				if ((SG(sapi_headers).http_response_code < 300 ||
@@ -846,11 +846,11 @@ SAPI_API int sapi_send_headers(void)
 
 			SG(sapi_headers).mimetype = default_mimetype;
 
-			default_header.header_len = sizeof("Content-type: ") - 1 + len;
+			default_header.header_len = strlen("Content-type: ") + len;
 			default_header.header = emalloc(default_header.header_len + 1);
 
-			memcpy(default_header.header, "Content-type: ", sizeof("Content-type: ") - 1);
-			memcpy(default_header.header + sizeof("Content-type: ") - 1, SG(sapi_headers).mimetype, len + 1);
+			memcpy(default_header.header, "Content-type: ", strlen("Content-type: "));
+			memcpy(default_header.header + strlen("Content-type: "), SG(sapi_headers).mimetype, len + 1);
 
 			sapi_header_add_op(SAPI_HEADER_ADD, &default_header);
 		} else {
@@ -1016,7 +1016,7 @@ SAPI_API char *sapi_getenv(const char *name, size_t name_len)
 		if (tmp) {
 			value = estrdup(tmp);
 #ifdef PHP_WIN32
-			if (strlen(sapi_module.name) == sizeof("cgi-fcgi") - 1 && !strcmp(sapi_module.name, "cgi-fcgi")) {
+			if (strlen(sapi_module.name) == strlen("cgi-fcgi") && !strcmp(sapi_module.name, "cgi-fcgi")) {
 				/* XXX more modules to go, if needed. */
 				free(tmp);
 			}
@@ -1126,11 +1126,11 @@ SAPI_API void sapi_add_request_header(const char *var, unsigned int var_len, cha
 			}
 		}
 		*str = 0;
-	} else if (var_len == sizeof("CONTENT_TYPE")-1 &&
-	           memcmp(var, "CONTENT_TYPE", sizeof("CONTENT_TYPE")-1) == 0) {
+	} else if (var_len == strlen("CONTENT_TYPE") &&
+	           memcmp(var, "CONTENT_TYPE", strlen("CONTENT_TYPE")) == 0) {
 		var = "Content-Type";
-	} else if (var_len == sizeof("CONTENT_LENGTH")-1 &&
-	           memcmp(var, "CONTENT_LENGTH", sizeof("CONTENT_LENGTH")-1) == 0) {
+	} else if (var_len == strlen("CONTENT_LENGTH") &&
+	           memcmp(var, "CONTENT_LENGTH", strlen("CONTENT_LENGTH")) == 0) {
 		var = "Content-Length";
 	} else {
 		return;

--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -487,7 +487,7 @@ int fcgi_init(void)
 		socklen_t len = sizeof(sa);
 #endif
 		zend_hash_init(&fcgi_mgmt_vars, 8, NULL, fcgi_free_mgmt_var_cb, 1);
-		fcgi_set_mgmt_var("FCGI_MPXS_CONNS", sizeof("FCGI_MPXS_CONNS")-1, "0", sizeof("0")-1);
+		fcgi_set_mgmt_var("FCGI_MPXS_CONNS", strlen("FCGI_MPXS_CONNS"), "0", strlen("0"));
 
 		is_initialized = 1;
 #ifdef _WIN32
@@ -680,7 +680,7 @@ int fcgi_listen(const char *path, int backlog)
 		sa.sa_inet.sin_port = htons(port);
 		sock_len = sizeof(sa.sa_inet);
 
-		if (!*host || !strncmp(host, "*", sizeof("*")-1)) {
+		if (!*host || !strncmp(host, "*", strlen("*"))) {
 			sa.sa_inet.sin_addr.s_addr = htonl(INADDR_ANY);
 		} else {
 #ifdef HAVE_INET_PTON
@@ -1105,13 +1105,13 @@ static int fcgi_read_request(fcgi_request *req)
 #endif
 		switch ((b->roleB1 << 8) + b->roleB0) {
 			case FCGI_RESPONDER:
-				fcgi_hash_set(&req->env, FCGI_HASH_FUNC("FCGI_ROLE", sizeof("FCGI_ROLE")-1), "FCGI_ROLE", sizeof("FCGI_ROLE")-1, "RESPONDER", sizeof("RESPONDER")-1);
+				fcgi_hash_set(&req->env, FCGI_HASH_FUNC("FCGI_ROLE", strlen("FCGI_ROLE")), "FCGI_ROLE", strlen("FCGI_ROLE"), "RESPONDER", strlen("RESPONDER"));
 				break;
 			case FCGI_AUTHORIZER:
-				fcgi_hash_set(&req->env, FCGI_HASH_FUNC("FCGI_ROLE", sizeof("FCGI_ROLE")-1), "FCGI_ROLE", sizeof("FCGI_ROLE")-1, "AUTHORIZER", sizeof("AUTHORIZER")-1);
+				fcgi_hash_set(&req->env, FCGI_HASH_FUNC("FCGI_ROLE", strlen("FCGI_ROLE")), "FCGI_ROLE", strlen("FCGI_ROLE"), "AUTHORIZER", strlen("AUTHORIZER"));
 				break;
 			case FCGI_FILTER:
-				fcgi_hash_set(&req->env, FCGI_HASH_FUNC("FCGI_ROLE", sizeof("FCGI_ROLE")-1), "FCGI_ROLE", sizeof("FCGI_ROLE")-1, "FILTER", sizeof("FILTER")-1);
+				fcgi_hash_set(&req->env, FCGI_HASH_FUNC("FCGI_ROLE", strlen("FCGI_ROLE")), "FCGI_ROLE", strlen("FCGI_ROLE"), "FILTER", strlen("FILTER"));
 				break;
 			default:
 				return 0;

--- a/main/main.c
+++ b/main/main.c
@@ -1377,7 +1377,7 @@ static ZEND_COLD void php_error_cb(int orig_type, zend_string *error_filename, c
 					sapi_header_line ctr = {0};
 
 					ctr.line = "HTTP/1.0 500 Internal Server Error";
-					ctr.line_len = sizeof("HTTP/1.0 500 Internal Server Error") - 1;
+					ctr.line_len = strlen("HTTP/1.0 500 Internal Server Error");
 					sapi_header_op(SAPI_HEADER_REPLACE, &ctr);
 				}
 				/* the parser would return 1 (failure), we can bail out nicely */
@@ -1476,7 +1476,7 @@ PHP_FUNCTION(set_time_limit)
 
 	new_timeout_strlen = (int)zend_spprintf(&new_timeout_str, 0, ZEND_LONG_FMT, new_timeout);
 
-	key = zend_string_init("max_execution_time", sizeof("max_execution_time")-1, 0);
+	key = zend_string_init("max_execution_time", strlen("max_execution_time"), 0);
 	if (zend_alter_ini_entry_chars_ex(key, new_timeout_str, new_timeout_strlen, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0) == SUCCESS) {
 		RETVAL_TRUE;
 	} else {
@@ -2262,7 +2262,7 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 
 	/* register additional functions */
 	if (sapi_module.additional_functions) {
-		if ((module = zend_hash_str_find_ptr(&module_registry, "standard", sizeof("standard")-1)) != NULL) {
+		if ((module = zend_hash_str_find_ptr(&module_registry, "standard", strlen("standard"))) != NULL) {
 			EG(current_module) = module;
 			zend_register_functions(NULL, sapi_module.additional_functions, NULL, MODULE_PERSISTENT);
 			EG(current_module) = NULL;
@@ -2274,7 +2274,7 @@ int php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_mod
 	php_disable_classes();
 
 	/* make core report what it should */
-	if ((module = zend_hash_str_find_ptr(&module_registry, "core", sizeof("core")-1)) != NULL) {
+	if ((module = zend_hash_str_find_ptr(&module_registry, "core", strlen("core"))) != NULL) {
 		module->version = PHP_VERSION;
 		module->info_func = PHP_MINFO(php_core);
 	}
@@ -2622,7 +2622,7 @@ PHPAPI int php_handle_auth_data(const char *auth)
 	int ret = -1;
 	size_t auth_len = auth != NULL ? strlen(auth) : 0;
 
-	if (auth && auth_len > 0 && zend_binary_strncasecmp(auth, auth_len, "Basic ", sizeof("Basic ")-1, sizeof("Basic ")-1) == 0) {
+	if (auth && auth_len > 0 && zend_binary_strncasecmp(auth, auth_len, "Basic ", strlen("Basic "), strlen("Basic ")) == 0) {
 		char *pass;
 		zend_string *user;
 
@@ -2645,7 +2645,7 @@ PHPAPI int php_handle_auth_data(const char *auth)
 		SG(request_info).auth_digest = NULL;
 	}
 
-	if (ret == -1 && auth && auth_len > 0 && zend_binary_strncasecmp(auth, auth_len, "Digest ", sizeof("Digest ")-1, sizeof("Digest ")-1) == 0) {
+	if (ret == -1 && auth && auth_len > 0 && zend_binary_strncasecmp(auth, auth_len, "Digest ", strlen("Digest "), strlen("Digest ")) == 0) {
 		SG(request_info).auth_digest = estrdup(auth + 7);
 		ret = 0;
 	}

--- a/main/php_ini.c
+++ b/main/php_ini.c
@@ -83,10 +83,10 @@ static ZEND_COLD void php_ini_displayer_cb(zend_ini_entry *ini_entry, int type)
 			} else {
 				if (!sapi_module.phpinfo_as_text) {
 					display_string = "<i>no value</i>";
-					display_string_length = sizeof("<i>no value</i>") - 1;
+					display_string_length = strlen("<i>no value</i>");
 				} else {
 					display_string = "no value";
-					display_string_length = sizeof("no value") - 1;
+					display_string_length = strlen("no value");
 				}
 			}
 		} else if (ini_entry->value && ZSTR_VAL(ini_entry->value)[0]) {
@@ -96,10 +96,10 @@ static ZEND_COLD void php_ini_displayer_cb(zend_ini_entry *ini_entry, int type)
 		} else {
 			if (!sapi_module.phpinfo_as_text) {
 				display_string = "<i>no value</i>";
-				display_string_length = sizeof("<i>no value</i>") - 1;
+				display_string_length = strlen("<i>no value</i>");
 			} else {
 				display_string = "no value";
-				display_string_length = sizeof("no value") - 1;
+				display_string_length = strlen("no value");
 			}
 		}
 
@@ -252,9 +252,9 @@ static void php_ini_parser_cb(zval *arg1, zval *arg2, zval *arg3, int callback_t
 				size_t key_len;
 
 				/* PATH sections */
-				if (!zend_binary_strncasecmp(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1), "PATH", sizeof("PATH") - 1, sizeof("PATH") - 1)) {
+				if (!zend_binary_strncasecmp(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1), "PATH", strlen("PATH"), strlen("PATH"))) {
 					key = Z_STRVAL_P(arg1);
-					key = key + sizeof("PATH") - 1;
+					key = key + strlen("PATH");
 					key_len = Z_STRLEN_P(arg1) - sizeof("PATH") + 1;
 					is_special_section = 1;
 					has_per_dir_config = 1;
@@ -263,9 +263,9 @@ static void php_ini_parser_cb(zval *arg1, zval *arg2, zval *arg3, int callback_t
 					TRANSLATE_SLASHES_LOWER(key);
 
 				/* HOST sections */
-				} else if (!zend_binary_strncasecmp(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1), "HOST", sizeof("HOST") - 1, sizeof("HOST") - 1)) {
+				} else if (!zend_binary_strncasecmp(Z_STRVAL_P(arg1), Z_STRLEN_P(arg1), "HOST", strlen("HOST"), strlen("HOST"))) {
 					key = Z_STRVAL_P(arg1);
-					key = key + sizeof("HOST") - 1;
+					key = key + strlen("HOST");
 					key_len = Z_STRLEN_P(arg1) - sizeof("HOST") + 1;
 					is_special_section = 1;
 					has_per_host_config = 1;
@@ -617,7 +617,7 @@ int php_init_config(void)
 			zval tmp;
 
 			ZVAL_NEW_STR(&tmp, zend_string_init(filename, strlen(filename), 1));
-			zend_hash_str_update(&configuration_hash, "cfg_file_path", sizeof("cfg_file_path")-1, &tmp);
+			zend_hash_str_update(&configuration_hash, "cfg_file_path", strlen("cfg_file_path"), &tmp);
 			if (opened_path) {
 				zend_string_release_ex(opened_path, 0);
 			}

--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -110,14 +110,14 @@ PHPAPI void php_register_variable_ex(const char *var_name, zval *val, zval *trac
 		return;
 	}
 
-	if (var_len == sizeof("this")-1 && EG(current_execute_data)) {
+	if (var_len == strlen("this") && EG(current_execute_data)) {
 		zend_execute_data *ex = EG(current_execute_data);
 
 		while (ex) {
 			if (ex->func && ZEND_USER_CODE(ex->func->common.type)) {
 				if ((ZEND_CALL_INFO(ex) & ZEND_CALL_HAS_SYMBOL_TABLE)
 						&& ex->symbol_table == symtable1) {
-					if (memcmp(var, "this", sizeof("this")-1) == 0) {
+					if (memcmp(var, "this", strlen("this")) == 0) {
 						zend_throw_error(NULL, "Cannot re-assign $this");
 						zval_ptr_dtor_nogc(val);
 						free_alloca(var_orig, use_heap);
@@ -132,8 +132,8 @@ PHPAPI void php_register_variable_ex(const char *var_name, zval *val, zval *trac
 
 	/* GLOBALS hijack attempt, reject parameter */
 	if (symtable1 == &EG(symbol_table) &&
-		var_len == sizeof("GLOBALS")-1 &&
-		!memcmp(var, "GLOBALS", sizeof("GLOBALS")-1)) {
+		var_len == strlen("GLOBALS") &&
+		!memcmp(var, "GLOBALS", strlen("GLOBALS"))) {
 		zval_ptr_dtor_nogc(val);
 		free_alloca(var_orig, use_heap);
 		return;
@@ -668,22 +668,22 @@ static inline void php_register_server_variables(void)
 	/* PHP Authentication support */
 	if (SG(request_info).auth_user) {
 		ZVAL_STRING(&tmp, SG(request_info).auth_user);
-		php_register_variable_quick("PHP_AUTH_USER", sizeof("PHP_AUTH_USER")-1, &tmp, ht);
+		php_register_variable_quick("PHP_AUTH_USER", strlen("PHP_AUTH_USER"), &tmp, ht);
 	}
 	if (SG(request_info).auth_password) {
 		ZVAL_STRING(&tmp, SG(request_info).auth_password);
-		php_register_variable_quick("PHP_AUTH_PW", sizeof("PHP_AUTH_PW")-1, &tmp, ht);
+		php_register_variable_quick("PHP_AUTH_PW", strlen("PHP_AUTH_PW"), &tmp, ht);
 	}
 	if (SG(request_info).auth_digest) {
 		ZVAL_STRING(&tmp, SG(request_info).auth_digest);
-		php_register_variable_quick("PHP_AUTH_DIGEST", sizeof("PHP_AUTH_DIGEST")-1, &tmp, ht);
+		php_register_variable_quick("PHP_AUTH_DIGEST", strlen("PHP_AUTH_DIGEST"), &tmp, ht);
 	}
 
 	/* store request init time */
 	ZVAL_DOUBLE(&tmp, sapi_get_request_time());
-	php_register_variable_quick("REQUEST_TIME_FLOAT", sizeof("REQUEST_TIME_FLOAT")-1, &tmp, ht);
+	php_register_variable_quick("REQUEST_TIME_FLOAT", strlen("REQUEST_TIME_FLOAT"), &tmp, ht);
 	ZVAL_LONG(&tmp, zend_dval_to_lval(Z_DVAL(tmp)));
-	php_register_variable_quick("REQUEST_TIME", sizeof("REQUEST_TIME")-1, &tmp, ht);
+	php_register_variable_quick("REQUEST_TIME", strlen("REQUEST_TIME"), &tmp, ht);
 }
 /* }}} */
 
@@ -794,15 +794,15 @@ static bool php_auto_globals_create_files(zend_string *name)
 /* Ugly hack to fix HTTP_PROXY issue, see bug #72573 */
 static void check_http_proxy(HashTable *var_table)
 {
-	if (zend_hash_str_exists(var_table, "HTTP_PROXY", sizeof("HTTP_PROXY")-1)) {
+	if (zend_hash_str_exists(var_table, "HTTP_PROXY", strlen("HTTP_PROXY"))) {
 		char *local_proxy = getenv("HTTP_PROXY");
 
 		if (!local_proxy) {
-			zend_hash_str_del(var_table, "HTTP_PROXY", sizeof("HTTP_PROXY")-1);
+			zend_hash_str_del(var_table, "HTTP_PROXY", strlen("HTTP_PROXY"));
 		} else {
 			zval local_zval;
 			ZVAL_STRING(&local_zval, local_proxy);
-			zend_hash_str_update(var_table, "HTTP_PROXY", sizeof("HTTP_PROXY")-1, &local_zval);
+			zend_hash_str_update(var_table, "HTTP_PROXY", strlen("HTTP_PROXY"), &local_zval);
 		}
 	}
 }
@@ -906,11 +906,11 @@ static bool php_auto_globals_create_request(zend_string *name)
 
 void php_startup_auto_globals(void)
 {
-	zend_register_auto_global(zend_string_init_interned("_GET", sizeof("_GET")-1, 1), 0, php_auto_globals_create_get);
-	zend_register_auto_global(zend_string_init_interned("_POST", sizeof("_POST")-1, 1), 0, php_auto_globals_create_post);
-	zend_register_auto_global(zend_string_init_interned("_COOKIE", sizeof("_COOKIE")-1, 1), 0, php_auto_globals_create_cookie);
+	zend_register_auto_global(zend_string_init_interned("_GET", strlen("_GET"), 1), 0, php_auto_globals_create_get);
+	zend_register_auto_global(zend_string_init_interned("_POST", strlen("_POST"), 1), 0, php_auto_globals_create_post);
+	zend_register_auto_global(zend_string_init_interned("_COOKIE", strlen("_COOKIE"), 1), 0, php_auto_globals_create_cookie);
 	zend_register_auto_global(ZSTR_KNOWN(ZEND_STR_AUTOGLOBAL_SERVER), PG(auto_globals_jit), php_auto_globals_create_server);
 	zend_register_auto_global(ZSTR_KNOWN(ZEND_STR_AUTOGLOBAL_ENV), PG(auto_globals_jit), php_auto_globals_create_env);
 	zend_register_auto_global(ZSTR_KNOWN(ZEND_STR_AUTOGLOBAL_REQUEST), PG(auto_globals_jit), php_auto_globals_create_request);
-	zend_register_auto_global(zend_string_init_interned("_FILES", sizeof("_FILES")-1, 1), 0, php_auto_globals_create_files);
+	zend_register_auto_global(zend_string_init_interned("_FILES", strlen("_FILES"), 1), 0, php_auto_globals_create_files);
 }

--- a/main/streams/glob_wrapper.c
+++ b/main/streams/glob_wrapper.c
@@ -201,8 +201,8 @@ static php_stream *php_glob_stream_opener(php_stream_wrapper *wrapper, const cha
 	int ret;
 	const char *tmp, *pos;
 
-	if (!strncmp(path, "glob://", sizeof("glob://")-1)) {
-		path += sizeof("glob://")-1;
+	if (!strncmp(path, "glob://", strlen("glob://"))) {
+		path += strlen("glob://");
 		if (opened_path) {
 			*opened_path = zend_string_init(path, strlen(path), 0);
 		}

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -651,7 +651,7 @@ static php_stream * php_stream_url_wrap_rfc2397(php_stream_wrapper *wrapper, con
 			add_assoc_stringl(&meta, "mediatype", (char *) path, plen);
 			mlen -= plen;
 			path += plen;
-		} else if (semi != path || mlen != sizeof(";base64")-1 || memcmp(path, ";base64", sizeof(";base64")-1)) { /* must be error since parameters are only allowed after mediatype */
+		} else if (semi != path || mlen != strlen(";base64") || memcmp(path, ";base64", strlen(";base64"))) { /* must be error since parameters are only allowed after mediatype */
 			zval_ptr_dtor(&meta);
 			php_stream_wrapper_log_error(wrapper, options, "rfc2397: illegal media type");
 			return NULL;
@@ -663,21 +663,21 @@ static php_stream * php_stream_url_wrap_rfc2397(php_stream_wrapper *wrapper, con
 			sep = memchr(path, '=', mlen);
 			semi = memchr(path, ';', mlen);
 			if (!sep || (semi && semi < sep)) { /* must be ';base64' or failure */
-				if (mlen != sizeof("base64")-1 || memcmp(path, "base64", sizeof("base64")-1)) {
+				if (mlen != strlen("base64") || memcmp(path, "base64", strlen("base64"))) {
 					/* must be error since parameters are only allowed after mediatype and we have no '=' sign */
 					zval_ptr_dtor(&meta);
 					php_stream_wrapper_log_error(wrapper, options, "rfc2397: illegal parameter");
 					return NULL;
 				}
 				base64 = 1;
-				mlen -= sizeof("base64") - 1;
-				path += sizeof("base64") - 1;
+				mlen -= strlen("base64");
+				path += strlen("base64");
 				break;
 			}
 			/* found parameter ... the heart of cs ppl lies in +1/-1 or was it +2 this time? */
 			plen = sep - path;
 			vlen = (semi ? (size_t)(semi - sep) : (mlen - plen)) - 1 /* '=' */;
-			if (plen != sizeof("mediatype")-1 || memcmp(path, "mediatype", sizeof("mediatype")-1)) {
+			if (plen != strlen("mediatype") || memcmp(path, "mediatype", strlen("mediatype"))) {
 				add_assoc_stringl_ex(&meta, path, plen, sep + 1, vlen);
 			}
 			plen += vlen + 1;

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -1203,8 +1203,8 @@ static php_stream *php_plain_files_stream_opener(php_stream_wrapper *wrapper, co
 static int php_plain_files_url_stater(php_stream_wrapper *wrapper, const char *url, int flags, php_stream_statbuf *ssb, php_stream_context *context)
 {
 	if (!(flags & PHP_STREAM_URL_STAT_IGNORE_OPEN_BASEDIR)) {
-		if (strncasecmp(url, "file://", sizeof("file://") - 1) == 0) {
-			url += sizeof("file://") - 1;
+		if (strncasecmp(url, "file://", strlen("file://")) == 0) {
+			url += strlen("file://");
 		}
 
 		if (php_check_open_basedir_ex(url, (flags & PHP_STREAM_URL_STAT_QUIET) ? 0 : 1)) {
@@ -1230,8 +1230,8 @@ static int php_plain_files_unlink(php_stream_wrapper *wrapper, const char *url, 
 {
 	int ret;
 
-	if (strncasecmp(url, "file://", sizeof("file://") - 1) == 0) {
-		url += sizeof("file://") - 1;
+	if (strncasecmp(url, "file://", strlen("file://")) == 0) {
+		url += strlen("file://");
 	}
 
 	if (php_check_open_basedir(url)) {
@@ -1271,12 +1271,12 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
 	}
 #endif
 
-	if (strncasecmp(url_from, "file://", sizeof("file://") - 1) == 0) {
-		url_from += sizeof("file://") - 1;
+	if (strncasecmp(url_from, "file://", strlen("file://")) == 0) {
+		url_from += strlen("file://");
 	}
 
-	if (strncasecmp(url_to, "file://", sizeof("file://") - 1) == 0) {
-		url_to += sizeof("file://") - 1;
+	if (strncasecmp(url_to, "file://", strlen("file://")) == 0) {
+		url_to += strlen("file://");
 	}
 
 	if (php_check_open_basedir(url_from) || php_check_open_basedir(url_to)) {
@@ -1355,8 +1355,8 @@ static int php_plain_files_rename(php_stream_wrapper *wrapper, const char *url_f
 
 static int php_plain_files_mkdir(php_stream_wrapper *wrapper, const char *dir, int mode, int options, php_stream_context *context)
 {
-	if (strncasecmp(dir, "file://", sizeof("file://") - 1) == 0) {
-		dir += sizeof("file://") - 1;
+	if (strncasecmp(dir, "file://", strlen("file://")) == 0) {
+		dir += strlen("file://");
 	}
 
 	if (!(options & PHP_STREAM_MKDIR_RECURSIVE)) {
@@ -1447,8 +1447,8 @@ static int php_plain_files_mkdir(php_stream_wrapper *wrapper, const char *dir, i
 
 static int php_plain_files_rmdir(php_stream_wrapper *wrapper, const char *url, int options, php_stream_context *context)
 {
-	if (strncasecmp(url, "file://", sizeof("file://") - 1) == 0) {
-		url += sizeof("file://") - 1;
+	if (strncasecmp(url, "file://", strlen("file://")) == 0) {
+		url += strlen("file://");
 	}
 
 	if (php_check_open_basedir(url)) {
@@ -1490,8 +1490,8 @@ static int php_plain_files_metadata(php_stream_wrapper *wrapper, const char *url
 	}
 #endif
 
-	if (strncasecmp(url, "file://", sizeof("file://") - 1) == 0) {
-		url += sizeof("file://") - 1;
+	if (strncasecmp(url, "file://", strlen("file://")) == 0) {
+		url += strlen("file://");
 	}
 
 	if (php_check_open_basedir(url)) {

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -405,8 +405,8 @@ static int sapi_cgi_send_headers(sapi_headers_struct *sapi_headers)
 			} else {
 				h = (sapi_header_struct*)zend_llist_get_first_ex(&sapi_headers->headers, &pos);
 				while (h) {
-					if (h->header_len > sizeof("Status:")-1 &&
-						strncasecmp(h->header, "Status:", sizeof("Status:")-1) == 0
+					if (h->header_len > strlen("Status:") &&
+						strncasecmp(h->header, "Status:", strlen("Status:")) == 0
 					) {
 						has_status = 1;
 						break;
@@ -442,16 +442,16 @@ static int sapi_cgi_send_headers(sapi_headers_struct *sapi_headers)
 	while (h) {
 		/* prevent CRLFCRLF */
 		if (h->header_len) {
-			if (h->header_len > sizeof("Status:")-1 &&
-				strncasecmp(h->header, "Status:", sizeof("Status:")-1) == 0
+			if (h->header_len > strlen("Status:") &&
+				strncasecmp(h->header, "Status:", strlen("Status:")) == 0
 			) {
 				if (!ignore_status) {
 					ignore_status = 1;
 					PHPWRITE_H(h->header, h->header_len);
 					PHPWRITE_H("\r\n", 2);
 				}
-			} else if (response_status == 304 && h->header_len > sizeof("Content-Type:")-1 &&
-				strncasecmp(h->header, "Content-Type:", sizeof("Content-Type:")-1) == 0
+			} else if (response_status == 304 && h->header_len > strlen("Content-Type:") &&
+				strncasecmp(h->header, "Content-Type:", strlen("Content-Type:")) == 0
 			) {
 				h = (sapi_header_struct*)zend_llist_get_next_ex(&sapi_headers->headers, &pos);
 				continue;
@@ -1199,7 +1199,7 @@ static void init_request_info(fcgi_request *request)
 		if (env_server_software &&
 			env_script_name &&
 			env_path_info &&
-			strncmp(env_server_software, "Microsoft-IIS", sizeof("Microsoft-IIS")-1) == 0 &&
+			strncmp(env_server_software, "Microsoft-IIS", strlen("Microsoft-IIS")) == 0 &&
 			strncmp(env_path_info, env_script_name, strlen(env_script_name)) == 0
 		) {
 			env_path_info = CGI_PUTENV("ORIG_PATH_INFO", env_path_info);
@@ -1638,11 +1638,11 @@ PHP_FUNCTION(apache_request_headers) /* {{{ */
 					}
 				}
 				*q = 0;
-			} else if (var_len == sizeof("CONTENT_TYPE")-1 &&
-			           memcmp(var, "CONTENT_TYPE", sizeof("CONTENT_TYPE")-1) == 0) {
+			} else if (var_len == strlen("CONTENT_TYPE") &&
+			           memcmp(var, "CONTENT_TYPE", strlen("CONTENT_TYPE")) == 0) {
 				var = "Content-Type";
-			} else if (var_len == sizeof("CONTENT_LENGTH")-1 &&
-			           memcmp(var, "CONTENT_LENGTH", sizeof("CONTENT_LENGTH")-1) == 0) {
+			} else if (var_len == strlen("CONTENT_LENGTH") &&
+			           memcmp(var, "CONTENT_LENGTH", strlen("CONTENT_LENGTH")) == 0) {
 				var = "Content-Length";
 			} else {
 				continue;
@@ -1983,9 +1983,9 @@ consult the installation file that came with this distribution, or visit \n\
 				fprintf(stderr, "PHP_FCGI_CHILDREN is not valid\n");
 				return FAILURE;
 			}
-			fcgi_set_mgmt_var("FCGI_MAX_CONNS", sizeof("FCGI_MAX_CONNS")-1, children_str, strlen(children_str));
+			fcgi_set_mgmt_var("FCGI_MAX_CONNS", strlen("FCGI_MAX_CONNS"), children_str, strlen(children_str));
 			/* This is the number of concurrent requests, equals FCGI_MAX_CONNS */
-			fcgi_set_mgmt_var("FCGI_MAX_REQS",  sizeof("FCGI_MAX_REQS")-1,  children_str, strlen(children_str));
+			fcgi_set_mgmt_var("FCGI_MAX_REQS",  strlen("FCGI_MAX_REQS"),  children_str, strlen(children_str));
 		} else {
 #ifdef PHP_WIN32
 			/* If this env var is set, the process was invoked as a child. Let
@@ -2003,8 +2003,8 @@ consult the installation file that came with this distribution, or visit \n\
 				SetEnvironmentVariable("PHP_FCGI_CHILDREN_FOR_KID", NULL);
 			}
 #endif
-			fcgi_set_mgmt_var("FCGI_MAX_CONNS", sizeof("FCGI_MAX_CONNS")-1, "1", sizeof("1")-1);
-			fcgi_set_mgmt_var("FCGI_MAX_REQS",  sizeof("FCGI_MAX_REQS")-1,  "1", sizeof("1")-1);
+			fcgi_set_mgmt_var("FCGI_MAX_CONNS", strlen("FCGI_MAX_CONNS"), "1", strlen("1"));
+			fcgi_set_mgmt_var("FCGI_MAX_REQS",  strlen("FCGI_MAX_REQS"),  "1", strlen("1"));
 		}
 
 #ifndef PHP_WIN32

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -558,15 +558,15 @@ static void cli_register_file_handles(bool no_close) /* {{{ */
 	php_stream_to_zval(s_err, &ec.value);
 
 	ZEND_CONSTANT_SET_FLAGS(&ic, CONST_CS, 0);
-	ic.name = zend_string_init_interned("STDIN", sizeof("STDIN")-1, 0);
+	ic.name = zend_string_init_interned("STDIN", strlen("STDIN"), 0);
 	zend_register_constant(&ic);
 
 	ZEND_CONSTANT_SET_FLAGS(&oc, CONST_CS, 0);
-	oc.name = zend_string_init_interned("STDOUT", sizeof("STDOUT")-1, 0);
+	oc.name = zend_string_init_interned("STDOUT", strlen("STDOUT"), 0);
 	zend_register_constant(&oc);
 
 	ZEND_CONSTANT_SET_FLAGS(&ec, CONST_CS, 0);
-	ec.name = zend_string_init_interned("STDERR", sizeof("STDERR")-1, 0);
+	ec.name = zend_string_init_interned("STDERR", strlen("STDERR"), 0);
 	zend_register_constant(&ec);
 }
 /* }}} */
@@ -1017,9 +1017,9 @@ do_repeat:
 						input[len] = '\0';
 					}
 					ZVAL_STRINGL(&argn, input, len + 1);
-					zend_hash_str_update(&EG(symbol_table), "argn", sizeof("argn")-1, &argn);
+					zend_hash_str_update(&EG(symbol_table), "argn", strlen("argn"), &argn);
 					ZVAL_LONG(&argi, ++index);
-					zend_hash_str_update(&EG(symbol_table), "argi", sizeof("argi")-1, &argi);
+					zend_hash_str_update(&EG(symbol_table), "argi", strlen("argi"), &argi);
 					if (exec_run) {
 						zend_eval_string_ex(exec_run, NULL, "Command line run code", 1);
 					} else {
@@ -1081,7 +1081,7 @@ do_repeat:
 
 					if (EG(exception)) {
 						zval rv;
-						zval *msg = zend_read_property(zend_ce_exception, EG(exception), "message", sizeof("message")-1, 0, &rv);
+						zval *msg = zend_read_property(zend_ce_exception, EG(exception), "message", strlen("message"), 0, &rv);
 						zend_printf("Exception: %s\n", Z_STRVAL_P(msg));
 						zend_object_release(EG(exception));
 						EG(exception) = NULL;

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -353,21 +353,21 @@ static void append_essential_headers(smart_str* buffer, php_cli_server_client *c
 	char *val;
 	struct timeval tv = {0};
 
-	if (NULL != (val = zend_hash_str_find_ptr(&client->request.headers, "host", sizeof("host")-1))) {
+	if (NULL != (val = zend_hash_str_find_ptr(&client->request.headers, "host", strlen("host")))) {
 		smart_str_appends_ex(buffer, "Host: ", persistent);
 		smart_str_appends_ex(buffer, val, persistent);
 		smart_str_appends_ex(buffer, "\r\n", persistent);
 	}
 
 	if (!gettimeofday(&tv, NULL)) {
-		zend_string *dt = php_format_date("D, d M Y H:i:s", sizeof("D, d M Y H:i:s") - 1, tv.tv_sec, 0);
+		zend_string *dt = php_format_date("D, d M Y H:i:s", strlen("D, d M Y H:i:s"), tv.tv_sec, 0);
 		smart_str_appends_ex(buffer, "Date: ", persistent);
 		smart_str_appends_ex(buffer, dt->val, persistent);
 		smart_str_appends_ex(buffer, " GMT\r\n", persistent);
 		zend_string_release_ex(dt, 0);
 	}
 
-	smart_str_appendl_ex(buffer, "Connection: close\r\n", sizeof("Connection: close\r\n") - 1, persistent);
+	smart_str_appendl_ex(buffer, "Connection: close\r\n", strlen("Connection: close\r\n"), persistent);
 } /* }}} */
 
 static const char *get_mime_type(const php_cli_server *server, const char *ext, size_t ext_len) /* {{{ */
@@ -575,7 +575,7 @@ static char *sapi_cli_server_read_cookies(void) /* {{{ */
 {
 	php_cli_server_client *client = SG(server_context);
 	char *val;
-	if (NULL == (val = zend_hash_str_find_ptr(&client->request.headers, "cookie", sizeof("cookie")-1))) {
+	if (NULL == (val = zend_hash_str_find_ptr(&client->request.headers, "cookie", strlen("cookie")))) {
 		return NULL;
 	}
 	return val;
@@ -1870,7 +1870,7 @@ static void php_cli_server_client_populate_request_info(const php_cli_server_cli
 	request_info->query_string = client->request.query_string;
 	request_info->content_length = client->request.content_len;
 	request_info->auth_user = request_info->auth_password = request_info->auth_digest = NULL;
-	if (NULL != (val = zend_hash_str_find_ptr(&client->request.headers, "content-type", sizeof("content-type")-1))) {
+	if (NULL != (val = zend_hash_str_find_ptr(&client->request.headers, "content-type", strlen("content-type")))) {
 		request_info->content_type = val;
 	}
 } /* }}} */
@@ -2095,7 +2095,7 @@ static int php_cli_server_begin_send_static(php_cli_server *server, php_cli_serv
 		}
 		append_essential_headers(&buffer, client, 1);
 		if (mime_type) {
-			smart_str_appendl_ex(&buffer, "Content-Type: ", sizeof("Content-Type: ") - 1, 1);
+			smart_str_appendl_ex(&buffer, "Content-Type: ", strlen("Content-Type: "), 1);
 			smart_str_appends_ex(&buffer, mime_type, 1);
 			if (strncmp(mime_type, "text/", 5) == 0) {
 				smart_str_appends_ex(&buffer, "; charset=UTF-8", 1);
@@ -2123,7 +2123,7 @@ static int php_cli_server_begin_send_static(php_cli_server *server, php_cli_serv
 static int php_cli_server_request_startup(php_cli_server *server, php_cli_server_client *client) { /* {{{ */
 	char *auth;
 	php_cli_server_client_populate_request_info(client, &SG(request_info));
-	if (NULL != (auth = zend_hash_str_find_ptr(&client->request.headers, "authorization", sizeof("authorization")-1))) {
+	if (NULL != (auth = zend_hash_str_find_ptr(&client->request.headers, "authorization", strlen("authorization")))) {
 		php_handle_auth_data(auth);
 	}
 	SG(sapi_headers).http_response_code = 200;

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -345,8 +345,8 @@ static int sapi_cgi_send_headers(sapi_headers_struct *sapi_headers) /* {{{ */
 			} else {
 				h = (sapi_header_struct*)zend_llist_get_first_ex(&sapi_headers->headers, &pos);
 				while (h) {
-					if (h->header_len > sizeof("Status:") - 1 &&
-						strncasecmp(h->header, "Status:", sizeof("Status:") - 1) == 0
+					if (h->header_len > strlen("Status:") &&
+						strncasecmp(h->header, "Status:", strlen("Status:")) == 0
 					) {
 						has_status = 1;
 						break;
@@ -382,16 +382,16 @@ static int sapi_cgi_send_headers(sapi_headers_struct *sapi_headers) /* {{{ */
 	while (h) {
 		/* prevent CRLFCRLF */
 		if (h->header_len) {
-			if (h->header_len > sizeof("Status:") - 1 &&
-				strncasecmp(h->header, "Status:", sizeof("Status:") - 1) == 0
+			if (h->header_len > strlen("Status:") &&
+				strncasecmp(h->header, "Status:", strlen("Status:")) == 0
 			) {
 				if (!ignore_status) {
 					ignore_status = 1;
 					PHPWRITE_H(h->header, h->header_len);
 					PHPWRITE_H("\r\n", 2);
 				}
-			} else if (response_status == 304 && h->header_len > sizeof("Content-Type:") - 1 &&
-				strncasecmp(h->header, "Content-Type:", sizeof("Content-Type:") - 1) == 0
+			} else if (response_status == 304 && h->header_len > strlen("Content-Type:") &&
+				strncasecmp(h->header, "Content-Type:", strlen("Content-Type:")) == 0
 			) {
 				h = (sapi_header_struct*)zend_llist_get_next_ex(&sapi_headers->headers, &pos);
 				continue;
@@ -555,7 +555,7 @@ static void sapi_cgi_register_variables(zval *track_vars_array) /* {{{ */
 	if (CGIG(fix_pathinfo)) {
 		char *script_name = SG(request_info).request_uri;
 		unsigned int script_name_len = script_name ? strlen(script_name) : 0;
-		char *path_info = sapi_cgibin_getenv("PATH_INFO", sizeof("PATH_INFO") - 1);
+		char *path_info = sapi_cgibin_getenv("PATH_INFO", strlen("PATH_INFO"));
 		unsigned int path_info_len = path_info ? strlen(path_info) : 0;
 
 		php_self_len = script_name_len + path_info_len;
@@ -987,7 +987,7 @@ static void init_request_info(void)
 		if (env_server_software &&
 			env_script_name &&
 			env_path_info &&
-			strncmp(env_server_software, "Microsoft-IIS", sizeof("Microsoft-IIS") - 1) == 0 &&
+			strncmp(env_server_software, "Microsoft-IIS", strlen("Microsoft-IIS")) == 0 &&
 			strncmp(env_path_info, env_script_name, strlen(env_script_name)) == 0
 		) {
 			env_path_info = FCGI_PUTENV(request, "ORIG_PATH_INFO", env_path_info);

--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -148,8 +148,8 @@ static int fpm_php_set_fcgi_mgmt_vars(struct fpm_worker_pool_s *wp) /* {{{ */
 
 	len = sprintf(max_workers, "%u", (unsigned int) wp->config->pm_max_children);
 
-	fcgi_set_mgmt_var("FCGI_MAX_CONNS", sizeof("FCGI_MAX_CONNS")-1, max_workers, len);
-	fcgi_set_mgmt_var("FCGI_MAX_REQS",  sizeof("FCGI_MAX_REQS")-1,  max_workers, len);
+	fcgi_set_mgmt_var("FCGI_MAX_CONNS", strlen("FCGI_MAX_CONNS"), max_workers, len);
+	fcgi_set_mgmt_var("FCGI_MAX_REQS",  strlen("FCGI_MAX_REQS"),  max_workers, len);
 	return 0;
 }
 /* }}} */

--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -171,7 +171,7 @@ int fpm_status_handle_request(void) /* {{{ */
 		fpm_request_executing();
 
 		/* full status ? */
-		_GET_str = zend_string_init("_GET", sizeof("_GET")-1, 0);
+		_GET_str = zend_string_init("_GET", strlen("_GET"), 0);
 		full = (fpm_php_get_string_from_table(_GET_str, "full") != NULL);
 		short_syntax = short_post = NULL;
 		full_separator = full_pre = full_syntax = full_post = NULL;

--- a/sapi/fpm/fpm/zlog.c
+++ b/sapi/fpm/fpm/zlog.c
@@ -128,7 +128,7 @@ int zlog_set_buffering(zlog_bool buffering) /* {{{ */
 
 static inline size_t zlog_truncate_buf(char *buf, size_t buf_size, size_t space_left) /* {{{ */
 {
-	memcpy(buf + buf_size - sizeof("...") + 1 - space_left, "...", sizeof("...") - 1);
+	memcpy(buf + buf_size - sizeof("...") + 1 - space_left, "...", strlen("..."));
 	return buf_size - space_left;
 }
 /* }}} */
@@ -389,7 +389,7 @@ static inline ssize_t zlog_stream_unbuffered_write(
 			append = NULL;
 		} else {
 			append = "...";
-			append_len = sizeof("...") - 1;
+			append_len = strlen("...");
 			len = zlog_limit - stream->len - append_len;
 		}
 	}

--- a/sapi/fuzzer/fuzzer-function-jit.c
+++ b/sapi/fuzzer/fuzzer-function-jit.c
@@ -23,21 +23,21 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 		return 0;
 	}
 
-	zend_string *jit_option = zend_string_init("opcache.jit", sizeof("opcache.jit") - 1, 1);
+	zend_string *jit_option = zend_string_init("opcache.jit", strlen("opcache.jit"), 1);
 
 	/* First run without JIT to determine whether we bail out. We should not run JITed code if
 	 * we bail out here, as the JIT code may loop infinitely. */
 	steps_left = MAX_STEPS;
 	bailed_out = false;
 	zend_alter_ini_entry_chars(
-		jit_option, "off", sizeof("off")-1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
+		jit_option, "off", strlen("off"), PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 	fuzzer_do_request_from_buffer(
 		FILE_NAME, (const char *) Data, Size, /* execute */ 1, opcache_invalidate);
 
 	if (!bailed_out) {
 		steps_left = MAX_STEPS;
 		zend_alter_ini_entry_chars(jit_option,
-			"function", sizeof("function")-1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
+			"function", strlen("function"), PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_execute_ex = orig_execute_ex;
 		fuzzer_do_request_from_buffer(
 			FILE_NAME, (const char *) Data, Size, /* execute */ 1, opcache_invalidate);

--- a/sapi/fuzzer/fuzzer-tracing-jit.c
+++ b/sapi/fuzzer/fuzzer-tracing-jit.c
@@ -23,21 +23,21 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 		return 0;
 	}
 
-	zend_string *jit_option = zend_string_init("opcache.jit", sizeof("opcache.jit") - 1, 1);
+	zend_string *jit_option = zend_string_init("opcache.jit", strlen("opcache.jit"), 1);
 
 	/* First run without JIT to determine whether we bail out. We should not run JITed code if
 	 * we bail out here, as the JIT code may loop infinitely. */
 	steps_left = MAX_STEPS;
 	bailed_out = false;
 	zend_alter_ini_entry_chars(
-		jit_option, "off", sizeof("off")-1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
+		jit_option, "off", strlen("off"), PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 	fuzzer_do_request_from_buffer(
 		FILE_NAME, (const char *) Data, Size, /* execute */ 1, opcache_invalidate);
 
 	if (!bailed_out) {
 		steps_left = MAX_STEPS;
 		zend_alter_ini_entry_chars(jit_option,
-			"tracing", sizeof("tracing")-1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
+			"tracing", strlen("tracing"), PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
 		zend_execute_ex = orig_execute_ex;
 		/* Trace & compile */
 		fuzzer_do_request_from_buffer(

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -392,8 +392,8 @@ static int sapi_lsapi_send_headers_like_cgi(sapi_headers_struct *sapi_headers)
         } else {
             h = (sapi_header_struct*)zend_llist_get_first_ex(&sapi_headers->headers, &pos);
             while (h) {
-                if (h->header_len > sizeof("Status:")-1 &&
-                    strncasecmp(h->header, "Status:", sizeof("Status:")-1) == 0
+                if (h->header_len > strlen("Status:") &&
+                    strncasecmp(h->header, "Status:", strlen("Status:")) == 0
                 ) {
                     has_status = 1;
                     break;
@@ -427,15 +427,15 @@ static int sapi_lsapi_send_headers_like_cgi(sapi_headers_struct *sapi_headers)
     while (h) {
         /* prevent CRLFCRLF */
         if (h->header_len) {
-            if (h->header_len > sizeof("Status:")-1 &&
-                strncasecmp(h->header, "Status:", sizeof("Status:")-1) == 0
+            if (h->header_len > strlen("Status:") &&
+                strncasecmp(h->header, "Status:", strlen("Status:")) == 0
             ) {
                 if (!ignore_status) {
                     ignore_status = 1;
                     LSAPI_AppendRespHeader(h->header, h->header_len);
                 }
-            } else if (response_status == 304 && h->header_len > sizeof("Content-Type:")-1 &&
-                       strncasecmp(h->header, "Content-Type:", sizeof("Content-Type:")-1) == 0
+            } else if (response_status == 304 && h->header_len > strlen("Content-Type:") &&
+                       strncasecmp(h->header, "Content-Type:", strlen("Content-Type:")) == 0
                    ) {
                 h = (sapi_header_struct*)zend_llist_get_next_ex(&sapi_headers->headers, &pos);
                 continue;

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1358,11 +1358,11 @@ phpdbg_main:
 
 			ini_entries = realloc(
 				ini_entries, ini_entries_len + (ze_len + (sizeof("zend_extension=\n"))));
-			memcpy(&ini_entries[ini_entries_len], "zend_extension=", (sizeof("zend_extension=\n")-1));
-			ini_entries_len += (sizeof("zend_extension=")-1);
+			memcpy(&ini_entries[ini_entries_len], "zend_extension=", (strlen("zend_extension=\n")));
+			ini_entries_len += (strlen("zend_extension="));
 			memcpy(&ini_entries[ini_entries_len], ze, ze_len);
 			ini_entries_len += ze_len;
-			memcpy(&ini_entries[ini_entries_len], "\n", (sizeof("\n") - 1));
+			memcpy(&ini_entries[ini_entries_len], "\n", (strlen("\n")));
 
 			free(zend_extensions[zend_extension]);
 			zend_extension++;

--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -877,7 +877,7 @@ static inline void phpdbg_create_conditional_break(phpdbg_breakcond_t *brake, co
 	new_break.code_len = expr_len;
 
 	bp_code = zend_string_concat3(
-		"return ", sizeof("return ")-1, expr, expr_len, ";", sizeof(";")-1);
+		"return ", strlen("return "), expr, expr_len, ";", strlen(";"));
 	new_break.ops = zend_compile_string(bp_code, "Conditional Breakpoint Code", ZEND_COMPILE_POSITION_AFTER_OPEN_TAG);
 	zend_string_release(bp_code);
 

--- a/sapi/phpdbg/phpdbg_cmd.c
+++ b/sapi/phpdbg/phpdbg_cmd.c
@@ -31,8 +31,8 @@ static inline const char *phpdbg_command_name(const phpdbg_command_t *command, c
 	if (command->parent) {
 		memcpy(&buffer[pos], command->parent->name, command->parent->name_len);
 		pos += command->parent->name_len;
-		memcpy(&buffer[pos], " ", sizeof(" ")-1);
-		pos += (sizeof(" ")-1);
+		memcpy(&buffer[pos], " ", strlen(" "));
+		pos += (strlen(" "));
 	}
 
 	memcpy(&buffer[pos], command->name, command->name_len);
@@ -627,15 +627,15 @@ PHPDBG_API const phpdbg_command_t *phpdbg_stack_resolve(const phpdbg_command_t *
 
 			while (it < matches) {
 				if (!list) {
-					list = emalloc(matched[it]->name_len + 1 + (it + 1 < matches ? sizeof(", ") - 1 : 0));
+					list = emalloc(matched[it]->name_len + 1 + (it + 1 < matches ? strlen(", ") : 0));
 				} else {
-					list = erealloc(list, (pos + matched[it]->name_len) + 1 + (it + 1 < matches ? sizeof(", ") - 1 : 0));
+					list = erealloc(list, (pos + matched[it]->name_len) + 1 + (it + 1 < matches ? strlen(", ") : 0));
 				}
 				memcpy(&list[pos], matched[it]->name, matched[it]->name_len);
 				pos += matched[it]->name_len;
 				if ((it + 1) < matches) {
-					memcpy(&list[pos], ", ", sizeof(", ") - 1);
-					pos += (sizeof(", ") - 1);
+					memcpy(&list[pos], ", ", strlen(", "));
+					pos += (strlen(", "));
 				}
 
 				list[pos] = 0;

--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -221,11 +221,11 @@ static void phpdbg_line_init(char *cmd, struct phpdbg_init_state *state) {
 
 	if (*cmd && cmd_len > 0L && cmd[0] != '#') {
 		if (cmd_len == 2) {
-			if (memcmp(cmd, "<:", sizeof("<:")-1) == SUCCESS) {
+			if (memcmp(cmd, "<:", strlen("<:")) == SUCCESS) {
 				state->in_code = 1;
 				return;
 			} else {
-				if (memcmp(cmd, ":>", sizeof(":>")-1) == SUCCESS) {
+				if (memcmp(cmd, ":>", strlen(":>")) == SUCCESS) {
 					state->in_code = 0;
 					state->code[state->code_len] = '\0';
 					zend_eval_stringl(state->code, state->code_len, NULL, "phpdbginit code");
@@ -525,7 +525,7 @@ int phpdbg_compile_stdin(zend_string *code) {
 		free(PHPDBG_G(exec));
 	}
 	PHPDBG_G(exec) = strdup("Standard input code");
-	PHPDBG_G(exec_len) = sizeof("Standard input code") - 1;
+	PHPDBG_G(exec_len) = strlen("Standard input code");
 	{ /* remove leading ?> from source */
 		int i;
 		/* remove trailing data after zero byte, used for avoiding conflicts in eval()'ed code snippets */
@@ -535,7 +535,7 @@ int phpdbg_compile_stdin(zend_string *code) {
 		PHPDBG_G(file_sources).pDestructor = NULL;
 		zend_hash_del(&PHPDBG_G(file_sources), source_path);
 		PHPDBG_G(file_sources).pDestructor = dtor;
-		zend_hash_str_update_ptr(&PHPDBG_G(file_sources), "Standard input code", sizeof("Standard input code")-1, data);
+		zend_hash_str_update_ptr(&PHPDBG_G(file_sources), "Standard input code", strlen("Standard input code"), data);
 		zend_string_release(source_path);
 
 		for (i = 1; i <= data->lines; i++) {

--- a/sapi/phpdbg/phpdbg_set.c
+++ b/sapi/phpdbg/phpdbg_set.c
@@ -221,9 +221,9 @@ PHPDBG_SET(stepping) /* {{{ */
 		phpdbg_writeln("Stepping %s", PHPDBG_G(flags) & PHPDBG_STEP_OPCODE ? "opcode" : "line");
 	} else switch (param->type) {
 		case STR_PARAM: {
-			if (param->len == sizeof("opcode") - 1 && !memcmp(param->str, "opcode", sizeof("opcode"))) {
+			if (param->len == strlen("opcode") && !memcmp(param->str, "opcode", sizeof("opcode"))) {
 				PHPDBG_G(flags) |= PHPDBG_STEP_OPCODE;
-			} else if (param->len == sizeof("line") - 1 && !memcmp(param->str, "line", sizeof("line"))) {
+			} else if (param->len == strlen("line") && !memcmp(param->str, "line", sizeof("line"))) {
 				PHPDBG_G(flags) &= ~PHPDBG_STEP_OPCODE;
 			} else {
 				phpdbg_error("usage set stepping [<opcode|line>]");

--- a/win32/console.c
+++ b/win32/console.c
@@ -111,6 +111,6 @@ PHP_WINUTIL_API BOOL php_win32_console_is_own(void)
 
 PHP_WINUTIL_API BOOL php_win32_console_is_cli_sapi(void)
 {/*{{{*/
-	return strlen(sapi_module.name) >= sizeof("cli") - 1 && !strncmp(sapi_module.name, "cli", sizeof("cli") - 1);
+	return strlen(sapi_module.name) >= strlen("cli") && !strncmp(sapi_module.name, "cli", strlen("cli"));
 }/*}}}*/
 


### PR DESCRIPTION
Modernize & unify code to the prefered variant [1]

regex replace used:
- from `sizeof(\s*\(\s*"[^"\\]*"\s*\))\s*-\s*1(?!\w)`
- to `strlen$1`

I firstly replaced all `*.h` and `*.c` files and then carefully reviewed the rest files.

[1] https://github.com/php/php-src/pull/8241#discussion_r834185411