### PR TITLE
Fix GH-11347: Memory leak when calling a static method inside an xpath query

### DIFF
--- a/ext/dom/tests/gh11347.phpt
+++ b/ext/dom/tests/gh11347.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-11347 (Memory leak when calling a static method inside an xpath query)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+class MyClass
+{
+    public static function dump(string $var) {
+        var_dump($var);
+    }
+}
+
+$doc = new DOMDocument();
+$doc->loadHTML('<a href="https://php.net">hello</a>');
+$xpath = new DOMXpath($doc);
+$xpath->registerNamespace("php", "http://php.net/xpath");
+$xpath->registerPHPFunctions();
+$xpath->query("//a[php:function('MyClass::dump', string(@href))]");
+
+?>
+Done
+--EXPECT--
+string(15) "https://php.net"
+Done

--- a/ext/dom/xpath.c
+++ b/ext/dom/xpath.c
@@ -182,7 +182,7 @@ static void dom_xpath_ext_function_php(xmlXPathParserContextPtr ctxt, int nargs,
 	}
 cleanup:
 	zend_string_release_ex(callable, 0);
-	zval_ptr_dtor_str(&fci.function_name);
+	zval_ptr_dtor_nogc(&fci.function_name);
 	if (fci.param_count > 0) {
 		for (i = 0; i < nargs - 1; i++) {
 			zval_ptr_dtor(&fci.params[i]);


### PR DESCRIPTION
It's a type confusion bug. `zend_make_callable` may change the function name of the fci to become an array, causing a crash in debug mode on `zval_ptr_dtor_str(&fci.function_name);` in `dom_xpath_ext_function_php`. On a production build it doesn't crash but only causes a leak, because the array elements are not destroyed, only the array container itself is.