### PR TITLE
Major overhaul of mbstring (part 26)

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfilter.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.c
@@ -154,7 +154,7 @@ void mbfl_buffer_converter_illegal_mode(mbfl_buffer_converter *convd, int mode)
 	}
 }
 
-void mbfl_buffer_converter_illegal_substchar(mbfl_buffer_converter *convd, int substchar)
+void mbfl_buffer_converter_illegal_substchar(mbfl_buffer_converter *convd, uint32_t substchar)
 {
 	if (convd->filter2) {
 		convd->filter2->illegal_substchar = substchar;
@@ -387,7 +387,7 @@ mbfl_convert_encoding(
 
 	if (filter2 != NULL) {
 		filter2->illegal_mode = MBFL_OUTPUTFILTER_ILLEGAL_MODE_CHAR;
-		filter2->illegal_substchar = 0x3f;		/* '?' */
+		filter2->illegal_substchar = '?';
 	}
 
 	mbfl_memory_device_init(&device, string->len, (string->len >> 2) + 8);

--- a/ext/mbstring/libmbfl/mbfl/mbfilter.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfilter.h
@@ -142,7 +142,7 @@ struct _mbfl_buffer_converter {
 MBFLAPI extern mbfl_buffer_converter * mbfl_buffer_converter_new(const mbfl_encoding *from, const mbfl_encoding *to, size_t buf_initsz);
 MBFLAPI extern void mbfl_buffer_converter_delete(mbfl_buffer_converter *convd);
 MBFLAPI extern void mbfl_buffer_converter_illegal_mode(mbfl_buffer_converter *convd, int mode);
-MBFLAPI extern void mbfl_buffer_converter_illegal_substchar(mbfl_buffer_converter *convd, int substchar);
+MBFLAPI extern void mbfl_buffer_converter_illegal_substchar(mbfl_buffer_converter *convd, uint32_t substchar);
 MBFLAPI extern size_t mbfl_buffer_converter_feed(mbfl_buffer_converter *convd, mbfl_string *string);
 MBFLAPI extern void mbfl_buffer_converter_flush(mbfl_buffer_converter *convd);
 MBFLAPI extern mbfl_string * mbfl_buffer_converter_result(mbfl_buffer_converter *convd, mbfl_string *result);

--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.c
@@ -243,7 +243,7 @@ int mbfl_filt_conv_illegal_output(int c, mbfl_convert_filter *filter)
 	unsigned int w = c;
 	int ret = 0;
 	int mode_backup = filter->illegal_mode;
-	int substchar_backup = filter->illegal_substchar;
+	uint32_t substchar_backup = filter->illegal_substchar;
 
 	/* The used substitution character may not be supported by the target character encoding.
 	 * If that happens, first try to use "?" instead and if that also fails, silently drop the

--- a/ext/mbstring/libmbfl/mbfl/mbfl_convert.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_convert.h
@@ -57,7 +57,7 @@ struct _mbfl_convert_filter {
 	const mbfl_encoding *from;
 	const mbfl_encoding *to;
 	int illegal_mode;
-	int illegal_substchar;
+	uint32_t illegal_substchar;
 	size_t num_illegalchar;
 	void *opaque;
 };

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -883,8 +883,8 @@ static PHP_INI_MH(OnUpdate_mbstring_substitute_character)
 	} else {
 		MBSTRG(filter_illegal_mode) = MBFL_OUTPUTFILTER_ILLEGAL_MODE_CHAR;
 		MBSTRG(current_filter_illegal_mode) = MBFL_OUTPUTFILTER_ILLEGAL_MODE_CHAR;
-		MBSTRG(filter_illegal_substchar) = 0x3f;	/* '?' */
-		MBSTRG(current_filter_illegal_substchar) = 0x3f;	/* '?' */
+		MBSTRG(filter_illegal_substchar) = '?';
+		MBSTRG(current_filter_illegal_substchar) = '?';
 	}
 
 	return SUCCESS;
@@ -1015,9 +1015,9 @@ ZEND_TSRMLS_CACHE_UPDATE();
 	mbstring_globals->default_detect_order_list = (enum mbfl_no_encoding *) php_mb_default_identify_list_neut;
 	mbstring_globals->default_detect_order_list_size = sizeof(php_mb_default_identify_list_neut) / sizeof(php_mb_default_identify_list_neut[0]);
 	mbstring_globals->filter_illegal_mode = MBFL_OUTPUTFILTER_ILLEGAL_MODE_CHAR;
-	mbstring_globals->filter_illegal_substchar = 0x3f;	/* '?' */
+	mbstring_globals->filter_illegal_substchar = '?';
 	mbstring_globals->current_filter_illegal_mode = MBFL_OUTPUTFILTER_ILLEGAL_MODE_CHAR;
-	mbstring_globals->current_filter_illegal_substchar = 0x3f;	/* '?' */
+	mbstring_globals->current_filter_illegal_substchar = '?';
 	mbstring_globals->illegalchars = 0;
 	mbstring_globals->encoding_translation = 0;
 	mbstring_globals->strict_detection = 0;

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2753,7 +2753,7 @@ PHP_FUNCTION(mb_convert_encoding)
 }
 /* }}} */
 
-static zend_string *mbstring_convert_case(int case_mode, const char *str, size_t str_len, const mbfl_encoding *enc)
+static zend_string *mbstring_convert_case(php_case_mode case_mode, const char *str, size_t str_len, const mbfl_encoding *enc)
 {
 	return php_unicode_convert_case(case_mode, str, str_len, enc, MBSTRG(current_filter_illegal_mode), MBSTRG(current_filter_illegal_substchar));
 }
@@ -2775,7 +2775,7 @@ PHP_FUNCTION(mb_convert_case)
 		RETURN_THROWS();
 	}
 
-	if (case_mode < 0 || case_mode > PHP_UNICODE_CASE_MODE_MAX) {
+	if (case_mode < 0 || case_mode >= PHP_UNICODE_CASE_MODE_MAX) {
 		zend_argument_value_error(2, "must be one of the MB_CASE_* constants");
 		RETURN_THROWS();
 	}

--- a/ext/mbstring/mbstring.h
+++ b/ext/mbstring/mbstring.h
@@ -87,9 +87,9 @@ ZEND_BEGIN_MODULE_GLOBALS(mbstring)
 	enum mbfl_no_encoding *default_detect_order_list;
 	size_t default_detect_order_list_size;
 	int filter_illegal_mode;
-	int filter_illegal_substchar;
+	uint32_t filter_illegal_substchar;
 	int current_filter_illegal_mode;
-	int current_filter_illegal_substchar;
+	uint32_t current_filter_illegal_substchar;
 	enum mbfl_no_language language;
 	bool encoding_translation;
 	bool strict_detection;

--- a/ext/mbstring/php_unicode.c
+++ b/ext/mbstring/php_unicode.c
@@ -238,7 +238,7 @@ static uint32_t *emit_special_casing_sequence(uint32_t w, uint32_t *out)
 	return out;
 }
 
-MBSTRING_API zend_string *php_unicode_convert_case(int case_mode, const char *srcstr, size_t in_len, const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar)
+MBSTRING_API zend_string *php_unicode_convert_case(php_case_mode case_mode, const char *srcstr, size_t in_len, const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar)
 {
 	/* A Unicode codepoint can expand out to up to 3 codepoints when uppercased, lowercased, or title cased
 	 * See http://www.unicode.org/Public/UNIDATA/SpecialCasing.txt */

--- a/ext/mbstring/php_unicode.c
+++ b/ext/mbstring/php_unicode.c
@@ -238,7 +238,7 @@ static uint32_t *emit_special_casing_sequence(uint32_t w, uint32_t *out)
 	return out;
 }
 
-MBSTRING_API zend_string *php_unicode_convert_case(php_case_mode case_mode, const char *srcstr, size_t in_len, const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar)
+MBSTRING_API zend_string *php_unicode_convert_case(php_case_mode case_mode, const char *srcstr, size_t in_len, const mbfl_encoding *src_encoding, int illegal_mode, uint32_t illegal_substchar)
 {
 	/* A Unicode codepoint can expand out to up to 3 codepoints when uppercased, lowercased, or title cased
 	 * See http://www.unicode.org/Public/UNIDATA/SpecialCasing.txt */

--- a/ext/mbstring/php_unicode.h
+++ b/ext/mbstring/php_unicode.h
@@ -77,19 +77,21 @@
 MBSTRING_API bool php_unicode_is_prop(unsigned long code, ...);
 MBSTRING_API bool php_unicode_is_prop1(unsigned long code, int prop);
 
-MBSTRING_API zend_string *php_unicode_convert_case(
-		int case_mode, const char *srcstr, size_t srclen,
-		const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar);
+typedef enum {
+	PHP_UNICODE_CASE_UPPER = 0,
+	PHP_UNICODE_CASE_LOWER,
+	PHP_UNICODE_CASE_TITLE,
+	PHP_UNICODE_CASE_FOLD,
+	PHP_UNICODE_CASE_UPPER_SIMPLE,
+	PHP_UNICODE_CASE_LOWER_SIMPLE,
+	PHP_UNICODE_CASE_TITLE_SIMPLE,
+	PHP_UNICODE_CASE_FOLD_SIMPLE,
+	PHP_UNICODE_CASE_MODE_MAX
+} php_case_mode;
 
-#define PHP_UNICODE_CASE_UPPER        0
-#define PHP_UNICODE_CASE_LOWER        1
-#define PHP_UNICODE_CASE_TITLE        2
-#define PHP_UNICODE_CASE_FOLD         3
-#define PHP_UNICODE_CASE_UPPER_SIMPLE 4
-#define PHP_UNICODE_CASE_LOWER_SIMPLE 5
-#define PHP_UNICODE_CASE_TITLE_SIMPLE 6
-#define PHP_UNICODE_CASE_FOLD_SIMPLE  7
-#define PHP_UNICODE_CASE_MODE_MAX     7
+MBSTRING_API zend_string *php_unicode_convert_case(
+		php_case_mode case_mode, const char *srcstr, size_t srclen,
+		const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar);
 
 /* Optimize the common ASCII case for lower/upper */
 

--- a/ext/mbstring/php_unicode.h
+++ b/ext/mbstring/php_unicode.h
@@ -91,7 +91,7 @@ typedef enum {
 
 MBSTRING_API zend_string *php_unicode_convert_case(
 		php_case_mode case_mode, const char *srcstr, size_t srclen,
-		const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar);
+		const mbfl_encoding *src_encoding, int illegal_mode, uint32_t illegal_substchar);
 
 /* Optimize the common ASCII case for lower/upper */
 

--- a/ext/mbstring/php_unicode.h
+++ b/ext/mbstring/php_unicode.h
@@ -77,8 +77,8 @@
 MBSTRING_API bool php_unicode_is_prop(unsigned long code, ...);
 MBSTRING_API bool php_unicode_is_prop1(unsigned long code, int prop);
 
-MBSTRING_API char *php_unicode_convert_case(
-		int case_mode, const char *srcstr, size_t srclen, size_t *ret_len,
+MBSTRING_API zend_string *php_unicode_convert_case(
+		int case_mode, const char *srcstr, size_t srclen,
 		const mbfl_encoding *src_encoding, int illegal_mode, int illegal_substchar);
 
 #define PHP_UNICODE_CASE_UPPER        0

--- a/ext/mbstring/tests/mb_convert_case_various_mode.phpt
+++ b/ext/mbstring/tests/mb_convert_case_various_mode.phpt
@@ -21,6 +21,12 @@ try {
     echo $e->getMessage() . \PHP_EOL;
 }
 
+/* Regression test for new implementation;
+ * When converting a codepoint, if we overwrite it with the converted version before
+ * checking whether we should shift in/out of 'title mode', then the conversion will be incorrect */
+var_dump(bin2hex(mb_convert_case("\x01I\x01,", MB_CASE_TITLE, 'UCS-2BE')));
+var_dump(bin2hex(mb_convert_case("\x01I\x01,", MB_CASE_TITLE_SIMPLE, 'UCS-2BE')));
+
 ?>
 --EXPECT--
 string(13) "FOO BAR SPASS"
@@ -32,3 +38,5 @@ string(13) "foo bar spaß"
 string(13) "Foo Bar Spaß"
 string(13) "foo bar spaß"
 mb_convert_case(): Argument #2 ($mode) must be one of the MB_CASE_* constants
+string(12) "02bc004e012d"
+string(8) "0149012d"


### PR DESCRIPTION
Use the new (faster) encoding conversion code for case conversion functions like `mb_convert_case`, `mb_strtoupper`, and `mb_strtolower`. Speed increase is only about 50% for title casing, but 2-3x for other types of case conversion.

Fuzzed with libfuzzer. One bug in my first draft of the implementation was found, and a regression test added.

Note: the signature of one function with public symbol (`php_unicode_convert_case`) is changed. This could break C extensions which link directly to mbstring and call this function. However, none of the PECL extensions do so.

FYA @cmb69 @nikic @kamil-tekiela 

Perhaps @mvorisek might be interested. Recently he raised some suggestions about how to make `mb_strtoupper` and `mb_strtolower` faster. This PR does not close the performance gap with `strtoupper` and `strtolower`, but at least makes it much smaller than it was.