### PR TITLE
Remove obsolete checks for random-related functionality from ext/standard/config.m4

### DIFF
--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -399,22 +399,6 @@ if test "$ac_cv_strptime_decl_fails" = "yes"; then
 fi
 
 dnl
-dnl Check for arc4random on BSD systems
-dnl
-AC_CHECK_DECLS([arc4random_buf])
-
-dnl
-dnl Check for CCRandomGenerateBytes
-dnl header absent in previous macOs releases
-dnl
-AC_CHECK_HEADERS([CommonCrypto/CommonRandom.h], [], [],
-[
-	#include <sys/types.h>
-	#include <Availability.h>
-	#include <CommonCrypto/CommonCryptoError.h>
-])
-
-dnl
 dnl Check for argon2
 dnl
 PHP_ARG_WITH([password-argon2],


### PR DESCRIPTION
The users of these checks have been moved to ext/random. ext/standard does not
reference the resulting defines.