### PR TITLE
Performance optimizations for mb_strlen and encoding conversion of SJIS, UHC, CP936, BIG5 text

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2041,7 +2041,10 @@ static zend_string* mb_get_substr(zend_string *input, size_t from, size_t len, c
 			len = in_len;
 		}
 		return zend_string_init_fast((const char*)in, len);
-	} else if (enc->mblen_table != NULL) {
+	} else if (enc->mblen_table) {
+		/* The use of the `mblen_table` means that for encodings like MacJapanese,
+		 * we treat each character in its native charset as "1 character", even if it
+		 * maps to a sequence of several codepoints */
 		const unsigned char *mbtab = enc->mblen_table;
 		unsigned char *limit = in + in_len;
 		while (from && in < limit) {
@@ -2254,7 +2257,21 @@ PHP_FUNCTION(mb_substr)
 
 	size_t mblen = 0;
 	if (from < 0 || (!len_is_null && len < 0)) {
-		mblen = mb_get_strlen(str, enc);
+		if (enc->mblen_table) {
+			/* Because we use the `mblen_table` when iterating over the string and
+			 * extracting the requested part, we also need to use it here for counting
+			 * the "length" of the string
+			 * Otherwise, we can get wrong results for text encodings like MacJapanese,
+			 * where one native 'character' can map to a sequence of several codepoints */
+			const unsigned char *mbtab = enc->mblen_table;
+			unsigned char *p = (unsigned char*)ZSTR_VAL(str), *e = p + ZSTR_LEN(str);
+			while (p < e) {
+				p += mbtab[*p];
+				mblen++;
+			}
+		} else {
+			mblen = mb_get_strlen(str, enc);
+		}
 	}
 
 	/* if "from" position is negative, count start position from the end

--- a/ext/mbstring/tests/mb_str_split_jp.phpt
+++ b/ext/mbstring/tests/mb_str_split_jp.phpt
@@ -80,6 +80,23 @@ foreach (['SJIS', 'SJIS-2004', 'MacJapanese', 'SJIS-Mobile#DOCOMO', 'SJIS-Mobile
     echo "$encoding: [" . implode(', ', array_map('bin2hex', $array)) . "]\n";
 }
 
+/*
+Some MacJapanese characters map to a sequence of several Unicode codepoints. Examples:
+
+0x85AB  0xF862+0x0058+0x0049+0x0049+0x0049  # roman numeral thirteen
+0x85AC  0xF861+0x0058+0x0049+0x0056 # roman numeral fourteen
+0x85AD  0xF860+0x0058+0x0056    # roman numeral fifteen
+0x85BF  0xF862+0x0078+0x0069+0x0069+0x0069  # small roman numeral thirteen
+0x85C0  0xF861+0x0078+0x0069+0x0076 # small roman numeral fourteen
+0x85C1  0xF860+0x0078+0x0076    # small roman numeral fifteen
+
+Even though they map to multiple codepoints, mb_str_split treats these as ONE character each
+*/
+
+echo "== MacJapanese characters which map to 3-5 codepoints each ==\n";
+echo "[", implode(', ', array_map('bin2hex', mb_str_split("abc\x85\xAB\x85\xAC\x85\xAD", 1, 'MacJapanese'))), "]\n";
+echo "[", implode(', ', array_map('bin2hex', mb_str_split("abc\x85\xBF\x85\xC0\x85\xC1", 2, 'MacJapanese'))), "]\n";
+
 ?>
 --EXPECT--
 BIG-5: a4e9 a5bb
@@ -104,3 +121,6 @@ SJIS-Mobile#KDDI: [80a1, 6162, 6380, a1]
 SJIS-Mobile#KDDI: [6162, 63fd, feff, 6162, fdfe, ff]
 SJIS-Mobile#SoftBank: [80a1, 6162, 6380, a1]
 SJIS-Mobile#SoftBank: [6162, 63fd, feff, 6162, fdfe, ff]
+== MacJapanese characters which map to 3-5 codepoints each ==
+[61, 62, 63, 85ab, 85ac, 85ad]
+[6162, 6385bf, 85c085c1]

--- a/ext/mbstring/tests/mb_strlen.phpt
+++ b/ext/mbstring/tests/mb_strlen.phpt
@@ -93,7 +93,7 @@ try {
 6
 == MacJapanese ==
 2
-6
+7
 == SJIS-2004 ==
 2
 6

--- a/ext/mbstring/tests/mb_substr.phpt
+++ b/ext/mbstring/tests/mb_substr.phpt
@@ -64,6 +64,16 @@ echo "SJIS-Mobile#SoftBank:\n";
 print bin2hex(mb_substr("\x80abc\x80\xA1", 3, 2, 'SJIS-Mobile#SoftBank')) . "\n";
 print bin2hex(mb_substr("\x80abc\x80\xA1", 0, 3, 'SJIS-Mobile#SoftBank')) . "\n";
 
+echo "-- Testing MacJapanese characters which map to 3-5 codepoints each --\n";
+
+/* There are many characters in MacJapanese which map to sequences of several codepoints */
+print bin2hex(mb_substr("abc\x85\xAB\x85\xAC\x85\xAD", 0, 3, 'MacJapanese')) . "\n";
+print bin2hex(mb_substr("abc\x85\xAB\x85\xAC\x85\xAD", 3, 2, 'MacJapanese')) . "\n";
+print bin2hex(mb_substr("abc\x85\xAB\x85\xAC\x85\xAD", -2, 1, 'MacJapanese')) . "\n";
+print bin2hex(mb_substr("abc\x85\xBF\x85\xC0\x85\xC1", 0, 3, 'MacJapanese')) . "\n";
+print bin2hex(mb_substr("abc\x85\xBF\x85\xC0\x85\xC1", 3, 2, 'MacJapanese')) . "\n";
+print bin2hex(mb_substr("abc\x85\xBF\x85\xC0\x85\xC1", -2, 1, 'MacJapanese')) . "\n";
+
 echo "ISO-2022-JP:\n";
 print "1: " . bin2hex(mb_substr($iso2022jp, 0, 3, 'ISO-2022-JP')) . "\n";
 print "2: " . bin2hex(mb_substr($iso2022jp, -1, null, 'ISO-2022-JP')) . "\n";
@@ -145,6 +155,13 @@ SJIS-Mobile#KDDI:
 SJIS-Mobile#SoftBank:
 6380
 806162
+-- Testing MacJapanese characters which map to 3-5 codepoints each --
+616263
+85ab85ac
+85ac
+616263
+85bf85c0
+85c0
 ISO-2022-JP:
 1: 1b2442212121721b284241
 2: 43


### PR DESCRIPTION
The reviewers will notice one optimization is applied here to the decoding routines for about 3 different legacy text encodings. It involves decrementing the pointer which marks the end of the input string:

```
e--; /* Stop the main loop 1 byte short of the end of the input */
```

And then fixing this up before exiting:

```
/* Finish up last byte of input string if there is one */
if (p == e && out < limit) {
	unsigned char c = *p++;
	*out++ = (c < 0x80) ? c : MBFL_BAD_INPUT;
}

*in_len = e - p + 1;
```

...the point of all this being that we can remove one `p < e` guard from the body of the main loop. If a lot of work is being done in the main loop, this might not make a noticeable difference, but if the main loop is already very tight, optimizing out just one such check can make it close to 10% faster.

Here is what I would love to hear some feedback on... doing this little "dance" to optimize out the `p < e` guard is not really necessary when the input string is a `zend_string`, because `zend_string`s always have one extra byte allocated after the end of the string content (used for a null terminator).

Actually, in a lot of our legacy text decoding routines, we could use the `zend_string` null terminator as a sentinel to optimize out even more checks and gain more performance.

The problem is that these text decoding routines are not only used for `mb_convert_encoding` but also by the PHP interpreter's scanner when reading in PHP scripts which are written in some funny text encoding... right here:

https://github.com/php/php-src/blob/3b5072f6f619b417614a154b7c2f98e1ea337060/Zend/zend_language_scanner.l#L137-L161

I don't know if I can rely on these input strings being null-terminated, but I guess the answer is probably no.

Any thoughts will be appreciated.

@cmb69 @Girgias @nikic @kamil-tekiela @youkidearitai 