### PR TITLE
Fix GH-11245 (In some specific cases SWITCH with one default statement will cause segfault)

### DIFF
--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -288,7 +288,7 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 							case ZEND_PRE_DEC_OBJ:
 							case ZEND_PRE_INC_STATIC_PROP:
 							case ZEND_PRE_DEC_STATIC_PROP:
-								if (src < op_array->opcodes + block->start || src > op_array->opcodes + block->len) {
+								if (src < op_array->opcodes + block->start) {
 									break;
 								}
 								src->result_type = IS_UNUSED;
@@ -303,7 +303,7 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 				} else if (opline->op1_type == IS_VAR) {
 					src = VAR_SOURCE(opline->op1);
 					/* V = OP, FREE(V) => OP. NOP */
-					if (src >= op_array->opcodes + block->start && src <= op_array->opcodes + block->len &&
+					if (src >= op_array->opcodes + block->start &&
 					    src->opcode != ZEND_FETCH_R &&
 					    src->opcode != ZEND_FETCH_STATIC_PROP_R &&
 					    src->opcode != ZEND_FETCH_DIM_R &&

--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -257,54 +257,54 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 				break;
 
 			case ZEND_FREE:
-				src = VAR_SOURCE(opline->op1);
-				if (!src) {
-					break;
-				}
 				/* Note: Only remove the source if the source is local to this block.
 				 * If it's not local, then the other blocks successors must also eventually either FREE or consume the temporary,
 				 * hence removing the temporary is not safe in the general case unless specified otherwise.
 				 * The source's result can also not be removed in such a case because that would cause a memory leak. */
 				if (opline->op1_type == IS_TMP_VAR) {
-					switch (src->opcode) {
-						case ZEND_BOOL:
-						case ZEND_BOOL_NOT:
-							/* T = BOOL(X), FREE(T) => T = BOOL(X) */
-							/* The remaining BOOL is removed by a separate optimization */
-							/* The source is a bool, no source removals take place, so can be done non-locally. */
-							VAR_SOURCE(opline->op1) = NULL;
-							MAKE_NOP(opline);
-							++(*opt_count);
-							break;
-						case ZEND_ASSIGN:
-						case ZEND_ASSIGN_DIM:
-						case ZEND_ASSIGN_OBJ:
-						case ZEND_ASSIGN_STATIC_PROP:
-						case ZEND_ASSIGN_OP:
-						case ZEND_ASSIGN_DIM_OP:
-						case ZEND_ASSIGN_OBJ_OP:
-						case ZEND_ASSIGN_STATIC_PROP_OP:
-						case ZEND_PRE_INC:
-						case ZEND_PRE_DEC:
-						case ZEND_PRE_INC_OBJ:
-						case ZEND_PRE_DEC_OBJ:
-						case ZEND_PRE_INC_STATIC_PROP:
-						case ZEND_PRE_DEC_STATIC_PROP:
-							if (src < op_array->opcodes + block->start || src > op_array->opcodes + block->len) {
+					src = VAR_SOURCE(opline->op1);
+					if (src) {
+						switch (src->opcode) {
+							case ZEND_BOOL:
+							case ZEND_BOOL_NOT:
+								/* T = BOOL(X), FREE(T) => T = BOOL(X) */
+								/* The remaining BOOL is removed by a separate optimization */
+								/* The source is a bool, no source removals take place, so can be done non-locally. */
+								VAR_SOURCE(opline->op1) = NULL;
+								MAKE_NOP(opline);
+								++(*opt_count);
 								break;
-							}
-							src->result_type = IS_UNUSED;
-							VAR_SOURCE(opline->op1) = NULL;
-							MAKE_NOP(opline);
-							++(*opt_count);
-							break;
-						default:
-							break;
+							case ZEND_ASSIGN:
+							case ZEND_ASSIGN_DIM:
+							case ZEND_ASSIGN_OBJ:
+							case ZEND_ASSIGN_STATIC_PROP:
+							case ZEND_ASSIGN_OP:
+							case ZEND_ASSIGN_DIM_OP:
+							case ZEND_ASSIGN_OBJ_OP:
+							case ZEND_ASSIGN_STATIC_PROP_OP:
+							case ZEND_PRE_INC:
+							case ZEND_PRE_DEC:
+							case ZEND_PRE_INC_OBJ:
+							case ZEND_PRE_DEC_OBJ:
+							case ZEND_PRE_INC_STATIC_PROP:
+							case ZEND_PRE_DEC_STATIC_PROP:
+								if (src < op_array->opcodes + block->start || src > op_array->opcodes + block->len) {
+									break;
+								}
+								src->result_type = IS_UNUSED;
+								VAR_SOURCE(opline->op1) = NULL;
+								MAKE_NOP(opline);
+								++(*opt_count);
+								break;
+							default:
+								break;
+						}
 					}
 				} else if (opline->op1_type == IS_VAR) {
+					src = VAR_SOURCE(opline->op1);
 					/* V = OP, FREE(V) => OP. NOP */
 					if (src >= op_array->opcodes + block->start && src <= op_array->opcodes + block->len &&
-						src->opcode != ZEND_FETCH_R &&
+					    src->opcode != ZEND_FETCH_R &&
 					    src->opcode != ZEND_FETCH_STATIC_PROP_R &&
 					    src->opcode != ZEND_FETCH_DIM_R &&
 					    src->opcode != ZEND_FETCH_OBJ_R &&

--- a/Zend/Optimizer/block_pass.c
+++ b/Zend/Optimizer/block_pass.c
@@ -257,46 +257,54 @@ static void zend_optimize_block(zend_basic_block *block, zend_op_array *op_array
 				break;
 
 			case ZEND_FREE:
+				src = VAR_SOURCE(opline->op1);
+				if (!src) {
+					break;
+				}
+				/* Note: Only remove the source if the source is local to this block.
+				 * If it's not local, then the other blocks successors must also eventually either FREE or consume the temporary,
+				 * hence removing the temporary is not safe in the general case unless specified otherwise.
+				 * The source's result can also not be removed in such a case because that would cause a memory leak. */
 				if (opline->op1_type == IS_TMP_VAR) {
-					src = VAR_SOURCE(opline->op1);
-					if (src) {
-						switch (src->opcode) {
-							case ZEND_BOOL:
-							case ZEND_BOOL_NOT:
-								/* T = BOOL(X), FREE(T) => T = BOOL(X) */
-								/* The remaining BOOL is removed by a separate optimization */
-								VAR_SOURCE(opline->op1) = NULL;
-								MAKE_NOP(opline);
-								++(*opt_count);
+					switch (src->opcode) {
+						case ZEND_BOOL:
+						case ZEND_BOOL_NOT:
+							/* T = BOOL(X), FREE(T) => T = BOOL(X) */
+							/* The remaining BOOL is removed by a separate optimization */
+							/* The source is a bool, no source removals take place, so can be done non-locally. */
+							VAR_SOURCE(opline->op1) = NULL;
+							MAKE_NOP(opline);
+							++(*opt_count);
+							break;
+						case ZEND_ASSIGN:
+						case ZEND_ASSIGN_DIM:
+						case ZEND_ASSIGN_OBJ:
+						case ZEND_ASSIGN_STATIC_PROP:
+						case ZEND_ASSIGN_OP:
+						case ZEND_ASSIGN_DIM_OP:
+						case ZEND_ASSIGN_OBJ_OP:
+						case ZEND_ASSIGN_STATIC_PROP_OP:
+						case ZEND_PRE_INC:
+						case ZEND_PRE_DEC:
+						case ZEND_PRE_INC_OBJ:
+						case ZEND_PRE_DEC_OBJ:
+						case ZEND_PRE_INC_STATIC_PROP:
+						case ZEND_PRE_DEC_STATIC_PROP:
+							if (src < op_array->opcodes + block->start || src > op_array->opcodes + block->len) {
 								break;
-							case ZEND_ASSIGN:
-							case ZEND_ASSIGN_DIM:
-							case ZEND_ASSIGN_OBJ:
-							case ZEND_ASSIGN_STATIC_PROP:
-							case ZEND_ASSIGN_OP:
-							case ZEND_ASSIGN_DIM_OP:
-							case ZEND_ASSIGN_OBJ_OP:
-							case ZEND_ASSIGN_STATIC_PROP_OP:
-							case ZEND_PRE_INC:
-							case ZEND_PRE_DEC:
-							case ZEND_PRE_INC_OBJ:
-							case ZEND_PRE_DEC_OBJ:
-							case ZEND_PRE_INC_STATIC_PROP:
-							case ZEND_PRE_DEC_STATIC_PROP:
-								src->result_type = IS_UNUSED;
-								VAR_SOURCE(opline->op1) = NULL;
-								MAKE_NOP(opline);
-								++(*opt_count);
-								break;
-							default:
-								break;
-						}
+							}
+							src->result_type = IS_UNUSED;
+							VAR_SOURCE(opline->op1) = NULL;
+							MAKE_NOP(opline);
+							++(*opt_count);
+							break;
+						default:
+							break;
 					}
 				} else if (opline->op1_type == IS_VAR) {
-					src = VAR_SOURCE(opline->op1);
 					/* V = OP, FREE(V) => OP. NOP */
-					if (src &&
-					    src->opcode != ZEND_FETCH_R &&
+					if (src >= op_array->opcodes + block->start && src <= op_array->opcodes + block->len &&
+						src->opcode != ZEND_FETCH_R &&
 					    src->opcode != ZEND_FETCH_STATIC_PROP_R &&
 					    src->opcode != ZEND_FETCH_DIM_R &&
 					    src->opcode != ZEND_FETCH_OBJ_R &&

--- a/ext/opcache/tests/opt/gh11245_1.phpt
+++ b/ext/opcache/tests/opt/gh11245_1.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-11245: In some specific cases SWITCH with one default statement will cause segfault (VAR variation)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=0x7FFFBFFF
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+function xx() { return "somegarbage"; }
+switch (xx()) {
+	default:
+		if (!empty($xx)) {return;}
+}
+?>
+--EXPECTF--
+$_main:
+     ; (lines=4, args=0, vars=1, tmps=1)
+     ; (after optimizer)
+     ; %s
+0000 T1 = ISSET_ISEMPTY_CV (empty) CV0($xx)
+0001 JMPNZ T1 0003
+0002 RETURN null
+0003 RETURN int(1)
+
+xx:
+     ; (lines=1, args=0, vars=0, tmps=0)
+     ; (after optimizer)
+     ; %s
+0000 RETURN string("somegarbage")

--- a/ext/opcache/tests/opt/gh11245_2.phpt
+++ b/ext/opcache/tests/opt/gh11245_2.phpt
@@ -1,0 +1,35 @@
+--TEST--
+GH-11245: In some specific cases SWITCH with one default statement will cause segfault (TMP variation)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.optimization_level=0x7FFFBFFF
+opcache.opt_debug_level=0x20000
+opcache.preload=
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+class X {
+    // Chosen to test for a memory leak.
+    static $prop = "aa";
+}
+switch (++X::$prop) {
+    default:
+        if (empty($xx)) {return;}
+}
+?>
+--EXPECTF--
+$_main:
+     ; (lines=7, args=0, vars=1, tmps=2)
+     ; (after optimizer)
+     ; %s
+0000 T1 = PRE_INC_STATIC_PROP string("prop") string("X")
+0001 T2 = ISSET_ISEMPTY_CV (empty) CV0($xx)
+0002 JMPZ T2 0005
+0003 FREE T1
+0004 RETURN null
+0005 FREE T1
+0006 RETURN int(1)
+LIVE RANGES:
+     1: 0001 - 0005 (tmp/var)


### PR DESCRIPTION
The block optimizer pass allows the use of sources of the preceding block if the block is a follower and not a target. This causes issues when trying to remove FREE instructions: if the source is not in the block of the FREE, then the FREE and source are still removed. Therefore the other successor blocks, which must consume or FREE the temporary, will still contain the FREE opline. This opline will now refer to a temporary that doesn't exist anymore, which most of the time results in a crash.

Fix it by checking if the source is in the same block as the FREE. For non-local optimizations, we'll let the SSA based optimizations handle those cases.