### PR TITLE
Fixed exit_counters memory leak in ZTS

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4436,9 +4436,6 @@ ZEND_EXT_API void zend_jit_shutdown(void)
 		zend_jit_perf_jitdump_close();
 	}
 #endif
-	if (JIT_G(exit_counters)) {
-		free(JIT_G(exit_counters));
-	}
 }
 
 static void zend_jit_reset_counters(void)

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4486,6 +4486,8 @@ ZEND_EXT_API void zend_jit_deactivate(void)
 
 		zend_jit_profile_counter = 0;
 	}
+
+	zend_jit_trace_free_caches();
 }
 
 static void zend_jit_restart_preloaded_op_array(zend_op_array *op_array)

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7890,11 +7890,9 @@ static void zend_jit_trace_reset_caches(void)
 
 static void zend_jit_trace_free_caches(void)
 {
-#ifdef ZTS
 	if (JIT_G(exit_counters)) {
 		free(JIT_G(exit_counters));
 	}
-#endif
 }
 
 static void zend_jit_trace_restart(void)

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7888,6 +7888,15 @@ static void zend_jit_trace_reset_caches(void)
 #endif
 }
 
+static void zend_jit_trace_free_caches(void)
+{
+#ifdef ZTS
+	if (JIT_G(exit_counters)) {
+		free(JIT_G(exit_counters));
+	}
+#endif
+}
+
 static void zend_jit_trace_restart(void)
 {
 	ZEND_JIT_TRACE_NUM = 1;


### PR DESCRIPTION
this code seems like it could use a tidy for the ZTS case.

This was causing some of my tests to fail in an extension when using ASan.