### PR TITLE
Move EG(exception) check outside the loop for unpacking

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -5186,14 +5186,13 @@ ZEND_VM_C_LABEL(send_again):
 			const zend_object_iterator_funcs *funcs = iter->funcs;
 			if (funcs->rewind) {
 				funcs->rewind(iter);
+				if (UNEXPECTED(EG(exception) != NULL)) {
+					ZEND_VM_C_GOTO(after_loop);
+				}
 			}
 
 			for (; funcs->valid(iter) == SUCCESS; ++arg_num) {
 				zval *arg, *top;
-
-				if (UNEXPECTED(EG(exception) != NULL)) {
-					break;
-				}
 
 				arg = funcs->get_current_data(iter);
 				if (UNEXPECTED(EG(exception) != NULL)) {
@@ -5277,6 +5276,7 @@ ZEND_VM_C_LABEL(send_again):
 				funcs->move_forward(iter);
 			}
 
+ZEND_VM_C_LABEL(after_loop):
 			zend_iterator_dtor(iter);
 		}
 	} else if (EXPECTED(Z_ISREF_P(args))) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -2324,14 +2324,13 @@ send_again:
 			const zend_object_iterator_funcs *funcs = iter->funcs;
 			if (funcs->rewind) {
 				funcs->rewind(iter);
+				if (UNEXPECTED(EG(exception) != NULL)) {
+					goto after_loop;
+				}
 			}
 
 			for (; funcs->valid(iter) == SUCCESS; ++arg_num) {
 				zval *arg, *top;
-
-				if (UNEXPECTED(EG(exception) != NULL)) {
-					break;
-				}
 
 				arg = funcs->get_current_data(iter);
 				if (UNEXPECTED(EG(exception) != NULL)) {
@@ -2415,6 +2414,7 @@ send_again:
 				funcs->move_forward(iter);
 			}
 
+after_loop:
 			zend_iterator_dtor(iter);
 		}
 	} else if (EXPECTED(Z_ISREF_P(args))) {


### PR DESCRIPTION
Right now there's an EG(exception) check inside the loop for the iterator object. As far as I know, funcs->valid(iter) will return FAILURE when an exception is set instead of success. That means that the exception check was not put there for funcs->valid. But it could be for funcs->rewind(iter), because if I look at other callers it looks like other callers do check for an exception after calling that function.
Move it outside the loop and inside the funcs->rewind case for better performance.
I think this is also more correct because funcs->valid(iter) probably shouldn't be called if the rewinding failed.