### PR TITLE
Make C functions returning "void" to return PHP "null"

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -2832,7 +2832,11 @@ static ZEND_FUNCTION(ffi_trampoline) /* {{{ */
 		free_alloca(arg_values, arg_values_use_heap);
 	}
 
-	zend_ffi_cdata_to_zval(NULL, ret, ZEND_FFI_TYPE(type->func.ret_type), BP_VAR_R, return_value, 0, 1, 0);
+	if (ZEND_FFI_TYPE(type->func.ret_type)->kind != ZEND_FFI_TYPE_VOID) {
+		zend_ffi_cdata_to_zval(NULL, ret, ZEND_FFI_TYPE(type->func.ret_type), BP_VAR_R, return_value, 0, 1, 0);
+	} else {
+		ZVAL_NULL(return_value);
+	}
 	free_alloca(ret, ret_use_heap);
 
 exit:

--- a/ext/ffi/tests/gh10568.phpt
+++ b/ext/ffi/tests/gh10568.phpt
@@ -20,6 +20,5 @@ var_dump($libc->strlen("abc"));
 ?>
 DONE
 --EXPECT--
-object(FFI\CData:void)#2 (0) {
-}
+NULL
 DONE


### PR DESCRIPTION
In PHP-8.2 and below we by mistake returned "object(FFI\CData:void)#2 (0) {}". We decided not to fix this in PHP-8.2 and below to avoid BC breaks.