### PR TITLE
Do not optimize out ini_get() when the entry does not exist during compilation

### DIFF
--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -17,6 +17,7 @@
    +----------------------------------------------------------------------+
 */
 
+#include "php.h"
 #include "zend_API.h"
 #include "zend_exceptions.h"
 #include "zend_ini.h"
@@ -908,6 +909,9 @@ static inline int ct_eval_func_call(
 
 			ini_entry = zend_hash_find_ptr(EG(ini_directives), Z_STR_P(args[0]));
 			if (!ini_entry) {
+				if (PG(enable_dl)) {
+					return FAILURE;
+				}
 				ZVAL_FALSE(result);
 			} else if (ini_entry->modifiable != ZEND_INI_SYSTEM) {
 				return FAILURE;

--- a/ext/opcache/tests/gh8466.phpt
+++ b/ext/opcache/tests/gh8466.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug GH-8466: ini_get() is optimized out when the option does not exist during compilation
+--SKIPIF--
+<?php include dirname(__DIR__, 2) . "/dl_test/tests/skip.inc"; ?>
+--FILE--
+<?php
+
+if (extension_loaded('dl_test')) {
+    exit('Error: dl_test is already loaded');
+}
+
+if (PHP_OS_FAMILY === 'Windows') {
+    $loaded = dl('php_dl_test.dll');
+} else {
+    $loaded = dl('dl_test.so');
+}
+
+var_dump($loaded);
+
+var_dump(ini_get('dl_test.long'));
+--EXPECT--
+bool(true)
+string(1) "0"

--- a/ext/standard/tests/general_functions/dl-001.phpt
+++ b/ext/standard/tests/general_functions/dl-001.phpt
@@ -20,9 +20,8 @@ var_dump($loaded);
 dl_test_test1();
 var_dump(dl_test_test2("World!"));
 
-// ini_get() gets optimized out, so we use ini_get_all() here
-var_dump(ini_get_all()["dl_test.long"]["local_value"]);
-var_dump(ini_get_all()["dl_test.string"]["local_value"]);
+var_dump(ini_get("dl_test.long"));
+var_dump(ini_get("dl_test.string"));
 
 echo "OK\n";
 --EXPECT--

--- a/ext/standard/tests/general_functions/dl-002.phpt
+++ b/ext/standard/tests/general_functions/dl-002.phpt
@@ -21,9 +21,8 @@ var_dump($loaded);
 dl_test_test1();
 var_dump(dl_test_test2("World!"));
 
-// ini_get() gets optimized out, so we use ini_get_all() here
-var_dump(ini_get_all()["dl_test.long"]["local_value"]);
-var_dump(ini_get_all()["dl_test.string"]["local_value"]);
+var_dump(ini_get("dl_test.long"));
+var_dump(ini_get("dl_test.string"));
 
 echo "OK\n";
 --EXPECT--

--- a/ext/standard/tests/general_functions/dl-003.phpt
+++ b/ext/standard/tests/general_functions/dl-003.phpt
@@ -22,9 +22,8 @@ var_dump(dl_test_test2("World!"));
 ini_set("dl_test.long", "1");
 ini_set("dl_test.string", "world");
 
-// ini_get() gets optimized out, so we use ini_get_all() here
-var_dump(ini_get_all()["dl_test.long"]["local_value"]);
-var_dump(ini_get_all()["dl_test.string"]["local_value"]);
+var_dump(ini_get("dl_test.long"));
+var_dump(ini_get("dl_test.string"));
 
 echo "OK\n";
 --EXPECT--


### PR DESCRIPTION
Do not optimize out ini_get() when the entry does not exist during compilation, as the entry may exist later

Fixed GH-8466