### PR TITLE
Mark `*_arginfo.h` as `linguist-generated`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,6 @@
 *.phpt diff=php
 *.php diff=php
 *.[ch] diff=cpp
+
+# Collapse the generated arginfo.h files within a pull request.
+**/*_arginfo.h linguist-generated


### PR DESCRIPTION
The generated `*_arginfo.h` usually cannot be usefully reviewed within a PR.
Collapse them by default by adding the `linguist-generated` attribute to reduce
the visual noise.

see https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
see https://github.com/github/linguist/blob/master/docs/overrides.md#summary