### PR TITLE
Fixes GH-8152: add __serialise and __unserialise methods to DateInterval

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2045,6 +2045,8 @@ static zend_object *date_object_clone_interval(zend_object *this_ptr) /* {{{ */
 	php_interval_obj *new_obj = php_interval_obj_from_obj(date_object_new_interval(old_obj->std.ce));
 
 	zend_objects_clone_members(&new_obj->std, &old_obj->std);
+	new_obj->civil_or_wall = old_obj->civil_or_wall;
+	new_obj->from_string = old_obj->from_string;
 	new_obj->initialized = old_obj->initialized;
 	if (old_obj->diff) {
 		new_obj->diff = timelib_rel_time_clone(old_obj->diff);

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2047,6 +2047,9 @@ static zend_object *date_object_clone_interval(zend_object *this_ptr) /* {{{ */
 	zend_objects_clone_members(&new_obj->std, &old_obj->std);
 	new_obj->civil_or_wall = old_obj->civil_or_wall;
 	new_obj->from_string = old_obj->from_string;
+	if (old_obj->date_string) {
+		new_obj->date_string = zend_string_copy(old_obj->date_string);
+	}
 	new_obj->initialized = old_obj->initialized;
 	if (old_obj->diff) {
 		new_obj->diff = timelib_rel_time_clone(old_obj->diff);

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4205,6 +4205,44 @@ PHP_METHOD(DateInterval, __set_state)
 /* }}} */
 
 /* {{{ */
+PHP_METHOD(DateInterval, __serialize)
+{
+	zval             *object = ZEND_THIS;
+	php_interval_obj *intervalobj;
+	HashTable        *myht;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	intervalobj = Z_PHPINTERVAL_P(object);
+	DATE_CHECK_INITIALIZED(intervalobj->initialized, DateInterval);
+
+	array_init(return_value);
+	myht = Z_ARRVAL_P(return_value);
+	date_interval_object_to_hash(intervalobj, myht, true);
+}
+/* }}} */
+
+
+/* {{{ */
+PHP_METHOD(DateInterval, __unserialize)
+{
+	zval             *object = ZEND_THIS;
+	php_interval_obj *intervalobj;
+	zval             *array;
+	HashTable        *myht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY(array)
+	ZEND_PARSE_PARAMETERS_END();
+
+	intervalobj = Z_PHPINTERVAL_P(object);
+	myht = Z_ARRVAL_P(array);
+
+	php_date_interval_initialize_from_hash(&object, &intervalobj, myht);
+}
+/* }}} */
+
+/* {{{ */
 PHP_METHOD(DateInterval, __wakeup)
 {
 	zval             *object = ZEND_THIS;

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4104,6 +4104,12 @@ PHP_METHOD(DateInterval, __construct)
 
 static void php_date_interval_initialize_from_hash(zval **return_value, php_interval_obj **intobj, HashTable *myht) /* {{{ */
 {
+	/* If ->diff is already set, then we need to free it first */
+	if ((*intobj)->diff) {
+		timelib_rel_time_dtor((*intobj)->diff);
+	}
+
+	/* Set new value */
 	(*intobj)->diff = timelib_rel_time_ctor();
 
 #define PHP_DATE_INTERVAL_READ_PROPERTY(element, member, itype, def) \

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2093,8 +2093,9 @@ static void date_interval_object_to_hash(php_interval_obj *intervalobj, HashTabl
 		PHP_DATE_INTERVAL_ADD_PROPERTY("special_type", special.type);
 		PHP_DATE_INTERVAL_ADD_PROPERTY("special_amount", special.amount);
 		PHP_DATE_INTERVAL_ADD_PROPERTY("have_weekday_relative", have_weekday_relative);
-		PHP_DATE_INTERVAL_ADD_PROPERTY("have_special_relative", have_special_relative);
 	}
+	/* Records whether this is a special relative interval that can't be serialized */
+	PHP_DATE_INTERVAL_ADD_PROPERTY("have_special_relative", have_special_relative);
 
 #undef PHP_DATE_INTERVAL_ADD_PROPERTY
 }
@@ -4221,6 +4222,10 @@ PHP_METHOD(DateInterval, __serialize)
 
 	intervalobj = Z_PHPINTERVAL_P(object);
 	DATE_CHECK_INITIALIZED(intervalobj->initialized, DateInterval);
+
+	if (intervalobj->diff->have_special_relative) {
+		zend_throw_exception_ex(NULL, 0, "Serializing special relative time specifications is not supported");
+	}
 
 	array_init(return_value);
 	myht = Z_ARRVAL_P(return_value);

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -72,6 +72,7 @@ static inline php_timezone_obj *php_timezone_obj_from_obj(zend_object *obj) {
 struct _php_interval_obj {
 	timelib_rel_time *diff;
 	int               civil_or_wall;
+	bool              from_string;
 	bool              initialized;
 	zend_object       std;
 };

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -73,6 +73,7 @@ struct _php_interval_obj {
 	timelib_rel_time *diff;
 	int               civil_or_wall;
 	bool              from_string;
+	zend_string      *date_string;
 	bool              initialized;
 	zend_object       std;
 };

--- a/ext/date/php_date.stub.php
+++ b/ext/date/php_date.stub.php
@@ -480,6 +480,10 @@ class DateInterval
      */
     public function format(string $format): string {}
 
+    public function __serialize(): array;
+
+    public function __unserialize(array $data): void;
+
     /** @tentative-return-type */
     public function __wakeup(): void {}
 

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a157de6bca4bcf5a9ddace9e81ef700f132b4dda */
+ * Stub hash: 4845891ab3872f292438de639953e2022f849125 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strtotime, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, datetime, IS_STRING, 0)
@@ -451,6 +451,10 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DateInterval_format arginfo_class_DateTimeInterface_format
 
+#define arginfo_class_DateInterval___serialize arginfo_timezone_abbreviations_list
+
+#define arginfo_class_DateInterval___unserialize arginfo_class_DateTimeInterface___unserialize
+
 #define arginfo_class_DateInterval___wakeup arginfo_class_DateTimeInterface___wakeup
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_DateInterval___set_state, 0, 1, DateInterval, 0)
@@ -562,6 +566,8 @@ ZEND_METHOD(DateTimeZone, __unserialize);
 ZEND_METHOD(DateTimeZone, __wakeup);
 ZEND_METHOD(DateTimeZone, __set_state);
 ZEND_METHOD(DateInterval, __construct);
+ZEND_METHOD(DateInterval, __serialize);
+ZEND_METHOD(DateInterval, __unserialize);
 ZEND_METHOD(DateInterval, __wakeup);
 ZEND_METHOD(DateInterval, __set_state);
 ZEND_METHOD(DatePeriod, __construct);
@@ -714,6 +720,8 @@ static const zend_function_entry class_DateInterval_methods[] = {
 	ZEND_ME(DateInterval, __construct, arginfo_class_DateInterval___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(createFromDateString, date_interval_create_from_date_string, arginfo_class_DateInterval_createFromDateString, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME_MAPPING(format, date_interval_format, arginfo_class_DateInterval_format, ZEND_ACC_PUBLIC)
+	ZEND_ME(DateInterval, __serialize, arginfo_class_DateInterval___serialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(DateInterval, __unserialize, arginfo_class_DateInterval___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(DateInterval, __wakeup, arginfo_class_DateInterval___wakeup, ZEND_ACC_PUBLIC)
 	ZEND_ME(DateInterval, __set_state, arginfo_class_DateInterval___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END

--- a/ext/date/tests/DateInterval_serialize-001.phpt
+++ b/ext/date/tests/DateInterval_serialize-001.phpt
@@ -1,0 +1,111 @@
+--TEST--
+Test DateInterval::__serialize and DateInterval::__unserialize
+--FILE--
+<?php
+date_default_timezone_set("Europe/London");
+
+$d = new DateInterval('P2Y4DT6H8M');
+echo "Original object:\n";
+var_dump($d);
+
+echo "\n\nSerialised object:\n";
+$s = serialize($d);
+var_dump($s);
+
+echo "\n\nUnserialised object:\n";
+$e = unserialize($s);
+var_dump($e);
+
+echo "\n\nCalling __serialize manually:\n";
+var_dump($d->__serialize());
+?>
+--EXPECTF--
+Original object:
+object(DateInterval)#1 (10) {
+  ["y"]=>
+  int(2)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(4)
+  ["h"]=>
+  int(6)
+  ["i"]=>
+  int(8)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+  ["have_special_relative"]=>
+  int(0)
+}
+
+
+Serialised object:
+string(332) "O:12:"DateInterval":16:{s:1:"y";i:2;s:1:"m";i:0;s:1:"d";i:4;s:1:"h";i:6;s:1:"i";i:8;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";b:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
+
+
+Unserialised object:
+object(DateInterval)#2 (10) {
+  ["y"]=>
+  int(2)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(4)
+  ["h"]=>
+  int(6)
+  ["i"]=>
+  int(8)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+  ["have_special_relative"]=>
+  int(0)
+}
+
+
+Calling __serialize manually:
+array(16) {
+  ["y"]=>
+  int(2)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(4)
+  ["h"]=>
+  int(6)
+  ["i"]=>
+  int(8)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["weekday"]=>
+  int(0)
+  ["weekday_behavior"]=>
+  int(0)
+  ["first_last_day_of"]=>
+  int(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+  ["special_type"]=>
+  int(0)
+  ["special_amount"]=>
+  int(0)
+  ["have_weekday_relative"]=>
+  int(0)
+  ["have_special_relative"]=>
+  int(0)
+}

--- a/ext/date/tests/DateInterval_serialize-001.phpt
+++ b/ext/date/tests/DateInterval_serialize-001.phpt
@@ -40,13 +40,13 @@ object(DateInterval)#1 (10) {
   int(0)
   ["days"]=>
   bool(false)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 
 
 Serialised object:
-string(332) "O:12:"DateInterval":16:{s:1:"y";i:2;s:1:"m";i:0;s:1:"d";i:4;s:1:"h";i:6;s:1:"i";i:8;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";b:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
+string(380) "O:12:"DateInterval":18:{s:1:"y";i:2;s:1:"m";i:0;s:1:"d";i:4;s:1:"h";i:6;s:1:"i";i:8;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;s:13:"civil_or_wall";i:2;s:11:"from_string";b:0;}"
 
 
 Unserialised object:
@@ -69,13 +69,13 @@ object(DateInterval)#2 (10) {
   int(0)
   ["days"]=>
   bool(false)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 
 
 Calling __serialize manually:
-array(16) {
+array(%d) {
   ["y"]=>
   int(2)
   ["m"]=>
@@ -90,16 +90,16 @@ array(16) {
   int(0)
   ["f"]=>
   float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
   ["weekday"]=>
   int(0)
   ["weekday_behavior"]=>
   int(0)
   ["first_last_day_of"]=>
   int(0)
-  ["invert"]=>
-  int(0)
-  ["days"]=>
-  bool(false)
   ["special_type"]=>
   int(0)
   ["special_amount"]=>
@@ -108,4 +108,8 @@ array(16) {
   int(0)
   ["have_special_relative"]=>
   int(0)
+  ["civil_or_wall"]=>
+  int(2)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/DateInterval_serialize-001.phpt
+++ b/ext/date/tests/DateInterval_serialize-001.phpt
@@ -46,7 +46,7 @@ object(DateInterval)#1 (10) {
 
 
 Serialised object:
-string(380) "O:12:"DateInterval":18:{s:1:"y";i:2;s:1:"m";i:0;s:1:"d";i:4;s:1:"h";i:6;s:1:"i";i:8;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;s:13:"civil_or_wall";i:2;s:11:"from_string";b:0;}"
+string(164) "O:12:"DateInterval":10:{s:1:"y";i:2;s:1:"m";i:0;s:1:"d";i:4;s:1:"h";i:6;s:1:"i";i:8;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:11:"from_string";b:0;}"
 
 
 Unserialised object:
@@ -94,22 +94,6 @@ array(%d) {
   int(0)
   ["days"]=>
   bool(false)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
-  ["civil_or_wall"]=>
-  int(2)
   ["from_string"]=>
   bool(false)
 }

--- a/ext/date/tests/DateInterval_serialize-001.phpt
+++ b/ext/date/tests/DateInterval_serialize-001.phpt
@@ -18,6 +18,11 @@ var_dump($e);
 
 echo "\n\nCalling __serialize manually:\n";
 var_dump($d->__serialize());
+
+echo "\n\nUsed serialised interval:\n";
+$now = new DateTimeImmutable("2022-04-22 16:25:11 BST");
+var_dump($now->add($e));
+var_dump($now->sub($e));
 ?>
 --EXPECTF--
 Original object:
@@ -96,4 +101,23 @@ array(%d) {
   bool(false)
   ["from_string"]=>
   bool(false)
+}
+
+
+Used serialised interval:
+object(DateTimeImmutable)#4 (3) {
+  ["date"]=>
+  string(26) "2024-04-26 22:33:11.000000"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(3) "BST"
+}
+object(DateTimeImmutable)#4 (3) {
+  ["date"]=>
+  string(26) "2020-04-18 10:17:11.000000"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(3) "BST"
 }

--- a/ext/date/tests/DateInterval_serialize-002.phpt
+++ b/ext/date/tests/DateInterval_serialize-002.phpt
@@ -37,6 +37,11 @@ $d->__unserialize(
 	]
 );
 var_dump($d);
+
+echo "\n\nUsed serialised interval:\n";
+$now = new DateTimeImmutable("2022-04-15 10:27:27 BST");
+var_dump($now->add($e));
+var_dump($now->sub($e));
 ?>
 --EXPECTF--
 Original object:
@@ -140,4 +145,23 @@ object(DateInterval)#5 (10) {
   int(15820)
   ["from_string"]=>
   bool(false)
+}
+
+
+Used serialised interval:
+object(DateTimeImmutable)#6 (3) {
+  ["date"]=>
+  string(26) "2065-08-08 11:39:54.000000"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(3) "BST"
+}
+object(DateTimeImmutable)#6 (3) {
+  ["date"]=>
+  string(26) "1978-12-22 09:15:00.000000"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(3) "BST"
 }

--- a/ext/date/tests/DateInterval_serialize-002.phpt
+++ b/ext/date/tests/DateInterval_serialize-002.phpt
@@ -65,7 +65,7 @@ object(DateInterval)#3 (10) {
 
 
 Serialised object:
-string(388) "O:12:"DateInterval":18:{s:1:"y";i:43;s:1:"m";i:3;s:1:"d";i:24;s:1:"h";i:1;s:1:"i";i:12;s:1:"s";i:27;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:15820;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;s:13:"civil_or_wall";i:1;s:11:"from_string";b:0;}"
+string(172) "O:12:"DateInterval":10:{s:1:"y";i:43;s:1:"m";i:3;s:1:"d";i:24;s:1:"h";i:1;s:1:"i";i:12;s:1:"s";i:27;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:15820;s:11:"from_string";b:0;}"
 
 
 Unserialised object:
@@ -113,22 +113,6 @@ array(%d) {
   int(0)
   ["days"]=>
   int(15820)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
-  ["civil_or_wall"]=>
-  int(1)
   ["from_string"]=>
   bool(false)
 }

--- a/ext/date/tests/DateInterval_serialize-002.phpt
+++ b/ext/date/tests/DateInterval_serialize-002.phpt
@@ -1,0 +1,155 @@
+--TEST--
+Test DateInterval::__serialize and DateInterval::__unserialize
+--FILE--
+<?php
+date_default_timezone_set("Europe/London");
+
+$d1 = new DateTimeImmutable("1978-12-22 09:15 CET");
+$d2 = new DateTimeImmutable("2022-04-15 10:27:27 BST");
+
+$d = $d1->diff($d2);
+echo "Original object:\n";
+var_dump($d);
+
+echo "\n\nSerialised object:\n";
+$s = serialize($d);
+var_dump($s);
+
+echo "\n\nUnserialised object:\n";
+$e = unserialize($s);
+var_dump($e);
+
+echo "\n\nCalling __serialize manually:\n";
+var_dump($d->__serialize());
+
+echo "\n\nCalling __unserialize manually:\n";
+$d = new DateInterval('P2Y4DT6H8M');
+$d->__unserialize(
+	[
+		'y' => 43,
+		'm' =>  3,
+		'd' => 24,
+		'h' =>  1,
+		'i' => 12,
+		's' => 27,
+		'f' => 0.654321,
+		'days' => 15820,
+	]
+);
+var_dump($d);
+?>
+--EXPECTF--
+Original object:
+object(DateInterval)#3 (10) {
+  ["y"]=>
+  int(43)
+  ["m"]=>
+  int(3)
+  ["d"]=>
+  int(24)
+  ["h"]=>
+  int(1)
+  ["i"]=>
+  int(12)
+  ["s"]=>
+  int(27)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(15820)
+  ["have_special_relative"]=>
+  int(0)
+}
+
+
+Serialised object:
+string(340) "O:12:"DateInterval":16:{s:1:"y";i:43;s:1:"m";i:3;s:1:"d";i:24;s:1:"h";i:1;s:1:"i";i:12;s:1:"s";i:27;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:15820;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
+
+
+Unserialised object:
+object(DateInterval)#4 (10) {
+  ["y"]=>
+  int(43)
+  ["m"]=>
+  int(3)
+  ["d"]=>
+  int(24)
+  ["h"]=>
+  int(1)
+  ["i"]=>
+  int(12)
+  ["s"]=>
+  int(27)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(15820)
+  ["have_special_relative"]=>
+  int(0)
+}
+
+
+Calling __serialize manually:
+array(16) {
+  ["y"]=>
+  int(43)
+  ["m"]=>
+  int(3)
+  ["d"]=>
+  int(24)
+  ["h"]=>
+  int(1)
+  ["i"]=>
+  int(12)
+  ["s"]=>
+  int(27)
+  ["f"]=>
+  float(0)
+  ["weekday"]=>
+  int(0)
+  ["weekday_behavior"]=>
+  int(0)
+  ["first_last_day_of"]=>
+  int(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(15820)
+  ["special_type"]=>
+  int(0)
+  ["special_amount"]=>
+  int(0)
+  ["have_weekday_relative"]=>
+  int(0)
+  ["have_special_relative"]=>
+  int(0)
+}
+
+
+Calling __unserialize manually:
+object(DateInterval)#5 (10) {
+  ["y"]=>
+  int(43)
+  ["m"]=>
+  int(3)
+  ["d"]=>
+  int(24)
+  ["h"]=>
+  int(1)
+  ["i"]=>
+  int(12)
+  ["s"]=>
+  int(27)
+  ["f"]=>
+  float(0.654321)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(15820)
+  ["have_special_relative"]=>
+  int(0)
+}

--- a/ext/date/tests/DateInterval_serialize-002.phpt
+++ b/ext/date/tests/DateInterval_serialize-002.phpt
@@ -59,13 +59,13 @@ object(DateInterval)#3 (10) {
   int(0)
   ["days"]=>
   int(15820)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 
 
 Serialised object:
-string(340) "O:12:"DateInterval":16:{s:1:"y";i:43;s:1:"m";i:3;s:1:"d";i:24;s:1:"h";i:1;s:1:"i";i:12;s:1:"s";i:27;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:15820;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
+string(388) "O:12:"DateInterval":18:{s:1:"y";i:43;s:1:"m";i:3;s:1:"d";i:24;s:1:"h";i:1;s:1:"i";i:12;s:1:"s";i:27;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:15820;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;s:13:"civil_or_wall";i:1;s:11:"from_string";b:0;}"
 
 
 Unserialised object:
@@ -88,13 +88,13 @@ object(DateInterval)#4 (10) {
   int(0)
   ["days"]=>
   int(15820)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 
 
 Calling __serialize manually:
-array(16) {
+array(%d) {
   ["y"]=>
   int(43)
   ["m"]=>
@@ -109,16 +109,16 @@ array(16) {
   int(27)
   ["f"]=>
   float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  int(15820)
   ["weekday"]=>
   int(0)
   ["weekday_behavior"]=>
   int(0)
   ["first_last_day_of"]=>
   int(0)
-  ["invert"]=>
-  int(0)
-  ["days"]=>
-  int(15820)
   ["special_type"]=>
   int(0)
   ["special_amount"]=>
@@ -127,6 +127,10 @@ array(16) {
   int(0)
   ["have_special_relative"]=>
   int(0)
+  ["civil_or_wall"]=>
+  int(1)
+  ["from_string"]=>
+  bool(false)
 }
 
 
@@ -150,6 +154,6 @@ object(DateInterval)#5 (10) {
   int(0)
   ["days"]=>
   int(15820)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/DateInterval_serialize-003.phpt
+++ b/ext/date/tests/DateInterval_serialize-003.phpt
@@ -36,8 +36,8 @@ object(DateInterval)#1 (10) {
   int(0)
   ["days"]=>
   bool(false)
-  ["have_special_relative"]=>
-  int(1)
+  ["from_string"]=>
+  bool(false)
 }
 
 

--- a/ext/date/tests/DateInterval_serialize-003.phpt
+++ b/ext/date/tests/DateInterval_serialize-003.phpt
@@ -4,6 +4,8 @@ Test DateInterval::__serialize and DateInterval::__unserialize
 <?php
 date_default_timezone_set("Europe/London");
 
+// the 15:30 gets ignored, as it's not a "relative" interval.
+// See: https://github.com/php/php-src/issues/8458
 $d = DateInterval::createFromDateString('next weekday 15:30');
 echo "Original object:\n";
 var_dump($d);
@@ -28,6 +30,11 @@ $d->__unserialize(
 	]
 );
 var_dump($d);
+
+echo "\n\nUsed serialised interval:\n";
+$now = new DateTimeImmutable("2022-04-22 16:25:11 BST");
+var_dump($now->add($e));
+var_dump($now->sub($e));
 ?>
 --EXPECTF--
 Original object:
@@ -67,4 +74,25 @@ object(DateInterval)#3 (2) {
   bool(true)
   ["date_string"]=>
   string(18) "next weekday 15:30"
+}
+
+
+Used serialised interval:
+object(DateTimeImmutable)#4 (3) {
+  ["date"]=>
+  string(26) "2022-04-25 16:25:11.000000"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(3) "BST"
+}
+
+Warning: DateTimeImmutable::sub(): Only non-special relative time specifications are supported for subtraction in %s on line %d
+object(DateTimeImmutable)#4 (3) {
+  ["date"]=>
+  string(26) "2022-04-22 16:25:11.000000"
+  ["timezone_type"]=>
+  int(2)
+  ["timezone"]=>
+  string(3) "BST"
 }

--- a/ext/date/tests/DateInterval_serialize-003.phpt
+++ b/ext/date/tests/DateInterval_serialize-003.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test DateInterval::__serialize and DateInterval::__unserialize
+--FILE--
+<?php
+date_default_timezone_set("Europe/London");
+
+$d = DateInterval::createFromDateString('next weekday 15:30');
+echo "Original object:\n";
+var_dump($d);
+
+echo "\n\nSerialised object:\n";
+try {
+	$s = serialize($d);
+} catch (Exception $e) {
+	echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Original object:
+object(DateInterval)#1 (10) {
+  ["y"]=>
+  int(0)
+  ["m"]=>
+  int(0)
+  ["d"]=>
+  int(0)
+  ["h"]=>
+  int(0)
+  ["i"]=>
+  int(0)
+  ["s"]=>
+  int(0)
+  ["f"]=>
+  float(0)
+  ["invert"]=>
+  int(0)
+  ["days"]=>
+  bool(false)
+  ["have_special_relative"]=>
+  int(1)
+}
+
+
+Serialised object:
+Serializing special relative time specifications is not supported

--- a/ext/date/tests/DateInterval_serialize-003.phpt
+++ b/ext/date/tests/DateInterval_serialize-003.phpt
@@ -9,37 +9,62 @@ echo "Original object:\n";
 var_dump($d);
 
 echo "\n\nSerialised object:\n";
-try {
-	$s = serialize($d);
-} catch (Exception $e) {
-	echo $e->getMessage(), "\n";
-}
+$s = serialize($d);
+var_dump($s);
+
+echo "\n\nUnserialised object:\n";
+$e = unserialize($s);
+var_dump($e);
+
+echo "\n\nCalling __serialize manually:\n";
+var_dump($d->__serialize());
+
+echo "\n\nCalling __unserialize manually:\n";
+$d = new DateInterval('P2Y4DT6H8M');
+$d->__unserialize(
+	[
+		'from_string' => true,
+		'date_string' => 'next weekday 15:30',
+	]
+);
+var_dump($d);
 ?>
 --EXPECTF--
 Original object:
-object(DateInterval)#1 (10) {
-  ["y"]=>
-  int(0)
-  ["m"]=>
-  int(0)
-  ["d"]=>
-  int(0)
-  ["h"]=>
-  int(0)
-  ["i"]=>
-  int(0)
-  ["s"]=>
-  int(0)
-  ["f"]=>
-  float(0)
-  ["invert"]=>
-  int(0)
-  ["days"]=>
-  bool(false)
+object(DateInterval)#1 (%d) {
   ["from_string"]=>
-  bool(false)
+  bool(true)
+  ["date_string"]=>
+  string(18) "next weekday 15:30"
 }
 
 
 Serialised object:
-Serializing special relative time specifications is not supported
+string(92) "O:12:"DateInterval":2:{s:11:"from_string";b:1;s:11:"date_string";s:18:"next weekday 15:30";}"
+
+
+Unserialised object:
+object(DateInterval)#2 (2) {
+  ["from_string"]=>
+  bool(true)
+  ["date_string"]=>
+  string(18) "next weekday 15:30"
+}
+
+
+Calling __serialize manually:
+array(2) {
+  ["from_string"]=>
+  bool(true)
+  ["date_string"]=>
+  string(18) "next weekday 15:30"
+}
+
+
+Calling __unserialize manually:
+object(DateInterval)#3 (2) {
+  ["from_string"]=>
+  bool(true)
+  ["date_string"]=>
+  string(18) "next weekday 15:30"
+}

--- a/ext/date/tests/DatePeriod_set_state.phpt
+++ b/ext/date/tests/DatePeriod_set_state.phpt
@@ -53,6 +53,8 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["days"]=>
     bool(false)
+    ["have_special_relative"]=>
+    int(0)
   }
   ["recurrences"]=>
   int(25)

--- a/ext/date/tests/DatePeriod_set_state.phpt
+++ b/ext/date/tests/DatePeriod_set_state.phpt
@@ -53,8 +53,8 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["days"]=>
     bool(false)
-    ["have_special_relative"]=>
-    int(0)
+    ["from_string"]=>
+    bool(false)
   }
   ["recurrences"]=>
   int(25)

--- a/ext/date/tests/DatePeriod_set_state.phpt
+++ b/ext/date/tests/DatePeriod_set_state.phpt
@@ -34,7 +34,7 @@ object(DatePeriod)#%d (6) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (16) {
+  object(DateInterval)#%d (%d) {
     ["y"]=>
     int(0)
     ["m"]=>
@@ -49,24 +49,10 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["f"]=>
     float(0)
-    ["weekday"]=>
-    int(0)
-    ["weekday_behavior"]=>
-    int(0)
-    ["first_last_day_of"]=>
-    int(0)
     ["invert"]=>
     int(0)
     ["days"]=>
     bool(false)
-    ["special_type"]=>
-    int(0)
-    ["special_amount"]=>
-    int(0)
-    ["have_weekday_relative"]=>
-    int(0)
-    ["have_special_relative"]=>
-    int(0)
   }
   ["recurrences"]=>
   int(25)

--- a/ext/date/tests/bug45682.phpt
+++ b/ext/date/tests/bug45682.phpt
@@ -13,7 +13,7 @@ $diff = date_diff($date, $other);
 var_dump($diff);
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -28,22 +28,8 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   int(3)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }

--- a/ext/date/tests/bug45682.phpt
+++ b/ext/date/tests/bug45682.phpt
@@ -32,6 +32,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(3)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/bug45682.phpt
+++ b/ext/date/tests/bug45682.phpt
@@ -32,4 +32,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(3)
+  ["have_special_relative"]=>
+  int(0)
 }

--- a/ext/date/tests/bug48678.phpt
+++ b/ext/date/tests/bug48678.phpt
@@ -17,15 +17,8 @@ DateInterval Object
     [i] => 30
     [s] => 5
     [f] => 0
-    [weekday] => 0
-    [weekday_behavior] => 0
-    [first_last_day_of] => 0
     [invert] => 0
     [days] => 
-    [special_type] => 0
-    [special_amount] => 0
-    [have_weekday_relative] => 0
-    [have_special_relative] => 0
 )
 DateInterval Object
 (
@@ -36,13 +29,6 @@ DateInterval Object
     [i] => 30
     [s] => 5
     [f] => 0
-    [weekday] => 0
-    [weekday_behavior] => 0
-    [first_last_day_of] => 0
     [invert] => 0
     [days] => 
-    [special_type] => 0
-    [special_amount] => 0
-    [have_weekday_relative] => 0
-    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug48678.phpt
+++ b/ext/date/tests/bug48678.phpt
@@ -19,6 +19,7 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 
+    [have_special_relative] => 0
 )
 DateInterval Object
 (
@@ -31,4 +32,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 
+    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug48678.phpt
+++ b/ext/date/tests/bug48678.phpt
@@ -19,7 +19,7 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 
-    [have_special_relative] => 0
+    [from_string] => 
 )
 DateInterval Object
 (
@@ -32,5 +32,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 
-    [have_special_relative] => 0
+    [from_string] => 
 )

--- a/ext/date/tests/bug49081.phpt
+++ b/ext/date/tests/bug49081.phpt
@@ -20,4 +20,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 30
+    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug49081.phpt
+++ b/ext/date/tests/bug49081.phpt
@@ -20,5 +20,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 30
-    [have_special_relative] => 0
+    [from_string] => 
 )

--- a/ext/date/tests/bug49081.phpt
+++ b/ext/date/tests/bug49081.phpt
@@ -18,13 +18,6 @@ DateInterval Object
     [i] => 0
     [s] => 0
     [f] => 0
-    [weekday] => 0
-    [weekday_behavior] => 0
-    [first_last_day_of] => 0
     [invert] => 0
     [days] => 30
-    [special_type] => 0
-    [special_amount] => 0
-    [have_weekday_relative] => 0
-    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug49778.phpt
+++ b/ext/date/tests/bug49778.phpt
@@ -27,8 +27,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   bool(false)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 7
 (unknown)

--- a/ext/date/tests/bug49778.phpt
+++ b/ext/date/tests/bug49778.phpt
@@ -27,6 +27,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   bool(false)
+  ["have_special_relative"]=>
+  int(0)
 }
 7
 (unknown)

--- a/ext/date/tests/bug49778.phpt
+++ b/ext/date/tests/bug49778.phpt
@@ -8,7 +8,7 @@ echo $i->format("%d"), "\n";
 echo $i->format("%a"), "\n";
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -23,24 +23,10 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   bool(false)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }
 7
 (unknown)

--- a/ext/date/tests/bug52113.phpt
+++ b/ext/date/tests/bug52113.phpt
@@ -52,6 +52,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
+  ["have_special_relative"]=>
+  int(0)
 }
 string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
 \DateInterval::__set_state(array(
@@ -64,6 +66,7 @@ string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h"
    'f' => 0.0,
    'invert' => 0,
    'days' => 0,
+   'have_special_relative' => 0,
 ))object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
@@ -82,6 +85,8 @@ string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h"
   ["invert"]=>
   int(0)
   ["days"]=>
+  int(0)
+  ["have_special_relative"]=>
   int(0)
 }
 object(DatePeriod)#%d (6) {
@@ -117,6 +122,8 @@ object(DatePeriod)#%d (6) {
     ["invert"]=>
     int(0)
     ["days"]=>
+    int(0)
+    ["have_special_relative"]=>
     int(0)
   }
   ["recurrences"]=>
@@ -143,6 +150,8 @@ object(DateInterval)#%d (%d) {
   int(1)
   ["days"]=>
   int(2400)
+  ["have_special_relative"]=>
+  int(0)
 }
 object(DatePeriod)#%d (6) {
   ["start"]=>
@@ -177,6 +186,8 @@ object(DatePeriod)#%d (6) {
     ["invert"]=>
     int(0)
     ["days"]=>
+    int(0)
+    ["have_special_relative"]=>
     int(0)
   }
   ["recurrences"]=>

--- a/ext/date/tests/bug52113.phpt
+++ b/ext/date/tests/bug52113.phpt
@@ -33,7 +33,7 @@ var_dump($unser, $p);
 
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -48,23 +48,9 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
-  int(0)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
   int(0)
 }
 string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
@@ -76,16 +62,9 @@ string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h"
    'i' => 0,
    's' => 0,
    'f' => 0.0,
-   'weekday' => 0,
-   'weekday_behavior' => 0,
-   'first_last_day_of' => 0,
    'invert' => 0,
    'days' => 0,
-   'special_type' => 0,
-   'special_amount' => 0,
-   'have_weekday_relative' => 0,
-   'have_special_relative' => 0,
-))object(DateInterval)#%d (16) {
+))object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -100,23 +79,9 @@ string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h"
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
-  int(0)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
   int(0)
 }
 object(DatePeriod)#%d (6) {
@@ -134,7 +99,7 @@ object(DatePeriod)#%d (6) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (16) {
+  object(DateInterval)#%d (%d) {
     ["y"]=>
     int(0)
     ["m"]=>
@@ -149,23 +114,9 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["f"]=>
     float(0)
-    ["weekday"]=>
-    int(0)
-    ["weekday_behavior"]=>
-    int(0)
-    ["first_last_day_of"]=>
-    int(0)
     ["invert"]=>
     int(0)
     ["days"]=>
-    int(0)
-    ["special_type"]=>
-    int(0)
-    ["special_amount"]=>
-    int(0)
-    ["have_weekday_relative"]=>
-    int(0)
-    ["have_special_relative"]=>
     int(0)
   }
   ["recurrences"]=>
@@ -173,7 +124,7 @@ object(DatePeriod)#%d (6) {
   ["include_start_date"]=>
   bool(true)
 }
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(7)
   ["m"]=>
@@ -188,24 +139,10 @@ object(DateInterval)#%d (16) {
   int(2)
   ["f"]=>
   float(0.876543)
-  ["weekday"]=>
-  int(-1)
-  ["weekday_behavior"]=>
-  int(-1)
-  ["first_last_day_of"]=>
-  int(-1)
   ["invert"]=>
   int(1)
   ["days"]=>
   int(2400)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(-1)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }
 object(DatePeriod)#%d (6) {
   ["start"]=>
@@ -222,7 +159,7 @@ object(DatePeriod)#%d (6) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (16) {
+  object(DateInterval)#%d (%d) {
     ["y"]=>
     int(0)
     ["m"]=>
@@ -237,23 +174,9 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["f"]=>
     float(0)
-    ["weekday"]=>
-    int(0)
-    ["weekday_behavior"]=>
-    int(0)
-    ["first_last_day_of"]=>
-    int(0)
     ["invert"]=>
     int(0)
     ["days"]=>
-    int(0)
-    ["special_type"]=>
-    int(0)
-    ["special_amount"]=>
-    int(0)
-    ["have_weekday_relative"]=>
-    int(0)
-    ["have_special_relative"]=>
     int(0)
   }
   ["recurrences"]=>

--- a/ext/date/tests/bug52113.phpt
+++ b/ext/date/tests/bug52113.phpt
@@ -55,7 +55,7 @@ object(DateInterval)#%d (%d) {
   ["from_string"]=>
   bool(false)
 }
-string(380) "O:12:"DateInterval":18:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;s:13:"civil_or_wall";i:1;s:11:"from_string";b:0;}"
+string(164) "O:12:"DateInterval":10:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:0;s:11:"from_string";b:0;}"
 DateInterval::__set_state(array(
    'y' => 0,
    'm' => 0,

--- a/ext/date/tests/bug52113.phpt
+++ b/ext/date/tests/bug52113.phpt
@@ -56,7 +56,7 @@ object(DateInterval)#%d (%d) {
   bool(false)
 }
 string(164) "O:12:"DateInterval":10:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:0;s:11:"from_string";b:0;}"
-DateInterval::__set_state(array(
+\DateInterval::__set_state(array(
    'y' => 0,
    'm' => 0,
    'd' => 0,

--- a/ext/date/tests/bug52113.phpt
+++ b/ext/date/tests/bug52113.phpt
@@ -52,11 +52,11 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
-string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}"
-\DateInterval::__set_state(array(
+string(380) "O:12:"DateInterval":18:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:4;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";i:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;s:13:"civil_or_wall";i:1;s:11:"from_string";b:0;}"
+DateInterval::__set_state(array(
    'y' => 0,
    'm' => 0,
    'd' => 0,
@@ -66,7 +66,7 @@ string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h"
    'f' => 0.0,
    'invert' => 0,
    'days' => 0,
-   'have_special_relative' => 0,
+   'from_string' => false,
 ))object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
@@ -86,8 +86,8 @@ string(332) "O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:0;s:1:"d";i:0;s:1:"h"
   int(0)
   ["days"]=>
   int(0)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 object(DatePeriod)#%d (6) {
   ["start"]=>
@@ -123,8 +123,8 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["days"]=>
     int(0)
-    ["have_special_relative"]=>
-    int(0)
+    ["from_string"]=>
+    bool(false)
   }
   ["recurrences"]=>
   int(3)
@@ -150,8 +150,8 @@ object(DateInterval)#%d (%d) {
   int(1)
   ["days"]=>
   int(2400)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 object(DatePeriod)#%d (6) {
   ["start"]=>
@@ -187,8 +187,8 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["days"]=>
     int(0)
-    ["have_special_relative"]=>
-    int(0)
+    ["from_string"]=>
+    bool(false)
   }
   ["recurrences"]=>
   int(3)

--- a/ext/date/tests/bug52738.phpt
+++ b/ext/date/tests/bug52738.phpt
@@ -31,5 +31,5 @@ di Object
     [f] => 0
     [invert] => 0
     [days] => 
-    [have_special_relative] => 0
+    [from_string] => 
 )

--- a/ext/date/tests/bug52738.phpt
+++ b/ext/date/tests/bug52738.phpt
@@ -31,4 +31,5 @@ di Object
     [f] => 0
     [invert] => 0
     [days] => 
+    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug52738.phpt
+++ b/ext/date/tests/bug52738.phpt
@@ -29,13 +29,6 @@ di Object
     [i] => 0
     [s] => 0
     [f] => 0
-    [weekday] => 0
-    [weekday_behavior] => 0
-    [first_last_day_of] => 0
     [invert] => 0
     [days] => 
-    [special_type] => 0
-    [special_amount] => 0
-    [have_weekday_relative] => 0
-    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug52808.phpt
+++ b/ext/date/tests/bug52808.phpt
@@ -44,8 +44,8 @@ object(DateInterval)#%d (%d) {
   int(1)
   ["days"]=>
   int(437)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 object(DateInterval)#%d (%d) {
   ["y"]=>
@@ -66,8 +66,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(294)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 object(DateInterval)#%d (%d) {
   ["y"]=>
@@ -88,8 +88,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(294)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 Failed to parse interval (2007-05-11T15:30:00Z/)
 Failed to parse interval (2007-05-11T15:30:00Z)

--- a/ext/date/tests/bug52808.phpt
+++ b/ext/date/tests/bug52808.phpt
@@ -25,7 +25,7 @@ foreach($intervals as $iv) {
 echo "==DONE==\n";
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(1)
   ["m"]=>
@@ -40,26 +40,12 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(1)
   ["days"]=>
   int(437)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -74,26 +60,12 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   int(294)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -108,24 +80,10 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   int(294)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }
 Failed to parse interval (2007-05-11T15:30:00Z/)
 Failed to parse interval (2007-05-11T15:30:00Z)

--- a/ext/date/tests/bug52808.phpt
+++ b/ext/date/tests/bug52808.phpt
@@ -44,6 +44,8 @@ object(DateInterval)#%d (%d) {
   int(1)
   ["days"]=>
   int(437)
+  ["have_special_relative"]=>
+  int(0)
 }
 object(DateInterval)#%d (%d) {
   ["y"]=>
@@ -64,6 +66,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(294)
+  ["have_special_relative"]=>
+  int(0)
 }
 object(DateInterval)#%d (%d) {
   ["y"]=>
@@ -84,6 +88,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(294)
+  ["have_special_relative"]=>
+  int(0)
 }
 Failed to parse interval (2007-05-11T15:30:00Z/)
 Failed to parse interval (2007-05-11T15:30:00Z)

--- a/ext/date/tests/bug53437.phpt
+++ b/ext/date/tests/bug53437.phpt
@@ -69,8 +69,8 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["days"]=>
     bool(false)
-    ["have_special_relative"]=>
-    int(0)
+    ["from_string"]=>
+    bool(false)
   }
   ["recurrences"]=>
   int(3)
@@ -118,8 +118,8 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["days"]=>
     bool(false)
-    ["have_special_relative"]=>
-    int(0)
+    ["from_string"]=>
+    bool(false)
   }
   ["recurrences"]=>
   int(3)

--- a/ext/date/tests/bug53437.phpt
+++ b/ext/date/tests/bug53437.phpt
@@ -69,6 +69,8 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["days"]=>
     bool(false)
+    ["have_special_relative"]=>
+    int(0)
   }
   ["recurrences"]=>
   int(3)
@@ -116,6 +118,8 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["days"]=>
     bool(false)
+    ["have_special_relative"]=>
+    int(0)
   }
   ["recurrences"]=>
   int(3)

--- a/ext/date/tests/bug53437.phpt
+++ b/ext/date/tests/bug53437.phpt
@@ -50,7 +50,7 @@ object(DatePeriod)#%d (6) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (16) {
+  object(DateInterval)#%d (%d) {
     ["y"]=>
     int(0)
     ["m"]=>
@@ -65,24 +65,10 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["f"]=>
     float(0)
-    ["weekday"]=>
-    int(0)
-    ["weekday_behavior"]=>
-    int(0)
-    ["first_last_day_of"]=>
-    int(0)
     ["invert"]=>
     int(0)
     ["days"]=>
     bool(false)
-    ["special_type"]=>
-    int(0)
-    ["special_amount"]=>
-    int(0)
-    ["have_weekday_relative"]=>
-    int(0)
-    ["have_special_relative"]=>
-    int(0)
   }
   ["recurrences"]=>
   int(3)
@@ -111,7 +97,7 @@ object(DatePeriod)#%d (6) {
   ["end"]=>
   NULL
   ["interval"]=>
-  object(DateInterval)#%d (16) {
+  object(DateInterval)#%d (%d) {
     ["y"]=>
     int(0)
     ["m"]=>
@@ -126,24 +112,10 @@ object(DatePeriod)#%d (6) {
     int(0)
     ["f"]=>
     float(0)
-    ["weekday"]=>
-    int(0)
-    ["weekday_behavior"]=>
-    int(0)
-    ["first_last_day_of"]=>
-    int(0)
     ["invert"]=>
     int(0)
     ["days"]=>
     bool(false)
-    ["special_type"]=>
-    int(0)
-    ["special_amount"]=>
-    int(0)
-    ["have_weekday_relative"]=>
-    int(0)
-    ["have_special_relative"]=>
-    int(0)
   }
   ["recurrences"]=>
   int(3)

--- a/ext/date/tests/bug53437_var2.phpt
+++ b/ext/date/tests/bug53437_var2.phpt
@@ -11,8 +11,8 @@ $di1 = unserialize($s);
 var_dump($di0, $di1);
 
 ?>
---EXPECT--
-object(DateInterval)#1 (16) {
+--EXPECTF--
+object(DateInterval)#1 (%d) {
   ["y"]=>
   int(2)
   ["m"]=>
@@ -27,26 +27,12 @@ object(DateInterval)#1 (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   bool(false)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }
-object(DateInterval)#2 (16) {
+object(DateInterval)#2 (%d) {
   ["y"]=>
   int(2)
   ["m"]=>
@@ -61,22 +47,8 @@ object(DateInterval)#2 (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   bool(false)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }

--- a/ext/date/tests/bug53437_var2.phpt
+++ b/ext/date/tests/bug53437_var2.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #53437 DateInterval basic serialization
+Bug #53437 (DateInterval basic serialization)
 --FILE--
 <?php
 $di0 = new DateInterval('P2Y4DT6H8M');
@@ -31,6 +31,8 @@ object(DateInterval)#1 (%d) {
   int(0)
   ["days"]=>
   bool(false)
+  ["have_special_relative"]=>
+  int(0)
 }
 object(DateInterval)#2 (%d) {
   ["y"]=>
@@ -51,4 +53,6 @@ object(DateInterval)#2 (%d) {
   int(0)
   ["days"]=>
   bool(false)
+  ["have_special_relative"]=>
+  int(0)
 }

--- a/ext/date/tests/bug53437_var2.phpt
+++ b/ext/date/tests/bug53437_var2.phpt
@@ -31,8 +31,8 @@ object(DateInterval)#1 (%d) {
   int(0)
   ["days"]=>
   bool(false)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 object(DateInterval)#2 (%d) {
   ["y"]=>
@@ -53,6 +53,6 @@ object(DateInterval)#2 (%d) {
   int(0)
   ["days"]=>
   bool(false)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/bug53437_var4.phpt
+++ b/ext/date/tests/bug53437_var4.phpt
@@ -40,6 +40,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(2)
+  ["have_special_relative"]=>
+  int(0)
 }
 int(0)
 int(0)

--- a/ext/date/tests/bug53437_var4.phpt
+++ b/ext/date/tests/bug53437_var4.phpt
@@ -40,8 +40,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(2)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 int(0)
 int(0)

--- a/ext/date/tests/bug53437_var4.phpt
+++ b/ext/date/tests/bug53437_var4.phpt
@@ -21,7 +21,7 @@ var_dump($df,
 
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -36,24 +36,10 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   int(2)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }
 int(0)
 int(0)

--- a/ext/date/tests/bug53437_var5.phpt
+++ b/ext/date/tests/bug53437_var5.phpt
@@ -30,6 +30,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/bug53437_var5.phpt
+++ b/ext/date/tests/bug53437_var5.phpt
@@ -11,7 +11,7 @@ var_dump($di);
 
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(2)
   ["m"]=>
@@ -24,24 +24,10 @@ object(DateInterval)#%d (16) {
   int(8)
   ["s"]=>
   int(0)
-  ["weekday"]=>
-  int(10)
-  ["weekday_behavior"]=>
-  int(10)
-  ["first_last_day_of"]=>
-  int(0)
+  ["f"]=>
+  float(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   int(0)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(9223372036854775807)
-  ["have_weekday_relative"]=>
-  int(9)
-  ["have_special_relative"]=>
-  int(0)
-  ["f"]=>
-  float(0)
 }

--- a/ext/date/tests/bug53437_var5.phpt
+++ b/ext/date/tests/bug53437_var5.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #53437 DateInterval unserialize bad data, 64 bit
+Bug #53437 (DateInterval unserialize bad data, 64 bit)
 --SKIPIF--
 <?php if (PHP_INT_SIZE != 8) { die('skip true 64 bit only'); } ?>
 --FILE--
@@ -29,5 +29,7 @@ object(DateInterval)#%d (%d) {
   ["invert"]=>
   int(0)
   ["days"]=>
+  int(0)
+  ["have_special_relative"]=>
   int(0)
 }

--- a/ext/date/tests/bug53437_var6.phpt
+++ b/ext/date/tests/bug53437_var6.phpt
@@ -30,6 +30,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/bug53437_var6.phpt
+++ b/ext/date/tests/bug53437_var6.phpt
@@ -11,7 +11,7 @@ var_dump($di);
 
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(2)
   ["m"]=>
@@ -26,22 +26,8 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0.123654)
-  ["weekday"]=>
-  int(10)
-  ["weekday_behavior"]=>
-  int(10)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
-  int(0)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(9223372036854775807)
-  ["have_weekday_relative"]=>
-  int(9)
-  ["have_special_relative"]=>
   int(0)
 }

--- a/ext/date/tests/bug53437_var6.phpt
+++ b/ext/date/tests/bug53437_var6.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #53437 DateInterval unserialize bad data, 64 bit
+Bug #53437 (DateInterval unserialize bad data, 64 bit)
 --SKIPIF--
 <?php if (PHP_INT_SIZE != 8) { die('skip true 64 bit only'); } ?>
 --FILE--
@@ -29,5 +29,7 @@ object(DateInterval)#%d (%d) {
   ["invert"]=>
   int(0)
   ["days"]=>
+  int(0)
+  ["have_special_relative"]=>
   int(0)
 }

--- a/ext/date/tests/bug60774.phpt
+++ b/ext/date/tests/bug60774.phpt
@@ -27,6 +27,8 @@ object(DateInterval)#1 (%d) {
   int(0)
   ["days"]=>
   bool(false)
+  ["have_special_relative"]=>
+  int(0)
 }
 2
 (unknown)

--- a/ext/date/tests/bug60774.phpt
+++ b/ext/date/tests/bug60774.phpt
@@ -23,24 +23,10 @@ object(DateInterval)#1 (%d) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   bool(false)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }
 2
 (unknown)

--- a/ext/date/tests/bug60774.phpt
+++ b/ext/date/tests/bug60774.phpt
@@ -27,8 +27,8 @@ object(DateInterval)#1 (%d) {
   int(0)
   ["days"]=>
   bool(false)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 2
 (unknown)

--- a/ext/date/tests/bug60774.phpt
+++ b/ext/date/tests/bug60774.phpt
@@ -9,26 +9,10 @@ echo $i->format("%a"), "\n";
 ?>
 --EXPECTF--
 object(DateInterval)#1 (%d) {
-  ["y"]=>
-  int(0)
-  ["m"]=>
-  int(0)
-  ["d"]=>
-  int(2)
-  ["h"]=>
-  int(0)
-  ["i"]=>
-  int(0)
-  ["s"]=>
-  int(0)
-  ["f"]=>
-  float(0)
-  ["invert"]=>
-  int(0)
-  ["days"]=>
-  bool(false)
   ["from_string"]=>
-  bool(false)
+  bool(true)
+  ["date_string"]=>
+  string(6) "2 days"
 }
 2
 (unknown)

--- a/ext/date/tests/bug66545.phpt
+++ b/ext/date/tests/bug66545.phpt
@@ -27,4 +27,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 14
+    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug66545.phpt
+++ b/ext/date/tests/bug66545.phpt
@@ -27,5 +27,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 14
-    [have_special_relative] => 0
+    [from_string] => 
 )

--- a/ext/date/tests/bug66545.phpt
+++ b/ext/date/tests/bug66545.phpt
@@ -25,13 +25,6 @@ DateInterval Object
     [i] => 59
     [s] => 59
     [f] => 0
-    [weekday] => 0
-    [weekday_behavior] => 0
-    [first_last_day_of] => 0
     [invert] => 0
     [days] => 14
-    [special_type] => 0
-    [special_amount] => 0
-    [have_weekday_relative] => 0
-    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug70153.phpt
+++ b/ext/date/tests/bug70153.phpt
@@ -25,9 +25,9 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 
-    [have_special_relative] => 0
+    [from_string] => 
 )
-O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";b:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}DateInterval Object
+O:12:"DateInterval":18:{s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;s:13:"civil_or_wall";i:1;s:11:"from_string";b:0;}DateInterval Object
 (
     [y] => 0
     [m] => 1
@@ -38,7 +38,7 @@ O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";
     [f] => 0
     [invert] => 0
     [days] => 
-    [have_special_relative] => 0
+    [from_string] => 
 )
 bool(false)
 bool(false)

--- a/ext/date/tests/bug70153.phpt
+++ b/ext/date/tests/bug70153.phpt
@@ -3,12 +3,40 @@ Bug #70153 (\DateInterval incorrectly unserialized)
 --FILE--
 <?php
 $i1 = \DateInterval::createFromDateString('+1 month');
-$i2 = unserialize(serialize($i1));
+print_r($i1);
+
+$s = serialize($i1);
+print_r($s);
+
+$i2 = unserialize($s);
+print_r($i2);
+
 var_dump($i1->days, $i2->days);
-var_dump($i2->special_amount, $i2->special_amount);
 ?>
 --EXPECT--
+DateInterval Object
+(
+    [y] => 0
+    [m] => 1
+    [d] => 0
+    [h] => 0
+    [i] => 0
+    [s] => 0
+    [f] => 0
+    [invert] => 0
+    [days] => 
+)
+O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";b:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}DateInterval Object
+(
+    [y] => 0
+    [m] => 1
+    [d] => 0
+    [h] => 0
+    [i] => 0
+    [s] => 0
+    [f] => 0
+    [invert] => 0
+    [days] => 
+)
 bool(false)
 bool(false)
-int(0)
-int(0)

--- a/ext/date/tests/bug70153.phpt
+++ b/ext/date/tests/bug70153.phpt
@@ -25,6 +25,7 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 
+    [have_special_relative] => 0
 )
 O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";b:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}DateInterval Object
 (
@@ -37,6 +38,7 @@ O:12:"DateInterval":16:{s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";
     [f] => 0
     [invert] => 0
     [days] => 
+    [have_special_relative] => 0
 )
 bool(false)
 bool(false)

--- a/ext/date/tests/bug70153.phpt
+++ b/ext/date/tests/bug70153.phpt
@@ -8,6 +8,8 @@ print_r($i1);
 $s = serialize($i1);
 print_r($s);
 
+echo "\n";
+
 $i2 = unserialize($s);
 print_r($i2);
 
@@ -16,29 +18,14 @@ var_dump($i1->days, $i2->days);
 --EXPECT--
 DateInterval Object
 (
-    [y] => 0
-    [m] => 1
-    [d] => 0
-    [h] => 0
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 
-    [from_string] => 
+    [from_string] => 1
+    [date_string] => +1 month
 )
-O:12:"DateInterval":18:{s:1:"y";i:0;s:1:"m";i:1;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:1:"f";d:0;s:6:"invert";i:0;s:4:"days";b:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;s:13:"civil_or_wall";i:1;s:11:"from_string";b:0;}DateInterval Object
+O:12:"DateInterval":2:{s:11:"from_string";b:1;s:11:"date_string";s:8:"+1 month";}
+DateInterval Object
 (
-    [y] => 0
-    [m] => 1
-    [d] => 0
-    [h] => 0
-    [i] => 0
-    [s] => 0
-    [f] => 0
-    [invert] => 0
-    [days] => 
-    [from_string] => 
+    [from_string] => 1
+    [date_string] => +1 month
 )
 bool(false)
 bool(false)

--- a/ext/date/tests/bug71700.phpt
+++ b/ext/date/tests/bug71700.phpt
@@ -31,4 +31,6 @@ object(DateInterval)#3 (%d) {
   int(0)
   ["days"]=>
   int(30)
+  ["have_special_relative"]=>
+  int(0)
 }

--- a/ext/date/tests/bug71700.phpt
+++ b/ext/date/tests/bug71700.phpt
@@ -11,8 +11,8 @@ $diff = date_diff($date1, $date2, true);
 
 var_dump($diff);
 ?>
---EXPECT--
-object(DateInterval)#3 (16) {
+--EXPECTF--
+object(DateInterval)#3 (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -27,22 +27,8 @@ object(DateInterval)#3 (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   int(30)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }

--- a/ext/date/tests/bug71700.phpt
+++ b/ext/date/tests/bug71700.phpt
@@ -31,6 +31,6 @@ object(DateInterval)#3 (%d) {
   int(0)
   ["days"]=>
   int(30)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/bug73091.phpt
+++ b/ext/date/tests/bug73091.phpt
@@ -31,6 +31,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(-1)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/bug73091.phpt
+++ b/ext/date/tests/bug73091.phpt
@@ -31,4 +31,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(-1)
+  ["have_special_relative"]=>
+  int(0)
 }

--- a/ext/date/tests/bug73091.phpt
+++ b/ext/date/tests/bug73091.phpt
@@ -12,9 +12,7 @@ class foo {
 var_dump(unserialize('O:12:"DateInterval":1:{s:4:"days";O:3:"foo":0:{}}'));
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
-  ["days"]=>
-  int(-1)
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(-1)
   ["m"]=>
@@ -29,20 +27,8 @@ object(DateInterval)#%d (16) {
   int(-1)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(-1)
-  ["weekday_behavior"]=>
-  int(-1)
-  ["first_last_day_of"]=>
-  int(-1)
   ["invert"]=>
   int(0)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
+  ["days"]=>
   int(-1)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }

--- a/ext/date/tests/bug74274.phpt
+++ b/ext/date/tests/bug74274.phpt
@@ -20,4 +20,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 1
+    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug74274.phpt
+++ b/ext/date/tests/bug74274.phpt
@@ -20,5 +20,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 1
-    [have_special_relative] => 0
+    [from_string] => 
 )

--- a/ext/date/tests/bug74274.phpt
+++ b/ext/date/tests/bug74274.phpt
@@ -18,13 +18,6 @@ DateInterval Object
     [i] => 0
     [s] => 0
     [f] => 0
-    [weekday] => 0
-    [weekday_behavior] => 0
-    [first_last_day_of] => 0
     [invert] => 0
     [days] => 1
-    [special_type] => 0
-    [special_amount] => 0
-    [have_weekday_relative] => 0
-    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug74524.phpt
+++ b/ext/date/tests/bug74524.phpt
@@ -22,4 +22,5 @@ DateInterval Object
     [f] => 0.920541
     [invert] => 1
     [days] => 227
+    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug74524.phpt
+++ b/ext/date/tests/bug74524.phpt
@@ -22,5 +22,5 @@ DateInterval Object
     [f] => 0.920541
     [invert] => 1
     [days] => 227
-    [have_special_relative] => 0
+    [from_string] => 
 )

--- a/ext/date/tests/bug74524.phpt
+++ b/ext/date/tests/bug74524.phpt
@@ -20,13 +20,6 @@ DateInterval Object
     [i] => 36
     [s] => 10
     [f] => 0.920541
-    [weekday] => 0
-    [weekday_behavior] => 0
-    [first_last_day_of] => 0
     [invert] => 1
     [days] => 227
-    [special_type] => 0
-    [special_amount] => 0
-    [have_weekday_relative] => 0
-    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug77571.phpt
+++ b/ext/date/tests/bug77571.phpt
@@ -23,5 +23,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 35
-    [have_special_relative] => 0
+    [from_string] => 
 )

--- a/ext/date/tests/bug77571.phpt
+++ b/ext/date/tests/bug77571.phpt
@@ -21,13 +21,6 @@ DateInterval Object
     [i] => 0
     [s] => 0
     [f] => 0
-    [weekday] => 0
-    [weekday_behavior] => 0
-    [first_last_day_of] => 0
     [invert] => 0
     [days] => 35
-    [special_type] => 0
-    [special_amount] => 0
-    [have_weekday_relative] => 0
-    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug77571.phpt
+++ b/ext/date/tests/bug77571.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #77571 (DateTime's diff DateInterval incorrect in timezones from UTC+01:00 to UTC+12:00
+Bug #77571 (DateTime's diff DateInterval incorrect in timezones from UTC+01:00 to UTC+12:00)
 --FILE--
 <?php
 
@@ -23,4 +23,5 @@ DateInterval Object
     [f] => 0
     [invert] => 0
     [days] => 35
+    [have_special_relative] => 0
 )

--- a/ext/date/tests/bug78452.phpt
+++ b/ext/date/tests/bug78452.phpt
@@ -27,6 +27,6 @@ object(DateInterval)#3 (%d) {
   int(1)
   ["days"]=>
   int(33)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/bug78452.phpt
+++ b/ext/date/tests/bug78452.phpt
@@ -27,4 +27,6 @@ object(DateInterval)#3 (%d) {
   int(1)
   ["days"]=>
   int(33)
+  ["have_special_relative"]=>
+  int(0)
 }

--- a/ext/date/tests/bug78452.phpt
+++ b/ext/date/tests/bug78452.phpt
@@ -7,8 +7,8 @@ $date1 = new \DateTime('2019-09-24 11:47:24');
 $date2 = new \DateTime('2019-08-21 12:47:24');
 var_dump($date1->diff($date2));
 ?>
---EXPECT--
-object(DateInterval)#3 (16) {
+--EXPECTF--
+object(DateInterval)#3 (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -23,22 +23,8 @@ object(DateInterval)#3 (16) {
   int(0)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(1)
   ["days"]=>
   int(33)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }

--- a/ext/date/tests/bug79015.phpt
+++ b/ext/date/tests/bug79015.phpt
@@ -25,6 +25,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   bool(false)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/bug79015.phpt
+++ b/ext/date/tests/bug79015.phpt
@@ -25,4 +25,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   bool(false)
+  ["have_special_relative"]=>
+  int(0)
 }

--- a/ext/date/tests/bug79015.phpt
+++ b/ext/date/tests/bug79015.phpt
@@ -6,7 +6,7 @@ $payload = 'O:12:"DateInterval":16:{s:1:"y";i:1;s:1:"m";i:0;s:1:"d";i:4;s:1:"h";
 var_dump(unserialize($payload));
 ?>
 --EXPECTF--
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(1)
   ["m"]=>
@@ -21,22 +21,8 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(%f)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   bool(false)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }

--- a/ext/date/tests/date_diff1.phpt
+++ b/ext/date/tests/date_diff1.phpt
@@ -47,4 +47,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(33)
+  ["have_special_relative"]=>
+  int(0)
 }

--- a/ext/date/tests/date_diff1.phpt
+++ b/ext/date/tests/date_diff1.phpt
@@ -47,6 +47,6 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(33)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }

--- a/ext/date/tests/date_diff1.phpt
+++ b/ext/date/tests/date_diff1.phpt
@@ -28,7 +28,7 @@ object(DateTime)#2 (3) {
   ["timezone"]=>
   string(3) "EDT"
 }
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -36,29 +36,15 @@ object(DateInterval)#%d (16) {
   ["d"]=>
   int(2)
   ["h"]=>
-  int(16)
+  int(%d)
   ["i"]=>
   int(19)
   ["s"]=>
   int(40)
   ["f"]=>
   float(0)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
   int(33)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
-  int(0)
 }

--- a/ext/date/tests/date_time_fractions.phpt
+++ b/ext/date/tests/date_time_fractions.phpt
@@ -77,8 +77,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
-  ["have_special_relative"]=>
-  int(0)
+  ["from_string"]=>
+  bool(false)
 }
 2016-10-03 13:20:06.724934
 2016-10-03 13:20:07.103123

--- a/ext/date/tests/date_time_fractions.phpt
+++ b/ext/date/tests/date_time_fractions.phpt
@@ -77,6 +77,8 @@ object(DateInterval)#%d (%d) {
   int(0)
   ["days"]=>
   int(0)
+  ["have_special_relative"]=>
+  int(0)
 }
 2016-10-03 13:20:06.724934
 2016-10-03 13:20:07.103123

--- a/ext/date/tests/date_time_fractions.phpt
+++ b/ext/date/tests/date_time_fractions.phpt
@@ -58,7 +58,7 @@ microseconds = true
 2016-10-02 00:00:00.000000
 2016-10-03 12:00:00.000000
 2016-10-17 12:47:18.081921
-object(DateInterval)#%d (16) {
+object(DateInterval)#%d (%d) {
   ["y"]=>
   int(0)
   ["m"]=>
@@ -73,23 +73,9 @@ object(DateInterval)#%d (16) {
   int(0)
   ["f"]=>
   float(0.378189)
-  ["weekday"]=>
-  int(0)
-  ["weekday_behavior"]=>
-  int(0)
-  ["first_last_day_of"]=>
-  int(0)
   ["invert"]=>
   int(0)
   ["days"]=>
-  int(0)
-  ["special_type"]=>
-  int(0)
-  ["special_amount"]=>
-  int(0)
-  ["have_weekday_relative"]=>
-  int(0)
-  ["have_special_relative"]=>
   int(0)
 }
 2016-10-03 13:20:06.724934


### PR DESCRIPTION
This PR adds support for `__serialize` and `__unserialize` to DateInterval.

Unlike the changes to `DateTime`, there are some behavioural changes:

- The exposed internal implementation details for "relative intervals" (such as `next weekday`) no longer express as (fake) properties. But note that you couldn't do anything with these properties, and upon the original deserialisation, these were ignored (and not warned against). If present upon deserialisation, they will continue to just be ignored as to not break existing serialisation strings.
- For situations where exposed internal implementation details were not-NIL, they've been replaced with a new property (`date_string`), and with the flag `from_string` set to `true`.
- This now allows for correct serialisation/unserialisation of *all* `DateInterval` objects