### PR TITLE
Fix #10133 set variables_order en ensure $ENV is set

### DIFF
--- a/Zend/tests/traits/constant_016.phpt
+++ b/Zend/tests/traits/constant_016.phpt
@@ -2,6 +2,8 @@
 Compatibility of values of same name trait constants is checked after their constant expressions are evaluated
 --ENV--
 ENSURE_CONSTANT_IS_DEFINED_AT_RUNTIME=1
+--INI--
+variables_order=EGPCS
 --FILE--
 <?php
 


### PR DESCRIPTION
When variables_order is set to "**GPCS**" (dev/prod value)

```
TEST 1/1 [Zend/tests/traits/constant_016.phpt]
========DIFF========
001+ Warning: Undefined array key "ENSURE_CONSTANT_IS_DEFINED_AT_RUNTIME" in /builddir/build/BUILD/php-8.2.1RC1/Zend/tests/traits/constant_016.php on line 4
001- 42
002+ 
003+ Warning: Uncaught Error: Undefined constant "CONSTANT" in /builddir/build/BUILD/php-8.2.1RC1/Zend/tests/traits/constant_016.php:12
004+ Stack trace:
005+ #0 {main}
006+   thrown in /builddir/build/BUILD/php-8.2.1RC1/Zend/tests/traits/constant_016.php on line 12
007+ 
008+ Fatal error: ComposingClass and TestTrait define the same constant (Constant) in the composition of ComposingClass. However, the definition differs and is considered incompatible. Class was composed in /builddir/build/BUILD/php-8.2.1RC1/Zend/tests/traits/constant_016.php on line 12
========DONE========
FAIL Compatibility of values of same name trait constants is checked after their constant expressions are evaluated [Zend/tests/traits/constant_016.phpt] 
```


Forcing to its default value of "**EGPCS**"

```
PASS Compatibility of values of same name trait constants is checked after their constant expressions are evaluated [Zend/tests/traits/constant_016.phpt] 
```