### PR TITLE
Escape problematic characters in CREDITS files

### DIFF
--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -1098,7 +1098,7 @@ function generate_version_info_resource(makefiletarget, basename, creditspath, s
 		if (thanks == null) {
 			thanks = "";
 		} else {
-			thanks = "Thanks to " + thanks;
+			thanks = "Thanks to " + thanks.replace(/([<>&|%])/g, "^$1").replace(/"/g, '\\"\\"');
 		}
 		credits.Close();
 	}


### PR DESCRIPTION
On Windows, the contents of the CREDITS files are passed to rc.exe via
the command line.  To avoid undesired behavior, we need to escape some
characters, most notably `<` (which is sometimes used in CREDITS to
enclose mail addresses), which otherwise is interpreted as redirection
operator, resulting in the hard to understand "The system cannot find
the file specified."

Even more dangerous is not properly escaping percent signs, which makes
it possible for a malicious CREDITS file to inject the values of
environment variables of the build system into the generated binaries.
This is particularly bad, because as of Windows Vista, the comments can
no longer be inspected via explorer.exe, although the binaries still
contain these comments.

We also cater to double-quotes, which need to be escaped as `\"\"` in
this context.

---

If we don't want to allow these characters in CREDITS, it would still make sense to explicitly error out, telling developers to remove these characters.

Note that I haven't been able to figure out how to properly deal with non ASCII UTF-8 characters (I assume that most CREDITS files are UTF-8 encoded nowadays). That appears to be a minor issue, though, since the comments are not visible via explorer.exe anyway.

cc @asgrim