### PR TITLE
Enforce literals in certain macros

### DIFF
--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -369,10 +369,10 @@ static zend_always_inline bool zend_string_equals(const zend_string *s1, const z
 	(ZSTR_LEN(s1) == ZSTR_LEN(s2) && !zend_binary_strcasecmp(ZSTR_VAL(s1), ZSTR_LEN(s1), ZSTR_VAL(s2), ZSTR_LEN(s2)))
 
 #define zend_string_equals_literal_ci(str, c) \
-	(ZSTR_LEN(str) == sizeof(c) - 1 && !zend_binary_strcasecmp(ZSTR_VAL(str), ZSTR_LEN(str), (c), sizeof(c) - 1))
+	(ZSTR_LEN(str) == sizeof("" c) - 1 && !zend_binary_strcasecmp(ZSTR_VAL(str), ZSTR_LEN(str), (c), sizeof(c) - 1))
 
 #define zend_string_equals_literal(str, literal) \
-	zend_string_equals_cstr(str, literal, strlen(literal))
+	zend_string_equals_cstr(str, "" literal, sizeof(literal) - 1)
 
 static zend_always_inline bool zend_string_starts_with_cstr(const zend_string *str, const char *prefix, size_t prefix_length)
 {


### PR DESCRIPTION
The `zend_string_equals_literal_ci` and `zend_string_equals_literal`
macros are designed only for literals. This is a standards compliant
trick to ensure they are literals. It relies on the fact that two
adjacent string literals are concatenated. For example, these are the
same:

```c
"Hello" " world"
"Hello world"
```

Since literals are ensured, use `sizeof(...) - 1` instead of `strlen`.

I spot checked usages visually, but running the CI in case it finds any
non-literal uses.