### PR TITLE
Add ASAN XLEAK support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,8 +40,6 @@ jobs:
       matrix:
         include:
           - debug: true
-            zts: false
-          - debug: false
             zts: true
     name: "LINUX_X64_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
     runs-on: ubuntu-22.04
@@ -68,6 +66,9 @@ jobs:
           configurationParameters: >-
             --${{ matrix.debug && 'enable' || 'disable' }}-debug
             --${{ matrix.zts && 'enable' || 'disable' }}-zts
+            --enable-address-sanitizer
+            --enable-undefined-sanitizer
+            CFLAGS="-DZEND_TRACK_ARENA_ALLOC"
       - name: make
         run: make -j$(/usr/bin/nproc) >/dev/null
       - name: make install
@@ -78,6 +79,7 @@ jobs:
         uses: ./.github/actions/test-linux
         with:
           testArtifacts: ${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}
+          runTestsParameters: --asan
       - name: Test Tracing JIT
         uses: ./.github/actions/test-linux
         with:
@@ -86,6 +88,7 @@ jobs:
             -d zend_extension=opcache.so
             -d opcache.enable_cli=1
             -d opcache.jit_buffer_size=16M
+            --asan
       - name: Verify generated files are up to date
         uses: ./.github/actions/verify-generated-files
   LINUX_X32:

--- a/ext/enchant/tests/dict_quick_check.phpt
+++ b/ext/enchant/tests/dict_quick_check.phpt
@@ -6,7 +6,7 @@ marcosptf - <marcosptf@yahoo.com.br>
 enchant
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('skip Known libenchant memory leak');
+if (getenv('SKIP_ASAN')) die('xleak Known libenchant memory leak');
 if (!is_object(enchant_broker_init())) {die("skip, resource dont load\n");}
 if (!is_array(enchant_broker_list_dicts(enchant_broker_init()))) {die("skip, no dictionary installed on this machine! \n");}
 

--- a/ext/ffi/tests/bug79576.phpt
+++ b/ext/ffi/tests/bug79576.phpt
@@ -4,7 +4,7 @@ Bug #79576 ("TYPE *" shows unhelpful message when type is not defined)
 ffi
 --SKIPIF--
 <?php
-if (PHP_DEBUG || getenv('SKIP_ASAN')) echo "xfail: FFI cleanup after parser error is nor implemented";
+if (PHP_DEBUG || getenv('SKIP_ASAN')) echo "xleak FFI cleanup after parser error is nor implemented";
 ?>
 --FILE--
 <?php

--- a/ext/imap/tests/imap_getsubscribed_basic.phpt
+++ b/ext/imap/tests/imap_getsubscribed_basic.phpt
@@ -7,7 +7,7 @@ imap
 --SKIPIF--
 <?php
 require_once(__DIR__.'/setup/skipif.inc');
-if (getenv("SKIP_ASAN")) die("skip asan chokes on this: 'LeakSanitizer does not work under ptrace (strace, gdb, etc)'");
+if (getenv("SKIP_ASAN")) die("xleak asan chokes on this: 'LeakSanitizer does not work under ptrace (strace, gdb, etc)'");
 ?>
 --CONFLICTS--
 defaultmailbox

--- a/ext/imap/tests/imap_lsub_basic.phpt
+++ b/ext/imap/tests/imap_lsub_basic.phpt
@@ -7,7 +7,7 @@ imap
 --SKIPIF--
 <?php
 require_once(__DIR__.'/setup/skipif.inc');
-if (getenv("SKIP_ASAN")) die("skip leak sanitizer crashes");
+if (getenv("SKIP_ASAN")) die("xleak leak sanitizer crashes");
 ?>
 --CONFLICTS--
 defaultmailbox

--- a/ext/imap/tests/imap_open_error.phpt
+++ b/ext/imap/tests/imap_open_error.phpt
@@ -8,7 +8,7 @@ imap
 --SKIPIF--
 <?php
 require_once(__DIR__.'/setup/skipif.inc');
-if (getenv("SKIP_ASAN")) die("skip leak sanitizer crashes");
+if (getenv("SKIP_ASAN")) die("xleak leak sanitizer crashes");
 ?>
 --FILE--
 <?php

--- a/ext/oci8/tests/privileged_connect1.phpt
+++ b/ext/oci8/tests/privileged_connect1.phpt
@@ -4,7 +4,7 @@ privileged connect tests
 oci8
 --SKIPIF--
 <?php 
-if (getenv('SKIP_ASAN')) die('skip leaks memory under asan');
+if (getenv('SKIP_ASAN')) die('xleak leaks memory under asan');
 ?>
 --INI--
 oci8.privileged_connect=1

--- a/ext/opcache/tests/gh9259_003.phpt
+++ b/ext/opcache/tests/gh9259_003.phpt
@@ -4,7 +4,7 @@ Bug GH-9259 003 (Setting opcache.interned_strings_buffer to a very high value le
 opcache
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('xfail Leaks memory with ASAN');
+if (getenv('SKIP_ASAN')) die('xleak Leaks memory with ASAN');
 ?>
 --INI--
 opcache.interned_strings_buffer=500

--- a/ext/opcache/tests/log_verbosity_bug.phpt
+++ b/ext/opcache/tests/log_verbosity_bug.phpt
@@ -14,7 +14,7 @@ opcache.log_verbosity_level=-1
 opcache
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('xfail Startup failure leak');
+if (getenv('SKIP_ASAN')) die('xleak Startup failure leak');
 ?>
 --FILE--
 <?php

--- a/ext/opcache/tests/preload_006.phpt
+++ b/ext/opcache/tests/preload_006.phpt
@@ -10,7 +10,7 @@ opcache
 --SKIPIF--
 <?php
 if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
-if (getenv('SKIP_ASAN')) die('xfail Startup failure leak');
+if (getenv('SKIP_ASAN')) die('xleak Startup failure leak');
 ?>
 --FILE--
 <?php

--- a/ext/opcache/tests/preload_parse_error.phpt
+++ b/ext/opcache/tests/preload_parse_error.phpt
@@ -10,7 +10,7 @@ opcache
 --SKIPIF--
 <?php
 if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
-if (getenv('SKIP_ASAN')) die('xfail Startup failure leak');
+if (getenv('SKIP_ASAN')) die('xleak Startup failure leak');
 ?>
 --FILE--
 OK

--- a/ext/pdo_oci/tests/pecl_bug_6364.phpt
+++ b/ext/pdo_oci/tests/pecl_bug_6364.phpt
@@ -5,7 +5,7 @@ pdo
 pdo_oci
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('skip leaks memory under asan');
+if (getenv('SKIP_ASAN')) die('xleak leaks memory under asan');
 require(__DIR__.'/../../pdo/tests/pdo_test.inc');
 PDOTest::skip();
 ?>

--- a/ext/posix/tests/posix_getgrgid_error.phpt
+++ b/ext/posix/tests/posix_getgrgid_error.phpt
@@ -4,7 +4,7 @@ Test posix_getgrgid() function : error conditions
 posix
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('skip LSan crashes when firebird is loaded');
+if (getenv('SKIP_ASAN')) die('xleak LSan crashes when firebird is loaded');
 ?>
 --FILE--
 <?php

--- a/ext/posix/tests/posix_getpwuid_error.phpt
+++ b/ext/posix/tests/posix_getpwuid_error.phpt
@@ -4,7 +4,7 @@ Test posix_getpwuid() function : error conditions
 posix
 --SKIPIF--
 <?php
-if (getenv('SKIP_ASAN')) die('skip LSan crashes when firebird is loaded');
+if (getenv('SKIP_ASAN')) die('xleak LSan crashes when firebird is loaded');
 ?>
 --FILE--
 <?php

--- a/ext/pspell/tests/005.phpt
+++ b/ext/pspell/tests/005.phpt
@@ -5,7 +5,7 @@ pspell
 --SKIPIF--
 <?php
 if (!@pspell_new('en')) die('skip English dictionary is not available');
-if (getenv('SKIP_ASAN')) die('skip pspell leaks memory for invalid dicationaries');
+if (getenv('SKIP_ASAN')) die('xleak pspell leaks memory for invalid dicationaries');
 ?>
 --FILE--
 <?php

--- a/ext/standard/tests/general_functions/get_cfg_var_variation8.phpt
+++ b/ext/standard/tests/general_functions/get_cfg_var_variation8.phpt
@@ -6,7 +6,7 @@ Francesco Fullone ff@ideato.it
 --INI--
 magic_quotes_gpc=1
 --SKIPIF--
-<?php if (getenv('SKIP_ASAN')) die('xfail Startup failure leak'); ?>
+<?php if (getenv('SKIP_ASAN')) die('xleak Startup failure leak'); ?>
 --FILE--
 <?php
 echo "*** Test by calling method or function with deprecated option ***\n";

--- a/ext/standard/tests/streams/bug46024.phpt
+++ b/ext/standard/tests/streams/bug46024.phpt
@@ -5,7 +5,7 @@ Bug #46024 stream_select() doesn't return the correct number
 if (!getenv('TEST_PHP_EXECUTABLE_ESCAPED')) die("skip TEST_PHP_EXECUTABLE_ESCAPED not defined");
 // Terminating the process may cause a bailout while writing out the phpinfo,
 // which may leak a temporary hash table. This does not seems worth fixing.
-if (getenv('SKIP_ASAN')) die("skip Test may leak");
+if (getenv('SKIP_ASAN')) die("xleak Test may leak");
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Only disable LSAN instead of skipping the test. This way we can still detect memory issues which is arguably more important anyway.