### PR TITLE
Build ext/zip as shared library by default on Windows

### DIFF
--- a/ext/zip/config.w32
+++ b/ext/zip/config.w32
@@ -1,6 +1,6 @@
 // vim:ft=javascript
 
-ARG_ENABLE("zip", "ZIP support", "yes");
+ARG_ENABLE("zip", "ZIP support", "yes,shared");
 
 if (PHP_ZIP != "no") {
 	if (CHECK_HEADER_ADD_INCLUDE("zip.h", "CFLAGS_ZIP", PHP_PHP_BUILD + "\\include;" + PHP_EXTRA_INCLUDES) &&


### PR DESCRIPTION
This allows users to use PECL/zip, which is well maintained and often
brings new features which are not yet available in ext/zip, as drop-in
replacement for the official Windows php-src builds.

---

As it is now, building Windows binaries for PECL/zip is pretty much useless, since these builds can't used for the official php-src binaries, because these have ext/zip statically built-in.