### PR TITLE
Add FPM process_restart_strategy option

### DIFF
--- a/sapi/fpm/fpm/fpm_children.c
+++ b/sapi/fpm/fpm/fpm_children.c
@@ -177,133 +177,150 @@ int fpm_children_free(struct fpm_child_s *child) /* {{{ */
 }
 /* }}} */
 
-void fpm_children_bury() /* {{{ */
+static bool fpm_child_bury_ex(pid_t pid, int status)
 {
-	int status;
-	pid_t pid;
 	struct fpm_child_s *child;
+	char buf[128];
+	int severity = ZLOG_NOTICE;
+	int restart_child = 1;
 
-	while ( (pid = waitpid(-1, &status, WNOHANG | WUNTRACED)) > 0) {
-		char buf[128];
-		int severity = ZLOG_NOTICE;
-		int restart_child = 1;
+	child = fpm_child_find(pid);
 
-		child = fpm_child_find(pid);
+	if (WIFEXITED(status)) {
 
-		if (WIFEXITED(status)) {
+		snprintf(buf, sizeof(buf), "with code %d", WEXITSTATUS(status));
 
-			snprintf(buf, sizeof(buf), "with code %d", WEXITSTATUS(status));
-
-			/* if it's been killed because of dynamic process management
-			 * don't restart it automatically
-			 */
-			if (child && child->idle_kill) {
-				restart_child = 0;
-			}
-
-			if (WEXITSTATUS(status) != FPM_EXIT_OK) {
-				severity = ZLOG_WARNING;
-			}
-
-		} else if (WIFSIGNALED(status)) {
-			const char *signame = fpm_signal_names[WTERMSIG(status)];
-#ifdef WCOREDUMP
-			const char *have_core = WCOREDUMP(status) ? " - core dumped" : "";
-#else
-			const char* have_core = "";
-#endif
-
-			if (signame == NULL) {
-				signame = "";
-			}
-
-			snprintf(buf, sizeof(buf), "on signal %d (%s%s)", WTERMSIG(status), signame, have_core);
-
-			/* if it's been killed because of dynamic process management
-			 * don't restart it automatically
-			 */
-			if (child && child->idle_kill && WTERMSIG(status) == SIGQUIT) {
-				restart_child = 0;
-			}
-
-			if (WTERMSIG(status) != SIGQUIT) { /* possible request loss */
-				severity = ZLOG_WARNING;
-			}
-		} else if (WIFSTOPPED(status)) {
-
-			zlog(ZLOG_NOTICE, "child %d stopped for tracing", (int) pid);
-
-			if (child && child->tracer) {
-				child->tracer(child);
-			}
-
-			continue;
+		/* if it's been killed because of dynamic process management
+			* don't restart it automatically
+			*/
+		if (child && child->idle_kill) {
+			restart_child = 0;
 		}
 
-		if (child) {
-			struct fpm_worker_pool_s *wp = child->wp;
-			struct timeval tv1, tv2;
+		if (WEXITSTATUS(status) != FPM_EXIT_OK) {
+			severity = ZLOG_WARNING;
+		}
 
-			fpm_child_unlink(child);
+	} else if (WIFSIGNALED(status)) {
+		const char *signame = fpm_signal_names[WTERMSIG(status)];
+#ifdef WCOREDUMP
+		const char *have_core = WCOREDUMP(status) ? " - core dumped" : "";
+#else
+		const char* have_core = "";
+#endif
 
-			fpm_scoreboard_proc_free(child);
+		if (signame == NULL) {
+			signame = "";
+		}
 
-			fpm_clock_get(&tv1);
+		snprintf(buf, sizeof(buf), "on signal %d (%s%s)", WTERMSIG(status), signame, have_core);
 
-			timersub(&tv1, &child->started, &tv2);
+		/* if it's been killed because of dynamic process management
+			* don't restart it automatically
+			*/
+		if (child && child->idle_kill && WTERMSIG(status) == SIGQUIT) {
+			restart_child = 0;
+		}
 
-			if (restart_child) {
-				if (!fpm_pctl_can_spawn_children()) {
-					severity = ZLOG_DEBUG;
-				}
-				zlog(severity, "[pool %s] child %d exited %s after %ld.%06d seconds from start", wp->config->name, (int) pid, buf, (long)tv2.tv_sec, (int) tv2.tv_usec);
-			} else {
-				zlog(ZLOG_DEBUG, "[pool %s] child %d has been killed by the process management after %ld.%06d seconds from start", wp->config->name, (int) pid, (long)tv2.tv_sec, (int) tv2.tv_usec);
+		if (WTERMSIG(status) != SIGQUIT) { /* possible request loss */
+			severity = ZLOG_WARNING;
+		}
+	} else if (WIFSTOPPED(status)) {
+
+		zlog(ZLOG_NOTICE, "child %d stopped for tracing", (int) pid);
+
+		if (child && child->tracer) {
+			child->tracer(child);
+		}
+
+		return false;
+	}
+
+	if (child) {
+		struct fpm_worker_pool_s *wp = child->wp;
+		struct timeval tv1, tv2;
+
+		fpm_child_unlink(child);
+
+		fpm_scoreboard_proc_free(child);
+
+		fpm_clock_get(&tv1);
+
+		timersub(&tv1, &child->started, &tv2);
+
+		if (restart_child) {
+			if (!fpm_pctl_can_spawn_children()) {
+				severity = ZLOG_DEBUG;
+			}
+			zlog(severity, "[pool %s] child %d exited %s after %ld.%06d seconds from start", wp->config->name, (int) pid, buf, (long)tv2.tv_sec, (int) tv2.tv_usec);
+		} else {
+			zlog(ZLOG_DEBUG, "[pool %s] child %d has been killed by the process management after %ld.%06d seconds from start", wp->config->name, (int) pid, (long)tv2.tv_sec, (int) tv2.tv_usec);
+		}
+
+		fpm_child_close(child, 1 /* in event_loop */);
+
+		fpm_pctl_child_exited();
+
+		if (last_faults && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS)) {
+			time_t now = tv1.tv_sec;
+			int restart_condition = 1;
+			int i;
+
+			last_faults[fault++] = now;
+
+			if (fault == fpm_global_config.emergency_restart_threshold) {
+				fault = 0;
 			}
 
-			fpm_child_close(child, 1 /* in event_loop */);
-
-			fpm_pctl_child_exited();
-
-			if (last_faults && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS)) {
-				time_t now = tv1.tv_sec;
-				int restart_condition = 1;
-				int i;
-
-				last_faults[fault++] = now;
-
-				if (fault == fpm_global_config.emergency_restart_threshold) {
-					fault = 0;
-				}
-
-				for (i = 0; i < fpm_global_config.emergency_restart_threshold; i++) {
-					if (now - last_faults[i] > fpm_global_config.emergency_restart_interval) {
-						restart_condition = 0;
-						break;
-					}
-				}
-
-				if (restart_condition) {
-
-					zlog(ZLOG_WARNING, "failed processes threshold (%d in %d sec) is reached, initiating reload", fpm_global_config.emergency_restart_threshold, fpm_global_config.emergency_restart_interval);
-
-					fpm_pctl(FPM_PCTL_STATE_RELOADING, FPM_PCTL_ACTION_SET);
-				}
-			}
-
-			if (restart_child) {
-				fpm_children_make(wp, 1 /* in event loop */, 1, 0);
-
-				if (fpm_globals.is_child) {
+			for (i = 0; i < fpm_global_config.emergency_restart_threshold; i++) {
+				if (now - last_faults[i] > fpm_global_config.emergency_restart_interval) {
+					restart_condition = 0;
 					break;
 				}
 			}
-		} else {
-			zlog(ZLOG_ALERT, "oops, unknown child (%d) exited %s. Please open a bug report (https://github.com/php/php-src/issues).", pid, buf);
+
+			if (restart_condition) {
+
+				zlog(ZLOG_WARNING, "failed processes threshold (%d in %d sec) is reached, initiating reload", fpm_global_config.emergency_restart_threshold, fpm_global_config.emergency_restart_interval);
+
+				fpm_pctl(FPM_PCTL_STATE_RELOADING, FPM_PCTL_ACTION_SET);
+			}
+		}
+
+		if (restart_child) {
+			fpm_children_make(wp, 1 /* in event loop */, 1, 0);
+
+			if (fpm_globals.is_child) {
+				return true;
+			}
+		}
+	} else {
+		zlog(ZLOG_ALERT, "oops, unknown child (%d) exited %s. Please open a bug report (https://github.com/php/php-src/issues).", pid, buf);
+	}
+
+	return false;
+}
+
+void fpm_child_bury(pid_t pid)
+{
+	int status;
+
+	if (waitpid(pid, &status, WNOHANG | WUNTRACED) > 0) {
+		fpm_child_bury_ex(pid, status);
+	}
+}
+
+void fpm_children_bury()
+{
+	int status;
+	pid_t pid;
+
+	while ((pid = waitpid(-1, &status, WNOHANG | WUNTRACED)) > 0) {
+		if (fpm_child_bury_ex(pid, status)) {
+			break;
 		}
 	}
 }
-/* }}} */
 
 static struct fpm_child_s *fpm_resources_prepare(struct fpm_worker_pool_s *wp) /* {{{ */
 {

--- a/sapi/fpm/fpm/fpm_children.h
+++ b/sapi/fpm/fpm/fpm_children.h
@@ -13,6 +13,7 @@
 int fpm_children_create_initial(struct fpm_worker_pool_s *wp);
 int fpm_children_free(struct fpm_child_s *child);
 void fpm_children_bury(void);
+void fpm_child_bury(pid_t pid);
 int fpm_children_init_main(void);
 int fpm_children_make(struct fpm_worker_pool_s *wp, int in_event_loop, int nb_to_spawn, int is_debug);
 

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include "php.h"
 
+/* Process manager to string */
 #define PM2STR(a) (a == PM_STYLE_STATIC ? "static" : (a == PM_STYLE_DYNAMIC ? "dynamic" : "ondemand"))
 
 #define FPM_CONF_MAX_PONG_LENGTH 64
@@ -36,6 +37,7 @@ struct fpm_global_config_s {
 	int process_control_timeout;
 	int process_max;
 	int process_priority;
+	int process_restart_strategy;
 	int daemonize;
 	int rlimit_files;
 	int rlimit_core;
@@ -115,6 +117,11 @@ enum {
 	PM_STYLE_STATIC = 1,
 	PM_STYLE_DYNAMIC = 2,
 	PM_STYLE_ONDEMAND = 3
+};
+
+enum {
+	FPM_PROC_RESTART_STRATEGY_ALL = 1,
+	FPM_PROC_RESTART_STRATEGY_SINGLE = 2,
 };
 
 int fpm_conf_init_main(int test_conf, int force_daemon);

--- a/sapi/fpm/fpm/fpm_signals.h
+++ b/sapi/fpm/fpm/fpm_signals.h
@@ -5,6 +5,11 @@
 
 #include <signal.h>
 
+struct fpm_signal_event_s {
+	char sig_char;
+	pid_t pid;
+};
+
 int fpm_signals_init_main(void);
 int fpm_signals_init_child(void);
 int fpm_signals_get_fd(void);

--- a/sapi/fpm/php-fpm.conf.in
+++ b/sapi/fpm/php-fpm.conf.in
@@ -79,6 +79,14 @@
 ; Default Value: 0
 ;process_control_timeout = 0
 
+; Policy used to restart a child process when it is killed.
+; Possible Values:
+;   all  - all killed child processes are iterated and restarted when a single
+;          child process is killed.
+;   single - only a killed child process is restarted when it is killed.
+; Default Value: all
+;process_restart_policy = single
+
 ; The maximum number of processes FPM will fork. This has been designed to control
 ; the global number of processes when using dynamic PM within a lot of pools.
 ; Use it with caution.

--- a/sapi/fpm/tests/proc-restart-strategy-single.phpt
+++ b/sapi/fpm/tests/proc-restart-strategy-single.phpt
@@ -1,0 +1,46 @@
+--TEST--
+FPM:
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+process_restart_strategy = single
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 2
+EOT;
+
+$code = <<<EOT
+<?php
+echo getmypid();
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$pid = $tester->request()->getBody();
+if (!is_numeric($pid)) {
+    die("ERROR: pid not returned");
+}
+$tester->signal('TERM', $pid);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
This adds an option that changes the way how the processes is restarted. The currently behavior which is still default kill all the child process when it gets SIGCHLD. The might be problematic if the child process immediately dies which can result in an endless loop and FPM master process being unresponsive as described in [bug #61558](https://bugs.php.net/bug.php?id=61558). The new `single` policy creates event just for a killed child (taken from a signal sender pid) which should be much more scalable and allow FPM master process responds to other events potentially. This can be further optimised and and some sort of delay for this scenario introduced which is in the future scope.

The obvious question is why this is not just replacing the old behavior without any option. The answer is to be safe because it might require some testing on many workloads so adding that initially as an option and later change the default should be much safer. It's kind of an experiments setting though.