### PR TITLE
Allow final modifier when using a method from a trait

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.3.0alpha2
 
+- Core:
+  . Fix GH-11388 (Allow "final" modifier when importing a method from a trait).
+    (nielsdos)
 
 08 Jun 2023, PHP 8.3.0alpha1
 

--- a/UPGRADING
+++ b/UPGRADING
@@ -63,6 +63,7 @@ PHP 8.3 UPGRADE NOTES
   . Class, interface, trait, and enum constants now support type
     declarations. RFC: https://wiki.php.net/rfc/typed_class_constants
   . Closures created from magic methods can now accept named arguments.
+  . The final modifier may now be used when using a method from a trait.
 
 - Posix
   . posix_getrlimit() now takes an optional $res parameter to allow fetching a

--- a/Zend/tests/traits/language019.phpt
+++ b/Zend/tests/traits/language019.phpt
@@ -10,6 +10,9 @@ class C1 {
         T1::foo as final;
     }
 }
+class C2 extends C1 {
+    public function foo() {}
+}
 ?>
 --EXPECTF--
-Fatal error: Cannot use "final" as method modifier in trait alias in %s on line %d
+Fatal error: Cannot override final method C1::foo() in %s on line %d

--- a/Zend/tests/traits/language020.phpt
+++ b/Zend/tests/traits/language020.phpt
@@ -1,0 +1,21 @@
+--TEST--
+final alias - positive test variation
+--FILE--
+<?php
+trait T1 {
+    function foo() {
+        echo "Done\n";
+    }
+}
+class C1 {
+    use T1 {
+        T1::foo as final;
+    }
+}
+class C2 extends C1 {
+    public function bar() {}
+}
+(new C2)->foo();
+?>
+--EXPECT--
+Done

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7727,8 +7727,6 @@ static void zend_check_trait_alias_modifiers(uint32_t attr) /* {{{ */
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot use \"static\" as method modifier in trait alias");
 	} else if (attr & ZEND_ACC_ABSTRACT) {
 		zend_error_noreturn(E_COMPILE_ERROR, "Cannot use \"abstract\" as method modifier in trait alias");
-	} else if (attr & ZEND_ACC_FINAL) {
-		zend_error_noreturn(E_COMPILE_ERROR, "Cannot use \"final\" as method modifier in trait alias");
 	}
 }
 /* }}} */


### PR DESCRIPTION
Fixes GH-11388.

Following https://wiki.php.net/rfc/horizontalreuse which introduced traits, this should be allowed.
The implementation was refactored in 3f8c729. That commit is the first time the "final" check appears AFAICT, but no reason was given for why. That commit seems to have landed in 5.4.11 and the NEWS for that version doesn't seem to mention something relevant to the behaviour change. This patch removes the restriction of the final modifier.