### PR TITLE
Properly handle shmget() ENOMEM error conditions on Windows

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -656,8 +656,12 @@ TSRM_API int shmget(key_t key, size_t size, int flags)
 	}
 	shm->segment = shm_handle;
 	shm->descriptor = MapViewOfFileEx(shm->segment, FILE_MAP_ALL_ACCESS, 0, 0, 0, NULL);
+	if (shm->descriptor == NULL) {
+		SET_ERRNO_FROM_WIN32_CODE(GetLastError());
+		return -1;
+	}
 
-	if (NULL != shm->descriptor && created) {
+	if (created) {
 		shm->descriptor->shm_perm.key	= key;
 		shm->descriptor->shm_segsz		= size;
 		shm->descriptor->shm_ctime		= time(NULL);
@@ -671,7 +675,7 @@ TSRM_API int shmget(key_t key, size_t size, int flags)
 		shm->descriptor->shm_perm.mode	= shm->descriptor->shm_perm.seq	= 0;
 	}
 
-	if (NULL != shm->descriptor && (shm->descriptor->shm_perm.key != key || size > shm->descriptor->shm_segsz)) {
+	if (shm->descriptor->shm_perm.key != key || size > shm->descriptor->shm_segsz) {
 		if (NULL != shm->segment) {
 			CloseHandle(shm->segment);
 		}


### PR DESCRIPTION
We need to properly handle `MapViewOfFileEx()` failures; otherwise strange error messages might be reported in the following.  E.g. bug72858.phpt is likely to fail on 32bit Windows with "Warning: shm_attach(): Failed for key 0x64: File exists".

---

Note that this issue also affects older PHP versions, but the chance of `MapViewOfFileEx()` failing is very small there, because we only tried to map an info segment there, instead of trying to map the whole segment now, due to #8648.