### PR TITLE
Mark constant static arrays in function bodies actually as const

### DIFF
--- a/Zend/zend_strtod.c
+++ b/Zend/zend_strtod.c
@@ -959,7 +959,7 @@ pow5mult
 {
 	Bigint *b1, *p5, *p51;
 	int i;
-	static int p05[3] = { 5, 25, 125 };
+	static const int p05[3] = { 5, 25, 125 };
 
 	if ((i = k & 3))
 		b = multadd(b, p05[i-1], 0);

--- a/ext/hash/hash_snefru.c
+++ b/ext/hash/hash_snefru.c
@@ -39,7 +39,7 @@ void ph(uint32_t h[16])
 
 static inline void Snefru(uint32_t input[16])
 {
-	static int shifts[4] = {16, 8, 16, 24};
+	static const int shifts[4] = {16, 8, 16, 24};
 	int b, index, rshift, lshift;
 	const uint32_t *t0,*t1;
 	uint32_t SBE,B00,B01,B02,B03,B04,B05,B06,B07,B08,B09,B10,B11,B12,B13,B14,B15;

--- a/ext/iconv/iconv.c
+++ b/ext/iconv/iconv.c
@@ -906,7 +906,7 @@ static php_iconv_err_t _php_iconv_mime_encode(smart_str *pretval, const char *fn
 	char *out_p;
 	size_t out_left;
 	zend_string *encoded = NULL;
-	static int qp_table[256] = {
+	static const int qp_table[256] = {
 		3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, /* 0x00 */
 		3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, /* 0x10 */
 		3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x20 */


### PR DESCRIPTION
These arrays are not meant to be modified, mark them as const.
This prevents accidental modification and places the arrays in .rodata.