### PR TITLE
DOMNodeList::item may return DOMElement.

### DIFF
--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -232,7 +232,7 @@ class DOMNodeList implements IteratorAggregate, Countable
 
     public function getIterator(): Iterator {}
 
-    /** @return DOMNode|DOMNameSpaceNode|null */
+    /** @return DOMElement|DOMNode|DOMNameSpaceNode|null */
     public function item(int $index) {}
 }
 


### PR DESCRIPTION
Not explicitly documenting the possibility of returning DOMElement causes the Intelephense linter (a popular PHP linter with ~9 million downloads: https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client ) to think this code is bad:

$xp->query("whatever")->item(0)->getAttribute("foo");

because DOMNode does not have getAttribute (while DOMElement does). documenting the DOMElement return type should fix Intelephense's linter.