### PR TITLE
QA - pcntl_getpriority_error.phpt - fix test context information and case

### DIFF
--- a/ext/pcntl/tests/pcntl_getpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_getpriority_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-pcntl_getpriority() - Wrong process identifier
+pcntl_getpriority() - Wrong mode passed
 --EXTENSIONS--
 pcntl
 --SKIPIF--
@@ -13,7 +13,7 @@ if (!function_exists('pcntl_getpriority')) {
 <?php
 
 try {
-    pcntl_getpriority(null, 42);
+    pcntl_getpriority(null, (PRIO_PGRP - PRIO_USER - PRIO_PROCESS));
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }

--- a/ext/pcntl/tests/pcntl_getpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_getpriority_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-pcntl_getpriority() - Wrong mode passed
+pcntl_getpriority() - Wrong mode passed and also for non existing process id provided
 --EXTENSIONS--
 pcntl
 --SKIPIF--
@@ -18,6 +18,10 @@ try {
     echo $exception->getMessage() . "\n";
 }
 
+pcntl_getpriority(-123);
+
 ?>
---EXPECT--
+--EXPECTF--
 pcntl_getpriority(): Argument #2 ($mode) must be one of PRIO_PGRP, PRIO_USER, or PRIO_PROCESS
+
+Warning: pcntl_getpriority(): Error 3: No process was located using the given parameters in %s


### PR DESCRIPTION
I changed an existing test as the information inside it is not accurate with what the test is testing.

Also added on more case for non-existing process id provided, in order to add more coverage also like image below shows

![image](https://user-images.githubusercontent.com/25756860/178697836-60839786-144d-47fc-8943-f32d6c949b6c.png)
