### PR TITLE
Properly forward the signal to the original handler if TSRM is shutdown

### DIFF
--- a/Zend/zend_signal.c
+++ b/Zend/zend_signal.c
@@ -183,8 +183,7 @@ static void zend_signal_handler(int signo, siginfo_t *siginfo, void *context)
 	zend_signal_entry_t p_sig;
 #ifdef ZTS
 	if (tsrm_is_shutdown() || !tsrm_get_ls_cache()) {
-		p_sig.flags = 0;
-		p_sig.handler = SIG_DFL;
+		p_sig = global_orig_handlers[signo-1];
 	} else
 #endif
 	p_sig = SIGG(handlers)[signo-1];


### PR DESCRIPTION
I've occasionally been observing stacktraces like:
```
#0  raise (sig=3) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x0000aaaab305e0f8 in zend_signal_handler (signo=3, siginfo=0xffffe6eafa20, context=0xffffe6eafaa0) at /usr/local/src/php/Zend/zend_signal.c:201
#2  0x0000aaaab305cf34 in zend_signal_handler_defer (signo=3, siginfo=0xffffe6eafa20, context=0xffffe6eafaa0) at /usr/local/src/php/Zend/zend_signal.c:91
#3  <signal handler called>
#4  0x0000ffff96344be8 in sched_yield () at ../sysdeps/unix/syscall-template.S:78
#5  0x0000ffff96f51fdc in ?? () from /usr/lib/aarch64-linux-gnu/libasan.so.5
#6  0x0000ffff96f59b9c in ?? () from /usr/lib/aarch64-linux-gnu/libasan.so.5
#7  0x0000ffff96393ae4 in __GI___dl_iterate_phdr (callback=0xffff96f59b90, data=0xffffe6eb0e20) at dl-iteratephdr.c:75
#8  0x0000ffff96f59ea8 in ?? () from /usr/lib/aarch64-linux-gnu/libasan.so.5
#9  0x0000ffff96f59438 in ?? () from /usr/lib/aarch64-linux-gnu/libasan.so.5
#10 0x0000ffff96f596a4 in ?? () from /usr/lib/aarch64-linux-gnu/libasan.so.5
#11 0x0000ffff962c0440 in __cxa_finalize (d=0xffff96fc05b0) at cxa_finalize.c:83
#12 0x0000ffff96e85bb0 in ?? () from /usr/lib/aarch64-linux-gnu/libasan.so.5
#13 0x0000ffff97cf7e1c in _dl_fini () at dl-fini.c:138
#14 0x0000ffff962bfe38 in __run_exit_handlers (status=0, listp=0xffff963f65c8 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:108
#15 0x0000ffff962bff9c in __GI_exit (status=<optimized out>) at exit.c:139
#16 0x0000ffff962abda8 in __libc_start_main (main=0xaaaab326f2a0 <main>, argc=2, argv=0xffffe6eb13a8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=<optimized out>) at ../csu/libc-start.c:342
#17 0x0000aaaab1d05804 in _start ()
```
(Asan builds incidentally make that particular issue a little bit more command as it has more overhead on process end.)

Coredumps were being created despite SIGQUIT being officially a signal for graceful handling in php-fpm, as signals are in ZTS builds not forwarded to the original handler if TSRM has already been shutdown.

This ensures proper handling of SIGQUIT in ZTS fpm builds outside of active requests.

I'm not sure whether that's truly the correct fix, but it looks sensible to me...