### PR TITLE
mb_encode_mimeheader does not crash if provided encoding has no MIME name set

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -2816,6 +2816,9 @@ PHP_FUNCTION(mb_encode_mimeheader)
 		charset = php_mb_get_encoding(charset_name, 2);
 		if (!charset) {
 			RETURN_THROWS();
+		} else if (charset->mime_name == NULL || charset->mime_name[0] == '\0') {
+			zend_argument_value_error(2, "\"%s\" cannot be used for MIME header encoding", ZSTR_VAL(charset_name));
+			RETURN_THROWS();
 		}
 	} else {
 		const mbfl_language *lang = mbfl_no2language(MBSTRG(language));

--- a/ext/mbstring/tests/mb_encode_mimeheader_crash.phpt
+++ b/ext/mbstring/tests/mb_encode_mimeheader_crash.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test mb_encode_mimeheader() function : text encoding with no MIME name
+--EXTENSIONS--
+mbstring
+--SKIPIF--
+<?php
+function_exists('mb_encode_mimeheader') or die("skip mb_encode_mimeheader() is not available in this build");
+?>
+--FILE--
+<?php
+try {
+    var_dump(mb_encode_mimeheader("abc", "UTF7-IMAP", "Q"));
+} catch (\ValueError $e) {
+    echo $e->getMessage() . \PHP_EOL;
+}
+
+echo "Done\n";
+?>
+--EXPECT--
+mb_encode_mimeheader(): Argument #2 ($charset) "UTF7-IMAP" cannot be used for MIME header encoding
+Done


### PR DESCRIPTION
Even from before PHP 8.0, it has been possible to crash the PHP interpreter with code like this:

```
mb_encode_mimeheader($str, "UTF7-IMAP", "Q");
```

The problem was that some supported legacy text encodings for mbstring, like UTF7-IMAP, don't have a 'mime name'. This causes `mbfl_mime_header_encode` to return NULL, and then we die with a null pointer dereference.

@cmb69 @Girgias @kamil-tekiela @youkidearitai @pakutoma