### PR TITLE
Allow specifying resource in posix_getrlimit() for single result

### DIFF
--- a/ext/posix/posix.stub.php
+++ b/ext/posix/posix.stub.php
@@ -338,7 +338,7 @@ function posix_getpwuid(int $user_id): array|false {}
  * @return array<string, int|string>|false
  * @refcount 1
  */
-function posix_getrlimit(): array|false {}
+function posix_getrlimit(?int $resource = null): array|false {}
 #endif
 
 #ifdef HAVE_SETRLIMIT

--- a/ext/posix/posix_arginfo.h
+++ b/ext/posix/posix_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 82454cec6f55336a530c23663efeb7ac71932bba */
+ * Stub hash: 2738ee335d62cb797a0e9969e0912019fca71e59 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_posix_kill, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
@@ -133,6 +133,7 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_GETRLIMIT)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_posix_getrlimit, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, resource, IS_LONG, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 

--- a/ext/posix/tests/posix_getrlimit_single_resource.phpt
+++ b/ext/posix/tests/posix_getrlimit_single_resource.phpt
@@ -1,0 +1,28 @@
+--TEST--
+posix_getrlimit() for single resource
+--EXTENSIONS--
+posix
+--SKIPIF--
+<?php
+if (!function_exists('posix_getrlimit')) die('skip posix_getrlimit() not found');
+if (!function_exists('posix_setrlimit') || !posix_setrlimit(POSIX_RLIMIT_CORE, 2048, -1)) {
+    die('skip Failed to set POSIX_RLIMIT_CORE');
+}
+?>
+--FILE--
+<?php
+
+posix_setrlimit(POSIX_RLIMIT_CORE, 2048, -1);
+[$hard, $soft] = posix_getrlimit(POSIX_RLIMIT_CORE);
+var_dump($hard, $soft);
+
+posix_setrlimit(POSIX_RLIMIT_CORE, 1024, 2048);
+[$hard, $soft] = posix_getrlimit(POSIX_RLIMIT_CORE);
+var_dump($hard, $soft);
+
+?>
+--EXPECT--
+int(2048)
+string(9) "unlimited"
+int(1024)
+int(2048)


### PR DESCRIPTION
Fetching all resource limits seems incredibly wasteful, and the API also becomes more awkward (`posix_getrlimit()['soft core']`). This PR allows specifying a resource, returning `[$softLimit, $hardLimit]` that can be destructured.