### PR TITLE
Fix GH-9372: HY010 when binding overlong parameter

### DIFF
--- a/ext/pdo_odbc/odbc_stmt.c
+++ b/ext/pdo_odbc/odbc_stmt.c
@@ -155,7 +155,7 @@ static int odbc_stmt_dtor(pdo_stmt_t *stmt)
 
 static int odbc_stmt_execute(pdo_stmt_t *stmt)
 {
-	RETCODE rc;
+	RETCODE rc, rc1;
 	pdo_odbc_stmt *S = (pdo_odbc_stmt*)stmt->driver_data;
 	char *buf = NULL;
 	SQLLEN row_count = -1;
@@ -192,11 +192,17 @@ static int odbc_stmt_execute(pdo_stmt_t *stmt)
 							Z_STRLEN_P(parameter),
 							&ulen)) {
 					case PDO_ODBC_CONV_NOT_REQUIRED:
-						SQLPutData(S->stmt, Z_STRVAL_P(parameter),
+						rc1 = SQLPutData(S->stmt, Z_STRVAL_P(parameter),
 							Z_STRLEN_P(parameter));
+						if (rc1 != SQL_SUCCESS && rc1 != SQL_SUCCESS_WITH_INFO) {
+							rc = rc1;
+						}
 						break;
 					case PDO_ODBC_CONV_OK:
-						SQLPutData(S->stmt, S->convbuf, ulen);
+						rc1 = SQLPutData(S->stmt, S->convbuf, ulen);
+						if (rc1 != SQL_SUCCESS && rc1 != SQL_SUCCESS_WITH_INFO) {
+							rc = rc1;
+						}
 						break;
 					case PDO_ODBC_CONV_FAIL:
 						pdo_odbc_stmt_error("error converting input string");
@@ -233,7 +239,10 @@ static int odbc_stmt_execute(pdo_stmt_t *stmt)
 				if (len == 0) {
 					break;
 				}
-				SQLPutData(S->stmt, buf, len);
+				rc1 = SQLPutData(S->stmt, buf, len);
+				if (rc1 != SQL_SUCCESS && rc1 != SQL_SUCCESS_WITH_INFO) {
+					rc = rc1;
+				}
 			} while (1);
 		}
 	}

--- a/ext/pdo_odbc/tests/gh9372.phpt
+++ b/ext/pdo_odbc/tests/gh9372.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Bug GH-9372 (HY010 when binding overlong parameter)
+--SKIPIF--
+<?php
+if (!extension_loaded('pdo_odbc')) die('skip pdo_odbc extension not available');
+require 'ext/pdo/tests/pdo_test.inc';
+PDOTest::skip();
+?>
+--FILE--
+<?php
+require 'ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$db->exec("CREATE TABLE gh9372 (col VARCHAR(10))");
+$db->exec("INSERT INTO gh9372 VALUES ('something')");
+
+$stmt = $db->prepare("SELECT * FROM bug74186 WHERE col = ?");
+$stmt->bindValue(1, 'something else');
+try {
+    $stmt->execute();
+} catch (PDOException $ex) {
+    if ($ex->getCode() !== "22001") {
+        var_dump($ex->getMessage());
+    }
+}
+
+$stmt = $db->prepare("SELECT * FROM bug74186 WHERE col = ?");
+$stream = fopen("php://memory", "w+");
+fwrite($stream, 'something else');
+rewind($stream);
+$stmt->bindvalue(1, $stream, PDO::PARAM_LOB);
+try {
+    $stmt->execute();
+} catch (PDOException $ex) {
+    if ($ex->getCode() !== "22001") {
+        var_dump($ex->getMessage());
+    }
+}
+?>
+--CLEAN--
+<?php
+require 'ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
+$db->exec("DROP TABLE gh9372");
+?>
+--EXPECT--

--- a/ext/pdo_odbc/tests/gh9372.phpt
+++ b/ext/pdo_odbc/tests/gh9372.phpt
@@ -15,7 +15,7 @@ $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->exec("CREATE TABLE gh9372 (col VARCHAR(10))");
 $db->exec("INSERT INTO gh9372 VALUES ('something')");
 
-$stmt = $db->prepare("SELECT * FROM bug74186 WHERE col = ?");
+$stmt = $db->prepare("SELECT * FROM gh9372 WHERE col = ?");
 $stmt->bindValue(1, 'something else');
 try {
     $stmt->execute();
@@ -25,7 +25,7 @@ try {
     }
 }
 
-$stmt = $db->prepare("SELECT * FROM bug74186 WHERE col = ?");
+$stmt = $db->prepare("SELECT * FROM gh9372 WHERE col = ?");
 $stream = fopen("php://memory", "w+");
 fwrite($stream, 'something else');
 rewind($stream);

--- a/ext/pdo_odbc/tests/gh9372.phpt
+++ b/ext/pdo_odbc/tests/gh9372.phpt
@@ -1,8 +1,9 @@
 --TEST--
 Bug GH-9372 (HY010 when binding overlong parameter)
+--EXTENSIONS--
+pdo_odbc
 --SKIPIF--
 <?php
-if (!extension_loaded('pdo_odbc')) die('skip pdo_odbc extension not available');
 require 'ext/pdo/tests/pdo_test.inc';
 PDOTest::skip();
 ?>

--- a/ext/pdo_odbc/tests/gh9372.phpt
+++ b/ext/pdo_odbc/tests/gh9372.phpt
@@ -8,6 +8,10 @@ PDOTest::skip();
 ?>
 --FILE--
 <?php
+// Executing the statements fails with some drivers, but not others.
+// The test is written in a way to always pass, unless the execution
+// fails with a different code than 22001 (String data, right truncation).
+
 require 'ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(dirname(__FILE__) . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
If `SQLPutData()` *fails*, we should not call `SQLParamData()` again, because that yields the confusing `HY010` (Function sequence error). Instead we properly handle `SQLPutData()` errors.

For the given case (paramter length > column length), some drivers let `SQLPutData()` fail, while others do not.  Either behavior seems to conform to the ODBC specification.  Anyhow, we do not want to silently truncate the given parameter, since that would break the behavior for drivers which do not fail, but still don't simply truncate the given parameter.  So it is finally up to userland to avoid passing overlong parameters – with this patch they at least get useful information about the actual issue.