### PR TITLE
Fix PDO MySQL URI test

### DIFF
--- a/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
@@ -18,7 +18,7 @@ MySQLPDOTest::skip();
             $dsn = MySQLPDOTest::getDSN();
             $user = PDO_MYSQL_TEST_USER;
             $pass = PDO_MYSQL_TEST_PASS;
-            $uri = sprintf('uri:file://%s', (substr(PHP_OS, 0, 3) == 'WIN' ? str_replace('\\', '/', $file) : $file));
+            $uri = 'uri:file://' . $file;
 
             if ($fp = @fopen($file, 'w')) {
                 // ok, great we can create a file with a DSN in it
@@ -38,8 +38,8 @@ MySQLPDOTest::skip();
             }
 
             if ($fp = @fopen($file, 'w')) {
-                fwrite($fp, sprintf('mysql:dbname=letshopeinvalid;%s%s',
-                    chr(0), $dsn));
+                $dsnUnknownDatabase = preg_replace('~dbname=[^;]+~', 'dbname=letshopeinvalid', $dsn);
+                fwrite($fp, $dsnUnknownDatabase);
                 fclose($fp);
                 clearstatcache();
                 assert(file_exists($file));
@@ -49,9 +49,8 @@ MySQLPDOTest::skip();
                     $expected = array(
                         "SQLSTATE[HY000] [1049] Unknown database 'letshopeinvalid'",
                         "SQLSTATE[42000] [1049] Unknown database 'letshopeinvalid'",
-                        "SQLSTATE[HY000] [2002] No such file or directory"
                     );
-                    printf("[003] URI=%s, DSN=%s, File=%s (%d bytes, '%s'), chr(0) test, %s\n",
+                    printf("[003] URI=%s, DSN=%s, File=%s (%d bytes, '%s'), %s\n",
                     $uri, $dsn,
                     $file, filesize($file), file_get_contents($file),
                     (in_array($e->getMessage(), $expected) ? 'EXPECTED ERROR' : $e->getMessage()));
@@ -73,5 +72,5 @@ MySQLPDOTest::skip();
     print "done!";
 ?>
 --EXPECTF--
-[003] URI=uri:file://%spdomuri.tst, DSN=mysql%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql%sdbname=letshopeinvalid%s'), chr(0) test, EXPECTED ERROR
+[003] URI=uri:file://%spdomuri.tst, DSN=mysql:%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql:%sdbname=letshopeinvalid%S'), EXPECTED ERROR
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
@@ -21,7 +21,6 @@ MySQLPDOTest::skip();
             $uri = 'uri:file://' . $file;
 
             if ($fp = @fopen($file, 'w')) {
-                // ok, great we can create a file with a DSN in it
                 fwrite($fp, $dsn);
                 fclose($fp);
                 clearstatcache();
@@ -38,23 +37,17 @@ MySQLPDOTest::skip();
             }
 
             if ($fp = @fopen($file, 'w')) {
-                $dsnUnknownDatabase = preg_replace('~dbname=[^;]+~', 'dbname=letshopeinvalid', $dsn)
-                    . chr(0) . ';host=nonsense;unix_socket=nonsense';
-                fwrite($fp, $dsnUnknownDatabase);
+                fwrite($fp, $dsn . chr(0) . ';host=nonsense;unix_socket=nonsense');
                 fclose($fp);
                 clearstatcache();
                 assert(file_exists($file));
                 try {
                     $db = new PDO($uri, $user, $pass);
                 } catch (PDOException $e) {
-                    $expected = array(
-                        "SQLSTATE[HY000] [1049] Unknown database 'letshopeinvalid'",
-                        "SQLSTATE[42000] [1049] Unknown database 'letshopeinvalid'",
-                    );
                     printf("[003] URI=%s, DSN=%s, File=%s (%d bytes, '%s'), %s\n",
-                    $uri, $dsn,
-                    $file, filesize($file), file_get_contents($file),
-                    (in_array($e->getMessage(), $expected) ? 'EXPECTED ERROR' : $e->getMessage()));
+                        $uri, $dsn,
+                        $file, filesize($file), file_get_contents($file),
+                        $e->getMessage());
                 }
                 unlink($file);
             }
@@ -71,5 +64,4 @@ MySQLPDOTest::skip();
     print "done!";
 ?>
 --EXPECTF--
-[003] URI=uri:file://%spdomuri.tst, DSN=mysql:%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql:%sdbname=letshopeinvalid%snonsense'), EXPECTED ERROR
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql___construct_uri.phpt
@@ -38,7 +38,8 @@ MySQLPDOTest::skip();
             }
 
             if ($fp = @fopen($file, 'w')) {
-                $dsnUnknownDatabase = preg_replace('~dbname=[^;]+~', 'dbname=letshopeinvalid', $dsn);
+                $dsnUnknownDatabase = preg_replace('~dbname=[^;]+~', 'dbname=letshopeinvalid', $dsn)
+                    . chr(0) . ';host=nonsense;unix_socket=nonsense';
                 fwrite($fp, $dsnUnknownDatabase);
                 fclose($fp);
                 clearstatcache();
@@ -60,8 +61,6 @@ MySQLPDOTest::skip();
 
         }
 
-        /* TODO: safe mode */
-
     } catch (PDOException $e) {
         printf("[001] %s, [%s] %s\n",
             $e->getMessage(),
@@ -72,5 +71,5 @@ MySQLPDOTest::skip();
     print "done!";
 ?>
 --EXPECTF--
-[003] URI=uri:file://%spdomuri.tst, DSN=mysql:%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql:%sdbname=letshopeinvalid%S'), EXPECTED ERROR
+[003] URI=uri:file://%spdomuri.tst, DSN=mysql:%sdbname=%s, File=%spdomuri.tst (%d bytes, 'mysql:%sdbname=letshopeinvalid%snonsense'), EXPECTED ERROR
 done!


### PR DESCRIPTION
`"\0"` char in URI causes the remaining part completely ignored, thus testing effectively only `mysql:dbname=letshopeinvalid`

but this URI then tested connection /w default host/port/credentials resulting with a many different failures (for example, consider MySQL server accessible on localhost /w and /wo default port)