### PR TITLE
Fix GH-9411: PgSQL large object resource is incorrectly closed

### DIFF
--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -215,7 +215,7 @@ void pdo_pgsql_close_lob_streams(pdo_dbh_t *dbh)
 	if (H->lob_streams) {
 		ZEND_HASH_REVERSE_FOREACH_PTR(H->lob_streams, res) {
 			if (res->type >= 0) {
-				zend_resource_dtor(res);
+				zend_list_close(res);
 			}
 		} ZEND_HASH_FOREACH_END();
 	}

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -228,7 +228,7 @@ static int pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 		if (H->lob_streams) {
 			pdo_pgsql_close_lob_streams(dbh);
 			zend_hash_destroy(H->lob_streams);
-			pefree(H->lob_streams, 1);
+			pefree(H->lob_streams, dbh->is_persistent);
 			H->lob_streams = NULL;
 		}
 		if (H->server) {

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -226,7 +226,7 @@ static int pgsql_handle_closer(pdo_dbh_t *dbh) /* {{{ */
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	if (H) {
 		if (H->lob_streams) {
-			zend_close_rsrc_list(H->lob_streams);
+			pdo_pgsql_close_lob_streams(dbh);
 			zend_hash_destroy(H->lob_streams);
 			pefree(H->lob_streams, 1);
 			H->lob_streams = NULL;

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -210,9 +210,14 @@ php_stream *pdo_pgsql_create_lob_stream(zval *dbh, int lfd, Oid oid)
 
 void pdo_pgsql_close_lob_streams(pdo_dbh_t *dbh)
 {
+	zend_resource *res;
 	pdo_pgsql_db_handle *H = (pdo_pgsql_db_handle *)dbh->driver_data;
 	if (H->lob_streams) {
-		zend_close_rsrc_list(H->lob_streams);
+		ZEND_HASH_REVERSE_FOREACH_PTR(H->lob_streams, res) {
+			if (res->type >= 0) {
+				zend_resource_dtor(res);
+			}
+		} ZEND_HASH_FOREACH_END();
 	}
 }
 

--- a/ext/pdo_pgsql/pgsql_driver.c
+++ b/ext/pdo_pgsql/pgsql_driver.c
@@ -1268,7 +1268,7 @@ static int pdo_pgsql_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{
 	}
 
 	H->server = PQconnectdb(conn_str);
-	H->lob_streams = (HashTable *) pemalloc(sizeof(HashTable), 1);
+	H->lob_streams = (HashTable *) pemalloc(sizeof(HashTable), dbh->is_persistent);
 	zend_hash_init(H->lob_streams, 0, NULL, NULL, 1);
 
 	if (tmp_user) {

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -254,8 +254,8 @@ stmt_retry:
 		stmt->row_count = (zend_long)PQntuples(S->result);
 	}
 
-	if (!in_trans && stmt->dbh->methods->in_transaction(stmt->dbh)) {
-		++H->trans_counter;
+	if (in_trans && !stmt->dbh->methods->in_transaction(stmt->dbh)) {
+		pdo_pgsql_close_lob_streams(stmt->dbh);
 	}
 
 	return 1;

--- a/ext/pdo_pgsql/pgsql_statement.c
+++ b/ext/pdo_pgsql/pgsql_statement.c
@@ -134,6 +134,8 @@ static int pgsql_stmt_execute(pdo_stmt_t *stmt)
 	pdo_pgsql_db_handle *H = S->H;
 	ExecStatusType status;
 
+	bool in_trans = stmt->dbh->methods->in_transaction(stmt->dbh);
+
 	/* ensure that we free any previous unfetched results */
 	if(S->result) {
 		PQclear(S->result);
@@ -250,6 +252,10 @@ stmt_retry:
 		H->pgoid = PQoidValue(S->result);
 	} else {
 		stmt->row_count = (zend_long)PQntuples(S->result);
+	}
+
+	if (!in_trans && stmt->dbh->methods->in_transaction(stmt->dbh)) {
+		++H->trans_counter;
 	}
 
 	return 1;

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -45,7 +45,7 @@ typedef struct {
 	zend_bool		emulate_prepares;
 	zend_bool		disable_native_prepares; /* deprecated since 5.6 */
 	zend_bool		disable_prepares;
-	unsigned int	trans_counter;
+	HashTable       *lob_streams;
 } pdo_pgsql_db_handle;
 
 typedef struct {
@@ -96,7 +96,6 @@ struct pdo_pgsql_lob_self {
 	PGconn *conn;
 	int lfd;
 	Oid oid;
-	unsigned int trans_counter_value;
 };
 
 enum pdo_pgsql_specific_constants {
@@ -111,5 +110,6 @@ php_stream *pdo_pgsql_create_lob_stream(zval *pdh, int lfd, Oid oid);
 extern const php_stream_ops pdo_pgsql_lob_stream_ops;
 
 void pdo_libpq_version(char *buf, size_t len);
+void pdo_pgsql_close_lob_streams(pdo_dbh_t *dbh);
 
 #endif /* PHP_PDO_PGSQL_INT_H */

--- a/ext/pdo_pgsql/php_pdo_pgsql_int.h
+++ b/ext/pdo_pgsql/php_pdo_pgsql_int.h
@@ -45,6 +45,7 @@ typedef struct {
 	zend_bool		emulate_prepares;
 	zend_bool		disable_native_prepares; /* deprecated since 5.6 */
 	zend_bool		disable_prepares;
+	unsigned int	trans_counter;
 } pdo_pgsql_db_handle;
 
 typedef struct {
@@ -95,6 +96,7 @@ struct pdo_pgsql_lob_self {
 	PGconn *conn;
 	int lfd;
 	Oid oid;
+	unsigned int trans_counter_value;
 };
 
 enum pdo_pgsql_specific_constants {

--- a/ext/pdo_pgsql/tests/gh9411.phpt
+++ b/ext/pdo_pgsql/tests/gh9411.phpt
@@ -18,12 +18,24 @@ $db->beginTransaction();
 $oid = $db->pgsqlLOBCreate();
 var_dump($lob = $db->pgsqlLOBOpen($oid, 'wb'));
 fwrite($lob, 'test');
+$db->rollback();
+var_dump($lob);
+
+$db->beginTransaction();
+$oid = $db->pgsqlLOBCreate();
+var_dump($lob = $db->pgsqlLOBOpen($oid, 'wb'));
+fwrite($lob, 'test');
 $db->commit();
+var_dump($lob);
+
 $db->beginTransaction();
 var_dump($lob = $db->pgsqlLOBOpen($oid, 'wb'));
 var_dump(fgets($lob));
 ?>
 --EXPECTF--
 resource(%d) of type (stream)
+resource(%d) of type (Unknown)
+resource(%d) of type (stream)
+resource(%d) of type (Unknown)
 resource(%d) of type (stream)
 string(4) "test"

--- a/ext/pdo_pgsql/tests/gh9411.phpt
+++ b/ext/pdo_pgsql/tests/gh9411.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GitHub #9411 (Fix PgSQL large object resource is incorrectly closed)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo') || !extension_loaded('pdo_pgsql')) die('skip not loaded');
+require __DIR__ . '/config.inc';
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+
+$db->beginTransaction();
+$oid = $db->pgsqlLOBCreate();
+var_dump($lob = $db->pgsqlLOBOpen($oid, 'wb'));
+fwrite($lob, 'test');
+$db->commit();
+$db->beginTransaction();
+var_dump($lob = $db->pgsqlLOBOpen($oid, 'wb'));
+var_dump(fgets($lob));
+?>
+--EXPECTF--
+resource(%d) of type (stream)
+resource(%d) of type (stream)
+string(4) "test"


### PR DESCRIPTION
fix #9411 

The large object opened by the previous transaction was in fact closed when the transaction was committed.

The next transaction to open the large object returns the same `lfd` as the last open.

So use `trans_counter` to distinguish the stream of ldf is open in which transaction.

<https://www.postgresql.org/docs/current/lo-interfaces.html>

`PQtransactionStatus()` No io will not cause performance problems: <https://github.com/postgres/postgres/blob/HEAD/src/interfaces/libpq/fe-connect.c#L6775>