### PR TITLE
Fix bug #74129: Incorrect SCRIPT_NAME with apache ProxyPassMatch when spaces are in path

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1157,11 +1157,31 @@ static void init_request_info(void)
 									 * As we can extract PATH_INFO from PATH_TRANSLATED
 									 * it is probably also in SCRIPT_NAME and need to be removed
 									 */
-									int snlen = strlen(env_script_name);
-									if (snlen>slen && !strcmp(env_script_name+snlen-slen, path_info)) {
+									char *decoded_path_info = NULL;
+									size_t decoded_path_info_len = 0;
+									if (strchr(path_info, '%')) {
+										decoded_path_info = estrdup(path_info);
+										decoded_path_info_len = php_url_decode(decoded_path_info, strlen(path_info));
+									}
+									size_t snlen = strlen(env_script_name);
+									size_t env_script_file_info_start = 0;
+									if (
+										(
+											snlen > slen &&
+											!strcmp(env_script_name + (env_script_file_info_start = snlen - slen), path_info)
+										) ||
+										(
+											decoded_path_info &&
+											snlen > decoded_path_info_len &&
+											!strcmp(env_script_name + (env_script_file_info_start = snlen - decoded_path_info_len), decoded_path_info)
+										)
+									) {
 										FCGI_PUTENV(request, "ORIG_SCRIPT_NAME", orig_script_name);
-										env_script_name[snlen-slen] = 0;
+										env_script_name[env_script_file_info_start] = 0;
 										SG(request_info).request_uri = FCGI_PUTENV(request, "SCRIPT_NAME", env_script_name);
+									}
+									if (decoded_path_info) {
+										efree(decoded_path_info);
 									}
 								}
 								env_path_info = FCGI_PUTENV(request, "PATH_INFO", path_info);

--- a/sapi/fpm/tests/fcgi-env-pif-apache-pp-sn-strip-encoded.phpt
+++ b/sapi/fpm/tests/fcgi-env-pif-apache-pp-sn-strip-encoded.phpt
@@ -1,0 +1,54 @@
+--TEST--
+FPM: FastCGI env var path info fix for Apache ProxyPass SCRIPT_NAME stripping with encoded path (bug #74129)
+--SKIPIF--
+<?php include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+php_admin_value[cgi.fix_pathinfo] = yes
+EOT;
+
+$code = <<<EOT
+<?php
+echo \$_SERVER["SCRIPT_NAME"] . "\n";
+echo \$_SERVER["ORIG_SCRIPT_NAME"] . "\n";
+echo \$_SERVER["SCRIPT_FILENAME"] . "\n";
+echo \$_SERVER["PATH_INFO"] . "\n";
+echo \$_SERVER["PHP_SELF"];
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+[$sourceFilePath, $scriptName] = $tester->createSourceFileAndScriptName();
+$tester->start();
+$tester->expectLogStartNotices();
+$tester
+    ->request(
+        uri: $scriptName . '/1%202',
+        scriptFilename: "proxy:fcgi://" . $tester->getAddr() . $sourceFilePath . '/1%202',
+        scriptName: $scriptName . '/1 2'
+    )
+    ->expectBody([$scriptName, $scriptName . '/1 2', $sourceFilePath, '/1%202', $scriptName . '/1%202']);
+$tester->terminate();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
As described in the pull request, this is caused by the fact that Apache URL decodes path info in the SCRIPT_NAME because it is required in CGI RFC.