### PR TITLE
Fix mb_strimwidth RC info

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -222,7 +222,6 @@ static const func_info_t func_infos[] = {
 	F1("mb_strrichr", MAY_BE_STRING|MAY_BE_FALSE),
 	F1("mb_substr", MAY_BE_STRING),
 	F1("mb_strcut", MAY_BE_STRING),
-	F1("mb_strimwidth", MAY_BE_STRING),
 	F1("mb_convert_encoding", MAY_BE_ARRAY|MAY_BE_ARRAY_KEY_LONG|MAY_BE_ARRAY_KEY_STRING|MAY_BE_ARRAY_OF_ANY|MAY_BE_STRING|MAY_BE_FALSE),
 	F1("mb_convert_case", MAY_BE_STRING),
 	F1("mb_strtoupper", MAY_BE_STRING),

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -761,7 +761,7 @@ static PHP_INI_MH(OnUpdate_mbstring_http_input)
 		php_error_docref("ref.mbstring", E_DEPRECATED, "Use of mbstring.http_input is deprecated");
 	}
 
-	if (!new_value || !ZSTR_VAL(new_value)) {
+	if (!new_value) {
 		const char *encoding = php_get_input_encoding();
 		MBSTRG(http_input_set) = 0;
 		_php_mb_ini_mbstring_http_input_set(encoding, strlen(encoding));

--- a/ext/mbstring/mbstring.stub.php
+++ b/ext/mbstring/mbstring.stub.php
@@ -118,7 +118,6 @@ function mb_strcut(string $string, int $start, ?int $length = null, ?string $enc
 
 function mb_strwidth(string $string, ?string $encoding = null): int {}
 
-/** @refcount 1 */
 function mb_strimwidth(string $string, int $start, int $width, string $trim_marker = "", ?string $encoding = null): string {}
 
 /**

--- a/ext/mbstring/mbstring_arginfo.h
+++ b/ext/mbstring/mbstring_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 48835e813592a48570d258a97dbf00f2e19d8b3a */
+ * Stub hash: 0c9ac8888b8332557f7098cfb9d259757af8b3c6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mb_language, 0, 0, MAY_BE_STRING|MAY_BE_BOOL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, language, IS_STRING, 1, "null")


### PR DESCRIPTION
https://github.com/php/php-src/blob/bd3cd6a41a0b0adcd1e402b4b0a8497ba2f427f9/ext/mbstring/mbstring.c#L2459

This function can now return values with RC != 1.

Associated failure on nightly:

https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=27444&view=ms.vss-test-web.build-test-results-tab&runId=608358&resultId=107821&paneView=debug