### PR TITLE
Fix GH-9389, allow to uninitialize typed property with __get

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -5650,7 +5650,7 @@ ZEND_METHOD(ReflectionProperty, setValue)
 }
 /* }}} */
 
-/* {{{ Returns this property's value */
+/* {{{ Returns true if property was initialized */
 ZEND_METHOD(ReflectionProperty, isInitialized)
 {
 	reflection_object *intern;
@@ -5692,6 +5692,13 @@ ZEND_METHOD(ReflectionProperty, isInitialized)
 
 		RETVAL_BOOL(retval);
 	}
+}
+/* }}} */
+
+/* {{{ Uninitialize this property's value */
+ZEND_METHOD(ReflectionProperty, uninitializeValue)
+{
+	// TODO
 }
 /* }}} */
 

--- a/ext/reflection/php_reflection.stub.php
+++ b/ext/reflection/php_reflection.stub.php
@@ -411,6 +411,9 @@ class ReflectionProperty implements Reflector
     public function isInitialized(?object $object = null): bool {}
 
     /** @tentative-return-type */
+    public function unitializeValue(?object $object = null): void {}
+
+    /** @tentative-return-type */
     public function isPublic(): bool {}
 
     /** @tentative-return-type */

--- a/ext/reflection/tests/ReflectionProperty_uninitializeValue.phpt
+++ b/ext/reflection/tests/ReflectionProperty_uninitializeValue.phpt
@@ -1,0 +1,159 @@
+--TEST--
+Test ReflectionProperty::uninitializeValue()
+--FILE--
+<?php
+
+class A {
+    public static ?string $ssv = null;
+    public static string $ssv2 = 'foo';
+    public static ?string $ss;
+    public static $s;
+
+    public ?int $iv = null;
+    public int $iv2 = 5;
+    public ?int $i;
+    public $n;
+}
+
+class B extends A {
+    public int $ivb = 6;
+
+    public function __get(string $n): void
+    {
+        var_dump('__get: ' . $n);
+    }
+}
+
+function dumpProperty($obj, string $name) {
+    try {
+        var_dump($obj->{$name});
+    } catch (\Error $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+echo "Static properties:\n";
+(new ReflectionProperty(A::class, 'ssv'))->uninitializeValue();
+(new ReflectionProperty(A::class, 'ssv2'))->uninitializeValue();
+(new ReflectionProperty(A::class, 'ss'))->uninitializeValue();
+(new ReflectionProperty(A::class, 's'))->uninitializeValue();
+var_dump((new ReflectionProperty(A::class, 'ssv'))->isInitialized());
+var_dump((new ReflectionProperty(A::class, 'ssv2'))->isInitialized());
+var_dump((new ReflectionProperty(A::class, 'ss'))->isInitialized());
+var_dump((new ReflectionProperty(A::class, 's'))->isInitialized());
+
+(new ReflectionProperty(B::class, 'ssv'))->uninitializeValue();
+(new ReflectionProperty(B::class, 'ssv2'))->uninitializeValue();
+(new ReflectionProperty(B::class, 'ss'))->uninitializeValue();
+(new ReflectionProperty(B::class, 's'))->uninitializeValue();
+var_dump((new ReflectionProperty(B::class, 'ssv'))->isInitialized());
+var_dump((new ReflectionProperty(B::class, 'ssv2'))->isInitialized());
+var_dump((new ReflectionProperty(B::class, 'ss'))->isInitialized());
+var_dump((new ReflectionProperty(B::class, 's'))->isInitialized());
+
+echo "Declared properties:\n";
+$a = new A();
+dumpProperty($a, 'iv');
+dumpProperty($a, 'iv2');
+dumpProperty($a, 'i');
+dumpProperty($a, 'n');
+(new ReflectionProperty($a, 'iv'))->uninitializeValue($a);
+(new ReflectionProperty($a, 'iv2'))->uninitializeValue($a);
+(new ReflectionProperty($a, 'i'))->uninitializeValue($a);
+(new ReflectionProperty($a, 'n'))->uninitializeValue($a);
+var_dump((new ReflectionProperty($a, 'iv'))->isInitialized($a));
+var_dump((new ReflectionProperty($a, 'iv2'))->isInitialized($a));
+var_dump((new ReflectionProperty($a, 'i'))->isInitialized($a));
+var_dump((new ReflectionProperty($a, 'n'))->isInitialized($a));
+dumpProperty($a, 'iv');
+dumpProperty($a, 'iv2');
+dumpProperty($a, 'i');
+dumpProperty($a, 'n');
+
+$b = new B();
+dumpProperty($b, 'iv');
+dumpProperty($b, 'iv2');
+dumpProperty($b, 'i');
+dumpProperty($b, 'n');
+dumpProperty($b, 'ivb');
+(new ReflectionProperty($b, 'iv'))->uninitializeValue($b);
+(new ReflectionProperty($b, 'iv2'))->uninitializeValue($b);
+(new ReflectionProperty($b, 'i'))->uninitializeValue($b);
+(new ReflectionProperty($b, 'n'))->uninitializeValue($b);
+(new ReflectionProperty($b, 'ivb'))->uninitializeValue($b);
+var_dump((new ReflectionProperty($b, 'iv'))->isInitialized($b));
+var_dump((new ReflectionProperty($b, 'iv2'))->isInitialized($b));
+var_dump((new ReflectionProperty($b, 'i'))->isInitialized($b));
+var_dump((new ReflectionProperty($b, 'n'))->isInitialized($b));
+var_dump((new ReflectionProperty($b, 'iv2'))->isInitialized($b));
+dumpProperty($b, 'iv');
+dumpProperty($b, 'iv2');
+dumpProperty($b, 'i');
+dumpProperty($b, 'n');
+dumpProperty($b, 'ivb');
+
+echo "Dynamic properties:\n";
+$a->d = 'da';
+dumpProperty($a, 'd');
+$rp = new ReflectionProperty($a, 'd');
+var_dump($rp->isInitialized($a));
+(new ReflectionProperty($a, 'd'))->uninitializeValue($a);
+var_dump($rp->isInitialized($a));
+dumpProperty($a, 'd');
+
+$b->d = 'db';
+dumpProperty($b, 'd');
+$rp = new ReflectionProperty($b, 'd');
+var_dump($rp->isInitialized($b));
+(new ReflectionProperty($b, 'd'))->uninitializeValue($b);
+var_dump($rp->isInitialized($b));
+dumpProperty($b, 'd');
+
+?>
+--EXPECT--
+Static properties:
+bool(false)
+bool(false)
+bool(false)
+bool(true)
+bool(false)
+bool(false)
+bool(false)
+bool(true)
+Declared properties:
+NULL
+int(5)
+Typed property A::$i must not be accessed before initialization
+NULL
+bool(false)
+bool(false)
+bool(false)
+bool(true)
+Typed property A::$iv must not be accessed before initialization
+Typed property A::$iv2 must not be accessed before initialization
+Typed property A::$i must not be accessed before initialization
+NULL
+NULL
+int(5)
+Typed property A::$i must not be accessed before initialization
+NULL
+int(6)
+bool(false)
+bool(false)
+bool(false)
+bool(true)
+bool(false)
+Typed property A::$iv must not be accessed before initialization
+Typed property A::$iv2 must not be accessed before initialization
+Typed property A::$i must not be accessed before initialization
+NULL
+Typed property B::$ivb must not be accessed before initialization
+Dynamic properties:
+string(2) "da"
+bool(true)
+bool(true)
+NULL
+string(2) "db"
+bool(true)
+bool(true)
+NULL

--- a/ext/reflection/tests/gh9389.phpt
+++ b/ext/reflection/tests/gh9389.phpt
@@ -1,0 +1,59 @@
+--TEST--
+GH-9389: Typed property /w magic __get cannot be uninitialized
+--FILE--
+<?php
+
+class Cl {
+    public string $name;
+    
+    public function __get(string $n): void
+    {
+        var_dump('__get: ' . $n);
+    }
+}
+
+$obj = new Cl();
+
+// read on uninitialized typed property - default
+try {
+    $obj->name;
+} catch (\Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+// read on unset typed property
+unset($obj->name);
+try {
+    $obj->name;
+} catch (\Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+// read of uninitialized typed property - after unset
+(new ReflectionProperty($obj, 'name'))->uninitializeValue($obj);
+try {
+    $obj->name;
+} catch (\Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+// read on set typed property
+$obj->name = 'foo';
+var_dump($obj->name);
+
+// read of uninitialized typed property - after set
+(new ReflectionProperty($obj, 'name'))->uninitializeValue($obj);
+try {
+    $obj->name;
+} catch (\Error $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECT--
+Typed property Cl::$name must not be accessed before initialization
+string(11) "__get: name"
+Cannot assign null to property Cl::$name of type string
+Typed property Cl::$name must not be accessed before initialization
+string(3) "foo"
+Typed property Cl::$name must not be accessed before initialization


### PR DESCRIPTION
fix #9389

Given two facts:
- uninitialized typed property access throws (as per RFC)
- `__get` must be called when property is unset with `unset` (current behaviour, needed for ORMs, ..., discussion https://github.com/php/php-src/issues/9389#issuecomment-1221380864)

`unset()` does currently two things - uninitialize a typed property and removes the property from an object

Currently there is no way to uninitialize a typed property only, to fix it/#9389 a new reflection method has to be introduced to allow the property to be uninitialized (/wo removal from an object as `unset()` does).

Currently reflection allows `isInitialized()` for non-typed properties, so the new `uninitializeValue()` method allows non-typed property as well and sets the value to `null` instead.

Currently reflection allows `setValue()` for unset properties, so the new `uninitializeValue()` method uninitialize the property as if was present - https://3v4l.org/nPRjM.

Implementation - I am looking for a help, I do not know the php internals enough to code it.