### PR TITLE
Add FrankenPHP to SAPI credits

### DIFF
--- a/EXTENSIONS
+++ b/EXTENSIONS
@@ -63,6 +63,11 @@ PRIMARY MAINTAINER:  Joe Watkins <krakjoe@php.net>, Bob Weinand <bwoebi@php.net>
 MAINTENANCE:         Unknown
 STATUS:              5.6
 -------------------------------------------------------------------------------
+EXTENSION:           frankenPHP
+PRIMARY MAINTAINER:  Kévin Dunglas <kevin@dunglas.fr>
+MAINTENANCE:         Maintained
+STATUS:              8.2
+-------------------------------------------------------------------------------
 
 
 == Database extensions ==

--- a/ext/standard/credits_sapi.h
+++ b/ext/standard/credits_sapi.h
@@ -17,3 +17,4 @@ CREDIT_LINE("Embed", "Edin Kadribasic");
 CREDIT_LINE("FastCGI Process Manager", "Andrei Nigmatulin, dreamcat4, Antony Dovgal, Jerome Loyet");
 CREDIT_LINE("litespeed", "George Wang");
 CREDIT_LINE("phpdbg", "Felipe Pena, Joe Watkins, Bob Weinand");
+CREDIT_LINE("FrankenPHP", "Kévin Dunglas");

--- a/sapi/frankenphp/CREDITS
+++ b/sapi/frankenphp/CREDITS
@@ -1,0 +1,2 @@
+FrankenPHP
+Kévin Dunglas


### PR DESCRIPTION
FrankenPHP was added [here](https://github.com/php/php-src/pull/9755) but is not listed in when running: `php -r 'echo phpinfo();'` in the SAPI credits section.

/cc @dunglas 