### PR TITLE
Fix GH-10990: mail() throws TypeError after iterating over $additional_headers array by reference

### DIFF
--- a/ext/standard/mail.c
+++ b/ext/standard/mail.c
@@ -136,6 +136,7 @@ static void php_mail_build_headers_elems(smart_str *s, zend_string *key, zval *v
 			zend_type_error("Header \"%s\" must only contain numeric keys, \"%s\" found", ZSTR_VAL(key), ZSTR_VAL(tmp_key));
 			break;
 		}
+		ZVAL_DEREF(tmp_val);
 		if (Z_TYPE_P(tmp_val) != IS_STRING) {
 			zend_type_error("Header \"%s\" must only contain values of type string, %s found", ZSTR_VAL(key), zend_zval_type_name(tmp_val));
 			break;
@@ -157,6 +158,7 @@ PHPAPI zend_string *php_mail_build_headers(HashTable *headers)
 			zend_type_error("Header name cannot be numeric, " ZEND_LONG_FMT " given", idx);
 			break;
 		}
+		ZVAL_DEREF(val);
 		/* https://tools.ietf.org/html/rfc2822#section-3.6 */
 		if (zend_string_equals_literal_ci(key, "orig-date")) {
 			PHP_MAIL_BUILD_HEADER_CHECK("orig-date", s, key, val);

--- a/ext/standard/tests/mail/gh10990.phpt
+++ b/ext/standard/tests/mail/gh10990.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-10990 (mail() throws TypeError after iterating over $additional_headers array by reference)
+--INI--
+sendmail_path=rubbish 2>/dev/null
+--SKIPIF--
+<?php
+if(substr(PHP_OS, 0, 3) == "WIN")
+  die("skip Won't run on Windows");
+?>
+--FILE--
+<?php
+$from = 'test@example.com';
+$headers = ['From' => &$from];
+var_dump(mail('test@example.com', 'Test', 'Test', $headers));
+?>
+--EXPECT--
+bool(false)


### PR DESCRIPTION
We should dereference the values, otherwise references don't work.

The error message was also quite confusing tbh, because it doesn't mention anything about references.