### PR TITLE
Store the original path used to open xport stream

### DIFF
--- a/ext/standard/tests/network/socket_get_status_basic.phpt
+++ b/ext/standard/tests/network/socket_get_status_basic.phpt
@@ -17,7 +17,7 @@ fclose($server);
 
 ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -32,4 +32,6 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:%d"
 }

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_basic.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_basic.phpt
@@ -9,7 +9,7 @@ fclose($tcp_socket);
 
 ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -24,4 +24,6 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31330"
 }

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation1.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation1.phpt
@@ -38,7 +38,7 @@ var_dump(stream_get_meta_data($client));
 ?>
 --EXPECTF--
 Write some data:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -53,11 +53,13 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31331"
 }
 
 
 Read a line from the client, causing data to be buffered:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -72,11 +74,13 @@ array(7) {
   int(15)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31331"
 }
 
 
 Read 3 bytes of data from the client:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -91,11 +95,13 @@ array(7) {
   int(12)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31331"
 }
 
 
 Close the server side socket and read the remaining data from the client:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -110,4 +116,6 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31331"
 }

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation2.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation2.phpt
@@ -36,7 +36,7 @@ fclose($server);
 
 ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -51,11 +51,13 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31332"
 }
 
 
 Set a timeout on the client and attempt a read:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(true)
   ["blocked"]=>
@@ -70,11 +72,13 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31332"
 }
 
 
 Write some data from the server:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(true)
   ["blocked"]=>
@@ -89,11 +93,13 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31332"
 }
 
 
 Read some data from the client:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -108,4 +114,6 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31332"
 }

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation3.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation3.phpt
@@ -31,7 +31,7 @@ fclose($server);
 
 ?>
 --EXPECTF--
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -46,12 +46,14 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31333"
 }
 
 
 Set blocking to false:
 bool(true)
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -66,12 +68,14 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31333"
 }
 
 
 Set blocking to true:
 bool(true)
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -86,4 +90,6 @@ array(7) {
   int(0)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31333"
 }

--- a/ext/standard/tests/streams/stream_get_meta_data_socket_variation4.phpt
+++ b/ext/standard/tests/streams/stream_get_meta_data_socket_variation4.phpt
@@ -36,7 +36,7 @@ fclose($client);
 ?>
 --EXPECTF--
 Write some data:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -51,11 +51,13 @@ array(7) {
   int(%i)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31334"
 }
 
 
 Read a line from the client:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -70,11 +72,13 @@ array(7) {
   int(%i)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31334"
 }
 
 
 Close the server side socket and read the remaining data from the client:
-array(7) {
+array(8) {
   ["timed_out"]=>
   bool(false)
   ["blocked"]=>
@@ -89,4 +93,6 @@ array(7) {
   int(%i)
   ["seekable"]=>
   bool(false)
+  ["uri"]=>
+  string(21) "tcp://127.0.0.1:31334"
 }

--- a/main/streams/transports.c
+++ b/main/streams/transports.c
@@ -59,7 +59,7 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 {
 	php_stream *stream = NULL;
 	php_stream_transport_factory factory = NULL;
-	const char *p, *protocol = NULL;
+	const char *p, *protocol, *orig_path = NULL;
 	size_t n = 0;
 	bool failed = false;
 	bool bailout = false;
@@ -94,6 +94,7 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 		}
 	}
 
+	orig_path = name;
 	for (p = name; isalnum((int)*p) || *p == '+' || *p == '-' || *p == '.'; p++) {
 		n++;
 	}
@@ -135,6 +136,7 @@ PHPAPI php_stream *_php_stream_xport_create(const char *name, size_t namelen, in
 	if (stream) {
 		zend_try {
 			php_stream_context_set(stream, context);
+			stream->orig_path = pestrdup(orig_path, persistent_id ? 1 : 0);
 
 			if ((flags & STREAM_XPORT_SERVER) == 0) {
 				/* client */

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -966,9 +966,5 @@ PHPAPI php_stream *php_stream_generic_socket_factory(const char *proto, size_t p
 		return NULL;
 	}
 
-	if (flags == 0) {
-		return stream;
-	}
-
 	return stream;
 }


### PR DESCRIPTION
Currently, with a code like `$stream = stream_socket_client("ssl://www.example.com:443")`, the original path used to open the stream is not stored.

This PR proposes to store it so it can be retrieved later.
