### PR TITLE
Don't write the shell script for failing tests on Windows by default

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -249,7 +249,7 @@ function main(): void
     if (getenv('TEST_PHP_LOG_FORMAT')) {
         $log_format = strtoupper(getenv('TEST_PHP_LOG_FORMAT'));
     } else {
-        $log_format = 'LEODS';
+        $log_format = IS_WINDOWS ? 'LEOD' : 'LEODS';
     }
 
     // Check whether a detailed log is wanted.


### PR DESCRIPTION
That shell script is completely useless there.