### PR TITLE
ext/gd/tests/bug45799.phpt: tweak to work with external gd.

### DIFF
--- a/ext/gd/tests/bug45799.phpt
+++ b/ext/gd/tests/bug45799.phpt
@@ -9,4 +9,4 @@ imagepng($img);
 imagedestroy($img);
 ?>
 --EXPECTF--
-Warning: imagepng(): gd-png error: no colors in palette in %s on line %d
+Warning: imagepng(): gd-png error: no colors in palette%win %s on line %d


### PR DESCRIPTION
The expected output from this test contains an extra newline with gd-2.3.3 from the system (Gentoo). Adding a whitespace wildcard takes care of it, and the test still passes with the bundled version of gd.