### PR TITLE
Fix GH-10251: Assertion `(flag & (1<<3)) == 0' failed. 

### DIFF
--- a/Zend/tests/gh10251.phpt
+++ b/Zend/tests/gh10251.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-10251 (Assertion `(flag & (1<<3)) == 0' failed.)
+--FILE--
+<?php
+class A
+{
+    function __set($o, $l)
+    {
+        $this->$p = $v;
+    }
+}
+$a = new A();
+$pp = "";
+$op = $pp & "";
+// Bitwise operators on strings don't compute the hash.
+// The code below previously assumed a hash was actually computed, leading to a crash.
+$a->$op = 0;
+echo "Done\n";
+?>
+--EXPECTF--
+Warning: Undefined variable $v in %s on line %d
+
+Warning: Undefined variable $p in %s on line %d
+Done

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -535,9 +535,8 @@ ZEND_API uint32_t *zend_get_property_guard(zend_object *zobj, zend_string *membe
 	if (EXPECTED(Z_TYPE_P(zv) == IS_STRING)) {
 		zend_string *str = Z_STR_P(zv);
 		if (EXPECTED(str == member) ||
-		     /* "str" always has a pre-calculated hash value here */
-		    (EXPECTED(ZSTR_H(str) == zend_string_hash_val(member)) &&
-		     EXPECTED(zend_string_equal_content(str, member)))) {
+		    /* str and member don't necessarily have a pre-calculated hash value here */
+		    EXPECTED(zend_string_equal_content(str, member))) {
 			return &Z_PROPERTY_GUARD_P(zv);
 		} else if (EXPECTED(Z_PROPERTY_GUARD_P(zv) == 0)) {
 			zval_ptr_dtor_str(zv);


### PR DESCRIPTION
Fixes GH-10251 (see also for analysis and discussion)

zend_get_property_guard previously assumed that at least "str" has a
pre-computed hash. This is not always the case, for example when a
string is created by bitwise operations, its hash is not set. Instead of
forcing a computation of the hashes, drop the hash comparison.