### PR TITLE
Fix incorrect timeout calculations of stream_set_timeout function

### DIFF
--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1367,8 +1367,8 @@ PHP_FUNCTION(stream_set_timeout)
 	t.tv_sec = (long)seconds;
 
 	if (argc == 3) {
-		t.tv_usec = (long)(microseconds % 1000000);
-		t.tv_sec +=(long)(microseconds / 1000000);
+		t.tv_usec = (long)((microseconds % 1000) * 1000);
+		t.tv_sec +=(long)(microseconds / 1000);
 	} else {
 		t.tv_usec = 0;
 	}
@@ -1376,8 +1376,8 @@ PHP_FUNCTION(stream_set_timeout)
 	t.tv_sec = seconds;
 
 	if (argc == 3) {
-		t.tv_usec = microseconds % 1000000;
-		t.tv_sec += microseconds / 1000000;
+		t.tv_usec = (microseconds % 1000) * 1000;
+		t.tv_sec += microseconds / 1000;
 	} else {
 		t.tv_usec = 0;
 	}

--- a/ext/standard/tests/streams/stream_set_timeout_with_mesc.phpt
+++ b/ext/standard/tests/streams/stream_set_timeout_with_mesc.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test stream_set_timeout() function : set timeout with microseconds
+--FILE--
+<?php
+$sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+
+stream_set_timeout($sockets[1], 1, 800);
+
+fwrite($sockets[0], "foo");
+var_dump(stream_get_contents($sockets[1], 3));
+?>
+--EXPECT--
+string(3) "foo"


### PR DESCRIPTION
Example
```php
<?php
stream_set_timeout($sockets[1], 1, 1800);
```
t.tv_usec is equal to (1800 % 1000 * 1000 = 800000) microseconds.
t.tv_sec is equal to (1 + 1800 / 1000 = 2) seconds.
