### PR TITLE
Fix ZEND_RC_MOD_CHECK() for thread local ini parser strings

### DIFF
--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -269,6 +269,9 @@ ZEND_API zend_result zend_parse_ini_string(char *str, bool unbuffered_errors, in
 static void zval_ini_dtor(zval *zv)
 {
 	if (Z_TYPE_P(zv) == IS_STRING) {
+		if (ZEND_SYSTEM_INI) {
+			GC_MAKE_PERSISTENT_LOCAL(Z_STR_P(zv));
+		}
 		zend_string_release(Z_STR_P(zv));
 	}
 }
@@ -324,6 +327,9 @@ statement:
 			printf("NORMAL: '%s' = '%s'\n", Z_STRVAL($1), Z_STRVAL($3));
 #endif
 			ZEND_INI_PARSER_CB(&$1, &$3, NULL, ZEND_INI_PARSER_ENTRY, ZEND_INI_PARSER_ARG);
+			if (ZEND_SYSTEM_INI) {
+				GC_MAKE_PERSISTENT_LOCAL(Z_STR($1));
+			}
 			zend_string_release(Z_STR($1));
 			zval_ini_dtor(&$3);
 		}


### PR DESCRIPTION
This fixes [this failure](https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=28336&view=ms.vss-test-web.build-test-results-tab&runId=619390&paneView=debug&resultId=116667) in `sapi/fpm/tests/bug77780-header-sent-error.phpt` when building with `zts` and `-DZEND_RC_DEBUG=1`.

The ini parser releases temporary strings that can be persistent. The strings are not marked as thread local, so when PHP is compiled with `zts` and `-DZEND_RC_DEBUG=1` releasing the string will fail even if the string has not yet had a chance to escape to other threads (as we're still parsing at this point). Thus we mark the string as thread local before releasing. Alternatively we could mark all strings generated by the lexer as thread local, and then remove the flag if the value survives the parsing phase. But those are harder to track down.

There are more places in the ini parser where strings are released/freed. I don't understand why this isn't triggered in other tests. Let me know if I need to extend this check to other places.