### PR TITLE
Fix type info generation with gen_stub and phpDoc

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1411,7 +1411,7 @@ function funcInfoToCode(FuncInfo $funcInfo): string {
     foreach ($funcInfo->args as $argInfo) {
         $argKind = $argInfo->isVariadic ? "ARG_VARIADIC" : "ARG";
         $argDefaultKind = $argInfo->hasProperDefaultValue() ? "_WITH_DEFAULT_VALUE" : "";
-        $argType = $argInfo->type;
+        $argType = $argInfo->type ?? $argInfo->phpDocType;
         if ($argType !== null) {
             if (null !== $simpleArgType = $argType->tryToSimpleType()) {
                 if ($simpleArgType->isBuiltin) {


### PR DESCRIPTION
`gen_stub` script doesn't generate type information if phpDoc is used. For example:
```php
/**
 * @param string $spam
 */
public function __construct($spam) {}         // ZEND_ARG_INFO(0, spam)

public function __construct(string $spam) {}  // ZEND_ARG_TYPE_INFO(0, spam, IS_STRING, 0)
```

This is because `funcInfoToCode` only uses the `type` attribute.