### PR TITLE
No more need to cater to mime_magic extension

### DIFF
--- a/sapi/fpm/fpm/fpm_php.h
+++ b/sapi/fpm/fpm/fpm_php.h
@@ -13,7 +13,6 @@
 	{ \
 		"error_log", \
 		"extension_dir", \
-		"mime_magic.magicfile", \
 		"sendmail_path", \
 		"session.cookie_path", \
 		"session_pgsql.sem_file_name", \


### PR DESCRIPTION
This extension is superseeded by fileinfo as of PHP 5.3.0, but the latter has no such configuration directive.

---

Likely, some other directives are no longer needed here, too.