### PR TITLE
Fix phpdbg segmentation fault in case of malformed input

### DIFF
--- a/sapi/phpdbg/phpdbg_utils.c
+++ b/sapi/phpdbg/phpdbg_utils.c
@@ -466,6 +466,9 @@ PHPDBG_API int phpdbg_parse_variable_with_arg(char *input, size_t len, HashTable
 				case ']':
 					break;
 				case '>':
+					if (!last_index) {
+						goto error;
+					}
 					if (last_index[index_len - 1] == '-') {
 						new_index = 1;
 						index_len--;

--- a/sapi/phpdbg/tests/watch_007.phpt
+++ b/sapi/phpdbg/tests/watch_007.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test malformed watchpoint name
+--INI--
+opcache.optimization_level=0
+--PHPDBG--
+b test
+r
+w $>
+q
+--EXPECTF--
+[Successful compilation of %s]
+prompt> [Breakpoint #0 added at test]
+prompt> [Breakpoint #0 in test() at %s:%d, hits: 1]
+>00004: }
+ 00005: test();
+ 00006: $a = 2;
+prompt> [Malformed input]
+prompt>
+--FILE--
+<?php
+$a = 1;
+function test() {
+}
+test();
+$a = 2;


### PR DESCRIPTION
If you were to enter "w $>" the function would crash with a segmentation fault because last_index is still NULL at that point. Fix it by checking for NULL and erroring out if it is.

Even though this is a very minor bug, I think it's worth it to fix this because accidentally entering malformed input could crash your debugging session.

Note:
I found this issue using a static analyser. I manually verified the issue by writing a test case. After fixing this the analyser no longer complains.