### PR TITLE
SAPI CLI Variable registration improvements

### DIFF
--- a/main/php_variables.c
+++ b/main/php_variables.c
@@ -54,6 +54,39 @@ static zend_always_inline void php_register_variable_quick(const char *name, siz
 	zend_string_release_ex(key, 0);
 }
 
+PHPAPI void php_register_known_variable(const char *var_name, size_t var_name_len, zval *value, zval *track_vars_array)
+{
+	HashTable *symbol_table = NULL;
+
+	ZEND_ASSERT(var_name != NULL);
+	ZEND_ASSERT(var_name_len != 0);
+	ZEND_ASSERT(track_vars_array != NULL && Z_TYPE_P(track_vars_array) == IS_ARRAY);
+
+	symbol_table = Z_ARRVAL_P(track_vars_array);
+
+#if ZEND_DEBUG
+	/* Verify the name is valid for a PHP variable */
+	ZEND_ASSERT(!(var_name_len == strlen("GLOBALS") && !memcmp(var_name, "GLOBALS", strlen("GLOBALS"))));
+	ZEND_ASSERT(!(var_name_len == strlen("this") && !memcmp(var_name, "this", strlen("this"))));
+
+	/* Assert that the variable name is not numeric */
+	zend_ulong idx;
+	ZEND_ASSERT(!ZEND_HANDLE_NUMERIC_STR(var_name, var_name_len, idx));
+	/* ensure that we don't have null bytes, spaces, dots, or array bracket in the variable name (not binary safe) */
+	const char *p = var_name;
+	for (size_t l = 0; l < var_name_len; l++) {
+		ZEND_ASSERT(*p != '\0' && *p != ' ' && *p != '.' && *p != '[');
+		p++;
+	}
+
+	/* Do not allow to register cookies this way */
+	ZEND_ASSERT(Z_TYPE(PG(http_globals)[TRACK_VARS_COOKIE]) == IS_UNDEF ||
+		Z_ARRVAL(PG(http_globals)[TRACK_VARS_COOKIE]) != symbol_table);
+#endif
+
+	php_register_variable_quick(var_name, var_name_len, value, symbol_table);
+}
+
 PHPAPI void php_register_variable_ex(const char *var_name, zval *val, zval *track_vars_array)
 {
 	char *p = NULL;

--- a/main/php_variables.h
+++ b/main/php_variables.h
@@ -36,6 +36,7 @@ PHPAPI void php_register_variable(const char *var, const char *val, zval *track_
 /* binary-safe version */
 PHPAPI void php_register_variable_safe(const char *var, const char *val, size_t val_len, zval *track_vars_array);
 PHPAPI void php_register_variable_ex(const char *var, zval *val, zval *track_vars_array);
+PHPAPI void php_register_known_variable(const char *var, size_t var_len, zval *value, zval *track_vars_array);
 
 PHPAPI void php_build_argv(const char *s, zval *track_vars_array);
 PHPAPI int php_hash_environment(void);

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -671,10 +671,12 @@ static void sapi_cli_server_register_variables(zval *track_vars_array) /* {{{ */
 
 			strncpy(port, tmp + 1, 8);
 			port[7] = '\0';
-			strncpy(addr, addr_start, addr_end - addr_start);
-			addr[addr_end - addr_start] = '\0';
+			size_t addr_len = addr_end - addr_start;
+			strncpy(addr, addr_start, addr_len);
+			addr[addr_len] = '\0';
+			ZEND_ASSERT(addr_len == strlen(addr));
 			sapi_cli_server_register_known_var_char(track_vars_array,
-				"REMOTE_ADDR", strlen("REMOTE_ADDR"), addr, strlen(addr));
+				"REMOTE_ADDR", strlen("REMOTE_ADDR"), addr, addr_len);
 			sapi_cli_server_register_known_var_char(track_vars_array,
 				"REMOTE_PORT", strlen("REMOTE_PORT"), port, strlen(port));
 		} else {


### PR DESCRIPTION
Introduce a new API ``php_register_known_variable()`` for when we already know the variable name and it is a valid PHP variable name. The current and only way to register a variable will always check that the variable name but that seems pretty pointless for stuff we know is safe.

Then use it in the CLI SAPI.

