### PR TITLE
Customize the link of some constants in the manual

### DIFF
--- a/ext/ffi/ffi.stub.php
+++ b/ext/ffi/ffi.stub.php
@@ -10,6 +10,7 @@ namespace {
         /**
          * @var int
          * @cvalue __BIGGEST_ALIGNMENT__
+         * @link ffi-ffi.constants.biggest-alignment
          */
         public const __BIGGEST_ALIGNMENT__ = UNKNOWN;
 

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 63f0ea1625eca4bb8309387d1b5626c10f2d101b */
+ * Stub hash: dd91ae1826acbc9b89cd74477edf8784216f1a63 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_cdef, 0, 0, FFI, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, code, IS_STRING, 0, "\"\"")

--- a/ext/snmp/snmp.stub.php
+++ b/ext/snmp/snmp.stub.php
@@ -186,62 +186,74 @@ class SNMP
     /**
      * @var int
      * @cvalue SNMP_VERSION_1
+     * @link snmp.class.constants.version-1
      */
     public const VERSION_1 = UNKNOWN;
     /**
      * @var int
      * @cvalue SNMP_VERSION_2c
+     * @link snmp.class.constants.version-2c
      */
     public const VERSION_2c = UNKNOWN;
     /**
      * @var int
      * @cvalue SNMP_VERSION_2c
+     * @link snmp.class.constants.version-2c
      */
     public const VERSION_2C = UNKNOWN;
     /**
      * @var int
      * @cvalue SNMP_VERSION_3
+     * @link snmp.class.constants.version-3
      */
     public const VERSION_3 = UNKNOWN;
 
     /**
      * @var int
      * @cvalue PHP_SNMP_ERRNO_NOERROR
+     * @link snmp.class.constants.errno-noerror
      */
     public const ERRNO_NOERROR = UNKNOWN;
     /**
      * @var int
      * @cvalue PHP_SNMP_ERRNO_ANY
+     * @link snmp.class.constants.errno-any
      */
     public const ERRNO_ANY = UNKNOWN;
     /**
      * @var int
      * @cvalue PHP_SNMP_ERRNO_GENERIC
+     * @link snmp.class.constants.errno-generic
      */
     public const ERRNO_GENERIC = UNKNOWN;
     /**
      * @var int
      * @cvalue PHP_SNMP_ERRNO_TIMEOUT
+     * @link snmp.class.constants.errno-timeout
      */
     public const ERRNO_TIMEOUT = UNKNOWN;
     /**
      * @var int
      * @cvalue PHP_SNMP_ERRNO_ERROR_IN_REPLY
+     * @link snmp.class.constants.errno-error-in-reply
      */
     public const ERRNO_ERROR_IN_REPLY = UNKNOWN;
     /**
      * @var int
      * @cvalue PHP_SNMP_ERRNO_OID_NOT_INCREASING
+     * @link snmp.class.constants.errno-oid-not-increasing
      */
     public const ERRNO_OID_NOT_INCREASING = UNKNOWN;
     /**
      * @var int
      * @cvalue PHP_SNMP_ERRNO_OID_PARSING_ERROR
+     * @link snmp.class.constants.errno-oid-parsing-error
      */
     public const ERRNO_OID_PARSING_ERROR = UNKNOWN;
     /**
      * @var int
      * @cvalue PHP_SNMP_ERRNO_MULTIPLE_SET_QUERIES
+     * @link snmp.class.constants.errno-multiple-set-queries
      */
     public const ERRNO_MULTIPLE_SET_QUERIES = UNKNOWN;
 

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: feff81a6d260b4c1c1d3f3acd11c564a5800e1c5 */
+ * Stub hash: a79a697fa8c1ab2513bde03e0c2367d0caaec7d8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmpget, 0, 3, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)

--- a/ext/sqlite3/sqlite3.stub.php
+++ b/ext/sqlite3/sqlite3.stub.php
@@ -74,6 +74,7 @@ class SQLite3
     /**
      * @var int
      * @cvalue SQLITE_OK
+     * @link sqlite3.class.constants.ok
      */
     public const OK = UNKNOWN;
 
@@ -82,11 +83,13 @@ class SQLite3
     /**
      * @var int
      * @cvalue SQLITE_DENY
+     * @link sqlite3.class.constants.deny
      */
     public const DENY = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_IGNORE
+     * @link sqlite3.class.constants.ignore
      */
     public const IGNORE = UNKNOWN;
 
@@ -95,172 +98,206 @@ class SQLite3
     /**
      * @var int
      * @cvalue SQLITE_CREATE_INDEX
+     * @link sqlite3.class.constants.create-index
      */
     public const CREATE_INDEX = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_CREATE_TABLE
+     * @link sqlite3.class.constants.create-table
      */
     public const CREATE_TABLE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_CREATE_TEMP_INDEX
+     * @link sqlite3.class.constants.create-temp-index
      */
     public const CREATE_TEMP_INDEX = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_CREATE_TEMP_TABLE
+     * @link sqlite3.class.constants.create-temp-table
      */
     public const CREATE_TEMP_TABLE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_CREATE_TEMP_TRIGGER
+     * @link sqlite3.class.constants.create-temp-trigger
      */
     public const CREATE_TEMP_TRIGGER = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_CREATE_TEMP_VIEW
+     * @link sqlite3.class.constants.create-temp-view
      */
     public const CREATE_TEMP_VIEW = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_CREATE_TRIGGER
+     * @link sqlite3.class.constants.create-trigger
      */
     public const CREATE_TRIGGER = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_CREATE_VIEW
+     * @link sqlite3.class.constants.create-view
      */
     public const CREATE_VIEW = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DELETE
+     * @link sqlite3.class.constants.delete
      */
     public const DELETE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_INDEX
+     * @link sqlite3.class.constants.drop-index
      */
     public const DROP_INDEX = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_TABLE
+     * @link sqlite3.class.constants.drop-table
      */
     public const DROP_TABLE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_TEMP_INDEX
+     * @link sqlite3.class.constants.drop-temp-index
      */
     public const DROP_TEMP_INDEX = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_TEMP_TABLE
+     * @link sqlite3.class.constants.drop-temp-table
      */
     public const DROP_TEMP_TABLE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_TEMP_TRIGGER
+     * @link sqlite3.class.constants.drop-temp-trigger
      */
     public const DROP_TEMP_TRIGGER = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_TEMP_VIEW
+     * @link sqlite3.class.constants.drop-temp-view
      */
     public const DROP_TEMP_VIEW = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_TRIGGER
+     * @link sqlite3.class.constants.drop-trigger
      */
     public const DROP_TRIGGER = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_VIEW
+     * @link sqlite3.class.constants.drop-view
      */
     public const DROP_VIEW = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_INSERT
+     * @link sqlite3.class.constants.insert
      */
     public const INSERT = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_PRAGMA
+     * @link sqlite3.class.constants.pragma
      */
     public const PRAGMA = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_READ
+     * @link sqlite3.class.constants.read
      */
     public const READ = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_SELECT
+     * @link sqlite3.class.constants.select
      */
     public const SELECT = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_TRANSACTION
+     * @link sqlite3.class.constants.transaction
      */
     public const TRANSACTION = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_UPDATE
+     * @link sqlite3.class.constants.update
      */
     public const UPDATE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_ATTACH
+     * @link sqlite3.class.constants.attach
      */
     public const ATTACH = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DETACH
+     * @link sqlite3.class.constants.detach
      */
     public const DETACH = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_ALTER_TABLE
+     * @link sqlite3.class.constants.alter-table
      */
     public const ALTER_TABLE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_REINDEX
+     * @link sqlite3.class.constants.reindex
      */
     public const REINDEX = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_ANALYZE
+     * @link sqlite3.class.constants.analyze
      */
     public const ANALYZE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_CREATE_VTABLE
+     * @link sqlite3.class.constants.create-vtable
      */
     public const CREATE_VTABLE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_DROP_VTABLE
+     * @link sqlite3.class.constants.drop-vtable
      */
     public const DROP_VTABLE = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_FUNCTION
+     * @link sqlite3.class.constants.function
      */
     public const FUNCTION = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_SAVEPOINT
+     * @link sqlite3.class.constants.savepoint
      */
     public const SAVEPOINT = UNKNOWN;
     /**
      * @var int
      * @cvalue SQLITE_COPY
+     * @link sqlite3.class.constants.copy
      */
     public const COPY = UNKNOWN;
 #ifdef SQLITE_RECURSIVE
     /**
      * @var int
      * @cvalue SQLITE_RECURSIVE
+     * @link sqlite3.class.constants.recursive
      */
     public const RECURSIVE = UNKNOWN;
 #endif

--- a/ext/sqlite3/sqlite3_arginfo.h
+++ b/ext/sqlite3/sqlite3_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bdee592c8babbc221080c6ea2d73f94b2b79274a */
+ * Stub hash: 61f4a2611ed8cef37003610991e357b0f227bec9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SQLite3___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)

--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -496,106 +496,127 @@ class ZipArchive implements Countable
     /**
      * @var int
      * @cvalue ZIP_OPSYS_DOS
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_DOS = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_AMIGA
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_AMIGA = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_OPENVMS
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_OPENVMS = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_UNIX
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_UNIX = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_VM_CMS
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_VM_CMS = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_ATARI_ST
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_ATARI_ST = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_OS_2
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_OS_2 = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_MACINTOSH
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_MACINTOSH = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_Z_SYSTEM
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_Z_SYSTEM = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_CPM
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_CPM = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_WINDOWS_NTFS
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_WINDOWS_NTFS = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_MVS
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_MVS = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_VSE
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_VSE = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_ACORN_RISC
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_ACORN_RISC = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_VFAT
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_VFAT = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_ALTERNATE_MVS
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_ALTERNATE_MVS = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_BEOS
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_BEOS = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_TANDEM
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_TANDEM = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_OS_400
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_OS_400 = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_OS_X
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_OS_X = UNKNOWN;
     /**
      * @var int
      * @cvalue ZIP_OPSYS_DEFAULT
+     * @link ziparchive.constants.opsys
      */
     public const OPSYS_DEFAULT = UNKNOWN;
 #endif

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d8c14dfe45c7eff2c18fd3c562488a827f658e12 */
+ * Stub hash: 69d4e8a343f237a7192728c805fb3a98bb04ca38 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)


### PR DESCRIPTION
These changes are necessary because the links which are generated by default are already taken. Related to https://github.com/php/doc-en/pull/2147