### PR TITLE
PoC: Allow catching "Non-abstract method must contain body" compile errors

### DIFF
--- a/Zend/tests/gh9333_1.phpt
+++ b/Zend/tests/gh9333_1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-9333: Allow catching "Non-abstract method must contain body" compile error
+--FILE--
+<?php
+try {
+    eval('
+    class Valid { function foo() {} }
+    class Invalid { function foo(); }
+    ');
+} catch (Throwable $e) {
+    echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+echo (new ReflectionClass(Valid::class))->getName(), "\n";
+try {
+    echo (new ReflectionClass(Invalid::class))->getName(), "\n";
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+CompileError: Non-abstract method Invalid::foo() must contain body
+Valid
+Class "Invalid" does not exist

--- a/Zend/tests/gh9333_2.phpt
+++ b/Zend/tests/gh9333_2.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-9333: Catchable compile error shouldn't leak memory
+--FILE--
+<?php
+
+for ($i = 1; $i <= 1000; $i++) {
+    // First iterations may allocate unrelated memory
+    if ($i === 10) {
+        $start = memory_get_usage();
+    }
+
+    try {
+        eval('class Invalid { function foo(); }');
+    } catch (Throwable) {}
+}
+var_dump(memory_get_usage() - $start);
+?>
+--EXPECT--
+int(0)

--- a/Zend/tests/gh9333_3.inc
+++ b/Zend/tests/gh9333_3.inc
@@ -1,0 +1,3 @@
+<?php
+class Valid { function foo() {} }
+class Invalid { function foo(); }

--- a/Zend/tests/gh9333_3.phpt
+++ b/Zend/tests/gh9333_3.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-9333: Allow catching "Non-abstract method must contain body" compile error
+--FILE--
+<?php
+try {
+    include __DIR__ . '/gh9333_3.inc';
+} catch (Throwable $e) {
+    echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+echo (new ReflectionClass(Valid::class))->getName(), "\n";
+try {
+    echo (new ReflectionClass(Invalid::class))->getName(), "\n";
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+CompileError: Non-abstract method Invalid::foo() must contain body
+Valid
+Class "Invalid" does not exist

--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1835,7 +1835,7 @@ static zend_persistent_script *opcache_compile_file(zend_file_handle *file_handl
 	EG(user_error_handler) = orig_user_error_handler;
 	EG(record_errors) = 0;
 
-	if (!op_array) {
+	if (!op_array || EG(exception)) {
 		/* compilation failed */
 		zend_free_recorded_errors();
 		if (do_bailout) {


### PR DESCRIPTION
 PoC: Allow catching "Non-abstract method must contain body" compile errors
  
Caveat main caveat in this PoC is that symbols declared before the failing symbols will remain declared. This means that an eval may not actually be repeated as it will fail due to redeclaration errors.

Fixes GH-9333

I'm not sure if this is actually a good idea due to the caveat mentioned above. Future changes might also leak or lead to uninitialized memory more easily. I wanted to created this PR nonetheless to gather some feedback.