### PR TITLE
Set SA_ONSTACK in zend_sigaction 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ PHP                                                                        NEWS
 - Core:
   . Fixed bug GH-9388 (Improve unset property and __get type incompatibility
     error message). (ilutov)
+  . SA_ONSTACK is now set for signal handlers to be friendlier to other
+    in-process code such as Go's cgo. (Kévin Dunglas)
 
 - Opcache:
   . Added start, restart and force restart time to opcache's

--- a/Zend/zend_signal.c
+++ b/Zend/zend_signal.c
@@ -248,7 +248,7 @@ ZEND_API void zend_sigaction(int signo, const struct sigaction *act, struct siga
 		if (SIGG(handlers)[signo-1].handler == (void *) SIG_IGN) {
 			sa.sa_sigaction = (void *) SIG_IGN;
 		} else {
-			sa.sa_flags     = SA_SIGINFO | (act->sa_flags & SA_FLAGS_MASK);
+			sa.sa_flags     = SA_ONSTACK | SA_SIGINFO | (act->sa_flags & SA_FLAGS_MASK);
 			sa.sa_sigaction = zend_signal_handler_defer;
 			sa.sa_mask      = global_sigmask;
 		}


### PR DESCRIPTION
I'm currently working on a new SAPI for web servers written in Go.

Many virtual machines, [including Go VM](https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG), depend on signals using [`SA_ONSTACK `](https://man7.org/linux/man-pages/man2/sigaltstack.2.html). This flag allows a thread to define a new alternate signal stack. Many argue that `SA_ONSTACK` should be a default, but it's not the case (yet).

This patch sets the `SA_ONSTACK` flag when PHP calls `sigaction()`.

Python merged a similar patch (https://github.com/python/cpython/pull/24730) in 2021 (Python 3.10+) for [the same reasons](https://bugs.python.org/issue43390), with no issues.