### PR TITLE
Fix LONG_CHECK_VALID_INT in socket extension

### DIFF
--- a/ext/sockets/sendrecvmsg.c
+++ b/ext/sockets/sendrecvmsg.c
@@ -72,7 +72,7 @@ inline ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags)
 
 #define LONG_CHECK_VALID_INT(l, arg_pos) \
 	do { \
-		if ((l) < INT_MIN && (l) > INT_MAX) { \
+		if ((l) < INT_MIN || (l) > INT_MAX) { \
 			zend_argument_value_error((arg_pos), "must be between %d and %d", INT_MIN, INT_MAX); \
 			RETURN_THROWS(); \
 		} \


### PR DESCRIPTION
This fixes this error 
```
php-src/ext/sockets/sendrecvmsg.c:75:21: error: logical 'and' of mutually exclusive tests is always false [-Werror=logical-op]
```