### PR TITLE
Attempt to fix build #9087 on macOs intel.

### DIFF
--- a/Zend/zend_long.h
+++ b/Zend/zend_long.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 
 /* This is the heart of the whole int64 enablement in zval. */
-#if defined(__x86_64__) || defined(__LP64__) || defined(_LP64) || defined(_WIN64)
+#if !defined(__APPLE__) && (defined(__x86_64__) || defined(__LP64__) || defined(_LP64) || defined(_WIN64))
 # define ZEND_ENABLE_ZVAL_LONG64 1
 #endif
 

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -375,6 +375,7 @@ ZEND_API bool ZEND_FASTCALL I_REPLACE_SONAME_FNNAME_ZU(NONE,zend_string_equal_va
 	return !memcmp(ZSTR_VAL(s1), ZSTR_VAL(s2), ZSTR_LEN(s1));
 }
 
+#if !defined(__APPLE__)
 #if defined(__GNUC__) && defined(__i386__)
 ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const zend_string *s2)
 {
@@ -450,6 +451,7 @@ ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const z
 		: "cc");
 	return ret;
 }
+#endif
 #endif
 
 ZEND_API zend_string *zend_string_concat2(

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -344,7 +344,7 @@ static zend_always_inline bool zend_string_equals_cstr(const zend_string *s1, co
 	return ZSTR_LEN(s1) == s2_length && !memcmp(ZSTR_VAL(s1), s2, s2_length);
 }
 
-#if defined(__GNUC__) && (defined(__i386__) || (defined(__x86_64__) && !defined(__ILP32__)))
+#if defined(__GNUC__) && !defined(__APPLE__) && (defined(__i386__) || (defined(__x86_64__) && !defined(__ILP32__)))
 BEGIN_EXTERN_C()
 ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const zend_string *s2);
 END_EXTERN_C()


### PR DESCRIPTION
Disable long 64 bits support and disable zend_string_equal_val assembly
implementation then as instructions are not longer understood.