### PR TITLE
Fix access on NULL pointer in array_merge_recursive()

### DIFF
--- a/Zend/tests/array_merge_recursive_next_key_overflow.phpt
+++ b/Zend/tests/array_merge_recursive_next_key_overflow.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Access on NULL pointer in array_merge_recursive()
+--FILE--
+<?php
+try {
+    array_merge_recursive(
+        ['' => [PHP_INT_MAX => null]],
+        ['' => [null]],
+    );
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    array_merge_recursive(
+        ['foo' => [PHP_INT_MAX => null]],
+        ['foo' => str_repeat('a', 2)],
+    );
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Cannot add element to the array as the next element is already occupied
+Cannot add element to the array as the next element is already occupied

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2231,7 +2231,7 @@ static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_use_scalar_as_array(v
 	zend_throw_error(NULL, "Cannot use a scalar value as an array");
 }
 
-static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_cannot_add_element(void)
+ZEND_API zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_cannot_add_element(void)
 {
 	zend_throw_error(NULL, "Cannot add element to the array as the next element is already occupied");
 }

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -76,6 +76,8 @@ ZEND_API ZEND_COLD void zend_wrong_string_offset_error(void);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_readonly_property_modification_error(zend_property_info *info);
 ZEND_API ZEND_COLD void ZEND_FASTCALL zend_readonly_property_indirect_modification_error(zend_property_info *info);
 
+ZEND_API ZEND_COLD void ZEND_FASTCALL zend_cannot_add_element(void);
+
 ZEND_API bool zend_verify_scalar_type_hint(uint32_t type_mask, zval *arg, bool strict, bool is_internal_arg);
 ZEND_API ZEND_COLD void zend_verify_arg_error(
 		const zend_function *zf, const zend_arg_info *arg_info, uint32_t arg_num, zval *value);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3595,7 +3595,12 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 					}
 				} else {
 					Z_TRY_ADDREF_P(src_zval);
-					zend_hash_next_index_insert(Z_ARRVAL_P(dest_zval), src_zval);
+					zval *zv = zend_hash_next_index_insert(Z_ARRVAL_P(dest_zval), src_zval);
+					if (EXPECTED(!zv)) {
+						Z_TRY_DELREF_P(src_zval);
+						zend_cannot_add_element();
+						return 0;
+					}
 				}
 				zval_ptr_dtor(&tmp);
 			} else {
@@ -3604,6 +3609,10 @@ PHPAPI int php_array_merge_recursive(HashTable *dest, HashTable *src) /* {{{ */
 			}
 		} else {
 			zval *zv = zend_hash_next_index_insert(dest, src_entry);
+			if (UNEXPECTED(!zv)) {
+				zend_cannot_add_element();
+				return 0;
+			}
 			zval_add_ref(zv);
 		}
 	} ZEND_HASH_FOREACH_END();


### PR DESCRIPTION
@dstogov Please check if this looks good to you. I checked all the `zend_hash_next_index_insert()` calls to make sure they handle `NULL` values but couldn't find any other obvious faulty cases. I opted for `Z_TRY_DELREF_P` rather than moving the `Z_TRY_ADDREF_P` into an `if` to avoid a jump in the happy-path.