### PR TITLE
random: Convert `php_random_(bytes|int)_(silent|throw)` into inline functions

### DIFF
--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -200,22 +200,22 @@ PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *resul
 
 static inline zend_result php_random_bytes_throw(void *bytes, size_t size)
 {
-	return php_random_bytes(bytes, size, 1);
+	return php_random_bytes(bytes, size, true);
 }
 
 static inline zend_result php_random_bytes_silent(void *bytes, size_t size)
 {
-	return php_random_bytes(bytes, size, 0);
+	return php_random_bytes(bytes, size, false);
 }
 
 static inline zend_result php_random_int_throw(zend_long min, zend_long max, zend_long *result)
 {
-	return php_random_int(min, max, result, 1);
+	return php_random_int(min, max, result, true);
 }
 
 static inline zend_result php_random_int_silent(zend_long min, zend_long max, zend_long *result)
 {
-	return php_random_int(min, max, result, 0);
+	return php_random_int(min, max, result, false);
 }
 
 typedef struct _php_random_status_ {

--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -195,13 +195,28 @@ static inline uint64_t php_random_pcgoneseq128xslrr64_rotr64(php_random_uint128_
 }
 # endif
 
-# define php_random_bytes_throw(b, s) php_random_bytes((b), (s), 1)
-# define php_random_bytes_silent(b, s) php_random_bytes((b), (s), 0)
-# define php_random_int_throw(min, max, result) php_random_int((min), (max), (result), 1)
-# define php_random_int_silent(min, max, result) php_random_int((min), (max), (result), 0)
-
 PHPAPI zend_result php_random_bytes(void *bytes, size_t size, bool should_throw);
 PHPAPI zend_result php_random_int(zend_long min, zend_long max, zend_long *result, bool should_throw);
+
+static inline zend_result php_random_bytes_throw(void *bytes, size_t size)
+{
+	return php_random_bytes(bytes, size, 1);
+}
+
+static inline zend_result php_random_bytes_silent(void *bytes, size_t size)
+{
+	return php_random_bytes(bytes, size, 0);
+}
+
+static inline zend_result php_random_int_throw(zend_long min, zend_long max, zend_long *result)
+{
+	return php_random_int(min, max, result, 1);
+}
+
+static inline zend_result php_random_int_silent(zend_long min, zend_long max, zend_long *result)
+{
+	return php_random_int(min, max, result, 0);
+}
 
 typedef struct _php_random_status_ {
 	size_t last_generated_size;


### PR DESCRIPTION
Compared to macros, inline functions are more robust and easier to debug.