### PR TITLE
Zend: fix gcc12 -Warray-bounds warning

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2769,8 +2769,8 @@ ZEND_API zend_result zend_register_functions(zend_class_entry *scope, const zend
 		}
 		lowercase_name = zend_string_tolower_ex(internal_function->function_name, type == MODULE_PERSISTENT);
 		lowercase_name = zend_new_interned_string(lowercase_name);
-		reg_function = malloc(sizeof(zend_internal_function));
-		memcpy(reg_function, &function, sizeof(zend_internal_function));
+		reg_function = calloc(1, sizeof(zend_function));
+		memcpy(reg_function, &function, sizeof(zend_function));
 		if (zend_hash_add_ptr(target_function_table, lowercase_name, reg_function) == NULL) {
 			unload=1;
 			free(reg_function);


### PR DESCRIPTION
gcc12 complains:

zend_API.c:2782:49: warning: array subscript ‘zend_function {aka union _zend_function}[0]’ is partly outside array bounds of ‘unsigned char[120]’ [-Warray-bounds]
zend_API.c:2772:32: note: object of size 120 allocated by ‘malloc’
reg_function = malloc(sizeof(zend_internal_function));

The warning is correct, reg_function allocation size is too small for its type,
allocate sizeof(zend_function) instead.