### PR TITLE
Fix bug #51056: blocking fread() will block even if data is available

### DIFF
--- a/ext/standard/tests/streams/bug51056.phpt
+++ b/ext/standard/tests/streams/bug51056.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bug #51056 (fread() on blocking stream will block even if data is available)
+--FILE--
+<?php
+
+$serverCode = <<<'CODE'
+$server = stream_socket_server('tcp://127.0.0.1:64324');
+phpt_notify();
+
+$conn = stream_socket_accept($server);
+
+fwrite($conn, "Hello 1\n"); // 8 bytes
+usleep(50000);
+fwrite($conn, str_repeat('a', 300)."\n"); // 301 bytes
+usleep(50000);
+fwrite($conn, "Hello 1\n"); // 8 bytes
+
+fclose($conn);
+fclose($server);
+CODE;
+
+$clientCode = <<<'CODE'
+
+phpt_wait();
+
+$fp = fsockopen("tcp://127.0.0.1:64324");
+
+while(!feof($fp)) {
+  $data = fread($fp, 256);
+  printf("fread read %d bytes\n", strlen($data));
+}
+CODE;
+
+include sprintf("%s/../../../openssl/tests/ServerClientTestCase.inc", __DIR__);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+
+?>
+--EXPECT--
+fread read 8 bytes
+fread read 256 bytes
+fread read 45 bytes
+fread read 8 bytes
+fread read 0 bytes

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -225,6 +225,7 @@ struct _php_stream  {
 	size_t readbuflen;
 	zend_off_t readpos;
 	zend_off_t writepos;
+	ssize_t didread;
 
 	/* how much data to read when filling buffer */
 	size_t chunk_size;


### PR DESCRIPTION
This fixes issue related to blocking stream that blocks even if there is buffered data.