### PR TITLE
Handle non-INDIRECT symbol table entries in zend_fiber_object_gc()

### DIFF
--- a/Zend/tests/fibers/gh10340-001.phpt
+++ b/Zend/tests/fibers/gh10340-001.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug GH-10340 001 (Assertion in zend_fiber_object_gc())
+--FILE--
+<?php
+function f() {
+    $$y = Fiber::getCurrent();
+    Fiber::suspend();
+}
+$fiber = new Fiber(function() {
+    get_defined_vars();
+    f();
+});
+$fiber->start();
+gc_collect_cycles();
+?>
+==DONE==
+--EXPECTF--
+Warning: Undefined variable $y in %s on line %d
+==DONE==

--- a/Zend/tests/fibers/gh10340-002.phpt
+++ b/Zend/tests/fibers/gh10340-002.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Bug GH-10340 002 (Assertion in zend_fiber_object_gc())
+--FILE--
+<?php
+function f() {
+    $y = 'a';
+    $$y = Fiber::getCurrent();
+    Fiber::suspend();
+}
+$fiber = new Fiber(function() {
+    get_defined_vars();
+    f();
+});
+$fiber->start();
+gc_collect_cycles();
+?>
+==DONE==
+--EXPECT--
+==DONE==

--- a/Zend/tests/fibers/gh10340-003.phpt
+++ b/Zend/tests/fibers/gh10340-003.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Bug GH-10340 003 (Assertion in zend_fiber_object_gc())
+--FILE--
+<?php
+
+class C {
+    public function __destruct() {
+        echo __METHOD__, "\n";
+    }
+}
+
+function f() {
+    $c = new C();
+    $y = 'a';
+    $$y = Fiber::getCurrent();
+    Fiber::suspend();
+}
+
+$fiber = new Fiber(function() {
+    get_defined_vars();
+    f();
+});
+
+$fiber->start();
+
+print "1\n";
+
+$fiber = null;
+gc_collect_cycles();
+
+print "2\n";
+?>
+==DONE==
+--EXPECT--
+1
+C::__destruct
+2
+==DONE==

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -656,8 +656,10 @@ static HashTable *zend_fiber_object_gc(zend_object *object, zval **table, int *n
 			if (lastSymTable) {
 				zval *val;
 				ZEND_HASH_FOREACH_VAL(lastSymTable, val) {
-					ZEND_ASSERT(Z_TYPE_P(val) == IS_INDIRECT);
-					zend_get_gc_buffer_add_zval(buf, Z_INDIRECT_P(val));
+					if (EXPECTED(Z_TYPE_P(val) == IS_INDIRECT)) {
+						val = Z_INDIRECT_P(val);
+					}
+					zend_get_gc_buffer_add_zval(buf, val);
 				} ZEND_HASH_FOREACH_END();
 			}
 			lastSymTable = symTable;


### PR DESCRIPTION
Fixes #10340 