### PR TITLE
Fix GH-8699: ini_get() opcache optimization in 8.1

### DIFF
--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -900,27 +900,6 @@ static inline int ct_eval_func_call(
 
 			ZVAL_LONG(result, zend_hash_num_elements(Z_ARRVAL_P(args[0])));
 			return SUCCESS;
-		} else if (zend_string_equals_literal(name, "ini_get")) {
-			zend_ini_entry *ini_entry;
-
-			if (Z_TYPE_P(args[0]) != IS_STRING) {
-				return FAILURE;
-			}
-
-			ini_entry = zend_hash_find_ptr(EG(ini_directives), Z_STR_P(args[0]));
-			if (!ini_entry) {
-				if (PG(enable_dl)) {
-					return FAILURE;
-				}
-				ZVAL_FALSE(result);
-			} else if (ini_entry->modifiable != ZEND_INI_SYSTEM) {
-				return FAILURE;
-			} else if (ini_entry->value) {
-				ZVAL_STR_COPY(result, ini_entry->value);
-			} else {
-				ZVAL_EMPTY_STRING(result);
-			}
-			return SUCCESS;
 		}
 	}
 

--- a/Zend/tests/gh8699/1.php
+++ b/Zend/tests/gh8699/1.php
@@ -1,0 +1,3 @@
+<?php
+echo '1: ' . ini_get('upload_tmp_dir') . PHP_EOL;
+include __DIR__ . '/shared.php';

--- a/Zend/tests/gh8699/2.php
+++ b/Zend/tests/gh8699/2.php
@@ -1,0 +1,3 @@
+<?php
+echo '2: ' . ini_get('upload_tmp_dir') . PHP_EOL;
+include __DIR__ . '/shared.php';

--- a/Zend/tests/gh8699/gh8699.phpt
+++ b/Zend/tests/gh8699/gh8699.phpt
@@ -1,0 +1,51 @@
+--TEST--
+GH-8699:Wrong value from ini_get() for shared files because of opcache optimization
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_cache={PWD}/cache
+opcache.file_cache_only=1
+opcache.jit=0
+--FILE--
+<?php
+$php = getenv('TEST_PHP_EXECUTABLE');
+$extraArgs = getenv('TEST_PHP_EXTRA_ARGS');
+$pwd = __DIR__;
+
+if (strpos($extraArgs, 'opcache.so') === false) {
+    $opcacheFile = dirname($php, 3) . '/modules/opcache.so';
+    $extraArgs = "-dzend_extension=$opcacheFile $extraArgs";
+}
+
+$cmd1 = "$php $extraArgs -d \"upload_tmp_dir=/tmp/num1\" " . __DIR__ . '/1.php';
+$cmd2 = "$php $extraArgs -d \"upload_tmp_dir=/tmp/num2\" " . __DIR__ . '/2.php';
+
+passthru($cmd1);
+passthru($cmd2);
+
+// Make sure we actually used the opcache
+$pattern = __DIR__ . '/cache/*' . str_replace(':', '', __DIR__) . '/shared.php.bin';
+$cachedFiles = glob($pattern);
+if (count($cachedFiles) !== 1) {
+    echo "Opcache did not cache the shared php file\n";
+}
+--CLEAN--
+<?php
+$pattern = __DIR__ . '/cache/*' . str_replace(':', '', __DIR__) . '/*.php.bin';
+foreach (glob($pattern) as $p) {
+    unlink($p);
+}
+
+$dir = glob(__DIR__ . '/cache/*' . str_replace(':', '', __DIR__))[0] ?? null;
+if ($dir ) {
+    $baseLen = strlen(__DIR__ . '/cache');
+    while(strlen($dir) > $baseLen) {
+        rmdir($dir);
+        $dir = dirname($dir);
+    }
+}
+--EXPECT--
+1: /tmp/num1
+shared: /tmp/num1
+2: /tmp/num2
+shared: /tmp/num2

--- a/Zend/tests/gh8699/shared.php
+++ b/Zend/tests/gh8699/shared.php
@@ -1,0 +1,2 @@
+<?php
+echo 'shared: ' . ini_get('upload_tmp_dir') . PHP_EOL;


### PR DESCRIPTION
This fixes #8699 for PHP-8.1.
Can also be used for 8.0 and 7.4.

For 8.2, the problematic code has been moved to [zend_optimizer.c](https://github.com/php/php-src/blob/master/Zend/Optimizer/zend_optimizer.c#L184-L199).
