### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/close-needs-feedback.yml
+++ b/.github/workflows/close-needs-feedback.yml
@@ -4,10 +4,16 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+# top level permissions for all jobs
+# each job gets its own specific write permission
+permissions: {} # none
+
 jobs:
   build:
     if: github.repository_owner == 'php'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Close old issues that need feedback
         uses: dwieeb/needs-reply@v2

--- a/.github/workflows/close-needs-feedback.yml
+++ b/.github/workflows/close-needs-feedback.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-# top level permissions for all jobs
-# each job gets its own specific write permission
 permissions: {} # none
 
 jobs:

--- a/.github/workflows/close-stale-feature-requests.yml
+++ b/.github/workflows/close-stale-feature-requests.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v4
         with:

--- a/.github/workflows/close-stale-feature-requests.yml
+++ b/.github/workflows/close-stale-feature-requests.yml
@@ -4,10 +4,14 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {} # none
+
 jobs:
   stale:
     if: github.repository_owner == 'php'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/stale@v4
         with:

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -4,10 +4,15 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {} # none
+
 jobs:
   stale:
     if: github.repository_owner == 'php'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,11 +3,14 @@ on:
   schedule:
    - cron: "0 1 * * *"
   workflow_dispatch: ~
+permissions: {} # none
 jobs:
   GENERATE_MATRIX:
     name: Generate Matrix
     if: github.repository_owner == 'php' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       branches: ${{ steps.set-matrix.outputs.branches }}
       asan-matrix: ${{ steps.set-matrix.outputs.asan-matrix }}
@@ -42,6 +45,8 @@ jobs:
         include: ${{ fromJson(needs.GENERATE_MATRIX.outputs.asan-matrix) }}
     name: "${{ matrix.branch.name }}_LINUX_X64${{ matrix.name }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -112,6 +117,8 @@ jobs:
         zts: [true, false]
     name: "${{ matrix.branch.name }}_MACOS_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
     runs-on: macos-11
+    permissions:
+      contents: read
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -166,6 +173,8 @@ jobs:
         uses: ./.github/actions/verify-generated-files
   COVERAGE_DEBUG_NTS:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
       - name: git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     branches:
       - '**'
+permissions: {} # none
 jobs:
   LINUX_X64:
     strategy:
@@ -29,6 +30,8 @@ jobs:
             zts: true
     name: "LINUX_X64_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -66,6 +69,8 @@ jobs:
         uses: ./.github/actions/verify-generated-files
   MACOS_DEBUG_NTS:
     runs-on: macos-11
+    permissions:
+      contents: read
     steps:
       - name: git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/remove-needs-feedback.yml
+++ b/.github/workflows/remove-needs-feedback.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+permissions: {} # none
+
 jobs:
   build:
     if: "github.repository_owner == 'php' && contains(github.event.issue.labels.*.name, 'Status: Needs Feedback') && github.event.issue.user.login == github.event.sender.login"
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.
