### PR TITLE
Remove unused php_stream_tell() result

### DIFF
--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -428,7 +428,6 @@ foundit:
 				PHAR_ZIP_FAIL("signatures larger than 64 KiB are not supported");
 			}
 
-			php_stream_tell(fp);
 			sigfile = php_stream_fopen_tmpfile();
 			if (!sigfile) {
 				PHAR_ZIP_FAIL("couldn't open temporary file");


### PR DESCRIPTION
Note: I found this using a static analysis pass that looks for unused results in code. I manually verified this.