### PR TITLE
Fix buffer-overflow in php_fgetcsv() when delimiter and enclosure are null byte

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -2088,7 +2088,7 @@ PHPAPI void php_fgetcsv(php_stream *stream, char delimiter, char enclosure, int 
 			while ((*tmp != delimiter) && isspace((int)*(unsigned char *)tmp)) {
 				tmp++;
 			}
-			if (*tmp == enclosure) {
+			if (*tmp == enclosure && tmp < limit) {
 				bptr = tmp;
 			}
 		}

--- a/ext/standard/tests/oss_fuzz_57392.phpt
+++ b/ext/standard/tests/oss_fuzz_57392.phpt
@@ -1,0 +1,17 @@
+--TEST--
+oss-fuzz #57392: str_getcsv() with null byte as delimiter and enclosure
+--FILE--
+<?php
+var_dump(str_getcsv(
+    "aaaaaaaaaaaa\0  ",
+    "\0",
+    "\0",
+));
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(12) "aaaaaaaaaaaa"
+  [1]=>
+  string(2) "  "
+}


### PR DESCRIPTION
Fixes oss-fuzz #57392