### PR TITLE
Fix GH-8517: FPM child pointer can be possibly uninitialized

### DIFF
--- a/sapi/fpm/fpm/fpm_children.c
+++ b/sapi/fpm/fpm/fpm_children.c
@@ -121,7 +121,7 @@ static void fpm_child_unlink(struct fpm_child_s *child) /* {{{ */
 }
 /* }}} */
 
-static struct fpm_child_s *fpm_child_find(pid_t pid) /* {{{ */
+struct fpm_child_s *fpm_child_find(pid_t pid) /* {{{ */
 {
 	struct fpm_worker_pool_s *wp;
 	struct fpm_child_s *child = 0;

--- a/sapi/fpm/fpm/fpm_children.h
+++ b/sapi/fpm/fpm/fpm_children.h
@@ -10,13 +10,14 @@
 #include "fpm_events.h"
 #include "zlog.h"
 
+struct fpm_child_s;
+
 int fpm_children_create_initial(struct fpm_worker_pool_s *wp);
 int fpm_children_free(struct fpm_child_s *child);
 void fpm_children_bury();
 int fpm_children_init_main();
 int fpm_children_make(struct fpm_worker_pool_s *wp, int in_event_loop, int nb_to_spawn, int is_debug);
-
-struct fpm_child_s;
+struct fpm_child_s *fpm_child_find(pid_t pid);
 
 struct fpm_child_s {
 	struct fpm_child_s *prev, *next;

--- a/sapi/fpm/fpm/fpm_stdio.c
+++ b/sapi/fpm/fpm/fpm_stdio.c
@@ -129,7 +129,10 @@ static void fpm_stdio_child_said(struct fpm_event_s *ev, short which, void *arg)
 	if (!arg) {
 		return;
 	}
-	child = (struct fpm_child_s *)arg;
+	child = fpm_child_find((intptr_t) arg);
+	if (!child) {
+		return;
+	}
 
 	is_stdout = (fd == child->fd_stdout);
 	if (is_stdout) {
@@ -275,10 +278,10 @@ int fpm_stdio_parent_use_pipes(struct fpm_child_s *child) /* {{{ */
 	child->fd_stdout = fd_stdout[0];
 	child->fd_stderr = fd_stderr[0];
 
-	fpm_event_set(&child->ev_stdout, child->fd_stdout, FPM_EV_READ, fpm_stdio_child_said, child);
+	fpm_event_set(&child->ev_stdout, child->fd_stdout, FPM_EV_READ, fpm_stdio_child_said, (void *) (intptr_t) child->pid);
 	fpm_event_add(&child->ev_stdout, 0);
 
-	fpm_event_set(&child->ev_stderr, child->fd_stderr, FPM_EV_READ, fpm_stdio_child_said, child);
+	fpm_event_set(&child->ev_stderr, child->fd_stderr, FPM_EV_READ, fpm_stdio_child_said, (void *) (intptr_t) child->pid);
 	fpm_event_add(&child->ev_stderr, 0);
 	return 0;
 }


### PR DESCRIPTION
The idea is that there might be a moment when the child log event is executed after freeing child. That could possibly happen if child output is triggered at the same time like terminating the child. Then the output event could be potentially processed after the terminating event which would cause this kind of issue. 

The issue might got more visible after introducing the `log_stream` on child because it is more likely that this cannot be dereferenced after free. However it is very hard to reproduce this issue so this is still a guess based on the logs and code.