### PR TITLE
Fix bug #79451: Using DOMDocument->replaceChild on doctype causes double free

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1001,7 +1001,8 @@ PHP_METHOD(DOMNode, replaceChild)
 	zval *id, *newnode, *oldnode;
 	xmlNodePtr children, newchild, oldchild, nodep;
 	dom_object *intern, *newchildobj, *oldchildobj;
-	int foundoldchild = 0, stricterror, replacedoctype = 0;
+	int foundoldchild = 0, stricterror;
+	bool replacedoctype = false;
 
 	int ret;
 

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1065,7 +1065,7 @@ PHP_METHOD(DOMNode, replaceChild)
 			}
 		} else if (oldchild != newchild) {
 			xmlDtdPtr intSubset = xmlGetIntSubset(nodep->doc);
-			replacedoctype = (intSubset == oldchild);
+			replacedoctype = (intSubset == (xmlDtd *) oldchild);
 
 			if (newchild->doc == NULL && nodep->doc != NULL) {
 				xmlSetTreeDoc(newchild, nodep->doc);

--- a/ext/dom/tests/bug79451.phpt
+++ b/ext/dom/tests/bug79451.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #79451 (Using DOMDocument->replaceChild on doctype causes double free)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$dom = new \DOMDocument();
+$dom->loadHTML("<!DOCTYPE html><p>hello</p>");
+$impl = new \DOMImplementation();
+$dt = $impl->createDocumentType("html_replace", "", "");
+$dom->replaceChild($dt, $dom->doctype);
+
+var_dump($dom->doctype->name);
+echo $dom->saveXML();
+?>
+--EXPECTF--
+string(12) "html_replace"
+<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE html_replace>
+<html><body><p>hello</p></body></html>


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=79451
We have to reset intSubset if replacing doctype with another doctype node.