### PR TITLE
Fix GH-10885: Leaking stream_socket_server context

### DIFF
--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -213,10 +213,6 @@ PHP_FUNCTION(stream_socket_server)
 
 	context = php_stream_context_from_zval(zcontext, flags & PHP_FILE_NO_DEFAULT_CONTEXT);
 
-	if (context) {
-		GC_ADDREF(context->res);
-	}
-
 	if (zerrno) {
 		ZEND_TRY_ASSIGN_REF_LONG(zerrno, 0);
 	}

--- a/ext/standard/tests/gh10885.phpt
+++ b/ext/standard/tests/gh10885.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-10885: stream_socket_server context leaks
+--FILE--
+<?php
+$context = stream_context_create();
+debug_zval_dump($context);
+$server = @\stream_socket_server(
+    'tcp://127.0.0.1:0',
+    $errno,
+    $errstr,
+    \STREAM_SERVER_BIND | \STREAM_SERVER_LISTEN,
+    $context,
+);
+debug_zval_dump($context);
+fclose($server);
+unset($server);
+debug_zval_dump($context);
+?>
+--EXPECTF--
+resource(%d) of type (stream-context) refcount(2)
+resource(%d) of type (stream-context) refcount(3)
+resource(%d) of type (stream-context) refcount(2)


### PR DESCRIPTION
`php_stream_context_set` already increases the refcount.