### PR TITLE
ext/mysqli tests "using password" optional in error messages

### DIFF
--- a/ext/mysqli/tests/mysqli_connect_oo.phpt
+++ b/ext/mysqli/tests/mysqli_connect_oo.phpt
@@ -149,9 +149,9 @@ require_once('skipifconnectfailure.inc');
     print "done!";
 ?>
 --EXPECTF--
-Warning: mysqli::__construct(): (%s/%d): Access denied for user '%sunknown%s'@'%s' (using password: %s) in %s on line %d
+Warning: mysqli::__construct(): (%s/%d): Access denied for user '%sunknown%s'@'%s' %r(\(using password: \w+\) ){0,1}%rin %s on line %d
 mysqli object is not fully initialized
 mysqli object is not fully initialized
 ... and now Exceptions
-Access denied for user '%s'@'%s' (using password: %s)
+Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
 done!

--- a/ext/mysqli/tests/mysqli_real_connect.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect.phpt
@@ -153,7 +153,7 @@ mysqli.allow_local_infile=1
 	require_once("clean_table.inc");
 ?>
 --EXPECTF--
-Warning: mysqli_real_connect(): (%s/%d): Access denied for user '%s'@'%s' (using password: YES) in %s on line %d
+Warning: mysqli_real_connect(): (%s/%d): Access denied for user '%s'@'%s' %r(\(using password: \w+\) ){0,1}%rin %s on line %d
 object(mysqli)#%d (%d) {
   ["client_info"]=>
   string(%d) "%s"

--- a/ext/mysqli/tests/mysqli_real_connect_pconn.phpt
+++ b/ext/mysqli/tests/mysqli_real_connect_pconn.phpt
@@ -152,5 +152,5 @@ mysqli.max_persistent=10
 	require_once("clean_table.inc");
 ?>
 --EXPECTF--
-Warning: mysqli_real_connect(): (%s/%d): Access denied for user '%s'@'%s' (using password: YES) in %s on line %d
+Warning: mysqli_real_connect(): (%s/%d): Access denied for user '%s'@'%s' %r(\(using password: \w+\) ){0,1}%rin %s on line %d
 done!

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -339,6 +339,6 @@ Warning: mysqli_stmt_attr_set(): (%s/%d): Not implemented in %s on line %d
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_stmt_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
-[013] Access denied for user '%s'@'%s' (using password: YES)
-[016] Access denied for user '%s'@'%s' (using password: YES)
+[013] Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
+[016] Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
 done!


### PR DESCRIPTION
In MariaDB the "using password" may not exist in the error message

e.g:
https://buildbot.mariadb.org/#/builders/237/builds/4279/steps/5/logs/stdio