### PR TITLE
Improve error messages in php_random_bytes()

### DIFF
--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -470,7 +470,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 	/* Defer to CryptGenRandom on Windows */
 	if (php_win32_get_random_bytes(bytes, size) == FAILURE) {
 		if (should_throw) {
-			zend_throw_exception(zend_ce_exception, "BCryptGenRandom failed", 0);
+			zend_throw_exception(zend_ce_exception, "Failed to retrieve randomness from the operating system (BCryptGenRandom)", 0);
 		}
 		return FAILURE;
 	}
@@ -483,7 +483,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 	 */
 	if (CCRandomGenerateBytes(bytes, size) != kCCSuccess) {
 		if (should_throw) {
-			zend_throw_exception(zend_ce_exception, "CCRandomGenerateBytes failed", 0);
+			zend_throw_exception(zend_ce_exception, "Failed to retrieve randomness from the operating system (CCRandomGenerateBytes)", 0);
 		}
 		return FAILURE;
 	}


### PR DESCRIPTION
see https://github.com/php/php-src/pull/9160#discussion_r931347027 for context

----------------

Not sure if this is lipstick on a pig, because `php_random_bytes()` really really should not fail on modern systems, but I'm putting it up for discussion nonetheless.

Technically a breaking change, in case someone relies in the specific wording in the error message, but this exception really shouldn't be caught as the system likely is broken beyond repair.

Review requests for devnexen for the general C and operating system experience, cmb for the Windows and PHP internals experience.