### PR TITLE
ext/opcache/zend_jit_trace: remove unnecessary NULL check

### DIFF
--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -8326,9 +8326,7 @@ static void zend_jit_trace_reset_caches(void)
 
 static void zend_jit_trace_free_caches(void)
 {
-	if (JIT_G(exit_counters)) {
-		free(JIT_G(exit_counters));
-	}
+	free(JIT_G(exit_counters));
 }
 
 static void zend_jit_trace_restart(void)


### PR DESCRIPTION
free(NULL) is legal, but that'll never happen because nobody will ever set it to NULL.