### PR TITLE
Fix missing check for xmlTextWriterEndElement

### DIFF
--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -449,7 +449,7 @@ PHP_FUNCTION(xmlwriter_write_element)
 			if (retval == -1) {
 				RETURN_FALSE;
 			}
-			xmlTextWriterEndElement(ptr);
+			retval = xmlTextWriterEndElement(ptr);
 			if (retval == -1) {
 				RETURN_FALSE;
 			}


### PR DESCRIPTION
xmlTextWriterEndElement returns -1 if the call fails. There was already a check for retval, but the return value wasn't assigned to retval. The other caller of xmlTextWriterEndElement is in xmlwriter_write_element_ns, which does the check correctly.

Full disclosure:
This bug was found using my own-developed (experimental) static analysis tool, which reported the missing check. I manually verified this bug report by doing code review as well. After applying this patch, my analyser no
longer reports this bug.