### PR TITLE
Fix GH-8235: iterator_count() may run indefinitely

### DIFF
--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -3157,6 +3157,9 @@ PHP_FUNCTION(iterator_to_array)
 
 static int spl_iterator_count_apply(zend_object_iterator *iter, void *puser) /* {{{ */
 {
+	if (UNEXPECTED(*(zend_long*)puser == ZEND_LONG_MAX)) {
+		return ZEND_HASH_APPLY_STOP;
+	}
 	(*(zend_long*)puser)++;
 	return ZEND_HASH_APPLY_KEEP;
 }


### PR DESCRIPTION
We need to prevent integer overflow to eventually stop the iteration.

A test case doesn't appear sensible for this, because even on 32bit
architectures a respective test easily runs for a few minutes.