### PR TITLE
Remove _zend_ast_decl->lex_pos

### DIFF
--- a/Zend/zend_ast.c
+++ b/Zend/zend_ast.c
@@ -121,7 +121,6 @@ ZEND_API zend_ast *zend_ast_create_decl(
 	ast->start_lineno = start_lineno;
 	ast->end_lineno = CG(zend_lineno);
 	ast->flags = flags;
-	ast->lex_pos = LANG_SCNG(yy_text);
 	ast->doc_comment = doc_comment;
 	ast->name = name;
 	ast->child[0] = child0;

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -208,7 +208,6 @@ typedef struct _zend_ast_decl {
 	uint32_t start_lineno;
 	uint32_t end_lineno;
 	uint32_t flags;
-	unsigned char *lex_pos;
 	zend_string *doc_comment;
 	zend_string *name;
 	zend_ast *child[5];

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -1250,7 +1250,6 @@ inline_function:
 		T_DOUBLE_ARROW backup_fn_flags backup_lex_pos expr backup_fn_flags
 			{ $$ = zend_ast_create_decl(ZEND_AST_ARROW_FUNC, $2 | $12, $1, $3,
 				  zend_string_init("{closure}", sizeof("{closure}") - 1, 0), $5, NULL, $11, $7, NULL);
-				  ((zend_ast_decl *) $$)->lex_pos = $10;
 				  CG(extra_fn_flags) = $9; }
 ;
 


### PR DESCRIPTION
This struct member was only written to, but never read.
On Linux x86-64, this shrinks `_zend_ast_decl ` from 80 bytes to 72 bytes.