### PR TITLE
Fix use-of-undefined in zend_fiber_object_gc of ex->call

### DIFF
--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -670,7 +670,7 @@ static HashTable *zend_fiber_object_gc(zend_object *object, zval **table, int *n
 	HashTable *lastSymTable = NULL;
 	zend_execute_data *ex = fiber->execute_data;
 	for (; ex; ex = ex->prev_execute_data) {
-		HashTable *symTable = zend_unfinished_execution_gc_ex(ex, ex->call, buf, false);
+		HashTable *symTable = zend_unfinished_execution_gc_ex(ex, ZEND_USER_CODE(ex->func->type) ? ex->call : NULL, buf, false);
 		if (symTable) {
 			if (lastSymTable) {
 				zval *val;


### PR DESCRIPTION
ex->call is only set for user calls, we shouldn't access it here. zend_unfinished_execution_gc_ex wouldn't actually use it for internal calls, so it didn't cause any serious issues.

Discovered using `MSAN`.