### PR TITLE
proc_open: ensure command_str is not interpreted as a shell option

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1242,9 +1242,9 @@ PHP_FUNCTION(proc_open)
 			execvp(ZSTR_VAL(command_str), argv);
 		} else {
 			if (env.envarray) {
-				execle("/bin/sh", "sh", "-c", ZSTR_VAL(command_str), NULL, env.envarray);
+				execle("/bin/sh", "sh", "-c", "--", ZSTR_VAL(command_str), NULL, env.envarray);
 			} else {
-				execl("/bin/sh", "sh", "-c", ZSTR_VAL(command_str), NULL);
+				execl("/bin/sh", "sh", "-c", "--", ZSTR_VAL(command_str), NULL);
 			}
 		}
 


### PR DESCRIPTION
avoid failure if via shell and command_str starts with + or - (both valid in command names)

This behaviour is mandatory in upcoming posix revisions too. (affects popen(3)  therefore php popen too)