### PR TITLE
Fix another use-after-free with static properties/destructors

### DIFF
--- a/Zend/tests/gh10168_1.phpt
+++ b/Zend/tests/gh10168_1.phpt
@@ -7,7 +7,7 @@ class Test
 {
     static $instances;
     public function __construct() {
-	    (self::$instances[NULL] = $this) > 0;
+	    var_dump(self::$instances[NULL] = $this);
 	    var_dump(self::$instances);
     }
 
@@ -19,14 +19,15 @@ new Test();
 new Test();
 
 ?>
---EXPECTF--
-Notice: Object of class Test could not be converted to int in %s on line %d
+--EXPECT--
+object(Test)#1 (0) {
+}
 array(1) {
   [""]=>
   object(Test)#1 (0) {
   }
 }
-
-Notice: Object of class Test could not be converted to int in %s on line %d
+object(Test)#2 (0) {
+}
 array(0) {
 }

--- a/Zend/tests/gh10168_10.phpt
+++ b/Zend/tests/gh10168_10.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
+--FILE--
+<?php
+
+class Test {
+    static ?Test $a = null;
+    function __construct() {
+        if(self::$a == null){
+            self::$a = &$this;
+        }
+    }
+    function __destruct(){
+        self::$a = null;
+    }
+}
+new Test;
+new Test;
+
+?>
+--EXPECT--

--- a/Zend/tests/gh10168_11.phpt
+++ b/Zend/tests/gh10168_11.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): global by ref val error
+--FILE--
+<?php
+
+class Test {
+    function __destruct(){
+        unset($GLOBALS['a']);
+    }
+}
+
+function returnsVal() {
+    return 42;
+}
+$a = new Test;
+var_dump($a =& returnsVal());
+
+?>
+--EXPECTF--
+Notice: Only variables should be assigned by reference in %s on line %d
+int(42)

--- a/Zend/tests/gh10168_12.phpt
+++ b/Zend/tests/gh10168_12.phpt
@@ -1,10 +1,10 @@
 --TEST--
-GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed static prop ref
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign static prop ref
 --FILE--
 <?php
 
 class Test {
-    static ?Test $a = null;
+    static $a = null;
     function __construct() {
         var_dump(self::$a = &$this);
     }

--- a/Zend/tests/gh10168_13.phpt
+++ b/Zend/tests/gh10168_13.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign prop ref
+--FILE--
+<?php
+
+class Box {
+	public $storage;
+}
+
+$box = new Box();
+
+class Test
+{
+	public function __construct() {
+		global $box;
+		var_dump($box->storage = &$this);
+	}
+
+	function __destruct() {
+		global $box;
+		var_dump($box->storage);
+		$box->storage = null;
+	}
+}
+new Test();
+new Test();
+
+?>
+--EXPECT--
+object(Test)#2 (0) {
+}
+object(Test)#3 (0) {
+}
+NULL
+NULL

--- a/Zend/tests/gh10168_14.phpt
+++ b/Zend/tests/gh10168_14.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop ref
+--FILE--
+<?php
+
+class Box {
+	public ?Test $storage = null;
+}
+
+$box = new Box();
+
+class Test
+{
+	public function __construct() {
+		global $box;
+		var_dump($box->storage = &$this);
+	}
+
+	function __destruct() {
+		global $box;
+		var_dump($box->storage);
+		$box->storage = null;
+	}
+}
+new Test();
+new Test();
+
+?>
+--EXPECT--
+object(Test)#2 (0) {
+}
+object(Test)#3 (0) {
+}
+NULL
+NULL

--- a/Zend/tests/gh10168_15.phpt
+++ b/Zend/tests/gh10168_15.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): global by ref
+--FILE--
+<?php
+
+class Test {
+    function __destruct(){
+        unset($GLOBALS['a']);
+    }
+}
+
+function &returnsVal() {
+    $a = 42;
+    return $a;
+}
+$a = new Test;
+var_dump($a =& returnsVal());
+
+?>
+--EXPECT--
+int(42)

--- a/Zend/tests/gh10168_2.phpt
+++ b/Zend/tests/gh10168_2.phpt
@@ -8,7 +8,7 @@ $a = null;
 class Test
 {
 	public function __construct() {
-		($GLOBALS['a'] = $this) > 0;
+		var_dump($GLOBALS['a'] = $this);
 		// Destructor called after comparison, so a will be NULL
 		var_dump($GLOBALS['a']);
 	}
@@ -22,11 +22,12 @@ new Test();
 
 ?>
 --EXPECTF--
-Notice: Object of class Test could not be converted to int in %s on line %d
 object(Test)#1 (0) {
 }
-
-Notice: Object of class Test could not be converted to int in %s on line %d
+object(Test)#1 (0) {
+}
+object(Test)#2 (0) {
+}
 
 Warning: Undefined global variable $a in %s on line %d
 NULL

--- a/Zend/tests/gh10168_3.phpt
+++ b/Zend/tests/gh10168_3.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed static prop
 --XFAIL--
 --FILE--
 <?php

--- a/Zend/tests/gh10168_3.phpt
+++ b/Zend/tests/gh10168_3.phpt
@@ -1,6 +1,5 @@
 --TEST--
 GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed static prop
---XFAIL--
 --FILE--
 <?php
 class Test

--- a/Zend/tests/gh10168_3.phpt
+++ b/Zend/tests/gh10168_3.phpt
@@ -26,5 +26,4 @@ new Test();
 --EXPECTF--
 object(Test)#1 (0) {
 }
-object(Test)#2 (0) {
-}
+NULL

--- a/Zend/tests/gh10168_4.phpt
+++ b/Zend/tests/gh10168_4.phpt
@@ -1,23 +1,32 @@
 --TEST--
 GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
---XFAIL--
 --FILE--
 <?php
+
+class Box {
+	public $storage;
+}
+
+$box = new Box();
+
 class Test
 {
 	static ?Test $a = null;
 
 	public function __construct() {
+		global $box;
+
 		if (self::$a === null) {
-			var_dump(self::$a = $this);
+			var_dump($box->storage = $this);
 		} else {
-			var_dump(self::$a = $this);
+			var_dump($box->storage = $this);
 		}
 	}
 
 	function __destruct() {
-		var_dump(self::$a);
-		self::$a = null;
+		global $box;
+		var_dump($box->storage);
+		$box->storage = null;
 	}
 }
 new Test();
@@ -25,10 +34,10 @@ new Test();
 
 ?>
 --EXPECT--
-object(Test)#1 (0) {
-}
 object(Test)#2 (0) {
 }
-object(Test)#2 (0) {
+object(Test)#3 (0) {
+}
+object(Test)#3 (0) {
 }
 NULL

--- a/Zend/tests/gh10168_5.phpt
+++ b/Zend/tests/gh10168_5.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): allocated assignment in destructor
 --FILE--
 <?php
 

--- a/Zend/tests/gh10168_5.phpt
+++ b/Zend/tests/gh10168_5.phpt
@@ -1,23 +1,20 @@
 --TEST--
 GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
---XFAIL--
 --FILE--
 <?php
+
+class Foo {}
+
 class Test
 {
-	static ?Test $a = null;
+	static Test|Foo|null $a = null;
 
 	public function __construct() {
-		if (self::$a === null) {
-			var_dump(self::$a = &$this);
-		} else {
-			var_dump(self::$a = $this);
-		}
+		var_dump(self::$a = $this);
 	}
 
 	function __destruct() {
-		var_dump(self::$a);
-		self::$a = null;
+		var_dump(self::$a = new Foo());
 	}
 }
 new Test();
@@ -27,8 +24,9 @@ new Test();
 --EXPECT--
 object(Test)#1 (0) {
 }
-object(Test)#2 (0) {
+object(Foo)#3 (0) {
 }
 object(Test)#2 (0) {
 }
-NULL
+object(Foo)#1 (0) {
+}

--- a/Zend/tests/gh10168_6.phpt
+++ b/Zend/tests/gh10168_6.phpt
@@ -1,5 +1,6 @@
 --TEST--
-GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop without cache slot
+--XFAIL--
 --FILE--
 <?php
 
@@ -12,13 +13,19 @@ $box = new Box();
 class Test
 {
 	public function __construct() {
+		static $i = 0;
+		$i++;
 		global $box;
-		var_dump($box->storage = $this);
+		if ($i === 1) {
+			var_dump($box->storage = $this);
+		} else {
+			// Avoid cache slot, triggering write_property
+			var_dump($box->storage = $this);
+		}
 	}
 
 	function __destruct() {
 		global $box;
-		var_dump($box->storage);
 		$box->storage = null;
 	}
 }
@@ -31,6 +38,3 @@ object(Test)#2 (0) {
 }
 object(Test)#3 (0) {
 }
-object(Test)#3 (0) {
-}
-NULL

--- a/Zend/tests/gh10168_7.phpt
+++ b/Zend/tests/gh10168_7.phpt
@@ -1,21 +1,15 @@
 --TEST--
-GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed static prop
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed static prop by ref
 --XFAIL--
 --FILE--
 <?php
+
 class Test
 {
 	static ?Test $a = null;
 
 	public function __construct() {
-		static $i = 0;
-		$i++;
-		if ($i === 1) {
-			var_dump(self::$a = $this);
-		} else {
-			// Avoid cache slot, triggering write_property
-			var_dump(self::$a = $this);
-		}
+		var_dump(self::$a = &$this);
 	}
 
 	function __destruct() {

--- a/Zend/tests/gh10168_7.phpt
+++ b/Zend/tests/gh10168_7.phpt
@@ -1,6 +1,5 @@
 --TEST--
 GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed static prop by ref
---XFAIL--
 --FILE--
 <?php
 
@@ -26,6 +25,5 @@ object(Test)#1 (0) {
 }
 object(Test)#2 (0) {
 }
-object(Test)#2 (0) {
-}
+NULL
 NULL

--- a/Zend/tests/gh10168_8.phpt
+++ b/Zend/tests/gh10168_8.phpt
@@ -1,10 +1,10 @@
 --TEST--
-GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign prop
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
 --FILE--
 <?php
 
 class Box {
-	public $storage;
+	public ?Test $storage = null;
 }
 
 $box = new Box();

--- a/Zend/tests/gh10168_9.phpt
+++ b/Zend/tests/gh10168_9.phpt
@@ -1,0 +1,34 @@
+--TEST--
+GH-10168 (heap-buffer-overflow at zval_undefined_cv): assign typed prop
+--FILE--
+<?php
+
+class Box {
+	public $value;
+}
+
+$box = new Box();
+
+class Test
+{
+	static $a = null;
+
+	public function __construct() {
+		global $box;
+		var_dump($box->value = $this);
+	}
+
+	function __destruct() {
+		global $box;
+		unset($box->value);
+	}
+}
+new Test();
+new Test();
+
+?>
+--EXPECT--
+object(Test)#2 (0) {
+}
+object(Test)#3 (0) {
+}

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3617,6 +3617,9 @@ ZEND_API zval* zend_assign_to_typed_ref_and_result(zval *variable_ptr, zval *ori
 		}
 	} else {
 		zval_ptr_dtor_nogc(&value);
+		if (result_variable_ptr) {
+			ZVAL_UNDEF(result_variable_ptr);
+		}
 	}
 	if (value_type & (IS_VAR|IS_TMP_VAR)) {
 		if (UNEXPECTED(ref)) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1049,7 +1049,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_STATIC_PROP_SPEC_OP_DAT
 static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_STATIC_PROP_REF_SPEC_HANDLER(ZEND_OPCODE_HANDLER_ARGS)
 {
 	USE_OPLINE
-	zval *prop, *value_ptr;
+	zval *prop, *value_ptr, *result_ptr;
 	zend_property_info *prop_info;
 
 	SAVE_OPLINE();
@@ -1061,19 +1061,16 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_STATIC_PROP_REF_SPEC_HA
 	}
 
 	value_ptr = get_zval_ptr_ptr((opline+1)->op1_type, (opline+1)->op1, BP_VAR_W);
+	result_ptr = UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL;
 
 	if ((opline+1)->op1_type == IS_VAR && (opline->extended_value & ZEND_RETURNS_FUNCTION) && UNEXPECTED(!Z_ISREF_P(value_ptr))) {
-		if (UNEXPECTED(!zend_wrong_assign_to_variable_reference(prop, value_ptr OPLINE_CC EXECUTE_DATA_CC))) {
+		if (UNEXPECTED(!zend_wrong_assign_to_variable_reference(result_ptr, prop, value_ptr OPLINE_CC EXECUTE_DATA_CC))) {
 			prop = &EG(uninitialized_zval);
 		}
 	} else if (UNEXPECTED(ZEND_TYPE_IS_SET(prop_info->type))) {
-		prop = zend_assign_to_typed_property_reference(prop_info, prop, value_ptr EXECUTE_DATA_CC);
+		prop = zend_assign_to_typed_property_reference(prop_info, result_ptr, prop, value_ptr EXECUTE_DATA_CC);
 	} else {
-		zend_assign_to_variable_reference(prop, value_ptr);
-	}
-
-	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-		ZVAL_COPY(EX_VAR(opline->result.var), prop);
+		zend_assign_to_variable_reference(result_ptr, prop, value_ptr);
 	}
 
 	FREE_OP((opline+1)->op1_type, (opline+1)->op1.var);
@@ -28051,19 +28048,18 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_REF_SPEC_VAR_VAR_HANDLE
 	           UNEXPECTED(Z_TYPE_P(EX_VAR(opline->op1.var)) != IS_INDIRECT)) {
 
 		zend_throw_error(NULL, "Cannot assign by reference to an array dimension of an object");
-		variable_ptr = &EG(uninitialized_zval);
+		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			ZVAL_COPY(EX_VAR(opline->result.var), &EG(uninitialized_zval));
+		}
 	} else if (IS_VAR == IS_VAR &&
 	           opline->extended_value == ZEND_RETURNS_FUNCTION &&
 			   UNEXPECTED(!Z_ISREF_P(value_ptr))) {
 
-		variable_ptr = zend_wrong_assign_to_variable_reference(
+		zend_wrong_assign_to_variable_reference(
+			UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL,
 			variable_ptr, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	} else {
-		zend_assign_to_variable_reference(variable_ptr, value_ptr);
-	}
-
-	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-		ZVAL_COPY(EX_VAR(opline->result.var), variable_ptr);
+		zend_assign_to_variable_reference(UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL, variable_ptr, value_ptr);
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
@@ -31584,19 +31580,18 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_REF_SPEC_VAR_CV_HANDLER
 	           UNEXPECTED(Z_TYPE_P(EX_VAR(opline->op1.var)) != IS_INDIRECT)) {
 
 		zend_throw_error(NULL, "Cannot assign by reference to an array dimension of an object");
-		variable_ptr = &EG(uninitialized_zval);
+		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			ZVAL_COPY(EX_VAR(opline->result.var), &EG(uninitialized_zval));
+		}
 	} else if (IS_CV == IS_VAR &&
 	           opline->extended_value == ZEND_RETURNS_FUNCTION &&
 			   UNEXPECTED(!Z_ISREF_P(value_ptr))) {
 
-		variable_ptr = zend_wrong_assign_to_variable_reference(
+		zend_wrong_assign_to_variable_reference(
+			UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL,
 			variable_ptr, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	} else {
-		zend_assign_to_variable_reference(variable_ptr, value_ptr);
-	}
-
-	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-		ZVAL_COPY(EX_VAR(opline->result.var), variable_ptr);
+		zend_assign_to_variable_reference(UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL, variable_ptr, value_ptr);
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op1.var));
@@ -47691,19 +47686,18 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_REF_SPEC_CV_VAR_HANDLER
 	           UNEXPECTED(Z_TYPE_P(EX_VAR(opline->op1.var)) != IS_INDIRECT)) {
 
 		zend_throw_error(NULL, "Cannot assign by reference to an array dimension of an object");
-		variable_ptr = &EG(uninitialized_zval);
+		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			ZVAL_COPY(EX_VAR(opline->result.var), &EG(uninitialized_zval));
+		}
 	} else if (IS_VAR == IS_VAR &&
 	           opline->extended_value == ZEND_RETURNS_FUNCTION &&
 			   UNEXPECTED(!Z_ISREF_P(value_ptr))) {
 
-		variable_ptr = zend_wrong_assign_to_variable_reference(
+		zend_wrong_assign_to_variable_reference(
+			UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL,
 			variable_ptr, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	} else {
-		zend_assign_to_variable_reference(variable_ptr, value_ptr);
-	}
-
-	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-		ZVAL_COPY(EX_VAR(opline->result.var), variable_ptr);
+		zend_assign_to_variable_reference(UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL, variable_ptr, value_ptr);
 	}
 
 	zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
@@ -52068,19 +52062,18 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_ASSIGN_REF_SPEC_CV_CV_HANDLER(
 	           UNEXPECTED(Z_TYPE_P(EX_VAR(opline->op1.var)) != IS_INDIRECT)) {
 
 		zend_throw_error(NULL, "Cannot assign by reference to an array dimension of an object");
-		variable_ptr = &EG(uninitialized_zval);
+		if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+			ZVAL_COPY(EX_VAR(opline->result.var), &EG(uninitialized_zval));
+		}
 	} else if (IS_CV == IS_VAR &&
 	           opline->extended_value == ZEND_RETURNS_FUNCTION &&
 			   UNEXPECTED(!Z_ISREF_P(value_ptr))) {
 
-		variable_ptr = zend_wrong_assign_to_variable_reference(
+		zend_wrong_assign_to_variable_reference(
+			UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL,
 			variable_ptr, value_ptr OPLINE_CC EXECUTE_DATA_CC);
 	} else {
-		zend_assign_to_variable_reference(variable_ptr, value_ptr);
-	}
-
-	if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
-		ZVAL_COPY(EX_VAR(opline->result.var), variable_ptr);
+		zend_assign_to_variable_reference(UNEXPECTED(RETURN_VALUE_USED(opline)) ? EX_VAR(opline->result.var) : NULL, variable_ptr, value_ptr);
 	}
 
 


### PR DESCRIPTION
Also make expression result of assignments consistent, containing the value of the variable from after the destructor has been executed.

See GH-10168

This will be backported to PHP-8.1 but runs against master CI to prove ASAN passes.

/cc @nielsdos (Can't add you as a reviewer)