### PR TITLE
Fix pdo_dblib ext test conflicts when run in parallel

### DIFF
--- a/ext/pdo_dblib/tests/CONFLICTS
+++ b/ext/pdo_dblib/tests/CONFLICTS
@@ -1,0 +1,1 @@
+pdo_dblib


### PR DESCRIPTION
I was checking if Oracle test issues are gone, they are, but I saw: https://github.com/php/php-src/runs/8033123653?check_suite_focus=true#step:10:1401

so fix it like https://github.com/php/php-src/pull/9424