### PR TITLE
Fix bug #80602 #81642 GH-9142

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -20,6 +20,7 @@
 #endif
 
 #include "php.h"
+
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
 #include "php_dom.h"
 
@@ -74,14 +75,14 @@ PHP_METHOD(DOMElement, __construct)
 			RETURN_THROWS();
 		}
 	} else {
-	    /* If you don't pass a namespace uri, then you can't set a prefix */
-	    localname = (char *) xmlSplitQName2((xmlChar *) name, (xmlChar **) &prefix);
-	    if (prefix != NULL) {
+		/* If you don't pass a namespace uri, then you can't set a prefix */
+		localname = (char *) xmlSplitQName2((xmlChar *) name, (xmlChar **) &prefix);
+		if (prefix != NULL) {
 			xmlFree(localname);
 			xmlFree(prefix);
-	        php_dom_throw_error(NAMESPACE_ERR, 1);
-	        RETURN_THROWS();
-	    }
+			php_dom_throw_error(NAMESPACE_ERR, 1);
+			RETURN_THROWS();
+		}
 		nodep = xmlNewNode(NULL, (xmlChar *) name);
 	}
 
@@ -152,8 +153,8 @@ int dom_element_schema_type_info_read(dom_object *obj, zval *retval)
 
 static xmlNodePtr dom_get_dom1_attribute(xmlNodePtr elem, xmlChar *name) /* {{{ */
 {
-    int len;
-    const xmlChar *nqname;
+	int len;
+	const xmlChar *nqname;
 
 	nqname = xmlSplitQName3(name, &len);
 	if (nqname != NULL) {
@@ -570,9 +571,9 @@ PHP_METHOD(DOMElement, getAttributeNS)
 
 static xmlNsPtr _dom_new_reconNs(xmlDocPtr doc, xmlNodePtr tree, xmlNsPtr ns) /* {{{ */
 {
-    xmlNsPtr def;
-    xmlChar prefix[50];
-    int counter = 1;
+	xmlNsPtr def;
+	xmlChar prefix[50];
+	int counter = 1;
 
 	if ((tree == NULL) || (ns == NULL) || (ns->type != XML_NAMESPACE_DECL)) {
 		return NULL;
@@ -883,12 +884,12 @@ PHP_METHOD(DOMElement, setAttributeNodeNS)
 		RETURN_FALSE;
 	}
 
-    nsp = attrp->ns;
-    if (nsp != NULL) {
-        existattrp = xmlHasNsProp(nodep, nsp->href, attrp->name);
-    } else {
-        existattrp = xmlHasProp(nodep, attrp->name);
-    }
+	nsp = attrp->ns;
+	if (nsp != NULL) {
+		existattrp = xmlHasNsProp(nodep, nsp->href, attrp->name);
+	} else {
+		existattrp = xmlHasProp(nodep, attrp->name);
+	}
 
 	if (existattrp != NULL && existattrp->type != XML_ATTRIBUTE_DECL) {
 		if ((oldobj = php_dom_object_get_data((xmlNodePtr) existattrp)) != NULL &&
@@ -1252,7 +1253,9 @@ PHP_METHOD(DOMElement, replaceWith)
 	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
 
 	dom_parent_node_after(intern, args, argc);
-	dom_child_node_remove(intern);
+	if (!dom_node_is_argument (intern, args, argc)) {
+		dom_child_node_remove(intern);
+	}
 }
 /* }}} end DOMElement::prepend */
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1253,7 +1253,7 @@ PHP_METHOD(DOMElement, replaceWith)
 	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
 
 	dom_parent_node_after(intern, args, argc);
-	if (!dom_node_is_argument (intern, args, argc)) {
+	if (!dom_node_is_argument(intern, args, argc)) {
 		dom_child_node_remove(intern);
 	}
 }

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -407,6 +407,29 @@ void dom_parent_node_before(dom_object *context, zval *nodes, int nodesc)
 	xmlFree(fragment);
 }
 
+bool dom_node_is_argument(dom_object *context, zval *nodes, int nodesc)
+{
+	int i;
+	xmlNode *newNode;
+	zend_class_entry *ce;
+	dom_object *newNodeObj;
+	xmlNode *child = dom_object_get_node(context);
+
+	for (i = 0; i < nodesc; i++) {
+		if (Z_TYPE(nodes[i]) == IS_OBJECT) {
+			ce = Z_OBJCE(nodes[i]);
+			if (instanceof_function(ce, dom_node_class_entry)) {
+				newNodeObj = Z_DOMOBJ_P(&nodes[i]);
+				newNode = dom_object_get_node(newNodeObj);
+				if (child == newNode) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
 void dom_child_node_remove(dom_object *context)
 {
 	xmlNode *child = dom_object_get_node(context);

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -181,6 +181,10 @@ xmlNode* dom_zvals_to_fragment(php_libxml_ref_obj *document, xmlNode *contextNod
 					return NULL;
 				}
 
+				if (nodesc > 1) {
+					newNode = xmlCopyNode(newNode, 1);
+				}
+
 				if (!xmlAddChild(fragment, newNode)) {
 					xmlFree(fragment);
 

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -341,12 +341,15 @@ void dom_parent_node_after(dom_object *context, zval *nodes, int nodesc)
 
 		if (prevsib) {
 			fragment->last->next = prevsib->next;
+			if (prevsib->next) {
+				prevsib->next->prev = fragment->last;
+			}
 			prevsib->next = newchild;
 		} else {
 			parentNode->children = newchild;
 			if (nextsib) {
-				newchild->next = nextsib;
-				nextsib->prev = newchild;
+				fragment->last->next = nextsib;
+				nextsib->prev = fragment->last;
 			}
 		}
 

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -130,6 +130,7 @@ void dom_parent_node_prepend(dom_object *context, zval *nodes, int nodesc);
 void dom_parent_node_append(dom_object *context, zval *nodes, int nodesc);
 void dom_parent_node_after(dom_object *context, zval *nodes, int nodesc);
 void dom_parent_node_before(dom_object *context, zval *nodes, int nodesc);
+bool dom_node_is_argument(dom_object *context, zval *nodes, int nodesc);
 void dom_child_node_remove(dom_object *context);
 
 #define REGISTER_DOM_CLASS(ce, name, parent_ce, funcs, entry) \

--- a/ext/dom/tests/bug80602.phpt
+++ b/ext/dom/tests/bug80602.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Bug #80602 (Segfault when using DOMChildNode::before())
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before('bar', 'baz', 'cat');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($doc->documentElement->firstChild, 'baz', 'cat');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before('bar', $doc->documentElement->firstChild, 'baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+// if `$doc->documentElement->firstChild` is the last parameter, it will cause segment fault.
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before('bar', $doc->documentElement->firstChild, 'baz', $doc->documentElement->firstChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($doc->documentElement->firstChild, $doc->documentElement->firstChild, $doc->documentElement->firstChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+?>
+--EXPECTF--
+<a>foobarbazcat<last/></a>
+<a>foobazcat<last/></a>
+<a>barfoobaz<last/></a>
+<a>barfoobazfoo<last/></a>
+<a>foofoofoo<last/></a>

--- a/ext/dom/tests/bug80602_2.phpt
+++ b/ext/dom/tests/bug80602_2.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #80602 (Segfault when using DOMChildNode::before())
+Bug #80602 (Segfault when using DOMChildNode::after())
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 --FILE--
@@ -9,126 +9,126 @@ declare(strict_types=1);
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->firstChild;
-$target->before($target);
+$target->after($target);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->lastChild;
-$target->before($target);
+$target->after($target);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->firstChild;
-$target->before($doc->documentElement->lastChild);
+$target->after($doc->documentElement->lastChild);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->lastChild;
-$target->before($doc->documentElement->firstChild);
+$target->after($doc->documentElement->firstChild);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->firstChild;
-$target->before($target, $doc->documentElement->lastChild);
+$target->after($target, $doc->documentElement->lastChild);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->firstChild;
-$target->before($doc->documentElement->lastChild, $target);
+$target->after($doc->documentElement->lastChild, $target);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->lastChild;
-$target->before($target, $doc->documentElement->firstChild);
+$target->after($target, $doc->documentElement->firstChild);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->lastChild;
-$target->before($doc->documentElement->firstChild, $target);
-echo $doc->saveXML($doc->documentElement).PHP_EOL;
-
-
-$doc = new \DOMDocument();
-$doc->loadXML('<a>foo<last/></a>');
-$target = $doc->documentElement->firstChild;
-$target->before('bar','baz');
-echo $doc->saveXML($doc->documentElement).PHP_EOL;
-
-$doc = new \DOMDocument();
-$doc->loadXML('<a>foo<last/></a>');
-$target = $doc->documentElement->lastChild;
-$target->before('bar','baz');
+$target->after($doc->documentElement->firstChild, $target);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->firstChild;
-$target->before($target, 'bar','baz');
-echo $doc->saveXML($doc->documentElement).PHP_EOL;
-
-$doc = new \DOMDocument();
-$doc->loadXML('<a>foo<last/></a>');
-$target = $doc->documentElement->firstChild;
-$target->before('bar', $target, 'baz');
-echo $doc->saveXML($doc->documentElement).PHP_EOL;
-
-$doc = new \DOMDocument();
-$doc->loadXML('<a>foo<last/></a>');
-$target = $doc->documentElement->firstChild;
-$target->before('bar', 'baz', $target);
-echo $doc->saveXML($doc->documentElement).PHP_EOL;
-
-
-
-$doc = new \DOMDocument();
-$doc->loadXML('<a>foo<last/></a>');
-$target = $doc->documentElement->lastChild;
-$target->before($target, 'bar','baz');
+$target->after('bar','baz');
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->lastChild;
-$target->before('bar', $target, 'baz');
-echo $doc->saveXML($doc->documentElement).PHP_EOL;
-
-$doc = new \DOMDocument();
-$doc->loadXML('<a>foo<last/></a>');
-$target = $doc->documentElement->lastChild;
-$target->before('bar', 'baz', $target);
-echo $doc->saveXML($doc->documentElement).PHP_EOL;
-
-
-
-$doc = new \DOMDocument();
-$doc->loadXML('<a>foo<last/></a>');
-$target = $doc->documentElement->firstChild;
-$target->before('bar', $target, $doc->documentElement->lastChild);
+$target->after('bar','baz');
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->firstChild;
-$target->before($target, 'bar', $doc->documentElement->lastChild);
+$target->after($target, 'bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after('bar', $target, 'baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after('bar', 'baz', $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after($target, 'bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after('bar', $target, 'baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after('bar', 'baz', $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after('bar', $target, $doc->documentElement->lastChild);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->firstChild;
-$target->before($target, $doc->documentElement->lastChild, 'bar');
+$target->after($target, 'bar', $doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after($target, $doc->documentElement->lastChild, 'bar');
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
@@ -137,35 +137,35 @@ echo $doc->saveXML($doc->documentElement).PHP_EOL;
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->lastChild;
-$target->before('bar', $doc->documentElement->firstChild, $target);
+$target->after('bar', $doc->documentElement->firstChild, $target);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->lastChild;
-$target->before($doc->documentElement->firstChild, 'bar', $target);
+$target->after($doc->documentElement->firstChild, 'bar', $target);
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 
 $doc = new \DOMDocument();
 $doc->loadXML('<a>foo<last/></a>');
 $target = $doc->documentElement->lastChild;
-$target->before($doc->documentElement->firstChild, $target, 'bar');
+$target->after($doc->documentElement->firstChild, $target, 'bar');
 echo $doc->saveXML($doc->documentElement).PHP_EOL;
 
 ?>
 --EXPECTF--
 <a>foo<last/></a>
 <a>foo<last/></a>
-<a><last/>foo</a>
-<a>foo<last/></a>
 <a>foo<last/></a>
 <a><last/>foo</a>
+<a>foo<last/></a>
+<a><last/>foo</a>
 <a><last/>foo</a>
 <a>foo<last/></a>
-<a>barbazfoo<last/></a>
 <a>foobarbaz<last/></a>
+<a>foo<last/>barbaz</a>
 <a>foobarbaz<last/></a>
 <a>barfoobaz<last/></a>
 <a>barbazfoo<last/></a>
@@ -178,4 +178,3 @@ echo $doc->saveXML($doc->documentElement).PHP_EOL;
 <a>barfoo<last/></a>
 <a>foobar<last/></a>
 <a>foo<last/>bar</a>
-

--- a/ext/dom/tests/bug81642.phpt
+++ b/ext/dom/tests/bug81642.phpt
@@ -6,13 +6,27 @@ Bug #81642 DOMChildNode::replaceWith() bug when replacing a node with itself.
 <?php
 require_once("dom_test.inc");
 
-$dom = new DOMDocument;
-$dom->loadXML('<test><mark>first</mark><mark>second</mark></test>');
-$element = $dom->documentElement->firstChild;
-$element->replaceWith($element);
+$doc = new DOMDocument;
+$headNode = $doc->createElement("head");
+$doc->appendChild($headNode);
+$titleNode = $doc->createElement("title");
+$headNode->appendChild($titleNode);
+$titleNode->replaceWith($titleNode);
+echo $doc->saveXML().PHP_EOL;
 
-print_node_list_compact($dom->documentElement->childNodes);
+$doc = new DOMDocument;
+$headNode = $doc->createElement("head");
+$doc->appendChild($headNode);
+$titleNode = $doc->createElement("title");
+$headNode->appendChild($titleNode);
+$titleNode->replaceWith($titleNode, 'foo');
+echo $doc->saveXML().PHP_EOL;
+
 ?>
 --EXPECT--
-<test><mark>first</mark><mark>second</mark></test>
+<?xml version="1.0"?>
+<head><title/></head>
+
+<?xml version="1.0"?>
+<head><title/>foo</head>
 

--- a/ext/dom/tests/bug81642.phpt
+++ b/ext/dom/tests/bug81642.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #81642 DOMChildNode::replaceWith() bug when replacing a node with itself.
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+require_once("dom_test.inc");
+
+$dom = new DOMDocument;
+$dom->loadXML('<test><mark>first</mark><mark>second</mark></test>');
+$element = $dom->documentElement->firstChild;
+$element->replaceWith($element);
+
+print_node_list_compact($dom->documentElement->childNodes);
+?>
+--EXPECT--
+<test><mark>first</mark><mark>second</mark></test>
+

--- a/ext/dom/tests/gh9142.phpt
+++ b/ext/dom/tests/gh9142.phpt
@@ -1,0 +1,40 @@
+--TEST--
+GitHub #9142 (DOMChildNode replaceWith() double-free error when replacing elements not separated by any whitespace)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$a = '<var>One</var> <var>Two</var>'; // Works fine
+($domA = new DOMDocument('1.0', 'UTF-8'))->loadHTML($a);
+foreach ((new DOMXPath($domA))->query('//var') as $var) {
+    $var->replaceWith($domA->createElement('p', $var->nodeValue));
+}
+var_dump($domA->saveHTML());
+
+
+$b = '<var>One</var><var>Two</var>'; // Causes a 'double free' error
+($domB = new DOMDocument('1.0', 'UTF-8'))->loadHTML($b);
+foreach ((new DOMXPath($domB))->query('//var') as $var) {
+    $var->replaceWith($domB->createElement('p', $var->nodeValue));
+}
+var_dump($domB->saveHTML());
+
+
+$document = '<var>One</var><var>Two</var>';
+($dom = new DOMDocument('1.0', 'UTF-8'))->loadHTML($document);
+foreach ((new DOMXPath($dom))->query('//var') as $var) {
+	$var->after($dom->createElement('p', $var->nodeValue));
+	$var->remove();
+}
+var_dump($dom->saveHTML());
+?>
+--EXPECT--
+string(155) "<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body><p>One</p> <p>Two</p></body></html>
+"
+string(154) "<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body><p>One</p><p>Two</p></body></html>
+"
+string(154) "<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body><p>One</p><p>Two</p></body></html>
+"


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=80602

```php
<?php
$doc = new \DOMDocument();
$doc->loadXML('<a>foo<last/></a>');
$target = $doc->documentElement->lastChild;
$target->before('bar', $doc->documentElement->firstChild, 'baz');
echo $doc->saveXML($doc->documentElement).PHP_EOL;
```
 If the number of parameters is greater than or equal to three, `xmlNewDocText` function always returns a pointer that point to `$doc->documentElement->firstChild`.

https://bugs.php.net/bug.php?id=81642

https://github.com/php/php-src/issues/9142