### PR TITLE
Fix GH-11104: STDIN/STDOUT/STDERR is not available for CLI without a script

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -951,9 +951,7 @@ do_repeat:
 		PG(during_request_startup) = 0;
 		switch (behavior) {
 		case PHP_MODE_STANDARD:
-			if (script_file) {
-				cli_register_file_handles();
-			}
+			cli_register_file_handles();
 
 			if (interactive) {
 				EG(exit_status) = cli_shell_callbacks.cli_shell_run();


### PR DESCRIPTION
I found no reason why this is done this way.
Of course this will allow users to do stupid stuff like `fclose(STDOUT);` etc. but if they type in that code they clearly know what they're doing...

Easy fix, but I targeted master since this behaviour is long-standing and I'm not even sure this qualifies as a bug or as a feature.
Requesting review from Ilija since he also interacted with the issue.