### PR TITLE
Fix GH-10292 1st param of mt_srand() has UNKNOWN default on PHP <8.3

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -1548,10 +1548,10 @@ function quoted_printable_encode(string $string): string {}
 
 /* mt_rand.c */
 
-function mt_srand(int $seed = 0, int $mode = MT_RAND_MT19937): void {}
+function mt_srand(int $seed = UNKNOWN, int $mode = MT_RAND_MT19937): void {}
 
 /** @alias mt_srand */
-function srand(int $seed = 0, int $mode = MT_RAND_MT19937): void {}
+function srand(int $seed = UNKNOWN, int $mode = MT_RAND_MT19937): void {}
 
 function rand(int $min = UNKNOWN, int $max = UNKNOWN): int {}
 

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 87ed2b04b9b46ce3df78d6f9d6d62bd6b2ae8fe5 */
+ * Stub hash: eb6a3a2e3cf8f62e768d5d4968606438819e6cf0 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1813,7 +1813,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_quoted_printable_encode arginfo_base64_encode
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_mt_srand, 0, 0, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, seed, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO(0, seed, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "MT_RAND_MT19937")
 ZEND_END_ARG_INFO()
 

--- a/ext/standard/tests/general_functions/rand.phpt
+++ b/ext/standard/tests/general_functions/rand.phpt
@@ -13,9 +13,20 @@ var_dump(rand(0,3));
 
 var_dump(srand());
 var_dump(srand(-1));
+try {
+    srand(mode: MT_RAND_MT19937);
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
 
 var_dump(mt_srand());
 var_dump(mt_srand(-1));
+
+try {
+    mt_srand(mode: MT_RAND_MT19937);
+} catch (Error $e) {
+    echo $e->getMessage() . "\n";
+}
 
 var_dump(getrandmax());
 
@@ -32,8 +43,10 @@ int(%i)
 int(%d)
 NULL
 NULL
+srand(): Argument #1 ($seed) must be passed explicitly, because the default value is not known
 NULL
 NULL
+mt_srand(): Argument #1 ($seed) must be passed explicitly, because the default value is not known
 int(%d)
 int(%d)
 Done


### PR DESCRIPTION
Rationale: https://github.com/php/php-src/pull/10380#pullrequestreview-1264026166