### PR TITLE
Fix phpize to include _GNU_SOURCE by default

### DIFF
--- a/scripts/phpize.m4
+++ b/scripts/phpize.m4
@@ -164,7 +164,7 @@ all_targets='$(PHP_MODULES) $(PHP_ZEND_EX)'
 install_targets="install-modules install-headers"
 phplibdir="`pwd`/modules"
 CPPFLAGS="$CPPFLAGS -DHAVE_CONFIG_H"
-CFLAGS_CLEAN='$(CFLAGS)'
+CFLAGS_CLEAN='$(CFLAGS) -D_GNU_SOURCE'
 CXXFLAGS_CLEAN='$(CXXFLAGS)'
 
 test "$prefix" = "NONE" && prefix="/usr/local"


### PR DESCRIPTION
This is to address the issue recognised by @dstogov  at
https://github.com/php/php-src/commit/067df263448ee26013cddee1065bc9c1f028bd23#commitcomment-61578732