### PR TITLE
SKIP_(SLOW|ONLINE)_TESTS

### DIFF
--- a/ext/sockets/tests/socket_shutdown-win32.phpt
+++ b/ext/sockets/tests/socket_shutdown-win32.phpt
@@ -10,6 +10,13 @@ sockets
 if(substr(PHP_OS, 0, 3) != 'WIN' ) {
     die('skip windows only test');
 }
+if (getenv("SKIP_SLOW_TESTS")) {
+    die("skip slow test");
+}
+if (getenv("SKIP_ONLINE_TESTS")) {
+    die("skip online test");
+}
+
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
it was missing the SKIP_ONLINE_TESTS check.

also not sure what qualifies as SLOW, but wouldn't surprise me if making a remote TCP connection (with the associated TCP handshake round-trip, https://networkengineering.stackexchange.com/a/76369 ) to yahoo.com qualifies as slow?