### PR TITLE
ext/mysqli: Throw error when mysql_stmt_data_seek cannot be executed

### DIFF
--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1488,10 +1488,12 @@ PHP_FUNCTION(mysqli_stmt_data_seek)
 
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
-	if (mysql_stmt_data_seek(stmt->stmt, offset)) {
-		zend_throw_error(NULL, "The result set buffer is empty");
+	if (!stmt->stmt->data || !stmt->stmt->data->result || !stmt->stmt->data->result->stored_data) {
+		zend_throw_error(NULL, "No result set associated with the statement");
 		RETURN_THROWS();
 	}
+
+	mysql_stmt_data_seek(stmt->stmt, offset);
 }
 /* }}} */
 

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1488,7 +1488,10 @@ PHP_FUNCTION(mysqli_stmt_data_seek)
 
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
-	mysql_stmt_data_seek(stmt->stmt, offset);
+	if (mysql_stmt_data_seek(stmt->stmt, offset)) {
+		zend_throw_error(NULL, "The result set buffer is empty");
+		RETURN_THROWS();
+	}
 }
 /* }}} */
 

--- a/ext/mysqli/mysqli_api.c
+++ b/ext/mysqli/mysqli_api.c
@@ -1489,7 +1489,11 @@ PHP_FUNCTION(mysqli_stmt_data_seek)
 	MYSQLI_FETCH_RESOURCE_STMT(stmt, mysql_stmt, MYSQLI_STATUS_VALID);
 
 	if (!stmt->stmt->data || !stmt->stmt->data->result || !stmt->stmt->data->result->stored_data) {
-		zend_throw_error(NULL, "No result set associated with the statement");
+		if (hasThis()) {
+			zend_throw_error(NULL, "mysqli_stmt::data_seek(): No result set associated with the statement");
+		} else {
+			zend_throw_error(NULL, "mysqli_stmt_data_seek(): No result set associated with the statement");
+		}
 		RETURN_THROWS();
 	}
 

--- a/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
@@ -25,6 +25,11 @@ require_once 'skipifconnectfailure.inc';
     if (true !== ($tmp = mysqli_stmt_execute($stmt)))
         printf("[006] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
 
+    try {
+        mysqli_stmt_data_seek($stmt, 1);
+    } catch (Error $exception) {
+        echo $exception->getMessage() . "\n";
+    }
 
     $id = null;
     if (!mysqli_stmt_bind_result($stmt, $id))
@@ -82,6 +87,7 @@ require_once 'skipifconnectfailure.inc';
 ?>
 --EXPECT--
 mysqli_stmt object is not fully initialized
+The result set buffer is empty
 int(3)
 int(1)
 int(1)

--- a/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
@@ -87,7 +87,7 @@ require_once 'skipifconnectfailure.inc';
 ?>
 --EXPECT--
 mysqli_stmt object is not fully initialized
-The result set buffer is empty
+No result set associated with the statement
 int(3)
 int(1)
 int(1)

--- a/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_data_seek.phpt
@@ -87,7 +87,7 @@ require_once 'skipifconnectfailure.inc';
 ?>
 --EXPECT--
 mysqli_stmt object is not fully initialized
-No result set associated with the statement
+mysqli_stmt_data_seek(): No result set associated with the statement
 int(3)
 int(1)
 int(1)


### PR DESCRIPTION
According to the MySQL standard `mysql_stmt_data_seek` should be a void function, but in mysqlnd it was always returning `bool`. In this case, it makes sense to check for an error condition and inform the mysqli user about incorrect usage. 
The only time this function returns false is if it's used on PS without a buffered result set, hence the text of the error message. 