### PR TITLE
Fix GH-10928: PHP Build Failed - Test curl_version() basic functional…

### DIFF
--- a/ext/curl/tests/curl_version_basic_001.phpt
+++ b/ext/curl/tests/curl_version_basic_001.phpt
@@ -22,6 +22,6 @@ int(%i)
 int(%i)
 string(%i) "%s"
 string(%i) "%s"
-string(%i) "%s"
-string(%i) "%s"
+string(%i) "%S"
+string(%i) "%S"
 bool(true)


### PR DESCRIPTION
…ity [ext/curl/tests/curl_version_basic_001.phpt]

It's possible that curl was compiled without SSL, and/or without libz support. In the case of the issue reporter it was without libz support. This causes the test to fail because we expect a non-empty string. Fix it by using %S instead of %s to allow empty strings.