### PR TITLE
3 minor cleanups in ext/session

### DIFF
--- a/ext/session/mod_files.c
+++ b/ext/session/mod_files.c
@@ -674,10 +674,8 @@ PS_CREATE_SID_FUNC(files)
 		/* Check collision */
 		/* FIXME: mod_data(data) should not be NULL (User handler could be NULL) */
 		if (data && ps_files_key_exists(data, sid) == SUCCESS) {
-			if (sid) {
-				zend_string_release_ex(sid, 0);
-				sid = NULL;
-			}
+			zend_string_release_ex(sid, 0);
+			sid = NULL;
 			if (--maxfail < 0) {
 				return NULL;
 			}

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -904,10 +904,9 @@ PS_SERIALIZER_DECODE_FUNC(php_binary) /* {{{ */
 	PHP_VAR_UNSERIALIZE_INIT(var_hash);
 
 	for (p = val; p < endptr; ) {
-		// Can this be changed to size_t?
-		int namelen = ((unsigned char)(*p)) & (~PS_BIN_UNDEF);
+		size_t namelen = ((unsigned char)(*p)) & (~PS_BIN_UNDEF);
 
-		if (namelen < 0 || namelen > PS_BIN_MAX || (p + namelen) >= endptr) {
+		if (namelen > PS_BIN_MAX || (p + namelen) >= endptr) {
 			PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
 			return FAILURE;
 		}

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -2909,7 +2909,7 @@ static PHP_MINFO_FUNCTION(session) /* {{{ */
 
 	/* Get serializer handlers */
 	for (i = 0, ser = ps_serializers; i < MAX_SERIALIZERS; i++, ser++) {
-		if (ser && ser->name) {
+		if (ser->name) {
 			smart_str_appends(&ser_handlers, ser->name);
 			smart_str_appendc(&ser_handlers, ' ');
 		}


### PR DESCRIPTION
* [Remove redundant check on ser](https://github.com/php/php-src/commit/8df9e6c748f63b8363e6ea90517f7e3f09c8b2fe)
* [Change namelen to size_t because it is always unsigned and less in size than size_t](https://github.com/php/php-src/commit/791700dc161ea6d90ea38cf9bf87ad0e92c2bb0b)
* [sid can never be NULL because it was NULL-checked earlier](https://github.com/php/php-src/commit/f985667bcf1554ed42d92722691781f99cfc4565)