### PR TITLE
Fix GH-11071: Revert "Fix [-Wundef] warning in INTL extension"

### DIFF
--- a/ext/intl/php_intl.c
+++ b/ext/intl/php_intl.c
@@ -286,7 +286,7 @@ PHP_RSHUTDOWN_FUNCTION( intl )
 /* {{{ PHP_MINFO_FUNCTION */
 PHP_MINFO_FUNCTION( intl )
 {
-#ifndef UCONFIG_NO_FORMATTING
+#if !UCONFIG_NO_FORMATTING
 	UErrorCode status = U_ZERO_ERROR;
 	const char *tzdata_ver = NULL;
 #endif
@@ -297,7 +297,7 @@ PHP_MINFO_FUNCTION( intl )
 #ifdef U_ICU_DATA_VERSION
 	php_info_print_table_row( 2, "ICU Data version", U_ICU_DATA_VERSION );
 #endif
-#ifndef UCONFIG_NO_FORMATTING
+#if !UCONFIG_NO_FORMATTING
 	tzdata_ver = ucal_getTZDataVersion(&status);
 	if (U_ZERO_ERROR == status) {
 		php_info_print_table_row( 2, "ICU TZData version", tzdata_ver);


### PR DESCRIPTION
This reverts commit ea8686540ac43e59dd3f8784e29a0c06e3446df2.