### PR TITLE
Skip tests if extension or SAPI is not included.

### DIFF
--- a/ext/libxml/tests/libxml_entity_loading_disabled_by_default.phpt
+++ b/ext/libxml/tests/libxml_entity_loading_disabled_by_default.phpt
@@ -3,6 +3,7 @@ libxml_disable_entity_loader()
 --EXTENSIONS--
 libxml
 dom
+simplexml
 --FILE--
 <?php
 

--- a/sapi/cgi/tests/005.phpt
+++ b/sapi/cgi/tests/005.phpt
@@ -1,5 +1,7 @@
 --TEST--
 using invalid combinations of cmdline options
+--SKIPIF--
+<?php include "skipif.inc"; ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
Bug #9927 relates in part.