### PR TITLE
Implement new closing tag =?> for keeping trailing newline

### DIFF
--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -2441,7 +2441,7 @@ inline_char_handler:
 	RETURN_OR_SKIP_TOKEN(T_COMMENT);
 }
 
-<ST_IN_SCRIPTING>"?>"{NEWLINE}? {
+<ST_IN_SCRIPTING>"=?>"|("?>"{NEWLINE}?) {
 	BEGIN(INITIAL);
 	if (yytext[yyleng-1] != '>') {
 		CG(increment_lineno) = 1;

--- a/tests/lang/closing_tag_001.phpt
+++ b/tests/lang/closing_tag_001.phpt
@@ -1,0 +1,6 @@
+--TEST--
+Closing tag without trailing newline
+--FILE--
+<?= 'Closing tag' ?> without trailing newline
+--EXPECT--
+Closing tag without trailing newline

--- a/tests/lang/closing_tag_002.phpt
+++ b/tests/lang/closing_tag_002.phpt
@@ -1,0 +1,7 @@
+--TEST--
+Closing tag with trailing newline
+--FILE--
+<?= 'Closing tag' ?>
+ with trailing newline
+--EXPECT--
+Closing tag with trailing newline

--- a/tests/lang/closing_tag_003.phpt
+++ b/tests/lang/closing_tag_003.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Closing tag with keeping trailing newline
+--FILE--
+<?= 'Closing tag' =?>
+ with keeping trailing newline
+--EXPECT--
+Closing tag
+ with keeping trailing newline


### PR DESCRIPTION
# Introduction
PHP currently automatically removes the newline character immediately following the closing tag  `"?>"`.

A more correct description of this would be that PHP's closing tag is `"?>"` with an optional trailing newline character.

For example, see the code below.

```php
- <?= 1 ?>
- <?= 2 ?>
- <?= 3 ?>
```

The newline characters are all eaten by their preceding closing tags, so the output would be like this.

```
- 1- 2- 3
```

This behavior was adopted around the time of PHP3 because it was convenient at several points when using PHP for templating HTML.

However, it has long been known that this behavior can be inconvenient in some cases, such as when PHP is used for templating plain texts, where the newline character should appear exactly as it does in the template.

In the current behavior, adding an explicit newline character is a workaround for this.

```
- <?= 1 . "\n" ?>
- <?= 2 . "\n" ?>
- <?= 3 . "\n" ?>
```

This way, when the output block is moved to a location other than the end of a line by editing the template later, the extra newline character must be removed each time.

# Proposal
Add  `"=?>"` as a new PHP closing tag with no optional trailing newline character. It behaves exactly the same as the existing closing tag, except that it does not erase the trailing newline character. This allows developers to choose to leave newline characters in the template as they appear, and make the behavior of output blocks position-independent.

So the next code

```php
- <?= 1 =?>
- <?= 2 =?>
- <?= 3 =?>
```

results like this.

```php
- 1
- 2
- 3
```

Of course, it can also be used in conjunction with non-shortened opening tags.

```php
- <?php echo 1 =?>
- <?php echo 2 =?>
- <?php echo 3 =?>
```

Note that in some cases it may be more appropriate to use an existing closing tag. When control statements are used in a template, it is probably preferable in many cases to start the control statement at the beginning of the line and terminate it with an existing closing tag, thus erasing the line containing the control statement completely from the output. The output of the following code is the same as the above examples.

```php
<?php foreach([1, 2, 3] as $item): ?>
- <?= $item =?>
<?php endforeach ?>
```

This addition to the language requires only a one-line modification to the lexer and does not break backward compatibility.

I understand that some people believe that advanced templating should be attempted in userland, as there are no restrictions on release cycles, so faster development iterations can be done. However, I think the benefits of this small modification would be large enough, so this time I would like to propose a language-side modification. All projects that use bare PHP for their templates for whatever reason could benefit from this addition.

This change requires an RFC. I will request the wiki karma later in the internals ML if the reaction from the community is not bad.

# References
- https://externals.io/message/100428
	- Previous discussion about this behavior of the existing closing tag.
- https://marc.info/?w=2&r=1&s=linefeeds%2C+difference&q=t
	- An old discussion on this behavior in the era of PHP3.