### PR TITLE
Store fiber parent observed frames on the VM stack and fix observing functions in fibers

### DIFF
--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -31,6 +31,7 @@
 #include "zend_inference.h"
 #include "zend_dump.h"
 #include "php.h"
+#include "zend_observer.h"
 
 #ifndef ZEND_OPTIMIZER_MAX_REGISTERED_PASSES
 # define ZEND_OPTIMIZER_MAX_REGISTERED_PASSES 32
@@ -1094,6 +1095,8 @@ static void zend_revert_pass_two(zend_op_array *op_array)
 	}
 #endif
 
+	op_array->T -= ZEND_OBSERVER_ENABLED;
+
 	op_array->fn_flags &= ~ZEND_ACC_DONE_PASS_TWO;
 }
 
@@ -1122,6 +1125,8 @@ static void zend_redo_pass_two(zend_op_array *op_array)
 		op_array->literals = NULL;
 	}
 #endif
+
+	op_array->T += ZEND_OBSERVER_ENABLED; // reserve last temporary for observers if enabled
 
 	opline = op_array->opcodes;
 	end = opline + op_array->last;
@@ -1550,6 +1555,12 @@ ZEND_API void zend_optimize_script(zend_script *script, zend_long optimization_l
 			}
 		}
 
+		if (ZEND_OBSERVER_ENABLED) {
+			for (i = 0; i < call_graph.op_arrays_count; i++) {
+				++call_graph.op_arrays[i]->T; // ensure accurate temporary count for stack size precalculation
+			}
+		}
+
 		if (ZEND_OPTIMIZER_PASS_12 & optimization_level) {
 			for (i = 0; i < call_graph.op_arrays_count; i++) {
 				zend_adjust_fcall_stack_size_graph(call_graph.op_arrays[i]);
@@ -1565,6 +1576,8 @@ ZEND_API void zend_optimize_script(zend_script *script, zend_long optimization_l
 					zend_recalc_live_ranges(op_array, needs_live_range);
 				}
 			} else {
+				op_array->T -= ZEND_OBSERVER_ENABLED; // redo_pass_two will re-increment it
+
 				zend_redo_pass_two(op_array);
 				if (op_array->live_range) {
 					zend_recalc_live_ranges(op_array, NULL);

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2685,6 +2685,7 @@ ZEND_API zend_result zend_register_functions(zend_class_entry *scope, const zend
 	}
 	internal_function->type = ZEND_INTERNAL_FUNCTION;
 	internal_function->module = EG(current_module);
+	internal_function->T = 0;
 	memset(internal_function->reserved, 0, ZEND_MAX_RESERVED_RESOURCES * sizeof(void*));
 
 	while (ptr->fname) {

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -448,12 +448,12 @@ struct _zend_op_array {
 	uint32_t required_num_args;
 	zend_arg_info *arg_info;
 	HashTable *attributes;
+	uint32_t T;         /* number of temporary variables */
 	ZEND_MAP_PTR_DEF(void **, run_time_cache);
 	/* END of common elements */
 
 	int cache_size;     /* number of run_time_cache_slots * sizeof(void*) */
 	int last_var;       /* number of CV variables */
-	uint32_t T;         /* number of temporary variables */
 	uint32_t last;      /* number of opcodes */
 
 	zend_op *opcodes;
@@ -503,6 +503,7 @@ typedef struct _zend_internal_function {
 	uint32_t required_num_args;
 	zend_internal_arg_info *arg_info;
 	HashTable *attributes;
+	uint32_t T;         /* number of temporary variables */
 	ZEND_MAP_PTR_DEF(void **, run_time_cache);
 	/* END of common elements */
 
@@ -528,6 +529,7 @@ union _zend_function {
 		uint32_t required_num_args;
 		zend_arg_info *arg_info;  /* index -1 represents the return value info, if any */
 		HashTable   *attributes;
+		uint32_t T;         /* number of temporary variables */
 		ZEND_MAP_PTR_DEF(void **, run_time_cache);
 	} common;
 

--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -23,6 +23,7 @@
 #include "zend_interfaces.h"
 #include "zend_enum.h"
 #include "zend_extensions.h"
+#include "zend_observer.h"
 
 #define ZEND_ENUM_DISALLOW_MAGIC_METHOD(propertyName, methodName) \
 	do { \
@@ -407,6 +408,7 @@ static void zend_enum_register_func(zend_class_entry *ce, zend_known_string_id n
 	zif->type = ZEND_INTERNAL_FUNCTION;
 	zif->module = EG(current_module);
 	zif->scope = ce;
+	zif->T = ZEND_OBSERVER_ENABLED;
 	ZEND_MAP_PTR_NEW(zif->run_time_cache);
 	ZEND_MAP_PTR_SET(zif->run_time_cache, zend_arena_alloc(&CG(arena), zend_internal_run_time_cache_reserved_size()));
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -144,6 +144,7 @@ ZEND_API const zend_internal_function zend_pass_function = {
 	0,                      /* required_num_args */
 	(zend_internal_arg_info *) zend_pass_function_arg_info + 1, /* arg_info */
 	NULL,                   /* attributes        */
+	0,                      /* T                 */
 	NULL,                   /* run_time_cache    */
 	ZEND_FN(pass),          /* handler           */
 	NULL,                   /* module            */

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -245,10 +245,10 @@ static zend_always_inline zend_execute_data *zend_vm_stack_push_call_frame_ex(ui
 
 static zend_always_inline uint32_t zend_vm_calc_used_stack(uint32_t num_args, zend_function *func)
 {
-	uint32_t used_stack = ZEND_CALL_FRAME_SLOT + num_args;
+	uint32_t used_stack = ZEND_CALL_FRAME_SLOT + num_args + func->common.T;
 
 	if (EXPECTED(ZEND_USER_CODE(func->type))) {
-		used_stack += func->op_array.last_var + func->op_array.T - MIN(func->op_array.num_args, num_args);
+		used_stack += func->op_array.last_var - MIN(func->op_array.num_args, num_args);
 	}
 	return used_stack * sizeof(zval);
 }

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -88,6 +88,9 @@ struct _zend_fiber_context {
 	/* Fiber status. */
 	zend_fiber_status status;
 
+	/* Observer state */
+	zend_execute_data *top_observed_frame;
+
 	/* Reserved for extensions */
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -27,6 +27,7 @@
 #include "zend_API.h"
 #include "zend_sort.h"
 #include "zend_constants.h"
+#include "zend_observer.h"
 
 #include "zend_vm.h"
 
@@ -1048,6 +1049,8 @@ ZEND_API void pass_two(zend_op_array *op_array)
 	CG(context).opcodes_size = op_array->last;
 	CG(context).literals_size = op_array->last_literal;
 #endif
+
+    op_array->T += ZEND_OBSERVER_ENABLED; // reserve last temporary for observers if enabled
 
 	/* Needs to be set directly after the opcode/literal reallocation, to ensure destruction
 	 * happens correctly if any of the following fixups generate a fatal error. */

--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -8407,7 +8407,7 @@ static int zend_jit_push_call_frame(dasm_State **Dst, const zend_op *opline, con
 			stack_check = 0;
 		}
 	} else {
-		used_stack = (ZEND_CALL_FRAME_SLOT + opline->extended_value) * sizeof(zval);
+		used_stack = (ZEND_CALL_FRAME_SLOT + opline->extended_value + ZEND_OBSERVER_ENABLED) * sizeof(zval);
 
 		|	// if (EXPECTED(ZEND_USER_CODE(func->type))) {
 		if (!is_closure) {

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -9010,7 +9010,7 @@ static int zend_jit_push_call_frame(dasm_State **Dst, const zend_op *opline, con
 			stack_check = 0;
 		}
 	} else {
-		used_stack = (ZEND_CALL_FRAME_SLOT + opline->extended_value) * sizeof(zval);
+		used_stack = (ZEND_CALL_FRAME_SLOT + opline->extended_value + ZEND_OBSERVER_ENABLED) * sizeof(zval);
 
 		|	// if (EXPECTED(ZEND_USER_CODE(func->type))) {
 		if (!is_closure) {

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -33,6 +33,7 @@
 #include "zend_object_handlers.h"
 #include "zend_hash.h"
 #include "pdo_dbh_arginfo.h"
+#include "zend_observer.h"
 
 static bool pdo_dbh_attribute_set(pdo_dbh_t *dbh, zend_long attr, zval *value);
 
@@ -1246,6 +1247,7 @@ bool pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
 		func.scope = dbh_obj->std.ce;
 		func.prototype = NULL;
 		ZEND_MAP_PTR(func.run_time_cache) = NULL;
+		func.T = ZEND_OBSERVER_ENABLED;
 		if (funcs->flags) {
 			func.fn_flags = funcs->flags | ZEND_ACC_NEVER_CACHE;
 		} else {

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -756,6 +756,7 @@ PHP_MSHUTDOWN_FUNCTION(zend_test)
 PHP_RINIT_FUNCTION(zend_test)
 {
 	zend_hash_init(&ZT_G(global_weakmap), 8, NULL, ZVAL_PTR_DTOR, 0);
+	ZT_G(observer_nesting_depth) = 0;
 	return SUCCESS;
 }
 

--- a/ext/zend_test/tests/observer_fiber_functions_01.phpt
+++ b/ext/zend_test/tests/observer_fiber_functions_01.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Observer: Basic function observing in fibers
+--EXTENSIONS--
+zend_test
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.fiber_init=1
+zend_test.observer.fiber_switch=1
+zend_test.observer.fiber_destroy=1
+--FILE--
+<?php
+
+$fiber = new Fiber(function (): void {
+    var_dump(1);
+    Fiber::suspend();
+    var_dump(2);
+});
+
+$fiber->start();
+$fiber->resume();
+
+?>
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init Fiber::__construct() -->
+  <Fiber::__construct>
+  </Fiber::__construct>
+  <!-- init Fiber::start() -->
+  <Fiber::start>
+<!-- alloc: %s -->
+<!-- switching from fiber %s to %s -->
+<init '%s'>
+    <!-- init {closure}() -->
+    <{closure}>
+      <!-- init var_dump() -->
+      <var_dump>
+int(1)
+      </var_dump>
+      <!-- init Fiber::suspend() -->
+      <Fiber::suspend>
+<!-- switching from fiber %s to %s -->
+<suspend '%s'>
+      </Fiber::start>
+      <!-- init Fiber::resume() -->
+      <Fiber::resume>
+<!-- switching from fiber %s to %s -->
+<resume '%s'>
+      </Fiber::suspend>
+      <var_dump>
+int(2)
+      </var_dump>
+    </{closure}>
+<!-- switching from fiber %s to %s -->
+<returned '%s'>
+<!-- destroy: %s -->
+  </Fiber::resume>
+</file '%s'>

--- a/ext/zend_test/tests/observer_fiber_functions_02.phpt
+++ b/ext/zend_test/tests/observer_fiber_functions_02.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Observer: Function observing in fibers with unfinished fiber
+--EXTENSIONS--
+zend_test
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.fiber_init=1
+zend_test.observer.fiber_switch=1
+zend_test.observer.fiber_destroy=1
+--FILE--
+<?php
+
+$fiber = new Fiber(function (): void {
+    var_dump(1);
+    Fiber::suspend();
+    var_dump(2);
+});
+
+$fiber->start();
+
+?>
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init Fiber::__construct() -->
+  <Fiber::__construct>
+  </Fiber::__construct>
+  <!-- init Fiber::start() -->
+  <Fiber::start>
+<!-- alloc: %s -->
+<!-- switching from fiber %s to %s -->
+<init '%s'>
+    <!-- init {closure}() -->
+    <{closure}>
+      <!-- init var_dump() -->
+      <var_dump>
+int(1)
+      </var_dump>
+      <!-- init Fiber::suspend() -->
+      <Fiber::suspend>
+<!-- switching from fiber %s to %s -->
+<suspend '%s'>
+      </Fiber::start>
+    </file '%s'>
+<!-- switching from fiber %s to %s -->
+<destroying '%s'>
+    <!-- Exception: GracefulExit -->
+  </Fiber::suspend>
+  <!-- Exception: GracefulExit -->
+</{closure}>
+<!-- switching from fiber %s to %s -->
+<destroyed '%s'>
+<!-- destroy: %s -->

--- a/ext/zend_test/tests/observer_fiber_functions_03.phpt
+++ b/ext/zend_test/tests/observer_fiber_functions_03.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Observer: Function observing in fibers with bailout in fiber
+--EXTENSIONS--
+zend_test
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.fiber_init=1
+zend_test.observer.fiber_switch=1
+zend_test.observer.fiber_destroy=1
+memory_limit=100M
+--FILE--
+<?php
+
+$notBailedOutFiber = new Fiber(function (): void {
+    var_dump(1);
+    Fiber::suspend();
+});
+
+$notBailedOutFiber->start();
+
+$fiber = new Fiber(function (): void {
+    var_dump(2);
+    Fiber::suspend();
+    str_repeat('A', 200_000_000);
+});
+
+$fiber->start();
+$fiber->resume();
+
+?>
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init Fiber::__construct() -->
+  <Fiber::__construct>
+  </Fiber::__construct>
+  <!-- init Fiber::start() -->
+  <Fiber::start>
+<!-- alloc: %s -->
+<!-- switching from fiber %s to %s -->
+<init '%s'>
+    <!-- init {closure}() -->
+    <{closure}>
+      <!-- init var_dump() -->
+      <var_dump>
+int(1)
+      </var_dump>
+      <!-- init Fiber::suspend() -->
+      <Fiber::suspend>
+<!-- switching from fiber %s to %s -->
+<suspend '%s'>
+      </Fiber::start>
+      <Fiber::__construct>
+      </Fiber::__construct>
+      <Fiber::start>
+<!-- alloc: %s -->
+<!-- switching from fiber %s to %s -->
+<init '%s'>
+        <!-- init {closure}() -->
+        <{closure}>
+          <var_dump>
+int(2)
+          </var_dump>
+          <Fiber::suspend>
+<!-- switching from fiber %s to %s -->
+<suspend '%s'>
+          </Fiber::start>
+          <!-- init Fiber::resume() -->
+          <Fiber::resume>
+<!-- switching from fiber %s to %s -->
+<resume '%s'>
+          </Fiber::suspend>
+          <!-- init str_repeat() -->
+          <str_repeat>
+
+Fatal error: Allowed memory size of 104857600 bytes exhausted %s on line %d
+          </str_repeat>
+        </{closure}>
+<!-- switching from fiber %s to %s -->
+<returned '%s'>
+<!-- destroy: %s -->
+      </Fiber::resume>
+    </file '%s'>


### PR DESCRIPTION
This PR addresses two/three issues:
a) There was a significant performance penalty, when some leaf function was observed, deep in the stack.
b) The current_observed_frame is carried along the fiber context and thus always correct now.
c) As a side effect, we are not iterating over prev_execute_data anymore and thus, non-observed fake frames, possibly on stack, cannot have any impact on the observer anymore (especially within zend_observer_fcall_end_all). 

Saving the previous observer happens now directly on the VM stack. If there is any observer, function frames are allocated an extra zval (the last temporary), which will, on observed frames, contain the previous observed frame address.