### PR TITLE
Use emalloc and friends in curl

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -383,7 +383,9 @@ static void *zend_curl_malloc(size_t size) {
 }
 
 static void zend_curl_free(void *ptr) {
-	efree(ptr);
+	if (ptr) {
+		efree(ptr);
+	}
 }
 
 static void *zend_curl_realloc(void *ptr, size_t size) {

--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -378,6 +378,26 @@ PHP_MINFO_FUNCTION(curl)
 }
 /* }}} */
 
+static void *zend_curl_malloc(size_t size) {
+	return emalloc(size);
+}
+
+static void zend_curl_free(void *ptr) {
+	efree(ptr);
+}
+
+static void *zend_curl_realloc(void *ptr, size_t size) {
+	return erealloc(ptr, size);
+}
+
+static char *zend_curl_strdup(const char *s) {
+	return estrdup(s);
+}
+
+static void *zend_curl_calloc(size_t nmemb, size_t size) {
+	return ecalloc(nmemb, size);
+}
+
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(curl)
 {
@@ -403,7 +423,7 @@ PHP_MINIT_FUNCTION(curl)
 	}
 #endif
 
-	if (curl_global_init(CURL_GLOBAL_DEFAULT) != CURLE_OK) {
+	if (curl_global_init_mem(CURL_GLOBAL_DEFAULT, zend_curl_malloc, zend_curl_free, zend_curl_realloc, zend_curl_strdup, zend_curl_calloc) != CURLE_OK) {
 		return FAILURE;
 	}
 

--- a/ext/curl/tests/bug45161.phpt
+++ b/ext/curl/tests/bug45161.phpt
@@ -25,11 +25,14 @@ for ($i = 0; $i < 100; $i++) {
 */
 
 // Start actual test
-$start = memory_get_usage() + 1024;
 for($i = 0; $i < 1024; $i++) {
     curl_setopt($ch, CURLOPT_URL, "{$host}/get.inc");
     curl_setopt($ch, CURLOPT_FILE, $fp);
     curl_exec($ch);
+
+    if ($i === 0) {
+        $start = memory_get_usage();
+    }
 }
 if ($start < memory_get_usage()) {
     echo 'FAIL';


### PR DESCRIPTION
This avoids memory leaks when bailing in unexpected places (e.g. due to memory limits).