### PR TITLE
remove LIBZIP_VERSION constant def from stub

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -3110,6 +3110,12 @@ static PHP_MINIT_FUNCTION(zip)
 	php_zip_register_prop_handler(&zip_prop_handlers, "filename",  NULL, php_zipobj_get_filename, IS_STRING);
 	php_zip_register_prop_handler(&zip_prop_handlers, "comment",   NULL, php_zipobj_get_zip_comment, IS_STRING);
 
+#ifdef HAVE_LIBZIP_VERSION
+	zend_declare_class_constant_string(zip_class_entry, "LIBZIP_VERSION", sizeof("LIBZIP_VERSION")-1, zip_libzip_version());
+#else
+	zend_declare_class_constant_string(zip_class_entry, "LIBZIP_VERSION", sizeof("LIBZIP_VERSION")-1, LIBZIP_VERSION);
+#endif
+
 	php_register_url_stream_wrapper("zip", &php_stream_zip_wrapper);
 
 	le_zip_dir   = zend_register_list_destructors_ex(php_zip_free_dir,   NULL, le_zip_dir_name,   module_number);

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -33,12 +33,6 @@ extern zend_module_entry zip_module_entry;
 
 #define PHP_ZIP_VERSION "1.21.0"
 
-#ifdef HAVE_LIBZIP_VERSION
-#define LIBZIP_VERSION_STR zip_libzip_version()
-#else
-#define LIBZIP_VERSION_STR LIBZIP_VERSION
-#endif
-
 #define ZIP_OPENBASEDIR_CHECKPATH(filename) php_check_open_basedir(filename)
 
 typedef struct _ze_zip_rsrc {

--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -633,12 +633,6 @@ class ZipArchive implements Countable
      */
     public const EM_UNKNOWN = UNKNOWN;
 
-    /**
-     * @var string
-     * @cvalue LIBZIP_VERSION_STR
-     */
-    public const LIBZIP_VERSION = UNKNOWN;
-
     /** @readonly */
     public int $lastId;
     /** @readonly */

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d8c14dfe45c7eff2c18fd3c562488a827f658e12 */
+ * Stub hash: 52db51284a16b7664a3f66ea5d8a4a7b23aa5127 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -1153,13 +1153,6 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zend_string *const_EM_UNKNOWN_name = zend_string_init_interned("EM_UNKNOWN", sizeof("EM_UNKNOWN") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_EM_UNKNOWN_name, &const_EM_UNKNOWN_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_EM_UNKNOWN_name);
-
-	zval const_LIBZIP_VERSION_value;
-	zend_string *const_LIBZIP_VERSION_value_str = zend_string_init(LIBZIP_VERSION_STR, sizeof(LIBZIP_VERSION_STR) - 1, 1);
-	ZVAL_STR(&const_LIBZIP_VERSION_value, const_LIBZIP_VERSION_value_str);
-	zend_string *const_LIBZIP_VERSION_name = zend_string_init_interned("LIBZIP_VERSION", sizeof("LIBZIP_VERSION") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_LIBZIP_VERSION_name, &const_LIBZIP_VERSION_value, ZEND_ACC_PUBLIC, NULL);
-	zend_string_release(const_LIBZIP_VERSION_name);
 
 	zval property_lastId_default_value;
 	ZVAL_UNDEF(&property_lastId_default_value);


### PR DESCRIPTION
Because `sizeof` does not work on function call, so value contain garbage.

https://github.com/php/php-src/commit/0c4c9fb93b33bf86e1f7b38b1ced738a050d0184#r84066944

Ping @kocsismate 