### PR TITLE
Fix [-Wenum-int-mismatch] compiler warnings

### DIFF
--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -129,7 +129,7 @@ int bc_modulo(bc_num num1, bc_num num2, bc_num *resul, int scale);
 
 int bc_divmod(bc_num num1, bc_num num2, bc_num *quo, bc_num *rem, int scale);
 
-int bc_raisemod(bc_num base, bc_num expo, bc_num mo, bc_num *result, int scale);
+zend_result bc_raisemod(bc_num base, bc_num expo, bc_num mo, bc_num *result, int scale);
 
 void bc_raise(bc_num num1, bc_num num2, bc_num *resul, int scale);
 

--- a/ext/ffi/ffi_parser.c
+++ b/ext/ffi/ffi_parser.c
@@ -3552,7 +3552,7 @@ static void parse(void) {
 	}
 }
 
-int zend_ffi_parse_decl(const char *str, size_t len) {
+zend_result zend_ffi_parse_decl(const char *str, size_t len) {
 	if (SETJMP(FFI_G(bailout))==0) {
 		FFI_G(allow_vla) = 0;
 		FFI_G(attribute_parsing) = 0;
@@ -3565,7 +3565,7 @@ int zend_ffi_parse_decl(const char *str, size_t len) {
 	}
 }
 
-int zend_ffi_parse_type(const char *str, size_t len, zend_ffi_dcl *dcl) {
+zend_result zend_ffi_parse_type(const char *str, size_t len, zend_ffi_dcl *dcl) {
 	int sym;
 
 	if (SETJMP(FFI_G(bailout))==0) {


### PR DESCRIPTION
Upgraded to Fedora 38 and a couple of new GCC 13 warnings popped up.