### PR TITLE
Use zval_ptr_dtor_nogc() for callable in ext/xslt

### DIFF
--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -289,7 +289,7 @@ static void xsl_ext_function_php(xmlXPathParserContextPtr ctxt, int nargs, int t
 		zval_ptr_dtor(&retval);
 	}
 	zend_string_release_ex(callable, 0);
-	zval_ptr_dtor(&handler);
+	zval_ptr_dtor_nogc(&handler);
 	if (fci.param_count > 0) {
 		for (i = 0; i < nargs - 1; i++) {
 			zval_ptr_dtor(&args[i]);


### PR DESCRIPTION
It cannot contain cycles because it's either a string or an array with 2 strings.