### PR TITLE
Close stale feature requests

### DIFF
--- a/.github/workflows/close-stale-feature-requests.yml
+++ b/.github/workflows/close-stale-feature-requests.yml
@@ -1,0 +1,23 @@
+name: Close stale feature requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    if: github.repository_owner == 'php'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-close: 7
+          days-before-stale: 90
+          exempt-issue-labels: "Status: Needs Triage"
+          only-issue-labels: Feature
+          # Hack to skip PRs, unfortunately there's no option to disable PRs
+          only-pr-labels: inexistent-label
+          stale-pr-message: >-
+            There has not been any recent activity in this feature request. It will automatically be closed in 7 days
+            if no further action is taken. Please see https://github.com/probot/stale#is-closing-stale-issues-really-a-good-idea
+            to understand why we auto-close stale feature requests.


### PR DESCRIPTION
@cmb69 As discussed a while back. If there's no activity in a feature request for 90 days it's very unlikely to get picked up after that. If there is in fact still interest the message could actually aid in making it happen as it serves as a reminder.