### PR TITLE
Fix GH-9905: constant() behaves inconsistent when class is undefined

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -589,7 +589,7 @@ PHP_FUNCTION(constant)
 	ZEND_PARSE_PARAMETERS_END();
 
 	scope = zend_get_executed_scope();
-	c = zend_get_constant_ex(const_name, scope, 0);
+	c = zend_get_constant_ex(const_name, scope, ZEND_FETCH_CLASS_EXCEPTION);
 	if (!c) {
 		RETURN_THROWS();
 	}

--- a/ext/standard/tests/general_functions/gh9905.phpt
+++ b/ext/standard/tests/general_functions/gh9905.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-9905 (constant() behaves inconsistent when class is undefined)
+--FILE--
+<?php
+try {
+    \constant("\NonExistantClass::non_existant_constant");
+} catch (\Throwable|\Error|\Exception $e) {
+    echo($e->getMessage());
+}
+?>
+--EXPECT--
+Class "NonExistantClass" not found

--- a/tests/lang/bug44827.phpt
+++ b/tests/lang/bug44827.phpt
@@ -21,5 +21,4 @@ try {
 ?>
 --EXPECTF--
 define(): Argument #1 ($constant_name) cannot be a class constant
-
-Fatal error: Class "" not found in %s on line %d
+Class "" not found


### PR DESCRIPTION
Directly referring to a constant of an undefined throws an exception; there is not much point in `constant()` raising a fatal error in this case.