### PR TITLE
Ignore -Warray-bounds compiler warning in JIT

### DIFF
--- a/ext/opcache/jit/dynasm/dasm_x86.h
+++ b/ext/opcache/jit/dynasm/dasm_x86.h
@@ -124,7 +124,14 @@ void dasm_free(Dst_DECL)
 void dasm_setupglobal(Dst_DECL, void **gl, unsigned int maxgl)
 {
   dasm_State *D = Dst_REF;
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   D->globals = gl - 10;  /* Negative bias to compensate for locals. */
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
   DASM_M_GROW(Dst, int, D->lglabels, D->lgsize, (10+maxgl)*sizeof(int));
 }
 


### PR DESCRIPTION
The out-of-bounds pointer is intentional.