### PR TITLE
Change status of BCMath into Maintained

### DIFF
--- a/EXTENSIONS
+++ b/EXTENSIONS
@@ -234,7 +234,7 @@ SINCE:               5.0
 -------------------------------------------------------------------------------
 EXTENSION:           bcmath
 PRIMARY MAINTAINER:  Andi Gutmans <andi@php.net> (2000 - 2004)
-MAINTENANCE:         Unknown
+MAINTENANCE:         Maintained
 STATUS:              Working
 -------------------------------------------------------------------------------
 EXTENSION:           bz2


### PR DESCRIPTION
Based on the commit history, I think it is fair to change the status away from Unknown. In this PR I have changed it into Maintained, maybe Odd Fixes it more appropriate. Maybe someone can clarify this.