### PR TITLE
Fix opcache checksum calc for inheritance_cache

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2114,7 +2114,7 @@ zend_op_array *persistent_compile_file(zend_file_handle *file_handle, int type)
 		unsigned int checksum = zend_accel_script_checksum(persistent_script);
 		if (checksum != persistent_script->dynamic_members.checksum ) {
 			/* The checksum is wrong */
-			zend_accel_error(ACCEL_LOG_INFO, "Checksum failed for '%s':  expected=0x%08x, found=0x%08x",
+			zend_accel_error(ACCEL_LOG_WARNING, "Checksum failed for '%s':  expected=0x%08x, found=0x%08x",
 							 ZSTR_VAL(persistent_script->script.filename), persistent_script->dynamic_members.checksum, checksum);
 			zend_shared_alloc_lock();
 			if (!persistent_script->corrupted) {

--- a/ext/opcache/tests/gh8065.inc
+++ b/ext/opcache/tests/gh8065.inc
@@ -1,0 +1,3 @@
+<?php
+
+class Bar extends Foo {}

--- a/ext/opcache/tests/gh8065.phpt
+++ b/ext/opcache/tests/gh8065.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Bug GH-8065: Opcache zend_class_entry.inheritance_cache breaks persistent script checksum
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.consistency_checks=1
+opcache.log_verbosity_level=2
+opcache.protect_memory=1
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php if (isset(opcache_get_status()["jit"])) die('skip: JIT breaks checksum due to modification of op handlers'); ?>
+--FILE--
+<?php
+
+class Foo {}
+
+require_once __DIR__ . '/gh8065.inc';
+
+echo "Done\n";
+
+?>
+--EXPECT--
+Done


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/8065

Since GH-6627 `zend_class_entry.inheritance_cache` can be modified after the script is already loaded into SHM. This is by-design but breaks checksum calculation of persistent scripts. The approach of this PR is to simply reset the `inheritance_cache` before the checksum calculation and then restore it.

The alternative approach I could think of is to use pointer indirection to make `inheritance_cache` itself immutable and make it point to a pointer at the end of the `zend_persistent_script.mem` block, and remove the mutable part from `size` so it doesn't count towards the checksum. This could break extension compatibility though, as the pointer would need to be dereferenced twice.

Unfortunately, the JIT makes additional modifications to data in SHM, for example:

https://github.com/php/php-src/blob/d766e916815acafd30081cc686bd6cce64c82599/ext/opcache/jit/zend_jit_trace.c#L8173

https://github.com/php/php-src/blob/d766e916815acafd30081cc686bd6cce64c82599/ext/opcache/jit/zend_jit_trace.c#L8215

As well as other places. So this fix only works for non-JIT. At this point I'm not completely sure if the checksum still serves a purpose if various parts of the persistent script are allowed to get modified. It might make more sense to deprecate `opcache.consistency_checks` or make it a no-op at this point.

@dstogov Please let me know what you think.