### PR TITLE
Fix null pointer dereference of param

### DIFF
--- a/sapi/phpdbg/phpdbg_bp.c
+++ b/sapi/phpdbg/phpdbg_bp.c
@@ -829,19 +829,21 @@ static inline void phpdbg_create_conditional_break(phpdbg_breakcond_t *brake, co
 	uint32_t cops = CG(compiler_options);
 	zend_string *bp_code;
 
-	switch (param->type) {
-	    case STR_PARAM:
-		case NUMERIC_FUNCTION_PARAM:
-		case METHOD_PARAM:
-		case NUMERIC_METHOD_PARAM:
-		case FILE_PARAM:
-		case ADDR_PARAM:
-		    /* do nothing */
-		break;
+	if (param) {
+		switch (param->type) {
+			case STR_PARAM:
+			case NUMERIC_FUNCTION_PARAM:
+			case METHOD_PARAM:
+			case NUMERIC_METHOD_PARAM:
+			case FILE_PARAM:
+			case ADDR_PARAM:
+				/* do nothing */
+			break;
 
-		default:
-			phpdbg_error("Invalid parameter type for conditional breakpoint");
-			return;
+			default:
+				phpdbg_error("Invalid parameter type for conditional breakpoint");
+				return;
+		}
 	}
 
 	PHPDBG_BREAK_INIT(new_break, PHPDBG_BREAK_COND);


### PR DESCRIPTION
When the validation logic for param->type was added, the logic did not account for the case where param could be NULL. The existing code did take that into account as can be seen in the `if (param)` check below. Furthermore, phpdbg_set_breakpoint_expression even calls phpdbg_create_conditional_break with param == NULL.

Fix it by placing the validation logic inside a NULL check.

Note: I found this issue using a static analysis tool and manually checked the code.