### PR TITLE
Drop support for SQLITE_COPY in authorizer callback

### DIFF
--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -765,15 +765,6 @@ static int authorizer(void *autharg, int access_type, const char *arg3, const ch
 {
 	char *filename;
 	switch (access_type) {
-		case SQLITE_COPY: {
-					filename = make_filename_safe(arg4);
-			if (!filename) {
-				return SQLITE_DENY;
-			}
-			efree(filename);
-			return SQLITE_OK;
-		}
-
 		case SQLITE_ATTACH: {
 					filename = make_filename_safe(arg3);
 			if (!filename) {


### PR DESCRIPTION
According to the sources, `SQLITE_COPY` is unused as of SQLite
3.6.10[1] (at least), so there is no need to support it any longer; we
require at least SQLite 3.7.7 at minimum.

[1] <https://github.com/sqlite/sqlite/blob/version-3.6.10/src/sqlite.h.in#L2411>