### PR TITLE
[RFC] Closure types

### DIFF
--- a/Zend/tests/closure_types/arity.phpt
+++ b/Zend/tests/closure_types/arity.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Closure type arity
+--FILE--
+<?php
+
+function test(string $closureType, string $params) {
+    try {
+        echo ($closureType ?: "''") . ' > ' . ($params ?: "''") . ': ';
+        eval("(function (fn ($closureType) \$c) {})(function($params) {});");
+        echo 'true';
+    } catch (\Throwable $e) {
+        echo $e->getMessage();
+    }
+    echo "\n";
+}
+
+$closureTypes = [
+    '',
+    'mixed',
+    'mixed&',
+    'mixed, mixed',
+    'mixed...',
+    'mixed, mixed...',
+];
+
+$params = [
+    '',
+    '$a',
+    '$a = null',
+    '&$a',
+    '$a, $b',
+    '$a, $b',
+];
+
+foreach ($closureTypes as $closureType) {
+    foreach ($params as $param) {
+        test($closureType, $param);
+    }
+}
+
+?>
+--EXPECTF--
+'' > '': true
+'' > $a: {closure}(): Argument #1 ($c) must be of type fn(), Closure given, called in %s on line %d
+'' > $a = null: true
+'' > &$a: {closure}(): Argument #1 ($c) must be of type fn(), Closure given, called in %s on line %d
+'' > $a, $b: {closure}(): Argument #1 ($c) must be of type fn(), Closure given, called in %s on line %d
+'' > $a, $b: {closure}(): Argument #1 ($c) must be of type fn(), Closure given, called in %s on line %d
+mixed > '': true
+mixed > $a: true
+mixed > $a = null: true
+mixed > &$a: true
+mixed > $a, $b: {closure}(): Argument #1 ($c) must be of type fn(mixed), Closure given, called in %s on line %d
+mixed > $a, $b: {closure}(): Argument #1 ($c) must be of type fn(mixed), Closure given, called in %s on line %d
+mixed& > '': true
+mixed& > $a: true
+mixed& > $a = null: true
+mixed& > &$a: true
+mixed& > $a, $b: {closure}(): Argument #1 ($c) must be of type fn(mixed&), Closure given, called in %s on line %d
+mixed& > $a, $b: {closure}(): Argument #1 ($c) must be of type fn(mixed&), Closure given, called in %s on line %d
+mixed, mixed > '': true
+mixed, mixed > $a: true
+mixed, mixed > $a = null: true
+mixed, mixed > &$a: true
+mixed, mixed > $a, $b: true
+mixed, mixed > $a, $b: true
+mixed... > '': true
+mixed... > $a: true
+mixed... > $a = null: true
+mixed... > &$a: true
+mixed... > $a, $b: true
+mixed... > $a, $b: true
+mixed, mixed... > '': true
+mixed, mixed... > $a: true
+mixed, mixed... > $a = null: true
+mixed, mixed... > &$a: true
+mixed, mixed... > $a, $b: true
+mixed, mixed... > $a, $b: true

--- a/Zend/tests/closure_types/covariance.phpt
+++ b/Zend/tests/closure_types/covariance.phpt
@@ -4,19 +4,19 @@ Closure type covariance
 <?php
 
 class Foo {
-    function a(): \Closure(): mixed {}
-    function b(): \Closure(int) {}
-    function c(\Closure(): int $x) {}
-    function d(\Closure(mixed) $x) {}
-    function e(\Closure(): \Closure(\Closure(int)): string $x) {}
+    function a(): fn(): mixed {}
+    function b(): fn(int) {}
+    function c(fn(): int $x) {}
+    function d(fn(mixed) $x) {}
+    function e(fn(): fn(fn(int)): string $x) {}
 }
 
 class Bar extends Foo {
-    function a(): \Closure(): int {}
-    function b(): \Closure(mixed) {}
-    function c(\Closure(): mixed $x) {}
-    function d(\Closure(int) $x) {}
-    function e(\Closure(): \Closure(\Closure(mixed)): string $x) {}
+    function a(): fn(): int {}
+    function b(): fn(mixed) {}
+    function c(fn(): mixed $x) {}
+    function d(fn(int) $x) {}
+    function e(fn(): fn(fn(mixed)): string $x) {}
 }
 
 ?>

--- a/Zend/tests/closure_types/covariance.phpt
+++ b/Zend/tests/closure_types/covariance.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Closure type covariance
+--FILE--
+<?php
+
+class Foo {
+    function a(): \Closure(): mixed {}
+    function b(): \Closure(int) {}
+    function c(\Closure(): int $x) {}
+    function d(\Closure(mixed) $x) {}
+    function e(\Closure(): \Closure(\Closure(int)): string $x) {}
+}
+
+class Bar extends Foo {
+    function a(): \Closure(): int {}
+    function b(): \Closure(mixed) {}
+    function c(\Closure(): mixed $x) {}
+    function d(\Closure(int) $x) {}
+    function e(\Closure(): \Closure(\Closure(mixed)): string $x) {}
+}
+
+?>
+--EXPECT--

--- a/Zend/tests/closure_types/non_last_variadic.phpt
+++ b/Zend/tests/closure_types/non_last_variadic.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Only last closure type parameter can be variadic
+--FILE--
+<?php
+
+function test(\Closure(string..., int): void $closure) {}
+
+?>
+--EXPECTF--
+Fatal error: Only the last parameter can be variadic in %s on line %d

--- a/Zend/tests/closure_types/non_last_variadic.phpt
+++ b/Zend/tests/closure_types/non_last_variadic.phpt
@@ -3,7 +3,7 @@ Only last closure type parameter can be variadic
 --FILE--
 <?php
 
-function test(\Closure(string..., int): void $closure) {}
+function test(fn(string..., int): void $c) {}
 
 ?>
 --EXPECTF--

--- a/Zend/tests/closure_types/param_type.phpt
+++ b/Zend/tests/closure_types/param_type.phpt
@@ -1,0 +1,303 @@
+--TEST--
+Closure type return type covariance
+--FILE--
+<?php
+
+interface Foo {}
+interface Bar {}
+
+function test($type, $value) {
+    echo ($type ?: 'none') . ' > ' . ($value ?: 'none') . ': ';
+    try {
+        eval("(function (\\Closure($type \$p) \$c) {})(function ($value \$p) {});");
+        echo 'true';
+    } catch (Error $e) {
+        echo 'false';
+    }
+    echo "\n";
+}
+
+$values = [
+    '',
+    'void',
+    'string',
+    'int',
+    'bool',
+    'string|int',
+    'string|int|bool',
+    '?string',
+    'object',
+    'Foo',
+    'Bar',
+    'Foo&Bar',
+    '\\Closure(): void',
+    '\\Closure(): string',
+    '\\Closure(): string|int',
+    'callable',
+];
+
+foreach ($values as $type) {
+    foreach ($values as $value) {
+        test($type, $value);
+    }
+}
+
+?>
+--EXPECT--
+
+none > none: false
+none > void: false
+none > string: false
+none > int: false
+none > bool: false
+none > string|int: false
+none > string|int|bool: false
+none > ?string: false
+none > object: false
+none > Foo: false
+none > Bar: false
+none > Foo&Bar: false
+none > \Closure(): void: false
+none > \Closure(): string: false
+none > \Closure(): string|int: false
+none > callable: false
+void > none: false
+void > void: false
+void > string: false
+void > int: false
+void > bool: false
+void > string|int: false
+void > string|int|bool: false
+void > ?string: false
+void > object: false
+void > Foo: false
+void > Bar: false
+void > Foo&Bar: false
+void > \Closure(): void: false
+void > \Closure(): string: false
+void > \Closure(): string|int: false
+void > callable: false
+string > none: false
+string > void: false
+string > string: false
+string > int: false
+string > bool: false
+string > string|int: false
+string > string|int|bool: false
+string > ?string: false
+string > object: false
+string > Foo: false
+string > Bar: false
+string > Foo&Bar: false
+string > \Closure(): void: false
+string > \Closure(): string: false
+string > \Closure(): string|int: false
+string > callable: false
+int > none: false
+int > void: false
+int > string: false
+int > int: false
+int > bool: false
+int > string|int: false
+int > string|int|bool: false
+int > ?string: false
+int > object: false
+int > Foo: false
+int > Bar: false
+int > Foo&Bar: false
+int > \Closure(): void: false
+int > \Closure(): string: false
+int > \Closure(): string|int: false
+int > callable: false
+bool > none: false
+bool > void: false
+bool > string: false
+bool > int: false
+bool > bool: false
+bool > string|int: false
+bool > string|int|bool: false
+bool > ?string: false
+bool > object: false
+bool > Foo: false
+bool > Bar: false
+bool > Foo&Bar: false
+bool > \Closure(): void: false
+bool > \Closure(): string: false
+bool > \Closure(): string|int: false
+bool > callable: false
+string|int > none: false
+string|int > void: false
+string|int > string: false
+string|int > int: false
+string|int > bool: false
+string|int > string|int: false
+string|int > string|int|bool: false
+string|int > ?string: false
+string|int > object: false
+string|int > Foo: false
+string|int > Bar: false
+string|int > Foo&Bar: false
+string|int > \Closure(): void: false
+string|int > \Closure(): string: false
+string|int > \Closure(): string|int: false
+string|int > callable: false
+string|int|bool > none: false
+string|int|bool > void: false
+string|int|bool > string: false
+string|int|bool > int: false
+string|int|bool > bool: false
+string|int|bool > string|int: false
+string|int|bool > string|int|bool: false
+string|int|bool > ?string: false
+string|int|bool > object: false
+string|int|bool > Foo: false
+string|int|bool > Bar: false
+string|int|bool > Foo&Bar: false
+string|int|bool > \Closure(): void: false
+string|int|bool > \Closure(): string: false
+string|int|bool > \Closure(): string|int: false
+string|int|bool > callable: false
+?string > none: false
+?string > void: false
+?string > string: false
+?string > int: false
+?string > bool: false
+?string > string|int: false
+?string > string|int|bool: false
+?string > ?string: false
+?string > object: false
+?string > Foo: false
+?string > Bar: false
+?string > Foo&Bar: false
+?string > \Closure(): void: false
+?string > \Closure(): string: false
+?string > \Closure(): string|int: false
+?string > callable: false
+object > none: false
+object > void: false
+object > string: false
+object > int: false
+object > bool: false
+object > string|int: false
+object > string|int|bool: false
+object > ?string: false
+object > object: false
+object > Foo: false
+object > Bar: false
+object > Foo&Bar: false
+object > \Closure(): void: false
+object > \Closure(): string: false
+object > \Closure(): string|int: false
+object > callable: false
+Foo > none: false
+Foo > void: false
+Foo > string: false
+Foo > int: false
+Foo > bool: false
+Foo > string|int: false
+Foo > string|int|bool: false
+Foo > ?string: false
+Foo > object: false
+Foo > Foo: false
+Foo > Bar: false
+Foo > Foo&Bar: false
+Foo > \Closure(): void: false
+Foo > \Closure(): string: false
+Foo > \Closure(): string|int: false
+Foo > callable: false
+Bar > none: false
+Bar > void: false
+Bar > string: false
+Bar > int: false
+Bar > bool: false
+Bar > string|int: false
+Bar > string|int|bool: false
+Bar > ?string: false
+Bar > object: false
+Bar > Foo: false
+Bar > Bar: false
+Bar > Foo&Bar: false
+Bar > \Closure(): void: false
+Bar > \Closure(): string: false
+Bar > \Closure(): string|int: false
+Bar > callable: false
+Foo&Bar > none: false
+Foo&Bar > void: false
+Foo&Bar > string: false
+Foo&Bar > int: false
+Foo&Bar > bool: false
+Foo&Bar > string|int: false
+Foo&Bar > string|int|bool: false
+Foo&Bar > ?string: false
+Foo&Bar > object: false
+Foo&Bar > Foo: false
+Foo&Bar > Bar: false
+Foo&Bar > Foo&Bar: false
+Foo&Bar > \Closure(): void: false
+Foo&Bar > \Closure(): string: false
+Foo&Bar > \Closure(): string|int: false
+Foo&Bar > callable: false
+\Closure(): void > none: false
+\Closure(): void > void: false
+\Closure(): void > string: false
+\Closure(): void > int: false
+\Closure(): void > bool: false
+\Closure(): void > string|int: false
+\Closure(): void > string|int|bool: false
+\Closure(): void > ?string: false
+\Closure(): void > object: false
+\Closure(): void > Foo: false
+\Closure(): void > Bar: false
+\Closure(): void > Foo&Bar: false
+\Closure(): void > \Closure(): void: false
+\Closure(): void > \Closure(): string: false
+\Closure(): void > \Closure(): string|int: false
+\Closure(): void > callable: false
+\Closure(): string > none: false
+\Closure(): string > void: false
+\Closure(): string > string: false
+\Closure(): string > int: false
+\Closure(): string > bool: false
+\Closure(): string > string|int: false
+\Closure(): string > string|int|bool: false
+\Closure(): string > ?string: false
+\Closure(): string > object: false
+\Closure(): string > Foo: false
+\Closure(): string > Bar: false
+\Closure(): string > Foo&Bar: false
+\Closure(): string > \Closure(): void: false
+\Closure(): string > \Closure(): string: false
+\Closure(): string > \Closure(): string|int: false
+\Closure(): string > callable: false
+\Closure(): string|int > none: false
+\Closure(): string|int > void: false
+\Closure(): string|int > string: false
+\Closure(): string|int > int: false
+\Closure(): string|int > bool: false
+\Closure(): string|int > string|int: false
+\Closure(): string|int > string|int|bool: false
+\Closure(): string|int > ?string: false
+\Closure(): string|int > object: false
+\Closure(): string|int > Foo: false
+\Closure(): string|int > Bar: false
+\Closure(): string|int > Foo&Bar: false
+\Closure(): string|int > \Closure(): void: false
+\Closure(): string|int > \Closure(): string: false
+\Closure(): string|int > \Closure(): string|int: false
+\Closure(): string|int > callable: false
+callable > none: false
+callable > void: false
+callable > string: false
+callable > int: false
+callable > bool: false
+callable > string|int: false
+callable > string|int|bool: false
+callable > ?string: false
+callable > object: false
+callable > Foo: false
+callable > Bar: false
+callable > Foo&Bar: false
+callable > \Closure(): void: false
+callable > \Closure(): string: false
+callable > \Closure(): string|int: false
+callable > callable: false

--- a/Zend/tests/closure_types/param_type.phpt
+++ b/Zend/tests/closure_types/param_type.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Closure type return type covariance
+Closure type parameter type check
 --FILE--
 <?php
 

--- a/Zend/tests/closure_types/param_type.phpt
+++ b/Zend/tests/closure_types/param_type.phpt
@@ -9,9 +9,10 @@ interface Bar {}
 function test($type, $value) {
     echo ($type ?: 'none') . ' > ' . ($value ?: 'none') . ': ';
     try {
-        eval("(function (fn($type \$p) \$c) {})(function ($value \$p) {});");
+        eval("(function (fn($type) \$c) {})(function ($value \$p) {});");
         echo 'true';
     } catch (Error $e) {
+        // FIXME: Make sure the error message matches
         echo 'false';
     }
     echo "\n";
@@ -19,7 +20,6 @@ function test($type, $value) {
 
 $values = [
     '',
-    'void',
     'string',
     'int',
     'bool',
@@ -44,47 +44,28 @@ foreach ($values as $type) {
 
 ?>
 --EXPECT--
-
-none > none: false
-none > void: false
-none > string: false
-none > int: false
-none > bool: false
-none > string|int: false
-none > string|int|bool: false
-none > ?string: false
-none > object: false
-none > Foo: false
-none > Bar: false
-none > Foo&Bar: false
-none > fn(): void: false
-none > fn(): string: false
-none > fn(): string|int: false
-none > callable: false
-void > none: false
-void > void: false
-void > string: false
-void > int: false
-void > bool: false
-void > string|int: false
-void > string|int|bool: false
-void > ?string: false
-void > object: false
-void > Foo: false
-void > Bar: false
-void > Foo&Bar: false
-void > fn(): void: false
-void > fn(): string: false
-void > fn(): string|int: false
-void > callable: false
-string > none: false
-string > void: false
-string > string: false
+none > none: true
+none > string: true
+none > int: true
+none > bool: true
+none > string|int: true
+none > string|int|bool: true
+none > ?string: true
+none > object: true
+none > Foo: true
+none > Bar: true
+none > Foo&Bar: true
+none > fn(): void: true
+none > fn(): string: true
+none > fn(): string|int: true
+none > callable: true
+string > none: true
+string > string: true
 string > int: false
 string > bool: false
-string > string|int: false
-string > string|int|bool: false
-string > ?string: false
+string > string|int: true
+string > string|int|bool: true
+string > ?string: true
 string > object: false
 string > Foo: false
 string > Bar: false
@@ -93,13 +74,12 @@ string > fn(): void: false
 string > fn(): string: false
 string > fn(): string|int: false
 string > callable: false
-int > none: false
-int > void: false
+int > none: true
 int > string: false
-int > int: false
+int > int: true
 int > bool: false
-int > string|int: false
-int > string|int|bool: false
+int > string|int: true
+int > string|int|bool: true
 int > ?string: false
 int > object: false
 int > Foo: false
@@ -109,13 +89,12 @@ int > fn(): void: false
 int > fn(): string: false
 int > fn(): string|int: false
 int > callable: false
-bool > none: false
-bool > void: false
+bool > none: true
 bool > string: false
 bool > int: false
-bool > bool: false
+bool > bool: true
 bool > string|int: false
-bool > string|int|bool: false
+bool > string|int|bool: true
 bool > ?string: false
 bool > object: false
 bool > Foo: false
@@ -125,13 +104,12 @@ bool > fn(): void: false
 bool > fn(): string: false
 bool > fn(): string|int: false
 bool > callable: false
-string|int > none: false
-string|int > void: false
+string|int > none: true
 string|int > string: false
 string|int > int: false
 string|int > bool: false
-string|int > string|int: false
-string|int > string|int|bool: false
+string|int > string|int: true
+string|int > string|int|bool: true
 string|int > ?string: false
 string|int > object: false
 string|int > Foo: false
@@ -141,13 +119,12 @@ string|int > fn(): void: false
 string|int > fn(): string: false
 string|int > fn(): string|int: false
 string|int > callable: false
-string|int|bool > none: false
-string|int|bool > void: false
+string|int|bool > none: true
 string|int|bool > string: false
 string|int|bool > int: false
 string|int|bool > bool: false
 string|int|bool > string|int: false
-string|int|bool > string|int|bool: false
+string|int|bool > string|int|bool: true
 string|int|bool > ?string: false
 string|int|bool > object: false
 string|int|bool > Foo: false
@@ -157,14 +134,13 @@ string|int|bool > fn(): void: false
 string|int|bool > fn(): string: false
 string|int|bool > fn(): string|int: false
 string|int|bool > callable: false
-?string > none: false
-?string > void: false
+?string > none: true
 ?string > string: false
 ?string > int: false
 ?string > bool: false
 ?string > string|int: false
 ?string > string|int|bool: false
-?string > ?string: false
+?string > ?string: true
 ?string > object: false
 ?string > Foo: false
 ?string > Bar: false
@@ -173,15 +149,14 @@ string|int|bool > callable: false
 ?string > fn(): string: false
 ?string > fn(): string|int: false
 ?string > callable: false
-object > none: false
-object > void: false
+object > none: true
 object > string: false
 object > int: false
 object > bool: false
 object > string|int: false
 object > string|int|bool: false
 object > ?string: false
-object > object: false
+object > object: true
 object > Foo: false
 object > Bar: false
 object > Foo&Bar: false
@@ -189,104 +164,97 @@ object > fn(): void: false
 object > fn(): string: false
 object > fn(): string|int: false
 object > callable: false
-Foo > none: false
-Foo > void: false
+Foo > none: true
 Foo > string: false
 Foo > int: false
 Foo > bool: false
 Foo > string|int: false
 Foo > string|int|bool: false
 Foo > ?string: false
-Foo > object: false
-Foo > Foo: false
+Foo > object: true
+Foo > Foo: true
 Foo > Bar: false
 Foo > Foo&Bar: false
 Foo > fn(): void: false
 Foo > fn(): string: false
 Foo > fn(): string|int: false
 Foo > callable: false
-Bar > none: false
-Bar > void: false
+Bar > none: true
 Bar > string: false
 Bar > int: false
 Bar > bool: false
 Bar > string|int: false
 Bar > string|int|bool: false
 Bar > ?string: false
-Bar > object: false
+Bar > object: true
 Bar > Foo: false
-Bar > Bar: false
+Bar > Bar: true
 Bar > Foo&Bar: false
 Bar > fn(): void: false
 Bar > fn(): string: false
 Bar > fn(): string|int: false
 Bar > callable: false
-Foo&Bar > none: false
-Foo&Bar > void: false
+Foo&Bar > none: true
 Foo&Bar > string: false
 Foo&Bar > int: false
 Foo&Bar > bool: false
 Foo&Bar > string|int: false
 Foo&Bar > string|int|bool: false
 Foo&Bar > ?string: false
-Foo&Bar > object: false
-Foo&Bar > Foo: false
-Foo&Bar > Bar: false
-Foo&Bar > Foo&Bar: false
+Foo&Bar > object: true
+Foo&Bar > Foo: true
+Foo&Bar > Bar: true
+Foo&Bar > Foo&Bar: true
 Foo&Bar > fn(): void: false
 Foo&Bar > fn(): string: false
 Foo&Bar > fn(): string|int: false
 Foo&Bar > callable: false
-fn(): void > none: false
-fn(): void > void: false
+fn(): void > none: true
 fn(): void > string: false
 fn(): void > int: false
 fn(): void > bool: false
 fn(): void > string|int: false
 fn(): void > string|int|bool: false
 fn(): void > ?string: false
-fn(): void > object: false
+fn(): void > object: true
 fn(): void > Foo: false
 fn(): void > Bar: false
 fn(): void > Foo&Bar: false
-fn(): void > fn(): void: false
+fn(): void > fn(): void: true
 fn(): void > fn(): string: false
 fn(): void > fn(): string|int: false
-fn(): void > callable: false
-fn(): string > none: false
-fn(): string > void: false
+fn(): void > callable: true
+fn(): string > none: true
 fn(): string > string: false
 fn(): string > int: false
 fn(): string > bool: false
 fn(): string > string|int: false
 fn(): string > string|int|bool: false
 fn(): string > ?string: false
-fn(): string > object: false
+fn(): string > object: true
 fn(): string > Foo: false
 fn(): string > Bar: false
 fn(): string > Foo&Bar: false
 fn(): string > fn(): void: false
-fn(): string > fn(): string: false
-fn(): string > fn(): string|int: false
-fn(): string > callable: false
-fn(): string|int > none: false
-fn(): string|int > void: false
+fn(): string > fn(): string: true
+fn(): string > fn(): string|int: true
+fn(): string > callable: true
+fn(): string|int > none: true
 fn(): string|int > string: false
 fn(): string|int > int: false
 fn(): string|int > bool: false
 fn(): string|int > string|int: false
 fn(): string|int > string|int|bool: false
 fn(): string|int > ?string: false
-fn(): string|int > object: false
+fn(): string|int > object: true
 fn(): string|int > Foo: false
 fn(): string|int > Bar: false
 fn(): string|int > Foo&Bar: false
 fn(): string|int > fn(): void: false
 fn(): string|int > fn(): string: false
-fn(): string|int > fn(): string|int: false
-fn(): string|int > callable: false
-callable > none: false
-callable > void: false
+fn(): string|int > fn(): string|int: true
+fn(): string|int > callable: true
+callable > none: true
 callable > string: false
 callable > int: false
 callable > bool: false
@@ -300,4 +268,4 @@ callable > Foo&Bar: false
 callable > fn(): void: false
 callable > fn(): string: false
 callable > fn(): string|int: false
-callable > callable: false
+callable > callable: true

--- a/Zend/tests/closure_types/param_type.phpt
+++ b/Zend/tests/closure_types/param_type.phpt
@@ -9,7 +9,7 @@ interface Bar {}
 function test($type, $value) {
     echo ($type ?: 'none') . ' > ' . ($value ?: 'none') . ': ';
     try {
-        eval("(function (\\Closure($type \$p) \$c) {})(function ($value \$p) {});");
+        eval("(function (fn($type \$p) \$c) {})(function ($value \$p) {});");
         echo 'true';
     } catch (Error $e) {
         echo 'false';
@@ -30,9 +30,9 @@ $values = [
     'Foo',
     'Bar',
     'Foo&Bar',
-    '\\Closure(): void',
-    '\\Closure(): string',
-    '\\Closure(): string|int',
+    'fn(): void',
+    'fn(): string',
+    'fn(): string|int',
     'callable',
 ];
 
@@ -57,9 +57,9 @@ none > object: false
 none > Foo: false
 none > Bar: false
 none > Foo&Bar: false
-none > \Closure(): void: false
-none > \Closure(): string: false
-none > \Closure(): string|int: false
+none > fn(): void: false
+none > fn(): string: false
+none > fn(): string|int: false
 none > callable: false
 void > none: false
 void > void: false
@@ -73,9 +73,9 @@ void > object: false
 void > Foo: false
 void > Bar: false
 void > Foo&Bar: false
-void > \Closure(): void: false
-void > \Closure(): string: false
-void > \Closure(): string|int: false
+void > fn(): void: false
+void > fn(): string: false
+void > fn(): string|int: false
 void > callable: false
 string > none: false
 string > void: false
@@ -89,9 +89,9 @@ string > object: false
 string > Foo: false
 string > Bar: false
 string > Foo&Bar: false
-string > \Closure(): void: false
-string > \Closure(): string: false
-string > \Closure(): string|int: false
+string > fn(): void: false
+string > fn(): string: false
+string > fn(): string|int: false
 string > callable: false
 int > none: false
 int > void: false
@@ -105,9 +105,9 @@ int > object: false
 int > Foo: false
 int > Bar: false
 int > Foo&Bar: false
-int > \Closure(): void: false
-int > \Closure(): string: false
-int > \Closure(): string|int: false
+int > fn(): void: false
+int > fn(): string: false
+int > fn(): string|int: false
 int > callable: false
 bool > none: false
 bool > void: false
@@ -121,9 +121,9 @@ bool > object: false
 bool > Foo: false
 bool > Bar: false
 bool > Foo&Bar: false
-bool > \Closure(): void: false
-bool > \Closure(): string: false
-bool > \Closure(): string|int: false
+bool > fn(): void: false
+bool > fn(): string: false
+bool > fn(): string|int: false
 bool > callable: false
 string|int > none: false
 string|int > void: false
@@ -137,9 +137,9 @@ string|int > object: false
 string|int > Foo: false
 string|int > Bar: false
 string|int > Foo&Bar: false
-string|int > \Closure(): void: false
-string|int > \Closure(): string: false
-string|int > \Closure(): string|int: false
+string|int > fn(): void: false
+string|int > fn(): string: false
+string|int > fn(): string|int: false
 string|int > callable: false
 string|int|bool > none: false
 string|int|bool > void: false
@@ -153,9 +153,9 @@ string|int|bool > object: false
 string|int|bool > Foo: false
 string|int|bool > Bar: false
 string|int|bool > Foo&Bar: false
-string|int|bool > \Closure(): void: false
-string|int|bool > \Closure(): string: false
-string|int|bool > \Closure(): string|int: false
+string|int|bool > fn(): void: false
+string|int|bool > fn(): string: false
+string|int|bool > fn(): string|int: false
 string|int|bool > callable: false
 ?string > none: false
 ?string > void: false
@@ -169,9 +169,9 @@ string|int|bool > callable: false
 ?string > Foo: false
 ?string > Bar: false
 ?string > Foo&Bar: false
-?string > \Closure(): void: false
-?string > \Closure(): string: false
-?string > \Closure(): string|int: false
+?string > fn(): void: false
+?string > fn(): string: false
+?string > fn(): string|int: false
 ?string > callable: false
 object > none: false
 object > void: false
@@ -185,9 +185,9 @@ object > object: false
 object > Foo: false
 object > Bar: false
 object > Foo&Bar: false
-object > \Closure(): void: false
-object > \Closure(): string: false
-object > \Closure(): string|int: false
+object > fn(): void: false
+object > fn(): string: false
+object > fn(): string|int: false
 object > callable: false
 Foo > none: false
 Foo > void: false
@@ -201,9 +201,9 @@ Foo > object: false
 Foo > Foo: false
 Foo > Bar: false
 Foo > Foo&Bar: false
-Foo > \Closure(): void: false
-Foo > \Closure(): string: false
-Foo > \Closure(): string|int: false
+Foo > fn(): void: false
+Foo > fn(): string: false
+Foo > fn(): string|int: false
 Foo > callable: false
 Bar > none: false
 Bar > void: false
@@ -217,9 +217,9 @@ Bar > object: false
 Bar > Foo: false
 Bar > Bar: false
 Bar > Foo&Bar: false
-Bar > \Closure(): void: false
-Bar > \Closure(): string: false
-Bar > \Closure(): string|int: false
+Bar > fn(): void: false
+Bar > fn(): string: false
+Bar > fn(): string|int: false
 Bar > callable: false
 Foo&Bar > none: false
 Foo&Bar > void: false
@@ -233,58 +233,58 @@ Foo&Bar > object: false
 Foo&Bar > Foo: false
 Foo&Bar > Bar: false
 Foo&Bar > Foo&Bar: false
-Foo&Bar > \Closure(): void: false
-Foo&Bar > \Closure(): string: false
-Foo&Bar > \Closure(): string|int: false
+Foo&Bar > fn(): void: false
+Foo&Bar > fn(): string: false
+Foo&Bar > fn(): string|int: false
 Foo&Bar > callable: false
-\Closure(): void > none: false
-\Closure(): void > void: false
-\Closure(): void > string: false
-\Closure(): void > int: false
-\Closure(): void > bool: false
-\Closure(): void > string|int: false
-\Closure(): void > string|int|bool: false
-\Closure(): void > ?string: false
-\Closure(): void > object: false
-\Closure(): void > Foo: false
-\Closure(): void > Bar: false
-\Closure(): void > Foo&Bar: false
-\Closure(): void > \Closure(): void: false
-\Closure(): void > \Closure(): string: false
-\Closure(): void > \Closure(): string|int: false
-\Closure(): void > callable: false
-\Closure(): string > none: false
-\Closure(): string > void: false
-\Closure(): string > string: false
-\Closure(): string > int: false
-\Closure(): string > bool: false
-\Closure(): string > string|int: false
-\Closure(): string > string|int|bool: false
-\Closure(): string > ?string: false
-\Closure(): string > object: false
-\Closure(): string > Foo: false
-\Closure(): string > Bar: false
-\Closure(): string > Foo&Bar: false
-\Closure(): string > \Closure(): void: false
-\Closure(): string > \Closure(): string: false
-\Closure(): string > \Closure(): string|int: false
-\Closure(): string > callable: false
-\Closure(): string|int > none: false
-\Closure(): string|int > void: false
-\Closure(): string|int > string: false
-\Closure(): string|int > int: false
-\Closure(): string|int > bool: false
-\Closure(): string|int > string|int: false
-\Closure(): string|int > string|int|bool: false
-\Closure(): string|int > ?string: false
-\Closure(): string|int > object: false
-\Closure(): string|int > Foo: false
-\Closure(): string|int > Bar: false
-\Closure(): string|int > Foo&Bar: false
-\Closure(): string|int > \Closure(): void: false
-\Closure(): string|int > \Closure(): string: false
-\Closure(): string|int > \Closure(): string|int: false
-\Closure(): string|int > callable: false
+fn(): void > none: false
+fn(): void > void: false
+fn(): void > string: false
+fn(): void > int: false
+fn(): void > bool: false
+fn(): void > string|int: false
+fn(): void > string|int|bool: false
+fn(): void > ?string: false
+fn(): void > object: false
+fn(): void > Foo: false
+fn(): void > Bar: false
+fn(): void > Foo&Bar: false
+fn(): void > fn(): void: false
+fn(): void > fn(): string: false
+fn(): void > fn(): string|int: false
+fn(): void > callable: false
+fn(): string > none: false
+fn(): string > void: false
+fn(): string > string: false
+fn(): string > int: false
+fn(): string > bool: false
+fn(): string > string|int: false
+fn(): string > string|int|bool: false
+fn(): string > ?string: false
+fn(): string > object: false
+fn(): string > Foo: false
+fn(): string > Bar: false
+fn(): string > Foo&Bar: false
+fn(): string > fn(): void: false
+fn(): string > fn(): string: false
+fn(): string > fn(): string|int: false
+fn(): string > callable: false
+fn(): string|int > none: false
+fn(): string|int > void: false
+fn(): string|int > string: false
+fn(): string|int > int: false
+fn(): string|int > bool: false
+fn(): string|int > string|int: false
+fn(): string|int > string|int|bool: false
+fn(): string|int > ?string: false
+fn(): string|int > object: false
+fn(): string|int > Foo: false
+fn(): string|int > Bar: false
+fn(): string|int > Foo&Bar: false
+fn(): string|int > fn(): void: false
+fn(): string|int > fn(): string: false
+fn(): string|int > fn(): string|int: false
+fn(): string|int > callable: false
 callable > none: false
 callable > void: false
 callable > string: false
@@ -297,7 +297,7 @@ callable > object: false
 callable > Foo: false
 callable > Bar: false
 callable > Foo&Bar: false
-callable > \Closure(): void: false
-callable > \Closure(): string: false
-callable > \Closure(): string|int: false
+callable > fn(): void: false
+callable > fn(): string: false
+callable > fn(): string|int: false
 callable > callable: false

--- a/Zend/tests/closure_types/param_type.phpt
+++ b/Zend/tests/closure_types/param_type.phpt
@@ -44,21 +44,21 @@ foreach ($values as $type) {
 
 ?>
 --EXPECT--
-none > none: true
-none > string: true
-none > int: true
-none > bool: true
-none > string|int: true
-none > string|int|bool: true
-none > ?string: true
-none > object: true
-none > Foo: true
-none > Bar: true
-none > Foo&Bar: true
-none > fn(): void: true
-none > fn(): string: true
-none > fn(): string|int: true
-none > callable: true
+none > none: false
+none > string: false
+none > int: false
+none > bool: false
+none > string|int: false
+none > string|int|bool: false
+none > ?string: false
+none > object: false
+none > Foo: false
+none > Bar: false
+none > Foo&Bar: false
+none > fn(): void: false
+none > fn(): string: false
+none > fn(): string|int: false
+none > callable: false
 string > none: true
 string > string: true
 string > int: false

--- a/Zend/tests/closure_types/return_type.phpt
+++ b/Zend/tests/closure_types/return_type.phpt
@@ -1,0 +1,304 @@
+--TEST--
+Closure type return type covariance
+--FILE--
+<?php
+
+interface Foo {}
+interface Bar {}
+
+function test($type, $value) {
+    echo ($type ?: 'none') . ' > ' . ($value ?: 'none') . ': ';
+    $typeColon = $type ? ': ' : '';
+    $valueColon = $value ? ': ' : '';
+    try {
+        eval("(function (\\Closure(){$typeColon}{$type} \$c) {})(function (){$valueColon}{$value} {});");
+        echo 'true';
+    } catch (Error $e) {
+        echo 'false';
+    }
+    echo "\n";
+}
+
+$values = [
+    '',
+    'void',
+    'string',
+    'int',
+    'bool',
+    'string|int',
+    'string|int|bool',
+    '?string',
+    'object',
+    'Foo',
+    'Bar',
+    'Foo&Bar',
+    '\\Closure(): void',
+    '\\Closure(): string',
+    '\\Closure(): string|int',
+    'callable',
+];
+
+foreach ($values as $type) {
+    foreach ($values as $value) {
+        test($type, $value);
+    }
+}
+
+?>
+--EXPECT--
+none > none: true
+none > void: true
+none > string: true
+none > int: true
+none > bool: true
+none > string|int: true
+none > string|int|bool: true
+none > ?string: true
+none > object: true
+none > Foo: true
+none > Bar: true
+none > Foo&Bar: true
+none > \Closure(): void: true
+none > \Closure(): string: true
+none > \Closure(): string|int: true
+none > callable: true
+void > none: false
+void > void: true
+void > string: false
+void > int: false
+void > bool: false
+void > string|int: false
+void > string|int|bool: false
+void > ?string: false
+void > object: false
+void > Foo: false
+void > Bar: false
+void > Foo&Bar: false
+void > \Closure(): void: false
+void > \Closure(): string: false
+void > \Closure(): string|int: false
+void > callable: false
+string > none: false
+string > void: false
+string > string: true
+string > int: false
+string > bool: false
+string > string|int: false
+string > string|int|bool: false
+string > ?string: false
+string > object: false
+string > Foo: false
+string > Bar: false
+string > Foo&Bar: false
+string > \Closure(): void: false
+string > \Closure(): string: false
+string > \Closure(): string|int: false
+string > callable: false
+int > none: false
+int > void: false
+int > string: false
+int > int: true
+int > bool: false
+int > string|int: false
+int > string|int|bool: false
+int > ?string: false
+int > object: false
+int > Foo: false
+int > Bar: false
+int > Foo&Bar: false
+int > \Closure(): void: false
+int > \Closure(): string: false
+int > \Closure(): string|int: false
+int > callable: false
+bool > none: false
+bool > void: false
+bool > string: false
+bool > int: false
+bool > bool: true
+bool > string|int: false
+bool > string|int|bool: false
+bool > ?string: false
+bool > object: false
+bool > Foo: false
+bool > Bar: false
+bool > Foo&Bar: false
+bool > \Closure(): void: false
+bool > \Closure(): string: false
+bool > \Closure(): string|int: false
+bool > callable: false
+string|int > none: false
+string|int > void: false
+string|int > string: true
+string|int > int: true
+string|int > bool: false
+string|int > string|int: true
+string|int > string|int|bool: false
+string|int > ?string: false
+string|int > object: false
+string|int > Foo: false
+string|int > Bar: false
+string|int > Foo&Bar: false
+string|int > \Closure(): void: false
+string|int > \Closure(): string: false
+string|int > \Closure(): string|int: false
+string|int > callable: false
+string|int|bool > none: false
+string|int|bool > void: false
+string|int|bool > string: true
+string|int|bool > int: true
+string|int|bool > bool: true
+string|int|bool > string|int: true
+string|int|bool > string|int|bool: true
+string|int|bool > ?string: false
+string|int|bool > object: false
+string|int|bool > Foo: false
+string|int|bool > Bar: false
+string|int|bool > Foo&Bar: false
+string|int|bool > \Closure(): void: false
+string|int|bool > \Closure(): string: false
+string|int|bool > \Closure(): string|int: false
+string|int|bool > callable: false
+?string > none: false
+?string > void: false
+?string > string: true
+?string > int: false
+?string > bool: false
+?string > string|int: false
+?string > string|int|bool: false
+?string > ?string: true
+?string > object: false
+?string > Foo: false
+?string > Bar: false
+?string > Foo&Bar: false
+?string > \Closure(): void: false
+?string > \Closure(): string: false
+?string > \Closure(): string|int: false
+?string > callable: false
+object > none: false
+object > void: false
+object > string: false
+object > int: false
+object > bool: false
+object > string|int: false
+object > string|int|bool: false
+object > ?string: false
+object > object: true
+object > Foo: true
+object > Bar: true
+object > Foo&Bar: true
+object > \Closure(): void: true
+object > \Closure(): string: true
+object > \Closure(): string|int: true
+object > callable: false
+Foo > none: false
+Foo > void: false
+Foo > string: false
+Foo > int: false
+Foo > bool: false
+Foo > string|int: false
+Foo > string|int|bool: false
+Foo > ?string: false
+Foo > object: false
+Foo > Foo: true
+Foo > Bar: false
+Foo > Foo&Bar: true
+Foo > \Closure(): void: false
+Foo > \Closure(): string: false
+Foo > \Closure(): string|int: false
+Foo > callable: false
+Bar > none: false
+Bar > void: false
+Bar > string: false
+Bar > int: false
+Bar > bool: false
+Bar > string|int: false
+Bar > string|int|bool: false
+Bar > ?string: false
+Bar > object: false
+Bar > Foo: false
+Bar > Bar: true
+Bar > Foo&Bar: true
+Bar > \Closure(): void: false
+Bar > \Closure(): string: false
+Bar > \Closure(): string|int: false
+Bar > callable: false
+Foo&Bar > none: false
+Foo&Bar > void: false
+Foo&Bar > string: false
+Foo&Bar > int: false
+Foo&Bar > bool: false
+Foo&Bar > string|int: false
+Foo&Bar > string|int|bool: false
+Foo&Bar > ?string: false
+Foo&Bar > object: false
+Foo&Bar > Foo: false
+Foo&Bar > Bar: false
+Foo&Bar > Foo&Bar: true
+Foo&Bar > \Closure(): void: false
+Foo&Bar > \Closure(): string: false
+Foo&Bar > \Closure(): string|int: false
+Foo&Bar > callable: false
+\Closure(): void > none: false
+\Closure(): void > void: false
+\Closure(): void > string: false
+\Closure(): void > int: false
+\Closure(): void > bool: false
+\Closure(): void > string|int: false
+\Closure(): void > string|int|bool: false
+\Closure(): void > ?string: false
+\Closure(): void > object: false
+\Closure(): void > Foo: false
+\Closure(): void > Bar: false
+\Closure(): void > Foo&Bar: false
+\Closure(): void > \Closure(): void: true
+\Closure(): void > \Closure(): string: false
+\Closure(): void > \Closure(): string|int: false
+\Closure(): void > callable: false
+\Closure(): string > none: false
+\Closure(): string > void: false
+\Closure(): string > string: false
+\Closure(): string > int: false
+\Closure(): string > bool: false
+\Closure(): string > string|int: false
+\Closure(): string > string|int|bool: false
+\Closure(): string > ?string: false
+\Closure(): string > object: false
+\Closure(): string > Foo: false
+\Closure(): string > Bar: false
+\Closure(): string > Foo&Bar: false
+\Closure(): string > \Closure(): void: false
+\Closure(): string > \Closure(): string: true
+\Closure(): string > \Closure(): string|int: false
+\Closure(): string > callable: false
+\Closure(): string|int > none: false
+\Closure(): string|int > void: false
+\Closure(): string|int > string: false
+\Closure(): string|int > int: false
+\Closure(): string|int > bool: false
+\Closure(): string|int > string|int: false
+\Closure(): string|int > string|int|bool: false
+\Closure(): string|int > ?string: false
+\Closure(): string|int > object: false
+\Closure(): string|int > Foo: false
+\Closure(): string|int > Bar: false
+\Closure(): string|int > Foo&Bar: false
+\Closure(): string|int > \Closure(): void: false
+\Closure(): string|int > \Closure(): string: true
+\Closure(): string|int > \Closure(): string|int: true
+\Closure(): string|int > callable: false
+callable > none: false
+callable > void: false
+callable > string: false
+callable > int: false
+callable > bool: false
+callable > string|int: false
+callable > string|int|bool: false
+callable > ?string: false
+callable > object: false
+callable > Foo: false
+callable > Bar: false
+callable > Foo&Bar: false
+callable > \Closure(): void: true
+callable > \Closure(): string: true
+callable > \Closure(): string|int: true
+callable > callable: true

--- a/Zend/tests/closure_types/return_type.phpt
+++ b/Zend/tests/closure_types/return_type.phpt
@@ -11,7 +11,7 @@ function test($type, $value) {
     $typeColon = $type ? ': ' : '';
     $valueColon = $value ? ': ' : '';
     try {
-        eval("(function (\\Closure(){$typeColon}{$type} \$c) {})(function (){$valueColon}{$value} {});");
+        eval("(function (fn(){$typeColon}{$type} \$c) {})(function (){$valueColon}{$value} {});");
         echo 'true';
     } catch (Error $e) {
         echo 'false';
@@ -32,9 +32,9 @@ $values = [
     'Foo',
     'Bar',
     'Foo&Bar',
-    '\\Closure(): void',
-    '\\Closure(): string',
-    '\\Closure(): string|int',
+    'fn(): void',
+    'fn(): string',
+    'fn(): string|int',
     'callable',
 ];
 
@@ -58,9 +58,9 @@ none > object: true
 none > Foo: true
 none > Bar: true
 none > Foo&Bar: true
-none > \Closure(): void: true
-none > \Closure(): string: true
-none > \Closure(): string|int: true
+none > fn(): void: true
+none > fn(): string: true
+none > fn(): string|int: true
 none > callable: true
 void > none: false
 void > void: true
@@ -74,9 +74,9 @@ void > object: false
 void > Foo: false
 void > Bar: false
 void > Foo&Bar: false
-void > \Closure(): void: false
-void > \Closure(): string: false
-void > \Closure(): string|int: false
+void > fn(): void: false
+void > fn(): string: false
+void > fn(): string|int: false
 void > callable: false
 string > none: false
 string > void: false
@@ -90,9 +90,9 @@ string > object: false
 string > Foo: false
 string > Bar: false
 string > Foo&Bar: false
-string > \Closure(): void: false
-string > \Closure(): string: false
-string > \Closure(): string|int: false
+string > fn(): void: false
+string > fn(): string: false
+string > fn(): string|int: false
 string > callable: false
 int > none: false
 int > void: false
@@ -106,9 +106,9 @@ int > object: false
 int > Foo: false
 int > Bar: false
 int > Foo&Bar: false
-int > \Closure(): void: false
-int > \Closure(): string: false
-int > \Closure(): string|int: false
+int > fn(): void: false
+int > fn(): string: false
+int > fn(): string|int: false
 int > callable: false
 bool > none: false
 bool > void: false
@@ -122,9 +122,9 @@ bool > object: false
 bool > Foo: false
 bool > Bar: false
 bool > Foo&Bar: false
-bool > \Closure(): void: false
-bool > \Closure(): string: false
-bool > \Closure(): string|int: false
+bool > fn(): void: false
+bool > fn(): string: false
+bool > fn(): string|int: false
 bool > callable: false
 string|int > none: false
 string|int > void: false
@@ -138,9 +138,9 @@ string|int > object: false
 string|int > Foo: false
 string|int > Bar: false
 string|int > Foo&Bar: false
-string|int > \Closure(): void: false
-string|int > \Closure(): string: false
-string|int > \Closure(): string|int: false
+string|int > fn(): void: false
+string|int > fn(): string: false
+string|int > fn(): string|int: false
 string|int > callable: false
 string|int|bool > none: false
 string|int|bool > void: false
@@ -154,9 +154,9 @@ string|int|bool > object: false
 string|int|bool > Foo: false
 string|int|bool > Bar: false
 string|int|bool > Foo&Bar: false
-string|int|bool > \Closure(): void: false
-string|int|bool > \Closure(): string: false
-string|int|bool > \Closure(): string|int: false
+string|int|bool > fn(): void: false
+string|int|bool > fn(): string: false
+string|int|bool > fn(): string|int: false
 string|int|bool > callable: false
 ?string > none: false
 ?string > void: false
@@ -170,9 +170,9 @@ string|int|bool > callable: false
 ?string > Foo: false
 ?string > Bar: false
 ?string > Foo&Bar: false
-?string > \Closure(): void: false
-?string > \Closure(): string: false
-?string > \Closure(): string|int: false
+?string > fn(): void: false
+?string > fn(): string: false
+?string > fn(): string|int: false
 ?string > callable: false
 object > none: false
 object > void: false
@@ -186,9 +186,9 @@ object > object: true
 object > Foo: true
 object > Bar: true
 object > Foo&Bar: true
-object > \Closure(): void: true
-object > \Closure(): string: true
-object > \Closure(): string|int: true
+object > fn(): void: true
+object > fn(): string: true
+object > fn(): string|int: true
 object > callable: false
 Foo > none: false
 Foo > void: false
@@ -202,9 +202,9 @@ Foo > object: false
 Foo > Foo: true
 Foo > Bar: false
 Foo > Foo&Bar: true
-Foo > \Closure(): void: false
-Foo > \Closure(): string: false
-Foo > \Closure(): string|int: false
+Foo > fn(): void: false
+Foo > fn(): string: false
+Foo > fn(): string|int: false
 Foo > callable: false
 Bar > none: false
 Bar > void: false
@@ -218,9 +218,9 @@ Bar > object: false
 Bar > Foo: false
 Bar > Bar: true
 Bar > Foo&Bar: true
-Bar > \Closure(): void: false
-Bar > \Closure(): string: false
-Bar > \Closure(): string|int: false
+Bar > fn(): void: false
+Bar > fn(): string: false
+Bar > fn(): string|int: false
 Bar > callable: false
 Foo&Bar > none: false
 Foo&Bar > void: false
@@ -234,58 +234,58 @@ Foo&Bar > object: false
 Foo&Bar > Foo: false
 Foo&Bar > Bar: false
 Foo&Bar > Foo&Bar: true
-Foo&Bar > \Closure(): void: false
-Foo&Bar > \Closure(): string: false
-Foo&Bar > \Closure(): string|int: false
+Foo&Bar > fn(): void: false
+Foo&Bar > fn(): string: false
+Foo&Bar > fn(): string|int: false
 Foo&Bar > callable: false
-\Closure(): void > none: false
-\Closure(): void > void: false
-\Closure(): void > string: false
-\Closure(): void > int: false
-\Closure(): void > bool: false
-\Closure(): void > string|int: false
-\Closure(): void > string|int|bool: false
-\Closure(): void > ?string: false
-\Closure(): void > object: false
-\Closure(): void > Foo: false
-\Closure(): void > Bar: false
-\Closure(): void > Foo&Bar: false
-\Closure(): void > \Closure(): void: true
-\Closure(): void > \Closure(): string: false
-\Closure(): void > \Closure(): string|int: false
-\Closure(): void > callable: false
-\Closure(): string > none: false
-\Closure(): string > void: false
-\Closure(): string > string: false
-\Closure(): string > int: false
-\Closure(): string > bool: false
-\Closure(): string > string|int: false
-\Closure(): string > string|int|bool: false
-\Closure(): string > ?string: false
-\Closure(): string > object: false
-\Closure(): string > Foo: false
-\Closure(): string > Bar: false
-\Closure(): string > Foo&Bar: false
-\Closure(): string > \Closure(): void: false
-\Closure(): string > \Closure(): string: true
-\Closure(): string > \Closure(): string|int: false
-\Closure(): string > callable: false
-\Closure(): string|int > none: false
-\Closure(): string|int > void: false
-\Closure(): string|int > string: false
-\Closure(): string|int > int: false
-\Closure(): string|int > bool: false
-\Closure(): string|int > string|int: false
-\Closure(): string|int > string|int|bool: false
-\Closure(): string|int > ?string: false
-\Closure(): string|int > object: false
-\Closure(): string|int > Foo: false
-\Closure(): string|int > Bar: false
-\Closure(): string|int > Foo&Bar: false
-\Closure(): string|int > \Closure(): void: false
-\Closure(): string|int > \Closure(): string: true
-\Closure(): string|int > \Closure(): string|int: true
-\Closure(): string|int > callable: false
+fn(): void > none: false
+fn(): void > void: false
+fn(): void > string: false
+fn(): void > int: false
+fn(): void > bool: false
+fn(): void > string|int: false
+fn(): void > string|int|bool: false
+fn(): void > ?string: false
+fn(): void > object: false
+fn(): void > Foo: false
+fn(): void > Bar: false
+fn(): void > Foo&Bar: false
+fn(): void > fn(): void: true
+fn(): void > fn(): string: false
+fn(): void > fn(): string|int: false
+fn(): void > callable: false
+fn(): string > none: false
+fn(): string > void: false
+fn(): string > string: false
+fn(): string > int: false
+fn(): string > bool: false
+fn(): string > string|int: false
+fn(): string > string|int|bool: false
+fn(): string > ?string: false
+fn(): string > object: false
+fn(): string > Foo: false
+fn(): string > Bar: false
+fn(): string > Foo&Bar: false
+fn(): string > fn(): void: false
+fn(): string > fn(): string: true
+fn(): string > fn(): string|int: false
+fn(): string > callable: false
+fn(): string|int > none: false
+fn(): string|int > void: false
+fn(): string|int > string: false
+fn(): string|int > int: false
+fn(): string|int > bool: false
+fn(): string|int > string|int: false
+fn(): string|int > string|int|bool: false
+fn(): string|int > ?string: false
+fn(): string|int > object: false
+fn(): string|int > Foo: false
+fn(): string|int > Bar: false
+fn(): string|int > Foo&Bar: false
+fn(): string|int > fn(): void: false
+fn(): string|int > fn(): string: true
+fn(): string|int > fn(): string|int: true
+fn(): string|int > callable: false
 callable > none: false
 callable > void: false
 callable > string: false
@@ -298,7 +298,7 @@ callable > object: false
 callable > Foo: false
 callable > Bar: false
 callable > Foo&Bar: false
-callable > \Closure(): void: true
-callable > \Closure(): string: true
-callable > \Closure(): string|int: true
+callable > fn(): void: true
+callable > fn(): string: true
+callable > fn(): string|int: true
 callable > callable: true

--- a/Zend/tests/closure_types/return_type.phpt
+++ b/Zend/tests/closure_types/return_type.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Closure type return type covariance
+Closure type return type check
 --FILE--
 <?php
 

--- a/Zend/tests/closure_types/syntax.phpt
+++ b/Zend/tests/closure_types/syntax.phpt
@@ -39,6 +39,7 @@ test('fn(Foo, Bar,)');
 test('fn ()');
 test('fn(Foo&)');
 test('fn(Foo&, Bar)');
+test('fn(Foo&Bar&)');
 test('fn(Foo...)');
 test('fn(Foo&...)');
 test('fn(,)');
@@ -90,6 +91,8 @@ fn(Foo&)
 fn(Foo&)
 fn(Foo&, Bar)
 fn(Foo&, Bar)
+fn(Foo&Bar&)
+fn(Foo&Bar&)
 fn(Foo...)
 fn(Foo...)
 fn(Foo&...)

--- a/Zend/tests/closure_types/syntax.phpt
+++ b/Zend/tests/closure_types/syntax.phpt
@@ -38,7 +38,7 @@ test('fn(Foo, Bar)');
 test('fn(Foo, Bar,)');
 test('fn ()');
 test('fn(Foo&)');
-test('fn(Foo, Bar&)');
+test('fn(Foo&, Bar)');
 test('fn(Foo...)');
 test('fn(Foo&...)');
 test('fn(,)');
@@ -86,14 +86,14 @@ fn(Foo, Bar)
 fn(Foo, Bar)
 fn()
 fn()
-syntax error, unexpected token ")"
-syntax error, unexpected token ")"
-syntax error, unexpected token ")"
-syntax error, unexpected token ")"
+fn(Foo&)
+fn(Foo&)
+fn(Foo&, Bar)
+fn(Foo&, Bar)
 fn(Foo...)
 fn(Foo...)
-syntax error, unexpected token "&", expecting ")"
-syntax error, unexpected token "&", expecting ")"
+fn(Foo&...)
+fn(Foo&...)
 syntax error, unexpected token ","
 syntax error, unexpected token ","
 syntax error, unexpected token ":"

--- a/Zend/tests/closure_types/syntax.phpt
+++ b/Zend/tests/closure_types/syntax.phpt
@@ -18,86 +18,86 @@ function test(string $closureType) {
     }
 }
 
-test('\\Closure()');
-test('\\Closure(): void');
-test('\\Closure(): string');
-test('\\Closure(): int|bool');
-test('\\Closure(): \\Closure(): void');
-test('\\Closure(\Closure())');
-test('\\Closure(): ?float');
-test('\\Closure(): Foo&Bar');
-test('\\Closure(): Foo|Bar');
-test('\\Closure(int)');
-test('\\Closure(string)');
-test('\\Closure(float)');
-test('\\Closure(array)');
-test('\\Closure(object)');
-test('\\Closure(bool)');
-test('\\Closure(Foo)');
-test('\\Closure(Foo, Bar)');
-test('\\Closure(Foo, Bar,)');
-test('\\Closure ()');
-test('\\Closure(Foo&)');
-test('\\Closure(Foo, Bar&)');
-test('\\Closure(Foo...)');
-test('\\Closure(Foo&...)');
-test('\\Closure(,)');
-test('\\Closure: int');
-test('\\Closure(): ');
-test('\\Closure(');
+test('fn()');
+test('fn(): void');
+test('fn(): string');
+test('fn(): int|bool');
+test('fn(): fn(): void');
+test('fn(fn())');
+test('fn(): ?float');
+test('fn(): Foo&Bar');
+test('fn(): Foo|Bar');
+test('fn(int)');
+test('fn(string)');
+test('fn(float)');
+test('fn(array)');
+test('fn(object)');
+test('fn(bool)');
+test('fn(Foo)');
+test('fn(Foo, Bar)');
+test('fn(Foo, Bar,)');
+test('fn ()');
+test('fn(Foo&)');
+test('fn(Foo, Bar&)');
+test('fn(Foo...)');
+test('fn(Foo&...)');
+test('fn(,)');
+test('fn: int');
+test('fn(): ');
+test('fn(');
 
 ?>
 --EXPECT--
-\Closure()
-\Closure()
-\Closure(): void
-\Closure(): void
-\Closure(): string
-\Closure(): string
-\Closure(): int|bool
-\Closure(): int|bool
-\Closure(): \Closure(): void
-\Closure(): \Closure(): void
-\Closure(\Closure())
-\Closure(\Closure())
-\Closure(): ?float
-\Closure(): ?float
-\Closure(): Foo&Bar
-\Closure(): Foo&Bar
-\Closure(): Foo|Bar
-\Closure(): Foo|Bar
-\Closure(int)
-\Closure(int)
-\Closure(string)
-\Closure(string)
-\Closure(float)
-\Closure(float)
-\Closure(array)
-\Closure(array)
-\Closure(object)
-\Closure(object)
-\Closure(bool)
-\Closure(bool)
-\Closure(Foo)
-\Closure(Foo)
-\Closure(Foo, Bar)
-\Closure(Foo, Bar)
-\Closure(Foo, Bar)
-\Closure(Foo, Bar)
-\Closure()
-\Closure()
+fn()
+fn()
+fn(): void
+fn(): void
+fn(): string
+fn(): string
+fn(): int|bool
+fn(): int|bool
+fn(): fn(): void
+fn(): fn(): void
+fn(fn())
+fn(fn())
+fn(): ?float
+fn(): ?float
+fn(): Foo&Bar
+fn(): Foo&Bar
+fn(): Foo|Bar
+fn(): Foo|Bar
+fn(int)
+fn(int)
+fn(string)
+fn(string)
+fn(float)
+fn(float)
+fn(array)
+fn(array)
+fn(object)
+fn(object)
+fn(bool)
+fn(bool)
+fn(Foo)
+fn(Foo)
+fn(Foo, Bar)
+fn(Foo, Bar)
+fn(Foo, Bar)
+fn(Foo, Bar)
+fn()
+fn()
 syntax error, unexpected token ")"
 syntax error, unexpected token ")"
 syntax error, unexpected token ")"
 syntax error, unexpected token ")"
-\Closure(Foo...)
-\Closure(Foo...)
+fn(Foo...)
+fn(Foo...)
 syntax error, unexpected token "&", expecting ")"
 syntax error, unexpected token "&", expecting ")"
 syntax error, unexpected token ","
 syntax error, unexpected token ","
-syntax error, unexpected token ":", expecting variable
-syntax error, unexpected token ":", expecting "{"
+syntax error, unexpected token ":"
+syntax error, unexpected token ":"
 syntax error, unexpected variable "$c"
 syntax error, unexpected token "{"
 syntax error, unexpected variable "$c"

--- a/Zend/tests/closure_types/syntax.phpt
+++ b/Zend/tests/closure_types/syntax.phpt
@@ -23,6 +23,7 @@ test('\\Closure(): void');
 test('\\Closure(): string');
 test('\\Closure(): int|bool');
 test('\\Closure(): \\Closure(): void');
+test('\\Closure(\Closure())');
 test('\\Closure(): ?float');
 test('\\Closure(): Foo&Bar');
 test('\\Closure(): Foo|Bar');
@@ -57,6 +58,8 @@ test('\\Closure(');
 \Closure(): int|bool
 \Closure(): \Closure(): void
 \Closure(): \Closure(): void
+\Closure(\Closure())
+\Closure(\Closure())
 \Closure(): ?float
 \Closure(): ?float
 \Closure(): Foo&Bar
@@ -83,14 +86,14 @@ test('\\Closure(');
 \Closure(Foo, Bar)
 \Closure()
 \Closure()
-\Closure(Foo&)
-\Closure(Foo&)
-\Closure(Foo, Bar&)
-\Closure(Foo, Bar&)
+syntax error, unexpected token ")"
+syntax error, unexpected token ")"
+syntax error, unexpected token ")"
+syntax error, unexpected token ")"
 \Closure(Foo...)
 \Closure(Foo...)
-\Closure(Foo&...)
-\Closure(Foo&...)
+syntax error, unexpected token "&", expecting ")"
+syntax error, unexpected token "&", expecting ")"
 syntax error, unexpected token ","
 syntax error, unexpected token ","
 syntax error, unexpected token ":", expecting variable

--- a/Zend/tests/closure_types/syntax.phpt
+++ b/Zend/tests/closure_types/syntax.phpt
@@ -1,0 +1,101 @@
+--TEST--
+Closure type syntax
+--FILE--
+<?php
+
+function test(string $closureType) {
+    try {
+        eval("(function ($closureType \$c) {})(42);");
+    } catch (\Error $e) {
+        preg_match('(Argument #1 \\(\\$c\\) must be of type (?<type>.*), int given)', $e->getMessage(), $matches);
+        echo $matches['type'] ?? $e->getMessage(), "\n";
+    }
+    try {
+        eval("(function (): $closureType { return 42; })();");
+    } catch (\Error $e) {
+        preg_match('(^\\{closure\\}\\(\\): Return value must be of type (?<type>.*), int returned$)', $e->getMessage(), $matches);
+        echo $matches['type'] ?? $e->getMessage(), "\n";
+    }
+}
+
+test('\\Closure()');
+test('\\Closure(): void');
+test('\\Closure(): string');
+test('\\Closure(): int|bool');
+test('\\Closure(): \\Closure(): void');
+test('\\Closure(): ?float');
+test('\\Closure(): Foo&Bar');
+test('\\Closure(): Foo|Bar');
+test('\\Closure(int)');
+test('\\Closure(string)');
+test('\\Closure(float)');
+test('\\Closure(array)');
+test('\\Closure(object)');
+test('\\Closure(bool)');
+test('\\Closure(Foo)');
+test('\\Closure(Foo, Bar)');
+test('\\Closure(Foo, Bar,)');
+test('\\Closure ()');
+test('\\Closure(Foo&)');
+test('\\Closure(Foo, Bar&)');
+test('\\Closure(Foo...)');
+test('\\Closure(Foo&...)');
+test('\\Closure(,)');
+test('\\Closure: int');
+test('\\Closure(): ');
+test('\\Closure(');
+
+?>
+--EXPECT--
+\Closure()
+\Closure()
+\Closure(): void
+\Closure(): void
+\Closure(): string
+\Closure(): string
+\Closure(): int|bool
+\Closure(): int|bool
+\Closure(): \Closure(): void
+\Closure(): \Closure(): void
+\Closure(): ?float
+\Closure(): ?float
+\Closure(): Foo&Bar
+\Closure(): Foo&Bar
+\Closure(): Foo|Bar
+\Closure(): Foo|Bar
+\Closure(int)
+\Closure(int)
+\Closure(string)
+\Closure(string)
+\Closure(float)
+\Closure(float)
+\Closure(array)
+\Closure(array)
+\Closure(object)
+\Closure(object)
+\Closure(bool)
+\Closure(bool)
+\Closure(Foo)
+\Closure(Foo)
+\Closure(Foo, Bar)
+\Closure(Foo, Bar)
+\Closure(Foo, Bar)
+\Closure(Foo, Bar)
+\Closure()
+\Closure()
+\Closure(Foo&)
+\Closure(Foo&)
+\Closure(Foo, Bar&)
+\Closure(Foo, Bar&)
+\Closure(Foo...)
+\Closure(Foo...)
+\Closure(Foo&...)
+\Closure(Foo&...)
+syntax error, unexpected token ","
+syntax error, unexpected token ","
+syntax error, unexpected token ":", expecting variable
+syntax error, unexpected token ":", expecting "{"
+syntax error, unexpected variable "$c"
+syntax error, unexpected token "{"
+syntax error, unexpected variable "$c"
+syntax error, unexpected token "{"

--- a/Zend/tests/closure_types/variadic_ref.phpt
+++ b/Zend/tests/closure_types/variadic_ref.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Closure type param can be variadic and by-ref
+--FILE--
+<?php
+
+function test(\Closure(string&...): void $closure) {}
+
+?>
+--EXPECT--

--- a/Zend/tests/closure_types/variadic_ref.phpt
+++ b/Zend/tests/closure_types/variadic_ref.phpt
@@ -6,5 +6,4 @@ Closure type param can be variadic and by-ref
 function test(fn(string&...): void $closure) {}
 
 ?>
---EXPECTF--
-Parse error: syntax error, unexpected token "&", expecting ")" in %s on line %d
+--EXPECT--

--- a/Zend/tests/closure_types/variadic_ref.phpt
+++ b/Zend/tests/closure_types/variadic_ref.phpt
@@ -6,4 +6,5 @@ Closure type param can be variadic and by-ref
 function test(\Closure(string&...): void $closure) {}
 
 ?>
---EXPECT--
+--EXPECTF--
+Parse error: syntax error, unexpected token "&", expecting ")" in %s on line %d

--- a/Zend/tests/closure_types/variadic_ref.phpt
+++ b/Zend/tests/closure_types/variadic_ref.phpt
@@ -3,7 +3,7 @@ Closure type param can be variadic and by-ref
 --FILE--
 <?php
 
-function test(\Closure(string&...): void $closure) {}
+function test(fn(string&...): void $closure) {}
 
 ?>
 --EXPECTF--

--- a/Zend/tests/closure_types/variance.phpt
+++ b/Zend/tests/closure_types/variance.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Closure type covariance
+Closure type variance
 --FILE--
 <?php
 

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -149,6 +149,7 @@ enum _zend_ast_kind {
 	ZEND_AST_MATCH,
 	ZEND_AST_MATCH_ARM,
 	ZEND_AST_NAMED_ARG,
+	ZEND_AST_TYPE_CALLABLE,
 
 	/* 3 child nodes */
 	ZEND_AST_METHOD_CALL = 3 << ZEND_AST_NUM_CHILDREN_SHIFT,
@@ -164,7 +165,6 @@ enum _zend_ast_kind {
 
 	// Pseudo node for initializing enums
 	ZEND_AST_CONST_ENUM_INIT,
-	ZEND_AST_TYPE_CALLABLE,
 
 	/* 4 child nodes */
 	ZEND_AST_FOR = 4 << ZEND_AST_NUM_CHILDREN_SHIFT,

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -164,6 +164,7 @@ enum _zend_ast_kind {
 
 	// Pseudo node for initializing enums
 	ZEND_AST_CONST_ENUM_INIT,
+	ZEND_AST_TYPE_CALLABLE,
 
 	/* 4 child nodes */
 	ZEND_AST_FOR = 4 << ZEND_AST_NUM_CHILDREN_SHIFT,

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1199,7 +1199,7 @@ zend_string *zend_type_to_string_resolved(zend_type type, zend_class_entry *scop
 		zend_closure_type *closure_type = ZEND_TYPE_CLOSURE(type);
 
 		smart_str ss = {0};
-		smart_str_appends(&ss, "\\Closure(");
+		smart_str_appends(&ss, "fn(");
 
 		for (uint32_t i = 0; i < closure_type->num_params; i++) {
 			zend_closure_param_type param_type = closure_type->param_types[i];
@@ -6366,9 +6366,7 @@ static zend_type zend_compile_typename(
 		/* Inform that the type list is an intersection type */
 		ZEND_TYPE_FULL_MASK(type) |= _ZEND_TYPE_INTERSECTION_BIT;
 	} else if (ast->kind == ZEND_AST_TYPE_CALLABLE) {
-		// FIXME: Assert \Closure
-		// zend_ast *class_name_ast = ast->child[0];
-		zend_ast_list *param_list = zend_ast_get_list(ast->child[1]);
+		zend_ast_list *param_list = zend_ast_get_list(ast->child[0]);
 		zend_closure_type *closure_type = zend_arena_alloc(&CG(arena), ZEND_TYPE_CLOSURE_SIZE(param_list->children));
 
 		bool variadic = false;
@@ -6390,7 +6388,7 @@ static zend_type zend_compile_typename(
 		}
 		closure_type->variadic = variadic;
 
-		zend_ast *return_type_ast = ast->child[2];
+		zend_ast *return_type_ast = ast->child[1];
 		closure_type->return_type = return_type_ast != NULL
 			? zend_compile_typename(return_type_ast, /* force_allow_null */ false)
 			: (zend_type) ZEND_TYPE_INIT_NONE(0);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1073,7 +1073,7 @@ static zend_always_inline bool zend_check_type_slow(
 			}
 
 			zend_closure_type *closure_type = ZEND_TYPE_CLOSURE(*type);
-			zend_function *closure = zend_get_closure_method_def(Z_OBJ_P(arg));
+			const zend_function *closure = zend_get_closure_method_def(Z_OBJ_P(arg));
 			zend_class_entry *scope = closure->common.scope;
 
 			/* The variadic argument is not included in the stored argument count. */

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1067,7 +1067,7 @@ static zend_always_inline bool zend_check_type_slow(
 					}
 				} ZEND_TYPE_LIST_FOREACH_END();
 			}
-		} if (UNEXPECTED(ZEND_TYPE_IS_CLOSURE(*type))) {
+		} else if (UNEXPECTED(ZEND_TYPE_IS_CLOSURE(*type))) {
 			if (Z_OBJCE_P(arg) != zend_ce_closure) {
 				return false;
 			}

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -635,7 +635,7 @@ ZEND_API inheritance_status zend_perform_covariant_type_check(
 			return status;
 		}
 		return INHERITANCE_ERROR;
-	} if (ZEND_TYPE_IS_INTERSECTION(fe_type)) {
+	} else if (ZEND_TYPE_IS_INTERSECTION(fe_type)) {
 		/* Currently, for object type any class name would be allowed here.
 		 * We still perform a class lookup for forward-compatibility reasons,
 		 * as we may have named types in the future that are not classes

--- a/Zend/zend_inheritance.h
+++ b/Zend/zend_inheritance.h
@@ -24,6 +24,16 @@
 
 BEGIN_EXTERN_C()
 
+/* Unresolved means that class declarations that are currently not available are needed to
+ * determine whether the inheritance is valid or not. At runtime UNRESOLVED should be treated
+ * as an ERROR. */
+typedef enum {
+	INHERITANCE_UNRESOLVED = -1,
+	INHERITANCE_ERROR = 0,
+	INHERITANCE_WARNING = 1,
+	INHERITANCE_SUCCESS = 2,
+} inheritance_status;
+
 ZEND_API void zend_do_implement_interface(zend_class_entry *ce, zend_class_entry *iface);
 ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *parent_ce, bool checked);
 
@@ -35,6 +45,10 @@ ZEND_API zend_class_entry *zend_do_link_class(zend_class_entry *ce, zend_string 
 void zend_verify_abstract_class(zend_class_entry *ce);
 void zend_build_properties_info_table(zend_class_entry *ce);
 ZEND_API zend_class_entry *zend_try_early_bind(zend_class_entry *ce, zend_class_entry *parent_ce, zend_string *lcname, zval *delayed_early_binding);
+
+ZEND_API inheritance_status zend_perform_covariant_type_check(
+	zend_class_entry *fe_scope, zend_type fe_type,
+	zend_class_entry *proto_scope, zend_type proto_type);
 
 ZEND_API extern zend_class_entry* (*zend_inheritance_cache_get)(zend_class_entry *ce, zend_class_entry *parent, zend_class_entry **traits_and_interfaces);
 ZEND_API extern zend_class_entry* (*zend_inheritance_cache_add)(zend_class_entry *ce, zend_class_entry *proto, zend_class_entry *parent, zend_class_entry **traits_and_interfaces, HashTable *dependencies);

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -883,8 +883,8 @@ closure_type_param_is_reference:
 ;
 
 closure_type_param:
-		type_without_static closure_type_param_is_reference is_variadic
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2 | $3, $1, NULL, NULL, NULL, NULL); }
+		type_expr_without_static is_variadic
+			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2, $1, NULL, NULL, NULL, NULL); }
 ;
 
 union_type_without_static:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -844,10 +844,10 @@ type_without_static:
 ;
 
 closure_type:
-		name closure_type_param_list
-					{ $$ = zend_ast_create(ZEND_AST_TYPE_CALLABLE, $1, $2, NULL); }
-	|	name closure_type_param_list ':' type_expr_without_static
-					{ $$ = zend_ast_create(ZEND_AST_TYPE_CALLABLE, $1, $2, $4); }
+		T_FN closure_type_param_list
+					{ $$ = zend_ast_create(ZEND_AST_TYPE_CALLABLE, $2, NULL); }
+	|	T_FN closure_type_param_list ':' type_expr_without_static
+					{ $$ = zend_ast_create(ZEND_AST_TYPE_CALLABLE, $2, $4); }
 ;
 
 closure_type_param_list:

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -284,7 +284,6 @@ static YYSIZE_T zend_yytnamerr(char*, const char*);
 %type <num> method_modifiers non_empty_member_modifiers member_modifier
 %type <num> optional_property_modifiers property_modifier
 %type <num> class_modifiers class_modifier use_type backup_fn_flags
-%type <num> closure_type_param_is_reference
 
 %type <ptr> backup_lex_pos
 %type <str> backup_doc_comment closure_type_param_list_cast 
@@ -876,15 +875,9 @@ non_empty_closure_type_param_list:
 			{ $$ = zend_ast_list_add($1, $3); }
 ;
 
-closure_type_param_is_reference:
-		%empty	{ $$ = 0; }
-	|	T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG	{ $$ = ZEND_PARAM_REF; }
-	|	T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG	{ $$ = ZEND_PARAM_REF; }
-;
-
 closure_type_param:
-		type_expr_without_static is_variadic
-			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2, $1, NULL, NULL, NULL, NULL); }
+		type_expr_without_static is_reference is_variadic
+			{ $$ = zend_ast_create_ex(ZEND_AST_PARAM, $2|$3, $1, NULL, NULL, NULL, NULL); }
 ;
 
 union_type_without_static:

--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1875,7 +1875,11 @@ NEWLINE ("\r"|"\n"|"\r\n")
 	RETURN_TOKEN(T_SR);
 }
 
-<ST_IN_SCRIPTING>"&"[ \t\r\n]*("$"|"...") {
+/*
+ * We also allow the & to be followed by ","|")" for closure type params which aren't actually followed by a variable,
+ * e.g. fn(string &, int &).
+ */
+<ST_IN_SCRIPTING>"&"[ \t\r\n]*("$"|"..."|","|")") {
 	yyless(1);
 	RETURN_TOKEN(T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG);
 }

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -120,6 +120,15 @@ ZEND_API void zend_type_release(zend_type type, bool persistent) {
 		}
 	} else if (ZEND_TYPE_HAS_NAME(type)) {
 		zend_string_release(ZEND_TYPE_NAME(type));
+	} else if (ZEND_TYPE_IS_CLOSURE(type)) {
+		zend_closure_type *closure_type = ZEND_TYPE_CLOSURE(type);
+		zend_type_release(closure_type->return_type, persistent);
+		for (uint32_t i = 0; i < closure_type->num_params; i++) {
+			zend_type_release(closure_type->param_types[i].type, persistent);
+		}
+		if (!ZEND_TYPE_USES_ARENA(type)) {
+			pefree(closure_type, persistent);
+		}
 	}
 }
 

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -138,12 +138,25 @@ typedef struct {
 	zend_type types[1];
 } zend_type_list;
 
+typedef struct {
+	bool by_ref;
+	zend_type type;
+} zend_closure_param_type;
+
+typedef struct {
+	zend_type return_type;
+	bool variadic;
+	uint32_t num_params;
+	zend_closure_param_type param_types[1];
+} zend_closure_type;
+
 #define _ZEND_TYPE_EXTRA_FLAGS_SHIFT 25
 #define _ZEND_TYPE_MASK ((1u << 25) - 1)
 /* Only one of these bits may be set. */
 #define _ZEND_TYPE_NAME_BIT (1u << 24)
+#define _ZEND_TYPE_CLOSURE_BIT (1u << 23)
 #define _ZEND_TYPE_LIST_BIT (1u << 22)
-#define _ZEND_TYPE_KIND_MASK (_ZEND_TYPE_LIST_BIT|_ZEND_TYPE_NAME_BIT)
+#define _ZEND_TYPE_KIND_MASK (_ZEND_TYPE_LIST_BIT|_ZEND_TYPE_NAME_BIT|_ZEND_TYPE_CLOSURE_BIT)
 /* For BC behaviour with iterable type */
 #define _ZEND_TYPE_ITERABLE_BIT (1u << 21)
 /* Whether the type list is arena allocated */
@@ -179,6 +192,12 @@ typedef struct {
 
 #define ZEND_TYPE_IS_UNION(t) \
 	((((t).type_mask) & _ZEND_TYPE_UNION_BIT) != 0)
+
+#define ZEND_TYPE_IS_CLOSURE(t) \
+	((((t).type_mask) & _ZEND_TYPE_CLOSURE_BIT) != 0)
+
+#define ZEND_TYPE_CLOSURE(t) \
+	((zend_closure_type *) (t).ptr)
 
 #define ZEND_TYPE_USES_ARENA(t) \
 	((((t).type_mask) & _ZEND_TYPE_ARENA_BIT) != 0)
@@ -288,6 +307,12 @@ typedef struct {
 
 #define ZEND_TYPE_INIT_CLASS_CONST_MASK(class_name, type_mask) \
 	ZEND_TYPE_INIT_PTR_MASK(class_name, _ZEND_TYPE_NAME_BIT | (type_mask))
+
+#define ZEND_TYPE_INIT_CLOSURE(ptr, extra_flags) \
+	{ (void *) (ptr), _ZEND_TYPE_CLOSURE_BIT | (extra_flags) }
+
+#define ZEND_TYPE_CLOSURE_SIZE(num_params) \
+	(sizeof(zend_closure_type) + (num_params) * sizeof(zend_closure_param_type) - sizeof(zend_closure_param_type))
 
 typedef union _zend_value {
 	zend_long         lval;				/* long value */


### PR DESCRIPTION
**NOTE**: The code is very much WIP and not review-worthy.

RFC will follow soon.

- [ ] Fix by-ref (can be stored in zend_type, remove zend_closure_param_type)
- [ ] Support for optional params `fn (int=)` (so that type of superfluous arg doesn't clash)
- [ ] `self` in closure type
- [ ] OPCache support (calc/persist `zend_closure_type`, JIT probably)
- [ ] Cache Slot support (for looking up classes in params/return types)
- [ ] Remove test redundancy, verify expectations
- [ ] Allow parameter names? Some types like `bool` are very nondescript.
- [ ] Allow closure types to be nullable
- [ ] Remove code duplication
- [x] Typealiases will be proposed in a separate RFC (`typealias Mapper = fn(mixed): mixed;`)

Ideas:

- [ ] Add "return type inference"

```php
function mapToInt(
    array $array,
    fn(mixed): int $closure
) {
    ...
}

// Allow no return type but store the required return type in the closure, verify when calling the closure.
mapToInt(fn() => 42);
```

This way, the return type doesn't have to be specified explicitly every time just because the closure type defines it (closures are meant to be short and most languages can infer the types). Param types never have to be specified as they are contravariant. Passing the closure to multiple params with a closure type (or returning from functions with a closure type return type) would narrow the return type by `&` of the two types. This would also mean that:

```php
function closureReturningInt(
    fn(): int $c,
) {}

function closureReturningString(
    fn(): string $c,
) {}

$c = function () { return 42; }
closureReturningInt($c);
closureReturningString($c);
$c();
```

Would always fail when calling `$c` as the inferred return type of `int&string` would essentially be equivalent to `never`.