### PR TITLE
More external gd-2.3.3 test fixes

### DIFF
--- a/ext/gd/tests/bug73155.phpt
+++ b/ext/gd/tests/bug73155.phpt
@@ -2,6 +2,12 @@
 Bug #73155 (imagegd2() writes wrong chunk sizes on boundaries)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 $im = imagecreate(64, 64);

--- a/ext/gd/tests/bug73157.phpt
+++ b/ext/gd/tests/bug73157.phpt
@@ -2,6 +2,12 @@
 Bug #73157 (imagegd2() ignores 3rd param if 4 are given)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 $im = imagecreate(8, 8);

--- a/ext/gd/tests/bug73159.phpt
+++ b/ext/gd/tests/bug73159.phpt
@@ -2,6 +2,12 @@
 Bug #73159 (imagegd2(): unrecognized formats may result in corrupted files)
 --EXTENSIONS--
 gd
+--SKIPIF--
+<?php
+    if (!GD_BUNDLED && version_compare(GD_VERSION, '2.3.3', '>=')) {
+        die("skip test requires GD 2.3.2 or older");
+    }
+?>
 --FILE--
 <?php
 $im = imagecreatetruecolor(10, 10);

--- a/ext/gd/tests/bug77973.phpt
+++ b/ext/gd/tests/bug77973.phpt
@@ -15,7 +15,7 @@ $im = imagecreatefromxbm($filepath);
 var_dump($im);
 ?>
 --EXPECTF--
-Warning: imagecreatefromxbm(): Invalid XBM in %s on line %d
+Warning: imagecreatefromxbm(): %cnvalid XBM in %s on line %d
 
 Warning: imagecreatefromxbm(): "%s" is not a valid XBM file in %s on line %d
 bool(false)


### PR DESCRIPTION
Support for the "gd" image format was removed from gd-2.3.3, breaking several of PHP's tests when a new enough external gd is used. Here I've addressed a few more failures that required some investigation.
