### PR TITLE
Fix `WeakMap` object reference offset causing `TypeError`

### DIFF
--- a/Zend/tests/weakrefs/weakmap_object_reference.phpt
+++ b/Zend/tests/weakrefs/weakmap_object_reference.phpt
@@ -1,0 +1,32 @@
+--TEST--
+WeakMap object reference offset
+--FILE--
+<?php
+
+$map = new WeakMap;
+$obj = new stdClass;
+$obj2 = &$obj;
+
+$map[$obj] = 1;
+var_dump(count($map));
+var_dump($map);
+var_dump(isset($map[$obj]));
+var_dump(!empty($map[$obj]));
+var_dump($map[$obj]);
+
+?>
+--EXPECT--
+int(1)
+object(WeakMap)#1 (1) {
+  [0]=>
+  array(2) {
+    ["key"]=>
+    object(stdClass)#2 (0) {
+    }
+    ["value"]=>
+    int(1)
+  }
+}
+bool(true)
+bool(true)
+int(1)

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -310,9 +310,7 @@ static zval *zend_weakmap_read_dimension(zend_object *object, zval *offset, int 
 		return NULL;
 	}
 
-	if (Z_ISREF_P(offset)) {
-		offset = Z_REFVAL_P(offset);
-	}
+	ZVAL_DEREF(offset);
 	if (Z_TYPE_P(offset) != IS_OBJECT) {
 		zend_type_error("WeakMap key must be an object");
 		return NULL;
@@ -343,9 +341,7 @@ static void zend_weakmap_write_dimension(zend_object *object, zval *offset, zval
 		return;
 	}
 
-	if (Z_ISREF_P(offset)) {
-		offset = Z_REFVAL_P(offset);
-	}
+	ZVAL_DEREF(offset);
 	if (Z_TYPE_P(offset) != IS_OBJECT) {
 		zend_type_error("WeakMap key must be an object");
 		return;
@@ -373,9 +369,7 @@ static void zend_weakmap_write_dimension(zend_object *object, zval *offset, zval
 /* int return and check_empty due to Object Handler API */
 static int zend_weakmap_has_dimension(zend_object *object, zval *offset, int check_empty)
 {
-	if (Z_ISREF_P(offset)) {
-		offset = Z_REFVAL_P(offset);
-	}
+	ZVAL_DEREF(offset);
 	if (Z_TYPE_P(offset) != IS_OBJECT) {
 		zend_type_error("WeakMap key must be an object");
 		return 0;
@@ -395,9 +389,7 @@ static int zend_weakmap_has_dimension(zend_object *object, zval *offset, int che
 
 static void zend_weakmap_unset_dimension(zend_object *object, zval *offset)
 {
-	if (Z_ISREF_P(offset)) {
-		offset = Z_REFVAL_P(offset);
-	}
+	ZVAL_DEREF(offset);
 	if (Z_TYPE_P(offset) != IS_OBJECT) {
 		zend_type_error("WeakMap key must be an object");
 		return;

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -310,6 +310,9 @@ static zval *zend_weakmap_read_dimension(zend_object *object, zval *offset, int 
 		return NULL;
 	}
 
+	if (Z_ISREF_P(offset)) {
+		offset = Z_REFVAL_P(offset);
+	}
 	if (Z_TYPE_P(offset) != IS_OBJECT) {
 		zend_type_error("WeakMap key must be an object");
 		return NULL;
@@ -340,6 +343,9 @@ static void zend_weakmap_write_dimension(zend_object *object, zval *offset, zval
 		return;
 	}
 
+	if (Z_ISREF_P(offset)) {
+		offset = Z_REFVAL_P(offset);
+	}
 	if (Z_TYPE_P(offset) != IS_OBJECT) {
 		zend_type_error("WeakMap key must be an object");
 		return;
@@ -367,6 +373,9 @@ static void zend_weakmap_write_dimension(zend_object *object, zval *offset, zval
 /* int return and check_empty due to Object Handler API */
 static int zend_weakmap_has_dimension(zend_object *object, zval *offset, int check_empty)
 {
+	if (Z_ISREF_P(offset)) {
+		offset = Z_REFVAL_P(offset);
+	}
 	if (Z_TYPE_P(offset) != IS_OBJECT) {
 		zend_type_error("WeakMap key must be an object");
 		return 0;
@@ -386,6 +395,9 @@ static int zend_weakmap_has_dimension(zend_object *object, zval *offset, int che
 
 static void zend_weakmap_unset_dimension(zend_object *object, zval *offset)
 {
+	if (Z_ISREF_P(offset)) {
+		offset = Z_REFVAL_P(offset);
+	}
 	if (Z_TYPE_P(offset) != IS_OBJECT) {
 		zend_type_error("WeakMap key must be an object");
 		return;


### PR DESCRIPTION
Fix `TypeError` when using object reference as `WeakMap` offset.

```php
$a = new stdClass();
$b = &$a;
$map = new WeakMap();
$map[$a] = true;
```
```
Fatal error: Uncaught TypeError: WeakMap key must be an object
```
