### PR TITLE
Fix GH-9674: RecursiveDirectoryIterator regression wrt. junctions

### DIFF
--- a/ext/spl/spl_directory.c
+++ b/ext/spl/spl_directory.c
@@ -1480,7 +1480,7 @@ PHP_METHOD(RecursiveDirectoryIterator, hasChildren)
 		php_stat(intern->file_name, FS_LPERMS, return_value);
 		if (Z_TYPE_P(return_value) == IS_FALSE) {
 			return;
-		} else if (!S_ISLNK(Z_LVAL_P(return_value))) {
+		} else if (!S_ISLNK(Z_LVAL_P(return_value)) && Z_LVAL_P(return_value) != 0) {
 			RETURN_BOOL(S_ISDIR(Z_LVAL_P(return_value)));
 		} else {
 			if (!allow_links

--- a/ext/spl/tests/gh9674.phpt
+++ b/ext/spl/tests/gh9674.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug GH-9674 (RecursiveDirectoryIterator regression wrt. junctions)
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY !== "Windows") die("skip test is for Windows only");
+?>
+--FILE--
+<?php
+$dir = __DIR__ . "/gh9674";
+mkdir($dir);
+touch("$dir/a.txt");
+touch("$dir/b.txt");
+mkdir("{$dir}_ext");
+touch("{$dir}_ext/c.txt");
+exec("mklink /j " . str_replace("/", "\\", "$dir/ext") . " " . realpath("{$dir}_ext"));
+
+$directory = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
+$iterator = new RecursiveIteratorIterator($directory);
+foreach ($iterator as $it) {
+    var_dump($it->getFilename());
+}
+?>
+--CLEAN--
+<?php
+$dir = __DIR__ . "/gh9674";
+@unlink("$dir/a.txt");
+@unlink("$dir/b.txt");
+@rmdir("$dir/ext");
+@unlink("{$dir}_ext/c.txt");
+@rmdir("{$dir}_ext");
+@rmdir($dir);
+?>
+--EXPECT--
+string(1) "."
+string(2) ".."
+string(5) "a.txt"
+string(5) "b.txt"
+string(1) "."
+string(2) ".."
+string(5) "c.txt"

--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -844,7 +844,7 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
 			memcpy(&BG(lssb), &ssb, sizeof(php_stream_statbuf));
 		}
 		if (!(flags & PHP_STREAM_URL_STAT_LINK)
-		 || !S_ISLNK(ssb.sb.st_mode)) {
+		 || !S_ISLNK(ssb.sb.st_mode) && ssb.sb.st_mode != 0) {
 			if (BG(CurrentStatFile)) {
 				zend_string_release(BG(CurrentStatFile));
 			}


### PR DESCRIPTION
If we `lstat()` a junction on Windows, it is not `S_ISLNK()`, but we still must not assume that it is not a link (in the broadest sense). In lack of a proper way to detect that, we use the fact that `.st_mode` is zero in this case.