### PR TITLE
Fix GH-8364: msgfmt_format $values may not support references

### DIFF
--- a/ext/intl/msgformat/msgformat_helpers.cpp
+++ b/ext/intl/msgformat/msgformat_helpers.cpp
@@ -392,6 +392,7 @@ U_CFUNC void umsg_format_helper(MessageFormatter_object *mfo,
 	zend_ulong		 num_index;
 
 	ZEND_HASH_FOREACH_KEY_VAL(args, num_index, str_index, elem) {
+		ZVAL_DEREF(elem);
 		Formattable& formattable = fargs[argNum];
 		UnicodeString& key = farg_names[argNum];
 		Formattable::Type argType = Formattable::kObject, //unknown

--- a/ext/intl/tests/gh8364.phpt
+++ b/ext/intl/tests/gh8364.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug GH-8364 (msgfmt_format $values may not support references)
+--SKIPIF--
+<?php
+if (!extension_loaded("intl")) die("skip intl extension not available");
+?>
+--FILE--
+<?php
+$formatter = new MessageFormatter('en', 'translate {0}');
+$args = ['string', 'string'];
+foreach ($args as &$arg) {
+//     do nothing;
+}
+$result = $formatter->format($args);
+var_dump($result);
+var_dump(intl_get_error_code());
+?>
+--EXPECT--
+string(16) "translate string"
+int(0)


### PR DESCRIPTION
We need to deref any references passed in the `$values` array.  While
we could handle this in the type switch, doing it right away in the
foreach loop makes that more explicit, and also circumvents the missing
range checks for integers which are not passed as int or double.