### PR TITLE
xmlRelaxNGCleanupTypes() is deprecated as of libxml2 2.10.0

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -775,7 +775,7 @@ PHP_LIBXML_API void php_libxml_initialize(void)
 PHP_LIBXML_API void php_libxml_shutdown(void)
 {
 	if (_php_libxml_initialized) {
-#ifdef LIBXML_SCHEMAS_ENABLED
+#if defined(LIBXML_SCHEMAS_ENABLED) && LIBXML_VERSION < 21000
 		xmlRelaxNGCleanupTypes();
 #endif
 		/* xmlCleanupParser(); */


### PR DESCRIPTION
The documentation[1] suggest to call `xmlCleanupParser()` instead, but
we are not doing that for reasons[2].  Thus, we do no longer call
`xmlRelaxNGCleanupTypes()` for libxml2 ≥ 2.10.0.

[1] <https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-relaxng.html#xmlRelaxNGCleanupTypes>
[2] <https://github.com/php/php-src/commit/8742276eb3905eb97a585417000c7b8df85006d4>