### PR TITLE
Fix misleading pass by reference error message

### DIFF
--- a/Zend/tests/bug72038.phpt
+++ b/Zend/tests/bug72038.phpt
@@ -25,6 +25,6 @@ function test(&$param) {
 
 ?>
 --EXPECT--
-test(): Argument #1 ($param) cannot be passed by reference
-test(): Argument #1 ($param) cannot be passed by reference
+test(): Argument #1 ($param) must be passed by reference
+test(): Argument #1 ($param) must be passed by reference
 int(1)

--- a/Zend/tests/bug72038.phpt
+++ b/Zend/tests/bug72038.phpt
@@ -25,6 +25,6 @@ function test(&$param) {
 
 ?>
 --EXPECT--
-test(): Argument #1 ($param) must be passed by reference
-test(): Argument #1 ($param) must be passed by reference
+test(): Argument #1 ($param) could not be passed by reference
+test(): Argument #1 ($param) could not be passed by reference
 int(1)

--- a/Zend/tests/bug73663_2.phpt
+++ b/Zend/tests/bug73663_2.phpt
@@ -12,7 +12,7 @@ change(list($val) = $array);
 var_dump($array);
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: change(): Argument #1 ($ref) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: change(): Argument #1 ($ref) could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug73663_2.phpt
+++ b/Zend/tests/bug73663_2.phpt
@@ -12,7 +12,7 @@ change(list($val) = $array);
 var_dump($array);
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: change(): Argument #1 ($ref) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: change(): Argument #1 ($ref) must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug78154.phpt
+++ b/Zend/tests/bug78154.phpt
@@ -22,5 +22,5 @@ namespace Foo {
 
 ?>
 --EXPECT--
-Exception: similar_text(): Argument #3 ($percent) must be passed by reference
-Exception: similar_text(): Argument #3 ($percent) must be passed by reference
+Exception: similar_text(): Argument #3 ($percent) could not be passed by reference
+Exception: similar_text(): Argument #3 ($percent) could not be passed by reference

--- a/Zend/tests/bug78154.phpt
+++ b/Zend/tests/bug78154.phpt
@@ -22,5 +22,5 @@ namespace Foo {
 
 ?>
 --EXPECT--
-Exception: similar_text(): Argument #3 ($percent) cannot be passed by reference
-Exception: similar_text(): Argument #3 ($percent) cannot be passed by reference
+Exception: similar_text(): Argument #3 ($percent) must be passed by reference
+Exception: similar_text(): Argument #3 ($percent) must be passed by reference

--- a/Zend/tests/bug79783.phpt
+++ b/Zend/tests/bug79783.phpt
@@ -5,7 +5,7 @@ Bug #79783: Segfault in php_str_replace_common
 str_replace("a", "b", "c", strlen("d"));
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: str_replace(): Argument #4 ($count) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: str_replace(): Argument #4 ($count) must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/bug79783.phpt
+++ b/Zend/tests/bug79783.phpt
@@ -5,7 +5,7 @@ Bug #79783: Segfault in php_str_replace_common
 str_replace("a", "b", "c", strlen("d"));
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: str_replace(): Argument #4 ($count) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: str_replace(): Argument #4 ($count) could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/closure_019.phpt
+++ b/Zend/tests/closure_019.phpt
@@ -26,7 +26,7 @@ int(9)
 Notice: Only variable references should be returned by reference in %sclosure_019.php on line 4
 int(81)
 
-Fatal error: Uncaught Error: {closure}(): Argument #1 ($x) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: {closure}(): Argument #1 ($x) must be passed by reference in %s:%d
 Stack trace:
 #0 %s(%d): test()
 #1 {main}

--- a/Zend/tests/closure_019.phpt
+++ b/Zend/tests/closure_019.phpt
@@ -26,7 +26,7 @@ int(9)
 Notice: Only variable references should be returned by reference in %sclosure_019.php on line 4
 int(81)
 
-Fatal error: Uncaught Error: {closure}(): Argument #1 ($x) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: {closure}(): Argument #1 ($x) could not be passed by reference in %s:%d
 Stack trace:
 #0 %s(%d): test()
 #1 {main}

--- a/Zend/tests/errmsg_022.phpt
+++ b/Zend/tests/errmsg_022.phpt
@@ -11,7 +11,7 @@ foo(1);
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: foo(): Argument #1 ($var) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: foo(): Argument #1 ($var) could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/errmsg_022.phpt
+++ b/Zend/tests/errmsg_022.phpt
@@ -11,7 +11,7 @@ foo(1);
 echo "Done\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: foo(): Argument #1 ($var) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: foo(): Argument #1 ($var) must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/match/027.phpt
+++ b/Zend/tests/match/027.phpt
@@ -30,7 +30,7 @@ main();
 usesValue 0
 i is 0
 
-Fatal error: Uncaught Error: Test::usesRef(): Argument #1 ($x) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: Test::usesRef(): Argument #1 ($x) could not be passed by reference in %s:%d
 Stack trace:
 #0 %s(%d): main()
 #1 {main}

--- a/Zend/tests/match/027.phpt
+++ b/Zend/tests/match/027.phpt
@@ -30,7 +30,7 @@ main();
 usesValue 0
 i is 0
 
-Fatal error: Uncaught Error: Test::usesRef(): Argument #1 ($x) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: Test::usesRef(): Argument #1 ($x) must be passed by reference in %s:%d
 Stack trace:
 #0 %s(%d): main()
 #1 {main}

--- a/Zend/tests/match/028.phpt
+++ b/Zend/tests/match/028.phpt
@@ -34,4 +34,4 @@ try {
 usesValue 42
 usesValue 42
 int(42)
-Caught Test::usesRef(): Argument #1 ($x) cannot be passed by reference
+Caught Test::usesRef(): Argument #1 ($x) must be passed by reference

--- a/Zend/tests/match/028.phpt
+++ b/Zend/tests/match/028.phpt
@@ -34,4 +34,4 @@ try {
 usesValue 42
 usesValue 42
 int(42)
-Caught Test::usesRef(): Argument #1 ($x) must be passed by reference
+Caught Test::usesRef(): Argument #1 ($x) could not be passed by reference

--- a/Zend/tests/named_params/cannot_pass_by_ref.phpt
+++ b/Zend/tests/named_params/cannot_pass_by_ref.phpt
@@ -10,4 +10,4 @@ try {
 }
 ?>
 --EXPECT--
-test(): Argument #2 ($e) cannot be passed by reference
+test(): Argument #2 ($e) must be passed by reference

--- a/Zend/tests/named_params/cannot_pass_by_ref.phpt
+++ b/Zend/tests/named_params/cannot_pass_by_ref.phpt
@@ -10,4 +10,4 @@ try {
 }
 ?>
 --EXPECT--
-test(): Argument #2 ($e) must be passed by reference
+test(): Argument #2 ($e) could not be passed by reference

--- a/Zend/tests/nullsafe_operator/016.phpt
+++ b/Zend/tests/nullsafe_operator/016.phpt
@@ -29,7 +29,7 @@ test(new Foo());
 
 ?>
 --EXPECT--
-set(): Argument #1 ($ref) must be passed by reference
-set(): Argument #1 ($ref) must be passed by reference
-set(): Argument #1 ($ref) must be passed by reference
-set(): Argument #1 ($ref) must be passed by reference
+set(): Argument #1 ($ref) could not be passed by reference
+set(): Argument #1 ($ref) could not be passed by reference
+set(): Argument #1 ($ref) could not be passed by reference
+set(): Argument #1 ($ref) could not be passed by reference

--- a/Zend/tests/nullsafe_operator/016.phpt
+++ b/Zend/tests/nullsafe_operator/016.phpt
@@ -29,7 +29,7 @@ test(new Foo());
 
 ?>
 --EXPECT--
-set(): Argument #1 ($ref) cannot be passed by reference
-set(): Argument #1 ($ref) cannot be passed by reference
-set(): Argument #1 ($ref) cannot be passed by reference
-set(): Argument #1 ($ref) cannot be passed by reference
+set(): Argument #1 ($ref) must be passed by reference
+set(): Argument #1 ($ref) must be passed by reference
+set(): Argument #1 ($ref) must be passed by reference
+set(): Argument #1 ($ref) must be passed by reference

--- a/Zend/tests/restrict_globals/invalid_pass_by_ref.phpt
+++ b/Zend/tests/restrict_globals/invalid_pass_by_ref.phpt
@@ -1,5 +1,5 @@
 --TEST--
-$GLOBALS cannot be passed by reference (runtime error)
+$GLOBALS must be passed by reference (runtime error)
 --FILE--
 <?php
 
@@ -19,5 +19,5 @@ function by_ref2(&$ref) {}
 
 ?>
 --EXPECT--
-by_ref(): Argument #1 ($ref) cannot be passed by reference
-by_ref2(): Argument #1 ($ref) cannot be passed by reference
+by_ref(): Argument #1 ($ref) must be passed by reference
+by_ref2(): Argument #1 ($ref) must be passed by reference

--- a/Zend/tests/restrict_globals/invalid_pass_by_ref.phpt
+++ b/Zend/tests/restrict_globals/invalid_pass_by_ref.phpt
@@ -19,5 +19,5 @@ function by_ref2(&$ref) {}
 
 ?>
 --EXPECT--
-by_ref(): Argument #1 ($ref) must be passed by reference
-by_ref2(): Argument #1 ($ref) must be passed by reference
+by_ref(): Argument #1 ($ref) could not be passed by reference
+by_ref2(): Argument #1 ($ref) could not be passed by reference

--- a/Zend/tests/variadic/by_ref_error.phpt
+++ b/Zend/tests/variadic/by_ref_error.phpt
@@ -9,7 +9,7 @@ test(1);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: test(): Argument #1 must be passed by reference in %s:%d
+Fatal error: Uncaught Error: test(): Argument #1 could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/variadic/by_ref_error.phpt
+++ b/Zend/tests/variadic/by_ref_error.phpt
@@ -9,7 +9,7 @@ test(1);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: test(): Argument #1 cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: test(): Argument #1 must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -595,7 +595,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_cannot_pass_by_reference(uint32_t arg
 	zend_string *func_name = get_function_or_method_name(EX(call)->func);
 	const char *param_name = get_function_arg_name(EX(call)->func, arg_num);
 
-	zend_throw_error(NULL, "%s(): Argument #%d%s%s%s cannot be passed by reference",
+	zend_throw_error(NULL, "%s(): Argument #%d%s%s%s must be passed by reference",
 		ZSTR_VAL(func_name), arg_num, param_name ? " ($" : "", param_name ? param_name : "", param_name ? ")" : ""
 	);
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -595,7 +595,7 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_cannot_pass_by_reference(uint32_t arg
 	zend_string *func_name = get_function_or_method_name(EX(call)->func);
 	const char *param_name = get_function_arg_name(EX(call)->func, arg_num);
 
-	zend_throw_error(NULL, "%s(): Argument #%d%s%s%s must be passed by reference",
+	zend_throw_error(NULL, "%s(): Argument #%d%s%s%s could not be passed by reference",
 		ZSTR_VAL(func_name), arg_num, param_name ? " ($" : "", param_name ? param_name : "", param_name ? ")" : ""
 	);
 

--- a/ext/opcache/tests/optimize_func_calls.phpt
+++ b/ext/opcache/tests/optimize_func_calls.phpt
@@ -128,7 +128,7 @@ Array
 string(7) "changed"
 string(7) "changed"
 
-Fatal error: Uncaught Error: ref(): Argument #1 ($b) must be passed by reference in %soptimize_func_calls.php:%d
+Fatal error: Uncaught Error: ref(): Argument #1 ($b) could not be passed by reference in %soptimize_func_calls.php:%d
 Stack trace:
 #0 {main}
   thrown in %soptimize_func_calls.php on line %d

--- a/ext/opcache/tests/optimize_func_calls.phpt
+++ b/ext/opcache/tests/optimize_func_calls.phpt
@@ -128,7 +128,7 @@ Array
 string(7) "changed"
 string(7) "changed"
 
-Fatal error: Uncaught Error: ref(): Argument #1 ($b) cannot be passed by reference in %soptimize_func_calls.php:%d
+Fatal error: Uncaught Error: ref(): Argument #1 ($b) must be passed by reference in %soptimize_func_calls.php:%d
 Stack trace:
 #0 {main}
   thrown in %soptimize_func_calls.php on line %d

--- a/ext/pcre/tests/preg_match_all_error3.phpt
+++ b/ext/pcre/tests/preg_match_all_error3.phpt
@@ -17,7 +17,7 @@ echo "Done";
 --EXPECTF--
 *** Testing preg_match_all() : error conditions ***
 
-Fatal error: Uncaught Error: preg_match_all(): Argument #3 ($matches) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: preg_match_all(): Argument #3 ($matches) must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pcre/tests/preg_match_all_error3.phpt
+++ b/ext/pcre/tests/preg_match_all_error3.phpt
@@ -17,7 +17,7 @@ echo "Done";
 --EXPECTF--
 *** Testing preg_match_all() : error conditions ***
 
-Fatal error: Uncaught Error: preg_match_all(): Argument #3 ($matches) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: preg_match_all(): Argument #3 ($matches) could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/pdo_mysql/tests/bug_37445.phpt
+++ b/ext/pdo_mysql/tests/bug_37445.phpt
@@ -19,7 +19,7 @@ $stmt = $db->prepare("SELECT 1");
 $stmt->bindParam(':a', 'b');
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: PDOStatement::bindParam(): Argument #2 ($var) cannot be passed by reference in %sbug_37445.php:%d
+Fatal error: Uncaught Error: PDOStatement::bindParam(): Argument #2 ($var) must be passed by reference in %sbug_37445.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug_37445.php on line %d

--- a/ext/pdo_mysql/tests/bug_37445.phpt
+++ b/ext/pdo_mysql/tests/bug_37445.phpt
@@ -19,7 +19,7 @@ $stmt = $db->prepare("SELECT 1");
 $stmt->bindParam(':a', 'b');
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: PDOStatement::bindParam(): Argument #2 ($var) must be passed by reference in %sbug_37445.php:%d
+Fatal error: Uncaught Error: PDOStatement::bindParam(): Argument #2 ($var) could not be passed by reference in %sbug_37445.php:%d
 Stack trace:
 #0 {main}
   thrown in %sbug_37445.php on line %d

--- a/ext/standard/tests/array/array_next_error2.phpt
+++ b/ext/standard/tests/array/array_next_error2.phpt
@@ -8,7 +8,7 @@ function f() {
 var_dump(next(array(1, 2)));
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: next(): Argument #1 ($array) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: next(): Argument #1 ($array) could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/standard/tests/array/array_next_error2.phpt
+++ b/ext/standard/tests/array/array_next_error2.phpt
@@ -8,7 +8,7 @@ function f() {
 var_dump(next(array(1, 2)));
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: next(): Argument #1 ($array) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: next(): Argument #1 ($array) must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/standard/tests/array/bug31158.phpt
+++ b/ext/standard/tests/array/bug31158.phpt
@@ -14,7 +14,7 @@ __();
 echo "ok\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: array_splice(): Argument #1 ($array) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: array_splice(): Argument #1 ($array) could not be passed by reference in %s:%d
 Stack trace:
 #0 %s(%d): __()
 #1 {main}

--- a/ext/standard/tests/array/bug31158.phpt
+++ b/ext/standard/tests/array/bug31158.phpt
@@ -14,7 +14,7 @@ __();
 echo "ok\n";
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: array_splice(): Argument #1 ($array) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: array_splice(): Argument #1 ($array) must be passed by reference in %s:%d
 Stack trace:
 #0 %s(%d): __()
 #1 {main}

--- a/ext/standard/tests/array/prev_error3.phpt
+++ b/ext/standard/tests/array/prev_error3.phpt
@@ -10,7 +10,7 @@ prev - ensure we cannot pass a temporary
 var_dump(prev(array(1, 2)));
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: prev(): Argument #1 ($array) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: prev(): Argument #1 ($array) could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/ext/standard/tests/array/prev_error3.phpt
+++ b/ext/standard/tests/array/prev_error3.phpt
@@ -10,7 +10,7 @@ prev - ensure we cannot pass a temporary
 var_dump(prev(array(1, 2)));
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: prev(): Argument #1 ($array) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: prev(): Argument #1 ($array) must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/constants_error_003.phpt
+++ b/tests/classes/constants_error_003.phpt
@@ -16,7 +16,7 @@ Basic class support - attempting to pass a class constant by reference.
   var_dump(aclass::myConst);
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: f(): Argument #1 ($a) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: f(): Argument #1 ($a) must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/classes/constants_error_003.phpt
+++ b/tests/classes/constants_error_003.phpt
@@ -16,7 +16,7 @@ Basic class support - attempting to pass a class constant by reference.
   var_dump(aclass::myConst);
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: f(): Argument #1 ($a) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: f(): Argument #1 ($a) could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/lang/passByReference_002.phpt
+++ b/tests/lang/passByReference_002.phpt
@@ -12,7 +12,7 @@ f(2);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: f(): Argument #1 ($arg1) must be passed by reference in %s:%d
+Fatal error: Uncaught Error: f(): Argument #1 ($arg1) could not be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/lang/passByReference_002.phpt
+++ b/tests/lang/passByReference_002.phpt
@@ -12,7 +12,7 @@ f(2);
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: f(): Argument #1 ($arg1) cannot be passed by reference in %s:%d
+Fatal error: Uncaught Error: f(): Argument #1 ($arg1) must be passed by reference in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/tests/lang/passByReference_010.phpt
+++ b/tests/lang/passByReference_010.phpt
@@ -50,11 +50,11 @@ try {
 ?>
 --EXPECT--
 ---> Pass constant assignment by reference:
-Exception: f(): Argument #1 ($a) cannot be passed by reference
+Exception: f(): Argument #1 ($a) must be passed by reference
 
 
 ---> Pass variable assignment by reference:
-Exception: f(): Argument #1 ($a) cannot be passed by reference
+Exception: f(): Argument #1 ($a) must be passed by reference
 
 
 ---> Pass reference assignment by reference:
@@ -63,4 +63,4 @@ string(9) "a.changed"
 
 
 ---> Pass concat assignment by reference:
-Exception: f(): Argument #1 ($a) cannot be passed by reference
+Exception: f(): Argument #1 ($a) must be passed by reference

--- a/tests/lang/passByReference_010.phpt
+++ b/tests/lang/passByReference_010.phpt
@@ -50,11 +50,11 @@ try {
 ?>
 --EXPECT--
 ---> Pass constant assignment by reference:
-Exception: f(): Argument #1 ($a) must be passed by reference
+Exception: f(): Argument #1 ($a) could not be passed by reference
 
 
 ---> Pass variable assignment by reference:
-Exception: f(): Argument #1 ($a) must be passed by reference
+Exception: f(): Argument #1 ($a) could not be passed by reference
 
 
 ---> Pass reference assignment by reference:
@@ -63,4 +63,4 @@ string(9) "a.changed"
 
 
 ---> Pass concat assignment by reference:
-Exception: f(): Argument #1 ($a) must be passed by reference
+Exception: f(): Argument #1 ($a) could not be passed by reference


### PR DESCRIPTION
Currently, when a reference parameter is passed by value, the `Argument #x ($y) cannot be passed by reference` is written in the error message. This is utterly misleading, since I would assume that the argument mustn't be passed by reference. Now, this is fixed by using the `must be passed by reference` wording..