### PR TITLE
Zend/zend_cpuinfo, ext/standard/crc32_x86: fix -Wstrict-prototypes

### DIFF
--- a/Zend/zend_cpuinfo.h
+++ b/Zend/zend_cpuinfo.h
@@ -208,7 +208,7 @@ static inline int zend_cpu_supports_avx2(void) {
 /* __builtin_cpu_supports has pclmul from gcc9 */
 #if PHP_HAVE_BUILTIN_CPU_SUPPORTS && (!defined(__GNUC__) || (ZEND_GCC_VERSION >= 9000))
 ZEND_NO_SANITIZE_ADDRESS
-static inline int zend_cpu_supports_pclmul() {
+static inline int zend_cpu_supports_pclmul(void) {
 #if PHP_HAVE_BUILTIN_CPU_INIT
 	__builtin_cpu_init();
 #endif

--- a/ext/standard/crc32_x86.c
+++ b/ext/standard/crc32_x86.c
@@ -323,7 +323,7 @@ typedef size_t (*crc32_x86_simd_func_t)(X86_CRC32_TYPE type, uint32_t *crc, cons
 
 ZEND_NO_SANITIZE_ADDRESS
 ZEND_ATTRIBUTE_UNUSED /* clang mistakenly warns about this */
-static crc32_x86_simd_func_t resolve_crc32_x86_simd_update() {
+static crc32_x86_simd_func_t resolve_crc32_x86_simd_update(void) {
 	if (zend_cpu_supports_sse42() && zend_cpu_supports_pclmul()) {
 		return crc32_sse42_pclmul_update;
 	}


### PR DESCRIPTION
In plain C, a function without arguments must be explicitly declared (void).