### PR TITLE
Use single allocation for indirect values in array_multisort

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5782,8 +5782,10 @@ PHP_FUNCTION(array_multisort)
 	 * of the input arrays + 1. The last column is UNDEF to indicate the end
 	 * of the row. It also stores the original position for stable sorting. */
 	indirect = (Bucket **)safe_emalloc(array_size, sizeof(Bucket *), 0);
+	/* Move num_array multiplication to size because it's essentially impossible to overflow. */
+	Bucket *indirects = (Bucket *)safe_emalloc(array_size, sizeof(Bucket) * (num_arrays + 1), 0);
 	for (i = 0; i < array_size; i++) {
-		indirect[i] = (Bucket *)safe_emalloc((num_arrays + 1), sizeof(Bucket), 0);
+		indirect[i] = indirects + (i * (num_arrays + 1));
 	}
 	for (i = 0; i < num_arrays; i++) {
 		k = 0;
@@ -5847,9 +5849,7 @@ PHP_FUNCTION(array_multisort)
 	RETVAL_TRUE;
 
 clean_up:
-	for (i = 0; i < array_size; i++) {
-		efree(indirect[i]);
-	}
+	efree(indirects);
 	efree(indirect);
 	efree(func);
 	efree(arrays);


### PR DESCRIPTION
<details><summary>Simple benchmarks</summary>
<p>

```php
// Tiny arrays

$a = array("row1" => 2, "row2" => 1, "row3" => 1);
$b = array("row1" => 2, "row2" => "aa", "row3" => "1");

for ($i = 0; $i < 10000000; $i++) {
    array_multisort($b, SORT_ASC, SORT_REGULAR, $a, SORT_DESC, SORT_STRING);
}

// Before:
// Time (mean ± σ):     821.5 ms ±   4.6 ms    [User: 817.9 ms, System: 1.5 ms]
// Range (min … max):   816.6 ms … 830.5 ms    10 runs
// After:
// Time (mean ± σ):     809.6 ms ±   2.9 ms    [User: 806.0 ms, System: 1.6 ms]
// Range (min … max):   805.3 ms … 814.7 ms    10 runs

// Small arrays

$a = array(
    'Second',
    'First.1',
    'First.2',
    'First.3',
    'Twentieth',
    'Tenth',
    'Third',
);

$b = array(
    '2 a',
    '1 bb 1',
    '1 bB 2',
    '1 BB 3',
    '20 c',
    '10 d',
    '3 e',
);

for ($i = 0; $i < 10000000; $i++) {
    array_multisort($b, SORT_STRING, $a);
}
  
// Before:
// Time (mean ± σ):      1.062 s ±  0.005 s    [User: 1.058 s, System: 0.001 s]
// Range (min … max):    1.052 s …  1.066 s    10 runs
// After:
// Time (mean ± σ):     878.2 ms ±   8.8 ms    [User: 874.3 ms, System: 1.5 ms]
// Range (min … max):   865.7 ms … 891.2 ms    10 runs

// Huge arrays

$a = range('a', 'z');
for ($i = 0; $i < 15; $i++) {
    $a = array_merge($a, $a);
}

$b = array_reverse($a);

for ($i = 0; $i < 20; $i++) {
    array_multisort($b, SORT_STRING, $a);
}

// Before:
// Time (mean ± σ):      4.377 s ±  0.043 s    [User: 4.294 s, System: 0.070 s]
// Range (min … max):    4.335 s …  4.481 s    10 runs
// After:
// Time (mean ± σ):      2.925 s ±  0.011 s    [User: 2.453 s, System: 0.463 s]
// Range (min … max):    2.907 s …  2.941 s    10 runs
```

</p>
</details> 