### PR TITLE
Fix potential NULL pointer dereference

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -702,7 +702,7 @@ TSRM_API void *shmat(int key, const void *shmaddr, int flags)
 {/*{{{*/
 	shm_pair *shm = shm_get(key, NULL);
 
-	if (!shm->segment) {
+	if (!shm || !shm->segment) {
 		return (void*)-1;
 	}
 
@@ -726,7 +726,7 @@ TSRM_API int shmdt(const void *shmaddr)
 	shm_pair *shm = shm_get(0, (void*)shmaddr);
 	int ret;
 
-	if (!shm->segment) {
+	if (!shm || !shm->segment) {
 		return -1;
 	}
 
@@ -746,7 +746,7 @@ TSRM_API int shmctl(int key, int cmd, struct shmid_ds *buf)
 {/*{{{*/
 	shm_pair *shm = shm_get(key, NULL);
 
-	if (!shm->segment) {
+	if (!shm || !shm->segment) {
 		return -1;
 	}
 


### PR DESCRIPTION
`shm_get()` (not to be confused with `shmget()`) returns `NULL` if reallocation fails; we need to cater to that when calling the function.

---

Not sure if there will be another regular bug fix release for PHP 8.0, but even if not, it might be worthwhile to merge this patch nonetheless.