### PR TITLE
Support enums in array_unique

### DIFF
--- a/Zend/tests/gh9775.phpt
+++ b/Zend/tests/gh9775.phpt
@@ -1,0 +1,54 @@
+--TEST--
+GH-9775: Enum in array_unique()
+--FILE--
+<?php
+
+enum Test: string
+{
+    case AUTHENTICATED = 'authenticated';
+    case COURSES_ADMIN = 'courses.admin';
+    case BUNDLES_ADMIN = 'bundles.admin';
+    case COURSES_REPORTING_ACCESS = 'courses-reporting.access';
+    case B2B_DASHBOARD_ACCESS = 'b2b-dashboard.access';
+    case INSTRUCTORS_ADMIN = 'instructors.admin';
+    case USERS_ADMIN = 'users.admin';
+    case COUPONS_ADMIN = 'coupons.admin';
+}
+
+$data = [
+    Test::COURSES_ADMIN,
+    Test::COURSES_REPORTING_ACCESS,
+    Test::BUNDLES_ADMIN,
+    Test::USERS_ADMIN,
+    Test::B2B_DASHBOARD_ACCESS,
+    Test::B2B_DASHBOARD_ACCESS,
+    Test::INSTRUCTORS_ADMIN,
+    Test::INSTRUCTORS_ADMIN,
+    Test::COUPONS_ADMIN,
+    Test::AUTHENTICATED,
+];
+
+$data = array_unique($data, flags: SORT_REGULAR);
+
+var_dump($data);
+
+?>
+--EXPECT--
+array(8) {
+  [0]=>
+  enum(Test::COURSES_ADMIN)
+  [1]=>
+  enum(Test::COURSES_REPORTING_ACCESS)
+  [2]=>
+  enum(Test::BUNDLES_ADMIN)
+  [3]=>
+  enum(Test::USERS_ADMIN)
+  [4]=>
+  enum(Test::B2B_DASHBOARD_ACCESS)
+  [6]=>
+  enum(Test::INSTRUCTORS_ADMIN)
+  [8]=>
+  enum(Test::COUPONS_ADMIN)
+  [9]=>
+  enum(Test::AUTHENTICATED)
+}

--- a/Zend/tests/gh9775_1.phpt
+++ b/Zend/tests/gh9775_1.phpt
@@ -1,0 +1,56 @@
+--TEST--
+GH-9775: Backed enum in array_unique()
+--FILE--
+<?php
+
+enum Test: string
+{
+    case AUTHENTICATED = 'authenticated';
+    case COURSES_ADMIN = 'courses.admin';
+    case BUNDLES_ADMIN = 'bundles.admin';
+    case COURSES_REPORTING_ACCESS = 'courses-reporting.access';
+    case B2B_DASHBOARD_ACCESS = 'b2b-dashboard.access';
+    case INSTRUCTORS_ADMIN = 'instructors.admin';
+    case USERS_ADMIN = 'users.admin';
+    case COUPONS_ADMIN = 'coupons.admin';
+}
+
+$instructorsAdmin = Test::INSTRUCTORS_ADMIN;
+
+$data = [
+    Test::COURSES_ADMIN,
+    Test::COURSES_REPORTING_ACCESS,
+    Test::BUNDLES_ADMIN,
+    Test::USERS_ADMIN,
+    Test::B2B_DASHBOARD_ACCESS,
+    Test::B2B_DASHBOARD_ACCESS,
+    Test::INSTRUCTORS_ADMIN,
+    &$instructorsAdmin,
+    Test::COUPONS_ADMIN,
+    Test::AUTHENTICATED,
+];
+
+$data = array_unique($data, flags: SORT_REGULAR);
+
+var_dump($data);
+
+?>
+--EXPECT--
+array(8) {
+  [0]=>
+  enum(Test::COURSES_ADMIN)
+  [1]=>
+  enum(Test::COURSES_REPORTING_ACCESS)
+  [2]=>
+  enum(Test::BUNDLES_ADMIN)
+  [3]=>
+  enum(Test::USERS_ADMIN)
+  [4]=>
+  enum(Test::B2B_DASHBOARD_ACCESS)
+  [6]=>
+  enum(Test::INSTRUCTORS_ADMIN)
+  [8]=>
+  enum(Test::COUPONS_ADMIN)
+  [9]=>
+  enum(Test::AUTHENTICATED)
+}

--- a/Zend/tests/gh9775_2.phpt
+++ b/Zend/tests/gh9775_2.phpt
@@ -1,19 +1,21 @@
 --TEST--
-GH-9775: Enum in array_unique()
+GH-9775: Pure enum in array_unique()
 --FILE--
 <?php
 
-enum Test: string
+enum Test
 {
-    case AUTHENTICATED = 'authenticated';
-    case COURSES_ADMIN = 'courses.admin';
-    case BUNDLES_ADMIN = 'bundles.admin';
-    case COURSES_REPORTING_ACCESS = 'courses-reporting.access';
-    case B2B_DASHBOARD_ACCESS = 'b2b-dashboard.access';
-    case INSTRUCTORS_ADMIN = 'instructors.admin';
-    case USERS_ADMIN = 'users.admin';
-    case COUPONS_ADMIN = 'coupons.admin';
+    case AUTHENTICATED;
+    case COURSES_ADMIN;
+    case BUNDLES_ADMIN;
+    case COURSES_REPORTING_ACCESS;
+    case B2B_DASHBOARD_ACCESS;
+    case INSTRUCTORS_ADMIN;
+    case USERS_ADMIN;
+    case COUPONS_ADMIN;
 }
+
+$instructorsAdmin = Test::INSTRUCTORS_ADMIN;
 
 $data = [
     Test::COURSES_ADMIN,
@@ -23,7 +25,7 @@ $data = [
     Test::B2B_DASHBOARD_ACCESS,
     Test::B2B_DASHBOARD_ACCESS,
     Test::INSTRUCTORS_ADMIN,
-    Test::INSTRUCTORS_ADMIN,
+    &$instructorsAdmin,
     Test::COUPONS_ADMIN,
     Test::AUTHENTICATED,
 ];

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -345,7 +345,24 @@ static zend_always_inline int php_array_key_compare_string_locale_unstable_i(Buc
 
 static zend_always_inline int php_array_data_compare_unstable_i(Bucket *f, Bucket *s) /* {{{ */
 {
-	return zend_compare(&f->val, &s->val);
+	int result = zend_compare(&f->val, &s->val);
+	// Special handling for enums
+	zval *rhs = &s->val;
+	if (UNEXPECTED(Z_TYPE_P(rhs) == IS_OBJECT)
+	 && result == ZEND_UNCOMPARABLE
+	 && (Z_OBJCE_P(rhs)->ce_flags & ZEND_ACC_ENUM)) {
+		zval *lhs = &f->val;
+		if (Z_TYPE_P(lhs) == IS_OBJECT && (Z_OBJCE_P(lhs)->ce_flags & ZEND_ACC_ENUM)) {
+			// Order doesn't matter, we just need to group the same enum values
+			uintptr_t lhs_uintptr = (uintptr_t)Z_OBJ_P(lhs);
+			uintptr_t rhs_uintptr = (uintptr_t)Z_OBJ_P(rhs);
+			return lhs_uintptr == rhs_uintptr ? 0 : (lhs_uintptr < rhs_uintptr ? -1 : 1);
+		} else {
+			// Shift enums to the end of the array
+			return -1;
+		}
+	}
+	return result;
 }
 /* }}} */
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -346,12 +346,15 @@ static zend_always_inline int php_array_key_compare_string_locale_unstable_i(Buc
 static zend_always_inline int php_array_data_compare_unstable_i(Bucket *f, Bucket *s) /* {{{ */
 {
 	int result = zend_compare(&f->val, &s->val);
-	// Special handling for enums
+	/* Special enums handling for array_unique. We don't want to add this logic to zend_compare as
+	 * that would be observable via comparison operators. */
 	zval *rhs = &s->val;
+	ZVAL_DEREF(rhs);
 	if (UNEXPECTED(Z_TYPE_P(rhs) == IS_OBJECT)
 	 && result == ZEND_UNCOMPARABLE
 	 && (Z_OBJCE_P(rhs)->ce_flags & ZEND_ACC_ENUM)) {
 		zval *lhs = &f->val;
+		ZVAL_DEREF(lhs);
 		if (Z_TYPE_P(lhs) == IS_OBJECT && (Z_OBJCE_P(lhs)->ce_flags & ZEND_ACC_ENUM)) {
 			// Order doesn't matter, we just need to group the same enum values
 			uintptr_t lhs_uintptr = (uintptr_t)Z_OBJ_P(lhs);


### PR DESCRIPTION
Fixes GH-9775

As suggested in https://github.com/php/php-src/issues/9775#issuecomment-1481151287.

I'm a little concerned about performance regression. Also, I think this is observable in `min`/`max`. These functions always return *something*, so it might as well return something that is consistent.