### PR TITLE
ext/fileinfo: softmagic.c has error: expected identifier

### DIFF
--- a/ext/fileinfo/libmagic/softmagic.c
+++ b/ext/fileinfo/libmagic/softmagic.c
@@ -512,6 +512,7 @@ check_fmt(struct magic_set *ms, const char *fmt)
 # if defined(__aiws__) || defined(_AIX)
 #  define strndup aix_strndup	/* aix is broken */
 # endif
+#undef strndup
 char *strndup(const char *, size_t);
 
 char *


### PR DESCRIPTION
CentOS Linux 7.9.2009 (Core)　
To prevent build failures like:
/www/server/source/php/php82/ext/fileinfo/libmagic/softmagic.c:507:7: error: expected identifier or ‘(’ before ‘__extension__’
 char *strndup(const char *, size_t);
       ^
/www/server/source/php/php82/ext/fileinfo/libmagic/softmagic.c:510:1: error: expected identifier or ‘(’ before ‘__extension__’
 strndup(const char *str, size_t n)
 ^
make: *** [libmagic/softmagic.lo] Error 1
make: *** [libmagic/softmagic.lo] Error 1

i fix it.

