### PR TITLE
Tweak $count range check of array_fill()

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2598,10 +2598,10 @@ PHP_FUNCTION(array_fill)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (EXPECTED(num > 0)) {
-		if (sizeof(num) > 4 && UNEXPECTED(EXPECTED(num > 0x7fffffff))) {
+		if (sizeof(num) > 4 && UNEXPECTED(num >INT_MAX)) {
 			zend_argument_value_error(2, "is too large");
 			RETURN_THROWS();
-		} else if (UNEXPECTED(start_key > ZEND_LONG_MAX - num + 1)) {
+		} else if (UNEXPECTED(start_key > ZEND_LONG_MAX - num)) {
 			zend_throw_error(NULL, "Cannot add element to the array as the next element is already occupied");
 			RETURN_THROWS();
 		} else if (EXPECTED(start_key >= 0) && EXPECTED(start_key < num)) {

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2601,7 +2601,7 @@ PHP_FUNCTION(array_fill)
 		if (sizeof(num) > 4 && UNEXPECTED(num >INT_MAX)) {
 			zend_argument_value_error(2, "is too large");
 			RETURN_THROWS();
-		} else if (UNEXPECTED(start_key > ZEND_LONG_MAX - num)) {
+		} else if (UNEXPECTED(start_key > ZEND_LONG_MAX - num + 1)) {
 			zend_throw_error(NULL, "Cannot add element to the array as the next element is already occupied");
 			RETURN_THROWS();
 		} else if (EXPECTED(start_key >= 0) && EXPECTED(start_key < num)) {

--- a/ext/standard/tests/array/array_fill_variation6.phpt
+++ b/ext/standard/tests/array/array_fill_variation6.phpt
@@ -1,0 +1,19 @@
+--TEST--
+array_fill(): last element
+--FILE--
+<?php
+$a = array_fill(PHP_INT_MAX, 1, "foo");
+var_dump(
+    count($a),
+    array_key_exists(PHP_INT_MAX, $a),
+);
+try {
+    $a[] = "bar";
+} catch (Error $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
+?>
+--EXPECT--
+int(1)
+bool(true)
+Cannot add element to the array as the next element is already occupied


### PR DESCRIPTION
~~`start_key + num` is supposed to fit into a `zend_long`, so we should
not allow to pass values which won't.~~

We ~~also~~ fix the `UNEXPECTED(EXPECTED(…))`, which does not make sense,
and replace the magic number with the respective macro. We also add a test case to verify the expected behavior for an `array_fill()` edge case.