### PR TITLE
Fix a memory leak in tracig JIT when the same closure is called through Closure::call() and natively

### DIFF
--- a/ext/opcache/tests/jit/closure_001.phpt
+++ b/ext/opcache/tests/jit/closure_001.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Closures should be always called with ZEND_ACC_CLOSURE flag set 
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+opcache.protect_memory=1
+opcache.jit_hot_func=2
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+class Foo {
+}
+
+function bar() {
+    return function () {
+        return function () {
+            return function () {
+                return 42;
+            };
+        };
+    };
+}
+
+$foo = new Foo;
+$f = bar();
+
+var_dump($f->call($foo));
+var_dump($f->call($foo));
+var_dump($f());
+?>
+--EXPECT--
+object(Closure)#3 (1) {
+  ["this"]=>
+  object(Foo)#1 (0) {
+  }
+}
+object(Closure)#3 (1) {
+  ["this"]=>
+  object(Foo)#1 (0) {
+  }
+}
+object(Closure)#3 (0) {
+}


### PR DESCRIPTION
Closure::call() makes a temporary copy of original closure function, modifies its scope, resets ZEND_ACC_CLOSURE flag and call it through zend_call_function(). As result the same function may be called with and without ZEND_ACC_CLOSURE flag, that confuses JIT and may lead to memory leak or even worse memory errors.

The patch allocates "fake" closure object and keep ZEND_ACC_CLOSURE flag to always behave in the same way.