### PR TITLE
FPM. access.log with stderr begins to write logs to error_log after daemon reload (GH-8885)

### DIFF
--- a/sapi/fpm/fpm/fpm_events.c
+++ b/sapi/fpm/fpm/fpm_events.c
@@ -104,6 +104,13 @@ static void fpm_got_signal(struct fpm_event_s *ev, short which, void *arg) /* {{
 				break;
 			case '1' :                  /* SIGUSR1 */
 				zlog(ZLOG_DEBUG, "received SIGUSR1");
+
+                                /* fpm_stdio_init_final tied STDERR fd with error_log fd. This affects logging to the
+                                 * access.log if it was configured to write to the stderr. Check #8885. */
+                                if (0 > fpm_stdio_restore_original_stderr()) {
+                                    zlog(ZLOG_SYSERROR, "failed to restore original STDERR descriptor, access.log records may appear in the error_log");
+                                }
+
 				if (0 == fpm_stdio_open_error_log(1)) {
 					zlog(ZLOG_NOTICE, "error log file re-opened");
 				} else {
@@ -117,6 +124,9 @@ static void fpm_got_signal(struct fpm_event_s *ev, short which, void *arg) /* {{
 					zlog(ZLOG_ERROR, "unable to re-opened access log file");
 				}
 				/* else no access log are set */
+
+                                /* We need to tie stderr with error_log in the master process after log files reload. Check #8885. */
+                                fpm_stdio_init_final();
 
 				break;
 			case '2' :                  /* SIGUSR2 */

--- a/sapi/fpm/fpm/fpm_process_ctl.c
+++ b/sapi/fpm/fpm/fpm_process_ctl.c
@@ -18,6 +18,7 @@
 #include "fpm_worker_pool.h"
 #include "fpm_scoreboard.h"
 #include "fpm_sockets.h"
+#include "fpm_stdio.h"
 #include "zlog.h"
 
 
@@ -81,6 +82,10 @@ static void fpm_pctl_exec(void) /* {{{ */
 	if (0 > fpm_signals_block()) {
 		zlog(ZLOG_WARNING, "concurrent reloads may be unstable");
 	}
+
+        if (0 > fpm_stdio_restore_original_stderr()) {
+            zlog(ZLOG_SYSERROR, "failed to restore original STDERR descriptor, access.log and slowlog records may appear in error_log");
+        }
 
 	zlog(ZLOG_NOTICE, "reloading: execvp(\"%s\", {\"%s\""
 			"%s%s%s" "%s%s%s" "%s%s%s" "%s%s%s" "%s%s%s"


### PR DESCRIPTION
Fixes #8885 