### PR TITLE
Add zend_alloc XLEAK support

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -2290,7 +2290,10 @@ void zend_mm_shutdown(zend_mm_heap *heap, bool full, bool silent)
 
 #if ZEND_DEBUG
 	if (!silent) {
-		zend_mm_check_leaks(heap);
+		char *tmp = getenv("ZEND_ALLOC_PRINT_LEAKS");
+		if (!tmp || ZEND_ATOL(tmp)) {
+			zend_mm_check_leaks(heap);
+		}
 	}
 #endif
 

--- a/ext/gettext/tests/bug53251.phpt
+++ b/ext/gettext/tests/bug53251.phpt
@@ -4,7 +4,7 @@ Bug #53251 (bindtextdomain with null dir doesn't return old value)
 gettext
 --SKIPIF--
 <?php
-if (getenv('SKIP_REPEAT')) die('skip gettext leaks global state across requests');
+if (getenv('SKIP_REPEAT')) die('xleak gettext leaks global state across requests');
 ?>
 --FILE--
 <?php

--- a/ext/pcntl/tests/bug81577_3.phpt
+++ b/ext/pcntl/tests/bug81577_3.phpt
@@ -3,7 +3,7 @@ Bug #81577: (Exceptions in interrupt handlers: cleanup_live_vars)
 --EXTENSIONS--
 pcntl
 posix
---XFAIL--
+--XLEAK--
 leaks are not fixed yet
 --FILE--
 <?php

--- a/run-tests.php
+++ b/run-tests.php
@@ -2464,8 +2464,11 @@ TEST $file
         $cmd = $valgrind->wrapCommand($cmd, $memcheck_filename, strpos($test_file, "pcre") !== false);
     }
 
-    if ($test->hasSection('XLEAK') && isset($env['SKIP_ASAN'])) {
-        $env['LSAN_OPTIONS'] = 'detect_leaks=0';
+    if ($test->hasSection('XLEAK')) {
+        $env['ZEND_ALLOC_PRINT_LEAKS'] = '0';
+        if (isset($env['SKIP_ASAN'])) {
+            $env['LSAN_OPTIONS'] = 'detect_leaks=0';
+        }
     }
 
     if ($DETAILED) {
@@ -2664,7 +2667,7 @@ COMMAND $cmd
             if ($test->hasSection('XFAIL')) {
                 $warn = true;
                 $info = " (warn: XFAIL section but test passes)";
-            } elseif ($test->hasSection('XLEAK') && !isset($env['SKIP_ASAN'])) {
+            } elseif ($test->hasSection('XLEAK') && $valgrind) {
                 // XLEAK with ASAN completely disables LSAN so the test is expected to pass
                 $warn = true;
                 $info = " (warn: XLEAK section but test passes)";
@@ -2702,7 +2705,7 @@ COMMAND $cmd
         if ($test->hasSection('XFAIL')) {
             $restype[] = 'XFAIL';
             $info = '  XFAIL REASON: ' . rtrim($test->getSection('XFAIL'));
-        } elseif ($test->hasSection('XLEAK') && !isset($env['SKIP_ASAN'])) {
+        } elseif ($test->hasSection('XLEAK') && $valgrind) {
             // XLEAK with ASAN completely disables LSAN so the test is expected to pass
             $restype[] = 'XLEAK';
             $info = '  XLEAK REASON: ' . rtrim($test->getSection('XLEAK'));


### PR DESCRIPTION
In the future we may want to use a different exit code to warn for tests that didn't leak.