### PR TITLE
Suppress arginfo / zpp mismatch via ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ PHP                                                                        NEWS
   . Fixed incorrect check condition in ZEND_YIELD. (nielsdos)
   . Fixed incorrect check condition in type inference. (nielsdos)
   . Fix incorrect check in zend_internal_call_should_throw(). (nielsdos)
+  . arginfo / zpp validation can now be skipped on debug build with 
+    ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=1 (zeriyoshi)
 
 - FFI:
   . Fixed incorrect bitshifting and masking in ffi bitfield. (nielsdos)

--- a/Zend/tests/arginfo_zpp_mismatch.inc
+++ b/Zend/tests/arginfo_zpp_mismatch.inc
@@ -10,6 +10,7 @@ function skipFunction($function): bool {
      || $function === 'zend_create_unterminated_string'
      || $function === 'zend_test_array_return'
      || $function === 'zend_leak_bytes'
+     || $function === 'zend_test_arginfo_zpp_mismatch'
         /* mess with output */
      || (is_string($function) && str_starts_with($function, 'ob_'))
      || $function === 'output_add_rewrite_var'

--- a/Zend/tests/arginfo_zpp_mismatch_suppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_suppress.phpt
@@ -2,6 +2,8 @@
 Test suppressing arginfo / zpp mismatch
 --EXTENSIONS--
 zend_test
+--SKIPIF--
+<?php if (!PHP_DEBUG) die('skip debug build only'); ?>
 --ENV--
 ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=1
 --FILE--

--- a/Zend/tests/arginfo_zpp_mismatch_suppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_suppress.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test suppressing arginfo / zpp mismatch
+--EXTENSIONS--
+zend_test
+--ENV--
+ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=1
+--FILE--
+<?php
+zend_test_arginfo_zpp_mismatch(1);
+echo 'success';
+--EXPECT--
+success

--- a/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
@@ -3,7 +3,7 @@ Test don't suppress arginfo / zpp mismatch
 --EXTENSIONS--
 zend_test
 --SKIPIF--
-<?php if (!PHP_DEBUG) die('skip debug build only'); if (extension_loaded('zend opcache')) die('skip OPcache replaces zend_execute_ex'); ?>
+<?php if (!PHP_DEBUG) die('skip debug build only'); if (extension_loaded('zend opcache') && opcache_get_status()['jit']['enabled']) die('skip sometimes skip arginfo / zpp check on JIT'); ?>
 --ENV--
 ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=0
 --FILE--

--- a/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test don't suppress arginfo / zpp mismatch
+--EXTENSIONS--
+zend_test
+--ENV--
+ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=0
+--FILE--
+<?php
+zend_test_arginfo_zpp_mismatch(1);
+echo 'success';
+--EXPECTF--
+Fatal error: Arginfo / zpp mismatch during call of zend_test_arginfo_zpp_mismatch() in %s on line %d

--- a/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
@@ -3,7 +3,7 @@ Test don't suppress arginfo / zpp mismatch
 --EXTENSIONS--
 zend_test
 --SKIPIF--
-<?php if (!PHP_DEBUG) die('skip debug build only'); if (extension_loaded('zend opcache') && opcache_get_status()['jit']['enabled']) die('skip sometimes skip arginfo / zpp check on JIT'); ?>
+<?php if (!PHP_DEBUG) die('skip debug build only'); if (extension_loaded('zend opcache') && opcache_get_status()['jit']['enabled'] ?? false) die('skip sometimes skip arginfo / zpp check on JIT'); ?>
 --ENV--
 ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=0
 --FILE--

--- a/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
@@ -3,7 +3,9 @@ Test don't suppress arginfo / zpp mismatch
 --EXTENSIONS--
 zend_test
 --SKIPIF--
-<?php if (!PHP_DEBUG) die('skip debug build only'); ?>
+<?php if (!PHP_DEBUG) die('skip debug build only'); if (extension_loaded('zend opcache')) die('skip OPcache replaces zend_execute_ex'); ?>
+--ENV--
+ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=0
 --FILE--
 <?php
 zend_test_arginfo_zpp_mismatch(1);

--- a/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
@@ -3,7 +3,7 @@ Test don't suppress arginfo / zpp mismatch
 --EXTENSIONS--
 zend_test
 --SKIPIF--
-<?php if (!PHP_DEBUG) die('skip debug build only'); if (extension_loaded('zend opcache') && opcache_get_status()['jit']['enabled'] ?? false) die('skip sometimes skip arginfo / zpp check on JIT'); ?>
+<?php if (!PHP_DEBUG) die('skip debug build only'); if (extension_loaded('zend opcache')) die('skip sometimes skip arginfo / zpp check on Zend OPcache'); ?>
 --ENV--
 ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=0
 --FILE--

--- a/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
@@ -4,8 +4,6 @@ Test don't suppress arginfo / zpp mismatch
 zend_test
 --SKIPIF--
 <?php if (!PHP_DEBUG) die('skip debug build only'); ?>
---ENV--
-ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=0
 --FILE--
 <?php
 zend_test_arginfo_zpp_mismatch(1);

--- a/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
+++ b/Zend/tests/arginfo_zpp_mismatch_unsuppress.phpt
@@ -2,6 +2,8 @@
 Test don't suppress arginfo / zpp mismatch
 --EXTENSIONS--
 zend_test
+--SKIPIF--
+<?php if (!PHP_DEBUG) die('skip debug build only'); ?>
 --ENV--
 ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH=0
 --FILE--

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1008,6 +1008,11 @@ void zend_startup(zend_utility_functions *utility_functions) /* {{{ */
 	tsrm_set_new_thread_end_handler(zend_new_thread_end_handler);
 	tsrm_set_shutdown_handler(zend_interned_strings_dtor);
 #endif
+
+#ifdef ZEND_DEBUG
+	char *tmp = getenv("ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH");
+	EG(suppress_arginfo_zpp_mismatch) = tmp && ZEND_ATOL(tmp);
+#endif
 }
 /* }}} */
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1210,6 +1210,10 @@ static zend_never_inline ZEND_ATTRIBUTE_UNUSED bool zend_verify_internal_arg_typ
  * trust that arginfo matches what is enforced by zend_parse_parameters. */
 ZEND_API bool zend_internal_call_should_throw(zend_function *fbc, zend_execute_data *call)
 {
+	if (EG(suppress_arginfo_zpp_mismatch)) {
+		return 0;
+	}
+
 	if (fbc->internal_function.handler == ZEND_FN(pass) || (fbc->internal_function.fn_flags & ZEND_ACC_FAKE_CLOSURE)) {
 		/* Be lenient about the special pass function and about fake closures. */
 		return 0;

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -271,6 +271,10 @@ struct _zend_executor_globals {
 	zend_string *filename_override;
 	zend_long lineno_override;
 
+#ifdef ZEND_DEBUG
+	bool suppress_arginfo_zpp_mismatch;
+#endif
+
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
 

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -335,8 +335,21 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_iterable_legacy, 0, 1, IS_I
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, arg2, IS_ITERABLE, 1, "null")
 ZEND_END_ARG_INFO()
 
+static ZEND_FUNCTION(zend_test_arginfo_zpp_mismatch)
+{
+	zend_long foo;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(foo);
+	ZEND_PARSE_PARAMETERS_END();
+}
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_arginfo_zpp_mismatch, 0, 0, IS_VOID, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry ext_function_legacy[] = {
 	ZEND_FE(zend_iterable_legacy, arginfo_zend_iterable_legacy)
+	ZEND_FE(zend_test_arginfo_zpp_mismatch, arginfo_zend_test_arginfo_zpp_mismatch)
 	ZEND_FE_END
 };
 


### PR DESCRIPTION
Currently, debug builds of PHP always detect an arginfo / zpp mismatch in shared extensions and raise a Fatal Error while running extensions that do not properly define arginfo. This is very inconvenient if you want to get a core dump while running an extension (e.g. protobuf, redis) that does not define arginfo properly.

To solve this problem, the environment variable `ZEND_SUPPRESS_ARGINFO_ZPP_MISMATCH` has been added to disable arginfo / zpp integrity checks even in debug builds when it is enabled.

~In PHP 8.2, a change was made to disable detection of Fake Closure arginfo / zpp mismatches, a side effect of which is that arginfo / zpp integrity checks are no longer performed for extensions built into PHP itself. It appears that this change is aready unnecessary, so we will revert it at the same time.~

_Update: This is bug and fixed in #10417_

In any case, this change affects only debug builds and does not affect normal builds.

Closes: #10451 