### PR TITLE
ensure session.sid_length have proper value for test

### DIFF
--- a/ext/session/tests/session_regenerate_id_cookie.phpt
+++ b/ext/session/tests/session_regenerate_id_cookie.phpt
@@ -2,6 +2,8 @@
 Test session_regenerate_id() function : basic functionality
 --EXTENSIONS--
 session
+--INI--
+session.sid_length = 32
 --SKIPIF--
 <?php
 


### PR DESCRIPTION
session.sid_length default is 32 but production and development configuration use 26
so test may fail when php.ini is one provided.
