### PR TITLE
posix: fix misuse of bool (invalid code in c23)

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -458,7 +458,7 @@ PHP_FUNCTION(posix_ttyname)
 			RETURN_FALSE;
 		}
 	} else {
-		if (!zend_parse_arg_long(z_fd, &fd, /* is_null */ false, /* check_null */ false, /* arg_num */ 1)) {
+		if (!zend_parse_arg_long(z_fd, &fd, /* is_null */ NULL, /* check_null */ false, /* arg_num */ 1)) {
 			php_error_docref(NULL, E_WARNING, "Argument #1 ($file_descriptor) must be of type int|resource, %s given",
 				zend_zval_value_name(z_fd));
 			fd = zval_get_long(z_fd);
@@ -508,7 +508,7 @@ PHP_FUNCTION(posix_isatty)
 			RETURN_FALSE;
 		}
 	} else {
-		if (!zend_parse_arg_long(z_fd, &fd, /* is_null */ false, /* check_null */ false, /* arg_num */ 1)) {
+		if (!zend_parse_arg_long(z_fd, &fd, /* is_null */ NULL, /* check_null */ false, /* arg_num */ 1)) {
 			php_error_docref(NULL, E_WARNING, "Argument #1 ($file_descriptor) must be of type int|resource, %s given",
 				zend_zval_value_name(z_fd));
 			fd = zval_get_long(z_fd);
@@ -1242,7 +1242,7 @@ PHP_FUNCTION(posix_fpathconf)
 			RETURN_FALSE;
 		}
 	} else {
-		if (!zend_parse_arg_long(z_fd, &fd, /* is_null */ false, /* check_null */ false, /* arg_num */ 1)) {
+		if (!zend_parse_arg_long(z_fd, &fd, /* is_null */ NULL, /* check_null */ false, /* arg_num */ 1)) {
 			zend_argument_type_error(1, "must be of type int|resource, %s given",
 				zend_zval_value_name(z_fd));
 			RETURN_THROWS();


### PR DESCRIPTION
a bool pointer argument cannot take true or false but either &boolval or NULL.

ext/posix/posix.c:511:67: error: incompatible type for argument 3 of ‘zend_parse_arg_long’
  511 |                 if (!zend_parse_arg_long(z_fd, &fd, /* is_null */ false, /* check_null */ false, /* arg_num */ 1)) {
      |                                                                   ^~~~~
      |                                                                   |
      |                                                                   _Bool
/home/crrodriguez/scm/php-src/Zend/zend_API.h:2160:86: note: expected ‘_Bool *’ but argument is of type ‘_Bool’