### PR TITLE
Fix GH-10406: fgets on a redis socket connection fails on PHP 8.3

### DIFF
--- a/ext/standard/tests/streams/gh11418.phpt
+++ b/ext/standard/tests/streams/gh11418.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-10406: fgets on a redis socket connection fails on PHP 8.3
+--FILE--
+<?php
+
+$serverCode = <<<'CODE'
+$server = stream_socket_server('tcp://127.0.0.1:64324');
+phpt_notify();
+
+$conn = stream_socket_accept($server);
+
+fwrite($conn, "Hi Hello"); // 8 bytes
+usleep(50000);
+fwrite($conn, " World\n"); // 8 bytes
+
+fclose($conn);
+fclose($server);
+CODE;
+
+$clientCode = <<<'CODE'
+
+phpt_wait();
+
+$fp = fsockopen("tcp://127.0.0.1:64324");
+
+echo fread($fp, 3);
+echo fgets($fp);
+
+CODE;
+
+include sprintf("%s/../../../openssl/tests/ServerClientTestCase.inc", __DIR__);
+ServerClientTestCase::getInstance()->run($clientCode, $serverCode);
+
+?>
+--EXPECT--
+Hi Hello World

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -211,6 +211,9 @@ struct _php_stream  {
 	 * PHP_STREAM_FCLOSE_XXX as appropriate */
 	uint8_t fclose_stdiocast:2;
 
+	/* flag to mark whether the stream has buffered data */
+	uint8_t has_buffered_data:1;
+
 	char mode[16];			/* "rwb" etc. ala stdio */
 
 	uint32_t flags;	/* PHP_STREAM_FLAG_XXX */
@@ -227,7 +230,6 @@ struct _php_stream  {
 	size_t readbuflen;
 	zend_off_t readpos;
 	zend_off_t writepos;
-	ssize_t didread;
 
 	/* how much data to read when filling buffer */
 	size_t chunk_size;

--- a/main/streams/streams.c
+++ b/main/streams/streams.c
@@ -680,8 +680,7 @@ PHPAPI zend_result _php_stream_fill_read_buffer(php_stream *stream, size_t size)
 
 PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t size)
 {
-	ssize_t toread = 0;
-	stream->didread = 0;
+	ssize_t toread = 0, didread = 0;
 
 	while (size > 0) {
 
@@ -700,7 +699,8 @@ PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t size)
 			stream->readpos += toread;
 			size -= toread;
 			buf += toread;
-			stream->didread += toread;
+			didread += toread;
+			stream->has_buffered_data = 1;
 		}
 
 		/* ignore eof here; the underlying state might have changed */
@@ -713,14 +713,14 @@ PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t size)
 			if (toread < 0) {
 				/* Report an error if the read failed and we did not read any data
 				 * before that. Otherwise return the data we did read. */
-				if (stream->didread == 0) {
+				if (didread == 0) {
 					return toread;
 				}
 				break;
 			}
 		} else {
 			if (php_stream_fill_read_buffer(stream, size) != SUCCESS) {
-				if (stream->didread == 0) {
+				if (didread == 0) {
 					return -1;
 				}
 				break;
@@ -737,9 +737,10 @@ PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t size)
 			}
 		}
 		if (toread > 0) {
-			stream->didread += toread;
+			didread += toread;
 			buf += toread;
 			size -= toread;
+			stream->has_buffered_data = 1;
 		} else {
 			/* EOF, or temporary end of data (for non-blocking mode). */
 			break;
@@ -753,11 +754,12 @@ PHPAPI ssize_t _php_stream_read(php_stream *stream, char *buf, size_t size)
 		}
 	}
 
-	if (stream->didread > 0) {
-		stream->position += stream->didread;
+	if (didread > 0) {
+		stream->position += didread;
+		stream->has_buffered_data = 0;
 	}
 
-	return stream->didread;
+	return didread;
 }
 
 /* Like php_stream_read(), but reading into a zend_string buffer. This has some similarity

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -168,7 +168,7 @@ static ssize_t php_sockop_read(php_stream *stream, char *buf, size_t count)
 	/* Special handling for blocking read. */
 	if (sock->is_blocked) {
 		/* Find out if there is any data buffered from the previous read. */
-		bool has_buffered_data = stream->didread > 0;
+		bool has_buffered_data = stream->has_buffered_data;
 		/* No need to wait if there is any data buffered or no timeout. */
 		bool dont_wait = has_buffered_data ||
 				(sock->timeout.tv_sec == 0 && sock->timeout.tv_usec == 0);


### PR DESCRIPTION
This is an alternative implementation for https://github.com/php/php-src/commit/18fe337bae37913e3ce1001fd3896ed0d89116c5 that resets the `has_buffered_data` flag after finishing stream read so it doesn't impact other `ops->read` use like for example `php_stream_get_line`.