### PR TITLE
Set DOMAttr::$value and DOMAttr::$nodeValue without expanding entities

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -48,6 +48,10 @@ PHP 8.3 UPGRADE NOTES
   . C functions that have a return type of void now return null instead of
     returning the following object object(FFI\CData:void) { }
 
+- DOM:
+  . Assignment to DOMAttr::$value and DOMAttr::$nodeValue no longer expands
+    entities in the new value.
+
 ========================================
 2. New Features
 ========================================

--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -136,6 +136,7 @@ int dom_attr_value_write(dom_object *obj, zval *newval)
 {
 	zend_string *str;
 	xmlAttrPtr attrp = (xmlAttrPtr) dom_object_get_node(obj);
+	xmlNodePtr node, next;
 
 	if (attrp == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
@@ -149,9 +150,17 @@ int dom_attr_value_write(dom_object *obj, zval *newval)
 
 	if (attrp->children) {
 		node_list_unlink(attrp->children);
+		node = attrp->children;
+		while (node) {
+			next = node->next;
+			xmlUnlinkNode(node);
+			xmlFreeNode(node);
+			node = next;
+		}
 	}
 
-	xmlNodeSetContentLen((xmlNodePtr) attrp, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
+	node = xmlNewTextLen((xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str));
+	xmlAddChild((xmlNodePtr) attrp, node);
 
 	zend_string_release_ex(str, 0);
 	return SUCCESS;

--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -136,7 +136,6 @@ int dom_attr_value_write(dom_object *obj, zval *newval)
 {
 	zend_string *str;
 	xmlAttrPtr attrp = (xmlAttrPtr) dom_object_get_node(obj);
-	xmlNodePtr node, next;
 
 	if (attrp == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
@@ -148,18 +147,8 @@ int dom_attr_value_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
-	if (attrp->children) {
-		node_list_unlink(attrp->children);
-		node = attrp->children;
-		while (node) {
-			next = node->next;
-			xmlUnlinkNode(node);
-			xmlFreeNode(node);
-			node = next;
-		}
-	}
-
-	node = xmlNewTextLen((xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str));
+	dom_remove_all_children((xmlNodePtr) attrp);
+	xmlNodePtr node = xmlNewTextLen((xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str));
 	xmlAddChild((xmlNodePtr) attrp, node);
 
 	zend_string_release_ex(str, 0);

--- a/ext/dom/characterdata.c
+++ b/ext/dom/characterdata.c
@@ -70,7 +70,7 @@ int dom_characterdata_data_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
-	xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
+	xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str));
 
 	zend_string_release_ex(str, 0);
 	return SUCCESS;

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -185,7 +185,7 @@ int dom_node_node_value_write(dom_object *obj, zval *newval)
 		case XML_COMMENT_NODE:
 		case XML_CDATA_SECTION_NODE:
 		case XML_PI_NODE:
-			xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
+			xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str));
 			break;
 		default:
 			break;

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -179,11 +179,7 @@ int dom_node_node_value_write(dom_object *obj, zval *newval)
 	switch (nodep->type) {
 		case XML_ELEMENT_NODE:
 		case XML_ATTRIBUTE_NODE:
-			if (nodep->children) {
-				node_list_unlink(nodep->children);
-				php_libxml_node_free_list((xmlNodePtr) nodep->children);
-				nodep->children = NULL;
-			}
+			dom_remove_all_children(nodep);
 			ZEND_FALLTHROUGH;
 		case XML_TEXT_NODE:
 		case XML_COMMENT_NODE:
@@ -783,12 +779,7 @@ int dom_node_text_content_write(dom_object *obj, zval *newval)
 	 * For the other cases, we *can* rely on xmlNodeSetContent because it is either a no-op, or handles
 	 * the content without encoding. */
 	if (type == XML_DOCUMENT_FRAG_NODE || type == XML_ELEMENT_NODE || type == XML_ATTRIBUTE_NODE) {
-		if (nodep->children) {
-			node_list_unlink(nodep->children);
-			php_libxml_node_free_list((xmlNodePtr) nodep->children);
-			nodep->children = NULL;
-		}
-
+		dom_remove_all_children(nodep);
 		xmlNode *textNode = xmlNewText(xmlChars);
 		xmlAddChild(nodep, textNode);
 	} else {

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -177,8 +177,11 @@ int dom_node_node_value_write(dom_object *obj, zval *newval)
 
 	/* Access to Element node is implemented as a convenience method */
 	switch (nodep->type) {
-		case XML_ELEMENT_NODE:
 		case XML_ATTRIBUTE_NODE:
+			dom_remove_all_children(nodep);
+			xmlAddChild(nodep, xmlNewTextLen((xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str)));
+			break;
+		case XML_ELEMENT_NODE:
 			dom_remove_all_children(nodep);
 			ZEND_FALLTHROUGH;
 		case XML_TEXT_NODE:

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1588,4 +1588,14 @@ static int dom_nodelist_has_dimension(zend_object *object, zval *member, int che
 	}
 } /* }}} end dom_nodelist_has_dimension */
 
+void dom_remove_all_children(xmlNodePtr nodep)
+{
+	if (nodep->children) {
+		node_list_unlink(nodep->children);
+		php_libxml_node_free_list((xmlNodePtr) nodep->children);
+		nodep->children = NULL;
+		nodep->last = NULL;
+	}
+}
+
 #endif /* HAVE_DOM */

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -142,6 +142,8 @@ void dom_parent_node_before(dom_object *context, zval *nodes, int nodesc);
 void dom_child_node_remove(dom_object *context);
 void dom_child_replace_with(dom_object *context, zval *nodes, int nodesc);
 
+void dom_remove_all_children(xmlNodePtr nodep);
+
 #define DOM_GET_OBJ(__ptr, __id, __prtype, __intern) { \
 	__intern = Z_DOMOBJ_P(__id); \
 	if (__intern->ptr == NULL || !(__ptr = (__prtype)((php_libxml_node_ptr *)__intern->ptr)->node)) { \

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -130,7 +130,7 @@ int dom_processinginstruction_data_write(dom_object *obj, zval *newval)
 
 	php_libxml_invalidate_node_list_cache_from_doc(nodep->doc);
 
-	xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str) + 1);
+	xmlNodeSetContentLen(nodep, (xmlChar *) ZSTR_VAL(str), ZSTR_LEN(str));
 
 	zend_string_release_ex(str, 0);
 	return SUCCESS;

--- a/ext/dom/tests/DOMAttr_entity_expansion.phpt
+++ b/ext/dom/tests/DOMAttr_entity_expansion.phpt
@@ -1,0 +1,30 @@
+--TEST--
+DOMAttr entity expansion
+--FILE--
+<?php
+$doc = new DOMDocument;
+$elt = $doc->createElement('elt');
+$doc->appendChild($elt);
+$elt->setAttribute('a','&');
+print $doc->saveXML($elt) . "\n";
+
+$attr = $elt->getAttributeNode('a');
+$attr->value = '&amp;';
+print $doc->saveXML($elt) . "\n";
+
+$attr->removeChild($attr->firstChild);
+print $doc->saveXML($elt) . "\n";
+
+$elt->setAttributeNS('http://www.w3.org/2000/svg', 'svg:id','&amp;');
+print $doc->saveXML($elt) . "\n";
+
+$attr = $elt->getAttributeNodeNS('http://www.w3.org/2000/svg', 'id');
+$attr->value = '&lt;&amp;';
+print $doc->saveXML($elt) . "\n";
+
+--EXPECT--
+<elt a="&amp;"/>
+<elt a="&amp;amp;"/>
+<elt a=""/>
+<elt xmlns:svg="http://www.w3.org/2000/svg" a="" svg:id="&amp;amp;"/>
+<elt xmlns:svg="http://www.w3.org/2000/svg" a="" svg:id="&amp;lt;&amp;amp;"/>

--- a/ext/dom/tests/DOMAttr_entity_expansion.phpt
+++ b/ext/dom/tests/DOMAttr_entity_expansion.phpt
@@ -15,6 +15,13 @@ print $doc->saveXML($elt) . "\n";
 $attr->removeChild($attr->firstChild);
 print $doc->saveXML($elt) . "\n";
 
+$attr->nodeValue = '&';
+print $doc->saveXML($elt) . "\n";
+
+$attr->nodeValue = '&amp;';
+print $doc->saveXML($elt) . "\n";
+
+$elt->removeAttributeNode($attr);
 $elt->setAttributeNS('http://www.w3.org/2000/svg', 'svg:id','&amp;');
 print $doc->saveXML($elt) . "\n";
 
@@ -26,5 +33,7 @@ print $doc->saveXML($elt) . "\n";
 <elt a="&amp;"/>
 <elt a="&amp;amp;"/>
 <elt a=""/>
-<elt xmlns:svg="http://www.w3.org/2000/svg" a="" svg:id="&amp;amp;"/>
-<elt xmlns:svg="http://www.w3.org/2000/svg" a="" svg:id="&amp;lt;&amp;amp;"/>
+<elt a="&amp;"/>
+<elt a="&amp;amp;"/>
+<elt xmlns:svg="http://www.w3.org/2000/svg" svg:id="&amp;amp;"/>
+<elt xmlns:svg="http://www.w3.org/2000/svg" svg:id="&amp;lt;&amp;amp;"/>

--- a/ext/dom/tests/DOMAttr_entity_expansion.phpt
+++ b/ext/dom/tests/DOMAttr_entity_expansion.phpt
@@ -1,5 +1,7 @@
 --TEST--
 DOMAttr entity expansion
+--EXTENSIONS--
+dom
 --FILE--
 <?php
 $doc = new DOMDocument;
@@ -10,15 +12,18 @@ print $doc->saveXML($elt) . "\n";
 
 $attr = $elt->getAttributeNode('a');
 $attr->value = '&amp;';
+print "$attr->value\n";
 print $doc->saveXML($elt) . "\n";
 
 $attr->removeChild($attr->firstChild);
 print $doc->saveXML($elt) . "\n";
 
 $attr->nodeValue = '&';
+print "$attr->nodeValue\n";
 print $doc->saveXML($elt) . "\n";
 
 $attr->nodeValue = '&amp;';
+print "$attr->nodeValue\n";
 print $doc->saveXML($elt) . "\n";
 
 $elt->removeAttributeNode($attr);
@@ -27,13 +32,18 @@ print $doc->saveXML($elt) . "\n";
 
 $attr = $elt->getAttributeNodeNS('http://www.w3.org/2000/svg', 'id');
 $attr->value = '&lt;&amp;';
+print "$attr->value\n";
 print $doc->saveXML($elt) . "\n";
 
 --EXPECT--
 <elt a="&amp;"/>
+&amp;
 <elt a="&amp;amp;"/>
 <elt a=""/>
+&
 <elt a="&amp;"/>
+&amp;
 <elt a="&amp;amp;"/>
 <elt xmlns:svg="http://www.w3.org/2000/svg" svg:id="&amp;amp;"/>
+&lt;&amp;
 <elt xmlns:svg="http://www.w3.org/2000/svg" svg:id="&amp;lt;&amp;amp;"/>


### PR DESCRIPTION
The manual refers to the DOM Level 3 Core spec which says:

"On setting, this creates a Text node with the unparsed contents of the
string. I.e. any characters that an XML processor would recognize as
markup are instead treated as literal text."

PHP is expanding entities when DOMAttr::value is set, which is
non-compliant and is a difference in behaviour compared to browser DOM
implementations.

So, when value is set, remove all children of the attribute node. Then
create a single text node and insert that as the only child of the
attribute.

Add tests.
