### PR TITLE
Use zval_ptr_dtor() instead of i_zval_ptr_dtor()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -17,6 +17,8 @@ PHP 8.3 INTERNALS UPGRADE NOTES
 * zend_class_entry now possesses a default_object_handlers field, which
   provides a default object handler when create_object() is not overriding it.
 
+* The i_zval_ptr_dtor() function has been removed, use zval_ptr_dtor() instead.
+
 ========================
 2. Build system changes
 ========================

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4010,7 +4010,7 @@ ZEND_API void zend_fcall_info_args_clear(zend_fcall_info *fci, bool free_mem) /*
 		zval *end = p + fci->param_count;
 
 		while (p != end) {
-			i_zval_ptr_dtor(p);
+			zval_ptr_dtor(p);
 			p++;
 		}
 		if (free_mem) {

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3780,7 +3780,7 @@ static zend_always_inline void i_free_compiled_variables(zend_execute_data *exec
 	zval *cv = EX_VAR_NUM(0);
 	int count = EX(func)->op_array.last_var;
 	while (EXPECTED(count != 0)) {
-		i_zval_ptr_dtor(cv);
+		zval_ptr_dtor(cv);
 		cv++;
 		count--;
 	}

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -273,7 +273,7 @@ static zend_always_inline void zend_vm_stack_free_extra_args_ex(uint32_t call_in
 		uint32_t count = ZEND_CALL_NUM_ARGS(call) - call->func->op_array.num_args;
 		zval *p = ZEND_CALL_VAR_NUM(call, call->func->op_array.last_var + call->func->op_array.T);
 		do {
-			i_zval_ptr_dtor(p);
+			zval_ptr_dtor(p);
 			p++;
 		} while (--count);
  	}

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -220,7 +220,7 @@ static void zend_unclean_zval_ptr_dtor(zval *zv) /* {{{ */
 	if (Z_TYPE_P(zv) == IS_INDIRECT) {
 		zv = Z_INDIRECT_P(zv);
 	}
-	i_zval_ptr_dtor(zv);
+	zval_ptr_dtor(zv);
 }
 /* }}} */
 
@@ -339,7 +339,7 @@ ZEND_API void zend_shutdown_executor_values(bool fast_shutdown)
 					zval *end = p + ce->default_properties_count;
 
 					while (p != end) {
-						i_zval_ptr_dtor(p);
+						zval_ptr_dtor(p);
 						ZVAL_UNDEF(p);
 						p++;
 					}

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -1749,7 +1749,7 @@ ZEND_API void ZEND_FASTCALL zend_array_destroy(HashTable *ht)
 			zval *end = zv + ht->nNumUsed;
 
 			do {
-				i_zval_ptr_dtor(zv);
+				zval_ptr_dtor(zv);
 			} while (++zv != end);
 		} else {
 			Bucket *p = ht->arData;
@@ -1757,11 +1757,11 @@ ZEND_API void ZEND_FASTCALL zend_array_destroy(HashTable *ht)
 
 			if (HT_HAS_STATIC_KEYS_ONLY(ht)) {
 				do {
-					i_zval_ptr_dtor(&p->val);
+					zval_ptr_dtor(&p->val);
 				} while (++p != end);
 			} else if (HT_IS_WITHOUT_HOLES(ht)) {
 				do {
-					i_zval_ptr_dtor(&p->val);
+					zval_ptr_dtor(&p->val);
 					if (EXPECTED(p->key)) {
 						zend_string_release_ex(p->key, 0);
 					}
@@ -1769,7 +1769,7 @@ ZEND_API void ZEND_FASTCALL zend_array_destroy(HashTable *ht)
 			} else {
 				do {
 					if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF)) {
-						i_zval_ptr_dtor(&p->val);
+						zval_ptr_dtor(&p->val);
 						if (EXPECTED(p->key)) {
 							zend_string_release_ex(p->key, 0);
 						}
@@ -1877,11 +1877,11 @@ ZEND_API void ZEND_FASTCALL zend_symtable_clean(HashTable *ht)
 		end = p + ht->nNumUsed;
 		if (HT_HAS_STATIC_KEYS_ONLY(ht)) {
 			do {
-				i_zval_ptr_dtor(&p->val);
+				zval_ptr_dtor(&p->val);
 			} while (++p != end);
 		} else if (HT_IS_WITHOUT_HOLES(ht)) {
 			do {
-				i_zval_ptr_dtor(&p->val);
+				zval_ptr_dtor(&p->val);
 				if (EXPECTED(p->key)) {
 					zend_string_release(p->key);
 				}
@@ -1889,7 +1889,7 @@ ZEND_API void ZEND_FASTCALL zend_symtable_clean(HashTable *ht)
 		} else {
 			do {
 				if (EXPECTED(Z_TYPE(p->val) != IS_UNDEF)) {
-					i_zval_ptr_dtor(&p->val);
+					zval_ptr_dtor(&p->val);
 					if (EXPECTED(p->key)) {
 						zend_string_release(p->key);
 					}

--- a/Zend/zend_objects.c
+++ b/Zend/zend_objects.c
@@ -68,7 +68,7 @@ ZEND_API void zend_object_std_dtor(zend_object *object)
 						ZEND_REF_DEL_TYPE_SOURCE(Z_REF_P(p), prop_info);
 					}
 				}
-				i_zval_ptr_dtor(p);
+				zval_ptr_dtor(p);
 			}
 			p++;
 		} while (p != end);
@@ -198,7 +198,7 @@ ZEND_API void ZEND_FASTCALL zend_objects_clone_members(zend_object *new_object, 
 		zval *end = src + old_object->ce->default_properties_count;
 
 		do {
-			i_zval_ptr_dtor(dst);
+			zval_ptr_dtor(dst);
 			ZVAL_COPY_VALUE_PROP(dst, src);
 			zval_add_ref(dst);
 			if (UNEXPECTED(Z_ISREF_P(dst)) &&

--- a/Zend/zend_opcode.c
+++ b/Zend/zend_opcode.c
@@ -188,7 +188,7 @@ ZEND_API void zend_cleanup_internal_class_data(zend_class_entry *ce)
 					}
 				} ZEND_REF_FOREACH_TYPE_SOURCES_END();
 			}
-			i_zval_ptr_dtor(p);
+			zval_ptr_dtor(p);
 			p++;
 		}
 		efree(static_members);
@@ -359,7 +359,7 @@ ZEND_API void destroy_zend_class(zval *zv)
 				zval *end = p + ce->default_properties_count;
 
 				while (p != end) {
-					i_zval_ptr_dtor(p);
+					zval_ptr_dtor(p);
 					p++;
 				}
 				efree(ce->default_properties_table);
@@ -370,7 +370,7 @@ ZEND_API void destroy_zend_class(zval *zv)
 
 				while (p != end) {
 					ZEND_ASSERT(!Z_ISREF_P(p));
-					i_zval_ptr_dtor(p);
+					zval_ptr_dtor(p);
 					p++;
 				}
 				efree(ce->default_static_members_table);

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -1941,14 +1941,14 @@ ZEND_API zend_result ZEND_FASTCALL concat_function(zval *result, zval *op1, zval
 	if (UNEXPECTED(Z_STRLEN_P(op1) == 0)) {
 		if (EXPECTED(result != op2)) {
 			if (result == orig_op1) {
-				i_zval_ptr_dtor(result);
+				zval_ptr_dtor(result);
 			}
 			ZVAL_COPY(result, op2);
 		}
 	} else if (UNEXPECTED(Z_STRLEN_P(op2) == 0)) {
 		if (EXPECTED(result != op1)) {
 			if (result == orig_op1) {
-				i_zval_ptr_dtor(result);
+				zval_ptr_dtor(result);
 			}
 			ZVAL_COPY(result, op1);
 		}
@@ -1975,7 +1975,7 @@ ZEND_API zend_result ZEND_FASTCALL concat_function(zval *result, zval *op1, zval
 			result_str = zend_string_alloc(result_len, 0);
 			memcpy(ZSTR_VAL(result_str), Z_STRVAL_P(op1), op1_len);
 			if (result == orig_op1) {
-				i_zval_ptr_dtor(result);
+				zval_ptr_dtor(result);
 			}
 		}
 

--- a/Zend/zend_variables.c
+++ b/Zend/zend_variables.c
@@ -71,19 +71,13 @@ static void ZEND_FASTCALL zend_string_destroy(zend_string *str)
 static void ZEND_FASTCALL zend_reference_destroy(zend_reference *ref)
 {
 	ZEND_ASSERT(!ZEND_REF_HAS_TYPE_SOURCES(ref));
-	i_zval_ptr_dtor(&ref->val);
+	zval_ptr_dtor(&ref->val);
 	efree_size(ref, sizeof(zend_reference));
 }
 
 static void ZEND_FASTCALL zend_empty_destroy(zend_reference *ref)
 {
 }
-
-ZEND_API void zval_ptr_dtor(zval *zval_ptr) /* {{{ */
-{
-	i_zval_ptr_dtor(zval_ptr);
-}
-/* }}} */
 
 ZEND_API void zval_internal_ptr_dtor(zval *zval_ptr) /* {{{ */
 {

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -36,7 +36,7 @@ static zend_always_inline void zval_ptr_dtor_nogc(zval *zval_ptr)
 	}
 }
 
-static zend_always_inline void i_zval_ptr_dtor(zval *zval_ptr)
+static zend_always_inline void zval_ptr_dtor(zval *zval_ptr)
 {
 	if (Z_REFCOUNTED_P(zval_ptr)) {
 		zend_refcounted *ref = Z_COUNTED_P(zval_ptr);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3959,7 +3959,7 @@ ZEND_VM_HOT_HANDLER(129, ZEND_DO_ICALL, ANY, ANY, SPEC(RETVAL,OBSERVER))
 	}
 
 	if (!RETURN_VALUE_USED(opline)) {
-		i_zval_ptr_dtor(ret);
+		zval_ptr_dtor(ret);
 	}
 
 	if (UNEXPECTED(EG(exception) != NULL)) {
@@ -4082,7 +4082,7 @@ ZEND_VM_C_LABEL(fcall_by_name_end):
 		}
 
 		if (!RETURN_VALUE_USED(opline)) {
-			i_zval_ptr_dtor(ret);
+			zval_ptr_dtor(ret);
 		}
 	}
 
@@ -4187,7 +4187,7 @@ ZEND_VM_C_LABEL(fcall_end):
 		}
 
 		if (!RETURN_VALUE_USED(opline)) {
-			i_zval_ptr_dtor(ret);
+			zval_ptr_dtor(ret);
 		}
 	}
 
@@ -7148,7 +7148,7 @@ ZEND_VM_C_LABEL(fe_fetch_w_exit):
 
 			ref = Z_REF_P(value);
 			GC_ADDREF(ref);
-			i_zval_ptr_dtor(variable_ptr);
+			zval_ptr_dtor(variable_ptr);
 			ZVAL_REF(variable_ptr, ref);
 		}
 	} else {
@@ -7598,7 +7598,7 @@ ZEND_VM_HOT_NOCONST_HANDLER(198, ZEND_JMP_NULL, CONST|TMP|VAR|CV, JMP_ADDR)
 	uint32_t short_circuiting_type = opline->extended_value & ZEND_SHORT_CIRCUITING_CHAIN_MASK;
 	if (EXPECTED(short_circuiting_type == ZEND_SHORT_CIRCUITING_CHAIN_EXPR)) {
 		ZVAL_NULL(result);
-		if (OP1_TYPE == IS_CV 
+		if (OP1_TYPE == IS_CV
 			&& UNEXPECTED(Z_TYPE_P(val) == IS_UNDEF)
 			&& (opline->extended_value & ZEND_JMP_NULL_BP_VAR_IS) == 0
 		) {
@@ -8851,7 +8851,7 @@ ZEND_VM_HANDLER(183, ZEND_BIND_STATIC, CV, UNUSED, REF)
 			}
 		}
 
-		i_zval_ptr_dtor(variable_ptr);
+		zval_ptr_dtor(variable_ptr);
 		if (UNEXPECTED(!Z_ISREF_P(value))) {
 			zend_reference *ref = (zend_reference*)emalloc(sizeof(zend_reference));
 			GC_SET_REFCOUNT(ref, 2);
@@ -8866,7 +8866,7 @@ ZEND_VM_HANDLER(183, ZEND_BIND_STATIC, CV, UNUSED, REF)
 			ZVAL_REF(variable_ptr, Z_REF_P(value));
 		}
 	} else {
-		i_zval_ptr_dtor(variable_ptr);
+		zval_ptr_dtor(variable_ptr);
 		ZVAL_COPY(variable_ptr, value);
 	}
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1276,7 +1276,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_ICALL_SPEC_RETV
 	}
 
 	if (!0) {
-		i_zval_ptr_dtor(ret);
+		zval_ptr_dtor(ret);
 	}
 
 	if (UNEXPECTED(EG(exception) != NULL)) {
@@ -1338,7 +1338,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_ICALL_SPEC_RETV
 	}
 
 	if (!1) {
-		i_zval_ptr_dtor(ret);
+		zval_ptr_dtor(ret);
 	}
 
 	if (UNEXPECTED(EG(exception) != NULL)) {
@@ -1402,7 +1402,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_ICALL_SPEC_OBS
 	}
 
 	if (!RETURN_VALUE_USED(opline)) {
-		i_zval_ptr_dtor(ret);
+		zval_ptr_dtor(ret);
 	}
 
 	if (UNEXPECTED(EG(exception) != NULL)) {
@@ -1570,7 +1570,7 @@ fcall_by_name_end:
 		}
 
 		if (!0) {
-			i_zval_ptr_dtor(ret);
+			zval_ptr_dtor(ret);
 		}
 	}
 
@@ -1665,7 +1665,7 @@ fcall_by_name_end:
 		}
 
 		if (!1) {
-			i_zval_ptr_dtor(ret);
+			zval_ptr_dtor(ret);
 		}
 	}
 
@@ -1763,7 +1763,7 @@ fcall_by_name_end:
 		}
 
 		if (!RETURN_VALUE_USED(opline)) {
-			i_zval_ptr_dtor(ret);
+			zval_ptr_dtor(ret);
 		}
 	}
 
@@ -1866,7 +1866,7 @@ fcall_end:
 		}
 
 		if (!0) {
-			i_zval_ptr_dtor(ret);
+			zval_ptr_dtor(ret);
 		}
 	}
 
@@ -1975,7 +1975,7 @@ fcall_end:
 		}
 
 		if (!1) {
-			i_zval_ptr_dtor(ret);
+			zval_ptr_dtor(ret);
 		}
 	}
 
@@ -2086,7 +2086,7 @@ fcall_end:
 		}
 
 		if (!RETURN_VALUE_USED(opline)) {
-			i_zval_ptr_dtor(ret);
+			zval_ptr_dtor(ret);
 		}
 	}
 
@@ -22268,7 +22268,7 @@ fe_fetch_w_exit:
 
 			ref = Z_REF_P(value);
 			GC_ADDREF(ref);
-			i_zval_ptr_dtor(variable_ptr);
+			zval_ptr_dtor(variable_ptr);
 			ZVAL_REF(variable_ptr, ref);
 		}
 	} else {
@@ -48638,7 +48638,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BIND_STATIC_SPEC_CV_UNUSED_HAN
 			}
 		}
 
-		i_zval_ptr_dtor(variable_ptr);
+		zval_ptr_dtor(variable_ptr);
 		if (UNEXPECTED(!Z_ISREF_P(value))) {
 			zend_reference *ref = (zend_reference*)emalloc(sizeof(zend_reference));
 			GC_SET_REFCOUNT(ref, 2);
@@ -48653,7 +48653,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_BIND_STATIC_SPEC_CV_UNUSED_HAN
 			ZVAL_REF(variable_ptr, Z_REF_P(value));
 		}
 	} else {
-		i_zval_ptr_dtor(variable_ptr);
+		zval_ptr_dtor(variable_ptr);
 		ZVAL_COPY(variable_ptr, value);
 	}
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -6155,7 +6155,7 @@ PHP_FUNCTION(array_map)
 
 			ZVAL_COPY(&arg, zv);
 			ret = zend_call_function(&fci, &fci_cache);
-			i_zval_ptr_dtor(&arg);
+			zval_ptr_dtor(&arg);
 			if (ret != SUCCESS || Z_TYPE(result) == IS_UNDEF) {
 				zend_array_destroy(Z_ARR_P(return_value));
 				RETURN_NULL();

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -305,7 +305,7 @@ PHPAPI void var_destroy(php_unserialize_data_t *var_hashx)
 				}
 			}
 
-			i_zval_ptr_dtor(zv);
+			zval_ptr_dtor(zv);
 		}
 		next = var_dtor_hash->next;
 		efree_size(var_dtor_hash, sizeof(var_dtor_entries));


### PR DESCRIPTION
And remove i_zval_ptr_dtor() as it is identical to zval_ptr_dtor() since PHP 7.

Am I missing something as to why this was not removed previously?