### PR TITLE
Optimize spread operator for packed arrays (fix GH-9794)

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -6047,23 +6047,45 @@ ZEND_VM_C_LABEL(add_unpack_again):
 	if (EXPECTED(Z_TYPE_P(op1) == IS_ARRAY)) {
 		HashTable *ht = Z_ARRVAL_P(op1);
 		zval *val;
-		zend_string *key;
-
-		ZEND_HASH_FOREACH_STR_KEY_VAL(ht, key, val) {
-			if (Z_ISREF_P(val) && Z_REFCOUNT_P(val) == 1) {
-				val = Z_REFVAL_P(val);
-			}
-			Z_TRY_ADDREF_P(val);
-			if (key) {
-				zend_hash_update(result_ht, key, val);
+		
+		if (HT_IS_PACKED(ht) && 
+			(zend_hash_num_elements(result_ht) == 0 || HT_IS_PACKED(result_ht))) {
+			if (zend_hash_num_elements(result_ht) == 0) {
+				result_ht->nTableSize = zend_hash_num_elements(ht);;
+				zend_hash_real_init_packed(result_ht);
 			} else {
-				if (!zend_hash_next_index_insert(result_ht, val)) {
-					zend_cannot_add_element();
-					zval_ptr_dtor_nogc(val);
-					break;
-				}
+				zend_hash_extend(result_ht, zend_hash_num_elements(result_ht) + zend_hash_num_elements(ht), 1);
 			}
-		} ZEND_HASH_FOREACH_END();
+			ZEND_HASH_FILL_PACKED(result_ht) {
+				ZEND_HASH_PACKED_FOREACH_VAL(ht, val) {
+					if (UNEXPECTED(Z_ISREF_P(val)) &&
+						UNEXPECTED(Z_REFCOUNT_P(val) == 1)) {
+						val = Z_REFVAL_P(val);
+					}
+					Z_TRY_ADDREF_P(val);
+					ZEND_HASH_FILL_ADD(val);
+				} ZEND_HASH_FOREACH_END();
+			} ZEND_HASH_FILL_END();
+		} else {
+			zend_string *key;
+
+			ZEND_HASH_FOREACH_STR_KEY_VAL(ht, key, val) {
+				if (UNEXPECTED(Z_ISREF_P(val)) &&
+					UNEXPECTED(Z_REFCOUNT_P(val) == 1)) {
+					val = Z_REFVAL_P(val);
+				}
+				Z_TRY_ADDREF_P(val);
+				if (key) {
+					zend_hash_update(result_ht, key, val);
+				} else {
+					if (!zend_hash_next_index_insert(result_ht, val)) {
+						zend_cannot_add_element();
+						zval_ptr_dtor_nogc(val);
+						break;
+					}
+				}
+			} ZEND_HASH_FOREACH_END();
+		}
 	} else if (EXPECTED(Z_TYPE_P(op1) == IS_OBJECT)) {
 		zend_class_entry *ce = Z_OBJCE_P(op1);
 		zend_object_iterator *iter;

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -6048,14 +6048,8 @@ ZEND_VM_C_LABEL(add_unpack_again):
 		HashTable *ht = Z_ARRVAL_P(op1);
 		zval *val;
 		
-		if (HT_IS_PACKED(ht) && 
-			(zend_hash_num_elements(result_ht) == 0 || HT_IS_PACKED(result_ht))) {
-			if (zend_hash_num_elements(result_ht) == 0) {
-				result_ht->nTableSize = zend_hash_num_elements(ht);;
-				zend_hash_real_init_packed(result_ht);
-			} else {
-				zend_hash_extend(result_ht, zend_hash_num_elements(result_ht) + zend_hash_num_elements(ht), 1);
-			}
+		if (HT_IS_PACKED(ht) && (zend_hash_num_elements(result_ht) == 0 || HT_IS_PACKED(result_ht))) {
+			zend_hash_extend(result_ht, zend_hash_num_elements(result_ht) + zend_hash_num_elements(ht), 1);
 			ZEND_HASH_FILL_PACKED(result_ht) {
 				ZEND_HASH_PACKED_FOREACH_VAL(ht, val) {
 					if (UNEXPECTED(Z_ISREF_P(val)) &&

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2625,14 +2625,8 @@ add_unpack_again:
 		HashTable *ht = Z_ARRVAL_P(op1);
 		zval *val;
 
-		if (HT_IS_PACKED(ht) &&
-			(zend_hash_num_elements(result_ht) == 0 || HT_IS_PACKED(result_ht))) {
-			if (zend_hash_num_elements(result_ht) == 0) {
-				result_ht->nTableSize = zend_hash_num_elements(ht);;
-				zend_hash_real_init_packed(result_ht);
-			} else {
-				zend_hash_extend(result_ht, zend_hash_num_elements(result_ht) + zend_hash_num_elements(ht), 1);
-			}
+		if (HT_IS_PACKED(ht) && (zend_hash_num_elements(result_ht) == 0 || HT_IS_PACKED(result_ht))) {
+			zend_hash_extend(result_ht, zend_hash_num_elements(result_ht) + zend_hash_num_elements(ht), 1);
 			ZEND_HASH_FILL_PACKED(result_ht) {
 				ZEND_HASH_PACKED_FOREACH_VAL(ht, val) {
 					if (UNEXPECTED(Z_ISREF_P(val)) &&

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2624,23 +2624,45 @@ add_unpack_again:
 	if (EXPECTED(Z_TYPE_P(op1) == IS_ARRAY)) {
 		HashTable *ht = Z_ARRVAL_P(op1);
 		zval *val;
-		zend_string *key;
 
-		ZEND_HASH_FOREACH_STR_KEY_VAL(ht, key, val) {
-			if (Z_ISREF_P(val) && Z_REFCOUNT_P(val) == 1) {
-				val = Z_REFVAL_P(val);
-			}
-			Z_TRY_ADDREF_P(val);
-			if (key) {
-				zend_hash_update(result_ht, key, val);
+		if (HT_IS_PACKED(ht) &&
+			(zend_hash_num_elements(result_ht) == 0 || HT_IS_PACKED(result_ht))) {
+			if (zend_hash_num_elements(result_ht) == 0) {
+				result_ht->nTableSize = zend_hash_num_elements(ht);;
+				zend_hash_real_init_packed(result_ht);
 			} else {
-				if (!zend_hash_next_index_insert(result_ht, val)) {
-					zend_cannot_add_element();
-					zval_ptr_dtor_nogc(val);
-					break;
-				}
+				zend_hash_extend(result_ht, zend_hash_num_elements(result_ht) + zend_hash_num_elements(ht), 1);
 			}
-		} ZEND_HASH_FOREACH_END();
+			ZEND_HASH_FILL_PACKED(result_ht) {
+				ZEND_HASH_PACKED_FOREACH_VAL(ht, val) {
+					if (UNEXPECTED(Z_ISREF_P(val)) &&
+						UNEXPECTED(Z_REFCOUNT_P(val) == 1)) {
+						val = Z_REFVAL_P(val);
+					}
+					Z_TRY_ADDREF_P(val);
+					ZEND_HASH_FILL_ADD(val);
+				} ZEND_HASH_FOREACH_END();
+			} ZEND_HASH_FILL_END();
+		} else {
+			zend_string *key;
+
+			ZEND_HASH_FOREACH_STR_KEY_VAL(ht, key, val) {
+				if (UNEXPECTED(Z_ISREF_P(val)) &&
+					UNEXPECTED(Z_REFCOUNT_P(val) == 1)) {
+					val = Z_REFVAL_P(val);
+				}
+				Z_TRY_ADDREF_P(val);
+				if (key) {
+					zend_hash_update(result_ht, key, val);
+				} else {
+					if (!zend_hash_next_index_insert(result_ht, val)) {
+						zend_cannot_add_element();
+						zval_ptr_dtor_nogc(val);
+						break;
+					}
+				}
+			} ZEND_HASH_FOREACH_END();
+		}
 	} else if (EXPECTED(Z_TYPE_P(op1) == IS_OBJECT)) {
 		zend_class_entry *ce = Z_OBJCE_P(op1);
 		zend_object_iterator *iter;


### PR DESCRIPTION
Current implementation doesn't optimize for packed arrays as point out in #9794, and this PR adds the optimization.

I used the benchmark script provided in #9794 (with small modification). 
```php
const ARRAY_SIZE = 50;

$a = range(1,ARRAY_SIZE); $b = range(1,ARRAY_SIZE); $t = microtime(true); for ( $i = 0; $i < 100000; $i++ ) { $c = [...$a, ...$b]; }
echo "array unpack:", microtime(true)-$t, PHP_EOL;

$a = range(1,ARRAY_SIZE); $b = range(1,ARRAY_SIZE); $t = microtime(true); for ( $i = 0; $i < 100000; $i++ ) { $c = array_merge($a,$b); }
echo "array_merge:", microtime(true)-$t, PHP_EOL;
```


Before patching:
array unpack:0.3077449798584
array_merge:0.13217878341675

After patching:
array unpack:0.12740397453308
array_merge:0.13788986206055