### PR TITLE
Fix GH-10031: [Stream] STREAM_NOTIFY_PROGRESS over HTTP emitted irregularly for last chunk of data

### DIFF
--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -955,6 +955,13 @@ out:
 		if (transfer_encoding) {
 			php_stream_filter_append(&stream->readfilters, transfer_encoding);
 		}
+
+		/* It's possible that the server already sent in more data than just the headers.
+		 * We account for this by adjusting the progress counter by the difference of
+		 * already read header data and the body. */
+		if (stream->writepos > stream->readpos) {
+			php_stream_notify_progress_increment(context, stream->writepos - stream->readpos, 0);
+		}
 	}
 
 	return stream;

--- a/ext/standard/tests/streams/gh10031.phpt
+++ b/ext/standard/tests/streams/gh10031.phpt
@@ -1,0 +1,52 @@
+--TEST--
+GH-10031 ([Stream] STREAM_NOTIFY_PROGRESS over HTTP emitted irregularly for last chunk of data)
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--INI--
+allow_url_fopen=1
+--CONFLICTS--
+server
+--FILE--
+<?php
+
+$serverCode = <<<'CODE'
+$fsize = 1000;
+$chunksize = 99;
+$chunks = floor($fsize / $chunksize); // 10 chunks * 99 bytes
+$lastchunksize = $fsize - $chunksize * $chunks; // 1 chunk * 10 bytes
+
+header("Content-Length: " . $fsize);
+flush();
+for ($chunk = 1; $chunk <= $chunks; $chunk++) {
+    echo str_repeat('x', $chunksize);
+    @ob_flush();
+    usleep(50 * 1000);
+}
+
+echo str_repeat('x', $lastchunksize);
+CODE;
+
+include __DIR__."/../../../../sapi/cli/tests/php_cli_server.inc";
+php_cli_server_start($serverCode, null, []);
+
+$context = stream_context_create(['http' => ['ignore_errors' => true,]]);
+$lastBytesTransferred = 0;
+stream_context_set_params($context, ['notification' => function ($code, $s, $m, $mc, $bytes_transferred, $bytes_max)
+use (&$lastBytesTransferred) {
+    if ($code === STREAM_NOTIFY_FILE_SIZE_IS) echo "expected filesize=$bytes_max".PHP_EOL;
+    $lastBytesTransferred = $bytes_transferred;
+    @ob_flush();
+}]);
+
+$get = file_get_contents("http://".PHP_CLI_SERVER_ADDRESS, false, $context);
+
+echo "got filesize=" . strlen($get) . PHP_EOL;
+var_dump($lastBytesTransferred);
+
+?>
+--EXPECT--
+expected filesize=1000
+got filesize=1000
+int(1000)


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/10031

It's possible that the server already sent in more data than just the headers.
Since the stream only accepts progress increments after the headers are
processed, the already read data is never added to the process.
We account for this by adjusting the progress counter by the difference of
already read header data and the body.

cc'ing @cmb69 since he also could reproduce the issue, and commented on the issue report.

I'm just not sure if I added the test case correctly. Is it correct to reuse the cli server in this way?

EDIT: Linux x64-NTS failed due to a failure in `./.github/scripts/setup-slapd.sh`; which I think is unrelated