### PR TITLE
Fix `--EXTENSIONS--` section for two tests in ext/zend_test

### DIFF
--- a/ext/zend_test/tests/observer_bug81430_1.phpt
+++ b/ext/zend_test/tests/observer_bug81430_1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #81430 (Attribute instantiation frame accessing invalid frame pointer)
 --EXTENSIONS--
-zend-test
+zend_test
 --INI--
 memory_limit=20M
 zend_test.observer.enabled=1

--- a/ext/zend_test/tests/observer_bug81430_2.phpt
+++ b/ext/zend_test/tests/observer_bug81430_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #81430 (Attribute instantiation leaves dangling execute_data pointer)
 --EXTENSIONS--
-zend-test
+zend_test
 --INI--
 memory_limit=20M
 zend_test.observer.enabled=1


### PR DESCRIPTION
The extension name got broken in e6cf583160f2054da92426e69143e80ee28e8e16.