### PR TITLE
FPM: refactor fpm_php_get_string_from_table() to better match usage

### DIFF
--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -252,7 +252,7 @@ int fpm_php_limit_extensions(char *path) /* {{{ */
 }
 /* }}} */
 
-bool fpm_php_is_key_in_table(zend_string *table, char *key, size_t key_len) /* {{{ */
+bool fpm_php_is_key_in_table(zend_string *table, const char *key, size_t key_len) /* {{{ */
 {
 	zval *data;
 	zend_string *str;
@@ -266,7 +266,9 @@ bool fpm_php_is_key_in_table(zend_string *table, char *key, size_t key_len) /* {
 
 	/* find the table and ensure it's an array */
 	data = zend_hash_find(&EG(symbol_table), table);
-	ZEND_ASSERT(data && Z_TYPE_P(data) == IS_ARRAY);
+	if (!data || Z_TYPE_P(data) != IS_ARRAY) {
+		return NULL;
+	}
 
 	ZEND_HASH_FOREACH_STR_KEY(Z_ARRVAL_P(data), str) {
 		if (str && zend_string_equals_cstr(str, key, key_len)) {

--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -252,13 +252,13 @@ int fpm_php_limit_extensions(char *path) /* {{{ */
 }
 /* }}} */
 
-char* fpm_php_get_string_from_table(zend_string *table, char *key) /* {{{ */
+bool fpm_php_is_key_in_table(zend_string *table, char *key, size_t key_len) /* {{{ */
 {
-	zval *data, *tmp;
+	zval *data;
 	zend_string *str;
-	if (!table || !key) {
-		return NULL;
-	}
+
+	ZEND_ASSERT(table);
+	ZEND_ASSERT(key);
 
 	/* inspired from ext/standard/info.c */
 
@@ -266,16 +266,14 @@ char* fpm_php_get_string_from_table(zend_string *table, char *key) /* {{{ */
 
 	/* find the table and ensure it's an array */
 	data = zend_hash_find(&EG(symbol_table), table);
-	if (!data || Z_TYPE_P(data) != IS_ARRAY) {
-		return NULL;
-	}
+	ZEND_ASSERT(data && Z_TYPE_P(data) == IS_ARRAY);
 
-	ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(data), str, tmp) {
-		if (str && !strncmp(ZSTR_VAL(str), key, ZSTR_LEN(str))) {
-			return Z_STRVAL_P(tmp);
+	ZEND_HASH_FOREACH_STR_KEY(Z_ARRVAL_P(data), str) {
+		if (str && zend_string_equals_cstr(str, key, key_len)) {
+			return true;
 		}
 	} ZEND_HASH_FOREACH_END();
 
-	return NULL;
+	return false;
 }
 /* }}} */

--- a/sapi/fpm/fpm/fpm_php.h
+++ b/sapi/fpm/fpm/fpm_php.h
@@ -3,7 +3,6 @@
 #ifndef FPM_PHP_H
 #define FPM_PHP_H 1
 
-#include <stdbool.h>
 #include <TSRM.h>
 
 #include "php.h"
@@ -42,6 +41,6 @@ void fpm_php_soft_quit(void);
 int fpm_php_init_main(void);
 int fpm_php_apply_defines_ex(struct key_value_s *kv, int mode);
 int fpm_php_limit_extensions(char *path);
-bool fpm_php_is_key_in_table(zend_string *table, char *key, size_t key_len);
+bool fpm_php_is_key_in_table(zend_string *table, const char *key, size_t key_len);
 
 #endif

--- a/sapi/fpm/fpm/fpm_php.h
+++ b/sapi/fpm/fpm/fpm_php.h
@@ -3,6 +3,7 @@
 #ifndef FPM_PHP_H
 #define FPM_PHP_H 1
 
+#include <stdbool.h>
 #include <TSRM.h>
 
 #include "php.h"
@@ -41,6 +42,6 @@ void fpm_php_soft_quit(void);
 int fpm_php_init_main(void);
 int fpm_php_apply_defines_ex(struct key_value_s *kv, int mode);
 int fpm_php_limit_extensions(char *path);
-char* fpm_php_get_string_from_table(zend_string *table, char *key);
+bool fpm_php_is_key_in_table(zend_string *table, char *key, size_t key_len);
 
 #endif

--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -143,7 +143,6 @@ int fpm_status_handle_request(void) /* {{{ */
 	int full, encode, has_start_time;
 	char *short_syntax, *short_post;
 	char *full_pre, *full_syntax, *full_post, *full_separator;
-	zend_string *_GET_str;
 
 	if (!SG(request_info).request_uri) {
 		return 0;
@@ -168,11 +167,13 @@ int fpm_status_handle_request(void) /* {{{ */
 
 	/* STATUS */
 	if (fpm_status_uri && !strcmp(fpm_status_uri, SG(request_info).request_uri)) {
+		zend_string *_GET_str;
+
 		fpm_request_executing();
 
 		/* full status ? */
 		_GET_str = ZSTR_INIT_LITERAL("_GET", 0);
-		full = fpm_php_is_key_in_table(_GET_str, "full", strlen("full"));
+		full = fpm_php_is_key_in_table(_GET_str, ZEND_STRL("full"));
 		short_syntax = short_post = NULL;
 		full_separator = full_pre = full_syntax = full_post = NULL;
 		encode = 0;
@@ -215,7 +216,7 @@ int fpm_status_handle_request(void) /* {{{ */
 		}
 
 		/* HTML */
-		if (fpm_php_is_key_in_table(_GET_str, "html", strlen("html"))) {
+		if (fpm_php_is_key_in_table(_GET_str, ZEND_STRL("html"))) {
 			sapi_add_header_ex(ZEND_STRL("Content-Type: text/html"), 1, 1);
 			time_format = "%d/%b/%Y:%H:%M:%S %z";
 			encode = 1;
@@ -284,7 +285,7 @@ int fpm_status_handle_request(void) /* {{{ */
 			}
 
 		/* XML */
-		} else if (fpm_php_is_key_in_table(_GET_str, "xml", strlen("xml"))) {
+		} else if (fpm_php_is_key_in_table(_GET_str, ZEND_STRL("xml"))) {
 			sapi_add_header_ex(ZEND_STRL("Content-Type: text/xml"), 1, 1);
 			time_format = "%s";
 			encode = 1;
@@ -332,7 +333,7 @@ int fpm_status_handle_request(void) /* {{{ */
 				}
 
 			/* JSON */
-		} else if (fpm_php_is_key_in_table(_GET_str, "json", strlen("json"))) {
+		} else if (fpm_php_is_key_in_table(_GET_str, ZEND_STRL("json"))) {
 			sapi_add_header_ex(ZEND_STRL("Content-Type: application/json"), 1, 1);
 			time_format = "%s";
 
@@ -379,7 +380,7 @@ int fpm_status_handle_request(void) /* {{{ */
 			}
 
 			/* OpenMetrics */
-		} else if (fpm_php_is_key_in_table(_GET_str, "openmetrics", strlen("openmetrics"))) {
+		} else if (fpm_php_is_key_in_table(_GET_str, ZEND_STRL("openmetrics"))) {
 			sapi_add_header_ex(ZEND_STRL("Content-Type: application/openmetrics-text; version=1.0.0; charset=utf-8"), 1, 1);
 			time_format = "%s";
 

--- a/sapi/fpm/fpm/fpm_status.c
+++ b/sapi/fpm/fpm/fpm_status.c
@@ -172,7 +172,7 @@ int fpm_status_handle_request(void) /* {{{ */
 
 		/* full status ? */
 		_GET_str = ZSTR_INIT_LITERAL("_GET", 0);
-		full = (fpm_php_get_string_from_table(_GET_str, "full") != NULL);
+		full = fpm_php_is_key_in_table(_GET_str, "full", strlen("full"));
 		short_syntax = short_post = NULL;
 		full_separator = full_pre = full_syntax = full_post = NULL;
 		encode = 0;
@@ -215,7 +215,7 @@ int fpm_status_handle_request(void) /* {{{ */
 		}
 
 		/* HTML */
-		if (fpm_php_get_string_from_table(_GET_str, "html")) {
+		if (fpm_php_is_key_in_table(_GET_str, "html", strlen("html"))) {
 			sapi_add_header_ex(ZEND_STRL("Content-Type: text/html"), 1, 1);
 			time_format = "%d/%b/%Y:%H:%M:%S %z";
 			encode = 1;
@@ -284,7 +284,7 @@ int fpm_status_handle_request(void) /* {{{ */
 			}
 
 		/* XML */
-		} else if (fpm_php_get_string_from_table(_GET_str, "xml")) {
+		} else if (fpm_php_is_key_in_table(_GET_str, "xml", strlen("xml"))) {
 			sapi_add_header_ex(ZEND_STRL("Content-Type: text/xml"), 1, 1);
 			time_format = "%s";
 			encode = 1;
@@ -332,7 +332,7 @@ int fpm_status_handle_request(void) /* {{{ */
 				}
 
 			/* JSON */
-		} else if (fpm_php_get_string_from_table(_GET_str, "json")) {
+		} else if (fpm_php_is_key_in_table(_GET_str, "json", strlen("json"))) {
 			sapi_add_header_ex(ZEND_STRL("Content-Type: application/json"), 1, 1);
 			time_format = "%s";
 
@@ -379,7 +379,7 @@ int fpm_status_handle_request(void) /* {{{ */
 			}
 
 			/* OpenMetrics */
-		} else if (fpm_php_get_string_from_table(_GET_str, "openmetrics")) {
+		} else if (fpm_php_is_key_in_table(_GET_str, "openmetrics", strlen("openmetrics"))) {
 			sapi_add_header_ex(ZEND_STRL("Content-Type: application/openmetrics-text; version=1.0.0; charset=utf-8"), 1, 1);
 			time_format = "%s";
 


### PR DESCRIPTION
Pass in length of the key to improve the existance of the key check.

Feel free to close if you don't agree @bukka, but the returned ``char*`` is never used and passing in the length of the key allows performing the quick check of "do both string lengths match".

