### PR TITLE
ext/pgsql: fix PGtrace invalid free issue.

### DIFF
--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -172,6 +172,7 @@ static void pgsql_link_free(pgsql_link_handle *link)
 		PQclear(res);
 	}
 	if (!link->persistent) {
+		PQuntrace(link->conn);
 		PQfinish(link->conn);
 	}
 	PGG(num_links)--;

--- a/ext/pgsql/tests/pg_trace.phpt
+++ b/ext/pgsql/tests/pg_trace.phpt
@@ -1,0 +1,20 @@
+--TEST--
+pg_trace
+--EXTENSIONS--
+pgsql
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+include('config.inc');
+
+$db = pg_connect($conn_str);
+$tracefile = __DIR__ . '/trace.tmp';
+
+var_dump(pg_trace($tracefile, 'w', $db));
+$res = pg_query($db, 'select 1');
+
+?>
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
disable trace when closing the connection, is a no op if there is no stream attached to it.