### PR TITLE
Deprecate SplFixedArray::__wakeup()

### DIFF
--- a/ext/spl/spl_fixedarray.stub.php
+++ b/ext/spl/spl_fixedarray.stub.php
@@ -6,7 +6,10 @@ class SplFixedArray implements IteratorAggregate, ArrayAccess, Countable, JsonSe
 {
     public function __construct(int $size = 0) {}
 
-    /** @tentative-return-type */
+    /**
+     * @tentative-return-type
+     * @deprecated
+     */
     public function __wakeup(): void {}
 
     public function __serialize(): array {}

--- a/ext/spl/spl_fixedarray_arginfo.h
+++ b/ext/spl/spl_fixedarray_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0b508ad6499b70c92bf25960b30fefa913532a3c */
+ * Stub hash: f39c0c49d0c2c6e51efc9b344ad1205a8f9a4a7d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SplFixedArray___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size, IS_LONG, 0, "0")
@@ -74,7 +74,7 @@ ZEND_METHOD(SplFixedArray, jsonSerialize);
 
 static const zend_function_entry class_SplFixedArray_methods[] = {
 	ZEND_ME(SplFixedArray, __construct, arginfo_class_SplFixedArray___construct, ZEND_ACC_PUBLIC)
-	ZEND_ME(SplFixedArray, __wakeup, arginfo_class_SplFixedArray___wakeup, ZEND_ACC_PUBLIC)
+	ZEND_ME(SplFixedArray, __wakeup, arginfo_class_SplFixedArray___wakeup, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 	ZEND_ME(SplFixedArray, __serialize, arginfo_class_SplFixedArray___serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFixedArray, __unserialize, arginfo_class_SplFixedArray___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(SplFixedArray, count, arginfo_class_SplFixedArray_count, ZEND_ACC_PUBLIC)


### PR DESCRIPTION
GH-9354 added the `__serialize` and `__unserialize` method, so unserialize() and other unserializers will call `__unserialize` instead of `__wakeup` for SplFixedArray and userland subclasses.

This targets php 8.3 because we've already released betas and release candidates for php 8.2.

This was brought up in review comments for php 8.2: https://github.com/php/php-src/pull/9354#discussion_r956615281