### PR TITLE
Add --progress option to run-tests.php

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,4 +25,4 @@ task:
   tests_script:
     - export SKIP_IO_CAPTURE_TESTS=1
     - export CI_NO_IPV6=1
-    - sapi/cli/php run-tests.php -P -q -j2 -g FAIL,BORK,LEAK,XLEAK --offline --show-diff --show-slow 1000 --set-timeout 120 -d zend_extension=opcache.so
+    - sapi/cli/php run-tests.php -P -q -j2 -g FAIL,BORK,LEAK,XLEAK --no-progress --offline --show-diff --show-slow 1000 --set-timeout 120 -d zend_extension=opcache.so

--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -25,6 +25,7 @@ runs:
         sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
           -j$(/usr/bin/nproc) \
           -g FAIL,BORK,LEAK,XLEAK \
+          --no-progress \
           --offline \
           --show-diff \
           --show-slow 1000 \

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -18,6 +18,7 @@ runs:
         sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
           -j$(sysctl -n hw.ncpu) \
           -g FAIL,BORK,LEAK,XLEAK \
+          --no-progress \
           --offline \
           --show-diff \
           --show-slow 1000 \

--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -136,7 +136,7 @@ mkdir c:\tests_tmp
 set TEST_PHP_JUNIT=c:\junit.out.xml
 
 cd "%APPVEYOR_BUILD_FOLDER%"
-nmake test TESTS="%OPCACHE_OPTS% -q --offline --show-diff --show-slow 1000 --set-timeout 120 --temp-source c:\tests_tmp --temp-target c:\tests_tmp --bless %PARALLEL%"
+nmake test TESTS="%OPCACHE_OPTS% -g FAIL,BORK,LEAK,XLEAK --no-progress -q --offline --show-diff --show-slow 1000 --set-timeout 120 --temp-source c:\tests_tmp --temp-target c:\tests_tmp --bless %PARALLEL%"
 
 set EXIT_CODE=%errorlevel%
 

--- a/azure/libmysqlclient_test.yml
+++ b/azure/libmysqlclient_test.yml
@@ -35,6 +35,7 @@ steps:
       rm -rf junit.xml | true
       sapi/cli/php run-tests.php -P -q \
           -g FAIL,BORK,LEAK,XLEAK \
+          --no-progress \
           --offline --show-diff --show-slow 1000 --set-timeout 120 \
           ext/pdo_mysql
     displayName: 'Test ${{ parameters.configurationName }}'

--- a/azure/test.yml
+++ b/azure/test.yml
@@ -19,6 +19,7 @@ steps:
       sapi/cli/php run-tests.php -P -q \
           -j$(/usr/bin/nproc) \
           -g FAIL,BORK,LEAK,XLEAK \
+          --no-progress \
           --offline \
           --show-diff \
           --show-slow 1000 \

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -7,6 +7,7 @@ if [ -z "$ARM64" ]; then export JOBS=$(nproc); else export JOBS=16; fi
 export SKIP_IO_CAPTURE_TESTS=1
 ./sapi/cli/php run-tests.php -P \
     -g "FAIL,BORK,LEAK" --offline --show-diff --show-slow 1000 \
+    --no-progress \
     --set-timeout 120 -j$JOBS \
     -d extension=`pwd`/modules/zend_test.so \
     -d zend_extension=`pwd`/modules/opcache.so \


### PR DESCRIPTION
The option is enabled in CLI but disabled in CI by default. Previously,
adding the -g argument would disable progress, even locally.