### PR TITLE
Fix incorrect zval type_flags in preg_replace_callback_array() for immutable arrays

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -2479,7 +2479,11 @@ PHP_FUNCTION(preg_replace_callback_array)
 	}
 
 	if (subject_ht) {
-		RETURN_ARR(subject_ht);
+		RETVAL_ARR(subject_ht);
+		if (GC_FLAGS(subject_ht) & GC_IMMUTABLE) {
+			Z_TYPE_FLAGS_P(return_value) = 0;
+		}
+		return;
 	} else {
 		RETURN_STR(subject_str);
 	}

--- a/ext/pcre/tests/gh10968.phpt
+++ b/ext/pcre/tests/gh10968.phpt
@@ -1,0 +1,11 @@
+--TEST--
+GH-10968: preg_replace_callback_array() segmentation fault
+--FILE--
+<?php
+var_dump(preg_replace_callback_array([], []));
+var_dump(preg_replace_callback_array([], ''));
+?>
+--EXPECT--
+array(0) {
+}
+string(0) ""


### PR DESCRIPTION
The ZVAL_ARR macro always set the zval type_info to IS_ARRAY_EX, even if the hash table is immutable. Since in preg_replace_callback_array() we can return the passed array directly, and that passed array can be immutable, we need to reset the type_flags to keep the VM from performing ref-counting on the array.

Fixes GH-10968

We could also introduce a new macro for this but I couldn't find another place that potentially returns an immutable array.