### PR TITLE
check_parameters.php: Make the script's retval reflect errors

### DIFF
--- a/scripts/dev/check_parameters.php
+++ b/scripts/dev/check_parameters.php
@@ -51,7 +51,7 @@ $API_params = array(
 /** reports an error, according to its level */
 function error($str, $level = 0)
 {
-    global $current_file, $current_function, $line;
+    global $current_file, $current_function, $line, $error_reported;
 
     if ($level <= REPORT_LEVEL) {
         if (strpos($current_file,PHPDIR) === 0) {
@@ -60,6 +60,7 @@ function error($str, $level = 0)
             $filename = $current_file;
         }
         echo $filename , " [$line] $current_function : $str\n";
+        $error_reported = true;
     }
 }
 
@@ -372,6 +373,9 @@ foreach($dirs as $dir) {
     }
 }
 
+$error_reported = false;
 foreach ($dirs as $dir) {
     recurse(realpath($dir));
 }
+
+exit($error_reported === false ? 0 : 2);


### PR DESCRIPTION
When the check_parameters.php script meets an error it prints it
out but the exit value is not affected, it's still 0. This does
not fly with projects that want to run this script as a part of
their test suite.

Therefore, make the script return 0 on success and 1 if any error
was reported.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>