### PR TITLE
Convert constructor arguments in PDO Handler to HashTable*

### DIFF
--- a/ext/pdo/php_pdo_driver.h
+++ b/ext/pdo/php_pdo_driver.h
@@ -487,7 +487,7 @@ struct _pdo_dbh_t {
 
 	zend_class_entry *def_stmt_ce;
 
-	zval def_stmt_ctor_args;
+	HashTable *def_stmt_ctor_args;
 
 	/* when calling PDO::query(), we need to keep the error
 	 * context from the statement around until we next clear it.

--- a/run-tests.php
+++ b/run-tests.php
@@ -857,13 +857,7 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
         $php_cgi_info = '';
     }
 
-    if ($phpdbg) {
-        $phpdbg_info = shell_exec("$phpdbg $pass_options $info_params $no_file_cache -qrr \"$info_file\"");
-        $php_info_sep = "\n---------------------------------------------------------------------";
-        $phpdbg_info = "$php_info_sep\nPHP         : $phpdbg $phpdbg_info$php_info_sep";
-    } else {
-        $phpdbg_info = '';
-    }
+    $phpdbg_info = '';
 
     if (function_exists('opcache_invalidate')) {
         opcache_invalidate($info_file, true);


### PR DESCRIPTION
Split from https://github.com/php/php-src/pull/9723 and similar to #9725 but has no user facing changes.