### PR TITLE
Expose zendi_try_get_long() function via a public API

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -375,7 +375,7 @@ static zend_always_inline zend_result zendi_try_convert_scalar_to_number(zval *o
 }
 /* }}} */
 
-static zend_never_inline zend_long ZEND_FASTCALL zendi_try_get_long(zval *op, bool *failed) /* {{{ */
+static zend_never_inline zend_long ZEND_FASTCALL zendi_try_get_long(const zval *op, bool *failed) /* {{{ */
 {
 	*failed = 0;
 	switch (Z_TYPE_P(op)) {
@@ -452,6 +452,15 @@ static zend_never_inline zend_long ZEND_FASTCALL zendi_try_get_long(zval *op, bo
 	}
 }
 /* }}} */
+
+ZEND_API zend_long ZEND_FASTCALL zval_try_get_long(const zval *op, bool *failed)
+{
+	if (EXPECTED(Z_TYPE_P(op) == IS_LONG)) {
+		*failed = false;
+		return Z_LVAL_P(op);
+	}
+	return zendi_try_get_long(op, failed);
+}
 
 #define ZEND_TRY_BINARY_OP1_OBJECT_OPERATION(opcode) \
 	if (UNEXPECTED(Z_TYPE_P(op1) == IS_OBJECT) \

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -275,6 +275,7 @@ ZEND_API void ZEND_FASTCALL convert_to_array(zval *op);
 ZEND_API void ZEND_FASTCALL convert_to_object(zval *op);
 
 ZEND_API zend_long    ZEND_FASTCALL zval_get_long_func(const zval *op, bool is_strict);
+ZEND_API zend_long    ZEND_FASTCALL zval_try_get_long(const zval *op, bool *failed);
 ZEND_API double       ZEND_FASTCALL zval_get_double_func(const zval *op);
 ZEND_API zend_string* ZEND_FASTCALL zval_get_string_func(zval *op);
 ZEND_API zend_string* ZEND_FASTCALL zval_try_get_string_func(zval *op);


### PR DESCRIPTION
We probably should be exposing ``zendi_try_convert_scalar_to_number()`` as well as this would make the implementation of #10161 slightly easier because I find it kinda insane that the APIs we provide to get certain types just blindly accept arrays and non-representable objects by making them return somewhat arbitrary values even though for int/float we consider this UB.