### PR TITLE
Tweak up SIMD-accelerated version of mb_check_encoding for more speed

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -4621,7 +4621,7 @@ static bool mb_fast_check_utf8(zend_string *str)
 
 check_operand:
 		/* If all 16 bytes are single-byte characters, then a number of checks can be skipped */
-		if (!_mm_movemask_epi8(_mm_cmplt_epi8(operand, _mm_setzero_si128()))) {
+		if (!_mm_movemask_epi8(operand)) {
 			/* Even if this block only contains single-byte characters, there may have been a
 			 * multi-byte character at the end of the previous block, which was supposed to
 			 * have continuation bytes in this block
@@ -4641,7 +4641,7 @@ check_operand:
 					goto finish_up_remaining_bytes;
 				}
 				operand = _mm_loadu_si128((__m128i*)p);
-				if (_mm_movemask_epi8(_mm_cmplt_epi8(operand, _mm_setzero_si128()))) {
+				if (_mm_movemask_epi8(operand)) {
 					break;
 				}
 			}


### PR DESCRIPTION
Today I had a look at the possibility of using AVX, AVX2, or AVX-512 instructions to further speed up `mb_fast_check_utf8`.

It turns out that I don't own any machine which supports AVX-512, so that's a non-starter. While AVX/AVX2 do include a wider variety of instructions than SSE2, it doesn't seem to me (at a first perusal) that those instructions really help much with what I need to do in `mb_fast_check_utf8`. The one thing which obviously would help is using 32-byte YMM registers instead of 16-byte XMM registers.

However, while poking around with AVX/AVX2 intrinsics, I noticed a couple places where my SSE2 code was not optimal. I was able to squeeze out a few instructions while also making the code shorter and more readable.

This boosts the function's speed (on longer strings) by 5%.

I also noticed that SSSE3 *does* include one "shuffle" instruction which is quite useful. (You can use it to do 16 table lookups in parallel from a table with 16 elements.) I tried writing an SSSE3-accelerated version of the function, and it's 12% faster than the SSE2-accelerated version.

For now, I'm just submitting the improvements to the SSE2 version.

@cmb69 @Girgias @nikic @kamil-tekiela @youkidearitai @nielsdos 