### PR TITLE
Drop superfluous check for imap_stream

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -1420,7 +1420,7 @@ PHP_FUNCTION(imap_check)
 		RETURN_FALSE;
 	}
 
-	if (imap_conn_struct->imap_stream && imap_conn_struct->imap_stream->mailbox) {
+	if (imap_conn_struct->imap_stream->mailbox) {
 		rfc822_date(date);
 		object_init(return_value);
 		add_property_string(return_value, "Date", date);


### PR DESCRIPTION
`GET_IMAP_STREAM` already checks whether `.imap_stream` is `NULL`, and bails out in that case.