### PR TITLE
Fix OSS-Fuzz 60011: Incorrect order of instruction with nullsafe operator

### DIFF
--- a/Zend/tests/oss_fuzz_60011.phpt
+++ b/Zend/tests/oss_fuzz_60011.phpt
@@ -1,0 +1,11 @@
+--TEST--
+OSS-Fuzz 60011 (Incorrect order of instruction with nullsafe operator)
+--FILE--
+<?php
+[&$y]=$y->y?->y;
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Attempt to modify property "y" on null in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -2891,16 +2891,16 @@ static zend_op *zend_delayed_compile_prop(znode *result, zend_ast *ast, uint32_t
 		opline = zend_delayed_compile_var(&obj_node, obj_ast, type, 0);
 		zend_separate_if_call_and_write(&obj_node, obj_ast, type);
 		if (nullsafe) {
-			if (obj_node.op_type == IS_TMP_VAR) {
+			if (obj_node.op_type & (IS_TMP_VAR | IS_VAR)) {
 				/* Flush delayed oplines */
 				zend_op *opline = NULL, *oplines = zend_stack_base(&CG(delayed_oplines_stack));
 				uint32_t var = obj_node.u.op.var;
 				uint32_t count = zend_stack_count(&CG(delayed_oplines_stack));
 				uint32_t i = count;
 
-				while (i > 0 && oplines[i-1].result_type == IS_TMP_VAR && oplines[i-1].result.var == var) {
+				while (i > 0 && oplines[i-1].result_type & (IS_TMP_VAR | IS_VAR) && oplines[i-1].result.var == var) {
 					i--;
-					if (oplines[i].op1_type == IS_TMP_VAR) {
+					if (oplines[i].op1_type & (IS_TMP_VAR | IS_VAR)) {
 						var = oplines[i].op1.var;
 					} else {
 						break;


### PR DESCRIPTION
The order of the emitted operation was incorrectly:
```
  V2 = JMP_NULL V1 0003
  V1 = FETCH_OBJ_W CV0($y) string("y")
```

This is because only TMP_VAR is handled in the delayed opcode flushing. We should also flush VARs.

After this patch the order becomes correct:
```
  V1 = FETCH_OBJ_W CV0($y) string("y")
  V2 = JMP_NULL V1 0003
```

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60011&sort=-opened&can=1&q=proj%3Aphp

----------

I'm not entirely sure, I haven't done much with the compiler yet; but I'm happy to learn more about it :)