### PR TITLE
Cleanup pubkey checks in ext/phar

### DIFF
--- a/ext/phar/util.c
+++ b/ext/phar/util.c
@@ -1539,10 +1539,8 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t sig_type,
 #ifndef PHAR_HAVE_OPENSSL
 			tempsig = sig_len;
 
-			if (FAILURE == phar_call_openssl_signverify(0, fp, end_of_phar, pubkey ? ZSTR_VAL(pubkey) : NULL, pubkey ? ZSTR_LEN(pubkey) : 0, &sig, &tempsig, sig_type)) {
-				if (pubkey) {
-					zend_string_release_ex(pubkey, 0);
-				}
+			if (FAILURE == phar_call_openssl_signverify(0, fp, end_of_phar, ZSTR_VAL(pubkey), ZSTR_LEN(pubkey), &sig, &tempsig, sig_type)) {
+				zend_string_release_ex(pubkey, 0);
 
 				if (error) {
 					spprintf(error, 0, "openssl signature could not be verified");
@@ -1551,13 +1549,11 @@ int phar_verify_signature(php_stream *fp, size_t end_of_phar, uint32_t sig_type,
 				return FAILURE;
 			}
 
-			if (pubkey) {
-				zend_string_release_ex(pubkey, 0);
-			}
+			zend_string_release_ex(pubkey, 0);
 
 			sig_len = tempsig;
 #else
-			in = BIO_new_mem_buf(pubkey ? ZSTR_VAL(pubkey) : NULL, pubkey ? ZSTR_LEN(pubkey) : 0);
+			in = BIO_new_mem_buf(ZSTR_VAL(pubkey), ZSTR_LEN(pubkey));
 
 			if (NULL == in) {
 				zend_string_release_ex(pubkey, 0);


### PR DESCRIPTION
These checks are always true because we bail out early if pubkey is NULL or empty.
But by having these checks, it makes the code more confusing because it implies pubkey can be false, while it can in fact not.