### PR TITLE
Fix arginfo generation from stubs for namespaced functions

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -64,7 +64,7 @@ PHP 8.2 INTERNALS UPGRADE NOTES
 
 * Identifier names for namespaced functions generated from stub files through
   gen_stub.php have been changed. This will require changes in extensions using
-  namespaced funtions.
+  namespaced functions.
 
 ========================
 3. Module changes

--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -62,6 +62,10 @@ PHP 8.2 INTERNALS UPGRADE NOTES
 2. Build system changes
 ========================
 
+* Identifier names for namespaced functions generated from stub files through
+  gen_stub.php have been changed. This will require changes in extensions using
+  namespaced funtions.
+
 ========================
 3. Module changes
 ========================

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1383,22 +1383,42 @@ class FuncInfo {
             $declarationName = $this->name->getDeclarationName();
 
             if ($this->alias && $this->isDeprecated) {
-                return sprintf(
-                    "\tZEND_DEP_FALIAS(%s, %s, %s)\n",
-                    $declarationName, $this->alias->getNonNamespacedName(), $this->getArgInfoName()
-                );
+                if ($namespace) {
+                    return sprintf(
+                        "\tZEND_NS_DEP_FALIAS(\"%s\", %s, %s, %s)\n",
+                        addslashes($namespace), $declarationName, $this->alias->getNonNamespacedName(), $this->getArgInfoName()
+                    );
+                } else {
+                    return sprintf(
+                        "\tZEND_DEP_FALIAS(%s, %s, %s)\n",
+                        $declarationName, $this->alias->getNonNamespacedName(), $this->getArgInfoName()
+                    );
+                }
             }
 
             if ($this->alias) {
-                return sprintf(
-                    "\tZEND_FALIAS(%s, %s, %s)\n",
-                    $declarationName, $this->alias->getNonNamespacedName(), $this->getArgInfoName()
-                );
+                if ($namespace) {
+                    return sprintf(
+                        "\tZEND_NS_FALIAS(\"%s\", %s, %s, %s)\n",
+                        addslashes($namespace), $declarationName, $this->alias->getNonNamespacedName(), $this->getArgInfoName()
+                    );
+                } else {
+                    return sprintf(
+                        "\tZEND_FALIAS(%s, %s, %s)\n",
+                        $declarationName, $this->alias->getNonNamespacedName(), $this->getArgInfoName()
+                    );
+                }
             }
 
             if ($this->isDeprecated) {
-                return sprintf(
-                    "\tZEND_DEP_FE(%s, %s)\n", $declarationName, $this->getArgInfoName());
+                if ($namespace) {
+                    return sprintf(
+                        "\tZEND_NS_DEP_FE(\"%s\", %s, %s)\n",
+                        addslashes($namespace), $declarationName, $this->getArgInfoName());
+                } else {
+                    return sprintf(
+                        "\tZEND_DEP_FE(%s, %s)\n", $declarationName, $this->getArgInfoName());
+                }
             }
 
             if ($namespace) {

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1408,11 +1408,16 @@ class FuncInfo {
                 );
             }
 
-            $macro = match (true) {
-                $this->isDeprecated => 'ZEND_DEP_FE',
-                $this->supportsCompileTimeEval => 'ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE',
-                default => 'ZEND_FE',
-            };
+            switch (true) {
+                case $this->isDeprecated:
+                    $macro = 'ZEND_DEP_FE';
+                    break;
+                case $this->supportsCompileTimeEval:
+                    $macro = 'ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE';
+                    break;
+                default:
+                    $macro = 'ZEND_FE';
+            }
 
             return sprintf("\t%s(%s, %s)\n", $macro, $functionName, $this->getArgInfoName());
         } else {

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -95,6 +95,16 @@ static ZEND_FUNCTION(zend_test_deprecated)
 	zend_parse_parameters(ZEND_NUM_ARGS(), "|z", &arg1);
 }
 
+static ZEND_FUNCTION(zend_test_alias)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+}
+
+static ZEND_FUNCTION(zend_test_deprecated_alias)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+}
+
 /* Create a string without terminating null byte. Must be terminated with
  * zend_terminate_string() before destruction, otherwise a warning is issued
  * in debug builds. */
@@ -419,6 +429,21 @@ static ZEND_FUNCTION(namespaced_func)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 	RETURN_TRUE;
+}
+
+static ZEND_FUNCTION(namespaced_deprecated_func)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+}
+
+static ZEND_FUNCTION(namespaced_alias_func)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+}
+
+static ZEND_FUNCTION(namespaced_deprecated_alias_func)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
 }
 
 static ZEND_FUNCTION(zend_test_parameter_with_attribute)

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -425,13 +425,24 @@ static ZEND_FUNCTION(zend_test_zend_ini_parse_uquantity)
 	}
 }
 
-static ZEND_FUNCTION(namespaced_func)
+static ZEND_FUNCTION(ZendTestNS2_namespaced_func)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 	RETURN_TRUE;
 }
 
-static ZEND_FUNCTION(namespaced_deprecated_func)
+static ZEND_FUNCTION(ZendTestNS2_namespaced_deprecated_func)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+}
+
+static ZEND_FUNCTION(ZendTestNS2_ZendSubNS_namespaced_func)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	RETURN_TRUE;
+}
+
+static ZEND_FUNCTION(ZendTestNS2_ZendSubNS_namespaced_deprecated_func)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
 }

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -177,6 +177,20 @@ namespace ZendTestNS2 {
         public function method(): void {}
     }
 
+    function namespaced_func(): bool {}
+
+    /** @deprecated */
+    function namespaced_deprecated_func(): void {}
+
+    /** @alias namespaced_alias_func */
+    function namespaced_aliased_func(): void {}
+
+    /**
+      * @deprecated
+      * @alias namespaced_deprecated_alias_func
+      */
+    function namespaced_deprecated_aliased_func(): void {}
+
 }
 
 namespace ZendTestNS2\ZendSubNS {

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -109,6 +109,15 @@ namespace {
     /** @deprecated */
     function zend_test_deprecated(mixed $arg = null): void {}
 
+    /** @alias zend_test_alias */
+    function zend_test_aliased(): void {}
+
+    /**
+      * @deprecated
+      * @alias zend_test_deprecated_alias
+      */
+    function zend_test_deprecated_aliased(): void {}
+
     function zend_create_unterminated_string(string $str): string {}
 
     function zend_terminate_string(string &$str): void {}
@@ -177,5 +186,17 @@ namespace ZendTestNS2\ZendSubNS {
     }
 
     function namespaced_func(): bool {}
+
+    /** @deprecated */
+    function namespaced_deprecated_func(): void {}
+
+    /** @alias namespaced_alias_func */
+    function namespaced_aliased_func(): void {}
+
+    /**
+      * @deprecated
+      * @alias namespaced_deprecated_alias_func
+      */
+    function namespaced_deprecated_aliased_func(): void {}
 
 }

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: daa7be53e9009c66c814fb5b0407a6dfbe09679a */
+ * Stub hash: 24aed3e7e025fa45e571f99faa43e6b8ee9a7ae7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -19,6 +19,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_deprecated, 0, 0, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, arg, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
+
+#define arginfo_zend_test_aliased arginfo_zend_test_void_return
+
+#define arginfo_zend_test_deprecated_aliased arginfo_zend_test_void_return
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_create_unterminated_string, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, str, IS_STRING, 0)
@@ -94,6 +98,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_ZendSubNS_namespaced_func, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_func arginfo_zend_test_void_return
+
+#define arginfo_ZendTestNS2_ZendSubNS_namespaced_aliased_func arginfo_zend_test_void_return
+
+#define arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_aliased_func arginfo_zend_test_void_return
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class__ZendTestClass_is_object, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -144,6 +154,8 @@ static ZEND_FUNCTION(zend_test_nullable_array_return);
 static ZEND_FUNCTION(zend_test_void_return);
 static ZEND_FUNCTION(zend_test_compile_string);
 static ZEND_FUNCTION(zend_test_deprecated);
+static ZEND_FUNCTION(zend_test_alias);
+static ZEND_FUNCTION(zend_test_deprecated_alias);
 static ZEND_FUNCTION(zend_create_unterminated_string);
 static ZEND_FUNCTION(zend_terminate_string);
 static ZEND_FUNCTION(zend_leak_variable);
@@ -163,6 +175,9 @@ static ZEND_FUNCTION(zend_call_method);
 static ZEND_FUNCTION(zend_test_zend_ini_parse_quantity);
 static ZEND_FUNCTION(zend_test_zend_ini_parse_uquantity);
 static ZEND_FUNCTION(namespaced_func);
+static ZEND_FUNCTION(namespaced_deprecated_func);
+static ZEND_FUNCTION(namespaced_alias_func);
+static ZEND_FUNCTION(namespaced_deprecated_alias_func);
 static ZEND_METHOD(_ZendTestClass, is_object);
 static ZEND_METHOD(_ZendTestClass, __toString);
 static ZEND_METHOD(_ZendTestClass, returnsStatic);
@@ -187,6 +202,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_test_void_return, arginfo_zend_test_void_return)
 	ZEND_FE(zend_test_compile_string, arginfo_zend_test_compile_string)
 	ZEND_DEP_FE(zend_test_deprecated, arginfo_zend_test_deprecated)
+	ZEND_FALIAS(zend_test_aliased, zend_test_alias, arginfo_zend_test_aliased)
+	ZEND_DEP_FALIAS(zend_test_deprecated_aliased, zend_test_deprecated_alias, arginfo_zend_test_deprecated_aliased)
 	ZEND_FE(zend_create_unterminated_string, arginfo_zend_create_unterminated_string)
 	ZEND_FE(zend_terminate_string, arginfo_zend_terminate_string)
 	ZEND_FE(zend_leak_variable, arginfo_zend_leak_variable)
@@ -206,6 +223,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_test_zend_ini_parse_quantity, arginfo_zend_test_zend_ini_parse_quantity)
 	ZEND_FE(zend_test_zend_ini_parse_uquantity, arginfo_zend_test_zend_ini_parse_uquantity)
 	ZEND_NS_FE("ZendTestNS2\\ZendSubNS", namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)
+	ZEND_NS_DEP_FE("ZendTestNS2\\ZendSubNS", namespaced_deprecated_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_func)
+	ZEND_NS_FALIAS("ZendTestNS2\\ZendSubNS", namespaced_aliased_func, namespaced_alias_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_aliased_func)
+	ZEND_NS_DEP_FALIAS("ZendTestNS2\\ZendSubNS", namespaced_deprecated_aliased_func, namespaced_deprecated_alias_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_aliased_func)
 	ZEND_FE_END
 };
 

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 24aed3e7e025fa45e571f99faa43e6b8ee9a7ae7 */
+ * Stub hash: 0c3e4da20bf5b32e289a795e0beac649294e83f3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -95,8 +95,16 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_zend_test_zend_ini_parse_uquantity arginfo_zend_test_zend_ini_parse_quantity
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_ZendSubNS_namespaced_func, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_namespaced_func, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_ZendTestNS2_namespaced_deprecated_func arginfo_zend_test_void_return
+
+#define arginfo_ZendTestNS2_namespaced_aliased_func arginfo_zend_test_void_return
+
+#define arginfo_ZendTestNS2_namespaced_deprecated_aliased_func arginfo_zend_test_void_return
+
+#define arginfo_ZendTestNS2_ZendSubNS_namespaced_func arginfo_ZendTestNS2_namespaced_func
 
 #define arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_func arginfo_zend_test_void_return
 
@@ -118,7 +126,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class__ZendTestChildClass_returnsThrowable, 0, 0, Exception, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class__ZendTestTrait_testMethod arginfo_ZendTestNS2_ZendSubNS_namespaced_func
+#define arginfo_class__ZendTestTrait_testMethod arginfo_ZendTestNS2_namespaced_func
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ZendTestParameterAttribute___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, parameter, IS_STRING, 0)
@@ -174,10 +182,12 @@ static ZEND_FUNCTION(zend_get_current_func_name);
 static ZEND_FUNCTION(zend_call_method);
 static ZEND_FUNCTION(zend_test_zend_ini_parse_quantity);
 static ZEND_FUNCTION(zend_test_zend_ini_parse_uquantity);
-static ZEND_FUNCTION(namespaced_func);
-static ZEND_FUNCTION(namespaced_deprecated_func);
+static ZEND_FUNCTION(ZendTestNS2_namespaced_func);
+static ZEND_FUNCTION(ZendTestNS2_namespaced_deprecated_func);
 static ZEND_FUNCTION(namespaced_alias_func);
 static ZEND_FUNCTION(namespaced_deprecated_alias_func);
+static ZEND_FUNCTION(ZendTestNS2_ZendSubNS_namespaced_func);
+static ZEND_FUNCTION(ZendTestNS2_ZendSubNS_namespaced_deprecated_func);
 static ZEND_METHOD(_ZendTestClass, is_object);
 static ZEND_METHOD(_ZendTestClass, __toString);
 static ZEND_METHOD(_ZendTestClass, returnsStatic);
@@ -222,8 +232,12 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_call_method, arginfo_zend_call_method)
 	ZEND_FE(zend_test_zend_ini_parse_quantity, arginfo_zend_test_zend_ini_parse_quantity)
 	ZEND_FE(zend_test_zend_ini_parse_uquantity, arginfo_zend_test_zend_ini_parse_uquantity)
-	ZEND_NS_FE("ZendTestNS2\\ZendSubNS", namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)
-	ZEND_NS_DEP_FE("ZendTestNS2\\ZendSubNS", namespaced_deprecated_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_func)
+	ZEND_NS_FALIAS("ZendTestNS2", namespaced_func, ZendTestNS2_namespaced_func, arginfo_ZendTestNS2_namespaced_func)
+	ZEND_NS_DEP_FALIAS("ZendTestNS2", namespaced_deprecated_func, ZendTestNS2_namespaced_deprecated_func, arginfo_ZendTestNS2_namespaced_deprecated_func)
+	ZEND_NS_FALIAS("ZendTestNS2", namespaced_aliased_func, namespaced_alias_func, arginfo_ZendTestNS2_namespaced_aliased_func)
+	ZEND_NS_DEP_FALIAS("ZendTestNS2", namespaced_deprecated_aliased_func, namespaced_deprecated_alias_func, arginfo_ZendTestNS2_namespaced_deprecated_aliased_func)
+	ZEND_NS_FALIAS("ZendTestNS2\\ZendSubNS", namespaced_func, ZendTestNS2_ZendSubNS_namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)
+	ZEND_NS_DEP_FALIAS("ZendTestNS2\\ZendSubNS", namespaced_deprecated_func, ZendTestNS2_ZendSubNS_namespaced_deprecated_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_func)
 	ZEND_NS_FALIAS("ZendTestNS2\\ZendSubNS", namespaced_aliased_func, namespaced_alias_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_aliased_func)
 	ZEND_NS_DEP_FALIAS("ZendTestNS2\\ZendSubNS", namespaced_deprecated_aliased_func, namespaced_deprecated_alias_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_deprecated_aliased_func)
 	ZEND_FE_END


### PR DESCRIPTION
This PR fixes two issues:
The first commit ensures that the `@deprecated` and `@alias` annotations are respected for namespaced functions as well as for those without a namespace.
The second commit fixes an issue where having functions with the same name in multiple namespaces would generate two identical `ZEND_FUNCTION` entries. Note that this also significantly refactors the code used to generate function arginfo to reduce duplication.

Changes don't affect any existing arginfo files in core, as none of the default extensions use namespaced functions. However, the changes could cause issues in downstream code, namely if an extension uses stub files to generate arginfo for namespaces functions. I'm not sure how to best deal with this and would like some feedback as to what kind of BC breaks we can make in the build scripts.

Last but not least, there is one remaining edge case which I deliberately did not solve. Consider the following stub file:
```php
namespace Foo {
    function Bar_baz(): void {}
}

namespace Foo\Bar {
    function baz(): void {}
}
```

In this case, we would once again create two identical `ZEND_FUNCTION` entries in the arginfo file. This could also happen with classes as long as they are defined in the same stub file, as the script always uses a single underscore to replace a backslash in the fully qualified name without treating the namespace and member name differently. However, due to the extensive refactoring involved to fix this as well as the low probability of that happening, I decided to blatantly ignore that issue for the time being.