### PR TITLE
Fix RC func info of str_split

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -571,7 +571,7 @@ static const func_info_t func_infos[] = {
 	F1("str_rot13", MAY_BE_STRING),
 	F1("str_shuffle", MAY_BE_STRING),
 	F1("str_word_count", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING|MAY_BE_LONG),
-	F1("str_split", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
+	FN("str_split", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_OF_STRING),
 	F1("strpbrk", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("utf8_encode", MAY_BE_STRING),
 	F1("utf8_decode", MAY_BE_STRING),

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1000,7 +1000,6 @@ function str_word_count(string $string, int $format = 0, ?string $characters = n
 
 /**
  * @return array<int, string>
- * @refcount 1
  * @compile-time-eval
  */
 function str_split(string $string, int $length = 1): array {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9fe68f4baa560dedf96b551c051cfaf3e6532d15 */
+ * Stub hash: 00c1b3312b1325e4dc0624c964f5bd2096245db2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)


### PR DESCRIPTION
See [test failure in nightly](https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=26596&view=ms.vss-test-web.build-test-results-tab&runId=601508&paneView=debug&resultId=100851).

Introduced in GH-8945

With RETURN_EMPTY_ARRAY this function can now return an interned array which
has refcount 2.