### PR TITLE
QA - pcntl_unshare - error handling

### DIFF
--- a/ext/pcntl/tests/pcntl_unshare_04.phpt
+++ b/ext/pcntl/tests/pcntl_unshare_04.phpt
@@ -22,7 +22,7 @@ var_dump($result);
 foreach ([CLONE_NEWNS, CLONE_NEWIPC , CLONE_NEWUTS , CLONE_NEWNET, CLONE_NEWPID ,CLONE_NEWUSER, CLONE_NEWCGROUP] as $flag) {
     $result = @pcntl_unshare($flag);
     var_dump($result);
-    $result = NULL;
+    $result = null;
 }
 
 ?>

--- a/ext/pcntl/tests/pcntl_unshare_04.phpt
+++ b/ext/pcntl/tests/pcntl_unshare_04.phpt
@@ -1,8 +1,7 @@
 --TEST--
-pcntl_unshare() with wrong flag
+pcntl_unshare() - Error with wrong flag. Test return value type for each valid flag.
 --EXTENSIONS--
 pcntl
-posix
 --SKIPIF--
 <?php
 if (!function_exists("pcntl_unshare")) die("skip pcntl_unshare is not available");
@@ -10,12 +9,29 @@ if (!function_exists("pcntl_unshare")) die("skip pcntl_unshare is not available"
 --FILE--
 <?php
 
+$result = null;
+
 try {
-    pcntl_unshare(42);
+    $result = pcntl_unshare(-1);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
+var_dump($result);
+
+foreach ([CLONE_NEWNS, CLONE_NEWIPC , CLONE_NEWUTS , CLONE_NEWNET, CLONE_NEWPID ,CLONE_NEWUSER, CLONE_NEWCGROUP] as $flag) {
+    $result = @pcntl_unshare($flag);
+    var_dump($result);
+}
+
 ?>
---EXPECT--
+--EXPECTF--
 pcntl_unshare(): Argument #1 ($flags) must be a combination of CLONE_* flags
+NULL
+bool(%s)
+bool(%s)
+bool(%s)
+bool(%s)
+bool(%s)
+bool(%s)
+bool(%s)

--- a/ext/pcntl/tests/pcntl_unshare_04.phpt
+++ b/ext/pcntl/tests/pcntl_unshare_04.phpt
@@ -22,6 +22,7 @@ var_dump($result);
 foreach ([CLONE_NEWNS, CLONE_NEWIPC , CLONE_NEWUTS , CLONE_NEWNET, CLONE_NEWPID ,CLONE_NEWUSER, CLONE_NEWCGROUP] as $flag) {
     $result = @pcntl_unshare($flag);
     var_dump($result);
+    $result = NULL;
 }
 
 ?>


### PR DESCRIPTION
Better check for errors in test, specially testing when should we expect a return value and when not.

This is very Operating System related, locally for me in Linux improved the code coverage also, but at the end depends on the host machine settings.

What I can say about this code is that the intention behind it is to better cover what is expected to do according to the documentation (Even though  ... I can always be wrong :D )

Thanks a lot for reviewing it.

PD: By the way ... I used the error suppression "@" operad on purpose because testing for error messages is hosting OS specific, that is why I focused