### PR TITLE
Remove dead code in ext/random/random.c

### DIFF
--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -889,10 +889,3 @@ zend_module_entry random_module_entry = {
 	STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */
-
-#ifdef COMPILE_DL_RANDOM
-# ifdef ZTS
-ZEND_TSRMLS_CACHE_DEFINE()
-# endif
-ZEND_GET_MODULE(random)
-#endif


### PR DESCRIPTION
My understanding is that this case is effectively the same as:

https://github.com/php/php-src/pull/9070#discussion_r925872500