### PR TITLE
Match FPM status pool's expose_php with parent

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -706,6 +706,17 @@ int fpm_worker_pool_config_free(struct fpm_worker_pool_config_s *wpc) /* {{{ */
 	} while (0)
 #define FPM_WPC_STR_CP(_cfg, _scfg, _field) FPM_WPC_STR_CP_EX(_cfg, _scfg, _field, _field)
 
+void fpm_conf_apply_kv_array_to_kv_array(struct key_value_s *src, void *dest) {
+	struct key_value_s *kv;
+
+	for (kv = src; kv; kv = kv->next) {
+		zval k, v;
+		ZVAL_STRING(&k, kv->key);
+		ZVAL_STRING(&v, kv->value);
+		fpm_conf_set_array(&k, &v, &dest, 0);
+	}
+}
+
 static int fpm_worker_pool_shared_status_alloc(struct fpm_worker_pool_s *shared_wp) { /* {{{ */
 	struct fpm_worker_pool_config_s *config, *shared_config;
 	config = fpm_worker_pool_config_alloc();
@@ -737,6 +748,9 @@ static int fpm_worker_pool_shared_status_alloc(struct fpm_worker_pool_s *shared_
 	FPM_WPC_STR_CP(config, shared_config, user);
 	FPM_WPC_STR_CP(config, shared_config, group);
 	FPM_WPC_STR_CP(config, shared_config, pm_status_path);
+
+	fpm_conf_apply_kv_array_to_kv_array(shared_config->php_values, (char *)config + WPO(php_values));
+	fpm_conf_apply_kv_array_to_kv_array(shared_config->php_admin_values, (char *)config + WPO(php_admin_values));
 
 	config->pm = PM_STYLE_ONDEMAND;
 	config->pm_max_children = 2;

--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -107,9 +107,20 @@ class Response
      *
      * @return Response
      */
-    public function expectHeader($name, $value): Response
+    public function expectHeader($name, $value, $useRegex = false): Response
     {
-        $this->checkHeader($name, $value);
+        $this->checkHeader($name, $value, $useRegex);
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return Response
+     */
+    public function expectNoHeader($name)
+    {
+        $this->checkNoHeader($name);
 
         return $this;
     }
@@ -259,6 +270,21 @@ class Response
 
         if ( ! preg_match($value, $header)) {
             return $this->error("The header $name value '$header' does not match RegExp '$value'");
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    private function checkNoHeader(string $name)
+    {
+        $lcName = strtolower($name);
+        $headers = $this->getHeaders();
+        if (isset($headers[$lcName])) {
+            return $this->error("The header $name is present");
         }
 
         return true;

--- a/sapi/fpm/tests/status-listen-expose-php-off.phpt
+++ b/sapi/fpm/tests/status-listen-expose-php-off.phpt
@@ -1,5 +1,5 @@
 --TEST--
-FPM: Status pool is inheriting FPM setting overrides test
+FPM: Status pool is inheriting FPM setting overrides test - expose_php = off
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/status-listen-expose-php-off.phpt
+++ b/sapi/fpm/tests/status-listen-expose-php-off.phpt
@@ -1,0 +1,39 @@
+--TEST--
+FPM: Status pool is inheriting FPM setting overrides test
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+pm.status_listen = {{ADDR[status]}}
+pm.status_path = /status
+php_flag[expose_php] = Off
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start();
+$tester->expectLogStartNotices();
+$response = $tester->request('', [], '/status', '{{ADDR[status]}}');
+$response->expectNoHeader('X-Powered-By');
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/status-listen-expose-php-on.phpt
+++ b/sapi/fpm/tests/status-listen-expose-php-on.phpt
@@ -1,5 +1,5 @@
 --TEST--
-FPM: Status pool is inheriting FPM setting overrides test
+FPM: Status pool is inheriting FPM setting overrides test - expose_php = on
 --SKIPIF--
 <?php include "skipif.inc"; ?>
 --FILE--

--- a/sapi/fpm/tests/status-listen-expose-php-on.phpt
+++ b/sapi/fpm/tests/status-listen-expose-php-on.phpt
@@ -1,0 +1,39 @@
+--TEST--
+FPM: Status pool is inheriting FPM setting overrides test
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+pm.status_listen = {{ADDR[status]}}
+pm.status_path = /status
+php_flag[expose_php] = On
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start();
+$tester->expectLogStartNotices();
+$response = $tester->request('', [], '/status', '{{ADDR[status]}}');
+$response->expectHeader('X-Powered-By', '|^PHP/8|', true);
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
If an installed php.ini turns expose_php on/off, and an FPM pool overrides that with php_flag[expose_php]=off/on, a status pool created with pm.status_listen in a pool config will have its expose_php reflect the php.ini value, and not the pool config's override.

This change looks for an override set in
php_flag/php_value/php_admin_flag/php_admin_value and carries that through.

Notably, when coupled with #9508, this fixes sapi/fpm/tests/status-listen.phpt which currently fails if a php.ini is installed with `expose_php=off`.