### PR TITLE
Access violation when ALLOC_FALLBACK fixed

### DIFF
--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -192,6 +192,7 @@ int zend_shared_alloc_startup(size_t requested_size, size_t reserved_size)
 	}
 #if ENABLE_FILE_CACHE_FALLBACK
 	if (ALLOC_FALLBACK == res) {
+		smm_shared_globals = NULL;
 		return ALLOC_FALLBACK;
 	}
 #endif


### PR DESCRIPTION
We had a problem with using opcache on the second php-cgi.exe (the fallback to file op cache on the second process was triggered by different load addresses of PHP8.dll in both processes - this was ok so far)
But the fallback to file opcache was not working - when the cache was accessed it caused ACCESS VIOLATION because of wrong opcache globals pointer.