### PR TITLE
Fix GH-10168: heap-buffer-overflow at zval_undefined_cv 

### DIFF
--- a/Zend/tests/gh10168_1.phpt
+++ b/Zend/tests/gh10168_1.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): array variation
+--FILE--
+<?php
+
+class Test
+{
+    static $instances;
+    public function __construct() {
+	    (self::$instances[NULL] = $this) > 0;
+	    var_dump(self::$instances);
+    }
+
+    function __destruct() {
+        unset(self::$instances[NULL]);
+    }
+}
+new Test();
+new Test();
+
+?>
+--EXPECTF--
+Notice: Object of class Test could not be converted to int in %s on line %d
+array(1) {
+  [""]=>
+  object(Test)#1 (0) {
+  }
+}
+
+Notice: Object of class Test could not be converted to int in %s on line %d
+array(0) {
+}

--- a/Zend/tests/gh10168_2.phpt
+++ b/Zend/tests/gh10168_2.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign global variation
+--FILE--
+<?php
+
+$a = null;
+
+class Test
+{
+    public function __construct() {
+	    ($GLOBALS['a'] = $this) > 0;
+	    var_dump($GLOBALS['a']);
+    }
+
+    function __destruct() {
+        unset($GLOBALS['a']);
+    }
+}
+new Test();
+new Test();
+
+?>
+--EXPECTF--
+Notice: Object of class Test could not be converted to int in %s on line %d
+object(Test)#1 (0) {
+}
+
+Notice: Object of class Test could not be converted to int in %s on line %d
+
+Warning: Undefined global variable $a in %s on line %d
+NULL

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -138,7 +138,7 @@ static zend_always_inline void zend_copy_to_variable(zval *variable_ptr, zval *v
 }
 
 /* Handles the garbage when using zend_assign_to_variable_delay_garbage_handling */
-static zend_always_inline void zend_assign_to_variable_handle_garbage(zend_refcounted *garbage)
+static zend_always_inline void zend_handle_garbage_from_variable_assignment(zend_refcounted *garbage)
 {
 	if (!garbage)
 		return;
@@ -152,7 +152,7 @@ static zend_always_inline void zend_assign_to_variable_handle_garbage(zend_refco
 	}
 }
 
-/* This is the same as zend_assign_to_variable() but without the garbage handling, this is left for the caller to do using zend_assign_to_variable_handle_garbage().
+/* This is the same as zend_assign_to_variable() but without the garbage handling, this is left for the caller to do using zend_handle_garbage_from_variable_assignment().
  * The reason one might want to delay garbage handling is because the garbage handling might destroy the newly returned value while
  * that value was supposed to be used in a result. Using zend_assign_to_variable() instead in that case would result in a potential use-after-free. */
 static zend_always_inline zval* zend_assign_to_variable_delay_garbage_handling(zval *variable_ptr, zval *value, zend_uchar value_type, bool strict, zend_refcounted **garbage)
@@ -185,7 +185,7 @@ static zend_always_inline zval* zend_assign_to_variable(zval *variable_ptr, zval
 {
 	zend_refcounted *garbage;
 	variable_ptr = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, value_type, strict, &garbage);
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 	return variable_ptr;
 }
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2577,6 +2577,9 @@ ZEND_VM_C_LABEL(try_assign_dim_array):
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = GET_OP2_ZVAL_PTR_UNDEF(BP_VAR_R);
 			if (OP2_TYPE == IS_CONST) {
@@ -2588,10 +2591,12 @@ ZEND_VM_C_LABEL(try_assign_dim_array):
 				ZEND_VM_C_GOTO(assign_dim_error);
 			}
 			value = GET_OP_DATA_ZVAL_PTR(BP_VAR_R);
-			value = zend_assign_to_variable(variable_ptr, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -2685,12 +2690,15 @@ ZEND_VM_HANDLER(22, ZEND_ASSIGN, VAR|CV, CONST|TMP|VAR|CV, SPEC(RETVAL))
 	value = GET_OP2_ZVAL_PTR(BP_VAR_R);
 	variable_ptr = GET_OP1_ZVAL_PTR_PTR_UNDEF(BP_VAR_W);
 
-	value = zend_assign_to_variable(variable_ptr, value, OP2_TYPE, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, OP2_TYPE, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	FREE_OP1_VAR_PTR();
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2596,7 +2596,7 @@ ZEND_VM_C_LABEL(try_assign_dim_array):
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -2695,7 +2695,7 @@ ZEND_VM_HANDLER(22, ZEND_ASSIGN, VAR|CV, CONST|TMP|VAR|CV, SPEC(RETVAL))
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	FREE_OP1_VAR_PTR();
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -23483,7 +23483,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23636,7 +23636,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23790,7 +23790,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23944,7 +23944,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -24042,7 +24042,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CONST_RETVAL_U
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
@@ -24065,7 +24065,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CONST_RETVAL_U
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
@@ -26208,7 +26208,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26361,7 +26361,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26515,7 +26515,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26669,7 +26669,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -27397,7 +27397,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_TMP_RETVAL_UNU
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
@@ -27420,7 +27420,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_TMP_RETVAL_USE
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
@@ -27487,7 +27487,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_VAR_RETVAL_UNU
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
@@ -27510,7 +27510,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_VAR_RETVAL_USE
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
@@ -27771,7 +27771,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -27924,7 +27924,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -28078,7 +28078,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -28232,7 +28232,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30467,7 +30467,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30620,7 +30620,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30774,7 +30774,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30928,7 +30928,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -31026,7 +31026,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CV_RETVAL_UNUS
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
@@ -31049,7 +31049,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CV_RETVAL_USED
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
@@ -41544,7 +41544,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41697,7 +41697,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41851,7 +41851,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -42005,7 +42005,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -42103,7 +42103,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CONST_RETVAL_UN
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
@@ -42125,7 +42125,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CONST_RETVAL_US
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
@@ -45346,7 +45346,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45499,7 +45499,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45653,7 +45653,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45807,7 +45807,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -46823,7 +46823,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_TMP_RETVAL_UNUS
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
@@ -46845,7 +46845,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_TMP_RETVAL_USED
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
@@ -46897,7 +46897,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_VAR_RETVAL_UNUS
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
@@ -46919,7 +46919,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_VAR_RETVAL_USED
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
@@ -47352,7 +47352,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47505,7 +47505,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47659,7 +47659,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47813,7 +47813,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50709,7 +50709,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50862,7 +50862,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -51016,7 +51016,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -51170,7 +51170,7 @@ try_assign_dim_array:
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_COPY(EX_VAR(opline->result.var), value);
 			}
-			zend_assign_to_variable_handle_garbage(garbage);
+			zend_handle_garbage_from_variable_assignment(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -51268,7 +51268,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CV_RETVAL_UNUSE
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
@@ -51290,7 +51290,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CV_RETVAL_USED_
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
-	zend_assign_to_variable_handle_garbage(garbage);
+	zend_handle_garbage_from_variable_assignment(garbage);
 
 	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -23464,6 +23464,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -23475,10 +23478,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23612,6 +23617,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -23623,10 +23631,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23761,6 +23771,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -23772,10 +23785,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23910,6 +23925,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -23921,10 +23939,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -24017,12 +24037,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CONST_RETVAL_U
 	value = RT_CONSTANT(opline, opline->op2);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -24037,12 +24060,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CONST_RETVAL_U
 	value = RT_CONSTANT(opline, opline->op2);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -26163,6 +26189,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -26174,10 +26203,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26311,6 +26342,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -26322,10 +26356,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26460,6 +26496,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -26471,10 +26510,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26609,6 +26650,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -26620,10 +26664,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -27346,12 +27392,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_TMP_RETVAL_UNU
 	value = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -27366,12 +27415,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_TMP_RETVAL_USE
 	value = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -27430,12 +27482,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_VAR_RETVAL_UNU
 	value = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -27450,12 +27505,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_VAR_RETVAL_USE
 	value = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -27694,6 +27752,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -27705,10 +27766,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -27842,6 +27905,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -27853,10 +27919,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -27991,6 +28059,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -28002,10 +28073,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -28140,6 +28213,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -28151,10 +28227,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30370,6 +30448,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -30381,10 +30462,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30518,6 +30601,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -30529,10 +30615,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30667,6 +30755,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -30678,10 +30769,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30816,6 +30909,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -30827,10 +30923,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30923,12 +31021,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CV_RETVAL_UNUS
 	value = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -30943,12 +31044,15 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CV_RETVAL_USED
 	value = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -41421,6 +41525,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -41432,10 +41539,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41569,6 +41678,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -41580,10 +41692,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41718,6 +41832,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -41729,10 +41846,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41867,6 +41986,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -41878,10 +42000,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41974,12 +42098,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CONST_RETVAL_UN
 	value = RT_CONSTANT(opline, opline->op2);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -41994,12 +42120,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CONST_RETVAL_US
 	value = RT_CONSTANT(opline, opline->op2);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -45199,6 +45327,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45210,10 +45341,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45347,6 +45480,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45358,10 +45494,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45496,6 +45634,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45507,10 +45648,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45645,6 +45788,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45656,10 +45802,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -46670,12 +46818,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_TMP_RETVAL_UNUS
 	value = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46690,12 +46840,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_TMP_RETVAL_USED
 	value = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46740,12 +46892,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_VAR_RETVAL_UNUS
 	value = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46760,12 +46914,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_VAR_RETVAL_USED
 	value = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -47177,6 +47333,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -47188,10 +47347,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47325,6 +47486,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -47336,10 +47500,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47474,6 +47640,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -47485,10 +47654,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47623,6 +47794,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -47634,10 +47808,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50514,6 +50690,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -50525,10 +50704,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50662,6 +50843,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -50673,10 +50857,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50811,6 +50997,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -50822,10 +51011,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50960,6 +51151,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -50971,10 +51165,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			zend_refcounted *garbage;
+			value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
+			zend_assign_to_variable_handle_garbage(garbage);
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -51067,12 +51263,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CV_RETVAL_UNUSE
 	value = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(0)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -51087,12 +51285,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CV_RETVAL_USED_
 	value = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+	zend_refcounted *garbage;
+	value = zend_assign_to_variable_delay_garbage_handling(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES(), &garbage);
 	if (UNEXPECTED(1)) {
 		ZVAL_COPY(EX_VAR(opline->result.var), value);
 	}
+	zend_assign_to_variable_handle_garbage(garbage);
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_variable_*() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/10168

cc'ing @iluuu1994 since he also was involved in the issue report

The problem is that we're using the variable_ptr in the opcode handler
*after* it has already been destroyed. The solution is to delay
executing the destructors until after the variable_ptr is used.
To accomplish this we introduce 2 new API functions:
* zend_assign_to_variable_delay_garbage_handling(); and
* zend_assign_to_variable_handle_garbage() that allows users to delay
the garbage handling. zend_assign_to_variable() is now a wrapper for
those such that there is no BC break.

We only have to apply this to ASSIGN_DIM and ASSIGN. That's because the
others rely on properties, in which case the variable_ptr can't be
destroyed.

The first commit fixes the bug, the second one adds a regression test.
Comparing the performance before and after this fix using Valgrind on
Zend/bench.php.
Instruction counts yields 3,339,632,671 before and 3,340,132,746 after.
The difference is only a performance decrease of ~0.015%, which seems
negligible.

**Additional notes**
I do have a local, experimental, patchset that improves performance of ZEND_ASSIGN and even results in a net win, but that's kinda unrelated to this PR and probably master-only material. Just thought I'd mention it since I did measurements of VM performance's tiny decrease.