### PR TITLE
Fix PcgOneseq128XslRr64::__construct() definition in random.stub.php

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ PHP                                                                        NEWS
 ?? ??? ????, PHP 8.2.0beta3
 
 - Random:
+  . Fixed bug GH-9235 (non-existant $sequence parameter in stub for
+    PcgOneseq128XslRr64::__construct()). (timwolla)
   . Removed redundant RuntimeExceptions from Randomizer methods. The
     exceptions thrown by the engines will be exposed directly. (timwolla)
 

--- a/ext/random/random.stub.php
+++ b/ext/random/random.stub.php
@@ -59,7 +59,7 @@ namespace Random\Engine
      */
     final class PcgOneseq128XslRr64 implements \Random\Engine
     {
-        public function __construct(string|int|null $seed = null, string|int $sequence = 0) {}
+        public function __construct(string|int|null $seed = null) {}
 
         /** @implementation-alias Random\Engine\Mt19937::generate */
         public function generate(): string {}

--- a/ext/random/random_arginfo.h
+++ b/ext/random/random_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9727755f39598fe1fbc16b501063cd3c30279ff9 */
+ * Stub hash: 82403b033dfd476695c4e11e0b01a3c984896f62 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_lcg_value, 0, 0, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
@@ -51,7 +51,6 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Random_Engine_PcgOneseq128XslRr64___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_MASK(0, seed, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL, "null")
-	ZEND_ARG_TYPE_MASK(0, sequence, MAY_BE_STRING|MAY_BE_LONG, "0")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Random_Engine_PcgOneseq128XslRr64_generate arginfo_class_Random_Engine_Mt19937_generate
@@ -66,9 +65,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Random_Engine_PcgOneseq128XslRr64___debugInfo arginfo_class_Random_Engine_Mt19937___serialize
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Random_Engine_Xoshiro256StarStar___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_MASK(0, seed, MAY_BE_STRING|MAY_BE_LONG|MAY_BE_NULL, "null")
-ZEND_END_ARG_INFO()
+#define arginfo_class_Random_Engine_Xoshiro256StarStar___construct arginfo_class_Random_Engine_PcgOneseq128XslRr64___construct
 
 #define arginfo_class_Random_Engine_Xoshiro256StarStar_generate arginfo_class_Random_Engine_Mt19937_generate
 


### PR DESCRIPTION
The second parameter does not actually exist for a Oneseq PCG. It was removed
from the RFC before it went into voting.