### PR TITLE
Fix undefined behaviour when writing 32-bit values in phar/tar.c

### DIFF
--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -1244,13 +1244,15 @@ nostub:
 			return EOF;
 		}
 #ifdef WORDS_BIGENDIAN
-# define PHAR_SET_32(var, buffer) \
-	*(uint32_t *)(var) = (((((unsigned char*)&(buffer))[3]) << 24) \
-		| ((((unsigned char*)&(buffer))[2]) << 16) \
-		| ((((unsigned char*)&(buffer))[1]) << 8) \
-		| (((unsigned char*)&(buffer))[0]))
+# define PHAR_SET_32(destination, source) do { \
+        uint32_t swapped = (((((unsigned char*)&(source))[3]) << 24) \
+            | ((((unsigned char*)&(source))[2]) << 16) \
+            | ((((unsigned char*)&(source))[1]) << 8) \
+            | (((unsigned char*)&(source))[0])); \
+        memcpy(destination, &swapped, 4); \
+    } while (0);
 #else
-# define PHAR_SET_32(var, buffer) *(uint32_t *)(var) = (uint32_t) (buffer)
+# define PHAR_SET_32(destination, source) memcpy(destination, &source, 4)
 #endif
 		PHAR_SET_32(sigbuf, phar->sig_flags);
 		PHAR_SET_32(sigbuf + 4, signature_length);


### PR DESCRIPTION
As shown on the CI runs on my fork (which runs with UBSAN), the pointers can sometimes be unaligned when trying to write. This is UB and on platforms like ARM this *can* result in a bus error. Replace it with memcpy, which at least on x86 and powerpc architectures does result in the same assembly code.