### PR TITLE
Fix stream_wrapper_unregister() resource leak

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,7 @@ PHP                                                                        NEWS
 - Streams:
   . Set IP_BIND_ADDRESS_NO_PORT if available when connecting to remote host.
     (Cristian Rodríguez)
+  . Fixed bug GH-8548 (stream_wrapper_unregister() leaks memory). (ilutov)
 
 - Zip:
   . add ZipArchive::clearError() method

--- a/Zend/tests/gh8548.phpt
+++ b/Zend/tests/gh8548.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GH-8548: stream_wrapper_unregister() leaks memory
+--FILE--
+<?php
+
+class Wrapper
+{
+    public $context;
+
+    public function stream_open(string $path, string $mode, int $options): bool
+    {
+        return true;
+    }
+}
+
+function test() {
+    if (!stream_wrapper_register('foo', Wrapper::class)) {
+        throw new \Exception('Could not register stream wrapper');
+    }
+    if (!stream_wrapper_unregister('foo')) {
+        throw new \Exception('Could not unregister stream wrapper');
+    }
+}
+
+// The first iterations will allocate space for things like the resource list
+for ($i = 0; $i < 5; $i++) {
+    test();
+}
+
+$before = memory_get_usage();
+for ($i = 0; $i < 1000; $i++) {
+    test();
+}
+$after = memory_get_usage();
+
+var_dump($before === $after);
+
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
Closes GH-8548 

The changes are bigger than I would've liked to. Let me know if you'd like me to change anything, I'm open to suggestions. The approach of this PR:

* Make `php_user_stream_wrapper.wrapper` the first member so that we can cast between `php_user_stream_wrapper` and `php_stream_wrapper`
* Add a discriminator to `php_stream_wrapper` (`INTERNAL` or `USER`) so that we know which is which
* Store a pointer to the reference in `php_user_stream_wrapper` so that we can deallocate it when the user stream wrapper is removed

To actually make this testable, I had to introduce a `AUTO_CLOSE_RESOURCE_LIST` env variable that circumvents automatically closing all open resources at the end of the request, as that hides resource leaks. This way the leak is reported both with zmm and asan.

This PR is not ABI compatible, so it's targeting master.