### PR TITLE
QA - pcntl_signal - error when handler is int and not SIG_DFL or SIG_IGN

### DIFF
--- a/ext/pcntl/tests/pcntl_signal_002.phpt
+++ b/ext/pcntl/tests/pcntl_signal_002.phpt
@@ -6,7 +6,7 @@ pcntl
 <?php
 
 try {
-    pcntl_signal(SIGTERM, 0);
+    pcntl_signal(SIGTERM, -1);
 } catch (Error $error) {
     echo $error->getMessage();
 }

--- a/ext/pcntl/tests/pcntl_signal_002.phpt
+++ b/ext/pcntl/tests/pcntl_signal_002.phpt
@@ -6,7 +6,7 @@ pcntl
 <?php
 
 try {
-    pcntl_signal(SIGTERM, (SIG_DFL - SIG_IGN - 1));
+    pcntl_signal(SIGTERM, 0);
 } catch (Error $error) {
     echo $error->getMessage();
 }

--- a/ext/pcntl/tests/pcntl_signal_002.phpt
+++ b/ext/pcntl/tests/pcntl_signal_002.phpt
@@ -1,0 +1,16 @@
+--TEST--
+pcntl_signal() - If handler is an int value different than SIG_DFL or SIG_IGN
+--EXTENSIONS--
+pcntl
+--FILE--
+<?php
+
+try {
+    pcntl_signal(SIGTERM, (SIG_DFL - SIG_IGN - 1));
+} catch (Error $error) {
+    echo $error->getMessage();
+}
+
+?>
+--EXPECT--
+pcntl_signal(): Argument #2 ($handler) must be either SIG_DFL or SIG_IGN when an integer value is given


### PR DESCRIPTION
Extension: pcntl
Function: pcntl_signal

When an int handler is passed that is different than SIG_DFL or SIG_IGN then error is expected.

Code coverage looks like:

Before
![image](https://user-images.githubusercontent.com/25756860/178768653-597e0e5f-c1a2-4046-9a44-8bbe262f0c96.png)

After
![image](https://user-images.githubusercontent.com/25756860/178768741-90449ea0-68dd-4fea-91fa-c034b35c002e.png)
