### PR TITLE
opcache: fix syntax error introduced in zend_jit_arm64.dasc

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -11545,7 +11545,7 @@ static int zend_jit_fetch_dim(dasm_State    **Dst,
 		|.cold_code
 		|2:
 		|	SET_EX_OPLINE opline, REG0
-		if (if (opline->opcode != ZEND_FETCH_DIM_RW) {
+		if (opline->opcode != ZEND_FETCH_DIM_RW) {
 			|	EXT_CALL zend_jit_prepare_assign_dim_ref, REG0
 		}
 		|	mov FCARG1x, RETVALx


### PR DESCRIPTION
Problem introduced here: https://github.com/php/php-src/commit/261a08af65168e24c43a81321284f3f461f3500d#r87734943

This creates build errors: https://github.com/dunglas/frankenphp/actions/runs/3313421053/jobs/5471375783

cc @dstogov