### PR TITLE
Fix __call in PDO subclass breaking method calls

### DIFF
--- a/ext/pdo_sqlite/tests/gh7803.phpt
+++ b/ext/pdo_sqlite/tests/gh7803.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-7803: PDO __call breaks method calls
+--FILE--
+<?php
+
+class DB extends PDO
+{
+    public function __call(string $name, array $args)
+    {
+        echo "__call: $name\n";
+    }
+}
+
+$db = new DB('sqlite::memory:', '', '', []);
+
+$db->sqliteCreateFunction('CONCAT', function (...$args) {
+    return implode('', $args);
+});
+
+$sqlite = 'sqlite';
+$createFunction = 'CreateFunction';
+$db->{$sqlite . $createFunction}('CONCAT2', function () {});
+
+$db->nonexistent();
+
+var_dump($db->query('SELECT CONCAT(\'123\', \'456\', \'789\')')->fetch());
+
+?>
+--EXPECT--
+__call: nonexistent
+array(2) {
+  ["CONCAT('123', '456', '789')"]=>
+  string(9) "123456789"
+  [0]=>
+  string(9) "123456789"
+}


### PR DESCRIPTION
Fixes GH-7803

Are changes like these acceptable after the feature freeze? The issue is marked as a `feature`, but that's mostly so that we don't back-port the fix and change longstanding behavior.