### PR TITLE
Implement `SQL_ATTR_CONNECTION_DEAD ` for ODBC

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2246,7 +2246,17 @@ try_and_get_another_connection:
 				RETCODE ret;
 				UCHAR d_name[32];
 				SQLSMALLINT len;
+				SQLUINTEGER dead = SQL_CD_FALSE;
 
+				ret = SQLGetConnectAttr(db_conn->hdbc,
+					SQL_ATTR_CONNECTION_DEAD,
+					&dead, 0, NULL);
+				if (dead == SQL_CD_TRUE) {
+					/* Bail early here, since we know it's gone */
+					zend_hash_str_del(&EG(persistent_list), hashed_details, hashed_len);
+					goto try_and_get_another_connection;
+				}
+				/* If the driver doesn't support it, fall back to old heuristic */
 				ret = SQLGetInfo(db_conn->hdbc,
 					SQL_DATA_SOURCE_READ_ONLY,
 					d_name, sizeof(d_name), &len);

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2256,7 +2256,10 @@ try_and_get_another_connection:
 					zend_hash_str_del(&EG(persistent_list), hashed_details, hashed_len);
 					goto try_and_get_another_connection;
 				}
-				/* If the driver doesn't support it, fall back to old heuristic */
+				/* If the driver doesn't support it, or returns
+				 * false (could be a false positive), fall back
+				 * to the old heuristic.
+				 */
 				ret = SQLGetInfo(db_conn->hdbc,
 					SQL_DATA_SOURCE_READ_ONLY,
 					d_name, sizeof(d_name), &len);

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2251,7 +2251,7 @@ try_and_get_another_connection:
 				ret = SQLGetConnectAttr(db_conn->hdbc,
 					SQL_ATTR_CONNECTION_DEAD,
 					&dead, 0, NULL);
-				if (dead == SQL_CD_TRUE) {
+				if (ret == SQL_SUCCESS && dead == SQL_CD_TRUE) {
 					/* Bail early here, since we know it's gone */
 					zend_hash_str_del(&EG(persistent_list), hashed_details, hashed_len);
 					goto try_and_get_another_connection;

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -405,7 +405,8 @@ static zend_result odbc_handle_check_liveness(pdo_dbh_t *dbh)
 		return FAILURE;
 	}
 	/*
-	 * If the driver doesn't support SQL_ATTR_CONNECTION_DEAD, fall back
+	 * If the driver doesn't support SQL_ATTR_CONNECTION_DEAD, or if
+	 * it returns false (which could be a false positive), fall back
 	 * to using SQL_DATA_SOURCE_READ_ONLY, which isn't semantically
 	 * correct, but works with many drivers.
 	 */

--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -400,7 +400,7 @@ static zend_result odbc_handle_check_liveness(pdo_dbh_t *dbh)
 	pdo_odbc_db_handle *H = (pdo_odbc_db_handle *)dbh->driver_data;
 
 	ret = SQLGetConnectAttr(H->dbc, SQL_ATTR_CONNECTION_DEAD, &dead, 0, NULL);
-	if (dead == SQL_CD_TRUE) {
+	if (ret == SQL_SUCCESS && dead == SQL_CD_TRUE) {
 		/* Bail early here, since we know it's gone */
 		return FAILURE;
 	}


### PR DESCRIPTION
This uses the semantically correct `SQL_ATTR_CONNECTION_DEAD` attribute when possible, and in the event it fails or returns a successful false (since at least for Db2i in some circumstances, may be inaccurate), tries the old heuristic.

May address GH-9347.