### PR TITLE
Allow for arbitrary (class) attributes in stubs

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -39,6 +39,9 @@ PHP 8.2 INTERNALS UPGRADE NOTES
   - zend_object_do_operation_t
 * Added a new zero_position argument to php_stream_fopen_from_fd_rel to reflect
   if this a newly created file so the current file offset needs not to be checked.
+* zend_internal_attribute_register() no longer takes a flags argument nor
+  registers the attribute class directly. Instead specify #[Attribute] with the
+  appropriate target flags in the .stub.php file.
 
 ========================
 2. Build system changes

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -39,9 +39,6 @@ PHP 8.2 INTERNALS UPGRADE NOTES
   - zend_object_do_operation_t
 * Added a new zero_position argument to php_stream_fopen_from_fd_rel to reflect
   if this a newly created file so the current file offset needs not to be checked.
-* zend_internal_attribute_register() no longer takes a flags argument nor
-  registers the attribute class directly. Instead specify #[Attribute] with the
-  appropriate target flags in the .stub.php file.
 
 ========================
 2. Build system changes

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -317,27 +317,31 @@ static void free_internal_attribute(zval *v)
 	pefree(Z_PTR_P(v), 1);
 }
 
-ZEND_API zend_internal_attribute *zend_internal_attribute_register(zend_class_entry *ce, uint32_t flags)
+ZEND_API zend_internal_attribute *zend_internal_attribute_register(zend_class_entry *ce)
 {
 	zend_internal_attribute *internal_attr;
+	zend_attribute *attr;
 
 	if (ce->type != ZEND_INTERNAL_CLASS) {
 		zend_error_noreturn(E_ERROR, "Only internal classes can be registered as compiler attribute");
 	}
 
-	internal_attr = pemalloc(sizeof(zend_internal_attribute), 1);
-	internal_attr->ce = ce;
-	internal_attr->flags = flags;
-	internal_attr->validator = NULL;
+	ZEND_HASH_FOREACH_PTR(ce->attributes, attr) {
+		if (zend_string_equals(attr->name, zend_ce_attribute->name)) {
+			internal_attr = pemalloc(sizeof(zend_internal_attribute), 1);
+			internal_attr->ce = ce;
+			internal_attr->flags = Z_LVAL(attr->args[0].value);
+			internal_attr->validator = NULL;
 
-	zend_string *lcname = zend_string_tolower_ex(ce->name, 1);
+			zend_string *lcname = zend_string_tolower_ex(ce->name, 1);
+			zend_hash_update_ptr(&internal_attributes, lcname, internal_attr);
+			zend_string_release(lcname);
 
-	zend_hash_update_ptr(&internal_attributes, lcname, internal_attr);
-	zend_attribute *attr = zend_add_class_attribute(ce, zend_ce_attribute->name, 1);
-	ZVAL_LONG(&attr->args[0].value, flags);
-	zend_string_release(lcname);
+			return internal_attr;
+		}
+	} ZEND_HASH_FOREACH_END();
 
-	return internal_attr;
+	zend_error_noreturn(E_ERROR, "Classes must be first marked as attribute before being able to be registered as internal attribute class");
 }
 
 ZEND_API zend_internal_attribute *zend_internal_attribute_get(zend_string *lcname)
@@ -352,27 +356,18 @@ void zend_register_attribute_ce(void)
 	zend_hash_init(&internal_attributes, 8, NULL, free_internal_attribute, 1);
 
 	zend_ce_attribute = register_class_Attribute();
-	attr = zend_internal_attribute_register(zend_ce_attribute, ZEND_ATTRIBUTE_TARGET_CLASS);
+	attr = zend_internal_attribute_register(zend_ce_attribute);
 	attr->validator = validate_attribute;
 
-	zend_declare_class_constant_long(zend_ce_attribute, ZEND_STRL("TARGET_CLASS"), ZEND_ATTRIBUTE_TARGET_CLASS);
-	zend_declare_class_constant_long(zend_ce_attribute, ZEND_STRL("TARGET_FUNCTION"), ZEND_ATTRIBUTE_TARGET_FUNCTION);
-	zend_declare_class_constant_long(zend_ce_attribute, ZEND_STRL("TARGET_METHOD"), ZEND_ATTRIBUTE_TARGET_METHOD);
-	zend_declare_class_constant_long(zend_ce_attribute, ZEND_STRL("TARGET_PROPERTY"), ZEND_ATTRIBUTE_TARGET_PROPERTY);
-	zend_declare_class_constant_long(zend_ce_attribute, ZEND_STRL("TARGET_CLASS_CONSTANT"), ZEND_ATTRIBUTE_TARGET_CLASS_CONST);
-	zend_declare_class_constant_long(zend_ce_attribute, ZEND_STRL("TARGET_PARAMETER"), ZEND_ATTRIBUTE_TARGET_PARAMETER);
-	zend_declare_class_constant_long(zend_ce_attribute, ZEND_STRL("TARGET_ALL"), ZEND_ATTRIBUTE_TARGET_ALL);
-	zend_declare_class_constant_long(zend_ce_attribute, ZEND_STRL("IS_REPEATABLE"), ZEND_ATTRIBUTE_IS_REPEATABLE);
-
 	zend_ce_return_type_will_change_attribute = register_class_ReturnTypeWillChange();
-	zend_internal_attribute_register(zend_ce_return_type_will_change_attribute, ZEND_ATTRIBUTE_TARGET_METHOD);
+	zend_internal_attribute_register(zend_ce_return_type_will_change_attribute);
 
 	zend_ce_allow_dynamic_properties = register_class_AllowDynamicProperties();
-	attr = zend_internal_attribute_register(zend_ce_allow_dynamic_properties, ZEND_ATTRIBUTE_TARGET_CLASS);
+	attr = zend_internal_attribute_register(zend_ce_allow_dynamic_properties);
 	attr->validator = validate_allow_dynamic_properties;
 
 	zend_ce_sensitive_parameter = register_class_SensitiveParameter();
-	attr = zend_internal_attribute_register(zend_ce_sensitive_parameter, ZEND_ATTRIBUTE_TARGET_PARAMETER);
+	zend_internal_attribute_register(zend_ce_sensitive_parameter);
 
 	memcpy(&attributes_object_handlers_sensitive_parameter_value, &std_object_handlers, sizeof(zend_object_handlers));
 	attributes_object_handlers_sensitive_parameter_value.get_properties_for = attributes_sensitive_parameter_value_get_properties_for;

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -77,7 +77,8 @@ ZEND_API zend_result zend_get_attribute_value(zval *ret, zend_attribute *attr, u
 ZEND_API zend_string *zend_get_attribute_target_names(uint32_t targets);
 ZEND_API bool zend_is_attribute_repeated(HashTable *attributes, zend_attribute *attr);
 
-ZEND_API zend_internal_attribute *zend_internal_attribute_register(zend_class_entry *ce);
+ZEND_API zend_internal_attribute *zend_mark_internal_attribute(zend_class_entry *ce);
+ZEND_API zend_internal_attribute *zend_internal_attribute_register(zend_class_entry *ce, uint32_t flags);
 ZEND_API zend_internal_attribute *zend_internal_attribute_get(zend_string *lcname);
 
 ZEND_API zend_attribute *zend_add_attribute(

--- a/Zend/zend_attributes.h
+++ b/Zend/zend_attributes.h
@@ -77,7 +77,7 @@ ZEND_API zend_result zend_get_attribute_value(zval *ret, zend_attribute *attr, u
 ZEND_API zend_string *zend_get_attribute_target_names(uint32_t targets);
 ZEND_API bool zend_is_attribute_repeated(HashTable *attributes, zend_attribute *attr);
 
-ZEND_API zend_internal_attribute *zend_internal_attribute_register(zend_class_entry *ce, uint32_t flags);
+ZEND_API zend_internal_attribute *zend_internal_attribute_register(zend_class_entry *ce);
 ZEND_API zend_internal_attribute *zend_internal_attribute_get(zend_string *lcname);
 
 ZEND_API zend_attribute *zend_add_attribute(

--- a/Zend/zend_attributes.stub.php
+++ b/Zend/zend_attributes.stub.php
@@ -2,18 +2,62 @@
 
 /** @generate-class-entries */
 
+#[Attribute(Attribute::TARGET_CLASS)]
 final class Attribute
 {
+    /**
+     * @var int
+     * @cname ZEND_ATTRIBUTE_TARGET_CLASS
+     */
+    const TARGET_CLASS = UNKNOWN;
+    /**
+     * @var int
+     * @cname ZEND_ATTRIBUTE_TARGET_FUNCTION
+     */
+    const TARGET_FUNCTION = UNKNOWN;
+    /**
+     * @var int
+     * @cname ZEND_ATTRIBUTE_TARGET_METHOD
+     */
+    const TARGET_METHOD = UNKNOWN;
+    /**
+     * @var int
+     * @cname ZEND_ATTRIBUTE_TARGET_PROPERTY
+     */
+    const TARGET_PROPERTY = UNKNOWN;
+    /**
+     * @var int
+     * @cname ZEND_ATTRIBUTE_TARGET_CLASS_CONST
+     */
+    const TARGET_CLASS_CONSTANT = UNKNOWN;
+    /**
+     * @var int
+     * @cname ZEND_ATTRIBUTE_TARGET_PARAMETER
+     */
+    const TARGET_PARAMETER = UNKNOWN;
+    /**
+     * @var int
+     * @cname ZEND_ATTRIBUTE_TARGET_ALL
+     */
+    const TARGET_ALL = UNKNOWN;
+    /**
+     * @var int
+     * @cname ZEND_ATTRIBUTE_IS_REPEATABLE
+     */
+    const IS_REPEATABLE = UNKNOWN;
+
     public int $flags;
 
     public function __construct(int $flags = Attribute::TARGET_ALL) {}
 }
 
+#[Attribute(Attribute::TARGET_METHOD)]
 final class ReturnTypeWillChange
 {
     public function __construct() {}
 }
 
+#[Attribute(Attribute::TARGET_CLASS)]
 final class AllowDynamicProperties
 {
     public function __construct() {}
@@ -22,6 +66,7 @@ final class AllowDynamicProperties
 /**
  * @strict-properties
  */
+#[Attribute(Attribute::TARGET_PARAMETER)]
 final class SensitiveParameter
 {
     public function __construct() {}

--- a/Zend/zend_attributes_arginfo.h
+++ b/Zend/zend_attributes_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5d9a092c1f0da5f32d9a161cc5166ed794ffe8e9 */
+ * Stub hash: a07e5020fd36cda191c1f3b4fca180157bd74cbc */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Attribute___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "Attribute::TARGET_ALL")
@@ -71,11 +71,65 @@ static zend_class_entry *register_class_Attribute(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 
+	zval const_TARGET_CLASS_value;
+	ZVAL_LONG(&const_TARGET_CLASS_value, ZEND_ATTRIBUTE_TARGET_CLASS);
+	zend_string *const_TARGET_CLASS_name = zend_string_init_interned("TARGET_CLASS", sizeof("TARGET_CLASS") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_TARGET_CLASS_name, &const_TARGET_CLASS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_TARGET_CLASS_name);
+
+	zval const_TARGET_FUNCTION_value;
+	ZVAL_LONG(&const_TARGET_FUNCTION_value, ZEND_ATTRIBUTE_TARGET_FUNCTION);
+	zend_string *const_TARGET_FUNCTION_name = zend_string_init_interned("TARGET_FUNCTION", sizeof("TARGET_FUNCTION") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_TARGET_FUNCTION_name, &const_TARGET_FUNCTION_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_TARGET_FUNCTION_name);
+
+	zval const_TARGET_METHOD_value;
+	ZVAL_LONG(&const_TARGET_METHOD_value, ZEND_ATTRIBUTE_TARGET_METHOD);
+	zend_string *const_TARGET_METHOD_name = zend_string_init_interned("TARGET_METHOD", sizeof("TARGET_METHOD") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_TARGET_METHOD_name, &const_TARGET_METHOD_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_TARGET_METHOD_name);
+
+	zval const_TARGET_PROPERTY_value;
+	ZVAL_LONG(&const_TARGET_PROPERTY_value, ZEND_ATTRIBUTE_TARGET_PROPERTY);
+	zend_string *const_TARGET_PROPERTY_name = zend_string_init_interned("TARGET_PROPERTY", sizeof("TARGET_PROPERTY") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_TARGET_PROPERTY_name, &const_TARGET_PROPERTY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_TARGET_PROPERTY_name);
+
+	zval const_TARGET_CLASS_CONSTANT_value;
+	ZVAL_LONG(&const_TARGET_CLASS_CONSTANT_value, ZEND_ATTRIBUTE_TARGET_CLASS_CONST);
+	zend_string *const_TARGET_CLASS_CONSTANT_name = zend_string_init_interned("TARGET_CLASS_CONSTANT", sizeof("TARGET_CLASS_CONSTANT") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_TARGET_CLASS_CONSTANT_name, &const_TARGET_CLASS_CONSTANT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_TARGET_CLASS_CONSTANT_name);
+
+	zval const_TARGET_PARAMETER_value;
+	ZVAL_LONG(&const_TARGET_PARAMETER_value, ZEND_ATTRIBUTE_TARGET_PARAMETER);
+	zend_string *const_TARGET_PARAMETER_name = zend_string_init_interned("TARGET_PARAMETER", sizeof("TARGET_PARAMETER") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_TARGET_PARAMETER_name, &const_TARGET_PARAMETER_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_TARGET_PARAMETER_name);
+
+	zval const_TARGET_ALL_value;
+	ZVAL_LONG(&const_TARGET_ALL_value, ZEND_ATTRIBUTE_TARGET_ALL);
+	zend_string *const_TARGET_ALL_name = zend_string_init_interned("TARGET_ALL", sizeof("TARGET_ALL") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_TARGET_ALL_name, &const_TARGET_ALL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_TARGET_ALL_name);
+
+	zval const_IS_REPEATABLE_value;
+	ZVAL_LONG(&const_IS_REPEATABLE_value, ZEND_ATTRIBUTE_IS_REPEATABLE);
+	zend_string *const_IS_REPEATABLE_name = zend_string_init_interned("IS_REPEATABLE", sizeof("IS_REPEATABLE") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_IS_REPEATABLE_name, &const_IS_REPEATABLE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_IS_REPEATABLE_name);
+
 	zval property_flags_default_value;
 	ZVAL_UNDEF(&property_flags_default_value);
 	zend_string *property_flags_name = zend_string_init("flags", sizeof("flags") - 1, 1);
 	zend_declare_typed_property(class_entry, property_flags_name, &property_flags_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_flags_name);
+	zend_string *attribute_name_Attribute_class_Attribute = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
+	zend_attribute *attribute_Attribute_class_Attribute = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_Attribute, 1);
+	zend_string_release(attribute_name_Attribute_class_Attribute);
+	zval attribute_Attribute_class_Attribute_arg0;
+	ZVAL_LONG(&attribute_Attribute_class_Attribute_arg0, ZEND_ATTRIBUTE_TARGET_CLASS);
+	ZVAL_COPY_VALUE(&attribute_Attribute_class_Attribute->args[0].value, &attribute_Attribute_class_Attribute_arg0);
 
 	return class_entry;
 }
@@ -87,6 +141,12 @@ static zend_class_entry *register_class_ReturnTypeWillChange(void)
 	INIT_CLASS_ENTRY(ce, "ReturnTypeWillChange", class_ReturnTypeWillChange_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+	zend_string *attribute_name_Attribute_class_ReturnTypeWillChange = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
+	zend_attribute *attribute_Attribute_class_ReturnTypeWillChange = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ReturnTypeWillChange, 1);
+	zend_string_release(attribute_name_Attribute_class_ReturnTypeWillChange);
+	zval attribute_Attribute_class_ReturnTypeWillChange_arg0;
+	ZVAL_LONG(&attribute_Attribute_class_ReturnTypeWillChange_arg0, ZEND_ATTRIBUTE_TARGET_METHOD);
+	ZVAL_COPY_VALUE(&attribute_Attribute_class_ReturnTypeWillChange->args[0].value, &attribute_Attribute_class_ReturnTypeWillChange_arg0);
 
 	return class_entry;
 }
@@ -98,6 +158,12 @@ static zend_class_entry *register_class_AllowDynamicProperties(void)
 	INIT_CLASS_ENTRY(ce, "AllowDynamicProperties", class_AllowDynamicProperties_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+	zend_string *attribute_name_Attribute_class_AllowDynamicProperties = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
+	zend_attribute *attribute_Attribute_class_AllowDynamicProperties = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_AllowDynamicProperties, 1);
+	zend_string_release(attribute_name_Attribute_class_AllowDynamicProperties);
+	zval attribute_Attribute_class_AllowDynamicProperties_arg0;
+	ZVAL_LONG(&attribute_Attribute_class_AllowDynamicProperties_arg0, ZEND_ATTRIBUTE_TARGET_CLASS);
+	ZVAL_COPY_VALUE(&attribute_Attribute_class_AllowDynamicProperties->args[0].value, &attribute_Attribute_class_AllowDynamicProperties_arg0);
 
 	return class_entry;
 }
@@ -109,6 +175,12 @@ static zend_class_entry *register_class_SensitiveParameter(void)
 	INIT_CLASS_ENTRY(ce, "SensitiveParameter", class_SensitiveParameter_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES;
+	zend_string *attribute_name_Attribute_class_SensitiveParameter = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
+	zend_attribute *attribute_Attribute_class_SensitiveParameter = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_SensitiveParameter, 1);
+	zend_string_release(attribute_name_Attribute_class_SensitiveParameter);
+	zval attribute_Attribute_class_SensitiveParameter_arg0;
+	ZVAL_LONG(&attribute_Attribute_class_SensitiveParameter_arg0, ZEND_ATTRIBUTE_TARGET_PARAMETER);
+	ZVAL_COPY_VALUE(&attribute_Attribute_class_SensitiveParameter->args[0].value, &attribute_Attribute_class_SensitiveParameter_arg0);
 
 	return class_entry;
 }

--- a/Zend/zend_attributes_arginfo.h
+++ b/Zend/zend_attributes_arginfo.h
@@ -124,6 +124,7 @@ static zend_class_entry *register_class_Attribute(void)
 	zend_string *property_flags_name = zend_string_init("flags", sizeof("flags") - 1, 1);
 	zend_declare_typed_property(class_entry, property_flags_name, &property_flags_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(property_flags_name);
+
 	zend_string *attribute_name_Attribute_class_Attribute = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
 	zend_attribute *attribute_Attribute_class_Attribute = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_Attribute, 1);
 	zend_string_release(attribute_name_Attribute_class_Attribute);
@@ -141,6 +142,7 @@ static zend_class_entry *register_class_ReturnTypeWillChange(void)
 	INIT_CLASS_ENTRY(ce, "ReturnTypeWillChange", class_ReturnTypeWillChange_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
 	zend_string *attribute_name_Attribute_class_ReturnTypeWillChange = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
 	zend_attribute *attribute_Attribute_class_ReturnTypeWillChange = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ReturnTypeWillChange, 1);
 	zend_string_release(attribute_name_Attribute_class_ReturnTypeWillChange);
@@ -158,6 +160,7 @@ static zend_class_entry *register_class_AllowDynamicProperties(void)
 	INIT_CLASS_ENTRY(ce, "AllowDynamicProperties", class_AllowDynamicProperties_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
 	zend_string *attribute_name_Attribute_class_AllowDynamicProperties = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
 	zend_attribute *attribute_Attribute_class_AllowDynamicProperties = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_AllowDynamicProperties, 1);
 	zend_string_release(attribute_name_Attribute_class_AllowDynamicProperties);
@@ -175,6 +178,7 @@ static zend_class_entry *register_class_SensitiveParameter(void)
 	INIT_CLASS_ENTRY(ce, "SensitiveParameter", class_SensitiveParameter_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL|ZEND_ACC_NO_DYNAMIC_PROPERTIES;
+
 	zend_string *attribute_name_Attribute_class_SensitiveParameter = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
 	zend_attribute *attribute_Attribute_class_SensitiveParameter = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_SensitiveParameter, 1);
 	zend_string_release(attribute_name_Attribute_class_SensitiveParameter);

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -354,6 +354,7 @@ static zend_class_entry *register_class_stdClass(void)
 	INIT_CLASS_ENTRY(ce, "stdClass", class_stdClass_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+
 	zend_string *attribute_name_AllowDynamicProperties_class_stdClass = zend_string_init("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
 	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class_stdClass, 0);
 	zend_string_release(attribute_name_AllowDynamicProperties_class_stdClass);

--- a/Zend/zend_builtin_functions_arginfo.h
+++ b/Zend/zend_builtin_functions_arginfo.h
@@ -354,7 +354,9 @@ static zend_class_entry *register_class_stdClass(void)
 	INIT_CLASS_ENTRY(ce, "stdClass", class_stdClass_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
-	zend_add_class_attribute(class_entry, zend_ce_allow_dynamic_properties->name, 0);
+	zend_string *attribute_name_AllowDynamicProperties_class_stdClass = zend_string_init("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
+	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class_stdClass, 0);
+	zend_string_release(attribute_name_AllowDynamicProperties_class_stdClass);
 
 	return class_entry;
 }

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -73,7 +73,7 @@ function processStubFile(string $stubFile, Context $context, bool $includeOnly =
 
             foreach ($fileInfo->dependencies as $dependency) {
                 // TODO add header search path for extensions?
-                $prefixes = [dirname($stubFile) . "/", ""];
+                $prefixes = [dirname($stubFile) . "/", dirname(__DIR__) . "/"];
                 foreach ($prefixes as $prefix) {
                     $depFile = $prefix . $dependency;
                     if (file_exists($depFile)) {

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -816,7 +816,9 @@ static zend_class_entry *register_class_OCILob(void)
 	INIT_CLASS_ENTRY(ce, "OCILob", class_OCILob_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
-	zend_add_class_attribute(class_entry, zend_ce_allow_dynamic_properties->name, 0);
+	zend_string *attribute_name_AllowDynamicProperties_class_OCILob = zend_string_init("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
+	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class_OCILob, 0);
+	zend_string_release(attribute_name_AllowDynamicProperties_class_OCILob);
 
 	return class_entry;
 }
@@ -828,7 +830,9 @@ static zend_class_entry *register_class_OCICollection(void)
 	INIT_CLASS_ENTRY(ce, "OCICollection", class_OCICollection_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
-	zend_add_class_attribute(class_entry, zend_ce_allow_dynamic_properties->name, 0);
+	zend_string *attribute_name_AllowDynamicProperties_class_OCICollection = zend_string_init("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
+	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class_OCICollection, 0);
+	zend_string_release(attribute_name_AllowDynamicProperties_class_OCICollection);
 
 	return class_entry;
 }

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -816,6 +816,7 @@ static zend_class_entry *register_class_OCILob(void)
 	INIT_CLASS_ENTRY(ce, "OCILob", class_OCILob_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+
 	zend_string *attribute_name_AllowDynamicProperties_class_OCILob = zend_string_init("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
 	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class_OCILob, 0);
 	zend_string_release(attribute_name_AllowDynamicProperties_class_OCILob);
@@ -830,6 +831,7 @@ static zend_class_entry *register_class_OCICollection(void)
 	INIT_CLASS_ENTRY(ce, "OCICollection", class_OCICollection_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+
 	zend_string *attribute_name_AllowDynamicProperties_class_OCICollection = zend_string_init("AllowDynamicProperties", sizeof("AllowDynamicProperties") - 1, 1);
 	zend_add_class_attribute(class_entry, attribute_name_AllowDynamicProperties_class_OCICollection, 0);
 	zend_string_release(attribute_name_AllowDynamicProperties_class_OCICollection);

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -634,12 +634,12 @@ PHP_MINIT_FUNCTION(zend_test)
 
 	zend_test_attribute = register_class_ZendTestAttribute();
 	{
-		zend_internal_attribute *attr = zend_internal_attribute_register(zend_test_attribute);
+		zend_internal_attribute *attr = zend_mark_internal_attribute(zend_test_attribute);
 		attr->validator = zend_attribute_validate_zendtestattribute;
 	}
 
 	zend_test_parameter_attribute = register_class_ZendTestParameterAttribute();
-	zend_internal_attribute_register(zend_test_parameter_attribute);
+	zend_mark_internal_attribute(zend_test_parameter_attribute);
 
 	{
 		zend_attribute *attr;

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -634,12 +634,12 @@ PHP_MINIT_FUNCTION(zend_test)
 
 	zend_test_attribute = register_class_ZendTestAttribute();
 	{
-		zend_internal_attribute *attr = zend_internal_attribute_register(zend_test_attribute, ZEND_ATTRIBUTE_TARGET_ALL);
+		zend_internal_attribute *attr = zend_internal_attribute_register(zend_test_attribute);
 		attr->validator = zend_attribute_validate_zendtestattribute;
 	}
 
 	zend_test_parameter_attribute = register_class_ZendTestParameterAttribute();
-	zend_internal_attribute_register(zend_test_parameter_attribute, ZEND_ATTRIBUTE_TARGET_PARAMETER);
+	zend_internal_attribute_register(zend_test_parameter_attribute);
 
 	{
 		zend_attribute *attr;

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -4,6 +4,8 @@
 
 namespace {
 
+    require "Zend/zend_attributes.stub.php";
+
     interface _ZendTestInterface
     {
     }

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -41,10 +41,12 @@ namespace {
         public function testMethod(): bool {}
     }
 
+    #[Attribute(Attribute::TARGET_ALL)]
     final class ZendTestAttribute {
 
     }
 
+    #[Attribute(Attribute::TARGET_PARAMETER)]
     final class ZendTestParameterAttribute {
         public string $parameter;
 

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1a23b7473e5b4525352445545c6b3ab374c4e949 */
+ * Stub hash: 7c78cce33ecdd481c76ebd97cbc163730a47dd4c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -390,6 +390,12 @@ static zend_class_entry *register_class_ZendTestAttribute(void)
 	INIT_CLASS_ENTRY(ce, "ZendTestAttribute", class_ZendTestAttribute_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+	zend_string *attribute_name_Attribute_class_ZendTestAttribute = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
+	zend_attribute *attribute_Attribute_class_ZendTestAttribute = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestAttribute, 1);
+	zend_string_release(attribute_name_Attribute_class_ZendTestAttribute);
+	zval attribute_Attribute_class_ZendTestAttribute_arg0;
+	ZVAL_LONG(&attribute_Attribute_class_ZendTestAttribute_arg0, ZEND_ATTRIBUTE_TARGET_ALL);
+	ZVAL_COPY_VALUE(&attribute_Attribute_class_ZendTestAttribute->args[0].value, &attribute_Attribute_class_ZendTestAttribute_arg0);
 
 	return class_entry;
 }
@@ -407,6 +413,12 @@ static zend_class_entry *register_class_ZendTestParameterAttribute(void)
 	zend_string *property_parameter_name = zend_string_init("parameter", sizeof("parameter") - 1, 1);
 	zend_declare_typed_property(class_entry, property_parameter_name, &property_parameter_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_parameter_name);
+	zend_string *attribute_name_Attribute_class_ZendTestParameterAttribute = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
+	zend_attribute *attribute_Attribute_class_ZendTestParameterAttribute = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestParameterAttribute, 1);
+	zend_string_release(attribute_name_Attribute_class_ZendTestParameterAttribute);
+	zval attribute_Attribute_class_ZendTestParameterAttribute_arg0;
+	ZVAL_LONG(&attribute_Attribute_class_ZendTestParameterAttribute_arg0, ZEND_ATTRIBUTE_TARGET_PARAMETER);
+	ZVAL_COPY_VALUE(&attribute_Attribute_class_ZendTestParameterAttribute->args[0].value, &attribute_Attribute_class_ZendTestParameterAttribute_arg0);
 
 	return class_entry;
 }

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7c78cce33ecdd481c76ebd97cbc163730a47dd4c */
+ * Stub hash: 3ad8ef04d52f1a099d9fd3b6c2c02b90de2980be */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -390,6 +390,7 @@ static zend_class_entry *register_class_ZendTestAttribute(void)
 	INIT_CLASS_ENTRY(ce, "ZendTestAttribute", class_ZendTestAttribute_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
 	zend_string *attribute_name_Attribute_class_ZendTestAttribute = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
 	zend_attribute *attribute_Attribute_class_ZendTestAttribute = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestAttribute, 1);
 	zend_string_release(attribute_name_Attribute_class_ZendTestAttribute);
@@ -413,6 +414,7 @@ static zend_class_entry *register_class_ZendTestParameterAttribute(void)
 	zend_string *property_parameter_name = zend_string_init("parameter", sizeof("parameter") - 1, 1);
 	zend_declare_typed_property(class_entry, property_parameter_name, &property_parameter_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(property_parameter_name);
+
 	zend_string *attribute_name_Attribute_class_ZendTestParameterAttribute = zend_string_init("Attribute", sizeof("Attribute") - 1, 1);
 	zend_attribute *attribute_Attribute_class_ZendTestParameterAttribute = zend_add_class_attribute(class_entry, attribute_name_Attribute_class_ZendTestParameterAttribute, 1);
 	zend_string_release(attribute_name_Attribute_class_ZendTestParameterAttribute);


### PR DESCRIPTION
Building on top of #8776, for flexibility and usage in other extensions, i.e. avoiding hardcoding attribute declarations.

This can be easily extended to other types of attributes (params, etc.).