### PR TITLE
Fix GH-8943: Reflection::getModifiersNames() with readonly modifier

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-8847 (PHP hanging infinitly at 100% cpu when check php
     syntaxe of a valid file). (Dmitry)
 
+- Reflection:
+  . Fixed bug GH-8943 (Fixed Reflection::getModifiersNames() with readonly
+    modifier). (Pierrick)
+
 - Standard:
   . Fixed the crypt_sha256/512 api build with clang > 12. (David Carier)
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1550,6 +1550,10 @@ ZEND_METHOD(Reflection, getModifierNames)
 	if (modifiers & ZEND_ACC_STATIC) {
 		add_next_index_stringl(return_value, "static", sizeof("static")-1);
 	}
+
+	if (modifiers & ZEND_ACC_READONLY) {
+		add_next_index_stringl(return_value, "readonly", sizeof("readonly")-1);
+	}
 }
 /* }}} */
 

--- a/ext/reflection/tests/Reflection_getModifierNames_001.phpt
+++ b/ext/reflection/tests/Reflection_getModifierNames_001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Reflection::getModifierNames() basic
+--FILE--
+<?php
+
+function printModifiers($modifiers) {
+	echo implode(',', Reflection::getModifierNames($modifiers)), PHP_EOL;
+}
+
+printModifiers(ReflectionProperty::IS_PRIVATE);
+printModifiers(ReflectionProperty::IS_PROTECTED | ReflectionProperty::IS_STATIC);
+printModifiers(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_READONLY);
+printModifiers(ReflectionClass::IS_EXPLICIT_ABSTRACT);
+printModifiers(ReflectionMethod::IS_ABSTRACT | ReflectionMethod::IS_FINAL);
+printModifiers(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_STATIC | ReflectionProperty::IS_READONLY);
+?>
+--EXPECT--
+private
+protected,static
+public,readonly
+abstract
+abstract,final
+public,static,readonly


### PR DESCRIPTION
This fixes only fixes PHP-8.1

I plan to add `ZEND_ACC_READONLY_CLASS` when merging into master to also support `ReflectionClass::IS_READONLY`