### PR TITLE
[Zend]: Remove unused code in MAKE_NOP macro

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -34,9 +34,6 @@
 } while (0)
 
 #define MAKE_NOP(opline) do { \
-	(opline)->op1.num = 0; \
-	(opline)->op2.num = 0; \
-	(opline)->result.num = 0; \
 	(opline)->opcode = ZEND_NOP; \
 	SET_UNUSED((opline)->op1); \
 	SET_UNUSED((opline)->op2); \


### PR DESCRIPTION
Prefer to see clean code.

In MAKE_NOP macro, op.num is first set to 0, but immediately set to -1 by SET_UNUSED macro, which invalidates previous set-to-zero code.

So clean the code to make it look nice and neat.