### PR TITLE
Fix missing second offset in DateTimeZone::getName()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ PHP                                                                        NEWS
   . Fixed bug GH-11222 (foreach by-ref may jump over keys during a rehash).
     (Bob)
 
+- Date:
+  . Fixed bug GH-11281 (DateTimeZone::getName() does not include seconds).
+    (ilutov)
+
 - Exif:
   . Fixed bug GH-10834 (exif_read_data() cannot read smaller stream wrapper
     chunk sizes). (nielsdos)

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1960,10 +1960,18 @@ static void php_timezone_to_string(php_timezone_obj *tzobj, zval *zv)
 			zend_string *tmpstr = zend_string_alloc(sizeof("UTC+05:00")-1, 0);
 			timelib_sll utc_offset = tzobj->tzi.utc_offset;
 
-			ZSTR_LEN(tmpstr) = snprintf(ZSTR_VAL(tmpstr), sizeof("+05:00"), "%c%02d:%02d",
-				utc_offset < 0 ? '-' : '+',
-				abs((int)(utc_offset / 3600)),
-				abs((int)(utc_offset % 3600) / 60));
+			if ((utc_offset % 60) == 0) {
+				ZSTR_LEN(tmpstr) = snprintf(ZSTR_VAL(tmpstr), sizeof("+05:00"), "%c%02d:%02d",
+					utc_offset < 0 ? '-' : '+',
+					abs((int)(utc_offset / 3600)),
+					abs((int)(utc_offset % 3600) / 60));
+			} else {
+				ZSTR_LEN(tmpstr) = snprintf(ZSTR_VAL(tmpstr), sizeof("+05:00:00"), "%c%02d:%02d:%02d",
+					utc_offset < 0 ? '-' : '+',
+					abs((int)(utc_offset / 3600)),
+					abs((int)(utc_offset % 3600) / 60),
+					abs((int)(utc_offset % 60)));
+			}
 
 			ZVAL_NEW_STR(zv, tmpstr);
 			}

--- a/ext/date/tests/bug81097.phpt
+++ b/ext/date/tests/bug81097.phpt
@@ -10,5 +10,5 @@ object(DateTimeZone)#%d (%d) {
   ["timezone_type"]=>
   int(1)
   ["timezone"]=>
-  string(6) "+01:45"
+  string(9) "+01:45:30"
 }

--- a/ext/date/tests/bug81565.phpt
+++ b/ext/date/tests/bug81565.phpt
@@ -17,4 +17,4 @@ DateTime::__set_state(array(
    'timezone_type' => 1,
    'timezone' => '+00:49',
 ))
-+01:45
++01:45:30

--- a/ext/date/tests/gh11281.phpt
+++ b/ext/date/tests/gh11281.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Bug GH-11281 (DateTimeZone::getName() does not include seconds)
+--FILE--
+<?php
+$tz = new DateTimeZone('+03:00:01');
+echo $tz->getName();
+?>
+--EXPECT--
++03:00:01


### PR DESCRIPTION
Fixes gh-11281

