### PR TITLE
serialize: Fixed handling of nested object references

### DIFF
--- a/ext/standard/tests/serialize/serialization_objects_019.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_019.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Object serialization with references
+--FILE--
+<?php
+function gen() {
+    $s = new stdClass;
+    $r = new stdClass;
+    $r->a = [$s];
+    $r->b = $r->a;
+    return $r;
+}
+var_dump(serialize(gen()));
+?>
+--EXPECTF--
+string(78) "O:8:"stdClass":2:{s:1:"a";a:1:{i:0;O:8:"stdClass":0:{}}s:1:"b";a:1:{i:0;r:3;}}"
+
+

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -666,8 +666,6 @@ static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var) /
 		/* pass */
 	} else if (Z_TYPE_P(var) != IS_OBJECT) {
 		return 0;
-	} else if (Z_REFCOUNT_P(var) == 1 && (Z_OBJ_P(var)->properties == NULL || GC_REFCOUNT(Z_OBJ_P(var)->properties) == 1)) {
-		return 0;
 	}
 
 	/* References to objects are treated as if the reference didn't exist */


### PR DESCRIPTION
PHP 8.1+ does not serialize object references correctly under certain circumstances.

See tests/serialize/serialization_objects_019.phpt

The bug was originally introduced in commit 6c5942f, and the problematic line was last modified in commit bb0b4eb9. (Fixes oss-fuzz #44954)

The testcase from bb0b4eb9 still passes.

I am not super familiar with the php codebase, but the removed IF looks suspicious and fixes my issue. I initially planned to just open an issue, but then I wrote the testcase and figured I might as well just submit the (likely) fix.

Someone else should obviously triple-check this. Especially since the original change was due to optimizations.



