### PR TITLE
ext/gd/tests: external gd-2.3.3 compatibility.

### DIFF
--- a/ext/gd/tests/bug38212-mb.phpt
+++ b/ext/gd/tests/bug38212-mb.phpt
@@ -2,6 +2,12 @@
 Bug #38212 (Seg Fault on invalid imagecreatefromgd2part() parameters)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 require __DIR__ . '/func.inc';

--- a/ext/gd/tests/bug38212.phpt
+++ b/ext/gd/tests/bug38212.phpt
@@ -2,6 +2,12 @@
 Bug #38212 (Seg Fault on invalid imagecreatefromgd2part() parameters)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 require __DIR__ . '/func.inc';

--- a/ext/gd/tests/bug41442.phpt
+++ b/ext/gd/tests/bug41442.phpt
@@ -4,6 +4,10 @@ Bug #41442 (imagegd2() under output control)
 gd
 --SKIPIF--
 <?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+
     if (!function_exists("imagegd2")) {
         die("skip GD2 support unavailable");
     }

--- a/ext/gd/tests/bug71912-mb.phpt
+++ b/ext/gd/tests/bug71912-mb.phpt
@@ -4,6 +4,14 @@ Bug #71912 (libgd: signedness vulnerability)
 gd
 --SKIPIF--
 <?php
+        if (!GD_BUNDLED) {
+            if (version_compare(GD_VERSION, '2.2.0', '<')) {
+                die("skip test requires GD 2.2.0 or higher");
+            }
+            if (version_compare(GD_VERSION, '2.3.3', '>=')) {
+                die("skip test requires GD 2.3.2 or older");
+            }
+        }
         if(!function_exists('imagecreatefromgd2')) die('skip imagecreatefromgd2() not available');
 ?>
 --FILE--

--- a/ext/gd/tests/bug71912.phpt
+++ b/ext/gd/tests/bug71912.phpt
@@ -4,8 +4,13 @@ Bug #71912 (libgd: signedness vulnerability)
 gd
 --SKIPIF--
 <?php
-        if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.0', '<')) {
-            die("skip test requires GD 2.2.0 or higher");
+        if (!GD_BUNDLED) {
+            if (version_compare(GD_VERSION, '2.2.0', '<')) {
+                die("skip test requires GD 2.2.0 or higher");
+            }
+            if (version_compare(GD_VERSION, '2.3.3', '>=')) {
+                die("skip test requires GD 2.3.2 or older");
+            }
         }
         if(!function_exists('imagecreatefromgd2')) die('skip imagecreatefromgd2() not available');
 ?>

--- a/ext/gd/tests/bug72339.phpt
+++ b/ext/gd/tests/bug72339.phpt
@@ -5,8 +5,14 @@ gd
 --SKIPIF--
 <?php
 if (!function_exists("imagecreatefromgd2")) print "skip";
-if (!GD_BUNDLED && version_compare(GD_VERSION, '2.2.2', '<')) {
-    die("skip test requires GD 2.2.2 or higher");
+
+if (!GD_BUNDLED) {
+    if (version_compare(GD_VERSION, '2.2.2', '<')) {
+        die("skip test requires GD 2.2.2 or higher");
+    }
+    if (version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
 }
 ?>
 --FILE--

--- a/ext/gd/tests/bug73161.phpt
+++ b/ext/gd/tests/bug73161.phpt
@@ -4,6 +4,12 @@ Bug #73161 (imagecreatefromgd2() may leak memory)
 We're testing for a memory leak that might not even show up with valgrind.
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 $im = imagecreatefromgd2(__DIR__ . DIRECTORY_SEPARATOR . 'bug73161.gd2');

--- a/ext/gd/tests/bug73868.phpt
+++ b/ext/gd/tests/bug73868.phpt
@@ -2,6 +2,12 @@
 Bug 73868 (DOS vulnerability in gdImageCreateFromGd2Ctx())
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 var_dump(imagecreatefromgd2(__DIR__ . DIRECTORY_SEPARATOR . 'bug73868.gd2'));

--- a/ext/gd/tests/bug73869.phpt
+++ b/ext/gd/tests/bug73869.phpt
@@ -2,6 +2,12 @@
 Bug #73869 (Signed Integer Overflow gd_io.c)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 var_dump(imagecreatefromgd2(__DIR__ . DIRECTORY_SEPARATOR . 'bug73869a.gd2'));

--- a/ext/gd/tests/crafted_gd2.phpt
+++ b/ext/gd/tests/crafted_gd2.phpt
@@ -2,6 +2,12 @@
 Test max colors for a gd image.
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 imagecreatefromgd(__DIR__ . '/crafted.gd2');

--- a/ext/gd/tests/createfromgd2.phpt
+++ b/ext/gd/tests/createfromgd2.phpt
@@ -4,6 +4,9 @@ imagecreatefromgd2
 gd
 --SKIPIF--
 <?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
         if (!function_exists('imagecreatefromgd2')) die("skip gd extension not available\n");
 ?>
 --FILE--

--- a/ext/gd/tests/gif2gd.phpt
+++ b/ext/gd/tests/gif2gd.phpt
@@ -4,6 +4,10 @@ gif --> gd1/gd2 conversion test
 gd
 --SKIPIF--
 <?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+
     if (!function_exists("imagecreatefromgif")) {
         die("skip gif read support unavailable");
     }

--- a/ext/gd/tests/jpg2gd-mb.phpt
+++ b/ext/gd/tests/jpg2gd-mb.phpt
@@ -4,6 +4,10 @@ jpeg <--> gd1/gd2 conversion test
 gd
 --SKIPIF--
 <?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+
     if (!function_exists("imagecreatefromjpeg") || !function_exists("imagejpeg")) {
         die("skip jpeg support unavailable");
     }

--- a/ext/gd/tests/jpg2gd.phpt
+++ b/ext/gd/tests/jpg2gd.phpt
@@ -4,6 +4,10 @@ jpeg <--> gd1/gd2 conversion test
 gd
 --SKIPIF--
 <?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+
     if (!function_exists("imagecreatefromjpeg") || !function_exists("imagejpeg")) {
         die("skip jpeg support unavailable");
     }

--- a/ext/gd/tests/png2gd.phpt
+++ b/ext/gd/tests/png2gd.phpt
@@ -4,6 +4,10 @@ png <--> gd1/gd2 conversion test
 gd
 --SKIPIF--
 <?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+
     if (!function_exists("imagecreatefrompng") || !function_exists("imagepng")) {
         die("skip png support unavailable");
     }

--- a/ext/gd/tests/xpm2gd.phpt
+++ b/ext/gd/tests/xpm2gd.phpt
@@ -4,6 +4,10 @@ xpm --> gd1/gd2 conversion test
 gd
 --SKIPIF--
 <?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+
     if (!function_exists("imagecreatefromxpm")) {
         die("skip xpm read support unavailable");
     }


### PR DESCRIPTION
Support for the legacy "gd" image format was removed from gd-2.3.3 upstream:

  https://github.com/libgd/libgd/blob/master/CHANGELOG.md#233---2021-09-12

Several tests for the gd extension utilize that format, and naturally fail when gd-2.3.3 from the system is used. This commit skips those tests when the version of gd is at least 2.3.3.