### PR TITLE
QA - adjust set/get priority tests to consider environment variables and root user

### DIFF
--- a/ext/pcntl/tests/pcntl_getpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_getpriority_error.phpt
@@ -2,8 +2,11 @@
 pcntl_getpriority() - Wrong mode passed and also for non existing process id provided
 --EXTENSIONS--
 pcntl
+posix
 --SKIPIF--
 <?php
+
+require_once("pcntl_skipif_user_env_rules.inc");
 
 if (!function_exists('pcntl_getpriority')) {
     die('skip pcntl_getpriority doesn\'t exist');

--- a/ext/pcntl/tests/pcntl_getpriority_error_darwin.phpt
+++ b/ext/pcntl/tests/pcntl_getpriority_error_darwin.phpt
@@ -2,8 +2,11 @@
 pcntl_getpriority() - Wrong mode passed and also for non existing process id provided
 --EXTENSIONS--
 pcntl
+posix
 --SKIPIF--
 <?php
+
+require_once("pcntl_skipif_user_env_rules.inc");
 
 if (!function_exists('pcntl_getpriority')) {
     die('skip pcntl_getpriority doesn\'t exist');

--- a/ext/pcntl/tests/pcntl_setpriority_error.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error.phpt
@@ -2,8 +2,11 @@
 pcntl_setpriority() - Check for errors
 --EXTENSIONS--
 pcntl
+posix
 --SKIPIF--
 <?php
+
+require_once("pcntl_skipif_user_env_rules.inc");
 
 if (!function_exists('pcntl_setpriority')) {
     die('skip pcntl_setpriority doesn\'t exist');

--- a/ext/pcntl/tests/pcntl_setpriority_error_darwin.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error_darwin.phpt
@@ -2,8 +2,11 @@
 pcntl_setpriority() - Check for errors
 --EXTENSIONS--
 pcntl
+posix
 --SKIPIF--
 <?php
+
+require_once("pcntl_skipif_user_env_rules.inc");
 
 if (!function_exists('pcntl_setpriority')) {
     die('skip pcntl_setpriority doesn\'t exist');

--- a/ext/pcntl/tests/pcntl_setpriority_error_linux.phpt
+++ b/ext/pcntl/tests/pcntl_setpriority_error_linux.phpt
@@ -2,8 +2,11 @@
 pcntl_setpriority() - Check for errors
 --EXTENSIONS--
 pcntl
+posix
 --SKIPIF--
 <?php
+
+require_once("pcntl_skipif_user_env_rules.inc");
 
 if (!function_exists('pcntl_setpriority')) {
     die('skip pcntl_setpriority doesn\'t exist');

--- a/ext/pcntl/tests/pcntl_skipif_user_env_rules.inc
+++ b/ext/pcntl/tests/pcntl_skipif_user_env_rules.inc
@@ -1,0 +1,15 @@
+<?php
+
+$envUser = getenv("USER") ?: getenv("USERNAME");
+
+if ($envUser === false) {
+    die("skip This test is not executed without environment variables USER/USERNAME");
+}
+
+if (function_exists("posix_geteuid")) {
+    if (posix_geteuid() === 0) {
+        die("skip This test is not executed with root user");
+    }
+}
+
+?>


### PR DESCRIPTION
The tests related to extension PCNTL to get/set priority in a process; now may SKIP if environment variables USER/USERNAME are not set or if test is executed as root user.

The change is the result of working out an issue experienced by another users from a different github project (https://github.com/fossar/nix-phps)

Link of the conversation regarding that issue: https://github.com/php/php-src/commit/520bb2ec6ca01698f863cb16a5e9a28764df01ae

Thanks in advance to reviewers.