### PR TITLE
Fix PDOStatement->execute() failed, then execute successfully, errorInfo() information is incorrect

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1671,8 +1671,10 @@ static PHP_METHOD(PDOStatement, errorInfo)
 	array_init(return_value);
 	add_next_index_string(return_value, stmt->error_code);
 
-	if (stmt->dbh->methods->fetch_err) {
-		stmt->dbh->methods->fetch_err(stmt->dbh, stmt, return_value);
+	if (strncmp(stmt->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE))) {
+		if (stmt->dbh->methods->fetch_err) {
+			stmt->dbh->methods->fetch_err(stmt->dbh, stmt, return_value);
+		}
 	}
 
 	error_count = zend_hash_num_elements(Z_ARRVAL_P(return_value));

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -1,0 +1,44 @@
+--TEST--
+GH-8626: PDOStatement->execute() failed, then execute successfully, errorInfo() information is incorrect
+--FILE--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+
+$db = PDOTest::factory();
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+
+@$db->exec("DROP TABLE test");
+$db->exec("CREATE TABLE test (x int)");
+
+$stmt = $db->prepare('INSERT INTO test VALUES(?)');
+
+// fail
+var_dump($stmt->execute([PHP_INT_MIN]), $stmt->errorCode(), $stmt->errorInfo());
+
+// success
+var_dump($stmt->execute([1]), $stmt->errorCode(), $stmt->errorInfo());
+?>
+===DONE===
+--EXPECTF--
+bool(false)
+string(%d) "%s"
+array(3) {
+  [0]=>
+  string(%d) "%s"
+  [1]=>
+  int(%d)
+  [2]=>
+  string(%d) "%s"
+}
+bool(true)
+string(5) "00000"
+array(3) {
+  [0]=>
+  string(5) "00000"
+  [1]=>
+  NULL
+  [2]=>
+  NULL
+}
+===DONE===

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -1,5 +1,13 @@
 --TEST--
 GH-8626: PDOStatement->execute() failed, then execute successfully, errorInfo() information is incorrect
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip');
+$dir = getenv('REDIR_TEST_DIR');
+if (false == $dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+?>
 --FILE--
 <?php
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');


### PR DESCRIPTION
Fix #8626

This problem exists for both PHP 7.4, 8.0, 8.1

Reference: <https://github.com/php/php-src/blob/af20923a0fa67bf8e506c4420a0cb950827366c6/ext/pdo/pdo_dbh.c#L1054>