### PR TITLE
Fix GH-10834: exif_read_data() cannot read smaller stream wrapper chunk sizes

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -748,7 +748,8 @@ PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t size)
 		/* just break anyway, to avoid greedy read for file://, php://memory, and php://temp */
 		if ((stream->wrapper != &php_plain_files_wrapper) &&
 			(stream->ops != &php_stream_memory_ops) &&
-			(stream->ops != &php_stream_temp_ops)) {
+			(stream->ops != &php_stream_temp_ops) &&
+			!(stream->ops == &php_stream_userspace_ops && !stream->wrapper->is_url)) {
 			break;
 		}
 	}


### PR DESCRIPTION
Exif uses php_stream_read() to read data from the stream and process it. In this case, it's a userspace stream. Userspace streams can either by local or url streams.

In 5060fc234944 and subsequently 0a45e8f096a0, the behaviour of the check was changed twice in total. In the latter commit the description talks about exceptions for streams that are local to the process. It looks like the exception for local userspace streams was forgotten. This patch updates the check such that local userspace streams also read greedily, while keeping url userspace streams unchanged.

This also updates the existing test to test both local and url userspace streams.

Targeting master because I think this could be a breaking change.