### PR TITLE
GH-8674: sockets extension build fix for older Linux kernels.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -395,6 +395,7 @@ fcntl.h \
 grp.h \
 ieeefp.h \
 langinfo.h \
+linux/sock_diag.h \
 malloc.h \
 poll.h \
 pty.h \

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -55,8 +55,10 @@
 # if HAVE_IF_NAMETOINDEX
 #  include <net/if.h>
 # endif
-# ifdef SO_MEMINFO
+# if defined(HAVE_LINUX_SOCK_DIAG_H)
 #  include <linux/sock_diag.h>
+# else
+#  undef SO_MEMINFO
 # endif
 #endif
 


### PR DESCRIPTION
in abscence of the needed header, disable the feature altogether.