### PR TITLE
 Zend/Optimizer/zend_func_info.h: remove forward declarations

### DIFF
--- a/Zend/Optimizer/dfa_pass.c
+++ b/Zend/Optimizer/dfa_pass.c
@@ -25,7 +25,6 @@
 #include "zend_bitset.h"
 #include "zend_cfg.h"
 #include "zend_ssa.h"
-#include "zend_func_info.h"
 #include "zend_call_graph.h"
 #include "zend_inference.h"
 #include "zend_dump.h"

--- a/Zend/Optimizer/zend_call_graph.h
+++ b/Zend/Optimizer/zend_call_graph.h
@@ -20,12 +20,13 @@
 #define ZEND_CALL_GRAPH_H
 
 #include "zend_ssa.h"
-#include "zend_func_info.h"
 #include "zend_optimizer.h"
 
 typedef struct _zend_send_arg_info {
 	zend_op                *opline;
 } zend_send_arg_info;
+
+typedef struct _zend_call_info zend_call_info;
 
 struct _zend_call_info {
 	zend_op_array          *caller_op_array;
@@ -42,7 +43,7 @@ struct _zend_call_info {
 	zend_send_arg_info      arg_info[1];
 };
 
-struct _zend_func_info {
+typedef struct _zend_func_info {
 	int                     num;
 	uint32_t                flags;
 	zend_ssa                ssa;          /* Static Single Assignment Form  */
@@ -50,13 +51,15 @@ struct _zend_func_info {
 	zend_call_info         *callee_info;  /* which functions are called from this one */
 	zend_call_info        **call_map;     /* Call info associated with init/call/send opnum */
 	zend_ssa_var_info       return_info;
-};
+} zend_func_info;
 
 typedef struct _zend_call_graph {
 	int                     op_arrays_count;
 	zend_op_array         **op_arrays;
 	zend_func_info         *func_infos;
 } zend_call_graph;
+
+#include "zend_func_info.h"
 
 BEGIN_EXTERN_C()
 

--- a/Zend/Optimizer/zend_cfg.c
+++ b/Zend/Optimizer/zend_cfg.c
@@ -18,11 +18,13 @@
 
 #include "zend_compile.h"
 #include "zend_cfg.h"
-#include "zend_func_info.h"
+#include "zend_call_graph.h"
 #include "zend_worklist.h"
 #include "zend_optimizer.h"
 #include "zend_optimizer_internal.h"
 #include "zend_sort.h"
+#include "zend_arena.h"
+#include "zend_globals.h"
 
 static void zend_mark_reachable(zend_op *opcodes, zend_cfg *cfg, zend_basic_block *b) /* {{{ */
 {

--- a/Zend/Optimizer/zend_cfg.h
+++ b/Zend/Optimizer/zend_cfg.h
@@ -19,6 +19,8 @@
 #ifndef ZEND_CFG_H
 #define ZEND_CFG_H
 
+#include "zend_arena.h"
+
 /* zend_basic_block.flags */
 #define ZEND_BB_START            (1<<0)  /* first block            */
 #define ZEND_BB_FOLLOW           (1<<1)  /* follows the next block */

--- a/Zend/Optimizer/zend_dump.c
+++ b/Zend/Optimizer/zend_dump.c
@@ -20,7 +20,6 @@
 #include "zend_cfg.h"
 #include "zend_ssa.h"
 #include "zend_inference.h"
-#include "zend_func_info.h"
 #include "zend_call_graph.h"
 #include "zend_dump.h"
 

--- a/Zend/Optimizer/zend_func_info.h
+++ b/Zend/Optimizer/zend_func_info.h
@@ -40,10 +40,6 @@
 #define ZEND_FUNC_JIT_ON_HOT_COUNTERS      (1<<15) /* used by JIT */
 #define ZEND_FUNC_JIT_ON_HOT_TRACE         (1<<16) /* used by JIT */
 
-
-typedef struct _zend_func_info zend_func_info;
-typedef struct _zend_call_info zend_call_info;
-
 #define ZEND_FUNC_INFO(op_array) \
 	((zend_func_info*)((op_array)->reserved[zend_func_info_rid]))
 

--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -19,11 +19,11 @@
 #include "zend_compile.h"
 #include "zend_generators.h"
 #include "zend_inference.h"
-#include "zend_func_info.h"
 #include "zend_call_graph.h"
 #include "zend_closures.h"
 #include "zend_worklist.h"
 #include "zend_optimizer_internal.h"
+#include "zend_globals.h"
 
 /* The used range inference algorithm is described in:
  *     V. Campos, R. Rodrigues, I. de Assis Costa and F. Pereira.

--- a/Zend/Optimizer/zend_optimizer_internal.h
+++ b/Zend/Optimizer/zend_optimizer_internal.h
@@ -23,7 +23,7 @@
 #define ZEND_OPTIMIZER_INTERNAL_H
 
 #include "zend_ssa.h"
-#include "zend_func_info.h"
+#include "zend_call_graph.h"
 
 #define ZEND_OP1_LITERAL(opline)		(op_array)->literals[(opline)->op1.constant]
 #define ZEND_OP1_JMP_ADDR(opline)		OP_JMP_ADDR(opline, (opline)->op1)

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -758,8 +758,6 @@ struct _zend_execute_data {
 
 #define ZEND_EXTRA_VALUE 1
 
-#include "zend_globals.h"
-
 typedef enum _zend_compile_position {
 	ZEND_COMPILE_POSITION_AT_SHEBANG = 0,
 	ZEND_COMPILE_POSITION_AT_OPEN_TAG,

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -43,7 +43,7 @@
 #include "zend_observer.h"
 #include "zend_system_id.h"
 #include "zend_call_stack.h"
-#include "Optimizer/zend_func_info.h"
+#include "Optimizer/zend_call_graph.h"
 
 /* Virtual current working directory support */
 #include "zend_virtual_cwd.h"

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -25,6 +25,7 @@
 #include "zend_hash.h"
 #include "zend_operators.h"
 #include "zend_variables.h"
+#include "zend_globals.h"
 
 BEGIN_EXTERN_C()
 struct _zend_fcall_info;
@@ -186,6 +187,7 @@ ZEND_API zend_result ZEND_FASTCALL zval_update_constant_ex(zval *pp, zend_class_
 ZEND_API zend_result ZEND_FASTCALL zval_update_constant_with_ctx(zval *pp, zend_class_entry *scope, zend_ast_evaluate_ctx *ctx);
 
 /* dedicated Zend executor functions - do not use! */
+typedef struct _zend_vm_stack *zend_vm_stack;
 struct _zend_vm_stack {
 	zval *top;
 	zval *end;

--- a/Zend/zend_extensions.c
+++ b/Zend/zend_extensions.c
@@ -19,6 +19,7 @@
 
 #include "zend_extensions.h"
 #include "zend_system_id.h"
+#include "zend_globals.h"
 
 ZEND_API zend_llist zend_extensions;
 ZEND_API uint32_t zend_extension_flags = 0;

--- a/Zend/zend_float.c
+++ b/Zend/zend_float.c
@@ -19,6 +19,7 @@
 #include "zend.h"
 #include "zend_compile.h"
 #include "zend_float.h"
+#include "zend_globals.h"
 
 ZEND_API void zend_init_fpu(void) /* {{{ */
 {

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -38,6 +38,7 @@
 #include "zend_multiply.h"
 #include "zend_arena.h"
 #include "zend_call_stack.h"
+#include "zend_ini.h"
 
 /* Define ZTS if you want a thread-safe Zend */
 /*#undef ZTS*/
@@ -66,7 +67,6 @@ END_EXTERN_C()
 #undef function_table
 
 typedef struct _zend_vm_stack *zend_vm_stack;
-typedef struct _zend_ini_entry zend_ini_entry;
 typedef struct _zend_fiber_context zend_fiber_context;
 typedef struct _zend_fiber zend_fiber;
 

--- a/Zend/zend_ini.h
+++ b/Zend/zend_ini.h
@@ -19,6 +19,7 @@
 #ifndef ZEND_INI_H
 #define ZEND_INI_H
 
+#include "zend_modules.h"
 #include "zend_result.h"
 
 #define ZEND_INI_USER	(1<<0)
@@ -29,6 +30,8 @@
 
 #define ZEND_INI_MH(name) int name(zend_ini_entry *entry, zend_string *new_value, void *mh_arg1, void *mh_arg2, void *mh_arg3, int stage)
 #define ZEND_INI_DISP(name) ZEND_COLD void name(zend_ini_entry *ini_entry, int type)
+
+typedef struct _zend_ini_entry zend_ini_entry;
 
 typedef struct _zend_ini_entry_def {
 	const char *name;

--- a/Zend/zend_language_scanner.h
+++ b/Zend/zend_language_scanner.h
@@ -20,6 +20,11 @@
 #ifndef ZEND_SCANNER_H
 #define ZEND_SCANNER_H
 
+#include "zend_stack.h"
+#include "zend_ptr_stack.h"
+#include "zend_multibyte.h"
+#include "zend_globals.h"
+
 typedef struct _zend_lex_state {
 	unsigned int yy_leng;
 	unsigned char *yy_start;

--- a/Zend/zend_multibyte.c
+++ b/Zend/zend_multibyte.c
@@ -22,6 +22,7 @@
 #include "zend_operators.h"
 #include "zend_multibyte.h"
 #include "zend_ini.h"
+#include "zend_globals.h"
 
 static const zend_encoding *dummy_encoding_fetcher(const char *encoding_name)
 {

--- a/Zend/zend_stream.c
+++ b/Zend/zend_stream.c
@@ -22,6 +22,7 @@
 #include "zend.h"
 #include "zend_compile.h"
 #include "zend_stream.h"
+#include "zend_globals.h"
 
 ZEND_DLIMPORT int isatty(int fd);
 

--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -50,6 +50,8 @@
 
 #include "zend_extensions.h"
 #include "zend_compile.h"
+#include "zend_types.h"
+#include "zend_modules.h"
 
 #include "Optimizer/zend_optimizer.h"
 #include "zend_accelerator_hash.h"

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -33,7 +33,6 @@
 
 #ifdef HAVE_JIT
 
-#include "Optimizer/zend_func_info.h"
 #include "Optimizer/zend_ssa.h"
 #include "Optimizer/zend_inference.h"
 #include "Optimizer/zend_call_graph.h"

--- a/ext/opcache/jit/zend_jit_vm_helpers.c
+++ b/ext/opcache/jit/zend_jit_vm_helpers.c
@@ -25,7 +25,6 @@
 #include "Zend/zend_API.h"
 
 #include <ZendAccelerator.h>
-#include "Optimizer/zend_func_info.h"
 #include "Optimizer/zend_call_graph.h"
 #include "zend_jit.h"
 #if ZEND_JIT_TARGET_X86

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -31,7 +31,7 @@
 #include "zend_attributes.h"
 
 #ifdef HAVE_JIT
-# include "Optimizer/zend_func_info.h"
+# include "Optimizer/zend_call_graph.h"
 # include "jit/zend_jit.h"
 #endif
 


### PR DESCRIPTION
These were added by commit c88ffa9a5673cb, but @dstogov himself opposed to the concept of forward declarations, see https://github.com/php/php-src/pull/10338#discussion_r1071148150 (which I don't agree with - in my opinion, forward declarations are a useful tool to reduce header dependencies).

Removing these unnecessary forward declarations requires some fiddling with include directives, because they were inconsistent and fragile previously.  (They still are, but this PR does not attempt to change this; it only makes problems caused by the forward declaration removal go away.)

Please merge this PR if (and only if) my RFC "include cleanup" (https://wiki.php.net/rfc/include_cleanup) gets rejected, to fix the PHP code base according to the RFC decision.