### PR TITLE
use_tls=0 on MSAN

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -199,3 +199,88 @@ jobs:
         run: .github/scripts/windows/build.bat
       - name: Test
         run: .github/scripts/windows/test.bat
+  MSAN:
+    name: "MSAN"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v3
+      - name: apt
+        uses: ./.github/actions/apt-x64
+      - name: ./configure
+        run: |
+          export CC=clang
+          export CXX=clang++
+          export CFLAGS="-DZEND_TRACK_ARENA_ALLOC"
+          ./buildconf --force
+          # msan requires all used libraries to be instrumented,
+          # so we should avoiding linking against anything but libc here
+          ./configure \
+            --enable-debug \
+            --enable-zts \
+            --enable-option-checking=fatal \
+            --prefix=/usr \
+            --without-sqlite3 \
+            --without-pdo-sqlite \
+            --without-libxml \
+            --disable-dom \
+            --disable-simplexml \
+            --disable-xml \
+            --disable-xmlreader \
+            --disable-xmlwriter \
+            --without-pcre-jit \
+            --disable-opcache-jit \
+            --enable-phpdbg \
+            --enable-fpm \
+            --with-pdo-mysql=mysqlnd \
+            --with-mysqli=mysqlnd \
+            --disable-mysqlnd-compression-support \
+            --without-pear \
+            --enable-exif \
+            --enable-sysvsem \
+            --enable-sysvshm \
+            --enable-shmop \
+            --enable-pcntl \
+            --enable-mbstring \
+            --disable-mbregex \
+            --enable-sockets \
+            --enable-bcmath \
+            --enable-calendar \
+            --enable-ftp \
+            --enable-zend-test \
+            --enable-werror \
+            --enable-memory-sanitizer \
+            --with-config-file-path=/etc \
+            --with-config-file-scan-dir=/etc/php.d \
+            --enable-dl-test=shared
+      - name: make
+        run: make -j$(/usr/bin/nproc) >/dev/null
+      - name: make install
+        run: |
+          sudo make install
+          sudo mkdir     /etc/php.d
+          sudo chmod 777 /etc/php.d
+          echo mysqli.default_socket=/var/run/mysqld/mysqld.sock    > /etc/php.d/mysqli.ini
+          echo pdo_mysql.default_socket=/var/run/mysqld/mysqld.sock > /etc/php.d/pdo_mysql.ini
+      - name: Setup
+        run: |
+          set -x
+          sudo service mysql start
+          mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS test"
+          # Ensure local_infile tests can run.
+          mysql -uroot -proot -e "SET GLOBAL local_infile = true"
+          sudo locale-gen de_DE
+      - name: Test
+        uses: ./.github/actions/test-linux
+        with:
+          runTestsParameters: >-
+            --msan
+      - name: Test Opcache
+        uses: ./.github/actions/test-linux
+        with:
+          runTestsParameters: >-
+            --msan
+            -d zend_extension=opcache.so
+            -d opcache.enable_cli=1
+      - name: Verify generated files are up to date
+        uses: ./.github/actions/verify-generated-files

--- a/run-tests.php
+++ b/run-tests.php
@@ -580,14 +580,22 @@ function main(): void
                     $environment['USE_TRACKED_ALLOC'] = 1;
                     $environment['SKIP_ASAN'] = 1;
                     $environment['SKIP_PERF_SENSITIVE'] = 1;
+                    $lsan_options = [];
                     if ($switch === '--msan') {
                         $environment['SKIP_MSAN'] = 1;
+                        // use_tls=0 is a workaround for MSAN crashing with "Tracer caught signal 11" (SIGSEGV),
+                        // which seems to be an issue with TLS support in newer glibc versions under virtualized
+                        // environments. Follow https://github.com/google/sanitizers/issues/1342 and
+                        // https://github.com/google/sanitizers/issues/1409 to track this issue.
+                        $lsan_options[] = 'use_tls=0';
                     }
-
                     $lsanSuppressions = __DIR__ . '/.github/lsan-suppressions.txt';
                     if (file_exists($lsanSuppressions)) {
-                        $environment['LSAN_OPTIONS'] = 'suppressions=' . $lsanSuppressions
-                            . ':print_suppressions=0';
+                        $lsan_options[] = 'suppressions=' . $lsanSuppressions;
+                        $lsan_options[] = 'print_suppressions=0';
+                    }
+                    if (!empty($lsan_options)) {
+                        $environment['LSAN_OPTIONS'] = join(':', $lsan_options);
                     }
                     break;
                 case '--repeat':


### PR DESCRIPTION
Attempt to fix MSAN failure in CI

For context, we get regular failures in MSAN nightly builds with the same stacktrace, failing at `__tls_get_addr`. On `master`, since upgrading to Ubuntu 22.04 the MSAN build is completely broken. Add the `use_tls=0` option in an attempt to avoid this issue.

```
========DIFF========
001+ MemorySanitizer:DEADLYSIGNAL
002+ ==179202==ERROR: MemorySanitizer: SEGV on unknown address (pc 0x7f73242b2bc0 bp 0x0000000000c0 sp 0x7ffe2810a3e8 T179202)
003+ ==179202==The signal is caused by a READ memory access.
004+ ==179202==Hint: this fault was caused by a dereference of a high value address (see register values below).  Dissassemble the provided pc to learn which register was used.
005+     #0 0x7f73242b2bc0  (/lib/x86_64-linux-gnu/libc.so.6+0x18bbc0)
006+     #1 0x65b59e in __msan::SetShadow(void const*, unsigned long, unsigned char) (/home/runner/work/php-src/php-src/sapi/cli/php+0x65b59e)
007+     #2 0x62a3ca in __tls_get_addr (/home/runner/work/php-src/php-src/sapi/cli/php+0x62a3ca)
008+     #3 0x7f7322c57ff3 in accel_globals_ctor /home/runner/work/php-src/php-src/ext/opcache/ZendAccelerator.c:2940:2
009+     #4 0x3a48f1c in tsrm_update_active_threads /home/runner/work/php-src/php-src/TSRM/TSRM.c:258:7
010+     #5 0x3a47d1a in ts_allocate_id /home/runner/work/php-src/php-src/TSRM/TSRM.c:299:2
001- <form action="//bad.net/do.php">
002- <fieldset>
003- <form action="//php.net/do.php"><input type="hidden" name="PHPSESSID" value="test021" />
004- <fieldset>
005- <form action="../do.php"><input type="hidden" name="PHPSESSID" value="test021" />
006- <fieldset>
007- <form action="/do.php"><input type="hidden" name="PHPSESSID" value="test021" />
008- <fieldset>
009- <form action="/foo/do.php"><input type="hidden" name="PHPSESSID" value="test021" />
010- <fieldset>
011+     #6 0x7f7322c4df79 in accel_startup /home/runner/work/php-src/php-src/ext/opcache/ZendAccelerator.c:3116:21
012+     #7 0x43b35bb in zend_extension_startup /home/runner/work/php-src/php-src/Zend/zend_extensions.c:196:7
013+     #8 0x4186e6c in zend_llist_apply_with_del /home/runner/work/php-src/php-src/Zend/zend_llist.c:171:7
014+     #9 0x43b3327 in zend_startup_extensions /home/runner/work/php-src/php-src/Zend/zend_extensions.c:217:2
015+     #10 0x3a6c1f5 in php_module_startup /home/runner/work/php-src/php-src/main/main.c:2263:2
016+     #11 0x55dcf76 in php_cli_startup /home/runner/work/php-src/php-src/sapi/cli/php_cli.c:410:9
017+     #12 0x55cfad2 in main /home/runner/work/php-src/php-src/sapi/cli/php_cli.c:1300:6
018+     #13 0x7f732414b082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
019+     #14 0x6013ad in _start (/home/runner/work/php-src/php-src/sapi/cli/php+0x6013ad)
020+ 
021+ MemorySanitizer can not provide additional info.
022+ SUMMARY: MemorySanitizer: SEGV (/lib/x86_64-linux-gnu/libc.so.6+0x18bbc0) 
023+ ==179202==ABORTING
========DONE========
FAIL rewriter handles form and fieldset tags correctly [ext/session/tests/021.phpt] 
```

The changes in .github/workflows/push.yml will be reverted once merged.