### PR TITLE
Prevent FPM tests from failing due to expose_php

### DIFF
--- a/sapi/fpm/tests/bug68420-ipv4-all-addresses.phpt
+++ b/sapi/fpm/tests/bug68420-ipv4-all-addresses.phpt
@@ -21,6 +21,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/bug68421-ipv6-access-log.phpt
+++ b/sapi/fpm/tests/bug68421-ipv6-access-log.phpt
@@ -23,6 +23,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/bug68423-multi-pool-all-pms.phpt
+++ b/sapi/fpm/tests/bug68423-multi-pool-all-pms.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 [pool_ondemand]
 listen = {{ADDR[ondemand]}}
 ping.path = /ping
@@ -26,12 +27,14 @@ ping.response = pong-on-demand
 pm = ondemand
 pm.max_children = 2
 pm.process_idle_timeout = 10
+php_flag[expose_php] = on
 [pool_static]
 listen = {{ADDR[static]}}
 ping.path = /ping
 ping.response = pong-static
 pm = static
 pm.max_children = 2
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/bug68442-signal-reload.phpt
+++ b/sapi/fpm/tests/bug68442-signal-reload.phpt
@@ -20,6 +20,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/bug72185-fcgi-empty-frame.phpt
+++ b/sapi/fpm/tests/bug72185-fcgi-empty-frame.phpt
@@ -20,6 +20,7 @@ pm.max_spare_servers = 2
 catch_workers_output = yes
 decorate_workers_output = no
 php_value[html_errors] = false
+php_flag[expose_php] = on
 EOT;
 
 $code = <<<'EOT'

--- a/sapi/fpm/tests/bug72573-http-proxy.phpt
+++ b/sapi/fpm/tests/bug72573-http-proxy.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $code = <<<EOT

--- a/sapi/fpm/tests/bug73342-nonblocking-stdio.phpt
+++ b/sapi/fpm/tests/bug73342-nonblocking-stdio.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $code = <<<EOT

--- a/sapi/fpm/tests/bug74083-concurrent-reload.phpt
+++ b/sapi/fpm/tests/bug74083-concurrent-reload.phpt
@@ -24,6 +24,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 1
+php_flag[expose_php] = on
 EOT;
 
 $code = <<<EOT

--- a/sapi/fpm/tests/bug75212-php-value-in-user-ini.phpt
+++ b/sapi/fpm/tests/bug75212-php-value-in-user-ini.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 php_admin_value[memory_limit]=32M
 php_value[date.timezone]=Europe/London
 EOT;

--- a/sapi/fpm/tests/bug77934-reload-process-control.phpt
+++ b/sapi/fpm/tests/bug77934-reload-process-control.phpt
@@ -21,6 +21,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 1
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/bug78599-path-info-underflow.phpt
+++ b/sapi/fpm/tests/bug78599-path-info-underflow.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $code = <<<EOT

--- a/sapi/fpm/tests/fastcgi_finish_request_basic.phpt
+++ b/sapi/fpm/tests/fastcgi_finish_request_basic.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $code = <<<EOT

--- a/sapi/fpm/tests/fpm_get_status_basic.phpt
+++ b/sapi/fpm/tests/fpm_get_status_basic.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $code = <<<EOT

--- a/sapi/fpm/tests/getallheaders.phpt
+++ b/sapi/fpm/tests/getallheaders.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $code = <<<EOT

--- a/sapi/fpm/tests/gh8885-stderr-fd-reload-usr1.phpt
+++ b/sapi/fpm/tests/gh8885-stderr-fd-reload-usr1.phpt
@@ -24,6 +24,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 // php-fpm must not be launched with --force-stderr option

--- a/sapi/fpm/tests/gh8885-stderr-fd-reload-usr2.phpt
+++ b/sapi/fpm/tests/gh8885-stderr-fd-reload-usr2.phpt
@@ -24,6 +24,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 // php-fpm must not be launched with --force-stderr option

--- a/sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
+++ b/sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt
+++ b/sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-bm-limit-2048-msg-4000.phpt
+++ b/sapi/fpm/tests/log-bm-limit-2048-msg-4000.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-bwd-limit-1050-msg-2048.phpt
+++ b/sapi/fpm/tests/log-bwd-limit-1050-msg-2048.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 decorate_workers_output = yes
 EOT;

--- a/sapi/fpm/tests/log-bwd-limit-1050-msg-2900.phpt
+++ b/sapi/fpm/tests/log-bwd-limit-1050-msg-2900.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-bwd-limit-8000-msg-4096.phpt
+++ b/sapi/fpm/tests/log-bwd-limit-8000-msg-4096.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-bwd-msg-with-nl.phpt
+++ b/sapi/fpm/tests/log-bwd-msg-with-nl.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-bwd-multiple-msgs-stdout-stderr.phpt
+++ b/sapi/fpm/tests/log-bwd-multiple-msgs-stdout-stderr.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-bwd-multiple-msgs.phpt
+++ b/sapi/fpm/tests/log-bwd-multiple-msgs.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-bwp-limit-1024-msg-120.phpt
+++ b/sapi/fpm/tests/log-bwp-limit-1024-msg-120.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 decorate_workers_output = no
 EOT;

--- a/sapi/fpm/tests/log-bwp-limit-1500-msg-3300.phpt
+++ b/sapi/fpm/tests/log-bwp-limit-1500-msg-3300.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 decorate_workers_output = no
 EOT;

--- a/sapi/fpm/tests/log-bwp-msg-flush-split-fallback.phpt
+++ b/sapi/fpm/tests/log-bwp-msg-flush-split-fallback.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 decorate_workers_output = no
 EOT;

--- a/sapi/fpm/tests/log-bwp-msg-flush-split-real.phpt
+++ b/sapi/fpm/tests/log-bwp-msg-flush-split-real.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 decorate_workers_output = no
 EOT;

--- a/sapi/fpm/tests/log-bwp-realloc-buffer.phpt
+++ b/sapi/fpm/tests/log-bwp-realloc-buffer.phpt
@@ -17,6 +17,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 decorate_workers_output = no
 EOT;

--- a/sapi/fpm/tests/log-dwd-limit-1050-msg-2048.phpt
+++ b/sapi/fpm/tests/log-dwd-limit-1050-msg-2048.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 decorate_workers_output = yes
 EOT;

--- a/sapi/fpm/tests/log-dwd-limit-1050-msg-2900.phpt
+++ b/sapi/fpm/tests/log-dwd-limit-1050-msg-2900.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-dwd-limit-8000-msg-4096.phpt
+++ b/sapi/fpm/tests/log-dwd-limit-8000-msg-4096.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 EOT;
 

--- a/sapi/fpm/tests/log-dwp-limit-1000-msg-2000.phpt
+++ b/sapi/fpm/tests/log-dwp-limit-1000-msg-2000.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 catch_workers_output = yes
 decorate_workers_output = no
 EOT;

--- a/sapi/fpm/tests/log-suppress-output-request-body.phpt
+++ b/sapi/fpm/tests/log-suppress-output-request-body.phpt
@@ -39,6 +39,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg, $testScript);

--- a/sapi/fpm/tests/log-suppress-output.phpt
+++ b/sapi/fpm/tests/log-suppress-output.phpt
@@ -78,6 +78,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $prefix = __DIR__;
@@ -105,6 +106,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 $tester->reload($cfg);
 $tester->expectLogReloadingNotices();

--- a/sapi/fpm/tests/main-global-prefix.phpt
+++ b/sapi/fpm/tests/main-global-prefix.phpt
@@ -23,6 +23,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $prefix = __DIR__;

--- a/sapi/fpm/tests/php-admin-doc-root.phpt
+++ b/sapi/fpm/tests/php-admin-doc-root.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 1
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 php_admin_value[doc_root] = $docRoot
 EOT;
 

--- a/sapi/fpm/tests/pm-max-spawn-rate-run.phpt
+++ b/sapi/fpm/tests/pm-max-spawn-rate-run.phpt
@@ -23,6 +23,7 @@ pm.max_spare_servers = 3
 pm.max_spawn_rate = 64
 ping.path = /ping
 ping.response = pong
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/pool-prefix.phpt
+++ b/sapi/fpm/tests/pool-prefix.phpt
@@ -28,6 +28,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/socket-uds-basic.phpt
+++ b/sapi/fpm/tests/socket-uds-basic.phpt
@@ -19,6 +19,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/socket-uds-numeric-ugid-nonroot.phpt
+++ b/sapi/fpm/tests/socket-uds-numeric-ugid-nonroot.phpt
@@ -26,6 +26,7 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+php_flag[expose_php] = on
 EOT;
 
 $tester = new FPM\Tester($cfg);

--- a/sapi/fpm/tests/status-basic.phpt
+++ b/sapi/fpm/tests/status-basic.phpt
@@ -15,6 +15,7 @@ listen = {{ADDR}}
 pm = static
 pm.max_children = 1
 pm.status_path = /status
+php_flag[expose_php] = on
 EOT;
 
 $expectedStatusData = [

--- a/sapi/fpm/tests/status-listen.phpt
+++ b/sapi/fpm/tests/status-listen.phpt
@@ -16,6 +16,7 @@ pm = static
 pm.max_children = 1
 pm.status_listen = {{ADDR[status]}}
 pm.status_path = /status
+php_flag[expose_php] = on
 EOT;
 
 $expectedStatusData = [


### PR DESCRIPTION
If a php.ini is installed in $PREFIX containing expose_php = off, a number of FPM tests fail due to a missing-but-expected X-Powered-By header. This change injects an "expose_php = on" into the fpm pool config.

This fails to fix one test - sapi/fpm/tests/status-listen.phpt - which continues to fail as the status pool doesn't pick up php_flag options from the fpm pool config. I'll see about applying php_ flags/values to the status pool, but leave that for a separate pull request as it's a more significant change.