### PR TITLE
random: Simplify control flow for handling /dev/urandom errors

### DIFF
--- a/ext/random/random.c
+++ b/ext/random/random.c
@@ -596,20 +596,17 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 		for (read_bytes = 0; read_bytes < size; read_bytes += (size_t) n) {
 			errno = 0;
 			n = read(fd, bytes + read_bytes, size - read_bytes);
-			if (n <= 0) {
-				break;
-			}
-		}
 
-		if (read_bytes < size) {
-			if (should_throw) {
-				if (errno != 0) {
-					zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Could not gather sufficient random data: %s", strerror(errno));
-				} else {
-					zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Could not gather sufficient random data");
+			if (n <= 0) {
+				if (should_throw) {
+					if (errno != 0) {
+						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Could not gather sufficient random data: %s", strerror(errno));
+					} else {
+						zend_throw_exception_ex(random_ce_Random_RandomException, 0, "Could not gather sufficient random data");
+					}
 				}
+				return FAILURE;
 			}
-			return FAILURE;
 		}
 	}
 #endif


### PR DESCRIPTION
Review recommended with whitespace changes ignored.

----------

The only way the previous `if (read_bytes < size)` branch could be taken is when the loop was exited by the `break;` statement. We can just merge this into the loop to make the code more obvious.