### PR TITLE
make FILE_USE_INCLUDE_PATH not colide with LOCK_SH

### DIFF
--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -54,11 +54,11 @@ PHPAPI ssize_t php_fputcsv(php_stream *stream, zval *fields, char delimiter, cha
 
 #define META_DEF_BUFSIZE 8192
 
-#define PHP_FILE_USE_INCLUDE_PATH (1 << 0)
 #define PHP_FILE_IGNORE_NEW_LINES (1 << 1)
 #define PHP_FILE_SKIP_EMPTY_LINES (1 << 2)
 #define PHP_FILE_APPEND (1 << 3)
 #define PHP_FILE_NO_DEFAULT_CONTEXT (1 << 4)
+#define PHP_FILE_USE_INCLUDE_PATH (1 << 5) // don't want to collide with LOCK_SH/LOCK_EX, also would be nice to not collide with any of the PHP_FILE constants.
 
 typedef enum _php_meta_tags_token {
 	TOK_EOF = 0,

--- a/ext/standard/tests/file/file_variation6.phpt
+++ b/ext/standard/tests/file/file_variation6.phpt
@@ -236,12 +236,21 @@ array(3) {
   [2]=>
   string(6) "Line 3"
 }
-file(): Argument #2 ($flags) must be a valid flag value
-file(): Argument #2 ($flags) must be a valid flag value
-file(): Argument #2 ($flags) must be a valid flag value
-file(): Argument #2 ($flags) must be a valid flag value
-file(): Argument #2 ($flags) must be a valid flag value
-file(): Argument #2 ($flags) must be a valid flag value
-file(): Argument #2 ($flags) must be a valid flag value
-file(): Argument #2 ($flags) must be a valid flag value
-file(): Argument #2 ($flags) must be a valid flag value
+PHP Warning:  file(): '24' flag is not supported in %s on line %d
+bool(false)
+PHP Warning:  file(): '25' flag is not supported in %s on line %d
+bool(false)
+PHP Warning:  file(): '26' flag is not supported in %s on line %d
+bool(false)
+PHP Warning:  file(): '27' flag is not supported in %s on line %d
+bool(false)
+PHP Warning:  file(): '28' flag is not supported in %s on line %d
+bool(false)
+PHP Warning:  file(): '29' flag is not supported in %s on line %d
+bool(false)
+PHP Warning:  file(): '30' flag is not supported in %s on line %d
+bool(false)
+PHP Warning:  file(): '31' flag is not supported in %s on line %d
+bool(false)
+PHP Warning:  file(): '32' flag is not supported in %s on line %d
+bool(false)

--- a/ext/standard/tests/file/file_variation6.phpt
+++ b/ext/standard/tests/file/file_variation6.phpt
@@ -236,21 +236,85 @@ array(3) {
   [2]=>
   string(6) "Line 3"
 }
-PHP Warning:  file(): '24' flag is not supported in %s on line %d
-bool(false)
-PHP Warning:  file(): '25' flag is not supported in %s on line %d
-bool(false)
-PHP Warning:  file(): '26' flag is not supported in %s on line %d
-bool(false)
-PHP Warning:  file(): '27' flag is not supported in %s on line %d
-bool(false)
-PHP Warning:  file(): '28' flag is not supported in %s on line %d
-bool(false)
-PHP Warning:  file(): '29' flag is not supported in %s on line %d
-bool(false)
-PHP Warning:  file(): '30' flag is not supported in %s on line %d
-bool(false)
-PHP Warning:  file(): '31' flag is not supported in %s on line %d
-bool(false)
-PHP Warning:  file(): '32' flag is not supported in %s on line %d
-bool(false)
+array(3) {
+  [0]=>
+  string(7) "Line 1
+"
+  [1]=>
+  string(7) "Line 2
+"
+  [2]=>
+  string(6) "Line 3"
+}
+array(3) {
+  [0]=>
+  string(7) "Line 1
+"
+  [1]=>
+  string(7) "Line 2
+"
+  [2]=>
+  string(6) "Line 3"
+}
+array(3) {
+  [0]=>
+  string(6) "Line 1"
+  [1]=>
+  string(6) "Line 2"
+  [2]=>
+  string(6) "Line 3"
+}
+array(3) {
+  [0]=>
+  string(6) "Line 1"
+  [1]=>
+  string(6) "Line 2"
+  [2]=>
+  string(6) "Line 3"
+}
+array(3) {
+  [0]=>
+  string(7) "Line 1
+"
+  [1]=>
+  string(7) "Line 2
+"
+  [2]=>
+  string(6) "Line 3"
+}
+array(3) {
+  [0]=>
+  string(7) "Line 1
+"
+  [1]=>
+  string(7) "Line 2
+"
+  [2]=>
+  string(6) "Line 3"
+}
+array(3) {
+  [0]=>
+  string(6) "Line 1"
+  [1]=>
+  string(6) "Line 2"
+  [2]=>
+  string(6) "Line 3"
+}
+array(3) {
+  [0]=>
+  string(6) "Line 1"
+  [1]=>
+  string(6) "Line 2"
+  [2]=>
+  string(6) "Line 3"
+}
+array(3) {
+  [0]=>
+  string(7) "Line 1
+"
+  [1]=>
+  string(7) "Line 2
+"
+  [2]=>
+  string(6) "Line 3"
+}


### PR DESCRIPTION
today FILE_USE_INCLUDE_PATH collides with LOCK_SH, and file_get_contents() does not support LOCK_SH, despite file_put_contents() supporting LOCK_EX

i have a dream that 1 day, file_get_contents()'s `bool $use_include_path = false` argument might be changed to `bool $use_include_path = false | int $flags = 0`, 
with $flags supporting both FILE_USE_INCLUDE_PATH and LOCK_SH.

but that cannot happen as long as FILE_USE_INCLUDE_PATH collides with LOCK_SH (as it does today)

hilariously, as of PHP7.0.0, file_get_contents()'s bool $use_include_path is not even compatible with declare(strict_types=1)+FILE_USE_INCLUDE_PATH  (but that might be fixed by changing the argument to bool|int in the future)