### PR TITLE
Log error cause when opcache cannot write to file cache

### DIFF
--- a/ext/opcache/tests/file_cache_error.phpt
+++ b/ext/opcache/tests/file_cache_error.phpt
@@ -10,8 +10,8 @@ opcache.file_cache={TMP}
 opcache.log_verbosity_level=2
 --SKIPIF--
 <?php
-posix_setrlimit(POSIX_RLIMIT_FSIZE, 1, 1) || die('skip Test requires setrlimit(RLIMIT_FSIZE) to work');
-ini_parse_quantity(ini_get('opcache.jit_buffer_size')) === 0 || die('skip File cache is disabled when JIT is on');
+if (!posix_setrlimit(POSIX_RLIMIT_FSIZE, 1, 1)) die('skip Test requires setrlimit(RLIMIT_FSIZE) to work');
+if (ini_parse_quantity(ini_get('opcache.jit_buffer_size')) !== 0) die('skip File cache is disabled when JIT is on');
 ?>
 --FILE--
 <?php

--- a/ext/opcache/tests/file_cache_error.phpt
+++ b/ext/opcache/tests/file_cache_error.phpt
@@ -8,7 +8,10 @@ opcache.enable_cli=1
 opcache.file_cache={TMP}
 opcache.log_verbosity_level=2
 --SKIPIF--
-<?php posix_setrlimit(POSIX_RLIMIT_FSIZE, 1, 1) || die('skip Test requires setrlimit(RLIMIT_FSIZE) to work'); ?>
+<?php
+posix_setrlimit(POSIX_RLIMIT_FSIZE, 1, 1) || die('skip Test requires setrlimit(RLIMIT_FSIZE) to work');
+ini_parse_quantity(ini_get('opcache.jit_buffer_size')) === 0 || die('skip File cache is disabled when JIT is on');
+?>
 --FILE--
 <?php
 

--- a/ext/opcache/tests/file_cache_error.phpt
+++ b/ext/opcache/tests/file_cache_error.phpt
@@ -3,6 +3,7 @@ File cache error 001
 --EXTENSIONS--
 opcache
 posix
+pcntl
 --INI--
 opcache.enable_cli=1
 opcache.file_cache={TMP}
@@ -22,6 +23,11 @@ register_shutdown_function(function () use ($file) {
 });
 file_put_contents($file, '<?php echo "OK";');
 touch($file, time() - 3600);
+
+// Some systems will raise SIGXFSZ when RLIMIT_FSIZE is exceeded
+if (defined('SIGXFSZ')) {
+    pcntl_signal(SIGXFSZ, SIG_IGN);
+}
 
 // Should cause writing to cache file to fail
 var_dump(posix_setrlimit(POSIX_RLIMIT_FSIZE, 1, 1));


### PR DESCRIPTION
When using `opcache.file_cache`, opcache can log the following error when it fails to write a cache file:

    Warning opcache cannot write to file '/cache/foo/bar.php'

It is not always obvious why it failed. This PR adds the cause of the failure, for example:

    Warning opcache cannot write to file '/cache/foo/bar.php': No space left on device