### PR TITLE
Add zend_string INI validators

### DIFF
--- a/Zend/zend_ini.c
+++ b/Zend/zend_ini.c
@@ -880,7 +880,7 @@ ZEND_API ZEND_INI_MH(OnUpdateStringUnempty) /* {{{ */
 ZEND_API ZEND_INI_MH(OnUpdateStr) /* {{{ */
 {
 	zend_string **p = (zend_string **) ZEND_INI_GET_ADDR();
-	*p = new_value ? new_value : NULL;
+	*p = new_value;
 	return SUCCESS;
 }
 /* }}} */

--- a/Zend/zend_ini.c
+++ b/Zend/zend_ini.c
@@ -876,3 +876,23 @@ ZEND_API ZEND_INI_MH(OnUpdateStringUnempty) /* {{{ */
 	return SUCCESS;
 }
 /* }}} */
+
+ZEND_API ZEND_INI_MH(OnUpdateStr) /* {{{ */
+{
+	zend_string **p = (zend_string **) ZEND_INI_GET_ADDR();
+	*p = new_value ? new_value : NULL;
+	return SUCCESS;
+}
+/* }}} */
+
+ZEND_API ZEND_INI_MH(OnUpdateStrNotEmpty) /* {{{ */
+{
+	if (new_value && ZSTR_LEN(new_value) == 0) {
+		return FAILURE;
+	}
+
+	zend_string **p = (zend_string **) ZEND_INI_GET_ADDR();
+	*p = new_value ? new_value : NULL;
+	return SUCCESS;
+}
+/* }}} */

--- a/Zend/zend_ini.c
+++ b/Zend/zend_ini.c
@@ -892,7 +892,7 @@ ZEND_API ZEND_INI_MH(OnUpdateStrNotEmpty) /* {{{ */
 	}
 
 	zend_string **p = (zend_string **) ZEND_INI_GET_ADDR();
-	*p = new_value ? new_value : NULL;
+	*p = new_value;
 	return SUCCESS;
 }
 /* }}} */

--- a/Zend/zend_ini.h
+++ b/Zend/zend_ini.h
@@ -209,8 +209,12 @@ ZEND_API ZEND_INI_MH(OnUpdateBool);
 ZEND_API ZEND_INI_MH(OnUpdateLong);
 ZEND_API ZEND_INI_MH(OnUpdateLongGEZero);
 ZEND_API ZEND_INI_MH(OnUpdateReal);
+/* char* versions */
 ZEND_API ZEND_INI_MH(OnUpdateString);
 ZEND_API ZEND_INI_MH(OnUpdateStringUnempty);
+/* zend_string* versions */
+ZEND_API ZEND_INI_MH(OnUpdateStr);
+ZEND_API ZEND_INI_MH(OnUpdateStrNotEmpty);
 END_EXTERN_C()
 
 #define ZEND_INI_DISPLAY_ORIG	1

--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -54,6 +54,8 @@ ZEND_BEGIN_MODULE_GLOBALS(zend_test)
 	bool print_stderr_mshutdown;
 	zend_test_fiber *active_fiber;
 	zend_long quantity_value;
+	zend_string *str_test;
+	zend_string *not_empty_str_test;
 ZEND_END_MODULE_GLOBALS(zend_test)
 
 extern ZEND_DECLARE_MODULE_GLOBALS(zend_test)

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -415,6 +415,13 @@ static ZEND_FUNCTION(zend_test_zend_ini_parse_uquantity)
 	}
 }
 
+static ZEND_FUNCTION(zend_test_zend_ini_str)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	RETURN_STR(ZT_G(str_test));
+}
+
 static ZEND_FUNCTION(namespaced_func)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -616,6 +623,8 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("zend_test.register_passes", "0", PHP_INI_SYSTEM, OnUpdateBool, register_passes, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.print_stderr_mshutdown", "0", PHP_INI_SYSTEM, OnUpdateBool, print_stderr_mshutdown, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_ENTRY("zend_test.quantity_value", "0", PHP_INI_ALL, OnUpdateLong, quantity_value, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_ENTRY("zend_test.str_test", "", PHP_INI_ALL, OnUpdateStr, str_test, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_ENTRY("zend_test.not_empty_str_test", "val", PHP_INI_ALL, OnUpdateStrNotEmpty, not_empty_str_test, zend_zend_test_globals, zend_test_globals)
 PHP_INI_END()
 
 void (*old_zend_execute_ex)(zend_execute_data *execute_data);

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -143,6 +143,8 @@ namespace {
 
     function zend_test_zend_ini_parse_quantity(string $str): int {}
     function zend_test_zend_ini_parse_uquantity(string $str): int {}
+
+    function zend_test_zend_ini_str(): string {}
 }
 
 namespace ZendTestNS {

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: daa7be53e9009c66c814fb5b0407a6dfbe09679a */
+ * Stub hash: 09e36fb87531b6ac8261c9ed0faa755a1c144638 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -91,6 +91,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_zend_test_zend_ini_parse_uquantity arginfo_zend_test_zend_ini_parse_quantity
 
+#define arginfo_zend_test_zend_ini_str arginfo_zend_get_current_func_name
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_ZendSubNS_namespaced_func, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -162,6 +164,7 @@ static ZEND_FUNCTION(zend_get_current_func_name);
 static ZEND_FUNCTION(zend_call_method);
 static ZEND_FUNCTION(zend_test_zend_ini_parse_quantity);
 static ZEND_FUNCTION(zend_test_zend_ini_parse_uquantity);
+static ZEND_FUNCTION(zend_test_zend_ini_str);
 static ZEND_FUNCTION(namespaced_func);
 static ZEND_METHOD(_ZendTestClass, is_object);
 static ZEND_METHOD(_ZendTestClass, __toString);
@@ -205,6 +208,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_call_method, arginfo_zend_call_method)
 	ZEND_FE(zend_test_zend_ini_parse_quantity, arginfo_zend_test_zend_ini_parse_quantity)
 	ZEND_FE(zend_test_zend_ini_parse_uquantity, arginfo_zend_test_zend_ini_parse_uquantity)
+	ZEND_FE(zend_test_zend_ini_str, arginfo_zend_test_zend_ini_str)
 	ZEND_NS_FE("ZendTestNS2\\ZendSubNS", namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)
 	ZEND_FE_END
 };

--- a/ext/zend_test/tests/zend_ini_str_validator_basic.phpt
+++ b/ext/zend_test/tests/zend_ini_str_validator_basic.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test OnUpdateStr and OnUpdateStrNotEmpty validators.
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+echo 'str_test INI', PHP_EOL;
+var_dump(ini_get("zend_test.str_test"));
+var_dump(ini_set("zend_test.str_test", "Test"));
+var_dump(ini_get("zend_test.str_test"));
+var_dump(ini_set("zend_test.str_test", ""));
+var_dump(ini_get("zend_test.str_test"));
+
+echo 'not_empty_str_test INI', PHP_EOL;
+var_dump(ini_get("zend_test.not_empty_str_test"));
+var_dump(ini_set("zend_test.not_empty_str_test", "Test"));
+var_dump(ini_get("zend_test.not_empty_str_test"));
+var_dump(ini_set("zend_test.not_empty_str_test", ""));
+var_dump(ini_get("zend_test.not_empty_str_test"));
+?>
+--EXPECT--
+str_test INI
+string(0) ""
+string(0) ""
+string(4) "Test"
+string(4) "Test"
+string(0) ""
+not_empty_str_test INI
+string(3) "val"
+string(3) "val"
+string(4) "Test"
+bool(false)
+string(4) "Test"

--- a/ext/zend_test/tests/zend_ini_str_validator_return_from_func.phpt
+++ b/ext/zend_test/tests/zend_ini_str_validator_return_from_func.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test zend_test_zend_ini_str() to check for GC refcount on global returned
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+var_dump(zend_test_zend_ini_str());
+?>
+--EXPECT--
+string(0) ""


### PR DESCRIPTION
Currently we only have validators for char* which is rather annoying as INI settings are saved as zend_string* in the first place