### PR TITLE
Fix loop in zend_shared_alloc_startup

### DIFF
--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -179,8 +179,8 @@ int zend_shared_alloc_startup(size_t requested_size, size_t reserved_size)
 				res = zend_shared_alloc_try(he, requested_size, &ZSMMG(shared_segments), &ZSMMG(shared_segments_count), &error_in);
 				if (res) {
 					/* this model works! */
+					break;
 				}
-				break;
 			}
 		}
 	}


### PR DESCRIPTION
The break is outside the if, so if it succeeds or not this will always stop after the first loop iteration instead of trying more allocators if the first one fails.