### PR TITLE
Fix some PDO tests

### DIFF
--- a/ext/pdo/tests/bug_65946.phpt
+++ b/ext/pdo/tests/bug_65946.phpt
@@ -17,7 +17,12 @@ $db = PDOTest::factory();
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 $db->exec('CREATE TABLE test(id int)');
 $db->exec('INSERT INTO test VALUES(1)');
-switch ($db->getAttribute(PDO::ATTR_DRIVER_NAME)) {
+
+$database = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+if ('odbc' === $database && 'MySQL' === $db->getAttribute(PDO::ATTR_SERVER_INFO))
+    $database = 'mysql';
+
+switch ($database) {
     case 'dblib':
         $sql = 'SELECT TOP :limit * FROM test';
         break;

--- a/ext/pdo/tests/pdo_039.phpt
+++ b/ext/pdo/tests/pdo_039.phpt
@@ -6,7 +6,6 @@ pdo
 <?php
 $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
-if (str_starts_with(getenv('PDOTEST_DSN'), "firebird")) die('xfail firebird driver does not behave as expected');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
 ?>
@@ -34,6 +33,9 @@ var_dump($conn->errorCode());
 $query = 'SELECT 1';
 if ($conn->getAttribute(PDO::ATTR_DRIVER_NAME) === 'oci') {
     $query .= ' FROM DUAL';
+}
+if ($conn->getAttribute(PDO::ATTR_DRIVER_NAME) === 'firebird') {
+    $query .= ' FROM FROM RDB$DATABASE';
 }
 var_dump($conn->errorCode());
 var_dump($conn->errorCode());

--- a/ext/pdo_dblib/tests/types.phpt
+++ b/ext/pdo_dblib/tests/types.phpt
@@ -19,6 +19,8 @@ function get_expected_float_string() {
         case '7.0':
         case '7.1':
         case '7.2':
+        case '7.3':
+        case '7.4':
         case '8.0':
             return '10.500';
         default:


### PR DESCRIPTION
- Adds support for TDS versions 7.3 and 7.4 in a PDO_DBLIB test
- Adds support for firebird in PDO_039 test
- Makes the bug_65946 test run with MySQL's ODBC connector

I also noticed that some of the PDO_ODBC tests check features that are unavailable on MySQL. Can tests be skipped or xfailed inside the FILE section? The DBMS is not known before a connection is made and that currently only happens after the SKIPIF section.