### PR TITLE
Fix undefined behaviour in phpdbg_load_module_or_extension

### DIFF
--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -1321,7 +1321,7 @@ PHPDBG_API const char *phpdbg_load_module_or_extension(char **path, const char *
 		module_entry->handle = handle;
 
 		if ((module_entry = zend_register_module_ex(module_entry)) == NULL) {
-			phpdbg_error("Unable to register module %s", module_entry->name);
+			phpdbg_error("Unable to register module %s", *name);
 
 			goto quit;
 		}


### PR DESCRIPTION
If `zend_register_module_ex` were to return NULL, then `module_entry` will be set to NULL, and the if's body will load `module_entry->name`. Since module_entry is NULL, loading the name would cause a NULL pointer dereference. However, since a NULL pointer dereference is undefined behaviour, the compiler is free to remove the check.
I verified this on my system's compiler, and indeed that check is actually removed when using Clang as a compiler. I did not test GCC, but I expect the behaviour of GCC to be the same in this case.

Fix it by using *name instead of module_entry->name.

Note: I found this using a static analysis tool and manually verified the issue.


EDIT: test failure "Test function gzfile() reading a gzip relative file [C:\projects\php-src\ext\zlib\tests\gzfile_basic.phpt]" seems unrelated