### PR TITLE
Fix bug #67764: fpm: syslog.ident does not work

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,9 @@ PHP                                                                        NEWS
   . Fixed bug #78139 (timezone_open accepts invalid timezone string argument).
     (Derick)
 
+- FPM:
+  . Fixed bug #67764 (fpm: syslog.ident don't work). (Jakub Zelenka)
+
 - MBString:
   . Fixed bug GH-8685 (pcre not ready at mbstring startup). (Remi)
 

--- a/ext/standard/syslog.c
+++ b/ext/standard/syslog.c
@@ -120,11 +120,6 @@ PHP_MSHUTDOWN_FUNCTION(syslog)
 	return SUCCESS;
 }
 
-void php_openlog(const char *ident, int option, int facility)
-{
-	openlog(ident, option, facility);
-	PG(have_called_openlog) = 1;
-}
 
 /* {{{ Open connection to system logger */
 /*
@@ -161,7 +156,7 @@ PHP_FUNCTION(closelog)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	closelog();
+	php_closelog();
 	if (BG(syslog_device)) {
 		free(BG(syslog_device));
 		BG(syslog_device)=NULL;

--- a/main/php_syslog.c
+++ b/main/php_syslog.c
@@ -32,6 +32,18 @@
 #define syslog std_syslog
 #endif
 
+void php_openlog(const char *ident, int option, int facility)
+{
+	openlog(ident, option, facility);
+	PG(have_called_openlog) = 1;
+}
+
+void php_closelog()
+{
+	closelog();
+	PG(have_called_openlog) = 0;
+}
+
 #ifdef PHP_WIN32
 PHPAPI void php_syslog(int priority, const char *format, ...) /* {{{ */
 {

--- a/main/php_syslog.h
+++ b/main/php_syslog.h
@@ -37,6 +37,7 @@
 BEGIN_EXTERN_C()
 PHPAPI void php_syslog(int, const char *format, ...);
 PHPAPI void php_openlog(const char *, int, int);
+PHPAPI void php_closelog();
 END_EXTERN_C()
 
 #endif

--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -88,7 +88,7 @@ int fpm_stdio_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 {
 #ifdef HAVE_SYSLOG_H
 	if (fpm_globals.error_log_fd == ZLOG_SYSLOG) {
-		closelog(); /* ensure to close syslog not to interrupt with PHP syslog code */
+		php_closelog(); /* ensure to close syslog not to interrupt with PHP syslog code */
 	} else
 #endif
 


### PR DESCRIPTION
This PR is a more structured implementation of #7334 and also applies it on PHP `closelog` function. The aim is to just make sure that `have_called_openlog` gets reset on each closelog.

I have been also thinking about a possible test but that would be just too flaky and only available to very limited set of platform (e.g. where /var/log/syslog is available and readable). So it wouldn't work in the pipeline anyway. Instead I just used a manual test for testing that this works that can be seen at https://github.com/bukka/php-util/tree/09f5c2e30d877d48e979514d8d1c602d1a8336ae/tests/fpm/syslog-ident .