### PR TITLE
imagesavealpha(…, false) should not save alpha channel

### DIFF
--- a/ext/gd/libgd/gd_avif.c
+++ b/ext/gd/libgd/gd_avif.c
@@ -528,6 +528,9 @@ void gdImageAvifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, int speed)
 	avifIm->matrixCoefficients = lossless ? AVIF_MATRIX_COEFFICIENTS_IDENTITY : AVIF_MATRIX_COEFFICIENTS_BT709;
 
 	avifRGBImageSetDefaults(&rgb, avifIm);
+	if (!im->saveAlphaFlag) {
+		rgb.format = AVIF_RGB_FORMAT_RGB;
+	}
 	// this allocates memory, and sets rgb.rowBytes and rgb.pixels.
 	avifRGBImageAllocatePixels(&rgb);
 
@@ -542,7 +545,9 @@ void gdImageAvifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, int speed)
 			*(p++) = gdTrueColorGetRed(val);
 			*(p++) = gdTrueColorGetGreen(val);
 			*(p++) = gdTrueColorGetBlue(val);
-			*(p++) = alpha7BitTo8Bit(gdTrueColorGetAlpha(val));
+			if (im->saveAlphaFlag) {
+				*(p++) = alpha7BitTo8Bit(gdTrueColorGetAlpha(val));
+			}
 		}
 	}
 

--- a/ext/gd/tests/imagesavealpha_avif.phpt
+++ b/ext/gd/tests/imagesavealpha_avif.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Testing imagesavealpha() with AVIF
+--EXTENSIONS--
+gd
+--SKIPIF--
+<?php
+$support = gd_info();
+if (!isset($support['AVIF Support']) || $support['AVIF Support'] === false) {
+    die("skip AVIF support not available");
+}
+?>
+--FILE--
+<?php
+$filename = __DIR__ . "/imagesavealpha_avif.avif";
+$im = imagecreatetruecolor(8, 8);
+imagealphablending($im, false);
+imagefilledrectangle($im, 0, 0, 7, 7, 0x7f000000);
+
+echo "without alpha\n";
+imagesavealpha($im, false);
+imageavif($im, $filename, 100); // lossless
+$im1 = imagecreatefromavif($filename);
+checkColors($im1, 0x000000);
+imagedestroy($im1);
+
+echo "with alpha\n";
+imagesavealpha($im, true);
+imageavif($im, $filename, 100); // lossless
+$im1 = imagecreatefromavif($filename);
+checkColors($im1, 0x7f000000);
+imagedestroy($im1);
+
+function checkColors(GdImage $im, int $expected) {
+    for ($i = 0; $i < 8; $i++) {
+        for ($j = 0; $j < 8; $j++) {
+            $actual = imagecolorat($im, $i, $j);
+            if ($actual !== $expected) {
+                echo "($i, $j) is $actual, but $expected expected\n";
+            }
+        }
+    }
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/imagesavealpha_avif.avif");
+?>
+--EXPECT--
+without alpha
+with alpha

--- a/ext/gd/tests/imagesavealpha_png.phpt
+++ b/ext/gd/tests/imagesavealpha_png.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Testing imagesavealpha() with PNG
+--EXTENSIONS--
+gd
+--SKIPIF--
+<?php
+$support = gd_info();
+if (!isset($support['PNG Support']) || $support['PNG Support'] === false) {
+    die("skip PNG support not available");
+}
+?>
+--FILE--
+<?php
+$filename = __DIR__ . "/imagesavealpha_png.png";
+$im = imagecreatetruecolor(8, 8);
+imagealphablending($im, false);
+imagefilledrectangle($im, 0, 0, 7, 7, 0x7f000000);
+
+echo "without alpha\n";
+imagesavealpha($im, false);
+imagepng($im, $filename);
+$im1 = imagecreatefrompng($filename);
+checkColors($im1, 0x000000);
+imagedestroy($im1);
+
+echo "with alpha\n";
+imagesavealpha($im, true);
+imagepng($im, $filename);
+$im1 = imagecreatefrompng($filename);
+checkColors($im1, 0x7f000000);
+imagedestroy($im1);
+
+function checkColors(GdImage $im, int $expected) {
+    for ($i = 0; $i < 8; $i++) {
+        for ($j = 0; $j < 8; $j++) {
+            $actual = imagecolorat($im, $i, $j);
+            if ($actual !== $expected) {
+                echo "($i, $j) is $actual, but $expected expected\n";
+            }
+        }
+    }
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/imagesavealpha_png.png");
+?>
+--EXPECT--
+without alpha
+with alpha

--- a/ext/gd/tests/imagesavealpha_webp.phpt
+++ b/ext/gd/tests/imagesavealpha_webp.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Testing imagesavealpha() with WebP
+--EXTENSIONS--
+gd
+--SKIPIF--
+<?php
+$support = gd_info();
+if (!isset($support['WebP Support']) || $support['WebP Support'] === false) {
+    die("skip WebP support not available");
+}
+?>
+--FILE--
+<?php
+$filename = __DIR__ . "/imagesavealpha_webp.webp";
+$im = imagecreatetruecolor(8, 8);
+imagealphablending($im, false);
+imagefilledrectangle($im, 0, 0, 7, 7, 0x7f000000);
+
+echo "without alpha\n";
+imagesavealpha($im, false);
+imagewebp($im, $filename, 101); // lossless
+$im1 = imagecreatefromwebp($filename);
+checkColors($im1, 0x000000);
+imagedestroy($im1);
+
+echo "with alpha\n";
+imagesavealpha($im, true);
+imagewebp($im, $filename, 101); // lossless
+$im1 = imagecreatefromwebp($filename);
+checkColors($im1, 0x7f000000);
+imagedestroy($im1);
+
+function checkColors(GdImage $im, int $expected) {
+    for ($i = 0; $i < 8; $i++) {
+        for ($j = 0; $j < 8; $j++) {
+            $actual = imagecolorat($im, $i, $j);
+            if ($actual !== $expected) {
+                echo "($i, $j) is $actual, but $expected expected\n";
+            }
+        }
+    }
+}
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/imagesavealpha_webp.webp");
+?>
+--EXPECT--
+without alpha
+with alpha


### PR DESCRIPTION
While this is properly handled for PNG images, it is apparently not for WebP and AVIF so far.

Noticed due to <https://github.com/php/doc-en/issues/2041>.

---

For now, this is just for testing. The issue actually needs to be resolved in libgd first.