### PR TITLE
Add support for generating namespaced constant

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -931,14 +931,26 @@ abstract class AbstractConstName implements ConstOrClassConstName
 class ConstName extends AbstractConstName {
     public string $const;
 
-    public function __construct(string $const)
+    public function __construct(?Name $namespace, string $const)
     {
+        if ($namespace && ($namespace = $namespace->slice(0, -1))) {
+            $const = $namespace->toString() . '\\' . $const;
+        }
         $this->const = $const;
     }
 
     public function isClassConst(): bool
     {
         return false;
+    }
+
+    public function isUnknown(): bool
+    {
+        $name = $this->__toString();
+        if (($pos = strrpos($name, '\\')) !== false) {
+            $name = substr($name, $pos + 1);
+        }
+        return strtolower($name) === "unknown";
     }
 
     public function __toString(): string
@@ -1587,7 +1599,7 @@ class EvaluatedValue
                 if ($expr instanceof Expr\ClassConstFetch) {
                     $originatingConstName = new ClassConstName($expr->class, $expr->name->toString());
                 } else {
-                    $originatingConstName = new ConstName($expr->name->toString());
+                    $originatingConstName = new ConstName($expr->name->getAttribute('namespacedName'), $expr->name->toString());
                 }
 
                 if ($originatingConstName->isUnknown()) {
@@ -3630,7 +3642,7 @@ function handleStatements(FileInfo $fileInfo, array $stmts, PrettyPrinterAbstrac
             foreach ($stmt->consts as $const) {
                 $fileInfo->constInfos[] = parseConstLike(
                     $prettyPrinter,
-                    new ConstName($const->name->toString()),
+                    new ConstName($const->namespacedName, $const->name->toString()),
                     $const,
                     0,
                     $stmt->getDocComment(),

--- a/ext/ftp/ftp.stub.php
+++ b/ext/ftp/ftp.stub.php
@@ -2,7 +2,7 @@
 
 /** @generate-class-entries */
 
-namespace FTP {
+namespace {
     /**
      * @var int
      * @cvalue FTPTYPE_ASCII
@@ -59,16 +59,6 @@ namespace FTP {
      */
     const FTP_MOREDATA = UNKNOWN;
 
-    /**
-     * @strict-properties
-     * @not-serializable
-     */
-    final class Connection
-    {
-    }
-}
-
-namespace {
     function ftp_connect(string $hostname, int $port = 21, int $timeout = 90): FTP\Connection|false {}
 
     #ifdef HAVE_FTP_SSL
@@ -144,4 +134,14 @@ namespace {
     /** @param int|bool $value */
     function ftp_set_option(FTP\Connection $ftp, int $option, $value): bool {}
     function ftp_get_option(FTP\Connection $ftp, int $option): int|bool {}
+}
+
+namespace FTP {
+    /**
+     * @strict-properties
+     * @not-serializable
+     */
+    final class Connection
+    {
+    }
 }

--- a/ext/ftp/ftp_arginfo.h
+++ b/ext/ftp/ftp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f66f9b5745bebb0280464b3c1a7f8413c0c6ebc */
+ * Stub hash: ba6c48ea91e85eefb9238ad6cd036fc9b63a75a8 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_ftp_connect, 0, 1, FTP\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -2,7 +2,7 @@
 
 /** @generate-class-entries */
 
-namespace PgSql {
+namespace {
     /* libpq version */
 
     /**
@@ -412,34 +412,6 @@ namespace PgSql {
      * @cvalue PGSQL_DML_STRING
      */
     const PGSQL_DML_STRING = UNKNOWN;
-
-    /**
-     * @strict-properties
-     * @not-serializable
-     */
-    final class Connection
-    {
-    }
-
-    /**
-     * @strict-properties
-     * @not-serializable
-     */
-    final class Result
-    {
-    }
-
-    /**
-     * @strict-properties
-     * @not-serializable
-     */
-    final class Lob
-    {
-    }
-
-}
-
-namespace {
 
     function pg_connect(string $connection_string, int $flags = 0): PgSql\Connection|false {}
 
@@ -922,4 +894,31 @@ namespace {
      * @refcount 1
      */
     function pg_select(PgSql\Connection $connection, string $table_name, array $conditions, int $flags = PGSQL_DML_EXEC, int $mode = PGSQL_ASSOC): array|string|false {}
+}
+
+namespace PgSql {
+    /**
+     * @strict-properties
+     * @not-serializable
+     */
+    final class Connection
+    {
+    }
+
+    /**
+     * @strict-properties
+     * @not-serializable
+     */
+    final class Result
+    {
+    }
+
+    /**
+     * @strict-properties
+     * @not-serializable
+     */
+    final class Lob
+    {
+    }
+
 }

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 16b910c38da087e1b4b55e38031b593334c698ec */
+ * Stub hash: 52d055086569456122f9d9a1264f7a3667127ea7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -29,6 +29,7 @@
 #include "zend_interfaces.h"
 #include "zend_weakrefs.h"
 #include "Zend/Optimizer/zend_optimizer.h"
+#include "test.h"
 #include "test_arginfo.h"
 
 ZEND_DECLARE_MODULE_GLOBALS(zend_test)

--- a/ext/zend_test/test.h
+++ b/ext/zend_test/test.h
@@ -1,0 +1,22 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) The PHP Group                                          |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://www.php.net/license/3_01.txt                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author:                                                              |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef ZEND_TEST_H
+#define ZEND_TEST_H
+
+#define ZEND_TEST_NS_CONSTANT_A "namespaced"
+
+#endif

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -12,6 +12,9 @@ namespace {
      */
     const ZEND_TEST_DEPRECATED = 42;
 
+    /** @var string */
+    const ZEND_CONSTANT_A = "global";
+
     require "Zend/zend_attributes.stub.php";
 
     interface _ZendTestInterface
@@ -180,6 +183,12 @@ namespace ZendTestNS {
 
 namespace ZendTestNS2 {
 
+    /**
+     * @var string
+     * @cvalue ZEND_TEST_NS_CONSTANT_A
+     */
+    const ZEND_CONSTANT_A = UNKNOWN;
+
     class Foo {
         public ZendSubNS\Foo $foo;
 
@@ -202,6 +211,10 @@ namespace ZendTestNS2 {
 }
 
 namespace ZendTestNS2\ZendSubNS {
+
+    /** @var string */
+    const ZEND_CONSTANT_A = \ZendTestNS2\ZEND_CONSTANT_A;
+    // Reference another namespaced constant.
 
     class Foo {
         public function method(): void {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 786b35a1fbff38215431d5ae46a5816c70defce5 */
+ * Stub hash: 2e96505b9e992f7e3976e52f4a7fed0c62f274e3 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -351,6 +351,9 @@ static const zend_function_entry class_ZendTestNS2_ZendSubNS_Foo_methods[] = {
 static void register_test_symbols(int module_number)
 {
 	REGISTER_LONG_CONSTANT("ZEND_TEST_DEPRECATED", 42, CONST_PERSISTENT | CONST_DEPRECATED);
+	REGISTER_STRING_CONSTANT("ZEND_CONSTANT_A", "global", CONST_PERSISTENT);
+	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZEND_CONSTANT_A", ZEND_TEST_NS_CONSTANT_A, CONST_PERSISTENT);
+	REGISTER_STRING_CONSTANT("ZendTestNS2\\ZendSubNS\\ZEND_CONSTANT_A", ZEND_TEST_NS_CONSTANT_A, CONST_PERSISTENT);
 }
 
 static zend_class_entry *register_class__ZendTestInterface(void)

--- a/ext/zend_test/tests/gen_stub_test_02.phpt
+++ b/ext/zend_test/tests/gen_stub_test_02.phpt
@@ -1,0 +1,16 @@
+--TEST--
+gen_stub.php: constants
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+var_dump(ZEND_CONSTANT_A);
+var_dump(ZendTestNS2\ZEND_CONSTANT_A);
+var_dump(ZendTestNS2\ZendSubNS\ZEND_CONSTANT_A);
+
+?>
+--EXPECT--
+string(6) "global"
+string(10) "namespaced"
+string(10) "namespaced"


### PR DESCRIPTION
Add support for generating namespaced constant to gen_stub.php.
The code already has escaping for namespaced constants, but constant instances are not initialized with a residing namespace.

Changes in ext/*.stub.php are to fix namespace of constants which actually are in global.

sample input:
```php
<?php
/** @generate-class-entries */
namespace {
    /** @var null */
    const CONST_NULL = null;
    /** @var bool */
    const CONST_BOOL = true;
    /** @var int */
    const CONST_INT = 1;
    /** @var float */
    const CONST_FLOAT = 1.5;
    /** @var string */
    const CONST_STRING = "str";
    /** @var bool
     *  @cvalue EXTERNAL_BOOL */
    const EXTERN_BOOL = UNKNOWN;
    /** @var int
     *  @cvalue EXTERNAL_INT */
    const EXTERN_INT = UNKNOWN;
    /** @var float
     *  @cvalue EXTERNAL_FLOAT */
    const EXTERN_FLOAT = UNKNOWN;
    /** @var string
     *  @cvalue EXTERNAL_STRING */
    const EXTERN_STRING = UNKNOWN;
}
namespace Not\In\Global {
    /** @var null */
    const CONST_NULL = null;
    /** @var bool */
    const CONST_BOOL = false;
    /** @var int */
    const CONST_INT = -1;
    /** @var float */
    const CONST_FLOAT = -1.5;
    /** @var string */
    const CONST_STRING = "STR";
    /** @var bool
     *  @cvalue EXTERNAL_NS_BOOL */
    const EXTERN_BOOL = UNKNOWN;
    /** @var int
     *  @cvalue EXTERNAL_NS_INT */
    const EXTERN_INT = UNKNOWN;
    /** @var float
     *  @cvalue EXTERNAL_NS_FLOAT */
    const EXTERN_FLOAT = UNKNOWN;
    /** @var string
     *  @cvalue EXTERNAL_NS_STRING */
    const EXTERN_STRING = UNKNOWN;
}
```
generated code:
```c
static void register_TestConstants_symbols(int module_number)
{
	REGISTER_NULL_CONSTANT("CONST_NULL", CONST_PERSISTENT);
	REGISTER_BOOL_CONSTANT("CONST_BOOL", true, CONST_PERSISTENT);
	REGISTER_LONG_CONSTANT("CONST_INT", 1, CONST_PERSISTENT);
	REGISTER_DOUBLE_CONSTANT("CONST_FLOAT", 1.5, CONST_PERSISTENT);
	REGISTER_STRING_CONSTANT("CONST_STRING", "str", CONST_PERSISTENT);
	REGISTER_BOOL_CONSTANT("EXTERN_BOOL", EXTERNAL_BOOL, CONST_PERSISTENT);
	REGISTER_LONG_CONSTANT("EXTERN_INT", EXTERNAL_INT, CONST_PERSISTENT);
	REGISTER_DOUBLE_CONSTANT("EXTERN_FLOAT", EXTERNAL_FLOAT, CONST_PERSISTENT);
	REGISTER_STRING_CONSTANT("EXTERN_STRING", EXTERNAL_STRING, CONST_PERSISTENT);
	REGISTER_NULL_CONSTANT("Not\\In\\Global\\CONST_NULL", CONST_PERSISTENT);
	REGISTER_BOOL_CONSTANT("Not\\In\\Global\\CONST_BOOL", false, CONST_PERSISTENT);
	REGISTER_LONG_CONSTANT("Not\\In\\Global\\CONST_INT", -1, CONST_PERSISTENT);
	REGISTER_DOUBLE_CONSTANT("Not\\In\\Global\\CONST_FLOAT", -1.5, CONST_PERSISTENT);
	REGISTER_STRING_CONSTANT("Not\\In\\Global\\CONST_STRING", "STR", CONST_PERSISTENT);
	REGISTER_BOOL_CONSTANT("Not\\In\\Global\\EXTERN_BOOL", EXTERNAL_NS_BOOL, CONST_PERSISTENT);
	REGISTER_LONG_CONSTANT("Not\\In\\Global\\EXTERN_INT", EXTERNAL_NS_INT, CONST_PERSISTENT);
	REGISTER_DOUBLE_CONSTANT("Not\\In\\Global\\EXTERN_FLOAT", EXTERNAL_NS_FLOAT, CONST_PERSISTENT);
	REGISTER_STRING_CONSTANT("Not\\In\\Global\\EXTERN_STRING", EXTERNAL_NS_STRING, CONST_PERSISTENT);
}
```