### PR TITLE
Fix --CGI-- support of run-tests.php

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -3895,7 +3895,7 @@ class TestFile
 
     public function isCGI(): bool
     {
-        return $this->sectionNotEmpty('CGI')
+        return $this->hasSection('CGI')
             || $this->sectionNotEmpty('GET')
             || $this->sectionNotEmpty('POST')
             || $this->sectionNotEmpty('GZIP_POST')


### PR DESCRIPTION
The `--CGI--` section is supposed to be just a marker, and to be empty
as such.  However, a previous refactoring[1] broke that.

[1] <https://github.com/php/php-src/commit/9140c9038a83ff55a78f357f8485de086d83d94e>