### PR TITLE
`phpinfo` HTML Output: Make module title names clickable and link to the URL fragment

### DIFF
--- a/ext/phar/tests/phpinfo_004.phpt
+++ b/ext/phar/tests/phpinfo_004.phpt
@@ -25,7 +25,7 @@ phpinfo(INFO_MODULES);
 ===DONE===
 --EXPECTF--
 %a
-<h2><a name="module_phar">Phar</a></h2>
+<h2><a name="module_phar" href="#module_phar">Phar</a></h2>
 <table>
 <tr class="h"><th>Phar: PHP Archive support</th><th>enabled</th></tr>
 <tr><td class="e">Phar API version </td><td class="v">1.1.1 </td></tr>
@@ -47,7 +47,7 @@ Phar based on pear/PHP_Archive, original concept by Davey Shafik.<br />Phar full
 <tr><td class="e">phar.require_hash</td><td class="v">Off</td><td class="v">Off</td></tr>
 </table>
 %a
-<h2><a name="module_phar">Phar</a></h2>
+<h2><a name="module_phar" href="#module_phar">Phar</a></h2>
 <table>
 <tr class="h"><th>Phar: PHP Archive support</th><th>enabled</th></tr>
 <tr><td class="e">Phar API version </td><td class="v">1.1.1 </td></tr>

--- a/ext/standard/css.c
+++ b/ext/standard/css.c
@@ -31,6 +31,7 @@ PHPAPI ZEND_COLD void php_info_print_css(void) /* {{{ */
 	PUTS("th {position: sticky; top: 0; background: inherit;}\n");
 	PUTS("h1 {font-size: 150%;}\n");
 	PUTS("h2 {font-size: 125%;}\n");
+	PUTS("h2 a:link, h2 a:visited{color: inherit; background: inherit;}\n");
 	PUTS(".p {text-align: left;}\n");
 	PUTS(".e {background-color: #ccf; width: 300px; font-weight: bold;}\n");
 	PUTS(".h {background-color: #99c; font-weight: bold;}\n");

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -137,7 +137,7 @@ PHPAPI ZEND_COLD void php_info_print_module(zend_module_entry *zend_module) /* {
 			zend_string *url_name = php_url_encode(zend_module->name, strlen(zend_module->name));
 
 			zend_str_tolower(ZSTR_VAL(url_name), ZSTR_LEN(url_name));
-			php_info_printf("<h2><a name=\"module_%s\">%s</a></h2>\n", ZSTR_VAL(url_name), zend_module->name);
+			php_info_printf("<h2><a name=\"module_%s\" href=\"#module_%s\">%s</a></h2>\n", ZSTR_VAL(url_name), ZSTR_VAL(url_name), zend_module->name);
 
 			efree(url_name);
 		} else {

--- a/ext/standard/tests/general_functions/phpinfo-header-anchors.phpt
+++ b/ext/standard/tests/general_functions/phpinfo-header-anchors.phpt
@@ -1,0 +1,11 @@
+--TEST--
+phpinfo() with clickable anchor tags
+--CGI--
+--FILE--
+<?php
+phpinfo();
+?>
+--EXPECTF--
+%a
+<h2><a name="module_core" href="#module_core">Core</a></h2>
+%a


### PR DESCRIPTION
This was split away from #8958, which I proposed to make `phpinfo` HTML output accessibility improvements with better contrast, in addition to the following change. For easier review, this PR only focuses on clickable module titles, while #8958 will focus on the contrast improvements.

---

Each section of `phpinfo` is titled with an `<h2><a name="module_NAME">NAME</a></h2>` tag. While the `name=module_NAME` attribute allows linking to that section using a URL fragment (e.g `info.php#module_NAME`), it lacks discoverability because the `<a>` tag does not contain an `href` attribute. This is also highlighted in accessibility scans (in Firefox for instance).

This adds a link to the `<a>` tag that links to the URL fragment, fixing the accessibility remark and improving the discoverability of the clickable section titles. Also contains minor CSS changes to account for the dark theme CSS.