### PR TITLE
Allow to not close stream on rscr dtor in php cli sapi

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,8 +4,10 @@ PHP                                                                        NEWS
 
 - CLI:
   . Updated the mime-type table for the builtin-server. (Ayesh Karunaratne)
-  . Fixed potential overflow for the builtin server via the PHP_CLI_SERVER_WORKERS
-    environment variable. (yiyuaner)
+  . Fixed potential overflow for the builtin server via the
+    PHP_CLI_SERVER_WORKERS environment variable. (yiyuaner)
+  . Fixed GH-8575 by changing STDOUT, STDERR and STDIN to not close on resource
+    destruction. (Jakub Zelenka)
 
 - Core:
   . Reduced the memory footprint of strings returned by var_export(),

--- a/UPGRADING
+++ b/UPGRADING
@@ -475,6 +475,11 @@ PHP 8.2 UPGRADE NOTES
 13. Other Changes
 ========================================
 
+- CLI:
+  . The STDOUT, STDERR and STDIN are no longer closed on resource destruction
+    which is mostly when the CLI finishes. It is however still possible to
+    explicitly close those streams using fclose and similar.
+
 - Core:
   . The iterable type is now a built-in compile time alias for array|Traversable.
     Error messages relating to iterable will therefore now use array|Traversable.

--- a/ext/zend_test/tests/gh8575.phpt
+++ b/ext/zend_test/tests/gh8575.phpt
@@ -1,7 +1,5 @@
 --TEST--
 CLI: stderr is available in mshutdown
---XFAIL--
-GH-8952 / GH-8833
 --SKIPIF--
 <?php if (php_sapi_name() != "cli") die('skip cli test only'); ?>
 --EXTENSIONS--

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -185,6 +185,9 @@ struct _php_stream_wrapper	{
  * Currently for internal use only. */
 #define PHP_STREAM_FLAG_SUPPRESS_ERRORS				0x100
 
+/* Do not close handle except it is explicitly closed by user (e.g. fclose) */
+#define PHP_STREAM_FLAG_NO_RSCR_DTOR_CLOSE			0x200
+
 #define PHP_STREAM_FLAG_WAS_WRITTEN					0x80000000
 
 struct _php_stream  {

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -383,7 +383,8 @@ PHPAPI int _php_stream_free(php_stream *stream, int close_options) /* {{{ */
 
 	context = PHP_STREAM_CONTEXT(stream);
 
-	if (stream->flags & PHP_STREAM_FLAG_NO_CLOSE) {
+	if ((stream->flags & PHP_STREAM_FLAG_NO_CLOSE) ||
+			((stream->flags & PHP_STREAM_FLAG_NO_RSCR_DTOR_CLOSE) && (close_options & PHP_STREAM_FREE_RSRC_DTOR))) {
 		preserve_handle = 1;
 	}
 

--- a/sapi/cli/tests/gh8827-001.phpt
+++ b/sapi/cli/tests/gh8827-001.phpt
@@ -8,12 +8,6 @@ if (php_sapi_name() != "cli") {
 if (PHP_OS_FAMILY == 'Windows') {
 	die("skip not for Windows");
 }
-if (PHP_DEBUG) {
-    die("skip std streams are not closeable in debug builds");
-}
-if (getenv('SKIP_REPEAT')) {
-    die("skip cannot be repeated");
-}
 ?>
 --FILE--
 <?php

--- a/sapi/cli/tests/gh8827-002.phpt
+++ b/sapi/cli/tests/gh8827-002.phpt
@@ -8,12 +8,6 @@ if (php_sapi_name() != "cli") {
 if (PHP_OS_FAMILY == 'Windows') {
 	die("skip not for Windows");
 }
-if (PHP_DEBUG) {
-    die("skip std streams are not closeable in debug builds");
-}
-if (getenv('SKIP_REPEAT')) {
-    die("skip cannot be repeated");
-}
 ?>
 --FILE--
 <?php

--- a/sapi/cli/tests/gh8827-003.phpt
+++ b/sapi/cli/tests/gh8827-003.phpt
@@ -8,12 +8,6 @@ if (php_sapi_name() != "cli") {
 if (PHP_OS_FAMILY == 'Windows') {
 	die("skip not for Windows");
 }
-if (PHP_DEBUG) {
-    die("skip std streams are not closeable in debug builds");
-}
-if (getenv('SKIP_REPEAT')) {
-    die("skip cannot be repeated");
-}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
This change allows not closing stream handle when resource dtor is being done. Fixes #8827