### PR TITLE
Fix interrupted CLI output causing the process to exit

### DIFF
--- a/sapi/cli/php_cli.c
+++ b/sapi/cli/php_cli.c
@@ -262,7 +262,7 @@ PHP_CLI_API ssize_t sapi_cli_single_write(const char *str, size_t str_length) /*
 #ifdef PHP_WRITE_STDOUT
 	do {
 		ret = write(STDOUT_FILENO, str, str_length);
-	} while (ret <= 0 && errno == EAGAIN && sapi_cli_select(STDOUT_FILENO));
+	} while (ret <= 0 && (errno == EINTR || (errno == EAGAIN && sapi_cli_select(STDOUT_FILENO))));
 #else
 	ret = fwrite(str, 1, MIN(str_length, 16384), stdout);
 	if (ret == 0 && ferror(stdout)) {


### PR DESCRIPTION
When writing the output in the CLI is interrupted by a signal, the writing will fail in sapi_cli_single_write(), causing an exit later in sapi_cli_ub_write(). This was the other part of the issue in GH-11498. The solution is to restart the write if an EINTR has been observed.