### PR TITLE
Zend/zend_type_code: remove hard-coded integer values

### DIFF
--- a/Zend/zend_type_code.h
+++ b/Zend/zend_type_code.h
@@ -18,38 +18,48 @@
 #define ZEND_TYPE_CODE_H
 
 enum {
-	/* Regular data types: Must be in sync with zend_variables.c. */
-	IS_UNDEF = 0,
-	IS_NULL = 1,
-	IS_FALSE = 2,
-	IS_TRUE = 3,
-	IS_LONG = 4,
-	IS_DOUBLE = 5,
-	IS_STRING = 6,
-	IS_ARRAY = 7,
-	IS_OBJECT = 8,
-	IS_RESOURCE = 9,
-	IS_REFERENCE = 10,
-	IS_CONSTANT_AST = 11, /* Constant expressions */
+	/* Regular data types */
+	IS_UNDEF,
+	IS_NULL,
+	IS_FALSE,
+	IS_TRUE,
+	IS_LONG,
+	IS_DOUBLE,
+	IS_STRING,
+	IS_ARRAY,
+	IS_OBJECT,
+	IS_RESOURCE,
+	IS_REFERENCE,
+	IS_CONSTANT_AST, /* Constant expressions */
+
+	/**
+	 * One after the largest regular data type; used internally
+	 * for overlapping ranges below.
+	 */
+	_IS_REGULAR_END,
 
 	/* Fake types used only for type hinting.
 	 * These are allowed to overlap with the types below. */
-	IS_CALLABLE = 12,
-	IS_ITERABLE = 13,
-	IS_VOID = 14,
-	IS_STATIC = 15,
-	IS_MIXED = 16,
-	IS_NEVER = 17,
+	IS_CALLABLE = _IS_REGULAR_END,
+	IS_ITERABLE,
+	IS_VOID,
+	IS_STATIC,
+	IS_MIXED,
+	IS_NEVER,
+
+	_IS_FAKE_END,
 
 	/* internal types */
-	IS_INDIRECT = 12,
-	IS_PTR = 13,
-	IS_ALIAS_PTR = 14,
-	_IS_ERROR = 15,
+	IS_INDIRECT = _IS_REGULAR_END,
+	IS_PTR,
+	IS_ALIAS_PTR,
+	_IS_ERROR,
+
+	_IS_INTERNAL_END,
 
 	/* used for casts */
-	_IS_BOOL = 18,
-	_IS_NUMBER = 19,
+	_IS_BOOL = _IS_FAKE_END > _IS_INTERNAL_END ? _IS_FAKE_END : _IS_INTERNAL_END,
+	_IS_NUMBER,
 };
 
 #define ZEND_SAME_FAKE_TYPE(faketype, realtype) ( \

--- a/Zend/zend_type_code.h
+++ b/Zend/zend_type_code.h
@@ -62,9 +62,4 @@ enum {
 	_IS_NUMBER,
 };
 
-#define ZEND_SAME_FAKE_TYPE(faketype, realtype) ( \
-	(faketype) == (realtype) \
-	|| ((faketype) == _IS_BOOL && ((realtype) == IS_TRUE || (realtype) == IS_FALSE)) \
-)
-
 #endif /* ZEND_TYPE_CODE_H */

--- a/Zend/zend_variables.c
+++ b/Zend/zend_variables.c
@@ -51,6 +51,11 @@ static const zend_rc_dtor_func_t zend_rc_dtor_func[] = {
 	[IS_CONSTANT_AST] = (zend_rc_dtor_func_t)zend_ast_ref_destroy
 };
 
+#if ZEND_GCC_VERSION >= 4006 || defined(__clang__)
+_Static_assert(sizeof(zend_rc_dtor_func) / sizeof(zend_rc_dtor_func[0]) == _IS_REGULAR_END,
+	       "zend_rc_dtor_func has the wrong size");
+#endif
+
 ZEND_API void ZEND_FASTCALL rc_dtor_func(zend_refcounted *p)
 {
 	ZEND_ASSERT(GC_TYPE(p) <= IS_CONSTANT_AST);


### PR DESCRIPTION
Also removing the comment about keeping those values in sync with `zend_variables.c` which was obsoleted by commit 0460420205974d (designated initializers)