### PR TITLE
Fix bug #80669: FPM numeric user fails to set groups

### DIFF
--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -269,6 +269,11 @@ static int fpm_unix_conf_wp(struct fpm_worker_pool_s *wp) /* {{{ */
 		if (wp->config->user && *wp->config->user) {
 			if (strlen(wp->config->user) == strspn(wp->config->user, "0123456789")) {
 				wp->set_uid = strtoul(wp->config->user, 0, 10);
+				pwd = getpwuid(wp->set_uid);
+				if (pwd) {
+					wp->set_gid = pwd->pw_gid;
+					wp->set_user = strdup(pwd->pw_name);
+				}
 			} else {
 				struct passwd *pwd;
 
@@ -392,7 +397,7 @@ int fpm_unix_init_child(struct fpm_worker_pool_s *wp) /* {{{ */
 			}
 		}
 		if (wp->set_uid) {
-			if (0 > initgroups(wp->config->user, wp->set_gid)) {
+			if (0 > initgroups(wp->set_user ? wp->set_user : wp->config->user, wp->set_gid)) {
 				zlog(ZLOG_SYSERROR, "[pool %s] failed to initgroups(%s, %d)", wp->config->name, wp->config->user, wp->set_gid);
 				return -1;
 			}

--- a/sapi/fpm/fpm/fpm_worker_pool.c
+++ b/sapi/fpm/fpm/fpm_worker_pool.c
@@ -34,6 +34,9 @@ void fpm_worker_pool_free(struct fpm_worker_pool_s *wp) /* {{{ */
 	if (wp->user) {
 		free(wp->user);
 	}
+	if (wp->set_user) {
+		free(wp->set_user);
+	}
 	if (wp->home) {
 		free(wp->home);
 	}

--- a/sapi/fpm/fpm/fpm_worker_pool.h
+++ b/sapi/fpm/fpm/fpm_worker_pool.h
@@ -24,6 +24,7 @@ struct fpm_worker_pool_s {
 	enum fpm_address_domain listen_address_domain;
 	int listening_socket;
 	int set_uid, set_gid;								/* config uid and gid */
+	char *set_user;										/* config user name */
 	int socket_uid, socket_gid, socket_mode;
 
 	/* runtime */

--- a/sapi/fpm/tests/bug80669-uid-user-groups.phpt
+++ b/sapi/fpm/tests/bug80669-uid-user-groups.phpt
@@ -1,0 +1,52 @@
+--TEST--
+FPM: Process user setting ignored when FPM is not running as root
+--SKIPIF--
+<?php
+include "skipif.inc";
+FPM\Tester::skipIfNotRoot();
+FPM\Tester::skipIfUserDoesNotExist('www-data');
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$pw = posix_getpwnam('www-data');
+$uid = $pw['uid'];
+$gid = $pw['gid'];
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+user = $uid
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+EOT;
+
+$code = <<<EOT
+<?php
+echo posix_getgid();
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectBody((string) $gid);
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -71,11 +71,11 @@ class Response
             $body = implode("\n", $body);
         }
 
-        if (
-            $this->checkIfValid() &&
-            $this->checkDefaultHeaders($contentType) &&
-            $body !== $this->rawBody
-        ) {
+        if (!$this->checkIfValid()) {
+            $this->error('Response is invalid');
+        } elseif (!$this->checkDefaultHeaders($contentType)) {
+            $this->error('Response default headers not found');
+        } elseif ($body !== $this->rawBody) {
             if ($multiLine) {
                 $this->error(
                     "==> The expected body:\n$body\n" .

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -294,7 +294,7 @@ class Tester
      */
     static public function skipIfNotRoot()
     {
-        if (getmyuid() != 0) {
+        if (exec('whoami') !== 'root') {
             die('skip not running as root');
         }
     }
@@ -304,7 +304,7 @@ class Tester
      */
     static public function skipIfRoot()
     {
-        if (getmyuid() == 0) {
+        if (exec('whoami') === 'root') {
             die('skip running as root');
         }
     }
@@ -316,6 +316,17 @@ class Tester
     {
         if ( ! extension_loaded('posix')) {
             die('skip posix extension not loaded');
+        }
+    }
+
+    /**
+     * Skip if posix extension not loaded.
+     */
+    static public function skipIfUserDoesNotExist($userName)
+    {
+        self::skipIfPosixNotLoaded();
+        if (posix_getpwnam($userName) === false) {
+            die("skip user $userName does not exist");
         }
     }
 


### PR DESCRIPTION
This PR fixes issue with not setting groups when user is set using UID. It basically makes it work in the same way like setting user name if the user exists during initialization. In addition it also sets the group ID if `group` is not specified which currently defaults to 0 (root) and works only if FPM is started with `--allow-to-run-as-root`. Even though the current behaviour is not desirable, there is small chance that someone could rely on this. For that reason it seems more reasonable to merge this bug fix only to PHP-8.2.