### PR TITLE
ext/opcache/jit/zend_jit_trace: fix memory leak in _compile_root_trace()

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7099,6 +7099,7 @@ static zend_jit_trace_stop zend_jit_compile_root_trace(zend_jit_trace_rec *trace
 			    if (t->stack_map_size) {
 					zend_jit_trace_stack *shared_stack_map = (zend_jit_trace_stack*)zend_shared_alloc(t->stack_map_size * sizeof(zend_jit_trace_stack));
 					if (!shared_stack_map) {
+						efree(t->stack_map);
 						ret = ZEND_JIT_TRACE_STOP_NO_SHM;
 						goto exit;
 					}


### PR DESCRIPTION
A copy of this piece of code exists in zend_jit_compile_side_trace(), but there, the leak bug does not exist.

This bug exists since both copies of this piece of code were added in commit 4bf2d09edeb14