### PR TITLE
Deprecate passing object without __set_state to var_export

### DIFF
--- a/Zend/tests/bug73350.phpt
+++ b/Zend/tests/bug73350.phpt
@@ -12,6 +12,7 @@ $e = new Exception();
 var_export($e);
 ?>
 --EXPECTF--
+Deprecated: Passing object of class (Exception) with no __set_state method is deprecated in %s on line %d
 \Exception::__set_state(array(
    'message' => '',
    'string' => 'Exception in %sbug73350.php:%d

--- a/Zend/tests/deprecate_var_export_on_non_set_state.phpt
+++ b/Zend/tests/deprecate_var_export_on_non_set_state.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Passing an object of a class with no __set_state method to var_export emits a deprecation
+--FILE--
+<?php
+
+class Foo {
+    public static function __set_state(array $values) {}
+}
+
+class Bar {}
+
+var_export(new Foo());
+var_export(new Bar());
+var_export([new Bar()]);
+
+?>
+--EXPECTF--
+\Foo::__set_state(array(
+))
+Deprecated: Passing object of class (Bar) with no __set_state method is deprecated in %s on line %d
+\Bar::__set_state(array(
+))
+Deprecated: Passing object of class (Bar) with no __set_state method is deprecated in %s on line %d
+array (
+  0 => 
+  \Bar::__set_state(array(
+  )),
+)

--- a/Zend/tests/function_arguments/sensitive_parameter_value.phpt
+++ b/Zend/tests/function_arguments/sensitive_parameter_value.phpt
@@ -33,6 +33,8 @@ object(SensitiveParameterValue)#%d (%d) refcount(%d){
 SensitiveParameterValue Object
 
 # var_export()
+
+Deprecated: Passing object of class (SensitiveParameterValue) with no __set_state method is deprecated in %s on line %d
 \SensitiveParameterValue::__set_state(array(
 ))
 

--- a/ext/spl/tests/bug65967.phpt
+++ b/ext/spl/tests/bug65967.phpt
@@ -9,6 +9,7 @@ gc_collect_cycles();
 
 var_export($objstore);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Passing object of class (SplObjectStorage) with no __set_state method is deprecated in %s on line %d
 \SplObjectStorage::__set_state(array(
 ))

--- a/ext/spl/tests/fixedarray_022.phpt
+++ b/ext/spl/tests/fixedarray_022.phpt
@@ -10,6 +10,8 @@ call_user_func(function () {
 });
 ?>
 --EXPECTF--
+Deprecated: Passing object of class (SplFixedArray) with no __set_state method is deprecated in %s on line %d
+
 Warning: var_export does not handle circular references in %s on line 5
 \SplFixedArray::__set_state(array(
    0 => NULL,

--- a/ext/spl/tests/fixedarray_023.phpt
+++ b/ext/spl/tests/fixedarray_023.phpt
@@ -15,6 +15,8 @@ call_user_func(function () {
 });
 ?>
 --EXPECTF--
+Deprecated: Passing object of class (SplFixedArray) with no __set_state method is deprecated in %s on line %d
+
 Warning: var_export does not handle circular references in %s on line 8
 
 Warning: var_export does not handle circular references in %s on line 8

--- a/ext/standard/tests/array/007.phpt
+++ b/ext/standard/tests/array/007.phpt
@@ -61,6 +61,7 @@ class cr {
         if ($a->priv_member === $b->priv_member) return 0;
         return ($a->priv_member > $b->priv_member)? 1:-1;
     }
+    public static function __set_state(array $values) {}
 }
 
 function comp_func($a, $b) {

--- a/ext/standard/tests/array/array_intersect_1.phpt
+++ b/ext/standard/tests/array/array_intersect_1.phpt
@@ -14,6 +14,7 @@ class cr {
         if ($a->priv_member === $b->priv_member) return 0;
         return ($a->priv_member > $b->priv_member)? 1:-1;
     }
+    public static function __set_state(array $values) {}
 }
 
 function comp_func($a, $b) {

--- a/ext/standard/tests/array/var_export3.phpt
+++ b/ext/standard/tests/array/var_export3.phpt
@@ -17,7 +17,8 @@ $kake = new kake;
 
 var_export($kake);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Passing object of class (kake) with no __set_state method is deprecated in %s on line %d
 \kake::__set_state(array(
    'mann' => 42,
    'kvinne' => 43,

--- a/ext/standard/tests/general_functions/bug47027.phpt
+++ b/ext/standard/tests/general_functions/bug47027.phpt
@@ -5,7 +5,8 @@ Bug #47027 (var_export doesn't show numeric indices on ArrayObject)
 $ao = new ArrayObject(array (2 => "foo", "bar" => "baz"));
 var_export ($ao);
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Passing object of class (ArrayObject) with no __set_state method is deprecated in %s on line %d
 \ArrayObject::__set_state(array(
    2 => 'foo',
    'bar' => 'baz',

--- a/ext/standard/tests/general_functions/var_export-locale.phpt
+++ b/ext/standard/tests/general_functions/var_export-locale.phpt
@@ -183,7 +183,7 @@ echo "*** Testing var_export() with valid objects ***\n";
 // class with no members
 class foo
 {
-// no members
+  public static function __set_state(array $values) {}
 }
 
 // abstract class
@@ -193,6 +193,8 @@ abstract class abstractClass
   public function printClassName () {
     echo $this->getClassName() . "\n";
   }
+
+  public static function __set_state(array $values) {}
 }
 // implement abstract class
 class concreteClass extends abstractClass
@@ -220,6 +222,8 @@ class Value implements iValue
   public function dumpVal () {
     var_export ( $vars );
   }
+
+  public static function __set_state(array $values) {}
 }
 
 // a gereral class
@@ -238,6 +242,8 @@ class myClass
     $this->private_var = new foo();
     $this->protected_var = new foo();
   }
+
+  public static function __set_state(array $values) {}
 }
 
 // create a object of each class defined above

--- a/ext/standard/tests/general_functions/var_export_basic6.phpt
+++ b/ext/standard/tests/general_functions/var_export_basic6.phpt
@@ -7,7 +7,7 @@ echo "*** Testing var_export() with valid objects ***\n";
 // class with no members
 class foo
 {
-// no members
+  public static function __set_state(array $values) {}
 }
 
 // abstract class
@@ -17,6 +17,8 @@ abstract class abstractClass
   public function printClassName () {
     echo $this->getClassName() . "\n";
   }
+
+  public static function __set_state(array $values) {}
 }
 // implement abstract class
 class concreteClass extends abstractClass
@@ -44,6 +46,8 @@ class Value implements iValue
   public function dumpVal () {
     var_export ( $vars );
   }
+
+  public static function __set_state(array $values) {}
 }
 
 // a gereral class
@@ -62,6 +66,8 @@ class myClass
     $this->private_var = new foo();
     $this->protected_var = new foo();
   }
+
+  public static function __set_state(array $values) {}
 }
 
 // create a object of each class defined above

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -583,6 +583,9 @@ again:
 					smart_str_appendl(buf, "::", 2);
 					smart_str_append(buf, Z_STR_P(case_name_zval));
 				} else {
+					if (!zend_hash_str_find_ptr(&ce->function_table, "__set_state", strlen("__set_state"))) {
+						zend_error(E_DEPRECATED, "Passing object of class (%s) with no __set_state method is deprecated", ZSTR_VAL(ce->name));
+					}
 					smart_str_appendl(buf, "::__set_state(array(\n", 21);
 				}
 			}


### PR DESCRIPTION
It would make sense in `var_export` to signal to the user that the generated code will fail due to `__set_state` missing before actually executing the generated code. This probably needs an RFC.