### PR TITLE
Saner array_(sum|product)()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -37,6 +37,8 @@ PHP 8.3 INTERNALS UPGRADE NOTES
 * The return types of the following functions have been changed from
   `bool` to `zend_result`:
   - zend_fiber_init_context()
+* The fast_add_function() has been removed, use add_function() that will
+  call the static inline add_function_fast() instead.
 
 ========================
 2. Build system changes

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -707,28 +707,6 @@ overflow: ZEND_ATTRIBUTE_COLD_LABEL
 #endif
 }
 
-static zend_always_inline zend_result fast_add_function(zval *result, zval *op1, zval *op2)
-{
-	if (EXPECTED(Z_TYPE_P(op1) == IS_LONG)) {
-		if (EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
-			fast_long_add_function(result, op1, op2);
-			return SUCCESS;
-		} else if (EXPECTED(Z_TYPE_P(op2) == IS_DOUBLE)) {
-			ZVAL_DOUBLE(result, ((double)Z_LVAL_P(op1)) + Z_DVAL_P(op2));
-			return SUCCESS;
-		}
-	} else if (EXPECTED(Z_TYPE_P(op1) == IS_DOUBLE)) {
-		if (EXPECTED(Z_TYPE_P(op2) == IS_DOUBLE)) {
-			ZVAL_DOUBLE(result, Z_DVAL_P(op1) + Z_DVAL_P(op2));
-			return SUCCESS;
-		} else if (EXPECTED(Z_TYPE_P(op2) == IS_LONG)) {
-			ZVAL_DOUBLE(result, Z_DVAL_P(op1) + ((double)Z_LVAL_P(op2)));
-			return SUCCESS;
-		}
-	}
-	return add_function(result, op1, op2);
-}
-
 static zend_always_inline void fast_long_sub_function(zval *result, zval *op1, zval *op2)
 {
 #if ZEND_USE_ASM_ARITHMETIC && defined(__i386__) && !(4 == __GNUC__ && 8 == __GNUC_MINOR__)

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5948,7 +5948,8 @@ PHP_FUNCTION(array_sum)
 				ZVAL_LONG(&tmp, 0);
 				add_function(return_value, return_value, &tmp);
 			}
-			// TODO Warning/Deprecation?
+			php_error_docref(NULL, E_WARNING, "Addition is not supported on type %s",
+				zend_zval_type_name(entry));
 		}
 	} ZEND_HASH_FOREACH_END();
 
@@ -6005,7 +6006,8 @@ PHP_FUNCTION(array_product)
 				ZVAL_LONG(&tmp, 0);
 				mul_function(return_value, return_value, &tmp);
 			}
-			// TODO Warning/Deprecation?
+			php_error_docref(NULL, E_WARNING, "Multiplication is not supported on type %s",
+				zend_zval_type_name(entry));
 		}
 	} ZEND_HASH_FOREACH_END();
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5942,7 +5942,7 @@ static void php_array_binop(INTERNAL_FUNCTION_PARAMETERS, const char *op_name, b
 				op(return_value, return_value, &tmp);
 			}
 			/* BC non numeric strings: previously were cast to 0 */
-			if (Z_TYPE_P(entry) == IS_STRING) {
+			else if (Z_TYPE_P(entry) == IS_STRING) {
 				zval tmp;
 				ZVAL_LONG(&tmp, 0);
 				op(return_value, return_value, &tmp);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5926,7 +5926,7 @@ PHP_FUNCTION(array_sum)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (zend_hash_num_elements(input) == 0) {
-		// TODO Deprecate empty array
+		php_error_docref(NULL, E_DEPRECATED, "Passing an empty array is deprecated");
 		RETURN_LONG(0);
 	}
 
@@ -5976,7 +5976,7 @@ PHP_FUNCTION(array_product)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (zend_hash_num_elements(input) == 0) {
-		// TODO Deprecate empty array
+		php_error_docref(NULL, E_DEPRECATED, "Passing an empty array is deprecated");
 		RETURN_LONG(1);
 	}
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5926,7 +5926,6 @@ static void php_array_binop(INTERNAL_FUNCTION_PARAMETERS, const char *op_name, b
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (zend_hash_num_elements(input) == 0) {
-		php_error_docref(NULL, E_DEPRECATED, "Passing an empty array is deprecated");
 		RETURN_LONG(initial);
 	}
 

--- a/ext/standard/tests/array/003.phpt
+++ b/ext/standard/tests/array/003.phpt
@@ -8,27 +8,27 @@ require(__DIR__ . '/data.inc');
 
 function cmp ($a, $b) {
     is_array ($a)
-        and $a = array_sum ($a);
+        and $a = count($a);
     is_array ($b)
-        and $b = array_sum ($b);
+        and $b = count($b);
     return strcmp ($a, $b);
 }
 
-echo " -- Testing uasort() -- \n";
+echo "-- Testing uasort() --\n";
 uasort ($data, 'cmp');
 var_dump ($data);
 
 
-echo "\n -- Testing uksort() -- \n";
+echo "\n-- Testing uksort() --\n";
 uksort ($data, 'cmp');
 var_dump ($data);
 
-echo "\n -- Testing usort() -- \n";
+echo "\n-- Testing usort() --\n";
 usort ($data, 'cmp');
 var_dump ($data);
 ?>
 --EXPECT--
--- Testing uasort() -- 
+-- Testing uasort() --
 array(8) {
   [16777216]=>
   float(-0.3333333333333333)
@@ -53,7 +53,7 @@ array(8) {
   string(4) "test"
 }
 
- -- Testing uksort() -- 
+-- Testing uksort() --
 array(8) {
   [-1000]=>
   array(2) {
@@ -78,7 +78,7 @@ array(8) {
   int(27)
 }
 
- -- Testing usort() -- 
+-- Testing usort() --
 array(8) {
   [0]=>
   float(-0.3333333333333333)

--- a/ext/standard/tests/array/array_product_empty_array.phpt
+++ b/ext/standard/tests/array/array_product_empty_array.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test array_product() function with empty array
+--FILE--
+<?php
+$input = [];
+var_dump(array_product($input));
+?>
+--EXPECTF--
+Deprecated: array_product(): Passing an empty array is deprecated in %s on line %d
+int(1)

--- a/ext/standard/tests/array/array_product_empty_array.phpt
+++ b/ext/standard/tests/array/array_product_empty_array.phpt
@@ -3,8 +3,17 @@ Test array_product() function with empty array
 --FILE--
 <?php
 $input = [];
+
+echo "array_product() version:\n";
 var_dump(array_product($input));
+
+echo "array_reduce() version:\n";
+var_dump(array_reduce($input, fn($carry, $value) => $carry * $value, 1));
 ?>
 --EXPECTF--
+array_product() version:
+
 Deprecated: array_product(): Passing an empty array is deprecated in %s on line %d
+int(1)
+array_reduce() version:
 int(1)

--- a/ext/standard/tests/array/array_product_empty_array.phpt
+++ b/ext/standard/tests/array/array_product_empty_array.phpt
@@ -10,10 +10,8 @@ var_dump(array_product($input));
 echo "array_reduce() version:\n";
 var_dump(array_reduce($input, fn($carry, $value) => $carry * $value, 1));
 ?>
---EXPECTF--
+--EXPECT--
 array_product() version:
-
-Deprecated: array_product(): Passing an empty array is deprecated in %s on line %d
 int(1)
 array_reduce() version:
 int(1)

--- a/ext/standard/tests/array/array_product_objects_operation_no_cast.phpt
+++ b/ext/standard/tests/array/array_product_objects_operation_no_cast.phpt
@@ -5,8 +5,20 @@ zend_test
 --FILE--
 <?php
 $input = [new DoOperationNoCast(25), new DoOperationNoCast(6), new DoOperationNoCast(10)];
+
+echo "array_product() version:\n";
 var_dump(array_product($input));
+
+echo "array_reduce() version:\n";
+var_dump(array_reduce($input, fn($carry, $value) => $carry * $value, 1));
 ?>
 --EXPECTF--
+array_product() version:
+
 Warning: Object of class DoOperationNoCast could not be converted to int|float in %s on line %d
 int(1)
+array_reduce() version:
+object(DoOperationNoCast)#5 (1) {
+  ["val":"DoOperationNoCast":private]=>
+  int(1500)
+}

--- a/ext/standard/tests/array/array_product_objects_operation_no_cast.phpt
+++ b/ext/standard/tests/array/array_product_objects_operation_no_cast.phpt
@@ -15,7 +15,11 @@ var_dump(array_reduce($input, fn($carry, $value) => $carry * $value, 1));
 --EXPECTF--
 array_product() version:
 
-Warning: Object of class DoOperationNoCast could not be converted to int|float in %s on line %d
+Warning: array_product(): Multiplication is not supported on type DoOperationNoCast in %s on line %d
+
+Warning: array_product(): Multiplication is not supported on type DoOperationNoCast in %s on line %d
+
+Warning: array_product(): Multiplication is not supported on type DoOperationNoCast in %s on line %d
 int(1)
 array_reduce() version:
 object(DoOperationNoCast)#5 (1) {

--- a/ext/standard/tests/array/array_product_objects_operation_no_cast.phpt
+++ b/ext/standard/tests/array/array_product_objects_operation_no_cast.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test array_product() function with objects that implement addition but not castable to numeric type
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+$input = [new DoOperationNoCast(25), new DoOperationNoCast(6), new DoOperationNoCast(10)];
+var_dump(array_product($input));
+?>
+--EXPECTF--
+Warning: Object of class DoOperationNoCast could not be converted to int|float in %s on line %d
+int(1)

--- a/ext/standard/tests/array/array_product_variation1.phpt
+++ b/ext/standard/tests/array/array_product_variation1.phpt
@@ -20,7 +20,7 @@ foreach ($types as $desc => $type) {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing array_product() : variation - using non numeric values ***
 boolean (true)
 int(1)
@@ -29,20 +29,28 @@ boolean (false)
 int(0)
 
 string
+
+Warning: array_product(): Multiplication is not supported on type string in %s on line %d
 int(0)
 
 numeric string
 int(12)
 
 resource
+
+Warning: array_product(): Multiplication is not supported on type resource in %s on line %d
 int(3)
 
 object
+
+Warning: array_product(): Multiplication is not supported on type A in %s on line %d
 int(1)
 
 null
 int(0)
 
 array
+
+Warning: array_product(): Multiplication is not supported on type array in %s on line %d
 int(1)
 

--- a/ext/standard/tests/array/array_product_variation1.phpt
+++ b/ext/standard/tests/array/array_product_variation1.phpt
@@ -7,22 +7,20 @@ echo "*** Testing array_product() : variation - using non numeric values ***\n";
 class A {
   static function help() { echo "hello\n"; }
 }
-$fp = fopen(__FILE__, "r");
 
 $types = array("boolean (true)" => true, "boolean (false)" => false,
        "string" => "hello", "numeric string" =>  "12",
-       "resource" => $fp, "object" => new A(), "null" => null,
+       "resource" => STDERR, "object" => new A(), "null" => null,
        "array" => array(3,2));
 
 foreach ($types as $desc => $type) {
-  echo $desc . "\n";
-  var_dump(array_product(array($type)));
+  echo $desc, "\n";
+  var_dump(array_product([1, $type]));
   echo "\n";
 }
 
-fclose($fp);
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing array_product() : variation - using non numeric values ***
 boolean (true)
 int(1)
@@ -37,7 +35,7 @@ numeric string
 int(12)
 
 resource
-int(%d)
+int(3)
 
 object
 int(1)

--- a/ext/standard/tests/array/array_product_variation5.phpt
+++ b/ext/standard/tests/array/array_product_variation5.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test array_product() function: ressources in array
+Test array_product() function: resources in array
 --FILE--
 <?php
 $input = [10, STDERR /* Should get casted to 3 as an integer */];

--- a/ext/standard/tests/array/array_product_variation5.phpt
+++ b/ext/standard/tests/array/array_product_variation5.phpt
@@ -3,8 +3,21 @@ Test array_product() function: ressources in array
 --FILE--
 <?php
 $input = [10, STDERR /* Should get casted to 3 as an integer */];
+
+echo "array_product() version:\n";
 var_dump(array_product($input));
+
+echo "array_reduce() version:\n";
+try {
+    var_dump(array_reduce($input, fn($carry, $value) => $carry * $value, 1));
+} catch (TypeError $e) {
+    echo $e->getMessage();
+}
 ?>
 --EXPECTF--
+array_product() version:
+
 Warning: array_product(): Multiplication is not supported on type resource in %s on line %d
 int(30)
+array_reduce() version:
+Unsupported operand types: int * resource

--- a/ext/standard/tests/array/array_product_variation5.phpt
+++ b/ext/standard/tests/array/array_product_variation5.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Test array_product() function: ressources in array
+--FILE--
+<?php
+$input = [10, STDERR /* Should get casted to 3 as an integer */];
+var_dump(array_product($input));
+?>
+--EXPECT--
+int(30)

--- a/ext/standard/tests/array/array_product_variation5.phpt
+++ b/ext/standard/tests/array/array_product_variation5.phpt
@@ -5,5 +5,6 @@ Test array_product() function: ressources in array
 $input = [10, STDERR /* Should get casted to 3 as an integer */];
 var_dump(array_product($input));
 ?>
---EXPECT--
+--EXPECTF--
+Warning: array_product(): Multiplication is not supported on type resource in %s on line %d
 int(30)

--- a/ext/standard/tests/array/array_product_variation6.phpt
+++ b/ext/standard/tests/array/array_product_variation6.phpt
@@ -5,7 +5,18 @@ gmp
 --FILE--
 <?php
 $input = [gmp_init(25), gmp_init(6)];
+
+echo "array_product() version:\n";
 var_dump(array_product($input));
+
+echo "array_reduce() version:\n";
+var_dump(array_reduce($input, fn($carry, $value) => $carry * $value, 1));
 ?>
 --EXPECT--
+array_product() version:
 int(150)
+array_reduce() version:
+object(GMP)#5 (1) {
+  ["num"]=>
+  string(3) "150"
+}

--- a/ext/standard/tests/array/array_product_variation6.phpt
+++ b/ext/standard/tests/array/array_product_variation6.phpt
@@ -8,4 +8,4 @@ $input = [gmp_init(25), gmp_init(6)];
 var_dump(array_product($input));
 ?>
 --EXPECT--
-int(1)
+int(150)

--- a/ext/standard/tests/array/array_product_variation6.phpt
+++ b/ext/standard/tests/array/array_product_variation6.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test array_product() function with objects castable to numeric type
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+$input = [gmp_init(25), gmp_init(6)];
+var_dump(array_product($input));
+?>
+--EXPECT--
+int(1)

--- a/ext/standard/tests/array/array_sum_empty_array.phpt
+++ b/ext/standard/tests/array/array_sum_empty_array.phpt
@@ -3,8 +3,17 @@ Test array_sum() function with empty array
 --FILE--
 <?php
 $input = [];
+
+echo "array_sum() version:\n";
 var_dump(array_sum($input));
+
+echo "array_reduce() version:\n";
+var_dump(array_reduce($input, fn($carry, $value) => $carry + $value, 0));
 ?>
 --EXPECTF--
+array_sum() version:
+
 Deprecated: array_sum(): Passing an empty array is deprecated in %s on line %d
+int(0)
+array_reduce() version:
 int(0)

--- a/ext/standard/tests/array/array_sum_empty_array.phpt
+++ b/ext/standard/tests/array/array_sum_empty_array.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test array_sum() function with empty array
+--FILE--
+<?php
+$input = [];
+var_dump(array_sum($input));
+?>
+--EXPECTF--
+Deprecated: array_sum(): Passing an empty array is deprecated in %s on line %d
+int(0)

--- a/ext/standard/tests/array/array_sum_empty_array.phpt
+++ b/ext/standard/tests/array/array_sum_empty_array.phpt
@@ -10,10 +10,8 @@ var_dump(array_sum($input));
 echo "array_reduce() version:\n";
 var_dump(array_reduce($input, fn($carry, $value) => $carry + $value, 0));
 ?>
---EXPECTF--
+--EXPECT--
 array_sum() version:
-
-Deprecated: array_sum(): Passing an empty array is deprecated in %s on line %d
 int(0)
 array_reduce() version:
 int(0)

--- a/ext/standard/tests/array/array_sum_objects_operation_no_cast.phpt
+++ b/ext/standard/tests/array/array_sum_objects_operation_no_cast.phpt
@@ -15,7 +15,9 @@ var_dump(array_reduce($input, fn($carry, $value) => $carry + $value, 0));
 --EXPECTF--
 array_sum() version:
 
-Warning: Object of class DoOperationNoCast could not be converted to int|float in %s on line %d
+Warning: array_sum(): Addition is not supported on type DoOperationNoCast in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type DoOperationNoCast in %s on line %d
 int(0)
 array_reduce() version:
 object(DoOperationNoCast)#5 (1) {

--- a/ext/standard/tests/array/array_sum_objects_operation_no_cast.phpt
+++ b/ext/standard/tests/array/array_sum_objects_operation_no_cast.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test array_sum() function with objects that implement addition but not castable to numeric type
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+$input = [new DoOperationNoCast(25), new DoOperationNoCast(6)];
+var_dump(array_sum($input));
+?>
+--EXPECTF--
+Warning: Object of class DoOperationNoCast could not be converted to int|float in %s on line %d
+int(0)

--- a/ext/standard/tests/array/array_sum_objects_operation_no_cast.phpt
+++ b/ext/standard/tests/array/array_sum_objects_operation_no_cast.phpt
@@ -5,8 +5,20 @@ zend_test
 --FILE--
 <?php
 $input = [new DoOperationNoCast(25), new DoOperationNoCast(6)];
+
+echo "array_sum() version:\n";
 var_dump(array_sum($input));
+
+echo "array_reduce() version:\n";
+var_dump(array_reduce($input, fn($carry, $value) => $carry + $value, 0));
 ?>
 --EXPECTF--
+array_sum() version:
+
 Warning: Object of class DoOperationNoCast could not be converted to int|float in %s on line %d
 int(0)
+array_reduce() version:
+object(DoOperationNoCast)#5 (1) {
+  ["val":"DoOperationNoCast":private]=>
+  int(31)
+}

--- a/ext/standard/tests/array/array_sum_objects_operation_no_cast_FFI.phpt
+++ b/ext/standard/tests/array/array_sum_objects_operation_no_cast_FFI.phpt
@@ -20,8 +20,8 @@ var_dump(array_reduce($input, fn($carry, $value) => $carry + $value, 0));
 --EXPECTF--
 array_sum() version:
 
-Warning: Object of class FFI\CData could not be converted to int|float in %s on line %d
-int(0)
+Warning: array_sum(): Addition is not supported on type FFI\CData in %s on line %d
+int(1)
 array_reduce() version:
 object(FFI\CData:int32_t*)#4 (1) {
   [0]=>

--- a/ext/standard/tests/array/array_sum_objects_operation_no_cast_FFI.phpt
+++ b/ext/standard/tests/array/array_sum_objects_operation_no_cast_FFI.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test array_sum() function with objects that implement addition but not castable to numeric type
+--EXTENSIONS--
+ffi
+--FILE--
+<?php
+
+$x = FFI::new("int[2]");
+$x[0] = 10;
+$x[1] = 25;
+
+$input = [$x, 1];
+
+echo "array_sum() version:\n";
+var_dump(array_sum($input));
+
+echo "array_reduce() version:\n";
+var_dump(array_reduce($input, fn($carry, $value) => $carry + $value, 0));
+?>
+--EXPECTF--
+array_sum() version:
+
+Warning: Object of class FFI\CData could not be converted to int|float in %s on line %d
+int(0)
+array_reduce() version:
+object(FFI\CData:int32_t*)#4 (1) {
+  [0]=>
+  int(25)
+}

--- a/ext/standard/tests/array/array_sum_variation7.phpt
+++ b/ext/standard/tests/array/array_sum_variation7.phpt
@@ -57,18 +57,48 @@ echo "-- array with mixed values --\n";
 var_dump( array_sum($input) );
 echo "Done"
 ?>
---EXPECT--
+--EXPECTF--
 *** Testing array_sum() : array with unexpected entries ***
 -- array with string values --
+
+Warning: array_sum(): Addition is not supported on type string in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type string in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type string in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type string in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type string in %s on line %d
 int(0)
 -- array with bool values --
 int(3)
 -- array with null values --
 int(0)
 -- array with subarrays --
+
+Warning: array_sum(): Addition is not supported on type array in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type array in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type array in %s on line %d
 int(0)
 -- array with object values --
+
+Warning: array_sum(): Addition is not supported on type MyClass in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type MyClass in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type MyClass in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type MyClass in %s on line %d
 int(0)
 -- array with mixed values --
+
+Warning: array_sum(): Addition is not supported on type string in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type string in %s on line %d
+
+Warning: array_sum(): Addition is not supported on type array in %s on line %d
 float(14)
 Done

--- a/ext/standard/tests/array/array_sum_variation7.phpt
+++ b/ext/standard/tests/array/array_sum_variation7.phpt
@@ -9,11 +9,6 @@ Test array_sum() function : usage variations - 'input' array with unexpected val
 
 echo "*** Testing array_sum() : array with unexpected entries ***\n";
 
-// empty array
-$input = array();
-echo "-- empty array --\n";
-var_dump( array_sum($input) );
-
 // string array
 $input = array('Apple', 'Banana', 'Carrot', 'Mango', 'Orange');
 echo "-- array with string values --\n";
@@ -64,8 +59,6 @@ echo "Done"
 ?>
 --EXPECT--
 *** Testing array_sum() : array with unexpected entries ***
--- empty array --
-int(0)
 -- array with string values --
 int(0)
 -- array with bool values --

--- a/ext/standard/tests/array/array_sum_variation8.phpt
+++ b/ext/standard/tests/array/array_sum_variation8.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Test array_sum() function: ressources in array
+--FILE--
+<?php
+$input = [10, STDERR /* Should get casted to 3 as an integer */];
+var_dump(array_sum($input));
+?>
+--EXPECT--
+int(13)

--- a/ext/standard/tests/array/array_sum_variation8.phpt
+++ b/ext/standard/tests/array/array_sum_variation8.phpt
@@ -5,5 +5,6 @@ Test array_sum() function: ressources in array
 $input = [10, STDERR /* Should get casted to 3 as an integer */];
 var_dump(array_sum($input));
 ?>
---EXPECT--
+--EXPECTF--
+Warning: array_sum(): Addition is not supported on type resource in %s on line %d
 int(13)

--- a/ext/standard/tests/array/array_sum_variation8.phpt
+++ b/ext/standard/tests/array/array_sum_variation8.phpt
@@ -3,8 +3,21 @@ Test array_sum() function: ressources in array
 --FILE--
 <?php
 $input = [10, STDERR /* Should get casted to 3 as an integer */];
+
+echo "array_sum() version:\n";
 var_dump(array_sum($input));
+
+echo "array_reduce() version:\n";
+try {
+    var_dump(array_reduce($input, fn($carry, $value) => $carry + $value, 0));
+} catch (TypeError $e) {
+    echo $e->getMessage();
+}
 ?>
 --EXPECTF--
+array_sum() version:
+
 Warning: array_sum(): Addition is not supported on type resource in %s on line %d
 int(13)
+array_reduce() version:
+Unsupported operand types: int + resource

--- a/ext/standard/tests/array/array_sum_variation8.phpt
+++ b/ext/standard/tests/array/array_sum_variation8.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test array_sum() function: ressources in array
+Test array_sum() function: resources in array
 --FILE--
 <?php
 $input = [10, STDERR /* Should get casted to 3 as an integer */];

--- a/ext/standard/tests/array/array_sum_variation9.phpt
+++ b/ext/standard/tests/array/array_sum_variation9.phpt
@@ -5,7 +5,18 @@ gmp
 --FILE--
 <?php
 $input = [gmp_init(25), gmp_init(6)];
+
+echo "array_sum() version:\n";
 var_dump(array_sum($input));
+
+echo "array_reduce() version:\n";
+var_dump(array_reduce($input, fn($carry, $value) => $carry + $value, 0));
 ?>
 --EXPECT--
+array_sum() version:
 int(31)
+array_reduce() version:
+object(GMP)#5 (1) {
+  ["num"]=>
+  string(2) "31"
+}

--- a/ext/standard/tests/array/array_sum_variation9.phpt
+++ b/ext/standard/tests/array/array_sum_variation9.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test array_sum() function with objects castable to numeric type
+--EXTENSIONS--
+gmp
+--FILE--
+<?php
+$input = [gmp_init(25), gmp_init(6)];
+var_dump(array_sum($input));
+?>
+--EXPECT--
+int(0)

--- a/ext/standard/tests/array/array_sum_variation9.phpt
+++ b/ext/standard/tests/array/array_sum_variation9.phpt
@@ -8,4 +8,4 @@ $input = [gmp_init(25), gmp_init(6)];
 var_dump(array_sum($input));
 ?>
 --EXPECT--
-int(0)
+int(31)

--- a/ext/standard/tests/array/bug35014.phpt
+++ b/ext/standard/tests/array/bug35014.phpt
@@ -5,7 +5,6 @@ Bug #35014 (array_product() always returns 0) (32bit)
 --FILE--
 <?php
 $tests = array(
-    array(),
     array(0),
     array(3),
     array(3, 3),
@@ -20,7 +19,6 @@ foreach ($tests as $v) {
 }
 ?>
 --EXPECT--
-int(1)
 int(0)
 int(3)
 int(9)

--- a/ext/standard/tests/array/bug35014_64bit.phpt
+++ b/ext/standard/tests/array/bug35014_64bit.phpt
@@ -7,7 +7,6 @@ precision=14
 --FILE--
 <?php
 $tests = array(
-    array(),
     array(0),
     array(3),
     array(3, 3),
@@ -22,7 +21,6 @@ foreach ($tests as $v) {
 }
 ?>
 --EXPECT--
-int(1)
 int(0)
 int(3)
 int(9)

--- a/ext/standard/tests/array/bug48484.phpt
+++ b/ext/standard/tests/array/bug48484.phpt
@@ -1,8 +1,0 @@
---TEST--
-Bug 48484 (array_product() always returns 0 for an empty array)
---FILE--
-<?php
-var_dump(array_product(array()));
-?>
---EXPECT--
-int(1)

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -717,6 +717,110 @@ static ZEND_METHOD(ZendTestForbidDynamicCall, callStatic)
 	zend_forbid_dynamic_call();
 }
 
+/* donc refers to DoOperationNoCast */
+static zend_class_entry *donc_ce;
+static zend_object_handlers donc_object_handlers;
+
+static zend_object* donc_object_create_ex(zend_class_entry* ce, zend_long l) {
+	zend_object *obj = zend_objects_new(ce);
+	object_properties_init(obj, ce);
+	obj->handlers = &donc_object_handlers;
+	ZVAL_LONG(OBJ_PROP_NUM(obj, 0), l);
+	return obj;
+}
+static zend_object *donc_object_create(zend_class_entry *ce) /* {{{ */
+{
+	return donc_object_create_ex(ce, 0);
+}
+/* }}} */
+
+static inline void donc_create(zval *target, zend_long l) /* {{{ */
+{
+	ZVAL_OBJ(target, donc_object_create_ex(donc_ce, l));
+}
+
+#define IS_DONC(zval) \
+	(Z_TYPE_P(zval) == IS_OBJECT && instanceof_function(Z_OBJCE_P(zval), donc_ce))
+
+static void donc_add(zval *result, zval *op1, zval *op2)
+{
+	zend_long val_1;
+	zend_long val_2;
+	if (IS_DONC(op1)) {
+		val_1 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op1), 0));
+	} else {
+		val_1 = zval_get_long(op1);
+	}
+	if (IS_DONC(op2)) {
+		val_2 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op2), 0));
+	} else {
+		val_2 = zval_get_long(op2);
+	}
+
+	donc_create(result, val_1 + val_2);
+}
+static void donc_mul(zval *result, zval *op1, zval *op2)
+{
+	zend_long val_1;
+	zend_long val_2;
+	if (IS_DONC(op1)) {
+		val_1 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op1), 0));
+	} else {
+		val_1 = zval_get_long(op1);
+	}
+	if (IS_DONC(op2)) {
+		val_2 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op2), 0));
+	} else {
+		val_2 = zval_get_long(op2);
+	}
+
+	donc_create(result, val_1 * val_2);
+}
+
+static zend_result donc_do_operation(zend_uchar opcode, zval *result, zval *op1, zval *op2)
+{
+	zval op1_copy;
+	zend_result status;
+
+	if (result == op1) {
+		ZVAL_COPY_VALUE(&op1_copy, op1);
+		op1 = &op1_copy;
+	}
+
+	switch (opcode) {
+		case ZEND_ADD:
+			donc_add(result, op1, op2);
+			if (UNEXPECTED(EG(exception))) { status = FAILURE; }
+			status = SUCCESS;
+			break;
+		case ZEND_MUL:
+			donc_mul(result, op1, op2);
+			if (UNEXPECTED(EG(exception))) { status = FAILURE; }
+			status = SUCCESS;
+			break;
+		default:
+			status = FAILURE;
+			break;
+	}
+
+	if (status == SUCCESS && op1 == &op1_copy) {
+		zval_ptr_dtor(op1);
+	}
+
+	return status;
+}
+
+PHP_METHOD(DoOperationNoCast, __construct)
+{
+	zend_long l;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(l)
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_LONG(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), l);
+}
+
 PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("zend_test.replace_zend_execute_ex", "0", PHP_INI_SYSTEM, OnUpdateBool, replace_zend_execute_ex, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.register_passes", "0", PHP_INI_SYSTEM, OnUpdateBool, register_passes, zend_zend_test_globals, zend_test_globals)
@@ -777,6 +881,12 @@ PHP_MINIT_FUNCTION(zend_test)
 	zend_test_unit_enum = register_class_ZendTestUnitEnum();
 	zend_test_string_enum = register_class_ZendTestStringEnum();
 	zend_test_int_enum = register_class_ZendTestIntEnum();
+
+	/* DoOperationNoCast class */
+    donc_ce = register_class_DoOperationNoCast();
+    donc_ce->create_object = donc_object_create;
+    memcpy(&donc_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    donc_object_handlers.do_operation = donc_do_operation;
 
 	zend_register_functions(NULL, ext_function_legacy, NULL, EG(current_module)->type);
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -883,10 +883,10 @@ PHP_MINIT_FUNCTION(zend_test)
 	zend_test_int_enum = register_class_ZendTestIntEnum();
 
 	/* DoOperationNoCast class */
-    donc_ce = register_class_DoOperationNoCast();
-    donc_ce->create_object = donc_object_create;
-    memcpy(&donc_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-    donc_object_handlers.do_operation = donc_do_operation;
+	donc_ce = register_class_DoOperationNoCast();
+	donc_ce->create_object = donc_object_create;
+	memcpy(&donc_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	donc_object_handlers.do_operation = donc_do_operation;
 
 	zend_register_functions(NULL, ext_function_legacy, NULL, EG(current_module)->type);
 

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -117,6 +117,11 @@ namespace {
         case Baz = -1;
     }
 
+    final class DoOperationNoCast {
+        private int $val;
+        public function __construct(int $val) {}
+    }
+
     function zend_test_array_return(): array {}
 
     function zend_test_nullable_array_return(): null|array {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3e2308593cea5289709dcfb1c9ee598de945d2e2 */
+ * Stub hash: 947056bfe52d586b8a4969e3022f84e83b677e0e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -160,6 +160,10 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ZendTestForbidDynamicCall_callStatic arginfo_zend_test_void_return
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DoOperationNoCast___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, val, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 #if (PHP_VERSION_ID >= 80100)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZendTestNS_Foo_method, 0, 0, IS_LONG, 0)
 #else
@@ -223,6 +227,7 @@ static ZEND_METHOD(ZendTestClassWithMethodWithParameterAttribute, override);
 static ZEND_METHOD(ZendTestChildClassWithMethodWithParameterAttribute, override);
 static ZEND_METHOD(ZendTestForbidDynamicCall, call);
 static ZEND_METHOD(ZendTestForbidDynamicCall, callStatic);
+static ZEND_METHOD(DoOperationNoCast, __construct);
 static ZEND_METHOD(ZendTestNS_Foo, method);
 static ZEND_METHOD(ZendTestNS_UnlikelyCompileError, method);
 static ZEND_METHOD(ZendTestNS2_Foo, method);
@@ -349,6 +354,12 @@ static const zend_function_entry class_ZendTestStringEnum_methods[] = {
 
 
 static const zend_function_entry class_ZendTestIntEnum_methods[] = {
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_DoOperationNoCast_methods[] = {
+	ZEND_ME(DoOperationNoCast, __construct, arginfo_class_DoOperationNoCast___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -694,6 +705,23 @@ static zend_class_entry *register_class_ZendTestIntEnum(void)
 	return class_entry;
 }
 #endif
+
+static zend_class_entry *register_class_DoOperationNoCast(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "DoOperationNoCast", class_DoOperationNoCast_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	zval property_val_default_value;
+	ZVAL_UNDEF(&property_val_default_value);
+	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_val_name);
+
+	return class_entry;
+}
 
 static zend_class_entry *register_class_ZendTestNS_Foo(void)
 {

--- a/ext/zend_test/tests/do_operation_not_cast.phpt
+++ b/ext/zend_test/tests/do_operation_not_cast.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test DoOperationNotCast dummy class
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+$a = new DoOperationNoCast(25);
+$b = new DoOperationNoCast(6);
+
+var_dump($a + $b);
+var_dump($a * $b);
+
+?>
+--EXPECT--
+object(DoOperationNoCast)#3 (1) {
+  ["val":"DoOperationNoCast":private]=>
+  int(31)
+}
+object(DoOperationNoCast)#3 (1) {
+  ["val":"DoOperationNoCast":private]=>
+  int(150)
+}


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/saner-array-sum-product

The current behaviour of ``array_sum()`` and ``array_product()`` is outright insane.
 - It ignores entries that are arrays or objects without any warning
 - It casts the remaining values to ``int|float`` to perform the operation, this includes resources and non-numeric strings which as of PHP 8.0 throw ``TypeError``s when used with arithmetic operations.

The objective of this PR, and yet to be written RFC, is to align the behaviour of these two functions as close as possible to doing: ``array_reduce($input, fn($carry, $value) => $carry + $value, 0)`` for ``array_sum($input)`` and ``array_reduce($input, fn($carry, $value) => $carry * $value, 1)`` for ``array_product($input)``.

To achieve this in a backwards compatible manner, we emit warnings for types which should throw type errors while still applying the current behaviour. Moreover, we now support performing the binary operation on objects that support it instead of ignoring them.

The one difference with the ``array_reduce()`` implementation is that if the traversal of the array encountered objects that supported the relevant binary operation, it also needs to be castable to ``int|float`` to preserve the return type of these functions.