### PR TITLE
Fix #79451: Using DOMDocument->replaceChild on doctype causes double …

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1003,6 +1003,7 @@ PHP_METHOD(DOMNode, replaceChild)
 	xmlNodePtr newchild, oldchild, nodep;
 	dom_object *intern, *newchildobj, *oldchildobj;
 	int stricterror;
+	bool replacedoctype = false;
 
 	int ret;
 
@@ -1059,6 +1060,9 @@ PHP_METHOD(DOMNode, replaceChild)
 			dom_reconcile_ns(nodep->doc, newchild);
 		}
 	} else if (oldchild != newchild) {
+		xmlDtdPtr intSubset = xmlGetIntSubset(nodep->doc);
+		replacedoctype = (intSubset == (xmlDtd *) oldchild);
+
 		if (newchild->doc == NULL && nodep->doc != NULL) {
 			xmlSetTreeDoc(newchild, nodep->doc);
 			newchildobj->document = intern->document;
@@ -1066,6 +1070,10 @@ PHP_METHOD(DOMNode, replaceChild)
 		}
 		xmlReplaceNode(oldchild, newchild);
 		dom_reconcile_ns(nodep->doc, newchild);
+
+		if (replacedoctype) {
+			nodep->doc->intSubset = (xmlDtd *) newchild;
+		}
 	}
 	DOM_RET_OBJ(oldchild, &ret, intern);
 }

--- a/ext/dom/tests/bug79451.phpt
+++ b/ext/dom/tests/bug79451.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #79451 (Using DOMDocument->replaceChild on doctype causes double free)
---SKIPIF--
-<?php require_once('skipif.inc'); ?>
+--EXTENSIONS--
+dom
 --FILE--
 <?php
 $dom = new \DOMDocument();


### PR DESCRIPTION
…free

This is porting the original fix to PHP-8.1.