### PR TITLE
 Fix GH-10548: copy() fails on cifs mounts because of incorrect length (cfr_max) specified in streams.c:1584 copy_file_range()

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -1614,6 +1614,13 @@ PHPAPI zend_result _php_stream_copy_to_stream_ex(php_stream *src, php_stream *de
 						/* not implemented by this Linux kernel */
 						break;
 
+					case EIO:
+						/* Some filesystems will cause failures if the max length is greater than the file length
+						 * in certain circumstances and configuration. In those cases the errno is EIO and we will
+						 * fall back to other methods. We cannot use stat to determine the file length upfront because
+						 * that is prone to races and outdated caching. */
+						break;
+
 					default:
 						/* unexpected I/O error - give up, no fallback */
 						*len = haveread;


### PR DESCRIPTION
On some filesystems, the copy operation fails if we specify a size
larger than the file size. We use a stat call to clamp the size to copy
to the actual filesize. This stat call shouldn't impact performance
notably because stat calls can be cached. In some cases (like for /proc
files), the returned size is 0, so we should avoid problems by not using
copy_file_range in those cases (copy_file_range wouldn't work anyway on
this particular example because the syscall is not supported for /proc).

I will do some cleanups and improvements on copy_file_range (like the loop I described in #10440 in a follow-up PR for the master branch).

/cc @knowsshit It would be great if you could test this patch out and let us know if this works for you :)
/cc @arnaud-lb since he reviewed the PR I referenced in here.

Edit: CI fail in x32 is unrelated 