### PR TITLE
Attempt to fix GH-10131:  Preloading anonymous class inheriting from autoloaded unlinked class leads to return type error

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1243,9 +1243,6 @@ ZEND_API void zend_activate(void) /* {{{ */
 	init_compiler();
 	init_executor();
 	startup_scanner();
-	if (CG(map_ptr_last)) {
-		memset(CG(map_ptr_real_base), 0, CG(map_ptr_last) * sizeof(void*));
-	}
 	zend_observer_activate();
 }
 /* }}} */


### PR DESCRIPTION
See GH-10131 for analysis and reasoning.
Marking as a draft because I'm absolutely not sure about this and this way there can be shed some light on this perhaps.
My gut feeling says that removing the clearing out might not be right because even though it seems only be used by CE cache, it could be used by extensions?