### PR TITLE
Fix incorrect UNEXPECTED paren placement in zend_gc.c

### DIFF
--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -591,7 +591,7 @@ static zend_never_inline void ZEND_FASTCALL gc_possible_root_when_full(zend_refc
 	if (GC_G(gc_enabled) && !GC_G(gc_active)) {
 		GC_ADDREF(ref);
 		gc_adjust_threshold(gc_collect_cycles());
-		if (UNEXPECTED(GC_DELREF(ref)) == 0) {
+		if (UNEXPECTED(GC_DELREF(ref) == 0)) {
 			rc_dtor_func(ref);
 			return;
 		} else if (UNEXPECTED(GC_INFO(ref))) {


### PR DESCRIPTION
Follow-up for #10364.
Credits to @TimWolla for this one :)