### PR TITLE
Fix GH-9271: Conflicts between interface constants and trait constants should trigger fatal error

### DIFF
--- a/Zend/tests/traits/constant_022.phpt
+++ b/Zend/tests/traits/constant_022.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Conflicts between trait constants and interface constants trigger fatal errors
+--FILE--
+<?php
+
+trait MyTrait {
+    const A = 1;
+}
+interface I {
+    const A = 2;
+}
+
+class D implements I {
+    use MyTrait;
+}
+
+echo D::A;
+--EXPECTF--
+Fatal error: I and MyTrait define the same constant (A) in the composition of D. However, the definition differs and is considered incompatible. Class was composed in %s on line %d

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2256,7 +2256,7 @@ static bool do_trait_constant_check(zend_class_entry *ce, zend_class_constant *t
 }
 /* }}} */
 
-static void zend_do_traits_constant_binding(zend_class_entry *ce, zend_class_entry **traits) /* {{{ */
+static void zend_do_bind_trait_constants(zend_class_entry *ce, zend_class_entry **traits) /* {{{ */
 {
 	size_t i;
 
@@ -2426,9 +2426,10 @@ static void zend_do_bind_traits(zend_class_entry *ce, zend_class_entry **traits)
 		efree(exclude_tables);
 	}
 
-	/* then flatten the constants and properties into it, to, mostly to notify developer about problems */
-	zend_do_traits_constant_binding(ce, traits);
+	/* then flatten the properties into it, to, mostly to notify developer about problems */
 	zend_do_traits_property_binding(ce, traits);
+
+	/* trait constants are flattened after inheriting interfaces to handle conflicts with constants from interfaces */
 }
 /* }}} */
 
@@ -2982,6 +2983,10 @@ ZEND_API zend_class_entry *zend_do_link_class(zend_class_entry *ce, zend_string 
 			zend_do_implement_interfaces(ce, interfaces);
 		} else if (parent && parent->num_interfaces) {
 			zend_do_inherit_interfaces(ce, parent);
+		}
+		if (ce->num_traits) {
+			/* trait constants are bound after processing interfaces to handle conflicts with constants from interfaces */
+			zend_do_bind_trait_constants(ce, traits_and_interfaces);
 		}
 		if (!(ce->ce_flags & (ZEND_ACC_INTERFACE|ZEND_ACC_TRAIT))
 			&& (ce->ce_flags & (ZEND_ACC_IMPLICIT_ABSTRACT_CLASS|ZEND_ACC_EXPLICIT_ABSTRACT_CLASS))


### PR DESCRIPTION
This fixes #9271

# The cause

The order of processing was:

1. inheritance
2. trait
3. interface

So when processing the trace constants, the constants derived from interface were not found in the constant table of the composing class.
The same problem with property conflicts did not occur because interfaces don't allow properties to be defined.

Since simply flipping bindings of traits and interfaces breaks other tests, I moved only the binding of trait constants to after the binding of interfaces.