### PR TITLE
For UTF-7, emit error marker if Base64 section ends abruptly after first half of surrogate pair

### DIFF
--- a/ext/mbstring/libmbfl/filters/mbfilter_utf7.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_utf7.c
@@ -537,8 +537,10 @@ static size_t mb_utf7_to_wchar(unsigned char **in, size_t *in_len, uint32_t *buf
 			if (p == e) {
 				/* It is an error if trailing padding bits are not zeroes or if we were
 				 * expecting the 2nd part of a surrogate pair when Base64 section ends */
-				if ((n3 & 0x3) || surrogate1)
+				if ((n3 & 0x3) || surrogate1) {
 					*out++ = MBFL_BAD_INPUT;
+					surrogate1 = 0;
+				}
 				break;
 			}
 
@@ -562,8 +564,10 @@ static size_t mb_utf7_to_wchar(unsigned char **in, size_t *in_len, uint32_t *buf
 			}
 			out = handle_utf16_cp((n3 << 14) | (n4 << 8) | (n5 << 2) | ((n6 & 0x30) >> 4), out, &surrogate1);
 			if (p == e) {
-				if ((n6 & 0xF) || surrogate1)
+				if ((n6 & 0xF) || surrogate1) {
 					*out++ = MBFL_BAD_INPUT;
+					surrogate1 = 0;
+				}
 				break;
 			}
 
@@ -601,6 +605,11 @@ static size_t mb_utf7_to_wchar(unsigned char **in, size_t *in_len, uint32_t *buf
 				*out++ = MBFL_BAD_INPUT;
 			}
 		}
+	}
+
+	if (p == e && surrogate1) {
+		ZEND_ASSERT(out < limit);
+		*out++ = MBFL_BAD_INPUT;
 	}
 
 	*state = (surrogate1 << 1) | base64;

--- a/ext/mbstring/tests/utf_encodings.phpt
+++ b/ext/mbstring/tests/utf_encodings.phpt
@@ -1074,6 +1074,9 @@ testInvalidString('+' . rawEncode("\x00.\x00.\xD8\x01\xD9\x02") . '-', "\x00\x00
 // First half of surrogate pair appearing at end of string
 testInvalidString('+' . rawEncode("\xD8\x01") . '-', "\x00\x00\x00%", 'UTF-7', 'UTF-32BE');
 testInvalidString('+' . rawEncode("\xD8\x01"), "\x00\x00\x00%", 'UTF-7', 'UTF-32BE');
+testInvalidString("+999999uJ", "\xEF\x9F\x9F\xE7\xB7\xB7%", 'UTF-7', 'UTF-8');
+testInvalidString("+999euJ", "\xEF\x9F\x9F\xE5\xBA\xB8%", "UTF-7", "UTF-8");
+testInvalidString("+euJ", "\xE7\xAB\xA2%", "UTF-7", "UTF-8");
 
 // Truncated string
 testInvalidString('+' . rawEncode("\x01") . '-', "\x00\x00\x00%", 'UTF-7', 'UTF-32BE');


### PR DESCRIPTION
This (rare) situation was already handled correctly for the 1st and 2nd of every 3 codepoints in a Base64-encoded section of a UTF-7 string. However, it was not handled correctly if it happened on the 3rd, 6th, 9th, etc. codepoint of such a Base64-encoded section.

This was discovered while fuzzing @pakutoma's recent PR, which introduced new validation logic for ISO-2022-JP, JIS, and UTF-7.

@cmb69 @Girgias @kamil-tekiela @youkidearitai 