### PR TITLE
Add a bit of verbosity in FPM logs

### DIFF
--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -218,7 +218,7 @@ stdio_read:
 			zlog_stream_finish(log_stream);
 		}
 		if (read_fail < 0) {
-			zlog(ZLOG_SYSERROR, "unable to read what child say");
+			zlog(ZLOG_SYSERROR, "unable to read what child %d said into %s", (int) child->pid, is_stdout ? "stdout" : "stderr");
 		}
 
 		fpm_event_del(event);


### PR DESCRIPTION
One more patch was found in our repository. When FPM fails to read from its children, it might be a good idea to know which process we communicated with as the FPM typically has lots of children processes.

Could you please take a look if might be useful? Please, let me know if something needs to be improved.