### PR TITLE
Fix get_function_or_method_name when included file is scoped

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -504,7 +504,7 @@ ZEND_API zend_string *get_active_function_or_method_name(void) /* {{{ */
 
 ZEND_API zend_string *get_function_or_method_name(const zend_function *func) /* {{{ */
 {
-	if (func->common.scope) {
+	if (func->common.scope && func->common.function_name) {
 		return zend_create_member_string(func->common.scope->name, func->common.function_name);
 	}
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -261,6 +261,15 @@ static ZEND_FUNCTION(zend_weakmap_dump)
 	RETURN_ARR(zend_array_dup(&ZT_G(global_weakmap)));
 }
 
+static ZEND_FUNCTION(zend_get_current_func_name)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    zend_string *function_name = get_function_or_method_name(EG(current_execute_data)->prev_execute_data->func);
+
+    RETURN_STR(function_name);
+}
+
 /* TESTS Z_PARAM_ITERABLE and Z_PARAM_ITERABLE_OR_NULL */
 static ZEND_FUNCTION(zend_iterable)
 {

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -66,6 +66,8 @@ function zend_weakmap_attach(object $object, mixed $value): bool {}
 function zend_weakmap_remove(object $object): bool {}
 function zend_weakmap_dump(): array {}
 
+function zend_get_current_func_name(): string {}
+
 }
 
 namespace ZendTestNS {

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a6755b9cb5c4625e91d69f17c3aa702a189ba01c */
+ * Stub hash: 1f8834339ebf0d56d2e4ec7f3d27d837f61ba5ef */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -62,6 +62,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_zend_weakmap_dump arginfo_zend_test_array_return
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_get_current_func_name, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_ZendSubNS_namespaced_func, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -97,6 +100,7 @@ static ZEND_FUNCTION(zend_iterable);
 static ZEND_FUNCTION(zend_weakmap_attach);
 static ZEND_FUNCTION(zend_weakmap_remove);
 static ZEND_FUNCTION(zend_weakmap_dump);
+static ZEND_FUNCTION(zend_get_current_func_name);
 static ZEND_FUNCTION(namespaced_func);
 static ZEND_METHOD(_ZendTestClass, is_object);
 static ZEND_METHOD(_ZendTestClass, __toString);
@@ -123,6 +127,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_weakmap_attach, arginfo_zend_weakmap_attach)
 	ZEND_FE(zend_weakmap_remove, arginfo_zend_weakmap_remove)
 	ZEND_FE(zend_weakmap_dump, arginfo_zend_weakmap_dump)
+	ZEND_FE(zend_get_current_func_name, arginfo_zend_get_current_func_name)
 	ZEND_NS_FE("ZendTestNS2\\ZendSubNS", namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)
 	ZEND_FE_END
 };

--- a/ext/zend_test/tests/get_function_or_method_name_01.inc
+++ b/ext/zend_test/tests/get_function_or_method_name_01.inc
@@ -1,0 +1,3 @@
+<?php
+
+return zend_get_current_func_name();

--- a/ext/zend_test/tests/get_function_or_method_name_01.phpt
+++ b/ext/zend_test/tests/get_function_or_method_name_01.phpt
@@ -1,0 +1,19 @@
+--TEST--
+get_function_or_method_name when included file is scoped
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--FILE--
+<?php
+
+class Foo
+{
+    public static function bar()
+    {
+        return require 'get_function_or_method_name_01.inc';
+    }
+}
+
+var_dump(Foo::bar());
+?>
+--EXPECT--
+string(4) "main"


### PR DESCRIPTION
`get_function_or_method_name` causes segfault when called on scoped included file (`require` or `include` from class method)

How to reproduce:

we'll need one extra php function

```c
PHP_FUNCTION(get_current_function_name) {
    ZEND_PARSE_PARAMETERS_NONE();

    zend_string *function_name = get_function_or_method_name(EG(current_execute_data)->prev_execute_data->func);

    RETURN_STR(function_name);
}
```

<br />

```php
// a.php

class Foo
{
    public static function bar()
    {
        return require 'b.php';
    }
}

var_dump(Foo::bar());
```

```php
// b.php

return [
    'foo' => get_current_function_name(),
];
```