### PR TITLE
Fix `str_split` UPGRADE note

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -81,8 +81,8 @@ PHP                                                                        NEWS
     iterable. (timwolla)
 
 - Standard:
-    . Implemented FR GH-8924 (str_split should return empty array for empty
-      string). (Michael Vorisek)
+  . Implemented FR GH-8924 (str_split should return empty array for empty
+    string). (Michael Vorisek)
   . Added ini_parse_quantity function to convert ini quantities shorthand
     notation to int. (Dennis Snell)
   . Enable arc4random_buf for Linux glibc 2.36 and onwards

--- a/NEWS
+++ b/NEWS
@@ -81,7 +81,7 @@ PHP                                                                        NEWS
     iterable. (timwolla)
 
 - Standard:
-  . Fixed empty array returned by str_split on empty input. (Michael Vorisek)
+  . Fixed str_split to return an empty array instead of a non-empty array on empty input. (Michael Vorisek)
   . Added ini_parse_quantity function to convert ini quantities shorthand
     notation to int. (Dennis Snell)
   . Enable arc4random_buf for Linux glibc 2.36 and onwards

--- a/NEWS
+++ b/NEWS
@@ -81,7 +81,8 @@ PHP                                                                        NEWS
     iterable. (timwolla)
 
 - Standard:
-  . Fixed str_split to return an empty array instead of a non-empty array on empty input. (Michael Vorisek)
+    . Implemented FR GH-8924 (str_split should return empty array for empty
+      string). (Michael Vorisek)
   . Added ini_parse_quantity function to convert ini quantities shorthand
     notation to int. (Dennis Snell)
   . Enable arc4random_buf for Linux glibc 2.36 and onwards

--- a/UPGRADING
+++ b/UPGRADING
@@ -45,7 +45,9 @@ PHP 8.2 UPGRADE NOTES
     stripos, strripos, lcfirst, ucfirst, ucwords, str_ireplace,
     array_change_key_case and sorting with SORT_FLAG_CASE use ASCII case
     conversion.
-  . str_split returns an empty array on empty string.
+  . str_split() returns an empty array for an empty string now. Previously it
+    returned an array with a single empty string entry. mb_str_split() is not
+    affected by this change since it was already behaving like that.
 
 - SPL:
   . The following methods now enforce their signature:

--- a/UPGRADING
+++ b/UPGRADING
@@ -45,7 +45,7 @@ PHP 8.2 UPGRADE NOTES
     stripos, strripos, lcfirst, ucfirst, ucwords, str_ireplace,
     array_change_key_case and sorting with SORT_FLAG_CASE use ASCII case
     conversion.
-  . str_split no longer returns an empty array on empty string.
+  . str_split returns an empty array on empty string.
 
 - SPL:
   . The following methods now enforce their signature:


### PR DESCRIPTION
If I'm not completely mistaken (and I had my coffee already 😅) this needs to be negated. Just noticed this when I wanted to adapt phpstan and link to the UPGRADE note.

See also e80925445c535ea83d8104f836207cdca608ffa0, https://github.com/php/php-src/pull/8945 and https://3v4l.org/XfZO4 vs https://3v4l.org/XfZO4/rfc#vgit.master
Fyi @mvorisek 