### PR TITLE
Fix regression from GH-8587

### DIFF
--- a/Zend/tests/gh8548.phpt
+++ b/Zend/tests/gh8548.phpt
@@ -11,19 +11,35 @@ class Wrapper
     {
         return true;
     }
+
+    public function stream_eof(): bool
+    {
+        return true;
+    }
 }
 
 function test() {
     if (!stream_wrapper_register('foo', \Wrapper::class)) {
         throw new \Exception('Could not register stream wrapper');
     }
+
+    $file = fopen('foo://bar', 'r');
+
     if (!stream_wrapper_unregister('foo')) {
         throw new \Exception('Could not unregister stream wrapper');
     }
+
+    $wrapper = stream_get_meta_data($file)['wrapper_data'];
+    if (!$wrapper instanceof Wrapper) {
+        throw new \Exception('Wrapper is not of expected type');
+    }
+
+    fclose($file);
+    unset($file);
 }
 
 // The first iterations will allocate space for things like the resource list
-for ($i = 0; $i < 5; $i++) {
+for ($i = 0; $i < 10; $i++) {
     test();
 }
 

--- a/Zend/tests/gh8548_2.phpt
+++ b/Zend/tests/gh8548_2.phpt
@@ -1,0 +1,56 @@
+--TEST--
+GH-8548: Test stream_wrapper_unregister() for directories
+--FILE--
+<?php
+
+class Wrapper
+{
+    public $context;
+
+    public function dir_opendir(string $path, int $options): bool
+    {
+        return true;
+    }
+
+    public function stream_eof(): bool
+    {
+        return true;
+    }
+}
+
+function test() {
+    if (!stream_wrapper_register('foo', \Wrapper::class)) {
+        throw new \Exception('Could not register stream wrapper');
+    }
+
+    $dir = opendir('foo://bar');
+
+    if (!stream_wrapper_unregister('foo')) {
+        throw new \Exception('Could not unregister stream wrapper');
+    }
+
+    $wrapper = stream_get_meta_data($dir)['wrapper_data'];
+    if (!$wrapper instanceof Wrapper) {
+        throw new \Exception('Wrapper is not of expected type');
+    }
+
+    closedir($dir);
+    unset($dir);
+}
+
+// The first iterations will allocate space for things like the resource list
+for ($i = 0; $i < 10; $i++) {
+    test();
+}
+
+$before = memory_get_usage();
+for ($i = 0; $i < 1000; $i++) {
+    test();
+}
+$after = memory_get_usage();
+
+var_dump($before === $after);
+
+?>
+--EXPECT--
+bool(true)

--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -42,6 +42,7 @@ struct php_user_stream_wrapper {
 };
 
 static php_stream *user_wrapper_opener(php_stream_wrapper *wrapper, const char *filename, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC);
+static int user_wrapper_close(php_stream_wrapper *wrapper, php_stream *stream);
 static int user_wrapper_stat_url(php_stream_wrapper *wrapper, const char *url, int flags, php_stream_statbuf *ssb, php_stream_context *context);
 static int user_wrapper_unlink(php_stream_wrapper *wrapper, const char *url, int options, php_stream_context *context);
 static int user_wrapper_rename(php_stream_wrapper *wrapper, const char *url_from, const char *url_to, int options, php_stream_context *context);
@@ -53,7 +54,7 @@ static php_stream *user_wrapper_opendir(php_stream_wrapper *wrapper, const char 
 
 static const php_stream_wrapper_ops user_stream_wops = {
 	user_wrapper_opener,
-	NULL, /* close - the streams themselves know how */
+	user_wrapper_close,
 	NULL, /* stat - the streams themselves know how */
 	user_wrapper_stat_url,
 	user_wrapper_opendir,
@@ -375,6 +376,8 @@ static php_stream *user_wrapper_opener(php_stream_wrapper *wrapper, const char *
 
 		/* set wrapper data to be a reference to our object */
 		ZVAL_COPY(&stream->wrapperdata, &us->object);
+
+		GC_ADDREF(us->wrapper->resource);
 	} else {
 		php_stream_wrapper_log_error(wrapper, options, "\"%s::" USERSTREAM_OPEN "\" call failed",
 			ZSTR_VAL(us->wrapper->ce->name));
@@ -397,6 +400,14 @@ static php_stream *user_wrapper_opener(php_stream_wrapper *wrapper, const char *
 
 	PG(in_user_include) = old_in_user_include;
 	return stream;
+}
+
+static int user_wrapper_close(php_stream_wrapper *wrapper, php_stream *stream)
+{
+	struct php_user_stream_wrapper *uwrap = (struct php_user_stream_wrapper*)wrapper->abstract;
+	zend_list_delete(uwrap->resource);
+	// FIXME: Unused?
+	return 0;
 }
 
 static php_stream *user_wrapper_opendir(php_stream_wrapper *wrapper, const char *filename, const char *mode,
@@ -440,6 +451,8 @@ static php_stream *user_wrapper_opendir(php_stream_wrapper *wrapper, const char 
 
 		/* set wrapper data to be a reference to our object */
 		ZVAL_COPY(&stream->wrapperdata, &us->object);
+
+		GC_ADDREF(us->wrapper->resource);
 	} else {
 		php_stream_wrapper_log_error(wrapper, options, "\"%s::" USERSTREAM_DIR_OPEN "\" call failed",
 			ZSTR_VAL(us->wrapper->ce->name));


### PR DESCRIPTION
Streams hold a reference to the stream wrapper. User stream wrappers
must not be released until the streams themselves are closed.

- [x] ~~Does overriding `stream_closer` mean the stream has to be closed manually now?~~ No
- [x] I'm not sure if `user_wrapper_opendir` is also closed through `user_wrapper_close`. I haven't figured out how to trigger that code path yet.

@nicolas-grekas FYI