### PR TITLE
Zend/zend_fibers: change return value to zend_result

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -34,6 +34,9 @@ PHP 8.3 INTERNALS UPGRADE NOTES
   the class table. zend_register_class_alias_ex() will not increase
   the refcount for class aliases and the cleanup function takes this
   into account.
+* The return types of the following functions have been changed from
+  `bool` to `zend_result`:
+  - zend_fiber_init_context()
 
 ========================
 2. Build system changes

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -394,12 +394,12 @@ ZEND_API bool zend_fiber_switch_blocked(void)
 	return zend_fiber_switch_blocking;
 }
 
-ZEND_API bool zend_fiber_init_context(zend_fiber_context *context, void *kind, zend_fiber_coroutine coroutine, size_t stack_size)
+ZEND_API zend_result zend_fiber_init_context(zend_fiber_context *context, void *kind, zend_fiber_coroutine coroutine, size_t stack_size)
 {
 	context->stack = zend_fiber_stack_allocate(stack_size);
 
 	if (UNEXPECTED(!context->stack)) {
-		return false;
+		return FAILURE;
 	}
 
 #ifdef ZEND_FIBER_UCONTEXT
@@ -438,7 +438,7 @@ ZEND_API bool zend_fiber_init_context(zend_fiber_context *context, void *kind, z
 
 	zend_observer_fiber_init_notify(context);
 
-	return true;
+	return SUCCESS;
 }
 
 ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context)
@@ -812,7 +812,7 @@ ZEND_METHOD(Fiber, start)
 		RETURN_THROWS();
 	}
 
-	if (!zend_fiber_init_context(&fiber->context, zend_ce_fiber, zend_fiber_execute, EG(fiber_stack_size))) {
+	if (zend_fiber_init_context(&fiber->context, zend_ce_fiber, zend_fiber_execute, EG(fiber_stack_size)) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/Zend/zend_fibers.h
+++ b/Zend/zend_fibers.h
@@ -133,7 +133,7 @@ struct _zend_fiber {
 };
 
 /* These functions may be used to create custom fiber objects using the bundled fiber switching context. */
-ZEND_API bool zend_fiber_init_context(zend_fiber_context *context, void *kind, zend_fiber_coroutine coroutine, size_t stack_size);
+ZEND_API zend_result zend_fiber_init_context(zend_fiber_context *context, void *kind, zend_fiber_coroutine coroutine, size_t stack_size);
 ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context);
 ZEND_API void zend_fiber_switch_context(zend_fiber_transfer *transfer);
 #ifdef ZEND_CHECK_STACK_LIMIT


### PR DESCRIPTION
According to @nikic:

> The current guideline for use of bool and zend_result in php-src is
> that bool is an appropriate return value for "is" or "has" style
> functions, which return a yes/no answer. zend_result is an
> appropriate return value for functions that perform some operation
> that may succeed or fail.