### PR TITLE
Disable asan instrumentation for phpdbg_watchpoint_userfaultfd_thread

### DIFF
--- a/sapi/phpdbg/phpdbg_watch.c
+++ b/sapi/phpdbg/phpdbg_watch.c
@@ -306,6 +306,9 @@ int phpdbg_watchpoint_segfault_handler(siginfo_t *info, void *context) {
 }
 
 #ifdef HAVE_USERFAULTFD_WRITEFAULT
+# if defined(__GNUC__) && !defined(__clang__)
+__attribute__((no_sanitize_address))
+# endif
 void *phpdbg_watchpoint_userfaultfd_thread(void *phpdbg_globals) {
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 	zend_phpdbg_globals *globals = (zend_phpdbg_globals *) phpdbg_globals;


### PR DESCRIPTION
On gcc. It reports a false positive stack-overflow.

/cc @Girgias 