### PR TITLE
Remove unnecessary checks in ftp_fopen_wrapper.c

### DIFF
--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -299,9 +299,7 @@ static php_stream *php_ftp_fopen_connect(php_stream_wrapper *wrapper, const char
 	return stream;
 
 connect_errexit:
-	if (resource) {
-		php_url_free(resource);
-	}
+	php_url_free(resource);
 
 	if (stream) {
 		php_stream_close(stream);
@@ -916,7 +914,7 @@ static int php_stream_ftp_unlink(php_stream_wrapper *wrapper, const char *url, i
 	}
 
 	/* Attempt to delete the file */
-	php_stream_printf(stream, "DELE %s\r\n", (resource->path != NULL ? ZSTR_VAL(resource->path) : "/"));
+	php_stream_printf(stream, "DELE %s\r\n", ZSTR_VAL(resource->path));
 
 	result = GET_FTP_RESULT(stream);
 	if (result < 200 || result > 299) {
@@ -979,7 +977,7 @@ static int php_stream_ftp_rename(php_stream_wrapper *wrapper, const char *url_fr
 	}
 
 	/* Rename FROM */
-	php_stream_printf(stream, "RNFR %s\r\n", (resource_from->path != NULL ? ZSTR_VAL(resource_from->path) : "/"));
+	php_stream_printf(stream, "RNFR %s\r\n", ZSTR_VAL(resource_from->path));
 
 	result = GET_FTP_RESULT(stream);
 	if (result < 300 || result > 399) {
@@ -990,7 +988,7 @@ static int php_stream_ftp_rename(php_stream_wrapper *wrapper, const char *url_fr
 	}
 
 	/* Rename TO */
-	php_stream_printf(stream, "RNTO %s\r\n", (resource_to->path != NULL ? ZSTR_VAL(resource_to->path) : "/"));
+	php_stream_printf(stream, "RNTO %s\r\n", ZSTR_VAL(resource_to->path));
 
 	result = GET_FTP_RESULT(stream);
 	if (result < 200 || result > 299) {


### PR DESCRIPTION
* resource is always non-NULL at this point because we check for NULL right after its creation.
* resource->path is always set at this point because of the check right above the code where it's used. It was also confusing to see "/" being considered as a "default".