### PR TITLE
Fix GH-9981: FPM does not reset fastcgi.error_header

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1911,6 +1911,9 @@ consult the installation file that came with this distribution, or visit \n\
 
 			fpm_request_executing();
 
+			/* Reset exit status from the previous execution */
+			EG(exit_status) = 0;
+
 			php_execute_script(&file_handle);
 
 fastcgi_request_done:

--- a/sapi/fpm/tests/gh9981-fastcgi-error-header-reset.phpt
+++ b/sapi/fpm/tests/gh9981-fastcgi-error-header-reset.phpt
@@ -1,0 +1,51 @@
+--TEST--
+FPM: gh9981 - fastcgi.error_header is not reset
+--SKIPIF--
+<?php
+include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+catch_workers_output = yes
+EOT;
+
+$code = <<<EOT
+<?php
+if (isset(\$_GET['q'])) {
+    echo 'ok';
+} else {
+    d();
+}
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start(iniEntries: [
+    'fastcgi.error_header' => '"HTTP/1.1 500 PHP Error"',
+    'output_buffering'     => 4096,
+]);
+$tester->expectLogStartNotices();
+$tester->request()->expectStatus('500 PHP Error');
+$tester->request('q=1')->expectNoStatus();
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->expectNoLogPattern('/Cannot modify header information/');
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -135,6 +135,36 @@ class Response
     }
 
     /**
+     * Expect response status.
+     *
+     * @param string|null $status Expected status.
+     *
+     * @return Response
+     */
+    public function expectStatus(string|null $status): Response {
+        $headers = $this->getHeaders();
+        if (is_null($status) && !isset($headers['status'])) {
+            return $this;
+        }
+        if (!is_null($status) && !isset($headers['status'])) {
+            $this->error('Status is expected but not supplied');
+        } elseif ($status !== $headers['status']) {
+            $statusMessage = $status === null ? "expected not to be set": "expected to be $status";
+            $this->error("Status is $statusMessage but the actual value is {$headers['status']}");
+        }
+        return $this;
+    }
+
+    /**
+     * Expect response status not to be set.
+     *
+     * @return Response
+     */
+    public function expectNoStatus(): Response {
+        return $this->expectStatus(null);
+    }
+
+    /**
      * Expect no error in the response.
      *
      * @return Response


### PR DESCRIPTION
The `EG(exit_status)` is not reset before the request execution so it stays on the value from the previous run which cause the issue in GH-9981.