### PR TITLE
Restore extra_named_params when restoring frozen call stack

### DIFF
--- a/Zend/tests/generators/gh9752.phpt
+++ b/Zend/tests/generators/gh9752.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Bug GH-9752 (Generator crashes when interrupted during a function call with extra named params)
+--FILE--
+<?php
+
+function f(...$x) {
+}
+
+function g() {
+    f(a: 1, b: yield);
+};
+
+$gen = g();
+
+foreach ($gen as $value) {
+    break;
+}
+
+?>
+==DONE==
+--EXPECT--
+==DONE==

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -44,6 +44,7 @@ ZEND_API void zend_generator_restore_call_stack(zend_generator *generator) /* {{
 			ZEND_CALL_NUM_ARGS(call),
 			Z_PTR(call->This));
 		memcpy(((zval*)new_call) + ZEND_CALL_FRAME_SLOT, ((zval*)call) + ZEND_CALL_FRAME_SLOT, ZEND_CALL_NUM_ARGS(call) * sizeof(zval));
+		new_call->extra_named_params = call->extra_named_params;
 		new_call->prev_execute_data = prev_call;
 		prev_call = new_call;
 


### PR DESCRIPTION
Fixes #9752