### PR TITLE
[Zend]: Fix unnecessary alignment in ZEND_CALL_FRAME_SLOT macro

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -606,8 +606,12 @@ struct _zend_execute_data {
 #define ZEND_CALL_NUM_ARGS(call) \
 	(call)->This.u2.num_args
 
+/* Ensure the correct alignment before slots calculation */
+ZEND_STATIC_ASSERT(ZEND_MM_ALIGNED_SIZE(sizeof(zval)) == sizeof(zval),
+                   "zval must be aligned by ZEND_MM_ALIGNMENT");\
+/* A number of call frame slots (zvals) reserved for zend_execute_data. */
 #define ZEND_CALL_FRAME_SLOT \
-	((int)((ZEND_MM_ALIGNED_SIZE(sizeof(zend_execute_data)) + ZEND_MM_ALIGNED_SIZE(sizeof(zval)) - 1) / ZEND_MM_ALIGNED_SIZE(sizeof(zval))))
+	((int)((sizeof(zend_execute_data) + sizeof(zval) - 1) / sizeof(zval)))
 
 #define ZEND_CALL_VAR(call, n) \
 	((zval*)(((char*)(call)) + ((int)(n))))

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -608,7 +608,7 @@ struct _zend_execute_data {
 
 /* Ensure the correct alignment before slots calculation */
 ZEND_STATIC_ASSERT(ZEND_MM_ALIGNED_SIZE(sizeof(zval)) == sizeof(zval),
-                   "zval must be aligned by ZEND_MM_ALIGNMENT");\
+                   "zval must be aligned by ZEND_MM_ALIGNMENT");
 /* A number of call frame slots (zvals) reserved for zend_execute_data. */
 #define ZEND_CALL_FRAME_SLOT \
 	((int)((sizeof(zend_execute_data) + sizeof(zval) - 1) / sizeof(zval)))

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -195,8 +195,12 @@ struct _zend_vm_stack {
 	zend_vm_stack prev;
 };
 
+/* Ensure the correct alignment before slots calculation */
+ZEND_STATIC_ASSERT(ZEND_MM_ALIGNED_SIZE(sizeof(zval)) == sizeof(zval),
+                   "zval must be aligned by ZEND_MM_ALIGNMENT");
+/* A number of call frame slots (zvals) reserved for _zend_vm_stack. */
 #define ZEND_VM_STACK_HEADER_SLOTS \
-	((ZEND_MM_ALIGNED_SIZE(sizeof(struct _zend_vm_stack)) + ZEND_MM_ALIGNED_SIZE(sizeof(zval)) - 1) / ZEND_MM_ALIGNED_SIZE(sizeof(zval)))
+	((sizeof(struct _zend_vm_stack) + sizeof(zval) - 1) / sizeof(zval))
 
 #define ZEND_VM_STACK_ELEMENTS(stack) \
 	(((zval*)(stack)) + ZEND_VM_STACK_HEADER_SLOTS)

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -750,4 +750,10 @@ extern "C++" {
 # define ZEND_CGG_DIAGNOSTIC_IGNORED_END
 #endif
 
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */
+# define ZEND_STATIC_ASSERT(c, m) _Static_assert((c), m)
+#else
+# define ZEND_STATIC_ASSERT(c, m)
+#endif
+
 #endif /* ZEND_PORTABILITY_H */


### PR DESCRIPTION
I spent almost one hour trying to understand the purpose of alignment while calculating ZEND_CALL_FRAME_SLOT and finally found that it might not be necessary. Here is my arguments:
1) ZEND_MM_ALIGNED_SIZE(sizeof(zval)) cleans the last 3 bits of
   sizeof(zval) and actually makes it smaller.
   If sizeof(zval) < 8, there will be a divied by zero error.

2) Aligning of the result of sizeof() opration is logically hard to
   understand and does not make sense for code beginners like me.
   (address can be aligned, but size should not.)

Why we have not got trouble so far?
Because sizeof(zend_execute_data) is 80 and sizeof(zval) is 16 in current code. Therefore, Alignment operations take no effect. If size changed in future, we might get logic trouble.

This patch cleans this macro and makes it logically correct and code beginner friendly.