### PR TITLE
Fix GH-8923: error_log on Windows can hold the file write lock

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -837,9 +837,10 @@ PHPAPI ZEND_COLD void php_log_err_with_severity(const char *log_message, int sys
 #endif
 			len = spprintf(&tmp, 0, "[%s] %s%s", ZSTR_VAL(error_time_str), log_message, PHP_EOL);
 #ifdef PHP_WIN32
-			php_flock(fd, 2);
+			php_flock(fd, LOCK_EX);
 			/* XXX should eventually write in a loop if len > UINT_MAX */
 			php_ignore_value(write(fd, tmp, (unsigned)len));
+			php_flock(fd, LOCK_UN);
 #else
 			php_ignore_value(write(fd, tmp, len));
 #endif


### PR DESCRIPTION
On Windows, closing a file which is locked may not immediately remove
the lock.  The `LockFileEx()` documentation states:

| Therefore, it is recommended that your process explicitly unlock all
| files it has locked when it terminates.

We comply, and also use the macro `LOCK_EX` instead of the magic number
`2`.