### PR TITLE
Select `rand_rangeXX()` variant only based on the requested range

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ PHP                                                                        NEWS
 - Random:
   . Fixed bug GH-9415 (Randomizer::getInt(0, 2**32 - 1) with Mt19937
     always returns 1). (timwolla)
+  . Fixed Randomizer::getInt() consistency for 32-bit engines. (timwolla)
 
 - Streams:
   . Fixed bug GH-9316 ($http_response_header is wrong for long status line).

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -313,7 +313,7 @@ PHPAPI zend_long php_random_range(const php_random_algo *algo, php_random_status
 {
 	zend_ulong umax = (zend_ulong) max - (zend_ulong) min;
 
-	if (algo->generate_size == 0 || algo->generate_size > sizeof(uint32_t) || umax > UINT32_MAX) {
+	if (umax > UINT32_MAX) {
 		return (zend_long) (rand_range64(algo, status, umax) + min);
 	}
 


### PR DESCRIPTION
This fixes an incompatibility when wrapping native 32-bit engines with a userland
engine. The latter always used the 64-bit range function which then used two
32-bit numbers from the underlying engine to fill the 64-bit range, whereas the
native implementation used only one.

Now the selection of the range variant only depends on the requested range. A
32-bit range uses the 32-bit variant (even for 64-bit engines), whereas a
larger range uses the 64-bit variant.

This was found in https://github.com/php/php-src/pull/9410#discussion_r953213000