### PR TITLE
JIT code cleanup

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -134,7 +134,7 @@ static const void *zend_jit_loop_trace_counter_handler = NULL;
 static int ZEND_FASTCALL zend_runtime_jit(void);
 
 static int zend_jit_trace_op_len(const zend_op *opline);
-static int zend_jit_trace_may_exit(const zend_op_array *op_array, const zend_op *opline);
+static bool zend_jit_trace_may_exit(const zend_op_array *op_array, const zend_op *opline);
 static uint32_t zend_jit_trace_get_exit_point(const zend_op *to_opline, uint32_t flags);
 static const void *zend_jit_trace_get_exit_addr(uint32_t n);
 static void zend_jit_trace_add_code(const void *start, uint32_t size);

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -756,6 +756,8 @@ typedef enum _sp_adj_kind {
 
 static int sp_adj[SP_ADJ_LAST];
 
+static int ZEND_FASTCALL zend_jit_trace_exit(uint32_t exit_num, zend_jit_registers_buf *regs);
+
 /* The generated code may contain tautological comparisons, ignore them. */
 #if defined(__clang__)
 # pragma clang diagnostic push

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -106,7 +106,8 @@ typedef struct _zend_jit_stub {
 zend_ulong zend_jit_profile_counter = 0;
 int zend_jit_profile_counter_rid = -1;
 
-int16_t zend_jit_hot_counters[ZEND_HOT_COUNTERS_COUNT];
+#define ZEND_HOT_COUNTERS_COUNT 128
+static int16_t zend_jit_hot_counters[ZEND_HOT_COUNTERS_COUNT];
 
 const zend_op *zend_jit_halt_op = NULL;
 static int zend_jit_vm_kind = 0;

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4276,7 +4276,7 @@ static int ZEND_FASTCALL zend_runtime_jit(void)
 	return 0;
 }
 
-void zend_jit_check_funcs(HashTable *function_table, bool is_method) {
+static void zend_jit_check_funcs(HashTable *function_table, bool is_method) {
 	zend_op *opline;
 	zend_function *func;
 	zend_op_array *op_array;

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -1108,7 +1108,7 @@ static void *dasm_link_and_encode(dasm_State             **dasm_state,
 	return entry;
 }
 
-static bool zend_may_overflow(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_op_array *op_array, zend_ssa *ssa)
+static bool zend_may_overflow(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_op_array *op_array, const zend_ssa *ssa)
 {
 	int res;
 	zend_long op1_min, op1_max, op2_min, op2_max;

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -707,7 +707,6 @@ ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_ret_trace_helper(ZEND_OPCODE_HAND
 ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_jit_loop_trace_helper(ZEND_OPCODE_HANDLER_ARGS);
 
 int ZEND_FASTCALL zend_jit_trace_hot_root(zend_execute_data *execute_data, const zend_op *opline);
-int ZEND_FASTCALL zend_jit_trace_exit(uint32_t exit_num, zend_jit_registers_buf *regs);
 zend_jit_trace_stop ZEND_FASTCALL zend_jit_trace_execute(zend_execute_data *execute_data, const zend_op *opline, zend_jit_trace_rec *trace_buffer, uint8_t start, uint32_t is_megamorphc);
 
 static zend_always_inline const zend_op* zend_jit_trace_get_exit_opline(zend_jit_trace_rec *trace, const zend_op *opline, bool *exit_if_true)

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -233,10 +233,6 @@ extern int zend_jit_profile_counter_rid;
 
 /* Hot Counters */
 
-#define ZEND_HOT_COUNTERS_COUNT 128
-
-extern int16_t zend_jit_hot_counters[ZEND_HOT_COUNTERS_COUNT];
-
 static zend_always_inline zend_long zend_jit_hash(const void *ptr)
 {
 	uintptr_t x;

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7902,7 +7902,7 @@ exit:;
 	return ret;
 }
 
-int ZEND_FASTCALL zend_jit_trace_hot_side(zend_execute_data *execute_data, uint32_t parent_num, uint32_t exit_num)
+static int zend_jit_trace_hot_side(zend_execute_data *execute_data, uint32_t parent_num, uint32_t exit_num)
 {
 	zend_jit_trace_stop stop;
 	int ret = 0;

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -8048,7 +8048,7 @@ abort:
 	return ret;
 }
 
-int ZEND_FASTCALL zend_jit_trace_exit(uint32_t exit_num, zend_jit_registers_buf *regs)
+static int ZEND_FASTCALL zend_jit_trace_exit(uint32_t exit_num, zend_jit_registers_buf *regs)
 {
 	uint32_t trace_num = EG(jit_trace_num);
 	zend_execute_data *execute_data = EG(current_execute_data);


### PR DESCRIPTION
While I developed https://github.com/php/php-src/pull/10138 I had to read lots of JIT code, but that took more time than I wanted to, and I felt part of that was because the code is largely undocumented and some of it looked confusing to me. This PR is my contributing to improve the situation for the next guy in my shoes - some API documentation (reflecting my understanding of how the code is supposed to work), some semantic code cleanup, some bigger code cleanup (merging several redundant code copies). This is just scratching the surface, and I'll probably submit some more later.

If you wish to have this PR split into smaller pieces, I can do that easily.

About coding style: my new code declares variables where they are used first, which I find much more readable (and robust) than declaring them at the beginning of the function. The rest of the PHP code base doesn't do this, even though PHP is supposed to be C99. Is this some kind of official coding style? If not, I may submit PRs to move variable declarations.

This PR contains https://github.com/php/php-src/pull/10146 because one commit depends on it. Once that other PR is merged, I'll rebase this PR, making that one commit vanish.