### PR TITLE
.github/workflows/push.yml: enable ccache

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,6 +20,9 @@ on:
       - '**'
 permissions:
   contents: read
+env:
+  CC: ccache gcc
+  CXX: ccache g++
 jobs:
   LINUX_X64:
     strategy:
@@ -41,6 +44,13 @@ jobs:
         uses: ./.github/actions/setup-oracle
       - name: apt
         uses: ./.github/actions/apt-x64
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          # This duplicates the "job.name" expression above because
+          # GitHub has no way to query the job name (github.job is the
+          # job id, not the job name)
+          key: "LINUX_X64_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}-${{hashFiles('main/php_version.h')}}"
       - name: ./configure
         uses: ./.github/actions/configure-x64
         with:
@@ -89,6 +99,10 @@ jobs:
         uses: actions/checkout@v3
       - name: apt
         uses: ./.github/actions/apt-x32
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "${{github.job}}-${{hashFiles('main/php_version.h')}}"
       - name: ./configure
         uses: ./.github/actions/configure-x32
         with:
@@ -115,6 +129,10 @@ jobs:
         uses: actions/checkout@v3
       - name: brew
         uses: ./.github/actions/brew
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "${{github.job}}-${{hashFiles('main/php_version.h')}}"
       - name: ./configure
         uses: ./.github/actions/configure-macos
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -285,6 +285,7 @@ tmp-php.ini
 # ------------------------------------------------------------------------------
 /branch-commit-cache.json
 /junit.out.xml
+/.ccache/
 
 # ------------------------------------------------------------------------------
 # Special cases to invert previous ignore patterns


### PR DESCRIPTION
This reduces the LINUX_X64_RELEASE_ZTS build time from 9-10 minutes to less than 3 minutes.