### PR TITLE
Reduce the scope of XFAIL

### DIFF
--- a/ext/opcache/tests/bug78175_2.phpt
+++ b/ext/opcache/tests/bug78175_2.phpt
@@ -9,9 +9,8 @@ opcache.preload={PWD}/preload_bug78175_2.inc
 <?php
 require_once('skipif.inc');
 if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (PHP_ZTS) die('xfail GH-8588');
 ?>
---XFAIL--
-GH-8588
 --FILE--
 <?php
 var_dump(get_class(Loader::getLoader()));

--- a/ext/opcache/tests/bug78376.phpt
+++ b/ext/opcache/tests/bug78376.phpt
@@ -9,9 +9,8 @@ opcache.preload={PWD}/preload_bug78376.inc
 <?php
 require_once('skipif.inc');
 if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (PHP_ZTS) die('xfail GH-8588');
 ?>
---XFAIL--
-GH-8588
 --FILE--
 <?php
 var_dump(\A::$a);

--- a/ext/opcache/tests/preload_method_static_vars.phpt
+++ b/ext/opcache/tests/preload_method_static_vars.phpt
@@ -9,9 +9,8 @@ opcache.preload={PWD}/preload_method_static_vars.inc
 <?php
 require_once('skipif.inc');
 if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (PHP_ZTS) die('xfail GH-8588');
 ?>
---XFAIL--
-GH-8588
 --FILE--
 <?php
 Foo::test();

--- a/ext/opcache/tests/preload_trait_static.phpt
+++ b/ext/opcache/tests/preload_trait_static.phpt
@@ -9,9 +9,8 @@ opcache.preload={PWD}/preload_trait_static.inc
 <?php
 require_once('skipif.inc');
 if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (PHP_ZTS) die('xfail GH-8588');
 ?>
---XFAIL--
-GH-8588
 --FILE--
 <?php
 $bar = new Bar;


### PR DESCRIPTION
These tests fail only in ZTS with opcache enabled