### PR TITLE
Fix INF/NAN to string rendering

### DIFF
--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -3779,8 +3779,8 @@ ZEND_API char *zend_dtoa(double dd, int mode, int ndigits, int *decpt, bool *sig
 #endif
 
 	u.d = dd;
-	if (word0(&u) & Sign_bit) {
-		/* set sign for everything, including 0's and NaNs */
+	if (!zend_isnan(dd) && word0(&u) & Sign_bit) {
+		/* set sign for everything, including 0's */
 		*sign = 1;
 		word0(&u) &= ~Sign_bit;	/* clear sign bit */
 		}
@@ -3791,7 +3791,7 @@ ZEND_API char *zend_dtoa(double dd, int mode, int ndigits, int *decpt, bool *sig
 #ifdef IEEE_Arith
 	if ((word0(&u) & Exp_mask) == Exp_mask)
 #else
-	if (word0(&u)  == 0x8000)
+	if (word0(&u) == 0x8000)
 #endif
 		{
 		/* Infinity or NaN */

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -243,17 +243,12 @@ php_sprintf_appenddouble(zend_string **buffer, size_t *pos,
 	}
 
 	if (zend_isnan(number)) {
-		is_negative = (number<0);
-		php_sprintf_appendstring(buffer, pos, "NaN", 3, 0, padding,
-								 alignment, 3, is_negative, 0, always_sign);
-		return;
+		always_sign = 0;
+		padding = ' ';
 	}
 
 	if (zend_isinf(number)) {
-		is_negative = (number<0);
-		php_sprintf_appendstring(buffer, pos, "INF", 3, 0, padding,
-								 alignment, 3, is_negative, 0, always_sign);
-		return;
+		padding = ' ';
 	}
 
 	switch (fmt) {

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1026,7 +1026,7 @@ PHPAPI zend_string *_php_math_number_format_ex(double d, int dec, const char *de
 	int count = 0;
 	int is_negative=0;
 
-	if (d < 0) {
+	if (d < 0 && !zend_isinf(d)) {
 		is_negative = 1;
 		d = -d;
 	}

--- a/ext/standard/tests/bug49244.phpt
+++ b/ext/standard/tests/bug49244.phpt
@@ -10,23 +10,23 @@ for ($i = 0; $i < 10; $i++) {
 
 ?>
 --EXPECT--
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
-{NaN} NaN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN
+{NAN} NAN

--- a/ext/standard/tests/strings/number_format_basic.phpt
+++ b/ext/standard/tests/strings/number_format_basic.phpt
@@ -14,7 +14,10 @@ $values = array(1234.5678,
                 "123.456789",
                 "12.3456789e1",
                 true,
-                false);
+                false,
+                INF,
+                -INF,
+                NAN);
 
 echo "\n-- number_format tests.....default --\n";
 for ($i = 0; $i < count($values); $i++) {
@@ -55,6 +58,9 @@ string(3) "123"
 string(3) "123"
 string(1) "1"
 string(1) "0"
+string(3) "inf"
+string(4) "-inf"
+string(3) "nan"
 
 -- number_format tests.....with two dp --
 string(8) "1,234.57"
@@ -68,6 +74,9 @@ string(6) "123.46"
 string(6) "123.46"
 string(4) "1.00"
 string(4) "0.00"
+string(3) "inf"
+string(4) "-inf"
+string(3) "nan"
 
 -- number_format tests.....English format --
 string(8) "1 234.57"
@@ -81,6 +90,9 @@ string(6) "123.46"
 string(6) "123.46"
 string(4) "1.00"
 string(4) "0.00"
+string(3) "inf"
+string(4) "-inf"
+string(3) "nan"
 
 -- number_format tests.....French format --
 string(8) "1 234,57"
@@ -94,3 +106,6 @@ string(6) "123,46"
 string(6) "123,46"
 string(4) "1,00"
 string(4) "0,00"
+string(3) "inf"
+string(4) "-inf"
+string(3) "nan"

--- a/ext/standard/tests/strings/printf_inf_nan.phpt
+++ b/ext/standard/tests/strings/printf_inf_nan.phpt
@@ -1,0 +1,123 @@
+--TEST--
+Test printf INF/-INF/NAN rendering
+--FILE--
+<?php
+
+$values = [
+    INF,
+    abs(log(0)),
+    -INF,
+    log(0),
+    NAN,
+    -NAN,
+    sqrt(-1)
+];
+
+$valuesShort = [
+    INF,
+    -INF,
+    NAN,
+    -NAN
+];
+
+// Test each float format
+foreach ($values as $value) {
+    printf("#%1\$e# #%1\$E# #%1\$f# #%1\$F# #%1\$g# #%1\$G# #%1\$h# #%1\$H#\n", $value);
+}
+
+// Test padding and sign
+vprintf(
+    "#%+f# #%+f# #%+f# #%+f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%10f# #%10f# #%10f# #%10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%+10f# #%+10f# #%+10f# #%+10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%-10f# #%-10f# #%-10f# #%-10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%-+10f# #%-+10f# #%-+10f# #%-+10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%010f# #%010f# #%010f# #%010f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%+010f# #%+010f# #%+010f# #%+010f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%-010f# #%-010f# #%-010f# #%-010f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%-+010f# #%-+010f# #%-+010f# #%-+010f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%'n10f# #%'n10f# #%'n10f# #%'n10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%+'n10f# #%+'n10f# #%+'n10f# #%+'n10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%-'n10f# #%-'n10f# #%-'n10f# #%-'n10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%-+'n10f# #%-+'n10f# #%-+'n10f# #%-+'n10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#% 10f# #% 10f# #% 10f# #% 10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%+ 10f# #%+ 10f# #%+ 10f# #%+ 10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%- 10f# #%- 10f# #%- 10f# #%- 10f#\n",
+    $valuesShort
+);
+vprintf(
+    "#%-+ 10f# #%-+ 10f# #%-+ 10f# #%-+ 10f#\n",
+    $valuesShort
+);
+
+?>
+--EXPECT--
+#INF# #INF# #INF# #INF# #INF# #INF# #INF# #INF#
+#INF# #INF# #INF# #INF# #INF# #INF# #INF# #INF#
+#-INF# #-INF# #-INF# #-INF# #-INF# #-INF# #-INF# #-INF#
+#-INF# #-INF# #-INF# #-INF# #-INF# #-INF# #-INF# #-INF#
+#NAN# #NAN# #NAN# #NAN# #NAN# #NAN# #NAN# #NAN#
+#NAN# #NAN# #NAN# #NAN# #NAN# #NAN# #NAN# #NAN#
+#NAN# #NAN# #NAN# #NAN# #NAN# #NAN# #NAN# #NAN#
+#+INF# #-INF# #NAN# #NAN#
+#       INF# #      -INF# #       NAN# #       NAN#
+#      +INF# #      -INF# #       NAN# #       NAN#
+#INF       # #-INF      # #NAN       # #NAN       #
+#+INF      # #-INF      # #NAN       # #NAN       #
+#       INF# #      -INF# #       NAN# #       NAN#
+#      +INF# #      -INF# #       NAN# #       NAN#
+#INF       # #-INF      # #NAN       # #NAN       #
+#+INF      # #-INF      # #NAN       # #NAN       #
+#       INF# #      -INF# #       NAN# #       NAN#
+#      +INF# #      -INF# #       NAN# #       NAN#
+#INF       # #-INF      # #NAN       # #NAN       #
+#+INF      # #-INF      # #NAN       # #NAN       #
+#       INF# #      -INF# #       NAN# #       NAN#
+#      +INF# #      -INF# #       NAN# #       NAN#
+#INF       # #-INF      # #NAN       # #NAN       #
+#+INF      # #-INF      # #NAN       # #NAN       #

--- a/main/snprintf.c
+++ b/main/snprintf.c
@@ -291,7 +291,6 @@ PHPAPI char * php_conv_fp(char format, double num,
 	if (isalpha((int)*p)) {
 		*len = strlen(p);
 		memcpy(buf, p, *len + 1);
-		*is_negative = false;
 		free(p_orig);
 		return (buf);
 	}
@@ -872,8 +871,13 @@ static size_t format_converter(buffy * odp, const char *fmt, va_list ap) /* {{{ 
 						s = "NAN";
 						s_len = 3;
 					} else if (zend_isinf(fp_num)) {
-						s = "INF";
-						s_len = 3;
+						if (fp_num > 0) {
+							s = "INF";
+							s_len = 3;
+						} else {
+							s = "-INF";
+							s_len = 4;
+						}
 					} else {
 #ifdef ZTS
 						localeconv_r(&lconv);

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -582,8 +582,13 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 						s = "nan";
 						s_len = 3;
 					} else if (zend_isinf(fp_num)) {
-						s = "inf";
-						s_len = 3;
+						if (fp_num > 0) {
+							s = "inf";
+							s_len = 3;
+						} else {
+							s = "-inf";
+							s_len = 4;
+						}
 					} else {
 #ifdef ZTS
 						localeconv_r(&lconv);


### PR DESCRIPTION
INF / -INF / NAN are not always rendered as desired when transformed to string using `number_format` and `printf`.


```php
echo number_format(INF), ' @ ', number_format(-INF), ' @ ', number_format(NAN);
# inf @ inf @ nan
// => Missing minus sign on second inf


printf('%f @ %f @ %f', INF, -INF, NAN);
# INF @ INF @ NaN
// => Missing minus sign on second INF
// => NaN is inconsistant with other 'not a number' rendering (nan or NAN)

printf('%+f', INF);
# INF
// => Missing plus sign before INF

printf('%+0f', INF);
printf('%+0f', -INF);
printf('%+0f', NAN);
# +NF
# -NF
# +aN
// => Buggy

printf('@%10f@', INF);
printf('@%-10f@', INF);
# @INF@
# @INF@
// => No right or left padding
```


This PR fix these cases