### PR TITLE
Use an explicit failure check for zend_result functions in the scanner

### DIFF
--- a/Zend/zend_language_scanner.l
+++ b/Zend/zend_language_scanner.l
@@ -1329,7 +1329,7 @@ static zend_result check_nesting_at_end(void)
 	} while (0)
 
 #define RETURN_EXIT_NESTING_TOKEN(_token) do { \
-		if (exit_nesting(_token) && PARSER_MODE()) { \
+		if (exit_nesting(_token) != SUCCESS && PARSER_MODE()) { \
 			RETURN_TOKEN(T_ERROR); \
 		} else { \
 			RETURN_TOKEN(_token); \
@@ -1337,7 +1337,7 @@ static zend_result check_nesting_at_end(void)
 	} while(0)
 
 #define RETURN_END_TOKEN do { \
-		if (check_nesting_at_end() && PARSER_MODE()) { \
+		if (check_nesting_at_end() != SUCCESS && PARSER_MODE()) { \
 			RETURN_TOKEN(T_ERROR); \
 		} else { \
 			RETURN_TOKEN(END); \


### PR DESCRIPTION
Small cleanup.
Instead of an implicit check, use an explicit failure check.

(A check against != SUCCESS would probably result in slightly nicer assembly, but I doubt that matters at all and it doesn't seem to be the style.)