### PR TITLE
Set SA_ONSTACK too when zend signals are disabled and in pcntl

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1483,7 +1483,7 @@ static void zend_set_timeout_ex(zend_long seconds, bool reset_signals) /* {{{ */
 
 			act.sa_handler = zend_timeout_handler;
 			sigemptyset(&act.sa_mask);
-			act.sa_flags = SA_RESETHAND | SA_NODEFER;
+			act.sa_flags = SA_ONSTACK | SA_RESETHAND | SA_NODEFER;
 			sigaction(signo, &act, NULL);
 #  else
 			signal(signo, zend_timeout_handler);

--- a/ext/pcntl/php_signal.c
+++ b/ext/pcntl/php_signal.c
@@ -35,7 +35,7 @@ Sigfunc *php_signal4(int signo, Sigfunc *func, int restart, int mask_all)
 	} else {
 		sigemptyset(&act.sa_mask);
 	}
-	act.sa_flags = 0;
+	act.sa_flags = SA_ONSTACK;
 #ifdef HAVE_STRUCT_SIGINFO_T
 	act.sa_flags |= SA_SIGINFO;
 #endif


### PR DESCRIPTION
Similar to #9597, but when `--disable-zend-signals` is passed (currently necessary when embedding PHP in Go because of #9649), and for pnctl.