### PR TITLE
Allow dynamic class names in class constant const exprs

### DIFF
--- a/Zend/tests/attributes/018_fatal_error_in_argument.phpt
+++ b/Zend/tests/attributes/018_fatal_error_in_argument.phpt
@@ -3,9 +3,9 @@ Don't free uninitialized memory if a fatal error occurs in an attribute argument
 --FILE--
 <?php
 
-#[Attr(a->b::c)]
+#[Attr(`exit 0`)]
 function test() {}
 
 ?>
 --EXPECTF--
-Fatal error: Dynamic class names are not allowed in compile-time class constant references in %s on line %d
+Fatal error: Constant expression contains invalid operations in %s on line %d

--- a/Zend/tests/class_on_expression_in_constant_expression.phpt
+++ b/Zend/tests/class_on_expression_in_constant_expression.phpt
@@ -1,10 +1,20 @@
 --TEST--
-::class on an expression cannot be used inside constant expressions
+::class on an expression inside constant expressions must be object
 --FILE--
 <?php
 
-const A = [0]::class;
+class Foo {}
+
+const A = (new Foo())::class;
+var_dump(A);
+
+const B = [0]::class;
 
 ?>
 --EXPECTF--
-Fatal error: (expression)::class cannot be used in constant expressions in %s on line %d
+string(3) "Foo"
+
+Fatal error: Uncaught TypeError: Cannot use "::class" on array in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/tests/constant_expressions_dynamic_class_name_error.phpt
+++ b/Zend/tests/constant_expressions_dynamic_class_name_error.phpt
@@ -8,4 +8,4 @@ const C = $foo::BAR;
 
 ?>
 --EXPECTF--
-Fatal error: Dynamic class names are not allowed in compile-time class constant references in %s on line %d
+Fatal error: Constant expression contains invalid operations in %s on line %d

--- a/Zend/tests/constexpr_class_const_dynamic_class_name_001.phpt
+++ b/Zend/tests/constexpr_class_const_dynamic_class_name_001.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Dynamic class names in class constants in constant expressions
+--FILE--
+<?php
+
+class A {
+    const CONST = 'CONST';
+}
+
+const A_CONST = 'A';
+
+class B {
+    const CC_STRING_NAME = (self::B_NAME)::CONST;
+    const B_NAME = 'B';
+    const CONST = 'CONST';
+    const CC_OBJECT_NAME = (A_CONST)::CONST;
+}
+
+var_dump(B::CC_STRING_NAME);
+var_dump(B::CC_OBJECT_NAME);
+
+?>
+--EXPECT--
+string(5) "CONST"
+string(5) "CONST"

--- a/Zend/tests/constexpr_class_const_dynamic_class_name_002.phpt
+++ b/Zend/tests/constexpr_class_const_dynamic_class_name_002.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Dynamic class names in class constants in constant expressions
+--FILE--
+<?php
+
+class B {
+    const CC = (self::C_NAME)::CONST;
+    const C_NAME = [];
+}
+
+try {
+    var_dump(B::CC);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+Class name must be a valid object or a string


### PR DESCRIPTION
There's not really a good reason why this isn't allowed.