### PR TITLE
Fix GH-10496: Segfault in fiber with nested calls

### DIFF
--- a/Zend/tests/fibers/gh10496.phpt
+++ b/Zend/tests/fibers/gh10496.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Bug GH-10496 (Segfault when garbage collector is invoked inside of fiber)
+--FILE--
+<?php
+
+function x(&$ref) {
+	$ref = new class() {
+		function __destruct() {
+			print "Dtor x()\n";
+		}
+	};
+}
+function suspend($x) {
+	Fiber::suspend();
+}
+$f = new Fiber(function() use (&$f) {
+	try {
+		x($var);
+		\ord(suspend(1));
+	} finally {
+		print "Cleaned\n";
+	}
+});
+$f->start();
+unset($f);
+gc_collect_cycles();
+print "Collected\n";
+
+?>
+--EXPECT--
+Cleaned
+Dtor x()
+Collected


### PR DESCRIPTION
Skip the current executing call in fibers, see analysis: https://github.com/php/php-src/issues/10496#issuecomment-1416871217