### PR TITLE
Fix #79700: Bad performance with namespaced nodes due to wrong libxml assumption

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1369,10 +1369,15 @@ void dom_normalize (xmlNodePtr nodep)
 
 /* {{{ void dom_set_old_ns(xmlDoc *doc, xmlNs *ns) */
 void dom_set_old_ns(xmlDoc *doc, xmlNs *ns) {
-	xmlNs *cur;
-
 	if (doc == NULL)
 		return;
+
+	ZEND_ASSERT(ns->next == NULL);
+
+	/* Note: we'll use a prepend strategy instead of append to
+	 * make sure we don't lose performance when the list is long.
+	 * As libxml2 could assume the xml node is the first one, we'll place our
+	 * new entries after the first one. */
 
 	if (doc->oldNs == NULL) {
 		doc->oldNs = (xmlNsPtr) xmlMalloc(sizeof(xmlNs));
@@ -1383,13 +1388,10 @@ void dom_set_old_ns(xmlDoc *doc, xmlNs *ns) {
 		doc->oldNs->type = XML_LOCAL_NAMESPACE;
 		doc->oldNs->href = xmlStrdup(XML_XML_NAMESPACE);
 		doc->oldNs->prefix = xmlStrdup((const xmlChar *)"xml");
+	} else {
+		ns->next = doc->oldNs->next;
 	}
-
-	cur = doc->oldNs;
-	while (cur->next != NULL) {
-		cur = cur->next;
-	}
-	cur->next = ns;
+	doc->oldNs->next = ns;
 }
 /* }}} end dom_set_old_ns */
 

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1413,6 +1413,9 @@ static void dom_reconcile_ns_internal(xmlDocPtr doc, xmlNodePtr nodep)
 					} else {
 						prevns->next = nsdftptr;
 					}
+					/* Note: we can't get here if the ns is already on the oldNs list.
+					 * This is because in that case the definition won't be on the node, and
+					 * therefore won't be in the nodep->nsDef list. */
 					dom_set_old_ns(doc, curns);
 					curns = prevns;
 				}

--- a/ext/dom/tests/reconcile_reused_namespace.phpt
+++ b/ext/dom/tests/reconcile_reused_namespace.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Reconcile a reused namespace from doc->oldNs
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$dom = new DOMDocument();
+$root = $dom->createElementNS('http://www.w3.org/2000/xhtml', 'html');
+
+$dom->loadXML(<<<XML
+<?xml version="1.0"?>
+<html
+    xmlns="http://www.w3.org/2000/xhtml"
+    xmlns:a="http://example.com/A"
+    xmlns:b="http://example.com/B"
+/>
+XML);
+$root = $dom->firstElementChild;
+
+echo "Add first\n";
+$element = $dom->createElementNS('http://example.com/B', 'p', 'Hello World');
+$root->appendChild($element);
+
+echo "Add second\n";
+$element = $dom->createElementNS('http://example.com/A', 'p', 'Hello World');
+$root->appendChild($element);
+
+echo "Add third\n";
+$element = $dom->createElementNS('http://example.com/A', 'p', 'Hello World');
+$root->appendChild($element);
+
+var_dump($dom->saveXML());
+
+?>
+--EXPECT--
+Add first
+Add second
+Add third
+string(201) "<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/2000/xhtml" xmlns:a="http://example.com/A" xmlns:b="http://example.com/B"><b:p>Hello World</b:p><a:p>Hello World</a:p><a:p>Hello World</a:p></html>
+"


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=79700 (that issue description also contains the benchmark!).
The issue talks about a wrong assumption, but I don't think it's a wrong assumption per-se. See also GH-5719 for more context and the emails from https://mail.gnome.org/archives/xml/2020-June/msg00000.html.

The purpose of oldNs AFAIK is actually to store the namespaces which can't be stored on the document nodes. They can't be freed because these nodes may be reused (and they don't refcount or anything). Also: not storing them on the oldNs list will leak memory when all relevant XML nodes are destroyed.

The problem in the original issue is the ever-growing list of duplicate ns nodes.
This PR solves this.

Commit list:
* Commit 1 `Use a prepending strategy instead of appending in dom_set_old_ns()` improves performance of the list management (see commit description).
* Commit 2 `Reuse namespaces from doc->oldNs if possible in dom_get_ns()` solves the actual problem by reusing ns nodes.
* Commit 3 adds a test to assert we cannot get cycles in the ns list.
* Commit 4 adds some comment explaining why we can't get cycles.

Targeting master because of potential impact of risky code changes.
Marking as draft for now because I need to double check this stuff.