### PR TITLE
A simple check for CommonCrypto/CommonRandom.h does not work on earlier

### DIFF
--- a/ext/random/config.m4
+++ b/ext/random/config.m4
@@ -7,7 +7,12 @@ dnl
 dnl Check for CCRandomGenerateBytes
 dnl header absent in previous macOs releases
 dnl
-AC_CHECK_HEADERS([CommonCrypto/CommonRandom.h])
+AC_CHECK_HEADERS([CommonCrypto/CommonRandom.h], [], [],
+[
+	#include <sys/types.h>
+	#include <Availability.h>
+	#include <CommonCrypto/CommonCryptoError.h>
+])
 
 dnl
 dnl Setup extension

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -407,7 +407,12 @@ dnl
 dnl Check for CCRandomGenerateBytes
 dnl header absent in previous macOs releases
 dnl
-AC_CHECK_HEADERS([CommonCrypto/CommonRandom.h])
+AC_CHECK_HEADERS([CommonCrypto/CommonRandom.h], [], [],
+[
+	#include <sys/types.h>
+	#include <Availability.h>
+	#include <CommonCrypto/CommonCryptoError.h>
+])
 
 dnl
 dnl Check for argon2


### PR DESCRIPTION
macOS. Must also pull in sys/types.h for size_t, Availability.h for
__OSX_AVAILABLE_STARTING, and CommonCrypto/CommonCryptoError.h for
CCCryptorStatus. Fixes GH #9464.