### PR TITLE
Add hint-type for `method_exists` & `property_exists`

### DIFF
--- a/Zend/zend_builtin_functions.stub.php
+++ b/Zend/zend_builtin_functions.stub.php
@@ -66,10 +66,10 @@ function get_mangled_object_vars(object $object): array {}
 function get_class_methods(object|string $object_or_class): array {}
 
 /** @param object|string $object_or_class */
-function method_exists($object_or_class, string $method): bool {}
+function method_exists(object|string $object_or_class, string $method): bool {}
 
 /** @param object|string $object_or_class */
-function property_exists($object_or_class, string $property): bool {}
+function property_exists(object|string $object_or_class, string $property): bool {}
 
 function class_exists(string $class, bool $autoload = true): bool {}
 


### PR DESCRIPTION
The `get_class_methods` has a type-hint, but `method_exists` & `property_exists` have no type-hint for `object_or_class` parameters.