### PR TITLE
Fix GH-11178: Segmentation fault in spl_array_it_get_current_data (PHP 8.1.18)

### DIFF
--- a/ext/spl/spl_array.c
+++ b/ext/spl/spl_array.c
@@ -1037,7 +1037,8 @@ static zval *spl_array_it_get_current_data(zend_object_iterator *iter) /* {{{ */
 		zend_hash_get_current_key_ex(aht, &key, NULL, spl_array_get_pos_ptr(aht, object));
 		zend_class_entry *ce = Z_OBJCE(object->array);
 		zend_property_info *prop_info = zend_get_property_info(ce, key, true);
-		if (ZEND_TYPE_IS_SET(prop_info->type)) {
+		ZEND_ASSERT(prop_info != ZEND_WRONG_PROPERTY_INFO);
+		if (EXPECTED(prop_info != NULL) && ZEND_TYPE_IS_SET(prop_info->type)) {
 			if (prop_info->flags & ZEND_ACC_READONLY) {
 				zend_throw_error(NULL,
 					"Cannot acquire reference to readonly property %s::$%s",

--- a/ext/spl/tests/gh11178.phpt
+++ b/ext/spl/tests/gh11178.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GH-11178 (Segmentation fault in spl_array_it_get_current_data (PHP 8.1.18))
+--FILE--
+<?php
+#[AllowDynamicProperties]
+class A implements IteratorAggregate {
+    function __construct() {
+        $this->{'x'} = 1;
+    }
+
+    function getIterator(): Traversable {
+        return new ArrayIterator($this);
+    }
+}
+
+$obj = new A;
+
+foreach ($obj as $k => &$v) {
+    $v = 3;
+}
+
+var_dump($obj);
+?>
+--EXPECT--
+object(A)#1 (1) {
+  ["x"]=>
+  &int(3)
+}


### PR DESCRIPTION
Dynamic property case in zend_get_property_info() can return NULL for prop info. This was not handled.