### PR TITLE
Zend/zend_portability.h: add ZEND_ATTRIBUTE_{PURE,CONST}

### DIFF
--- a/Zend/Optimizer/scdf.h
+++ b/Zend/Optimizer/scdf.h
@@ -75,7 +75,7 @@ static inline void scdf_add_def_to_worklist(scdf_ctx *scdf, int var_num) {
 	}
 }
 
-static inline uint32_t scdf_edge(const zend_cfg *cfg, int from, int to) {
+static inline ZEND_ATTRIBUTE_PURE uint32_t scdf_edge(const zend_cfg *cfg, int from, int to) {
 	const zend_basic_block *to_block = cfg->blocks + to;
 	int i;
 
@@ -89,7 +89,7 @@ static inline uint32_t scdf_edge(const zend_cfg *cfg, int from, int to) {
 	ZEND_UNREACHABLE();
 }
 
-static inline bool scdf_is_edge_feasible(const scdf_ctx *scdf, int from, int to) {
+static inline ZEND_ATTRIBUTE_PURE bool scdf_is_edge_feasible(const scdf_ctx *scdf, int from, int to) {
 	uint32_t edge = scdf_edge(&scdf->ssa->cfg, from, to);
 	return zend_bitset_in(scdf->feasible_edges, edge);
 }

--- a/Zend/Optimizer/zend_func_info.h
+++ b/Zend/Optimizer/zend_func_info.h
@@ -56,7 +56,7 @@ BEGIN_EXTERN_C()
 
 extern ZEND_API int zend_func_info_rid;
 
-uint32_t zend_get_internal_func_info(
+ZEND_ATTRIBUTE_PURE uint32_t zend_get_internal_func_info(
 	const zend_function *callee_func, const zend_call_info *call_info, const zend_ssa *ssa);
 ZEND_API uint32_t zend_get_func_info(
 	const zend_call_info *call_info, const zend_ssa *ssa,

--- a/Zend/Optimizer/zend_inference.h
+++ b/Zend/Optimizer/zend_inference.h
@@ -222,7 +222,7 @@ ZEND_API void zend_ssa_find_false_dependencies(const zend_op_array *op_array, ze
 ZEND_API void zend_ssa_find_sccs(const zend_op_array *op_array, zend_ssa *ssa);
 ZEND_API int zend_ssa_inference(zend_arena **raena, const zend_op_array *op_array, const zend_script *script, zend_ssa *ssa, zend_long optimization_level);
 
-ZEND_API uint32_t zend_array_element_type(uint32_t t1, uint8_t op_type, int write, int insert);
+ZEND_API ZEND_ATTRIBUTE_CONST uint32_t zend_array_element_type(uint32_t t1, uint8_t op_type, int write, int insert);
 
 ZEND_API bool zend_inference_propagate_range(const zend_op_array *op_array, const zend_ssa *ssa, const zend_op *opline, const zend_ssa_op* ssa_op, int var, zend_ssa_range *tmp);
 
@@ -234,8 +234,8 @@ uint32_t zend_get_return_info_from_signature_only(
 		const zend_function *func, const zend_script *script,
 		zend_class_entry **ce, bool *ce_is_instanceof, bool use_tentative_return_info);
 
-ZEND_API bool zend_may_throw_ex(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_op_array *op_array, const zend_ssa *ssa, uint32_t t1, uint32_t t2);
-ZEND_API bool zend_may_throw(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_op_array *op_array, const zend_ssa *ssa);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_may_throw_ex(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_op_array *op_array, const zend_ssa *ssa, uint32_t t1, uint32_t t2);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_may_throw(const zend_op *opline, const zend_ssa_op *ssa_op, const zend_op_array *op_array, const zend_ssa *ssa);
 
 ZEND_API zend_result zend_update_type_info(
 	const zend_op_array *op_array, zend_ssa *ssa, const zend_script *script,

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -217,15 +217,15 @@ ZEND_API ZEND_ATTRIBUTE_MALLOC char * __zend_strdup(const char *s);
 #define pestrdup_rel(s, persistent) ((persistent)?strdup(s):estrdup_rel(s))
 
 ZEND_API zend_result zend_set_memory_limit(size_t memory_limit);
-ZEND_API bool zend_alloc_in_memory_limit_error_reporting(void);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_alloc_in_memory_limit_error_reporting(void);
 
 ZEND_API void start_memory_manager(void);
 ZEND_API void shutdown_memory_manager(bool silent, bool full_shutdown);
-ZEND_API bool is_zend_mm(void);
-ZEND_API bool is_zend_ptr(const void *ptr);
+ZEND_API ZEND_ATTRIBUTE_CONST bool is_zend_mm(void);
+ZEND_API ZEND_ATTRIBUTE_PURE bool is_zend_ptr(const void *ptr);
 
-ZEND_API size_t zend_memory_usage(bool real_usage);
-ZEND_API size_t zend_memory_peak_usage(bool real_usage);
+ZEND_API ZEND_ATTRIBUTE_PURE size_t zend_memory_usage(bool real_usage);
+ZEND_API ZEND_ATTRIBUTE_PURE size_t zend_memory_peak_usage(bool real_usage);
 ZEND_API void zend_memory_reset_peak_usage(void);
 
 /* fast cache for HashTables */
@@ -250,7 +250,7 @@ ZEND_API ZEND_ATTRIBUTE_MALLOC void*  ZEND_FASTCALL _zend_mm_alloc(zend_mm_heap 
 ZEND_API void   ZEND_FASTCALL _zend_mm_free(zend_mm_heap *heap, void *p ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
 ZEND_API void*  ZEND_FASTCALL _zend_mm_realloc(zend_mm_heap *heap, void *p, size_t size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
 ZEND_API void*  ZEND_FASTCALL _zend_mm_realloc2(zend_mm_heap *heap, void *p, size_t size, size_t copy_size ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
-ZEND_API size_t ZEND_FASTCALL _zend_mm_block_size(zend_mm_heap *heap, void *p ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
+ZEND_API ZEND_ATTRIBUTE_PURE size_t ZEND_FASTCALL _zend_mm_block_size(zend_mm_heap *heap, void *p ZEND_FILE_LINE_DC ZEND_FILE_LINE_ORIG_DC);
 
 #define zend_mm_alloc(heap, size)			_zend_mm_alloc((heap), (size) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
 #define zend_mm_free(heap, p)				_zend_mm_free((heap), (p) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
@@ -265,7 +265,7 @@ ZEND_API size_t ZEND_FASTCALL _zend_mm_block_size(zend_mm_heap *heap, void *p ZE
 #define zend_mm_block_size_rel(heap, p)		_zend_mm_block_size((heap), (p) ZEND_FILE_LINE_CC ZEND_FILE_LINE_EMPTY_CC)
 
 ZEND_API zend_mm_heap *zend_mm_set_heap(zend_mm_heap *new_heap);
-ZEND_API zend_mm_heap *zend_mm_get_heap(void);
+ZEND_API ZEND_ATTRIBUTE_PURE zend_mm_heap *zend_mm_get_heap(void);
 
 ZEND_API size_t zend_mm_gc(zend_mm_heap *heap);
 
@@ -273,7 +273,7 @@ ZEND_API size_t zend_mm_gc(zend_mm_heap *heap);
 #define ZEND_MM_CUSTOM_HEAP_STD   1
 #define ZEND_MM_CUSTOM_HEAP_DEBUG 2
 
-ZEND_API bool zend_mm_is_custom_heap(zend_mm_heap *new_heap);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_mm_is_custom_heap(zend_mm_heap *new_heap);
 ZEND_API void zend_mm_set_custom_handlers(zend_mm_heap *heap,
                                           void* (*_malloc)(size_t),
                                           void  (*_free)(void*),
@@ -309,7 +309,7 @@ struct _zend_mm_storage {
 	void *data;
 };
 
-ZEND_API zend_mm_storage *zend_mm_get_storage(zend_mm_heap *heap);
+ZEND_API ZEND_ATTRIBUTE_PURE zend_mm_storage *zend_mm_get_storage(zend_mm_heap *heap);
 ZEND_API zend_mm_heap *zend_mm_startup_ex(const zend_mm_handlers *handlers, void *data, size_t data_size);
 
 /*
@@ -398,7 +398,7 @@ static void apc_init_heap(void)
 */
 
 #ifdef ZTS
-size_t zend_mm_globals_size(void);
+ZEND_ATTRIBUTE_CONST size_t zend_mm_globals_size(void);
 #endif
 
 END_EXTERN_C()

--- a/Zend/zend_bitset.h
+++ b/Zend/zend_bitset.h
@@ -45,7 +45,7 @@ typedef zend_ulong *zend_bitset;
 	(zend_bitset)do_alloca((n) * ZEND_BITSET_ELM_SIZE, use_heap)
 
 /* Number of trailing zero bits (0x01 -> 0; 0x40 -> 6; 0x00 -> LEN) */
-static zend_always_inline int zend_ulong_ntz(zend_ulong num)
+static zend_always_inline ZEND_ATTRIBUTE_CONST int zend_ulong_ntz(zend_ulong num)
 {
 #if (defined(__GNUC__) || __has_builtin(__builtin_ctzl)) \
 	&& SIZEOF_ZEND_LONG == SIZEOF_LONG && defined(PHP_HAVE_BUILTIN_CTZL)
@@ -83,7 +83,7 @@ static zend_always_inline int zend_ulong_ntz(zend_ulong num)
 }
 
 /* Number of leading zero bits (Undefined for zero) */
-static zend_always_inline int zend_ulong_nlz(zend_ulong num)
+static zend_always_inline ZEND_ATTRIBUTE_CONST int zend_ulong_nlz(zend_ulong num)
 {
 #if (defined(__GNUC__) || __has_builtin(__builtin_clzl)) \
 	&& SIZEOF_ZEND_LONG == SIZEOF_LONG && defined(PHP_HAVE_BUILTIN_CLZL)
@@ -165,7 +165,7 @@ static inline void zend_bitset_fill(zend_bitset set, uint32_t len)
 	memset(set, 0xff, len * ZEND_BITSET_ELM_SIZE);
 }
 
-static inline bool zend_bitset_equal(zend_bitset set1, zend_bitset set2, uint32_t len)
+static inline ZEND_ATTRIBUTE_PURE bool zend_bitset_equal(zend_bitset set1, zend_bitset set2, uint32_t len)
 {
     return memcmp(set1, set2, len * ZEND_BITSET_ELM_SIZE) == 0;
 }
@@ -232,7 +232,7 @@ static inline bool zend_bitset_subset(zend_bitset set1, zend_bitset set2, uint32
 	return 1;
 }
 
-static inline int zend_bitset_first(zend_bitset set, uint32_t len)
+static inline ZEND_ATTRIBUTE_PURE int zend_bitset_first(zend_bitset set, uint32_t len)
 {
 	uint32_t i;
 
@@ -244,7 +244,7 @@ static inline int zend_bitset_first(zend_bitset set, uint32_t len)
 	return -1; /* empty set */
 }
 
-static inline int zend_bitset_last(zend_bitset set, uint32_t len)
+static inline ZEND_ATTRIBUTE_PURE int zend_bitset_last(zend_bitset set, uint32_t len)
 {
 	uint32_t i = len;
 

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1206,8 +1206,8 @@ END_EXTERN_C()
 /* The default value for CG(compiler_options) during eval() */
 #define ZEND_COMPILE_DEFAULT_FOR_EVAL			0
 
-ZEND_API bool zend_is_op_long_compatible(const zval *op);
-ZEND_API bool zend_binary_op_produces_error(uint32_t opcode, const zval *op1, const zval *op2);
-ZEND_API bool zend_unary_op_produces_error(uint32_t opcode, const zval *op);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_is_op_long_compatible(const zval *op);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_binary_op_produces_error(uint32_t opcode, const zval *op1, const zval *op2);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_unary_op_produces_error(uint32_t opcode, const zval *op);
 
 #endif /* ZEND_COMPILE_H */

--- a/Zend/zend_constants.h
+++ b/Zend/zend_constants.h
@@ -73,11 +73,11 @@ void free_zend_constant(zval *zv);
 void zend_startup_constants(void);
 void zend_shutdown_constants(void);
 void zend_register_standard_constants(void);
-ZEND_API bool zend_verify_const_access(zend_class_constant *c, zend_class_entry *ce);
-ZEND_API zval *zend_get_constant(zend_string *name);
-ZEND_API zval *zend_get_constant_str(const char *name, size_t name_len);
-ZEND_API zval *zend_get_constant_ex(zend_string *name, zend_class_entry *scope, uint32_t flags);
-ZEND_API zval *zend_get_class_constant_ex(zend_string *class_name, zend_string *constant_name, zend_class_entry *scope, uint32_t flags);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_verify_const_access(zend_class_constant *c, zend_class_entry *ce);
+ZEND_API ZEND_ATTRIBUTE_PURE zval *zend_get_constant(zend_string *name);
+ZEND_API ZEND_ATTRIBUTE_PURE zval *zend_get_constant_str(const char *name, size_t name_len);
+ZEND_API ZEND_ATTRIBUTE_PURE zval *zend_get_constant_ex(zend_string *name, zend_class_entry *scope, uint32_t flags);
+ZEND_API ZEND_ATTRIBUTE_PURE zval *zend_get_class_constant_ex(zend_string *class_name, zend_string *constant_name, zend_class_entry *scope, uint32_t flags);
 ZEND_API void zend_register_bool_constant(const char *name, size_t name_len, bool bval, int flags, int module_number);
 ZEND_API void zend_register_null_constant(const char *name, size_t name_len, int flags, int module_number);
 ZEND_API void zend_register_long_constant(const char *name, size_t name_len, zend_long lval, int flags, int module_number);
@@ -89,9 +89,9 @@ ZEND_API zend_result zend_register_constant(zend_constant *c);
 void zend_copy_constants(HashTable *target, HashTable *source);
 #endif
 
-ZEND_API zend_constant *_zend_get_special_const(const char *name, size_t name_len);
+ZEND_API ZEND_ATTRIBUTE_PURE zend_constant *_zend_get_special_const(const char *name, size_t name_len);
 
-static zend_always_inline zend_constant *zend_get_special_const(
+static zend_always_inline ZEND_ATTRIBUTE_PURE zend_constant *zend_get_special_const(
 		const char *name, size_t name_len) {
 	if (name_len == 4 || name_len == 5) {
 		return _zend_get_special_const(name, name_len);

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -80,7 +80,7 @@ static int zend_implement_throwable(zend_class_entry *interface, zend_class_entr
 }
 /* }}} */
 
-static inline zend_class_entry *i_get_exception_base(zend_object *object) /* {{{ */
+static inline ZEND_ATTRIBUTE_PURE zend_class_entry *i_get_exception_base(zend_object *object) /* {{{ */
 {
 	return instanceof_function(object->ce, zend_ce_exception) ? zend_ce_exception : zend_ce_error;
 }

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -47,13 +47,13 @@ ZEND_API ZEND_COLD void zend_throw_exception_internal(zend_object *exception);
 
 void zend_register_default_exception(void);
 
-ZEND_API zend_class_entry *zend_get_exception_base(zend_object *object);
+ZEND_API ZEND_ATTRIBUTE_PURE zend_class_entry *zend_get_exception_base(zend_object *object);
 
 /* Deprecated - Use zend_ce_exception directly instead */
-ZEND_API zend_class_entry *zend_exception_get_default(void);
+ZEND_API ZEND_ATTRIBUTE_CONST zend_class_entry *zend_exception_get_default(void);
 
 /* Deprecated - Use zend_ce_error_exception directly instead */
-ZEND_API zend_class_entry *zend_get_error_exception(void);
+ZEND_API ZEND_ATTRIBUTE_CONST zend_class_entry *zend_get_error_exception(void);
 
 ZEND_API void zend_register_default_classes(void);
 
@@ -77,8 +77,8 @@ ZEND_API ZEND_COLD zend_object *zend_create_unwind_exit(void);
 ZEND_API ZEND_COLD zend_object *zend_create_graceful_exit(void);
 ZEND_API ZEND_COLD void zend_throw_unwind_exit(void);
 ZEND_API ZEND_COLD void zend_throw_graceful_exit(void);
-ZEND_API bool zend_is_unwind_exit(const zend_object *ex);
-ZEND_API bool zend_is_graceful_exit(const zend_object *ex);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_is_unwind_exit(const zend_object *ex);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_is_graceful_exit(const zend_object *ex);
 
 #include "zend_globals.h"
 

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -174,15 +174,15 @@ ZEND_API void ZEND_FASTCALL zend_hash_del_bucket(HashTable *ht, Bucket *p);
 ZEND_API void ZEND_FASTCALL zend_hash_packed_del_val(HashTable *ht, zval *zv);
 
 /* Data retrieval */
-ZEND_API zval* ZEND_FASTCALL zend_hash_find(const HashTable *ht, zend_string *key);
-ZEND_API zval* ZEND_FASTCALL zend_hash_str_find(const HashTable *ht, const char *key, size_t len);
-ZEND_API zval* ZEND_FASTCALL zend_hash_index_find(const HashTable *ht, zend_ulong h);
-ZEND_API zval* ZEND_FASTCALL _zend_hash_index_find(const HashTable *ht, zend_ulong h);
+ZEND_API ZEND_ATTRIBUTE_PURE zval* ZEND_FASTCALL zend_hash_find(const HashTable *ht, zend_string *key);
+ZEND_API ZEND_ATTRIBUTE_PURE zval* ZEND_FASTCALL zend_hash_str_find(const HashTable *ht, const char *key, size_t len);
+ZEND_API ZEND_ATTRIBUTE_PURE zval* ZEND_FASTCALL zend_hash_index_find(const HashTable *ht, zend_ulong h);
+ZEND_API ZEND_ATTRIBUTE_PURE zval* ZEND_FASTCALL _zend_hash_index_find(const HashTable *ht, zend_ulong h);
 
 /* The same as zend_hash_find(), but hash value of the key must be already calculated. */
-ZEND_API zval* ZEND_FASTCALL zend_hash_find_known_hash(const HashTable *ht, const zend_string *key);
+ZEND_API ZEND_ATTRIBUTE_PURE zval* ZEND_FASTCALL zend_hash_find_known_hash(const HashTable *ht, const zend_string *key);
 
-static zend_always_inline zval *zend_hash_find_ex(const HashTable *ht, zend_string *key, bool known_hash)
+static ZEND_ATTRIBUTE_PURE zend_always_inline zval *zend_hash_find_ex(const HashTable *ht, zend_string *key, bool known_hash)
 {
 	if (known_hash) {
 		return zend_hash_find_known_hash(ht, key);
@@ -211,8 +211,8 @@ static zend_always_inline zval *zend_hash_find_ex(const HashTable *ht, zend_stri
 
 
 /* Find or add NULL, if doesn't exist */
-ZEND_API zval* ZEND_FASTCALL zend_hash_lookup(HashTable *ht, zend_string *key);
-ZEND_API zval* ZEND_FASTCALL zend_hash_index_lookup(HashTable *ht, zend_ulong h);
+ZEND_API ZEND_ATTRIBUTE_PURE zval* ZEND_FASTCALL zend_hash_lookup(HashTable *ht, zend_string *key);
+ZEND_API ZEND_ATTRIBUTE_PURE zval* ZEND_FASTCALL zend_hash_index_lookup(HashTable *ht, zend_ulong h);
 
 #define ZEND_HASH_INDEX_LOOKUP(_ht, _h, _ret) do { \
 		if (EXPECTED(HT_IS_PACKED(_ht))) { \
@@ -294,7 +294,7 @@ ZEND_API void  zend_hash_bucket_renum_swap(Bucket *p, Bucket *q);
 ZEND_API void  zend_hash_bucket_packed_swap(Bucket *p, Bucket *q);
 
 typedef int (*bucket_compare_func_t)(Bucket *a, Bucket *b);
-ZEND_API int   zend_hash_compare(HashTable *ht1, HashTable *ht2, compare_func_t compar, bool ordered);
+ZEND_API ZEND_ATTRIBUTE_PURE int   zend_hash_compare(HashTable *ht1, HashTable *ht2, compare_func_t compar, bool ordered);
 ZEND_API void  ZEND_FASTCALL zend_hash_sort_ex(HashTable *ht, sort_func_t sort_func, bucket_compare_func_t compare_func, bool renumber);
 ZEND_API zval* ZEND_FASTCALL zend_hash_minmax(const HashTable *ht, compare_func_t compar, uint32_t flag);
 

--- a/Zend/zend_multibyte.h
+++ b/Zend/zend_multibyte.h
@@ -61,17 +61,17 @@ ZEND_API extern const zend_encoding *zend_multibyte_encoding_utf8;
 /* multibyte utility functions */
 ZEND_API zend_result zend_multibyte_set_functions(const zend_multibyte_functions *functions);
 ZEND_API void zend_multibyte_restore_functions(void);
-ZEND_API const zend_multibyte_functions *zend_multibyte_get_functions(void);
+ZEND_API ZEND_ATTRIBUTE_PURE const zend_multibyte_functions *zend_multibyte_get_functions(void);
 
-ZEND_API const zend_encoding *zend_multibyte_fetch_encoding(const char *name);
-ZEND_API const char *zend_multibyte_get_encoding_name(const zend_encoding *encoding);
-ZEND_API int zend_multibyte_check_lexer_compatibility(const zend_encoding *encoding);
+ZEND_API ZEND_ATTRIBUTE_PURE const zend_encoding *zend_multibyte_fetch_encoding(const char *name);
+ZEND_API ZEND_ATTRIBUTE_PURE const char *zend_multibyte_get_encoding_name(const zend_encoding *encoding);
+ZEND_API ZEND_ATTRIBUTE_PURE int zend_multibyte_check_lexer_compatibility(const zend_encoding *encoding);
 ZEND_API const zend_encoding *zend_multibyte_encoding_detector(const unsigned char *string, size_t length, const zend_encoding **list, size_t list_size);
 ZEND_API size_t zend_multibyte_encoding_converter(unsigned char **to, size_t *to_length, const unsigned char *from, size_t from_length, const zend_encoding *encoding_to, const zend_encoding *encoding_from);
 ZEND_API int zend_multibyte_parse_encoding_list(const char *encoding_list, size_t encoding_list_len, const zend_encoding ***return_list, size_t *return_size, bool persistent);
 
-ZEND_API const zend_encoding *zend_multibyte_get_internal_encoding(void);
-ZEND_API const zend_encoding *zend_multibyte_get_script_encoding(void);
+ZEND_API ZEND_ATTRIBUTE_PURE const zend_encoding *zend_multibyte_get_internal_encoding(void);
+ZEND_API ZEND_ATTRIBUTE_PURE const zend_encoding *zend_multibyte_get_script_encoding(void);
 ZEND_API int zend_multibyte_set_script_encoding(const zend_encoding **encoding_list, size_t encoding_list_size);
 ZEND_API int zend_multibyte_set_internal_encoding(const zend_encoding *encoding);
 ZEND_API zend_result zend_multibyte_set_script_encoding_by_string(const char *new_value, size_t new_value_length);

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -94,7 +94,7 @@ static zend_always_inline void *zend_object_alloc(size_t obj_size, zend_class_en
 	return obj;
 }
 
-static inline zend_property_info *zend_get_property_info_for_slot(zend_object *obj, zval *slot)
+static inline ZEND_ATTRIBUTE_PURE zend_property_info *zend_get_property_info_for_slot(zend_object *obj, zval *slot)
 {
 	zend_property_info **table = obj->ce->properties_info_table;
 	intptr_t prop_num = slot - obj->properties_table;
@@ -103,7 +103,7 @@ static inline zend_property_info *zend_get_property_info_for_slot(zend_object *o
 }
 
 /* Helper for cases where we're only interested in property info of typed properties. */
-static inline zend_property_info *zend_get_typed_property_info_for_slot(zend_object *obj, zval *slot)
+static inline ZEND_ATTRIBUTE_PURE zend_property_info *zend_get_typed_property_info_for_slot(zend_object *obj, zval *slot)
 {
 	zend_property_info *prop_info = zend_get_property_info_for_slot(obj, slot);
 	if (prop_info && ZEND_TYPE_IS_SET(prop_info->type)) {

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -57,7 +57,7 @@ ZEND_API zend_result ZEND_FASTCALL shift_left_function(zval *result, zval *op1, 
 ZEND_API zend_result ZEND_FASTCALL shift_right_function(zval *result, zval *op1, zval *op2);
 ZEND_API zend_result ZEND_FASTCALL concat_function(zval *result, zval *op1, zval *op2);
 
-ZEND_API bool ZEND_FASTCALL zend_is_identical(const zval *op1, const zval *op2);
+ZEND_API ZEND_ATTRIBUTE_PURE bool ZEND_FASTCALL zend_is_identical(const zval *op1, const zval *op2);
 
 ZEND_API zend_result ZEND_FASTCALL is_equal_function(zval *result, zval *op1, zval *op2);
 ZEND_API zend_result ZEND_FASTCALL is_identical_function(zval *result, zval *op1, zval *op2);
@@ -66,8 +66,8 @@ ZEND_API zend_result ZEND_FASTCALL is_not_equal_function(zval *result, zval *op1
 ZEND_API zend_result ZEND_FASTCALL is_smaller_function(zval *result, zval *op1, zval *op2);
 ZEND_API zend_result ZEND_FASTCALL is_smaller_or_equal_function(zval *result, zval *op1, zval *op2);
 
-ZEND_API bool ZEND_FASTCALL zend_class_implements_interface(const zend_class_entry *class_ce, const zend_class_entry *interface_ce);
-ZEND_API bool ZEND_FASTCALL instanceof_function_slow(const zend_class_entry *instance_ce, const zend_class_entry *ce);
+ZEND_API ZEND_ATTRIBUTE_PURE bool ZEND_FASTCALL zend_class_implements_interface(const zend_class_entry *class_ce, const zend_class_entry *interface_ce);
+ZEND_API ZEND_ATTRIBUTE_PURE bool ZEND_FASTCALL instanceof_function_slow(const zend_class_entry *instance_ce, const zend_class_entry *ce);
 
 static zend_always_inline bool instanceof_function(
 		const zend_class_entry *instance_ce, const zend_class_entry *ce) {
@@ -92,8 +92,8 @@ static zend_always_inline bool instanceof_function(
 ZEND_API uint8_t ZEND_FASTCALL _is_numeric_string_ex(const char *str, size_t length, zend_long *lval,
 	double *dval, bool allow_errors, int *oflow_info, bool *trailing_data);
 
-ZEND_API const char* ZEND_FASTCALL zend_memnstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
-ZEND_API const char* ZEND_FASTCALL zend_memnrstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
+ZEND_API ZEND_ATTRIBUTE_PURE const char* ZEND_FASTCALL zend_memnstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
+ZEND_API ZEND_ATTRIBUTE_PURE const char* ZEND_FASTCALL zend_memnrstr_ex(const char *haystack, const char *needle, size_t needle_len, const char *end);
 
 #if SIZEOF_ZEND_LONG == 4
 #	define ZEND_DOUBLE_FITS_LONG(d) (!((d) > (double)ZEND_LONG_MAX || (d) < (double)ZEND_LONG_MIN))
@@ -102,9 +102,9 @@ ZEND_API const char* ZEND_FASTCALL zend_memnrstr_ex(const char *haystack, const 
 #	define ZEND_DOUBLE_FITS_LONG(d) (!((d) >= (double)ZEND_LONG_MAX || (d) < (double)ZEND_LONG_MIN))
 #endif
 
-ZEND_API zend_long ZEND_FASTCALL zend_dval_to_lval_slow(double d);
+ZEND_API ZEND_ATTRIBUTE_CONST zend_long ZEND_FASTCALL zend_dval_to_lval_slow(double d);
 
-static zend_always_inline zend_long zend_dval_to_lval(double d)
+static zend_always_inline ZEND_ATTRIBUTE_CONST zend_long zend_dval_to_lval(double d)
 {
 	if (UNEXPECTED(!zend_finite(d)) || UNEXPECTED(zend_isnan(d))) {
 		return 0;
@@ -115,7 +115,7 @@ static zend_always_inline zend_long zend_dval_to_lval(double d)
 }
 
 /* Used to convert a string float to integer during an (int) cast */
-static zend_always_inline zend_long zend_dval_to_lval_cap(double d)
+static zend_always_inline ZEND_ATTRIBUTE_CONST zend_long zend_dval_to_lval_cap(double d)
 {
 	if (UNEXPECTED(!zend_finite(d)) || UNEXPECTED(zend_isnan(d))) {
 		return 0;
@@ -160,7 +160,7 @@ static zend_always_inline uint8_t is_numeric_string(const char *str, size_t leng
 
 ZEND_API uint8_t ZEND_FASTCALL is_numeric_str_function(const zend_string *str, zend_long *lval, double *dval);
 
-static zend_always_inline const char *
+static zend_always_inline ZEND_ATTRIBUTE_PURE const char *
 zend_memnstr(const char *haystack, const char *needle, size_t needle_len, const char *end)
 {
 	const char *p = haystack;
@@ -201,7 +201,7 @@ zend_memnstr(const char *haystack, const char *needle, size_t needle_len, const 
 	}
 }
 
-static zend_always_inline const void *zend_memrchr(const void *s, int c, size_t n)
+static zend_always_inline ZEND_ATTRIBUTE_PURE const void *zend_memrchr(const void *s, int c, size_t n)
 {
 #if defined(HAVE_MEMRCHR) && !defined(i386)
 	/* On x86 memrchr() doesn't use SSE/AVX, so inlined version is faster */
@@ -222,7 +222,7 @@ static zend_always_inline const void *zend_memrchr(const void *s, int c, size_t 
 }
 
 
-static zend_always_inline const char *
+static zend_always_inline ZEND_ATTRIBUTE_PURE const char *
 zend_memnrstr(const char *haystack, const char *needle, size_t needle_len, const char *end)
 {
     const char *p = end;
@@ -449,17 +449,17 @@ static zend_always_inline zend_string* zend_string_toupper(zend_string *str) {
 	return zend_string_toupper_ex(str, false);
 }
 
-ZEND_API int ZEND_FASTCALL zend_binary_zval_strcmp(zval *s1, zval *s2);
-ZEND_API int ZEND_FASTCALL zend_binary_zval_strncmp(zval *s1, zval *s2, zval *s3);
-ZEND_API int ZEND_FASTCALL zend_binary_strcmp(const char *s1, size_t len1, const char *s2, size_t len2);
-ZEND_API int ZEND_FASTCALL zend_binary_strncmp(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
-ZEND_API int ZEND_FASTCALL zend_binary_strcasecmp(const char *s1, size_t len1, const char *s2, size_t len2);
-ZEND_API int ZEND_FASTCALL zend_binary_strncasecmp(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
-ZEND_API int ZEND_FASTCALL zend_binary_strcasecmp_l(const char *s1, size_t len1, const char *s2, size_t len2);
-ZEND_API int ZEND_FASTCALL zend_binary_strncasecmp_l(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zend_binary_zval_strcmp(zval *s1, zval *s2);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zend_binary_zval_strncmp(zval *s1, zval *s2, zval *s3);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zend_binary_strcmp(const char *s1, size_t len1, const char *s2, size_t len2);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zend_binary_strncmp(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zend_binary_strcasecmp(const char *s1, size_t len1, const char *s2, size_t len2);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zend_binary_strncasecmp(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zend_binary_strcasecmp_l(const char *s1, size_t len1, const char *s2, size_t len2);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zend_binary_strncasecmp_l(const char *s1, size_t len1, const char *s2, size_t len2, size_t length);
 
-ZEND_API bool ZEND_FASTCALL zendi_smart_streq(zend_string *s1, zend_string *s2);
-ZEND_API int ZEND_FASTCALL zendi_smart_strcmp(zend_string *s1, zend_string *s2);
+ZEND_API ZEND_ATTRIBUTE_PURE bool ZEND_FASTCALL zendi_smart_streq(zend_string *s1, zend_string *s2);
+ZEND_API ZEND_ATTRIBUTE_PURE int ZEND_FASTCALL zendi_smart_strcmp(zend_string *s1, zend_string *s2);
 ZEND_API int ZEND_FASTCALL zend_compare_symbol_tables(HashTable *ht1, HashTable *ht2);
 ZEND_API int ZEND_FASTCALL zend_compare_arrays(zval *a1, zval *a2);
 ZEND_API int ZEND_FASTCALL zend_compare_objects(zval *o1, zval *o2);
@@ -929,7 +929,7 @@ static zend_always_inline bool zend_strnieq(const char *ptr1, const char *ptr2, 
 	return 1;
 }
 
-static zend_always_inline const char *
+static zend_always_inline ZEND_ATTRIBUTE_PURE const char *
 zend_memnistr(const char *haystack, const char *needle, size_t needle_len, const char *end)
 {
 	ZEND_ASSERT(end >= haystack);

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -237,6 +237,12 @@ char *alloca();
 # define ZEND_ATTRIBUTE_CONST
 #endif
 
+#if ZEND_GCC_VERSION >= 3000 || __has_attribute(pure)
+# define ZEND_ATTRIBUTE_PURE __attribute__((pure))
+#else
+# define ZEND_ATTRIBUTE_PURE
+#endif
+
 #if ZEND_GCC_VERSION >= 2007 || __has_attribute(format)
 # define ZEND_ATTRIBUTE_FORMAT(type, idx, first) __attribute__ ((format(type, idx, first)))
 #else

--- a/Zend/zend_ptr_stack.h
+++ b/Zend/zend_ptr_stack.h
@@ -39,7 +39,7 @@ ZEND_API void zend_ptr_stack_destroy(zend_ptr_stack *stack);
 ZEND_API void zend_ptr_stack_apply(zend_ptr_stack *stack, void (*func)(void *));
 ZEND_API void zend_ptr_stack_reverse_apply(zend_ptr_stack *stack, void (*func)(void *));
 ZEND_API void zend_ptr_stack_clean(zend_ptr_stack *stack, void (*func)(void *), bool free_elements);
-ZEND_API int zend_ptr_stack_num_elements(zend_ptr_stack *stack);
+ZEND_API ZEND_ATTRIBUTE_PURE int zend_ptr_stack_num_elements(zend_ptr_stack *stack);
 END_EXTERN_C()
 
 #define ZEND_PTR_STACK_RESIZE_IF_NEEDED(stack, count)		\

--- a/Zend/zend_stack.h
+++ b/Zend/zend_stack.h
@@ -36,13 +36,13 @@ typedef enum {
 BEGIN_EXTERN_C()
 ZEND_API void zend_stack_init(zend_stack *stack, int size);
 ZEND_API int zend_stack_push(zend_stack *stack, const void *element);
-ZEND_API void *zend_stack_top(const zend_stack *stack);
+ZEND_API ZEND_ATTRIBUTE_PURE void *zend_stack_top(const zend_stack *stack);
 ZEND_API void zend_stack_del_top(zend_stack *stack);
-ZEND_API int zend_stack_int_top(const zend_stack *stack);
-ZEND_API bool zend_stack_is_empty(const zend_stack *stack);
+ZEND_API ZEND_ATTRIBUTE_PURE int zend_stack_int_top(const zend_stack *stack);
+ZEND_API ZEND_ATTRIBUTE_PURE bool zend_stack_is_empty(const zend_stack *stack);
 ZEND_API void zend_stack_destroy(zend_stack *stack);
-ZEND_API void *zend_stack_base(const zend_stack *stack);
-ZEND_API int zend_stack_count(const zend_stack *stack);
+ZEND_API ZEND_ATTRIBUTE_PURE void *zend_stack_base(const zend_stack *stack);
+ZEND_API ZEND_ATTRIBUTE_PURE int zend_stack_count(const zend_stack *stack);
 ZEND_API void zend_stack_apply(zend_stack *stack, int type, int (*apply_function)(void *element));
 ZEND_API void zend_stack_apply_with_argument(zend_stack *stack, zend_stack_apply_direction type, int (*apply_function)(void *element, void *arg), void *arg);
 ZEND_API void zend_stack_clean(zend_stack *stack, void (*func)(void *), bool free_elements);

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -34,7 +34,7 @@ ZEND_API extern zend_string_init_interned_func_t zend_string_init_interned;
 ZEND_API extern zend_string_init_existing_interned_func_t zend_string_init_existing_interned;
 
 ZEND_API zend_ulong ZEND_FASTCALL zend_string_hash_func(zend_string *str);
-ZEND_API zend_ulong ZEND_FASTCALL zend_hash_func(const char *str, size_t len);
+ZEND_API ZEND_ATTRIBUTE_PURE zend_ulong ZEND_FASTCALL zend_hash_func(const char *str, size_t len);
 ZEND_API zend_string* ZEND_FASTCALL zend_interned_string_find_permanent(zend_string *str);
 
 ZEND_API zend_string *zend_string_concat2(
@@ -361,28 +361,28 @@ static zend_always_inline void zend_string_release_ex(zend_string *s, bool persi
 	}
 }
 
-static zend_always_inline bool zend_string_equals_cstr(const zend_string *s1, const char *s2, size_t s2_length)
+static zend_always_inline ZEND_ATTRIBUTE_PURE bool zend_string_equals_cstr(const zend_string *s1, const char *s2, size_t s2_length)
 {
 	return ZSTR_LEN(s1) == s2_length && !memcmp(ZSTR_VAL(s1), s2, s2_length);
 }
 
 #if defined(__GNUC__) && (defined(__i386__) || (defined(__x86_64__) && !defined(__ILP32__)))
 BEGIN_EXTERN_C()
-ZEND_API bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const zend_string *s2);
+ZEND_API ZEND_ATTRIBUTE_PURE bool ZEND_FASTCALL zend_string_equal_val(const zend_string *s1, const zend_string *s2);
 END_EXTERN_C()
 #else
-static zend_always_inline bool zend_string_equal_val(const zend_string *s1, const zend_string *s2)
+static zend_always_inline ZEND_ATTRIBUTE_PURE bool zend_string_equal_val(const zend_string *s1, const zend_string *s2)
 {
 	return !memcmp(ZSTR_VAL(s1), ZSTR_VAL(s2), ZSTR_LEN(s1));
 }
 #endif
 
-static zend_always_inline bool zend_string_equal_content(const zend_string *s1, const zend_string *s2)
+static zend_always_inline ZEND_ATTRIBUTE_PURE bool zend_string_equal_content(const zend_string *s1, const zend_string *s2)
 {
 	return ZSTR_LEN(s1) == ZSTR_LEN(s2) && zend_string_equal_val(s1, s2);
 }
 
-static zend_always_inline bool zend_string_equals(const zend_string *s1, const zend_string *s2)
+static zend_always_inline ZEND_ATTRIBUTE_PURE bool zend_string_equals(const zend_string *s1, const zend_string *s2)
 {
 	return s1 == s2 || zend_string_equal_content(s1, s2);
 }
@@ -396,12 +396,12 @@ static zend_always_inline bool zend_string_equals(const zend_string *s1, const z
 #define zend_string_equals_literal(str, literal) \
 	zend_string_equals_cstr(str, "" literal, sizeof(literal) - 1)
 
-static zend_always_inline bool zend_string_starts_with_cstr(const zend_string *str, const char *prefix, size_t prefix_length)
+static zend_always_inline ZEND_ATTRIBUTE_PURE bool zend_string_starts_with_cstr(const zend_string *str, const char *prefix, size_t prefix_length)
 {
 	return ZSTR_LEN(str) >= prefix_length && !memcmp(ZSTR_VAL(str), prefix, prefix_length);
 }
 
-static zend_always_inline bool zend_string_starts_with(const zend_string *str, const zend_string *prefix)
+static zend_always_inline ZEND_ATTRIBUTE_PURE bool zend_string_starts_with(const zend_string *str, const zend_string *prefix)
 {
 	return zend_string_starts_with_cstr(str, ZSTR_VAL(prefix), ZSTR_LEN(prefix));
 }
@@ -442,7 +442,7 @@ static zend_always_inline bool zend_string_starts_with(const zend_string *str, c
  *                  -- Ralf S. Engelschall <rse@engelschall.com>
  */
 
-static zend_always_inline zend_ulong zend_inline_hash_func(const char *str, size_t len)
+static zend_always_inline ZEND_ATTRIBUTE_PURE zend_ulong zend_inline_hash_func(const char *str, size_t len)
 {
 	zend_ulong hash = Z_UL(5381);
 

--- a/Zend/zend_virtual_cwd.c
+++ b/Zend/zend_virtual_cwd.c
@@ -434,7 +434,7 @@ static inline void realpath_cache_add(const char *path, size_t path_len, const c
 }
 /* }}} */
 
-static inline realpath_cache_bucket* realpath_cache_find(const char *path, size_t path_len, time_t t) /* {{{ */
+static inline ZEND_ATTRIBUTE_PURE realpath_cache_bucket* realpath_cache_find(const char *path, size_t path_len, time_t t) /* {{{ */
 {
 	zend_ulong key = realpath_cache_key(path, path_len);
 	zend_ulong n = key % (sizeof(CWDG(realpath_cache)) / sizeof(CWDG(realpath_cache)[0]));

--- a/Zend/zend_virtual_cwd.h
+++ b/Zend/zend_virtual_cwd.h
@@ -176,7 +176,7 @@ CWD_API int virtual_mkdir(const char *pathname, mode_t mode);
 CWD_API int virtual_rmdir(const char *pathname);
 CWD_API DIR *virtual_opendir(const char *pathname);
 CWD_API FILE *virtual_popen(const char *command, const char *type);
-CWD_API int virtual_access(const char *pathname, int mode);
+CWD_API ZEND_ATTRIBUTE_PURE int virtual_access(const char *pathname, int mode);
 
 #if HAVE_UTIME
 CWD_API int virtual_utime(const char *filename, struct utimbuf *buf);
@@ -237,10 +237,10 @@ extern virtual_cwd_globals cwd_globals;
 
 CWD_API void realpath_cache_clean(void);
 CWD_API void realpath_cache_del(const char *path, size_t path_len);
-CWD_API realpath_cache_bucket* realpath_cache_lookup(const char *path, size_t path_len, time_t t);
+CWD_API ZEND_ATTRIBUTE_PURE realpath_cache_bucket* realpath_cache_lookup(const char *path, size_t path_len, time_t t);
 CWD_API zend_long realpath_cache_size(void);
 CWD_API zend_long realpath_cache_max_buckets(void);
-CWD_API realpath_cache_bucket** realpath_cache_get_buckets(void);
+CWD_API ZEND_ATTRIBUTE_PURE realpath_cache_bucket** realpath_cache_get_buckets(void);
 
 #ifdef CWD_EXPORTS
 extern void virtual_cwd_main_cwd_init(uint8_t);

--- a/Zend/zend_vm_gen.php
+++ b/Zend/zend_vm_gen.php
@@ -2350,9 +2350,9 @@ function gen_vm_opcodes_header(
     $str .= "#define ZEND_VM_OP2_FLAGS(flags) ((flags >> 8) & 0xff)\n";
     $str .= "\n";
     $str .= "BEGIN_EXTERN_C()\n\n";
-    $str .= "ZEND_API const char* ZEND_FASTCALL zend_get_opcode_name(uint8_t opcode);\n";
-    $str .= "ZEND_API uint32_t ZEND_FASTCALL zend_get_opcode_flags(uint8_t opcode);\n";
-    $str .= "ZEND_API uint8_t zend_get_opcode_id(const char *name, size_t length);\n\n";
+    $str .= "ZEND_API ZEND_ATTRIBUTE_CONST const char* ZEND_FASTCALL zend_get_opcode_name(uint8_t opcode);\n";
+    $str .= "ZEND_API ZEND_ATTRIBUTE_CONST uint32_t ZEND_FASTCALL zend_get_opcode_flags(uint8_t opcode);\n";
+    $str .= "ZEND_API ZEND_ATTRIBUTE_PURE uint8_t zend_get_opcode_id(const char *name, size_t length);\n\n";
     $str .= "END_EXTERN_C()\n\n";
 
     $code_len = strlen((string) $max_opcode);

--- a/Zend/zend_vm_opcodes.h
+++ b/Zend/zend_vm_opcodes.h
@@ -77,9 +77,9 @@
 
 BEGIN_EXTERN_C()
 
-ZEND_API const char* ZEND_FASTCALL zend_get_opcode_name(uint8_t opcode);
-ZEND_API uint32_t ZEND_FASTCALL zend_get_opcode_flags(uint8_t opcode);
-ZEND_API uint8_t zend_get_opcode_id(const char *name, size_t length);
+ZEND_API ZEND_ATTRIBUTE_CONST const char* ZEND_FASTCALL zend_get_opcode_name(uint8_t opcode);
+ZEND_API ZEND_ATTRIBUTE_CONST uint32_t ZEND_FASTCALL zend_get_opcode_flags(uint8_t opcode);
+ZEND_API ZEND_ATTRIBUTE_PURE uint8_t zend_get_opcode_id(const char *name, size_t length);
 
 END_EXTERN_C()
 

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -731,7 +731,7 @@ static zend_always_inline const zend_op* zend_jit_trace_get_exit_opline(zend_jit
 	return NULL;
 }
 
-static inline bool zend_jit_may_be_modified(const zend_function *func, const zend_op_array *called_from)
+static inline bool ZEND_ATTRIBUTE_PURE zend_jit_may_be_modified(const zend_function *func, const zend_op_array *called_from)
 {
 	if (func->type == ZEND_INTERNAL_FUNCTION) {
 #ifdef _WIN32
@@ -751,7 +751,7 @@ static inline bool zend_jit_may_be_modified(const zend_function *func, const zen
 	return 1;
 }
 
-static zend_always_inline bool zend_jit_may_be_polymorphic_call(const zend_op *opline)
+static zend_always_inline ZEND_ATTRIBUTE_PURE bool zend_jit_may_be_polymorphic_call(const zend_op *opline)
 {
 	if (opline->opcode == ZEND_INIT_FCALL
 	 || opline->opcode == ZEND_INIT_FCALL_BY_NAME
@@ -835,7 +835,7 @@ static zend_always_inline uint32_t concrete_type(uint32_t value_type)
 	return floor_log2(value_type & (MAY_BE_ANY|MAY_BE_UNDEF));
 }
 
-static zend_always_inline bool is_signed(double d)
+static zend_always_inline ZEND_ATTRIBUTE_CONST bool is_signed(double d)
 {
 	return (((unsigned char*)&d)[sizeof(double)-1] & 0x80) != 0;
 }

--- a/ext/opcache/zend_shared_alloc.h
+++ b/ext/opcache/zend_shared_alloc.h
@@ -183,15 +183,15 @@ void zend_shared_alloc_safe_unlock(void);
 void zend_shared_alloc_init_xlat_table(void);
 void zend_shared_alloc_destroy_xlat_table(void);
 void zend_shared_alloc_clear_xlat_table(void);
-uint32_t zend_shared_alloc_checkpoint_xlat_table(void);
+ZEND_ATTRIBUTE_PURE uint32_t zend_shared_alloc_checkpoint_xlat_table(void);
 void zend_shared_alloc_restore_xlat_table(uint32_t checkpoint);
 void zend_shared_alloc_register_xlat_entry(const void *key, const void *value);
-void *zend_shared_alloc_get_xlat_entry(const void *key);
+ZEND_ATTRIBUTE_PURE void *zend_shared_alloc_get_xlat_entry(const void *key);
 
 size_t zend_shared_alloc_get_free_memory(void);
 void zend_shared_alloc_save_state(void);
 void zend_shared_alloc_restore_state(void);
-const char *zend_accel_get_shared_model(void);
+ZEND_ATTRIBUTE_PURE const char *zend_accel_get_shared_model(void);
 
 /**
  * Memory write protection

--- a/ext/standard/basic_functions.h
+++ b/ext/standard/basic_functions.h
@@ -121,10 +121,10 @@ PHPAPI extern int basic_globals_id;
 PHPAPI extern php_basic_globals basic_globals;
 #endif
 
-PHPAPI zend_string *php_getenv(const char *str, size_t str_len);
+PHPAPI ZEND_ATTRIBUTE_PURE zend_string *php_getenv(const char *str, size_t str_len);
 
-PHPAPI double php_get_nan(void);
-PHPAPI double php_get_inf(void);
+PHPAPI ZEND_ATTRIBUTE_CONST double php_get_nan(void);
+PHPAPI ZEND_ATTRIBUTE_CONST double php_get_inf(void);
 
 typedef struct _php_shutdown_function_entry {
 	zend_fcall_info fci;

--- a/ext/standard/crc32.h
+++ b/ext/standard/crc32.h
@@ -26,7 +26,7 @@
 #define php_crc32_bulk_init() (0 ^ 0xffffffff)
 #define php_crc32_bulk_end(c) ((c) ^ 0xffffffff)
 
-PHPAPI uint32_t php_crc32_bulk_update(uint32_t crc, const char *p, size_t nr);
+PHPAPI ZEND_ATTRIBUTE_PURE uint32_t php_crc32_bulk_update(uint32_t crc, const char *p, size_t nr);
 
 /* Return FAILURE if stream reading fail */
 PHPAPI int php_crc32_stream_bulk_update(uint32_t *crc, php_stream *fp, size_t nr);

--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -36,7 +36,7 @@ PHPAPI PHP_FUNCTION(fpassthru);
 
 PHP_MINIT_FUNCTION(user_streams);
 
-PHPAPI int php_le_stream_context(void);
+PHPAPI ZEND_ATTRIBUTE_PURE int php_le_stream_context(void);
 PHPAPI int php_set_sock_blocking(php_socket_t socketd, int block);
 PHPAPI int php_copy_file(const char *src, const char *dest);
 PHPAPI int php_copy_file_ex(const char *src, const char *dest, int src_chk);

--- a/ext/standard/php_string.h
+++ b/ext/standard/php_string.h
@@ -32,7 +32,7 @@ PHP_MINIT_FUNCTION(string_intrin);
 	strnatcmp_ex(a, strlen(a), b, strlen(b), 0)
 #define strnatcasecmp(a, b) \
 	strnatcmp_ex(a, strlen(a), b, strlen(b), 1)
-PHPAPI int strnatcmp_ex(char const *a, size_t a_len, char const *b, size_t b_len, bool is_case_insensitive);
+PHPAPI ZEND_ATTRIBUTE_PURE int strnatcmp_ex(char const *a, size_t a_len, char const *b, size_t b_len, bool is_case_insensitive);
 PHPAPI struct lconv *localeconv_r(struct lconv *out);
 PHPAPI char *php_strtoupper(char *s, size_t len);
 PHPAPI char *php_strtolower(char *s, size_t len);
@@ -46,7 +46,7 @@ PHPAPI zend_string *php_addcslashes(zend_string *str, const char *what, size_t w
 PHPAPI void php_stripcslashes(zend_string *str);
 PHPAPI zend_string *php_basename(const char *s, size_t len, const char *suffix, size_t sufflen);
 PHPAPI size_t php_dirname(char *str, size_t len);
-PHPAPI char *php_stristr(char *s, char *t, size_t s_len, size_t t_len);
+PHPAPI ZEND_ATTRIBUTE_PURE char *php_stristr(char *s, char *t, size_t s_len, size_t t_len);
 PHPAPI zend_string *php_str_to_str(const char *haystack, size_t length, const char *needle,
 		size_t needle_len, const char *str, size_t str_len);
 PHPAPI zend_string *php_trim(zend_string *str, const char *what, size_t what_len, int mode);
@@ -55,12 +55,12 @@ PHPAPI size_t php_strip_tags_ex(char *rbuf, size_t len, const char *allow, size_
 PHPAPI void php_implode(const zend_string *delim, HashTable *arr, zval *return_value);
 PHPAPI void php_explode(const zend_string *delim, zend_string *str, zval *return_value, zend_long limit);
 
-PHPAPI size_t php_strspn(const char *s1, const char *s2, const char *s1_end, const char *s2_end);
-PHPAPI size_t php_strcspn(const char *s1, const char *s2, const char *s1_end, const char *s2_end);
+PHPAPI ZEND_ATTRIBUTE_PURE size_t php_strspn(const char *s1, const char *s2, const char *s1_end, const char *s2_end);
+PHPAPI ZEND_ATTRIBUTE_PURE size_t php_strcspn(const char *s1, const char *s2, const char *s1_end, const char *s2_end);
 
-PHPAPI int string_natural_compare_function_ex(zval *result, zval *op1, zval *op2, bool case_insensitive);
-PHPAPI int string_natural_compare_function(zval *result, zval *op1, zval *op2);
-PHPAPI int string_natural_case_compare_function(zval *result, zval *op1, zval *op2);
+PHPAPI ZEND_ATTRIBUTE_PURE int string_natural_compare_function_ex(zval *result, zval *op1, zval *op2, bool case_insensitive);
+PHPAPI ZEND_ATTRIBUTE_PURE int string_natural_compare_function(zval *result, zval *op1, zval *op2);
+PHPAPI ZEND_ATTRIBUTE_PURE int string_natural_case_compare_function(zval *result, zval *op1, zval *op2);
 
 PHPAPI bool php_binary_string_shuffle(const php_random_algo *algo, php_random_status *status, char *str, zend_long len);
 

--- a/main/SAPI.h
+++ b/main/SAPI.h
@@ -195,10 +195,10 @@ SAPI_API int sapi_register_treat_data(void (*treat_data)(int arg, char *str, zva
 SAPI_API int sapi_register_input_filter(unsigned int (*input_filter)(int arg, const char *var, char **val, size_t val_len, size_t *new_val_len), unsigned int (*input_filter_init)(void));
 
 SAPI_API int sapi_flush(void);
-SAPI_API zend_stat_t *sapi_get_stat(void);
-SAPI_API char *sapi_getenv(const char *name, size_t name_len);
+SAPI_API ZEND_ATTRIBUTE_PURE zend_stat_t *sapi_get_stat(void);
+SAPI_API ZEND_ATTRIBUTE_PURE char *sapi_getenv(const char *name, size_t name_len);
 
-SAPI_API char *sapi_get_default_content_type(void);
+SAPI_API ZEND_ATTRIBUTE_PURE char *sapi_get_default_content_type(void);
 SAPI_API void sapi_get_default_content_type_header(sapi_header_struct *default_header);
 SAPI_API size_t sapi_apply_default_charset(char **mimetype, size_t len);
 SAPI_API void sapi_activate_headers_only(void);
@@ -208,7 +208,7 @@ SAPI_API int sapi_force_http_10(void);
 
 SAPI_API int sapi_get_target_uid(uid_t *);
 SAPI_API int sapi_get_target_gid(gid_t *);
-SAPI_API double sapi_get_request_time(void);
+SAPI_API ZEND_ATTRIBUTE_PURE double sapi_get_request_time(void);
 SAPI_API void sapi_terminate_process(void);
 END_EXTERN_C()
 

--- a/main/php.h
+++ b/main/php.h
@@ -354,11 +354,11 @@ PHPAPI extern int (*php_register_internal_extensions_func)(void);
 PHPAPI int php_register_internal_extensions(void);
 PHPAPI void php_register_pre_request_shutdown(void (*func)(void *), void *userdata);
 PHPAPI void php_com_initialize(void);
-PHPAPI char *php_get_current_user(void);
+PHPAPI ZEND_ATTRIBUTE_PURE char *php_get_current_user(void);
 
-PHPAPI const char *php_get_internal_encoding(void);
-PHPAPI const char *php_get_input_encoding(void);
-PHPAPI const char *php_get_output_encoding(void);
+PHPAPI ZEND_ATTRIBUTE_PURE const char *php_get_internal_encoding(void);
+PHPAPI ZEND_ATTRIBUTE_PURE const char *php_get_input_encoding(void);
+PHPAPI ZEND_ATTRIBUTE_PURE const char *php_get_output_encoding(void);
 PHPAPI extern void (*php_internal_encoding_changed)(void);
 END_EXTERN_C()
 

--- a/main/php_ini.h
+++ b/main/php_ini.h
@@ -24,18 +24,18 @@ PHPAPI void config_zval_dtor(zval *zvalue);
 int php_init_config(void);
 int php_shutdown_config(void);
 void php_ini_register_extensions(void);
-PHPAPI zval *cfg_get_entry_ex(zend_string *name);
-PHPAPI zval *cfg_get_entry(const char *name, size_t name_length);
+PHPAPI ZEND_ATTRIBUTE_PURE zval *cfg_get_entry_ex(zend_string *name);
+PHPAPI ZEND_ATTRIBUTE_PURE zval *cfg_get_entry(const char *name, size_t name_length);
 PHPAPI int cfg_get_long(const char *varname, zend_long *result);
 PHPAPI int cfg_get_double(const char *varname, double *result);
 PHPAPI int cfg_get_string(const char *varname, char **result);
 PHPAPI int php_parse_user_ini_file(const char *dirname, const char *ini_filename, HashTable *target_hash);
 PHPAPI void php_ini_activate_config(HashTable *source_hash, int modify_type, int stage);
-PHPAPI int php_ini_has_per_dir_config(void);
-PHPAPI int php_ini_has_per_host_config(void);
+PHPAPI ZEND_ATTRIBUTE_PURE int php_ini_has_per_dir_config(void);
+PHPAPI ZEND_ATTRIBUTE_PURE int php_ini_has_per_host_config(void);
 PHPAPI void php_ini_activate_per_dir_config(char *path, size_t path_len);
 PHPAPI void php_ini_activate_per_host_config(const char *host, size_t host_len);
-PHPAPI HashTable* php_ini_get_configuration_hash(void);
+PHPAPI ZEND_ATTRIBUTE_CONST HashTable* php_ini_get_configuration_hash(void);
 END_EXTERN_C()
 
 #define PHP_INI_USER	ZEND_INI_USER

--- a/main/php_memory_streams.h
+++ b/main/php_memory_streams.h
@@ -47,8 +47,8 @@ PHPAPI php_stream *_php_stream_temp_create(int mode, size_t max_memory_usage STR
 PHPAPI php_stream *_php_stream_temp_create_ex(int mode, size_t max_memory_usage, const char *tmpdir STREAMS_DC);
 PHPAPI php_stream *_php_stream_temp_open(int mode, size_t max_memory_usage, const char *buf, size_t length STREAMS_DC);
 
-PHPAPI int php_stream_mode_from_str(const char *mode);
-PHPAPI const char *_php_stream_mode_to_str(int mode);
+PHPAPI ZEND_ATTRIBUTE_PURE int php_stream_mode_from_str(const char *mode);
+PHPAPI ZEND_ATTRIBUTE_CONST const char *_php_stream_mode_to_str(int mode);
 
 END_EXTERN_C()
 

--- a/main/php_network.h
+++ b/main/php_network.h
@@ -308,7 +308,7 @@ PHPAPI int php_network_get_peer_name(php_socket_t sock,
 		);
 
 PHPAPI void php_any_addr(int family, php_sockaddr_storage *addr, unsigned short port);
-PHPAPI int php_sockaddr_size(php_sockaddr_storage *addr);
+PHPAPI ZEND_ATTRIBUTE_PURE int php_sockaddr_size(php_sockaddr_storage *addr);
 END_EXTERN_C()
 
 struct _php_netstream_data_t	{
@@ -341,7 +341,7 @@ PHPAPI void php_network_populate_name_from_sockaddr(
 PHPAPI int php_network_parse_network_address_with_port(const char *addr,
 		zend_long addrlen, struct sockaddr *sa, socklen_t *sl);
 
-PHPAPI struct hostent*	php_network_gethostbyname(const char *name);
+PHPAPI ZEND_ATTRIBUTE_PURE struct hostent*	php_network_gethostbyname(const char *name);
 
 PHPAPI int php_set_sock_blocking(php_socket_t socketd, int block);
 END_EXTERN_C()

--- a/main/php_output.h
+++ b/main/php_output.h
@@ -192,10 +192,10 @@ PHPAPI int php_output_activate(void);
 PHPAPI void php_output_deactivate(void);
 
 PHPAPI void php_output_set_status(int status);
-PHPAPI int php_output_get_status(void);
+PHPAPI ZEND_ATTRIBUTE_PURE int php_output_get_status(void);
 PHPAPI void php_output_set_implicit_flush(int flush);
-PHPAPI const char *php_output_get_start_filename(void);
-PHPAPI int php_output_get_start_lineno(void);
+PHPAPI ZEND_ATTRIBUTE_PURE const char *php_output_get_start_filename(void);
+PHPAPI ZEND_ATTRIBUTE_PURE int php_output_get_start_lineno(void);
 
 PHPAPI size_t php_output_write_unbuffered(const char *str, size_t len);
 PHPAPI size_t php_output_write(const char *str, size_t len);
@@ -211,8 +211,8 @@ PHPAPI void php_output_discard_all(void);
 
 PHPAPI int php_output_get_contents(zval *p);
 PHPAPI int php_output_get_length(zval *p);
-PHPAPI int php_output_get_level(void);
-PHPAPI php_output_handler* php_output_get_active_handler(void);
+PHPAPI ZEND_ATTRIBUTE_PURE int php_output_get_level(void);
+PHPAPI ZEND_ATTRIBUTE_PURE php_output_handler* php_output_get_active_handler(void);
 
 PHPAPI int php_output_start_default(void);
 PHPAPI int php_output_start_devnull(void);

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -306,7 +306,7 @@ PHPAPI int _php_stream_seek(php_stream *stream, zend_off_t offset, int whence);
 #define php_stream_rewind(stream)	_php_stream_seek((stream), 0L, SEEK_SET)
 #define php_stream_seek(stream, offset, whence)	_php_stream_seek((stream), (offset), (whence))
 
-PHPAPI zend_off_t _php_stream_tell(php_stream *stream);
+PHPAPI ZEND_ATTRIBUTE_PURE zend_off_t _php_stream_tell(php_stream *stream);
 #define php_stream_tell(stream)	_php_stream_tell((stream))
 
 PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t count);
@@ -326,7 +326,7 @@ PHPAPI ssize_t _php_stream_printf(php_stream *stream, const char *fmt, ...) PHP_
 /* php_stream_printf macro & function require */
 #define php_stream_printf _php_stream_printf
 
-PHPAPI bool _php_stream_eof(php_stream *stream);
+PHPAPI ZEND_ATTRIBUTE_PURE bool _php_stream_eof(php_stream *stream);
 #define php_stream_eof(stream)	_php_stream_eof((stream))
 
 PHPAPI int _php_stream_getc(php_stream *stream);
@@ -603,12 +603,12 @@ PHPAPI int _php_stream_make_seekable(php_stream *origstream, php_stream **newstr
 #define php_stream_make_seekable(origstream, newstream, flags)	_php_stream_make_seekable((origstream), (newstream), (flags) STREAMS_CC)
 
 /* Give other modules access to the url_stream_wrappers_hash and stream_filters_hash */
-PHPAPI HashTable *_php_stream_get_url_stream_wrappers_hash(void);
+PHPAPI ZEND_ATTRIBUTE_PURE HashTable *_php_stream_get_url_stream_wrappers_hash(void);
 #define php_stream_get_url_stream_wrappers_hash()	_php_stream_get_url_stream_wrappers_hash()
-PHPAPI HashTable *php_stream_get_url_stream_wrappers_hash_global(void);
-PHPAPI HashTable *_php_get_stream_filters_hash(void);
+PHPAPI ZEND_ATTRIBUTE_CONST HashTable *php_stream_get_url_stream_wrappers_hash_global(void);
+PHPAPI ZEND_ATTRIBUTE_PURE HashTable *_php_get_stream_filters_hash(void);
 #define php_get_stream_filters_hash()	_php_get_stream_filters_hash()
-PHPAPI HashTable *php_get_stream_filters_hash_global(void);
+PHPAPI ZEND_ATTRIBUTE_CONST HashTable *php_get_stream_filters_hash_global(void);
 extern const php_stream_wrapper_ops *php_stream_user_wrapper_ops;
 END_EXTERN_C()
 #endif

--- a/main/streams/php_stream_transport.h
+++ b/main/streams/php_stream_transport.h
@@ -211,6 +211,6 @@ typedef struct _php_stream_xport_crypto_param {
 } php_stream_xport_crypto_param;
 
 BEGIN_EXTERN_C()
-PHPAPI HashTable *php_stream_xport_get_hash(void);
+PHPAPI ZEND_ATTRIBUTE_CONST HashTable *php_stream_xport_get_hash(void);
 PHPAPI php_stream_transport_factory_func php_stream_generic_socket_factory;
 END_EXTERN_C()


### PR DESCRIPTION
Adding "pure" and "const" attributes to some functions allows the compiler to do more optimizations, e.g. cache certain values in registers across function calls because it has been given a guarantee that those values will not change from inside a "pure" function call.

See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html for documentation.