### PR TITLE
Fix GH-11438: mysqlnd fails to authenticate with sha256_password accounts using passwords longer than 19 characters

### DIFF
--- a/ext/mysqli/tests/gh11438.phpt
+++ b/ext/mysqli/tests/gh11438.phpt
@@ -1,0 +1,129 @@
+--TEST--
+GH-11438 (mysqlnd fails to authenticate with sha256_password accounts using passwords longer than 19 characters)
+--EXTENSIONS--
+mysqli
+--SKIPIF--
+<?php
+// Test based on mysqli_pam_sha256_public_key_ini.phpt
+require_once('skipifconnectfailure.inc');
+
+ob_start();
+phpinfo(INFO_MODULES);
+$tmp = ob_get_contents();
+ob_end_clean();
+if (!stristr($tmp, "auth_plugin_sha256_password"))
+    die("skip SHA256 auth plugin not built-in to mysqlnd");
+
+require_once('connect.inc');
+if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
+        die(printf("skip: [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+
+if (mysqli_get_server_version($link) < 50606)
+    die("skip: SHA-256 requires MySQL 5.6.6+");
+
+if (!($res = $link->query("SHOW PLUGINS"))) {
+    die(sprintf("skip [%d] %s\n", $link->errno, $link->error));
+}
+
+$found = false;
+while ($row = $res->fetch_assoc()) {
+    if (($row['Name'] == 'sha256_password') && ($row['Status'] == 'ACTIVE')) {
+        $found = true;
+        break;
+    }
+}
+if (!$found)
+    die("skip SHA-256 server plugin unavailable");
+
+if (!($res = $link->query("SHOW STATUS LIKE 'Rsa_public_key'"))) {
+    die(sprintf("skip [%d] %s\n", $link->errno, $link->error));
+}
+
+if (!($row = $res->fetch_assoc())) {
+    die(sprintf("skip Failed to check RSA pub key, [%d] %s\n", $link->errno, $link->error));
+}
+
+$key = $row['Value'];
+if (strlen($key) < 100) {
+    die(sprintf("skip Server misconfiguration? RSA pub key is suspicious, [%d] %s\n", $link->errno, $link->error));
+}
+
+/* date changes may give false positive */
+$file = "test_sha256_ini";
+if ((file_exists($file) && !unlink($file)) || !($fp = @fopen($file, "w"))) {
+    die(sprintf("skip Cannot create RSA pub key file '%s'", $file));
+}
+$key = str_replace("A", "a", $key);
+$key = str_replace("M", "m", $key);
+if (strlen($key) != fwrite($fp, $key)) {
+    die(sprintf("skip Failed to create pub key file"));
+}
+
+// Ignore errors because this variable exists only in MySQL 5.6 and 5.7
+$link->query("SET @@session.old_passwords=2");
+
+$link->query('DROP USER shatest');
+$link->query("DROP USER shatest@localhost");
+
+
+if (!$link->query('CREATE USER shatest@"%" IDENTIFIED WITH sha256_password') ||
+    !$link->query('CREATE USER shatest@"localhost" IDENTIFIED WITH sha256_password')) {
+    die(sprintf("skip CREATE USER failed [%d] %s", $link->errno, $link->error));
+}
+
+// Password of length 52, more than twice the length of the scramble data to ensure scramble is repeated correctly
+if (!$link->query('SET PASSWORD FOR shatest@"%" = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"') ||
+    !$link->query('SET PASSWORD FOR shatest@"localhost" = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"')) {
+    die(sprintf("skip SET PASSWORD failed [%d] %s", $link->errno, $link->error));
+}
+
+if (!$link->query("DROP TABLE IF EXISTS test") ||
+    !$link->query("CREATE TABLE test (id INT)") ||
+    !$link->query("INSERT INTO test(id) VALUES (1), (2), (3)"))
+    die(sprintf("SKIP [%d] %s\n", $link->errno, $link->error));
+
+
+if (!$link->query(sprintf("GRANT SELECT ON TABLE %s.test TO shatest@'%%'", $db)) ||
+    !$link->query(sprintf("GRANT SELECT ON TABLE %s.test TO shatest@'localhost'", $db))) {
+    die(sprintf("skip Cannot grant SELECT to user [%d] %s", mysqli_errno($link), mysqli_error($link)));
+}
+
+$link->close();
+echo "nocache";
+?>
+--INI--
+mysqlnd.sha256_server_public_key="test_sha256_ini"
+--FILE--
+<?php
+    require_once("connect.inc");
+
+
+    $link = new mysqli($host, 'shatest', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', $db, $port, $socket);
+    if ($link->connect_errno) {
+        printf("[001] [%d] %s\n", $link->connect_errno, $link->connect_error);
+    } else {
+        if (!$res = $link->query("SELECT id FROM test WHERE id = 1"))
+            printf("[002] [%d] %s\n", $link->errno, $link->error);
+
+        if (!$row = mysqli_fetch_assoc($res)) {
+            printf("[003] [%d] %s\n", $link->errno, $link->error);
+        }
+
+        if ($row['id'] != 1) {
+            printf("[004] Expecting 1 got %s/'%s'", gettype($row['id']), $row['id']);
+        }
+    }
+    print "done!";
+?>
+--CLEAN--
+<?php
+	require_once("clean_table.inc");
+	$link->query('DROP USER shatest');
+	$link->query('DROP USER shatest@localhost');
+	$file = "test_sha256_ini";
+	@unlink($file);
+?>
+--EXPECTF--
+Warning: mysqli::__construct(): (HY000/1045): %s in %s on line %d
+[001] [1045] %s
+done!

--- a/ext/mysqli/tests/gh11438.phpt
+++ b/ext/mysqli/tests/gh11438.phpt
@@ -4,8 +4,7 @@ GH-11438 (mysqlnd fails to authenticate with sha256_password accounts using pass
 mysqli
 --SKIPIF--
 <?php
-// Test based on mysqli_pam_sha256_public_key_ini.phpt
-require_once('skipifconnectfailure.inc');
+require_once 'skipifconnectfailure.inc';
 
 ob_start();
 phpinfo(INFO_MODULES);
@@ -14,9 +13,8 @@ ob_end_clean();
 if (!stristr($tmp, "auth_plugin_sha256_password"))
     die("skip SHA256 auth plugin not built-in to mysqlnd");
 
-require_once('connect.inc');
 if (!$link = my_mysqli_connect($host, $user, $passwd, $db, $port, $socket))
-        die(printf("skip: [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
+    die(printf("skip: [%d] %s\n", mysqli_connect_errno(), mysqli_connect_error()));
 
 if (mysqli_get_server_version($link) < 50606)
     die("skip: SHA-256 requires MySQL 5.6.6+");
@@ -35,36 +33,11 @@ while ($row = $res->fetch_assoc()) {
 if (!$found)
     die("skip SHA-256 server plugin unavailable");
 
-if (!($res = $link->query("SHOW STATUS LIKE 'Rsa_public_key'"))) {
-    die(sprintf("skip [%d] %s\n", $link->errno, $link->error));
-}
-
-if (!($row = $res->fetch_assoc())) {
-    die(sprintf("skip Failed to check RSA pub key, [%d] %s\n", $link->errno, $link->error));
-}
-
-$key = $row['Value'];
-if (strlen($key) < 100) {
-    die(sprintf("skip Server misconfiguration? RSA pub key is suspicious, [%d] %s\n", $link->errno, $link->error));
-}
-
-/* date changes may give false positive */
-$file = "test_sha256_ini";
-if ((file_exists($file) && !unlink($file)) || !($fp = @fopen($file, "w"))) {
-    die(sprintf("skip Cannot create RSA pub key file '%s'", $file));
-}
-$key = str_replace("A", "a", $key);
-$key = str_replace("M", "m", $key);
-if (strlen($key) != fwrite($fp, $key)) {
-    die(sprintf("skip Failed to create pub key file"));
-}
-
 // Ignore errors because this variable exists only in MySQL 5.6 and 5.7
 $link->query("SET @@session.old_passwords=2");
 
 $link->query('DROP USER shatest');
 $link->query("DROP USER shatest@localhost");
-
 
 if (!$link->query('CREATE USER shatest@"%" IDENTIFIED WITH sha256_password') ||
     !$link->query('CREATE USER shatest@"localhost" IDENTIFIED WITH sha256_password')) {
@@ -77,53 +50,35 @@ if (!$link->query('SET PASSWORD FOR shatest@"%" = "abcdefghijklmnopqrstuvwxyzABC
     die(sprintf("skip SET PASSWORD failed [%d] %s", $link->errno, $link->error));
 }
 
-if (!$link->query("DROP TABLE IF EXISTS test") ||
-    !$link->query("CREATE TABLE test (id INT)") ||
-    !$link->query("INSERT INTO test(id) VALUES (1), (2), (3)"))
-    die(sprintf("SKIP [%d] %s\n", $link->errno, $link->error));
-
-
-if (!$link->query(sprintf("GRANT SELECT ON TABLE %s.test TO shatest@'%%'", $db)) ||
-    !$link->query(sprintf("GRANT SELECT ON TABLE %s.test TO shatest@'localhost'", $db))) {
-    die(sprintf("skip Cannot grant SELECT to user [%d] %s", mysqli_errno($link), mysqli_error($link)));
-}
-
-$link->close();
 echo "nocache";
 ?>
---INI--
-mysqlnd.sha256_server_public_key="test_sha256_ini"
 --FILE--
 <?php
-    require_once("connect.inc");
+require_once 'connect.inc';
 
+$link = new mysqli($host, 'shatest', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', null, $port, $socket);
+if ($link->connect_errno) {
+    printf("[001] [%d] %s\n", $link->connect_errno, $link->connect_error);
+} else {
+    if (!$res = $link->query("SELECT USER()"))
+        printf("[002] [%d] %s\n", $link->errno, $link->error);
 
-    $link = new mysqli($host, 'shatest', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', $db, $port, $socket);
-    if ($link->connect_errno) {
-        printf("[001] [%d] %s\n", $link->connect_errno, $link->connect_error);
-    } else {
-        if (!$res = $link->query("SELECT id FROM test WHERE id = 1"))
-            printf("[002] [%d] %s\n", $link->errno, $link->error);
-
-        if (!$row = mysqli_fetch_assoc($res)) {
-            printf("[003] [%d] %s\n", $link->errno, $link->error);
-        }
-
-        if ($row['id'] != 1) {
-            printf("[004] Expecting 1 got %s/'%s'", gettype($row['id']), $row['id']);
-        }
+    if (!$row = mysqli_fetch_assoc($res)) {
+        printf("[003] [%d] %s\n", $link->errno, $link->error);
     }
-    print "done!";
+
+    if (!is_string($row['USER()']) || !str_starts_with($row['USER()'], 'shatest')) {
+        printf("[004] Expecting 1 got %s/'%s'", gettype($row['USER()']), $row['USER()']);
+    }
+}
+
+print "done!";
 ?>
 --CLEAN--
 <?php
-	require_once("clean_table.inc");
-	$link->query('DROP USER shatest');
-	$link->query('DROP USER shatest@localhost');
-	$file = "test_sha256_ini";
-	@unlink($file);
+require_once 'connect.inc';
+$link->query('DROP USER shatest');
+$link->query('DROP USER shatest@localhost');
 ?>
 --EXPECTF--
-Warning: mysqli::__construct(): (HY000/1045): %s in %s on line %d
-[001] [1045] %s
 done!

--- a/ext/mysqlnd/mysqlnd_auth.c
+++ b/ext/mysqlnd/mysqlnd_auth.c
@@ -924,7 +924,10 @@ mysqlnd_sha256_auth_get_auth_data(struct st_mysqlnd_authentication_plugin * self
 			char *xor_str = do_alloca(passwd_len + 1, use_heap);
 			memcpy(xor_str, passwd, passwd_len);
 			xor_str[passwd_len] = '\0';
-			mysqlnd_xor_string(xor_str, passwd_len, (char *) auth_plugin_data, auth_plugin_data_len);
+			/* https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html
+			 * This tells us that the nonce is 20 (==SCRAMBLE_LENGTH) bytes long.
+			 * In a 5.5+ server we might get additional scramble data in php_mysqlnd_greet_read, not used by this authentication method. */
+			mysqlnd_xor_string(xor_str, passwd_len, (char *) auth_plugin_data, SCRAMBLE_LENGTH);
 			ret = mysqlnd_sha256_public_encrypt(conn, server_public_key, passwd_len, auth_data_len, xor_str);
 			free_alloca(xor_str, use_heap);
 		}


### PR DESCRIPTION
https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html tells us that the nonce used in this authentication method is 20 bytes long. However, we might receive additional scramble data in php_mysqlnd_greet_read not used in this method.
On my test setup, I received 21 bytes (20 bytes + '\0'). This resulted in the xor computation to incorrectly include the NUL byte. Every password of at least 20 characters therefore failed to authenticate using this method.

Looking at mysql-server source code also seems to reveal that it always uses a fixed number of scramble bytes [1].

[1] https://github.com/mysql/mysql-server/blob/ea7087d885006918ad54458e7aad215b1650312c/sql/auth/sha2_password.cc#L1078-L1079

I'm a mysqlnd noob, so someone should triple check this please.