### PR TITLE
Display PHPDoc property type declarations in the manual

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -2263,6 +2263,14 @@ class PropertyInfo extends VariableLike
 
     protected function addModifiersToFieldSynopsis(DOMDocument $doc, DOMElement $fieldsynopsisElement): void
     {
+        if ($this->phpDocType && $this->type === null) {
+            $fieldsynopsisElement->appendChild(new DOMText("\n     "));
+            $classSynopsisInfo = $doc->createElement("classsynopsisinfo", "/** @var " . $this->phpDocType->__toString() . " */");
+            $classSynopsisInfo->setAttribute("role", "phpdoc");
+
+            $fieldsynopsisElement->appendChild($classSynopsisInfo);
+        }
+
         parent::addModifiersToFieldSynopsis($doc, $fieldsynopsisElement);
 
         if ($this->flags & Class_::MODIFIER_STATIC) {
@@ -2278,11 +2286,9 @@ class PropertyInfo extends VariableLike
 
     protected function addTypeToFieldSynopsis(DOMDocument $doc, DOMElement $fieldsynopsisElement): void
     {
-        $type = $this->phpDocType ?? $this->type;
-
-        if ($type) {
+        if ($this->type) {
             $fieldsynopsisElement->appendChild(new DOMText("\n     "));
-            $fieldsynopsisElement->appendChild($type->getTypeForDoc($doc));
+            $fieldsynopsisElement->appendChild($this->type->getTypeForDoc($doc));
         }
     }
 


### PR DESCRIPTION
In order to fix https://github.com/php/doc-en/issues/2232, this PR removes the "fake" property type declarations from the manual. On the other hand, these types are now displayed via PHPDoc.

For this purpose, a new `phpdoc` role is added for `classsynopsisinfo` elements. A couple of up followup PRs are needed (doc-base, web-php) before the changes in doc-en can be released.

An example:
<img width="924" alt="Screenshot 2023-01-24 at 22 46 08" src="https://user-images.githubusercontent.com/6057627/214428181-1cb45a41-8a54-4091-8da9-b9c710d0270a.png">
