### PR TITLE
Fix GH-10202: posix_getgr(gid|nam)_basic.phpt fail

### DIFF
--- a/ext/posix/tests/posix_getgrgid_basic.phpt
+++ b/ext/posix/tests/posix_getgrgid_basic.phpt
@@ -17,7 +17,7 @@ Basic test of POSIX getgid and getgrid functions
 Array
 (
     [name] => %s
-    [passwd] => %a
+    [passwd] => %A
     [members] => Array
 %a
 

--- a/ext/posix/tests/posix_getgrnam_basic.phpt
+++ b/ext/posix/tests/posix_getgrnam_basic.phpt
@@ -20,7 +20,7 @@ array(4) {
   ["name"]=>
   string(%d) "%s"
   ["passwd"]=>
-  string(1) "%s"
+  string(%d) "%S"
   ["members"]=>
 %a
   ["gid"]=>


### PR DESCRIPTION
The issue was that passwd was empty for the issue reporter, but the test expected passwd to be non-empty. An empty passwd can occur if there is no (encrypted) group password set up.