### PR TITLE
Fix PDOStatement->execute() failed, then execute successfully, errorInfo() information is incorrect

### DIFF
--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -1617,8 +1617,10 @@ PHP_METHOD(PDOStatement, errorInfo)
 	array_init(return_value);
 	add_next_index_string(return_value, stmt->error_code);
 
-	if (stmt->dbh->methods->fetch_err) {
-		stmt->dbh->methods->fetch_err(stmt->dbh, stmt, return_value);
+	if (strncmp(stmt->error_code, PDO_ERR_NONE, sizeof(PDO_ERR_NONE))) {
+		if (stmt->dbh->methods->fetch_err) {
+			stmt->dbh->methods->fetch_err(stmt->dbh, stmt, return_value);
+		}
 	}
 
 	error_count = zend_hash_num_elements(Z_ARRVAL_P(return_value));

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -6,9 +6,6 @@ if (!extension_loaded('pdo')) die('skip');
 $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
 $driver = substr(getenv('PDOTEST_DSN'), 0, strpos(getenv('PDOTEST_DSN'), ':'));
-if (!in_array($driver, array('mysql', 'pgsql', 'sqlite'))) {
-    die('skip not supported');
-}
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
 ?>

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -5,6 +5,7 @@ GH-8626: PDOStatement->execute() failed, then execute successfully, errorInfo() 
 if (!extension_loaded('pdo')) die('skip');
 $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
+if (!strncasecmp(getenv('PDOTEST_DSN'), 'mysql', strlen('mysql'))) die('skip not relevant for mysql driver');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
 ?>

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -17,8 +17,9 @@ require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
-@$db->exec("DROP TABLE test");
-$db->exec("CREATE TABLE test (x int)");
+$db->exec("SET SESSION sql_mode=CONCAT((select @@sql_mode),',STRICT_TRANS_TABLES')");
+@$db->exec('DROP TABLE test');
+$db->exec('CREATE TABLE test (x int)');
 
 $stmt = $db->prepare('INSERT INTO test VALUES(?)');
 

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -1,0 +1,52 @@
+--TEST--
+GH-8626: PDOStatement->execute() failed, then execute successfully, errorInfo() information is incorrect
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo')) die('skip');
+$dir = getenv('REDIR_TEST_DIR');
+if (false == $dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+
+$db = PDOTest::factory();
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+
+@$db->exec("DROP TABLE test");
+$db->exec("CREATE TABLE test (x int)");
+
+$stmt = $db->prepare('INSERT INTO test VALUES(?)');
+
+// fail
+var_dump($stmt->execute([PHP_INT_MIN]), $stmt->errorCode(), $stmt->errorInfo());
+
+// success
+var_dump($stmt->execute([1]), $stmt->errorCode(), $stmt->errorInfo());
+?>
+===DONE===
+--EXPECTF--
+bool(false)
+string(%d) "%s"
+array(3) {
+  [0]=>
+  string(%d) "%s"
+  [1]=>
+  int(%d)
+  [2]=>
+  string(%d) "%s"
+}
+bool(true)
+string(5) "00000"
+array(3) {
+  [0]=>
+  string(5) "00000"
+  [1]=>
+  NULL
+  [2]=>
+  NULL
+}
+===DONE===

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -2,10 +2,10 @@
 GH-8626: PDOStatement->execute() failed, then execute successfully, errorInfo() information is incorrect
 --SKIPIF--
 <?php
-if (!extension_loaded('pdo')) die('skip');
+if (!extension_loaded('pdo') || !extension_loaded('pdo_mysql')) die('skip');
 $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
-if (!strncasecmp(getenv('PDOTEST_DSN'), 'mysql', strlen('mysql'))) die('skip not relevant for mysql driver');
+if (!str_starts_with(getenv('PDOTEST_DSN'), 'mysql')) die('skip non-mysql drivers');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
 ?>

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -5,7 +5,6 @@ GH-8626: PDOStatement->execute() failed, then execute successfully, errorInfo() 
 if (!extension_loaded('pdo')) die('skip');
 $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
-$driver = substr(getenv('PDOTEST_DSN'), 0, strpos(getenv('PDOTEST_DSN'), ':'));
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
 ?>
@@ -23,12 +22,22 @@ $db->exec('CREATE TABLE test (x int NOT NULL)');
 $stmt = $db->prepare('INSERT INTO test VALUES(?)');
 
 // fail
-var_dump($stmt->execute([null]), $stmt->errorCode(), $stmt->errorInfo());
+var_dump($stmt->execute([null]), $stmt->errorCode());
+$errorInfo = $stmt->errorInfo();
+if (isset($errorInfo[3])) {
+    unset($errorInfo[3]); // odbc
+}
+var_dump($errorInfo);
 
-$stmt->closeCursor();
+$stmt->closeCursor(); // sqlite
 
 // success
-var_dump($stmt->execute([1]), $stmt->errorCode(), $stmt->errorInfo());
+var_dump($stmt->execute([1]), $stmt->errorCode());
+$errorInfo = $stmt->errorInfo();
+if (isset($errorInfo[3])) {
+    unset($errorInfo[3]); // odbc
+}
+var_dump($errorInfo);
 ?>
 ===DONE===
 --EXPECTF--

--- a/ext/pdo/tests/gh8626.phpt
+++ b/ext/pdo/tests/gh8626.phpt
@@ -34,25 +34,25 @@ $stmt->closeCursor();
 var_dump($stmt->execute([1]), $stmt->errorCode(), $stmt->errorInfo());
 ?>
 ===DONE===
---EXPECTREGEX--
-bool\(false\)
-string\(\d+\) "[^"]+"
-array\(3\) {
-  \[0\]=>
-  string\(\d+\) "[^"]+"
-  \[1\]=>
-  int\(\d+\)
-  \[2\]=>
-  string\(\d+\) "[^"]+((.+".+)*[^"]+)?"
+--EXPECTF--
+bool(false)
+string(%d) "%s"
+array(3) {
+  [0]=>
+  string(%d) "%s"
+  [1]=>
+  int(%d)
+  [2]=>
+  string(%d) "%s%w%S"
 }
-bool\(true\)
-string\(5\) "00000"
-array\(3\) {
-  \[0\]=>
-  string\(5\) "00000"
-  \[1\]=>
+bool(true)
+string(5) "00000"
+array(3) {
+  [0]=>
+  string(5) "00000"
+  [1]=>
   NULL
-  \[2\]=>
+  [2]=>
   NULL
 }
 ===DONE===

--- a/ext/pdo_pgsql/tests/bug62593.phpt
+++ b/ext/pdo_pgsql/tests/bug62593.phpt
@@ -51,7 +51,7 @@ $expect = 'No errors found';
 
 foreach ($errors as $error)
 {
-  if (strpos('Invalid text representation', $error[2]) !== false)
+  if (null !== $error[2] && strpos('Invalid text representation', $error[2]) !== false)
   {
     $expect = 'Invalid boolean found';
   }


### PR DESCRIPTION
Fix #8626

This problem exists for both PHP 7.4, 8.0, 8.1

Reference: <https://github.com/php/php-src/blob/af20923a0fa67bf8e506c4420a0cb950827366c6/ext/pdo/pdo_dbh.c#L1054>