### PR TITLE
Add warning to log, when fpm socket was not registered on the expected path

### DIFF
--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -396,9 +396,25 @@ static int fpm_socket_af_inet_listening_socket(struct fpm_worker_pool_s *wp) /* 
 static int fpm_socket_af_unix_listening_socket(struct fpm_worker_pool_s *wp) /* {{{ */
 {
 	struct sockaddr_un sa_un;
+    size_t socket_length = sizeof(sa_un.sun_path);
+    size_t address_length = strlen(wp->config->listen_address);
 
 	memset(&sa_un, 0, sizeof(sa_un));
-	strlcpy(sa_un.sun_path, wp->config->listen_address, sizeof(sa_un.sun_path));
+	strlcpy(sa_un.sun_path, wp->config->listen_address, socket_length);
+
+    if (address_length >= socket_length) {
+        zlog(
+            ZLOG_WARNING,
+            "[pool %s] cannot bind to UNIX socket '%s' as path is too long (found length: %zu, "
+				"maximal length: %zu), trying cut socket path instead '%s'",
+            wp->config->name,
+			wp->config->listen_address,
+			address_length,
+			socket_length,
+			sa_un.sun_path
+        );
+    }
+
 	sa_un.sun_family = AF_UNIX;
 	return fpm_sockets_get_listening_socket(wp, (struct sockaddr *) &sa_un, sizeof(struct sockaddr_un));
 }

--- a/sapi/fpm/tests/logreader.inc
+++ b/sapi/fpm/tests/logreader.inc
@@ -16,7 +16,7 @@ class LogReader
      *
      * @var string|null
      */
-    private ?string $currentSourceName;
+    private ?string $currentSourceName = null;
 
     /**
      * Log descriptors.

--- a/sapi/fpm/tests/socket-uds-too-long-filename-start.phpt
+++ b/sapi/fpm/tests/socket-uds-too-long-filename-start.phpt
@@ -1,0 +1,74 @@
+--TEST--
+FPM: UNIX socket filename is too for start
+--SKIPIF--
+<?php
+include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+$socketFilePrefix = __DIR__ . '/socket-file';
+$socketFile = sprintf(
+    "%s-fpm-unix-socket-too-long-filename-but-starts-anyway%s.sock",
+    $socketFilePrefix,
+    str_repeat('-0000', 11)
+);
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+
+[fpm_pool]
+listen = $socketFile
+pm = static
+pm.max_children = 1
+catch_workers_output = yes
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->expectLogPattern(
+    sprintf(
+        '/\[pool fpm_pool\] cannot bind to UNIX socket \'%s\' as path is too long '
+            . '\(found length: %d, maximal length: \d+\), trying cut socket path instead \'.+\'/',
+        preg_quote($socketFile, '/'),
+        strlen($socketFile)
+    ),
+    true
+);
+
+$files = glob($socketFilePrefix . '*');
+
+if ($files === []) {
+    echo 'Socket files were not found.' . PHP_EOL;
+}
+
+if ($socketFile === $files[0]) {
+    // this means the socket file path length is not an issue (anymore). Might be not long enough
+    echo 'Socket file is the same as configured.' . PHP_EOL;
+}
+
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+
+// cleanup socket file if php-fpm was not killed
+$socketFile = sprintf(
+    "/socket-file-fpm-unix-socket-too-long-filename-but-starts-anyway%s.sock",
+    __DIR__,
+    str_repeat('-0000', 11)
+);
+
+if (is_file($socketFile)) {
+    unlink($socketFile);
+}
+?>

--- a/sapi/fpm/tests/socket-uds-too-long-filename-test.phpt
+++ b/sapi/fpm/tests/socket-uds-too-long-filename-test.phpt
@@ -1,0 +1,47 @@
+--TEST--
+FPM: UNIX socket filename is too for test
+--SKIPIF--
+<?php
+include "skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$socketFilePrefix = __DIR__ . '/socket-file';
+$socketFile = sprintf(
+    "/socket-file-fpm-unix-socket-too-long-filename-but-starts-anyway%s.sock",
+    __DIR__,
+    str_repeat('-0000', 11)
+);
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+
+[fpm_pool]
+listen = $socketFile
+pm = static
+pm.max_children = 1
+catch_workers_output = yes
+EOT;
+
+$tester = new FPM\Tester($cfg);
+$tester->testConfig(true, [
+    sprintf(
+        '/cannot bind to UNIX socket \'%s\' as path is too long '
+            . '\(found length: %d, maximal length: \d+\)/',
+        preg_quote($socketFile, '/'),
+        strlen($socketFile)
+    ),
+    '/FPM initialization failed/',
+]);
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -382,26 +382,50 @@ class Tester
      * @return null|array
      * @throws \Exception
      */
-    public function testConfig($silent = false)
+    public function testConfig($silent = false, array|string|null $expectedPattern = null): ?array
     {
         $configFile = $this->createConfig();
         $cmd        = self::findExecutable() . ' -n -tt -y ' . $configFile . ' 2>&1';
         $this->trace('Testing config using command', $cmd, true);
         exec($cmd, $output, $code);
+        $found = 0;
+        if ($expectedPattern !== null) {
+            $expectedPatterns = is_array($expectedPattern) ? $expectedPattern : [$expectedPattern];
+        }
         if ($code) {
             $messages = [];
             foreach ($output as $outputLine) {
                 $message    = preg_replace("/\[.+?\]/", "", $outputLine, 1);
+                if ($expectedPattern !== null) {
+                    for ($i = 0; $i < count($expectedPatterns); $i++) {
+                        $pattern = $expectedPatterns[$i];
+                        if ($pattern !== null && preg_match($pattern, $message)) {
+                            $found++;
+                            $expectedPatterns[$i] = null;
+                        }
+                    }
+                }
                 $messages[] = $message;
                 if ( ! $silent) {
                     $this->error($message, null, false);
                 }
             }
-
-            return $messages;
+        } else {
+            $messages = null;
         }
 
-        return null;
+        if ($expectedPattern !== null && $found < count($expectedPatterns)) {
+            $missingPatterns = array_filter($expectedPatterns);
+            $errorMessage = sprintf(
+                "The expected config %s %s %s not been found",
+                count($missingPatterns) > 1 ? 'patterns' : 'pattern',
+                implode(', ', $missingPatterns),
+                count($missingPatterns) > 1 ? 'have' : 'has',
+            );
+            $this->error($errorMessage);
+        }
+
+        return $messages;
     }
 
     /**
@@ -1155,9 +1179,19 @@ class Tester
                 return $address;
             }
 
-            return sys_get_temp_dir() . '/' .
-                   hash('crc32', dirname($address)) . '-' .
-                   basename($address);
+            $addressPart = hash('crc32', dirname($address)) . '-' . basename($address);
+
+            // is longer on Mac, than on Linux
+            $tmpDirAddress = sys_get_temp_dir() . '/' . $addressPart;
+                   ;
+
+            if (strlen($tmpDirAddress) <= 104) {
+                return $tmpDirAddress;
+            }
+
+            $srcRootAddress = dirname(__DIR__, 3) . '/' . $addressPart;
+
+            return $srcRootAddress;
         }
 
         return $this->getHost($type) . ':' . $port;


### PR DESCRIPTION
I decided it to be a warning, because you can still run against the newly created socket file but fail it for the configuration test. It felt right to do it like that.

## Where am I coming from?

I have an experiments folder deep down in a folder structure on my work machine (`/home/name/projects/delete-to-free-storage/experiments`). In there I cloned a project where I wanted to try out devenv for a part in a subfolder (`/home/name/projects/delete-to-free-storage/experiments/foobar/php-web`). I set up devenv, it uses process-compose to orchestrate php-fpm for me and it places the php-fpm socket file in a project specific sub directory (`/home/name/projects/delete-to-free-storage/experiments/foobar/php-web/.devenv/state/php-fpm/web`). When I opened up the nginx served page, all I get is a white page and nginx prints into the log `dialing backend: dial unix /home/name/projects/delete-to-free-storage/experiments/foobar/php-web/.devenv/state/php-fpm/web.sock: connect: invalid argument`.

So now try to debug this. You have multiple sources for this error (devenv, process-compose, nix, a nix package for php, php itself, nginx, a nix package for nginx). I was looking into to this with @jochenmanz for several days. Our question was: "Why is the file extension missing?" We were looking through the different tools but no solution

Just today I just received the message "What OS are you on and did you know that socket file names are limited in length?" After just moving the project into a directory with a shorter path, we saw, that it was working and the socket file had the .sock extension as expected. "the extension .sock was missing" is just a coincidence in after a string length cut. So we found the issue it was on binding the socket. We found some checks against in php for every socket access. But for some reason not for php-fpm. The socket will just get cut off. So I decided to fix that so have other people minds less stressed :)