### PR TITLE
Fix GH-11044 keep ZipArchive open when a stream is open

### DIFF
--- a/ext/zip/php_zip.c
+++ b/ext/zip/php_zip.c
@@ -2903,7 +2903,7 @@ PHP_METHOD(ZipArchive, getStream)
 		RETURN_FALSE;
 	}
 
-	stream = php_stream_zip_open(intern, ZSTR_VAL(filename), mode STREAMS_CC);
+	stream = php_stream_zip_open(self, intern, ZSTR_VAL(filename), mode STREAMS_CC);
 	if (stream) {
 		php_stream_to_zval(stream, return_value);
 	} else {

--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -75,7 +75,7 @@ static inline ze_zip_object *php_zip_fetch_object(zend_object *obj) {
 #define Z_ZIP_P(zv) php_zip_fetch_object(Z_OBJ_P((zv)))
 
 php_stream *php_stream_zip_opener(php_stream_wrapper *wrapper, const char *path, const char *mode, int options, zend_string **opened_path, php_stream_context *context STREAMS_DC);
-php_stream *php_stream_zip_open(struct zip *arch, const char *path, const char *mode STREAMS_DC);
+php_stream *php_stream_zip_open(zval *zv, struct zip *arch, const char *path, const char *mode STREAMS_DC);
 
 extern const php_stream_wrapper php_stream_zip_wrapper;
 

--- a/ext/zip/tests/bug80833.phpt
+++ b/ext/zip/tests/bug80833.phpt
@@ -37,7 +37,16 @@ $file_stream = $extract_zip->getStream("test2.txt");
 var_dump(stream_get_contents($file_stream));
 fclose($file_stream);
 
+// Archive unset before the stream
+$extract_zip->setPassword("first_password");
+$file_stream = $extract_zip->getStream("test.txt");
+unset($extract_zip);
+var_dump(stream_get_contents($file_stream));
+fclose($file_stream);
+
 // Archive close before the stream
+$extract_zip = new ZipArchive();
+$extract_zip->open(__DIR__ . "/80833.zip", ZipArchive::RDONLY);
 $extract_zip->setPassword("first_password");
 $file_stream = $extract_zip->getStream("test.txt");
 $extract_zip->close();
@@ -52,6 +61,7 @@ fclose($file_stream);
 string(22) "This is a test string."
 string(22) "This is a test string."
 string(28) "This is another test string."
+string(22) "This is a test string."
 
 Warning: stream_get_contents(): Zip stream error: Containing zip archive was closed in %s
 string(0) ""


### PR DESCRIPTION
see #11044

This allows the ZipArchive to be destroyed (but not to be closed)
The archive is really closed after all open streams are closed.