### PR TITLE
Fix FPM status json encoded value test

### DIFF
--- a/sapi/fpm/tests/bug64539-status-json-encoding.phpt
+++ b/sapi/fpm/tests/bug64539-status-json-encoding.phpt
@@ -1,6 +1,5 @@
 --TEST--
 FPM: bug64539 - status json format escaping
---XFAIL--
 --SKIPIF--
 <?php
 include "skipif.inc"; ?>
@@ -33,8 +32,7 @@ $responses = $tester
         ['query' => 'a=b"c'],
         ['uri' => '/status', 'query' => 'full&json', 'delay' => 100000],
     ]);
-$data = json_decode($responses[1]->getBody('application/json'), true);
-var_dump(explode('?', $data['processes'][0]['request uri'])[1]);
+$responses[1]->expectJsonBodyPatternForStatusProcessField('request uri', '\?a=b"c$');
 $tester->terminate();
 $tester->expectLogTerminatingNotices();
 $tester->close();
@@ -42,7 +40,6 @@ $tester->close();
 ?>
 Done
 --EXPECT--
-string(5) "a=b"c"
 Done
 --CLEAN--
 <?php

--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -92,6 +92,37 @@ class Response
     }
 
     /**
+     * Expect that one of the processes in json status process list has a field with value that
+     * matches the supplied pattern.
+     *
+     * @param string $fieldName
+     * @param string $pattern
+     *
+     * @return Response
+     */
+    public function expectJsonBodyPatternForStatusProcessField(string $fieldName, string $pattern)
+    {
+        $rawData = $this->getBody('application/json');
+        $data = json_decode($rawData, true);
+        if (empty($data['processes']) || !is_array($data['processes'])) {
+            $this->error(
+                "The body data is not a valid status json containing processes field '$rawData'"
+            );
+        }
+        foreach ($data['processes'] as $process) {
+            if (preg_match('/' . $pattern . '/', $process[$fieldName]) !== false) {
+                return $this;
+            }
+        }
+
+        $this->error(
+            "No field $fieldName matched pattern $pattern for any process in status data '$rawData'"
+        );
+
+        return $this;
+    }
+
+    /**
      * @return Response
      */
     public function expectEmptyBody()


### PR DESCRIPTION
This should fix the failure when incorrect process is selected. As it is a static pool, it can be in any process so we cannot expect that process 0 is the query one. 