### PR TITLE
Fix missing and inconsistent error check on SQLAllocHandle

### DIFF
--- a/ext/pdo_odbc/odbc_driver.c
+++ b/ext/pdo_odbc/odbc_driver.c
@@ -220,7 +220,7 @@ static zend_long odbc_handle_doer(pdo_dbh_t *dbh, const zend_string *sql)
 	PDO_ODBC_HSTMT	stmt;
 
 	rc = SQLAllocHandle(SQL_HANDLE_STMT, H->dbc, &stmt);
-	if (rc != SQL_SUCCESS) {
+	if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
 		pdo_odbc_drv_error("SQLAllocHandle: STMT");
 		return -1;
 	}
@@ -439,7 +439,12 @@ static int pdo_odbc_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ 
 
 	dbh->driver_data = H;
 
-	SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &H->env);
+	rc = SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &H->env);
+	if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
+		pdo_odbc_drv_error("SQLAllocHandle: ENV");
+		goto fail;
+	}
+
 	rc = SQLSetEnvAttr(H->env, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
 
 	if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
@@ -459,7 +464,7 @@ static int pdo_odbc_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ 
 
 	rc = SQLAllocHandle(SQL_HANDLE_DBC, H->env, &H->dbc);
 	if (rc != SQL_SUCCESS && rc != SQL_SUCCESS_WITH_INFO) {
-		pdo_odbc_drv_error("SQLAllocHandle (DBC)");
+		pdo_odbc_drv_error("SQLAllocHandle: DBC");
 		goto fail;
 	}
 


### PR DESCRIPTION
* Missing check: SQLAllocHandle() for the environment wasn't checked in pdo_odbc_handle_factory(). Add a check similar to the other ones for SQLAllocHandle().
* Inconsistent check: one of the SQLAllocHandle() calls wasn't checked for SQL_SUCCESS_WITH_INFO. However, looking at the other uses and the documentation we should probably check this as well.

Furthermore, since there was a mix of "SQLAllocHandle: reason" and "SQLAllocHandle (reason)" in the error reporting, I made them consistently use the first option as that seems to be the most used for error reporting in this file.

Found using an experimental static analyser I'm developing.