### PR TITLE
Allow reply to interractive SASL mechanisms

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -1442,6 +1442,12 @@ static int _php_sasl_interact(LDAP *ld, unsigned flags, void *defaults, void *in
 			case SASL_CB_PASS:
 				p = ctx->passwd;
 				break;
+			case SASL_CB_NOECHOPROMPT:
+				/* FALLTHROUGH */
+			case SASL_CB_ECHOPROMPT:
+				if (interact->challenge != NULL)
+					p = ctx->passwd;
+				break;
 		}
 		if (p) {
 			interact->result = p;


### PR DESCRIPTION
Some SASL mechanisms like OTP perform an interractive challenge-response.

Obviously it is not possible to perform the interraction within a single
HTTP transaction, but we may obtain the challenge from a first HTTP
transaction and send the reply during a second one. The only requirement
is that PHP LDAP module does not reject the second operation because
it should be part of an interractive exchange. This change does just that.