### PR TITLE
List skipped extensions in run-tests.php

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -877,8 +877,12 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         $ext_dir = ini_get('extension_dir');
         foreach (scandir($ext_dir) as $file) {
             if (preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:so|dll)$/', $file, $matches)) {
-                $t = microtime(true);
-                var_dump($matches[1]);
+                // remove once https://github.com/php/php-src/issues/9196 is fixed
+                // @dl() is fast (about 1 ms / dl() call)
+                if (extension_loaded($matches[1])) {
+                    continue;
+                }
+
                 if (dl($matches[1])) {
                     $exts[] = $matches[1];
                     $exts[] = microtime(true) - $t;

--- a/run-tests.php
+++ b/run-tests.php
@@ -878,6 +878,7 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         foreach (scandir($ext_dir) as $file) {
             if (preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:so|dll)$/', $file, $matches)) {
                 $t = microtime(true);
+                var_dump($matches[1]);
                 if (dl($matches[1])) {
                     $exts[] = $matches[1];
                     $exts[] = microtime(true) - $t;

--- a/run-tests.php
+++ b/run-tests.php
@@ -748,11 +748,6 @@ function main(): void
             }
         }
 
-        // Convert extension names to lowercase
-        foreach ($exts_to_test as $key => $val) {
-            $exts_to_test[$key] = strtolower($val);
-        }
-
         foreach ($test_dirs as $dir) {
             find_files(TEST_PHP_SRCDIR . "/{$dir}", $dir == 'ext');
         }

--- a/run-tests.php
+++ b/run-tests.php
@@ -1049,7 +1049,7 @@ function find_files(string $dir, bool $is_ext_dir = false, bool $ignore = false)
 
     while (($name = readdir($o)) !== false) {
         if (is_dir("{$dir}/{$name}") && !in_array($name, ['.', '..', '.svn'])) {
-            $skip_ext = ($is_ext_dir && !in_array(strtolower($name), $exts_to_test));
+            $skip_ext = ($is_ext_dir && !in_array($name, $exts_to_test));
             if ($skip_ext) {
                 $exts_skipped[] = $name;
             }

--- a/run-tests.php
+++ b/run-tests.php
@@ -877,22 +877,20 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         $ext_dir = ini_get('extension_dir');
         foreach (scandir($ext_dir) as $file) {
             if (preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:so|dll)$/', $file, $matches)) {
+                // workaround dl('mysqli') fatal error
                 // remove once https://github.com/php/php-src/issues/9196 is fixed
-                // @dl() is fast (about 1 ms / dl() call)
-                if (extension_loaded($matches[1])) {
+                if ($matches[1] === 'mysqli') {
                     continue;
                 }
 
-                if (dl($matches[1])) {
+                if (@dl($matches[1])) {
                     $exts[] = $matches[1];
-                    $exts[] = microtime(true) - $t;
                 }
             }
         }
         echo implode(',', $exts);
         PHP);
     $extensionsNames = explode(',', shell_exec("$php $pass_options $info_params $no_file_cache \"$info_file\""));
-    print_r($extensionsNames);echo "\nxxxxxx\n\n\n";
     $exts_to_test = array_unique(remap_loaded_extensions_names($extensionsNames));
     // check for extensions that need special handling and regenerate
     $info_params_ex = [

--- a/run-tests.php
+++ b/run-tests.php
@@ -877,14 +877,17 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         $ext_dir = ini_get('extension_dir');
         foreach (scandir($ext_dir) as $file) {
             if (preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:so|dll)$/', $file, $matches)) {
-                if (@dl($matches[1])) {
+                $t = microtime(true);
+                if (dl($matches[1])) {
                     $exts[] = $matches[1];
+                    $exts[] = microtime(true) - $t;
                 }
             }
         }
         echo implode(',', $exts);
         PHP);
     $extensionsNames = explode(',', shell_exec("$php $pass_options $info_params $no_file_cache \"$info_file\""));
+    print_r($extensionsNames);echo "\nxxxxxx\n\n\n";
     $exts_to_test = array_unique(remap_loaded_extensions_names($extensionsNames));
     // check for extensions that need special handling and regenerate
     $info_params_ex = [

--- a/run-tests.php
+++ b/run-tests.php
@@ -23,8 +23,6 @@
    +----------------------------------------------------------------------+
  */
 
-/* $Id$ */
-
 /* Temporary variables while this file is being refactored. */
 /** @var ?JUnit */
 $junit = null;

--- a/run-tests.php
+++ b/run-tests.php
@@ -3100,43 +3100,43 @@ function get_summary(bool $show_ext_summary): string
 =====================================================================
 TEST RESULT SUMMARY
 ---------------------------------------------------------------------
-Exts skipped    : ' . sprintf('%4d', count($exts_skipped)) . ($exts_skipped ? ' (' . implode(', ', $exts_skipped) . ')' : '') . '
-Exts tested     : ' . sprintf('%4d', count($exts_tested)) . '
+Exts skipped    : ' . sprintf('%5d', count($exts_skipped)) . ($exts_skipped ? ' (' . implode(', ', $exts_skipped) . ')' : '') . '
+Exts tested     : ' . sprintf('%5d', count($exts_tested)) . '
 ---------------------------------------------------------------------
 ';
     }
 
     $summary .= '
-Number of tests : ' . sprintf('%4d', $n_total) . '          ' . sprintf('%8d', $x_total);
+Number of tests : ' . sprintf('%5d', $n_total) . '          ' . sprintf('%8d', $x_total);
 
     if ($sum_results['BORKED']) {
         $summary .= '
-Tests borked    : ' . sprintf('%4d (%5.1f%%)', $sum_results['BORKED'], $percent_results['BORKED']) . ' --------';
+Tests borked    : ' . sprintf('%5d (%5.1f%%)', $sum_results['BORKED'], $percent_results['BORKED']) . ' --------';
     }
 
     $summary .= '
-Tests skipped   : ' . sprintf('%4d (%5.1f%%)', $sum_results['SKIPPED'], $percent_results['SKIPPED']) . ' --------
-Tests warned    : ' . sprintf('%4d (%5.1f%%)', $sum_results['WARNED'], $percent_results['WARNED']) . ' ' . sprintf('(%5.1f%%)', $x_warned) . '
-Tests failed    : ' . sprintf('%4d (%5.1f%%)', $sum_results['FAILED'], $percent_results['FAILED']) . ' ' . sprintf('(%5.1f%%)', $x_failed);
+Tests skipped   : ' . sprintf('%5d (%5.1f%%)', $sum_results['SKIPPED'], $percent_results['SKIPPED']) . ' --------
+Tests warned    : ' . sprintf('%5d (%5.1f%%)', $sum_results['WARNED'], $percent_results['WARNED']) . ' ' . sprintf('(%5.1f%%)', $x_warned) . '
+Tests failed    : ' . sprintf('%5d (%5.1f%%)', $sum_results['FAILED'], $percent_results['FAILED']) . ' ' . sprintf('(%5.1f%%)', $x_failed);
 
     if ($sum_results['XFAILED']) {
         $summary .= '
-Expected fail   : ' . sprintf('%4d (%5.1f%%)', $sum_results['XFAILED'], $percent_results['XFAILED']) . ' ' . sprintf('(%5.1f%%)', $x_xfailed);
+Expected fail   : ' . sprintf('%5d (%5.1f%%)', $sum_results['XFAILED'], $percent_results['XFAILED']) . ' ' . sprintf('(%5.1f%%)', $x_xfailed);
     }
 
     if ($valgrind) {
         $summary .= '
-Tests leaked    : ' . sprintf('%4d (%5.1f%%)', $sum_results['LEAKED'], $percent_results['LEAKED']) . ' ' . sprintf('(%5.1f%%)', $x_leaked);
+Tests leaked    : ' . sprintf('%5d (%5.1f%%)', $sum_results['LEAKED'], $percent_results['LEAKED']) . ' ' . sprintf('(%5.1f%%)', $x_leaked);
         if ($sum_results['XLEAKED']) {
             $summary .= '
-Expected leak   : ' . sprintf('%4d (%5.1f%%)', $sum_results['XLEAKED'], $percent_results['XLEAKED']) . ' ' . sprintf('(%5.1f%%)', $x_xleaked);
+Expected leak   : ' . sprintf('%5d (%5.1f%%)', $sum_results['XLEAKED'], $percent_results['XLEAKED']) . ' ' . sprintf('(%5.1f%%)', $x_xleaked);
         }
     }
 
     $summary .= '
-Tests passed    : ' . sprintf('%4d (%5.1f%%)', $sum_results['PASSED'], $percent_results['PASSED']) . ' ' . sprintf('(%5.1f%%)', $x_passed) . '
+Tests passed    : ' . sprintf('%5d (%5.1f%%)', $sum_results['PASSED'], $percent_results['PASSED']) . ' ' . sprintf('(%5.1f%%)', $x_passed) . '
 ---------------------------------------------------------------------
-Time taken      : ' . sprintf('%4d seconds', $end_time - $start_time) . '
+Time taken      : ' . sprintf('%5d seconds', $end_time - $start_time) . '
 =====================================================================
 ';
     $failed_test_summary = '';

--- a/run-tests.php
+++ b/run-tests.php
@@ -2020,7 +2020,7 @@ TEST $file
         $ext_prefix = IS_WINDOWS ? "php_" : "";
         $missing = [];
         foreach ($extensions as $req_ext) {
-            if (!in_array(strtolower($req_ext), $loaded)) {
+            if (!in_array($req_ext, $loaded, true)) {
                 if ($req_ext == 'opcache' || $req_ext == 'xdebug') {
                     $ext_file = $ext_dir . DIRECTORY_SEPARATOR . $ext_prefix . $req_ext . '.' . PHP_SHLIB_SUFFIX;
                     $ini_settings['zend_extension'][] = $ext_file;

--- a/run-tests.php
+++ b/run-tests.php
@@ -877,13 +877,7 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         $ext_dir = ini_get('extension_dir');
         foreach (scandir($ext_dir) as $file) {
             if (preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:so|dll)$/', $file, $matches)) {
-                // workaround dl('mysqli') fatal error
-                // remove once https://github.com/php/php-src/issues/9196 is fixed
-                if ($matches[1] === 'mysqli') {
-                    continue;
-                }
-
-                if (@dl($matches[1])) {
+                if (!extension_loaded($matches[1]) && @dl($matches[1])) {
                     $exts[] = $matches[1];
                 }
             }

--- a/run-tests.php
+++ b/run-tests.php
@@ -880,17 +880,21 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
     // load list of enabled and loadable extensions
     save_text($info_file, <<<'PHP'
         <?php
-        echo str_replace("Zend OPcache", "opcache", implode(",", get_loaded_extensions()));
-        $ext_dir = ini_get("extension_dir");
+        $exts = [];
+        foreach (get_loaded_extensions() as $ext) {
+            $exts[] = ['Zend OPcache' => 'opcache'][$ext] ?? $ext;
+        }
+        $ext_dir = ini_get('extension_dir');
         foreach (scandir($ext_dir) as $file) {
             if (!preg_match('/^(?:php_)?([_a-zA-Z0-9]+)\.(?:so|dll)$/', $file, $matches)) {
                 continue;
             }
             $ext = $matches[1];
-            if (!extension_loaded($ext) && @dl($file)) {
-                echo ",", $ext;
+            if (!in_array($ext, $exts) && !extension_loaded($ext) && @dl($file)) {
+                $exts[] = $ext;
             }
         }
+        echo implode(',', $exts);
         ?>
     PHP);
     $exts_to_test = explode(',', shell_exec("$php $pass_options $info_params $no_file_cache \"$info_file\""));


### PR DESCRIPTION
discovered in https://github.com/php/php-src/pull/8348 - Tests skipped because of missing ext were listed nowhere, this change improves the testing output by listing the skipped exts.

discovered in https://github.com/php/php-src/pull/8363#issuecomment-1243634794 - The https://github.com/php/php-src/blob/c809a213f231eba7a10b1a61164bf2b1ea9df7b3/run-tests.php#L890 was producing silently ignored! fatal error due https://github.com/php/php-src/issues/9196 (as the loaded exts were echoed at the start, the problem remained hidden, with this PR, we echo at the end, and fatal error will imply no loaded ext will be detected at all - easy to notice any problem)

also, we centralize the place where we normalize the loaded ext names to ext so/dll filenames