### PR TITLE
QA - pcntl_alarm - adjust current test

### DIFF
--- a/ext/pcntl/tests/pcntl_alarm.phpt
+++ b/ext/pcntl/tests/pcntl_alarm.phpt
@@ -3,20 +3,25 @@ pcntl_alarm()
 --EXTENSIONS--
 pcntl
 --SKIPIF--
-<?php if (!function_exists("pcntl_sigtimedwait")) die("skip pcntl_sigtimedwait() not available"); ?>
+<?php
+    if (!function_exists("pcntl_sigtimedwait")) die("skip pcntl_sigtimedwait() not available");
+    if (!function_exists("pcntl_alarm")) die("skip pcntl_alarm() not available");
+    if (!function_exists("pcntl_signal")) die("skip pcntl_signal() not available");
+?>
 --INI--
-max_execution_time=0
+max_execution_time=3
 --FILE--
 <?php
 pcntl_signal(SIGALRM, function(){});
 
-pcntl_alarm(0);
+var_dump(pcntl_alarm(0));
 var_dump(pcntl_alarm(60));
 var_dump(pcntl_alarm(1) > 0);
 $siginfo = array();
-var_dump(pcntl_sigtimedwait(array(SIGALRM),$siginfo,2) === SIGALRM);
+var_dump(pcntl_sigtimedwait(array(SIGALRM),$siginfo,1) === SIGALRM);
 ?>
 --EXPECT--
+int(0)
 int(0)
 bool(true)
 bool(true)


### PR DESCRIPTION
Extension: pcntl
Function: pcntl_alarm

I found that the test does not look covered in the **lcov** report, but the test was there already, so I change it a little bit to activate the coverage properly.

Before:

![image](https://user-images.githubusercontent.com/25756860/178740015-ffbad656-d81c-4d6e-af4b-e3a87917ece2.png)


After:

![image](https://user-images.githubusercontent.com/25756860/178740080-55b3898f-1112-4767-8260-d5e468bd3e74.png)


I don't know if max execution time was set to 0 intentionally in the past.