### PR TITLE
Add function exposing HAVE_GCC_GLOBAL_REGS

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -240,6 +240,15 @@ ZEND_API zval* zend_get_compiled_variable_value(const zend_execute_data *execute
 	return EX_VAR(var);
 }
 
+ZEND_API bool zend_gcc_global_regs(void)
+{
+  #if defined(HAVE_GCC_GLOBAL_REGS)
+        return 1;
+  #else
+        return 0;
+  #endif
+}
+
 static zend_always_inline zval *_get_zval_ptr_tmp(uint32_t var EXECUTE_DATA_DC)
 {
 	zval *ret = EX_VAR(var);

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -334,6 +334,8 @@ ZEND_API void zend_fetch_dimension_const(zval *result, zval *container, zval *di
 
 ZEND_API zval* zend_get_compiled_variable_value(const zend_execute_data *execute_data_ptr, uint32_t var);
 
+ZEND_API bool zend_gcc_global_regs(void);
+
 #define ZEND_USER_OPCODE_CONTINUE   0 /* execute next opcode */
 #define ZEND_USER_OPCODE_RETURN     1 /* exit from executor (return from function) */
 #define ZEND_USER_OPCODE_DISPATCH   2 /* call original opcode handler */

--- a/Zend/zend_vm.h
+++ b/Zend/zend_vm.h
@@ -29,6 +29,7 @@ ZEND_API const void* ZEND_FASTCALL zend_get_opcode_handler_func(const zend_op *o
 ZEND_API const zend_op *zend_get_halt_op(void);
 ZEND_API int ZEND_FASTCALL zend_vm_call_opcode_handler(zend_execute_data *ex);
 ZEND_API int zend_vm_kind(void);
+ZEND_API int zend_gcc_global_regs(void);
 
 void zend_vm_init(void);
 void zend_vm_dtor(void);

--- a/Zend/zend_vm.h
+++ b/Zend/zend_vm.h
@@ -29,7 +29,7 @@ ZEND_API const void* ZEND_FASTCALL zend_get_opcode_handler_func(const zend_op *o
 ZEND_API const zend_op *zend_get_halt_op(void);
 ZEND_API int ZEND_FASTCALL zend_vm_call_opcode_handler(zend_execute_data *ex);
 ZEND_API int zend_vm_kind(void);
-ZEND_API int zend_gcc_global_regs(void);
+ZEND_API bool zend_gcc_global_regs(void);
 
 void zend_vm_init(void);
 void zend_vm_dtor(void);

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -144,12 +144,3 @@ ZEND_API int zend_vm_kind(void)
 {
 	return ZEND_VM_KIND;
 }
-
-ZEND_API bool zend_gcc_global_regs(void)
-{
-#if defined(HAVE_GCC_GLOBAL_REGS)
-        return 1;
-#else
-        return 0;
-#endif
-}

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -145,7 +145,7 @@ ZEND_API int zend_vm_kind(void)
 	return ZEND_VM_KIND;
 }
 
-ZEND_API int zend_gcc_global_regs(void)
+ZEND_API bool zend_gcc_global_regs(void)
 {
 #if defined(HAVE_GCC_GLOBAL_REGS)
         return 1;

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -144,3 +144,12 @@ ZEND_API int zend_vm_kind(void)
 {
 	return ZEND_VM_KIND;
 }
+
+ZEND_API int zend_gcc_global_regs(void)
+{
+#if defined(HAVE_GCC_GLOBAL_REGS)
+        return 1;
+#else
+        return 0;
+#endif
+}


### PR DESCRIPTION
# What's the problem?

Understanding what's happening during the PHP JIT compilation process is a bit tricky. Some of this complexity is inherent, but the Zend Engine (at present) doesn't make it that easy to gauge what's going on via a debugger like GDB.

For example, consider the following snippet from the JIT compiler:

https://github.com/php/php-src/blob/c345b6ee7232df3ce88bfe3521ce00643ae66c3a/ext/opcache/jit/zend_jit_x86.dasc#L1742-L1766

To understand how this impacts the generated code you need to know at minimum:

- The VM mode that has been used, and 
- Whether GCC was used to compile the Zend Engine or not.

You can deduce the first of these at runtime using ```zend_vm_kind```:

https://github.com/php/php-src/blob/5b01c4863fe9e4bc2702b2bbf66d292d23001a18/Zend/zend_vm.h#L31

But there's no way to know the second of these programatically at present. You can deduce this by looking at the object code in GDB, but that's tedious and not suited to any sort of automated checking.

# This PR
This PR just adds a public function called ```zend_gcc_global_regs``` that returns 1 if HAVE_GCC_GLOBAL_REGS is set and 0 otherwise. This makes it far simpler to detect what calling convention to expect. 