### PR TITLE
Fix some missing and inconsistent error checking in mbstring

### DIFF
--- a/ext/mbstring/libmbfl/filters/mbfilter_7bit.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_7bit.c
@@ -76,7 +76,7 @@ int mbfl_filt_conv_any_7bit(int c, mbfl_convert_filter *filter)
 	if (c >= 0 && c < 0x80) {
 		CK((*filter->output_function)(c, filter->data));
 	} else {
-		mbfl_filt_conv_illegal_output(c, filter);
+		CK(mbfl_filt_conv_illegal_output(c, filter));
 	}
 	return 0;
 }

--- a/ext/mbstring/libmbfl/filters/mbfilter_iso2022jp_mobile.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_iso2022jp_mobile.c
@@ -288,7 +288,7 @@ int mbfl_filt_conv_wchar_2022jp_mobile(int c, mbfl_convert_filter *filter)
 		}
 	}
 
-	if (mbfilter_unicode2sjis_emoji_kddi(c, &s1, filter)) {
+	if (mbfilter_unicode2sjis_emoji_kddi(c, &s1, filter) > 0) {
 		CODE2JIS(c1,c2,s1,s2);
 		s1 -= 0x1600;
 	}

--- a/ext/mbstring/libmbfl/filters/mbfilter_sjis_mobile.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_sjis_mobile.c
@@ -819,9 +819,9 @@ int mbfl_filt_conv_wchar_sjis_mobile(int c, mbfl_convert_filter *filter)
 		}
 	}
 
-	if ((filter->to == &mbfl_encoding_sjis_docomo && mbfilter_unicode2sjis_emoji_docomo(c, &s1, filter)) ||
-		  (filter->to == &mbfl_encoding_sjis_kddi   && mbfilter_unicode2sjis_emoji_kddi(c, &s1, filter)) ||
-		  (filter->to == &mbfl_encoding_sjis_sb     && mbfilter_unicode2sjis_emoji_sb(c, &s1, filter))) {
+	if ((filter->to == &mbfl_encoding_sjis_docomo && mbfilter_unicode2sjis_emoji_docomo(c, &s1, filter) > 0) ||
+		  (filter->to == &mbfl_encoding_sjis_kddi   && mbfilter_unicode2sjis_emoji_kddi(c, &s1, filter) > 0) ||
+		  (filter->to == &mbfl_encoding_sjis_sb     && mbfilter_unicode2sjis_emoji_sb(c, &s1, filter) > 0)) {
 		CODE2JIS(c1,c2,s1,s2);
  	}
 

--- a/ext/mbstring/libmbfl/filters/mbfilter_sjis_mobile.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_sjis_mobile.c
@@ -518,7 +518,7 @@ int mbfilter_unicode2sjis_emoji_sb(int c, int *s1, mbfl_convert_filter *filter)
 			}
 			return 1;
 		} else {
-			(*filter->output_function)(c1, filter->data);
+			CK((*filter->output_function)(c1, filter->data));
 		}
 	} else if (filter->status == 2) {
 		int c1 = filter->cache;

--- a/ext/mbstring/libmbfl/filters/mbfilter_sjis_mobile.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_sjis_mobile.c
@@ -462,7 +462,7 @@ int mbfilter_unicode2sjis_emoji_kddi(int c, int *s1, mbfl_convert_filter *filter
 
 		/* If none of the KDDI national flag emoji matched, then we have no way
 		 * to convert the previous codepoint... */
-		mbfl_filt_conv_illegal_output(c1, filter);
+		CK(mbfl_filt_conv_illegal_output(c1, filter));
 	}
 
 	if (c == '#' || (c >= '0' && c <= '9')) {
@@ -534,7 +534,7 @@ int mbfilter_unicode2sjis_emoji_sb(int c, int *s1, mbfl_convert_filter *filter)
 
 		/* If none of the SoftBank national flag emoji matched, then we have no way
 		 * to convert the previous codepoint... */
-		mbfl_filt_conv_illegal_output(c1, filter);
+		CK(mbfl_filt_conv_illegal_output(c1, filter));
 	}
 
 	if (c == '#' || (c >= '0' && c <= '9')) {
@@ -855,7 +855,7 @@ int mbfl_filt_conv_sjis_mobile_flush(mbfl_convert_filter *filter)
 	} else if (filter->status == 2) {
 		/* First of a pair of Regional Indicator codepoints came at the end of a string */
 		filter->cache = filter->status = 0;
-		mbfl_filt_conv_illegal_output(c1, filter);
+		CK(mbfl_filt_conv_illegal_output(c1, filter));
 	}
 
 	if (filter->flush_function) {


### PR DESCRIPTION
*  Make error checks on encoding methods for docomo, kddi, sb consistent

    Some places use an if check, which implicitly checks for a non-zero
    value, and some places use > 0. The > 0 is the correct one because at
    least some of those functions already use the CK() macro to return -1 on
    error. Because -1 != 0 this is wrongly interpreted as a success instead
    of a failure.

*  Use CK() macro to check the output function in mbfilter_unicode2sjis_emoji_sb()

    We can now do this properly because we check the return value correctly.

* Propagate error checks for mbfl_filt_conv_illegal_output()

    Most callers check it correctly, but a couple of places were forgotten.

Found using an experimental static analyser I'm developing.

cc @alexdowad 