### PR TITLE
crypt_sha256/crypt_sha512, fix build with more recent versions of cla…

### DIFF
--- a/ext/standard/crypt_sha256.c
+++ b/ext/standard/crypt_sha256.c
@@ -371,15 +371,15 @@ char * php_sha256_crypt_r(const char *key, const char *salt, char *buffer, int b
 	salt_len = MIN(strcspn(salt, "$"), SALT_LEN_MAX);
 	key_len = strlen(key);
 
-	if ((key - (char *) 0) % __alignof__ (uint32_t) != 0) {
+	if ((uintptr_t)key % __alignof__ (uint32_t) != 0) {
 		char *tmp = (char *) alloca(key_len + __alignof__(uint32_t));
-		key = copied_key = memcpy(tmp + __alignof__(uint32_t) - (tmp - (char *) 0) % __alignof__(uint32_t), key, key_len);
+		key = copied_key = memcpy(tmp + __alignof__(uint32_t) - (uintptr_t)tmp  % __alignof__(uint32_t), key, key_len);
 	}
 
-	if ((salt - (char *) 0) % __alignof__(uint32_t) != 0) {
+	if ((uintptr_t)salt % __alignof__(uint32_t) != 0) {
 		char *tmp = (char *) alloca(salt_len + 1 + __alignof__(uint32_t));
 		salt = copied_salt =
-		memcpy(tmp + __alignof__(uint32_t) - (tmp - (char *) 0) % __alignof__ (uint32_t), salt, salt_len);
+		memcpy(tmp + __alignof__(uint32_t) - (uintptr_t)tmp % __alignof__ (uint32_t), salt, salt_len);
 		copied_salt[salt_len] = 0;
 	}
 

--- a/ext/standard/crypt_sha512.c
+++ b/ext/standard/crypt_sha512.c
@@ -405,15 +405,15 @@ php_sha512_crypt_r(const char *key, const char *salt, char *buffer, int buflen) 
 	salt_len = MIN(strcspn(salt, "$"), SALT_LEN_MAX);
 	key_len = strlen(key);
 
-	if ((key - (char *) 0) % __alignof__ (uint64_t) != 0) {
+	if ((uintptr_t)key % __alignof__ (uint64_t) != 0) {
 		char *tmp = (char *) alloca (key_len + __alignof__ (uint64_t));
 		key = copied_key =
-		memcpy(tmp + __alignof__(uint64_t) - (tmp - (char *) 0) % __alignof__(uint64_t), key, key_len);
+		memcpy(tmp + __alignof__(uint64_t) - (uintptr_t)tmp % __alignof__(uint64_t), key, key_len);
 	}
 
-	if ((salt - (char *) 0) % __alignof__ (uint64_t) != 0) {
+	if ((uintptr_t)salt % __alignof__ (uint64_t) != 0) {
 		char *tmp = (char *) alloca(salt_len + 1 + __alignof__(uint64_t));
-		salt = copied_salt = memcpy(tmp + __alignof__(uint64_t) - (tmp - (char *) 0) % __alignof__(uint64_t), salt, salt_len);
+		salt = copied_salt = memcpy(tmp + __alignof__(uint64_t) - (uintptr_t)tmp % __alignof__(uint64_t), salt, salt_len);
 		copied_salt[salt_len] = 0;
 	}
 

--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -910,7 +910,7 @@ static ssize_t phpdbg_stdiop_write(php_stream *stream, const char *buf, size_t c
 	while (data->fd >= 0) {
 		struct stat stat[3];
 		memset(stat, 0, sizeof(stat));
-		if (((fstat(fileno(stderr), &stat[2]) < 0) & (fstat(fileno(stdout), &stat[0]) < 0)) | (fstat(data->fd, &stat[1]) < 0)) {
+		if (((fstat(fileno(stderr), &stat[2]) < 0) && (fstat(fileno(stdout), &stat[0]) < 0)) || (fstat(data->fd, &stat[1]) < 0)) {
 			break;
 		}
 


### PR DESCRIPTION
…ng (> 11).

clang picks up the address subtraction to null as UB, but the implementations
are based on glibc.

`error: performing pointer subtraction with a null pointer has undefined behavior [-Werror,-Wnull-pointer-subtraction]
        if ((key - (char *) 0) % __alignof__ (uint64_t) != 0) {`