### PR TITLE
[random] remove unnecessary old header files

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -51,6 +51,14 @@ PHP 8.2 INTERNALS UPGRADE NOTES
   are deprecated (see main UPGRADING notes). To suppress the notice, e.g. to
   avoid duplicates when processing the same value multiple times, pass or add
   IS_CALLABLE_SUPPRESS_DEPRECATIONS to the check_flags parameter.
+* php_lcg.h, php_rand.h, php_mt_rand.h and php_random.h has already removed in 
+  ext/standard, They have been merged into a single ext/random/php_random.h 
+  header file. If you are using them in an extension, change the headers to read as follows
+  #if PHP_VERSION_ID < 80200
+  # include "ext/standard/php_XYZ.h"
+  #else
+  # include "ext/random/php_random.h"
+  #endif
 
 ========================
 2. Build system changes

--- a/ext/standard/php_lcg.h
+++ b/ext/standard/php_lcg.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_mt_rand.h
+++ b/ext/standard/php_mt_rand.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_rand.h
+++ b/ext/standard/php_rand.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"

--- a/ext/standard/php_random.h
+++ b/ext/standard/php_random.h
@@ -1,1 +1,0 @@
-#include "ext/random/php_random.h"


### PR DESCRIPTION
#8094

The Random Extension 5.x implementation kept the old header files to maintain extension compatibility.

- ext/standard/php_lcg.h
- ext/standard/php_rand.h
- ext/standard/php_mt_rand.h
- ext/standard/php_random.h

However, these files actually exist only to include `php_random.h` in the new `ext/random` and are no longer needed.

Deleting these files may affect some extensions, but this should not be a problem since it can be easily handled by branching with preprocessor macros.

```c
#if PHP_VERSION_ID < 80200
# include "ext/standard/php_ABC.h"
# include "ext/standard/php_XYZ.h"
#else
# include "ext/random/php_random.h"
#endif
```

cc / @TimWolla @kocsismate 