### PR TITLE
Initialize blacklist_path_length

### DIFF
--- a/ext/opcache/zend_accelerator_blacklist.c
+++ b/ext/opcache/zend_accelerator_blacklist.c
@@ -241,7 +241,7 @@ static void zend_accel_blacklist_loadone(zend_blacklist *blacklist, char *filena
 {
 	char buf[MAXPATHLEN + 1], real_path[MAXPATHLEN + 1], *blacklist_path = NULL;
 	FILE *fp;
-	int path_length, blacklist_path_length = NULL;
+	int path_length, blacklist_path_length = 0;
 
 	if ((fp = fopen(filename, "r")) == NULL) {
 		zend_accel_error(ACCEL_LOG_WARNING, "Cannot load blacklist file: %s\n", filename);

--- a/ext/opcache/zend_accelerator_blacklist.c
+++ b/ext/opcache/zend_accelerator_blacklist.c
@@ -241,7 +241,7 @@ static void zend_accel_blacklist_loadone(zend_blacklist *blacklist, char *filena
 {
 	char buf[MAXPATHLEN + 1], real_path[MAXPATHLEN + 1], *blacklist_path = NULL;
 	FILE *fp;
-	int path_length, blacklist_path_length;
+	int path_length, blacklist_path_length = NULL;
 
 	if ((fp = fopen(filename, "r")) == NULL) {
 		zend_accel_error(ACCEL_LOG_WARNING, "Cannot load blacklist file: %s\n", filename);


### PR DESCRIPTION
For some reason, GCC warns[1]:

| ‘blacklist_path_length’ may be used uninitialized in this function
| [-Werror=maybe-uninitialized]

This looks like a false positive to me, but it doesn't hurt to
explicitly initialize the variable.

[1] <https://github.com/php/php-src/runs/7502212969?check_suite_focus=true>