### PR TITLE
Fix json_validate double free in parser when discarding lookahead

### DIFF
--- a/ext/json/json_parser.y
+++ b/ext/json/json_parser.y
@@ -280,13 +280,16 @@ static int php_json_parser_object_update_validate(php_json_parser *parser, zval 
 static int php_json_yylex(union YYSTYPE *value, php_json_parser *parser)
 {
 	int token = php_json_scan(&parser->scanner);
-	value->value = parser->scanner.value;
 
-	if (parser->methods.array_create == php_json_parser_array_create_validate
+	bool validate = parser->methods.array_create == php_json_parser_array_create_validate
 		&& parser->methods.array_append == php_json_parser_array_append_validate
 		&& parser->methods.object_create == php_json_parser_object_create_validate
-		&& parser->methods.object_update == php_json_parser_object_update_validate) {
+		&& parser->methods.object_update == php_json_parser_object_update_validate;
+
+	if (validate) {
 		zval_ptr_dtor_str(&(parser->scanner.value));
+	} else {
+		value->value = parser->scanner.value;
 	}
 
 	return token;

--- a/ext/json/json_parser.y
+++ b/ext/json/json_parser.y
@@ -288,6 +288,7 @@ static int php_json_yylex(union YYSTYPE *value, php_json_parser *parser)
 
 	if (validate) {
 		zval_ptr_dtor_str(&(parser->scanner.value));
+		ZVAL_UNDEF(&value->value);
 	} else {
 		value->value = parser->scanner.value;
 	}


### PR DESCRIPTION
/cc @juan-morales 