### PR TITLE
Fixed bug #8338 (Intel CET is disabled unintentionally since PHP-8.1.0)

### DIFF
--- a/Zend/asm/jump_x86_64_sysv_elf_gas.S
+++ b/Zend/asm/jump_x86_64_sysv_elf_gas.S
@@ -24,12 +24,18 @@
  *                                                                                      *
  ****************************************************************************************/
 
+# if defined __CET__
+#  include <cet.h>
+# else
+#  define _CET_ENDBR
+# endif
 .file "jump_x86_64_sysv_elf_gas.S"
 .text
 .globl jump_fcontext
 .type jump_fcontext,@function
 .align 16
 jump_fcontext:
+    _CET_ENDBR
     leaq  -0x38(%rsp), %rsp /* prepare stack */
 
 #if !defined(BOOST_USE_TSX)

--- a/Zend/asm/make_x86_64_sysv_elf_gas.S
+++ b/Zend/asm/make_x86_64_sysv_elf_gas.S
@@ -24,12 +24,18 @@
  *                                                                                      *
  ****************************************************************************************/
 
+# if defined __CET__
+#  include <cet.h>
+# else
+#  define _CET_ENDBR
+# endif
 .file "make_x86_64_sysv_elf_gas.S"
 .text
 .globl make_fcontext
 .type make_fcontext,@function
 .align 16
 make_fcontext:
+    _CET_ENDBR
     /* first arg of make_fcontext() == top of context-stack */
     movq  %rdi, %rax
 
@@ -66,11 +72,13 @@ make_fcontext:
 trampoline:
     /* store return address on stack */
     /* fix stack alignment */
+    _CET_ENDBR
     push %rbp
     /* jump to context-function */
     jmp *%rbx
 
 finish:
+    _CET_ENDBR
     /* exit code is zero */
     xorq  %rdi, %rdi
     /* exit application */

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -141,7 +141,7 @@ typedef struct {
 
 /* These functions are defined in assembler files provided by boost.context (located in "Zend/asm"). */
 extern void *make_fcontext(void *sp, size_t size, void (*fn)(boost_context_data));
-extern boost_context_data jump_fcontext(void *to, zend_fiber_transfer *transfer);
+extern ZEND_INDIRECT_RETURN boost_context_data jump_fcontext(void *to, zend_fiber_transfer *transfer);
 #endif
 
 ZEND_API zend_class_entry *zend_ce_fiber;

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -679,4 +679,10 @@ extern "C++" {
 # define ZEND_VOIDP(ptr) (ptr)
 #endif
 
+#if defined(__GNUC__) && ZEND_GCC_VERSION >= 9000
+# define ZEND_INDIRECT_RETURN __attribute__((__indirect_return__))
+#else
+# define ZEND_INDIRECT_RETURN
+#endif
+
 #endif /* ZEND_PORTABILITY_H */


### PR DESCRIPTION
Intel Control Flow Enforcement Technology (CET) is enabled by default
since gcc v8.1. With CET, gcc emits following processor-specific program
property types in .note.gnu.property section:
- Indirect Branch Tracking (IBT)
- Shadow Stack (SHSTK)

Such properties are there before PHP-8.1.0.
$ sudo readelf -n sapi/cli/php
Displaying notes found in: .note.gnu.property
  Owner                Data size        Description
  GNU                  0x00000020       NT_GNU_PROPERTY_TYPE_0
        Properties: x86 feature: IBT, SHSTK
        x86 ISA needed: x86-64-baseline

However, the properties are missing since PHP-8.1.0.
$ sudo readelf -n sapi/cli/php
Displaying notes found in: .note.gnu.property
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_PROPERTY_TYPE_0
        Properties: x86 ISA needed: x86-64-baseline

This is caused by commit c276c16 "Implement Fibers" which introduces
some assembly files such as jump_x86_64_sysv_elf_gas.S and
make_x86_64_sysv_elf_gas.S. The object files of such assembly miss
.note.gnu.property section and thus the final output files miss it too.

Fix this via adding linker option.

Signed-off-by: Chen, Hu <hu1.chen@intel.com>