### PR TITLE
socket add socket_atmark support.

### DIFF
--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -5,6 +5,7 @@ PHP_ARG_ENABLE([sockets],
 
 if test "$PHP_SOCKETS" != "no"; then
   AC_CHECK_FUNCS([hstrerror if_nametoindex if_indextoname])
+  AC_CHECK_FUNCS(sockatmark)
   AC_CHECK_HEADERS([netinet/tcp.h sys/un.h sys/sockio.h linux/filter.h])
   AC_DEFINE([HAVE_SOCKETS], 1, [ ])
 

--- a/ext/sockets/sockets.c
+++ b/ext/sockets/sockets.c
@@ -2109,6 +2109,32 @@ PHP_FUNCTION(socket_shutdown)
 /* }}} */
 #endif
 
+#ifdef HAVE_SOCKATMARK
+PHP_FUNCTION(socket_atmark)
+{
+	zval		*arg1;
+	php_socket	*php_sock;
+	int r;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &arg1, socket_ce) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	php_sock = Z_SOCKET_P(arg1);
+	ENSURE_SOCKET_VALID(php_sock);
+
+	r = sockatmark(php_sock->bsd_socket);
+	if (r < 0) {
+		PHP_SOCKET_ERROR(php_sock, "Unable to apply sockmark", errno);
+		RETURN_FALSE;
+	} else if (r == 0) {
+		RETURN_FALSE;
+	} else {
+		RETURN_TRUE;
+	}
+}
+#endif
+
 /* {{{ Returns the last socket error (either the last used or the provided socket resource) */
 PHP_FUNCTION(socket_last_error)
 {

--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -1798,6 +1798,10 @@ function socket_create_pair(int $domain, int $type, int $protocol, &$pair): bool
 function socket_shutdown(Socket $socket, int $mode = 2): bool {}
 #endif
 
+#ifdef HAVE_SOCKATMARK
+function socket_atmark(Socket $socket): bool {}
+#endif
+
 function socket_last_error(?Socket $socket = null): int {}
 
 function socket_clear_error(?Socket $socket = null): void {}

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 546bd6fd43a68c8b6a95b4145afa94c04e36364a */
+ * Stub hash: 4fb48cdd2188e8834fd2210027adc1072e885d6e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -140,6 +140,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_socket_shutdown, 0, 1, _IS_BOOL,
 ZEND_END_ARG_INFO()
 #endif
 
+#if defined(HAVE_SOCKATMARK)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_socket_atmark, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, socket, Socket, 0)
+ZEND_END_ARG_INFO()
+#endif
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_socket_last_error, 0, 0, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, socket, Socket, 1, "null")
 ZEND_END_ARG_INFO()
@@ -237,6 +243,9 @@ ZEND_FUNCTION(socket_create_pair);
 #if defined(HAVE_SHUTDOWN)
 ZEND_FUNCTION(socket_shutdown);
 #endif
+#if defined(HAVE_SOCKATMARK)
+ZEND_FUNCTION(socket_atmark);
+#endif
 ZEND_FUNCTION(socket_last_error);
 ZEND_FUNCTION(socket_clear_error);
 ZEND_FUNCTION(socket_import_stream);
@@ -288,6 +297,9 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_SHUTDOWN)
 	ZEND_FE(socket_shutdown, arginfo_socket_shutdown)
+#endif
+#if defined(HAVE_SOCKATMARK)
+	ZEND_FE(socket_atmark, arginfo_socket_atmark)
 #endif
 	ZEND_FE(socket_last_error, arginfo_socket_last_error)
 	ZEND_FE(socket_clear_error, arginfo_socket_clear_error)


### PR DESCRIPTION
checks whether the socket belongs to the out-of-band mark, thus allows to be
 processed accordingly (using the MSG_OOB flag on send/recv).