### PR TITLE
makedist: Use fixed sort in generated tarball

### DIFF
--- a/scripts/dev/makedist
+++ b/scripts/dev/makedist
@@ -175,7 +175,7 @@ cd ..
 
 echo ""
 echo "makedist: Creating $prefix.tar archive."
-"$tar" cf "$prefix".tar --owner=0 --group=0 --numeric-owner "$prefix"
+"$tar" cf "$prefix".tar --owner=0 --group=0 --numeric-owner --sort=name "$prefix"
 rm -rf "$prefix" "$prefix".tar.*
 
 echo "makedist: Creating $prefix.tar.gz archive."


### PR DESCRIPTION
Instead of some undefined order, the files will now be includes in alphabetical order to make the tarball more reproducible.