### PR TITLE
Fix GH-10248: Assertion `!(zval_get_type(&(*(property))) == 10)' failed. 

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1207,6 +1207,7 @@ static void zend_verify_internal_read_property_type(zend_object *obj, zend_strin
 	zend_property_info *prop_info =
 		zend_get_property_info(obj->ce, name, /* silent */ true);
 	if (prop_info && prop_info != ZEND_WRONG_PROPERTY_INFO && ZEND_TYPE_IS_SET(prop_info->type)) {
+		ZVAL_OPT_DEREF(val);
 		zend_verify_property_type(prop_info, val, /* strict */ true);
 	}
 }

--- a/ext/spl/tests/gh10248.phpt
+++ b/ext/spl/tests/gh10248.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-10248 (Assertion `!(zval_get_type(&(*(property))) == 10)' failed.)
+--FILE--
+<?php
+
+class a extends ArrayIterator
+{
+    public ?int $property;
+}
+$a = new a();
+$a->property = &$b;
+$a->property;
+
+echo "Done\n";
+
+?>
+--EXPECT--
+Done


### PR DESCRIPTION
Fixes GH-10248

The assertion failure was triggered in a debug code-path that validates property types for internal classes.
zend_verify_internal_read_property_type was called with retval being a reference, which is not allowed because that function eventually calls to i_zend_check_property_type, which does not expect a reference.
The non-debug code-path already takes into account that retval can be a reference, as it optionally dereferences retval.

Add a dereference in zend_verify_internal_read_property_type just before the call to zend_verify_property_type, which is how other callers often behave as well.

(An alternative I considered and posted in the issue report is performing the dereference in the VM, but this solution is a little cleaner.)