### PR TITLE
Zend/zend_globals: convert fiber_stack_size to `size_t`

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -223,7 +223,7 @@ static ZEND_INI_MH(OnUpdateReservedStackSize) /* {{{ */
 static ZEND_INI_MH(OnUpdateFiberStackSize) /* {{{ */
 {
 	if (new_value) {
-		EG(fiber_stack_size) = zend_ini_parse_quantity_warn(new_value, entry->name);
+		EG(fiber_stack_size) = zend_ini_parse_uquantity_warn(new_value, entry->name);
 	} else {
 		EG(fiber_stack_size) = ZEND_FIBER_DEFAULT_C_STACK_SIZE;
 	}

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -269,7 +269,7 @@ struct _zend_executor_globals {
 	zend_fiber *active_fiber;
 
 	/* Default fiber C stack size. */
-	zend_long fiber_stack_size;
+	size_t fiber_stack_size;
 
 	/* If record_errors is enabled, all emitted diagnostics will be recorded,
 	 * in addition to being processed as usual. */


### PR DESCRIPTION
`zend_long` is a signed integer that's only 32 bit on some 64 bit architectures (e.g. ARM64).  The proper type for memory sizes is `size_t`, and this type is accepted by zend_fiber_init_context().