### PR TITLE
ext/opcache/zend_shared_alloc: use memfd for locking if available

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -105,7 +105,7 @@ if test "$PHP_OPCACHE" != "no"; then
 
   fi
 
-  AC_CHECK_FUNCS([mprotect])
+  AC_CHECK_FUNCS([mprotect memfd_create])
 
   AC_MSG_CHECKING(for sysvipc shared memory support)
   AC_RUN_IFELSE([AC_LANG_SOURCE([[


### PR DESCRIPTION
A memfd is a virtual file that has no reachable path, therefore does not clobber any filesystem.  It is deleted automatically as soon as the last handle gets closed.  The feature is available since Linux kernel 3.17.