### PR TITLE
Initialize ping_auto_globals_mask to prevent undefined behaviour

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4444,6 +4444,8 @@ static int accel_preload(const char *config, bool in_child)
 
 		if (PG(auto_globals_jit)) {
 			ping_auto_globals_mask = zend_accel_get_auto_globals();
+		} else {
+			ping_auto_globals_mask = 0;
 		}
 
 		if (EG(zend_constants)) {

--- a/ext/opcache/tests/preloading_no_auto_globals_jit.inc
+++ b/ext/opcache/tests/preloading_no_auto_globals_jit.inc
@@ -1,0 +1,6 @@
+<?php
+class Test {
+    function count_global_server() {
+        return count($_SERVER);
+    }
+}

--- a/ext/opcache/tests/preloading_no_auto_globals_jit.phpt
+++ b/ext/opcache/tests/preloading_no_auto_globals_jit.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Preloading with auto_globals_jit=0
+--INI--
+auto_globals_jit=0
+opcache.enable=1
+opcache.enable_cli=1
+opcache.preload={PWD}/preloading_no_auto_globals_jit.inc
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+$test = new Test;
+var_dump($test->count_global_server());
+?>
+--EXPECTF--
+int(%d)


### PR DESCRIPTION
`ping_auto_globals_mask` was not initialized on all paths towards `script->ping_auto_globals_mask = ping_auto_globals_mask;`, which is undefined behaviour.