### PR TITLE
Fix GH-9420: Allow native parameter attributes on promoted properties

### DIFF
--- a/Zend/tests/function_arguments/sensitive_parameter_promoted_property.phpt
+++ b/Zend/tests/function_arguments/sensitive_parameter_promoted_property.phpt
@@ -1,0 +1,43 @@
+--TEST--
+The SensitiveParameter attribute works as well with promoted properties.
+--FILE--
+<?php
+
+class WithSensitiveParameter
+{
+    public function __construct(#[SensitiveParameter] public string $password)
+    {
+        var_dump(debug_backtrace());
+    }
+}
+
+new WithSensitiveParameter('sensitive');
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(7) {
+    ["file"]=>
+    string(%d) "%ssensitive_parameter_promoted_property.php"
+    ["line"]=>
+    int(11)
+    ["function"]=>
+    string(11) "__construct"
+    ["class"]=>
+    string(22) "WithSensitiveParameter"
+    ["object"]=>
+    object(WithSensitiveParameter)#1 (1) {
+      ["password"]=>
+      string(9) "sensitive"
+    }
+    ["type"]=>
+    string(2) "->"
+    ["args"]=>
+    array(1) {
+      [0]=>
+      object(SensitiveParameterValue)#2 (0) {
+      }
+    }
+  }
+}

--- a/Zend/tests/function_arguments/sensitive_parameter_promoted_property_reflection.phpt
+++ b/Zend/tests/function_arguments/sensitive_parameter_promoted_property_reflection.phpt
@@ -1,0 +1,30 @@
+--TEST--
+The SensitiveParameter attribute can not be instantiated against property
+--FILE--
+<?php
+
+class WithSensitiveParameter
+{
+    public function __construct(#[SensitiveParameter] public string $password)
+    {
+    }
+}
+$reflection = (new ReflectionClass(WithSensitiveParameter::class));
+
+var_dump(
+    [
+        'parameterAttribute' => $reflection->getConstructor()->getParameters()[0]->getAttributes()[0]->newInstance(),
+        'propertyAttribute' => $reflection->getProperties()[0]->getAttributes(),
+    ]
+);
+
+?>
+--EXPECTF--
+array(2) {
+  ["parameterAttribute"]=>
+  object(SensitiveParameter)#3 (0) {
+  }
+  ["propertyAttribute"]=>
+  array(0) {
+  }
+}

--- a/Zend/tests/function_arguments/sensitive_parameter_regular_property.phpt
+++ b/Zend/tests/function_arguments/sensitive_parameter_regular_property.phpt
@@ -1,0 +1,14 @@
+--TEST--
+The SensitiveParameter attribute leads to fatal error on non-promoted properties.
+--FILE--
+<?php
+
+class WithSensitiveParameter
+{
+    #[SensitiveParameter]
+    public string $prop;
+}
+
+?>
+--EXPECTF--
+Fatal error: Attribute "SensitiveParameter" cannot target property (allowed targets: parameter) in %ssensitive_parameter_regular_property.php on line 6

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6550,7 +6550,7 @@ static void zend_compile_attributes(HashTable **attributes, zend_ast *ast, uint3
 
 	zend_ast_list *list = zend_ast_get_list(ast);
 	uint32_t g, i, j;
-	uint32_t addedAttributesCount = 0;
+	uint32_t added_attributes_count = 0;
 
 	ZEND_ASSERT(ast->kind == ZEND_AST_ATTRIBUTE_LIST);
 
@@ -6593,7 +6593,7 @@ static void zend_compile_attributes(HashTable **attributes, zend_ast *ast, uint3
 
 			attr = zend_add_attribute(
 				attributes, name, args ? args->children : 0, flags, offset, el->lineno);
-			addedAttributesCount++;
+			added_attributes_count++;
 			zend_string_release(name);
 
 			/* Populate arguments */
@@ -6634,7 +6634,7 @@ static void zend_compile_attributes(HashTable **attributes, zend_ast *ast, uint3
 		}
 	}
 
-	if (addedAttributesCount == 0) {
+	if (added_attributes_count == 0) {
 		// Attributes wasn't initialized
 		return;
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6550,7 +6550,7 @@ static void zend_compile_attributes(HashTable **attributes, zend_ast *ast, uint3
 
 	zend_ast_list *list = zend_ast_get_list(ast);
 	uint32_t g, i, j;
-	uint32_t added = 0;
+	uint32_t addedAttributesCount = 0;
 
 	ZEND_ASSERT(ast->kind == ZEND_AST_ATTRIBUTE_LIST);
 
@@ -6581,13 +6581,11 @@ static void zend_compile_attributes(HashTable **attributes, zend_ast *ast, uint3
 			zend_string_release(lcname);
 
 			if (
-					config != NULL
-					// If attribute is targeted to PARAMETER only ...
-					&& (ZEND_ATTRIBUTE_TARGET_PARAMETER & config->flags)
-					&& !(ZEND_ATTRIBUTE_TARGET_PROPERTY & config->flags)
-					// ... and current target is promoted property ...
-					&& (target & ZEND_ATTRIBUTE_TARGET_PROPERTY)
-					&& (target & ZEND_ATTRIBUTE_TARGET_PARAMETER)) {
+				config != NULL
+				// If attribute is targeted to PARAMETER only ...
+				&& (config->flags & ZEND_ATTRIBUTE_TARGET_ALL) == ZEND_ATTRIBUTE_TARGET_PARAMETER
+				// ... and current target is promoted property ...
+				&& target == (ZEND_ATTRIBUTE_TARGET_PROPERTY | ZEND_ATTRIBUTE_TARGET_PARAMETER)) {
 				// ... then skip processing as it was already linked to parameter
 				zend_string_release(name);
 				continue;
@@ -6595,7 +6593,7 @@ static void zend_compile_attributes(HashTable **attributes, zend_ast *ast, uint3
 
 			attr = zend_add_attribute(
 				attributes, name, args ? args->children : 0, flags, offset, el->lineno);
-			added++;
+			addedAttributesCount++;
 			zend_string_release(name);
 
 			/* Populate arguments */
@@ -6636,8 +6634,8 @@ static void zend_compile_attributes(HashTable **attributes, zend_ast *ast, uint3
 		}
 	}
 
-	if (added == 0) {
-		// attributes wasn't initialized
+	if (addedAttributesCount == 0) {
+		// Attributes wasn't initialized
 		return;
 	}
 


### PR DESCRIPTION
Skip zend_add_attribute and checks for internal attributes
with target=parameter on promoted properties during compilation

Continuing the discussion [9457](https://github.com/php/php-src/pull/9457)