### PR TITLE
Fix list() assignment in array literals

### DIFF
--- a/Zend/tests/gh11320_1.phpt
+++ b/Zend/tests/gh11320_1.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GH-11320: Array literals can contain list() assignments
+--FILE--
+<?php
+$index = 1;
+function getList() { return [2, 3]; }
+var_dump([$index => list($x, $y) = getList()]);
+var_dump([$index => [$x, $y] = getList()]);
+?>
+--EXPECT--
+array(1) {
+  [1]=>
+  array(2) {
+    [0]=>
+    int(2)
+    [1]=>
+    int(3)
+  }
+}
+array(1) {
+  [1]=>
+  array(2) {
+    [0]=>
+    int(2)
+    [1]=>
+    int(3)
+  }
+}

--- a/Zend/tests/gh11320_2.phpt
+++ b/Zend/tests/gh11320_2.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-11320: list() expressions can contain magic constants
+--FILE--
+<?php
+[list(__FILE__ => $foo) = [__FILE__ => 'foo']];
+var_dump($foo);
+[[__FILE__ => $foo] = [__FILE__ => 'foo']];
+var_dump($foo);
+?>
+--EXPECT--
+string(3) "foo"
+string(3) "foo"

--- a/Zend/tests/gh11320_3.phpt
+++ b/Zend/tests/gh11320_3.phpt
@@ -1,0 +1,8 @@
+--TEST--
+GH-11320: list() must not appear as a standalone array element
+--FILE--
+<?php
+[list($a)];
+?>
+--EXPECTF--
+Fatal error: Cannot use list() as standalone expression in %s on line %d


### PR DESCRIPTION
Fixes GH-11320

This is a bit messy :( The LHS of assignment can look like other expressions, but is interpreted differently in the compiler. This makes evaluating the LHS unsafe. I'm not aware of other such AST elements but I wouldn't rule it out. It might be better to revert the original commit... The idea was to simplify, not make it more complicated.