### PR TITLE
Add missing error checks on EVP_MD_CTX_create() and EVP_VerifyInit()

### DIFF
--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1579,7 +1579,15 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t sig_type,
 			}
 
 			md_ctx = EVP_MD_CTX_create();
-			EVP_VerifyInit(md_ctx, mdtype);
+			if (!md_ctx || !EVP_VerifyInit(md_ctx, mdtype)) {
+				if (md_ctx) {
+					EVP_MD_CTX_destroy(md_ctx);
+				}
+				if (error) {
+					spprintf(error, 0, "openssl signature could not be verified");
+				}
+				return FAILURE;
+			}
 			read_len = end_of_phar;
 
 			if ((size_t)read_len > sizeof(buf)) {


### PR DESCRIPTION
The first one returns NULL on error, and the second one returns 0 on error. These weren't checked.

Found using an experimental static analyser I'm developing.