### PR TITLE
Improve string class constant code generation

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1670,7 +1670,7 @@ class EvaluatedValue
                 $code .= "\tZVAL_EMPTY_STRING(&$zvalName);\n";
             } else {
                 $constValue = $cConstValue ?: '"' . addslashes($this->value) . '"';
-                $code .= "\tzend_string *{$zvalName}_str = zend_string_init($constValue, sizeof($constValue) - 1, 1);\n";
+                $code .= "\tzend_string *{$zvalName}_str = zend_string_init($constValue, strlen($constValue), 1);\n";
                 $code .= "\tZVAL_STR(&$zvalName, {$zvalName}_str);\n";
             }
         } elseif ($this->type->isArray()) {

--- a/ext/date/php_date_arginfo.h
+++ b/ext/date/php_date_arginfo.h
@@ -789,98 +789,98 @@ static zend_class_entry *register_class_DateTimeInterface(void)
 	class_entry = zend_register_internal_interface(&ce);
 
 	zval const_ATOM_value;
-	zend_string *const_ATOM_value_str = zend_string_init(DATE_FORMAT_RFC3339, sizeof(DATE_FORMAT_RFC3339) - 1, 1);
+	zend_string *const_ATOM_value_str = zend_string_init(DATE_FORMAT_RFC3339, strlen(DATE_FORMAT_RFC3339), 1);
 	ZVAL_STR(&const_ATOM_value, const_ATOM_value_str);
 	zend_string *const_ATOM_name = zend_string_init_interned("ATOM", sizeof("ATOM") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_ATOM_name, &const_ATOM_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_ATOM_name);
 
 	zval const_COOKIE_value;
-	zend_string *const_COOKIE_value_str = zend_string_init(DATE_FORMAT_COOKIE, sizeof(DATE_FORMAT_COOKIE) - 1, 1);
+	zend_string *const_COOKIE_value_str = zend_string_init(DATE_FORMAT_COOKIE, strlen(DATE_FORMAT_COOKIE), 1);
 	ZVAL_STR(&const_COOKIE_value, const_COOKIE_value_str);
 	zend_string *const_COOKIE_name = zend_string_init_interned("COOKIE", sizeof("COOKIE") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_COOKIE_name, &const_COOKIE_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_COOKIE_name);
 
 	zval const_ISO8601_value;
-	zend_string *const_ISO8601_value_str = zend_string_init(DATE_FORMAT_ISO8601, sizeof(DATE_FORMAT_ISO8601) - 1, 1);
+	zend_string *const_ISO8601_value_str = zend_string_init(DATE_FORMAT_ISO8601, strlen(DATE_FORMAT_ISO8601), 1);
 	ZVAL_STR(&const_ISO8601_value, const_ISO8601_value_str);
 	zend_string *const_ISO8601_name = zend_string_init_interned("ISO8601", sizeof("ISO8601") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_ISO8601_name, &const_ISO8601_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_ISO8601_name);
 
 	zval const_ISO8601_EXPANDED_value;
-	zend_string *const_ISO8601_EXPANDED_value_str = zend_string_init(DATE_FORMAT_ISO8601_EXPANDED, sizeof(DATE_FORMAT_ISO8601_EXPANDED) - 1, 1);
+	zend_string *const_ISO8601_EXPANDED_value_str = zend_string_init(DATE_FORMAT_ISO8601_EXPANDED, strlen(DATE_FORMAT_ISO8601_EXPANDED), 1);
 	ZVAL_STR(&const_ISO8601_EXPANDED_value, const_ISO8601_EXPANDED_value_str);
 	zend_string *const_ISO8601_EXPANDED_name = zend_string_init_interned("ISO8601_EXPANDED", sizeof("ISO8601_EXPANDED") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_ISO8601_EXPANDED_name, &const_ISO8601_EXPANDED_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_ISO8601_EXPANDED_name);
 
 	zval const_RFC822_value;
-	zend_string *const_RFC822_value_str = zend_string_init(DATE_FORMAT_RFC822, sizeof(DATE_FORMAT_RFC822) - 1, 1);
+	zend_string *const_RFC822_value_str = zend_string_init(DATE_FORMAT_RFC822, strlen(DATE_FORMAT_RFC822), 1);
 	ZVAL_STR(&const_RFC822_value, const_RFC822_value_str);
 	zend_string *const_RFC822_name = zend_string_init_interned("RFC822", sizeof("RFC822") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RFC822_name, &const_RFC822_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RFC822_name);
 
 	zval const_RFC850_value;
-	zend_string *const_RFC850_value_str = zend_string_init(DATE_FORMAT_RFC850, sizeof(DATE_FORMAT_RFC850) - 1, 1);
+	zend_string *const_RFC850_value_str = zend_string_init(DATE_FORMAT_RFC850, strlen(DATE_FORMAT_RFC850), 1);
 	ZVAL_STR(&const_RFC850_value, const_RFC850_value_str);
 	zend_string *const_RFC850_name = zend_string_init_interned("RFC850", sizeof("RFC850") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RFC850_name, &const_RFC850_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RFC850_name);
 
 	zval const_RFC1036_value;
-	zend_string *const_RFC1036_value_str = zend_string_init(DATE_FORMAT_RFC1036, sizeof(DATE_FORMAT_RFC1036) - 1, 1);
+	zend_string *const_RFC1036_value_str = zend_string_init(DATE_FORMAT_RFC1036, strlen(DATE_FORMAT_RFC1036), 1);
 	ZVAL_STR(&const_RFC1036_value, const_RFC1036_value_str);
 	zend_string *const_RFC1036_name = zend_string_init_interned("RFC1036", sizeof("RFC1036") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RFC1036_name, &const_RFC1036_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RFC1036_name);
 
 	zval const_RFC1123_value;
-	zend_string *const_RFC1123_value_str = zend_string_init(DATE_FORMAT_RFC1123, sizeof(DATE_FORMAT_RFC1123) - 1, 1);
+	zend_string *const_RFC1123_value_str = zend_string_init(DATE_FORMAT_RFC1123, strlen(DATE_FORMAT_RFC1123), 1);
 	ZVAL_STR(&const_RFC1123_value, const_RFC1123_value_str);
 	zend_string *const_RFC1123_name = zend_string_init_interned("RFC1123", sizeof("RFC1123") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RFC1123_name, &const_RFC1123_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RFC1123_name);
 
 	zval const_RFC7231_value;
-	zend_string *const_RFC7231_value_str = zend_string_init(DATE_FORMAT_RFC7231, sizeof(DATE_FORMAT_RFC7231) - 1, 1);
+	zend_string *const_RFC7231_value_str = zend_string_init(DATE_FORMAT_RFC7231, strlen(DATE_FORMAT_RFC7231), 1);
 	ZVAL_STR(&const_RFC7231_value, const_RFC7231_value_str);
 	zend_string *const_RFC7231_name = zend_string_init_interned("RFC7231", sizeof("RFC7231") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RFC7231_name, &const_RFC7231_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RFC7231_name);
 
 	zval const_RFC2822_value;
-	zend_string *const_RFC2822_value_str = zend_string_init(DATE_FORMAT_RFC2822, sizeof(DATE_FORMAT_RFC2822) - 1, 1);
+	zend_string *const_RFC2822_value_str = zend_string_init(DATE_FORMAT_RFC2822, strlen(DATE_FORMAT_RFC2822), 1);
 	ZVAL_STR(&const_RFC2822_value, const_RFC2822_value_str);
 	zend_string *const_RFC2822_name = zend_string_init_interned("RFC2822", sizeof("RFC2822") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RFC2822_name, &const_RFC2822_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RFC2822_name);
 
 	zval const_RFC3339_value;
-	zend_string *const_RFC3339_value_str = zend_string_init(DATE_FORMAT_RFC3339, sizeof(DATE_FORMAT_RFC3339) - 1, 1);
+	zend_string *const_RFC3339_value_str = zend_string_init(DATE_FORMAT_RFC3339, strlen(DATE_FORMAT_RFC3339), 1);
 	ZVAL_STR(&const_RFC3339_value, const_RFC3339_value_str);
 	zend_string *const_RFC3339_name = zend_string_init_interned("RFC3339", sizeof("RFC3339") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RFC3339_name, &const_RFC3339_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RFC3339_name);
 
 	zval const_RFC3339_EXTENDED_value;
-	zend_string *const_RFC3339_EXTENDED_value_str = zend_string_init(DATE_FORMAT_RFC3339_EXTENDED, sizeof(DATE_FORMAT_RFC3339_EXTENDED) - 1, 1);
+	zend_string *const_RFC3339_EXTENDED_value_str = zend_string_init(DATE_FORMAT_RFC3339_EXTENDED, strlen(DATE_FORMAT_RFC3339_EXTENDED), 1);
 	ZVAL_STR(&const_RFC3339_EXTENDED_value, const_RFC3339_EXTENDED_value_str);
 	zend_string *const_RFC3339_EXTENDED_name = zend_string_init_interned("RFC3339_EXTENDED", sizeof("RFC3339_EXTENDED") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RFC3339_EXTENDED_name, &const_RFC3339_EXTENDED_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RFC3339_EXTENDED_name);
 
 	zval const_RSS_value;
-	zend_string *const_RSS_value_str = zend_string_init(DATE_FORMAT_RFC1123, sizeof(DATE_FORMAT_RFC1123) - 1, 1);
+	zend_string *const_RSS_value_str = zend_string_init(DATE_FORMAT_RFC1123, strlen(DATE_FORMAT_RFC1123), 1);
 	ZVAL_STR(&const_RSS_value, const_RSS_value_str);
 	zend_string *const_RSS_name = zend_string_init_interned("RSS", sizeof("RSS") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_RSS_name, &const_RSS_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_RSS_name);
 
 	zval const_W3C_value;
-	zend_string *const_W3C_value_str = zend_string_init(DATE_FORMAT_RFC3339, sizeof(DATE_FORMAT_RFC3339) - 1, 1);
+	zend_string *const_W3C_value_str = zend_string_init(DATE_FORMAT_RFC3339, strlen(DATE_FORMAT_RFC3339), 1);
 	ZVAL_STR(&const_W3C_value, const_W3C_value_str);
 	zend_string *const_W3C_name = zend_string_init_interned("W3C", sizeof("W3C") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_W3C_name, &const_W3C_value, ZEND_ACC_PUBLIC, NULL);

--- a/ext/intl/locale/locale_arginfo.h
+++ b/ext/intl/locale/locale_arginfo.h
@@ -131,49 +131,49 @@ static zend_class_entry *register_class_Locale(void)
 	zend_string_release(const_DEFAULT_LOCALE_name);
 
 	zval const_LANG_TAG_value;
-	zend_string *const_LANG_TAG_value_str = zend_string_init(LOC_LANG_TAG, sizeof(LOC_LANG_TAG) - 1, 1);
+	zend_string *const_LANG_TAG_value_str = zend_string_init(LOC_LANG_TAG, strlen(LOC_LANG_TAG), 1);
 	ZVAL_STR(&const_LANG_TAG_value, const_LANG_TAG_value_str);
 	zend_string *const_LANG_TAG_name = zend_string_init_interned("LANG_TAG", sizeof("LANG_TAG") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_LANG_TAG_name, &const_LANG_TAG_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_LANG_TAG_name);
 
 	zval const_EXTLANG_TAG_value;
-	zend_string *const_EXTLANG_TAG_value_str = zend_string_init(LOC_EXTLANG_TAG, sizeof(LOC_EXTLANG_TAG) - 1, 1);
+	zend_string *const_EXTLANG_TAG_value_str = zend_string_init(LOC_EXTLANG_TAG, strlen(LOC_EXTLANG_TAG), 1);
 	ZVAL_STR(&const_EXTLANG_TAG_value, const_EXTLANG_TAG_value_str);
 	zend_string *const_EXTLANG_TAG_name = zend_string_init_interned("EXTLANG_TAG", sizeof("EXTLANG_TAG") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_EXTLANG_TAG_name, &const_EXTLANG_TAG_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_EXTLANG_TAG_name);
 
 	zval const_SCRIPT_TAG_value;
-	zend_string *const_SCRIPT_TAG_value_str = zend_string_init(LOC_SCRIPT_TAG, sizeof(LOC_SCRIPT_TAG) - 1, 1);
+	zend_string *const_SCRIPT_TAG_value_str = zend_string_init(LOC_SCRIPT_TAG, strlen(LOC_SCRIPT_TAG), 1);
 	ZVAL_STR(&const_SCRIPT_TAG_value, const_SCRIPT_TAG_value_str);
 	zend_string *const_SCRIPT_TAG_name = zend_string_init_interned("SCRIPT_TAG", sizeof("SCRIPT_TAG") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_SCRIPT_TAG_name, &const_SCRIPT_TAG_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_SCRIPT_TAG_name);
 
 	zval const_REGION_TAG_value;
-	zend_string *const_REGION_TAG_value_str = zend_string_init(LOC_REGION_TAG, sizeof(LOC_REGION_TAG) - 1, 1);
+	zend_string *const_REGION_TAG_value_str = zend_string_init(LOC_REGION_TAG, strlen(LOC_REGION_TAG), 1);
 	ZVAL_STR(&const_REGION_TAG_value, const_REGION_TAG_value_str);
 	zend_string *const_REGION_TAG_name = zend_string_init_interned("REGION_TAG", sizeof("REGION_TAG") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_REGION_TAG_name, &const_REGION_TAG_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_REGION_TAG_name);
 
 	zval const_VARIANT_TAG_value;
-	zend_string *const_VARIANT_TAG_value_str = zend_string_init(LOC_VARIANT_TAG, sizeof(LOC_VARIANT_TAG) - 1, 1);
+	zend_string *const_VARIANT_TAG_value_str = zend_string_init(LOC_VARIANT_TAG, strlen(LOC_VARIANT_TAG), 1);
 	ZVAL_STR(&const_VARIANT_TAG_value, const_VARIANT_TAG_value_str);
 	zend_string *const_VARIANT_TAG_name = zend_string_init_interned("VARIANT_TAG", sizeof("VARIANT_TAG") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_VARIANT_TAG_name, &const_VARIANT_TAG_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_VARIANT_TAG_name);
 
 	zval const_GRANDFATHERED_LANG_TAG_value;
-	zend_string *const_GRANDFATHERED_LANG_TAG_value_str = zend_string_init(LOC_GRANDFATHERED_LANG_TAG, sizeof(LOC_GRANDFATHERED_LANG_TAG) - 1, 1);
+	zend_string *const_GRANDFATHERED_LANG_TAG_value_str = zend_string_init(LOC_GRANDFATHERED_LANG_TAG, strlen(LOC_GRANDFATHERED_LANG_TAG), 1);
 	ZVAL_STR(&const_GRANDFATHERED_LANG_TAG_value, const_GRANDFATHERED_LANG_TAG_value_str);
 	zend_string *const_GRANDFATHERED_LANG_TAG_name = zend_string_init_interned("GRANDFATHERED_LANG_TAG", sizeof("GRANDFATHERED_LANG_TAG") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_GRANDFATHERED_LANG_TAG_name, &const_GRANDFATHERED_LANG_TAG_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_GRANDFATHERED_LANG_TAG_name);
 
 	zval const_PRIVATE_TAG_value;
-	zend_string *const_PRIVATE_TAG_value_str = zend_string_init(LOC_PRIVATE_TAG, sizeof(LOC_PRIVATE_TAG) - 1, 1);
+	zend_string *const_PRIVATE_TAG_value_str = zend_string_init(LOC_PRIVATE_TAG, strlen(LOC_PRIVATE_TAG), 1);
 	ZVAL_STR(&const_PRIVATE_TAG_value, const_PRIVATE_TAG_value_str);
 	zend_string *const_PRIVATE_TAG_name = zend_string_init_interned("PRIVATE_TAG", sizeof("PRIVATE_TAG") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_PRIVATE_TAG_name, &const_PRIVATE_TAG_value, ZEND_ACC_PUBLIC, NULL);

--- a/ext/intl/uchar/uchar_arginfo.h
+++ b/ext/intl/uchar/uchar_arginfo.h
@@ -319,7 +319,7 @@ static zend_class_entry *register_class_IntlChar(void)
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 
 	zval const_UNICODE_VERSION_value;
-	zend_string *const_UNICODE_VERSION_value_str = zend_string_init(U_UNICODE_VERSION, sizeof(U_UNICODE_VERSION) - 1, 1);
+	zend_string *const_UNICODE_VERSION_value_str = zend_string_init(U_UNICODE_VERSION, strlen(U_UNICODE_VERSION), 1);
 	ZVAL_STR(&const_UNICODE_VERSION_value, const_UNICODE_VERSION_value_str);
 	zend_string *const_UNICODE_VERSION_name = zend_string_init_interned("UNICODE_VERSION", sizeof("UNICODE_VERSION") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_UNICODE_VERSION_name, &const_UNICODE_VERSION_value, ZEND_ACC_PUBLIC, NULL);

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1493,7 +1493,7 @@ static zend_class_entry *register_class_mysqli_sql_exception(zend_class_entry *c
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
 
 	zval property_sqlstate_default_value;
-	zend_string *property_sqlstate_default_value_str = zend_string_init("00000", sizeof("00000") - 1, 1);
+	zend_string *property_sqlstate_default_value_str = zend_string_init("00000", strlen("00000"), 1);
 	ZVAL_STR(&property_sqlstate_default_value, property_sqlstate_default_value_str);
 	zend_string *property_sqlstate_name = zend_string_init("sqlstate", sizeof("sqlstate") - 1, 1);
 	zend_declare_typed_property(class_entry, property_sqlstate_name, &property_sqlstate_default_value, ZEND_ACC_PROTECTED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));

--- a/ext/pdo/pdo_dbh_arginfo.h
+++ b/ext/pdo/pdo_dbh_arginfo.h
@@ -500,7 +500,7 @@ static zend_class_entry *register_class_PDO(void)
 	zend_string_release(const_NULL_TO_STRING_name);
 
 	zval const_ERR_NONE_value;
-	zend_string *const_ERR_NONE_value_str = zend_string_init(PDO_ERR_NONE, sizeof(PDO_ERR_NONE) - 1, 1);
+	zend_string *const_ERR_NONE_value_str = zend_string_init(PDO_ERR_NONE, strlen(PDO_ERR_NONE), 1);
 	ZVAL_STR(&const_ERR_NONE_value, const_ERR_NONE_value_str);
 	zend_string *const_ERR_NONE_name = zend_string_init_interned("ERR_NONE", sizeof("ERR_NONE") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_ERR_NONE_name, &const_ERR_NONE_value, ZEND_ACC_PUBLIC, NULL);

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -556,22 +556,22 @@ static zend_class_entry *register_class_ZendTestStringEnum(void)
 	zend_class_entry *class_entry = zend_register_internal_enum("ZendTestStringEnum", IS_STRING, class_ZendTestStringEnum_methods);
 
 	zval enum_case_Foo_value;
-	zend_string *enum_case_Foo_value_str = zend_string_init("Test1", sizeof("Test1") - 1, 1);
+	zend_string *enum_case_Foo_value_str = zend_string_init("Test1", strlen("Test1"), 1);
 	ZVAL_STR(&enum_case_Foo_value, enum_case_Foo_value_str);
 	zend_enum_add_case_cstr(class_entry, "Foo", &enum_case_Foo_value);
 
 	zval enum_case_Bar_value;
-	zend_string *enum_case_Bar_value_str = zend_string_init("Test2", sizeof("Test2") - 1, 1);
+	zend_string *enum_case_Bar_value_str = zend_string_init("Test2", strlen("Test2"), 1);
 	ZVAL_STR(&enum_case_Bar_value, enum_case_Bar_value_str);
 	zend_enum_add_case_cstr(class_entry, "Bar", &enum_case_Bar_value);
 
 	zval enum_case_Baz_value;
-	zend_string *enum_case_Baz_value_str = zend_string_init("Test2\\a", sizeof("Test2\\a") - 1, 1);
+	zend_string *enum_case_Baz_value_str = zend_string_init("Test2\\a", strlen("Test2\\a"), 1);
 	ZVAL_STR(&enum_case_Baz_value, enum_case_Baz_value_str);
 	zend_enum_add_case_cstr(class_entry, "Baz", &enum_case_Baz_value);
 
 	zval enum_case_FortyTwo_value;
-	zend_string *enum_case_FortyTwo_value_str = zend_string_init("42", sizeof("42") - 1, 1);
+	zend_string *enum_case_FortyTwo_value_str = zend_string_init("42", strlen("42"), 1);
 	ZVAL_STR(&enum_case_FortyTwo_value, enum_case_FortyTwo_value_str);
 	zend_enum_add_case_cstr(class_entry, "FortyTwo", &enum_case_FortyTwo_value);
 

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -33,6 +33,12 @@ extern zend_module_entry zip_module_entry;
 
 #define PHP_ZIP_VERSION "1.21.1"
 
+#ifdef HAVE_LIBZIP_VERSION
+#define LIBZIP_VERSION_STR zip_libzip_version()
+#else
+#define LIBZIP_VERSION_STR LIBZIP_VERSION
+#endif
+
 #define ZIP_OPENBASEDIR_CHECKPATH(filename) php_check_open_basedir(filename)
 
 typedef struct _ze_zip_rsrc {

--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -633,6 +633,12 @@ class ZipArchive implements Countable
      */
     public const EM_UNKNOWN = UNKNOWN;
 
+    /**
+     * @var string
+     * @cvalue LIBZIP_VERSION_STR
+     */
+    public const LIBZIP_VERSION = UNKNOWN;
+
     /** @readonly */
     public int $lastId;
     /** @readonly */

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 52db51284a16b7664a3f66ea5d8a4a7b23aa5127 */
+ * Stub hash: d8c14dfe45c7eff2c18fd3c562488a827f658e12 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -1153,6 +1153,13 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zend_string *const_EM_UNKNOWN_name = zend_string_init_interned("EM_UNKNOWN", sizeof("EM_UNKNOWN") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_EM_UNKNOWN_name, &const_EM_UNKNOWN_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_EM_UNKNOWN_name);
+
+	zval const_LIBZIP_VERSION_value;
+	zend_string *const_LIBZIP_VERSION_value_str = zend_string_init(LIBZIP_VERSION_STR, strlen(LIBZIP_VERSION_STR), 1);
+	ZVAL_STR(&const_LIBZIP_VERSION_value, const_LIBZIP_VERSION_value_str);
+	zend_string *const_LIBZIP_VERSION_name = zend_string_init_interned("LIBZIP_VERSION", sizeof("LIBZIP_VERSION") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_LIBZIP_VERSION_name, &const_LIBZIP_VERSION_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_LIBZIP_VERSION_name);
 
 	zval property_lastId_default_value;
 	ZVAL_UNDEF(&property_lastId_default_value);


### PR DESCRIPTION
Using strlen() will make sure that non-constant values can also be used.

There was some issue with the tests on the original PR, so I tried to create a new one.