### PR TITLE
Implement GH-7922: print_r should not produce a fatal error

### DIFF
--- a/Zend/tests/debug_info-error-0.0.phpt
+++ b/Zend/tests/debug_info-error-0.0.phpt
@@ -17,4 +17,8 @@ $c = new C(0.0);
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-0.0.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-0.0.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-0.phpt
+++ b/Zend/tests/debug_info-error-0.phpt
@@ -17,4 +17,8 @@ $c = new C(0);
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-0.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-0.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-0.phpt
+++ b/Zend/tests/debug_info-error-0.phpt
@@ -17,7 +17,7 @@ $c = new C(0);
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: __debuginfo() must return an array in __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-0.php:14
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s:%d
 Stack trace:
 #0 %s(14): var_dump(Object(C))
 #1 {main}

--- a/Zend/tests/debug_info-error-1.0.phpt
+++ b/Zend/tests/debug_info-error-1.0.phpt
@@ -17,4 +17,8 @@ $c = new C(1.0);
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-1.0.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-1.0.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-1.phpt
+++ b/Zend/tests/debug_info-error-1.phpt
@@ -17,4 +17,8 @@ $c = new C(1);
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-1.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-1.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-empty_str.phpt
+++ b/Zend/tests/debug_info-error-empty_str.phpt
@@ -17,4 +17,8 @@ $c = new C("");
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-empty_str.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-empty_str.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-false.phpt
+++ b/Zend/tests/debug_info-error-false.phpt
@@ -17,4 +17,8 @@ $c = new C(false);
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-false.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-false.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-object.phpt
+++ b/Zend/tests/debug_info-error-object.phpt
@@ -17,4 +17,8 @@ $c = new C(new stdClass);
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-object.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-object.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-resource.phpt
+++ b/Zend/tests/debug_info-error-resource.phpt
@@ -19,4 +19,8 @@ $c = new C(fopen("data:text/plain,Foo", 'r'));
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-resource.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-resource.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-str.phpt
+++ b/Zend/tests/debug_info-error-str.phpt
@@ -17,4 +17,8 @@ $c = new C("foo");
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-str.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-str.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/debug_info-error-true.phpt
+++ b/Zend/tests/debug_info-error-true.phpt
@@ -17,4 +17,8 @@ $c = new C(true);
 var_dump($c);
 ?>
 --EXPECTF--
-Fatal error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-true.php on line %d
+Fatal error: Uncaught Error: __debuginfo() must return an array in %s%eZend%etests%edebug_info-error-true.php:14
+Stack trace:
+#0 %s(14): var_dump(Object(C))
+#1 {main}
+  thrown in %s on line 14

--- a/Zend/tests/gh7922.phpt
+++ b/Zend/tests/gh7922.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-7922 (print_r should not produce a fatal error)
+--FILE--
+<?php
+class A
+{
+    public function __debugInfo(): array
+    {
+        throw new \Error('x');
+    }
+}
+
+try {
+    $a = new A();
+    print_r($a, true);
+} catch (\Throwable $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECT--
+__debuginfo() must return an array

--- a/Zend/tests/gh7922.phpt
+++ b/Zend/tests/gh7922.phpt
@@ -4,7 +4,7 @@ GH-7922 (print_r should not produce a fatal error)
 <?php
 class A
 {
-    public function __debugInfo(): array
+    public function __debugInfo()
     {
         throw new \Error('x');
     }
@@ -12,10 +12,32 @@ class A
 
 try {
     $a = new A();
+    print_r($a);
+} catch (\Throwable $e) {
+    echo (string) $e . "\n";
+}
+
+try {
+    $a = new class() extends A {
+        public function __debugInfo(): array
+        {
+            throw new \Exception('y');
+        }
+    };
     print_r($a, true);
 } catch (\Throwable $e) {
-    echo $e->getMessage();
+    echo (string) $e . "\n";
 }
 ?>
---EXPECT--
-__debuginfo() must return an array
+--EXPECTF--
+Error: x in %s:6
+Stack trace:
+#0 [internal function]: A->__debugInfo()
+#1 %s(12): print_r(Object(A))
+#2 {main}
+
+Exception: y in %s:21
+Stack trace:
+#0 [internal function]: A@anonymous->__debugInfo()
+#1 %s(24): print_r(Object(A@anonymous), true)
+#2 {main}

--- a/Zend/tests/gh7922.phpt
+++ b/Zend/tests/gh7922.phpt
@@ -62,7 +62,6 @@ try {
 ?>
 --EXPECTF--
 Exception in __debugInfo:
-A Object
 Error: x in %s:%d
 Stack trace:
 #0 [internal function]: A->__debugInfo()
@@ -70,7 +69,6 @@ Stack trace:
 #2 {main}
 
 Exception in __debugInfo in anonymous class:
-A@anonymous Object
 Exception: y in %s:%d
 Stack trace:
 #0 [internal function]: A@anonymous->__debugInfo()
@@ -78,7 +76,6 @@ Stack trace:
 #2 {main}
 
 Exception in __destruct of __debugInfo in anonymous class:
-A@anonymous Object
 Exception: z_w_assign in %s:%d
 Stack trace:
 #0 [internal function]: class@anonymous->__destruct()
@@ -86,12 +83,6 @@ Stack trace:
 #2 {main}
 
 Exception occuring later on:
-Array
-(
-    [foo] => bar
-    [baz] => A Object
-
-)
 Error: x in %s:%d
 Stack trace:
 #0 [internal function]: A->__debugInfo()

--- a/Zend/tests/gh7922.phpt
+++ b/Zend/tests/gh7922.phpt
@@ -10,46 +10,31 @@ class A
     }
 }
 
-try {
-    $a = new A();
-    print_r($a);
-} catch (\Throwable $e) {
-    echo (string) $e . "\n";
-}
+echo "Exception in __debugInfo:\n";
 
 try {
-    $a = new class() extends A {
+    print_r(new A());
+} catch (\Throwable $e) {
+    echo $e . "\n";
+}
+
+echo "\nException in __debugInfo in anonymous class:\n";
+
+try {
+    print_r(new class() extends A {
         public function __debugInfo(): array
         {
             throw new \Exception('y');
         }
-    };
-    print_r($a, true);
+    });
 } catch (\Throwable $e) {
-    echo (string) $e . "\n";
+    echo $e . "\n";
 }
 
-try {
-    $a = new class() extends A {
-        public function __debugInfo(): array
-        {
-            new class() {
-                public function __destruct()
-                {
-                    throw new \Exception('z_wo_assign');
-                }
-            };
-
-            return ['foo' => 2];
-        }
-    };
-    print_r($a);
-} catch (\Throwable $e) {
-    echo (string) $e . "\n";
-}
+echo "\nException in __destruct of __debugInfo in anonymous class:\n";
 
 try {
-    $a = new class() extends A {
+    print_r(new class() extends A {
         public function __debugInfo(): array
         {
             $o = new class() {
@@ -61,33 +46,54 @@ try {
 
             return ['foo' => 2];
         }
-    };
-    print_r($a);
+    });
 } catch (\Throwable $e) {
-    echo (string) $e . "\n";
+    echo $e . "\n";
 }
+
+echo "\nException occuring later on:\n";
+
+try {
+    print_r(['foo' => 'bar', 'baz' => new A()]);
+} catch (\Throwable $e) {
+    echo $e . "\n";
+}
+
 ?>
 --EXPECTF--
-Error: x in %s:6
+Exception in __debugInfo:
+A Object
+Error: x in %s:%d
 Stack trace:
 #0 [internal function]: A->__debugInfo()
-#1 %s(12): print_r(Object(A))
+#1 %s(%d): print_r(Object(A))
 #2 {main}
 
-Exception: y in %s:21
+Exception in __debugInfo in anonymous class:
+A@anonymous Object
+Exception: y in %s:%d
 Stack trace:
 #0 [internal function]: A@anonymous->__debugInfo()
-#1 %s(24): print_r(Object(A@anonymous), true)
+#1 %s(%d): print_r(Object(A@anonymous))
 #2 {main}
 
-Exception: z_wo_assign in %s:35
+Exception in __destruct of __debugInfo in anonymous class:
+A@anonymous Object
+Exception: z_w_assign in %s:%d
 Stack trace:
-#0 [internal function]: A@anonymous->__destruct()
-#1 %s(42): print_r(Object(A@anonymous))
+#0 [internal function]: class@anonymous->__destruct()
+#1 %s(%d): print_r(Object(A@anonymous))
 #2 {main}
 
-Exception: z_w_assign in %s:54
+Exception occuring later on:
+Array
+(
+    [foo] => bar
+    [baz] => A Object
+
+)
+Error: x in %s:%d
 Stack trace:
-#0 [internal function]: A@anonymous->__destruct()
-#1 %s(61): print_r(Object(A@anonymous))
+#0 [internal function]: A->__debugInfo()
+#1 %s(%d): print_r(Array)
 #2 {main}

--- a/Zend/tests/gh7922.phpt
+++ b/Zend/tests/gh7922.phpt
@@ -51,10 +51,18 @@ try {
     echo $e . "\n";
 }
 
-echo "\nException occuring later on:\n";
+echo "\nException occuring later on (print_r):\n";
 
 try {
     print_r(['foo' => 'bar', 'baz' => new A()]);
+} catch (\Throwable $e) {
+    echo $e . "\n";
+}
+
+echo "\nException occuring later on (var_dump):\n";
+
+try {
+    var_dump(['u' => 1], ['foo' => 'bar', 'baz' => new A()], ['u' => 1]);
 } catch (\Throwable $e) {
     echo $e . "\n";
 }
@@ -82,9 +90,16 @@ Stack trace:
 #1 %s(%d): print_r(Object(A@anonymous))
 #2 {main}
 
-Exception occuring later on:
+Exception occuring later on (print_r):
 Error: x in %s:%d
 Stack trace:
 #0 [internal function]: A->__debugInfo()
 #1 %s(%d): print_r(Array)
+#2 {main}
+
+Exception occuring later on (var_dump):
+Error: x in %s:%d
+Stack trace:
+#0 [internal function]: A->__debugInfo()
+#1 %s(%d): var_dump(Array)
 #2 {main}

--- a/Zend/tests/gh7922.phpt
+++ b/Zend/tests/gh7922.phpt
@@ -28,6 +28,44 @@ try {
 } catch (\Throwable $e) {
     echo (string) $e . "\n";
 }
+
+try {
+    $a = new class() extends A {
+        public function __debugInfo(): array
+        {
+            new class() {
+                public function __destruct()
+                {
+                    throw new \Exception('z_wo_assign');
+                }
+            };
+
+            return ['foo' => 2];
+        }
+    };
+    print_r($a);
+} catch (\Throwable $e) {
+    echo (string) $e . "\n";
+}
+
+try {
+    $a = new class() extends A {
+        public function __debugInfo(): array
+        {
+            $o = new class() {
+                public function __destruct()
+                {
+                    throw new \Exception('z_w_assign');
+                }
+            };
+
+            return ['foo' => 2];
+        }
+    };
+    print_r($a);
+} catch (\Throwable $e) {
+    echo (string) $e . "\n";
+}
 ?>
 --EXPECTF--
 Error: x in %s:6
@@ -40,4 +78,16 @@ Exception: y in %s:21
 Stack trace:
 #0 [internal function]: A@anonymous->__debugInfo()
 #1 %s(24): print_r(Object(A@anonymous), true)
+#2 {main}
+
+Exception: z_wo_assign in %s:35
+Stack trace:
+#0 [internal function]: A@anonymous->__destruct()
+#1 %s(42): print_r(Object(A@anonymous))
+#2 {main}
+
+Exception: z_w_assign in %s:54
+Stack trace:
+#0 [internal function]: A@anonymous->__destruct()
+#1 %s(61): print_r(Object(A@anonymous))
 #2 {main}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -164,6 +164,11 @@ ZEND_API HashTable *zend_std_get_debug_info(zend_object *object, int *is_temp) /
 	}
 
 	zend_call_known_instance_method_with_0_params(ce->__debugInfo, object, &retval);
+	if (EG(exception)) {
+		zval_ptr_dtor(&retval);
+		return NULL;
+	}
+
 	switch (Z_TYPE(retval)) {
 		case IS_ARRAY:
 			if (!Z_REFCOUNTED(retval)) {
@@ -178,14 +183,14 @@ ZEND_API HashTable *zend_std_get_debug_info(zend_object *object, int *is_temp) /
 				zval_ptr_dtor(&retval);
 				return Z_ARRVAL(retval);
 			}
-		default:
-			zend_throw_error(NULL, ZEND_DEBUGINFO_FUNC_NAME "() must return an array");
-			zval_ptr_dtor(&retval);
-			/* fallthrough */
 		case IS_NULL:
 			*is_temp = 1;
 			ht = zend_new_array(0);
 			return ht;
+		default:
+			zend_throw_error(NULL, ZEND_DEBUGINFO_FUNC_NAME "() must return an array");
+			zval_ptr_dtor(&retval);
+			return NULL;
 	}
 
 	return NULL; /* Compilers are dumb and don't understand that noreturn means that the function does NOT need a return value... */

--- a/ext/ffi/tests/035.phpt
+++ b/ext/ffi/tests/035.phpt
@@ -23,6 +23,4 @@ object(FFI\CData:uint16_t[2])#%d (2) {
   [1]=>
   int(0)
 }
-object(FFI\CData:uint16_t[2])#%d (0) {
-}
 FFI\Exception: Use after free()

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -161,6 +161,9 @@ again:
 			Z_PROTECT_RECURSION_P(struc);
 
 			myht = zend_get_properties_for(struc, ZEND_PROP_PURPOSE_DEBUG);
+			if (EG(exception)) {
+				break;
+			}
 			class_name = Z_OBJ_HANDLER_P(struc, get_class_name)(Z_OBJ_P(struc));
 			php_printf("%sobject(%s)#%d (%d) {\n", COMMON, ZSTR_VAL(class_name), Z_OBJ_HANDLE_P(struc), myht ? zend_array_count(myht) : 0);
 			zend_string_release_ex(class_name, 0);


### PR DESCRIPTION
fixes https://github.com/php/php-src/issues/7922, impl. based on https://github.com/php/php-src/pull/7964

Fataling if `::__debugInfo()` doesn't return an array appears to be overly restrictive; we can handle that like returning null, namely by throwing an `Error` exception and returning an empty array instead.

PS: if null is returned, we don't throw an exception like before. Exception is only thrown if not array|null.