### PR TITLE
ext/gd: imagerotate removes ignore_transparent argument.

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -111,6 +111,10 @@ PHP 8.3 UPGRADE NOTES
 - Dom:
   . Changed DOMCharacterData::appendData() tentative return type to true.
 
+- Gd:
+  . Changed imagerotate signature, removed the `ignore_transparent` argument
+    as it was not used internally anyway from PHP 7.x.
+
 - Intl:
   . datefmt_set_timezone (and its alias IntlDateformatter::setTimeZone) 
     now returns true on success, previously null was returned.

--- a/ext/gd/gd.c
+++ b/ext/gd/gd.c
@@ -1189,9 +1189,8 @@ PHP_FUNCTION(imagerotate)
 	gdImagePtr im_dst, im_src;
 	double degrees;
 	zend_long color;
-	bool ignoretransparent = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Odl|b", &SIM, gd_image_ce,  &degrees, &color, &ignoretransparent) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Odl", &SIM, gd_image_ce,  &degrees, &color) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/ext/gd/gd.stub.php
+++ b/ext/gd/gd.stub.php
@@ -530,9 +530,8 @@ function imagegrabscreen(): GdImage|false {}
 
 #endif
 
-// TODO: $ignore_transparent is ignored???
 /** @refcount 1 */
-function imagerotate(GdImage $image, float $angle, int $background_color, bool $ignore_transparent = false): GdImage|false {}
+function imagerotate(GdImage $image, float $angle, int $background_color): GdImage|false {}
 
 function imagesettile(GdImage $image, GdImage $tile): bool {}
 

--- a/ext/gd/gd_arginfo.h
+++ b/ext/gd/gd_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 810838932a482065c48ab715857062c071db31fd */
+ * Stub hash: 0f8a22bff1d123313f37da400500e573baace837 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_gd_info, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -122,7 +122,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_imagerotate, 0, 3, GdImage, 
 	ZEND_ARG_OBJ_INFO(0, image, GdImage, 0)
 	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO(0, background_color, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ignore_transparent, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_imagesettile, 0, 2, _IS_BOOL, 0)


### PR DESCRIPTION
seems to be a relic of PHP 5 but no longer makes sense in regard of gdImageRotateInterpolated.