### PR TITLE
Fix GH-8366: ArrayIterator may leak when calling __construct()

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1129,7 +1129,10 @@ static void spl_array_set_array(zval *object, spl_array_object *intern, zval *ar
 
 	intern->ar_flags &= ~SPL_ARRAY_IS_SELF & ~SPL_ARRAY_USE_OTHER;
 	intern->ar_flags |= ar_flags;
-	intern->ht_iter = (uint32_t)-1;
+	if (intern->ht_iter != (uint32_t)-1) {
+		zend_hash_iterator_del(intern->ht_iter);
+		intern->ht_iter = (uint32_t)-1;
+	}
 }
 /* }}} */
 

--- a/ext/spl/tests/gh8366.phpt
+++ b/ext/spl/tests/gh8366.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug GH-8366 (ArrayIterator may leak when calling __construct())
+--FILE--
+<?php
+$it = new \ArrayIterator();
+foreach ($it as $elt) {}
+$it->__construct([]);
+?>
+--EXPECT--


### PR DESCRIPTION
When we detach an iterator, we must also have to delete it.