### PR TITLE
intl extension, build fix for icu >= 71.x release.

### DIFF
--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -933,10 +933,18 @@ static zend_object *php_converter_clone_object(zend_object *object) {
 
 	intl_errors_reset(&oldobj->error);
 
+#if U_ICU_VERSION_MAJOR_NUM > 70
+	objval->src = ucnv_clone(oldobj->src, &error);
+#else
 	objval->src = ucnv_safeClone(oldobj->src, NULL, NULL, &error);
+#endif
 	if (U_SUCCESS(error)) {
 		error = U_ZERO_ERROR;
+#if U_ICU_VERSION_MAJOR_NUM > 70
+		objval->dest = ucnv_clone(oldobj->dest, &error);
+#else
 		objval->dest = ucnv_safeClone(oldobj->dest, NULL, NULL, &error);
+#endif
 	}
 	if (U_FAILURE(error)) {
 		zend_string *err_msg;

--- a/ext/intl/grapheme/grapheme_util.c
+++ b/ext/intl/grapheme/grapheme_util.c
@@ -372,8 +372,6 @@ zend_long grapheme_strrpos_ascii(char *haystack, size_t haystack_len, char *need
 /* {{{ grapheme_get_break_iterator: get a clone of the global character break iterator */
 UBreakIterator* grapheme_get_break_iterator(void *stack_buffer, UErrorCode *status )
 {
-	int32_t buffer_size;
-
 	UBreakIterator *global_break_iterator = INTL_G( grapheme_iterator );
 
 	if ( NULL == global_break_iterator ) {
@@ -387,8 +385,12 @@ UBreakIterator* grapheme_get_break_iterator(void *stack_buffer, UErrorCode *stat
 		INTL_G(grapheme_iterator) = global_break_iterator;
 	}
 
-	buffer_size = U_BRK_SAFECLONE_BUFFERSIZE;
+#if U_ICU_VERSION_MAJOR_NUM >= 69
+	return ubrk_clone(global_break_iterator, status);
+#else
+	int32_t buffer_size = U_BRK_SAFECLONE_BUFFERSIZE;
 
 	return ubrk_safeClone(global_break_iterator, stack_buffer, &buffer_size, status);
+#endif
 }
 /* }}} */


### PR DESCRIPTION
ubrk/ucnv_safeClone had been deprecated in favor
of ubrk/ucnv_clone which does not use user provided stacks
but remain thread safe.