### PR TITLE
Handle exceptions from __toString in XXH3's initialization

### DIFF
--- a/ext/hash/hash_xxhash.c
+++ b/ext/hash/hash_xxhash.c
@@ -174,7 +174,9 @@ zend_always_inline static void _PHP_XXH3_Init(PHP_XXH3_64_CTX *ctx, HashTable *a
 			func_init_seed(&ctx->s, (XXH64_hash_t)Z_LVAL_P(_seed));
 			return;
 		} else if (_secret) {
-			convert_to_string(_secret);
+			if (!try_convert_to_string(_secret)) {
+				return;
+			}
 			size_t len = Z_STRLEN_P(_secret);
 			if (len < PHP_XXH3_SECRET_SIZE_MIN) {
 				zend_throw_error(NULL, "%s: Secret length must be >= %u bytes, %zu bytes passed", algo_name, XXH3_SECRET_SIZE_MIN, len);

--- a/ext/hash/tests/xxhash_secret.phpt
+++ b/ext/hash/tests/xxhash_secret.phpt
@@ -3,6 +3,13 @@ Hash: xxHash secret
 --FILE--
 <?php
 
+class StringableThrowingClass {
+    public function __toString(): string {
+        throw new Exception('exception in __toString');
+        return '';
+    }
+}
+
 foreach (["xxh3", "xxh128"] as $a) {
 
 	//$secret = random_bytes(256);
@@ -10,6 +17,12 @@ foreach (["xxh3", "xxh128"] as $a) {
 
 	try {
 		$ctx = hash_init($a, options: ["seed" => 24, "secret" => $secret]);
+	} catch (Throwable $e) {
+		var_dump($e->getMessage());
+	}
+
+	try {
+		$ctx = hash_init($a, options: ["secret" => new StringableThrowingClass()]);
 	} catch (Throwable $e) {
 		var_dump($e->getMessage());
 	}
@@ -35,8 +48,10 @@ foreach (["xxh3", "xxh128"] as $a) {
 ?>
 --EXPECT--
 string(67) "xxh3: Only one of seed or secret is to be passed for initialization"
+string(23) "exception in __toString"
 string(57) "xxh3: Secret length must be >= 136 bytes, 17 bytes passed"
 8028aa834c03557a == 8028aa834c03557a == true
 string(69) "xxh128: Only one of seed or secret is to be passed for initialization"
+string(23) "exception in __toString"
 string(59) "xxh128: Secret length must be >= 136 bytes, 17 bytes passed"
 54279097795e7218093a05d4d781cbb9 == 54279097795e7218093a05d4d781cbb9 == true


### PR DESCRIPTION
The initialization routine for XXH3 was not prepared for exceptions from seed. Fix this by using `try_convert_to_string`.

For discussion, please see:
https://github.com/php/php-src/issues/10305#issuecomment-1381598772 and https://github.com/php/php-src/issues/10305#issuecomment-1384333126