### PR TITLE
Fix bug #65489: glob() basedir check is inconsistent

### DIFF
--- a/ext/standard/dir.c
+++ b/ext/standard/dir.c
@@ -472,18 +472,6 @@ PHP_FUNCTION(glob)
 #ifdef GLOB_NOMATCH
 no_results:
 #endif
-#ifndef PHP_WIN32
-		/* Paths containing '*', '?' and some other chars are
-		illegal on Windows but legit on other platforms. For
-		this reason the direct basedir check against the glob
-		query is senseless on windows. For instance while *.txt
-		is a pretty valid filename on EXT3, it's invalid on NTFS. */
-		if (PG(open_basedir) && *PG(open_basedir)) {
-			if (php_check_open_basedir_ex(pattern, 0)) {
-				RETURN_FALSE;
-			}
-		}
-#endif
 		array_init(return_value);
 		return;
 	}

--- a/ext/standard/tests/file/bug41655_1.phpt
+++ b/ext/standard/tests/file/bug41655_1.phpt
@@ -17,5 +17,6 @@ var_dump($a);
 echo "Done\n";
 ?>
 --EXPECT--
-bool(false)
+array(0) {
+}
 Done

--- a/ext/standard/tests/file/glob_variation5.phpt
+++ b/ext/standard/tests/file/glob_variation5.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test glob() function: ensure no platform difference, variation 3
 --SKIPIF--
-<?php if( substr(PHP_OS, 0, 3) == "WIN" ) {die('skip not valid on Windows');} ?>
+<?php if( substr(PHP_OS, 0, 3) == "WIN" ) die('skip not valid directory on Windows'); ?>
 --FILE--
 <?php
 $path = __DIR__;
@@ -19,10 +19,16 @@ var_dump(glob("$path/directly_not_exists"));
 var_dump($open_basedir == ini_get('open_basedir'));
 ?>
 --EXPECT--
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
+array(0) {
+}
+array(0) {
+}
+array(0) {
+}
+array(0) {
+}
+array(0) {
+}
+array(0) {
+}
 bool(true)

--- a/ext/standard/tests/file/glob_variation6.phpt
+++ b/ext/standard/tests/file/glob_variation6.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test glob() function: ensure no platform difference, variation 4
 --SKIPIF--
-<?php if( substr(PHP_OS, 0, 3) != "WIN" ) {die('skip only valid on Windows');} ?>
+<?php if( substr(PHP_OS, 0, 3) != "WIN" ) die('skip only valid directory on Windows'); ?>
 --FILE--
 <?php
 $path = __DIR__;


### PR DESCRIPTION
This removes the inconsistent and incorrectly working open basedir check on pattern in glob. It means that an empty array will be returned even if the whole pattern is outside the open basedir restriction.