### PR TITLE
Fix concat_function use-after-free on out-of-memory error

### DIFF
--- a/Zend/tests/bug79836_4.phpt
+++ b/Zend/tests/bug79836_4.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Bug #79836 (use-after-free in concat_function)
+--INI--
+memory_limit=10M
+--FILE--
+<?php
+class Foo {
+    public function __toString() {
+        return str_repeat('a', 10);
+    }
+}
+
+$i = str_repeat('a', 5 * 1024 * 1024);
+$e = new Foo();
+$e .= $i;
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted%s(tried to allocate %d bytes) in %s on line %d

--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2048,13 +2048,16 @@ has_op2_string:;
 		}
 
 		if (result == op1) {
+			/* special case, perform operations on result */
+			result_str = zend_string_extend(op1_string, result_len, 0);
+			/* Free result after zend_string_extend(), as it may throw an out-of-memory error. If we
+			 * free it before we would leave the released variable on the stack with shutdown trying
+			 * to free it again. */
 			if (free_op1_string) {
 				/* op1_string will be used as the result, so we should not free it */
 				i_zval_ptr_dtor(result);
 				free_op1_string = false;
 			}
-			/* special case, perform operations on result */
-			result_str = zend_string_extend(op1_string, result_len, 0);
 			/* account for the case where result_str == op1_string == op2_string and the realloc is done */
 			if (op1_string == op2_string) {
 				if (free_op2_string) {


### PR DESCRIPTION
Introduced by GH-10049

Unfortunately, I was not able to provide a test case for this. The example from https://github.com/php/php-src/commit/727e26f9f27ed0737fdbf6d2626d37a916e08c22#commitcomment-114423406 only worked in the very specific case of keeping the file in the project root, and running it without run-tests.php.