### PR TITLE
Fix the node that cannot be removed permanently

### DIFF
--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1129,6 +1129,9 @@ PHP_METHOD(DOMNode, removeChild)
 
 	while (children) {
 		if (children == child) {
+			if ((child->properties != NULL) && (child->doc != NULL) && child->properties->atype == XML_ATTRIBUTE_ID) {
+				xmlRemoveID(child->doc, child->properties);
+			}
 			xmlUnlinkNode(child);
 			DOM_RET_OBJ(child, &ret, intern);
 			return;
@@ -1678,7 +1681,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 		buf = xmlAllocOutputBuffer(NULL);
 	}
 
-    if (buf != NULL) {
+	if (buf != NULL) {
 		ret = xmlC14NDocSaveTo(docp, nodeset, exclusive, inclusive_ns_prefixes,
 			with_comments, buf);
 	}
@@ -1693,9 +1696,9 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 		xmlXPathFreeContext(ctxp);
 	}
 
-    if (buf == NULL || ret < 0) {
-        RETVAL_FALSE;
-    } else {
+	if (buf == NULL || ret < 0) {
+		RETVAL_FALSE;
+	} else {
 		if (mode == 0) {
 #ifdef LIBXML2_NEW_BUFFER
 			ret = xmlOutputBufferGetSize(buf);
@@ -1712,7 +1715,7 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 				RETVAL_EMPTY_STRING();
 			}
 		}
-    }
+	}
 
 	if (buf) {
 		int bytes;

--- a/ext/dom/tests/removeChild_permanently.phpt
+++ b/ext/dom/tests/removeChild_permanently.phpt
@@ -24,6 +24,7 @@ var_dump($dom->getElementById('foo'));
 $root->removeChild($dom->getElementById('foo'));
 var_dump($dom->getElementById('bar'));
 var_dump($dom->getElementById('foo'));
+echo $dom->saveXML();
 ?>
 --EXPECTF--
 object(DOMElement)#%d (%d) {
@@ -123,3 +124,5 @@ object(DOMElement)#%d (%d) {
   string(0) ""
 }
 NULL
+<?xml version="1.0"?>
+<html><p2 id="bar"/></html>

--- a/ext/dom/tests/removeChild_permanently.phpt
+++ b/ext/dom/tests/removeChild_permanently.phpt
@@ -1,0 +1,125 @@
+--TEST--
+DOMDocument::removeChild: The node cannot be removed permanently
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--FILE--
+<?php
+$dom = new DOMDocument();
+$root = $dom->createElement('html');
+$dom->appendChild($root);
+
+$el1 = $dom->createElement('p1');
+$el1->setAttribute('id', 'foo');
+$el1->setIdAttribute('id', true);
+
+$root->appendChild($el1);
+
+$el2 = $dom->createElement('p2');
+$el2->setAttribute('id', 'bar');
+$el2->setIdAttribute('id', true);
+
+$root->appendChild($el2);
+
+var_dump($dom->getElementById('foo'));
+$root->removeChild($dom->getElementById('foo'));
+var_dump($dom->getElementById('bar'));
+var_dump($dom->getElementById('foo'));
+?>
+--EXPECTF--
+object(DOMElement)#%d (%d) {
+  ["tagName"]=>
+  string(2) "p1"
+  ["schemaTypeInfo"]=>
+  NULL
+  ["firstElementChild"]=>
+  NULL
+  ["lastElementChild"]=>
+  NULL
+  ["childElementCount"]=>
+  int(0)
+  ["previousElementSibling"]=>
+  NULL
+  ["nextElementSibling"]=>
+  string(22) "(object value omitted)"
+  ["nodeName"]=>
+  string(2) "p1"
+  ["nodeValue"]=>
+  string(0) ""
+  ["nodeType"]=>
+  int(1)
+  ["parentNode"]=>
+  string(22) "(object value omitted)"
+  ["childNodes"]=>
+  string(22) "(object value omitted)"
+  ["firstChild"]=>
+  NULL
+  ["lastChild"]=>
+  NULL
+  ["previousSibling"]=>
+  NULL
+  ["nextSibling"]=>
+  string(22) "(object value omitted)"
+  ["attributes"]=>
+  string(22) "(object value omitted)"
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["namespaceURI"]=>
+  NULL
+  ["prefix"]=>
+  string(0) ""
+  ["localName"]=>
+  string(2) "p1"
+  ["baseURI"]=>
+  NULL
+  ["textContent"]=>
+  string(0) ""
+}
+object(DOMElement)#%d (%d) {
+  ["tagName"]=>
+  string(2) "p2"
+  ["schemaTypeInfo"]=>
+  NULL
+  ["firstElementChild"]=>
+  NULL
+  ["lastElementChild"]=>
+  NULL
+  ["childElementCount"]=>
+  int(0)
+  ["previousElementSibling"]=>
+  NULL
+  ["nextElementSibling"]=>
+  NULL
+  ["nodeName"]=>
+  string(2) "p2"
+  ["nodeValue"]=>
+  string(0) ""
+  ["nodeType"]=>
+  int(1)
+  ["parentNode"]=>
+  string(22) "(object value omitted)"
+  ["childNodes"]=>
+  string(22) "(object value omitted)"
+  ["firstChild"]=>
+  NULL
+  ["lastChild"]=>
+  NULL
+  ["previousSibling"]=>
+  NULL
+  ["nextSibling"]=>
+  NULL
+  ["attributes"]=>
+  string(22) "(object value omitted)"
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["namespaceURI"]=>
+  NULL
+  ["prefix"]=>
+  string(0) ""
+  ["localName"]=>
+  string(2) "p2"
+  ["baseURI"]=>
+  NULL
+  ["textContent"]=>
+  string(0) ""
+}
+NULL

--- a/ext/dom/tests/removeChild_permanently.phpt
+++ b/ext/dom/tests/removeChild_permanently.phpt
@@ -1,5 +1,5 @@
 --TEST--
-DOMDocument::removeChild: The node cannot be removed permanently
+DOMDocument::removeChild: The node that cannot be removed permanently
 --SKIPIF--
 <?php require_once('skipif.inc'); ?>
 --FILE--


### PR DESCRIPTION
See the example.
```php
$dom = new DOMDocument();
$root = $dom->createElement('html');
$dom->appendChild($root);
$el1 = $dom->createElement('p1');
$el1->setAttribute('id', 'foo');
$el1->setIdAttribute('id', true);
$root->appendChild($el1);

$root->removeChild($dom->getElementById('foo'));
var_dump($dom->getElementById('foo'));  // it is not null.
```

I have removed the `$dom->getElementById('foo')` from $root, but the output of `var_dump($dom->getElementById('foo'))` is not null.

About the bug https://bugs.php.net/bug.php?id=79701
I found it difficult to fix this bug after I read the source code of libxml2 and the easiest way to fix it is to throw the exception if the duplicate id is found.
But it will lead to a BC.