### PR TITLE
build/php.m4: remove test for integer types

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -26,6 +26,10 @@ PHP 8.3 INTERNALS UPGRADE NOTES
   break the build of third-party extensions which relied on this
   implementation detail.  Those extensions may need to add the missing
   #include lines.
+* Since version 8, PHP requires a C99 compiler.  Configure-time checks
+  for C99 features have been removed and therefore macro definitions
+  from php_config.h have disappeared.  Do not use those feature
+  macros.
 
 ========================
 2. Build system changes

--- a/Zend/zend_strtod_int.h
+++ b/Zend/zend_strtod_int.h
@@ -44,22 +44,6 @@
 
 #include <inttypes.h>
 
-#ifndef HAVE_INT32_T
-# if SIZEOF_INT == 4
-typedef int int32_t;
-# elif SIZEOF_LONG == 4
-typedef long int int32_t;
-# endif
-#endif
-
-#ifndef HAVE_UINT32_T
-# if SIZEOF_INT == 4
-typedef unsigned int uint32_t;
-# elif SIZEOF_LONG == 4
-typedef unsigned long int uint32_t;
-# endif
-#endif
-
 #ifdef USE_LOCALE
 #undef USE_LOCALE
 #endif

--- a/build/php.m4
+++ b/build/php.m4
@@ -2443,14 +2443,6 @@ AC_DEFUN([PHP_CHECK_STDINT_TYPES], [
   AC_CHECK_SIZEOF([long long])
   AC_CHECK_SIZEOF([size_t])
   AC_CHECK_SIZEOF([off_t])
-  AC_CHECK_TYPES([int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t], [], [
-    AC_MSG_ERROR([One of the intN_t or uintN_t types is not available])
-  ], [
-#include <stdint.h>
-#if HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-  ])
 ])
 
 dnl

--- a/ext/date/lib/timelib.h
+++ b/ext/date/lib/timelib.h
@@ -39,22 +39,6 @@
 #include <limits.h>
 #include <inttypes.h>
 
-# ifndef HAVE_INT32_T
-#  if SIZEOF_INT == 4
-typedef int int32_t;
-#  elif SIZEOF_LONG == 4
-typedef long int int32_t;
-#  endif
-# endif
-
-# ifndef HAVE_UINT32_T
-#  if SIZEOF_INT == 4
-typedef unsigned int uint32_t;
-#  elif SIZEOF_LONG == 4
-typedef unsigned long int uint32_t;
-#  endif
-# endif
-
 #ifdef _WIN32
 # if _MSC_VER >= 1600
 # include <stdint.h>

--- a/ext/mysqlnd/config-win.h
+++ b/ext/mysqlnd/config-win.h
@@ -15,32 +15,6 @@ This file is public domain and comes with NO WARRANTY of any kind */
 
 #include <stdint.h>
 
-#ifndef HAVE_INT8_T
-#define HAVE_INT8_T
-#endif
-#ifndef HAVE_UINT8_T
-#define HAVE_UINT8_T
-#endif
-#ifndef HAVE_INT16_T
-#define HAVE_INT16_T
-#endif
-#ifndef HAVE_UINT16_T
-#define HAVE_UINT16_T
-#endif
-#ifndef HAVE_INT32_T
-#define HAVE_INT32_T
-#endif
-#ifndef HAVE_UINT32_T
-#define HAVE_UINT32_T
-#endif
-#ifndef HAVE_INT64_T
-#define HAVE_INT64_T
-#endif
-#ifndef HAVE_UINT64_T
-#define HAVE_UINT64_T
-#endif
-
-
 #ifndef _WIN64
 #ifndef _WIN32
 #define _WIN32				/* Compatible with old source */


### PR DESCRIPTION
These are mandatory in C99, so it's a pointless waste of time to check for them.

(Actually, the fixed-size integer types are not mandatory, but if they are really not available on some theoretical system, PHP's fallbacks won't work either, so nothing is gained from this check.)