### PR TITLE
Test anonymous class in trait must be declared only once

### DIFF
--- a/Zend/tests/anon/017.phpt
+++ b/Zend/tests/anon/017.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Anonymous class in trait must be declared only once
+--FILE--
+<?php
+
+trait TraitWithAnonymousClass
+{
+    public function foo(): object
+    {
+        return new class() {};
+    }
+}
+
+$c = count(get_declared_classes());
+
+if (time() > 0) {
+    class A { use TraitWithAnonymousClass; }
+    var_dump(count(get_declared_classes()) - $c);
+    
+    $o = new A();
+    var_dump(count(get_declared_classes()) - $c);
+    
+    $o->foo();
+    var_dump(count(get_declared_classes()) - $c);
+}
+
+eval('class B { use TraitWithAnonymousClass; }');
+var_dump(count(get_declared_classes()) - $c);
+
+$o = new B();
+var_dump(count(get_declared_classes()) - $c);
+
+$o->foo();
+var_dump(count(get_declared_classes()) - $c);
+
+?>
+--EXPECT--
+int(1)
+int(1)
+int(1)
+int(2)
+int(2)
+int(2)

--- a/Zend/tests/static_variables_parent_trait_method.phpt
+++ b/Zend/tests/static_variables_parent_trait_method.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Behavior of static variables in parent trait method
+--FILE--
+<?php
+
+trait T {
+    public function foo()
+    {
+        var_dump(__CLASS__);
+
+        static $v = null;
+        if ($v === null) {
+            $v = random_bytes(64);
+        }
+        
+        return $v;
+    }
+}
+
+class A { use T; }
+class B extends A {}
+class C extends A { use T; }
+class D { use T; }
+
+$a = (new A())->foo();
+var_dump($a === (new A())->foo());
+var_dump($a === (new B())->foo());
+$c = new C();
+var_dump($a === $c->foo());
+var_dump($a === (new \ReflectionMethod(A::class, 'foo'))->invoke($c));
+var_dump($a === (new D())->foo());
+
+?>
+--EXPECT--
+string(1) "A"
+string(1) "A"
+bool(true)
+string(1) "A"
+bool(true)
+string(1) "C"
+bool(false)
+string(1) "A"
+bool(true)
+string(1) "D"
+bool(false)


### PR DESCRIPTION
There is no single "anonymous class in trait" test - I searched whole php-src with regex: `trait(\s|\S)*new class`.

This test asserts the anonymous class in the trait is declared only once even if the trait is used in multiple classes.

Also test static variable in parent/redeclared trait method - related with https://github.com/php/php-src/pull/6719