### PR TITLE
Implement GH-10024: support linting multiple files at once using php -l

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -2268,112 +2268,111 @@ parent_loop_end:
 			init_request_info(request);
 
 			if (!cgi && !fastcgi) {
-				if (behavior != PHP_MODE_LINT) {
-					while ((c = php_getopt(argc, argv, OPTIONS, &php_optarg, &php_optind, 0, 2)) != -1) {
-						switch (c) {
+				while ((c = php_getopt(argc, argv, OPTIONS, &php_optarg, &php_optind, 0, 2)) != -1) {
+					switch (c) {
 
-							case 'a':	/* interactive mode */
-								printf("Interactive mode enabled\n\n");
-								fflush(stdout);
-								break;
+						case 'a':	/* interactive mode */
+							printf("Interactive mode enabled\n\n");
+							fflush(stdout);
+							break;
 
-							case 'C': /* don't chdir to the script directory */
-								SG(options) |= SAPI_OPTION_NO_CHDIR;
-								break;
+						case 'C': /* don't chdir to the script directory */
+							SG(options) |= SAPI_OPTION_NO_CHDIR;
+							break;
 
-							case 'e': /* enable extended info output */
-								CG(compiler_options) |= ZEND_COMPILE_EXTENDED_INFO;
-								break;
+						case 'e': /* enable extended info output */
+							CG(compiler_options) |= ZEND_COMPILE_EXTENDED_INFO;
+							break;
 
-							case 'f': /* parse file */
-								if (script_file) {
-									efree(script_file);
-								}
-								script_file = estrdup(php_optarg);
-								no_headers = 1;
-								break;
+						case 'f': /* parse file */
+							if (script_file) {
+								efree(script_file);
+							}
+							script_file = estrdup(php_optarg);
+							no_headers = 1;
+							break;
 
-							case 'i': /* php info & quit */
-								if (script_file) {
-									efree(script_file);
-								}
-								if (php_request_startup() == FAILURE) {
-									SG(server_context) = NULL;
-									php_module_shutdown();
-									free(bindpath);
-									return FAILURE;
-								}
-								if (no_headers) {
-									SG(headers_sent) = 1;
-									SG(request_info).no_headers = 1;
-								}
-								php_print_info(0xFFFFFFFF);
-								php_request_shutdown((void *) 0);
-								fcgi_shutdown();
-								exit_status = 0;
-								goto out;
-
-							case 'l': /* syntax check mode */
-								no_headers = 1;
-								behavior = PHP_MODE_LINT;
-								break;
-
-							case 'm': /* list compiled in modules */
-								if (script_file) {
-									efree(script_file);
-								}
-								SG(headers_sent) = 1;
-								php_printf("[PHP Modules]\n");
-								print_modules();
-								php_printf("\n[Zend Modules]\n");
-								print_extensions();
-								php_printf("\n");
-								php_output_end_all();
-								fcgi_shutdown();
-								exit_status = 0;
-								goto out;
-
-							case 'q': /* do not generate HTTP headers */
-								no_headers = 1;
-								break;
-
-							case 'v': /* show php version & quit */
-								if (script_file) {
-									efree(script_file);
-								}
-								no_headers = 1;
-								if (php_request_startup() == FAILURE) {
-									SG(server_context) = NULL;
-									php_module_shutdown();
-									free(bindpath);
-									return FAILURE;
-								}
+						case 'i': /* php info & quit */
+							if (script_file) {
+								efree(script_file);
+							}
+							if (php_request_startup() == FAILURE) {
+								SG(server_context) = NULL;
+								php_module_shutdown();
+								free(bindpath);
+								return FAILURE;
+							}
+							if (no_headers) {
 								SG(headers_sent) = 1;
 								SG(request_info).no_headers = 1;
-	#if ZEND_DEBUG
-								php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
-	#else
-								php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
-	#endif
-								php_request_shutdown((void *) 0);
-								fcgi_shutdown();
-								exit_status = 0;
-								goto out;
+							}
+							php_print_info(0xFFFFFFFF);
+							php_request_shutdown((void *) 0);
+							fcgi_shutdown();
+							exit_status = 0;
+							goto out;
 
-							case 'w':
-								behavior = PHP_MODE_STRIP;
-								break;
+						case 'l': /* syntax check mode */
+							no_headers = 1;
+							behavior = PHP_MODE_LINT;
+							break;
 
-							case 'z': /* load extension file */
-								zend_load_extension(php_optarg);
-								break;
+						case 'm': /* list compiled in modules */
+							if (script_file) {
+								efree(script_file);
+							}
+							SG(headers_sent) = 1;
+							php_printf("[PHP Modules]\n");
+							print_modules();
+							php_printf("\n[Zend Modules]\n");
+							print_extensions();
+							php_printf("\n");
+							php_output_end_all();
+							fcgi_shutdown();
+							exit_status = 0;
+							goto out;
 
-							default:
-								break;
-						}
+						case 'q': /* do not generate HTTP headers */
+							no_headers = 1;
+							break;
+
+						case 'v': /* show php version & quit */
+							if (script_file) {
+								efree(script_file);
+							}
+							no_headers = 1;
+							if (php_request_startup() == FAILURE) {
+								SG(server_context) = NULL;
+								php_module_shutdown();
+								free(bindpath);
+								return FAILURE;
+							}
+							SG(headers_sent) = 1;
+							SG(request_info).no_headers = 1;
+#if ZEND_DEBUG
+							php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
+#else
+							php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
+#endif
+							php_request_shutdown((void *) 0);
+							fcgi_shutdown();
+							exit_status = 0;
+							goto out;
+
+						case 'w':
+							behavior = PHP_MODE_STRIP;
+							break;
+
+						case 'z': /* load extension file */
+							zend_load_extension(php_optarg);
+							break;
+
+						default:
+							break;
 					}
 				}
 
+do_repeat:
 				if (script_file) {
 					/* override path_translated if -f on command line */
 					if (SG(request_info).path_translated) efree(SG(request_info).path_translated);
@@ -2585,7 +2584,7 @@ fastcgi_request_done:
 				if (behavior == PHP_MODE_LINT && argc - 1 > php_optind) {
 					php_optind++;
 					script_file = NULL;
-					continue;
+					goto do_repeat;
 				}
 				break;
 			}

--- a/sapi/cgi/tests/012.phpt
+++ b/sapi/cgi/tests/012.phpt
@@ -14,6 +14,10 @@ function run_and_output($cmd) {
     }
     exec($cmd, $output, $exit_code);
     print_r($output);
+    // Normalize Windows vs Linux exit codes. On Windows exit code -1 is actually -1 instead of 255.
+    if ($exit_code < 0) {
+        $exit_code += 256;
+    }
     var_dump($exit_code);
 }
 

--- a/sapi/cgi/tests/012.phpt
+++ b/sapi/cgi/tests/012.phpt
@@ -14,7 +14,7 @@ function run_and_output($cmd) {
     }
     exec($cmd, $output, $exit_code);
     print_r($output);
-    var_dump($exit_code == 0);
+    var_dump($exit_code);
 }
 
 $php = get_cgi_path();
@@ -33,9 +33,6 @@ echo "hi";
 
 file_put_contents($filename_good, $code);
 
-run_and_output("$php -n -l $filename_good_escaped $filename_good_escaped");
-run_and_output("$php -n -l $filename_good_escaped some.unknown $filename_good_escaped");
-
 $code = '
 <?php
 
@@ -48,6 +45,8 @@ class test
 
 file_put_contents($filename_bad, $code);
 
+run_and_output("$php -n -l $filename_good_escaped $filename_good_escaped");
+run_and_output("$php -n -l $filename_good_escaped some.unknown $filename_good_escaped");
 run_and_output("$php -n -l $filename_good_escaped $filename_bad_escaped $filename_good_escaped");
 run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped");
 run_and_output("$php -n -l $filename_bad_escaped some.unknown $filename_bad_escaped");
@@ -66,13 +65,13 @@ Array
     [0] => No syntax errors detected in %s012_good.test.php
     [1] => No syntax errors detected in %s012_good.test.php
 )
-bool(true)
+int(0)
 Array
 (
     [0] => No syntax errors detected in %s012_good.test.php
     [1] => No input file specified.
 )
-bool(false)
+int(255)
 Array
 (
     [0] => No syntax errors detected in %s012_good.test.php
@@ -81,7 +80,7 @@ Array
     [3] => Errors parsing %s012_bad.test.php
     [4] => No syntax errors detected in %s012_good.test.php
 )
-bool(false)
+int(255)
 Array
 (
     [0] => <br />
@@ -91,7 +90,7 @@ Array
     [4] => <b>Parse error</b>:  syntax error, unexpected token &quot;private&quot;, expecting &quot;{&quot; in <b>%s012_bad.test.php</b> on line <b>5</b><br />
     [5] => Errors parsing %s012_bad.test.php
 )
-bool(false)
+int(255)
 Array
 (
     [0] => <br />
@@ -99,7 +98,7 @@ Array
     [2] => Errors parsing %s012_bad.test.php
     [3] => No input file specified.
 )
-bool(false)
+int(255)
 Array
 (
     [0] => <br />
@@ -110,5 +109,5 @@ Array
     [5] => Errors parsing %s012_bad.test.php
     [6] => No input file specified.
 )
-bool(false)
+int(255)
 Done

--- a/sapi/cgi/tests/012.phpt
+++ b/sapi/cgi/tests/012.phpt
@@ -1,0 +1,114 @@
+--TEST--
+multiple files syntax check
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--INI--
+display_errors=stdout
+--FILE--
+<?php
+include "include.inc";
+
+function run_and_output($cmd) {
+    if (!defined("PHP_WINDOWS_VERSION_MAJOR")) {
+        $cmd .= " 2>/dev/null";
+    }
+    exec($cmd, $output, $exit_code);
+    print_r($output);
+    var_dump($exit_code == 0);
+}
+
+$php = get_cgi_path();
+reset_env_vars();
+
+$filename_good = __DIR__."/012_good.test.php";
+$filename_good_escaped = escapeshellarg($filename_good);
+$filename_bad = __DIR__."/012_bad.test.php";
+$filename_bad_escaped = escapeshellarg($filename_bad);
+
+$code = '
+<?php
+
+echo "hi";
+';
+
+file_put_contents($filename_good, $code);
+
+run_and_output("$php -n -l $filename_good_escaped $filename_good_escaped");
+run_and_output("$php -n -l $filename_good_escaped some.unknown $filename_good_escaped");
+
+$code = '
+<?php
+
+class test
+    private $var;
+}
+
+?>
+';
+
+file_put_contents($filename_bad, $code);
+
+run_and_output("$php -n -l $filename_good_escaped $filename_bad_escaped $filename_good_escaped");
+run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped");
+run_and_output("$php -n -l $filename_bad_escaped some.unknown $filename_bad_escaped");
+run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped some.unknown");
+
+echo "Done\n";
+?>
+--CLEAN--
+<?php
+@unlink($filename_good);
+@unlink($filename_bad);
+?>
+--EXPECTF--
+Array
+(
+    [0] => No syntax errors detected in %s012_good.test.php
+    [1] => No syntax errors detected in %s012_good.test.php
+)
+bool(true)
+Array
+(
+    [0] => No syntax errors detected in %s012_good.test.php
+    [1] => No input file specified.
+)
+bool(false)
+Array
+(
+    [0] => No syntax errors detected in %s012_good.test.php
+    [1] => <br />
+    [2] => <b>Parse error</b>:  syntax error, unexpected token &quot;private&quot;, expecting &quot;{&quot; in <b>%s012_bad.test.php</b> on line <b>5</b><br />
+    [3] => Errors parsing %s012_bad.test.php
+    [4] => No syntax errors detected in %s012_good.test.php
+)
+bool(false)
+Array
+(
+    [0] => <br />
+    [1] => <b>Parse error</b>:  syntax error, unexpected token &quot;private&quot;, expecting &quot;{&quot; in <b>%s012_bad.test.php</b> on line <b>5</b><br />
+    [2] => Errors parsing %s012_bad.test.php
+    [3] => <br />
+    [4] => <b>Parse error</b>:  syntax error, unexpected token &quot;private&quot;, expecting &quot;{&quot; in <b>%s012_bad.test.php</b> on line <b>5</b><br />
+    [5] => Errors parsing %s012_bad.test.php
+)
+bool(false)
+Array
+(
+    [0] => <br />
+    [1] => <b>Parse error</b>:  syntax error, unexpected token &quot;private&quot;, expecting &quot;{&quot; in <b>%s012_bad.test.php</b> on line <b>5</b><br />
+    [2] => Errors parsing %s012_bad.test.php
+    [3] => No input file specified.
+)
+bool(false)
+Array
+(
+    [0] => <br />
+    [1] => <b>Parse error</b>:  syntax error, unexpected token &quot;private&quot;, expecting &quot;{&quot; in <b>%s012_bad.test.php</b> on line <b>5</b><br />
+    [2] => Errors parsing %s012_bad.test.php
+    [3] => <br />
+    [4] => <b>Parse error</b>:  syntax error, unexpected token &quot;private&quot;, expecting &quot;{&quot; in <b>%s012_bad.test.php</b> on line <b>5</b><br />
+    [5] => Errors parsing %s012_bad.test.php
+    [6] => No input file specified.
+)
+bool(false)
+Done

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -1131,14 +1131,14 @@ out:
 	}
 	if (request_started) {
 		php_request_shutdown((void *) 0);
+		request_started = 0;
 	}
 	if (translated_path) {
 		free(translated_path);
+		translated_path = NULL;
 	}
 	if (behavior == PHP_MODE_LINT && argc > php_optind && strcmp(argv[php_optind],"--")) {
 		script_file = NULL;
-		request_started = 0;
-		translated_path = NULL;
 		goto do_repeat;
 	}
 	/* Don't repeat fork()ed processes. */

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -734,6 +734,10 @@ static int do_cli(int argc, char **argv) /* {{{ */
 					break;
 				}
 				behavior=PHP_MODE_LINT;
+				/* We want to set the error exit status if at least one lint failed.
+				 * If all were successful we set the exit status to 0.
+				 * We already set EG(exit_status) here such that only failures set the exit status. */
+				EG(exit_status) = 0;
 				break;
 
 			case 'q': /* do not generate HTTP headers */
@@ -962,7 +966,6 @@ do_repeat:
 		case PHP_MODE_LINT:
 			if (php_lint_script(&file_handle) == SUCCESS) {
 				zend_printf("No syntax errors detected in %s\n", php_self);
-				EG(exit_status) = 0;
 			} else {
 				zend_printf("Errors parsing %s\n", php_self);
 				EG(exit_status) = 255;
@@ -1131,6 +1134,12 @@ out:
 	}
 	if (translated_path) {
 		free(translated_path);
+	}
+	if (behavior == PHP_MODE_LINT && argc > php_optind && strcmp(argv[php_optind],"--")) {
+		script_file = NULL;
+		request_started = 0;
+		translated_path = NULL;
+		goto do_repeat;
 	}
 	/* Don't repeat fork()ed processes. */
 	if (--num_repeats && pid == getpid()) {

--- a/sapi/cli/tests/024.phpt
+++ b/sapi/cli/tests/024.phpt
@@ -38,12 +38,12 @@ class test
 
 file_put_contents($filename_bad, $code);
 
-run_and_output("$php -n -l $filename_good_escaped $filename_good_escaped");
-run_and_output("$php -n -l $filename_good_escaped some.unknown $filename_good_escaped");
-run_and_output("$php -n -l $filename_good_escaped $filename_bad_escaped $filename_good_escaped");
-run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped");
-run_and_output("$php -n -l $filename_bad_escaped some.unknown $filename_bad_escaped");
-run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped some.unknown");
+run_and_output("$php -n -l $filename_good_escaped $filename_good_escaped 2>&1");
+run_and_output("$php -n -l $filename_good_escaped some.unknown $filename_good_escaped 2>&1");
+run_and_output("$php -n -l $filename_good_escaped $filename_bad_escaped $filename_good_escaped 2>&1");
+run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped 2>&1");
+run_and_output("$php -n -l $filename_bad_escaped some.unknown $filename_bad_escaped 2>&1");
+run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped some.unknown 2>&1");
 
 echo "Done\n";
 ?>

--- a/sapi/cli/tests/024.phpt
+++ b/sapi/cli/tests/024.phpt
@@ -1,0 +1,111 @@
+--TEST--
+multiple files syntax check
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+function run_and_output($cmd) {
+    exec($cmd, $output, $exit_code);
+    print_r($output);
+    var_dump($exit_code);
+}
+
+$php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+
+$filename_good = __DIR__."/024_good.test.php";
+$filename_good_escaped = escapeshellarg($filename_good);
+$filename_bad = __DIR__."/024_bad.test.php";
+$filename_bad_escaped = escapeshellarg($filename_bad);
+
+$code = '
+<?php
+
+echo "hi";
+';
+
+file_put_contents($filename_good, $code);
+
+run_and_output("$php -n -l $filename_good_escaped $filename_good_escaped");
+run_and_output("$php -n -l $filename_good_escaped some.unknown $filename_good_escaped");
+
+$code = '
+<?php
+
+class test
+    private $var;
+}
+
+?>
+';
+
+file_put_contents($filename_bad, $code);
+
+run_and_output("$php -n -l $filename_good_escaped $filename_bad_escaped $filename_good_escaped");
+run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped");
+run_and_output("$php -n -l $filename_bad_escaped some.unknown $filename_bad_escaped");
+run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped some.unknown");
+
+echo "Done\n";
+?>
+--CLEAN--
+<?php
+@unlink($filename_good);
+@unlink($filename_bad);
+?>
+--EXPECTF--
+Array
+(
+    [0] => No syntax errors detected in %s024_good.test.php
+    [1] => No syntax errors detected in %s024_good.test.php
+)
+int(0)
+Array
+(
+    [0] => No syntax errors detected in %s024_good.test.php
+    [1] => Could not open input file: some.unknown
+    [2] => No syntax errors detected in %s024_good.test.php
+)
+int(1)
+Array
+(
+    [0] => No syntax errors detected in %s024_good.test.php
+    [1] => 
+    [2] => Parse error: syntax error, unexpected token "private", expecting "{" in %s on line %d
+    [3] => Errors parsing %s024_bad.test.php
+    [4] => No syntax errors detected in %s024_good.test.php
+)
+int(255)
+Array
+(
+    [0] => 
+    [1] => Parse error: syntax error, unexpected token "private", expecting "{" in %s on line %d
+    [2] => Errors parsing %s024_bad.test.php
+    [3] => 
+    [4] => Parse error: syntax error, unexpected token "private", expecting "{" in %s on line %d
+    [5] => Errors parsing %s024_bad.test.php
+)
+int(255)
+Array
+(
+    [0] => 
+    [1] => Parse error: syntax error, unexpected token "private", expecting "{" in %s on line %d
+    [2] => Errors parsing %s024_bad.test.php
+    [3] => Could not open input file: some.unknown
+    [4] => 
+    [5] => Parse error: syntax error, unexpected token "private", expecting "{" in %s on line %d
+    [6] => Errors parsing %s024_bad.test.php
+)
+int(255)
+Array
+(
+    [0] => 
+    [1] => Parse error: syntax error, unexpected token "private", expecting "{" in %s on line %d
+    [2] => Errors parsing %s024_bad.test.php
+    [3] => 
+    [4] => Parse error: syntax error, unexpected token "private", expecting "{" in %s on line %d
+    [5] => Errors parsing %s024_bad.test.php
+    [6] => Could not open input file: some.unknown
+)
+int(1)
+Done

--- a/sapi/cli/tests/024.phpt
+++ b/sapi/cli/tests/024.phpt
@@ -26,9 +26,6 @@ echo "hi";
 
 file_put_contents($filename_good, $code);
 
-run_and_output("$php -n -l $filename_good_escaped $filename_good_escaped");
-run_and_output("$php -n -l $filename_good_escaped some.unknown $filename_good_escaped");
-
 $code = '
 <?php
 
@@ -41,6 +38,8 @@ class test
 
 file_put_contents($filename_bad, $code);
 
+run_and_output("$php -n -l $filename_good_escaped $filename_good_escaped");
+run_and_output("$php -n -l $filename_good_escaped some.unknown $filename_good_escaped");
 run_and_output("$php -n -l $filename_good_escaped $filename_bad_escaped $filename_good_escaped");
 run_and_output("$php -n -l $filename_bad_escaped $filename_bad_escaped");
 run_and_output("$php -n -l $filename_bad_escaped some.unknown $filename_bad_escaped");


### PR DESCRIPTION
Closes GH-10024

This is supported in both the CLI and CGI modes. For CLI this required little changes.

For CGI, the tricky part was that the options parsing happens inside the loop. This means that options passed after the -l flag were previously simply ignored. As we now re-enter the loop we would parse the options again, and if they are handled but don't set the script name, then CGI will think you want to read from standard in. To keep the same "don't parse options" behaviour I simply wrapped the options handling inside an if.