### PR TITLE
Fix Autoconf check for development versions

### DIFF
--- a/buildconf
+++ b/buildconf
@@ -81,7 +81,7 @@ echo "buildconf: Checking installation"
 min_version=$(sed -n 's/AC_PREREQ(\[\(.*\)\])/\1/p' configure.ac)
 
 # Check if autoconf exists.
-ac_version=$($PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[a-z]* *$//')
+ac_version=$($PHP_AUTOCONF --version 2>/dev/null|head -n 1|sed -e 's/^[^0-9]*//' -e 's/[^0-9.]*$//')
 
 if test -z "$ac_version"; then
   echo "buildconf: autoconf not found." >&2


### PR DESCRIPTION
When Autoconf version includes also development patch character (for example, `2.72c`), such as in unreleased Autoconf versions, this now sets proper number for checking minimum required Autoconf version.

Found at #11427