### PR TITLE
`http_response_code` should warn if headers already sent

### DIFF
--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -365,10 +365,10 @@ PHP_FUNCTION(http_response_code)
 	{
 		if (SG(headers_sent) && !SG(request_info).no_headers) {
 			const char *output_start_filename = php_output_get_start_filename();
-			uint32_t output_start_lineno = php_output_get_start_lineno();
+			int output_start_lineno = php_output_get_start_lineno();
 
 			if (output_start_filename) {
-				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent by (output started at %s:%u)", output_start_filename, output_start_lineno);
+				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent by (output started at %s:%"PRIi32")", output_start_filename, output_start_lineno);
 			} else {
 				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent");
 			}

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -365,10 +365,10 @@ PHP_FUNCTION(http_response_code)
 	{
 		if (SG(headers_sent) && !SG(request_info).no_headers) {
 			const char *output_start_filename = php_output_get_start_filename();
-			int output_start_lineno = php_output_get_start_lineno();
+			uint32_t output_start_lineno = php_output_get_start_lineno();
 
 			if (output_start_filename) {
-				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent by (output started at %s:%d)", output_start_filename, output_start_lineno);
+				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent by (output started at %s:%u)", output_start_filename, output_start_lineno);
 			} else {
 				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent");
 			}

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -368,7 +368,8 @@ PHP_FUNCTION(http_response_code)
 			int output_start_lineno = php_output_get_start_lineno();
 
 			if (output_start_filename) {
-				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent (output started at %s:%"PRIi32")", output_start_filename, output_start_lineno);
+				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent "
+					"(output started at %s:%d)", output_start_filename, output_start_lineno);
 			} else {
 				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent");
 			}

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -368,7 +368,7 @@ PHP_FUNCTION(http_response_code)
 			int output_start_lineno = php_output_get_start_lineno();
 
 			if (output_start_filename) {
-				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent by (output started at %s:%"PRIi32")", output_start_filename, output_start_lineno);
+				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent (output started at %s:%"PRIi32")", output_start_filename, output_start_lineno);
 			} else {
 				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent");
 			}

--- a/ext/standard/head.c
+++ b/ext/standard/head.c
@@ -363,6 +363,17 @@ PHP_FUNCTION(http_response_code)
 
 	if (response_code)
 	{
+		if (SG(headers_sent) && !SG(request_info).no_headers) {
+			const char *output_start_filename = php_output_get_start_filename();
+			int output_start_lineno = php_output_get_start_lineno();
+
+			if (output_start_filename) {
+				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent by (output started at %s:%d)", output_start_filename, output_start_lineno);
+			} else {
+				php_error_docref(NULL, E_WARNING, "Cannot set response code - headers already sent");
+			}
+			RETURN_FALSE;
+		}
 		zend_long old_response_code;
 
 		old_response_code = SG(sapi_headers).http_response_code;

--- a/ext/standard/tests/general_functions/http_response_code.phpt
+++ b/ext/standard/tests/general_functions/http_response_code.phpt
@@ -33,5 +33,5 @@ bool(true)
 int(201)
 Now we've sent the headers
 
-Warning: http_response_code(): Cannot set response code - headers already sent by (output started at %s:%d) in %s on line %d
+Warning: http_response_code(): Cannot set response code - headers already sent (output started at %s:%d) in %s on line %d
 bool(false)

--- a/ext/standard/tests/general_functions/http_response_code.phpt
+++ b/ext/standard/tests/general_functions/http_response_code.phpt
@@ -21,8 +21,17 @@ var_dump(
     // Get the new response code
     http_response_code()
 );
+echo "Now we've sent the headers\n";
+var_dump(
+    // This should fail
+    http_response_code(500)
+);
 ?>
---EXPECT--
+--EXPECTF--
 bool(false)
 bool(true)
 int(201)
+Now we've sent the headers
+
+Warning: http_response_code(): Cannot set response code - headers already sent by (output started at %s:%d) in %s on line %d
+bool(false)

--- a/sapi/fpm/tests/log-suppress-output.phpt
+++ b/sapi/fpm/tests/log-suppress-output.phpt
@@ -38,7 +38,7 @@ function doTestCalls(FPM\Tester &$tester, bool $expectSuppressableEntries)
     $tester->request(query: 'test=output', uri: '/ping')->expectBody('pong', 'text/plain');
     $tester->expectAccessLog("'GET /ping?test=output' 200", suppressable: false);
 
-    $tester->request(headers: ['X_ERROR' => 1])->expectBody('Not OK');
+    $tester->request(headers: ['X_ERROR' => 1])->expectStatus('500 Internal Server Error')->expectBody('Not OK');
     $tester->expectAccessLog("'GET /log-suppress-output.src.php' 500", suppressable: false);
 
     $tester->request()->expectBody('OK');
@@ -54,8 +54,8 @@ function doTestCalls(FPM\Tester &$tester, bool $expectSuppressableEntries)
 $src = <<<EOT
 <?php
 if (isset(\$_SERVER['X_ERROR'])) {
-    echo "Not OK";
     http_response_code(500);
+    echo "Not OK";
     exit;
 }
 echo \$_REQUEST['test'] ?? "OK";


### PR DESCRIPTION
This would fail silently otherwise. The warning should be similar to the one that header emits (the code is some copy and paste from `main/SAPI.c`, to match). It'll also return false in that case.

Fixes GH-10742