### PR TITLE
session: Remove PS_EXTRA_RAND_BYTES

### DIFF
--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -306,17 +306,14 @@ static void bin_to_readable(unsigned char *in, size_t inlen, char *out, size_t o
 }
 /* }}} */
 
-#define PS_EXTRA_RAND_BYTES 60
-
 PHPAPI zend_string *php_session_create_id(PS_CREATE_SID_ARGS) /* {{{ */
 {
-	unsigned char rbuf[PS_MAX_SID_LENGTH + PS_EXTRA_RAND_BYTES];
+	unsigned char rbuf[PS_MAX_SID_LENGTH];
 	zend_string *outid;
 
 	/* It would be enough to read ceil(sid_length * sid_bits_per_character / 8) bytes here.
 	 * We read sid_length bytes instead for simplicity. */
-	/* Read additional PS_EXTRA_RAND_BYTES just in case CSPRNG is not safe enough */
-	if (php_random_bytes_throw(rbuf, PS(sid_length) + PS_EXTRA_RAND_BYTES) == FAILURE) {
+	if (php_random_bytes_throw(rbuf, PS(sid_length)) == FAILURE) {
 		return NULL;
 	}
 


### PR DESCRIPTION
This was introduced in 3467526a65bfb15eaf9ec49a0b5673b84e26bca4 and the corresponding RFC gives some reasoning. However the CSPRNG being “not secure enough” is not a thing and reading these extra bytes is just security theater:

If the CSPRNG would hypothetically be broken, then PHP’s session IDs are the least of one’s concerns, because we already trust it in `random_bytes()` and might generate long-term secrets using that.