### PR TITLE
Fix GH-8426: make test fail while soap extention build

### DIFF
--- a/ext/soap/tests/bug73037.phpt
+++ b/ext/soap/tests/bug73037.phpt
@@ -59,8 +59,12 @@ function get_data($max)
 }
 
 $router = "bug73037_server.php";
-$args = substr(PHP_OS, 0, 3) == 'WIN'
-    ? ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=php_soap.dll"] : [];
+$args = ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=" . (substr(PHP_OS, 0, 3) == "WIN" ? "php_" : "") . "soap." . PHP_SHLIB_SUFFIX];
+if (php_ini_loaded_file()) {
+    // Necessary such that it works from a development directory in which case extension_dir might not be the real extension dir
+    $args[] = "-c";
+    $args[] = php_ini_loaded_file();
+}
 $code = <<<'PHP'
 $s = new SoapServer(NULL, array('uri' => 'http://here'));
 $s->setObject(new stdclass());

--- a/ext/soap/tests/custom_content_type.phpt
+++ b/ext/soap/tests/custom_content_type.phpt
@@ -13,8 +13,12 @@ soap
 
 include __DIR__ . "/../../../sapi/cli/tests/php_cli_server.inc";
 
-$args = substr(PHP_OS, 0, 3) == 'WIN'
-    ? ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=php_soap.dll"] : [];
+$args = ["-d", "extension_dir=" . ini_get("extension_dir"), "-d", "extension=" . (substr(PHP_OS, 0, 3) == "WIN" ? "php_" : "") . "soap." . PHP_SHLIB_SUFFIX];
+if (php_ini_loaded_file()) {
+  // Necessary such that it works from a development directory in which case extension_dir might not be the real extension dir
+  $args[] = "-c";
+  $args[] = php_ini_loaded_file();
+}
 $code = <<<'PHP'
 /* Receive */
 $content = trim(file_get_contents("php://input")) . PHP_EOL;


### PR DESCRIPTION
If you build soap as a shared object, then these tests fail on non-Windows, or when the PHP install hasn't been make install-ed yet, but is executed from the development directory.