### PR TITLE
Fix GH-10326: XSLTProcessor::transformToXml() doesn't need null return type

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -74,6 +74,10 @@ PHP 8.3 UPGRADE NOTES
   . password_hash() will now chain the underlying Random\RandomException
     as the ValueError’s $previous Exception when salt generation fails.
 
+- XSL:
+  . XSLTProcessor::transformToXml() no longer returns null if there are no children
+    in the resulting document.
+
 ========================================
 6. New Functions
 ========================================

--- a/ext/xsl/php_xsl.stub.php
+++ b/ext/xsl/php_xsl.stub.php
@@ -93,7 +93,7 @@ class XSLTProcessor
      * @param DOMDocument|SimpleXMLElement $document
      * @tentative-return-type
      */
-    public function transformToXml(object $document): string|null|false {}
+    public function transformToXml(object $document): string|false {}
 
     /** @tentative-return-type */
     public function setParameter(string $namespace, array|string $name, ?string $value = null): bool {}

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a0615bef7b2211570d9da95a31857832a06360dd */
+ * Stub hash: 94adc2591aa489c61de55b6236b5aa0bea739aa5 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_importStylesheet, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, stylesheet, IS_OBJECT, 0)
@@ -15,7 +15,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_tr
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_XSLTProcessor_transformToXml, 0, 1, MAY_BE_STRING|MAY_BE_NULL|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_XSLTProcessor_transformToXml, 0, 1, MAY_BE_STRING|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, document, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/xsl/tests/xsltprocessor_registerPHPFunctions-array-notallowed.phpt
+++ b/ext/xsl/tests/xsltprocessor_registerPHPFunctions-array-notallowed.phpt
@@ -19,7 +19,7 @@ var_dump($proc->transformToXml($dom));
 NULL
 
 Warning: XSLTProcessor::transformToXml(): Not allowed to call handler 'ucwords()' in %s on line %d
-NULL
+string(0) ""
 --CREDITS--
 Christian Weiske, cweiske@php.net
 PHP Testfest Berlin 2009-05-09

--- a/ext/xsl/tests/xsltprocessor_registerPHPFunctions-funcnostring.phpt
+++ b/ext/xsl/tests/xsltprocessor_registerPHPFunctions-funcnostring.phpt
@@ -22,7 +22,7 @@ var_dump($proc->transformToXml($dom));
 NULL
 
 Warning: XSLTProcessor::transformToXml(): Handler name must be a string in %s on line %d
-NULL
+string(0) ""
 --CREDITS--
 Christian Weiske, cweiske@php.net
 PHP Testfest Berlin 2009-05-09

--- a/ext/xsl/tests/xsltprocessor_registerPHPFunctions-funcundef.phpt
+++ b/ext/xsl/tests/xsltprocessor_registerPHPFunctions-funcundef.phpt
@@ -21,7 +21,7 @@ var_dump($proc->transformToXml($dom));
 NULL
 
 Warning: XSLTProcessor::transformToXml(): Unable to call handler undefinedfunc() in %s on line %d
-NULL
+string(0) ""
 --CREDITS--
 Christian Weiske, cweiske@php.net
 PHP Testfest Berlin 2009-05-09

--- a/ext/xsl/tests/xsltprocessor_registerPHPFunctions-string-notallowed.phpt
+++ b/ext/xsl/tests/xsltprocessor_registerPHPFunctions-string-notallowed.phpt
@@ -19,7 +19,7 @@ var_dump($proc->transformToXml($dom));
 NULL
 
 Warning: XSLTProcessor::transformToXml(): Not allowed to call handler 'ucwords()' in %s on line %d
-NULL
+string(0) ""
 --CREDITS--
 Christian Weiske, cweiske@php.net
 PHP Testfest Berlin 2009-05-09

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -653,9 +653,13 @@ PHP_METHOD(XSLTProcessor, transformToXml)
 	ret = -1;
 	if (newdocp) {
 		ret = xsltSaveResultToString(&doc_txt_ptr, &doc_txt_len, newdocp, sheetp);
-		if (doc_txt_ptr && doc_txt_len) {
-			RETVAL_STRINGL((char *) doc_txt_ptr, doc_txt_len);
-			xmlFree(doc_txt_ptr);
+		if (ret == 0) {
+			if (doc_txt_ptr == NULL) {
+				RETVAL_EMPTY_STRING();
+			} else {
+				RETVAL_STRINGL((char *) doc_txt_ptr, doc_txt_len);
+				xmlFree(doc_txt_ptr);
+			}
 		}
 		xmlFreeDoc(newdocp);
 	}


### PR DESCRIPTION
Fixes GH-10326

transformToXml returns either null, false (in case of error), or a string (containing the output)
It was possible that transformToXml returned null if there is are no children in the resulting output.
This is a little bit of a footgun, and this PR gets rid of that by returning the empty string in that case.

/cc @kocsismate 