### PR TITLE
Improve and fix stub return types

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -134,7 +134,6 @@ static const func_info_t func_infos[] = {
 #if defined(HAVE_GD_BMP)
     F1("imagecreatefrombmp", MAY_BE_OBJECT|MAY_BE_FALSE),
 #endif
-    F0("imagecolorset", MAY_BE_FALSE|MAY_BE_NULL),
     F1("imagecolorsforindex", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG),
     F1("imagegetclip", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_LONG),
 #if defined(HAVE_GD_FREETYPE)
@@ -514,7 +513,6 @@ static const func_info_t func_infos[] = {
     F1("get_current_user", MAY_BE_STRING),
     FN("get_cfg_var", MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_STRING|MAY_BE_ARRAY_OF_ARRAY|MAY_BE_FALSE),
     F1("error_get_last", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_NULL),
-    F0("register_shutdown_function", MAY_BE_FALSE|MAY_BE_NULL),
     F1("highlight_file", MAY_BE_STRING|MAY_BE_BOOL),
     F1("php_strip_whitespace", MAY_BE_STRING),
     F1("highlight_string", MAY_BE_STRING|MAY_BE_BOOL),
@@ -619,7 +617,6 @@ static const func_info_t func_infos[] = {
 #endif
     F1("exec", MAY_BE_STRING|MAY_BE_FALSE),
     F1("system", MAY_BE_STRING|MAY_BE_FALSE),
-    F0("passthru", MAY_BE_FALSE|MAY_BE_NULL),
     F1("escapeshellcmd", MAY_BE_STRING),
     F1("escapeshellarg", MAY_BE_STRING),
     F1("shell_exec", MAY_BE_STRING|MAY_BE_FALSE|MAY_BE_NULL),

--- a/ext/gd/gd.stub.php
+++ b/ext/gd/gd.stub.php
@@ -190,8 +190,7 @@ function imagecolorresolve(GdImage $image, int $red, int $green, int $blue): int
 
 function imagecolorexact(GdImage $image, int $red, int $green, int $blue): int {}
 
-/** @return false|null */
-function imagecolorset(GdImage $image, int $color, int $red, int $green, int $blue, int $alpha = 0): ?bool {}
+function imagecolorset(GdImage $image, int $color, int $red, int $green, int $blue, int $alpha = 0): false|null {}
 
 /**
  * @return array<string, int>

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4de3d369fad259705acc5bf5de0e935b7e142ec7 */
+ * Stub hash: a60454e502813da9aba42100fdbfd619c8da54d2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gd_info, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -315,7 +315,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_imagecolorexact arginfo_imagecolorclosest
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagecolorset, 0, 5, _IS_BOOL, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagecolorset, 0, 5, IS_FALSE, 1)
 	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
 	ZEND_ARG_TYPE_INFO(0, color, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, red, IS_LONG, 0)

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -464,8 +464,7 @@ function forward_static_call(callable $callback, mixed ...$args): mixed {}
 
 function forward_static_call_array(callable $callback, array $args): mixed {}
 
-/** @return false|null */
-function register_shutdown_function(callable $callback, mixed ...$args): ?bool {}
+function register_shutdown_function(callable $callback, mixed ...$args): void {}
 
 /** @refcount 1 */
 function highlight_file(string $filename, bool $return = false): string|bool {}
@@ -1087,11 +1086,8 @@ function exec(string $command, &$output = null, &$result_code = null): string|fa
  */
 function system(string $command, &$result_code = null): string|false {}
 
-/**
- * @param int $result_code
- * @return false|null
- */
-function passthru(string $command, &$result_code = null): ?bool {}
+/** @param int $result_code */
+function passthru(string $command, &$result_code = null): false|null {}
 
 /** @refcount 1 */
 function escapeshellcmd(string $command): string {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bbcebdb57572133d5f442f220f1e98a1320ed0f6 */
+ * Stub hash: b1c51fabe59bba6706500365f3eb7d9676d625f6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -459,7 +459,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_forward_static_call_array arginfo_call_user_func_array
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_register_shutdown_function, 0, 1, _IS_BOOL, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_register_shutdown_function, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, args, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
@@ -1151,7 +1151,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_system, 0, 1, MAY_BE_STRING|MAY_
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, result_code, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_passthru, 0, 1, _IS_BOOL, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_passthru, 0, 1, IS_FALSE, 1)
 	ZEND_ARG_TYPE_INFO(0, command, IS_STRING, 0)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, result_code, "null")
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
I don't see how ``register_shutdown_function()`` can ever return ``false``