### PR TITLE
Fix GH-8409: SSL handshake timeout persistent connections hanging

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1366,6 +1366,9 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 		EG(num_errors)++;
 		EG(errors) = erealloc(EG(errors), sizeof(zend_error_info) * EG(num_errors));
 		EG(errors)[EG(num_errors)-1] = info;
+		if (EG(record_errors_without_emitting)) {
+			return;
+		}
 	}
 
 	/* Report about uncaught exception in case of fatal errors */
@@ -1619,12 +1622,32 @@ ZEND_API ZEND_COLD void zend_error_zstr(int type, zend_string *message) {
 	zend_error_zstr_at(type, filename, lineno, message);
 }
 
-ZEND_API void zend_begin_record_errors(void)
+static zend_always_inline void zend_begin_record_errors_ex(bool no_emmitting)
 {
-	ZEND_ASSERT(!EG(record_errors) && "Error recoreding already enabled");
+	ZEND_ASSERT(!EG(record_errors) && "Error recording already enabled");
 	EG(record_errors) = true;
+	EG(record_errors_without_emitting) = no_emmitting;
 	EG(num_errors) = 0;
 	EG(errors) = NULL;
+}
+
+ZEND_API void zend_begin_record_errors(void)
+{
+	zend_begin_record_errors_ex(false);
+}
+
+ZEND_API void zend_begin_record_errors_without_emitting(void)
+{
+	zend_begin_record_errors_ex(true);
+}
+
+ZEND_API void zend_emit_recorded_errors(void)
+{
+	EG(record_errors) = false;
+	for (uint32_t i = 0; i < EG(num_errors); i++) {
+		zend_error_info *error = EG(errors)[i];
+		zend_error_zstr_at(error->type, error->filename, error->lineno, error->message);
+	}
 }
 
 ZEND_API void zend_free_recorded_errors(void)

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -394,6 +394,8 @@ ZEND_API void zend_save_error_handling(zend_error_handling *current);
 ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, zend_class_entry *exception_class, zend_error_handling *current);
 ZEND_API void zend_restore_error_handling(zend_error_handling *saved);
 ZEND_API void zend_begin_record_errors(void);
+ZEND_API void zend_begin_record_errors_without_emitting(void);
+ZEND_API void zend_emit_recorded_errors(void);
 ZEND_API void zend_free_recorded_errors(void);
 END_EXTERN_C()
 

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -261,8 +261,10 @@ struct _zend_executor_globals {
 	zend_long fiber_stack_size;
 
 	/* If record_errors is enabled, all emitted diagnostics will be recorded,
-	 * in addition to being processed as usual. */
+	 * in addition to being processed as usual unless record_errors_without_emitting
+	 * is enabled which supresses processing when the errors are recorded. */
 	bool record_errors;
+	bool record_errors_without_emitting;
 	uint32_t num_errors;
 	zend_error_info **errors;
 

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3929,12 +3929,7 @@ static void preload_link(void)
 
 						/* Inheritance successful, print out any warnings. */
 						zend_error_cb = orig_error_cb;
-						EG(record_errors) = false;
-						for (uint32_t i = 0; i < EG(num_errors); i++) {
-							zend_error_info *error = EG(errors)[i];
-							zend_error_zstr_at(
-								error->type, error->filename, error->lineno, error->message);
-						}
+						zend_emit_recorded_errors();
 					} zend_catch {
 						/* Clear variance obligations that were left behind on bailout. */
 						if (CG(delayed_variance_obligations)) {

--- a/ext/standard/tests/streams/gh8409.phpt
+++ b/ext/standard/tests/streams/gh8409.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-8409: Error in socket creation when error handler does not clean persistent connection
+--FILE--
+<?php
+set_error_handler(function($errno, $errstring, $errfile, $errline) {
+    foreach (get_resources() as $res) {
+        if (get_resource_type($res) === "persistent stream") {
+            echo "ERROR: persistent stream not closed\n";
+        }
+    }
+    echo "DONE\n";
+    exit(1);
+});
+
+stream_socket_client("tcp://9999.9999.9999.9999:9999", $error_code, $error_message, 0.2, STREAM_CLIENT_CONNECT | STREAM_CLIENT_PERSISTENT);
+
+echo "ERROR: this should not be visible\n";
+?>
+--EXPECT--
+DONE

--- a/main/streams/transports.c
+++ b/main/streams/transports.c
@@ -131,6 +131,8 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 			(char*)name, namelen, persistent_id, options, flags, timeout,
 			context STREAMS_REL_CC);
 
+	zend_begin_record_errors_without_emitting();
+
 	if (stream) {
 		php_stream_context_set(stream, context);
 
@@ -180,6 +182,9 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 		}
 		stream = NULL;
 	}
+
+	zend_emit_recorded_errors();
+	zend_free_recorded_errors();
 
 	return stream;
 }


### PR DESCRIPTION
This fixes #8409 . It is not actually related to SSL handshake but stream socket creation which does not clean errors if the error handler is set. This fix prevents emitting errors until the stream is freed.