### PR TITLE
Update expires format for session cookie

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,9 @@ PHP                                                                        NEWS
   . Added extension specific Exceptions/Errors (RandomException, RandomError,
     BrokenRandomEngineError). (timwolla)
 
+- Session:
+  . Fixed GH-9200 (setcookie has an obsolete expires date format). (timwolla)
+
 - Standard:
   . Fixed bug #65489 (glob() basedir check is inconsistent). (Jakub Zelenka)
   . Fixed GH-9200 (setcookie has an obsolete expires date format). (Derick)

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1345,7 +1345,7 @@ static zend_result php_session_send_cookie(void) /* {{{ */
 		t = tv.tv_sec + PS(cookie_lifetime);
 
 		if (t > 0) {
-			date_fmt = php_format_date("D, d-M-Y H:i:s T", sizeof("D, d-M-Y H:i:s T")-1, t, 0);
+			date_fmt = php_format_date("D, d M Y H:i:s \\G\\M\\T", sizeof("D, d M Y H:i:s \\G\\M\\T")-1, t, 0);
 			smart_str_appends(&ncookie, COOKIE_EXPIRES);
 			smart_str_appendl(&ncookie, ZSTR_VAL(date_fmt), ZSTR_LEN(date_fmt));
 			zend_string_release_ex(date_fmt, 0);

--- a/ext/session/tests/gh9200.phpt
+++ b/ext/session/tests/gh9200.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-9200: setcookie has an obsolete expires date format
+--INI--
+session.cookie_lifetime=3600
+--EXTENSIONS--
+session
+--CGI--
+--FILE--
+<?php
+session_name("foo");
+session_id('bar');
+session_start();
+
+foreach (headers_list() as $header) {
+	if (preg_match('/^Set-Cookie: foo=bar; expires=(Mon|Tue|Wed|Thu|Fri|Sat|Sun), [0-9][0-9] (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) 2[0-9][0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] GMT; Max-Age=3600; path=\\/$/', $header)) {
+		echo "Success", PHP_EOL;
+		exit;
+	}
+}
+echo "Fail", PHP_EOL;
+?>
+--EXPECT--
+Success


### PR DESCRIPTION
Even if `DATE_FORMAT_COOKIE` is not updated, at the very least regular cookies and sessions cookies should be consistent.

-------------------

see GH-9200
see 15e3fcb468d7ef6faddc8f99f8f708fe8c2d8492