### PR TITLE
Don't throw CompileError after parsing

### DIFF
--- a/Zend/tests/use_statement/aliasing_builtin_types.phpt
+++ b/Zend/tests/use_statement/aliasing_builtin_types.phpt
@@ -3,76 +3,8 @@ Aliasing built-in types
 --FILE--
 <?php
 
-/* Taken from zend_compile.c reserved_class_names[] struct */
-/* array and list are also added as they are language constructs */
-$types = [
-    "bool",
-    "false",
-    "float",
-    "int",
-    "null",
-    "parent",
-    "self",
-    "static",
-    "string",
-    "true",
-    "void",
-    "never",
-    "iterable",
-    "object",
-    "mixed",
-    "array",
-    "list",
-];
-
-foreach ($types as $type) {
-    try {
-        eval("use $type as A;");
-    } catch (\Throwable $e) {
-        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
-    }
-    try {
-        eval("use $type as A; function foo$type(A \$v): A { return \$v; }");
-    } catch (\Throwable $e) {
-        echo $e::class, ': ', $e->getMessage(), PHP_EOL;
-    }
-}
+use bool as A;
 
 ?>
-DONE
---EXPECT--
-CompileError: Cannot alias 'bool' as it is a built-in type
-CompileError: Cannot alias 'bool' as it is a built-in type
-CompileError: Cannot alias 'false' as it is a built-in type
-CompileError: Cannot alias 'false' as it is a built-in type
-CompileError: Cannot alias 'float' as it is a built-in type
-CompileError: Cannot alias 'float' as it is a built-in type
-CompileError: Cannot alias 'int' as it is a built-in type
-CompileError: Cannot alias 'int' as it is a built-in type
-CompileError: Cannot alias 'null' as it is a built-in type
-CompileError: Cannot alias 'null' as it is a built-in type
-CompileError: Cannot alias 'parent' as it is a built-in type
-CompileError: Cannot alias 'parent' as it is a built-in type
-CompileError: Cannot alias 'self' as it is a built-in type
-CompileError: Cannot alias 'self' as it is a built-in type
-ParseError: syntax error, unexpected token "static"
-ParseError: syntax error, unexpected token "static"
-CompileError: Cannot alias 'string' as it is a built-in type
-CompileError: Cannot alias 'string' as it is a built-in type
-CompileError: Cannot alias 'true' as it is a built-in type
-CompileError: Cannot alias 'true' as it is a built-in type
-CompileError: Cannot alias 'void' as it is a built-in type
-CompileError: Cannot alias 'void' as it is a built-in type
-CompileError: Cannot alias 'never' as it is a built-in type
-CompileError: Cannot alias 'never' as it is a built-in type
-CompileError: Cannot alias 'iterable' as it is a built-in type
-CompileError: Cannot alias 'iterable' as it is a built-in type
-CompileError: Cannot alias 'object' as it is a built-in type
-CompileError: Cannot alias 'object' as it is a built-in type
-CompileError: Cannot alias 'mixed' as it is a built-in type
-CompileError: Cannot alias 'mixed' as it is a built-in type
-ParseError: syntax error, unexpected token "array"
-ParseError: syntax error, unexpected token "array"
-ParseError: syntax error, unexpected token "list"
-ParseError: syntax error, unexpected token "list"
-DONE
+--EXPECTF--
+Fatal error: Cannot alias 'bool' as it is a built-in type in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8084,9 +8084,8 @@ static void zend_compile_use(zend_ast *ast) /* {{{ */
 
 		/* Check that we are not attempting to alias a built-in type */
 		if (type == ZEND_SYMBOL_CLASS && zend_is_reserved_class_name(old_name)) {
-			zend_throw_exception_ex(zend_ce_compile_error, 0,
+			zend_error_noreturn(E_COMPILE_ERROR, 
 				"Cannot alias '%s' as it is a built-in type", ZSTR_VAL(old_name));
-			return;
 		}
 
 		if (new_name_ast) {


### PR DESCRIPTION
Aborting parsing is not safe, a fatal error is necessary.

See https://github.com/php/php-src/commit/b9f7123c5e4ccdc3c381ab949ff01e3c14f3465c