### PR TITLE
Improve FCC API

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4145,6 +4145,24 @@ ZEND_API zend_result zend_fcall_info_call(zend_fcall_info *fci, zend_fcall_info_
 }
 /* }}} */
 
+ZEND_API void zend_get_callable_zval_from_fcc(const zend_fcall_info_cache *fcc, zval *callable)
+{
+	if (fcc->closure) {
+		ZVAL_OBJ_COPY(callable, fcc->closure);
+	} else if (fcc->function_handler->common.scope) {
+		array_init(callable);
+		if (fcc->object) {
+			GC_ADDREF(fcc->object);
+			add_next_index_object(callable, fcc->object);
+		} else {
+			add_next_index_str(callable, zend_string_copy(fcc->calling_scope->name));
+		}
+		add_next_index_str(callable, zend_string_copy(fcc->function_handler->common.function_name));
+	} else {
+		ZVAL_STR_COPY(callable, fcc->function_handler->common.function_name);
+	}
+}
+
 ZEND_API const char *zend_get_module_version(const char *module_name) /* {{{ */
 {
 	zend_string *lname;

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3856,6 +3856,7 @@ ZEND_API bool zend_is_callable_at_frame(
 	fcc->called_scope = NULL;
 	fcc->function_handler = NULL;
 	fcc->object = NULL;
+	fcc->closure = NULL;
 
 again:
 	switch (Z_TYPE_P(callable)) {
@@ -3929,6 +3930,7 @@ check_func:
 		case IS_OBJECT:
 			if (Z_OBJ_HANDLER_P(callable, get_closure) && Z_OBJ_HANDLER_P(callable, get_closure)(Z_OBJ_P(callable), &fcc->calling_scope, &fcc->function_handler, &fcc->object, 1) == SUCCESS) {
 				fcc->called_scope = fcc->calling_scope;
+				fcc->closure = Z_OBJ_P(callable);
 				if (fcc == &fcc_local) {
 					zend_release_fcall_info_cache(fcc);
 				}

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -58,7 +58,8 @@ typedef struct _zend_fcall_info_cache {
 	zend_function *function_handler;
 	zend_class_entry *calling_scope;
 	zend_class_entry *called_scope;
-	zend_object *object;
+	zend_object *object; /* Instance of object for method calls */
+	zend_object *closure; /* Closure reference, only if the callable *is* the object */
 } zend_fcall_info_cache;
 
 #define ZEND_NS_NAME(ns, name)			ns "\\" name

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -328,6 +328,7 @@ typedef struct _zend_fcall_info_cache {
 	zend_class_backed_enum_table(ce)
 
 #define ZEND_FCI_INITIALIZED(fci) ((fci).size != 0)
+#define ZEND_FCC_INITIALIZED(fcc) ((fcc).function_handler != NULL)
 
 ZEND_API int zend_next_free_module(void);
 
@@ -729,6 +730,57 @@ ZEND_API void zend_fcall_info_argn(zend_fcall_info *fci, uint32_t argc, ...);
  */
 ZEND_API zend_result zend_fcall_info_call(zend_fcall_info *fci, zend_fcall_info_cache *fcc, zval *retval, zval *args);
 
+/* Zend FCC API to store and handle PHP userland functions */
+static zend_always_inline bool zend_fcc_equals(const zend_fcall_info_cache* a, const zend_fcall_info_cache* b)
+{
+	return a->function_handler == b->function_handler
+		&& a->object == b->object
+		&& a->calling_scope == b->calling_scope
+		&& a->closure == b->closure
+	;
+}
+
+static zend_always_inline void zend_fcc_addref(zend_fcall_info_cache *fcc)
+{
+	if (fcc->object) {
+		GC_ADDREF(fcc->object);
+	}
+	if (fcc->closure) {
+		GC_ADDREF(fcc->closure);
+	}
+}
+
+static zend_always_inline void zend_fcc_dup(/* restrict */ zend_fcall_info_cache *dest, const zend_fcall_info_cache *src)
+{
+	memcpy(dest, src, sizeof(zend_fcall_info_cache));
+	zend_fcc_addref(dest);
+}
+
+static zend_always_inline void zend_fcc_dtor(zend_fcall_info_cache *fcc)
+{
+	if (fcc->object) {
+		OBJ_RELEASE(fcc->object);
+	}
+	if (fcc->closure) {
+		OBJ_RELEASE(fcc->closure);
+	}
+	memcpy(fcc, &empty_fcall_info_cache, sizeof(zend_fcall_info_cache));
+}
+
+ZEND_API void zend_get_callable_zval_from_fcc(const zend_fcall_info_cache *fcc, zval *callable);
+
+/* Moved out of zend_gc.h because zend_fcall_info_cache is an unknown type in that header */
+static zend_always_inline void zend_get_gc_buffer_add_fcc(zend_get_gc_buffer *gc_buffer, zend_fcall_info_cache *fcc)
+{
+	ZEND_ASSERT(ZEND_FCC_INITIALIZED(*fcc));
+	if (fcc->object) {
+		zend_get_gc_buffer_add_obj(gc_buffer, fcc->object);
+	}
+	if (fcc->closure) {
+		zend_get_gc_buffer_add_obj(gc_buffer, fcc->closure);
+	}
+}
+
 /* Can only return FAILURE if EG(active) is false during late engine shutdown.
  * If the call or call setup throws, EG(exception) will be set and the retval
  * will be UNDEF. Otherwise, the retval will be a non-UNDEF value. */
@@ -750,6 +802,12 @@ static zend_always_inline zend_result zend_call_function_with_return_value(
 ZEND_API void zend_call_known_function(
 		zend_function *fn, zend_object *object, zend_class_entry *called_scope, zval *retval_ptr,
 		uint32_t param_count, zval *params, HashTable *named_params);
+
+static zend_always_inline void zend_call_known_fcc(
+	zend_fcall_info_cache *fcc, zval *retval_ptr, uint32_t param_count, zval *params, HashTable *named_params)
+{
+	zend_call_known_function(fcc->function_handler, fcc->object, fcc->called_scope, retval_ptr, param_count, params, named_params);
+}
 
 /* Call the provided zend_function instance method on an object. */
 static zend_always_inline void zend_call_known_instance_method(

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -50,7 +50,7 @@ ZEND_API zend_class_entry *(*zend_autoload)(zend_string *name, zend_string *lc_n
 
 /* true globals */
 ZEND_API const zend_fcall_info empty_fcall_info = {0};
-ZEND_API const zend_fcall_info_cache empty_fcall_info_cache = { NULL, NULL, NULL, NULL };
+ZEND_API const zend_fcall_info_cache empty_fcall_info_cache = {0};
 
 #ifdef ZEND_WIN32
 ZEND_TLS HANDLE tq_timer = NULL;

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -42,11 +42,7 @@ ZEND_BEGIN_MODULE_GLOBALS(libxml)
 	zval stream_context;
 	smart_str error_buffer;
 	zend_llist *error_list;
-	struct _php_libxml_entity_resolver {
-		zval 					callback;
-		zend_fcall_info 		fci;
-		zend_fcall_info_cache	fcc;
-	} entity_loader;
+	zend_fcall_info_cache entity_loader_callback;
 	bool entity_loader_disabled;
 ZEND_END_MODULE_GLOBALS(libxml)
 

--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -40,11 +40,6 @@ struct php_sqlite3_bound_param  {
 	zval parameter;
 };
 
-struct php_sqlite3_fci {
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcc;
-};
-
 /* Structure for SQLite function. */
 typedef struct _php_sqlite3_func {
 	struct _php_sqlite3_func *next;
@@ -62,8 +57,7 @@ typedef struct _php_sqlite3_collation {
 	struct _php_sqlite3_collation *next;
 
 	const char *collation_name;
-	zval cmp_func;
-	struct php_sqlite3_fci fci;
+	zend_fcall_info_cache cmp_func;
 } php_sqlite3_collation;
 
 /* Structure for SQLite Database object. */

--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -66,7 +66,6 @@ typedef struct _php_sqlite3_db_object  {
 	sqlite3 *db;
 	php_sqlite3_func *funcs;
 	php_sqlite3_collation *collations;
-	zend_fcall_info authorizer_fci;
 	zend_fcall_info_cache authorizer_fcc;
 
 	bool exception;

--- a/ext/sqlite3/php_sqlite3_structs.h
+++ b/ext/sqlite3/php_sqlite3_structs.h
@@ -52,8 +52,9 @@ typedef struct _php_sqlite3_func {
 	const char *func_name;
 	int argc;
 
-	zval func, step, fini;
-	struct php_sqlite3_fci afunc, astep, afini;
+	zend_fcall_info_cache func;
+	zend_fcall_info_cache step;
+	zend_fcall_info_cache fini;
 } php_sqlite3_func;
 
 /* Structure for SQLite collation function */


### PR DESCRIPTION
This PR improves the FCC struct and API and contains a use case of the improved API.

First, a ``closure`` field is added to the FCC struct to keep a reference for closure when the callable is an object.

Secondly, we add APIs to add/del FCC references to manage userland callables references in a global API. We also add some QoL APIs to call FCCs, compare them, and check that they are initialized.

Thirdly, we use this new API in a concrete refactoring case in SPL.