### PR TITLE
Fix GH-10692: PHP crashes on Windows when an inexistent filename is executed

### DIFF
--- a/main/fopen_wrappers.c
+++ b/main/fopen_wrappers.c
@@ -353,6 +353,8 @@ PHPAPI int php_fopen_primary_script(zend_file_handle *file_handle)
 	size_t length;
 	bool orig_display_errors;
 
+	memset(file_handle, 0, sizeof(zend_file_handle));
+
 	path_info = SG(request_info).request_uri;
 #if HAVE_PWD_H
 	if (PG(user_dir) && *PG(user_dir) && path_info && '/' == path_info[0] && '~' == path_info[1]) {


### PR DESCRIPTION
Fixes GH-10692

php_fopen_primary_script() does not initialize all fields of zend_file_handle. So when it fails and when fastcgi is true, the zend_destroy_file_handle() function will try to free uninitialized pointers, causing a segmentation fault. Fix it by zero-initializing file handles just like the zend_stream_init_fp() counterpart does.

I didn't find an easy way to write a test for this, as all fastcgi tests seem to be for FPM and not for classic CGI(?)