### PR TITLE
Fix GH-11451: Invalid associative array containing duplicate keys

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1982,7 +1982,9 @@ PHP_METHOD(SQLite3Result, fetchArray)
 							Z_ADDREF(data);
 						}
 					}
-					zend_symtable_add_new(Z_ARR_P(return_value), result_obj->column_names[i], &data);
+					/* Note: we can't use the "add_new" variant here instead of "update" because
+					 * when the same column name is encountered, the last result should be taken. */
+					zend_symtable_update(Z_ARR_P(return_value), result_obj->column_names[i], &data);
 				}
 			}
 			break;

--- a/ext/sqlite3/tests/gh11451.phpt
+++ b/ext/sqlite3/tests/gh11451.phpt
@@ -1,0 +1,25 @@
+--TEST--
+GH-11451 (Invalid associative array containing duplicate keys)
+--EXTENSIONS--
+sqlite3
+--FILE--
+<?php
+var_dump((new SQLite3(':memory:'))
+	->query('SELECT 1 AS key, 2 AS key')
+	->fetchArray(SQLITE3_ASSOC));
+
+var_dump((new SQLite3(':memory:'))
+	->query('SELECT 0 AS dummy, 1 AS key, 2 AS key')
+	->fetchArray(SQLITE3_ASSOC));
+?>
+--EXPECT--
+array(1) {
+  ["key"]=>
+  int(2)
+}
+array(2) {
+  ["dummy"]=>
+  int(0)
+  ["key"]=>
+  int(2)
+}


### PR DESCRIPTION
It used the "add_new" variant which assumes the key doesn't already exist. But in case of duplicate keys we have to take the last result.

Closes GH-11451.