### PR TITLE
Bump minimum re2c version requirement to 1.0.3

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1870,7 +1870,7 @@ AC_DEFUN([PHP_PROG_RE2C],[
     if test "$php_re2c_check" != "invalid"; then
       AC_MSG_RESULT([$php_re2c_version (ok)])
     else
-      AC_MSG_RESULT([$php_re2c_version])
+      AC_MSG_RESULT([$php_re2c_version (too old)])
     fi
   fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ PHP_RUNPATH_SWITCH
 dnl Checks for some support/generator progs.
 PHP_PROG_AWK
 PHP_PROG_BISON([3.0.0])
-PHP_PROG_RE2C([0.13.4])
+PHP_PROG_RE2C([1.0.3])
 PHP_PROG_PHP()
 
 PHP_ARG_ENABLE([re2c-cgoto],


### PR DESCRIPTION
The release VMs already enforced this, but PHP's configure script did not.

re2c 0.13.5, which timelib's date/time parser requires is no longer compatible with the current version of Zend/zend_language_scanner.l, as it starts spinning in a loop.