### PR TITLE
Fix GH-10728: opcache capstone header's inclusion.

### DIFF
--- a/ext/opcache/jit/zend_jit_disasm.c
+++ b/ext/opcache/jit/zend_jit_disasm.c
@@ -21,7 +21,7 @@
 
 #ifdef HAVE_CAPSTONE
 # define HAVE_DISASM 1
-# include <capstone/capstone.h>
+# include <capstone.h>
 # define HAVE_CAPSTONE_ITER 1
 #elif ZEND_JIT_TARGET_X86
 # define HAVE_DISASM 1


### PR DESCRIPTION
Remove capstone include folder.
For most of the supported systems it worked fine somehow despite
 the pkg-config --cflags, but is always include it even on Linux.