### PR TITLE
Add some const qualifiers and better return types to zend_object_handlers.h

### DIFF
--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -488,7 +488,7 @@ found:
 }
 /* }}} */
 
-ZEND_API int zend_check_property_access(zend_object *zobj, zend_string *prop_info_name, bool is_dynamic) /* {{{ */
+ZEND_API zend_result zend_check_property_access(const zend_object *zobj, zend_string *prop_info_name, bool is_dynamic) /* {{{ */
 {
 	zend_property_info *property_info;
 	const char *class_name = NULL;
@@ -1228,9 +1228,9 @@ static zend_never_inline zend_function *zend_get_parent_private_method(zend_clas
 
 /* Ensures that we're allowed to call a protected method.
  */
-ZEND_API int zend_check_protected(zend_class_entry *ce, zend_class_entry *scope) /* {{{ */
+ZEND_API bool zend_check_protected(const zend_class_entry *ce, const zend_class_entry *scope) /* {{{ */
 {
-	zend_class_entry *fbc_scope = ce;
+	const zend_class_entry *fbc_scope = ce;
 
 	/* Is the context that's calling the function, the same as one of
 	 * the function's parents?
@@ -1255,7 +1255,7 @@ ZEND_API int zend_check_protected(zend_class_entry *ce, zend_class_entry *scope)
 }
 /* }}} */
 
-ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend_string *method_name, int is_static) /* {{{ */
+ZEND_API zend_function *zend_get_call_trampoline_func(const zend_class_entry *ce, zend_string *method_name, bool is_static) /* {{{ */
 {
 	size_t mname_len;
 	zend_op_array *func;

--- a/Zend/zend_object_handlers.h
+++ b/Zend/zend_object_handlers.h
@@ -233,11 +233,11 @@ ZEND_API HashTable *zend_std_build_object_properties_array(zend_object *zobj);
  * Only objects with the same identity will be considered equal. */
 ZEND_API int zend_objects_not_comparable(zval *o1, zval *o2);
 
-ZEND_API int zend_check_protected(zend_class_entry *ce, zend_class_entry *scope);
+ZEND_API bool zend_check_protected(const zend_class_entry *ce, const zend_class_entry *scope);
 
-ZEND_API int zend_check_property_access(zend_object *zobj, zend_string *prop_info_name, bool is_dynamic);
+ZEND_API zend_result zend_check_property_access(const zend_object *zobj, zend_string *prop_info_name, bool is_dynamic);
 
-ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend_string *method_name, int is_static);
+ZEND_API zend_function *zend_get_call_trampoline_func(const zend_class_entry *ce, zend_string *method_name, bool is_static);
 
 ZEND_API uint32_t *zend_get_property_guard(zend_object *zobj, zend_string *member);
 


### PR DESCRIPTION
I initially wanted to add them to the zend_strings but because they are used in zend_hash_find() which might modify the hash field.