### PR TITLE
Fix run-tests.php hanging when a worker process dies without notice

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1583,6 +1583,10 @@ escape:
                     kill_children($workerProcs);
                     error("Could not find worker stdout in array of worker stdouts, THIS SHOULD NOT HAPPEN.");
                 }
+                if (feof($workerSock)) {
+                    kill_children($workerProcs);
+                    error("Worker $i died unexpectedly");
+                }
                 while (false !== ($rawMessage = fgets($workerSock))) {
                     // work around fgets truncating things
                     if (($rawMessageBuffers[$i] ?? '') !== '') {


### PR DESCRIPTION
run-tests.php with `-jN` can hang if a parallel worker dies without notice. This can happen due to fatal errors in the worker, or if the worker is killed.


```
- run-tests.php (main process)
  \_ run-tests.php (worker #0) // main process hangs if this one crashes
     \_ test-001.php (test-001.phpt)
```