### PR TITLE
Fix tmp file deletion in mysqli_pam_sha256_public_key_ini.phpt test

### DIFF
--- a/.github/actions/verify-generated-files/action.yml
+++ b/.github/actions/verify-generated-files/action.yml
@@ -9,4 +9,4 @@ runs:
         scripts/dev/genfiles
         Zend/zend_vm_gen.php
         build/gen_stub.php -f
-        git add . -Nu && git diff --exit-code
+        git add . -N && git diff --exit-code

--- a/ext/mysqli/tests/clean_table.inc
+++ b/ext/mysqli/tests/clean_table.inc
@@ -9,6 +9,3 @@ if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 if (!mysqli_query($link, 'DROP TABLE IF EXISTS test')) {
     printf("[clean] Failed to drop old test table: [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 }
-
-mysqli_close($link);
-?>


### PR DESCRIPTION
the 1st (revert) commit should be merged into PHP 8.0 branch

https://github.com/php/php-src/pull/8295 was designed to detect also residual/uncleaned tmp files from build/tests

it works with PHP 8.0 & master, but one test for PHP 8.1 has an issue:

![image](https://user-images.githubusercontent.com/2228672/164780666-d32f935e-868d-4ff1-a7c5-bf2e611b59ff.png)

![image](https://user-images.githubusercontent.com/2228672/164780795-cb9d0a5a-c0ce-45a0-ab45-e6099e00245d.png)

for some reasons the `mysqlnd.sha256_server_public_key="test_sha256_ini"` config is not deleted by the CLEAN section