### PR TITLE
Fix GH-9675: Re-adjust run_time_cache init for internal enum methods

### DIFF
--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -409,8 +409,11 @@ static void zend_enum_register_func(zend_class_entry *ce, zend_known_string_id n
 	zif->module = EG(current_module);
 	zif->scope = ce;
 	zif->T = ZEND_OBSERVER_ENABLED;
-	ZEND_MAP_PTR_NEW(zif->run_time_cache);
-	ZEND_MAP_PTR_SET(zif->run_time_cache, zend_arena_alloc(&CG(arena), zend_internal_run_time_cache_reserved_size()));
+    if (EG(active)) { // at run-time: this ought to only happen if registered with dl() or somehow temporarily at runtime
+		ZEND_MAP_PTR_INIT(zif->run_time_cache, zend_arena_alloc(&CG(arena), zend_internal_run_time_cache_reserved_size()));
+	} else {
+		ZEND_MAP_PTR_NEW(zif->run_time_cache);
+	}
 
 	if (!zend_hash_add_ptr(&ce->function_table, name, zif)) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot redeclare %s::%s()", ZSTR_VAL(ce->name), ZSTR_VAL(name));


### PR DESCRIPTION
After [bisecting](https://github.com/php/php-src/issues/9675#issuecomment-1342985940) the commit history in order to track down the cause of the reported [issue](https://github.com/php/php-src/issues/9675), I started going through the origin [pull request](https://github.com/php/php-src/pull/9024) in order to understand the context behind the observed changes.

This [discussion](https://github.com/php/php-src/pull/9024#discussion_r933279495) prompted me to dig deeper into the `run_time_cache` mechanism, as it was describing the issue we're currently having in web context (PHP-FPM).

I noticed in the two places where `run_time_cache` mechanism was introduced for internal functions, the way it was handled was inconsistent.

With the applied fix, we're not experiencing anymore errors in production. We are running a high-traffic PHP application inside a Kubernetes cluster with over 41k RPM.

It would be helpful if @PhilETaylor and @Zenexer could confirm if this fixes the issue for them as well.