### PR TITLE
ext/opcache/zend_jit: cast function to fix -Wincompatible-pointer-types

### DIFF
--- a/TSRM/tsrm_win32.c
+++ b/TSRM/tsrm_win32.c
@@ -91,7 +91,7 @@ static void tsrm_win32_dtor(tsrm_win32_globals *globals)
 TSRM_API void tsrm_win32_startup(void)
 {/*{{{*/
 #ifdef ZTS
-	ts_allocate_id(&win32_globals_id, sizeof(tsrm_win32_globals), (ts_allocate_ctor)tsrm_win32_ctor, (ts_allocate_ctor)tsrm_win32_dtor);
+	ts_allocate_id(&win32_globals_id, sizeof(tsrm_win32_globals), (ts_allocate_ctor)tsrm_win32_ctor, (ts_allocate_dtor)tsrm_win32_dtor);
 #else
 	tsrm_win32_ctor(&win32_globals);
 #endif

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4878,7 +4878,7 @@ ZEND_EXT_API int zend_jit_debug_config(zend_long old_val, zend_long new_val, int
 ZEND_EXT_API void zend_jit_init(void)
 {
 #ifdef ZTS
-	jit_globals_id = ts_allocate_id(&jit_globals_id, sizeof(zend_jit_globals), (ts_allocate_ctor) zend_jit_globals_ctor, zend_jit_globals_dtor);
+	jit_globals_id = ts_allocate_id(&jit_globals_id, sizeof(zend_jit_globals), (ts_allocate_ctor) zend_jit_globals_ctor, (ts_allocate_dtor) zend_jit_globals_dtor);
 #else
 	zend_jit_globals_ctor(&jit_globals);
 #endif


### PR DESCRIPTION
Regression by commit a21195650e53e34266806a8c379dd5a91f0dbb61

@dstogov 