### PR TITLE
Fix GH-10112: LDAP\Connection::__construct() refers to ldap_create()

### DIFF
--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -119,7 +119,7 @@ static zend_object *ldap_link_create_object(zend_class_entry *class_type) {
 }
 
 static zend_function *ldap_link_get_constructor(zend_object *object) {
-	zend_throw_error(NULL, "Cannot directly construct LDAP\\Connection, use ldap_create() instead");
+	zend_throw_error(NULL, "Cannot directly construct LDAP\\Connection, use ldap_connect() instead");
 	return NULL;
 }
 

--- a/ext/ldap/tests/ldap_constructor.phpt
+++ b/ext/ldap/tests/ldap_constructor.phpt
@@ -11,4 +11,4 @@ try {
     echo "Exception: ", $ex->getMessage(), "\n";
 }
 --EXPECT--
-Exception: Cannot directly construct LDAP\Connection, use ldap_create() instead
+Exception: Cannot directly construct LDAP\Connection, use ldap_connect() instead


### PR DESCRIPTION
There is no `ldap_create()`, but rather `ldap_connect()`.