### PR TITLE
Fix test for GH-10251 get it passing again on 8.2+

### DIFF
--- a/Zend/tests/gh10251.phpt
+++ b/Zend/tests/gh10251.phpt
@@ -2,7 +2,7 @@
 GH-10251 (Assertion `(flag & (1<<3)) == 0' failed.)
 --FILE--
 <?php
-class A
+class A extends stdClass
 {
     function __set($o, $l)
     {


### PR DESCRIPTION
Dynamic properties are deprecated on PHP8.2+.
Therefore, a deprecation warning is outputted.
I didn't want to fix it by silencing deprecations or using the attribute solution, instead I extended stdClass, because dynamic properties will go away in the future IIRC except for stdClass.