### PR TITLE
Fix compile for Windows x86 with /W1 /WX options (warnings are fatal)

### DIFF
--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -31,12 +31,7 @@ if %errorlevel% neq 0 exit /b 3
 if "%THREAD_SAFE%" equ "0" set ADD_CONF=%ADD_CONF% --disable-zts
 if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INTRINSICS%
 
-rem Some undefined behavior is reported on 32-bit, this should be fixed
-if "%PLATFORM%" == "x86" (
-	set CFLAGS=/W1
-) else (
-	set CFLAGS=/W1 /WX
-)
+set CFLAGS=/W1 /WX
 
 cmd /c configure.bat ^
 	--enable-snapshot-build ^

--- a/.github/scripts/windows/build_task.bat
+++ b/.github/scripts/windows/build_task.bat
@@ -33,6 +33,9 @@ if "%INTRINSICS%" neq "" set ADD_CONF=%ADD_CONF% --enable-native-intrinsics=%INT
 
 set CFLAGS=/W1 /WX
 
+patch --binary %DEPS_DIR%\include\net-snmp\net-snmp-config.h -i %~dp0net-snmp-config.h.patch.bin
+if %errorlevel% neq 0 exit /b 3
+
 cmd /c configure.bat ^
 	--enable-snapshot-build ^
 	--disable-debug-pack ^

--- a/.github/scripts/windows/net-snmp-config.h.patch.bin
+++ b/.github/scripts/windows/net-snmp-config.h.patch.bin
@@ -1,0 +1,14 @@
+--- net-snmp-config.h	2019-07-01 13:04:57.401354900 +0200
++++ net-snmp-config.h	2022-05-04 11:52:42.229867900 +0200
+@@ -1365,9 +1365,9 @@
+ # define HAVE_SSIZE_T
+ #elif defined(_MSC_VER)
+ # ifdef _M_X64
+-typedef __int64 ssize_t;
++// prevent redefine warning typedef __int64 ssize_t;
+ # else
+-typedef __int32 ssize_t;
++// prevent redefine warning typedef __int32 ssize_t;
+ # endif
+ #endif
+ 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -239,7 +239,17 @@ jobs:
         uses: ./.github/actions/verify-generated-files
   WINDOWS:
     if: github.repository == 'php/php-src' || github.event_name == 'pull_request'
-    name: WINDOWS_X64_ZTS
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - x64: true
+            zts: false
+            opcache: true
+          - x64: false
+            zts: true
+            opcache: false
+    name: "WINDOWS_${{ matrix.x64 && 'X64' || 'X86' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
     runs-on: windows-2019
     env:
       PHP_BUILD_CACHE_BASE_DIR: C:\build-cache
@@ -247,11 +257,11 @@ jobs:
       PHP_BUILD_CACHE_SDK_DIR: C:\build-cache\sdk
       PHP_BUILD_SDK_BRANCH: php_downloads_server_migration_v1
       PHP_BUILD_CRT: vs16
-      PLATFORM: x64
-      THREAD_SAFE: "1"
-      INTRINSICS: AVX2
+      PLATFORM: ${{ matrix.x64 && 'x64' || 'x86' }}
+      THREAD_SAFE: "${{ matrix.zts && '1' || '0' }}"
+      INTRINSICS: "${{ matrix.zts && 'AVX2' || '' }}"
       PARALLEL: -j2
-      OPCACHE: "1"
+      OPCACHE: "${{ matrix.opcache && '1' || '0' }}"
     steps:
       - name: git config
         run: git config --global core.autocrlf false && git config --global core.eol lf


### PR DESCRIPTION
Thankfully there are only a few issues to fix to remove all x86 warnings failing the compile with /WX option, so we fix them.