### PR TITLE
Fix use-after-free with nested FFI::addr() calls

### DIFF
--- a/ext/ffi/tests/gh9598.phpt
+++ b/ext/ffi/tests/gh9598.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-9598: Fix use-after-free for nested FFI::addr() calls
+--SKIPIF--
+<?php
+if (!extension_loaded('ffi')) die('skip ffi extension not available');
+?>
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+
+$ffi = \FFI::cdef(<<<'CPP'
+typedef struct {
+    int8_t a;
+} Example;
+CPP);
+
+$struct = $ffi->new('Example');
+$structPtrPtr = \FFI::addr(\FFI::addr($struct));
+var_dump($structPtrPtr[0][0]);
+
+?>
+--EXPECTF--
+object(FFI\CData:struct <anonymous>)#6 (1) {
+  ["a"]=>
+  int(0)
+}


### PR DESCRIPTION
Fixes GH-9598

@dstogov I did not see another way to solve this. Basically, `cdata1.ptr -> cdata1.ptr_holder -> cdata2.ptr_holder -> Example`. Right after `\FFI::addr(\FFI::addr($struct))` `cdata2` is released. Since this object is released by the VM when the `TMPVAR` is destroyed we need to increase the refcount of the CData object itself.

Please let me know if you can see a better solution. This is the first time I've looked at the FFI internals, very much possible I'm missing something simple.

Thanks!