### PR TITLE
Fix GH-10627: mb_convert_encoding crashes PHP on Windows

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2446,6 +2446,9 @@ MBSTRING_API HashTable *php_mb_convert_encoding_recursive(HashTable *input, cons
 			ckey = php_mb_convert_encoding(
 				ZSTR_VAL(key), ZSTR_LEN(key),
 				to_encoding, from_encodings, num_from_encodings, &ckey_len);
+			if (!ckey) {
+				continue;
+			}
 			key = zend_string_init(ckey, ckey_len, 0);
 			efree(ckey);
 		}
@@ -2457,6 +2460,12 @@ try_again:
 				cval = php_mb_convert_encoding(
 					Z_STRVAL_P(entry), Z_STRLEN_P(entry),
 					to_encoding, from_encodings, num_from_encodings, &cval_len);
+				if (!cval) {
+					if (key) {
+						zend_string_release(key);
+					}
+					continue;
+				}
 				ZVAL_STRINGL(&entry_tmp, cval, cval_len);
 				efree(cval);
 				break;

--- a/ext/mbstring/tests/gh10627.phpt
+++ b/ext/mbstring/tests/gh10627.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-10627 (mb_convert_encoding crashes PHP on Windows)
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+
+$str = 'Sökinställningar';
+$data = [$str, 'abc'];
+var_dump(mb_convert_encoding($data, 'UTF-8', 'auto'));
+$data = [$str => 'abc', 'abc' => 'def'];
+var_dump(mb_convert_encoding($data, 'UTF-8', 'auto'));
+
+?>
+--EXPECTF--
+Warning: mb_convert_encoding(): Unable to detect character encoding in %s on line %d
+array(1) {
+  [1]=>
+  string(3) "abc"
+}
+
+Warning: mb_convert_encoding(): Unable to detect character encoding in %s on line %d
+array(1) {
+  ["abc"]=>
+  string(3) "def"
+}


### PR DESCRIPTION
Fixes GH-10627

The php_mb_convert_encoding() function can return NULL on error, but this case was not handled, which led to a NULL pointer dereference and hence a crash.