### PR TITLE
Implement GH-10854: TSRM should set a smarter value for expected_threads

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2647,13 +2647,18 @@ PHPAPI void php_reserve_tsrm_memory(void)
 }
 /* }}} */
 
-/* {{{ php_tsrm_startup */
-PHPAPI bool php_tsrm_startup(void)
+PHPAPI bool php_tsrm_startup_ex(int expected_threads)
 {
-	bool ret = tsrm_startup(1, 1, 0, NULL);
+	bool ret = tsrm_startup(expected_threads, 1, 0, NULL);
 	php_reserve_tsrm_memory();
 	(void)ts_resource(0);
 	return ret;
+}
+
+/* {{{ php_tsrm_startup */
+PHPAPI bool php_tsrm_startup(void)
+{
+	return php_tsrm_startup_ex(1);
 }
 /* }}} */
 #endif

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -47,6 +47,7 @@ extern int php_shutdown_environ(void);
 
 #ifdef ZTS
 PHPAPI void php_reserve_tsrm_memory(void);
+PHPAPI bool php_tsrm_startup_ex(int expected_threads);
 PHPAPI bool php_tsrm_startup(void);
 
 #define PHP_ZTS 1

--- a/sapi/apache2handler/sapi_apache2.c
+++ b/sapi/apache2handler/sapi_apache2.c
@@ -485,7 +485,16 @@ php_apache_server_startup(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp
 		apache2_sapi_module.php_ini_path_override = apache2_php_ini_path_override;
 	}
 #ifdef ZTS
-	php_tsrm_startup();
+	int expected_threads;
+#ifdef AP_MPMQ_MAX_THREADS
+	if (ap_mpm_query(AP_MPMQ_MAX_THREADS, &expected_threads) != APR_SUCCESS) {
+		expected_threads = 1;
+	}
+#else
+	expected_threads = 1;
+#endif
+
+	php_tsrm_startup_ex(expected_threads);
 # ifdef PHP_WIN32
 	ZEND_TSRMLS_CACHE_UPDATE();
 # endif


### PR DESCRIPTION
Closes GH-10854

The tsrm_startup() function is currently always called with expected_threads = 1. This means that the hashtable used in the TSRM will only contain a single bucket, and all thread resources will therefore be in the same linked list. So it's not really a hashtable right now, even though it's supposed to be.

This patch adds a function tsrm_startup_ex() which takes the expected thread count as an argument. It also keeps the tsrm_startup() function so there are no BC breaks.

In the Apache SAPI we query how many threads we have, and pass that to the tsrm_startup_ex() function.