### PR TITLE
zend_hash_check_size: allow nSize <= HT_MAX_SIZE

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -118,7 +118,7 @@ static zend_always_inline uint32_t zend_hash_check_size(uint32_t nSize)
 	/* size should be between HT_MIN_SIZE and HT_MAX_SIZE */
 	if (nSize <= HT_MIN_SIZE) {
 		return HT_MIN_SIZE;
-	} else if (UNEXPECTED(nSize >= HT_MAX_SIZE)) {
+	} else if (UNEXPECTED(nSize > HT_MAX_SIZE)) {
 		zend_error_noreturn(E_ERROR, "Possible integer overflow in memory allocation (%u * %zu + %zu)", nSize, sizeof(Bucket), sizeof(Bucket));
 	}
 


### PR DESCRIPTION
zend_hash_check_size() restricts the nSize parameter to be strictly less than HT_MAX_SIZE, which makes the name of the HT_MAX_SIZE macro slightly confusing.

In this PR I change zend_hash_check_size() so that it allows nSize values <= HT_MAX_SIZE instead of strictly < HT_MAX_SIZE.

This does not actually extend the maximum hash size, as it was already possible to create hashes with a size of HT_MAX_SIZE:
* zend_hash_packed_grow() and zend_hash_do_resize() accept to grow hashes to a size <= HT_MAX_SIZE
* zend_hash_check_size() already returns `HT_MAX_SIZE` for nSize values in the range `]HT_MAX_SIZE/2...HT_MAX_SIZE[`

I found this while testing https://github.com/php/php-src/pull/10149. Also related: #10242.