### PR TITLE
Remove XFAIL from sibling method call test

### DIFF
--- a/Zend/tests/access_modifiers_008.phpt
+++ b/Zend/tests/access_modifiers_008.phpt
@@ -1,21 +1,60 @@
 --TEST--
 Inconsistencies when accessing protected members
---XFAIL--
-Discussion: http://marc.info/?l=php-internals&m=120221184420957&w=2
 --FILE--
 <?php
 
 class A {
-    static protected function f() {return 'A::f()';}
+    static protected function ma() {
+        return 'A::ma()';
+    }
+
+    static private function mp() {
+        return 'A::mp()';
+    }
 }
+
 class B1 extends A {
-    static protected function f() {return 'B1::f()';}
+    static protected function ma() {
+        return 'B1::ma()';
+    }
+
+    static protected function mp() {
+        return 'B1::mp()';
+    }
+
+    static protected function mb() {
+        return 'B1::mb()';
+    }
 }
+
 class B2 extends A {
-    static public function test() {echo B1::f();}
+    static public function test() {
+        echo A::ma() . "\n";
+        try {
+            echo A::mp() . "\n";
+        } catch (\Throwable $e) {
+            echo $e->getMessage() . "\n";
+        }
+        echo B1::ma() . "\n"; // protected method defined also in A
+        try {
+            echo B1::mp() . "\n"; // protected method defined also in A but as private
+        } catch (\Throwable $e) {
+            echo $e->getMessage() . "\n";
+        }
+        try {
+            echo B1::mb() . "\n";
+        } catch (\Throwable $e) {
+            echo $e->getMessage() . "\n";
+        }
+    }
 }
+
 B2::test();
 
 ?>
---EXPECTF--
-Fatal error: Call to protected method B1::f() from scope B2 in %s on line %d
+--EXPECT--
+A::ma()
+Call to private method A::mp() from scope B2
+B1::ma()
+Call to protected method B1::mp() from scope B2
+Call to protected method B1::mb() from scope B2

--- a/Zend/tests/access_modifiers_009.phpt
+++ b/Zend/tests/access_modifiers_009.phpt
@@ -1,26 +1,58 @@
 --TEST--
-Inconsistencies when accessing protected members - 2
---XFAIL--
-Discussion: http://marc.info/?l=php-internals&m=120221184420957&w=2
+Inconsistencies when accessing protected members - is_callable
 --FILE--
 <?php
 
 class A {
-    static protected function f() {return 'A::f()';}
-}
-class B1 extends A {
-    static protected function f() {return 'B1::f()';}
-}
-class B2 extends A {
-    static public function test() {
-        var_dump(is_callable('B1::f'));
-        B1::f();
+    static protected function ma() {
+        return 'A::ma()';
+    }
+
+    static private function mp() {
+        return 'A::mp()';
     }
 }
+
+class B1 extends A {
+    static protected function ma() {
+        return 'B1::ma()';
+    }
+
+    static protected function mp() {
+        return 'B1::mp()';
+    }
+
+    static protected function mb() {
+        return 'B1::mb()';
+    }
+}
+
+class B2 extends A {
+    static public function test() {
+        var_dump(is_callable('A::ma'));
+        var_dump(is_callable('A::mp'));
+        var_dump(is_callable('B1::ma')); // protected method defined also in A
+        var_dump(is_callable('B1::mp')); // protected method defined also in A but as private
+        var_dump(is_callable('B1::mb'));
+    }
+}
+
+var_dump(is_callable('B2::ma'));
+var_dump(is_callable('B2::mp'));
+var_dump(is_callable('B2::mb'));
+var_dump(is_callable('B2::test'));
+echo '----' . "\n";
 B2::test();
 
 ?>
---EXPECTF--
+--EXPECT--
 bool(false)
-
-Fatal error: Call to protected method B1::f() from scope B2 in %s on line %d
+bool(false)
+bool(false)
+bool(true)
+----
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(false)


### PR DESCRIPTION
I belive the XFAIL is not needed. Method defined in shared parent class MUST be accessible even if redeclared in sibling class.