### PR TITLE
Propagate STREAM_DISABLE_OPEN_BASEDIR src flag to php_stream_stat_path_ex

### DIFF
--- a/Zend/tests/gh11138.phpt
+++ b/Zend/tests/gh11138.phpt
@@ -1,0 +1,28 @@
+--TEST--
+move_uploaded_file() and open_basedir
+--POST_RAW--
+Content-type: multipart/form-data, boundary=AaB03x
+
+--AaB03x
+content-disposition: form-data; name="file"; filename="file.txt"
+Content-Type: text/plain
+
+foo
+--AaB03x--
+--FILE--
+<?php
+
+ini_set('open_basedir', __DIR__);
+
+$destination = __DIR__ . '/gh11138.tmp';
+var_dump(move_uploaded_file($_FILES['file']['tmp_name'], $destination));
+echo file_get_contents($destination), "\n";
+
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh11138.tmp');
+?>
+--EXPECT--
+bool(true)
+foo

--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -1669,8 +1669,9 @@ PHPAPI int php_copy_file_ctx(const char *src, const char *dest, int src_flg, php
 	php_stream *srcstream = NULL, *deststream = NULL;
 	int ret = FAILURE;
 	php_stream_statbuf src_s, dest_s;
+	int src_stat_flags = (src_flg & STREAM_DISABLE_OPEN_BASEDIR) ? PHP_STREAM_URL_STAT_IGNORE_OPEN_BASEDIR : 0;
 
-	switch (php_stream_stat_path_ex(src, 0, &src_s, ctx)) {
+	switch (php_stream_stat_path_ex(src, src_stat_flags, &src_s, ctx)) {
 		case -1:
 			/* non-statable stream */
 			goto safe_to_copy;


### PR DESCRIPTION
Otherwise we can get open_basedir warnings from the stat call while still performing the actual copy.

Fixes GH-11138