### PR TITLE
Allow cloning of GdImage from gd 2.2.3

### DIFF
--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -203,7 +203,7 @@ void php_gd_assign_libgdimageptr_as_extgdimage(zval *val, gdImagePtr image)
 	php_gd_exgdimage_from_zobj_p(Z_OBJ_P(val))->image = image;
 }
 
-#if GD_MAJOR_VERSION > 2 || (GD_MAJOR_VERSION == 2 && (GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3))
+#if GD_MAJOR_VERSION > 2 || (GD_MAJOR_VERSION == 2 && (GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3)))
 static zend_object *php_gd_clone(zend_object *zobj)
 {
 	gdImagePtr oldim = php_gd_exgdimage_from_zobj_p(zobj)->image;
@@ -223,7 +223,7 @@ static void php_gd_object_minit_helper(void)
 
 	/* setting up the object handlers for the GdImage class */
 	memcpy(&php_gd_image_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-#if GD_MAJOR_VERSION > 2 || (GD_MAJOR_VERSION == 2 && (GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3))
+#if GD_MAJOR_VERSION > 2 || (GD_MAJOR_VERSION == 2 && (GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3)))
 	php_gd_image_object_handlers.clone_obj = php_gd_clone;
 #else
     php_gd_image_object_handlers.clone_obj = NULL;

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -203,6 +203,19 @@ void php_gd_assign_libgdimageptr_as_extgdimage(zval *val, gdImagePtr image)
 	php_gd_exgdimage_from_zobj_p(Z_OBJ_P(val))->image = image;
 }
 
+#if GD_MAJOR_VERSION >= 2 && GD_MINOR_VERSION >= 2
+static zend_object *php_gd_clone(zend_object *zobj)
+{
+	gdImagePtr oldim = php_gd_exgdimage_from_zobj_p(zobj)->image;
+	gdImagePtr newim = gdImageClone(oldim);
+    zval znew;
+
+	php_gd_assign_libgdimageptr_as_extgdimage(&znew, newim);
+
+	return Z_OBJ(znew);
+}
+#endif
+
 static void php_gd_object_minit_helper(void)
 {
 	gd_image_ce = register_class_GdImage();
@@ -210,7 +223,11 @@ static void php_gd_object_minit_helper(void)
 
 	/* setting up the object handlers for the GdImage class */
 	memcpy(&php_gd_image_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	php_gd_image_object_handlers.clone_obj = NULL;
+#if GD_MAJOR_VERSION >= 2 && GD_MINOR_VERSION >= 2
+	php_gd_image_object_handlers.clone_obj = php_gd_clone;
+#else
+    php_gd_image_object_handlers.clone_obj = NULL;
+#endif
 	php_gd_image_object_handlers.free_obj = php_gd_image_object_free;
 	php_gd_image_object_handlers.get_constructor = php_gd_image_object_get_constructor;
 	php_gd_image_object_handlers.compare = zend_objects_not_comparable;

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -203,8 +203,9 @@ void php_gd_assign_libgdimageptr_as_extgdimage(zval *val, gdImagePtr image)
 	php_gd_exgdimage_from_zobj_p(Z_OBJ_P(val))->image = image;
 }
 
-#if GD_MAJOR_VERSION >= 2 && GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3)
-static zend_object *php_gd_clone(zend_object *zobj) {
+#if GD_MAJOR_VERSION > 2 || (GD_MAJOR_VERSION == 2 && (GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3))
+static zend_object *php_gd_clone(zend_object *zobj)
+{
 	gdImagePtr oldim = php_gd_exgdimage_from_zobj_p(zobj)->image;
 	gdImagePtr newim = gdImageClone(oldim);
     zval znew;
@@ -222,7 +223,7 @@ static void php_gd_object_minit_helper(void)
 
 	/* setting up the object handlers for the GdImage class */
 	memcpy(&php_gd_image_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-#if GD_MAJOR_VERSION >= 2 && GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3)
+#if GD_MAJOR_VERSION > 2 || (GD_MAJOR_VERSION == 2 && (GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3))
 	php_gd_image_object_handlers.clone_obj = php_gd_clone;
 #else
     php_gd_image_object_handlers.clone_obj = NULL;

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -203,9 +203,8 @@ void php_gd_assign_libgdimageptr_as_extgdimage(zval *val, gdImagePtr image)
 	php_gd_exgdimage_from_zobj_p(Z_OBJ_P(val))->image = image;
 }
 
-#if GD_MAJOR_VERSION >= 2 && GD_MINOR_VERSION >= 2
-static zend_object *php_gd_clone(zend_object *zobj)
-{
+#if GD_MAJOR_VERSION >= 2 && GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3)
+static zend_object *php_gd_clone(zend_object *zobj) {
 	gdImagePtr oldim = php_gd_exgdimage_from_zobj_p(zobj)->image;
 	gdImagePtr newim = gdImageClone(oldim);
     zval znew;
@@ -223,7 +222,7 @@ static void php_gd_object_minit_helper(void)
 
 	/* setting up the object handlers for the GdImage class */
 	memcpy(&php_gd_image_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-#if GD_MAJOR_VERSION >= 2 && GD_MINOR_VERSION >= 2
+#if GD_MAJOR_VERSION >= 2 && GD_MINOR_VERSION > 2 || (GD_MINOR_VERSION == 2 && GD_RELEASE_VERSION >= 3)
 	php_gd_image_object_handlers.clone_obj = php_gd_clone;
 #else
     php_gd_image_object_handlers.clone_obj = NULL;

--- a/ext/gd/tests/gdimage_cloning.phpt
+++ b/ext/gd/tests/gdimage_cloning.phpt
@@ -1,9 +1,9 @@
 --TEST--
 Checks that GdImage instances can be cloned from gd > 2.2.3
---SKIPIF--
-<?php if (version_compare(GD_VERSION, '2.2.0', '<')) { die("Skipped: GdImage is not clonable before gd 2.2.3"); } ?>
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php if (version_compare(GD_VERSION, '2.2.3', '<')) die("Skipped: GdImage is not clonable before gd 2.2.3"); ?>
 --FILE--
 <?php
 

--- a/ext/gd/tests/gdimage_cloning.phpt
+++ b/ext/gd/tests/gdimage_cloning.phpt
@@ -1,23 +1,23 @@
 --TEST--
-Checks that GdImage instances can be cloned from gd > 2.2.0
+Checks that GdImage instances can be cloned from gd > 2.2.3
 --SKIPIF--
-<?php if (version_compare(GD_VERSION, '2.2.0', '<')) { die("Skipped: GdImage is not clonable before gd 2.2.0"); } ?>
+<?php if (version_compare(GD_VERSION, '2.2.0', '<')) { die("Skipped: GdImage is not clonable before gd 2.2.3"); } ?>
 --EXTENSIONS--
 gd
 --FILE--
 <?php
 
-    $foo = imageCreateTrueColor(32, 32);
+    $foo = imagecreatetruecolor(32, 32);
     $bar = clone $foo;
 
-    $red = imageColorAllocate($foo, 255, 0, 0);
-    imageFill($foo, 0, 0, $red);
+    $red = imagecolorallocate($foo, 255, 0, 0);
+    imagefill($foo, 0, 0, $red);
 
-    $green = imageColorAllocate($bar, 0, 255, 0);
-    imageFill($bar, 0, 0, $green);
+    $green = imagecolorallocate($bar, 0, 255, 0);
+    imagefill($bar, 0, 0, $green);
 
-    var_dump(imageColorAt($foo, 0, 0) === $red);
-    var_dump(imageColorAt($bar, 0, 0) === $green);
+    var_dump(imagecolorat($foo, 0, 0) === $red);
+    var_dump(imagecolorat($bar, 0, 0) === $green);
 
 
 ?>

--- a/ext/gd/tests/gdimage_cloning.phpt
+++ b/ext/gd/tests/gdimage_cloning.phpt
@@ -7,17 +7,17 @@ gd
 --FILE--
 <?php
 
-    $foo = imagecreatetruecolor(32, 32);
-    $bar = clone $foo;
+$foo = imagecreatetruecolor(32, 32);
+$bar = clone $foo;
 
-    $red = imagecolorallocate($foo, 255, 0, 0);
-    imagefill($foo, 0, 0, $red);
+$red = imagecolorallocate($foo, 255, 0, 0);
+imagefill($foo, 0, 0, $red);
 
-    $green = imagecolorallocate($bar, 0, 255, 0);
-    imagefill($bar, 0, 0, $green);
+$green = imagecolorallocate($bar, 0, 255, 0);
+imagefill($bar, 0, 0, $green);
 
-    var_dump(imagecolorat($foo, 0, 0) === $red);
-    var_dump(imagecolorat($bar, 0, 0) === $green);
+var_dump(imagecolorat($foo, 0, 0) === $red);
+var_dump(imagecolorat($bar, 0, 0) === $green);
 
 
 ?>

--- a/ext/gd/tests/gdimage_cloning.phpt
+++ b/ext/gd/tests/gdimage_cloning.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Checks that GdImage instances can be cloned from gd > 2.2.0
+--SKIPIF--
+<?php if (version_compare(GD_VERSION, '2.2.0', '<')) { die("Skipped: GdImage is not clonable before gd 2.2.0"); } ?>
+--EXTENSIONS--
+gd
+--FILE--
+<?php
+
+    $foo = imageCreateTrueColor(32, 32);
+    $bar = clone $foo;
+
+    $red = imageColorAllocate($foo, 255, 0, 0);
+    imageFill($foo, 0, 0, $red);
+
+    $green = imageColorAllocate($bar, 0, 255, 0);
+    imageFill($bar, 0, 0, $green);
+
+    var_dump(imageColorAt($foo, 0, 0) === $red);
+    var_dump(imageColorAt($bar, 0, 0) === $green);
+
+
+?>
+--EXPECTF--
+bool(true)
+bool(true)

--- a/ext/gd/tests/gdimage_prevent_cloning.phpt
+++ b/ext/gd/tests/gdimage_prevent_cloning.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Checks that GdImage instances cannot be cloned
 --SKIPIF--
-<?php if (version_compare(GD_VERSION, '2.2.0', '>=')) { die("Skipped: GdImage is clonable from gd 2.2.0"); } ?>
+<?php if (version_compare(GD_VERSION, '2.2.3', '>=')) { die("Skipped: GdImage is clonable from gd 2.2.3"); } ?>
 --EXTENSIONS--
 gd
 --FILE--

--- a/ext/gd/tests/gdimage_prevent_cloning.phpt
+++ b/ext/gd/tests/gdimage_prevent_cloning.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Checks that GdImage instances cannot be cloned
+--SKIPIF--
+<?php if (version_compare(GD_VERSION, '2.2.0', '>=')) { die("Skipped: GdImage is clonable from gd 2.2.0"); } ?>
 --EXTENSIONS--
 gd
 --FILE--

--- a/ext/gd/tests/gdimage_prevent_cloning.phpt
+++ b/ext/gd/tests/gdimage_prevent_cloning.phpt
@@ -1,9 +1,9 @@
 --TEST--
 Checks that GdImage instances cannot be cloned
---SKIPIF--
-<?php if (version_compare(GD_VERSION, '2.2.3', '>=')) { die("Skipped: GdImage is clonable from gd 2.2.3"); } ?>
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php if (version_compare(GD_VERSION, '2.2.3', '>=')) die("Skipped: GdImage is clonable from gd 2.2.3"); ?>
 --FILE--
 <?php
 


### PR DESCRIPTION
From version 2.2.3 gd supports cloning https://libgd.github.io/manuals/2.2.3/files/gd-c.html#gdImageClone

The bundled version of gd is at version 2.0.35 so cloning is only supported with `--with-external-gd`