### PR TITLE
Fix arm build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ freebsd_task:
 arm_task:
   name: ARM_DEBUG_NTS
   arm_container:
-    image: gcc:10
+    image: debian:11
     additional_containers:
       - name: mysql
         image: mysql:8
@@ -52,6 +52,9 @@ arm_task:
     - apt-get update -y
     - >-
         apt-get install -y
+        gcc
+        g++
+        autoconf
         bison
         re2c
         locales
@@ -68,6 +71,7 @@ arm_task:
         libsasl2-dev
         libxpm-dev
         libzip-dev
+        libbz2-dev
         libsqlite3-dev
         libwebp-dev
         libonig-dev


### PR DESCRIPTION
Switch to debian base image. The gcc image upgraded to debian bookworm which broke the build.

https://github.com/docker-library/gcc/commit/392d8bf4ee9d494f03331c540c1f0d7f32259ff1