### PR TITLE
Fix GH-10011 (Trampoline autoloader will get reregistered and cannot …

### DIFF
--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -402,6 +402,16 @@ static autoload_func_info *autoload_func_info_from_fci(
 
 static bool autoload_func_info_equals(
 		const autoload_func_info *alfi1, const autoload_func_info *alfi2) {
+	if (UNEXPECTED(
+		(alfi1->func_ptr->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) &&
+		(alfi2->func_ptr->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)
+	)) {
+		return alfi1->obj == alfi2->obj
+			&& alfi1->ce == alfi2->ce
+			&& alfi1->closure == alfi2->closure
+			&& zend_string_equals(alfi1->func_ptr->common.function_name, alfi2->func_ptr->common.function_name)
+		;
+	}
 	return alfi1->func_ptr == alfi2->func_ptr
 		&& alfi1->obj == alfi2->obj
 		&& alfi1->ce == alfi2->ce
@@ -578,6 +588,13 @@ PHP_FUNCTION(spl_autoload_unregister)
 		/* Don't destroy the hash table, as we might be iterating over it right now. */
 		zend_hash_clean(spl_autoload_functions);
 		RETURN_TRUE;
+	}
+
+	if (!fcc.function_handler) {
+		/* Call trampoline has been cleared by zpp. Refetch it, because we want to deal
+		 * with it outselves. It is important that it is not refetched on every call,
+		 * because calls may occur from different scopes. */
+		zend_is_callable_ex(&fci.function_name, NULL, 0, NULL, &fcc, NULL);
 	}
 
 	autoload_func_info *alfi = autoload_func_info_from_fci(&fci, &fcc);

--- a/ext/spl/tests/gh10011.phpt
+++ b/ext/spl/tests/gh10011.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Bug GH-10011 (Trampoline autoloader will get reregistered and cannot be unregistered)
+--FILE--
+<?php
+
+class TrampolineTest {
+    public function __call(string $name, array $arguments) {
+        echo 'Trampoline for ', $name, PHP_EOL;
+    }
+}
+$o = new TrampolineTest();
+$callback1 = [$o, 'trampoline1'];
+$callback2 = [$o, 'trampoline2'];
+
+spl_autoload_register($callback1);
+spl_autoload_register($callback2);
+spl_autoload_register($callback1); // 2nd call ignored
+
+var_dump(spl_autoload_functions());
+
+var_dump(class_exists("TestClass", true));
+
+echo "Unregister trampoline:\n";
+var_dump(spl_autoload_unregister($callback1));
+var_dump(spl_autoload_unregister($callback1));
+var_dump(spl_autoload_unregister($callback2));
+
+var_dump(spl_autoload_functions());
+var_dump(class_exists("TestClass", true));
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    object(TrampolineTest)#1 (0) {
+    }
+    [1]=>
+    string(11) "trampoline1"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    object(TrampolineTest)#1 (0) {
+    }
+    [1]=>
+    string(11) "trampoline2"
+  }
+}
+Trampoline for trampoline1
+Trampoline for trampoline2
+bool(false)
+Unregister trampoline:
+bool(true)
+bool(false)
+bool(true)
+array(0) {
+}
+bool(false)


### PR DESCRIPTION
…be unregistered)

There are two issues to resolve:
 1. The FCC is not refetch when trying to unregister a trampoline
 2. Comparing the function pointer of trampolines is meaningless as they are reallocated, thus we need to compare the name of the function

Found while working on GH-8294