### PR TITLE
Convert PDO Statement constructor arguments to HashTable*

### DIFF
--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -607,17 +607,17 @@ struct _pdo_stmt_t {
 	union {
 		int column;
 		struct {
-			zval ctor_args;            /* freed */
+			zval retval;
+			HashTable *ctor_args;            /* freed */
 			zend_fcall_info fci;
 			zend_fcall_info_cache fcc;
-			zval retval;
 			zend_class_entry *ce;
 		} cls;
 		struct {
-			zval fetch_args;           /* freed */
+			zval object;
+			HashTable *fetch_args;           /* freed */
 			zend_fcall_info fci;
 			zend_fcall_info_cache fcc;
-			zval object;
 			zval function;
 			zval *values;              /* freed */
 		} func;

--- a/ext/pdo/tests/pdo_005.phpt
+++ b/ext/pdo/tests/pdo_005.phpt
@@ -110,9 +110,15 @@ array(3) {
     string(2) "CC"
   }
 }
+
+Warning: TestDerived::__construct(): Argument #1 ($row) must be passed by reference, value given in %s on line %d
 TestDerived::__construct(0,1)
-TestDerived::__construct(1,2)
-TestDerived::__construct(2,3)
+
+Warning: TestDerived::__construct(): Argument #1 ($row) must be passed by reference, value given in %s on line %d
+TestDerived::__construct(0,2)
+
+Warning: TestDerived::__construct(): Argument #1 ($row) must be passed by reference, value given in %s on line %d
+TestDerived::__construct(0,3)
 array(3) {
   [0]=>
   object(TestDerived)#%d (5) {
@@ -136,7 +142,7 @@ array(3) {
     ["val2":"TestBase":private]=>
     NULL
     ["row":protected]=>
-    int(1)
+    int(0)
     ["val2"]=>
     string(2) "BB"
   }
@@ -149,7 +155,7 @@ array(3) {
     ["val2":"TestBase":private]=>
     NULL
     ["row":protected]=>
-    int(2)
+    int(0)
     ["val2"]=>
     string(2) "CC"
   }


### PR DESCRIPTION
Stepping stone for using named_params in the FCI directly.

Split out of #9723 because it a rather consequential change.

One thing I'm not sure about, is that currently PDO can currently pass arguments by-reference to te constructor when the fetch mode is ``FETCH_CLASS``. I'm not sure if this sensible at all, but in any case this PR would break this.

Is this breaking change sensible in theory, or does it really make sense for PDO to pass args by ref to the constructor? 