### PR TITLE
Fix attribute target validation on fake closures

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1882,7 +1882,7 @@ ZEND_METHOD(ReflectionFunctionAbstract, getAttributes)
 
 	GET_REFLECTION_OBJECT_PTR(fptr);
 
-	if (fptr->common.scope && !(fptr->common.fn_flags & ZEND_ACC_CLOSURE)) {
+	if (fptr->common.scope && ((!(fptr->common.fn_flags & ZEND_ACC_CLOSURE) || fptr->common.fn_flags & ZEND_ACC_FAKE_CLOSURE))) {
 		target = ZEND_ATTRIBUTE_TARGET_METHOD;
 	} else {
 		target = ZEND_ATTRIBUTE_TARGET_FUNCTION;

--- a/ext/reflection/tests/gh8982.phpt
+++ b/ext/reflection/tests/gh8982.phpt
@@ -1,0 +1,52 @@
+--TEST--
+GH-8982 (Attribute target validation fails when read via ReflectionFunction)
+--FILE--
+<?php
+
+#[Attribute(Attribute::TARGET_FUNCTION)]
+class F
+{
+}
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class M
+{
+}
+
+class C
+{
+    #[F]
+    #[M]
+    public function m()
+    {
+    }
+}
+
+#[F]
+#[M]
+function f() {}
+
+function test(string $attributeClass, $value) {
+    try {
+        var_dump((new ReflectionFunction($value))->getAttributes($attributeClass)[0]->newInstance());
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+$m = [new C(), 'm'](...);
+$f = f(...);
+
+test(F::class, $f);
+test(M::class, $f);
+test(F::class, $m);
+test(M::class, $m);
+
+?>
+--EXPECT--
+object(F)#4 (0) {
+}
+Attribute "M" cannot target function (allowed targets: method)
+Attribute "F" cannot target method (allowed targets: function)
+object(M)#4 (0) {
+}


### PR DESCRIPTION
Closes GH-8982

~~I'll still need to check fake closures of callables created in class scope, which I suspect might fail.~~

Actually, this should be fine. Closures are the only function that can have a scope but not actually be a method. But closures can never be converted to fake closures since they early-return in that case.