### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# The following volunteers have self-identified as subject matter experts
+# or interested parties over a particular area of the php-src source code.
+# While requesting a review from someone does not obligate that person to
+# review a pull request, these reviewers might have valuable knowledge of
+# the problem area and could aid in deciding whether a pull request is ready
+# for merging.
+#
+# For more information, see the GitHub CODEOWNERS documentation:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+/ext/date/                  @derickr
+/ext/oci8/                  @cjbj
+/ext/pdo_oci/               @cjbj


### PR DESCRIPTION
I'm using this pull request as a point of discussion and to get feedback from the internals community.

As release managers go through open PRs, tagging them with "Waiting on Review," it would be helpful to know from whom we should request reviews, based on the area of the code. One way is to set up a table on the wiki with this information. Another way is to use a [GitHub CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file, which takes care of requesting the reviews automatically.

I don't know how feasible it is to maintain a list like this for the PHP project. Ideally, folks would add themselves to the list and self-identify which areas of the code base they want to have automatically request them for reviews.