### PR TITLE
A connection string may contain just a single key

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2170,7 +2170,8 @@ int odbc_sqlconnect(odbc_connection **conn, char *db, char *uid, char *pwd, int 
 		char    *ldb = 0;
 		int		ldb_len = 0;
 
-		if (strstr((char*)db, ";")) {
+		/* a connection string may have = but not ; - i.e. "DSN=PHP" */
+		if (strstr((char*)db, "=")) {
 			direct = 1;
 			/* Force UID and PWD to be set in the DSN */
 			bool is_uid_set = uid && *uid

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -480,7 +480,8 @@ static int pdo_odbc_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ 
 		goto fail;
 	}
 
-	if (strchr(dbh->data_source, ';')) {
+	/* a connection string may have = but not ; - i.e. "DSN=PHP" */
+	if (strchr(dbh->data_source, '=')) {
 		SQLCHAR dsnbuf[1024];
 		SQLSMALLINT dsnbuflen;
 


### PR DESCRIPTION
PHP used ";" as the heuristic to detect if a string was a connection string versus plain DSN. However, a single-key connection string would get treated like a DSN name, i.e. "DSN=*LOCAL". This makes it so that "=" is used, as a connection string must contain a key.