### PR TITLE
Propagate success status of ftp_close() to userland

### DIFF
--- a/ext/ftp/php_ftp.c
+++ b/ext/ftp/php_ftp.c
@@ -1224,6 +1224,7 @@ PHP_FUNCTION(ftp_close)
 {
 	zval		*z_ftp;
 	php_ftp_object *obj;
+	bool success = true;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &z_ftp, php_ftp_ce) == FAILURE) {
 		RETURN_THROWS();
@@ -1231,12 +1232,12 @@ PHP_FUNCTION(ftp_close)
 
 	obj = ftp_object_from_zend_object(Z_OBJ_P(z_ftp));
 	if (obj->ftp) {
-		ftp_quit(obj->ftp);
+		success = ftp_quit(obj->ftp);
 		ftp_close(obj->ftp);
 		obj->ftp = NULL;
 	}
 
-	RETURN_TRUE;
+	RETURN_BOOL(success);
 }
 /* }}} */
 

--- a/ext/ftp/tests/004.phpt
+++ b/ext/ftp/tests/004.phpt
@@ -28,4 +28,4 @@ bool(true)
 
 Warning: ftp_login(): Not logged in. in %s on line %d
 bool(false)
-bool(true)
+bool(false)

--- a/ext/ftp/tests/server.inc
+++ b/ext/ftp/tests/server.inc
@@ -183,6 +183,7 @@ if ($pid) {
             fputs($s, "200 OK\r\n");
 
         } elseif ($buf === "QUIT\r\n") {
+            fputs($s, "221 Bye\r\n");
             break;
 
         } elseif (preg_match("~^PORT (\d+),(\d+),(\d+),(\d+),(\d+),(\d+)\r\n$~", $buf, $m)) {


### PR DESCRIPTION
The docs say that this function returns true on success, and false on error. This function always returns true in the current implementation because the success return value from ftp_close() is never propagated to userland. This affects one test: since the test server exits after an invalid login, the ftp close correctly fails (because the server has gone away).

Found using an experimental static analyser I'm developing.