### PR TITLE
strlcpy update to last openbsd version.

### DIFF
--- a/main/strlcat.c
+++ b/main/strlcat.c
@@ -61,10 +61,7 @@ static const char *rcsid = "$OpenBSD: strlcat.c,v 1.17 2016/10/14 18:19:04 dtuck
  * Returns strlen(src) + MIN(siz, strlen(initial dst).
  * If retval >= siz, truncation occurred.
  */
-PHPAPI size_t php_strlcat(dst, src, siz)
-	char *dst;
-	const char *src;
-	size_t siz;
+PHPAPI size_t php_strlcat(char *dst, const char *src, size_t siz)
 {
 	const char *d = dst;
 	const char *s = src;

--- a/main/strlcpy.c
+++ b/main/strlcpy.c
@@ -59,10 +59,7 @@ static const char *rcsid = "$OpenBSD: strlcpy.c,v 1.15 2016/10/16 17:37:39 dtuck
  * will be copied.  Always NUL terminates (unless siz == 0).
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
-PHPAPI size_t php_strlcpy(dst, src, siz)
-	char *dst;
-	const char *src;
-	size_t siz;
+PHPAPI size_t php_strlcpy(char *dst, const char *src, size_t siz)
 {
 	const char *s = src;
 	size_t n = siz;
@@ -83,12 +80,7 @@ PHPAPI size_t php_strlcpy(dst, src, siz)
 			;
 	}
 
-	/*
-	 * Cast pointers to unsigned type before calculation, to avoid signed
-	 * overflow when the string ends where the MSB has changed.
-	 * Return value does not include NUL.
-	 */
-	return((uintptr_t)src - (uintptr_t)s - 1);
+	return(src - s - 1);
 }
 
 #endif /* !HAVE_STRLCPY */


### PR DESCRIPTION
CVS date not changed as in fact the actual version is related to an earier date
 in reality.
They ditched the `uintptr_t`cast finally.