### PR TITLE
Fix GH-8924 str_split of empty string must return empty array

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5882,7 +5882,11 @@ PHP_FUNCTION(str_split)
 		RETURN_THROWS();
 	}
 
-	if (0 == ZSTR_LEN(str) || (size_t)split_length >= ZSTR_LEN(str)) {
+	if ((size_t)split_length >= ZSTR_LEN(str)) {
+		if (0 == ZSTR_LEN(str)) {
+			RETURN_EMPTY_ARRAY();
+		}
+
 		array_init_size(return_value, 1);
 		add_next_index_stringl(return_value, ZSTR_VAL(str), ZSTR_LEN(str));
 		return;

--- a/ext/standard/tests/strings/str_split_basic.phpt
+++ b/ext/standard/tests/strings/str_split_basic.phpt
@@ -16,7 +16,11 @@ var_dump( str_split($str,$split_length) );
 echo "-- With split_length as default argument --\n";
 var_dump( str_split($str) );
 
-echo "Done"
+echo "-- Empty string must always return empty array --\n";
+var_dump( str_split('') );
+var_dump( str_split('', 1) );
+var_dump( str_split('', 100) );
+
 ?>
 --EXPECT--
 *** Testing str_split() : basic functionality ***
@@ -80,4 +84,10 @@ array(22) {
   [21]=>
   string(1) "e"
 }
-Done
+-- Empty string must always return empty array --
+array(0) {
+}
+array(0) {
+}
+array(0) {
+}

--- a/ext/standard/tests/strings/str_split_variation3.phpt
+++ b/ext/standard/tests/strings/str_split_variation3.phpt
@@ -39,9 +39,7 @@ echo "Done"
 --EXPECTF--
 *** Testing str_split() : double quoted strings for 'str' ***
 -- Iteration 1 --
-array(1) {
-  [0]=>
-  string(0) ""
+array(0) {
 }
 -- Iteration 2 --
 array(1) {

--- a/ext/standard/tests/strings/str_split_variation4.phpt
+++ b/ext/standard/tests/strings/str_split_variation4.phpt
@@ -38,9 +38,7 @@ echo "Done"
 --EXPECT--
 *** Testing str_split() : single quoted strings for 'str' ***
 -- Iteration 1 --
-array(1) {
-  [0]=>
-  string(0) ""
+array(0) {
 }
 -- Iteration 2 --
 array(1) {

--- a/ext/standard/tests/strings/str_split_variation5.phpt
+++ b/ext/standard/tests/strings/str_split_variation5.phpt
@@ -81,14 +81,10 @@ echo "Done"
 --EXPECT--
 *** Testing str_split() : heredoc strings as 'str' argument ***
 -- Iteration 1 --
-array(1) {
-  [0]=>
-  string(0) ""
+array(0) {
 }
 -- Iteration 2 --
-array(1) {
-  [0]=>
-  string(0) ""
+array(0) {
 }
 -- Iteration 3 --
 array(1) {


### PR DESCRIPTION
The inconsistency was introduced in https://github.com/php/php-src/commit/0818faee7f4f3501b5521e31a830e647cea2d1ec by a mistake as found out by @emkey08.

`mb_str_split` behaves properly and empty input is covered by a test already.

As some algorithms might rely on the bad - always non-empty array - behaviour, targetting master only.