### PR TITLE
Modified _php_sqlite3_result_object struct to fix DOUBLE QUERY EXECUT…

### DIFF
--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -106,6 +106,12 @@ struct _php_sqlite3_result_object  {
 	php_sqlite3_db_object *db_obj;
 	php_sqlite3_stmt *stmt_obj;
 	zval stmt_obj_zval;
+	
+	/* START */
+	/* Store the last step error code from Sqlite3::query(), SQlite3Stmt::execute() to passe it to SQLite3Result::fetchArray() */
+	/* Also stores last step error from last SQLite3Result::fetchArray() */
+	int last_error;
+	/* END */
 
 	/* Cache of column names to speed up repeated fetchArray(SQLITE3_ASSOC) calls.
 	 * Cache is cleared on reset() and finalize() calls. */


### PR DESCRIPTION
…ION on first SQLite3Result->fetchArray()

Store the last step error code from Sqlite3::query(), SQlite3Stmt::execute() in  _php_sqlite3_result_object, to passe it to SQLite3Result::fetchArray() and to pass it to next SQLite3Result::fetchArray().