### PR TITLE
Fix unevaluated rhs of class constant fetch in constant expression

### DIFF
--- a/Zend/tests/oss_fuzz_57821.phpt
+++ b/Zend/tests/oss_fuzz_57821.phpt
@@ -1,0 +1,12 @@
+--TEST--
+oss-fuzz #57821: Unevaluated rhs of class constant fetch in constant expression
+--FILE--
+<?php
+class Foo {
+    const Foo = 'foo';
+}
+const C = Foo::{Foo::class};
+var_dump(C);
+?>
+--EXPECT--
+string(3) "foo"

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -10761,13 +10761,13 @@ static void zend_eval_const_expr(zend_ast **ast_ptr) /* {{{ */
 			zend_ast *name_ast;
 			zend_string *resolved_name;
 
+			zend_eval_const_expr(&ast->child[0]);
+			zend_eval_const_expr(&ast->child[1]);
+
 			if (UNEXPECTED(ast->child[1]->kind != ZEND_AST_ZVAL
 				|| Z_TYPE_P(zend_ast_get_zval(ast->child[1])) != IS_STRING)) {
 				return;
 			}
-
-			zend_eval_const_expr(&ast->child[0]);
-			zend_eval_const_expr(&ast->child[1]);
 
 			class_ast = ast->child[0];
 			name_ast = ast->child[1];


### PR DESCRIPTION
Fixes oss-fuzz #57821

op1 and op2 should always be evaluated, even if the class constant fetch itself fails. Otherwise we can get unexpected constant ASTs at runtime (e.g. `Foo::class`). This wasn't previously an issue because we don't allow `(const_expr)::FOO` in constant expressions, and op2 was always a string.

/cc @dstogov