### PR TITLE
check PQsetErrorContextVisibility availability (libpq >= 9.6)

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -219,7 +219,8 @@ PHP 8.3 UPGRADE NOTES
   . Added posix_eaccess call to check the effective user id's permission for a path.
 
 - PGSQL:
-  . Added pg_set_error_context_visilibity to set the visibility of the context in error messages.
+  . Added pg_set_error_context_visilibity to set the visibility of the context
+    in error messages (with libpq >= 9.6).
 
 - Random:
   . Added Randomizer::getBytesFromString().

--- a/ext/pgsql/config.m4
+++ b/ext/pgsql/config.m4
@@ -65,6 +65,7 @@ if test "$PHP_PGSQL" != "no"; then
   AC_CHECK_LIB(pq, PQlibVersion,, AC_MSG_ERROR([Unable to build the PostgreSQL extension: at least libpq 9.1 is required]))
   AC_CHECK_LIB(pq, pg_encoding_to_char,AC_DEFINE(HAVE_PGSQL_WITH_MULTIBYTE_SUPPORT,1,[Whether libpq is compiled with --enable-multibyte]))
   AC_CHECK_LIB(pq, lo_truncate64, AC_DEFINE(HAVE_PG_LO64,1,[PostgreSQL 9.3 or later]))
+  AC_CHECK_LIB(pq, PQsetErrorContextVisibility, AC_DEFINE(HAVE_PG_CONTEXT_VISIBILITY,1,[PostgreSQL 9.6 or later]))
   LIBS=$old_LIBS
   LDFLAGS=$old_LDFLAGS
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -2834,6 +2834,7 @@ PHP_FUNCTION(pg_set_error_verbosity)
 }
 /* }}} */
 
+#ifdef HAVE_PG_CONTEXT_VISIBILITY
 PHP_FUNCTION(pg_set_error_context_visibility)
 {
 	zval *pgsql_link = NULL;
@@ -2856,6 +2857,7 @@ PHP_FUNCTION(pg_set_error_context_visibility)
 		RETURN_THROWS();
 	}
 }
+#endif
 
 /* {{{ Set client encoding */
 PHP_FUNCTION(pg_set_client_encoding)

--- a/ext/pgsql/pgsql.stub.php
+++ b/ext/pgsql/pgsql.stub.php
@@ -463,6 +463,7 @@ namespace {
     const PGSQL_PIPELINE_ABORTED = UNKNOWN;
 #endif
     
+#ifdef HAVE_PG_CONTEXT_VISIBILITY
     /* For pg_set_error_context_visibility() */
 
     /**
@@ -480,7 +481,7 @@ namespace {
      * @cvalue PQSHOW_CONTEXT_ALWAYS
      */
     const PGSQL_SHOW_CONTEXT_ALWAYS = UNKNOWN;
-    
+#endif
 
     function pg_connect(string $connection_string, int $flags = 0): PgSql\Connection|false {}
 
@@ -971,7 +972,9 @@ namespace {
     function pg_pipeline_status(PgSql\Connection $connection): int {}
 #endif
 
+#ifdef HAVE_PG_CONTEXT_VISIBILITY
     function pg_set_error_context_visibility(PgSql\Connection $connection, int $visibility): int {}
+#endif
 }
 
 namespace PgSql {

--- a/ext/pgsql/pgsql_arginfo.h
+++ b/ext/pgsql/pgsql_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a37be19da43ac0838655b0ba7e34382e9c7424f5 */
+ * Stub hash: fb57575ac2153c888b95c18a7bf6d6a7e200f5dc */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_pg_connect, 0, 1, PgSql\\Connection, MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, connection_string, IS_STRING, 0)
@@ -472,10 +472,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_pipeline_status, 0, 1, IS_LON
 ZEND_END_ARG_INFO()
 #endif
 
+#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_pg_set_error_context_visibility, 0, 2, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO(0, connection, PgSql\\Connection, 0)
 	ZEND_ARG_TYPE_INFO(0, visibility, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+#endif
 
 
 ZEND_FUNCTION(pg_connect);
@@ -579,7 +581,9 @@ ZEND_FUNCTION(pg_pipeline_sync);
 #if defined(LIBPQ_HAS_PIPELINING)
 ZEND_FUNCTION(pg_pipeline_status);
 #endif
+#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 ZEND_FUNCTION(pg_set_error_context_visibility);
+#endif
 
 
 static const zend_function_entry ext_functions[] = {
@@ -709,7 +713,9 @@ static const zend_function_entry ext_functions[] = {
 #if defined(LIBPQ_HAS_PIPELINING)
 	ZEND_FE(pg_pipeline_status, arginfo_pg_pipeline_status)
 #endif
+#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	ZEND_FE(pg_set_error_context_visibility, arginfo_pg_set_error_context_visibility)
+#endif
 	ZEND_FE_END
 };
 
@@ -842,9 +848,15 @@ static void register_pgsql_symbols(int module_number)
 #if defined(LIBPQ_HAS_PIPELINING)
 	REGISTER_LONG_CONSTANT("PGSQL_PIPELINE_ABORTED", PQ_PIPELINE_ABORTED, CONST_PERSISTENT);
 #endif
+#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_NEVER", PQSHOW_CONTEXT_NEVER, CONST_PERSISTENT);
+#endif
+#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ERRORS", PQSHOW_CONTEXT_ERRORS, CONST_PERSISTENT);
+#endif
+#if defined(HAVE_PG_CONTEXT_VISIBILITY)
 	REGISTER_LONG_CONSTANT("PGSQL_SHOW_CONTEXT_ALWAYS", PQSHOW_CONTEXT_ALWAYS, CONST_PERSISTENT);
+#endif
 }
 
 static zend_class_entry *register_class_PgSql_Connection(void)

--- a/ext/pgsql/tests/07optional.phpt
+++ b/ext/pgsql/tests/07optional.phpt
@@ -21,9 +21,11 @@ if (function_exists('pg_set_error_verbosity')) {
     pg_set_error_verbosity($db, PGSQL_ERRORS_VERBOSE);
     pg_set_error_verbosity($db, PGSQL_ERRORS_SQLSTATE);
 }
-pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_NEVER);
-pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ERRORS);
-pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ALWAYS);
+if (function_exists('pg_set_error_context_visibility')) {
+    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_NEVER);
+    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ERRORS);
+    pg_set_error_context_visibility($db, PGSQL_SHOW_CONTEXT_ALWAYS);
+}
 echo "OK";
 ?>
 --EXPECT--


### PR DESCRIPTION
Introduced in pr #11395 

`PQsetErrorContextVisibility` was introduced in **9.6**

Minimal supported version is **9.1**

Notice: RHEL/CentOS 7 (and clones) still have 9.2 and will be EOL in ~1 year

