### PR TITLE
GCC 13 static analysis fixes

### DIFF
--- a/Zend/zend_enum.c
+++ b/Zend/zend_enum.c
@@ -597,6 +597,7 @@ ZEND_API void zend_enum_add_case_cstr(zend_class_entry *ce, const char *name, zv
 
 ZEND_API zend_object *zend_enum_get_case(zend_class_entry *ce, zend_string *name) {
 	zend_class_constant *c = zend_hash_find_ptr(CE_CONSTANTS_TABLE(ce), name);
+	ZEND_ASSERT(c && "Must be a valid enum case");
 	ZEND_ASSERT(ZEND_CLASS_CONST_FLAGS(c) & ZEND_CLASS_CONST_IS_CASE);
 
 	if (Z_TYPE(c->value) == IS_CONSTANT_AST) {

--- a/Zend/zend_gdb.c
+++ b/Zend/zend_gdb.c
@@ -113,7 +113,7 @@ ZEND_API bool zend_gdb_present(void)
 #if defined(__linux__) /* netbsd while having this procfs part, does not hold the tracer pid */
 	int fd = open("/proc/self/status", O_RDONLY);
 
-	if (fd > 0) {
+	if (fd >= 0) {
 		char buf[1024];
 		ssize_t n = read(fd, buf, sizeof(buf) - 1);
 		char *s;

--- a/ext/standard/http_fopen_wrapper.c
+++ b/ext/standard/http_fopen_wrapper.c
@@ -160,6 +160,7 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 		return NULL;
 	}
 
+	ZEND_ASSERT(resource->scheme);
 	if (!zend_string_equals_literal_ci(resource->scheme, "http") &&
 		!zend_string_equals_literal_ci(resource->scheme, "https")) {
 		if (!context ||
@@ -183,7 +184,7 @@ static php_stream *php_stream_url_wrap_http_ex(php_stream_wrapper *wrapper,
 			return NULL;
 		}
 
-		use_ssl = resource->scheme && (ZSTR_LEN(resource->scheme) > 4) && ZSTR_VAL(resource->scheme)[4] == 's';
+		use_ssl = (ZSTR_LEN(resource->scheme) > 4) && ZSTR_VAL(resource->scheme)[4] == 's';
 		/* choose default ports */
 		if (use_ssl && resource->port == 0)
 			resource->port = 443;

--- a/main/streams/memory.c
+++ b/main/streams/memory.c
@@ -349,7 +349,7 @@ static ssize_t php_stream_temp_write(php_stream *stream, const char *buf, size_t
 	}
 	if (php_stream_is(ts->innerstream, PHP_STREAM_IS_MEMORY)) {
 		zend_off_t pos = php_stream_tell(ts->innerstream);
-		
+
 		if (pos + count >= ts->smax) {
 			zend_string *membuf = php_stream_memory_get_buffer(ts->innerstream);
 			php_stream *file = php_stream_fopen_temporary_file(ts->tmpdir, "php", NULL);
@@ -614,6 +614,8 @@ static php_stream * php_stream_url_wrap_rfc2397(php_stream_wrapper *wrapper, con
 	int base64 = 0;
 	zend_string *base64_comma = NULL;
 
+	ZEND_ASSERT(mode);
+
 	ZVAL_NULL(&meta);
 	if (memcmp(path, "data:", 5)) {
 		return NULL;
@@ -729,7 +731,7 @@ static php_stream * php_stream_url_wrap_rfc2397(php_stream_wrapper *wrapper, con
 		stream->ops = &php_stream_rfc2397_ops;
 		ts = (php_stream_temp_data*)stream->abstract;
 		assert(ts != NULL);
-		ts->mode = mode && mode[0] == 'r' && mode[1] != '+' ? TEMP_STREAM_READONLY : 0;
+		ts->mode = mode[0] == 'r' && mode[1] != '+' ? TEMP_STREAM_READONLY : 0;
 		ZVAL_COPY_VALUE(&ts->meta, &meta);
 	}
 	if (base64_comma) {


### PR DESCRIPTION
I thought the proper way to initialise a C array was to do ``= {0}`` but it still seems to complain.

Another issue is that GCC's static analyser will analyse branches that cannot happen, and thus raises false positives.