### PR TITLE
Fix GH-8576: Bad interpretation of length when char is UTF-8

### DIFF
--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -204,6 +204,9 @@ static int firebird_stmt_describe(pdo_stmt_t *stmt, int colno) /* {{{ */
 	int colname_len;
 	char *cp;
 
+	if ((var->sqltype & ~1) == SQL_TEXT) {
+		var->sqltype = SQL_VARYING | (var->sqltype & 1);
+	}
 	colname_len = (S->H->fetch_table_names && var->relname_length)
 					? (var->aliasname_length + var->relname_length + 1)
 					: (var->aliasname_length);

--- a/ext/pdo_firebird/tests/gh8576.phpt
+++ b/ext/pdo_firebird/tests/gh8576.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-8576 (Bad interpretation of length when char is UTF-8)
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require 'skipif.inc'; ?>
+--FILE--
+<?php
+require 'testdb.inc';
+
+$dbh->exec("CREATE TABLE gh8576 (name CHAR(1) CHARACTER SET UTF8)");
+$dbh->exec("INSERT INTO gh8576 VALUES ('A')");
+$stmt = $dbh->query("SELECT * FROM gh8576");
+var_dump($stmt->fetchAll());
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(2) {
+    ["NAME"]=>
+    string(1) "A"
+    [0]=>
+    string(1) "A"
+  }
+}
+--CLEAN--
+<?php
+require 'testdb.inc';
+$dbh->exec("DROP TABLE gh8576");
+?>


### PR DESCRIPTION
For columns of type `SQL_TEXT`, Firebird does not properly report the
actual column length, but rather only the maximum column length, so for
multi-byte encodings like UTF-8, such columns may have trailing
spaces.  We work around that by treating such columns as `SQL_VARYING`
when we ask the server to describe the colum, what yields the desired
results.

Given that this is a work-around, and may break code which expects the
results with trailing spaces, we target "master" only.