### PR TITLE
Cache UTF-8-validity status of strings in GC flags

### DIFF
--- a/ext/mbstring/mbstring.h
+++ b/ext/mbstring/mbstring.h
@@ -65,7 +65,7 @@ MBSTRING_API zend_string* php_mb_convert_encoding(
 MBSTRING_API size_t php_mb_mbchar_bytes(const char *s, const mbfl_encoding *enc);
 
 MBSTRING_API size_t php_mb_stripos(int mode, const char *old_haystack, size_t old_haystack_len, const char *old_needle, size_t old_needle_len, zend_long offset, const mbfl_encoding *encoding);
-MBSTRING_API int php_mb_check_encoding(const char *input, size_t length, const mbfl_encoding *encoding);
+MBSTRING_API bool php_mb_check_encoding(const char *input, size_t length, const mbfl_encoding *encoding);
 
 ZEND_BEGIN_MODULE_GLOBALS(mbstring)
 	char *internal_encoding_name;


### PR DESCRIPTION
In #9613, @cmb69 astonished me by pointing out that we have a dedicated bit in the `zend_string` GC flags for marking strings which are known to be valid UTF-8. This is used by the PCRE extension.

If we use this flag in mbstring as well, it would help to make some programs faster (repeated calls to `mb_check_encoding` and similar functions on the same UTF-8 string would be very fast after the first time).

Further, going forward, there may be cases where we would like to check that UTF-8 strings are valid before operating on them. Using this flag would alleviate concerns about the performance cost of such checks. (As discussed in #9613, this is specifically interesting for `mb_strpos` and `mb_stripos`, but I think we will find other cases where it is also useful.)

One thing which is *not* done in this PR is to mark UTF-8 strings which are emitted *by* mbstring as valid UTF-8. Functions such as `mb_convert_encoding` never emit invalid UTF-8, so we could set the flag there so that any subsequent validity checks are fast.

This change should result in a negligible slowdown for non-UTF-8 strings, bad UTF-8 strings, and good UTF-8 strings which are checked only once. However, when microbenchmarking this change using a variety of text encodings and string lengths, I found that in most of these cases, the 'new' code was a few percent faster. In a couple of cases, the 'old' code was a few percent faster. This was not a result of sampling error, since I could reproduce these test results repeatedly, and even when running a large number of iterations. Both the new and old code were compiled with `-O3 -march=native`. My (unproved) hypothesis is that although the new code appears to only add one more conditional branch, the compiler may emit slightly different code from before (perhaps with different register allocation and so on), and this may cause some cases to run slightly faster and others to run slightly slower. I have not disassembled the old and new binaries to see if an examination of the emitted assembly code would support this hypothesis.

For good UTF-8 strings which are checked repeatedly, the speedup is about 40% even for strings 1-5 bytes in length. For ~100 byte strings, it is ~700%, and for ~10000 byte strings, it is ~80000%.

I tried fuzzing mbstring's `php_mb_check_encoding` function and pcre2lib's `valid_utf` function to see if I could find any cases where their output would be different. (If so, then it would be problematic for both mbstring and pcre to use this same flag.) After running the fuzzer for a couple of minutes, it had tried more than 1 million test cases without finding any where the output was different. Therefore, it appears that mbstring's UTF-8 validation is compatible with PCRE's.

I would like to loop in the pcre extension maintainer to the discussion here, but `EXTENSIONS` only shows Nuno Lopez as maintainer up to 2009, and nobody after that.

FYI @cmb69 @nikic @kamil-tekiela @Girgias

Perhaps @youkidearitai might be interested, since this resulted from a GH issue which he opened...