### PR TITLE
Initialize run time cache in PDO methods

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -6522,23 +6522,25 @@ static zend_type zend_compile_typename(
 
 		ZEND_ASSERT(list->children == type_list->num_types);
 
-		ZEND_TYPE_FULL_MASK(type) |= _ZEND_TYPE_ARENA_BIT;
 		/* An implicitly nullable intersection type needs to be converted to a DNF type */
 		if (force_allow_null) {
 			zend_type intersection_type = ZEND_TYPE_INIT_NONE(0);
 			ZEND_TYPE_SET_LIST(intersection_type, type_list);
 			ZEND_TYPE_FULL_MASK(intersection_type) |= _ZEND_TYPE_INTERSECTION_BIT;
+			ZEND_TYPE_FULL_MASK(intersection_type) |= _ZEND_TYPE_ARENA_BIT;
 
-			zend_type_list *dnf_type_list = zend_arena_alloc(&CG(arena), ZEND_TYPE_LIST_SIZE(list->children));
+			zend_type_list *dnf_type_list = zend_arena_alloc(&CG(arena), ZEND_TYPE_LIST_SIZE(1));
 			dnf_type_list->num_types = 1;
 			dnf_type_list->types[0] = intersection_type;
 			ZEND_TYPE_SET_LIST(type, dnf_type_list);
 			/* Inform that the type list is a DNF type */
 			ZEND_TYPE_FULL_MASK(type) |= _ZEND_TYPE_UNION_BIT;
+			ZEND_TYPE_FULL_MASK(type) |= _ZEND_TYPE_ARENA_BIT;
 		} else {
 			ZEND_TYPE_SET_LIST(type, type_list);
 			/* Inform that the type list is an intersection type */
 			ZEND_TYPE_FULL_MASK(type) |= _ZEND_TYPE_INTERSECTION_BIT;
+			ZEND_TYPE_FULL_MASK(type) |= _ZEND_TYPE_ARENA_BIT;
 		}
 	} else {
 		type = zend_compile_single_typename(ast);

--- a/ext/gd/tests/bug81739.phpt
+++ b/ext/gd/tests/bug81739.phpt
@@ -1,9 +1,7 @@
 --TEST--
 Bug #81739 (OOB read due to insufficient validation in imageloadfont())
---SKIPIF--
-<?php
-if (!extension_loaded("gd")) die("skip gd extension not available");
-?>
+--EXTENSIONS--
+gd
 --FILE--
 <?php
 $s = fopen(__DIR__ . "/font.font", "w");

--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -11418,7 +11418,7 @@ static int zend_jit_fetch_dim(dasm_State    **Dst,
 		|.cold_code
 		|2:
 		|	SET_EX_OPLINE opline, REG0
-		if (if (opline->opcode != ZEND_FETCH_DIM_RW) {
+		if (opline->opcode != ZEND_FETCH_DIM_RW) {
 			|	EXT_CALL zend_jit_prepare_assign_dim_ref, REG0
 		}
 		|	mov FCARG1x, RETVALx

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -1254,7 +1254,11 @@ bool pdo_hash_methods(pdo_dbh_object_t *dbh_obj, int kind)
 		func.function_name = zend_string_init(funcs->fname, strlen(funcs->fname), dbh->is_persistent);
 		func.scope = dbh_obj->std.ce;
 		func.prototype = NULL;
-		ZEND_MAP_PTR(func.run_time_cache) = rt_cache_size ? pemalloc(rt_cache_size, dbh->is_persistent) : NULL;
+		ZEND_MAP_PTR(func.run_time_cache) = NULL;
+        if (rt_cache_size > 0) {
+            ZEND_MAP_PTR(func.run_time_cache) = pemalloc(rt_cache_size, dbh->is_persistent);
+            memset(ZEND_MAP_PTR(func.run_time_cache), 0, rt_cache_size);
+        }
 		func.T = ZEND_OBSERVER_ENABLED;
 		if (funcs->flags) {
 			func.fn_flags = funcs->flags | ZEND_ACC_NEVER_CACHE;

--- a/ext/zend_test/tests/observer_sqlite_create_function.phpt
+++ b/ext/zend_test/tests/observer_sqlite_create_function.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Observer: PDO::sqliteCreateFunction() can be observed
+--EXTENSIONS--
+zend_test
+PDO
+pdo_sqlite
+--INI--
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+--FILE--
+<?php
+
+function returnOne() {
+    return 1;
+}
+
+$db = new PDO('sqlite::memory:');
+$db->sqliteCreateFunction('returnOne', 'returnOne', 0);
+
+foreach ($db->query('SELECT returnOne()') as $row) {
+    var_dump($row);
+}
+
+echo 'Done' . PHP_EOL;
+?>
+--EXPECTF--
+<!-- init '%s' -->
+<file '%s'>
+  <!-- init PDO::__construct() -->
+  <PDO::__construct>
+  </PDO::__construct>
+  <!-- init PDO::sqliteCreateFunction() -->
+  <PDO::sqliteCreateFunction>
+  </PDO::sqliteCreateFunction>
+  <!-- init PDO::query() -->
+  <PDO::query>
+    <!-- init returnOne() -->
+    <returnOne>
+    </returnOne>
+  </PDO::query>
+  <!-- init var_dump() -->
+  <var_dump>
+array(2) {
+  ["returnOne()"]=>
+  int(1)
+  [0]=>
+  int(1)
+}
+  </var_dump>
+Done
+</file '%s'>


### PR DESCRIPTION
Without the memset the memory was uninitialized and the new test segfaulted when accessing the memory in `_zend_observe_fcall_begin()`.