### PR TITLE
Fix GH-11433: Unable to set CURLOPT_ACCEPT_ENCODING to NULL

### DIFF
--- a/ext/curl/interface.c
+++ b/ext/curl/interface.c
@@ -2493,7 +2493,6 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 		case CURLOPT_TLSAUTH_TYPE:
 		case CURLOPT_TLSAUTH_PASSWORD:
 		case CURLOPT_TLSAUTH_USERNAME:
-		case CURLOPT_ACCEPT_ENCODING:
 		case CURLOPT_TRANSFER_ENCODING:
 		case CURLOPT_DNS_SERVERS:
 		case CURLOPT_MAIL_AUTH:
@@ -2553,6 +2552,7 @@ static int _php_curl_setopt(php_curl *ch, zend_long option, zval *zvalue, bool i
 		case CURLOPT_RANGE:
 		case CURLOPT_FTP_ACCOUNT:
 		case CURLOPT_RTSP_SESSION_ID:
+		case CURLOPT_ACCEPT_ENCODING:
 #if LIBCURL_VERSION_NUM >= 0x072100 /* Available since 7.33.0 */
 		case CURLOPT_DNS_INTERFACE:
 		case CURLOPT_DNS_LOCAL_IP4:

--- a/ext/curl/tests/curl_setopt_CURLOPT_ACCEPT_ENCODING.phpt
+++ b/ext/curl/tests/curl_setopt_CURLOPT_ACCEPT_ENCODING.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test curl_setopt() with CURLOPT_ACCEPT_ENCODING
+--EXTENSIONS--
+curl
+--FILE--
+<?php
+
+include 'server.inc';
+$host = curl_cli_server_start();
+
+$ch = curl_init();
+
+$url = "{$host}/get.inc?test=";
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_ACCEPT_ENCODING, "gzip");
+curl_setopt($ch, CURLINFO_HEADER_OUT, 1);
+
+// First execution, with gzip accept
+curl_exec($ch);
+echo curl_getinfo($ch, CURLINFO_HEADER_OUT);
+
+// Second execution, with the encoding accept disabled
+curl_setopt($ch, CURLOPT_ACCEPT_ENCODING, NULL);
+curl_exec($ch);
+echo curl_getinfo($ch, CURLINFO_HEADER_OUT);
+
+curl_close($ch);
+?>
+--EXPECTF--
+GET /get.inc?test= HTTP/1.1
+Host: %s
+Accept: */*
+Accept-Encoding: gzip
+
+GET /get.inc?test= HTTP/1.1
+Host: %s
+Accept: */*


### PR DESCRIPTION
Note: I'm unsure how to write a phpt in a meaningful way for this one. I tried setting NULL and a string and it works, but I don't see an encoding test I can copy/amend.