### PR TITLE
Handle zend_execute_internal in JIT

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -9705,13 +9705,17 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 
 		zend_jit_reset_last_valid_opline();
 
-		|	// fbc->internal_function.handler(call, ret);
+		|	// (zend_execute_internal ? zend_execute_internal : fbc->internal_function.handler)(call, ret);
 		|	mov FCARG1x, RX
-		if (func) {
-			|	EXT_CALL func->internal_function.handler, REG0
+		if (zend_execute_internal) {
+			|	EXT_CALL zend_execute_internal, REG0
 		} else {
-			|	ldr TMP1, [REG0, #offsetof(zend_internal_function, handler)]
-			|	blr TMP1
+			if (func) {
+				|	EXT_CALL func->internal_function.handler, REG0
+			} else {
+				|	ldr TMP1, [REG0, #offsetof(zend_internal_function, handler)]
+				|	blr TMP1
+			}
 		}
 
 		|	// EG(current_execute_data) = execute_data;

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -10395,10 +10395,17 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 		zend_jit_reset_last_valid_opline();
 
 		|	// (zend_execute_internal ? zend_execute_internal : fbc->internal_function.handler)(call, ret);
-		|	mov FCARG1a, RX
 		if (zend_execute_internal) {
+			|.if X64
+				| // CARG2 and FCARG2a are identical
+				|	mov CARG1, RX
+			|.else
+				|	mov aword A2, FCARG2a
+				|	mov aword A1, RX
+			|.endif
 			|	EXT_CALL zend_execute_internal, r0
 		} else {
+			|	mov FCARG1a, RX
 			if (func) {
 				|	EXT_CALL func->internal_function.handler, r0
 			} else {

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -10394,12 +10394,16 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 
 		zend_jit_reset_last_valid_opline();
 
-		|	// fbc->internal_function.handler(call, ret);
+		|	// (zend_execute_internal ? zend_execute_internal : fbc->internal_function.handler)(call, ret);
 		|	mov FCARG1a, RX
-		if (func) {
-			|	EXT_CALL func->internal_function.handler, r0
+		if (zend_execute_internal) {
+			|	EXT_CALL zend_execute_internal, r0
 		} else {
-			|	call aword [r0 + offsetof(zend_internal_function, handler)]
+			if (func) {
+				|	EXT_CALL func->internal_function.handler, r0
+			} else {
+				|	call aword [r0 + offsetof(zend_internal_function, handler)]
+			}
 		}
 
 		|	// EG(current_execute_data) = execute_data;

--- a/ext/zend_test/observer.c
+++ b/ext/zend_test/observer.c
@@ -256,6 +256,27 @@ static void fiber_suspend_observer(zend_fiber_context *from, zend_fiber_context 
 	}
 }
 
+static void (*zend_test_prev_execute_internal)(zend_execute_data *execute_data, zval *return_value);
+static void zend_test_execute_internal(zend_execute_data *execute_data, zval *return_value) {
+	zend_function *fbc = execute_data->func;
+
+	if (fbc->common.function_name) {
+		if (fbc->common.scope) {
+			php_printf("%*s<!-- internal enter %s::%s() -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->common.scope->name), ZSTR_VAL(fbc->common.function_name));
+		} else {
+			php_printf("%*s<!-- internal enter %s() -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->common.function_name));
+		}
+	} else {
+		php_printf("%*s<!-- internal enter '%s' -->\n", 2 * ZT_G(observer_nesting_depth), "", ZSTR_VAL(fbc->op_array.filename));
+	}
+
+	if (zend_test_prev_execute_internal) {
+		zend_test_prev_execute_internal(execute_data, return_value);
+	} else {
+		fbc->internal_function.handler(execute_data, return_value);
+	}
+}
+
 static ZEND_INI_MH(zend_test_observer_OnUpdateCommaList)
 {
 	zend_array **p = (zend_array **) ZEND_INI_GET_ADDR();
@@ -291,6 +312,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("zend_test.observer.fiber_init", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_fiber_init, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.observer.fiber_switch", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_fiber_switch, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.observer.fiber_destroy", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_fiber_destroy, zend_zend_test_globals, zend_test_globals)
+	STD_PHP_INI_BOOLEAN("zend_test.observer.execute_internal", "0", PHP_INI_SYSTEM, OnUpdateBool, observer_execute_internal, zend_zend_test_globals, zend_test_globals)
 PHP_INI_END()
 
 void zend_test_observer_init(INIT_FUNC_ARGS)
@@ -315,6 +337,11 @@ void zend_test_observer_init(INIT_FUNC_ARGS)
 		zend_observer_fiber_switch_register(fiber_enter_observer);
 		zend_observer_fiber_switch_register(fiber_suspend_observer);
 		zend_observer_fiber_destroy_register(fiber_destroy_observer);
+	}
+
+	if (ZT_G(observer_execute_internal)) {
+		zend_test_prev_execute_internal = zend_execute_internal;
+		zend_execute_internal = zend_test_execute_internal;
 	}
 }
 

--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -48,6 +48,7 @@ ZEND_BEGIN_MODULE_GLOBALS(zend_test)
 	int observer_fiber_init;
 	int observer_fiber_switch;
 	int observer_fiber_destroy;
+	int observer_execute_internal;
 	HashTable global_weakmap;
 	int replace_zend_execute_ex;
 	int register_passes;

--- a/ext/zend_test/tests/execute_internal.phpt
+++ b/ext/zend_test/tests/execute_internal.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test zend_execute_internal being called
+--EXTENSIONS--
+zend_test
+--INI--
+zend_test.observer.execute_internal=1
+--FILE--
+<?php
+
+function f($a) {
+    var_dump(array_sum($a));
+}
+
+f(time() > 0 ? [1, 2, 3] : []);
+
+?>
+--EXPECT--
+<!-- internal enter time() -->
+<!-- internal enter array_sum() -->
+<!-- internal enter var_dump() -->
+int(6)


### PR DESCRIPTION
I honestly already expected that to be the case.
I found this wasn't the case, when debugging why things suddenly stopped calling zend_execute_internal after a while with our extension...