### PR TITLE
Fix undefined behaviour in GENERATE_SEED()

### DIFF
--- a/ext/standard/php_rand.h
+++ b/ext/standard/php_rand.h
@@ -61,9 +61,9 @@
 	(__n) = (__min) + (zend_long) ((double) ( (double) (__max) - (__min) + 1.0) * ((__n) / ((__tmax) + 1.0)))
 
 #ifdef PHP_WIN32
-#define GENERATE_SEED() (((zend_long) (time(0) * GetCurrentProcessId())) ^ ((zend_long) (1000000.0 * php_combined_lcg())))
+#define GENERATE_SEED() (((zend_long) ((zend_ulong) time(0) * (zend_ulong) GetCurrentProcessId())) ^ ((zend_long) (1000000.0 * php_combined_lcg())))
 #else
-#define GENERATE_SEED() (((zend_long) (time(0) * getpid())) ^ ((zend_long) (1000000.0 * php_combined_lcg())))
+#define GENERATE_SEED() (((zend_long) ((zend_ulong) time(0) * (zend_ulong) getpid())) ^ ((zend_long) (1000000.0 * php_combined_lcg())))
 #endif
 
 PHPAPI void php_srand(zend_long seed);


### PR DESCRIPTION
Signed multiply overflow is undefined behaviour.
If you run the CI tests with UBSAN enabled on a 32-bit platform, this is quite easy to hit. On 64-bit it's more difficult to hit though, but not impossible.