### PR TITLE
Remove unnecessary NULL assignments after ecalloc in streams

### DIFF
--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -2315,7 +2315,6 @@ PHPAPI php_stream_context *php_stream_context_alloc(void)
 	php_stream_context *context;
 
 	context = ecalloc(1, sizeof(php_stream_context));
-	context->notifier = NULL;
 	array_init(&context->options);
 
 	context->res = zend_register_resource(context, php_le_stream_context());

--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -469,7 +469,6 @@ PHP_FUNCTION(stream_wrapper_register)
 	uwrap->wrapper.wops = &user_stream_wops;
 	uwrap->wrapper.abstract = uwrap;
 	uwrap->wrapper.is_url = ((flags & PHP_STREAM_IS_URL) != 0);
-	uwrap->resource = NULL;
 
 	rsrc = zend_register_resource(uwrap, le_protocols);
 


### PR DESCRIPTION
ecalloc already zeroes the structure, so writing NULL is not necessary.