### PR TITLE
Document zend_enum_get_case_by_value() function

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -57,6 +57,8 @@ PHP 8.2 INTERNALS UPGRADE NOTES
 * The CHECK_NULL_PATH and CHECK_ZVAL_NULL_PATH macros are now wrappers using
   the new inline functions: bool zend_str_has_nul_byte(const zend_string *str)
   and zend_char_has_nul_byte(const char *s, size_t known_length)
+* Added zend_enum_get_case_by_value() function, which provides an internal API
+  similiar to BackedEnum::from() and BackedEnum::tryFrom().
 
 ========================
 2. Build system changes


### PR DESCRIPTION
@iluuu1994: This might have been missed in https://github.com/php/php-src/pull/8518. Looking at the git-blame for `UPGRADING.INTERNALS` it seems like most entries are added along with code changes.
