### PR TITLE
New test case from ed0c0df351 exercises the code it was intended to

### DIFF
--- a/ext/mbstring/tests/gh10627.phpt
+++ b/ext/mbstring/tests/gh10627.phpt
@@ -2,27 +2,35 @@
 GH-10627 (mb_convert_encoding crashes PHP on Windows)
 --EXTENSIONS--
 mbstring
+--INI--
+mbstring.strict_detection=1
 --FILE--
 <?php
 
-$str = 'Sökinställningar';
+$str = "S\xF6kinst\xE4llningar";
 $data = [$str, 'abc'];
 var_dump(mb_convert_encoding($data, 'UTF-8', 'auto'));
 $data = [$str => 'abc', 'abc' => 'def'];
 var_dump(mb_convert_encoding($data, 'UTF-8', 'auto'));
+$data = ['abc' => $str, 'def' => 'abc'];
+var_dump(mb_convert_encoding($data, 'UTF-8', 'auto'));
 
 ?>
---EXPECT--
-array(2) {
-  [0]=>
-  string(16) "S?kinst?llningar"
+--EXPECTF--
+Warning: mb_convert_encoding(): Unable to detect character encoding in %s on line %d
+array(1) {
   [1]=>
   string(3) "abc"
 }
-array(2) {
-  ["S?kinst?llningar"]=>
-  string(3) "abc"
+
+Warning: mb_convert_encoding(): Unable to detect character encoding in %s on line %d
+array(1) {
   ["abc"]=>
   string(3) "def"
 }
 
+Warning: mb_convert_encoding(): Unable to detect character encoding in %s on line %d
+array(1) {
+  ["def"]=>
+  string(3) "abc"
+}


### PR DESCRIPTION
In ed0c0df351, Niels Dossche fixed a bug in mbstring whereby mb_convert_encoding could dereference a NULL pointer and crash if it was called on an array, with multiple candidate encodings, and at least one of the strings inside the array was invalid in all the candidate encodings.

He kindly included a test case, but after being merged into master, the test case was not actually testing what it was intended to test. That is now fixed.

As discussed in #10628.

@Girgias @nielsdos 