### PR TITLE
Fix GCC 12 compiler warnings

### DIFF
--- a/ext/bcmath/libbcmath/src/add.c
+++ b/ext/bcmath/libbcmath/src/add.c
@@ -42,10 +42,7 @@
    N1 is added to N2 and the result placed into RESULT.  SCALE_MIN
    is the minimum scale for the result. */
 
-void
-bc_add (n1, n2, result, scale_min)
-     bc_num n1, n2, *result;
-     int scale_min;
+void bc_add (bc_num n1, bc_num n2, bc_num *result, int scale_min)
 {
   bc_num sum = NULL;
   int cmp_res;

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -55,7 +55,8 @@ typedef struct bc_struct
 #include "config.h"
 #endif
 
-#include "php.h"
+#include <stdbool.h>
+#include "php.h" /* Needed for safe_pemalloc() in init.c */
 #include "../../php_bcmath.h"
 
 /* The base used in storing the numbers in n_value above.
@@ -112,9 +113,9 @@ char bc_is_zero(bc_num num);
 
 char bc_is_zero_for_scale(bc_num num, int scale);
 
-char bc_is_near_zero(bc_num num, int scale);
+bool bc_is_near_zero(bc_num num, int scale);
 
-char bc_is_neg(bc_num num);
+bool bc_is_neg(bc_num num);
 
 void bc_add(bc_num n1, bc_num n2, bc_num *result, int scale_min);
 
@@ -132,7 +133,7 @@ int bc_raisemod(bc_num base, bc_num expo, bc_num mo, bc_num *result, int scale);
 
 void bc_raise(bc_num num1, bc_num num2, bc_num *resul, int scale);
 
-int bc_sqrt(bc_num *num, int scale);
+bool bc_sqrt(bc_num *num, int scale);
 
 void bc_out_num(bc_num num, int o_base, void (* out_char)(char), int leading_zero);
 

--- a/ext/bcmath/libbcmath/src/compare.c
+++ b/ext/bcmath/libbcmath/src/compare.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include "bcmath.h"
 #include "private.h"
 
@@ -42,11 +43,7 @@
    than N2 and +1 if N1 is greater than N2.  If USE_SIGN is false, just
    compare the magnitudes. */
 
- int
-_bc_do_compare (n1, n2, use_sign, ignore_last)
-     bc_num n1, n2;
-     int use_sign;
-     int ignore_last;
+int _bc_do_compare(bc_num n1, bc_num n2, bool use_sign, bool ignore_last)
 {
   char *n1ptr, *n2ptr;
   int  count;
@@ -151,9 +148,7 @@ _bc_do_compare (n1, n2, use_sign, ignore_last)
 
 /* This is the "user callable" routine to compare numbers N1 and N2. */
 
-int
-bc_compare (n1, n2)
-     bc_num n1, n2;
+int bc_compare(bc_num n1, bc_num n2)
 {
-  return _bc_do_compare (n1, n2, TRUE, FALSE);
+  return _bc_do_compare (n1, n2, true, false);
 }

--- a/ext/bcmath/libbcmath/src/div.c
+++ b/ext/bcmath/libbcmath/src/div.c
@@ -79,8 +79,7 @@ static void _one_mult (unsigned char *num, int size, int digit, unsigned char *r
    digits after the decimal point is SCALE. It returns -1 if division
    by zero is tried.  The algorithm is found in Knuth Vol 2. p237. */
 
-int
-bc_divide (bc_num n1, bc_num n2, bc_num *quot, int scale)
+int bc_divide (bc_num n1, bc_num n2, bc_num *quot, int scale)
 {
   bc_num qval;
   unsigned char *num1, *num2;

--- a/ext/bcmath/libbcmath/src/divmod.c
+++ b/ext/bcmath/libbcmath/src/divmod.c
@@ -43,8 +43,7 @@
    is NULL then that store will be omitted.
  */
 
-int
-bc_divmod (bc_num num1, bc_num num2, bc_num *quot, bc_num *rem, int scale)
+int bc_divmod (bc_num num1, bc_num num2, bc_num *quot, bc_num *rem, int scale)
 {
   bc_num quotient = NULL;
   bc_num temp;
@@ -78,8 +77,7 @@ bc_divmod (bc_num num1, bc_num num2, bc_num *quot, bc_num *rem, int scale)
 /* Modulo for numbers.  This computes NUM1 % NUM2  and puts the
    result in RESULT.   */
 
-int
-bc_modulo (bc_num num1, bc_num num2, bc_num *result, int scale)
+int bc_modulo (bc_num num1, bc_num num2, bc_num *result, int scale)
 {
   return bc_divmod (num1, num2, NULL, result, scale);
 }

--- a/ext/bcmath/libbcmath/src/doaddsub.c
+++ b/ext/bcmath/libbcmath/src/doaddsub.c
@@ -42,10 +42,7 @@
    returned.  The signs of N1 and N2 are ignored.
    SCALE_MIN is to set the minimum scale of the result. */
 
- bc_num
-_bc_do_add (n1, n2, scale_min)
-     bc_num n1, n2;
-     int scale_min;
+bc_num _bc_do_add(bc_num n1, bc_num n2, int scale_min)
 {
   bc_num sum;
   int sum_scale, sum_digits;
@@ -134,10 +131,7 @@ _bc_do_add (n1, n2, scale_min)
    assumed to be larger than N2.  SCALE_MIN is the minimum scale
    of the result. */
 
- bc_num
-_bc_do_sub (n1, n2, scale_min)
-     bc_num n1, n2;
-     int scale_min;
+bc_num _bc_do_sub(bc_num n1, bc_num n2, int scale_min)
 {
   bc_num diff;
   int diff_scale, diff_len;

--- a/ext/bcmath/libbcmath/src/init.c
+++ b/ext/bcmath/libbcmath/src/init.c
@@ -39,9 +39,7 @@
 
 /* new_num allocates a number and sets fields to known values. */
 
-bc_num
-_bc_new_num_ex (length, scale, persistent)
-     int length, scale, persistent;
+bc_num _bc_new_num_ex (int length, int scale, int persistent)
 {
   bc_num temp;
   /* PHP Change:  malloc() -> pemalloc(), removed free_list code */
@@ -61,10 +59,7 @@ _bc_new_num_ex (length, scale, persistent)
 /* "Frees" a bc_num NUM.  Actually decreases reference count and only
    frees the storage if reference count is zero. */
 
-void
-_bc_free_num_ex (num, persistent)
-    bc_num *num;
-    int persistent;
+void _bc_free_num_ex(bc_num *num, int persistent)
 {
   if (*num == NULL) return;
   (*num)->n_refs--;
@@ -80,8 +75,7 @@ _bc_free_num_ex (num, persistent)
 
 /* Initialize the number package! */
 
-void
-bc_init_numbers (void)
+void bc_init_numbers(void)
 {
   BCG(_zero_) = _bc_new_num_ex (1,0,1);
   BCG(_one_)  = _bc_new_num_ex (1,0,1);
@@ -93,8 +87,7 @@ bc_init_numbers (void)
 
 /* Make a copy of a number!  Just increments the reference count! */
 
-bc_num
-bc_copy_num (bc_num num)
+bc_num bc_copy_num(bc_num num)
 {
   num->n_refs++;
   return num;
@@ -103,8 +96,7 @@ bc_copy_num (bc_num num)
 
 /* Initialize a number NUM by making it a copy of zero. */
 
-void
-bc_init_num (bc_num *num)
+void bc_init_num(bc_num *num)
 {
   *num = bc_copy_num (BCG(_zero_));
 }

--- a/ext/bcmath/libbcmath/src/int2num.c
+++ b/ext/bcmath/libbcmath/src/int2num.c
@@ -30,20 +30,12 @@
 *************************************************************************/
 
 #include <config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <stdarg.h>
 #include "bcmath.h"
-#include "private.h"
 
 
 /* Convert an integer VAL to a bc number NUM. */
 
-void
-bc_int2num (num, val)
-     bc_num *num;
-     int val;
+void bc_int2num(bc_num *num, int val)
 {
   char buffer[30];
   char *bptr, *vptr;

--- a/ext/bcmath/libbcmath/src/nearzero.c
+++ b/ext/bcmath/libbcmath/src/nearzero.c
@@ -29,22 +29,14 @@
 
 *************************************************************************/
 
-#include <config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <stdarg.h>
+#include <stdbool.h>
 #include "bcmath.h"
-#include "private.h"
 
 /* In some places we need to check if the number NUM is almost zero.
    Specifically, all but the last digit is 0 and the last digit is 1.
    Last digit is defined by scale. */
 
-char
-bc_is_near_zero (num, scale)
-     bc_num num;
-     int scale;
+bool bc_is_near_zero(bc_num num, int scale)
 {
   int  count;
   char *nptr;
@@ -61,7 +53,7 @@ bc_is_near_zero (num, scale)
   while ((count > 0) && (*nptr++ == 0)) count--;
 
   if (count != 0 && (count != 1 || *--nptr != 1))
-    return FALSE;
+    return false;
   else
-    return TRUE;
+    return true;
 }

--- a/ext/bcmath/libbcmath/src/neg.c
+++ b/ext/bcmath/libbcmath/src/neg.c
@@ -29,19 +29,11 @@
 
 *************************************************************************/
 
-#include <config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <stdarg.h>
+#include <stdbool.h>
 #include "bcmath.h"
-#include "private.h"
 
 /* In some places we need to check if the number is negative. */
-
-char
-bc_is_neg (num)
-     bc_num num;
+bool bc_is_neg(bc_num num)
 {
   return num->n_sign == MINUS;
 }

--- a/ext/bcmath/libbcmath/src/num2long.c
+++ b/ext/bcmath/libbcmath/src/num2long.c
@@ -30,21 +30,14 @@
 *************************************************************************/
 
 #include <config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <stdarg.h>
 #include "bcmath.h"
-#include "private.h"
 
 /* Convert a number NUM to a long.  The function returns only the integer
    part of the number.  For numbers that are too large to represent as
    a long, this function returns a zero.  This can be detected by checking
    the NUM for zero after having a zero returned. */
 
-long
-bc_num2long (num)
-     bc_num num;
+long bc_num2long(bc_num num)
 {
   long val;
   char *nptr;

--- a/ext/bcmath/libbcmath/src/num2str.c
+++ b/ext/bcmath/libbcmath/src/num2str.c
@@ -39,10 +39,7 @@
 
 /* Convert a numbers to a string.  Base 10 only.*/
 
-zend_string
-*bc_num2str_ex (num, scale)
-      bc_num num;
-	  int scale;
+zend_string *bc_num2str_ex(bc_num num, int scale)
 {
 	zend_string *str;
 	char *sptr;

--- a/ext/bcmath/libbcmath/src/private.h
+++ b/ext/bcmath/libbcmath/src/private.h
@@ -31,8 +31,10 @@
 
 /* "Private" routines to bcmath. */
 
+#include <stdbool.h>
+
 /* routines */
-int _bc_do_compare (bc_num n1, bc_num n2, int use_sign, int ignore_last);
+int _bc_do_compare (bc_num n1, bc_num n2, bool use_sign, bool ignore_last);
 bc_num _bc_do_add (bc_num n1, bc_num n2, int scale_min);
 bc_num _bc_do_sub (bc_num n1, bc_num n2, int scale_min);
 void _bc_rm_leading_zeros (bc_num num);

--- a/ext/bcmath/libbcmath/src/recmul.c
+++ b/ext/bcmath/libbcmath/src/recmul.c
@@ -30,11 +30,7 @@
 *************************************************************************/
 
 #include <config.h>
-#include <stdio.h>
 #include <assert.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <stdarg.h>
 #include "bcmath.h"
 #include "private.h"
 

--- a/ext/bcmath/libbcmath/src/rmzero.c
+++ b/ext/bcmath/libbcmath/src/rmzero.c
@@ -30,10 +30,6 @@
 *************************************************************************/
 
 #include <config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <stdarg.h>
 #include "bcmath.h"
 #include "private.h"
 
@@ -41,9 +37,7 @@
    _bc_rm_leading_zeros just moves the data "value" pointer to the
    correct place and adjusts the length. */
 
- void
-_bc_rm_leading_zeros (num)
-     bc_num num;
+void _bc_rm_leading_zeros(bc_num num)
 {
   /* We can move n_value to point to the first non zero digit! */
   while (*num->n_value == 0 && num->n_len > 1) {

--- a/ext/bcmath/libbcmath/src/sqrt.c
+++ b/ext/bcmath/libbcmath/src/sqrt.c
@@ -30,42 +30,36 @@
 *************************************************************************/
 
 #include <config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <stdarg.h>
+#include <stdbool.h>
 #include "bcmath.h"
 #include "private.h"
 
 /* Take the square root NUM and return it in NUM with SCALE digits
    after the decimal place. */
 
-int
-bc_sqrt (bc_num *num, int scale)
+bool bc_sqrt(bc_num *num, int scale)
 {
-  int rscale, cmp_res, done;
+  int rscale, cmp_res;
   int cscale;
   bc_num guess, guess1, point5, diff;
 
   /* Initial checks. */
   cmp_res = bc_compare (*num, BCG(_zero_));
-  if (cmp_res < 0)
-    return 0;		/* error */
-  else
-    {
-      if (cmp_res == 0)
-	{
+  if (cmp_res < 0) {
+    return false; /* error */
+  } else {
+    if (cmp_res == 0) {
 	  bc_free_num (num);
 	  *num = bc_copy_num (BCG(_zero_));
-	  return 1;
+	  return true;
 	}
-    }
+  }
   cmp_res = bc_compare (*num, BCG(_one_));
   if (cmp_res == 0)
     {
       bc_free_num (num);
       *num = bc_copy_num (BCG(_one_));
-      return 1;
+      return true;
     }
 
   /* Initialize the variables. */
@@ -77,14 +71,11 @@ bc_sqrt (bc_num *num, int scale)
 
 
   /* Calculate the initial guess. */
-  if (cmp_res < 0)
-    {
+  if (cmp_res < 0) {
       /* The number is between 0 and 1.  Guess should start at 1. */
       guess = bc_copy_num (BCG(_one_));
       cscale = (*num)->n_scale;
-    }
-  else
-    {
+  } else {
       /* The number is greater than 1.  Guess should start at 10^(exp/2). */
       bc_init_num(&guess);
       bc_int2num (&guess,10);
@@ -95,26 +86,25 @@ bc_sqrt (bc_num *num, int scale)
       bc_raise (guess, guess1, &guess, 0);
       bc_free_num (&guess1);
       cscale = 3;
-    }
+  }
 
   /* Find the square root using Newton's algorithm. */
-  done = FALSE;
-  while (!done)
-    {
+  bool done = false;
+  while (!done) {
       bc_free_num (&guess1);
       guess1 = bc_copy_num (guess);
       bc_divide (*num, guess, &guess, cscale);
       bc_add (guess, guess1, &guess, 0);
       bc_multiply (guess, point5, &guess, cscale);
       bc_sub (guess, guess1, &diff, cscale+1);
-      if (bc_is_near_zero (diff, cscale))
-	{
-	  if (cscale < rscale+1)
-	    cscale = MIN (cscale*3, rscale+1);
-	  else
-	    done = TRUE;
-	}
-    }
+      if (bc_is_near_zero (diff, cscale)) {
+	    if (cscale < rscale+1) {
+	      cscale = MIN (cscale*3, rscale+1);
+	    } else {
+	      done = true;
+	    }
+	  }
+  }
 
   /* Assign the number and clean up. */
   bc_free_num (num);
@@ -123,5 +113,5 @@ bc_sqrt (bc_num *num, int scale)
   bc_free_num (&guess1);
   bc_free_num (&point5);
   bc_free_num (&diff);
-  return 1;
+  return true;
 }

--- a/ext/bcmath/libbcmath/src/sub.c
+++ b/ext/bcmath/libbcmath/src/sub.c
@@ -30,22 +30,14 @@
 *************************************************************************/
 
 #include <config.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <stdarg.h>
 #include "bcmath.h"
 #include "private.h"
-
 
 /* Here is the full subtract routine that takes care of negative numbers.
    N2 is subtracted from N1 and the result placed in RESULT.  SCALE_MIN
    is the minimum scale for the result. */
 
-void
-bc_sub (n1, n2, result, scale_min)
-     bc_num n1, n2, *result;
-     int scale_min;
+void bc_sub(bc_num n1, bc_num n2, bc_num *result, int scale_min)
 {
   bc_num diff = NULL;
   int cmp_res;

--- a/ext/dba/libcdb/cdb.c
+++ b/ext/dba/libcdb/cdb.c
@@ -185,7 +185,7 @@ int cdb_find(struct cdb *c, char *key, unsigned int len)
 /* }}} */
 
 /* {{{ cdb_version */
-const char *cdb_version()
+const char *cdb_version(void)
 {
 	return "0.75, $Id$";
 }

--- a/ext/dba/libflatfile/flatfile.c
+++ b/ext/dba/libflatfile/flatfile.c
@@ -276,7 +276,7 @@ datum flatfile_nextkey(flatfile *dba) {
 /* }}} */
 
 /* {{{ flatfile_version */
-const char *flatfile_version()
+const char *flatfile_version(void)
 {
 	return "1.0, $Id$";
 }

--- a/ext/dba/libinifile/inifile.c
+++ b/ext/dba/libinifile/inifile.c
@@ -38,7 +38,7 @@
  */
 
 /* {{{ inifile_version */
-const char *inifile_version()
+const char *inifile_version(void)
 {
 	return "1.0, $Id$";
 }

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -3764,14 +3764,14 @@ static void exif_process_APP12(image_info_type *ImageInfo, char *buffer, size_t 
  * Parse the marker stream until SOS or EOI is seen; */
 static bool exif_scan_JPEG_header(image_info_type *ImageInfo)
 {
-	int section, sn;
+	int sn;
 	int marker = 0, last_marker = M_PSEUDO, comment_correction=1;
 	unsigned int ll, lh;
 	uchar *Data;
 	size_t fpos, size, got, itemlen;
 	jpeg_sof_info sof_info;
 
-	for(section=0;;section++) {
+	while (true) {
 #ifdef EXIF_DEBUG
 		fpos = php_stream_tell(ImageInfo->infile);
 		exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Needing section %d @ 0x%08X", ImageInfo->file.count, fpos);

--- a/ext/mysqli/mysqli_nonapi.c
+++ b/ext/mysqli/mysqli_nonapi.c
@@ -673,12 +673,11 @@ static int mysqlnd_zval_array_to_mysqlnd_array(zval *in_array, MYSQLND ***out_ar
 /* }}} */
 
 /* {{{ mysqlnd_zval_array_from_mysqlnd_array */
-static int mysqlnd_zval_array_from_mysqlnd_array(MYSQLND **in_array, zval *out_array)
+static zend_result mysqlnd_zval_array_from_mysqlnd_array(MYSQLND **in_array, zval *out_array)
 {
 	MYSQLND **p = in_array;
 	zval dest_array;
 	zval *elem, *dest_elem;
-	int ret = 0;
 
 	array_init_size(&dest_array, zend_hash_num_elements(Z_ARRVAL_P(out_array)));
 
@@ -701,7 +700,6 @@ static int mysqlnd_zval_array_from_mysqlnd_array(MYSQLND **in_array, zval *out_a
 				if (dest_elem) {
 					zval_add_ref(dest_elem);
 				}
-				ret++;
 				p++;
 			}
 		}
@@ -711,16 +709,15 @@ static int mysqlnd_zval_array_from_mysqlnd_array(MYSQLND **in_array, zval *out_a
 	zval_ptr_dtor(out_array);
 	ZVAL_COPY_VALUE(out_array, &dest_array);
 
-	return 0;
+	return SUCCESS;
 }
 /* }}} */
 
 /* {{{ mysqlnd_dont_poll_zval_array_from_mysqlnd_array */
-static int mysqlnd_dont_poll_zval_array_from_mysqlnd_array(MYSQLND **in_array, zval *in_zval_array, zval *out_array)
+static void mysqlnd_dont_poll_zval_array_from_mysqlnd_array(MYSQLND **in_array, zval *in_zval_array, zval *out_array)
 {
 	MYSQLND **p = in_array;
 	zval proxy, *elem, *dest_elem;
-	int ret = 0;
 
 	array_init(&proxy);
 	if (in_array) {
@@ -733,7 +730,6 @@ static int mysqlnd_dont_poll_zval_array_from_mysqlnd_array(MYSQLND **in_array, z
 				if (dest_elem) {
 					zval_add_ref(dest_elem);
 				}
-				ret++;
 				p++;
 			}
 		} ZEND_HASH_FOREACH_END();
@@ -742,8 +738,6 @@ static int mysqlnd_dont_poll_zval_array_from_mysqlnd_array(MYSQLND **in_array, z
 	/* destroy old array and add new one */
 	zval_ptr_dtor(out_array);
 	ZVAL_COPY_VALUE(out_array, &proxy);
-
-	return 0;
 }
 /* }}} */
 

--- a/ext/mysqlnd/mysqlnd_ps.c
+++ b/ext/mysqlnd/mysqlnd_ps.c
@@ -1978,7 +1978,7 @@ MYSQLND_CLASS_METHODS_END;
 
 
 /* {{{ _mysqlnd_init_ps_subsystem */
-void _mysqlnd_init_ps_subsystem()
+void _mysqlnd_init_ps_subsystem(void)
 {
 	mysqlnd_stmt_set_methods(&MYSQLND_CLASS_METHOD_TABLE_NAME(mysqlnd_stmt));
 	_mysqlnd_init_ps_fetch_subsystem();

--- a/ext/mysqlnd/mysqlnd_ps_codec.c
+++ b/ext/mysqlnd/mysqlnd_ps_codec.c
@@ -355,7 +355,7 @@ ps_fetch_bit(zval * zv, const MYSQLND_FIELD * const field, const unsigned int pa
 
 
 /* {{{ _mysqlnd_init_ps_fetch_subsystem */
-void _mysqlnd_init_ps_fetch_subsystem()
+void _mysqlnd_init_ps_fetch_subsystem(void)
 {
 	memset(mysqlnd_ps_fetch_functions, 0, sizeof(mysqlnd_ps_fetch_functions));
 	mysqlnd_ps_fetch_functions[MYSQL_TYPE_NULL].func		= ps_fetch_null;

--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -450,7 +450,7 @@ static int X509_get_signature_nid(const X509 *x)
 	PHP_OPENSSL_CHECK_NUMBER_CONVERSION_NULL_RETURN(ZEND_LONG_EXCEEDS_INT(_var), _name)
 
 /* {{{ php_openssl_store_errors */
-void php_openssl_store_errors()
+void php_openssl_store_errors(void)
 {
 	struct php_openssl_errors *errors;
 	int error_code = ERR_get_error();

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -3414,7 +3414,7 @@ static void set_xsi_type(xmlNodePtr node, char *type)
 	set_ns_prop(node, XSI_NAMESPACE, "type", type);
 }
 
-void encode_reset_ns()
+void encode_reset_ns(void)
 {
 	SOAP_GLOBAL(cur_uniq_ns) = 0;
 	SOAP_GLOBAL(cur_uniq_ref) = 0;
@@ -3426,7 +3426,7 @@ void encode_reset_ns()
 	zend_hash_init(SOAP_GLOBAL(ref_map), 0, NULL, NULL, 0);
 }
 
-void encode_finish()
+void encode_finish(void)
 {
 	SOAP_GLOBAL(cur_uniq_ns) = 0;
 	SOAP_GLOBAL(cur_uniq_ref) = 0;


### PR DESCRIPTION
I finally upgraded to Fedora 37 and GCC got updated to GCC 12.2 which greeted me with some new compiler warnings.

While I was at it I decided to improve BC Math but there is still a lot to do and might make sense to split into a seperate PR.