### PR TITLE
Support sapi/cli/tests/017.phpt on Windows, too

### DIFF
--- a/sapi/cli/tests/017.phpt
+++ b/sapi/cli/tests/017.phpt
@@ -8,13 +8,12 @@ include "skipif.inc";
 if (readline_info('done') !== NULL) {
     die ("skip need readline support using libedit");
 }
-if(substr(PHP_OS, 0, 3) == 'WIN' ) {
-    die('skip not for Windows');
-}
 ?>
 --FILE--
 <?php
 $php = getenv('TEST_PHP_EXECUTABLE');
+$ini = getenv('TEST_PHP_EXTRA_ARGS');
+$descriptorspec = [['pipe', 'r'], STDOUT, STDERR];
 
 $codes = array();
 
@@ -55,8 +54,10 @@ EOT;
 
 foreach ($codes as $key => $code) {
     echo "\n--------------\nSnippet no. $key:\n--------------\n";
-    $code = escapeshellarg($code);
-    echo `echo $code | "$php" -a`, "\n";
+    $proc = proc_open("$php $ini -a", $descriptorspec, $pipes);
+    fwrite($pipes[0], $code);
+    fclose($pipes[0]);
+    proc_close($proc);
 }
 
 echo "\nDone\n";
@@ -69,7 +70,6 @@ Interactive shell
 
 Hello world
 
-
 --------------
 Snippet no. 2:
 --------------
@@ -78,7 +78,6 @@ Interactive shell
 multine
 single
 quote
-
 
 --------------
 Snippet no. 3:
@@ -90,14 +89,12 @@ comes
 the
 doc
 
-
 --------------
 Snippet no. 4:
 --------------
 Interactive shell
 
 Done
-
 
 --------------
 Snippet no. 5:
@@ -106,6 +103,5 @@ Interactive shell
 
 
 Parse error: Unmatched ')' in php shell code on line 1
-
 
 Done


### PR DESCRIPTION
`escapeshellarg()` is pretty useless on Windows, and there is no way to
support multiple lines (i.e. line breaks).  Thus, we use `proc_open()`
instead of `shell_exec()`.

We also remove some apparently superfluous empty lines from the test
expectation; that seems to match libedit behavior on Linux.