### PR TITLE
Disable opcache.consistency_checks

### DIFF
--- a/ext/opcache/tests/gh8065.phpt
+++ b/ext/opcache/tests/gh8065.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-8065: opcache.consistency_checks > 0 causes segfaults in PHP >= 8.1.5 in fpm context
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable_cli=1
+opcache.consistency_checks=1
+opcache.log_verbosity_level=2
+--FILE--
+<?php
+var_dump(ini_get("opcache.consistency_checks"));
+var_dump(ini_set("opcache.consistency_checks", 1));
+var_dump(ini_set("opcache.consistency_checks", -1));
+var_dump(ini_set("opcache.consistency_checks", 0));
+?>
+--EXPECTF--
+%sWarning opcache.consistency_checks is reset back to 0 because it does not work properly (see GH-8065, GH-10624).
+
+string(1) "0"
+%sWarning opcache.consistency_checks is reset back to 0 because it does not work properly (see GH-8065, GH-10624).
+
+bool(false)
+%sWarning opcache.consistency_checks is reset back to 0 because it does not work properly (see GH-8065, GH-10624).
+
+bool(false)
+string(1) "0"

--- a/ext/opcache/zend_accelerator_module.c
+++ b/ext/opcache/zend_accelerator_module.c
@@ -108,6 +108,19 @@ static ZEND_INI_MH(OnUpdateMaxWastedPercentage)
 	return SUCCESS;
 }
 
+static ZEND_INI_MH(OnUpdateConsistencyChecks)
+{
+	zend_long *p = (zend_long *) ZEND_INI_GET_ADDR();
+	zend_long consistency_checks = atoi(ZSTR_VAL(new_value));
+
+	if (consistency_checks != 0) {
+		zend_accel_error(ACCEL_LOG_WARNING, "opcache.consistency_checks is reset back to 0 because it does not work properly (see GH-8065, GH-10624).\n");
+		return FAILURE;
+	}
+	*p = 0;
+	return SUCCESS;
+}
+
 static ZEND_INI_MH(OnEnable)
 {
 	if (stage == ZEND_INI_STAGE_STARTUP ||
@@ -242,7 +255,7 @@ ZEND_INI_BEGIN()
 	STD_PHP_INI_ENTRY("opcache.interned_strings_buffer", "8"  , PHP_INI_SYSTEM, OnUpdateLong,                 accel_directives.interned_strings_buffer,   zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.max_accelerated_files" , "10000", PHP_INI_SYSTEM, OnUpdateMaxAcceleratedFiles,	 accel_directives.max_accelerated_files,     zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.max_wasted_percentage" , "5"   , PHP_INI_SYSTEM, OnUpdateMaxWastedPercentage,	 accel_directives.max_wasted_percentage,     zend_accel_globals, accel_globals)
-	STD_PHP_INI_ENTRY("opcache.consistency_checks"    , "0"   , PHP_INI_ALL   , OnUpdateLong,	             accel_directives.consistency_checks,        zend_accel_globals, accel_globals)
+	STD_PHP_INI_ENTRY("opcache.consistency_checks"    , "0"   , PHP_INI_ALL   , OnUpdateConsistencyChecks,	     accel_directives.consistency_checks,        zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.force_restart_timeout" , "180" , PHP_INI_SYSTEM, OnUpdateLong,	             accel_directives.force_restart_timeout,     zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.revalidate_freq"       , "2"   , PHP_INI_ALL   , OnUpdateLong,	             accel_directives.revalidate_freq,           zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.file_update_protection", "2"   , PHP_INI_ALL   , OnUpdateLong,                accel_directives.file_update_protection,    zend_accel_globals, accel_globals)


### PR DESCRIPTION
Replaces GH-10624
Closes GH-8065

This feature does not work right now and leads to memory leaks and other problems. For analysis and discussion see GH-8065. In GH-10624 it was decided to disable the feature to prevent problems for end users. If end users which to get some consistency guarantees, they can rely on opcache.protect_memory.

For now I left the code checking for consistency checks intact in ZendAccelerator.c. We can remove it later if it is decided the feature needs to be removed.