### PR TITLE
Add assertion that php_pcre_replace_impl() returns a valid pointer in SPL RegexIterator()

### DIFF
--- a/ext/spl/spl_iterators.c
+++ b/ext/spl/spl_iterators.c
@@ -1866,6 +1866,12 @@ PHP_METHOD(RegexIterator, accept)
 			}
 
 			result = php_pcre_replace_impl(intern->u.regex.pce, subject, ZSTR_VAL(subject), ZSTR_LEN(subject), replacement_str, -1, &count);
+			zend_string_release(replacement_str);
+			zend_string_release(subject);
+
+			if (!result) {
+				RETURN_FALSE;
+			}
 
 			if (intern->u.regex.flags & REGIT_USE_KEY) {
 				zval_ptr_dtor(&intern->current.key);
@@ -1875,7 +1881,6 @@ PHP_METHOD(RegexIterator, accept)
 				ZVAL_STR(&intern->current.data, result);
 			}
 
-			zend_string_release(replacement_str);
 			RETVAL_BOOL(count > 0);
 		}
 	}

--- a/ext/spl/tests/gh8271.phpt
+++ b/ext/spl/tests/gh8271.phpt
@@ -1,0 +1,37 @@
+--TEST--
+GH-8271: NULL pointer dereference in RegexIterator::accept()
+--EXTENSIONS--
+spl
+--FILE--
+<?php
+function words() {
+    yield "f\xC3oo";
+    yield "bar";
+    yield "baz";
+}
+
+$it = new RegexIterator(words(), '/a/u', RegexIterator::REPLACE);
+var_dump(iterator_to_array($it));
+
+function wordsForEach() {
+    foreach (["f\xC3oo", "bar", "baz"] as $word) {
+        yield $word;
+    }
+}
+$it = new RegexIterator(wordsForEach(), '/a/u', RegexIterator::REPLACE);
+var_dump(iterator_to_array($it));
+
+?>
+--EXPECT--
+array(2) {
+  [1]=>
+  string(2) "br"
+  [2]=>
+  string(2) "bz"
+}
+array(2) {
+  [1]=>
+  string(2) "br"
+  [2]=>
+  string(2) "bz"
+}


### PR DESCRIPTION
The regex is precompiled during the constructions of the object at line 1424 in spl_iterators.c Moreover, the warnings emitted by pcre_get_compiled_regex_cache() get promoted to InvalidArgumentExceptions.

php_pcre_replace_impl() will only return NULL in case of an internal PCRE error, something which should not happen.

Closes GH-8271

I tried coming up with a test case to trigger this, but it seems impossible? @nielsdos could you have a look at this? I imagine static analysis is going to complain but wouldn't be able to come up with a test case for it... maybe creating a fuzzer for ext-pcre and the RegexIterator might be a good idea.