### PR TITLE
opcache: add FrankenPHP to the allow list

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2824,6 +2824,7 @@ static inline int accel_find_sapi(void)
 		"litespeed",
 		"uwsgi",
 		"fuzzer",
+		"frankenphp",
 		NULL
 	};
 	const char **sapi_name;
@@ -3156,7 +3157,7 @@ static int accel_startup(zend_extension *extension)
 		    strcmp(sapi_module.name, "cli") == 0) {
 			zps_startup_failure("Opcode Caching is disabled for CLI", NULL, accelerator_remove_cb);
 		} else {
-			zps_startup_failure("Opcode Caching is only supported in Apache, FPM, FastCGI and LiteSpeed SAPIs", NULL, accelerator_remove_cb);
+			zps_startup_failure("Opcode Caching is only supported in Apache, FPM, FastCGI, FrankenPHP, LiteSpeed and uWSGI SAPIs", NULL, accelerator_remove_cb);
 		}
 		return SUCCESS;
 	}


### PR DESCRIPTION
Add [FrankenPHP](https://frankenphp.dev) to the list of SAPIs supported by the opcache extension.