### PR TITLE
fix litespeed SAPI build warnings.

### DIFF
--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -537,9 +537,9 @@ static void log_message (const char *fmt, ...)
 #define DEBUG_MESSAGE(fmt, ...)
 #endif
 
-static int lsapi_activate_user_ini();
+static int lsapi_activate_user_ini(void);
 
-static int sapi_lsapi_activate()
+static int sapi_lsapi_activate(void)
 {
     char *path, *server_name;
     size_t path_len, server_name_len;
@@ -677,10 +677,9 @@ static int do_clean_shutdown = 1;
 static int clean_onexit = 1;
 
 
-static void lsapi_clean_shutdown()
+static void lsapi_clean_shutdown(void)
 {
     struct sigaction act;
-    int sa_rc;
     struct itimerval tmv;
 #if PHP_MAJOR_VERSION >= 7
     zend_string * key;
@@ -689,15 +688,14 @@ static void lsapi_clean_shutdown()
     sigemptyset(&act.sa_mask);
     act.sa_flags = 0;
     act.sa_handler = lsapi_sigsegv;
-    sa_rc = sigaction(SIGINT,  &act, NULL);
-    sa_rc = sigaction(SIGQUIT, &act, NULL);
-    sa_rc = sigaction(SIGILL,  &act, NULL);
-    sa_rc = sigaction(SIGABRT, &act, NULL);
-    sa_rc = sigaction(SIGBUS,  &act, NULL);
-    sa_rc = sigaction(SIGSEGV, &act, NULL);
-    sa_rc = sigaction(SIGTERM, &act, NULL);
-
-    sa_rc = sigaction(SIGPROF, &act, NULL);
+    (void)sigaction(SIGINT,  &act, NULL);
+    (void)sigaction(SIGQUIT, &act, NULL);
+    (void)sigaction(SIGILL,  &act, NULL);
+    (void)sigaction(SIGABRT, &act, NULL);
+    (void)sigaction(SIGBUS,  &act, NULL);
+    (void)sigaction(SIGSEGV, &act, NULL);
+    (void)sigaction(SIGTERM, &act, NULL);
+    (void)sigaction(SIGPROF, &act, NULL);
     memset(&tmv, 0, sizeof(struct itimerval));
     tmv.it_value.tv_sec = 0;
     tmv.it_value.tv_usec = 100000;
@@ -738,11 +736,9 @@ static void lsapi_atexit(void)
     }
 }
 
-
 static int lsapi_module_main(int show_source)
 {
     struct sigaction act;
-    int sa_rc;
     if (php_request_startup() == FAILURE ) {
         return -1;
     }
@@ -751,13 +747,13 @@ static int lsapi_module_main(int show_source)
         sigemptyset(&act.sa_mask);
         act.sa_flags = SA_NODEFER;
         act.sa_handler = lsapi_sigterm;
-        sa_rc = sigaction( SIGINT, &act, NULL);
-        sa_rc = sigaction( SIGQUIT, &act, NULL);
-        sa_rc = sigaction( SIGILL, &act, NULL);
-        sa_rc = sigaction( SIGABRT, &act, NULL);
-        sa_rc = sigaction( SIGBUS, &act, NULL);
-        sa_rc = sigaction( SIGSEGV, &act, NULL);
-        sa_rc = sigaction( SIGTERM, &act, NULL);
+        (void)sigaction( SIGINT, &act, NULL);
+        (void)sigaction( SIGQUIT, &act, NULL);
+        (void)sigaction( SIGILL, &act, NULL);
+        (void)sigaction( SIGABRT, &act, NULL);
+        (void)sigaction( SIGBUS, &act, NULL);
+        (void)sigaction( SIGSEGV, &act, NULL);
+        (void)sigaction( SIGTERM, &act, NULL);
 
         clean_onexit = 0;
     }

--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -922,6 +922,7 @@ static int LSAPI_perror_r( LSAPI_Request * pReq, const char * pErr1, const char 
 }
 
 
+#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux__)
 static int lsapi_lve_error( LSAPI_Request * pReq )
 {
     static const char * headers[] =
@@ -945,10 +946,8 @@ static int lsapi_lve_error( LSAPI_Request * pReq )
     return 0;
 }
 
-
 static int lsapi_enterLVE( LSAPI_Request * pReq, uid_t uid )
 {
-#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux__)
     if ( s_lve && uid ) //root user should not do that
     {
         uint32_t cookie;
@@ -962,16 +961,13 @@ static int lsapi_enterLVE( LSAPI_Request * pReq, uid_t uid )
             return -1;
         }
     }
-#endif
 
     return 0;
 }
 
-
 static int lsapi_jailLVE( LSAPI_Request * pReq, uid_t uid, struct passwd * pw )
 {
     int ret = 0;
-#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux__)
     char  error_msg[1024] = "";
     ret = (*fp_lve_jail)( pw, error_msg );
     if ( ret < 0 )
@@ -981,12 +977,10 @@ static int lsapi_jailLVE( LSAPI_Request * pReq, uid_t uid, struct passwd * pw )
         LSAPI_perror_r( pReq, "LSAPI: jail() failure.", NULL );
         return -1;
     }
-#endif
     return ret;
 }
 
 
-#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux__)
 static int lsapi_initLVE(void)
 {
     const char * pEnv;
@@ -1365,30 +1359,6 @@ static inline int lsapi_notify_pid( int fd )
         return -1;
     return 0;
 }
-
-
-static char s_conn_key_packet[16];
-static inline int init_conn_key( int fd )
-{
-    struct lsapi_packet_header * pHeader = (struct lsapi_packet_header *)s_conn_key_packet;
-    struct timeval tv;
-    int i;
-    gettimeofday( &tv, NULL );
-    srand( (tv.tv_sec % 0x1000 + tv.tv_usec) ^ rand() );
-    for( i = 8; i < 16; ++i )
-    {
-        s_conn_key_packet[i]=(int) (256.0*rand()/(RAND_MAX+1.0));
-    }
-    lsapi_buildPacketHeader( pHeader, LSAPI_REQ_RECEIVED,
-                        8 + LSAPI_PACKET_HEADER_LEN );
-    if ( write( fd, s_conn_key_packet, LSAPI_PACKET_HEADER_LEN+8 )
-                < LSAPI_PACKET_HEADER_LEN+8 )
-        return -1;
-    return 0;
-
-
-}
-
 
 static int readReq( LSAPI_Request * pReq )
 {
@@ -3160,11 +3130,11 @@ static void lsapi_check_child_status( long tmCur )
 //}
 
 
-void set_skip_write()
+void set_skip_write(void)
 {   s_skip_write = 1;   }
 
 
-int is_enough_free_mem()
+int is_enough_free_mem(void)
 {
 #if defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux__)
     //minimum 1GB or 10% available free memory
@@ -3832,7 +3802,7 @@ void LSAPI_No_Check_ppid(void)
 }
 
 
-int LSAPI_Get_ppid()
+int LSAPI_Get_ppid(void)
 {
     return(s_ppid);
 }


### PR DESCRIPTION
helpers only called on linux anyways, proper C calls prototypes.