### PR TITLE
Add `intadd` function

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -3003,6 +3003,9 @@ function is_nan(float $num): bool {}
 function intdiv(int $num1, int $num2): int {}
 
 /** @compile-time-eval */
+function intadd(int $num1, int $num2): int {}
+
+/** @compile-time-eval */
 function is_infinite(float $num): bool {}
 
 /** @compile-time-eval */

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 39d455982dfdea9d0b9b646bc207b05f7108d1b2 */
+ * Stub hash: e8852fec678c5ce2a0c9bbba38c47c2c976da9cf */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1669,6 +1669,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_intdiv, 0, 2, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, num2, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_intadd arginfo_intdiv
+
 #define arginfo_is_infinite arginfo_is_finite
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pow, 0, 2, MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_OBJECT)
@@ -2662,6 +2664,7 @@ ZEND_FUNCTION(pi);
 ZEND_FUNCTION(is_finite);
 ZEND_FUNCTION(is_nan);
 ZEND_FUNCTION(intdiv);
+ZEND_FUNCTION(intadd);
 ZEND_FUNCTION(is_infinite);
 ZEND_FUNCTION(pow);
 ZEND_FUNCTION(exp);
@@ -3300,6 +3303,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE(is_finite, arginfo_is_finite)
 	ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE(is_nan, arginfo_is_nan)
 	ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE(intdiv, arginfo_intdiv)
+	ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE(intadd, arginfo_intadd)
 	ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE(is_infinite, arginfo_is_infinite)
 	ZEND_SUPPORTS_COMPILE_TIME_EVAL_FE(pow, arginfo_pow)
 	ZEND_FE(exp, arginfo_exp)

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1215,3 +1215,17 @@ PHP_FUNCTION(intdiv)
 	RETURN_LONG(dividend / divisor);
 }
 /* }}} */
+
+/* {{{ Returns sum of integers, allowing overflow */
+PHP_FUNCTION(intadd)
+{
+	zend_long addend1, addend2;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(addend1)
+		Z_PARAM_LONG(addend2)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_LONG(addend1 + addend2);
+}
+/* }}} */

--- a/ext/standard/tests/math/intadd.phpt
+++ b/ext/standard/tests/math/intadd.phpt
@@ -1,0 +1,14 @@
+--TEST--
+intadd functionality
+--FILE--
+<?php
+var_dump(intadd(41, 1)           === 42);
+var_dump(intadd(-1, 1)           === 0);
+var_dump(intadd(PHP_INT_MAX,  1) === PHP_INT_MIN);
+var_dump(intadd(PHP_INT_MIN, -1) === PHP_INT_MAX);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Useful for when integer overflow is desired instead of becoming a float.

Synopsis:
```
php > var_dump(PHP_INT_MAX + 1);
float(9.223372036854776E+18)
php > var_dump(intadd(PHP_INT_MAX, 1));
int(-9223372036854775808)
```

Can write an RFC if desired.

(Requesting `hacktoberfest-accepted` label for Hacktoberfest cred.)
