### PR TITLE
ext/mysqli tests "using password" optional in error messages (part 2)

### DIFF
--- a/ext/mysqli/tests/mysqli_connect.phpt
+++ b/ext/mysqli/tests/mysqli_connect.phpt
@@ -145,7 +145,7 @@ require_once('skipifconnectfailure.inc');
     print "done!";
 ?>
 --EXPECTF--
-Warning: mysqli_connect(): (%s/%d): Access denied for user '%s'@'%s' (using password: YES) in %s on line %d
+Warning: mysqli_connect(): (%s/%d): Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r in %s on line %d
 array(1) {
   ["testing"]=>
   string(21) "mysqli.default_socket"


### PR DESCRIPTION
Like GH-10035 for ext/mysqli/tests/mysqli_connect.phpt test.