### PR TITLE
Implement delyed early binding for classes without parents

### DIFF
--- a/Zend/zend_inheritance.c
+++ b/Zend/zend_inheritance.c
@@ -3276,8 +3276,17 @@ ZEND_API zend_class_entry *zend_try_early_bind(zend_class_entry *ce, zend_class_
 	inheritance_status status;
 	zend_class_entry *proto = NULL;
 	zend_class_entry *orig_linking_class;
-	uint32_t is_cacheable = ce->ce_flags & ZEND_ACC_IMMUTABLE;
 
+	if (ce->ce_flags & ZEND_ACC_LINKED) {
+		ZEND_ASSERT(ce->parent == NULL);
+		if (UNEXPECTED(!register_early_bound_ce(delayed_early_binding, lcname, ce))) {
+			return NULL;
+		}
+		zend_observer_class_linked_notify(ce, lcname);
+		return ce;
+	}
+
+	uint32_t is_cacheable = ce->ce_flags & ZEND_ACC_IMMUTABLE;
 	UPDATE_IS_CACHEABLE(parent_ce);
 	if (is_cacheable) {
 		if (zend_inheritance_cache_get && zend_inheritance_cache_add) {

--- a/ext/opcache/tests/gh8846-1.inc
+++ b/ext/opcache/tests/gh8846-1.inc
@@ -1,0 +1,4 @@
+<?php
+class Foo {
+	const BAR = true;
+}

--- a/ext/opcache/tests/gh8846-2.inc
+++ b/ext/opcache/tests/gh8846-2.inc
@@ -1,0 +1,5 @@
+<?php
+var_dump(Foo::BAR);
+class Foo {
+	const BAR = true;
+}

--- a/ext/opcache/tests/gh8846.phpt
+++ b/ext/opcache/tests/gh8846.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Bug GH-8846: Delayed early binding can be used for classes without parents
+--EXTENSIONS--
+opcache
+--CONFLICTS--
+server
+--INI--
+opcache.validate_timestamps=1
+opcache.revalidate_freq=0
+--FILE--
+<?php
+
+file_put_contents(__DIR__ . '/gh8846-index.php', <<<'PHP'
+<?php
+if (!@$_GET['skip']) {
+    include __DIR__ . '/gh8846-1.inc';
+}
+include __DIR__ . '/gh8846-2.inc';
+echo "Ok\n";
+PHP);
+
+include 'php_cli_server.inc';
+php_cli_server_start('-d opcache.enable=1 -d opcache.enable_cli=1');
+
+echo file_get_contents('http://' . PHP_CLI_SERVER_ADDRESS . '/gh8846-index.php');
+echo "\n";
+echo file_get_contents('http://' . PHP_CLI_SERVER_ADDRESS . '/gh8846-index.php?skip=1');
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/gh8846-index.php');
+?>
+--EXPECTF--
+bool(true)
+<br />
+<b>Fatal error</b>:  Cannot declare class Foo, because the name is already in use in <b>%sgh8846-2.inc</b> on line <b>%d</b><br />
+
+bool(true)
+Ok

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -357,9 +357,10 @@ static void zend_accel_do_delayed_early_binding(
 			zval *zv = zend_hash_find_known_hash(EG(class_table), early_binding->rtd_key);
 			if (zv) {
 				zend_class_entry *orig_ce = Z_CE_P(zv);
-				zend_class_entry *parent_ce =
-					zend_hash_find_ex_ptr(EG(class_table), early_binding->lc_parent_name, 1);
-				if (parent_ce) {
+				zend_class_entry *parent_ce = !(orig_ce->ce_flags & ZEND_ACC_LINKED)
+					? zend_hash_find_ex_ptr(EG(class_table), early_binding->lc_parent_name, 1)
+					: NULL;
+				if (parent_ce || (orig_ce->ce_flags & ZEND_ACC_LINKED)) {
 					ce = zend_try_early_bind(orig_ce, parent_ce, early_binding->lcname, zv);
 				}
 			}


### PR DESCRIPTION
Fixes GH-8846

Reduced scope of GH-11227, it avoids storing classes without parents in inheritance cache during delayed early binding. 

~~Once again, this depends on GH-11226, which should be merged first.~~
Done.