### PR TITLE
Fix undefined left shift in oci

### DIFF
--- a/ext/oci8/php_oci8_int.h
+++ b/ext/oci8/php_oci8_int.h
@@ -103,7 +103,7 @@ extern zend_class_entry *oci_coll_class_entry_ptr;
  * PHP_OCI_CRED_EXT must be distinct from the OCI_xxx privilege
  * values.
  */
-#define PHP_OCI_CRED_EXT                    (1<<31)
+#define PHP_OCI_CRED_EXT                    (1u<<31)
 #if ((PHP_OCI_CRED_EXT == OCI_DEFAULT) || (PHP_OCI_CRED_EXT & (OCI_SYSOPER | OCI_SYSDBA)))
 #error Invalid value for PHP_OCI_CRED_EXT
 #endif

--- a/ext/oci8/tests/privileged_connect1.phpt
+++ b/ext/oci8/tests/privileged_connect1.phpt
@@ -1,7 +1,10 @@
 --TEST--
 privileged connect tests
 --SKIPIF--
-<?php if (!extension_loaded('oci8')) die("skip no oci8 extension"); ?>
+<?php 
+if (!extension_loaded('oci8')) die("skip no oci8 extension");
+if (getenv('SKIP_ASAN')) die('skip leaks memory under asan');
+?>
 --INI--
 oci8.privileged_connect=1
 --FILE--

--- a/ext/pdo_oci/tests/pecl_bug_6364.phpt
+++ b/ext/pdo_oci/tests/pecl_bug_6364.phpt
@@ -3,6 +3,7 @@ PECL PDO_OCI Bug #6364 (segmentation fault on stored procedure call with OUT bin
 --SKIPIF--
 <?php
 if (!extension_loaded('pdo') || !extension_loaded('pdo_oci')) die('skip not loaded');
+if (getenv('SKIP_ASAN')) die('skip leaks memory under asan');
 require(__DIR__.'/../../pdo/tests/pdo_test.inc');
 PDOTest::skip();
 ?>


### PR DESCRIPTION
The bit is shifted into the signed bit which is undefined. Make the
integer explicitly unsigned before shifting.

Also skip some oci tests that leak under asan.