### PR TITLE
Fix GH-9248: Segmentation fault in mb_strimwidth()

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2502,7 +2502,7 @@ append_trim_marker:
 /* Trim the string to terminal width; optional, add a 'trim marker' if it was truncated */
 PHP_FUNCTION(mb_strimwidth)
 {
-	zend_string *str, *trimmarker, *encoding = NULL;
+	zend_string *str, *trimmarker = zend_empty_string, *encoding = NULL;
 	zend_long from, width;
 
 	ZEND_PARSE_PARAMETERS_START(3, 5)

--- a/ext/mbstring/tests/gh9248.phpt
+++ b/ext/mbstring/tests/gh9248.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug GH-9248 (Segmentation fault in mb_strimwidth())
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+var_dump(mb_strimwidth('The quick brown fox', 0, 8));
+?>
+--EXPECT--
+string(8) "The quic"


### PR DESCRIPTION
We need to initialize the optional argument `trimmarker` with its
default value.