### PR TITLE
Skip locale tests /w musl libc

### DIFF
--- a/ext/ctype/tests/lc_ctype_inheritance.phpt
+++ b/ext/ctype/tests/lc_ctype_inheritance.phpt
@@ -2,6 +2,7 @@
 Do not inherit LC_CTYPE from environment
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (!setlocale(LC_CTYPE, "de_DE", "de-DE")) die("skip requires de_DE locale");
 ?>
 --ENV--

--- a/ext/fileinfo/tests/bug74170.phpt
+++ b/ext/fileinfo/tests/bug74170.phpt
@@ -5,6 +5,7 @@ fileinfo
 intl
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (setlocale(LC_CTYPE, 'ru_RU.koi8r') === false)
     die('skip ru_RU.koi8r locale is not available');
 ?>

--- a/ext/iconv/tests/iconv_basic_001.phpt
+++ b/ext/iconv/tests/iconv_basic_001.phpt
@@ -5,8 +5,11 @@ Rodrigo Prado de Jesus <royopa [at] gmail [dot] com>
 --EXTENSIONS--
 iconv
 --SKIPIF--
-<?php if(substr(PHP_OS, 0, 3) == 'WIN' ) {die('skip not for windows');} ?>
-<?php if(setlocale(LC_ALL, "en_US.utf8") === false) { die('skip en_US.utf8 locales not available'); } ?>
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN' ) {die('skip not for windows');}
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
+if (setlocale(LC_ALL, "en_US.utf8") === false) { die('skip en_US.utf8 locales not available'); }
+?>
 --FILE--
 <?php
 setlocale(LC_ALL, "en_US.utf8");

--- a/ext/pcre/tests/ctype_back_to_c.phpt
+++ b/ext/pcre/tests/ctype_back_to_c.phpt
@@ -2,6 +2,7 @@
 Changing LC_CTYPE back to C
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (!setlocale(LC_CTYPE, "de_DE", "de-DE")) die("skip requires de_DE locale");
 ?>
 --FILE--

--- a/ext/pcre/tests/locales.phpt
+++ b/ext/pcre/tests/locales.phpt
@@ -2,9 +2,8 @@
 Localized match
 --SKIPIF--
 <?php
-
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (!@setlocale(LC_ALL, 'pt_PT', 'pt', 'pt_PT.ISO8859-1', 'portuguese')) die('skip pt locale not available');
-
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/array/locale_sort.phpt
+++ b/ext/standard/tests/array/locale_sort.phpt
@@ -2,6 +2,7 @@
 Sort with SORT_LOCALE_STRING
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
   die("skip Unix locale name only, not available on windows (and crashes with VC6)\n");
 }

--- a/ext/standard/tests/strings/locale_independent_float_to_string.phpt
+++ b/ext/standard/tests/strings/locale_independent_float_to_string.phpt
@@ -2,7 +2,7 @@
 Test that floats are converted to string locale independently
 --SKIPIF--
 <?php
-
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (!setlocale
     (LC_ALL,
     "german", "de", "de_DE", "de_DE.ISO8859-1", "de_DE.ISO_8859-1", "de_DE.UTF-8",
@@ -10,7 +10,6 @@ if (!setlocale
     )) {
     die("skip - locale needed for this test is not supported on this platform");
 }
-
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/strings/printf_h_H.phpt
+++ b/ext/standard/tests/strings/printf_h_H.phpt
@@ -2,6 +2,7 @@
 sprintf() %h and %H specifiers
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (!setlocale(LC_ALL, "de_DE.utf8")) die("skip de_DE.utf8 locale not available");
 ?>
 --FILE--

--- a/ext/standard/tests/strings/setlocale_basic1.phpt
+++ b/ext/standard/tests/strings/setlocale_basic1.phpt
@@ -2,6 +2,7 @@
 Test setlocale() function : basic functionality - setting system locale to a specific
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip Not valid for windows');
 }

--- a/ext/standard/tests/strings/setlocale_basic2.phpt
+++ b/ext/standard/tests/strings/setlocale_basic2.phpt
@@ -2,6 +2,7 @@
 Test setlocale() function : basic functionality - set locale using an array
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip Not valid for windows');
 }

--- a/ext/standard/tests/strings/setlocale_basic3.phpt
+++ b/ext/standard/tests/strings/setlocale_basic3.phpt
@@ -2,6 +2,7 @@
 Test setlocale() function : basic functionality - passing multiple locales as argument
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip Not valid for windows');
 }

--- a/ext/standard/tests/strings/setlocale_error.phpt
+++ b/ext/standard/tests/strings/setlocale_error.phpt
@@ -4,6 +4,7 @@ Test setlocale() function : error condition
 error_reporting=E_ALL
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip Not valid for windows');
 }

--- a/ext/standard/tests/strings/setlocale_variation1.phpt
+++ b/ext/standard/tests/strings/setlocale_variation1.phpt
@@ -2,6 +2,7 @@
 Test setlocale() function : usage variations - passing multiple valid/invalid locales as argument
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip Not valid for windows');
 }

--- a/ext/standard/tests/strings/setlocale_variation3.phpt
+++ b/ext/standard/tests/strings/setlocale_variation3.phpt
@@ -2,6 +2,7 @@
 Test setlocale() function : usage variations - setting system locale = 0
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip Not valid for windows');
 }

--- a/ext/standard/tests/strings/setlocale_variation4.phpt
+++ b/ext/standard/tests/strings/setlocale_variation4.phpt
@@ -2,6 +2,7 @@
 Test setlocale() function : usage variations - setting system locale as null
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip Not valid for windows');
 }

--- a/ext/standard/tests/strings/setlocale_variation5.phpt
+++ b/ext/standard/tests/strings/setlocale_variation5.phpt
@@ -2,6 +2,7 @@
 Test setlocale() function : usage variations - Setting system locale as empty string
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (substr(PHP_OS, 0, 3) == 'WIN') {
     die('skip Not valid for windows');
 }

--- a/ext/standard/tests/strings/sprintf_f_3.phpt
+++ b/ext/standard/tests/strings/sprintf_f_3.phpt
@@ -1,7 +1,10 @@
 --TEST--
 sprintf %f #3
 --SKIPIF--
-<?php if(false == setlocale(LC_NUMERIC, "is_IS", "is_IS.UTF-8")) print "skip icelandic locale not supported"; ?>
+<?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
+if(false == setlocale(LC_NUMERIC, "is_IS", "is_IS.UTF-8")) print "skip icelandic locale not supported";
+?>
 --FILE--
 <?php
 setlocale(LC_NUMERIC, "is_IS", "is_IS.UTF-8");

--- a/tests/basic/consistent_float_string_casts.phpt
+++ b/tests/basic/consistent_float_string_casts.phpt
@@ -2,6 +2,7 @@
 Test that float to string and string to float casts are consistent
 --SKIPIF--
 <?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
 if (!setlocale(
     LC_ALL,
     "german", "de", "de_DE", "de_DE.ISO8859-1", "de_DE.ISO_8859-1", "de_DE.UTF-8",

--- a/tests/lang/bug30638.phpt
+++ b/tests/lang/bug30638.phpt
@@ -1,7 +1,9 @@
 --TEST--
 Bug #30638 (localeconv returns wrong LC_NUMERIC settings) (ok to fail on MacOS X)
 --SKIPIF--
-<?php  # try to activate a german locale
+<?php
+if (setlocale(LC_ALL, 'invalid') === 'invalid') { die('skip setlocale() is broken /w musl'); }
+# try to activate a german locale
 if (setlocale(LC_NUMERIC, "de_DE.UTF-8", "de_DE", "de", "german", "ge", "de_DE.ISO-8859-1") === FALSE) {
     print "skip setlocale() failed";
 } elseif (strtolower(php_uname('s')) == 'darwin') {


### PR DESCRIPTION
locale support is broken /w musl libc (used as default in Alpine OS), thus these tests must be skipped

isolated from https://github.com/php/php-src/pull/8621