### PR TITLE
mb_strcut cuts out the requested range of bytes (no less)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,10 @@ PHP                                                                        NEWS
     encoded words as required by RFC 2047; they are converted to spaces.
     Underscores must be encoded as "=5F" in such MIME encoded words.
     (Alex Dowad)
+  . mb_encode_mimeheader no longer drops NUL (zero) bytes when
+    QPrint-encoding the input string. This previously caused strings in
+    certain text encodings, especially UTF-16 and UTF-32, to be
+    corrupted by mb_encode_mimeheader. (Alex Dowad)
 
 - mysqli:
   . mysqli_fetch_object raises a ValueError instead of an Exception.

--- a/NEWS
+++ b/NEWS
@@ -77,6 +77,12 @@ PHP                                                                        NEWS
     QPrint-encoding the input string. This previously caused strings in
     certain text encodings, especially UTF-16 and UTF-32, to be
     corrupted by mb_encode_mimeheader. (Alex Dowad)
+  . mb_strcut now extracts the requested range of bytes and no less; this is
+    a change from PHP 8.2 for all legacy text encodings which can represent the
+    same string in more than one way (such as JIS or UTF-7), and all legacy
+    text encodings which use escape sequences to select one of multiple decoding
+    modes for the following bytes (such as UTF-7, HZ, or ISO-2022-JP).
+    (Alex Dowad)
 
 - mysqli:
   . mysqli_fetch_object raises a ValueError instead of an Exception.

--- a/UPGRADING
+++ b/UPGRADING
@@ -91,6 +91,9 @@ PHP 8.3 UPGRADE NOTES
     encoded words as required by RFC 2047; they are converted to spaces.
     Underscores must be encoded as "=5F" in such MIME encoded words.
     (Alex Dowad)
+  . In rare cases, mb_encode_mimeheader will transfer-encode its input
+    string where it would pass it through as raw ASCII in PHP 8.2.
+    (Alex Dowad)
 
 - mysqli:
   . mysqli_fetch_object now raises a ValueError instead of an Exception when the constructor_args

--- a/UPGRADING
+++ b/UPGRADING
@@ -94,6 +94,12 @@ PHP 8.3 UPGRADE NOTES
   . In rare cases, mb_encode_mimeheader will transfer-encode its input
     string where it would pass it through as raw ASCII in PHP 8.2.
     (Alex Dowad)
+  . mb_strcut now extracts the requested range of bytes and no less; this is
+    a change from PHP 8.2 for all legacy text encodings which can represent the
+    same string in more than one way (such as JIS or UTF-7), and all legacy
+    text encodings which use escape sequences to select one of multiple decoding
+    modes for the following bytes (such as UTF-7, HZ, or ISO-2022-JP).
+    (Alex Dowad)
 
 - mysqli:
   . mysqli_fetch_object now raises a ValueError instead of an Exception when the constructor_args

--- a/ext/mbstring/tests/gh9535.phpt
+++ b/ext/mbstring/tests/gh9535.phpt
@@ -78,8 +78,11 @@ foreach($encodings as $encoding) {
 
 echo PHP_EOL;
 
+// Here, we are cutting bytes not from a converted string, but from a plain ASCII string
+// which does not include any escape sequences
+// So ISO-2022-KR will still get two question marks
 foreach($encodings as $encoding) {
-    echo $encoding.trim(': '.mb_strcut($input, 0, $bytes_length, $encoding)).PHP_EOL;
+    echo $encoding.trim(': '.bin2hex(mb_strcut($input, 0, $bytes_length, $encoding))).PHP_EOL;
 }
 
 ?>
@@ -87,36 +90,36 @@ foreach($encodings as $encoding) {
 UTF-16: 宛如繁星般宛如
 UTF-16BE: 宛如繁星般宛如
 UTF-16LE: 宛如繁星般宛如
-UTF-7: 宛如繁星
-UTF7-IMAP: 宛如繁星
-ISO-2022-JP-MS: 宛如繁星
+UTF-7: 宛如繁星般
+UTF7-IMAP: 宛如繁星般
+ISO-2022-JP-MS: 宛如繁星般宛
 GB18030: 宛如繁星般宛如
-HZ: 宛如繁星般
-ISO-2022-KR: 宛如繁星
-ISO-2022-JP-MOBILE#KDDI: 宛如繁星
-CP50220: 宛如繁星
-CP50221: 宛如繁星
-CP50222: 宛如繁星
+HZ: 宛如繁星般宛
+ISO-2022-KR: 宛如繁星般
+ISO-2022-JP-MOBILE#KDDI: 宛如繁星般宛
+CP50220: 宛如繁星般宛
+CP50221: 宛如繁星般宛
+CP50222: 宛如繁星般宛
 
 UTF-16: 星のように月のように
 UTF-16BE: 星のように月のように
 UTF-16LE: 星のように月のように
-UTF-7: 星のように月
-UTF7-IMAP: 星のように月
-ISO-2022-JP-MS: 星のように月の
+UTF-7: 星のように月の
+UTF7-IMAP: 星のように月の
+ISO-2022-JP-MS: 星のように月のよ
 GB18030: 星のように月のように
-HZ: 星のように月のよ
+HZ: 星のように月のよう
 ISO-2022-KR: 星のように月の
-ISO-2022-JP-MOBILE#KDDI: 星のように月の
-CP50220: 星のように月の
-CP50221: 星のように月の
-CP50222: 星のように月の
+ISO-2022-JP-MOBILE#KDDI: 星のように月のよ
+CP50220: 星のように月のよ
+CP50221: 星のように月のよ
+CP50222: 星のように月のよ
 
 UTF-16: あaいb
 UTF-16BE: あaいb
 UTF-16LE: あaいb
-UTF-7: あa
-UTF7-IMAP: あa
+UTF-7: あaい
+UTF7-IMAP: あaい
 ISO-2022-JP-MS: あa
 GB18030: あaいb
 HZ: あa
@@ -154,16 +157,16 @@ CP50220: ??
 CP50221: ??
 CP50222: ??
 
-UTF-16: ??
-UTF-16BE: ??
-UTF-16LE: ??
-UTF-7: ??
-UTF7-IMAP: ??
-ISO-2022-JP-MS: ??
-GB18030: ??
-HZ: ??
-ISO-2022-KR:
-ISO-2022-JP-MOBILE#KDDI: ??
-CP50220: ??
-CP50221: ??
-CP50222: ??
+UTF-16: 3f3f
+UTF-16BE: 3f3f
+UTF-16LE: 3f3f
+UTF-7: 3f3f
+UTF7-IMAP: 3f3f
+ISO-2022-JP-MS: 3f3f
+GB18030: 3f3f
+HZ: 3f3f
+ISO-2022-KR: 1b2429433f3f
+ISO-2022-JP-MOBILE#KDDI: 3f3f
+CP50220: 3f3f
+CP50221: 3f3f
+CP50222: 3f3f

--- a/ext/mbstring/tests/gh9535b.phpt
+++ b/ext/mbstring/tests/gh9535b.phpt
@@ -8,16 +8,14 @@ mbstring
 // escape sequence to a string which would otherwise end in a non-default conversion mode
 // See https://github.com/php/php-src/pull/9562 for details on the bug
 
-// These tests were developed when fixing a different bug, but they don't pass because of
-// the bug involving the added closing escape sequences
-// When that bug is fixed, we can remove XFAIL (or combine this file with gh9535.phpt)
-
 $encodings = [
     'JIS',
     'ISO-2022-JP',
     'ISO-2022-JP-2004',
 ];
 
+// ISO-2022-JP-2004 will get one fewer character for the following string than JIS and ISO-2022-JP
+// That is because in ISO-2022-JP-2004, the opening escape sequence has 4 bytes instead of 3
 $input = '宛如繁星般宛如皎月般';
 $bytes_length = 15;
 foreach($encodings as $encoding) {
@@ -78,16 +76,14 @@ foreach($encodings as $encoding) {
 }
 
 ?>
---XFAIL--
-Discussion: https://github.com/php/php-src/pull/9562
---EXPECTF--
-JIS: 宛如繁星般
-ISO-2022-JP: 宛如繁星般
-ISO-2022-JP-2004: 宛如繁星
+--EXPECT--
+JIS: 宛如繁星般宛
+ISO-2022-JP: 宛如繁星般宛
+ISO-2022-JP-2004: 宛如繁星般
 
-JIS: 星のように月の
-ISO-2022-JP: 星のように月の
-ISO-2022-JP-2004: 星のように月の
+JIS: 星のように月のよ
+ISO-2022-JP: 星のように月のよ
+ISO-2022-JP-2004: 星のように月のよ
 
 JIS: あa
 ISO-2022-JP: あa

--- a/ext/mbstring/tests/mb_strcut.phpt
+++ b/ext/mbstring/tests/mb_strcut.phpt
@@ -19,7 +19,7 @@ include_once('common.inc');
 // EUC-JP
 $euc_jp = pack('H*', '30313233a4b3a4cecab8bbfacef3a4cfc6fccbdcb8eca4c7a4b9a1a34555432d4a50a4f2bbc8a4c3a4c6a4a4a4dea4b9a1a3c6fccbdcb8eca4cfccccc5ddbdada4a4a1a3');
 // UTF-8
-$utf8    = pack('H*', 'e288ae2045e28b856461203d2051'); // has 2 multi-byte characters: [e288ae 20 45 e28b85 64 61 20 3d 20 51]
+$utf8 = pack('H*', 'e288ae2045e28b856461203d2051'); // has 2 multi-byte characters: [e288ae 20 45 e28b85 64 61 20 3d 20 51]
 // UTF-16LE
 $utf16le = pack('H*', '1a043804400438043b043b04380446043004200069007300200043007900720069006c006c0069006300');
 
@@ -78,5 +78,5 @@ OK
 [1a04]
 [1a04]
 [1a04]
-[1a04]
+[1a04 3804]
 [1a04 3804]


### PR DESCRIPTION
The documentation for mb_strcut reads:
 
> mb_strcut() extracts a substring from a string similarly to
> mb_substr(), but operates on bytes instead of characters. If the cut
> position happens to be between two bytes of a multi-byte character,
> the cut is performed starting from the first byte of that character.
> This is also the difference to the substr() function, which would
> simply cut the string between the bytes and thus result in a
> malformed byte sequence.
    
(Ref: https://www.php.net/manual/en/function.mb-strcut.php)
    
However, from the very beginning, this function has never behaved
exactly as described in the documentation. To be more precise, for some
of mbstring's supported text encodings, it would behave as described,
but for many others, it would not.
    
For the *starting* cut, the function has always behaved as described.
The problem was with the *ending* cut. Instead of cutting out bytes up
to the ending cut point if it was a character boundary, or the
immediately preceding character boundary otherwise, the function would
do this:
    
It would start cutting out bytes from the starting cut point (or
immediately preceding character boundary), running these bytes through
the mbstring decoding/encoding filters for the text encoding in
question, and collect the output of the encoding filter, until the
number of bytes of output equalled the requested cut length.
    
That was fine for text encodings which only have one way to represent
any sequence of characters, and where no extra bytes need to be used
for escape sequences.
    
For encodings with more than one way to represent the same characters,
it didn't work. Take JIS7/8 for example. In this text encoding, a
single byte from 0xA1-DF encodes a katakana character. But the same
katakana can also be encoded using two bytes. For example, take the
following (contrived) JIS string (in hexadecimal notation, with UTF-8
below):

```    
61 62 63 A7 A8 A9 AA AB 61 62 63
a  b  c  ｧ  ｨ  ｩ  ｪ  ｫ  a  b  c
```
 
Say we want to extract the 3 kana "ｧｨｩ". The kana start at an offset of
3 bytes from the beginning of the string, so this should work:

```    
mb_strcut("abc\xA7\xA8\xA9\xAA\xABabc", 3, 3, 'JIS');
```

However, in PHP 8.2, this returns an empty string! After this patch,
however, it returns:

```    
1b2442 0027 0028 0029 1b2842
(Escape sequence for JIS X 0208) ｧ ｨ ｩ (Escape sequence for ASCII)
```
 
One might think that mb_strcut should cut out raw bytes from the input
string, and simply adjust the cut points to character boundaries, rather
than adding escape sequences or converting JISX-0201-encoded kana to
JISX-0208-encoded kana. However, from the beginning, mb_strcut has
always decoded and re-encoded its input, so this is the backwards-
compatible behavior. This patch maintains that behavior, but ensures
that the range of characters extracted actually correspnds to the
requested byte range.
    
For encodings which use escape sequences, mb_strcut could also fail in
a similar way. When cutting bytes out of the middle of such a string,
it is often necessary to prefix them with an escape sequence so their
meaning is not changed. But this leading escape sequence would take up
some of the limited number of bytes which the function wanted to output,
meaning that the portion actually cut out was systemically too short.
This affected text encodings like UTF-7, HZ, and all the ISO-2022
text encodings.

For reviewers, please note that I did *not* blindly adjust the expected results of test cases to match the output of my code. I looked at *each* failing test case in hex notation and considered whether the new result makes sense or not.

@NathanFreeman might be interested in this, since he provided the XFAIL test cases which are now passing.

@cmb69 @Girgias @kamil-tekiela @youkidearitai @pakutoma