### PR TITLE
Remove XFAIL from test cases for mb_strcut when used with JIS or ISO-2022-JP encoding

### DIFF
--- a/ext/mbstring/tests/gh9535b.phpt
+++ b/ext/mbstring/tests/gh9535b.phpt
@@ -1,16 +1,9 @@
 --TEST--
-Output of mb_strcut covers requested range of bytes even when output contains ending escape sequences
+Test output of mb_strcut for text encodings which use escape sequences
 --EXTENSIONS--
 mbstring
 --FILE--
 <?php
-// The existing behavior of mb_strcut is wrong for these encodings, when they add an extra closing
-// escape sequence to a string which would otherwise end in a non-default conversion mode
-// See https://github.com/php/php-src/pull/9562 for details on the bug
-
-// These tests were developed when fixing a different bug, but they don't pass because of
-// the bug involving the added closing escape sequences
-// When that bug is fixed, we can remove XFAIL (or combine this file with gh9535.phpt)
 
 $encodings = [
     'JIS',
@@ -78,16 +71,14 @@ foreach($encodings as $encoding) {
 }
 
 ?>
---XFAIL--
-Discussion: https://github.com/php/php-src/pull/9562
 --EXPECTF--
-JIS: 宛如繁星般
-ISO-2022-JP: 宛如繁星般
+JIS: 宛如繁星
+ISO-2022-JP: 宛如繁星
 ISO-2022-JP-2004: 宛如繁星
 
 JIS: 星のように月の
 ISO-2022-JP: 星のように月の
-ISO-2022-JP-2004: 星のように月の
+ISO-2022-JP-2004: 星のように月
 
 JIS: あa
 ISO-2022-JP: あa


### PR DESCRIPTION
The documentation for mb_strcut states:

    mb_strcut(
        string $string,
        int $start,
        ?int $length = null,
        ?string $encoding = null
    ): string

    mb_strcut() extracts a substring from a string similarly to mb_substr(),
    but operates on bytes instead of characters. If the cut position happens
    to be between two bytes of a multi-byte character, the cut is performed
    starting from the first byte of that character.

My understanding of the $length parameter for mb_strcut is that it specified the range of bytes to extract from $string, and that all characters encoded by those bytes should be included in the returned string, even if that means the returned string would be longer than $length bytes. This can happen either if 1) there is more than one way to encode the same character in $encoding, and one way requires more bytes than the other, or 2) $encoding uses escape sequences.

However, discussion with users of mb_strcut indicates that many of them interpret $length as the maximum length of the *returned* string. This is also the historical behavior of the function.

Hence, there is no need to modify the behavior of mb_strcut and then remove XFAIL from these test cases afterwards. We can keep the current behavior.

@cmb69 @Girgias @NathanFreeman @youkidearitai @pakutoma 