### PR TITLE
remove assert raising strange behavior with GCC 10

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -1748,7 +1748,6 @@ ZEND_METHOD(ReflectionFunctionAbstract, getClosureUsedVariables)
 
 		zend_op *opline = ops->opcodes + ops->num_args;
 		if (ops->fn_flags & ZEND_ACC_VARIADIC) {
-			ZEND_ASSERT(opline->opcode == ZEND_RECV_VARIADIC);
 			opline++;
 		}
 


### PR DESCRIPTION
Very strangely, since ae16471628be04b9c4c4c5eaf99e70452bb2514f 2 tests are failing

```
TEST 155/403 [ext/reflection/tests/ReflectionFunction_getClosureUsedVariables.phpt]
========DIFF========
--
     }
     array(0) {
     }
005+ array(0) {
006+ }
007+ array(0) {
008+ }
       ["one"]=>
       int(1)
       ["two"]=>
009+ array(0) {
005- array(2) {
006-   ["one"]=>
007-   int(1)
008-   ["two"]=>
009-   int(2)
     }
011- array(1) {
012-   ["one"]=>
013-   int(1)
014- }
015- array(1) {
016-   ["one"]=>
017-   &int(1)
018- }
========DONE========
FAIL ReflectionFunctionAbstract::getClosureUsedVariables [ext/reflection/tests/ReflectionFunction_getClosureUsedVariables.phpt] 

TEST 372/403 [ext/reflection/tests/gh10623.phpt]
========DIFF========
001- array(1) {
002-   ["data1"]=>
003-   int(1)
001+ array(0) {
     }
     array(0) {
     }
--
========DONE========
FAIL GH-10623 (ReflectionFunction::getClosureUsedVariables() returns empty array in presence of variadic arguments) [ext/reflection/tests/gh10623.phpt] 

```

This seems to be a very strange undefined behavior, only encountered on RHEL-7 with GCC 10

```
 		for (; opline->opcode == ZEND_BIND_STATIC; opline++)  {
```
Strangely loop is not entered, but if displayed opcode is 183 (ZEND_BIND_STATIC)
