### PR TITLE
Import timelib 2021.16

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@ PHP                                                                        NEWS
     different type). (Derick)
   . Fixed bug GH-8964 (DateTime object comparison after applying delta less
     than 1 second). (Derick)
+  . Fixed bug GH-9106: (DateInterval 1.5s added to DateTimeInterface is rounded
+    down since PHP 8.1.0). (Derick)
   . Fixed bug #81263 (Wrong result from DateTimeImmutable::diff). (Derick)
 
 - DBA:

--- a/ext/date/lib/interval.c
+++ b/ext/date/lib/interval.c
@@ -361,12 +361,21 @@ timelib_time *timelib_add_wall(timelib_time *old_time, timelib_rel_time *interva
 			timelib_update_ts(t, NULL);
 		}
 
-		do_range_limit(0, 1000000, 1000000, &interval->us, &interval->s);
-		t->sse += bias * timelib_hms_to_seconds(interval->h, interval->i, interval->s);
-		timelib_update_from_sse(t);
-		t->us += interval->us * bias;
-		if (bias == -1 && interval->us > 0) {
-			t->sse--;
+		if (interval->us == 0) {
+			t->sse += bias * timelib_hms_to_seconds(interval->h, interval->i, interval->s);
+			timelib_update_from_sse(t);
+		} else {
+			timelib_rel_time *temp_interval = timelib_rel_time_clone(interval);
+
+			do_range_limit(0, 1000000, 1000000, &temp_interval->us, &temp_interval->s);
+			t->sse += bias * timelib_hms_to_seconds(temp_interval->h, temp_interval->i, temp_interval->s);
+			timelib_update_from_sse(t);
+			t->us += temp_interval->us * bias;
+
+			timelib_do_normalize(t);
+			timelib_update_ts(t, NULL);
+
+			timelib_rel_time_dtor(temp_interval);
 		}
 		timelib_do_normalize(t);
 	}

--- a/ext/date/lib/timelib.h
+++ b/ext/date/lib/timelib.h
@@ -30,9 +30,9 @@
 # include "timelib_config.h"
 #endif
 
-#define TIMELIB_VERSION 202115
-#define TIMELIB_EXTENDED_VERSION 20211501
-#define TIMELIB_ASCII_VERSION "2021.15"
+#define TIMELIB_VERSION 202116
+#define TIMELIB_EXTENDED_VERSION 20211601
+#define TIMELIB_ASCII_VERSION "2021.16"
 
 #include <stdlib.h>
 #include <stdbool.h>

--- a/ext/date/tests/bug-gh9106.phpt
+++ b/ext/date/tests/bug-gh9106.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test for bug GH-9601: DateInterval 1.5s added to DateTimeInterface is rounded down since PHP 8.1.0
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+
+$start = new \DateTimeImmutable("2020-01-01 00:00:00 UTC");
+
+$oneAndHalfSec = new \DateInterval("PT1S");
+$oneAndHalfSec->f = 0.5;
+
+$t1 = $start->add($oneAndHalfSec);
+$t2 = $t1->add($oneAndHalfSec);
+$t3 = $t2->add($oneAndHalfSec);
+$t4 = $t3->add($oneAndHalfSec);
+
+var_dump($start->getTimestamp());
+var_dump($t1->getTimestamp());
+var_dump($t2->getTimestamp());
+var_dump($t3->getTimestamp());
+var_dump($t4->getTimestamp());
+?>
+--EXPECT--
+int(1577836800)
+int(1577836801)
+int(1577836803)
+int(1577836804)
+int(1577836806)


### PR DESCRIPTION
Fixes bug #9106: DateInterval 1.5s added to DateTimeInterface is rounded down since PHP 8.1.0