### PR TITLE
ext/opcache/zend_jit: call TSRM dtor before unloading opcache.so

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -5078,7 +5078,9 @@ ZEND_EXT_API void zend_jit_shutdown(void)
 		zend_jit_perf_jitdump_close();
 	}
 #endif
-#ifndef ZTS
+#ifdef ZTS
+	ts_free_id(jit_globals_id);
+#else
 	zend_jit_trace_free_caches();
 #endif
 }


### PR DESCRIPTION
Commit a21195650e53e added a TSRM destructor, but that destructor will get called by tsrm_shutdown(), which is after opcache.so has already been unloaded, resulting in a shutdown crash, e.g.:

```
  #0  0x00007fad01737500 in ?? ()
  #1  0x000055ac54e723c4 in tsrm_shutdown () at TSRM/TSRM.c:194
  #2  0x000055ac54c42180 in main (argc=80, argv=0x55ac57bc14d0) at sapi/cli/php_cli.c:1388
```

By calling ts_free_id() before opcache.so gets unloaded, we can easily fix this crash bug.

(@dstogov, this should fix the CI failures after your JIT dtor change.)