### PR TITLE
QA - filter_input - LCOV - FILTER_NULL_ON_FAILURE

### DIFF
--- a/ext/filter/tests/012.phpt
+++ b/ext/filter/tests/012.phpt
@@ -9,10 +9,17 @@ var_dump(filter_input(INPUT_GET, "test"));
 var_dump(filter_input(INPUT_POST, "test"));
 var_dump(filter_input(INPUT_COOKIE, ""));
 
+var_dump(filter_input(INPUT_GET, "test", FILTER_DEFAULT, FILTER_NULL_ON_FAILURE));
+var_dump(filter_input(INPUT_POST, "test", FILTER_DEFAULT, FILTER_NULL_ON_FAILURE));
+var_dump(filter_input(INPUT_COOKIE, "", FILTER_DEFAULT, FILTER_NULL_ON_FAILURE));
+
 echo "Done\n";
 ?>
 --EXPECT--
 NULL
 NULL
 NULL
+bool(false)
+bool(false)
+bool(false)
 Done


### PR DESCRIPTION
### QA - Code coverage
Adding code coverage to the **filter_input** function when option **FILTER_NULL_ON_FAILURE** is provided

#### Before 
![qa-filter-input-null-on-failure-PRE](https://user-images.githubusercontent.com/25756860/195455658-ff3b4e65-bdae-4bc4-b5bd-e1f48215a9cb.png)

#### After
![qa-filter-input-null-on-failure-AFTER](https://user-images.githubusercontent.com/25756860/195455678-17692657-cfb0-4d28-8d99-59229bf3e20f.png)
