### PR TITLE
sapi/fpm: add "pcntl" when running test depending pcntl_sigprocmask()

### DIFF
--- a/sapi/fpm/tests/reload-uses-sigkill-as-last-measure.phpt
+++ b/sapi/fpm/tests/reload-uses-sigkill-as-last-measure.phpt
@@ -35,7 +35,7 @@ pcntl_sigprocmask(SIG_BLOCK, [SIGQUIT, SIGTERM]);
 EOT;
 
 $tester = new FPM\Tester($cfg, $code);
-$tester->start();
+$tester->start(extensions: ['pcntl']);
 $tester->expectLogStartNotices();
 $tester->request()->expectEmptyBody();
 $tester->signal('USR2');


### PR DESCRIPTION
If "pcntl" is built as a shared module, the extension will not load automatically when we spawn the FPM