### PR TITLE
Add ReflectionFunction::isAnonymous()

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1790,6 +1790,19 @@ ZEND_METHOD(ReflectionFunctionAbstract, isUserDefined)
 }
 /* }}} */
 
+/* {{{ Returns whether this function is an anonymous closure or not */
+ZEND_METHOD(ReflectionFunction, isAnonymous)
+{
+	reflection_object *intern;
+	zend_function *fptr;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	GET_REFLECTION_OBJECT_PTR(fptr);
+	RETURN_BOOL((fptr->common.fn_flags & (ZEND_ACC_CLOSURE | ZEND_ACC_FAKE_CLOSURE)) == ZEND_ACC_CLOSURE);
+}
+/* }}} */
+
 /* {{{ Returns whether this function has been disabled or not */
 ZEND_METHOD(ReflectionFunction, isDisabled)
 {

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -117,6 +117,8 @@ class ReflectionFunction extends ReflectionFunctionAbstract
 
     public function __toString(): string {}
 
+    public function isAnonymous(): bool {}
+
     /**
      * @tentative-return-type
      * @deprecated ReflectionFunction can no longer be constructed for disabled functions

--- a/ext/reflection/php_reflection_arginfo.h
+++ b/ext/reflection/php_reflection_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 62fcf63d2f3e93537560c3a03e71fda131a31586 */
+ * Stub hash: f06163b02a76ee7fa526e4662f015201e243743d */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Reflection_getModifierNames, 0, 1, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, modifiers, IS_LONG, 0)
@@ -90,6 +90,8 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ReflectionFunction___toString, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_ReflectionFunction_isAnonymous arginfo_class_ReflectionFunctionAbstract_hasTentativeReturnType
 
 #define arginfo_class_ReflectionFunction_isDisabled arginfo_class_ReflectionFunctionAbstract_inNamespace
 
@@ -630,6 +632,7 @@ ZEND_METHOD(ReflectionFunctionAbstract, getTentativeReturnType);
 ZEND_METHOD(ReflectionFunctionAbstract, getAttributes);
 ZEND_METHOD(ReflectionFunction, __construct);
 ZEND_METHOD(ReflectionFunction, __toString);
+ZEND_METHOD(ReflectionFunction, isAnonymous);
 ZEND_METHOD(ReflectionFunction, isDisabled);
 ZEND_METHOD(ReflectionFunction, invoke);
 ZEND_METHOD(ReflectionFunction, invokeArgs);
@@ -878,6 +881,7 @@ static const zend_function_entry class_ReflectionFunctionAbstract_methods[] = {
 static const zend_function_entry class_ReflectionFunction_methods[] = {
 	ZEND_ME(ReflectionFunction, __construct, arginfo_class_ReflectionFunction___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunction, __toString, arginfo_class_ReflectionFunction___toString, ZEND_ACC_PUBLIC)
+	ZEND_ME(ReflectionFunction, isAnonymous, arginfo_class_ReflectionFunction_isAnonymous, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunction, isDisabled, arginfo_class_ReflectionFunction_isDisabled, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 	ZEND_ME(ReflectionFunction, invoke, arginfo_class_ReflectionFunction_invoke, ZEND_ACC_PUBLIC)
 	ZEND_ME(ReflectionFunction, invokeArgs, arginfo_class_ReflectionFunction_invokeArgs, ZEND_ACC_PUBLIC)

--- a/ext/reflection/tests/ReflectionFunction_isAnonymous.phpt
+++ b/ext/reflection/tests/ReflectionFunction_isAnonymous.phpt
@@ -1,0 +1,17 @@
+--TEST--
+ReflectionFunction::isAnonymous
+--FILE--
+<?php
+$rf = new ReflectionFunction(function() {});
+var_dump($rf->isAnonymous());
+
+$rf = new ReflectionFunction('strlen');
+var_dump($rf->isAnonymous());
+
+$rf = new ReflectionFunction(strlen(...));
+var_dump($rf->isAnonymous());
+?>
+--EXPECT--
+bool(true)
+bool(false)
+bool(false)


### PR DESCRIPTION
As proposed at https://externals.io/message/116282

This would be very much appreciated instead of doing `str_contains((new ReflectionFunction($f))->name, '{closure}')`.

In Symfony, we use this check in many places to display user-friendly names for closures.