### PR TITLE
random: Remove check for HAVE_DEV_URANDOM

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -35,6 +35,12 @@ PHP 8.3 INTERNALS UPGRADE NOTES
 2. Build system changes
 ========================
 
+* Removed the HAVE_DEV_URANDOM compile time check.  HAVE_DEV_URANDOM will
+  now never be defined. Any checks relying on HAVE_DEV_URANDOM should be
+  removed.  Even with HAVE_DEV_URANDOM it was not guaranteed that
+  /dev/urandom is actually available at run time and thus a runtime
+  check needs to happen in all cases.
+
 ========================
 3. Module changes
 ========================

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -304,14 +304,6 @@ AC_MSG_RESULT($ZEND_SIGNALS)
 
 ])
 
-AC_MSG_CHECKING(whether /dev/urandom exists)
-if test -r "/dev/urandom" && test -c "/dev/urandom"; then
-  AC_DEFINE([HAVE_DEV_URANDOM], 1, [Define if the target system has /dev/urandom device])
-  AC_MSG_RESULT(yes)
-else
-  AC_MSG_RESULT(no)
-fi
-
 AC_ARG_ENABLE([gcc-global-regs],
   [AS_HELP_STRING([--disable-gcc-global-regs],
     [whether to enable GCC global register variables])],

--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -557,9 +557,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 
 		if (fd < 0) {
 			errno = 0;
-# if HAVE_DEV_URANDOM
 			fd = open("/dev/urandom", O_RDONLY);
-# endif
 			if (fd < 0) {
 				if (should_throw) {
 					if (errno != 0) {


### PR DESCRIPTION
It cannot be decided whether the device is available at build time, PHP might
run in a container or chroot that does not expose the device. Simply attempt to
open it, if it does not exist it will fail.

This improves readability of php_random_bytes() by removing one layer of
preprocessor conditions.