### PR TITLE
Do not display the value of UNKNOWN constants in the manual

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1911,6 +1911,10 @@ class ConstInfo extends VariableLike
     protected function getFieldSynopsisValueString(iterable $allConstInfos): ?string
     {
         $value = EvaluatedValue::createFromExpression($this->value, null, $this->cValue, $allConstInfos);
+        if ($value->isUnknownConstValue) {
+            return null;
+        }
+
         if ($value->originatingConst) {
             return $value->originatingConst->getFieldSynopsisValueString($allConstInfos);
         }


### PR DESCRIPTION
Just like in case of unknown parameter default values, no initializer is generated for constants having an unknown value. The manual can still display `?` if phd is also updated, or the value may also be omitted entirely if we want to.