### PR TITLE
Zend/zend_string: convert macros to functions

### DIFF
--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -98,37 +98,57 @@ END_EXTERN_C()
 
 /*---*/
 
-#define ZSTR_IS_INTERNED(s)					(GC_FLAGS(s) & IS_STR_INTERNED)
-#define ZSTR_IS_VALID_UTF8(s)				(GC_FLAGS(s) & IS_STR_VALID_UTF8)
+static zend_always_inline bool ZSTR_IS_INTERNED(const zend_string *s)
+{
+	return GC_FLAGS(s) & IS_STR_INTERNED;
+}
+
+static zend_always_inline bool ZSTR_IS_VALID_UTF8(const zend_string *s)
+{
+	return GC_FLAGS(s) & IS_STR_VALID_UTF8;
+}
 
 /* These are properties, encoded as flags, that will hold on the resulting string
  * after concatenating two strings that have these property.
  * Example: concatenating two UTF-8 strings yields another UTF-8 string. */
 #define ZSTR_COPYABLE_CONCAT_PROPERTIES		(IS_STR_VALID_UTF8)
 
-#define ZSTR_GET_COPYABLE_CONCAT_PROPERTIES(s) 				(GC_FLAGS(s) & ZSTR_COPYABLE_CONCAT_PROPERTIES)
-/* This macro returns the copyable concat properties which hold on both strings. */
-#define ZSTR_GET_COPYABLE_CONCAT_PROPERTIES_BOTH(s1, s2)	(GC_FLAGS(s1) & GC_FLAGS(s2) & ZSTR_COPYABLE_CONCAT_PROPERTIES)
+static zend_always_inline uint32_t ZSTR_GET_COPYABLE_CONCAT_PROPERTIES(const zend_string *s)
+{
+	return GC_FLAGS(s) & ZSTR_COPYABLE_CONCAT_PROPERTIES;
+}
 
-#define ZSTR_COPY_CONCAT_PROPERTIES(out, in) do { \
-	zend_string *_out = (out); \
-	uint32_t properties = ZSTR_GET_COPYABLE_CONCAT_PROPERTIES((in)); \
-	GC_ADD_FLAGS(_out, properties); \
-} while (0)
+/* This function returns the copyable concat properties which hold on both strings. */
+static zend_always_inline uint32_t ZSTR_GET_COPYABLE_CONCAT_PROPERTIES_BOTH(const zend_string *s1, const zend_string *s2)
+{
+	return GC_FLAGS(s1) & GC_FLAGS(s2) & ZSTR_COPYABLE_CONCAT_PROPERTIES;
+}
 
-#define ZSTR_COPY_CONCAT_PROPERTIES_BOTH(out, in1, in2) do { \
-	zend_string *_out = (out); \
-	uint32_t properties = ZSTR_GET_COPYABLE_CONCAT_PROPERTIES_BOTH((in1), (in2)); \
-	GC_ADD_FLAGS(_out, properties); \
-} while (0)
+static zend_always_inline void ZSTR_COPY_CONCAT_PROPERTIES(zend_string *out, const zend_string *in)
+{
+	uint32_t properties = ZSTR_GET_COPYABLE_CONCAT_PROPERTIES(in);
+	GC_ADD_FLAGS(out, properties);
+}
+
+static zend_always_inline void ZSTR_COPY_CONCAT_PROPERTIES_BOTH(zend_string *out, const zend_string *in1, const zend_string *in2)
+{
+	uint32_t properties = ZSTR_GET_COPYABLE_CONCAT_PROPERTIES_BOTH(in1, in2);
+	GC_ADD_FLAGS(out, properties);
+}
 
 #define ZSTR_EMPTY_ALLOC() zend_empty_string
-#define ZSTR_CHAR(c) zend_one_char_string[c]
-#define ZSTR_KNOWN(idx) zend_known_strings[idx]
+
+static zend_always_inline zend_string *ZSTR_CHAR(zend_uchar c)
+{
+	return zend_one_char_string[c];
+}
 
 #define _ZSTR_HEADER_SIZE XtOffsetOf(zend_string, val)
 
-#define _ZSTR_STRUCT_SIZE(len) (_ZSTR_HEADER_SIZE + len + 1)
+static zend_always_inline size_t _ZSTR_STRUCT_SIZE(size_t len)
+{
+	return _ZSTR_HEADER_SIZE + len + 1;
+}
 
 #define ZSTR_MAX_OVERHEAD (ZEND_MM_ALIGNED_SIZE(_ZSTR_HEADER_SIZE + 1))
 #define ZSTR_MAX_LEN (SIZE_MAX - ZSTR_MAX_OVERHEAD)
@@ -643,5 +663,13 @@ ZEND_KNOWN_STRINGS(_ZEND_STR_ID)
 #undef _ZEND_STR_ID
 	ZEND_STR_LAST_KNOWN
 } zend_known_string_id;
+
+static zend_always_inline zend_string *ZSTR_KNOWN(zend_known_string_id id)
+{
+	ZEND_ASSERT(id >= 0);
+	ZEND_ASSERT(id < ZEND_STR_LAST_KNOWN);
+
+	return zend_known_strings[id];
+}
 
 #endif /* ZEND_STRING_H */


### PR DESCRIPTION
Functions result in the same machine code, but are type-safe, and there are two specific advantages of this change:

- the parameter to `ZSTR_CHAR()` is now implicitly casted to `zend_uchar`, which had to be done in every caller site previously, which made using the macro very fragile and dangerous, prone to out-of-bounds array accesses when the highest bit of the character was set (because `char` is signed on most architectures).

- `ZSTR_KNOWN()` has an enum parameter now, and passing a different type can be caught by a compiler warning; plus, a `ZEND_ASSERT()` helps finding bugs at runtime.