### PR TITLE
[Zend]: Remove unnecessary ZEND_DEBUG in zval_refcount_p

### DIFF
--- a/Zend/zend_types.h
+++ b/Zend/zend_types.h
@@ -1260,9 +1260,7 @@ static zend_always_inline uint32_t zend_gc_delref_ex(zend_refcounted_h *p, uint3
 }
 
 static zend_always_inline uint32_t zval_refcount_p(const zval* pz) {
-#if ZEND_DEBUG
 	ZEND_ASSERT(Z_REFCOUNTED_P(pz) || Z_TYPE_P(pz) == IS_ARRAY);
-#endif
 	return GC_REFCOUNT(Z_COUNTED_P(pz));
 }
 


### PR DESCRIPTION
Make zval_refcount_p function have the same ASSERT style as other similar functions like zval_set_refcount_p, zval_addref_p, etc.

If surrounded by ZEND_DEBUG, ZEND_ASSERT will disappear in product release.