### PR TITLE
Quick fix for resolving issue #11099

### DIFF
--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -29,22 +29,38 @@ $(builddir)/phar/phar.inc: $(srcdir)/phar/phar.inc
 	-@test -d $(builddir)/phar || mkdir $(builddir)/phar
 	-@test -f $(builddir)/phar/phar.inc || cp $(srcdir)/phar/phar.inc $(builddir)/phar/phar.inc
 
+
+TEST_PHP_EXECUTABLE = $(shell $(PHP_EXECUTABLE) -v 2>&1)
+TEST_PHP_EXECUTABLE_RES = $(shell echo "$(TEST_PHP_EXECUTABLE)" | grep -c 'Exec format error')
+
 $(builddir)/phar.php: $(srcdir)/build_precommand.php $(srcdir)/phar/*.inc $(srcdir)/phar/*.php $(SAPI_CLI_PATH)
-	-@echo "Generating phar.php"
-	@$(PHP_PHARCMD_EXECUTABLE) $(PHP_PHARCMD_SETTINGS) $(srcdir)/build_precommand.php > $(builddir)/phar.php
+	-@(echo "Generating phar.php"; \
+	if [ $(TEST_PHP_EXECUTABLE_RES) -ne 1 ]; then \
+		$(PHP_PHARCMD_EXECUTABLE) $(PHP_PHARCMD_SETTINGS) $(srcdir)/build_precommand.php > $(builddir)/phar.php; \
+	else \
+		echo "Skipping phar.php generating during cross compilation"; \
+	fi)
 
 $(builddir)/phar.phar: $(builddir)/phar.php $(builddir)/phar/phar.inc $(srcdir)/phar/*.inc $(srcdir)/phar/*.php $(SAPI_CLI_PATH)
-	-@echo "Generating phar.phar"
-	-@rm -f $(builddir)/phar.phar
-	-@rm -f $(srcdir)/phar.phar
-	@$(PHP_PHARCMD_EXECUTABLE) $(PHP_PHARCMD_SETTINGS) $(builddir)/phar.php pack -f $(builddir)/phar.phar -a pharcommand -c auto -x \\.svn -p 0 -s $(srcdir)/phar/phar.php -h sha1 -b "$(PHP_PHARCMD_BANG)"  $(srcdir)/phar/
-	-@chmod +x $(builddir)/phar.phar
+	-@(echo "Generating phar.phar"; \
+	if [ $(TEST_PHP_EXECUTABLE_RES) -ne 1 ]; then \
+		rm -f $(builddir)/phar.phar; \
+		rm -f $(srcdir)/phar.phar; \
+		$(PHP_PHARCMD_EXECUTABLE) $(PHP_PHARCMD_SETTINGS) $(builddir)/phar.php pack -f $(builddir)/phar.phar -a pharcommand -c auto -x \\.svn -p 0 -s $(srcdir)/phar/phar.php -h sha1 -b "$(PHP_PHARCMD_BANG)"  $(srcdir)/phar/; \
+		chmod +x $(builddir)/phar.phar; \
+	else \
+		echo "Skipping phar.phar generating during cross compilation"; \
+	fi)
 
 install-pharcmd: pharcmd
-	-@$(mkinstalldirs) $(INSTALL_ROOT)$(bindir)
-	$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix).phar
-	-@rm -f $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix)
-	$(LN_S) -f $(program_prefix)phar$(program_suffix).phar $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix)
-	@$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1
-	@$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phar$(program_suffix).1
-	@$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phar$(program_suffix).phar.1
+	@(if [ $(TEST_PHP_EXECUTABLE_RES) -ne 1 ]; then \
+		$(mkinstalldirs) $(INSTALL_ROOT)$(bindir); \
+		$(INSTALL) $(builddir)/phar.phar $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix).phar; \
+		rm -f $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix); \
+		$(LN_S) -f $(program_prefix)phar$(program_suffix).phar $(INSTALL_ROOT)$(bindir)/$(program_prefix)phar$(program_suffix); \
+		$(mkinstalldirs) $(INSTALL_ROOT)$(mandir)/man1; \
+		$(INSTALL_DATA) $(builddir)/phar.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phar$(program_suffix).1; \
+		$(INSTALL_DATA) $(builddir)/phar.phar.1 $(INSTALL_ROOT)$(mandir)/man1/$(program_prefix)phar$(program_suffix).phar.1; \
+	else \
+		echo "Skipping install-pharcmd during cross compilation"; \
+	fi)


### PR DESCRIPTION
# Changed log

- It's the quick fix for resolving the issue #11099. It can ignore error about generating `phar` steps when running the cross compiling.