### PR TITLE
Fix overflow check in OnUpdateMemoryConsumption

### DIFF
--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -70,8 +70,8 @@ static ZEND_INI_MH(OnUpdateMemoryConsumption)
 		zend_accel_error(ACCEL_LOG_WARNING, "opcache.memory_consumption is set below the required 8MB.\n");
 		return FAILURE;
 	}
-	if (UNEXPECTED(memsize > ZEND_ULONG_MAX / (1024 * 1024))) {
-		*p = ZEND_ULONG_MAX;
+	if (UNEXPECTED(memsize > ZEND_LONG_MAX / (1024 * 1024))) {
+		*p = ZEND_LONG_MAX;
 	} else {
 		*p = memsize * (1024 * 1024);
 	}


### PR DESCRIPTION
memsize is a signed long, therefore the check against the (*un*signed long maximum) / 1024² will never trigger. This check worked correctly in d4b3f89c53f8 where it checked against the maximum signed value, but was broken in 003346c450b5. Fix it by changing ZEND_ULONG_MAX to ZEND_LONG_MAX.