### PR TITLE
Fix GH-10766: PharData archive created with Phar::Zip format does not keep files metadata (datetime)

### DIFF
--- a/ext/phar/tests/zip/gh10766.phpt
+++ b/ext/phar/tests/zip/gh10766.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-10766 (PharData archive created with Phar::Zip format does not keep files metadata (datetime))
+--EXTENSIONS--
+phar
+zip
+--INI--
+phar.readonly=0
+--FILE--
+<?php
+$phar = new PharData(__DIR__ . '/gh10766.zip', 0, null, Phar::ZIP);
+$phar->addFromString('name', 'contents');
+unset($phar);
+
+// Re-read from disk, but using the zip extension because the phar bug will not make it possible
+// to use their timestamp methods.
+$zip = new ZipArchive();
+$zip->open(__DIR__ . '/gh10766.zip');
+var_dump($zip->statName('name')['mtime'] > 315529200 /* earliest possible zip timestamp */);
+$zip->close();
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/gh10766.zip');
+?>
+--EXPECT--
+bool(true)

--- a/ext/phar/zip.c
+++ b/ext/phar/zip.c
@@ -147,7 +147,8 @@ static void phar_zip_u2d_time(time_t time, char *dtime, char *ddate) /* {{{ */
 	struct tm *tm, tmbuf;
 
 	tm = php_localtime_r(&time, &tmbuf);
-	if (tm->tm_year >= 1980) {
+	/* Note: tm_year is the year - 1900 */
+	if (tm->tm_year >= 80) {
 		cdate = ((tm->tm_year+1900-1980)<<9) + ((tm->tm_mon+1)<<5) + tm->tm_mday;
 		ctime = ((tm->tm_hour)<<11) + ((tm->tm_min)<<5) + ((tm->tm_sec)>>1);
 	} else {


### PR DESCRIPTION
Fixes GH-10766

Due to an incorrect check, the datetime was never actually set. To test this we need to write the file using phar, but read the file using a different method to not get a cached, or a value that's been transformed twice and is therefore accidentally correct.