### PR TITLE
Fix pcntl get/set priority

### DIFF
--- a/ext/pcntl/tests/pcntl_getpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_getpriority_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-pcntl_getpriority() - Wrong process identifier
+pcntl_getpriority() - Wrong mode passed and also for non existing process id provided
 --EXTENSIONS--
 pcntl
 --SKIPIF--
@@ -8,16 +8,26 @@ pcntl
 if (!function_exists('pcntl_getpriority')) {
     die('skip pcntl_getpriority doesn\'t exist');
 }
+
+if (PHP_OS == "Darwin") {
+    die("skip This test is not for Darwin");
+}
+
 ?>
 --FILE--
 <?php
 
 try {
-    pcntl_getpriority(null, 42);
+    pcntl_getpriority(null, PRIO_PGRP + PRIO_USER + PRIO_PROCESS + 10);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
+// Different behavior in MacOS than rest of operating systems
+pcntl_getpriority(-1, PRIO_PROCESS);
+
 ?>
---EXPECT--
+--EXPECTF--
 pcntl_getpriority(): Argument #2 ($mode) must be one of PRIO_PGRP, PRIO_USER, or PRIO_PROCESS
+
+Warning: pcntl_getpriority(): Error %d: No process was located using the given parameters in %s

--- a/ext/pcntl/tests/pcntl_getpriority_error_darwin.phpt
+++ b/ext/pcntl/tests/pcntl_getpriority_error_darwin.phpt
@@ -1,0 +1,43 @@
+--TEST--
+pcntl_getpriority() - Wrong mode passed and also for non existing process id provided
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+
+if (!function_exists('pcntl_getpriority')) {
+    die('skip pcntl_getpriority doesn\'t exist');
+}
+
+if (PHP_OS !== "Darwin") {
+    die("skip This test only runs on Darwin");
+}
+
+?>
+--FILE--
+<?php
+
+try {
+    pcntl_getpriority(null, (PRIO_PGRP + PRIO_USER + PRIO_PROCESS + 10));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    pcntl_getpriority(-1, PRIO_DARWIN_THREAD);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    // Different behavior in MacOS than rest of operating systems
+    pcntl_getpriority(-1, PRIO_PROCESS);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+pcntl_getpriority(): Argument #2 ($mode) must be one of PRIO_PGRP, PRIO_USER, PRIO_PROCESS or PRIO_DARWIN_THREAD
+pcntl_getpriority(): Argument #1 ($process_id) must be 0 (zero) if PRIO_DARWIN_THREAD is provided as second parameter
+pcntl_getpriority(): Argument #1 ($process_id) is not a valid process, process group, or user ID

--- a/ext/pcntl/tests/pcntl_setpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error.phpt
@@ -1,5 +1,5 @@
 --TEST--
-pcntl_setpriority() - Wrong process identifier
+pcntl_setpriority() - Check for errors
 --EXTENSIONS--
 pcntl
 --SKIPIF--
@@ -8,16 +8,25 @@ pcntl
 if (!function_exists('pcntl_setpriority')) {
     die('skip pcntl_setpriority doesn\'t exist');
 }
+
+if (PHP_OS == "Darwin") {
+    die("skip This test is not for Darwin");
+}
+
 ?>
 --FILE--
 <?php
 
 try {
-    pcntl_setpriority(0, null, 42);
+    $result = pcntl_setpriority(0, null, (PRIO_PGRP + PRIO_USER + PRIO_PROCESS + 10));
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
+pcntl_setpriority(0, -123);
+
 ?>
---EXPECT--
+--EXPECTF--
 pcntl_setpriority(): Argument #3 ($mode) must be one of PRIO_PGRP, PRIO_USER, or PRIO_PROCESS
+
+Warning: pcntl_setpriority(): Error 3: No process was located using the given parameters in %s

--- a/ext/pcntl/tests/pcntl_setpriority_error_darwin.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error_darwin.phpt
@@ -1,0 +1,46 @@
+--TEST--
+pcntl_setpriority() - Check for errors
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+
+if (!function_exists('pcntl_setpriority')) {
+    die('skip pcntl_setpriority doesn\'t exist');
+}
+
+if (PHP_OS !== "Darwin") {
+    die("skip This test only runs on Darwin");
+}
+
+?>
+--FILE--
+<?php
+
+try {
+    pcntl_setpriority(0, null, (PRIO_PGRP + PRIO_USER + PRIO_PROCESS + 10));
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    pcntl_setpriority(0, -1, PRIO_DARWIN_THREAD);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    pcntl_setpriority(0, -123);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+pcntl_setpriority(-1000, 1);
+
+?>
+--EXPECTF--
+pcntl_setpriority(): Argument #3 ($mode) must be one of PRIO_PGRP, PRIO_USER, PRIO_PROCESS or PRIO_DARWIN_THREAD
+pcntl_setpriority(): Argument #2 ($process_id) must be 0 (zero) if PRIO_DARWIN_THREAD is provided as second parameter
+pcntl_setpriority(): Argument #2 ($process_id) is not a valid process, process group, or user ID
+
+Warning: pcntl_setpriority(): Error 1: A process was located, but neither its effective nor real user ID matched the effective user ID of the caller in %s

--- a/ext/pcntl/tests/pcntl_setpriority_error_linux.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error_linux.phpt
@@ -1,0 +1,27 @@
+--TEST--
+pcntl_setpriority() - Check for errors
+--EXTENSIONS--
+pcntl
+--SKIPIF--
+<?php
+
+if (!function_exists('pcntl_setpriority')) {
+    die('skip pcntl_setpriority doesn\'t exist');
+}
+
+if (PHP_OS !== "Linux") {
+    die("skip This test only runs on Linux");
+}
+
+?>
+--FILE--
+<?php
+
+pcntl_setpriority(-1000, 1);
+pcntl_setpriority(-1000, 0);
+
+?>
+--EXPECTF--
+Warning: pcntl_setpriority(): Error 1: A process was located, but neither its effective nor real user ID matched the effective user ID of the caller in %s
+
+Warning: pcntl_setpriority(): Error 13: Only a super user may attempt to increase the process priority in %s on line %d


### PR DESCRIPTION
### Code

Extension: pcntl
Functions: `pcntl_setpriority()` , `pcntl_getpriority()`

### The problem

The PHP code to handle the errors for the mentioned functions is Linux aware only. Mac OS has a different behavior and uses the same error code for different things; plus FreeBSD does not respond in the same way as Linux or Mac under certain circumstances.

Because this feature (managing processes) is very OS dependent we cannot fully test the whole code, and also we cannot manage it in a uniform way (one code for all of them).

### Documentation per OS related to possible error codes that can be return for the getpriority() and setpriority() functions

Errors per OS:
**Mac**
![image](https://user-images.githubusercontent.com/25756860/179788265-635d9dd3-1fc0-4c64-ae2b-94679f502c2e.png)

**FreeBSD**
![image](https://user-images.githubusercontent.com/25756860/179788323-2ab86a46-8d63-4b83-a35a-2b5dd7088c1f.png)

**Linux**
![image](https://user-images.githubusercontent.com/25756860/179788396-0f36cb9e-e3af-41c5-b39f-410c0d47331c.png)


###  The PHP code at the moment (master)

`pcntl_getpriority()`
![image](https://user-images.githubusercontent.com/25756860/179788639-a2463953-3daf-46db-9c7d-c51d7cff3acb.png)

`pcntl_setpriority()`
![image](https://user-images.githubusercontent.com/25756860/179788771-b7b165ab-eada-4e55-a0a3-d6fd6eaf1d68.png)


So as we can see the code to manage the errors is wrong as it will work as expected in Linux and FreeBSD, but not in MacOS.

This change pretends to fix this issue.

Relates to (already closed):
https://github.com/php/php-src/pull/8994
https://github.com/php/php-src/pull/8993


**This is the first time I do such a change, please keep that in mind and advise me about anything that should be change, delete, adjust, etc.**

Thanks in advance to all reviewers.

@cmb69 as promised ... here it is.