### PR TITLE
Fix use-after-free in write_property when object is released

### DIFF
--- a/Zend/tests/gh10169.phpt
+++ b/Zend/tests/gh10169.phpt
@@ -1,0 +1,37 @@
+--TEST--
+GH-10169: Fix use-after-free when releasing object during property assignment
+--FILE--
+<?php
+class A
+{
+    public string $prop;
+}
+class B
+{
+    public function __toString()
+    {
+        global $a;
+        $a = null;
+        return str_repeat('a', 1);
+    }
+}
+
+$a = new A();
+try {
+    $a->prop = new B();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+$a = new A();
+$a->prop = '';
+try {
+    $a->prop = new B();
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Object was released while assigning property A::$prop
+Object was released while assigning property A::$prop

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -894,6 +894,12 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_readonly_property_indirect_modificati
 		ZSTR_VAL(info->ce->name), zend_get_unmangled_property_name(info->name));
 }
 
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_object_released_while_assigning_to_property_error(const zend_property_info *info)
+{
+	zend_throw_error(NULL, "Object was released while assigning property %s::$%s",
+		ZSTR_VAL(info->ce->name), zend_get_unmangled_property_name(info->name));
+}
+
 static const zend_class_entry *resolve_single_class_type(zend_string *name, const zend_class_entry *self_ce) {
 	if (zend_string_equals_literal_ci(name, "self")) {
 		return self_ce;

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -82,6 +82,8 @@ ZEND_API ZEND_COLD void zend_wrong_string_offset_error(void);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_readonly_property_modification_error(const zend_property_info *info);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_readonly_property_indirect_modification_error(const zend_property_info *info);
 
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_object_released_while_assigning_to_property_error(const zend_property_info *info);
+
 ZEND_API bool zend_verify_scalar_type_hint(uint32_t type_mask, zval *arg, bool strict, bool is_internal_arg);
 ZEND_API ZEND_COLD void zend_verify_arg_error(
 		const zend_function *zf, const zend_arg_info *arg_info, uint32_t arg_num, zval *value);


### PR DESCRIPTION
Fixes GH-10169

This fix does some additional refcounting in `write_property` (particularly before/after `zend_verify_property_type`) to detect releasing the object. That's unfortunate because it's not *really* needed as usually one can't modify local variables of other stack frames. Globals are the exception to this rule.

This fix throws an error when the object gets released. However, it's not completely obvious to me if this is the "correct" behavior. It sounds more intuitive to drop the assignment. However, that is non-trivial as `zend_std_write_property` must return a pointer to some `zval` which should contain the assigned value. But as the object is released we can't point into its properties as usual, and allocating a `zval` would mean that the caller of `write_property` needs to release it.

So, I wonder if this is something actually worth fixing...