### PR TITLE
Fix add_function_array() separation

### DIFF
--- a/Zend/tests/gh10085.phpt
+++ b/Zend/tests/gh10085.phpt
@@ -1,0 +1,9 @@
+--TEST--
+GH-10085: Assertion in add_function_array()
+--FILE--
+<?php
+$i = [[], 0];
+$ref = &$i;
+$i[0] += $ref;
+?>
+--EXPECT--

--- a/Zend/tests/gh10085_1.phpt
+++ b/Zend/tests/gh10085_1.phpt
@@ -5,5 +5,18 @@ GH-10085: Assertion in add_function_array()
 $i = [[], 0];
 $ref = &$i;
 $i[0] += $ref;
+var_dump($i);
 ?>
 --EXPECT--
+array(2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    array(0) {
+    }
+    [1]=>
+    int(0)
+  }
+  [1]=>
+  int(0)
+}

--- a/Zend/tests/gh10085_2.phpt
+++ b/Zend/tests/gh10085_2.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-10085: Assertion in add_function_array()
+--FILE--
+<?php
+$tmp = [0];
+unset($tmp[0]);
+$i = [$tmp, 0];
+unset($tmp);
+$ref = &$i;
+$i[0] += $ref;
+var_dump($i);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    array(0) {
+    }
+    [1]=>
+    int(0)
+  }
+  [1]=>
+  int(0)
+}

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -970,13 +970,13 @@ static zend_never_inline void ZEND_FASTCALL add_function_array(zval *result, zva
 		return;
 	}
 	zval tmp;
-	if (result != op1) {
-		ZVAL_ARR(&tmp, zend_array_dup(Z_ARR_P(op1)));
-	} else {
-		ZVAL_COPY_VALUE(&tmp, result);
-		SEPARATE_ARRAY(&tmp);
-	}
+	ZVAL_ARR(&tmp, zend_array_dup(Z_ARR_P(op1)));
 	zend_hash_merge(Z_ARRVAL_P(&tmp), Z_ARRVAL_P(op2), zval_add_ref, 0);
+	if (result == op1) {
+		/* When result == op1 the caller is assuming that reused when rc == 1.
+		 * Since we're not doing that (GH-10085) we need to release it. */
+		zval_ptr_dtor(result);
+	}
 	ZVAL_COPY_VALUE(result, &tmp);
 }
 /* }}} */

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -969,12 +969,15 @@ static zend_never_inline void ZEND_FASTCALL add_function_array(zval *result, zva
 		/* $a += $a */
 		return;
 	}
+	zval tmp;
 	if (result != op1) {
-		ZVAL_ARR(result, zend_array_dup(Z_ARR_P(op1)));
+		ZVAL_ARR(&tmp, zend_array_dup(Z_ARR_P(op1)));
 	} else {
-		SEPARATE_ARRAY(result);
+		ZVAL_COPY_VALUE(&tmp, result);
+		SEPARATE_ARRAY(&tmp);
 	}
-	zend_hash_merge(Z_ARRVAL_P(result), Z_ARRVAL_P(op2), zval_add_ref, 0);
+	zend_hash_merge(Z_ARRVAL_P(&tmp), Z_ARRVAL_P(op2), zval_add_ref, 0);
+	ZVAL_COPY_VALUE(result, &tmp);
 }
 /* }}} */
 


### PR DESCRIPTION
result may be a slot in op2. In that case SEPARATE_ARRAY() will change both result and the slot in op2. Looping over op2 and inserting the element results in both reference-less recursion which we don't allow, and increasing the refcount to 2, failing any further insertions into the array.

Avoid this by copying result into a temporary zval and performing separation there instead.

Fixes GH-10085