### PR TITLE
Fix module shutdown crash during ZTS JIT shutdown

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -4762,7 +4762,7 @@ static void zend_jit_globals_ctor(zend_jit_globals *jit_globals)
 #ifdef ZTS
 static void zend_jit_globals_dtor(zend_jit_globals *jit_globals)
 {
-	zend_jit_trace_free_caches();
+	zend_jit_trace_free_caches(jit_globals);
 }
 #endif
 
@@ -5081,7 +5081,7 @@ ZEND_EXT_API void zend_jit_shutdown(void)
 #ifdef ZTS
 	ts_free_id(jit_globals_id);
 #else
-	zend_jit_trace_free_caches();
+	zend_jit_trace_free_caches(&jit_globals);
 #endif
 }
 

--- a/ext/opcache/jit/zend_jit_trace.c
+++ b/ext/opcache/jit/zend_jit_trace.c
@@ -8324,10 +8324,10 @@ static void zend_jit_trace_reset_caches(void)
 #endif
 }
 
-static void zend_jit_trace_free_caches(void)
+static void zend_jit_trace_free_caches(zend_jit_globals *jit_globals)
 {
-	if (JIT_G(exit_counters)) {
-		free(JIT_G(exit_counters));
+	if (jit_globals->exit_counters) {
+		free(jit_globals->exit_counters);
 	}
 }
 


### PR DESCRIPTION
Commit a21195650e53 fixed a leak by adding a TSRM destructor for the JIT globals in ZTS mode. In case the main thread shuts down the TSRM, it will call all the destructors. The JIT globals destructor will be invoked, but will always access the main thread globals using JIT_G. This means that instead of freeing the JIT globals in the different threads, the one in the main thread is freed repeatedly over and over, crashing PHP. Fix it by always passing the pointer instead of relying on JIT_G.

This can be triggered reliably even when opcache is on. The JIT does not need to be enabled, because the JIT globals are always constructed. To reproduce this locally, I used an Apache worker/event MPM, and send a lot of requests using ApacheBench. Eventually you'll see the segfaults in the error_log file. You can also crash it by stopping the Apache server. Other SAPIs might be affected as well.

This bug exists only in 8.1.17RC1, 8.2.4RC1 and master.
Discovered while working on https://github.com/php/php-src/issues/10737