### PR TITLE
Deal with compiler warning in file sapi/fpm/fpm/fpm_conf.c

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -1497,7 +1497,7 @@ static void fpm_conf_ini_parser_array(zval *name, zval *key, zval *value, void *
 	char *err = NULL;
 	void *config;
 
-	if (!Z_STRVAL_P(key) || !Z_STRVAL_P(value) || !*Z_STRVAL_P(key)) {
+	if (!*Z_STRVAL_P(key)) {
 		zlog(ZLOG_ERROR, "[%s:%d] Misspelled  array ?", ini_filename, ini_lineno);
 		*error = 1;
 		return;


### PR DESCRIPTION
The "val" filed in "string type" ZVAL is a variable length array with minimal size 1. Never will the pointer to it be NULL.

```c
struct _zend_string {
	zend_refcounted_h gc;
	zend_ulong        h;                /* hash value */
	size_t            len;
	char              val[1];
};
```

![compiler-warning](https://user-images.githubusercontent.com/9657318/170783024-317e1f63-579a-48cb-aef3-11d50c2c8615.png)

So I think it's a redundant condition judgment just like compiler warning told.