### PR TITLE
Don't enforce 64bit hit counter on Windows

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2192,10 +2192,11 @@ zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type)
 #else
 #if ZEND_ENABLE_ZVAL_LONG64
 		InterlockedIncrement64(&ZCSG(hits));
+		InterlockedIncrement64(&persistent_script->dynamic_members.hits);
 #else
 		InterlockedIncrement(&ZCSG(hits));
+		InterlockedIncrement(&persistent_script->dynamic_members.hits);
 #endif
-		InterlockedIncrement64(&persistent_script->dynamic_members.hits);
 #endif
 
 		/* see bug #15471 (old BTS) */

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -137,11 +137,7 @@ typedef struct _zend_persistent_script {
 	 */
 	struct zend_persistent_script_dynamic_members {
 		time_t       last_used;
-#ifdef ZEND_WIN32
-		LONGLONG   hits;
-#else
-		zend_ulong        hits;
-#endif
+		zend_ulong   hits;
 		unsigned int memory_consumption;
 		unsigned int checksum;
 		time_t       revalidate;

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -545,7 +545,7 @@ static int accelerator_get_scripts(zval *return_value)
 
 			array_init(&persistent_script_report);
 			add_assoc_str(&persistent_script_report, "full_path", zend_string_dup(script->script.filename, 0));
-			add_assoc_long(&persistent_script_report, "hits", (zend_long)script->dynamic_members.hits);
+			add_assoc_long(&persistent_script_report, "hits", script->dynamic_members.hits);
 			add_assoc_long(&persistent_script_report, "memory_consumption", script->dynamic_members.memory_consumption);
 			ta = localtime(&script->dynamic_members.last_used);
 			str = asctime(ta);


### PR DESCRIPTION
There is no particular need to have a 64bit hit counter on Windows.

---

AFAIK, there is no good reason to use `InterlockedIncrement(64)` here either, but maybe I'm missing something.