### PR TITLE
ext/pdo_sqlite: simplifying sqlite3_exec usage.

### DIFF
--- a/ext/pdo_sqlite/sqlite_driver.c
+++ b/ext/pdo_sqlite/sqlite_driver.c
@@ -203,13 +203,9 @@ static bool sqlite_handle_preparer(pdo_dbh_t *dbh, zend_string *sql, pdo_stmt_t 
 static zend_long sqlite_handle_doer(pdo_dbh_t *dbh, const zend_string *sql)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
-	char *errmsg = NULL;
 
-	if (sqlite3_exec(H->db, ZSTR_VAL(sql), NULL, NULL, &errmsg) != SQLITE_OK) {
+	if (sqlite3_exec(H->db, ZSTR_VAL(sql), NULL, NULL, NULL) != SQLITE_OK) {
 		pdo_sqlite_error(dbh);
-		if (errmsg)
-			sqlite3_free(errmsg);
-
 		return -1;
 	} else {
 		return sqlite3_changes(H->db);
@@ -241,12 +237,9 @@ static zend_string* sqlite_handle_quoter(pdo_dbh_t *dbh, const zend_string *unqu
 static bool sqlite_handle_begin(pdo_dbh_t *dbh)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
-	char *errmsg = NULL;
 
-	if (sqlite3_exec(H->db, "BEGIN", NULL, NULL, &errmsg) != SQLITE_OK) {
+	if (sqlite3_exec(H->db, "BEGIN", NULL, NULL, NULL) != SQLITE_OK) {
 		pdo_sqlite_error(dbh);
-		if (errmsg)
-			sqlite3_free(errmsg);
 		return false;
 	}
 	return true;
@@ -255,12 +248,9 @@ static bool sqlite_handle_begin(pdo_dbh_t *dbh)
 static bool sqlite_handle_commit(pdo_dbh_t *dbh)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
-	char *errmsg = NULL;
 
-	if (sqlite3_exec(H->db, "COMMIT", NULL, NULL, &errmsg) != SQLITE_OK) {
+	if (sqlite3_exec(H->db, "COMMIT", NULL, NULL, NULL) != SQLITE_OK) {
 		pdo_sqlite_error(dbh);
-		if (errmsg)
-			sqlite3_free(errmsg);
 		return false;
 	}
 	return true;
@@ -269,12 +259,9 @@ static bool sqlite_handle_commit(pdo_dbh_t *dbh)
 static bool sqlite_handle_rollback(pdo_dbh_t *dbh)
 {
 	pdo_sqlite_db_handle *H = (pdo_sqlite_db_handle *)dbh->driver_data;
-	char *errmsg = NULL;
 
-	if (sqlite3_exec(H->db, "ROLLBACK", NULL, NULL, &errmsg) != SQLITE_OK) {
+	if (sqlite3_exec(H->db, "ROLLBACK", NULL, NULL, NULL) != SQLITE_OK) {
 		pdo_sqlite_error(dbh);
-		if (errmsg)
-			sqlite3_free(errmsg);
 		return false;
 	}
 	return true;


### PR DESCRIPTION
pdo_sqlite_error copy the error message via the php's allocator,
 while the one from sqlite3_exec is unused.