### PR TITLE
ext/pgsql: adding pg_set_error_context_visibility.

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -187,6 +187,9 @@ PHP 8.3 UPGRADE NOTES
   . Added posix_fpathconf call to get configuration value from a file descriptor.
   . Added posix_eaccess call to check the effective user id's permission for a path.
 
+- PGSQL:
+  . Added pg_set_error_context_visilibity to set the visibility of the context in error messages.
+
 - Random:
   . Added Randomizer::getBytesFromString().
     RFC: https://wiki.php.net/rfc/randomizer_additions

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -2840,26 +2840,19 @@ PHP_FUNCTION(pg_set_error_context_visibility)
 	PGconn *pgsql;
 	pgsql_link_handle *link;
 
-	if (ZEND_NUM_ARGS() == 1) {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &visibility) == FAILURE) {
-			RETURN_THROWS();
-		}
-		link = FETCH_DEFAULT_LINK();
-		CHECK_DEFAULT_LINK(link);
-	} else {
-		if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol", &pgsql_link, pgsql_link_ce, &visibility) == FAILURE) {
-			RETURN_THROWS();
-		}
-		link = Z_PGSQL_LINK_P(pgsql_link);
-		CHECK_PGSQL_LINK(link);
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol", &pgsql_link, pgsql_link_ce, &visibility) == FAILURE) {
+		RETURN_THROWS();
 	}
+	link = Z_PGSQL_LINK_P(pgsql_link);
+	CHECK_PGSQL_LINK(link);
 
 	pgsql = link->conn;
 
-	if (visibility & (PQSHOW_CONTEXT_NEVER|PQSHOW_CONTEXT_ERRORS|PQSHOW_CONTEXT_ALWAYS)) {
+	if (visibility == PQSHOW_CONTEXT_NEVER || visibility & (PQSHOW_CONTEXT_ERRORS|PQSHOW_CONTEXT_ALWAYS)) {
 		RETURN_LONG(PQsetErrorContextVisibility(pgsql, visibility));
 	} else {
-		RETURN_FALSE;
+		zend_argument_value_error(2, "must be one of PGSQL_SHOW_CONTEXT_NEVER, PGSQL_SHOW_CONTEXT_ERRORS or PGSQL_SHOW_CONTEXT_ALWAYS");
+		RETURN_THROWS();
 	}
 }
 

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -462,6 +462,25 @@ namespace {
      */
     const PGSQL_PIPELINE_ABORTED = UNKNOWN;
 #endif
+    
+    /* For pg_set_error_context_visibility() */
+
+    /**
+     * @var int
+     * @cvalue PQSHOW_CONTEXT_NEVER
+     */
+    const PGSQL_SHOW_CONTEXT_NEVER = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue PQSHOW_CONTEXT_ERRORS
+     */
+    const PGSQL_SHOW_CONTEXT_ERRORS = UNKNOWN;
+    /**
+     * @var int
+     * @cvalue PQSHOW_CONTEXT_ALWAYS
+     */
+    const PGSQL_SHOW_CONTEXT_ALWAYS = UNKNOWN;
+    
 
     function pg_connect(string $connection_string, int $flags = 0): PgSql\Connection|false {}
 
@@ -951,6 +970,9 @@ namespace {
     function pg_pipeline_sync(PgSql\Connection $connection): bool {}
     function pg_pipeline_status(PgSql\Connection $connection): int {}
 #endif
+
+    /** @param PgSql\Connection|int $connection */
+    function pg_set_error_context_visibility($connection, int $visibility = UNKNOWN): int|false {}
 }
 
 namespace PgSql {

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -972,7 +972,7 @@ namespace {
 #endif
 
     /** @param PgSql\Connection|int $connection */
-    function pg_set_error_context_visibility($connection, int $visibility = UNKNOWN): int|false {}
+    function pg_set_error_context_visibility(PgSql\Connection $connection, int $visibility): int {}
 }
 
 namespace PgSql {

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b631bef87c0c997e94566f8a575a3fa2bc181936 */
+ * Stub hash: f0d8d4bd754f684e71c5802a6708342735134018 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -472,8 +472,8 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_pipeline_status, 0, 1, IS_LON
 ZEND_END_ARG_INFO()
 #endif
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_set_error_context_visibility, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
-	ZEND_ARG_INFO(0, connection)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_set_error_context_visibility, 0, 2, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, connection, PgSql\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, visibility, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: bf714281e441d59e0760e51df9f4050c96319794 */
+ * Stub hash: b631bef87c0c997e94566f8a575a3fa2bc181936 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -472,6 +472,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_pipeline_status, 0, 1, IS_LON
 ZEND_END_ARG_INFO()
 #endif
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_pg_set_error_context_visibility, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+	ZEND_ARG_INFO(0, connection)
+	ZEND_ARG_TYPE_INFO(0, visibility, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 
 ZEND_FUNCTION(pg_connect);
 ZEND_FUNCTION(pg_pconnect);
@@ -574,6 +579,7 @@ ZEND_FUNCTION(pg_pipeline_sync);
 #if defined(LIBPQ_HAS_PIPELINING)
 ZEND_FUNCTION(pg_pipeline_status);
 #endif
+ZEND_FUNCTION(pg_set_error_context_visibility);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -703,6 +709,7 @@ static const zend_function_entry ext_functions[] = {
 #if defined(LIBPQ_HAS_PIPELINING)
 	ZEND_FE(pg_pipeline_status, arginfo_pg_pipeline_status)
 #endif
+	ZEND_FE(pg_set_error_context_visibility, arginfo_pg_set_error_context_visibility)
 	ZEND_FE_END
 };
 
@@ -835,6 +842,9 @@ static void register_pgsql_symbols(int module_number)
 #if defined(LIBPQ_HAS_PIPELINING)
 	REGISTER_LONG_CONSTANT("PGSQL_PIPELINE_ABORTED", PQ_PIPELINE_ABORTED, CONST_PERSISTENT);
 #endif
+	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_NEVER", PQSHOW_CONTEXT_NEVER, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ERRORS", PQSHOW_CONTEXT_ERRORS, CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ALWAYS", PQSHOW_CONTEXT_ALWAYS, CONST_PERSISTENT);
 }
 
 static zend_class_entry *register_class_PgSql_Connection(void)

--- a/ext/pgsql/tests/07optional.phpt
+++ b/ext/pgsql/tests/07optional.phpt
@@ -21,11 +21,9 @@ if (function_exists('pg_set_error_verbosity')) {
     pg_set_error_verbosity($db, PGSQL_ERRORS_VERBOSE);
     pg_set_error_verbosity($db, PGSQL_ERRORS_SQLSTATE);
 }
-if (function_exists('pg_set_error_context_visibility')) {
-    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_NEVER);
-    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ERRORS);
-    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ALWAYS);
-}
+pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_NEVER);
+pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ERRORS);
+pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ALWAYS);
 echo "OK";
 ?>
 --EXPECT--

--- a/ext/pgsql/tests/07optional.phpt
+++ b/ext/pgsql/tests/07optional.phpt
@@ -21,6 +21,11 @@ if (function_exists('pg_set_error_verbosity')) {
     pg_set_error_verbosity($db, PGSQL_ERRORS_VERBOSE);
     pg_set_error_verbosity($db, PGSQL_ERRORS_SQLSTATE);
 }
+if (function_exists('pg_set_error_context_visibility')) {
+    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_NEVER);
+    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ERRORS);
+    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ALWAYS);
+}
 echo "OK";
 ?>
 --EXPECT--


### PR DESCRIPTION
another level of context for pg_last_error/pg_result_error() to include or not the context in those. PQSHOW_CONTEXT_ERRORS being the default.