### PR TITLE
fpm sockets set listen back queue size to negative which trim down

### DIFF
--- a/sapi/fpm/fpm/fpm_sockets.h
+++ b/sapi/fpm/fpm/fpm_sockets.h
@@ -12,9 +12,9 @@
 #include "fpm_worker_pool.h"
 
 /*
-  On FreeBSD and OpenBSD, backlog negative values are truncated to SOMAXCONN
+  On Linux, FreeBSD, OpenBSD and macOS, backlog negative values are truncated to SOMAXCONN
 */
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__linux__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__linux__) || defined(__APPLE__)
 #define FPM_BACKLOG_DEFAULT -1
 #else
 #define FPM_BACKLOG_DEFAULT 511


### PR DESCRIPTION
 to the 128 hard limit on macOs.