### PR TITLE
Use Zend allocator methods in gd

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -149,6 +149,7 @@ AC_DEFUN([PHP_GD_CHECK_VERSION],[
   PHP_CHECK_LIBRARY(gd, gdImageStringFT,               [AC_DEFINE(HAVE_GD_FREETYPE,          1, [ ])], [], [ $GD_SHARED_LIBADD ])
   PHP_CHECK_LIBRARY(gd, gdVersionString,               [AC_DEFINE(HAVE_GD_LIBVERSION,        1, [ ])], [], [ $GD_SHARED_LIBADD ])
   PHP_CHECK_LIBRARY(gd, gdImageGetInterpolationMethod, [AC_DEFINE(HAVE_GD_GET_INTERPOLATION, 1, [ ])], [], [ $GD_SHARED_LIBADD ])
+  PHP_CHECK_LIBRARY(gd, gdSetMemoryMallocMethod,       [AC_DEFINE(HAVE_GD_MEMORY_ALLOCATORS, 1, [ ])], [], [ $GD_SHARED_LIBADD ])
 ])
 
 dnl

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -338,6 +338,13 @@ PHP_MINIT_FUNCTION(gd)
 	php_gd_object_minit_helper();
 	php_gd_font_minit_helper();
 
+#if defined(HAVE_GD_MEMORY_ALLOCATORS) && !ZEND_DEBUG
+	gdSetMemoryMallocMethod(_emalloc);
+	gdSetMemoryCallocMethod(_ecalloc);
+	gdSetMemoryReallocMethod(_erealloc);
+	gdSetMemoryFreeMethod(_efree);
+#endif
+
 #if defined(HAVE_GD_FREETYPE) && defined(HAVE_GD_BUNDLED)
 	gdFontCacheMutexSetup();
 #endif
@@ -354,6 +361,12 @@ PHP_MINIT_FUNCTION(gd)
 /* {{{ PHP_MSHUTDOWN_FUNCTION */
 PHP_MSHUTDOWN_FUNCTION(gd)
 {
+#if defined(HAVE_GD_MEMORY_ALLOCATORS)
+	gdClearMemoryMallocMethod();
+	gdClearMemoryCallocMethod();
+	gdClearMemoryReallocMethod();
+	gdClearMemoryFreeMethod();
+#endif
 #if defined(HAVE_GD_FREETYPE) && defined(HAVE_GD_BUNDLED)
 	gdFontCacheMutexShutdown();
 #endif


### PR DESCRIPTION
Previously when using system `gd` there was no way to use the Zend allocator methods to limit its memory usage.
This PR fixes this by using the new memory allocator setters in libgd/libgd#692. Also, this PR gives the possibility to unbundle `ext/gd/libgd`.
