### PR TITLE
QA - mb_http_input - function returns FALSE for type 'L' or 'l'

### DIFF
--- a/ext/mbstring/tests/mb_http_input_001.phpt
+++ b/ext/mbstring/tests/mb_http_input_001.phpt
@@ -1,0 +1,17 @@
+--TEST--
+mb_http_input() - Returns FALSE for $type 'L' or 'l'
+--EXTENSIONS--
+mbstring
+--INI--
+input_encoding=-1
+--FILE--
+<?php
+var_dump(mb_http_input('L'));
+var_dump(mb_http_input('l'));
+?>
+--EXPECT--
+Warning: PHP Startup: INI setting contains invalid encoding "-1" in Unknown on line 0
+
+Warning: PHP Startup: INI setting contains invalid encoding "-1" in Unknown on line 0
+bool(false)
+bool(false)


### PR DESCRIPTION
### Information
Extension: mbstring
Function: mb_http_input
Case: Parameter $type is 'L' or 'l' is provided and function returns **false**

Another reason to test this is that in the code there is a //TODO note on this case, suggesting that there might be a possibility that in the future instead of FALSE ... empty string might be returned ... is an open question developer left there.

I think is wort the effort to have a test on this, but is just my opinion.

### Code coverage

Before
![image](https://user-images.githubusercontent.com/25756860/179172639-69f6313d-845c-4302-847d-b44880c4ce8c.png)

After
![image](https://user-images.githubusercontent.com/25756860/179172742-5fba5c7b-a697-44d7-9ce7-729f02f1dc7f.png)

