### PR TITLE
copy optimisations for macos proposal.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -365,6 +365,7 @@ PHP_CHECK_FUNC(htonl, socket, network)
 PHP_CHECK_FUNC(gethostname, nsl, network)
 PHP_CHECK_FUNC(gethostbyaddr, nsl, network)
 PHP_CHECK_FUNC(copy_file_range)
+PHP_CHECK_FUNC(copyfile)
 PHP_CHECK_FUNC(dlopen, dl, root)
 PHP_CHECK_FUNC(dlsym, dl, root)
 if test "$ac_cv_func_dlopen" = "yes"; then
@@ -389,6 +390,7 @@ netinet/in.h \
 alloca.h \
 arpa/inet.h \
 arpa/nameser.h \
+copyfile.h \
 crypt.h \
 dns.h \
 fcntl.h \


### PR DESCRIPTION
when copy path to path is supported (but with no sense of buffering)
 we intercede with a native call for now macos only but after files
 precheck are done within php_copy_file.