### PR TITLE
Use built php for composer in community build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,13 @@ jobs:
     parameters:
       configurationName: I386_DEBUG_ZTS
       configurationParameters: '--enable-debug --enable-zts'
+  - template: azure/community_job.yml
+    parameters:
+      configurationName: COMMUNITY
+      configurationParameters: >-
+          --enable-debug --enable-zts --enable-address-sanitizer --enable-undefined-sanitizer
+          CFLAGS='-fno-sanitize-recover'
+      timeoutInMinutes: 90
   - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
     - template: azure/i386/job.yml
       parameters:
@@ -49,13 +56,6 @@ jobs:
         configurationName: DEBUG_ZTS_MSAN
         configurationParameters: '--enable-debug --enable-zts'
         runTestsParameters: --msan
-        timeoutInMinutes: 90
-    - template: azure/community_job.yml
-      parameters:
-        configurationName: COMMUNITY
-        configurationParameters: >-
-            --enable-debug --enable-zts --enable-address-sanitizer --enable-undefined-sanitizer
-            CFLAGS='-fno-sanitize-recover'
         timeoutInMinutes: 90
     - template: azure/opcache_variation_job.yml
       parameters:

--- a/azure/community_job.yml
+++ b/azure/community_job.yml
@@ -47,7 +47,7 @@ jobs:
         sed -i 's/PHP_OS/"Darwin"/' tests/Filesystem/FilesystemTest.php
         export USE_ZEND_ALLOC=0
         export ASAN_OPTIONS=exitcode=139
-        php vendor/bin/phpunit
+        php vendor/bin/phpunit --verbose --testdox
         if [ $? -gt 128 ]; then
           exit 1
         fi
@@ -64,7 +64,7 @@ jobs:
         export SYMFONY_DEPRECATIONS_HELPER=max[total]=999
         X=0
         for component in $(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h\n'); do
-          php ./phpunit $component --exclude-group tty,benchmark,intl-data,transient;
+          php ./phpunit $component --exclude-group tty,benchmark,intl-data,transient --verbose --testdox
           if [ $? -gt 128 ]; then
             X=1;
           fi

--- a/azure/community_job.yml
+++ b/azure/community_job.yml
@@ -42,7 +42,7 @@ jobs:
         git clone https://github.com/laravel/framework.git --branch=master --depth=1
         cd framework
         git rev-parse HEAD
-        php8.0 /usr/bin/composer install --no-progress
+        php /usr/bin/composer install --no-progress --ignore-platform-reqs
         # Hack to disable a test that hangs on azure
         sed -i 's/PHP_OS/"Darwin"/' tests/Filesystem/FilesystemTest.php
         export USE_ZEND_ALLOC=0
@@ -56,8 +56,8 @@ jobs:
         git clone https://github.com/symfony/symfony.git --depth=1
         cd symfony
         git rev-parse HEAD
-        php8.0 /usr/bin/composer install --no-progress
-        php8.0 ./phpunit install
+        php /usr/bin/composer install --no-progress --ignore-platform-reqs
+        php ./phpunit install
         export USE_ZEND_ALLOC=0
         export USE_TRACKED_ALLOC=1
         export ASAN_OPTIONS=exitcode=139
@@ -89,7 +89,7 @@ jobs:
         export USE_ZEND_ALLOC=0
         export USE_TRACKED_ALLOC=1
         export ASAN_OPTIONS=exitcode=139
-        php8.0 /usr/bin/composer install --no-progress
+        php /usr/bin/composer install --no-progress --ignore-platform-reqs
         php ./phpunit
         if [ $? -gt 128 ]; then
           exit 1
@@ -97,7 +97,7 @@ jobs:
       displayName: 'Test PHPUnit'
       condition: or(succeeded(), failed())
     - script: |
-        php8.0 /usr/bin/composer create-project symfony/symfony-demo symfony_demo --no-progress
+        php /usr/bin/composer create-project symfony/symfony-demo symfony_demo --no-progress --ignore-platform-reqs
         cd symfony_demo
         git rev-parse HEAD
         export USE_ZEND_ALLOC=0

--- a/azure/community_job.yml
+++ b/azure/community_job.yml
@@ -83,7 +83,7 @@ jobs:
       displayName: 'Test Amphp'
       condition: or(succeeded(), failed())
     - script: |
-        git clone https://github.com/sebastianbergmann/phpunit.git --branch=master --depth=1
+        git clone https://github.com/sebastianbergmann/phpunit.git --branch=main --depth=1
         cd phpunit
         git rev-parse HEAD
         export USE_ZEND_ALLOC=0


### PR DESCRIPTION
Laravel and Symfony no longer support PHP-8.0. Composer will assert that the PHP version is compatible when installing. I'm not sure what the rationale was for using a different PHP version for Composer in the first place. Alternatively, we could update the PHP version used or we pass `--ignore-platform-reqs`.

*Edit*:

> I'm not sure what the rationale was for using a different PHP version for Composer in the first place.

Ah, probably to support `master`. Maybe we should just pass `--ignore-platform-reqs` then.