### PR TITLE
Prevent fiber switching in tick function and signal handlers

### DIFF
--- a/Zend/tests/fibers/signal-async.phpt
+++ b/Zend/tests/fibers/signal-async.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Prevent switchcing fibers when async signals are enabled
+--EXTENSIONS--
+pcntl
+posix
+--FILE--
+<?php
+
+pcntl_async_signals(true);
+
+pcntl_signal(SIGUSR1, function (): void {
+    if (Fiber::getCurrent() !== null) {
+        Fiber::suspend();
+    }
+});
+
+$fiber = new Fiber(function (): void {
+    echo "Fiber start\n";
+    posix_kill(posix_getpid(), SIGUSR1);
+    time_nanosleep(1);
+    echo "Fiber end\n";
+});
+
+$fiber->start();
+
+?>
+--EXPECTF--
+Fiber start
+
+Fatal error: Uncaught FiberError: Cannot switch fibers in current execution context in %ssignal-async.php:%d
+Stack trace:
+#0 %ssignal-async.php(%d): Fiber::suspend()
+#1 %ssignal-async.php(%d): {closure}(%d, Array)
+#2 [internal function]: {closure}()
+#3 %ssignal-async.php(%d): Fiber->start()
+#4 {main}
+  thrown in %ssignal-async.php on line %d

--- a/Zend/tests/fibers/signal-async.phpt
+++ b/Zend/tests/fibers/signal-async.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Prevent switchcing fibers when async signals are enabled
+Prevent switching fibers when async signals are enabled
 --EXTENSIONS--
 pcntl
 posix

--- a/Zend/tests/fibers/signal-dispatch.phpt
+++ b/Zend/tests/fibers/signal-dispatch.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Prevent switchcing fibers when dispatching pending signals
+Prevent switching fibers when dispatching pending signals
 --EXTENSIONS--
 pcntl
 posix

--- a/Zend/tests/fibers/signal-dispatch.phpt
+++ b/Zend/tests/fibers/signal-dispatch.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Prevent switchcing fibers when dispatching pending signals
+--EXTENSIONS--
+pcntl
+posix
+--FILE--
+<?php
+
+pcntl_signal(SIGUSR1, function (): void {
+    if (Fiber::getCurrent() !== null) {
+        Fiber::suspend();
+    }
+});
+
+$fiber = new Fiber(function (): void {
+    echo "Fiber start\n";
+
+    posix_kill(posix_getpid(), SIGUSR1);
+
+    try {
+        pcntl_signal_dispatch();
+    } catch (FiberError $e) {
+        Fiber::suspend($e);
+    }
+
+    echo "Fiber end\n";
+});
+
+$e = $fiber->start();
+
+echo $e, "\n";
+
+$fiber->resume();
+
+?>
+--EXPECTF--
+Fiber start
+FiberError: Cannot switch fibers in current execution context in %ssignal-dispatch.php:%d
+Stack trace:
+#0 %ssignal-dispatch.php(%d): Fiber::suspend()
+#1 [internal function]: {closure}(%d, Array)
+#2 %ssignal-dispatch.php(%d): pcntl_signal_dispatch()
+#3 [internal function]: {closure}()
+#4 %ssignal-dispatch.php(%d): Fiber->start()
+#5 {main}
+Fiber end

--- a/Zend/tests/fibers/ticks.phpt
+++ b/Zend/tests/fibers/ticks.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Prevent switchcing fibers in tick function
+Prevent switching fibers in tick function
 --FILE--
 <?php
 

--- a/Zend/tests/fibers/ticks.phpt
+++ b/Zend/tests/fibers/ticks.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Prevent switchcing fibers in tick function
+--FILE--
+<?php
+
+declare(ticks=1);
+
+register_tick_function(function (): void {
+    if (Fiber::getCurrent() !== null) {
+        Fiber::suspend();
+    }
+});
+
+$fiber = new Fiber(function (): void {
+    echo "1\n";
+    echo "2\n";
+    echo "3\n";
+});
+
+$fiber->start();
+
+?>
+--EXPECTF--
+1
+
+Fatal error: Uncaught FiberError: Cannot switch fibers in current execution context in %sticks.php:%d
+Stack trace:
+#0 %sticks.php(%d): Fiber::suspend()
+#1 %sticks.php(%d): {closure}()
+#2 [internal function]: {closure}()
+#3 %sticks.php(%d): Fiber->start()
+#4 {main}
+  thrown in %sticks.php on line %d

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7752,7 +7752,9 @@ ZEND_VM_HANDLER(105, ZEND_TICKS, ANY, ANY, NUM)
 		EG(ticks_count) = 0;
 		if (zend_ticks_function) {
 			SAVE_OPLINE();
+			zend_fiber_switch_block();
 			zend_ticks_function(opline->extended_value);
+			zend_fiber_switch_unblock();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 	}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2996,7 +2996,9 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_TICKS_SPEC_HANDLER(ZEND_OPCODE
 		EG(ticks_count) = 0;
 		if (zend_ticks_function) {
 			SAVE_OPLINE();
+			zend_fiber_switch_block();
 			zend_ticks_function(opline->extended_value);
+			zend_fiber_switch_unblock();
 			ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 		}
 	}


### PR DESCRIPTION
Switching fibers in these contexts causes unexpected consequences:
- Switching during a tick will prevent further ticks from being executed until the fiber is resumed.
- Switching when handing a signal will prevent further signals being handled until the fiber is resumed.

This PR prevents fiber switching in either context. It is possible in the future ticks or signal handling may be modified to be re-entrant, allowing multiple fibers to enter the handler function. Preventing fiber switching gives us greater freedom to define switching behavior in the future should we decide to properly support switching fibers. However, it is my opinion that support for fiber switching is not really necessary in these contexts.