### PR TITLE
Fix GH-9720: Null pointer dereference while serializing the response

### DIFF
--- a/ext/soap/soap.c
+++ b/ext/soap/soap.c
@@ -3481,11 +3481,11 @@ static int serialize_response_call2(xmlNodePtr body, sdlFunctionPtr function, ch
 		zend_ulong param_index = i;
 
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(ret), param_index, param_name, data) {
-			parameter = get_param(function, ZSTR_VAL(param_name), param_index, TRUE);
+			parameter = get_param(function, param_name ? ZSTR_VAL(param_name) : NULL, param_index, TRUE);
 			if (style == SOAP_RPC) {
-				param = serialize_parameter(parameter, data, i, ZSTR_VAL(param_name), use, method);
+				param = serialize_parameter(parameter, data, i, param_name ? ZSTR_VAL(param_name) : NULL, use, method);
 			} else {
-				param = serialize_parameter(parameter, data, i, ZSTR_VAL(param_name), use, body);
+				param = serialize_parameter(parameter, data, i, param_name ? ZSTR_VAL(param_name) : NULL, use, body);
 				if (function && function->binding->bindingType == BINDING_SOAP) {
 					if (parameter && parameter->element) {
 						ns = encode_add_ns(param, parameter->element->namens);

--- a/ext/soap/tests/gh9720.phpt
+++ b/ext/soap/tests/gh9720.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Bug GH-9720 (Null pointer dereference while serializing the response)
+--SKIPIF--
+<?php require_once("skipif.inc"); ?>
+--FILE--
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+ini_set("soap.wsdl_cache_enabled", 0);
+
+class SoapService {
+    function openSession($user) {
+        return ["OK", "200"];
+    }
+}
+
+$server = new SoapServer(__DIR__ . '/gh9720.wsdl');
+$server->setClass(SoapService::class);
+$request = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:soapService" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+    <SOAP-ENV:Body>
+        <ns1:openSession>
+            <user xsi:type="xsd:string">istoph</user>
+        </ns1:openSession>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+XML;
+
+$server->handle($request);
+?>
+--EXPECT--
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="urn:soapService" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><SOAP-ENV:Body><ns1:openSessionResponse><status xsi:type="xsd:string">OK</status><error_code xsi:type="xsd:string">200</error_code></ns1:openSessionResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/ext/soap/tests/gh9720.wsdl
+++ b/ext/soap/tests/gh9720.wsdl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<definitions name="soapService" targetNamespace="urn:soapService" xmlns:typens="urn:soapService" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/">
+  <message name="openSession">
+    <part name="user" type="xsd:string" />
+  </message>
+  <message name="openSessionResponse">
+    <part name="status" type="xsd:string" />
+    <part name="error_code" type="xsd:string" />
+  </message>
+  <portType name="soapServicePortType">
+    <operation name="openSession">
+      <documentation>Service Call: openSession</documentation>
+      <input message="typens:openSession" />
+      <output message="typens:openSessionResponse" />
+    </operation>
+  </portType>
+  <binding name="soapServiceBinding" type="typens:soapServicePortType">
+    <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http" />
+    <operation name="openSession">
+      <soap:operation soapAction="urn:openSession" />
+      <input>
+        <soap:body namespace="urn:soapService" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+      </input>
+      <output>
+        <soap:body namespace="urn:soapService" use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" />
+      </output>
+    </operation>
+  </binding>
+  <service name="soapServiceService">
+    <port name="soapServicePort" binding="typens:soapServiceBinding">
+      <soap:address location="###PHP_SELF###" />
+    </port>
+  </service>
+</definitions>


### PR DESCRIPTION
When traversing the result array, we need to cater to `param_name` possibly being `NULL`.  Prior to PHP 7.0.0, this was implicitly done because `param_name` was of type `char*`.