### PR TITLE
Fix GH-9155: dba_open("non-existing", "c-", "flatfile") segfaults

### DIFF
--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -860,11 +860,10 @@ restart:
 				fcntl(info->fd, F_SETFL, flags & ~O_APPEND);
 #elif defined(PHP_WIN32)
 			} else if (modenr == DBA_CREAT && need_creation && !restarted) {
-				zend_bool close_both;
-
-				close_both = (info->fp != info->lock.fp);
-				php_stream_free(info->lock.fp, persistent ? PHP_STREAM_FREE_CLOSE_PERSISTENT : PHP_STREAM_FREE_CLOSE);
-				if (close_both) {
+				if (info->lock.fp != NULL) {
+					php_stream_free(info->lock.fp, persistent ? PHP_STREAM_FREE_CLOSE_PERSISTENT : PHP_STREAM_FREE_CLOSE);
+				}
+				if (info->fp != info->lock.fp) {
 					php_stream_free(info->fp, persistent ? PHP_STREAM_FREE_CLOSE_PERSISTENT : PHP_STREAM_FREE_CLOSE);
 				}
 				info->fp = NULL;

--- a/ext/dba/tests/gh9155.phpt
+++ b/ext/dba/tests/gh9155.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug GH-9155 (dba_open("non-existing", "c-", "flatfile") segfaults)
+--SKIPIF--
+<?php
+$handler = "flatfile";
+require_once(__DIR__ .'/skipif.inc');
+?>
+--FILE--
+<?php
+
+require_once(__DIR__ .'/test.inc');
+
+$db = dba_open($db_filename, 'c-', 'flatfile');
+var_dump($db);
+?>
+--CLEAN--
+<?php
+require_once(__DIR__ .'/clean.inc');
+?>
+--EXPECTF--
+resource(%d) of type (dba)


### PR DESCRIPTION
We must not assume that the lock file has been opened.