### PR TITLE
Fix GH-9971: Incorrect NUMERIC value returned from PDO_Firebird

### DIFF
--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -382,6 +382,8 @@ static int firebird_stmt_get_col(
 				case SQL_INT64:
 					n = *(ISC_INT64*)var->sqldata;
 					break;
+				case SQL_DOUBLE:
+					break;
 				EMPTY_SWITCH_DEFAULT_CASE()
 			}
 


### PR DESCRIPTION
Dialect 1 databases store and transfer `NUMERIC(15,2)` values as doubles, which we need to cater to in `firebird_stmt_get_col()` to avoid `ZEND_ASSUME(0)` to ever be triggered, since that may result in undefined behavior.

Since adding a regression test would require to create a dialect 1 database, we go without it.

---

An alternative fix would be to drop the `EMPTY_SWITCH_DEFAULT_CASE()` altogether, and [fix the unitialized var warning](https://github.com/php/php-src/commit/cc23fcfca6f67e61eb123b87ea886f7aa9e22d45) by initializing `n` to `0` instead.