### PR TITLE
Avoid creating indirect pointer in SplFixedArray __wakeup in 8.1+

### DIFF
--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -608,7 +608,7 @@ PHP_METHOD(SplFixedArray, __wakeup)
 
 		spl_fixedarray_init(&intern->array, size);
 
-		ZEND_HASH_FOREACH_VAL(intern_ht, data) {
+		ZEND_HASH_FOREACH_VAL_IND(intern_ht, data) {
 			ZVAL_COPY(&intern->array.elements[index], data);
 			index++;
 		} ZEND_HASH_FOREACH_END();

--- a/ext/spl/tests/fixedarray_025.phpt
+++ b/ext/spl/tests/fixedarray_025.phpt
@@ -1,0 +1,35 @@
+--TEST--
+SPL: FixedArray: __wakeup
+--FILE--
+<?php
+#[AllowDynamicProperties]
+class MyFixedArray extends SplFixedArray {
+    public stdClass $x;
+    public $y;
+}
+$a = new MyFixedArray();
+$a->x = new stdClass();
+$y = new ArrayObject();
+$a->y = &$y;
+$a->z = new stdClass();
+$x = &$a->x;
+// NOTE: Creating references from dynamic properties in the backing C array
+// is a bug that will be fixed in newer php minor versions.
+$a->__wakeup();
+var_dump($a);
+?>
+--EXPECTF--
+object(MyFixedArray)#%d (3) {
+  [0]=>
+  &object(stdClass)#%d (0) {
+  }
+  [1]=>
+  &object(ArrayObject)#%d (1) {
+    ["storage":"ArrayObject":private]=>
+    array(0) {
+    }
+  }
+  [2]=>
+  object(stdClass)#%d (0) {
+  }
+}

--- a/ext/spl/tests/fixedarray_026.phpt
+++ b/ext/spl/tests/fixedarray_026.phpt
@@ -1,0 +1,52 @@
+--TEST--
+SPL: FixedArray: __wakeup
+--FILE--
+<?php
+#[AllowDynamicProperties]
+class MyFixedArray extends SplFixedArray {
+    public stdClass $x;
+    public $y;
+}
+$a = new MyFixedArray();
+$a->x = new stdClass();
+$y = new ArrayObject();
+$a->y = &$a->x;
+$a->z = &$a->x;
+
+$ser = serialize($a);
+// NOTE: Creating references from dynamic properties in the backing C array
+// is a bug that will be fixed in newer php minor versions.
+$obj = unserialize($ser);
+var_dump($obj);
+var_dump($obj->toArray());
+var_dump(count($obj));
+var_dump($obj->x ?? null);
+var_dump($obj->z ?? null);
+?>
+--EXPECTF--
+object(MyFixedArray)#%d (3) {
+  [0]=>
+  &object(stdClass)#%d (0) {
+  }
+  [1]=>
+  &object(stdClass)#%d (0) {
+  }
+  [2]=>
+  &object(stdClass)#%d (0) {
+  }
+}
+array(3) {
+  [0]=>
+  &object(stdClass)#%d (0) {
+  }
+  [1]=>
+  &object(stdClass)#%d (0) {
+  }
+  [2]=>
+  &object(stdClass)#%d (0) {
+  }
+}
+int(3)
+object(stdClass)#%d (0) {
+}
+NULL


### PR DESCRIPTION
A typed property of an object properties table is an indirect pointer (IS_IND) to a typed reference (IS_REF).
With https://wiki.php.net/rfc/restrict_globals_usage, php 8.1 arrays are meant to stop containing IS_IND pointers,
and php-src removed code to check for IS_IND pointers.

`unserialize()` would also be affected.

A more aggressive bug fix would be to also stop allowing references in unserialize entirely, though there's a tiny chance application behavior would depend on these references, so that fix wasn't backported.