### PR TITLE
Make socket path shorter for socket_cmsg_{rights|credentials}.phpt

### DIFF
--- a/ext/sockets/tests/socket_cmsg_credentials.phpt
+++ b/ext/sockets/tests/socket_cmsg_credentials.phpt
@@ -17,7 +17,7 @@ die('skip SO_PASSCRED is not defined');
 --FILE--
 <?php
 include __DIR__."/mcast_helpers.php.inc";
-$path = __DIR__ . "/socket_cmsg_credentials.sock";
+$path = sys_get_temp_dir() . "/socket_cmsg_credentials.sock";
 
 @unlink($path);
 
@@ -55,7 +55,7 @@ var_dump($data['control'][0]['data']['pid'] === $pid);
 ?>
 --CLEAN--
 <?php
-$path = __DIR__ . "/socket_cmsg_credentials.sock";
+$path = sys_get_temp_dir() . "/socket_cmsg_credentials.sock";
 @unlink($path);
 --EXPECTF--
 creating send socket

--- a/ext/sockets/tests/socket_cmsg_rights.phpt
+++ b/ext/sockets/tests/socket_cmsg_rights.phpt
@@ -11,14 +11,10 @@ die('skip not for Microsoft Windows');
 if (strtolower(substr(PHP_OS, 0, 3)) == 'aix') {
 die('skip not for AIX');
 }
---CLEAN--
-<?php
-$path = __DIR__ . "/socket_cmsg_rights.sock";
-@unlink($path);
 --FILE--
 <?php
 include __DIR__."/mcast_helpers.php.inc";
-$path = __DIR__ . "/socket_cmsg_rights.sock";
+$path = sys_get_temp_dir() . "/socket_cmsg_rights.sock";
 
 @unlink($path);
 
@@ -78,6 +74,10 @@ if ($data["control"]) {
     var_dump($data);
 }
 ?>
+--CLEAN--
+<?php
+$path = sys_get_temp_dir() . "/socket_cmsg_rights.sock";
+@unlink($path);
 --EXPECTF--
 creating send socket
 object(Socket)#%d (0) {


### PR DESCRIPTION
When running in CI it fails when path/address is longer 108 with following message

`Fatal error: Uncaught ValueError: socket_bind(): Argument #2 ($address) must be less than 108 in ...`