### PR TITLE
Remove support for libmysql-client from mysqli test suite

### DIFF
--- a/ext/mysqli/tests/071.phpt
+++ b/ext/mysqli/tests/071.phpt
@@ -16,22 +16,8 @@ require_once('skipifconnectfailure.inc');
     var_dump($mysql->ping());
 
     $ret = $mysql->kill($mysql->thread_id);
-    if ($IS_MYSQLND) {
-        if ($ret !== true){
-            printf("[001] Expecting boolean/true got %s/%s\n", gettype($ret), var_export($ret, true));
-        }
-    } else {
-        /* libmysql return value seems to depend on server version */
-        if ((($version >= 50123) || ($version <= 40200)) && $version != 50200) {
-            /* TODO: find exact version */
-            if ($ret !== true){
-                printf("[001] Expecting boolean/true got %s/%s @\n", gettype($ret), var_export($ret, true), $version);
-            }
-        } else {
-            if ($ret !== false){
-                printf("[001] Expecting boolean/false got %s/%s @\n", gettype($ret), var_export($ret, true), $version);
-            }
-        }
+    if ($ret !== true){
+        printf("[001] Expecting boolean/true got %s/%s\n", gettype($ret), var_export($ret, true));
     }
 
     var_dump($mysql->ping());
@@ -43,22 +29,8 @@ require_once('skipifconnectfailure.inc');
     var_dump(mysqli_ping($mysql));
 
     $ret = $mysql->kill($mysql->thread_id);
-    if ($IS_MYSQLND) {
-        if ($ret !== true){
-            printf("[002] Expecting boolean/true got %s/%s\n", gettype($ret), var_export($ret, true));
-        }
-    } else {
-        /* libmysql return value seems to depend on server version */
-        if ((($version >= 50123) || ($version <= 40200)) && $version != 50200) {
-            /* TODO: find exact version */
-            if ($ret !== true){
-                printf("[002] Expecting boolean/true got %s/%s @\n", gettype($ret), var_export($ret, true), $version);
-            }
-        } else {
-            if ($ret !== false){
-            printf("[002] Expecting boolean/false got %s/%s @\n", gettype($ret), var_export($ret, true), $version);
-            }
-        }
+    if ($ret !== true){
+        printf("[002] Expecting boolean/true got %s/%s\n", gettype($ret), var_export($ret, true));
     }
 
     var_dump(mysqli_ping($mysql));

--- a/ext/mysqli/tests/bug38710.phpt
+++ b/ext/mysqli/tests/bug38710.phpt
@@ -16,7 +16,7 @@ $qry->prepare("SELECT REPEAT('a',100000)");
 $qry->execute();
 $qry->bind_result($text);
 $qry->fetch();
-if ($text !== str_repeat('a', ($IS_MYSQLND || mysqli_get_server_version($db) > 50110)? 100000:(mysqli_get_server_version($db)>=50000? 8193:8191))) {
+if ($text !== str_repeat('a', 100000)) {
     var_dump(strlen($text));
 }
 echo "Done";

--- a/ext/mysqli/tests/bug44897.phpt
+++ b/ext/mysqli/tests/bug44897.phpt
@@ -6,10 +6,6 @@ mysqli
 <?php
 require_once 'connect.inc';
 
-if (!$IS_MYSQLND) {
-    die("skip: only available in mysqlnd");
-}
-
 if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }

--- a/ext/mysqli/tests/bug45019.phpt
+++ b/ext/mysqli/tests/bug45019.phpt
@@ -33,15 +33,9 @@ require_once('skipifconnectfailure.inc');
 
     $index = 0;
     while ($stmt->fetch()) {
-        /* NOTE: libmysql - http://bugs.mysql.com/bug.php?id=47483 */
         if ($data[$index] != $column1) {
-            if ($IS_MYSQLND || $index != 1) {
-                printf("[004] Row %d, expecting %s/%s got %s/%s\n",
-                    $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
-            } else {
-                if ($column1 != "thre")
-                    printf("[005] Got '%s'. Please check if http://bugs.mysql.com/bug.php?id=47483 has been fixed and adapt tests bug45019.phpt/mysqli_ps_select_union.phpt", $column1);
-            }
+            printf("[004] Row %d, expecting %s/%s got %s/%s\n",
+                $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
         }
         $index++;
     }

--- a/ext/mysqli/tests/bug45289.phpt
+++ b/ext/mysqli/tests/bug45289.phpt
@@ -25,10 +25,7 @@ require_once('skipifconnectfailure.inc');
         printf("[003] [%d] %s\n", $stmt->errno, $stmt->error);
 
     if ($res = $link->store_result()) {
-        if ($IS_MYSQLND)
-            printf("[004] Can store result!\n");
-        else
-            printf("[004] [007] http://bugs.mysql.com/bug.php?id=47485\n");
+        printf("[004] Can store result!\n");
     } else {
         printf("[004] [%d] %s\n", $link->errno, $link->error);
     }

--- a/ext/mysqli/tests/bug49442.phpt
+++ b/ext/mysqli/tests/bug49442.phpt
@@ -63,45 +63,43 @@ mysqli.max_persistent=1
     mysqli_query($link, "DELETE FROM test");
     mysqli_close($link);
 
-    if ($IS_MYSQLND) {
-        /*
-            mysqlnd makes a connection created through mysql_init()/mysqli_real_connect() always a 'persistent' one.
-            At this point 'persistent' is not to be confused with what a user calls a 'persistent' - in this case
-            'persistent' means that mysqlnd uses malloc() instead of emalloc(). nothing else. ext/mysqli will
-            not consider it as a 'persistent' connection in a user sense, ext/mysqli will not apply max_persistent etc.
-            It's only about malloc() vs. emalloc().
+    /*
+        mysqlnd makes a connection created through mysql_init()/mysqli_real_connect() always a 'persistent' one.
+        At this point 'persistent' is not to be confused with what a user calls a 'persistent' - in this case
+        'persistent' means that mysqlnd uses malloc() instead of emalloc(). nothing else. ext/mysqli will
+        not consider it as a 'persistent' connection in a user sense, ext/mysqli will not apply max_persistent etc.
+        It's only about malloc() vs. emalloc().
 
-            However, the bug is about malloc() and efree(). You can make mysqlnd use malloc() by either using
-            pconnect or mysql_init() - so we should test pconnect as well.
-        */
-        $host = 'p:' . $host;
-        if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
-            printf("[007] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
-        }
-
-        /* bug happened during query processing */
-        if (!@mysqli_query($link, sprintf("LOAD DATA LOCAL INFILE '%s'
-            INTO TABLE test
-            FIELDS TERMINATED BY ';' OPTIONALLY ENCLOSED BY '\''
-            LINES TERMINATED BY '\n'",
-            mysqli_real_escape_string($link, $file)))) {
-            printf("[008] [%d] %s\n",  mysqli_errno($link), mysqli_error($link));
-        }
-
-        /* we survived? that's good enough... */
-
-        if (!$res = mysqli_query($link, "SELECT * FROM test ORDER BY id"))
-            printf("[009] [%d] %s\n",  mysqli_errno($link), mysqli_error($link));
-
-        $i = 0;
-        while ($row = mysqli_fetch_assoc($res)) {
-            if (($row['id'] != $rows[$i]['id']) || ($row['label'] != $rows[$i]['label'])) {
-                printf("[010] Wrong values, check manually!\n");
-            }
-            $i++;
-        }
-        mysqli_close($link);
+        However, the bug is about malloc() and efree(). You can make mysqlnd use malloc() by either using
+        pconnect or mysql_init() - so we should test pconnect as well.
+    */
+    $host = 'p:' . $host;
+    if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
+        printf("[007] Connect failed, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
     }
+
+    /* bug happened during query processing */
+    if (!@mysqli_query($link, sprintf("LOAD DATA LOCAL INFILE '%s'
+        INTO TABLE test
+        FIELDS TERMINATED BY ';' OPTIONALLY ENCLOSED BY '\''
+        LINES TERMINATED BY '\n'",
+        mysqli_real_escape_string($link, $file)))) {
+        printf("[008] [%d] %s\n",  mysqli_errno($link), mysqli_error($link));
+    }
+
+    /* we survived? that's good enough... */
+
+    if (!$res = mysqli_query($link, "SELECT * FROM test ORDER BY id"))
+        printf("[009] [%d] %s\n",  mysqli_errno($link), mysqli_error($link));
+
+    $i = 0;
+    while ($row = mysqli_fetch_assoc($res)) {
+        if (($row['id'] != $rows[$i]['id']) || ($row['label'] != $rows[$i]['label'])) {
+            printf("[010] Wrong values, check manually!\n");
+        }
+        $i++;
+    }
+    mysqli_close($link);
 
     print "done!";
 ?>

--- a/ext/mysqli/tests/bug51647.phpt
+++ b/ext/mysqli/tests/bug51647.phpt
@@ -9,7 +9,7 @@ require_once "connect.inc";
 if (!defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'))
     die("skip Requires MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT");
 
-if ($IS_MYSQLND && !extension_loaded("openssl"))
+if (!extension_loaded("openssl"))
     die("skip PHP streams lack support for SSL. mysqli is compiled to use mysqlnd which uses PHP streams in turn.");
 
 if (!($link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)))

--- a/ext/mysqli/tests/bug52891.phpt
+++ b/ext/mysqli/tests/bug52891.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once('skipifconnectfailure.inc');
-if (!$IS_MYSQLND) {
-    die("skip: test applies only to mysqlnd");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug55283.phpt
+++ b/ext/mysqli/tests/bug55283.phpt
@@ -9,7 +9,7 @@ require_once "connect.inc";
 if (!defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'))
     die("skip Requires MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT");
 
-if ($IS_MYSQLND && !extension_loaded("openssl"))
+if (!extension_loaded("openssl"))
     die("skip PHP streams lack support for SSL. mysqli is compiled to use mysqlnd which uses PHP streams in turn.");
 
 if (!($link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)))

--- a/ext/mysqli/tests/bug62885.phpt
+++ b/ext/mysqli/tests/bug62885.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once("connect.inc");
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug63398.phpt
+++ b/ext/mysqli/tests/bug63398.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once "skipifconnectfailure.inc";
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug64726.phpt
+++ b/ext/mysqli/tests/bug64726.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once "skipifconnectfailure.inc";
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug67983.phpt
+++ b/ext/mysqli/tests/bug67983.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once('skipifconnectfailure.inc');
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug68077.phpt
+++ b/ext/mysqli/tests/bug68077.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'connect.inc';
-if (!$IS_MYSQLND) {
-    die("skip: test applies only to mysqlnd");
-}
 if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 }

--- a/ext/mysqli/tests/bug69899.phpt
+++ b/ext/mysqli/tests/bug69899.phpt
@@ -11,9 +11,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once __DIR__ . '/skipifconnectfailure.inc';
-if (!$IS_MYSQLND) {
-    die('skip mysqlnd only');
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug70949.phpt
+++ b/ext/mysqli/tests/bug70949.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug71863.phpt
+++ b/ext/mysqli/tests/bug71863.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/bug77935.phpt
+++ b/ext/mysqli/tests/bug77935.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once('skipifconnectfailure.inc');
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/connect.inc
+++ b/ext/mysqli/tests/connect.inc
@@ -25,8 +25,6 @@
     /* Development setting: test experimental features and/or feature requests that never worked before? */
     $TEST_EXPERIMENTAL = 1 == getenv("MYSQL_TEST_EXPERIMENTAL");
 
-    $IS_MYSQLND = stristr(mysqli_get_client_info(), "mysqlnd");
-
     if (!function_exists('sys_get_temp_dir')) {
         function sys_get_temp_dir() {
 

--- a/ext/mysqli/tests/gh7837.phpt
+++ b/ext/mysqli/tests/gh7837.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND) {
-    die("skip requires mysqlnd");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/gh9590.phpt
+++ b/ext/mysqli/tests/gh9590.phpt
@@ -6,9 +6,6 @@ mysqli
 <?php
 require_once('skipifconnectfailure.inc');
 
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only feature, compile PHP using --with-mysqli=mysqlnd");
-
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     die("skip cannot connect");
 

--- a/ext/mysqli/tests/mysqli_change_user_insert_id.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_insert_id.phpt
@@ -5,10 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-
-if (!$IS_MYSQLND) {
-    die("skip Might hit known and open bugs http://bugs.mysql.com/bug.php?id=30472, http://bugs.mysql.com/bug.php?id=45184");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_change_user_oo.phpt
+++ b/ext/mysqli/tests/mysqli_change_user_oo.phpt
@@ -7,9 +7,6 @@ mysqli
 require_once 'skipifconnectfailure.inc';
 
 require_once 'table.inc';
-if (!$IS_MYSQLND && (mysqli_get_server_version($link) < 50118 && mysqli_get_server_version($link) > 50100)) {
-    die("skip Your MySQL Server version has a known bug that will cause a crash");
-}
 
 if (mysqli_get_server_version($link) >= 50600)
     die("SKIP For MySQL < 5.6.0");

--- a/ext/mysqli/tests/mysqli_class_mysqli_interface.phpt
+++ b/ext/mysqli/tests/mysqli_class_mysqli_interface.phpt
@@ -61,13 +61,10 @@ require_once('skipifconnectfailure.inc');
         'use_result'			=> true,
     );
 
-    if ($IS_MYSQLND) {
-        // mysqlnd only
-        /* $expected_methods['get_client_stats']	= true; */
-        $expected_methods['get_connection_stats']	= true;
-        $expected_methods['reap_async_query']	= true;
-        $expected_methods['poll'] = true;
-    }
+    /* $expected_methods['get_client_stats']	= true; */
+    $expected_methods['get_connection_stats']	= true;
+    $expected_methods['reap_async_query']	= true;
+    $expected_methods['poll'] = true;
 
     /* we should add ruled when to expect them */
     if (function_exists('mysqli_debug'))

--- a/ext/mysqli/tests/mysqli_class_mysqli_result_interface.phpt
+++ b/ext/mysqli/tests/mysqli_class_mysqli_result_interface.phpt
@@ -111,8 +111,7 @@ require_once('skipifconnectfailure.inc');
     printf("mysqli_result->unknown = '%s'\n", @$mysqli_result->unknown);
 
     printf("\nConstructor:\n");
-    if (!is_object($res = new mysqli_result($link)))
-        printf("[001] Expecting object/mysqli_result got %s/%s\n", gettye($res), $res);
+    $res = new mysqli_result($link);
 
     try {
         $res->num_rows;
@@ -123,14 +122,9 @@ require_once('skipifconnectfailure.inc');
     if (!mysqli_query($link, "SELECT id FROM test ORDER BY id"))
         printf("[003] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    if (!is_object($res = new mysqli_result($link)))
-        printf("[004] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!is_object($res = new mysqli_result($link, MYSQLI_STORE_RESULT)))
-        printf("[005] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-
-    if (!is_object($res = new mysqli_result($link, MYSQLI_USE_RESULT)))
-        printf("[006] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    $res = new mysqli_result($link);
+    $res = new mysqli_result($link, MYSQLI_STORE_RESULT);
+    $res = new mysqli_result($link, MYSQLI_USE_RESULT);
 
     $valid = array(MYSQLI_STORE_RESULT, MYSQLI_USE_RESULT);
     do {
@@ -139,8 +133,7 @@ require_once('skipifconnectfailure.inc');
 
     if ($TEST_EXPERIMENTAL) {
         ob_start();
-        if (!is_object($res = new mysqli_result($link, $mode)))
-            printf("[008] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+        $res = new mysqli_result($link, $mode);
         $content = ob_get_contents();
         ob_end_clean();
         if (!stristr($content, 'Invalid value for resultmode'))

--- a/ext/mysqli/tests/mysqli_class_mysqli_stmt_interface.phpt
+++ b/ext/mysqli/tests/mysqli_class_mysqli_stmt_interface.phpt
@@ -40,11 +40,9 @@ mysqli
         'store_result'      => true,
     );
 
-    if ($IS_MYSQLND) {
-        $expected_methods['get_result'] = true;
-        $expected_methods['more_results'] = true;
-        $expected_methods['next_result'] = true;
-    }
+    $expected_methods['get_result'] = true;
+    $expected_methods['more_results'] = true;
+    $expected_methods['next_result'] = true;
 
     foreach ($methods as $k => $method) {
     if (isset($expected_methods[$method])) {

--- a/ext/mysqli/tests/mysqli_connect.phpt
+++ b/ext/mysqli/tests/mysqli_connect.phpt
@@ -118,28 +118,26 @@ require_once('skipifconnectfailure.inc');
         mysqli_close($link);
     }
 
-    if ($IS_MYSQLND) {
-        ini_set('mysqli.default_host', 'p:' . $host);
-            if (!is_object($link = mysqli_connect())) {
-                printf("[021] Usage of mysqli.default_host (persistent) failed\n") ;
-        } else {
-            if (!$res = mysqli_query($link, "SELECT 'mysqli.default_host (persistent)' AS 'testing'"))
-                printf("[022] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-            $tmp = mysqli_fetch_assoc($res);
-            if ($tmp['testing'] !== 'mysqli.default_host (persistent)') {
-                printf("[023] Result looks strange - check manually, [%d] %s\n",
-                    mysqli_errno($link), mysqli_error($link));
-                var_dump($tmp);
-            }
-            mysqli_free_result($res);
-            mysqli_close($link);
+    ini_set('mysqli.default_host', 'p:' . $host);
+        if (!is_object($link = mysqli_connect())) {
+            printf("[021] Usage of mysqli.default_host (persistent) failed\n") ;
+    } else {
+        if (!$res = mysqli_query($link, "SELECT 'mysqli.default_host (persistent)' AS 'testing'"))
+            printf("[022] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+        $tmp = mysqli_fetch_assoc($res);
+        if ($tmp['testing'] !== 'mysqli.default_host (persistent)') {
+            printf("[023] Result looks strange - check manually, [%d] %s\n",
+                mysqli_errno($link), mysqli_error($link));
+            var_dump($tmp);
         }
+        mysqli_free_result($res);
+        mysqli_close($link);
+    }
 
-        ini_set('mysqli.default_host', 'p:');
-        if (is_object($link = @mysqli_connect())) {
-            printf("[024] Usage of mysqli.default_host=p: did not fail\n") ;
-            mysqli_close($link);
-        }
+    ini_set('mysqli.default_host', 'p:');
+    if (is_object($link = @mysqli_connect())) {
+        printf("[024] Usage of mysqli.default_host=p: did not fail\n") ;
+        mysqli_close($link);
     }
 
     print "done!";

--- a/ext/mysqli/tests/mysqli_connect.phpt
+++ b/ext/mysqli/tests/mysqli_connect.phpt
@@ -119,8 +119,8 @@ require_once('skipifconnectfailure.inc');
     }
 
     ini_set('mysqli.default_host', 'p:' . $host);
-        if (!is_object($link = mysqli_connect())) {
-            printf("[021] Usage of mysqli.default_host (persistent) failed\n") ;
+    if (!is_object($link = mysqli_connect())) {
+        printf("[021] Usage of mysqli.default_host (persistent) failed\n") ;
     } else {
         if (!$res = mysqli_query($link, "SELECT 'mysqli.default_host (persistent)' AS 'testing'"))
             printf("[022] [%d] %s\n", mysqli_errno($link), mysqli_error($link));

--- a/ext/mysqli/tests/mysqli_connect_attr.phpt
+++ b/ext/mysqli/tests/mysqli_connect_attr.phpt
@@ -6,9 +6,6 @@ mysqli
 <?php
 require_once 'connect.inc';
 
-if (!$IS_MYSQLND)
-    die("skip: test applies only to mysqlnd");
-
 if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 

--- a/ext/mysqli/tests/mysqli_connect_oo.phpt
+++ b/ext/mysqli/tests/mysqli_connect_oo.phpt
@@ -24,35 +24,40 @@ require_once('skipifconnectfailure.inc');
 
     // Run the following tests without an anoynmous MySQL user and use a password for the test user!
     ini_set('mysqli.default_socket', $socket);
-    if (!is_object($mysqli = new mysqli($host, $user, $passwd, $db, $port)) || (0 !== mysqli_connect_errno())) {
+    $mysqli = new mysqli($host, $user, $passwd, $db, $port);
+    if (0 !== mysqli_connect_errno()) {
         printf("[005] Usage of mysqli.default_socket failed\n") ;
     } else {
         $mysqli->close();
     }
 
     ini_set('mysqli.default_port', $port);
-    if (!is_object($mysqli = new mysqli($host, $user, $passwd, $db)) || (0 !== mysqli_connect_errno())) {
+    $mysqli = new mysqli($host, $user, $passwd, $db);
+    if (0 !== mysqli_connect_errno()) {
         printf("[006] Usage of mysqli.default_port failed\n") ;
     } else {
         $mysqli->close();
     }
 
     ini_set('mysqli.default_pw', $passwd);
-    if (!is_object($mysqli = new mysqli($host, $user)) || (0 !== mysqli_connect_errno())) {
+    $mysqli = new mysqli($host, $user);
+    if (0 !== mysqli_connect_errno()) {
         printf("[007] Usage of mysqli.default_pw failed\n") ;
     } else {
         $mysqli->close();
     }
 
     ini_set('mysqli.default_user', $user);
-    if (!is_object($mysqli = new mysqli($host)) || (0 !== mysqli_connect_errno())) {
+    $mysqli = new mysqli($host);
+    if (0 !== mysqli_connect_errno()) {
         printf("[008] Usage of mysqli.default_user failed\n") ;
     } else {
         $mysqli->close();
     }
 
     ini_set('mysqli.default_host', $host);
-    if (!is_object($mysqli = new mysqli()) || (0 !== mysqli_connect_errno())) {
+    $mysqli = new mysqli();
+    if (0 !== mysqli_connect_errno()) {
         printf("[012] Failed to create mysqli object\n");
     } else {
         // There shall be NO connection! Using new mysqli(void) shall not use defaults for a connection!
@@ -67,19 +72,15 @@ require_once('skipifconnectfailure.inc');
     }
 
     ini_set('mysqli.default_host', 'p:' . $host);
-    if (!is_object($mysqli = new mysqli())) {
-        // Due to an API flaw this shall not connect
-        printf("[010] Failed to create mysqli object\n");
-    } else {
-        // There shall be NO connection! Using new mysqli(void) shall not use defaults for a connection!
-        // We had long discussions on this and found that the ext/mysqli API as
-        // such is broken. As we can't fix it, we document how it has behaved from
-        // the first day on. And that's: no connection.
-        try {
-            $mysqli->query('SELECT 1');
-        } catch (Error $exception) {
-            echo $exception->getMessage() . "\n";
-        }
+    $mysqli = new mysqli();
+    // There shall be NO connection! Using new mysqli(void) shall not use defaults for a connection!
+    // We had long discussions on this and found that the ext/mysqli API as
+    // such is broken. As we can't fix it, we document how it has behaved from
+    // the first day on. And that's: no connection.
+    try {
+        $mysqli->query('SELECT 1');
+    } catch (Error $exception) {
+        echo $exception->getMessage() . "\n";
     }
 
     print "... and now Exceptions\n";

--- a/ext/mysqli/tests/mysqli_connect_oo.phpt
+++ b/ext/mysqli/tests/mysqli_connect_oo.phpt
@@ -66,21 +66,19 @@ require_once('skipifconnectfailure.inc');
         }
     }
 
-    if ($IS_MYSQLND) {
-        ini_set('mysqli.default_host', 'p:' . $host);
-        if (!is_object($mysqli = new mysqli())) {
-            // Due to an API flaw this shall not connect
-            printf("[010] Failed to create mysqli object\n");
-        } else {
-            // There shall be NO connection! Using new mysqli(void) shall not use defaults for a connection!
-            // We had long discussions on this and found that the ext/mysqli API as
-            // such is broken. As we can't fix it, we document how it has behaved from
-            // the first day on. And that's: no connection.
-            try {
-                $mysqli->query('SELECT 1');
-            } catch (Error $exception) {
-                echo $exception->getMessage() . "\n";
-            }
+    ini_set('mysqli.default_host', 'p:' . $host);
+    if (!is_object($mysqli = new mysqli())) {
+        // Due to an API flaw this shall not connect
+        printf("[010] Failed to create mysqli object\n");
+    } else {
+        // There shall be NO connection! Using new mysqli(void) shall not use defaults for a connection!
+        // We had long discussions on this and found that the ext/mysqli API as
+        // such is broken. As we can't fix it, we document how it has behaved from
+        // the first day on. And that's: no connection.
+        try {
+            $mysqli->query('SELECT 1');
+        } catch (Error $exception) {
+            echo $exception->getMessage() . "\n";
         }
     }
 

--- a/ext/mysqli/tests/mysqli_constants.phpt
+++ b/ext/mysqli/tests/mysqli_constants.phpt
@@ -7,7 +7,6 @@ mysqli.allow_local_infile=1
 --FILE--
 <?php
 
-$IS_MYSQLND = stristr(mysqli_get_client_info(), "mysqlnd");
 $constants = get_defined_constants(true);
 sort($constants);
 
@@ -103,48 +102,27 @@ $expected_constants = array(
     "MYSQLI_TRANS_COR_NO_RELEASE"		=> true,
 );
 
-/* depends on the build - experimental */
-if ($IS_MYSQLND) {
-    $expected_constants['MYSQLI_OPT_INT_AND_FLOAT_NATIVE'] = true;
-}
+$expected_constants['MYSQLI_OPT_INT_AND_FLOAT_NATIVE'] = true;
 
-if ($IS_MYSQLND) {
-    $expected_constants['MYSQLI_STORE_RESULT_COPY_DATA'] = true;
-}
+$expected_constants['MYSQLI_STORE_RESULT_COPY_DATA'] = true;
 
-if ($IS_MYSQLND) {
-    $expected_constants['MYSQLI_REFRESH_BACKUP_LOG'] = true;
-}
+$expected_constants['MYSQLI_REFRESH_BACKUP_LOG'] = true;
 
-if ($IS_MYSQLND) {
-    $version = 50007 + 1;
-    $expected_constants['MYSQLI_OPT_NET_CMD_BUFFER_SIZE'] = true;
-    $expected_constants['MYSQLI_OPT_NET_READ_BUFFER_SIZE'] = true;
-    $expected_constants['MYSQLI_ASYNC'] = true;
+$version = 50007 + 1;
+$expected_constants['MYSQLI_OPT_NET_CMD_BUFFER_SIZE'] = true;
+$expected_constants['MYSQLI_OPT_NET_READ_BUFFER_SIZE'] = true;
+$expected_constants['MYSQLI_ASYNC'] = true;
 
-    $expected_constants['MYSQLI_SERVER_PS_OUT_PARAMS'] = true;
-} else {
-    $version = mysqli_get_client_version();
-}
+$expected_constants['MYSQLI_SERVER_PS_OUT_PARAMS'] = true;
 
-if (($version > 51122 && $version < 60000) || ($version > 60003) || $IS_MYSQLND) {
-    $expected_constants['MYSQLI_ON_UPDATE_NOW_FLAG'] = true;
-}
+$expected_constants['MYSQLI_ON_UPDATE_NOW_FLAG'] = true;
 
-/* First introduced in MySQL 6.0, backported to MySQL 5.5 */
-if ($version >= 50500 || $IS_MYSQLND) {
-    $expected_constants['MYSQLI_SERVER_QUERY_WAS_SLOW'] = true;
-}
+$expected_constants['MYSQLI_SERVER_QUERY_WAS_SLOW'] = true;
 
 $expected_constants['MYSQLI_CLIENT_SSL_VERIFY_SERVER_CERT'] = true;
-if ($IS_MYSQLND) {
-    $expected_constants['MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'] = true;
-}
+$expected_constants['MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT'] = true;
 
-/* First introduced in MySQL 6.0, backported to MySQL 5.5 */
-if ($version >= 50606 || $IS_MYSQLND) {
-    $expected_constants['MYSQLI_SERVER_PUBLIC_KEY'] = true;
-}
+$expected_constants['MYSQLI_SERVER_PUBLIC_KEY'] = true;
 
 $expected_constants = array_merge($expected_constants, array(
     "MYSQLI_TYPE_NEWDECIMAL"	=> true,
@@ -165,22 +143,15 @@ $expected_constants = array_merge($expected_constants, array(
     "MYSQLI_STMT_ATTR_PREFETCH_ROWS"	=> true,
 ));
 
-if ($version < 80000 || $version >= 100000 || $IS_MYSQLND) {
-    $expected_constants['MYSQLI_OPT_SSL_VERIFY_SERVER_CERT'] = true;
-}
+$expected_constants['MYSQLI_OPT_SSL_VERIFY_SERVER_CERT'] = true;
 
 /* pretty dump test, but that is the best way to mimic mysql.c */
 $expected_constants["MYSQLI_DATA_TRUNCATED"] = true;
 
-if ($IS_MYSQLND || (!$IS_MYSQLND && ($version > 50610))) {
-    /* could be that MySQL/libmysql 5.6.9 had the flag already but it was no stable release */
-    $expected_constants["MYSQLI_OPT_CAN_HANDLE_EXPIRED_PASSWORDS"] = true;
-    $expected_constants["MYSQLI_CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS"] = true;
-}
+$expected_constants["MYSQLI_OPT_CAN_HANDLE_EXPIRED_PASSWORDS"] = true;
+$expected_constants["MYSQLI_CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS"] = true;
 
-if ($IS_MYSQLND) {
-    $expected_constants["MYSQLI_TYPE_JSON"]	= true;
-}
+$expected_constants["MYSQLI_TYPE_JSON"]	= true;
 
 $unexpected_constants = array();
 

--- a/ext/mysqli/tests/mysqli_debug.phpt
+++ b/ext/mysqli/tests/mysqli_debug.phpt
@@ -23,38 +23,34 @@ if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     if (true !== ($tmp = mysqli_debug(sprintf('d:t:O,%s/mysqli_debug_phpt.trace', sys_get_temp_dir()))))
         printf("[002] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
-    if ($IS_MYSQLND) {
-        // let's make this mysqlnd only - for libmysql we need debug installation
+    // table.inc will create a database connection and run some SQL queries, therefore
+    // the debug file should have entries
+    require_once('table.inc');
 
-        // table.inc will create a database connection and run some SQL queries, therefore
-        // the debug file should have entries
-        require_once('table.inc');
+    clearstatcache();
+    $trace_file = sprintf('%s/mysqli_debug_phpt.trace', sys_get_temp_dir());
+    if (!file_exists($trace_file))
+        printf("[003] Trace file '%s' has not been created\n", $trace_file);
+    if (filesize($trace_file) < 50)
+        printf("[004] Trace file '%s' is very small. filesize() reports only %d bytes. Please check.\n",
+            $trace_file,
+            filesize($trace_file));
 
-        clearstatcache();
-        $trace_file = sprintf('%s/mysqli_debug_phpt.trace', sys_get_temp_dir());
-        if (!file_exists($trace_file))
-            printf("[003] Trace file '%s' has not been created\n", $trace_file);
-        if (filesize($trace_file) < 50)
-            printf("[004] Trace file '%s' is very small. filesize() reports only %d bytes. Please check.\n",
-                $trace_file,
-                filesize($trace_file));
+    // will mysqli_debug() mind if the trace file gets removed?
+    unlink($trace_file);
+    clearstatcache();
 
-        // will mysqli_debug() mind if the trace file gets removed?
-        unlink($trace_file);
-        clearstatcache();
+    if (!$res = mysqli_query($link, 'SELECT * FROM test'))
+            printf("[005] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+        else
+            mysqli_free_result($res);
 
-        if (!$res = mysqli_query($link, 'SELECT * FROM test'))
-                printf("[005] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-            else
-                mysqli_free_result($res);
+    mysqli_close($link);
 
-        mysqli_close($link);
-
-        clearstatcache();
-        if (!file_exists($trace_file))
-            printf("[006] Trace file '%s' does not exist\n", $trace_file);
-        unlink($trace_file);
-    }
+    clearstatcache();
+    if (!file_exists($trace_file))
+        printf("[006] Trace file '%s' does not exist\n", $trace_file);
+    unlink($trace_file);
 
     print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_debug_append.phpt
+++ b/ext/mysqli/tests/mysqli_debug_append.phpt
@@ -15,9 +15,6 @@ if (!defined('MYSQLI_DEBUG_TRACE_ENABLED'))
 if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     die("skip: debug functionality not enabled");
 
-if (!$IS_MYSQLND)
-    die("SKIP Libmysql feature not sufficiently spec'd in MySQL C API documentation");
-
 if (substr(PHP_OS, 0, 3) == 'WIN') die("skip this test is not for Windows platforms");
 ?>
 --FILE--
@@ -84,8 +81,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') die("skip this test is not for Windows platfo
 
     mysqli_close($link);
     print "done";
-    if ($IS_MYSQLND)
-        print "libmysql/DBUG package prints some debug info here."
+    print "libmysql/DBUG package prints some debug info here."
 ?>
 --CLEAN--
 <?php

--- a/ext/mysqli/tests/mysqli_debug_control_string.phpt
+++ b/ext/mysqli/tests/mysqli_debug_control_string.phpt
@@ -14,9 +14,6 @@ if (!defined('MYSQLI_DEBUG_TRACE_ENABLED'))
 
 if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     die("skip: debug functionality not enabled");
-
-if (!$IS_MYSQLND)
-    die("SKIP Libmysql feature not sufficiently spec'd in MySQL C API documentation");
 ?>
 --FILE--
 <?php
@@ -69,8 +66,7 @@ if (!$IS_MYSQLND)
 
     mysqli_close($link);
     print "done";
-    if ($IS_MYSQLND)
-        print "libmysql/DBUG package prints some debug info here."
+    print "libmysql/DBUG package prints some debug info here."
 ?>
 --EXPECTF--
 Warning: mysqli_debug(): Unrecognized format ',' in %s on line %d

--- a/ext/mysqli/tests/mysqli_debug_ini.phpt
+++ b/ext/mysqli/tests/mysqli_debug_ini.phpt
@@ -15,9 +15,6 @@ if (!defined('MYSQLI_DEBUG_TRACE_ENABLED'))
 if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     die("skip: debug functionality not enabled");
 
-if (!$IS_MYSQLND)
-    die("skip needs mysqlnd");
-
 if (!$fp = @fopen('/tmp/mysqli_debug_phpt.trace', 'w'))
     die("skip PHP cannot create a file in /tmp/mysqli_debug_phpt");
 else

--- a/ext/mysqli/tests/mysqli_debug_mysqlnd_control_string.phpt
+++ b/ext/mysqli/tests/mysqli_debug_mysqlnd_control_string.phpt
@@ -14,9 +14,6 @@ if (!defined('MYSQLI_DEBUG_TRACE_ENABLED'))
 
 if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     die("skip: debug functionality not enabled");
-
-if (!$IS_MYSQLND)
-    die("SKIP Libmysql feature not sufficiently spec'd in MySQL C API documentation");
 ?>
 --FILE--
 <?php
@@ -203,22 +200,17 @@ if (!$IS_MYSQLND)
         var_dump($tmp);
     }
 
-    if ($IS_MYSQLND) {
-        // mysqlnd only option
-        // m - trace memory allocations
-        $trace = try_control_string($link, 't:O,' . $trace_file . ':m', $trace_file, 120);
-        if (!preg_match("@^[|\s]*>\_mysqlnd_p?efree@ismU", $trace, $matches) &&
-                !preg_match("@^[|\s]*>\_mysqlnd_p?emalloc@ismU", $trace, $matches)) {
-            printf("[125] Memory dump does neither contain _mysqlnd_pefree nor _mysqlnd_pemalloc calls - check manually.\n");
-            var_dump($trace);
-        }
-
+    // m - trace memory allocations
+    $trace = try_control_string($link, 't:O,' . $trace_file . ':m', $trace_file, 120);
+    if (!preg_match("@^[|\s]*>\_mysqlnd_p?efree@ismU", $trace, $matches) &&
+            !preg_match("@^[|\s]*>\_mysqlnd_p?emalloc@ismU", $trace, $matches)) {
+        printf("[125] Memory dump does neither contain _mysqlnd_pefree nor _mysqlnd_pemalloc calls - check manually.\n");
+        var_dump($trace);
     }
 
     mysqli_close($link);
     print "done";
-    if ($IS_MYSQLND)
-        print "libmysql/DBUG package prints some debug info here.";
+    print "libmysql/DBUG package prints some debug info here.";
     @unlink($trace_file);
 ?>
 --CLEAN--

--- a/ext/mysqli/tests/mysqli_debug_mysqlnd_only.phpt
+++ b/ext/mysqli/tests/mysqli_debug_mysqlnd_only.phpt
@@ -14,9 +14,6 @@ if (!defined('MYSQLI_DEBUG_TRACE_ENABLED'))
 
 if (defined('MYSQLI_DEBUG_TRACE_ENABLED') && !MYSQLI_DEBUG_TRACE_ENABLED)
     die("skip: debug functionality not enabled");
-
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only test");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_driver.phpt
+++ b/ext/mysqli/tests/mysqli_driver.phpt
@@ -10,9 +10,7 @@ require_once('skipifconnectfailure.inc');
 <?php
 require_once('connect.inc');
 
-if (!is_object($driver = new mysqli_driver())) {
-    printf("[001] Failed to create mysqli_driver object\n");
-}
+$driver = new mysqli_driver();
 
 $client_info = mysqli_get_client_info();
 if (($tmp = $driver->client_info) !== $client_info) {

--- a/ext/mysqli/tests/mysqli_expire_password.phpt
+++ b/ext/mysqli/tests/mysqli_expire_password.phpt
@@ -26,10 +26,6 @@ if ($link->server_version >= 100000) {
 
 }
 
-if  (!$IS_MYSQLND && (mysqli_get_client_version() < 50610)) {
-    die(sprintf("SKIP Needs libmysql 5.6.10 or newer, found  %s\n", mysqli_get_client_version()));
-}
-
 mysqli_query($link, 'DROP USER expiretest');
 mysqli_query($link, 'DROP USER expiretest@localhost');
 

--- a/ext/mysqli/tests/mysqli_explain_metadata.phpt
+++ b/ext/mysqli/tests/mysqli_explain_metadata.phpt
@@ -5,8 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND)
-  die("skip Open libmysql/MySQL issue http://bugs.mysql.com/?id=62350");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_fetch_array.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_array.phpt
@@ -176,12 +176,10 @@ require_once('skipifconnectfailure.inc');
     func_mysqli_fetch_array($link, $engine, "INTEGER UNSIGNED", "4294967295", "4294967295", 230);
     func_mysqli_fetch_array($link, $engine, "INTEGER UNSIGNED", NULL, NULL, 240);
 
-    if ($IS_MYSQLND || mysqli_get_server_version($link) >= 51000) {
-        func_mysqli_fetch_array($link, $engine, "BIGINT", "-9223372036854775808", "-9223372036854775808", 250);
-        func_mysqli_fetch_array($link, $engine, "BIGINT", NULL, NULL, 260);
-        func_mysqli_fetch_array($link, $engine, "BIGINT UNSIGNED", "18446744073709551615", "18446744073709551615", 260);
-        func_mysqli_fetch_array($link, $engine, "BIGINT UNSIGNED", NULL, NULL, 280);
-    }
+    func_mysqli_fetch_array($link, $engine, "BIGINT", "-9223372036854775808", "-9223372036854775808", 250);
+    func_mysqli_fetch_array($link, $engine, "BIGINT", NULL, NULL, 260);
+    func_mysqli_fetch_array($link, $engine, "BIGINT UNSIGNED", "18446744073709551615", "18446744073709551615", 260);
+    func_mysqli_fetch_array($link, $engine, "BIGINT UNSIGNED", NULL, NULL, 280);
 
     func_mysqli_fetch_array($link, $engine, "FLOAT", (string)(-9223372036854775808 - 1.1), "-9.22337e+18", 290, "/-9\.22337e\+?[0]?18/iu");
     func_mysqli_fetch_array($link, $engine, "FLOAT", NULL, NULL, 300);

--- a/ext/mysqli/tests/mysqli_fetch_array_oo.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_array_oo.phpt
@@ -171,12 +171,10 @@ require_once('skipifconnectfailure.inc');
     func_mysqli_fetch_array($mysqli, $engine, "INTEGER UNSIGNED", "4294967295", "4294967295", 230);
     func_mysqli_fetch_array($mysqli, $engine, "INTEGER UNSIGNED", NULL, NULL, 240);
 
-    if ($IS_MYSQLND || mysqli_get_server_version($link) >= 51000) {
-        func_mysqli_fetch_array($mysqli, $engine, "BIGINT", "-9223372036854775808", "-9223372036854775808", 250);
-        func_mysqli_fetch_array($mysqli, $engine, "BIGINT", NULL, NULL, 260);
-        func_mysqli_fetch_array($mysqli, $engine, "BIGINT UNSIGNED", "18446744073709551615", "18446744073709551615", 270);
-        func_mysqli_fetch_array($mysqli, $engine, "BIGINT UNSIGNED", NULL, NULL, 280);
-    }
+    func_mysqli_fetch_array($mysqli, $engine, "BIGINT", "-9223372036854775808", "-9223372036854775808", 250);
+    func_mysqli_fetch_array($mysqli, $engine, "BIGINT", NULL, NULL, 260);
+    func_mysqli_fetch_array($mysqli, $engine, "BIGINT UNSIGNED", "18446744073709551615", "18446744073709551615", 270);
+    func_mysqli_fetch_array($mysqli, $engine, "BIGINT UNSIGNED", NULL, NULL, 280);
 
     func_mysqli_fetch_array($mysqli, $engine, "FLOAT", (string)(-9223372036854775808 - 1.1), "-9.22337e+18", 290, "/-9\.22337e\+?[0]?18/iu");
     func_mysqli_fetch_array($mysqli, $engine, "FLOAT", NULL, NULL, 300);

--- a/ext/mysqli/tests/mysqli_fetch_column.phpt
+++ b/ext/mysqli/tests/mysqli_fetch_column.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_get_host_info.phpt
+++ b/ext/mysqli/tests/mysqli_get_host_info.phpt
@@ -14,7 +14,7 @@ require_once('skipifconnectfailure.inc');
     if (!is_string($info = mysqli_get_host_info($link)) || ('' === $info))
         printf("[003] Expecting string/any_non_empty, got %s/%s\n", gettype($info), $info);
 
-    if ($IS_MYSQLND && $host != 'localhost' && $host != '127.0.0.1' && $port != '' && $host != "" && strtoupper(substr(PHP_OS, 0, 3)) != 'WIN') {
+    if ($host != 'localhost' && $host != '127.0.0.1' && $port != '' && $host != "" && strtoupper(substr(PHP_OS, 0, 3)) != 'WIN') {
         /* this should be a TCP/IP connection and not a Unix Socket (or SHM or Named Pipe) */
         if (!stristr($info, "TCP/IP"))
             printf("[004] Should be a TCP/IP connection but mysqlnd says '%s'\n", $info);

--- a/ext/mysqli/tests/mysqli_get_warnings.phpt
+++ b/ext/mysqli/tests/mysqli_get_warnings.phpt
@@ -92,8 +92,7 @@ if (!$TEST_EXPERIMENTAL)
     if (!$mysqli->query("CREATE TABLE t1 (a smallint)"))
         printf("[023] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
-    if (!is_object($warning = new mysqli_warning($mysqli)))
-        printf("[024] Expecting object/mysqli_warning, got %s/%s", gettype($warning), $warning);
+    $warning = new mysqli_warning($mysqli);
 
     if (!is_string($warning->message) || ('' == $warning->message))
         printf("[025] Expecting string, got %s/%s", gettype($warning->message), $warning->message);

--- a/ext/mysqli/tests/mysqli_kill.phpt
+++ b/ext/mysqli/tests/mysqli_kill.phpt
@@ -33,14 +33,8 @@ require_once('skipifconnectfailure.inc');
         printf("[007] Expecting string/any non empty, got %s/%s\n", gettype($error), $error);
     var_dump($res);
     var_dump($link);
-    if ($IS_MYSQLND) {
-        if ($link->info != 'Records: 6  Duplicates: 0  Warnings: 0') {
-            printf("[008] mysqlnd used to be more verbose and used to support SELECT\n");
-        }
-    } else {
-        if ($link->info != NULL) {
-            printf("[008] Time for wonders - libmysql has started to support SELECT, change test\n");
-        }
+    if ($link->info != 'Records: 6  Duplicates: 0  Warnings: 0') {
+        printf("[008] mysqlnd used to be more verbose and used to support SELECT\n");
     }
 
     mysqli_close($link);

--- a/ext/mysqli/tests/mysqli_mysqlnd_read_timeout.phpt
+++ b/ext/mysqli/tests/mysqli_mysqlnd_read_timeout.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND)
-    /* The libmysql read_timeout limit default is 365 * 24 * 3600 seconds. It cannot be altered through PHP API calls */
-    die("skip mysqlnd only test");
 ?>
 --INI--
 default_socket_timeout=60

--- a/ext/mysqli/tests/mysqli_mysqlnd_read_timeout_long.phpt
+++ b/ext/mysqli/tests/mysqli_mysqlnd_read_timeout_long.phpt
@@ -6,10 +6,6 @@ mysqli
 <?php
 require_once "connect.inc";
 
-if (!$IS_MYSQLND) {
-    die("skip: test applies only to mysqlnd");
-}
-
 if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
 }

--- a/ext/mysqli/tests/mysqli_mysqlnd_read_timeout_zero.phpt
+++ b/ext/mysqli/tests/mysqli_mysqlnd_read_timeout_zero.phpt
@@ -6,10 +6,6 @@ mysqli
 <?php
 require_once "connect.inc";
 
-if (!$IS_MYSQLND) {
-    die("skip: test applies only to mysqlnd");
-}
-
 if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
     die(sprintf('skip Cannot connect to MySQL, [%d] %s.', mysqli_connect_errno(), mysqli_connect_error()));
 }

--- a/ext/mysqli/tests/mysqli_no_reconnect.phpt
+++ b/ext/mysqli/tests/mysqli_no_reconnect.phpt
@@ -83,17 +83,14 @@ require_once('skipifconnectfailure.inc');
       the server always manages to send a full a reply. Whereas MySQl 5.5
       may not. The behaviour is undefined. Any return value is fine.
     */
-    if ($IS_MYSQLND) {
-        /*
-        mysqlnd is a bit more verbose than libmysql. mysqlnd should print:
-        Warning: mysqli_query(): MySQL server has gone away in %s on line %d
+    /*
+    mysqlnd is a bit more verbose than libmysql. mysqlnd should print:
+    Warning: mysqli_query(): MySQL server has gone away in %s on line %d
 
-        Warning: mysqli_query(): Error reading result set's header in %d on line %d
-        */
-        @mysqli_query($link, sprintf('KILL %d', $thread_id_timeout));
-    } else {
-        mysqli_query($link, sprintf('KILL %d', $thread_id_timeout));
-    }
+    Warning: mysqli_query(): Error reading result set's header in %d on line %d
+    */
+    @mysqli_query($link, sprintf('KILL %d', $thread_id_timeout));
+
     // Give the server a second to really kill the other thread...
     sleep(1);
 

--- a/ext/mysqli/tests/mysqli_options.phpt
+++ b/ext/mysqli/tests/mysqli_options.phpt
@@ -91,9 +91,6 @@ $link = mysqli_init();
 // test for error reporting - only mysqlnd reports errors
 try {
     mysqli_options($link, MYSQLI_SET_CHARSET_NAME, "foobar");
-    if (!$IS_MYSQLND) {
-        print "Unknown character set\n";
-    }
 } catch (mysqli_sql_exception $e) {
     echo $e->getMessage() . "\n";
 }

--- a/ext/mysqli/tests/mysqli_options_int_and_float_native.phpt
+++ b/ext/mysqli/tests/mysqli_options_int_and_float_native.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only test");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_options_openbasedir.phpt
+++ b/ext/mysqli/tests/mysqli_options_openbasedir.phpt
@@ -13,15 +13,9 @@ ini_set("open_basedir", __DIR__);
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     printf("[001] Cannot connect, [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error());
 
-if ($IS_MYSQLND) {
-    if (true !== mysqli_options($link, MYSQLI_OPT_LOCAL_INFILE, 1))
-        printf("[002] Cannot set MYSQLI_OPT_LOCAL_INFILE although open_basedir is set!\n");
+if (true !== mysqli_options($link, MYSQLI_OPT_LOCAL_INFILE, 1))
+    printf("[002] Cannot set MYSQLI_OPT_LOCAL_INFILE although open_basedir is set!\n");
 
-} else {
-    if (false !== mysqli_options($link, MYSQLI_OPT_LOCAL_INFILE, 1))
-        printf("[002] Can set MYSQLI_OPT_LOCAL_INFILE although open_basedir is set!\n");
-
-}
 mysqli_close($link);
 print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_phpinfo.phpt
+++ b/ext/mysqli/tests/mysqli_phpinfo.phpt
@@ -41,16 +41,14 @@ require_once('skipifconnectfailure.inc');
     if (!stristr($phpinfo, "mysqli.max_links"))
         printf("[008] php.ini setting mysqli.max_links not shown.\n");
 
-    if ($IS_MYSQLND) {
-        $expected = array(
-            'size',
-            'mysqli.allow_local_infile', 'mysqli.local_infile_directory',
-            'mysqli.allow_persistent', 'mysqli.max_persistent'
-        );
-        foreach ($expected as $k => $entry)
-            if (!stristr($phpinfo, $entry))
-                printf("[010] Could not find entry for '%s'\n", $entry);
-    }
+    $expected = array(
+        'size',
+        'mysqli.allow_local_infile', 'mysqli.local_infile_directory',
+        'mysqli.allow_persistent', 'mysqli.max_persistent'
+    );
+    foreach ($expected as $k => $entry)
+        if (!stristr($phpinfo, $entry))
+            printf("[010] Could not find entry for '%s'\n", $entry);
 
     print "done!";
 ?>

--- a/ext/mysqli/tests/mysqli_poll.phpt
+++ b/ext/mysqli/tests/mysqli_poll.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only feature, compile PHP using --with-mysqli=mysqlnd");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_poll_kill.phpt
+++ b/ext/mysqli/tests/mysqli_poll_kill.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only feature, compile PHP using --with-mysqli=mysqlnd");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_poll_mixing_insert_select.phpt
+++ b/ext/mysqli/tests/mysqli_poll_mixing_insert_select.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only feature, compile PHP using --with-mysqli=mysqlnd");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_poll_reference.phpt
+++ b/ext/mysqli/tests/mysqli_poll_reference.phpt
@@ -6,9 +6,6 @@ mysqli
 <?php
 require_once 'connect.inc';
 
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only feature, compile PHP using --with-mysqli=mysqlnd");
-
 if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
     die(sprintf("skip Can't connect to MySQL Server - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 

--- a/ext/mysqli/tests/mysqli_ps_select_union.phpt
+++ b/ext/mysqli/tests/mysqli_ps_select_union.phpt
@@ -41,32 +41,30 @@ require_once('skipifconnectfailure.inc');
     }
     $stmt->close();
 
-    if ($IS_MYSQLND) {
-        /*
-        Advantage mysqlnd -
-        The metadata mysqlnd has available after prepare is better than
-        the one made available by the MySQL Client Library (libmysql).
-        "libmysql" will give wrong results and that is OK -
-        http://bugs.mysql.com/bug.php?id=47483
-        */
-        if (!($stmt = $link->prepare("SELECT CAST('one' AS CHAR) AS column1 UNION SELECT CAST('three' AS CHAR) UNION SELECT CAST('two' AS CHAR)")))
-            printf("[005] [%d] %s\n", $link->errno, $link->error);
+    /*
+    Advantage mysqlnd -
+    The metadata mysqlnd has available after prepare is better than
+    the one made available by the MySQL Client Library (libmysql).
+    "libmysql" will give wrong results and that is OK -
+    http://bugs.mysql.com/bug.php?id=47483
+    */
+    if (!($stmt = $link->prepare("SELECT CAST('one' AS CHAR) AS column1 UNION SELECT CAST('three' AS CHAR) UNION SELECT CAST('two' AS CHAR)")))
+        printf("[005] [%d] %s\n", $link->errno, $link->error);
 
-        $column1 = null;
-        /* Note: bind_result before execute */
-        if (!$stmt->bind_result($column1) || !$stmt->execute())
-            printf("[006] [%d] %s\n", $stmt->errno, $stmt->error);
+    $column1 = null;
+    /* Note: bind_result before execute */
+    if (!$stmt->bind_result($column1) || !$stmt->execute())
+        printf("[006] [%d] %s\n", $stmt->errno, $stmt->error);
 
-        $index = 0;
-        while ($stmt->fetch()) {
-            if ($data[$index] != $column1) {
-                printf("[007] Row %d, expecting %s/%s got %s/%s\n",
-                    $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
-            }
-            $index++;
+    $index = 0;
+    while ($stmt->fetch()) {
+        if ($data[$index] != $column1) {
+            printf("[007] Row %d, expecting %s/%s got %s/%s\n",
+                $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
         }
-        $stmt->close();
+        $index++;
     }
+    $stmt->close();
 
     // Regular (non-prepared) queries
     print "Mixing CAST('somestring'AS CHAR), integer and CAST(integer AS CHAR)...\n";
@@ -98,25 +96,23 @@ require_once('skipifconnectfailure.inc');
     }
     $stmt->close();
 
-    if ($IS_MYSQLND) {
-        /* Advantage mysqlnd - see above... */
-        if (!($stmt = $link->prepare("SELECT 1 AS column1 UNION SELECT CAST('three' AS CHAR) UNION SELECT CAST(2 AS CHAR)")))
-            printf("[012] [%d] %s\n", $link->errno, $link->error);
+    /* Advantage mysqlnd - see above... */
+    if (!($stmt = $link->prepare("SELECT 1 AS column1 UNION SELECT CAST('three' AS CHAR) UNION SELECT CAST(2 AS CHAR)")))
+        printf("[012] [%d] %s\n", $link->errno, $link->error);
 
-        $column1 = null;
-        if (!$stmt->bind_result($column1) || !$stmt->execute())
-            printf("[013] [%d] %s\n", $stmt->errno, $stmt->error);
+    $column1 = null;
+    if (!$stmt->bind_result($column1) || !$stmt->execute())
+        printf("[013] [%d] %s\n", $stmt->errno, $stmt->error);
 
-        $index = 0;
-        while ($stmt->fetch()) {
-            if ($data[$index] != $column1) {
-                printf("[014] Row %d, expecting %s/%s got %s/%s\n",
-                    $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
-            }
-            $index++;
+    $index = 0;
+    while ($stmt->fetch()) {
+        if ($data[$index] != $column1) {
+            printf("[014] Row %d, expecting %s/%s got %s/%s\n",
+                $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
         }
-        $stmt->close();
+        $index++;
     }
+    $stmt->close();
 
     print "Using integer only...\n";
     if (!($res = $link->query("SELECT 1 AS column1 UNION SELECT 303 UNION SELECT 2")))
@@ -147,25 +143,23 @@ require_once('skipifconnectfailure.inc');
     }
     $stmt->close();
 
-    if ($IS_MYSQLND) {
-        /* Advantage mysqlnd - see above */
-        if (!($stmt = $link->prepare("SELECT 1 AS column1 UNION SELECT 303 UNION SELECT 2")))
-            printf("[019] [%d] %s\n", $link->errno, $link->error);
+    /* Advantage mysqlnd - see above */
+    if (!($stmt = $link->prepare("SELECT 1 AS column1 UNION SELECT 303 UNION SELECT 2")))
+        printf("[019] [%d] %s\n", $link->errno, $link->error);
 
-        $column1 = null;
-        if (!$stmt->bind_result($column1) || !$stmt->execute())
-            printf("[020] [%d] %s\n", $stmt->errno, $stmt->error);
+    $column1 = null;
+    if (!$stmt->bind_result($column1) || !$stmt->execute())
+        printf("[020] [%d] %s\n", $stmt->errno, $stmt->error);
 
-        $index = 0;
-        while ($stmt->fetch()) {
-            if ($data[$index] != $column1) {
-                printf("[021] Row %d, expecting %s/%s got %s/%s\n",
-                    $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
-            }
-            $index++;
+    $index = 0;
+    while ($stmt->fetch()) {
+        if ($data[$index] != $column1) {
+            printf("[021] Row %d, expecting %s/%s got %s/%s\n",
+                $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
         }
-        $stmt->close();
+        $index++;
     }
+    $stmt->close();
 
     print "Testing bind_param(), strings only...\n";
     $two = 'two';
@@ -185,27 +179,25 @@ require_once('skipifconnectfailure.inc');
     }
     $stmt->close();
 
-    if ($IS_MYSQLND) {
-        /* Advantage mysqlnd - see above */
-        $two = 'two';
-        $three = 'three';
-        if (!($stmt = $link->prepare("SELECT 'one' AS column1 UNION SELECT ? UNION SELECT ?")))
-            printf("[024] [%d] %s\n", $stmt->errno, $stmt->error);
+    /* Advantage mysqlnd - see above */
+    $two = 'two';
+    $three = 'three';
+    if (!($stmt = $link->prepare("SELECT 'one' AS column1 UNION SELECT ? UNION SELECT ?")))
+        printf("[024] [%d] %s\n", $stmt->errno, $stmt->error);
 
-        $column1 = null;
-        if (!$stmt->bind_param('ss', $three, $two) || !$stmt->bind_result($column1) || !$stmt->execute())
-            printf("[025] [%d] %s\n", $stmt->errno, $stmt->error);
+    $column1 = null;
+    if (!$stmt->bind_param('ss', $three, $two) || !$stmt->bind_result($column1) || !$stmt->execute())
+        printf("[025] [%d] %s\n", $stmt->errno, $stmt->error);
 
-        $index = 0;
-        while ($stmt->fetch()) {
-            if ($data[$index] != $column1) {
-                printf("[26] Row %d, expecting %s/%s, got %s/%s\n",
-                    $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
-            }
-            $index++;
+    $index = 0;
+    while ($stmt->fetch()) {
+        if ($data[$index] != $column1) {
+            printf("[26] Row %d, expecting %s/%s, got %s/%s\n",
+                $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
         }
-        $stmt->close();
+        $index++;
     }
+    $stmt->close();
 
     print "Testing bind_param(), strings only, with CAST AS CHAR...\n";
     $two = 'two';
@@ -225,27 +217,25 @@ require_once('skipifconnectfailure.inc');
     }
     $stmt->close();
 
-    if ($IS_MYSQLND) {
-        /* Advantage mysqlnd - see above */
-        $two = 'two';
-        $three = 'three beers are more than enough';
-        if (!($stmt = $link->prepare("SELECT CAST('one' AS CHAR) AS column1 UNION SELECT CAST(? AS CHAR) UNION SELECT CAST(? AS CHAR)")))
-            printf("[029] [%d] %s\n", $stmt->errno, $stmt->error);
+    /* Advantage mysqlnd - see above */
+    $two = 'two';
+    $three = 'three beers are more than enough';
+    if (!($stmt = $link->prepare("SELECT CAST('one' AS CHAR) AS column1 UNION SELECT CAST(? AS CHAR) UNION SELECT CAST(? AS CHAR)")))
+        printf("[029] [%d] %s\n", $stmt->errno, $stmt->error);
 
-        $column1 = null;
-        if (!$stmt->bind_param('ss', $three, $two) || !$stmt->bind_result($column1) || !$stmt->execute())
-            printf("[030] [%d] %s\n", $stmt->errno, $stmt->error);
+    $column1 = null;
+    if (!$stmt->bind_param('ss', $three, $two) || !$stmt->bind_result($column1) || !$stmt->execute())
+        printf("[030] [%d] %s\n", $stmt->errno, $stmt->error);
 
-        $index = 0;
-        while ($stmt->fetch()) {
-            if ($data[$index] != $column1) {
-                printf("[31] Row %d, expecting %s/%s, got %s/%s\n",
-                    $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
-            }
-            $index++;
+    $index = 0;
+    while ($stmt->fetch()) {
+        if ($data[$index] != $column1) {
+            printf("[31] Row %d, expecting %s/%s, got %s/%s\n",
+                $index + 1, gettype($data[$index]), $data[$index], gettype($column1), $column1);
         }
-        $stmt->close();
+        $index++;
     }
+    $stmt->close();
 
     $link->close();
 

--- a/ext/mysqli/tests/mysqli_real_connect.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect.phpt
@@ -113,32 +113,30 @@ mysqli.allow_local_infile=1
     mysqli_close($link);
     var_dump($link);
 
-    if ($IS_MYSQLND) {
-        ini_set('mysqli.default_host', 'p:' . $host);
-        $link = mysqli_init();
-        if (!@mysqli_real_connect($link)) {
-            printf("[022] Usage of mysqli.default_host=p:%s (persistent) failed\n", $host) ;
-        } else {
-            if (!$res = mysqli_query($link, "SELECT 'mysqli.default_host (persistent)' AS 'testing'"))
-                printf("[023] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-            $tmp = mysqli_fetch_assoc($res);
-            if ($tmp['testing'] !== 'mysqli.default_host (persistent)') {
-                printf("[024] Result looks strange - check manually, [%d] %s\n",
-                    mysqli_errno($link), mysqli_error($link));
-                var_dump($tmp);
-            }
-            mysqli_free_result($res);
-            mysqli_close($link);
+    ini_set('mysqli.default_host', 'p:' . $host);
+    $link = mysqli_init();
+    if (!@mysqli_real_connect($link)) {
+        printf("[022] Usage of mysqli.default_host=p:%s (persistent) failed\n", $host) ;
+    } else {
+        if (!$res = mysqli_query($link, "SELECT 'mysqli.default_host (persistent)' AS 'testing'"))
+            printf("[023] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+        $tmp = mysqli_fetch_assoc($res);
+        if ($tmp['testing'] !== 'mysqli.default_host (persistent)') {
+            printf("[024] Result looks strange - check manually, [%d] %s\n",
+                mysqli_errno($link), mysqli_error($link));
+            var_dump($tmp);
         }
-
-        ini_set('mysqli.default_host', 'p:');
-        $link = mysqli_init();
-        if (@mysqli_real_connect($link)) {
-            printf("[025] Usage of mysqli.default_host=p: did not fail\n") ;
-            mysqli_close($link);
-        }
-        @mysqli_close($link);
+        mysqli_free_result($res);
+        mysqli_close($link);
     }
+
+    ini_set('mysqli.default_host', 'p:');
+    $link = mysqli_init();
+    if (@mysqli_real_connect($link)) {
+        printf("[025] Usage of mysqli.default_host=p: did not fail\n") ;
+        mysqli_close($link);
+    }
+    @mysqli_close($link);
 
     try {
         mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket);

--- a/ext/mysqli/tests/mysqli_real_connect_pconn.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect_pconn.phpt
@@ -5,8 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only test");
 ?>
 --INI--
 mysqli.allow_local_infile=1
@@ -116,29 +114,27 @@ mysqli.max_persistent=10
 
     mysqli_close($link);
 
-    if ($IS_MYSQLND) {
-        $link = mysqli_init();
-        if (!@mysqli_real_connect($link)) {
-            printf("[022] Usage of mysqli.default_host=p:%s (persistent) failed\n", $host) ;
-        } else {
-            if (!$res = mysqli_query($link, "SELECT 'mysqli.default_host (persistent)' AS 'testing'"))
-                printf("[023] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
-            $tmp = mysqli_fetch_assoc($res);
-            if ($tmp['testing'] !== 'mysqli.default_host (persistent)') {
-                printf("[024] Result looks strange - check manually, [%d] %s\n",
-                    mysqli_errno($link), mysqli_error($link));
-                var_dump($tmp);
-            }
-            mysqli_free_result($res);
-            mysqli_close($link);
+    $link = mysqli_init();
+    if (!@mysqli_real_connect($link)) {
+        printf("[022] Usage of mysqli.default_host=p:%s (persistent) failed\n", $host) ;
+    } else {
+        if (!$res = mysqli_query($link, "SELECT 'mysqli.default_host (persistent)' AS 'testing'"))
+            printf("[023] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+        $tmp = mysqli_fetch_assoc($res);
+        if ($tmp['testing'] !== 'mysqli.default_host (persistent)') {
+            printf("[024] Result looks strange - check manually, [%d] %s\n",
+                mysqli_errno($link), mysqli_error($link));
+            var_dump($tmp);
         }
+        mysqli_free_result($res);
+        mysqli_close($link);
+    }
 
-        ini_set('mysqli.default_host', 'p:');
-        $link = mysqli_init();
-        if (@mysqli_real_connect($link)) {
-            printf("[025] Usage of mysqli.default_host=p: did not fail\n") ;
-            mysqli_close($link);
-        }
+    ini_set('mysqli.default_host', 'p:');
+    $link = mysqli_init();
+    if (@mysqli_real_connect($link)) {
+        printf("[025] Usage of mysqli.default_host=p: did not fail\n") ;
+        mysqli_close($link);
     }
 
     if (NULL === ($tmp = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, $socket)))

--- a/ext/mysqli/tests/mysqli_reap_async_query.phpt
+++ b/ext/mysqli/tests/mysqli_reap_async_query.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-
-if (!$IS_MYSQLND)
-    die("skip mysqlnd only feature, compile PHP using --with-mysqli=mysqlnd");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_result_references_mysqlnd.phpt
+++ b/ext/mysqli/tests/mysqli_result_references_mysqlnd.phpt
@@ -5,8 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND)
-    die("skip Test for mysqlnd only");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_stmt_bind_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_bind_result.phpt
@@ -276,12 +276,8 @@ require_once('skipifconnectfailure.inc');
     func_mysqli_stmt_bind_result($link, $engine, "b", "MEDIUMTEXT", "", 1640, 'string');
 
     /* Is this one related? http://bugs.php.net/bug.php?id=35759 */
-    if (($IS_MYSQLND) || (!$IS_MYSQLND && (ini_get('memory_limit') > 4294967296))) {
-        /* NOTE: the MySQL Client Library - not mysqlnd - will allocate
-        a hugge max_length(type) = 4GB bind buffer */
-        func_mysqli_stmt_bind_result($link, $engine, "b", "LONGBLOB", "", 1660);
-        func_mysqli_stmt_bind_result($link, $engine, "b", "LONGTEXT", "", 1680, 'string');
-    }
+    func_mysqli_stmt_bind_result($link, $engine, "b", "LONGBLOB", "", 1660);
+    func_mysqli_stmt_bind_result($link, $engine, "b", "LONGTEXT", "", 1680, 'string');
 
     func_mysqli_stmt_bind_result($link, $engine, "s", "ENUM('a', 'b')", "a", 1700, 'string');
     func_mysqli_stmt_bind_result($link, $engine, "s", "ENUM('a', 'b')", NULL, 1720, 'string');

--- a/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_bind.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once 'skipifconnectfailure.inc';
-if (!$IS_MYSQLND) {
-    die("skip only available in mysqlnd");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_stmt_execute_stored_proc_out.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute_stored_proc_out.phpt
@@ -11,11 +11,6 @@ if (!$link = @my_mysqli_connect($host, $user, $passwd, $db, $port, $socket)) {
 if (mysqli_get_server_version($link) < 50503) {
     die(sprintf('skip Needs MySQL 5.5.3+, found version %d.', mysqli_get_server_version($link)));
 }
-/*
-if ($IS_MYSQLND) {
-    die(sprintf("skip WHY ?!"));
-}
-*/
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_stmt_multires.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_multires.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once "skipifconnectfailure.inc";
-if (!$IS_MYSQLND) {
-    die("skip mysqlnd only test");
-}
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_stmt_num_rows.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_num_rows.phpt
@@ -83,7 +83,7 @@ require_once('skipifconnectfailure.inc');
         day, after Klingons visited earth, becomes the official one. Meanwhile, do
         not rely on it.
         */
-        if ($IS_MYSQLND && (7 !== ($tmp = mysqli_stmt_num_rows($stmt))))
+        if (7 !== ($tmp = mysqli_stmt_num_rows($stmt)))
             printf("[54] Expecting int/7, got %s/%s\n", gettype($tmp), $tmp);
 
     } else {

--- a/ext/mysqli/tests/mysqli_stmt_send_long_data_packet_size_mysqlnd.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_send_long_data_packet_size_mysqlnd.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once('skipifconnectfailure.inc');
-
-if (!$IS_MYSQLND)
-    die("skip: warnings only available in mysqlnd");
 ?>
 --FILE--
 <?php

--- a/ext/mysqli/tests/mysqli_store_result_copy.phpt
+++ b/ext/mysqli/tests/mysqli_store_result_copy.phpt
@@ -5,9 +5,6 @@ mysqli
 --SKIPIF--
 <?php
 require_once('skipifconnectfailure.inc');
-if (!$IS_MYSQLND) {
-    die("SKIP mysqlnd only test");
-}
 ?>
 --INI--
 mysqlnd.debug="d:t:O,{TMP}/mysqlnd.trace"


### PR DESCRIPTION
Since mysqli can no longer be built against libmysql-client, there is no longer the need to distinguish.

---

By the way, do we really still [support MySQL < 5.0](https://github.com/php/php-src/blob/63a0775474f7feff5598681960ef96354772fabb/ext/mysqli/tests/009.phpt#L47)?

