### PR TITLE
Auto-close FRs and PRs as not planned

### DIFF
--- a/.github/workflows/close-stale-feature-requests.yml
+++ b/.github/workflows/close-stale-feature-requests.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5
         with:
           days-before-close: 14
           days-before-stale: 90
@@ -23,6 +23,7 @@ jobs:
           only-issue-labels: "Status: Requires RFC,Feature"
           # Hack to skip PRs, unfortunately there's no option to disable PRs
           only-pr-labels: inexistent-label
+          close-issue-reason: not_planned
           stale-issue-message: >-
             There has not been any recent activity in this feature request. It will automatically be closed in 14 days
             if no further action is taken. Please see https://github.com/probot/stale#is-closing-stale-issues-really-a-good-idea

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5
         with:
           days-before-close: 7
           days-before-stale: 60
@@ -23,4 +23,5 @@ jobs:
           # Hack to skip issues, unfortunately there's no option to disable issues
           only-issue-labels: inexistent-label
           only-pr-labels: Waiting on Author
+          close-issue-reason: not_planned
           stale-pr-message: There has not been any recent activity in this PR. It will automatically be closed in 7 days if no further action is taken.


### PR DESCRIPTION
As it is now, FRs and PRs are closed after some time of inactivity as `completed`[1] instead of as `not_planned`.  We change that, what requires us to update to actions/stale@v5.

[1] <https://github.com/php/php-src/issues/8784#event-7529358762>