### PR TITLE
Fix UPGRADING and #9556 "iterable" alias "array|Traversable" breaks PHP 8.1 code

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -231,7 +231,7 @@ PHP 8.2 UPGRADE NOTES
 
 - OpenSSL:
   . openssl_cipher_key_length(): Returns a key length for the supplied
-    cipher.  
+    cipher.
 
 - Reflection:
   . ReflectionFunction::isAnonymous()
@@ -399,6 +399,10 @@ PHP 8.2 UPGRADE NOTES
   . CURL_VERSION_HTTP3 (libcurl >= 7.66.0)
   . CURL_VERSION_UNICODE (libcurl >= 7.72.0)
   . CURL_VERSION_ZSTD (libcurl >= 7.72.0)
+
+- DBA
+  . DBA_LMDB_USE_SUB_DIR
+  . DBA_LMDB_NO_SUB_DIR
 
 - Filter
   . FILTER_FLAG_GLOBAL_RANGE

--- a/Zend/tests/type_declarations/dnf_types/redundant_types/object_and_dnf_type.phpt
+++ b/Zend/tests/type_declarations/dnf_types/redundant_types/object_and_dnf_type.phpt
@@ -1,0 +1,14 @@
+--TEST--
+A DNF type which contains object is redundant
+--FILE--
+<?php
+
+interface A {}
+interface B {}
+
+function test(): (A&B)|object {}
+
+?>
+===DONE===
+--EXPECTF--
+Fatal error: Type (A&B)|object contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/dnf_types/redundant_types/object_and_dnf_type2.phpt
+++ b/Zend/tests/type_declarations/dnf_types/redundant_types/object_and_dnf_type2.phpt
@@ -1,0 +1,14 @@
+--TEST--
+A DNF type which contains object is redundant 2
+--FILE--
+<?php
+
+interface A {}
+interface B {}
+
+function test(): object|(A&B) {}
+
+?>
+===DONE===
+--EXPECTF--
+Fatal error: Type (A&B)|object contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_array_1.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_array_1.phpt
@@ -1,0 +1,12 @@
+--TEST--
+iterable type with array should be redundant
+--FILE--
+<?php
+
+function bar(): array|iterable|null {
+    return null;
+}
+
+?>
+--EXPECTF--
+Fatal error: Duplicate type array is redundant in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_array_2.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_array_2.phpt
@@ -1,0 +1,12 @@
+--TEST--
+iterable type with array should be redundant
+--FILE--
+<?php
+
+function bar(): iterable|array|null {
+    return null;
+}
+
+?>
+--EXPECTF--
+Fatal error: Duplicate type array is redundant in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_iterable.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_iterable.phpt
@@ -1,0 +1,12 @@
+--TEST--
+iterable type with second iterable should be redundant
+--FILE--
+<?php
+
+function bar(): iterable|iterable|null {
+    return null;
+}
+
+?>
+--EXPECTF--
+Fatal error: Duplicate type array is redundant in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_1.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_1.phpt
@@ -1,0 +1,13 @@
+--TEST--
+iterable type with object should NOT be redundant 1
+--FILE--
+<?php
+
+function bar(): iterable|object|null {
+    return null;
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_2.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_2.phpt
@@ -1,0 +1,13 @@
+--TEST--
+iterable type with object should NOT be redundant 2
+--FILE--
+<?php
+
+function bar(): object|iterable|null {
+    return null;
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_3.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_3.phpt
@@ -1,0 +1,12 @@
+--TEST--
+iterable type with object and class T should be redundant
+--FILE--
+<?php
+
+function bar(): object|iterable|T|null {
+    return null;
+}
+
+?>
+--EXPECTF--
+Fatal error: Type Traversable|T|object|array|null contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_4.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_4.phpt
@@ -1,0 +1,12 @@
+--TEST--
+iterable type with object and class T should be redundant
+--FILE--
+<?php
+
+function bar(): iterable|object|T|null {
+    return null;
+}
+
+?>
+--EXPECTF--
+Fatal error: Type Traversable|T|object|array|null contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_5.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_5.phpt
@@ -1,0 +1,12 @@
+--TEST--
+iterable type with object and class T should be redundant
+--FILE--
+<?php
+
+function bar(): T|object|iterable|null {
+    return null;
+}
+
+?>
+--EXPECTF--
+Fatal error: Type T|Traversable|object|array|null contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_6.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_6.phpt
@@ -1,0 +1,12 @@
+--TEST--
+iterable type with object and class T should be redundant
+--FILE--
+<?php
+
+function bar(): T|iterable|object|null {
+    return null;
+}
+
+?>
+--EXPECTF--
+Fatal error: Type T|Traversable|object|array|null contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_variance.phpt
+++ b/Zend/tests/type_declarations/iterable/iterable_alias_redundancy_object_variance.phpt
@@ -1,0 +1,18 @@
+--TEST--
+iterable type with object should be allowed in variance checks
+--FILE--
+<?php
+
+class A {
+    public object|iterable $x;
+    public object|array $y;
+}
+class B extends A {
+    public object|array $x;
+    public object|iterable $y;
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/type_declarations/union_types/redundant_types/object_and_class_type2.phpt
+++ b/Zend/tests/type_declarations/union_types/redundant_types/object_and_class_type2.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Using both object and a class type 2
+--FILE--
+<?php
+
+function test(): Test|object {
+}
+
+?>
+--EXPECTF--
+Fatal error: Type Test|object contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/tests/type_declarations/union_types/redundant_types/object_and_static2.phpt
+++ b/Zend/tests/type_declarations/union_types/redundant_types/object_and_static2.phpt
@@ -1,0 +1,12 @@
+--TEST--
+object and static are redundant 2
+--FILE--
+<?php
+
+class Test {
+    public function foo(): object|static {}
+}
+
+?>
+--EXPECTF--
+Fatal error: Type static|object contains both object and a class type, which is redundant in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6363,6 +6363,7 @@ static zend_type zend_compile_typename(
 		zend_ast_list *list = zend_ast_get_list(ast);
 		zend_type_list *type_list;
 		bool is_composite = false;
+		bool has_only_iterable_class = true;
 		ALLOCA_FLAG(use_heap)
 
 		type_list = do_alloca(ZEND_TYPE_LIST_SIZE(list->children), use_heap);
@@ -6371,8 +6372,10 @@ static zend_type zend_compile_typename(
 		for (uint32_t i = 0; i < list->children; i++) {
 			zend_ast *type_ast = list->child[i];
 			zend_type single_type;
+			uint32_t type_mask = ZEND_TYPE_FULL_MASK(type);
 
 			if (type_ast->kind == ZEND_AST_TYPE_INTERSECTION) {
+				has_only_iterable_class = false;
 				is_composite = true;
 				/* The first class type can be stored directly as the type ptr payload. */
 				if (ZEND_TYPE_IS_COMPLEX(type) && !ZEND_TYPE_HAS_LIST(type)) {
@@ -6380,8 +6383,9 @@ static zend_type zend_compile_typename(
 					type_list->num_types = 1;
 					type_list->types[0] = type;
 					ZEND_TYPE_FULL_MASK(type_list->types[0]) &= ~_ZEND_TYPE_MAY_BE_MASK;
-					ZEND_TYPE_SET_LIST(type, type_list);
 				}
+				/* Mark type as list type */
+				ZEND_TYPE_SET_LIST(type, type_list);
 
 				single_type = zend_compile_typename(type_ast, false);
 				ZEND_ASSERT(ZEND_TYPE_IS_INTERSECTION(single_type));
@@ -6406,6 +6410,9 @@ static zend_type zend_compile_typename(
 			if (single_type_mask == MAY_BE_ANY) {
 				zend_error_noreturn(E_COMPILE_ERROR, "Type mixed can only be used as a standalone type");
 			}
+			if (ZEND_TYPE_IS_COMPLEX(single_type) && !ZEND_TYPE_IS_ITERABLE_FALLBACK(single_type)) {
+				has_only_iterable_class = false;
+			}
 
 			uint32_t type_mask_overlap = ZEND_TYPE_PURE_MASK(type) & single_type_mask;
 			if (type_mask_overlap) {
@@ -6414,8 +6421,9 @@ static zend_type zend_compile_typename(
 				zend_error_noreturn(E_COMPILE_ERROR,
 					"Duplicate type %s is redundant", ZSTR_VAL(overlap_type_str));
 			}
-			if ( ((ZEND_TYPE_PURE_MASK(type) & MAY_BE_TRUE) && (single_type_mask == MAY_BE_FALSE))
-					|| ((ZEND_TYPE_PURE_MASK(type) & MAY_BE_FALSE) && (single_type_mask == MAY_BE_TRUE)) ) {
+
+			if ( ((type_mask & MAY_BE_TRUE) && (single_type_mask == MAY_BE_FALSE))
+					|| ((type_mask & MAY_BE_FALSE) && (single_type_mask == MAY_BE_TRUE)) ) {
 				zend_error_noreturn(E_COMPILE_ERROR,
 					"Type contains both true and false, bool should be used instead");
 			}
@@ -6457,7 +6465,8 @@ static zend_type zend_compile_typename(
 		free_alloca(type_list, use_heap);
 
 		uint32_t type_mask = ZEND_TYPE_FULL_MASK(type);
-		if ((type_mask & MAY_BE_OBJECT) && (ZEND_TYPE_IS_COMPLEX(type) || (type_mask & MAY_BE_STATIC))) {
+		if ((type_mask & MAY_BE_OBJECT) &&
+				((!has_only_iterable_class && ZEND_TYPE_IS_COMPLEX(type)) || (type_mask & MAY_BE_STATIC))) {
 			zend_string *type_str = zend_type_to_string(type);
 			zend_error_noreturn(E_COMPILE_ERROR,
 				"Type %s contains both object and a class type, which is redundant",


### PR DESCRIPTION
This kinda address #9556 by making it a documentation issue, and adds tests to verify the behaviour.