### PR TITLE
Make SERVER_SOFTWARE compliant with RFC3875

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -66,6 +66,9 @@ PHP 8.3 UPGRADE NOTES
 3. Changes in SAPI modules
 ========================================
 
+- $_SERVER['SERVER_SOFTWARE'] value from the built-in CLI server changed
+  to make it compliant with RFC3875.
+
 ========================================
 4. Deprecated Functionality
 ========================================

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -696,7 +696,7 @@ static void sapi_cli_server_register_variables(zval *track_vars_array) /* {{{ */
 		}
 	}
 	{
-		zend_string *tmp = strpprintf(0, "PHP %s Development Server", PHP_VERSION);
+		zend_string *tmp = strpprintf(0, "PHP/%s (Development Server)", PHP_VERSION);
 		sapi_cli_server_register_known_var_str(track_vars_array, "SERVER_SOFTWARE", strlen("SERVER_SOFTWARE"), tmp);
 		zend_string_release_ex(tmp, /* persistent */ false);
 	}

--- a/sapi/cli/tests/php_cli_server_002.phpt
+++ b/sapi/cli/tests/php_cli_server_002.phpt
@@ -14,7 +14,7 @@ var_dump(file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS));
 ?>
 --EXPECTF--
 string(%d) "string(%d) "%sphp_cli_server_002"
-string(%d) "PHP %s Development Server"
+string(%d) "PHP/%s (Development Server)"
 string(%d) "localhost"
 string(%d) "%s"
 "


### PR DESCRIPTION
I work on an open source software that runs on PHP. We collect anonymized data to be able to do some statistics about execution environment of our software, and I figured out that the PHP internal server information was not collected as expected. This is due to the fact that we expect the `SERVER_SOFTWARE` to be compliant with RFC3875 (see below).

I am not sure this RFC should apply here, but as far as I know, all webservers I know are compliant with it.
Examples:
- Apache/2.4.56 (Debian)
- nginx/1.14.0
- lighttpd/1.4.53
- Microsoft-IIS/10.0
- Microsoft-HTTPAPI/2.0

**_According to RFC3875_**
>    The SERVER_SOFTWARE meta-variable MUST be set to the name and version
   of the information server software making the CGI request (and
   running the gateway).  It SHOULD be the same as the server
   description reported to the client, if any.

      SERVER_SOFTWARE = 1*( product | comment )
      product         = token [ "/" product-version ]
      product-version = token
      comment         = "(" *( ctext | comment ) ")"
      ctext           = <any TEXT excluding "(" and ")">