### PR TITLE
Revert unintended test expectation change

### DIFF
--- a/ext/standard/tests/network/bug73594.phpt
+++ b/ext/standard/tests/network/bug73594.phpt
@@ -24,4 +24,4 @@ $res = dns_get_record('php.net', DNS_MX, $auth, $additional);
 var_dump(!empty($res) && empty($additional));
 ?>
 --EXPECT--
-bool(true)
+bool(false)


### PR DESCRIPTION
Commit fbe3059 included an unintended change to the test which checks if dns_get_record populates its additional parameter. This patch reverts such change.

The issue was not detected by the CIs because their tests run in the --offline mode, and the test in question needs internet connection.