### PR TITLE
Add case insensitive versions of the zend_string_starts_with_* APIs

### DIFF
--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -411,6 +411,19 @@ static zend_always_inline bool zend_string_starts_with(const zend_string *str, c
 #define zend_string_starts_with_literal(str, prefix) \
 	zend_string_starts_with_cstr(str, prefix, strlen(prefix))
 
+static zend_always_inline bool zend_string_starts_with_cstr_ci(const zend_string *str, const char *prefix, size_t prefix_length)
+{
+	return ZSTR_LEN(str) >= prefix_length && !strncasecmp(ZSTR_VAL(str), prefix, prefix_length);
+}
+
+static zend_always_inline bool zend_string_starts_with_ci(const zend_string *str, const zend_string *prefix)
+{
+	return zend_string_starts_with_cstr_ci(str, ZSTR_VAL(prefix), ZSTR_LEN(prefix));
+}
+
+#define zend_string_starts_with_literal_ci(str, prefix) \
+	zend_string_starts_with_cstr(str, prefix, strlen(prefix))
+
 /*
  * DJBX33A (Daniel J. Bernstein, Times 33 with Addition)
  *


### PR DESCRIPTION
We have the case-sensitive ones, having the case-insensitive ones makes sense.

Found while staring at ext/phar and realizing that stream wrapper protocols are case-insensitive.