### PR TITLE
Fix GH-9483: Autoconf warnings for newer Autoconf versions

### DIFF
--- a/build/libtool.m4
+++ b/build/libtool.m4
@@ -271,7 +271,7 @@ $rm -r conftest*
 
 dnl autoconf 2.13 compatibility
 dnl _LT_AC_TRY_LINK()
-AC_DEFUN(_LT_AC_TRY_LINK, [
+AC_DEFUN([_LT_AC_TRY_LINK], [
 cat > conftest.$ac_ext <<EOF
 dnl This sometimes fails to find confdefs.h, for some reason.
 dnl [#]line __oline__ "[$]0"
@@ -675,10 +675,9 @@ s390*-*linux*|sparc*-*linux*)
   SAVE_CFLAGS="$CFLAGS"
   CFLAGS="$CFLAGS -belf"
   AC_CACHE_CHECK([whether the C compiler needs -belf], lt_cv_cc_needs_belf,
-    [AC_LANG_SAVE
-     AC_LANG_C
-     AC_TRY_LINK([],[],[lt_cv_cc_needs_belf=yes],[lt_cv_cc_needs_belf=no])
-     AC_LANG_RESTORE])
+    [AC_LANG_PUSH([C])
+     AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[lt_cv_cc_needs_belf=yes],[lt_cv_cc_needs_belf=no])
+    AC_LANG_POP([C])])
   if test x"$lt_cv_cc_needs_belf" != x"yes"; then
     # this is probably gcc 2.8.0, egcs 1.0 or newer; no need for -belf
     CFLAGS="$SAVE_CFLAGS"
@@ -1197,7 +1196,7 @@ if test "$_LT_AC_TAGVAR(lt_cv_prog_compiler_c_o, $1)" = no && test "$need_locks"
   ln conftest.a conftest.b 2>/dev/null && hard_links=no
   AC_MSG_RESULT([$hard_links])
   if test "$hard_links" = no; then
-    AC_MSG_WARN([\`$CC' does not support \`-c -o', so \`make -j' may be unsafe])
+    AC_MSG_WARN(['$CC' does not support '-c -o', so 'make -j' may be unsafe])
     need_locks=warn
   fi
 else
@@ -1935,15 +1934,15 @@ AC_ARG_WITH([tags],
 
 if test -f "$ltmain" && test -n "$tagnames"; then
   if test ! -f "${ofile}"; then
-    AC_MSG_WARN([output file \`$ofile' does not exist])
+    AC_MSG_WARN([output file '$ofile' does not exist])
   fi
 
   if test -z "$LTCC"; then
     eval "`$SHELL ${ofile} --config | grep '^LTCC='`"
     if test -z "$LTCC"; then
-      AC_MSG_WARN([output file \`$ofile' does not look like a libtool script])
+      AC_MSG_WARN([output file '$ofile' does not look like a libtool script])
     else
-      AC_MSG_WARN([using \`LTCC=$LTCC', extracted from \`$ofile'])
+      AC_MSG_WARN([using 'LTCC=$LTCC', extracted from '$ofile'])
     fi
   fi
   if test -z "$LTCFLAGS"; then
@@ -1966,7 +1965,7 @@ if test -f "$ltmain" && test -n "$tagnames"; then
 
     if grep "^# ### BEGIN LIBTOOL TAG CONFIG: $tagname$" < "${ofile}" > /dev/null
     then
-      AC_MSG_ERROR([tag name \"$tagname\" already exists])
+      AC_MSG_ERROR([tag name "$tagname" already exists])
     fi
 
     # Update the list of available tags.
@@ -2738,8 +2737,7 @@ fi
 AC_DEFUN([AC_LIBTOOL_LANG_C_CONFIG], [_LT_AC_LANG_C_CONFIG])
 AC_DEFUN([_LT_AC_LANG_C_CONFIG],
 [lt_save_CC="$CC"
-AC_LANG_SAVE
-AC_LANG_C
+AC_LANG_PUSH([C])
 
 # Source file extension for C test sources.
 ac_ext=c
@@ -2807,7 +2805,7 @@ AC_MSG_RESULT([$enable_static])
 
 AC_LIBTOOL_CONFIG($1)
 
-AC_LANG_RESTORE
+AC_LANG_POP([C])
 CC="$lt_save_CC"
 ])# AC_LIBTOOL_LANG_C_CONFIG
 
@@ -2819,8 +2817,7 @@ CC="$lt_save_CC"
 # AC_LIBTOOL_CONFIG to write the compiler configuration to `libtool'.
 AC_DEFUN([AC_LIBTOOL_LANG_CXX_CONFIG], [_LT_AC_LANG_CXX_CONFIG(CXX)])
 AC_DEFUN([_LT_AC_LANG_CXX_CONFIG],
-[AC_LANG_SAVE
-AC_LANG_CPLUSPLUS
+[AC_LANG_PUSH([C++])
 AC_REQUIRE([AC_PROG_CXX])
 AC_REQUIRE([_LT_AC_PROG_CXXCPP])
 
@@ -3806,7 +3803,7 @@ AC_LIBTOOL_PROG_LD_HARDCODE_LIBPATH($1)
 
 AC_LIBTOOL_CONFIG($1)
 
-AC_LANG_RESTORE
+AC_LANG_POP([C++])
 CC=$lt_save_CC
 LDCXX=$LD
 LD=$lt_save_LD

--- a/build/php.m4
+++ b/build/php.m4
@@ -2152,7 +2152,7 @@ EOF
    else
     break
    fi
-   $as_echo "$CURRENT_ARG \\" >>$1
+   AS_ECHO(["$CURRENT_ARG \\"]) >>$1
    CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS $CURRENT_ARG"
   done
   echo '"[$]@"' >> $1

--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,9 @@ PKG_PROG_PKG_CONFIG
 AC_PROG_CC([cc gcc])
 PHP_DETECT_ICC
 PHP_DETECT_SUNCC
-AC_PROG_CC_C99
+
+dnl AC_PROG_CC_C99 is obsolete with autoconf >= 2.70 yet necessary for <= 2.69.
+m4_version_prereq([2.70],,[AC_PROG_CC_C99])
 AC_PROG_CPP
 AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_LN_S


### PR DESCRIPTION
Hello, this fixes Autoconf warnings for PHP-8.1 branch. Reported at #9483 

It includes 3 patches:
- AS_ECHO patch
- PHP's forked libtool.m4 patched to not emit Autoconf warnings
- AC_PROG_CC_C99 is done like in the master branch (For Autoconf versions <2.70 it is called, and for newer versions not because it is already done in another Autoconf macro for 2.70 and above).

Thanks.