### PR TITLE
Serialize object fix

### DIFF
--- a/ext/standard/tests/serialize/serialization_objects_019.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_019.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Object serialization with references
+--FILE--
+<?php
+function gen() {
+    $s = new stdClass;
+    $r = new stdClass;
+    $r->a = [$s];
+    $r->b = $r->a;
+    return $r;
+}
+var_dump(serialize(gen()));
+?>
+--EXPECTF--
+string(78) "O:8:"stdClass":2:{s:1:"a";a:1:{i:0;O:8:"stdClass":0:{}}s:1:"b";a:1:{i:0;r:3;}}"
+
+

--- a/ext/standard/tests/serialize/serialization_objects_019.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_019.phpt
@@ -2,16 +2,41 @@
 Object serialization with references
 --FILE--
 <?php
-function gen() {
-    $s = new stdClass;
-    $r = new stdClass;
-    $r->a = [$s];
-    $r->b = $r->a;
-    return $r;
+
+function rcn() {
+    $root = new stdClass;
+    $end = new stdClass;
+    $root->a = [$end];
+    $root->b = $root->a;
+    unset($end);
+    echo serialize($root), "\n";
 }
-var_dump(serialize(gen()));
+
+function rcn_rc1() {
+    $root = new stdClass;
+    $end = new stdClass;
+    $root->a = [[$end]];
+    $root->b = $root->a;
+    unset($end);
+    echo serialize($root), "\n";
+}
+
+function rcn_properties_ht() {
+    $object = new stdClass;
+    $object->object = new stdClass;
+    $array = (array) $object;
+    $root = [$object, $array];
+    unset($object);
+    unset($array);
+    echo serialize($root), "\n";
+}
+
+rcn();
+rcn_rc1();
+rcn_properties_ht();
+
 ?>
---EXPECTF--
-string(78) "O:8:"stdClass":2:{s:1:"a";a:1:{i:0;O:8:"stdClass":0:{}}s:1:"b";a:1:{i:0;r:3;}}"
-
-
+--EXPECT--
+O:8:"stdClass":2:{s:1:"a";a:1:{i:0;O:8:"stdClass":0:{}}s:1:"b";a:1:{i:0;r:3;}}
+O:8:"stdClass":2:{s:1:"a";a:1:{i:0;a:1:{i:0;O:8:"stdClass":0:{}}}s:1:"b";a:1:{i:0;a:1:{i:0;r:4;}}}
+a:2:{i:0;O:8:"stdClass":1:{s:6:"object";O:8:"stdClass":0:{}}i:1;a:1:{s:6:"object";r:3;}}

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -666,8 +666,6 @@ static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var) /
 		/* pass */
 	} else if (Z_TYPE_P(var) != IS_OBJECT) {
 		return 0;
-	} else if (Z_REFCOUNT_P(var) == 1 && (Z_OBJ_P(var)->properties == NULL || GC_REFCOUNT(Z_OBJ_P(var)->properties) == 1)) {
-		return 0;
 	}
 
 	/* References to objects are treated as if the reference didn't exist */

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -652,9 +652,12 @@ PHP_FUNCTION(var_export)
 }
 /* }}} */
 
-static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash);
+static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash, bool in_rcn_array, bool is_root);
 
-static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var) /* {{{ */
+/**
+ * @param bool in_rcn_array Whether the element appears in a potentially nested array with RC > 1.
+ */
+static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var, bool in_rcn_array) /* {{{ */
 {
 	zval *zv;
 	zend_ulong key;
@@ -665,6 +668,10 @@ static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var) /
 	if (is_ref) {
 		/* pass */
 	} else if (Z_TYPE_P(var) != IS_OBJECT) {
+		return 0;
+	} else if (!in_rcn_array
+	 && Z_REFCOUNT_P(var) == 1
+	 && (Z_OBJ_P(var)->properties == NULL || GC_REFCOUNT(Z_OBJ_P(var)->properties) == 1)) {
 		return 0;
 	}
 
@@ -921,7 +928,7 @@ static int php_var_serialize_get_sleep_props(
 }
 /* }}} */
 
-static void php_var_serialize_nested_data(smart_str *buf, zval *struc, HashTable *ht, uint32_t count, bool incomplete_class, php_serialize_data_t var_hash) /* {{{ */
+static void php_var_serialize_nested_data(smart_str *buf, zval *struc, HashTable *ht, uint32_t count, bool incomplete_class, php_serialize_data_t var_hash, bool in_rcn_array) /* {{{ */
 {
 	smart_str_append_unsigned(buf, count);
 	smart_str_appendl(buf, ":{", 2);
@@ -951,19 +958,19 @@ static void php_var_serialize_nested_data(smart_str *buf, zval *struc, HashTable
 			if (Z_TYPE_P(data) == IS_ARRAY) {
 				if (UNEXPECTED(Z_IS_RECURSIVE_P(data))
 					|| UNEXPECTED(Z_TYPE_P(struc) == IS_ARRAY && Z_ARR_P(data) == Z_ARR_P(struc))) {
-					php_add_var_hash(var_hash, struc);
+					php_add_var_hash(var_hash, struc, in_rcn_array);
 					smart_str_appendl(buf, "N;", 2);
 				} else {
 					if (Z_REFCOUNTED_P(data)) {
 						Z_PROTECT_RECURSION_P(data);
 					}
-					php_var_serialize_intern(buf, data, var_hash);
+					php_var_serialize_intern(buf, data, var_hash, in_rcn_array, false);
 					if (Z_REFCOUNTED_P(data)) {
 						Z_UNPROTECT_RECURSION_P(data);
 					}
 				}
 			} else {
-				php_var_serialize_intern(buf, data, var_hash);
+				php_var_serialize_intern(buf, data, var_hash, in_rcn_array, false);
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
@@ -978,13 +985,13 @@ static void php_var_serialize_class(smart_str *buf, zval *struc, HashTable *ht, 
 	if (php_var_serialize_get_sleep_props(&props, struc, ht) == SUCCESS) {
 		php_var_serialize_class_name(buf, struc);
 		php_var_serialize_nested_data(
-			buf, struc, &props, zend_hash_num_elements(&props), /* incomplete_class */ 0, var_hash);
+			buf, struc, &props, zend_hash_num_elements(&props), /* incomplete_class */ 0, var_hash, GC_REFCOUNT(&props) > 1);
 	}
 	zend_hash_destroy(&props);
 }
 /* }}} */
 
-static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash) /* {{{ */
+static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash, bool in_rcn_array, bool is_root) /* {{{ */
 {
 	zend_long var_already;
 	HashTable *myht;
@@ -993,7 +1000,7 @@ static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_
 		return;
 	}
 
-	if (var_hash && (var_already = php_add_var_hash(var_hash, struc))) {
+	if (var_hash && (var_already = php_add_var_hash(var_hash, struc, in_rcn_array))) {
 		if (var_already == -1) {
 			/* Reference to an object that failed to serialize, replace with null. */
 			smart_str_appendl(buf, "N;", 2);
@@ -1102,7 +1109,7 @@ again:
 						if (Z_ISREF_P(data) && Z_REFCOUNT_P(data) == 1) {
 							data = Z_REFVAL_P(data);
 						}
-						php_var_serialize_intern(buf, data, var_hash);
+						php_var_serialize_intern(buf, data, var_hash, Z_REFCOUNT(retval) > 1, false);
 					} ZEND_HASH_FOREACH_END();
 					smart_str_appendc(buf, '}');
 
@@ -1224,7 +1231,7 @@ again:
 								prop = Z_REFVAL_P(prop);
 							}
 
-							php_var_serialize_intern(buf, prop, var_hash);
+							php_var_serialize_intern(buf, prop, var_hash, false, false);
 						}
 						smart_str_appendc(buf, '}');
 					} else {
@@ -1239,7 +1246,7 @@ again:
 				if (count > 0 && incomplete_class) {
 					--count;
 				}
-				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
+				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash, GC_REFCOUNT(myht) > 1);
 				zend_release_properties(myht);
 				return;
 			}
@@ -1247,7 +1254,8 @@ again:
 			smart_str_appendl(buf, "a:", 2);
 			myht = Z_ARRVAL_P(struc);
 			php_var_serialize_nested_data(
-				buf, struc, myht, zend_array_count(myht), /* incomplete_class */ 0, var_hash);
+				buf, struc, myht, zend_array_count(myht), /* incomplete_class */ 0, var_hash,
+					!is_root && (in_rcn_array || GC_REFCOUNT(myht) > 1));
 			return;
 		case IS_REFERENCE:
 			struc = Z_REFVAL_P(struc);
@@ -1261,7 +1269,7 @@ again:
 
 PHPAPI void php_var_serialize(smart_str *buf, zval *struc, php_serialize_data_t *data) /* {{{ */
 {
-	php_var_serialize_intern(buf, struc, *data);
+	php_var_serialize_intern(buf, struc, *data, false, true);
 	smart_str_0(buf);
 }
 /* }}} */


### PR DESCRIPTION
Adapted from https://github.com/php/php-src/pull/11305.

The tracking of RC1 arrays was straight-forward. The most common case is likely passing a flat array of objects to serialize. Unfortunately, this will still result in an array with RC2 if the array is stored in a CV, because `ZEND_SEND_VAR[_EX]` increases the refcount. I'm trying to look for the corresponding `ZEND_SEND_VAR` opcode in the parent call frame. At least in terms of the synthetic benchmark the change seems worth it.

<details><summary>Benchmark</summary>
<p>

```php
<?php

class Foo {}

$objects = [];
for ($i = 0; $i < 10000; $i++) {
    $objects[] = new Foo();
}

for ($i = 0; $i < 1000; $i++) {
    serialize($objects);
}

?>
```

```
Before this PR:
  Time (mean ± σ):     168.7 ms ±   2.2 ms    [User: 166.0 ms, System: 2.2 ms]
  Range (min … max):   164.8 ms … 172.5 ms    17 runs

Before unique:
  Time (mean ± σ):     599.7 ms ±   7.0 ms    [User: 418.0 ms, System: 179.1 ms]
  Range (min … max):   586.0 ms … 608.4 ms    10 runs

After unique:
  Time (mean ± σ):     166.1 ms ±   1.9 ms    [User: 163.4 ms, System: 2.1 ms]
  Range (min … max):   163.7 ms … 168.9 ms    17 runs
```

</p>
</details> 

<details><summary>Patch</summary>
<p>

```patch
From 718dae4761de8a4d411f6466fca4b4b89c8572f4 Mon Sep 17 00:00:00 2001
From: Ilija Tovilo <ilija.tovilo@me.com>
Date: Tue, 30 May 2023 14:59:25 +0200
Subject: [PATCH] Skip serialize object recording when array paths are rc1

Additionally, handle the common case of passing a CV-array with RC1 to
serialize. This results in RC2 which we can safely treat as RC1 because no
additional internal references are possible.
---
 .../serialize/serialization_objects_019.phpt  | 33 +++++++---
 ext/standard/var.c                            | 66 ++++++++++++++-----
 2 files changed, 74 insertions(+), 25 deletions(-)

diff --git a/ext/standard/tests/serialize/serialization_objects_019.phpt b/ext/standard/tests/serialize/serialization_objects_019.phpt
index 505fc3d9af..916a899b17 100644
--- a/ext/standard/tests/serialize/serialization_objects_019.phpt
+++ b/ext/standard/tests/serialize/serialization_objects_019.phpt
@@ -2,16 +2,29 @@
 Object serialization with references
 --FILE--
 <?php
-function gen() {
-    $s = new stdClass;
-    $r = new stdClass;
-    $r->a = [$s];
-    $r->b = $r->a;
-    return $r;
+
+function rcn() {
+    $root = new stdClass;
+    $end = new stdClass;
+    $root->a = [$end];
+    $root->b = $root->a;
+    unset($end);
+    var_dump(serialize($root));
 }
-var_dump(serialize(gen()));
-?>
---EXPECTF--
-string(78) "O:8:"stdClass":2:{s:1:"a";a:1:{i:0;O:8:"stdClass":0:{}}s:1:"b";a:1:{i:0;r:3;}}"
 
+function rcn_rc1() {
+    $root = new stdClass;
+    $end = new stdClass;
+    $root->a = [[$end]];
+    $root->b = $root->a;
+    unset($end);
+    var_dump(serialize($root));
+}
 
+rcn();
+rcn_rc1();
+
+?>
+--EXPECT--
+string(78) "O:8:"stdClass":2:{s:1:"a";a:1:{i:0;O:8:"stdClass":0:{}}s:1:"b";a:1:{i:0;r:3;}}"
+string(98) "O:8:"stdClass":2:{s:1:"a";a:1:{i:0;a:1:{i:0;O:8:"stdClass":0:{}}}s:1:"b";a:1:{i:0;a:1:{i:0;r:4;}}}"
diff --git a/ext/standard/var.c b/ext/standard/var.c
index 641e0275f5..08a9996472 100644
--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -652,9 +652,13 @@ PHP_FUNCTION(var_export)
 }
 /* }}} */
 
-static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash);
+static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash, bool unique, bool subtract_rc);
 
-static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var) /* {{{ */
+/**
+ * @param bool unique Whether the element can only appear once in the serialized data. It can appear
+ *                    multiple times if it is embedded in an array with RC > 1.
+ */
+static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var, bool unique) /* {{{ */
 {
 	zval *zv;
 	zend_ulong key;
@@ -666,6 +670,10 @@ static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var) /
 		/* pass */
 	} else if (Z_TYPE_P(var) != IS_OBJECT) {
 		return 0;
+	} else if (unique
+	 && Z_REFCOUNT_P(var) == 1
+	 && (Z_OBJ_P(var)->properties == NULL || GC_REFCOUNT(Z_OBJ_P(var)->properties) == 1)) {
+		return 0;
 	}
 
 	/* References to objects are treated as if the reference didn't exist */
@@ -921,7 +929,7 @@ static int php_var_serialize_get_sleep_props(
 }
 /* }}} */
 
-static void php_var_serialize_nested_data(smart_str *buf, zval *struc, HashTable *ht, uint32_t count, bool incomplete_class, php_serialize_data_t var_hash) /* {{{ */
+static void php_var_serialize_nested_data(smart_str *buf, zval *struc, HashTable *ht, uint32_t count, bool incomplete_class, php_serialize_data_t var_hash, bool unique) /* {{{ */
 {
 	smart_str_append_unsigned(buf, count);
 	smart_str_appendl(buf, ":{", 2);
@@ -951,19 +959,19 @@ static void php_var_serialize_nested_data(smart_str *buf, zval *struc, HashTable
 			if (Z_TYPE_P(data) == IS_ARRAY) {
 				if (UNEXPECTED(Z_IS_RECURSIVE_P(data))
 					|| UNEXPECTED(Z_TYPE_P(struc) == IS_ARRAY && Z_ARR_P(data) == Z_ARR_P(struc))) {
-					php_add_var_hash(var_hash, struc);
+					php_add_var_hash(var_hash, struc, unique);
 					smart_str_appendl(buf, "N;", 2);
 				} else {
 					if (Z_REFCOUNTED_P(data)) {
 						Z_PROTECT_RECURSION_P(data);
 					}
-					php_var_serialize_intern(buf, data, var_hash);
+					php_var_serialize_intern(buf, data, var_hash, unique, false);
 					if (Z_REFCOUNTED_P(data)) {
 						Z_UNPROTECT_RECURSION_P(data);
 					}
 				}
 			} else {
-				php_var_serialize_intern(buf, data, var_hash);
+				php_var_serialize_intern(buf, data, var_hash, unique, false);
 			}
 		} ZEND_HASH_FOREACH_END();
 	}
@@ -978,13 +986,13 @@ static void php_var_serialize_class(smart_str *buf, zval *struc, HashTable *ht,
 	if (php_var_serialize_get_sleep_props(&props, struc, ht) == SUCCESS) {
 		php_var_serialize_class_name(buf, struc);
 		php_var_serialize_nested_data(
-			buf, struc, &props, zend_hash_num_elements(&props), /* incomplete_class */ 0, var_hash);
+			buf, struc, &props, zend_hash_num_elements(&props), /* incomplete_class */ 0, var_hash, GC_REFCOUNT(&props) == 1);
 	}
 	zend_hash_destroy(&props);
 }
 /* }}} */
 
-static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash) /* {{{ */
+static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_data_t var_hash, bool unique, bool subtract_rc) /* {{{ */
 {
 	zend_long var_already;
 	HashTable *myht;
@@ -993,7 +1001,7 @@ static void php_var_serialize_intern(smart_str *buf, zval *struc, php_serialize_
 		return;
 	}
 
-	if (var_hash && (var_already = php_add_var_hash(var_hash, struc))) {
+	if (var_hash && (var_already = php_add_var_hash(var_hash, struc, unique))) {
 		if (var_already == -1) {
 			/* Reference to an object that failed to serialize, replace with null. */
 			smart_str_appendl(buf, "N;", 2);
@@ -1102,7 +1110,7 @@ again:
 						if (Z_ISREF_P(data) && Z_REFCOUNT_P(data) == 1) {
 							data = Z_REFVAL_P(data);
 						}
-						php_var_serialize_intern(buf, data, var_hash);
+						php_var_serialize_intern(buf, data, var_hash, Z_REFCOUNT_P(&retval) == 1, false);
 					} ZEND_HASH_FOREACH_END();
 					smart_str_appendc(buf, '}');
 
@@ -1224,7 +1232,7 @@ again:
 								prop = Z_REFVAL_P(prop);
 							}
 
-							php_var_serialize_intern(buf, prop, var_hash);
+							php_var_serialize_intern(buf, prop, var_hash, true, false);
 						}
 						smart_str_appendc(buf, '}');
 					} else {
@@ -1239,7 +1247,7 @@ again:
 				if (count > 0 && incomplete_class) {
 					--count;
 				}
-				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash);
+				php_var_serialize_nested_data(buf, struc, myht, count, incomplete_class, var_hash, GC_REFCOUNT(myht) == 1);
 				zend_release_properties(myht);
 				return;
 			}
@@ -1247,7 +1255,7 @@ again:
 			smart_str_appendl(buf, "a:", 2);
 			myht = Z_ARRVAL_P(struc);
 			php_var_serialize_nested_data(
-				buf, struc, myht, zend_array_count(myht), /* incomplete_class */ 0, var_hash);
+				buf, struc, myht, zend_array_count(myht), /* incomplete_class */ 0, var_hash, unique && (GC_REFCOUNT(myht) - (subtract_rc ? 1 : 0)) == 1);
 			return;
 		case IS_REFERENCE:
 			struc = Z_REFVAL_P(struc);
@@ -1261,11 +1269,17 @@ again:
 
 PHPAPI void php_var_serialize(smart_str *buf, zval *struc, php_serialize_data_t *data) /* {{{ */
 {
-	php_var_serialize_intern(buf, struc, *data);
+	php_var_serialize_intern(buf, struc, *data, true, false);
 	smart_str_0(buf);
 }
 /* }}} */
 
+static void php_var_serialize_cv(smart_str *buf, zval *struc, php_serialize_data_t *data)
+{
+	php_var_serialize_intern(buf, struc, *data, true, true);
+	smart_str_0(buf);
+}
+
 PHPAPI php_serialize_data_t php_var_serialize_init(void) {
 	struct php_serialize_data *d;
 	/* fprintf(stderr, "SERIALIZE_INIT      == lock: %u, level: %u\n", BG(serialize_lock), BG(serialize).level); */
@@ -1306,8 +1320,30 @@ PHP_FUNCTION(serialize)
 		Z_PARAM_ZVAL(struc)
 	ZEND_PARSE_PARAMETERS_END();
 
+	bool data_is_cv = false;
+	if (Z_TYPE_P(struc) == IS_ARRAY
+	 && !(GC_FLAGS(Z_ARRVAL_P(struc)) & IS_ARRAY_IMMUTABLE)
+	 && EG(current_execute_data)
+	 && EG(current_execute_data)->prev_execute_data) {
+		zend_execute_data *execute_data = EG(current_execute_data)->prev_execute_data;
+		if (execute_data->func && ZEND_USER_CODE(execute_data->func->type)) {
+			zend_op_array *func = &execute_data->func->op_array;
+			const zend_op *opline = execute_data->opline;
+			if (func->opcodes < opline) {
+				const zend_op *prev_opline = opline - 1;
+				if ((prev_opline->opcode == ZEND_SEND_VAR || prev_opline->opcode == ZEND_SEND_VAR_EX) && prev_opline->op1_type == IS_CV) {
+					data_is_cv = true;
+				}
+			}
+		}
+	}
+
 	PHP_VAR_SERIALIZE_INIT(var_hash);
-	php_var_serialize(&buf, struc, &var_hash);
+	if (data_is_cv) {
+		php_var_serialize_cv(&buf, struc, &var_hash);
+	} else {
+		php_var_serialize(&buf, struc, &var_hash);
+	}
 	PHP_VAR_SERIALIZE_DESTROY(var_hash);
 
 	if (EG(exception)) {
-- 
2.40.1
```

</p>
</details> 
