### PR TITLE
Fix GH-10200 (zif_get_object_vars: Assertion `!(((__ht)->u.flags & (1<<2)) != 0)' failed.)

### DIFF
--- a/Zend/tests/gh10200.phpt
+++ b/Zend/tests/gh10200.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-10200 (zif_get_object_vars: Assertion `!(((__ht)->u.flags & (1<<2)) != 0)' failed.)
+--FILE--
+<?php
+
+$xmlData = <<<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<document>https://github.com/php/php-src/issues/10200 not encountered</document>
+EOF;
+
+$xml = simplexml_load_string($xmlData);
+$output = get_object_vars($xml);
+var_dump($output);
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(59) "https://github.com/php/php-src/issues/10200 not encountered"
+}

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -760,7 +760,7 @@ ZEND_FUNCTION(get_object_vars)
 	} else {
 		array_init_size(return_value, zend_hash_num_elements(properties));
 
-		ZEND_HASH_MAP_FOREACH_KEY_VAL(properties, num_key, key, value) {
+		ZEND_HASH_FOREACH_KEY_VAL(properties, num_key, key, value) {
 			bool is_dynamic = 1;
 			if (Z_TYPE_P(value) == IS_INDIRECT) {
 				value = Z_INDIRECT_P(value);


### PR DESCRIPTION
Analysis is in GH-10200.
This restores the behaviour of PHP<8.2.

I manually checked the other places where https://github.com/php/php-src/commit/90b7bde61507cee1c6b37f153909d72f5b203b8c made modifications, but they look alright to me. I *think*  this is the only bug that was introduced back then.

One little oddity remains (that was already present in older PHP versions):
According to [the man page of `get_object_vars`](https://www.php.net/manual/en/function.get-object-vars):
> Returns an associative array of defined object accessible non-static properties for the specified object in scope. 

I guess that might be a bit confusing because for example we can see in the test example here the keys are all integer indices.