### PR TITLE
include cleanup part 6

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -22,6 +22,7 @@
 #include "Optimizer/zend_optimizer.h"
 #include "Optimizer/zend_optimizer_internal.h"
 #include "zend_API.h"
+#include "zend_arena.h"
 #include "zend_constants.h"
 #include "zend_execute.h"
 #include "zend_vm.h"

--- a/Zend/Optimizer/compact_literals.c
+++ b/Zend/Optimizer/compact_literals.c
@@ -23,6 +23,7 @@
 
 #include "Optimizer/zend_optimizer.h"
 #include "Optimizer/zend_optimizer_internal.h"
+#include "zend_arena.h"
 #include "zend_API.h"
 #include "zend_constants.h"
 #include "zend_execute.h"

--- a/Zend/Optimizer/dce.c
+++ b/Zend/Optimizer/dce.c
@@ -22,6 +22,7 @@
 #include "Optimizer/zend_ssa.h"
 #include "Optimizer/zend_func_info.h"
 #include "Optimizer/zend_call_graph.h"
+#include "zend_arena.h"
 #include "zend_bitset.h"
 
 /* This pass implements a form of dead code elimination (DCE). The algorithm optimistically assumes

--- a/Zend/Optimizer/dfa_pass.c
+++ b/Zend/Optimizer/dfa_pass.c
@@ -19,6 +19,7 @@
 #include "Optimizer/zend_optimizer.h"
 #include "Optimizer/zend_optimizer_internal.h"
 #include "zend_API.h"
+#include "zend_arena.h"
 #include "zend_constants.h"
 #include "zend_execute.h"
 #include "zend_vm.h"

--- a/Zend/Optimizer/optimize_temp_vars_5.c
+++ b/Zend/Optimizer/optimize_temp_vars_5.c
@@ -21,6 +21,7 @@
 
 #include "Optimizer/zend_optimizer.h"
 #include "Optimizer/zend_optimizer_internal.h"
+#include "zend_arena.h"
 #include "zend_API.h"
 #include "zend_constants.h"
 #include "zend_execute.h"

--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -18,8 +18,11 @@
 */
 
 #include "zend_API.h"
+#include "zend_arena.h"
+#include "zend_multiply.h"
 #include "zend_exceptions.h"
 #include "zend_ini.h"
+#include "zend_optimizer.h"
 #include "zend_type_info.h"
 #include "Optimizer/zend_optimizer_internal.h"
 #include "Optimizer/zend_call_graph.h"

--- a/Zend/zend_build.h
+++ b/Zend/zend_build.h
@@ -19,6 +19,12 @@
 #ifndef ZEND_BUILD_H
 #define ZEND_BUILD_H
 
+#ifdef PHP_WIN32
+#include "config.w32.h"
+#else
+#include "zend_config.h"
+#endif
+
 #define ZEND_TOSTR_(x) #x
 #define ZEND_TOSTR(x) ZEND_TOSTR_(x)
 

--- a/Zend/zend_globals_macros.h
+++ b/Zend/zend_globals_macros.h
@@ -20,6 +20,12 @@
 #ifndef ZEND_GLOBALS_MACROS_H
 #define ZEND_GLOBALS_MACROS_H
 
+#include "zend_portability.h"
+
+#ifdef ZTS
+# include "TSRM.h"
+#endif
+
 typedef struct _zend_compiler_globals zend_compiler_globals;
 typedef struct _zend_executor_globals zend_executor_globals;
 typedef struct _zend_php_scanner_globals zend_php_scanner_globals;

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -18,6 +18,7 @@
 */
 
 #include "zend.h"
+#include "zend_arena.h"
 #include "zend_API.h"
 #include "zend_compile.h"
 #include "zend_execute.h"

--- a/Zend/zend_iterators.h
+++ b/Zend/zend_iterators.h
@@ -17,6 +17,9 @@
    +----------------------------------------------------------------------+
 */
 
+#ifndef ZEND_ITERATORS_H
+#define ZEND_ITERATORS_H
+
 /* These iterators were designed to operate within the foreach()
  * structures provided by the engine, but could be extended for use
  * with other iterative engine opcodes.
@@ -89,3 +92,5 @@ ZEND_API void zend_iterator_dtor(zend_object_iterator *iter);
 
 ZEND_API void zend_register_iterator_wrapper(void);
 END_EXTERN_C()
+
+#endif /* ZEND_ITERATORS_H */

--- a/Zend/zend_long.h
+++ b/Zend/zend_long.h
@@ -19,6 +19,12 @@
 #ifndef ZEND_LONG_H
 #define ZEND_LONG_H
 
+#ifdef PHP_WIN32
+#include "config.w32.h"
+#else
+#include "zend_config.h"
+#endif
+
 #include <inttypes.h>
 #include <stdint.h>
 

--- a/Zend/zend_multiply.h
+++ b/Zend/zend_multiply.h
@@ -17,10 +17,14 @@
    +----------------------------------------------------------------------+
 */
 
-#include "zend_portability.h"
-
 #ifndef ZEND_MULTIPLY_H
 #define ZEND_MULTIPLY_H
+
+#include "zend_long.h"
+#include "zend_portability.h"
+#include "zend.h"
+
+#include <stdbool.h>
 
 #if PHP_HAVE_BUILTIN_SMULL_OVERFLOW && SIZEOF_LONG == SIZEOF_ZEND_LONG
 

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -21,6 +21,12 @@
 #ifndef ZEND_PORTABILITY_H
 #define ZEND_PORTABILITY_H
 
+#ifdef PHP_WIN32
+#include "config.w32.h"
+#else
+#include "zend_config.h"
+#endif
+
 #ifdef __cplusplus
 #define BEGIN_EXTERN_C() extern "C" {
 #define END_EXTERN_C() }

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -28,6 +28,7 @@
 #include "zend_refcounted.h"
 #include "zend_result.h"
 #include "zend_type_code.h"
+#include "zend_type_info.h"
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -50,6 +50,7 @@
 
 #include "zend_extensions.h"
 #include "zend_compile.h"
+#include "zend_modules.h"
 
 #include "Optimizer/zend_optimizer.h"
 #include "zend_accelerator_hash.h"

--- a/ext/opcache/shared_alloc_mmap.c
+++ b/ext/opcache/shared_alloc_mmap.c
@@ -23,6 +23,10 @@
 
 #ifdef USE_MMAP
 
+#if defined(__linux__)
+# include "ZendAccelerator.h"
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdio.h>
@@ -36,6 +40,10 @@
 #include "zend_execute.h"
 #ifdef HAVE_SYS_PROCCTL_H
 #include <sys/procctl.h>
+#endif
+
+#if defined(__FreeBSD__) || (defined(HAVE_PROCCTL) && defined(PROC_WXMAP_CTL))
+# include <unistd.h>
 #endif
 
 #if defined(MAP_ANON) && !defined(MAP_ANONYMOUS)

--- a/ext/opcache/shared_alloc_win32.c
+++ b/ext/opcache/shared_alloc_win32.c
@@ -23,6 +23,7 @@
 #include "ZendAccelerator.h"
 #include "zend_shared_alloc.h"
 #include "zend_accelerator_util_funcs.h"
+#include "zend_accelerator_debug.h"
 #include "zend_execute.h"
 #include "zend_system_id.h"
 #include "SAPI.h"

--- a/ext/opcache/zend_accelerator_hash.c
+++ b/ext/opcache/zend_accelerator_hash.c
@@ -21,8 +21,10 @@
 
 #include "ZendAccelerator.h"
 #include "zend_accelerator_hash.h"
-#include "zend_hash.h"
+#include "zend_accelerator_debug.h"
 #include "zend_shared_alloc.h"
+#include "ZendAccelerator.h"
+#include "Zend/zend_string.h"
 
 /* Generated on an Octa-ALPHA 300MHz CPU & 2.5GB RAM monster */
 static const uint32_t prime_numbers[] =

--- a/main/main.c
+++ b/main/main.c
@@ -83,6 +83,8 @@
 #include "rfc1867.h"
 
 #include "ext/standard/html_tables.h"
+
+#include <float.h>
 #include "main_arginfo.h"
 /* }}} */
 

--- a/main/php.h
+++ b/main/php.h
@@ -441,4 +441,19 @@ typedef bool zend_bool;
 typedef intptr_t zend_intptr_t;
 typedef uintptr_t zend_uintptr_t;
 
+/* the following headers used to be included indirectly, and we have
+ * them here only for backwards compatibility with thirdparty
+ * extensions */
+#include "php_globals.h"
+#include "php_ini.h"
+#include "zend_alloc.h"
+#include "zend_arena.h"
+#include "zend_iterators.h"
+#include "zend_multiply.h"
+#include "zend_objects.h"
+#include "zend_strtod.h"
+#include <errno.h>
+#include <float.h>
+#include <string.h>
+
 #endif

--- a/main/php_globals.h
+++ b/main/php_globals.h
@@ -17,6 +17,7 @@
 #ifndef PHP_GLOBALS_H
 #define PHP_GLOBALS_H
 
+#include "php.h"
 #include "zend_globals.h"
 
 #include <stdint.h>

--- a/main/streams/plain_wrapper.c
+++ b/main/streams/plain_wrapper.c
@@ -42,6 +42,9 @@
 # include "win32/readdir.h"
 #endif
 
+#include <errno.h>
+#include <string.h>
+
 #define php_stream_fopen_from_fd_int(fd, mode, persistent_id)	_php_stream_fopen_from_fd_int((fd), (mode), (persistent_id) STREAMS_CC)
 #define php_stream_fopen_from_fd_int_rel(fd, mode, persistent_id)	 _php_stream_fopen_from_fd_int((fd), (mode), (persistent_id) STREAMS_REL_CC)
 #define php_stream_fopen_from_file_int(file, mode)	_php_stream_fopen_from_file_int((file), (mode) STREAMS_CC)

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -32,6 +32,9 @@
 #include <fcntl.h>
 #include "php_streams_int.h"
 
+#include <errno.h>
+#include <string.h>
+
 /* {{{ resource and registration code */
 /* Global wrapper hash, copied to FG(stream_wrappers) on registration of volatile wrapper */
 static HashTable url_stream_wrappers_hash;

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -25,7 +25,10 @@
 
 #ifdef AF_UNIX
 #include <sys/un.h>
+#include <string.h>
 #endif
+
+#include <errno.h>
 
 #ifndef MSG_DONTWAIT
 # define MSG_DONTWAIT 0

--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -95,6 +95,8 @@ int __riscosify_control = __RISCOSIFY_STRICT_UNIX_SPECS;
 # include "valgrind/callgrind.h"
 #endif
 
+#include <errno.h>
+
 #ifndef PHP_WIN32
 /* XXX this will need to change later when threaded fastcgi is implemented.  shane */
 struct sigaction act, old_term, old_quit, old_int;

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -92,6 +92,8 @@
 # include "openssl/applink.c"
 #endif
 
+#include <errno.h>
+
 PHPAPI extern char *php_ini_opened_path;
 PHPAPI extern char *php_ini_scanned_path;
 PHPAPI extern char *php_ini_scanned_files;

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -106,6 +106,9 @@
 #include "php_cli_process_title.h"
 #include "php_cli_process_title_arginfo.h"
 
+#include <errno.h>
+#include <string.h>
+
 #define OUTPUT_NOT_CHECKED -1
 #define OUTPUT_IS_TTY 1
 #define OUTPUT_NOT_TTY 0

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -94,6 +94,9 @@ int __riscosify_control = __RISCOSIFY_STRICT_UNIX_SPECS;
 #include "fpm_log.h"
 #include "zlog.h"
 
+#include <errno.h>
+#include <string.h>
+
 /* XXX this will need to change later when threaded fastcgi is implemented.  shane */
 struct sigaction act, old_term, old_quit, old_int;
 

--- a/sapi/phpdbg/phpdbg_io.c
+++ b/sapi/phpdbg/phpdbg_io.c
@@ -20,6 +20,8 @@
 
 #include "phpdbg_io.h"
 
+#include <errno.h>
+
 ZEND_EXTERN_MODULE_GLOBALS(phpdbg)
 
 /* is easy to generalize ... but not needed for now */


### PR DESCRIPTION
As suggested on php-internals, this PR contains parts of https://github.com/php/php-src/pull/10345 that are not so controversial, because they mostly add missing things, but do not remove anything just yet.

One new commit adds compatibility `#includes` to `main/php.h`, because people on php-internals have suggested that source compatibility with third-party extensions should be retained, even if those extensions are buggy (e.g. forgetting to include `errno.h` even though they use `errno`). Much of that commit addresses issues that will arise once more includes are cleaned up; it makes those header dependencies explicit, instead of making them accidental and implicit.