### PR TITLE
Use same type error wording for alias iterable in ZPP

### DIFF
--- a/Zend/tests/iterable_or_null.phpt
+++ b/Zend/tests/iterable_or_null.phpt
@@ -40,8 +40,8 @@ try {
 
 ?>
 --EXPECT--
-zend_iterable(): Argument #1 ($arg1) must be of type iterable, string given
-zend_iterable(): Argument #1 ($arg1) must be of type iterable, int given
-zend_iterable(): Argument #1 ($arg1) must be of type iterable, null given
-zend_iterable(): Argument #2 ($arg2) must be of type ?iterable, string given
+zend_iterable(): Argument #1 ($arg1) must be of type Traversable|array, string given
+zend_iterable(): Argument #1 ($arg1) must be of type Traversable|array, int given
+zend_iterable(): Argument #1 ($arg1) must be of type Traversable|array, null given
+zend_iterable(): Argument #2 ($arg2) must be of type Traversable|array|null, string given
 

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1319,8 +1319,8 @@ static zend_always_inline zval *zend_try_array_init(zval *zv)
 	_(Z_EXPECTED_ARRAY_OR_NULL,		"of type ?array") \
 	_(Z_EXPECTED_ARRAY_OR_LONG,		"of type array|int") \
 	_(Z_EXPECTED_ARRAY_OR_LONG_OR_NULL, "of type array|int|null") \
-	_(Z_EXPECTED_ITERABLE,				"of type iterable") \
-	_(Z_EXPECTED_ITERABLE_OR_NULL,		"of type ?iterable") \
+	_(Z_EXPECTED_ITERABLE,				"of type Traversable|array") \
+	_(Z_EXPECTED_ITERABLE_OR_NULL,		"of type Traversable|array|null") \
 	_(Z_EXPECTED_FUNC,				"a valid callback") \
 	_(Z_EXPECTED_FUNC_OR_NULL,		"a valid callback or null") \
 	_(Z_EXPECTED_RESOURCE,			"of type resource") \


### PR DESCRIPTION
Follow-up from #7309 as I didn't change the ZPP TypeError wording.