### PR TITLE
opcache fixing w/x pages creation on freebsd 13.1 and above.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -401,6 +401,7 @@ sys/file.h \
 sys/mman.h \
 sys/mount.h \
 sys/poll.h \
+sys/procctl.h \
 sys/resource.h \
 sys/select.h \
 sys/socket.h \
@@ -587,6 +588,7 @@ mmap \
 nice \
 nl_langinfo \
 poll \
+procctl \
 putenv \
 scandir \
 setitimer \

--- a/ext/opcache/shared_alloc_mmap.c
+++ b/ext/opcache/shared_alloc_mmap.c
@@ -33,6 +33,10 @@
 #include <mach/vm_statistics.h>
 #endif
 
+#ifdef HAVE_SYS_PROCCTL_H
+#include <sys/procctl.h>
+#endif
+
 #if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)
 # define MAP_ANONYMOUS MAP_ANON
 #endif
@@ -45,6 +49,12 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 	zend_shared_segment *shared_segment;
 	int flags = PROT_READ | PROT_WRITE, fd = -1;
 	void *p;
+#if defined(HAVE_PROCCTL) && defined(PROC_WXMAP_CTL)
+	int enable_wxmap = PROC_WX_MAPPINGS_PERMIT;
+	if (procctl(P_PID, getpid(), PROC_WXMAP_CTL, &enable_wxmap) == -1) {
+		return ALLOC_FAILURE;
+	}
+#endif
 #ifdef PROT_MPROTECT
 	flags |= PROT_MPROTECT(PROT_EXEC);
 #endif


### PR DESCRIPTION
By default, the system allows these but admin can disable them system wide. However the procctl api permits to control it per process.