### PR TITLE
support running testsuite with negative niceness

### DIFF
--- a/ext/standard/tests/general_functions/proc_nice_basic.phpt
+++ b/ext/standard/tests/general_functions/proc_nice_basic.phpt
@@ -19,7 +19,7 @@ if ($exit_code !== 0) {
     function getNice($id)
     {
         $res = shell_exec('ps -p ' . $id .' -o "pid,nice"');
-        preg_match('/^\s*\w+\s+\w+\s*(\d+)\s+(\d+)/m', $res, $matches);
+        preg_match('/^\s*\w+\s+\w+\s*(\d+)\s+(\\-?\d+)/m', $res, $matches);
         if (count($matches) > 2)
             return $matches[2];
         else

--- a/ext/standard/tests/general_functions/proc_nice_basic.phpt
+++ b/ext/standard/tests/general_functions/proc_nice_basic.phpt
@@ -19,7 +19,7 @@ if ($exit_code !== 0) {
     function getNice($id)
     {
         $res = shell_exec('ps -p ' . $id .' -o "pid,nice"');
-        preg_match('/^\s*\w+\s+\w+\s*(\d+)\s+(\\-?\d+)/m', $res, $matches);
+        preg_match('/^\s*\w+\s+\w+\s*(\d+)\s+(-?\d+)/m', $res, $matches);
         if (count($matches) > 2)
             return $matches[2];
         else


### PR DESCRIPTION
a bug in the regex would break getNice() if the current niceness was negative, which would make the whole test fail.

Previously:
this would fail:
time sudo nice --adjustment=-19 ./php run-tests.php -j$(nproc) -x --offline ext/standard/tests/general_functions/proc_nice_basic.phpt --color --show-all

and this would work: 
time sudo ./php run-tests.php -j$(nproc) -x --offline ext/standard/tests/general_functions/proc_nice_basic.phpt --color --show-all

now they both work.