### PR TITLE
Increase test portability

### DIFF
--- a/ext/com_dotnet/tests/bug77578.phpt
+++ b/ext/com_dotnet/tests/bug77578.phpt
@@ -7,9 +7,13 @@ com_dotnet
 // To actually be able to verify the crash during shutdown on Windows, we have
 // to execute a PHP subprocess, and check its exit status.
 $php = PHP_BINARY;
-$ini = php_ini_loaded_file();
-$iniopt = $ini ? "-c $ini" : '';
-$command = "$php $iniopt -d extension=com_dotnet -d com.autoregister_typelib=1 -r \"new COM('WbemScripting.SWbemLocator');\"";
+$extension_dir = ini_get("extension_dir");
+$script = <<<SCRIPT
+if (!extension_loaded('com_dotnet')) dl('com_dotnet');
+ini_set('com.autoregister_typelib', '1');
+new COM('WbemScripting.SWbemLocator');
+SCRIPT;
+$command = "$php -d extension_dir=$extension_dir -r \"$script\"";
 exec($command, $output, $status);
 var_dump($output, $status);
 ?>


### PR DESCRIPTION
The test as is can only work if com_dotnet is built dynamically, and
not already loaded via the php.ini file.  While this is given on
AppVeyor, it may not be given in other environments.