### PR TITLE
run-tests.php fixes

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -683,8 +683,8 @@ function main(): void
     $environment['TEST_PHP_EXECUTABLE_ESCAPED'] = escapeshellarg($php);
     putenv("TEST_PHP_CGI_EXECUTABLE=$php_cgi");
     $environment['TEST_PHP_CGI_EXECUTABLE'] = $php_cgi;
-    putenv("TEST_PHP_CGI_EXECUTABLE_ESCAPED=" . escapeshellarg($php_cgi));
-    $environment['TEST_PHP_CGI_EXECUTABLE_ESCAPED'] = escapeshellarg($php_cgi);
+    putenv("TEST_PHP_CGI_EXECUTABLE_ESCAPED=" . escapeshellarg($php_cgi ?? ''));
+    $environment['TEST_PHP_CGI_EXECUTABLE_ESCAPED'] = escapeshellarg($php_cgi ?? '');
     putenv("TEST_PHPDBG_EXECUTABLE=$phpdbg");
     $environment['TEST_PHPDBG_EXECUTABLE'] = $phpdbg;
     putenv("TEST_PHPDBG_EXECUTABLE_ESCAPED=" . escapeshellarg($phpdbg ?? ''));


### PR DESCRIPTION
if php was compiled with
`./configure --disable-cgi --enable-cli`
then this would happen previously:

>PHP Deprecated:  escapeshellarg(): Passing null to parameter https://github.com/php/php-src/pull/1 ($arg) of type string is deprecated in /home/hans/projects/php-src/run-tests.php on line 687
>PHP Deprecated:  escapeshellarg(): Passing null to parameter https://github.com/php/php-src/pull/1 ($arg) of type string is deprecated in /home/hans/projects/php-src/run-tests.php on line 688

also did some miscellaneous fixes/improvements, for example 
```
$pass_options .= " -d opcache.preload=" . $preload_filename;
```
would fail if `$preload_filename` had whitespace in it.
and replaced some regex-number-checks with FILTER_VALIDATE_INT.
and fixed an issue where command-line-arguments were escaped with addslashes() instead of escapeshellarg()
(btw i have issues with escapeshellarg() which you can read more about here https://github.com/divinity76/phpquoteshellarg , but i don't intend to address that issue in this PR)