### PR TITLE
Clean up OpenSSL engine list when OpenSSL 1.0.2 used

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -57,6 +57,10 @@
 #include <openssl/pkcs12.h>
 #include <openssl/cms.h>
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L && !defined(OPENSSL_NO_ENGINE)
+#include <openssl/engine.h>
+#endif
+
 /* Common */
 #include <time.h>
 
@@ -1436,6 +1440,11 @@ PHP_MSHUTDOWN_FUNCTION(openssl)
 {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER)
 	EVP_cleanup();
+
+#ifndef OPENSSL_NO_ENGINE
+	/* Free engine list initialized by OPENSSL_config */
+	ENGINE_cleanup();
+#endif
 
 	/* prevent accessing locking callback from unloaded extension */
 	CRYPTO_set_locking_callback(NULL);


### PR DESCRIPTION
This is an attempt to fix GH-8620 . The problem is that OpenSSL adds new engine (rdrand in the reported case) but it doesn't clean up the engines. It means that internally in OpenSSL 1.0.2, the `engine_list_head` is still set even after OpenSSL reference drops to zero and then curl tries to clean it up and it crashes. Interestingly it happens only when shared ldap extension is in the mix which might be related to the fact that it might be somehow releasing the reference too. So the idea of this fix is to clear the engine list before curl tries to clear it so it is empty at that time.

@remicollet Unfortunately I'm unable to test it - tried to compile it but no segfault there - it happens for me only with RPM including your RPM's (both php81 and php82) that I tried on Amazon Linux 2 so I assume it might be also visible on CentOS 7 and even RHEL 7 (if you could check that would be awesome). Please would you be able to test this by packaging RPM with this fix (think it should apply cleanly to 8.1 and 8.2 too but also present on 8.0 which I test it with distro package)?

I was just able to get segfault by installing php81 and php81-php-ldap from your repo and then executing this script:
```php
<?php
$connection = ldap_connect("ldaps://ldap.google.com");
$bind_results = ldap_bind($connection, 'AnyUsername','AnyPassword');
```

If you can't recreate it and you are able to provide the RPM and steps how to test it on Amazon Linux 2, I can potentially try it too.