### PR TITLE
No longer allow block mode for declare(encoding)

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6109,6 +6109,11 @@ static void zend_compile_declare(zend_ast *ast) /* {{{ */
 				zend_error_noreturn(E_COMPILE_ERROR, "Encoding declaration pragma must be "
 					"the very first statement in the script");
 			}
+
+			if (ast->child[1] != NULL) {
+				zend_error_noreturn(E_COMPILE_ERROR, "Encoding declaration pragma must not "
+					"use block mode");
+			}
 		} else if (zend_string_equals_literal_ci(name, "strict_types")) {
 			zval value_zv;
 


### PR DESCRIPTION
As discussed in #9446, this isn't properly supported, and it is
doubtful if it ever can be useful, let alone if it could be properly
supported.  Therefore, we disallow the confusing block mode in the
first place.