### PR TITLE
Fix recently broken test case

### DIFF
--- a/ext/pdo/tests/bug_43663.phpt
+++ b/ext/pdo/tests/bug_43663.phpt
@@ -23,7 +23,7 @@ class test extends PDO{
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 
-$a = new test('sqlite::memory:');
+$a = PDOTest::factory(test::class);
 $a->foo();
 $a->bar();
 ?>


### PR DESCRIPTION
This test was written to always use the sqlite PDO driver; however,
that driver may no longer be available[1], and actually the test is
supposed to work for all drivers – otherwise it should be placed in
ext/pdo_sqlite/tests.

[1] <https://github.com/php/php-src/commit/938049b92734e37a3c4cbebe4656bfcf8d758d49>