### PR TITLE
Fix uninitialized variable accesses in sockets/conversions

### DIFF
--- a/ext/sockets/conversions.c
+++ b/ext/sockets/conversions.c
@@ -720,6 +720,10 @@ static void from_zval_write_sockaddr_aux(const zval *container,
 		zend_llist_add_element(&ctx->keys, &node);
 		from_zval_write_int(elem, (char*)&family, ctx);
 		zend_llist_remove_tail(&ctx->keys);
+
+		if (UNEXPECTED(ctx->err.has_error)) {
+			return;
+		}
 	} else {
 		family = ctx->sock->type;
 	}
@@ -1115,7 +1119,10 @@ static void from_zval_write_controllen(const zval *elem, char *msghdr_c, ser_con
 	 * this least common denominator
 	 */
 	from_zval_write_uint32(elem, (char*)&len, ctx);
-	if (!ctx->err.has_error && len == 0) {
+	if (ctx->err.has_error) {
+		return;
+	}
+	if (len == 0) {
 		do_from_zval_err(ctx, "controllen cannot be 0");
 		return;
 	}


### PR DESCRIPTION
This was first pointed out in GH-10959.
The from_zval_... functions don't always write to the pointer, in particular it is necessary to check for an error before using the value. Otherwise we can access an uninitialized value and that's UB (and dangerous).

Note: this does *NOT* get rid of the compiler warning. Even though there is error checking now, the compiler isn't smart enough to figure out that the values can not be used uninitialized.