### PR TITLE
Fix detection of unknown gcc function attributes

### DIFF
--- a/build/ax_gcc_func_attribute.m4
+++ b/build/ax_gcc_func_attribute.m4
@@ -227,7 +227,7 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
             dnl GCC doesn't exit with an error if an unknown attribute is
             dnl provided but only outputs a warning, so accept the attribute
             dnl only if no warning were issued.
-            [AS_IF([test -s conftest.err],
+            [AS_IF([grep -- -Wattributes conftest.err],
                 [AS_VAR_SET([ac_var], [no])],
                 [AS_VAR_SET([ac_var], [yes])])],
             [AS_VAR_SET([ac_var], [no])])


### PR DESCRIPTION
As described in autoconf-archive upstream [1], from where
`build/ax_gcc_func_attribute.m4` is forked, the old unknown func attr
detection method would throw a false negative anytime an unrelated
warning was raised.

This results in `ax_cv_have_func_attribute_target` being set to `no`
whenever certain compiler Warning flags are switched on. Namely, having
`-Wall` on, which is a default CFLAG for some linux distributions, will
result in

```
warning: ‘bar’ declared ‘static’ but never defined [-Wunused-function]
```

when evaluating support for the `target` function attribute.

With that configuration value set to `no`, the compiled php binaries
will not support x86_64 v3 instructions such as avx2 and sse2, which
should speed up specific tasks ran by PHP.

This issue was originally reported in Ubuntu [2].

[1] http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=commitdiff;h=df0894ad1a8195df67a52108b931e07d708cec9a
[2] https://bugs.launchpad.net/ubuntu/+source/php8.1/+bug/1882279