### PR TITLE
fpm: enable tcp_info api for OpenBSD.

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -308,7 +308,11 @@ AC_DEFUN([AC_FPM_LQ],
 
   AC_MSG_CHECKING([for TCP_INFO])
 
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netinet/tcp.h>]], [[struct tcp_info ti; int x = TCP_INFO;]])], [
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
+    #include <netinet/tcp.h>
+  ]], [[
+    struct tcp_info ti; int x = TCP_INFO;
+  ]])], [
     have_lq=tcp_info
     AC_MSG_RESULT([yes])
   ], [

--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -539,7 +539,7 @@ int fpm_socket_get_listening_queue(int sock, unsigned *cur_lq, unsigned *max_lq)
 		zlog(ZLOG_SYSERROR, "failed to retrieve TCP_INFO for socket");
 		return -1;
 	}
-#if defined(__FreeBSD__) || defined(__NetBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 	if (info.__tcpi_sacked == 0) {
 		return -1;
 	}


### PR DESCRIPTION
available since two releases, as it is how far back the releases support policy goes.