### PR TITLE
Fix GH-11274: POST/PATCH request via file_get_contents + stream_context_create switches to GET after a HTTP 308 redirect

### DIFF
--- a/ext/standard/tests/http/bug67430.phpt
+++ b/ext/standard/tests/http/bug67430.phpt
@@ -41,7 +41,7 @@ POST / HTTP/1.1
 Host: %s:%d
 Connection: close
 
-GET /foo HTTP/1.1
+POST /foo HTTP/1.1
 Host: %s:%d
 Connection: close
 

--- a/ext/standard/tests/http/gh11274.phpt
+++ b/ext/standard/tests/http/gh11274.phpt
@@ -1,0 +1,62 @@
+--TEST--
+GH-11274 (POST/PATCH request via file_get_contents + stream_context_create switches to GET after a HTTP 308 redirect)
+--INI--
+allow_url_fopen=1
+--CONFLICTS--
+server
+--FILE--
+<?php
+$serverCode = <<<'CODE'
+$uri = $_SERVER['REQUEST_URI'];
+if (isset($_GET["desired_status"]) && $uri[strlen($uri) - 1] !== '/') {
+    $desired_status = (int) $_GET["desired_status"];
+    http_response_code($desired_status);
+    header("Location: $uri/");
+    exit;
+}
+
+echo "method: ", $_SERVER['REQUEST_METHOD'], "; body: ", file_get_contents('php://input'), "\n";
+CODE;
+
+include __DIR__."/../../../../sapi/cli/tests/php_cli_server.inc";
+php_cli_server_start($serverCode, null, []);
+
+foreach ([null, 301, 302, 307, 308] as $status) {
+    if (is_null($status)) {
+        echo "-- Testing unredirected request --\n";
+    } else {
+        echo "-- Testing redirect status code $status --\n";
+    }
+    $suffix = $status ? "?desired_status=$status" : "";
+    echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/test$suffix", false, stream_context_create(['http' => ['method' => 'POST', 'header' => 'Content-type: application/x-www-form-urlencoded', 'content' => http_build_query(['hello' => 'world'])]]));
+    echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/test$suffix", false, stream_context_create(['http' => ['method' => 'PATCH', 'header' => 'Content-type: application/x-www-form-urlencoded', 'content' => http_build_query(['hello' => 'world'])]]));
+    echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/test/$suffix", false, stream_context_create(['http' => ['method' => 'POST', 'header' => 'Content-type: application/x-www-form-urlencoded', 'content' => http_build_query(['hello' => 'world'])]]));
+    echo file_get_contents("http://" . PHP_CLI_SERVER_ADDRESS . "/test/$suffix", false, stream_context_create(['http' => ['method' => 'PATCH', 'header' => 'Content-type: application/x-www-form-urlencoded', 'content' => http_build_query(['hello' => 'world'])]]));
+}
+?>
+--EXPECT--
+-- Testing unredirected request --
+method: POST; body: hello=world
+method: PATCH; body: hello=world
+method: POST; body: hello=world
+method: PATCH; body: hello=world
+-- Testing redirect status code 301 --
+method: GET; body: 
+method: GET; body: 
+method: GET; body: 
+method: GET; body: 
+-- Testing redirect status code 302 --
+method: GET; body: 
+method: GET; body: 
+method: GET; body: 
+method: GET; body: 
+-- Testing redirect status code 307 --
+method: POST; body: hello=world
+method: PATCH; body: hello=world
+method: POST; body: hello=world
+method: PATCH; body: hello=world
+-- Testing redirect status code 308 --
+method: POST; body: hello=world
+method: PATCH; body: hello=world
+method: POST; body: hello=world
+method: PATCH; body: hello=world


### PR DESCRIPTION
RFC 7231 states that status code 307 should keep the POST method upon redirect. RFC 7538 does the same for code 308. Although it's not mandated by the RFCs that PATCH is also kept (we can choose), it seems like keeping PATCH will be the most consistent and understandable behaviour.

This patch also changes an existing test because it was testing for the wrong behaviour.