### PR TITLE
Fix occasional "failed to acquire scoreboard" warning

### DIFF
--- a/sapi/fpm/fpm/fpm_request.c
+++ b/sapi/fpm/fpm/fpm_request.c
@@ -231,7 +231,7 @@ void fpm_request_check_timed_out(struct fpm_child_s *child, struct timeval *now,
 
 	proc_p = fpm_scoreboard_proc_acquire(child->wp->scoreboard, child->scoreboard_i, 1);
 	if (!proc_p) {
-		zlog(ZLOG_WARNING, "failed to acquire scoreboard");
+		zlog(ZLOG_NOTICE, "failed to acquire scoreboard");
 		return;
 	}
 


### PR DESCRIPTION
With request timeouts configured, php-fpm occasionally prints the
following warning:

```
WARNING: failed to acquire scoreboard
```

This is happens when php-fpm checks the child scoreboards for timeouts,
but fails to acquire a lock immediately.  As this can (and does) occur
during normal operation, this commit simply removes the warning
altogether.