### PR TITLE
Suppress warning when the test run under non-root

### DIFF
--- a/ext/pcntl/tests/pcntl_unshare_03.phpt
+++ b/ext/pcntl/tests/pcntl_unshare_03.phpt
@@ -9,7 +9,7 @@ if (!function_exists("pcntl_unshare")) die("skip pcntl_unshare is not available"
 if (!defined("CLONE_NEWNET")) die("skip flag unavailable");
 if (posix_getuid() !== 0 &&
     (!defined("CLONE_NEWUSER") ||
-    (pcntl_unshare(CLONE_NEWUSER) == false && pcntl_get_last_error() == PCNTL_EPERM))) {
+    (@pcntl_unshare(CLONE_NEWUSER) == false && pcntl_get_last_error() == PCNTL_EPERM))) {
     die("skip Insufficient privileges for CLONE_NEWUSER");
 }
 if (@pcntl_unshare(CLONE_NEWNET) == false && pcntl_get_last_error() == PCNTL_EPERM) {


### PR DESCRIPTION
When we run the test under non-root user, the test gets BORKed with:

Warning: pcntl_unshare(): Error 1: No privilege to use these flags in ext/pcntl/tests/pcntl_unshare_03.skip.php on line 8 skip Insufficient privileges for CLONE_NEWUSER

It looks like for the root-user there is the similar warning which is already suppressed (see the following "skip"). Let us skip the test properly if we aren't able to execute it