### PR TITLE
Fix segmentation fault in Randomizer::getBytes() if a user engine throws

### DIFF
--- a/ext/random/engine_user.c
+++ b/ext/random/engine_user.c
@@ -30,6 +30,11 @@ static uint64_t generate(php_random_status *status)
 
 	zend_call_known_instance_method_with_0_params(s->generate_method, s->object, &retval);
 
+	if (EG(exception)) {
+		status->last_unsafe = true;
+		return 0;
+	}
+
 	/* Store generated size in a state */
 	size = Z_STRLEN(retval);
 

--- a/ext/random/tests/03_randomizer/user_exits.phpt
+++ b/ext/random/tests/03_randomizer/user_exits.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Random: Randomizer: User: Engine exits
+--FILE--
+<?php
+
+$randomizer = (new \Random\Randomizer(
+    new class () implements \Random\Engine {
+        public function generate(): string
+        {
+            exit("Exit\n");
+        }
+    }
+));
+
+var_dump($randomizer->getBytes(1));
+
+?>
+--EXPECT--
+Exit

--- a/ext/random/tests/03_randomizer/user_throws.phpt
+++ b/ext/random/tests/03_randomizer/user_throws.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Random: Randomizer: User: Engine throws
+--FILE--
+<?php
+
+$randomizer = (new \Random\Randomizer(
+    new class () implements \Random\Engine {
+        public function generate(): string
+        {
+            throw new Exception('Error');
+        }
+    }
+));
+
+var_dump($randomizer->getBytes(1));
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: Error in %s:%d
+Stack trace:
+#0 [internal function]: Random\Engine@anonymous->generate()
+#1 %s(%d): Random\Randomizer->getBytes(1)
+#2 {main}
+
+Next RuntimeException: Random number generation failed in %s:%d
+Stack trace:
+#0 %s(%d): Random\Randomizer->getBytes(1)
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
I'm a bit surprised that the exception check also fixes the SEGV in the `exit()` case. Does `exit()` use an exception internally or is my fix not actually correct and just happens to work for whatever reason?

/cc @zeriyoshi 