### PR TITLE
Update gen_stub to support #if around classes

### DIFF
--- a/ext/com_dotnet/com_extension_arginfo.h
+++ b/ext/com_dotnet/com_extension_arginfo.h
@@ -220,12 +220,12 @@ static const zend_function_entry class_com_methods[] = {
 };
 
 
-static const zend_function_entry class_dotnet_methods[] = {
 #if HAVE_MSCOREE_H
+static const zend_function_entry class_dotnet_methods[] = {
 	ZEND_ME(dotnet, __construct, arginfo_class_dotnet___construct, ZEND_ACC_PUBLIC)
-#endif
 	ZEND_FE_END
 };
+#endif
 
 
 static const zend_function_entry class_com_safearray_proxy_methods[] = {
@@ -322,6 +322,7 @@ static zend_class_entry *register_class_com(zend_class_entry *class_entry_varian
 	return class_entry;
 }
 
+#if HAVE_MSCOREE_H
 static zend_class_entry *register_class_dotnet(zend_class_entry *class_entry_variant)
 {
 	zend_class_entry ce, *class_entry;
@@ -331,6 +332,7 @@ static zend_class_entry *register_class_dotnet(zend_class_entry *class_entry_var
 
 	return class_entry;
 }
+#endif
 
 static zend_class_entry *register_class_com_safearray_proxy(void)
 {

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -876,24 +876,16 @@ static const zend_function_entry class_DOMProcessingInstruction_methods[] = {
 };
 
 
+#if defined(LIBXML_XPATH_ENABLED)
 static const zend_function_entry class_DOMXPath_methods[] = {
-#if defined(LIBXML_XPATH_ENABLED)
 	ZEND_ME(DOMXPath, __construct, arginfo_class_DOMXPath___construct, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 	ZEND_ME(DOMXPath, evaluate, arginfo_class_DOMXPath_evaluate, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 	ZEND_ME(DOMXPath, query, arginfo_class_DOMXPath_query, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 	ZEND_ME(DOMXPath, registerNamespace, arginfo_class_DOMXPath_registerNamespace, ZEND_ACC_PUBLIC)
-#endif
-#if defined(LIBXML_XPATH_ENABLED)
 	ZEND_ME(DOMXPath, registerPhpFunctions, arginfo_class_DOMXPath_registerPhpFunctions, ZEND_ACC_PUBLIC)
-#endif
 	ZEND_FE_END
 };
+#endif
 
 static void register_php_dom_symbols(int module_number)
 {
@@ -1702,6 +1694,7 @@ static zend_class_entry *register_class_DOMProcessingInstruction(zend_class_entr
 	return class_entry;
 }
 
+#if defined(LIBXML_XPATH_ENABLED)
 static zend_class_entry *register_class_DOMXPath(void)
 {
 	zend_class_entry ce, *class_entry;
@@ -1725,3 +1718,4 @@ static zend_class_entry *register_class_DOMXPath(void)
 
 	return class_entry;
 }
+#endif

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -694,7 +694,7 @@ PHP_MINIT_FUNCTION(mysqli)
 	REGISTER_BOOL_CONSTANT("MYSQLI_IS_MARIADB", 0, CONST_CS | CONST_PERSISTENT);
 #endif
 
-	register_mysqli_symbols(module_number, mysqli_link_class_entry);
+	register_mysqli_symbols(module_number);
 
 	mysqlnd_reverse_api_register_api(&mysqli_reverse_api);
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1025,15 +1025,11 @@ static const zend_function_entry class_mysqli_sql_exception_methods[] = {
 	ZEND_FE_END
 };
 
-static void register_mysqli_symbols(int module_number, zend_class_entry *class_entry_mysqli)
+static void register_mysqli_symbols(int module_number)
 {
 	zend_mark_function_parameter_as_sensitive(CG(function_table), "mysqli_change_user", 2);
 	zend_mark_function_parameter_as_sensitive(CG(function_table), "mysqli_connect", 2);
 	zend_mark_function_parameter_as_sensitive(CG(function_table), "mysqli_real_connect", 3);
-	zend_mark_function_parameter_as_sensitive(&class_entry_mysqli->function_table, "__construct", 2);
-	zend_mark_function_parameter_as_sensitive(&class_entry_mysqli->function_table, "change_user", 1);
-	zend_mark_function_parameter_as_sensitive(&class_entry_mysqli->function_table, "connect", 2);
-	zend_mark_function_parameter_as_sensitive(&class_entry_mysqli->function_table, "real_connect", 2);
 }
 
 static zend_class_entry *register_class_mysqli_driver(void)
@@ -1185,6 +1181,11 @@ static zend_class_entry *register_class_mysqli(void)
 	zend_string *property_warning_count_name = zend_string_init("warning_count", sizeof("warning_count") - 1, 1);
 	zend_declare_typed_property(class_entry, property_warning_count_name, &property_warning_count_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_warning_count_name);
+
+	zend_mark_function_parameter_as_sensitive(&class_entry->function_table, "__construct", 2);
+	zend_mark_function_parameter_as_sensitive(&class_entry->function_table, "change_user", 1);
+	zend_mark_function_parameter_as_sensitive(&class_entry->function_table, "connect", 2);
+	zend_mark_function_parameter_as_sensitive(&class_entry->function_table, "real_connect", 2);
 
 	return class_entry;
 }

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1424,8 +1424,6 @@ void pdo_dbh_init(int module_number)
 
 	REGISTER_PDO_CLASS_CONST_LONG("CURSOR_FWDONLY", (zend_long)PDO_CURSOR_FWDONLY);
 	REGISTER_PDO_CLASS_CONST_LONG("CURSOR_SCROLL", (zend_long)PDO_CURSOR_SCROLL);
-
-	register_pdo_dbh_symbols(module_number, pdo_dbh_ce);
 }
 
 static void dbh_free(pdo_dbh_t *dbh, bool free_persistent)

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -95,11 +95,6 @@ static const zend_function_entry class_PDO_methods[] = {
 	ZEND_FE_END
 };
 
-static void register_pdo_dbh_symbols(int module_number, zend_class_entry *class_entry_PDO)
-{
-	zend_mark_function_parameter_as_sensitive(&class_entry_PDO->function_table, "__construct", 2);
-}
-
 static zend_class_entry *register_class_PDO(void)
 {
 	zend_class_entry ce, *class_entry;
@@ -107,6 +102,8 @@ static zend_class_entry *register_class_PDO(void)
 	INIT_CLASS_ENTRY(ce, "PDO", class_PDO_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+
+	zend_mark_function_parameter_as_sensitive(&class_entry->function_table, "__construct", 2);
 
 	return class_entry;
 }

--- a/ext/spl/spl_directory_arginfo.h
+++ b/ext/spl/spl_directory_arginfo.h
@@ -438,15 +438,13 @@ static const zend_function_entry class_RecursiveDirectoryIterator_methods[] = {
 };
 
 
+#if defined(HAVE_GLOB)
 static const zend_function_entry class_GlobIterator_methods[] = {
-#if defined(HAVE_GLOB)
 	ZEND_ME(GlobIterator, __construct, arginfo_class_GlobIterator___construct, ZEND_ACC_PUBLIC)
-#endif
-#if defined(HAVE_GLOB)
 	ZEND_ME(GlobIterator, count, arginfo_class_GlobIterator_count, ZEND_ACC_PUBLIC)
-#endif
 	ZEND_FE_END
 };
+#endif
 
 
 static const zend_function_entry class_SplFileObject_methods[] = {
@@ -535,6 +533,7 @@ static zend_class_entry *register_class_RecursiveDirectoryIterator(zend_class_en
 	return class_entry;
 }
 
+#if defined(HAVE_GLOB)
 static zend_class_entry *register_class_GlobIterator(zend_class_entry *class_entry_FilesystemIterator, zend_class_entry *class_entry_Countable)
 {
 	zend_class_entry ce, *class_entry;
@@ -545,6 +544,7 @@ static zend_class_entry *register_class_GlobIterator(zend_class_entry *class_ent
 
 	return class_entry;
 }
+#endif
 
 static zend_class_entry *register_class_SplFileObject(zend_class_entry *class_entry_SplFileInfo, zend_class_entry *class_entry_RecursiveIterator, zend_class_entry *class_entry_SeekableIterator)
 {

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -3256,8 +3256,6 @@ static PHP_MINIT_FUNCTION(zip)
 	le_zip_dir   = zend_register_list_destructors_ex(php_zip_free_dir,   NULL, le_zip_dir_name,   module_number);
 	le_zip_entry = zend_register_list_destructors_ex(php_zip_free_entry, NULL, le_zip_entry_name, module_number);
 
-	register_php_zip_symbols(module_number, zip_class_entry);
-
 	return SUCCESS;
 }
 /* }}} */

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -486,17 +486,6 @@ static const zend_function_entry class_ZipArchive_methods[] = {
 	ZEND_FE_END
 };
 
-static void register_php_zip_symbols(int module_number, zend_class_entry *class_entry_ZipArchive)
-{
-	zend_mark_function_parameter_as_sensitive(&class_entry_ZipArchive->function_table, "setpassword", 0);
-#if defined(HAVE_ENCRYPTION)
-	zend_mark_function_parameter_as_sensitive(&class_entry_ZipArchive->function_table, "setencryptionname", 2);
-#endif
-#if defined(HAVE_ENCRYPTION)
-	zend_mark_function_parameter_as_sensitive(&class_entry_ZipArchive->function_table, "setencryptionindex", 2);
-#endif
-}
-
 static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry_Countable)
 {
 	zend_class_entry ce, *class_entry;
@@ -540,6 +529,14 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zend_string *property_comment_name = zend_string_init("comment", sizeof("comment") - 1, 1);
 	zend_declare_typed_property(class_entry, property_comment_name, &property_comment_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_comment_name);
+
+	zend_mark_function_parameter_as_sensitive(&class_entry->function_table, "setpassword", 0);
+#if defined(HAVE_ENCRYPTION)
+	zend_mark_function_parameter_as_sensitive(&class_entry->function_table, "setencryptionname", 2);
+#endif
+#if defined(HAVE_ENCRYPTION)
+	zend_mark_function_parameter_as_sensitive(&class_entry->function_table, "setencryptionindex", 2);
+#endif
 
 	return class_entry;
 }


### PR DESCRIPTION
I have a case where I only want to create a class on some conditions 

```
#if LIBCURL_VERSION_NUM >= 0x073E00 /* Available since 7.62.0 */
/**
 * @strict-properties
 * @not-serializable
 */
final class CurlUrl
{
}
#endif
```

This change will add the appropriate conditions around the `zend_function_entry` and `zend_class_entry`