### PR TITLE
ext/opcache/jit/zend_jit: fix inverted bailout value in zend_runtime_jit()

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4287,7 +4287,7 @@ static int ZEND_FASTCALL zend_runtime_jit(void)
 			/* perform real JIT for this function */
 			zend_real_jit_func(op_array, NULL, NULL);
 		} zend_catch {
-			do_bailout = 0;
+			do_bailout = true;
 		} zend_end_try();
 
 		zend_jit_protect();


### PR DESCRIPTION
In the "catch" block, do_bailout must be set to true, not false, or else zend_bailout() never gets called.