### PR TITLE
Remove ZEND_DVAL_TO_LVAL_CAST_OK

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,7 @@ PHP                                                                        NEWS
 - Standard:
   . Fixed bug GH-9017 (php_stream_sock_open_from_socket could return NULL).
     (Heiko Weber)
+  . Fixed incorrect double to long casting in latest clang. (zeriyoshi)
 
 04 Aug 2022, PHP 8.0.22
 

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -149,40 +149,6 @@ dnl Checks for library functions.
 AC_CHECK_FUNCS(getpid kill sigsetjmp)
 
 ZEND_CHECK_FLOAT_PRECISION
-
-dnl Test whether double cast to long preserves least significant bits.
-AC_MSG_CHECKING(whether double cast to long preserves least significant bits)
-
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <limits.h>
-#include <stdlib.h>
-
-int main()
-{
-	if (sizeof(long) == 4) {
-		double d = (double) LONG_MIN * LONG_MIN + 2e9;
-
-		if ((long) d == 2e9 && (long) -d == -2e9) {
-			return 0;
-		}
-	} else if (sizeof(long) == 8) {
-		double correct = 18e18 - ((double) LONG_MIN * -2); /* Subtract ULONG_MAX + 1 */
-
-		if ((long) 18e18 == correct) { /* On 64-bit, only check between LONG_MAX and ULONG_MAX */
-			return 0;
-		}
-	}
-	return 1;
-}
-]])], [
-  AC_DEFINE([ZEND_DVAL_TO_LVAL_CAST_OK], 1, [Define if double cast to long preserves least significant bits])
-  AC_MSG_RESULT(yes)
-], [
-  AC_MSG_RESULT(no)
-], [
-  AC_MSG_RESULT(no)
-])
-
 ])
 
 dnl

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -3222,8 +3222,7 @@ ZEND_API const char* ZEND_FASTCALL zend_memnrstr_ex(const char *haystack, const 
 }
 /* }}} */
 
-#ifndef ZEND_DVAL_TO_LVAL_CAST_OK
-# if SIZEOF_ZEND_LONG == 4
+#if SIZEOF_ZEND_LONG == 4
 ZEND_API zend_long ZEND_FASTCALL zend_dval_to_lval_slow(double d) /* {{{ */
 {
 	double	two_pow_32 = pow(2., 32.),
@@ -3252,5 +3251,4 @@ ZEND_API zend_long ZEND_FASTCALL zend_dval_to_lval_slow(double d)
 	return (zend_long)(zend_ulong)dmod;
 }
 /* }}} */
-#endif
 #endif

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -99,16 +99,6 @@ ZEND_API const char* ZEND_FASTCALL zend_memnrstr_ex(const char *haystack, const 
 #	define ZEND_DOUBLE_FITS_LONG(d) (!((d) >= (double)ZEND_LONG_MAX || (d) < (double)ZEND_LONG_MIN))
 #endif
 
-#ifdef ZEND_DVAL_TO_LVAL_CAST_OK
-static zend_always_inline zend_long zend_dval_to_lval(double d)
-{
-    if (EXPECTED(zend_finite(d)) && EXPECTED(!zend_isnan(d))) {
-        return (zend_long)d;
-    } else {
-        return 0;
-    }
-}
-#else
 ZEND_API zend_long ZEND_FASTCALL zend_dval_to_lval_slow(double d);
 
 static zend_always_inline zend_long zend_dval_to_lval(double d)
@@ -120,7 +110,6 @@ static zend_always_inline zend_long zend_dval_to_lval(double d)
 	}
 	return (zend_long)d;
 }
-#endif
 
 static zend_always_inline zend_long zend_dval_to_lval_cap(double d)
 {


### PR DESCRIPTION
As far as I can see, this operation should always use the slow (right) method, and the results seem to be wrong when `ZEND_DVAL_TO_LVAL_CAST_OK` is enabled.

I see, this macro seems to be always disabled in Linux / gcc and macOS 10.15 / clang (13.0.0) environments. (If clang is updated, the autoconf check succeeds and it is enabled. The test always fails because it does not work as expected)

Are there cases where this macro is correctly enabled?

Blocker: #9087 