### PR TITLE
Set ce->parent_name to NULL after it's released

### DIFF
--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -1470,6 +1470,7 @@ ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *par
 
 	if (ce->parent_name) {
 		zend_string_release_ex(ce->parent_name, 0);
+		ce->parent_name = NULL;
 	}
 	ce->parent = parent_ce;
 	ce->default_object_handlers = parent_ce->default_object_handlers;


### PR DESCRIPTION
Make it more robust.

I have not read all relevant codes so I searched for similar codes.
This seems to be common:

```
static zend_always_inline void smart_str_free_ex(smart_str *str, bool persistent) {
	if (str->s) {
		zend_string_release_ex(str->s, persistent);
		str->s = NULL;
	}
	str->a = 0;
}
```