### PR TITLE
Fix run-tests.php for explicitly given test cases

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -362,6 +362,7 @@ function main(): void
     $context_line_count = 3;
     $num_repeats = 1;
     $show_progress = true;
+    $ignored_by_ext = [];
 
     $cfgtypes = ['show', 'keep'];
     $cfgfiles = ['skip', 'php', 'clean', 'out', 'diff', 'exp', 'mem'];
@@ -735,7 +736,6 @@ function main(): void
         $test_files = [];
         $exts_tested = $exts_to_test;
         $exts_skipped = [];
-        $ignored_by_ext = [];
         sort($exts_to_test);
         $test_dirs = [];
         $optionals = ['Zend', 'tests', 'ext', 'sapi'];


### PR DESCRIPTION
The recent improvement to list skipped extensions explicitly[1] missed to properly initialize `$ignored_by_ext` for the case where an explicit set of test cases are given; this was not a problem previously, since the undefined *global* variable was coerced to int.  We fix this by initializing the variable earlier.

[1] <https://github.com/php/php-src/commit/baef47ef3eafc37a4e69ef4ca530206517425768>