### PR TITLE
Fix GH-10755: Memory leak in phar_rename_archive()

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,6 +15,7 @@ on:
       - PHP-8.1
       - PHP-8.2
       - master
+      - Trigger-branch
   pull_request:
     branches:
       - '**'

--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2116,7 +2116,8 @@ static zend_object *phar_rename_archive(phar_archive_data **sphar, char *ext) /*
 				phar_destroy_phar_data(phar);
 				*sphar = NULL;
 				phar = pphar;
-				phar->refcount++;
+				/* FIX: GH-10755 Memory leak in phar_rename_archive() */
+				/* phar->refcount++; */
 				newpath = oldpath;
 				goto its_ok;
 			}

--- a/ext/phar/tests/bug69958.phpt
+++ b/ext/phar/tests/bug69958.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Phar: bug #69958: Segfault in Phar::convertToData on invalid file
---XFAIL--
-Still has memory leaks, see https://bugs.php.net/bug.php?id=70005
 --EXTENSIONS--
 phar
 --FILE--


### PR DESCRIPTION
In phar_renmae_archive() context, added one reference but immediately destroyed another, so do not need to increase refcount. With removal of refcount++ line, PHP/Zend no longer reports memory leak. Updated bug69958.phpt test file accordingly.

Testing (PASS on both Debug and Release build)
Debug: ./configure --enable-debug
Release: ./configure

1) Running selected tests.
PASS Phar: bug #69958: Segfault in Phar::convertToData on invalid file [bug69958.phpt]

2) All tests under ext/phar/tests PASSED except skipped. =====================================================================
Number of tests :   530               515
Tests skipped   :    15 (  2.8%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     0 (  0.0%) (  0.0%)
Tests passed    :   515 ( 97.2%) (100.0%)
---------------------------------------------------------------------
Time taken      :    26 seconds
=====================================================================