### PR TITLE
Check at compile time that a built-in class is not being aliased

### DIFF
--- a/Zend/tests/use_statement/aliasing_builtin_types.phpt
+++ b/Zend/tests/use_statement/aliasing_builtin_types.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Aliasing built-in types
+--FILE--
+<?php
+
+/* Taken from zend_compile.c reserved_class_names[] struct */
+/* array and list are also added as they are language constructs */
+$types = [
+    "bool",
+    "false",
+    "float",
+    "int",
+    "null",
+    "parent",
+    "self",
+    "static",
+    "string",
+    "true",
+    "void",
+    "never",
+    "iterable",
+    "object",
+    "mixed",
+    "array",
+    "list",
+];
+
+foreach ($types as $type) {
+    try {
+        eval("use $type as A;");
+    } catch (\Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    }
+    try {
+        eval("use $type as A; function foo$type(A \$v): A { return \$v; }");
+    } catch (\Throwable $e) {
+        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+    }
+}
+
+?>
+DONE
+--EXPECT--
+CompileError: Cannot alias 'bool' as it is a built-in type
+CompileError: Cannot alias 'bool' as it is a built-in type
+CompileError: Cannot alias 'false' as it is a built-in type
+CompileError: Cannot alias 'false' as it is a built-in type
+CompileError: Cannot alias 'float' as it is a built-in type
+CompileError: Cannot alias 'float' as it is a built-in type
+CompileError: Cannot alias 'int' as it is a built-in type
+CompileError: Cannot alias 'int' as it is a built-in type
+CompileError: Cannot alias 'null' as it is a built-in type
+CompileError: Cannot alias 'null' as it is a built-in type
+CompileError: Cannot alias 'parent' as it is a built-in type
+CompileError: Cannot alias 'parent' as it is a built-in type
+CompileError: Cannot alias 'self' as it is a built-in type
+CompileError: Cannot alias 'self' as it is a built-in type
+ParseError: syntax error, unexpected token "static"
+ParseError: syntax error, unexpected token "static"
+CompileError: Cannot alias 'string' as it is a built-in type
+CompileError: Cannot alias 'string' as it is a built-in type
+CompileError: Cannot alias 'true' as it is a built-in type
+CompileError: Cannot alias 'true' as it is a built-in type
+CompileError: Cannot alias 'void' as it is a built-in type
+CompileError: Cannot alias 'void' as it is a built-in type
+CompileError: Cannot alias 'never' as it is a built-in type
+CompileError: Cannot alias 'never' as it is a built-in type
+CompileError: Cannot alias 'iterable' as it is a built-in type
+CompileError: Cannot alias 'iterable' as it is a built-in type
+CompileError: Cannot alias 'object' as it is a built-in type
+CompileError: Cannot alias 'object' as it is a built-in type
+CompileError: Cannot alias 'mixed' as it is a built-in type
+CompileError: Cannot alias 'mixed' as it is a built-in type
+ParseError: syntax error, unexpected token "array"
+ParseError: syntax error, unexpected token "array"
+ParseError: syntax error, unexpected token "list"
+ParseError: syntax error, unexpected token "list"
+DONE

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8056,6 +8056,13 @@ static void zend_compile_use(zend_ast *ast) /* {{{ */
 		zend_string *old_name = zend_ast_get_str(old_name_ast);
 		zend_string *new_name, *lookup_name;
 
+		/* Check that we are not attempting to alias a built-in type */
+		if (type == ZEND_SYMBOL_CLASS && zend_is_reserved_class_name(old_name)) {
+			zend_throw_exception_ex(zend_ce_compile_error, 0,
+				"Cannot alias '%s' as it is a built-in type", ZSTR_VAL(old_name));
+			return;
+		}
+
 		if (new_name_ast) {
 			new_name = zend_string_copy(zend_ast_get_str(new_name_ast));
 		} else {


### PR DESCRIPTION
If one tries to use such an alias as a type declaration the following error would be raised:
Fatal error: Cannot use 'int' as class name as it is reserved