### PR TITLE
QA - pcntl_setpriority() - adjust error/code coverage

### DIFF
--- a/ext/pcntl/tests/pcntl_setpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-pcntl_setpriority() - Wrong process identifier
+pcntl_setpriority() - check for errors
 --EXTENSIONS--
 pcntl
 --SKIPIF--
@@ -12,12 +12,22 @@ if (!function_exists('pcntl_setpriority')) {
 --FILE--
 <?php
 
+$result = true;
 try {
-    pcntl_setpriority(0, null, 42);
+    $result = pcntl_setpriority(0, null, (PRIO_PGRP - PRIO_USER - PRIO_PROCESS));
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
+var_dump($result);
 
+pcntl_setpriority(0, -123);
+
+pcntl_setpriority(0, 1);
 ?>
---EXPECT--
+--EXPECTF--
 pcntl_setpriority(): Argument #3 ($mode) must be one of PRIO_PGRP, PRIO_USER, or PRIO_PROCESS
+bool(true)
+
+Warning: pcntl_setpriority(): Error 3: No process was located using the given parameters in %s
+
+Warning: pcntl_setpriority(): Error 1: A process was located, but neither its effective nor real user ID matched the effective user ID of the caller in %s


### PR DESCRIPTION
I changed the existing test that checks for errors on the pcntl_setpriority() function.

Extension: pcntl
Function: pcntl_setpriority

Also code coverage was improved.

Before
![image](https://user-images.githubusercontent.com/25756860/178703820-6bc6d4f4-6368-4ac4-8314-a2a13e88ee30.png)

After
![image](https://user-images.githubusercontent.com/25756860/178704116-3757c9a8-945f-4669-99bc-1cbc0da434b2.png)
