### PR TITLE
Note where a session was already started

### DIFF
--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -154,7 +154,7 @@ typedef struct _php_ps_globals {
 	const ps_module *default_mod;
 	void *mod_data;
 	php_session_status session_status;
-	char *session_started_filename;
+	zend_string *session_started_filename;
 	uint32_t session_started_lineno;
 	zend_long gc_probability;
 	zend_long gc_divisor;

--- a/ext/session/php_session.h
+++ b/ext/session/php_session.h
@@ -154,6 +154,8 @@ typedef struct _php_ps_globals {
 	const ps_module *default_mod;
 	void *mod_data;
 	php_session_status session_status;
+	char *session_started_filename;
+	uint32_t session_started_lineno;
 	zend_long gc_probability;
 	zend_long gc_divisor;
 	zend_long gc_maxlifetime;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1505,7 +1505,7 @@ PHPAPI zend_result php_session_start(void) /* {{{ */
 	switch (PS(session_status)) {
 		case php_session_active:
 			if (PS(session_started_filename)) {
-				php_error(E_NOTICE, "Ignoring session_start() because a session has already been started (started from %s on line %u)", ZSTR_VAL(PS(session_started_filename)), PS(session_started_lineno));
+				php_error(E_NOTICE, "Ignoring session_start() because a session has already been started (started from %s on line %"PRIu32")", ZSTR_VAL(PS(session_started_filename)), PS(session_started_lineno));
 			} else {
 				php_error(E_NOTICE, "Ignoring session_start() because a session has already been started");
 			}
@@ -2541,7 +2541,7 @@ PHP_FUNCTION(session_start)
 
 	if (PS(session_status) == php_session_active) {
 		if (PS(session_started_filename)) {
-			php_error_docref(NULL, E_NOTICE, "Ignoring session_start() because a session is already active (started from %s on line %d)", ZSTR_VAL(PS(session_started_filename)), PS(session_started_lineno));
+			php_error_docref(NULL, E_NOTICE, "Ignoring session_start() because a session is already active (started from %s on line %"PRIu32")", ZSTR_VAL(PS(session_started_filename)), PS(session_started_lineno));
 		} else {
 			php_error_docref(NULL, E_NOTICE, "Ignoring session_start() because a session is already active");
 		}

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -479,6 +479,13 @@ static zend_result php_session_initialize(void) /* {{{ */
 		php_session_decode(val);
 		zend_string_release_ex(val, 0);
 	}
+
+	php_session_cleanup_filename();
+	zend_string *session_started_filename = zend_get_executed_filename_ex();
+	if (session_started_filename != NULL) {
+		PS(session_started_filename) = zend_string_copy(session_started_filename);
+		PS(session_started_lineno) = zend_get_executed_lineno();
+	}
 	return SUCCESS;
 }
 /* }}} */
@@ -1617,14 +1624,6 @@ PHPAPI zend_result php_session_start(void) /* {{{ */
 			PS(id) = NULL;
 		}
 		return FAILURE;
-	}
-
-	/* Should these be set here, or in session_initialize? */
-	php_session_cleanup_filename();
-	zend_string *session_started_filename = zend_get_executed_filename_ex();
-	if (session_started_filename != NULL) {
-		PS(session_started_filename) = zend_string_copy(session_started_filename);
-		PS(session_started_lineno) = zend_get_executed_lineno();
 	}
 
 	return SUCCESS;

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -1513,6 +1513,9 @@ PHPAPI zend_result php_session_start(void) /* {{{ */
 		case php_session_active:
 			if (PS(session_started_filename)) {
 				php_error(E_NOTICE, "Ignoring session_start() because a session has already been started (started from %s on line %"PRIu32")", ZSTR_VAL(PS(session_started_filename)), PS(session_started_lineno));
+			} else if (PS(auto_start)) {
+				/* This option can't be changed at runtime, so we can assume it's because of this */
+				php_error(E_NOTICE, "Ignoring session_start() because a session has already been started automatically");
 			} else {
 				php_error(E_NOTICE, "Ignoring session_start() because a session has already been started");
 			}
@@ -2541,6 +2544,9 @@ PHP_FUNCTION(session_start)
 	if (PS(session_status) == php_session_active) {
 		if (PS(session_started_filename)) {
 			php_error_docref(NULL, E_NOTICE, "Ignoring session_start() because a session is already active (started from %s on line %"PRIu32")", ZSTR_VAL(PS(session_started_filename)), PS(session_started_lineno));
+		} else if (PS(auto_start)) {
+			/* This option can't be changed at runtime, so we can assume it's because of this */
+			php_error_docref(NULL, E_NOTICE, "Ignoring session_start() because a session is already automatically active");
 		} else {
 			php_error_docref(NULL, E_NOTICE, "Ignoring session_start() because a session is already active");
 		}

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -123,6 +123,16 @@ static inline void php_rinit_session_globals(void) /* {{{ */
 }
 /* }}} */
 
+static inline void php_session_cleanup_filename(void) /* {{{ */
+{
+	if (PS(session_started_filename)) {
+		efree(PS(session_started_filename));
+		PS(session_started_filename) = NULL;
+		PS(session_started_lineno) = 0;
+	}
+}
+/* }}} */
+
 /* Dispatched by RSHUTDOWN and by php_session_destroy */
 static inline void php_rshutdown_session_globals(void) /* {{{ */
 {
@@ -151,11 +161,7 @@ static inline void php_rshutdown_session_globals(void) /* {{{ */
 		PS(mod_user_class_name) = NULL;
 	}
 
-	if (PS(session_started_filename)) {
-		efree(PS(session_started_filename));
-		PS(session_started_filename) = NULL;
-		PS(session_started_lineno) = 0;
-	}
+	php_session_cleanup_filename();
 
 	/* User save handlers may end up directly here by misuse, bugs in user script, etc. */
 	/* Set session status to prevent error while restoring save handler INI value. */
@@ -1614,6 +1620,7 @@ PHPAPI zend_result php_session_start(void) /* {{{ */
 	}
 
 	/* Should these be set here, or in session_initialize? */
+	php_session_cleanup_filename();
 	PS(session_started_filename) = estrdup(zend_get_executed_filename());
 	PS(session_started_lineno) = zend_get_executed_lineno();
 

--- a/ext/session/session.c
+++ b/ext/session/session.c
@@ -110,8 +110,6 @@ static inline void php_rinit_session_globals(void) /* {{{ */
 	/* TODO: These could be moved to MINIT and removed. These should be initialized by php_rshutdown_session_globals() always when execution is finished. */
 	PS(id) = NULL;
 	PS(session_status) = php_session_none;
-	PS(session_started_filename) = NULL;
-	PS(session_started_lineno) = 0;
 	PS(in_save_handler) = 0;
 	PS(set_handler) = 0;
 	PS(mod_data) = NULL;
@@ -2882,6 +2880,8 @@ static PHP_MINIT_FUNCTION(session) /* {{{ */
 	PS(module_number) = module_number;
 
 	PS(session_status) = php_session_none;
+	PS(session_started_filename) = NULL;
+	PS(session_started_lineno) = 0;
 	REGISTER_INI_ENTRIES();
 
 #ifdef HAVE_LIBMM

--- a/ext/session/tests/session_start_variation1.phpt
+++ b/ext/session/tests/session_start_variation1.phpt
@@ -25,15 +25,15 @@ ob_end_flush();
 *** Testing session_start() : variation ***
 bool(true)
 
-Notice: session_start(): Ignoring session_start() because a session is already active in %s on line %d
+Notice: session_start(): Ignoring session_start() because a session is already active (started from %s on line %d) in %s on line %d
 bool(true)
 
-Notice: session_start(): Ignoring session_start() because a session is already active in %s on line %d
+Notice: session_start(): Ignoring session_start() because a session is already active (started from %s on line %d) in %s on line %d
 bool(true)
 
-Notice: session_start(): Ignoring session_start() because a session is already active in %s on line %d
+Notice: session_start(): Ignoring session_start() because a session is already active (started from %s on line %d) in %s on line %d
 bool(true)
 
-Notice: session_start(): Ignoring session_start() because a session is already active in %s on line %d
+Notice: session_start(): Ignoring session_start() because a session is already active (started from %s on line %d) in %s on line %d
 bool(true)
 Done

--- a/ext/session/tests/session_start_variation9.phpt
+++ b/ext/session/tests/session_start_variation9.phpt
@@ -26,7 +26,7 @@ ob_end_flush();
 *** Testing session_start() : variation ***
 string(%d) "%s"
 
-Notice: session_start(): Ignoring session_start() because a session is already active in %s on line %d
+Notice: session_start(): Ignoring session_start() because a session is already automatically active in %s on line %d
 bool(true)
 string(%d) "%s"
 bool(true)

--- a/ext/session/tests/session_start_variation9.phpt
+++ b/ext/session/tests/session_start_variation9.phpt
@@ -26,7 +26,7 @@ ob_end_flush();
 *** Testing session_start() : variation ***
 string(%d) "%s"
 
-Notice: session_start(): Ignoring session_start() because a session is already active (started from %s on line %d) in %s on line %d
+Notice: session_start(): Ignoring session_start() because a session is already active in %s on line %d
 bool(true)
 string(%d) "%s"
 bool(true)

--- a/ext/session/tests/session_start_variation9.phpt
+++ b/ext/session/tests/session_start_variation9.phpt
@@ -26,7 +26,7 @@ ob_end_flush();
 *** Testing session_start() : variation ***
 string(%d) "%s"
 
-Notice: session_start(): Ignoring session_start() because a session is already active in %s on line %d
+Notice: session_start(): Ignoring session_start() because a session is already active (started from %s on line %d) in %s on line %d
 bool(true)
 string(%d) "%s"
 bool(true)


### PR DESCRIPTION
Duplicated session starts can be annoying to debug. The error that occurs when a session is already active doesn't tell you where it was initialized, so figuring out the callsite involves manual debugging to find it out.

This keeps track of the call site of session_start as a request global, and frees at the end of the request. It should make it easier to find these instances for PHP users.

The resulting message can look like:
```
Notice: session_start(): Ignoring session_start() because a session is already active (started from /home/calvin/src/php-src/inc.php on line 4) in /home/calvin/src/php-src/index.php on line 9
```

Fixes GH-10721