### PR TITLE
Clean up the implementation of Randomizer::__construct()

### DIFF
--- a/ext/random/tests/03_randomizer/construct_twice.phpt
+++ b/ext/random/tests/03_randomizer/construct_twice.phpt
@@ -13,28 +13,28 @@ final class UserEngine implements \Random\Engine
 
 try {
     (new \Random\Randomizer())->__construct();
-} catch (\BadMethodCallException $e) {
+} catch (\Error $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     $r = new \Random\Randomizer(new \Random\Engine\Xoshiro256StarStar());
     $r->__construct(new \Random\Engine\PcgOneseq128XslRr64());
-} catch (\BadMethodCallException $e) {
+} catch (\Error $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     $r = new \Random\Randomizer(new \UserEngine());
     $r->__construct(new \UserEngine());
-} catch (\BadMethodCallException $e) {
+} catch (\Error $e) {
     echo $e->getMessage() . PHP_EOL;
 }
 
 try {
     $r = new \Random\Randomizer(new \Random\Engine\Xoshiro256StarStar());
     $r->__construct(new \UserEngine());
-} catch (\BadMethodCallException $e) {
+} catch (\Error $e) {
     echo $e->getMessage(), PHP_EOL;
 }
 
@@ -43,9 +43,9 @@ var_dump($r->engine::class);
 die('success');
 ?>
 --EXPECT--
-Cannot call constructor twice
-Cannot call constructor twice
-Cannot call constructor twice
-Cannot call constructor twice
+Cannot modify readonly property Random\Randomizer::$engine
+Cannot modify readonly property Random\Randomizer::$engine
+Cannot modify readonly property Random\Randomizer::$engine
+Cannot modify readonly property Random\Randomizer::$engine
 string(32) "Random\Engine\Xoshiro256StarStar"
 success

--- a/ext/random/tests/03_randomizer/construct_twice.phpt
+++ b/ext/random/tests/03_randomizer/construct_twice.phpt
@@ -31,10 +31,21 @@ try {
     echo $e->getMessage() . PHP_EOL;
 }
 
+try {
+    $r = new \Random\Randomizer(new \Random\Engine\Xoshiro256StarStar());
+    $r->__construct(new \UserEngine());
+} catch (\BadMethodCallException $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
+
+var_dump($r->engine::class);
+
 die('success');
 ?>
 --EXPECT--
 Cannot call constructor twice
 Cannot call constructor twice
 Cannot call constructor twice
+Cannot call constructor twice
+string(32) "Random\Engine\Xoshiro256StarStar"
 success


### PR DESCRIPTION
Instead of manually checking whether the constructor was already called, we rely on the `readonly` modifier of the `$engine` property.

Additionally use `object_init_ex()` instead of manually calling `->create_object()`.

-------------------

I'm not at all sure that the implementation is correct, but it passes the tests locally both with Zend MM and valgrind.