### PR TITLE
QA -mb_convert_encoding_array - error for object item in array

### DIFF
--- a/ext/mbstring/tests/mb_convert_encoding_array_error_001.phpt
+++ b/ext/mbstring/tests/mb_convert_encoding_array_error_001.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test mb_convert_encoding() function : array functionality with objects not supported
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+mb_convert_encoding(["key" => new stdClass()], 'UTF-8');
+?>
+--EXPECTF--
+Warning: mb_convert_encoding(): Object is not supported in %s on line %d


### PR DESCRIPTION
Extension: mbstring
Function: mb_convert_encoding()

Case:
Array with an object item is passed in the first parameter. Objects are not supported, then error.

Code coverage improved.

Before
![image](https://user-images.githubusercontent.com/25756860/179244868-457128a9-1b53-4412-a9d4-01b673015065.png)

After
![image](https://user-images.githubusercontent.com/25756860/179244957-5e165917-3fd0-414f-99d3-09dfc74bda5f.png)
