### PR TITLE
Fix #65069: GlobIterator incorrect handling of open_basedir check

### DIFF
--- a/ext/spl/tests/bug65069.phpt
+++ b/ext/spl/tests/bug65069.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Bug #65069: GlobIterator fails to access files inside an open_basedir restricted dir
+--FILE--
+<?php
+$file_path = __DIR__;
+// temp dirname used here
+$dirname = "$file_path/bug65069";
+// temp dir created
+mkdir($dirname);
+
+ini_set('open_basedir', $dirname);
+
+// temp files created
+touch("$dirname/wonder12345");
+touch("$dirname/wonder.txt");
+touch("$dirname/file.text");
+
+$spl_glob_it = new \GlobIterator("$dirname/*.txt");
+foreach ($spl_glob_it as $file_info) {
+    echo $file_info->getFilename() . "\n";
+}
+
+$spl_glob_it = new \GlobIterator(dirname(dirname($dirname)) . "/*/*/*");
+foreach ($spl_glob_it as $file_info) {
+    echo $file_info->getFilename() . "\n";
+}
+
+$spl_glob_empty = new \GlobIterator("$dirname/*.php");
+var_dump($spl_glob_empty->count());
+
+// top directory
+var_dump(iterator_to_array(new \GlobIterator(dirname(dirname($dirname)))));
+
+// not existing file
+var_dump(iterator_to_array(new \GlobIterator("$file_path/bug65069-this-will-never-exists")));
+
+
+?>
+--CLEAN--
+<?php
+$file_path = dirname(__FILE__);
+$dirname = "$file_path/bug65069";
+unlink("$dirname/wonder12345");
+unlink("$dirname/wonder.txt");
+unlink("$dirname/file.text");
+rmdir($dirname);
+?>
+--EXPECT--
+wonder.txt
+file.text
+wonder.txt
+wonder12345
+int(0)
+array(0) {
+}
+array(0) {
+}

--- a/ext/standard/tests/streams/glob-wrapper.phpt
+++ b/ext/standard/tests/streams/glob-wrapper.phpt
@@ -5,6 +5,7 @@ open_basedir=/does_not_exist
 --SKIPIF--
 <?php
 if (!in_array("glob", stream_get_wrappers())) echo "skip";
+?>
 --FILE--
 <?php
 
@@ -29,8 +30,4 @@ Warning: opendir(): open_basedir restriction in effect. File(%s) is not within t
 Warning: opendir(%s): Failed to open directory: Operation not permitted in %s%eglob-wrapper.php on line 5
 Failed to open %s
 ** Opening glob://%s
-
-Warning: opendir(): open_basedir restriction in effect. File(%s) is not within the allowed path(s): (/does_not_exist) in %s%eglob-wrapper.php on line 5
-
-Warning: opendir(glob://%s): Failed to open directory: operation failed in %s%eglob-wrapper.php on line 5
-Failed to open glob://%s
+No files in glob://%s


### PR DESCRIPTION
Proper checking and filtering of glob stream paths when open_basedir set.

This is a rebase with some minor changes of PR #398 that I did 9 years ago that got somehow sidetracked discussion about the correct glob behavior. After thinking about this, the PR still makes sense to me as it fixes the reported problem even though it doesn't do anything about the inconsistency which is however already present in glob so there is no reason to not apply this.