### PR TITLE
Fix test failure for init_fcall_003.phpt without opcache

### DIFF
--- a/ext/opcache/tests/jit/init_fcall_003.phpt
+++ b/ext/opcache/tests/jit/init_fcall_003.phpt
@@ -11,6 +11,8 @@ opcache.jit_hot_loop=64
 opcache.jit_hot_func=127
 opcache.jit_hot_return=8
 opcache.jit_hot_side_exit=8
+--EXTENSIONS--
+opcache
 --FILE--
 <?php
 include(__DIR__ . '/init_fcall_003.inc');


### PR DESCRIPTION
If opcache isn't loaded, then opcache_invalidate() will fail. Reproducible when you compile PHP without opcache, or run PHP without opcache loaded, and try to run this test.

This pops up from time to time on my system because I often configure with `./configure --enable-debug` and only like 1 extension extra or so (or even none) to save time.