### PR TITLE
Fix memory leaks in ext-tidy

### DIFF
--- a/ext/tidy/tests/parsing_file_too_large.phpt
+++ b/ext/tidy/tests/parsing_file_too_large.phpt
@@ -4,6 +4,7 @@ Trying to parse a file that is too large (over 4GB)
 tidy
 --SKIPIF--
 <?php
+if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only");
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 ?>
 --INI--

--- a/ext/tidy/tests/parsing_file_too_large.phpt
+++ b/ext/tidy/tests/parsing_file_too_large.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Trying to parse a file that is too large (over 4GB)
+--EXTENSIONS--
+tidy
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
+?>
+--INI--
+memory_limit="5G"
+--FILE--
+<?php
+
+$path = __DIR__ . '/too_large_test.html';
+$file = fopen($path, 'w+');
+
+// Write over 4GB
+const MIN_FILE_SIZE = 4_294_967_295;
+$total_bytes = 0;
+$s = str_repeat("a", 10_000);
+while ($total_bytes < MIN_FILE_SIZE) {
+    $bytes_written = fwrite($file, $s);
+    if ($bytes_written === false) {
+        echo "Didn't write bytes\n";
+    }
+    $total_bytes += $bytes_written;
+}
+
+$tidy = new tidy;
+try {
+    var_dump($tidy->parseFile($path));
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    var_dump(tidy_parse_file($path));
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+
+try {
+    $tidy = new tidy($path);
+} catch (\Throwable $e) {
+    echo $e::class, ': ', $e->getMessage(), PHP_EOL;
+}
+?>
+--CLEAN--
+<?php
+$path = __DIR__ . '/too_large_test.html';
+unlink($path);
+?>
+--EXPECT--
+ValueError: Input string is too long
+ValueError: Input string is too long
+ValueError: Input string is too long

--- a/ext/tidy/tests/parsing_file_too_large.phpt
+++ b/ext/tidy/tests/parsing_file_too_large.phpt
@@ -16,14 +16,12 @@ $file = fopen($path, 'w+');
 
 // Write over 4GB
 const MIN_FILE_SIZE = 4_294_967_295;
-$total_bytes = 0;
-$s = str_repeat("a", 10_000);
-while ($total_bytes < MIN_FILE_SIZE) {
-    $bytes_written = fwrite($file, $s);
-    if ($bytes_written === false) {
-        echo "Didn't write bytes\n";
-    }
-    $total_bytes += $bytes_written;
+
+var_dump(fseek($file, MIN_FILE_SIZE+10));
+$s = str_repeat("a", 10);
+$bytes_written = fwrite($file, $s);
+if ($bytes_written === false) {
+    echo "Didn't write bytes\n";
 }
 
 $tidy = new tidy;
@@ -51,6 +49,7 @@ $path = __DIR__ . '/too_large_test.html';
 unlink($path);
 ?>
 --EXPECT--
+int(0)
 ValueError: Input string is too long
 ValueError: Input string is too long
 ValueError: Input string is too long

--- a/ext/tidy/tests/parsing_inexistent_file.phpt
+++ b/ext/tidy/tests/parsing_inexistent_file.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Trying to parse a non existent file
+--EXTENSIONS--
+tidy
+--FILE--
+<?php
+
+$tidy = new tidy;
+var_dump($tidy->parseFile("does_not_exist.html"));
+
+var_dump(tidy_parse_file("does_not_exist.html"));
+
+$tidy = new tidy("does_not_exist.html");
+?>
+--EXPECTF--
+Warning: tidy::parseFile(): Cannot load "does_not_exist.html" into memory in %s on line %d
+bool(false)
+
+Warning: tidy_parse_file(): Cannot load "does_not_exist.html" into memory in %s on line %d
+bool(false)
+
+Warning: tidy::__construct(): Cannot load "does_not_exist.html" into memory in %s on line %d

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -1059,18 +1059,19 @@ PHP_FUNCTION(tidy_parse_file)
 		Z_PARAM_BOOL(use_include_path)
 	ZEND_PARSE_PARAMETERS_END();
 
-	tidy_instanciate(tidy_ce_doc, return_value);
-	obj = Z_TIDY_P(return_value);
-
 	if (!(contents = php_tidy_file_to_mem(ZSTR_VAL(inputfile), use_include_path))) {
 		php_error_docref(NULL, E_WARNING, "Cannot load \"%s\" into memory%s", ZSTR_VAL(inputfile), (use_include_path) ? " (using include path)" : "");
 		RETURN_FALSE;
 	}
 
 	if (ZEND_SIZE_T_UINT_OVFL(ZSTR_LEN(contents))) {
+		zend_string_release_ex(contents, 0);
 		zend_value_error("Input string is too long");
 		RETURN_THROWS();
 	}
+
+	tidy_instanciate(tidy_ce_doc, return_value);
+	obj = Z_TIDY_P(return_value);
 
 	TIDY_APPLY_CONFIG(obj->ptdoc->doc, options_str, options_ht);
 
@@ -1362,6 +1363,7 @@ PHP_METHOD(tidy, __construct)
 		}
 
 		if (ZEND_SIZE_T_UINT_OVFL(ZSTR_LEN(contents))) {
+			zend_string_release_ex(contents, 0);
 			zend_value_error("Input string is too long");
 			RETURN_THROWS();
 		}
@@ -1400,6 +1402,7 @@ PHP_METHOD(tidy, parseFile)
 	}
 
 	if (ZEND_SIZE_T_UINT_OVFL(ZSTR_LEN(contents))) {
+		zend_string_release_ex(contents, 0);
 		zend_value_error("Input string is too long");
 		RETURN_THROWS();
 	}


### PR DESCRIPTION
We must not instantiate the object prior to checking error conditions.

Moreover, we need to release the ***HUGE*** amount of memory for files which are over 4GB when throwing a ValueError.