### PR TITLE
configure.ac: don't `unset LDFLAGS`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1187,7 +1187,7 @@ if test "$ac_cv_lib_crypt_crypt" = "yes"; then
   EXTRA_LIBS="-lcrypt $EXTRA_LIBS -lcrypt"
 fi
 
-unset LIBS LDFLAGS
+unset LIBS
 
 dnl PEAR
 dnl ----------------------------------------------------------------------------
@@ -1360,7 +1360,7 @@ if test "$abs_srcdir" != "$abs_builddir"; then
 fi
 
 ZEND_EXTRA_LIBS="$LIBS"
-unset LIBS LDFLAGS
+unset LIBS
 
 PHP_HELP_SEPARATOR([TSRM:])
 PHP_CONFIGURE_PART(Configuring TSRM)


### PR DESCRIPTION
The `LDFLAGS` variable was initially cleared by commit c4d84aa33390 in 2009, and reverted in commit 21a6e1f96229 later that year, but the revert was reverted one day later in commit 937358ebc7a6; the edit war continued another day later with another revert by commit 477649cd3f09, but was reverted again on the same day by commit 16450418b188

The reverts (don't clear) were documented:

 "unsetting LIBS and LDFLAGS just makes it impossible to specify
 LDFLAGS from the environment"

... but none of the "unset LDFLAGS" commits had any explanation in the commit message.

Clearing `LDFLAGS` obviously breaks a feature that is documented by `./configure --help`:

 "Some influential environment variables:
  [...]
   LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
               nonstandard directory <lib dir>"

This feature is used by several CI scripts, e.g. `.cirrus.yml`, `.github/actions/configure-x32/action.yml` and
`.github/nightly_matrix.php` - but there, it didn't ever work. Apparently, nobody ever noticed this.

Unlike the other reverts, this patch keeps the `unset LIBS`, because the `LIBS` variable had already been copied to `EXTRA_LIBS`.  Same for the last `unset LIBS LDFLAGS` command in line 1374: prior to that, `LDFLAGS` had already been copied to `EXTRA_LDFLAGS`.  Maybe that's enough to keep people from revert it again and again?

With this patch, I can use the `mold` linker for the first time by simply doing `./configure .... LDFLAGS="-fuse-ld=mold"`.

(php-internals thread: https://news-web.php.net/php.internals/119593)