### PR TITLE
Fix UNEXPECTED() paren mistakes.

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4723,7 +4723,7 @@ ZEND_API zend_result zend_update_static_property_ex(zend_class_entry *scope, zen
 	zend_class_entry *old_scope = EG(fake_scope);
 
 	if (UNEXPECTED(!(scope->ce_flags & ZEND_ACC_CONSTANTS_UPDATED))) {
-		if (UNEXPECTED(zend_update_class_constants(scope)) != SUCCESS) {
+		if (UNEXPECTED(zend_update_class_constants(scope) != SUCCESS)) {
 			return FAILURE;
 		}
 	}

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1541,7 +1541,7 @@ undeclared_property:
 	}
 
 	if (UNEXPECTED(!(ce->ce_flags & ZEND_ACC_CONSTANTS_UPDATED))) {
-		if (UNEXPECTED(zend_update_class_constants(ce)) != SUCCESS) {
+		if (UNEXPECTED(zend_update_class_constants(ce) != SUCCESS)) {
 			return NULL;
 		}
 	}


### PR DESCRIPTION
This corrects the paren placement to the intended one. As these functions use zend_result, the success value is zero. Therefore this has no functional change. The only difference is that this now hints the compiler optimizer correctly.

As this does not fix a bug (can only improve performance), I targeted master.

I found these by grepping for more of cases like #10332.