### PR TITLE
fix: use zval_get_long() to read value of FTP context option "overwrite"

### DIFF
--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -490,7 +490,7 @@ php_stream * php_stream_url_wrap_ftp(php_stream_wrapper *wrapper, const char *pa
 	} else if (read_write == 2) {
 		/* when writing file (but not appending), it must NOT exist, unless a context option exists which allows it */
 		if (context && (tmpzval = php_stream_context_get_option(context, "ftp", "overwrite")) != NULL) {
-			allow_overwrite = zval_get_long(tmpzval) != 0;
+			allow_overwrite = zend_is_true(tmpzval);
 		}
 		if (result <= 299 && result >= 200) {
 			if (allow_overwrite) {

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -490,7 +490,7 @@ php_stream * php_stream_url_wrap_ftp(php_stream_wrapper *wrapper, const char *pa
 	} else if (read_write == 2) {
 		/* when writing file (but not appending), it must NOT exist, unless a context option exists which allows it */
 		if (context && (tmpzval = php_stream_context_get_option(context, "ftp", "overwrite")) != NULL) {
-			allow_overwrite = Z_LVAL_P(tmpzval) ? 1 : 0;
+			allow_overwrite = zval_get_long(tmpzval) != 0;
 		}
 		if (result <= 299 && result >= 200) {
 			if (allow_overwrite) {


### PR DESCRIPTION
The FTP context option "overwrite" is read directly via Z_LVAL_P without performing a type check or conversion. Because of this, the option only works reliably if it's set to an integer or if it's absent (defaulting to false), while setting it explicitly to false or null will likely **allow** overwriting and setting it to true has a small chance of disabling it.

I tried to implement the behavior as described in the commit that added the option (https://github.com/php/php-src/commit/cb89565ba4deab745e38b9d9f93f3e504d3b2f55):

> Allow overwriting of files via ftp:// wrapper.
> Requires context option:  $context['ftp']['overwrite'] != 0