### PR TITLE
Refactor code handling file.current_zval

### DIFF
--- a/ext/spl/tests/SplFileObject/fgetcsv_blank_file.phpt
+++ b/ext/spl/tests/SplFileObject/fgetcsv_blank_file.phpt
@@ -1,0 +1,31 @@
+--TEST--
+SplFileObject: fgetcsv() on a blank line
+--FILE--
+<?php
+
+$file_path = __DIR__ . '/SplFileObject_fgetcsv_empty.csv';
+$file = new SplFileObject($file_path, 'w');
+$file = new SplTempFileObject();
+
+// write to file
+$file->fwrite("");
+
+// read from file
+$file->rewind();
+var_dump($file->fgetcsv());
+
+$file->setFlags(SplFileObject::SKIP_EMPTY);
+$file->rewind();
+var_dump($file->fgetcsv());
+?>
+--CLEAN--
+<?php
+$file_path = __DIR__ . '/SplFileObject_fgetcsv_empty.csv';
+unlink($file_path);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  NULL
+}
+bool(false)


### PR DESCRIPTION
Code refactoring while I'm attempting to get a better grasp of this code.

@twose you wouldn't have a test case which would hit the:
```
if (SPL_HAS_FLAG(intern->flags, SPL_FILE_OBJECT_READ_CSV)
				&& zend_hash_num_elements(Z_ARRVAL(intern->u.file.current_zval)) == 1) {
			ZEND_ASSERT(false && "Can this happen?");
```
code path do you? As I don't understand what this branch is attempting to do.