### PR TITLE
Fix GH-11028: Heap Buffer Overflow in zval_undefined_cv.

### DIFF
--- a/Zend/tests/generators/gh11028_1.phpt
+++ b/Zend/tests/generators/gh11028_1.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-11028 (Heap Buffer Overflow in zval_undefined_cv with generators) - other types variant
+--FILE--
+<?php
+function generator($x) {
+    try {
+        yield $x => 0;
+    } finally {
+        return [];
+    }
+}
+
+function test($msg, $x) {
+    echo "yield $msg\n";
+    try {
+        var_dump([...generator($x)]);
+    } catch (Throwable $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+test("null", null);
+test("false", false);
+test("true", true);
+test("object", new stdClass);
+?>
+--EXPECT--
+yield null
+Keys must be of type int|string during array unpacking
+yield false
+Keys must be of type int|string during array unpacking
+yield true
+Keys must be of type int|string during array unpacking
+yield object
+Keys must be of type int|string during array unpacking

--- a/Zend/tests/generators/gh11028_2.phpt
+++ b/Zend/tests/generators/gh11028_2.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GH-11028 (Heap Buffer Overflow in zval_undefined_cv with generators) - original variant
+--FILE--
+<?php
+$c = (function () {
+    [
+        ...($r = (function () {
+            try {
+                yield $a => 0;
+            } finally {
+                return [];
+            }
+        })()),
+    ];
+})()[0];
+?>
+--EXPECTF--
+Warning: Undefined variable $a in %s on line %d
+
+Fatal error: Uncaught Error: Keys must be of type int|string during array unpacking in %s:%d
+Stack trace:
+#0 %s(%d): {closure}()
+#1 {main}
+  thrown in %s on line %d

--- a/Zend/tests/generators/gh11028_3.phpt
+++ b/Zend/tests/generators/gh11028_3.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-11028 (Heap Buffer Overflow in zval_undefined_cv with generators) - throw in finally variant
+--FILE--
+<?php
+function generator() {
+    try {
+        yield null => 0;
+    } finally {
+        throw new Exception("exception");
+        return [];
+    }
+}
+
+try {
+    var_dump([...generator()]);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+exception


### PR DESCRIPTION
For analysis see https://github.com/php/php-src/issues/11028#issuecomment-1508460440

Thanks to Arnaud for pointing out the last missing piece, which was the opline before exception part.