### PR TITLE
github: add build scripts to "Category: Build System" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,8 @@
 "Category: Build System":
 - build/*
 - scripts/**/*
+- '**/*.m4'
+- '**/*.w32'
 
 "Extension: bcmath":
 - ext/bcmath/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,10 +5,14 @@
 - Zend/Optimizer/**/*
 
 "Category: Build System":
-- build/*
-- scripts/**/*
 - '**/*.m4'
 - '**/*.w32'
+- build/**/*
+- buildconf
+- buildconf.bat
+- configure.ac
+- scripts/**/*
+- win32/build/**/*
 
 "Extension: bcmath":
 - ext/bcmath/**/*


### PR DESCRIPTION
Currently in #11427  it keeps removing the build system labels, even though all m4 files, and w32 files for that matter are build system related