### PR TITLE
random: Fix check before closing `random_fd`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,9 @@ PHP                                                                        NEWS
 - Posix:
   . Fix memory leak in posix_ttyname() (girgias)
 
+- Random:
+  . Fixed bug GH-10247 (Theoretical file descriptor leak for /dev/urandom). (timwolla)
+
 - Standard:
   . Fix GH-10187 (Segfault in stripslashes() with arm64). (nielsdos)
 

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -828,7 +828,7 @@ static PHP_GINIT_FUNCTION(random)
 /* {{{ PHP_GSHUTDOWN_FUNCTION */
 static PHP_GSHUTDOWN_FUNCTION(random)
 {
-	if (random_globals->random_fd > 0) {
+	if (random_globals->random_fd >= 0) {
 		close(random_globals->random_fd);
 		random_globals->random_fd = -1;
 	}


### PR DESCRIPTION
If, for whatever reason, the random_fd has been assigned file descriptor `0` it previously failed to close during module shutdown, thus leaking the descriptor.