### PR TITLE
Add clean_module_functions()

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3033,6 +3033,7 @@ void module_destructor(zend_module_entry *module) /* {{{ */
 	module->module_started=0;
 	if (module->type == MODULE_TEMPORARY && module->functions) {
 		zend_unregister_functions(module->functions, -1, NULL);
+		/* Clean functions registered separately from module->functions */
 		clean_module_functions(module);
 	}
 

--- a/ext/dl_test/dl_test.c
+++ b/ext/dl_test/dl_test.c
@@ -52,6 +52,23 @@ PHP_FUNCTION(dl_test_test2)
 }
 /* }}}*/
 
+/* {{{ PHP_DL_TEST_USE_REGISTER_FUNCTIONS_DIRECTLY */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dl_test_use_register_functions_directly, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+PHP_FUNCTION(dl_test_use_register_functions_directly)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	RETURN_STRING("OK");
+}
+
+static const zend_function_entry php_dl_test_use_register_functions_directly_functions[] = {
+	ZEND_FENTRY(dl_test_use_register_functions_directly, ZEND_FN(dl_test_use_register_functions_directly), arginfo_dl_test_use_register_functions_directly,  0)
+	ZEND_FE_END
+};
+/* }}} */
+
 /* {{{ INI */
 PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("dl_test.long",      "0", PHP_INI_ALL, OnUpdateLong,       long_value,       zend_dl_test_globals, dl_test_globals)
@@ -67,6 +84,10 @@ PHP_MINIT_FUNCTION(dl_test)
 		zend_register_ini_entries(ini_entries, module_number);
 	} else {
 		REGISTER_INI_ENTRIES();
+	}
+
+	if (getenv("PHP_DL_TEST_USE_REGISTER_FUNCTIONS_DIRECTLY")) {
+		zend_register_functions(NULL, php_dl_test_use_register_functions_directly_functions, NULL, type);
 	}
 
 	return SUCCESS;

--- a/ext/dl_test/tests/dl-use_register_functions_directly.phpt
+++ b/ext/dl_test/tests/dl-use_register_functions_directly.phpt
@@ -1,0 +1,25 @@
+--TEST--
+dl(): use zend_register_functions() directly
+--ENV--
+PHP_DL_TEST_USE_REGISTER_FUNCTIONS_DIRECTLY=1
+--SKIPIF--
+<?php require __DIR__ . "/skip.inc"; ?>
+--FILE--
+<?php
+
+if (extension_loaded('dl_test')) {
+    exit('Error: dl_test is already loaded');
+}
+
+if (PHP_OS_FAMILY === 'Windows') {
+    $loaded = dl('php_dl_test.dll');
+} else {
+    $loaded = dl('dl_test.so');
+}
+
+var_dump($loaded);
+var_dump(dl_test_use_register_functions_directly());
+?>
+--EXPECT--
+bool(true)
+string(2) "OK"

--- a/ext/standard/tests/general_functions/dl-use_register_functions_directly.phpt
+++ b/ext/standard/tests/general_functions/dl-use_register_functions_directly.phpt
@@ -3,7 +3,7 @@ dl(): use zend_register_functions() directly
 --ENV--
 PHP_DL_TEST_USE_REGISTER_FUNCTIONS_DIRECTLY=1
 --SKIPIF--
-<?php require __DIR__ . "/skip.inc"; ?>
+<?php require dirname(__DIR__, 3) . "/dl_test/tests/skip.inc"; ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
Add clean_module_functions() to clean functions which are registered by zend_register_functions().
The general logic of clean_module_functions() is consistent with clean_module_classes().