### PR TITLE
Use AVX2 to accelerate strto{upper,lower} (only on 'AVX2-native' builds for now)

### DIFF
--- a/ext/standard/tests/strings/strtoupper1.phpt
+++ b/ext/standard/tests/strings/strtoupper1.phpt
@@ -28,6 +28,11 @@ $strings = array (
   "zzzzzzzzzzzzzzzzzzzz",
   "````````````````````",
   "{{{{{{{{{{{{{{{{{{{{",
+  /* And the AVX2 implementation also */
+  "{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{",
+  "abcdefghijklmnopqrstuvwxyz01234",
+  "abcdefghijklmnopqrstuvwxyz012345",
+  "abcdefghijklmnopqrstuvwxyz0123456",
   "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 );
 
@@ -348,6 +353,18 @@ string(20) "````````````````````"
 string(20) "{{{{{{{{{{{{{{{{{{{{"
 
 -- Iteration 12 --
+string(40) "{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{"
+
+-- Iteration 13 --
+string(31) "ABCDEFGHIJKLMNOPQRSTUVWXYZ01234"
+
+-- Iteration 14 --
+string(32) "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+
+-- Iteration 15 --
+string(33) "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456"
+
+-- Iteration 16 --
 string(62) "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 *** Testing strtoupper() with two different case strings ***


### PR DESCRIPTION
On short strings, there is no difference in performance. However, for strings around 10,000 bytes long, the AVX2-accelerated function is about 55% faster than the SSE2-accelerated one.

FYA @cmb69 @Girgias @nikic @nielsdos 