### PR TITLE
CODING_STANDARDS.md: establish C99 as the implementation language

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -9,6 +9,10 @@ rewritten to comply with these rules.
 
 1. Document your code in source files and the manual. (tm)
 
+1. PHP is implemented in C99.  The optional fixed-width integers from
+    stdint.h (int8_t, int16_t, int32_t, int64_t and their unsigned
+    counterparts) must be available.
+
 1. Functions that are given pointers to resources should not free them.
 
     For instance, `function int mail(char *to, char *from)` should NOT free `to`


### PR DESCRIPTION
PHP 8 switched to C99, but did not documented that anywhere.

After @derickr rejected a pull request on timelib
(https://github.com/derickr/timelib/pull/141#issuecomment-1386773784) because my suggested change removed compile-time checks for fixed-width integer types, pointing out that they are optional in the C99 standard, @nikic disagreed with using `uint_least8_t` instead (which is guaranteed to be available), stating that "We already make extensive use of uint8_t, you can assume it exists" (https://github.com/php/php-src/pull/10621#pullrequestreview-1304760668).

In order to avoid such confusion in the future, let's document this architecture requirement.