### PR TITLE
Fix GH-9209: precision 0 -INF

### DIFF
--- a/Zend/tests/gh9209.phpt
+++ b/Zend/tests/gh9209.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-9209 (precision 0 -INF)
+--FILE--
+<?php
+ini_set("precision", 0);
+
+var_dump((string)INF);
+var_dump((string)-INF);
+var_dump((string)NAN);
+var_dump((string)-NAN);
+var_dump((string)-123);
+?>
+--EXPECT--
+string(3) "INF"
+string(4) "-INF"
+string(3) "NAN"
+string(3) "NAN"
+string(4) "-123"

--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -4523,7 +4523,7 @@ ZEND_API char *zend_gcvt(double value, int ndigit, char dec_point, char exponent
 		 * Infinity or NaN, convert to inf or nan with sign.
 		 * We assume the buffer is at least ndigit long.
 		 */
-		snprintf(buf, ndigit + 1, "%s%s", (sign && *digits == 'I') ? "-" : "", *digits == 'I' ? "INF" : "NAN");
+		snprintf(buf, (sign && *digits == 'I') + 4, "%s%s", (sign && *digits == 'I') ? "-" : "", *digits == 'I' ? "INF" : "NAN");
 		zend_freedtoa(digits);
 		return (buf);
 	}

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -1078,7 +1078,8 @@ static xmlNodePtr to_xml_double(encodeTypePtr type, zval *data, int style, xmlNo
 
 	ZVAL_DOUBLE(&tmp, zval_get_double(data));
 
-	str = (char *) safe_emalloc(EG(precision) >= 0 ? EG(precision) : 17, 1, MAX_LENGTH_OF_DOUBLE + 1);
+	/* We need at least 5 bytes for the -INF exceptional case. */
+	str = (char *) safe_emalloc(EG(precision) >= 0 ? MAX(EG(precision), 5) : 17, 1, MAX_LENGTH_OF_DOUBLE + 1);
 	zend_gcvt(Z_DVAL(tmp), EG(precision), '.', 'E', str);
 	xmlNodeSetContentLen(ret, BAD_CAST(str), strlen(str));
 	efree(str);


### PR DESCRIPTION
As suggested by cmb69, this is fixed by changing zend_gcvt() and verifying whether the callers have enough buffer space.
The only place that did not allocate enough buffer space was in php_encoding.c. However, it actually uses `safe_emalloc` with an offset of `MAX_LENGTH_OF_DOUBLE + 1` so it wouldn't have overflowed in practice I guess, but I think it's still better to not rely on the overflow protection and do it properly.