### PR TITLE
main/streams/streams: use copy_file_range() on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -364,6 +364,7 @@ PHP_CHECK_FUNC(socketpair, socket, network)
 PHP_CHECK_FUNC(htonl, socket, network)
 PHP_CHECK_FUNC(gethostname, nsl, network)
 PHP_CHECK_FUNC(gethostbyaddr, nsl, network)
+PHP_CHECK_FUNC(copy_file_range)
 PHP_CHECK_FUNC(dlopen, dl, root)
 PHP_CHECK_FUNC(dlsym, dl, root)
 if test "$ac_cv_func_dlopen" = "yes"; then

--- a/ext/standard/tests/file/stream_copy_to_stream.phpt
+++ b/ext/standard/tests/file/stream_copy_to_stream.phpt
@@ -12,6 +12,8 @@ stream_filter_append($src, "string.rot13", STREAM_FILTER_READ);
 
 $dest = fopen($new_file, 'w');
 var_dump(stream_copy_to_stream($src, $dest, 0));
+var_dump(ftell($src));
+var_dump(ftell($dest));
 fclose($src); fclose($dest);
 
 var_dump(file_get_contents($new_file));
@@ -24,6 +26,8 @@ stream_filter_append($src, "string.rot13", STREAM_FILTER_READ);
 
 $dest = fopen($new_file, 'w');
 var_dump(stream_copy_to_stream($src, $dest, -1));
+var_dump(ftell($src));
+var_dump(ftell($dest));
 fclose($src); fclose($dest);
 if (WIN) {
   var_dump(str_replace("\r\n","\n", file_get_contents($new_file)));
@@ -39,6 +43,8 @@ stream_filter_append($src, "string.rot13", STREAM_FILTER_READ);
 
 $dest = fopen($new_file, 'w');
 var_dump(stream_copy_to_stream($src, $dest));
+var_dump(ftell($src));
+var_dump(ftell($dest));
 fclose($src); fclose($dest);
 
 if (WIN) {
@@ -54,6 +60,8 @@ $src = fopen($initial_file, 'r');
 
 $dest = fopen($new_file, 'w');
 var_dump(stream_copy_to_stream($src, $dest));
+var_dump(ftell($src));
+var_dump(ftell($dest));
 fclose($src); fclose($dest);
 
 if (WIN) {
@@ -69,6 +77,8 @@ $src = fopen($initial_file, 'r');
 
 $dest = fopen($new_file, 'w');
 var_dump(stream_copy_to_stream($src, $dest, 1000000));
+var_dump(ftell($src));
+var_dump(ftell($dest));
 fclose($src); fclose($dest);
 
 if (WIN) {
@@ -85,6 +95,8 @@ $src = fopen($initial_file, 'r');
 
 $dest = fopen($new_file, 'w');
 var_dump(stream_copy_to_stream($src, $dest, 10));
+var_dump(ftell($src));
+var_dump(ftell($dest));
 fclose($src); fclose($dest);
 
 if (WIN) {
@@ -100,6 +112,8 @@ $src = fopen($initial_file, 'r');
 
 $dest = fopen($new_file, 'w');
 var_dump(stream_copy_to_stream($src, $dest, -1));
+var_dump(ftell($src));
+var_dump(ftell($dest));
 fclose($src); fclose($dest);
 
 if (WIN) {
@@ -113,8 +127,12 @@ echo "Done\n";
 ?>
 --EXPECTF--
 int(0)
+int(0)
+int(0)
 string(0) ""
 int(%d)
+int(134)
+int(134)
 string(134) "Nabgure qnl
 Jura gur cnvaf bs yvsr jba'g one zl jnl
 V'yy oernx gurfr punvaf
@@ -122,6 +140,8 @@ Gung ubyq zr qbja
 V'yy grne lbh qbja vagb zl cevingr uryy
 "
 int(%d)
+int(134)
+int(134)
 string(134) "Nabgure qnl
 Jura gur cnvaf bs yvsr jba'g one zl jnl
 V'yy oernx gurfr punvaf
@@ -129,6 +149,8 @@ Gung ubyq zr qbja
 V'yy grne lbh qbja vagb zl cevingr uryy
 "
 int(%d)
+int(134)
+int(134)
 string(134) "Another day
 When the pains of life won't bar my way
 I'll break these chains
@@ -136,6 +158,8 @@ That hold me down
 I'll tear you down into my private hell
 "
 int(%d)
+int(134)
+int(134)
 string(134) "Another day
 When the pains of life won't bar my way
 I'll break these chains
@@ -143,8 +167,12 @@ That hold me down
 I'll tear you down into my private hell
 "
 int(%d)
+int(10)
+int(10)
 string(10) "Another da"
 int(%d)
+int(134)
+int(134)
 string(134) "Another day
 When the pains of life won't bar my way
 I'll break these chains

--- a/ext/standard/tests/file/stream_copy_to_stream_interleaved.phpt
+++ b/ext/standard/tests/file/stream_copy_to_stream_interleaved.phpt
@@ -1,0 +1,48 @@
+--TEST--
+stream_copy_to_stream() tests with interleaved read/write calls
+--FILE--
+<?php
+define('WIN', substr(PHP_OS, 0, 3) == 'WIN');
+
+$initial_file = __DIR__.'/bug38086.txt';
+$new_file = __DIR__.'/stream_copy_to_stream_interleaved.txt';
+
+$src = fopen($initial_file, 'r');
+
+$dest = fopen($new_file, 'w');
+
+var_dump(fread($src, 10));
+var_dump(fwrite($dest, "foo"));
+var_dump(stream_copy_to_stream($src, $dest, 10));
+var_dump(ftell($src));
+var_dump(ftell($dest));
+var_dump(fread($src, 10));
+var_dump(fwrite($dest, "bar"));
+var_dump(stream_copy_to_stream($src, $dest, 10));
+var_dump(ftell($src));
+var_dump(ftell($dest));
+fclose($src); fclose($dest);
+
+if (WIN) {
+  var_dump(str_replace("\r\n","\n", file_get_contents($new_file)));
+} else {
+  var_dump(file_get_contents($new_file));
+}
+unlink($new_file);
+
+echo "Done\n";
+?>
+--EXPECTF--
+string(10) "Another da"
+int(3)
+int(10)
+int(20)
+int(13)
+string(10) " pains of "
+int(3)
+int(10)
+int(40)
+int(26)
+string(26) "fooy
+When thebarlife won't"
+Done

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1555,6 +1555,90 @@ PHPAPI zend_result _php_stream_copy_to_stream_ex(php_stream *src, php_stream *de
 		return SUCCESS;
 	}
 
+#ifdef HAVE_COPY_FILE_RANGE
+
+	/* TODO: on FreeBSD, copy_file_range() works only with the
+	   undocumented flag 0x01000000; until the problem is fixed
+	   properly, copy_file_range() is not used on FreeBSD */
+#ifndef __FreeBSD__
+	if (php_stream_is(src, PHP_STREAM_IS_STDIO) &&
+	    php_stream_is(dest, PHP_STREAM_IS_STDIO) &&
+	    src->writepos == src->readpos &&
+	    php_stream_can_cast(src, PHP_STREAM_AS_FD) == SUCCESS &&
+	    php_stream_can_cast(dest, PHP_STREAM_AS_FD) == SUCCESS) {
+		/* both php_stream instances are backed by a file
+		   descriptor, are not filtered and the read buffer is
+		   empty: we can use copy_file_range() */
+
+		int src_fd, dest_fd;
+
+		php_stream_cast(src, PHP_STREAM_AS_FD, (void*)&src_fd, 0);
+		php_stream_cast(dest, PHP_STREAM_AS_FD, (void*)&dest_fd, 0);
+
+		/* clamp to INT_MAX to avoid EOVERFLOW */
+		const size_t cfr_max = MIN(maxlen, (size_t)SSIZE_MAX);
+
+		/* copy_file_range() is a Linux-specific system call
+		   which allows efficient copying between two file
+		   descriptors, eliminating the need to transfer data
+		   from the kernel to userspace and back.  For
+		   networking file systems like NFS and Ceph, it even
+		   eliminates copying data to the client, and local
+		   filesystems like Btrfs and XFS can create shared
+		   extents. */
+
+		ssize_t result = copy_file_range(src_fd, NULL,
+						 dest_fd, NULL,
+						 cfr_max, 0);
+		if (result > 0) {
+			size_t nbytes = (size_t)result;
+			haveread += nbytes;
+
+			src->position += nbytes;
+			dest->position += nbytes;
+
+			if ((maxlen != PHP_STREAM_COPY_ALL && nbytes == maxlen) ||
+			    php_stream_eof(src)) {
+				/* the whole request was satisfied or
+				   end-of-file reached - done */
+				*len = haveread;
+				return SUCCESS;
+			}
+
+			/* there may be more data; continue copying
+			   using the fallback code below */
+		} else if (result == 0) {
+			/* end of file */
+			*len = haveread;
+			return SUCCESS;
+		} else if (result < 0) {
+			switch (errno) {
+			case EINVAL:
+				/* some formal error, e.g. overlapping
+				   file ranges */
+				break;
+
+			case EXDEV:
+				/* pre Linux 5.3 error */
+				break;
+
+			case ENOSYS:
+				/* not implemented by this Linux kernel */
+				break;
+
+			default:
+				/* unexpected I/O error - give up, no
+				   fallback */
+				*len = haveread;
+				return FAILURE;
+			}
+
+			/* fall back to classic copying */
+		}
+	}
+#endif // __FreeBSD__
+#endif // HAVE_COPY_FILE_RANGE
+
 	if (maxlen == PHP_STREAM_COPY_ALL) {
 		maxlen = 0;
 	}


### PR DESCRIPTION
copy_file_range() is a Linux-specific system call which allows
efficient copying between two file descriptors, eliminating the need
to transfer data from the kernel to userspace and back.  For
networking file systems like NFS and Ceph, it even eliminates copying
data to the client, and local filesystems like Btrfs and XFS can
create shared extents.
