### PR TITLE
Remove pcre_get_compiled_regex_ex()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -65,6 +65,10 @@ PHP 8.3 INTERNALS UPGRADE NOTES
    mysqlnd_command::shutdown & mysqlnd_conn_data::shutdown have been removed.
    These functions are deprecated by MySQL in favour of SHUTDOWN SQL statement.
 
+ d. ext/pcre
+   - The function pcre_get_compiled_regex_ex has been removed.
+   Use pcre_get_compiled_regex instead.
+
 ========================
 4. OpCode changes
 ========================

--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -910,25 +910,6 @@ PHPAPI pcre2_code *pcre_get_compiled_regex(zend_string *regex, uint32_t *capture
 }
 /* }}} */
 
-/* {{{ pcre_get_compiled_regex_ex */
-PHPAPI pcre2_code* pcre_get_compiled_regex_ex(zend_string *regex, uint32_t *capture_count, uint32_t *preg_options, uint32_t *compile_options)
-{
-	pcre_cache_entry * pce = pcre_get_compiled_regex_cache(regex);
-
-	if (preg_options) {
-		*preg_options = pce ? pce->preg_options : 0;
-	}
-	if (compile_options) {
-		*compile_options = pce ? pce->compile_options : 0;
-	}
-	if (capture_count) {
-		*capture_count = pce ? pce->capture_count : 0;
-	}
-
-	return pce ? pce->re : NULL;
-}
-/* }}} */
-
 /* XXX For the cases where it's only about match yes/no and no capture
 		required, perhaps just a minimum sized data would suffice. */
 PHPAPI pcre2_match_data *php_pcre_create_match_data(uint32_t capture_count, pcre2_code *re)

--- a/ext/pcre/php_pcre.h
+++ b/ext/pcre/php_pcre.h
@@ -27,7 +27,6 @@
 
 PHPAPI zend_string *php_pcre_replace(zend_string *regex, zend_string *subject_str, const char *subject, size_t subject_len, zend_string *replace_str, size_t limit, size_t *replace_count);
 PHPAPI pcre2_code* pcre_get_compiled_regex(zend_string *regex, uint32_t *capture_count);
-PHPAPI pcre2_code* pcre_get_compiled_regex_ex(zend_string *regex, uint32_t *capture_count, uint32_t *preg_options, uint32_t *coptions);
 
 extern zend_module_entry pcre_module_entry;
 #define pcre_module_ptr &pcre_module_entry


### PR DESCRIPTION
Please correct me if I am wrong, but this method is not used internally within PHP. If any extension wants to use it they can still use `pcre_get_compiled_regex` as it does the same thing. 