### PR TITLE
Make `"{$g{'h'}}"` emit fatal error and no incorrect deprecation notice in 8.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Fixed incorrect double to long casting in latest clang. (zeriyoshi)
   . Added support for defining constants in traits. (sj-i)
+  . Stop incorrectly emitting false positive deprecation notice alongside
+    unsupported syntax fatal error for `"{$g{'h'}}"`. (TysonAndre)
 
 - Random:
   . Fixed bug GH-9235 (non-existant $sequence parameter in stub for
@@ -73,7 +75,7 @@ PHP                                                                        NEWS
     $advance). (Anton Smirnov)
   . Changed Mt19937 to throw a ValueError instead of InvalidArgumentException
     for invalid $mode. (timwolla)
-  . Splitted Random\Randomizer::getInt() (without arguments) to 
+  . Splitted Random\Randomizer::getInt() (without arguments) to
     Random\Randomizer::nextInt(). (zeriyoshi)
 
 - Sockets:

--- a/Zend/tests/alternative_offset_syntax_in_encaps_string.phpt
+++ b/Zend/tests/alternative_offset_syntax_in_encaps_string.phpt
@@ -1,0 +1,6 @@
+--TEST--
+Alternative offset syntax should emit only E_COMPILE_ERROR in string interpolation
+--FILE--
+<?php "{$g{'h'}}"; ?>
+--EXPECTF--
+Fatal error: Array and string offset access syntax with curly braces is no longer supported in %s on line 1

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9625,9 +9625,9 @@ static void zend_compile_encaps_list(znode *result, zend_ast *ast) /* {{{ */
 		zend_ast *encaps_var = list->child[i];
 
 		if (encaps_var->attr & (ZEND_ENCAPS_VAR_DOLLAR_CURLY|ZEND_ENCAPS_VAR_DOLLAR_CURLY_VAR_VAR)) {
-			if (encaps_var->attr & ZEND_ENCAPS_VAR_DOLLAR_CURLY) {
+			if ((encaps_var->kind == ZEND_AST_VAR || encaps_var->kind == ZEND_AST_DIM) && (encaps_var->attr & ZEND_ENCAPS_VAR_DOLLAR_CURLY)) {
 				zend_error(E_DEPRECATED, "Using ${var} in strings is deprecated, use {$var} instead");
-			} else if (encaps_var->kind == ZEND_AST_VAR) {
+			} else if (encaps_var->kind == ZEND_AST_VAR && (encaps_var->attr & ZEND_ENCAPS_VAR_DOLLAR_CURLY_VAR_VAR)) {
 				zend_error(E_DEPRECATED, "Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead");
 			}
 		}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -9623,11 +9623,12 @@ static void zend_compile_encaps_list(znode *result, zend_ast *ast) /* {{{ */
 	last_const_node.op_type = IS_UNUSED;
 	for (i = 0; i < list->children; i++) {
 		zend_ast *encaps_var = list->child[i];
+
 		if (encaps_var->attr & (ZEND_ENCAPS_VAR_DOLLAR_CURLY|ZEND_ENCAPS_VAR_DOLLAR_CURLY_VAR_VAR)) {
-			if (encaps_var->attr & ZEND_ENCAPS_VAR_DOLLAR_CURLY_VAR_VAR) {
-				zend_error(E_DEPRECATED, "Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead");
-			} else {
+			if (encaps_var->attr & ZEND_ENCAPS_VAR_DOLLAR_CURLY) {
 				zend_error(E_DEPRECATED, "Using ${var} in strings is deprecated, use {$var} instead");
+			} else if (encaps_var->kind == ZEND_AST_VAR) {
+				zend_error(E_DEPRECATED, "Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead");
 			}
 		}
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1016,8 +1016,14 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 #define ZEND_ARG_TYPE_IS_TENTATIVE(arg_info) \
 	((ZEND_TYPE_FULL_MASK((arg_info)->type) & _ZEND_IS_TENTATIVE_BIT) != 0)
 
-#define ZEND_DIM_IS					(1 << 0) /* isset fetch needed for null coalesce */
+#define ZEND_DIM_IS					(1 << 0) /* isset fetch needed for null coalesce. Set in zend_compile.c for ZEND_AST_DIM nested within ZEND_AST_COALESCE. */
 #define ZEND_DIM_ALTERNATIVE_SYNTAX	(1 << 1) /* deprecated curly brace usage */
+
+/* Attributes for ${} encaps var in strings (ZEND_AST_DIM or ZEND_AST_VAR node) */
+/* ZEND_AST_VAR nodes can have any of the ZEND_ENCAPS_VAR_* flags */
+/* ZEND_AST_DIM flags can have ZEND_DIM_ALTERNATIVE_SYNTAX or ZEND_ENCAPS_VAR_DOLLAR_CURLY during the parse phase (ZEND_DIM_ALTERNATIVE_SYNTAX is a thrown fatal error). */
+#define ZEND_ENCAPS_VAR_DOLLAR_CURLY (1 << 0)
+#define ZEND_ENCAPS_VAR_DOLLAR_CURLY_VAR_VAR (1 << 1)
 
 /* Make sure these don't clash with ZEND_FETCH_CLASS_* flags. */
 #define IS_CONSTANT_CLASS                    0x400 /* __CLASS__ in trait */
@@ -1087,10 +1093,6 @@ static zend_always_inline bool zend_check_arg_send_type(const zend_function *zf,
 
 /* Attribute for ternary inside parentheses */
 #define ZEND_PARENTHESIZED_CONDITIONAL 1
-
-/* Attributes for ${} encaps var in strings */
-#define ZEND_ENCAPS_VAR_DOLLAR_CURLY (1<<0)
-#define ZEND_ENCAPS_VAR_DOLLAR_CURLY_VAR_VAR (1<<1)
 
 /* For "use" AST nodes and the seen symbol table */
 #define ZEND_SYMBOL_CLASS    (1<<0)


### PR DESCRIPTION
The ast node flag constants ZEND_DIM_ALTERNATIVE_SYNTAX and
ZEND_ENCAPS_VAR_DOLLAR_CURLY_VAR_VAR node have identical values (1<<1),
causing a deprecation notice to be incorrectly emitted before the fatal error
for unsupported syntax.

To fix this, check if the kind is the expected kind of `AST_VAR`/`AST_DIM` associated with the flag being checked for. The node kind in encapsulated strings can also be `PROP`/`METHOD_CALL`, which currently have no flags, but explicitly check the kind to make the deprecation notice logic easier to reason about and less likely to break if flags are added.

- Previously, the test would incorrectly also emit `Deprecated: Using ${expr} (variable variables) in strings is deprecated, use {${expr}} instead` before the fatal error

Fixes GH-9263

Followup to https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation in php 8.2

