### PR TITLE
Add ngx-php to opcache supported sapis

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2828,6 +2828,7 @@ static inline zend_result accel_find_sapi(void)
 		"uwsgi",
 		"fuzzer",
 		"frankenphp",
+		"ngx-php",
 		NULL
 	};
 	const char **sapi_name;


### PR DESCRIPTION
Now we are using the cli-server.
But it's time to use our name in the SAPI.

This SAPI embed PHP in Nginx server.
https://github.com/rryqszq4/ngx-php

And in the Techempower benchmarks, it's the fastest PHP SAPI. https://www.techempower.com/benchmarks/#section=data-r20

Thank you.