### PR TITLE
ext/json: Unnecessary parentheses

### DIFF
--- a/ext/json/json.c
+++ b/ext/json/json.c
@@ -303,8 +303,7 @@ PHP_FUNCTION(json_validate)
 		Z_PARAM_LONG(options)
 	ZEND_PARSE_PARAMETERS_END();
 
-
-	if ((options != 0) && (options != PHP_JSON_INVALID_UTF8_IGNORE)) {
+	if (options != 0 && options != PHP_JSON_INVALID_UTF8_IGNORE) {
 		zend_argument_value_error(3, "must be a valid flag (allowed flags: JSON_INVALID_UTF8_IGNORE)");
 		RETURN_THROWS();
 	}
@@ -315,7 +314,7 @@ PHP_FUNCTION(json_validate)
 	}
 
 	JSON_G(error_code) = PHP_JSON_ERROR_NONE;
-	
+
 	if (depth <= 0) {
 		zend_argument_value_error(2, "must be greater than 0");
 		RETURN_THROWS();


### PR DESCRIPTION
Hello,

a small tweak to the comparison within the json_validate function, the use of parentheses is unnecessary and nothing will be affected.