### PR TITLE
Fix bug #80602 Segfault when using DOMChildNode::before()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -948,6 +948,9 @@ PHP                                                                        NEWS
   . Fixed bug #81433 (DOMElement::setIdAttribute() called twice may remove ID).
     (Viktor Volkov)
 
+  . Fixed bug #80602 (Segfault when using DOMChildNode::before()).
+    (Nathan Freeman)
+
 - FFI:
   . Fixed bug #79576 ("TYPE *" shows unhelpful message when type is not
     defined). (Dmitry)

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -335,7 +335,7 @@ void dom_parent_node_after(dom_object *context, zval *nodes, int nodesc)
 	newchild = fragment->children;
 
 	if (newchild) {
-		// first node and last node are both both parameters to DOMElement::before() method so nextsib and prevsib are null.
+		// first node and last node are both both parameters to DOMElement::after() method so nextsib and prevsib are null.
 		if (!parentNode->children) {
 			prevsib = nextsib = NULL;
 		} else if (afterlastchild) {

--- a/ext/dom/tests/bug80602.phpt
+++ b/ext/dom/tests/bug80602.phpt
@@ -1,0 +1,178 @@
+--TEST--
+Bug #80602 (Segfault when using DOMChildNode::before())
+--FILE--
+<?php
+declare(strict_types=1);
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before($target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before($doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($doc->documentElement->firstChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before($target, $doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before($doc->documentElement->lastChild, $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($target, $doc->documentElement->firstChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($doc->documentElement->firstChild, $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before('bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before('bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before($target, 'bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before('bar', $target, 'baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before('bar', 'baz', $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($target, 'bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before('bar', $target, 'baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before('bar', 'baz', $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before('bar', $target, $doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before($target, 'bar', $doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->before($target, $doc->documentElement->lastChild, 'bar');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before('bar', $doc->documentElement->firstChild, $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($doc->documentElement->firstChild, 'bar', $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->before($doc->documentElement->firstChild, $target, 'bar');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+?>
+--EXPECTF--
+<a>foo<last/></a>
+<a>foo<last/></a>
+<a><last/>foo</a>
+<a>foo<last/></a>
+<a>foo<last/></a>
+<a><last/>foo</a>
+<a><last/>foo</a>
+<a>foo<last/></a>
+<a>barbazfoo<last/></a>
+<a>foobarbaz<last/></a>
+<a>foobarbaz<last/></a>
+<a>barfoobaz<last/></a>
+<a>barbazfoo<last/></a>
+<a>foo<last/>barbaz</a>
+<a>foobar<last/>baz</a>
+<a>foobarbaz<last/></a>
+<a>barfoo<last/></a>
+<a>foobar<last/></a>
+<a>foo<last/>bar</a>
+<a>barfoo<last/></a>
+<a>foobar<last/></a>
+<a>foo<last/>bar</a>

--- a/ext/dom/tests/bug80602_2.phpt
+++ b/ext/dom/tests/bug80602_2.phpt
@@ -1,0 +1,178 @@
+--TEST--
+Bug #80602 (Segfault when using DOMChildNode::after())
+--FILE--
+<?php
+declare(strict_types=1);
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after($target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after($target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after($doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after($doc->documentElement->firstChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after($target, $doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after($doc->documentElement->lastChild, $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after($target, $doc->documentElement->firstChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after($doc->documentElement->firstChild, $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after('bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after('bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after($target, 'bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after('bar', $target, 'baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after('bar', 'baz', $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after($target, 'bar','baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after('bar', $target, 'baz');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after('bar', 'baz', $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after('bar', $target, $doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after($target, 'bar', $doc->documentElement->lastChild);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->firstChild;
+$target->after($target, $doc->documentElement->lastChild, 'bar');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after('bar', $doc->documentElement->firstChild, $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after($doc->documentElement->firstChild, 'bar', $target);
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+
+$doc = new \DOMDocument();
+$doc->loadXML('<a>foo<last/></a>');
+$target = $doc->documentElement->lastChild;
+$target->after($doc->documentElement->firstChild, $target, 'bar');
+echo $doc->saveXML($doc->documentElement).PHP_EOL;
+
+?>
+--EXPECTF--
+<a>foo<last/></a>
+<a>foo<last/></a>
+<a>foo<last/></a>
+<a><last/>foo</a>
+<a>foo<last/></a>
+<a><last/>foo</a>
+<a><last/>foo</a>
+<a>foo<last/></a>
+<a>foobarbaz<last/></a>
+<a>foo<last/>barbaz</a>
+<a>foobarbaz<last/></a>
+<a>barfoobaz<last/></a>
+<a>barbazfoo<last/></a>
+<a>foo<last/>barbaz</a>
+<a>foobar<last/>baz</a>
+<a>foobarbaz<last/></a>
+<a>barfoo<last/></a>
+<a>foobar<last/></a>
+<a>foo<last/>bar</a>
+<a>barfoo<last/></a>
+<a>foobar<last/></a>
+<a>foo<last/>bar</a>


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=80602
https://github.com/php/php-src/pull/8729
I make a new pr base on PHP-8.1 branch because PHP-8.0 that is supported for critical security issues only.
