### PR TITLE
Fix string coercion for $a .= $a

### DIFF
--- a/Zend/tests/bug79836_3.phpt
+++ b/Zend/tests/bug79836_3.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #79836 ($a .= $a should coerce to string)
+--FILE--
+<?php
+$a = false;
+$a .= $a;
+var_dump($a);
+?>
+--EXPECT--
+string(0) ""

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2005,7 +2005,7 @@ ZEND_API zend_result ZEND_FASTCALL concat_function(zval *result, zval *op1, zval
 
 has_op2_string:;
 	if (UNEXPECTED(ZSTR_LEN(op1_string) == 0)) {
-		if (EXPECTED(free_op2_string || result != op2)) {
+		if (EXPECTED(result != op2 || Z_TYPE_P(result) != IS_STRING)) {
 			if (result == orig_op1) {
 				i_zval_ptr_dtor(result);
 			}
@@ -2018,7 +2018,7 @@ has_op2_string:;
 			}
 		}
 	} else if (UNEXPECTED(ZSTR_LEN(op2_string) == 0)) {
-		if (EXPECTED(free_op1_string || result != op1)) {
+		if (EXPECTED(result != op1 || Z_TYPE_P(result) != IS_STRING)) {
 			if (result == orig_op1) {
 				i_zval_ptr_dtor(result);
 			}


### PR DESCRIPTION
free_op2_string may be set to false when the operands are not strings and `result == op1 == op2`, by re-using the same string for both operands. In that case, the string should still be copied to result because result is not actually a string. Also change the op1 branch to stay consistent.

Introduced by GH-10049