### PR TITLE
Fix GH-8556: FFI\CData use-after-free after FFI object destroyed

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -2777,7 +2777,17 @@ static ZEND_FUNCTION(ffi_trampoline) /* {{{ */
 		free_alloca(arg_values, arg_values_use_heap);
 	}
 
-	zend_ffi_cdata_to_zval(NULL, ret, ZEND_FFI_TYPE(type->func.ret_type), BP_VAR_R, return_value, 0, 1, 0);
+	zend_ffi_type *func_ret_type = type->func.ret_type;
+
+	if (ZEND_FFI_TYPE_IS_OWNED(func_ret_type)) {
+		func_ret_type = ZEND_FFI_TYPE(func_ret_type);
+		if (!(func_ret_type->attr & ZEND_FFI_ATTR_STORED)
+			&& func_ret_type->kind == ZEND_FFI_TYPE_POINTER) {
+			type->func.ret_type = func_ret_type = zend_ffi_remember_type(func_ret_type);
+		}
+	}
+
+	zend_ffi_cdata_to_zval(NULL, ret, func_ret_type, BP_VAR_R, return_value, 0, 1, 0);
 	free_alloca(ret, ret_use_heap);
 
 exit:
@@ -2919,7 +2929,7 @@ ZEND_METHOD(FFI, cdef) /* {{{ */
 
 	if (code && ZSTR_LEN(code)) {
 		/* Parse C definitions */
-		FFI_G(default_type_attr) = ZEND_FFI_ATTR_STORED;
+		FFI_G(default_type_attr) = 0;
 
 		if (zend_ffi_parse_decl(ZSTR_VAL(code), ZSTR_LEN(code)) != SUCCESS) {
 			if (FFI_G(symbols)) {
@@ -3144,6 +3154,7 @@ static void zend_ffi_cleanup_type(zend_ffi_type *old, zend_ffi_type *type) /* {{
 
 static zend_ffi_type *zend_ffi_remember_type(zend_ffi_type *type) /* {{{ */
 {
+	ZEND_ASSERT(!ZEND_FFI_TYPE_IS_OWNED(type) && "type argument must not be a tagged pointer");
 	if (!FFI_G(weak_types)) {
 		FFI_G(weak_types) = emalloc(sizeof(HashTable));
 		zend_hash_init(FFI_G(weak_types), 0, NULL, zend_ffi_type_hash_dtor, 0);

--- a/ext/ffi/tests/gh8556.phpt
+++ b/ext/ffi/tests/gh8556.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-8556 (FFI\CData use-after-free after FFI object destroyed)
+--EXTENSIONS--
+ffi
+--SKIPIF--
+<?php
+try {
+    $libc = FFI::cdef("char *getenv(char *);", "libc.so.6");
+} catch (Throwable $_) {
+    die('skip libc.so.6 not available');
+}
+?>
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+
+putenv("TEST=123");
+
+// Original
+$c = (FFI::cdef("char *getenv(char *);", "libc.so.6"))->getenv("TEST");
+var_dump($c);
+
+// Variant on the original
+$libc = FFI::cdef("char *getenv(char *);", "libc.so.6");
+$result = $libc->getenv("TEST");
+unset($libc); // Frees ffi cdata ->type member
+var_dump($result);
+
+?>
+--EXPECT--
+object(FFI\CData:char*)#2 (1) {
+  [0]=>
+  string(1) "1"
+}
+object(FFI\CData:char*)#3 (1) {
+  [0]=>
+  string(1) "1"
+}


### PR DESCRIPTION
Fixes GH-8556

The return type from a ffi trampoline was just copied over without taking into account that the cdata may outlive the cdef. Fix it in the same way that others have fixed it: by using the zend_ffi_remember_type function.
This by itself was not enough. The FFI::cdef function sets the default type attr to ZEND_FFI_ATTR_STORED, but the type isn't actually stored into the weak_types hashtable. This causes the lifetime management code to mistakenly think it is already in the table and therefore leads to use after frees. Fix it by changing the default flags to 0.