### PR TITLE
AC_PROG_CC_C99 is obsolete with autoconf >= 2.70

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,9 @@ PKG_PROG_PKG_CONFIG
 AC_PROG_CC([cc gcc])
 PHP_DETECT_ICC
 PHP_DETECT_SUNCC
-AC_PROG_CC_C99
+
+dnl AC_PROG_CC_C99 is obsolete with autoconf >= 2.70 yet necessary for <= 2.69.
+m4_version_prereq([2.70],,[AC_PROG_CC_C99])
 AC_PROG_CPP
 AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_LN_S


### PR DESCRIPTION
Fixes part of #9483

To make sure that compiler supports C99 before Autoconf 2.69, this was needed. But with Autoconf 2.70 and later the macro is obsolete because the checks are done in AC_PROG_CC and warnings are emitted when building configure script.

I'm not sure whether we should target PHP 8.1 here or is master fine though? Basically, the obsolete warnings when creating configure script won't cause compilation issues on the older PHP versions.