### PR TITLE
Fix type for index in ZipArchive::replaceFile

### DIFF
--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -91,7 +91,7 @@ class ZipArchive
     public function addFile(string $filepath, string $entryname = "", int $start = 0, int $length = 0, int $flags = ZipArchive::FL_OVERWRITE) {}
 
     /** @return bool */
-    public function replaceFile(string $filepath, string $index, int $start = 0, int $length = 0, int $flags = 0) {}
+    public function replaceFile(string $filepath, int $index, int $start = 0, int $length = 0, int $flags = 0) {}
 
     /** @return array|false */
     public function addGlob(string $pattern, int $flags = 0, array $options = []) {}

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 095084d2a2df557398191af5dd6c8bea6bb7c338 */
+ * Stub hash: 5ebaf48b6736126648a981f5bbb25b0bf46dc22a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -77,7 +77,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZipArchive_replaceFile, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, filepath, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, index, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")


### PR DESCRIPTION
see https://github.com/php/doc-en/pull/1563

> In all of the `ZipArchive` methods, the index is always described as `int` (see https://www.php.net/manual/en/class.ziparchive.php). Only for the `replaceFile` it is documented as `string`. However, actually passing a string will trigger (in PHP 8.1.5)
> 
> Fatal error: Uncaught TypeError: ZipArchive::replaceFile(): Argument https://github.com/php/doc-en/pull/2 ($index) must be of type int, string given
> 
> TypeError: ZipArchive::replaceFile(): Argument https://github.com/php/doc-en/pull/2 ($index) must be of type int, string given