### PR TITLE
ext/openssl: pass ini options to extra processes in tests

### DIFF
--- a/ext/openssl/tests/ServerClientTestCase.inc
+++ b/ext/openssl/tests/ServerClientTestCase.inc
@@ -72,8 +72,9 @@ class ServerClientTestCase
             );
         } else {
             $cmd = sprintf(
-                '%s "%s" %s %s',
+                '%s %s "%s" %s %s',
                 PHP_BINARY,
+                getenv('TEST_PHP_EXTRA_ARGS'),
                 __FILE__,
                 WORKER_ARGV_VALUE,
                 $worker


### PR DESCRIPTION
If openssl is build as a shared extension (`--with-openssl=shared`), many tests from **ext/openssl** will fail since they spawn new processes without passing `-d extension=openssl`. This PR fixes them by passing the ini options from `TEST_PHP_EXTRA_ARGS`.

This PR fixes the following tests when `with-openssl=shared`:
```
#46127 php_openssl_tcp_sockop_accept forgets to set context on accepted stream [ext/openssl/tests/bug46127.phpt]
Bug #48182: ssl handshake fails during asynchronous socket connection [ext/openssl/tests/bug48182.phpt]
Bug #54992: Stream not closed and error not returned when SSL CN_match fails [ext/openssl/tests/bug54992.phpt]
Bug #62890 (default_socket_timeout=-1 causes connection to timeout) [ext/openssl/tests/bug62890.phpt]
Bug #65538: SSL context "cafile" supports stream wrappers [ext/openssl/tests/bug65538_001.phpt]
Bug #65538: SSL context "cafile" supports phar wrapper [ext/openssl/tests/bug65538_003.phpt]
Bug #65729: CN_match gives false positive when wildcard is used [ext/openssl/tests/bug65729.phpt]
Bug #68265: SAN match fails with trailing DNS dot [ext/openssl/tests/bug68265.phpt]
Bug #68879: Match IP address fields in subjectAltName checks [ext/openssl/tests/bug68879.phpt]
Bug #68920: peer_fingerprint input checks should be strict [ext/openssl/tests/bug68920.phpt]
Bug #69215: Crypto servers should send client CA list [ext/openssl/tests/bug69215.phpt]
Bug #72333: fwrite() on non-blocking SSL sockets doesn't work [ext/openssl/tests/bug72333.phpt]
Bug #73072: Invalid path SNI_server_certs causes segfault [ext/openssl/tests/bug73072.phpt]
Bug #74159: Writing a large buffer to non-blocking encrypted streams fails [ext/openssl/tests/bug74159.phpt]
Bug #76705: unusable ssl => peer_fingerprint in stream_context_create() [ext/openssl/tests/bug76705.phpt]
Bug #76705: feof might hang on TLS streams in case of fragmented TLS records [ext/openssl/tests/bug77390.phpt]
capture_peer_cert context captures on verify failure [ext/openssl/tests/capture_peer_cert_001.phpt]
GH-9310: local_cert and local_pk do not respect open_basedir restriction [ext/openssl/tests/gh9310.phpt]
Testing peer fingerprint on connection [ext/openssl/tests/openssl_peer_fingerprint_basic.phpt]
Peer verification enabled for client streams [ext/openssl/tests/peer_verification.phpt]
Peer verification matches SAN names [ext/openssl/tests/san_peer_matching.phpt]
Capture SSL session meta array in stream context [ext/openssl/tests/session_meta_capture.phpt]
Capture SSL session meta array in stream context for TLSv1.3 [ext/openssl/tests/session_meta_capture_tlsv13.phpt]
sni_server [ext/openssl/tests/sni_server.phpt]
sni_server with separate pk and cert [ext/openssl/tests/sni_server_key_cert.phpt]
Basic bitwise stream crypto context flag assignment [ext/openssl/tests/stream_crypto_flags_001.phpt]
TLSv1.1 and TLSv1.2 bitwise stream crypto flag assignment [ext/openssl/tests/stream_crypto_flags_002.phpt]
Server bitwise stream crypto flag assignment [ext/openssl/tests/stream_crypto_flags_003.phpt]
Specific protocol method specification [ext/openssl/tests/stream_crypto_flags_004.phpt]
security_level setting to prohibit cert [ext/openssl/tests/stream_security_level.phpt]
Verify host name by default in client transfers [ext/openssl/tests/stream_verify_peer_name_001.phpt]
Allow host name mismatch when "verify_host" disabled [ext/openssl/tests/stream_verify_peer_name_002.phpt]
Host name mismatch triggers error [ext/openssl/tests/stream_verify_peer_name_003.phpt]
Specific crypto method for ssl:// transports. [ext/openssl/tests/streams_crypto_method.phpt]
tls stream wrapper with min version 1.0 and max version 1.1 [ext/openssl/tests/tls_min_v1.0_max_v1.1_wrapper.phpt]
tls stream wrapper [ext/openssl/tests/tls_wrapper.phpt]
tls stream wrapper when TLS 1.3 available [ext/openssl/tests/tls_wrapper_with_tls_v1.3.phpt]
tlsv1.0 stream wrapper [ext/openssl/tests/tlsv1.0_wrapper.phpt]
tlsv1.1 stream wrapper [ext/openssl/tests/tlsv1.1_wrapper.phpt]
tlsv1.2 stream wrapper [ext/openssl/tests/tlsv1.2_wrapper.phpt]
tlsv1.3 stream wrapper [ext/openssl/tests/tlsv1.3_wrapper.phpt]

```

A similar issue also happens to some tests from soap or readline extensions, and other extensions may also be affected. We decided to discuss the issue with openssl first and depending on the outcome we can potentially propose the fixes for other extensions/tests.