### PR TITLE
Fix GH-10755: Memory leak in phar_rename_archive()

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -2114,7 +2114,8 @@ static zend_object *phar_rename_archive(phar_archive_data **sphar, char *ext) /*
 				phar_destroy_phar_data(phar);
 				*sphar = NULL;
 				phar = pphar;
-				phar->refcount++;
+				/* FIX: GH-10755 Memory leak in phar_rename_archive() */
+				/* phar->refcount++; */
 				newpath = oldpath;
 				goto its_ok;
 			}

--- a/ext/phar/tests/bug69958.phpt
+++ b/ext/phar/tests/bug69958.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Phar: bug #69958: Segfault in Phar::convertToData on invalid file
---XFAIL--
-Still has memory leaks, see https://bugs.php.net/bug.php?id=70005
 --EXTENSIONS--
 phar
 --FILE--

--- a/ext/phar/tests/bug69958.phpt
+++ b/ext/phar/tests/bug69958.phpt
@@ -8,8 +8,8 @@ $tarphar = new PharData(__DIR__.'/bug69958.tar');
 $phar = $tarphar->convertToData(Phar::TAR);
 ?>
 --EXPECTF--
-Fatal error: Uncaught BadMethodCallException: phar "%s/bug69958.tar" exists and must be unlinked prior to conversion in %s/bug69958.php:%d
+Fatal error: Uncaught BadMethodCallException: phar "%sbug69958.tar" exists and must be unlinked prior to conversion in %sbug69958.php:%d
 Stack trace:
-#0 %s/bug69958.php(%d): PharData->convertToData(%d)
+#0 %sbug69958.php(%d): PharData->convertToData(%d)
 #1 {main}
-  thrown in %s/bug69958.php on line %d
+  thrown in %sbug69958.php on line %d


### PR DESCRIPTION
    In phar_renmae_archive() context, added one reference but immediately
    destroyed another, so do not need to increase refcount. With removal of
    refcount++ line, PHP/Zend no longer reports memory leak.
    Updated bug69958.phpt test file accordingly.
    
    Testing (PASS on both Debug and Release build)
    Debug: ./configure --enable-debug
    Release: ./configure
    
    1) Running selected tests.
    PASS Phar: bug #69958: Segfault in Phar::convertToData on invalid file [bug69958.phpt]
    
    2) All tests under ext/phar/tests PASSED except skipped.
    =====================================================================
    Number of tests :   530               515
    Tests skipped   :    15 (  2.8%) --------
    Tests warned    :     0 (  0.0%) (  0.0%)
    Tests failed    :     0 (  0.0%) (  0.0%)
    Tests passed    :   515 ( 97.2%) (100.0%)
    ---------------------------------------------------------------------
    Time taken      :    26 seconds
    =====================================================================