### PR TITLE
Fixed GH-10270 Unable to return CURL_READFUNC_PAUSE in readfunc callback

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -1547,6 +1547,8 @@ static size_t curl_read(char *data, size_t size, size_t nmemb, void *ctx)
 				if (Z_TYPE(retval) == IS_STRING) {
 					length = MIN((int) (size * nmemb), Z_STRLEN(retval));
 					memcpy(data, Z_STRVAL(retval), length);
+				} else if (Z_TYPE(retval) == IS_LONG) {
+					length = Z_LVAL_P(&retval);
 				}
 				zval_ptr_dtor(&retval);
 			}

--- a/ext/curl/tests/curl_pause_001.phpt
+++ b/ext/curl/tests/curl_pause_001.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Test CURL_READFUNC_PAUSE and curl_pause()
+--EXTENSIONS--
+curl
+--FILE--
+<?php
+include 'server.inc';
+$host = curl_cli_server_start();
+
+class Input {
+	private static $RESPONSES = [
+		'Foo bar ',
+		CURL_READFUNC_PAUSE,
+		'baz qux',
+		null
+	];
+	private int $res = 0;
+	public function __invoke($ch, $hReadHandle, $iMaxOut)
+	{
+		return self::$RESPONSES[$this->res++];
+	}
+}
+
+$inputHandle = fopen(__FILE__, 'r');
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, "{$host}/get.inc?test=input");
+curl_setopt($ch, CURLOPT_UPLOAD,       1);
+curl_setopt($ch, CURLOPT_READFUNCTION, new Input);
+curl_setopt($ch, CURLOPT_INFILE,       $inputHandle);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+$mh = curl_multi_init();
+curl_multi_add_handle($mh, $ch);
+do {
+	$status = curl_multi_exec($mh, $active);
+	curl_pause($ch, CURLPAUSE_CONT);
+	if ($active) {
+		usleep(100);
+		curl_multi_select($mh);
+	}
+} while ($active && $status == CURLM_OK);
+
+echo curl_multi_getcontent($ch);
+?>
+--EXPECT--
+string(15) "Foo bar baz qux"

--- a/ext/curl/tests/responder/get.inc
+++ b/ext/curl/tests/responder/get.inc
@@ -4,6 +4,9 @@
     case 'post':
       var_dump($_POST);
       break;
+    case 'input':
+      var_dump(file_get_contents('php://input'));
+      break;
     case 'getpost':
       var_dump($_GET);
       var_dump($_POST);


### PR DESCRIPTION
Fixes GH-10270 - If the value returned in the `CURLOPT_READFUNCTION` is an integer then return it. This will allow to return the `CURL_READFUNC_PAUSE` magic value.