### PR TITLE
Add ext/random Exception hierarchy

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ PHP                                                                        NEWS
     PcgOneseq128XslRr64::__construct()). (timwolla)
   . Removed redundant RuntimeExceptions from Randomizer methods. The
     exceptions thrown by the engines will be exposed directly. (timwolla)
+  . Added extension specific Exceptions/Errors (RandomException, RandomError,
+    BrokenRandomEngineError). (timwolla)
 
 04 Aug 2022, PHP 8.2.0beta2
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -201,6 +201,10 @@ PHP 8.2 UPGRADE NOTES
     dba_fetch(string|array $key, $skip, $dba): string|false
     is still accepted, but it is recommended to use the new standard variant.
 
+- Random
+  . random_bytes() and random_int() now throw \Random\RandomException on CSPRNG failure.
+    Previously a plain \Exception was thrown.
+
 - SPL
   . The $iterator parameter of iterator_to_array() and iterator_count() is
     widened to iterable from Iterator, allowing arrays to be passed.

--- a/ext/random/engine_combinedlcg.c
+++ b/ext/random/engine_combinedlcg.c
@@ -22,7 +22,6 @@
 #include "php.h"
 #include "php_random.h"
 
-#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_exceptions.h"
 
 /*

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -30,7 +30,6 @@
 #include "php.h"
 #include "php_random.h"
 
-#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_exceptions.h"
 
 /*
@@ -280,7 +279,7 @@ PHP_METHOD(Random_Engine_Mt19937, __construct)
 	if (seed_is_null) {
 		/* MT19937 has a very large state, uses CSPRNG for seeding only */
 		if (php_random_bytes_throw(&seed, sizeof(zend_long)) == FAILURE) {
-			zend_throw_exception(spl_ce_RuntimeException, "Failed to generate a random seed", 0);
+			zend_throw_exception(random_ce_Random_RandomException, "Failed to generate a random seed", 0);
 			RETURN_THROWS();
 		}
 	}

--- a/ext/random/engine_pcgoneseq128xslrr64.c
+++ b/ext/random/engine_pcgoneseq128xslrr64.c
@@ -23,7 +23,6 @@
 #include "php.h"
 #include "php_random.h"
 
-#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_exceptions.h"
 
 static inline void step(php_random_status_state_pcgoneseq128xslrr64 *s)
@@ -149,7 +148,7 @@ PHP_METHOD(Random_Engine_PcgOneseq128XslRr64, __construct)
 
 	if (seed_is_null) {
 		if (php_random_bytes_throw(&state->state, sizeof(php_random_uint128_t)) == FAILURE) {
-			zend_throw_exception(spl_ce_RuntimeException, "Failed to generate a random seed", 0);
+			zend_throw_exception(random_ce_Random_RandomException, "Failed to generate a random seed", 0);
 			RETURN_THROWS();
 		}
 	} else {

--- a/ext/random/engine_secure.c
+++ b/ext/random/engine_secure.c
@@ -22,7 +22,6 @@
 #include "php.h"
 #include "php_random.h"
 
-#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_exceptions.h"
 
 static uint64_t generate(php_random_status *status)

--- a/ext/random/engine_user.c
+++ b/ext/random/engine_user.c
@@ -49,7 +49,7 @@ static uint64_t generate(php_random_status *status)
 			result += ((uint64_t) (unsigned char) Z_STRVAL(retval)[i]) << (8 * i);
 		}
 	} else {
-		zend_throw_error(NULL, "A random engine must return a non-empty string");
+		zend_throw_error(random_ce_Random_BrokenRandomEngineError, "A random engine must return a non-empty string");
 		return 0;
 	}
 

--- a/ext/random/engine_xoshiro256starstar.c
+++ b/ext/random/engine_xoshiro256starstar.c
@@ -24,7 +24,6 @@
 #include "php.h"
 #include "php_random.h"
 
-#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_exceptions.h"
 
 static inline uint64_t splitmix64(uint64_t *seed)
@@ -207,7 +206,7 @@ PHP_METHOD(Random_Engine_Xoshiro256StarStar, __construct)
 
 	if (seed_is_null) {
 		if (php_random_bytes_throw(&state->state, 32) == FAILURE) {
-			zend_throw_exception(spl_ce_RuntimeException, "Failed to generate a random seed", 0);
+			zend_throw_exception(random_ce_Random_RandomException, "Failed to generate a random seed", 0);
 			RETURN_THROWS();
 		}
 	} else {

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -260,6 +260,10 @@ typedef struct _php_random_randomizer {
 extern PHPAPI zend_class_entry *random_ce_Random_Engine;
 extern PHPAPI zend_class_entry *random_ce_Random_CryptoSafeEngine;
 
+extern PHPAPI zend_class_entry *random_ce_Random_RandomError;
+extern PHPAPI zend_class_entry *random_ce_Random_BrokenRandomEngineError;
+extern PHPAPI zend_class_entry *random_ce_Random_RandomException;
+
 extern PHPAPI zend_class_entry *random_ce_Random_Engine_PcgOneseq128XslRr64;
 extern PHPAPI zend_class_entry *random_ce_Random_Engine_Mt19937;
 extern PHPAPI zend_class_entry *random_ce_Random_Engine_Xoshiro256StarStar;

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -126,7 +126,7 @@ static inline uint32_t rand_range32(const php_random_algo *algo, php_random_stat
 	while (UNEXPECTED(result > limit)) {
 		/* If the requirements cannot be met in a cycles, return fail */
 		if (++count > RANDOM_RANGE_ATTEMPTS) {
-			zend_throw_error(NULL, "Failed to generate an acceptable random number in %d attempts", RANDOM_RANGE_ATTEMPTS);
+			zend_throw_error(random_ce_Random_BrokenRandomEngineError, "Failed to generate an acceptable random number in %d attempts", RANDOM_RANGE_ATTEMPTS);
 			return 0;
 		}
 
@@ -182,7 +182,7 @@ static inline uint64_t rand_range64(const php_random_algo *algo, php_random_stat
 	while (UNEXPECTED(result > limit)) {
 		/* If the requirements cannot be met in a cycles, return fail */
 		if (++count > RANDOM_RANGE_ATTEMPTS) {
-			zend_throw_error(NULL, "Failed to generate an acceptable random number in %d attempts", RANDOM_RANGE_ATTEMPTS);
+			zend_throw_error(random_ce_Random_BrokenRandomEngineError, "Failed to generate an acceptable random number in %d attempts", RANDOM_RANGE_ATTEMPTS);
 			return 0;
 		}
 

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -74,7 +74,12 @@ PHPAPI zend_class_entry *random_ce_Random_Engine_Mt19937;
 PHPAPI zend_class_entry *random_ce_Random_Engine_PcgOneseq128XslRr64;
 PHPAPI zend_class_entry *random_ce_Random_Engine_Xoshiro256StarStar;
 PHPAPI zend_class_entry *random_ce_Random_Engine_Secure;
+
 PHPAPI zend_class_entry *random_ce_Random_Randomizer;
+
+PHPAPI zend_class_entry *random_ce_Random_RandomError;
+PHPAPI zend_class_entry *random_ce_Random_BrokenRandomEngineError;
+PHPAPI zend_class_entry *random_ce_Random_RandomException;
 
 static zend_object_handlers random_engine_mt19937_object_handlers;
 static zend_object_handlers random_engine_pcgoneseq128xslrr64_object_handlers;
@@ -831,6 +836,15 @@ PHP_MINIT_FUNCTION(random)
 
 	/* Random\CryptoSafeEngine */
 	random_ce_Random_CryptoSafeEngine = register_class_Random_CryptoSafeEngine(random_ce_Random_Engine);
+
+	/* Random\RandomError */
+	random_ce_Random_RandomError = register_class_Random_RandomError(zend_ce_error);
+
+	/* Random\BrokenRandomEngineError */
+	random_ce_Random_BrokenRandomEngineError = register_class_Random_BrokenRandomEngineError(random_ce_Random_RandomError);
+
+	/* Random\RandomException */
+	random_ce_Random_RandomException = register_class_Random_RandomException(zend_ce_exception);
 
 	/* Random\Engine\Mt19937 */
 	random_ce_Random_Engine_Mt19937 = register_class_Random_Engine_Mt19937(random_ce_Random_Engine);

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -26,7 +26,6 @@
 
 #include "php.h"
 
-#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_exceptions.h"
 
 #include "php_random.h"

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -475,7 +475,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 	/* Defer to CryptGenRandom on Windows */
 	if (php_win32_get_random_bytes(bytes, size) == FAILURE) {
 		if (should_throw) {
-			zend_throw_exception(zend_ce_exception, "Failed to retrieve randomness from the operating system (BCryptGenRandom)", 0);
+			zend_throw_exception(random_ce_Random_RandomException, "Failed to retrieve randomness from the operating system (BCryptGenRandom)", 0);
 		}
 		return FAILURE;
 	}
@@ -488,7 +488,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 	 */
 	if (CCRandomGenerateBytes(bytes, size) != kCCSuccess) {
 		if (should_throw) {
-			zend_throw_exception(zend_ce_exception, "Failed to retrieve randomness from the operating system (CCRandomGenerateBytes)", 0);
+			zend_throw_exception(random_ce_Random_RandomException, "Failed to retrieve randomness from the operating system (CCRandomGenerateBytes)", 0);
 		}
 		return FAILURE;
 	}
@@ -553,9 +553,9 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 			if (fd < 0) {
 				if (should_throw) {
 					if (errno != 0) {
-						zend_throw_exception_ex(zend_ce_exception, 0, "Cannot open /dev/urandom: %s", strerror(errno));
+						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Cannot open /dev/urandom: %s", strerror(errno));
 					} else {
-						zend_throw_exception_ex(zend_ce_exception, 0, "Cannot open /dev/urandom");
+						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Cannot open /dev/urandom");
 					}
 				}
 				return FAILURE;
@@ -573,9 +573,9 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 				close(fd);
 				if (should_throw) {
 					if (errno != 0) {
-						zend_throw_exception_ex(zend_ce_exception, 0, "Error reading from /dev/urandom: %s", strerror(errno));
+						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Error reading from /dev/urandom: %s", strerror(errno));
 					} else {
-						zend_throw_exception_ex(zend_ce_exception, 0, "Error reading from /dev/urandom");
+						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Error reading from /dev/urandom");
 					}
 				}
 				return FAILURE;
@@ -594,9 +594,9 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 		if (read_bytes < size) {
 			if (should_throw) {
 				if (errno != 0) {
-					zend_throw_exception_ex(zend_ce_exception, 0, "Could not gather sufficient random data: %s", strerror(errno));
+					zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Could not gather sufficient random data: %s", strerror(errno));
 				} else {
-					zend_throw_exception_ex(zend_ce_exception, 0, "Could not gather sufficient random data");
+					zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Could not gather sufficient random data");
 				}
 			}
 			return FAILURE;

--- a/ext/random/random.stub.php
+++ b/ext/random/random.stub.php
@@ -147,4 +147,25 @@ namespace Random
 
         public function __unserialize(array $data): void {}
     }
+
+    /**
+     * @strict-properties
+     */
+    class RandomError extends \Error
+    {
+    }
+
+    /**
+     * @strict-properties
+     */
+    class BrokenRandomEngineError extends RandomError
+    {
+    }
+
+    /**
+     * @strict-properties
+     */
+    class RandomException extends \Exception
+    {
+    }
 }

--- a/ext/random/random_arginfo.h
+++ b/ext/random/random_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 82403b033dfd476695c4e11e0b01a3c984896f62 */
+ * Stub hash: 6cc9022516ce23c2e95af30606db43e9fc28e38a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_lcg_value, 0, 0, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
@@ -217,6 +217,21 @@ static const zend_function_entry class_Random_Randomizer_methods[] = {
 	ZEND_FE_END
 };
 
+
+static const zend_function_entry class_Random_RandomError_methods[] = {
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Random_BrokenRandomEngineError_methods[] = {
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Random_RandomException_methods[] = {
+	ZEND_FE_END
+};
+
 static void register_random_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("MT_RAND_MT19937", MT_RAND_MT19937, CONST_CS | CONST_PERSISTENT);
@@ -306,6 +321,39 @@ static zend_class_entry *register_class_Random_Randomizer(void)
 	zend_string *property_engine_name = zend_string_init("engine", sizeof("engine") - 1, 1);
 	zend_declare_typed_property(class_entry, property_engine_name, &property_engine_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_engine_class_Random_Engine, 0, 0));
 	zend_string_release(property_engine_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Random_RandomError(zend_class_entry *class_entry_Error)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Random", "RandomError", class_Random_RandomError_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_Error);
+	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES;
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Random_BrokenRandomEngineError(zend_class_entry *class_entry_Random_RandomError)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Random", "BrokenRandomEngineError", class_Random_BrokenRandomEngineError_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_Random_RandomError);
+	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES;
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Random_RandomException(zend_class_entry *class_entry_Exception)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Random", "RandomException", class_Random_RandomException_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_Exception);
+	class_entry->ce_flags |= ZEND_ACC_NO_DYNAMIC_PROPERTIES;
 
 	return class_entry;
 }

--- a/ext/random/tests/03_randomizer/user_unsafe.phpt
+++ b/ext/random/tests/03_randomizer/user_unsafe.phpt
@@ -74,35 +74,35 @@ foreach ([
 EmptyStringEngine
 =====================
 
-Error: A random engine must return a non-empty string in %s:%d
+Random\BrokenRandomEngineError: A random engine must return a non-empty string in %s:%d
 Stack trace:
 #0 %s(%d): Random\Randomizer->getInt(0, 123)
 #1 {main}
 
 -------
 
-Error: A random engine must return a non-empty string in %s:%d
+Random\BrokenRandomEngineError: A random engine must return a non-empty string in %s:%d
 Stack trace:
 #0 %s(%d): Random\Randomizer->nextInt()
 #1 {main}
 
 -------
 
-Error: A random engine must return a non-empty string in %s:%d
+Random\BrokenRandomEngineError: A random engine must return a non-empty string in %s:%d
 Stack trace:
 #0 %s(%d): Random\Randomizer->getBytes(1)
 #1 {main}
 
 -------
 
-Error: A random engine must return a non-empty string in %s:%d
+Random\BrokenRandomEngineError: A random engine must return a non-empty string in %s:%d
 Stack trace:
 #0 %s(%d): Random\Randomizer->shuffleArray(Array)
 #1 {main}
 
 -------
 
-Error: A random engine must return a non-empty string in %s:%d
+Random\BrokenRandomEngineError: A random engine must return a non-empty string in %s:%d
 Stack trace:
 #0 %s(%d): Random\Randomizer->shuffleBytes('foobar')
 #1 {main}
@@ -111,7 +111,7 @@ Stack trace:
 HeavilyBiasedEngine
 =====================
 
-Error: Failed to generate an acceptable random number in 50 attempts in %s:%d
+Random\BrokenRandomEngineError: Failed to generate an acceptable random number in 50 attempts in %s:%d
 Stack trace:
 #0 %s(%d): Random\Randomizer->getInt(0, 123)
 #1 {main}
@@ -126,14 +126,14 @@ string(2) "ff"
 
 -------
 
-Error: Failed to generate an acceptable random number in 50 attempts in %s:%d
+Random\BrokenRandomEngineError: Failed to generate an acceptable random number in 50 attempts in %s:%d
 Stack trace:
 #0 %s(%d): Random\Randomizer->shuffleArray(Array)
 #1 {main}
 
 -------
 
-Error: Failed to generate an acceptable random number in 50 attempts in %s:%d
+Random\BrokenRandomEngineError: Failed to generate an acceptable random number in 50 attempts in %s:%d
 Stack trace:
 #0 %s(%d): Random\Randomizer->shuffleBytes('foobar')
 #1 {main}


### PR DESCRIPTION
This complements #9211.

---------

The hierarchy is roughly based on @Danack's recommendations in this comment: https://github.com/php/php-src/pull/9071#issuecomment-1193162754.

# Choice of base Exception

`RandomError` and `RandomException` both represent the base Exceptions. I considered using an interface, but thus would make it harder to not catch `Error` / `RandomError`:

You can easily do `catch (\Random\RandomError|\Random\RandomException)` if you want to catch both `Error`s and `Exception`s for whatever reason. But doing `catch ((\Random\RandomExceptionInterface & \Random\RandomException))` is not legal if you want to catch just `Exception`s, but not `Error`s.

# BrokenRandomEngineError

While you should not catch an `Error`, I found it useful to have a meaningful class name here. `BrokenRandomEngineError` is used for:

- A user engine that returns an empty string (which is equivalent to 0 bits of randomness and thus disallowed).
- An engine that fails to generate acceptable randomness for use with `range()` (e.g. `getInt()`) in 50 attempts. The chance of rejection for a uniform bytestring is less that 50%. Thus the chance of failure for an unbiased engine is less than 0.5<sup>50</sup> (~ 8.8×10<sup>-16</sup>). If an engine fails that then it must be heavily biased.

# RandomException

This is used directly for:

- Failure of the CSPRNG in `random_bytes()` and `random_int()` (which should not happen on modern OSes).
- Failure to seed `Mt19937`, `Xoshiro256StarStar`, `PcgOneseq128XslRr64` from the CSPRNG when a `null` seed is used to improve the error reporting as per GH-9160. Thus the failure mode is identical to the one above (none of modern systems).