### PR TITLE
Add support for validation of missing method synopses

### DIFF
--- a/ext/dl_test/dl_test.stub.php
+++ b/ext/dl_test/dl_test.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @undocumentable
+ */
 
 function dl_test_test1(): void {}
 

--- a/ext/dl_test/dl_test_arginfo.h
+++ b/ext/dl_test/dl_test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 39ccf8141b0eb785cafd490b420f2e99d6a7a66d */
+ * Stub hash: 547ddbc21e9aa853b491cb17e902bbbb9cc2df00 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_dl_test_test1, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()

--- a/ext/skeleton/skeleton.stub.php
+++ b/ext/skeleton/skeleton.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @undocumentable
+ */
 
 function test1(): void {}
 

--- a/ext/skeleton/skeleton_arginfo.h
+++ b/ext/skeleton/skeleton_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: efdd79c2c8ccff694699c86fdd6248a13839c744 */
+ * Stub hash: 54b0ffc3af871b189435266df516f7575c1b9675 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_test1, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()

--- a/ext/zlib/zlib.stub.php
+++ b/ext/zlib/zlib.stub.php
@@ -212,6 +212,7 @@ function gzwrite($stream, string $data, ?int $length = null): int|false {}
 /**
  * @param resource $stream
  * @alias fwrite
+ * @undocumentable gzputs is an alias of gzwrite, but transitive aliases are not yet supported
  */
 function gzputs($stream, string $data, ?int $length = null): int|false {}
 

--- a/ext/zlib/zlib_arginfo.h
+++ b/ext/zlib/zlib_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 338e64b821dc3f27b6d1d262a90cb7c144ed78b6 */
+ * Stub hash: 3660ad3239f93c84b6909c36ddfcc92dd0773c70 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_ob_gzhandler, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)


### PR DESCRIPTION
This PR adds support for `./build/gen_stub.php --replace-methodsynopses --verify ./ ../doc-en/`, similarly to the class synopsis validation. Additionally, we also check if aliases are documented properly. Unfortunately, the output of the script is much longer than the one for classes:

```
Warning: timezone_open() is incorrectly documented as an alias for DateTimeZone::__construct()
Warning: date_create_immutable() is incorrectly documented as an alias for DateTimeImmutable::__construct()
Warning: OCILob::saveFile() is an alias of oci_lob_import(), but it is incorrectly documented as an alias for OCILob::import()
Warning: OCILob::writeToFile() is an alias of oci_lob_export(), but it is incorrectly documented as an alias for OCILob::export()
Warning: ocicollsize() is an alias of oci_collection_size(), but it is incorrectly documented as an alias for OCICollection::size()
Warning: ociloadlob() is an alias of oci_lob_load(), but it is incorrectly documented as an alias for OCILob::load()
Warning: ocisavelob() is an alias of oci_lob_save(), but it is incorrectly documented as an alias for OCILob::save()
Warning: ocicolltrim() is an alias of oci_collection_trim(), but it is incorrectly documented as an alias for OCICollection::trim()
Warning: ocicollmax() is an alias of oci_collection_max(), but it is incorrectly documented as an alias for OCICollection::max()
Warning: ocicollappend() is an alias of oci_collection_append(), but it is incorrectly documented as an alias for OCICollection::append()
Warning: ocisavelobfile() is an alias of oci_lob_import(), but it is incorrectly documented as an alias for OCILob::import()
Warning: ocifreecollection() is an alias of oci_free_collection(), but it is incorrectly documented as an alias for OCICollection::free()
Warning: ociwritelobtofile() is an alias of oci_lob_export(), but it is incorrectly documented as an alias for OCILob::export()
Warning: ocicollgetelem() is an alias of oci_collection_element_get(), but it is incorrectly documented as an alias for OCICollection::getElem()
Warning: ocifreedesc() is an alias of oci_free_descriptor(), but it is incorrectly documented as an alias for OCILob::free()
Warning: ocicollassignelem() is an alias of oci_collection_element_assign(), but it is incorrectly documented as an alias for OCICollection::assignElem()
Warning: mysqli_connect() is incorrectly documented as an alias for mysqli::__construct()
Warning: Missing method synopsis for Attribute::__construct()
Warning: Missing method synopsis for ReturnTypeWillChange::__construct()
Warning: Missing method synopsis for AllowDynamicProperties::__construct()
Warning: Missing method synopsis for SensitiveParameter::__construct()
Warning: Missing method synopsis for SensitiveParameterValue::__construct()
Warning: Missing method synopsis for SensitiveParameterValue::getValue()
Warning: Missing method synopsis for SensitiveParameterValue::__debugInfo()
Warning: Missing method synopsis for Exception::__wakeup()
Warning: Missing method synopsis for Error::__wakeup()
Warning: Missing method synopsis for InternalIterator::__construct()
Warning: Missing method synopsis for InternalIterator::current()
Warning: Missing method synopsis for InternalIterator::key()
Warning: Missing method synopsis for InternalIterator::next()
Warning: Missing method synopsis for InternalIterator::valid()
Warning: Missing method synopsis for InternalIterator::rewind()
Warning: Missing method synopsis for curl_upkeep()
Warning: Missing method synopsis for DateTimeInterface::__serialize()
Warning: Missing method synopsis for DateTimeInterface::__unserialize()
Warning: Missing method synopsis for DateTime::__serialize()
Warning: Missing method synopsis for DateTime::__unserialize()
Warning: Missing method synopsis for DateTimeImmutable::__serialize()
Warning: Missing method synopsis for DateTimeImmutable::__unserialize()
Warning: Missing method synopsis for DateTimeZone::__serialize()
Warning: Missing method synopsis for DateTimeZone::__unserialize()
Warning: Missing method synopsis for DateTimeZone::__wakeup()
Warning: Missing method synopsis for DateTimeZone::__set_state()
Warning: Missing method synopsis for DateInterval::__serialize()
Warning: Missing method synopsis for DateInterval::__unserialize()
Warning: Missing method synopsis for DateInterval::__wakeup()
Warning: Missing method synopsis for DateInterval::__set_state()
Warning: Missing method synopsis for DatePeriod::__serialize()
Warning: Missing method synopsis for DatePeriod::__unserialize()
Warning: Missing method synopsis for DatePeriod::__wakeup()
Warning: Missing method synopsis for DatePeriod::__set_state()
Warning: Missing method synopsis for DatePeriod::getIterator()
Warning: Missing method synopsis for DOMNode::lookupNamespaceURI()
Warning: Missing method synopsis for DOMImplementation::getFeature()
Warning: Missing method synopsis for DOMDocumentFragment::append()
Warning: Missing method synopsis for DOMDocumentFragment::prepend()
Warning: Missing method synopsis for DOMNodeList::getIterator()
Warning: Missing method synopsis for DOMCharacterData::replaceWith()
Warning: Missing method synopsis for DOMCharacterData::remove()
Warning: Missing method synopsis for DOMCharacterData::before()
Warning: Missing method synopsis for DOMCharacterData::after()
Warning: Missing method synopsis for DOMElement::remove()
Warning: Missing method synopsis for DOMElement::before()
Warning: Missing method synopsis for DOMElement::after()
Warning: Missing method synopsis for DOMElement::replaceWith()
Warning: Missing method synopsis for DOMElement::append()
Warning: Missing method synopsis for DOMElement::prepend()
Warning: Missing method synopsis for DOMDocument::adoptNode()
Warning: Missing method synopsis for DOMDocument::append()
Warning: Missing method synopsis for DOMDocument::prepend()
Warning: Missing method synopsis for DOMNamedNodeMap::getIterator()
Warning: Missing method synopsis for _()
Warning: Missing method synopsis for IntlBreakIterator::getIterator()
Warning: Missing method synopsis for IntlPartsIterator::getRuleStatus()
Warning: Missing method synopsis for intlgregcal_create_instance()
Warning: Missing method synopsis for intlgregcal_set_gregorian_change()
Warning: Missing method synopsis for intlgregcal_get_gregorian_change()
Warning: Missing method synopsis for intlgregcal_is_leap_year()
Warning: Missing method synopsis for locale_canonicalize()
Warning: Missing method synopsis for ResourceBundle::getIterator()
Warning: Missing method synopsis for Spoofchecker::setRestrictionLevel()
Warning: Missing method synopsis for libxml_get_external_entity_loader()
Warning: Missing method synopsis for mysqli_execute_query()
Warning: Missing method synopsis for mysqli::execute_query()
Warning: Missing method synopsis for mysqli::escape_string()
Warning: Missing method synopsis for mysqli::set_opt()
Warning: Missing method synopsis for oci_lob_save()
Warning: Missing method synopsis for oci_lob_import()
Warning: Missing method synopsis for oci_lob_load()
Warning: Missing method synopsis for oci_lob_read()
Warning: Missing method synopsis for oci_lob_eof()
Warning: Missing method synopsis for oci_lob_tell()
Warning: Missing method synopsis for oci_lob_rewind()
Warning: Missing method synopsis for oci_lob_seek()
Warning: Missing method synopsis for oci_lob_size()
Warning: Missing method synopsis for oci_lob_write()
Warning: Missing method synopsis for oci_lob_append()
Warning: Missing method synopsis for oci_lob_truncate()
Warning: Missing method synopsis for oci_lob_erase()
Warning: Missing method synopsis for oci_lob_flush()
Warning: Missing method synopsis for ocisetbufferinglob()
Warning: Missing method synopsis for ocigetbufferinglob()
Warning: Missing method synopsis for oci_lob_export()
Warning: Missing method synopsis for ocifetchinto()
Warning: Missing method synopsis for oci_free_cursor()
Warning: Missing method synopsis for ocipasswordchange()
Warning: Missing method synopsis for oci_free_collection()
Warning: Missing method synopsis for oci_collection_append()
Warning: Missing method synopsis for oci_collection_element_get()
Warning: Missing method synopsis for oci_collection_assign()
Warning: Missing method synopsis for oci_collection_element_assign()
Warning: Missing method synopsis for oci_collection_size()
Warning: Missing method synopsis for oci_collection_max()
Warning: Missing method synopsis for oci_collection_trim()
Warning: Missing method synopsis for odbc_connection_string_is_quoted()
Warning: Missing method synopsis for odbc_connection_string_should_quote()
Warning: Missing method synopsis for odbc_connection_string_quote()
Warning: Missing method synopsis for openssl_cipher_key_length()
Warning: Missing method synopsis for pcntl_wifcontinued()
Warning: Missing method synopsis for pcntl_forkx()
Warning: Missing method synopsis for pg_errormessage()
Warning: Missing method synopsis for pg_exec()
Warning: Missing method synopsis for pg_numrows()
Warning: Missing method synopsis for pg_numfields()
Warning: Missing method synopsis for pg_cmdtuples()
Warning: Missing method synopsis for pg_fieldname()
Warning: Missing method synopsis for pg_fieldsize()
Warning: Missing method synopsis for pg_fieldtype()
Warning: Missing method synopsis for pg_fieldnum()
Warning: Missing method synopsis for pg_result()
Warning: Missing method synopsis for pg_fieldprtlen()
Warning: Missing method synopsis for pg_fieldisnull()
Warning: Missing method synopsis for pg_freeresult()
Warning: Missing method synopsis for pg_getlastoid()
Warning: Missing method synopsis for pg_locreate()
Warning: Missing method synopsis for pg_lounlink()
Warning: Missing method synopsis for pg_loopen()
Warning: Missing method synopsis for pg_loclose()
Warning: Missing method synopsis for pg_loread()
Warning: Missing method synopsis for pg_lowrite()
Warning: Missing method synopsis for pg_loreadall()
Warning: Missing method synopsis for pg_loimport()
Warning: Missing method synopsis for pg_loexport()
Warning: Missing method synopsis for pg_setclientencoding()
Warning: Missing method synopsis for pg_clientencoding()
Warning: Missing method synopsis for PharData::count()
Warning: Missing method synopsis for PharData::getAlias()
Warning: Missing method synopsis for PharData::getPath()
Warning: Missing method synopsis for PharData::getMetadata()
Warning: Missing method synopsis for PharData::getModified()
Warning: Missing method synopsis for PharData::getSignature()
Warning: Missing method synopsis for PharData::getStub()
Warning: Missing method synopsis for PharData::getVersion()
Warning: Missing method synopsis for PharData::hasMetadata()
Warning: Missing method synopsis for PharData::isBuffering()
Warning: Missing method synopsis for PharData::isCompressed()
Warning: Missing method synopsis for PharData::isFileFormat()
Warning: Missing method synopsis for PharData::offsetExists()
Warning: Missing method synopsis for PharData::offsetGet()
Warning: Missing method synopsis for PharData::startBuffering()
Warning: Missing method synopsis for PharData::stopBuffering()
Warning: Missing method synopsis for PharData::apiVersion()
Warning: Missing method synopsis for PharData::canCompress()
Warning: Missing method synopsis for PharData::canWrite()
Warning: Missing method synopsis for PharData::createDefaultStub()
Warning: Missing method synopsis for PharData::getSupportedCompression()
Warning: Missing method synopsis for PharData::getSupportedSignatures()
Warning: Missing method synopsis for PharData::interceptFileFuncs()
Warning: Missing method synopsis for PharData::isValidPharFilename()
Warning: Missing method synopsis for PharData::loadPhar()
Warning: Missing method synopsis for PharData::mapPhar()
Warning: Missing method synopsis for PharData::running()
Warning: Missing method synopsis for PharData::mount()
Warning: Missing method synopsis for PharData::mungServer()
Warning: Missing method synopsis for PharData::unlinkArchive()
Warning: Missing method synopsis for PharData::webPhar()
Warning: Missing method synopsis for Random\Engine\Mt19937::__construct()
Warning: Missing method synopsis for Random\Engine\Mt19937::generate()
Warning: Missing method synopsis for Random\Engine\Mt19937::__serialize()
Warning: Missing method synopsis for Random\Engine\Mt19937::__unserialize()
Warning: Missing method synopsis for Random\Engine\Mt19937::__debugInfo()
Warning: Missing method synopsis for Random\Engine\PcgOneseq128XslRr64::__construct()
Warning: Missing method synopsis for Random\Engine\PcgOneseq128XslRr64::generate()
Warning: Missing method synopsis for Random\Engine\PcgOneseq128XslRr64::jump()
Warning: Missing method synopsis for Random\Engine\PcgOneseq128XslRr64::__serialize()
Warning: Missing method synopsis for Random\Engine\PcgOneseq128XslRr64::__unserialize()
Warning: Missing method synopsis for Random\Engine\PcgOneseq128XslRr64::__debugInfo()
Warning: Missing method synopsis for Random\Engine\Xoshiro256StarStar::__construct()
Warning: Missing method synopsis for Random\Engine\Xoshiro256StarStar::generate()
Warning: Missing method synopsis for Random\Engine\Xoshiro256StarStar::jump()
Warning: Missing method synopsis for Random\Engine\Xoshiro256StarStar::jumpLong()
Warning: Missing method synopsis for Random\Engine\Xoshiro256StarStar::__serialize()
Warning: Missing method synopsis for Random\Engine\Xoshiro256StarStar::__unserialize()
Warning: Missing method synopsis for Random\Engine\Xoshiro256StarStar::__debugInfo()
Warning: Missing method synopsis for Random\Engine\Secure::generate()
Warning: Missing method synopsis for Random\Engine::generate()
Warning: Missing method synopsis for Random\Randomizer::__construct()
Warning: Missing method synopsis for Random\Randomizer::nextInt()
Warning: Missing method synopsis for Random\Randomizer::getInt()
Warning: Missing method synopsis for Random\Randomizer::getBytes()
Warning: Missing method synopsis for Random\Randomizer::shuffleArray()
Warning: Missing method synopsis for Random\Randomizer::shuffleBytes()
Warning: Missing method synopsis for Random\Randomizer::pickArrayKeys()
Warning: Missing method synopsis for Random\Randomizer::__serialize()
Warning: Missing method synopsis for Random\Randomizer::__unserialize()
Warning: Missing method synopsis for ReflectionFunctionAbstract::isStatic()
Warning: Missing method synopsis for ReflectionFunctionAbstract::getClosureCalledClass()
Warning: Missing method synopsis for ReflectionFunction::isAnonymous()
Warning: Missing method synopsis for ReflectionMethod::hasPrototype()
Warning: Missing method synopsis for ReflectionClass::__clone()
Warning: Missing method synopsis for ReflectionClass::isReadOnly()
Warning: Missing method synopsis for ReflectionClassConstant::__clone()
Warning: Missing method synopsis for ReflectionParameter::isPromoted()
Warning: Missing method synopsis for ReflectionType::__clone()
Warning: Missing method synopsis for ReflectionReference::__clone()
Warning: Missing method synopsis for ReflectionAttribute::__toString()
Warning: Missing method synopsis for ReflectionAttribute::__clone()
Warning: Missing method synopsis for SimpleXMLElement::rewind()
Warning: Missing method synopsis for SimpleXMLElement::valid()
Warning: Missing method synopsis for SimpleXMLElement::current()
Warning: Missing method synopsis for SimpleXMLElement::key()
Warning: Missing method synopsis for SimpleXMLElement::next()
Warning: Missing method synopsis for SimpleXMLElement::hasChildren()
Warning: Missing method synopsis for SimpleXMLElement::getChildren()
Warning: Missing method synopsis for sodium_crypto_stream_xchacha20_xor_ic()
Warning: Missing method synopsis for ArrayObject::__serialize()
Warning: Missing method synopsis for ArrayObject::__unserialize()
Warning: Missing method synopsis for ArrayObject::__debugInfo()
Warning: Missing method synopsis for ArrayIterator::__serialize()
Warning: Missing method synopsis for ArrayIterator::__unserialize()
Warning: Missing method synopsis for ArrayIterator::__debugInfo()
Warning: Missing method synopsis for SplFileInfo::__debugInfo()
Warning: Missing method synopsis for SplFileInfo::_bad_state_ex()
Warning: Missing method synopsis for SplDoublyLinkedList::__debugInfo()
Warning: Missing method synopsis for SplDoublyLinkedList::__serialize()
Warning: Missing method synopsis for SplDoublyLinkedList::__unserialize()
Warning: Missing method synopsis for SplFixedArray::__serialize()
Warning: Missing method synopsis for SplFixedArray::__unserialize()
Warning: Missing method synopsis for SplFixedArray::getIterator()
Warning: Missing method synopsis for SplFixedArray::jsonSerialize()
Warning: Missing method synopsis for SplPriorityQueue::__debugInfo()
Warning: Missing method synopsis for SplHeap::__debugInfo()
Warning: Missing method synopsis for RecursiveRegexIterator::accept()
Warning: Missing method synopsis for SplObjectStorage::__serialize()
Warning: Missing method synopsis for SplObjectStorage::__unserialize()
Warning: Missing method synopsis for SplObjectStorage::__debugInfo()
Warning: Missing method synopsis for MultipleIterator::__debugInfo()
Warning: Missing method synopsis for SQLite3::lastExtendedErrorCode()
Warning: Missing method synopsis for SQLite3::enableExtendedResultCodes()
Warning: Missing method synopsis for ini_parse_quantity()
Warning: Missing method synopsis for config_get_hash()
Warning: Missing method synopsis for memory_reset_peak_usage()
Warning: Missing method synopsis for XSLTProcessor::transformToUri()
Warning: Missing method synopsis for litespeed_request_headers()
Warning: Missing method synopsis for litespeed_response_headers()
Warning: Missing method synopsis for litespeed_finish_request()
```
