### PR TITLE
Fix GC_BENCH flag

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1310,16 +1310,7 @@ ZEND_API void zend_deactivate(void) /* {{{ */
 	}
 
 #if GC_BENCH
-	fprintf(stderr, "GC Statistics\n");
-	fprintf(stderr, "-------------\n");
-	fprintf(stderr, "Runs:               %d\n", GC_G(gc_runs));
-	fprintf(stderr, "Collected:          %d\n", GC_G(collected));
-	fprintf(stderr, "Root buffer length: %d\n", GC_G(root_buf_length));
-	fprintf(stderr, "Root buffer peak:   %d\n\n", GC_G(root_buf_peak));
-	fprintf(stderr, "      Possible            Remove from  Marked\n");
-	fprintf(stderr, "        Root    Buffered     buffer     grey\n");
-	fprintf(stderr, "      --------  --------  -----------  ------\n");
-	fprintf(stderr, "ZVAL  %8d  %8d  %9d  %8d\n", GC_G(zval_possible_root), GC_G(zval_buffered), GC_G(zval_remove_from_buffer), GC_G(zval_marked_grey));
+	gc_bench_print();
 #endif
 }
 /* }}} */

--- a/Zend/zend_gc.c
+++ b/Zend/zend_gc.c
@@ -1741,6 +1741,22 @@ static void zend_gc_root_tmpvars(void) {
 	}
 }
 
+#if GC_BENCH
+void gc_bench_print(void)
+{
+	fprintf(stderr, "GC Statistics\n");
+	fprintf(stderr, "-------------\n");
+	fprintf(stderr, "Runs:               %d\n", GC_G(gc_runs));
+	fprintf(stderr, "Collected:          %d\n", GC_G(collected));
+	fprintf(stderr, "Root buffer length: %d\n", GC_G(root_buf_length));
+	fprintf(stderr, "Root buffer peak:   %d\n\n", GC_G(root_buf_peak));
+	fprintf(stderr, "      Possible            Remove from  Marked\n");
+	fprintf(stderr, "        Root    Buffered     buffer     grey\n");
+	fprintf(stderr, "      --------  --------  -----------  ------\n");
+	fprintf(stderr, "ZVAL  %8d  %8d  %9d  %8d\n", GC_G(zval_possible_root), GC_G(zval_buffered), GC_G(zval_remove_from_buffer), GC_G(zval_marked_grey));
+}
+#endif
+
 #ifdef ZTS
 size_t zend_gc_globals_size(void)
 {

--- a/Zend/zend_gc.h
+++ b/Zend/zend_gc.h
@@ -46,6 +46,10 @@ ZEND_API bool gc_enabled(void);
 ZEND_API bool gc_protect(bool protect);
 ZEND_API bool gc_protected(void);
 
+#if GC_BENCH
+void gc_bench_print(void);
+#endif
+
 /* The default implementation of the gc_collect_cycles callback. */
 ZEND_API int  zend_gc_collect_cycles(void);
 


### PR DESCRIPTION
zend_gc_globals is now hidden, so we can't access it from zend.c.