### PR TITLE
Optimize mb_strtoupper/mb_strtolower for UTF-8 enc and ASCII input

### DIFF
--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -449,6 +449,7 @@ ZEND_API char*        ZEND_FASTCALL zend_str_tolower_dup_ex(const char *source, 
 ZEND_API char*        ZEND_FASTCALL zend_str_toupper_dup_ex(const char *source, size_t length);
 ZEND_API zend_string* ZEND_FASTCALL zend_string_tolower_ex(zend_string *str, bool persistent);
 ZEND_API zend_string* ZEND_FASTCALL zend_string_toupper_ex(zend_string *str, bool persistent);
+ZEND_API bool         ZEND_FASTCALL zend_str_is_utf8_pure_ascii(const char *str, size_t length);
 
 #define zend_string_tolower(str) zend_string_tolower_ex(str, 0)
 #define zend_string_toupper(str) zend_string_toupper_ex(str, 0)


### PR DESCRIPTION
fixes https://bugs.php.net/bug.php?id=79545

### 🚀 improve performance by 250 - 6 000 % 🚀

UTF-8 is "special" encoding for 2 reasons - it is default and also mostly (and almost only) used [1].

Pure ASCII `strtolower`/`strtoupper` case conversion functions are highly optimized using SSE2.

`mb_strtoupper`/`mb_strtolower` case conversion functions are complex and a lot of calls are involved during the conversion. Thus they will always be slower. Much slower.

In English speaking countries, most texts consist of 7-bit ASCII strings only. This usecase can be optimized internally so `mbstring` case conversion functions can be used without a performance drop.

Here is a benchmark:

<details>
<summary>code:</summary>

```
<?php

$cnt = 1_000_000;

$strs = [
    'empty' => '',
    'short' => 'zluty kun',
    'short_with_uc' => 'zluty Kun',
    'long' => str_repeat('this is about 10000 chars long string', 270),
    'long_with_uc' => str_repeat('this is about 10000 chars long String', 270),
    'short_utf8' => 'žlutý kůň',
    'short_utf8_with_uc' => 'Žlutý kŮň',
];

foreach ($strs as $k => $str) {
    $a1 = microtime(true);
    for($i=0; $i < $cnt; ++$i){
        $res = strtolower($str);
    }
    $t1 = microtime(true) - $a1;
    // echo 'it took ' . round($t1 * 1000, 3) . ' ms for ++$i'."\n";

    $a2 = microtime(true);
    for($i=0; $i < $cnt; $i++){
        $res = mb_strtolower($str);
    }
    $t2 = microtime(true) - $a2;
    // echo 'it took ' . round($t2 * 1000, 3) . ' ms for $i++'."\n";

    echo 'strtolower is ' . round($t2/$t1, 2) . 'x faster than mb_strtolower for ' . $k . "\n\n";
}
```

</details>

```diff
-strtolower is 3.4x faster than mb_strtolower for empty
+strtolower is 1.16x faster than mb_strtolower for empty

-strtolower is 4.72x faster than mb_strtolower for short
+strtolower is 1.23x faster than mb_strtolower for short

-strtolower is 2.76x faster than mb_strtolower for short_with_uc
+strtolower is 1.13x faster than mb_strtolower for short_with_uc

-strtolower is 61.34x faster than mb_strtolower for long
+strtolower is 1.7x faster than mb_strtolower for long

-strtolower is 32.89x faster than mb_strtolower for long_with_uc
+strtolower is 1.37x faster than mb_strtolower for long_with_uc

-strtolower is 5.38x faster than mb_strtolower for short_utf8
+strtolower is 5.63x faster than mb_strtolower for short_utf8

-strtolower is 5.31x faster than mb_strtolower for short_utf8_with_uc
+strtolower is 5.52x faster than mb_strtolower for short_utf8_with_uc
```

[1] https://w3techs.com/technologies/cross/character_encoding/ranking (~98% market share)