### PR TITLE
Disable zend_rc_debug during dl()

### DIFF
--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -58,10 +58,19 @@ PHPAPI PHP_FUNCTION(dl)
 		RETURN_FALSE;
 	}
 
+#if ZEND_RC_DEBUG
+	bool orig_rc_debug = zend_rc_debug;
+	zend_rc_debug = false;
+#endif
+
 	php_dl(filename, MODULE_TEMPORARY, return_value, 0);
 	if (Z_TYPE_P(return_value) == IS_TRUE) {
 		EG(full_tables_cleanup) = 1;
 	}
+
+#if ZEND_RC_DEBUG
+	zend_rc_debug = orig_rc_debug;
+#endif
 }
 /* }}} */
 


### PR DESCRIPTION
Newly added dl() tests fail because of [an assertion](https://github.com/php/php-src/blob/b388e95/Zend/zend_string.c#L306-L312) failure in ZEND_RC_DEBUG builds. This change disables zend_rc_debug during dl() to allows these tests to pass.

This is not a regression, hence the "fix".

The issue is that we assert that we do not create persistent interned strings during request, which I believe would indicate a bug and would not be thread safe. But, as acknowledged by the comments above the assertions, this can still happen during dl(). I'm not sure whether this is safe or not, although it may be as long as dl() is not enabled in threaded SAPIs.