### PR TITLE
Allow passing serial as string in openssl_csr_sign

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,10 @@ PHP                                                                        NEWS
   . Made opcache.preload_user always optional in the cli and phpdbg SAPIs.
     (Arnaud)
 
+- OpenSSL:
+  . Allow passing serial as hex encoded string in openssl_csr_sign()
+    (Florian Sowade)
+
 - PCNTL:
   . SA_ONSTACK is now set for pcntl_signal. (Kévin Dunglas)
 

--- a/ext/openssl/openssl.stub.php
+++ b/ext/openssl/openssl.stub.php
@@ -430,7 +430,7 @@ function openssl_csr_export(OpenSSLCertificateSigningRequest|string $csr, &$outp
 /**
  * @param OpenSSLAsymmetricKey|OpenSSLCertificate|array|string $private_key
  */
-function openssl_csr_sign(OpenSSLCertificateSigningRequest|string $csr, OpenSSLCertificate|string|null $ca_certificate, #[\SensitiveParameter] $private_key, int $days, ?array $options = null, int $serial = 0): OpenSSLCertificate|false {}
+function openssl_csr_sign(OpenSSLCertificateSigningRequest|string $csr, OpenSSLCertificate|string|null $ca_certificate, #[\SensitiveParameter] $private_key, int $days, ?array $options = null, int|string $serial = 0): OpenSSLCertificate|false {}
 
 /**
  * @param OpenSSLAsymmetricKey $private_key

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ec0f6d5850d52d9bf8f6e9262ef49c68a818a946 */
+ * Stub hash: 7b086de74b4644df88a077c035154e7a6036488d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_x509_export_to_file, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, certificate, OpenSSLCertificate, MAY_BE_STRING, NULL)
@@ -89,7 +89,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_openssl_csr_sign, 0, 4, Open
 	ZEND_ARG_INFO(0, private_key)
 	ZEND_ARG_TYPE_INFO(0, days, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, serial, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_MASK(0, serial, MAY_BE_LONG|MAY_BE_STRING, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_openssl_csr_new, 0, 2, OpenSSLCertificateSigningRequest, MAY_BE_FALSE)

--- a/ext/openssl/tests/openssl_csr_sign_string_serial.phpt
+++ b/ext/openssl/tests/openssl_csr_sign_string_serial.phpt
@@ -1,0 +1,65 @@
+--TEST--
+openssl_csr_sign() allows string serial
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$config = __DIR__ . DIRECTORY_SEPARATOR . 'openssl.cnf';
+$config_arg = array('config' => $config);
+
+$dn = array(
+    "countryName" => "BR",
+    "stateOrProvinceName" => "Rio Grande do Sul",
+    "localityName" => "Porto Alegre",
+    "commonName" => "Henrique do N. Angelo",
+    "emailAddress" => "hnangelo@php.net"
+);
+
+$args = array(
+    "digest_alg" => "sha256",
+    "private_key_bits" => 2048,
+    "private_key_type" => OPENSSL_KEYTYPE_DSA,
+    "encrypt_key" => true,
+    "config" => $config
+);
+
+$privkey = openssl_pkey_new($config_arg);
+$csr = openssl_csr_new($dn, $privkey, $args);
+
+var_dump($cert1 = openssl_csr_sign($csr, null, $privkey, 365, $args, 1234567));
+var_dump($cert2 = openssl_csr_sign($csr, null, $privkey, 365, $args, 'DEADBEEF'));
+var_dump($cert3 = openssl_csr_sign($csr, null, $privkey, 365, $args, 'DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF'));
+
+var_dump(openssl_csr_sign($csr, null, $privkey, 365, $args, 'DEADBEEG'));
+var_dump(openssl_csr_sign($csr, null, $privkey, 365, $args, '0xDEADBEEF'));
+var_dump(openssl_csr_sign($csr, null, $privkey, 365, $args, str_repeat('FF', 500)));
+
+var_dump(openssl_x509_parse($cert1)['serialNumber']);
+var_dump(openssl_x509_parse($cert1)['serialNumberHex']);
+var_dump(openssl_x509_parse($cert2)['serialNumber']);
+var_dump(openssl_x509_parse($cert2)['serialNumberHex']);
+var_dump(openssl_x509_parse($cert3)['serialNumber']);
+var_dump(openssl_x509_parse($cert3)['serialNumberHex']);
+?>
+--EXPECTF--
+object(OpenSSLCertificate)#%d (0) {
+}
+object(OpenSSLCertificate)#%d (0) {
+}
+object(OpenSSLCertificate)#%d (0) {
+}
+
+Warning: openssl_csr_sign(): Error parsing serial number in %s on line %d
+bool(false)
+
+Warning: openssl_csr_sign(): Error parsing serial number in %s on line %d
+bool(false)
+
+Warning: openssl_csr_sign(): Error parsing serial number in %s on line %d
+bool(false)
+string(7) "1234567"
+string(6) "12D687"
+string(10) "3735928559"
+string(8) "DEADBEEF"
+string(42) "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+string(40) "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"


### PR DESCRIPTION
According to [RFC 5280 section 4.1.2.2](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2) serial numbers can be up to 20 bytes. Passing the serial as long only allows the serials to be up to 8 bytes. This change allows users to pass the serial as a hex encoded string instead of a long. This allows users to specify longer serials.

Since this is a rather minor API change, I did not create an RFC for the change. I am however happy to create an RFC, if you think it makes sense.