### PR TITLE
Fix bug #80332 Completely broken array access functionality with DOMNamedNodeMap

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -355,6 +355,8 @@ PHP                                                                        NEWS
 - DOM:
   . Fixed bug #79451 (DOMDocument->replaceChild on doctype causes double free).
     (Nathan Freeman)
+  . Fixed bug #80332 (Completely broken array access functionality with
+    DOMNamedNodeMap). (Nathan Freeman)
 
 - FPM:
   . Fixed bug GH-8885 (FPM access.log with stderr begins to write logs to

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -21,6 +21,7 @@
 #endif
 
 #include "php.h"
+
 #if defined(HAVE_LIBXML) && defined(HAVE_DOM)
 #include "ext/standard/php_rand.h"
 #include "php_dom.h"
@@ -1519,7 +1520,14 @@ static zval *dom_nodelist_read_dimension(zend_object *object, zval *offset, int 
 		return NULL;
 	}
 
-	ZVAL_LONG(&offset_copy, zval_get_long(offset));
+	zend_long lval;
+	if (Z_TYPE_P(offset) == IS_LONG) {
+		ZVAL_LONG(&offset_copy, Z_LVAL_P(offset));
+	} else if (Z_TYPE_P(offset) == IS_STRING && is_numeric_string(Z_STRVAL_P(offset), Z_STRLEN_P(offset), &lval, NULL, false) == IS_LONG) {
+		ZVAL_LONG(&offset_copy, lval);
+	} else {
+		return NULL;
+	}
 
 	zend_call_method_with_1_params(object, object->ce, NULL, "item", rv, &offset_copy);
 
@@ -1528,7 +1536,14 @@ static zval *dom_nodelist_read_dimension(zend_object *object, zval *offset, int 
 
 static int dom_nodelist_has_dimension(zend_object *object, zval *member, int check_empty)
 {
-	zend_long offset = zval_get_long(member);
+	zend_long lval;
+	zend_long offset = -1;
+	if (Z_TYPE_P(member) == IS_LONG) {
+		offset = Z_LVAL_P(member);
+	} else if (Z_TYPE_P(member) == IS_STRING && is_numeric_string(Z_STRVAL_P(member), Z_STRLEN_P(member), &lval, NULL, false) == IS_LONG) {
+		offset = lval;
+	}
+
 	zval rv;
 
 	if (offset < 0) {

--- a/ext/dom/tests/bug67949.phpt
+++ b/ext/dom/tests/bug67949.phpt
@@ -78,12 +78,16 @@ array(1) {
   string(4) "test"
 }
 string(4) "test"
-bool(true)
-string(4) "data"
+
+Warning: Attempt to read property "textContent" on null in %s on line %d
+bool(false)
+NULL
 string(4) "test"
 string(4) "test"
-bool(true)
-string(4) "data"
+
+Warning: Attempt to read property "textContent" on null in %s on line %d
+bool(false)
+NULL
 string(4) "test"
 testing read_dimension with null offset
 Cannot access node list without offset

--- a/ext/dom/tests/bug80332.phpt
+++ b/ext/dom/tests/bug80332.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Bug #80332 (Completely broken array access functionality with DOMNamedNodeMap)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadHTML('<span attr1="value1" attr2="value2"></span>');
+
+$x = new DOMXPath($doc);
+$span = $x->query('//span')[0];
+
+var_dump($span->attributes[0]->nodeName);
+var_dump($span->attributes[0]->nodeValue);
+
+var_dump($span->attributes['1']->nodeName);
+var_dump($span->attributes['1']->nodeValue);
+
+var_dump($span->attributes[0.6]->nodeName);
+var_dump($span->attributes[0.6]->nodeValue);
+
+var_dump($span->attributes['0.6']->nodeName);
+var_dump($span->attributes['0.6']->nodeValue);
+
+var_dump($span->attributes[12345678]->nodeName);
+var_dump($span->attributes[12345678]->nodeValue);
+
+var_dump($span->attributes['12345678']->nodeName);
+var_dump($span->attributes['12345678']->nodeValue);
+
+var_dump($span->attributes[9999999999999999999999999999999999]->nodeName);
+var_dump($span->attributes[9999999999999999999999999999999999]->nodeValue);
+
+var_dump($span->attributes['9999999999999999999999999999999999']->nodeName);
+var_dump($span->attributes['9999999999999999999999999999999999']->nodeValue);
+
+var_dump($span->attributes['hi']->nodeName);
+var_dump($span->attributes['hi']->nodeValue);
+?>
+--EXPECTF--
+string(5) "attr1"
+string(6) "value1"
+string(5) "attr2"
+string(6) "value2"
+
+Warning: Attempt to read property "nodeName" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeValue" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeName" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeValue" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeName" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeValue" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeName" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeValue" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeName" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeValue" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeName" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeValue" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeName" on null in %s on line %d
+NULL
+
+Warning: Attempt to read property "nodeValue" on null in %s on line %d
+NULL


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=80332

The function `zval_get_long` will always return `0` if the `offset` is string, resulting in always pointing to the first element of the array.