### PR TITLE
Test snmp on Windows CI

### DIFF
--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -120,6 +120,8 @@ nmake test TESTS="%OPCACHE_OPTS% -q --offline --show-diff --show-slow 1000 --set
 
 set EXIT_CODE=%errorlevel%
 
+taskkill /f /im snmpd.exe
+
 appveyor PushArtifact %TEST_PHP_JUNIT%
 
 if %EXIT_CODE% GEQ 1 (

--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -89,6 +89,10 @@ if not exist "%PHP_BUILD_CACHE_ENCHANT_DICT_DIR%\en_US.aff" (
 mkdir %LOCALAPPDATA%\enchant\hunspell
 copy %PHP_BUILD_CACHE_ENCHANT_DICT_DIR%\* %LOCALAPPDATA%\enchant\hunspell
 
+rem prepare for snmp
+set MIBDIRS=%DEPS_DIR%\share\mibs
+start %DEPS_DIR%\bin\snmpd.exe -C -c %APPVEYOR_BUILD_FOLDER%\ext\snmp\tests\snmpd.conf -Ln
+
 set PHP_BUILD_DIR=%PHP_BUILD_OBJ_DIR%\Release
 if "%THREAD_SAFE%" equ "1" set PHP_BUILD_DIR=%PHP_BUILD_DIR%_TS
 
@@ -101,7 +105,7 @@ rem work-around for some spawned PHP processes requiring OpenSSL
 echo extension=php_openssl.dll >> %PHP_BUILD_DIR%\php.ini
 
 rem remove ext dlls for which tests are not supported
-for %%i in (imap ldap oci8_12c pdo_firebird pdo_oci snmp) do (
+for %%i in (imap ldap oci8_12c pdo_firebird pdo_oci) do (
 	del %PHP_BUILD_DIR%\php_%%i.dll
 )
 

--- a/ext/exif/tests/exif004.phpt
+++ b/ext/exif/tests/exif004.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Check for exif_read_data, Unicode WinXP tags
 --EXTENSIONS--
+mbstring
 exif
 --SKIPIF--
 <?php

--- a/ext/snmp/tests/bug64159.phpt
+++ b/ext/snmp/tests/bug64159.phpt
@@ -7,6 +7,7 @@ snmp
 --SKIPIF--
 <?php
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === "Windows") die("xfail fails on Windows for unknown reasons");
 ?>
 --ENV--
 MIBS=noneXistent

--- a/ext/snmp/tests/snmp_getvalue.phpt
+++ b/ext/snmp/tests/snmp_getvalue.phpt
@@ -7,6 +7,7 @@ snmp
 --SKIPIF--
 <?php
 require_once(__DIR__.'/skipif.inc');
+if (PHP_OS_FAMILY === "Windows") die("xfail fails on Windows for unknown reasons");
 ?>
 --FILE--
 <?php

--- a/ext/snmp/tests/snmpd.conf
+++ b/ext/snmp/tests/snmpd.conf
@@ -5,7 +5,7 @@ rocommunity public 127.0.0.1
 rocommunity6 public ::1
 rwcommunity private 127.0.0.1
 
-Do not enable them - being set here they make appropriate OID switch into r/o
+# Do not enable them - being set here they make appropriate OID switch into r/o
 #syslocation  "Somewhere in the world"
 #syscontact  "root"
 

--- a/ext/standard/tests/file/windows_mb_path/bug54028.phpt
+++ b/ext/standard/tests/file/windows_mb_path/bug54028.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Bug #54028 Directory::read() cannot handle non-unicode chars properly
+--EXTENSIONS--
+mbstring
 --SKIPIF--
 <?php
 include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --FILE--

--- a/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_0.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_0.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test fopen() for reading CP1251 with zend.multibyte
+--EXTENSIONS--
+mbstring
 --INI--
 zend.multibyte=1
 zend.script_encoding=cp1251
@@ -9,7 +11,7 @@ include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --CONFLICTS--

--- a/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_1.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_1.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test mkdir/rmdir CP1251 with zend.multibyte
+--EXTENSIONS--
+mbstring
 --INI--
 zend.multibyte=1
 zend.script_encoding=cp1251
@@ -9,7 +11,7 @@ include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --CONFLICTS--

--- a/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_2.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_2.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test fopen() for write CP1251 with zend.multibyte
+--EXTENSIONS--
+mbstring
 --INI--
 zend.multibyte=1
 zend.script_encoding=cp1251
@@ -9,7 +11,7 @@ include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --CONFLICTS--

--- a/ext/standard/tests/file/windows_mb_path/test_long_path_0.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_long_path_0.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Basic long path test
+--EXTENSIONS--
+mbstring
 --SKIPIF--
 <?php
 include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --FILE--

--- a/ext/standard/tests/file/windows_mb_path/test_long_path_2.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_long_path_2.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Basic long path test with file I/O, multibyte path and realpath() check
+--EXTENSIONS--
+mbstring
 --SKIPIF--
 <?php
 include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --FILE--


### PR DESCRIPTION
We use the snmpd which is now bundled with the net-snmp dependency, and
the MIBS which are also shipped with it.

We also fix the tests/snmpd.conf.