### PR TITLE
makedist: Use fixed owner/group in generated tarball

### DIFF
--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -175,7 +175,7 @@ cd ..
 
 echo ""
 echo "makedist: Creating $prefix.tar archive."
-"$tar" cf "$prefix".tar "$prefix"
+"$tar" cf "$prefix".tar --owner=0 --group=0 --numeric-owner "$prefix"
 rm -rf "$prefix" "$prefix".tar.*
 
 echo "makedist: Creating $prefix.tar.gz archive."


### PR DESCRIPTION
This reduces the amount of system-dependent data within the tarball and makes it more reproducible. Instead of the information of the release manager that generates the tarball, the tarball will include the fixed 0:0 value as owner:group.

-------------

Specifically requesting a review from @ramsey, because https://phpc.social/@ramsey/109876124091468563. Feel free to request additional reviews from whomever you consider helpful.