### PR TITLE
Fixed failed test in extension skeleton

### DIFF
--- a/ext/skeleton/tests/003.phpt
+++ b/ext/skeleton/tests/003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-%EXTNAME%_test2() Basic test
+test2() Basic test
 --SKIPIF--
 <?php
 if (!extension_loaded('%EXTNAME%')) {
@@ -8,8 +8,8 @@ if (!extension_loaded('%EXTNAME%')) {
 ?>
 --FILE--
 <?php
-var_dump(%EXTNAME%_test2());
-var_dump(%EXTNAME%_test2('PHP'));
+var_dump(test2());
+var_dump(test2('PHP'));
 ?>
 --EXPECT--
 string(11) "Hello World"


### PR DESCRIPTION
This bug was fixed in 8.1, but not in 8.0
<https://github.com/php/php-src/commit/9fb93e8ed16ba495e0ac06bf706db764db4973b8>