### PR TITLE
Make php_fgetcsv() return a HashTale instead of in-out zval param

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1958,7 +1958,11 @@ static zend_result spl_filesystem_file_read_csv(spl_filesystem_object *intern, c
 		ZVAL_UNDEF(&intern->u.file.current_zval);
 	}
 
-	php_fgetcsv(intern->u.file.stream, delimiter, enclosure, escape, buf_len, buf, &intern->u.file.current_zval);
+	HashTable *values = php_fgetcsv(intern->u.file.stream, delimiter, enclosure, escape, buf_len, buf);
+	if (values == NULL) {
+		BC_EMPTY_CSV_LINE_ARRAY(values);
+	}
+	ZVAL_ARR(&intern->u.file.current_zval, values);
 	if (return_value) {
 		ZVAL_COPY(return_value, &intern->u.file.current_zval);
 	}

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -48,7 +48,9 @@ PHPAPI void php_flock_common(php_stream *stream, zend_long operation, uint32_t o
 	zval *wouldblock, zval *return_value);
 
 #define PHP_CSV_NO_ESCAPE EOF
-PHPAPI void php_fgetcsv(php_stream *stream, char delimiter, char enclosure, int escape_char, size_t buf_len, char *buf, zval *return_value);
+#define BC_EMPTY_CSV_LINE_ARRAY(values) { (values) = zend_new_array(1); zval _______z_tmp; \
+	ZVAL_NULL(&_______z_tmp); zend_hash_next_index_insert((values), &_______z_tmp); }
+PHPAPI HashTable *php_fgetcsv(php_stream *stream, char delimiter, char enclosure, int escape_char, size_t buf_len, char *buf);
 PHPAPI ssize_t php_fputcsv(php_stream *stream, zval *fields, char delimiter, char enclosure, int escape_char, zend_string *eol_str);
 
 #define META_DEF_BUFSIZE 8192

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5253,7 +5253,11 @@ PHP_FUNCTION(str_getcsv)
 		esc = esc_len ? (unsigned char) esc_str[0] : PHP_CSV_NO_ESCAPE;
 	}
 
-	php_fgetcsv(NULL, delim, enc, esc, ZSTR_LEN(str), ZSTR_VAL(str), return_value);
+	HashTable *values = php_fgetcsv(NULL, delim, enc, esc, ZSTR_LEN(str), ZSTR_VAL(str));
+	if (values == NULL) {
+		BC_EMPTY_CSV_LINE_ARRAY(values);
+	}
+	RETURN_ARR(values);
 }
 /* }}} */
 


### PR DESCRIPTION
Also refactor what happens on an empty line to return NULL instead of setting the array to [NULL] which makes no design sense at all.
However, as this is the current behaviour create a BC Shim macro to recreate this weird HashTable in the function which currently use this API