### PR TITLE
CODING_STANDARDS.md: add rules for bool/zend_result return types

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -74,6 +74,11 @@ rewritten to comply with these rules.
     may need to control or free the memory, or when the memory in question needs
     to survive between multiple requests.
 
+1. The return type of "is" or "has" style functions should be `bool`,
+    which return a "yes"/"no" answer.  `zend_result` is an appropriate
+    return value for functions that perform some operation that may
+    succeed or fail.
+
 ## User functions/methods naming conventions
 
 1. Function names for user-level functions should be enclosed with in the


### PR DESCRIPTION
@nikic mentioned this guideline on php-internals
(https://news-web.php.net/php.internals/119573), but it appears to be undocumented.