### PR TITLE
Fix uninitialised variable warning in mbfilter_sjis.c

### DIFF
--- a/ext/mbstring/libmbfl/filters/mbfilter_sjis.c
+++ b/ext/mbstring/libmbfl/filters/mbfilter_sjis.c
@@ -1400,8 +1400,8 @@ process_codepoint: ;
 						/* This might be a valid transcoding hint sequence */
 						int index = 3;
 
-resume_transcoding_hint:
 						if (buf->state) {
+resume_transcoding_hint:
 							i = buf->state >> 24;
 							index = (buf->state >> 16) & 0xFF;
 							buf->state = 0;


### PR DESCRIPTION
Compiling in release mode with UBSAN gives me the following compiler warning:
```
In function ‘mb_wchar_to_sjismac’:
mbfilter_sjis.c:1419:89: warning: ‘i’ may be used uninitialized [-Wmaybe-uninitialized]
 1419 | buf->state = (i << 24) | (index << 16) | (w & 0xFFFF);
      |                 ^~
mbfilter_sjis.c:1398:42: note: ‘i’ was declared here
 1398 | for (int i = 0; i < code_tbl_m_len; i++) {
      |          ^
```

Since the if condition will always be taken after the goto, we can get rid of the warning by moving the label inside the if.