### PR TITLE
Update warning messages about undefined variables

### DIFF
--- a/Zend/tests/019.phpt
+++ b/Zend/tests/019.phpt
@@ -357,7 +357,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -369,7 +369,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -381,7 +381,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -393,7 +393,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -405,7 +405,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -417,7 +417,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -429,7 +429,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -441,7 +441,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -453,7 +453,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -465,7 +465,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -477,7 +477,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -489,7 +489,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -501,7 +501,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -513,7 +513,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -525,7 +525,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -537,7 +537,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -549,7 +549,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -561,7 +561,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -573,7 +573,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -585,7 +585,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -597,7 +597,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -609,7 +609,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -621,7 +621,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -633,7 +633,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -645,7 +645,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -657,7 +657,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -669,7 +669,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var in %s on line %d
+Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -686,7 +686,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -702,18 +702,18 @@ bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -729,18 +729,18 @@ bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -756,18 +756,18 @@ bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -783,18 +783,18 @@ bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -816,13 +816,13 @@ array(3) {
   int(4)
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(3) {
   [1]=>
@@ -840,13 +840,13 @@ array(2) {
   int(4)
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(2) {
   [2]=>
@@ -860,13 +860,13 @@ array(1) {
   int(4)
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   [3]=>
@@ -876,18 +876,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -907,13 +907,13 @@ array(2) {
   float(5.6)
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(2) {
   [1]=>
@@ -927,13 +927,13 @@ array(1) {
   float(5.6)
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   [2]=>
@@ -943,18 +943,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -972,13 +972,13 @@ array(1) {
   string(3) "two"
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   [2]=>
@@ -988,18 +988,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -1017,13 +1017,13 @@ array(1) {
   string(2) "30"
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   ["Age"]=>
@@ -1033,18 +1033,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -1068,13 +1068,13 @@ array(4) {
   string(0) ""
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(4) {
   [1]=>
@@ -1096,13 +1096,13 @@ array(3) {
   string(0) ""
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(3) {
   ["One"]=>
@@ -1120,13 +1120,13 @@ array(2) {
   string(0) ""
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(2) {
   [2]=>
@@ -1140,13 +1140,13 @@ array(1) {
   string(0) ""
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   [""]=>
@@ -1156,18 +1156,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val in %s on line %d
+Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var in %s on line %d
+Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -1185,7 +1185,7 @@ bool(true)
 bool(false)
 bool(false)
 
-Warning: Undefined variable $resource in %s on line %d
+Warning: Undefined variable $resource (This will become an error in PHP 9.0) in %s on line %d
 NULL
 -- Iteration 2 --
 resource(%d) of type (stream)
@@ -1198,10 +1198,10 @@ bool(true)
 bool(false)
 bool(false)
 
-Warning: Undefined variable $resource in %s on line %d
+Warning: Undefined variable $resource (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $resources in %s on line %d
+Warning: Undefined variable $resources (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(true)
@@ -1218,16 +1218,16 @@ object(Point)#%d (3) {
 bool(true)
 bool(false)
 
-Warning: Undefined variable $lable in %s on line %d
+Warning: Undefined variable $lable (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $lable in %s on line %d
+Warning: Undefined variable $lable (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $lable in %s on line %d
+Warning: Undefined variable $lable (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $lable in %s on line %d
+Warning: Undefined variable $lable (This will become an error in PHP 9.0) in %s on line %d
 bool(true)
 object(Point)#%d (3) {
   ["x"]=>
@@ -1252,7 +1252,7 @@ bool(false)
 bool(false)
 bool(true)
 
-Warning: Undefined variable $point1 in %s on line %d
+Warning: Undefined variable $point1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(true)
@@ -1282,7 +1282,7 @@ value of static_var before unset: 1
 bool(true)
 bool(false)
 
-Warning: Undefined variable $static_var in %s on line %d
+Warning: Undefined variable $static_var (This will become an error in PHP 9.0) in %s on line %d
 value of static_var after unset: 
 bool(false)
 bool(true)
@@ -1291,7 +1291,7 @@ value of static_var before unset: 2
 bool(true)
 bool(false)
 
-Warning: Undefined variable $static_var in %s on line %d
+Warning: Undefined variable $static_var (This will become an error in PHP 9.0) in %s on line %d
 value of static_var after unset: 
 bool(false)
 bool(true)
@@ -1300,7 +1300,7 @@ value of static_var before unset: 3
 bool(true)
 bool(false)
 
-Warning: Undefined variable $static_var in %s on line %d
+Warning: Undefined variable $static_var (This will become an error in PHP 9.0) in %s on line %d
 value of static_var after unset: 
 bool(false)
 bool(true)

--- a/Zend/tests/019.phpt
+++ b/Zend/tests/019.phpt
@@ -357,7 +357,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -369,7 +369,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -381,7 +381,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -393,7 +393,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -405,7 +405,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -417,7 +417,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -429,7 +429,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -441,7 +441,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -453,7 +453,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -465,7 +465,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -477,7 +477,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -489,7 +489,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -501,7 +501,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -513,7 +513,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -525,7 +525,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -537,7 +537,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -549,7 +549,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -561,7 +561,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -573,7 +573,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -585,7 +585,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -597,7 +597,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -609,7 +609,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -621,7 +621,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -633,7 +633,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -645,7 +645,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -657,7 +657,7 @@ bool(true)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -669,7 +669,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $scalar_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $scalar_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -686,7 +686,7 @@ bool(true)
 bool(true)
 bool(true)
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -702,18 +702,18 @@ bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -729,18 +729,18 @@ bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -756,18 +756,18 @@ bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -783,18 +783,18 @@ bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -816,13 +816,13 @@ array(3) {
   int(4)
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(3) {
   [1]=>
@@ -840,13 +840,13 @@ array(2) {
   int(4)
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(2) {
   [2]=>
@@ -860,13 +860,13 @@ array(1) {
   int(4)
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   [3]=>
@@ -876,18 +876,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -907,13 +907,13 @@ array(2) {
   float(5.6)
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(2) {
   [1]=>
@@ -927,13 +927,13 @@ array(1) {
   float(5.6)
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   [2]=>
@@ -943,18 +943,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -972,13 +972,13 @@ array(1) {
   string(3) "two"
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   [2]=>
@@ -988,18 +988,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -1017,13 +1017,13 @@ array(1) {
   string(2) "30"
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   ["Age"]=>
@@ -1033,18 +1033,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -1068,13 +1068,13 @@ array(4) {
   string(0) ""
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(4) {
   [1]=>
@@ -1096,13 +1096,13 @@ array(3) {
   string(0) ""
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(3) {
   ["One"]=>
@@ -1120,13 +1120,13 @@ array(2) {
   string(0) ""
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(2) {
   [2]=>
@@ -1140,13 +1140,13 @@ array(1) {
   string(0) ""
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(1) {
   [""]=>
@@ -1156,18 +1156,18 @@ array(1) {
 array(0) {
 }
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $key_val (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key_val (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 array(0) {
 }
 
-Warning: Undefined variable $array_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $array_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)
@@ -1185,7 +1185,7 @@ bool(true)
 bool(false)
 bool(false)
 
-Warning: Undefined variable $resource (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $resource (this will become an error in PHP 9.0) in %s on line %d
 NULL
 -- Iteration 2 --
 resource(%d) of type (stream)
@@ -1198,10 +1198,10 @@ bool(true)
 bool(false)
 bool(false)
 
-Warning: Undefined variable $resource (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $resource (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $resources (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $resources (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(true)
@@ -1218,16 +1218,16 @@ object(Point)#%d (3) {
 bool(true)
 bool(false)
 
-Warning: Undefined variable $lable (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $lable (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $lable (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $lable (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 
-Warning: Undefined variable $lable (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $lable (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $lable (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $lable (this will become an error in PHP 9.0) in %s on line %d
 bool(true)
 object(Point)#%d (3) {
   ["x"]=>
@@ -1252,7 +1252,7 @@ bool(false)
 bool(false)
 bool(true)
 
-Warning: Undefined variable $point1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $point1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(true)
@@ -1282,7 +1282,7 @@ value of static_var before unset: 1
 bool(true)
 bool(false)
 
-Warning: Undefined variable $static_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $static_var (this will become an error in PHP 9.0) in %s on line %d
 value of static_var after unset: 
 bool(false)
 bool(true)
@@ -1291,7 +1291,7 @@ value of static_var before unset: 2
 bool(true)
 bool(false)
 
-Warning: Undefined variable $static_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $static_var (this will become an error in PHP 9.0) in %s on line %d
 value of static_var after unset: 
 bool(false)
 bool(true)
@@ -1300,7 +1300,7 @@ value of static_var before unset: 3
 bool(true)
 bool(false)
 
-Warning: Undefined variable $static_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $static_var (this will become an error in PHP 9.0) in %s on line %d
 value of static_var after unset: 
 bool(false)
 bool(true)

--- a/Zend/tests/024.phpt
+++ b/Zend/tests/024.phpt
@@ -15,30 +15,30 @@ var_dump($a->$b->{$c[1]});
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 NULL
 
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $c in %s on line %d
+Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 NULL
 
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 int(1)
 
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $b in %s on line %d
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
 int(0)
 
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $b in %s on line %d
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
 int(1)
 
 Warning: Attempt to read property "1" on int in %s on line %d
@@ -47,7 +47,7 @@ NULL
 Warning: Attempt to read property "1" on int in %s on line %d
 NULL
 
-Warning: Undefined variable $c in %s on line %d
+Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 

--- a/Zend/tests/024.phpt
+++ b/Zend/tests/024.phpt
@@ -15,30 +15,30 @@ var_dump($a->$b->{$c[1]});
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 NULL
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $c (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 NULL
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 int(1)
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line %d
 int(0)
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line %d
 int(1)
 
 Warning: Attempt to read property "1" on int in %s on line %d
@@ -47,7 +47,7 @@ NULL
 Warning: Attempt to read property "1" on int in %s on line %d
 NULL
 
-Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $c (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 

--- a/Zend/tests/033.phpt
+++ b/Zend/tests/033.phpt
@@ -25,7 +25,7 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $arr (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $arr (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
@@ -37,7 +37,7 @@ Warning: Trying to access array offset on value of type null in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
-Warning: Undefined variable $arr (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $arr (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
@@ -49,7 +49,7 @@ Warning: Trying to access array offset on value of type null in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
-Warning: Undefined variable $arr (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $arr (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 

--- a/Zend/tests/033.phpt
+++ b/Zend/tests/033.phpt
@@ -25,7 +25,7 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $arr in %s on line %d
+Warning: Undefined variable $arr (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
@@ -37,7 +37,7 @@ Warning: Trying to access array offset on value of type null in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
-Warning: Undefined variable $arr in %s on line %d
+Warning: Undefined variable $arr (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
@@ -49,7 +49,7 @@ Warning: Trying to access array offset on value of type null in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
-Warning: Undefined variable $arr in %s on line %d
+Warning: Undefined variable $arr (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 

--- a/Zend/tests/array_unpack/undef_var.phpt
+++ b/Zend/tests/array_unpack/undef_var.phpt
@@ -7,7 +7,7 @@ var_dump([...$arr]);
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $arr in %s on line %d
+Warning: Undefined variable $arr (This will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught Error: Only arrays and Traversables can be unpacked in %s:%d
 Stack trace:

--- a/Zend/tests/array_unpack/undef_var.phpt
+++ b/Zend/tests/array_unpack/undef_var.phpt
@@ -7,7 +7,7 @@ var_dump([...$arr]);
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $arr (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $arr (this will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught Error: Only arrays and Traversables can be unpacked in %s:%d
 Stack trace:

--- a/Zend/tests/arrow_functions/002.phpt
+++ b/Zend/tests/arrow_functions/002.phpt
@@ -9,5 +9,5 @@ var_dump((fn() => $b + $c)());
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $c in %s on line %d
+Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
 int(1)

--- a/Zend/tests/arrow_functions/002.phpt
+++ b/Zend/tests/arrow_functions/002.phpt
@@ -9,5 +9,5 @@ var_dump((fn() => $b + $c)());
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $c (this will become an error in PHP 9.0) in %s on line %d
 int(1)

--- a/Zend/tests/arrow_functions/003.phpt
+++ b/Zend/tests/arrow_functions/003.phpt
@@ -14,8 +14,8 @@ var_dump($fn());
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $5 in %s on line %d
+Warning: Undefined variable $5 (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/arrow_functions/003.phpt
+++ b/Zend/tests/arrow_functions/003.phpt
@@ -14,8 +14,8 @@ var_dump($fn());
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $5 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $5 (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/assign_coalesce_007.phpt
+++ b/Zend/tests/assign_coalesce_007.phpt
@@ -6,7 +6,7 @@ $a[0] ??= $a;
 var_dump($a);
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_coalesce_007.php on line 2
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_coalesce_007.php on line 2
 array(1) {
   [0]=>
   NULL

--- a/Zend/tests/assign_coalesce_007.phpt
+++ b/Zend/tests/assign_coalesce_007.phpt
@@ -6,7 +6,7 @@ $a[0] ??= $a;
 var_dump($a);
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %sassign_coalesce_007.php on line 2
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_coalesce_007.php on line 2
 array(1) {
   [0]=>
   NULL

--- a/Zend/tests/assign_dim_op_undef.phpt
+++ b/Zend/tests/assign_dim_op_undef.phpt
@@ -6,9 +6,9 @@ $a[$b] += 1;
 var_dump($a);
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $b in %s on line %d
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Undefined array key "" in %s on line %d
 array(1) {

--- a/Zend/tests/assign_dim_op_undef.phpt
+++ b/Zend/tests/assign_dim_op_undef.phpt
@@ -6,9 +6,9 @@ $a[$b] += 1;
 var_dump($a);
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Undefined array key "" in %s on line %d
 array(1) {

--- a/Zend/tests/bug30162.phpt
+++ b/Zend/tests/bug30162.phpt
@@ -44,7 +44,7 @@ $db = new hariCow;
 var_dump($db);
 ?>
 --EXPECTF--
-Warning: Undefined variable $db (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $db (this will become an error in PHP 9.0) in %s on line %d
 NULL
 object(hariCow)#%d (2) {
   ["x"]=>

--- a/Zend/tests/bug30162.phpt
+++ b/Zend/tests/bug30162.phpt
@@ -44,7 +44,7 @@ $db = new hariCow;
 var_dump($db);
 ?>
 --EXPECTF--
-Warning: Undefined variable $db in %s on line %d
+Warning: Undefined variable $db (This will become an error in PHP 9.0) in %s on line %d
 NULL
 object(hariCow)#%d (2) {
   ["x"]=>

--- a/Zend/tests/bug31720.phpt
+++ b/Zend/tests/bug31720.phpt
@@ -11,5 +11,5 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $nonesuchvar (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $nonesuchvar (this will become an error in PHP 9.0) in %s on line %d
 array_walk(): Argument #2 ($callback) must be a valid callback, first array member is not a valid class name or object

--- a/Zend/tests/bug31720.phpt
+++ b/Zend/tests/bug31720.phpt
@@ -11,5 +11,5 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $nonesuchvar in %s on line %d
+Warning: Undefined variable $nonesuchvar (This will become an error in PHP 9.0) in %s on line %d
 array_walk(): Argument #2 ($callback) must be a valid callback, first array member is not a valid class name or object

--- a/Zend/tests/bug39036.phpt
+++ b/Zend/tests/bug39036.phpt
@@ -14,6 +14,6 @@ var_dump($key);
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $key (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $key (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/bug39036.phpt
+++ b/Zend/tests/bug39036.phpt
@@ -14,6 +14,6 @@ var_dump($key);
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $key in %s on line %d
+Warning: Undefined variable $key (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/bug41209.phpt
+++ b/Zend/tests/bug41209.phpt
@@ -39,7 +39,7 @@ var_dump(isset($cache[$id]));
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught ErrorException: Undefined variable $id in %s:%d
+Fatal error: Uncaught ErrorException: Undefined variable $id (This will become an error in PHP 9.0) in %s:%d
 Stack trace:
 #0 %s(%d): env::errorHandler(2, 'Undefined varia...', '%s', %d)
 #1 {main}

--- a/Zend/tests/bug41209.phpt
+++ b/Zend/tests/bug41209.phpt
@@ -39,7 +39,7 @@ var_dump(isset($cache[$id]));
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught ErrorException: Undefined variable $id (This will become an error in PHP 9.0) in %s:%d
+Fatal error: Uncaught ErrorException: Undefined variable $id (this will become an error in PHP 9.0) in %s:%d
 Stack trace:
 #0 %s(%d): env::errorHandler(2, 'Undefined varia...', '%s', %d)
 #1 {main}

--- a/Zend/tests/bug43201.phpt
+++ b/Zend/tests/bug43201.phpt
@@ -26,39 +26,39 @@ Notice: Indirect modification of overloaded property Foo::$arr has no effect in 
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 14
 
-Warning: Undefined variable $ref (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $ref (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
-
-Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
-
-Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
-
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
 
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
 
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
 
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
 
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
+
+Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
+
+Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
+
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 

--- a/Zend/tests/bug43201.phpt
+++ b/Zend/tests/bug43201.phpt
@@ -26,39 +26,39 @@ Notice: Indirect modification of overloaded property Foo::$arr has no effect in 
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 14
 
-Warning: Undefined variable $ref in %s on line %d
+Warning: Undefined variable $ref (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $undef in %s on line %d
-
-Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
-
-Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
-
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
 
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
 
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
 
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 
 Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
 
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+
+Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
+
+Notice: Indirect modification of overloaded property Foo::$arr has no effect in %sbug43201.php on line 17
+
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: chop(): Passing null to parameter #1 ($string) of type string is deprecated in %s on line %d
 

--- a/Zend/tests/bug47109.phpt
+++ b/Zend/tests/bug47109.phpt
@@ -5,6 +5,6 @@ Bug #47109 (Memory leak on $a->{"a"."b"} when $a is not an object)
 $a->{"a"."b"};
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "ab" on null in %s on line %d

--- a/Zend/tests/bug47109.phpt
+++ b/Zend/tests/bug47109.phpt
@@ -5,6 +5,6 @@ Bug #47109 (Memory leak on $a->{"a"."b"} when $a is not an object)
 $a->{"a"."b"};
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "ab" on null in %s on line %d

--- a/Zend/tests/bug52001.phpt
+++ b/Zend/tests/bug52001.phpt
@@ -11,7 +11,7 @@ var_dump($temp1);
 function a($b,$c) {}
 ?>
 --EXPECTF--
-Warning: Undefined variable $var in %s on line %d
+Warning: Undefined variable $var (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $ in %s on line %d
+Warning: Undefined variable $ (This will become an error in PHP 9.0) in %s on line %d
 int(1)

--- a/Zend/tests/bug52001.phpt
+++ b/Zend/tests/bug52001.phpt
@@ -11,7 +11,7 @@ var_dump($temp1);
 function a($b,$c) {}
 ?>
 --EXPECTF--
-Warning: Undefined variable $var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $var (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $ (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $ (this will become an error in PHP 9.0) in %s on line %d
 int(1)

--- a/Zend/tests/bug52041.phpt
+++ b/Zend/tests/bug52041.phpt
@@ -47,47 +47,47 @@ foo()[0][0] += 2;
 var_dump(foo());
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 Attempt to assign property "a" on null
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 Attempt to increment/decrement property "a" on null
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 Attempt to assign property "a" on null
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $x in %s on line %d
-
-Warning: Undefined array key 0 in %s on line %d
-
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Undefined array key 0 in %s on line %d
 
-Warning: Undefined array key 0 in %s on line %d
-
-Warning: Undefined variable $x in %s on line %d
-
-Warning: Undefined array key 0 in %s on line %d
-
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Undefined array key 0 in %s on line %d
 
 Warning: Undefined array key 0 in %s on line %d
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+
+Warning: Undefined array key 0 in %s on line %d
+
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+
+Warning: Undefined array key 0 in %s on line %d
+
+Warning: Undefined array key 0 in %s on line %d
+
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/bug52041.phpt
+++ b/Zend/tests/bug52041.phpt
@@ -47,47 +47,47 @@ foo()[0][0] += 2;
 var_dump(foo());
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 Attempt to assign property "a" on null
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 Attempt to increment/decrement property "a" on null
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 Attempt to assign property "a" on null
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
-
-Warning: Undefined array key 0 in %s on line %d
-
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Undefined array key 0 in %s on line %d
 
-Warning: Undefined array key 0 in %s on line %d
-
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
-
-Warning: Undefined array key 0 in %s on line %d
-
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Undefined array key 0 in %s on line %d
 
 Warning: Undefined array key 0 in %s on line %d
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
+
+Warning: Undefined array key 0 in %s on line %d
+
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
+
+Warning: Undefined array key 0 in %s on line %d
+
+Warning: Undefined array key 0 in %s on line %d
+
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/bug61767.phpt
+++ b/Zend/tests/bug61767.phpt
@@ -16,9 +16,9 @@ register_shutdown_function(function(){
 $undefined->foo();
 ?>
 --EXPECTF--
-Error handler called (Undefined variable $undefined)
+Error handler called (Undefined variable $undefined (This will become an error in PHP 9.0))
 
-Fatal error: Uncaught ErrorException: Undefined variable $undefined in %sbug61767.php:%d
+Fatal error: Uncaught ErrorException: Undefined variable $undefined (This will become an error in PHP 9.0) in %sbug61767.php:%d
 Stack trace:
 #0 %sbug61767.php(%d): {closure}(%s, 'Undefined varia...', '%s', %d)
 #1 {main}

--- a/Zend/tests/bug61767.phpt
+++ b/Zend/tests/bug61767.phpt
@@ -16,7 +16,7 @@ register_shutdown_function(function(){
 $undefined->foo();
 ?>
 --EXPECTF--
-Error handler called (Undefined variable $undefined (This will become an error in PHP 9.0))
+Error handler called (Undefined variable $undefined (this will become an error in PHP 9.0))
 
 Fatal error: Uncaught ErrorException: Undefined variable $undefined (this will become an error in PHP 9.0) in %sbug61767.php:%d
 Stack trace:

--- a/Zend/tests/bug61767.phpt
+++ b/Zend/tests/bug61767.phpt
@@ -18,7 +18,7 @@ $undefined->foo();
 --EXPECTF--
 Error handler called (Undefined variable $undefined (This will become an error in PHP 9.0))
 
-Fatal error: Uncaught ErrorException: Undefined variable $undefined (This will become an error in PHP 9.0) in %sbug61767.php:%d
+Fatal error: Uncaught ErrorException: Undefined variable $undefined (this will become an error in PHP 9.0) in %sbug61767.php:%d
 Stack trace:
 #0 %sbug61767.php(%d): {closure}(%s, 'Undefined varia...', '%s', %d)
 #1 {main}

--- a/Zend/tests/bug67314.phpt
+++ b/Zend/tests/bug67314.phpt
@@ -16,8 +16,8 @@ crash();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $i in %s on line %d
+Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
 made it once
 
-Warning: Undefined variable $i in %s on line %d
+Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
 ok

--- a/Zend/tests/bug67314.phpt
+++ b/Zend/tests/bug67314.phpt
@@ -16,8 +16,8 @@ crash();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $i (this will become an error in PHP 9.0) in %s on line %d
 made it once
 
-Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $i (this will become an error in PHP 9.0) in %s on line %d
 ok

--- a/Zend/tests/bug70124.phpt
+++ b/Zend/tests/bug70124.phpt
@@ -39,7 +39,7 @@ try  {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $f (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $f (this will become an error in PHP 9.0) in %s on line %d
 string(34) "Value of type null is not callable"
 string(31) "Call to undefined method A::y()"
 string(31) "Call to undefined method A::y()"

--- a/Zend/tests/bug70124.phpt
+++ b/Zend/tests/bug70124.phpt
@@ -39,7 +39,7 @@ try  {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $f in %s on line %d
+Warning: Undefined variable $f (This will become an error in PHP 9.0) in %s on line %d
 string(34) "Value of type null is not callable"
 string(31) "Call to undefined method A::y()"
 string(31) "Call to undefined method A::y()"

--- a/Zend/tests/bug72944.phpt
+++ b/Zend/tests/bug72944.phpt
@@ -7,5 +7,5 @@ define('e', 'e');
 echo "OK\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $A (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $A (this will become an error in PHP 9.0) in %s on line %d
 OK

--- a/Zend/tests/bug72944.phpt
+++ b/Zend/tests/bug72944.phpt
@@ -7,5 +7,5 @@ define('e', 'e');
 echo "OK\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $A in %s on line %d
+Warning: Undefined variable $A (This will become an error in PHP 9.0) in %s on line %d
 OK

--- a/Zend/tests/bug75921.phpt
+++ b/Zend/tests/bug75921.phpt
@@ -47,21 +47,21 @@ unset($null);
 --EXPECTF--
 Attempt to assign property "a" on null
 
-Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $null (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $null (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $null (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $null (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $null (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/bug75921.phpt
+++ b/Zend/tests/bug75921.phpt
@@ -47,21 +47,21 @@ unset($null);
 --EXPECTF--
 Attempt to assign property "a" on null
 
-Warning: Undefined variable $null in %s on line %d
+Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $null in %s on line %d
+Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $null in %s on line %d
+Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $null in %s on line %d
+Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Attempt to modify property "a" on null
 
-Warning: Undefined variable $null in %s on line %d
+Warning: Undefined variable $null (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/bug76667.phpt
+++ b/Zend/tests/bug76667.phpt
@@ -23,7 +23,7 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $undefined (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undefined (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "1" on null in %s on line %d
 Division by zero

--- a/Zend/tests/bug76667.phpt
+++ b/Zend/tests/bug76667.phpt
@@ -23,7 +23,7 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $undefined in %s on line %d
+Warning: Undefined variable $undefined (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "1" on null in %s on line %d
 Division by zero

--- a/Zend/tests/bug78531.phpt
+++ b/Zend/tests/bug78531.phpt
@@ -24,14 +24,14 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 Attempt to assign property "a" on null
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 Attempt to increment/decrement property "a" on null
 
-Warning: Undefined variable $u3 in %s on line %d
+Warning: Undefined variable $u3 (This will become an error in PHP 9.0) in %s on line %d
 Attempt to increment/decrement property "a" on null
 
-Warning: Undefined variable $u4 in %s on line %d
+Warning: Undefined variable $u4 (This will become an error in PHP 9.0) in %s on line %d
 Attempt to modify property "a" on null

--- a/Zend/tests/bug78531.phpt
+++ b/Zend/tests/bug78531.phpt
@@ -24,14 +24,14 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 Attempt to assign property "a" on null
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 Attempt to increment/decrement property "a" on null
 
-Warning: Undefined variable $u3 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u3 (this will become an error in PHP 9.0) in %s on line %d
 Attempt to increment/decrement property "a" on null
 
-Warning: Undefined variable $u4 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u4 (this will become an error in PHP 9.0) in %s on line %d
 Attempt to modify property "a" on null

--- a/Zend/tests/bug79599.phpt
+++ b/Zend/tests/bug79599.phpt
@@ -23,5 +23,5 @@ try{
 }
 ?>
 --EXPECT--
-string(21) "Undefined variable $b"
-string(21) "Undefined variable $c"
+string(60) "Undefined variable $b (This will become an error in PHP 9.0)"
+string(60) "Undefined variable $c (This will become an error in PHP 9.0)"

--- a/Zend/tests/bug79599.phpt
+++ b/Zend/tests/bug79599.phpt
@@ -23,5 +23,5 @@ try{
 }
 ?>
 --EXPECT--
-string(60) "Undefined variable $b (This will become an error in PHP 9.0)"
-string(60) "Undefined variable $c (This will become an error in PHP 9.0)"
+string(60) "Undefined variable $b (this will become an error in PHP 9.0)"
+string(60) "Undefined variable $c (this will become an error in PHP 9.0)"

--- a/Zend/tests/bug79828.phpt
+++ b/Zend/tests/bug79828.phpt
@@ -8,7 +8,7 @@ function foo(): AnyType {
 foo();
 ?>
 --EXPECTF--
-Warning: Undefined variable $uninitialized in %s on line %d
+Warning: Undefined variable $uninitialized (This will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught TypeError: foo(): Return value must be of type AnyType, null returned in %s:%d
 Stack trace:

--- a/Zend/tests/bug79828.phpt
+++ b/Zend/tests/bug79828.phpt
@@ -8,7 +8,7 @@ function foo(): AnyType {
 foo();
 ?>
 --EXPECTF--
-Warning: Undefined variable $uninitialized (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $uninitialized (this will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught TypeError: foo(): Return value must be of type AnyType, null returned in %s:%d
 Stack trace:

--- a/Zend/tests/bug80030.phpt
+++ b/Zend/tests/bug80030.phpt
@@ -10,7 +10,7 @@ test();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $className in %s on line %d
+Warning: Undefined variable $className (This will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught Error: Class name must be a valid object or a string in %s:%d
 Stack trace:

--- a/Zend/tests/bug80030.phpt
+++ b/Zend/tests/bug80030.phpt
@@ -10,7 +10,7 @@ test();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $className (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $className (this will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught Error: Class name must be a valid object or a string in %s:%d
 Stack trace:

--- a/Zend/tests/bug81631.phpt
+++ b/Zend/tests/bug81631.phpt
@@ -6,7 +6,7 @@ $a = 0;
 var_dump($b::class);
 ?>
 --EXPECTF--
-Warning: Undefined variable $b in %s on line 3
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line 3
 
 Fatal error: Uncaught TypeError: Cannot use "::class" on value of type null in %s:3
 Stack trace:

--- a/Zend/tests/bug81631.phpt
+++ b/Zend/tests/bug81631.phpt
@@ -6,7 +6,7 @@ $a = 0;
 var_dump($b::class);
 ?>
 --EXPECTF--
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line 3
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line 3
 
 Fatal error: Uncaught TypeError: Cannot use "::class" on value of type null in %s:3
 Stack trace:

--- a/Zend/tests/call_user_func_002.phpt
+++ b/Zend/tests/call_user_func_002.phpt
@@ -34,8 +34,8 @@ string(3) "foo"
 call_user_func(): Argument #1 ($callback) must be a valid callback, class "foo" not found
 call_user_func(): Argument #1 ($callback) must be a valid callback, class "" not found
 
-Warning: Undefined variable $foo in %s on line %d
+Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line %d
 call_user_func(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object
 
-Warning: Undefined variable $foo in %s on line %d
+Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line %d
 call_user_func(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object

--- a/Zend/tests/call_user_func_002.phpt
+++ b/Zend/tests/call_user_func_002.phpt
@@ -34,8 +34,8 @@ string(3) "foo"
 call_user_func(): Argument #1 ($callback) must be a valid callback, class "foo" not found
 call_user_func(): Argument #1 ($callback) must be a valid callback, class "" not found
 
-Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $foo (this will become an error in PHP 9.0) in %s on line %d
 call_user_func(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object
 
-Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $foo (this will become an error in PHP 9.0) in %s on line %d
 call_user_func(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object

--- a/Zend/tests/clone_003.phpt
+++ b/Zend/tests/clone_003.phpt
@@ -7,7 +7,7 @@ $a = clone $b;
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $b in %s on line %d
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught Error: __clone method called on non-object in %s:%d
 Stack trace:

--- a/Zend/tests/clone_003.phpt
+++ b/Zend/tests/clone_003.phpt
@@ -7,7 +7,7 @@ $a = clone $b;
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught Error: __clone method called on non-object in %s:%d
 Stack trace:

--- a/Zend/tests/closure_012.phpt
+++ b/Zend/tests/closure_012.phpt
@@ -16,8 +16,8 @@ $lambda();
 var_dump($i);
 ?>
 --EXPECTF--
-Warning: Undefined variable $i in %s on line %d
+Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $i in %s on line %d
+Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
 NULL
 int(2)

--- a/Zend/tests/closure_012.phpt
+++ b/Zend/tests/closure_012.phpt
@@ -16,8 +16,8 @@ $lambda();
 var_dump($i);
 ?>
 --EXPECTF--
-Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $i (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $i (this will become an error in PHP 9.0) in %s on line %d
 NULL
 int(2)

--- a/Zend/tests/closure_027.phpt
+++ b/Zend/tests/closure_027.phpt
@@ -27,7 +27,7 @@ object(stdClass)#%d (0) {
 }
 NULL
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %s on line %d
 Exception: Too few arguments to function {closure}(), 0 passed in %s on line %d and exactly 1 expected
 
 Fatal error: Uncaught TypeError: test(): Argument #1 ($a) must be of type Closure, stdClass given, called in %s:%d

--- a/Zend/tests/closure_027.phpt
+++ b/Zend/tests/closure_027.phpt
@@ -27,7 +27,7 @@ object(stdClass)#%d (0) {
 }
 NULL
 
-Warning: Undefined variable $y in %s on line %d
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
 Exception: Too few arguments to function {closure}(), 0 passed in %s on line %d and exactly 1 expected
 
 Fatal error: Uncaught TypeError: test(): Argument #1 ($a) must be of type Closure, stdClass given, called in %s:%d

--- a/Zend/tests/code_before_loop_var_free.phpt
+++ b/Zend/tests/code_before_loop_var_free.phpt
@@ -9,4 +9,4 @@ default:
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/code_before_loop_var_free.phpt
+++ b/Zend/tests/code_before_loop_var_free.phpt
@@ -9,4 +9,4 @@ default:
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/dead_array_type_inference.phpt
+++ b/Zend/tests/dead_array_type_inference.phpt
@@ -13,6 +13,6 @@ test();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d

--- a/Zend/tests/dead_array_type_inference.phpt
+++ b/Zend/tests/dead_array_type_inference.phpt
@@ -13,6 +13,6 @@ test();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d

--- a/Zend/tests/dereference_007.phpt
+++ b/Zend/tests/dereference_007.phpt
@@ -33,5 +33,5 @@ print "ok\n";
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 ok

--- a/Zend/tests/dereference_007.phpt
+++ b/Zend/tests/dereference_007.phpt
@@ -33,5 +33,5 @@ print "ok\n";
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 ok

--- a/Zend/tests/div_by_zero_compound_with_conversion.phpt
+++ b/Zend/tests/div_by_zero_compound_with_conversion.phpt
@@ -10,5 +10,5 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $42 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $42 (this will become an error in PHP 9.0) in %s on line %d
 Division by zero

--- a/Zend/tests/div_by_zero_compound_with_conversion.phpt
+++ b/Zend/tests/div_by_zero_compound_with_conversion.phpt
@@ -10,5 +10,5 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $42 in %s on line %d
+Warning: Undefined variable $42 (This will become an error in PHP 9.0) in %s on line %d
 Division by zero

--- a/Zend/tests/dynamic_call_004.phpt
+++ b/Zend/tests/dynamic_call_004.phpt
@@ -7,7 +7,7 @@ $a::$b();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught Error: Class name must be a valid object or a string in %s:%d
 Stack trace:

--- a/Zend/tests/dynamic_call_004.phpt
+++ b/Zend/tests/dynamic_call_004.phpt
@@ -7,7 +7,7 @@ $a::$b();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
 Fatal error: Uncaught Error: Class name must be a valid object or a string in %s:%d
 Stack trace:

--- a/Zend/tests/entry_block_with_predecessors.phpt
+++ b/Zend/tests/entry_block_with_predecessors.phpt
@@ -28,6 +28,6 @@ test2();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 int(1)
 int(2)

--- a/Zend/tests/entry_block_with_predecessors.phpt
+++ b/Zend/tests/entry_block_with_predecessors.phpt
@@ -28,6 +28,6 @@ test2();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 int(1)
 int(2)

--- a/Zend/tests/errmsg_045.phpt
+++ b/Zend/tests/errmsg_045.phpt
@@ -17,4 +17,4 @@ eval('class A { private function __invoke() { } }');
 string(%d) "The magic method A::__invoke() must have public visibility"
 string(%d) "%s(%d) : eval()'d code"
 
-Warning: Undefined variable $undefined (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undefined (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/errmsg_045.phpt
+++ b/Zend/tests/errmsg_045.phpt
@@ -17,4 +17,4 @@ eval('class A { private function __invoke() { } }');
 string(%d) "The magic method A::__invoke() must have public visibility"
 string(%d) "%s(%d) : eval()'d code"
 
-Warning: Undefined variable $undefined in %s on line %d
+Warning: Undefined variable $undefined (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/error_reporting03.phpt
+++ b/Zend/tests/error_reporting03.phpt
@@ -30,6 +30,6 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef2 (this will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting03.phpt
+++ b/Zend/tests/error_reporting03.phpt
@@ -30,6 +30,6 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef2 in %s on line %d
+Warning: Undefined variable $undef2 (This will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting04.phpt
+++ b/Zend/tests/error_reporting04.phpt
@@ -18,6 +18,6 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting04.phpt
+++ b/Zend/tests/error_reporting04.phpt
@@ -18,6 +18,6 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting05.phpt
+++ b/Zend/tests/error_reporting05.phpt
@@ -27,8 +27,8 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef_value (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef_value (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $undef_name (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef_name (this will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting05.phpt
+++ b/Zend/tests/error_reporting05.phpt
@@ -27,8 +27,8 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef_value in %s on line %d
+Warning: Undefined variable $undef_value (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $undef_name in %s on line %d
+Warning: Undefined variable $undef_name (This will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting08.phpt
+++ b/Zend/tests/error_reporting08.phpt
@@ -27,6 +27,6 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef3 in %s on line %d
+Warning: Undefined variable $undef3 (This will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting08.phpt
+++ b/Zend/tests/error_reporting08.phpt
@@ -27,6 +27,6 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef3 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef3 (this will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting09.phpt
+++ b/Zend/tests/error_reporting09.phpt
@@ -24,8 +24,8 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $blah in %s on line %d
+Warning: Undefined variable $blah (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $undef2 in %s on line %d
+Warning: Undefined variable $undef2 (This will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/error_reporting09.phpt
+++ b/Zend/tests/error_reporting09.phpt
@@ -24,8 +24,8 @@ var_dump(error_reporting());
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $blah (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $blah (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $undef2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef2 (this will become an error in PHP 9.0) in %s on line %d
 int(32767)
 Done

--- a/Zend/tests/exception_before_fatal.phpt
+++ b/Zend/tests/exception_before_fatal.phpt
@@ -55,10 +55,10 @@ try {
 }
 ?>
 --EXPECT--
-string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
-string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
-string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
-string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
-string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
-string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
-string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (this will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (this will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (this will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (this will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (this will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (this will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (this will become an error in PHP 9.0)"

--- a/Zend/tests/exception_before_fatal.phpt
+++ b/Zend/tests/exception_before_fatal.phpt
@@ -55,10 +55,10 @@ try {
 }
 ?>
 --EXPECT--
-string(23) "Undefined variable $foo"
-string(23) "Undefined variable $foo"
-string(23) "Undefined variable $foo"
-string(23) "Undefined variable $foo"
-string(23) "Undefined variable $foo"
-string(23) "Undefined variable $foo"
-string(23) "Undefined variable $foo"
+string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"
+string(62) "Undefined variable $foo (This will become an error in PHP 9.0)"

--- a/Zend/tests/foreach_undefined.phpt
+++ b/Zend/tests/foreach_undefined.phpt
@@ -8,7 +8,7 @@ foreach($a as $val);
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d
 Done

--- a/Zend/tests/foreach_undefined.phpt
+++ b/Zend/tests/foreach_undefined.phpt
@@ -8,7 +8,7 @@ foreach($a as $val);
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d
 Done

--- a/Zend/tests/generators/errors/resume_running_generator_error_003.phpt
+++ b/Zend/tests/generators/errors/resume_running_generator_error_003.phpt
@@ -13,7 +13,7 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %sresume_running_generator_error_003.php on line 4
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sresume_running_generator_error_003.php on line 4
 
 Fatal error: Uncaught Error: Cannot resume an already running generator in %sresume_running_generator_error_003.php:4
 Stack trace:

--- a/Zend/tests/generators/errors/resume_running_generator_error_003.phpt
+++ b/Zend/tests/generators/errors/resume_running_generator_error_003.phpt
@@ -13,7 +13,7 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sresume_running_generator_error_003.php on line 4
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sresume_running_generator_error_003.php on line 4
 
 Fatal error: Uncaught Error: Cannot resume an already running generator in %sresume_running_generator_error_003.php:4
 Stack trace:

--- a/Zend/tests/globals_001.phpt
+++ b/Zend/tests/globals_001.phpt
@@ -29,6 +29,6 @@ string(%d) "%s"
 Warning: Undefined array key "PHP_SELF" in %s on line %d
 NULL
 
-Warning: Undefined global variable $_SERVER in %s on line %d
+Warning: Undefined global variable $_SERVER (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/globals_001.phpt
+++ b/Zend/tests/globals_001.phpt
@@ -29,6 +29,6 @@ string(%d) "%s"
 Warning: Undefined array key "PHP_SELF" in %s on line %d
 NULL
 
-Warning: Undefined global variable $_SERVER (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined global variable $_SERVER (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/globals_002.phpt
+++ b/Zend/tests/globals_002.phpt
@@ -32,6 +32,6 @@ string(%d) "%s"
 Warning: Undefined array key "PHP_SELF" in %s on line %d
 NULL
 
-Warning: Undefined global variable $_SERVER in %s on line %d
+Warning: Undefined global variable $_SERVER (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/globals_002.phpt
+++ b/Zend/tests/globals_002.phpt
@@ -32,6 +32,6 @@ string(%d) "%s"
 Warning: Undefined array key "PHP_SELF" in %s on line %d
 NULL
 
-Warning: Undefined global variable $_SERVER (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined global variable $_SERVER (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/globals_003.phpt
+++ b/Zend/tests/globals_003.phpt
@@ -38,6 +38,6 @@ string(%d) "%s"
 Warning: Undefined array key "PHP_SELF" in %s on line %d
 NULL
 
-Warning: Undefined global variable $_SERVER in %s on line %d
+Warning: Undefined global variable $_SERVER (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/globals_003.phpt
+++ b/Zend/tests/globals_003.phpt
@@ -38,6 +38,6 @@ string(%d) "%s"
 Warning: Undefined array key "PHP_SELF" in %s on line %d
 NULL
 
-Warning: Undefined global variable $_SERVER (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined global variable $_SERVER (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/globals_004.phpt
+++ b/Zend/tests/globals_004.phpt
@@ -23,6 +23,6 @@ string(%d) "%s"
 Warning: Undefined array key "PHP_SELF" in %s on line %d
 NULL
 
-Warning: Undefined global variable $_SERVER (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined global variable $_SERVER (this will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/globals_004.phpt
+++ b/Zend/tests/globals_004.phpt
@@ -23,6 +23,6 @@ string(%d) "%s"
 Warning: Undefined array key "PHP_SELF" in %s on line %d
 NULL
 
-Warning: Undefined global variable $_SERVER in %s on line %d
+Warning: Undefined global variable $_SERVER (This will become an error in PHP 9.0) in %s on line %d
 NULL
 Done

--- a/Zend/tests/ignore_repeated_errors.phpt
+++ b/Zend/tests/ignore_repeated_errors.phpt
@@ -16,10 +16,10 @@ $u + 1;
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/ignore_repeated_errors.phpt
+++ b/Zend/tests/ignore_repeated_errors.phpt
@@ -16,10 +16,10 @@ $u + 1;
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u in %s on line %d
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u in %s on line %d
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/ignore_repeated_source.phpt
+++ b/Zend/tests/ignore_repeated_source.phpt
@@ -17,8 +17,8 @@ $u + 1;
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/ignore_repeated_source.phpt
+++ b/Zend/tests/ignore_repeated_source.phpt
@@ -17,8 +17,8 @@ $u + 1;
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u in %s on line %d
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/incdec_undef.phpt
+++ b/Zend/tests/incdec_undef.phpt
@@ -15,11 +15,11 @@ unset($x);
 var_dump(++$x);
 ?>
 --EXPECT--
-Undefined variable $x
+Undefined variable $x (This will become an error in PHP 9.0)
 NULL
-Undefined variable $x
+Undefined variable $x (This will become an error in PHP 9.0)
 NULL
-Undefined variable $x
+Undefined variable $x (This will become an error in PHP 9.0)
 NULL
-Undefined variable $x
+Undefined variable $x (This will become an error in PHP 9.0)
 int(1)

--- a/Zend/tests/incdec_undef.phpt
+++ b/Zend/tests/incdec_undef.phpt
@@ -15,11 +15,11 @@ unset($x);
 var_dump(++$x);
 ?>
 --EXPECT--
-Undefined variable $x (This will become an error in PHP 9.0)
+Undefined variable $x (this will become an error in PHP 9.0)
 NULL
-Undefined variable $x (This will become an error in PHP 9.0)
+Undefined variable $x (this will become an error in PHP 9.0)
 NULL
-Undefined variable $x (This will become an error in PHP 9.0)
+Undefined variable $x (this will become an error in PHP 9.0)
 NULL
-Undefined variable $x (This will become an error in PHP 9.0)
+Undefined variable $x (this will become an error in PHP 9.0)
 int(1)

--- a/Zend/tests/inference_infinite_loop.phpt
+++ b/Zend/tests/inference_infinite_loop.phpt
@@ -14,4 +14,4 @@ test();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/inference_infinite_loop.phpt
+++ b/Zend/tests/inference_infinite_loop.phpt
@@ -14,4 +14,4 @@ test();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/isset_003.phpt
+++ b/Zend/tests/isset_003.phpt
@@ -29,9 +29,9 @@ bool(true)
 bool(false)
 bool(false)
 
-Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $c (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $d (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $d (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 

--- a/Zend/tests/isset_003.phpt
+++ b/Zend/tests/isset_003.phpt
@@ -29,9 +29,9 @@ bool(true)
 bool(false)
 bool(false)
 
-Warning: Undefined variable $c in %s on line %d
+Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $d in %s on line %d
+Warning: Undefined variable $d (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 

--- a/Zend/tests/match/029.phpt
+++ b/Zend/tests/match/029.phpt
@@ -16,7 +16,7 @@ echo "unreachable\n";
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception: Custom error handler: Undefined variable $undefVar in %s029.php:4
+Fatal error: Uncaught Exception: Custom error handler: Undefined variable $undefVar (This will become an error in PHP 9.0) in %s029.php:4
 Stack trace:
 #0 %s029.php(7): {closure}(%d, 'Undefined varia...', '%s', %d)
 #1 {main}

--- a/Zend/tests/match/029.phpt
+++ b/Zend/tests/match/029.phpt
@@ -16,7 +16,7 @@ echo "unreachable\n";
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception: Custom error handler: Undefined variable $undefVar (This will become an error in PHP 9.0) in %s029.php:4
+Fatal error: Uncaught Exception: Custom error handler: Undefined variable $undefVar (this will become an error in PHP 9.0) in %s029.php:4
 Stack trace:
 #0 %s029.php(7): {closure}(%d, 'Undefined varia...', '%s', %d)
 #1 {main}

--- a/Zend/tests/match/030.phpt
+++ b/Zend/tests/match/030.phpt
@@ -16,7 +16,7 @@ echo "unreachable\n";
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception: Custom error handler: Undefined variable $undefVar in %s030.php:4
+Fatal error: Uncaught Exception: Custom error handler: Undefined variable $undefVar (This will become an error in PHP 9.0) in %s030.php:4
 Stack trace:
 #0 %s030.php(7): {closure}(%d, 'Undefined varia...', '%s', %d)
 #1 {main}

--- a/Zend/tests/match/030.phpt
+++ b/Zend/tests/match/030.phpt
@@ -16,7 +16,7 @@ echo "unreachable\n";
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Exception: Custom error handler: Undefined variable $undefVar (This will become an error in PHP 9.0) in %s030.php:4
+Fatal error: Uncaught Exception: Custom error handler: Undefined variable $undefVar (this will become an error in PHP 9.0) in %s030.php:4
 Stack trace:
 #0 %s030.php(7): {closure}(%d, 'Undefined varia...', '%s', %d)
 #1 {main}

--- a/Zend/tests/match/042.phpt
+++ b/Zend/tests/match/042.phpt
@@ -15,8 +15,8 @@ var_dump(match ($undefinedVariable) {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undefinedVariable in %s.php on line 3
+Warning: Undefined variable $undefinedVariable (This will become an error in PHP 9.0) in %s.php on line 3
 string(4) "null"
 
-Warning: Undefined variable $undefinedVariable in %s.php on line 8
+Warning: Undefined variable $undefinedVariable (This will become an error in PHP 9.0) in %s.php on line 8
 string(3) "bar"

--- a/Zend/tests/match/042.phpt
+++ b/Zend/tests/match/042.phpt
@@ -15,8 +15,8 @@ var_dump(match ($undefinedVariable) {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undefinedVariable (This will become an error in PHP 9.0) in %s.php on line 3
+Warning: Undefined variable $undefinedVariable (this will become an error in PHP 9.0) in %s.php on line 3
 string(4) "null"
 
-Warning: Undefined variable $undefinedVariable (This will become an error in PHP 9.0) in %s.php on line 8
+Warning: Undefined variable $undefinedVariable (this will become an error in PHP 9.0) in %s.php on line 8
 string(3) "bar"

--- a/Zend/tests/method_argument_binding.phpt
+++ b/Zend/tests/method_argument_binding.phpt
@@ -43,4 +43,4 @@ class E extends D {
 --EXPECTF--
 int(2)
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/method_argument_binding.phpt
+++ b/Zend/tests/method_argument_binding.phpt
@@ -43,4 +43,4 @@ class E extends D {
 --EXPECTF--
 int(2)
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/named_params/undef_var.phpt
+++ b/Zend/tests/named_params/undef_var.phpt
@@ -10,8 +10,8 @@ function func2($arg) { var_dump($arg); }
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/named_params/undef_var.phpt
+++ b/Zend/tests/named_params/undef_var.phpt
@@ -10,8 +10,8 @@ function func2($arg) { var_dump($arg); }
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/nullsafe_operator/018.phpt
+++ b/Zend/tests/nullsafe_operator/018.phpt
@@ -9,11 +9,11 @@ var_dump($foo);
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s.php on line 3
+Warning: Undefined variable $foo (this will become an error in PHP 9.0) in %s.php on line 3
 NULL
 
-Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s.php on line 4
+Warning: Undefined variable $foo (this will become an error in PHP 9.0) in %s.php on line 4
 NULL
 
-Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s.php on line 5
+Warning: Undefined variable $foo (this will become an error in PHP 9.0) in %s.php on line 5
 NULL

--- a/Zend/tests/nullsafe_operator/018.phpt
+++ b/Zend/tests/nullsafe_operator/018.phpt
@@ -9,11 +9,11 @@ var_dump($foo);
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $foo in %s.php on line 3
+Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s.php on line 3
 NULL
 
-Warning: Undefined variable $foo in %s.php on line 4
+Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s.php on line 4
 NULL
 
-Warning: Undefined variable $foo in %s.php on line 5
+Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s.php on line 5
 NULL

--- a/Zend/tests/nullsafe_operator/025.phpt
+++ b/Zend/tests/nullsafe_operator/025.phpt
@@ -8,7 +8,7 @@ var_dump(${$a?->b}->c);
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $ in %s on line %d
+Warning: Undefined variable $ (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "c" on null in %s on line %d
 NULL

--- a/Zend/tests/nullsafe_operator/025.phpt
+++ b/Zend/tests/nullsafe_operator/025.phpt
@@ -8,7 +8,7 @@ var_dump(${$a?->b}->c);
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $ (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $ (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "c" on null in %s on line %d
 NULL

--- a/Zend/tests/nullsafe_operator/039.phpt
+++ b/Zend/tests/nullsafe_operator/039.phpt
@@ -15,4 +15,4 @@ try {
 
 ?>
 --EXPECT--
-Undefined variable $foo
+Undefined variable $foo (This will become an error in PHP 9.0)

--- a/Zend/tests/nullsafe_operator/039.phpt
+++ b/Zend/tests/nullsafe_operator/039.phpt
@@ -15,4 +15,4 @@ try {
 
 ?>
 --EXPECT--
-Undefined variable $foo (This will become an error in PHP 9.0)
+Undefined variable $foo (this will become an error in PHP 9.0)

--- a/Zend/tests/remove_predecessor_of_pi_node.phpt
+++ b/Zend/tests/remove_predecessor_of_pi_node.phpt
@@ -11,4 +11,4 @@ test();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $n (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $n (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/remove_predecessor_of_pi_node.phpt
+++ b/Zend/tests/remove_predecessor_of_pi_node.phpt
@@ -11,4 +11,4 @@ test();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $n in %s on line %d
+Warning: Undefined variable $n (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/restore_error_reporting.phpt
+++ b/Zend/tests/restore_error_reporting.phpt
@@ -8,7 +8,7 @@ var_dump($undef_var);
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef_var in %s on line %d
+Warning: Undefined variable $undef_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
 Fatal error: Cannot use 'self' as class name as it is reserved in %s on line %d

--- a/Zend/tests/restore_error_reporting.phpt
+++ b/Zend/tests/restore_error_reporting.phpt
@@ -8,7 +8,7 @@ var_dump($undef_var);
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
 Fatal error: Cannot use 'self' as class name as it is reserved in %s on line %d

--- a/Zend/tests/restrict_globals/valid.phpt
+++ b/Zend/tests/restrict_globals/valid.phpt
@@ -33,7 +33,7 @@ var_dump($x);
 
 ?>
 --EXPECTF--
-Warning: Undefined global variable $x in %s on line %d
+Warning: Undefined global variable $x (This will become an error in PHP 9.0) in %s on line %d
 NULL
 int(1)
 int(2)
@@ -41,7 +41,7 @@ int(4)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $y in %s on line %d
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
 int(4)
 NULL
 array(1) {

--- a/Zend/tests/restrict_globals/valid.phpt
+++ b/Zend/tests/restrict_globals/valid.phpt
@@ -33,7 +33,7 @@ var_dump($x);
 
 ?>
 --EXPECTF--
-Warning: Undefined global variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined global variable $x (this will become an error in PHP 9.0) in %s on line %d
 NULL
 int(1)
 int(2)
@@ -41,7 +41,7 @@ int(4)
 bool(true)
 bool(false)
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %s on line %d
 int(4)
 NULL
 array(1) {

--- a/Zend/tests/str_offset_006.phpt
+++ b/Zend/tests/str_offset_006.phpt
@@ -10,7 +10,7 @@ $a[$y]=$a.=($y);
 var_dump($a);
 ?>
 --EXPECT--
-Err: Undefined variable $y (This will become an error in PHP 9.0)
-Err: Undefined variable $y (This will become an error in PHP 9.0)
+Err: Undefined variable $y (this will become an error in PHP 9.0)
+Err: Undefined variable $y (this will become an error in PHP 9.0)
 Err: String offset cast occurred
 NULL

--- a/Zend/tests/str_offset_006.phpt
+++ b/Zend/tests/str_offset_006.phpt
@@ -10,7 +10,7 @@ $a[$y]=$a.=($y);
 var_dump($a);
 ?>
 --EXPECT--
-Err: Undefined variable $y
-Err: Undefined variable $y
+Err: Undefined variable $y (This will become an error in PHP 9.0)
+Err: Undefined variable $y (This will become an error in PHP 9.0)
 Err: String offset cast occurred
 NULL

--- a/Zend/tests/str_offset_007.phpt
+++ b/Zend/tests/str_offset_007.phpt
@@ -11,6 +11,6 @@ $a[0][$d]='b';
 var_dump($a);
 ?>
 --EXPECT--
-Err: Undefined variable $d
+Err: Undefined variable $d (This will become an error in PHP 9.0)
 Err: String offset cast occurred
 string(0) ""

--- a/Zend/tests/str_offset_007.phpt
+++ b/Zend/tests/str_offset_007.phpt
@@ -11,6 +11,6 @@ $a[0][$d]='b';
 var_dump($a);
 ?>
 --EXPECT--
-Err: Undefined variable $d (This will become an error in PHP 9.0)
+Err: Undefined variable $d (this will become an error in PHP 9.0)
 Err: String offset cast occurred
 string(0) ""

--- a/Zend/tests/str_offset_008.phpt
+++ b/Zend/tests/str_offset_008.phpt
@@ -12,7 +12,7 @@ var_dump($a[0][$b]);
 var_dump($a);
 ?>
 --EXPECT--
-Err: Undefined variable $b
+Err: Undefined variable $b (This will become an error in PHP 9.0)
 Err: String offset cast occurred
 string(1) "x"
 int(8)

--- a/Zend/tests/str_offset_008.phpt
+++ b/Zend/tests/str_offset_008.phpt
@@ -12,7 +12,7 @@ var_dump($a[0][$b]);
 var_dump($a);
 ?>
 --EXPECT--
-Err: Undefined variable $b (This will become an error in PHP 9.0)
+Err: Undefined variable $b (this will become an error in PHP 9.0)
 Err: String offset cast occurred
 string(1) "x"
 int(8)

--- a/Zend/tests/this_in_extract.phpt
+++ b/Zend/tests/this_in_extract.phpt
@@ -15,5 +15,5 @@ foo();
 --EXPECTF--
 Cannot re-assign $this
 
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/this_in_extract.phpt
+++ b/Zend/tests/this_in_extract.phpt
@@ -15,5 +15,5 @@ foo();
 --EXPECTF--
 Cannot re-assign $this
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/Zend/tests/undef_index_to_exception.phpt
+++ b/Zend/tests/undef_index_to_exception.phpt
@@ -42,5 +42,5 @@ array(0) {
 Undefined array key "key"
 array(0) {
 }
-Undefined global variable $test (This will become an error in PHP 9.0)
-Undefined variable $test (This will become an error in PHP 9.0)
+Undefined global variable $test (this will become an error in PHP 9.0)
+Undefined variable $test (this will become an error in PHP 9.0)

--- a/Zend/tests/undef_index_to_exception.phpt
+++ b/Zend/tests/undef_index_to_exception.phpt
@@ -42,5 +42,5 @@ array(0) {
 Undefined array key "key"
 array(0) {
 }
-Undefined global variable $test
-Undefined variable $test
+Undefined global variable $test (This will become an error in PHP 9.0)
+Undefined variable $test (This will become an error in PHP 9.0)

--- a/Zend/tests/undef_var_in_verify_return.phpt
+++ b/Zend/tests/undef_var_in_verify_return.phpt
@@ -15,7 +15,7 @@ test();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ErrorException: Undefined variable $test in %s:%d
+Fatal error: Uncaught ErrorException: Undefined variable $test (This will become an error in PHP 9.0) in %s:%d
 Stack trace:
 #0 %s(%d): {closure}(2, 'Undefined varia...', '%s', 8)
 #1 %s(%d): test()

--- a/Zend/tests/undef_var_in_verify_return.phpt
+++ b/Zend/tests/undef_var_in_verify_return.phpt
@@ -15,7 +15,7 @@ test();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught ErrorException: Undefined variable $test (This will become an error in PHP 9.0) in %s:%d
+Fatal error: Uncaught ErrorException: Undefined variable $test (this will become an error in PHP 9.0) in %s:%d
 Stack trace:
 #0 %s(%d): {closure}(2, 'Undefined varia...', '%s', 8)
 #1 %s(%d): test()

--- a/Zend/tests/unreachable_phi_cycle.phpt
+++ b/Zend/tests/unreachable_phi_cycle.phpt
@@ -12,4 +12,4 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $i in %s on line %d
+Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unreachable_phi_cycle.phpt
+++ b/Zend/tests/unreachable_phi_cycle.phpt
@@ -12,4 +12,4 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $i (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $i (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_cv01.phpt
+++ b/Zend/tests/unset_cv01.phpt
@@ -10,4 +10,4 @@ echo $x;
 --EXPECTF--
 ok
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_cv01.phpt
+++ b/Zend/tests/unset_cv01.phpt
@@ -10,4 +10,4 @@ echo $x;
 --EXPECTF--
 ok
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_cv02.phpt
+++ b/Zend/tests/unset_cv02.phpt
@@ -10,4 +10,4 @@ echo $x;
 --EXPECTF--
 ok
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_cv02.phpt
+++ b/Zend/tests/unset_cv02.phpt
@@ -10,4 +10,4 @@ echo $x;
 --EXPECTF--
 ok
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_cv03.phpt
+++ b/Zend/tests/unset_cv03.phpt
@@ -10,4 +10,4 @@ echo $x;
 --EXPECTF--
 ok
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_cv03.phpt
+++ b/Zend/tests/unset_cv03.phpt
@@ -10,4 +10,4 @@ echo $x;
 --EXPECTF--
 ok
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_cv04.phpt
+++ b/Zend/tests/unset_cv04.phpt
@@ -13,4 +13,4 @@ f();
 --EXPECTF--
 ok
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_cv04.phpt
+++ b/Zend/tests/unset_cv04.phpt
@@ -13,4 +13,4 @@ f();
 --EXPECTF--
 ok
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/unset_non_array.phpt
+++ b/Zend/tests/unset_non_array.phpt
@@ -94,7 +94,7 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: Automatic conversion of false to array is deprecated in %s
 Cannot unset offset in a non-array variable
@@ -103,7 +103,7 @@ Cannot unset offset in a non-array variable
 Cannot unset string offsets
 Cannot use object of type stdClass as array
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: Automatic conversion of false to array is deprecated in %s
 Cannot unset offset in a non-array variable

--- a/Zend/tests/unset_non_array.phpt
+++ b/Zend/tests/unset_non_array.phpt
@@ -94,7 +94,7 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: Automatic conversion of false to array is deprecated in %s
 Cannot unset offset in a non-array variable
@@ -103,7 +103,7 @@ Cannot unset offset in a non-array variable
 Cannot unset string offsets
 Cannot use object of type stdClass as array
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 
 Deprecated: Automatic conversion of false to array is deprecated in %s
 Cannot unset offset in a non-array variable

--- a/Zend/tests/warning_during_heredoc_scan_ahead.phpt
+++ b/Zend/tests/warning_during_heredoc_scan_ahead.phpt
@@ -16,4 +16,4 @@ Warning: Octal escape sequence overflow \400 is greater than \377 in %s on line 
 
 Deprecated: Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead in %s on line %d
 
-Warning: Undefined variable $ (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $ (this will become an error in PHP 9.0) in %s on line %d

--- a/Zend/tests/warning_during_heredoc_scan_ahead.phpt
+++ b/Zend/tests/warning_during_heredoc_scan_ahead.phpt
@@ -16,4 +16,4 @@ Warning: Octal escape sequence overflow \400 is greater than \377 in %s on line 
 
 Deprecated: Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead in %s on line %d
 
-Warning: Undefined variable $ in %s on line %d
+Warning: Undefined variable $ (This will become an error in PHP 9.0) in %s on line %d

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -269,7 +269,7 @@ static zend_never_inline ZEND_COLD zval* zval_undefined_cv(uint32_t var EXECUTE_
 {
 	if (EXPECTED(EG(exception) == NULL)) {
 		zend_string *cv = CV_DEF_OF(EX_VAR_TO_NUM(var));
-		zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
+		zend_error(E_WARNING, "Undefined variable $%s (this will become an error in PHP 9.0)", ZSTR_VAL(cv));
 	}
 	return &EG(uninitialized_zval);
 }
@@ -3700,7 +3700,7 @@ static zend_never_inline void zend_fetch_this_var(int type OPLINE_DC EXECUTE_DAT
 				Z_ADDREF_P(result);
 			} else {
 				ZVAL_NULL(result);
-				zend_error(E_WARNING, "Undefined variable $this (This will become an error in PHP 9.0)");
+				zend_error(E_WARNING, "Undefined variable $this (this will become an error in PHP 9.0)");
 			}
 			break;
 		case BP_VAR_IS:

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -269,7 +269,7 @@ static zend_never_inline ZEND_COLD zval* zval_undefined_cv(uint32_t var EXECUTE_
 {
 	if (EXPECTED(EG(exception) == NULL)) {
 		zend_string *cv = CV_DEF_OF(EX_VAR_TO_NUM(var));
-		zend_error(E_WARNING, "Undefined variable $%s", ZSTR_VAL(cv));
+		zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
 	}
 	return &EG(uninitialized_zval);
 }
@@ -3700,7 +3700,7 @@ static zend_never_inline void zend_fetch_this_var(int type OPLINE_DC EXECUTE_DAT
 				Z_ADDREF_P(result);
 			} else {
 				ZVAL_NULL(result);
-				zend_error(E_WARNING, "Undefined variable $this");
+				zend_error(E_WARNING, "Undefined variable $this (This will become an error in PHP 9.0)");
 			}
 			break;
 		case BP_VAR_IS:

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1748,7 +1748,7 @@ ZEND_VM_C_LABEL(fetch_this):
 		} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 			retval = &EG(uninitialized_zval);
 		} else {
-			zend_error(E_WARNING, "Undefined %svariable $%s",
+			zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
 				(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 			if (type == BP_VAR_RW && !EG(exception)) {
 				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
@@ -1768,7 +1768,7 @@ ZEND_VM_C_LABEL(fetch_this):
 			} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 				retval = &EG(uninitialized_zval);
 			} else {
-				zend_error(E_WARNING, "Undefined %svariable $%s",
+				zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
 					(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 				if (type == BP_VAR_RW && !EG(exception)) {
 					ZVAL_NULL(retval);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1748,7 +1748,7 @@ ZEND_VM_C_LABEL(fetch_this):
 		} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 			retval = &EG(uninitialized_zval);
 		} else {
-			zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
+			zend_error(E_WARNING, "Undefined %svariable $%s (this will become an error in PHP 9.0)",
 				(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 			if (type == BP_VAR_RW && !EG(exception)) {
 				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
@@ -1768,7 +1768,7 @@ ZEND_VM_C_LABEL(fetch_this):
 			} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 				retval = &EG(uninitialized_zval);
 			} else {
-				zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
+				zend_error(E_WARNING, "Undefined %svariable $%s (this will become an error in PHP 9.0)",
 					(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 				if (type == BP_VAR_RW && !EG(exception)) {
 					ZVAL_NULL(retval);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -9873,7 +9873,7 @@ fetch_this:
 		} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 			retval = &EG(uninitialized_zval);
 		} else {
-			zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
+			zend_error(E_WARNING, "Undefined %svariable $%s (this will become an error in PHP 9.0)",
 				(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 			if (type == BP_VAR_RW && !EG(exception)) {
 				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
@@ -9893,7 +9893,7 @@ fetch_this:
 			} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 				retval = &EG(uninitialized_zval);
 			} else {
-				zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
+				zend_error(E_WARNING, "Undefined %svariable $%s (this will become an error in PHP 9.0)",
 					(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 				if (type == BP_VAR_RW && !EG(exception)) {
 					ZVAL_NULL(retval);
@@ -17678,7 +17678,7 @@ fetch_this:
 		} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 			retval = &EG(uninitialized_zval);
 		} else {
-			zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
+			zend_error(E_WARNING, "Undefined %svariable $%s (this will become an error in PHP 9.0)",
 				(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 			if (type == BP_VAR_RW && !EG(exception)) {
 				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
@@ -17698,7 +17698,7 @@ fetch_this:
 			} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 				retval = &EG(uninitialized_zval);
 			} else {
-				zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
+				zend_error(E_WARNING, "Undefined %svariable $%s (this will become an error in PHP 9.0)",
 					(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 				if (type == BP_VAR_RW && !EG(exception)) {
 					ZVAL_NULL(retval);
@@ -47207,7 +47207,7 @@ fetch_this:
 		} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 			retval = &EG(uninitialized_zval);
 		} else {
-			zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
+			zend_error(E_WARNING, "Undefined %svariable $%s (this will become an error in PHP 9.0)",
 				(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 			if (type == BP_VAR_RW && !EG(exception)) {
 				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
@@ -47227,7 +47227,7 @@ fetch_this:
 			} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 				retval = &EG(uninitialized_zval);
 			} else {
-				zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
+				zend_error(E_WARNING, "Undefined %svariable $%s (this will become an error in PHP 9.0)",
 					(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 				if (type == BP_VAR_RW && !EG(exception)) {
 					ZVAL_NULL(retval);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -9873,7 +9873,7 @@ fetch_this:
 		} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 			retval = &EG(uninitialized_zval);
 		} else {
-			zend_error(E_WARNING, "Undefined %svariable $%s",
+			zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
 				(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 			if (type == BP_VAR_RW && !EG(exception)) {
 				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
@@ -9893,7 +9893,7 @@ fetch_this:
 			} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 				retval = &EG(uninitialized_zval);
 			} else {
-				zend_error(E_WARNING, "Undefined %svariable $%s",
+				zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
 					(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 				if (type == BP_VAR_RW && !EG(exception)) {
 					ZVAL_NULL(retval);
@@ -17678,7 +17678,7 @@ fetch_this:
 		} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 			retval = &EG(uninitialized_zval);
 		} else {
-			zend_error(E_WARNING, "Undefined %svariable $%s",
+			zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
 				(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 			if (type == BP_VAR_RW && !EG(exception)) {
 				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
@@ -17698,7 +17698,7 @@ fetch_this:
 			} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 				retval = &EG(uninitialized_zval);
 			} else {
-				zend_error(E_WARNING, "Undefined %svariable $%s",
+				zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
 					(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 				if (type == BP_VAR_RW && !EG(exception)) {
 					ZVAL_NULL(retval);
@@ -47207,7 +47207,7 @@ fetch_this:
 		} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 			retval = &EG(uninitialized_zval);
 		} else {
-			zend_error(E_WARNING, "Undefined %svariable $%s",
+			zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
 				(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 			if (type == BP_VAR_RW && !EG(exception)) {
 				retval = zend_hash_update(target_symbol_table, name, &EG(uninitialized_zval));
@@ -47227,7 +47227,7 @@ fetch_this:
 			} else if (type == BP_VAR_IS || type == BP_VAR_UNSET) {
 				retval = &EG(uninitialized_zval);
 			} else {
-				zend_error(E_WARNING, "Undefined %svariable $%s",
+				zend_error(E_WARNING, "Undefined %svariable $%s (This will become an error in PHP 9.0)",
 					(opline->extended_value & ZEND_FETCH_GLOBAL ? "global " : ""), ZSTR_VAL(name));
 				if (type == BP_VAR_RW && !EG(exception)) {
 					ZVAL_NULL(retval);

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -105,7 +105,7 @@ static ZEND_COLD void ZEND_FASTCALL zend_jit_invalid_method_call(zval *object)
 	if (Z_TYPE_P(object) == IS_UNDEF && opline->op1_type == IS_CV) {
 		zend_string *cv = EX(func)->op_array.vars[EX_VAR_TO_NUM(opline->op1.var)];
 
-		zend_error(E_WARNING, "Undefined variable $%s", ZSTR_VAL(cv));
+		zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
 		if (UNEXPECTED(EG(exception) != NULL)) {
 			return;
 		}
@@ -350,7 +350,7 @@ static int ZEND_FASTCALL zend_jit_undefined_op_helper(uint32_t var)
 	const zend_execute_data *execute_data = EG(current_execute_data);
 	zend_string *cv = EX(func)->op_array.vars[EX_VAR_TO_NUM(var)];
 
-	zend_error(E_WARNING, "Undefined variable $%s", ZSTR_VAL(cv));
+	zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
 	return EG(exception) == NULL;
 }
 
@@ -364,7 +364,7 @@ static int ZEND_FASTCALL zend_jit_undefined_op_helper_write(HashTable *ht, uint3
 	if (!(GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE)) {
 		GC_ADDREF(ht);
 	}
-	zend_error(E_WARNING, "Undefined variable $%s", ZSTR_VAL(cv));
+	zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
 	if (!(GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) && GC_DELREF(ht) != 1) {
 		if (!GC_REFCOUNT(ht)) {
 			zend_array_destroy(ht);
@@ -2366,7 +2366,7 @@ static void ZEND_FASTCALL zend_jit_invalid_property_incdec(zval *container, cons
 	if (Z_TYPE_P(container) == IS_UNDEF && opline->op1_type == IS_CV) {
 		zend_string *cv = EX(func)->op_array.vars[EX_VAR_TO_NUM(opline->op1.var)];
 
-		zend_error(E_WARNING, "Undefined variable $%s", ZSTR_VAL(cv));
+		zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
 	}
 	if (opline->result_type & (IS_VAR|IS_TMP_VAR)) {
 		ZVAL_UNDEF(EX_VAR(opline->result.var));

--- a/ext/opcache/jit/zend_jit_helpers.c
+++ b/ext/opcache/jit/zend_jit_helpers.c
@@ -105,7 +105,7 @@ static ZEND_COLD void ZEND_FASTCALL zend_jit_invalid_method_call(zval *object)
 	if (Z_TYPE_P(object) == IS_UNDEF && opline->op1_type == IS_CV) {
 		zend_string *cv = EX(func)->op_array.vars[EX_VAR_TO_NUM(opline->op1.var)];
 
-		zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
+		zend_error(E_WARNING, "Undefined variable $%s (this will become an error in PHP 9.0)", ZSTR_VAL(cv));
 		if (UNEXPECTED(EG(exception) != NULL)) {
 			return;
 		}
@@ -350,7 +350,7 @@ static int ZEND_FASTCALL zend_jit_undefined_op_helper(uint32_t var)
 	const zend_execute_data *execute_data = EG(current_execute_data);
 	zend_string *cv = EX(func)->op_array.vars[EX_VAR_TO_NUM(var)];
 
-	zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
+	zend_error(E_WARNING, "Undefined variable $%s (this will become an error in PHP 9.0)", ZSTR_VAL(cv));
 	return EG(exception) == NULL;
 }
 
@@ -364,7 +364,7 @@ static int ZEND_FASTCALL zend_jit_undefined_op_helper_write(HashTable *ht, uint3
 	if (!(GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE)) {
 		GC_ADDREF(ht);
 	}
-	zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
+	zend_error(E_WARNING, "Undefined variable $%s (this will become an error in PHP 9.0)", ZSTR_VAL(cv));
 	if (!(GC_FLAGS(ht) & IS_ARRAY_IMMUTABLE) && GC_DELREF(ht) != 1) {
 		if (!GC_REFCOUNT(ht)) {
 			zend_array_destroy(ht);
@@ -2366,7 +2366,7 @@ static void ZEND_FASTCALL zend_jit_invalid_property_incdec(zval *container, cons
 	if (Z_TYPE_P(container) == IS_UNDEF && opline->op1_type == IS_CV) {
 		zend_string *cv = EX(func)->op_array.vars[EX_VAR_TO_NUM(opline->op1.var)];
 
-		zend_error(E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(cv));
+		zend_error(E_WARNING, "Undefined variable $%s (this will become an error in PHP 9.0)", ZSTR_VAL(cv));
 	}
 	if (opline->result_type & (IS_VAR|IS_TMP_VAR)) {
 		ZVAL_UNDEF(EX_VAR(opline->result.var));

--- a/ext/opcache/tests/block_pass_001.phpt
+++ b/ext/opcache/tests/block_pass_001.phpt
@@ -9,4 +9,4 @@ opcache
 (bool) new stdClass;
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d

--- a/ext/opcache/tests/block_pass_001.phpt
+++ b/ext/opcache/tests/block_pass_001.phpt
@@ -9,4 +9,4 @@ opcache
 (bool) new stdClass;
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d

--- a/ext/opcache/tests/bool_not_cv.phpt
+++ b/ext/opcache/tests/bool_not_cv.phpt
@@ -26,9 +26,9 @@ undef_bool_cast();
 --EXPECTF--
 In undef_negation
 
-Warning: Undefined variable $v in %s on line 4
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line 4
 true
 In undef_bool_cast
 
-Warning: Undefined variable $v in %s on line 10
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line 10
 false

--- a/ext/opcache/tests/bool_not_cv.phpt
+++ b/ext/opcache/tests/bool_not_cv.phpt
@@ -26,9 +26,9 @@ undef_bool_cast();
 --EXPECTF--
 In undef_negation
 
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line 4
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %s on line 4
 true
 In undef_bool_cast
 
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line 10
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %s on line 10
 false

--- a/ext/opcache/tests/bug73668.phpt
+++ b/ext/opcache/tests/bug73668.phpt
@@ -7,4 +7,4 @@ opcache
 $a/-1;
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d

--- a/ext/opcache/tests/bug73668.phpt
+++ b/ext/opcache/tests/bug73668.phpt
@@ -7,4 +7,4 @@ opcache
 $a/-1;
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d

--- a/ext/opcache/tests/bug76446.phpt
+++ b/ext/opcache/tests/bug76446.phpt
@@ -18,5 +18,5 @@ function test()
 var_dump(test());
 ?>
 --EXPECTF--
-Warning: Undefined variable $addlang in %s on line %d
+Warning: Undefined variable $addlang (This will become an error in PHP 9.0) in %s on line %d
 int(0)

--- a/ext/opcache/tests/bug76446.phpt
+++ b/ext/opcache/tests/bug76446.phpt
@@ -18,5 +18,5 @@ function test()
 var_dump(test());
 ?>
 --EXPECTF--
-Warning: Undefined variable $addlang (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $addlang (this will become an error in PHP 9.0) in %s on line %d
 int(0)

--- a/ext/opcache/tests/bug77058.phpt
+++ b/ext/opcache/tests/bug77058.phpt
@@ -18,5 +18,5 @@ myfunc();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 '2' is expected to be 2

--- a/ext/opcache/tests/bug77058.phpt
+++ b/ext/opcache/tests/bug77058.phpt
@@ -18,5 +18,5 @@ myfunc();
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 '2' is expected to be 2

--- a/ext/opcache/tests/bug79412.phpt
+++ b/ext/opcache/tests/bug79412.phpt
@@ -20,6 +20,6 @@ foreach ($foo as $bar) {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $foo (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d

--- a/ext/opcache/tests/bug79412.phpt
+++ b/ext/opcache/tests/bug79412.phpt
@@ -20,6 +20,6 @@ foreach ($foo as $bar) {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $foo in %s on line %d
+Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d

--- a/ext/opcache/tests/jit/add_011.phpt
+++ b/ext/opcache/tests/jit/add_011.phpt
@@ -20,181 +20,181 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-13)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-32)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-97)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-228)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-493)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1024)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-3073)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-7172)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-15373)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-31776)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-64609)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-130276)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-261613)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-524288)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1572865)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-3670020)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-7864333)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-16252960)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-33030241)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-66584804)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-133693933)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-267912192)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-536349697)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1073224708)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-2146974733)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4294474784)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-8589474913)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-17179475172)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-34359475693)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-68719476736)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-206158430209)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-481036337156)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1030792151053)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-2130303778848)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4329327034465)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-8727373545700)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-17523466568173)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-35115652613120)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-70300024704001)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-140668768885764)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-281406257249293)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-562881233976352)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1125831187430497)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-2251731094338788)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4503530908155373)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-9007130535788544)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-18014329791578113)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-36028728303157252)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-72057525326315533)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-144115119372632096)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-288230307465265249)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-576460683650531556)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1152921436021064173)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-2305842940762129408)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4611685950244260865)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-9223371969208523780)
 
-Warning: Undefined variable $u in %sadd_011.php on line 5
+Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
 
 Deprecated: Implicit conversion from float %f to int loses precision in %sadd_011.php on line 5
 int(66572500992)

--- a/ext/opcache/tests/jit/add_011.phpt
+++ b/ext/opcache/tests/jit/add_011.phpt
@@ -20,181 +20,181 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-13)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-32)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-97)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-228)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-493)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1024)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-3073)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-7172)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-15373)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-31776)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-64609)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-130276)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-261613)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-524288)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1572865)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-3670020)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-7864333)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-16252960)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-33030241)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-66584804)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-133693933)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-267912192)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-536349697)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1073224708)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-2146974733)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4294474784)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-8589474913)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-17179475172)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-34359475693)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-68719476736)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-206158430209)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-481036337156)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1030792151053)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-2130303778848)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4329327034465)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-8727373545700)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-17523466568173)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-35115652613120)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-70300024704001)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-140668768885764)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-281406257249293)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-562881233976352)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1125831187430497)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-2251731094338788)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4503530908155373)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-9007130535788544)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-18014329791578113)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-36028728303157252)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-72057525326315533)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-144115119372632096)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-288230307465265249)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-576460683650531556)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-1152921436021064173)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-2305842940762129408)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-4611685950244260865)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 int(-9223371969208523780)
 
-Warning: Undefined variable $u (This will become an error in PHP 9.0) in %sadd_011.php on line 5
+Warning: Undefined variable $u (this will become an error in PHP 9.0) in %sadd_011.php on line 5
 
 Deprecated: Implicit conversion from float %f to int loses precision in %sadd_011.php on line 5
 int(66572500992)

--- a/ext/opcache/tests/jit/assign_022.phpt
+++ b/ext/opcache/tests/jit/assign_022.phpt
@@ -21,5 +21,5 @@ foo();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 ok

--- a/ext/opcache/tests/jit/assign_022.phpt
+++ b/ext/opcache/tests/jit/assign_022.phpt
@@ -21,5 +21,5 @@ foo();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 ok

--- a/ext/opcache/tests/jit/assign_023.phpt
+++ b/ext/opcache/tests/jit/assign_023.phpt
@@ -21,5 +21,5 @@ foo();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 ok

--- a/ext/opcache/tests/jit/assign_023.phpt
+++ b/ext/opcache/tests/jit/assign_023.phpt
@@ -21,5 +21,5 @@ foo();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 ok

--- a/ext/opcache/tests/jit/assign_024.phpt
+++ b/ext/opcache/tests/jit/assign_024.phpt
@@ -20,5 +20,5 @@ foo();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 ok

--- a/ext/opcache/tests/jit/assign_024.phpt
+++ b/ext/opcache/tests/jit/assign_024.phpt
@@ -20,5 +20,5 @@ foo();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 ok

--- a/ext/opcache/tests/jit/assign_025.phpt
+++ b/ext/opcache/tests/jit/assign_025.phpt
@@ -21,5 +21,5 @@ foo();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $ref (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $ref (this will become an error in PHP 9.0) in %s on line %d
 ok

--- a/ext/opcache/tests/jit/assign_025.phpt
+++ b/ext/opcache/tests/jit/assign_025.phpt
@@ -21,5 +21,5 @@ foo();
 echo "ok\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $ref in %s on line %d
+Warning: Undefined variable $ref (This will become an error in PHP 9.0) in %s on line %d
 ok

--- a/ext/opcache/tests/jit/assign_040.phpt
+++ b/ext/opcache/tests/jit/assign_040.phpt
@@ -23,5 +23,5 @@ try {
     echo $e->getMessage(), "\n";
 }
 --EXPECTF--
-Warning: Undefined variable $y in %s on line %d
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string

--- a/ext/opcache/tests/jit/assign_040.phpt
+++ b/ext/opcache/tests/jit/assign_040.phpt
@@ -23,5 +23,5 @@ try {
     echo $e->getMessage(), "\n";
 }
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string

--- a/ext/opcache/tests/jit/assign_043.phpt
+++ b/ext/opcache/tests/jit/assign_043.phpt
@@ -19,4 +19,4 @@ try {
 }
 ?>
 --EXPECT--
-Undefined variable $b
+Undefined variable $b (This will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/assign_043.phpt
+++ b/ext/opcache/tests/jit/assign_043.phpt
@@ -19,4 +19,4 @@ try {
 }
 ?>
 --EXPECT--
-Undefined variable $b (This will become an error in PHP 9.0)
+Undefined variable $b (this will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/assign_046.phpt
+++ b/ext/opcache/tests/jit/assign_046.phpt
@@ -20,19 +20,19 @@ test();
 --EXPECTF--
 NULL
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %sassign_046.php on line 6

--- a/ext/opcache/tests/jit/assign_046.phpt
+++ b/ext/opcache/tests/jit/assign_046.phpt
@@ -20,19 +20,19 @@ test();
 --EXPECTF--
 NULL
 
-Warning: Undefined variable $b in %sassign_046.php on line 6
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b in %sassign_046.php on line 6
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b in %sassign_046.php on line 6
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b in %sassign_046.php on line 6
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b in %sassign_046.php on line 6
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6
 int(0)
 
-Warning: Undefined variable $b in %sassign_046.php on line 6
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sassign_046.php on line 6

--- a/ext/opcache/tests/jit/assign_047.phpt
+++ b/ext/opcache/tests/jit/assign_047.phpt
@@ -20,6 +20,6 @@ test()
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a in %sassign_047.php on line 5
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_047.php on line 5
 DONE
 

--- a/ext/opcache/tests/jit/assign_047.phpt
+++ b/ext/opcache/tests/jit/assign_047.phpt
@@ -20,6 +20,6 @@ test()
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_047.php on line 5
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_047.php on line 5
 DONE
 

--- a/ext/opcache/tests/jit/assign_048.phpt
+++ b/ext/opcache/tests/jit/assign_048.phpt
@@ -21,23 +21,23 @@ test();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a in %sassign_048.php on line 7
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
 DONE

--- a/ext/opcache/tests/jit/assign_048.phpt
+++ b/ext/opcache/tests/jit/assign_048.phpt
@@ -21,23 +21,23 @@ test();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_048.php on line 7
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_048.php on line 7
 DONE

--- a/ext/opcache/tests/jit/assign_053.phpt
+++ b/ext/opcache/tests/jit/assign_053.phpt
@@ -16,9 +16,9 @@ $test->x = " $y ";
 $r = &$test->x + ($r = $y);
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %sassign_053.php on line 6
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sassign_053.php on line 6
 
-Warning: Undefined variable $y in %sassign_053.php on line 7
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sassign_053.php on line 7
 
 Fatal error: Uncaught TypeError: Cannot assign null to reference held by property Test::$x of type string in %sassign_053.php:7
 Stack trace:

--- a/ext/opcache/tests/jit/assign_053.phpt
+++ b/ext/opcache/tests/jit/assign_053.phpt
@@ -16,9 +16,9 @@ $test->x = " $y ";
 $r = &$test->x + ($r = $y);
 ?>
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sassign_053.php on line 6
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sassign_053.php on line 6
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sassign_053.php on line 7
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sassign_053.php on line 7
 
 Fatal error: Uncaught TypeError: Cannot assign null to reference held by property Test::$x of type string in %sassign_053.php:7
 Stack trace:

--- a/ext/opcache/tests/jit/assign_dim_002.phpt
+++ b/ext/opcache/tests/jit/assign_dim_002.phpt
@@ -223,5 +223,5 @@ array(1) {
 Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 Illegal offset type
 
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/ext/opcache/tests/jit/assign_dim_002.phpt
+++ b/ext/opcache/tests/jit/assign_dim_002.phpt
@@ -223,5 +223,5 @@ array(1) {
 Deprecated: Automatic conversion of false to array is deprecated in %s on line %d
 Illegal offset type
 
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/ext/opcache/tests/jit/assign_dim_003.phpt
+++ b/ext/opcache/tests/jit/assign_dim_003.phpt
@@ -16,5 +16,5 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $v in %sassign_dim_003.php on line 3
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %sassign_dim_003.php on line 3
 NULL

--- a/ext/opcache/tests/jit/assign_dim_003.phpt
+++ b/ext/opcache/tests/jit/assign_dim_003.phpt
@@ -16,5 +16,5 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %sassign_dim_003.php on line 3
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %sassign_dim_003.php on line 3
 NULL

--- a/ext/opcache/tests/jit/assign_dim_004.phpt
+++ b/ext/opcache/tests/jit/assign_dim_004.phpt
@@ -22,5 +22,5 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 offsetSet(, 1)

--- a/ext/opcache/tests/jit/assign_dim_004.phpt
+++ b/ext/opcache/tests/jit/assign_dim_004.phpt
@@ -22,5 +22,5 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 offsetSet(, 1)

--- a/ext/opcache/tests/jit/assign_dim_005.phpt
+++ b/ext/opcache/tests/jit/assign_dim_005.phpt
@@ -17,6 +17,6 @@ $a[$c] = 'x' ;
 var_dump($a);
 ?>
 --EXPECT--
-Error: Undefined variable $c
-Error: Undefined variable $c
+Error: Undefined variable $c (This will become an error in PHP 9.0)
+Error: Undefined variable $c (This will become an error in PHP 9.0)
 NULL

--- a/ext/opcache/tests/jit/assign_dim_005.phpt
+++ b/ext/opcache/tests/jit/assign_dim_005.phpt
@@ -17,6 +17,6 @@ $a[$c] = 'x' ;
 var_dump($a);
 ?>
 --EXPECT--
-Error: Undefined variable $c (This will become an error in PHP 9.0)
-Error: Undefined variable $c (This will become an error in PHP 9.0)
+Error: Undefined variable $c (this will become an error in PHP 9.0)
+Error: Undefined variable $c (this will become an error in PHP 9.0)
 NULL

--- a/ext/opcache/tests/jit/assign_dim_010.phpt
+++ b/ext/opcache/tests/jit/assign_dim_010.phpt
@@ -18,7 +18,7 @@ test();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a in %sassign_dim_010.php on line 4
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_dim_010.php on line 4
 
-Warning: Undefined variable $y in %sassign_dim_010.php on line 4
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sassign_dim_010.php on line 4
 DONE

--- a/ext/opcache/tests/jit/assign_dim_010.phpt
+++ b/ext/opcache/tests/jit/assign_dim_010.phpt
@@ -18,7 +18,7 @@ test();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_dim_010.php on line 4
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_dim_010.php on line 4
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sassign_dim_010.php on line 4
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sassign_dim_010.php on line 4
 DONE

--- a/ext/opcache/tests/jit/assign_dim_014.phpt
+++ b/ext/opcache/tests/jit/assign_dim_014.phpt
@@ -15,5 +15,5 @@ $a[$y] = function(){};
 ?>
 DONE
 --EXPECT--
-Error: Undefined variable $y
+Error: Undefined variable $y (This will become an error in PHP 9.0)
 DONE

--- a/ext/opcache/tests/jit/assign_dim_014.phpt
+++ b/ext/opcache/tests/jit/assign_dim_014.phpt
@@ -15,5 +15,5 @@ $a[$y] = function(){};
 ?>
 DONE
 --EXPECT--
-Error: Undefined variable $y (This will become an error in PHP 9.0)
+Error: Undefined variable $y (this will become an error in PHP 9.0)
 DONE

--- a/ext/opcache/tests/jit/assign_dim_015.phpt
+++ b/ext/opcache/tests/jit/assign_dim_015.phpt
@@ -15,5 +15,5 @@ $my_var[] = $y;
 ?>
 DONE
 --EXPECT--
-Error: Undefined variable $y
+Error: Undefined variable $y (This will become an error in PHP 9.0)
 DONE

--- a/ext/opcache/tests/jit/assign_dim_015.phpt
+++ b/ext/opcache/tests/jit/assign_dim_015.phpt
@@ -15,5 +15,5 @@ $my_var[] = $y;
 ?>
 DONE
 --EXPECT--
-Error: Undefined variable $y (This will become an error in PHP 9.0)
+Error: Undefined variable $y (this will become an error in PHP 9.0)
 DONE

--- a/ext/opcache/tests/jit/assign_dim_op_002.phpt
+++ b/ext/opcache/tests/jit/assign_dim_op_002.phpt
@@ -12,4 +12,4 @@ opcache
 $a[] &= 1;
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d

--- a/ext/opcache/tests/jit/assign_dim_op_002.phpt
+++ b/ext/opcache/tests/jit/assign_dim_op_002.phpt
@@ -12,4 +12,4 @@ opcache
 $a[] &= 1;
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d

--- a/ext/opcache/tests/jit/assign_dim_op_003.phpt
+++ b/ext/opcache/tests/jit/assign_dim_op_003.phpt
@@ -13,4 +13,4 @@ $a[] &= $b;
 --EXTENSIONS--
 opcache
 --EXPECTF--
-Warning: Undefined variable $b in %s on line %d
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d

--- a/ext/opcache/tests/jit/assign_dim_op_003.phpt
+++ b/ext/opcache/tests/jit/assign_dim_op_003.phpt
@@ -13,4 +13,4 @@ $a[] &= $b;
 --EXTENSIONS--
 opcache
 --EXPECTF--
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line %d

--- a/ext/opcache/tests/jit/assign_dim_op_005.phpt
+++ b/ext/opcache/tests/jit/assign_dim_op_005.phpt
@@ -28,5 +28,5 @@ try {
 }
 ?>
 --EXPECT--
-Undefined variable $undef (This will become an error in PHP 9.0)
-Undefined variable $a (This will become an error in PHP 9.0)
+Undefined variable $undef (this will become an error in PHP 9.0)
+Undefined variable $a (this will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/assign_dim_op_005.phpt
+++ b/ext/opcache/tests/jit/assign_dim_op_005.phpt
@@ -28,5 +28,5 @@ try {
 }
 ?>
 --EXPECT--
-Undefined variable $undef
-Undefined variable $a
+Undefined variable $undef (This will become an error in PHP 9.0)
+Undefined variable $a (This will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/assign_dim_undef_exception.phpt
+++ b/ext/opcache/tests/jit/assign_dim_undef_exception.phpt
@@ -34,5 +34,5 @@ try {
 }
 ?>
 --EXPECT--
-Undefined variable $undef (This will become an error in PHP 9.0)
-Undefined variable $undef (This will become an error in PHP 9.0)
+Undefined variable $undef (this will become an error in PHP 9.0)
+Undefined variable $undef (this will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/assign_dim_undef_exception.phpt
+++ b/ext/opcache/tests/jit/assign_dim_undef_exception.phpt
@@ -34,5 +34,5 @@ try {
 }
 ?>
 --EXPECT--
-Undefined variable $undef
-Undefined variable $undef
+Undefined variable $undef (This will become an error in PHP 9.0)
+Undefined variable $undef (This will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/assign_obj_002.phpt
+++ b/ext/opcache/tests/jit/assign_obj_002.phpt
@@ -29,8 +29,8 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to property Test::$prop2 of type int

--- a/ext/opcache/tests/jit/assign_obj_002.phpt
+++ b/ext/opcache/tests/jit/assign_obj_002.phpt
@@ -29,8 +29,8 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to property Test::$prop2 of type int

--- a/ext/opcache/tests/jit/bool_not_002.phpt
+++ b/ext/opcache/tests/jit/bool_not_002.phpt
@@ -19,9 +19,9 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %sbool_not_002.php on line 6
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sbool_not_002.php on line 6
 
-Warning: Undefined variable $a in %sbool_not_002.php on line 6
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sbool_not_002.php on line 6
 
 Deprecated: Implicit conversion from float %f to int loses precision in %sbool_not_002.php on line 6
 

--- a/ext/opcache/tests/jit/bool_not_002.phpt
+++ b/ext/opcache/tests/jit/bool_not_002.phpt
@@ -19,9 +19,9 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sbool_not_002.php on line 6
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sbool_not_002.php on line 6
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sbool_not_002.php on line 6
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sbool_not_002.php on line 6
 
 Deprecated: Implicit conversion from float %f to int loses precision in %sbool_not_002.php on line 6
 

--- a/ext/opcache/tests/jit/bw_not_001.phpt
+++ b/ext/opcache/tests/jit/bw_not_001.phpt
@@ -12,9 +12,9 @@ $x[~"$x"]*=1;
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $x in %sbw_not_001.php on line 2
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %sbw_not_001.php on line 2
 
-Warning: Undefined variable $x in %sbw_not_001.php on line 2
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %sbw_not_001.php on line 2
 
 Warning: Undefined array key "" in %sbw_not_001.php on line 2
 DONE

--- a/ext/opcache/tests/jit/bw_not_001.phpt
+++ b/ext/opcache/tests/jit/bw_not_001.phpt
@@ -12,9 +12,9 @@ $x[~"$x"]*=1;
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %sbw_not_001.php on line 2
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %sbw_not_001.php on line 2
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %sbw_not_001.php on line 2
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %sbw_not_001.php on line 2
 
 Warning: Undefined array key "" in %sbw_not_001.php on line 2
 DONE

--- a/ext/opcache/tests/jit/cmp_006.phpt
+++ b/ext/opcache/tests/jit/cmp_006.phpt
@@ -44,14 +44,14 @@ test3(false);
 test4(false);
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %s on line %d
 bool(false)

--- a/ext/opcache/tests/jit/cmp_006.phpt
+++ b/ext/opcache/tests/jit/cmp_006.phpt
@@ -44,14 +44,14 @@ test3(false);
 test4(false);
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $y in %s on line %d
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
 bool(false)
 
-Warning: Undefined variable $y in %s on line %d
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
 bool(false)

--- a/ext/opcache/tests/jit/cmp_008.phpt
+++ b/ext/opcache/tests/jit/cmp_008.phpt
@@ -15,9 +15,9 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %scmp_008.php on line 3
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %scmp_008.php on line 3
 
-Warning: Undefined variable $a in %scmp_008.php on line 3
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %scmp_008.php on line 3
 
 Fatal error: Uncaught DivisionByZeroError: Modulo by zero in %scmp_008.php:3
 Stack trace:

--- a/ext/opcache/tests/jit/cmp_008.phpt
+++ b/ext/opcache/tests/jit/cmp_008.phpt
@@ -15,9 +15,9 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %scmp_008.php on line 3
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %scmp_008.php on line 3
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %scmp_008.php on line 3
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %scmp_008.php on line 3
 
 Fatal error: Uncaught DivisionByZeroError: Modulo by zero in %scmp_008.php:3
 Stack trace:

--- a/ext/opcache/tests/jit/fe_reset_001.phpt
+++ b/ext/opcache/tests/jit/fe_reset_001.phpt
@@ -14,23 +14,23 @@ for ($i = 0; $i < 5; $i++) {
 ?>
 OK
 --EXPECTF--
-Warning: Undefined variable $0 in %sfe_reset_001.php on line 4
+Warning: Undefined variable $0 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 
-Warning: Undefined variable $1 in %sfe_reset_001.php on line 4
+Warning: Undefined variable $1 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 
-Warning: Undefined variable $2 in %sfe_reset_001.php on line 4
+Warning: Undefined variable $2 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 
-Warning: Undefined variable $3 in %sfe_reset_001.php on line 4
+Warning: Undefined variable $3 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 
-Warning: Undefined variable $4 in %sfe_reset_001.php on line 4
+Warning: Undefined variable $4 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 OK

--- a/ext/opcache/tests/jit/fe_reset_001.phpt
+++ b/ext/opcache/tests/jit/fe_reset_001.phpt
@@ -14,23 +14,23 @@ for ($i = 0; $i < 5; $i++) {
 ?>
 OK
 --EXPECTF--
-Warning: Undefined variable $0 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
+Warning: Undefined variable $0 (this will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 
-Warning: Undefined variable $1 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
+Warning: Undefined variable $1 (this will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 
-Warning: Undefined variable $2 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
+Warning: Undefined variable $2 (this will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 
-Warning: Undefined variable $3 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
+Warning: Undefined variable $3 (this will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 
-Warning: Undefined variable $4 (This will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
+Warning: Undefined variable $4 (this will become an error in PHP 9.0) in %sfe_reset_001.php on line 4
 
 Warning: foreach() argument must be of type array|object, null given in %sfe_reset_001.php on line 4
 OK

--- a/ext/opcache/tests/jit/fe_reset_undef.phpt
+++ b/ext/opcache/tests/jit/fe_reset_undef.phpt
@@ -16,6 +16,6 @@ function test($c) {
 test(false);
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d

--- a/ext/opcache/tests/jit/fe_reset_undef.phpt
+++ b/ext/opcache/tests/jit/fe_reset_undef.phpt
@@ -16,6 +16,6 @@ function test($c) {
 test(false);
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: foreach() argument must be of type array|object, null given in %s on line %d

--- a/ext/opcache/tests/jit/fetch_dim_rw_001.phpt
+++ b/ext/opcache/tests/jit/fetch_dim_rw_001.phpt
@@ -17,7 +17,7 @@ function foo() {
 var_dump(foo());
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Undefined array key 0 in %sfetch_dim_rw_001.php on line 3
 

--- a/ext/opcache/tests/jit/fetch_dim_rw_001.phpt
+++ b/ext/opcache/tests/jit/fetch_dim_rw_001.phpt
@@ -17,7 +17,7 @@ function foo() {
 var_dump(foo());
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Undefined array key 0 in %sfetch_dim_rw_001.php on line 3
 

--- a/ext/opcache/tests/jit/fetch_obj_008.phpt
+++ b/ext/opcache/tests/jit/fetch_obj_008.phpt
@@ -25,7 +25,7 @@ $a->prop = new B;
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $e in %sfetch_obj_008.php on line 9
+Warning: Undefined variable $e (This will become an error in PHP 9.0) in %sfetch_obj_008.php on line 9
 
 Warning: Attempt to read property "prop" on string in %sfetch_obj_008.php on line 10
 DONE

--- a/ext/opcache/tests/jit/fetch_obj_008.phpt
+++ b/ext/opcache/tests/jit/fetch_obj_008.phpt
@@ -25,7 +25,7 @@ $a->prop = new B;
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $e (This will become an error in PHP 9.0) in %sfetch_obj_008.php on line 9
+Warning: Undefined variable $e (this will become an error in PHP 9.0) in %sfetch_obj_008.php on line 9
 
 Warning: Attempt to read property "prop" on string in %sfetch_obj_008.php on line 10
 DONE

--- a/ext/opcache/tests/jit/inc_obj_005.phpt
+++ b/ext/opcache/tests/jit/inc_obj_005.phpt
@@ -11,7 +11,7 @@ opcache.protect_memory=1
 json_encode($y)->y++;
 ?>
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sinc_obj_005.php on line 2
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sinc_obj_005.php on line 2
 
 Fatal error: Uncaught Error: Attempt to increment/decrement property "y" on string in %sinc_obj_005.php:2
 Stack trace:

--- a/ext/opcache/tests/jit/inc_obj_005.phpt
+++ b/ext/opcache/tests/jit/inc_obj_005.phpt
@@ -11,7 +11,7 @@ opcache.protect_memory=1
 json_encode($y)->y++;
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %sinc_obj_005.php on line 2
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sinc_obj_005.php on line 2
 
 Fatal error: Uncaught Error: Attempt to increment/decrement property "y" on string in %sinc_obj_005.php:2
 Stack trace:

--- a/ext/opcache/tests/jit/isset_001.phpt
+++ b/ext/opcache/tests/jit/isset_001.phpt
@@ -13,5 +13,5 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 bool(false)

--- a/ext/opcache/tests/jit/isset_001.phpt
+++ b/ext/opcache/tests/jit/isset_001.phpt
@@ -13,5 +13,5 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 bool(false)

--- a/ext/opcache/tests/jit/mul_009.phpt
+++ b/ext/opcache/tests/jit/mul_009.phpt
@@ -12,7 +12,7 @@ $x[""][] = 1;
 $x[~"$y"] *= 1;
 ?>
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %smul_009.php on line 3
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %smul_009.php on line 3
 
 Fatal error: Uncaught TypeError: Unsupported operand types: array * int in %smul_009.php:3
 Stack trace:

--- a/ext/opcache/tests/jit/mul_009.phpt
+++ b/ext/opcache/tests/jit/mul_009.phpt
@@ -12,7 +12,7 @@ $x[""][] = 1;
 $x[~"$y"] *= 1;
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %smul_009.php on line 3
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %smul_009.php on line 3
 
 Fatal error: Uncaught TypeError: Unsupported operand types: array * int in %smul_009.php:3
 Stack trace:

--- a/ext/opcache/tests/jit/qm_assign_002.phpt
+++ b/ext/opcache/tests/jit/qm_assign_002.phpt
@@ -19,11 +19,11 @@ test();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a in %sqm_assign_002.php on line 4
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sqm_assign_002.php on line 4
 
-Warning: Undefined variable $b in %sqm_assign_002.php on line 5
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sqm_assign_002.php on line 5
 
-Warning: Undefined variable $a in %sqm_assign_002.php on line 4
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sqm_assign_002.php on line 4
 
 Warning: Array to string conversion in %sqm_assign_002.php on line 5
 DONE

--- a/ext/opcache/tests/jit/qm_assign_002.phpt
+++ b/ext/opcache/tests/jit/qm_assign_002.phpt
@@ -19,11 +19,11 @@ test();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sqm_assign_002.php on line 4
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sqm_assign_002.php on line 4
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sqm_assign_002.php on line 5
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %sqm_assign_002.php on line 5
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sqm_assign_002.php on line 4
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sqm_assign_002.php on line 4
 
 Warning: Array to string conversion in %sqm_assign_002.php on line 5
 DONE

--- a/ext/opcache/tests/jit/qm_assign_undef_exception.phpt
+++ b/ext/opcache/tests/jit/qm_assign_undef_exception.phpt
@@ -19,4 +19,4 @@ try {
 }
 ?>
 --EXPECT--
-Undefined variable $b
+Undefined variable $b (This will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/qm_assign_undef_exception.phpt
+++ b/ext/opcache/tests/jit/qm_assign_undef_exception.phpt
@@ -19,4 +19,4 @@ try {
 }
 ?>
 --EXPECT--
-Undefined variable $b (This will become an error in PHP 9.0)
+Undefined variable $b (this will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/reg_alloc_004.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_004.phpt
@@ -22,13 +22,13 @@ function createTree($depth) {
 createTree(4);
 ?>
 --EXPECTF--
-Warning: Undefined variable $d in %sreg_alloc_004.php on line 7
+Warning: Undefined variable $d (This will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
 
-Warning: Undefined variable $d in %sreg_alloc_004.php on line 7
+Warning: Undefined variable $d (This will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
 
-Warning: Undefined variable $d in %sreg_alloc_004.php on line 7
+Warning: Undefined variable $d (This will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
 
-Warning: Undefined variable $d in %sreg_alloc_004.php on line 7
+Warning: Undefined variable $d (This will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
 
 Fatal error: Uncaught Error: First array member is not a valid class name or object in %sreg_alloc_004.php:7
 Stack trace:

--- a/ext/opcache/tests/jit/reg_alloc_004.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_004.phpt
@@ -22,13 +22,13 @@ function createTree($depth) {
 createTree(4);
 ?>
 --EXPECTF--
-Warning: Undefined variable $d (This will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
+Warning: Undefined variable $d (this will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
 
-Warning: Undefined variable $d (This will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
+Warning: Undefined variable $d (this will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
 
-Warning: Undefined variable $d (This will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
+Warning: Undefined variable $d (this will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
 
-Warning: Undefined variable $d (This will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
+Warning: Undefined variable $d (this will become an error in PHP 9.0) in %sreg_alloc_004.php on line 7
 
 Fatal error: Uncaught Error: First array member is not a valid class name or object in %sreg_alloc_004.php:7
 Stack trace:

--- a/ext/opcache/tests/jit/reg_alloc_006.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_006.phpt
@@ -18,17 +18,17 @@ foo()
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $y in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_006.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_006.phpt
@@ -18,17 +18,17 @@ foo()
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_006.php on line 5
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_007.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_007.phpt
@@ -17,7 +17,7 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sreg_alloc_007.php on line 4
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sreg_alloc_007.php on line 4
 
 Fatal error: Uncaught DivisionByZeroError: Modulo by zero in %sreg_alloc_007.php:6
 Stack trace:

--- a/ext/opcache/tests/jit/reg_alloc_007.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_007.phpt
@@ -17,7 +17,7 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %sreg_alloc_007.php on line 4
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sreg_alloc_007.php on line 4
 
 Fatal error: Uncaught DivisionByZeroError: Modulo by zero in %sreg_alloc_007.php:6
 Stack trace:

--- a/ext/opcache/tests/jit/reg_alloc_008.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_008.phpt
@@ -14,4 +14,4 @@ function foo($a) {
 foo(7);
 ?>
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_008.php on line 4
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_008.php on line 4

--- a/ext/opcache/tests/jit/reg_alloc_008.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_008.phpt
@@ -14,4 +14,4 @@ function foo($a) {
 foo(7);
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %sreg_alloc_008.php on line 4
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_008.php on line 4

--- a/ext/opcache/tests/jit/reg_alloc_009.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_009.phpt
@@ -15,7 +15,7 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $j (This will become an error in PHP 9.0) in %sreg_alloc_009.php on line 4
+Warning: Undefined variable $j (this will become an error in PHP 9.0) in %sreg_alloc_009.php on line 4
 
 Fatal error: Uncaught ArithmeticError: Bit shift by negative number in %sreg_alloc_009.php:4
 Stack trace:

--- a/ext/opcache/tests/jit/reg_alloc_009.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_009.phpt
@@ -15,7 +15,7 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $j in %sreg_alloc_009.php on line 4
+Warning: Undefined variable $j (This will become an error in PHP 9.0) in %sreg_alloc_009.php on line 4
 
 Fatal error: Uncaught ArithmeticError: Bit shift by negative number in %sreg_alloc_009.php:4
 Stack trace:

--- a/ext/opcache/tests/jit/reg_alloc_010.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_010.phpt
@@ -18,7 +18,7 @@ foo(null);
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $cnt (This will become an error in PHP 9.0) in %sreg_alloc_010.php on line 3
+Warning: Undefined variable $cnt (this will become an error in PHP 9.0) in %sreg_alloc_010.php on line 3
 
-Warning: Undefined variable $cnt (This will become an error in PHP 9.0) in %sreg_alloc_010.php on line 3
+Warning: Undefined variable $cnt (this will become an error in PHP 9.0) in %sreg_alloc_010.php on line 3
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_010.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_010.phpt
@@ -18,7 +18,7 @@ foo(null);
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $cnt in %sreg_alloc_010.php on line 3
+Warning: Undefined variable $cnt (This will become an error in PHP 9.0) in %sreg_alloc_010.php on line 3
 
-Warning: Undefined variable $cnt in %sreg_alloc_010.php on line 3
+Warning: Undefined variable $cnt (This will become an error in PHP 9.0) in %sreg_alloc_010.php on line 3
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_013.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_013.phpt
@@ -15,5 +15,5 @@ foo();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $j in %sreg_alloc_013.php on line 3
+Warning: Undefined variable $j (This will become an error in PHP 9.0) in %sreg_alloc_013.php on line 3
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_013.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_013.phpt
@@ -15,5 +15,5 @@ foo();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $j (This will become an error in PHP 9.0) in %sreg_alloc_013.php on line 3
+Warning: Undefined variable $j (this will become an error in PHP 9.0) in %sreg_alloc_013.php on line 3
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_014.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_014.phpt
@@ -17,5 +17,5 @@ foo();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a in %sreg_alloc_014.php on line 4
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sreg_alloc_014.php on line 4
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_014.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_014.phpt
@@ -17,5 +17,5 @@ foo();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sreg_alloc_014.php on line 4
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sreg_alloc_014.php on line 4
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_015.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_015.phpt
@@ -16,7 +16,7 @@ foo()
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_015.php on line 3
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_015.php on line 3
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_015.php on line 3
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sreg_alloc_015.php on line 3
 DONE

--- a/ext/opcache/tests/jit/reg_alloc_015.phpt
+++ b/ext/opcache/tests/jit/reg_alloc_015.phpt
@@ -16,7 +16,7 @@ foo()
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $y in %sreg_alloc_015.php on line 3
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_015.php on line 3
 
-Warning: Undefined variable $y in %sreg_alloc_015.php on line 3
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %sreg_alloc_015.php on line 3
 DONE

--- a/ext/opcache/tests/jit/send_val_002.phpt
+++ b/ext/opcache/tests/jit/send_val_002.phpt
@@ -13,7 +13,7 @@ function o(){
 o();
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %ssend_val_002.php on line 3
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %ssend_val_002.php on line 3
 
 Fatal error: Uncaught ArgumentCountError: var_dump() expects at least 1 argument, 0 given in %ssend_val_002.php:3
 Stack trace:

--- a/ext/opcache/tests/jit/send_val_002.phpt
+++ b/ext/opcache/tests/jit/send_val_002.phpt
@@ -13,7 +13,7 @@ function o(){
 o();
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %ssend_val_002.php on line 3
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %ssend_val_002.php on line 3
 
 Fatal error: Uncaught ArgumentCountError: var_dump() expects at least 1 argument, 0 given in %ssend_val_002.php:3
 Stack trace:

--- a/ext/opcache/tests/jit/shift_right_004.phpt
+++ b/ext/opcache/tests/jit/shift_right_004.phpt
@@ -21,11 +21,11 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %sshift_right_004.php on line 8
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sshift_right_004.php on line 8
 
-Warning: Undefined variable $a in %sshift_right_004.php on line 8
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sshift_right_004.php on line 8
 
-Warning: Undefined variable $c in %sshift_right_004.php on line 7
+Warning: Undefined variable $c (This will become an error in PHP 9.0) in %sshift_right_004.php on line 7
 
 Warning: Undefined array key 0 in %sshift_right_004.php on line 7
 

--- a/ext/opcache/tests/jit/shift_right_004.phpt
+++ b/ext/opcache/tests/jit/shift_right_004.phpt
@@ -21,11 +21,11 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sshift_right_004.php on line 8
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sshift_right_004.php on line 8
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sshift_right_004.php on line 8
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sshift_right_004.php on line 8
 
-Warning: Undefined variable $c (This will become an error in PHP 9.0) in %sshift_right_004.php on line 7
+Warning: Undefined variable $c (this will become an error in PHP 9.0) in %sshift_right_004.php on line 7
 
 Warning: Undefined array key 0 in %sshift_right_004.php on line 7
 

--- a/ext/opcache/tests/jit/type_check_001.phpt
+++ b/ext/opcache/tests/jit/type_check_001.phpt
@@ -22,4 +22,4 @@ try {
 }
 ?>
 --EXPECT--
-Exception: Undefined variable $a
+Exception: Undefined variable $a (This will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/type_check_001.phpt
+++ b/ext/opcache/tests/jit/type_check_001.phpt
@@ -22,4 +22,4 @@ try {
 }
 ?>
 --EXPECT--
-Exception: Undefined variable $a (This will become an error in PHP 9.0)
+Exception: Undefined variable $a (this will become an error in PHP 9.0)

--- a/ext/opcache/tests/jit/undef_to_typed_ref.phpt
+++ b/ext/opcache/tests/jit/undef_to_typed_ref.phpt
@@ -88,20 +88,20 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $v in %s on line %d
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v in %s on line %d
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v in %s on line %d
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v in %s on line %d
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v in %s on line %d
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v in %s on line %d
+Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string

--- a/ext/opcache/tests/jit/undef_to_typed_ref.phpt
+++ b/ext/opcache/tests/jit/undef_to_typed_ref.phpt
@@ -88,20 +88,20 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string
 
-Warning: Undefined variable $v (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $v (this will become an error in PHP 9.0) in %s on line %d
 Cannot assign null to reference held by property Test::$x of type string

--- a/ext/opcache/tests/jit/verify_return_undef.phpt
+++ b/ext/opcache/tests/jit/verify_return_undef.phpt
@@ -20,5 +20,5 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 test(): Return value must be of type int, null returned

--- a/ext/opcache/tests/jit/verify_return_undef.phpt
+++ b/ext/opcache/tests/jit/verify_return_undef.phpt
@@ -20,5 +20,5 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 test(): Return value must be of type int, null returned

--- a/ext/opcache/tests/jmpz_jmp_elim.phpt
+++ b/ext/opcache/tests/jmpz_jmp_elim.phpt
@@ -14,5 +14,5 @@ echo "done\n";
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 done

--- a/ext/opcache/tests/jmpz_jmp_elim.phpt
+++ b/ext/opcache/tests/jmpz_jmp_elim.phpt
@@ -14,5 +14,5 @@ echo "done\n";
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 done

--- a/ext/opcache/tests/opt/assign_obj_001.phpt
+++ b/ext/opcache/tests/opt/assign_obj_001.phpt
@@ -13,7 +13,7 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %sassign_obj_001.php on line 3
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sassign_obj_001.php on line 3
 
 Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_obj_001.php on line 3
 

--- a/ext/opcache/tests/opt/assign_obj_001.phpt
+++ b/ext/opcache/tests/opt/assign_obj_001.phpt
@@ -15,7 +15,7 @@ test();
 --EXPECTF--
 Warning: Undefined variable $y in %sassign_obj_001.php on line 3
 
-Warning: Undefined variable $a in %sassign_obj_001.php on line 3
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_obj_001.php on line 3
 
 Fatal error: Uncaught Error: Attempt to assign property "y" on string in %sassign_obj_001.php:4
 Stack trace:

--- a/ext/opcache/tests/opt/assign_obj_op_001.phpt
+++ b/ext/opcache/tests/opt/assign_obj_op_001.phpt
@@ -13,9 +13,9 @@ function s() {
 s();
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %sassign_obj_op_001.php on line 3
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %sassign_obj_op_001.php on line 3
 
-Warning: Undefined variable $a in %sassign_obj_op_001.php on line 3
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_obj_op_001.php on line 3
 
 Fatal error: Uncaught Error: Attempt to assign property "y" on string in %sassign_obj_op_001.php:4
 Stack trace:

--- a/ext/opcache/tests/opt/assign_op_001.phpt
+++ b/ext/opcache/tests/opt/assign_op_001.phpt
@@ -17,9 +17,9 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_op_001.php on line 4
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_op_001.php on line 4
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_op_001.php on line 4
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sassign_op_001.php on line 4
 
 Warning: Undefined array key "b" in %sassign_op_001.php on line 7
 

--- a/ext/opcache/tests/opt/assign_op_001.phpt
+++ b/ext/opcache/tests/opt/assign_op_001.phpt
@@ -17,9 +17,9 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %sassign_op_001.php on line 4
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_op_001.php on line 4
 
-Warning: Undefined variable $a in %sassign_op_001.php on line 4
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sassign_op_001.php on line 4
 
 Warning: Undefined array key "b" in %sassign_op_001.php on line 7
 

--- a/ext/opcache/tests/opt/coalesce_002.phpt
+++ b/ext/opcache/tests/opt/coalesce_002.phpt
@@ -12,7 +12,7 @@ function t() {
 t();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %scoalesce_002.php on line 3
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %scoalesce_002.php on line 3
 
 Fatal error: Uncaught ArgumentCountError: var_dump() expects at least 1 argument, 0 given in %scoalesce_002.php:3
 Stack trace:

--- a/ext/opcache/tests/opt/coalesce_002.phpt
+++ b/ext/opcache/tests/opt/coalesce_002.phpt
@@ -12,7 +12,7 @@ function t() {
 t();
 ?>
 --EXPECTF--
-Warning: Undefined variable $a in %scoalesce_002.php on line 3
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %scoalesce_002.php on line 3
 
 Fatal error: Uncaught ArgumentCountError: var_dump() expects at least 1 argument, 0 given in %scoalesce_002.php:3
 Stack trace:

--- a/ext/opcache/tests/opt/dce_011.phpt
+++ b/ext/opcache/tests/opt/dce_011.phpt
@@ -6,7 +6,7 @@ Incorrect DCE of ADD_ARRAY_ELEMENT
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sdce_011.php on line 2
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %sdce_011.php on line 2
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sdce_011.php on line 2
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %sdce_011.php on line 2
 DONE

--- a/ext/opcache/tests/opt/dce_011.phpt
+++ b/ext/opcache/tests/opt/dce_011.phpt
@@ -6,7 +6,7 @@ Incorrect DCE of ADD_ARRAY_ELEMENT
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $a in %sdce_011.php on line 2
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %sdce_011.php on line 2
 
-Warning: Undefined variable $b in %sdce_011.php on line 2
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %sdce_011.php on line 2
 DONE

--- a/ext/opcache/tests/opt/inference_001.phpt
+++ b/ext/opcache/tests/opt/inference_001.phpt
@@ -28,13 +28,13 @@ test2();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $obj (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $obj (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "x" on null in %s on line %d
 
 Warning: Undefined property: stdClass::$x in %s on line %d
 
-Warning: Undefined variable $obj (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $obj (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "x" on null in %s on line %d
 DONE

--- a/ext/opcache/tests/opt/inference_001.phpt
+++ b/ext/opcache/tests/opt/inference_001.phpt
@@ -28,13 +28,13 @@ test2();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $obj in %s on line %d
+Warning: Undefined variable $obj (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "x" on null in %s on line %d
 
 Warning: Undefined property: stdClass::$x in %s on line %d
 
-Warning: Undefined variable $obj in %s on line %d
+Warning: Undefined variable $obj (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Attempt to read property "x" on null in %s on line %d
 DONE

--- a/ext/opcache/tests/opt/inference_012.phpt
+++ b/ext/opcache/tests/opt/inference_012.phpt
@@ -20,7 +20,7 @@ test();
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $x in %sinference_012.php on line 4
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %sinference_012.php on line 4
 
-Warning: Undefined variable $arr in %sinference_012.php on line 5
+Warning: Undefined variable $arr (this will become an error in PHP 9.0) in %sinference_012.php on line 5
 DONE

--- a/ext/opcache/tests/opt/match_001.phpt
+++ b/ext/opcache/tests/opt/match_001.phpt
@@ -9,9 +9,9 @@ opcache.optimization_level=-1
 +$y . +$y . match(y) {}
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %smatch_001.php on line 2
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %smatch_001.php on line 2
 
-Warning: Undefined variable $y in %smatch_001.php on line 2
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %smatch_001.php on line 2
 
 Fatal error: Uncaught Error: Undefined constant "y" in %smatch_001.php:2
 Stack trace:

--- a/ext/opcache/tests/opt/sccp_034.phpt
+++ b/ext/opcache/tests/opt/sccp_034.phpt
@@ -10,7 +10,7 @@ is_array(["$y $y"]);
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %ssccp_034.php on line 2
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %ssccp_034.php on line 2
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %ssccp_034.php on line 2
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %ssccp_034.php on line 2
 DONE

--- a/ext/opcache/tests/opt/sccp_034.phpt
+++ b/ext/opcache/tests/opt/sccp_034.phpt
@@ -10,7 +10,7 @@ is_array(["$y $y"]);
 ?>
 DONE
 --EXPECTF--
-Warning: Undefined variable $y in %ssccp_034.php on line 2
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %ssccp_034.php on line 2
 
-Warning: Undefined variable $y in %ssccp_034.php on line 2
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %ssccp_034.php on line 2
 DONE

--- a/ext/opcache/tests/opt/sccp_040.phpt
+++ b/ext/opcache/tests/opt/sccp_040.phpt
@@ -13,7 +13,7 @@ function f() {
 f();
 ?>
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %ssccp_040.php on line 3
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %ssccp_040.php on line 3
 
 Fatal error: Uncaught Error: Array callback must have exactly two elements in %ssccp_040.php:4
 Stack trace:

--- a/ext/opcache/tests/opt/sccp_040.phpt
+++ b/ext/opcache/tests/opt/sccp_040.phpt
@@ -13,7 +13,7 @@ function f() {
 f();
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %ssccp_040.php on line 3
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %ssccp_040.php on line 3
 
 Fatal error: Uncaught Error: Array callback must have exactly two elements in %ssccp_040.php:4
 Stack trace:

--- a/ext/opcache/tests/opt/tmp_001.phpt
+++ b/ext/opcache/tests/opt/tmp_001.phpt
@@ -9,7 +9,7 @@ opcache.optimization_level=-1
 is_a((int)" $y " + 0);
 ?>
 --EXPECTF--
-Warning: Undefined variable $y in %stmp_001.php on line 2
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %stmp_001.php on line 2
 
 Fatal error: Uncaught ArgumentCountError: is_a() expects at least 2 arguments, 1 given in %stmp_001.php:2
 Stack trace:

--- a/ext/opcache/tests/opt/tmp_001.phpt
+++ b/ext/opcache/tests/opt/tmp_001.phpt
@@ -9,7 +9,7 @@ opcache.optimization_level=-1
 is_a((int)" $y " + 0);
 ?>
 --EXPECTF--
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %stmp_001.php on line 2
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %stmp_001.php on line 2
 
 Fatal error: Uncaught ArgumentCountError: is_a() expects at least 2 arguments, 1 given in %stmp_001.php:2
 Stack trace:

--- a/ext/opcache/tests/wrong_inlining_003.phpt
+++ b/ext/opcache/tests/wrong_inlining_003.phpt
@@ -19,5 +19,5 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 int(42)

--- a/ext/opcache/tests/wrong_inlining_003.phpt
+++ b/ext/opcache/tests/wrong_inlining_003.phpt
@@ -19,5 +19,5 @@ function test() {
 test();
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 int(42)

--- a/ext/pdo_sqlite/tests/bug43831.phpt
+++ b/ext/pdo_sqlite/tests/bug43831.phpt
@@ -49,5 +49,5 @@ object(PDO)#%d (0) {
 object(MyPDO)#%d (0) {
 }
 
-Warning: Undefined variable $bar (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $bar (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/ext/pdo_sqlite/tests/bug43831.phpt
+++ b/ext/pdo_sqlite/tests/bug43831.phpt
@@ -49,5 +49,5 @@ object(PDO)#%d (0) {
 object(MyPDO)#%d (0) {
 }
 
-Warning: Undefined variable $bar in %s on line %d
+Warning: Undefined variable $bar (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/ext/pgsql/tests/bug72195.phpt
+++ b/ext/pgsql/tests/bug72195.phpt
@@ -14,5 +14,5 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $var1 in %s on line %d
+Warning: Undefined variable $var1 (This will become an error in PHP 9.0) in %s on line %d
 pg_pconnect() expects at most 2 arguments, 4 given

--- a/ext/pgsql/tests/bug72195.phpt
+++ b/ext/pgsql/tests/bug72195.phpt
@@ -14,5 +14,5 @@ try {
 }
 ?>
 --EXPECTF--
-Warning: Undefined variable $var1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $var1 (this will become an error in PHP 9.0) in %s on line %d
 pg_pconnect() expects at most 2 arguments, 4 given

--- a/ext/reflection/tests/ReflectionParameter_003.phpt
+++ b/ext/reflection/tests/ReflectionParameter_003.phpt
@@ -56,7 +56,7 @@ foreach($refParameters as $parameter) {
 hello from test
 third is jack
 
-Warning: Undefined variable $theIncrement (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $theIncrement (this will become an error in PHP 9.0) in %s on line %d
 parameter names from staticMethod method:
 
 object(ReflectionParameter)#%d (1) {

--- a/ext/reflection/tests/ReflectionParameter_003.phpt
+++ b/ext/reflection/tests/ReflectionParameter_003.phpt
@@ -56,7 +56,7 @@ foreach($refParameters as $parameter) {
 hello from test
 third is jack
 
-Warning: Undefined variable $theIncrement in %s on line %d
+Warning: Undefined variable $theIncrement (This will become an error in PHP 9.0) in %s on line %d
 parameter names from staticMethod method:
 
 object(ReflectionParameter)#%d (1) {

--- a/ext/session/tests/session_decode_variation3.phpt
+++ b/ext/session/tests/session_decode_variation3.phpt
@@ -33,7 +33,7 @@ ob_end_flush();
 Warning: session_start(): Cannot find session serialization handler "blah" - session startup failed in %s on line %d
 bool(false)
 
-Warning: Undefined global variable $_SESSION in %s on line %d
+Warning: Undefined global variable $_SESSION (This will become an error in PHP 9.0) in %s on line %d
 NULL
 array(3) {
   ["foo"]=>

--- a/ext/session/tests/session_decode_variation3.phpt
+++ b/ext/session/tests/session_decode_variation3.phpt
@@ -33,7 +33,7 @@ ob_end_flush();
 Warning: session_start(): Cannot find session serialization handler "blah" - session startup failed in %s on line %d
 bool(false)
 
-Warning: Undefined global variable $_SESSION (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined global variable $_SESSION (this will become an error in PHP 9.0) in %s on line %d
 NULL
 array(3) {
   ["foo"]=>

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_012.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_012.phpt
@@ -45,7 +45,7 @@ var_dump(session_id(), $oldHandler, ini_get('session.save_handler'), $handler->i
 Open:
 SessionHandler::open() expects exactly 2 arguments, 0 given
 
-Warning: Undefined global variable $_SESSION in %s on line %d
+Warning: Undefined global variable $_SESSION (This will become an error in PHP 9.0) in %s on line %d
 string(0) ""
 string(5) "files"
 string(4) "user"

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_012.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_012.phpt
@@ -45,7 +45,7 @@ var_dump(session_id(), $oldHandler, ini_get('session.save_handler'), $handler->i
 Open:
 SessionHandler::open() expects exactly 2 arguments, 0 given
 
-Warning: Undefined global variable $_SESSION (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined global variable $_SESSION (this will become an error in PHP 9.0) in %s on line %d
 string(0) ""
 string(5) "files"
 string(4) "user"

--- a/ext/simplexml/tests/SimpleXMLElement_xpath_4.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_xpath_4.phpt
@@ -17,5 +17,5 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $x (this will become an error in PHP 9.0) in %s on line %d
 simplexml_load_string(): Argument #3 ($options) is too large

--- a/ext/simplexml/tests/SimpleXMLElement_xpath_4.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_xpath_4.phpt
@@ -17,5 +17,5 @@ try {
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $x in %s on line %d
+Warning: Undefined variable $x (This will become an error in PHP 9.0) in %s on line %d
 simplexml_load_string(): Argument #3 ($options) is too large

--- a/ext/spl/tests/arrayObject_exchangeArray_basic3.phpt
+++ b/ext/spl/tests/arrayObject_exchangeArray_basic3.phpt
@@ -84,7 +84,7 @@ array(2) {
 --> exchangeArray() with no arg:
 Exception: ArrayObject::exchangeArray() expects exactly 1 argument, 0 given
 
-Warning: Undefined variable $copy in %s on line %d
+Warning: Undefined variable $copy (This will become an error in PHP 9.0) in %s on line %d
 object(ArrayObject)#2 (1) {
   ["storage":"ArrayObject":private]=>
   object(C)#3 (2) {
@@ -106,7 +106,7 @@ NULL
 --> exchangeArray() with bad arg type:
 ArrayObject::exchangeArray(): Argument #1 ($array) must be of type array, null given
 
-Warning: Undefined variable $copy in %s on line %d
+Warning: Undefined variable $copy (This will become an error in PHP 9.0) in %s on line %d
 object(ArrayObject)#3 (1) {
   ["storage":"ArrayObject":private]=>
   object(C)#2 (2) {

--- a/ext/spl/tests/arrayObject_exchangeArray_basic3.phpt
+++ b/ext/spl/tests/arrayObject_exchangeArray_basic3.phpt
@@ -84,7 +84,7 @@ array(2) {
 --> exchangeArray() with no arg:
 Exception: ArrayObject::exchangeArray() expects exactly 1 argument, 0 given
 
-Warning: Undefined variable $copy (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $copy (this will become an error in PHP 9.0) in %s on line %d
 object(ArrayObject)#2 (1) {
   ["storage":"ArrayObject":private]=>
   object(C)#3 (2) {
@@ -106,7 +106,7 @@ NULL
 --> exchangeArray() with bad arg type:
 ArrayObject::exchangeArray(): Argument #1 ($array) must be of type array, null given
 
-Warning: Undefined variable $copy (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $copy (this will become an error in PHP 9.0) in %s on line %d
 object(ArrayObject)#3 (1) {
   ["storage":"ArrayObject":private]=>
   object(C)#2 (2) {

--- a/ext/spl/tests/array_026.phpt
+++ b/ext/spl/tests/array_026.phpt
@@ -8,7 +8,7 @@ $test['d1']['d3'] = 'world';
 var_dump($test, $test3['mmmmm']);
 ?>
 --EXPECTF--
-Warning: Undefined variable $test3 in %s on line %d
+Warning: Undefined variable $test3 (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 object(ArrayObject)#1 (1) {

--- a/ext/spl/tests/array_026.phpt
+++ b/ext/spl/tests/array_026.phpt
@@ -8,7 +8,7 @@ $test['d1']['d3'] = 'world';
 var_dump($test, $test3['mmmmm']);
 ?>
 --EXPECTF--
-Warning: Undefined variable $test3 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $test3 (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 object(ArrayObject)#1 (1) {

--- a/ext/spl/tests/bug62978.phpt
+++ b/ext/spl/tests/bug62978.phpt
@@ -32,7 +32,7 @@ NULL
 Warning: Undefined array key "epic_magic" in %s on line %d
 NULL
 
-Warning: Undefined variable $c in %s on line %d
+Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 NULL

--- a/ext/spl/tests/bug62978.phpt
+++ b/ext/spl/tests/bug62978.phpt
@@ -32,7 +32,7 @@ NULL
 Warning: Undefined array key "epic_magic" in %s on line %d
 NULL
 
-Warning: Undefined variable $c (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $c (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 NULL

--- a/ext/spl/tests/bug72888.phpt
+++ b/ext/spl/tests/bug72888.phpt
@@ -14,5 +14,5 @@ var_dump($y);
 --EXPECTF--
 string(60) "Trying to clone an uncloneable object of class SplFileObject"
 
-Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $y (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/ext/spl/tests/bug72888.phpt
+++ b/ext/spl/tests/bug72888.phpt
@@ -14,5 +14,5 @@ var_dump($y);
 --EXPECTF--
 string(60) "Trying to clone an uncloneable object of class SplFileObject"
 
-Warning: Undefined variable $y in %s on line %d
+Warning: Undefined variable $y (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2478,7 +2478,7 @@ static void php_compact_var(HashTable *eg_active_symbol_table, zval *return_valu
 				zend_hash_update(Z_ARRVAL_P(return_value), Z_STR_P(entry), &data);
 			}
 		} else {
-			php_error_docref(NULL, E_WARNING, "Undefined variable $%s", ZSTR_VAL(Z_STR_P(entry)));
+			php_error_docref(NULL, E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(Z_STR_P(entry)));
 		}
 	} else if (Z_TYPE_P(entry) == IS_ARRAY) {
 	    if (Z_REFCOUNTED_P(entry)) {

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2478,7 +2478,7 @@ static void php_compact_var(HashTable *eg_active_symbol_table, zval *return_valu
 				zend_hash_update(Z_ARRVAL_P(return_value), Z_STR_P(entry), &data);
 			}
 		} else {
-			php_error_docref(NULL, E_WARNING, "Undefined variable $%s (This will become an error in PHP 9.0)", ZSTR_VAL(Z_STR_P(entry)));
+			php_error_docref(NULL, E_WARNING, "Undefined variable $%s (this will become an error in PHP 9.0)", ZSTR_VAL(Z_STR_P(entry)));
 		}
 	} else if (Z_TYPE_P(entry) == IS_ARRAY) {
 	    if (Z_REFCOUNTED_P(entry)) {

--- a/ext/standard/tests/array/array_fill_keys_variation4.phpt
+++ b/ext/standard/tests/array/array_fill_keys_variation4.phpt
@@ -77,7 +77,7 @@ array(1) {
 
 -- Testing array_fill_keys() function with unset var --
 
-Warning: Undefined variable $unset_var in %s on line %d
+Warning: Undefined variable $unset_var (This will become an error in PHP 9.0) in %s on line %d
 array(1) {
   ["one"]=>
   NULL

--- a/ext/standard/tests/array/array_fill_keys_variation4.phpt
+++ b/ext/standard/tests/array/array_fill_keys_variation4.phpt
@@ -77,7 +77,7 @@ array(1) {
 
 -- Testing array_fill_keys() function with unset var --
 
-Warning: Undefined variable $unset_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $unset_var (this will become an error in PHP 9.0) in %s on line %d
 array(1) {
   ["one"]=>
   NULL

--- a/ext/standard/tests/array/bug30074.phpt
+++ b/ext/standard/tests/array/bug30074.phpt
@@ -7,7 +7,7 @@ var_dump(array($a));
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undefined in %s on line %d
+Warning: Undefined variable $undefined (This will become an error in PHP 9.0) in %s on line %d
 array(1) {
   [0]=>
   NULL

--- a/ext/standard/tests/array/bug30074.phpt
+++ b/ext/standard/tests/array/bug30074.phpt
@@ -7,7 +7,7 @@ var_dump(array($a));
 echo "Done\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undefined (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undefined (this will become an error in PHP 9.0) in %s on line %d
 array(1) {
   [0]=>
   NULL

--- a/ext/standard/tests/array/bug69198.phpt
+++ b/ext/standard/tests/array/bug69198.phpt
@@ -9,7 +9,7 @@ $result = compact('willNeverBeDefined');
 var_dump($result, empty($result), $result === array(), empty($willNeverBeDefined));
 ?>
 --EXPECTF--
-Warning: compact(): Undefined variable $willNeverBeDefined in %s on line %d
+Warning: compact(): Undefined variable $willNeverBeDefined (This will become an error in PHP 9.0) in %s on line %d
 array(0) {
 }
 bool(true)

--- a/ext/standard/tests/array/bug69198.phpt
+++ b/ext/standard/tests/array/bug69198.phpt
@@ -9,7 +9,7 @@ $result = compact('willNeverBeDefined');
 var_dump($result, empty($result), $result === array(), empty($willNeverBeDefined));
 ?>
 --EXPECTF--
-Warning: compact(): Undefined variable $willNeverBeDefined (This will become an error in PHP 9.0) in %s on line %d
+Warning: compact(): Undefined variable $willNeverBeDefined (this will become an error in PHP 9.0) in %s on line %d
 array(0) {
 }
 bool(true)

--- a/ext/standard/tests/array/compact.phpt
+++ b/ext/standard/tests/array/compact.phpt
@@ -20,7 +20,7 @@ var_dump($result);
 
 ?>
 --EXPECTF--
-Warning: compact(): Undefined variable $c\u0327ity in %s on line %d
+Warning: compact(): Undefined variable $c\u0327ity (This will become an error in PHP 9.0) in %s on line %d
 array(2) {
   ["event"]=>
   string(8) "SIGGRAPH"

--- a/ext/standard/tests/array/compact.phpt
+++ b/ext/standard/tests/array/compact.phpt
@@ -20,7 +20,7 @@ var_dump($result);
 
 ?>
 --EXPECTF--
-Warning: compact(): Undefined variable $c\u0327ity (This will become an error in PHP 9.0) in %s on line %d
+Warning: compact(): Undefined variable $c\u0327ity (this will become an error in PHP 9.0) in %s on line %d
 array(2) {
   ["event"]=>
   string(8) "SIGGRAPH"

--- a/ext/standard/tests/array/compact_basic.phpt
+++ b/ext/standard/tests/array/compact_basic.phpt
@@ -67,7 +67,7 @@ array(2) {
   float(0.2)
 }
 
-Warning: compact(): Undefined variable $g (This will become an error in PHP 9.0) in %s on line %d
+Warning: compact(): Undefined variable $g (this will become an error in PHP 9.0) in %s on line %d
 array(0) {
 }
 Done

--- a/ext/standard/tests/array/compact_basic.phpt
+++ b/ext/standard/tests/array/compact_basic.phpt
@@ -67,7 +67,7 @@ array(2) {
   float(0.2)
 }
 
-Warning: compact(): Undefined variable $g in %s on line %d
+Warning: compact(): Undefined variable $g (This will become an error in PHP 9.0) in %s on line %d
 array(0) {
 }
 Done

--- a/ext/standard/tests/array/compact_variation2.phpt
+++ b/ext/standard/tests/array/compact_variation2.phpt
@@ -20,7 +20,7 @@ f();
 --EXPECTF--
 *** Testing compact() : usage variations  - variables outside of current scope ***
 
-Warning: compact(): Undefined variable $a in %s on line %d
+Warning: compact(): Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 array(2) {
   ["b"]=>
   string(3) "f.b"
@@ -28,7 +28,7 @@ array(2) {
   string(3) "f.c"
 }
 
-Warning: compact(): Undefined variable $a in %s on line %d
+Warning: compact(): Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 array(2) {
   ["b"]=>
   string(3) "f.b"

--- a/ext/standard/tests/array/compact_variation2.phpt
+++ b/ext/standard/tests/array/compact_variation2.phpt
@@ -20,7 +20,7 @@ f();
 --EXPECTF--
 *** Testing compact() : usage variations  - variables outside of current scope ***
 
-Warning: compact(): Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: compact(): Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 array(2) {
   ["b"]=>
   string(3) "f.b"
@@ -28,7 +28,7 @@ array(2) {
   string(3) "f.c"
 }
 
-Warning: compact(): Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: compact(): Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 array(2) {
   ["b"]=>
   string(3) "f.b"

--- a/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
@@ -80,8 +80,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing get_class_methods() : usage variations ***
-Error: 2 - Undefined variable $undefined_var
-Error: 2 - Undefined variable $unset_var
+Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
 
 Arg value 0
 get_class_methods(): Argument #1 ($object_or_class) must be an object or a valid class name, int given

--- a/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_methods_variation_001.phpt
@@ -80,8 +80,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing get_class_methods() : usage variations ***
-Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
-Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $undefined_var (this will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (this will become an error in PHP 9.0)
 
 Arg value 0
 get_class_methods(): Argument #1 ($object_or_class) must be an object or a valid class name, int given

--- a/ext/standard/tests/class_object/get_class_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_variation_001.phpt
@@ -74,9 +74,9 @@ echo "Done";
 --EXPECTF--
 *** Testing get_class() : usage variations ***
 
-Warning: Undefined variable $undefined_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undefined_var (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $unset_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $unset_var (this will become an error in PHP 9.0) in %s on line %d
 
 Arg value: 0 (type: integer)
 get_class(): Argument #1 ($object) must be of type object, int given

--- a/ext/standard/tests/class_object/get_class_variation_001.phpt
+++ b/ext/standard/tests/class_object/get_class_variation_001.phpt
@@ -74,9 +74,9 @@ echo "Done";
 --EXPECTF--
 *** Testing get_class() : usage variations ***
 
-Warning: Undefined variable $undefined_var in %s on line %d
+Warning: Undefined variable $undefined_var (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $unset_var in %s on line %d
+Warning: Undefined variable $unset_var (This will become an error in PHP 9.0) in %s on line %d
 
 Arg value: 0 (type: integer)
 get_class(): Argument #1 ($object) must be of type object, int given

--- a/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
+++ b/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
@@ -83,8 +83,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing get_parent_class() : usage variations ***
-Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
-Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $undefined_var (this will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (this will become an error in PHP 9.0)
 
 Arg value 0
 get_parent_class(): Argument #1 ($object_or_class) must be an object or a valid class name, int given

--- a/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
+++ b/ext/standard/tests/class_object/get_parent_class_variation_002.phpt
@@ -83,8 +83,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing get_parent_class() : usage variations ***
-Error: 2 - Undefined variable $undefined_var
-Error: 2 - Undefined variable $unset_var
+Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
 
 Arg value 0
 get_parent_class(): Argument #1 ($object_or_class) must be an object or a valid class name, int given

--- a/ext/standard/tests/class_object/is_a_variation_001.phpt
+++ b/ext/standard/tests/class_object/is_a_variation_001.phpt
@@ -72,9 +72,9 @@ echo "Done";
 --EXPECTF--
 *** Testing is_a() : usage variations ***
 
-Warning: Undefined variable $undefined_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undefined_var (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $unset_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $unset_var (this will become an error in PHP 9.0) in %s on line %d
 
 Arg value 0 
 bool(false)

--- a/ext/standard/tests/class_object/is_a_variation_001.phpt
+++ b/ext/standard/tests/class_object/is_a_variation_001.phpt
@@ -72,9 +72,9 @@ echo "Done";
 --EXPECTF--
 *** Testing is_a() : usage variations ***
 
-Warning: Undefined variable $undefined_var in %s on line %d
+Warning: Undefined variable $undefined_var (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $unset_var in %s on line %d
+Warning: Undefined variable $unset_var (This will become an error in PHP 9.0) in %s on line %d
 
 Arg value 0 
 bool(false)

--- a/ext/standard/tests/class_object/is_subclass_of_variation_001.phpt
+++ b/ext/standard/tests/class_object/is_subclass_of_variation_001.phpt
@@ -81,8 +81,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing is_subclass_of() : usage variations ***
-Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
-Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $undefined_var (this will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (this will become an error in PHP 9.0)
 
 Arg value 0 
 bool(false)

--- a/ext/standard/tests/class_object/is_subclass_of_variation_001.phpt
+++ b/ext/standard/tests/class_object/is_subclass_of_variation_001.phpt
@@ -81,8 +81,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing is_subclass_of() : usage variations ***
-Error: 2 - Undefined variable $undefined_var
-Error: 2 - Undefined variable $unset_var
+Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
 
 Arg value 0 
 bool(false)

--- a/ext/standard/tests/class_object/is_subclass_of_variation_004.phpt
+++ b/ext/standard/tests/class_object/is_subclass_of_variation_004.phpt
@@ -81,8 +81,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing is_subclass_of() : usage variations ***
-Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
-Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $undefined_var (this will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (this will become an error in PHP 9.0)
 
 Arg value 0 
 bool(false)

--- a/ext/standard/tests/class_object/is_subclass_of_variation_004.phpt
+++ b/ext/standard/tests/class_object/is_subclass_of_variation_004.phpt
@@ -81,8 +81,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing is_subclass_of() : usage variations ***
-Error: 2 - Undefined variable $undefined_var
-Error: 2 - Undefined variable $unset_var
+Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
 
 Arg value 0 
 bool(false)

--- a/ext/standard/tests/class_object/method_exists_variation_001.phpt
+++ b/ext/standard/tests/class_object/method_exists_variation_001.phpt
@@ -83,8 +83,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing method_exists() : usage variations ***
-Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
-Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $undefined_var (this will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (this will become an error in PHP 9.0)
 
 Arg value 0 
 method_exists(): Argument #1 ($object_or_class) must be of type object|string, int given

--- a/ext/standard/tests/class_object/method_exists_variation_001.phpt
+++ b/ext/standard/tests/class_object/method_exists_variation_001.phpt
@@ -83,8 +83,8 @@ echo "Done";
 ?>
 --EXPECT--
 *** Testing method_exists() : usage variations ***
-Error: 2 - Undefined variable $undefined_var
-Error: 2 - Undefined variable $unset_var
+Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
 
 Arg value 0 
 method_exists(): Argument #1 ($object_or_class) must be of type object|string, int given

--- a/ext/standard/tests/file/005_variation2.phpt
+++ b/ext/standard/tests/file/005_variation2.phpt
@@ -55,7 +55,7 @@ echo "Done";
 
 *** testing touch ***
 
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)

--- a/ext/standard/tests/file/005_variation2.phpt
+++ b/ext/standard/tests/file/005_variation2.phpt
@@ -55,7 +55,7 @@ echo "Done";
 
 *** testing touch ***
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 NULL
 bool(false)
 bool(false)

--- a/ext/standard/tests/general_functions/bug32647.phpt
+++ b/ext/standard/tests/general_functions/bug32647.phpt
@@ -72,10 +72,10 @@ register_shutdown_function(array($obj,'barfoo'));
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $obj in %s on line %d
+Warning: Undefined variable $obj (This will become an error in PHP 9.0) in %s on line %d
 register_shutdown_function(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object
 
-Warning: Undefined variable $obj in %s on line %d
+Warning: Undefined variable $obj (This will become an error in PHP 9.0) in %s on line %d
 register_shutdown_function(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object
 register_shutdown_function(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object
 register_shutdown_function(): Argument #1 ($callback) must be a valid callback, class bar does not have a method "foo"

--- a/ext/standard/tests/general_functions/bug32647.phpt
+++ b/ext/standard/tests/general_functions/bug32647.phpt
@@ -72,10 +72,10 @@ register_shutdown_function(array($obj,'barfoo'));
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $obj (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $obj (this will become an error in PHP 9.0) in %s on line %d
 register_shutdown_function(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object
 
-Warning: Undefined variable $obj (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $obj (this will become an error in PHP 9.0) in %s on line %d
 register_shutdown_function(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object
 register_shutdown_function(): Argument #1 ($callback) must be a valid callback, first array member is not a valid class name or object
 register_shutdown_function(): Argument #1 ($callback) must be a valid callback, class bar does not have a method "foo"

--- a/ext/standard/tests/general_functions/bug60723.phpt
+++ b/ext/standard/tests/general_functions/bug60723.phpt
@@ -14,6 +14,6 @@ readfile($log);
 unlink($log);
 ?>
 --EXPECTF--
-Warning: Undefined variable $aa (This will become an error in PHP 9.0) in %s on line %d
-[%s ASIA/Chongqing] PHP Warning:  Undefined variable $aa (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $aa (this will become an error in PHP 9.0) in %s on line %d
+[%s ASIA/Chongqing] PHP Warning:  Undefined variable $aa (this will become an error in PHP 9.0) in %s on line %d
 [%s ASIA/Chongqing] dummy

--- a/ext/standard/tests/general_functions/bug60723.phpt
+++ b/ext/standard/tests/general_functions/bug60723.phpt
@@ -14,6 +14,6 @@ readfile($log);
 unlink($log);
 ?>
 --EXPECTF--
-Warning: Undefined variable $aa in %s on line %d
-[%s ASIA/Chongqing] PHP Warning:  Undefined variable $aa in %s on line %d
+Warning: Undefined variable $aa (This will become an error in PHP 9.0) in %s on line %d
+[%s ASIA/Chongqing] PHP Warning:  Undefined variable $aa (This will become an error in PHP 9.0) in %s on line %d
 [%s ASIA/Chongqing] dummy

--- a/ext/standard/tests/general_functions/debug_zval_dump_v.phpt
+++ b/ext/standard/tests/general_functions/debug_zval_dump_v.phpt
@@ -142,7 +142,7 @@ int(10)
 
 -- Value of $ref_first_var --
 
-Warning: Undefined variable $ref_first_var (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $ref_first_var (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
 -- Value of $first_var --
@@ -161,7 +161,7 @@ int(10)
 
 -- Value of $var_3: (after unsetting var_3) --
 
-Warning: Undefined variable $var_3 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $var_3 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
 -- Value of $var_2: --
@@ -172,7 +172,7 @@ int(10)
 
 -- Value of $var_1: (after unsetting variable_1) --
 
-Warning: Undefined variable $var_1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $var_1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
 -- Value of $var_2: --

--- a/ext/standard/tests/general_functions/debug_zval_dump_v.phpt
+++ b/ext/standard/tests/general_functions/debug_zval_dump_v.phpt
@@ -142,7 +142,7 @@ int(10)
 
 -- Value of $ref_first_var --
 
-Warning: Undefined variable $ref_first_var in %s on line %d
+Warning: Undefined variable $ref_first_var (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
 -- Value of $first_var --
@@ -161,7 +161,7 @@ int(10)
 
 -- Value of $var_3: (after unsetting var_3) --
 
-Warning: Undefined variable $var_3 in %s on line %d
+Warning: Undefined variable $var_3 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
 -- Value of $var_2: --
@@ -172,7 +172,7 @@ int(10)
 
 -- Value of $var_1: (after unsetting variable_1) --
 
-Warning: Undefined variable $var_1 in %s on line %d
+Warning: Undefined variable $var_1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
 -- Value of $var_2: --

--- a/ext/standard/tests/general_functions/error_clear_last.phpt
+++ b/ext/standard/tests/general_functions/error_clear_last.phpt
@@ -22,7 +22,7 @@ array(4) {
   ["type"]=>
   int(2)
   ["message"]=>
-  string(60) "Undefined variable $b (This will become an error in PHP 9.0)"
+  string(60) "Undefined variable $b (this will become an error in PHP 9.0)"
   ["file"]=>
   string(%d) "%s"
   ["line"]=>

--- a/ext/standard/tests/general_functions/error_clear_last.phpt
+++ b/ext/standard/tests/general_functions/error_clear_last.phpt
@@ -22,7 +22,7 @@ array(4) {
   ["type"]=>
   int(2)
   ["message"]=>
-  string(21) "Undefined variable $b"
+  string(60) "Undefined variable $b (This will become an error in PHP 9.0)"
   ["file"]=>
   string(%d) "%s"
   ["line"]=>

--- a/ext/standard/tests/general_functions/error_get_last.phpt
+++ b/ext/standard/tests/general_functions/error_get_last.phpt
@@ -22,12 +22,12 @@ NULL
 error_get_last() expects exactly 0 arguments, 1 given
 NULL
 
-Warning: Undefined variable $b in %s on line %d
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
 array(4) {
   ["type"]=>
   int(2)
   ["message"]=>
-  string(21) "Undefined variable $b"
+  string(60) "Undefined variable $b (This will become an error in PHP 9.0)"
   ["file"]=>
   string(%d) "%s"
   ["line"]=>

--- a/ext/standard/tests/general_functions/error_get_last.phpt
+++ b/ext/standard/tests/general_functions/error_get_last.phpt
@@ -27,7 +27,7 @@ array(4) {
   ["type"]=>
   int(2)
   ["message"]=>
-  string(60) "Undefined variable $b (This will become an error in PHP 9.0)"
+  string(60) "Undefined variable $b (this will become an error in PHP 9.0)"
   ["file"]=>
   string(%d) "%s"
   ["line"]=>

--- a/ext/standard/tests/general_functions/error_get_last.phpt
+++ b/ext/standard/tests/general_functions/error_get_last.phpt
@@ -22,7 +22,7 @@ NULL
 error_get_last() expects exactly 0 arguments, 1 given
 NULL
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line %d
 array(4) {
   ["type"]=>
   int(2)

--- a/ext/standard/tests/image/getimagesize_variation2.phpt
+++ b/ext/standard/tests/image/getimagesize_variation2.phpt
@@ -74,8 +74,8 @@ foreach($values as $key => $value) {
 ?>
 --EXPECT--
 *** Testing getimagesize() : usage variations ***
-Error: 2 - Undefined variable $undefined_var
-Error: 2 - Undefined variable $unset_var
+Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
 
 -- Arg value 0 --
 string(28) "4a46494600010201006000600000"

--- a/ext/standard/tests/image/getimagesize_variation2.phpt
+++ b/ext/standard/tests/image/getimagesize_variation2.phpt
@@ -74,8 +74,8 @@ foreach($values as $key => $value) {
 ?>
 --EXPECT--
 *** Testing getimagesize() : usage variations ***
-Error: 2 - Undefined variable $undefined_var (This will become an error in PHP 9.0)
-Error: 2 - Undefined variable $unset_var (This will become an error in PHP 9.0)
+Error: 2 - Undefined variable $undefined_var (this will become an error in PHP 9.0)
+Error: 2 - Undefined variable $unset_var (this will become an error in PHP 9.0)
 
 -- Arg value 0 --
 string(28) "4a46494600010201006000600000"

--- a/ext/standard/tests/serialize/serialization_objects_002.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_002.phpt
@@ -71,9 +71,9 @@ echo "\nDone";
 --EXPECTF--
 --- Testing Variations in objects ---
 
-Warning: Undefined variable $file_handle (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $file_handle (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $file_handle (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $file_handle (this will become an error in PHP 9.0) in %s on line %d
 After Serialization => string(493) "O:1:"C":8:{s:1:"a";i:10;s:1:"b";s:6:"string";s:1:"c";b:1;s:1:"d";d:-2.344440000000000079438677857979200780391693115234375;s:1:"e";a:7:{i:0;i:1;i:1;d:2.220000000000000195399252334027551114559173583984375;i:2;s:6:"string";i:3;b:1;i:4;a:0:{}i:5;O:7:"members":3:{s:20:"%0members%0var_private";i:10;s:16:"%0*%0var_protected";s:6:"string";s:10:"var_public";a:3:{i:0;d:-100.1230000000000046611603465862572193145751953125;i:1;s:6:"string";i:2;b:1;}}i:6;N;}s:1:"f";O:9:"nomembers":0:{}s:1:"g";N;s:1:"h";N;}"
 After Unserialization => object(C)#%d (8) {
   ["a"]=>

--- a/ext/standard/tests/serialize/serialization_objects_002.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_002.phpt
@@ -71,9 +71,9 @@ echo "\nDone";
 --EXPECTF--
 --- Testing Variations in objects ---
 
-Warning: Undefined variable $file_handle in %s on line %d
+Warning: Undefined variable $file_handle (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $file_handle in %s on line %d
+Warning: Undefined variable $file_handle (This will become an error in PHP 9.0) in %s on line %d
 After Serialization => string(493) "O:1:"C":8:{s:1:"a";i:10;s:1:"b";s:6:"string";s:1:"c";b:1;s:1:"d";d:-2.344440000000000079438677857979200780391693115234375;s:1:"e";a:7:{i:0;i:1;i:1;d:2.220000000000000195399252334027551114559173583984375;i:2;s:6:"string";i:3;b:1;i:4;a:0:{}i:5;O:7:"members":3:{s:20:"%0members%0var_private";i:10;s:16:"%0*%0var_protected";s:6:"string";s:10:"var_public";a:3:{i:0;d:-100.1230000000000046611603465862572193145751953125;i:1;s:6:"string";i:2;b:1;}}i:6;N;}s:1:"f";O:9:"nomembers":0:{}s:1:"g";N;s:1:"h";N;}"
 After Unserialization => object(C)#%d (8) {
   ["a"]=>

--- a/ext/standard/tests/strings/crc32_variation3.phpt
+++ b/ext/standard/tests/strings/crc32_variation3.phpt
@@ -71,9 +71,9 @@ echo "Done";
 --EXPECTF--
 *** Testing crc32() : with different strings in double quotes ***
 
-Warning: Undefined variable $hello (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $hello (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $world (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $world (this will become an error in PHP 9.0) in %s on line %d
 
 -- Iteration 1 --
 int(0)

--- a/ext/standard/tests/strings/crc32_variation3.phpt
+++ b/ext/standard/tests/strings/crc32_variation3.phpt
@@ -71,9 +71,9 @@ echo "Done";
 --EXPECTF--
 *** Testing crc32() : with different strings in double quotes ***
 
-Warning: Undefined variable $hello in %s on line %d
+Warning: Undefined variable $hello (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $world in %s on line %d
+Warning: Undefined variable $world (This will become an error in PHP 9.0) in %s on line %d
 
 -- Iteration 1 --
 int(0)

--- a/ext/standard/tests/strings/lcfirst.phpt
+++ b/ext/standard/tests/strings/lcfirst.phpt
@@ -189,7 +189,7 @@ string(0) ""
 string(5) "world"
 string(7) "world'S"
 
-Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $strS (this will become an error in PHP 9.0) in %s on line %d
 string(0) ""
 string(6) "worldS"
 string(6) "worldS"

--- a/ext/standard/tests/strings/lcfirst.phpt
+++ b/ext/standard/tests/strings/lcfirst.phpt
@@ -189,7 +189,7 @@ string(0) ""
 string(5) "world"
 string(7) "world'S"
 
-Warning: Undefined variable $strS in %s on line %d
+Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
 string(0) ""
 string(6) "worldS"
 string(6) "worldS"

--- a/ext/standard/tests/strings/str_replace_variation3.phpt
+++ b/ext/standard/tests/strings/str_replace_variation3.phpt
@@ -220,7 +220,7 @@ int(0)
 string(5) "FOUND"
 string(5) "FOUND"
 
-Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $strS (this will become an error in PHP 9.0) in %s on line %d
 string(0) ""
 string(5) "FOUND"
 string(5) "FOUND"

--- a/ext/standard/tests/strings/str_replace_variation3.phpt
+++ b/ext/standard/tests/strings/str_replace_variation3.phpt
@@ -220,7 +220,7 @@ int(0)
 string(5) "FOUND"
 string(5) "FOUND"
 
-Warning: Undefined variable $strS in %s on line %d
+Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
 string(0) ""
 string(5) "FOUND"
 string(5) "FOUND"

--- a/ext/standard/tests/strings/str_word_count1.phpt
+++ b/ext/standard/tests/strings/str_word_count1.phpt
@@ -23,8 +23,8 @@ var_dump($a);
 int(0)
 str_word_count(): Argument #2 ($format) must be a valid format value
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 str_word_count(): Argument #2 ($format) must be a valid format value
 
-Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $a (this will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/ext/standard/tests/strings/str_word_count1.phpt
+++ b/ext/standard/tests/strings/str_word_count1.phpt
@@ -23,8 +23,8 @@ var_dump($a);
 int(0)
 str_word_count(): Argument #2 ($format) must be a valid format value
 
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 str_word_count(): Argument #2 ($format) must be a valid format value
 
-Warning: Undefined variable $a in %s on line %d
+Warning: Undefined variable $a (This will become an error in PHP 9.0) in %s on line %d
 NULL

--- a/ext/standard/tests/strings/strcasecmp.phpt
+++ b/ext/standard/tests/strings/strcasecmp.phpt
@@ -120,44 +120,44 @@ Array
 (
     [0] => a
     [1] => A
-    [2] => €
-    [3] => ÿ
+    [2] => ï¿½
+    [3] => ï¿½
     [4] => %0
 )
 
 Iteration 0
 - strcasecmp of 'a' and 'a' is => int(0)
 - strcasecmp of 'a' and 'A' is => int(0)
-- strcasecmp of 'a' and '€' is => int(-%d)
-- strcasecmp of 'a' and 'ÿ' is => int(-%d)
+- strcasecmp of 'a' and 'ï¿½' is => int(-%d)
+- strcasecmp of 'a' and 'ï¿½' is => int(-%d)
 - strcasecmp of 'a' and '%0' is => int(%d)
 
 Iteration 1
 - strcasecmp of 'A' and 'a' is => int(0)
 - strcasecmp of 'A' and 'A' is => int(0)
-- strcasecmp of 'A' and '€' is => int(-%d)
-- strcasecmp of 'A' and 'ÿ' is => int(-%d)
+- strcasecmp of 'A' and 'ï¿½' is => int(-%d)
+- strcasecmp of 'A' and 'ï¿½' is => int(-%d)
 - strcasecmp of 'A' and '%0' is => int(%d)
 
 Iteration 2
-- strcasecmp of '€' and 'a' is => int(%d)
-- strcasecmp of '€' and 'A' is => int(%d)
-- strcasecmp of '€' and '€' is => int(0)
-- strcasecmp of '€' and 'ÿ' is => int(-%d)
-- strcasecmp of '€' and '%0' is => int(%d)
+- strcasecmp of 'ï¿½' and 'a' is => int(%d)
+- strcasecmp of 'ï¿½' and 'A' is => int(%d)
+- strcasecmp of 'ï¿½' and 'ï¿½' is => int(0)
+- strcasecmp of 'ï¿½' and 'ï¿½' is => int(-%d)
+- strcasecmp of 'ï¿½' and '%0' is => int(%d)
 
 Iteration 3
-- strcasecmp of 'ÿ' and 'a' is => int(%d)
-- strcasecmp of 'ÿ' and 'A' is => int(%d)
-- strcasecmp of 'ÿ' and '€' is => int(%d)
-- strcasecmp of 'ÿ' and 'ÿ' is => int(0)
-- strcasecmp of 'ÿ' and '%0' is => int(%d)
+- strcasecmp of 'ï¿½' and 'a' is => int(%d)
+- strcasecmp of 'ï¿½' and 'A' is => int(%d)
+- strcasecmp of 'ï¿½' and 'ï¿½' is => int(%d)
+- strcasecmp of 'ï¿½' and 'ï¿½' is => int(0)
+- strcasecmp of 'ï¿½' and '%0' is => int(%d)
 
 Iteration 4
 - strcasecmp of '%0' and 'a' is => int(-%d)
 - strcasecmp of '%0' and 'A' is => int(-%d)
-- strcasecmp of '%0' and '€' is => int(-%d)
-- strcasecmp of '%0' and 'ÿ' is => int(-%d)
+- strcasecmp of '%0' and 'ï¿½' is => int(-%d)
+- strcasecmp of '%0' and 'ï¿½' is => int(-%d)
 - strcasecmp of '%0' and '%0' is => int(0)
 
 *** comparing the strings in an 
@@ -542,7 +542,7 @@ int(-%d)
 int(-%d)
 int(-%d)
 
-Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $strS (this will become an error in PHP 9.0) in %s on line %d
 int(%d)
 int(-%d)
 int(-%d)

--- a/ext/standard/tests/strings/strcasecmp.phpt
+++ b/ext/standard/tests/strings/strcasecmp.phpt
@@ -120,44 +120,44 @@ Array
 (
     [0] => a
     [1] => A
-    [2] => ï¿½
-    [3] => ï¿½
+    [2] => €
+    [3] => ÿ
     [4] => %0
 )
 
 Iteration 0
 - strcasecmp of 'a' and 'a' is => int(0)
 - strcasecmp of 'a' and 'A' is => int(0)
-- strcasecmp of 'a' and 'ï¿½' is => int(-%d)
-- strcasecmp of 'a' and 'ï¿½' is => int(-%d)
+- strcasecmp of 'a' and '€' is => int(-%d)
+- strcasecmp of 'a' and 'ÿ' is => int(-%d)
 - strcasecmp of 'a' and '%0' is => int(%d)
 
 Iteration 1
 - strcasecmp of 'A' and 'a' is => int(0)
 - strcasecmp of 'A' and 'A' is => int(0)
-- strcasecmp of 'A' and 'ï¿½' is => int(-%d)
-- strcasecmp of 'A' and 'ï¿½' is => int(-%d)
+- strcasecmp of 'A' and '€' is => int(-%d)
+- strcasecmp of 'A' and 'ÿ' is => int(-%d)
 - strcasecmp of 'A' and '%0' is => int(%d)
 
 Iteration 2
-- strcasecmp of 'ï¿½' and 'a' is => int(%d)
-- strcasecmp of 'ï¿½' and 'A' is => int(%d)
-- strcasecmp of 'ï¿½' and 'ï¿½' is => int(0)
-- strcasecmp of 'ï¿½' and 'ï¿½' is => int(-%d)
-- strcasecmp of 'ï¿½' and '%0' is => int(%d)
+- strcasecmp of '€' and 'a' is => int(%d)
+- strcasecmp of '€' and 'A' is => int(%d)
+- strcasecmp of '€' and '€' is => int(0)
+- strcasecmp of '€' and 'ÿ' is => int(-%d)
+- strcasecmp of '€' and '%0' is => int(%d)
 
 Iteration 3
-- strcasecmp of 'ï¿½' and 'a' is => int(%d)
-- strcasecmp of 'ï¿½' and 'A' is => int(%d)
-- strcasecmp of 'ï¿½' and 'ï¿½' is => int(%d)
-- strcasecmp of 'ï¿½' and 'ï¿½' is => int(0)
-- strcasecmp of 'ï¿½' and '%0' is => int(%d)
+- strcasecmp of 'ÿ' and 'a' is => int(%d)
+- strcasecmp of 'ÿ' and 'A' is => int(%d)
+- strcasecmp of 'ÿ' and '€' is => int(%d)
+- strcasecmp of 'ÿ' and 'ÿ' is => int(0)
+- strcasecmp of 'ÿ' and '%0' is => int(%d)
 
 Iteration 4
 - strcasecmp of '%0' and 'a' is => int(-%d)
 - strcasecmp of '%0' and 'A' is => int(-%d)
-- strcasecmp of '%0' and 'ï¿½' is => int(-%d)
-- strcasecmp of '%0' and 'ï¿½' is => int(-%d)
+- strcasecmp of '%0' and '€' is => int(-%d)
+- strcasecmp of '%0' and 'ÿ' is => int(-%d)
 - strcasecmp of '%0' and '%0' is => int(0)
 
 *** comparing the strings in an 

--- a/ext/standard/tests/strings/strcasecmp.phpt
+++ b/ext/standard/tests/strings/strcasecmp.phpt
@@ -120,44 +120,44 @@ Array
 (
     [0] => a
     [1] => A
-    [2] => €
-    [3] => ÿ
+    [2] => ï¿½
+    [3] => ï¿½
     [4] => %0
 )
 
 Iteration 0
 - strcasecmp of 'a' and 'a' is => int(0)
 - strcasecmp of 'a' and 'A' is => int(0)
-- strcasecmp of 'a' and '€' is => int(-%d)
-- strcasecmp of 'a' and 'ÿ' is => int(-%d)
+- strcasecmp of 'a' and 'ï¿½' is => int(-%d)
+- strcasecmp of 'a' and 'ï¿½' is => int(-%d)
 - strcasecmp of 'a' and '%0' is => int(%d)
 
 Iteration 1
 - strcasecmp of 'A' and 'a' is => int(0)
 - strcasecmp of 'A' and 'A' is => int(0)
-- strcasecmp of 'A' and '€' is => int(-%d)
-- strcasecmp of 'A' and 'ÿ' is => int(-%d)
+- strcasecmp of 'A' and 'ï¿½' is => int(-%d)
+- strcasecmp of 'A' and 'ï¿½' is => int(-%d)
 - strcasecmp of 'A' and '%0' is => int(%d)
 
 Iteration 2
-- strcasecmp of '€' and 'a' is => int(%d)
-- strcasecmp of '€' and 'A' is => int(%d)
-- strcasecmp of '€' and '€' is => int(0)
-- strcasecmp of '€' and 'ÿ' is => int(-%d)
-- strcasecmp of '€' and '%0' is => int(%d)
+- strcasecmp of 'ï¿½' and 'a' is => int(%d)
+- strcasecmp of 'ï¿½' and 'A' is => int(%d)
+- strcasecmp of 'ï¿½' and 'ï¿½' is => int(0)
+- strcasecmp of 'ï¿½' and 'ï¿½' is => int(-%d)
+- strcasecmp of 'ï¿½' and '%0' is => int(%d)
 
 Iteration 3
-- strcasecmp of 'ÿ' and 'a' is => int(%d)
-- strcasecmp of 'ÿ' and 'A' is => int(%d)
-- strcasecmp of 'ÿ' and '€' is => int(%d)
-- strcasecmp of 'ÿ' and 'ÿ' is => int(0)
-- strcasecmp of 'ÿ' and '%0' is => int(%d)
+- strcasecmp of 'ï¿½' and 'a' is => int(%d)
+- strcasecmp of 'ï¿½' and 'A' is => int(%d)
+- strcasecmp of 'ï¿½' and 'ï¿½' is => int(%d)
+- strcasecmp of 'ï¿½' and 'ï¿½' is => int(0)
+- strcasecmp of 'ï¿½' and '%0' is => int(%d)
 
 Iteration 4
 - strcasecmp of '%0' and 'a' is => int(-%d)
 - strcasecmp of '%0' and 'A' is => int(-%d)
-- strcasecmp of '%0' and '€' is => int(-%d)
-- strcasecmp of '%0' and 'ÿ' is => int(-%d)
+- strcasecmp of '%0' and 'ï¿½' is => int(-%d)
+- strcasecmp of '%0' and 'ï¿½' is => int(-%d)
 - strcasecmp of '%0' and '%0' is => int(0)
 
 *** comparing the strings in an 
@@ -542,7 +542,7 @@ int(-%d)
 int(-%d)
 int(-%d)
 
-Warning: Undefined variable $strS in %s on line %d
+Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
 int(%d)
 int(-%d)
 int(-%d)

--- a/ext/standard/tests/strings/strcmp.phpt
+++ b/ext/standard/tests/strings/strcmp.phpt
@@ -122,8 +122,8 @@ Array
     [1] => A
     [2] => a
     [3] => A
-    [4] => €
-    [5] => ÿ
+    [4] => ï¿½
+    [5] => ï¿½
     [6] => %0
 )
 
@@ -132,8 +132,8 @@ Iteration 0
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and '€' is => int(-%d)
-- strcmp of 'a' and 'ÿ' is => int(-%d)
+- strcmp of 'a' and 'ï¿½' is => int(-%d)
+- strcmp of 'a' and 'ï¿½' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 1
@@ -141,8 +141,8 @@ Iteration 1
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and '€' is => int(-%d)
-- strcmp of 'A' and 'ÿ' is => int(-%d)
+- strcmp of 'A' and 'ï¿½' is => int(-%d)
+- strcmp of 'A' and 'ï¿½' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 2
@@ -150,8 +150,8 @@ Iteration 2
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and '€' is => int(-%d)
-- strcmp of 'a' and 'ÿ' is => int(-%d)
+- strcmp of 'a' and 'ï¿½' is => int(-%d)
+- strcmp of 'a' and 'ï¿½' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 3
@@ -159,35 +159,35 @@ Iteration 3
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and '€' is => int(-%d)
-- strcmp of 'A' and 'ÿ' is => int(-%d)
+- strcmp of 'A' and 'ï¿½' is => int(-%d)
+- strcmp of 'A' and 'ï¿½' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 4
-- strcmp of '€' and 'a' is => int(%d)
-- strcmp of '€' and 'A' is => int(%d)
-- strcmp of '€' and 'a' is => int(%d)
-- strcmp of '€' and 'A' is => int(%d)
-- strcmp of '€' and '€' is => int(0)
-- strcmp of '€' and 'ÿ' is => int(-%d)
-- strcmp of '€' and '%0' is => int(%d)
+- strcmp of 'ï¿½' and 'a' is => int(%d)
+- strcmp of 'ï¿½' and 'A' is => int(%d)
+- strcmp of 'ï¿½' and 'a' is => int(%d)
+- strcmp of 'ï¿½' and 'A' is => int(%d)
+- strcmp of 'ï¿½' and 'ï¿½' is => int(0)
+- strcmp of 'ï¿½' and 'ï¿½' is => int(-%d)
+- strcmp of 'ï¿½' and '%0' is => int(%d)
 
 Iteration 5
-- strcmp of 'ÿ' and 'a' is => int(%d)
-- strcmp of 'ÿ' and 'A' is => int(%d)
-- strcmp of 'ÿ' and 'a' is => int(%d)
-- strcmp of 'ÿ' and 'A' is => int(%d)
-- strcmp of 'ÿ' and '€' is => int(%d)
-- strcmp of 'ÿ' and 'ÿ' is => int(0)
-- strcmp of 'ÿ' and '%0' is => int(%d)
+- strcmp of 'ï¿½' and 'a' is => int(%d)
+- strcmp of 'ï¿½' and 'A' is => int(%d)
+- strcmp of 'ï¿½' and 'a' is => int(%d)
+- strcmp of 'ï¿½' and 'A' is => int(%d)
+- strcmp of 'ï¿½' and 'ï¿½' is => int(%d)
+- strcmp of 'ï¿½' and 'ï¿½' is => int(0)
+- strcmp of 'ï¿½' and '%0' is => int(%d)
 
 Iteration 6
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
-- strcmp of '%0' and '€' is => int(-%d)
-- strcmp of '%0' and 'ÿ' is => int(-%d)
+- strcmp of '%0' and 'ï¿½' is => int(-%d)
+- strcmp of '%0' and 'ï¿½' is => int(-%d)
 - strcmp of '%0' and '%0' is => int(0)
 
 *** comparing the strings in an 
@@ -550,7 +550,7 @@ int(-%d)
 int(-%d)
 int(-%d)
 
-Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $strS (this will become an error in PHP 9.0) in %s on line %d
 int(%d)
 int(-%d)
 int(-%d)

--- a/ext/standard/tests/strings/strcmp.phpt
+++ b/ext/standard/tests/strings/strcmp.phpt
@@ -122,8 +122,8 @@ Array
     [1] => A
     [2] => a
     [3] => A
-    [4] => �
-    [5] => �
+    [4] => ?
+    [5] => ?
     [6] => %0
 )
 
@@ -132,8 +132,8 @@ Iteration 0
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and '�' is => int(-%d)
-- strcmp of 'a' and '�' is => int(-%d)
+- strcmp of 'a' and '?' is => int(-%d)
+- strcmp of 'a' and '?' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 1
@@ -141,8 +141,8 @@ Iteration 1
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and '�' is => int(-%d)
-- strcmp of 'A' and '�' is => int(-%d)
+- strcmp of 'A' and '?' is => int(-%d)
+- strcmp of 'A' and '?' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 2
@@ -150,8 +150,8 @@ Iteration 2
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and '�' is => int(-%d)
-- strcmp of 'a' and '�' is => int(-%d)
+- strcmp of 'a' and '?' is => int(-%d)
+- strcmp of 'a' and '?' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 3
@@ -159,35 +159,35 @@ Iteration 3
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and '�' is => int(-%d)
-- strcmp of 'A' and '�' is => int(-%d)
+- strcmp of 'A' and '?' is => int(-%d)
+- strcmp of 'A' and '?' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 4
-- strcmp of '�' and 'a' is => int(%d)
-- strcmp of '�' and 'A' is => int(%d)
-- strcmp of '�' and 'a' is => int(%d)
-- strcmp of '�' and 'A' is => int(%d)
-- strcmp of '�' and '�' is => int(0)
-- strcmp of '�' and '�' is => int(-%d)
-- strcmp of '�' and '%0' is => int(%d)
+- strcmp of '?' and 'a' is => int(%d)
+- strcmp of '?' and 'A' is => int(%d)
+- strcmp of '?' and 'a' is => int(%d)
+- strcmp of '?' and 'A' is => int(%d)
+- strcmp of '?' and '?' is => int(0)
+- strcmp of '?' and '?' is => int(-%d)
+- strcmp of '?' and '%0' is => int(%d)
 
 Iteration 5
-- strcmp of '�' and 'a' is => int(%d)
-- strcmp of '�' and 'A' is => int(%d)
-- strcmp of '�' and 'a' is => int(%d)
-- strcmp of '�' and 'A' is => int(%d)
-- strcmp of '�' and '�' is => int(%d)
-- strcmp of '�' and '�' is => int(0)
-- strcmp of '�' and '%0' is => int(%d)
+- strcmp of '?' and 'a' is => int(%d)
+- strcmp of '?' and 'A' is => int(%d)
+- strcmp of '?' and 'a' is => int(%d)
+- strcmp of '?' and 'A' is => int(%d)
+- strcmp of '?' and '?' is => int(%d)
+- strcmp of '?' and '?' is => int(0)
+- strcmp of '?' and '%0' is => int(%d)
 
 Iteration 6
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
-- strcmp of '%0' and '�' is => int(-%d)
-- strcmp of '%0' and '�' is => int(-%d)
+- strcmp of '%0' and '?' is => int(-%d)
+- strcmp of '%0' and '?' is => int(-%d)
 - strcmp of '%0' and '%0' is => int(0)
 
 *** comparing the strings in an 

--- a/ext/standard/tests/strings/strcmp.phpt
+++ b/ext/standard/tests/strings/strcmp.phpt
@@ -122,8 +122,8 @@ Array
     [1] => A
     [2] => a
     [3] => A
-    [4] => ï¿½
-    [5] => ï¿½
+    [4] => €
+    [5] => ÿ
     [6] => %0
 )
 
@@ -132,8 +132,8 @@ Iteration 0
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and 'ï¿½' is => int(-%d)
-- strcmp of 'a' and 'ï¿½' is => int(-%d)
+- strcmp of 'a' and '€' is => int(-%d)
+- strcmp of 'a' and 'ÿ' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 1
@@ -141,8 +141,8 @@ Iteration 1
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and 'ï¿½' is => int(-%d)
-- strcmp of 'A' and 'ï¿½' is => int(-%d)
+- strcmp of 'A' and '€' is => int(-%d)
+- strcmp of 'A' and 'ÿ' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 2
@@ -150,8 +150,8 @@ Iteration 2
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and 'ï¿½' is => int(-%d)
-- strcmp of 'a' and 'ï¿½' is => int(-%d)
+- strcmp of 'a' and '€' is => int(-%d)
+- strcmp of 'a' and 'ÿ' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 3
@@ -159,35 +159,35 @@ Iteration 3
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and 'ï¿½' is => int(-%d)
-- strcmp of 'A' and 'ï¿½' is => int(-%d)
+- strcmp of 'A' and '€' is => int(-%d)
+- strcmp of 'A' and 'ÿ' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 4
-- strcmp of 'ï¿½' and 'a' is => int(%d)
-- strcmp of 'ï¿½' and 'A' is => int(%d)
-- strcmp of 'ï¿½' and 'a' is => int(%d)
-- strcmp of 'ï¿½' and 'A' is => int(%d)
-- strcmp of 'ï¿½' and 'ï¿½' is => int(0)
-- strcmp of 'ï¿½' and 'ï¿½' is => int(-%d)
-- strcmp of 'ï¿½' and '%0' is => int(%d)
+- strcmp of '€' and 'a' is => int(%d)
+- strcmp of '€' and 'A' is => int(%d)
+- strcmp of '€' and 'a' is => int(%d)
+- strcmp of '€' and 'A' is => int(%d)
+- strcmp of '€' and '€' is => int(0)
+- strcmp of '€' and 'ÿ' is => int(-%d)
+- strcmp of '€' and '%0' is => int(%d)
 
 Iteration 5
-- strcmp of 'ï¿½' and 'a' is => int(%d)
-- strcmp of 'ï¿½' and 'A' is => int(%d)
-- strcmp of 'ï¿½' and 'a' is => int(%d)
-- strcmp of 'ï¿½' and 'A' is => int(%d)
-- strcmp of 'ï¿½' and 'ï¿½' is => int(%d)
-- strcmp of 'ï¿½' and 'ï¿½' is => int(0)
-- strcmp of 'ï¿½' and '%0' is => int(%d)
+- strcmp of 'ÿ' and 'a' is => int(%d)
+- strcmp of 'ÿ' and 'A' is => int(%d)
+- strcmp of 'ÿ' and 'a' is => int(%d)
+- strcmp of 'ÿ' and 'A' is => int(%d)
+- strcmp of 'ÿ' and '€' is => int(%d)
+- strcmp of 'ÿ' and 'ÿ' is => int(0)
+- strcmp of 'ÿ' and '%0' is => int(%d)
 
 Iteration 6
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
-- strcmp of '%0' and 'ï¿½' is => int(-%d)
-- strcmp of '%0' and 'ï¿½' is => int(-%d)
+- strcmp of '%0' and '€' is => int(-%d)
+- strcmp of '%0' and 'ÿ' is => int(-%d)
 - strcmp of '%0' and '%0' is => int(0)
 
 *** comparing the strings in an 

--- a/ext/standard/tests/strings/strcmp.phpt
+++ b/ext/standard/tests/strings/strcmp.phpt
@@ -122,8 +122,8 @@ Array
     [1] => A
     [2] => a
     [3] => A
-    [4] => ?
-    [5] => ?
+    [4] => €
+    [5] => ÿ
     [6] => %0
 )
 
@@ -132,8 +132,8 @@ Iteration 0
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and '?' is => int(-%d)
-- strcmp of 'a' and '?' is => int(-%d)
+- strcmp of 'a' and '€' is => int(-%d)
+- strcmp of 'a' and 'ÿ' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 1
@@ -141,8 +141,8 @@ Iteration 1
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and '?' is => int(-%d)
-- strcmp of 'A' and '?' is => int(-%d)
+- strcmp of 'A' and '€' is => int(-%d)
+- strcmp of 'A' and 'ÿ' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 2
@@ -150,8 +150,8 @@ Iteration 2
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and '?' is => int(-%d)
-- strcmp of 'a' and '?' is => int(-%d)
+- strcmp of 'a' and '€' is => int(-%d)
+- strcmp of 'a' and 'ÿ' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 3
@@ -159,35 +159,35 @@ Iteration 3
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and '?' is => int(-%d)
-- strcmp of 'A' and '?' is => int(-%d)
+- strcmp of 'A' and '€' is => int(-%d)
+- strcmp of 'A' and 'ÿ' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 4
-- strcmp of '?' and 'a' is => int(%d)
-- strcmp of '?' and 'A' is => int(%d)
-- strcmp of '?' and 'a' is => int(%d)
-- strcmp of '?' and 'A' is => int(%d)
-- strcmp of '?' and '?' is => int(0)
-- strcmp of '?' and '?' is => int(-%d)
-- strcmp of '?' and '%0' is => int(%d)
+- strcmp of '€' and 'a' is => int(%d)
+- strcmp of '€' and 'A' is => int(%d)
+- strcmp of '€' and 'a' is => int(%d)
+- strcmp of '€' and 'A' is => int(%d)
+- strcmp of '€' and '€' is => int(0)
+- strcmp of '€' and 'ÿ' is => int(-%d)
+- strcmp of '€' and '%0' is => int(%d)
 
 Iteration 5
-- strcmp of '?' and 'a' is => int(%d)
-- strcmp of '?' and 'A' is => int(%d)
-- strcmp of '?' and 'a' is => int(%d)
-- strcmp of '?' and 'A' is => int(%d)
-- strcmp of '?' and '?' is => int(%d)
-- strcmp of '?' and '?' is => int(0)
-- strcmp of '?' and '%0' is => int(%d)
+- strcmp of 'ÿ' and 'a' is => int(%d)
+- strcmp of 'ÿ' and 'A' is => int(%d)
+- strcmp of 'ÿ' and 'a' is => int(%d)
+- strcmp of 'ÿ' and 'A' is => int(%d)
+- strcmp of 'ÿ' and '€' is => int(%d)
+- strcmp of 'ÿ' and 'ÿ' is => int(0)
+- strcmp of 'ÿ' and '%0' is => int(%d)
 
 Iteration 6
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
-- strcmp of '%0' and '?' is => int(-%d)
-- strcmp of '%0' and '?' is => int(-%d)
+- strcmp of '%0' and '€' is => int(-%d)
+- strcmp of '%0' and 'ÿ' is => int(-%d)
 - strcmp of '%0' and '%0' is => int(0)
 
 *** comparing the strings in an 

--- a/ext/standard/tests/strings/strcmp.phpt
+++ b/ext/standard/tests/strings/strcmp.phpt
@@ -122,8 +122,8 @@ Array
     [1] => A
     [2] => a
     [3] => A
-    [4] => €
-    [5] => ÿ
+    [4] => ï¿½
+    [5] => ï¿½
     [6] => %0
 )
 
@@ -132,8 +132,8 @@ Iteration 0
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and '€' is => int(-%d)
-- strcmp of 'a' and 'ÿ' is => int(-%d)
+- strcmp of 'a' and 'ï¿½' is => int(-%d)
+- strcmp of 'a' and 'ï¿½' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 1
@@ -141,8 +141,8 @@ Iteration 1
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and '€' is => int(-%d)
-- strcmp of 'A' and 'ÿ' is => int(-%d)
+- strcmp of 'A' and 'ï¿½' is => int(-%d)
+- strcmp of 'A' and 'ï¿½' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 2
@@ -150,8 +150,8 @@ Iteration 2
 - strcmp of 'a' and 'A' is => int(%d)
 - strcmp of 'a' and 'a' is => int(0)
 - strcmp of 'a' and 'A' is => int(%d)
-- strcmp of 'a' and '€' is => int(-%d)
-- strcmp of 'a' and 'ÿ' is => int(-%d)
+- strcmp of 'a' and 'ï¿½' is => int(-%d)
+- strcmp of 'a' and 'ï¿½' is => int(-%d)
 - strcmp of 'a' and '%0' is => int(%d)
 
 Iteration 3
@@ -159,35 +159,35 @@ Iteration 3
 - strcmp of 'A' and 'A' is => int(0)
 - strcmp of 'A' and 'a' is => int(-%d)
 - strcmp of 'A' and 'A' is => int(0)
-- strcmp of 'A' and '€' is => int(-%d)
-- strcmp of 'A' and 'ÿ' is => int(-%d)
+- strcmp of 'A' and 'ï¿½' is => int(-%d)
+- strcmp of 'A' and 'ï¿½' is => int(-%d)
 - strcmp of 'A' and '%0' is => int(%d)
 
 Iteration 4
-- strcmp of '€' and 'a' is => int(%d)
-- strcmp of '€' and 'A' is => int(%d)
-- strcmp of '€' and 'a' is => int(%d)
-- strcmp of '€' and 'A' is => int(%d)
-- strcmp of '€' and '€' is => int(0)
-- strcmp of '€' and 'ÿ' is => int(-%d)
-- strcmp of '€' and '%0' is => int(%d)
+- strcmp of 'ï¿½' and 'a' is => int(%d)
+- strcmp of 'ï¿½' and 'A' is => int(%d)
+- strcmp of 'ï¿½' and 'a' is => int(%d)
+- strcmp of 'ï¿½' and 'A' is => int(%d)
+- strcmp of 'ï¿½' and 'ï¿½' is => int(0)
+- strcmp of 'ï¿½' and 'ï¿½' is => int(-%d)
+- strcmp of 'ï¿½' and '%0' is => int(%d)
 
 Iteration 5
-- strcmp of 'ÿ' and 'a' is => int(%d)
-- strcmp of 'ÿ' and 'A' is => int(%d)
-- strcmp of 'ÿ' and 'a' is => int(%d)
-- strcmp of 'ÿ' and 'A' is => int(%d)
-- strcmp of 'ÿ' and '€' is => int(%d)
-- strcmp of 'ÿ' and 'ÿ' is => int(0)
-- strcmp of 'ÿ' and '%0' is => int(%d)
+- strcmp of 'ï¿½' and 'a' is => int(%d)
+- strcmp of 'ï¿½' and 'A' is => int(%d)
+- strcmp of 'ï¿½' and 'a' is => int(%d)
+- strcmp of 'ï¿½' and 'A' is => int(%d)
+- strcmp of 'ï¿½' and 'ï¿½' is => int(%d)
+- strcmp of 'ï¿½' and 'ï¿½' is => int(0)
+- strcmp of 'ï¿½' and '%0' is => int(%d)
 
 Iteration 6
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
 - strcmp of '%0' and 'a' is => int(-%d)
 - strcmp of '%0' and 'A' is => int(-%d)
-- strcmp of '%0' and '€' is => int(-%d)
-- strcmp of '%0' and 'ÿ' is => int(-%d)
+- strcmp of '%0' and 'ï¿½' is => int(-%d)
+- strcmp of '%0' and 'ï¿½' is => int(-%d)
 - strcmp of '%0' and '%0' is => int(0)
 
 *** comparing the strings in an 
@@ -550,7 +550,7 @@ int(-%d)
 int(-%d)
 int(-%d)
 
-Warning: Undefined variable $strS in %s on line %d
+Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
 int(%d)
 int(-%d)
 int(-%d)

--- a/ext/standard/tests/strings/strlen.phpt
+++ b/ext/standard/tests/strings/strlen.phpt
@@ -181,7 +181,7 @@ int(0)
 int(5)
 int(7)
 
-Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $strS (this will become an error in PHP 9.0) in %s on line %d
 int(0)
 int(6)
 int(6)

--- a/ext/standard/tests/strings/strlen.phpt
+++ b/ext/standard/tests/strings/strlen.phpt
@@ -137,7 +137,7 @@ String length of '' is => int(0)
 String length of ' ' is => int(1)
 String length of '%0' is => int(1)
 String length of '%00' is => int(2)
-String length of 'ï¿½C' is => int(2)
+String length of '«C' is => int(2)
 String length of '%00' is => int(2)
 String length of '0' is => int(1)
 String length of '0' is => int(1)
@@ -155,7 +155,7 @@ String length of 'Hello, World
 String length of 'Hello, World	' is => int(13)
 String length of 'Hello, World\' is => int(13)
 String length of '              ' is => int(14)
-String length of 'ï¿½ï¿½Aï¿½%0' is => int(5)
+String length of '€êAÿ%0' is => int(5)
 String length of 'abcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()_+=|?><-;:$
                    []{}{{{}}}[[[[]][]]]***&&&^^%$###@@!!@#$%&^&**/////|\\\
                    abcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()_+=|?><-;:$

--- a/ext/standard/tests/strings/strlen.phpt
+++ b/ext/standard/tests/strings/strlen.phpt
@@ -150,8 +150,7 @@ String length of 'Hello%0World' is => int(11)
 String length of 'Hello, World\0' is => int(14)
 String length of 'Hello, World
 ' is => int(13)
-String length of 'Hello, World
-' is => int(13)
+String length of 'Hello, World' is => int(13)
 String length of 'Hello, World	' is => int(13)
 String length of 'Hello, World\' is => int(13)
 String length of '              ' is => int(14)

--- a/ext/standard/tests/strings/strlen.phpt
+++ b/ext/standard/tests/strings/strlen.phpt
@@ -137,7 +137,7 @@ String length of '' is => int(0)
 String length of ' ' is => int(1)
 String length of '%0' is => int(1)
 String length of '%00' is => int(2)
-String length of '«C' is => int(2)
+String length of 'ï¿½C' is => int(2)
 String length of '%00' is => int(2)
 String length of '0' is => int(1)
 String length of '0' is => int(1)
@@ -150,11 +150,12 @@ String length of 'Hello%0World' is => int(11)
 String length of 'Hello, World\0' is => int(14)
 String length of 'Hello, World
 ' is => int(13)
-String length of 'Hello, World' is => int(13)
+String length of 'Hello, World
+' is => int(13)
 String length of 'Hello, World	' is => int(13)
 String length of 'Hello, World\' is => int(13)
 String length of '              ' is => int(14)
-String length of '€êAÿ%0' is => int(5)
+String length of 'ï¿½ï¿½Aï¿½%0' is => int(5)
 String length of 'abcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()_+=|?><-;:$
                    []{}{{{}}}[[[[]][]]]***&&&^^%$###@@!!@#$%&^&**/////|\\\
                    abcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*()_+=|?><-;:$
@@ -181,7 +182,7 @@ int(0)
 int(5)
 int(7)
 
-Warning: Undefined variable $strS in %s on line %d
+Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
 int(0)
 int(6)
 int(6)

--- a/ext/standard/tests/strings/strpos.phpt
+++ b/ext/standard/tests/strings/strpos.phpt
@@ -271,7 +271,7 @@ bool(false)
 int(7)
 int(7)
 
-Warning: Undefined variable $needleS in %s on line %d
+Warning: Undefined variable $needleS (This will become an error in PHP 9.0) in %s on line %d
 int(0)
 int(7)
 int(7)

--- a/ext/standard/tests/strings/strpos.phpt
+++ b/ext/standard/tests/strings/strpos.phpt
@@ -271,7 +271,7 @@ bool(false)
 int(7)
 int(7)
 
-Warning: Undefined variable $needleS (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $needleS (this will become an error in PHP 9.0) in %s on line %d
 int(0)
 int(7)
 int(7)

--- a/ext/standard/tests/strings/strstr.phpt
+++ b/ext/standard/tests/strings/strstr.phpt
@@ -338,7 +338,7 @@ bool(false)
 string(5) "world"
 string(7) "world'S"
 
-Warning: Undefined variable $needleS (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $needleS (this will become an error in PHP 9.0) in %s on line %d
 string(13) "Hello, worldS"
 string(6) "worldS"
 string(6) "worldS"

--- a/ext/standard/tests/strings/strstr.phpt
+++ b/ext/standard/tests/strings/strstr.phpt
@@ -338,7 +338,7 @@ bool(false)
 string(5) "world"
 string(7) "world'S"
 
-Warning: Undefined variable $needleS in %s on line %d
+Warning: Undefined variable $needleS (This will become an error in PHP 9.0) in %s on line %d
 string(13) "Hello, worldS"
 string(6) "worldS"
 string(6) "worldS"

--- a/ext/standard/tests/strings/ucfirst.phpt
+++ b/ext/standard/tests/strings/ucfirst.phpt
@@ -157,7 +157,7 @@ string(0) ""
 string(5) "World"
 string(7) "World'S"
 
-Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $strS (this will become an error in PHP 9.0) in %s on line %d
 string(0) ""
 string(6) "WorldS"
 string(6) "WorldS"

--- a/ext/standard/tests/strings/ucfirst.phpt
+++ b/ext/standard/tests/strings/ucfirst.phpt
@@ -157,7 +157,7 @@ string(0) ""
 string(5) "World"
 string(7) "World'S"
 
-Warning: Undefined variable $strS in %s on line %d
+Warning: Undefined variable $strS (This will become an error in PHP 9.0) in %s on line %d
 string(0) ""
 string(6) "WorldS"
 string(6) "WorldS"

--- a/ext/zend_test/tests/observer_error_03.phpt
+++ b/ext/zend_test/tests/observer_error_03.phpt
@@ -31,7 +31,7 @@ echo 'Done.' . PHP_EOL;
     <!-- init foo() -->
     <foo>
 
-Warning: Undefined variable $this_does_not_exit in %s on line %d
+Warning: Undefined variable $this_does_not_exit (This will become an error in PHP 9.0) in %s on line %d
     </foo:NULL>
 After error.
   </main:NULL>

--- a/ext/zend_test/tests/observer_error_03.phpt
+++ b/ext/zend_test/tests/observer_error_03.phpt
@@ -31,7 +31,7 @@ echo 'Done.' . PHP_EOL;
     <!-- init foo() -->
     <foo>
 
-Warning: Undefined variable $this_does_not_exit (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $this_does_not_exit (this will become an error in PHP 9.0) in %s on line %d
     </foo:NULL>
 After error.
   </main:NULL>

--- a/ext/zend_test/tests/observer_retval_05.phpt
+++ b/ext/zend_test/tests/observer_retval_05.phpt
@@ -23,11 +23,11 @@ echo 'Done' . PHP_EOL;
   <!-- init foo() -->
   <foo>
 
-Warning: Undefined variable $i_do_not_exist (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $i_do_not_exist (this will become an error in PHP 9.0) in %s on line %d
   </foo:NULL>
   <foo>
 
-Warning: Undefined variable $i_do_not_exist (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $i_do_not_exist (this will become an error in PHP 9.0) in %s on line %d
   </foo:NULL>
 Done
 </file '%s%eobserver_retval_%d.php'>

--- a/ext/zend_test/tests/observer_retval_05.phpt
+++ b/ext/zend_test/tests/observer_retval_05.phpt
@@ -23,11 +23,11 @@ echo 'Done' . PHP_EOL;
   <!-- init foo() -->
   <foo>
 
-Warning: Undefined variable $i_do_not_exist in %s on line %d
+Warning: Undefined variable $i_do_not_exist (This will become an error in PHP 9.0) in %s on line %d
   </foo:NULL>
   <foo>
 
-Warning: Undefined variable $i_do_not_exist in %s on line %d
+Warning: Undefined variable $i_do_not_exist (This will become an error in PHP 9.0) in %s on line %d
   </foo:NULL>
 Done
 </file '%s%eobserver_retval_%d.php'>

--- a/tests/basic/025.phpt
+++ b/tests/basic/025.phpt
@@ -13,7 +13,7 @@ var_dump($_POST, $HTTP_RAW_POST_DATA);
 --EXPECTF--
 Warning: PHP Request Startup: POST Content-Length of 2050 bytes exceeds the limit of 1024 bytes in Unknown on line 0
 
-Warning: Undefined variable $HTTP_RAW_POST_DATA (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $HTTP_RAW_POST_DATA (this will become an error in PHP 9.0) in %s on line %d
 array(0) {
 }
 NULL

--- a/tests/basic/025.phpt
+++ b/tests/basic/025.phpt
@@ -13,7 +13,7 @@ var_dump($_POST, $HTTP_RAW_POST_DATA);
 --EXPECTF--
 Warning: PHP Request Startup: POST Content-Length of 2050 bytes exceeds the limit of 1024 bytes in Unknown on line 0
 
-Warning: Undefined variable $HTTP_RAW_POST_DATA in %s on line %d
+Warning: Undefined variable $HTTP_RAW_POST_DATA (This will become an error in PHP 9.0) in %s on line %d
 array(0) {
 }
 NULL

--- a/tests/basic/enable_post_data_reading_01.phpt
+++ b/tests/basic/enable_post_data_reading_01.phpt
@@ -19,7 +19,7 @@ array(0) {
 array(0) {
 }
 
-Warning: Undefined variable $HTTP_RAW_POST_DATA in %s on line %d
+Warning: Undefined variable $HTTP_RAW_POST_DATA (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(9) "a=1&b=ZYX"
 string(9) "a=1&b=ZYX"

--- a/tests/basic/enable_post_data_reading_01.phpt
+++ b/tests/basic/enable_post_data_reading_01.phpt
@@ -19,7 +19,7 @@ array(0) {
 array(0) {
 }
 
-Warning: Undefined variable $HTTP_RAW_POST_DATA (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $HTTP_RAW_POST_DATA (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(9) "a=1&b=ZYX"
 string(9) "a=1&b=ZYX"

--- a/tests/basic/enable_post_data_reading_03.phpt
+++ b/tests/basic/enable_post_data_reading_03.phpt
@@ -20,7 +20,7 @@ array(0) {
 array(0) {
 }
 
-Warning: Undefined variable $HTTP_RAW_POST_DATA in %s on line %d
+Warning: Undefined variable $HTTP_RAW_POST_DATA (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(9) "a=1&b=ZYX"
 string(9) "a=1&b=ZYX"

--- a/tests/basic/enable_post_data_reading_03.phpt
+++ b/tests/basic/enable_post_data_reading_03.phpt
@@ -20,7 +20,7 @@ array(0) {
 array(0) {
 }
 
-Warning: Undefined variable $HTTP_RAW_POST_DATA (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $HTTP_RAW_POST_DATA (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(9) "a=1&b=ZYX"
 string(9) "a=1&b=ZYX"

--- a/tests/basic/enable_post_data_reading_04.phpt
+++ b/tests/basic/enable_post_data_reading_04.phpt
@@ -20,7 +20,7 @@ array(0) {
 array(0) {
 }
 
-Warning: Undefined variable $HTTP_RAW_POST_DATA in %s on line %d
+Warning: Undefined variable $HTTP_RAW_POST_DATA (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(9) "a=1&b=ZYX"
 string(9) "a=1&b=ZYX"

--- a/tests/basic/enable_post_data_reading_04.phpt
+++ b/tests/basic/enable_post_data_reading_04.phpt
@@ -20,7 +20,7 @@ array(0) {
 array(0) {
 }
 
-Warning: Undefined variable $HTTP_RAW_POST_DATA (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $HTTP_RAW_POST_DATA (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(9) "a=1&b=ZYX"
 string(9) "a=1&b=ZYX"

--- a/tests/classes/constants_basic_001.phpt
+++ b/tests/classes/constants_basic_001.phpt
@@ -55,7 +55,7 @@ Class constant declarations
   echo "\nYou should not see this.";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef in %s on line %d
+Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
 
 Attempt to access various kinds of class constants:
 int(1)

--- a/tests/classes/constants_basic_001.phpt
+++ b/tests/classes/constants_basic_001.phpt
@@ -55,7 +55,7 @@ Class constant declarations
   echo "\nYou should not see this.";
 ?>
 --EXPECTF--
-Warning: Undefined variable $undef (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef (this will become an error in PHP 9.0) in %s on line %d
 
 Attempt to access various kinds of class constants:
 int(1)

--- a/tests/lang/bison1.phpt
+++ b/tests/lang/bison1.phpt
@@ -5,5 +5,5 @@ Bison weirdness
 echo "blah-$foo\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $foo in %s on line %d
+Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line %d
 blah-

--- a/tests/lang/bison1.phpt
+++ b/tests/lang/bison1.phpt
@@ -5,5 +5,5 @@ Bison weirdness
 echo "blah-$foo\n";
 ?>
 --EXPECTF--
-Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $foo (this will become an error in PHP 9.0) in %s on line %d
 blah-

--- a/tests/lang/bug23584.phpt
+++ b/tests/lang/bug23584.phpt
@@ -10,4 +10,4 @@ echo $foo;
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $foo in %s on line 6
+Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line 6

--- a/tests/lang/bug23584.phpt
+++ b/tests/lang/bug23584.phpt
@@ -10,4 +10,4 @@ echo $foo;
 
 ?>
 --EXPECTF--
-Warning: Undefined variable $foo (This will become an error in PHP 9.0) in %s on line 6
+Warning: Undefined variable $foo (this will become an error in PHP 9.0) in %s on line 6

--- a/tests/lang/bug25922.phpt
+++ b/tests/lang/bug25922.phpt
@@ -19,6 +19,6 @@ function test()
 test();
 ?>
 --EXPECT--
-Undefined variable $data
+Undefined variable $data (This will become an error in PHP 9.0)
 Trying to access array offset on value of type null
 Undefined index here: ''

--- a/tests/lang/bug25922.phpt
+++ b/tests/lang/bug25922.phpt
@@ -19,6 +19,6 @@ function test()
 test();
 ?>
 --EXPECT--
-Undefined variable $data (This will become an error in PHP 9.0)
+Undefined variable $data (this will become an error in PHP 9.0)
 Trying to access array offset on value of type null
 Undefined index here: ''

--- a/tests/lang/passByReference_003.phpt
+++ b/tests/lang/passByReference_003.phpt
@@ -25,7 +25,7 @@ var_dump($undef2)
 --EXPECTF--
 Passing undefined by value
 
-Warning: Undefined variable $undef1 in %s on line %d
+Warning: Undefined variable $undef1 (This will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
@@ -34,7 +34,7 @@ NULL
 
 After call
 
-Warning: Undefined variable $undef1 in %s on line %d
+Warning: Undefined variable $undef1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 
 Passing undefined by reference

--- a/tests/lang/passByReference_003.phpt
+++ b/tests/lang/passByReference_003.phpt
@@ -25,7 +25,7 @@ var_dump($undef2)
 --EXPECTF--
 Passing undefined by value
 
-Warning: Undefined variable $undef1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef1 (this will become an error in PHP 9.0) in %s on line %d
 
 Warning: Trying to access array offset on value of type null in %s on line %d
 
@@ -34,7 +34,7 @@ NULL
 
 After call
 
-Warning: Undefined variable $undef1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $undef1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 
 Passing undefined by reference

--- a/tests/lang/passByReference_005.phpt
+++ b/tests/lang/passByReference_005.phpt
@@ -170,31 +170,31 @@ var_dump($u1, $u2);
 --EXPECTF--
 ---- Pass by ref / pass by val: functions ----
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 NULL
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 string(11) "Ref changed"
 NULL
 string(12) "Ref1 changed"
@@ -203,31 +203,31 @@ string(12) "Ref2 changed"
 
  ---- Pass by ref / pass by val: static method calls ----
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 NULL
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 string(11) "Ref changed"
 NULL
 string(12) "Ref1 changed"
@@ -236,37 +236,37 @@ string(12) "Ref2 changed"
 
  ---- Pass by ref / pass by val: instance method calls ----
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 NULL
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 in %s on line %d
+Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 in %s on line %d
+Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
 string(11) "Ref changed"
 NULL
 string(12) "Ref1 changed"

--- a/tests/lang/passByReference_005.phpt
+++ b/tests/lang/passByReference_005.phpt
@@ -170,31 +170,31 @@ var_dump($u1, $u2);
 --EXPECTF--
 ---- Pass by ref / pass by val: functions ----
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 NULL
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 string(11) "Ref changed"
 NULL
 string(12) "Ref1 changed"
@@ -203,31 +203,31 @@ string(12) "Ref2 changed"
 
  ---- Pass by ref / pass by val: static method calls ----
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 NULL
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 string(11) "Ref changed"
 NULL
 string(12) "Ref1 changed"
@@ -236,37 +236,37 @@ string(12) "Ref2 changed"
 
  ---- Pass by ref / pass by val: instance method calls ----
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 NULL
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u1 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u1 (this will become an error in PHP 9.0) in %s on line %d
 NULL
 string(11) "Ref changed"
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $u2 (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $u2 (this will become an error in PHP 9.0) in %s on line %d
 string(11) "Ref changed"
 NULL
 string(12) "Ref1 changed"

--- a/tests/lang/short_tags.004.phpt
+++ b/tests/lang/short_tags.004.phpt
@@ -29,6 +29,6 @@ This gets echoed twice
 <? $b=3; ?>
 
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
+Warning: Undefined variable $b (this will become an error in PHP 9.0) in %s on line %d

--- a/tests/lang/short_tags.004.phpt
+++ b/tests/lang/short_tags.004.phpt
@@ -29,6 +29,6 @@ This gets echoed twice
 <? $b=3; ?>
 
 
-Warning: Undefined variable $b in %s on line %d
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d
 
-Warning: Undefined variable $b in %s on line %d
+Warning: Undefined variable $b (This will become an error in PHP 9.0) in %s on line %d


### PR DESCRIPTION
As per RFC https://wiki.php.net/rfc/undefined_variable_error_promotion the next version will include a modified warning message when accessing undefined variables to indicate that they will become errors in PHP 9.0.