### PR TITLE
Implement mysqli_execute_query()

### DIFF
--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -209,6 +209,11 @@ class mysqli
     public function get_charset(): ?object {}
 
     /**
+     * @alias mysqli_execute_query
+     */
+    public function execute_query(string $query, ?array $params = null): mysqli_result|bool {}
+
+    /**
      * @tentative-return-type
      * @alias mysqli_get_client_info
      * @deprecated 8.1.0
@@ -792,6 +797,8 @@ function mysqli_stmt_execute(mysqli_stmt $statement, ?array $params = null): boo
 
 /** @alias mysqli_stmt_execute */
 function mysqli_execute(mysqli_stmt $statement, ?array $params = null): bool {}
+
+function mysqli_execute_query(mysqli $mysql, string $query, ?array $params = null): mysqli_result|bool {}
 
 /** @refcount 1 */
 function mysqli_fetch_field(mysqli_result $result): object|false {}

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -528,13 +528,11 @@ PHP_FUNCTION(mysqli_execute_query)
 		RETURN_FALSE;
 	}
 
-	/* The bit below, which is copied from mysqli_stmt_prepare, is needed for bad index exceptions */ 
+	/* The bit below, which is copied from mysqli_prepare, is needed for bad index exceptions */ 
 	/* don't initialize stmt->query with NULL, we ecalloc()-ed the memory */
 	/* Get performance boost if reporting is switched off */
 	if (query_len && (MyG(report_mode) & MYSQLI_REPORT_INDEX)) {
-		stmt->query = (char *)emalloc(query_len + 1);
-		memcpy(stmt->query, query, query_len);
-		stmt->query[query_len] = '\0';
+		stmt->query = estrdup(query);
 	}
 
 	// bind-in-execute
@@ -1330,9 +1328,7 @@ PHP_FUNCTION(mysqli_prepare)
 	/* don't initialize stmt->query with NULL, we ecalloc()-ed the memory */
 	/* Get performance boost if reporting is switched off */
 	if (stmt->stmt && query_len && (MyG(report_mode) & MYSQLI_REPORT_INDEX)) {
-		stmt->query = (char *)emalloc(query_len + 1);
-		memcpy(stmt->query, query, query_len);
-		stmt->query[query_len] = '\0';
+		stmt->query = estrdup(query);
 	}
 
 	/* don't join to the previous if because it won't work if mysql_stmt_prepare_fails */

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e528bb1e05a85d3d764272c5f3f4256d2608da6c */
+ * Stub hash: 2dae4302d825a7f5da3c4e00ce87aebc5502a8af */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -77,6 +77,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mysqli_stmt_execute, 0, 1, _IS_B
 ZEND_END_ARG_INFO()
 
 #define arginfo_mysqli_execute arginfo_mysqli_stmt_execute
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_mysqli_execute_query, 0, 2, mysqli_result, MAY_BE_BOOL)
+	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
+	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_fetch_field, 0, 1, MAY_BE_OBJECT|MAY_BE_FALSE)
 	ZEND_ARG_OBJ_INFO(0, result, mysqli_result, 0)
@@ -458,6 +464,11 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_mysqli_get_charset, 0, 0, IS_OBJECT, 1)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_mysqli_execute_query, 0, 1, mysqli_result, MAY_BE_BOOL)
+	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_mysqli_get_client_info arginfo_class_mysqli_character_set_name
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_mysqli_get_connection_stats, 0, 0, IS_ARRAY, 0)
@@ -713,6 +724,7 @@ ZEND_FUNCTION(mysqli_errno);
 ZEND_FUNCTION(mysqli_error);
 ZEND_FUNCTION(mysqli_error_list);
 ZEND_FUNCTION(mysqli_stmt_execute);
+ZEND_FUNCTION(mysqli_execute_query);
 ZEND_FUNCTION(mysqli_fetch_field);
 ZEND_FUNCTION(mysqli_fetch_fields);
 ZEND_FUNCTION(mysqli_fetch_field_direct);
@@ -827,6 +839,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mysqli_error_list, arginfo_mysqli_error_list)
 	ZEND_FE(mysqli_stmt_execute, arginfo_mysqli_stmt_execute)
 	ZEND_FALIAS(mysqli_execute, mysqli_stmt_execute, arginfo_mysqli_execute)
+	ZEND_FE(mysqli_execute_query, arginfo_mysqli_execute_query)
 	ZEND_FE(mysqli_fetch_field, arginfo_mysqli_fetch_field)
 	ZEND_FE(mysqli_fetch_fields, arginfo_mysqli_fetch_fields)
 	ZEND_FE(mysqli_fetch_field_direct, arginfo_mysqli_fetch_field_direct)
@@ -935,6 +948,7 @@ static const zend_function_entry class_mysqli_methods[] = {
 	ZEND_ME_MAPPING(dump_debug_info, mysqli_dump_debug_info, arginfo_class_mysqli_dump_debug_info, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(debug, mysqli_debug, arginfo_class_mysqli_debug, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(get_charset, mysqli_get_charset, arginfo_class_mysqli_get_charset, ZEND_ACC_PUBLIC)
+	ZEND_ME_MAPPING(execute_query, mysqli_execute_query, arginfo_class_mysqli_execute_query, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(get_client_info, mysqli_get_client_info, arginfo_class_mysqli_get_client_info, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 	ZEND_ME_MAPPING(get_connection_stats, mysqli_get_connection_stats, arginfo_class_mysqli_get_connection_stats, ZEND_ACC_PUBLIC)
 	ZEND_ME_MAPPING(get_server_info, mysqli_get_server_info, arginfo_class_mysqli_get_server_info, ZEND_ACC_PUBLIC)

--- a/ext/mysqli/tests/mysqli_class_mysqli_interface.phpt
+++ b/ext/mysqli/tests/mysqli_class_mysqli_interface.phpt
@@ -29,6 +29,7 @@ require_once('skipifconnectfailure.inc');
         'connect'				=> true,
         'dump_debug_info'		=> true,
         'escape_string'			=> true,
+        'execute_query'			=> true,
         'get_charset'			=> true,
         'get_client_info'		=> true,
         'get_server_info'		=> true,

--- a/ext/mysqli/tests/mysqli_execute_query.phpt
+++ b/ext/mysqli/tests/mysqli_execute_query.phpt
@@ -1,0 +1,97 @@
+--TEST--
+mysqli_execute_query()
+--EXTENSIONS--
+mysqli
+--SKIPIF--
+<?php
+require_once 'skipifconnectfailure.inc';
+?>
+--FILE--
+<?php
+
+require 'table.inc';
+
+if (!($tmp = mysqli_execute_query($link, "SELECT id, label FROM test ORDER BY id"))) {
+    printf("[001] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+}
+
+if (!is_a($tmp, mysqli_result::class)) {
+    printf("[002] Expecting mysqli_result, got %s/%s\n", gettype($tmp), $tmp);
+}
+
+unset($tmp);
+
+// procedural
+if (!($tmp = mysqli_execute_query($link, "SELECT ? AS a, ? AS b, ? AS c", [42, "foo", null]))) {
+    printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+}
+
+assert($tmp->fetch_assoc() === ['a' => '42', 'b' => 'foo', 'c' => null]);
+
+// OO style
+if (!($tmp = $link->execute_query("SELECT ? AS a, ? AS b, ? AS c", [42, "foo", null]))) {
+    printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+}
+
+assert($tmp->fetch_assoc() === ['a' => '42', 'b' => 'foo', 'c' => null]);
+
+// prepare error
+if (!($tmp = $link->execute_query("some random gibberish", [1, "foo"]))) {
+    printf("[005] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+}
+
+// stmt error - duplicate key
+if (!$link->execute_query("INSERT INTO test(id, label) VALUES (?, ?)", [1, "foo"])) {
+    printf("[006] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+}
+
+// successful update returns true
+if (!($tmp = $link->execute_query("UPDATE test SET label=? WHERE id=?", ["baz", 1]))) {
+    printf("[007] Expecting true, got %s/%s\n", gettype($tmp), $tmp);
+}
+if ($link->affected_rows <= 0) {
+    printf("[008] Expecting positive non-zero integer for affected_rows, got %s/%s\n", gettype($link->affected_rows), $link->affected_rows);
+}
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+// check if value error is properly reported
+try {
+    $link->execute_query('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?', ['foo', 42]);
+} catch (ValueError $e) {
+    echo '[009] '.$e->getMessage()."\n";
+}
+try {
+    $link->execute_query('SELECT label, ? AS anon, ? AS num FROM test WHERE id=?', ['foo' => 42]);
+} catch (ValueError $e) {
+    echo '[010] '.$e->getMessage()."\n";
+}
+
+// check if insert_id is copied
+$link->execute_query("ALTER TABLE test MODIFY id INT NOT NULL AUTO_INCREMENT");
+$link->execute_query("INSERT INTO test(label) VALUES (?)", ["foo"]);
+if ($link->insert_id <= 0) {
+    printf("[011] Expecting positive non-zero integer for insert_id, got %s/%s\n", gettype($link->insert_id), $link->insert_id);
+}
+
+// bad index
+mysqli_report(MYSQLI_REPORT_ALL);
+try {
+    $link->execute_query("SELECT id FROM test WHERE label = ?", ["foo"]);
+} catch (mysqli_sql_exception $e) {
+    echo '[012] '.$e->getMessage()."\n";
+}
+
+print "done!";
+?>
+--CLEAN--
+<?php
+require_once "clean_table.inc";
+?>
+--EXPECTF--
+[005] [1064] You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'some random gibberish' at line 1
+[006] [1062] Duplicate entry '1' for key '%s'
+[009] mysqli::execute_query(): Argument #2 ($params) must consist of exactly 3 elements, 2 present
+[010] mysqli::execute_query(): Argument #2 ($params) must be a list array
+[012] No index used in query/prepared statement SELECT id FROM test WHERE label = ?
+done!


### PR DESCRIPTION
This is the implementation for RFC https://wiki.php.net/rfc/mysqli_execute_query

Key notes:
- While the code was copied from prepare, execute, and get_result, there were some adjustments and it's not identical.
- It returns `true` on success when no result is present. It resembles more `mysqli_query` than `get_result`. 
- The authors of the RFC decided that it was a bug that `affected_rows` was reset to -1. The value is now preserved in the `$mysql` object. 
- Regarding performance: a quick artificial benchmark showed 6% decrease in execution time when compared to calling all 3 methods separately. 
- As the mysqli_stmt object is never exposed, special attention was put to error handling and ensuring the memory is freed when necessary. The error messages are preserved on the `$mysql` object for when automatic error reporting is switched off. 