### PR TITLE
Revert "Stop copying zend_module_entry (#8551)"

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -22,7 +22,6 @@ PHP 8.2 INTERNALS UPGRADE NOTES
 * php_stristr() no longer lowercases the haystack and needle as a side effect.
   Call zend_str_tolower() yourself if necessary. You no longer need to copy
   the haystack and needle before passing them to php_stristr().
-* zend_register_module_ex() no longer copies the module entry.
 * The main/php_stdint.h header has been removed.
   Include the standard <inttypes.h> and/or <stdint.h> headers instead.
   Replace usage of u_char by the standard C99 uint8_t type.

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -840,7 +840,9 @@ static void php_scanner_globals_ctor(zend_php_scanner_globals *scanner_globals_p
 static void module_destructor_zval(zval *zv) /* {{{ */
 {
 	zend_module_entry *module = (zend_module_entry*)Z_PTR_P(zv);
+
 	module_destructor(module);
+	free(module);
 }
 /* }}} */
 

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2411,7 +2411,7 @@ ZEND_API zend_module_entry* zend_register_module_ex(zend_module_entry *module) /
 	zend_str_tolower_copy(ZSTR_VAL(lcname), module->name, name_len);
 
 	lcname = zend_new_interned_string(lcname);
-	if ((module_ptr = zend_hash_add_ptr(&module_registry, lcname, module)) == NULL) {
+	if ((module_ptr = zend_hash_add_mem(&module_registry, lcname, module, sizeof(zend_module_entry))) == NULL) {
 		zend_error(E_CORE_WARNING, "Module \"%s\" is already loaded", module->name);
 		zend_string_release(lcname);
 		return NULL;
@@ -3143,6 +3143,7 @@ ZEND_API void zend_post_deactivate_modules(void) /* {{{ */
 				break;
 			}
 			module_destructor(module);
+			free(module);
 			zend_string_release_ex(key, 0);
 		} ZEND_HASH_MAP_FOREACH_END_DEL();
 	} else {


### PR DESCRIPTION
This reverts commit b63df3ce0e9f4eef94310aeb2ef7e8dfd0f953e4.

Fixes #9589

After all, copying the module entry was useful. This at least prevents overriding the module entry in case the module is loaded again in https://github.com/php/php-src/blob/ed0f1f04b909f9de82194819bbbaef752f07f383/ext/standard/dl.c#L228-L230