### PR TITLE
Add fallback value syntax for ini variables

### DIFF
--- a/Zend/tests/bug70748.phpt
+++ b/Zend/tests/bug70748.phpt
@@ -15,6 +15,6 @@ var_dump(parse_ini_file($ini_file));
 unlink(__DIR__ . "/bug70748.ini");
 ?>
 --EXPECTF--
-Warning: syntax error, unexpected end of file, expecting '}' in %sbug70748.ini on line %d
+Warning: syntax error, unexpected end of file, expecting TC_FALLBACK or '}' in %s on line %d
  in %sbug70748.php on line %d
 bool(false)

--- a/Zend/zend_ini_parser.y
+++ b/Zend/zend_ini_parser.y
@@ -342,6 +342,7 @@ static void normalize_value(zval *zv)
 %token TC_DOLLAR_CURLY
 %token TC_VARNAME
 %token TC_QUOTED_STRING
+%token TC_FALLBACK
 %token BOOL_TRUE
 %token BOOL_FALSE
 %token NULL_NULL
@@ -445,7 +446,7 @@ expr:
 
 cfg_var_ref:
 		TC_DOLLAR_CURLY TC_VARNAME '}'				{ zend_ini_get_var(&$$, &$2, NULL); zend_string_free(Z_STR($2)); }
-	|	TC_DOLLAR_CURLY TC_VARNAME '!' fallback '}'	{ zend_ini_get_var(&$$, &$2, &$4); zend_string_free(Z_STR($2)); zend_string_free(Z_STR($4)); }
+	|	TC_DOLLAR_CURLY TC_VARNAME TC_FALLBACK fallback '}'	{ zend_ini_get_var(&$$, &$2, &$4); zend_string_free(Z_STR($2)); zend_string_free(Z_STR($4)); }
 ;
 
 

--- a/Zend/zend_ini_scanner.l
+++ b/Zend/zend_ini_scanner.l
@@ -370,6 +370,7 @@ RAW_VALUE_CHARS [^\n\r;\000]
 
 LITERAL_DOLLAR ("$"([^{\000]|("\\"{ANY_CHAR})))
 VALUE_CHARS         ([^$= \t\n\r;&|^~()!"'\000]|{LITERAL_DOLLAR})
+FALLBACK_CHARS		([^$\n\r;"'!}\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
 SECTION_VALUE_CHARS ([^$\n\r;"'\]\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
 
 <!*> := yyleng = YYCURSOR - SCNG(yy_text);
@@ -417,7 +418,7 @@ SECTION_VALUE_CHARS ([^$\n\r;"'\]\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
 	return ']';
 }
 
-<ST_DOUBLE_QUOTES,ST_SECTION_VALUE,ST_VALUE,ST_OFFSET>{DOLLAR_CURLY} { /* Variable start */
+<ST_DOUBLE_QUOTES,ST_SECTION_VALUE,ST_VALUE,ST_OFFSET,ST_VAR_FALLBACK>{DOLLAR_CURLY} { /* Variable start */
 	yy_push_state(ST_VARNAME);
 	return TC_DOLLAR_CURLY;
 }
@@ -432,7 +433,13 @@ SECTION_VALUE_CHARS ([^$\n\r;"'\]\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
 	RETURN_TOKEN(TC_VARNAME, yytext, yyleng);
 }
 
-<ST_VARNAME>"}" { /* Variable end */
+<ST_VARNAME>"!" { /* End Variable name, fallback start */
+	yy_pop_state();
+	yy_push_state(ST_VAR_FALLBACK);
+	return '!';
+}
+
+<ST_VARNAME,ST_VAR_FALLBACK>"}" { /* Variable/fallback end */
 	yy_pop_state();
 	return '}';
 }
@@ -522,11 +529,11 @@ end_raw_value_chars:
 	return END_OF_LINE;
 }
 
-<ST_SECTION_VALUE,ST_VALUE,ST_OFFSET>{CONSTANT} { /* Get constant option value */
+<ST_SECTION_VALUE,ST_VALUE,ST_VAR_FALLBACK,ST_OFFSET>{CONSTANT} { /* Get constant option value */
 	RETURN_TOKEN(TC_CONSTANT, yytext, yyleng);
 }
 
-<ST_SECTION_VALUE,ST_VALUE,ST_OFFSET>{NUMBER} { /* Get number option value as string */
+<ST_SECTION_VALUE,ST_VALUE,ST_VAR_FALLBACK,ST_OFFSET>{NUMBER} { /* Get number option value as string */
 	RETURN_TOKEN(TC_NUMBER, yytext, yyleng);
 }
 
@@ -548,11 +555,15 @@ end_raw_value_chars:
 	RETURN_TOKEN(TC_STRING, yytext, yyleng);
 }
 
+<ST_VAR_FALLBACK>{FALLBACK_CHARS}+ { /* Same as above, but excluding '}' */
+	RETURN_TOKEN(TC_STRING, yytext, yyleng);
+}
+
 <ST_SECTION_VALUE,ST_OFFSET>{SECTION_VALUE_CHARS}+ { /* Get rest as section/offset value */
 	RETURN_TOKEN(TC_STRING, yytext, yyleng);
 }
 
-<ST_SECTION_VALUE,ST_VALUE,ST_OFFSET>{TABS_AND_SPACES}*["] { /* Double quoted '"' string start */
+<ST_SECTION_VALUE,ST_VALUE,ST_VAR_FALLBACK,ST_OFFSET>{TABS_AND_SPACES}*["] { /* Double quoted '"' string start */
 	yy_push_state(ST_DOUBLE_QUOTES);
 	return '"';
 }
@@ -603,7 +614,7 @@ end_raw_value_chars:
 	return TC_QUOTED_STRING;
 }
 
-<ST_SECTION_VALUE,ST_VALUE,ST_OFFSET>{WHITESPACE} {
+<ST_SECTION_VALUE,ST_VALUE,ST_OFFSET,ST_VAR_FALLBACK>{WHITESPACE} {
 	RETURN_TOKEN(TC_WHITESPACE, yytext, yyleng);
 }
 

--- a/Zend/zend_ini_scanner.l
+++ b/Zend/zend_ini_scanner.l
@@ -360,7 +360,6 @@ TABS_AND_SPACES [ \t]
 WHITESPACE [ \t]+
 CONSTANT [a-zA-Z_][a-zA-Z0-9_]*
 LABEL_CHAR [^=\n\r\t;&|^$~(){}!"\[\]\x00]
-/* FIXME: Is this missing a \0? */
 LABEL ({LABEL_CHAR}+)
 TOKENS [:,.\[\]"'()&|^+-/*=%$!~<>?@{}]
 OPERATORS [&|^~()!]
@@ -372,7 +371,7 @@ RAW_VALUE_CHARS [^\n\r;\000]
 
 LITERAL_DOLLAR ("$"([^{\000]|("\\"{ANY_CHAR})))
 VALUE_CHARS         ([^$= \t\n\r;&|^~()!"'\000]|{LITERAL_DOLLAR})
-FALLBACK_CHARS		([^$\n\r;"'!}\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
+FALLBACK_CHARS		([^$\n\r;"'}\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
 SECTION_VALUE_CHARS ([^$\n\r;"'\]\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
 
 <!*> := yyleng = YYCURSOR - SCNG(yy_text);
@@ -600,7 +599,7 @@ end_raw_value_chars:
 	RETURN_TOKEN(TC_STRING, yytext, yyleng);
 }
 
-<ST_VAR_FALLBACK>{FALLBACK_CHARS}+ { /* Same as above, but excluding '}' */
+<ST_VAR_FALLBACK>{FALLBACK_CHARS}+ { /* Same as below, but excluding '}' */
 	RETURN_TOKEN(TC_STRING, yytext, yyleng);
 }
 

--- a/Zend/zend_ini_scanner.l
+++ b/Zend/zend_ini_scanner.l
@@ -359,7 +359,9 @@ NEWLINE	("\r"|"\n"|"\r\n")
 TABS_AND_SPACES [ \t]
 WHITESPACE [ \t]+
 CONSTANT [a-zA-Z_][a-zA-Z0-9_]*
-LABEL [^=\n\r\t;&|^$~(){}!"\[]+
+LABEL_CHAR [^=\n\r\t;&|^$~(){}!"\[\]\x00]
+/* FIXME: Is this missing a \0? */
+LABEL ({LABEL_CHAR}+)
 TOKENS [:,.\[\]"'()&|^+-/*=%$!~<>?@{}]
 OPERATORS [&|^~()!]
 DOLLAR_CURLY "${"
@@ -423,7 +425,56 @@ SECTION_VALUE_CHARS ([^$\n\r;"'\]\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
 	return TC_DOLLAR_CURLY;
 }
 
-<ST_VARNAME>{LABEL} { /* Variable name */
+<ST_VARNAME>":-" { /* End Variable name, fallback start */
+fallback_lexing:
+	yy_pop_state();
+	yy_push_state(ST_VAR_FALLBACK);
+	return TC_FALLBACK;
+}
+
+<ST_VARNAME>{LABEL_CHAR} { /* Variable name */
+	if (YYCURSOR[0] == ':' && YYCURSOR[1] == '-') {
+		YYCURSOR++;
+		goto fallback_lexing;
+	}
+
+	while (YYCURSOR < YYLIMIT) {
+		switch (*YYCURSOR++) {
+			case '=':
+			case '\n':
+			case '\r':
+			case '\t':
+			case ';':
+			case '&':
+			case '|':
+			case '^':
+			case '$':
+			case '~':
+			case '(':
+			case ')':
+			case '{':
+			case '}':
+			case '!':
+			case '"':
+			case '[':
+			case ']':
+				break;
+			/* ':' is only allowed if it isn't followed by '-'. */
+			case ':':
+				if (YYCURSOR[0] == '-') {
+					break;
+				} else {
+					continue;
+				}
+			default:
+				continue;
+		}
+
+		YYCURSOR--;
+		yyleng = YYCURSOR - SCNG(yy_text);
+		break;
+	}
+
 	/* Eat leading whitespace */
 	EAT_LEADING_WHITESPACE();
 
@@ -431,12 +482,6 @@ SECTION_VALUE_CHARS ([^$\n\r;"'\]\\]|("\\"{ANY_CHAR})|{LITERAL_DOLLAR})
 	EAT_TRAILING_WHITESPACE();
 
 	RETURN_TOKEN(TC_VARNAME, yytext, yyleng);
-}
-
-<ST_VARNAME>"!" { /* End Variable name, fallback start */
-	yy_pop_state();
-	yy_push_state(ST_VAR_FALLBACK);
-	return '!';
 }
 
 <ST_VARNAME,ST_VAR_FALLBACK>"}" { /* Variable/fallback end */

--- a/ext/standard/tests/general_functions/parse_ini_basic.data
+++ b/ext/standard/tests/general_functions/parse_ini_basic.data
@@ -76,11 +76,13 @@ novalue_option4[]=
 ["Quoted strings and variables in sections"]
 
 [${basicval}]
+[${undefinedval!foo}]
 [${basicval}/foo]
 [foo/${basicval}]
 [foo/${basicval}/foo]
 
 ["${basicqval}"]
+["${undefinedval!foo}"]
 ["${basicqval}/foo"]
 ["foo/${basicqval}"]
 ["foo/${basicqval}/foo"]
@@ -141,3 +143,22 @@ double_quoted_multiline = "Lorem \"ipsum\"""
  dolor"
 dollar_test = "\${test}"
 unescaped ="\n\r\t"
+
+[variable-fallback]
+defined1 = "Hello, ${basicval!world}!"
+defined2 = ${basicval!123}
+falsy = ${falsyval!hi}
+undefined = "Hello, ${undefined_var!world}!"
+empty = ${emptyval!foo}
+spaces = ${undefined_var!hi there}
+exclamation = ${hi_is_this_undefined!"no, this is fallback!"}
+nested = ${undefined_var!${also_undefined!${undefined_too!hello}}}
+hostname = localhost:${undefined_var!8080}
+outer_quotes = "foo:${undefined_var!bar}"
+number_value = ${undefined_var!12345}
+true_value = ${undefined_var!true}
+false_value = ${undefined_var!false}
+null_value = ${undefined_var!null}
+empty1 = ${undefined_var!}
+empty2 = ${undefined}
+constant = ${undefined!TEST_CONSTANT}

--- a/ext/standard/tests/general_functions/parse_ini_basic.data
+++ b/ext/standard/tests/general_functions/parse_ini_basic.data
@@ -76,13 +76,13 @@ novalue_option4[]=
 ["Quoted strings and variables in sections"]
 
 [${basicval}]
-[${undefinedval!foo}]
+[${undefinedval:-foo}]
 [${basicval}/foo]
 [foo/${basicval}]
 [foo/${basicval}/foo]
 
 ["${basicqval}"]
-["${undefinedval!foo}"]
+["${undefinedval:-foo}"]
 ["${basicqval}/foo"]
 ["foo/${basicqval}"]
 ["foo/${basicqval}/foo"]
@@ -145,20 +145,22 @@ dollar_test = "\${test}"
 unescaped ="\n\r\t"
 
 [variable-fallback]
-defined1 = "Hello, ${basicval!world}!"
-defined2 = ${basicval!123}
-falsy = ${falsyval!hi}
-undefined = "Hello, ${undefined_var!world}!"
-empty = ${emptyval!foo}
-spaces = ${undefined_var!hi there}
-exclamation = ${hi_is_this_undefined!"no, this is fallback!"}
-nested = ${undefined_var!${also_undefined!${undefined_too!hello}}}
-hostname = localhost:${undefined_var!8080}
-outer_quotes = "foo:${undefined_var!bar}"
-number_value = ${undefined_var!12345}
-true_value = ${undefined_var!true}
-false_value = ${undefined_var!false}
-null_value = ${undefined_var!null}
-empty1 = ${undefined_var!}
+defined1 = "Hello, ${basicval:-world}!"
+defined2 = ${basicval:-123}
+falsy = ${falsyval:-hi}
+undefined = "Hello, ${undefined_var:-world}!"
+empty = ${emptyval:-foo}
+spaces = ${undefined_var:-hi there}
+exclamation = ${hi_is_this_undefined:-"no, this is fallback!"}
+nested = ${undefined_var:-${also_undefined:-${undefined_too:-hello}}}
+hostname = localhost:${undefined_var:-8080}
+outer_quotes = "foo:${undefined_var:-bar}"
+number_value = ${undefined_var:-12345}
+true_value = ${undefined_var:-true}
+false_value = ${undefined_var:-false}
+null_value = ${undefined_var:-null}
+empty1 = ${undefined_var:-}
 empty2 = ${undefined}
-constant = ${undefined!TEST_CONSTANT}
+constant = ${undefined:-TEST_CONSTANT}
+INI:WITH:COLON = ${INI:WITH:COLON:-}
+NONEXISTENT:INI:WITH:COLON = ${NONEXISTENT:INI:WITH:COLON:-fallback}

--- a/ext/standard/tests/general_functions/parse_ini_basic.phpt
+++ b/ext/standard/tests/general_functions/parse_ini_basic.phpt
@@ -3,6 +3,8 @@ parse_ini_file() tests
 --ENV--
 basicval=FUBAR_VARIABLE
 basicqval=FUBAR_QUOTES_VARIABLE
+falsyval=false
+emptyval=
 --FILE--
 <?php
 
@@ -15,7 +17,7 @@ var_dump(parse_ini_file($ini_file, 1));
 echo "Done.\n";
 ?>
 --EXPECT--
-array(27) {
+array(29) {
   ["basic"]=>
   array(15) {
     ["basicval"]=>
@@ -179,6 +181,9 @@ array(27) {
   ["FUBAR_VARIABLE"]=>
   array(0) {
   }
+  ["foo"]=>
+  array(0) {
+  }
   ["FUBAR_VARIABLE/foo"]=>
   array(0) {
   }
@@ -294,6 +299,43 @@ array(27) {
     string(7) "${test}"
     ["unescaped"]=>
     string(6) "\n\r\t"
+  }
+  ["variable-fallback"]=>
+  array(17) {
+    ["defined1"]=>
+    string(22) "Hello, FUBAR_VARIABLE!"
+    ["defined2"]=>
+    string(14) "FUBAR_VARIABLE"
+    ["falsy"]=>
+    string(5) "false"
+    ["undefined"]=>
+    string(13) "Hello, world!"
+    ["empty"]=>
+    string(3) "foo"
+    ["spaces"]=>
+    string(8) "hi there"
+    ["exclamation"]=>
+    string(21) "no, this is fallback!"
+    ["nested"]=>
+    string(5) "hello"
+    ["hostname"]=>
+    string(14) "localhost:8080"
+    ["outer_quotes"]=>
+    string(7) "foo:bar"
+    ["number_value"]=>
+    string(5) "12345"
+    ["true_value"]=>
+    string(1) "1"
+    ["false_value"]=>
+    string(0) ""
+    ["null_value"]=>
+    string(0) ""
+    ["empty1"]=>
+    string(0) ""
+    ["empty2"]=>
+    string(0) ""
+    ["constant"]=>
+    string(21) "this_is_test_constant"
   }
 }
 Done.

--- a/ext/standard/tests/general_functions/parse_ini_basic.phpt
+++ b/ext/standard/tests/general_functions/parse_ini_basic.phpt
@@ -5,6 +5,8 @@ basicval=FUBAR_VARIABLE
 basicqval=FUBAR_QUOTES_VARIABLE
 falsyval=false
 emptyval=
+--INI--
+INI:WITH:COLON=ini_with_colon
 --FILE--
 <?php
 
@@ -301,7 +303,7 @@ array(29) {
     string(6) "\n\r\t"
   }
   ["variable-fallback"]=>
-  array(17) {
+  array(19) {
     ["defined1"]=>
     string(22) "Hello, FUBAR_VARIABLE!"
     ["defined2"]=>
@@ -336,6 +338,10 @@ array(29) {
     string(0) ""
     ["constant"]=>
     string(21) "this_is_test_constant"
+    ["INI:WITH:COLON"]=>
+    string(14) "ini_with_colon"
+    ["NONEXISTENT:INI:WITH:COLON"]=>
+    string(8) "fallback"
   }
 }
 Done.

--- a/ext/standard/tests/general_functions/parse_ini_string_error.phpt
+++ b/ext/standard/tests/general_functions/parse_ini_string_error.phpt
@@ -11,10 +11,10 @@ Warning: syntax error, unexpected end of file, expecting TC_DOLLAR_CURLY or TC_Q
  in %s on line %d
 bool(false)
 
-Warning: syntax error, unexpected end of file, expecting TC_VARNAME in Unknown on line 1
+Warning: syntax error, unexpected end of file, expecting TC_FALLBACK or '}' in Unknown on line 1
  in %s on line %d
 bool(false)
 
-Warning: syntax error, unexpected end of file, expecting '}' in Unknown on line 1
+Warning: syntax error, unexpected end of file, expecting TC_FALLBACK or '}' in Unknown on line 1
  in %s on line %d
 bool(false)

--- a/ext/standard/tests/general_functions/parse_ini_string_error.phpt
+++ b/ext/standard/tests/general_functions/parse_ini_string_error.phpt
@@ -3,8 +3,18 @@ Ini parsing errors should not result in memory leaks
 --FILE--
 <?php
 var_dump(parse_ini_string('a="b'));
+var_dump(parse_ini_string('a=${b'));
+var_dump(parse_ini_string('a=${b!a'));
 ?>
 --EXPECTF--
 Warning: syntax error, unexpected end of file, expecting TC_DOLLAR_CURLY or TC_QUOTED_STRING or '"' in Unknown on line 1
+ in %s on line %d
+bool(false)
+
+Warning: syntax error, unexpected end of file, expecting TC_VARNAME in Unknown on line 1
+ in %s on line %d
+bool(false)
+
+Warning: syntax error, unexpected end of file, expecting '}' in Unknown on line 1
  in %s on line %d
 bool(false)

--- a/ext/standard/tests/general_functions/parse_ini_string_error.phpt
+++ b/ext/standard/tests/general_functions/parse_ini_string_error.phpt
@@ -4,7 +4,7 @@ Ini parsing errors should not result in memory leaks
 <?php
 var_dump(parse_ini_string('a="b'));
 var_dump(parse_ini_string('a=${b'));
-var_dump(parse_ini_string('a=${b!a'));
+var_dump(parse_ini_string('a=${b:-a'));
 ?>
 --EXPECTF--
 Warning: syntax error, unexpected end of file, expecting TC_DOLLAR_CURLY or TC_QUOTED_STRING or '"' in Unknown on line 1
@@ -15,6 +15,6 @@ Warning: syntax error, unexpected end of file, expecting TC_FALLBACK or '}' in U
  in %s on line %d
 bool(false)
 
-Warning: syntax error, unexpected end of file, expecting TC_FALLBACK or '}' in Unknown on line 1
+Warning: syntax error, unexpected TC_FALLBACK, expecting TC_VARNAME in Unknown on line 1
  in %s on line %d
 bool(false)


### PR DESCRIPTION
Hi, all!

This PR implements fallback/default values when substituting variables on ini files, like: `${VAR:-fallback}`. I was actually surprised this wasn't implemented yet, as it's a very useful feature.

I know a thing or two about lexers/parsers, but it's not something I'm super familiar with, so let me know if there's any way this can be improved!

~At the moment, the fallback value is treated similarly to a raw string, so it does not support arbitrary expressions (such as nested variables), I couldn't get it to without adding state pushes and pops everywhere on the lexer.~ It works similarly to offsets/sections now, and supports nesting!

As I understand, this should go through the RFC process? If so, I'm totally okay with writing one :). Let me know if there's any etiquette I might have missed, too.

---
As an example, my usecase is using environment variables to configure php-fpm, while also having some sane defaults. Like so:
```ini
error_log = syslog
daemonize = false

[www]
listen = localhost:${DRUPAL_FPM_PORT:-9000}
```