### PR TITLE
Do not require opcache.preload_user in cli SAPIs 

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4670,7 +4670,7 @@ static int accel_finish_startup_preload_subprocess(pid_t *pid)
 	if (euid != 0) {
 		if (ZCG(accel_directives).preload_user
 		 && *ZCG(accel_directives).preload_user) {
-			zend_accel_error(ACCEL_LOG_WARNING, "\"opcache.preload_user\" is ignored");
+			zend_accel_error(ACCEL_LOG_WARNING, "\"opcache.preload_user\" is ignored because the current user is not \"root\"");
 		}
 
 		*pid = -1;

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4680,6 +4680,13 @@ static int accel_finish_startup_preload_subprocess(pid_t *pid)
 	if (!ZCG(accel_directives).preload_user
 	 || !*ZCG(accel_directives).preload_user) {
 
+		bool sapi_requires_preload_user = !(strcmp(sapi_module.name, "cli") == 0
+		  || strcmp(sapi_module.name, "phpdbg") == 0);
+
+		if (!sapi_requires_preload_user) {
+			*pid = -1;
+			return SUCCESS;
+		}
 
 		zend_shared_alloc_unlock();
 		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "\"opcache.preload\" requires \"opcache.preload_user\" when running under uid 0");

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4565,206 +4565,227 @@ static void preload_send_header(sapi_header_struct *sapi_header, void *server_co
 {
 }
 
+#ifndef ZEND_WIN32
+static int accel_finish_startup_preload(bool in_child)
+{
+	int ret = SUCCESS;
+	int rc;
+	int orig_error_reporting;
+
+	int (*orig_activate)(void) = sapi_module.activate;
+	int (*orig_deactivate)(void) = sapi_module.deactivate;
+	void (*orig_register_server_variables)(zval *track_vars_array) = sapi_module.register_server_variables;
+	int (*orig_header_handler)(sapi_header_struct *sapi_header, sapi_header_op_enum op, sapi_headers_struct *sapi_headers) = sapi_module.header_handler;
+	int (*orig_send_headers)(sapi_headers_struct *sapi_headers) = sapi_module.send_headers;
+	void (*orig_send_header)(sapi_header_struct *sapi_header, void *server_context)= sapi_module.send_header;
+	char *(*orig_getenv)(const char *name, size_t name_len) = sapi_module.getenv;
+	size_t (*orig_ub_write)(const char *str, size_t str_length) = sapi_module.ub_write;
+	void (*orig_flush)(void *server_context) = sapi_module.flush;
+#ifdef ZEND_SIGNALS
+	bool old_reset_signals = SIGG(reset);
+#endif
+
+	sapi_module.activate = NULL;
+	sapi_module.deactivate = NULL;
+	sapi_module.register_server_variables = NULL;
+	sapi_module.header_handler = preload_header_handler;
+	sapi_module.send_headers = preload_send_headers;
+	sapi_module.send_header = preload_send_header;
+	sapi_module.getenv = NULL;
+	sapi_module.ub_write = preload_ub_write;
+	sapi_module.flush = preload_flush;
+
+	zend_interned_strings_switch_storage(1);
+
+#ifdef ZEND_SIGNALS
+	SIGG(reset) = false;
+#endif
+
+	orig_error_reporting = EG(error_reporting);
+	EG(error_reporting) = 0;
+
+	rc = php_request_startup();
+
+	EG(error_reporting) = orig_error_reporting;
+
+	if (rc == SUCCESS) {
+		bool orig_report_memleaks;
+
+		/* don't send headers */
+		SG(headers_sent) = true;
+		SG(request_info).no_headers = true;
+		php_output_set_status(0);
+
+		ZCG(auto_globals_mask) = 0;
+		ZCG(request_time) = (time_t)sapi_get_request_time();
+		ZCG(cache_opline) = NULL;
+		ZCG(cache_persistent_script) = NULL;
+		ZCG(include_path_key_len) = 0;
+		ZCG(include_path_check) = true;
+
+		ZCG(cwd) = NULL;
+		ZCG(cwd_key_len) = 0;
+		ZCG(cwd_check) = true;
+
+		if (accel_preload(ZCG(accel_directives).preload, in_child) != SUCCESS) {
+			ret = FAILURE;
+		}
+		preload_flush(NULL);
+
+		orig_report_memleaks = PG(report_memleaks);
+		PG(report_memleaks) = false;
+#ifdef ZEND_SIGNALS
+		/* We may not have registered signal handlers due to SIGG(reset)=0, so
+		 * also disable the check that they are registered. */
+		SIGG(check) = false;
+#endif
+		php_request_shutdown(NULL); /* calls zend_shared_alloc_unlock(); */
+		PG(report_memleaks) = orig_report_memleaks;
+	} else {
+		zend_shared_alloc_unlock();
+		ret = FAILURE;
+	}
+#ifdef ZEND_SIGNALS
+	SIGG(reset) = old_reset_signals;
+#endif
+
+	sapi_module.activate = orig_activate;
+	sapi_module.deactivate = orig_deactivate;
+	sapi_module.register_server_variables = orig_register_server_variables;
+	sapi_module.header_handler = orig_header_handler;
+	sapi_module.send_headers = orig_send_headers;
+	sapi_module.send_header = orig_send_header;
+	sapi_module.getenv = orig_getenv;
+	sapi_module.ub_write = orig_ub_write;
+	sapi_module.flush = orig_flush;
+
+	sapi_activate();
+
+	return ret;
+}
+
+static int accel_finish_startup_preload_subprocess(pid_t *pid)
+{
+	uid_t euid = geteuid();
+	if (euid != 0) {
+		if (ZCG(accel_directives).preload_user
+		 && *ZCG(accel_directives).preload_user) {
+			zend_accel_error(ACCEL_LOG_WARNING, "\"opcache.preload_user\" is ignored");
+		}
+
+		*pid = -1;
+		return SUCCESS;
+	}
+
+	if (!ZCG(accel_directives).preload_user
+	 || !*ZCG(accel_directives).preload_user) {
+
+
+		zend_shared_alloc_unlock();
+		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "\"opcache.preload\" requires \"opcache.preload_user\" when running under uid 0");
+		return FAILURE;
+	}
+
+	struct passwd *pw = getpwnam(ZCG(accel_directives).preload_user);
+	if (pw == NULL) {
+		zend_shared_alloc_unlock();
+		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to getpwnam(\"%s\")", ZCG(accel_directives).preload_user);
+		return FAILURE;
+	}
+
+	if (pw->pw_uid == euid) {
+		*pid = -1;
+		return SUCCESS;
+	}
+
+	*pid = fork();
+	if (*pid == -1) {
+		zend_shared_alloc_unlock();
+		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to fork()");
+		return FAILURE;
+	}
+
+	if (*pid == 0) { /* children */
+		if (setgid(pw->pw_gid) < 0) {
+			zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setgid(%d)", pw->pw_gid);
+			exit(1);
+		}
+		if (initgroups(pw->pw_name, pw->pw_gid) < 0) {
+			zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to initgroups(\"%s\", %d)", pw->pw_name, pw->pw_uid);
+			exit(1);
+		}
+		if (setuid(pw->pw_uid) < 0) {
+			zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setuid(%d)", pw->pw_uid);
+			exit(1);
+		}
+	}
+
+	return SUCCESS;
+}
+#endif /* ZEND_WIN32 */
+
 static int accel_finish_startup(void)
 {
 	if (!ZCG(enabled) || !accel_startup_ok) {
 		return SUCCESS;
 	}
 
-	if (ZCG(accel_directives).preload && *ZCG(accel_directives).preload) {
-#ifdef ZEND_WIN32
-		zend_accel_error_noreturn(ACCEL_LOG_ERROR, "Preloading is not supported on Windows");
-		return FAILURE;
-#else
-		bool in_child = false;
-		int ret = SUCCESS;
-		int rc;
-		int orig_error_reporting;
-
-		int (*orig_activate)(void) = sapi_module.activate;
-		int (*orig_deactivate)(void) = sapi_module.deactivate;
-		void (*orig_register_server_variables)(zval *track_vars_array) = sapi_module.register_server_variables;
-		int (*orig_header_handler)(sapi_header_struct *sapi_header, sapi_header_op_enum op, sapi_headers_struct *sapi_headers) = sapi_module.header_handler;
-		int (*orig_send_headers)(sapi_headers_struct *sapi_headers) = sapi_module.send_headers;
-		void (*orig_send_header)(sapi_header_struct *sapi_header, void *server_context)= sapi_module.send_header;
-		char *(*orig_getenv)(const char *name, size_t name_len) = sapi_module.getenv;
-		size_t (*orig_ub_write)(const char *str, size_t str_length) = sapi_module.ub_write;
-		void (*orig_flush)(void *server_context) = sapi_module.flush;
-#ifdef ZEND_SIGNALS
-		bool old_reset_signals = SIGG(reset);
-#endif
-
-		if (UNEXPECTED(file_cache_only)) {
-			zend_accel_error(ACCEL_LOG_WARNING, "Preloading doesn't work in \"file_cache_only\" mode");
-			return SUCCESS;
-		}
-
-		/* exclusive lock */
-		zend_shared_alloc_lock();
-
-		if (ZCSG(preload_script)) {
-			/* Preloading was done in another process */
-			preload_load();
-			zend_shared_alloc_unlock();
-			return SUCCESS;
-		}
-
-		uid_t euid = geteuid();
-		if (euid == 0) {
-			pid_t pid;
-			struct passwd *pw;
-
-			if (!ZCG(accel_directives).preload_user
-			 || !*ZCG(accel_directives).preload_user) {
-				zend_shared_alloc_unlock();
-				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "\"opcache.preload\" requires \"opcache.preload_user\" when running under uid 0");
-				return FAILURE;
-			}
-
-			pw = getpwnam(ZCG(accel_directives).preload_user);
-			if (pw == NULL) {
-				zend_shared_alloc_unlock();
-				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to getpwnam(\"%s\")", ZCG(accel_directives).preload_user);
-				return FAILURE;
-			}
-
-			if (pw->pw_uid != euid) {
-				pid = fork();
-				if (pid == -1) {
-					zend_shared_alloc_unlock();
-					zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to fork()");
-					return FAILURE;
-				} else if (pid == 0) { /* children */
-					if (setgid(pw->pw_gid) < 0) {
-						zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setgid(%d)", pw->pw_gid);
-						exit(1);
-					}
-					if (initgroups(pw->pw_name, pw->pw_gid) < 0) {
-						zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to initgroups(\"%s\", %d)", pw->pw_name, pw->pw_uid);
-						exit(1);
-					}
-					if (setuid(pw->pw_uid) < 0) {
-						zend_accel_error(ACCEL_LOG_WARNING, "Preloading failed to setuid(%d)", pw->pw_uid);
-						exit(1);
-					}
-					in_child = true;
-				} else { /* parent */
-					int status;
-
-					if (waitpid(pid, &status, 0) < 0) {
-						zend_shared_alloc_unlock();
-						zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to waitpid(%d)", pid);
-						return FAILURE;
-					}
-
-					if (ZCSG(preload_script)) {
-						preload_load();
-					}
-
-					zend_shared_alloc_unlock();
-					if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
-						return SUCCESS;
-					} else {
-						return FAILURE;
-					}
-				}
-			}
-		} else {
-			if (ZCG(accel_directives).preload_user
-			 && *ZCG(accel_directives).preload_user) {
-				zend_accel_error(ACCEL_LOG_WARNING, "\"opcache.preload_user\" is ignored");
-			}
-		}
-
-		sapi_module.activate = NULL;
-		sapi_module.deactivate = NULL;
-		sapi_module.register_server_variables = NULL;
-		sapi_module.header_handler = preload_header_handler;
-		sapi_module.send_headers = preload_send_headers;
-		sapi_module.send_header = preload_send_header;
-		sapi_module.getenv = NULL;
-		sapi_module.ub_write = preload_ub_write;
-		sapi_module.flush = preload_flush;
-
-		zend_interned_strings_switch_storage(1);
-
-#ifdef ZEND_SIGNALS
-		SIGG(reset) = false;
-#endif
-
-		orig_error_reporting = EG(error_reporting);
-		EG(error_reporting) = 0;
-
-		rc = php_request_startup();
-
-		EG(error_reporting) = orig_error_reporting;
-
-		if (rc == SUCCESS) {
-			bool orig_report_memleaks;
-
-			/* don't send headers */
-			SG(headers_sent) = true;
-			SG(request_info).no_headers = true;
-			php_output_set_status(0);
-
-			ZCG(auto_globals_mask) = 0;
-			ZCG(request_time) = (time_t)sapi_get_request_time();
-			ZCG(cache_opline) = NULL;
-			ZCG(cache_persistent_script) = NULL;
-			ZCG(include_path_key_len) = 0;
-			ZCG(include_path_check) = true;
-
-			ZCG(cwd) = NULL;
-			ZCG(cwd_key_len) = 0;
-			ZCG(cwd_check) = true;
-
-			if (accel_preload(ZCG(accel_directives).preload, in_child) != SUCCESS) {
-				ret = FAILURE;
-			}
-			preload_flush(NULL);
-
-			orig_report_memleaks = PG(report_memleaks);
-			PG(report_memleaks) = false;
-#ifdef ZEND_SIGNALS
-			/* We may not have registered signal handlers due to SIGG(reset)=0, so
-			 * also disable the check that they are registered. */
-			SIGG(check) = false;
-#endif
-			php_request_shutdown(NULL); /* calls zend_shared_alloc_unlock(); */
-			PG(report_memleaks) = orig_report_memleaks;
-		} else {
-			zend_shared_alloc_unlock();
-			ret = FAILURE;
-		}
-#ifdef ZEND_SIGNALS
-		SIGG(reset) = old_reset_signals;
-#endif
-
-		sapi_module.activate = orig_activate;
-		sapi_module.deactivate = orig_deactivate;
-		sapi_module.register_server_variables = orig_register_server_variables;
-		sapi_module.header_handler = orig_header_handler;
-		sapi_module.send_headers = orig_send_headers;
-		sapi_module.send_header = orig_send_header;
-		sapi_module.getenv = orig_getenv;
-		sapi_module.ub_write = orig_ub_write;
-		sapi_module.flush = orig_flush;
-
-		sapi_activate();
-
-		if (in_child) {
-			if (ret == SUCCESS) {
-				exit(0);
-			} else {
-				exit(2);
-			}
-		}
-
-		return ret;
-#endif
+	if (!(ZCG(accel_directives).preload && *ZCG(accel_directives).preload)) {
+		return SUCCESS;
 	}
 
-	return SUCCESS;
+#ifdef ZEND_WIN32
+	zend_accel_error_noreturn(ACCEL_LOG_ERROR, "Preloading is not supported on Windows");
+	return FAILURE;
+#else /* ZEND_WIN32 */
+
+	if (UNEXPECTED(file_cache_only)) {
+		zend_accel_error(ACCEL_LOG_WARNING, "Preloading doesn't work in \"file_cache_only\" mode");
+		return SUCCESS;
+	}
+
+	/* exclusive lock */
+	zend_shared_alloc_lock();
+
+	if (ZCSG(preload_script)) {
+		/* Preloading was done in another process */
+		preload_load();
+		zend_shared_alloc_unlock();
+		return SUCCESS;
+	}
+
+
+	pid_t pid;
+	if (accel_finish_startup_preload_subprocess(&pid) == FAILURE) {
+		zend_shared_alloc_unlock();
+		return FAILURE;
+	}
+
+	if (pid == -1) { /* no subprocess was needed */
+		return accel_finish_startup_preload(false);
+	} else if (pid == 0) { /* subprocess */
+		int ret = accel_finish_startup_preload(true);
+
+		exit(ret == SUCCESS ? 0 : 1);
+	} else { /* parent */
+		int status;
+
+		if (waitpid(pid, &status, 0) < 0) {
+			zend_shared_alloc_unlock();
+			zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Preloading failed to waitpid(%d)", pid);
+		}
+
+		if (ZCSG(preload_script)) {
+			preload_load();
+		}
+
+		if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+			return SUCCESS;
+		} else {
+			return FAILURE;
+		}
+	}
+#endif /* ZEND_WIN32 */
 }
 
 ZEND_EXT_API zend_extension zend_extension_entry = {

--- a/ext/opcache/tests/preload_user.inc
+++ b/ext/opcache/tests/preload_user.inc
@@ -1,0 +1,5 @@
+<?php
+
+var_dump(posix_getuid() === 0);
+
+require __DIR__ . '/preload.inc';

--- a/ext/opcache/tests/preload_user_001.phpt
+++ b/ext/opcache/tests/preload_user_001.phpt
@@ -22,7 +22,7 @@ var_dump(function_exists("f2"));
 ?>
 OK
 --EXPECTF--
-%sWarning "opcache.preload_user" is ignored
+%sWarning "opcache.preload_user" is ignored because the current user is not "root"
 bool(true)
 bool(false)
 OK

--- a/ext/opcache/tests/preload_user_001.phpt
+++ b/ext/opcache/tests/preload_user_001.phpt
@@ -1,0 +1,28 @@
+--TEST--
+preload_user has no effect when euid is not 0
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.preload={PWD}/preload.inc
+opcache.preload_user=php
+opcache.log_verbosity_level=2
+--EXTENSIONS--
+opcache
+posix
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (posix_geteuid() === 0) die('skip Test needs non-root user');
+?>
+--FILE--
+<?php
+var_dump(function_exists("f1"));
+var_dump(function_exists("f2"));
+?>
+OK
+--EXPECTF--
+%sWarning "opcache.preload_user" is ignored
+bool(true)
+bool(false)
+OK

--- a/ext/opcache/tests/preload_user_002.phpt
+++ b/ext/opcache/tests/preload_user_002.phpt
@@ -1,0 +1,28 @@
+--TEST--
+preload_user sets the process uid
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.preload={PWD}/preload_user.inc
+opcache.preload_user={ENV:TEST_NON_ROOT_USER}
+opcache.log_verbosity_level=2
+--EXTENSIONS--
+opcache
+posix
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (posix_geteuid() !== 0) die('skip Test needs root user');
+?>
+--FILE--
+<?php
+var_dump(function_exists("f1"));
+var_dump(function_exists("f2"));
+?>
+OK
+--EXPECTF--
+bool(false)
+bool(true)
+bool(false)
+OK

--- a/ext/opcache/tests/preload_user_003.phpt
+++ b/ext/opcache/tests/preload_user_003.phpt
@@ -1,0 +1,29 @@
+--TEST--
+preload_user has no effect when preload_user is the current user
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.preload={PWD}/preload_user.inc
+opcache.preload_user=root
+opcache.log_verbosity_level=2
+--EXTENSIONS--
+opcache
+posix
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (posix_geteuid() !== 0) die('skip Test needs root user');
+if (posix_getpwnam('root') === false) die('skip Root user does not exist');
+?>
+--FILE--
+<?php
+var_dump(function_exists("f1"));
+var_dump(function_exists("f2"));
+?>
+OK
+--EXPECTF--
+bool(true)
+bool(true)
+bool(false)
+OK

--- a/ext/opcache/tests/preload_user_004.phpt
+++ b/ext/opcache/tests/preload_user_004.phpt
@@ -1,0 +1,72 @@
+--TEST--
+preload_user is required when euid is 0 under non-cli SAPIs
+--INI--
+--EXTENSIONS--
+opcache
+posix
+--SKIPIF--
+<?php
+require dirname(__DIR__, 3) . '/sapi/fpm/tests/skipif.inc';
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (posix_geteuid() !== 0) die('skip Test needs root user');
+?>
+--FILE--
+<?php
+
+require_once dirname(__DIR__, 3) . '/sapi/fpm/tests/tester.inc';
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$code = <<<EOT
+<?php
+var_dump(function_exists("f1"));
+var_dump(function_exists("f2"));
+?>
+OK
+EOT;
+
+$args = [];
+if (file_exists(ini_get('extension_dir').'/opcache.so')) {
+    $args[] = '-dzend_extension='.ini_get('extension_dir').'/opcache.so';
+}
+if (file_exists(ini_get('extension_dir').'/posix.so')) {
+    $args[] = '-dextension='.ini_get('extension_dir').'/posix.so';
+}
+$args = [
+    ...$args,
+    '-dopcache.enable=1',
+    '-dopcache.optimization_level=-1',
+    '-dopcache.preload='.__DIR__.'/preload.inc',
+    '-dopcache.log_verbosity_level=2',
+];
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start($args);
+var_dump($tester->getLogLines(1));
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECTF--
+array(1) {
+  [0]=>
+  string(%d) "%sFatal Error "opcache.preload" requires "opcache.preload_user" when running under uid 0
+"
+}
+Done
+--CLEAN--
+<?php
+require_once dirname(__DIR__, 3) . '/sapi/fpm/tests/tester.inc';
+FPM\Tester::clean();
+?>

--- a/ext/opcache/tests/preload_user_005.phpt
+++ b/ext/opcache/tests/preload_user_005.phpt
@@ -1,0 +1,77 @@
+--TEST--
+preload_user=root is allowed under non-cli SAPIs
+--INI--
+--EXTENSIONS--
+opcache
+posix
+--SKIPIF--
+<?php
+require dirname(__DIR__, 3) . '/sapi/fpm/tests/skipif.inc';
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+if (posix_geteuid() !== 0) die('skip Test needs root user');
+if (posix_getpwnam('root') === false) die('skip Root user does not exist');
+?>
+--FILE--
+<?php
+
+require_once dirname(__DIR__, 3) . '/sapi/fpm/tests/tester.inc';
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$code = <<<EOT
+<?php
+var_dump(function_exists("f1"));
+var_dump(function_exists("f2"));
+?>
+OK
+EOT;
+
+$args = [];
+if (file_exists(ini_get('extension_dir').'/opcache.so')) {
+    $args[] = '-dzend_extension='.ini_get('extension_dir').'/opcache.so';
+}
+if (file_exists(ini_get('extension_dir').'/posix.so')) {
+    $args[] = '-dextension='.ini_get('extension_dir').'/posix.so';
+}
+$args = [
+    ...$args,
+    '-dopcache.enable=1',
+    '-dopcache.optimization_level=-1',
+    '-dopcache.preload='.__DIR__.'/preload.inc',
+    '-dopcache.preload_user=root',
+    '-dopcache.log_verbosity_level=2',
+    '-R',
+];
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start($args);
+$tester->expectLogStartNotices();
+$tester
+    ->request()
+    ->expectBody([
+        'bool(true)',
+        'bool(false)',
+        'OK',
+    ]);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once dirname(__DIR__, 3) . '/sapi/fpm/tests/tester.inc';
+FPM\Tester::clean();
+?>

--- a/run-tests.php
+++ b/run-tests.php
@@ -2067,9 +2067,6 @@ TEST $file
         // Make sure warnings still show up on the second run.
         $ini_settings['opcache.record_warnings'] = '1';
     }
-    if (extension_loaded('posix') && posix_getuid() === 0) {
-        $ini_settings['opcache.preload_user'] = 'root';
-    }
 
     // Any special ini settings
     // these may overwrite the test defaults...
@@ -2078,6 +2075,19 @@ TEST $file
         $ini = str_replace('{TMP}', sys_get_temp_dir(), $ini);
         $replacement = IS_WINDOWS ? '"' . PHP_BINARY . ' -r \"while ($in = fgets(STDIN)) echo $in;\" > $1"' : 'tee $1 >/dev/null';
         $ini = preg_replace('/{MAIL:(\S+)}/', $replacement, $ini);
+        $skip = false;
+        $ini = preg_replace_callback('/{ENV:(\S+)}/', function ($m) use (&$skip) {
+            $name = $m[1];
+            $value = getenv($name);
+            if ($value === false) {
+                $skip = sprintf('Environment variable %s is not set', $name);
+                return '';
+            }
+            return $value;
+        }, $ini);
+        if ($skip !== false) {
+            return skip_test($tested, $tested_file, $shortname, $skip);
+        }
         settings2array(preg_split("/[\n\r]+/", $ini), $ini_settings);
 
         if ($num_repeats > 1 && isset($ini_settings['opcache.opt_debug_level'])) {


### PR DESCRIPTION
This is a followup of #9473: `opcache.preload_user` does not have to be required when the SAPI executes requests and startup as the same user.

This PR changes `opcache.preload_user` so that it's not required under cli and phpdbg SAPIs.
