### PR TITLE
Configure diff drivers for `php`, `phpt`, `c` and `h` in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,7 +13,8 @@
 /UPGRADING           merge=NEWS
 /UPGRADING.INTERNALS merge=NEWS
 
-# Enable commit diffs for binary PHP test files. Some PHP test files include
-# special characters, such as ASCII control characters. Git recognizes these as
-# binary and wouldn't generate diffs.
-*.phpt diff
+# Configure proper diff drivers to improve the context lines in the output
+# of git diff and to improve token splitting for --word-diff.
+*.phpt diff=php
+*.php diff=php
+*.[ch] diff=cpp


### PR DESCRIPTION
Example for `*.phpt`:

git diff -U7 2145f80d4bb76c3fe9739671300091265b6e20d6^..2145f80d4bb76c3fe9739671300091265b6e20d6

Old:
```diff
@@ -22,14 +22,18 @@ enum CustomFoo implements JsonSerializable {
         return 'Custom ' . $this->name;
     }
 }
 
 function test($value) {
     var_dump(json_encode($value));
     echo json_last_error_msg() . "\n";
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        echo json_last_error() . ' === '  . JSON_ERROR_NON_BACKED_ENUM . ":\n";
+        var_dump(json_last_error() === JSON_ERROR_NON_BACKED_ENUM);
+    }
 
     try {
         var_dump(json_encode($value, JSON_THROW_ON_ERROR));
         echo json_last_error_msg() . "\n";
     } catch (Exception $e) {
         echo get_class($e) . ': ' . $e->getMessage() . "\n";
     }
```

New:
```diff
@@ -22,14 +22,18 @@ public function jsonSerialize(): mixed {
         return 'Custom ' . $this->name;
     }
 }
 
 function test($value) {
     var_dump(json_encode($value));
     echo json_last_error_msg() . "\n";
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        echo json_last_error() . ' === '  . JSON_ERROR_NON_BACKED_ENUM . ":\n";
+        var_dump(json_last_error() === JSON_ERROR_NON_BACKED_ENUM);
+    }
 
     try {
         var_dump(json_encode($value, JSON_THROW_ON_ERROR));
         echo json_last_error_msg() . "\n";
     } catch (Exception $e) {
         echo get_class($e) . ': ' . $e->getMessage() . "\n";
     }
```

:point_right: git understands that `return 'Custom ' . $this->name;` is in a method called `jsonSerialize` and not just in an enum called `CustomFoo`.

Example for `*.c`:

git diff --word-diff 7710f9946b1172721916b2b0982e19cc1dd17c13^..7710f9946b1172721916b2b0982e19cc1dd17c13

Old:
```diff
@@ -257,7 +257,7 @@ ZEND_END_ARG_INFO()
ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplFileObject_hasChildren, 0, 0, IS_FALSE, 0)
ZEND_END_ARG_INFO()

[-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_SplFileObject_getChildren,-]{+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplFileObject_getChildren,+} 0, 0, [-MAY_BE_NULL)-]{+IS_NULL, 1)+}
ZEND_END_ARG_INFO()

ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplFileObject_seek, 0, 1, IS_VOID, 0)
```

New:
```diff
@@ -257,7 +257,7 @@ ZEND_END_ARG_INFO()
ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplFileObject_hasChildren, 0, 0, IS_FALSE, 0)
ZEND_END_ARG_INFO()

[-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX-]{+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX+}(arginfo_class_SplFileObject_getChildren, 0, 0, [-MAY_BE_NULL-]{+IS_NULL, 1+})
ZEND_END_ARG_INFO()

ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_SplFileObject_seek, 0, 1, IS_VOID, 0)
```

:point_right: git understands that `(` is a token / word delimiter for `C` and thus realizes that `arginfo_class_SplFileObject_getChildren` is unchanged.