### PR TITLE
stream fd type copy optimisation for macOs.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -365,6 +365,7 @@ PHP_CHECK_FUNC(htonl, socket, network)
 PHP_CHECK_FUNC(gethostname, nsl, network)
 PHP_CHECK_FUNC(gethostbyaddr, nsl, network)
 PHP_CHECK_FUNC(copy_file_range)
+PHP_CHECK_FUNC(fcopyfile)
 PHP_CHECK_FUNC(dlopen, dl, root)
 PHP_CHECK_FUNC(dlsym, dl, root)
 if test "$ac_cv_func_dlopen" = "yes"; then
@@ -389,6 +390,7 @@ netinet/in.h \
 alloca.h \
 arpa/inet.h \
 arpa/nameser.h \
+copyfile.h \
 crypt.h \
 dns.h \
 fcntl.h \


### PR DESCRIPTION
using copyfile api, without control on the buffering tough but
supporting large files.