### PR TITLE
Fix bug #79589: ssl3_read_n:unexpected eof while reading

### DIFF
--- a/ext/openssl/tests/bug79589.phpt
+++ b/ext/openssl/tests/bug79589.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug #65538: TLS unexpected EOF failure
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php
+if (getenv("SKIP_ONLINE_TESTS")) die("skip online test");
+?>
+--FILE--
+<?php
+
+$release = file_get_contents(
+    'https://chromedriver.storage.googleapis.com/LATEST_RELEASE',
+    false,
+    stream_context_create(['ssl' => ['verify_peer'=> false]])
+);
+echo gettype($release);
+
+?>
+--EXPECT--
+string

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -1639,6 +1639,11 @@ int php_openssl_setup_crypto(php_stream *stream,
 
 	ssl_ctx_options &= ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
 
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+	/* Only for OpenSSL 3+ to keep OpenSSL 1.1.1 behavior */
+	ssl_ctx_options |= SSL_OP_IGNORE_UNEXPECTED_EOF;
+#endif
+
 	if (!GET_VER_OPT("disable_compression") || zend_is_true(val)) {
 		ssl_ctx_options |= SSL_OP_NO_COMPRESSION;
 	}


### PR DESCRIPTION
The unexpected EOF failure was introduced in OpenSSL 3.0 to prevent truncation attack. However there are many non complaint servers and it is causing break for many users including potential majority of those where the truncation attack is not applicable. For that reason we try to keep behavior consitent with older OpenSSL versions which is also the path chosen by some other languages and web servers.

Closes GH-8369