### PR TITLE
Fix openssl_csr_export() stub

### DIFF
--- a/ext/openssl/openssl.stub.php
+++ b/ext/openssl/openssl.stub.php
@@ -66,7 +66,7 @@ function openssl_pkcs12_read(string $pkcs12, &$certificates, string $passphrase)
 
 function openssl_csr_export_to_file(OpenSSLCertificateSigningRequest|string $csr, string $output_filename, bool $no_text = true): bool {}
 
-/** @param OpenSSLAsymmetricKey $output */
+/** @param string $output */
 function openssl_csr_export(OpenSSLCertificateSigningRequest|string $csr, &$output, bool $no_text = true): bool {}
 
 /** @param OpenSSLAsymmetricKey|OpenSSLCertificate|array|string $private_key */


### PR DESCRIPTION
There is a problem with current documentation of `openssl_csr_export()` function:

From [the documentation](https://www.php.net/manual/en/function.openssl-csr-export.php):

openssl_csr_export — Exports a CSR as a string

```php
openssl_csr_export(OpenSSLCertificateSigningRequest|string $csr, OpenSSLAsymmetricKey &$output, bool $no_text = true): bool
```

The `$output` parameter was changed from `string` to `OpenSSLAsymmetricKey` in 9f44eca6b60f8073dc9e2aa31154f9d70b42938d

This was probably just a mistake due to the first `$csr` parameter type being changed from `resource` to dedicated data type, along with other `openssl_*` functions. The function actually crashes when passed a reference to a variable of type `OpenSSLAsymmetricKey`.

- Link to 7.4.28 source code [ext/openssl/openssl.c](https://github.com/php/php-src/blob/PHP-7.4.28/ext/openssl/openssl.c#L3404)
- Link to 8.0.0 source code [ext/openssl/openssl.c](https://github.com/php/php-src/blob/PHP-8.0.0/ext/openssl/openssl.c#L3092) 
- Link to test [ext/openssl/tests/openssl_csr_export_basic.phpt](https://github.com/php/php-src/blob/PHP-8.0.0/ext/openssl/tests/openssl_csr_export_basic.phpt)

Here's a test that crashes:

```php
<?php

declare(strict_types=1);

$private_key = openssl_pkey_new(array(
    "private_key_bits" => 2048,
    "private_key_type" => OPENSSL_KEYTYPE_RSA,
));

$csr = openssl_csr_new([], $private_key);

/**
 * Test 1
 * openssl_csr_export() accepts string
 */
class StringTest {
    public string $string;

    public function __construct(string $string = '') {
        $this->string = $string;
    }
}

$test = new StringTest;

openssl_csr_export($csr, $test->string);

/**
 * Test 2
 * openssl_csr_export() does not accept OpenSSLAsymmetricKey
 */
class ObjectTest {
    public OpenSSLAsymmetricKey $object;

    public function __construct(OpenSSLAsymmetricKey $object) {
        $this->object = $object;
    }
}

$test = new ObjectTest($private_key);

// PHP Fatal error:  Uncaught TypeError: Cannot assign string to reference held by property ObjectTest::$object of type OpenSSLAsymmetricKey
openssl_csr_export($csr, $test->object);
```