### PR TITLE
ext/curl: suppress -Wdeprecated-declarations in curl_arginfo.h

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -60,13 +60,14 @@
 #include "ext/standard/file.h"
 #include "ext/standard/url.h"
 #include "curl_private.h"
-#include "curl_arginfo.h"
 
 #ifdef __GNUC__
 /* don't complain about deprecated CURLOPT_* we're exposing to PHP; we
    need to keep using those to avoid breaking PHP API compatibiltiy */
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
+
+#include "curl_arginfo.h"
 
 #ifdef PHP_CURL_NEED_OPENSSL_TSL /* {{{ */
 static MUTEX_T *php_curl_openssl_tsl = NULL;


### PR DESCRIPTION
Disable the warning before including curl_arginfo.h.

(Follow-up for https://github.com/php/php-src/pull/10531)