### PR TITLE
Fix test timeout on slow machine

### DIFF
--- a/Zend/tests/concat_003.phpt
+++ b/Zend/tests/concat_003.phpt
@@ -11,7 +11,7 @@ if (getenv('SKIP_PERF_SENSITIVE')) die("skip performance sensitive test");
 $time = microtime(TRUE);
 
 /* This might vary on Linux/Windows, so the worst case and also count in slow machines. */
-$t_max = 1.0;
+$t_max = 5.0;
 
 $datas = array_fill(0, 220000, [
     '000.000.000.000',


### PR DESCRIPTION
The concat 003 test in Zend Engine will fail on some RISC-V board like VisionFive/SiFive Unmatched because of the poor performace. This commit increase the `$t_max` value for the worst case.