### PR TITLE
QA - ftp_rawlist - check list return value

### DIFF
--- a/ext/ftp/tests/ftp_rawlist_basic1.phpt
+++ b/ext/ftp/tests/ftp_rawlist_basic1.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Testing ftp_rawlist basic functionality
+--CREDITS--
+Gabriel Caruso (carusogabriel34@gmail.com)
 --EXTENSIONS--
 ftp
 pcntl

--- a/ext/ftp/tests/ftp_rawlist_basic1.phpt
+++ b/ext/ftp/tests/ftp_rawlist_basic1.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Testing ftp_rawlist basic functionality
---CREDITS--
-Gabriel Caruso (carusogabriel34@gmail.com)
 --EXTENSIONS--
 ftp
 pcntl
@@ -13,7 +11,19 @@ $ftp = ftp_connect('127.0.0.1', $port);
 ftp_login($ftp, 'user', 'pass');
 $ftp or die("Couldn't connect to the server");
 
-var_dump(is_array(ftp_rawlist($ftp, 'www/')));
+$result = ftp_rawlist($ftp, 'www/');
+var_dump(is_array($result));
+var_dump($result);
+ftp_close($ftp);
 ?>
 --EXPECT--
 bool(true)
+array(3) {
+  [0]=>
+  string(5) "file1"
+  [1]=>
+  string(5) "file1"
+  [2]=>
+  string(9) "file
+b0rk"
+}

--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -454,7 +454,7 @@ if ($pid) {
                 }
             } else {
                 fputs($s, "125 Data connection already open; transfer starting.\r\n");
-                $fs=$pasvs;
+                $fs = $pasvs;
             }
 
 

--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -446,8 +446,27 @@ if ($pid) {
             fputs($s, "200 " . $matches[1] . " bytes allocated\r\n");
 
         }elseif (preg_match('/^LIST www\//', $buf, $matches)) {
-            fputs($s, "226 Transfer complete\r\n");
+            if (empty($pasv)) {
+                fputs($s, "150 File status okay; about to open data connection\r\n");
+                if (!$fs = stream_socket_client("tcp://$host:$port")) {
+                    fputs($s, "425 Can't open data connection\r\n");
+                    continue;
+                }
+            } else {
+                fputs($s, "125 Data connection already open; transfer starting.\r\n");
+                $fs=$pasvs;
+            }
 
+
+            if ((!empty($ssl)) && (!stream_socket_enable_crypto($pasvs, true, STREAM_CRYPTO_METHOD_SSLv23_SERVER))) {
+                die("SSLv23 handshake failed.\n");
+            }
+
+            fputs($fs, "file1\r\nfile1\r\nfile\nb0rk\r\n");
+            fputs($s, "226 Closing data Connection.\r\n");
+            fclose($fs);
+            
+            fputs($s, "226 Transfer complete\r\n");
         }elseif (preg_match('/^LIST no_exists\//', $buf, $matches)) {
             fputs($s, "425 Error establishing connection\r\n");
 


### PR DESCRIPTION
I am not sure if is wort the effort honestly.

Extension: ftp
Function: ftp_rawlist

I pretend to generate a code coverage on the part that we generate the result list of entries as shown in the picture:

![image](https://user-images.githubusercontent.com/25756860/178998358-802a067b-157e-4472-929f-07599826d9b2.png)

That picture was the result **after** my change (I lost the picture of before my change)

But I had to adjust server.inc file, using kind of like the same code used for the NLIST ftp command in the same file.

Thanks in advance.