### PR TITLE
random: whitelist arc4random_buf if glibc

### DIFF
--- a/ext/standard/random.c
+++ b/ext/standard/random.c
@@ -94,7 +94,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 		}
 		return FAILURE;
 	}
-#elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405) || (defined(__NetBSD__) && __NetBSD_Version__ >= 700000001) || defined(__APPLE__))
+#elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405) || (defined(__NetBSD__) && __NetBSD_Version__ >= 700000001) || defined(__APPLE__) || defined(__GLIBC__))
 	arc4random_buf(bytes, size);
 #else
 	size_t read_bytes = 0;


### PR DESCRIPTION
Glibc will provide the BSD arc4random API, either on version 2.36 or slightly later.. whitelist its implementation as it uses the variant with modern crypto