### PR TITLE
Implement Unicode conditional casing rules for Greek letter sigma

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -56,6 +56,12 @@ PHP 8.3 UPGRADE NOTES
     "buffer_size" => int
     See GH-9336
 
+- MBString:
+  . mb_strtolower, mb_strtotitle, and mb_convert_case implement conditional
+    casing rules for the Greek letter sigma. For mb_convert_case, conditional
+    casing only applies to MB_CASE_LOWER and MB_CASE_TITLE modes, not to
+    MB_CASE_LOWER_SIMPLE and MB_CASE_TITLE_SIMPLE. (Alex Dowad)
+
 - Standard:
   . E_NOTICEs emitted by unserialized() have been promoted to E_WARNING.
     RFC: https://wiki.php.net/rfc/improve_unserialize_error_handling

--- a/ext/mbstring/tests/mb_convert_case_various_mode.phpt
+++ b/ext/mbstring/tests/mb_convert_case_various_mode.phpt
@@ -21,6 +21,33 @@ try {
     echo $e->getMessage() . \PHP_EOL;
 }
 
+echo "\n-- Greek letter sigma --\n";
+var_dump(mb_convert_case("Σ", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("aΣ", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("aΣb", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("aΣ b", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case(" ΣΣΣΣ ", MB_CASE_TITLE, 'UTF-8'));
+
+// Apostrophe, full stop, colon, etc. are "case-ignorable"
+// When checking whether capital sigma is at the end of a word or not, we skip over
+// any number of case-ignorable characters, both when scanning back and when scanning forward
+var_dump(mb_convert_case("'Σ", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("ab'Σ", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("Σ'", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("Σ'a", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("a'Σ'a", MB_CASE_TITLE, 'UTF-8'));
+
+// We scan back by at least 63 characters when necessary,
+// but there is no guarantee that we will scan back further than that
+var_dump(mb_convert_case('a' . str_repeat('.', 63) . "Σ", MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case('a' . str_repeat('.', 64) . "Σ", MB_CASE_TITLE, 'UTF-8')); // Context-sensitive casing doesn't work here!
+
+// When scanning forward to confirm if capital sigma is at the end of a word or not,
+// there is no limit as to how far we will scan
+var_dump(mb_convert_case("abcΣ" . str_repeat('.', 64) . ' abc', MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("abcΣ" . str_repeat('.', 64) . 'a abc', MB_CASE_TITLE, 'UTF-8'));
+var_dump(mb_convert_case("abcΣ" . str_repeat('.', 256) . ' abc', MB_CASE_TITLE, 'UTF-8'));
+
 /* Regression test for new implementation;
  * When converting a codepoint, if we overwrite it with the converted version before
  * checking whether we should shift in/out of 'title mode', then the conversion will be incorrect */
@@ -38,5 +65,22 @@ string(13) "foo bar spaß"
 string(13) "Foo Bar Spaß"
 string(13) "foo bar spaß"
 mb_convert_case(): Argument #2 ($mode) must be one of the MB_CASE_* constants
+
+-- Greek letter sigma --
+string(2) "Σ"
+string(3) "Aς"
+string(4) "Aσb"
+string(5) "Aς B"
+string(10) " Σσσς "
+string(3) "'Σ"
+string(5) "Ab'ς"
+string(3) "Σ'"
+string(4) "Σ'a"
+string(6) "A'σ'a"
+string(66) "A...............................................................ς"
+string(67) "A................................................................σ"
+string(73) "Abcς................................................................ Abc"
+string(74) "Abcσ................................................................a Abc"
+string(265) "Abcς................................................................................................................................................................................................................................................................ Abc"
 string(12) "02bc004e012d"
 string(8) "0149012d"

--- a/ext/mbstring/tests/mb_strtolower_basic.phpt
+++ b/ext/mbstring/tests/mb_strtolower_basic.phpt
@@ -35,6 +35,33 @@ if ($mb == $greek_lower) {
     echo "Incorrectly converted\n";
 }
 
+echo "\n-- Greek letter sigma --\n";
+var_dump(mb_strtolower("Σ", 'UTF-8'));
+var_dump(mb_strtolower("aΣ", 'UTF-8'));
+var_dump(mb_strtolower("aΣb", 'UTF-8'));
+var_dump(mb_strtolower("aΣ b", 'UTF-8'));
+var_dump(mb_strtolower(" ΣΣΣΣ ", 'UTF-8'));
+
+// Apostrophe, full stop, colon, etc. are "case-ignorable"
+// When checking whether capital sigma is at the end of a word or not, we skip over
+// any number of case-ignorable characters, both when scanning back and when scanning forward
+var_dump(mb_strtolower("'Σ", 'UTF-8'));
+var_dump(mb_strtolower("ab'Σ", 'UTF-8'));
+var_dump(mb_strtolower("Σ'", 'UTF-8'));
+var_dump(mb_strtolower("Σ'a", 'UTF-8'));
+var_dump(mb_strtolower("a'Σ'a", 'UTF-8'));
+
+// We scan back by at least 63 characters when necessary,
+// but there is no guarantee that we will scan back further than that
+var_dump(mb_strtolower('a' . str_repeat('.', 63) . "Σ", 'UTF-8'));
+var_dump(mb_strtolower('a' . str_repeat('.', 64) . "Σ", 'UTF-8')); // Context-sensitive casing doesn't work here!
+
+// When scanning forward to confirm if capital sigma is at the end of a word or not,
+// there is no limit as to how far we will scan
+var_dump(mb_strtolower("abcΣ" . str_repeat('.', 64) . ' abc', 'UTF-8'));
+var_dump(mb_strtolower("abcΣ" . str_repeat('.', 64) . 'a abc', 'UTF-8'));
+var_dump(mb_strtolower("abcΣ" . str_repeat('.', 256) . ' abc', 'UTF-8'));
+
 echo "Done";
 ?>
 --EXPECT--
@@ -47,4 +74,21 @@ Correctly converted
 -- Multibyte String --
 string(64) "zrHOss6zzrTOtc62zrfOuM65zrrOu868zr3Ovs6/z4DPgc+Dz4TPhc+Gz4fPiM+J"
 Correctly converted
+
+-- Greek letter sigma --
+string(2) "σ"
+string(3) "aς"
+string(4) "aσb"
+string(5) "aς b"
+string(10) " σσσς "
+string(3) "'σ"
+string(5) "ab'ς"
+string(3) "σ'"
+string(4) "σ'a"
+string(6) "a'σ'a"
+string(66) "a...............................................................ς"
+string(67) "a................................................................σ"
+string(73) "abcς................................................................ abc"
+string(74) "abcσ................................................................a abc"
+string(265) "abcς................................................................................................................................................................................................................................................................ abc"
 Done


### PR DESCRIPTION
The capital Greek letter sigma (Σ) should be lowercased as σ except when it appears at the end of a word; in that case, it should be lowercased as the special form ς.

This rule is included in the Unicode data file SpecialCasing.txt. The condition for applying the rule is called "Final_Sigma" and is defined in Unicode technical report 21. The rule is:

• For the special casing form to apply, the capital letter sigma must
  be preceded by 0 or more "case-ignorable" characters, preceded by
  at least 1 "cased" character.
• Further, capital sigma must NOT be followed by 0 or more
  case-ignorable characters and then at least 1 cased character.

"Case-ignorable" characters include certain punctuation marks, like the apostrophe, as well as various accent marks. There are actually close to 500 different case-ignorable characters, including accent marks from Cyrillic, Hebrew, Armenian, Arabic, Syriac, Bengali, Gujarati, Telugu, Tibetan, and many other alphabets. This category also includes zero-width spaces, codepoints which indicate RTL/LTR text direction, certain musical symbols, etc.

Since the rule involves scanning over "0 or more" of such case-ignorable characters, it may be necessary to scan arbitrarily far to the left and right of capital sigma to determine whether the special lowercase form should be used or not. However, since we are trying to be both memory-efficient and CPU-efficient, this implementation limits how far to the left we will scan. Generally, we scan up to 63 characters to the left looking for a "cased" character, but not more.

When scanning to the right, we go up to the end of the string if necessary, even if it means scanning over thousands of characters.

Anyways, it is almost impossible to imagine that natural text will include "words" with more than 63 successive apostrophes (for example) followed by a capital sigma.

Closes GH-8096.

FYA @cmb69 @Girgias @nikic @kamil-tekiela @youkidearitai 