### PR TITLE
Fix class link observer with file_cache_only=1

### DIFF
--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -232,10 +232,10 @@ static zend_always_inline void _zend_accel_class_hash_copy(HashTable *target, Ha
 		} else {
 			zend_class_entry *ce = Z_PTR(p->val);
 			_zend_hash_append_ptr_ex(target, p->key, Z_PTR(p->val), 1);
-			if ((ce->ce_flags & ZEND_ACC_LINKED)
-			 && ZSTR_HAS_CE_CACHE(ce->name)
-			 && ZSTR_VAL(p->key)[0]) {
-				ZSTR_SET_CE_CACHE_EX(ce->name, ce, 0);
+			if ((ce->ce_flags & ZEND_ACC_LINKED) && ZSTR_VAL(p->key)[0]) {
+				if (ZSTR_HAS_CE_CACHE(ce->name)) {
+					ZSTR_SET_CE_CACHE_EX(ce->name, ce, 0);
+				}
 				if (UNEXPECTED(call_observers)) {
 					_zend_observer_class_linked_notify(ce, p->key);
 				}

--- a/ext/zend_test/tests/observer_declarations_file_cache.phpt
+++ b/ext/zend_test/tests/observer_declarations_file_cache.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Observer: Observe function and class declarations with file_cache_only
+--EXTENSIONS--
+zend_test
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_declaring=1
+opcache.enable_cli=1
+opcache.file_cache={TMP}
+opcache.file_cache_only=1
+--FILE--
+<?php
+
+function a() {}
+class A {}
+class B extends A {}
+
+?>
+--EXPECTF--
+<!-- declared function 'a' -->
+<!-- declared class 'a' -->
+<!-- declared class 'b' -->
+<!-- init '%s' -->


### PR DESCRIPTION
Previously, notify would only get called on classes with CE_CACHE. However, during compilation class names are non-permanent which won't get a CE_CACHE and thus wouldn't not get notified.

For reference: https://dev.azure.com/phpazuredevops/PHP/_build/results?buildId=28488&view=ms.vss-test-web.build-test-results-tab&runId=620904&resultId=116510&paneView=debug