### PR TITLE
Fix GH-9008: mb_detect_encoding(): wrong results with null $encodings

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2694,10 +2694,10 @@ PHP_FUNCTION(mb_strtolower)
 }
 /* }}} */
 
-static mbfl_encoding **duplicate_elist(const mbfl_encoding **elist, size_t size)
+static const mbfl_encoding **duplicate_elist(const mbfl_encoding **elist, size_t size)
 {
-	mbfl_encoding **new_elist = safe_emalloc(size, sizeof(mbfl_encoding*), 0);
-	memcpy(new_elist, elist, size * sizeof(mbfl_encoding*));
+	const mbfl_encoding **new_elist = safe_emalloc(size, sizeof(mbfl_encoding*), 0);
+	memcpy(ZEND_VOIDP(new_elist), elist, size * sizeof(mbfl_encoding*));
 	return new_elist;
 }
 

--- a/ext/mbstring/tests/gh9008.phpt
+++ b/ext/mbstring/tests/gh9008.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-9008 (mb_detect_encoding(): wrong results with null $encodings)
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+$string = "<?php
+
+function test()
+{
+
+}
+";
+
+mb_detect_order(["ASCII", "UUENCODE"]);
+
+var_dump(
+    mb_detect_encoding($string, null, true),
+    mb_detect_encoding($string, mb_detect_order(), true),
+);
+?>
+--EXPECT--
+string(5) "ASCII"
+string(5) "ASCII"


### PR DESCRIPTION
Passing `null` to `$encodings` is supposed to behave like passing the
result of `mb_detect_order()`.  Therefore, we need to remove the non-
encodings from the `elist` in this case as well.  Thus, we duplicate
the global `elist`, so we can modify it.