### PR TITLE
ext/imap: Refactor + Update to modern property write API

### DIFF
--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -1447,12 +1447,42 @@ PHP_FUNCTION(imap_listscan)
 
 /* }}} */
 
+static void php_imap_populate_mailbox_properties_object(zval *z_object, const MAILSTREAM *imap_stream)
+{
+	char date[100];
+	rfc822_date(date);
+	zend_update_property_string(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"Date", strlen("Date"),
+		date
+	);
+	zend_update_property_string(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"Driver", strlen("Driver"),
+		imap_stream->dtb->name
+	);
+	zend_update_property_string(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"Mailbox", strlen("Mailbox"),
+		imap_stream->mailbox
+	);
+	zend_update_property_long(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"Nmsgs", strlen("Nmsgs"),
+		imap_stream->nmsgs
+	);
+	zend_update_property_long(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"Recent", strlen("Recent"),
+		imap_stream->recent
+	);
+}
+
 /* {{{ Get mailbox properties */
 PHP_FUNCTION(imap_check)
 {
 	zval *imap_conn_obj;
 	php_imap_object *imap_conn_struct;
-	char date[100];
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &imap_conn_obj, php_imap_ce) == FAILURE) {
 		RETURN_THROWS();
@@ -1465,33 +1495,8 @@ PHP_FUNCTION(imap_check)
 	}
 
 	if (imap_conn_struct->imap_stream->mailbox) {
-		rfc822_date(date);
 		object_init(return_value);
-		zend_update_property_string(
-			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-			"Date", strlen("Date"),
-			date
-		);
-		zend_update_property_string(
-			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-			"Driver", strlen("Driver"),
-			imap_conn_struct->imap_stream->dtb->name
-		);
-		zend_update_property_string(
-			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-			"Mailbox", strlen("Mailbox"),
-			imap_conn_struct->imap_stream->mailbox
-		);
-		zend_update_property_long(
-			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-			"Nmsgs", strlen("Nmsgs"),
-			imap_conn_struct->imap_stream->nmsgs
-		);
-		zend_update_property_long(
-			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-			"Recent", strlen("Recent"),
-			imap_conn_struct->imap_stream->recent
-		);
+		php_imap_populate_mailbox_properties_object(return_value, imap_conn_struct->imap_stream);
 	} else {
 		RETURN_FALSE;
 	}
@@ -2076,7 +2081,6 @@ PHP_FUNCTION(imap_mailboxmsginfo)
 {
 	zval *imap_conn_obj;
 	php_imap_object *imap_conn_struct;
-	char date[100];
 	unsigned long msgno;
 	zend_ulong unreadmsg = 0, deletedmsg = 0, msize = 0;
 
@@ -2114,35 +2118,11 @@ PHP_FUNCTION(imap_mailboxmsginfo)
 	);
 	zend_update_property_long(
 		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-		"Nmsgs", strlen("Nmsgs"),
-		imap_conn_struct->imap_stream->nmsgs
-	);
-	zend_update_property_long(
-		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
 		"Size", strlen("Size"),
 		msize
 	);
-	rfc822_date(date);
-	zend_update_property_string(
-		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-		"Date", strlen("Date"),
-		date
-	);
-	zend_update_property_string(
-		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-		"Driver", strlen("Driver"),
-		imap_conn_struct->imap_stream->dtb->name
-	);
-	zend_update_property_string(
-		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-		"Mailbox", strlen("Mailbox"),
-		imap_conn_struct->imap_stream->mailbox
-	);
-	zend_update_property_long(
-		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
-		"Recent", strlen("Recent"),
-		imap_conn_struct->imap_stream->recent
-	);
+
+	php_imap_populate_mailbox_properties_object(return_value, imap_conn_struct->imap_stream);
 }
 /* }}} */
 

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -1351,6 +1351,33 @@ PHP_FUNCTION(imap_list)
 
 /* }}} */
 
+static void php_imap_populate_mailbox_object(zval *z_object, const FOBJECTLIST *mailbox)
+{
+	zend_update_property_string(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"name", strlen("name"),
+		(char*)mailbox->LTEXT
+	);
+	zend_update_property_long(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"attributes", strlen("attributes"),
+		mailbox->attributes
+	);
+#ifdef IMAP41
+	zend_update_property_str(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"delimiter", strlen("delimiter"),
+		ZSTR_CHAR((unsigned char)mailbox->delimiter)
+	);
+#else
+	zend_update_property_string(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"delimiter", strlen("delimiter"),
+		mailbox->delimiter
+	);
+#endif
+}
+
 /* {{{ Reads the list of mailboxes and returns a full array of objects containing name, attributes, and delimiter */
 /* Author: CJH */
 PHP_FUNCTION(imap_getmailboxes)
@@ -1359,7 +1386,6 @@ PHP_FUNCTION(imap_getmailboxes)
 	zend_string *ref, *pat;
 	php_imap_object *imap_conn_struct;
 	FOBJECTLIST *cur=NIL;
-	char *delim=NIL;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "OSS", &imap_conn_obj, php_imap_ce, &ref, &pat) == FAILURE) {
 		RETURN_THROWS();
@@ -1377,24 +1403,14 @@ PHP_FUNCTION(imap_getmailboxes)
 	}
 
 	array_init(return_value);
-	delim = safe_emalloc(2, sizeof(char), 0);
 	cur=IMAPG(imap_folder_objects);
 	while (cur != NIL) {
 		object_init(&mboxob);
-		add_property_string(&mboxob, "name", (char*)cur->LTEXT);
-		add_property_long(&mboxob, "attributes", cur->attributes);
-#ifdef IMAP41
-		delim[0] = (char)cur->delimiter;
-		delim[1] = 0;
-		add_property_string(&mboxob, "delimiter", delim);
-#else
-		add_property_string(&mboxob, "delimiter", cur->delimiter);
-#endif
+		php_imap_populate_mailbox_object(&mboxob, cur);
 		php_imap_list_add_object(return_value, &mboxob);
 		cur=cur->next;
 	}
 	mail_free_foblist(&IMAPG(imap_folder_objects), &IMAPG(imap_folder_objects_tail));
-	efree(delim);
 	IMAPG(folderlist_style) = FLIST_ARRAY;		/* reset to default */
 }
 /* }}} */
@@ -1451,11 +1467,31 @@ PHP_FUNCTION(imap_check)
 	if (imap_conn_struct->imap_stream->mailbox) {
 		rfc822_date(date);
 		object_init(return_value);
-		add_property_string(return_value, "Date", date);
-		add_property_string(return_value, "Driver", imap_conn_struct->imap_stream->dtb->name);
-		add_property_string(return_value, "Mailbox", imap_conn_struct->imap_stream->mailbox);
-		add_property_long(return_value, "Nmsgs", imap_conn_struct->imap_stream->nmsgs);
-		add_property_long(return_value, "Recent", imap_conn_struct->imap_stream->recent);
+		zend_update_property_string(
+			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+			"Date", strlen("Date"),
+			date
+		);
+		zend_update_property_string(
+			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+			"Driver", strlen("Driver"),
+			imap_conn_struct->imap_stream->dtb->name
+		);
+		zend_update_property_string(
+			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+			"Mailbox", strlen("Mailbox"),
+			imap_conn_struct->imap_stream->mailbox
+		);
+		zend_update_property_long(
+			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+			"Nmsgs", strlen("Nmsgs"),
+			imap_conn_struct->imap_stream->nmsgs
+		);
+		zend_update_property_long(
+			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+			"Recent", strlen("Recent"),
+			imap_conn_struct->imap_stream->recent
+		);
 	} else {
 		RETURN_FALSE;
 	}
@@ -1555,33 +1591,83 @@ PHP_FUNCTION(imap_headerinfo)
 
 	/* now run through properties that are only going to be returned
 	   from a server, not text headers */
-	add_property_string(return_value, "Recent", cache->recent ? (cache->seen ? "R": "N") : " ");
-	add_property_string(return_value, "Unseen", (cache->recent | cache->seen) ? " " : "U");
-	add_property_string(return_value, "Flagged", cache->flagged ? "F" : " ");
-	add_property_string(return_value, "Answered", cache->answered ? "A" : " ");
-	add_property_string(return_value, "Deleted", cache->deleted ? "D" : " ");
-	add_property_string(return_value, "Draft", cache->draft ? "X" : " ");
+	zend_update_property_str(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Recent", strlen("Recent"),
+		cache->recent ? (
+			cache->seen ? ZSTR_CHAR('R') : ZSTR_CHAR('N')
+		) : ZSTR_CHAR(' ')
+	);
+	zend_update_property_str(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Unseen", strlen("Unseen"),
+		(cache->recent | cache->seen) ? ZSTR_CHAR(' ') : ZSTR_CHAR('U')
+	);
+	zend_update_property_str(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Flagged", strlen("Flagged"),
+		(cache->recent | cache->seen) ? ZSTR_CHAR('F') : ZSTR_CHAR(' ')
+	);
+	zend_update_property_str(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Answered", strlen("Answered"),
+		(cache->recent | cache->seen) ? ZSTR_CHAR('A') : ZSTR_CHAR(' ')
+	);
+	zend_update_property_str(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Deleted", strlen("Deleted"),
+		(cache->recent | cache->seen) ? ZSTR_CHAR('D') : ZSTR_CHAR(' ')
+	);
+	zend_update_property_str(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Draft", strlen("Draft"),
+		(cache->recent | cache->seen) ? ZSTR_CHAR('X') : ZSTR_CHAR(' ')
+	);
 
 	snprintf(dummy, sizeof(dummy), "%4ld", cache->msgno);
-	add_property_string(return_value, "Msgno", dummy);
+	zend_update_property_string(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Msgno", strlen("Msgno"),
+		dummy
+	);
 
 	mail_date(dummy, cache);
-	add_property_string(return_value, "MailDate", dummy);
+	zend_update_property_string(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"MailDate", strlen("MailDate"),
+		dummy
+	);
 
 	snprintf(dummy, sizeof(dummy), "%ld", cache->rfc822_size);
-	add_property_string(return_value, "Size", dummy);
+	zend_update_property_string(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Size", strlen("Size"),
+		dummy
+	);
 
-	add_property_long(return_value, "udate", mail_longdate(cache));
+	zend_update_property_long(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"udate", strlen("udate"),
+		mail_longdate(cache)
+	);
 
 	if (en->from && fromlength) {
 		fulladdress[0] = 0x00;
 		mail_fetchfrom(fulladdress, imap_conn_struct->imap_stream, msgno, fromlength);
-		add_property_string(return_value, "fetchfrom", fulladdress);
+		zend_update_property_string(
+			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+			"fetchfrom", strlen("fetchfrom"),
+			fulladdress
+		);
 	}
 	if (en->subject && subjectlength) {
 		fulladdress[0] = 0x00;
 		mail_fetchsubject(fulladdress, imap_conn_struct->imap_stream, msgno, subjectlength);
-		add_property_string(return_value, "fetchsubject", fulladdress);
+		zend_update_property_string(
+			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+			"fetchsubject", strlen("fetchsubject"),
+			fulladdress
+		);
 	}
 }
 /* }}} */
@@ -1654,7 +1740,6 @@ PHP_FUNCTION(imap_getsubscribed)
 	zend_string *ref, *pat;
 	php_imap_object *imap_conn_struct;
 	FOBJECTLIST *cur=NIL;
-	char *delim=NIL;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "OSS", &imap_conn_obj, php_imap_ce, &ref, &pat) == FAILURE) {
 		RETURN_THROWS();
@@ -1674,24 +1759,14 @@ PHP_FUNCTION(imap_getsubscribed)
 	}
 
 	array_init(return_value);
-	delim = safe_emalloc(2, sizeof(char), 0);
 	cur=IMAPG(imap_sfolder_objects);
 	while (cur != NIL) {
 		object_init(&mboxob);
-		add_property_string(&mboxob, "name", (char*)cur->LTEXT);
-		add_property_long(&mboxob, "attributes", cur->attributes);
-#ifdef IMAP41
-		delim[0] = (char)cur->delimiter;
-		delim[1] = 0;
-		add_property_string(&mboxob, "delimiter", delim);
-#else
-		add_property_string(&mboxob, "delimiter", cur->delimiter);
-#endif
+		php_imap_populate_mailbox_object(&mboxob, cur);
 		php_imap_list_add_object(return_value, &mboxob);
 		cur=cur->next;
 	}
 	mail_free_foblist (&IMAPG(imap_sfolder_objects), &IMAPG(imap_sfolder_objects_tail));
-	efree(delim);
 	IMAPG(folderlist_style) = FLIST_ARRAY; /* reset to default */
 }
 /* }}} */
@@ -2027,15 +2102,47 @@ PHP_FUNCTION(imap_mailboxmsginfo)
 		}
 		msize = msize + cache->rfc822_size;
 	}
-	add_property_long(return_value, "Unread", unreadmsg);
-	add_property_long(return_value, "Deleted", deletedmsg);
-	add_property_long(return_value, "Nmsgs", imap_conn_struct->imap_stream->nmsgs);
-	add_property_long(return_value, "Size", msize);
+	zend_update_property_long(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Unread", strlen("Unread"),
+		unreadmsg
+	);
+	zend_update_property_long(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Deleted", strlen("Deleted"),
+		deletedmsg
+	);
+	zend_update_property_long(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Nmsgs", strlen("Nmsgs"),
+		imap_conn_struct->imap_stream->nmsgs
+	);
+	zend_update_property_long(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Size", strlen("Size"),
+		msize
+	);
 	rfc822_date(date);
-	add_property_string(return_value, "Date", date);
-	add_property_string(return_value, "Driver", imap_conn_struct->imap_stream->dtb->name);
-	add_property_string(return_value, "Mailbox", imap_conn_struct->imap_stream->mailbox);
-	add_property_long(return_value, "Recent", imap_conn_struct->imap_stream->recent);
+	zend_update_property_string(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Date", strlen("Date"),
+		date
+	);
+	zend_update_property_string(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Driver", strlen("Driver"),
+		imap_conn_struct->imap_stream->dtb->name
+	);
+	zend_update_property_string(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Mailbox", strlen("Mailbox"),
+		imap_conn_struct->imap_stream->mailbox
+	);
+	zend_update_property_long(
+		Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+		"Recent", strlen("Recent"),
+		imap_conn_struct->imap_stream->recent
+	);
 }
 /* }}} */
 
@@ -2078,13 +2185,57 @@ PHP_FUNCTION(imap_rfc822_write_address)
 }
 /* }}} */
 
+static void php_imap_construct_address_object(zval *z_object, const ADDRESS *address)
+{
+	if (address->mailbox) {
+		zend_update_property_string(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"mailbox", strlen("mailbox"),
+			address->mailbox
+		);
+	}
+	if (address->host) {
+		zend_update_property_string(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"host", strlen("host"),
+			address->host
+		);
+	}
+	if (address->personal) {
+		zend_update_property_string(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"personal", strlen("personal"),
+			address->personal
+		);
+	}
+	if (address->adl) {
+		zend_update_property_string(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"adl", strlen("adl"),
+			address->adl
+		);
+	}
+}
+
+static void php_imap_construct_list_of_addresses(zval *list, const ADDRESS *const address_list)
+{
+	const ADDRESS *current_address;
+
+	current_address = address_list;
+	do {
+		zval tmp_object;
+		object_init(&tmp_object);
+		php_imap_construct_address_object(&tmp_object, current_address);
+		php_imap_list_add_object(list, &tmp_object);
+	} while ((current_address = current_address->next));
+}
+
 /* {{{ Parses an address string */
 PHP_FUNCTION(imap_rfc822_parse_adrlist)
 {
-	zval tovals;
 	zend_string *str, *defaulthost;
 	char *str_copy;
-	ADDRESS *addresstmp;
+	ADDRESS *address_list;
 	ENVELOPE *env;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &str, &defaulthost) == FAILURE) {
@@ -2100,28 +2251,14 @@ PHP_FUNCTION(imap_rfc822_parse_adrlist)
 
 	array_init(return_value);
 
-	addresstmp = env->to;
+	address_list = env->to;
 
-	if (addresstmp) do {
-		object_init(&tovals);
-		if (addresstmp->mailbox) {
-			add_property_string(&tovals, "mailbox", addresstmp->mailbox);
-		}
-		if (addresstmp->host) {
-			add_property_string(&tovals, "host", addresstmp->host);
-		}
-		if (addresstmp->personal) {
-			add_property_string(&tovals, "personal", addresstmp->personal);
-		}
-		if (addresstmp->adl) {
-			add_property_string(&tovals, "adl", addresstmp->adl);
-		}
-		php_imap_list_add_object(return_value, &tovals);
-	} while ((addresstmp = addresstmp->next));
+	if (address_list) {
+		php_imap_construct_list_of_addresses(return_value, address_list);
+	}
 
 	mail_free_envelope(&env);
 }
-/* }}} */
 
 /* {{{ Convert a mime-encoded text to UTF-8 */
 PHP_FUNCTION(imap_utf8)
@@ -2671,30 +2808,237 @@ PHP_FUNCTION(imap_status)
 		RETURN_THROWS();
 	}
 
-	object_init(return_value);
-
 	if (mail_status(imap_conn_struct->imap_stream, ZSTR_VAL(mbx), flags)) {
-		add_property_long(return_value, "flags", IMAPG(status_flags));
+		object_init(return_value);
+
+		zend_update_property_long(
+			Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+			"flags", strlen("flags"),
+			IMAPG(status_flags)
+		);
 		if (IMAPG(status_flags) & SA_MESSAGES) {
-			add_property_long(return_value, "messages", IMAPG(status_messages));
+			zend_update_property_long(
+				Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+				"messages", strlen("messages"),
+				IMAPG(status_messages)
+			);
 		}
 		if (IMAPG(status_flags) & SA_RECENT) {
-			add_property_long(return_value, "recent", IMAPG(status_recent));
+			zend_update_property_long(
+				Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+				"recent", strlen("recent"),
+				IMAPG(status_recent)
+			);
 		}
 		if (IMAPG(status_flags) & SA_UNSEEN) {
-			add_property_long(return_value, "unseen", IMAPG(status_unseen));
+			zend_update_property_long(
+				Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+				"unseen", strlen("unseen"),
+				IMAPG(status_unseen)
+			);
 		}
 		if (IMAPG(status_flags) & SA_UIDNEXT) {
-			add_property_long(return_value, "uidnext", IMAPG(status_uidnext));
+			zend_update_property_long(
+				Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+				"uidnext", strlen("uidnext"),
+				IMAPG(status_uidnext)
+			);
 		}
 		if (IMAPG(status_flags) & SA_UIDVALIDITY) {
-			add_property_long(return_value, "uidvalidity", IMAPG(status_uidvalidity));
+			zend_update_property_long(
+				Z_OBJCE_P(return_value), Z_OBJ_P(return_value),
+				"uidvalidity", strlen("uidvalidity"),
+				IMAPG(status_uidvalidity)
+			);
 		}
 	} else {
 		RETURN_FALSE;
 	}
 }
 /* }}} */
+
+static void php_imap_populate_body_struct_object(zval *z_object, const BODY *body)
+{
+	if (body->type <= TYPEMAX) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"type", strlen("type"),
+			body->type
+		);
+	}
+
+	if (body->encoding <= ENCMAX) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"encoding", strlen("encoding"),
+			body->encoding
+		);
+	}
+
+	if (body->subtype) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifsubtype", strlen("ifsubtype"),
+			1
+		);
+		zend_update_property_string(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"subtype", strlen("subtype"),
+			body->subtype
+		);
+	} else {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifsubtype", strlen("ifsubtype"),
+			0
+		);
+	}
+
+	if (body->description) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifdescription", strlen("ifdescription"),
+			1
+		);
+		zend_update_property_string(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"description", strlen("description"),
+			body->description
+		);
+	} else {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifdescription", strlen("ifdescription"),
+			0
+		);
+	}
+
+	if (body->id) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifid", strlen("ifid"),
+			1
+		);
+		zend_update_property_string(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"id", strlen("id"),
+			body->id
+		);
+	} else {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifid", strlen("ifid"),
+			0
+		);
+	}
+
+	if (body->size.lines) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"lines", strlen("lines"),
+			body->size.lines
+		);
+	}
+
+	if (body->size.bytes) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"bytes", strlen("bytes"),
+			body->size.bytes
+		);
+	}
+
+#ifdef IMAP41
+	if (body->disposition.type) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifdisposition", strlen("ifdisposition"),
+			1
+		);
+		zend_update_property_string(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"disposition", strlen("disposition"),
+			body->disposition.type
+		);
+	} else {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifdisposition", strlen("ifdisposition"),
+			0
+		);
+	}
+
+	if (body->disposition.parameter) {
+		PARAMETER *disposition_parameter = body->disposition.parameter;
+		zval z_disposition_parameters, z_disposition_parameter;
+
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifdparameters", strlen("ifdparameters"),
+			1
+		);
+		array_init(&z_disposition_parameters);
+		do {
+			object_init(&z_disposition_parameter);
+			zend_update_property_string(
+				Z_OBJCE_P(&z_disposition_parameter), Z_OBJ_P(&z_disposition_parameter),
+				"attribute", strlen("attribute"),
+				disposition_parameter->attribute
+			);
+			zend_update_property_string(
+				Z_OBJCE_P(&z_disposition_parameter), Z_OBJ_P(&z_disposition_parameter),
+				"value", strlen("value"),
+				disposition_parameter->value
+			);
+			php_imap_list_add_object(&z_disposition_parameters, &z_disposition_parameter);
+		} while ((disposition_parameter = disposition_parameter->next));
+		php_imap_hash_add_object(z_object, "dparameters", &z_disposition_parameters);
+	} else {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifdparameters", strlen("ifdparameters"),
+			0
+		);
+	}
+#endif
+
+	PARAMETER *body_parameters = body->parameter;
+	zval z_body_parameters;
+	zval z_body_parameter;
+
+	if (body_parameters) {
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifparameters", strlen("ifparameters"),
+			1
+		);
+
+		array_init(&z_body_parameters);
+		do {
+			object_init(&z_body_parameter);
+			zend_update_property_string(
+				Z_OBJCE_P(&z_body_parameter), Z_OBJ_P(&z_body_parameter),
+				"attribute", strlen("attribute"),
+				body_parameters->attribute
+			);
+			zend_update_property_string(
+				Z_OBJCE_P(&z_body_parameter), Z_OBJ_P(&z_body_parameter),
+				"value", strlen("value"),
+				body_parameters->value
+			);
+
+			php_imap_list_add_object(&z_body_parameters, &z_body_parameter);
+		} while ((body_parameters = body_parameters->next));
+	} else {
+		object_init(&z_body_parameters);
+		zend_update_property_long(
+			Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+			"ifparameters", strlen("ifparameters"),
+			0
+		);
+	}
+	php_imap_hash_add_object(z_object, "parameters", &z_body_parameters);
+}
 
 /* {{{ Read the structure of a specified body section of a specific message */
 PHP_FUNCTION(imap_bodystruct)
@@ -2703,8 +3047,6 @@ PHP_FUNCTION(imap_bodystruct)
 	zend_long msgno;
 	zend_string *section;
 	php_imap_object *imap_conn_struct;
-	zval parametres, param, dparametres, dparam;
-	PARAMETER *par, *dpar;
 	BODY *body;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "OlS", &imap_conn_obj, php_imap_ce, &msgno, &section) == FAILURE) {
@@ -2715,89 +3057,13 @@ PHP_FUNCTION(imap_bodystruct)
 
 	PHP_IMAP_CHECK_MSGNO(msgno, 2);
 
-	body=mail_body(imap_conn_struct->imap_stream, msgno, (unsigned char*)ZSTR_VAL(section));
+	body = mail_body(imap_conn_struct->imap_stream, msgno, (unsigned char*)ZSTR_VAL(section));
 	if (body == NULL) {
 		RETURN_FALSE;
 	}
 
 	object_init(return_value);
-	if (body->type <= TYPEMAX) {
-		add_property_long(return_value, "type", body->type);
-	}
-	if (body->encoding <= ENCMAX) {
-		add_property_long(return_value, "encoding", body->encoding);
-	}
-
-	if (body->subtype) {
-		add_property_long(return_value, "ifsubtype", 1);
-		add_property_string(return_value, "subtype", body->subtype);
-	} else {
-		add_property_long(return_value, "ifsubtype", 0);
-	}
-
-	if (body->description) {
-		add_property_long(return_value, "ifdescription", 1);
-		add_property_string(return_value, "description", body->description);
-	} else {
-		add_property_long(return_value, "ifdescription", 0);
-	}
-	if (body->id) {
-		add_property_long(return_value, "ifid", 1);
-		add_property_string(return_value, "id", body->id);
-	} else {
-		add_property_long(return_value, "ifid", 0);
-	}
-
-	if (body->size.lines) {
-		add_property_long(return_value, "lines", body->size.lines);
-	}
-	if (body->size.bytes) {
-		add_property_long(return_value, "bytes", body->size.bytes);
-	}
-#ifdef IMAP41
-	if (body->disposition.type) {
-		add_property_long(return_value, "ifdisposition", 1);
-		add_property_string(return_value, "disposition", body->disposition.type);
-	} else {
-		add_property_long(return_value, "ifdisposition", 0);
-	}
-
-	if (body->disposition.parameter) {
-		dpar = body->disposition.parameter;
-		add_property_long(return_value, "ifdparameters", 1);
-		array_init(&dparametres);
-		do {
-			object_init(&dparam);
-			add_property_string(&dparam, "attribute", dpar->attribute);
-			add_property_string(&dparam, "value", dpar->value);
-			php_imap_list_add_object(&dparametres, &dparam);
-		} while ((dpar = dpar->next));
-		php_imap_hash_add_object(return_value, "dparameters", &dparametres);
-	} else {
-		add_property_long(return_value, "ifdparameters", 0);
-	}
-#endif
-
-	if ((par = body->parameter)) {
-		add_property_long(return_value, "ifparameters", 1);
-
-		array_init(&parametres);
-		do {
-			object_init(&param);
-			if (par->attribute) {
-				add_property_string(&param, "attribute", par->attribute);
-			}
-			if (par->value) {
-				add_property_string(&param, "value", par->value);
-			}
-
-			php_imap_list_add_object(&parametres, &param);
-		} while ((par = par->next));
-	} else {
-		object_init(&parametres);
-		add_property_long(return_value, "ifparameters", 0);
-	}
-	php_imap_hash_add_object(return_value, "parameters", &parametres);
+	php_imap_populate_body_struct_object(return_value, body);
 }
 
 /* }}} */
@@ -2837,46 +3103,118 @@ PHP_FUNCTION(imap_fetch_overview)
 		for (i = 1; i <= imap_conn_struct->imap_stream->nmsgs; i++) {
 			if (((elt = mail_elt (imap_conn_struct->imap_stream, i))->sequence) &&
 				(env = mail_fetch_structure (imap_conn_struct->imap_stream, i, NIL, NIL))) {
+
+				// TODO Use part _php_make_header_object function?
 				object_init(&myoverview);
 				if (env->subject) {
-					add_property_string(&myoverview, "subject", env->subject);
+					zend_update_property_string(
+						Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+						"subject", strlen("subject"),
+						env->subject
+					);
 				}
 				if (env->from) {
 					env->from->next=NULL;
 					address =_php_rfc822_write_address(env->from);
 					if (address) {
-						add_property_str(&myoverview, "from", address);
+						zend_update_property_str(
+							Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+							"from", strlen("from"),
+							address
+						);
+						zend_string_release(address);
 					}
 				}
 				if (env->to) {
 					env->to->next = NULL;
 					address = _php_rfc822_write_address(env->to);
 					if (address) {
-						add_property_str(&myoverview, "to", address);
+						zend_update_property_str(
+							Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+							"to", strlen("to"),
+							address
+						);
+						zend_string_release(address);
 					}
 				}
 				if (env->date) {
-					add_property_string(&myoverview, "date", (char*)env->date);
+					zend_update_property_string(
+						Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+						"date", strlen("date"),
+						(char*)env->date
+					);
 				}
 				if (env->message_id) {
-					add_property_string(&myoverview, "message_id", env->message_id);
+					zend_update_property_string(
+						Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+						"message_id", strlen("message_id"),
+						env->message_id
+					);
 				}
 				if (env->references) {
-					add_property_string(&myoverview, "references", env->references);
+					zend_update_property_string(
+						Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+						"references", strlen("references"),
+						env->references
+					);
 				}
 				if (env->in_reply_to) {
-					add_property_string(&myoverview, "in_reply_to", env->in_reply_to);
+					zend_update_property_string(
+						Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+						"in_reply_to", strlen("in_reply_to"),
+						env->in_reply_to
+					);
 				}
-				add_property_long(&myoverview, "size", elt->rfc822_size);
-				add_property_long(&myoverview, "uid", mail_uid(imap_conn_struct->imap_stream, i));
-				add_property_long(&myoverview, "msgno", i);
-				add_property_long(&myoverview, "recent", elt->recent);
-				add_property_long(&myoverview, "flagged", elt->flagged);
-				add_property_long(&myoverview, "answered", elt->answered);
-				add_property_long(&myoverview, "deleted", elt->deleted);
-				add_property_long(&myoverview, "seen", elt->seen);
-				add_property_long(&myoverview, "draft", elt->draft);
-				add_property_long(&myoverview, "udate", mail_longdate(elt));
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"size", strlen("size"),
+					elt->rfc822_size
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"uid", strlen("uid"),
+					mail_uid(imap_conn_struct->imap_stream, i)
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"msgno", strlen("msgno"),
+					i
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"recent", strlen("recent"),
+					elt->recent
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"flagged", strlen("flagged"),
+					elt->flagged
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"answered", strlen("answered"),
+					elt->answered
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"deleted", strlen("deleted"),
+					elt->deleted
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"seen", strlen("seen"),
+					elt->seen
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"draft", strlen("draft"),
+					elt->draft
+				);
+				zend_update_property_long(
+					Z_OBJCE_P(&myoverview), Z_OBJ_P(&myoverview),
+					"udate", strlen("udate"),
+					mail_longdate(elt)
+				);
 				php_imap_list_add_object(return_value, &myoverview);
 			}
 		}
@@ -3707,6 +4045,21 @@ PHP_FUNCTION(imap_last_error)
 }
 /* }}} */
 
+static void php_imap_populate_mime_header_object(zval *z_object, const char *charset, const char *content)
+{
+	ZEND_ASSERT(z_object && "Object must be initialized");
+	zend_update_property_string(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"charset", strlen("charset"),
+		charset
+	);
+	zend_update_property_string(
+		Z_OBJCE_P(z_object), Z_OBJ_P(z_object),
+		"text", strlen("text"),
+		content
+	);
+}
+
 /* {{{ Decode mime header element in accordance with RFC 2047 and return array of objects containing 'charset' encoding and decoded 'text' */
 PHP_FUNCTION(imap_mime_header_decode)
 {
@@ -3736,8 +4089,7 @@ PHP_FUNCTION(imap_mime_header_decode)
 				memcpy(text, &string[offset], charset_token-offset);
 				text[charset_token - offset] = 0x00;
 				object_init(&myobject);
-				add_property_string(&myobject, "charset", "default");
-				add_property_string(&myobject, "text", text);
+				php_imap_populate_mime_header_object(&myobject, "default", text);
 				zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &myobject);
 			}
 			if ((encoding_token = (zend_long)php_memnstr(&string[charset_token+2], "?", 1, string+end))) {		/* Find token for encoding */
@@ -3762,8 +4114,7 @@ PHP_FUNCTION(imap_mime_header_decode)
 						RETURN_FALSE;
 					}
 					object_init(&myobject);
-					add_property_string(&myobject, "charset", charset);
-					add_property_string(&myobject, "text", decode);
+					php_imap_populate_mime_header_object(&myobject, charset, decode);
 					zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &myobject);
 
 					/* only free decode if it was allocated by rfc822_qprint or rfc822_base64 */
@@ -3791,8 +4142,7 @@ PHP_FUNCTION(imap_mime_header_decode)
 		memcpy(text, &string[charset_token], end - charset_token);	/* Extract unencoded text from string */
 		text[end - charset_token] = 0x00;
 		object_init(&myobject);
-		add_property_string(&myobject, "charset", "default");
-		add_property_string(&myobject, "text", text);
+		php_imap_populate_mime_header_object(&myobject, "default", text);
 		zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &myobject);
 
 		offset = end;	/* We have reached the end of the string. */
@@ -3909,25 +4259,16 @@ static zend_string* _php_rfc822_write_address(ADDRESS *addresslist)
 /* }}} */
 #endif
 /* {{{ _php_imap_parse_address */
-static zend_string* _php_imap_parse_address (ADDRESS *addresslist, zval *paddress)
+static zend_string* _php_imap_parse_address (ADDRESS *address_list, zval *paddress)
 {
 	zend_string *fulladdress;
 	ADDRESS *addresstmp;
-	zval tmpvals;
 
-	addresstmp = addresslist;
+	addresstmp = address_list;
 
 	fulladdress = _php_rfc822_write_address(addresstmp);
 
-	addresstmp = addresslist;
-	do {
-		object_init(&tmpvals);
-		if (addresstmp->personal) add_property_string(&tmpvals, "personal", addresstmp->personal);
-		if (addresstmp->adl) add_property_string(&tmpvals, "adl", addresstmp->adl);
-		if (addresstmp->mailbox) add_property_string(&tmpvals, "mailbox", addresstmp->mailbox);
-		if (addresstmp->host) add_property_string(&tmpvals, "host", addresstmp->host);
-		php_imap_list_add_object(paddress, &tmpvals);
-	} while ((addresstmp = addresstmp->next));
+	php_imap_construct_list_of_addresses(paddress, address_list);
 	return fulladdress;
 }
 /* }}} */
@@ -3940,22 +4281,83 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 
 	object_init(myzvalue);
 
-	if (en->remail) add_property_string(myzvalue, "remail", en->remail);
-	if (en->date) add_property_string(myzvalue, "date", (char*)en->date);
-	if (en->date) add_property_string(myzvalue, "Date", (char*)en->date);
-	if (en->subject) add_property_string(myzvalue, "subject", en->subject);
-	if (en->subject) add_property_string(myzvalue, "Subject", en->subject);
-	if (en->in_reply_to) add_property_string(myzvalue, "in_reply_to", en->in_reply_to);
-	if (en->message_id) add_property_string(myzvalue, "message_id", en->message_id);
-	if (en->newsgroups) add_property_string(myzvalue, "newsgroups", en->newsgroups);
-	if (en->followup_to) add_property_string(myzvalue, "followup_to", en->followup_to);
-	if (en->references) add_property_string(myzvalue, "references", en->references);
+	if (en->remail) {
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"remail", strlen("remail"),
+			en->remail
+		);
+	}
+	if (en->date) {
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"date", strlen("date"),
+			(char*)en->date
+		);
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"Date", strlen("Date"),
+			(char*)en->date
+		);
+	}
+	if (en->subject) {
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"subject", strlen("subject"),
+			en->subject
+		);
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"Subject", strlen("Subject"),
+			en->subject
+		);
+	}
+	if (en->in_reply_to) {
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"in_reply_to", strlen("in_reply_to"),
+			en->in_reply_to
+		);
+	}
+	if (en->message_id) {
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"message_id", strlen("message_id"),
+			en->message_id
+		);
+	}
+	if (en->newsgroups) {
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"newsgroups", strlen("newsgroups"),
+			en->newsgroups
+		);
+	}
+	if (en->followup_to) {
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"followup_to", strlen("followup_to"),
+			en->followup_to
+		);
+	}
+	if (en->references) {
+		zend_update_property_string(
+			Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+			"references", strlen("references"),
+			en->references
+		);
+	}
 
 	if (en->to) {
 		array_init(&paddress);
 		fulladdress = _php_imap_parse_address(en->to, &paddress);
 		if (fulladdress) {
-			add_property_str(myzvalue, "toaddress", fulladdress);
+			zend_update_property_str(
+				Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+				"toaddress", strlen("toaddress"),
+				fulladdress
+			);
+			zend_string_release(fulladdress);
 		}
 		php_imap_hash_add_object(myzvalue, "to", &paddress);
 	}
@@ -3964,7 +4366,12 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		array_init(&paddress);
 		fulladdress = _php_imap_parse_address(en->from, &paddress);
 		if (fulladdress) {
-			add_property_str(myzvalue, "fromaddress", fulladdress);
+			zend_update_property_str(
+				Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+				"fromaddress", strlen("fromaddress"),
+				fulladdress
+			);
+			zend_string_release(fulladdress);
 		}
 		php_imap_hash_add_object(myzvalue, "from", &paddress);
 	}
@@ -3973,7 +4380,12 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		array_init(&paddress);
 		fulladdress = _php_imap_parse_address(en->cc, &paddress);
 		if (fulladdress) {
-			add_property_str(myzvalue, "ccaddress", fulladdress);
+			zend_update_property_str(
+				Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+				"ccaddress", strlen("ccaddress"),
+				fulladdress
+			);
+			zend_string_release(fulladdress);
 		}
 		php_imap_hash_add_object(myzvalue, "cc", &paddress);
 	}
@@ -3982,7 +4394,12 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		array_init(&paddress);
 		fulladdress = _php_imap_parse_address(en->bcc, &paddress);
 		if (fulladdress) {
-			add_property_str(myzvalue, "bccaddress", fulladdress);
+			zend_update_property_str(
+				Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+				"bccaddress", strlen("bccaddress"),
+				fulladdress
+			);
+			zend_string_release(fulladdress);
 		}
 		php_imap_hash_add_object(myzvalue, "bcc", &paddress);
 	}
@@ -3991,7 +4408,12 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		array_init(&paddress);
 		fulladdress = _php_imap_parse_address(en->reply_to, &paddress);
 		if (fulladdress) {
-			add_property_str(myzvalue, "reply_toaddress", fulladdress);
+			zend_update_property_str(
+				Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+				"reply_toaddress", strlen("reply_toaddress"),
+				fulladdress
+			);
+			zend_string_release(fulladdress);
 		}
 		php_imap_hash_add_object(myzvalue, "reply_to", &paddress);
 	}
@@ -4000,7 +4422,12 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		array_init(&paddress);
 		fulladdress = _php_imap_parse_address(en->sender, &paddress);
 		if (fulladdress) {
-			add_property_str(myzvalue, "senderaddress", fulladdress);
+			zend_update_property_str(
+				Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+				"senderaddress", strlen("senderaddress"),
+				fulladdress
+			);
+			zend_string_release(fulladdress);
 		}
 		php_imap_hash_add_object(myzvalue, "sender", &paddress);
 	}
@@ -4009,7 +4436,12 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 		array_init(&paddress);
 		fulladdress = _php_imap_parse_address(en->return_path, &paddress);
 		if (fulladdress) {
-			add_property_str(myzvalue, "return_pathaddress", fulladdress);
+			zend_update_property_str(
+				Z_OBJCE_P(myzvalue), Z_OBJ_P(myzvalue),
+				"return_pathaddress", strlen("return_pathaddress"),
+				fulladdress
+			);
+			zend_string_release(fulladdress);
 		}
 		php_imap_hash_add_object(myzvalue, "return_path", &paddress);
 		// From rebase might need?
@@ -4021,111 +4453,33 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 /* {{{ _php_imap_add_body */
 void _php_imap_add_body(zval *arg, BODY *body)
 {
-	zval parametres, param, dparametres, dparam;
-	PARAMETER *par, *dpar;
-	PART *part;
-
-	if (body->type <= TYPEMAX) {
-		add_property_long(arg, "type", body->type);
-	}
-
-	if (body->encoding <= ENCMAX) {
-		add_property_long(arg, "encoding", body->encoding);
-	}
-
-	if (body->subtype) {
-		add_property_long(arg, "ifsubtype", 1);
-		add_property_string(arg, "subtype", body->subtype);
-	} else {
-		add_property_long(arg, "ifsubtype", 0);
-	}
-
-	if (body->description) {
-		add_property_long(arg, "ifdescription", 1);
-		add_property_string(arg, "description", body->description);
-	} else {
-		add_property_long(arg, "ifdescription", 0);
-	}
-
-	if (body->id) {
-		add_property_long(arg, "ifid", 1);
-		add_property_string(arg, "id", body->id);
-	} else {
-		add_property_long(arg, "ifid", 0);
-	}
-
-	if (body->size.lines) {
-		add_property_long(arg, "lines", body->size.lines);
-	}
-
-	if (body->size.bytes) {
-		add_property_long(arg, "bytes", body->size.bytes);
-	}
-
-#ifdef IMAP41
-	if (body->disposition.type) {
-		add_property_long(arg, "ifdisposition", 1);
-		add_property_string(arg, "disposition", body->disposition.type);
-	} else {
-		add_property_long(arg, "ifdisposition", 0);
-	}
-
-	if (body->disposition.parameter) {
-		dpar = body->disposition.parameter;
-		add_property_long(arg, "ifdparameters", 1);
-		array_init(&dparametres);
-		do {
-			object_init(&dparam);
-			add_property_string(&dparam, "attribute", dpar->attribute);
-			add_property_string(&dparam, "value", dpar->value);
-			php_imap_list_add_object(&dparametres, &dparam);
-		} while ((dpar = dpar->next));
-		php_imap_hash_add_object(arg, "dparameters", &dparametres);
-	} else {
-		add_property_long(arg, "ifdparameters", 0);
-	}
-#endif
-
-	if ((par = body->parameter)) {
-		add_property_long(arg, "ifparameters", 1);
-
-		array_init(&parametres);
-		do {
-			object_init(&param);
-			if (par->attribute) {
-				add_property_string(&param, "attribute", par->attribute);
-			}
-			if (par->value) {
-				add_property_string(&param, "value", par->value);
-			}
-
-			php_imap_list_add_object(&parametres, &param);
-		} while ((par = par->next));
-	} else {
-		object_init(&parametres);
-		add_property_long(arg, "ifparameters", 0);
-	}
-	php_imap_hash_add_object(arg, "parameters", &parametres);
+	php_imap_populate_body_struct_object(arg, body);
 
 	/* multipart message ? */
 	if (body->type == TYPEMULTIPART) {
-		array_init(&parametres);
-		for (part = body->CONTENT_PART; part; part = part->next) {
-			object_init(&param);
-			_php_imap_add_body(&param, &part->body);
-			php_imap_list_add_object(&parametres, &param);
+		zval z_content_parts;
+		PART *content_part;
+
+		array_init(&z_content_parts);
+		for (content_part = body->CONTENT_PART; content_part; content_part = content_part->next) {
+			zval z_content_part;
+			object_init(&z_content_part);
+			_php_imap_add_body(&z_content_part, &content_part->body);
+			php_imap_list_add_object(&z_content_parts, &z_content_part);
 		}
-		php_imap_hash_add_object(arg, "parts", &parametres);
+		php_imap_hash_add_object(arg, "parts", &z_content_parts);
 	}
 
 	/* encapsulated message ? */
 	if ((body->type == TYPEMESSAGE) && (!strcasecmp(body->subtype, "rfc822"))) {
+		zval messages, message;
+
 		body = body->CONTENT_MSG_BODY;
-		array_init(&parametres);
-		object_init(&param);
-		_php_imap_add_body(&param, body);
-		php_imap_list_add_object(&parametres, &param);
-		php_imap_hash_add_object(arg, "parts", &parametres);
+		array_init(&messages);
+		object_init(&message);
+		_php_imap_add_body(&message, body);
+		php_imap_list_add_object(&messages, &message);
+		php_imap_hash_add_object(arg, "parts", &messages);
 	}
 }
 /* }}} */

--- a/ext/imap/php_imap.c
+++ b/ext/imap/php_imap.c
@@ -83,7 +83,7 @@ MAILSTREAM DEFAULTPROTO;
 #endif
 
 static void _php_make_header_object(zval *myzvalue, ENVELOPE *en);
-static void _php_imap_add_body(zval *arg, BODY *body);
+static void _php_imap_add_body(zval *arg, const BODY *body);
 static zend_string* _php_imap_parse_address(ADDRESS *addresslist, zval *paddress);
 static zend_string* _php_rfc822_write_address(ADDRESS *addresslist);
 
@@ -4429,14 +4429,13 @@ static void _php_make_header_object(zval *myzvalue, ENVELOPE *en)
 /* }}} */
 
 /* {{{ _php_imap_add_body */
-void _php_imap_add_body(zval *arg, BODY *body)
+void _php_imap_add_body(zval *arg, const BODY *body)
 {
 	php_imap_populate_body_struct_object(arg, body);
 
 	/* multipart message ? */
 	if (body->type == TYPEMULTIPART) {
 		zval z_content_part_list;
-		PART *content_part;
 
 		array_init(&z_content_part_list);
 		for (const PART *content_part = body->CONTENT_PART; content_part; content_part = content_part->next) {
@@ -4452,10 +4451,10 @@ void _php_imap_add_body(zval *arg, BODY *body)
 	if ((body->type == TYPEMESSAGE) && (!strcasecmp(body->subtype, "rfc822"))) {
 		zval message_list, message;
 
-		body = body->CONTENT_MSG_BODY;
+		const BODY *message_body = body->CONTENT_MSG_BODY;
 		array_init(&message_list);
 		object_init(&message);
-		_php_imap_add_body(&message, body);
+		_php_imap_add_body(&message, message_body);
 		php_imap_list_add_object(&message_list, &message);
 		php_imap_hash_add_object(arg, "parts", &message_list);
 	}


### PR DESCRIPTION
Also use common functions for creating and setting up similar objects.

Split out from #11387 without using the newly introduced APIs as this is a major refactoring.