### PR TITLE
proc_open: reject array with empty command name

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -73,6 +73,7 @@ PHP 8.3 UPGRADE NOTES
   . strtok() raises a warning in the case token is not provided when starting tokenization.
   . password_hash() will now chain the underlying Random\RandomException
     as the ValueError’s $previous Exception when salt generation fails.
+  . proc_open() $command array must now have at least one non empty element.
 
 ========================================
 6. New Functions

--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -475,6 +475,12 @@ static zend_string *get_valid_arg_string(zval *zv, int elem_num) {
 		return NULL;
 	}
 
+	if (elem_num == 1 && ZSTR_LEN(str) == 0) {
+		zend_value_error("First element must contain a non-empty program name");
+		zend_string_release(str);
+		return NULL;
+	}
+
 	if (strlen(ZSTR_VAL(str)) != ZSTR_LEN(str)) {
 		zend_value_error("Command array element %d contains a null byte", elem_num);
 		zend_string_release(str);

--- a/ext/standard/tests/general_functions/proc_open_array.phpt
+++ b/ext/standard/tests/general_functions/proc_open_array.phpt
@@ -31,6 +31,13 @@ try {
     echo $exception->getMessage() . "\n";
 }
 
+echo "\nEmpty program name:\n";
+try {
+     proc_open([""], $ds, $pipes);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
 echo "\nBasic usage:\n";
 $proc = proc_open([$php, '-r', 'echo "Hello World!\n";'], $ds, $pipes);
 fpassthru($pipes[1]);
@@ -75,6 +82,9 @@ Command array element 1 contains a null byte
 
 Nul byte in argument:
 Command array element 2 contains a null byte
+
+Empty program name:
+First element must contain a non-empty program name
 
 Basic usage:
 Hello World!


### PR DESCRIPTION
This has been split from #7933

proc_open([""], $ds, $pipes) is invalid, reject and raise an error if that happens.