### PR TITLE
implement fseek for zip stream when possible with libzip 1.9.1

### DIFF
--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -31,7 +31,7 @@ extern zend_module_entry zip_module_entry;
 #define ZIP_OVERWRITE ZIP_TRUNCATE
 #endif
 
-#define PHP_ZIP_VERSION "1.20.1"
+#define PHP_ZIP_VERSION "1.21.0"
 
 #define ZIP_OPENBASEDIR_CHECKPATH(filename) php_check_open_basedir(filename)
 
@@ -78,5 +78,7 @@ php_stream *php_stream_zip_opener(php_stream_wrapper *wrapper, const char *path,
 php_stream *php_stream_zip_open(struct zip *arch, struct zip_stat *sb, const char *mode, zip_flags_t flags STREAMS_DC);
 
 extern const php_stream_wrapper php_stream_zip_wrapper;
+
+#define LIBZIP_ATLEAST(m,n,p) (((m<<16) + (n<<8) + p) <= ((LIBZIP_VERSION_MAJOR<<16) + (LIBZIP_VERSION_MINOR<<8) + LIBZIP_VERSION_MICRO))
 
 #endif	/* PHP_ZIP_H */

--- a/ext/zip/tests/oo_stream_seek.phpt
+++ b/ext/zip/tests/oo_stream_seek.phpt
@@ -1,0 +1,79 @@
+--TEST--
+getStream and seek
+--EXTENSIONS--
+zip
+--SKIPIF--
+<?php
+if(version_compare(ZipArchive::LIBZIP_VERSION, '1.9.1', '<')) die('skip libzip < 1.9.1');
+?>
+--FILE--
+<?php
+var_dump(ZipArchive::LIBZIP_VERSION);
+$file = __DIR__ . '/test.zip';
+$zip = new ZipArchive;
+if (!$zip->open($file)) {
+	exit('failed');
+}
+echo "+ ZipArchive::getStream\n";
+$fp = $zip->getStream('bar');
+if(!$fp) exit("\n");
+var_dump($fp);
+
+var_dump(fseek($fp, 1, SEEK_SET));
+var_dump(fread($fp, 2));
+var_dump(ftell($fp));
+var_dump(fseek($fp, 0, SEEK_SET));
+var_dump(fread($fp, 2));
+var_dump(ftell($fp));
+
+fclose($fp);
+
+echo "+ ZipArchive::getStream no supported\n";
+$fp = $zip->getStream('entry1.txt');
+if(!$fp) exit("\n");
+var_dump($fp);
+
+var_dump(fseek($fp, 2, SEEK_SET));
+var_dump(fread($fp, 2));
+fclose($fp);
+
+$zip->close();
+
+
+echo "+ Zip Stream\n";
+$fp = fopen('zip://' . __DIR__ . '/test.zip#bar', 'rb');
+if(!$fp) exit("\n");
+var_dump($fp);
+var_dump(fseek($fp, 1, SEEK_SET));
+var_dump(fread($fp, 2));
+var_dump(ftell($fp));
+var_dump(fseek($fp, 0, SEEK_SET));
+var_dump(fread($fp, 2));
+var_dump(ftell($fp));
+fclose($fp);
+
+?>
+--EXPECTF--
+string(%d) "%s"
++ ZipArchive::getStream
+resource(%d) of type (stream)
+int(0)
+string(2) "ar"
+int(3)
+int(0)
+string(2) "ba"
+int(2)
++ ZipArchive::getStream no supported
+resource(%d) of type (stream)
+
+Warning: fseek(): %s does not support seeking in %s
+int(-1)
+string(2) "en"
++ Zip Stream
+resource(%d) of type (stream)
+int(0)
+string(2) "ar"
+int(3)
+int(0)
+string(2) "ba"
+int(2)

--- a/ext/zip/tests/stream_meta_data.phpt
+++ b/ext/zip/tests/stream_meta_data.phpt
@@ -45,7 +45,7 @@ array(8) {
   ["unread_bytes"]=>
   int(0)
   ["seekable"]=>
-  bool(false)
+  bool(%s)
   ["uri"]=>
   string(3) "foo"
 }
@@ -65,7 +65,7 @@ array(9) {
   ["unread_bytes"]=>
   int(0)
   ["seekable"]=>
-  bool(false)
+  bool(%s)
   ["uri"]=>
   string(%d) "zip://%stest_with_comment.zip#foo"
 }

--- a/ext/zip/zip_stream.c
+++ b/ext/zip/zip_stream.c
@@ -197,6 +197,35 @@ static int php_zip_ops_stat(php_stream *stream, php_stream_statbuf *ssb) /* {{{ 
 }
 /* }}} */
 
+#if LIBZIP_ATLEAST(1,9,1)
+/* {{{ php_zip_ops_seek */
+static int php_zip_ops_seek(php_stream *stream, zend_off_t offset, int whence, zend_off_t *newoffset)
+{
+	int ret = -1;
+	STREAM_DATA_FROM_STREAM();
+
+	if (self->zf) {
+		ret = zip_fseek(self->zf, offset, whence);
+		*newoffset = zip_ftell(self->zf);
+	}
+
+	return ret;
+}
+/* }}} */
+
+/* with seek command */
+const php_stream_ops php_stream_zipio_seek_ops = {
+	php_zip_ops_write, php_zip_ops_read,
+	php_zip_ops_close, php_zip_ops_flush,
+	"zip",
+	php_zip_ops_seek, /* seek */
+	NULL, /* cast */
+	php_zip_ops_stat, /* stat */
+	NULL  /* set_option */
+};
+#endif
+
+/* without seek command */
 const php_stream_ops php_stream_zipio_ops = {
 	php_zip_ops_write, php_zip_ops_read,
 	php_zip_ops_close, php_zip_ops_flush,
@@ -228,7 +257,14 @@ php_stream *php_stream_zip_open(struct zip *arch, struct zip_stat *sb, const cha
 			self->zf = zf;
 			self->stream = NULL;
 			self->cursor = 0;
-			stream = php_stream_alloc(&php_stream_zipio_ops, self, NULL, mode);
+#if LIBZIP_ATLEAST(1,9,1)
+			if (zip_file_is_seekable(zf) > 0) {
+				stream = php_stream_alloc(&php_stream_zipio_seek_ops, self, NULL, mode);
+			} else
+#endif
+			{
+				stream = php_stream_alloc(&php_stream_zipio_ops, self, NULL, mode);
+			}
 			stream->orig_path = estrdup(sb->name);
 		}
 	}
@@ -307,7 +343,14 @@ php_stream *php_stream_zip_opener(php_stream_wrapper *wrapper,
 			self->zf = zf;
 			self->stream = NULL;
 			self->cursor = 0;
-			stream = php_stream_alloc(&php_stream_zipio_ops, self, NULL, mode);
+#if LIBZIP_ATLEAST(1,9,1)
+			if (zip_file_is_seekable(zf) > 0) {
+				stream = php_stream_alloc(&php_stream_zipio_seek_ops, self, NULL, mode);
+			} else
+#endif
+			{
+				stream = php_stream_alloc(&php_stream_zipio_ops, self, NULL, mode);
+			}
 
 			if (opened_path) {
 				*opened_path = zend_string_init(path, strlen(path), 0);


### PR DESCRIPTION
Notice `zip_file_is_seekable` was added in 1.9.0 but unusable, works in 1.9.1
