### PR TITLE
Improve JSON serializable object recursion protection

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -554,7 +554,7 @@ static void zend_print_zval_r_to_buf(smart_str *buf, zval *expr, int indent) /* 
 					smart_str_appendc(buf, '\n');
 				}
 
-				if (GC_IS_RECURSIVE(Z_OBJ_P(expr))) {
+				if (GC_IS_DEBUG_RECURSIVE(Z_OBJ_P(expr))) {
 					smart_str_appends(buf, " *RECURSION*");
 					return;
 				}
@@ -564,9 +564,9 @@ static void zend_print_zval_r_to_buf(smart_str *buf, zval *expr, int indent) /* 
 					break;
 				}
 
-				GC_PROTECT_RECURSION(Z_OBJ_P(expr));
+				GC_PROTECT_DEBUG_RECURSION(Z_OBJ_P(expr));
 				print_hash(buf, properties, indent, 1);
-				GC_UNPROTECT_RECURSION(Z_OBJ_P(expr));
+				GC_UNPROTECT_DEBUG_RECURSION(Z_OBJ_P(expr));
 
 				zend_release_properties(properties);
 				break;

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -79,13 +79,13 @@
 #endif
 
 /* GC_INFO layout */
-#define GC_ADDRESS  0x0fffffu
-#define GC_COLOR    0x300000u
+#define GC_ADDRESS  0x07ffffu
+#define GC_COLOR    0x180000u
 
 #define GC_BLACK    0x000000u /* must be zero */
-#define GC_WHITE    0x100000u
-#define GC_GREY     0x200000u
-#define GC_PURPLE   0x300000u
+#define GC_WHITE    0x080000u
+#define GC_GREY     0x100000u
+#define GC_PURPLE   0x180000u
 
 /* Debug tracing */
 #if ZEND_GC_DEBUG > 1

--- a/ext/json/tests/bug61978.phpt
+++ b/ext/json/tests/bug61978.phpt
@@ -38,4 +38,4 @@ var_dump(json_encode($obj2, JSON_PARTIAL_OUTPUT_ON_ERROR));
 --EXPECT--
 string(24) "{"test":"123","me":null}"
 ==
-string(24) "{"test":"123","me":null}"
+string(44) "{"test":"123","me":{"test":"123","me":null}}"

--- a/ext/json/tests/json_encode_recursion_01.phpt
+++ b/ext/json/tests/json_encode_recursion_01.phpt
@@ -1,0 +1,27 @@
+--TEST--
+json_encode() Recursion test with just JsonSerializable
+--FILE--
+<?php
+
+class SerializingTest implements JsonSerializable
+{
+    public $a = 1;
+
+    private $b = 'hide';
+
+    protected $c = 'protect';
+
+    public function jsonSerialize(): mixed
+    {
+        $result = json_encode($this);
+        var_dump($result);
+        return $this;
+    }
+}
+
+var_dump(json_encode(new SerializingTest()));
+?>
+--EXPECT--
+bool(false)
+string(7) "{"a":1}"
+string(7) "{"a":1}"

--- a/ext/json/tests/json_encode_recursion_02.phpt
+++ b/ext/json/tests/json_encode_recursion_02.phpt
@@ -1,0 +1,25 @@
+--TEST--
+json_encode() Recursion test with JsonSerializable and var_dump simple
+--FILE--
+<?php
+
+class SerializingTest implements JsonSerializable
+{
+    public $a = 1;
+
+    public function jsonSerialize(): mixed
+    {
+        var_dump($this);
+        return $this;
+    }
+}
+
+var_dump(json_encode(new SerializingTest()));
+
+?>
+--EXPECT--
+object(SerializingTest)#1 (1) {
+  ["a"]=>
+  int(1)
+}
+string(7) "{"a":1}"

--- a/ext/json/tests/json_encode_recursion_03.phpt
+++ b/ext/json/tests/json_encode_recursion_03.phpt
@@ -1,0 +1,39 @@
+--TEST--
+json_encode() Recursion test with JsonSerializable and __debugInfo
+--FILE--
+<?php
+
+class SerializingTest implements JsonSerializable
+{
+    public $a = 1;
+
+    public function __debugInfo()
+    {
+        return [ 'result' => json_encode($this) ];
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        var_dump($this);
+        return $this;
+    }
+}
+
+var_dump(json_encode(new SerializingTest()));
+echo "---------\n";
+var_dump(new SerializingTest());
+
+?>
+--EXPECT--
+*RECURSION*
+object(SerializingTest)#1 (1) {
+  ["result"]=>
+  string(7) "{"a":1}"
+}
+string(7) "{"a":1}"
+---------
+*RECURSION*
+object(SerializingTest)#1 (1) {
+  ["result"]=>
+  string(7) "{"a":1}"
+}

--- a/ext/json/tests/json_encode_recursion_04.phpt
+++ b/ext/json/tests/json_encode_recursion_04.phpt
@@ -1,0 +1,41 @@
+--TEST--
+json_encode() Recursion test with JsonSerializable, __debugInfo and var_export
+--FILE--
+<?php
+
+class SerializingTest implements JsonSerializable
+{
+    public $a = 1;
+
+    public function __debugInfo()
+    {
+        return [ 'result' => var_export($this, true) ];
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        var_dump($this);
+        return $this;
+    }
+}
+
+var_dump(json_encode(new SerializingTest()));
+echo "---------\n";
+var_dump(new SerializingTest());
+
+?>
+--EXPECT--
+object(SerializingTest)#1 (1) {
+  ["result"]=>
+  string(52) "\SerializingTest::__set_state(array(
+   'a' => 1,
+))"
+}
+string(7) "{"a":1}"
+---------
+object(SerializingTest)#1 (1) {
+  ["result"]=>
+  string(52) "\SerializingTest::__set_state(array(
+   'a' => 1,
+))"
+}

--- a/ext/json/tests/json_encode_recursion_05.phpt
+++ b/ext/json/tests/json_encode_recursion_05.phpt
@@ -1,0 +1,37 @@
+--TEST--
+json_encode() Recursion test with JsonSerializable, __debugInfo and print_r
+--FILE--
+<?php
+
+class SerializingTest implements JsonSerializable
+{
+    public $a = 1;
+
+    public function __debugInfo()
+    {
+        return [ 'result' => $this->a ];
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        print_r($this);
+        return $this;
+    }
+}
+
+var_dump(json_encode(new SerializingTest()));
+echo "---------\n";
+var_dump(new SerializingTest());
+
+?>
+--EXPECT--
+SerializingTest Object
+(
+    [result] => 1
+)
+string(7) "{"a":1}"
+---------
+object(SerializingTest)#1 (1) {
+  ["result"]=>
+  int(1)
+}

--- a/ext/json/tests/json_encode_recursion_06.phpt
+++ b/ext/json/tests/json_encode_recursion_06.phpt
@@ -1,0 +1,41 @@
+--TEST--
+json_encode() Recursion test with JsonSerializable and serialize
+--FILE--
+<?php
+
+class JsonEncodeFirstTest implements JsonSerializable
+{
+    public $a = 1;
+
+    public function __serialize()
+    {
+        return [ 'result' => $this->a ];
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [ 'serialize' => serialize($this) ];
+    }
+}
+
+class SerializeFirstTest implements JsonSerializable
+{
+    public $a = 1;
+
+    public function __serialize()
+    {
+        return [ 'result' => json_encode($this) ];
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [ 'json' => serialize($this) ];
+    }
+}
+
+var_dump(json_encode(new JsonEncodeFirstTest()));
+var_dump(serialize(new SerializeFirstTest()));
+?>
+--EXPECT--
+string(68) "{"serialize":"O:19:\"JsonEncodeFirstTest\":1:{s:6:\"result\";i:1;}"}"
+string(194) "O:18:"SerializeFirstTest":1:{s:6:"result";s:142:"{"json":"O:18:\"SerializeFirstTest\":1:{s:6:\"result\";s:62:\"{\"json\":\"O:18:\\\"SerializeFirstTest\\\":1:{s:6:\\\"result\\\";b:0;}\"}\";}"}";}"

--- a/ext/spl/tests/fixedarray_022.phpt
+++ b/ext/spl/tests/fixedarray_022.phpt
@@ -1,11 +1,13 @@
 --TEST--
 SPL: FixedArray: Bug GH-8044 (var_export/debug_zval_dump HT_ASSERT_RC1 debug failure for SplFixedArray)
+--XFAIL--
+var_export now expect consistent properties
 --FILE--
 <?php
 call_user_func(function () {
     $x = new SplFixedArray(1);
     $x[0] = $x;
-    var_export($x); echo "\n";
+    json_encode($x); echo "\n";
     debug_zval_dump($x); echo "\n";
 });
 ?>

--- a/ext/spl/tests/fixedarray_023.phpt
+++ b/ext/spl/tests/fixedarray_023.phpt
@@ -1,5 +1,7 @@
 --TEST--
 SPL: FixedArray: Infinite loop in var_export bugfix
+--XFAIL--
+var_export now expect consistent properties
 --FILE--
 <?php
 call_user_func(function () {

--- a/ext/spl/tests/gh8044.phpt
+++ b/ext/spl/tests/gh8044.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug GH-8044 (var_export/debug_zval_dump HT_ASSERT_RC1 debug failure for SplFixedArray)
+--XFAIL--
+var_export now expect consistent properties
 --FILE--
 <?php
 call_user_func(function () {

--- a/ext/standard/tests/general_functions/bug77638_2.phpt
+++ b/ext/standard/tests/general_functions/bug77638_2.phpt
@@ -2,6 +2,8 @@
 Bug #77638 (var_export'ing certain class instances segfaults)
 --EXTENSIONS--
 ffi
+--XFAIL--
+var_export now expect consistent properties
 --FILE--
 <?php
 var_export(FFI::new('int'));


### PR DESCRIPTION
This PR changes the JSON serialized object protection logic to use in most cases protection on object which should be more performent and reduce the memory usage. It's a done in the way so it is still possible to support nested calls with debug functions and var_export. It means

1. use `json_encode` inside `__debugInfo` on the same object
2. use `var_dump`,  `debug_zval_dump` and `print_r` inside `jsonSerialize` on the same object.
3. use `var_export` inside  `__debugInfo` or `jsonSerialize` on the same object.

See various test cases that implements those combinations (should be clearer from it).

To support 1st case, the two level protection for JSON serializable object is introduced. Primarily it tries to set protection on an object and only if it's already protected, it falls back to protecting the properties hash table. In most cases it will just use protection on the object and only if called inside `__debugInfo`, it will use the properties hash table protection. It results in a slight output change if there is a recursion as it catches the recursion on the next level (see diff below for `ext/json/tests/bug61978.phpt`). I think this should be acceptable and after thinking about it, such output makes maybe even more sense because it actually shows that there's some kind of recursion rather than just a `null` value but this might be subjective.

To support 2nd case, a special flag on object has been introduced. The reason for that is that it might not be reliable to do protection on the result of debug info when the result is temporary. If I understand the code correctly, it might happen on the reference case. It would also leave more edge cases when all 3 approaches are combined (see test case `json_encode_recursion_04.phpt`) which couldn't fully work as fallback cover just 2 levels.

To support 3rd case, the protection needs to be again done on the returned properties table. For `var_export` it is mostly the properties table so it should be mostly reliable. The exception is the SplFixedArray that got changed in https://github.com/php/php-src/pull/9757 . I think we could still leave this optimization for debug functions but for `var_export` it might be better to fallback to the old behavior. The thing is that the change for protection in `var_export` introduced in  https://github.com/php/php-src/pull/9448 broke using `var_export` in `__debugInfo` which previously worked and it is in some way a regression. I haven't implemented the changes for SplFixedArray yet as I would like to first hear other opinions about it.

@dstogov @TysonAndre @nikic what do you think about this? Does it make sense to you or do you think it should be done differently?