### PR TITLE
ext/session: pass ini options to extra processes in tests

### DIFF
--- a/ext/session/tests/session_regenerate_id_cookie.phpt
+++ b/ext/session/tests/session_regenerate_id_cookie.phpt
@@ -52,7 +52,8 @@ var_dump(session_destroy());
 ob_end_flush();
 ?>');
 
-var_dump(`$php -n -d session.name=PHPSESSID $file`);
+$extra_arguments = getenv('TEST_PHP_EXTRA_ARGS');
+var_dump(`$php $extra_arguments -d session.name=PHPSESSID $file`);
 
 unlink($file);
 


### PR DESCRIPTION
The change and the problem are similar to #11004.

When we build with `--enable-session=shared`, the tests are running with `-d session.so` but as long as we don't pass this argument to the inner process, it will fail with `undefined function session_start()`.