### PR TITLE
Fix GH-10092 (Internal stream casting should not emit lost bytes warning twice)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.1.15
 
-
+- Core:
+  . Fixed bug GH-10092 (Internal stream casting should not emit lost bytes
+    warning twice). (Girgias)
 
 05 Jan 2023, PHP 8.1.14
 

--- a/ext/standard/tests/file/gh10092.phpt
+++ b/ext/standard/tests/file/gh10092.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug GH-10092 (Internal stream casting should not emit lost bytes warning twice)
+--FILE--
+<?php
+$handle = fopen('http://example.com', 'r');
+var_dump(stream_isatty($handle));
+?>
+--EXPECT--
+bool(false)

--- a/main/streams/cast.c
+++ b/main/streams/cast.c
@@ -317,7 +317,9 @@ PHPAPI int _php_stream_cast(php_stream *stream, int castas, void **ret, int show
 
 exit_success:
 
-	if ((stream->writepos - stream->readpos) > 0 &&
+	if (
+		show_err &&
+		(stream->writepos - stream->readpos) > 0 &&
 		stream->fclose_stdiocast != PHP_STREAM_FCLOSE_FOPENCOOKIE &&
 		(flags & PHP_STREAM_CAST_INTERNAL) == 0
 	) {


### PR DESCRIPTION
The reason why the warning was emitted is that it was not guarded via the show_err parameter.

This parameter is set to false/0 via the macro function php_stream_can_cast() to check this silently.

The warning is completely removed as this function in particular sets this parameter to 0 when it casts the streams, it "performs a cast" just to retrieve the underlying file number.