### PR TITLE
Fix fake closure leaking when called from internal func

### DIFF
--- a/Zend/tests/fake_closure_in_internal_func_leaks.phpt
+++ b/Zend/tests/fake_closure_in_internal_func_leaks.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Fake closure called from internal function leaks
+--FILE--
+<?php
+
+$c = \is_array(...);
+var_dump(array_filter([[]], $c));
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(0) {
+  }
+}

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -973,6 +973,10 @@ cleanup_args:
 				zend_interrupt_function(EG(current_execute_data));
 			}
 		}
+
+		if (UNEXPECTED(ZEND_CALL_INFO(call) & ZEND_CALL_RELEASE_THIS)) {
+			OBJ_RELEASE(Z_OBJ(call->This));
+		}
 	}
 	EG(fake_scope) = orig_fake_scope;
 


### PR DESCRIPTION
Introduced in 8e49d7f32f3bf8e20a699bfef5c2b2591a56e8ec.

ZEND_CALL_RELEASE_THIS was previously not handled for internal calls but just for user calls in the zend_leave_helper.