### PR TITLE
Fix GH-10570: Assertion `(key)->h != 0 && "Hash must be known"' failed. 

### DIFF
--- a/Zend/tests/gh10570.phpt
+++ b/Zend/tests/gh10570.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-10570 (Assertion `(key)->h != 0 && "Hash must be known"' failed.): constant variation
+--FILE--
+<?php
+$a = new stdClass();
+for ($i = 0; $i < 2; $i++) {
+    $a->{90};
+    $a->{0} = 0;
+}
+?>
+--EXPECTF--
+Warning: Undefined property: stdClass::$90 in %s on line %d
+
+Warning: Undefined property: stdClass::$90 in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2924,6 +2924,7 @@ static zend_op *zend_delayed_compile_prop(znode *result, zend_ast *ast, uint32_t
 	opline = zend_delayed_emit_op(result, ZEND_FETCH_OBJ_R, &obj_node, &prop_node);
 	if (opline->op2_type == IS_CONST) {
 		convert_to_string(CT_CONSTANT(opline->op2));
+		zend_string_hash_val(Z_STR_P(CT_CONSTANT(opline->op2)));
 		opline->extended_value = zend_alloc_cache_slots(3);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/php/php-src/issues/10570, see https://github.com/php/php-src/issues/10570 for analysis.