### PR TITLE
Support test-ini also for phpize builds

### DIFF
--- a/win32/build/Makefile.phpize
+++ b/win32/build/Makefile.phpize
@@ -42,11 +42,19 @@ _EXTENSION_DLL=$(PECL_TARGETS)
 _EXTENSION_DLL=$(EXT_TARGETS)
 !endif
 
+!if $(PHP_TEST_INI_PATH) == ""
 test: set-tmp-env
-	$(DEBUGGER_CMD) $(DEBUGGER_ARGS) "$(PHP_PREFIX)\php.exe" -d open_basedir= -d output_buffering=0 run-tests.php $(TESTS) -p "$(PHP_PREFIX)\php.exe" -d extension=$(BUILD_DIR)\$(_EXTENSION_DLL)
+	$(DEBUGGER_CMD) $(DEBUGGER_ARGS) "$(PHP_PREFIX)\php.exe" -d open_basedir= -d output_buffering=0 run-tests.php -p "$(PHP_PREFIX)\php.exe" -d extension=$(BUILD_DIR)\$(_EXTENSION_DLL) $(TESTS)
 
 run: set-tmp-env
 	$(DEBUGGER_CMD) $(DEBUGGER_ARGS) "$(PHP_PREFIX)\php.exe" -n -d extension=$(BUILD_DIR)\\$(_EXTENSION_DLL) $(ARGS)
+!else
+test: set-tmp-env
+	$(DEBUGGER_CMD) $(DEBUGGER_ARGS) "$(PHP_PREFIX)\php.exe" -n -d open_basedir= -d output_buffering=0 -d memory_limit=-1 run-tests.php -p "$(PHP_PREFIX)\php.exe" -n -c $(PHP_TEST_INI_PATH) $(TESTS)
+
+run: set-tmp-env
+	$(DEBUGGER_CMD) $(DEBUGGER_ARGS) "$(PHP_PREFIX)\php.exe" -n -c $(PHP_TEST_INI_PATH) $(ARGS)
+!endif
 
 !if $(MT) == ""
 _VC_MANIFEST_EMBED_EXE=

--- a/win32/build/config.w32.phpize.in
+++ b/win32/build/config.w32.phpize.in
@@ -128,6 +128,12 @@ DEFINE("PHP_DIR", PHP_DIR);
 ARG_WITH("codegen-arch", "Architecture for code generation", "no");
 toolset_setup_codegen_arch();
 
+ARG_ENABLE("test-ini", "Enable automatic php.ini generation. The test.ini will be put \
+		into the build dir and used to automatically load the shared extensions.", "no");
+
+ARG_WITH("test-ini-ext-exclude", "Comma separated list of shared extensions to \
+		be excluded from the test.ini", "no");
+
 ARG_ENABLE("native-intrinsics", "Comma separated list of intrinsic optimizations to enable. \
 	Available optimization names are sse, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2. \
 	SSE and SSE2 are enabled by default. The best optimization specified will \

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -2083,9 +2083,7 @@ function generate_files()
 	}
 
 	STDOUT.WriteLine("Generating files...");
-	if (!MODE_PHPIZE) {
-		generate_tmp_php_ini();
-	}
+	generate_tmp_php_ini();
 	generate_makefile();
 	if (!MODE_PHPIZE) {
 		generate_internal_functions();
@@ -2528,11 +2526,9 @@ function generate_makefile()
 		handle_analyzer_makefile_flags(MF, keys[i], val);
 	}
 
-	if (!MODE_PHPIZE) {
-		var val = "yes" == PHP_TEST_INI ? PHP_TEST_INI_PATH : "";
-		/* Be sure it's done after generate_tmp_php_ini(). */
-		MF.WriteLine("PHP_TEST_INI_PATH=\"" + val + "\"");
-	}
+	var val = "yes" == PHP_TEST_INI ? PHP_TEST_INI_PATH : "";
+	/* Be sure it's done after generate_tmp_php_ini(). */
+	MF.WriteLine("PHP_TEST_INI_PATH=\"" + val + "\"");
 
 	MF.WriteBlankLines(1);
 	if (MODE_PHPIZE) {


### PR DESCRIPTION
Automatically generating and using test INI files is supported for
in-tree build (`buildconf`) for a long time, and this can make sense
for phpize builds too, especially when the build extension is a zend
extension, so it can be properly loaded.

Thus we make `--enable-test-ini` and `--with-test-ini-ext-exclude`
available for phpize, but default to false for full BC.