### PR TITLE
Fix GH-9339: OpenSSL oid_file path check warning prints uninitialized path

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-9033 (Loading blacklist file can fail due to negative length).
     (cmb)
 
+- OpenSSL:
+  . Fixed bug GH-9339 (OpenSSL oid_file path check warning contains
+    uninitialized path). (Jakub Zelenka)
+
 - PDO_SQLite:
   . Fixed bug GH-9032 (SQLite3 authorizer crashes on NULL values). (cmb)
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -506,15 +506,15 @@ static bool php_openssl_check_path_ex(
 		error_msg = "must not contain any null bytes";
 		error_type = E_ERROR;
 	} else if (expand_filepath(fs_file_path, real_path) == NULL) {
-		error_msg = "The argument must be a valid file path";
+		error_msg = "must be a valid file path";
 	}
 
 	if (error_msg != NULL) {
 		if (arg_num == 0) {
 			const char *option_title = option_name ? option_name : "unknown";
 			const char *option_label = is_from_array ? "array item" : "option";
-			php_error_docref(NULL, E_WARNING, "Path '%s' for %s %s %s",
-				real_path, option_title, option_label, error_msg);
+			php_error_docref(NULL, E_WARNING, "Path for %s %s %s",
+					option_title, option_label, error_msg);
 		} else if (is_from_array && option_name != NULL) {
 			php_openssl_check_path_error(
 					arg_num, error_type, "option %s array item %s", option_name, error_msg);

--- a/ext/openssl/tests/gh9339.phpt
+++ b/ext/openssl/tests/gh9339.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-9339: oid_file path check warning contains uninitialized path
+--SKIPIF--
+<?php
+if (!extension_loaded("openssl")) die("skip openssl not loaded");
+?>
+--FILE--
+<?php
+$configCode = <<<CONFIG
+oid_file = %s
+[ req ]
+default_bits = 1024
+CONFIG;
+
+$configFile = __DIR__ . '/gh9339.cnf';
+file_put_contents($configFile, sprintf($configCode,  __DIR__ . '/' . str_repeat('a', 9000)));
+openssl_pkey_new([ 'config' => $configFile ]);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh9339.cnf');
+?>
+--EXPECTF--
+
+Warning: openssl_pkey_new(): Path for oid_file option must be a valid file path in %s on line %d


### PR DESCRIPTION
Real path is initialized only if all checks are successful so it is incorrectly used here. Not much point to print the path at all so this is now skipped. Fixes #9339 