### PR TITLE
Fix GH-8472: stream_socket_accept result may have incorrect metadata

### DIFF
--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2287,6 +2287,10 @@ static inline int php_openssl_tcp_sockop_accept(php_stream *stream, php_openssl_
 		memcpy(clisockdata, sock, sizeof(clisockdata->s));
 
 		clisockdata->s.socket = clisock;
+#ifdef __linux__
+		/* O_NONBLOCK is not inherited on Linux */
+		clisockdata->s.is_blocked = 1;
+#endif
 
 		xparam->outputs.client = php_stream_alloc_rel(stream->ops, clisockdata, NULL, "r+");
 		if (xparam->outputs.client) {

--- a/ext/standard/tests/streams/gh8472.phpt
+++ b/ext/standard/tests/streams/gh8472.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-8472: The resource returned by stream_socket_accept may have incorrect metadata
+--FILE--
+<?php
+function setNonBlocking($stream)
+{
+    $block = stream_get_meta_data($stream)['blocked'];
+    if ($block) {
+        stream_set_blocking($stream, false);
+    }
+}
+
+$server = stream_socket_server("tcp://127.0.0.1:9100");
+setNonBlocking($server);
+
+$client = stream_socket_client("tcp://127.0.0.1:9100");
+
+$res = stream_socket_accept($server);
+stream_set_timeout($res, 1);
+setNonBlocking($res);
+
+fwrite($client, str_repeat('0', 5));
+
+$read = [$res];
+$write = [];
+$except = [];
+
+if (stream_select($read, $write, $except, 1)) {
+    var_dump(fread($res, 4));
+    var_dump(fread($res, 4));
+}
+?>
+--EXPECT--
+string(4) "0000"
+string(1) "0"

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -840,6 +840,10 @@ static inline int php_tcp_sockop_accept(php_stream *stream, php_netstream_data_t
 
 		memcpy(clisockdata, sock, sizeof(*clisockdata));
 		clisockdata->socket = clisock;
+#ifdef __linux__
+		/* O_NONBLOCK is not inherited on Linux */
+		clisockdata->is_blocked = 1;
+#endif
 
 		xparam->outputs.client = php_stream_alloc_rel(stream->ops, clisockdata, NULL, "r+");
 		if (xparam->outputs.client) {


### PR DESCRIPTION
Linux does not inherit O_NONBLOCK. It fixes #8472 .