### PR TITLE
Fix GH-9033: Loading blacklist file can fail due to negative length

### DIFF
--- a/ext/opcache/zend_accelerator_blacklist.c
+++ b/ext/opcache/zend_accelerator_blacklist.c
@@ -276,12 +276,12 @@ static void zend_accel_blacklist_loadone(zend_blacklist *blacklist, char *filena
 		}
 
 		/* strip \" */
-		if (pbuf[0] == '\"' && pbuf[path_length - 1]== '\"') {
+		if (path_length > 0 && pbuf[0] == '\"' && pbuf[path_length - 1]== '\"') {
 			*pbuf++ = 0;
 			path_length -= 2;
 		}
 
-		if (path_length == 0) {
+		if (path_length <= 0) {
 			continue;
 		}
 


### PR DESCRIPTION
If the blacklist file contains a line with a single double-quote, we
called `zend_strndup(pbuf, -1)` what causes an unnecessary bail out;
instead we just ignore that line.

If the blacklist file contains an empty line, we may have caused an OOB
read; instead we just ignore that line.