### PR TITLE
Prevent dtor of generator in suspended fiber

### DIFF
--- a/Zend/tests/gh9916-001.phpt
+++ b/Zend/tests/gh9916-001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug GH-9916 001 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    try {
+        print "Before suspend\n";
+        Fiber::suspend();
+        print "Not executed";
+        yield;
+    } finally {
+        print "Finally\n";
+    }
+    print "Not executed";
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->current();
+    print "Not executed";
+});
+$fiber->start();
+?>
+==DONE==
+--EXPECT--
+Before suspend
+==DONE==
+Finally

--- a/Zend/tests/gh9916-002.phpt
+++ b/Zend/tests/gh9916-002.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Bug GH-9916 002 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    print "Before suspend\n";
+    Fiber::suspend();
+    print "Not executed\n";
+    yield;
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->current();
+    print "Not executed";
+});
+$fiber->start();
+?>
+==DONE==
+--EXPECT--
+Before suspend
+==DONE==

--- a/Zend/tests/gh9916-003.phpt
+++ b/Zend/tests/gh9916-003.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Bug GH-9916 003 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    try {
+        yield from (function () {
+            $x = new stdClass;
+            try {
+                print "Before suspend\n";
+                Fiber::suspend();
+                print "Not executed\n";
+                yield;
+            } finally {
+                print "Finally (inner)\n";
+            }
+        })();
+        print "Not executed\n";
+        yield;
+    } finally {
+        print "Finally\n";
+    }
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->current();
+    print "Not executed";
+});
+$fiber->start();
+?>
+==DONE==
+--EXPECT--
+Before suspend
+==DONE==
+Finally (inner)
+Finally

--- a/Zend/tests/gh9916-004.phpt
+++ b/Zend/tests/gh9916-004.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug GH-9916 004 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    yield from (function () {
+        $x = new stdClass;
+        print "Before suspend\n";
+        Fiber::suspend();
+        print "Not executed\n";
+        yield;
+    })();
+    print "Not executed\n";
+    yield;
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->current();
+    print "Not executed";
+});
+$fiber->start();
+?>
+==DONE==
+--EXPECT--
+Before suspend
+==DONE==

--- a/Zend/tests/gh9916-005.phpt
+++ b/Zend/tests/gh9916-005.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug GH-9916 005 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    $fiber = yield;
+    print "Before suspend\n";
+    Fiber::suspend();
+    yield;
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->send($fiber);
+    $gen->current();
+});
+$fiber->start();
+
+$gen = null;
+$fiber = null;
+gc_collect_cycles();
+?>
+==DONE==
+--EXPECT--
+Before suspend
+==DONE==

--- a/Zend/tests/gh9916-006.phpt
+++ b/Zend/tests/gh9916-006.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Bug GH-9916 006 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    yield from (function () {
+        $x = new stdClass;
+        print "Before suspend\n";
+        Fiber::suspend();
+        print "After suspend\n";
+        yield;
+    })();
+    yield from (function () {
+        $x = new stdClass;
+        print "Before exit\n";
+        exit;
+        print "Not executed\n";
+        yield;
+    })();
+    yield;
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->current();
+    print "Fiber return\n";
+});
+$fiber->start();
+$fiber->resume();
+$gen->next();
+$gen->current();
+?>
+==DONE==
+--EXPECT--
+Before suspend
+After suspend
+Fiber return
+Before exit

--- a/Zend/tests/gh9916-007.phpt
+++ b/Zend/tests/gh9916-007.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Bug GH-9916 007 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$it = new class implements Iterator
+{
+    public function current(): mixed
+    {
+        return null;
+    }
+
+    public function key(): mixed
+    {
+        return 0;
+    }
+
+    public function next(): void
+    {
+    }
+
+    public function rewind(): void
+    {
+        try {
+            print "Before suspend\n";
+            Fiber::suspend();
+            print "Not executed\n";
+        } finally {
+            print "Finally (iterator)\n";
+        }
+    }
+
+    public function valid(): bool
+    {
+        return true;
+    }
+};
+
+$gen = (function() use ($it) {
+    try {
+        yield from $it;
+        print "Not executed\n";
+    } finally {
+        print "Finally\n";
+    }
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->current();
+    print "Not executed";
+});
+$fiber->start();
+?>
+==DONE==
+--EXPECT--
+Before suspend
+==DONE==
+Finally (iterator)
+Finally

--- a/Zend/tests/gh9916-008.phpt
+++ b/Zend/tests/gh9916-008.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Bug GH-9916 008 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$it = new class implements Iterator
+{
+    public function current(): mixed
+    {
+        return null;
+    }
+
+    public function key(): mixed
+    {
+        return 0;
+    }
+
+    public function next(): void
+    {
+    }
+
+    public function rewind(): void
+    {
+        $x = new stdClass;
+        print "Before suspend\n";
+        Fiber::suspend();
+    }
+
+    public function valid(): bool
+    {
+        return true;
+    }
+};
+
+$gen = (function() use ($it) {
+    $x = new stdClass;
+    yield from $it;
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->current();
+    print "Not executed";
+});
+$fiber->start();
+?>
+==DONE==
+--EXPECT--
+Before suspend
+==DONE==

--- a/Zend/tests/gh9916-009.phpt
+++ b/Zend/tests/gh9916-009.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug GH-9916 009 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    try {
+        print "Before suspend\n";
+        Fiber::suspend();
+        print "Not executed\n";
+    } finally {
+        print "Finally\n";
+        yield from ['foo' => new stdClass];
+        print "Not executed\n";
+    }
+})();
+$fiber = new Fiber(function() use ($gen, &$fiber) {
+    $gen->current();
+    print "Not executed\n";
+});
+$fiber->start();
+?>
+==DONE==
+--EXPECTF--
+Before suspend
+==DONE==
+Finally
+
+Fatal error: Uncaught Error: Cannot use "yield from" in a force-closed generator in %s:%d
+Stack trace:
+#0 [internal function]: {closure}()
+#1 %s(%d): Generator->current()
+#2 [internal function]: {closure}()
+#3 {main}
+  thrown in %s on line %d

--- a/Zend/tests/gh9916-010.phpt
+++ b/Zend/tests/gh9916-010.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug GH-9916 010 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    print "Before yield\n";
+    yield from (function () {
+        $x = new stdClass;
+        print "Before yield 2\n";
+        yield;
+        print "Before suspend\n";
+        Fiber::suspend();
+    })();
+})();
+
+$fiber = new Fiber(function () use ($gen, &$fiber) {
+    print "Before current\n";
+    $gen->current();
+    print "Before next\n";
+    $gen->next();
+    print "Not executed\n";
+});
+
+$fiber->start();
+?>
+==DONE==
+--EXPECT--
+Before current
+Before yield
+Before yield 2
+Before next
+Before suspend
+==DONE==
+.

--- a/Zend/tests/gh9916-010.phpt
+++ b/Zend/tests/gh9916-010.phpt
@@ -32,4 +32,3 @@ Before yield 2
 Before next
 Before suspend
 ==DONE==
-.

--- a/Zend/tests/gh9916-011.phpt
+++ b/Zend/tests/gh9916-011.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Bug GH-9916 011 (Entering shutdown sequence with a fiber suspended in a Generator emits an unavoidable fatal error or crashes)
+--FILE--
+<?php
+$gen = (function() {
+    $x = new stdClass;
+    print "Before yield\n";
+    $from = (function () {
+        $x = new stdClass;
+        print "Before yield 2\n";
+        yield;
+        print "Before suspend\n";
+        Fiber::suspend();
+        print "Not executed\n";
+        yield;
+    })();
+    try {
+        yield from $from;
+    } finally {
+        $from->next();
+    }
+})();
+
+$fiber = new Fiber(function () use ($gen, &$fiber) {
+    print "Before current\n";
+    $gen->current();
+    print "Before next\n";
+    $gen->next();
+    print "Not executed\n";
+});
+
+$fiber->start();
+?>
+==DONE==
+--EXPECT--
+Before current
+Before yield
+Before yield 2
+Before next
+Before suspend
+==DONE==

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -787,7 +787,8 @@ try_again:
 		goto try_again;
 	}
 
-	orig_generator->flags &= ~(ZEND_GENERATOR_DO_INIT | ZEND_GENERATOR_IN_FIBER);
+	generator->flags &= ~ZEND_GENERATOR_IN_FIBER;
+	orig_generator->flags &= ~ZEND_GENERATOR_DO_INIT;
 }
 /* }}} */
 

--- a/Zend/zend_generators.c
+++ b/Zend/zend_generators.c
@@ -223,6 +223,14 @@ static void zend_generator_dtor_storage(zend_object *object) /* {{{ */
 	uint32_t op_num, try_catch_offset;
 	int i;
 
+	/* Generator is running in a suspended fiber.
+	 * Will be dtor during fiber dtor */
+	if (generator->flags & ZEND_GENERATOR_IN_FIBER) {
+		/* Prevent finally blocks from yielding */
+		generator->flags |= ZEND_GENERATOR_FORCED_CLOSE;
+		return;
+	}
+
 	/* leave yield from mode to properly allow finally execution */
 	if (UNEXPECTED(Z_TYPE(generator->values) != IS_UNDEF)) {
 		zval_ptr_dtor(&generator->values);
@@ -727,7 +735,8 @@ try_again:
 	}
 
 	/* Resume execution */
-	generator->flags |= ZEND_GENERATOR_CURRENTLY_RUNNING;
+	generator->flags |= ZEND_GENERATOR_CURRENTLY_RUNNING
+						| (EG(active_fiber) ? ZEND_GENERATOR_IN_FIBER : 0);
 	if (!ZEND_OBSERVER_ENABLED) {
 		zend_execute_ex(generator->execute_data);
 	} else {
@@ -778,7 +787,7 @@ try_again:
 		goto try_again;
 	}
 
-	orig_generator->flags &= ~ZEND_GENERATOR_DO_INIT;
+	orig_generator->flags &= ~(ZEND_GENERATOR_DO_INIT | ZEND_GENERATOR_IN_FIBER);
 }
 /* }}} */
 

--- a/Zend/zend_generators.h
+++ b/Zend/zend_generators.h
@@ -92,6 +92,7 @@ static const zend_uchar ZEND_GENERATOR_CURRENTLY_RUNNING = 0x1;
 static const zend_uchar ZEND_GENERATOR_FORCED_CLOSE      = 0x2;
 static const zend_uchar ZEND_GENERATOR_AT_FIRST_YIELD    = 0x4;
 static const zend_uchar ZEND_GENERATOR_DO_INIT           = 0x8;
+static const zend_uchar ZEND_GENERATOR_IN_FIBER          = 0x10;
 
 void zend_register_generator_ce(void);
 ZEND_API void zend_generator_close(zend_generator *generator, bool finished_execution);


### PR DESCRIPTION
Fixes #9916

The shutdown sequence calls the destructor of any live generator or fiber (or any object).

When a fiber is suspended in a generator, the fiber destructor will resume the execution the generator, which may be already be destroyed. This leads to the issues described in #9916.

Because of this, we must not attempt to destroy a generator that was executing in a suspended fiber.

The fiber destructor conveniently throws a zend_ce_graceful_exit in the fiber context, which will also properly terminate the generator (and execute its finally blocks). I believe that this has the same semantics as the generator destructor.