### PR TITLE
Work around dl(mysqli) issue with OPcache on AppVeyor

### DIFF
--- a/appveyor/test_task.bat
+++ b/appveyor/test_task.bat
@@ -64,6 +64,8 @@ rem set SSLEAY_CONF=
 
 rem prepare for OPcache
 if "%OPCACHE%" equ "1" set OPCACHE_OPTS=-d opcache.enable=1 -d opcache.enable_cli=1 -d opcache.protect_memory=1 -d opcache.jit_buffer_size=16M
+rem work-around for failing to dl(mysqli) with OPcache (https://github.com/php/php-src/issues/8508)
+if "%OPCACHE%" equ "1" set OPCACHE_OPTS=%OPCACHE_OPTS% -d extension=mysqli
 
 rem prepare for enchant
 mkdir C:\usr\local\lib\enchant-2


### PR DESCRIPTION
As described in #8508, if OPcache is enabled, ext/mysqli can't be dl()'d; we work around that by loading the extension on startup.