### PR TITLE
Remove always-false check in CLI

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -632,7 +632,7 @@ static int do_cli(int argc, char **argv) /* {{{ */
 				request_started = 1;
 				php_print_info(PHP_INFO_ALL & ~PHP_INFO_CREDITS);
 				php_output_end_all();
-				EG(exit_status) = (c == '?' && argc > 1 && !strchr(argv[1],  c));
+				EG(exit_status) = 0;
 				goto out;
 
 			case 'v': /* show php version & quit */


### PR DESCRIPTION
This is the case c == 'i', so c == '?' is always false, hence the result is always 0.