### PR TITLE
Fix incorrect type for return value in zend_update_static_property_ex()

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4658,7 +4658,7 @@ ZEND_API zend_result zend_update_static_property_ex(zend_class_entry *scope, zen
 ZEND_API zend_result zend_update_static_property(zend_class_entry *scope, const char *name, size_t name_length, zval *value) /* {{{ */
 {
 	zend_string *key = zend_string_init(name, name_length, 0);
-	bool retval = zend_update_static_property_ex(scope, key, value);
+	zend_result retval = zend_update_static_property_ex(scope, key, value);
 	zend_string_efree(key);
 	return retval;
 }


### PR DESCRIPTION
zend_update_static_property_ex() returns a zend_result, but the return value is stored here in a bool. A bool is unsigned on my system, so in case zend_update_static_property_ex() returns FAILURE (== -1) this gets converted to 1 instead. This is not a valid zend_result value. This means that (transitive) callers could mistakingly think the function succeeded while it did in fact not succeed. Fix it by changing the type to zend_result.

Found using an experimental static analyser I'm developing.