### PR TITLE
Don't unnecessarily skip mb related tests

### DIFF
--- a/ext/exif/tests/exif004.phpt
+++ b/ext/exif/tests/exif004.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Check for exif_read_data, Unicode WinXP tags
 --EXTENSIONS--
+mbstring
 exif
 --SKIPIF--
 <?php

--- a/ext/standard/tests/file/windows_mb_path/bug54028.phpt
+++ b/ext/standard/tests/file/windows_mb_path/bug54028.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Bug #54028 Directory::read() cannot handle non-unicode chars properly
+--EXTENSIONS--
+mbstring
 --SKIPIF--
 <?php
 include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --FILE--

--- a/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_0.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_0.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test fopen() for reading CP1251 with zend.multibyte
+--EXTENSIONS--
+mbstring
 --INI--
 zend.multibyte=1
 zend.script_encoding=cp1251
@@ -9,7 +11,7 @@ include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --CONFLICTS--

--- a/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_1.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_1.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test mkdir/rmdir CP1251 with zend.multibyte
+--EXTENSIONS--
+mbstring
 --INI--
 zend.multibyte=1
 zend.script_encoding=cp1251
@@ -9,7 +11,7 @@ include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --CONFLICTS--

--- a/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_2.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_cp1251_zend_multibyte_2.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test fopen() for write CP1251 with zend.multibyte
+--EXTENSIONS--
+mbstring
 --INI--
 zend.multibyte=1
 zend.script_encoding=cp1251
@@ -9,7 +11,7 @@ include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --CONFLICTS--

--- a/ext/standard/tests/file/windows_mb_path/test_long_path_0.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_long_path_0.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Basic long path test
+--EXTENSIONS--
+mbstring
 --SKIPIF--
 <?php
 include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --FILE--

--- a/ext/standard/tests/file/windows_mb_path/test_long_path_2.phpt
+++ b/ext/standard/tests/file/windows_mb_path/test_long_path_2.phpt
@@ -1,12 +1,14 @@
 --TEST--
 Basic long path test with file I/O, multibyte path and realpath() check
+--EXTENSIONS--
+mbstring
 --SKIPIF--
 <?php
 include __DIR__ . DIRECTORY_SEPARATOR . "util.inc";
 
 skip_if_not_win();
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-skip_if_no_required_exts("mbstring");
+skip_if_no_required_exts();
 
 ?>
 --FILE--


### PR DESCRIPTION
Apparently, these tests have been overlooked when we switched to using
the `--EXTENSIONS--` section.  That caused to skip these tests on
AppVeyor.