### PR TITLE
Fix Tidy tests failing due to different spelling

### DIFF
--- a/ext/tidy/tests/006.phpt
+++ b/ext/tidy/tests/006.phpt
@@ -8,9 +8,9 @@ tidy
     echo tidy_get_error_buffer($a);
 
 ?>
---EXPECT--
+--EXPECTF--
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
-line 1 column 7 - Error: <asd> is not recognized!
+line 1 column 7 - Error: <asd> is not recogni%ced!
 line 1 column 7 - Warning: discarding unexpected <asd>
 line 1 column 17 - Warning: discarding unexpected </html>
 line 1 column 7 - Warning: inserting missing 'title' element

--- a/ext/tidy/tests/008.phpt
+++ b/ext/tidy/tests/008.phpt
@@ -7,9 +7,9 @@ tidy
     $a = tidy_parse_string("<HTML><asd asdf></HTML>");
     echo $a->errorBuffer;
 ?>
---EXPECT--
+--EXPECTF--
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
-line 1 column 7 - Error: <asd> is not recognized!
+line 1 column 7 - Error: <asd> is not recogni%ced!
 line 1 column 7 - Warning: discarding unexpected <asd>
 line 1 column 17 - Warning: discarding unexpected </html>
 line 1 column 7 - Warning: inserting missing 'title' element


### PR DESCRIPTION
On my system, with Tidy 5.7.45, I get the following error diff for two tests:
002+ line 1 column 7 - Error: <asd> is not recognised!
002- line 1 column 7 - Error: <asd> is not recognized!

As we can see, the spelling of recognised is different. Use an EXPECTF and %c to mitigate this issue.