### PR TITLE
Fix memory leak in posix_ttyname()

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -547,15 +547,15 @@ PHP_FUNCTION(posix_ttyname)
 		efree(p);
 		RETURN_FALSE;
 	}
-	RETURN_STRING(p);
+	RETVAL_STRING(p);
 	efree(p);
 #else
 	if (NULL == (p = ttyname(fd))) {
 		POSIX_G(last_error) = errno;
 		RETURN_FALSE;
 	}
-#endif
 	RETURN_STRING(p);
+#endif
 }
 /* }}} */
 


### PR DESCRIPTION
Not sure how to write a test case for this.

The other thing I don't get is why we only use ``ttyname_r()`` in ZTS builds.