### PR TITLE
Add separate static property through trait if parent already declares it

### DIFF
--- a/Zend/tests/gh10935.phpt
+++ b/Zend/tests/gh10935.phpt
@@ -1,0 +1,83 @@
+--TEST--
+GH-1093: Add separate static property through trait if parent already declares it
+--FILE--
+<?php
+trait Foo {
+    static $test;
+
+    public static function getFooSelf() {
+        return self::$test;
+    }
+
+    public static function getFooStatic() {
+        return static::$test;
+    }
+}
+trait Bar {
+    public static function getBarSelf() {
+        return self::$test;
+    }
+
+    public static function getBarStatic() {
+        return static::$test;
+    }
+}
+
+class A {
+    use Foo;
+    use Bar;
+
+    public static function getASelf() {
+        return self::$test;
+    }
+
+    public static function getAStatic() {
+        return static::$test;
+    }
+}
+
+class B extends A {
+    use Foo;
+
+    public static function getBSelf() {
+        return self::$test;
+    }
+
+    public static function getBStatic() {
+        return static::$test;
+    }
+}
+
+A::$test = 'A';
+B::$test = 'B';
+
+echo 'A::$test: ' . A::$test . "\n";
+echo 'A::getASelf(): ' . A::getASelf() . "\n";
+echo 'A::getAStatic(): ' . A::getAStatic() . "\n";
+echo 'A::getFooSelf(): ' . A::getFooSelf() . "\n";
+echo 'A::getFooStatic(): ' . A::getFooStatic() . "\n";
+echo 'B::$test: ' . B::$test . "\n";
+echo 'B::getASelf(): ' . B::getASelf() . "\n";
+echo 'B::getAStatic(): ' . B::getAStatic() . "\n";
+echo 'B::getBSelf(): ' . B::getBSelf() . "\n";
+echo 'B::getBStatic(): ' . B::getBStatic() . "\n";
+echo 'B::getFooSelf(): ' . B::getFooSelf() . "\n";
+echo 'B::getFooStatic(): ' . B::getFooStatic() . "\n";
+echo 'B::getBarSelf(): ' . B::getBarSelf() . "\n";
+echo 'B::getBarStatic(): ' . B::getBarStatic() . "\n";
+?>
+--EXPECT--
+A::$test: A
+A::getASelf(): A
+A::getAStatic(): A
+A::getFooSelf(): A
+A::getFooStatic(): A
+B::$test: B
+B::getASelf(): A
+B::getAStatic(): B
+B::getBSelf(): B
+B::getBStatic(): B
+B::getFooSelf(): B
+B::getFooStatic(): B
+B::getBarSelf(): A
+B::getBarStatic(): B

--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -2377,7 +2377,9 @@ static void zend_do_traits_property_binding(zend_class_entry *ce, zend_class_ent
 								ZSTR_VAL(prop_name),
 								ZSTR_VAL(ce->name));
 					}
-					continue;
+					if (!(flags & ZEND_ACC_STATIC)) {
+						continue;
+					}
 				}
 			}
 

--- a/ext/opcache/zend_persist.c
+++ b/ext/opcache/zend_persist.c
@@ -1082,7 +1082,15 @@ void zend_update_parent_ce(zend_class_entry *ce)
 				end = parent->parent ? parent->parent->default_static_members_count : 0;
 				for (; i >= end; i--) {
 					zval *p = &ce->default_static_members_table[i];
-					ZVAL_INDIRECT(p, &parent->default_static_members_table[i]);
+					/* The static property may have been overridden by a trait
+					 * during inheritance. In that case, the property default
+					 * value is replaced by zend_declare_typed_property() at the
+					 * property index of the parent property. Make sure we only
+					 * point to the parent property value if the child value was
+					 * already indirect. */
+					if (Z_TYPE_P(p) == IS_INDIRECT) {
+						ZVAL_INDIRECT(p, &parent->default_static_members_table[i]);
+					}
 				}
 
 				parent = parent->parent;


### PR DESCRIPTION
Closes GH-10935

https://wiki.php.net/rfc/horizontalreuse

> It is almost like a language supported and failsafe copy'n'paste mechanism to build classes. 

It's reasonable to expect the case with and without properties to behave equivalently.