### PR TITLE
Fix incorrect page_size check

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3197,7 +3197,7 @@ static zend_result accel_post_startup(void)
 			size_t page_size;
 
 			page_size = zend_get_page_size();
-			if (!page_size && (page_size & (page_size - 1))) {
+			if (!page_size || (page_size & (page_size - 1))) {
 				zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Failure to initialize shared memory structures - can't get page size.");
 				abort();
 			}


### PR DESCRIPTION
The current check always evaluated to false because if `!page_size` is true, then `page_size & (page_size - 1)` equals `0 & (0 - 1)` which is always 0. The if condition is meant to check if page_size is zero or not a power of two, thus we must change the AND to an OR to fix this issue.

Found using static analysis, and manually verified.