### PR TITLE
porting ZEND_ASSUME for clang for the optimiser with

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -89,6 +89,9 @@
 
 #if defined(ZEND_WIN32) && !defined(__clang__)
 # define ZEND_ASSUME(c)	__assume(c)
+#elif defined(__clang__) && __has_builtin(__builtin_assume)
+# pragma clang diagnostic ignored "-Wassume"
+# define ZEND_ASSUME(c)	__builtin_assume(c)
 #elif ((defined(__GNUC__) && ZEND_GCC_VERSION >= 4005) || __has_builtin(__builtin_unreachable)) && PHP_HAVE_BUILTIN_EXPECT
 # define ZEND_ASSUME(c)	do { \
 		if (__builtin_expect(!(c), 0)) __builtin_unreachable(); \


### PR DESCRIPTION
a given condition.

using `__builtin_assume` instead of the actual generic solution,
 disable `-Wassume` warning for the ZEND_ASSERT cases.