### PR TITLE
Fix #81742: open_basedir bypass in SQLite3 by using file URI

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2040,14 +2040,10 @@ static int php_sqlite3_authorizer(void *autharg, int action, const char *arg1, c
 			if (memcmp(arg1, ":memory:", sizeof(":memory:")) && *arg1) {
 				if (strncmp(arg1, "file:", 5) == 0) {
 					/* starts with "file:" */
-					if (!arg1[5]) {
+					if (PG(open_basedir) && *PG(open_basedir)) {
 						return SQLITE_DENY;
 					}
-					if (php_check_open_basedir(arg1 + 5)) {
-						return SQLITE_DENY;
-					}
-				}
-				if (php_check_open_basedir(arg1)) {
+				} else if (php_check_open_basedir(arg1)) {
 					return SQLITE_DENY;
 				}
 			}

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2040,9 +2040,7 @@ static int php_sqlite3_authorizer(void *autharg, int action, const char *arg1, c
 			if (memcmp(arg1, ":memory:", sizeof(":memory:")) && *arg1) {
 				if (strncmp(arg1, "file:", 5) == 0) {
 					/* starts with "file:" */
-					if (PG(open_basedir) && *PG(open_basedir)) {
-						return SQLITE_DENY;
-					}
+					return SQLITE_DENY;
 				} else if (php_check_open_basedir(arg1)) {
 					return SQLITE_DENY;
 				}

--- a/ext/sqlite3/tests/bug81742.phpt
+++ b/ext/sqlite3/tests/bug81742.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Bug #81742 (open_basedir bypass in SQLite3 by using url encoded file)
+--EXTENSIONS--
+sqlite3
+--INI--
+open_basedir=.
+--FILE--
+<?php
+$db = new SQLite3(':memory:');
+$db->query("ATTACH 'file:..%2ffoo.php' as db2;");
+?>
+--EXPECTF--
+Warning: SQLite3::query(): not authorized in %s on line %d


### PR DESCRIPTION
A previous fix[1] was not sufficient to catch all potential file URIs, because the patch did not cater to URL encoding.  Properly parsing and decoding the URI may yield a different result than the handling of SQLite3, so we play it safe, and reject any file URIs if open_basedir is configured.

[1] <https://bugs.php.net/bug.php?id=77967>

----

Obviously, this can break existing code using (maybe even hard-coded) file URIs. As such, we should consider to postpone this fix to PHP-8.2.

cc @bohwaz 