### PR TITLE
Fix GCC 12 compilation on riscv64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -373,6 +373,16 @@ if test "$ac_cv_func_dlopen" = "yes"; then
 fi
 AC_CHECK_LIB(m, sin)
 
+case $host_alias in
+  riscv64*)
+    AC_CHECK_LIB(atomic, __atomic_exchange_1, [
+      PHP_ADD_LIBRARY(atomic)
+    ], [
+      AC_MSG_ERROR([Problem with enabling atomic. Please check config.log for details.])
+    ])
+    ;;
+esac
+
 dnl Check for inet_aton in -lc, -lbind and -lresolv.
 PHP_CHECK_FUNC(inet_aton, resolv, bind)
 


### PR DESCRIPTION
Fixes "undefined reference to `__atomic_exchange_1'" errors when compiling on riscv64 with GCC 12.
Newer versions of GCC should inline these atomics (https://www.mail-archive.com/gcc-patches@gcc.gnu.org/msg283700.html), this PR fixes compilations on slightly older versions of GCC, like the one distributed on Debian 12 (currently GCC 12.2).