### PR TITLE
Tweak SSE2-accelerated strtoupper() and strtolower() for speed

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -60,8 +60,8 @@ static _locale_t current_locale = NULL;
 /* Common code for SSE2 accelerated character case conversion */
 
 #define BLOCKCONV_INIT_RANGE(start, end) \
-	const __m128i blconv_start_minus_1 = _mm_set1_epi8((start) - 1); \
-	const __m128i blconv_end_plus_1 = _mm_set1_epi8((end) + 1);
+	const __m128i blconv_offset = _mm_set1_epi8((signed char)(CHAR_MIN - start)); \
+	const __m128i blconv_threshold = _mm_set1_epi8(CHAR_MIN + (end - start) + 1);
 
 #define BLOCKCONV_STRIDE sizeof(__m128i)
 
@@ -70,14 +70,12 @@ static _locale_t current_locale = NULL;
 
 #define BLOCKCONV_LOAD(input) \
 	__m128i blconv_operand = _mm_loadu_si128((__m128i*)(input)); \
-	__m128i blconv_gt = _mm_cmpgt_epi8(blconv_operand, blconv_start_minus_1); \
-	__m128i blconv_lt = _mm_cmplt_epi8(blconv_operand, blconv_end_plus_1); \
-	__m128i blconv_mingle = _mm_and_si128(blconv_gt, blconv_lt);
+	__m128i blconv_mask = _mm_cmplt_epi8(_mm_add_epi8(blconv_operand, blconv_offset), blconv_threshold);
 
-#define BLOCKCONV_FOUND() _mm_movemask_epi8(blconv_mingle)
+#define BLOCKCONV_FOUND() _mm_movemask_epi8(blconv_mask)
 
 #define BLOCKCONV_STORE(dest) \
-	__m128i blconv_add = _mm_and_si128(blconv_mingle, blconv_delta); \
+	__m128i blconv_add = _mm_and_si128(blconv_mask, blconv_delta); \
 	__m128i blconv_result = _mm_add_epi8(blconv_operand, blconv_add); \
 	_mm_storeu_si128((__m128i *)(dest), blconv_result);
 

--- a/ext/standard/tests/strings/strtolower.phpt
+++ b/ext/standard/tests/strings/strtolower.phpt
@@ -30,6 +30,7 @@ $strings = array (
   "ZZZZZZZZZZZZZZZZZZZZ",
   "@@@@@@@@@@@@@@@@@@@@",
   "[[[[[[[[[[[[[[[[[[[[",
+  "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 );
 
 $count = 0;
@@ -346,6 +347,9 @@ string(20) "@@@@@@@@@@@@@@@@@@@@"
 
 -- Iteration 11 --
 string(20) "[[[[[[[[[[[[[[[[[[[["
+
+-- Iteration 12 --
+string(62) "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz"
 
 *** Testing strtolower() with two different case strings ***
 strings are same, with Case Insensitive

--- a/ext/standard/tests/strings/strtoupper1.phpt
+++ b/ext/standard/tests/strings/strtoupper1.phpt
@@ -28,6 +28,7 @@ $strings = array (
   "zzzzzzzzzzzzzzzzzzzz",
   "````````````````````",
   "{{{{{{{{{{{{{{{{{{{{",
+  "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 );
 
 $count = 0;
@@ -345,6 +346,9 @@ string(20) "````````````````````"
 
 -- Iteration 11 --
 string(20) "{{{{{{{{{{{{{{{{{{{{"
+
+-- Iteration 12 --
+string(62) "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 *** Testing strtoupper() with two different case strings ***
 strings are same, with Case Insensitive


### PR DESCRIPTION
I learned this trick for doing a faster bounds check with both upper and lower bounds by reading a disassembler listing of optimized code produced by GCC; instead of doing 2 compares to check the upper and the lower bound, add an immediate value to shift the range you are testing for to the far low or high end of the range of possible values for the type in question, and then a single compare will do. Intstead of compare + compare + AND, you just do ADD + compare.

From microbenchmarking on my development PC, this makes strtoupper() about 10% faster on long strings (~10,000 bytes).

@cmb69 @Girgias @nielsdos 