### PR TITLE
Remove superfluous helper variable in `Randomizer::getBytes()`

### DIFF
--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -142,7 +142,7 @@ PHP_METHOD(Random_Randomizer, getBytes)
 	zend_string *retval;
 	zend_long length;
 	uint64_t result;
-	size_t total_size = 0, required_size;
+	size_t total_size = 0;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_LONG(length)
@@ -154,9 +154,8 @@ PHP_METHOD(Random_Randomizer, getBytes)
 	}
 
 	retval = zend_string_alloc(length, 0);
-	required_size = length;
 
-	while (total_size < required_size) {
+	while (total_size < length) {
 		result = randomizer->algo->generate(randomizer->status);
 		if (EG(exception)) {
 			zend_string_free(retval);
@@ -164,7 +163,7 @@ PHP_METHOD(Random_Randomizer, getBytes)
 		}
 		for (size_t i = 0; i < randomizer->status->last_generated_size; i++) {
 			ZSTR_VAL(retval)[total_size++] = (result >> (i * 8)) & 0xff;
-			if (total_size >= required_size) {
+			if (total_size >= length) {
 				break;
 			}
 		}

--- a/ext/random/randomizer.c
+++ b/ext/random/randomizer.c
@@ -141,7 +141,6 @@ PHP_METHOD(Random_Randomizer, getBytes)
 	php_random_randomizer *randomizer = Z_RANDOM_RANDOMIZER_P(ZEND_THIS);
 	zend_string *retval;
 	zend_long length;
-	uint64_t result;
 	size_t total_size = 0;
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -156,7 +155,7 @@ PHP_METHOD(Random_Randomizer, getBytes)
 	retval = zend_string_alloc(length, 0);
 
 	while (total_size < length) {
-		result = randomizer->algo->generate(randomizer->status);
+		uint64_t result = randomizer->algo->generate(randomizer->status);
 		if (EG(exception)) {
 			zend_string_free(retval);
 			RETURN_THROWS();


### PR DESCRIPTION
I am currently looking at the random extension to extend it in the future. In the process, I noticed that an auxiliary variable was introduced at this point, which is not needed in my eyes. I don't know if the compiler doesn't optimise this variable anyway, but I wanted to make the pull request anyway, because I think the code is more understandable this way. 