### PR TITLE
Zend/zend_types.h: move `zend_result` to separate header

### DIFF
--- a/Zend/Optimizer/zend_ssa.h
+++ b/Zend/Optimizer/zend_ssa.h
@@ -21,6 +21,7 @@
 
 #include "zend_optimizer.h"
 #include "zend_cfg.h"
+#include "zend_result.h"
 
 typedef struct _zend_ssa_range {
 	zend_long              min;

--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -21,6 +21,8 @@
 #ifndef ZEND_ALLOC_H
 #define ZEND_ALLOC_H
 
+#include "zend_result.h"
+
 #include <stdio.h>
 
 #include "../TSRM/TSRM.h"

--- a/Zend/zend_exceptions.h
+++ b/Zend/zend_exceptions.h
@@ -22,6 +22,8 @@
 #ifndef ZEND_EXCEPTIONS_H
 #define ZEND_EXCEPTIONS_H
 
+#include "zend_result.h"
+
 BEGIN_EXTERN_C()
 
 extern ZEND_API zend_class_entry *zend_ce_throwable;

--- a/Zend/zend_extensions.h
+++ b/Zend/zend_extensions.h
@@ -22,6 +22,7 @@
 
 #include "zend_compile.h"
 #include "zend_build.h"
+#include "zend_result.h"
 
 /*
 The constants below are derived from ext/opcache/ZendAccelerator.h

--- a/Zend/zend_highlight.h
+++ b/Zend/zend_highlight.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_HIGHLIGHT_H
 #define ZEND_HIGHLIGHT_H
 
+#include "zend_result.h"
+
 #define HL_COMMENT_COLOR     "#FF8000"    /* orange */
 #define HL_DEFAULT_COLOR     "#0000BB"    /* blue */
 #define HL_HTML_COLOR        "#000000"    /* black */

--- a/Zend/zend_ini.h
+++ b/Zend/zend_ini.h
@@ -19,6 +19,8 @@
 #ifndef ZEND_INI_H
 #define ZEND_INI_H
 
+#include "zend_result.h"
+
 #define ZEND_INI_USER	(1<<0)
 #define ZEND_INI_PERDIR	(1<<1)
 #define ZEND_INI_SYSTEM	(1<<2)

--- a/Zend/zend_modules.h
+++ b/Zend/zend_modules.h
@@ -23,6 +23,7 @@
 #include "zend.h"
 #include "zend_compile.h"
 #include "zend_build.h"
+#include "zend_result.h"
 
 #define INIT_FUNC_ARGS		int type, int module_number
 #define INIT_FUNC_ARGS_PASSTHRU	type, module_number

--- a/Zend/zend_multibyte.h
+++ b/Zend/zend_multibyte.h
@@ -20,6 +20,8 @@
 #ifndef ZEND_MULTIBYTE_H
 #define ZEND_MULTIBYTE_H
 
+#include "zend_result.h"
+
 typedef struct _zend_encoding zend_encoding;
 
 typedef size_t (*zend_encoding_filter)(unsigned char **str, size_t *str_length, const unsigned char *buf, size_t length);

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -21,6 +21,8 @@
 #ifndef ZEND_OPERATORS_H
 #define ZEND_OPERATORS_H
 
+#include "zend_result.h"
+
 #include <errno.h>
 #include <math.h>
 #include <assert.h>

--- a/Zend/zend_result.h
+++ b/Zend/zend_result.h
@@ -12,20 +12,16 @@
    | obtain it through the world-wide-web, please send a note to          |
    | license@zend.com so we can mail you a copy immediately.              |
    +----------------------------------------------------------------------+
-   | Authors: Andi Gutmans <andi@php.net>                                 |
-   |          Zeev Suraski <zeev@php.net>                                 |
-   +----------------------------------------------------------------------+
 */
 
-#ifndef ZEND_BUILTIN_FUNCTIONS_H
-#define ZEND_BUILTIN_FUNCTIONS_H
+#ifndef ZEND_RESULT_H
+#define ZEND_RESULT_H
 
-#include "zend_result.h"
+typedef enum {
+  SUCCESS =  0,
+  FAILURE = -1,		/* this MUST stay a negative number, or it may affect functions! */
+} ZEND_RESULT_CODE;
 
-zend_result zend_startup_builtin_functions(void);
+typedef ZEND_RESULT_CODE zend_result;
 
-BEGIN_EXTERN_C()
-ZEND_API void zend_fetch_debug_backtrace(zval *return_value, int skip_last, int options, int limit);
-END_EXTERN_C()
-
-#endif /* ZEND_BUILTIN_FUNCTIONS_H */
+#endif /* ZEND_RESULT_H */

--- a/Zend/zend_stream.h
+++ b/Zend/zend_stream.h
@@ -22,6 +22,8 @@
 #ifndef ZEND_STREAM_H
 #define ZEND_STREAM_H
 
+#include "zend_result.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/Zend/zend_system_id.h
+++ b/Zend/zend_system_id.h
@@ -17,6 +17,8 @@
 #ifndef ZEND_SYSTEM_ID_H
 #define ZEND_SYSTEM_ID_H
 
+#include "zend_result.h"
+
 BEGIN_EXTERN_C()
 /* True global; Write-only during MINIT/startup */
 extern ZEND_API char zend_system_id[32];

--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -24,6 +24,8 @@
 
 #include "zend_portability.h"
 #include "zend_long.h"
+#include "zend_result.h"
+
 #include <stdbool.h>
 
 #ifdef __SSE2__
@@ -49,13 +51,6 @@
 
 typedef bool zend_bool;
 typedef unsigned char zend_uchar;
-
-typedef enum {
-  SUCCESS =  0,
-  FAILURE = -1,		/* this MUST stay a negative number, or it may affect functions! */
-} ZEND_RESULT_CODE;
-
-typedef ZEND_RESULT_CODE zend_result;
 
 #ifdef ZEND_ENABLE_ZVAL_LONG64
 # ifdef ZEND_WIN32


### PR DESCRIPTION
Many sources need just `zend_result`, and with this new header, they only need to include `zend_result.h` instead of `zend_types.h`; the latter is large and has fat dependencies, which slows down the build.

(This implements the vote "Is it allowed to split a large header to reduce dependencies?" which was accepted by a supermajority, see https://wiki.php.net/rfc/include_cleanup)