### PR TITLE
Fixing pdo_sqlite bug_42589.phpt

### DIFF
--- a/ext/pdo_sqlite/tests/bug_42589.phpt
+++ b/ext/pdo_sqlite/tests/bug_42589.phpt
@@ -3,6 +3,13 @@ PDO SQLite Feature Request #42589 (getColumnMeta() should also return table name
 --EXTENSIONS--
 pdo
 pdo_sqlite
+--SKIPIF--
+<?php
+$db = new PDO("sqlite::memory:");
+$options = $db->query('PRAGMA compile_options')->fetchAll(PDO::FETCH_COLUMN);
+if(!in_array('ENABLE_COLUMN_METADATA', $options, true))
+    die("skip sqlite3 must be compiled with SQLITE_ENABLE_COLUMN_METADATA");
+?>
 --FILE--
 <?php
 $db = new PDO("sqlite::memory:");


### PR DESCRIPTION
Fixing `ext/pdo_sqlite/tests/bug_42589.phpt` test when ENABLE_COLUMN_METADATA is disabled.

Fixes #11492 