### PR TITLE
Prevent regex cache reuse when JIT flag does not match php.ini

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -630,17 +630,18 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, in
 	if (zv) {
 		pcre_cache_entry *pce = (pcre_cache_entry*)Z_PTR_P(zv);
 #ifdef HAVE_PCRE_JIT_SUPPORT
-		if ((bool)(pce->preg_options & PREG_JIT_ATTEMPTED) == jit_enabled) {
+		bool recompile = (bool)(pce->preg_options & PREG_JIT_ATTEMPTED) != jit_enabled;
+#else
+		bool recompile = false;
 #endif
+		if (recompile) {
+			zend_hash_del(&PCRE_G(pcre_cache), key);
+		} else {
 			if (key != regex) {
 				zend_string_release_ex(key, 0);
 			}
 			return pce;
-#ifdef HAVE_PCRE_JIT_SUPPORT
-		} else {
-			zend_hash_del(&PCRE_G(pcre_cache), key);
 		}
-#endif
 	}
 
 	p = ZSTR_VAL(regex);

--- a/ext/pcre/tests/gh11374.phpt
+++ b/ext/pcre/tests/gh11374.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-11374 PCRE cache entry must not be reused when PCRE JIT flag has changed
+--SKIPIF--
+<?php
+if (ini_get("pcre.jit") === false) {
+    die("skip no jit built");
+}
+--FILE--
+<?php
+
+// testing if PCRE cache entry was reused or not is not possible from userland, so instead we test
+// if PCRE JIT flag can be cleared and the pcre_match pass
+
+foreach ([true, false, true] as $pcreJit) {
+    ini_set('pcre.jit', $pcreJit ? '1' : '0');
+    var_dump(ini_get('pcre.jit'));
+
+    var_dump(preg_match('/^a(b+)/', 'abbc', $matches));
+    var_dump($matches === ['abb', 'bb']);
+}
+
+?>
+--EXPECT--
+string(1) "1"
+int(1)
+bool(true)
+string(1) "0"
+int(1)
+bool(true)
+string(1) "1"
+int(1)
+bool(true)


### PR DESCRIPTION
Fix #11374, replace #11396 and #11511