### PR TITLE
Fix GH-9890: OpenSSL legacy providers not available on Windows

### DIFF
--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -357,6 +357,22 @@ foreach ($ENCHANT_DLLS as $dll) {
     }
 }
 
+$OPENSSL_DLLS = $php_build_dir . "/lib/ossl-modules/*.dll";
+$fls = glob($OPENSSL_DLLS);
+if (!empty($fls)) {
+    $openssl_dest_dir = "$dist_dir/extras/ssl";
+    if (!file_exists($openssl_dest_dir) || !is_dir($openssl_dest_dir)) {
+        if (!mkdir($openssl_dest_dir, 0777, true)) {
+            echo "WARNING: couldn't create '$openssl_dest_dir' for OpenSSL providers ";
+        }
+    }
+    foreach ($fls as $fl) {
+        if (!copy($fl, "$openssl_dest_dir/" . basename($fl))) {
+            echo "WARNING: couldn't copy $fl into the $openssl_dest_dir";
+        }
+    }
+}
+
 $SASL_DLLS = $php_build_dir . "/bin/sasl2/sasl*.dll";
 $fls = glob($SASL_DLLS);
 if (!empty($fls)) {


### PR DESCRIPTION
We need to copy the provider DLLs from the dependency package to the PHP distribution.

---

How to use the legacy provider needs to be documented. And it seems prudent to overhaul that mkdist.php script; from a quick glance some stuff is no longer needed, or otherwise confusing, e.g.

https://github.com/php/php-src/blob/02ed12240ede3c012faab5c9dda759c0cc45969f/win32/build/mkdist.php#L505-L507