### PR TITLE
add SensitiveParameter as known string and use it in arginfo

### DIFF
--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -592,6 +592,7 @@ EMPTY_SWITCH_DEFAULT_CASE()
 	_(ZEND_STR_AUTOGLOBAL_ENV,         "_ENV") \
 	_(ZEND_STR_AUTOGLOBAL_REQUEST,     "_REQUEST") \
 	_(ZEND_STR_COUNT,                  "count") \
+	_(ZEND_STR_SENSITIVEPARAMETER,     "SensitiveParameter") \
 
 
 typedef enum _zend_known_string_id {

--- a/ext/ftp/ftp_arginfo.h
+++ b/ext/ftp/ftp_arginfo.h
@@ -295,9 +295,7 @@ static void register_ftp_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("FTP_MOREDATA", PHP_FTP_MOREDATA, CONST_CS | CONST_PERSISTENT);
 
 
-	zend_string *attribute_name_SensitiveParameter_ftp_login_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ftp_login", sizeof("ftp_login") - 1), 2, attribute_name_SensitiveParameter_ftp_login_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ftp_login_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ftp_login", sizeof("ftp_login") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_FTP_Connection(void)

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -215,33 +215,19 @@ static void register_hash_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("HASH_HMAC", PHP_HASH_HMAC, CONST_CS | CONST_PERSISTENT);
 
 
-	zend_string *attribute_name_SensitiveParameter_hash_hmac_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hmac", sizeof("hash_hmac") - 1), 2, attribute_name_SensitiveParameter_hash_hmac_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_hash_hmac_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hmac", sizeof("hash_hmac") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_hash_hmac_file_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hmac_file", sizeof("hash_hmac_file") - 1), 2, attribute_name_SensitiveParameter_hash_hmac_file_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_hash_hmac_file_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hmac_file", sizeof("hash_hmac_file") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_hash_init_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_init", sizeof("hash_init") - 1), 2, attribute_name_SensitiveParameter_hash_init_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_hash_init_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_init", sizeof("hash_init") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_hash_pbkdf2_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_pbkdf2", sizeof("hash_pbkdf2") - 1), 1, attribute_name_SensitiveParameter_hash_pbkdf2_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_hash_pbkdf2_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_pbkdf2", sizeof("hash_pbkdf2") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_hash_equals_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", sizeof("hash_equals") - 1), 0, attribute_name_SensitiveParameter_hash_equals_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_hash_equals_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", sizeof("hash_equals") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_hash_equals_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", sizeof("hash_equals") - 1), 1, attribute_name_SensitiveParameter_hash_equals_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_hash_equals_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_equals", sizeof("hash_equals") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_hash_hkdf_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hkdf", sizeof("hash_hkdf") - 1), 1, attribute_name_SensitiveParameter_hash_hkdf_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_hash_hkdf_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "hash_hkdf", sizeof("hash_hkdf") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_HashContext(void)

--- a/ext/imap/php_imap_arginfo.h
+++ b/ext/imap/php_imap_arginfo.h
@@ -596,9 +596,7 @@ static void register_php_imap_symbols(int module_number)
 	REGISTER_LONG_CONSTANT("IMAP_GC_TEXTS", GC_TEXTS, CONST_CS | CONST_PERSISTENT);
 
 
-	zend_string *attribute_name_SensitiveParameter_imap_open_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "imap_open", sizeof("imap_open") - 1), 2, attribute_name_SensitiveParameter_imap_open_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_imap_open_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "imap_open", sizeof("imap_open") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_IMAP_Connection(void)

--- a/ext/ldap/ldap_arginfo.h
+++ b/ext/ldap/ldap_arginfo.h
@@ -832,33 +832,21 @@ static void register_ldap_symbols(int module_number)
 
 #if defined(HAVE_ORALDAP)
 
-	zend_string *attribute_name_SensitiveParameter_ldap_connect_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_connect", sizeof("ldap_connect") - 1), 3, attribute_name_SensitiveParameter_ldap_connect_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ldap_connect_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_connect", sizeof("ldap_connect") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_string *attribute_name_SensitiveParameter_ldap_bind_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_bind", sizeof("ldap_bind") - 1), 2, attribute_name_SensitiveParameter_ldap_bind_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ldap_bind_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_bind", sizeof("ldap_bind") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_ldap_bind_ext_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_bind_ext", sizeof("ldap_bind_ext") - 1), 2, attribute_name_SensitiveParameter_ldap_bind_ext_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ldap_bind_ext_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_bind_ext", sizeof("ldap_bind_ext") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(HAVE_LDAP_SASL)
 
-	zend_string *attribute_name_SensitiveParameter_ldap_sasl_bind_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_sasl_bind", sizeof("ldap_sasl_bind") - 1), 2, attribute_name_SensitiveParameter_ldap_sasl_bind_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ldap_sasl_bind_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_sasl_bind", sizeof("ldap_sasl_bind") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(HAVE_LDAP_PASSWD)
 
-	zend_string *attribute_name_SensitiveParameter_ldap_exop_passwd_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_exop_passwd", sizeof("ldap_exop_passwd") - 1), 2, attribute_name_SensitiveParameter_ldap_exop_passwd_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ldap_exop_passwd_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_exop_passwd", sizeof("ldap_exop_passwd") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_ldap_exop_passwd_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_exop_passwd", sizeof("ldap_exop_passwd") - 1), 3, attribute_name_SensitiveParameter_ldap_exop_passwd_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ldap_exop_passwd_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ldap_exop_passwd", sizeof("ldap_exop_passwd") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 }
 

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1046,17 +1046,11 @@ static const zend_function_entry class_mysqli_sql_exception_methods[] = {
 static void register_mysqli_symbols(int module_number)
 {
 
-	zend_string *attribute_name_SensitiveParameter_mysqli_change_user_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_change_user", sizeof("mysqli_change_user") - 1), 2, attribute_name_SensitiveParameter_mysqli_change_user_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_mysqli_change_user_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_change_user", sizeof("mysqli_change_user") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_mysqli_connect_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_connect", sizeof("mysqli_connect") - 1), 2, attribute_name_SensitiveParameter_mysqli_connect_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_mysqli_connect_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_connect", sizeof("mysqli_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_mysqli_real_connect_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_real_connect", sizeof("mysqli_real_connect") - 1), 3, attribute_name_SensitiveParameter_mysqli_real_connect_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_mysqli_real_connect_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_real_connect", sizeof("mysqli_real_connect") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_mysqli_driver(void)
@@ -1210,21 +1204,13 @@ static zend_class_entry *register_class_mysqli(void)
 	zend_string_release(property_warning_count_name);
 
 
-	zend_string *attribute_name_SensitiveParameter_mysqli___construct_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__construct", sizeof("__construct") - 1), 2, attribute_name_SensitiveParameter_mysqli___construct_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_mysqli___construct_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__construct", sizeof("__construct") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_mysqli_change_user_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "change_user", sizeof("change_user") - 1), 1, attribute_name_SensitiveParameter_mysqli_change_user_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_mysqli_change_user_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "change_user", sizeof("change_user") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_mysqli_connect_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "connect", sizeof("connect") - 1), 2, attribute_name_SensitiveParameter_mysqli_connect_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_mysqli_connect_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "connect", sizeof("connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_mysqli_real_connect_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "real_connect", sizeof("real_connect") - 1), 2, attribute_name_SensitiveParameter_mysqli_real_connect_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_mysqli_real_connect_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "real_connect", sizeof("real_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	return class_entry;
 }

--- a/ext/oci8/oci8_arginfo.h
+++ b/ext/oci8/oci8_arginfo.h
@@ -802,29 +802,17 @@ static const zend_function_entry class_OCICollection_methods[] = {
 static void register_oci8_symbols(int module_number)
 {
 
-	zend_string *attribute_name_SensitiveParameter_oci_new_connect_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "oci_new_connect", sizeof("oci_new_connect") - 1), 1, attribute_name_SensitiveParameter_oci_new_connect_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_oci_new_connect_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "oci_new_connect", sizeof("oci_new_connect") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_ocinlogon_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ocinlogon", sizeof("ocinlogon") - 1), 1, attribute_name_SensitiveParameter_ocinlogon_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ocinlogon_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ocinlogon", sizeof("ocinlogon") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_oci_connect_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "oci_connect", sizeof("oci_connect") - 1), 1, attribute_name_SensitiveParameter_oci_connect_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_oci_connect_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "oci_connect", sizeof("oci_connect") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_ocilogon_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ocilogon", sizeof("ocilogon") - 1), 1, attribute_name_SensitiveParameter_ocilogon_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ocilogon_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ocilogon", sizeof("ocilogon") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_oci_pconnect_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "oci_pconnect", sizeof("oci_pconnect") - 1), 1, attribute_name_SensitiveParameter_oci_pconnect_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_oci_pconnect_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "oci_pconnect", sizeof("oci_pconnect") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_ociplogon_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ociplogon", sizeof("ociplogon") - 1), 1, attribute_name_SensitiveParameter_ociplogon_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ociplogon_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "ociplogon", sizeof("ociplogon") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_OCILob(void)

--- a/ext/odbc/odbc_arginfo.h
+++ b/ext/odbc/odbc_arginfo.h
@@ -395,11 +395,7 @@ static const zend_function_entry ext_functions[] = {
 static void register_odbc_symbols(int module_number)
 {
 
-	zend_string *attribute_name_SensitiveParameter_odbc_connect_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_connect", sizeof("odbc_connect") - 1), 2, attribute_name_SensitiveParameter_odbc_connect_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_odbc_connect_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_connect", sizeof("odbc_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_odbc_pconnect_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_pconnect", sizeof("odbc_pconnect") - 1), 2, attribute_name_SensitiveParameter_odbc_pconnect_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_odbc_pconnect_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "odbc_pconnect", sizeof("odbc_pconnect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -537,161 +537,83 @@ static const zend_function_entry class_OpenSSLAsymmetricKey_methods[] = {
 static void register_openssl_symbols(int module_number)
 {
 
-	zend_string *attribute_name_SensitiveParameter_openssl_x509_check_private_key_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_x509_check_private_key", sizeof("openssl_x509_check_private_key") - 1), 1, attribute_name_SensitiveParameter_openssl_x509_check_private_key_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_x509_check_private_key_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_x509_check_private_key", sizeof("openssl_x509_check_private_key") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkcs12_export_to_file_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", sizeof("openssl_pkcs12_export_to_file") - 1), 2, attribute_name_SensitiveParameter_openssl_pkcs12_export_to_file_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkcs12_export_to_file_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", sizeof("openssl_pkcs12_export_to_file") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkcs12_export_to_file_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", sizeof("openssl_pkcs12_export_to_file") - 1), 3, attribute_name_SensitiveParameter_openssl_pkcs12_export_to_file_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkcs12_export_to_file_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export_to_file", sizeof("openssl_pkcs12_export_to_file") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkcs12_export_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export", sizeof("openssl_pkcs12_export") - 1), 2, attribute_name_SensitiveParameter_openssl_pkcs12_export_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkcs12_export_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export", sizeof("openssl_pkcs12_export") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkcs12_export_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export", sizeof("openssl_pkcs12_export") - 1), 3, attribute_name_SensitiveParameter_openssl_pkcs12_export_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkcs12_export_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_export", sizeof("openssl_pkcs12_export") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkcs12_read_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_read", sizeof("openssl_pkcs12_read") - 1), 2, attribute_name_SensitiveParameter_openssl_pkcs12_read_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkcs12_read_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs12_read", sizeof("openssl_pkcs12_read") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_csr_sign_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_csr_sign", sizeof("openssl_csr_sign") - 1), 2, attribute_name_SensitiveParameter_openssl_csr_sign_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_csr_sign_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_csr_sign", sizeof("openssl_csr_sign") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_csr_new_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_csr_new", sizeof("openssl_csr_new") - 1), 1, attribute_name_SensitiveParameter_openssl_csr_new_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_csr_new_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_csr_new", sizeof("openssl_csr_new") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkey_export_to_file_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export_to_file", sizeof("openssl_pkey_export_to_file") - 1), 0, attribute_name_SensitiveParameter_openssl_pkey_export_to_file_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkey_export_to_file_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export_to_file", sizeof("openssl_pkey_export_to_file") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkey_export_to_file_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export_to_file", sizeof("openssl_pkey_export_to_file") - 1), 2, attribute_name_SensitiveParameter_openssl_pkey_export_to_file_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkey_export_to_file_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export_to_file", sizeof("openssl_pkey_export_to_file") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkey_export_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", sizeof("openssl_pkey_export") - 1), 0, attribute_name_SensitiveParameter_openssl_pkey_export_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkey_export_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", sizeof("openssl_pkey_export") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkey_export_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", sizeof("openssl_pkey_export") - 1), 2, attribute_name_SensitiveParameter_openssl_pkey_export_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkey_export_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_export", sizeof("openssl_pkey_export") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkey_get_private_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", sizeof("openssl_pkey_get_private") - 1), 0, attribute_name_SensitiveParameter_openssl_pkey_get_private_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkey_get_private_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", sizeof("openssl_pkey_get_private") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkey_get_private_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", sizeof("openssl_pkey_get_private") - 1), 1, attribute_name_SensitiveParameter_openssl_pkey_get_private_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkey_get_private_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_get_private", sizeof("openssl_pkey_get_private") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_get_privatekey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_get_privatekey", sizeof("openssl_get_privatekey") - 1), 0, attribute_name_SensitiveParameter_openssl_get_privatekey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_get_privatekey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_get_privatekey", sizeof("openssl_get_privatekey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_get_privatekey_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_get_privatekey", sizeof("openssl_get_privatekey") - 1), 1, attribute_name_SensitiveParameter_openssl_get_privatekey_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_get_privatekey_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_get_privatekey", sizeof("openssl_get_privatekey") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pbkdf2_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pbkdf2", sizeof("openssl_pbkdf2") - 1), 0, attribute_name_SensitiveParameter_openssl_pbkdf2_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pbkdf2_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pbkdf2", sizeof("openssl_pbkdf2") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkcs7_sign_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_sign", sizeof("openssl_pkcs7_sign") - 1), 3, attribute_name_SensitiveParameter_openssl_pkcs7_sign_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkcs7_sign_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_sign", sizeof("openssl_pkcs7_sign") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkcs7_decrypt_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_decrypt", sizeof("openssl_pkcs7_decrypt") - 1), 2, attribute_name_SensitiveParameter_openssl_pkcs7_decrypt_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkcs7_decrypt_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_decrypt", sizeof("openssl_pkcs7_decrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkcs7_decrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_decrypt", sizeof("openssl_pkcs7_decrypt") - 1), 3, attribute_name_SensitiveParameter_openssl_pkcs7_decrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkcs7_decrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkcs7_decrypt", sizeof("openssl_pkcs7_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_cms_sign_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_sign", sizeof("openssl_cms_sign") - 1), 3, attribute_name_SensitiveParameter_openssl_cms_sign_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_cms_sign_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_sign", sizeof("openssl_cms_sign") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_cms_decrypt_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_decrypt", sizeof("openssl_cms_decrypt") - 1), 2, attribute_name_SensitiveParameter_openssl_cms_decrypt_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_cms_decrypt_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_decrypt", sizeof("openssl_cms_decrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_cms_decrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_decrypt", sizeof("openssl_cms_decrypt") - 1), 3, attribute_name_SensitiveParameter_openssl_cms_decrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_cms_decrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_cms_decrypt", sizeof("openssl_cms_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_private_encrypt_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_encrypt", sizeof("openssl_private_encrypt") - 1), 0, attribute_name_SensitiveParameter_openssl_private_encrypt_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_private_encrypt_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_encrypt", sizeof("openssl_private_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_private_encrypt_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_encrypt", sizeof("openssl_private_encrypt") - 1), 2, attribute_name_SensitiveParameter_openssl_private_encrypt_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_private_encrypt_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_encrypt", sizeof("openssl_private_encrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_private_decrypt_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_decrypt", sizeof("openssl_private_decrypt") - 1), 1, attribute_name_SensitiveParameter_openssl_private_decrypt_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_private_decrypt_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_decrypt", sizeof("openssl_private_decrypt") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_private_decrypt_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_decrypt", sizeof("openssl_private_decrypt") - 1), 2, attribute_name_SensitiveParameter_openssl_private_decrypt_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_private_decrypt_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_private_decrypt", sizeof("openssl_private_decrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_public_encrypt_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_public_encrypt", sizeof("openssl_public_encrypt") - 1), 0, attribute_name_SensitiveParameter_openssl_public_encrypt_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_public_encrypt_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_public_encrypt", sizeof("openssl_public_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_public_decrypt_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_public_decrypt", sizeof("openssl_public_decrypt") - 1), 1, attribute_name_SensitiveParameter_openssl_public_decrypt_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_public_decrypt_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_public_decrypt", sizeof("openssl_public_decrypt") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_sign_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_sign", sizeof("openssl_sign") - 1), 2, attribute_name_SensitiveParameter_openssl_sign_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_sign_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_sign", sizeof("openssl_sign") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_seal_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_seal", sizeof("openssl_seal") - 1), 0, attribute_name_SensitiveParameter_openssl_seal_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_seal_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_seal", sizeof("openssl_seal") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_open_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_open", sizeof("openssl_open") - 1), 1, attribute_name_SensitiveParameter_openssl_open_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_open_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_open", sizeof("openssl_open") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_open_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_open", sizeof("openssl_open") - 1), 3, attribute_name_SensitiveParameter_openssl_open_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_open_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_open", sizeof("openssl_open") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_encrypt_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_encrypt", sizeof("openssl_encrypt") - 1), 0, attribute_name_SensitiveParameter_openssl_encrypt_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_encrypt_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_encrypt", sizeof("openssl_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_encrypt_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_encrypt", sizeof("openssl_encrypt") - 1), 2, attribute_name_SensitiveParameter_openssl_encrypt_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_encrypt_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_encrypt", sizeof("openssl_encrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_decrypt_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_decrypt", sizeof("openssl_decrypt") - 1), 2, attribute_name_SensitiveParameter_openssl_decrypt_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_decrypt_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_decrypt", sizeof("openssl_decrypt") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_dh_compute_key_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_dh_compute_key", sizeof("openssl_dh_compute_key") - 1), 1, attribute_name_SensitiveParameter_openssl_dh_compute_key_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_dh_compute_key_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_dh_compute_key", sizeof("openssl_dh_compute_key") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_pkey_derive_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_derive", sizeof("openssl_pkey_derive") - 1), 1, attribute_name_SensitiveParameter_openssl_pkey_derive_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_pkey_derive_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_pkey_derive", sizeof("openssl_pkey_derive") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_openssl_spki_new_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_spki_new", sizeof("openssl_spki_new") - 1), 0, attribute_name_SensitiveParameter_openssl_spki_new_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_openssl_spki_new_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "openssl_spki_new", sizeof("openssl_spki_new") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_OpenSSLCertificate(void)

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -104,9 +104,7 @@ static zend_class_entry *register_class_PDO(void)
 	class_entry->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
 
 
-	zend_string *attribute_name_SensitiveParameter_PDO___construct_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__construct", sizeof("__construct") - 1), 2, attribute_name_SensitiveParameter_PDO___construct_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_PDO___construct_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "__construct", sizeof("__construct") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	return class_entry;
 }

--- a/ext/sodium/libsodium_arginfo.h
+++ b/ext/sodium/libsodium_arginfo.h
@@ -888,332 +888,186 @@ static void register_libsodium_symbols(int module_number)
 {
 #if defined(HAVE_AESGCM)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_decrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_decrypt", sizeof("sodium_crypto_aead_aes256gcm_decrypt") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_decrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_decrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_decrypt", sizeof("sodium_crypto_aead_aes256gcm_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(HAVE_AESGCM)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_encrypt_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_encrypt_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_encrypt_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_encrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_encrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_aes256gcm_encrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_decrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_decrypt", sizeof("sodium_crypto_aead_chacha20poly1305_decrypt") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_decrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_decrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_decrypt", sizeof("sodium_crypto_aead_chacha20poly1305_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_encrypt_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_encrypt") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_encrypt_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_encrypt_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_encrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_encrypt") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_encrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_encrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_decrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_decrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_decrypt") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_decrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_decrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_decrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_encrypt_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_encrypt") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_encrypt_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_encrypt_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_encrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_encrypt") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_encrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_chacha20poly1305_ietf_encrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_chacha20poly1305_ietf_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_decrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_decrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_decrypt") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_decrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_decrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_decrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_aead_xchacha20poly1305_IETF_NPUBBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_encrypt_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_encrypt_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_encrypt_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_encrypt_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_encrypt_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_aead_xchacha20poly1305_ietf_encrypt_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_xchacha20poly1305_ietf_encrypt", sizeof("sodium_crypto_aead_xchacha20poly1305_ietf_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_auth_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_auth", sizeof("sodium_crypto_auth") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_auth_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_auth_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_auth", sizeof("sodium_crypto_auth") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_auth_verify_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_auth_verify", sizeof("sodium_crypto_auth_verify") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_auth_verify_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_auth_verify_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_auth_verify", sizeof("sodium_crypto_auth_verify") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box", sizeof("sodium_crypto_box") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_box_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box", sizeof("sodium_crypto_box") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box", sizeof("sodium_crypto_box") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_box_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box", sizeof("sodium_crypto_box") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_seed_keypair_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seed_keypair", sizeof("sodium_crypto_box_seed_keypair") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_box_seed_keypair_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_seed_keypair_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seed_keypair", sizeof("sodium_crypto_box_seed_keypair") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_keypair_from_secretkey_and_publickey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_keypair_from_secretkey_and_publickey", sizeof("sodium_crypto_box_keypair_from_secretkey_and_publickey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_box_keypair_from_secretkey_and_publickey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_keypair_from_secretkey_and_publickey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_keypair_from_secretkey_and_publickey", sizeof("sodium_crypto_box_keypair_from_secretkey_and_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_open_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_open", sizeof("sodium_crypto_box_open") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_box_open_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_open_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_open", sizeof("sodium_crypto_box_open") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_publickey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_publickey", sizeof("sodium_crypto_box_publickey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_box_publickey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_publickey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_publickey", sizeof("sodium_crypto_box_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_publickey_from_secretkey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_publickey_from_secretkey", sizeof("sodium_crypto_box_publickey_from_secretkey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_box_publickey_from_secretkey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_publickey_from_secretkey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_publickey_from_secretkey", sizeof("sodium_crypto_box_publickey_from_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_seal_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seal", sizeof("sodium_crypto_box_seal") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_box_seal_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_seal_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seal", sizeof("sodium_crypto_box_seal") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_seal_open_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seal_open", sizeof("sodium_crypto_box_seal_open") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_box_seal_open_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_seal_open_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_seal_open", sizeof("sodium_crypto_box_seal_open") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_box_secretkey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_secretkey", sizeof("sodium_crypto_box_secretkey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_box_secretkey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_box_secretkey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_box_secretkey", sizeof("sodium_crypto_box_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_kx_publickey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_publickey", sizeof("sodium_crypto_kx_publickey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_kx_publickey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_kx_publickey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_publickey", sizeof("sodium_crypto_kx_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_kx_secretkey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_secretkey", sizeof("sodium_crypto_kx_secretkey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_kx_secretkey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_kx_secretkey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_secretkey", sizeof("sodium_crypto_kx_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_kx_seed_keypair_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_seed_keypair", sizeof("sodium_crypto_kx_seed_keypair") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_kx_seed_keypair_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_kx_seed_keypair_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_seed_keypair", sizeof("sodium_crypto_kx_seed_keypair") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_kx_client_session_keys_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_client_session_keys", sizeof("sodium_crypto_kx_client_session_keys") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_kx_client_session_keys_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_kx_client_session_keys_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_client_session_keys", sizeof("sodium_crypto_kx_client_session_keys") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_kx_server_session_keys_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_server_session_keys", sizeof("sodium_crypto_kx_server_session_keys") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_kx_server_session_keys_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_kx_server_session_keys_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kx_server_session_keys", sizeof("sodium_crypto_kx_server_session_keys") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_generichash_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_generichash", sizeof("sodium_crypto_generichash") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_generichash_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_generichash_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_generichash", sizeof("sodium_crypto_generichash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_generichash_init_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_generichash_init", sizeof("sodium_crypto_generichash_init") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_generichash_init_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_generichash_init_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_generichash_init", sizeof("sodium_crypto_generichash_init") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_kdf_derive_from_key_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kdf_derive_from_key", sizeof("sodium_crypto_kdf_derive_from_key") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_kdf_derive_from_key_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_kdf_derive_from_key_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_kdf_derive_from_key", sizeof("sodium_crypto_kdf_derive_from_key") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(crypto_pwhash_SALTBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_pwhash_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash", sizeof("sodium_crypto_pwhash") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_pwhash_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_pwhash_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash", sizeof("sodium_crypto_pwhash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_pwhash_SALTBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_pwhash_str_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str", sizeof("sodium_crypto_pwhash_str") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_pwhash_str_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_pwhash_str_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str", sizeof("sodium_crypto_pwhash_str") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_pwhash_SALTBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_pwhash_str_verify_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str_verify", sizeof("sodium_crypto_pwhash_str_verify") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_pwhash_str_verify_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_pwhash_str_verify_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_str_verify", sizeof("sodium_crypto_pwhash_str_verify") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_str_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256_str") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_str_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_str_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256_str") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_str_verify_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str_verify", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256_str_verify") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_str_verify_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_pwhash_scryptsalsa208sha256_str_verify_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_pwhash_scryptsalsa208sha256_str_verify", sizeof("sodium_crypto_pwhash_scryptsalsa208sha256_str_verify") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_secretbox_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox", sizeof("sodium_crypto_secretbox") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_secretbox_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_secretbox_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox", sizeof("sodium_crypto_secretbox") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_secretbox_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox", sizeof("sodium_crypto_secretbox") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_secretbox_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_secretbox_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox", sizeof("sodium_crypto_secretbox") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_secretbox_open_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox_open", sizeof("sodium_crypto_secretbox_open") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_secretbox_open_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_secretbox_open_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretbox_open", sizeof("sodium_crypto_secretbox_open") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_init_push_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_push", sizeof("sodium_crypto_secretstream_xchacha20poly1305_init_push") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_init_push_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_init_push_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_push", sizeof("sodium_crypto_secretstream_xchacha20poly1305_init_push") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_push_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_push", sizeof("sodium_crypto_secretstream_xchacha20poly1305_push") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_push_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_push_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_push", sizeof("sodium_crypto_secretstream_xchacha20poly1305_push") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_secretstream_xchacha20poly1305_ABYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_init_pull_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_pull", sizeof("sodium_crypto_secretstream_xchacha20poly1305_init_pull") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_init_pull_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_secretstream_xchacha20poly1305_init_pull_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_secretstream_xchacha20poly1305_init_pull", sizeof("sodium_crypto_secretstream_xchacha20poly1305_init_pull") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_shorthash_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_shorthash", sizeof("sodium_crypto_shorthash") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_shorthash_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_shorthash_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_shorthash", sizeof("sodium_crypto_shorthash") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_sign_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign", sizeof("sodium_crypto_sign") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_sign_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_sign_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign", sizeof("sodium_crypto_sign") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_sign_detached_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_detached", sizeof("sodium_crypto_sign_detached") - 1), 1, attribute_name_SensitiveParameter_sodium_crypto_sign_detached_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_sign_detached_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_detached", sizeof("sodium_crypto_sign_detached") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_sign_ed25519_sk_to_curve25519_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_ed25519_sk_to_curve25519", sizeof("sodium_crypto_sign_ed25519_sk_to_curve25519") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_sign_ed25519_sk_to_curve25519_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_sign_ed25519_sk_to_curve25519_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_ed25519_sk_to_curve25519", sizeof("sodium_crypto_sign_ed25519_sk_to_curve25519") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_sign_keypair_from_secretkey_and_publickey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_keypair_from_secretkey_and_publickey", sizeof("sodium_crypto_sign_keypair_from_secretkey_and_publickey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_sign_keypair_from_secretkey_and_publickey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_sign_keypair_from_secretkey_and_publickey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_keypair_from_secretkey_and_publickey", sizeof("sodium_crypto_sign_keypair_from_secretkey_and_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_sign_publickey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_publickey", sizeof("sodium_crypto_sign_publickey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_sign_publickey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_sign_publickey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_publickey", sizeof("sodium_crypto_sign_publickey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_sign_secretkey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_secretkey", sizeof("sodium_crypto_sign_secretkey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_sign_secretkey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_sign_secretkey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_secretkey", sizeof("sodium_crypto_sign_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_sign_publickey_from_secretkey_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_publickey_from_secretkey", sizeof("sodium_crypto_sign_publickey_from_secretkey") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_sign_publickey_from_secretkey_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_sign_publickey_from_secretkey_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_publickey_from_secretkey", sizeof("sodium_crypto_sign_publickey_from_secretkey") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_sign_seed_keypair_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_seed_keypair", sizeof("sodium_crypto_sign_seed_keypair") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_sign_seed_keypair_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_sign_seed_keypair_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_sign_seed_keypair", sizeof("sodium_crypto_sign_seed_keypair") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_stream_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream", sizeof("sodium_crypto_stream") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_stream_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_stream_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream", sizeof("sodium_crypto_stream") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_stream_xor_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xor", sizeof("sodium_crypto_stream_xor") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_stream_xor_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_stream_xor_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xor", sizeof("sodium_crypto_stream_xor") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_stream_xor_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xor", sizeof("sodium_crypto_stream_xor") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_stream_xor_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_stream_xor_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xor", sizeof("sodium_crypto_stream_xor") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(crypto_stream_xchacha20_KEYBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20", sizeof("sodium_crypto_stream_xchacha20") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20", sizeof("sodium_crypto_stream_xchacha20") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_stream_xchacha20_KEYBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", sizeof("sodium_crypto_stream_xchacha20_xor") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", sizeof("sodium_crypto_stream_xchacha20_xor") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", sizeof("sodium_crypto_stream_xchacha20_xor") - 1), 2, attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor", sizeof("sodium_crypto_stream_xchacha20_xor") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(crypto_stream_xchacha20_KEYBYTES)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_ic_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", sizeof("sodium_crypto_stream_xchacha20_xor_ic") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_ic_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_ic_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", sizeof("sodium_crypto_stream_xchacha20_xor_ic") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_ic_arg3 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", sizeof("sodium_crypto_stream_xchacha20_xor_ic") - 1), 3, attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_ic_arg3, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_stream_xchacha20_xor_ic_arg3);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_stream_xchacha20_xor_ic", sizeof("sodium_crypto_stream_xchacha20_xor_ic") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_string *attribute_name_SensitiveParameter_sodium_compare_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_compare", sizeof("sodium_compare") - 1), 0, attribute_name_SensitiveParameter_sodium_compare_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_compare_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_compare", sizeof("sodium_compare") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_compare_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_compare", sizeof("sodium_compare") - 1), 1, attribute_name_SensitiveParameter_sodium_compare_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_compare_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_compare", sizeof("sodium_compare") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_memcmp_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memcmp", sizeof("sodium_memcmp") - 1), 0, attribute_name_SensitiveParameter_sodium_memcmp_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_memcmp_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memcmp", sizeof("sodium_memcmp") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_memcmp_arg1 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memcmp", sizeof("sodium_memcmp") - 1), 1, attribute_name_SensitiveParameter_sodium_memcmp_arg1, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_memcmp_arg1);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memcmp", sizeof("sodium_memcmp") - 1), 1, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_memzero_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memzero", sizeof("sodium_memzero") - 1), 0, attribute_name_SensitiveParameter_sodium_memzero_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_memzero_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_memzero", sizeof("sodium_memzero") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_pad_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_pad", sizeof("sodium_pad") - 1), 0, attribute_name_SensitiveParameter_sodium_pad_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_pad_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_pad", sizeof("sodium_pad") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_unpad_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_unpad", sizeof("sodium_unpad") - 1), 0, attribute_name_SensitiveParameter_sodium_unpad_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_unpad_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_unpad", sizeof("sodium_unpad") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_bin2hex_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2hex", sizeof("sodium_bin2hex") - 1), 0, attribute_name_SensitiveParameter_sodium_bin2hex_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_bin2hex_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2hex", sizeof("sodium_bin2hex") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_sodium_hex2bin_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_hex2bin", sizeof("sodium_hex2bin") - 1), 0, attribute_name_SensitiveParameter_sodium_hex2bin_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_hex2bin_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_hex2bin", sizeof("sodium_hex2bin") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(sodium_base64_VARIANT_ORIGINAL)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_bin2base64_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2base64", sizeof("sodium_bin2base64") - 1), 0, attribute_name_SensitiveParameter_sodium_bin2base64_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_bin2base64_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_bin2base64", sizeof("sodium_bin2base64") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(sodium_base64_VARIANT_ORIGINAL)
 
-	zend_string *attribute_name_SensitiveParameter_sodium_base642bin_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_base642bin", sizeof("sodium_base642bin") - 1), 0, attribute_name_SensitiveParameter_sodium_base642bin_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_base642bin_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_base642bin", sizeof("sodium_base642bin") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
-	zend_string *attribute_name_SensitiveParameter_sodium_crypto_scalarmult_base_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_scalarmult_base", sizeof("sodium_crypto_scalarmult_base") - 1), 0, attribute_name_SensitiveParameter_sodium_crypto_scalarmult_base_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_sodium_crypto_scalarmult_base_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_scalarmult_base", sizeof("sodium_crypto_scalarmult_base") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class_SodiumException(zend_class_entry *class_entry_Exception)

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -3532,13 +3532,9 @@ static void register_basic_functions_symbols(int module_number)
 	ZEND_ASSERT(M_E == 2.7182818284590451);
 
 
-	zend_string *attribute_name_SensitiveParameter_password_hash_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_hash", sizeof("password_hash") - 1), 0, attribute_name_SensitiveParameter_password_hash_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_password_hash_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_hash", sizeof("password_hash") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
-	zend_string *attribute_name_SensitiveParameter_password_verify_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_verify", sizeof("password_verify") - 1), 0, attribute_name_SensitiveParameter_password_verify_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_password_verify_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "password_verify", sizeof("password_verify") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 }
 
 static zend_class_entry *register_class___PHP_Incomplete_Class(void)

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -531,20 +531,14 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zend_string_release(property_comment_name);
 
 
-	zend_string *attribute_name_SensitiveParameter_ZipArchive_setPassword_arg0 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setpassword", sizeof("setpassword") - 1), 0, attribute_name_SensitiveParameter_ZipArchive_setPassword_arg0, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ZipArchive_setPassword_arg0);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setpassword", sizeof("setpassword") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #if defined(HAVE_ENCRYPTION)
 
-	zend_string *attribute_name_SensitiveParameter_ZipArchive_setEncryptionName_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionname", sizeof("setencryptionname") - 1), 2, attribute_name_SensitiveParameter_ZipArchive_setEncryptionName_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ZipArchive_setEncryptionName_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionname", sizeof("setencryptionname") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 #if defined(HAVE_ENCRYPTION)
 
-	zend_string *attribute_name_SensitiveParameter_ZipArchive_setEncryptionIndex_arg2 = zend_string_init("SensitiveParameter", sizeof("SensitiveParameter") - 1, 1);
-	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionindex", sizeof("setencryptionindex") - 1), 2, attribute_name_SensitiveParameter_ZipArchive_setEncryptionIndex_arg2, 0);
-	zend_string_release(attribute_name_SensitiveParameter_ZipArchive_setEncryptionIndex_arg2);
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "setencryptionindex", sizeof("setencryptionindex") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
 	return class_entry;


### PR DESCRIPTION
Following PR #8836 

To avoid so much (148)  init / release of the same string

notice, perhaps some others may be added later (AllowDynamicProperties only used 2 or Attribute only used in zend_test...)
