### PR TITLE
Fix memory-leak in CLI web server

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1673,6 +1673,7 @@ static void php_cli_server_client_save_header(php_cli_server_client *client)
 	zend_hash_add(&client->request.headers_original_case, client->current_header_name, &tmp);
 
 	zend_string_release_ex(lc_header_name, /* persistent */ true);
+	zend_string_release_ex(client->current_header_name, /* persistent */ true);
 
 	client->current_header_name = NULL;
 	client->current_header_value = NULL;


### PR DESCRIPTION
Hi all :wave: :slightly_smiling_face: ,
my local test suite is complaining about a memory leak (see valgrind report below)

<details>
<summary>Valgrind Report</summary>

```
==471513== 112 bytes in 3 blocks are definitely lost in loss record 22 of 30
==471513==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==471513==    by 0x8BBB7B: __zend_malloc (zend_alloc.c:3089)
==471513==    by 0xA79298: zend_string_alloc (zend_string.h:150)
==471513==    by 0xA79338: zend_string_init (zend_string.h:172)
==471513==    by 0xA7DA55: php_cli_server_client_read_request_on_header_field (php_cli_server.c:1706)
==471513==    by 0xA780CC: php_http_parser_execute (php_http_parser.c:1121)
==471513==    by 0xA7DF17: php_cli_server_client_read_request (php_cli_server.c:1843)
==471513==    by 0xA7FCAC: php_cli_server_recv_event_read_request (php_cli_server.c:2557)
==471513==    by 0xA801C3: php_cli_server_do_event_for_each_fd_callback (php_cli_server.c:2661)
==471513==    by 0xA7BAE8: php_cli_server_poller_iter_on_active (php_cli_server.c:909)
==471513==    by 0xA8025D: php_cli_server_do_event_for_each_fd (php_cli_server.c:2681)
==471513==    by 0xA802E9: php_cli_server_do_event_loop (php_cli_server.c:2692)
```
</details>

Based on my research, it has been introduced in Php8.2 in this PR https://github.com/php/php-src/pull/8605
This is related to the `zend_string` containing the current header name during parsing.
Then, if your HTTP request doesn't include any header, there is no leak.

I'm not yet usual with the php-src test suite, but if you have an idea how to cover this leak by a test, I can give it a try.

Thanks a lot for your amazing work :hugs: 
