### PR TITLE
GH-9370: Fix opcache jit protection bits.

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4611,7 +4611,6 @@ ZEND_EXT_API void zend_jit_unprotect(void)
 #ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 		if (zend_write_protect) {
 			pthread_jit_write_protect_np(0);
-			return;
 		}
 #endif
 		opts |= PROT_EXEC;
@@ -4645,7 +4644,6 @@ ZEND_EXT_API void zend_jit_protect(void)
 #ifdef HAVE_PTHREAD_JIT_WRITE_PROTECT_NP
 		if (zend_write_protect) {
 			pthread_jit_write_protect_np(1);
-			return;
 		}
 #endif
 		if (mprotect(dasm_buf, dasm_size, PROT_READ | PROT_EXEC) != 0) {

--- a/ext/opcache/shared_alloc_mmap.c
+++ b/ext/opcache/shared_alloc_mmap.c
@@ -166,6 +166,9 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 #ifdef PROT_MAX
 	flags |= PROT_MAX(PROT_READ | PROT_WRITE | PROT_EXEC);
 #endif
+#ifdef MAP_JIT
+	flags |= MAP_JIT;
+#endif
 #if (defined(__linux__) || defined(__FreeBSD__)) && (defined(__x86_64__) || defined (__aarch64__))
 	void *hint = find_prefered_mmap_base(requested_size);
 	if (hint != MAP_FAILED) {


### PR DESCRIPTION
Allow mprotect to occur, pthread_jit_write_np are just to allow mprotect
 flags to be used.