### PR TITLE
Add FPM process.restart_batch_size option

### DIFF
--- a/sapi/fpm/fpm/fpm_children.c
+++ b/sapi/fpm/fpm/fpm_children.c
@@ -177,133 +177,146 @@ int fpm_children_free(struct fpm_child_s *child) /* {{{ */
 }
 /* }}} */
 
-void fpm_children_bury() /* {{{ */
+static bool fpm_child_bury_ex(pid_t pid, int status)
 {
-	int status;
-	pid_t pid;
 	struct fpm_child_s *child;
+	char buf[128];
+	int severity = ZLOG_NOTICE;
+	int restart_child = 1;
 
-	while ( (pid = waitpid(-1, &status, WNOHANG | WUNTRACED)) > 0) {
-		char buf[128];
-		int severity = ZLOG_NOTICE;
-		int restart_child = 1;
+	child = fpm_child_find(pid);
 
-		child = fpm_child_find(pid);
+	if (WIFEXITED(status)) {
 
-		if (WIFEXITED(status)) {
+		snprintf(buf, sizeof(buf), "with code %d", WEXITSTATUS(status));
 
-			snprintf(buf, sizeof(buf), "with code %d", WEXITSTATUS(status));
-
-			/* if it's been killed because of dynamic process management
-			 * don't restart it automatically
-			 */
-			if (child && child->idle_kill) {
-				restart_child = 0;
-			}
-
-			if (WEXITSTATUS(status) != FPM_EXIT_OK) {
-				severity = ZLOG_WARNING;
-			}
-
-		} else if (WIFSIGNALED(status)) {
-			const char *signame = fpm_signal_names[WTERMSIG(status)];
-#ifdef WCOREDUMP
-			const char *have_core = WCOREDUMP(status) ? " - core dumped" : "";
-#else
-			const char* have_core = "";
-#endif
-
-			if (signame == NULL) {
-				signame = "";
-			}
-
-			snprintf(buf, sizeof(buf), "on signal %d (%s%s)", WTERMSIG(status), signame, have_core);
-
-			/* if it's been killed because of dynamic process management
-			 * don't restart it automatically
-			 */
-			if (child && child->idle_kill && WTERMSIG(status) == SIGQUIT) {
-				restart_child = 0;
-			}
-
-			if (WTERMSIG(status) != SIGQUIT) { /* possible request loss */
-				severity = ZLOG_WARNING;
-			}
-		} else if (WIFSTOPPED(status)) {
-
-			zlog(ZLOG_NOTICE, "child %d stopped for tracing", (int) pid);
-
-			if (child && child->tracer) {
-				child->tracer(child);
-			}
-
-			continue;
+		/* if it's been killed because of dynamic process management
+			* don't restart it automatically
+			*/
+		if (child && child->idle_kill) {
+			restart_child = 0;
 		}
 
-		if (child) {
-			struct fpm_worker_pool_s *wp = child->wp;
-			struct timeval tv1, tv2;
+		if (WEXITSTATUS(status) != FPM_EXIT_OK) {
+			severity = ZLOG_WARNING;
+		}
 
-			fpm_child_unlink(child);
+	} else if (WIFSIGNALED(status)) {
+		const char *signame = fpm_signal_names[WTERMSIG(status)];
+#ifdef WCOREDUMP
+		const char *have_core = WCOREDUMP(status) ? " - core dumped" : "";
+#else
+		const char* have_core = "";
+#endif
 
-			fpm_scoreboard_proc_free(child);
+		if (signame == NULL) {
+			signame = "";
+		}
 
-			fpm_clock_get(&tv1);
+		snprintf(buf, sizeof(buf), "on signal %d (%s%s)", WTERMSIG(status), signame, have_core);
 
-			timersub(&tv1, &child->started, &tv2);
+		/* if it's been killed because of dynamic process management
+			* don't restart it automatically
+			*/
+		if (child && child->idle_kill && WTERMSIG(status) == SIGQUIT) {
+			restart_child = 0;
+		}
 
-			if (restart_child) {
-				if (!fpm_pctl_can_spawn_children()) {
-					severity = ZLOG_DEBUG;
-				}
-				zlog(severity, "[pool %s] child %d exited %s after %ld.%06d seconds from start", wp->config->name, (int) pid, buf, (long)tv2.tv_sec, (int) tv2.tv_usec);
-			} else {
-				zlog(ZLOG_DEBUG, "[pool %s] child %d has been killed by the process management after %ld.%06d seconds from start", wp->config->name, (int) pid, (long)tv2.tv_sec, (int) tv2.tv_usec);
+		if (WTERMSIG(status) != SIGQUIT) { /* possible request loss */
+			severity = ZLOG_WARNING;
+		}
+	} else if (WIFSTOPPED(status)) {
+
+		zlog(ZLOG_NOTICE, "child %d stopped for tracing", (int) pid);
+
+		if (child && child->tracer) {
+			child->tracer(child);
+		}
+
+		return false;
+	}
+
+	if (child) {
+		struct fpm_worker_pool_s *wp = child->wp;
+		struct timeval tv1, tv2;
+
+		fpm_child_unlink(child);
+
+		fpm_scoreboard_proc_free(child);
+
+		fpm_clock_get(&tv1);
+
+		timersub(&tv1, &child->started, &tv2);
+
+		if (restart_child) {
+			if (!fpm_pctl_can_spawn_children()) {
+				severity = ZLOG_DEBUG;
+			}
+			zlog(severity, "[pool %s] child %d exited %s after %ld.%06d seconds from start", wp->config->name, (int) pid, buf, (long)tv2.tv_sec, (int) tv2.tv_usec);
+		} else {
+			zlog(ZLOG_DEBUG, "[pool %s] child %d has been killed by the process management after %ld.%06d seconds from start", wp->config->name, (int) pid, (long)tv2.tv_sec, (int) tv2.tv_usec);
+		}
+
+		fpm_child_close(child, 1 /* in event_loop */);
+
+		fpm_pctl_child_exited();
+
+		if (last_faults && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS)) {
+			time_t now = tv1.tv_sec;
+			int restart_condition = 1;
+			int i;
+
+			last_faults[fault++] = now;
+
+			if (fault == fpm_global_config.emergency_restart_threshold) {
+				fault = 0;
 			}
 
-			fpm_child_close(child, 1 /* in event_loop */);
-
-			fpm_pctl_child_exited();
-
-			if (last_faults && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS)) {
-				time_t now = tv1.tv_sec;
-				int restart_condition = 1;
-				int i;
-
-				last_faults[fault++] = now;
-
-				if (fault == fpm_global_config.emergency_restart_threshold) {
-					fault = 0;
-				}
-
-				for (i = 0; i < fpm_global_config.emergency_restart_threshold; i++) {
-					if (now - last_faults[i] > fpm_global_config.emergency_restart_interval) {
-						restart_condition = 0;
-						break;
-					}
-				}
-
-				if (restart_condition) {
-
-					zlog(ZLOG_WARNING, "failed processes threshold (%d in %d sec) is reached, initiating reload", fpm_global_config.emergency_restart_threshold, fpm_global_config.emergency_restart_interval);
-
-					fpm_pctl(FPM_PCTL_STATE_RELOADING, FPM_PCTL_ACTION_SET);
-				}
-			}
-
-			if (restart_child) {
-				fpm_children_make(wp, 1 /* in event loop */, 1, 0);
-
-				if (fpm_globals.is_child) {
+			for (i = 0; i < fpm_global_config.emergency_restart_threshold; i++) {
+				if (now - last_faults[i] > fpm_global_config.emergency_restart_interval) {
+					restart_condition = 0;
 					break;
 				}
 			}
-		} else {
-			zlog(ZLOG_ALERT, "oops, unknown child (%d) exited %s. Please open a bug report (https://github.com/php/php-src/issues).", pid, buf);
+
+			if (restart_condition) {
+
+				zlog(ZLOG_WARNING, "failed processes threshold (%d in %d sec) is reached, initiating reload", fpm_global_config.emergency_restart_threshold, fpm_global_config.emergency_restart_interval);
+
+				fpm_pctl(FPM_PCTL_STATE_RELOADING, FPM_PCTL_ACTION_SET);
+			}
+		}
+
+		if (restart_child) {
+			fpm_children_make(wp, 1 /* in event loop */, 1, 0);
+
+			if (fpm_globals.is_child) {
+				return true;
+			}
+		}
+	} else {
+		zlog(ZLOG_ALERT, "oops, unknown child (%d) exited %s. Please open a bug report (https://github.com/php/php-src/issues).", pid, buf);
+	}
+
+	return false;
+}
+
+void fpm_children_bury(pid_t pid)
+{
+	int status;
+
+	if (waitpid(pid, &status, WNOHANG | WUNTRACED) > 0 && fpm_child_bury_ex(pid, status)) {
+		return;
+	}
+
+	int batch_size = fpm_global_config.process_restart_batch_size;
+	int count = batch_size == 0 ? fpm_globals.running_children + 1 : batch_size - 1;
+	for (int i = 0; (pid = waitpid(-1, &status, WNOHANG | WUNTRACED)) > 0 && i < count; i ++) {
+		if (fpm_child_bury_ex(pid, status)) {
+			break;
 		}
 	}
 }
-/* }}} */
 
 static struct fpm_child_s *fpm_resources_prepare(struct fpm_worker_pool_s *wp) /* {{{ */
 {

--- a/sapi/fpm/fpm/fpm_children.h
+++ b/sapi/fpm/fpm/fpm_children.h
@@ -12,7 +12,7 @@
 
 int fpm_children_create_initial(struct fpm_worker_pool_s *wp);
 int fpm_children_free(struct fpm_child_s *child);
-void fpm_children_bury(void);
+void fpm_children_bury(pid_t pid);
 int fpm_children_init_main(void);
 int fpm_children_make(struct fpm_worker_pool_s *wp, int in_event_loop, int nb_to_spawn, int is_debug);
 

--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -39,9 +39,11 @@
 #include "fpm_systemd.h"
 #endif
 
-
+/* Nullable string to string */
 #define STR2STR(a) (a ? a : "undefined")
+/* Boolean to string */
 #define BOOL2STR(a) (a ? "yes" : "no")
+
 #define GO(field) offsetof(struct fpm_global_config_s, field)
 #define WPO(field) offsetof(struct fpm_worker_pool_config_s, field)
 
@@ -67,6 +69,7 @@ struct fpm_global_config_s fpm_global_config = {
 #endif
 	.process_max = 0,
 	.process_priority = 64, /* 64 means unset */
+	.process_restart_batch_size = 0,
 #ifdef HAVE_SYSTEMD
 	.systemd_watchdog = 0,
 	.systemd_interval = -1, /* -1 means not set */
@@ -98,6 +101,7 @@ static struct ini_value_parser_s ini_fpm_global_options[] = {
 	{ "process_control_timeout",     &fpm_conf_set_time,            GO(process_control_timeout) },
 	{ "process.max",                 &fpm_conf_set_integer,         GO(process_max) },
 	{ "process.priority",            &fpm_conf_set_integer,         GO(process_priority) },
+	{ "process.restart_batch_size",  &fpm_conf_set_integer,         GO(process_restart_batch_size) },
 	{ "daemonize",                   &fpm_conf_set_boolean,         GO(daemonize) },
 	{ "rlimit_files",                &fpm_conf_set_integer,         GO(rlimit_files) },
 	{ "rlimit_core",                 &fpm_conf_set_rlimit_core,     GO(rlimit_core) },
@@ -1712,6 +1716,7 @@ static void fpm_conf_dump(void) /* {{{ */
 	zlog(ZLOG_NOTICE, "\temergency_restart_interval = %ds", fpm_global_config.emergency_restart_interval);
 	zlog(ZLOG_NOTICE, "\temergency_restart_threshold = %d", fpm_global_config.emergency_restart_threshold);
 	zlog(ZLOG_NOTICE, "\tprocess_control_timeout = %ds",    fpm_global_config.process_control_timeout);
+	zlog(ZLOG_NOTICE, "\tprocess.restart_batch_size = %d",  fpm_global_config.process_restart_batch_size);
 	zlog(ZLOG_NOTICE, "\tprocess.max = %d",                 fpm_global_config.process_max);
 	if (fpm_global_config.process_priority == 64) {
 		zlog(ZLOG_NOTICE, "\tprocess.priority = undefined");

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include "php.h"
 
+/* Process manager to string */
 #define PM2STR(a) (a == PM_STYLE_STATIC ? "static" : (a == PM_STYLE_DYNAMIC ? "dynamic" : "ondemand"))
 
 #define FPM_CONF_MAX_PONG_LENGTH 64
@@ -36,6 +37,7 @@ struct fpm_global_config_s {
 	int process_control_timeout;
 	int process_max;
 	int process_priority;
+	int process_restart_batch_size;
 	int daemonize;
 	int rlimit_files;
 	int rlimit_core;

--- a/sapi/fpm/fpm/fpm_signals.h
+++ b/sapi/fpm/fpm/fpm_signals.h
@@ -5,6 +5,11 @@
 
 #include <signal.h>
 
+struct fpm_signal_event_s {
+	char sig_char;
+	pid_t pid;
+};
+
 int fpm_signals_init_main(void);
 int fpm_signals_init_child(void);
 int fpm_signals_get_fd(void);

--- a/sapi/fpm/php-fpm.conf.in
+++ b/sapi/fpm/php-fpm.conf.in
@@ -94,6 +94,13 @@
 ; Default Value: no set
 ; process.priority = -19
 
+
+; Process restart batch size is the maximal number of children awaited after
+; a single child process is killed.
+; Note: A value of 0 means number of running childer + 1
+; Default Value: 0
+; process.restart_batch_size = 2
+
 ; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
 ; Default Value: yes
 ;daemonize = yes

--- a/sapi/fpm/tests/proc-restart-basic.phpt
+++ b/sapi/fpm/tests/proc-restart-basic.phpt
@@ -1,0 +1,45 @@
+--TEST--
+FPM: Process restart without any customization
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 3
+EOT;
+
+$code = <<<EOT
+<?php
+echo getmypid();
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$pid = $tester->request()->getBody();
+if (!is_numeric($pid)) {
+    die("ERROR: pid not returned");
+}
+$tester->signal('TERM', $pid);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/proc-restart-with-batch-size-set.phpt
+++ b/sapi/fpm/tests/proc-restart-with-batch-size-set.phpt
@@ -1,0 +1,46 @@
+--TEST--
+FPM: Process restart with batch size set
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+process.restart_batch_size = 3
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 3
+EOT;
+
+$code = <<<EOT
+<?php
+echo getmypid();
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$pid = $tester->request()->getBody();
+if (!is_numeric($pid)) {
+    die("ERROR: pid not returned");
+}
+$tester->signal('TERM', $pid);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
New option to select a number restarting precesses in one go. It also limits the current unlimited number of restarts to the number of running children by default which should improve FPM responsiveness for continuous children restart (e.g. if the child process dies immediately after the start).