### PR TITLE
Fix trailing if element JMP lineno

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5408,6 +5408,9 @@ static void zend_compile_if(zend_ast *ast) /* {{{ */
 			zend_compile_stmt(stmt_ast);
 
 			if (i != list->children - 1) {
+				/* Set the lineno of JMP to the position of the if keyword, as we don't want to
+				 * report the last line in the if branch as covered if it hasn't actually executed. */
+				CG(zend_lineno) = elem_ast->lineno;
 				jmp_opnums[i] = zend_emit_jump(0);
 			}
 			zend_update_jump_target_to_next(opnum_jmpz);


### PR DESCRIPTION
Having this lineno on the same last compiled element can lead to an incorrectly covered line number.

```php
if (true) {
    if (false) {
        echo 'Never executed';
    }
} else {
}
```

The echo will be reported as covered because the JMP from the if (true) branch to the end of the else branch has the same lineno as the echo.

This is lacking a test because zend_dump.c does not have access to ctx->debug_level and I don't think it's worth adjusting all the cases.