### PR TITLE
Simplify checks and returns in ext/xmlwriter

### DIFF
--- a/ext/xmlwriter/php_xmlwriter.c
+++ b/ext/xmlwriter/php_xmlwriter.c
@@ -215,14 +215,9 @@ static void php_xmlwriter_string_arg(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_rea
 		XMLW_NAME_CHK(2, subject_name);
 	}
 
-	if (ptr) {
-		retval = internal_function(ptr, (xmlChar *) name);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = internal_function(ptr, (xmlChar *) name);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 
 static void php_xmlwriter_end(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_read_int_t internal_function)
@@ -236,14 +231,9 @@ static void php_xmlwriter_end(INTERNAL_FUNCTION_PARAMETERS, xmlwriter_read_int_t
 	}
 	XMLWRITER_FROM_OBJECT(ptr, self);
 
-	if (ptr) {
-		retval = internal_function(ptr);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = internal_function(ptr);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 
 /* {{{ Toggle indentation on/off - returns FALSE on error */
@@ -259,14 +249,9 @@ PHP_FUNCTION(xmlwriter_set_indent)
 	}
 	XMLWRITER_FROM_OBJECT(ptr, self);
 
-	if (ptr) {
-		retval = xmlTextWriterSetIndent(ptr, indent);
-		if (retval == 0) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterSetIndent(ptr, indent);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval == 0);
 }
 /* }}} */
 
@@ -308,14 +293,9 @@ PHP_FUNCTION(xmlwriter_start_attribute_ns)
 
 	XMLW_NAME_CHK(3, "attribute name");
 
-	if (ptr) {
-		retval = xmlTextWriterStartAttributeNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterStartAttributeNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -336,14 +316,9 @@ PHP_FUNCTION(xmlwriter_write_attribute)
 
 	XMLW_NAME_CHK(2, "attribute name");
 
-	if (ptr) {
-		retval = xmlTextWriterWriteAttribute(ptr, (xmlChar *)name, (xmlChar *)content);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterWriteAttribute(ptr, (xmlChar *)name, (xmlChar *)content);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -364,14 +339,9 @@ PHP_FUNCTION(xmlwriter_write_attribute_ns)
 
 	XMLW_NAME_CHK(3, "attribute name");
 
-	if (ptr) {
-		retval = xmlTextWriterWriteAttributeNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri, (xmlChar *)content);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterWriteAttributeNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri, (xmlChar *)content);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -399,15 +369,9 @@ PHP_FUNCTION(xmlwriter_start_element_ns)
 
 	XMLW_NAME_CHK(3, "element name");
 
-	if (ptr) {
-		retval = xmlTextWriterStartElementNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
+	retval = xmlTextWriterStartElementNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri);
 
-	}
-
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -442,25 +406,17 @@ PHP_FUNCTION(xmlwriter_write_element)
 
 	XMLW_NAME_CHK(2, "element name");
 
-	if (ptr) {
-		if (!content) {
-			retval = xmlTextWriterStartElement(ptr, (xmlChar *)name);
-			if (retval == -1) {
-				RETURN_FALSE;
-			}
-			retval = xmlTextWriterEndElement(ptr);
-			if (retval == -1) {
-				RETURN_FALSE;
-			}
-		} else {
-			retval = xmlTextWriterWriteElement(ptr, (xmlChar *)name, (xmlChar *)content);
+	if (!content) {
+		retval = xmlTextWriterStartElement(ptr, (xmlChar *)name);
+		if (retval == -1) {
+			RETURN_FALSE;
 		}
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
+		retval = xmlTextWriterEndElement(ptr);
+	} else {
+		retval = xmlTextWriterWriteElement(ptr, (xmlChar *)name, (xmlChar *)content);
 	}
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -481,25 +437,17 @@ PHP_FUNCTION(xmlwriter_write_element_ns)
 
 	XMLW_NAME_CHK(3, "element name");
 
-	if (ptr) {
-		if (!content) {
-			retval = xmlTextWriterStartElementNS(ptr,(xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri);
-            if (retval == -1) {
-                RETURN_FALSE;
-            }
-			retval = xmlTextWriterEndElement(ptr);
-            if (retval == -1) {
-                RETURN_FALSE;
-            }
-		} else {
-			retval = xmlTextWriterWriteElementNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri, (xmlChar *)content);
+	if (!content) {
+		retval = xmlTextWriterStartElementNS(ptr,(xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri);
+		if (retval == -1) {
+			RETURN_FALSE;
 		}
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
+		retval = xmlTextWriterEndElement(ptr);
+	} else {
+		retval = xmlTextWriterWriteElementNS(ptr, (xmlChar *)prefix, (xmlChar *)name, (xmlChar *)uri, (xmlChar *)content);
 	}
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -534,14 +482,9 @@ PHP_FUNCTION(xmlwriter_write_pi)
 
 	XMLW_NAME_CHK(2, "PI target");
 
-	if (ptr) {
-		retval = xmlTextWriterWritePI(ptr, (xmlChar *)name, (xmlChar *)content);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterWritePI(ptr, (xmlChar *)name, (xmlChar *)content);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -557,14 +500,9 @@ PHP_FUNCTION(xmlwriter_start_cdata)
 	}
 	XMLWRITER_FROM_OBJECT(ptr, self);
 
-	if (ptr) {
-		retval = xmlTextWriterStartCDATA(ptr);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterStartCDATA(ptr);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -608,14 +546,9 @@ PHP_FUNCTION(xmlwriter_start_comment)
 	}
 	XMLWRITER_FROM_OBJECT(ptr, self);
 
-	if (ptr) {
-		retval = xmlTextWriterStartComment(ptr);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterStartComment(ptr);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -647,14 +580,9 @@ PHP_FUNCTION(xmlwriter_start_document)
 	}
 	XMLWRITER_FROM_OBJECT(ptr, self);
 
-	if (ptr) {
-		retval = xmlTextWriterStartDocument(ptr, version, enc, alone);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterStartDocument(ptr, version, enc, alone);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -679,14 +607,9 @@ PHP_FUNCTION(xmlwriter_start_dtd)
 	}
 	XMLWRITER_FROM_OBJECT(ptr, self);
 
-	if (ptr) {
-		retval = xmlTextWriterStartDTD(ptr, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterStartDTD(ptr, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -711,14 +634,9 @@ PHP_FUNCTION(xmlwriter_write_dtd)
 	}
 	XMLWRITER_FROM_OBJECT(ptr, self);
 
-	if (ptr) {
-		retval = xmlTextWriterWriteDTD(ptr, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid, (xmlChar *)subset);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterWriteDTD(ptr, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid, (xmlChar *)subset);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -753,14 +671,9 @@ PHP_FUNCTION(xmlwriter_write_dtd_element)
 
 	XMLW_NAME_CHK(2, "element name");
 
-	if (ptr) {
-		retval = xmlTextWriterWriteDTDElement(ptr, (xmlChar *)name, (xmlChar *)content);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterWriteDTDElement(ptr, (xmlChar *)name, (xmlChar *)content);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -795,14 +708,9 @@ PHP_FUNCTION(xmlwriter_write_dtd_attlist)
 
 	XMLW_NAME_CHK(2, "element name");
 
-	if (ptr) {
-		retval = xmlTextWriterWriteDTDAttlist(ptr, (xmlChar *)name, (xmlChar *)content);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterWriteDTDAttlist(ptr, (xmlChar *)name, (xmlChar *)content);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -823,14 +731,9 @@ PHP_FUNCTION(xmlwriter_start_dtd_entity)
 
 	XMLW_NAME_CHK(2, "attribute name");
 
-	if (ptr) {
-		retval = xmlTextWriterStartDTDEntity(ptr, isparm, (xmlChar *)name);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterStartDTDEntity(ptr, isparm, (xmlChar *)name);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -863,14 +766,9 @@ PHP_FUNCTION(xmlwriter_write_dtd_entity)
 
 	XMLW_NAME_CHK(2, "element name");
 
-	if (ptr) {
-		retval = xmlTextWriterWriteDTDEntity(ptr, pe, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid, (xmlChar *)ndataid, (xmlChar *)content);
-		if (retval != -1) {
-			RETURN_TRUE;
-		}
-	}
+	retval = xmlTextWriterWriteDTDEntity(ptr, pe, (xmlChar *)name, (xmlChar *)pubid, (xmlChar *)sysid, (xmlChar *)ndataid, (xmlChar *)content);
 
-	RETURN_FALSE;
+	RETURN_BOOL(retval != -1);
 }
 /* }}} */
 
@@ -993,24 +891,19 @@ static void php_xmlwriter_flush(INTERNAL_FUNCTION_PARAMETERS, int force_string) 
 	}
 	XMLWRITER_FROM_OBJECT(ptr, self);
 
-	if (ptr) {
-		buffer = Z_XMLWRITER_P(self)->output;
-		if (force_string == 1 && buffer == NULL) {
-			RETURN_EMPTY_STRING();
-		}
-		output_bytes = xmlTextWriterFlush(ptr);
-		if (buffer) {
-			RETVAL_STRING((char *) buffer->content);
-			if (empty) {
-				xmlBufferEmpty(buffer);
-			}
-		} else {
-			RETVAL_LONG(output_bytes);
-		}
-		return;
+	buffer = Z_XMLWRITER_P(self)->output;
+	if (force_string == 1 && buffer == NULL) {
+		RETURN_EMPTY_STRING();
 	}
-
-	RETURN_EMPTY_STRING();
+	output_bytes = xmlTextWriterFlush(ptr);
+	if (buffer) {
+		RETVAL_STRING((char *) buffer->content);
+		if (empty) {
+			xmlBufferEmpty(buffer);
+		}
+	} else {
+		RETVAL_LONG(output_bytes);
+	}
 }
 /* }}} */
 


### PR DESCRIPTION
* The ptr check is redundant because XMLWRITER_FROM_OBJECT will return if ptr is NULL.
* Use RETURN_BOOL to simplify the return code.