### PR TITLE
Add zend_test_crash funtion to segfault PHP process

### DIFF
--- a/Zend/tests/arginfo_zpp_mismatch.inc
+++ b/Zend/tests/arginfo_zpp_mismatch.inc
@@ -9,6 +9,7 @@ function skipFunction($function): bool {
         /* intentionally violate invariants */
      || $function === 'zend_create_unterminated_string'
      || $function === 'zend_test_array_return'
+     || $function === 'zend_test_crash'
      || $function === 'zend_leak_bytes'
         /* mess with output */
      || (is_string($function) && str_starts_with($function, 'ob_'))

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -327,6 +327,23 @@ static ZEND_FUNCTION(zend_get_map_ptr_last)
 	RETURN_LONG(CG(map_ptr_last));
 }
 
+static ZEND_FUNCTION(zend_test_crash)
+{
+	zend_string *message;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(message)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (message) {
+		php_printf("%s", ZSTR_VAL(message));
+	}
+
+	char *invalid = (char *) 1;
+	php_printf("%s", invalid);
+}
+
 static zend_object *zend_test_class_new(zend_class_entry *class_type)
 {
 	zend_object *obj = zend_objects_new(class_type);

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -119,6 +119,8 @@ namespace {
     function zend_call_method(string $class, string $method, mixed $arg1 = UNKNOWN, mixed $arg2 = UNKNOWN): mixed {}
 
     function zend_get_map_ptr_last(): int {}
+
+    function zend_test_crash(?string $message = null): void {}
 }
 
 namespace ZendTestNS {

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 614310958c6e2acde46c9b7932ba894caf72d6df */
+ * Stub hash: 47eb58d644268f4fdce7a6b5007f7755ebfcb197 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -82,6 +82,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_get_map_ptr_last, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_crash, 0, 0, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, message, IS_STRING, 1, "null")
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_ZendTestNS2_ZendSubNS_namespaced_func, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -143,6 +147,7 @@ static ZEND_FUNCTION(zend_test_parameter_with_attribute);
 static ZEND_FUNCTION(zend_get_current_func_name);
 static ZEND_FUNCTION(zend_call_method);
 static ZEND_FUNCTION(zend_get_map_ptr_last);
+static ZEND_FUNCTION(zend_test_crash);
 static ZEND_FUNCTION(namespaced_func);
 static ZEND_METHOD(_ZendTestClass, is_object);
 static ZEND_METHOD(_ZendTestClass, __toString);
@@ -182,6 +187,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_get_current_func_name, arginfo_zend_get_current_func_name)
 	ZEND_FE(zend_call_method, arginfo_zend_call_method)
 	ZEND_FE(zend_get_map_ptr_last, arginfo_zend_get_map_ptr_last)
+	ZEND_FE(zend_test_crash, arginfo_zend_test_crash)
 	ZEND_NS_FE("ZendTestNS2\\ZendSubNS", namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)
 	ZEND_FE_END
 };


### PR DESCRIPTION
This is useful for testing PHP-FPM handling of crashed children. It is currently not used in the core but I use it in my tests and might eventually add some automated FPM tests with that in the future.