### PR TITLE
Fix GH-9316: $http_response_header is wrong for long status line

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -717,6 +717,10 @@ finish:
 				if (tmp_line_len >= 1 &&tmp_line[tmp_line_len - 1] == '\r') {
 					--tmp_line_len;
 				}
+			} else {
+				// read and discard rest of status line
+				char *line = php_stream_get_line(stream, NULL, 0, NULL);
+				efree(line);
 			}
 			ZVAL_STRINGL(&http_response, tmp_line, tmp_line_len);
 			zend_hash_next_index_insert(Z_ARRVAL_P(response_header), &http_response);

--- a/ext/standard/tests/http/gh9316.phpt
+++ b/ext/standard/tests/http/gh9316.phpt
@@ -10,7 +10,7 @@ require 'server.inc';
 
 $responses = array(
     "data://text/plain,HTTP/1.1 200 Some very long reason-phrase to test that this is properly handled by our code without adding a new header like  Bad: Header\r\nGood: Header\r\n\r\nBody",
-    "data://text/plain,HTTP/1.1 200\r\nGood: Header\r\n\r\nBody",
+    "data://text/plain,HTTP/1.1 200 \r\nGood: Header\r\n\r\nBody",
 );
 
 ['pid' => $pid, 'uri' => $uri] = http_server($responses, $output);

--- a/ext/standard/tests/http/gh9316.phpt
+++ b/ext/standard/tests/http/gh9316.phpt
@@ -32,7 +32,7 @@ array(2) {
 }
 array(2) {
   [0]=>
-  string(12) "HTTP/1.1 200"
+  string(13) "HTTP/1.1 200 "
   [1]=>
   string(12) "Good: Header"
 }

--- a/ext/standard/tests/http/gh9316.phpt
+++ b/ext/standard/tests/http/gh9316.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Bug GH-9316 ($http_response_header is wrong for long status line)
+--SKIPIF--
+<?php require 'server.inc'; http_server_skipif(); ?>
+--INI--
+allow_url_fopen=1
+--FILE--
+<?php
+require 'server.inc';
+
+$responses = array(
+    "data://text/plain,HTTP/1.1 200 Some very long reason-phrase to test that this is properly handled by our code without adding a new header like  Bad: Header\r\nGood: Header\r\n\r\nBody",
+    "data://text/plain,HTTP/1.1 200\r\nGood: Header\r\n\r\nBody",
+);
+
+['pid' => $pid, 'uri' => $uri] = http_server($responses, $output);
+
+for ($i = 0; $i < count($responses); ++$i) {
+    $f = @fopen($uri, "r");
+    var_dump($http_response_header);
+    fclose($f);
+}
+
+http_server_kill($pid);
+
+--EXPECT--
+array(2) {
+  [0]=>
+  string(126) "HTTP/1.1 200 Some very long reason-phrase to test that this is properly handled by our code without adding a new header like  "
+  [1]=>
+  string(12) "Good: Header"
+}
+array(2) {
+  [0]=>
+  string(12) "HTTP/1.1 200"
+  [1]=>
+  string(12) "Good: Header"
+}


### PR DESCRIPTION
While the reason-phrase in a HTTP response status line is usually
short, there is no actual limit specified by the RFCs.  As such, we
must not assume that the line fits into the buffer (which is currently
128 bytes large).

Since there is no real need to present the complete status line, we
simply read and discard the rest of a long line.