### PR TITLE
remove #include comments

### DIFF
--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -27,10 +27,10 @@
 
 #include "php_ini.h"
 #include "ext/standard/info.h"
-#include "ext/standard/file.h" /* needed for context stuff */
+#include "ext/standard/file.h"
 #include "php_fileinfo.h"
 #include "fileinfo_arginfo.h"
-#include "fopen_wrappers.h" /* needed for is_url */
+#include "fopen_wrappers.h"
 #include "Zend/zend_exceptions.h"
 
 /* {{{ macros and type definitions */

--- a/ext/hash/murmur/PMurHash.c
+++ b/ext/hash/murmur/PMurHash.c
@@ -70,7 +70,7 @@ on big endian machines, or a byte-by-byte read if the endianess is unknown.
 /* Find best way to ROTL */
 #if defined(_MSC_VER)
   #define FORCE_INLINE  static __forceinline
-  #include <stdlib.h>  /* Microsoft put _rotl declaration in here */
+  #include <stdlib.h>
   #define ROTL32(x,y)  _rotl(x,y)
 #else
   #define FORCE_INLINE static inline __attribute__((always_inline))

--- a/ext/hash/murmur/PMurHash128.c
+++ b/ext/hash/murmur/PMurHash128.c
@@ -62,7 +62,7 @@ on big endian machines.
 /* Find best way to ROTL */
 #if defined(_MSC_VER)
   #define FORCE_INLINE  static __forceinline
-  #include <stdlib.h>  /* Microsoft put _rotl declaration in here */
+  #include <stdlib.h>
   #define ROTL32(x,y)  _rotl(x,y)
   #define ROTL64(x,y)  _rotl64(x,y)
   #define BIG_CONSTANT(x) (x)

--- a/ext/hash/xxhash/xxhash.h
+++ b/ext/hash/xxhash/xxhash.h
@@ -339,7 +339,7 @@ XXH_PUBLIC_API unsigned XXH_versionNumber (void);
 /* ****************************
 *  Common basic types
 ******************************/
-#include <stddef.h>   /* size_t */
+#include <stddef.h>
 typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 
 
@@ -1482,7 +1482,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
     return memcpy(dest,src,size);
 }
 
-#include <limits.h>   /* ULLONG_MAX */
+#include <limits.h>
 
 
 /* *************************************
@@ -5445,7 +5445,7 @@ XXH_PUBLIC_API XXH128_hash_t XXH3_128bits_digest (const XXH3_state_t* state)
 
 /* 128-bit utility functions */
 
-#include <string.h>   /* memcmp, memcpy */
+#include <string.h>
 
 /* return : 1 is equal, 0 if different */
 /*! @ingroup xxh3_family */

--- a/ext/mbstring/php_mbregex.c
+++ b/ext/mbstring/php_mbregex.c
@@ -27,7 +27,7 @@
 #include "mbstring.h"
 #include "libmbfl/filters/mbfilter_utf8.h"
 
-#include "php_onig_compat.h" /* must come prior to the oniguruma header */
+#include "php_onig_compat.h"
 #include <oniguruma.h>
 #undef UChar
 

--- a/ext/mysqlnd/config-win.h
+++ b/ext/mysqlnd/config-win.h
@@ -8,7 +8,7 @@ This file is public domain and comes with NO WARRANTY of any kind */
 
 #include <sys/locking.h>
 #include <windows.h>
-#include <math.h>			/* Because of rint() */
+#include <math.h>
 #include <fcntl.h>
 #include <io.h>
 #include <malloc.h>

--- a/ext/opcache/jit/vtune/ittnotify_config.h
+++ b/ext/opcache/jit/vtune/ittnotify_config.h
@@ -395,7 +395,7 @@ typedef struct ___itt_thread_info
     struct ___itt_thread_info* next;
 } __itt_thread_info;
 
-#include "ittnotify_types.h" /* For __itt_group_id definition */
+#include "ittnotify_types.h"
 
 typedef struct ___itt_api_info_20101001
 {

--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -4,7 +4,7 @@
 #endif
 #include "sockaddr_conv.h"
 #include "conversions.h"
-#include "sendrecvmsg.h" /* for ancillary registry */
+#include "sendrecvmsg.h"
 #ifdef PHP_WIN32
 # include "windows_common.h"
 #endif

--- a/ext/sockets/sockaddr_conv.h
+++ b/ext/sockets/sockaddr_conv.h
@@ -2,7 +2,7 @@
 #define PHP_SOCKADR_CONV_H
 
 #include <php_network.h>
-#include "php_sockets.h" /* php_socket */
+#include "php_sockets.h"
 
 #ifndef PHP_WIN32
 # include <netinet/in.h>

--- a/ext/sockets/windows_common.h
+++ b/ext/sockets/windows_common.h
@@ -16,7 +16,7 @@
 
 #include <Winsock2.h>
 #define NTDDI_XP NTDDI_WINXP /* bug in SDK */
-#include <IPHlpApi.h> /* conflicting definition of CMSG_DATA */
+#include <IPHlpApi.h>
 #undef NTDDI_XP
 
 #define HAVE_IF_NAMETOINDEX 1

--- a/ext/standard/formatted_print.c
+++ b/ext/standard/formatted_print.c
@@ -14,7 +14,7 @@
    +----------------------------------------------------------------------+
  */
 
-#include <math.h>				/* modf() */
+#include <math.h>
 #include "php.h"
 #include "ext/standard/head.h"
 #include "php_string.h"

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -27,7 +27,7 @@
 #include "SAPI.h"
 #include <time.h>
 #include "php_main.h"
-#include "zend_globals.h"		/* needs ELS */
+#include "zend_globals.h"
 #include "zend_extensions.h"
 #include "zend_highlight.h"
 #ifdef HAVE_SYS_UTSNAME_H

--- a/ext/standard/php_http.h
+++ b/ext/standard/php_http.h
@@ -18,7 +18,7 @@
 #define PHP_HTTP_H
 
 #include "php.h"
-#include "zend_types.h" /* for zend_string */
+#include "zend_types.h"
 #include "zend_smart_str.h"
 
 PHPAPI void php_url_encode_hash_ex(HashTable *ht, smart_str *formstr,

--- a/main/reentrancy.c
+++ b/main/reentrancy.c
@@ -22,7 +22,7 @@
 #endif
 
 #include "php_reentrancy.h"
-#include "ext/random/php_random.h"                   /* for PHP_RAND_MAX */
+#include "ext/random/php_random.h"
 
 enum {
 	LOCALTIME_R,

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -26,8 +26,8 @@
 #include "php_network.h"
 #include "php_open_temporary_file.h"
 #include "ext/standard/file.h"
-#include "ext/standard/basic_functions.h" /* for BG(CurrentStatFile) */
-#include "ext/standard/php_string.h" /* for php_memnstr, used by php_stream_get_record() */
+#include "ext/standard/basic_functions.h"
+#include "ext/standard/php_string.h"
 #include <stddef.h>
 #include <fcntl.h>
 #include "php_streams_int.h"

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -90,12 +90,12 @@
 # define SOCK_EADDRINUSE WSAEADDRINUSE
 #endif
 
-#include "ext/standard/file.h" /* for php_set_sock_blocking() :-( */
+#include "ext/standard/file.h"
 #include "zend_smart_str.h"
 #include "ext/standard/html.h"
-#include "ext/standard/url.h" /* for php_raw_url_decode() */
-#include "ext/standard/php_string.h" /* for php_dirname() */
-#include "ext/date/php_date.h" /* for php_format_date() */
+#include "ext/standard/url.h"
+#include "ext/standard/php_string.h"
+#include "ext/date/php_date.h"
 #include "php_network.h"
 
 #include "php_http_parser.h"

--- a/sapi/cli/ps_title.c
+++ b/sapi/cli/ps_title.c
@@ -51,10 +51,10 @@ extern char** environ;
 #include <stdlib.h>
 
 #ifdef HAVE_SYS_PSTAT_H
-#include <sys/pstat.h> /* for HP-UX */
+#include <sys/pstat.h>
 #endif
 #ifdef HAVE_PS_STRINGS
-#include <machine/vmparam.h> /* for old BSD */
+#include <machine/vmparam.h>
 #include <sys/exec.h>
 #endif
 #if defined(DARWIN)

--- a/sapi/fpm/fpm/fpm.c
+++ b/sapi/fpm/fpm/fpm.c
@@ -2,7 +2,7 @@
 
 #include "fpm_config.h"
 
-#include <stdlib.h> /* for exit */
+#include <stdlib.h>
 
 #include "fpm.h"
 #include "fpm_children.h"

--- a/sapi/fpm/fpm/fpm_clock.c
+++ b/sapi/fpm/fpm/fpm_clock.c
@@ -3,7 +3,7 @@
 #include "fpm_config.h"
 
 #ifdef HAVE_CLOCK_GETTIME
-#include <time.h> /* for CLOCK_MONOTONIC */
+#include <time.h>
 #endif
 
 #include "fpm_clock.h"

--- a/sapi/fpm/fpm/fpm_events.c
+++ b/sapi/fpm/fpm/fpm_events.c
@@ -4,7 +4,7 @@
 
 #include <unistd.h>
 #include <errno.h>
-#include <stdlib.h> /* for putenv */
+#include <stdlib.h>
 #include <string.h>
 
 #include <php.h>

--- a/sapi/fpm/fpm/fpm_php.h
+++ b/sapi/fpm/fpm/fpm_php.h
@@ -6,7 +6,7 @@
 #include <TSRM.h>
 
 #include "php.h"
-#include "build-defs.h" /* for PHP_ defines */
+#include "build-defs.h"
 #include "fpm/fpm_conf.h"
 
 #define FPM_PHP_INI_TO_EXPAND \

--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -6,7 +6,7 @@
 #include <alloca.h>
 #endif
 #include <sys/types.h>
-#include <sys/stat.h> /* for chmod(2) */
+#include <sys/stat.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/win32/sendmail.c
+++ b/win32/sendmail.c
@@ -17,7 +17,7 @@
  *
  */
 
-#include "php.h"				/*php specific */
+#include "php.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <winsock2.h>

--- a/win32/wsyslog.c
+++ b/win32/wsyslog.c
@@ -50,7 +50,7 @@
  *  Lift a leg, Yunie.  Luv ya forever!!!!
  */
 
-#include "php.h"				/*php specific */
+#include "php.h"
 #include "syslog.h"
 #include <stdio.h>
 #include <fcntl.h>


### PR DESCRIPTION
Several PHP maintainers have argued that code comments explaining include directives are bad.

- @dstogov wrote "It adds almost useless comments that are not goigg to be kept as to date" https://marc.info/?l=php-internals&m=167403155727727&w=2

- @derickr wrote "Adding comments that go out of date as to why a header is included is also clutter." https://marc.info/?l=php-internals&m=167405646312575&w=2

- @kamil-tekiela wrote "I am against putting comments on #includes. Comments are noise in code and often go out of date." https://marc.info/?l=php-internals&m=167406432218721&w=2

I don't agree with them; I believe that code comments help others understand and maintain the code.  Of course, like any code comment, they become obsolete and wrong, but outdated comments are still better than no comment at all.  With this argument, you can easily say that nobody should ever write a code comment.

My RFC https://wiki.php.net/rfc/include_cleanup contains a vote on whether #includes are allowed to have explanatory code comments; if this is denied, then please merge this PR to get rid of many existing comments which my work has imitated.