### PR TITLE
Store default object handlers alongside the class entry

### DIFF
--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -182,6 +182,8 @@ struct _zend_class_entry {
 	zend_function *__serialize;
 	zend_function *__unserialize;
 
+	const zend_object_handlers *default_object_handlers;
+
 	/* allocated only if class implements Iterator or IteratorAggregate interface */
 	zend_class_iterator_funcs *iterator_funcs_ptr;
 	/* allocated only if class implements ArrayAccess interface */

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -272,11 +272,13 @@ typedef struct _zend_fcall_info_cache {
 	{															\
 		memset(&class_container, 0, sizeof(zend_class_entry)); \
 		class_container.name = zend_string_init_interned(class_name, class_name_len, 1); \
+		class_container.default_object_handlers = &std_object_handlers;	\
 		class_container.info.internal.builtin_functions = functions;	\
 	}
 
 #define INIT_CLASS_ENTRY_INIT_METHODS(class_container, functions) \
 	{															\
+		class_container.default_object_handlers = &std_object_handlers;	\
 		class_container.constructor = NULL;						\
 		class_container.destructor = NULL;						\
 		class_container.clone = NULL;							\

--- a/Zend/zend_attributes.c
+++ b/Zend/zend_attributes.c
@@ -131,18 +131,6 @@ ZEND_METHOD(SensitiveParameterValue, __debugInfo)
 	RETURN_EMPTY_ARRAY();
 }
 
-static zend_object *attributes_sensitive_parameter_value_new(zend_class_entry *ce)
-{
-	zend_object *object;
-
-	object = zend_objects_new(ce);
-	object->handlers = &attributes_object_handlers_sensitive_parameter_value;
-
-	object_properties_init(object, ce);
-
-	return object;
-}
-
 static HashTable *attributes_sensitive_parameter_value_get_properties_for(zend_object *zobj, zend_prop_purpose purpose)
 {
 	return NULL;
@@ -382,7 +370,7 @@ void zend_register_attribute_ce(void)
 
 	/* This is not an actual attribute, thus the zend_mark_internal_attribute() call is missing. */
 	zend_ce_sensitive_parameter_value = register_class_SensitiveParameterValue();
-	zend_ce_sensitive_parameter_value->create_object = attributes_sensitive_parameter_value_new;
+	zend_ce_sensitive_parameter_value->default_object_handlers = &attributes_object_handlers_sensitive_parameter_value;
 }
 
 void zend_attributes_shutdown(void)

--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -521,7 +521,6 @@ static zend_object *zend_closure_new(zend_class_entry *class_type) /* {{{ */
 	memset(closure, 0, sizeof(zend_closure));
 
 	zend_object_std_init(&closure->std, class_type);
-	closure->std.handlers = &closure_handlers;
 
 	return (zend_object*)closure;
 }
@@ -678,6 +677,7 @@ void zend_register_closure_ce(void) /* {{{ */
 {
 	zend_ce_closure = register_class_Closure();
 	zend_ce_closure->create_object = zend_closure_new;
+	zend_ce_closure->default_object_handlers = &closure_handlers;
 
 	memcpy(&closure_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	closure_handlers.free_obj = zend_closure_free_storage;

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1828,6 +1828,7 @@ ZEND_API void zend_initialize_class_data(zend_class_entry *ce, bool nullify_hand
 	ZEND_MAP_PTR_INIT(ce->static_members_table, NULL);
 	ZEND_MAP_PTR_INIT(ce->mutable_data, NULL);
 
+	ce->default_object_handlers = &std_object_handlers;
 	ce->default_properties_count = 0;
 	ce->default_static_members_count = 0;
 	ce->properties_info_table = NULL;

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -47,8 +47,6 @@ zend_object *zend_enum_new(zval *result, zend_class_entry *ce, zend_string *case
 		ZVAL_COPY(OBJ_PROP_NUM(zobj, 1), backing_value_zv);
 	}
 
-	zobj->handlers = &enum_handlers;
-
 	return zobj;
 }
 
@@ -184,6 +182,8 @@ void zend_enum_add_interfaces(zend_class_entry *ce)
 		ce->interface_names[num_interfaces_before + 1].name = zend_string_copy(zend_ce_backed_enum->name);
 		ce->interface_names[num_interfaces_before + 1].lc_name = zend_string_init("backedenum", sizeof("backedenum") - 1, 0);	
 	}
+
+	ce->default_object_handlers = &enum_handlers;
 }
 
 zend_result zend_enum_build_backed_enum_table(zend_class_entry *ce)

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -240,7 +240,7 @@ ZEND_API void zend_clear_exception(void) /* {{{ */
 }
 /* }}} */
 
-static zend_object *zend_default_exception_new_ex(zend_class_entry *class_type, bool skip_top_traces) /* {{{ */
+static zend_object *zend_default_exception_new(zend_class_entry *class_type) /* {{{ */
 {
 	zval tmp;
 	zval trace;
@@ -248,13 +248,11 @@ static zend_object *zend_default_exception_new_ex(zend_class_entry *class_type, 
 	zend_string *filename;
 
 	zend_object *object = zend_objects_new(class_type);
-	object->handlers = &default_exception_handlers;
-
 	object_properties_init(object, class_type);
 
 	if (EG(current_execute_data)) {
 		zend_fetch_debug_backtrace(&trace,
-			skip_top_traces,
+			0,
 			EG(exception_ignore_args) ? DEBUG_BACKTRACE_IGNORE_ARGS : 0, 0);
 	} else {
 		array_init(&trace);
@@ -279,18 +277,6 @@ static zend_object *zend_default_exception_new_ex(zend_class_entry *class_type, 
 	zend_update_property_ex(base_ce, object, ZSTR_KNOWN(ZEND_STR_TRACE), &trace);
 
 	return object;
-}
-/* }}} */
-
-static zend_object *zend_default_exception_new(zend_class_entry *class_type) /* {{{ */
-{
-	return zend_default_exception_new_ex(class_type, 0);
-}
-/* }}} */
-
-static zend_object *zend_error_exception_new(zend_class_entry *class_type) /* {{{ */
-{
-	return zend_default_exception_new_ex(class_type, 0);
 }
 /* }}} */
 
@@ -739,6 +725,11 @@ ZEND_METHOD(Exception, __toString)
 }
 /* }}} */
 
+static void zend_init_exception_class_entry(zend_class_entry *ce) {
+	ce->create_object = zend_default_exception_new;
+	ce->default_object_handlers = &default_exception_handlers;
+}
+
 void zend_register_default_exception(void) /* {{{ */
 {
 	zend_ce_throwable = register_class_Throwable(zend_ce_stringable);
@@ -748,37 +739,37 @@ void zend_register_default_exception(void) /* {{{ */
 	default_exception_handlers.clone_obj = NULL;
 
 	zend_ce_exception = register_class_Exception(zend_ce_throwable);
-	zend_ce_exception->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_exception);
 
 	zend_ce_error_exception = register_class_ErrorException(zend_ce_exception);
-	zend_ce_error_exception->create_object = zend_error_exception_new;
+	zend_init_exception_class_entry(zend_ce_error_exception);
 
 	zend_ce_error = register_class_Error(zend_ce_throwable);
-	zend_ce_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_error);
 
 	zend_ce_compile_error = register_class_CompileError(zend_ce_error);
-	zend_ce_compile_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_compile_error);
 
 	zend_ce_parse_error = register_class_ParseError(zend_ce_compile_error);
-	zend_ce_parse_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_parse_error);
 
 	zend_ce_type_error = register_class_TypeError(zend_ce_error);
-	zend_ce_type_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_type_error);
 
 	zend_ce_argument_count_error = register_class_ArgumentCountError(zend_ce_type_error);
-	zend_ce_argument_count_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_argument_count_error);
 
 	zend_ce_value_error = register_class_ValueError(zend_ce_error);
-	zend_ce_value_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_value_error);
 
 	zend_ce_arithmetic_error = register_class_ArithmeticError(zend_ce_error);
-	zend_ce_arithmetic_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_arithmetic_error);
 
 	zend_ce_division_by_zero_error = register_class_DivisionByZeroError(zend_ce_arithmetic_error);
-	zend_ce_division_by_zero_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_division_by_zero_error);
 
 	zend_ce_unhandled_match_error = register_class_UnhandledMatchError(zend_ce_error);
-	zend_ce_unhandled_match_error->create_object = zend_default_exception_new;
+	zend_init_exception_class_entry(zend_ce_unhandled_match_error);
 
 	INIT_CLASS_ENTRY(zend_ce_unwind_exit, "UnwindExit", NULL);
 

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -574,12 +574,9 @@ static zend_always_inline zend_fiber_transfer zend_fiber_suspend(zend_fiber *fib
 static zend_object *zend_fiber_object_create(zend_class_entry *ce)
 {
 	zend_fiber *fiber = emalloc(sizeof(zend_fiber));
-
 	memset(fiber, 0, sizeof(zend_fiber));
 
 	zend_object_std_init(&fiber->std, ce);
-	fiber->std.handlers = &zend_fiber_handlers;
-
 	return &fiber->std;
 }
 
@@ -888,6 +885,7 @@ void zend_register_fiber_ce(void)
 {
 	zend_ce_fiber = register_class_Fiber();
 	zend_ce_fiber->create_object = zend_fiber_object_create;
+	zend_ce_fiber->default_object_handlers = &zend_fiber_handlers;
 
 	zend_fiber_handlers = std_object_handlers;
 	zend_fiber_handlers.dtor_obj = zend_fiber_object_destroy;

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -404,9 +404,7 @@ static HashTable *zend_generator_get_gc(zend_object *object, zval **table, int *
 
 static zend_object *zend_generator_create(zend_class_entry *class_type) /* {{{ */
 {
-	zend_generator *generator;
-
-	generator = emalloc(sizeof(zend_generator));
+	zend_generator *generator = emalloc(sizeof(zend_generator));
 	memset(generator, 0, sizeof(zend_generator));
 
 	/* The key will be incremented on first use, so it'll start at 0 */
@@ -421,8 +419,6 @@ static zend_object *zend_generator_create(zend_class_entry *class_type) /* {{{ *
 	generator->node.ptr.root = NULL;
 
 	zend_object_std_init(&generator->std, class_type);
-	generator->std.handlers = &zend_generator_handlers;
-
 	return (zend_object*)generator;
 }
 /* }}} */
@@ -1132,6 +1128,7 @@ void zend_register_generator_ce(void) /* {{{ */
 	zend_ce_generator->create_object = zend_generator_create;
 	/* get_iterator has to be assigned *after* implementing the interface */
 	zend_ce_generator->get_iterator = zend_generator_get_iterator;
+	zend_ce_generator->default_object_handlers = &zend_generator_handlers;
 
 	memcpy(&zend_generator_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	zend_generator_handlers.free_obj = zend_generator_free_storage;

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1472,6 +1472,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 		zend_string_release_ex(ce->parent_name, 0);
 	}
 	ce->parent = parent_ce;
+	ce->default_object_handlers = parent_ce->default_object_handlers;
 	ce->ce_flags |= ZEND_ACC_RESOLVED_PARENT;
 
 	/* Inherit properties */

--- a/Zend/zend_interfaces.c
+++ b/Zend/zend_interfaces.c
@@ -480,7 +480,6 @@ typedef struct {
 static zend_object *zend_internal_iterator_create(zend_class_entry *ce) {
 	zend_internal_iterator *intern = emalloc(sizeof(zend_internal_iterator));
 	zend_object_std_init(&intern->std, ce);
-	intern->std.handlers = &zend_internal_iterator_handlers;
 	intern->iter = NULL;
 	intern->rewind_called = 0;
 	return &intern->std;
@@ -655,6 +654,7 @@ ZEND_API void zend_register_interfaces(void)
 
 	zend_ce_internal_iterator = register_class_InternalIterator(zend_ce_iterator);
 	zend_ce_internal_iterator->create_object = zend_internal_iterator_create;
+	zend_ce_internal_iterator->default_object_handlers = &zend_internal_iterator_handlers;
 
 	memcpy(&zend_internal_iterator_handlers, zend_get_std_object_handlers(),
 		sizeof(zend_object_handlers));

--- a/Zend/zend_iterators.c
+++ b/Zend/zend_iterators.c
@@ -57,6 +57,7 @@ static const zend_object_handlers iterator_object_handlers = {
 ZEND_API void zend_register_iterator_wrapper(void)
 {
 	INIT_CLASS_ENTRY(zend_iterator_class_entry, "__iterator_wrapper", NULL);
+	zend_iterator_class_entry.default_object_handlers = &iterator_object_handlers;
 }
 
 static void iter_wrapper_free(zend_object *object)
@@ -83,7 +84,6 @@ static HashTable *iter_wrapper_get_gc(zend_object *object, zval **table, int *n)
 ZEND_API void zend_iterator_init(zend_object_iterator *iter)
 {
 	zend_object_std_init(&iter->std, &zend_iterator_class_entry);
-	iter->std.handlers = &iterator_object_handlers;
 }
 
 ZEND_API void zend_iterator_dtor(zend_object_iterator *iter)

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -31,6 +31,7 @@ static zend_always_inline void _zend_object_std_init(zend_object *object, zend_c
 	GC_SET_REFCOUNT(object, 1);
 	GC_TYPE_INFO(object) = GC_OBJECT;
 	object->ce = ce;
+	object->handlers = ce->default_object_handlers;
 	object->properties = NULL;
 	zend_objects_store_put(object);
 	if (UNEXPECTED(ce->ce_flags & ZEND_ACC_USE_GUARDS)) {
@@ -186,7 +187,6 @@ ZEND_API zend_object* ZEND_FASTCALL zend_objects_new(zend_class_entry *ce)
 	zend_object *object = emalloc(sizeof(zend_object) + zend_object_properties_size(ce));
 
 	_zend_object_std_init(object, ce);
-	object->handlers = &std_object_handlers;
 	return object;
 }
 

--- a/Zend/zend_weakrefs.c
+++ b/Zend/zend_weakrefs.c
@@ -210,9 +210,6 @@ static zend_object* zend_weakref_new(zend_class_entry *ce) {
 	zend_weakref *wr = zend_object_alloc(sizeof(zend_weakref), zend_ce_weakref);
 
 	zend_object_std_init(&wr->std, zend_ce_weakref);
-
-	wr->std.handlers = &zend_weakref_handlers;
-
 	return &wr->std;
 }
 
@@ -304,7 +301,6 @@ static zend_object *zend_weakmap_create_object(zend_class_entry *ce)
 {
 	zend_weakmap *wm = zend_object_alloc(sizeof(zend_weakmap), ce);
 	zend_object_std_init(&wm->std, ce);
-	wm->std.handlers = &zend_weakmap_handlers;
 
 	zend_hash_init(&wm->ht, 0, NULL, ZVAL_PTR_DTOR, 0);
 	return &wm->std;
@@ -651,6 +647,7 @@ void zend_register_weakref_ce(void) /* {{{ */
 	zend_ce_weakref = register_class_WeakReference();
 
 	zend_ce_weakref->create_object = zend_weakref_new;
+	zend_ce_weakref->default_object_handlers = &zend_weakref_handlers;
 
 	memcpy(&zend_weakref_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	zend_weakref_handlers.offset = XtOffsetOf(zend_weakref, std);
@@ -662,6 +659,7 @@ void zend_register_weakref_ce(void) /* {{{ */
 
 	zend_ce_weakmap->create_object = zend_weakmap_create_object;
 	zend_ce_weakmap->get_iterator = zend_weakmap_get_iterator;
+	zend_ce_weakmap->default_object_handlers = &zend_weakmap_handlers;
 
 	memcpy(&zend_weakmap_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	zend_weakmap_handlers.offset = XtOffsetOf(zend_weakmap, std);

--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -184,18 +184,22 @@ PHP_MINIT_FUNCTION(com_dotnet)
 
 	php_com_saproxy_class_entry = register_class_com_safearray_proxy();
 /*	php_com_saproxy_class_entry->constructor->common.fn_flags |= ZEND_ACC_PROTECTED; */
+	php_com_saproxy_class_entry->default_object_handlers = &php_com_saproxy_handlers;
 	php_com_saproxy_class_entry->get_iterator = php_com_saproxy_iter_get;
 
 	php_com_variant_class_entry = register_class_variant();
+	php_com_variant_class_entry->default_object_handlers = &php_com_object_handlers;
 	php_com_variant_class_entry->create_object = php_com_object_new;
 	php_com_variant_class_entry->get_iterator = php_com_iter_get;
 
 	tmp = register_class_com(php_com_variant_class_entry);
+	tmp->default_object_handlers = &php_com_object_handlers;
 	tmp->create_object = php_com_object_new;
 	tmp->get_iterator = php_com_iter_get;
 
 #if HAVE_MSCOREE_H
 	tmp = register_class_dotnet(php_com_variant_class_entry);
+	tmp->default_object_handlers = &php_com_object_handlers;
 	tmp->create_object = php_com_object_new;
 	tmp->get_iterator = php_com_iter_get;
 #endif

--- a/ext/com_dotnet/com_handlers.c
+++ b/ext/com_dotnet/com_handlers.c
@@ -627,7 +627,6 @@ zend_object* php_com_object_new(zend_class_entry *ce)
 	obj->ce = ce;
 
 	zend_object_std_init(&obj->zo, ce);
-	obj->zo.handlers = &php_com_object_handlers;
 
 	obj->typeinfo = NULL;
 

--- a/ext/com_dotnet/com_misc.c
+++ b/ext/com_dotnet/com_misc.c
@@ -61,7 +61,6 @@ PHP_COM_DOTNET_API void php_com_wrap_dispatch(zval *z, IDispatch *disp,
 	IDispatch_GetTypeInfo(V_DISPATCH(&obj->v), 0, LANG_NEUTRAL, &obj->typeinfo);
 
 	zend_object_std_init(&obj->zo, php_com_variant_class_entry);
-	obj->zo.handlers = &php_com_object_handlers;
 	ZVAL_OBJ(z, &obj->zo);
 }
 
@@ -85,7 +84,6 @@ PHP_COM_DOTNET_API void php_com_wrap_variant(zval *z, VARIANT *v,
 	}
 
 	zend_object_std_init(&obj->zo, php_com_variant_class_entry);
-	obj->zo.handlers = &php_com_object_handlers;
 	ZVAL_OBJ(z, &obj->zo);
 }
 

--- a/ext/com_dotnet/com_persist.c
+++ b/ext/com_dotnet/com_persist.c
@@ -709,7 +709,6 @@ static zend_object* helper_new(zend_class_entry *ce)
 	memset(helper, 0, sizeof(*helper));
 
 	zend_object_std_init(&helper->std, helper_ce);
-	helper->std.handlers = &helper_handlers;
 
 	return &helper->std;
 }
@@ -722,6 +721,7 @@ void php_com_persist_minit(INIT_FUNC_ARGS)
 
 	helper_ce = register_class_COMPersistHelper();
 	helper_ce->create_object = helper_new;
+	helper_ce->default_object_handlers = &helper_handlers;
 
 	le_istream = zend_register_list_destructors_ex(istream_dtor,
 			NULL, "com_dotnet_istream_wrapper", module_number);

--- a/ext/com_dotnet/com_saproxy.c
+++ b/ext/com_dotnet/com_saproxy.c
@@ -440,7 +440,6 @@ void php_com_saproxy_create(zend_object *com_object, zval *proxy_out, zval *inde
 	ZVAL_DUP(&proxy->indices[proxy->dimensions-1], index);
 
 	zend_object_std_init(&proxy->std, php_com_saproxy_class_entry);
-	proxy->std.handlers = &php_com_saproxy_handlers;
 	ZVAL_OBJ(proxy_out, &proxy->std);
 }
 

--- a/ext/com_dotnet/php_com_dotnet_internal.h
+++ b/ext/com_dotnet/php_com_dotnet_internal.h
@@ -78,6 +78,7 @@ void php_com_object_enable_event_sink(php_com_dotnet_object *obj, bool enable);
 /* com_saproxy.c */
 zend_object_iterator *php_com_saproxy_iter_get(zend_class_entry *ce, zval *object, int by_ref);
 void php_com_saproxy_create(zend_object *com_object, zval *proxy_out, zval *index);
+extern zend_object_handlers php_com_saproxy_handlers;
 
 /* com_olechar.c */
 PHP_COM_DOTNET_API zend_string *php_com_olestring_to_string(OLECHAR *olestring, int codepage);

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -398,6 +398,7 @@ PHP_MINIT_FUNCTION(curl)
 
 	curl_ce = register_class_CurlHandle();
 	curl_ce->create_object = curl_create_object;
+	curl_ce->default_object_handlers = &curl_object_handlers;
 
 	memcpy(&curl_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	curl_object_handlers.offset = XtOffsetOf(php_curl, std);
@@ -426,7 +427,6 @@ static zend_object *curl_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &curl_object_handlers;
 
 	return &intern->std;
 }

--- a/ext/curl/multi.c
+++ b/ext/curl/multi.c
@@ -512,14 +512,11 @@ PHP_FUNCTION(curl_multi_setopt)
 
 /* CurlMultiHandle class */
 
-static zend_object_handlers curl_multi_handlers;
-
 static zend_object *curl_multi_create_object(zend_class_entry *class_type) {
 	php_curlm *intern = zend_object_alloc(sizeof(php_curlm), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &curl_multi_handlers;
 
 	return &intern->std;
 }
@@ -582,8 +579,11 @@ static HashTable *curl_multi_get_gc(zend_object *object, zval **table, int *n)
 	return zend_std_get_properties(object);
 }
 
+static zend_object_handlers curl_multi_handlers;
+
 void curl_multi_register_handlers(void) {
 	curl_multi_ce->create_object = curl_multi_create_object;
+	curl_multi_ce->default_object_handlers = &curl_multi_handlers;
 
 	memcpy(&curl_multi_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	curl_multi_handlers.offset = XtOffsetOf(php_curlm, std);

--- a/ext/curl/share.c
+++ b/ext/curl/share.c
@@ -136,14 +136,11 @@ PHP_FUNCTION(curl_share_strerror)
 
 /* CurlShareHandle class */
 
-static zend_object_handlers curl_share_handlers;
-
 static zend_object *curl_share_create_object(zend_class_entry *class_type) {
 	php_curlsh *intern = zend_object_alloc(sizeof(php_curlsh), class_type);
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &curl_share_handlers;
 
 	return &intern->std;
 }
@@ -161,8 +158,11 @@ void curl_share_free_obj(zend_object *object)
 	zend_object_std_dtor(&sh->std);
 }
 
+static zend_object_handlers curl_share_handlers;
+
 void curl_share_register_handlers(void) {
 	curl_share_ce->create_object = curl_share_create_object;
+	curl_share_ce->default_object_handlers = &curl_share_handlers;
 
 	memcpy(&curl_share_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	curl_share_handlers.offset = XtOffsetOf(php_curlsh, std);

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1722,6 +1722,7 @@ static void date_register_classes(void) /* {{{ */
 
 	date_ce_date = register_class_DateTime(date_ce_interface);
 	date_ce_date->create_object = date_object_new_date;
+	date_ce_date->default_object_handlers = &date_object_handlers_date;
 	memcpy(&date_object_handlers_date, &std_object_handlers, sizeof(zend_object_handlers));
 	date_object_handlers_date.offset = XtOffsetOf(php_date_obj, std);
 	date_object_handlers_date.free_obj = date_object_free_storage_date;
@@ -1732,6 +1733,7 @@ static void date_register_classes(void) /* {{{ */
 
 	date_ce_immutable = register_class_DateTimeImmutable(date_ce_interface);
 	date_ce_immutable->create_object = date_object_new_date;
+	date_ce_immutable->default_object_handlers = &date_object_handlers_date;
 	memcpy(&date_object_handlers_immutable, &std_object_handlers, sizeof(zend_object_handlers));
 	date_object_handlers_immutable.clone_obj = date_object_clone_date;
 	date_object_handlers_immutable.compare = date_object_compare_date;
@@ -1740,6 +1742,7 @@ static void date_register_classes(void) /* {{{ */
 
 	date_ce_timezone = register_class_DateTimeZone();
 	date_ce_timezone->create_object = date_object_new_timezone;
+	date_ce_timezone->default_object_handlers = &date_object_handlers_timezone;
 	memcpy(&date_object_handlers_timezone, &std_object_handlers, sizeof(zend_object_handlers));
 	date_object_handlers_timezone.offset = XtOffsetOf(php_timezone_obj, std);
 	date_object_handlers_timezone.free_obj = date_object_free_storage_timezone;
@@ -1751,6 +1754,7 @@ static void date_register_classes(void) /* {{{ */
 
 	date_ce_interval = register_class_DateInterval();
 	date_ce_interval->create_object = date_object_new_interval;
+	date_ce_interval->default_object_handlers = &date_object_handlers_interval;
 	memcpy(&date_object_handlers_interval, &std_object_handlers, sizeof(zend_object_handlers));
 	date_object_handlers_interval.offset = XtOffsetOf(php_interval_obj, std);
 	date_object_handlers_interval.free_obj = date_object_free_storage_interval;
@@ -1765,6 +1769,7 @@ static void date_register_classes(void) /* {{{ */
 
 	date_ce_period = register_class_DatePeriod(zend_ce_aggregate);
 	date_ce_period->create_object = date_object_new_period;
+	date_ce_period->default_object_handlers = &date_object_handlers_period;
 	date_ce_period->get_iterator = date_object_period_get_iterator;
 	memcpy(&date_object_handlers_period, &std_object_handlers, sizeof(zend_object_handlers));
 	date_object_handlers_period.offset = XtOffsetOf(php_period_obj, std);
@@ -1782,7 +1787,6 @@ static zend_object *date_object_new_date(zend_class_entry *class_type) /* {{{ */
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &date_object_handlers_date;
 
 	return &intern->std;
 } /* }}} */
@@ -1923,7 +1927,6 @@ static zend_object *date_object_new_timezone(zend_class_entry *class_type) /* {{
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &date_object_handlers_timezone;
 
 	return &intern->std;
 } /* }}} */
@@ -2076,7 +2079,6 @@ static zend_object *date_object_new_interval(zend_class_entry *class_type) /* {{
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &date_object_handlers_interval;
 
 	return &intern->std;
 } /* }}} */
@@ -2168,8 +2170,6 @@ static zend_object *date_object_new_period(zend_class_entry *class_type) /* {{{ 
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-
-	intern->std.handlers = &date_object_handlers_period;
 
 	return &intern->std;
 } /* }}} */

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -782,6 +782,7 @@ PHP_MINIT_FUNCTION(dom)
 
 	dom_xpath_class_entry = register_class_DOMXPath();
 	dom_xpath_class_entry->create_object = dom_xpath_objects_new;
+	dom_xpath_class_entry->default_object_handlers = &dom_xpath_object_handlers;
 
 	zend_hash_init(&dom_xpath_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
 	dom_register_prop_handler(&dom_xpath_prop_handlers, "document", sizeof("document")-1, dom_xpath_document_read, NULL);
@@ -989,7 +990,6 @@ zend_object *dom_xpath_objects_new(zend_class_entry *class_type)
 	intern->register_node_ns = 1;
 
 	intern->dom.prop_handler = &dom_xpath_prop_handlers;
-	intern->dom.std.handlers = &dom_xpath_object_handlers;
 
 	zend_object_std_init(&intern->dom.std, class_type);
 	object_properties_init(&intern->dom.std, class_type);

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -660,6 +660,7 @@ PHP_MINIT_FUNCTION(dom)
 
 	dom_nodelist_class_entry = register_class_DOMNodeList(zend_ce_aggregate, zend_ce_countable);
 	dom_nodelist_class_entry->create_object = dom_nnodemap_objects_new;
+	dom_nodelist_class_entry->default_object_handlers = &dom_nnodemap_object_handlers;
 	dom_nodelist_class_entry->get_iterator = php_dom_get_iterator;
 
 	zend_hash_init(&dom_nodelist_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
@@ -668,6 +669,7 @@ PHP_MINIT_FUNCTION(dom)
 
 	dom_namednodemap_class_entry = register_class_DOMNamedNodeMap(zend_ce_aggregate, zend_ce_countable);
 	dom_namednodemap_class_entry->create_object = dom_nnodemap_objects_new;
+	dom_namednodemap_class_entry->default_object_handlers = &dom_nnodemap_object_handlers;
 	dom_namednodemap_class_entry->get_iterator = php_dom_get_iterator;
 
 	zend_hash_init(&dom_namednodemap_prop_handlers, 0, NULL, dom_dtor_prop_handler, 1);
@@ -1038,8 +1040,6 @@ zend_object *dom_nnodemap_objects_new(zend_class_entry *class_type) /* {{{ */
 	objmap->ht = NULL;
 	objmap->local = NULL;
 	objmap->ns = NULL;
-
-	intern->std.handlers = &dom_nnodemap_object_handlers;
 
 	return &intern->std;
 }

--- a/ext/enchant/enchant.c
+++ b/ext/enchant/enchant.c
@@ -61,7 +61,6 @@ static zend_object *enchant_broker_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &enchant_broker_handlers;
 
 	return &intern->std;
 }
@@ -80,7 +79,6 @@ static zend_object *enchant_dict_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &enchant_dict_handlers;
 
 	return &intern->std;
 }
@@ -191,6 +189,7 @@ PHP_MINIT_FUNCTION(enchant)
 {
 	enchant_broker_ce = register_class_EnchantBroker();
 	enchant_broker_ce->create_object = enchant_broker_create_object;
+	enchant_broker_ce->default_object_handlers = &enchant_broker_handlers;
 
 	memcpy(&enchant_broker_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	enchant_broker_handlers.offset = XtOffsetOf(enchant_broker, std);
@@ -200,6 +199,7 @@ PHP_MINIT_FUNCTION(enchant)
 
 	enchant_dict_ce = register_class_EnchantDictionary();
 	enchant_dict_ce->create_object = enchant_dict_create_object;
+	enchant_dict_ce->default_object_handlers = &enchant_dict_handlers;
 
 	memcpy(&enchant_dict_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	enchant_dict_handlers.offset = XtOffsetOf(enchant_dict, std);

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -234,6 +234,7 @@ static zend_always_inline void zend_ffi_object_init(zend_object *object, zend_cl
 	GC_SET_REFCOUNT(object, 1);
 	GC_TYPE_INFO(object) = GC_OBJECT | (IS_OBJ_DESTRUCTOR_CALLED << GC_FLAGS_SHIFT);
 	object->ce = ce;
+	object->handlers = ce->default_object_handlers;
 	object->properties = NULL;
 	zend_objects_store_put(object);
 }
@@ -246,7 +247,6 @@ static zend_object *zend_ffi_cdata_new(zend_class_entry *class_type) /* {{{ */
 	cdata = emalloc(sizeof(zend_ffi_cdata));
 
 	zend_ffi_object_init(&cdata->std, class_type);
-	cdata->std.handlers = &zend_ffi_cdata_handlers;
 
 	cdata->type = NULL;
 	cdata->ptr = NULL;
@@ -495,7 +495,6 @@ static zend_never_inline zend_ffi_cdata *zend_ffi_cdata_to_zval_slow_ptr(void *p
 	zend_ffi_cdata *cdata = emalloc(sizeof(zend_ffi_cdata));
 
 	zend_ffi_object_init(&cdata->std, zend_ffi_cdata_ce);
-	cdata->std.handlers = &zend_ffi_cdata_handlers;
 	cdata->type = type;
 	cdata->flags = flags;
 	cdata->ptr = (void*)&cdata->ptr_holder;
@@ -2174,7 +2173,6 @@ static zend_object *zend_ffi_ctype_new(zend_class_entry *class_type) /* {{{ */
 	ctype = emalloc(sizeof(zend_ffi_ctype));
 
 	zend_ffi_object_init(&ctype->std, class_type);
-	ctype->std.handlers = &zend_ffi_ctype_handlers;
 
 	ctype->type = NULL;
 
@@ -2261,7 +2259,6 @@ static zend_object *zend_ffi_new(zend_class_entry *class_type) /* {{{ */
 	ffi = emalloc(sizeof(zend_ffi));
 
 	zend_ffi_object_init(&ffi->std, class_type);
-	ffi->std.handlers = &zend_ffi_handlers;
 
 	ffi->lib = NULL;
 	ffi->symbols = NULL;
@@ -2473,7 +2470,6 @@ static zval *zend_ffi_read_var(zend_object *obj, zend_string *var_name, int read
 
 		cdata = emalloc(sizeof(zend_ffi_cdata));
 		zend_ffi_object_init(&cdata->std, zend_ffi_cdata_ce);
-		cdata->std.handlers = &zend_ffi_cdata_handlers;
 		cdata->type = ZEND_FFI_TYPE_MAKE_OWNED(new_type);
 		cdata->flags = ZEND_FFI_FLAG_CONST;
 		cdata->ptr_holder = sym->addr;
@@ -5305,6 +5301,7 @@ ZEND_MINIT_FUNCTION(ffi)
 
 	zend_ffi_ce = register_class_FFI();
 	zend_ffi_ce->create_object = zend_ffi_new;
+	zend_ffi_ce->default_object_handlers = &zend_ffi_handlers;
 
 	memcpy(&zend_ffi_new_fn, zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "new", sizeof("new")-1), sizeof(zend_internal_function));
 	zend_ffi_new_fn.fn_flags &= ~ZEND_ACC_STATIC;
@@ -5336,6 +5333,7 @@ ZEND_MINIT_FUNCTION(ffi)
 
 	zend_ffi_cdata_ce = register_class_FFI_CData();
 	zend_ffi_cdata_ce->create_object = zend_ffi_cdata_new;
+	zend_ffi_cdata_ce->default_object_handlers = &zend_ffi_cdata_handlers;
 	zend_ffi_cdata_ce->get_iterator = zend_ffi_cdata_get_iterator;
 
 	memcpy(&zend_ffi_cdata_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
@@ -5410,6 +5408,7 @@ ZEND_MINIT_FUNCTION(ffi)
 
 	zend_ffi_ctype_ce = register_class_FFI_CType();
 	zend_ffi_ctype_ce->create_object = zend_ffi_ctype_new;
+	zend_ffi_ctype_ce->default_object_handlers = &zend_ffi_ctype_handlers;
 
 	memcpy(&zend_ffi_ctype_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	zend_ffi_ctype_handlers.get_constructor      = zend_fake_get_constructor;

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -89,7 +89,6 @@ PHP_FILEINFO_API zend_object *finfo_objects_new(zend_class_entry *class_type)
 
 	zend_object_std_init(&intern->zo, class_type);
 	object_properties_init(&intern->zo, class_type);
-	intern->zo.handlers = &finfo_object_handlers;
 
 	return &intern->zo;
 }
@@ -108,6 +107,7 @@ PHP_MINIT_FUNCTION(finfo)
 {
 	finfo_class_entry = register_class_finfo();
 	finfo_class_entry->create_object = finfo_objects_new;
+	finfo_class_entry->default_object_handlers = &finfo_object_handlers;
 
 	/* copy the standard object handlers to you handler table */
 	memcpy(&finfo_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -177,7 +177,6 @@ zend_object *php_gd_image_object_create(zend_class_entry *class_type)
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &php_gd_image_object_handlers;
 
 	return &intern->std;
 }
@@ -207,6 +206,7 @@ static void php_gd_object_minit_helper(void)
 {
 	gd_image_ce = register_class_GdImage();
 	gd_image_ce->create_object = php_gd_image_object_create;
+	gd_image_ce->default_object_handlers = &php_gd_image_object_handlers;
 
 	/* setting up the object handlers for the GdImage class */
 	memcpy(&php_gd_image_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));

--- a/ext/gmp/gmp.c
+++ b/ext/gmp/gmp.c
@@ -256,7 +256,6 @@ static inline zend_object *gmp_create_object_ex(zend_class_entry *ce, mpz_ptr *g
 
 	mpz_init(intern->num);
 	*gmpnum_target = intern->num;
-	intern->std.handlers = &gmp_object_handlers;
 
 	return &intern->std;
 }
@@ -533,6 +532,7 @@ ZEND_MINIT_FUNCTION(gmp)
 {
 	gmp_ce = register_class_GMP();
 	gmp_ce->create_object = gmp_create_object;
+	gmp_ce->default_object_handlers = &gmp_object_handlers;
 	gmp_ce->serialize = gmp_serialize;
 	gmp_ce->unserialize = gmp_unserialize;
 

--- a/ext/intl/breakiterator/breakiterator_class.cpp
+++ b/ext/intl/breakiterator/breakiterator_class.cpp
@@ -209,8 +209,6 @@ static zend_object *BreakIterator_object_create(zend_class_entry *ce)
 	object_properties_init(&intern->zo, ce);
 	breakiterator_object_init(intern);
 
-	intern->zo.handlers = &BreakIterator_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -224,6 +222,7 @@ U_CFUNC void breakiterator_register_BreakIterator_class(void)
 
 	BreakIterator_ce_ptr = register_class_IntlBreakIterator(zend_ce_aggregate);
 	BreakIterator_ce_ptr->create_object = BreakIterator_object_create;
+	BreakIterator_ce_ptr->default_object_handlers = &BreakIterator_handlers;
 	BreakIterator_ce_ptr->get_iterator = _breakiterator_get_iterator;
 
 	memcpy(&BreakIterator_handlers, &std_object_handlers,

--- a/ext/intl/calendar/calendar_class.cpp
+++ b/ext/intl/calendar/calendar_class.cpp
@@ -256,9 +256,6 @@ static zend_object *Calendar_object_create(zend_class_entry *ce)
     object_properties_init(&intern->zo, ce);
 	calendar_object_init(intern);
 
-
-	intern->zo.handlers = &Calendar_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -270,6 +267,7 @@ void calendar_register_IntlCalendar_class(void)
 {
 	/* Create and register 'IntlCalendar' class. */
 	Calendar_ce_ptr = register_class_IntlCalendar();
+	Calendar_ce_ptr->default_object_handlers = &Calendar_handlers;
 	Calendar_ce_ptr->create_object = Calendar_object_create;
 
 	memcpy( &Calendar_handlers, &std_object_handlers,

--- a/ext/intl/collator/collator_class.c
+++ b/ext/intl/collator/collator_class.c
@@ -50,8 +50,6 @@ zend_object *Collator_object_create(zend_class_entry *ce )
 	zend_object_std_init(&intern->zo, ce );
 	object_properties_init(&intern->zo, ce);
 
-	intern->zo.handlers = &Collator_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -70,6 +68,7 @@ void collator_register_Collator_symbols(int module_number)
 	/* Create and register 'Collator' class. */
 	Collator_ce_ptr = register_class_Collator();
 	Collator_ce_ptr->create_object = Collator_object_create;
+	Collator_ce_ptr->default_object_handlers = &Collator_handlers;
 
 	memcpy(&Collator_handlers, &std_object_handlers,
 		sizeof Collator_handlers);

--- a/ext/intl/common/common_enum.cpp
+++ b/ext/intl/common/common_enum.cpp
@@ -200,8 +200,6 @@ static zend_object *IntlIterator_object_create(zend_class_entry *ce)
 
 	intern->iterator = NULL;
 
-	intern->zo.handlers = &IntlIterator_handlers;
-
 	return &intern->zo;
 }
 
@@ -287,6 +285,7 @@ U_CFUNC void intl_register_common_symbols(int module_number)
 	/* Create and register 'IntlIterator' class. */
 	IntlIterator_ce_ptr = register_class_IntlIterator(zend_ce_iterator);
 	IntlIterator_ce_ptr->create_object = IntlIterator_object_create;
+	IntlIterator_ce_ptr->default_object_handlers = &IntlIterator_handlers;
 	IntlIterator_ce_ptr->get_iterator = IntlIterator_get_iterator;
 
 	memcpy(&IntlIterator_handlers, &std_object_handlers,

--- a/ext/intl/converter/converter.c
+++ b/ext/intl/converter/converter.c
@@ -911,7 +911,6 @@ static zend_object *php_converter_object_ctor(zend_class_entry *ce, php_converte
 	object_properties_init(&objval->obj, ce);
 	intl_error_init(&(objval->error));
 
-	objval->obj.handlers = &php_converter_object_handlers;
 	*pobjval = objval;
 
 	return &objval->obj;
@@ -973,6 +972,7 @@ static zend_object *php_converter_clone_object(zend_object *object) {
 int php_converter_minit(INIT_FUNC_ARGS) {
 	php_converter_ce = register_class_UConverter();
 	php_converter_ce->create_object = php_converter_create_object;
+	php_converter_ce->default_object_handlers = &php_converter_object_handlers;
 	memcpy(&php_converter_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	php_converter_object_handlers.offset = XtOffsetOf(php_converter_object, obj);
 	php_converter_object_handlers.clone_obj = php_converter_clone_object;

--- a/ext/intl/dateformat/dateformat_class.c
+++ b/ext/intl/dateformat/dateformat_class.c
@@ -57,8 +57,6 @@ zend_object *IntlDateFormatter_object_create(zend_class_entry *ce)
 	intern->calendar			= -1;
 	intern->requested_locale	= NULL;
 
-	intern->zo.handlers = &IntlDateFormatter_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -104,6 +102,7 @@ void dateformat_register_IntlDateFormatter_class( void )
 	/* Create and register 'IntlDateFormatter' class. */
 	IntlDateFormatter_ce_ptr = register_class_IntlDateFormatter();
 	IntlDateFormatter_ce_ptr->create_object = IntlDateFormatter_object_create;
+	IntlDateFormatter_ce_ptr->default_object_handlers = &IntlDateFormatter_handlers;
 
 	memcpy(&IntlDateFormatter_handlers, &std_object_handlers,
 		sizeof IntlDateFormatter_handlers);

--- a/ext/intl/dateformat/datepatterngenerator_class.cpp
+++ b/ext/intl/dateformat/datepatterngenerator_class.cpp
@@ -98,8 +98,6 @@ static zend_object *IntlDatePatternGenerator_object_create(zend_class_entry *ce)
 	object_properties_init(&intern->zo, ce);
 	IntlDatePatternGenerator_object_init(intern);
 
-	intern->zo.handlers = &IntlDatePatternGenerator_handlers;
-
 	return &intern->zo;
 }
 
@@ -115,6 +113,7 @@ void dateformat_register_IntlDatePatternGenerator_class( void )
 	/* Create and register 'IntlDatePatternGenerator' class. */
 	IntlDatePatternGenerator_ce_ptr = register_class_IntlDatePatternGenerator();
 	IntlDatePatternGenerator_ce_ptr->create_object = IntlDatePatternGenerator_object_create;
+	IntlDatePatternGenerator_ce_ptr->default_object_handlers = &IntlDatePatternGenerator_handlers;
 
 	memcpy(&IntlDatePatternGenerator_handlers, &std_object_handlers,
 		sizeof IntlDatePatternGenerator_handlers);

--- a/ext/intl/formatter/formatter_class.c
+++ b/ext/intl/formatter/formatter_class.c
@@ -51,8 +51,6 @@ zend_object *NumberFormatter_object_create(zend_class_entry *ce)
 	zend_object_std_init( &intern->zo, ce );
 	object_properties_init(&intern->zo, ce);
 
-	intern->zo.handlers = &NumberFormatter_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -99,6 +97,7 @@ void formatter_register_class( void )
 	/* Create and register 'NumberFormatter' class. */
 	NumberFormatter_ce_ptr = register_class_NumberFormatter();
 	NumberFormatter_ce_ptr->create_object = NumberFormatter_object_create;
+	NumberFormatter_ce_ptr->default_object_handlers = &NumberFormatter_handlers;
 
 	memcpy(&NumberFormatter_handlers, &std_object_handlers,
 		sizeof(NumberFormatter_handlers));

--- a/ext/intl/msgformat/msgformat_class.c
+++ b/ext/intl/msgformat/msgformat_class.c
@@ -49,8 +49,6 @@ zend_object *MessageFormatter_object_create(zend_class_entry *ce)
 	zend_object_std_init( &intern->zo, ce );
 	object_properties_init(&intern->zo, ce);
 
-	intern->zo.handlers = &MessageFormatter_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -98,6 +96,7 @@ void msgformat_register_class( void )
 	/* Create and register 'MessageFormatter' class. */
 	MessageFormatter_ce_ptr = register_class_MessageFormatter();
 	MessageFormatter_ce_ptr->create_object = MessageFormatter_object_create;
+	MessageFormatter_ce_ptr->default_object_handlers = &MessageFormatter_handlers;
 
 	memcpy(&MessageFormatter_handlers, &std_object_handlers,
 		sizeof MessageFormatter_handlers);

--- a/ext/intl/resourcebundle/resourcebundle_class.c
+++ b/ext/intl/resourcebundle/resourcebundle_class.c
@@ -67,8 +67,6 @@ static zend_object *ResourceBundle_object_create( zend_class_entry *ce )
 	rb->me = NULL;
 	rb->child = NULL;
 
-	rb->zend.handlers = &ResourceBundle_object_handlers;
-
 	return &rb->zend;
 }
 /* }}} */
@@ -375,6 +373,7 @@ void resourcebundle_register_class( void )
 {
 	ResourceBundle_ce_ptr = register_class_ResourceBundle(zend_ce_aggregate, zend_ce_countable);
 	ResourceBundle_ce_ptr->create_object = ResourceBundle_object_create;
+	ResourceBundle_ce_ptr->default_object_handlers = &ResourceBundle_object_handlers;
 	ResourceBundle_ce_ptr->get_iterator = resourcebundle_get_iterator;
 
 	ResourceBundle_object_handlers = std_object_handlers;

--- a/ext/intl/spoofchecker/spoofchecker_class.c
+++ b/ext/intl/spoofchecker/spoofchecker_class.c
@@ -47,8 +47,6 @@ zend_object *Spoofchecker_object_create(zend_class_entry *ce)
 	zend_object_std_init(&intern->zo, ce);
 	object_properties_init(&intern->zo, ce);
 
-	intern->zo.handlers = &Spoofchecker_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -93,6 +91,7 @@ void spoofchecker_register_Spoofchecker_class(void)
 	/* Create and register 'Spoofchecker' class. */
 	Spoofchecker_ce_ptr = register_class_Spoofchecker();
 	Spoofchecker_ce_ptr->create_object = Spoofchecker_object_create;
+	Spoofchecker_ce_ptr->default_object_handlers = &Spoofchecker_handlers;
 
 	memcpy(&Spoofchecker_handlers, &std_object_handlers,
 		sizeof Spoofchecker_handlers);

--- a/ext/intl/timezone/timezone_class.cpp
+++ b/ext/intl/timezone/timezone_class.cpp
@@ -377,8 +377,6 @@ static zend_object *TimeZone_object_create(zend_class_entry *ce)
     object_properties_init(&intern->zo, ce);
 	TimeZone_object_init(intern);
 
-	intern->zo.handlers = &TimeZone_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -391,6 +389,7 @@ U_CFUNC void timezone_register_IntlTimeZone_class(void)
 	/* Create and register 'IntlTimeZone' class. */
 	TimeZone_ce_ptr = register_class_IntlTimeZone();
 	TimeZone_ce_ptr->create_object = TimeZone_object_create;
+	TimeZone_ce_ptr->default_object_handlers = &TimeZone_handlers;
 
 	memcpy(&TimeZone_handlers, &std_object_handlers,
 		sizeof TimeZone_handlers);

--- a/ext/intl/transliterator/transliterator_class.c
+++ b/ext/intl/transliterator/transliterator_class.c
@@ -117,8 +117,6 @@ static zend_object *Transliterator_object_create( zend_class_entry *ce )
 	object_properties_init( &intern->zo, ce );
 	transliterator_object_init( intern );
 
-	intern->zo.handlers = &Transliterator_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -184,6 +182,7 @@ void transliterator_register_Transliterator_class( void )
 	/* Create and register 'Transliterator' class. */
 	Transliterator_ce_ptr = register_class_Transliterator();
 	Transliterator_ce_ptr->create_object = Transliterator_object_create;
+	Transliterator_ce_ptr->default_object_handlers = &Transliterator_handlers;
 	memcpy( &Transliterator_handlers, &std_object_handlers, sizeof Transliterator_handlers );
 	Transliterator_handlers.offset = XtOffsetOf(Transliterator_object, zo);
 	Transliterator_handlers.free_obj = Transliterator_objects_free;

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -115,7 +115,6 @@ static zend_object *ldap_link_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &ldap_link_object_handlers;
 
 	return &intern->std;
 }
@@ -161,7 +160,6 @@ static zend_object *ldap_result_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &ldap_result_object_handlers;
 
 	return &intern->std;
 }
@@ -199,7 +197,6 @@ static zend_object *ldap_result_entry_create_object(zend_class_entry *class_type
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &ldap_result_entry_object_handlers;
 
 	return &intern->std;
 }
@@ -828,6 +825,7 @@ PHP_MINIT_FUNCTION(ldap)
 
 	ldap_link_ce = register_class_LDAP_Connection();
 	ldap_link_ce->create_object = ldap_link_create_object;
+	ldap_link_ce->default_object_handlers = &ldap_link_object_handlers;
 
 	memcpy(&ldap_link_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	ldap_link_object_handlers.offset = XtOffsetOf(ldap_linkdata, std);
@@ -838,6 +836,7 @@ PHP_MINIT_FUNCTION(ldap)
 
 	ldap_result_ce = register_class_LDAP_Result();
 	ldap_result_ce->create_object = ldap_result_create_object;
+	ldap_result_ce->default_object_handlers = &ldap_result_object_handlers;
 
 	memcpy(&ldap_result_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	ldap_result_object_handlers.offset = XtOffsetOf(ldap_resultdata, std);
@@ -848,6 +847,7 @@ PHP_MINIT_FUNCTION(ldap)
 
 	ldap_result_entry_ce = register_class_LDAP_ResultEntry();
 	ldap_result_entry_ce->create_object = ldap_result_entry_create_object;
+	ldap_result_entry_ce->default_object_handlers = &ldap_result_entry_object_handlers;
 
 	memcpy(&ldap_result_entry_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	ldap_result_entry_object_handlers.offset = XtOffsetOf(ldap_result_entry, std);

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -144,7 +144,6 @@ static zend_object *php_openssl_certificate_create_object(zend_class_entry *clas
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &php_openssl_certificate_object_handlers;
 
 	return &intern->std;
 }
@@ -184,7 +183,6 @@ static zend_object *php_openssl_request_create_object(zend_class_entry *class_ty
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &php_openssl_request_object_handlers;
 
 	return &intern->std;
 }
@@ -225,7 +223,6 @@ static zend_object *php_openssl_pkey_create_object(zend_class_entry *class_type)
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &php_openssl_pkey_object_handlers;
 
 	return &intern->std;
 }
@@ -1215,6 +1212,7 @@ PHP_MINIT_FUNCTION(openssl)
 
 	php_openssl_certificate_ce = register_class_OpenSSLCertificate();
 	php_openssl_certificate_ce->create_object = php_openssl_certificate_create_object;
+	php_openssl_certificate_ce->default_object_handlers = &php_openssl_certificate_object_handlers;
 
 	memcpy(&php_openssl_certificate_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	php_openssl_certificate_object_handlers.offset = XtOffsetOf(php_openssl_certificate_object, std);
@@ -1225,6 +1223,7 @@ PHP_MINIT_FUNCTION(openssl)
 
 	php_openssl_request_ce = register_class_OpenSSLCertificateSigningRequest();
 	php_openssl_request_ce->create_object = php_openssl_request_create_object;
+	php_openssl_request_ce->default_object_handlers = &php_openssl_request_object_handlers;
 
 	memcpy(&php_openssl_request_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	php_openssl_request_object_handlers.offset = XtOffsetOf(php_openssl_request_object, std);
@@ -1235,6 +1234,7 @@ PHP_MINIT_FUNCTION(openssl)
 
 	php_openssl_pkey_ce = register_class_OpenSSLAsymmetricKey();
 	php_openssl_pkey_ce->create_object = php_openssl_pkey_create_object;
+	php_openssl_pkey_ce->default_object_handlers = &php_openssl_pkey_object_handlers;
 
 	memcpy(&php_openssl_pkey_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	php_openssl_pkey_object_handlers.offset = XtOffsetOf(php_openssl_pkey_object, std);

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1333,6 +1333,7 @@ void pdo_dbh_init(int module_number)
 {
 	pdo_dbh_ce = register_class_PDO();
 	pdo_dbh_ce->create_object = pdo_dbh_new;
+	pdo_dbh_ce->default_object_handlers = &pdo_dbh_object_handlers;
 
 	memcpy(&pdo_dbh_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	pdo_dbh_object_handlers.offset = XtOffsetOf(pdo_dbh_object_t, std);
@@ -1418,8 +1419,6 @@ zend_object *pdo_dbh_new(zend_class_entry *ce)
 	rebuild_object_properties(&dbh->std);
 	dbh->inner = ecalloc(1, sizeof(pdo_dbh_t));
 	dbh->inner->def_stmt_ce = pdo_dbstmt_ce;
-
-	dbh->std.handlers = &pdo_dbh_object_handlers;
 
 	return &dbh->std;
 }

--- a/ext/pdo/pdo_stmt.c
+++ b/ext/pdo/pdo_stmt.c
@@ -218,7 +218,6 @@ static void get_lazy_object(pdo_stmt_t *stmt, zval *return_value) /* {{{ */
 		row->stmt = stmt;
 		zend_object_std_init(&row->std, pdo_row_ce);
 		ZVAL_OBJ(&stmt->lazy_object_ref, &row->std);
-		row->std.handlers = &pdo_row_object_handlers;
 		GC_ADDREF(&stmt->std);
 		GC_DELREF(&row->std);
 	}
@@ -2137,8 +2136,6 @@ zend_object *pdo_dbstmt_new(zend_class_entry *ce)
 	zend_object_std_init(&stmt->std, ce);
 	object_properties_init(&stmt->std, ce);
 
-	stmt->std.handlers = &pdo_dbstmt_object_handlers;
-
 	return &stmt->std;
 }
 /* }}} */
@@ -2464,7 +2461,6 @@ zend_object *pdo_row_new(zend_class_entry *ce)
 {
 	pdo_row_t *row = ecalloc(1, sizeof(pdo_row_t));
 	zend_object_std_init(&row->std, ce);
-	row->std.handlers = &pdo_row_object_handlers;
 
 	return &row->std;
 }
@@ -2474,6 +2470,7 @@ void pdo_stmt_init(void)
 	pdo_dbstmt_ce = register_class_PDOStatement(zend_ce_aggregate);
 	pdo_dbstmt_ce->get_iterator = pdo_stmt_iter_get;
 	pdo_dbstmt_ce->create_object = pdo_dbstmt_new;
+	pdo_dbstmt_ce->default_object_handlers = &pdo_dbstmt_object_handlers;
 
 	memcpy(&pdo_dbstmt_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	pdo_dbstmt_object_handlers.offset = XtOffsetOf(pdo_stmt_t, std);
@@ -2486,6 +2483,7 @@ void pdo_stmt_init(void)
 
 	pdo_row_ce = register_class_PDORow();
 	pdo_row_ce->create_object = pdo_row_new;
+	pdo_row_ce->default_object_handlers = &pdo_row_object_handlers;
 
 	memcpy(&pdo_row_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	pdo_row_object_handlers.free_obj = pdo_row_free_storage;

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -157,7 +157,6 @@ static zend_object *pgsql_link_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &pgsql_link_object_handlers;
 
 	return &intern->std;
 }
@@ -213,7 +212,6 @@ static zend_object *pgsql_result_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &pgsql_result_object_handlers;
 
 	return &intern->std;
 }
@@ -251,7 +249,6 @@ static zend_object *pgsql_lob_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &pgsql_lob_object_handlers;
 
 	return &intern->std;
 }
@@ -440,6 +437,7 @@ PHP_MINIT_FUNCTION(pgsql)
 
 	pgsql_link_ce = register_class_PgSql_Connection();
 	pgsql_link_ce->create_object = pgsql_link_create_object;
+	pgsql_link_ce->default_object_handlers = &pgsql_link_object_handlers;
 
 	memcpy(&pgsql_link_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	pgsql_link_object_handlers.offset = XtOffsetOf(pgsql_link_handle, std);
@@ -450,6 +448,7 @@ PHP_MINIT_FUNCTION(pgsql)
 
 	pgsql_result_ce = register_class_PgSql_Result();
 	pgsql_result_ce->create_object = pgsql_result_create_object;
+	pgsql_result_ce->default_object_handlers = &pgsql_result_object_handlers;
 
 	memcpy(&pgsql_result_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	pgsql_result_object_handlers.offset = XtOffsetOf(pgsql_result_handle, std);
@@ -460,6 +459,7 @@ PHP_MINIT_FUNCTION(pgsql)
 
 	pgsql_lob_ce = register_class_PgSql_Lob();
 	pgsql_lob_ce->create_object = pgsql_lob_create_object;
+	pgsql_lob_ce->default_object_handlers = &pgsql_lob_object_handlers;
 
 	memcpy(&pgsql_lob_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	pgsql_lob_object_handlers.offset = XtOffsetOf(pgLofp, std);

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -227,8 +227,6 @@ static zend_object *php_random_randomizer_new(zend_class_entry *ce)
 	zend_object_std_init(&randomizer->std, ce);
 	object_properties_init(&randomizer->std, ce);
 
-	randomizer->std.handlers = &random_randomizer_object_handlers;
-
 	return &randomizer->std;
 }
 
@@ -880,6 +878,7 @@ PHP_MINIT_FUNCTION(random)
 	/* Random\Randomizer */
 	random_ce_Random_Randomizer = register_class_Random_Randomizer();
 	random_ce_Random_Randomizer->create_object = php_random_randomizer_new;
+	random_ce_Random_Randomizer->default_object_handlers = &random_randomizer_object_handlers;
 	memcpy(&random_randomizer_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	random_randomizer_object_handlers.offset = XtOffsetOf(php_random_randomizer, std);
 	random_randomizer_object_handlers.free_obj = randomizer_free_obj;

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -283,7 +283,6 @@ static zend_object *reflection_objects_new(zend_class_entry *class_type) /* {{{ 
 
 	zend_object_std_init(&intern->zo, class_type);
 	object_properties_init(&intern->zo, class_type);
-	intern->zo.handlers = &reflection_object_handlers;
 	return &intern->zo;
 }
 /* }}} */
@@ -7127,67 +7126,88 @@ PHP_MINIT_FUNCTION(reflection) /* {{{ */
 	reflector_ptr = register_class_Reflector(zend_ce_stringable);
 
 	reflection_function_abstract_ptr = register_class_ReflectionFunctionAbstract(reflector_ptr);
+	reflection_function_abstract_ptr->default_object_handlers = &reflection_object_handlers;
 	reflection_function_abstract_ptr->create_object = reflection_objects_new;
 
 	reflection_function_ptr = register_class_ReflectionFunction(reflection_function_abstract_ptr);
 	reflection_function_ptr->create_object = reflection_objects_new;
+	reflection_function_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_generator_ptr = register_class_ReflectionGenerator();
 	reflection_generator_ptr->create_object = reflection_objects_new;
+	reflection_generator_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_parameter_ptr = register_class_ReflectionParameter(reflector_ptr);
 	reflection_parameter_ptr->create_object = reflection_objects_new;
+	reflection_parameter_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_type_ptr = register_class_ReflectionType(zend_ce_stringable);
 	reflection_type_ptr->create_object = reflection_objects_new;
+	reflection_type_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_named_type_ptr = register_class_ReflectionNamedType(reflection_type_ptr);
 	reflection_named_type_ptr->create_object = reflection_objects_new;
+	reflection_named_type_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_union_type_ptr = register_class_ReflectionUnionType(reflection_type_ptr);
 	reflection_union_type_ptr->create_object = reflection_objects_new;
+	reflection_union_type_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_intersection_type_ptr = register_class_ReflectionIntersectionType(reflection_type_ptr);
 	reflection_intersection_type_ptr->create_object = reflection_objects_new;
+	reflection_intersection_type_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_method_ptr = register_class_ReflectionMethod(reflection_function_abstract_ptr);
 	reflection_method_ptr->create_object = reflection_objects_new;
+	reflection_method_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_class_ptr = register_class_ReflectionClass(reflector_ptr);
 	reflection_class_ptr->create_object = reflection_objects_new;
+	reflection_class_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_object_ptr = register_class_ReflectionObject(reflection_class_ptr);
 	reflection_object_ptr->create_object = reflection_objects_new;
+	reflection_object_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_property_ptr = register_class_ReflectionProperty(reflector_ptr);
 	reflection_property_ptr->create_object = reflection_objects_new;
+	reflection_property_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_class_constant_ptr = register_class_ReflectionClassConstant(reflector_ptr);
 	reflection_class_constant_ptr->create_object = reflection_objects_new;
+	reflection_class_constant_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_extension_ptr = register_class_ReflectionExtension(reflector_ptr);
 	reflection_extension_ptr->create_object = reflection_objects_new;
+	reflection_extension_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_zend_extension_ptr = register_class_ReflectionZendExtension(reflector_ptr);
 	reflection_zend_extension_ptr->create_object = reflection_objects_new;
+	reflection_zend_extension_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_reference_ptr = register_class_ReflectionReference();
 	reflection_reference_ptr->create_object = reflection_objects_new;
+	reflection_reference_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_attribute_ptr = register_class_ReflectionAttribute(reflector_ptr);
 	reflection_attribute_ptr->create_object = reflection_objects_new;
+	reflection_attribute_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_enum_ptr = register_class_ReflectionEnum(reflection_class_ptr);
 	reflection_enum_ptr->create_object = reflection_objects_new;
+	reflection_enum_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_enum_unit_case_ptr = register_class_ReflectionEnumUnitCase(reflection_class_constant_ptr);
 	reflection_enum_unit_case_ptr->create_object = reflection_objects_new;
+	reflection_enum_unit_case_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_enum_backed_case_ptr = register_class_ReflectionEnumBackedCase(reflection_enum_unit_case_ptr);
 	reflection_enum_backed_case_ptr->create_object = reflection_objects_new;
+	reflection_enum_backed_case_ptr->default_object_handlers = &reflection_object_handlers;
 
 	reflection_fiber_ptr = register_class_ReflectionFiber();
 	reflection_fiber_ptr->create_object = reflection_objects_new;
+	reflection_fiber_ptr->default_object_handlers = &reflection_object_handlers;
 
 	REFLECTION_G(key_initialized) = 0;
 

--- a/ext/shmop/shmop.c
+++ b/ext/shmop/shmop.c
@@ -84,7 +84,6 @@ static zend_object *shmop_create_object(zend_class_entry *class_type)
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &shmop_object_handlers;
 
 	return &intern->std;
 }
@@ -109,6 +108,7 @@ PHP_MINIT_FUNCTION(shmop)
 {
 	shmop_ce = register_class_Shmop();
 	shmop_ce->create_object = shmop_create_object;
+	shmop_ce->default_object_handlers = &shmop_object_handlers;
 
 	memcpy(&shmop_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	shmop_object_handlers.offset = XtOffsetOf(php_shmop, std);

--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -2222,7 +2222,6 @@ static php_sxe_object* php_sxe_object_new(zend_class_entry *ce, zend_function *f
 
 	zend_object_std_init(&intern->zo, ce);
 	object_properties_init(&intern->zo, ce);
-	intern->zo.handlers = &sxe_object_handlers;
 
 	return intern;
 }
@@ -2673,6 +2672,7 @@ PHP_MINIT_FUNCTION(simplexml)
 {
 	sxe_class_entry = register_class_SimpleXMLElement(zend_ce_stringable, zend_ce_countable, spl_ce_RecursiveIterator);
 	sxe_class_entry->create_object = sxe_object_new;
+	sxe_class_entry->default_object_handlers = &sxe_object_handlers;
 	sxe_class_entry->get_iterator = php_sxe_get_iterator;
 
 	memcpy(&sxe_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));

--- a/ext/snmp/snmp.c
+++ b/ext/snmp/snmp.c
@@ -185,8 +185,6 @@ static zend_object *php_snmp_object_new(zend_class_entry *class_type) /* {{{ */
 	zend_object_std_init(&intern->zo, class_type);
 	object_properties_init(&intern->zo, class_type);
 
-	intern->zo.handlers = &php_snmp_object_handlers;
-
 	return &intern->zo;
 
 }
@@ -2024,6 +2022,7 @@ PHP_MINIT_FUNCTION(snmp)
 	/* Register SNMP Class */
 	php_snmp_ce = register_class_SNMP();
 	php_snmp_ce->create_object = php_snmp_object_new;
+	php_snmp_ce->default_object_handlers = &php_snmp_object_handlers;
 	php_snmp_object_handlers.offset = XtOffsetOf(php_snmp_object, zo);
 	php_snmp_object_handlers.clone_obj = NULL;
 	php_snmp_object_handlers.free_obj = php_snmp_object_free_storage;

--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -194,7 +194,6 @@ static zend_object *soap_server_object_create(zend_class_entry *ce)
 	soap_server_object *obj = zend_object_alloc(sizeof(soap_server_object), ce);
 	zend_object_std_init(&obj->std, ce);
 	object_properties_init(&obj->std, ce);
-	obj->std.handlers = &soap_server_object_handlers;
 	return &obj->std;
 }
 
@@ -407,6 +406,7 @@ PHP_MINIT_FUNCTION(soap)
 	/* Register SoapServer class */
 	soap_server_class_entry = register_class_SoapServer();
 	soap_server_class_entry->create_object = soap_server_object_create;
+	soap_server_class_entry->default_object_handlers = &soap_server_object_handlers;
 
 	memcpy(&soap_server_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	soap_server_object_handlers.offset = XtOffsetOf(soap_server_object, std);

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -101,7 +101,6 @@ static zend_object *socket_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &socket_object_handlers;
 
 	intern->bsd_socket = -1; /* invalid socket */
 	intern->type		 = PF_UNSPEC;
@@ -163,7 +162,6 @@ static zend_object *address_info_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &address_info_object_handlers;
 
 	return &intern->std;
 }
@@ -428,6 +426,7 @@ static PHP_MINIT_FUNCTION(sockets)
 
 	socket_ce = register_class_Socket();
 	socket_ce->create_object = socket_create_object;
+	socket_ce->default_object_handlers = &socket_object_handlers;
 
 	memcpy(&socket_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	socket_object_handlers.offset = XtOffsetOf(php_socket, std);
@@ -439,6 +438,7 @@ static PHP_MINIT_FUNCTION(sockets)
 
 	address_info_ce = register_class_AddressInfo();
 	address_info_ce->create_object = address_info_create_object;
+	address_info_ce->default_object_handlers = &address_info_object_handlers;
 
 	memcpy(&address_info_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	address_info_object_handlers.offset = XtOffsetOf(php_addrinfo, std);

--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -177,11 +177,7 @@ static zend_object *spl_array_object_new_ex(zend_class_entry *class_type, zend_o
 	}
 
 	while (parent) {
-		if (parent == spl_ce_ArrayIterator || parent == spl_ce_RecursiveArrayIterator) {
-			intern->std.handlers = &spl_handler_ArrayIterator;
-			break;
-		} else if (parent == spl_ce_ArrayObject) {
-			intern->std.handlers = &spl_handler_ArrayObject;
+		if (parent == spl_ce_ArrayIterator || parent == spl_ce_RecursiveArrayIterator || parent == spl_ce_ArrayObject) {
 			break;
 		}
 		parent = parent->parent;
@@ -1778,6 +1774,7 @@ PHP_MINIT_FUNCTION(spl_array)
 {
 	spl_ce_ArrayObject = register_class_ArrayObject(zend_ce_aggregate, zend_ce_arrayaccess, zend_ce_serializable, zend_ce_countable);
 	spl_ce_ArrayObject->create_object = spl_array_object_new;
+	spl_ce_ArrayObject->default_object_handlers = &spl_handler_ArrayObject;
 
 	memcpy(&spl_handler_ArrayObject, &std_object_handlers, sizeof(zend_object_handlers));
 
@@ -1803,6 +1800,7 @@ PHP_MINIT_FUNCTION(spl_array)
 
 	spl_ce_ArrayIterator = register_class_ArrayIterator(spl_ce_SeekableIterator, zend_ce_arrayaccess, zend_ce_serializable, zend_ce_countable);
 	spl_ce_ArrayIterator->create_object = spl_array_object_new;
+	spl_ce_ArrayIterator->default_object_handlers = &spl_handler_ArrayIterator;
 	spl_ce_ArrayIterator->get_iterator = spl_array_get_iterator;
 
 	memcpy(&spl_handler_ArrayIterator, &spl_handler_ArrayObject, sizeof(zend_object_handlers));

--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -199,7 +199,6 @@ static zend_object *spl_filesystem_object_new_ex(zend_class_entry *class_type)
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &spl_filesystem_object_handlers;
 
 	return &intern->std;
 }
@@ -210,15 +209,6 @@ static zend_object *spl_filesystem_object_new_ex(zend_class_entry *class_type)
 static zend_object *spl_filesystem_object_new(zend_class_entry *class_type)
 {
 	return spl_filesystem_object_new_ex(class_type);
-}
-/* }}} */
-
-/* {{{ spl_filesystem_object_new_check */
-static zend_object *spl_filesystem_object_new_check(zend_class_entry *class_type)
-{
-	spl_filesystem_object *ret = spl_filesystem_from_obj(spl_filesystem_object_new_ex(class_type));
-	ret->std.handlers = &spl_filesystem_object_check_handlers;
-	return &ret->std;
 }
 /* }}} */
 
@@ -2756,6 +2746,7 @@ PHP_MINIT_FUNCTION(spl_directory)
 {
 	spl_ce_SplFileInfo = register_class_SplFileInfo(zend_ce_stringable);
 	spl_ce_SplFileInfo->create_object = spl_filesystem_object_new;
+	spl_ce_SplFileInfo->default_object_handlers = &spl_filesystem_object_handlers;
 
 	memcpy(&spl_filesystem_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	spl_filesystem_object_handlers.offset = XtOffsetOf(spl_filesystem_object, std);
@@ -2781,14 +2772,16 @@ PHP_MINIT_FUNCTION(spl_directory)
 
 #ifdef HAVE_GLOB
 	spl_ce_GlobIterator = register_class_GlobIterator(spl_ce_FilesystemIterator, zend_ce_countable);
-	spl_ce_GlobIterator->create_object = spl_filesystem_object_new_check;
+	spl_ce_GlobIterator->create_object = spl_filesystem_object_new;
+	spl_ce_GlobIterator->default_object_handlers = &spl_filesystem_object_check_handlers;
 #endif
 
 	spl_ce_SplFileObject = register_class_SplFileObject(spl_ce_SplFileInfo, spl_ce_RecursiveIterator, spl_ce_SeekableIterator);
-	spl_ce_SplFileObject->create_object = spl_filesystem_object_new_check;
+	spl_ce_SplFileObject->default_object_handlers = &spl_filesystem_object_check_handlers;
+	spl_ce_SplFileObject->create_object = spl_filesystem_object_new;
 
 	spl_ce_SplTempFileObject = register_class_SplTempFileObject(spl_ce_SplFileObject);
-	spl_ce_SplTempFileObject->create_object = spl_filesystem_object_new_check;
+	spl_ce_SplTempFileObject->create_object = spl_filesystem_object_new;
 
 	return SUCCESS;
 }

--- a/ext/spl/spl_dllist.c
+++ b/ext/spl/spl_dllist.c
@@ -344,14 +344,11 @@ static zend_object *spl_dllist_object_new_ex(zend_class_entry *class_type, zend_
 	while (parent) {
 		if (parent == spl_ce_SplStack) {
 			intern->flags |= (SPL_DLLIST_IT_FIX | SPL_DLLIST_IT_LIFO);
-			intern->std.handlers = &spl_handler_SplDoublyLinkedList;
 		} else if (parent == spl_ce_SplQueue) {
 			intern->flags |= SPL_DLLIST_IT_FIX;
-			intern->std.handlers = &spl_handler_SplDoublyLinkedList;
 		}
 
 		if (parent == spl_ce_SplDoublyLinkedList) {
-			intern->std.handlers = &spl_handler_SplDoublyLinkedList;
 			break;
 		}
 
@@ -1257,6 +1254,7 @@ PHP_MINIT_FUNCTION(spl_dllist) /* {{{ */
 		zend_ce_iterator, zend_ce_countable, zend_ce_arrayaccess, zend_ce_serializable
 	);
 	spl_ce_SplDoublyLinkedList->create_object = spl_dllist_object_new;
+	spl_ce_SplDoublyLinkedList->default_object_handlers = &spl_handler_SplDoublyLinkedList;
 	spl_ce_SplDoublyLinkedList->get_iterator = spl_dllist_get_iterator;
 
 	memcpy(&spl_handler_SplDoublyLinkedList, &std_object_handlers, sizeof(zend_object_handlers));

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -277,7 +277,6 @@ static zend_object *spl_fixedarray_object_new_ex(zend_class_entry *class_type, z
 
 	while (parent) {
 		if (parent == spl_ce_SplFixedArray) {
-			intern->std.handlers = &spl_handler_SplFixedArray;
 			break;
 		}
 
@@ -882,6 +881,7 @@ PHP_MINIT_FUNCTION(spl_fixedarray)
 	spl_ce_SplFixedArray = register_class_SplFixedArray(
 		zend_ce_aggregate, zend_ce_arrayaccess, zend_ce_countable, php_json_serializable_ce);
 	spl_ce_SplFixedArray->create_object = spl_fixedarray_new;
+	spl_ce_SplFixedArray->default_object_handlers = &spl_handler_SplFixedArray;
 	spl_ce_SplFixedArray->get_iterator = spl_fixedarray_get_iterator;
 
 	memcpy(&spl_handler_SplFixedArray, &std_object_handlers, sizeof(zend_object_handlers));

--- a/ext/spl/spl_heap.c
+++ b/ext/spl/spl_heap.c
@@ -428,7 +428,6 @@ static zend_object *spl_heap_object_new_ex(zend_class_entry *class_type, zend_ob
 	while (parent) {
 		if (parent == spl_ce_SplPriorityQueue) {
 			intern->heap = spl_ptr_heap_init(spl_ptr_pqueue_elem_cmp, spl_ptr_heap_pqueue_elem_ctor, spl_ptr_heap_pqueue_elem_dtor, sizeof(spl_pqueue_elem));
-			intern->std.handlers = &spl_handler_SplPriorityQueue;
 			intern->flags = SPL_PQUEUE_EXTR_DATA;
 			break;
 		}
@@ -438,7 +437,6 @@ static zend_object *spl_heap_object_new_ex(zend_class_entry *class_type, zend_ob
 			intern->heap = spl_ptr_heap_init(
 				parent == spl_ce_SplMinHeap ? spl_ptr_heap_zval_min_cmp : spl_ptr_heap_zval_max_cmp,
 				spl_ptr_heap_zval_ctor, spl_ptr_heap_zval_dtor, sizeof(zval));
-			intern->std.handlers = &spl_handler_SplHeap;
 			break;
 		}
 
@@ -1129,6 +1127,7 @@ PHP_MINIT_FUNCTION(spl_heap) /* {{{ */
 {
 	spl_ce_SplHeap = register_class_SplHeap(zend_ce_iterator, zend_ce_countable);
 	spl_ce_SplHeap->create_object = spl_heap_object_new;
+	spl_ce_SplHeap->default_object_handlers = &spl_handler_SplHeap;
 	spl_ce_SplHeap->get_iterator = spl_heap_get_iterator;
 
 	memcpy(&spl_handler_SplHeap, &std_object_handlers, sizeof(zend_object_handlers));
@@ -1149,6 +1148,7 @@ PHP_MINIT_FUNCTION(spl_heap) /* {{{ */
 
 	spl_ce_SplPriorityQueue = register_class_SplPriorityQueue(zend_ce_iterator, zend_ce_countable);
 	spl_ce_SplPriorityQueue->create_object = spl_heap_object_new;
+	spl_ce_SplPriorityQueue->default_object_handlers = &spl_handler_SplPriorityQueue;
 	spl_ce_SplPriorityQueue->get_iterator = spl_pqueue_get_iterator;
 
 	memcpy(&spl_handler_SplPriorityQueue, &std_object_handlers, sizeof(zend_object_handlers));

--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1019,7 +1019,6 @@ static zend_object *spl_RecursiveIteratorIterator_new_ex(zend_class_entry *class
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 
-	intern->std.handlers = &spl_handlers_rec_it_it;
 	return &intern->std;
 }
 /* }}} */
@@ -2206,7 +2205,6 @@ static zend_object *spl_dual_it_new(zend_class_entry *class_type)
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 
-	intern->std.handlers = &spl_handlers_dual_it;
 	return &intern->std;
 }
 /* }}} */
@@ -3261,6 +3259,7 @@ PHP_MINIT_FUNCTION(spl_iterators)
 
 	spl_ce_RecursiveIteratorIterator = register_class_RecursiveIteratorIterator(spl_ce_OuterIterator);
 	spl_ce_RecursiveIteratorIterator->create_object = spl_RecursiveIteratorIterator_new;
+	spl_ce_RecursiveIteratorIterator->default_object_handlers = &spl_handlers_rec_it_it;
 	spl_ce_RecursiveIteratorIterator->get_iterator = spl_recursive_it_get_iterator;
 
 	memcpy(&spl_handlers_rec_it_it, &std_object_handlers, sizeof(zend_object_handlers));
@@ -3279,6 +3278,7 @@ PHP_MINIT_FUNCTION(spl_iterators)
 
 	spl_ce_IteratorIterator = register_class_IteratorIterator(spl_ce_OuterIterator);
 	spl_ce_IteratorIterator->create_object = spl_dual_it_new;
+	spl_ce_IteratorIterator->default_object_handlers = &spl_handlers_dual_it;
 
 	spl_ce_FilterIterator = register_class_FilterIterator(spl_ce_IteratorIterator);
 	spl_ce_FilterIterator->create_object = spl_dual_it_new;

--- a/ext/spl/spl_observer.c
+++ b/ext/spl/spl_observer.c
@@ -265,8 +265,6 @@ static zend_object *spl_object_storage_new_ex(zend_class_entry *class_type, zend
 
 	zend_hash_init(&intern->storage, 0, NULL, spl_object_storage_dtor, 0);
 
-	intern->std.handlers = &spl_handler_SplObjectStorage;
-
 	while (parent) {
 		if (parent == spl_ce_SplObjectStorage) {
 			/* Possible optimization: Cache these results with a map from class entry to IS_NULL/IS_PTR.
@@ -1329,6 +1327,7 @@ PHP_MINIT_FUNCTION(spl_observer)
 
 	spl_ce_SplObjectStorage = register_class_SplObjectStorage(zend_ce_countable, zend_ce_iterator, zend_ce_serializable, zend_ce_arrayaccess);
 	spl_ce_SplObjectStorage->create_object = spl_SplObjectStorage_new;
+	spl_ce_SplObjectStorage->default_object_handlers = &spl_handler_SplObjectStorage;
 
 	memcpy(&spl_handler_SplObjectStorage, &std_object_handlers, sizeof(zend_object_handlers));
 
@@ -1344,6 +1343,7 @@ PHP_MINIT_FUNCTION(spl_observer)
 
 	spl_ce_MultipleIterator = register_class_MultipleIterator(zend_ce_iterator);
 	spl_ce_MultipleIterator->create_object = spl_SplObjectStorage_new;
+	spl_ce_MultipleIterator->default_object_handlers = &spl_handler_SplObjectStorage;
 
 	return SUCCESS;
 }

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2298,8 +2298,6 @@ static zend_object *php_sqlite3_object_new(zend_class_entry *class_type) /* {{{ 
 	zend_object_std_init(&intern->zo, class_type);
 	object_properties_init(&intern->zo, class_type);
 
-	intern->zo.handlers = &sqlite3_object_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -2314,8 +2312,6 @@ static zend_object *php_sqlite3_stmt_object_new(zend_class_entry *class_type) /*
 	zend_object_std_init(&intern->zo, class_type);
 	object_properties_init(&intern->zo, class_type);
 
-	intern->zo.handlers = &sqlite3_stmt_object_handlers;
-
 	return &intern->zo;
 }
 /* }}} */
@@ -2329,8 +2325,6 @@ static zend_object *php_sqlite3_result_object_new(zend_class_entry *class_type) 
 
 	zend_object_std_init(&intern->zo, class_type);
 	object_properties_init(&intern->zo, class_type);
-
-	intern->zo.handlers = &sqlite3_result_object_handlers;
 
 	return &intern->zo;
 }
@@ -2373,6 +2367,7 @@ PHP_MINIT_FUNCTION(sqlite3)
 	sqlite3_object_handlers.free_obj = php_sqlite3_object_free_storage;
 	php_sqlite3_sc_entry = register_class_SQLite3();
 	php_sqlite3_sc_entry->create_object = php_sqlite3_object_new;
+	php_sqlite3_sc_entry->default_object_handlers = &sqlite3_object_handlers;
 
 	/* Register SQLite 3 Prepared Statement Class */
 	sqlite3_stmt_object_handlers.offset = XtOffsetOf(php_sqlite3_stmt, zo);
@@ -2380,6 +2375,7 @@ PHP_MINIT_FUNCTION(sqlite3)
 	sqlite3_stmt_object_handlers.free_obj = php_sqlite3_stmt_object_free_storage;
 	php_sqlite3_stmt_entry = register_class_SQLite3Stmt();
 	php_sqlite3_stmt_entry->create_object = php_sqlite3_stmt_object_new;
+	php_sqlite3_stmt_entry->default_object_handlers = &sqlite3_stmt_object_handlers;
 
 	/* Register SQLite 3 Result Class */
 	sqlite3_result_object_handlers.offset = XtOffsetOf(php_sqlite3_result, zo);
@@ -2387,6 +2383,7 @@ PHP_MINIT_FUNCTION(sqlite3)
 	sqlite3_result_object_handlers.free_obj = php_sqlite3_result_object_free_storage;
 	php_sqlite3_result_entry = register_class_SQLite3Result();
 	php_sqlite3_result_entry->create_object = php_sqlite3_result_object_new;
+	php_sqlite3_result_entry->default_object_handlers = &sqlite3_result_object_handlers;
 
 	REGISTER_INI_ENTRIES();
 

--- a/ext/sysvmsg/sysvmsg.c
+++ b/ext/sysvmsg/sysvmsg.c
@@ -79,7 +79,6 @@ static zend_object *sysvmsg_queue_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &sysvmsg_queue_object_handlers;
 
 	return &intern->std;
 }
@@ -102,6 +101,7 @@ PHP_MINIT_FUNCTION(sysvmsg)
 {
 	sysvmsg_queue_ce = register_class_SysvMessageQueue();
 	sysvmsg_queue_ce->create_object = sysvmsg_queue_create_object;
+	sysvmsg_queue_ce->default_object_handlers = &sysvmsg_queue_object_handlers;
 
 	memcpy(&sysvmsg_queue_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	sysvmsg_queue_object_handlers.offset = XtOffsetOf(sysvmsg_queue_t, std);

--- a/ext/sysvsem/sysvsem.c
+++ b/ext/sysvsem/sysvsem.c
@@ -100,7 +100,6 @@ static zend_object *sysvsem_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &sysvsem_object_handlers;
 
 	return &intern->std;
 }
@@ -152,6 +151,7 @@ PHP_MINIT_FUNCTION(sysvsem)
 {
 	sysvsem_ce = register_class_SysvSemaphore();
 	sysvsem_ce->create_object = sysvsem_create_object;
+	sysvsem_ce->default_object_handlers = &sysvsem_object_handlers;
 
 	memcpy(&sysvsem_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	sysvsem_object_handlers.offset = XtOffsetOf(sysvsem_sem, std);

--- a/ext/sysvshm/sysvshm.c
+++ b/ext/sysvshm/sysvshm.c
@@ -47,7 +47,6 @@ static zend_object *sysvshm_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &sysvshm_object_handlers;
 
 	return &intern->std;
 }
@@ -101,6 +100,7 @@ PHP_MINIT_FUNCTION(sysvshm)
 {
 	sysvshm_ce = register_class_SysvSharedMemory();
 	sysvshm_ce->create_object = sysvshm_create_object;
+	sysvshm_ce->default_object_handlers = &sysvshm_object_handlers;
 
 	memcpy(&sysvshm_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	sysvshm_object_handlers.offset = XtOffsetOf(sysvshm_shm, std);

--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -245,6 +245,7 @@ PHP_MINIT_FUNCTION(xml)
 {
 	xml_parser_ce = register_class_XMLParser();
 	xml_parser_ce->create_object = xml_parser_create_object;
+	xml_parser_ce->default_object_handlers = &xml_parser_object_handlers;
 
 	memcpy(&xml_parser_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	xml_parser_object_handlers.offset = XtOffsetOf(xml_parser, std);
@@ -313,7 +314,6 @@ static zend_object *xml_parser_create_object(zend_class_entry *class_type) {
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &xml_parser_object_handlers;
 
 	return &intern->std;
 }

--- a/ext/xmlreader/php_xmlreader.c
+++ b/ext/xmlreader/php_xmlreader.c
@@ -368,7 +368,6 @@ zend_object *xmlreader_objects_new(zend_class_entry *class_type)
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
 	intern->prop_handler = &xmlreader_prop_handlers;
-	intern->std.handlers = &xmlreader_object_handlers;
 
 	return &intern->std;
 }
@@ -1163,6 +1162,7 @@ PHP_MINIT_FUNCTION(xmlreader)
 
 	xmlreader_class_entry = register_class_XMLReader();
 	xmlreader_class_entry->create_object = xmlreader_objects_new;
+	xmlreader_class_entry->default_object_handlers = &xmlreader_object_handlers;
 
 	memcpy(&xmlreader_open_fn, zend_hash_str_find_ptr(&xmlreader_class_entry->function_table, "open", sizeof("open")-1), sizeof(zend_internal_function));
 	xmlreader_open_fn.fn_flags &= ~ZEND_ACC_STATIC;

--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -82,7 +82,6 @@ static zend_object *xmlwriter_object_new(zend_class_entry *class_type)
 	intern = zend_object_alloc(sizeof(ze_xmlwriter_object), class_type);
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &xmlwriter_object_handlers;
 
 	return &intern->std;
 }
@@ -1039,6 +1038,7 @@ static PHP_MINIT_FUNCTION(xmlwriter)
 	xmlwriter_object_handlers.clone_obj = NULL;
 	xmlwriter_class_entry_ce = register_class_XMLWriter();
 	xmlwriter_class_entry_ce->create_object = xmlwriter_object_new;
+	xmlwriter_class_entry_ce->default_object_handlers = &xmlwriter_object_handlers;
 
 	return SUCCESS;
 }

--- a/ext/xsl/php_xsl.c
+++ b/ext/xsl/php_xsl.c
@@ -103,7 +103,6 @@ zend_object *xsl_objects_new(zend_class_entry *class_type)
 	intern->parameter = zend_new_array(0);
 	intern->registered_phpfunctions = zend_new_array(0);
 
-	intern->std.handlers = &xsl_object_handlers;
 	return &intern->std;
 }
 /* }}} */
@@ -118,6 +117,7 @@ PHP_MINIT_FUNCTION(xsl)
 
 	xsl_xsltprocessor_class_entry = register_class_XSLTProcessor();
 	xsl_xsltprocessor_class_entry->create_object = xsl_objects_new;
+	xsl_xsltprocessor_class_entry->default_object_handlers = &xsl_object_handlers;
 
 #ifdef HAVE_XSL_EXSLT
 	exsltRegisterAll();

--- a/ext/zend_test/fiber.c
+++ b/ext/zend_test/fiber.c
@@ -150,7 +150,6 @@ static zend_object *zend_test_fiber_object_create(zend_class_entry *ce)
 	memset(fiber, 0, sizeof(zend_test_fiber));
 
 	zend_object_std_init(&fiber->std, ce);
-	fiber->std.handlers = &zend_test_fiber_handlers;
 
 	return &fiber->std;
 }
@@ -344,6 +343,7 @@ void zend_test_fiber_init(void)
 {
 	zend_test_fiber_class = register_class__ZendTestFiber();
 	zend_test_fiber_class->create_object = zend_test_fiber_object_create;
+	zend_test_fiber_class->default_object_handlers = &zend_test_fiber_handlers;
 
 	zend_test_fiber_handlers = std_object_handlers;
 	zend_test_fiber_handlers.dtor_obj = zend_test_fiber_object_destroy;

--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -1075,7 +1075,6 @@ static zend_object *php_zip_object_new(zend_class_entry *class_type) /* {{{ */
 	intern->prop_handler = &zip_prop_handlers;
 	zend_object_std_init(&intern->zo, class_type);
 	object_properties_init(&intern->zo, class_type);
-	intern->zo.handlers = &zip_object_handlers;
 	intern->last_id = -1;
 
 	return &intern->zo;
@@ -3101,6 +3100,7 @@ static PHP_MINIT_FUNCTION(zip)
 
 	zip_class_entry = register_class_ZipArchive(zend_ce_countable);
 	zip_class_entry->create_object = php_zip_object_new;
+	zip_class_entry->default_object_handlers = &zip_object_handlers;
 
 	zend_hash_init(&zip_prop_handlers, 0, NULL, php_zip_free_prop_handler, 1);
 	php_zip_register_prop_handler(&zip_prop_handlers, "lastId",    php_zip_last_id, NULL, IS_LONG);

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -60,7 +60,6 @@ static zend_object *inflate_context_create_object(zend_class_entry *class_type) 
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &inflate_context_object_handlers;
 
 	return &intern->std;
 }
@@ -99,7 +98,6 @@ static zend_object *deflate_context_create_object(zend_class_entry *class_type) 
 
 	zend_object_std_init(&intern->std, class_type);
 	object_properties_init(&intern->std, class_type);
-	intern->std.handlers = &deflate_context_object_handlers;
 
 	return &intern->std;
 }
@@ -1340,6 +1338,7 @@ static PHP_MINIT_FUNCTION(zlib)
 
 	inflate_context_ce = register_class_InflateContext();
 	inflate_context_ce->create_object = inflate_context_create_object;
+	inflate_context_ce->default_object_handlers = &inflate_context_object_handlers;
 
 	memcpy(&inflate_context_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	inflate_context_object_handlers.offset = XtOffsetOf(php_zlib_context, std);
@@ -1350,6 +1349,7 @@ static PHP_MINIT_FUNCTION(zlib)
 
 	deflate_context_ce = register_class_DeflateContext();
 	deflate_context_ce->create_object = deflate_context_create_object;
+	deflate_context_ce->default_object_handlers = &deflate_context_object_handlers;
 
 	memcpy(&deflate_context_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
 	deflate_context_object_handlers.offset = XtOffsetOf(php_zlib_context, std);


### PR DESCRIPTION
Object handlers being separate from class entries is a legacy inherited from PHP 5. Today it has little benefit to keep them separate: in fact, accessing object handlers usually requires not-so-safe hacks.
While it is possible to swap handlers in a custom installed create_object handler, this mostly is tedious, as well as it requires allocating the object handlers struct at runtime, possibly caching it etc..

This allows extensions, which intend to observe other classes to install their own class handlers.
The life cycle of internal classes may now be simply observed by swapping the class handlers in post_startup stage.
The life cycle of userland classes may be observed by iterating over the new classes in zend_compile_file and zend_compile_string and then swapping their handlers.

In general, this would also be a first step in directly tying the object handlers to classes (i.e., removing the handlers field from zend_object). Especially given that I am not aware of any case where the object handlers would be different between various instances of a given class.


This PR (for now) only changes occurrences in Zend. Once the general approach is approved, I will update all other occurrences in ext/ as well.