### PR TITLE
Random Extension 5.x follow-up

### DIFF
--- a/EXTENSIONS
+++ b/EXTENSIONS
@@ -430,6 +430,7 @@ PRIMARY MAINTAINER   Go Kudo <zeriyoshi@gmail.com> (2022 - 2022)
                      Tim Düsterhus <timwolla@php.net> (2022 - 2022)
 MAINTENANCE:         Maintained
 STATUS:              Working
+SINCE:               8.2.0
 -------------------------------------------------------------------------------
 EXTENSION:           readline
 PRIMARY MAINTAINER:  Unknown

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -51,6 +51,14 @@ PHP 8.2 INTERNALS UPGRADE NOTES
   are deprecated (see main UPGRADING notes). To suppress the notice, e.g. to
   avoid duplicates when processing the same value multiple times, pass or add
   IS_CALLABLE_SUPPRESS_DEPRECATIONS to the check_flags parameter.
+* php_lcg.h, php_rand.h, php_mt_rand.h and php_random.h has already removed in 
+  ext/standard, They have been merged into a single ext/random/php_random.h 
+  header file. If you are using them in an extension, change the headers to read as follows
+  #if PHP_VERSION_ID < 80200
+  # include "ext/standard/php_XYZ.h"
+  #else
+  # include "ext/random/php_random.h"
+  #endif
 
 ========================
 2. Build system changes

--- a/ext/random/random.stub.php
+++ b/ext/random/random.stub.php
@@ -120,7 +120,9 @@ namespace Random
 
         public function __construct(?Engine $engine = null) {}
 
-        public function getInt(int $min = UNKNOWN, int $max = UNKNOWN): int {}
+        public function nextInt(): int {}
+
+        public function getInt(int $min, int $max): int {}
 
         public function getBytes(int $length): string {}
 

--- a/ext/random/random_arginfo.h
+++ b/ext/random/random_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 995783f78e8fc6071f5b2ca2690c16a1eafe584d */
+ * Stub hash: 223d23f47fa36fd12d11d750d6f50bd442f35bb3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_lcg_value, 0, 0, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
@@ -91,7 +91,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Random_Randomizer___construct, 0, 0, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, engine, Random\\Engine, 1, "null")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Random_Randomizer_getInt arginfo_rand
+#define arginfo_class_Random_Randomizer_nextInt arginfo_mt_getrandmax
+
+#define arginfo_class_Random_Randomizer_getInt arginfo_random_int
 
 #define arginfo_class_Random_Randomizer_getBytes arginfo_random_bytes
 
@@ -131,6 +133,7 @@ ZEND_METHOD(Random_Engine_Xoshiro256StarStar, __construct);
 ZEND_METHOD(Random_Engine_Xoshiro256StarStar, jump);
 ZEND_METHOD(Random_Engine_Xoshiro256StarStar, jumpLong);
 ZEND_METHOD(Random_Randomizer, __construct);
+ZEND_METHOD(Random_Randomizer, nextInt);
 ZEND_METHOD(Random_Randomizer, getInt);
 ZEND_METHOD(Random_Randomizer, getBytes);
 ZEND_METHOD(Random_Randomizer, shuffleArray);
@@ -206,6 +209,7 @@ static const zend_function_entry class_Random_CryptoSafeEngine_methods[] = {
 
 static const zend_function_entry class_Random_Randomizer_methods[] = {
 	ZEND_ME(Random_Randomizer, __construct, arginfo_class_Random_Randomizer___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Random_Randomizer, nextInt, arginfo_class_Random_Randomizer_nextInt, ZEND_ACC_PUBLIC)
 	ZEND_ME(Random_Randomizer, getInt, arginfo_class_Random_Randomizer_getInt, ZEND_ACC_PUBLIC)
 	ZEND_ME(Random_Randomizer, getBytes, arginfo_class_Random_Randomizer_getBytes, ZEND_ACC_PUBLIC)
 	ZEND_ME(Random_Randomizer, shuffleArray, arginfo_class_Random_Randomizer_shuffleArray, ZEND_ACC_PUBLIC)

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -86,26 +86,34 @@ PHP_METHOD(Random_Randomizer, __construct)
 }
 /* }}} */
 
+/* {{{ Generate random number */
+PHP_METHOD(Random_Randomizer, nextInt)
+{
+	php_random_randomizer *randomizer = Z_RANDOM_RANDOMIZER_P(ZEND_THIS);
+	uint64_t result;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	result = randomizer->algo->generate(randomizer->status);
+	if (randomizer->status->last_generated_size > sizeof(zend_long)) {
+			zend_throw_exception(spl_ce_RuntimeException, "Generated value exceeds size of int", 0);
+			RETURN_THROWS();
+	}
+	if (randomizer->status->last_unsafe) {
+		zend_throw_exception(spl_ce_RuntimeException, "Random number generation failed", 0);
+		RETURN_THROWS();
+	}
+
+	RETURN_LONG((zend_long) (result >> 1));
+}
+/* }}} */
+
 /* {{{ Generate random number in range */
 PHP_METHOD(Random_Randomizer, getInt)
 {
 	php_random_randomizer *randomizer = Z_RANDOM_RANDOMIZER_P(ZEND_THIS);
 	uint64_t result;
 	zend_long min, max;
-	int argc = ZEND_NUM_ARGS();
-
-	if (argc == 0) {
-		result = randomizer->algo->generate(randomizer->status);
-		if (randomizer->status->last_generated_size > sizeof(zend_long)) {
-			zend_throw_exception(spl_ce_RuntimeException, "Generated value exceeds size of int", 0);
-			RETURN_THROWS();
-		}
-		if (randomizer->status->last_unsafe) {
-			zend_throw_exception(spl_ce_RuntimeException, "Random number generation failed", 0);
-			RETURN_THROWS();
-		}
-		RETURN_LONG((zend_long) (result >> 1));
-	}
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_LONG(min)

--- a/ext/random/tests/03_randomizer/basic.phpt
+++ b/ext/random/tests/03_randomizer/basic.phpt
@@ -27,6 +27,13 @@ $engines[] = new UserEngine();
 foreach ($engines as $engine) {
     $randomizer = new Random\Randomizer($engine);
 
+    // nextInt
+    for ($i = 0; $i < 1000; $i++) {
+        if (!\is_int($randomizer->nextInt())) {
+            die($engine::class . ': nextInt: failure');
+        }
+    }
+
     // getInt
     for ($i = 0; $i < 1000; $i++) {
         $result = $randomizer->getInt(-50, 50);

--- a/ext/random/tests/03_randomizer/basic.phpt
+++ b/ext/random/tests/03_randomizer/basic.phpt
@@ -29,8 +29,14 @@ foreach ($engines as $engine) {
 
     // nextInt
     for ($i = 0; $i < 1000; $i++) {
-        if (!\is_int($randomizer->nextInt())) {
-            die($engine::class . ': nextInt: failure');
+        try {
+            if (!\is_int($randomizer->nextInt())) {
+                die($engine::class . ': nextInt: failure');
+            }
+        } catch (\RuntimeException $e) {
+            if ($e->getMessage() !== 'Generated value exceeds size of int') {
+                throw $e;
+            }
         }
     }
 

--- a/ext/random/tests/03_randomizer/compatibility_mt.phpt
+++ b/ext/random/tests/03_randomizer/compatibility_mt.phpt
@@ -6,7 +6,7 @@ Random: Randomizer: Compatibility: Mt19937
 $randomizer = new \Random\Randomizer(new \Random\Engine\Mt19937(1234, \MT_RAND_PHP));
 \mt_srand(1234, \MT_RAND_PHP);
 for ($i = 0; $i < 1000; $i++) {
-    if ($randomizer->getInt() !== \mt_rand()) {
+    if ($randomizer->nextInt() !== \mt_rand()) {
         die('failure');
     }
 }
@@ -14,7 +14,7 @@ for ($i = 0; $i < 1000; $i++) {
 $randomizer = new \Random\Randomizer(new \Random\Engine\Mt19937(1234, \MT_RAND_MT19937));
 \mt_srand(1234, \MT_RAND_MT19937);
 for ($i = 0; $i < 1000; $i++) {
-    if ($randomizer->getInt() !== \mt_rand()) {
+    if ($randomizer->nextInt() !== \mt_rand()) {
         die('failure');
     }
 }

--- a/ext/random/tests/03_randomizer/compatibility_user.phpt
+++ b/ext/random/tests/03_randomizer/compatibility_user.phpt
@@ -15,8 +15,8 @@ $user_randomizer = new \Random\Randomizer(new class () implements \Random\Engine
     }
 });
 for ($i = 0; $i < 1000; $i++) {
-    $native = $native_randomizer->getInt();
-    $user = $user_randomizer->getInt();
+    $native = $native_randomizer->nextInt();
+    $user = $user_randomizer->nextInt();
     if ($native !== $user) {
         die("failure Mt19937 i: {$i} native: {$native} user: {$user}");
     }
@@ -36,8 +36,8 @@ try {
     });
     
     for ($i = 0; $i < 1000; $i++) {
-        $native = $native_randomizer->getInt();
-        $user = $user_randomizer->getInt();
+        $native = $native_randomizer->nextInt();
+        $user = $user_randomizer->nextInt();
         if ($native !== $user) {
             die("failure PcgOneseq128XslRr64 i: {$i} native: {$native} user: {$user}");
         }
@@ -65,8 +65,8 @@ try {
     });
     
     for ($i = 0; $i < 1000; $i++) {
-        $native = $native_randomizer->getInt();
-        $user = $user_randomizer->getInt();
+        $native = $native_randomizer->nextInt();
+        $user = $user_randomizer->nextInt();
         if ($native !== $user) {
             die("failure Xoshiro256StarStar i: {$i} native: {$native} user: {$user}");
         }

--- a/ext/standard/php_lcg.h
+++ b/ext/standard/php_lcg.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_mt_rand.h
+++ b/ext/standard/php_mt_rand.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_rand.h
+++ b/ext/standard/php_rand.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_random.h
+++ b/ext/standard/php_random.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"


### PR DESCRIPTION
The Random Extension 5.x and Random Extension Improvement proposals passed, but with the problem of argument overloading.

https://github.com/php/php-src/pull/8094

As noted by some, argument overloading is now discouraged and should not be implemented anew.

- https://externals.io/message/118163#118269
- https://github.com/php/php-src/pull/8094/files#r919693108

This changes separates the argumentless `Random\Randomizer::getInt()` into `Random\Randomizer::nextInt()`.

At the same time, compatibility header files for internal APIs were removed.
This may affect downstream extensions, but can be easily circumvented by macro-branching with `PHP_VERSION_ID`.

- https://github.com/php/php-src/pull/8094/files#r917308676