### PR TITLE
Fix missing zend_shared_alloc_unlock()

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4785,6 +4785,7 @@ static int accel_finish_startup(void)
 	}
 
 	if (pid == -1) { /* no subprocess was needed */
+		/* The called function unlocks the shared alloc lock */
 		return accel_finish_startup_preload(false);
 	} else if (pid == 0) { /* subprocess */
 		int ret = accel_finish_startup_preload(true);
@@ -4801,6 +4802,8 @@ static int accel_finish_startup(void)
 		if (ZCSG(preload_script)) {
 			preload_load();
 		}
+
+		zend_shared_alloc_unlock();
 
 		if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
 			return SUCCESS;


### PR DESCRIPTION
This code was refactored and the unlock was forgotten. The following assertion is triggered in debug mode:
  zend_shared_alloc_lock: Assertion `!(accel_globals.locked)' failed.
And in release mode this likely deadlocks.
Fix this by re-adding the unlock.