### PR TITLE
Disable zend_rc_debug during dtor of dl()'ed module

### DIFF
--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -60,6 +60,9 @@ PHPAPI PHP_FUNCTION(dl)
 
 #if ZEND_RC_DEBUG
 	bool orig_rc_debug = zend_rc_debug;
+	/* FIXME: Loading extensions during the request breaks some invariants. In
+	 * particular, it will create persistent interned strings, which is not
+	 * allowed at this stage. */
 	zend_rc_debug = false;
 #endif
 


### PR DESCRIPTION
Newly added dl() tests trigger an assertion in ZEND_RC_DEBUG builds. This change disables zend_rc_debug to allows these tests to pass until this issue is resolved.

See GH-8552