### PR TITLE
Remove unnecessary ast eval bailout

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -801,8 +801,6 @@ static zend_result ZEND_FASTCALL zend_ast_evaluate_ex(zval *result, zend_ast *as
 		{
 			zend_string *class_name = zend_ast_get_str(ast->child[0]);
 			zend_string *const_name = zend_ast_get_str(ast->child[1]);
-			zval *zv;
-			bool bailout = 0;
 
 			zend_string *previous_filename;
 			zend_long previous_lineno;
@@ -812,17 +810,10 @@ static zend_result ZEND_FASTCALL zend_ast_evaluate_ex(zval *result, zend_ast *as
 				EG(filename_override) = scope->info.user.filename;
 				EG(lineno_override) = zend_ast_get_lineno(ast);
 			}
-			zend_try {
-				zv = zend_get_class_constant_ex(class_name, const_name, scope, ast->attr);
-			} zend_catch {
-				bailout = 1;
-			}  zend_end_try();
+			zval *zv = zend_get_class_constant_ex(class_name, const_name, scope, ast->attr);
 			if (scope) {
 				EG(filename_override) = previous_filename;
 				EG(lineno_override) = previous_lineno;
-			}
-			if (bailout) {
-				zend_bailout();
 			}
 
 			if (UNEXPECTED(zv == NULL)) {

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -471,8 +471,6 @@ void shutdown_executor(void) /* {{{ */
 		if (EG(ht_iterators) != EG(ht_iterators_slots)) {
 			efree(EG(ht_iterators));
 		}
-
-		ZEND_ASSERT(EG(filename_override) == NULL);
 	}
 
 #if ZEND_DEBUG

--- a/main/main.c
+++ b/main/main.c
@@ -1588,6 +1588,9 @@ static void php_free_request_globals(void)
 		efree(PG(php_sys_temp_dir));
 		PG(php_sys_temp_dir) = NULL;
 	}
+
+	EG(filename_override) = NULL;
+	EG(lineno_override) = -1;
 }
 /* }}} */
 


### PR DESCRIPTION
We can just reset the filename_override to NULL in php_request_shutdown.

This was only added to PHP-8.2. So I hope it's fine to remove it at this point.