### PR TITLE
Reset JIT for dynamic functions on opcache restrart

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -5154,6 +5154,11 @@ static void zend_jit_restart_preloaded_op_array(zend_op_array *op_array)
 		}
 #endif
 	}
+	if (op_array->num_dynamic_func_defs) {
+		for (uint32_t i = 0; i < op_array->num_dynamic_func_defs; i++) {
+			zend_jit_restart_preloaded_op_array(op_array->dynamic_func_defs[i]);
+		}
+	}
 }
 
 static void zend_jit_restart_preloaded_script(zend_persistent_script *script)


### PR DESCRIPTION
This is a straightforward cherry-pick of 61e563ca4070de1569ecaa261c88721eba17f4c5 on top of PHP 8.1.12 branch, because it fixes the critical bug #7817 and it should be released as soon possible as part of 8.1.12.