### PR TITLE
Use function HT_IS_PACKED where it's missing

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2882,7 +2882,7 @@ ZEND_API void ZEND_FASTCALL zend_hash_sort_ex(HashTable *ht, sort_func_t sort, b
 		ht->nNumUsed = i;
 	}
 
-	if (!(HT_FLAGS(ht) & HASH_FLAG_PACKED)) {
+	if (!HT_IS_PACKED(ht)) {
 		/* We broke the hash colisions chains overriding Z_NEXT() by Z_EXTRA().
 		 * Reset the hash headers table as well to avoid possilbe inconsistent
 		 * access on recursive data structures.

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2883,8 +2883,8 @@ ZEND_API void ZEND_FASTCALL zend_hash_sort_ex(HashTable *ht, sort_func_t sort, b
 	}
 
 	if (!HT_IS_PACKED(ht)) {
-		/* We broke the hash colisions chains overriding Z_NEXT() by Z_EXTRA().
-		 * Reset the hash headers table as well to avoid possilbe inconsistent
+		/* We broke the hash collisions chains overriding Z_NEXT() by Z_EXTRA().
+		 * Reset the hash headers table as well to avoid possible inconsistent
 		 * access on recursive data structures.
 	     *
 	     * See Zend/tests/bug63882_2.phpt

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -192,7 +192,7 @@ static zend_always_inline zval *zend_hash_find_ex(const HashTable *ht, zend_stri
 }
 
 #define ZEND_HASH_INDEX_FIND(_ht, _h, _ret, _not_found) do { \
-		if (EXPECTED(HT_FLAGS(_ht) & HASH_FLAG_PACKED)) { \
+		if (EXPECTED(HT_IS_PACKED(_ht))) { \
 			if (EXPECTED((zend_ulong)(_h) < (zend_ulong)(_ht)->nNumUsed)) { \
 				_ret = &_ht->arPacked[_h]; \
 				if (UNEXPECTED(Z_TYPE_P(_ret) == IS_UNDEF)) { \
@@ -215,7 +215,7 @@ ZEND_API zval* ZEND_FASTCALL zend_hash_lookup(HashTable *ht, zend_string *key);
 ZEND_API zval* ZEND_FASTCALL zend_hash_index_lookup(HashTable *ht, zend_ulong h);
 
 #define ZEND_HASH_INDEX_LOOKUP(_ht, _h, _ret) do { \
-		if (EXPECTED(HT_FLAGS(_ht) & HASH_FLAG_PACKED)) { \
+		if (EXPECTED(HT_IS_PACKED(_ht))) { \
 			if (EXPECTED((zend_ulong)(_h) < (zend_ulong)(_ht)->nNumUsed)) { \
 				_ret = &_ht->arPacked[_h]; \
 				if (EXPECTED(Z_TYPE_P(_ret) != IS_UNDEF)) { \
@@ -1513,7 +1513,7 @@ static zend_always_inline void *zend_hash_get_current_data_ptr_ex(HashTable *ht,
 		HashTable *__fill_ht = (ht); \
 		zval *__fill_val = __fill_ht->arPacked + __fill_ht->nNumUsed; \
 		uint32_t __fill_idx = __fill_ht->nNumUsed; \
-		ZEND_ASSERT(HT_FLAGS(__fill_ht) & HASH_FLAG_PACKED);
+		ZEND_ASSERT(HT_IS_PACKED(__fill_ht));
 
 #define ZEND_HASH_FILL_GROW() do { \
 		if (UNEXPECTED(__fill_idx >= __fill_ht->nTableSize)) { \

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -813,7 +813,7 @@ static inline int object_common(UNSERIALIZE_PARAMETER, zend_long elements, bool 
 		return 0;
 	}
 
-	zend_hash_extend(ht, zend_hash_num_elements(ht) + elements, HT_FLAGS(ht) & HASH_FLAG_PACKED);
+	zend_hash_extend(ht, zend_hash_num_elements(ht) + elements, HT_IS_PACKED(ht));
 	if (!process_nested_object_data(UNSERIALIZE_PASSTHRU, ht, elements, Z_OBJ_P(rval))) {
 		if (has_wakeup) {
 			ZVAL_DEREF(rval);


### PR DESCRIPTION
Hello everyone,
I found a few places where we can replace a bitwise operation with the function `HT_IS_PACKED` so I did the refactoring.

This is my first PR and I'm still exploring how PHP source code works. If the scope of this PR is too narrow or there are some issues with my changes I would be very glad to get some assist.

Kind regards