### PR TITLE
Add an API to manipulate observers at runtime

### DIFF
--- a/Zend/zend_observer.h
+++ b/Zend/zend_observer.h
@@ -56,10 +56,16 @@ typedef zend_observer_fcall_handlers (*zend_observer_fcall_init)(zend_execute_da
 // Call during minit/startup ONLY
 ZEND_API void zend_observer_fcall_register(zend_observer_fcall_init);
 
+// Call during runtime, but only if you have used zend_observer_fcall_register.
+// You must not have more than one begin and one end handler active at the same time. Remove the old one first, if there is an existing one.
+ZEND_API void zend_observer_add_begin_handler(zend_op_array *op_array, zend_observer_fcall_begin_handler begin);
+ZEND_API bool zend_observer_remove_begin_handler(zend_op_array *op_array, zend_observer_fcall_begin_handler begin);
+ZEND_API void zend_observer_add_end_handler(zend_op_array *op_array, zend_observer_fcall_end_handler end);
+ZEND_API bool zend_observer_remove_end_handler(zend_op_array *op_array, zend_observer_fcall_end_handler end);
+
 ZEND_API void zend_observer_startup(void); // Called by engine before MINITs
 ZEND_API void zend_observer_post_startup(void); // Called by engine after MINITs
 ZEND_API void zend_observer_activate(void);
-ZEND_API void zend_observer_deactivate(void);
 ZEND_API void zend_observer_shutdown(void);
 
 ZEND_API void ZEND_FASTCALL zend_observer_fcall_begin(

--- a/ext/zend_test/tests/observer_basic_06.phpt
+++ b/ext/zend_test/tests/observer_basic_06.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Observer: Basic observability of functions only (with run-time swapping)
+--EXTENSIONS--
+zend_test
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_function_names=foo
+--FILE--
+<?php
+function foo()
+{
+    echo 'Foo' . PHP_EOL;
+}
+
+function bar()
+{
+    echo 'Bar' . PHP_EOL;
+}
+
+foo();
+bar();
+
+ini_set("zend_test.observer.observe_function_names", "bar");
+
+foo();
+bar();
+
+?>
+--EXPECTF--
+<!-- init '%s%eobserver_basic_06.php' -->
+<!-- init foo() -->
+<foo>
+Foo
+</foo>
+<!-- init bar() -->
+Bar
+Foo
+<bar>
+Bar
+</bar>


### PR DESCRIPTION
This covers the use case of being able to dynamically trace and untrace functions. E.g. functions, which shall only be observed in a specific context.

It is not a very flexible API (it essentially does a lookup for the old observer (which needs to be specified), then removes it, nor does it allow adding multiple observers at once, unless your extension registers multiple observer init handlers), but it should be good enough for basic use cases.