### PR TITLE
Avoid allocations when getting content of DOM nodes if possible

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -121,21 +121,23 @@ PHP 8.3 INTERNALS UPGRADE NOTES
      properties in a read-only way. This function avoids allocation when there are
      no document properties changed yet.
    - The node list returned by DOMNode::getElementsByTagName() and
-	 DOMNode::getElementsByTagNameNS() now caches the length and the last requested item.
-	 This means that the length and the last requested item are not recalculated
-	 when the node list is iterated over multiple times.
-	 If you do not use the internal PHP dom APIs to modify the document, you need to
-	 manually invalidate the cache using php_libxml_invalidate_node_list_cache_from_doc().
-	 Furthermore, the following internal APIs were added to handle the cache:
-	   . php_dom_is_cache_tag_stale_from_doc_ptr()
-	   . php_dom_is_cache_tag_stale_from_node()
-	   . php_dom_mark_cache_tag_up_to_date_from_node()
+	   DOMNode::getElementsByTagNameNS() now caches the length and the last requested item.
+	   This means that the length and the last requested item are not recalculated
+	   when the node list is iterated over multiple times.
+	   If you do not use the internal PHP dom APIs to modify the document, you need to
+	   manually invalidate the cache using php_libxml_invalidate_node_list_cache_from_doc().
+	   Furthermore, the following internal APIs were added to handle the cache:
+	     . php_dom_is_cache_tag_stale_from_doc_ptr()
+	     . php_dom_is_cache_tag_stale_from_node()
+	     . php_dom_mark_cache_tag_up_to_date_from_node()
    - The function dom_get_elements_by_tag_name_ns_raw() has an additional parameter to indicate
      the base node of the node list. This function also no longer accepts -1 as the index argument.
    - The function dom_namednode_iter() has additional arguments to avoid recomputing the length of
      the strings.
    - The functions dom_parent_node_prepend(), dom_parent_node_append(), dom_parent_node_after(), and
      dom_parent_node_before() now use an uint32_t argument for the number of nodes instead of int.
+   - There is now a helper function php_dom_get_content_into_zval() to get the conetnts of a node.
+     This avoids allocation if possible.
 
  g. ext/libxml
    - Two new functions: php_libxml_invalidate_node_list_cache_from_doc() and

--- a/ext/dom/attr.c
+++ b/ext/dom/attr.c
@@ -121,6 +121,7 @@ int dom_attr_value_read(dom_object *obj, zval *retval)
 		return FAILURE;
 	}
 
+	/* Can't avoid a content copy because it's an attribute node */
 	if ((content = xmlNodeGetContent((xmlNodePtr) attrp)) != NULL) {
 		ZVAL_STRING(retval, (char *) content);
 		xmlFree(content);

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -140,7 +140,7 @@ int dom_node_node_value_read(dom_object *obj, zval *retval)
 		case XML_PI_NODE:
 			php_dom_get_content_into_zval(nodep, retval, true);
 			break;
-		case XML_NAMESPACE_DECL:
+		case XML_NAMESPACE_DECL: {
 			char *str = (char *) xmlNodeGetContent(nodep->children);
 			if (str != NULL) {
 				ZVAL_STRING(retval, str);
@@ -149,6 +149,7 @@ int dom_node_node_value_read(dom_object *obj, zval *retval)
 				ZVAL_NULL(retval);
 			}
 			break;
+		}
 		default:
 			ZVAL_NULL(retval);
 			break;

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -124,7 +124,6 @@ Since:
 int dom_node_node_value_read(dom_object *obj, zval *retval)
 {
 	xmlNode *nodep = dom_object_get_node(obj);
-	char *str = NULL;
 
 	if (nodep == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
@@ -139,25 +138,23 @@ int dom_node_node_value_read(dom_object *obj, zval *retval)
 		case XML_COMMENT_NODE:
 		case XML_CDATA_SECTION_NODE:
 		case XML_PI_NODE:
-			str = (char *) xmlNodeGetContent(nodep);
+			php_dom_get_content_into_zval(nodep, retval, true);
 			break;
 		case XML_NAMESPACE_DECL:
-			str = (char *) xmlNodeGetContent(nodep->children);
+			char *str = (char *) xmlNodeGetContent(nodep->children);
+			if (str != NULL) {
+				ZVAL_STRING(retval, str);
+				xmlFree(str);
+			} else {
+				ZVAL_NULL(retval);
+			}
 			break;
 		default:
-			str = NULL;
+			ZVAL_NULL(retval);
 			break;
-	}
-
-	if(str != NULL) {
-		ZVAL_STRING(retval, str);
-		xmlFree(str);
-	} else {
-		ZVAL_NULL(retval);
 	}
 
 	return SUCCESS;
-
 }
 
 int dom_node_node_value_write(dom_object *obj, zval *newval)
@@ -733,21 +730,13 @@ Since: DOM Level 3
 int dom_node_text_content_read(dom_object *obj, zval *retval)
 {
 	xmlNode *nodep = dom_object_get_node(obj);
-	char *str = NULL;
 
 	if (nodep == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
 		return FAILURE;
 	}
 
-	str = (char *) xmlNodeGetContent(nodep);
-
-	if (str != NULL) {
-		ZVAL_STRING(retval, str);
-		xmlFree(str);
-	} else {
-		ZVAL_EMPTY_STRING(retval);
-	}
+	php_dom_get_content_into_zval(nodep, retval, false);
 
 	return SUCCESS;
 }

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1741,6 +1741,39 @@ void dom_remove_all_children(xmlNodePtr nodep)
 	}
 }
 
+void php_dom_get_content_into_zval(const xmlNode *nodep, zval *retval, bool default_is_null)
+{
+	ZEND_ASSERT(nodep != NULL);
+
+	if (nodep->type == XML_TEXT_NODE
+		|| nodep->type == XML_CDATA_SECTION_NODE
+		|| nodep->type == XML_PI_NODE
+		|| nodep->type == XML_COMMENT_NODE) {
+		char *str = (char * ) nodep->content;
+		if (str != NULL) {
+			ZVAL_STRING(retval, str);
+		} else {
+			goto failure;
+		}
+		return;
+	}
+
+	char *str = (char *) xmlNodeGetContent(nodep);
+
+	if (str != NULL) {
+		ZVAL_STRING(retval, str);
+		xmlFree(str);
+		return;
+	}
+
+failure:
+	if (default_is_null) {
+		ZVAL_NULL(retval);
+	} else {
+		ZVAL_EMPTY_STRING(retval);
+	}
+}
+
 static zval *dom_nodemap_read_dimension(zend_object *object, zval *offset, int type, zval *rv) /* {{{ */
 {
 	if (UNEXPECTED(!offset)) {

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -147,6 +147,7 @@ xmlNode *php_dom_libxml_notation_iter(xmlHashTable *ht, int index);
 zend_object_iterator *php_dom_get_iterator(zend_class_entry *ce, zval *object, int by_ref);
 void dom_set_doc_classmap(php_libxml_ref_obj *document, zend_class_entry *basece, zend_class_entry *ce);
 xmlNodePtr php_dom_create_fake_namespace_decl(xmlNodePtr nodep, xmlNsPtr original, zval *return_value, dom_object *parent_intern);
+void php_dom_get_content_into_zval(const xmlNode *nodep, zval *target, bool default_is_null);
 
 void dom_parent_node_prepend(dom_object *context, zval *nodes, uint32_t nodesc);
 void dom_parent_node_append(dom_object *context, zval *nodes, uint32_t nodesc);

--- a/ext/dom/processinginstruction.c
+++ b/ext/dom/processinginstruction.c
@@ -93,22 +93,14 @@ Since:
 */
 int dom_processinginstruction_data_read(dom_object *obj, zval *retval)
 {
-	xmlNodePtr nodep;
-	xmlChar *content;
-
-	nodep = dom_object_get_node(obj);
+	xmlNodePtr nodep = dom_object_get_node(obj);
 
 	if (nodep == NULL) {
 		php_dom_throw_error(INVALID_STATE_ERR, 1);
 		return FAILURE;
 	}
 
-	if ((content = xmlNodeGetContent(nodep)) != NULL) {
-		ZVAL_STRING(retval, (char *) content);
-		xmlFree(content);
-	} else {
-		ZVAL_EMPTY_STRING(retval);
-	}
+	php_dom_get_content_into_zval(nodep, retval, false);
 
 	return SUCCESS;
 }

--- a/ext/dom/text.c
+++ b/ext/dom/text.c
@@ -132,7 +132,7 @@ PHP_METHOD(DOMText, splitText)
 		RETURN_FALSE;
 	}
 
-	cur = xmlNodeGetContent(node);
+	cur = node->content;
 	if (cur == NULL) {
 		/* TODO Add warning? */
 		RETURN_FALSE;
@@ -141,14 +141,11 @@ PHP_METHOD(DOMText, splitText)
 
 	if (ZEND_LONG_INT_OVFL(offset) || (int)offset > length) {
 		/* TODO Add warning? */
-		xmlFree(cur);
 		RETURN_FALSE;
 	}
 
 	first = xmlUTF8Strndup(cur, (int)offset);
 	second = xmlUTF8Strsub(cur, (int)offset, (int)(length - offset));
-
-	xmlFree(cur);
 
 	xmlNodeSetContent(node, first);
 	nnode = xmlNewDocText(node->doc, second);


### PR DESCRIPTION
Everytime text content or node value or something alike is requested, it currently allocates memory *twice*: once in getting the data from libxml2, and then allocating a zend_string to copy the data into.
We can very often skip the first allocation. Let's do that because it's actually quite common to get the `textContent` for example from a node when processing documents.

Here's a microbenchmark with time measurements (only for textContent, but for nodeValue etc the result is similar). 
There's no noticeable slowdown because of the extra checks for the cases where we cannot avoid an allocation.
Based on these results I'd say it's worth it:

```php
<?php

$doc = new DOMDocument;
$doc->loadXML('<?xml version="1.0"?><div/>');
$doc->documentElement->append(str_repeat('hello world', 10));
$el = $doc->documentElement->firstChild;

for ($i = 0; $i < 1000000; $i++) {
    $el->textContent;
}
```

Bench results:
```
Benchmark 1: ./sapi/cli/php dom.php
  Time (mean ± σ):      43.1 ms ±   2.2 ms    [User: 40.4 ms, System: 2.6 ms]
  Range (min … max):    40.3 ms …  51.5 ms    62 runs
 
Benchmark 2: ./sapi/cli/php_old dom.php
  Time (mean ± σ):     107.6 ms ±   1.6 ms    [User: 104.5 ms, System: 2.9 ms]
  Range (min … max):   105.4 ms … 112.1 ms    27 runs
 
Summary
  ./sapi/cli/php dom.php ran
    2.50 ± 0.13 times faster than ./sapi/cli/php_old dom.php
```