### PR TITLE
Remove the link to the custom bugs tracker from the new issue window

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Documentation issue
     url: https://github.com/php/doc-en/issues
     about: Please report documentation issues on the doc-en repository.
-  - name: Security issue
-    url: https://bugs.php.net/report.php?security_bug
-    about: Please report security issues in this private bug tracker.


### PR DESCRIPTION
Side PR related to https://github.com/php/web-bugs/pull/115. If we stop using bugs.php.net for security reports we don't need the link to it on the new issue template.

Screenshot is what the new issue window currently looks like. The third option already links to the security advisories on Github, so the 5th option is obsolete.

<img width="1189" alt="Screenshot 2023-06-26 at 15 33 31" src="https://github.com/php/php-src/assets/24303072/3f167046-ccb1-4cbd-9e5e-83ec6cc3efc6">
