### PR TITLE
Alternative fix for GH-10168 (alternative to GH-10500)

### DIFF
--- a/Zend/tests/gh10168_1.phpt
+++ b/Zend/tests/gh10168_1.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): array variation
+--FILE--
+<?php
+
+class Test
+{
+    static $instances;
+    public function __construct() {
+	    (self::$instances[NULL] = $this) > 0;
+	    var_dump(self::$instances);
+    }
+
+    function __destruct() {
+        unset(self::$instances[NULL]);
+    }
+}
+new Test();
+new Test();
+
+?>
+--EXPECTF--
+Notice: Object of class Test could not be converted to int in %s on line %d
+array(1) {
+  [""]=>
+  object(Test)#1 (0) {
+  }
+}
+
+Notice: Object of class Test could not be converted to int in %s on line %d
+array(0) {
+}

--- a/Zend/tests/gh10168_2.phpt
+++ b/Zend/tests/gh10168_2.phpt
@@ -7,14 +7,15 @@ $a = null;
 
 class Test
 {
-    public function __construct() {
-	    ($GLOBALS['a'] = $this) > 0;
-	    var_dump($GLOBALS['a']);
-    }
+	public function __construct() {
+		($GLOBALS['a'] = $this) > 0;
+		// Destructor called after comparison, so a will be NULL
+		var_dump($GLOBALS['a']);
+	}
 
-    function __destruct() {
-        unset($GLOBALS['a']);
-    }
+	function __destruct() {
+		unset($GLOBALS['a']);
+	}
 }
 new Test();
 new Test();
@@ -26,5 +27,6 @@ object(Test)#1 (0) {
 }
 
 Notice: Object of class Test could not be converted to int in %s on line %d
-object(Test)#1 (0) {
-}
+
+Warning: Undefined global variable $a in %s on line %d
+NULL

--- a/Zend/tests/gh10168_2.phpt
+++ b/Zend/tests/gh10168_2.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign global variation
+--FILE--
+<?php
+
+$a = null;
+
+class Test
+{
+    public function __construct() {
+	    ($GLOBALS['a'] = $this) > 0;
+	    var_dump($GLOBALS['a']);
+    }
+
+    function __destruct() {
+        unset($GLOBALS['a']);
+    }
+}
+new Test();
+new Test();
+
+?>
+--EXPECTF--
+Notice: Object of class Test could not be converted to int in %s on line %d
+object(Test)#1 (0) {
+}
+
+Notice: Object of class Test could not be converted to int in %s on line %d
+object(Test)#1 (0) {
+}

--- a/Zend/tests/gh10168_3.phpt
+++ b/Zend/tests/gh10168_3.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
+--FILE--
+<?php
+class Test
+{
+	static ?Test $a = null;
+
+	public function __construct() {
+		if (self::$a === null) {
+			var_dump(self::$a = &$this);
+		} else {
+			var_dump(self::$a = $this);
+		}
+	}
+
+	function __destruct() {
+		self::$a = null;
+	}
+}
+new Test();
+new Test();
+
+?>
+--EXPECTF--
+object(Test)#1 (0) {
+}
+object(Test)#2 (0) {
+}

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3562,7 +3562,7 @@ static zend_always_inline void i_zval_ptr_dtor_noref(zval *zval_ptr) {
 	}
 }
 
-ZEND_API zval* zend_assign_to_typed_ref(zval *variable_ptr, zval *orig_value, zend_uchar value_type, bool strict)
+ZEND_API zval* zend_assign_to_typed_ref_and_result(zval *variable_ptr, zval *orig_value, zend_uchar value_type, bool strict, zval *result_variable_ptr)
 {
 	bool ret;
 	zval value;
@@ -3582,6 +3582,9 @@ ZEND_API zval* zend_assign_to_typed_ref(zval *variable_ptr, zval *orig_value, ze
 	} else {
 		zval_ptr_dtor_nogc(&value);
 	}
+	if (result_variable_ptr) {
+		ZVAL_COPY(result_variable_ptr, variable_ptr);
+	}
 	if (value_type & (IS_VAR|IS_TMP_VAR)) {
 		if (UNEXPECTED(ref)) {
 			if (UNEXPECTED(GC_DELREF(ref) == 0)) {
@@ -3593,6 +3596,11 @@ ZEND_API zval* zend_assign_to_typed_ref(zval *variable_ptr, zval *orig_value, ze
 		}
 	}
 	return variable_ptr;
+}
+
+ZEND_API zval* zend_assign_to_typed_ref(zval *variable_ptr, zval *orig_value, zend_uchar value_type, bool strict)
+{
+	return zend_assign_to_typed_ref_and_result(variable_ptr, orig_value, value_type, strict, NULL);
 }
 
 ZEND_API bool ZEND_FASTCALL zend_verify_prop_assignable_by_ref(zend_property_info *prop_info, zval *orig_val, bool strict) {

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -108,6 +108,7 @@ ZEND_API bool zend_verify_internal_return_type(zend_function *zf, zval *ret);
 ZEND_API void ZEND_FASTCALL zend_ref_add_type_source(zend_property_info_source_list *source_list, zend_property_info *prop);
 ZEND_API void ZEND_FASTCALL zend_ref_del_type_source(zend_property_info_source_list *source_list, zend_property_info *prop);
 
+ZEND_API zval* zend_assign_to_typed_ref_and_result(zval *variable_ptr, zval *orig_value, zend_uchar value_type, bool strict, zval *result_variable_ptr);
 ZEND_API zval* zend_assign_to_typed_ref(zval *variable_ptr, zval *value, zend_uchar value_type, bool strict);
 
 static zend_always_inline void zend_copy_to_variable(zval *variable_ptr, zval *value, zend_uchar value_type)
@@ -180,8 +181,7 @@ static zend_always_inline zval* zend_assign_to_two_variables(zval *result_variab
 		if (UNEXPECTED(Z_REFCOUNTED_P(variable_ptr))) {
 			if (Z_ISREF_P(variable_ptr)) {
 				if (UNEXPECTED(ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(variable_ptr)))) {
-					variable_ptr = zend_assign_to_typed_ref(variable_ptr, value, value_type, strict);
-					ZVAL_COPY(result_variable_ptr, variable_ptr);
+					variable_ptr = zend_assign_to_typed_ref_and_result(variable_ptr, value, value_type, strict, result_variable_ptr);
 					return variable_ptr;
 				}
 

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -174,14 +174,14 @@ static zend_always_inline zval* zend_assign_to_variable(zval *variable_ptr, zval
 	return variable_ptr;
 }
 
-static zend_always_inline zval* zend_assign_to_two_variables(zval *result_variable_ptr, zval *variable_ptr, zval *value, zend_uchar value_type, zend_uchar variable_type, bool strict)
+static zend_always_inline zval* zend_assign_to_two_variables(zval *result_variable_ptr, zval *variable_ptr, zval *value, zend_uchar value_type, bool strict)
 {
 	do {
 		if (UNEXPECTED(Z_REFCOUNTED_P(variable_ptr))) {
 			if (Z_ISREF_P(variable_ptr)) {
 				if (UNEXPECTED(ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(variable_ptr)))) {
 					variable_ptr = zend_assign_to_typed_ref(variable_ptr, value, value_type, strict);
-					zend_copy_to_variable(result_variable_ptr, variable_ptr, variable_type);
+					ZVAL_COPY(result_variable_ptr, variable_ptr);
 					return variable_ptr;
 				}
 
@@ -192,14 +192,14 @@ static zend_always_inline zval* zend_assign_to_two_variables(zval *result_variab
 			}
 			zend_refcounted *garbage = Z_COUNTED_P(variable_ptr);
 			zend_copy_to_variable(variable_ptr, value, value_type);
-			zend_copy_to_variable(result_variable_ptr, variable_ptr, variable_type);
+			ZVAL_COPY(result_variable_ptr, variable_ptr);
 			zend_handle_garbage_from_variable_assignment(garbage);
 			return variable_ptr;
 		}
 	} while (0);
 
 	zend_copy_to_variable(variable_ptr, value, value_type);
-	zend_copy_to_variable(result_variable_ptr, variable_ptr, variable_type);
+	ZVAL_COPY(result_variable_ptr, variable_ptr);
 	return variable_ptr;
 }
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2593,7 +2593,7 @@ ZEND_VM_C_LABEL(try_assign_dim_array):
 			value = GET_OP_DATA_ZVAL_PTR(BP_VAR_R);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, OP_DATA_TYPE, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
 			}
@@ -2691,7 +2691,7 @@ ZEND_VM_HANDLER(22, ZEND_ASSIGN, VAR|CV, CONST|TMP|VAR|CV, SPEC(RETVAL))
 	variable_ptr = GET_OP1_ZVAL_PTR_PTR_UNDEF(BP_VAR_W);
 
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, OP2_TYPE, OP1_TYPE, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, OP2_TYPE, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, OP2_TYPE, EX_USES_STRICT_TYPES());
 	}

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2592,7 +2592,6 @@ ZEND_VM_C_LABEL(try_assign_dim_array):
 			}
 			value = GET_OP_DATA_ZVAL_PTR(BP_VAR_R);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2577,6 +2577,9 @@ ZEND_VM_C_LABEL(try_assign_dim_array):
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = GET_OP2_ZVAL_PTR_UNDEF(BP_VAR_R);
 			if (OP2_TYPE == IS_CONST) {
@@ -2588,10 +2591,12 @@ ZEND_VM_C_LABEL(try_assign_dim_array):
 				ZEND_VM_C_GOTO(assign_dim_error);
 			}
 			value = GET_OP_DATA_ZVAL_PTR(BP_VAR_R);
-			value = zend_assign_to_variable(variable_ptr, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, OP_DATA_TYPE, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, OP_DATA_TYPE, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -2685,12 +2690,14 @@ ZEND_VM_HANDLER(22, ZEND_ASSIGN, VAR|CV, CONST|TMP|VAR|CV, SPEC(RETVAL))
 	value = GET_OP2_ZVAL_PTR(BP_VAR_R);
 	variable_ptr = GET_OP1_ZVAL_PTR_PTR_UNDEF(BP_VAR_W);
 
-	value = zend_assign_to_variable(variable_ptr, value, OP2_TYPE, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, OP2_TYPE, OP1_TYPE, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, OP2_TYPE, EX_USES_STRICT_TYPES());
 	}
+
 	FREE_OP1_VAR_PTR();
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -23464,6 +23464,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -23475,10 +23478,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23612,6 +23617,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -23623,10 +23631,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23761,6 +23771,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -23772,10 +23785,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -23910,6 +23925,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -23921,10 +23939,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -24017,12 +24037,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CONST_RETVAL_U
 	value = RT_CONSTANT(opline, opline->op2);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(0)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_VAR, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -24037,12 +24059,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CONST_RETVAL_U
 	value = RT_CONSTANT(opline, opline->op2);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(1)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_VAR, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -26163,6 +26187,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -26174,10 +26201,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26311,6 +26340,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -26322,10 +26354,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26460,6 +26494,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -26471,10 +26508,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -26609,6 +26648,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -26620,10 +26662,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -27346,12 +27390,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_TMP_RETVAL_UNU
 	value = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(0)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_VAR, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -27366,12 +27412,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_TMP_RETVAL_USE
 	value = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(1)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_VAR, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -27430,12 +27478,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_VAR_RETVAL_UNU
 	value = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(0)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_VAR, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -27450,12 +27500,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_VAR_RETVAL_USE
 	value = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(1)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_VAR, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -27694,6 +27746,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -27705,10 +27760,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -27842,6 +27899,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -27853,10 +27913,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -27991,6 +28053,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -28002,10 +28067,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -28140,6 +28207,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -28151,10 +28221,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30370,6 +30442,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -30381,10 +30456,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30518,6 +30595,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -30529,10 +30609,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30667,6 +30749,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -30678,10 +30763,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30816,6 +30903,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -30827,10 +30917,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -30923,12 +31015,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CV_RETVAL_UNUS
 	value = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(0)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_VAR, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -30943,12 +31037,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CV_RETVAL_USED
 	value = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(1)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_VAR, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
+
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -41421,6 +41517,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -41432,10 +41531,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41569,6 +41670,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -41580,10 +41684,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41718,6 +41824,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -41729,10 +41838,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41867,6 +41978,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = RT_CONSTANT(opline, opline->op2);
 			if (IS_CONST == IS_CONST) {
@@ -41878,10 +41992,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -41974,12 +42090,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CONST_RETVAL_UN
 	value = RT_CONSTANT(opline, opline->op2);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(0)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -41994,12 +42111,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CONST_RETVAL_US
 	value = RT_CONSTANT(opline, opline->op2);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(1)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -45199,6 +45317,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45210,10 +45331,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45347,6 +45470,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45358,10 +45484,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45496,6 +45624,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45507,10 +45638,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -45645,6 +45778,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 			if ((IS_TMP_VAR|IS_VAR) == IS_CONST) {
@@ -45656,10 +45792,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -46670,12 +46808,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_TMP_RETVAL_UNUS
 	value = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(0)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46690,12 +46829,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_TMP_RETVAL_USED
 	value = _get_zval_ptr_tmp(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(1)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46740,12 +46880,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_VAR_RETVAL_UNUS
 	value = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(0)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -46760,12 +46901,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_VAR_RETVAL_USED
 	value = _get_zval_ptr_var(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(1)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -47177,6 +47319,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -47188,10 +47333,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47325,6 +47472,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -47336,10 +47486,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47474,6 +47626,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -47485,10 +47640,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -47623,6 +47780,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = NULL;
 			if (IS_UNUSED == IS_CONST) {
@@ -47634,10 +47794,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50514,6 +50676,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -50525,10 +50690,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50662,6 +50829,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -50673,10 +50843,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50811,6 +50983,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -50822,10 +50997,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -50960,6 +51137,9 @@ try_assign_dim_array:
 					Z_ADDREF_P(value);
 				}
 			}
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_COPY(EX_VAR(opline->result.var), value);
+			}
 		} else {
 			dim = EX_VAR(opline->op2.var);
 			if (IS_CV == IS_CONST) {
@@ -50971,10 +51151,12 @@ try_assign_dim_array:
 				goto assign_dim_error;
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
-			value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
-		}
-		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-			ZVAL_COPY(EX_VAR(opline->result.var), value);
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				/* Using IS_CV here to trigger the refcount check and update */
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+			} else {
+				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
+			}
 		}
 	} else {
 		if (EXPECTED(Z_ISREF_P(object_ptr))) {
@@ -51067,12 +51249,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CV_RETVAL_UNUSE
 	value = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(0)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }
@@ -51087,12 +51270,13 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CV_RETVAL_USED_
 	value = _get_zval_ptr_cv_BP_VAR_R(opline->op2.var EXECUTE_DATA_CC);
 	variable_ptr = EX_VAR(opline->op1.var);
 
-	value = zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	if (UNEXPECTED(1)) {
-		ZVAL_COPY(EX_VAR(opline->result.var), value);
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+	} else {
+		zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
 
-	/* zend_assign_to_variable() always takes care of op2, never free it! */
+	/* zend_assign_to_(two_)variable(s)() always takes care of op2, never free it! */
 
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 }

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -23479,7 +23479,6 @@ try_assign_dim_array:
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
@@ -23632,7 +23631,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
@@ -23786,7 +23784,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
@@ -23940,7 +23937,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
@@ -26202,7 +26198,6 @@ try_assign_dim_array:
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
@@ -26355,7 +26350,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
@@ -26509,7 +26503,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
@@ -26663,7 +26656,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
@@ -27761,7 +27753,6 @@ try_assign_dim_array:
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
@@ -27914,7 +27905,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
@@ -28068,7 +28058,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
@@ -28222,7 +28211,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
@@ -30457,7 +30445,6 @@ try_assign_dim_array:
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
@@ -30610,7 +30597,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
@@ -30764,7 +30750,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
@@ -30918,7 +30903,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
@@ -41532,7 +41516,6 @@ try_assign_dim_array:
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
@@ -41685,7 +41668,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
@@ -41839,7 +41821,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
@@ -41993,7 +41974,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
@@ -45332,7 +45312,6 @@ try_assign_dim_array:
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
@@ -45485,7 +45464,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
@@ -45639,7 +45617,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
@@ -45793,7 +45770,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
@@ -47334,7 +47310,6 @@ try_assign_dim_array:
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
@@ -47487,7 +47462,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
@@ -47641,7 +47615,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
@@ -47795,7 +47768,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
@@ -50691,7 +50663,6 @@ try_assign_dim_array:
 			}
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
@@ -50844,7 +50815,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
@@ -50998,7 +50968,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
@@ -51152,7 +51121,6 @@ try_assign_dim_array:
 			}
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-				/* Using IS_CV here to trigger the refcount check and update */
 				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -23480,7 +23480,7 @@ try_assign_dim_array:
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			}
@@ -23633,7 +23633,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -23787,7 +23787,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -23941,7 +23941,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			}
@@ -24038,7 +24038,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CONST_RETVAL_U
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	if (UNEXPECTED(0)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_VAR, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
@@ -24060,7 +24060,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CONST_RETVAL_U
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	if (UNEXPECTED(1)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_VAR, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
@@ -26203,7 +26203,7 @@ try_assign_dim_array:
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			}
@@ -26356,7 +26356,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -26510,7 +26510,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -26664,7 +26664,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			}
@@ -27391,7 +27391,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_TMP_RETVAL_UNU
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	if (UNEXPECTED(0)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_VAR, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
@@ -27413,7 +27413,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_TMP_RETVAL_USE
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	if (UNEXPECTED(1)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_VAR, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
@@ -27479,7 +27479,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_VAR_RETVAL_UNU
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	if (UNEXPECTED(0)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_VAR, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
@@ -27501,7 +27501,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_VAR_RETVAL_USE
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	if (UNEXPECTED(1)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_VAR, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
@@ -27762,7 +27762,7 @@ try_assign_dim_array:
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			}
@@ -27915,7 +27915,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -28069,7 +28069,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -28223,7 +28223,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			}
@@ -30458,7 +30458,7 @@ try_assign_dim_array:
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			}
@@ -30611,7 +30611,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -30765,7 +30765,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -30919,7 +30919,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			}
@@ -31016,7 +31016,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CV_RETVAL_UNUS
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	if (UNEXPECTED(0)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_VAR, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
@@ -31038,7 +31038,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_VAR_CV_RETVAL_USED
 	variable_ptr = _get_zval_ptr_ptr_var(opline->op1.var EXECUTE_DATA_CC);
 
 	if (UNEXPECTED(1)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_VAR, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
@@ -41533,7 +41533,7 @@ try_assign_dim_array:
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			}
@@ -41686,7 +41686,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -41840,7 +41840,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -41994,7 +41994,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			}
@@ -42091,7 +42091,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CONST_RETVAL_UN
 	variable_ptr = EX_VAR(opline->op1.var);
 
 	if (UNEXPECTED(0)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
@@ -42112,7 +42112,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CONST_RETVAL_US
 	variable_ptr = EX_VAR(opline->op1.var);
 
 	if (UNEXPECTED(1)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 	}
@@ -45333,7 +45333,7 @@ try_assign_dim_array:
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			}
@@ -45486,7 +45486,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -45640,7 +45640,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -45794,7 +45794,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			}
@@ -46809,7 +46809,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_TMP_RETVAL_UNUS
 	variable_ptr = EX_VAR(opline->op1.var);
 
 	if (UNEXPECTED(0)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
@@ -46830,7 +46830,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_TMP_RETVAL_USED
 	variable_ptr = EX_VAR(opline->op1.var);
 
 	if (UNEXPECTED(1)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 	}
@@ -46881,7 +46881,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_VAR_RETVAL_UNUS
 	variable_ptr = EX_VAR(opline->op1.var);
 
 	if (UNEXPECTED(0)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
@@ -46902,7 +46902,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_VAR_RETVAL_USED
 	variable_ptr = EX_VAR(opline->op1.var);
 
 	if (UNEXPECTED(1)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 	}
@@ -47335,7 +47335,7 @@ try_assign_dim_array:
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			}
@@ -47488,7 +47488,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -47642,7 +47642,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -47796,7 +47796,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			}
@@ -50692,7 +50692,7 @@ try_assign_dim_array:
 			value = RT_CONSTANT((opline+1), (opline+1)->op1);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CONST, EX_USES_STRICT_TYPES());
 			}
@@ -50845,7 +50845,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_tmp((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_TMP_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -50999,7 +50999,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_var((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_VAR, EX_USES_STRICT_TYPES());
 			}
@@ -51153,7 +51153,7 @@ try_assign_dim_array:
 			value = _get_zval_ptr_cv_BP_VAR_R((opline+1)->op1.var EXECUTE_DATA_CC);
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				/* Using IS_CV here to trigger the refcount check and update */
-				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+				zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			} else {
 				zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 			}
@@ -51250,7 +51250,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CV_RETVAL_UNUSE
 	variable_ptr = EX_VAR(opline->op1.var);
 
 	if (UNEXPECTED(0)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}
@@ -51271,7 +51271,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_SPEC_CV_CV_RETVAL_USED_
 	variable_ptr = EX_VAR(opline->op1.var);
 
 	if (UNEXPECTED(1)) {
-		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, IS_CV, EX_USES_STRICT_TYPES());
+		zend_assign_to_two_variables(EX_VAR(opline->result.var), variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	} else {
 		zend_assign_to_variable(variable_ptr, value, IS_CV, EX_USES_STRICT_TYPES());
 	}


### PR DESCRIPTION
Alternative to GH-10500 as suggested by @dstogov .
I don't know if I did it 100% correctly though...
According to Callgrind, the instructions count for Zend/bench.php is:
- 3,341,844,801 with `zend_copy_to_variable` (this approach was my first attempt, see commit log, but this caused 2 test failures in readdir tests. I probably did something wrong here...).
- If I swap out the `zend_copy_to_variable` with `ZVAL_COPY`, I get 3,340,811,227 though (done in last commit).
This is slightly higher than my first attempt in GH-10500.