### PR TITLE
Fix GH-8841: error on return type check of func declaration isn't removing the function from function_table

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6992,7 +6992,16 @@ void zend_compile_func_decl(znode *result, zend_ast *ast, zend_bool toplevel) /*
 	} else if (uses_ast) {
 		zend_compile_closure_uses(uses_ast);
 	}
-	zend_compile_stmt(stmt_ast);
+
+	zend_try {
+		zend_compile_stmt(stmt_ast);
+	} zend_catch {
+		if (!is_method && toplevel) {
+			zend_hash_del(CG(function_table), CG(active_op_array)->function_name);
+		}
+
+		zend_bailout();
+	} zend_end_try();
 
 	if (is_method) {
 		CG(zend_lineno) = decl->start_lineno;

--- a/sapi/cli/tests/gh8841_1.phpt
+++ b/sapi/cli/tests/gh8841_1.phpt
@@ -1,0 +1,89 @@
+--TEST--
+GH-8841: Fix invalid return type compilation doesn't register function (without libedit)
+--SKIPIF--
+<?php
+include "skipif.inc";
+if (!extension_loaded('readline') || READLINE_LIB !== "readline") {
+    die ("skip need readline support");
+}
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+
+// disallow console escape sequences that may break the output
+putenv('TERM=VT100');
+
+$codes = array();
+
+$codes[1] = <<<EOT
+function f(\$x): void { return \$x; }
+f(1);
+EOT;
+
+$codes[2] = <<<EOT
+function f(\$x): void { return \$x; }
+function f(\$x): int { return \$x; }
+echo f(1);
+EOT;
+
+$codes[3] = <<<EOT
+function foo() { return \$x[]; }
+foo();
+EOT;
+
+foreach ($codes as $key => $code) {
+    echo "\n--------------\nSnippet no. $key:\n--------------\n";
+    $code = escapeshellarg($code);
+    echo `echo $code | "$php" -a`, "\n";
+}
+
+echo "\nDone\n";
+?>
+--EXPECT--
+--------------
+Snippet no. 1:
+--------------
+Interactive shell
+
+php > function f($x): void { return $x; }
+
+Fatal error: A void function must not return a value in php shell code on line 1
+php > f(1);
+
+Warning: Uncaught Error: Call to undefined function f() in php shell code:1
+Stack trace:
+#0 {main}
+  thrown in php shell code on line 1
+php > 
+
+--------------
+Snippet no. 2:
+--------------
+Interactive shell
+
+php > function f($x): void { return $x; }
+
+Fatal error: A void function must not return a value in php shell code on line 1
+php > function f($x): int { return $x; }
+php > echo f(1);
+1
+php > 
+
+--------------
+Snippet no. 3:
+--------------
+Interactive shell
+
+php > function foo() { return $x[]; }
+
+Fatal error: Cannot use [] for reading in php shell code on line 1
+php > foo();
+
+Warning: Uncaught Error: Call to undefined function foo() in php shell code:1
+Stack trace:
+#0 {main}
+  thrown in php shell code on line 1
+php > 
+
+Done

--- a/sapi/cli/tests/gh8841_2.phpt
+++ b/sapi/cli/tests/gh8841_2.phpt
@@ -1,0 +1,75 @@
+--TEST--
+GH-8841: Fix invalid return type compilation doesn't register function (with libedit)
+--SKIPIF--
+<?php
+include "skipif.inc";
+if (!extension_loaded('readline')) die("skip need readline support");
+if (READLINE_LIB !== "libedit") die('skip libedit only');
+?>
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$codes = array();
+
+$codes[1] = <<<EOT
+function f(\$x): void { return \$x; }
+f(1);
+EOT;
+
+$codes[2] = <<<EOT
+function f(\$x): void { return \$x; }
+function f(\$x): int { return \$x; }
+echo f(1);
+EOT;
+
+$codes[3] = <<<EOT
+function foo() { return \$x[]; }
+foo();
+EOT;
+
+foreach ($codes as $key => $code) {
+    echo "\n--------------\nSnippet no. $key:\n--------------\n";
+    $php = getenv('TEST_PHP_EXECUTABLE');
+    $ini = getenv('TEST_PHP_EXTRA_ARGS');
+    $descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
+    $proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+    fwrite($pipes[0], $code);
+    fclose($pipes[0]);
+    proc_close($proc);
+}
+?>
+--EXPECT--
+--------------
+Snippet no. 1:
+--------------
+Interactive shell
+
+
+Fatal error: A void function must not return a value in php shell code on line 1
+
+Warning: Uncaught Error: Call to undefined function f() in php shell code:1
+Stack trace:
+#0 {main}
+  thrown in php shell code on line 1
+
+--------------
+Snippet no. 2:
+--------------
+Interactive shell
+
+
+Fatal error: A void function must not return a value in php shell code on line 1
+1
+
+--------------
+Snippet no. 3:
+--------------
+Interactive shell
+
+
+Fatal error: Cannot use [] for reading in php shell code on line 1
+
+Warning: Uncaught Error: Call to undefined function foo() in php shell code:1
+Stack trace:
+#0 {main}
+  thrown in php shell code on line 1


### PR DESCRIPTION
At compile time, if the return type check fails during a function declaration, then the function isn't removed from the global `function_table` in SAPI. It causes 2 problems:

- Calling the function even after the failed declaration results in a core dump
- As the function is present in the global `function_table`, it is not possible to (try to) redefine the function, as function name is considered as "already in use"

Fixes https://github.com/php/php-src/issues/8841