### PR TITLE
Make array_pad's $length warning less confusing

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4344,13 +4344,14 @@ PHP_FUNCTION(array_pad)
 		Z_PARAM_ZVAL(pad_value)
 	ZEND_PARSE_PARAMETERS_END();
 
+	if (pad_size < Z_L(-HT_MAX_SIZE) || pad_size > Z_L(HT_MAX_SIZE)) {
+		zend_argument_value_error(2, "must not exceed the maximum allowed array size");
+		RETURN_THROWS();
+	}
+
 	/* Do some initial calculations */
 	input_size = zend_hash_num_elements(Z_ARRVAL_P(input));
 	pad_size_abs = ZEND_ABS(pad_size);
-	if (pad_size_abs < 0 || pad_size_abs - input_size > Z_L(1048576)) {
-		zend_argument_value_error(2, "must be less than or equal to 1048576");
-		RETURN_THROWS();
-	}
 
 	if (input_size >= pad_size_abs) {
 		/* Copy the original array */

--- a/ext/standard/tests/array/array_pad.phpt
+++ b/ext/standard/tests/array/array_pad.phpt
@@ -13,12 +13,6 @@ var_dump(array_pad(array("", -1, 2.0), 2, array()));
 var_dump(array_pad(array("", -1, 2.0), -3, array()));
 var_dump(array_pad(array("", -1, 2.0), -4, array()));
 
-try {
-    var_dump(array_pad(array("", -1, 2.0), 2000000, 0));
-} catch (\ValueError $e) {
-    echo $e->getMessage() . "\n";
-}
-
 ?>
 --EXPECT--
 array(1) {
@@ -84,4 +78,3 @@ array(4) {
   [3]=>
   float(2)
 }
-array_pad(): Argument #2 ($length) is too large because it results in a padding of 1999997 elements, which is larger than the allowed 1048576 elements

--- a/ext/standard/tests/array/array_pad.phpt
+++ b/ext/standard/tests/array/array_pad.phpt
@@ -84,4 +84,4 @@ array(4) {
   [3]=>
   float(2)
 }
-array_pad(): Argument #2 ($length) must be less than or equal to 1048576
+array_pad(): Argument #2 ($length) is too large because it results in a padding of 1999997 elements, which is larger than the allowed 1048576 elements

--- a/ext/standard/tests/array/array_pad_too_large_padding.phpt
+++ b/ext/standard/tests/array/array_pad_too_large_padding.phpt
@@ -1,0 +1,20 @@
+--TEST--
+array_pad() with too large padding should fail
+--FILE--
+<?php
+
+function test($length) {
+    try {
+        var_dump(array_pad(array("", -1, 2.0), $length, 0));
+    } catch (\ValueError $e) {
+        echo $e->getMessage() . "\n";
+    }
+}
+
+test(PHP_INT_MIN);
+test(PHP_INT_MAX);
+
+?>
+--EXPECT--
+array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size
+array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size


### PR DESCRIPTION
The error message was wrong; it *is* possible to use a larger length. The error message should be clear it's about how much padding is required.

Valid example with length greater than 1048576:
```php
<?php
var_dump(array_pad(array_fill(0, 1048576 * 2), 1048576 * 3 - 1, 0));
?>
```

If we were to remove the `- 1` in the above code snippet such that the required padding length becomes too large, it would be especially confusing for developers using the `array_pad` function.

~~This patch also removes a redundant check on pad_size_abs: it can never be negative since it is the absolute value of pad_size.~~

EDIT: I changed the code to check the *new* array length instead of having an arbtrary limit. This also simplifies the error message.

Note: I targeted the master branch because I'm not sure how much confusion is considered a bug.