### PR TITLE
QA - pcntl_exec - check stringable parameters error

### DIFF
--- a/ext/pcntl/tests/pcntl_exec_004.phpt
+++ b/ext/pcntl/tests/pcntl_exec_004.phpt
@@ -1,0 +1,28 @@
+--TEST--
+pcntl_exec() - Testing error when non-stringable arguments are passed for $args and $env_vars.
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+if (!getenv("TEST_PHP_EXECUTABLE") || !is_executable(getenv("TEST_PHP_EXECUTABLE"))) die("skip TEST_PHP_EXECUTABLE not set");
+?>
+--FILE--
+<?php
+try {
+    pcntl_exec(getenv("TEST_PHP_EXECUTABLE"), ['-n', new stdClass()]);
+} catch (Error $error) {
+    echo $error->getMessage() . "\n";
+}
+
+try {
+    pcntl_exec(getenv("TEST_PHP_EXECUTABLE"), ['-n'], [new stdClass()]);
+} catch (Error $error) {
+    echo $error->getMessage() . "\n";
+}
+
+echo "ok\n";
+?>
+--EXPECT--
+Object of class stdClass could not be converted to string
+Object of class stdClass could not be converted to string
+ok

--- a/ext/pcntl/tests/pcntl_exec_004.phpt
+++ b/ext/pcntl/tests/pcntl_exec_004.phpt
@@ -19,10 +19,7 @@ try {
 } catch (Error $error) {
     echo $error->getMessage() . "\n";
 }
-
-echo "ok\n";
 ?>
 --EXPECT--
 Object of class stdClass could not be converted to string
 Object of class stdClass could not be converted to string
-ok


### PR DESCRIPTION
Moving forward on this trip to add more coverage to our code now this change is presented.

Extension: pcntl
Function: pcntl_exec

If non-stringable arguments are passed to $args or $env_vars then exception is thrown (Fatal Error).

Instead to let the error explote, I catched them, also to test that the kind of error generated can be catch.

I attach the coverage gained.

Before
![image](https://user-images.githubusercontent.com/25756860/178679971-cf2b8cee-940a-404c-9b52-91bd2881ad48.png)

After
![image](https://user-images.githubusercontent.com/25756860/178680115-1aa5b88c-8a3d-46e1-b015-33ef7b18f3aa.png)
