### PR TITLE
Fix replaced error handling in SQLite3Stmt::__construct

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -1820,7 +1820,6 @@ PHP_METHOD(SQLite3Stmt, __construct)
 	zval *db_zval;
 	zend_string *sql;
 	int errcode;
-	zend_error_handling error_handling;
 	php_sqlite3_free_list *free_item;
 
 	stmt_obj = Z_SQLITE3_STMT_P(object);
@@ -1831,9 +1830,7 @@ PHP_METHOD(SQLite3Stmt, __construct)
 
 	db_obj = Z_SQLITE3_DB_P(db_zval);
 
-	zend_replace_error_handling(EH_THROW, NULL, &error_handling);
 	SQLITE3_CHECK_INITIALIZED(db_obj, db_obj->initialised, SQLite3)
-	zend_restore_error_handling(&error_handling);
 
 	if (!ZSTR_LEN(sql)) {
 		RETURN_FALSE;


### PR DESCRIPTION
The error handling is replaced using zend_replace_error_handling(), but when SQLITE3_CHECK_INITIALIZED() returns early, the old error handling isn't restored.

In the past, SQLITE3_CHECK_INITIALIZED() threw a warning when the check failed. This was replaced a few years ago with an error exception. So we can fix the bug by just removing the replacing error handling as it accomplishes nothing anymore.