### PR TITLE
Add new test for array_fill() to cover the case when the parameter count is too large

### DIFF
--- a/ext/standard/tests/array/array_fill_error2.phpt
+++ b/ext/standard/tests/array/array_fill_error2.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test array_fill() function : error conditions - count is too large
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platform only"); ?>
+--FILE--
+<?php
+$intMax = 2147483647;
+
+// calling array_fill() with 'count' larger than INT_MAX
+try {
+    $array = array_fill(0, $intMax+1, 1);
+} catch (\ValueError $e) {
+    echo $e->getMessage() . "\n";
+}
+
+// calling array_fill() with 'count' equals to INT_MAX
+$array = array_fill(0, $intMax, 1);
+
+?>
+--EXPECTF--
+array_fill(): Argument #2 ($count) is too large
+
+Fatal error: Possible integer overflow in memory allocation (%d * %d + %d) in %s on line %d


### PR DESCRIPTION
I added a new test to cover an untested case in the array_fill() function.

**Before**
![image](https://user-images.githubusercontent.com/16556006/235812540-6f40b046-74ca-4ed5-a8a5-5dcb02cd4a39.png)

**After**
![image](https://user-images.githubusercontent.com/16556006/235812610-1c3336e7-e6de-41d8-9f36-94bd2362edc4.png)
