### PR TITLE
ext/json: add php_json_scanner_defs.h as make target

### DIFF
--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -5,7 +5,7 @@
 $(builddir)/zend_language_scanner.lo: $(srcdir)/zend_language_parser.h
 $(builddir)/zend_ini_scanner.lo: $(srcdir)/zend_ini_parser.h
 
-$(srcdir)/zend_language_scanner.c: $(srcdir)/zend_language_scanner.l
+$(srcdir)/zend_language_scanner.c $(srcdir)/zend_language_scanner_defs.h: $(srcdir)/zend_language_scanner.l
 	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_language_scanner_defs.h -oZend/zend_language_scanner.c Zend/zend_language_scanner.l)
 
 $(srcdir)/zend_language_parser.h: $(srcdir)/zend_language_parser.c

--- a/ext/json/Makefile.frag
+++ b/ext/json/Makefile.frag
@@ -1,5 +1,5 @@
-$(srcdir)/json_scanner.c: $(srcdir)/json_scanner.re
+$(srcdir)/json_scanner.c $(srcdir)/php_json_scanner_defs.h: $(srcdir)/json_scanner.re $(srcdir)/json_parser.tab.h
 	@$(RE2C) $(RE2C_FLAGS) -t $(srcdir)/php_json_scanner_defs.h --no-generation-date -bci -o $@ $(srcdir)/json_scanner.re
 
-$(srcdir)/json_parser.tab.c: $(srcdir)/json_parser.y
+$(srcdir)/json_parser.tab.c $(srcdir)/json_parser.tab.h: $(srcdir)/json_parser.y
 	@$(YACC) $(YFLAGS) --defines -l $(srcdir)/json_parser.y -o $@

--- a/ext/json/Makefile.frag.w32
+++ b/ext/json/Makefile.frag.w32
@@ -1,5 +1,5 @@
-ext\json\json_scanner.c: ext\json\json_scanner.re
+ext\json\json_scanner.c ext\json\php_json_scanner_defs.h: ext\json\json_scanner.re ext\json\json_parser.tab.h
 	$(RE2C) $(RE2C_FLAGS) -t ext/json/php_json_scanner_defs.h --no-generation-date -bci -o ext/json/json_scanner.c ext/json/json_scanner.re
 
-ext\json\json_parser.tab.c: ext\json\json_parser.y
+ext\json\json_parser.tab.c ext\json\json_parser.tab.h: ext\json\json_parser.y
 	$(BISON) --defines -l ext/json/json_parser.y -o ext/json/json_parser.tab.c

--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -59,14 +59,17 @@ all: generated_files $(EXT_TARGETS) $(PECL_TARGETS) $(SAPI_TARGETS)
 build_dirs: $(BUILD_DIR) $(BUILD_DIRS_SUB) $(BUILD_DIR_DEV)
 
 !if $(RE2C) == ""
-generated_files: build_dirs Zend\zend_ini_parser.c \
+generated_files: build_dirs \
+	Zend\zend_ini_parser.c Zend\zend_ini_parser.h \
 	Zend\zend_language_parser.c \
 	sapi\phpdbg\phpdbg_parser.c \
 	$(PHPDEF) $(MCFILE)
 !else
-generated_files: build_dirs Zend\zend_ini_parser.c \
-	Zend\zend_language_parser.c Zend\zend_ini_scanner.c \
-	Zend\zend_language_scanner.c \
+generated_files: build_dirs \
+	Zend\zend_ini_parser.c Zend\zend_ini_parser.h \
+	Zend\zend_language_parser.c \
+	Zend\zend_ini_scanner.c Zend\zend_ini_scanner_defs.h \
+	Zend\zend_language_scanner.c Zend\zend_language_scanner_defs.h \
 	sapi\phpdbg\phpdbg_parser.c sapi\phpdbg\phpdbg_lexer.c \
 	$(PHPDEF) $(MCFILE)
 !endif
@@ -87,10 +90,10 @@ sapi\phpdbg\phpdbg_parser.c sapi\phpdbg\phpdbg_parser.h: sapi\phpdbg\phpdbg_pars
 	$(BISON) --output=sapi/phpdbg/phpdbg_parser.c -v -d sapi/phpdbg/phpdbg_parser.y
 
 !if $(RE2C) != ""
-Zend\zend_ini_scanner.c: Zend\zend_ini_scanner.l
+Zend\zend_ini_scanner.c Zend\zend_ini_scanner_defs.h: Zend\zend_ini_scanner.l
 	$(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l
 
-Zend\zend_language_scanner.c: Zend\zend_language_scanner.l
+Zend\zend_language_scanner.c Zend\zend_language_scanner_defs.h: Zend\zend_language_scanner.l
 	$(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_language_scanner_defs.h -oZend/zend_language_scanner.c Zend/zend_language_scanner.l
 
 sapi\phpdbg\phpdbg_lexer.c: sapi\phpdbg\phpdbg_lexer.l


### PR DESCRIPTION
To prevent build failures like:

make: *** No rule to make target '/code/master/ext/json/php_json_scanner_defs.h', needed by 'ext/json/json_scanner.lo'.  Stop.

Example where this occurred is the 8.1 and master branches here: https://buildbot.mariadb.org/#/builders/237/builds/4280