### PR TITLE
Improve phrasing in argument value errors in ext/random

### DIFF
--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -273,7 +273,7 @@ PHP_METHOD(Random_Engine_Mt19937, __construct)
 			state->mode = MT_RAND_PHP;
 			break;
 		default:
-			zend_argument_value_error(2, "mode must be MT_RAND_MT19937 or MT_RAND_PHP");
+			zend_argument_value_error(2, "must be MT_RAND_MT19937 or MT_RAND_PHP");
 			RETURN_THROWS();
 	}
 

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -273,7 +273,7 @@ PHP_METHOD(Random_Engine_Mt19937, __construct)
 			state->mode = MT_RAND_PHP;
 			break;
 		default:
-			zend_argument_value_error(2, "must be MT_RAND_MT19937 or MT_RAND_PHP");
+			zend_argument_value_error(2, "must be either MT_RAND_MT19937 or MT_RAND_PHP");
 			RETURN_THROWS();
 	}
 

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -165,7 +165,7 @@ PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 				}
 				seed128(engine->status, php_random_uint128_constant(t[0], t[1]));
 			} else {
-				zend_argument_value_error(1, "state strings must be 16 bytes");
+				zend_argument_value_error(1, "must be a 16 byte (128 bit) string");
 				RETURN_THROWS();
 			}
 		} else {

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -225,7 +225,7 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, __construct)
 				}
 				seed256(engine->status, t[0], t[1], t[2], t[3]);
 			} else {
-				zend_argument_value_error(1, "state strings must be 32 bytes");
+				zend_argument_value_error(1, "must be a 32 byte (256 bit) string");
 				RETURN_THROWS();
 			}
 		} else {

--- a/ext/random/tests/02_engine/mt19937_error.phpt
+++ b/ext/random/tests/02_engine/mt19937_error.phpt
@@ -11,4 +11,4 @@ try {
 
 ?>
 --EXPECT--
-Random\Engine\Mt19937::__construct(): Argument #2 ($mode) mode must be MT_RAND_MT19937 or MT_RAND_PHP
+Random\Engine\Mt19937::__construct(): Argument #2 ($mode) must be MT_RAND_MT19937 or MT_RAND_PHP

--- a/ext/random/tests/02_engine/mt19937_error.phpt
+++ b/ext/random/tests/02_engine/mt19937_error.phpt
@@ -11,4 +11,4 @@ try {
 
 ?>
 --EXPECT--
-Random\Engine\Mt19937::__construct(): Argument #2 ($mode) must be MT_RAND_MT19937 or MT_RAND_PHP
+Random\Engine\Mt19937::__construct(): Argument #2 ($mode) must be either MT_RAND_MT19937 or MT_RAND_PHP

--- a/ext/random/tests/02_engine/pcgoneseq128xslrr64_seed.phpt
+++ b/ext/random/tests/02_engine/pcgoneseq128xslrr64_seed.phpt
@@ -30,7 +30,7 @@ for ($i = 0; $i < 1000; $i++) {
 ?>
 --EXPECTF--
 Random\Engine\PcgOneseq128XslRr64::__construct(): Argument #1 ($seed) must be of type string|int|null, float given
-Random\Engine\PcgOneseq128XslRr64::__construct(): Argument #1 ($seed) state strings must be 16 bytes
+Random\Engine\PcgOneseq128XslRr64::__construct(): Argument #1 ($seed) must be a 16 byte (128 bit) string
 object(Random\Engine\PcgOneseq128XslRr64)#%d (%d) {
   ["__states"]=>
   array(2) {

--- a/ext/random/tests/02_engine/xoshiro256starstar_seed.phpt
+++ b/ext/random/tests/02_engine/xoshiro256starstar_seed.phpt
@@ -30,7 +30,7 @@ for ($i = 0; $i < 1000; $i++) {
 ?>
 --EXPECTF--
 Random\Engine\Xoshiro256StarStar::__construct(): Argument #1 ($seed) must be of type string|int|null, float given
-Random\Engine\Xoshiro256StarStar::__construct(): Argument #1 ($seed) state strings must be 32 bytes
+Random\Engine\Xoshiro256StarStar::__construct(): Argument #1 ($seed) must be a 32 byte (256 bit) string
 object(Random\Engine\Xoshiro256StarStar)#%d (%d) {
   ["__states"]=>
   array(4) {


### PR DESCRIPTION
This rephrases the error message for argument errors to be a proper English
sentence.