### PR TITLE
Fix GH-11281: DateTimeZone::getName() does not include seconds in offset

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1957,13 +1957,25 @@ static void php_timezone_to_string(php_timezone_obj *tzobj, zval *zv)
 			ZVAL_STRING(zv, tzobj->tzi.tz->name);
 			break;
 		case TIMELIB_ZONETYPE_OFFSET: {
-			zend_string *tmpstr = zend_string_alloc(sizeof("UTC+05:00")-1, 0);
 			timelib_sll utc_offset = tzobj->tzi.utc_offset;
+			int seconds = utc_offset % 60;
+			size_t size;
+			const char *format;
+			if (seconds == 0) {
+				size = sizeof("+05:00");
+				format = "%c%02d:%02d";
+			} else {
+				size = sizeof("+05:00:01");
+				format = "%c%02d:%02d:%02d";
+			}
+			zend_string *tmpstr = zend_string_alloc(size - 1, 0);
 
-			ZSTR_LEN(tmpstr) = snprintf(ZSTR_VAL(tmpstr), sizeof("+05:00"), "%c%02d:%02d",
+			/* Note: if seconds == 0, the seconds argument will be excessive and therefore ignored. */
+			ZSTR_LEN(tmpstr) = snprintf(ZSTR_VAL(tmpstr), size, format,
 				utc_offset < 0 ? '-' : '+',
 				abs((int)(utc_offset / 3600)),
-				abs((int)(utc_offset % 3600) / 60));
+				abs((int)(utc_offset % 3600) / 60),
+				abs(seconds));
 
 			ZVAL_NEW_STR(zv, tmpstr);
 			}

--- a/ext/date/tests/bug81097.phpt
+++ b/ext/date/tests/bug81097.phpt
@@ -10,5 +10,5 @@ object(DateTimeZone)#%d (%d) {
   ["timezone_type"]=>
   int(1)
   ["timezone"]=>
-  string(6) "+01:45"
+  string(9) "+01:45:30"
 }

--- a/ext/date/tests/bug81565.phpt
+++ b/ext/date/tests/bug81565.phpt
@@ -17,4 +17,4 @@ DateTime::__set_state(array(
    'timezone_type' => 1,
    'timezone' => '+00:49',
 ))
-+01:45
++01:45:30

--- a/ext/date/tests/gh11281.phpt
+++ b/ext/date/tests/gh11281.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-11281 (DateTimeZone::getName() does not include seconds in offset)
+--FILE--
+<?php
+$tz = new DateTimeZone('+03:00');
+echo $tz->getName(), "\n";
+$tz = new DateTimeZone('+03:00:00');
+echo $tz->getName(), "\n";
+$tz = new DateTimeZone('-03:00:00');
+echo $tz->getName(), "\n";
+$tz = new DateTimeZone('+03:00:01');
+echo $tz->getName(), "\n";
+$tz = new DateTimeZone('-03:00:01');
+echo $tz->getName(), "\n";
+$tz = new DateTimeZone('+03:00:58');
+echo $tz->getName(), "\n";
+$tz = new DateTimeZone('-03:00:58');
+echo $tz->getName(), "\n";
+$tz = new DateTimeZone('+03:00:59');
+echo $tz->getName(), "\n";
+$tz = new DateTimeZone('-03:00:59');
+echo $tz->getName(), "\n";
+?>
+--EXPECT--
++03:00
++03:00
+-03:00
++03:00:01
+-03:00:01
++03:00:58
+-03:00:58
++03:00:59
+-03:00:59


### PR DESCRIPTION
If the seconds portion is non-zero, include the seconds in the output.

I didn't split the `snprintf` call along two paths to reduce code duplication. I looked up if this is well-defined behaviour: according to the C11 standard section 7.21.6.1 & 7.21.6.6 we can pass additional arguments to *printf functions and they'll just get ignored.