### PR TITLE
Fix use-of-uninitialized value in phar_object.c

### DIFF
--- a/ext/phar/phar_object.c
+++ b/ext/phar/phar_object.c
@@ -3697,7 +3697,7 @@ PHP_METHOD(Phar, offsetSet)
 {
 	char *fname, *cont_str = NULL;
 	size_t fname_len, cont_len;
-	zval *zresource;
+	zval *zresource = NULL;
 
 	if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, ZEND_NUM_ARGS(), "pr", &fname, &fname_len, &zresource) == FAILURE
 	&& zend_parse_parameters(ZEND_NUM_ARGS(), "ps", &fname, &fname_len, &cont_str, &cont_len) == FAILURE) {


### PR DESCRIPTION
resource would stay uninitialized if the first call to zend_parse_parameters fails, but the value is still passed to phar_add_file(). It's not used there if cont_str is provided and so didn't cause any issues.