### PR TITLE
make FILE_ constants not collide with LOCK_

### DIFF
--- a/ext/standard/file.h
+++ b/ext/standard/file.h
@@ -54,11 +54,11 @@ PHPAPI ssize_t php_fputcsv(php_stream *stream, zval *fields, char delimiter, cha
 
 #define META_DEF_BUFSIZE 8192
 
-#define PHP_FILE_USE_INCLUDE_PATH (1 << 0)
-#define PHP_FILE_IGNORE_NEW_LINES (1 << 1)
-#define PHP_FILE_SKIP_EMPTY_LINES (1 << 2)
-#define PHP_FILE_APPEND (1 << 3)
-#define PHP_FILE_NO_DEFAULT_CONTEXT (1 << 4)
+#define PHP_FILE_USE_INCLUDE_PATH (1 << 3) // avoid collision with the LOCK_ constants.
+#define PHP_FILE_IGNORE_NEW_LINES (1 << 4)
+#define PHP_FILE_SKIP_EMPTY_LINES (1 << 5)
+#define PHP_FILE_APPEND (1 << 6)
+#define PHP_FILE_NO_DEFAULT_CONTEXT (1 << 7)
 
 typedef enum _php_meta_tags_token {
 	TOK_EOF = 0,


### PR DESCRIPTION
Ultimately i wish to make LOCK_SH usable in file_get_contents. With baby steps, i think the first step is to make sure FILE_USE_INCLUDE_PATH does not collide with LOCK_SH (which, prior to this patch, it does)

it's annoying to have to write
```
$fp = fopen("file","rb");
flock($fp, LOCK_SH);
$content = stream_get_contents($fp);
flock($fp, LOCK_UN);
fclose($fp);
```
when all i want to write is
$content = file_get_contents("file", LOCK_SH);

also it's really weird that file_put_contents support LOCK_EX but file_get_contents does not support LOCK_SH.