### PR TITLE
fix macOS github action build

### DIFF
--- a/.github/actions/brew/action.yml
+++ b/.github/actions/brew/action.yml
@@ -27,8 +27,9 @@ runs:
           gd \
           libzip \
           gmp \
-          tidyp \
+          tidy-html5 \
           libxml2 \
+          libjpeg \
           libxslt \
           postgresql
         brew link icu4c gettext --force

--- a/.github/actions/configure-macos/action.yml
+++ b/.github/actions/configure-macos/action.yml
@@ -38,7 +38,7 @@ runs:
           --enable-soap \
           --enable-xmlreader \
           --with-xsl \
-          --with-tidy=/usr/local/opt/tidyp \
+          --with-tidy=/usr/local/opt/tidy-html5 \
           --with-libxml \
           --enable-sysvsem \
           --enable-sysvshm \


### PR DESCRIPTION
Previously mac os build was failed (https://github.com/php/php-src/runs/7769082421), because homebrew has disabled tidyp formula (https://github.com/Homebrew/homebrew-core/commit/3763cf0f78c3ae0fd6191b4c185b07f0abce6402), but we can use tidy-html5, which already used in php formula (https://github.com/Homebrew/homebrew-core/blob/master/Formula/php.rb#L53)