### PR TITLE
Fix shift out of bounds on 32-bit non-fast-path platforms

### DIFF
--- a/ext/mysqlnd/mysqlnd_portability.h
+++ b/ext/mysqlnd/mysqlnd_portability.h
@@ -215,8 +215,8 @@ typedef union {
                   *(((char *)(T))+1) = (char)(((A) >> 8));\
                   *(((char *)(T))+2) = (char)(((A) >> 16));\
                   *(((char *)(T))+3) = (char)(((A) >> 24)); \
-                  *(((char *)(T))+4) = (char)(((A) >> 32)); } while (0)
-#define int8store(T,A)        { uint32_t def_temp= (uint32_t) (A), def_temp2= (uint32_t) ((A) >> 32); \
+                  *(((char *)(T))+4) = sizeof(A) == 4 ? 0 : (char)(((A) >> 32)); } while (0)
+#define int8store(T,A)        { uint32_t def_temp= (uint32_t) (A), def_temp2= sizeof(A) == 4 ? 0 : (uint32_t) ((A) >> 32); \
                   int4store((T),def_temp); \
                   int4store((T+4),def_temp2); \
                 }


### PR DESCRIPTION
The x86-32 build uses a fast path, but when I disabled the fast path I got the following compile error with -Werror:
mysqlnd_portability.h:221:95: error: right shift count >= width of type [-Werror=shift-count-overflow]

For 32-bit platforms that don't have the fast path, this can cause undefined behaviour at runtime. Some CPUs just mask the shift amount so in those cases you even get wrong results.
This is not always found during the build because -Werror is off by default.