### PR TITLE
Fix GH-9309: Segfault when connection is used after imap_close()

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -198,7 +198,7 @@ static void imap_object_destroy(zend_object *zobj) {
 
 #define GET_IMAP_STREAM(imap_conn_struct, zval_imap_obj) \
 	imap_conn_struct = imap_object_from_zend_object(Z_OBJ_P(zval_imap_obj)); \
-	if (!imap_conn_struct) { \
+	if (imap_conn_struct->imap_stream == NULL) { \
 		zend_throw_exception(zend_ce_value_error, "IMAP\\Connection is already closed", 0); \
 		RETURN_THROWS(); \
 	}

--- a/ext/imap/tests/gh9309.phpt
+++ b/ext/imap/tests/gh9309.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug GH-9309 (Segfault when connection is used after imap_close())
+--EXTENSIONS--
+imap
+--SKIPIF--
+<?php
+require_once(__DIR__.'/setup/skipif.inc');
+?>
+--FILE--
+<?php
+require_once(__DIR__.'/setup/imap_include.inc');
+$stream_id = setup_test_mailbox('gh9309', 0, $mailbox);
+imap_close($stream_id);
+try {
+    imap_headers($stream_id);
+} catch (ValueError $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
+?>
+--CLEAN--
+<?php
+$mailbox_suffix = 'gh9309';
+require_once(__DIR__.'/setup/clean.inc');
+?>
+--EXPECT--
+Create a temporary mailbox and add 0 msgs
+New mailbox created
+IMAP\Connection is already closed


### PR DESCRIPTION
We actually need to check whether `php_imap_object.imap_stream` is
`NULL` to detect that the connection has already been closed.