### PR TITLE
Fix enum preloading again

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -115,6 +115,7 @@ typedef struct _zend_class_mutable_data {
 	zval      *default_properties_table;
 	HashTable *constants_table;
 	uint32_t   ce_flags;
+	HashTable *backed_enum_table;
 } zend_class_mutable_data;
 
 typedef struct _zend_class_dependency {

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -321,6 +321,9 @@ typedef struct _zend_fcall_info_cache {
 #define CE_DEFAULT_PROPERTIES_TABLE(ce) \
 	zend_class_default_properties_table(ce)
 
+#define CE_BACKED_ENUM_TABLE(ce) \
+	zend_class_backed_enum_table(ce)
+
 #define ZEND_FCI_INITIALIZED(fci) ((fci).size != 0)
 
 ZEND_API int zend_next_free_module(void);
@@ -447,6 +450,26 @@ static zend_always_inline zval *zend_class_default_properties_table(zend_class_e
 		return mutable_data->default_properties_table;
 	} else {
 		return ce->default_properties_table;
+	}
+}
+
+static zend_always_inline void zend_class_set_backed_enum_table(zend_class_entry *ce, HashTable *backed_enum_table)
+{
+	if (ZEND_MAP_PTR(ce->mutable_data) && ce->type == ZEND_USER_CLASS) {
+		zend_class_mutable_data *mutable_data = (zend_class_mutable_data*)ZEND_MAP_PTR_GET_IMM(ce->mutable_data);
+		mutable_data->backed_enum_table = backed_enum_table;
+	} else {
+		ce->backed_enum_table = backed_enum_table;
+	}
+}
+
+static zend_always_inline HashTable *zend_class_backed_enum_table(zend_class_entry *ce)
+{
+	if (ZEND_MAP_PTR(ce->mutable_data) && ce->type == ZEND_USER_CLASS) {
+		zend_class_mutable_data *mutable_data = (zend_class_mutable_data*)ZEND_MAP_PTR_GET_IMM(ce->mutable_data);
+		return mutable_data->backed_enum_table;
+	} else {
+		return ce->backed_enum_table;
 	}
 }
 

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -275,6 +275,11 @@ ZEND_API void zend_cleanup_mutable_class_data(zend_class_entry *ce)
 			mutable_data->default_properties_table = NULL;
 		}
 
+		if (mutable_data->backed_enum_table) {
+			zend_hash_release(mutable_data->backed_enum_table);
+			mutable_data->backed_enum_table = NULL;
+		}
+
 		ZEND_MAP_PTR_SET_IMM(ce->mutable_data, NULL);
 	}
 }


### PR DESCRIPTION
My assumption was incorrect. With preloading enums do use `ZEND_ACC_IMMUTABLE`. This PR adds `backed_enum_table` to `zend_class_mutable_data`. It's only used for user class as internal classes will not modify the backed enum table at runtime.