### PR TITLE
main: set IP_BIND_ADDRESS_NO_PORT if available when connecting to remote host

### DIFF
--- a/main/network.c
+++ b/main/network.c
@@ -885,6 +885,12 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
 				}
 			}
 #endif
+#ifdef IP_BIND_ADDRESS_NO_PORT
+        {
+            int val = 1;
+            (void) setsockopt(sock, SOL_IP, IP_BIND_ADDRESS_NO_PORT, &val, sizeof(val));
+        }
+#endif
 			if (local_address_len == 0) {
 				php_error_docref(NULL, E_WARNING, "Invalid IP Address: %s", bindto);
 			} else if (bind(sock, &local_address.common, local_address_len)) {


### PR DESCRIPTION


When you choose to bind() to a local address and connect to a remote host
the kernel does not know if socket is listener or whatnot and has to reserve
a port within a ~32k range on which you are also competing with other
applications bound to the same address, this is easy to exhaust and get a
EADDRINUSE.
The linux kernel implemented IP_BIND_ADDRESS_NO_PORT on
https://github.com/torvalds/linux/commit/90c337da1524863838658078ec34241f45d8394d
which delays the port allocation until the 4-tuple is known in case source port
is 0.