### PR TITLE
Fix test on non-UTC platforms

### DIFF
--- a/ext/date/tests/gh10747-1.phpt
+++ b/ext/date/tests/gh10747-1.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Bug GH-10747 (Private fields in serialized DateTimeImmutable objects throw)
+--INI--
+date.timezone=UTC
 --FILE--
 <?php
 class I extends DateTimeImmutable


### PR DESCRIPTION
@derickr I've added a `---INI---` section to force timezone to UTC.

Somehow the file shows as binary so I've decived to open a PR vs pushing directly to master ;-)

For reference: https://revive.beccati.com/bamboo/browse/PHP-SRC-3336/test

```
FAILED: 
--
       ["timezone_type"]=>
       int(3)
       ["timezone"]=>
015+   string(11) "Europe/Rome"
015-   string(3) "UTC"
     }
017+ string(188) "O:1:"I":7:{s:4:"date";s:26:"2023-03-11 03:11:24.319381";s:13:"timezone_type";i:3;s:8:"timezone";s:11:"Europe/Rome";s:7:"[[0x00]]I[[0x00]]var1";i:1;s:7:"[[0x00]]I[[0x00]]var2";i:2;s:7:"[[0x00]]*[[0x00]]var3";i:3;s:7:"[[0x00]]*[[0x00]]var4";i:4;}"
017- string(%d) "O:1:"I":7:{s:4:"date";s:%d:"%s";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";s:7:"[[0x00]]I[[0x00]]var1";i:1;s:7:"[[0x00]]I[[0x00]]var2";i:2;s:7:"[[0x00]]*[[0x00]]var3";i:3;s:7:"[[0x00]]*[[0x00]]var4";i:4;}"
     object(I)#2 (7) {
       ["var1":"I":private]=>
       int(1)
--
       ["timezone_type"]=>
       int(3)
       ["timezone"]=>
032+   string(11) "Europe/Rome"
032-   string(3) "UTC"
     }
```