### PR TITLE
Fix compilation warning

### DIFF
--- a/main/php_network.h
+++ b/main/php_network.h
@@ -207,11 +207,13 @@ PHPAPI void _php_emit_fd_setsize_warning(int max_fd);
 static inline bool _php_check_fd_setsize(php_socket_t *max_fd, int setsize)
 {
 #ifdef PHP_WIN32
+	(void)(max_fd); // Unused
 	if (setsize + 1 >= FD_SETSIZE) {
 		_php_emit_fd_setsize_warning(setsize);
 		return false;
 	}
 #else
+	(void)(setsize); // Unused
 	if (*max_fd >= FD_SETSIZE) {
 		_php_emit_fd_setsize_warning(*max_fd);
 		*max_fd = FD_SETSIZE - 1;


### PR DESCRIPTION
Hi there :wave: :slightly_smiling_face: 
I noticed a new warning while compiling my extension on Linux/Ubuntu with php8.2 branch:
```
/path/php-8.2-debug/include/php/main/php_network.h:214:68: warning: unused parameter ‘setsize’ [-Wunused-parameter]
  214 | static inline bool _php_check_fd_setsize(php_socket_t *max_fd, int setsize)
      |                                                                ~~~~^~~~~~~
```

The function `_php_check_fd_setsize` has been introduced here: https://github.com/php/php-src/pull/9602
Depending of the platform (WIN32), one of the two input parameters is never used.
I didn't find any generic `UNUSED()` macro, then I directly added the code to prevent the warning, but feel free to suggest something better :smile:

Thanks :bow: 

