### PR TITLE
QA - ftp_connect - error behavior when connection fails

### DIFF
--- a/ext/ftp/tests/ftp_connect_001.phpt
+++ b/ext/ftp/tests/ftp_connect_001.phpt
@@ -10,5 +10,5 @@ $ftp = ftp_connect('dummy-host-name', 21);
 var_dump($ftp);
 ?>
 --EXPECTF--
-Warning: ftp_connect(): php_network_getaddresses: getaddrinfo for dummy-host-name failed: Temporary failure in name resolution %s
+Warning: ftp_connect(): php_network_getaddresses: getaddrinfo for dummy-host-name failed: %s in %s on line %d
 bool(false)

--- a/ext/ftp/tests/ftp_connect_001.phpt
+++ b/ext/ftp/tests/ftp_connect_001.phpt
@@ -2,11 +2,9 @@
 ftp_connect - return FALSE if connection fails and Waning is generated
 --EXTENSIONS--
 ftp
---INI--
-max_execution_time=2
 --FILE--
 <?php
-$ftp = ftp_connect('dummy-host-name', 21);
+$ftp = ftp_connect('dummy-host-name', 21, 5);
 var_dump($ftp);
 ?>
 --EXPECTF--

--- a/ext/ftp/tests/ftp_connect_001.phpt
+++ b/ext/ftp/tests/ftp_connect_001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+ftp_connect - return FALSE if connection fails and Waning is generated
+--EXTENSIONS--
+ftp
+--INI--
+max_execution_time=2
+--FILE--
+<?php
+$ftp = ftp_connect('dummy-host-name', 21);
+var_dump($ftp);
+?>
+--EXPECTF--
+Warning: ftp_connect(): php_network_getaddresses: getaddrinfo for dummy-host-name failed: Temporary failure in name resolution %s
+bool(false)


### PR DESCRIPTION
Extension: ftp
Function: ftp_connect

Test and coverage when connection fails.
We test expected result , PLUS, the PHP error (warning) generated.

Coverage looks like:

![image](https://user-images.githubusercontent.com/25756860/178775143-f2a2d034-df92-4127-97fe-4d5532935c17.png)


After

![image](https://user-images.githubusercontent.com/25756860/178775203-12284fcd-a936-40d4-ba87-a40e2396ba2d.png)
