### PR TITLE
ext/opcache: use C11 atomics for "restart_in"

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -55,6 +55,14 @@
 #include "zend_accelerator_hash.h"
 #include "zend_accelerator_debug.h"
 
+#ifdef HAVE_STDATOMIC_H
+# ifdef __cplusplus
+#  include <atomic>
+# else
+#  include <stdatomic.h>
+# endif
+#endif // HAVE_STDATOMIC_H
+
 #ifndef PHPAPI
 # ifdef ZEND_WIN32
 #  define PHPAPI __declspec(dllimport)
@@ -261,7 +269,13 @@ typedef struct _zend_accel_shared_globals {
 	bool       restart_pending;
 	zend_accel_restart_reason restart_reason;
 	bool       cache_status_before_restart;
-#ifdef ZEND_WIN32
+#ifdef HAVE_STDATOMIC_H
+# ifdef __cplusplus
+	std::atomic_llong mem_usage, restart_in;
+# else
+	atomic_llong mem_usage, restart_in;
+# endif
+#elif defined(ZEND_WIN32)
 	LONGLONG   mem_usage;
 	LONGLONG   restart_in;
 #endif

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -23,6 +23,8 @@ if test "$PHP_OPCACHE" != "no"; then
   dnl Always build as shared extension
   ext_shared=yes
 
+  AC_CHECK_HEADERS([stdatomic.h])
+
   if test "$PHP_HUGE_CODE_PAGES" = "yes"; then
     AC_DEFINE(HAVE_HUGE_CODE_PAGES, 1, [Define to enable copying PHP CODE pages into HUGE PAGES (experimental)])
   fi


### PR DESCRIPTION
Cheaper than fcntl(F_SETLK).  The same is done already on Windows, so if that works, why not use it everywhere?  (Of course, only if the compiler supports this C11 feature.)

As a bonus, the code in this commit also works on C++ via C++11 std::atomic, just in case somebody adds some C++ code to the opcache extension one day.