### PR TITLE
[ci skip] NEWS and UPGRADING for constants in traits

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ PHP                                                                        NEWS
 - Core:
   . Fixed --CGI-- support of run-tests.php. (cmb)
   . Fixed incorrect double to long casting in latest clang. (zeriyoshi)
+  . Added support for defining constants in traits. (sj-i)
 
 - Random:
   . Fixed bug GH-9235 (non-existant $sequence parameter in stub for

--- a/UPGRADING
+++ b/UPGRADING
@@ -88,7 +88,8 @@ PHP 8.2 UPGRADE NOTES
     error log file.
   . Added support for fetching properties of enums in constant expressions.
     RFC: https://wiki.php.net/rfc/fetch_property_in_const_expressions
-
+  . Added support for defining constants in traits.
+    RFC: https://wiki.php.net/rfc/constants_in_traits
 
 - Curl:
   . Added CURLINFO_EFFECTIVE_METHOD option and returning the effective


### PR DESCRIPTION
The implementation is already merged: #8888