### PR TITLE
random: Do not trust arc4random_buf() on glibc

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ PHP                                                                        NEWS
 - GMP:
   . Properly implement GMP::__construct(). (nielsdos)
 
+- Random:
+  . Fix GH-10390 (Do not trust arc4random_buf() on glibc). (timwolla)
+
 - Standard:
   - Fixed bug GH-8086 (Introduce mail.mixed_lf_and_crlf INI). (Jakub Zelenka)
 

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -505,7 +505,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 		}
 		return FAILURE;
 	}
-#elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405) || (defined(__NetBSD__) && __NetBSD_Version__ >= 700000001) || defined(__APPLE__) || defined(__GLIBC__))
+#elif HAVE_DECL_ARC4RANDOM_BUF && ((defined(__OpenBSD__) && OpenBSD >= 201405) || (defined(__NetBSD__) && __NetBSD_Version__ >= 700000001) || defined(__APPLE__))
 	arc4random_buf(bytes, size);
 #else
 	size_t read_bytes = 0;


### PR DESCRIPTION
Targeting PHP-8.2, because the the original PR was landed in PHP-8.2 and it does not appear to be useful to allow this for the entirety of 8.2 only, but no other branch.

/cc @crrodriguez 

-------------

This effectively reverts #8984.

As discussed in #10327 which will enable the use of the getrandom(2) syscall on NetBSD instead of relying on the userland arc4random_buf(), the CSPRNG should prioritize security over speed [1] and history has shown that userland implementations unavoidably fall short on the security side. In fact the glibc implementation is a thin wrapper around the syscall due to security concerns and thus does not provide any benefit over just calling getrandom(2) ourselves.

Even without any performance optimizations the CSPRNG should be plenty fast for the vast majority of applications, because they often only need a few bytes of randomness to generate a session ID. If speed is desired, the OO API offers faster, but non-cryptographically secure engines.

