### PR TITLE
Fix GH-9244: Segfault with array_multisort + array_shift

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5791,6 +5791,8 @@ PHP_FUNCTION(array_multisort)
 			}
 			if (repack) {
 				zend_hash_to_packed(hash);
+			} else {
+				zend_hash_rehash(hash);
 			}
 		}
 	}

--- a/ext/standard/tests/array/gh9244.phpt
+++ b/ext/standard/tests/array/gh9244.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug GH-9244 (Segfault with array_multisort + array_shift)
+--FILE--
+<?php
+$items = ['foo' => 1, 'bar' => 2];
+$order = [4, 3];
+array_multisort($order, $items);
+var_dump(array_shift($items));
+?>
+--EXPECT--
+int(2)


### PR DESCRIPTION
After restructuring non-packed arrays, we either need to pack them if
possible, or to rehash them.