### PR TITLE
Fix lineno for all constant expressions

### DIFF
--- a/Zend/tests/bug41633_2.phpt
+++ b/Zend/tests/bug41633_2.phpt
@@ -10,5 +10,6 @@ echo Foo::A."\n";
 --EXPECTF--
 Fatal error: Uncaught Error: Undefined constant self::B in %s:%d
 Stack trace:
-#0 {main}
+#0 %s(%d): [constant expression]()
+#1 {main}
   thrown in %sbug41633_2.php on line 3

--- a/Zend/tests/bug41633_3.phpt
+++ b/Zend/tests/bug41633_3.phpt
@@ -11,5 +11,6 @@ echo Foo::A;
 --EXPECTF--
 Fatal error: Uncaught Error: Cannot declare self-referencing constant Foo::B in %s:%d
 Stack trace:
-#0 {main}
+#0 %s(%d): [constant expression]()
+#1 {main}
   thrown in %sbug41633_3.php on line %d

--- a/Zend/tests/bug47572.phpt
+++ b/Zend/tests/bug47572.phpt
@@ -16,5 +16,6 @@ $foo = new Foo();
 --EXPECTF--
 Fatal error: Uncaught Error: Undefined constant "FOO" in %s:%d
 Stack trace:
-#0 {main}
+#0 %s(%d): [constant expression]()
+#1 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug74657.phpt
+++ b/Zend/tests/bug74657.phpt
@@ -21,5 +21,6 @@ var_dump((new C)->options);
 --EXPECTF--
 Fatal error: Uncaught Error: Undefined constant I::FOO in %s:%d
 Stack trace:
-#0 {main}
+#0 %s(%d): [constant expression]()
+#1 {main}
   thrown in %sbug74657.php on line %d

--- a/Zend/tests/constant_expressions_self_referencing_array.phpt
+++ b/Zend/tests/constant_expressions_self_referencing_array.phpt
@@ -11,5 +11,6 @@ var_dump(A::FOO);
 --EXPECTF--
 Fatal error: Uncaught Error: Cannot declare self-referencing constant self::BAR in %s:%d
 Stack trace:
-#0 {main}
+#0 %s(%d): [constant expression]()
+#1 {main}
   thrown in %s on line %d

--- a/Zend/tests/enum/offsetGet-in-const-expr.phpt
+++ b/Zend/tests/enum/offsetGet-in-const-expr.phpt
@@ -25,5 +25,6 @@ var_dump(X::FOO_BAR);
 --EXPECTF--
 Fatal error: Uncaught Error: Cannot use [] on objects in constant expression in %s:%d
 Stack trace:
-#0 {main}
+#0 %s(%d): [constant expression]()
+#1 {main}
   thrown in %s on line %d

--- a/Zend/tests/gh7771_1.phpt
+++ b/Zend/tests/gh7771_1.phpt
@@ -11,5 +11,6 @@ new Foo();
 --EXPECTF--
 Fatal error: Uncaught Error: Class "NonExistent" not found in %sgh7771_1_definition.inc:4
 Stack trace:
-#0 {main}
+#0 %sgh7771_1.php(5): [constant expression]()
+#1 {main}
   thrown in %sgh7771_1_definition.inc on line 4

--- a/Zend/tests/gh7771_2.phpt
+++ b/Zend/tests/gh7771_2.phpt
@@ -11,5 +11,6 @@ new Foo();
 --EXPECTF--
 Fatal error: Uncaught Error: Class "NonExistent" not found in %sgh7771_2_definition.inc:6
 Stack trace:
-#0 {main}
+#0 %sgh7771_2.php(5): [constant expression]()
+#1 {main}
   thrown in %sgh7771_2_definition.inc on line 6

--- a/Zend/tests/gh8821.phpt
+++ b/Zend/tests/gh8821.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-8821: Fix reported line number of constant expression
+--FILE--
+<?php
+
+enum Alpha {
+    case Foo;
+}
+
+class Bravo {
+    public const C = [Alpha::Foo => 3];
+}
+
+new Bravo();
+
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Illegal offset type in %sgh8821.php:8
+Stack trace:
+#0 %sgh8821.php(11): [constant expression]()
+#1 {main}
+  thrown in %sgh8821.php on line 8

--- a/Zend/tests/type_declarations/typed_properties_022.phpt
+++ b/Zend/tests/type_declarations/typed_properties_022.phpt
@@ -11,5 +11,6 @@ $foo = new Foo();
 --EXPECTF--
 Fatal error: Uncaught Error: Class "BAR" not found in %s:%d
 Stack trace:
-#0 {main}
+#0 %s(%d): [constant expression]()
+#1 {main}
   thrown in %s on line %d

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -352,6 +352,9 @@ static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 	if (ast->kind == ZEND_AST_ZVAL) {
 		zval *zv = zend_ast_get_zval(ast);
 		return Z_LINENO_P(zv);
+	} else if (ast->kind == ZEND_AST_CONSTANT) {
+		zval *zv = &((zend_ast_zval *) ast)->val;
+		return Z_LINENO_P(zv);
 	} else {
 		return ast->lineno;
 	}

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -594,6 +594,7 @@ EMPTY_SWITCH_DEFAULT_CASE()
 	_(ZEND_STR_AUTOGLOBAL_REQUEST,     "_REQUEST") \
 	_(ZEND_STR_COUNT,                  "count") \
 	_(ZEND_STR_SENSITIVEPARAMETER,     "SensitiveParameter") \
+	_(ZEND_STR_CONST_EXPR_PLACEHOLDER, "[constant expression]") \
 
 
 typedef enum _zend_known_string_id {

--- a/ext/standard/tests/streams/bug77664.phpt
+++ b/ext/standard/tests/streams/bug77664.phpt
@@ -12,6 +12,7 @@ file_get_contents('error://test');
 --EXPECTF--
 Fatal error: Uncaught Error: Undefined constant self::INVALID in %s:%d
 Stack trace:
-#0 %sbug77664.php(%d): file_get_contents('error://test')
-#1 {main}
+#0 %s(%d): [constant expression]()
+#1 %s(%d): file_get_contents('error://test')
+#2 {main}
   thrown in %sbug77664.php on line %d

--- a/tests/classes/constants_error_004.phpt
+++ b/tests/classes/constants_error_004.phpt
@@ -12,5 +12,6 @@ Class constant whose initial value references a non-existent class
 --EXPECTF--
 Fatal error: Uncaught Error: Class "D" not found in %s:%d
 Stack trace:
-#0 {main}
+#0 %s(%d): [constant expression]()
+#1 {main}
   thrown in %s on line %d


### PR DESCRIPTION
Closes GH-8821

I'm not sure what the performance implications of the setjmp are for each iteration of `zend_ast_evaluate`, but if `zend_ast_evaluate` bails we could end up with a freed string in `filename_override` which would be bad.