### PR TITLE
Propagate errors correctly in ps_files_cleanup_dir()

### DIFF
--- a/ext/session/mod_files.c
+++ b/ext/session/mod_files.c
@@ -292,7 +292,7 @@ static int ps_files_cleanup_dir(const char *dirname, zend_long maxlifetime)
 	dir = opendir(dirname);
 	if (!dir) {
 		php_error_docref(NULL, E_NOTICE, "ps_files_cleanup_dir: opendir(%s) failed: %s (%d)", dirname, strerror(errno), errno);
-		return (0);
+		return -1;
 	}
 
 	time(&now);
@@ -302,7 +302,7 @@ static int ps_files_cleanup_dir(const char *dirname, zend_long maxlifetime)
 	if (dirname_len >= MAXPATHLEN) {
 		php_error_docref(NULL, E_NOTICE, "ps_files_cleanup_dir: dirname(%s) is too long", dirname);
 		closedir(dir);
-		return (0);
+		return -1;
 	}
 
 	/* Prepare buffer (dirname never changes) */


### PR DESCRIPTION
In SessionHandler::gc, we use a virtual call to PS(default_mod)->s_gc to call the gc implementation. That return value is checked against FAILURE.
One of the call targets of PS(default_mod)->s_gc is ps_gc_files(). ps_gc_files() calls to ps_files_cleanup_dir(). The latter function has some error checks and outputs a notice if something goes wrong. In cases of errors, the function returns 0. This means that the check in SessionHandler::gc will misinterpret this as a success and report that 0 files have been *successfully* cleaned up. Fix it by returning -1 to indicate something *did* go wrong.

Found using an experimental static analyser I'm developing.