### PR TITLE
support using SIGALARM instead of SIGPROF for Go compatibility

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1463,7 +1463,7 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 			t_r.it_value.tv_sec = seconds;
 			t_r.it_value.tv_usec = t_r.it_interval.tv_sec = t_r.it_interval.tv_usec = 0;
 
-# if defined(__CYGWIN__) || defined(__PASE__)
+# if defined(__CYGWIN__) || defined(__PASE__) || defined(NO_SIGPROF)
 			setitimer(ITIMER_REAL, &t_r, NULL);
 		}
 		signo = SIGALRM;

--- a/Zend/zend_signal.c
+++ b/Zend/zend_signal.c
@@ -64,7 +64,7 @@ ZEND_API zend_signal_globals_t zend_signal_globals;
 static void zend_signal_handler(int signo, siginfo_t *siginfo, void *context);
 static int zend_signal_register(int signo, void (*handler)(int, siginfo_t*, void*));
 
-#if defined(__CYGWIN__) || defined(__PASE__)
+#if defined(__CYGWIN__) || defined(__PASE__) || defined(NO_SIGPROF)
 /* Matches zend_execute_API.c; these platforms don't support ITIMER_PROF. */
 #define TIMEOUT_SIG SIGALRM
 #else


### PR DESCRIPTION
Go uses `SIGPROF` [for internal purposes](https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG) and can send this signal to the C code. PHP also uses it for the timeout system. This causes issues when embedding PHP in Go programs.

 For some platforms, when `SIGPROF` isn't available, PHP already uses `SIGALARM` instead. This patch adds a new compilation flag to force using `SIGALARM`. This fixes issues with Go.

Related: #9597, #9672.