### PR TITLE
Fix GH-9310: SSL local_cert and local_pk do not respect open_basedir

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -588,7 +588,7 @@ ZEND_API const char *get_active_function_arg_name(uint32_t arg_num) /* {{{ */
 
 ZEND_API const char *get_function_arg_name(const zend_function *func, uint32_t arg_num) /* {{{ */
 {
-	if (!func || func->common.num_args < arg_num) {
+	if (!func || arg_num == 0 || func->common.num_args < arg_num) {
 		return NULL;
 	}
 

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -489,7 +489,7 @@ static void php_openssl_check_path_error(uint32_t arg_num, int type, const char 
 }
 
 /* openssl file path check extended */
-static bool php_openssl_check_path_ex(
+bool php_openssl_check_path_ex(
 		const char *file_path, size_t file_path_len, char *real_path, uint32_t arg_num,
 		bool contains_file_protocol, bool is_from_array, const char *option_name)
 {
@@ -544,31 +544,6 @@ static bool php_openssl_check_path_ex(
 	}
 
 	return false;
-}
-
-/* openssl file path check */
-static inline bool php_openssl_check_path(
-		const char *file_path, size_t file_path_len, char *real_path, uint32_t arg_num)
-{
-	return php_openssl_check_path_ex(
-			file_path, file_path_len, real_path, arg_num, false, false, NULL);
-}
-
-/* openssl file path extra check with zend string */
-static inline bool php_openssl_check_path_str_ex(
-		zend_string *file_path, char *real_path, uint32_t arg_num,
-		bool contains_file_protocol, bool is_from_array, const char *option_name)
-{
-	return php_openssl_check_path_ex(
-			ZSTR_VAL(file_path), ZSTR_LEN(file_path), real_path, arg_num, contains_file_protocol,
-			is_from_array, option_name);
-}
-
-/* openssl file path check with zend string */
-static inline bool php_openssl_check_path_str(
-		zend_string *file_path, char *real_path, uint32_t arg_num)
-{
-	return php_openssl_check_path_str_ex(file_path, real_path, arg_num, true, false, NULL);
 }
 
 static int ssl_stream_data_index;

--- a/ext/openssl/php_openssl.h
+++ b/ext/openssl/php_openssl.h
@@ -92,6 +92,36 @@ php_stream_transport_factory_func php_openssl_ssl_socket_factory;
 
 void php_openssl_store_errors(void);
 
+/* openssl file path extra */
+bool php_openssl_check_path_ex(
+		const char *file_path, size_t file_path_len, char *real_path, uint32_t arg_num,
+		bool contains_file_protocol, bool is_from_array, const char *option_name);
+
+/* openssl file path check */
+static inline bool php_openssl_check_path(
+		const char *file_path, size_t file_path_len, char *real_path, uint32_t arg_num)
+{
+	return php_openssl_check_path_ex(
+			file_path, file_path_len, real_path, arg_num, false, false, NULL);
+}
+
+/* openssl file path extra check with zend string */
+static inline bool php_openssl_check_path_str_ex(
+		zend_string *file_path, char *real_path, uint32_t arg_num,
+		bool contains_file_protocol, bool is_from_array, const char *option_name)
+{
+	return php_openssl_check_path_ex(
+			ZSTR_VAL(file_path), ZSTR_LEN(file_path), real_path, arg_num, contains_file_protocol,
+			is_from_array, option_name);
+}
+
+/* openssl file path check with zend string */
+static inline bool php_openssl_check_path_str(
+		zend_string *file_path, char *real_path, uint32_t arg_num)
+{
+	return php_openssl_check_path_str_ex(file_path, real_path, arg_num, true, false, NULL);
+}
+
 PHP_OPENSSL_API zend_long php_openssl_cipher_iv_length(const char *method);
 PHP_OPENSSL_API zend_string* php_openssl_random_pseudo_bytes(zend_long length);
 PHP_OPENSSL_API zend_string* php_openssl_encrypt(

--- a/ext/openssl/tests/CertificateGenerator.inc
+++ b/ext/openssl/tests/CertificateGenerator.inc
@@ -85,8 +85,8 @@ class CertificateGenerator
         openssl_x509_export_to_file($this->ca, $file);
     }
 
-    public function saveNewCertAsFileWithKey(
-        $commonNameForCert, $file, $keyLength = null, $subjectAltName = null
+    public function saveNewCertAndKey(
+        $commonNameForCert, $certFile, $keyFile, $keyLength = null, $subjectAltName = null
     ) {
         $dn = [
             'countryName' => 'BY',
@@ -117,7 +117,7 @@ $subjectAltNameConfig
 basicConstraints = CA:FALSE
 $subjectAltNameConfig
 CONFIG;
-        $configFile = $file . '.cnf';
+        $configFile = $certFile . '.cnf';
         file_put_contents($configFile, $configCode);
 
         try {
@@ -146,10 +146,22 @@ CONFIG;
             $keyText = '';
             openssl_pkey_export($this->lastKey, $keyText, null, $config);
 
-            file_put_contents($file, $certText . PHP_EOL . $keyText);
+            if ($certFile === $keyFile) {
+                file_put_contents($certFile, $certText . PHP_EOL . $keyText);
+            } else {
+                file_put_contents($certFile, $certText);
+                file_put_contents($keyFile, $keyText);
+            }
         } finally {
             unlink($configFile);
         }
+    }
+
+
+    public function saveNewCertAsFileWithKey(
+        $commonNameForCert, $file, $keyLength = null, $subjectAltName = null
+    ) {
+        $this->saveNewCertAndKey($commonNameForCert, $file, $file, $keyLength, $subjectAltName);
     }
 
     public function getCertDigest($algo)

--- a/ext/openssl/tests/gh9310.phpt
+++ b/ext/openssl/tests/gh9310.phpt
@@ -1,0 +1,186 @@
+--TEST--
+GH-9310: local_cert and local_pk do not respect open_basedir restriction
+--EXTENSIONS--
+openssl
+--SKIPIF--
+<?php
+if (!function_exists("proc_open")) die("skip no proc_open");
+?>
+--FILE--
+<?php
+include 'ServerClientTestCase.inc';
+
+$baseDir = __DIR__ . '/gh9310';
+@mkdir($baseDir);
+$baseDirCertFile = $baseDir . '/cert.crt';
+$baseDirPkFile = $baseDir . '/private.key';
+$certFile = __DIR__ . '/gh9310.crt';
+$pkFile = __DIR__ . '/gh9310.key';
+
+include 'CertificateGenerator.inc';
+$certificateGenerator = new CertificateGenerator();
+$certificateGenerator->saveNewCertAndKey('gh9310', $certFile, $pkFile);
+
+copy($certFile, $baseDirCertFile);
+copy($pkFile, $baseDirPkFile);
+copy(__DIR__ . '/sni_server_uk_cert.pem', $baseDir . '/sni_server_uk_cert.pem');
+
+
+$serverCodeTemplate = <<<'CODE'
+    ini_set('log_errors', 'On');
+    ini_set('open_basedir',  __DIR__ . '/gh9310');
+    $serverUri = "ssl://127.0.0.1:64321";
+    $serverFlags = STREAM_SERVER_BIND | STREAM_SERVER_LISTEN;
+    $serverCtx = stream_context_create(['ssl' => [
+        'local_cert' => '%s',
+        'local_pk' => '%s',
+    ]]);
+
+    $sock = stream_socket_server($serverUri, $errno, $errstr, $serverFlags, $serverCtx);
+    phpt_notify();
+
+    $link = stream_socket_accept($sock);
+CODE;
+
+$clientCode = <<<'CODE'
+    $serverUri = "ssl://127.0.0.1:64321";
+    $clientFlags = STREAM_CLIENT_CONNECT;
+
+    $clientCtx = stream_context_create(['ssl' => [
+        'verify_peer' => false,
+        'verify_peer_name' => false
+    ]]);
+
+    phpt_wait();
+    @stream_socket_client($serverUri, $errno, $errstr, 2, $clientFlags, $clientCtx);
+CODE;
+
+$sniServerCodeV1 = <<<'CODE'
+    ini_set('log_errors', 'On');
+    ini_set('open_basedir', __DIR__ . '/gh9310');
+    $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+    $ctx = stream_context_create(['ssl' => [
+        'SNI_server_certs' => [
+            "cs.php.net" => __DIR__ . "/sni_server_cs.pem",
+        ]
+    ]]);
+
+    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
+    phpt_notify();
+
+    stream_socket_accept($server);
+CODE;
+
+$sniServerCodeV2 = <<<'CODE'
+    ini_set('log_errors', 'On');
+    ini_set('open_basedir', __DIR__ . '/gh9310');
+    $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+    $ctx = stream_context_create(['ssl' => [
+        'SNI_server_certs' => [
+            "uk.php.net" => [
+                'local_cert' => __DIR__ . '/gh9310/sni_server_uk_cert.pem',
+                'local_pk' => __DIR__ . '/sni_server_uk_key.pem',
+            ]
+        ]
+    ]]);
+
+    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
+    phpt_notify();
+
+    stream_socket_accept($server);
+CODE;
+
+$sniServerCodeV3 = <<<'CODE'
+    ini_set('log_errors', 'On');
+    ini_set('open_basedir', __DIR__ . '/gh9310');
+    $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN;
+    $ctx = stream_context_create(['ssl' => [
+        'SNI_server_certs' => [
+            "us.php.net" => [
+                'local_cert' => __DIR__ . '/sni_server_us_cert.pem',
+                'local_pk' => __DIR__ . '/sni_server_us_key.pem',
+            ]
+        ]
+    ]]);
+
+    $server = stream_socket_server('tls://127.0.0.1:64321', $errno, $errstr, $flags, $ctx);
+    phpt_notify();
+
+    stream_socket_accept($server);
+CODE;
+
+$sniClientCodeTemplate = <<<'CODE'
+    $flags = STREAM_CLIENT_CONNECT;
+    $ctxArr = [
+        'cafile' => __DIR__ . '/sni_server_ca.pem',
+    ];
+
+    phpt_wait();
+
+    $ctxArr['peer_name'] = '%s';
+    $ctx = stream_context_create(['ssl' => $ctxArr]);
+    @stream_socket_client("tls://127.0.0.1:64321", $errno, $errstr, 1, $flags, $ctx);
+CODE;
+
+$serverCode = sprintf($serverCodeTemplate, $baseDirCertFile . "\0test", $baseDirPkFile);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+
+$serverCode = sprintf($serverCodeTemplate, $baseDirCertFile, $baseDirPkFile . "\0test");
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+
+$serverCode = sprintf($serverCodeTemplate, $certFile, $pkFile);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+
+$serverCode = sprintf($serverCodeTemplate, $baseDirCertFile, $pkFile);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+
+$sniClientCode = sprintf($sniClientCodeTemplate, 'cs.php.net');
+ServerClientTestCase::getInstance()->run($sniClientCode, $sniServerCodeV1);
+
+$sniClientCode = sprintf($sniClientCodeTemplate, 'uk.php.net');
+ServerClientTestCase::getInstance()->run($sniClientCode, $sniServerCodeV2);
+
+$sniClientCode = sprintf($sniClientCodeTemplate, 'us.php.net');
+ServerClientTestCase::getInstance()->run($sniClientCode, $sniServerCodeV3);
+
+?>
+--CLEAN--
+<?php
+$baseDir = __DIR__ . '/gh9310';
+
+@unlink(__DIR__ . '/gh9310.crt');
+@unlink(__DIR__ . '/gh9310.key');
+@unlink($baseDir . '/cert.crt');
+@unlink($baseDir . '/private.key');
+@unlink($baseDir . '/sni_server_uk_cert.pem');
+@rmdir($baseDir);
+?>
+--EXPECTF--
+PHP Warning:  stream_socket_accept(): Path for local_cert in ssl stream context option must not contain any null bytes in %s
+PHP Warning:  stream_socket_accept(): Unable to get real path of certificate file `%scert.crt' in %s
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Accept failed: %s
+PHP Warning:  stream_socket_accept(): Path for local_pk in ssl stream context option must not contain any null bytes in %s
+PHP Warning:  stream_socket_accept(): Unable to get real path of private key file `%sprivate.key' in %s
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Accept failed: %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310.crt) is not within the allowed path(s): (%sgh9310) in %s
+PHP Warning:  stream_socket_accept(): Unable to get real path of certificate file `%sgh9310.crt' in %s
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Accept failed: %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%sgh9310.key) is not within the allowed path(s): (%sgh9310) in %s
+PHP Warning:  stream_socket_accept(): Unable to get real path of private key file `%sgh9310.key' in %s
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Accept failed: %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%ssni_server_cs.pem) is not within the allowed path(s): (%sgh9310) in %s
+PHP Warning:  stream_socket_accept(): Failed setting local cert chain file `%ssni_server_cs.pem'; file not found in %s
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Accept failed: %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%ssni_server_uk_key.pem) is not within the allowed path(s): (%sgh9310) in %s
+PHP Warning:  stream_socket_accept(): Failed setting local private key file `%ssni_server_uk_key.pem';  could not open file in %s
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Accept failed: %s
+PHP Warning:  stream_socket_accept(): open_basedir restriction in effect. File(%ssni_server_us_cert.pem) is not within the allowed path(s): (%sgh9310) in %s
+PHP Warning:  stream_socket_accept(): Failed setting local cert chain file `%ssni_server_us_cert.pem'; could not open file in %s
+PHP Warning:  stream_socket_accept(): Failed to enable crypto in %s
+PHP Warning:  stream_socket_accept(): Accept failed: %s

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -101,14 +101,25 @@
 #endif
 
 /* Simplify ssl context option retrieval */
-#define GET_VER_OPT(name) \
-	(PHP_STREAM_CONTEXT(stream) && (val = php_stream_context_get_option(PHP_STREAM_CONTEXT(stream), "ssl", name)) != NULL)
-#define GET_VER_OPT_STRING(name, str) \
-	if (GET_VER_OPT(name)) { \
-		if (try_convert_to_string(val)) str = Z_STRVAL_P(val); \
-	}
-#define GET_VER_OPT_LONG(name, num) \
-	if (GET_VER_OPT(name)) { num = zval_get_long(val); }
+#define GET_VER_OPT(_name) \
+	(PHP_STREAM_CONTEXT(stream) && (val = php_stream_context_get_option(PHP_STREAM_CONTEXT(stream), "ssl", _name)) != NULL)
+#define GET_VER_OPT_STRING(_name, _str) \
+	do { \
+		if (GET_VER_OPT(_name)) { \
+			if (try_convert_to_string(val)) _str = Z_STRVAL_P(val); \
+		} \
+	} while (0)
+#define GET_VER_OPT_STRINGL(_name, _str, _len) \
+	do { \
+		if (GET_VER_OPT(_name)) { \
+			if (try_convert_to_string(val)) { \
+				_str = Z_STRVAL_P(val); \
+				_len = Z_STRLEN_P(val); \
+			} \
+		} \
+	} while (0)
+#define GET_VER_OPT_LONG(_name, _num) \
+	if (GET_VER_OPT(_name)) _num = zval_get_long(val)
 
 /* Used for peer verification in windows */
 #define PHP_X509_NAME_ENTRY_TO_UTF8(ne, i, out) \
@@ -893,14 +904,18 @@ static int php_openssl_set_local_cert(SSL_CTX *ctx, php_stream *stream) /* {{{ *
 {
 	zval *val = NULL;
 	char *certfile = NULL;
+	size_t certfile_len;
 
-	GET_VER_OPT_STRING("local_cert", certfile);
+	GET_VER_OPT_STRINGL("local_cert", certfile, certfile_len);
 
 	if (certfile) {
 		char resolved_path_buff[MAXPATHLEN];
 		const char *private_key = NULL;
+		size_t private_key_len;
 
-		if (!VCWD_REALPATH(certfile, resolved_path_buff)) {
+		if (!php_openssl_check_path_ex(
+				certfile, certfile_len, resolved_path_buff, 0, false, false,
+				"local_cert in ssl stream context")) {
 			php_error_docref(NULL, E_WARNING, "Unable to get real path of certificate file `%s'", certfile);
 			return FAILURE;
 		}
@@ -913,8 +928,10 @@ static int php_openssl_set_local_cert(SSL_CTX *ctx, php_stream *stream) /* {{{ *
 			return FAILURE;
 		}
 
-		GET_VER_OPT_STRING("local_pk", private_key);
-		if (private_key && !VCWD_REALPATH(private_key, resolved_path_buff)) {
+		GET_VER_OPT_STRINGL("local_pk", private_key, private_key_len);
+		if (private_key && !php_openssl_check_path_ex(
+				private_key, private_key_len, resolved_path_buff, 0, false, false,
+				"local_pk in ssl stream context")) {
 			php_error_docref(NULL, E_WARNING, "Unable to get real path of private key file `%s'", private_key);
 			return FAILURE;
 		}
@@ -1447,9 +1464,11 @@ static int php_openssl_enable_server_sni(php_stream *stream, php_openssl_netstre
 			if (UNEXPECTED(!local_cert_str)) {
 				return FAILURE;
 			}
-			if (!VCWD_REALPATH(ZSTR_VAL(local_cert_str), resolved_cert_path_buff)) {
+			if (!php_openssl_check_path_str_ex(
+					local_cert_str, resolved_cert_path_buff, 0, false, false,
+					"SNI_server_certs local_cert in ssl stream context")) {
 				php_error_docref(NULL, E_WARNING,
-					"Failed setting local cert chain file `%s'; file not found",
+					"Failed setting local cert chain file `%s'; could not open file",
 					ZSTR_VAL(local_cert_str)
 				);
 				zend_string_release(local_cert_str);
@@ -1469,9 +1488,11 @@ static int php_openssl_enable_server_sni(php_stream *stream, php_openssl_netstre
 			if (UNEXPECTED(!local_pk_str)) {
 				return FAILURE;
 			}
-			if (!VCWD_REALPATH(ZSTR_VAL(local_pk_str), resolved_pk_path_buff)) {
+			if (!php_openssl_check_path_str_ex(
+					local_pk_str, resolved_pk_path_buff, 0, false, false,
+					"SNI_server_certs local_pk in ssl stream context")) {
 				php_error_docref(NULL, E_WARNING,
-					"Failed setting local private key file `%s'; file not found",
+					"Failed setting local private key file `%s';  could not open file",
 					ZSTR_VAL(local_pk_str)
 				);
 				zend_string_release(local_pk_str);
@@ -1481,7 +1502,9 @@ static int php_openssl_enable_server_sni(php_stream *stream, php_openssl_netstre
 
 			ctx = php_openssl_create_sni_server_ctx(resolved_cert_path_buff, resolved_pk_path_buff);
 
-		} else if (VCWD_REALPATH(Z_STRVAL_P(current), resolved_path_buff)) {
+		} else if (php_openssl_check_path_str_ex(
+				Z_STR_P(current), resolved_path_buff, 0, false, false,
+				"SNI_server_certs in ssl stream context")) {
 			ctx = php_openssl_create_sni_server_ctx(resolved_path_buff, resolved_path_buff);
 		} else {
 			php_error_docref(NULL, E_WARNING,


### PR DESCRIPTION
This fixes #9310 by using proper path checks for all certs in tls streams options for certs and pk.