### PR TITLE
Reduce HT_MAX_SIZE to account for the max load factor of 0.5

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -166,6 +166,8 @@ static zend_always_inline void zend_hash_real_init_mixed_ex(HashTable *ht)
 	void *data;
 	uint32_t nSize = ht->nTableSize;
 
+	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize));
+
 	if (UNEXPECTED(GC_FLAGS(ht) & IS_ARRAY_PERSISTENT)) {
 		data = pemalloc(HT_SIZE_EX(nSize, HT_SIZE_TO_MASK(nSize)), 1);
 	} else if (EXPECTED(nSize == HT_MIN_SIZE)) {
@@ -341,6 +343,8 @@ ZEND_API void ZEND_FASTCALL zend_hash_packed_to_hash(HashTable *ht)
 	Bucket *old_buckets = ht->arData;
 	uint32_t nSize = ht->nTableSize;
 
+	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize));
+
 	HT_ASSERT_RC1(ht);
 	HT_FLAGS(ht) &= ~HASH_FLAG_PACKED;
 	new_data = pemalloc(HT_SIZE_EX(nSize, HT_SIZE_TO_MASK(nSize)), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
@@ -369,7 +373,11 @@ ZEND_API void ZEND_FASTCALL zend_hash_to_packed(HashTable *ht)
 ZEND_API void ZEND_FASTCALL zend_hash_extend(HashTable *ht, uint32_t nSize, bool packed)
 {
 	HT_ASSERT_RC1(ht);
+
 	if (nSize == 0) return;
+
+	ZEND_ASSERT(HT_SIZE_TO_MASK(nSize));
+
 	if (UNEXPECTED(HT_FLAGS(ht) & HASH_FLAG_UNINITIALIZED)) {
 		if (nSize > ht->nTableSize) {
 			ht->nTableSize = zend_hash_check_size(nSize);
@@ -1206,6 +1214,8 @@ static void ZEND_FASTCALL zend_hash_do_resize(HashTable *ht)
 		void *new_data, *old_data = HT_GET_DATA_ADDR(ht);
 		uint32_t nSize = ht->nTableSize + ht->nTableSize;
 		Bucket *old_buckets = ht->arData;
+
+		ZEND_ASSERT(HT_SIZE_TO_MASK(nSize));
 
 		ht->nTableSize = nSize;
 		new_data = pemalloc(HT_SIZE_EX(nSize, HT_SIZE_TO_MASK(nSize)), GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -435,7 +435,7 @@ struct _zend_array {
 #define HT_SIZE_TO_MASK(nTableSize) \
 	((uint32_t)(-((nTableSize) + (nTableSize))))
 #define HT_HASH_SIZE(nTableMask) \
-	(((size_t)(uint32_t)-(int32_t)(nTableMask)) * sizeof(uint32_t))
+	(((size_t)-(uint32_t)(nTableMask)) * sizeof(uint32_t))
 #define HT_DATA_SIZE(nTableSize) \
 	((size_t)(nTableSize) * sizeof(Bucket))
 #define HT_SIZE_EX(nTableSize, nTableMask) \

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -401,7 +401,7 @@ struct _zend_array {
 #define HT_MIN_SIZE 8
 
 #if SIZEOF_SIZE_T == 4
-# define HT_MAX_SIZE 0x04000000 /* small enough to avoid overflow checks */
+# define HT_MAX_SIZE 0x02000000 /* small enough to avoid overflow checks */
 # define HT_HASH_TO_BUCKET_EX(data, idx) \
 	((Bucket*)((char*)(data) + (idx)))
 # define HT_IDX_TO_HASH(idx) \
@@ -409,7 +409,7 @@ struct _zend_array {
 # define HT_HASH_TO_IDX(idx) \
 	((idx) / sizeof(Bucket))
 #elif SIZEOF_SIZE_T == 8
-# define HT_MAX_SIZE 0x80000000
+# define HT_MAX_SIZE 0x40000000
 # define HT_HASH_TO_BUCKET_EX(data, idx) \
 	((data) + (idx))
 # define HT_IDX_TO_HASH(idx) \

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -400,8 +400,15 @@ struct _zend_array {
 #define HT_MIN_MASK ((uint32_t) -2)
 #define HT_MIN_SIZE 8
 
+/* HT_MAX_SIZE is chosen to satisfy the following constraints:
+ * - HT_SIZE_TO_MASK(HT_MAX_SIZE) != 0
+ * - HT_SIZE_EX(HT_MAX_SIZE, HT_SIZE_TO_MASK(HT_MAX_SIZE)) does not overflow or
+ *   wrapparound, and is <= the addressable space size
+ * - HT_MAX_SIZE must be a power of two:
+ *   (nTableSize<HT_MAX_SIZE ? nTableSize+nTableSize : nTableSize) <= HT_MAX_SIZE
+ */
 #if SIZEOF_SIZE_T == 4
-# define HT_MAX_SIZE 0x02000000 /* small enough to avoid overflow checks */
+# define HT_MAX_SIZE 0x02000000
 # define HT_HASH_TO_BUCKET_EX(data, idx) \
 	((Bucket*)((char*)(data) + (idx)))
 # define HT_IDX_TO_HASH(idx) \


### PR DESCRIPTION
zend_hash allocates a hash table twice as big as nTableSize: `HT_HASH_SIZE(HT_SIZE_TO_MASK(nTableSize)) == nTableSize*2`, so HT_MAX_SIZE must be half the max table size or less.

This fixes #10240:

In HT_HASH_RESET, HT_HASH_SIZE((ht)->nTableMask) evaluates to 0, leading to the assertion failure.

`0` is indeed an invalid value for nTableMask, given how the hash table offsets are computed:

```
offset = (hash | nTableMask)        // e.g. in zend_hash_str_find_bucket
idx = ht->arData[ (int32_t)offset ] // HT_HASH_EX
```

This relies on nTableMask having at least the highest bit set, so that interpreting (hash | nTableMask) as signed gives an offset in the range `]-(~(nTableMask)+1)...0]`. `ht->arData` points to the end of the hash table. `hash` is always > 0, so the range is actually `]-(~(nTableMask)+1)...-1]`.

HT_SIZE_TO_MASK multiples nSize by 2 to ensure a load factor of 0.5.

Given that, I think that HT_MAX_SIZE should be (2**31 / 2) : 0x40000000.

