### PR TITLE
Fix bug #77106: Missing separator in FPM FastCGI errors

### DIFF
--- a/sapi/fpm/tests/bug77106-fcgi-missing-nl.phpt
+++ b/sapi/fpm/tests/bug77106-fcgi-missing-nl.phpt
@@ -1,0 +1,46 @@
+--TEST--
+FPM: bug77106 - Missing new lines in FCGI error stream
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+php_admin_flag[log_errors] = 1
+EOT;
+
+$code = <<<EOT
+<?php
+echo \$a;
+echo \$a;
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectErrorPattern(
+    '/Undefined variable \$a in .+ on line \d+; PHP message: PHP Warning:/'
+);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -42,6 +42,11 @@ class Response
     private $expectInvalid;
 
     /**
+     * @var bool
+     */
+    private bool $debugOutputted = false;
+
+    /**
      * @param string|array|null $data
      * @param bool              $expectInvalid
      */
@@ -71,9 +76,9 @@ class Response
             $body = implode("\n", $body);
         }
 
-        if (!$this->checkIfValid()) {
+        if ( ! $this->checkIfValid()) {
             $this->error('Response is invalid');
-        } elseif (!$this->checkDefaultHeaders($contentType)) {
+        } elseif ( ! $this->checkDefaultHeaders($contentType)) {
             $this->error('Response default headers not found');
         } elseif ($body !== $this->rawBody) {
             if ($multiLine) {
@@ -135,6 +140,26 @@ class Response
     }
 
     /**
+     * Expect error pattern in the response.
+     *
+     * @param string $errorMessagePattern Expected error message RegExp patter.
+     *
+     * @return Response
+     */
+    public function expectErrorPattern(string $errorMessagePattern): Response
+    {
+        $errorData = $this->getErrorData();
+        if (preg_match($errorMessagePattern, $errorData) === 0) {
+            $this->error(
+                "The expected error pattern $errorMessagePattern does not match the returned error '$errorData'"
+            );
+            $this->debugOutput();
+        }
+
+        return $this;
+    }
+
+    /**
      * Expect no error in the response.
      *
      * @return Response
@@ -187,6 +212,8 @@ class Response
         echo "----------------- ERR -----------------\n";
         echo $this->data['err_response'] . "\n";
         echo "---------------------------------------\n\n";
+
+        $this->debugOutputted = true;
     }
 
     /**
@@ -331,8 +358,11 @@ class Response
      *
      * @return bool
      */
-    private function error($message): bool
+    private function error(string $message): bool
     {
+        if ( ! $this->debugOutputted) {
+            $this->debugOutput();
+        }
         echo "ERROR: $message\n";
 
         return false;


### PR DESCRIPTION
This PR separate FastCGI error messages in a more readable way.