### PR TITLE
Fix GH-9589: dl() segfaults when module is already loaded

### DIFF
--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -205,6 +205,10 @@ PHPAPI int php_load_extension(const char *filename, int type, int start_now)
 		return FAILURE;
 	}
 	module_entry = get_module();
+	if (zend_hash_str_exists(&module_registry, module_entry->name, strlen(module_entry->name))) {
+		zend_error(E_CORE_WARNING, "Module \"%s\" is already loaded", module_entry->name);
+		return FAILURE;
+	}
 	if (module_entry->zend_api != ZEND_MODULE_API_NO) {
 			php_error_docref(NULL, error_type,
 					"%s: Unable to initialize module\n"

--- a/ext/standard/dl.c
+++ b/ext/standard/dl.c
@@ -206,6 +206,7 @@ PHPAPI int php_load_extension(const char *filename, int type, int start_now)
 	}
 	module_entry = get_module();
 	if (zend_hash_str_exists(&module_registry, module_entry->name, strlen(module_entry->name))) {
+		DL_UNLOAD(handle);
 		zend_error(E_CORE_WARNING, "Module \"%s\" is already loaded", module_entry->name);
 		return FAILURE;
 	}

--- a/ext/standard/tests/general_functions/gh9589.phpt
+++ b/ext/standard/tests/general_functions/gh9589.phpt
@@ -1,0 +1,10 @@
+--TEST--
+dl() segfaults when module is already loaded
+--EXTENSIONS--
+dl_test
+--FILE--
+<?php
+dl("dl_test");
+?>
+--EXPECT--
+Warning: Module "dl_test" is already loaded in Unknown on line 0


### PR DESCRIPTION
As of PHP 8.2.0, `zend_module_entry` structures are no longer copied, so when a module is permanently loaded, and users try to dynamically load that module again, the structure is corrupted[1], causing a segfault on shutdown.

We catch that by checking whether any dynamically loaded module is already loaded, and bailing out in that case without modifying the `zend_module_entry` structure.

[1] <https://github.com/php/php-src/issues/9589#issuecomment-1263718701>