### PR TITLE
Use true return type for XML functions which always return true

### DIFF
--- a/ext/xml/xml.c
+++ b/ext/xml/xml.c
@@ -1052,7 +1052,7 @@ PHP_FUNCTION(xml_set_object)
 	zval_ptr_dtor(&parser->object);
 	ZVAL_OBJ_COPY(&parser->object, Z_OBJ_P(mythis));
 
-	RETVAL_TRUE;
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1070,7 +1070,8 @@ PHP_FUNCTION(xml_set_element_handler)
 	xml_set_handler(&parser->startElementHandler, shdl);
 	xml_set_handler(&parser->endElementHandler, ehdl);
 	XML_SetElementHandler(parser->parser, _xml_startElementHandler, _xml_endElementHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1087,7 +1088,8 @@ PHP_FUNCTION(xml_set_character_data_handler)
 	parser = Z_XMLPARSER_P(pind);
 	xml_set_handler(&parser->characterDataHandler, hdl);
 	XML_SetCharacterDataHandler(parser->parser, _xml_characterDataHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1104,7 +1106,8 @@ PHP_FUNCTION(xml_set_processing_instruction_handler)
 	parser = Z_XMLPARSER_P(pind);
 	xml_set_handler(&parser->processingInstructionHandler, hdl);
 	XML_SetProcessingInstructionHandler(parser->parser, _xml_processingInstructionHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1121,7 +1124,8 @@ PHP_FUNCTION(xml_set_default_handler)
 	parser = Z_XMLPARSER_P(pind);
 	xml_set_handler(&parser->defaultHandler, hdl);
 	XML_SetDefaultHandler(parser->parser, _xml_defaultHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1138,7 +1142,8 @@ PHP_FUNCTION(xml_set_unparsed_entity_decl_handler)
 	parser = Z_XMLPARSER_P(pind);
 	xml_set_handler(&parser->unparsedEntityDeclHandler, hdl);
 	XML_SetUnparsedEntityDeclHandler(parser->parser, _xml_unparsedEntityDeclHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1155,7 +1160,8 @@ PHP_FUNCTION(xml_set_notation_decl_handler)
 	parser = Z_XMLPARSER_P(pind);
 	xml_set_handler(&parser->notationDeclHandler, hdl);
 	XML_SetNotationDeclHandler(parser->parser, _xml_notationDeclHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1172,7 +1178,8 @@ PHP_FUNCTION(xml_set_external_entity_ref_handler)
 	parser = Z_XMLPARSER_P(pind);
 	xml_set_handler(&parser->externalEntityRefHandler, hdl);
 	XML_SetExternalEntityRefHandler(parser->parser, (void *) _xml_externalEntityRefHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1189,7 +1196,8 @@ PHP_FUNCTION(xml_set_start_namespace_decl_handler)
 	parser = Z_XMLPARSER_P(pind);
 	xml_set_handler(&parser->startNamespaceDeclHandler, hdl);
 	XML_SetStartNamespaceDeclHandler(parser->parser, _xml_startNamespaceDeclHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1206,7 +1214,8 @@ PHP_FUNCTION(xml_set_end_namespace_decl_handler)
 	parser = Z_XMLPARSER_P(pind);
 	xml_set_handler(&parser->endNamespaceDeclHandler, hdl);
 	XML_SetEndNamespaceDeclHandler(parser->parser, _xml_endNamespaceDeclHandler);
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -1406,6 +1415,7 @@ PHP_FUNCTION(xml_parser_set_option)
 			if (parser->toffset < 0) {
 				php_error_docref(NULL, E_WARNING, "tagstart ignored, because it is out of range");
 				parser->toffset = 0;
+				/* TODO Should this return false? */
 			}
 			break;
 		case PHP_XML_OPTION_SKIP_WHITE:
@@ -1431,7 +1441,8 @@ PHP_FUNCTION(xml_parser_set_option)
 			RETURN_THROWS();
 			break;
 	}
-	RETVAL_TRUE;
+
+	RETURN_TRUE;
 }
 /* }}} */
 

--- a/ext/xml/xml.stub.php
+++ b/ext/xml/xml.stub.php
@@ -138,37 +138,37 @@ function xml_parser_create(?string $encoding = null): XMLParser {}
 
 function xml_parser_create_ns(?string $encoding = null, string $separator = ":"): XMLParser {}
 
-function xml_set_object(XMLParser $parser, object $object): bool {}
+function xml_set_object(XMLParser $parser, object $object): true {}
 
 /**
  * @param callable $start_handler
  * @param callable $end_handler
  */
-function xml_set_element_handler(XMLParser $parser, $start_handler, $end_handler): bool {}
+function xml_set_element_handler(XMLParser $parser, $start_handler, $end_handler): true {}
 
 /** @param callable $handler */
-function xml_set_character_data_handler(XMLParser $parser, $handler): bool {}
+function xml_set_character_data_handler(XMLParser $parser, $handler): true {}
 
 /** @param callable $handler */
-function xml_set_processing_instruction_handler(XMLParser $parser, $handler): bool {}
+function xml_set_processing_instruction_handler(XMLParser $parser, $handler): true {}
 
 /** @param callable $handler */
-function xml_set_default_handler(XMLParser $parser, $handler): bool {}
+function xml_set_default_handler(XMLParser $parser, $handler): true {}
 
 /** @param callable $handler */
-function xml_set_unparsed_entity_decl_handler(XMLParser $parser, $handler): bool {}
+function xml_set_unparsed_entity_decl_handler(XMLParser $parser, $handler): true {}
 
 /** @param callable $handler */
-function xml_set_notation_decl_handler(XMLParser $parser, $handler): bool {}
+function xml_set_notation_decl_handler(XMLParser $parser, $handler): true {}
 
 /** @param callable $handler */
-function xml_set_external_entity_ref_handler(XMLParser $parser, $handler): bool {}
+function xml_set_external_entity_ref_handler(XMLParser $parser, $handler): true {}
 
 /** @param callable $handler */
-function xml_set_start_namespace_decl_handler(XMLParser $parser, $handler): bool {}
+function xml_set_start_namespace_decl_handler(XMLParser $parser, $handler): true {}
 
 /** @param callable $handler */
-function xml_set_end_namespace_decl_handler(XMLParser $parser, $handler): bool {}
+function xml_set_end_namespace_decl_handler(XMLParser $parser, $handler): true {}
 
 function xml_parse(XMLParser $parser, string $data, bool $is_final = false): int {}
 
@@ -192,7 +192,7 @@ function xml_get_current_byte_index(XMLParser $parser): int {}
 function xml_parser_free(XMLParser $parser): bool {}
 
 /** @param string|int $value */
-function xml_parser_set_option(XMLParser $parser, int $option, $value): bool {}
+function xml_parser_set_option(XMLParser $parser, int $option, $value): true {}
 
 /** @refcount 1 */
 function xml_parser_get_option(XMLParser $parser, int $option): string|int {}

--- a/ext/xml/xml_arginfo.h
+++ b/ext/xml/xml_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 97b941147b54b4e1cd3d8fff2cba8a43a3065aad */
+ * Stub hash: b4170c863f645ea5ebf7a26ede204cc92e8c97a1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_xml_parser_create, 0, 0, XMLParser, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, encoding, IS_STRING, 1, "null")
@@ -10,18 +10,18 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_xml_parser_create_ns, 0, 0, XMLPa
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, separator, IS_STRING, 0, "\":\"")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_set_object, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_set_object, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_OBJ_INFO(0, parser, XMLParser, 0)
 	ZEND_ARG_TYPE_INFO(0, object, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_set_element_handler, 0, 3, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_set_element_handler, 0, 3, IS_TRUE, 0)
 	ZEND_ARG_OBJ_INFO(0, parser, XMLParser, 0)
 	ZEND_ARG_INFO(0, start_handler)
 	ZEND_ARG_INFO(0, end_handler)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_set_character_data_handler, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_set_character_data_handler, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_OBJ_INFO(0, parser, XMLParser, 0)
 	ZEND_ARG_INFO(0, handler)
 ZEND_END_ARG_INFO()
@@ -71,7 +71,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_parser_free, 0, 1, _IS_BOOL,
 	ZEND_ARG_OBJ_INFO(0, parser, XMLParser, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_parser_set_option, 0, 3, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_xml_parser_set_option, 0, 3, IS_TRUE, 0)
 	ZEND_ARG_OBJ_INFO(0, parser, XMLParser, 0)
 	ZEND_ARG_TYPE_INFO(0, option, IS_LONG, 0)
 	ZEND_ARG_INFO(0, value)


### PR DESCRIPTION
I hope this can land for PHP-8.2. As I think those functions have only been returning true since PHP 8.0 and the false return I expect to be from ZPP failures.

Docs will probably need amending, but this might make more sense to do via the stubs generation script.