### PR TITLE
Add option to run all tests with active observers

### DIFF
--- a/ext/zend_test/tests/observer_backtrace_01.phpt
+++ b/ext/zend_test/tests/observer_backtrace_01.phpt
@@ -6,6 +6,7 @@ zend_test
 zend_test.observer.enabled=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_init_backtrace=1
+zend_test.observer.show_output=1
 --FILE--
 <?php
 class TestClass

--- a/ext/zend_test/tests/observer_basic_01.phpt
+++ b/ext/zend_test/tests/observer_basic_01.phpt
@@ -4,6 +4,7 @@ Observer: Basic observability of userland functions
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_basic_02.phpt
+++ b/ext/zend_test/tests/observer_basic_02.phpt
@@ -4,6 +4,7 @@ Observer: Basic observability of userland methods
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_basic_03.phpt
+++ b/ext/zend_test/tests/observer_basic_03.phpt
@@ -4,6 +4,7 @@ Observer: Basic observability of includes
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_basic_04.phpt
+++ b/ext/zend_test/tests/observer_basic_04.phpt
@@ -4,6 +4,8 @@ Observer: Basic observability of includes only (no functions)
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.observe_includes=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_basic_05.phpt
+++ b/ext/zend_test/tests/observer_basic_05.phpt
@@ -4,6 +4,8 @@ Observer: Basic observability of functions only (no includes)
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.observe_functions=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_basic_06.phpt
+++ b/ext/zend_test/tests/observer_basic_06.phpt
@@ -4,6 +4,8 @@ Observer: Basic observability of functions only (with run-time swapping)
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.observe_function_names=foo
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_bug81430_1.phpt
+++ b/ext/zend_test/tests/observer_bug81430_1.phpt
@@ -5,6 +5,7 @@ zend_test
 --INI--
 memory_limit=20M
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_bug81430_2.phpt
+++ b/ext/zend_test/tests/observer_bug81430_2.phpt
@@ -5,6 +5,7 @@ zend_test
 --INI--
 memory_limit=20M
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --SKIPIF--
 <?php

--- a/ext/zend_test/tests/observer_bug81435.phpt
+++ b/ext/zend_test/tests/observer_bug81435.phpt
@@ -5,6 +5,8 @@ zend_test
 --INI--
 memory_limit=20M
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.observe_function_names=a,d
 opcache.optimization_level=0
 --SKIPIF--

--- a/ext/zend_test/tests/observer_call_user_func_01.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_01.phpt
@@ -4,6 +4,7 @@ Observer: call_user_func() from root namespace
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_call_user_func_02.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_02.phpt
@@ -4,6 +4,7 @@ Observer: call_user_func_array() from root namespace
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_call_user_func_03.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_03.phpt
@@ -4,6 +4,7 @@ Observer: call_user_func() from namespace
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_call_user_func_04.phpt
+++ b/ext/zend_test/tests/observer_call_user_func_04.phpt
@@ -4,6 +4,7 @@ Observer: call_user_func_array() from namespace
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_closure_01.phpt
+++ b/ext/zend_test/tests/observer_closure_01.phpt
@@ -4,6 +4,7 @@ Observer: Basic observability of closures
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_closure_02.phpt
+++ b/ext/zend_test/tests/observer_closure_02.phpt
@@ -4,6 +4,7 @@ Observer: Observability of fake closures
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_declarations_01.phpt
+++ b/ext/zend_test/tests/observer_declarations_01.phpt
@@ -4,6 +4,7 @@ Observer: Observe function and class declarations
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.observe_declaring=1
 --FILE--

--- a/ext/zend_test/tests/observer_declarations_file_cache.phpt
+++ b/ext/zend_test/tests/observer_declarations_file_cache.phpt
@@ -4,6 +4,8 @@ Observer: Observe function and class declarations with file_cache_only
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.observe_declaring=1
 opcache.enable_cli=1
 opcache.file_cache={TMP}

--- a/ext/zend_test/tests/observer_error_01.phpt
+++ b/ext/zend_test/tests/observer_error_01.phpt
@@ -4,6 +4,7 @@ Observer: End handlers fire after a fatal error
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 memory_limit=2M

--- a/ext/zend_test/tests/observer_error_02.phpt
+++ b/ext/zend_test/tests/observer_error_02.phpt
@@ -4,6 +4,7 @@ Observer: End handlers fire after a userland fatal error
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_error_03.phpt
+++ b/ext/zend_test/tests/observer_error_03.phpt
@@ -4,6 +4,7 @@ Observer: non-fatal errors do not fire end handlers prematurely
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_error_04.phpt
+++ b/ext/zend_test/tests/observer_error_04.phpt
@@ -5,6 +5,7 @@ zend_test
 soap
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_error_05.phpt
+++ b/ext/zend_test/tests/observer_error_05.phpt
@@ -4,6 +4,7 @@ Observer: End handlers fire after a userland fatal error
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_eval_01.phpt
+++ b/ext/zend_test/tests/observer_eval_01.phpt
@@ -4,6 +4,7 @@ Observer: Basic eval observability
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_exception_01.phpt
+++ b/ext/zend_test/tests/observer_exception_01.phpt
@@ -4,6 +4,7 @@ Observer: Basic observability of userland functions with uncaught exceptions
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_fiber_01.phpt
+++ b/ext/zend_test/tests/observer_fiber_01.phpt
@@ -4,6 +4,8 @@ Observer: Basic fiber switching
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.fiber_init=1
 zend_test.observer.fiber_switch=1
 zend_test.observer.fiber_destroy=1

--- a/ext/zend_test/tests/observer_fiber_02.phpt
+++ b/ext/zend_test/tests/observer_fiber_02.phpt
@@ -4,6 +4,8 @@ Observer: Unfinished fiber
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.fiber_switch=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_fiber_03.phpt
+++ b/ext/zend_test/tests/observer_fiber_03.phpt
@@ -4,6 +4,8 @@ Observer: Nested fibers
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.fiber_switch=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_fiber_04.phpt
+++ b/ext/zend_test/tests/observer_fiber_04.phpt
@@ -4,6 +4,8 @@ Observer: Nested fibers with unfinished fiber
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.fiber_switch=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_fiber_05.phpt
+++ b/ext/zend_test/tests/observer_fiber_05.phpt
@@ -4,6 +4,8 @@ Observer: Nested fibers with both unfinished
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.fiber_switch=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_fiber_06.phpt
+++ b/ext/zend_test/tests/observer_fiber_06.phpt
@@ -4,6 +4,8 @@ Observer: Throwing fiber
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
+zend_test.observer.observe_all=0
 zend_test.observer.fiber_switch=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_fiber_functions_01.phpt
+++ b/ext/zend_test/tests/observer_fiber_functions_01.phpt
@@ -4,6 +4,7 @@ Observer: Basic function observing in fibers
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.fiber_init=1
 zend_test.observer.fiber_switch=1

--- a/ext/zend_test/tests/observer_fiber_functions_02.phpt
+++ b/ext/zend_test/tests/observer_fiber_functions_02.phpt
@@ -4,6 +4,7 @@ Observer: Function observing in fibers with unfinished fiber
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.fiber_init=1
 zend_test.observer.fiber_switch=1

--- a/ext/zend_test/tests/observer_fiber_functions_03.phpt
+++ b/ext/zend_test/tests/observer_fiber_functions_03.phpt
@@ -4,6 +4,7 @@ Observer: Function observing in fibers with bailout in fiber
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.fiber_init=1
 zend_test.observer.fiber_switch=1

--- a/ext/zend_test/tests/observer_generator_01.phpt
+++ b/ext/zend_test/tests/observer_generator_01.phpt
@@ -4,6 +4,7 @@ Observer: Basic generator observability
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_generator_02.phpt
+++ b/ext/zend_test/tests/observer_generator_02.phpt
@@ -4,6 +4,7 @@ Observer: Generator with explicit return
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_generator_03.phpt
+++ b/ext/zend_test/tests/observer_generator_03.phpt
@@ -4,6 +4,7 @@ Observer: Generator with 'yield from'
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_generator_04.phpt
+++ b/ext/zend_test/tests/observer_generator_04.phpt
@@ -4,6 +4,7 @@ Observer: Generator with manual traversal
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_generator_05.phpt
+++ b/ext/zend_test/tests/observer_generator_05.phpt
@@ -4,6 +4,7 @@ Observer: Generator with uncaught exception
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_magic_01.phpt
+++ b/ext/zend_test/tests/observer_magic_01.phpt
@@ -4,6 +4,7 @@ Observer: Basic magic method observability
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_opline_01.phpt
+++ b/ext/zend_test/tests/observer_opline_01.phpt
@@ -4,6 +4,7 @@ Observer: Ensure opline exists on the execute_data
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_opcode=1
 opcache.jit=0

--- a/ext/zend_test/tests/observer_retval_01.phpt
+++ b/ext/zend_test/tests/observer_retval_01.phpt
@@ -4,6 +4,7 @@ Observer: Retvals are observable that are: IS_CONST
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 opcache.optimization_level=0

--- a/ext/zend_test/tests/observer_retval_02.phpt
+++ b/ext/zend_test/tests/observer_retval_02.phpt
@@ -4,6 +4,7 @@ Observer: Unused retvals from generators are still observable
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_retval_03.phpt
+++ b/ext/zend_test/tests/observer_retval_03.phpt
@@ -4,6 +4,7 @@ Observer: Retvals are observable that are: refcounted, IS_CV
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_retval_04.phpt
+++ b/ext/zend_test/tests/observer_retval_04.phpt
@@ -4,6 +4,7 @@ Observer: Retvals are observable that are: refcounted, IS_VAR
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_retval_05.phpt
+++ b/ext/zend_test/tests/observer_retval_05.phpt
@@ -4,6 +4,7 @@ Observer: Retvals are observable that are: IS_CV, IS_UNDEF
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_retval_06.phpt
+++ b/ext/zend_test/tests/observer_retval_06.phpt
@@ -4,6 +4,7 @@ Observer: Retvals are observable that are: IS_CV
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_retval_07.phpt
+++ b/ext/zend_test/tests/observer_retval_07.phpt
@@ -4,6 +4,7 @@ Observer: Retvals are observable that are: IS_REFERENCE, IS_VAR
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_retval_by_ref_01.phpt
+++ b/ext/zend_test/tests/observer_retval_by_ref_01.phpt
@@ -4,6 +4,7 @@ Observer: Retvals by reference are observable that are: IS_CV
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_retval_by_ref_02.phpt
+++ b/ext/zend_test/tests/observer_retval_by_ref_02.phpt
@@ -4,6 +4,7 @@ Observer: Retvals by reference are observable that are: IS_TMP_VAR
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_retval_by_ref_03.phpt
+++ b/ext/zend_test/tests/observer_retval_by_ref_03.phpt
@@ -4,6 +4,7 @@ Observer: Retvals by reference are observable that are: IS_VAR, ZEND_RETURNS_FUN
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 opcache.optimization_level=0

--- a/ext/zend_test/tests/observer_shutdown_01.phpt
+++ b/ext/zend_test/tests/observer_shutdown_01.phpt
@@ -4,6 +4,7 @@ Observer: Function calls from a shutdown handler are observable
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_shutdown_02.phpt
+++ b/ext/zend_test/tests/observer_shutdown_02.phpt
@@ -4,6 +4,7 @@ Observer: Function calls from a __destruct during shutdown are observable
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_sqlite_create_function.phpt
+++ b/ext/zend_test/tests/observer_sqlite_create_function.phpt
@@ -6,6 +6,7 @@ PDO
 pdo_sqlite
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php

--- a/ext/zend_test/tests/observer_types_01.phpt
+++ b/ext/zend_test/tests/observer_types_01.phpt
@@ -4,6 +4,7 @@ Observer: Observe basic TypeError
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 zend_test.observer.show_return_value=1
 --FILE--

--- a/ext/zend_test/tests/observer_zend_call_function_01.phpt
+++ b/ext/zend_test/tests/observer_zend_call_function_01.phpt
@@ -4,6 +4,7 @@ Observer: Calls that go through zend_call_function are observed
 zend_test
 --INI--
 zend_test.observer.enabled=1
+zend_test.observer.show_output=1
 zend_test.observer.observe_all=1
 --FILE--
 <?php


### PR DESCRIPTION
Some bugs only happen when observers are registered. This change makes it possible to register observers from the zend_test extension in all tests. The observers don’t really do anything, but just by being registered some bugs in the observer implementation can be caught.

The full test suite can be run with observers by executing `TEST_PHP_ARGS='--with-test-observers' make test`.

Right now some tests fail because of the issue fixed in #9849. I actually found that bug by running all tests with this new flag.