### PR TITLE
Use php_info_print_table_header for actual column headers only

### DIFF
--- a/ext/com_dotnet/com_extension.c
+++ b/ext/com_dotnet/com_extension.c
@@ -256,13 +256,13 @@ PHP_MINFO_FUNCTION(com_dotnet)
 {
 	php_info_print_table_start();
 
-	php_info_print_table_header(2, "COM support", "enabled");
-	php_info_print_table_header(2, "DCOM support", COMG(allow_dcom) ? "enabled" : "disabled");
+	php_info_print_table_row(2, "COM support", "enabled");
+	php_info_print_table_row(2, "DCOM support", COMG(allow_dcom) ? "enabled" : "disabled");
 
 #if HAVE_MSCOREE_H
-	php_info_print_table_header(2, ".Net support", "enabled");
+	php_info_print_table_row(2, ".Net support", "enabled");
 #else
-	php_info_print_table_header(2, ".Net support", "not present in this build");
+	php_info_print_table_row(2, ".Net support", "not present in this build");
 #endif
 
 	php_info_print_table_end();

--- a/ext/dl_test/dl_test.c
+++ b/ext/dl_test/dl_test.c
@@ -123,7 +123,7 @@ PHP_RINIT_FUNCTION(dl_test)
 PHP_MINFO_FUNCTION(dl_test)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "dl_test support", "enabled");
+	php_info_print_table_row(2, "dl_test support", "enabled");
 	php_info_print_table_end();
 
 	DISPLAY_INI_ENTRIES();

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -5465,7 +5465,7 @@ ZEND_RSHUTDOWN_FUNCTION(ffi)
 ZEND_MINFO_FUNCTION(ffi)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "FFI support", "enabled");
+	php_info_print_table_row(2, "FFI support", "enabled");
 	php_info_print_table_end();
 
 	DISPLAY_INI_ENTRIES();

--- a/ext/intl/php_intl.c
+++ b/ext/intl/php_intl.c
@@ -257,7 +257,7 @@ PHP_MINFO_FUNCTION( intl )
 #endif
 
 	php_info_print_table_start();
-	php_info_print_table_header( 2, "Internationalization support", "enabled" );
+	php_info_print_table_row( 2, "Internationalization support", "enabled" );
 	php_info_print_table_row( 2, "ICU version", U_ICU_VERSION );
 #ifdef U_ICU_DATA_VERSION
 	php_info_print_table_row( 2, "ICU Data version", U_ICU_DATA_VERSION );

--- a/ext/mysqli/mysqli.c
+++ b/ext/mysqli/mysqli.c
@@ -588,7 +588,7 @@ PHP_MINFO_FUNCTION(mysqli)
 	char buf[32];
 
 	php_info_print_table_start();
-	php_info_print_table_header(2, "MysqlI Support", "enabled");
+	php_info_print_table_row(2, "MysqlI Support", "enabled");
 	php_info_print_table_row(2, "Client API library version", mysql_get_client_info());
 	snprintf(buf, sizeof(buf), ZEND_LONG_FMT, MyG(num_active_persistent));
 	php_info_print_table_row(2, "Active Persistent Links", buf);

--- a/ext/mysqlnd/php_mysqlnd.c
+++ b/ext/mysqlnd/php_mysqlnd.c
@@ -79,7 +79,7 @@ PHP_MINFO_FUNCTION(mysqlnd)
 	char buf[32];
 
 	php_info_print_table_start();
-	php_info_print_table_header(2, "mysqlnd", "enabled");
+	php_info_print_table_row(2, "mysqlnd", "enabled");
 	php_info_print_table_row(2, "Version", mysqlnd_get_client_info());
 	php_info_print_table_row(2, "Compression",
 #ifdef MYSQLND_COMPRESSION_ENABLED

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -438,7 +438,7 @@ PHP_MINFO_FUNCTION(odbc)
 	char buf[32];
 
 	php_info_print_table_start();
-	php_info_print_table_header(2, "ODBC Support", "enabled");
+	php_info_print_table_row(2, "ODBC Support", "enabled");
 	snprintf(buf, sizeof(buf), ZEND_LONG_FMT, ODBCG(num_persistent));
 	php_info_print_table_row(2, "Active Persistent Links", buf);
 	snprintf(buf, sizeof(buf), ZEND_LONG_FMT, ODBCG(num_links));

--- a/ext/pcntl/pcntl.c
+++ b/ext/pcntl/pcntl.c
@@ -160,7 +160,7 @@ PHP_RSHUTDOWN_FUNCTION(pcntl)
 PHP_MINFO_FUNCTION(pcntl)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "pcntl support", "enabled");
+	php_info_print_table_row(2, "pcntl support", "enabled");
 	php_info_print_table_end();
 }
 

--- a/ext/pdo/pdo.c
+++ b/ext/pdo/pdo.c
@@ -275,7 +275,7 @@ PHP_MINFO_FUNCTION(pdo)
 	pdo_driver_t *pdriver;
 
 	php_info_print_table_start();
-	php_info_print_table_header(2, "PDO support", "enabled");
+	php_info_print_table_row(2, "PDO support", "enabled");
 
 	ZEND_HASH_MAP_FOREACH_PTR(&pdo_driver_hash, pdriver) {
 		spprintf(&drivers, 0, "%s, %s", ldrivers, pdriver->driver_name);

--- a/ext/pdo_dblib/pdo_dblib.c
+++ b/ext/pdo_dblib/pdo_dblib.c
@@ -223,7 +223,7 @@ PHP_MSHUTDOWN_FUNCTION(pdo_dblib)
 PHP_MINFO_FUNCTION(pdo_dblib)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "PDO Driver for "
+	php_info_print_table_row(2, "PDO Driver for "
 #ifdef PDO_DBLIB_IS_MSSQL
 		"MSSQL"
 #elif defined(PHP_WIN32)

--- a/ext/pdo_firebird/pdo_firebird.c
+++ b/ext/pdo_firebird/pdo_firebird.c
@@ -85,7 +85,7 @@ PHP_MINFO_FUNCTION(pdo_firebird) /* {{{ */
 	isc_get_client_version(version);
 
 	php_info_print_table_start();
-	php_info_print_table_header(2, "PDO Driver for Firebird", "enabled");
+	php_info_print_table_row(2, "PDO Driver for Firebird", "enabled");
 	php_info_print_table_row(2, "Client Library Version", version);
 	php_info_print_table_end();
 }

--- a/ext/pdo_mysql/pdo_mysql.c
+++ b/ext/pdo_mysql/pdo_mysql.c
@@ -153,7 +153,7 @@ static PHP_MINFO_FUNCTION(pdo_mysql)
 {
 	php_info_print_table_start();
 
-	php_info_print_table_header(2, "PDO Driver for MySQL", "enabled");
+	php_info_print_table_row(2, "PDO Driver for MySQL", "enabled");
 	php_info_print_table_row(2, "Client API version", mysql_get_client_info());
 
 	php_info_print_table_end();

--- a/ext/pdo_oci/pdo_oci.c
+++ b/ext/pdo_oci/pdo_oci.c
@@ -147,7 +147,7 @@ PHP_MSHUTDOWN_FUNCTION(pdo_oci)
 PHP_MINFO_FUNCTION(pdo_oci)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "PDO Driver for OCI 8 and later", "enabled");
+	php_info_print_table_row(2, "PDO Driver for OCI 8 and later", "enabled");
 	php_info_print_table_end();
 }
 /* }}} */

--- a/ext/pdo_odbc/pdo_odbc.c
+++ b/ext/pdo_odbc/pdo_odbc.c
@@ -118,7 +118,7 @@ PHP_MSHUTDOWN_FUNCTION(pdo_odbc)
 PHP_MINFO_FUNCTION(pdo_odbc)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "PDO Driver for ODBC (" PDO_ODBC_TYPE ")" , "enabled");
+	php_info_print_table_row(2, "PDO Driver for ODBC (" PDO_ODBC_TYPE ")" , "enabled");
 #ifdef SQL_ATTR_CONNECTION_POOLING
 	php_info_print_table_row(2, "ODBC Connection Pooling",	pdo_odbc_pool_on == SQL_CP_OFF ?
 			"Disabled" : (pdo_odbc_pool_mode == SQL_CP_STRICT_MATCH ? "Enabled, strict matching" : "Enabled, relaxed matching"));

--- a/ext/pdo_sqlite/pdo_sqlite.c
+++ b/ext/pdo_sqlite/pdo_sqlite.c
@@ -84,7 +84,7 @@ PHP_MSHUTDOWN_FUNCTION(pdo_sqlite)
 PHP_MINFO_FUNCTION(pdo_sqlite)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "PDO Driver for SQLite 3.x", "enabled");
+	php_info_print_table_row(2, "PDO Driver for SQLite 3.x", "enabled");
 	php_info_print_table_row(2, "SQLite Library", sqlite3_libversion());
 	php_info_print_table_end();
 }

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -512,7 +512,7 @@ PHP_MINFO_FUNCTION(pgsql)
 	char buf[256];
 
 	php_info_print_table_start();
-	php_info_print_table_header(2, "PostgreSQL Support", "enabled");
+	php_info_print_table_row(2, "PostgreSQL Support", "enabled");
 	php_info_print_table_row(2, "PostgreSQL (libpq) Version", pgsql_libpq_version);
 #ifdef HAVE_PGSQL_WITH_MULTIBYTE_SUPPORT
 	php_info_print_table_row(2, "Multibyte character support", "enabled");

--- a/ext/phar/phar.c
+++ b/ext/phar/phar.c
@@ -3565,7 +3565,7 @@ PHP_MINFO_FUNCTION(phar) /* {{{ */
 {
 	phar_request_initialize();
 	php_info_print_table_start();
-	php_info_print_table_header(2, "Phar: PHP Archive support", "enabled");
+	php_info_print_table_row(2, "Phar: PHP Archive support", "enabled");
 	php_info_print_table_row(2, "Phar API version", PHP_PHAR_API_VERSION);
 	php_info_print_table_row(2, "Phar-based phar archives", "enabled");
 	php_info_print_table_row(2, "Tar-based phar archives", "enabled");

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -800,7 +800,7 @@ PHP_MSHUTDOWN_FUNCTION(cli_readline)
 PHP_MINFO_FUNCTION(cli_readline)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "Readline Support", "enabled");
+	php_info_print_table_row(2, "Readline Support", "enabled");
 #ifdef PHP_WIN32
 	php_info_print_table_row(2, "Readline library", "WinEditLine");
 #else

--- a/ext/skeleton/skeleton.c
+++ b/ext/skeleton/skeleton.c
@@ -58,7 +58,7 @@ PHP_RINIT_FUNCTION(%EXTNAME%)
 PHP_MINFO_FUNCTION(%EXTNAME%)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "%EXTNAME% support", "enabled");
+	php_info_print_table_row(2, "%EXTNAME% support", "enabled");
 	php_info_print_table_end();
 }
 /* }}} */

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -184,7 +184,7 @@ PHP_MSHUTDOWN_FUNCTION(sodium)
 PHP_MINFO_FUNCTION(sodium)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "sodium support", "enabled");
+	php_info_print_table_row(2, "sodium support", "enabled");
 	php_info_print_table_row(2, "libsodium headers version", SODIUM_VERSION_STRING);
 	php_info_print_table_row(2, "libsodium library version", sodium_version_string());
 	php_info_print_table_end();

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -670,7 +670,7 @@ PHP_MINFO_FUNCTION(spl)
 	char *strg;
 
 	php_info_print_table_start();
-	php_info_print_table_header(2, "SPL support",        "enabled");
+	php_info_print_table_row(2, "SPL support", "enabled");
 
 	array_init(&list);
 	SPL_LIST_CLASSES(&list, 0, 1, ZEND_ACC_INTERFACE)

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2406,7 +2406,7 @@ PHP_MSHUTDOWN_FUNCTION(sqlite3)
 PHP_MINFO_FUNCTION(sqlite3)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "SQLite3 support", "enabled");
+	php_info_print_table_row(2, "SQLite3 support", "enabled");
 	php_info_print_table_row(2, "SQLite Library", sqlite3_libversion());
 	php_info_print_table_end();
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -804,7 +804,7 @@ static PHP_GSHUTDOWN_FUNCTION(zend_test)
 PHP_MINFO_FUNCTION(zend_test)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "zend_test extension", "enabled");
+	php_info_print_table_row(2, "zend_test extension", "enabled");
 	php_info_print_table_end();
 
 	DISPLAY_INI_ENTRIES();

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1404,7 +1404,7 @@ static PHP_RSHUTDOWN_FUNCTION(zlib)
 static PHP_MINFO_FUNCTION(zlib)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "ZLib Support", "enabled");
+	php_info_print_table_row(2, "ZLib Support", "enabled");
 	php_info_print_table_row(2, "Stream Wrapper", "compress.zlib://");
 	php_info_print_table_row(2, "Stream Filter", "zlib.inflate, zlib.deflate");
 	php_info_print_table_row(2, "Compiled Version", ZLIB_VERSION);


### PR DESCRIPTION
Using php_info_print_table_header() for "Foo: bar" looks odd and out of place,
because the whole line is colored. It is also questionable from a HTML
semantics point of view, because it does not described the columns that follow.

The use of this across extensions is inconsistent. It was part of the skeleton,
but ext/date or ext/json already use a regular row.