### PR TITLE
Fix GH-8421: Attributes that target functions are not valid for anonymous functions defined within a method

### DIFF
--- a/Zend/tests/attributes/gh8421.phpt
+++ b/Zend/tests/attributes/gh8421.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Bug #8421: Attributes that target functions are not valid for anonymous functions defined within a method
+--FILE--
+<?php
+#[Attribute(Attribute::TARGET_FUNCTION)]
+class FunctionAttribute
+{
+    public int $number = 1;
+}
+
+$globalClosure       = #[FunctionAttribute] fn() => true;
+$globalStaticClosure = #[FunctionAttribute] static fn() => true;
+
+class ClosureHolder
+{
+    public function getClosureDefinedInScope(): Closure
+    {
+        return #[FunctionAttribute] fn() => true;
+    }
+
+    public function getStaticClosureDefinedInScope(): Closure
+    {
+        return #[FunctionAttribute] static fn() => true;
+    }
+
+    public static function getClosureDefinedInScopeStatically(): Closure
+    {
+        return #[FunctionAttribute] fn() => true;
+    }
+
+    public static function getStaticClosureDefinedInScopeStatically(): Closure
+    {
+        return #[FunctionAttribute] static fn() => true;
+    }
+}
+
+echo (new ReflectionFunction($globalClosure))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
+echo (new ReflectionFunction($globalStaticClosure))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
+echo (new ReflectionFunction(ClosureHolder::getClosureDefinedInScopeStatically()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
+echo (new ReflectionFunction(ClosureHolder::getStaticClosureDefinedInScopeStatically()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
+
+$holder = new ClosureHolder;
+
+echo (new ReflectionFunction($holder->getClosureDefinedInScope()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
+echo (new ReflectionFunction($holder->getStaticClosureDefinedInScope()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
+?>
+--EXPECT--
+111111

--- a/Zend/tests/attributes/gh8421.phpt
+++ b/Zend/tests/attributes/gh8421.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #8421: Attributes that target functions are not valid for anonymous functions defined within a method
+Bug GH-8421: Attributes that target functions are not valid for anonymous functions defined within a method
 --FILE--
 <?php
 #[Attribute(Attribute::TARGET_FUNCTION)]

--- a/Zend/tests/attributes/gh8421.phpt
+++ b/Zend/tests/attributes/gh8421.phpt
@@ -8,41 +8,52 @@ class FunctionAttribute
     public int $number = 1;
 }
 
-$globalClosure       = #[FunctionAttribute] fn() => true;
-$globalStaticClosure = #[FunctionAttribute] static fn() => true;
+$globalClosure = #[FunctionAttribute]
+fn() => true;
+$globalStaticClosure = #[FunctionAttribute]
+static fn() => true;
 
 class ClosureHolder
 {
     public function getClosureDefinedInScope(): Closure
     {
-        return #[FunctionAttribute] fn() => true;
+        return #[FunctionAttribute]
+        fn() => true;
     }
 
     public function getStaticClosureDefinedInScope(): Closure
     {
-        return #[FunctionAttribute] static fn() => true;
+        return #[FunctionAttribute]
+        static fn() => true;
     }
 
     public static function getClosureDefinedInScopeStatically(): Closure
     {
-        return #[FunctionAttribute] fn() => true;
+        return #[FunctionAttribute]
+        fn() => true;
     }
 
     public static function getStaticClosureDefinedInScopeStatically(): Closure
     {
-        return #[FunctionAttribute] static fn() => true;
+        return #[FunctionAttribute]
+        static fn() => true;
     }
 }
 
-echo (new ReflectionFunction($globalClosure))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
-echo (new ReflectionFunction($globalStaticClosure))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
-echo (new ReflectionFunction(ClosureHolder::getClosureDefinedInScopeStatically()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
-echo (new ReflectionFunction(ClosureHolder::getStaticClosureDefinedInScopeStatically()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
+var_dump((new ReflectionFunction($globalClosure))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number);
+var_dump((new ReflectionFunction($globalStaticClosure))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number);
+var_dump((new ReflectionFunction(ClosureHolder::getClosureDefinedInScopeStatically()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number);
+var_dump((new ReflectionFunction(ClosureHolder::getStaticClosureDefinedInScopeStatically()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number);
 
 $holder = new ClosureHolder;
 
-echo (new ReflectionFunction($holder->getClosureDefinedInScope()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
-echo (new ReflectionFunction($holder->getStaticClosureDefinedInScope()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number;
+var_dump((new ReflectionFunction($holder->getClosureDefinedInScope()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number);
+var_dump((new ReflectionFunction($holder->getStaticClosureDefinedInScope()))->getAttributes(FunctionAttribute::class)[0]->newInstance()->number);
 ?>
 --EXPECT--
-111111
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1871,7 +1871,7 @@ ZEND_METHOD(ReflectionFunctionAbstract, getAttributes)
 
 	GET_REFLECTION_OBJECT_PTR(fptr);
 
-	if (fptr->common.scope) {
+	if (fptr->common.scope && !(fptr->common.fn_flags & ZEND_ACC_CLOSURE)) {
 		target = ZEND_ATTRIBUTE_TARGET_METHOD;
 	} else {
 		target = ZEND_ATTRIBUTE_TARGET_FUNCTION;


### PR DESCRIPTION
This fixes #8421, allowing anonymous functions defined within a method to have attributes targeting functions.

I've added tests for:
- Closure defined in the global context
- Static Closure defined in the global context
- Closure defined in the context of `ClosureHolder`
- Static Closure defined in the context of `ClosureHolder`
- Closure defined inside `ClosureHolder` but within a static context
- Static Closure defined inside `ClosureHolder` but within a static context