### PR TITLE
Fix undefined behavior in php_set_inet6_addr

### DIFF
--- a/ext/sockets/sockaddr_conv.c
+++ b/ext/sockets/sockaddr_conv.c
@@ -60,7 +60,8 @@ int php_set_inet6_addr(struct sockaddr_in6 *sin6, char *string, php_socket *php_
 
 	}
 
-	if (scope++) {
+	if (scope) {
+		scope++;
 		zend_long lval = 0;
 		double dval = 0;
 		unsigned scope_id = 0;


### PR DESCRIPTION
Postfix `++` on `NULL` is undefined behavior

Found with Clangs UndefinedBehaviorSanitizer.

Should this target PHP 7.4? Do we consider all UB a security issue?