### PR TITLE
Fix the BOLT problem with GCC10.

### DIFF
--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -52134,7 +52134,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NULL_HANDLER(ZEND_OPCODE_HANDL
 # pragma GCC push_options
 # pragma GCC optimize("no-gcse")
 # pragma GCC optimize("no-ivopts")
+#ifdef HAVE_BOLT
 # pragma GCC optimize("no-reorder-blocks-and-partition")
+#endif
 #endif
 ZEND_API void execute_ex(zend_execute_data *ex)
 {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -52134,6 +52134,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NULL_HANDLER(ZEND_OPCODE_HANDL
 # pragma GCC push_options
 # pragma GCC optimize("no-gcse")
 # pragma GCC optimize("no-ivopts")
+# pragma GCC optimize("no-reorder-blocks-and-partition")
 #endif
 ZEND_API void execute_ex(zend_execute_data *ex)
 {

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -4,7 +4,9 @@
 # pragma GCC push_options
 # pragma GCC optimize("no-gcse")
 # pragma GCC optimize("no-ivopts")
+#ifdef HAVE_BOLT
 # pragma GCC optimize("no-reorder-blocks-and-partition")
+#endif
 #endif
 ZEND_API void {%EXECUTOR_NAME%}_ex(zend_execute_data *ex)
 {

--- a/Zend/zend_vm_execute.skl
+++ b/Zend/zend_vm_execute.skl
@@ -4,6 +4,7 @@
 # pragma GCC push_options
 # pragma GCC optimize("no-gcse")
 # pragma GCC optimize("no-ivopts")
+# pragma GCC optimize("no-reorder-blocks-and-partition")
 #endif
 ZEND_API void {%EXECUTOR_NAME%}_ex(zend_execute_data *ex)
 {

--- a/ext/hash/xxhash/xxhash.h
+++ b/ext/hash/xxhash/xxhash.h
@@ -2934,9 +2934,10 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
   && defined(__OPTIMIZE__) && !defined(__OPTIMIZE_SIZE__) /* respect -O0 and -Os */
 #  pragma GCC push_options
 #  pragma GCC optimize("-O2")
+#ifdef HAVE_BOLT
 #  pragma GCC optimize("no-reorder-blocks-and-partition")
 #endif
-
+#endif
 
 #if XXH_VECTOR == XXH_NEON
 /*

--- a/ext/hash/xxhash/xxhash.h
+++ b/ext/hash/xxhash/xxhash.h
@@ -2934,6 +2934,7 @@ enum XXH_VECTOR_TYPE /* fake enum */ {
   && defined(__OPTIMIZE__) && !defined(__OPTIMIZE_SIZE__) /* respect -O0 and -Os */
 #  pragma GCC push_options
 #  pragma GCC optimize("-O2")
+#  pragma GCC optimize("no-reorder-blocks-and-partition")
 #endif
 
 

--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -62,7 +62,9 @@ static inline int has_crc32_insn() {
 # if defined(__GNUC__) && !defined(__clang__)
 #  pragma GCC push_options
 #  pragma GCC target ("+nothing+crc")
+#ifdef HAVE_BOLT
 #  pragma GCC optimize("no-reorder-blocks-and-partition")
+# endif
 # endif
 static uint32_t crc32_aarch64(uint32_t crc, const char *p, size_t nr) {
 	while (nr >= sizeof(uint64_t)) {

--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -62,6 +62,7 @@ static inline int has_crc32_insn() {
 # if defined(__GNUC__) && !defined(__clang__)
 #  pragma GCC push_options
 #  pragma GCC target ("+nothing+crc")
+#  pragma GCC optimize("no-reorder-blocks-and-partition")
 # endif
 static uint32_t crc32_aarch64(uint32_t crc, const char *p, size_t nr) {
 	while (nr >= sizeof(uint64_t)) {


### PR DESCRIPTION
BOLT method can bring PHP 3% and even more performance improvement. While BOLT requires CFLAGS ‘-fno-reorder-blocks-and-partition’ from GCC9. More information can be found at following link:
https://github.com/facebookincubator/BOLT
https://github.com/facebookincubator/BOLT/issues/288

In GCC7, ‘reorder-blocks-and-partition’ is disable by default. So there’s no problem by default with GCC7.
In GCC10, ‘reorder-blocks-and-partition’ is enabled by default. We need set CFLAGS ‘`-fno-reorder-blocks-and-partition`’ when using BOLT. But there’s still a bug in code which ignore the CFLAGS with ‘`GCC push_options`’ like below example:

```
#if (ZEND_VM_KIND != ZEND_VM_KIND_CALL) && (ZEND_GCC_VERSION >= 4000) && !defined(__clang__)
# pragma GCC push_options
# pragma GCC optimize("no-gcse")
# pragma GCC optimize("no-ivopts")
#endif
ZEND_API void execute_ex(zend_execute_data *ex)
```

This patch is to fix this issue.
