### PR TITLE
Fix incorrect check in zend_internal_call_should_throw()

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1210,7 +1210,7 @@ static zend_never_inline ZEND_ATTRIBUTE_UNUSED bool zend_verify_internal_arg_typ
  * trust that arginfo matches what is enforced by zend_parse_parameters. */
 ZEND_API bool zend_internal_call_should_throw(zend_function *fbc, zend_execute_data *call)
 {
-	if (fbc->internal_function.handler == ZEND_FN(pass) || (fbc->internal_function.fn_flags | ZEND_ACC_FAKE_CLOSURE)) {
+	if (fbc->internal_function.handler == ZEND_FN(pass) || (fbc->internal_function.fn_flags & ZEND_ACC_FAKE_CLOSURE)) {
 		/* Be lenient about the special pass function and about fake closures. */
 		return 0;
 	}


### PR DESCRIPTION
This debug code is part of arginfo validation. This validation will never trigger properly because the OR operation makes the first if always true. Fix it by changing to an AND.

Found using a static analyser.