### PR TITLE
fpm: listen backlog should default to -1 also on Linux

### DIFF
--- a/sapi/fpm/fpm/fpm_sockets.h
+++ b/sapi/fpm/fpm/fpm_sockets.h
@@ -14,7 +14,7 @@
 /*
   On FreeBSD and OpenBSD, backlog negative values are truncated to SOMAXCONN
 */
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__linux__)
 #define FPM_BACKLOG_DEFAULT -1
 #else
 #define FPM_BACKLOG_DEFAULT 511


### PR DESCRIPTION
On linux -1 means system administrator choosen default or kernel
default, this varies between kernel versions or distributions
it used to be 128,on which 511 won't work unless default was overriden by sysadmin.
 Now it is 4096, where 511 is too low.