### PR TITLE
Avoid undefined behavior in Windows ftok(3) emulation

### DIFF
--- a/win32/ftok.c
+++ b/win32/ftok.c
@@ -51,7 +51,7 @@ ftok(const char *pathname, int proj_id)
 		return (key_t)-1;
 	}
 
-	ret = (key_t) ((proj_id & 0xff) << 24 | (st.st_dev & 0xff) << 16 | ((bhfi.nFileIndexLow | (__int64)bhfi.nFileIndexHigh << 32) & 0xffff));
+	ret = (key_t) ((proj_id & 0xff) << 24 | (st.st_dev & 0xff) << 16 | (bhfi.nFileIndexLow & 0xffff));
 
 	CloseHandle(fh);
 	PHP_WIN32_IOUTIL_CLEANUP_W()


### PR DESCRIPTION
`.nFileIndexHigh` is a unsigned 32bit number.  Casting that to `__int64` and shifting left by 32bits triggers undefined behavior if the most significant bit of `.nFileIndexHigh` is set.  We could avoid that by casting to `(__uint64)`, but in that case the whole clause doesn't have an effect anymore, so we drop it altogether.
