### PR TITLE
random: Add missing `php.h` include to php_random.h

### DIFF
--- a/ext/random/php_random.h
+++ b/ext/random/php_random.h
@@ -31,6 +31,8 @@
 #ifndef PHP_RANDOM_H
 # define PHP_RANDOM_H
 
+# include "php.h"
+
 PHPAPI double php_combined_lcg(void);
 
 /*


### PR DESCRIPTION
`PHPAPI` is defined in `php.h`. It appears that without the explicit include, recent versions of Visual Studio Code’s intellisense (rightfully) no longer detect `PHPAPI`. This will then lead to a misparsing of the file, because `PHPAPI` is assumed to be the return type and the actual return type is assumed to be the function name, thus expecting a semicolon after the actual return type. This in turn colors the entire header in red due to the detected syntax error(s), making development very hard / impossible.

This did not cause issues outside of the IDE use case, because apparently all users of `php_random.h` include `php.h` before including `php_random.h`.