### PR TITLE
Fix GH-8563

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1883,22 +1883,21 @@ static zend_result spl_filesystem_file_read_ex(spl_filesystem_object *intern, bo
 	}
 
 	if (!buf) {
-		intern->u.file.current_line = estrdup("");
-		intern->u.file.current_line_len = 0;
-	} else {
-		if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
-			if (line_len > 0 && buf[line_len - 1] == '\n') {
-				line_len--;
-				if (line_len > 0 && buf[line_len - 1] == '\r') {
-					line_len--;
-				}
-				buf[line_len] = '\0';
-			}
-		}
-
-		intern->u.file.current_line = buf;
-		intern->u.file.current_line_len = line_len;
+		return FAILURE;
 	}
+
+	if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_DROP_NEW_LINE)) {
+		if (line_len > 0 && buf[line_len - 1] == '\n') {
+			line_len--;
+			if (line_len > 0 && buf[line_len - 1] == '\r') {
+				line_len--;
+			}
+			buf[line_len] = '\0';
+		}
+	}
+
+	intern->u.file.current_line = buf;
+	intern->u.file.current_line_len = line_len;
 	intern->u.file.current_line_num += line_add;
 
 	return SUCCESS;

--- a/ext/spl/tests/SplFileObject/SplFileObject_fgetcsv_basic.phpt
+++ b/ext/spl/tests/SplFileObject/SplFileObject_fgetcsv_basic.phpt
@@ -13,6 +13,7 @@ fclose($fp);
 
 $fo = new SplFileObject('SplFileObject__fgetcsv1.csv');
 var_dump($fo->fgetcsv());
+var_dump($fo->fgetcsv());
 ?>
 --CLEAN--
 <?php
@@ -29,3 +30,4 @@ array(4) {
   [3]=>
   string(1) "5"
 }
+NULL

--- a/ext/spl/tests/SplFileObject/SplFileObject_key_error001.phpt
+++ b/ext/spl/tests/SplFileObject/SplFileObject_key_error001.phpt
@@ -12,11 +12,11 @@ Erwin Poeze <erwin.poeze@gmail.com>
 //line 5
 $s = new SplFileObject(__FILE__);
 
-$s->seek(120);
+$s->seek(13);
 $s->next();
 var_dump($s->key());
 var_dump($s->valid());
 ?>
 --EXPECT--
-int(13)
+int(12)
 bool(false)

--- a/ext/spl/tests/SplFileObject/SplFileObject_key_error002.phpt
+++ b/ext/spl/tests/SplFileObject/SplFileObject_key_error002.phpt
@@ -12,11 +12,11 @@ Erwin Poeze <erwin.poeze@gmail.com>
 //line 5
 $s = new SplFileObject(__FILE__);
 
-$s->seek(13);
+$s->seek(120);
 $s->next();
 var_dump($s->key());
 var_dump($s->valid());
 ?>
 --EXPECT--
-int(14)
+int(12)
 bool(false)

--- a/ext/spl/tests/SplFileObject/fgetcsv_file_empty_lines.phpt
+++ b/ext/spl/tests/SplFileObject/fgetcsv_file_empty_lines.phpt
@@ -1,0 +1,38 @@
+--TEST--
+SplFileObject::fgetcsv with empty lines
+--FILE--
+<?php
+
+$file = new SplTempFileObject();
+
+$file->fwrite("foo,bar\n");
+$file->fwrite("\n");
+$file->fwrite("baz,qux");
+
+$file->rewind();
+
+
+var_dump($file->fgetcsv());
+var_dump($file->fgetcsv());
+var_dump($file->fgetcsv());
+var_dump($file->fgetcsv());
+
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+}
+array(1) {
+  [0]=>
+  NULL
+}
+array(2) {
+  [0]=>
+  string(3) "baz"
+  [1]=>
+  string(3) "qux"
+}
+NULL

--- a/ext/spl/tests/SplFileObject/foreach_file_empty_lines.phpt
+++ b/ext/spl/tests/SplFileObject/foreach_file_empty_lines.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Iterate over SplFileObject with empty lines with CSV flags
+--FILE--
+<?php
+
+$file = new SplTempFileObject();
+
+$file->fwrite("foo,bar\n");
+$file->fwrite("\n");
+$file->fwrite("baz,qux");
+
+$file->rewind();
+
+$file->setFlags(SplFileObject::READ_CSV | SplFileObject::READ_AHEAD | SplFileObject::SKIP_EMPTY /* | SplFileObject::DROP_NEW_LINE */);
+
+
+foreach ($file as $line) {
+    var_dump($line);
+}
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+}
+array(1) {
+  [0]=>
+  NULL
+}
+array(2) {
+  [0]=>
+  string(3) "baz"
+  [1]=>
+  string(3) "qux"
+}

--- a/ext/spl/tests/SplFileObject/gh8563.phpt
+++ b/ext/spl/tests/SplFileObject/gh8563.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Bug GH-8563: Different results for seek() on SplFileObject and SplTempFileObject
+--FILE--
+<?php
+
+const LINES = 5;
+const INDEX = 10;
+
+$file_01 = new SplFileObject(__DIR__ . '/gh8563.txt', 'w+');
+$file_02 = new SplTempFileObject(-1);
+$file_03 = new SplTempFileObject(0);
+$file_04 = new SplTempFileObject();
+
+// write to files
+for ($i = 0; $i < LINES; $i++) {
+    $file_01->fwrite("line {$i}" . PHP_EOL);
+    $file_02->fwrite("line {$i}" . PHP_EOL);
+    $file_03->fwrite("line {$i}" . PHP_EOL);
+    $file_04->fwrite("line {$i}" . PHP_EOL);
+}
+
+// reset
+$file_01->rewind();
+$file_02->rewind();
+$file_03->rewind();
+$file_04->rewind();
+
+// seek
+$file_01->seek(INDEX);
+$file_02->seek(INDEX);
+$file_03->seek(INDEX);
+$file_04->seek(INDEX);
+
+// show results
+echo 'file_01: ' . $file_01->key(), PHP_EOL;
+echo 'file_02: ' . $file_02->key(), PHP_EOL;
+echo 'file_03: ' . $file_03->key(), PHP_EOL;
+echo 'file_04: ' . $file_04->key(), PHP_EOL;
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/gh8563.txt');
+?>
+--EXPECT--
+file_01: 4
+file_02: 4
+file_03: 4
+file_04: 4

--- a/ext/spl/tests/bug81477.phpt
+++ b/ext/spl/tests/bug81477.phpt
@@ -21,7 +21,6 @@ string(8) "baz,bat
 "
 string(10) "more,data
 "
-string(0) ""
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/bug81477.csv');

--- a/ext/spl/tests/fileobject_001.phpt
+++ b/ext/spl/tests/fileobject_001.phpt
@@ -70,7 +70,7 @@ string(1) "4"
 int(5)
 string(1) "5"
 int(6)
-string(0) ""
+bool(false)
 ===B===
 int(0)
 string(1) "0"


### PR DESCRIPTION
With memory streams if we get a NULL buffer we must not instantiate an empty line.

Splitting this from #8644 as this one seems to be fixed properly