### PR TITLE
Fix GH-8478: PHP 8.0 tests must be compatible /w MySQL 8.0

### DIFF
--- a/ext/mysqli/tests/mysqli_character_set.phpt
+++ b/ext/mysqli/tests/mysqli_character_set.phpt
@@ -44,7 +44,7 @@ if (!function_exists('mysqli_set_charset')) {
         /* The server currently 17.07.2007 can't handle data sent in ucs2 */
         /* The server currently 16.08.2010 can't handle data sent in utf16 and utf32 */
         /* The server currently 02.09.2011 can't handle data sent in utf16le */
-        /* As of MySQL 8.0.28, utf8mb3 is deprecated, although still reported by `SHOW CHARACTER SET` */
+        /* As of MySQL 8.0.28, `SHOW CHARACTER SET` contains utf8mb3, but that is not yet supported by mysqlnd */
         if ($charset['Charset'] == 'ucs2' || $charset['Charset'] == 'utf16' || $charset['Charset'] == 'utf32' || 'utf16le' == $charset['Charset'] || 'utf8mb3' == $charset['Charset']) {
             continue;
         }

--- a/ext/mysqli/tests/mysqli_character_set.phpt
+++ b/ext/mysqli/tests/mysqli_character_set.phpt
@@ -44,6 +44,7 @@ if (!function_exists('mysqli_set_charset')) {
         /* The server currently 17.07.2007 can't handle data sent in ucs2 */
         /* The server currently 16.08.2010 can't handle data sent in utf16 and utf32 */
         /* The server currently 02.09.2011 can't handle data sent in utf16le */
+        /* As of MySQL 8.0.28, utf8mb3 is deprecated, although still reported by `SHOW CHARACTER SET` */
         if ($charset['Charset'] == 'ucs2' || $charset['Charset'] == 'utf16' || $charset['Charset'] == 'utf32' || 'utf16le' == $charset['Charset'] || 'utf8mb3' == $charset['Charset']) {
             continue;
         }

--- a/ext/mysqli/tests/mysqli_character_set.phpt
+++ b/ext/mysqli/tests/mysqli_character_set.phpt
@@ -44,7 +44,7 @@ if (!function_exists('mysqli_set_charset')) {
         /* The server currently 17.07.2007 can't handle data sent in ucs2 */
         /* The server currently 16.08.2010 can't handle data sent in utf16 and utf32 */
         /* The server currently 02.09.2011 can't handle data sent in utf16le */
-        if ($charset['Charset'] == 'ucs2' || $charset['Charset'] == 'utf16' || $charset['Charset'] == 'utf32' || 'utf16le' == $charset['Charset']) {
+        if ($charset['Charset'] == 'ucs2' || $charset['Charset'] == 'utf16' || $charset['Charset'] == 'utf32' || 'utf16le' == $charset['Charset'] || 'utf8mb3' == $charset['Charset']) {
             continue;
         }
 

--- a/ext/mysqli/tests/mysqli_options.phpt
+++ b/ext/mysqli/tests/mysqli_options.phpt
@@ -68,7 +68,7 @@ require_once('skipifconnectfailure.inc');
         $k = $charset['Charset'];
         /* The server currently 17.07.2007 can't handle data sent in ucs2 */
         /* The server currently 16.08.2010 can't handle data sent in utf16 and utf32 */
-        if ($charset['Charset'] == 'ucs2' || $charset['Charset'] == 'utf16' || $charset['Charset'] == 'utf32') {
+        if ($charset['Charset'] == 'ucs2' || $charset['Charset'] == 'utf16' || $charset['Charset'] == 'utf32' || $charset['Charset'] == 'utf8mb3') {
             continue;
         }
         if (true !== mysqli_options($link, MYSQLI_SET_CHARSET_NAME, $charset['Charset'])) {

--- a/ext/mysqli/tests/mysqli_options.phpt
+++ b/ext/mysqli/tests/mysqli_options.phpt
@@ -68,6 +68,7 @@ require_once('skipifconnectfailure.inc');
         $k = $charset['Charset'];
         /* The server currently 17.07.2007 can't handle data sent in ucs2 */
         /* The server currently 16.08.2010 can't handle data sent in utf16 and utf32 */
+        /* As of MySQL 8.0.28, utf8mb3 is deprecated, although still reported by `SHOW CHARACTER SET` */
         if ($charset['Charset'] == 'ucs2' || $charset['Charset'] == 'utf16' || $charset['Charset'] == 'utf32' || $charset['Charset'] == 'utf8mb3') {
             continue;
         }

--- a/ext/mysqli/tests/mysqli_options.phpt
+++ b/ext/mysqli/tests/mysqli_options.phpt
@@ -68,7 +68,7 @@ require_once('skipifconnectfailure.inc');
         $k = $charset['Charset'];
         /* The server currently 17.07.2007 can't handle data sent in ucs2 */
         /* The server currently 16.08.2010 can't handle data sent in utf16 and utf32 */
-        /* As of MySQL 8.0.28, utf8mb3 is deprecated, although still reported by `SHOW CHARACTER SET` */
+        /* As of MySQL 8.0.28, `SHOW CHARACTER SET` contains utf8mb3, but that is not yet supported by mysqlnd */
         if ($charset['Charset'] == 'ucs2' || $charset['Charset'] == 'utf16' || $charset['Charset'] == 'utf32' || $charset['Charset'] == 'utf8mb3') {
             continue;
         }

--- a/ext/mysqli/tests/mysqli_set_charset.phpt
+++ b/ext/mysqli/tests/mysqli_set_charset.phpt
@@ -85,7 +85,7 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
         printf("[016] Cannot get list of character sets\n");
 
     while ($tmp = mysqli_fetch_assoc($res)) {
-        if ('ucs2' == $tmp['Charset'] || 'utf16' == $tmp['Charset'] || 'utf32' == $tmp['Charset'] || 'utf16le' == $tmp['Charset'])
+        if ('ucs2' == $tmp['Charset'] || 'utf16' == $tmp['Charset'] || 'utf32' == $tmp['Charset'] || 'utf16le' == $tmp['Charset'] || 'utf8mb3' == $tmp['Charset'])
             continue;
 
         /* Uncomment to see where it hangs - var_dump($tmp); flush(); */

--- a/ext/mysqli/tests/mysqli_set_charset.phpt
+++ b/ext/mysqli/tests/mysqli_set_charset.phpt
@@ -85,7 +85,7 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
         printf("[016] Cannot get list of character sets\n");
 
     while ($tmp = mysqli_fetch_assoc($res)) {
-        /* As of MySQL 8.0.28, utf8mb3 is deprecated, although still reported by `SHOW CHARACTER SET` */
+        /* As of MySQL 8.0.28, `SHOW CHARACTER SET` contains utf8mb3, but that is not yet supported by mysqlnd */
         if ('ucs2' == $tmp['Charset'] || 'utf16' == $tmp['Charset'] || 'utf32' == $tmp['Charset'] || 'utf16le' == $tmp['Charset'] || 'utf8mb3' == $tmp['Charset'])
             continue;
 

--- a/ext/mysqli/tests/mysqli_set_charset.phpt
+++ b/ext/mysqli/tests/mysqli_set_charset.phpt
@@ -85,6 +85,7 @@ if ((($res = mysqli_query($link, 'SHOW CHARACTER SET LIKE "latin1"', MYSQLI_STOR
         printf("[016] Cannot get list of character sets\n");
 
     while ($tmp = mysqli_fetch_assoc($res)) {
+        /* As of MySQL 8.0.28, utf8mb3 is deprecated, although still reported by `SHOW CHARACTER SET` */
         if ('ucs2' == $tmp['Charset'] || 'utf16' == $tmp['Charset'] || 'utf32' == $tmp['Charset'] || 'utf16le' == $tmp['Charset'] || 'utf8mb3' == $tmp['Charset'])
             continue;
 


### PR DESCRIPTION
As of MySQL 8.0.28, the `utf8mb3` charset is deprecated, so we should
avoid trying to use it.