### PR TITLE
Fix test when session extension is shared

### DIFF
--- a/sapi/fpm/tests/bug77780-header-sent-error.phpt
+++ b/sapi/fpm/tests/bug77780-header-sent-error.phpt
@@ -24,7 +24,7 @@ echo str_repeat('asdfghjkl', 150000) . "\n";
 EOT;
 
 $tester = new FPM\Tester($cfg, $code);
-$tester->start();
+$tester->start(['-dextension=session']);
 $tester->expectLogStartNotices();
 $tester
     ->request(

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -392,7 +392,7 @@ class Tester
         $configFile = $this->createConfig();
         $desc       = $this->outDesc ? [] : [1 => array('pipe', 'w'), 2 => array('redirect', 1)];
 
-        $cmd = [self::findExecutable(), '-F', '-y', $configFile];
+        $cmd = [self::findExecutable(), '-F', '-y', $configFile, '-dextension_dir=modules'];
 
         if ($forceStderr) {
             $cmd[] = '-O';


### PR DESCRIPTION
When extension is build as shared then testing fpm configuration gets no extensions from EXTENSIONS section

Actual order in which extensions are loaded is defined by distro-builders (often via numeric prefix 00_ 10_) and I see no good "grepable" way to figure order from .m4 and .w32 files (they need clean-up) only few hard dependencies are found using `ZEND_MOD_REQUIRED` (will provide PR later)

Ref https://github.com/php/php-src/pull/9523#issuecomment-1261298575