### PR TITLE
Forward shutdown exceptions to user error handlers

### DIFF
--- a/Zend/Optimizer/zend_func_infos.h
+++ b/Zend/Optimizer/zend_func_infos.h
@@ -689,6 +689,7 @@ static const func_info_t func_infos[] = {
 	F1("serialize", MAY_BE_STRING),
 	F1("xml_error_string", MAY_BE_STRING|MAY_BE_NULL),
 	F1("xml_parser_get_option", MAY_BE_STRING|MAY_BE_LONG|MAY_BE_BOOL),
+	FN("zend_test_create_throwing_resource", MAY_BE_RESOURCE),
 	FN("zip_open", MAY_BE_RESOURCE|MAY_BE_LONG|MAY_BE_FALSE),
 	FN("zip_read", MAY_BE_RESOURCE|MAY_BE_FALSE),
 	F1("ob_gzhandler", MAY_BE_STRING|MAY_BE_FALSE),

--- a/Zend/tests/gh10695_1.phpt
+++ b/Zend/tests/gh10695_1.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-10695: Exceptions in register_shutdown_function() are caught by set_exception_handler()
+--FILE--
+<?php
+set_exception_handler(function (\Throwable $exception) {
+    echo 'Caught: ' . $exception->getMessage() . "\n";
+});
+
+register_shutdown_function(function () {
+    echo "register_shutdown_function()\n";
+    throw new \Exception('shutdown');
+});
+?>
+--EXPECT--
+register_shutdown_function()
+Caught: shutdown

--- a/Zend/tests/gh10695_2.phpt
+++ b/Zend/tests/gh10695_2.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-10695: Exceptions in destructor during shutdown are caught
+--FILE--
+<?php
+class Foo {
+    public function __destruct() {
+        throw new \Exception(__METHOD__);
+    }
+}
+
+set_exception_handler(function (\Throwable $exception) {
+    echo 'Caught: ' . $exception->getMessage() . "\n";
+});
+
+const FOO = new Foo;
+?>
+--EXPECT--
+Caught: Foo::__destruct

--- a/Zend/tests/gh10695_3.phpt
+++ b/Zend/tests/gh10695_3.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-10695: Uncaught exceptions are not caught again
+--FILE--
+<?php
+register_shutdown_function(function () {
+    echo "shutdown\n";
+    set_exception_handler(function (\Throwable $exception) {
+        echo 'Caught: ' . $exception->getMessage() . "\n";
+    });
+});
+
+throw new \Exception('main');
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: main in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d
+shutdown

--- a/Zend/tests/gh10695_4.phpt
+++ b/Zend/tests/gh10695_4.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-10695: Exception handlers are not called twice
+--FILE--
+<?php
+set_exception_handler(function (\Throwable $exception) {
+    echo 'Caught: ' . $exception->getMessage() . "\n";
+    throw new \Exception('exception handler');
+});
+
+throw new \Exception('main');
+?>
+--EXPECTF--
+Caught: main
+
+Fatal error: Uncaught Exception: exception handler in %s:%d
+Stack trace:
+#0 [internal function]: {closure}(Object(Exception))
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/gh10695_5.phpt
+++ b/Zend/tests/gh10695_5.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-10695: Exception handlers can register another exception handler
+--FILE--
+<?php
+set_exception_handler(function (\Throwable $exception) {
+    echo 'Caught: ' . $exception->getMessage() . "\n";
+    set_exception_handler(function (\Throwable $exception) {
+        echo 'Caught: ' . $exception->getMessage() . "\n";
+    });
+    throw new \Exception('exception handler');
+});
+
+throw new \Exception('main');
+?>
+--EXPECT--
+Caught: main
+Caught: exception handler

--- a/Zend/tests/gh10695_6.phpt
+++ b/Zend/tests/gh10695_6.phpt
@@ -1,0 +1,14 @@
+--TEST--
+GH-10695: Exceptions from output buffering handlers during shutdown are caught
+--FILE--
+<?php
+set_exception_handler(function (\Throwable $exception) {
+    echo 'Caught: ' . $exception->getMessage() . "\n";
+});
+
+ob_start(function () {
+    throw new \Exception('ob_start');
+});
+?>
+--EXPECT--
+Caught: ob_start

--- a/Zend/tests/gh10695_7.phpt
+++ b/Zend/tests/gh10695_7.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-10695: Exceptions in error handlers during shutdown are caught
+--FILE--
+<?php
+set_exception_handler(function (\Throwable $exception) {
+    echo 'Caught: ' . $exception->getMessage() . "\n";
+});
+set_error_handler(function ($errno, $errstr) {
+    throw new \Exception($errstr);
+});
+register_shutdown_function(function () {
+    trigger_error('main', E_USER_ERROR);
+});
+?>
+--EXPECT--
+Caught: main

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1796,6 +1796,7 @@ ZEND_API ZEND_COLD void zend_user_exception_handler(void) /* {{{ */
 	EG(exception) = NULL;
 	ZVAL_OBJ(&params[0], old_exception);
 	ZVAL_COPY_VALUE(&orig_user_exception_handler, &EG(user_exception_handler));
+	ZVAL_UNDEF(&EG(user_exception_handler));
 
 	if (call_user_function(CG(function_table), NULL, &orig_user_exception_handler, &retval2, 1, params) == SUCCESS) {
 		zval_ptr_dtor(&retval2);
@@ -1807,6 +1808,8 @@ ZEND_API ZEND_COLD void zend_user_exception_handler(void) /* {{{ */
 	} else {
 		EG(exception) = old_exception;
 	}
+
+	zval_ptr_dtor(&orig_user_exception_handler);
 } /* }}} */
 
 ZEND_API zend_result zend_execute_scripts(int type, zval *retval, int file_count, ...) /* {{{ */

--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -199,7 +199,11 @@ ZEND_API ZEND_COLD void zend_throw_exception_internal(zend_object *exception) /*
 			return;
 		}
 		if (EG(exception)) {
-			zend_exception_error(EG(exception), E_ERROR);
+			if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
+				zend_user_exception_handler();
+			} else {
+				zend_exception_error(EG(exception), E_ERROR);
+			}
 			zend_bailout();
 		}
 		zend_error_noreturn(E_CORE_ERROR, "Exception thrown without a stack frame");

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1010,7 +1010,11 @@ cleanup_args:
 
 	if (UNEXPECTED(EG(exception))) {
 		if (UNEXPECTED(!EG(current_execute_data))) {
-			zend_throw_exception_internal(NULL);
+			if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
+				zend_user_exception_handler();
+			} else {
+				zend_throw_exception_internal(NULL);
+			}
 		} else if (EG(current_execute_data)->func &&
 		           ZEND_USER_CODE(EG(current_execute_data)->func->common.type)) {
 			zend_rethrow_exception(EG(current_execute_data));

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -196,6 +196,9 @@ namespace {
     function zend_test_crash(?string $message = null): void {}
 
     function zend_test_fill_packed_array(array &$array): void {}
+
+    /** @return resource */
+    function zend_test_create_throwing_resource() {}
 }
 
 namespace ZendTestNS {

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: eb6dd9bae381ca8163307e8a0f54bf3983b79cb5 */
+ * Stub hash: 58ae12118458386ab204a2400966c25c833baeae */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -122,6 +122,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_fill_packed_array, 0, 
 	ZEND_ARG_TYPE_INFO(1, array, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zend_test_create_throwing_resource, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_namespaced_func, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -227,6 +230,7 @@ static ZEND_FUNCTION(zend_test_is_string_marked_as_valid_utf8);
 static ZEND_FUNCTION(zend_get_map_ptr_last);
 static ZEND_FUNCTION(zend_test_crash);
 static ZEND_FUNCTION(zend_test_fill_packed_array);
+static ZEND_FUNCTION(zend_test_create_throwing_resource);
 static ZEND_FUNCTION(ZendTestNS2_namespaced_func);
 static ZEND_FUNCTION(ZendTestNS2_namespaced_deprecated_func);
 static ZEND_FUNCTION(ZendTestNS2_ZendSubNS_namespaced_func);
@@ -289,6 +293,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_get_map_ptr_last, arginfo_zend_get_map_ptr_last)
 	ZEND_FE(zend_test_crash, arginfo_zend_test_crash)
 	ZEND_FE(zend_test_fill_packed_array, arginfo_zend_test_fill_packed_array)
+	ZEND_FE(zend_test_create_throwing_resource, arginfo_zend_test_create_throwing_resource)
 	ZEND_NS_FALIAS("ZendTestNS2", namespaced_func, ZendTestNS2_namespaced_func, arginfo_ZendTestNS2_namespaced_func)
 	ZEND_NS_DEP_FALIAS("ZendTestNS2", namespaced_deprecated_func, ZendTestNS2_namespaced_deprecated_func, arginfo_ZendTestNS2_namespaced_deprecated_func)
 	ZEND_NS_FALIAS("ZendTestNS2", namespaced_aliased_func, zend_test_void_return, arginfo_ZendTestNS2_namespaced_aliased_func)

--- a/ext/zend_test/tests/gh10695_1.phpt
+++ b/ext/zend_test/tests/gh10695_1.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-10695: Exceptions in resource dtors during shutdown are caught
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+set_exception_handler(function (\Throwable $exception) {
+    echo 'Caught: ' . $exception->getMessage() . "\n";
+});
+
+$resource = zend_test_create_throwing_resource();
+?>
+--EXPECT--
+Fatal error: Uncaught Exception: Throwing resource destructor called in [no active file]:0
+Stack trace:
+#0 {main}
+  thrown in [no active file] on line 0

--- a/ext/zend_test/tests/gh10695_1.phpt
+++ b/ext/zend_test/tests/gh10695_1.phpt
@@ -11,7 +11,4 @@ set_exception_handler(function (\Throwable $exception) {
 $resource = zend_test_create_throwing_resource();
 ?>
 --EXPECT--
-Fatal error: Uncaught Exception: Throwing resource destructor called in [no active file]:0
-Stack trace:
-#0 {main}
-  thrown in [no active file] on line 0
+Caught: Throwing resource destructor called

--- a/ext/zend_test/tests/gh10695_2.phpt
+++ b/ext/zend_test/tests/gh10695_2.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-10695: Uncaught exception in exception handler catching resource dtor exception
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+set_exception_handler(function (\Throwable $exception) {
+    throw new Exception('Caught');
+});
+
+$resource = zend_test_create_throwing_resource();
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: Caught in %s:%d
+Stack trace:
+#0 [internal function]: {closure}(Object(Exception))
+#1 {main}
+  thrown in %s on line %d


### PR DESCRIPTION
Fixes GH-10695

I'm not yet sure if this makes sense. It might also make more sense targetting `master` for this one.