### PR TITLE
Fix GH-11507: String concatenation performance regression in 8.3

### DIFF
--- a/Zend/zend_operators.c
+++ b/Zend/zend_operators.c
@@ -2057,16 +2057,17 @@ has_op2_string:;
 		}
 
 		if (result == op1) {
-			/* special case, perform operations on result */
-			result_str = zend_string_extend(op1_string, result_len, 0);
-			/* Free result after zend_string_extend(), as it may throw an out-of-memory error. If we
-			 * free it before we would leave the released variable on the stack with shutdown trying
-			 * to free it again. */
+			/* Extend first to drop the refcount, such that $x .= ...; may happen in-place. */
 			if (free_op1_string) {
 				/* op1_string will be used as the result, so we should not free it */
 				i_zval_ptr_dtor(result);
+				/* Set it to NULL in case that the extension will cause an out-of-memory error.
+				 * Otherwise the shutdown sequence will try to free this again. */
+				ZVAL_NULL(result);
 				free_op1_string = false;
 			}
+			/* special case, perform operations on result */
+			result_str = zend_string_extend(op1_string, result_len, 0);
 			/* account for the case where result_str == op1_string == op2_string and the realloc is done */
 			if (op1_string == op2_string) {
 				if (free_op2_string) {


### PR DESCRIPTION
When the code was moved to solve the uaf for memory overflow, this caused the refcount to be higher than one in some self-concatenation scenarios. This in turn causes quadratic time performance problems when these concatenations happen in a loop.