### PR TITLE
Add PDO::PARAM_AUTO

### DIFF
--- a/ext/pdo/pdo_dbh.stub.php
+++ b/ext/pdo/pdo_dbh.stub.php
@@ -37,6 +37,11 @@ class PDO
     public const PARAM_STMT = 4;
     /**
      * @var int
+     * @cvalue LONG_CONST(PDO_PARAM_AUTO)
+     */
+    public const PARAM_AUTO = 6;
+    /**
+     * @var int
      * @cvalue LONG_CONST(PDO_PARAM_INPUT_OUTPUT)
      */
     public const PARAM_INPUT_OUTPUT = UNKNOWN;

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7dcba884671fd90b891fab7e3f0d4cc9a4ac76a1 */
+ * Stub hash: 660bd25c42e1cad1a2276b59888f75243c7f6391 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_PDO___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, dsn, IS_STRING, 0)
@@ -144,6 +144,13 @@ static zend_class_entry *register_class_PDO(void)
 	zend_declare_class_constant_ex(class_entry, const_PARAM_STMT_name, &const_PARAM_STMT_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_PARAM_STMT_name);
 	ZEND_ASSERT(LONG_CONST(PDO_PARAM_STMT) == 4);
+
+	zval const_PARAM_AUTO_value;
+	ZVAL_LONG(&const_PARAM_AUTO_value, LONG_CONST(PDO_PARAM_AUTO));
+	zend_string *const_PARAM_AUTO_name = zend_string_init_interned("PARAM_AUTO", sizeof("PARAM_AUTO") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_PARAM_AUTO_name, &const_PARAM_AUTO_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_PARAM_AUTO_name);
+	ZEND_ASSERT(LONG_CONST(PDO_PARAM_AUTO) == 6);
 
 	zval const_PARAM_INPUT_OUTPUT_value;
 	ZVAL_LONG(&const_PARAM_INPUT_OUTPUT_value, LONG_CONST(PDO_PARAM_INPUT_OUTPUT));

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -275,6 +275,20 @@ static bool really_register_bound_param(struct pdo_bound_param_data *param, pdo_
 		parameter = Z_REFVAL(param->parameter);
 	}
 
+	if (PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_AUTO) {
+		if (Z_TYPE_P(parameter) == IS_NULL) {
+			param->param_type = PDO_PARAM_NULL | PDO_PARAM_MAGIC_FLAGS(param->param_type);
+		} else if (Z_TYPE_P(parameter) == IS_TRUE || Z_TYPE_P(parameter) == IS_FALSE) {
+			param->param_type = PDO_PARAM_BOOL | PDO_PARAM_MAGIC_FLAGS(param->param_type);
+		} else if(Z_TYPE_P(parameter) == IS_LONG) {
+			param->param_type = PDO_PARAM_INT | PDO_PARAM_MAGIC_FLAGS(param->param_type);
+		} else if(Z_TYPE_P(parameter) == IS_RESOURCE) {
+			param->param_type = PDO_PARAM_LOB | PDO_PARAM_MAGIC_FLAGS(param->param_type);
+		} else {
+			param->param_type = PDO_PARAM_STR | PDO_PARAM_MAGIC_FLAGS(param->param_type);
+		}
+	}
+
 	if (PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_STR && param->max_value_len <= 0 && !Z_ISNULL_P(parameter)) {
 		if (!try_convert_to_string(parameter)) {
 			return 0;

--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -42,6 +42,7 @@ enum pdo_param_type {
 	PDO_PARAM_INT = 1,
 	PDO_PARAM_STR = 2,
 	PDO_PARAM_LOB = 3,
+	PDO_PARAM_AUTO = 6,
 
 	/* get_col: Not supported (yet?) */
 	PDO_PARAM_STMT = 4, /* hierarchical result set */
@@ -58,9 +59,10 @@ enum pdo_param_type {
 	PDO_PARAM_STR_CHAR = 0x20000000,
 };
 
-#define PDO_PARAM_FLAGS			0xFFFF0000
+#define PDO_PARAM_FLAGS				0xFFFF0000
 
-#define PDO_PARAM_TYPE(x)		((x) & ~PDO_PARAM_FLAGS)
+#define PDO_PARAM_TYPE(x)			((x) & ~PDO_PARAM_FLAGS)
+#define PDO_PARAM_MAGIC_FLAGS(x)	((x) & ~0x0000FFFF)
 
 enum pdo_fetch_type {
 	PDO_FETCH_USE_DEFAULT,

--- a/ext/pdo/tests/pdo_param_auto.phpt
+++ b/ext/pdo/tests/pdo_param_auto.phpt
@@ -34,17 +34,18 @@ unlink($file);
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
-$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->exec('DROP TABLE IF EXISTS test');
-
+$null = 'NULL';
 switch ($db->getAttribute(PDO::ATTR_DRIVER_NAME)) {
     case 'mysql':
         $bitType = 'bit';
         break;
     case 'pgsql':
+        $bitType = 'boolean';
+        break;
     case 'firebird':
         $bitType = 'boolean';
+        $null = '';
         break;
     default:
         $bitType = 'int';
@@ -54,7 +55,7 @@ $db->exec(<<<SQL
 CREATE TABLE test(
     f_int int NOT NULL,
     f_bool {$bitType} NOT NULL,
-    f_null int NULL,
+    f_null int {$null},
     f_lob varchar(32) NOT NULL,
     f_str varchar(32) NOT NULL
 )
@@ -73,18 +74,38 @@ $stmt->bindValue(1, 123, PDO::PARAM_AUTO);
 $stmt->bindValue(2, true, PDO::PARAM_AUTO);
 $stmt->bindValue(3, null, PDO::PARAM_AUTO);
 $stmt->bindValue(4, $fp, PDO::PARAM_AUTO);
-$stmt->bindValue(5, 'test', PDO::PARAM_AUTO);
+$stmt->bindValue(5, 'test1', PDO::PARAM_AUTO);
 if (!$stmt->execute()) {
     printf("Failed to INSERT data, %s\n", var_export($stmt->errorInfo(), true));
     exit(1);
 }
-
-fclose($fp);
-
 $query_stmt = $db->query('SELECT * FROM test WHERE f_int = 123');
 $row = $query_stmt->fetch(PDO::FETCH_ASSOC);
-var_dump($row);
-var_dump(1 === $row['f_bool'] || true === $row['f_bool']);
+var_dump(123 == $row['f_int']);
+var_dump(1 == $row['f_bool']);
+var_dump(null === $row['f_null']);
+var_dump('blob content' === $row['f_lob']);
+var_dump('test1' === $row['f_str']);
+
+fseek($fp, 0);
+$stmt->bindValue(1, 456, PDO::PARAM_AUTO);
+$stmt->bindValue(2, false, PDO::PARAM_AUTO);
+$stmt->bindValue(3, 789, PDO::PARAM_AUTO);
+$stmt->bindValue(4, $fp, PDO::PARAM_AUTO);
+$stmt->bindValue(5, 'test2', PDO::PARAM_AUTO);
+if (!$stmt->execute()) {
+    printf("Failed to INSERT data, %s\n", var_export($stmt->errorInfo(), true));
+    exit(1);
+}
+$query_stmt = $db->query('SELECT * FROM test WHERE f_int = 456');
+$row = $query_stmt->fetch(PDO::FETCH_ASSOC);
+var_dump(456 == $row['f_int']);
+var_dump(0 == $row['f_bool']);
+var_dump(789 == $row['f_null']);
+var_dump('blob content' === $row['f_lob']);
+var_dump('test2' === $row['f_str']);
+
+fclose($fp);
 ?>
 --CLEAN--
 <?php
@@ -94,17 +115,14 @@ $db = PDOTest::factory();
 $db->exec('DROP TABLE IF EXISTS test');
 @unlink(PDOTest::get_temp_dir() . DIRECTORY_SEPARATOR . 'pdoblob.tst');
 ?>
---EXPECTF--
-array(5) {
-  ["f_int"]=>
-  int(123)
-  ["f_bool"]=>
-  %s(%s)
-  ["f_null"]=>
-  NULL
-  ["f_lob"]=>
-  string(12) "blob content"
-  ["f_str"]=>
-  string(4) "test"
-}
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
 bool(true)

--- a/ext/pdo/tests/pdo_param_auto.phpt
+++ b/ext/pdo/tests/pdo_param_auto.phpt
@@ -90,7 +90,6 @@ var_dump('blob content' === $row['f_lob']);
 var_dump('test1' === $row['f_str']);
 
 rewind($fp);
-$stmt = $db->prepare('INSERT INTO test VALUES(?,?,?,?,?)');
 $stmt->bindValue(1, 456, PDO::PARAM_AUTO);
 $stmt->bindValue(2, false, PDO::PARAM_AUTO);
 $stmt->bindValue(3, 789, PDO::PARAM_AUTO);

--- a/ext/pdo/tests/pdo_param_auto.phpt
+++ b/ext/pdo/tests/pdo_param_auto.phpt
@@ -1,0 +1,110 @@
+--TEST--
+PDO Common: PDO::PARAM_AUTO
+--EXTENSIONS--
+pdo
+--SKIPIF--
+<?php
+$dir = getenv('REDIR_TEST_DIR');
+if (false == $dir) die('skip no driver');
+require_once $dir . 'pdo_test.inc';
+PDOTest::skip();
+
+$tmp = PDOTest::get_temp_dir();
+if (!$tmp)
+    die("skip Can't create temporary file");
+
+$file = $tmp . DIRECTORY_SEPARATOR . 'pdoblob.tst';
+$fp = fopen($file, 'w');
+if (!$fp)
+    die("skip Can't create temporary file");
+
+if (4 != fwrite($fp, 'test')) {
+    die("skip Can't create temporary file");
+}
+fclose($fp);
+clearstatcache();
+
+if (!file_exists($file))
+    die("skip Can't create temporary file");
+
+unlink($file);
+?>
+--FILE--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+$db = PDOTest::factory();
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+
+$db->exec('DROP TABLE IF EXISTS test');
+
+switch ($db->getAttribute(PDO::ATTR_DRIVER_NAME)) {
+    case 'mysql':
+        $bitType = 'bit';
+        break;
+    case 'pgsql':
+    case 'firebird':
+        $bitType = 'boolean';
+        break;
+    default:
+        $bitType = 'int';
+}
+
+$db->exec(<<<SQL
+CREATE TABLE test(
+    f_int int NOT NULL,
+    f_bool {$bitType} NOT NULL,
+    f_null int NULL,
+    f_lob varchar(32) NOT NULL,
+    f_str varchar(32) NOT NULL
+)
+SQL);
+
+$file = PDOTest::get_temp_dir() . DIRECTORY_SEPARATOR . 'pdoblob.tst';
+file_put_contents($file, 'blob content');
+$fp = fopen($file, 'r');
+if (!$fp) {
+    printf("Cannot create test file '%s'\n", $file);
+    exit(1);
+}
+
+$stmt = $db->prepare('INSERT INTO test VALUES(?,?,?,?,?)');
+$stmt->bindValue(1, 123, PDO::PARAM_AUTO);
+$stmt->bindValue(2, true, PDO::PARAM_AUTO);
+$stmt->bindValue(3, null, PDO::PARAM_AUTO);
+$stmt->bindValue(4, $fp, PDO::PARAM_AUTO);
+$stmt->bindValue(5, 'test', PDO::PARAM_AUTO);
+if (!$stmt->execute()) {
+    printf("Failed to INSERT data, %s\n", var_export($stmt->errorInfo(), true));
+    exit(1);
+}
+
+fclose($fp);
+
+$query_stmt = $db->query('SELECT * FROM test WHERE f_int = 123');
+$row = $query_stmt->fetch(PDO::FETCH_ASSOC);
+var_dump($row);
+var_dump(1 === $row['f_bool'] || true === $row['f_bool']);
+?>
+--CLEAN--
+<?php
+if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
+require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
+$db = PDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test');
+@unlink(PDOTest::get_temp_dir() . DIRECTORY_SEPARATOR . 'pdoblob.tst');
+?>
+--EXPECTF--
+array(5) {
+  ["f_int"]=>
+  int(123)
+  ["f_bool"]=>
+  %s(%s)
+  ["f_null"]=>
+  NULL
+  ["f_lob"]=>
+  string(12) "blob content"
+  ["f_str"]=>
+  string(4) "test"
+}
+bool(true)

--- a/ext/pdo/tests/pdo_param_auto.phpt
+++ b/ext/pdo/tests/pdo_param_auto.phpt
@@ -35,7 +35,7 @@ if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
 
-$null = 'NULL';
+$null = '';
 switch ($db->getAttribute(PDO::ATTR_DRIVER_NAME)) {
     case 'mysql':
         $bitType = 'bit';
@@ -45,7 +45,10 @@ switch ($db->getAttribute(PDO::ATTR_DRIVER_NAME)) {
         break;
     case 'firebird':
         $bitType = 'boolean';
-        $null = '';
+        break;
+    case 'dblib':
+        $null = 'NULL';
+        $bitType = 'bit';
         break;
     default:
         $bitType = 'int';
@@ -106,14 +109,6 @@ var_dump('blob content' === $row['f_lob']);
 var_dump('test2' === $row['f_str']);
 
 fclose($fp);
-?>
---CLEAN--
-<?php
-if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
-require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
-$db = PDOTest::factory();
-$db->exec('DROP TABLE test');
-@unlink(PDOTest::get_temp_dir() . DIRECTORY_SEPARATOR . 'pdoblob.tst');
 ?>
 --EXPECT--
 bool(true)

--- a/ext/pdo/tests/pdo_param_auto.phpt
+++ b/ext/pdo/tests/pdo_param_auto.phpt
@@ -41,11 +41,10 @@ switch ($db->getAttribute(PDO::ATTR_DRIVER_NAME)) {
         $bitType = 'bit';
         break;
     case 'pgsql':
-        $bitType = 'boolean';
-        break;
     case 'firebird':
         $bitType = 'boolean';
         break;
+    case 'odbc':
     case 'dblib':
         $null = 'NULL';
         $bitType = 'bit';
@@ -91,6 +90,7 @@ var_dump('blob content' === $row['f_lob']);
 var_dump('test1' === $row['f_str']);
 
 rewind($fp);
+$stmt = $db->prepare('INSERT INTO test VALUES(?,?,?,?,?)');
 $stmt->bindValue(1, 456, PDO::PARAM_AUTO);
 $stmt->bindValue(2, false, PDO::PARAM_AUTO);
 $stmt->bindValue(3, 789, PDO::PARAM_AUTO);

--- a/ext/pdo/tests/pdo_param_auto.phpt
+++ b/ext/pdo/tests/pdo_param_auto.phpt
@@ -87,7 +87,7 @@ var_dump(null === $row['f_null']);
 var_dump('blob content' === $row['f_lob']);
 var_dump('test1' === $row['f_str']);
 
-fseek($fp, 0);
+rewind($fp);
 $stmt->bindValue(1, 456, PDO::PARAM_AUTO);
 $stmt->bindValue(2, false, PDO::PARAM_AUTO);
 $stmt->bindValue(3, 789, PDO::PARAM_AUTO);
@@ -112,7 +112,7 @@ fclose($fp);
 if (getenv('REDIR_TEST_DIR') === false) putenv('REDIR_TEST_DIR='.__DIR__ . '/../../pdo/tests/');
 require_once getenv('REDIR_TEST_DIR') . 'pdo_test.inc';
 $db = PDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE test');
 @unlink(PDOTest::get_temp_dir() . DIRECTORY_SEPARATOR . 'pdoblob.tst');
 ?>
 --EXPECT--

--- a/ext/pdo/tests/pdo_test.inc
+++ b/ext/pdo/tests/pdo_test.inc
@@ -82,5 +82,27 @@ class PDOTest {
 
         return $config;
     }
+
+    static function get_temp_dir() {
+        if (!function_exists('sys_get_temp_dir')) {
+
+            if (!empty($_ENV['TMP']))
+                return realpath( $_ENV['TMP'] );
+            if (!empty($_ENV['TMPDIR']))
+                return realpath( $_ENV['TMPDIR'] );
+            if (!empty($_ENV['TEMP']))
+                return realpath( $_ENV['TEMP'] );
+
+            $temp_file = tempnam(md5(uniqid(rand(), TRUE)), '');
+            if ($temp_file) {
+                $temp_dir = realpath(dirname($temp_file));
+                unlink($temp_file);
+                return $temp_dir;
+            }
+            return FALSE;
+        } else {
+            return sys_get_temp_dir();
+        }
+    }
 }
 ?>

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -320,6 +320,7 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 					 * so we need to guess */
 					switch (PDO_PARAM_TYPE(param->param_type)) {
 						case PDO_PARAM_INT:
+						case PDO_PARAM_BOOL:
 							sqltype = SQL_INTEGER;
 							break;
 						case PDO_PARAM_LOB:

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -310,6 +310,15 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 					case PDO_PARAM_STMT:
 						return 0;
 
+					case PDO_PARAM_BOOL:
+						if (!Z_ISREF(param->parameter)) {
+							parameter = &param->parameter;
+						} else {
+							parameter = Z_REFVAL(param->parameter);
+						}
+						ZVAL_LONG(parameter, zval_is_true(parameter) ? 1 : 0);
+						break;
+
 					default:
 						break;
 				}
@@ -459,20 +468,6 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 					}
 				} else if (Z_TYPE_P(parameter) == IS_NULL || PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_NULL) {
 					P->len = SQL_NULL_DATA;
-				} else if (Z_TYPE_P(parameter) == IS_TRUE) {
-					if (P->outbuf) {
-						P->len = sizeof(int);
-						P->outbuf[0] = 1;
-					} else {
-						P->len = SQL_LEN_DATA_AT_EXEC(Z_STRLEN_P(parameter));
-					}
-				} else if (Z_TYPE_P(parameter) == IS_FALSE) {
-					if (P->outbuf) {
-						P->len = sizeof(int);
-						P->outbuf[0] = 0;
-					} else {
-						P->len = SQL_LEN_DATA_AT_EXEC(Z_STRLEN_P(parameter));
-					}
 				} else {
 					convert_to_string(parameter);
 					if (P->outbuf) {

--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -320,8 +320,10 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 					 * so we need to guess */
 					switch (PDO_PARAM_TYPE(param->param_type)) {
 						case PDO_PARAM_INT:
-						case PDO_PARAM_BOOL:
 							sqltype = SQL_INTEGER;
+							break;
+						case PDO_PARAM_BOOL:
+							sqltype = SQL_BIT;
 							break;
 						case PDO_PARAM_LOB:
 							sqltype = SQL_LONGVARBINARY;
@@ -457,6 +459,20 @@ static int odbc_stmt_param_hook(pdo_stmt_t *stmt, struct pdo_bound_param_data *p
 					}
 				} else if (Z_TYPE_P(parameter) == IS_NULL || PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_NULL) {
 					P->len = SQL_NULL_DATA;
+				} else if (Z_TYPE_P(parameter) == IS_TRUE) {
+					if (P->outbuf) {
+						P->len = sizeof(int);
+						P->outbuf[0] = 1;
+					} else {
+						P->len = SQL_LEN_DATA_AT_EXEC(Z_STRLEN_P(parameter));
+					}
+				} else if (Z_TYPE_P(parameter) == IS_FALSE) {
+					if (P->outbuf) {
+						P->len = sizeof(int);
+						P->outbuf[0] = 0;
+					} else {
+						P->len = SQL_LEN_DATA_AT_EXEC(Z_STRLEN_P(parameter));
+					}
 				} else {
 					convert_to_string(parameter);
 					if (P->outbuf) {


### PR DESCRIPTION
PHP's strong typing system is getting better and better, and more and more developers are using strong types for their projects.

I wish `PDOStatement->bindValue()` could be more intelligent in determining the type of the bound value without having to be specified by the developer.

In fact many frameworks do the following.

* <https://github.com/laravel/framework/blob/25d84d7ce49bf72a6fe4bec7bdf7e64544f291fa/src/Illuminate/Database/Connection.php#L656>

* <https://github.com/catfan/Medoo/blob/74be58f80d330d1075ef3bfd0fb3d057349597ae/src/Medoo.php#L744>

* <https://github.com/imiphp/imi/blob/b9e74a55ee3ff0f1918014b2c4c408301684cb2a/src/Db/Drivers/TPdoStatement.php#L309>

I have implemented the addition of `PDO::PARAM_AUTO` to intelligently select the PDO data type based on the value type

---

* Add `PDO::PARAM_AUTO`
* Fix `PDO::PARAM_BOOL` in odbc