### PR TITLE
Skip tests under MSAN

### DIFF
--- a/Zend/tests/stack_limit/stack_limit_001.phpt
+++ b/Zend/tests/stack_limit/stack_limit_001.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Stack limit 001 - Stack limit checks with max_allowed_stack_size detection
+--SKIPIF--
+<?php
+if (getenv('SKIP_MSAN')) die("skip msan requires a considerably higher zend.reserved_stack_size due to instrumentation");
+?>
 --EXTENSIONS--
 zend_test
 --INI--

--- a/Zend/tests/stack_limit/stack_limit_002.phpt
+++ b/Zend/tests/stack_limit/stack_limit_002.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Stack limit 002 - Stack limit checks with max_allowed_stack_size detection (fibers)
+--SKIPIF--
+<?php
+if (getenv('SKIP_MSAN')) die("skip msan requires a considerably higher zend.reserved_stack_size due to instrumentation");
+?>
 --EXTENSIONS--
 zend_test
 --INI--

--- a/Zend/tests/stack_limit/stack_limit_006.phpt
+++ b/Zend/tests/stack_limit/stack_limit_006.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Stack limit 006 - env size affects __libc_stack_end
+--SKIPIF--
+<?php
+if (getenv('SKIP_MSAN')) die("skip msan requires a considerably higher zend.reserved_stack_size due to instrumentation");
+?>
 --EXTENSIONS--
 zend_test
 --INI--

--- a/Zend/tests/stack_limit/stack_limit_009.phpt
+++ b/Zend/tests/stack_limit/stack_limit_009.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Stack limit 009 - Check that we can actually use all the stack
+--SKIPIF--
+<?php
+if (getenv('SKIP_MSAN')) die("skip msan requires a considerably higher zend.reserved_stack_size due to instrumentation");
+?>
 --EXTENSIONS--
 zend_test
 --FILE--


### PR DESCRIPTION
Stack overflows can be detected as long as C stack frames between two execute_ex() calls use less than zend.reserved_stack_size bytes of stack.

The default value of zend.reserved_stack_size accounts for the largest stack users, but MSAN instrumentation increases usage considerably: php_pcre2_match uses more than 200KiB of stack in some MSAN build, compared to 20KiB without MSAN according to -fstack-usage.

I'm disabling these tests under MSAN because increasing zend.reserved_stack_size would render them useless under non-MSAN builds.