### PR TITLE
Change the way how lifetimes work in ext/dom

### DIFF
--- a/ext/dom/characterdata.c
+++ b/ext/dom/characterdata.c
@@ -330,15 +330,13 @@ PHP_METHOD(DOMCharacterData, replaceData)
 
 PHP_METHOD(DOMCharacterData, remove)
 {
-	zval *id = ZEND_THIS;
-	xmlNodePtr child;
 	dom_object *intern;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	DOM_GET_OBJ(child, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_child_node_remove(intern);
 	RETURN_NULL();
@@ -347,16 +345,14 @@ PHP_METHOD(DOMCharacterData, remove)
 PHP_METHOD(DOMCharacterData, after)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_after(intern, args, argc);
 }
@@ -364,16 +360,14 @@ PHP_METHOD(DOMCharacterData, after)
 PHP_METHOD(DOMCharacterData, before)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_before(intern, args, argc);
 }
@@ -381,16 +375,14 @@ PHP_METHOD(DOMCharacterData, before)
 PHP_METHOD(DOMCharacterData, replaceWith)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_after(intern, args, argc);
 	dom_child_node_remove(intern);

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -772,18 +772,15 @@ Since:
 */
 PHP_METHOD(DOMDocument, getElementsByTagName)
 {
-	zval *id;
-	xmlDocPtr docp;
 	size_t name_len;
 	dom_object *intern, *namednode;
 	char *name;
 
-	id = ZEND_THIS;
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	DOM_GET_OBJ(docp, id, xmlDocPtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	php_dom_create_iterator(return_value, DOM_NODELIST);
 	namednode = Z_DOMOBJ_P(return_value);
@@ -796,7 +793,7 @@ Since: DOM Level 2
 */
 PHP_METHOD(DOMDocument, importNode)
 {
-	zval *id, *node;
+	zval *node;
 	xmlDocPtr docp;
 	xmlNodePtr nodep, retnodep;
 	dom_object *intern, *nodeobj;
@@ -805,12 +802,11 @@ PHP_METHOD(DOMDocument, importNode)
 	/* See http://www.xmlsoft.org/html/libxml-tree.html#xmlDocCopyNode for meaning of values */
 	int extended_recursive;
 
-	id = ZEND_THIS;
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|b", &node, dom_node_class_entry, &recursive) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	DOM_GET_OBJ(docp, id, xmlDocPtr, intern);
+	DOM_GET_OBJ(docp, ZEND_THIS, xmlDocPtr, intern);
 
 	DOM_GET_OBJ(nodep, node, xmlNodePtr, nodeobj);
 
@@ -982,18 +978,15 @@ Since: DOM Level 2
 */
 PHP_METHOD(DOMDocument, getElementsByTagNameNS)
 {
-	zval *id;
-	xmlDocPtr docp;
 	size_t uri_len, name_len;
 	dom_object *intern, *namednode;
 	char *uri, *name;
 
-	id = ZEND_THIS;
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!s", &uri, &uri_len, &name, &name_len) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	DOM_GET_OBJ(docp, id, xmlDocPtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	php_dom_create_iterator(return_value, DOM_NODELIST);
 	namednode = Z_DOMOBJ_P(return_value);
@@ -2130,18 +2123,15 @@ PHP_METHOD(DOMDocument, saveHTML)
 /* {{{ Register extended class used to create base node type */
 PHP_METHOD(DOMDocument, registerNodeClass)
 {
-	zval *id;
-	xmlDoc *docp;
 	zend_class_entry *basece = dom_node_class_entry, *ce = NULL;
 	dom_object *intern;
 
-	id = ZEND_THIS;
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "CC!", &basece, &ce) == FAILURE) {
 		RETURN_THROWS();
 	}
 
 	if (ce == NULL || instanceof_function(ce, basece)) {
-		DOM_GET_OBJ(docp, id, xmlDocPtr, intern);
+		DOM_GET_THIS_INTERN(intern);
 		dom_set_doc_classmap(intern->document, basece, ce);
 		RETURN_TRUE;
 	}
@@ -2156,16 +2146,14 @@ Since: DOM Living Standard (DOM4)
 PHP_METHOD(DOMDocument, append)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_append(intern, args, argc);
 }
@@ -2177,16 +2165,14 @@ Since: DOM Living Standard (DOM4)
 PHP_METHOD(DOMDocument, prepend)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_prepend(intern, args, argc);
 }

--- a/ext/dom/documentfragment.c
+++ b/ext/dom/documentfragment.c
@@ -98,16 +98,14 @@ Since: DOM Living Standard (DOM4)
 PHP_METHOD(DOMDocumentFragment, append)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_append(intern, args, argc);
 }
@@ -119,16 +117,14 @@ Since: DOM Living Standard (DOM4)
 PHP_METHOD(DOMDocumentFragment, prepend)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_prepend(intern, args, argc);
 }

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -495,18 +495,15 @@ Since:
 */
 PHP_METHOD(DOMElement, getElementsByTagName)
 {
-	zval *id;
-	xmlNodePtr elemp;
 	size_t name_len;
 	dom_object *intern, *namednode;
 	char *name;
 
-	id = ZEND_THIS;
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	DOM_GET_OBJ(elemp, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	php_dom_create_iterator(return_value, DOM_NODELIST);
 	namednode = Z_DOMOBJ_P(return_value);
@@ -900,18 +897,15 @@ Since: DOM Level 2
 */
 PHP_METHOD(DOMElement, getElementsByTagNameNS)
 {
-	zval *id;
-	xmlNodePtr elemp;
 	size_t uri_len, name_len;
 	dom_object *intern, *namednode;
 	char *uri, *name;
 
-	id = ZEND_THIS;
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!s", &uri, &uri_len, &name, &name_len) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	DOM_GET_OBJ(elemp, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	php_dom_create_iterator(return_value, DOM_NODELIST);
 	namednode = Z_DOMOBJ_P(return_value);
@@ -1115,16 +1109,13 @@ Since:
 */
 PHP_METHOD(DOMElement, remove)
 {
-	zval *id;
-	xmlNodePtr child;
 	dom_object *intern;
 
 	if (zend_parse_parameters_none() == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(child, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_child_node_remove(intern);
 }
@@ -1133,16 +1124,14 @@ PHP_METHOD(DOMElement, remove)
 PHP_METHOD(DOMElement, after)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_after(intern, args, argc);
 }
@@ -1150,16 +1139,14 @@ PHP_METHOD(DOMElement, after)
 PHP_METHOD(DOMElement, before)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_before(intern, args, argc);
 }
@@ -1170,16 +1157,14 @@ Since: DOM Living Standard (DOM4)
 PHP_METHOD(DOMElement, append)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_append(intern, args, argc);
 }
@@ -1191,16 +1176,14 @@ Since: DOM Living Standard (DOM4)
 PHP_METHOD(DOMElement, prepend)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_parent_node_prepend(intern, args, argc);
 }
@@ -1212,16 +1195,14 @@ Since: DOM Living Standard (DOM4)
 PHP_METHOD(DOMElement, replaceWith)
 {
 	uint32_t argc;
-	zval *args, *id;
+	zval *args;
 	dom_object *intern;
-	xmlNode *context;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
-	id = ZEND_THIS;
-	DOM_GET_OBJ(context, id, xmlNodePtr, intern);
+	DOM_GET_THIS_INTERN(intern);
 
 	dom_child_replace_with(intern, args, argc);
 }

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -310,10 +310,6 @@ zval *dom_read_property(zend_object *object, zend_string *name, int type, void *
 
 	if (obj->prop_handler != NULL) {
 		hnd = zend_hash_find_ptr(obj->prop_handler, name);
-	} else if (instanceof_function(obj->std.ce, dom_node_class_entry)) {
-		zend_throw_error(NULL, "Couldn't fetch %s. Node no longer exists", ZSTR_VAL(obj->std.ce->name));
-		retval = &EG(uninitialized_zval);
-		return retval;
 	}
 
 	if (hnd) {

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -167,12 +167,19 @@ void php_dom_nodelist_get_item_into_zval(dom_nnodemap_object *objmap, zend_long 
 int php_dom_get_namednodemap_length(dom_object *obj);
 int php_dom_get_nodelist_length(dom_object *obj);
 
-#define DOM_GET_OBJ(__ptr, __id, __prtype, __intern) { \
+#define DOM_GET_INTERN(__id, __intern) { \
 	__intern = Z_DOMOBJ_P(__id); \
-	if (__intern->ptr == NULL || !(__ptr = (__prtype)((php_libxml_node_ptr *)__intern->ptr)->node)) { \
+	if (UNEXPECTED(__intern->ptr == NULL)) { \
 		zend_throw_error(NULL, "Couldn't fetch %s", ZSTR_VAL(__intern->std.ce->name));\
 		RETURN_THROWS();\
   	} \
+}
+
+#define DOM_GET_THIS_INTERN(__intern) DOM_GET_INTERN(ZEND_THIS, __intern)
+
+#define DOM_GET_OBJ(__ptr, __id, __prtype, __intern) { \
+	DOM_GET_INTERN(__id, __intern); \
+	__ptr = (__prtype)((php_libxml_node_ptr *)__intern->ptr)->node; \
 }
 
 #define DOM_NO_ARGS() \

--- a/ext/dom/tests/DOMAttr_ownerElement_error_001.phpt
+++ b/ext/dom/tests/DOMAttr_ownerElement_error_001.phpt
@@ -14,11 +14,7 @@ $document->appendChild($root);
 $attr = $root->setAttribute('category', 'books');
 $document->removeChild($root);
 $root = null;
-try {
-    var_dump($attr->ownerElement);
-} catch (\Error $e) {
-    echo get_class($e) . ': ' . $e->getMessage() . \PHP_EOL;
-}
+var_dump($attr->ownerElement);
 ?>
 --EXPECT--
-Error: Couldn't fetch DOMAttr. Node no longer exists
+NULL

--- a/ext/dom/tests/bug36756.phpt
+++ b/ext/dom/tests/bug36756.phpt
@@ -20,15 +20,11 @@ $node = $xpath->query('//child')->item(0);
 echo $node->nodeName . "\n";
 $GLOBALS['dom']->removeChild($GLOBALS['dom']->firstChild);
 
-try {
-    echo "nodeType: " . $node->nodeType . "\n";
-} catch (\Error $e) {
-    echo get_class($e) . ': ' . $e->getMessage() .\PHP_EOL;
-}
+echo "nodeType: " . $node->nodeType . "\n";
 
 ?>
 --EXPECT--
 root
 nodeType: 1
 child
-Error: Couldn't fetch DOMElement. Node no longer exists
+nodeType: 1

--- a/ext/dom/tests/bug70359.phpt
+++ b/ext/dom/tests/bug70359.phpt
@@ -29,11 +29,7 @@ var_dump($spaceNode->nodeType);
 var_dump($spaceNode->nodeValue);
 
 $dom->documentElement->firstElementChild->remove();
-try {
-    print_r($spaceNode->parentNode);
-} catch (\Error $e) {
-    echo $e->getMessage(), "\n";
-}
+var_dump($spaceNode->parentNode);
 
 echo "-- Test with parent and ns attribute --\n";
 
@@ -67,7 +63,7 @@ DOMNameSpaceNode Object
 -- Test with parent and non-ns attribute --
 int(2)
 string(3) "bar"
-Couldn't fetch DOMAttr. Node no longer exists
+NULL
 -- Test with parent and ns attribute --
 DOMNameSpaceNode Object
 (

--- a/ext/dom/tests/delayed_freeing/attribute_declaration.phpt
+++ b/ext/dom/tests/delayed_freeing/attribute_declaration.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Delayed freeing attribute declaration
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML(<<<'XML'
+<?xml version="1.0"?>
+<!DOCTYPE book [
+<!ELEMENT book (#PCDATA)>
+<!ATTLIST book
+title CDATA #REQUIRED
+>
+]>
+<book title="book title"/>
+XML);
+echo $doc->saveXML(), "\n";
+// Note: no way to query the attribute declaration, but this at least tests destruction order
+$doc->removeChild($doc->doctype);
+echo $doc->saveXML(), "\n";
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<!DOCTYPE book [
+<!ELEMENT book (#PCDATA)>
+<!ATTLIST book title CDATA #REQUIRED>
+]>
+<book title="book title"/>
+
+<?xml version="1.0"?>
+<book title="book title"/>

--- a/ext/dom/tests/delayed_freeing/comment_node.phpt
+++ b/ext/dom/tests/delayed_freeing/comment_node.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Delayed freeing comment node
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$comment = $doc->appendChild($doc->createElement('container'))
+    ->appendChild($doc->createComment('my comment'));
+echo $doc->saveXML(), "\n";
+$comment->parentNode->remove();
+echo $doc->saveXML(), "\n";
+echo $doc->saveXML($comment), "\n";
+var_dump($comment->parentNode);
+?>
+--EXPECTF--
+<?xml version="1.0"?>
+<container><!--my comment--></container>
+
+<?xml version="1.0"?>
+
+
+Fatal error: Uncaught Error: Couldn't fetch DOMComment in %s:%d
+Stack trace:
+#0 %s(%d): DOMDocument->saveXML(Object(DOMComment))
+#1 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/comment_node.phpt
+++ b/ext/dom/tests/delayed_freeing/comment_node.phpt
@@ -13,15 +13,11 @@ echo $doc->saveXML(), "\n";
 echo $doc->saveXML($comment), "\n";
 var_dump($comment->parentNode);
 ?>
---EXPECTF--
+--EXPECT--
 <?xml version="1.0"?>
 <container><!--my comment--></container>
 
 <?xml version="1.0"?>
 
-
-Fatal error: Uncaught Error: Couldn't fetch DOMComment in %s:%d
-Stack trace:
-#0 %s(%d): DOMDocument->saveXML(Object(DOMComment))
-#1 {main}
-  thrown in %s on line %d
+<!--my comment-->
+NULL

--- a/ext/dom/tests/delayed_freeing/direct_construction.phpt
+++ b/ext/dom/tests/delayed_freeing/direct_construction.phpt
@@ -1,0 +1,137 @@
+--TEST--
+Tests with direction construction
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+function node_alike_test($test) {
+    try {
+        var_dump($test->parentNode);
+        var_dump($test->nodeValue);
+    } catch (Throwable $e) {
+        echo $e->getMessage(), "\n";
+    }
+    try {
+        var_dump($test->appendChild($test));
+    } catch (Throwable $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+echo "-- Test DOMCharacterData --\n";
+$test = new DOMCharacterData("test");
+try {
+    var_dump($test->textContent);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    var_dump($test->appendData('test'));
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "-- Test DOMCdataSection --\n";
+$test = new DOMCdataSection("test");
+var_dump($test->textContent);
+var_dump($test->appendData('test'));
+
+echo "-- Test DOMText --\n";
+$test = new DOMText("test");
+try {
+    var_dump($test->wholeText);
+    var_dump($test->parentNode);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    var_dump($test->isWhitespaceInElementContent());
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "-- Test DOMComment --\n";
+$test = new DOMComment("my comment");
+var_dump($test->textContent);
+var_dump($test->parentNode);
+var_dump($test->getLineNo());
+
+echo "-- Test DOMElement --\n";
+$test = new DOMElement("qualifiedName", "test");
+var_dump($test->textContent);
+var_dump($test->parentNode);
+try {
+    var_dump($test->appendChild($test));
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "-- Test DOMNode --\n";
+node_alike_test(new DOMNode());
+
+echo "-- Test DOMNotation --\n";
+node_alike_test(new DOMNotation());
+
+echo "-- Test DOMProcessingInstruction --\n";
+node_alike_test(new DOMProcessingInstruction("name", "value"));
+
+echo "-- Test DOMEntity --\n";
+$test = new DOMEntity();
+try {
+    var_dump($test->nodeValue);
+    var_dump($test->parentNode);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    var_dump($test->appendChild($test));
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "-- Test DOMAttr --\n";
+$test = new DOMAttr("attr", "value");
+var_dump($test->nodeValue);
+var_dump($test->parentNode);
+try {
+    var_dump($test->appendChild($test));
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+-- Test DOMCharacterData --
+Invalid State Error
+Couldn't fetch DOMCharacterData
+-- Test DOMCdataSection --
+string(4) "test"
+bool(true)
+-- Test DOMText --
+string(4) "test"
+NULL
+bool(false)
+-- Test DOMComment --
+string(10) "my comment"
+NULL
+int(0)
+-- Test DOMElement --
+string(4) "test"
+NULL
+No Modification Allowed Error
+-- Test DOMNode --
+Invalid State Error
+Couldn't fetch DOMNode
+-- Test DOMNotation --
+Invalid State Error
+Couldn't fetch DOMNotation
+-- Test DOMProcessingInstruction --
+NULL
+string(5) "value"
+bool(false)
+-- Test DOMEntity --
+Invalid State Error
+Couldn't fetch DOMEntity
+-- Test DOMAttr --
+string(5) "value"
+NULL
+No Modification Allowed Error

--- a/ext/dom/tests/delayed_freeing/document_fragment.phpt
+++ b/ext/dom/tests/delayed_freeing/document_fragment.phpt
@@ -25,8 +25,8 @@ var_dump($child->parentNode);
 --EXPECTF--
 string(12) "text content"
 string(0) ""
+string(12) "text content"
 
-Fatal error: Uncaught Error: Couldn't fetch DOMElement. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+Warning: DOMNode::appendChild(): Document Fragment is empty in %s on line %d
+string(0) ""
+NULL

--- a/ext/dom/tests/delayed_freeing/document_fragment.phpt
+++ b/ext/dom/tests/delayed_freeing/document_fragment.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Delayed freeing document fragment
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$frag = $doc->createDocumentFragment();
+$frag->appendChild($doc->createElementNS('some:ns', 'child', 'text content'));
+$child = $doc->appendChild($doc->createElement('root'))->appendChild($frag);
+var_dump($doc->textContent);
+$doc->documentElement->remove();
+var_dump($doc->textContent);
+unset($doc);
+var_dump($child->textContent);
+
+$doc = new DOMDocument;
+$doc->appendChild($doc->createElement('container'));
+$doc->documentElement->appendChild($doc->importNode($frag));
+unset($frag);
+var_dump($doc->textContent);
+
+var_dump($child->parentNode);
+?>
+--EXPECTF--
+string(12) "text content"
+string(0) ""
+
+Fatal error: Uncaught Error: Couldn't fetch DOMElement. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/dom_character_data.phpt
+++ b/ext/dom/tests/delayed_freeing/dom_character_data.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Delayed freeing character data
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML(<<<'XML'
+<?xml version="1.0"?>
+<container><![CDATA[This is a CDATA section<p>test</p>]]></container>
+XML);
+$cdata = $doc->documentElement->firstChild;
+var_dump($cdata->wholeText, $cdata->parentNode->tagName);
+$cdata->parentNode->remove();
+var_dump($cdata->wholeText, $cdata->parentNode->tagName);
+?>
+--EXPECTF--
+string(34) "This is a CDATA section<p>test</p>"
+string(9) "container"
+
+Fatal error: Uncaught Error: Couldn't fetch DOMCdataSection. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/dom_character_data.phpt
+++ b/ext/dom/tests/delayed_freeing/dom_character_data.phpt
@@ -18,7 +18,6 @@ var_dump($cdata->wholeText, $cdata->parentNode->tagName);
 string(34) "This is a CDATA section<p>test</p>"
 string(9) "container"
 
-Fatal error: Uncaught Error: Couldn't fetch DOMCdataSection. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+Warning: Attempt to read property "tagName" on null in %s on line %d
+string(34) "This is a CDATA section<p>test</p>"
+NULL

--- a/ext/dom/tests/delayed_freeing/dtd_node.phpt
+++ b/ext/dom/tests/delayed_freeing/dtd_node.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Delayed freeing dtd node
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$dtd = $doc->implementation->createDocumentType('qualified name', 'public', 'system');
+$doc = $doc->implementation->createDocument('', '', $dtd);
+echo $doc->saveXML(), "\n";
+unset($doc);
+echo $dtd->ownerDocument->saveXML();
+$dtd->ownerDocument->removeChild($dtd);
+var_dump($dtd->ownerDocument->nodeName);
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<!DOCTYPE qualified name PUBLIC "public" "system">
+
+<?xml version="1.0"?>
+<!DOCTYPE qualified name PUBLIC "public" "system">
+string(9) "#document"

--- a/ext/dom/tests/delayed_freeing/element_declaration.phpt
+++ b/ext/dom/tests/delayed_freeing/element_declaration.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Delayed freeing element declaration
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML(<<<'XML'
+<?xml version="1.0"?>
+<!DOCTYPE books [
+<!ELEMENT parent (child1, child2)>
+<!ELEMENT child1 (#PCDATA)>
+<!ELEMENT child2 (#PCDATA)>
+]>
+<container><parent/></container>
+XML, LIBXML_NOENT);
+$element = $doc->documentElement->firstElementChild;
+echo $doc->saveXML(), "\n";
+var_dump($element->tagName);
+var_dump($element->textContent);
+
+$doc->removeChild($doc->doctype);
+echo $doc->saveXML(), "\n";
+var_dump($element->tagName);
+var_dump($element->textContent);
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<!DOCTYPE books [
+<!ELEMENT parent (child1 , child2)>
+<!ELEMENT child1 (#PCDATA)>
+<!ELEMENT child2 (#PCDATA)>
+]>
+<container><parent/></container>
+
+string(6) "parent"
+string(0) ""
+<?xml version="1.0"?>
+<container><parent/></container>
+
+string(6) "parent"
+string(0) ""

--- a/ext/dom/tests/delayed_freeing/element_uaf_crash.phpt
+++ b/ext/dom/tests/delayed_freeing/element_uaf_crash.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Delayed freeing should not cause a UAF
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$xml = new DomDocument();
+$d = $xml->createElement("div");
+$d->appendChild($b = $xml->createElement("b"));
+$ret = $d->appendChild($xml->createElement("xxx"));
+echo $xml->saveXML($d), "\n";
+unset($d);
+
+echo $ret->textContent, "Done\n";
+?>
+--EXPECTF--
+<div><b/><xxx/></div>
+
+Fatal error: Uncaught Error: Couldn't fetch DOMElement. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/element_uaf_crash.phpt
+++ b/ext/dom/tests/delayed_freeing/element_uaf_crash.phpt
@@ -13,10 +13,6 @@ unset($d);
 
 echo $ret->textContent, "Done\n";
 ?>
---EXPECTF--
+--EXPECT--
 <div><b/><xxx/></div>
-
-Fatal error: Uncaught Error: Couldn't fetch DOMElement. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+Done

--- a/ext/dom/tests/delayed_freeing/entity_declaration.phpt
+++ b/ext/dom/tests/delayed_freeing/entity_declaration.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Delayed freeing entity declaration
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML(<<<'XML'
+<?xml version="1.0"?>
+<!DOCTYPE books [
+<!ENTITY test "entity is only for test purposes">
+]>
+<container/>
+XML);
+$entity = $doc->doctype->entities[0];
+var_dump($entity->nodeName, $entity->parentNode->nodeName);
+$doc->removeChild($doc->doctype);
+var_dump($entity->nodeName, $entity->parentNode);
+?>
+--EXPECTF--
+string(4) "test"
+string(5) "books"
+
+Fatal error: Uncaught Error: Couldn't fetch DOMEntity. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/entity_declaration.phpt
+++ b/ext/dom/tests/delayed_freeing/entity_declaration.phpt
@@ -17,11 +17,8 @@ var_dump($entity->nodeName, $entity->parentNode->nodeName);
 $doc->removeChild($doc->doctype);
 var_dump($entity->nodeName, $entity->parentNode);
 ?>
---EXPECTF--
+--EXPECT--
 string(4) "test"
 string(5) "books"
-
-Fatal error: Uncaught Error: Couldn't fetch DOMEntity. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+string(4) "test"
+NULL

--- a/ext/dom/tests/delayed_freeing/entity_reference.phpt
+++ b/ext/dom/tests/delayed_freeing/entity_reference.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Delayed freeing entity reference
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$entityRef = $doc->appendChild($doc->createElementNS('some:ns', 'container'))
+    ->appendChild($doc->createEntityReference('nbsp'));
+echo $doc->saveXML(), "\n";
+$entityRef->parentNode->remove();
+echo $doc->saveXML(), "\n";
+var_dump($entityRef->parentNode);
+var_dump($entityRef->nodeName);
+var_dump($entityRef->textContent);
+
+$doc = new DOMDocument;
+$doc->loadXML(<<<'XML'
+<?xml version="1.0"?>
+<!DOCTYPE books [
+<!ENTITY test "entity is only for test purposes">
+]>
+<div/>
+XML);
+$entityRef = $doc->documentElement->appendChild($doc->createEntityReference('test'));
+echo $doc->saveXML(), "\n";
+$entityRef->parentNode->remove();
+unset($doc);
+var_dump($entityRef->nodeName);
+var_dump($entityRef->textContent);
+?>
+--EXPECTF--
+<?xml version="1.0"?>
+<container xmlns="some:ns">&nbsp;</container>
+
+<?xml version="1.0"?>
+
+
+Fatal error: Uncaught Error: Couldn't fetch DOMEntityReference. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/entity_reference.phpt
+++ b/ext/dom/tests/delayed_freeing/entity_reference.phpt
@@ -29,14 +29,20 @@ unset($doc);
 var_dump($entityRef->nodeName);
 var_dump($entityRef->textContent);
 ?>
---EXPECTF--
+--EXPECT--
 <?xml version="1.0"?>
 <container xmlns="some:ns">&nbsp;</container>
 
 <?xml version="1.0"?>
 
+NULL
+string(4) "nbsp"
+string(0) ""
+<?xml version="1.0"?>
+<!DOCTYPE books [
+<!ENTITY test "entity is only for test purposes">
+]>
+<div>&test;</div>
 
-Fatal error: Uncaught Error: Couldn't fetch DOMEntityReference. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+string(4) "test"
+string(0) ""

--- a/ext/dom/tests/delayed_freeing/gh9628_1.phpt
+++ b/ext/dom/tests/delayed_freeing/gh9628_1.phpt
@@ -1,0 +1,45 @@
+--TEST--
+GH-9628 (Implicitly removing nodes from \DOMDocument breaks existing references) - simple variation
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$html = <<<'HTML'
+<p xmlns="some:ns">
+    <span id="1" xmlns:test="some:ns2">
+        <strong>
+            <span id="2">Test <test:test/></span>
+        </strong>
+    </span>
+</p>
+HTML;
+
+$doc = new DOMDocument('1.0', 'UTF-8');
+$doc->loadXML($html);
+
+$outer_span = $doc->documentElement->firstElementChild;
+$inner_span = $outer_span->firstElementChild->firstElementChild;
+var_dump($inner_span->namespaceURI);
+
+// Remove strong
+$outer_span->firstElementChild->remove();
+
+var_dump($inner_span->getAttribute('id'));
+var_dump($inner_span->namespaceURI);
+
+// Import test
+$doc = new DOMDocument();
+$doc->append($doc->importNode($outer_span, true), $doc->importNode($inner_span, true));
+echo $doc->saveXML();
+
+var_dump($inner_span->getAttribute('id'));
+var_dump($inner_span->namespaceURI);
+?>
+--EXPECTF--
+string(7) "some:ns"
+
+Fatal error: Uncaught Error: Couldn't fetch DOMElement in %s:%d
+Stack trace:
+#0 %s(%d): DOMElement->getAttribute('id')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/gh9628_1.phpt
+++ b/ext/dom/tests/delayed_freeing/gh9628_1.phpt
@@ -35,11 +35,14 @@ echo $doc->saveXML();
 var_dump($inner_span->getAttribute('id'));
 var_dump($inner_span->namespaceURI);
 ?>
---EXPECTF--
+--EXPECT--
 string(7) "some:ns"
-
-Fatal error: Uncaught Error: Couldn't fetch DOMElement in %s:%d
-Stack trace:
-#0 %s(%d): DOMElement->getAttribute('id')
-#1 {main}
-  thrown in %s on line %d
+string(1) "2"
+string(7) "some:ns"
+<?xml version="1.0"?>
+<span xmlns:test="some:ns2" xmlns="some:ns" id="1">
+        
+    </span>
+<span xmlns="some:ns" id="2">Test <test:test xmlns:test="some:ns2"/></span>
+string(1) "2"
+string(7) "some:ns"

--- a/ext/dom/tests/delayed_freeing/gh9628_2.phpt
+++ b/ext/dom/tests/delayed_freeing/gh9628_2.phpt
@@ -1,0 +1,59 @@
+--TEST--
+GH-9628 (Implicitly removing nodes from \DOMDocument breaks existing references) - advanced variation
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$html = <<<'HTML'
+<p>
+    <span>
+        <strong>
+            <span>
+                Test
+            </span>
+        </strong>
+    </span>
+</p>
+HTML;
+
+$doc = new \DOMDocument('1.0', 'UTF-8');
+$doc->loadHTML(
+    '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>' . $html . '</body></html>'
+);
+$xpath = new \DOMXPath($doc);
+
+$spans = [];
+foreach ($xpath->query('//span') as $span) {
+    $spans[] = $span;
+}
+
+\assert(\count($spans) === 2);
+
+foreach ($spans as $span) {
+    \assert($span instanceof \DOMElement);
+    \assert($span->ownerDocument === $doc);
+}
+
+foreach ($spans as $span) {
+    \assert($span instanceof \DOMElement);
+
+    // This call will fail for the second `<span>`. It does not really
+    // matter what is accessed here, the error message will be the same.
+    $span->hasAttribute('test');
+
+    while ($span->childNodes->length) {
+        $span->removeChild($span->childNodes[0]);
+    }
+    $span->appendChild(
+        $span->ownerDocument->createTextNode('Hello World')
+    );
+}
+
+echo $spans[0]->textContent . "\n"; // Hello World
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Couldn't fetch DOMElement in %s:%d
+Stack trace:
+#0 %s(%d): DOMElement->hasAttribute('test')
+#1 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/gh9628_2.phpt
+++ b/ext/dom/tests/delayed_freeing/gh9628_2.phpt
@@ -51,9 +51,5 @@ foreach ($spans as $span) {
 
 echo $spans[0]->textContent . "\n"; // Hello World
 ?>
---EXPECTF--
-Fatal error: Uncaught Error: Couldn't fetch DOMElement in %s:%d
-Stack trace:
-#0 %s(%d): DOMElement->hasAttribute('test')
-#1 {main}
-  thrown in %s on line %d
+--EXPECT--
+Hello World

--- a/ext/dom/tests/delayed_freeing/namespace_definition_crash.phpt
+++ b/ext/dom/tests/delayed_freeing/namespace_definition_crash.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Delayed freeing namespace definition should not crash
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->appendChild($doc->createElement('container'));
+$child = $doc->documentElement->appendChild($doc->createElementNS('some:ns', 'child'));
+$child_child = $child->appendChild($doc->createElementNS('some:ns', 'x'));
+
+echo $doc->saveXML();
+
+$child->remove();
+echo $doc->saveXML();
+
+unset($child);
+var_dump($child_child->namespaceURI);
+?>
+--EXPECTF--
+<?xml version="1.0"?>
+<container><child xmlns="some:ns"><x/></child></container>
+<?xml version="1.0"?>
+<container/>
+
+Fatal error: Uncaught Error: Couldn't fetch DOMElement. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/namespace_definition_crash.phpt
+++ b/ext/dom/tests/delayed_freeing/namespace_definition_crash.phpt
@@ -17,13 +17,9 @@ echo $doc->saveXML();
 unset($child);
 var_dump($child_child->namespaceURI);
 ?>
---EXPECTF--
+--EXPECT--
 <?xml version="1.0"?>
 <container><child xmlns="some:ns"><x/></child></container>
 <?xml version="1.0"?>
 <container/>
-
-Fatal error: Uncaught Error: Couldn't fetch DOMElement. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+string(7) "some:ns"

--- a/ext/dom/tests/delayed_freeing/namespace_definition_crash_in_attribute.phpt
+++ b/ext/dom/tests/delayed_freeing/namespace_definition_crash_in_attribute.phpt
@@ -37,13 +37,17 @@ var_dump($attr3->namespaceURI);
 echo $doc->saveXML($attr3), "\n";
 echo $doc->saveXML($attr3->parentNode), "\n";
 ?>
---EXPECTF--
+--EXPECT--
 <?xml version="1.0"?>
 <container xmlns="some:ns2"><child xmlns="some:ns" hello="hello content 2" hello2=""><childcontainer hello=""/></child></container>
 <?xml version="1.0"?>
 <container xmlns="some:ns2"/>
-
-Fatal error: Uncaught Error: Couldn't fetch DOMAttr. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+string(15) "hello content 2"
+string(0) ""
+string(8) "some:ns2"
+NULL
+string(0) ""
+string(7) "some:ns"
+string(7) "some:ns"
+ hello=""
+<?xml version="1.0"?>

--- a/ext/dom/tests/delayed_freeing/namespace_definition_crash_in_attribute.phpt
+++ b/ext/dom/tests/delayed_freeing/namespace_definition_crash_in_attribute.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Delayed freeing namespace definition should not crash in attribute
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->appendChild($doc->createElement('container'));
+$child = $doc->documentElement->appendChild($doc->createElementNS('some:ns', 'child'));
+$child_attr1 = $child->appendChild($doc->createAttributeNS('some:ns2', 'hello'));
+$child_attr1->textContent = 'hello content 1';
+$child_attr2 = $child->appendChild($doc->createAttribute('hello2'));
+$child_attr1->textContent = 'hello content 2';
+$attr3 = $child->appendChild($doc->createElementNS('some:ns', 'childcontainer'))
+        ->appendChild($doc->createAttributeNS('some:ns', 'hello'));
+
+echo $doc->saveXML();
+
+$child->remove();
+echo $doc->saveXML();
+
+unset($child);
+
+var_dump($child_attr1->textContent);
+var_dump($child_attr2->textContent);
+var_dump($child_attr1->namespaceURI);
+var_dump($child_attr2->namespaceURI);
+var_dump($attr3->textContent);
+var_dump($attr3->namespaceURI);
+
+$doc->documentElement->remove();
+
+unset($child_attr1);
+unset($child_attr2);
+var_dump($attr3->namespaceURI);
+
+echo $doc->saveXML($attr3), "\n";
+echo $doc->saveXML($attr3->parentNode), "\n";
+?>
+--EXPECTF--
+<?xml version="1.0"?>
+<container xmlns="some:ns2"><child xmlns="some:ns" hello="hello content 2" hello2=""><childcontainer hello=""/></child></container>
+<?xml version="1.0"?>
+<container xmlns="some:ns2"/>
+
+Fatal error: Uncaught Error: Couldn't fetch DOMAttr. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/namespace_xmlns_declaration.phpt
+++ b/ext/dom/tests/delayed_freeing/namespace_xmlns_declaration.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Delayed freeing namespace xmlns declaration
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML('<?xml version="1.0"?><container xmlns="http://php.net"/>');
+$doc->documentElement->appendChild($el = $doc->createElementNS('http://php.net', 'example'));
+echo $doc->saveXML(), "\n";
+
+$doc->documentElement->remove();
+echo $doc->saveXML(), "\n";
+
+var_dump($el->namespaceURI);
+?>
+--EXPECTF--
+<?xml version="1.0"?>
+<container xmlns="http://php.net"><example/></container>
+
+<?xml version="1.0"?>
+
+
+Fatal error: Uncaught Error: Couldn't fetch DOMElement. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/namespace_xmlns_declaration.phpt
+++ b/ext/dom/tests/delayed_freeing/namespace_xmlns_declaration.phpt
@@ -14,14 +14,10 @@ echo $doc->saveXML(), "\n";
 
 var_dump($el->namespaceURI);
 ?>
---EXPECTF--
+--EXPECT--
 <?xml version="1.0"?>
 <container xmlns="http://php.net"><example/></container>
 
 <?xml version="1.0"?>
 
-
-Fatal error: Uncaught Error: Couldn't fetch DOMElement. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+string(14) "http://php.net"

--- a/ext/dom/tests/delayed_freeing/namespace_xmlns_declaration_attribute_variation.phpt
+++ b/ext/dom/tests/delayed_freeing/namespace_xmlns_declaration_attribute_variation.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Delayed freeing namespace xmlns declaration - attribute variation
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML('<?xml version="1.0"?><container xmlns="http://php.net"/>');
+$doc->documentElement->appendChild($doc->createElementNS('http://php.net', 'example'));
+echo $doc->saveXML(), "\n";
+
+$declaration = $doc->documentElement->getAttributeNode('xmlns');
+var_dump($declaration->nodeValue);
+
+$doc->documentElement->remove();
+echo $doc->saveXML(), "\n";
+
+var_dump($declaration->nodeValue);
+unset($doc);
+var_dump($declaration->parentNode->nodeName);
+var_dump($declaration->parentNode->childNodes[0]->nodeName);
+
+$declaration->parentNode->childNodes[0]->remove();
+var_dump($declaration->parentNode->nodeName);
+var_dump($declaration->parentNode->childNodes[0]);
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<container xmlns="http://php.net"><example/></container>
+
+string(14) "http://php.net"
+<?xml version="1.0"?>
+
+string(14) "http://php.net"
+string(9) "container"
+string(7) "example"
+string(9) "container"
+NULL

--- a/ext/dom/tests/delayed_freeing/notation_declaration.phpt
+++ b/ext/dom/tests/delayed_freeing/notation_declaration.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Delayed freeing notation declaration
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML(<<<'XML'
+<?xml version="1.0"?>
+<!DOCTYPE books [
+<!NOTATION myNotation SYSTEM "test.dtd">
+]>
+<container/>
+XML);
+$notation = $doc->doctype->notations[0];
+var_dump($notation->nodeName, $notation->publicId, $notation->systemId);
+$doc->removeChild($doc->doctype);
+var_dump($notation->nodeName, $notation->publicId, $notation->systemId);
+unset($doc);
+var_dump($notation->nodeName, $notation->publicId, $notation->systemId);
+?>
+--EXPECT--
+string(10) "myNotation"
+string(0) ""
+string(8) "test.dtd"
+string(10) "myNotation"
+string(0) ""
+string(8) "test.dtd"
+string(10) "myNotation"
+string(0) ""
+string(8) "test.dtd"

--- a/ext/dom/tests/delayed_freeing/processing_instruction.phpt
+++ b/ext/dom/tests/delayed_freeing/processing_instruction.phpt
@@ -13,14 +13,11 @@ echo $doc->saveXML(), "\n";
 var_dump($pi->parentNode);
 var_dump($pi->nodeValue);
 ?>
---EXPECTF--
+--EXPECT--
 <?xml version="1.0"?>
 <container xmlns="some:ns"><?hello world?></container>
 
 <?xml version="1.0"?>
 
-
-Fatal error: Uncaught Error: Couldn't fetch DOMProcessingInstruction. Node no longer exists in %s:%d
-Stack trace:
-#0 {main}
-  thrown in %s on line %d
+NULL
+string(5) "world"

--- a/ext/dom/tests/delayed_freeing/processing_instruction.phpt
+++ b/ext/dom/tests/delayed_freeing/processing_instruction.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Delayed freeing processing instruction
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$pi = $doc->appendChild($doc->createElementNS('some:ns', 'container'))
+    ->appendChild($doc->createProcessingInstruction('hello', 'world'));
+echo $doc->saveXML(), "\n";
+$pi->parentNode->remove();
+echo $doc->saveXML(), "\n";
+var_dump($pi->parentNode);
+var_dump($pi->nodeValue);
+?>
+--EXPECTF--
+<?xml version="1.0"?>
+<container xmlns="some:ns"><?hello world?></container>
+
+<?xml version="1.0"?>
+
+
+Fatal error: Uncaught Error: Couldn't fetch DOMProcessingInstruction. Node no longer exists in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/text_node.phpt
+++ b/ext/dom/tests/delayed_freeing/text_node.phpt
@@ -17,15 +17,15 @@ echo $doc->saveXML($text2), "\n";
 var_dump($text1->parentNode, $text2->parentNode);
 var_dump($text1->nextSibling, $text2->previousSibling);
 ?>
---EXPECTF--
+--EXPECT--
 <?xml version="1.0"?>
 <container>my text 1my text 2</container>
 
 <?xml version="1.0"?>
 
-
-Fatal error: Uncaught Error: Couldn't fetch DOMText in %s:%d
-Stack trace:
-#0 %s(%d): DOMDocument->saveXML(Object(DOMText))
-#1 {main}
-  thrown in %s on line %d
+my text 1
+my text 2
+NULL
+NULL
+NULL
+NULL

--- a/ext/dom/tests/delayed_freeing/text_node.phpt
+++ b/ext/dom/tests/delayed_freeing/text_node.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Delayed freeing text node
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+// Text nodes are special as the underlying library has a tendency to merge adjacent ones
+$text1 = $doc->appendChild($doc->createElement('container'))
+    ->appendChild($doc->createTextNode('my text 1'));
+$text2 = $doc->documentElement->appendChild($doc->createTextNode('my text 2'));
+echo $doc->saveXML(), "\n";
+$text1->parentNode->remove();
+echo $doc->saveXML(), "\n";
+echo $doc->saveXML($text1), "\n";
+echo $doc->saveXML($text2), "\n";
+var_dump($text1->parentNode, $text2->parentNode);
+var_dump($text1->nextSibling, $text2->previousSibling);
+?>
+--EXPECTF--
+<?xml version="1.0"?>
+<container>my text 1my text 2</container>
+
+<?xml version="1.0"?>
+
+
+Fatal error: Uncaught Error: Couldn't fetch DOMText in %s:%d
+Stack trace:
+#0 %s(%d): DOMDocument->saveXML(Object(DOMText))
+#1 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/delayed_freeing/without_contructor.phpt
+++ b/ext/dom/tests/delayed_freeing/without_contructor.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Tests without running the constructor
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$rc = new ReflectionClass('DOMNode');
+$node = $rc->newInstanceWithoutConstructor();
+
+// Property read test
+try {
+    var_dump($node);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// Call test
+try {
+    $node->removeChild($node);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// Import test
+$doc = new DOMDocument;
+try {
+    $doc->appendChild($doc->importNode($node));
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+object(DOMNode)#2 (0) {
+}
+Invalid State Error
+Couldn't fetch DOMNode
+Couldn't fetch DOMNode

--- a/ext/dom/xml_common.h
+++ b/ext/dom/xml_common.h
@@ -61,20 +61,18 @@ PHP_DOM_EXPORT xmlNodePtr dom_object_get_node(dom_object *obj);
 
 #define NODE_GET_OBJ(__ptr, __id, __prtype, __intern) { \
 	__intern = Z_LIBXML_NODE_P(__id); \
-	if (__intern->node == NULL || !(__ptr = (__prtype)__intern->node->node)) { \
-  		php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", \
+	if (UNEXPECTED(__intern->node == NULL)) { \
+		php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", \
 			ZSTR_VAL(__intern->std.ce->name));\
-  		RETURN_NULL();\
-  	} \
+		RETURN_NULL();\
+	} \
+	__ptr = (__prtype)__intern->node->node; \
 }
 
 #define DOC_GET_OBJ(__ptr, __id, __prtype, __intern) { \
 	__intern = Z_LIBXML_NODE_P(__id); \
-	if (__intern->document != NULL) { \
-		if (!(__ptr = (__prtype)__intern->document->ptr)) { \
-  			php_error_docref(NULL, E_WARNING, "Couldn't fetch %s", __intern->std.ce->name);\
-  			RETURN_NULL();\
-  		} \
+	if (EXPECTED(__intern->document != NULL)) { \
+		__ptr = (__prtype)__intern->document->ptr); \
 	} \
 }
 


### PR DESCRIPTION
Fixes GH-9628

Currently, when you remove a node from the DOM, that node will become inaccessible. This even happens when the node is implicitly removed, even when you still hold a reference to it in a variable. This is not possible to detect and prevent easily (see issue details).
This patch changes how lifetimes works. If there's still a userland reference, the node is unlinked instead of freed.
This causes some complications because of how freeing works, especially because of some libxml2 peculiarities (see comments in the code).