### PR TITLE
Fix unexpected deprecated dynamic property warning

### DIFF
--- a/Zend/tests/throw/exit_in_finally.phpt
+++ b/Zend/tests/throw/exit_in_finally.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test exit with uncaught exception in finally block
+--FILE--
+<?php
+try {
+    throw new Exception();
+} finally {
+    echo "Done\n";
+    exit();
+}
+?>
+--EXPECT--
+Done

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7876,7 +7876,12 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 			/* Chain potential exception from wrapping finally block */
 			if (Z_OBJ_P(fast_call)) {
 				if (ex) {
-					zend_exception_set_previous(ex, Z_OBJ_P(fast_call));
+					if (zend_is_unwind_exit(ex) || zend_is_graceful_exit(ex)) {
+						/* discard the previously thrown exception */
+						OBJ_RELEASE(Z_OBJ_P(fast_call));
+					} else {
+						zend_exception_set_previous(ex, Z_OBJ_P(fast_call));
+					}
 				} else {
 					ex = EG(exception) = Z_OBJ_P(fast_call);
 				}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -3130,7 +3130,12 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try
 			/* Chain potential exception from wrapping finally block */
 			if (Z_OBJ_P(fast_call)) {
 				if (ex) {
-					zend_exception_set_previous(ex, Z_OBJ_P(fast_call));
+					if (zend_is_unwind_exit(ex) || zend_is_graceful_exit(ex)) {
+						/* discard the previously thrown exception */
+						OBJ_RELEASE(Z_OBJ_P(fast_call));
+					} else {
+						zend_exception_set_previous(ex, Z_OBJ_P(fast_call));
+					}
 				} else {
 					ex = EG(exception) = Z_OBJ_P(fast_call);
 				}


### PR DESCRIPTION
Occurred when exit() with uncaught exception in finally block.