### PR TITLE
Fix GH-10623: ReflectionFunction::getClosureUsedVariables() returns empty array in presence of variadic arguments

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1747,6 +1747,10 @@ ZEND_METHOD(ReflectionFunctionAbstract, getClosureUsedVariables)
 		}
 
 		zend_op *opline = ops->opcodes + ops->num_args;
+		if (ops->fn_flags & ZEND_ACC_VARIADIC) {
+			ZEND_ASSERT(opline->opcode == ZEND_RECV_VARIADIC);
+			opline++;
+		}
 
 		for (; opline->opcode == ZEND_BIND_STATIC; opline++)  {
 			if (!(opline->extended_value & (ZEND_BIND_IMPLICIT|ZEND_BIND_EXPLICIT))) {

--- a/ext/reflection/tests/gh10623.phpt
+++ b/ext/reflection/tests/gh10623.phpt
@@ -1,0 +1,64 @@
+--TEST--
+GH-10623 (ReflectionFunction::getClosureUsedVariables() returns empty array in presence of variadic arguments)
+--FILE--
+<?php
+
+$data1 = 1;
+$data2 = 2;
+$data3 = 3;
+
+$closure = function($var) use($data1) {};
+var_dump((new ReflectionFunction($closure))->getClosureUsedVariables());
+
+$closure = function($var, ...$variadic) {};
+var_dump((new ReflectionFunction($closure))->getClosureUsedVariables());
+
+$closure = function($var, ...$variadic) use($data1) {};
+var_dump((new ReflectionFunction($closure))->getClosureUsedVariables());
+
+$closure = function($var, ...$variadic) use($data1, $data2, $data3) {};
+var_dump((new ReflectionFunction($closure))->getClosureUsedVariables());
+
+$closure = function(...$variadic) use($data1) {};
+var_dump((new ReflectionFunction($closure))->getClosureUsedVariables());
+
+$closure = function($var, $var2, ...$variadic) {};
+var_dump((new ReflectionFunction($closure))->getClosureUsedVariables());
+
+$closure = function($var, $var2, $var3, ...$variadic) use($data1, $data2, $data3) {};
+var_dump((new ReflectionFunction($closure))->getClosureUsedVariables());
+
+?>
+--EXPECT--
+array(1) {
+  ["data1"]=>
+  int(1)
+}
+array(0) {
+}
+array(1) {
+  ["data1"]=>
+  int(1)
+}
+array(3) {
+  ["data1"]=>
+  int(1)
+  ["data2"]=>
+  int(2)
+  ["data3"]=>
+  int(3)
+}
+array(1) {
+  ["data1"]=>
+  int(1)
+}
+array(0) {
+}
+array(3) {
+  ["data1"]=>
+  int(1)
+  ["data2"]=>
+  int(2)
+  ["data3"]=>
+  int(3)
+}


### PR DESCRIPTION
Fixes GH-10623
The code was missing the handling for the RECV_VARIADIC instruction.
