### PR TITLE
Fix variation5-win32(-mb).phpt wrt. parallel test execution

### DIFF
--- a/ext/standard/tests/file/file_variation5-win32-mb.phpt
+++ b/ext/standard/tests/file/file_variation5-win32-mb.phpt
@@ -14,7 +14,7 @@ chdir($script_directory);
 $test_dirname = basename(__FILE__, ".php") . "私はガラスを食べられますtestdir";
 mkdir($test_dirname);
 
-$filepath = __DIR__ . '/file_variation_5.tmp';
+$filepath = __DIR__ . '/file_variation_5_mb.tmp';
 $filename = basename($filepath);
 $fd = fopen($filepath, "w+");
 fwrite($fd, "Line 1\nLine 2\nLine 3");
@@ -35,8 +35,8 @@ chdir($script_directory);
 --CLEAN--
 <?php
 $test_dirname = __DIR__ . '/' . basename(__FILE__, ".clean.php") . "私はガラスを食べられますtestdir";
-$filepath = __DIR__ . '/file_variation_5.tmp';
-unlink($filepath);
+$filepath = __DIR__ . '/file_variation_5_mb.tmp';
+@unlink($filepath);
 rmdir($test_dirname);
 ?>
 --EXPECT--

--- a/ext/standard/tests/file/file_variation5-win32.phpt
+++ b/ext/standard/tests/file/file_variation5-win32.phpt
@@ -36,7 +36,7 @@ chdir($script_directory);
 <?php
 $test_dirname = __DIR__ . '/' . basename(__FILE__, ".clean.php") . "testdir";
 $filepath = __DIR__ . '/file_variation_5.tmp';
-unlink($filepath); // Should be delete via the symlink deletion
+@unlink($filepath);
 rmdir($test_dirname);
 ?>
 --EXPECT--


### PR DESCRIPTION
Each test should use its own temporary filenames to avoid issues when the tests are executed in parallel[1].  We also silence the `unlink()` calls in the CLEAN section just in case.

And while we're at it, we also remove the erroneous comment; there is no symlinking involved for the Windows test variants.

[1] <https://github.com/php/php-src/pull/10175#issuecomment-1366809933>

---

cc @Girgias