### PR TITLE
feat: enable Zend Max Execution Timers by default in 8.3

### DIFF
--- a/.github/lsan-suppressions.txt
+++ b/.github/lsan-suppressions.txt
@@ -1,1 +1,2 @@
 leak:acommon::DictInfoList::elements
+leak:timer_create

--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,8 @@ PHP                                                                        NEWS
   . Fix bug GH-8821 (Improve line numbers for errors in constant expressions).
     (ilutov)
   . Fix bug GH-10083 (Allow comments between & and parameter). (ilutov)
+  . Zend Max Execution Timers is now enabled by default for ZTS builds on
+    Linux. (Kévin Dunglas)
 
 - Date:
   . Implement More Appropriate Date/Time Exceptions RFC. (Derick)

--- a/UPGRADING
+++ b/UPGRADING
@@ -33,6 +33,8 @@ PHP 8.3 UPGRADE NOTES
     Internally, this works by caching the result on posix systems. If you want
     the old behaviour, you can check the "cached" key in the array returned by
     proc_get_status() to check whether the result was cached.
+  . Zend Max Execution Timers is now enabled by default for ZTS builds on
+    Linux.
 
 - FFI:
   . C functions that have a return type of void now return null instead of

--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -307,7 +307,7 @@ AC_ARG_ENABLE([zend-max-execution-timers],
   [AS_HELP_STRING([--enable-zend-max-execution-timers],
     [whether to enable zend max execution timers])],
     [ZEND_MAX_EXECUTION_TIMERS=$enableval],
-    [ZEND_MAX_EXECUTION_TIMERS='no'])
+    [ZEND_MAX_EXECUTION_TIMERS=$ZEND_ZTS])
 
 AS_CASE(["$host_alias"], [*linux*], [], [ZEND_MAX_EXECUTION_TIMERS='no'])
 


### PR DESCRIPTION
This is a PR that follows #10141. As suggested by @arnaud-lb, this patch enables Zend Max Execution Timers by default for ZTS builds on Linux in PHP 8.3. This was not feasible in 8.1 because it introduces a change in the ABI used by compiled extensions.