### PR TITLE
Use absolute paths in OPCache tests when calling `opcache_compile_file()`

### DIFF
--- a/ext/opcache/tests/gh9968-1.inc
+++ b/ext/opcache/tests/gh9968-1.inc
@@ -1,3 +1,3 @@
 <?php
 
-opcache_compile_file('ext/opcache/tests/gh9968-2.inc');
+opcache_compile_file(__DIR__ . '/gh9968-2.inc');

--- a/ext/opcache/tests/preload_const_autoload.inc
+++ b/ext/opcache/tests/preload_const_autoload.inc
@@ -4,4 +4,4 @@ spl_autoload_register(function($class) {
     var_dump($class);
     new Abc;
 });
-opcache_compile_file('preload_const_autoload_2.inc');
+opcache_compile_file(__DIR__ . '/preload_const_autoload_2.inc');


### PR DESCRIPTION
This make sure the tests do not fail if they are not run from the repository root.

We encountered the issue while trying to upgrade PHP in `nixpkgs` https://github.com/NixOS/nixpkgs/pull/208928#issuecomment-1373412076