### PR TITLE
Fix GH-11336: php still tries to unlock the shared memory ZendSem with opcache.file_cache_only=1 but it was never locked

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -354,6 +354,10 @@ static inline void accel_unlock_all(void)
 #ifdef ZEND_WIN32
 	accel_deactivate_sub();
 #else
+	if (lock_file == -1) {
+		return;
+	}
+
 	struct flock mem_usage_unlock_all;
 
 	mem_usage_unlock_all.l_type = F_UNLCK;

--- a/ext/opcache/zend_shared_alloc.c
+++ b/ext/opcache/zend_shared_alloc.c
@@ -52,7 +52,7 @@ zend_smm_shared_globals *smm_shared_globals;
 #ifdef ZTS
 static MUTEX_T zts_lock;
 #endif
-int lock_file;
+int lock_file = -1;
 static char lockfile_name[MAXPATHLEN];
 #endif
 


### PR DESCRIPTION
I chose to check for the value of lock_file instead of checking the file_cache_only, because it is probably a little bit faster and we're going to access the lock_file variable anyway. It's also more generic.