### PR TITLE
[main][linux] set IP(6)_RECVERR on connected datagram sockets.

### DIFF
--- a/main/network.c
+++ b/main/network.c
@@ -920,6 +920,20 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
 			}
 		}
 #endif
+#ifdef __linux__
+		if (socktype == SOCK_DGRAM) {
+			int val = 1;
+			switch (sa->sa_family)
+			{
+				case AF_INET:
+					setsockopt(sock, SOL_IP, IP_RECVERR, &val, sizeof (val));
+					break;
+				case AF_INET6:
+					setsockopt(sock, SOL_IPV6, IPV6_RECVERR, &val, sizeof (val));
+					break;
+			}
+		}
+#endif
 		n = php_network_connect_socket(sock, sa, socklen, asynchronous,
 				timeout ? &working_timeout : NULL,
 				error_string, error_code);


### PR DESCRIPTION
Contrary to most other OS, the linux kernel does not
consider Destination Net/Host Unreachable,
Source Route failed, or Fragmentation Required ICMP mesages as errors
on connected UDP sockets. Normally this is not a problem but when
on a flaky network connections may hang until timeout with no way
to know what went wrong. This will ruin the day for people expecting
inmediate feedback for protocols like DNS that return data or fail instead of
lingering around until timeout.

Setting IP(6)_RECVERR makes it behave like the rest of the world as a side effect.