### PR TITLE
Fix #80332: Completely broken array access functionality with DOMNamedNodeMap

### DIFF
--- a/ext/dom/namednodemap.c
+++ b/ext/dom/namednodemap.c
@@ -31,7 +31,7 @@
 * Since:
 */
 
-static int get_namednodemap_length(dom_object *obj)
+int php_dom_get_namednodemap_length(dom_object *obj)
 {
 	dom_nnodemap_object *objmap = (dom_nnodemap_object *) obj->ptr;
 	if (!objmap) {
@@ -65,95 +65,74 @@ Since:
 */
 int dom_namednodemap_length_read(dom_object *obj, zval *retval)
 {
-	ZVAL_LONG(retval, get_namednodemap_length(obj));
+	ZVAL_LONG(retval, php_dom_get_namednodemap_length(obj));
 	return SUCCESS;
 }
 
 /* }}} */
+
+xmlNodePtr php_dom_named_node_map_get_named_item(dom_nnodemap_object *objmap, const char *named, bool may_transform)
+{
+	xmlNodePtr itemnode = NULL;
+	if (objmap != NULL) {
+		if ((objmap->nodetype == XML_NOTATION_NODE) ||
+			objmap->nodetype == XML_ENTITY_NODE) {
+			if (objmap->ht) {
+				if (objmap->nodetype == XML_ENTITY_NODE) {
+					itemnode = (xmlNodePtr)xmlHashLookup(objmap->ht, (const xmlChar *) named);
+				} else {
+					xmlNotationPtr notep = xmlHashLookup(objmap->ht, (const xmlChar *) named);
+					if (notep) {
+						if (may_transform) {
+							itemnode = create_notation(notep->name, notep->PublicID, notep->SystemID);
+						} else {
+							itemnode = (xmlNodePtr) notep;
+						}
+					}
+				}
+			}
+		} else {
+			xmlNodePtr nodep = dom_object_get_node(objmap->baseobj);
+			if (nodep) {
+				itemnode = (xmlNodePtr)xmlHasProp(nodep, (const xmlChar *) named);
+			}
+		}
+	}
+	return itemnode;
+}
+
+void php_dom_named_node_map_get_named_item_into_zval(dom_nnodemap_object *objmap, const char *named, zval *return_value)
+{
+	int ret;
+	xmlNodePtr itemnode = php_dom_named_node_map_get_named_item(objmap, named, true);
+	if (itemnode) {
+		DOM_RET_OBJ(itemnode, &ret, objmap->baseobj);
+	} else {
+		RETURN_NULL();
+	}
+}
 
 /* {{{ URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-1074577549
 Since:
 */
 PHP_METHOD(DOMNamedNodeMap, getNamedItem)
 {
-	zval *id;
-	int ret;
-	size_t namedlen=0;
-	dom_object *intern;
-	xmlNodePtr itemnode = NULL;
+	size_t namedlen;
 	char *named;
 
-	dom_nnodemap_object *objmap;
-	xmlNodePtr nodep;
-	xmlNotation *notep = NULL;
-
-	id = ZEND_THIS;
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &named, &namedlen) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	intern = Z_DOMOBJ_P(id);
-
-	objmap = (dom_nnodemap_object *)intern->ptr;
-
-	if (objmap != NULL) {
-		if ((objmap->nodetype == XML_NOTATION_NODE) ||
-			objmap->nodetype == XML_ENTITY_NODE) {
-			if (objmap->ht) {
-				if (objmap->nodetype == XML_ENTITY_NODE) {
-					itemnode = (xmlNodePtr)xmlHashLookup(objmap->ht, (xmlChar *) named);
-				} else {
-					notep = (xmlNotation *)xmlHashLookup(objmap->ht, (xmlChar *) named);
-					if (notep) {
-						itemnode = create_notation(notep->name, notep->PublicID, notep->SystemID);
-					}
-				}
-			}
-		} else {
-			nodep = dom_object_get_node(objmap->baseobj);
-			if (nodep) {
-				itemnode = (xmlNodePtr)xmlHasProp(nodep, (xmlChar *) named);
-			}
-		}
-	}
-
-	if (itemnode) {
-		DOM_RET_OBJ(itemnode, &ret, objmap->baseobj);
-		return;
-	} else {
-		RETVAL_NULL();
-	}
+	zval *id = ZEND_THIS;
+	dom_nnodemap_object *objmap = Z_DOMOBJ_P(id)->ptr;
+	php_dom_named_node_map_get_named_item_into_zval(objmap, named, return_value);
 }
 /* }}} end dom_namednodemap_get_named_item */
 
-/* {{{ URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-349467F9
-Since:
-*/
-PHP_METHOD(DOMNamedNodeMap, item)
+xmlNodePtr php_dom_named_node_map_get_item(dom_nnodemap_object *objmap, zend_long index)
 {
-	zval *id;
-	zend_long index;
-	int ret;
-	dom_object *intern;
 	xmlNodePtr itemnode = NULL;
-
-	dom_nnodemap_object *objmap;
-	xmlNodePtr nodep, curnode;
-	int count;
-
-	id = ZEND_THIS;
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &index) == FAILURE) {
-		RETURN_THROWS();
-	}
-	if (index < 0 || ZEND_LONG_INT_OVFL(index)) {
-		zend_argument_value_error(1, "must be between 0 and %d", INT_MAX);
-		RETURN_THROWS();
-	}
-
-	intern = Z_DOMOBJ_P(id);
-
-	objmap = (dom_nnodemap_object *)intern->ptr;
-
 	if (objmap != NULL) {
 		if ((objmap->nodetype == XML_NOTATION_NODE) ||
 			objmap->nodetype == XML_ENTITY_NODE) {
@@ -165,10 +144,10 @@ PHP_METHOD(DOMNamedNodeMap, item)
 				}
 			}
 		} else {
-			nodep = dom_object_get_node(objmap->baseobj);
+			xmlNodePtr nodep = dom_object_get_node(objmap->baseobj);
 			if (nodep) {
-				curnode = (xmlNodePtr)nodep->properties;
-				count = 0;
+				xmlNodePtr curnode = (xmlNodePtr)nodep->properties;
+				zend_long count = 0;
 				while (count < index && curnode != NULL) {
 					count++;
 					curnode = (xmlNodePtr)curnode->next;
@@ -177,13 +156,38 @@ PHP_METHOD(DOMNamedNodeMap, item)
 			}
 		}
 	}
+	return itemnode;
+}
 
+void php_dom_named_node_map_get_item_into_zval(dom_nnodemap_object *objmap, zend_long index, zval *return_value)
+{
+	int ret;
+	xmlNodePtr itemnode = php_dom_named_node_map_get_item(objmap, index);
 	if (itemnode) {
 		DOM_RET_OBJ(itemnode, &ret, objmap->baseobj);
-		return;
+	} else {
+		RETURN_NULL();
+	}
+}
+
+/* {{{ URL: http://www.w3.org/TR/2003/WD-DOM-Level-3-Core-20030226/DOM3-Core.html#core-ID-349467F9
+Since:
+*/
+PHP_METHOD(DOMNamedNodeMap, item)
+{
+	zend_long index;
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &index) == FAILURE) {
+		RETURN_THROWS();
+	}
+	if (index < 0 || ZEND_LONG_INT_OVFL(index)) {
+		zend_argument_value_error(1, "must be between 0 and %d", INT_MAX);
+		RETURN_THROWS();
 	}
 
-	RETVAL_NULL();
+	zval *id = ZEND_THIS;
+	dom_object *intern = Z_DOMOBJ_P(id);
+	dom_nnodemap_object *objmap = intern->ptr;
+	php_dom_named_node_map_get_item_into_zval(objmap, index, return_value);
 }
 /* }}} end dom_namednodemap_item */
 
@@ -254,7 +258,7 @@ PHP_METHOD(DOMNamedNodeMap, count)
 	}
 
 	intern = Z_DOMOBJ_P(id);
-	RETURN_LONG(get_namednodemap_length(intern));
+	RETURN_LONG(php_dom_get_namednodemap_length(intern));
 }
 /* }}} end dom_namednodemap_count */
 

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -147,6 +147,15 @@ void dom_parent_node_before(dom_object *context, zval *nodes, int nodesc);
 void dom_child_node_remove(dom_object *context);
 void dom_child_replace_with(dom_object *context, zval *nodes, int nodesc);
 
+/* nodemap and nodelist APIs */
+xmlNodePtr php_dom_named_node_map_get_named_item(dom_nnodemap_object *objmap, const char *named, bool may_transform);
+void php_dom_named_node_map_get_named_item_into_zval(dom_nnodemap_object *objmap, const char *named, zval *return_value);
+xmlNodePtr php_dom_named_node_map_get_item(dom_nnodemap_object *objmap, zend_long index);
+void php_dom_named_node_map_get_item_into_zval(dom_nnodemap_object *objmap, zend_long index, zval *return_value);
+void php_dom_nodelist_get_item_into_zval(dom_nnodemap_object *objmap, zend_long index, zval *return_value);
+int php_dom_get_namednodemap_length(dom_object *obj);
+int php_dom_get_nodelist_length(dom_object *obj);
+
 #define DOM_GET_OBJ(__ptr, __id, __prtype, __intern) { \
 	__intern = Z_DOMOBJ_P(__id); \
 	if (__intern->ptr == NULL || !(__ptr = (__prtype)((php_libxml_node_ptr *)__intern->ptr)->node)) { \

--- a/ext/dom/tests/bug67949.phpt
+++ b/ext/dom/tests/bug67949.phpt
@@ -86,7 +86,7 @@ bool(true)
 string(4) "data"
 string(4) "test"
 testing read_dimension with null offset
-Cannot access node list without offset
+Cannot access DOMNodeList without offset
 testing attribute access
 string(4) "href"
 ==DONE==

--- a/ext/dom/tests/bug80332_1.phpt
+++ b/ext/dom/tests/bug80332_1.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Bug #80332 (Completely broken array access functionality with DOMNamedNodeMap) - DOMNamedNodeMap variation
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+
+$doc->loadHTML('<span attr1="value1" attr2="value2"></span>');
+
+$x = new DOMXPath($doc);
+$span = $x->query('//span')[0];
+
+print "Node name: {$span->nodeName}\n";
+
+function test($span, $key) {
+    $key_formatted = match ($key) {
+        false => 'false',
+        true => 'true',
+        null => 'null',
+        default => is_string($key) ? "'$key'" : $key,
+    };
+    echo "Attribute [{$key_formatted}] name: ", $span->attributes[$key]->nodeName ?? '/', "\n";
+    echo "Attribute [{$key_formatted}] value: ", $span->attributes[$key]->nodeValue ?? '/', "\n";
+    echo "Attribute [{$key_formatted}] isset: ", isset($span->attributes[$key]) ? "yes" : "no", "\n";
+    echo "\n";
+}
+
+test($span, 0);
+test($span, false);
+test($span, true);
+test($span, null);
+test($span, 'attr2');
+// This one should fail because there is no 'hi' attribute
+test($span, 'hi');
+test($span, '0');
+test($span, '0.5');
+test($span, '1');
+// This one should fail because it's out of bounds
+test($span, '2147483647');
+
+?>
+--EXPECT--
+Node name: span
+Attribute [0] name: attr1
+Attribute [0] value: value1
+Attribute [0] isset: yes
+
+Attribute [false] name: attr1
+Attribute [false] value: value1
+Attribute [false] isset: yes
+
+Attribute [true] name: attr2
+Attribute [true] value: value2
+Attribute [true] isset: yes
+
+Attribute [null] name: attr1
+Attribute [null] value: value1
+Attribute [null] isset: yes
+
+Attribute ['attr2'] name: attr1
+Attribute ['attr2'] value: value1
+Attribute ['attr2'] isset: yes
+
+Attribute ['hi'] name: attr1
+Attribute ['hi'] value: value1
+Attribute ['hi'] isset: yes
+
+Attribute ['0'] name: attr1
+Attribute ['0'] value: value1
+Attribute ['0'] isset: yes
+
+Attribute ['0.5'] name: attr1
+Attribute ['0.5'] value: value1
+Attribute ['0.5'] isset: yes
+
+Attribute ['1'] name: attr2
+Attribute ['1'] value: value2
+Attribute ['1'] isset: yes
+
+Attribute ['2147483647'] name: /
+Attribute ['2147483647'] value: /
+Attribute ['2147483647'] isset: no

--- a/ext/dom/tests/bug80332_1.phpt
+++ b/ext/dom/tests/bug80332_1.phpt
@@ -59,13 +59,13 @@ Attribute [null] name: attr1
 Attribute [null] value: value1
 Attribute [null] isset: yes
 
-Attribute ['attr2'] name: attr1
-Attribute ['attr2'] value: value1
+Attribute ['attr2'] name: attr2
+Attribute ['attr2'] value: value2
 Attribute ['attr2'] isset: yes
 
-Attribute ['hi'] name: attr1
-Attribute ['hi'] value: value1
-Attribute ['hi'] isset: yes
+Attribute ['hi'] name: /
+Attribute ['hi'] value: /
+Attribute ['hi'] isset: no
 
 Attribute ['0'] name: attr1
 Attribute ['0'] value: value1

--- a/ext/dom/tests/bug80332_2.phpt
+++ b/ext/dom/tests/bug80332_2.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Bug #80332 (Completely broken array access functionality with DOMNamedNodeMap) - DOMNodeList variation
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+$doc->loadXML('<?xml version="1.0"?><span><strong id="1"/><strong id="2"/></span>');
+
+$list = $doc->getElementsByTagName('strong');
+
+function test($list, $key) {
+    $key_formatted = match ($key) {
+        false => 'false',
+        true => 'true',
+        null => 'null',
+        default => is_string($key) ? "'$key'" : $key,
+    };
+    echo "list[$key_formatted] id attribute: ", $list[$key] ? $list[$key]->getAttribute('id') : '/', "\n";
+}
+
+test($list, 0);
+test($list, false);
+test($list, true);
+test($list, null);
+test($list, '0');
+test($list, '0.5');
+test($list, '1');
+// These two should fail because there's no named lookup possible here
+test($list, 'attr2');
+test($list, 'hi');
+// This one should fail because it's out of bounds
+test($list, '2147483647');
+
+?>
+--EXPECT--
+list[0] id attribute: 1
+list[false] id attribute: 1
+list[true] id attribute: 2
+list[null] id attribute: 1
+list['0'] id attribute: 1
+list['0.5'] id attribute: 1
+list['1'] id attribute: 2
+list['attr2'] id attribute: 1
+list['hi'] id attribute: 1
+list['2147483647'] id attribute: /

--- a/ext/dom/tests/bug80332_2.phpt
+++ b/ext/dom/tests/bug80332_2.phpt
@@ -42,6 +42,6 @@ list[null] id attribute: 1
 list['0'] id attribute: 1
 list['0.5'] id attribute: 1
 list['1'] id attribute: 2
-list['attr2'] id attribute: 1
-list['hi'] id attribute: 1
+list['attr2'] id attribute: /
+list['hi'] id attribute: /
 list['2147483647'] id attribute: /


### PR DESCRIPTION
    The problem is the usage of zval_get_long(). In particular, if the
    string is non-numeric the result of zval_get_long() will be 0 without
    giving an error or warning. This is misleading for users: users get the
    impression that they can use strings to access the map because it
    coincidentally works for the first item (which is at index 0). Of
    course, this fails with any other index which causes confusion and bugs.
    
    This patch adds proper support for using string offsets while accessing
    the map. It does so by detecting if it's a non-numeric string, and then
    using the getNamedItem() method instead of item(). I had to split up the
    array access implementation code for DOMNodeList and DOMNamedNodeMap
    first to be able to do this.
