### PR TITLE
Require PHP 7.4 at least for running the build system

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -62,6 +62,8 @@ PHP 8.2 INTERNALS UPGRADE NOTES
 2. Build system changes
 ========================
 
+* The build system now requires PHP 7.4.0 at least. Previously PHP 7.1 was
+  required.
 * Unsupported libxml2 2.10.0 symbols are no longer exported on Windows.
 * Identifier names for namespaced functions generated from stub files through
   gen_stub.php have been changed. This requires that namespaced functions

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -17,10 +17,6 @@ use PhpParser\PrettyPrinterAbstract;
 error_reporting(E_ALL);
 ini_set("precision", "-1");
 
-if (PHP_VERSION_ID < 70400) {
-    throw new Exception("The build system requires PHP 7.4 at least.\n");
-}
-
 const PHP_70_VERSION_ID = 70000;
 const PHP_80_VERSION_ID = 80000;
 const PHP_81_VERSION_ID = 80100;

--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -17,6 +17,10 @@ use PhpParser\PrettyPrinterAbstract;
 error_reporting(E_ALL);
 ini_set("precision", "-1");
 
+if (PHP_VERSION_ID < 70400) {
+    throw new Exception("The build system requires PHP 7.4 at least.\n");
+}
+
 const PHP_70_VERSION_ID = 70000;
 const PHP_80_VERSION_ID = 80000;
 const PHP_81_VERSION_ID = 80100;

--- a/build/php.m4
+++ b/build/php.m4
@@ -1900,8 +1900,8 @@ AC_DEFUN([PHP_PROG_PHP],[
     set $php_version
     IFS=$ac_IFS
     php_version_num=`expr [$]{1:-0} \* 10000 + [$]{2:-0} \* 100 + [$]{3:-0}`
-    dnl Minimum supported version for gen_stubs.php is PHP 7.1.
-    if test "$php_version_num" -lt 70100; then
+    dnl Minimum supported version for gen_stubs.php is PHP 7.4.
+    if test "$php_version_num" -lt 70400; then
       AC_MSG_RESULT([$php_version (too old)])
       unset PHP
     else

--- a/build/php.m4
+++ b/build/php.m4
@@ -1900,7 +1900,7 @@ AC_DEFUN([PHP_PROG_PHP],[
     set $php_version
     IFS=$ac_IFS
     php_version_num=`expr [$]{1:-0} \* 10000 + [$]{2:-0} \* 100 + [$]{3:-0}`
-    dnl Minimum supported version for gen_stubs.php is PHP 7.4.
+    dnl Minimum supported version for gen_stub.php is PHP 7.4.
     if test "$php_version_num" -lt 70400; then
       AC_MSG_RESULT([$php_version (too old)])
       unset PHP


### PR DESCRIPTION
Due to https://github.com/php/php-src/pull/9512#issuecomment-1242388676. The target branch (PHP-8.2 vs master) can be under debate, but I chose the former for now.

I guess our Travis config should be adapted as well in order to use PHP 7.4, but I'm not sure yet how to do (will have time later to find it out)