### PR TITLE
Remove mysqlnd_shutdown()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -60,6 +60,11 @@ PHP 8.3 INTERNALS UPGRADE NOTES
      length at each call. The key_suffix parameter was dropped as it was a
      constant value and depended on the key_prefix parameter to not be NULL.
 
+ c. ext/mysqlnd
+   - The function mysqlnd_shutdown and its corresponding internal methods
+   mysqlnd_command::shutdown & mysqlnd_conn_data::shutdown have been removed.
+   These functions are deprecated by MySQL in favour of SHUTDOWN SQL statement.
+
 ========================
 4. OpCode changes
 ========================

--- a/ext/mysqlnd/mysqlnd.h
+++ b/ext/mysqlnd/mysqlnd.h
@@ -194,7 +194,6 @@ PHPAPI void mysqlnd_local_infile_default(MYSQLND_CONN_DATA * conn);
 #define mysqlnd_ping(conn)					((conn)->data)->m->ping((conn)->data)
 #define mysqlnd_kill(conn, pid)				((conn)->data)->m->kill_connection((conn)->data, (pid))
 #define mysqlnd_refresh(conn, options)		((conn)->data)->m->refresh_server((conn)->data, (options))
-#define mysqlnd_shutdown(conn, level)		((conn)->data)->m->shutdown_server((conn)->data, (level))
 #define mysqlnd_set_character_set(conn, cs)	((conn)->data)->m->set_charset((conn)->data, (cs))
 #define mysqlnd_stat(conn, msg)				((conn)->data)->m->get_server_statistics(((conn)->data), (msg))
 #define mysqlnd_options(conn, opt, value)	((conn)->data)->m->set_client_option((conn)->data, (opt), (value))

--- a/ext/mysqlnd/mysqlnd_commands.c
+++ b/ext/mysqlnd/mysqlnd_commands.c
@@ -250,35 +250,6 @@ MYSQLND_METHOD(mysqlnd_command, refresh)(MYSQLND_CONN_DATA * const conn, const u
 /* }}} */
 
 
-/* {{{ mysqlnd_command::shutdown */
-static enum_func_status
-MYSQLND_METHOD(mysqlnd_command, shutdown)(MYSQLND_CONN_DATA * const conn, const uint8_t level)
-{
-	const func_mysqlnd_protocol_payload_decoder_factory__send_command send_command = conn->payload_decoder_factory->m.send_command;
-	const func_mysqlnd_protocol_payload_decoder_factory__send_command_handle_response send_command_handle_response = conn->payload_decoder_factory->m.send_command_handle_response;
-	zend_uchar bits[1];
-	enum_func_status ret = FAIL;
-
-	DBG_ENTER("mysqlnd_command::shutdown");
-	int1store(bits, level);
-
-	ret = send_command(conn->payload_decoder_factory, COM_SHUTDOWN, bits, 1, FALSE,
-					   &conn->state,
-					   conn->error_info,
-					   conn->upsert_status,
-					   conn->stats,
-					   conn->m->send_close,
-					   conn);
-	if (PASS == ret) {
-		ret = send_command_handle_response(conn->payload_decoder_factory, PROT_OK_PACKET, FALSE, COM_SHUTDOWN, TRUE,
-										   conn->error_info, conn->upsert_status, &conn->last_message);
-	}
-
-	DBG_RETURN(ret);
-}
-/* }}} */
-
-
 /* {{{ mysqlnd_command::quit */
 static enum_func_status
 MYSQLND_METHOD(mysqlnd_command, quit)(MYSQLND_CONN_DATA * const conn)
@@ -680,7 +651,6 @@ MYSQLND_CLASS_METHODS_START(mysqlnd_command)
 	MYSQLND_METHOD(mysqlnd_command, statistics),
 	MYSQLND_METHOD(mysqlnd_command, process_kill),
 	MYSQLND_METHOD(mysqlnd_command, refresh),
-	MYSQLND_METHOD(mysqlnd_command, shutdown),
 	MYSQLND_METHOD(mysqlnd_command, quit),
 	MYSQLND_METHOD(mysqlnd_command, query),
 	MYSQLND_METHOD(mysqlnd_command, change_user),

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -289,7 +289,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, free_contents)(MYSQLND_CONN_DATA * conn)
 	mysqlnd_set_persistent_string(&conn->unix_socket, NULL, 0, pers);
 	DBG_INF_FMT("scheme=%s", conn->scheme.s);
 	mysqlnd_set_persistent_string(&conn->scheme, NULL, 0, pers);
-	
+
 	if (conn->server_version) {
 		mnd_pefree(conn->server_version, pers);
 		conn->server_version = NULL;
@@ -1041,17 +1041,6 @@ MYSQLND_METHOD(mysqlnd_conn_data, refresh)(MYSQLND_CONN_DATA * const conn, uint8
 	DBG_ENTER("mysqlnd_conn_data::refresh");
 	DBG_INF_FMT("conn=%" PRIu64 " options=%u", conn->thread_id, options);
 	DBG_RETURN(conn->command->refresh(conn, options));
-}
-/* }}} */
-
-
-/* {{{ mysqlnd_conn_data::shutdown */
-static enum_func_status
-MYSQLND_METHOD(mysqlnd_conn_data, shutdown)(MYSQLND_CONN_DATA * const conn, uint8_t level)
-{
-	DBG_ENTER("mysqlnd_conn_data::shutdown");
-	DBG_INF_FMT("conn=%" PRIu64 " level=%u", conn->thread_id, level);
-	DBG_RETURN(conn->command->shutdown(conn, level));
 }
 /* }}} */
 
@@ -1954,7 +1943,6 @@ MYSQLND_CLASS_METHODS_START(mysqlnd_conn_data)
 
 	MYSQLND_METHOD(mysqlnd_conn_data, stmt_init),
 
-	MYSQLND_METHOD(mysqlnd_conn_data, shutdown),
 	MYSQLND_METHOD(mysqlnd_conn_data, refresh),
 
 	MYSQLND_METHOD(mysqlnd_conn_data, ping),

--- a/ext/mysqlnd/mysqlnd_structs.h
+++ b/ext/mysqlnd/mysqlnd_structs.h
@@ -311,7 +311,6 @@ typedef enum_func_status (*func_mysqlnd_execute_com_ping)(MYSQLND_CONN_DATA * co
 typedef enum_func_status (*func_mysqlnd_execute_com_statistics)(MYSQLND_CONN_DATA * const conn, zend_string ** message);
 typedef enum_func_status (*func_mysqlnd_execute_com_process_kill)(MYSQLND_CONN_DATA * const conn, const unsigned int process_id, const bool read_response);
 typedef enum_func_status (*func_mysqlnd_execute_com_refresh)(MYSQLND_CONN_DATA * const conn, const uint8_t options);
-typedef enum_func_status (*func_mysqlnd_execute_com_shutdown)(MYSQLND_CONN_DATA * const conn, const uint8_t level);
 typedef enum_func_status (*func_mysqlnd_execute_com_quit)(MYSQLND_CONN_DATA * const conn);
 typedef enum_func_status (*func_mysqlnd_execute_com_query)(MYSQLND_CONN_DATA * const conn, MYSQLND_CSTRING query);
 typedef enum_func_status (*func_mysqlnd_execute_com_change_user)(MYSQLND_CONN_DATA * const conn, const MYSQLND_CSTRING payload, const bool silent);
@@ -335,7 +334,6 @@ MYSQLND_CLASS_METHODS_TYPE(mysqlnd_command)
 	func_mysqlnd_execute_com_statistics statistics;
 	func_mysqlnd_execute_com_process_kill process_kill;
 	func_mysqlnd_execute_com_refresh refresh;
-	func_mysqlnd_execute_com_shutdown shutdown;
 	func_mysqlnd_execute_com_quit quit;
 	func_mysqlnd_execute_com_query query;
 	func_mysqlnd_execute_com_change_user change_user;
@@ -533,7 +531,6 @@ MYSQLND_CLASS_METHODS_TYPE(mysqlnd_conn_data)
 
 	func_mysqlnd_conn_data__stmt_init stmt_init;
 
-	func_mysqlnd_conn_data__shutdown_server shutdown_server;
 	func_mysqlnd_conn_data__refresh_server refresh_server;
 
 	func_mysqlnd_conn_data__ping ping;


### PR DESCRIPTION
MySQL has deprecated and removed this command. https://dev.mysql.com/worklog/task/?id=9014
I found no information about MariaDB, but in line with MySQL I propose to remove this method. We are not using it in mysqli or PDO_MySQL. 