### PR TITLE
Fix wrong flags check for compression method in phar_object.c

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -3312,7 +3312,7 @@ PHP_METHOD(Phar, compressFiles)
 	}
 
 	if (!pharobj_cancompress(&phar_obj->archive->manifest)) {
-		if (flags == PHAR_FILE_COMPRESSED_GZ) {
+		if (flags == PHAR_ENT_COMPRESSED_GZ) {
 			zend_throw_exception_ex(spl_ce_BadMethodCallException, 0,
 				"Cannot compress all files as Gzip, some are compressed as bzip2 and cannot be decompressed");
 		} else {


### PR DESCRIPTION
I found this issue using static analysis tools, it reported that the condition was always false.
We can see that `flags` is assigned in the switch statement above, but a mistake was made in the comparison.