### PR TITLE
Fix GH-9139: Allow FFI in opcache.preload when opcache.preload_user=root

### DIFF
--- a/ext/ffi/tests/300.phpt
+++ b/ext/ffi/tests/300.phpt
@@ -6,7 +6,6 @@ opcache
 --SKIPIF--
 <?php
 if (substr(PHP_OS, 0, 3) == 'WIN') die('skip not for Windows');
-if (ini_get('opcache.preload_user')) die('skip FFI::load() does not support opcache.preload_user');
 ?>
 --INI--
 ffi.enable=1

--- a/ext/ffi/tests/bug78761.phpt
+++ b/ext/ffi/tests/bug78761.phpt
@@ -5,7 +5,6 @@ ffi
 --SKIPIF--
 <?php
 if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
-if (ini_get('opcache.preload_user')) die('skip FFI::load() does not support opcache.preload_user');
 ?>
 --INI--
 opcache.enable_cli=1

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4604,14 +4604,15 @@ static int accel_finish_startup(void)
 			return SUCCESS;
 		}
 
-		if (geteuid() == 0) {
+		uid_t euid = geteuid();
+		if (euid == 0) {
 			pid_t pid;
 			struct passwd *pw;
 
 			if (!ZCG(accel_directives).preload_user
 			 || !*ZCG(accel_directives).preload_user) {
 				zend_shared_alloc_unlock();
-				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "\"opcache.preload_user\" has not been defined");
+				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "\"opcache.preload\" requires \"opcache.preload_user\" when running under uid 0");
 				return FAILURE;
 			}
 
@@ -4622,43 +4623,45 @@ static int accel_finish_startup(void)
 				return FAILURE;
 			}
 
-			pid = fork();
-			if (pid == -1) {
-				zend_shared_alloc_unlock();
-				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to fork()");
-				return FAILURE;
-			} else if (pid == 0) { /* children */
-				if (setgid(pw->pw_gid) < 0) {
-					zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setgid(%d)", pw->pw_gid);
-					exit(1);
-				}
-				if (initgroups(pw->pw_name, pw->pw_gid) < 0) {
-					zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to initgroups(\"%s\", %d)", pw->pw_name, pw->pw_uid);
-					exit(1);
-				}
-				if (setuid(pw->pw_uid) < 0) {
-					zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setuid(%d)", pw->pw_uid);
-					exit(1);
-				}
-				in_child = true;
-			} else { /* parent */
-				int status;
-
-				if (waitpid(pid, &status, 0) < 0) {
+			if (pw->pw_uid != euid) {
+				pid = fork();
+				if (pid == -1) {
 					zend_shared_alloc_unlock();
-					zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to waitpid(%d)", pid);
+					zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to fork()");
 					return FAILURE;
-				}
+				} else if (pid == 0) { /* children */
+					if (setgid(pw->pw_gid) < 0) {
+						zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setgid(%d)", pw->pw_gid);
+						exit(1);
+					}
+					if (initgroups(pw->pw_name, pw->pw_gid) < 0) {
+						zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to initgroups(\"%s\", %d)", pw->pw_name, pw->pw_uid);
+						exit(1);
+					}
+					if (setuid(pw->pw_uid) < 0) {
+						zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setuid(%d)", pw->pw_uid);
+						exit(1);
+					}
+					in_child = true;
+				} else { /* parent */
+					int status;
 
-				if (ZCSG(preload_script)) {
-					preload_load();
-				}
+					if (waitpid(pid, &status, 0) < 0) {
+						zend_shared_alloc_unlock();
+						zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to waitpid(%d)", pid);
+						return FAILURE;
+					}
 
-				zend_shared_alloc_unlock();
-				if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
-					return SUCCESS;
-				} else {
-					return FAILURE;
+					if (ZCSG(preload_script)) {
+						preload_load();
+					}
+
+					zend_shared_alloc_unlock();
+					if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+						return SUCCESS;
+					} else {
+						return FAILURE;
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
`opcache.preload` can not be used for FFI preloading when running as root, because of a chain of causes:

- `opcache.preload` requires `opcache.preload_user` when running as root
- FFI does not work when `opcache.preload_user` is defined, because the preloading happens in a sub-process in this case

It is not strictly necessary to preload in a sub-process when `opcache.preload_user` is the current user, because we are not going to change the uid of the process.

This PR skips the fork() when `opcache.preload_user` is the current user, thus allowing FFI in `opcache.preload` when running as root, as long as `opcache.preload_user=root`.

Although running as root is not recommended, it is common practice with docker containers. This change also allows to have at least one CI pipeline running as root.

Fixes https://github.com/php/php-src/issues/9139

Most changes are whitespaces.