### PR TITLE
Re-fix GH-8409: SSL handshake timeout persistent connections hanging

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1366,9 +1366,6 @@ ZEND_API ZEND_COLD void zend_error_zstr_at(
 		EG(num_errors)++;
 		EG(errors) = erealloc(EG(errors), sizeof(zend_error_info) * EG(num_errors));
 		EG(errors)[EG(num_errors)-1] = info;
-		if (EG(record_errors_without_emitting)) {
-			return;
-		}
 	}
 
 	/* Report about uncaught exception in case of fatal errors */
@@ -1622,23 +1619,12 @@ ZEND_API ZEND_COLD void zend_error_zstr(int type, zend_string *message) {
 	zend_error_zstr_at(type, filename, lineno, message);
 }
 
-static zend_always_inline void zend_begin_record_errors_ex(bool no_emmitting)
+ZEND_API void zend_begin_record_errors(void)
 {
 	ZEND_ASSERT(!EG(record_errors) && "Error recording already enabled");
 	EG(record_errors) = true;
-	EG(record_errors_without_emitting) = no_emmitting;
 	EG(num_errors) = 0;
 	EG(errors) = NULL;
-}
-
-ZEND_API void zend_begin_record_errors(void)
-{
-	zend_begin_record_errors_ex(false);
-}
-
-ZEND_API void zend_begin_record_errors_without_emitting(void)
-{
-	zend_begin_record_errors_ex(true);
 }
 
 ZEND_API void zend_emit_recorded_errors(void)

--- a/Zend/zend.h
+++ b/Zend/zend.h
@@ -394,7 +394,6 @@ ZEND_API void zend_save_error_handling(zend_error_handling *current);
 ZEND_API void zend_replace_error_handling(zend_error_handling_t error_handling, zend_class_entry *exception_class, zend_error_handling *current);
 ZEND_API void zend_restore_error_handling(zend_error_handling *saved);
 ZEND_API void zend_begin_record_errors(void);
-ZEND_API void zend_begin_record_errors_without_emitting(void);
 ZEND_API void zend_emit_recorded_errors(void);
 ZEND_API void zend_free_recorded_errors(void);
 END_EXTERN_C()

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -261,10 +261,8 @@ struct _zend_executor_globals {
 	zend_long fiber_stack_size;
 
 	/* If record_errors is enabled, all emitted diagnostics will be recorded,
-	 * in addition to being processed as usual unless record_errors_without_emitting
-	 * is enabled which supresses processing when the errors are recorded. */
+	 * in addition to being processed as usual. */
 	bool record_errors;
-	bool record_errors_without_emitting;
 	uint32_t num_errors;
 	zend_error_info **errors;
 

--- a/ext/standard/tests/streams/gh8409.phpt
+++ b/ext/standard/tests/streams/gh8409.phpt
@@ -2,19 +2,24 @@
 GH-8409: Error in socket creation when error handler does not clean persistent connection
 --FILE--
 <?php
-set_error_handler(function($errno, $errstring, $errfile, $errline) {
-    foreach (get_resources() as $res) {
-        if (get_resource_type($res) === "persistent stream") {
-            echo "ERROR: persistent stream not closed\n";
-        }
-    }
-    echo "DONE\n";
-    exit(1);
+set_error_handler(function (int $errno, string $errstring): never {
+    trigger_error($errstring, E_USER_ERROR);
 });
 
-stream_socket_client("tcp://9999.9999.9999.9999:9999", $error_code, $error_message, 0.2, STREAM_CLIENT_CONNECT | STREAM_CLIENT_PERSISTENT);
+register_shutdown_function(function (): void {
+    foreach (get_resources() as $res) {
+        if (get_resource_type($res) === 'persistent stream') {
+            echo "ERROR: persistent stream not closed\n";
+            return;
+        }
+    }
+    echo "OK: persistent stream closed\n";
+});
+
+stream_socket_client('tcp://9999.9999.9999.9999:9999', $error_code, $error_message, 0.2, STREAM_CLIENT_CONNECT | STREAM_CLIENT_PERSISTENT);
 
 echo "ERROR: this should not be visible\n";
 ?>
---EXPECT--
-DONE
+--EXPECTF--
+Fatal error: stream_socket_client(): %s in %sgh8409.php on line %d
+OK: persistent stream closed

--- a/main/streams/transports.c
+++ b/main/streams/transports.c
@@ -61,7 +61,8 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 	php_stream_transport_factory factory = NULL;
 	const char *p, *protocol = NULL;
 	size_t n = 0;
-	int failed = 0;
+	bool failed = false;
+	bool bailout = false;
 	zend_string *error_text = NULL;
 	struct timeval default_timeout = { 0, 0 };
 
@@ -131,49 +132,51 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 			(char*)name, namelen, persistent_id, options, flags, timeout,
 			context STREAMS_REL_CC);
 
-	zend_begin_record_errors_without_emitting();
-
 	if (stream) {
-		php_stream_context_set(stream, context);
+		zend_try {
+			php_stream_context_set(stream, context);
 
-		if ((flags & STREAM_XPORT_SERVER) == 0) {
-			/* client */
+			if ((flags & STREAM_XPORT_SERVER) == 0) {
+				/* client */
 
-			if (flags & (STREAM_XPORT_CONNECT|STREAM_XPORT_CONNECT_ASYNC)) {
-				if (-1 == php_stream_xport_connect(stream, name, namelen,
-							flags & STREAM_XPORT_CONNECT_ASYNC ? 1 : 0,
-							timeout, &error_text, error_code)) {
+				if (flags & (STREAM_XPORT_CONNECT|STREAM_XPORT_CONNECT_ASYNC)) {
+					if (-1 == php_stream_xport_connect(stream, name, namelen,
+								flags & STREAM_XPORT_CONNECT_ASYNC ? 1 : 0,
+								timeout, &error_text, error_code)) {
 
-					ERR_RETURN(error_string, error_text, "connect() failed: %s");
+						ERR_RETURN(error_string, error_text, "connect() failed: %s");
 
-					failed = 1;
-				}
-			}
-
-		} else {
-			/* server */
-			if (flags & STREAM_XPORT_BIND) {
-				if (0 != php_stream_xport_bind(stream, name, namelen, &error_text)) {
-					ERR_RETURN(error_string, error_text, "bind() failed: %s");
-					failed = 1;
-				} else if (flags & STREAM_XPORT_LISTEN) {
-					zval *zbacklog = NULL;
-					int backlog = 32;
-
-					if (PHP_STREAM_CONTEXT(stream) && (zbacklog = php_stream_context_get_option(PHP_STREAM_CONTEXT(stream), "socket", "backlog")) != NULL) {
-						backlog = zval_get_long(zbacklog);
-					}
-
-					if (0 != php_stream_xport_listen(stream, backlog, &error_text)) {
-						ERR_RETURN(error_string, error_text, "listen() failed: %s");
 						failed = 1;
 					}
 				}
+
+			} else {
+				/* server */
+				if (flags & STREAM_XPORT_BIND) {
+					if (0 != php_stream_xport_bind(stream, name, namelen, &error_text)) {
+						ERR_RETURN(error_string, error_text, "bind() failed: %s");
+						failed = 1;
+					} else if (flags & STREAM_XPORT_LISTEN) {
+						zval *zbacklog = NULL;
+						int backlog = 32;
+
+						if (PHP_STREAM_CONTEXT(stream) && (zbacklog = php_stream_context_get_option(PHP_STREAM_CONTEXT(stream), "socket", "backlog")) != NULL) {
+							backlog = zval_get_long(zbacklog);
+						}
+
+						if (0 != php_stream_xport_listen(stream, backlog, &error_text)) {
+							ERR_RETURN(error_string, error_text, "listen() failed: %s");
+							failed = 1;
+						}
+					}
+				}
 			}
-		}
+		} zend_catch {
+			bailout = 1;
+		} zend_end_try();
 	}
 
-	if (failed) {
+	if (failed || bailout) {
 		/* failure means that they don't get a stream to play with */
 		if (persistent_id) {
 			php_stream_pclose(stream);
@@ -181,10 +184,11 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 			php_stream_close(stream);
 		}
 		stream = NULL;
+		if (bailout) {
+			zend_bailout();
+		}
 	}
 
-	zend_emit_recorded_errors();
-	zend_free_recorded_errors();
 
 	return stream;
 }


### PR DESCRIPTION
This patch reverts part of d052742, d052742 makes Swoole/Swow can not work anymore, because Coroutine will yield to another one during socket operation, and EG(record_errors) assertion will always fail, and zend_begin_record_errors was only used during compile time before.
Use zend_try and zend_catch to fix it, and this patch also can be applied to PHP-8.0.