### PR TITLE
Emit EXT_STMT for each 'elseif' clause

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5229,6 +5229,12 @@ void zend_compile_if(zend_ast *ast) /* {{{ */
 		if (cond_ast) {
 			znode cond_node;
 			uint32_t opnum_jmpz;
+
+			if (i > 0) {
+				CG(zend_lineno) = cond_ast->lineno;
+				zend_do_extended_stmt();
+			}
+
 			zend_compile_expr(&cond_node, cond_ast);
 			opnum_jmpz = zend_emit_cond_jump(ZEND_JMPZ, &cond_node, 0);
 


### PR DESCRIPTION
This tiny change emits an extra EXT_STMT opcode for each `elseif` child in an AST_IF list.

The reason why I am proposing this, is as follows:

A user reported a [bug #2095](https://bugs.xdebug.org/view.php?id=2095) with Xdebug's code coverage, which complains that lines with `elseif` on them do not get "counted" as being it, where `else if` lines do.

The generated opcodes are for the `elseif` version:

```
   12     0  E >   EXT_STMT                                                 
          1        ASSIGN                                                   !0, 'bar'
   13     2        EXT_STMT                                                 
          3      > JMPZ                                                     <false>, ->7
   14     4    >   EXT_STMT                                                 
          5        ECHO                                                     'hello+1'
          6      > JMP                                                      ->11
   15     7    >   IN_ARRAY                                                 !0, <array>
          8      > JMPZ                                                     ~2, ->11
   16     9    >   EXT_STMT                                                 
         10        ECHO                                                     'hello+2'
   18    11    >   EXT_STMT                                                 
         12      > RETURN                                                   null
```

And for the `else if` version: 

```
    3     0  E >   EXT_STMT                                                 
          1        ASSIGN                                                   !0, 'bar'
    4     2        EXT_STMT                                                 
          3      > JMPZ                                                     <false>, ->7
    5     4    >   EXT_STMT                                                 
          5        ECHO                                                     'hello+1'
          6      > JMP                                                      ->12
    6     7    >   EXT_STMT                                                 
          8        IN_ARRAY                                                 !0, <array>
          9      > JMPZ                                                     ~2, ->12
    7    10    >   EXT_STMT                                                 
         11        ECHO                                                     'hello+2'
    9    12    >   EXT_STMT                                                 
         13      > RETURN                                                   null
```

In the `elseif` variant, the `EXT_STMT` (opcode 7) is indeed missing.

Xdebug uses this opcode for both code coverage analysis, as well as single stepping. The step debugger would also not have stopped at the `elseif` line.

The reason here is that with `else if` it is really seen as two different things, with the `if` being a new statement (and hence creating its own `EXT_STMT`), where with `elseif` it is a continuation of the original `if`, which does **not** emit an `EXT_STMT` for each separate condition. This patch equalizes the behaviour. 