### PR TITLE
INI parser: Fix typo /multipler/multiplier

### DIFF
--- a/Zend/tests/zend_ini_parse_quantity_error.phpt
+++ b/Zend/tests/zend_ini_parse_quantity_error.phpt
@@ -40,7 +40,7 @@ int(1048576)
 
 # "1X"
 
-Warning: Invalid quantity "1X": unknown multipler "X", interpreting as "1" for backwards compatibility in %s%ezend_ini_parse_quantity_error.php on line %d
+Warning: Invalid quantity "1X": unknown multiplier "X", interpreting as "1" for backwards compatibility in %s%ezend_ini_parse_quantity_error.php on line %d
 int(1)
 
 # "1.0K"
@@ -70,10 +70,10 @@ int(125952)
 
 # " 123K\000"
 
-Warning: Invalid quantity " 123K\x00": unknown multipler "\x00", interpreting as " 123" for backwards compatibility in %s on line %d
+Warning: Invalid quantity " 123K\x00": unknown multiplier "\x00", interpreting as " 123" for backwards compatibility in %s on line %d
 int(123)
 
 # " 123\000"
 
-Warning: Invalid quantity " 123\x00": unknown multipler "\x00", interpreting as " 123" for backwards compatibility in %s on line %d
+Warning: Invalid quantity " 123\x00": unknown multiplier "\x00", interpreting as " 123" for backwards compatibility in %s on line %d
 int(123)

--- a/Zend/tests/zend_ini_parse_quantity_ini_set_error.phpt
+++ b/Zend/tests/zend_ini_parse_quantity_ini_set_error.phpt
@@ -8,6 +8,6 @@ zend_test
 var_dump(ini_set("zend_test.quantity_value", "1MB"));
 var_dump(ini_get("zend_test.quantity_value"));
 --EXPECTF--
-Warning: Invalid "zend_test.quantity_value" setting. Invalid quantity "1MB": unknown multipler "B", interpreting as "1" for backwards compatibility in %s on line %d
+Warning: Invalid "zend_test.quantity_value" setting. Invalid quantity "1MB": unknown multiplier "B", interpreting as "1" for backwards compatibility in %s on line %d
 string(1) "0"
 string(3) "1MB"

--- a/Zend/tests/zend_ini_parse_quantity_ini_setting_error.phpt
+++ b/Zend/tests/zend_ini_parse_quantity_ini_setting_error.phpt
@@ -9,5 +9,5 @@ zend_test.quantity_value=1MB
 
 var_dump(ini_get("zend_test.quantity_value"));
 --EXPECTF--
-Warning: Invalid "zend_test.quantity_value" setting. Invalid quantity "1MB": unknown multipler "B", interpreting as "1" for backwards compatibility in %s on line %d
+Warning: Invalid "zend_test.quantity_value" setting. Invalid quantity "1MB": unknown multiplier "B", interpreting as "1" for backwards compatibility in %s on line %d
 string(3) "1MB"

--- a/Zend/zend_ini.c
+++ b/Zend/zend_ini.c
@@ -635,7 +635,7 @@ static zend_ulong zend_ini_parse_quantity_internal(zend_string *value, zend_ini_
 			smart_str_append_escaped(&chr, str_end-1, 1);
 			smart_str_0(&chr);
 
-			*errstr = zend_strpprintf(0, "Invalid quantity \"%s\": unknown multipler \"%s\", interpreting as \"%s\" for backwards compatibility",
+			*errstr = zend_strpprintf(0, "Invalid quantity \"%s\": unknown multiplier \"%s\", interpreting as \"%s\" for backwards compatibility",
 						ZSTR_VAL(invalid.s), ZSTR_VAL(chr.s), ZSTR_VAL(interpreted.s));
 
 			smart_str_free(&invalid);

--- a/Zend/zend_ini.h
+++ b/Zend/zend_ini.h
@@ -95,7 +95,7 @@ ZEND_API bool zend_ini_parse_bool(zend_string *str);
  *
  * The value parameter must be a string in the form
  *
- *     sign? digits ws* multipler?
+ *     sign? digits ws* multiplier?
  *
  * with
  *
@@ -103,7 +103,7 @@ ZEND_API bool zend_ini_parse_bool(zend_string *str);
  *     digit: [0-9]
  *     digits: digit+
  *     ws: [ \t\n\r\v\f]
- *     multipler: [KMG]
+ *     multiplier: [KMG]
  *
  * Leading and trailing whitespaces are ignored.
  *

--- a/tests/basic/ini_parse_quantity_warnings.phpt
+++ b/tests/basic/ini_parse_quantity_warnings.phpt
@@ -9,6 +9,6 @@ ini_parse_quantity('1mb');
 ini_parse_quantity('256 then skip a few then g')
 ?>
 --EXPECTF--
-Warning: Invalid quantity "1mb": unknown multipler "b", interpreting as "1" for backwards compatibility in %sini_parse_quantity_warnings.php on line 3
+Warning: Invalid quantity "1mb": unknown multiplier "b", interpreting as "1" for backwards compatibility in %sini_parse_quantity_warnings.php on line 3
 
 Warning: Invalid quantity "256 then skip a few then g", interpreting as "256 g" for backwards compatibility in %sini_parse_quantity_warnings.php on line 4


### PR DESCRIPTION
Fixes tests and source that mentioned `multipler` with `multiplier`.
Related: #8454 