### PR TITLE
Increase zend.reserved_stack_size minimum value in ASAN/MSAN builds

### DIFF
--- a/Zend/tests/stack_limit/stack_limit_001.phpt
+++ b/Zend/tests/stack_limit/stack_limit_001.phpt
@@ -3,7 +3,6 @@ Stack limit 001 - Stack limit checks with max_allowed_stack_size detection
 --SKIPIF--
 <?php
 if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
-if (getenv('SKIP_MSAN')) die("skip msan requires a considerably higher zend.reserved_stack_size due to instrumentation");
 ?>
 --EXTENSIONS--
 zend_test

--- a/Zend/tests/stack_limit/stack_limit_002.phpt
+++ b/Zend/tests/stack_limit/stack_limit_002.phpt
@@ -3,7 +3,6 @@ Stack limit 002 - Stack limit checks with max_allowed_stack_size detection (fibe
 --SKIPIF--
 <?php
 if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
-if (getenv('SKIP_MSAN')) die("skip msan requires a considerably higher zend.reserved_stack_size due to instrumentation");
 ?>
 --EXTENSIONS--
 zend_test

--- a/Zend/tests/stack_limit/stack_limit_003.phpt
+++ b/Zend/tests/stack_limit/stack_limit_003.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=512K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_004.phpt
+++ b/Zend/tests/stack_limit/stack_limit_004.phpt
@@ -27,12 +27,12 @@ $callback = function (): int {
     throw new \Exception();
 };
 
-ini_set('fiber.stack_size', '400K');
+ini_set('fiber.stack_size', '1M');
 $fiber = new Fiber($callback);
 $fiber->start();
 $depth1 = $fiber->getReturn();
 
-ini_set('fiber.stack_size', '200K');
+ini_set('fiber.stack_size', '512K');
 $fiber = new Fiber($callback);
 $fiber->start();
 $depth2 = $fiber->getReturn();

--- a/Zend/tests/stack_limit/stack_limit_006.phpt
+++ b/Zend/tests/stack_limit/stack_limit_006.phpt
@@ -3,7 +3,6 @@ Stack limit 006 - env size affects __libc_stack_end
 --SKIPIF--
 <?php
 if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
-if (getenv('SKIP_MSAN')) die("skip msan requires a considerably higher zend.reserved_stack_size due to instrumentation");
 ?>
 --EXTENSIONS--
 zend_test

--- a/Zend/tests/stack_limit/stack_limit_007.phpt
+++ b/Zend/tests/stack_limit/stack_limit_007.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=512K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_008.phpt
+++ b/Zend/tests/stack_limit/stack_limit_008.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=512K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_009.phpt
+++ b/Zend/tests/stack_limit/stack_limit_009.phpt
@@ -3,7 +3,6 @@ Stack limit 009 - Check that we can actually use all the stack
 --SKIPIF--
 <?php
 if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
-if (getenv('SKIP_MSAN')) die("skip msan requires a considerably higher zend.reserved_stack_size due to instrumentation");
 ?>
 --EXTENSIONS--
 zend_test

--- a/Zend/tests/stack_limit/stack_limit_011.phpt
+++ b/Zend/tests/stack_limit/stack_limit_011.phpt
@@ -7,24 +7,27 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=512K
 --FILE--
 <?php
 
 var_dump(zend_test_zend_call_stack_get());
 
-class Test1 {
-    public function __destruct() {
-        new Test1;
-    }
-}
-
-function replace() {
+function replace2() {
     return preg_replace_callback('#.#', function () {
+        replace2();
+    }, 'x');
+}
+function replace() {
+    static $once = false;
+    return preg_replace_callback('#.#', function () use (&$once) {
         try {
             replace();
         } finally {
-            new Test1();
+            if (!$once) {
+                $once = true;
+                replace2();
+            }
         }
     }, 'x');
 }

--- a/Zend/tests/stack_limit/stack_limit_012.phpt
+++ b/Zend/tests/stack_limit/stack_limit_012.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=512K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_013.inc
+++ b/Zend/tests/stack_limit/stack_limit_013.inc
@@ -1,0 +1,13 @@
+<?php
+
+if (!class_exists("constructs_in_destructor")) {
+    class constructs_in_destructor {
+        public function __destruct() {
+            $a = new constructs_in_destructor;
+            $time = '';
+            require(__FILE__);
+        }
+    }
+}
+
+$a = new constructs_in_destructor;

--- a/Zend/tests/stack_limit/stack_limit_014.inc
+++ b/Zend/tests/stack_limit/stack_limit_014.inc
@@ -1,0 +1,13 @@
+<?php
+
+if (!class_exists("constructs_in_destructor")) {
+    class constructs_in_destructor {
+        public function __destruct() {
+            $a = new constructs_in_destructor;
+            $time = '';
+            require(__FILE__);
+        }
+    }
+}
+
+$a = new constructs_in_destructor;

--- a/Zend/tests/stack_limit/stack_limit_014.phpt
+++ b/Zend/tests/stack_limit/stack_limit_014.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Stack limit 014 - Fuzzer
+--SKIPIF--
+<?php
+if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_call_stack_get() is not available");
+?>
+--EXTENSIONS--
+zend_test
+--INI--
+; The test may use a large amount of memory on systems with a large stack limit
+memory_limit=1G
+--FILE--
+<?php
+
+try {
+    require __DIR__.'/stack_limit_014.inc';
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+%S%rMaximum call stack size of [0-9]+ bytes reached|Allowed memory size of [0-9]+ bytes exhausted%r%s

--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -206,6 +206,12 @@ static ZEND_INI_MH(OnUpdateReservedStackSize) /* {{{ */
 	zend_ulong min = 32*1024;
 #endif
 
+#if defined(__SANITIZE_ADDRESS__) || __has_feature(memory_sanitizer)
+	/* AddressSanitizer and MemorySanitizer use more stack due to
+	 * instrumentation */
+	min *= 10;
+#endif
+
 	if (size == 0) {
 		size = min;
 	} else if (size < min) {

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -102,9 +102,14 @@ static void zend_compile_assign(znode *result, zend_ast *ast);
 #ifdef ZEND_CHECK_STACK_LIMIT
 zend_never_inline static void zend_stack_limit_error(void)
 {
+	size_t max_stack_size = 0;
+	if ((uintptr_t) EG(stack_base) > (uintptr_t) EG(stack_limit)) {
+		max_stack_size = (size_t) ((uintptr_t) EG(stack_base) - (uintptr_t) EG(stack_limit));
+	}
+
 	zend_error_noreturn(E_COMPILE_ERROR,
 		"Maximum call stack size of %zu bytes reached during compilation. Try splitting expression",
-		(size_t) ((uintptr_t) EG(stack_base) - (uintptr_t) EG(stack_limit)));
+		max_stack_size);
 }
 
 static void zend_check_stack_limit(void)

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2308,8 +2308,13 @@ static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_use_new_element_for_s
 #ifdef ZEND_CHECK_STACK_LIMIT
 static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_call_stack_size_error(void)
 {
-	zend_throw_error(NULL, "Maximum call stack size of %zu bytes reached. Infinite recursion?",
-		(size_t) ((uintptr_t) EG(stack_base) - (uintptr_t) EG(stack_limit)));
+	size_t max_stack_size = 0;
+	if ((uintptr_t) EG(stack_base) > (uintptr_t) EG(stack_limit)) {
+		max_stack_size = (size_t) ((uintptr_t) EG(stack_base) - (uintptr_t) EG(stack_limit));
+	}
+	zend_throw_error(NULL,
+		"Maximum call stack size of %zu bytes reached. Infinite recursion?",
+		max_stack_size);
 }
 #endif /* ZEND_CHECK_STACK_LIMIT */
 


### PR DESCRIPTION
`zend.reserved_stack_size` is the size of the stack space that is reserved for native code called by the VM. This reserved space is similar to the shadow space described in https://pangin.pro/posts/stack-overflow-handling.

The minimum and default value of `zend.reserved_stack_size` is ZEND_ALLOCA_MAX_SIZE + some empirically chosen value. If this is too low, the program may crash as if no [stack limit](https://github.com/php/php-src/pull/9104) was in place.

ASAN/MSAN builds use considerably more stack space due to instrumentation, so this default value is too low in these builds. https://clang.llvm.org/docs/AddressSanitizer.html#limitations mentions an increase of up to 3x, but the stack usage of individual functions can increase much more than that. For example, here is a stack trace annotated with stack usage of each function as reported by -fstack-usage:

```
                                         non-asan asan

total                                    5176     52912

zend_mm_small_size_to_bin                40       88
zend_mm_alloc_heap                       96       424
_zend_mm_alloc                           64       120
zend_mm_realloc_heap                     192      1224
_erealloc                                96       184
_safe_erealloc                           64       152
zend_stack_push                          48       296
enter_nesting                            48       152
lex_scan                                 1056     30424
zendlex                                  80       152
zendparse                                2448     17688
zend_compile                             224      280
compile_file                             304      184
compile_filename                         144      216
zend_include_or_eval                     176      408
ZEND_INCLUDE_OR_EVAL_SPEC_CONST_HANDLER  96       920
execute_ex         <-- stack limit check is made here
```

In this PR I increase the minimum and default value of `zend.reserved_stack_size` by 10x in ASAN/MSAN builds.