### PR TITLE
Allow 'h' and 'k' flags to be combined for mb_convert_kana

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -3185,10 +3185,7 @@ next_option:
 		 * or all FW hiragana to FW katakana, or all FW katakana to FW hiragana, but not
 		 * more than one of these */
 		if (opt & MBFL_ZEN2HAN_HIRAGANA) {
-			if (opt & MBFL_ZEN2HAN_KATAKANA) {
-				zend_argument_value_error(2, "must not combine 'h' and 'k' flags");
-				RETURN_THROWS();
-			} else if (opt & MBFL_ZENKAKU_HIRA2KATA) {
+			if (opt & MBFL_ZENKAKU_HIRA2KATA) {
 				zend_argument_value_error(2, "must not combine 'h' and 'C' flags");
 				RETURN_THROWS();
 			} else if (opt & MBFL_ZENKAKU_KATA2HIRA) {

--- a/ext/mbstring/tests/mb_convert_kana.phpt
+++ b/ext/mbstring/tests/mb_convert_kana.phpt
@@ -78,6 +78,7 @@ echo bin2hex(mb_convert_kana("\x30\x9B", 'k', 'UTF-16BE')), "\n";
 echo bin2hex(mb_convert_kana("\x30\x9C", 'k', 'UTF-16BE')), "\n";
 echo bin2hex(mb_convert_kana("\x30\xFC", 'k', 'UTF-16BE')), "\n";
 echo bin2hex(mb_convert_kana("\x30\xFB", 'k', 'UTF-16BE')), "\n";
+echo bin2hex(mb_convert_kana("fooあいうエオ", "rnaskh", "UTF-8")), "\n";
 echo "Including one which will expand to two codepoints:\n";
 echo bin2hex(mb_convert_kana("\x30\x52", 'h', 'UTF-16BE')), "\n\n";
 
@@ -117,7 +118,6 @@ tryIncompatibleFlags('R', 'r');
 tryIncompatibleFlags('N', 'n');
 tryIncompatibleFlags('S', 's');
 tryIncompatibleFlags('K', 'H');
-tryIncompatibleFlags('k', 'h');
 tryIncompatibleFlags('C', 'c');
 tryIncompatibleFlags('M', 'm');
 tryIncompatibleFlags('h', 'C');
@@ -204,6 +204,7 @@ ff9e
 ff9f
 ff70
 ff65
+666f6fefbdb1efbdb2efbdb3efbdb4efbdb5
 Including one which will expand to two codepoints:
 ff79ff9e
 
@@ -237,8 +238,6 @@ mb_convert_kana(): Argument #2 ($mode) must not combine 'S' and 's' flags
 mb_convert_kana(): Argument #2 ($mode) must not combine 'S' and 's' flags
 mb_convert_kana(): Argument #2 ($mode) must not combine 'H' and 'K' flags
 mb_convert_kana(): Argument #2 ($mode) must not combine 'H' and 'K' flags
-mb_convert_kana(): Argument #2 ($mode) must not combine 'h' and 'k' flags
-mb_convert_kana(): Argument #2 ($mode) must not combine 'h' and 'k' flags
 mb_convert_kana(): Argument #2 ($mode) must not combine 'C' and 'c' flags
 mb_convert_kana(): Argument #2 ($mode) must not combine 'C' and 'c' flags
 mb_convert_kana(): Argument #2 ($mode) must not combine 'M' and 'm' flags


### PR DESCRIPTION
The 'h' flag makes mb_convert_kana convert zenkaku hiragana to hankaku katakana; 'k' makes it convert zenkaku katakana to hankaku katakana.

When working on the implementation of mb_convert_kana, I added some additional checks to catch combinations of flags which do not make sense; but there is no conflict between 'h' and 'k' (they control conversions for two disjoint ranges of codepoints) and this combination should not have been restricted.

Thanks to the GitHub user 'akira345' for reporting this problem.

Closes GH-10174.

FYA @cmb69 @youkidearitai 