### PR TITLE
mbstring requires pcre

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -161,9 +161,18 @@ static const php_mb_nls_ident_list php_mb_default_identify_list[] = {
 
 /* }}} */
 
+/* {{{ mbstring_deps[] */
+static const zend_module_dep mbstring_deps[] = {
+	ZEND_MOD_REQUIRED("pcre")
+	ZEND_MOD_END
+};
+/* }}} */
+
 /* {{{ zend_module_entry mbstring_module_entry */
 zend_module_entry mbstring_module_entry = {
-	STANDARD_MODULE_HEADER,
+	STANDARD_MODULE_HEADER_EX,
+	NULL,
+	mbstring_deps,
 	"mbstring",
 	ext_functions,
 	PHP_MINIT(mbstring),


### PR DESCRIPTION
Fixing #8685 
Adding this dependency ensure MINIT of pcre is run before MINIT of mbstring

mbstring calls OnUpdate_mbstring_http_output_conv_mimetypes => _php_mb_compile_regex => php_pcre_cctx