### PR TITLE
ext/opcache: remove option huge_code_pages

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -187,9 +187,6 @@ typedef struct _zend_accel_directives {
 #if ENABLE_FILE_CACHE_FALLBACK
 	bool      file_cache_fallback;
 #endif
-#ifdef HAVE_HUGE_CODE_PAGES
-	bool      huge_code_pages;
-#endif
 	char *preload;
 #ifndef ZEND_WIN32
 	char *preload_user;

--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -4,13 +4,6 @@ PHP_ARG_ENABLE([opcache],
     [Disable Zend OPcache support])],
   [yes])
 
-PHP_ARG_ENABLE([huge-code-pages],
-  [whether to enable copying PHP CODE pages into HUGE PAGES],
-  [AS_HELP_STRING([--disable-huge-code-pages],
-    [Disable copying PHP CODE pages into HUGE PAGES])],
-  [yes],
-  [no])
-
 PHP_ARG_ENABLE([opcache-jit],
   [whether to enable JIT],
   [AS_HELP_STRING([--disable-opcache-jit],

--- a/ext/opcache/jit/zend_jit_perf_dump.c
+++ b/ext/opcache/jit/zend_jit_perf_dump.c
@@ -52,12 +52,12 @@ extern unsigned int thr_self(void);
 /*
  * 1) Profile using perf-<pid>.map
  *
- * perf record php -d opcache.huge_code_pages=0 -d opcache.jit_debug=0x10 bench.php
+ * perf record php -d opcache.jit_debug=0x10 bench.php
  * perf report
  *
  * 2) Profile using jit-<pid>.dump
  *
- * perf record -k 1 php -d opcache.huge_code_pages=0 -d opcache.jit_debug=0x20 bench.php
+ * perf record -k 1 php -d opcache.jit_debug=0x20 bench.php
  * perf inject -j -i perf.data -o perf.data.jitted
  * perf report -i perf.data.jitted
  *

--- a/ext/opcache/tests/zzz_basic_logging.phpt
+++ b/ext/opcache/tests/zzz_basic_logging.phpt
@@ -9,7 +9,6 @@ opcache.enable_cli=1
 opcache.file_cache_only=0
 opcache.error_log=
 opcache.log_verbosity_level=4
-opcache.huge_code_pages=0
 opcache.preload=
 opcache.interned_strings_buffer=8
 --EXTENSIONS--

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -294,9 +294,6 @@ ZEND_INI_BEGIN()
 #if ENABLE_FILE_CACHE_FALLBACK
 	STD_PHP_INI_BOOLEAN("opcache.file_cache_fallback"           , "1"   , PHP_INI_SYSTEM, OnUpdateBool,	   accel_directives.file_cache_fallback,           zend_accel_globals, accel_globals)
 #endif
-#ifdef HAVE_HUGE_CODE_PAGES
-	STD_PHP_INI_BOOLEAN("opcache.huge_code_pages"             , "0"   , PHP_INI_SYSTEM, OnUpdateBool,      accel_directives.huge_code_pages,               zend_accel_globals, accel_globals)
-#endif
 	STD_PHP_INI_ENTRY("opcache.preload"                       , ""    , PHP_INI_SYSTEM, OnUpdateStringUnempty,    accel_directives.preload,                zend_accel_globals, accel_globals)
 #ifndef ZEND_WIN32
 	STD_PHP_INI_ENTRY("opcache.preload_user"                  , ""    , PHP_INI_SYSTEM, OnUpdateStringUnempty,    accel_directives.preload_user,           zend_accel_globals, accel_globals)
@@ -807,9 +804,6 @@ ZEND_FUNCTION(opcache_get_configuration)
 	add_assoc_long(&directives,   "opcache.file_update_protection",  ZCG(accel_directives).file_update_protection);
 	add_assoc_long(&directives,   "opcache.opt_debug_level",         ZCG(accel_directives).opt_debug_level);
 	add_assoc_string(&directives, "opcache.restrict_api",            STRING_NOT_NULL(ZCG(accel_directives).restrict_api));
-#ifdef HAVE_HUGE_CODE_PAGES
-	add_assoc_bool(&directives,   "opcache.huge_code_pages",         ZCG(accel_directives).huge_code_pages);
-#endif
 	add_assoc_string(&directives, "opcache.preload", STRING_NOT_NULL(ZCG(accel_directives).preload));
 #ifndef ZEND_WIN32
 	add_assoc_string(&directives, "opcache.preload_user", STRING_NOT_NULL(ZCG(accel_directives).preload_user));

--- a/php.ini-development
+++ b/php.ini-development
@@ -1914,15 +1914,6 @@ ldap.max_links = -1
 ; cache is required.
 ;opcache.file_cache_fallback=1
 
-; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
-; Under certain circumstances (if only a single global PHP process is
-; started from which all others fork), this can increase performance
-; by a tiny amount because TLB misses are reduced.  On the other hand, this
-; delays PHP startup, increases memory usage and degrades performance
-; under memory pressure - use with care.
-; Requires appropriate OS configuration.
-;opcache.huge_code_pages=0
-
 ; Validate cached file permissions.
 ;opcache.validate_permission=0
 

--- a/php.ini-production
+++ b/php.ini-production
@@ -1916,15 +1916,6 @@ ldap.max_links = -1
 ; cache is required.
 ;opcache.file_cache_fallback=1
 
-; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
-; Under certain circumstances (if only a single global PHP process is
-; started from which all others fork), this can increase performance
-; by a tiny amount because TLB misses are reduced.  On the other hand, this
-; delays PHP startup, increases memory usage and degrades performance
-; under memory pressure - use with care.
-; Requires appropriate OS configuration.
-;opcache.huge_code_pages=0
-
 ; Validate cached file permissions.
 ;opcache.validate_permission=0
 


### PR DESCRIPTION
This feature is useless at best, but is fragile and increases memory usage because it creates a copy of the PHP executable in RAM, when another copy is already in the kernel's page cache.

Additionally, each PHP process has its own copy, multiplying the memory usage with the number of PHP processes.

Even worse: under memory pressure, the kernel would usually just discard those code pages, and reload them from disk on demand; but with `huge_code_pages`, the kernel cannot simply discard those pages, instead it has to allocate room in the swap partition and then has to write the pages to the swap partition before being able to discard them.  This adds disk I/O to an already extremely constrained situation.

The feature was added 7 years ago in commit 669f0b39b184, and the commit message stated that this "provided 2% improvement on real-life apps, because of 2-3 times reduction in number of iTLB misses", but did not tell how these results were produced.

I tried, but failed to measure a difference.  None of my tests went any faster with `huge_code_pages` enabled.

In a second attempt, I tried `perf stat` with events `itlb_misses.miss_causes_a_walk`, `itlb_misses.stlb_hit`, `itlb_misses.walk_completed`, `itlb_misses.walk_duration` and could not see any improvements here either.  The results were unstable, but nothing suggested it was better with `huge_code_pages`.

Quite contrary, this operation delays PHP startup by 5 ms (measured on an Intel Xeon E5-2630).

phpinfo() with opcache.huge_code_pages=0:

             17.92 msec task-clock:u                     #    0.985 CPUs utilized
        29,804,809      cycles:u                         #    1.663 GHz
        44,512,668      instructions:u                   #    1.49  insn per cycle

phpinfo() with opcache.huge_code_pages=1:

             23.20 msec task-clock:u                     #    0.988 CPUs utilized
        35,709,593      cycles:u                         #    1.539 GHz
        45,940,779      instructions:u                   #    1.29  insn per cycle


In order to reduce PHP's memory size, reduce the load during PHP startup, simplify debugging and profiling, I propose removing this feature.