### PR TITLE
number_format() Support rounding negative places

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1030,8 +1030,8 @@ PHPAPI zend_string *_php_math_number_format_ex(double d, int dec, const char *de
 		d = -d;
 	}
 
-	dec = MAX(0, dec);
 	d = _php_math_round(d, dec, PHP_ROUND_HALF_UP);
+	dec = MAX(0, dec);
 	tmpbuf = strpprintf(0, "%.*F", dec, d);
 	if (tmpbuf == NULL) {
 		return NULL;

--- a/ext/standard/tests/math/number_format_decimals.phpt
+++ b/ext/standard/tests/math/number_format_decimals.phpt
@@ -1,0 +1,151 @@
+--TEST--
+Test number_format() - test function with different decimal places
+--FILE--
+<?php
+$values = array(
+    1.5151,
+    15.151,
+    151.51,
+    1515.1,
+    15151,
+    -1.5151,
+    -15.151,
+    -151.51,
+    -1515.1,
+    -15151
+);
+
+$decimals = array(0, 1, 2, 3, 4, 5, -1, -2, -3, -4, -5);
+
+foreach ($values as $value) {
+    echo 'testing ';
+    var_dump($value);
+
+    foreach ($decimals as $decimal) {
+        echo '... with decimal places of ' . $decimal . ': ';
+        var_dump(number_format($value, $decimal));
+    }
+}
+
+?>
+--EXPECT--
+testing float(1.5151)
+... with decimal places of 0: string(1) "2"
+... with decimal places of 1: string(3) "1.5"
+... with decimal places of 2: string(4) "1.52"
+... with decimal places of 3: string(5) "1.515"
+... with decimal places of 4: string(6) "1.5151"
+... with decimal places of 5: string(7) "1.51510"
+... with decimal places of -1: string(1) "0"
+... with decimal places of -2: string(1) "0"
+... with decimal places of -3: string(1) "0"
+... with decimal places of -4: string(1) "0"
+... with decimal places of -5: string(1) "0"
+testing float(15.151)
+... with decimal places of 0: string(2) "15"
+... with decimal places of 1: string(4) "15.2"
+... with decimal places of 2: string(5) "15.15"
+... with decimal places of 3: string(6) "15.151"
+... with decimal places of 4: string(7) "15.1510"
+... with decimal places of 5: string(8) "15.15100"
+... with decimal places of -1: string(2) "20"
+... with decimal places of -2: string(1) "0"
+... with decimal places of -3: string(1) "0"
+... with decimal places of -4: string(1) "0"
+... with decimal places of -5: string(1) "0"
+testing float(151.51)
+... with decimal places of 0: string(3) "152"
+... with decimal places of 1: string(5) "151.5"
+... with decimal places of 2: string(6) "151.51"
+... with decimal places of 3: string(7) "151.510"
+... with decimal places of 4: string(8) "151.5100"
+... with decimal places of 5: string(9) "151.51000"
+... with decimal places of -1: string(3) "150"
+... with decimal places of -2: string(3) "200"
+... with decimal places of -3: string(1) "0"
+... with decimal places of -4: string(1) "0"
+... with decimal places of -5: string(1) "0"
+testing float(1515.1)
+... with decimal places of 0: string(5) "1,515"
+... with decimal places of 1: string(7) "1,515.1"
+... with decimal places of 2: string(8) "1,515.10"
+... with decimal places of 3: string(9) "1,515.100"
+... with decimal places of 4: string(10) "1,515.1000"
+... with decimal places of 5: string(11) "1,515.10000"
+... with decimal places of -1: string(5) "1,520"
+... with decimal places of -2: string(5) "1,500"
+... with decimal places of -3: string(5) "2,000"
+... with decimal places of -4: string(1) "0"
+... with decimal places of -5: string(1) "0"
+testing int(15151)
+... with decimal places of 0: string(6) "15,151"
+... with decimal places of 1: string(8) "15,151.0"
+... with decimal places of 2: string(9) "15,151.00"
+... with decimal places of 3: string(10) "15,151.000"
+... with decimal places of 4: string(11) "15,151.0000"
+... with decimal places of 5: string(12) "15,151.00000"
+... with decimal places of -1: string(6) "15,150"
+... with decimal places of -2: string(6) "15,200"
+... with decimal places of -3: string(6) "15,000"
+... with decimal places of -4: string(6) "20,000"
+... with decimal places of -5: string(1) "0"
+testing float(-1.5151)
+... with decimal places of 0: string(2) "-2"
+... with decimal places of 1: string(4) "-1.5"
+... with decimal places of 2: string(5) "-1.52"
+... with decimal places of 3: string(6) "-1.515"
+... with decimal places of 4: string(7) "-1.5151"
+... with decimal places of 5: string(8) "-1.51510"
+... with decimal places of -1: string(1) "0"
+... with decimal places of -2: string(1) "0"
+... with decimal places of -3: string(1) "0"
+... with decimal places of -4: string(1) "0"
+... with decimal places of -5: string(1) "0"
+testing float(-15.151)
+... with decimal places of 0: string(3) "-15"
+... with decimal places of 1: string(5) "-15.2"
+... with decimal places of 2: string(6) "-15.15"
+... with decimal places of 3: string(7) "-15.151"
+... with decimal places of 4: string(8) "-15.1510"
+... with decimal places of 5: string(9) "-15.15100"
+... with decimal places of -1: string(3) "-20"
+... with decimal places of -2: string(1) "0"
+... with decimal places of -3: string(1) "0"
+... with decimal places of -4: string(1) "0"
+... with decimal places of -5: string(1) "0"
+testing float(-151.51)
+... with decimal places of 0: string(4) "-152"
+... with decimal places of 1: string(6) "-151.5"
+... with decimal places of 2: string(7) "-151.51"
+... with decimal places of 3: string(8) "-151.510"
+... with decimal places of 4: string(9) "-151.5100"
+... with decimal places of 5: string(10) "-151.51000"
+... with decimal places of -1: string(4) "-150"
+... with decimal places of -2: string(4) "-200"
+... with decimal places of -3: string(1) "0"
+... with decimal places of -4: string(1) "0"
+... with decimal places of -5: string(1) "0"
+testing float(-1515.1)
+... with decimal places of 0: string(6) "-1,515"
+... with decimal places of 1: string(8) "-1,515.1"
+... with decimal places of 2: string(9) "-1,515.10"
+... with decimal places of 3: string(10) "-1,515.100"
+... with decimal places of 4: string(11) "-1,515.1000"
+... with decimal places of 5: string(12) "-1,515.10000"
+... with decimal places of -1: string(6) "-1,520"
+... with decimal places of -2: string(6) "-1,500"
+... with decimal places of -3: string(6) "-2,000"
+... with decimal places of -4: string(1) "0"
+... with decimal places of -5: string(1) "0"
+testing int(-15151)
+... with decimal places of 0: string(7) "-15,151"
+... with decimal places of 1: string(9) "-15,151.0"
+... with decimal places of 2: string(10) "-15,151.00"
+... with decimal places of 3: string(11) "-15,151.000"
+... with decimal places of 4: string(12) "-15,151.0000"
+... with decimal places of 5: string(13) "-15,151.00000"
+... with decimal places of -1: string(7) "-15,150"
+... with decimal places of -2: string(7) "-15,200"
+... with decimal places of -3: string(7) "-15,000"
+... with decimal places of -4: string(7) "-20,000"
+... with decimal places of -5: string(1) "0"

--- a/ext/standard/tests/math/number_format_negative_zero.phpt
+++ b/ext/standard/tests/math/number_format_negative_zero.phpt
@@ -4,28 +4,13 @@ Prevent number_format from returning negative zero
 <?php
 
 $number = -1.15E-15;
+
 var_dump($number);
 var_dump(number_format($number, 2));
-
-$number = -0.01;
-var_dump($number);
-var_dump(number_format($number, 2));
-
-$number = -1234567.89;
-var_dump($number);
-var_dump(number_format($number, -3));
-
-$number = -1234321.09;
-var_dump($number);
-var_dump(number_format($number, -3));
+var_dump(number_format(-0.01, 2));
 
 ?>
 --EXPECT--
 float(-1.15E-15)
 string(4) "0.00"
-float(-0.01)
 string(5) "-0.01"
-float(-1234567.89)
-string(10) "-1,235,000"
-float(-1234321.09)
-string(10) "-1,234,000"

--- a/ext/standard/tests/math/number_format_negative_zero.phpt
+++ b/ext/standard/tests/math/number_format_negative_zero.phpt
@@ -4,13 +4,28 @@ Prevent number_format from returning negative zero
 <?php
 
 $number = -1.15E-15;
-
 var_dump($number);
 var_dump(number_format($number, 2));
-var_dump(number_format(-0.01, 2));
+
+$number = -0.01;
+var_dump($number);
+var_dump(number_format($number, 2));
+
+$number = -1234567.89;
+var_dump($number);
+var_dump(number_format($number, -3));
+
+$number = -1234321.09;
+var_dump($number);
+var_dump(number_format($number, -3));
 
 ?>
 --EXPECT--
 float(-1.15E-15)
 string(4) "0.00"
+float(-0.01)
 string(5) "-0.01"
+float(-1234567.89)
+string(10) "-1,235,000"
+float(-1234321.09)
+string(10) "-1,234,000"


### PR DESCRIPTION
This PR adds support for rounding negative `$decimals` in `number_format()`.

Previously negative `$decimals` got silently ignored and the number got rounded to zero decimal places.
With this change, when `$decimals` is negative, `$num` is rounded to `$decimals` significant digits before the decimal point.

This is matching the behavior for the `$precision` argument of `round()`.

The previous behavior wasn't documented or tested at all.