### PR TITLE
Fix memory leak in fiber constructor

### DIFF
--- a/Zend/tests/fibers/call-to-ctor-of-terminated-fiber.phpt
+++ b/Zend/tests/fibers/call-to-ctor-of-terminated-fiber.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Multiple calls to constructor are prevented after fiber terminated
+--FILE--
+<?php
+
+$fiber = new Fiber(function () {
+    return 123;
+});
+
+var_dump($fiber->start());
+var_dump($fiber->getReturn());
+
+$fiber->__construct(function () {
+    return 321;
+});
+
+?>
+--EXPECTF--
+NULL
+int(123)
+
+Fatal error: Uncaught FiberError: Cannot call constructor twice in %scall-to-ctor-of-terminated-fiber.php:%d
+Stack trace:
+#0 %scall-to-ctor-of-terminated-fiber.php(%d): Fiber->__construct(Object(Closure))
+#1 {main}
+  thrown in %scall-to-ctor-of-terminated-fiber.php on line %d

--- a/Zend/tests/fibers/multiple-calls-to-ctor.phpt
+++ b/Zend/tests/fibers/multiple-calls-to-ctor.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Multiple calls to constructor are prevented
+--FILE--
+<?php
+
+$fiber = new Fiber(function () {
+    return 123;
+});
+
+$fiber->__construct(function () {
+    return 321;
+});
+
+?>
+--EXPECTF--
+Fatal error: Uncaught FiberError: Cannot call constructor twice in %smultiple-calls-to-ctor.php:%d
+Stack trace:
+#0 %smultiple-calls-to-ctor.php(%d): Fiber->__construct(Object(Closure))
+#1 {main}
+  thrown in %smultiple-calls-to-ctor.php on line %d

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -644,11 +644,22 @@ static HashTable *zend_fiber_object_gc(zend_object *object, zval **table, int *n
 
 ZEND_METHOD(Fiber, __construct)
 {
-	zend_fiber *fiber = (zend_fiber *) Z_OBJ_P(ZEND_THIS);
+	zend_fcall_info fci;
+	zend_fcall_info_cache fcc;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_FUNC(fiber->fci, fiber->fci_cache)
+		Z_PARAM_FUNC(fci, fcc)
 	ZEND_PARSE_PARAMETERS_END();
+
+	zend_fiber *fiber = (zend_fiber *) Z_OBJ_P(ZEND_THIS);
+
+	if (UNEXPECTED(fiber->context.status != ZEND_FIBER_STATUS_INIT || Z_TYPE(fiber->fci.function_name) != IS_UNDEF)) {
+		zend_throw_error(zend_ce_fiber_error, "Cannot call constructor twice");
+		RETURN_THROWS();
+	}
+
+	fiber->fci = fci;
+	fiber->fci_cache = fcc;
 
 	// Keep a reference to closures or callable objects while the fiber is running.
 	Z_TRY_ADDREF(fiber->fci.function_name);


### PR DESCRIPTION
Fixes memory leak due to multiple calls to fiber constructor as reported in #8367.

@trowski Multiple calls to fiber constructor are prevented by throwing an error. The error message is identical to the one being used by `Phar` and `PharFileInfo` in this situation.