### PR TITLE
Fix delayed early binding class redeclaration error

### DIFF
--- a/Zend/tests/delayed_early_binding_redeclaration-1.inc
+++ b/Zend/tests/delayed_early_binding_redeclaration-1.inc
@@ -1,0 +1,2 @@
+<?php
+class Bar extends Foo {}

--- a/Zend/tests/delayed_early_binding_redeclaration-2.inc
+++ b/Zend/tests/delayed_early_binding_redeclaration-2.inc
@@ -1,0 +1,2 @@
+<?php
+class Bar extends Foo {}

--- a/Zend/tests/delayed_early_binding_redeclaration.phpt
+++ b/Zend/tests/delayed_early_binding_redeclaration.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Delayed early binding throws class redeclaration error
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+class Foo {}
+include __DIR__ . '/delayed_early_binding_redeclaration-1.inc';
+include __DIR__ . '/delayed_early_binding_redeclaration-2.inc';
+var_dump(class_exists(Bar::class));
+?>
+--EXPECTF--
+Fatal error: Cannot declare class Bar, because the name is already in use in %sdelayed_early_binding_redeclaration-2.inc on line %d

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -358,9 +358,9 @@ static void zend_accel_do_delayed_early_binding(
 					ce = zend_try_early_bind(orig_ce, parent_ce, early_binding->lcname, zv);
 				}
 			}
-		}
-		if (ce && early_binding->cache_slot != (uint32_t) -1) {
-			*(void**)((char*)run_time_cache + early_binding->cache_slot) = ce;
+			if (ce && early_binding->cache_slot != (uint32_t) -1) {
+				*(void**)((char*)run_time_cache + early_binding->cache_slot) = ce;
+			}
 		}
 	}
 	CG(compiled_filename) = orig_compiled_filename;


### PR DESCRIPTION
If we bind the class to the runtime slot even if we're not the ones who have performed early binding we'll miss the redeclaration error in the ZEND_DECLARE_CLASS_DELAYED handler.