### PR TITLE
Remove `->last_unsafe` from php_random_status

### DIFF
--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -301,7 +301,7 @@ PHP_METHOD(Random_Engine_Mt19937, generate)
 
 	generated = engine->algo->generate(engine->status);
 	size = engine->status->last_generated_size;
-	if (engine->status->last_unsafe) {
+	if (EG(exception)) {
 		zend_throw_exception(spl_ce_RuntimeException, "Random number generation failed", 0);
 		RETURN_THROWS();
 	}

--- a/ext/random/engine_secure.c
+++ b/ext/random/engine_secure.c
@@ -29,9 +29,7 @@ static uint64_t generate(php_random_status *status)
 {
 	zend_ulong r = 0;
 
-	if (php_random_bytes_throw(&r, sizeof(zend_ulong)) == FAILURE) {
-		status->last_unsafe = true;
-	}
+	php_random_bytes_throw(&r, sizeof(zend_ulong));
 
 	return r;
 }
@@ -40,9 +38,7 @@ static zend_long range(php_random_status *status, zend_long min, zend_long max)
 {
 	zend_long result = 0;
 
-	if (php_random_int_throw(min, max, &result) == FAILURE) {
-		status->last_unsafe = true;
-	}
+	php_random_int_throw(min, max, &result);
 
 	return result;
 }

--- a/ext/random/engine_user.c
+++ b/ext/random/engine_user.c
@@ -31,7 +31,6 @@ static uint64_t generate(php_random_status *status)
 	zend_call_known_instance_method_with_0_params(s->generate_method, s->object, &retval);
 
 	if (EG(exception)) {
-		status->last_unsafe = true;
 		return 0;
 	}
 
@@ -51,7 +50,6 @@ static uint64_t generate(php_random_status *status)
 		}
 	} else {
 		zend_throw_error(NULL, "A random engine must return a non-empty string");
-		status->last_unsafe = true;
 		return 0;
 	}
 

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -201,7 +201,6 @@ PHPAPI int php_random_int(zend_long min, zend_long max, zend_long *result, bool 
 
 typedef struct _php_random_status_ {
 	size_t last_generated_size;
-	bool last_unsafe;
 	void *state;
 } php_random_status;
 

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -96,7 +96,7 @@ static inline uint32_t rand_range32(const php_random_algo *algo, php_random_stat
 		r = algo->generate(status);
 		result = result | (r << (total_size * 8));
 		total_size += status->last_generated_size;
-		if (status->last_unsafe) {
+		if (EG(exception)) {
 			return 0;
 		}
 	} while (total_size < sizeof(uint32_t));
@@ -122,7 +122,6 @@ static inline uint32_t rand_range32(const php_random_algo *algo, php_random_stat
 		/* If the requirements cannot be met in a cycles, return fail */
 		if (++count > RANDOM_RANGE_ATTEMPTS) {
 			zend_throw_error(NULL, "Failed to generate an acceptable random number in %d attempts", RANDOM_RANGE_ATTEMPTS);
-			status->last_unsafe = true;
 			return 0;
 		}
 
@@ -132,7 +131,7 @@ static inline uint32_t rand_range32(const php_random_algo *algo, php_random_stat
 			r = algo->generate(status);
 			result = result | (r << (total_size * 8));
 			total_size += status->last_generated_size;
-			if (status->last_unsafe) {
+			if (EG(exception)) {
 				return 0;
 			}
 		} while (total_size < sizeof(uint32_t));
@@ -153,7 +152,7 @@ static inline uint64_t rand_range64(const php_random_algo *algo, php_random_stat
 		r = algo->generate(status);
 		result = result | (r << (total_size * 8));
 		total_size += status->last_generated_size;
-		if (status->last_unsafe) {
+		if (EG(exception)) {
 			return 0;
 		}
 	} while (total_size < sizeof(uint64_t));
@@ -179,7 +178,6 @@ static inline uint64_t rand_range64(const php_random_algo *algo, php_random_stat
 		/* If the requirements cannot be met in a cycles, return fail */
 		if (++count > RANDOM_RANGE_ATTEMPTS) {
 			zend_throw_error(NULL, "Failed to generate an acceptable random number in %d attempts", RANDOM_RANGE_ATTEMPTS);
-			status->last_unsafe = true;
 			return 0;
 		}
 
@@ -189,7 +187,7 @@ static inline uint64_t rand_range64(const php_random_algo *algo, php_random_stat
 			r = algo->generate(status);
 			result = result | (r << (total_size * 8));
 			total_size += status->last_generated_size;
-			if (status->last_unsafe) {
+			if (EG(exception)) {
 				return 0;
 			}
 		} while (total_size < sizeof(uint64_t));
@@ -245,7 +243,6 @@ PHPAPI php_random_status *php_random_status_alloc(const php_random_algo *algo, c
 	php_random_status *status = pecalloc(1, sizeof(php_random_status), persistent);
 
 	status->last_generated_size = algo->generate_size;
-	status->last_unsafe = false;
 	status->state = algo->state_size > 0 ? pecalloc(1, algo->state_size, persistent) : NULL;
 
 	return status;
@@ -254,7 +251,6 @@ PHPAPI php_random_status *php_random_status_alloc(const php_random_algo *algo, c
 PHPAPI php_random_status *php_random_status_copy(const php_random_algo *algo, php_random_status *old_status, php_random_status *new_status)
 {
 	new_status->last_generated_size = old_status->last_generated_size;
-	new_status->last_unsafe = old_status->last_unsafe;
 	new_status->state = memcpy(new_status->state, old_status->state, algo->state_size);
 
 	return new_status;

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -105,7 +105,7 @@ PHP_METHOD(Random_Randomizer, getInt)
 			zend_throw_exception(spl_ce_RuntimeException, "Generated value exceeds size of int", 0);
 			RETURN_THROWS();
 		}
-		if (randomizer->status->last_unsafe) {
+		if (EG(exception)) {
 			zend_throw_exception(spl_ce_RuntimeException, "Random number generation failed", 0);
 			RETURN_THROWS();
 		}
@@ -123,7 +123,7 @@ PHP_METHOD(Random_Randomizer, getInt)
 	}
 
 	result = randomizer->algo->range(randomizer->status, min, max);
-	if (randomizer->status->last_unsafe) {
+	if (EG(exception)) {
 		zend_throw_exception(spl_ce_RuntimeException, "Random number generation failed", 0);
 		RETURN_THROWS();
 	}
@@ -155,7 +155,7 @@ PHP_METHOD(Random_Randomizer, getBytes)
 
 	while (total_size < required_size) {
 		result = randomizer->algo->generate(randomizer->status);
-		if (randomizer->status->last_unsafe) {
+		if (EG(exception)) {
 			zend_string_free(retval);
 			zend_throw_exception(spl_ce_RuntimeException, "Random number generation failed", 0);
 			RETURN_THROWS();

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -2936,7 +2936,7 @@ PHPAPI bool php_array_data_shuffle(const php_random_algo *algo, php_random_statu
 		}
 		while (--n_left) {
 			rnd_idx = algo->range(status, 0, n_left);
-			if (status->last_unsafe) {
+			if (EG(exception)) {
 				return false;
 			}
 			if (rnd_idx != n_left) {
@@ -2964,7 +2964,7 @@ PHPAPI bool php_array_data_shuffle(const php_random_algo *algo, php_random_statu
 		}
 		while (--n_left) {
 			rnd_idx = algo->range(status, 0, n_left);
-			if (status->last_unsafe) {
+			if (EG(exception)) {
 				return false;
 			}
 			if (rnd_idx != n_left) {

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -5755,7 +5755,7 @@ PHPAPI bool php_binary_string_shuffle(const php_random_algo *algo, php_random_st
 
 	while (--n_left) {
 		rnd_idx = algo->range(status, 0, n_left);
-		if (status->last_unsafe) {
+		if (EG(exception)) {
 			return false;
 		}
 		if (rnd_idx != n_left) {


### PR DESCRIPTION
Whenever ->last_unsafe is set to `true` an exception has been thrown. Thus we
can replace the check for `->last_unsafe` with a check for `EG(exception)`
which is a much more natural way to ommunicate an error up the chain.