### PR TITLE
#include cleanup

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -51,8 +51,8 @@
  * with more specialized routines when the requested size is known.
  */
 
-#include "zend.h"
 #include "zend_alloc.h"
+#include "zend.h"
 #include "zend_globals.h"
 #include "zend_operators.h"
 #include "zend_multiply.h"

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -21,10 +21,8 @@
 #ifndef ZEND_ALLOC_H
 #define ZEND_ALLOC_H
 
-#include <stdio.h>
-
-#include "../TSRM/TSRM.h"
-#include "zend.h"
+#include "zend_portability.h" // for BEGIN_EXTERN_C
+#include "zend_types.h" // for zend_result
 
 #ifndef ZEND_MM_ALIGNMENT
 # error "ZEND_MM_ALIGNMENT was not defined during configure"

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -18,6 +18,7 @@
    +----------------------------------------------------------------------+
 */
 
+#include "zend_hash.h"
 #include "zend.h"
 #include "zend_globals.h"
 #include "zend_variables.h"

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -21,8 +21,11 @@
 #ifndef ZEND_HASH_H
 #define ZEND_HASH_H
 
-#include "zend.h"
-#include "zend_sort.h"
+#include "zend_alloc.h" // for pefree()
+#include "zend_long.h"
+#include "zend_portability.h" // for BEGIN_EXTERN_C
+#include "zend_sort.h" // for zend_sort()
+#include "zend_string.h" // for ZSTR_VAL()
 
 #define HASH_KEY_IS_STRING 1
 #define HASH_KEY_IS_LONG 2

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -21,6 +21,12 @@
 #ifndef ZEND_PORTABILITY_H
 #define ZEND_PORTABILITY_H
 
+#ifdef PHP_WIN32
+#include "config.w32.h"
+#else
+#include "php_config.h" // for HAVE_*
+#endif
+
 #ifdef __cplusplus
 #define BEGIN_EXTERN_C() extern "C" {
 #define END_EXTERN_C() }

--- a/Zend/zend_sort.c
+++ b/Zend/zend_sort.c
@@ -17,9 +17,7 @@
    +----------------------------------------------------------------------+
 */
 
-#include "zend.h"
 #include "zend_sort.h"
-#include <limits.h>
 
 static inline void zend_sort_2(void *a, void *b, compare_func_t cmp, swap_func_t swp) /* {{{ */ {
 	if (cmp(a, b) > 0) {

--- a/Zend/zend_sort.h
+++ b/Zend/zend_sort.h
@@ -20,6 +20,9 @@
 #ifndef ZEND_SORT_H
 #define ZEND_SORT_H
 
+#include "zend_portability.h" // for BEGIN_EXTERN_C
+#include "zend_types.h" // for compare_func_t, swap_func_t
+
 BEGIN_EXTERN_C()
 ZEND_API void zend_sort(void *base, size_t nmemb, size_t siz, compare_func_t cmp, swap_func_t swp);
 ZEND_API void zend_insert_sort(void *base, size_t nmemb, size_t siz, compare_func_t cmp, swap_func_t swp);

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -16,6 +16,7 @@
    +----------------------------------------------------------------------+
 */
 
+#include "zend_string.h"
 #include "zend.h"
 #include "zend_globals.h"
 

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -19,7 +19,9 @@
 #ifndef ZEND_STRING_H
 #define ZEND_STRING_H
 
-#include "zend.h"
+#include "zend_alloc.h" // for pemalloc()
+#include "zend_portability.h" // for BEGIN_EXTERN_C
+#include "zend_types.h" // for zend_string
 
 BEGIN_EXTERN_C()
 


### PR DESCRIPTION
This PR is the start of an effort to reduce header bloat in the PHP code base. My idea is: in each `.c` file, include its own `.h` file first, and ensure that the header includes only a minimal set of other headers, possibly using forward declarations.
This increases code correctness and reduces compile times.
If you agree with this idea, I'll post more PRs.