### PR TITLE
Fix GH-8528: ZipArchive::getStream() meta data missing wrapper_type

### DIFF
--- a/ext/zip/tests/gh8528.phpt
+++ b/ext/zip/tests/gh8528.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug GH-8528 (ZipArchive::getStream() meta data missing wrapper_type)
+--SKIPIF--
+<?php
+if (!extension_loaded("zip")) die("skip zip extension not available");
+?>
+--FILE--
+<?php
+$zip = new ZipArchive();
+$zip->open(__DIR__ . "/gh8528.zip", ZipArchive::CREATE|ZipArchive::OVERWRITE);
+$zip->addFromString("text.txt", "foo");
+$zip->close();
+
+$zip->open(__DIR__ . "/gh8528.zip");
+var_dump(stream_get_meta_data($zip->getStream("text.txt"))["wrapper_type"]);
+?>
+--EXPECT--
+string(11) "zip wrapper"
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/gh8528.zip");
+?>

--- a/ext/zip/zip_stream.c
+++ b/ext/zip/zip_stream.c
@@ -230,6 +230,7 @@ php_stream *php_stream_zip_open(struct zip *arch, const char *path, const char *
 			self->cursor = 0;
 			stream = php_stream_alloc(&php_stream_zipio_ops, self, NULL, mode);
 			stream->orig_path = estrdup(path);
+			stream->wrapper = (php_stream_wrapper *) &php_stream_zip_wrapper;
 		}
 	}
 


### PR DESCRIPTION
Not setting the `stream->wrapper` looks like an oversight.