### PR TITLE
FPM: fastcgi_finish_request supports force close connection param

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1452,9 +1452,10 @@ static PHP_MINFO_FUNCTION(cgi)
 
 PHP_FUNCTION(fastcgi_finish_request) /* {{{ */
 {
+	zend_bool close_conn = 0;
 	fcgi_request *request = (fcgi_request*) SG(server_context);
 
-	if (zend_parse_parameters_none() == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|b", &close_conn) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -1463,7 +1464,7 @@ PHP_FUNCTION(fastcgi_finish_request) /* {{{ */
 		php_header();
 
 		fcgi_end(request);
-		fcgi_close(request, 0, 0);
+		fcgi_close(request, close_conn, 0);
 		RETURN_TRUE;
 	}
 

--- a/sapi/fpm/fpm/fpm_main_arginfo.h
+++ b/sapi/fpm/fpm/fpm_main_arginfo.h
@@ -2,6 +2,7 @@
  * Stub hash: b4ac4c0f1d91c354293e21185a2e6d9f99cc9fcc */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fastcgi_finish_request, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, close_conn, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_apache_request_headers, 0, 0, IS_ARRAY, 0)


### PR DESCRIPTION
when using fastcgi keepalive connection and fastcgi_finish_request, potentially deadlock may happens.

for example: process-a request same host after called fastcgi_finish_request, the proxy may using keepalived connection which is serve by same process(process-a), this may causes a dead lock

this PR  introduced  a new param which let user decide whether to force close a [keepalive] connection. 