### PR TITLE
Fix streams copy length after partial copy_file_range.

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1626,6 +1626,9 @@ PHPAPI zend_result _php_stream_copy_to_stream_ex(php_stream *src, php_stream *de
 	}
 #endif // HAVE_COPY_FILE_RANGE
 
+    // If we are falling back, remove read bytes from the total size to copy
+    maxlen -= haveread;
+
 	if (maxlen == PHP_STREAM_COPY_ALL) {
 		maxlen = 0;
 	}


### PR DESCRIPTION
Hi,

it seems that on some file systems (here, BTRFS), `copy_file_range` succeeds but does not copy the whole file. Then, we fall back to a second method that tries to copy `maxlen` bytes from the current location. Since the copy succeeded in the previous attempt, the file pointer was moved, but `maxlen` is not updated, so more bytes than expected are copied from the file.

This caused a failure for me in several phar tests, as `ext/phar/phar.c` checks for how much was copied, in addition to the success returned by the function, even in that case. After applying the patch, these tests now all pass.

If the first method is not attempted, fails or copies 0 bytes, `haveread` stays at 0, so `maxlen` is not affected. If enough bytes were copied, the function returns immediately. If the first copy is partial, `maxlen` is updated to reflect how much bytes should still be copied.