### PR TITLE
zend introduce const GNUC attribute.

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -223,10 +223,14 @@ char *alloca();
 #if ZEND_GCC_VERSION >= 4003 || __has_attribute(alloc_size)
 # define ZEND_ATTRIBUTE_ALLOC_SIZE(X) __attribute__ ((alloc_size(X)))
 # define ZEND_ATTRIBUTE_ALLOC_SIZE2(X,Y) __attribute__ ((alloc_size(X,Y)))
-# define ZEND_ATTRIBUTE_CONST __attribute__((const))
 #else
 # define ZEND_ATTRIBUTE_ALLOC_SIZE(X)
 # define ZEND_ATTRIBUTE_ALLOC_SIZE2(X,Y)
+#endif
+
+#if ZEND_GCC_VERSION >= 3000
+# define ZEND_ATTRIBUTE_CONST __attribute__((const))
+#else
 # define ZEND_ATTRIBUTE_CONST
 #endif
 

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -223,9 +223,11 @@ char *alloca();
 #if ZEND_GCC_VERSION >= 4003 || __has_attribute(alloc_size)
 # define ZEND_ATTRIBUTE_ALLOC_SIZE(X) __attribute__ ((alloc_size(X)))
 # define ZEND_ATTRIBUTE_ALLOC_SIZE2(X,Y) __attribute__ ((alloc_size(X,Y)))
+# define ZEND_ATTRIBUTE_CONST __attribute__((const))
 #else
 # define ZEND_ATTRIBUTE_ALLOC_SIZE(X)
 # define ZEND_ATTRIBUTE_ALLOC_SIZE2(X,Y)
+# define ZEND_ATTRIBUTE_CONST
 #endif
 
 #if ZEND_GCC_VERSION >= 2007 || __has_attribute(format)

--- a/ext/standard/pack.c
+++ b/ext/standard/pack.c
@@ -102,13 +102,13 @@ static void php_pack(zval *val, size_t size, int *map, char *output)
 }
 /* }}} */
 
-static inline uint16_t php_pack_reverse_int16(uint16_t arg)
+ZEND_ATTRIBUTE_CONST static inline uint16_t php_pack_reverse_int16(uint16_t arg)
 {
 	return ((arg & 0xFF) << 8) | ((arg >> 8) & 0xFF);
 }
 
 /* {{{ php_pack_reverse_int32 */
-static inline uint32_t php_pack_reverse_int32(uint32_t arg)
+ZEND_ATTRIBUTE_CONST static inline uint32_t php_pack_reverse_int32(uint32_t arg)
 {
 	uint32_t result;
 	result = ((arg & 0xFF) << 24) | ((arg & 0xFF00) << 8) | ((arg >> 8) & 0xFF00) | ((arg >> 24) & 0xFF);


### PR DESCRIPTION
sub optimisation where there is no pointers, nor particular memory
 layout, thread local/volatile ... involved.
usage concealed for now into little pack helpers.