### PR TITLE
Panic with abort()

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -364,7 +364,7 @@ static ZEND_COLD ZEND_NORETURN void zend_mm_panic(const char *message)
 #if ZEND_DEBUG && defined(HAVE_KILL) && defined(HAVE_GETPID)
 	kill(getpid(), SIGSEGV);
 #endif
-	exit(1);
+	abort();
 }
 
 static ZEND_COLD ZEND_NORETURN void zend_mm_safe_error(zend_mm_heap *heap,


### PR DESCRIPTION
This changes `zend_mm_panic()` so that `abort()` is used instead of `exit(1)`.

The goal is to make panics more detectable by run-tests even when `zend_mm_panic()` was not able to write to stderr (see #8588).

An other effect is that `abort()` will also skip normal process termination (e.g. atexit functions, flushing stdio streams). I think that this is desirable in case of memory corruption.