### PR TITLE
Fix potential heap corruption due to alignment mismatch

### DIFF
--- a/ext/mysqlnd/mysqlnd_alloc.c
+++ b/ext/mysqlnd/mysqlnd_alloc.c
@@ -346,7 +346,7 @@ static char * _mysqlnd_pestrdup(const char * const ptr, bool persistent MYSQLND_
 		smart_str_appendc(&tmp_str, *p);
 	} while (*p++);
 
-	ret = pemalloc_rel(ZSTR_LEN(tmp_str.s) + sizeof(size_t), persistent);
+	ret = pemalloc_rel(REAL_SIZE(ZSTR_LEN(tmp_str.s)), persistent);
 	memcpy(FAKE_PTR(ret), ZSTR_VAL(tmp_str.s), ZSTR_LEN(tmp_str.s));
 
 	if (ret && collect_memory_statistics) {


### PR DESCRIPTION
The fix for bug [63327][1] changed the extra size of mysqlnd allocations from `sizeof(size_t)` to the properly aligned values; however, the allocation in `_mysqlnd_pestrdup()` has apparently been overlooked, which (currently) causes detectable heap corruption when running mysqli_get_client_stats.phpt on 32bit Windows versions.

 [1]: <https://github.com/php/php-src/commit/338a47bb856872f9ab0db94e867333d73279ca85>

---

~~There may be further issues; that should be checked.~~ Apparently, there are no other issues in this regard.
