### PR TITLE
Fix GH-9710: phpdbg memory leaks by option "-h"

### DIFF
--- a/sapi/phpdbg/phpdbg.c
+++ b/sapi/phpdbg/phpdbg.c
@@ -1414,6 +1414,8 @@ phpdbg_main:
 					get_zend_version()
 				);
 			}
+			PHPDBG_G(flags) |= PHPDBG_IS_QUITTING;
+			php_module_shutdown();
 			sapi_deactivate();
 			sapi_shutdown();
 			if (ini_entries) {


### PR DESCRIPTION
Fixes #9710 