### PR TITLE
Fix substr_replace with slots in repl_ht being UNDEF

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -2472,7 +2472,7 @@ PHP_FUNCTION(substr_replace)
 			if (repl_ht) {
 				while (repl_idx < repl_ht->nNumUsed) {
 					tmp_repl = &repl_ht->arData[repl_idx].val;
-					if (repl_ht != IS_UNDEF) {
+					if (Z_TYPE_P(tmp_repl) != IS_UNDEF) {
 						break;
 					}
 					repl_idx++;

--- a/ext/standard/tests/strings/substr_replace_array_unset.phpt
+++ b/ext/standard/tests/strings/substr_replace_array_unset.phpt
@@ -1,0 +1,27 @@
+--TEST--
+substr_replace() function - array with unset
+--FILE--
+<?php
+
+$replacement = ['A', 'C', 'B'];
+unset($replacement[1]);
+$newarr = substr_replace(['1 string', '2 string'], $replacement, 0);
+print_r($newarr);
+
+$replacement = ['foo', 42 => 'bar', 'baz'];
+unset($replacement[42]);
+$newarr = substr_replace(['1 string', '2 string'], $replacement, 0);
+print_r($newarr);
+
+?>
+--EXPECT--
+Array
+(
+    [0] => A
+    [1] => B
+)
+Array
+(
+    [0] => foo
+    [1] => baz
+)


### PR DESCRIPTION
The check that was supposed to check whether the array slot was UNDEF was wrong and never triggered. This resulted in a replacement with the empty string or the wrong string instead of the correct one. The correct check pattern can be observed higher up in the function's code.

EDIT: Appveyor failure due to `Bug #48182: ssl handshake fails during asynchronous socket connection [C:\projects\php-src\ext\openssl\tests\bug48182.phpt]`, which is unrelated