### PR TITLE
ext/opcache/zend_shared_alloc: add assertions on "locked" flag

### DIFF
--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -453,6 +453,8 @@ void zend_shared_alloc_safe_unlock(void)
 
 void zend_shared_alloc_lock(void)
 {
+	ZEND_ASSERT(!ZCG(locked));
+
 #ifndef ZEND_WIN32
 	struct flock mem_write_lock;
 
@@ -490,6 +492,8 @@ void zend_shared_alloc_lock(void)
 
 void zend_shared_alloc_unlock(void)
 {
+	ZEND_ASSERT(ZCG(locked));
+
 #ifndef ZEND_WIN32
 	struct flock mem_write_unlock;
 

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -336,6 +336,8 @@ static size_t zend_shared_alloc_get_largest_free_block(void)
 
 void *zend_shared_alloc(size_t size)
 {
+	ZEND_ASSERT(ZCG(locked));
+
 	int i;
 	unsigned int block_size = ZEND_ALIGNED_SIZE(size);
 
@@ -343,11 +345,6 @@ void *zend_shared_alloc(size_t size)
 		zend_accel_error_noreturn(ACCEL_LOG_ERROR, "Possible integer overflow in shared memory allocation (%zu + %zu)", size, PLATFORM_ALIGNMENT);
 	}
 
-#if 1
-	if (!ZCG(locked)) {
-		zend_accel_error_noreturn(ACCEL_LOG_ERROR, "Shared memory lock not obtained");
-	}
-#endif
 	if (block_size > ZSMMG(shared_free)) { /* No hope to find a big-enough block */
 		SHARED_ALLOC_FAILED();
 		return NULL;


### PR DESCRIPTION
Let the PHP process crash if a bug causes incorrect locking calls.