### PR TITLE
Fix GH-11440: authentication to a sha256_password account fails over SSL

### DIFF
--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -912,9 +912,12 @@ mysqlnd_sha256_auth_get_auth_data(struct st_mysqlnd_authentication_plugin * self
 	if (conn->vio->data->ssl) {
 		DBG_INF("simple clear text under SSL");
 		/* clear text under SSL */
-		*auth_data_len = passwd_len;
-		ret = malloc(passwd_len);
+		/* NUL termination byte required: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_authentication_methods_clear_text_password.html
+		 * (this is similar to bug #78680, but now as GH-11440) */
+		*auth_data_len = passwd_len + 1;
+		ret = malloc(passwd_len + 1);
 		memcpy(ret, passwd, passwd_len);
+		ret[passwd_len] = '\0';
 	} else {
 		*auth_data_len = 0;
 		server_public_key = mysqlnd_sha256_get_rsa_key(conn, session_options, pfc_data);


### PR DESCRIPTION
This is similar to bug #78680, but that bug wasn't really fixed in all places. This is the only remaining place.

I'm a mysqlnd noob, so someone should triple check this please.

EDIT: LINUX_X64_RELEASE_ZTS failure is unrelated, CI fails in the setup phase.