### PR TITLE
Fix failure of AVX2-accelerated mb_check_encoding on 32-bit MS Windows

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -5155,7 +5155,12 @@ finish_up_remaining_bytes:
 			goto check_operand;
 		case 7:
 		case 8:
-			operand = _mm256_set_epi64x(0, 0, 0, *((int64_t*)p));
+			/* This was originally: operand = _mm256_set_epi64x(0, 0, 0, *((int64_t*)p));
+			 * However, that caused test failures on 32-bit MS Windows
+			 * (Bad 7/8-byte UTF-8 strings would be wrongly passed through as 'valid')
+			 * It seems this is caused by a bug in MS Visual C++
+			 * Ref: https://stackoverflow.com/questions/37509129/potential-bug-in-visual-studio-c-compiler-or-in-intel-intrinsics-avx2-mm256-s */
+			operand = _mm256_set_epi32(0, 0, 0, 0, 0, 0, ((int32_t*)p)[1], ((int32_t*)p)[0]);
 			goto check_operand;
 		case 9:
 			operand = _mm256_set_m128i(_mm_setzero_si128(), _mm_srli_si128(_mm_loadu_si128((__m128i*)(p - 6)), 6));

--- a/ext/mbstring/tests/utf_encodings.phpt
+++ b/ext/mbstring/tests/utf_encodings.phpt
@@ -5,7 +5,6 @@ mbstring
 --SKIPIF--
 <?php
 if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
-if (substr(PHP_OS, 0, 3) === 'WIN' && PHP_INT_SIZE === 4) die("skip not for Windows x86");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Not sure if this will do the trick, just opening a PR to see what happens in CI run...