### PR TITLE
Stop using the deprecated `set-output` command in nightly_matrix.php

### DIFF
--- a/.github/nightly_matrix.php
+++ b/.github/nightly_matrix.php
@@ -88,5 +88,7 @@ if ($discard_cache) {
 $branches = get_branches();
 $matrix_include = get_matrix_include($branches);
 
-echo '::set-output name=branches::' . json_encode($branches, JSON_UNESCAPED_SLASHES) . "\n";
-echo '::set-output name=matrix-include::' . json_encode($matrix_include, JSON_UNESCAPED_SLASHES) . "\n";
+$f = fopen(getenv('GITHUB_OUTPUT'), 'a');
+fwrite($f, 'branches=' . json_encode($branches, JSON_UNESCAPED_SLASHES) . "\n");
+fwrite($f, 'matrix-include=' . json_encode($matrix_include, JSON_UNESCAPED_SLASHES) . "\n");
+fclose($f);


### PR DESCRIPTION
Tested to verify that the script actually writes to the file provided in the environment variable, did not test against GHA itself.

-------------

see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/