### PR TITLE
Fix Enum::from/tryFrom memory leak in JIT

### DIFF
--- a/Zend/tests/enum/internal_enums.phpt
+++ b/Zend/tests/enum/internal_enums.phpt
@@ -21,6 +21,9 @@ var_dump(ZendTestStringEnum::Foo->value);
 var_dump($bar = ZendTestStringEnum::from("Test2"));
 var_dump($bar === ZendTestStringEnum::Bar);
 var_dump(ZendTestStringEnum::tryFrom("Test3"));
+var_dump(ZendTestStringEnum::tryFrom(42));
+var_dump(ZendTestStringEnum::tryFrom(43));
+var_dump(ZendTestStringEnum::tryFrom(0));
 var_dump(ZendTestStringEnum::cases());
 
 var_dump($s = serialize($foo));
@@ -47,13 +50,18 @@ string(5) "Test1"
 enum(ZendTestStringEnum::Bar)
 bool(true)
 NULL
-array(3) {
+enum(ZendTestStringEnum::FortyTwo)
+NULL
+NULL
+array(4) {
   [0]=>
   enum(ZendTestStringEnum::Foo)
   [1]=>
   enum(ZendTestStringEnum::Bar)
   [2]=>
   enum(ZendTestStringEnum::Baz)
+  [3]=>
+  enum(ZendTestStringEnum::FortyTwo)
 }
 string(30) "E:22:"ZendTestStringEnum:Foo";"
 enum(ZendTestStringEnum::Foo)

--- a/Zend/tests/enum/internal_enums_strict_types.phpt
+++ b/Zend/tests/enum/internal_enums_strict_types.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Internal enums from/tryFrom in strict_types=1
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+var_dump(ZendTestStringEnum::from("Test2"));
+
+try {
+    var_dump(ZendTestStringEnum::from(42));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    var_dump(ZendTestStringEnum::tryFrom(43));
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+enum(ZendTestStringEnum::Bar)
+ZendTestStringEnum::from(): Argument #1 ($value) must be of type string, int given
+ZendTestStringEnum::tryFrom(): Argument #1 ($value) must be of type string, int given

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -72,6 +72,7 @@ namespace {
         case Foo = "Test1";
         case Bar = "Test2";
         case Baz = "Test2\\a";
+        case FortyTwo = "42";
     }
 
     function zend_test_array_return(): array {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7b0abebae0b0eeea0f45dccb04759fceec1096e3 */
+ * Stub hash: 6d9ff0e2263a39420dd157206331a9e897d9e775 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -416,6 +416,11 @@ static zend_class_entry *register_class_ZendTestStringEnum(void)
 	zend_string *enum_case_Baz_value_str = zend_string_init("Test2\\a", sizeof("Test2\\a") - 1, 1);
 	ZVAL_STR(&enum_case_Baz_value, enum_case_Baz_value_str);
 	zend_enum_add_case_cstr(class_entry, "Baz", &enum_case_Baz_value);
+
+	zval enum_case_FortyTwo_value;
+	zend_string *enum_case_FortyTwo_value_str = zend_string_init("42", sizeof("42") - 1, 1);
+	ZVAL_STR(&enum_case_FortyTwo_value, enum_case_FortyTwo_value_str);
+	zend_enum_add_case_cstr(class_entry, "FortyTwo", &enum_case_FortyTwo_value);
 
 	return class_entry;
 }


### PR DESCRIPTION
when passing an int to a string enum. Previously, the int was coerced to
a string. The JIT skips parameter clean up when unnecessary. In this
particular case, passing int to from(int|string) normally doesn't cause
a coercion so no dtor for the $value zval is generated.

To circumvent this we avoid coersion by explicitly allowing ints and
converting them to strings ourselves. Then we can free it appropriately.

See GH-8518