### PR TITLE
[CLI] Stop closing standard streams

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@ PHP                                                                        NEWS
 
 - CLI:
   . Fixed bug #81496 (Server logs incorrect request method). (lauri)
-  . Fixed GH-8575 (CLI closes standard streams too early). (Levi Morrison)
+  . Fixed bug GH-8575 (CLI closes standard streams too early). (Levi Morrison)
 
 - Core:
   . Fixed bug #81380 (Observer may not be initialized properly). (krakjoe)

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ PHP                                                                        NEWS
 
 - CLI:
   . Fixed bug #81496 (Server logs incorrect request method). (lauri)
+  . Fixed GH-8575 (CLI closes standard streams too early). (Levi Morrison)
 
 - Core:
   . Fixed bug #81380 (Observer may not be initialized properly). (krakjoe)

--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -51,6 +51,7 @@ ZEND_BEGIN_MODULE_GLOBALS(zend_test)
 	HashTable global_weakmap;
 	int replace_zend_execute_ex;
 	int register_passes;
+	bool print_stderr_mshutdown;
 	zend_test_fiber *active_fiber;
 ZEND_END_MODULE_GLOBALS(zend_test)
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -495,6 +495,7 @@ static ZEND_METHOD(ZendTestChildClassWithMethodWithParameterAttribute, override)
 PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("zend_test.replace_zend_execute_ex", "0", PHP_INI_SYSTEM, OnUpdateBool, replace_zend_execute_ex, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.register_passes", "0", PHP_INI_SYSTEM, OnUpdateBool, register_passes, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.print_stderr_mshutdown", "0", PHP_INI_SYSTEM, OnUpdateBool, print_stderr_mshutdown, zend_zend_test_globals, zend_test_globals)
 PHP_INI_END()
 
 void (*old_zend_execute_ex)(zend_execute_data *execute_data);
@@ -619,6 +620,10 @@ PHP_MSHUTDOWN_FUNCTION(zend_test)
 	}
 
 	zend_test_observer_shutdown(SHUTDOWN_FUNC_ARGS_PASSTHRU);
+
+	if (ZT_G(print_stderr_mshutdown)) {
+		fprintf(stderr, "[zend-test] MSHUTDOWN\n");
+	}
 
 	return SUCCESS;
 }

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -622,7 +622,7 @@ PHP_MSHUTDOWN_FUNCTION(zend_test)
 	zend_test_observer_shutdown(SHUTDOWN_FUNC_ARGS_PASSTHRU);
 
 	if (ZT_G(print_stderr_mshutdown)) {
-		fprintf(stderr, "[zend-test] MSHUTDOWN\n");
+		fprintf(stderr, "[zend_test] MSHUTDOWN\n");
 	}
 
 	return SUCCESS;

--- a/ext/zend_test/tests/gh8575.phpt
+++ b/ext/zend_test/tests/gh8575.phpt
@@ -1,0 +1,11 @@
+--TEST--
+CLI: stderr is available in mshutdown
+--SKIPIF--
+<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+--INI--
+zend_test.print_stderr_mshutdown=1
+--FILE--
+==DONE==
+--EXPECTF--
+==DONE==
+[zend-test] MSHUTDOWN

--- a/ext/zend_test/tests/gh8575.phpt
+++ b/ext/zend_test/tests/gh8575.phpt
@@ -1,7 +1,9 @@
 --TEST--
 CLI: stderr is available in mshutdown
 --SKIPIF--
-<?php if (!extension_loaded('zend-test')) die('skip: zend-test extension required'); ?>
+<?php if (php_sapi_name() != "cli")) die('skip: cli test only'); ?>
+--EXTENSIONS--
+zend-test
 --INI--
 zend_test.print_stderr_mshutdown=1
 --FILE--

--- a/ext/zend_test/tests/gh8575.phpt
+++ b/ext/zend_test/tests/gh8575.phpt
@@ -3,11 +3,11 @@ CLI: stderr is available in mshutdown
 --SKIPIF--
 <?php if (php_sapi_name() != "cli")) die('skip: cli test only'); ?>
 --EXTENSIONS--
-zend-test
+zend_test
 --INI--
 zend_test.print_stderr_mshutdown=1
 --FILE--
 ==DONE==
 --EXPECTF--
 ==DONE==
-[zend-test] MSHUTDOWN
+[zend_test] MSHUTDOWN

--- a/ext/zend_test/tests/gh8575.phpt
+++ b/ext/zend_test/tests/gh8575.phpt
@@ -1,7 +1,7 @@
 --TEST--
 CLI: stderr is available in mshutdown
 --SKIPIF--
-<?php if (php_sapi_name() != "cli")) die('skip cli test only'); ?>
+<?php if (php_sapi_name() != "cli") die('skip cli test only'); ?>
 --EXTENSIONS--
 zend_test
 --INI--

--- a/ext/zend_test/tests/gh8575.phpt
+++ b/ext/zend_test/tests/gh8575.phpt
@@ -1,7 +1,7 @@
 --TEST--
 CLI: stderr is available in mshutdown
 --SKIPIF--
-<?php if (php_sapi_name() != "cli")) die('skip: cli test only'); ?>
+<?php if (php_sapi_name() != "cli")) die('skip cli test only'); ?>
 --EXTENSIONS--
 zend_test
 --INI--

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -526,7 +526,7 @@ static void php_cli_usage(char *argv0)
 
 static php_stream *s_in_process = NULL;
 
-static void cli_register_file_handles(bool no_close) /* {{{ */
+static void cli_register_file_handles(void) /* {{{ */
 {
 	php_stream *s_in, *s_out, *s_err;
 	php_stream_context *sc_in=NULL, *sc_out=NULL, *sc_err=NULL;
@@ -536,17 +536,19 @@ static void cli_register_file_handles(bool no_close) /* {{{ */
 	s_out = php_stream_open_wrapper_ex("php://stdout", "wb", 0, NULL, sc_out);
 	s_err = php_stream_open_wrapper_ex("php://stderr", "wb", 0, NULL, sc_err);
 
+	/* Release stream resources, but don't free the underlying handles. Othewrise,
+	 * extensions which write to stderr or company during mshutdown/gshutdown
+	 * won't have the expected functionality.
+	 */
+	if (s_in) s_in->flags |= PHP_STREAM_FLAG_NO_CLOSE;
+	if (s_out) s_out->flags |= PHP_STREAM_FLAG_NO_CLOSE;
+	if (s_err) s_err->flags |= PHP_STREAM_FLAG_NO_CLOSE;
+
 	if (s_in==NULL || s_out==NULL || s_err==NULL) {
 		if (s_in) php_stream_close(s_in);
 		if (s_out) php_stream_close(s_out);
 		if (s_err) php_stream_close(s_err);
 		return;
-	}
-
-	if (no_close) {
-		s_in->flags |= PHP_STREAM_FLAG_NO_CLOSE;
-		s_out->flags |= PHP_STREAM_FLAG_NO_CLOSE;
-		s_err->flags |= PHP_STREAM_FLAG_NO_CLOSE;
 	}
 
 	s_in_process = s_in;
@@ -954,7 +956,7 @@ do_repeat:
 		switch (behavior) {
 		case PHP_MODE_STANDARD:
 			if (script_file) {
-				cli_register_file_handles(/* no_close */ PHP_DEBUG || num_repeats > 1);
+				cli_register_file_handles();
 			}
 
 			if (interactive) {
@@ -989,7 +991,7 @@ do_repeat:
 			}
 			break;
 		case PHP_MODE_CLI_DIRECT:
-			cli_register_file_handles(/* no_close */ PHP_DEBUG || num_repeats > 1);
+			cli_register_file_handles();
 			zend_eval_string_ex(exec_direct, NULL, "Command line code", 1);
 			break;
 
@@ -1004,7 +1006,7 @@ do_repeat:
 					file_handle.filename = NULL;
 				}
 
-				cli_register_file_handles(/* no_close */ PHP_DEBUG || num_repeats > 1);
+				cli_register_file_handles();
 
 				if (exec_begin) {
 					zend_eval_string_ex(exec_begin, NULL, "Command line begin code", 1);


### PR DESCRIPTION
Extensions may (and do) write to stderr in mshutdown and similar. In
the best case, with the stderr stream closed, it's just swallowed.

However, some libraries will do things like try to detect color, and
these will outright fail and cause an error path to be taken.

See also #8569 and #8570.