### PR TITLE
labeler.yml: set top-level read-only permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,10 +2,12 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     permissions:
-      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As discussed in the [mailing-list](https://marc.info/?l=php-internals&m=166690957300800).

Shifting the read-only permissions to the top-level future-proofs the workflow in case a job is ever added. It also makes the workflow consistent with all others which have such top-level permissions.