### PR TITLE
Micro-optimize zend_string_equal_val

### DIFF
--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -381,31 +381,33 @@ ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const z
 	const char *ptr = ZSTR_VAL(s1);
 	size_t delta = (const char*)s2 - (const char*)s1;
 	size_t len = ZSTR_LEN(s1);
-	zend_ulong ret;
+	zend_ulong accumulator;
+	bool ret;
 
 	__asm__ (
 		".LL0%=:\n\t"
-		"movl (%2,%3), %0\n\t"
-		"xorl (%2), %0\n\t"
+		"movl (%3,%4), %0\n\t"
+		"xorl (%3), %0\n\t"
 		"jne .LL1%=\n\t"
-		"addl $0x4, %2\n\t"
-		"subl $0x4, %1\n\t"
+		"addl $0x4, %3\n\t"
+		"subl $0x4, %2\n\t"
 		"ja .LL0%=\n\t"
-		"movl $0x1, %0\n\t"
+		"movl $0x1, %k1\n\t"
 		"jmp .LL3%=\n\t"
 		".LL1%=:\n\t"
-		"cmpl $0x4,%1\n\t"
+		"cmpl $0x4,%2\n\t"
 		"jb .LL2%=\n\t"
-		"xorl %0, %0\n\t"
+		"xorl %k1, %k1\n\t"
 		"jmp .LL3%=\n\t"
 		".LL2%=:\n\t"
-		"negl %1\n\t"
-		"lea 0x20(,%1,8), %1\n\t"
-		"shll %b1, %0\n\t"
-		"sete %b0\n\t"
-		"movzbl %b0, %0\n\t"
+		"negl %2\n\t"
+		"lea 0x20(,%2,8), %2\n\t"
+		"shll %b2, %0\n\t"
+		"sete %b1\n\t"
+		"movzbl %b1, %k1\n\t"
 		".LL3%=:\n"
-		: "=&a"(ret),
+		: "=r"(accumulator),
+		  "=a"(ret),
 		  "+c"(len),
 		  "+r"(ptr)
 		: "r"(delta)
@@ -419,31 +421,33 @@ ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const z
 	const char *ptr = ZSTR_VAL(s1);
 	size_t delta = (const char*)s2 - (const char*)s1;
 	size_t len = ZSTR_LEN(s1);
-	zend_ulong ret;
+	zend_ulong accumulator;
+	bool ret;
 
 	__asm__ (
 		".LL0%=:\n\t"
-		"movq (%2,%3), %0\n\t"
-		"xorq (%2), %0\n\t"
+		"movq (%3,%4), %0\n\t"
+		"xorq (%3), %0\n\t"
 		"jne .LL1%=\n\t"
-		"addq $0x8, %2\n\t"
-		"subq $0x8, %1\n\t"
+		"addq $0x8, %3\n\t"
+		"subq $0x8, %2\n\t"
 		"ja .LL0%=\n\t"
-		"movq $0x1, %0\n\t"
+		"movl $0x1, %k1\n\t"
 		"jmp .LL3%=\n\t"
 		".LL1%=:\n\t"
-		"cmpq $0x8,%1\n\t"
+		"cmpq $0x8,%2\n\t"
 		"jb .LL2%=\n\t"
-		"xorq %0, %0\n\t"
+		"xorl %k1, %k1\n\t"
 		"jmp .LL3%=\n\t"
 		".LL2%=:\n\t"
-		"negq %1\n\t"
-		"lea 0x40(,%1,8), %1\n\t"
-		"shlq %b1, %0\n\t"
-		"sete %b0\n\t"
-		"movzbq %b0, %0\n\t"
+		"negq %2\n\t"
+		"lea 0x40(,%2,8), %2\n\t"
+		"shlq %b2, %0\n\t"
+		"sete %b1\n\t"
+		"movzbl %b1, %k1\n\t"
 		".LL3%=:\n"
-		: "=&a"(ret),
+		: "=r"(accumulator),
+		  "=a"(ret),
 		  "+c"(len),
 		  "+r"(ptr)
 		: "r"(delta)


### PR DESCRIPTION
As a 64-bit value was used for both a temporary result and the return value, the assembly was slightly sub-optimal: there was some additional bit testing that can be avoided.
By splitting the temporary register and the return value, this results in more optimal code.
This also takes the opportunity to shrink some instructions because they are now encoded in fewer bytes (e.g. movl $1, %rax).

We can see in both bitnesses that the code takes less bytes (so better for instruction cache), and there's no redundant zero-extension and test at the end.

## Comparison of 64-bit version (78 bytes vs 68 bytes)

### old

```as
   <+0>:	sub    %rdi,%rsi
   <+3>:	mov    0x10(%rdi),%rcx
   <+7>:	lea    0x18(%rdi),%rdx
   <+11>:	mov    (%rdx,%rsi,1),%rax
   <+15>:	xor    (%rdx),%rax
   <+18>:	jne    0x571737 <zend_string_equal_val+39>
   <+20>:	add    $0x8,%rdx
   <+24>:	sub    $0x8,%rcx
   <+28>:	ja     0x57171b <zend_string_equal_val+11>
   <+30>:	mov    $0x1,%rax
   <+37>:	jmp    0x571757 <zend_string_equal_val+71>
   <+39>:	cmp    $0x8,%rcx
   <+43>:	jb     0x571742 <zend_string_equal_val+50>
   <+45>:	xor    %rax,%rax
   <+48>:	jmp    0x571757 <zend_string_equal_val+71>
   <+50>:	neg    %rcx
   <+53>:	lea    0x40(,%rcx,8),%rcx
   <+61>:	shl    %cl,%rax
   <+64>:	sete   %al
   <+67>:	movzbq %al,%rax
   <+71>:	test   %rax,%rax
   <+74>:	setne  %al
   <+77>:	ret    
```

### new

```as
   <+0>:	mov    0x10(%rdi),%rcx
   <+4>:	lea    0x18(%rdi),%rdx
   <+8>:	sub    %rdi,%rsi
   <+11>:	mov    (%rdx,%rsi,1),%rsi
   <+15>:	xor    (%rdx),%rsi
   <+18>:	jne    0x10b5 <zend_string_equal_val+37>
   <+20>:	add    $0x8,%rdx
   <+24>:	sub    $0x8,%rcx
   <+28>:	ja     0x109b <zend_string_equal_val+11>
   <+30>:	mov    $0x1,%eax
   <+35>:	jmp    0x10d3 <zend_string_equal_val+67>
   <+37>:	cmp    $0x8,%rcx
   <+41>:	jb     0x10bf <zend_string_equal_val+47>
   <+43>:	xor    %eax,%eax
   <+45>:	jmp    0x10d3 <zend_string_equal_val+67>
   <+47>:	neg    %rcx
   <+50>:	lea    0x40(,%rcx,8),%rcx
   <+58>:	shl    %cl,%rsi
   <+61>:	sete   %al
   <+64>:	movzbl %al,%eax
   <+67>:	ret    
```

## Comparison of 32-bit version (68 vs 61 bytes)

### old

```as
   <+0>:	push   %ebx
   <+1>:	mov    %ecx,%eax
   <+3>:	mov    %edx,%ebx
   <+5>:	lea    0x10(%ecx),%edx
   <+8>:	sub    %eax,%ebx
   <+10>:	mov    0xc(%ecx),%ecx
   <+13>:	mov    (%edx,%ebx,1),%eax
   <+16>:	xor    (%edx),%eax
   <+18>:	jne    0xe53 <zend_string_equal_val+35>
   <+20>:	add    $0x4,%edx
   <+23>:	sub    $0x4,%ecx
   <+26>:	ja     0xe3d <zend_string_equal_val+13>
   <+28>:	mov    $0x1,%eax
   <+33>:	jmp    0xe6d <zend_string_equal_val+61>
   <+35>:	cmp    $0x4,%ecx
   <+38>:	jb     0xe5c <zend_string_equal_val+44>
   <+40>:	xor    %eax,%eax
   <+42>:	jmp    0xe6d <zend_string_equal_val+61>
   <+44>:	neg    %ecx
   <+46>:	lea    0x20(,%ecx,8),%ecx
   <+53>:	shl    %cl,%eax
   <+55>:	sete   %al
   <+58>:	movzbl %al,%eax
   <+61>:	test   %eax,%eax
   <+63>:	pop    %ebx
   <+64>:	setne  %al
   <+67>:	ret  
```

### new

```as
   <+0>:	mov    %ecx,%eax
   <+2>:	push   %ebx
   <+3>:	lea    0x10(%ecx),%ebx
   <+6>:	mov    0xc(%ecx),%ecx
   <+9>:	sub    %eax,%edx
   <+11>:	mov    (%ebx,%edx,1),%edx
   <+14>:	xor    (%ebx),%edx
   <+16>:	jne    0x10c1 <zend_string_equal_val+33>
   <+18>:	add    $0x4,%ebx
   <+21>:	sub    $0x4,%ecx
   <+24>:	ja     0x10ab <zend_string_equal_val+11>
   <+26>:	mov    $0x1,%eax
   <+31>:	jmp    0x10db <zend_string_equal_val+59>
   <+33>:	cmp    $0x4,%ecx
   <+36>:	jb     0x10ca <zend_string_equal_val+42>
   <+38>:	xor    %eax,%eax
   <+40>:	jmp    0x10db <zend_string_equal_val+59>
   <+42>:	neg    %ecx
   <+44>:	lea    0x20(,%ecx,8),%ecx
   <+51>:	shl    %cl,%edx
   <+53>:	sete   %al
   <+56>:	movzbl %al,%eax
   <+59>:	pop    %ebx
   <+60>:	ret    
```