### PR TITLE
JIT: Fix SIGSEGV issue while running hyperf-skeleton

### DIFF
--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -10015,8 +10015,10 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 				if (func
 				 && !(func->op_array.fn_flags & ZEND_ACC_CLOSURE)
 				 && ZEND_MAP_PTR_IS_OFFSET(func->op_array.run_time_cache)) {
-					|	MEM_LOAD_ZTS r2, aword, compiler_globals, map_ptr_base, r1
-					|	mov r2, aword [r2 + (uintptr_t)ZEND_MAP_PTR(func->op_array.run_time_cache)]
+					|	mov r0, EX:RX->func
+					|	mov r2, aword [r0 + offsetof(zend_op_array, run_time_cache__ptr)]
+					|	MEM_LOAD_OP_ZTS add, r2, aword, compiler_globals, map_ptr_base, r1
+					|	mov r2, aword [r2]
 				} else if ((func && (func->op_array.fn_flags & ZEND_ACC_CLOSURE)) ||
 						(JIT_G(current_frame) &&
 						 JIT_G(current_frame)->call &&


### PR DESCRIPTION
While benchmark hyperf-skeleton with JIT tracing enabled, the following message is thrown in the output of hyperf:

`Server::check_worker_exit_status(): worker(pid=70835, id=7) \ abnormal exit, status=0, signal=11`

Checking the core dump file, it's seen that:

```
Thread 1 "php" received signal SIGSEGV, Segmentation fault. 0x00005570c716b034 in zend_fetch_ce_from_cache_slot (cache_slot=0x8,\
 type=0x7fa96f368d18) at /home/sdp/php/php-src/Zend/zend_execute.c:980
980             if (EXPECTED(HAVE_CACHE_SLOT && *cache_slot)) {
```

EX(run_time_cache) is NULL which directly causes the issue.

With JIT tracing enabled, run_time_cache is loaded in zend_jit_do_fcall(). For the case that run_time_cache is an offset, if we load it from EX:RX->func, rather than func, the SIGSEGV will be resolved. So it seems that EX:RX->func->op_array->run_time_cache__ptr and func->op_array->run_time_cache__ptr does not always keep accordance with each other during runtime. It's safe to load from EX:RX->func.

This fix is verified on PHP-8.2.3 and swoole v5.0.2, benchmark hyperf-skeleton with:
`wrk -t 10 -c 500 -d 300  http://127.0.0.1:9501/`
With this fix, hyperf-skeleton can gain around 9% RPS gain with JIT tracing enabled.