### PR TITLE
Store JIT/non-JIT regex in a different PCRE cache slot

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -627,11 +627,24 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, in
 	pcre_cache_entry *ret;
 
 	if (locale_aware && BG(ctype_string)) {
-		key = zend_string_concat2(
+		key = zend_string_concat3(
 			ZSTR_VAL(BG(ctype_string)), ZSTR_LEN(BG(ctype_string)),
-			ZSTR_VAL(regex), ZSTR_LEN(regex));
+			ZSTR_VAL(regex), ZSTR_LEN(regex),
+#ifdef HAVE_PCRE_JIT_SUPPORT
+			PCRE_G(jit) ? "1" : "0", 1
+#else
+			"", 0
+#endif
+		);
 	} else {
+#ifdef HAVE_PCRE_JIT_SUPPORT
+		key = zend_string_concat2(
+			ZSTR_VAL(regex), ZSTR_LEN(regex),
+			PCRE_G(jit) ? "1" : "0", 1
+		);
+#else
 		key = regex;
+#endif
 	}
 
 	/* Try to lookup the cached regex entry, and if successful, just pass
@@ -786,7 +799,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, in
 		return NULL;
 	}
 
-	if (key != regex) {
+	if (locale_aware && BG(ctype_string)) {
 		tables = (uint8_t *)zend_hash_find_ptr(&char_tables, BG(ctype_string));
 		if (!tables) {
 			zend_string *_k;


### PR DESCRIPTION
`pcre.jit` php.ini option can be changed on runtime, so we must make sure the option is always honored even if the regex string was already cached

as advised in https://github.com/php/php-src/issues/11374#issuecomment-1578898535

performance impact should be minimal