### PR TITLE
Fix incorrect comparison in block optimization pass

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -671,13 +671,13 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 			case ZEND_JMPNZ_EX:
 				while (1) {
 					if (opline->op1_type == IS_CONST) {
-						if (zend_is_true(&ZEND_OP1_LITERAL(opline)) ==
-						    (opline->opcode == ZEND_JMPZ_EX)) {
+						bool is_jmpz_ex = opline->opcode == ZEND_JMPZ_EX;
+						if (zend_is_true(&ZEND_OP1_LITERAL(opline)) == is_jmpz_ex) {
 
 							++(*opt_count);
 							opline->opcode = ZEND_QM_ASSIGN;
 							zval_ptr_dtor_nogc(&ZEND_OP1_LITERAL(opline));
-							ZVAL_BOOL(&ZEND_OP1_LITERAL(opline), opline->opcode == ZEND_JMPZ_EX);
+							ZVAL_BOOL(&ZEND_OP1_LITERAL(opline), is_jmpz_ex);
 							opline->op2.num = 0;
 							block->successors_count = 1;
 							block->successors[0] = block->successors[1];


### PR DESCRIPTION
We're in the case of ZEND_JMPZ_EX or ZEND_JMPNZ_EX. The opcode gets overwritten and only after the overwriting gets checked if we're in a JMPZ or JMPNZ case. This results in a wrong optimization.

Unfortunately, I couldn't find an easy way to write a test because `zend_compile.c` already checks for the constant case. Still, it could be that this code can still be reached because of a combination of optimizations.

Note that I found this issue using a static analyser which reported this always-false check.