### PR TITLE
Prevent unnecessary string duplication in assert()

### DIFF
--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -34,8 +34,6 @@ ZEND_DECLARE_MODULE_GLOBALS(assert)
 
 #define ASSERTG(v) ZEND_MODULE_GLOBALS_ACCESSOR(assert, v)
 
-#define SAFE_STRING(s) ((s)?(s):"")
-
 PHPAPI zend_class_entry *assertion_error_ce;
 
 static PHP_INI_MH(OnChangeCallback) /* {{{ */
@@ -151,9 +149,12 @@ PHP_FUNCTION(assert)
 		zval args[4];
 		zval retval;
 		uint32_t lineno = zend_get_executed_lineno();
-		const char *filename = zend_get_executed_filename();
+		zend_string *filename = zend_get_executed_filename_ex();
+		if (UNEXPECTED(!filename)) {
+			filename = ZSTR_KNOWN(ZEND_STR_UNKNOWN_CAPITALIZED);
+		}
 
-		ZVAL_STRING(&args[0], SAFE_STRING(filename));
+		ZVAL_STR(&args[0], filename);
 		ZVAL_LONG(&args[1], lineno);
 		ZVAL_NULL(&args[2]);
 

--- a/ext/standard/assert.c
+++ b/ext/standard/assert.c
@@ -167,7 +167,6 @@ PHP_FUNCTION(assert)
 			call_user_function(NULL, NULL, &ASSERTG(callback), &retval, 3, args);
 		}
 
-		zval_ptr_dtor(&args[0]);
 		zval_ptr_dtor(&retval);
 	}
 

--- a/ext/standard/tests/assert/assert_closures_multiple.phpt
+++ b/ext/standard/tests/assert/assert_closures_multiple.phpt
@@ -1,0 +1,35 @@
+--TEST--
+assert() asserting multiple with callback
+--INI--
+assert.active = 1
+assert.warning = 1
+assert.bail = 0
+assert.exception=1
+--FILE--
+<?php
+assert_options(ASSERT_CALLBACK, function ($f) {});
+try {
+    assert(false);
+} catch (Throwable) {}
+try {
+    assert(false);
+} catch (Throwable) {}
+try {
+    assert(false);
+} catch (Throwable) {}
+try {
+    assert(false);
+} catch (Throwable) {}
+try {
+    assert(false);
+} catch (Throwable) {}
+try {
+    assert(false);
+} catch (Throwable) {}
+try {
+    assert(false);
+} catch (Throwable) {}
+?>
+DONE
+--EXPECT--
+DONE


### PR DESCRIPTION
This prevents recomputing the length of the string that we already know and duplicating memory.