### PR TITLE
random: Fix return type of php_random_(bytes|int)

### DIFF
--- a/ext/random/csprng.c
+++ b/ext/random/csprng.c
@@ -25,6 +25,7 @@
 
 #include "php.h"
 
+#include "zend_result.h"
 #include "Zend/zend_exceptions.h"
 
 #include "php_random.h"
@@ -60,7 +61,7 @@
 # include <sanitizer/msan_interface.h>
 #endif
 
-PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
+PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw)
 {
 #ifdef PHP_WIN32
 	/* Defer to CryptGenRandom on Windows */
@@ -209,7 +210,7 @@ PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw)
 	return SUCCESS;
 }
 
-PHPAPI int php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw)
+PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw)
 {
 	zend_ulong umax;
 	zend_ulong trial;

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -31,6 +31,8 @@
 #ifndef PHP_RANDOM_H
 # define PHP_RANDOM_H
 
+# include "zend_result.h"
+
 PHPAPI double php_combined_lcg(void);
 
 /*
@@ -198,8 +200,8 @@ static inline uint64_t php_random_pcgoneseq128xslrr64_rotr64(php_random_uint128_
 # define php_random_int_throw(min, max, result) php_random_int((min), (max), (result), 1)
 # define php_random_int_silent(min, max, result) php_random_int((min), (max), (result), 0)
 
-PHPAPI int php_random_bytes(void *bytes, size_t size, bool should_throw);
-PHPAPI int php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
+PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
+PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
 
 typedef struct _php_random_status_ {
 	size_t last_generated_size;


### PR DESCRIPTION
These return a `zend_result`, not `int`.