### PR TITLE
Fix bug GH-11246 cli/get_set_process_title initialisation failure on MacOS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-11222 (foreach by-ref may jump over keys during a rehash).
     (Bob)
 
+- CLI:
+  . Fixed bug GH-11246 (cli/get_set_process_title fails
+    on MacOS). (James Lucas)
+
 - Exif:
   . Fixed bug GH-10834 (exif_read_data() cannot read smaller stream wrapper
     chunk sizes). (nielsdos)

--- a/sapi/cli/ps_title.c
+++ b/sapi/cli/ps_title.c
@@ -167,18 +167,20 @@ char** save_ps_args(int argc, char** argv)
             end_of_area = argv[i] + strlen(argv[i]);
         }
 
+		if (non_contiguous_area != 0)
+			goto clobber_error;
+
         /*
          * check for contiguous environ strings following argv
          */
         for (i = 0; (non_contiguous_area == 0) && (environ[i] != NULL); i++)
         {
-            if (end_of_area + 1 != environ[i])
+            if (end_of_area + 1 != environ[i]) {
                 non_contiguous_area = 1;
-            end_of_area = environ[i] + strlen(environ[i]);
+            } else {
+            	end_of_area = environ[i] + strlen(environ[i]);
+            }
         }
-
-        if (non_contiguous_area != 0)
-            goto clobber_error;
 
         ps_buffer = argv[0];
         ps_buffer_size = end_of_area - argv[0];


### PR DESCRIPTION
Fixes #11246, when executing on MacOS it was found that the environ area my not be contiguous. 

Checking the original Postgres implementation https://github.com/postgres/postgres/blob/master/src/backend/utils/misc/ps_status.c the PHP code fails if either argv or environ is non-contiguous whereas the original code only fails if argv is ever non-contiguous.

Additionally the end_of_area variable is changed even if we hit a non-contiguous environ section, another divergence from the original code