### PR TITLE
Restrict range of buffer_length on all platforms to INT_MAX

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7642,8 +7642,12 @@ PHP_FUNCTION(openssl_cipher_iv_length)
 PHP_OPENSSL_API zend_string* php_openssl_random_pseudo_bytes(zend_long buffer_length)
 {
 	zend_string *buffer = NULL;
-	if (buffer_length <= 0 || ZEND_LONG_INT_OVFL(buffer_length)) {
-		zend_argument_value_error(1, "must be greater than 0 and less than 2147483648");
+	if (buffer_length <= 0) {
+		zend_argument_value_error(1, "must be greater than 0");
+		return NULL;
+	}
+	if (ZEND_LONG_INT_OVFL(buffer_length)) {
+		zend_argument_value_error(1, "must be less than 2147483648");
 		return NULL;
 	}
 	buffer = zend_string_alloc(buffer_length, 0);

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7642,12 +7642,8 @@ PHP_FUNCTION(openssl_cipher_iv_length)
 PHP_OPENSSL_API zend_string* php_openssl_random_pseudo_bytes(zend_long buffer_length)
 {
 	zend_string *buffer = NULL;
-	if (buffer_length <= 0
-#ifndef PHP_WIN32
-		|| ZEND_LONG_INT_OVFL(buffer_length)
-#endif
-			) {
-		zend_argument_value_error(1, "must be greater than 0");
+	if (buffer_length <= 0 || ZEND_LONG_INT_OVFL(buffer_length)) {
+		zend_argument_value_error(1, "must be greater than 0 and less than 2147483648");
 		return NULL;
 	}
 	buffer = zend_string_alloc(buffer_length, 0);
@@ -7663,7 +7659,6 @@ PHP_OPENSSL_API zend_string* php_openssl_random_pseudo_bytes(zend_long buffer_le
 
 	PHP_OPENSSL_CHECK_LONG_TO_INT_NULL_RETURN(buffer_length, length);
 	PHP_OPENSSL_RAND_ADD_TIME();
-	/* FIXME loop if requested size > INT_MAX */
 	if (RAND_bytes((unsigned char*)ZSTR_VAL(buffer), (int)buffer_length) <= 0) {
 		zend_string_release_ex(buffer, 0);
 		zend_throw_exception(zend_ce_exception, "Error reading from source device", 0);

--- a/ext/openssl/tests/openssl_random_pseudo_bytes_error.phpt
+++ b/ext/openssl/tests/openssl_random_pseudo_bytes_error.phpt
@@ -11,4 +11,4 @@ try {
 }
 ?>
 --EXPECT--
-openssl_random_pseudo_bytes(): Argument #1 ($length) must be greater than 0
+openssl_random_pseudo_bytes(): Argument #1 ($length) must be greater than 0 and less than 2147483648

--- a/ext/openssl/tests/openssl_random_pseudo_bytes_error.phpt
+++ b/ext/openssl/tests/openssl_random_pseudo_bytes_error.phpt
@@ -11,4 +11,4 @@ try {
 }
 ?>
 --EXPECT--
-openssl_random_pseudo_bytes(): Argument #1 ($length) must be greater than 0 and less than 2147483648
+openssl_random_pseudo_bytes(): Argument #1 ($length) must be greater than 0


### PR DESCRIPTION
This has only been done for Windows systems so far, and there was a
TODO comment about looping for larger values; that appears to be
overkill, though, since 2 million bytes should be sufficient for all
use cases, and if there is really the need for more, users can still
loop manually.  Anyhow, checking the range upfront on all platforms
is clearer then silently casting to `int`.

---

I've noticed that while I was about to get rid of the Windows specifc code in that function, and I think it's a sensible preparation for that.