### PR TITLE
Reintroduce legacy 'SJIS-win' text encoding in mbstring

### DIFF
--- a/ext/mbstring/libmbfl/filters/mbfilter_cp932.h
+++ b/ext/mbstring/libmbfl/filters/mbfilter_cp932.h
@@ -36,7 +36,12 @@ extern const mbfl_encoding mbfl_encoding_cp932;
 extern const struct mbfl_convert_vtbl vtbl_cp932_wchar;
 extern const struct mbfl_convert_vtbl vtbl_wchar_cp932;
 
+extern const mbfl_encoding mbfl_encoding_sjiswin;
+extern const struct mbfl_convert_vtbl vtbl_sjiswin_wchar;
+extern const struct mbfl_convert_vtbl vtbl_wchar_sjiswin;
+
 int mbfl_filt_conv_cp932_wchar(int c, mbfl_convert_filter *filter);
 int mbfl_filt_conv_wchar_cp932(int c, mbfl_convert_filter *filter);
+int mbfl_filt_conv_wchar_sjiswin(int c, mbfl_convert_filter *filter);
 
 #endif /* MBFL_MBFILTER_CP932_H */

--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
@@ -121,6 +121,7 @@ static const mbfl_encoding *mbfl_encoding_ptr_list[] = {
 	&mbfl_encoding_utf8_kddi_b,
 	&mbfl_encoding_utf8_sb,
 	&mbfl_encoding_cp932,
+	&mbfl_encoding_sjiswin,
 	&mbfl_encoding_cp51932,
 	&mbfl_encoding_jis,
 	&mbfl_encoding_2022jp,

--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.h
@@ -74,6 +74,7 @@ enum mbfl_no_encoding {
  	mbfl_no_encoding_sjis_mac,
 	mbfl_no_encoding_sjis2004,
 	mbfl_no_encoding_cp932,
+	mbfl_no_encoding_sjiswin,
 	mbfl_no_encoding_cp51932,
 	mbfl_no_encoding_jis,
 	mbfl_no_encoding_2022jp,

--- a/ext/mbstring/tests/cp932_encoding.phpt
+++ b/ext/mbstring/tests/cp932_encoding.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Exhaustive test of CP932 encoding verification and conversion
+Exhaustive test of CP932 encoding verification and conversion (including 'SJIS-win' variant)
 --EXTENSIONS--
 mbstring
 --SKIPIF--
@@ -34,8 +34,10 @@ for ($i = 0xF0; $i <= 0xF9; $i++) {
 $fromUnicode["\x00\xA2"] = "\x81\x91";
 /* U+00A3 is POUND SIGN; convert to FULLWIDTH POUND SIGN */
 $fromUnicode["\x00\xA3"] = "\x81\x92";
-/* U+00A5 is YEN SIGN; convert to FULLWIDTH YEN SIGN */
-$fromUnicode["\x00\xA5"] = "\x81\x8F";
+/* U+00A5 is YEN SIGN; convert to 0x5C, which has conflicting uses
+ * (either as backslash or as Yen sign) */
+$fromUnicode["\x00\xA5"] = "\x5C";
+
 
 /* We map the JIS X 0208 FULLWIDTH TILDE to U+FF5E (FULLWIDTH TILDE)
  * But when converting Unicode to CP932, we also accept U+301C (WAVE DASH) */
@@ -51,11 +53,12 @@ $fromUnicode["\x20\x16"] = "\x81\x61";
  * but when converting Unicode to CP932, we also accept U+00AC (NOT SIGN) */
 $fromUnicode["\x00\xAC"] = "\x81\xCA";
 
-/* U+203E is OVERLINE; convert to JIS X 0208 FULLWIDTH MACRON */
-$fromUnicode["\x20\x3E"] = "\x81\x50";
-
-/* U+00AF is MACRON; it can also go to FULLWIDTH MACRON */
+/* U+00AF is MACRON; convert to FULLWIDTH MACRON */
 $fromUnicode["\x00\xAF"] = "\x81\x50";
+
+/* U+203E is OVERLINE; convert to 0x7E, which has conflicting uses
+ * (either as tilde or as overline) */
+$fromUnicode["\x20\x3E"] = "\x7E";
 
 findInvalidChars($validChars, $invalidChars, $truncated, array_fill_keys(range(0x81, 0x9F), 2) + array_fill_keys(range(0xE0, 0xFC), 2));
 
@@ -106,12 +109,38 @@ echo "CP932 verification and conversion works on all invalid characters\n";
 convertAllInvalidChars($invalidCodepoints, $fromUnicode, 'UTF-16BE', 'CP932', '%');
 echo "Unicode -> CP932 conversion works on all invalid codepoints\n";
 
+/* Now test 'SJIS-win' variant of CP932, which is really CP932 but with
+ * two different mappings
+ * Instead of mapping U+00A5 and U+203E to the single bytes 0x5C and 07E
+ * (which have conflicting uses), 'SJIS-win' maps them to appropriate
+ * JIS X 0208 characters */
+
+/* U+00A5 is YEN SIGN; convert to FULLWIDTH YEN SIGN */
+$fromUnicode["\x00\xA5"] = "\x81\x8F";
+/* U+203E is OVERLINE; convert to JIS X 0208 FULLWIDTH MACRON */
+$fromUnicode["\x20\x3E"] = "\x81\x50";
+
+testAllValidChars($validChars, 'SJIS-win', 'UTF-16BE');
+foreach ($nonInvertible as $cp932 => $unicode)
+	testValidString($cp932, $unicode, 'SJIS-win', 'UTF-16BE', false);
+echo "SJIS-win verification and conversion works on all valid characters\n";
+
+testAllInvalidChars($invalidChars, $validChars, 'SJIS-win', 'UTF-16BE', "\x00%");
+echo "SJIS-win verification and conversion works on all invalid characters\n";
+
+convertAllInvalidChars($invalidCodepoints, $fromUnicode, 'UTF-16BE', 'SJIS-win', '%');
+echo "Unicode -> SJIS-win conversion works on all invalid codepoints\n";
+
 // Test "long" illegal character markers
 mb_substitute_character("long");
 convertInvalidString("\x80", "%", "CP932", "UTF-8");
 convertInvalidString("\xEA", "%", "CP932", "UTF-8");
 convertInvalidString("\x81\x20", "%", "CP932", "UTF-8");
 convertInvalidString("\xEA\xA9", "%", "CP932", "UTF-8");
+convertInvalidString("\x80", "%", "SJIS-win", "UTF-8");
+convertInvalidString("\xEA", "%", "SJIS-win", "UTF-8");
+convertInvalidString("\x81\x20", "%", "SJIS-win", "UTF-8");
+convertInvalidString("\xEA\xA9", "%", "SJIS-win", "UTF-8");
 
 echo "Done!\n";
 ?>
@@ -119,4 +148,7 @@ echo "Done!\n";
 CP932 verification and conversion works on all valid characters
 CP932 verification and conversion works on all invalid characters
 Unicode -> CP932 conversion works on all invalid codepoints
+SJIS-win verification and conversion works on all valid characters
+SJIS-win verification and conversion works on all invalid characters
+Unicode -> SJIS-win conversion works on all invalid codepoints
 Done!

--- a/ext/mbstring/tests/mb_internal_encoding_variation2.phpt
+++ b/ext/mbstring/tests/mb_internal_encoding_variation2.phpt
@@ -176,10 +176,10 @@ string(9) "eucJP-win"
 -- Iteration 20 --
 string(9) "eucJP-win"
 bool(true)
-string(5) "CP932"
+string(8) "SJIS-win"
 
 -- Iteration 21 --
-string(5) "CP932"
+string(8) "SJIS-win"
 bool(true)
 string(11) "ISO-2022-JP"
 


### PR DESCRIPTION
Commit log message:

```
In e2459857af, I combined mbstring's "SJIS-win" text encoding
into CP932. This was done after doing some testing which appeared
to show that the mappings for "SJIS-win" were the same as those
for "CP932".

Later, it was found that there was actually a small difference
prior to e2459857af when converting Unicode to CP932. The
mappings for the following two codepoints were different:

        CP932  SJIS-win
U+203E  0x7E   0x81 0x50
U+00A5  0x5C   0x81 0x8F

As shown, mbstring's "CP932" mapped Unicode's 'OVERLINE' and
'YEN SIGN' to the ASCII bytes which have conflicting uses in
most legacy Japanese text encodings. "SJIS-win" mapped these
to equivalent JIS X 0208 fullwidth characters.

Since e2459867af was not intended to cause any user-visible
change in behavior, I am rolling back the merge of "CP932"
and "SJIS-win".

It seems doubtful whether these two text encodings should
be kept separate or merged in a future release. An extensive
discussion of the related historical background and
compatibility issues involved can be found in this
GitHub thread:

https://github.com/php/php-src/issues/8308
```

FYA @nikic @cmb69 @zonuexe @sj-i