### PR TITLE
Fix "%f" regex in run-tests.php

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2583,10 +2583,9 @@ COMMAND $cmd
             $wanted_re = str_replace('%i', '[+-]?\d+', $wanted_re);
             $wanted_re = str_replace('%d', '\d+', $wanted_re);
             $wanted_re = str_replace('%x', '[0-9a-fA-F]+', $wanted_re);
-            $wanted_re = str_replace('%f', '[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?', $wanted_re);
+            $wanted_re = str_replace('%f', '[+-]?(?:\d+|(?=\.\d))(?:\.\d+)?(?:[Ee][+-]?\d+)?', $wanted_re);
             $wanted_re = str_replace('%c', '.', $wanted_re);
             $wanted_re = str_replace('%0', '\x00', $wanted_re);
-            // %f allows two points "-.0.0" but that is the best *simple* expression
         }
 
         if (preg_match("/^$wanted_re\$/s", $output)) {


### PR DESCRIPTION
"-.0.0" and "0." is no longer matched wrongly