### PR TITLE
Resolve #11099 in case of a debug-zts-asan build

### DIFF
--- a/ext/phar/Makefile.frag
+++ b/ext/phar/Makefile.frag
@@ -31,7 +31,7 @@ $(builddir)/phar/phar.inc: $(srcdir)/phar/phar.inc
 
 
 TEST_PHP_EXECUTABLE = $(shell $(PHP_EXECUTABLE) -v 2>&1)
-TEST_PHP_EXECUTABLE_RES = $(shell echo "$(TEST_PHP_EXECUTABLE)" | grep -c 'Exec format error')
+TEST_PHP_EXECUTABLE_RES = $(shell [ -z "$(TEST_PHP_EXECUTABLE)" ] || echo "$(TEST_PHP_EXECUTABLE)" | grep -q "Exec format error" && echo 1 || echo 0)
 
 $(builddir)/phar.php: $(srcdir)/build_precommand.php $(srcdir)/phar/*.inc $(srcdir)/phar/*.php $(SAPI_CLI_PATH)
 	-@(echo "Generating phar.php"; \


### PR DESCRIPTION
When building the PHP 8.3 versions with phar support from source with aarch64-linux-gnu tool chain, it will fail with:
```
/bin/bash: line 1: 11317 Killed                  /tmp/build-php/sapi/cli/php -v 2>&1
Generating phar.php
/bin/bash /tmp/build-php/libtool --silent --preserve-dup-deps --tag CC --mode=link x86_64-linux-gnu-gcc -shared -I/tmp/build-php/include -I/tmp/build-php/main -I/usr/local/src/php -I/tmp/build-php/ext/date/lib -I/usr/local/src/php/ext/date/lib -I/usr/include/libxml2 -I/usr/include/x86_64-linux-gnu -I/usr/local/src/php/ext/mbstring/libmbfl -I/tmp/build-php/ext/mbstring/libmbfl -I/usr/local/src/php/ext/mbstring/libmbfl/mbfl -I/tmp/build-php/ext/mbstring/libmbfl/mbfl -I/usr/include/postgresql -I/usr/include/editline -I/tmp/build-php/TSRM -I/tmp/build-php/Zend -I/usr/local/src/php/main -I/usr/local/src/php/Zend -I/usr/local/src/php/TSRM -I/tmp/build-php/  -D_GNU_SOURCE -D_REENTRANT -pthread  -fno-common -Wformat-truncation -Wlogical-op -Wduplicated-cond -Wno-clobbered -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -fsanitize=address -DZEND_TRACK_ARENA_ALLOC -fvisibility=hidden -pthread -Wimplicit-fallthrough=1 -DZTS -DZEND_MAX_EXECUTION_TIMERS   -fsanitize=address  -o ext/opcache/opcache.la -export-dynamic -avoid-version -prefer-pic -module -rpath /tmp/build-php/modules -avoid-version -module -L/usr/lib/x86_64-linux-gnu ext/opcache/ZendAccelerator.lo ext/opcache/zend_accelerator_blacklist.lo ext/opcache/zend_accelerator_debug.lo ext/opcache/zend_accelerator_hash.lo ext/opcache/zend_accelerator_module.lo ext/opcache/zend_persist.lo ext/opcache/zend_persist_calc.lo ext/opcache/zend_file_cache.lo ext/opcache/zend_shared_alloc.lo ext/opcache/zend_accelerator_util_funcs.lo ext/opcache/shared_alloc_shm.lo ext/opcache/shared_alloc_mmap.lo ext/opcache/shared_alloc_posix.lo ext/opcache/jit/zend_jit.lo ext/opcache/jit/zend_jit_gdb.lo ext/opcache/jit/zend_jit_vm_helpers.lo 
/bin/bash /tmp/build-php/libtool --silent --preserve-dup-deps --tag CC --mode=install cp ext/opcache/opcache.la /tmp/build-php/modules
/bin/bash: line 5: 13654 Killed                  ` if test -x "/tmp/build-php/sapi/cli/php"; then /usr/local/src/php/build/shtool echo -n -- "/tmp/build-php/sapi/cli/php -n"; if test "x/tmp/build-php/modules/zend_test.la" != "x"; then /usr/local/src/php/build/shtool echo -n -- " -d extension_dir=/tmp/build-php/modules"; for i in bz2 zlib phar; do if test -f "/tmp/build-php/modules/$i.la"; then . /tmp/build-php/modules/$i.la; /usr/local/src/php/build/shtool echo -n -- " -d extension=$dlname"; fi; done; fi; else /usr/local/src/php/build/shtool echo -n -- "/tmp/build-php/sapi/cli/php"; fi;` -n -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1' -d phar.readonly=0 /usr/local/src/php/ext/phar/build_precommand.php > ext/phar/phar.php
make: [Makefile:444: ext/phar/phar.php] Error 137 (ignored)
/bin/bash: line 1: 13993 Killed                  /tmp/build-php/sapi/cli/php -v 2>&1
Generating phar.phar
/bin/bash: line 8: 14177 Killed                  ` if test -x "/tmp/build-php/sapi/cli/php"; then /usr/local/src/php/build/shtool echo -n -- "/tmp/build-php/sapi/cli/php -n"; if test "x/tmp/build-php/modules/zend_test.la" != "x"; then /usr/local/src/php/build/shtool echo -n -- " -d extension_dir=/tmp/build-php/modules"; for i in bz2 zlib phar; do if test -f "/tmp/build-php/modules/$i.la"; then . /tmp/build-php/modules/$i.la; /usr/local/src/php/build/shtool echo -n -- " -d extension=$dlname"; fi; done; fi; else /usr/local/src/php/build/shtool echo -n -- "/tmp/build-php/sapi/cli/php"; fi;` -n -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1' -d phar.readonly=0 ext/phar/phar.php pack -f ext/phar/phar.phar -a pharcommand -c auto -x \\.svn -p 0 -s /usr/local/src/php/ext/phar/phar/phar.php -h sha1 -b "`/usr/local/src/php/build/shtool echo -n -- "/opt//debut-zts-asan/bin/php";`" /usr/local/src/php/ext/phar/phar/
chmod: cannot access 'ext/phar/phar.phar': No such file or directory
make: [Makefile:452: ext/phar/phar.phar] Error 1 (ignored)

Build complete.
Don't forget to run 'make test'.
````

This PR will add a check for an empty return from `php -v` to the quickfix from #11243 that resolved #11099
