### PR TITLE
Fix FETCH_STATIC_PROP_W to prevent returning INDIRECT/UNDEF zval

### DIFF
--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1845,6 +1845,10 @@ ZEND_VM_HELPER(zend_fetch_static_prop_helper, ANY, ANY, int type)
 	if (type == BP_VAR_R || type == BP_VAR_IS) {
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), prop);
 	} else {
+		if (UNEXPECTED(Z_TYPE_P(prop) == IS_UNDEF) && !EG(exception)) {
+			/* uninitialized typed property */
+			ZVAL_NULL(prop);
+		}
 		ZVAL_INDIRECT(EX_VAR(opline->result.var), prop);
 	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -854,6 +854,10 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_fetch_static
 	if (type == BP_VAR_R || type == BP_VAR_IS) {
 		ZVAL_COPY_DEREF(EX_VAR(opline->result.var), prop);
 	} else {
+		if (UNEXPECTED(Z_TYPE_P(prop) == IS_UNDEF) && !EG(exception)) {
+			/* uninitialized typed property */
+			ZVAL_NULL(prop);
+		}
 		ZVAL_INDIRECT(EX_VAR(opline->result.var), prop);
 	}
 	ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();

--- a/ext/opcache/tests/jit/fetch_static_prop_001.phpt
+++ b/ext/opcache/tests/jit/fetch_static_prop_001.phpt
@@ -1,0 +1,20 @@
+--TEST--
+FETCH_STATIC_PROP_W should not return UNDEF
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+--FILE--
+<?php
+class F {
+    static array $a;
+}
+F::$a[] = 2;
+var_dump(F::$a);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(2)
+}


### PR DESCRIPTION
This behaviour repeats FETCH_OBJ_W behaviour introduced by the typed properties patch.