### PR TITLE
Fix typo (Paletter → Palette)

### DIFF
--- a/ext/gd/libgd/gd_webp.c
+++ b/ext/gd/libgd/gd_webp.c
@@ -113,7 +113,7 @@ void gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
 	}
 
 	if (!gdImageTrueColor(im)) {
-		zend_error(E_ERROR, "Paletter image not supported by webp");
+		zend_error(E_ERROR, "Palette image not supported by webp");
 		return;
 	}
 


### PR DESCRIPTION
This also aligns the error message with upstream[1].

[1] <https://github.com/libgd/libgd/blob/gd-2.3.3/src/gd_webp.c#L182>