### PR TITLE
Enable `-Wassign-enum` in the Cirrus clang build (plus two fixes)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -147,7 +147,8 @@ asan_task:
         `#--with-pdo-firebird`
         `#--with-pdo-dblib`
         --enable-werror
-        CFLAGS='-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC' LDFLAGS='-fsanitize=undefined,address'
+        CFLAGS='-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC'
+        LDFLAGS='-fsanitize=undefined,address'
         CC=clang
         CXX=clang++
     - make -j2

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -147,7 +147,7 @@ asan_task:
         `#--with-pdo-firebird`
         `#--with-pdo-dblib`
         --enable-werror
-        CFLAGS='-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC'
+        CFLAGS='-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC -Wassign-enum'
         LDFLAGS='-fsanitize=undefined,address'
         CC=clang
         CXX=clang++

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1026,7 +1026,7 @@ static void php_set_attribute_id(xmlAttrPtr attrp, bool is_id) /* {{{ */
 		}
 	} else if (is_id == 0 && attrp->atype == XML_ATTRIBUTE_ID) {
 		xmlRemoveID(attrp->doc, attrp);
-		attrp->atype = 0;
+		attrp->atype = (xmlAttributeType)0;
 	}
 }
 /* }}} */

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -1149,9 +1149,6 @@ MYSQLND_METHOD(mysqlnd_stmt, bind_parameters)(MYSQLND_STMT * const s, MYSQLND_PA
 			/* Don't update is_ref, or we will leak during conversion */
 			Z_TRY_ADDREF(stmt->param_bind[i].zv);
 			stmt->param_bind[i].flags = 0;
-			if (stmt->param_bind[i].type == MYSQL_TYPE_LONG_BLOB) {
-				stmt->param_bind[i].flags &= ~MYSQLND_PARAM_BIND_BLOB_USED;
-			}
 		}
 		stmt->send_types_to_server = 1;
 	} else if (param_bind && param_bind != stmt->param_bind) {

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -919,7 +919,7 @@ MYSQLND_METHOD(mysqlnd_stmt, reset)(MYSQLND_STMT * const s)
 			/* Reset Long Data */
 			for (i = 0; i < stmt->param_count; i++) {
 				if (stmt->param_bind[i].flags & MYSQLND_PARAM_BIND_BLOB_USED) {
-					stmt->param_bind[i].flags &= ~MYSQLND_PARAM_BIND_BLOB_USED;
+					stmt->param_bind[i].flags = (enum_param_bind_flags)(stmt->param_bind[i].flags & ~MYSQLND_PARAM_BIND_BLOB_USED);
 				}
 			}
 		}
@@ -1148,7 +1148,7 @@ MYSQLND_METHOD(mysqlnd_stmt, bind_parameters)(MYSQLND_STMT * const s, MYSQLND_PA
 			/* Prevent from freeing */
 			/* Don't update is_ref, or we will leak during conversion */
 			Z_TRY_ADDREF(stmt->param_bind[i].zv);
-			stmt->param_bind[i].flags = 0;
+			stmt->param_bind[i].flags = (enum_param_bind_flags)0;
 		}
 		stmt->send_types_to_server = 1;
 	} else if (param_bind && param_bind != stmt->param_bind) {
@@ -1204,7 +1204,7 @@ MYSQLND_METHOD(mysqlnd_stmt, bind_one_parameter)(MYSQLND_STMT * const s, unsigne
 		zval_ptr_dtor(&stmt->param_bind[param_no].zv);
 		if (type == MYSQL_TYPE_LONG_BLOB) {
 			/* The client will use stmt_send_long_data */
-			stmt->param_bind[param_no].flags &= ~MYSQLND_PARAM_BIND_BLOB_USED;
+			stmt->param_bind[param_no].flags = (enum_param_bind_flags)(stmt->param_bind[param_no].flags & ~MYSQLND_PARAM_BIND_BLOB_USED);
 		}
 		ZVAL_COPY_VALUE(&stmt->param_bind[param_no].zv, zv);
 		stmt->param_bind[param_no].type = type;

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -768,7 +768,7 @@ mysqlnd_stmt_execute_store_param_values(MYSQLND_STMT_DATA * stmt, zval * copies,
 					break;
 				case MYSQL_TYPE_LONG_BLOB:
 					if (stmt->param_bind[i].flags & MYSQLND_PARAM_BIND_BLOB_USED) {
-						stmt->param_bind[i].flags &= ~MYSQLND_PARAM_BIND_BLOB_USED;
+						stmt->param_bind[i].flags = (enum_param_bind_flags)(stmt->param_bind[i].flags & ~MYSQLND_PARAM_BIND_BLOB_USED);
 					} else {
 						/* send_long_data() not called, send empty string */
 						*p = php_mysqlnd_net_store_length(*p, 0);

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -7634,7 +7634,7 @@ repeat:
 	if (stop & ZEND_JIT_TRACE_HALT) {
 		ret = -1;
 	}
-	stop &= ~ZEND_JIT_TRACE_HALT;
+	stop = (zend_jit_trace_stop)(stop & ~ZEND_JIT_TRACE_HALT);
 
 	if (UNEXPECTED(trace_buffer[1].opline != orig_opline)) {
 		orig_opline = trace_buffer[1].opline;
@@ -7972,7 +7972,7 @@ int ZEND_FASTCALL zend_jit_trace_hot_side(zend_execute_data *execute_data, uint3
 	if (stop & ZEND_JIT_TRACE_HALT) {
 		ret = -1;
 	}
-	stop &= ~ZEND_JIT_TRACE_HALT;
+	stop = (zend_jit_trace_stop)(stop & ~ZEND_JIT_TRACE_HALT);
 
 	if (UNEXPECTED(trace_buffer->start != ZEND_JIT_TRACE_START_SIDE)) {
 		if (JIT_G(debug) & ZEND_JIT_DEBUG_TRACE_START) {

--- a/ext/openssl/xp_ssl.c
+++ b/ext/openssl/xp_ssl.c
@@ -2323,7 +2323,7 @@ static inline int php_openssl_tcp_sockop_accept(php_stream *stream, php_openssl_
 
 		if (xparam->outputs.client && sock->enable_on_connect) {
 			/* remove the client bit */
-			sock->method &= ~STREAM_CRYPTO_IS_CLIENT;
+			sock->method = (php_stream_xport_crypt_method_t)(sock->method & ~STREAM_CRYPTO_IS_CLIENT);
 
 			clisockdata->method = sock->method;
 


### PR DESCRIPTION
See https://github.com/php/php-src/pull/10617#pullrequestreview-1305655803

I've submitted the two fixes to PHP-8.1 as well: https://github.com/php/php-src/pull/10640 - if that PR gets merged, I'll drop these commits here. You decide.