### PR TITLE
Fix redundant ZSTR_VAL condition in php_date.c

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -477,7 +477,7 @@ timelib_tzinfo *php_date_parse_tzfile_wrapper(const char *formal_tzname, const t
 /* {{{ static PHP_INI_MH(OnUpdate_date_timezone) */
 static PHP_INI_MH(OnUpdate_date_timezone)
 {
-	if (new_value && ZSTR_VAL(new_value) && !timelib_timezone_id_is_valid(ZSTR_VAL(new_value), DATE_TIMEZONEDB)) {
+	if (new_value && !timelib_timezone_id_is_valid(ZSTR_VAL(new_value), DATE_TIMEZONEDB)) {
 		php_error_docref(
 			NULL, E_WARNING,
 			"Invalid date.timezone value '%s', using '%s' instead",


### PR DESCRIPTION
ZSTR_VAL can never be NULL as zend_string.val is a char[1] which will
always decay to a non-nullable pointer.

This fails with -Werror on newer gcc versions.

/cc @derickr 