### PR TITLE
Fix GH-10249: Assertion `size >= page_size + 1 * page_size' failed.

### DIFF
--- a/Zend/tests/fibers/gh10249.phpt
+++ b/Zend/tests/fibers/gh10249.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-10249 (Assertion `size >= page_size + 1 * page_size' failed.)
+--FILE--
+<?php
+
+$callback = function () {};
+ini_set("fiber.stack_size", "");
+$fiber = new Fiber($callback);
+try {
+    $fiber->start();
+} catch (Exception $e) {
+    echo $e->getMessage() . "\n";
+}
+
+?>
+--EXPECTF--
+Fiber stack size is too small, it needs to be at least %d bytes

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -174,8 +174,12 @@ static zend_fiber_stack *zend_fiber_stack_allocate(size_t size)
 {
 	void *pointer;
 	const size_t page_size = zend_fiber_get_page_size();
+	const size_t minimum_stack_size = page_size + ZEND_FIBER_GUARD_PAGES * page_size;
 
-	ZEND_ASSERT(size >= page_size + ZEND_FIBER_GUARD_PAGES * page_size);
+	if (size < minimum_stack_size) {
+		zend_throw_exception_ex(NULL, 0, "Fiber stack size is too small, it needs to be at least %zu bytes", minimum_stack_size);
+		return NULL;
+	}
 
 	const size_t stack_size = (size + page_size - 1) / page_size * page_size;
 	const size_t alloc_size = stack_size + ZEND_FIBER_GUARD_PAGES * page_size;


### PR DESCRIPTION
Closes GH-10249
See GH-10249 for analysis and discussion

EDIT macOS CI failure is due to "Bug #72333: fwrite() on non-blocking SSL sockets doesn't work [ext/openssl/tests/bug72333.phpt]", which is unrelated