### PR TITLE
Added ReflectionMethod::hasPrototype method

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3654,6 +3654,22 @@ ZEND_METHOD(ReflectionMethod, getDeclaringClass)
 }
 /* }}} */
 
+/* {{{ Returns whether a method has a prototype or not */
+ZEND_METHOD(ReflectionMethod, hasPrototype)
+{
+    reflection_object *intern;
+    zend_function *mptr;
+
+    GET_REFLECTION_OBJECT_PTR(mptr);
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    RETURN_BOOL(mptr->common.prototype != NULL);
+}
+/* }}} */
+
 /* {{{ Get the prototype */
 ZEND_METHOD(ReflectionMethod, getPrototype)
 {

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -205,6 +205,9 @@ class ReflectionMethod extends ReflectionFunctionAbstract
     public function getPrototype(): ReflectionMethod {}
 
     /** @tentative-return-type */
+    public function hasPrototype(): bool {}
+
+    /** @tentative-return-type */
     public function setAccessible(bool $accessible): void {}
 }
 

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 62fcf63d2f3e93537560c3a03e71fda131a31586 */
+ * Stub hash: dcd4a469fb0431c98f4c9965a122717006b36415 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -166,6 +166,8 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_ReflectionMethod_getPrototype, 0, 0, ReflectionMethod, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_ReflectionMethod_hasPrototype arginfo_class_ReflectionFunctionAbstract_inNamespace
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionMethod_setAccessible, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, accessible, _IS_BOOL, 0)
@@ -656,6 +658,7 @@ ZEND_METHOD(ReflectionMethod, invoke);
 ZEND_METHOD(ReflectionMethod, invokeArgs);
 ZEND_METHOD(ReflectionMethod, getDeclaringClass);
 ZEND_METHOD(ReflectionMethod, getPrototype);
+ZEND_METHOD(ReflectionMethod, hasPrototype);
 ZEND_METHOD(ReflectionMethod, setAccessible);
 ZEND_METHOD(ReflectionClass, __construct);
 ZEND_METHOD(ReflectionClass, __toString);
@@ -914,6 +917,7 @@ static const zend_function_entry class_ReflectionMethod_methods[] = {
 	ZEND_ME(ReflectionMethod, invokeArgs, arginfo_class_ReflectionMethod_invokeArgs, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionMethod, getDeclaringClass, arginfo_class_ReflectionMethod_getDeclaringClass, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionMethod, getPrototype, arginfo_class_ReflectionMethod_getPrototype, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionMethod, hasPrototype, arginfo_class_ReflectionMethod_hasPrototype, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionMethod, setAccessible, arginfo_class_ReflectionMethod_setAccessible, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/ext/reflection/tests/ReflectionMethod_hasPrototype_basic.phpt
+++ b/ext/reflection/tests/ReflectionMethod_hasPrototype_basic.phpt
@@ -1,0 +1,28 @@
+--TEST--
+public ReflectionMethod ReflectionMethod::hasPrototype ( void );
+--CREDITS--
+ollieread - <code@ollie.codes>
+--FILE--
+<?php
+class Hello {
+    public function sayHelloTo($name) {
+        return 'Hello ' . $name;
+    }
+}
+
+class HelloWorld extends Hello {
+    public function sayHelloTo($name) {
+        return 'Hello world: ' . $name;
+    }
+}
+
+$reflectionMethod1 = new ReflectionMethod('HelloWorld', 'sayHelloTo');
+var_dump($reflectionMethod1->hasPrototype());
+
+$reflectionMethod2 = new ReflectionMethod('Hello', 'sayHelloTo');
+var_dump($reflectionMethod2->hasPrototype());
+
+?>
+--EXPECT--
+bool(true)
+bool(false)


### PR DESCRIPTION
This PR adds the `ReflectionMethod::hasPrototype` method, to allow users to check whether a method has a prototype, falling more in line with the way the other reflection methods are handled (`getMethod`/`hasMethod`, etc).