### PR TITLE
Move stack->next assignment within if (stack) check

### DIFF
--- a/sapi/phpdbg/phpdbg_cmd.c
+++ b/sapi/phpdbg/phpdbg_cmd.c
@@ -371,7 +371,9 @@ PHPDBG_API void phpdbg_param_debug(const phpdbg_param_t *param, const char *msg)
 
 /* {{{ */
 PHPDBG_API void phpdbg_stack_free(phpdbg_param_t *stack) {
-	if (stack && stack->next) {
+	ZEND_ASSERT(stack != NULL);
+
+	if (stack->next) {
 		phpdbg_param_t *remove = stack->next;
 
 		while (remove) {
@@ -422,10 +424,9 @@ PHPDBG_API void phpdbg_stack_free(phpdbg_param_t *stack) {
 				remove = next;
 			else break;
 		}
+
+		stack->next = NULL;
 	}
-
-
-	stack->next = NULL;
 } /* }}} */
 
 /* {{{ */


### PR DESCRIPTION
The code checks if stack is a NULL pointer. Below that if the stack->next pointer is updated unconditionally. Therefore a call with a NULL pointer will crash, even though the if (stack) check shows the intent that it is valid to call the function with NULL. The assignment to stack->next was not in the initial version of the code. Fix it by moving the assignment inside the if's body.

Note: I'm not sure if this should go into master or into 8.1, I chose master for now. Technically it is a bugfix, but it also likely doesn't affect existing uses because otherwise there likely would've been a bug report somewhere.