### PR TITLE
Narrow some XSLTProcessor method parameter types

### DIFF
--- a/ext/xsl/php_xsl.stub.php
+++ b/ext/xsl/php_xsl.stub.php
@@ -71,29 +71,17 @@ const LIBEXSLT_DOTTED_VERSION = UNKNOWN;
 
 class XSLTProcessor
 {
-    /**
-     * @param DOMDocument|SimpleXMLElement $stylesheet
-     * @tentative-return-type
-     */
-    public function importStylesheet(object $stylesheet): bool {}
+    /** @tentative-return-type */
+    public function importStylesheet(DOMDocument|SimpleXMLElement $stylesheet): bool {}
 
-    /**
-     * @param DOMDocument|SimpleXMLElement $document
-     * @tentative-return-type
-     */
-    public function transformToDoc(object $document, ?string $returnClass = null): DOMDocument|false {}
+    /** @tentative-return-type */
+    public function transformToDoc(DOMDocument|SimpleXMLElement $document, ?string $returnClass = null): DOMDocument|false {}
 
-    /**
-     * @param DOMDocument|SimpleXMLElement $document
-     * @tentative-return-type
-     */
-    public function transformToUri(object $document, string $uri): int {}
+    /** @tentative-return-type */
+    public function transformToUri(DOMDocument|SimpleXMLElement $document, string $uri): int {}
 
-    /**
-     * @param DOMDocument|SimpleXMLElement $document
-     * @tentative-return-type
-     */
-    public function transformToXml(object $document): string|null|false {}
+    /** @tentative-return-type */
+    public function transformToXml(DOMDocument|SimpleXMLElement $document): string|null|false {}
 
     /** @tentative-return-type */
     public function setParameter(string $namespace, array|string $name, ?string $value = null): bool {}

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -1,22 +1,22 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7d747e7b5989c18169e67d9a9d70256583fffd8e */
+ * Stub hash: 3196c51fa9e9e41288572b42bbd74c5f8698a7de */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_importStylesheet, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, stylesheet, IS_OBJECT, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, stylesheet, DOMDocument|SimpleXMLElement, 0, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_XSLTProcessor_transformToDoc, 0, 1, DOMDocument, MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, document, IS_OBJECT, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, document, DOMDocument|SimpleXMLElement, 0, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, returnClass, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_transformToUri, 0, 2, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, document, IS_OBJECT, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, document, DOMDocument|SimpleXMLElement, 0, NULL)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_XSLTProcessor_transformToXml, 0, 1, MAY_BE_STRING|MAY_BE_NULL|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, document, IS_OBJECT, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, document, DOMDocument|SimpleXMLElement, 0, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_setParameter, 0, 2, _IS_BOOL, 0)


### PR DESCRIPTION
Apparently, `php_libxml_import_node` and `php_xsl_apply_stylesheet` (via `php_libxml_import_node`) throw an exception for invalid types.