### PR TITLE
Fix leak introduced by GH-8241

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1586,6 +1586,8 @@ int main(int argc, char *argv[])
 			case 'd':
 				/* define ini entries on command line */
 				php_ini_builder_define(&ini_builder, php_optarg);
+				/* main can terminate without finishing or deiniting the ini builder, call finish each iteration to avoid leaking the buffer */
+				cgi_sapi_module.ini_entries = php_ini_builder_finish(&ini_builder);
 				break;
 
 			case 'y':


### PR DESCRIPTION
Temporarily store result of ini builder in ini_entries to avoid a leak
when main() exists prematurely. Technically ini_entries isn't released
either but ASAN doesn't consider unreleased memory referenced from
globals leaks.

@MaxKellermann WDYT? Do you see a cleaner solution?