### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
       branches: ${{ steps.set-matrix.outputs.branches }}
       matrix-include: ${{ steps.set-matrix.outputs.matrix-include }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Set fetch-depth to 0 to clone the full repository
           # including all branches. This is required to find
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch.ref }}
       - name: Create MSSQL container
@@ -115,7 +115,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch.ref }}
       - name: brew
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create MSSQL container
         uses: ./.github/actions/setup-mssql
       - name: Create Oracle container
@@ -209,7 +209,7 @@ jobs:
       USE_TRACKED_ALLOC: 1
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch.ref }}
       - name: apt
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch.ref }}
       - name: Create MSSQL container
@@ -375,7 +375,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch.ref }}
       - name: apt

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create MSSQL container
         uses: ./.github/actions/setup-mssql
       - name: Create Oracle container
@@ -65,7 +65,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: brew
         uses: ./.github/actions/brew
       - name: ./configure


### PR DESCRIPTION
The relevant difference is that the v3 uses a newer node.js version. GitHub currently warns when using v2, as the node.js version used is deprecated:

> Node.js 12 actions are deprecated. For more information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout,
> actions/checkout