### PR TITLE
FPM: Fix memory leak for invalid primary script file handle

### DIFF
--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -1924,19 +1924,16 @@ consult the installation file that came with this distribution, or visit \n\
 					}
 				} zend_catch {
 				} zend_end_try();
-				/* we want to serve more requests if this is fastcgi
-				 * so cleanup and continue, request shutdown is
-				 * handled later */
+				/* We want to serve more requests if this is fastcgi so cleanup and continue,
+				 * request shutdown is handled later. */
+			} else {
+				fpm_request_executing();
 
-				goto fastcgi_request_done;
+				/* Reset exit status from the previous execution */
+				EG(exit_status) = 0;
+
+				php_execute_script(&file_handle);
 			}
-
-			fpm_request_executing();
-
-			/* Reset exit status from the previous execution */
-			EG(exit_status) = 0;
-
-			php_execute_script(&file_handle);
 
 			/* Without opcache, or the first time with opcache, the file handle will be placed
 			 * in the CG(open_files) list by open_file_for_scanning(). Starting from the second


### PR DESCRIPTION
This is follow up for #10707 that fixed the primary script file handle leak. It is actually necessary to destroy file handle even if the `php_fopen_primary_script` fails which we did not anticipate. I noticed the leak when testing #10986 . 