### PR TITLE
Fix rand_range32() for umax = UINT32_MAX

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-9285 (Traits cannot be used in readonly classes).
     (kocsismate)
 
+- Random:
+  . Fixed bug GH-9415 (Randomizer::getInt(0, 2**32 - 1) with Mt19937
+    always returns 1). (timwolla)
+
 - Streams:
   . Fixed bug GH-9316 ($http_response_header is wrong for long status line).
     (cmb, timwolla)

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -107,7 +107,7 @@ static inline uint32_t rand_range32(const php_random_algo *algo, php_random_stat
 
 	/* Special case where no modulus is required */
 	if (UNEXPECTED(umax == UINT32_MAX)) {
-		return true;
+		return result;
 	}
 
 	/* Increment the max so range is inclusive of max */

--- a/ext/random/tests/03_randomizer/gh9415.phpt
+++ b/ext/random/tests/03_randomizer/gh9415.phpt
@@ -7,12 +7,13 @@ use Random\Randomizer;
 use Random\Engine\Mt19937;
 
 $randomizer = new Randomizer(new Mt19937(1234));
-var_dump($randomizer->getInt(0, 2**32 - 1));
+// Parameters shifted by -2147483648 to be compatible with 32-bit.
+var_dump($randomizer->getInt(-2147483648, 2147483647));
 
 $randomizer = new Randomizer(new Mt19937(4321));
-var_dump($randomizer->getInt(0, 2**32 - 1));
+var_dump($randomizer->getInt(-2147483648, 2147483647));
 
 ?>
 --EXPECT--
-int(822569775)
-int(304096061)
+int(-1324913873)
+int(-1843387587)

--- a/ext/random/tests/03_randomizer/gh9415.phpt
+++ b/ext/random/tests/03_randomizer/gh9415.phpt
@@ -9,10 +9,10 @@ use Random\Engine\Mt19937;
 $randomizer = new Randomizer(new Mt19937(1234));
 var_dump($randomizer->getInt(0, 2**32 - 1));
 
-$randomizer = new Randomizer(new Mt19937());
-var_dump($randomizer->getInt(0, 2**32 - 1) !== 1 || $randomizer->getInt(0, 2**32 - 1) !== $randomizer->getInt(0, 2**32 - 1));
+$randomizer = new Randomizer(new Mt19937(4321));
+var_dump($randomizer->getInt(0, 2**32 - 1));
 
 ?>
 --EXPECT--
 int(822569775)
-bool(true)
+int(304096061)

--- a/ext/random/tests/03_randomizer/gh9415.phpt
+++ b/ext/random/tests/03_randomizer/gh9415.phpt
@@ -6,11 +6,11 @@ GH-9415: Randomizer::getInt(0, 2**32 - 1) with Mt19937 always returns 1
 use Random\Randomizer;
 use Random\Engine\Mt19937;
 
-$r = new Randomizer(new Mt19937(1234));
-var_dump($r->getInt(0, 2**32 - 1));
+$randomizer = new Randomizer(new Mt19937(1234));
+var_dump($randomizer->getInt(0, 2**32 - 1));
 
-$r = new Randomizer(new Mt19937());
-var_dump($r->getInt(0, 2**32 - 1) !== 1 || $r->getInt(0, 2**32 - 1) !== $r->getInt(0, 2**32 - 1));
+$randomizer = new Randomizer(new Mt19937());
+var_dump($randomizer->getInt(0, 2**32 - 1) !== 1 || $randomizer->getInt(0, 2**32 - 1) !== $randomizer->getInt(0, 2**32 - 1));
 
 ?>
 --EXPECT--

--- a/ext/random/tests/03_randomizer/gh9415.phpt
+++ b/ext/random/tests/03_randomizer/gh9415.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-9415: Randomizer::getInt(0, 2**32 - 1) with Mt19937 always returns 1
+--FILE--
+<?php
+
+use Random\Randomizer;
+use Random\Engine\Mt19937;
+
+$r = new Randomizer(new Mt19937(1234));
+var_dump($r->getInt(0, 2**32 - 1));
+
+$r = new Randomizer(new Mt19937());
+var_dump($r->getInt(0, 2**32 - 1) !== 1 || $r->getInt(0, 2**32 - 1) !== $r->getInt(0, 2**32 - 1));
+
+?>
+--EXPECT--
+int(822569775)
+bool(true)


### PR DESCRIPTION
This was introduced in the commit that added the random extension:
4d8dd8d258ff365b146bcadcb277ede8992706d0.

Resolves GH-9415