### PR TITLE
Fix GH-10437: Set active fiber to null on bailout

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ PHP                                                                        NEWS
   . Fixed overflow check in OnUpdateMemoryConsumption. (nielsdos)
   . Fixed bug GH-9916 (Entering shutdown sequence with a fiber suspended in a
     Generator emits an unavoidable fatal error or crashes). (Arnaud)
+  . Fixed bug GH-10437 (Segfault/assertion when using fibers in shutdown
+    function after bailout). (trowski)
 
 - FFI:
   . Fixed incorrect bitshifting and masking in ffi bitfield. (nielsdos)

--- a/Zend/tests/fibers/gh10437.phpt
+++ b/Zend/tests/fibers/gh10437.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-10437 (Segfault/assertion when using fibers in shutdown function after bailout)
+--FILE--
+<?php
+
+register_shutdown_function(function (): void {
+    var_dump(Fiber::getCurrent());
+});
+
+$fiber = new Fiber(function (): never {
+    trigger_error('Bailout in fiber', E_USER_ERROR);
+});
+$fiber->start();
+
+?>
+--EXPECTF--
+Fatal error: Bailout in fiber in %sgh10437.php on line %d
+NULL

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -543,6 +543,7 @@ static zend_always_inline zend_fiber_transfer zend_fiber_switch_to(
 
 	/* Forward bailout into current fiber. */
 	if (UNEXPECTED(transfer.flags & ZEND_FIBER_TRANSFER_FLAG_BAILOUT)) {
+		EG(active_fiber) = NULL;
 		zend_bailout();
 	}
 


### PR DESCRIPTION
A bailout in a fiber is not setting the active fiber to NULL, causing `Fiber::getCurrent()` to return a bogus `Fiber` object from `{main}` in a shutdown function.

This is a simple fix, setting `EG(active_fiber)` to NULL before forwarding the bailout.