### PR TITLE
Bump minimum OpenSSL version to 1.1.1

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1942,7 +1942,7 @@ dnl
 AC_DEFUN([PHP_SETUP_OPENSSL],[
   found_openssl=no
 
-  PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.0.2], [found_openssl=yes])
+  PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.1.1], [found_openssl=yes])
 
   if test "$found_openssl" = "yes"; then
     PHP_EVAL_LIBLINE($OPENSSL_LIBS, $1)

--- a/ext/openssl/config0.m4
+++ b/ext/openssl/config0.m4
@@ -1,7 +1,7 @@
 PHP_ARG_WITH([openssl],
   [for OpenSSL support],
   [AS_HELP_STRING([--with-openssl],
-    [Include OpenSSL support (requires OpenSSL >= 1.0.2)])])
+    [Include OpenSSL support (requires OpenSSL >= 1.1.1)])])
 
 PHP_ARG_WITH([kerberos],
   [for Kerberos support],

--- a/php.ini-development
+++ b/php.ini-development
@@ -929,11 +929,7 @@ default_socket_timeout = 60
 ;
 ;extension=bz2
 
-; The ldap extension must be before curl if OpenSSL 1.0.2 and OpenLDAP is used
-; otherwise it results in segfault when unloading after using SASL.
-; See https://github.com/php/php-src/issues/8620 for more info.
 ;extension=ldap
-
 ;extension=curl
 ;extension=ffi
 ;extension=ftp

--- a/php.ini-production
+++ b/php.ini-production
@@ -931,11 +931,7 @@ default_socket_timeout = 60
 ;
 ;extension=bz2
 
-; The ldap extension must be before curl if OpenSSL 1.0.2 and OpenLDAP is used
-; otherwise it results in segfault when unloading after using SASL.
-; See https://github.com/php/php-src/issues/8620 for more info.
 ;extension=ldap
-
 ;extension=curl
 ;extension=ffi
 ;extension=ftp


### PR DESCRIPTION
OpenSSL 1.0.2 has been EOL since December 31, 2019, and OpenSSL 1.1.1 will be EOL on September 11, 2023. I don't think it makes sense to continue to support OpenSSL 1.0.2, when upgrading to 1.1.1 (and even 3.0, in some cases) is mostly easy. Most Linux distributions ship with OpenSSL 3.0 LTS these days, too. I would propose we bump the minimum version to 1.1.1 in PHP 8.3, then to 3.0 in PHP 8.5. Bumping to 1.1.1 also allows us to fix some deprecation warnings that appear when building on 3.0 (I think), while maintaining 1.1.1 compatibility, which will ultimately be necessary to enable building with 4.0 when that comes out.

---

List of major Linux distributions that will not be EOL before PHP 8.3's release date:

* Debian 10 ships with OpenSSL 1.1.1n.
* Debian 11 ships with OpenSSL 1.1.1n.
* Debian 12 will ship with OpenSSL 3.0.8.
* RHEL 8 ships with OpenSSL 1.1.1k.
* RHEL 9 ships with OpenSSL 3.0.1.
* Ubuntu 20.04 ships with OpenSSL 1.1.1f.
* Ubuntu 22.04 ships with OpenSSL 3.0.2.
* Alpine 3.16 ships with OpenSSL 1.1.1t.
* Alpine 3.17 ships with OpenSSL 3.0.8.

All of them have 1.1.1 or 3.0.