### PR TITLE
Fix incorrect check in phar tar parsing

### DIFF
--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -478,14 +478,15 @@ bail:
 			return FAILURE;
 		}
 
+		uint32_t entry_mode = phar_tar_number(hdr->mode, sizeof(hdr->mode));
 		entry.tar_type = ((old & (hdr->typeflag == '\0')) ? TAR_FILE : hdr->typeflag);
 		entry.offset = entry.offset_abs = pos; /* header_offset unused in tar */
 		entry.fp_type = PHAR_FP;
-		entry.flags = phar_tar_number(hdr->mode, sizeof(hdr->mode)) & PHAR_ENT_PERM_MASK;
+		entry.flags = entry_mode & PHAR_ENT_PERM_MASK;
 		entry.timestamp = phar_tar_number(hdr->mtime, sizeof(hdr->mtime));
 		entry.is_persistent = myphar->is_persistent;
 
-		if (old && entry.tar_type == TAR_FILE && S_ISDIR(entry.flags)) {
+		if (old && entry.tar_type == TAR_FILE && S_ISDIR(entry_mode)) {
 			entry.tar_type = TAR_DIR;
 		}
 


### PR DESCRIPTION
The entry.flags was used to check whether the entry has the directory flag. The flags however were masked to only contain the permissions. We need to check the mode, before the permission masking, instead of the flags to check whether it is a directory.

Found using static analysis that reported an always-false branch.