### PR TITLE
Add `$before_needle` argument to `strrchr()`

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -2395,7 +2395,7 @@ function strripos(string $haystack, string $needle, int $offset = 0): int|false 
  * @compile-time-eval
  * @refcount 1
  */
-function strrchr(string $haystack, string $needle): string|false {}
+function strrchr(string $haystack, string $needle, bool $before_needle = false): string|false {}
 
 /** @compile-time-eval */
 function str_contains(string $haystack, string $needle): bool {}

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: decfa1e3d862d81880ea18150e2ba239bf15b8af */
+ * Stub hash: 487cee0751d47b18bf0a8fbdb050313783f1b369 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -913,10 +913,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_strripos arginfo_strpos
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_strrchr, 0, 2, MAY_BE_STRING|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, haystack, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, needle, IS_STRING, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_strrchr arginfo_stristr
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_str_contains, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, haystack, IS_STRING, 0)

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1656,7 +1656,7 @@ PHP_FUNCTION(stristr)
 	if (part) {
 		RETURN_STRINGL(ZSTR_VAL(haystack), found_offset);
 	}
-	RETURN_STRINGL(ZSTR_VAL(haystack) + found_offset, ZSTR_LEN(haystack) - found_offset);
+	RETURN_STRINGL(found, ZSTR_LEN(haystack) - found_offset);
 }
 /* }}} */
 
@@ -1684,7 +1684,7 @@ PHP_FUNCTION(strstr)
 	if (part) {
 		RETURN_STRINGL(ZSTR_VAL(haystack), found_offset);
 	}
-	RETURN_STRINGL(ZSTR_VAL(haystack) + found_offset, ZSTR_LEN(haystack) - found_offset);
+	RETURN_STRINGL(found, ZSTR_LEN(haystack) - found_offset);
 }
 /* }}} */
 
@@ -1934,10 +1934,13 @@ PHP_FUNCTION(strrchr)
 	zend_string *haystack, *needle;
 	const char *found = NULL;
 	zend_long found_offset;
+	bool part = 0;
 
-	ZEND_PARSE_PARAMETERS_START(2, 2)
+	ZEND_PARSE_PARAMETERS_START(2, 3)
 		Z_PARAM_STR(haystack)
 		Z_PARAM_STR(needle)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(part)
 	ZEND_PARSE_PARAMETERS_END();
 
 	found = zend_memrchr(ZSTR_VAL(haystack), *ZSTR_VAL(needle), ZSTR_LEN(haystack));
@@ -1945,6 +1948,9 @@ PHP_FUNCTION(strrchr)
 		RETURN_FALSE;
 	}
 	found_offset = found - ZSTR_VAL(haystack);
+	if (part) {
+		RETURN_STRINGL(ZSTR_VAL(haystack), found_offset);
+	}
 	RETURN_STRINGL(found, ZSTR_LEN(haystack) - found_offset);
 }
 /* }}} */

--- a/ext/standard/tests/strings/strrchr_basic.phpt
+++ b/ext/standard/tests/strings/strrchr_basic.phpt
@@ -4,49 +4,79 @@ Test strrchr() function : basic functionality
 <?php
 echo "*** Testing strrchr() function: basic functionality ***\n";
 var_dump( strrchr("Hello, World", "H") ); //needle as single char
+var_dump( strrchr("Hello, World", "H", true) ); //needle as single char
 var_dump( strrchr("Hello, World", "Hello") ); //needle as a first word of haystack
+var_dump( strrchr("Hello, World", "Hello", true) ); //needle as a first word of haystack
 var_dump( strrchr('Hello, World', 'H') );
+var_dump( strrchr('Hello, World', 'H', true) );
 var_dump( strrchr('Hello, World', 'Hello') );
+var_dump( strrchr('Hello, World', 'Hello', true) );
 
 //considering case
 var_dump( strrchr("Hello, World", "h") );
+var_dump( strrchr("Hello, World", "h", true) );
 var_dump( strrchr("Hello, World", "hello") );
+var_dump( strrchr("Hello, World", "hello", true) );
 
 //needle as second word of haystack
 var_dump( strrchr("Hello, World", "World") );
+var_dump( strrchr("Hello, World", "World", true) );
 var_dump( strrchr('Hello, World', 'World') );
+var_dump( strrchr('Hello, World', 'World', true) );
 
 //needle as special char
 var_dump( strrchr("Hello, World", ",") );
+var_dump( strrchr("Hello, World", ",", true) );
 var_dump( strrchr('Hello, World', ',') );
+var_dump( strrchr('Hello, World', ',', true) );
 
 var_dump( strrchr("Hello, World", "Hello, World") ); //needle as haystack
+var_dump( strrchr("Hello, World", "Hello, World", true) ); //needle as haystack
 
 //needle string containing one existing and one non-existing char
 var_dump( strrchr("Hello, World", "Hi") );
+var_dump( strrchr("Hello, World", "Hi", true) );
 
 //multiple existence of needle in haystack
 var_dump( strrchr("Hello, World", "o") );
+var_dump( strrchr("Hello, World", "o", true) );
 var_dump( strrchr("Hello, World", "ooo") );
+var_dump( strrchr("Hello, World", "ooo", true) );
 
 var_dump( strrchr("Hello, World", "Zzzz") ); //non-existent needle in haystack
+var_dump( strrchr("Hello, World", "Zzzz", true) ); //non-existent needle in haystack
 echo "*** Done ***";
 ?>
 --EXPECT--
 *** Testing strrchr() function: basic functionality ***
 string(12) "Hello, World"
+string(0) ""
 string(12) "Hello, World"
+string(0) ""
 string(12) "Hello, World"
+string(0) ""
 string(12) "Hello, World"
+string(0) ""
+bool(false)
+bool(false)
 bool(false)
 bool(false)
 string(5) "World"
+string(7) "Hello, "
 string(5) "World"
+string(7) "Hello, "
 string(7) ", World"
+string(5) "Hello"
 string(7) ", World"
+string(5) "Hello"
 string(12) "Hello, World"
+string(0) ""
 string(12) "Hello, World"
+string(0) ""
 string(4) "orld"
+string(8) "Hello, W"
 string(4) "orld"
+string(8) "Hello, W"
+bool(false)
 bool(false)
 *** Done ***


### PR DESCRIPTION
Similar functions such as [`strstr()`](https://www.php.net/manual/en/function.strstr.php), [`stristr()`](https://www.php.net/manual/en/function.stristr.php) or its mb counterpart [`mb_strrchr()`](https://www.php.net/manual/en/function.mb-strrchr.php) all have this parameter that allows returning part of the haystack before the occurrence of the needle. This function seems to be an exception.