### PR TITLE
Throw in FFI::addr() when referencing temporary pointer

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -4215,6 +4215,11 @@ ZEND_METHOD(FFI, addr) /* {{{ */
 	cdata = (zend_ffi_cdata*)Z_OBJ_P(zv);
 	type = ZEND_FFI_TYPE(cdata->type);
 
+	if (GC_REFCOUNT(&cdata->std) == 1 && Z_REFCOUNT_P(arg) == 1 && type->kind == ZEND_FFI_TYPE_POINTER) {
+		zend_throw_error(zend_ffi_exception_ce, "Cannot reference temporary pointer");
+		RETURN_THROWS();
+	}
+
 	new_type = emalloc(sizeof(zend_ffi_type));
 	new_type->kind = ZEND_FFI_TYPE_POINTER;
 	new_type->attr = 0;

--- a/ext/ffi/tests/addr_to_owned.phpt
+++ b/ext/ffi/tests/addr_to_owned.phpt
@@ -1,0 +1,24 @@
+--TEST--
+FFI Referencing temporary owned data transfers ownership
+--EXTENSIONS--
+ffi
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+$ffi = \FFI::cdef(<<<'CPP'
+typedef struct {
+    int8_t bar;
+} Foo;
+CPP);
+$structPtr = \FFI::addr($ffi->new('Foo'));
+var_dump($structPtr);
+?>
+--EXPECT--
+object(FFI\CData:struct <anonymous>*)#3 (1) {
+  [0]=>
+  object(FFI\CData:struct <anonymous>)#2 (1) {
+    ["bar"]=>
+    int(0)
+  }
+}

--- a/ext/ffi/tests/nested_addr.phpt
+++ b/ext/ffi/tests/nested_addr.phpt
@@ -1,0 +1,23 @@
+--TEST--
+FFI Cannot nest FFI::addr() calls
+--EXTENSIONS--
+ffi
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+$ffi = \FFI::cdef(<<<'CPP'
+typedef struct {
+    int8_t bar;
+} Foo;
+CPP);
+
+$struct = $ffi->new('Foo');
+$structPtrPtr = \FFI::addr(\FFI::addr($struct));
+?>
+--EXPECTF--
+Fatal error: Uncaught FFI\Exception: Cannot reference temporary pointer in %s:%d
+Stack trace:
+#0 %s(%d): FFI::addr(Object(FFI\CData:struct <anonymous>*))
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
We're only disallowing pointers, as they always rely not only on the data but also the `CData.ptr_holder` to be there. Other unowned structures should be allowed, like structs, even if `refcount == 1`. Targeting `master` as this is an improvement rather than a bugfix.