### PR TITLE
Do not resolve constants on non-linked class during preloading

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3975,7 +3975,7 @@ static void preload_link(void)
 			if (ce->type == ZEND_INTERNAL_CLASS) {
 				break;
 			}
-			if (!(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
+			if ((ce->ce_flags & ZEND_ACC_LINKED) && !(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED)) {
 				if (!(ce->ce_flags & ZEND_ACC_TRAIT)) { /* don't update traits */
 					CG(in_compilation) = 1; /* prevent autoloading */
 					if (preload_try_resolve_constants(ce)) {

--- a/ext/opcache/tests/gh9968-1.inc
+++ b/ext/opcache/tests/gh9968-1.inc
@@ -1,0 +1,3 @@
+<?php
+
+opcache_compile_file('ext/opcache/tests/gh9968-2.inc');

--- a/ext/opcache/tests/gh9968-2.inc
+++ b/ext/opcache/tests/gh9968-2.inc
@@ -1,0 +1,15 @@
+<?php
+
+class Root1_Constant_Definer
+{
+    const CONSTANT = 'value';
+}
+
+class Root1_Constant_Empty
+{
+}
+
+class Root1_Constant_Referencer extends Root2_Empty_Empty
+{
+    protected $propertyReferencingAnExternalConstant = Root1_Constant_Definer::CONSTANT;
+}

--- a/ext/opcache/tests/gh9968.phpt
+++ b/ext/opcache/tests/gh9968.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-9968: Preload crash on non-linked class
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.preload={PWD}/gh9968-1.inc
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+
+new Root1_Constant_Referencer();
+
+?>
+==DONE==
+--EXPECTF--
+Warning: Can't preload unlinked class Root1_Constant_Referencer: Unknown parent Root2_Empty_Empty in %s on line %d
+
+Fatal error: Uncaught Error: Class "Root1_Constant_Referencer" not found in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
Fixes #9968 