### PR TITLE
Fix some minor warnings

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -34,6 +34,9 @@ PHP 8.2 INTERNALS UPGRADE NOTES
       string_natural_case_compare_function(), and string_natural_compare_function()
       have been removed. They always returned SUCCESS and were a wrapper around
       strnatcmp_ex(). Use strnatcmp_ex() directly instead.
+  b. ext/pdo
+    - pdo_raise_impl_error()'s parameter sqlstate has been changed from
+      const char * to pdo_error_type (aka char [6]).
 
 ========================
 4. OpCode changes

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -62,7 +62,7 @@ void pdo_throw_exception(unsigned int driver_errcode, char *driver_errmsg, pdo_e
 		zend_throw_exception_object(&pdo_exception);
 }
 
-void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *sqlstate, const char *supp) /* {{{ */
+void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, pdo_error_type sqlstate, const char *supp) /* {{{ */
 {
 	pdo_error_type *pdo_err = &dbh->error_code;
 	char *message = NULL;
@@ -81,7 +81,7 @@ void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *sqlstate
 		pdo_err = &stmt->error_code;
 	}
 
-	strncpy(*pdo_err, sqlstate, 6);
+	memcpy(*pdo_err, sqlstate, sizeof(pdo_error_type));
 
 	/* hash sqlstate to error messages */
 	msg = pdo_sqlstate_state_to_description(*pdo_err);

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -672,7 +672,7 @@ PDO_API zend_class_entry *php_pdo_get_exception(void);
 PDO_API int pdo_parse_params(pdo_stmt_t *stmt, zend_string *inquery, zend_string **outquery);
 
 PDO_API void pdo_raise_impl_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt,
-	const char *sqlstate, const char *supp);
+	pdo_error_type sqlstate, const char *supp);
 
 PDO_API void php_pdo_dbh_addref(pdo_dbh_t *dbh);
 PDO_API void php_pdo_dbh_delref(pdo_dbh_t *dbh);

--- a/sapi/apache2handler/php_functions.c
+++ b/sapi/apache2handler/php_functions.c
@@ -317,7 +317,7 @@ PHP_FUNCTION(apache_getenv)
 }
 /* }}} */
 
-static char *php_apache_get_version()
+static char *php_apache_get_version(void)
 {
 #if MODULE_MAGIC_NUMBER_MAJOR >= 20060905
 	return (char *) ap_get_server_banner();


### PR DESCRIPTION
I found these while working on something else, so it's not a
comprehensive pass on warnings.

Here's all the usages of [`pdo_raise_impl_error`](https://heap.space/search?project=php-src&full=&defs=&refs=pdo_raise_impl_error&path=&hist=&type=). This is a breaking
change technically, but not in practice (within the engine itself).
Should I leave a note in UPGRADING.INTERNALS anyway?