### PR TITLE
Replace unnecessary strlen function calls with fixed numbers

### DIFF
--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1731,7 +1731,7 @@ NEWLINE ("\r"|"\n"|"\r\n")
 
 /* Don't treat "readonly(" as a keyword, to allow using it as a function name. */
 <ST_IN_SCRIPTING>"readonly"[ \n\r\t]*"(" {
-	yyless(strlen("readonly"));
+	yyless(8);
 	RETURN_TOKEN_WITH_STR(T_STRING, 0);
 }
 


### PR DESCRIPTION
Using fixed number substitution is clearly possible and should be. Same as for the "enum" case. The actual length of the token processed by both at this time is a fixed number.

```lex
/* Don't treat "readonly(" as a keyword, to allow using it as a function name. */
<ST_IN_SCRIPTING>"readonly"[ \n\r\t]*"(" {
	yyless(strlen("readonly"));
	RETURN_TOKEN_WITH_STR(T_STRING, 0);
}
```

```lex
/*
 * The enum keyword must be followed by whitespace and another identifier.
 * This avoids the BC break of using enum in classes, namespaces, functions and constants.
 */
<ST_IN_SCRIPTING>"enum"{WHITESPACE}("extends"|"implements") {
	yyless(4);
	RETURN_TOKEN_WITH_STR(T_STRING, 0);
}
<ST_IN_SCRIPTING>"enum"{WHITESPACE}[a-zA-Z_\x80-\xff] {
	yyless(4);
	RETURN_TOKEN_WITH_IDENT(T_ENUM);
}
```

I think lexical analysis is performance sensitive and should be modified here rather than relying on the compiler.