### PR TITLE
Extend map_ptr before copying class table

### DIFF
--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -743,6 +743,7 @@ static zend_always_inline uint32_t zval_gc_info(uint32_t gc_type_info) {
 
 #define ZSTR_SET_CE_CACHE_EX(s, ce, validate) do { \
 		if (!(validate) || ZSTR_VALID_CE_CACHE(s)) { \
+			ZEND_ASSERT((validate) || ZSTR_VALID_CE_CACHE(s)); \
 			SET_CE_CACHE(GC_REFCOUNT(s), ce); \
 		} \
 	} while (0)

--- a/ext/opcache/tests/gh9164.phpt
+++ b/ext/opcache/tests/gh9164.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Bug GH-9164: Segfault in zend_accel_class_hash_copy
+--EXTENSIONS--
+opcache
+pcntl
+--INI--
+opcache.enable_cli=1
+--FILE--
+<?php
+
+$incfile = __DIR__.'/gh9164.inc';
+
+// Generate enough classes so that the out of bound access will cause a crash
+// without relying on assertion
+$fd = fopen($incfile, 'w');
+fwrite($fd, "<?php\n");
+for ($i = 0; $i < 4096; $i++) {
+    fprintf($fd, "class FooBar%04d {}\n", $i);
+}
+fclose($fd);
+
+// Ensure cacheability
+touch($incfile, time() - 3600);
+
+$pid = pcntl_fork();
+if ($pid == 0) {
+    // Child: Declare classes to allocate CE cache slots.
+    require $incfile;
+} else if ($pid > 0) {
+    pcntl_wait($status);
+    // Ensure that file has been cached. If not, this is testing nothing anymore.
+    if (!isset(opcache_get_status()['scripts'][$incfile])) {
+        print "File not cached\n";
+    }
+    // Populates local cache
+    require $incfile;
+    var_dump(new FooBar4095);
+    unlink($incfile);
+} else {
+    echo "pcntl_fork() failed\n";
+}
+
+?>
+--EXPECTF--
+object(FooBar4095)#%d (0) {
+}

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -347,15 +347,11 @@ zend_op_array* zend_accel_load_script(zend_persistent_script *persistent_script,
 	op_array = (zend_op_array *) emalloc(sizeof(zend_op_array));
 	*op_array = persistent_script->script.main_op_array;
 
-	if (zend_hash_num_elements(&persistent_script->script.function_table) > 0) {
-		zend_accel_function_hash_copy(CG(function_table), &persistent_script->script.function_table);
-	}
-
-	if (zend_hash_num_elements(&persistent_script->script.class_table) > 0) {
-		zend_accel_class_hash_copy(CG(class_table), &persistent_script->script.class_table);
-	}
-
 	if (EXPECTED(from_shared_memory)) {
+		if (ZCSG(map_ptr_last) > CG(map_ptr_last)) {
+			zend_map_ptr_extend(ZCSG(map_ptr_last));
+		}
+
 		/* Register __COMPILER_HALT_OFFSET__ constant */
 		if (persistent_script->compiler_halt_offset != 0 &&
 		    persistent_script->script.filename) {
@@ -368,10 +364,14 @@ zend_op_array* zend_accel_load_script(zend_persistent_script *persistent_script,
 			}
 			zend_string_release_ex(name, 0);
 		}
+	}
 
-		if (ZCSG(map_ptr_last) > CG(map_ptr_last)) {
-			zend_map_ptr_extend(ZCSG(map_ptr_last));
-		}
+	if (zend_hash_num_elements(&persistent_script->script.function_table) > 0) {
+		zend_accel_function_hash_copy(CG(function_table), &persistent_script->script.function_table);
+	}
+
+	if (zend_hash_num_elements(&persistent_script->script.class_table) > 0) {
+		zend_accel_class_hash_copy(CG(class_table), &persistent_script->script.class_table);
 	}
 
 	if (persistent_script->num_early_bindings) {


### PR DESCRIPTION
A script loaded from shared memory may reference `map_ptr` entries higher than `CG(map_ptr_last)`, so we may need to extend the `map_ptr` before loading the script. 

`zend_accel_load_script()` does a `zend_map_ptr_extend(ZCSG(map_ptr_last))`, but I believe that it does it too late. In this change I move the  `zend_map_ptr_extend(ZCSG(map_ptr_last))` before anything else in `zend_accel_load_script()`. I moved the whole `if (EXPECTED(from_shared_memory)) {` block up to avoid duplicating the condition.

Fixes #9164

I understand that `map_ptr` is what allows opcache structures to be immutable, and to be used directly from SHM without copy. Each php process has a local mutable `map_ptr` vector, in which opcache structures can reference elements by index. The opcache can allocate new `map_ptr` indices in one process, but other processes need to extend the vector themselves.