### PR TITLE
fix: indirect_return compilation warning

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -679,7 +679,7 @@ extern "C++" {
 # define ZEND_VOIDP(ptr) (ptr)
 #endif
 
-#if defined(__GNUC__) && ZEND_GCC_VERSION >= 9000
+#if __has_attribute(__indirect_return__)
 # define ZEND_INDIRECT_RETURN __attribute__((__indirect_return__))
 #else
 # define ZEND_INDIRECT_RETURN


### PR DESCRIPTION
This attribute doesn't look available on all platforms and generates a compilation warning on Linux on Apple Silicon (GCC 10).