### PR TITLE
Fix string length handling in \SplFileinfo::getBasename()

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1038,8 +1038,8 @@ PHP_METHOD(SplFileInfo, getBasename)
 	path = spl_filesystem_object_get_path(intern);
 
 	if (path && ZSTR_LEN(path) < ZSTR_LEN(intern->file_name)) {
-		fname = ZSTR_VAL(intern->file_name) + ZSTR_LEN(path) + 1;
-		flen = ZSTR_LEN(intern->file_name) - (ZSTR_LEN(path) + 1);
+		fname = ZSTR_VAL(intern->file_name) + ZSTR_LEN(path);
+		flen = ZSTR_LEN(intern->file_name) - ZSTR_LEN(path);
 	} else {
 		fname = ZSTR_VAL(intern->file_name);
 		flen = ZSTR_LEN(intern->file_name);

--- a/ext/spl/tests/SplFileinfo_getBasename_basic.phpt
+++ b/ext/spl/tests/SplFileinfo_getBasename_basic.phpt
@@ -1,0 +1,32 @@
+--TEST--
+SPL: SplFileInfo::getBasename() basic test
+--FILE--
+<?php
+// without $suffix
+echo (new \SplFileInfo('/path/to/a.txt'))->getBasename() . PHP_EOL;
+echo (new \SplFileInfo('path/to/b'))->getBasename() . PHP_EOL;
+echo (new \SplFileInfo('c.txt'))->getBasename() . PHP_EOL;
+echo (new \SplFileInfo('d'))->getBasename() . PHP_EOL;
+echo (new \SplFileInfo('~/path/to//e'))->getBasename() . PHP_EOL . PHP_EOL;
+
+// with $suffix
+echo (new \SplFileInfo('path/to/a.txt'))->getBasename('.txt') . PHP_EOL;
+echo (new \SplFileInfo('path/to/bbb.txt'))->getBasename('b.txt') . PHP_EOL;
+echo (new \SplFileInfo('path/to/ccc.txt'))->getBasename('to/ccc.txt') . PHP_EOL;
+echo (new \SplFileInfo('d.txt'))->getBasename('txt') . PHP_EOL;
+echo (new \SplFileInfo('e.txt'))->getBasename('e.txt') . PHP_EOL;
+echo (new \SplFileInfo('f'))->getBasename('.txt');
+?>
+--EXPECT--
+a.txt
+b
+c.txt
+d
+e
+
+a
+bb
+ccc.txt
+d.
+e.txt
+f


### PR DESCRIPTION
Here is an attempt at fixing #8861. I also added some general tests for `SplFileInfo::getBasename()`. 

Though I have to admit, that I'm not familiar with the php source at all. So please have a very critical look at this. :relaxed: 

/cc @Girgias 