### PR TITLE
Fix GH-8778: Integer arithmethic with large number variants fails

### DIFF
--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -453,7 +453,11 @@ static int com_object_cast(zend_object *readobj, zval *writeobj, int type)
 	switch(type) {
 		case IS_LONG:
 		case _IS_NUMBER:
-			vt = VT_INT;
+#if SIZEOF_ZEND_LONG == 4
+			vt = VT_I4;
+#else
+			vt = VT_I8;
+#endif
 			break;
 		case IS_DOUBLE:
 			vt = VT_R8;

--- a/ext/com_dotnet/tests/gh8778.phpt
+++ b/ext/com_dotnet/tests/gh8778.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug GH-8778 (Integer arithmethic with large number variants fails)
+--SKIPIF--
+<?php
+if (!extension_loaded("com_dotnet")) die("skip com_dotnet extension not available");
+if (PHP_INT_SIZE < 8) die("skip for 64bit only");
+?>
+--FILE--
+<?php
+$int = 0x100000000;
+var_dump(
+    $int,
+    new variant($int) + 1
+);
+?>
+--EXPECT--
+int(4294967296)
+int(4294967297)


### PR DESCRIPTION
When casting a `variant` to `int`, we need to heed the proper `zval`
type, which is an signed 64bit integer on x64, while `VT_INT` is only
a signed 32bit integer.