### PR TITLE
Fix GH-11141: Could not open input file: should be sent to stderr

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -2107,7 +2107,7 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 
 	/* start up winsock services */
 	if (WSAStartup(wVersionRequested, &wsaData) != 0) {
-		php_printf("\nwinsock.dll unusable. %d\n", WSAGetLastError());
+		fprintf(stderr, "\nwinsock.dll unusable. %d\n", WSAGetLastError());
 		return FAILURE;
 	}
 	php_win32_signal_ctrl_handler_init();
@@ -2166,7 +2166,7 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 	 * (this uses configuration parameters from php.ini)
 	 */
 	if (php_init_stream_wrappers(module_number) == FAILURE)	{
-		php_printf("PHP:  Unable to initialize stream url wrappers.\n");
+		fprintf(stderr, "PHP:  Unable to initialize stream url wrappers.\n");
 		return FAILURE;
 	}
 
@@ -2180,7 +2180,7 @@ zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additi
 
 	/* startup extensions statically compiled in */
 	if (php_register_internal_extensions_func() == FAILURE) {
-		php_printf("Unable to start builtin modules\n");
+		fprintf(stderr, "Unable to start builtin modules\n");
 		return FAILURE;
 	}
 

--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -574,7 +574,7 @@ static zend_result cli_seek_file_begin(zend_file_handle *file_handle, char *scri
 {
 	FILE *fp = VCWD_FOPEN(script_file, "rb");
 	if (!fp) {
-		php_printf("Could not open input file: %s\n", script_file);
+		fprintf(stderr, "Could not open input file: %s\n", script_file);
 		return FAILURE;
 	}
 

--- a/sapi/cli/tests/007.phpt
+++ b/sapi/cli/tests/007.phpt
@@ -45,8 +45,8 @@ string(81) "
 <?php
  class test { public $var = "test"; private $pri; function foo() { } } ?>
 "
-string(33) "Could not open input file: wrong
-"
+Could not open input file: wrong
+NULL
 string(43) "<?php  class test { function foo() {} } ?>
 "
 Done

--- a/sapi/cli/tests/008.phpt
+++ b/sapi/cli/tests/008.phpt
@@ -41,6 +41,6 @@ Stack trace:
 #0 {main}
   thrown in %s on line %d
 "
-string(33) "Could not open input file: wrong
-"
+Could not open input file: wrong
+NULL
 Done

--- a/sapi/cli/tests/011.phpt
+++ b/sapi/cli/tests/011.phpt
@@ -50,8 +50,8 @@ echo "Done\n";
 --EXPECTF--
 string(%d) "No syntax errors detected in %s011.test.php
 "
-string(40) "Could not open input file: some.unknown
-"
+Could not open input file: some.unknown
+NULL
 string(%d) "
 Parse error: %s expecting %s{%s in %s on line %d
 Errors parsing %s011.test.php

--- a/sapi/cli/tests/014.phpt
+++ b/sapi/cli/tests/014.phpt
@@ -40,6 +40,6 @@ string(1478) "<code><span style="color: #000000">
 <br /><span style="color: #0000BB">&lt;?php<br />$test&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">"var"</span><span style="color: #007700">;&nbsp;</span><span style="color: #FF8000">//var<br />/*&nbsp;test&nbsp;class&nbsp;*/<br /></span><span style="color: #007700">class&nbsp;</span><span style="color: #0000BB">test&nbsp;</span><span style="color: #007700">{<br />&nbsp;&nbsp;&nbsp;&nbsp;private&nbsp;</span><span style="color: #0000BB">$var&nbsp;</span><span style="color: #007700">=&nbsp;array();<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;public&nbsp;static&nbsp;function&nbsp;</span><span style="color: #0000BB">foo</span><span style="color: #007700">(</span><span style="color: #0000BB">Test&nbsp;$arg</span><span style="color: #007700">)&nbsp;{<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;echo&nbsp;</span><span style="color: #DD0000">"hello"</span><span style="color: #007700">;<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">);<br />&nbsp;&nbsp;&nbsp;&nbsp;}<br />}<br /><br /></span><span style="color: #0000BB">$o&nbsp;</span><span style="color: #007700">=&nbsp;new&nbsp;</span><span style="color: #0000BB">test</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">?&gt;<br /></span>
 </span>
 </code>"
-string(35) "Could not open input file: unknown
-"
+Could not open input file: unknown
+NULL
 Done

--- a/sapi/litespeed/lsapi_main.c
+++ b/sapi/litespeed/lsapi_main.c
@@ -1347,7 +1347,7 @@ static int cli_main( int argc, char * argv[] )
                         php_request_shutdown( NULL );
                     }
                 } else {
-                    php_printf("Could not open input file: %s.\n", *p);
+                    fprintf(stderr, "Could not open input file: %s.\n", *p);
                 }
             } else {
                 cli_usage();


### PR DESCRIPTION
Closes GH-11141.

I grepped for php_printf cases in main/ and sapi/ and converted the cases which clearly indicate errors to fprintf(stderr, ...), like suggested in the linked issue.