### PR TITLE
Fixed DOUBLE EXECUTION OF QUERIES when executing first SQLite3Result-…

### DIFF
--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -106,9 +106,9 @@ struct _php_sqlite3_result_object  {
 	php_sqlite3_db_object *db_obj;
 	php_sqlite3_stmt *stmt_obj;
 	zval stmt_obj_zval;
+	
 	/* START */
 	/* Store the last step error code from Sqlite3::query(), SQlite3Stmt::execute() to passe it to SQLite3Result::fetchArray() */
-	/* Also stores last step error from last SQLite3Result::fetchArray() */
 	int last_error;
 	/* END */
 

--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -106,6 +106,11 @@ struct _php_sqlite3_result_object  {
 	php_sqlite3_db_object *db_obj;
 	php_sqlite3_stmt *stmt_obj;
 	zval stmt_obj_zval;
+	/* START */
+	/* Store the last step error code from Sqlite3::query(), SQlite3Stmt::execute() to passe it to SQLite3Result::fetchArray() */
+	/* Also stores last step error from last SQLite3Result::fetchArray() */
+	int last_error;
+	/* END */
 
 	/* Cache of column names to speed up repeated fetchArray(SQLITE3_ASSOC) calls.
 	 * Cache is cleared on reset() and finalize() calls. */


### PR DESCRIPTION
…>fetcharray()

Steps to fix the bug:

1. Disabled sqlite3_reset(stmt_obj->stmt) in SQLite3::query() and SQLite3Stmt::execute().
sqlite3_reset(stmt_obj->stmt) forces a new execution of the query on the first execution of SQLite3Result::fetcharray().

2. Added 'int last_error' to struct '_php_sqlite3_result_object'.
last_error is used to store the returned value of the step command executed in SQLite3::query() and SQLite3Stmt::execute(), in order to pass this step return code to SQLite3Result::fetcharray().

3. SQLite3Result::fetcharray() reads last_error, process it and only steps if it is equal to SQLITE_ROW.