### PR TITLE
Don't skip test on Windows due to missing ext/posix

### DIFF
--- a/ext/standard/tests/mail/gh7875.phpt
+++ b/ext/standard/tests/mail/gh7875.phpt
@@ -5,8 +5,10 @@ sendmail_path={MAIL:{PWD}/gh7875.mail.out}
 mail.log={PWD}/gh7875.mail.log
 --SKIPIF--
 <?php
-if (!extension_loaded('posix')) die('skip POSIX extension not loaded');
-if (posix_geteuid() == 0) die('skip Cannot run test as root.');
+if (PHP_OS_FAMILY !== "Windows") {
+    if (!extension_loaded('posix')) die('skip POSIX extension not loaded');
+    if (posix_geteuid() == 0) die('skip Cannot run test as root.');
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
ext/posix is not available on Windows, but there is no need to check for root (i.e. elevated privileges) on this platform, either.