### PR TITLE
use bit shift to set bitflags

### DIFF
--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -53,11 +53,11 @@ PHPAPI ssize_t php_fputcsv(php_stream *stream, zval *fields, char delimiter, cha
 
 #define META_DEF_BUFSIZE 8192
 
-#define PHP_FILE_USE_INCLUDE_PATH 1
-#define PHP_FILE_IGNORE_NEW_LINES 2
-#define PHP_FILE_SKIP_EMPTY_LINES 4
-#define PHP_FILE_APPEND 8
-#define PHP_FILE_NO_DEFAULT_CONTEXT 16
+#define PHP_FILE_USE_INCLUDE_PATH (1 << 0)
+#define PHP_FILE_IGNORE_NEW_LINES (1 << 1)
+#define PHP_FILE_SKIP_EMPTY_LINES (1 << 2)
+#define PHP_FILE_APPEND (1 << 3)
+#define PHP_FILE_NO_DEFAULT_CONTEXT (1 << 4)
 
 typedef enum _php_meta_tags_token {
 	TOK_EOF = 0,


### PR DESCRIPTION
nitpicking, this makes it practically impossible to accidentally use a number with 2 bits set in the future, 
it's also my personal preference, its trivial to see "PHP_FILE_NO_DEFAULT_CONTEXT use bit 4" and that "the next unused bit is bit 5"