### PR TITLE
Add deprecation notices to utf8_encode and utf8_decode

### DIFF
--- a/ext/soap/tests/interop/Round2/Base/r2_base_005p.phpt
+++ b/ext/soap/tests/interop/Round2/Base/r2_base_005p.phpt
@@ -5,7 +5,7 @@ soap
 --FILE--
 <?php
 $client = new SoapClient(NULL,array("location"=>"test://","uri"=>"http://soapinterop.org/","trace"=>1,"exceptions"=>0));
-$client->__soapCall("echoString", array(utf8_encode('ỗÈéóÒ₧⅜ỗỸ')), array("soapaction"=>"http://soapinterop.org/","uri"=>"http://soapinterop.org/"));
+$client->__soapCall("echoString", array('ỗÈéóÒ₧⅜ỗỸ'), array("soapaction"=>"http://soapinterop.org/","uri"=>"http://soapinterop.org/"));
 echo $client->__getlastrequest();
 $HTTP_RAW_POST_DATA = $client->__getlastrequest();
 include("round2_base.inc");
@@ -13,7 +13,7 @@ echo "ok\n";
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoString><param0 xsi:type="xsd:string">á»ÃÃ©Ã³Ãâ§âá»á»¸</param0></ns1:echoString></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoString><param0 xsi:type="xsd:string">ỗÈéóÒ₧⅜ỗỸ</param0></ns1:echoString></SOAP-ENV:Body></SOAP-ENV:Envelope>
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoStringResponse><outputString xsi:type="xsd:string">á»ÃÃ©Ã³Ãâ§âá»á»¸</outputString></ns1:echoStringResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoStringResponse><outputString xsi:type="xsd:string">ỗÈéóÒ₧⅜ỗỸ</outputString></ns1:echoStringResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
 ok

--- a/ext/soap/tests/interop/Round2/Base/r2_base_005s.phpt
+++ b/ext/soap/tests/interop/Round2/Base/r2_base_005s.phpt
@@ -5,7 +5,7 @@ soap
 --FILE--
 <?php
 $client = new SoapClient(NULL,array("location"=>"test://","uri"=>"http://soapinterop.org/","trace"=>1,"exceptions"=>0));
-$client->__soapCall("echoString", array(new SoapParam(new SoapVar(utf8_encode('ỗÈéóÒ₧⅜ỗỸ'),XSD_STRING),"inputString")), array("soapaction"=>"http://soapinterop.org/","uri"=>"http://soapinterop.org/"));
+$client->__soapCall("echoString", array(new SoapParam(new SoapVar('ỗÈéóÒ₧⅜ỗỸ',XSD_STRING),"inputString")), array("soapaction"=>"http://soapinterop.org/","uri"=>"http://soapinterop.org/"));
 echo $client->__getlastrequest();
 $HTTP_RAW_POST_DATA = $client->__getlastrequest();
 include("round2_base.inc");
@@ -13,7 +13,7 @@ echo "ok\n";
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoString><inputString xsi:type="xsd:string">á»ÃÃ©Ã³Ãâ§âá»á»¸</inputString></ns1:echoString></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoString><inputString xsi:type="xsd:string">ỗÈéóÒ₧⅜ỗỸ</inputString></ns1:echoString></SOAP-ENV:Body></SOAP-ENV:Envelope>
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoStringResponse><outputString xsi:type="xsd:string">á»ÃÃ©Ã³Ãâ§âá»á»¸</outputString></ns1:echoStringResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoStringResponse><outputString xsi:type="xsd:string">ỗÈéóÒ₧⅜ỗỸ</outputString></ns1:echoStringResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
 ok

--- a/ext/soap/tests/interop/Round2/Base/r2_base_005w.phpt
+++ b/ext/soap/tests/interop/Round2/Base/r2_base_005w.phpt
@@ -7,7 +7,7 @@ soap.wsdl_cache_enabled=0
 --FILE--
 <?php
 $client = new SoapClient(__DIR__."/round2_base.wsdl",array("trace"=>1,"exceptions"=>0));
-$client->echoString(utf8_encode('ỗÈéóÒ₧⅜ỗỸ'));
+$client->echoString('ỗÈéóÒ₧⅜ỗỸ');
 echo $client->__getlastrequest();
 $HTTP_RAW_POST_DATA = $client->__getlastrequest();
 include("round2_base.inc");
@@ -15,7 +15,7 @@ echo "ok\n";
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoString><inputString xsi:type="xsd:string">á»ÃÃ©Ã³Ãâ§âá»á»¸</inputString></ns1:echoString></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoString><inputString xsi:type="xsd:string">ỗÈéóÒ₧⅜ỗỸ</inputString></ns1:echoString></SOAP-ENV:Body></SOAP-ENV:Envelope>
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoStringResponse><outputString xsi:type="xsd:string">á»ÃÃ©Ã³Ãâ§âá»á»¸</outputString></ns1:echoStringResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://soapinterop.org/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:echoStringResponse><outputString xsi:type="xsd:string">ỗÈéóÒ₧⅜ỗỸ</outputString></ns1:echoStringResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>
 ok

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1021,10 +1021,16 @@ function strpbrk(string $string, string $characters): string|false {}
 
 function substr_compare(string $haystack, string $needle, int $offset, ?int $length = null, bool $case_insensitive = false): int {}
 
-/** @refcount 1 */
+/**
+ * @refcount 1
+ * @deprecated
+ */
 function utf8_encode(string $string): string {}
 
-/** @refcount 1 */
+/**
+ * @refcount 1
+ * @deprecated
+ */
 function utf8_decode(string $string): string {}
 
 /* dir.c */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0be859a950e082bb02f747630068ea658c6673dd */
+ * Stub hash: f35440fd9902dd0201fbaa9005bc51c5aecadf2c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -3164,8 +3164,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE(str_split, arginfo_str_split)
 	ZEND_FE(strpbrk, arginfo_strpbrk)
 	ZEND_FE(substr_compare, arginfo_substr_compare)
-	ZEND_FE(utf8_encode, arginfo_utf8_encode)
-	ZEND_FE(utf8_decode, arginfo_utf8_decode)
+	ZEND_DEP_FE(utf8_encode, arginfo_utf8_encode)
+	ZEND_DEP_FE(utf8_decode, arginfo_utf8_decode)
 	ZEND_FE(opendir, arginfo_opendir)
 	ZEND_FE(dir, arginfo_dir)
 	ZEND_FE(closedir, arginfo_closedir)

--- a/ext/standard/tests/strings/bug20934.phpt
+++ b/ext/standard/tests/strings/bug20934.phpt
@@ -2,10 +2,10 @@
 Bug #20934 (htmlspecialchars returns latin1 from UTF-8)
 --FILE--
 <?php
-$str = utf8_encode("\xe0\xe1");
-var_dump(utf8_decode($str));
-var_dump(utf8_decode(htmlspecialchars($str, ENT_COMPAT, "UTF-8")));
+$str = "\xc3\xa0\xc3\xa1";
+echo bin2hex($str), "\n";
+echo bin2hex(htmlspecialchars($str, ENT_COMPAT, "UTF-8")), "\n";
 ?>
---EXPECT--
-string(2) "аб"
-string(2) "аб"
+--EXPECTF--
+c3a0c3a1
+c3a0c3a1

--- a/ext/standard/tests/strings/bug43957.phpt
+++ b/ext/standard/tests/strings/bug43957.phpt
@@ -4,5 +4,6 @@ Bug #43957 (utf8_decode() bogus conversion on multibyte indicator near end of st
 <?php
   echo utf8_decode('abc'.chr(0xe0));
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function utf8_decode() is deprecated in %s on line %d
 abc?

--- a/ext/standard/tests/strings/bug49687.phpt
+++ b/ext/standard/tests/strings/bug49687.phpt
@@ -13,8 +13,13 @@ foreach ($tests as $t) {
 }
 echo "Done.\n";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function utf8_decode() is deprecated in %s on line %d
 413f3e42
+
+Deprecated: Function utf8_decode() is deprecated in %s on line %d
 3f22
+
+Deprecated: Function utf8_decode() is deprecated in %s on line %d
 413f3f423f433f3f
 Done.

--- a/ext/standard/tests/strings/utf8.phpt
+++ b/ext/standard/tests/strings/utf8.phpt
@@ -5,6 +5,9 @@ UTF-8<->ISO Latin 1 encoding/decoding test
 printf("%s -> %s\n", urlencode("æ"), urlencode(utf8_encode("æ")));
 printf("%s <- %s\n", urlencode(utf8_decode(urldecode("%C3%A6"))), "%C3%A6");
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function utf8_encode() is deprecated in %s on line %d
 %E6 -> %C3%A6
+
+Deprecated: Function utf8_decode() is deprecated in %s on line %d
 %E6 <- %C3%A6


### PR DESCRIPTION
Implements initial stage of accepted RFC to remove them:
https://wiki.php.net/rfc/remove_utf8_decode_and_utf8_encode