### PR TITLE
Fix gmp_long/gmp_ulong typedef warning on Windows x86

### DIFF
--- a/ext/gmp/php_gmp_int.h
+++ b/ext/gmp/php_gmp_int.h
@@ -28,7 +28,7 @@ static inline gmp_object *php_gmp_object_from_zend_object(zend_object *zobj) {
 PHP_GMP_API zend_class_entry *php_gmp_class_entry(void);
 
 /* GMP and MPIR use different datatypes on different platforms */
-#ifdef PHP_WIN32
+#ifdef _WIN64
 typedef zend_long gmp_long;
 typedef zend_ulong gmp_ulong;
 #else

--- a/ext/gmp/php_gmp_int.h
+++ b/ext/gmp/php_gmp_int.h
@@ -28,12 +28,7 @@ static inline gmp_object *php_gmp_object_from_zend_object(zend_object *zobj) {
 PHP_GMP_API zend_class_entry *php_gmp_class_entry(void);
 
 /* GMP and MPIR use different datatypes on different platforms */
-#ifdef _WIN64
-typedef zend_long gmp_long;
-typedef zend_ulong gmp_ulong;
-#else
 typedef long gmp_long;
 typedef unsigned long gmp_ulong;
-#endif
 
 #endif

--- a/ext/gmp/php_gmp_int.h
+++ b/ext/gmp/php_gmp_int.h
@@ -28,7 +28,12 @@ static inline gmp_object *php_gmp_object_from_zend_object(zend_object *zobj) {
 PHP_GMP_API zend_class_entry *php_gmp_class_entry(void);
 
 /* GMP and MPIR use different datatypes on different platforms */
+#ifdef _WIN64
+typedef zend_long gmp_long;
+typedef zend_ulong gmp_ulong;
+#else
 typedef long gmp_long;
 typedef unsigned long gmp_ulong;
+#endif
 
 #endif


### PR DESCRIPTION
extracted from #8479

discussed in https://github.com/php/php-src/pull/8479#discussion_r1173493175

introduced in https://github.com/php/php-src/commit/08b732f26bfe0330d873d622386ea5624ceaab36