### PR TITLE
Fix GH-10983: State-dependant segfault in ReflectionObject::getProperties

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -4686,7 +4686,7 @@ ZEND_METHOD(ReflectionClass, getProperties)
 	if (Z_TYPE(intern->obj) != IS_UNDEF && (filter & ZEND_ACC_PUBLIC) != 0) {
 		HashTable *properties = Z_OBJ_HT(intern->obj)->get_properties(Z_OBJ(intern->obj));
 		zval *prop;
-		ZEND_HASH_MAP_FOREACH_STR_KEY_VAL(properties, key, prop) {
+		ZEND_HASH_FOREACH_STR_KEY_VAL(properties, key, prop) {
 			_adddynproperty(prop, key, ce, return_value);
 		} ZEND_HASH_FOREACH_END();
 	}

--- a/ext/simplexml/tests/gh10983.phpt
+++ b/ext/simplexml/tests/gh10983.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-10983 (State-dependant segfault in ReflectionObject::getProperties)
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+
+$xml = <<<XML
+<form name="test"></form>
+XML;
+
+$simplexml = simplexml_load_string($xml);
+
+var_dump($simplexml['name']);
+$reflector = new ReflectionObject($simplexml['name']);
+$rprops = $reflector->getProperties();
+
+?>
+--EXPECT--
+object(SimpleXMLElement)#2 (1) {
+  [0]=>
+  string(4) "test"
+}


### PR DESCRIPTION
This is a variant of GH-10200, but in a different place. Basically, simplexml may create a properties table that's packed instead of associative. But the macro that was used to loop over the properties table assumed that it was always associative. Replace it by the macro that figures it out automatically which one of the two it is.

Test was co-authored-by: jnvsor

(Note to self: add co-authored-by tag for test during merge!)