### PR TITLE
Fix GH-9754: SaltStack hangs when running php-fpm 8.1.11

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -1282,7 +1282,7 @@ static int fpm_conf_post_process(int force_daemon) /* {{{ */
 		fpm_evaluate_full_path(&fpm_global_config.error_log, NULL, PHP_LOCALSTATEDIR, 0);
 	}
 
-	if (0 > fpm_stdio_save_original_stderr()) {
+	if (!fpm_global_config.daemonize && 0 > fpm_stdio_save_original_stderr()) {
 		return -1;
 	}
 

--- a/sapi/fpm/tests/gh9754-daemonized-stderr-close.phpt
+++ b/sapi/fpm/tests/gh9754-daemonized-stderr-close.phpt
@@ -1,0 +1,44 @@
+--TEST--
+FPM: GH-9754 - stderr is not closed in daemonized run
+--SKIPIF--
+<?php
+include "skipif.inc";
+FPM\Tester::skipIfRoot();
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+pid = {{FILE:PID}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start(daemonize: true);
+$tester->expectLogStartNotices();
+$tester->switchLogSource('{{MASTER:OUT}}');
+$tester->expectLogEmpty();
+$tester->switchLogSource('{{FILE:LOG}}');
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/logreader.inc
+++ b/sapi/fpm/tests/logreader.inc
@@ -81,15 +81,23 @@ class LogReader
     /**
      * Get a single log line.
      *
-     * @param int $timeoutSeconds
-     * @param int $timeoutMicroseconds
+     * @param int  $timeoutSeconds      Read timeout in seconds
+     * @param int  $timeoutMicroseconds Read timeout in microseconds
+     * @param bool $throwOnTimeout      Whether to throw an exception on timeout
      *
      * @return null|string
      * @throws \Exception
      */
-    public function getLine(int $timeoutSeconds = 3, int $timeoutMicroseconds = 0): ?string
-    {
-        $line = $this->getSource()->getLine($timeoutSeconds, $timeoutMicroseconds);
+    public function getLine(
+        int $timeoutSeconds = 3,
+        int $timeoutMicroseconds = 0,
+        bool $throwOnTimeout = false
+    ): ?string {
+        $line = $this->getSource()->getLine(
+            $timeoutSeconds,
+            $timeoutMicroseconds,
+            $throwOnTimeout
+        );
         $this->trace(is_null($line) ? "LINE - null" : "LINE: $line");
 
         return $line;
@@ -196,17 +204,27 @@ class LogReader
     }
 }
 
+class LogTimoutException extends \Exception
+{
+}
+
 abstract class LogSource
 {
     /**
      * Get single line from the source.
      *
-     * @param int $timeoutSeconds      Read timeout in seconds
-     * @param int $timeoutMicroseconds Read timeout in microseconds
+     * @param int  $timeoutSeconds      Read timeout in seconds
+     * @param int  $timeoutMicroseconds Read timeout in microseconds
+     * @param bool $throwOnTimeout      Whether to throw an exception on timeout
      *
      * @return string|null
+     * @throws LogTimoutException
      */
-    public abstract function getLine(int $timeoutSeconds, int $timeoutMicroseconds): ?string;
+    public abstract function getLine(
+        int $timeoutSeconds,
+        int $timeoutMicroseconds,
+        bool $throwOnTimeout = false
+    ): ?string;
 
     /**
      * Get all lines that has been returned by getLine() method.
@@ -236,13 +254,18 @@ class LogStreamSource extends LogSource
     /**
      * Get single line from the stream.
      *
-     * @param int $timeoutSeconds      Read timeout in seconds
-     * @param int $timeoutMicroseconds Read timeout in microseconds
+     * @param int  $timeoutSeconds      Read timeout in seconds
+     * @param int  $timeoutMicroseconds Read timeout in microseconds
+     * @param bool $throwOnTimeout      Whether to throw an exception on timeout
      *
      * @return string|null
+     * @throws LogTimoutException
      */
-    public function getLine(int $timeoutSeconds, int $timeoutMicroseconds): ?string
-    {
+    public function getLine(
+        int $timeoutSeconds,
+        int $timeoutMicroseconds,
+        bool $throwOnTimeout = false
+    ): ?string {
         if (feof($this->stream)) {
             return null;
         }
@@ -255,6 +278,10 @@ class LogStreamSource extends LogSource
 
             return $line;
         } else {
+            if ($throwOnTimeout) {
+                throw new LogTimoutException('Timout exceeded when reading line');
+            }
+
             return null;
         }
     }
@@ -296,13 +323,18 @@ class LogFileSource extends LogSource
     /**
      * Get single line from the file.
      *
-     * @param int $timeoutSeconds      Read timeout in seconds
-     * @param int $timeoutMicroseconds Read timeout in microseconds
+     * @param int  $timeoutSeconds      Read timeout in seconds
+     * @param int  $timeoutMicroseconds Read timeout in microseconds
+     * @param bool $throwOnTimeout      Whether to throw an exception on timeout
      *
      * @return string|null
+     * @throws LogTimoutException
      */
-    public function getLine(int $timeoutSeconds, int $timeoutMicroseconds): ?string
-    {
+    public function getLine(
+        int $timeoutSeconds,
+        int $timeoutMicroseconds,
+        bool $throwOnTimeout = false
+    ): ?string {
         $endTime = microtime(true) + $timeoutSeconds + ($timeoutMicroseconds / 1_000_000);
         while ($this->position >= count($this->lines)) {
             if (is_file($this->filePath)) {
@@ -317,6 +349,10 @@ class LogFileSource extends LogSource
             }
             usleep(50_000);
             if (microtime(true) > $endTime) {
+                if ($throwOnTimeout) {
+                    throw new LogTimoutException('Timout exceeded when reading line');
+                }
+
                 return null;
             }
         }

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -105,6 +105,11 @@ class Tester
     private $masterProcess;
 
     /**
+     * @var bool
+     */
+    private bool $daemonized;
+
+    /**
      * @var resource
      */
     private $outDesc;
@@ -373,19 +378,25 @@ class Tester
      *
      * @param array $extraArgs   Command extra arguments.
      * @param bool  $forceStderr Whether to output to stderr so error log is used.
+     * @param bool $daemonize Whether to start FPM daemonized
      *
      * @return bool
      * @throws \Exception
      */
-    public function start(array $extraArgs = [], bool $forceStderr = true)
+    public function start(array $extraArgs = [], bool $forceStderr = true, bool $daemonize = false)
     {
         $configFile = $this->createConfig();
         $desc       = $this->outDesc ? [] : [1 => array('pipe', 'w'), 2 => array('redirect', 1)];
 
-        $cmd = [self::findExecutable(), '-F', '-y', $configFile];
+        $cmd = [self::findExecutable(), '-y', $configFile];
 
         if ($forceStderr) {
             $cmd[] = '-O';
+        }
+
+        $this->daemonized = $daemonize;
+        if ( ! $daemonize) {
+            $cmd[] = '-F';
         }
 
         if (getenv('TEST_FPM_RUN_AS_ROOT')) {
@@ -410,6 +421,9 @@ class Tester
         if ( ! $this->outDesc !== false) {
             $this->outDesc = $pipes[1];
             $this->logReader->setStreamSource('{{MASTER:OUT}}', $this->outDesc);
+            if ($daemonize) {
+                $this->switchLogSource('{{FILE:LOG}}');
+            }
         }
 
         return true;
@@ -833,7 +847,11 @@ class Tester
      */
     public function terminate()
     {
-        proc_terminate($this->masterProcess);
+        if ($this->daemonized) {
+            $this->signal('TERM');
+        } else {
+            proc_terminate($this->masterProcess);
+        }
     }
 
     /**
@@ -1270,6 +1288,25 @@ class Tester
     ) {
         $this->logTool->setExpectedMessage($message, $limit, $repeat);
         $this->logTool->checkTruncatedMessage($this->response->getErrorData());
+    }
+
+    /**
+     * Expect log to be closed.
+     *
+     * @throws \Exception
+     */
+    public function expectLogEmpty() {
+        try {
+            $line = $this->logReader->getLine(1, 0, true);
+            if ($line === '') {
+                $line = $this->logReader->getLine(1, 0, true);
+            }
+            if ($line !== null) {
+                $this->error('Log is not closed and returned line: ' . $line);
+            }
+        } catch (LogTimoutException $exception) {
+            $this->error('Log is not closed and timed out', $exception);
+        }
     }
 
     /**


### PR DESCRIPTION
SaltStack uses Python subprocess and redirects stderr to stdout which is then piped to the returned output. If php-fpm starts in daemonized mode, it should close stderr. However a fix introduced in GH-8913 keeps stderr around so it can be later restored. That causes the issue reported in GH-9754. The solution is to keep stderr around only when php-fpm runs in foreground as the issue is most likely visible only there. Basically there is no need to restore stderr when php-fpm is daemonized.