### PR TITLE
Make the usage of the role attribute more clear

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1487,14 +1487,10 @@ class FuncInfo {
 
         $methodSynopsis = $doc->createElement($synopsisType);
 
-        $aliasedFunc = $this->aliasType === "alias" && isset($funcMap[$this->alias->__toString()]) ? $funcMap[$this->alias->__toString()] : null;
-        $aliasFunc = $aliasMap[$this->name->__toString()] ?? null;
-
-        if (($this->aliasType === "alias" && $aliasedFunc !== null && $aliasedFunc->isMethod() !== $this->isMethod()) ||
-            ($aliasFunc !== null && $aliasFunc->isMethod() !== $this->isMethod())
-        ) {
+        if ($this->isMethod()) {
+            assert($this->name instanceof MethodName);
             $role = $doc->createAttribute("role");
-            $role->value = $this->isMethod() ? "oop" : "procedural";
+            $role->value = $this->name->className->__toString();
             $methodSynopsis->appendChild($role);
         }
 
@@ -2772,7 +2768,7 @@ class ClassInfo {
                 $classSynopsis->appendChild(new DOMText("\n    "));
                 $includeElement = $this->createIncludeElement(
                     $doc,
-                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"
+                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='$this->name'])"
                 );
                 $classSynopsis->appendChild($includeElement);
             }
@@ -2781,7 +2777,7 @@ class ClassInfo {
                 $classSynopsis->appendChild(new DOMText("\n    "));
                 $includeElement = $this->createIncludeElement(
                     $doc,
-                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"
+                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='$this->name'])"
                 );
                 $classSynopsis->appendChild($includeElement);
             }
@@ -2790,7 +2786,7 @@ class ClassInfo {
                 $classSynopsis->appendChild(new DOMText("\n    "));
                 $includeElement = $this->createIncludeElement(
                     $doc,
-                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[not(@role='procedural')])"
+                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$classReference')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='$this->name'])"
                 );
                 $classSynopsis->appendChild($includeElement);
             }
@@ -2807,7 +2803,7 @@ class ClassInfo {
                 $parentReference = self::getClassSynopsisReference($parent);
                 $includeElement = $this->createIncludeElement(
                     $doc,
-                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$parentReference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"
+                    "xmlns(db=http://docbook.org/ns/docbook) xpointer(id('$parentReference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='$parent')])"
                 );
                 $classSynopsis->appendChild($includeElement);
             }


### PR DESCRIPTION
Currently, the role attribute is used to differentiate OO and procedural "aliases" when they are documented on the same page (e.g. https://www.php.net/manual/en/datetime.diff.php). However, these function-method counterparts are not always aliases in fact according to the stubs (https://github.com/php/php-src/pull/9491). That's why sometimes the usage of the role attribute is ambiguous, thus syncing the manual with the stubs results in false positive diffs.

This PR fixes the problem by a very obtrusive way: by changing the value of all `role="oop"` attributes to the actual class name, like `role="DateTime"`, and by getting rid of all `role="procedural"` attributes as they became unnecessary. This way, class synopsis pages can clearly reference methods, and skip functions.

By having this PR, we can get rid of quite a few false positive diff between the output of gen_stub.php and the manual, most notably in ext/mysqli, ext/date and ext/curl. On the other hand, it will take a lot of followup changes in the manual to actually get rid of the diff. :(