### PR TITLE
Fix lifetime issue with getAttributeNodeNS()

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -787,7 +787,7 @@ Since: DOM Level 2
 PHP_METHOD(DOMElement, getAttributeNodeNS)
 {
 	zval *id;
-	xmlNodePtr elemp, fakeAttrp;
+	xmlNodePtr elemp;
 	xmlAttrPtr attrp;
 	dom_object *intern;
 	size_t uri_len, name_len;
@@ -808,21 +808,9 @@ PHP_METHOD(DOMElement, getAttributeNodeNS)
 			xmlNsPtr nsptr;
 			nsptr = dom_get_nsdecl(elemp, (xmlChar *)name);
 			if (nsptr != NULL) {
-				xmlNsPtr curns;
-				curns = xmlNewNs(NULL, nsptr->href, NULL);
-				if (nsptr->prefix) {
-					curns->prefix = xmlStrdup((xmlChar *) nsptr->prefix);
-				}
-				if (nsptr->prefix) {
-					fakeAttrp = xmlNewDocNode(elemp->doc, NULL, (xmlChar *) nsptr->prefix, nsptr->href);
-				} else {
-					fakeAttrp = xmlNewDocNode(elemp->doc, NULL, (xmlChar *)"xmlns", nsptr->href);
-				}
-				fakeAttrp->type = XML_NAMESPACE_DECL;
-				fakeAttrp->parent = elemp;
-				fakeAttrp->ns = curns;
-
-				DOM_RET_OBJ(fakeAttrp, &ret, intern);
+				/* Keep parent alive, because we're a fake child. */
+				GC_ADDREF(&intern->std);
+				(void) php_dom_create_fake_namespace_decl(elemp, nsptr, return_value, intern);
 			} else {
 				RETURN_NULL();
 			}

--- a/ext/dom/tests/bug_lifetime_parentNode_getAttributeNodeNS.phpt
+++ b/ext/dom/tests/bug_lifetime_parentNode_getAttributeNodeNS.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Lifetime issue with parentNode on getAttributeNodeNS()
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$xmlString = '<?xml version="1.0" encoding="utf-8" ?>
+<root xmlns="http://ns" xmlns:ns2="http://ns2">
+    <ns2:child />
+</root>';
+
+$xml=new DOMDocument();
+$xml->loadXML($xmlString);
+$ns2 = $xml->documentElement->getAttributeNodeNS("http://www.w3.org/2000/xmlns/", "ns2");
+$ns2->parentNode->remove();
+var_dump($ns2->parentNode->localName);
+
+?>
+--EXPECT--
+string(4) "root"


### PR DESCRIPTION
It's the same issue that I fixed previously in GH-11402, but in a different place.
I think I got them all now.