### PR TITLE
Zend/zend_execute: clear reference before calling dtor

### DIFF
--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3554,6 +3554,13 @@ static zend_always_inline void i_zval_ptr_dtor_noref(zval *zval_ptr) {
 	if (Z_REFCOUNTED_P(zval_ptr)) {
 		zend_refcounted *ref = Z_COUNTED_P(zval_ptr);
 		ZEND_ASSERT(Z_TYPE_P(zval_ptr) != IS_REFERENCE);
+
+		/* clear reference before invoking the destructor, or
+		   else something inside the destructor may assign the
+		   reference again, triggering another recursive
+		   destructor call */
+		ZVAL_UNDEF(zval_ptr);
+
 		if (!GC_DELREF(ref)) {
 			rc_dtor_func(ref);
 		} else if (UNEXPECTED(GC_MAY_LEAK(ref))) {


### PR DESCRIPTION
If we don't do this, then `zend_objects_store_del()` will call the PHP destructor, which may then recurse into `zend_objects_store_del()`, leading to a use-after-free / double-free bug.

Fixes failures of `Zend/tests/gh10168_3.phpt` (added recently by 71ddede5655) which, depending on the timing, can trigger the recursive zend_objects_store_del() call.

This is similar to commit a057f060e864ff2

@dstogov @nielsdos 