### PR TITLE
Improve the optimizer's check if a function is a prototype or not

### DIFF
--- a/ext/opcache/tests/opt/type_inference_final_class.phpt
+++ b/ext/opcache/tests/opt/type_inference_final_class.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Type inference test with final class
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=-1
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+final class Test {
+    public function getInt(): int {
+        return 42;
+    }
+    public function getInt2(): int {
+        return $this->getInt();
+    }
+}
+
+?>
+--EXPECTF--
+$_main:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(1)
+
+Test::getInt:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN int(42)
+
+Test::getInt2:
+     ; (lines=2, args=0, vars=0, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 V0 = QM_ASSIGN int(42)
+0001 RETURN V0


### PR DESCRIPTION
Currently, a function is considered a prototype if the function is not marked as final. However, a class marked as final or an anonymous class also make it impossible for a function to be overridden. Therefore, we know in these 2 cases too that the function is not a prototype. This allows the type inference algorithm to determine some types more precisely, and can allow for more optimizations of the instructions. Additionally, place some computation of the flags in their respective blocks as a micro-optimization.