### PR TITLE
Fix GH-11520: Test fails due to compatibility issue with libzip 1.10.0

### DIFF
--- a/ext/zip/tests/oo_getstreamindex.phpt
+++ b/ext/zip/tests/oo_getstreamindex.phpt
@@ -34,7 +34,11 @@ fclose($fp);
 
 echo "== Index, changed\n";
 $fp = $zip->getStreamIndex(1);
-var_dump($zip->status);
+if (version_compare(ZipArchive::LIBZIP_VERSION, "1.10.0", "<")) {
+    var_dump($zip->status === 15);
+} else {
+    var_dump($zip->status === 0);
+}
 $zip->clearError();
 
 echo "== Index, unchanged\n";
@@ -60,7 +64,7 @@ string(3) "foo"
 int(0)
 string(3) "foo"
 == Index, changed
-int(15)
+bool(true)
 == Index, unchanged
 int(0)
 string(3) "bar"


### PR DESCRIPTION
In libzip versions prior to 1.10.0, you couldn't do a read for a changed file: this would result in an error. This is tested in our .phpt test. Starting from version 1.10.0 [1] this is no longer an error. Therefore, we amend the test to check the behaviour depending on which version is used.

[1] https://github.com/nih-at/libzip/pull/286

Closes GH-11520