### PR TITLE
posix detects posix_pathconf api.

### DIFF
--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -10,7 +10,7 @@ if test "$PHP_POSIX" = "yes"; then
 
   AC_CHECK_HEADERS([sys/mkdev.h sys/sysmacros.h])
 
-  AC_CHECK_FUNCS(seteuid setegid setsid getsid getpgid ctermid mkfifo mknod setrlimit getrlimit getgroups makedev initgroups getgrgid_r)
+  AC_CHECK_FUNCS(seteuid setegid setsid getsid getpgid ctermid mkfifo mknod setrlimit getrlimit getgroups makedev initgroups getgrgid_r posix_pathconf)
 
   AC_MSG_CHECKING([for working ttyname_r() implementation])
   AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -1197,6 +1197,7 @@ PHP_FUNCTION(posix_sysconf)
 	RETURN_LONG(sysconf(conf_id));
 }
 
+#ifdef HAVE_POSIX_PATHCONF
 PHP_FUNCTION(posix_pathconf)
 {
 	zend_long name, ret;
@@ -1257,3 +1258,4 @@ PHP_FUNCTION(posix_fpathconf)
 
 	RETURN_LONG(ret);
 }
+#endif

--- a/ext/posix/posix.stub.php
+++ b/ext/posix/posix.stub.php
@@ -428,6 +428,8 @@ function posix_initgroups(string $username, int $group_id): bool {}
 
 function posix_sysconf(int $conf_id): int {}
 
+#ifdef HAVE_POSIX_PATHCONF
 function posix_pathconf(string $path, int $name): int|false {}
 /** @param resource|int $file_descriptor */
 function posix_fpathconf($file_descriptor, int $name): int|false {}
+#endif

--- a/ext/posix/posix_arginfo.h
+++ b/ext/posix/posix_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b0c74c2ad41d4ae6a624f73109815fc9fe47fd1f */
+ * Stub hash: 5359511a464e0d35c7d5c4ea3320c70210b2b9a7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_posix_kill, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
@@ -164,15 +164,19 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_posix_sysconf, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, conf_id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+#if defined(HAVE_POSIX_PATHCONF)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_posix_pathconf, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if defined(HAVE_POSIX_PATHCONF)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_posix_fpathconf, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, file_descriptor)
 	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+#endif
 
 
 ZEND_FUNCTION(posix_kill);
@@ -238,8 +242,12 @@ ZEND_FUNCTION(posix_strerror);
 ZEND_FUNCTION(posix_initgroups);
 #endif
 ZEND_FUNCTION(posix_sysconf);
+#if defined(HAVE_POSIX_PATHCONF)
 ZEND_FUNCTION(posix_pathconf);
+#endif
+#if defined(HAVE_POSIX_PATHCONF)
 ZEND_FUNCTION(posix_fpathconf);
+#endif
 
 
 static const zend_function_entry ext_functions[] = {
@@ -307,8 +315,12 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(posix_initgroups, arginfo_posix_initgroups)
 #endif
 	ZEND_FE(posix_sysconf, arginfo_posix_sysconf)
+#if defined(HAVE_POSIX_PATHCONF)
 	ZEND_FE(posix_pathconf, arginfo_posix_pathconf)
+#endif
+#if defined(HAVE_POSIX_PATHCONF)
 	ZEND_FE(posix_fpathconf, arginfo_posix_fpathconf)
+#endif
 	ZEND_FE_END
 };
 

--- a/ext/posix/tests/posix_fpathconf.phpt
+++ b/ext/posix/tests/posix_fpathconf.phpt
@@ -2,6 +2,10 @@
 Test posix_fpathconf
 --EXTENSIONS--
 posix
+--SKIPIF--
+<?php
+if (!function_exists("posix_pathconf")) die("skip only platforms with posix_pathconf");
+?>
 --FILE--
 <?php
 var_dump(posix_fpathconf(-1, POSIX_PC_PATH_MAX));

--- a/ext/posix/tests/posix_pathconf.phpt
+++ b/ext/posix/tests/posix_pathconf.phpt
@@ -2,6 +2,10 @@
 Test posix_pathconf
 --EXTENSIONS--
 posix
+--SKIPIF--
+<?php
+if (!function_exists("posix_pathconf")) die("skip only platforms with posix_pathconf");
+?>
 --FILE--
 <?php
 try {


### PR DESCRIPTION
alpine linux throws undefined reference at build time, thus
 not assuming it s necessarily available.