### PR TITLE
Replace RuntimeException in Randomizer::nextInt() by RandomException

### DIFF
--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -24,7 +24,6 @@
 #include "ext/standard/php_array.h"
 #include "ext/standard/php_string.h"
 
-#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_exceptions.h"
 
 static inline void randomizer_common_init(php_random_randomizer *randomizer, zend_object *engine_object) {
@@ -102,7 +101,7 @@ PHP_METHOD(Random_Randomizer, nextInt)
 		RETURN_THROWS();
 	}
 	if (randomizer->status->last_generated_size > sizeof(zend_long)) {
-		zend_throw_exception(spl_ce_RuntimeException, "Generated value exceeds size of int", 0);
+		zend_throw_exception(random_ce_Random_RandomException, "Generated value exceeds size of int", 0);
 		RETURN_THROWS();
 	}
 	

--- a/ext/random/tests/03_randomizer/basic.phpt
+++ b/ext/random/tests/03_randomizer/basic.phpt
@@ -31,7 +31,7 @@ foreach ($engines as $engine) {
     for ($i = 0; $i < 1000; $i++) {
         try {
             $randomizer->nextInt();
-        } catch (\RuntimeException $e) {
+        } catch (\Random\RandomException $e) {
             if ($e->getMessage() !== 'Generated value exceeds size of int') {
                 die($engine::class . ": nextInt: failure: {$e->getMessage()}");
             }

--- a/ext/random/tests/03_randomizer/compatibility_user.phpt
+++ b/ext/random/tests/03_randomizer/compatibility_user.phpt
@@ -42,7 +42,7 @@ try {
             die("failure PcgOneseq128XslRr64 i: {$i} native: {$native} user: {$user}");
         }
     }
-} catch (\RuntimeException $e) {
+} catch (\Random\RandomException $e) {
     if ($e->getMessage() !== 'Generated value exceeds size of int') {
         throw $e;
     }
@@ -68,7 +68,7 @@ try {
             die("failure Xoshiro256StarStar i: {$i} native: {$native} user: {$user}");
         }
     }
-} catch (\RuntimeException $e) {
+} catch (\Random\RandomException $e) {
     if ($e->getMessage() !== 'Generated value exceeds size of int') {
         throw $e;
     }

--- a/ext/random/tests/03_randomizer/nextint_error.phpt
+++ b/ext/random/tests/03_randomizer/nextint_error.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Random: Randomizer: nextInt() throws for too large values on 32 Bit
+--SKIPIF--
+<?php if (PHP_INT_SIZE == 8) die("skip 32-bit only"); ?>
+--FILE--
+<?php
+
+$randomizer = new \Random\Randomizer(new \Random\Engine\Xoshiro256StarStar());
+
+try {
+	var_dump($randomizer->nextInt());
+} catch (\Random\RandomException $e) {
+	echo $e->getMessage(), PHP_EOL;
+}
+
+?>
+--EXPECT--
+Generated value exceeds size of int


### PR DESCRIPTION
Honestly, this exception likely should not really exist, because it's not really actionable by the user, but in any case it should not be a RuntimeException.

@zeriyoshi Is there a specific reason for this Exception? Should we just clamp a 64 bit value (which is the maximum generated size, even for user engines) to the upper 32 bits for 32 bit systems (which are the only systems that will ever throw the exception)?