### PR TITLE
Fix GH-10709: Recursive class constant evaluation

### DIFF
--- a/Zend/tests/array_unpack/classes.phpt
+++ b/Zend/tests/array_unpack/classes.phpt
@@ -44,4 +44,4 @@ array(3) {
   [2]=>
   int(3)
 }
-Exception: Cannot declare self-referencing constant self::B
+Exception: Cannot declare self-referencing constant D::A

--- a/Zend/tests/bug41633_3.phpt
+++ b/Zend/tests/bug41633_3.phpt
@@ -9,7 +9,7 @@ class Foo {
 echo Foo::A;
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot declare self-referencing constant Foo::B in %s:%d
+Fatal error: Uncaught Error: Cannot declare self-referencing constant Foo::A in %s:%d
 Stack trace:
 #0 {main}
   thrown in %sbug41633_3.php on line %d

--- a/Zend/tests/constant_expressions_self_referencing_array.phpt
+++ b/Zend/tests/constant_expressions_self_referencing_array.phpt
@@ -9,7 +9,7 @@ class A {
 var_dump(A::FOO);
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot declare self-referencing constant self::BAR in %s:%d
+Fatal error: Uncaught Error: Cannot declare self-referencing constant A::FOO in %s:%d
 Stack trace:
 #0 {main}
   thrown in %s on line %d

--- a/Zend/tests/gh10709.phpt
+++ b/Zend/tests/gh10709.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-10634: Fix recursive class constant evaluation
+--FILE--
+<?php
+
+class B { const HW = A::HW . " extended by B"; }
+
+spl_autoload_register(function ($class) {
+    class A { const HW = "this is A"; }
+    var_dump(B::HW);
+});
+
+try {
+    var_dump(new B());
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Cannot declare self-referencing constant B::HW

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1429,7 +1429,7 @@ ZEND_API zend_result zend_update_class_constants(zend_class_entry *class_type) /
 				}
 
 				val = &c->value;
-				if (UNEXPECTED(zval_update_constant_ex(val, c->ce) != SUCCESS)) {
+				if (UNEXPECTED(zend_update_class_constant(val, name, c->ce) != SUCCESS)) {
 					return FAILURE;
 				}
 			}

--- a/Zend/zend_constants.h
+++ b/Zend/zend_constants.h
@@ -78,6 +78,7 @@ ZEND_API zval *zend_get_constant(zend_string *name);
 ZEND_API zval *zend_get_constant_str(const char *name, size_t name_len);
 ZEND_API zval *zend_get_constant_ex(zend_string *name, zend_class_entry *scope, uint32_t flags);
 ZEND_API zval *zend_get_class_constant_ex(zend_string *class_name, zend_string *constant_name, zend_class_entry *scope, uint32_t flags);
+ZEND_API zend_result zend_update_class_constant(zval *const_zv, zend_string *constant_name, zend_class_entry *ce);
 ZEND_API void zend_register_bool_constant(const char *name, size_t name_len, bool bval, int flags, int module_number);
 ZEND_API void zend_register_null_constant(const char *name, size_t name_len, int flags, int module_number);
 ZEND_API void zend_register_long_constant(const char *name, size_t name_len, zend_long lval, int flags, int module_number);

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5914,7 +5914,7 @@ ZEND_VM_HANDLER(181, ZEND_FETCH_CLASS_CONSTANT, VAR|CONST|UNUSED|CLASS_FETCH, CO
 			}
 			value = &c->value;
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
-				zval_update_constant_ex(value, c->ce);
+				zend_update_class_constant(value, Z_STR_P(RT_CONSTANT(opline, opline->op2)), c->ce);
 				if (UNEXPECTED(EG(exception) != NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 					HANDLE_EXCEPTION();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -7089,7 +7089,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_CONS
 			}
 			value = &c->value;
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
-				zval_update_constant_ex(value, c->ce);
+				zend_update_class_constant(value, Z_STR_P(RT_CONSTANT(opline, opline->op2)), c->ce);
 				if (UNEXPECTED(EG(exception) != NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 					HANDLE_EXCEPTION();
@@ -24597,7 +24597,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_VAR_
 			}
 			value = &c->value;
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
-				zval_update_constant_ex(value, c->ce);
+				zend_update_class_constant(value, Z_STR_P(RT_CONSTANT(opline, opline->op2)), c->ce);
 				if (UNEXPECTED(EG(exception) != NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 					HANDLE_EXCEPTION();
@@ -33382,7 +33382,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FETCH_CLASS_CONSTANT_SPEC_UNUS
 			}
 			value = &c->value;
 			if (Z_TYPE_P(value) == IS_CONSTANT_AST) {
-				zval_update_constant_ex(value, c->ce);
+				zend_update_class_constant(value, Z_STR_P(RT_CONSTANT(opline, opline->op2)), c->ce);
 				if (UNEXPECTED(EG(exception) != NULL)) {
 					ZVAL_UNDEF(EX_VAR(opline->result.var));
 					HANDLE_EXCEPTION();

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -3742,10 +3742,11 @@ static bool preload_try_resolve_constants(zend_class_entry *ce)
 	do {
 		ok = 1;
 		changed = 0;
-		ZEND_HASH_FOREACH_PTR(&ce->constants_table, c) {
+		zend_string *const_name;
+		ZEND_HASH_FOREACH_STR_KEY_PTR(&ce->constants_table, const_name, c) {
 			val = &c->value;
 			if (Z_TYPE_P(val) == IS_CONSTANT_AST) {
-				if (EXPECTED(zval_update_constant_ex(val, c->ce) == SUCCESS)) {
+				if (EXPECTED(zend_update_class_constant(val, const_name, c->ce) == SUCCESS)) {
 					was_changed = changed = 1;
 				} else {
 					ok = 0;

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -596,7 +596,7 @@ PHP_FUNCTION(constant)
 
 	ZVAL_COPY_OR_DUP(return_value, c);
 	if (Z_TYPE_P(return_value) == IS_CONSTANT_AST) {
-		if (UNEXPECTED(zval_update_constant_ex(return_value, scope) != SUCCESS)) {
+		if (UNEXPECTED(zend_update_class_constant(return_value, const_name, scope) != SUCCESS)) {
 			RETURN_THROWS();
 		}
 	}


### PR DESCRIPTION
Fixes https://oss-fuzz.com/testcase-detail/6445949468934144

We currently make no distinction in `zval_update_constant_ex()` regarding what type of constant is updated. This can include constants, class constants, default properties, enums, amongst others. Most of those are triggered implicitly (e.g. by instantiating a class) but some are loaded explicitly (e.g. accessing a specific constant). Updating the constants can trigger the autoloader and thus userland code. If this userland code explicitly triggers an evaluation of the AST that has triggered the autoloader in the first place, this can lead to two nested calls of the same AST evaluation. When the nested one finishes it will destroy the AST, thus leading to a use-after-free in the outer one. To avoid this, guard for nested class const evaluations in a new `zend_update_class_constant()` function.

I have not yet definitively checked if any other AST evaluations can lead to similar issues. I will do so soon. I'll also look at the fixme in reflection.c.

/cc @nielsdos