### PR TITLE
Enable Intel CET on Windows by default

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3394,9 +3394,12 @@ function toolset_setup_common_ldlags()
 	ADD_FLAG("PHP_LDFLAGS", "/nodefaultlib:libcmt");
 
 	if (VS_TOOLSET) {
-		if (VCVERS >= 1900) {
-			if (PHP_SECURITY_FLAGS == "yes") {
+        if (PHP_SECURITY_FLAGS == "yes") {
+            if (VCVERS >= 1900) {
 				ADD_FLAG('LDFLAGS', "/GUARD:CF");
+			}
+			if (VCVERS >= 1920) {
+				ADD_FLAG('LDFLAGS', "/CETCOMPAT");
 			}
 		}
 	}


### PR DESCRIPTION
based on https://github.com/php/php-src/pull/8339#issuecomment-1117135954

this is a security fix, so targetting PHP 8.0

tested with https://github.com/php/php-src/pull/8392, build & all tests on x64 & x86 pass

the security can be maybe improved even more, see https://airbus-seclab.github.io/c-compiler-security/msvc_compilation.html