### PR TITLE
zend allocators adding __declspec allocator for windows.

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -215,7 +215,7 @@ char *alloca();
 #if ZEND_GCC_VERSION >= 2096 || __has_attribute(__malloc__)
 # define ZEND_ATTRIBUTE_MALLOC __attribute__ ((__malloc__))
 #elif defined(ZEND_WIN32)
-# define ZEND_ATTRIBUTE_MALLOC __declspec(restrict)
+# define ZEND_ATTRIBUTE_MALLOC __declspec(allocator) __declspec(restrict)
 #else
 # define ZEND_ATTRIBUTE_MALLOC
 #endif


### PR DESCRIPTION
does not affect the performance, however making those custom calls more meaningful
 for Event Tracing/Visual Studio.