### PR TITLE
Fix GH-10801: Named arguments in CTE functions cause a segfault

### DIFF
--- a/Zend/Optimizer/sccp.c
+++ b/Zend/Optimizer/sccp.c
@@ -1801,8 +1801,9 @@ static void sccp_visit_instr(scdf_ctx *scdf, zend_op *opline, zend_ssa_op *ssa_o
 				break;
 			}
 
-			/* We're only interested in functions with up to three arguments right now */
-			if (call->num_args > 3 || call->send_unpack || call->is_prototype) {
+			/* We're only interested in functions with up to three arguments right now.
+			 * Note that named arguments with the argument in declaration order will still work. */
+			if (call->num_args > 3 || call->send_unpack || call->is_prototype || call->named_args) {
 				SET_RESULT_BOT(result);
 				break;
 			}

--- a/ext/opcache/tests/opt/gh10801.phpt
+++ b/ext/opcache/tests/opt/gh10801.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-10801 (Named arguments in CTE functions cause a segfault)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=0xe0
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+// Named argument case and does not do CTE as expected
+print_r(array_keys(array: [1 => 1], strict: true, filter_value: 0));
+// Will not use named arguments and do CTE as expected
+print_r(array_keys(array: [1 => 1], filter_value: 0, strict: true));
+?>
+--EXPECT--
+Array
+(
+)
+Array
+(
+)


### PR DESCRIPTION
Fixes GH-10801

Named arguments are not supported by the constant evaluation routine, in the sense that they are ignored. This causes two issues:
  - It causes a crash because not all oplines belonging to the call are removed, which results in SEND_VA{L,R} which should've been removed.
  - It causes semantic issues (demonstrated in the test case).

This case never worked anyway, leading to crashes or incorrect behaviour, so just prevent CTE of calls with named parameters for now. We can choose to support it later, but introducing support for this in a stable branch seems too dangerous.

This patch does not change the removal of SEND_* opcodes in remove_call because the crash bug can't be triggered anymore with this patch as there are no named parameters anymore and no variadic CTE functions exist.

### Question

I do have the patch already on my machine to support named arguments & variadics in the `remove_call` function, which solves bullet point 1. If we're interested in supporting named arguments in CTE, I can write the code to actually pass the named arguments during CTE, which would solve bullet point 2. This would make CTE possible with named arguments. Is this something we want?