### PR TITLE
Fix pre-PHP 8.2 compatibility for php_mt_rand_range() with MT_RAND_PHP

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-9818 (Initialize run time cache in PDO methods).
     (Florian Sowade)
 
+- Random:
+  . Fixed bug GH-9839 (Pre-PHP 8.2 output compatibility for non-mt_rand()
+    functions for MT_RAND_PHP). (timwolla)
+
 27 Oct 2022, PHP 8.2.0RC5
 
 - CLI:

--- a/ext/random/engine_mt19937.c
+++ b/ext/random/engine_mt19937.c
@@ -162,23 +162,7 @@ static uint64_t generate(php_random_status *status)
 
 static zend_long range(php_random_status *status, zend_long min, zend_long max)
 {
-	php_random_status_state_mt19937 *s = status->state;
-
-	if (s->mode == MT_RAND_MT19937) {
-		return php_random_range(&php_random_algo_mt19937, status, min, max);
-	}
-
-	/* Legacy mode deliberately not inside php_mt_rand_range()
-	 * to prevent other functions being affected */
-
-	uint64_t r = php_random_algo_mt19937.generate(status) >> 1;
-
-	/* This is an inlined version of the RAND_RANGE_BADSCALING macro that does not invoke UB when encountering
-	 * (max - min) > ZEND_LONG_MAX.
-	 */
-	zend_ulong offset = (double) ( (double) max - min + 1.0) * (r / (PHP_MT_RAND_MAX + 1.0));
-
-	return (zend_long) (offset + min);
+	return php_random_range(&php_random_algo_mt19937, status, min, max);
 }
 
 static bool serialize(php_random_status *status, HashTable *data)

--- a/ext/random/tests/01_functions/array_rand_mt_rand_php.phpt
+++ b/ext/random/tests/01_functions/array_rand_mt_rand_php.phpt
@@ -1,0 +1,32 @@
+--TEST--
+array_rand() is not affected by MT_RAND_PHP as with PHP < 8.2
+--FILE--
+<?php
+
+$array = [
+    'foo',
+    'bar',
+    'baz',
+];
+
+mt_srand(1, MT_RAND_PHP);
+function custom_array_rand() {
+    global $array;
+    $key = array_rand($array);
+    var_dump('found key ' . $key);
+    return $array[$key];
+}
+
+var_dump(
+    custom_array_rand(),
+    custom_array_rand(),
+    custom_array_rand(),
+);
+?>
+--EXPECTF--
+string(11) "found key 0"
+string(11) "found key 1"
+string(11) "found key 0"
+string(3) "foo"
+string(3) "bar"
+string(3) "foo"


### PR DESCRIPTION
Example: https://3v4l.org/0gEEY

--------------

As some left-over comments indicated:

> Legacy mode deliberately not inside php_mt_rand_range()
> to prevent other functions being affected

The broken scaler was only used for `php_mt_rand_common()`, not `php_mt_rand_range()`. The former is only used for `mt_rand()`, whereas the latter is used for `array_rand()` and others.

With the refactoring for the introduction of ext/random `php_mt_rand_common()` and `php_mt_rand_range()` were accidentally unified, thus introducing a behavioral change that was reported in FakerPHP/Faker#528.

This commit moves the checks for `MT_RAND_PHP` from the general-purpose `range()` function back into `php_mt_rand_common()` and also into `Randomizer::getInt()` for drop-in compatibility with `mt_rand()`.