### PR TITLE
When running FPM tests, pass -n option to php-fpm

### DIFF
--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -385,7 +385,7 @@ class Tester
     public function testConfig($silent = false)
     {
         $configFile = $this->createConfig();
-        $cmd        = self::findExecutable() . ' -tt -y ' . $configFile . ' 2>&1';
+        $cmd        = self::findExecutable() . ' -n -tt -y ' . $configFile . ' 2>&1';
         $this->trace('Testing config using command', $cmd, true);
         exec($cmd, $output, $code);
         if ($code) {
@@ -426,7 +426,7 @@ class Tester
         $configFile = $this->createConfig();
         $desc       = $this->outDesc ? [] : [1 => array('pipe', 'w'), 2 => array('redirect', 1)];
 
-        $cmd = [self::findExecutable(), '-y', $configFile];
+        $cmd = [self::findExecutable(), '-n', '-y', $configFile];
 
         if ($forceStderr) {
             $cmd[] = '-O';


### PR DESCRIPTION
"make test" was failing for me, because I was running it prior to
install, and there was an old installed version which was incompatible.
The FPM tests were using the installed php.ini which referenced
installed dynamically linked extensions.

So, pass -n to php-fpm.

FPM\Tester::start() has $extensions, $iniEntries and
TEST_FPM_EXTENSION_DIR but they are not actually set by anything. Rather
than rely on the installed php.ini to be correct, it seems safer to pass
-n, and any tests that need specific config can pass $iniEntries.
