### PR TITLE
ext/sockets: add macOs's SO_NOSIGPIPE setsockopt flag.

### DIFF
--- a/ext/sockets/sockets.stub.php
+++ b/ext/sockets/sockets.stub.php
@@ -314,6 +314,13 @@ const SO_SPLICE = UNKNOWN;
  */
 const SO_ZEROIZE = UNKNOWN;
 #endif
+#ifdef SO_NOSIGPIPE
+/**
+ * @var int
+ * @cvalue SO_NOSIGPIPE
+ */
+const SO_NOSIGPIPE = UNKNOWN;
+#endif
 #ifdef SOL_FILTER
 /**
  * @var int

--- a/ext/sockets/sockets_arginfo.h
+++ b/ext/sockets/sockets_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e636fc791c75cffe089fdcba26d38c9dedb89b57 */
+ * Stub hash: c1a43cb4316b1d648548f2772d2fb962794ebf2f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_socket_select, 0, 4, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
@@ -440,6 +440,9 @@ static void register_sockets_symbols(int module_number)
 #endif
 #if defined(SO_ZEROIZE)
 	REGISTER_LONG_CONSTANT("SO_ZEROIZE", SO_ZEROIZE, CONST_PERSISTENT);
+#endif
+#if defined(SO_NOSIGPIPE)
+	REGISTER_LONG_CONSTANT("SO_NOSIGPIPE", SO_NOSIGPIPE, CONST_PERSISTENT);
 #endif
 #if defined(SOL_FILTER)
 	REGISTER_LONG_CONSTANT("SOL_FILTER", SOL_FILTER, CONST_PERSISTENT);


### PR DESCRIPTION
goal is preventing SIGPIPE being generated when the peer is no longer alive similar to send with MSG_NOSIGNAL on some platforms.