### PR TITLE
Set error_log to an empty value if the test relies on that feature

### DIFF
--- a/Zend/tests/bug39542.phpt
+++ b/Zend/tests/bug39542.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #39542 (Behaviour of require_once/include_once different to < 5.2.0)
+--INI--
+error_log=
 --FILE--
 <?php
 $oldcwd = getcwd();

--- a/Zend/tests/bug79919.phpt
+++ b/Zend/tests/bug79919.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug #79919 (Stack use-after-scope in define())
+--INI--
+error_log=
 --EXTENSIONS--
 simplexml
 --FILE--

--- a/ext/opcache/tests/jit/bug80861.phpt
+++ b/ext/opcache/tests/jit/bug80861.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Bug #80839: PHP problem with JIT
 --INI--
+error_log=
 opcache.enable=1
 opcache.enable_cli=1
 opcache.jit_buffer_size=1M


### PR DESCRIPTION
Some tests fail if the error_log is overriden by the loaded ini configuration. Explicitly set it to an empty value to prevent the failures.
See https://github.com/php/php-src/issues/10737#issuecomment-1452899299