### PR TITLE
Print deprecation when openssl_encrypt truncates passphrase

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -7324,6 +7324,10 @@ static int php_openssl_cipher_init(const EVP_CIPHER *cipher_type,
 	} else {
 		if (password_len > key_len && !EVP_CIPHER_CTX_set_key_length(cipher_ctx, password_len)) {
 			php_openssl_store_errors();
+			php_error_docref(NULL, E_DEPRECATED, "Passphrase is too long and will be truncated to %d characters", key_len);
+			if (EG(exception)) {
+				return FAILURE;
+			}
 		}
 		key = (unsigned char*)*ppassword;
 	}

--- a/ext/openssl/tests/gh9026.phpt
+++ b/ext/openssl/tests/gh9026.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Bug GH-9026: openssl_encrypt() silently truncates passphrase
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+
+$cipher = "aes-128-ctr";
+$data = "test";
+$passphrase = "KeyLengthIs16_12";
+$iv = str_repeat("\x00", openssl_cipher_iv_length($cipher));
+$flags = 0;
+
+$m1 = openssl_encrypt(
+    $data,
+    $cipher,
+    $passphrase,
+    $flags,
+    $iv
+);
+
+$passphrase .= "3";
+$m2 = openssl_encrypt(
+    $data,
+    $cipher,
+    $passphrase,
+    $flags,
+    $iv
+);
+
+var_dump($m1 === $m2);
+
+?>
+--EXPECTF--
+Deprecated: openssl_encrypt(): Passphrase is too long and will be truncated to 16 characters in %s on line %d
+bool(true)

--- a/ext/openssl/tests/gh9026_2.phpt
+++ b/ext/openssl/tests/gh9026_2.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bug GH-9026: openssl_encrypt() passphrase too long with error handler
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+
+function err_handler($errno, $errstr, $errfile, $errline) {
+    throw new Exception($errstr);
+}
+
+set_error_handler("err_handler", E_DEPRECATED);
+
+$cipher = "aes-128-ctr";
+$data = "test";
+$passphrase = "KeyLengthIs16_123";
+$iv = str_repeat("\x00", openssl_cipher_iv_length($cipher));
+$flags = 0;
+
+try {
+    var_dump(openssl_encrypt(
+        $data,
+        $cipher,
+        $passphrase,
+        $flags,
+        $iv
+    ));
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
+
+?>
+--EXPECT--
+openssl_encrypt(): Passphrase is too long and will be truncated to 16 characters

--- a/ext/openssl/tests/openssl_error_string_basic.phpt
+++ b/ext/openssl/tests/openssl_error_string_basic.phpt
@@ -73,6 +73,9 @@ $private_key_file_with_pass = "file://" .__DIR__ . "/private_rsa_2048_pass_php.k
 $data = "test";
 $method = "AES-128-ECB";
 $enc_key = str_repeat('x', 40);
+// Suppress passphrase truncation deprecation
+$error_reporting = error_reporting();
+error_reporting($error_reporting ^ E_DEPRECATED);
 // error because password is longer then key length and
 // EVP_CIPHER_CTX_set_key_length fails for AES
 openssl_encrypt($data, $method, $enc_key);
@@ -84,6 +87,7 @@ var_dump(openssl_error_string());
 for ($i = 0; $i < 20; $i++) {
     openssl_encrypt($data, $method, $enc_key);
 }
+error_reporting($error_reporting);
 $error_queue_size = 0;
 while (($enc_error_new = openssl_error_string()) !== false) {
     if ($enc_error_new !== $enc_error) {


### PR DESCRIPTION
Fixes GH-9026