### PR TITLE
Throw in ReflectionMethod::__construct() when initialized with private parent method

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,5 +21,8 @@ PHP                                                                        NEWS
   . Added pdeathsig to builtin server to terminate workers when the master
     process is killed. (ilutov)
 
+- Reflection:
+  . Fix GH-9470 (ReflectionMethod constructor should not find private parent
+    method). (ilutov)
 
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3281,7 +3281,9 @@ ZEND_METHOD(ReflectionMethod, __construct)
 		&& (mptr = zend_get_closure_invoke_method(orig_obj)) != NULL)
 	{
 		/* do nothing, mptr already set */
-	} else if ((mptr = zend_hash_str_find_ptr(&ce->function_table, lcname, method_name_len)) == NULL) {
+	} else if ((mptr = zend_hash_str_find_ptr(&ce->function_table, lcname, method_name_len)) == NULL
+		|| ((mptr->common.fn_flags & ZEND_ACC_PRIVATE) && mptr->common.scope != ce))
+	{
 		efree(lcname);
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
 			"Method %s::%s() does not exist", ZSTR_VAL(ce->name), method_name);

--- a/ext/reflection/tests/gh9470.phpt
+++ b/ext/reflection/tests/gh9470.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-9470: ReflectionMethod constructor should not find private parent method
+--FILE--
+<?php
+
+class A
+{
+    public function publicMethod() {}
+    protected function protectedMethod() {}
+    private function privateMethod() {}
+}
+class B extends A {}
+
+echo (string) new ReflectionMethod('B', 'publicMethod');
+echo (string) new ReflectionMethod('B', 'protectedMethod');
+try {
+    echo (string) new ReflectionMethod('B', 'privateMethod');
+} catch(Throwable $e){
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+Method [ <user, inherits A> public method publicMethod ] {
+  @@ %s 5 - 5
+}
+Method [ <user, inherits A> protected method protectedMethod ] {
+  @@ %s 6 - 6
+}
+Method B::privateMethod() does not exist


### PR DESCRIPTION
Closes GH-9470