### PR TITLE
Add AllowDynamicProperties on OCILob and OCICollection

### DIFF
--- a/ext/oci8/oci8.stub.php
+++ b/ext/oci8/oci8.stub.php
@@ -560,6 +560,7 @@ function oci_register_taf_callback($connection, ?callable $callback): bool {}
 /** @param resource $connection */
 function oci_unregister_taf_callback($connection): bool {}
 
+#[\AllowDynamicProperties]
 class OCILob {
     /**
      * @alias oci_lob_save
@@ -688,6 +689,7 @@ class OCILob {
     public function free(): bool {}
 }
 
+#[\AllowDynamicProperties]
 class OCICollection {
     /**
      * @alias oci_free_collection

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: db170b61403c53d4d420d0095031944f3d036508 */
+ * Stub hash: 592fbc9718ff272e1cb182025963683541a7a646 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_oci_define_by_name, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, statement)
@@ -815,6 +815,8 @@ static zend_class_entry *register_class_OCILob(void)
 
 	INIT_CLASS_ENTRY(ce, "OCILob", class_OCILob_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+	zend_add_class_attribute(class_entry, zend_ce_allow_dynamic_properties->name, 0);
 
 	return class_entry;
 }
@@ -825,6 +827,8 @@ static zend_class_entry *register_class_OCICollection(void)
 
 	INIT_CLASS_ENTRY(ce, "OCICollection", class_OCICollection_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+	zend_add_class_attribute(class_entry, zend_ce_allow_dynamic_properties->name, 0);
 
 	return class_entry;
 }


### PR DESCRIPTION
Fix GH-8756 : oci_new_descriptor() triggers dynamic property
deprecation.

This fix should be temporary. At some point we should either define
those properties or just hide them since they should probably not be
used.

Better fix is here : https://github.com/php/php-src/pull/8758 but
waiting feedback from Oracle team before going ahead.