### PR TITLE
Fix incorrect check condition in type inference

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -2505,7 +2505,7 @@ static zend_always_inline int _zend_update_type_info(
 					UPDATE_SSA_TYPE(orig, ssa_op->op1_def);
 					COPY_SSA_OBJ_TYPE(ssa_op->op1_use, ssa_op->op1_def);
 				}
-			} else if (opline->opcode == ZEND_ASSIGN_STATIC_PROP) {
+			} else if (opline->opcode == ZEND_ASSIGN_STATIC_PROP_OP) {
 				/* Nothing to do */
 			} else {
 				if (opline->opcode == ZEND_ASSIGN_OP && ssa_op->result_def >= 0 && (tmp & MAY_BE_RC1)) {


### PR DESCRIPTION
The "nothing to do" case would never be hit because the switch block would execute if the opcode is ZEND_ASSIGN_STATIC_PROP_OP, not ZEND_ASSIGN_STATIC_PROP. This meant that we were falling through to the else block. Fix this by correcting the check condition.

I couldn't easily find a way to write a test case for this, any pointers for that would be appreciated :)