### PR TITLE
php.init: set variables_order to EGPCS

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -151,8 +151,8 @@
 
 ; variables_order
 ;   Default Value: "EGPCS"
-;   Development Value: "GPCS"
-;   Production Value: "GPCS"
+;   Development Value: "EGPCS"
+;   Production Value: "EGPCS"
 
 ; zend.exception_ignore_args
 ;   Default Value: Off
@@ -644,10 +644,10 @@ report_memleaks = On
 ; can still get access to the environment variables through getenv() should you
 ; need to.
 ; Default Value: "EGPCS"
-; Development Value: "GPCS"
-; Production Value: "GPCS";
+; Development Value: "EGPCS"
+; Production Value: "EGPCS";
 ; http://php.net/variables-order
-variables_order = "GPCS"
+variables_order = "EGPCS"
 
 ; This directive determines which super global data (G,P & C) should be
 ; registered into the super global array REQUEST. If so, it also determines

--- a/php.ini-production
+++ b/php.ini-production
@@ -151,8 +151,8 @@
 
 ; variables_order
 ;   Default Value: "EGPCS"
-;   Development Value: "GPCS"
-;   Production Value: "GPCS"
+;   Development Value: "EGPCS"
+;   Production Value: "EGPCS"
 
 ; zend.exception_ignore_args
 ;   Default Value: Off
@@ -646,10 +646,10 @@ report_memleaks = On
 ; can still get access to the environment variables through getenv() should you
 ; need to.
 ; Default Value: "EGPCS"
-; Development Value: "GPCS"
-; Production Value: "GPCS";
+; Development Value: "EGPCS"
+; Production Value: "EGPCS";
 ; http://php.net/variables-order
-variables_order = "GPCS"
+variables_order = "EGPCS"
 
 ; This directive determines which super global data (G,P & C) should be
 ; registered into the super global array REQUEST. If so, it also determines


### PR DESCRIPTION
heyho,

during development i encountered some issues with $_ENV and cli scripts invoked like this:

```shell
$ CONFIG_TARGET=qa composer symlinks
```

which was odd, because on my debian box this worked fine but on a macos install via homebrew it was not working. we noticed that variables_order was set to `GPCS` and thus ommitting the $_ENV superglobal i required to have the `CONFIG_TARGET` set.

after some digging around, i found the formular for php on homebrew with its source for the default configuration:

https://github.com/Homebrew/homebrew-core/blob/56299f3dac37eaf9fe0b1e187b889f559a74be26/Formula/php.rb#L219
```rb
    config_files = {
      "php.ini-development"   => "php.ini",
      "php.ini-production"    => "php.ini-production",
      "sapi/fpm/php-fpm.conf" => "php-fpm.conf",
      "sapi/fpm/www.conf"     => "php-fpm.d/www.conf",
    }
```

the default for the `variables_order` is defined as `ECPGS` in the [documentation](https://www.php.net/manual/en/ini.core.php) but both the `php.ini-production` and `php.ini-development` had those set to `GPCS` which contradicts the dokumentation.

the current dockerhub image also uses EGPCS as a sane default

```
$ docker run --pull=always -it --rm php php -i 2>/dev/null | grep variables_order
variables_order => EGPCS => EGPCS
```

so i figured the right thing to do is to update both php.ini files according to the documentation.
