### PR TITLE
Remove unnecessary check of p in phpdbg_trim

### DIFF
--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -199,7 +199,7 @@ PHPDBG_API char *phpdbg_trim(const char *str, size_t len, size_t *new_len) /* {{
 	const char *p = str;
 	char *new = NULL;
 
-	while (p && isspace(*p)) {
+	while (isspace(*p)) {
 		++p;
 		--len;
 	}


### PR DESCRIPTION
The check checks whether p is non-NULL. But if it were NULL the function would crash in later code, so the check is useless. It seems like *p was intended, but that is redundant as well because isspace would return false on '\0'.

EDIT: Failing test is proc_open02.phpt which seems to be unrelated, just flaky.