### PR TITLE
Fix GH-11408: Unable to build PHP 8.3.0 alpha 1 / fileinfo extension

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.3.0alpha3
 
+- Fileinfo:
+  . Fix GH-11408 (Unable to build PHP 8.3.0 alpha 1 / fileinfo extension).
+    (nielsdos)
+
 - MBString:
   . Implement mb_str_pad() RFC. (nielsdos)
 

--- a/ext/fileinfo/fileinfo.c
+++ b/ext/fileinfo/fileinfo.c
@@ -14,6 +14,9 @@
   +----------------------------------------------------------------------+
 */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include "php.h"
 
 #include "libmagic/magic.h"


### PR DESCRIPTION
On some configurations, the COMPILE_DL_FILEINFO must come from the config.h file. If the COMPILE_DL_FILEINFO macro is not set, the build won't include the ZEND_GET_MODULE block necessary for building this extension as a shared object.

EDIT: FWIW, it's confirmed that this fixed the issue for the issue reporter.