### PR TITLE
Increase maximum size of an uploaded file to 50Mbyte

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -693,7 +693,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; https://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 50M
 
 ; Automatically add files before PHP document.
 ; https://php.net/auto-prepend-file
@@ -845,7 +845,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; https://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 50M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20

--- a/php.ini-production
+++ b/php.ini-production
@@ -695,7 +695,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; https://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 50M
 
 ; Automatically add files before PHP document.
 ; https://php.net/auto-prepend-file
@@ -847,7 +847,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; https://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 50M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
Current value is 2Mb. Its so small value, when photo image can take 8Mb on iPhone X.
We should increase it to 50Mb, because DevOps engineers do useless work trying to change it.