### PR TITLE
Escape \U and \u in generated stubs

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -533,7 +533,12 @@ class SimpleType {
     }
 
     public function toEscapedName(): string {
-        return str_replace('\\', '\\\\', $this->name);
+        // Escape \u and \U to avoid compilation errors in generated macros
+        return str_replace(
+            ['\\', '\u', '\U'],
+            ['\\\\', '\\\\165', '\\\\125'],
+            $this->name
+        );
     }
 
     public function toVarEscapedName(): string {

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -533,9 +533,9 @@ class SimpleType {
     }
 
     public function toEscapedName(): string {
-        // Escape \u and \U to avoid compilation errors in generated macros
+        // Escape backslashes, and also encode \u and \U to avoid compilation errors in generated macros
         return str_replace(
-            ['\\', '\u', '\U'],
+            ['\\', '\\u', '\\U'],
             ['\\\\', '\\\\165', '\\\\125'],
             $this->name
         );

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -43,6 +43,7 @@ static zend_class_entry *zend_test_class_with_method_with_parameter_attribute;
 static zend_class_entry *zend_test_child_class_with_method_with_parameter_attribute;
 static zend_class_entry *zend_test_forbid_dynamic_call;
 static zend_class_entry *zend_test_ns_foo_class;
+static zend_class_entry *zend_test_ns_unlikely_compile_error_class;
 static zend_class_entry *zend_test_ns2_foo_class;
 static zend_class_entry *zend_test_ns2_ns_foo_class;
 static zend_class_entry *zend_test_unit_enum;
@@ -535,6 +536,15 @@ static ZEND_METHOD(ZendTestNS_Foo, method)
 	RETURN_LONG(0);
 }
 
+static ZEND_METHOD(ZendTestNS_UnlikelyCompileError, method)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	return_value = ZEND_THIS;
+
+   return return_value;
+}
+
 static ZEND_METHOD(ZendTestNS2_Foo, method)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -698,6 +708,7 @@ PHP_MINIT_FUNCTION(zend_test)
 	zend_test_forbid_dynamic_call = register_class_ZendTestForbidDynamicCall();
 
 	zend_test_ns_foo_class = register_class_ZendTestNS_Foo();
+	zend_test_ns_unlikely_compile_error_class = register_class_ZendTestNS_UnlikelyCompileError();
 	zend_test_ns2_foo_class = register_class_ZendTestNS2_Foo();
 	zend_test_ns2_ns_foo_class = register_class_ZendTestNS2_ZendSubNS_Foo();
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -540,9 +540,7 @@ static ZEND_METHOD(ZendTestNS_UnlikelyCompileError, method)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 
-	return_value = ZEND_THIS;
-
-   return return_value;
+	RETURN_NULL();
 }
 
 static ZEND_METHOD(ZendTestNS2_Foo, method)

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -150,6 +150,12 @@ namespace ZendTestNS {
         public function method(): int {}
     }
 
+    class UnlikelyCompileError {
+        /* This method signature would create a compile error due to the string
+         * "ZendTestNS\UnlikelyCompileError" in the generated macro call */
+        public function method(): UnlikelyCompileError {}
+    }
+
 }
 
 namespace ZendTestNS2 {

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -153,7 +153,7 @@ namespace ZendTestNS {
     class UnlikelyCompileError {
         /* This method signature would create a compile error due to the string
          * "ZendTestNS\UnlikelyCompileError" in the generated macro call */
-        public function method(): UnlikelyCompileError {}
+        public function method(): ?UnlikelyCompileError {}
     }
 
 }

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: de4b91530a2aaf4c72436b0e8e9628d11a62fa15 */
+ * Stub hash: 2c654cefda278094fa4cdc25b83ced269e83cadf */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -131,7 +131,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZendTestNS_Foo_method, 0, 0, 0)
 #endif
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ZendTestNS_UnlikelyCompileError_method, 0, 0, ZendTestNS\\\125nlikelyCompileError, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ZendTestNS_UnlikelyCompileError_method, 0, 0, ZendTestNS\\\125nlikelyCompileError, 1)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_ZendTestNS2_Foo_method arginfo_zend_test_void_return

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 64a10ff1af71cb2f9024f73ddaa34a924b85b968 */
+ * Stub hash: de4b91530a2aaf4c72436b0e8e9628d11a62fa15 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -131,6 +131,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZendTestNS_Foo_method, 0, 0, 0)
 #endif
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_ZendTestNS_UnlikelyCompileError_method, 0, 0, ZendTestNS\\\125nlikelyCompileError, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_ZendTestNS2_Foo_method arginfo_zend_test_void_return
 
 #define arginfo_class_ZendTestNS2_ZendSubNS_Foo_method arginfo_zend_test_void_return
@@ -173,6 +176,7 @@ static ZEND_METHOD(ZendTestChildClassWithMethodWithParameterAttribute, override)
 static ZEND_METHOD(ZendTestForbidDynamicCall, call);
 static ZEND_METHOD(ZendTestForbidDynamicCall, callStatic);
 static ZEND_METHOD(ZendTestNS_Foo, method);
+static ZEND_METHOD(ZendTestNS_UnlikelyCompileError, method);
 static ZEND_METHOD(ZendTestNS2_Foo, method);
 static ZEND_METHOD(ZendTestNS2_ZendSubNS_Foo, method);
 
@@ -280,6 +284,12 @@ static const zend_function_entry class_ZendTestIntEnum_methods[] = {
 
 static const zend_function_entry class_ZendTestNS_Foo_methods[] = {
 	ZEND_ME(ZendTestNS_Foo, method, arginfo_class_ZendTestNS_Foo_method, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_ZendTestNS_UnlikelyCompileError_methods[] = {
+	ZEND_ME(ZendTestNS_UnlikelyCompileError, method, arginfo_class_ZendTestNS_UnlikelyCompileError_method, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -555,6 +565,16 @@ static zend_class_entry *register_class_ZendTestNS_Foo(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS", "Foo", class_ZendTestNS_Foo_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_ZendTestNS_UnlikelyCompileError(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "ZendTestNS", "UnlikelyCompileError", class_ZendTestNS_UnlikelyCompileError_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 
 	return class_entry;

--- a/ext/zend_test/tests/gen_stub_test_01.phpt
+++ b/ext/zend_test/tests/gen_stub_test_01.phpt
@@ -9,6 +9,8 @@ $foo = new \ZendTestNS2\Foo();
 var_dump($foo);
 $foo->foo = new \ZendTestNS2\ZendSubNS\Foo();
 var_dump($foo);
+$foo = new \ZendTestNS\UnlikelyCompileError();
+var_dump($foo);
 ?>
 --EXPECTF--
 object(ZendTestNS2\Foo)#%d (%d) {
@@ -19,4 +21,6 @@ object(ZendTestNS2\Foo)#%d (%d) {
   ["foo"]=>
   object(ZendTestNS2\ZendSubNS\Foo)#%d (%d) {
   }
+}
+object(ZendTestNS\UnlikelyCompileError)#%d (%d) {
 }


### PR DESCRIPTION
This fixes an issue where a namespaced class beginning with "U" or "u" would yield an invalid arginfo file due to the occurrence of a unicode escape sequence, causing a compile error.

Note: waiting for CI test results due to the absence of a local test environment.