### PR TITLE
Fix accidental handling of unwind and gracful exit exceptions

### DIFF
--- a/Zend/zend_exceptions.c
+++ b/Zend/zend_exceptions.c
@@ -199,8 +199,14 @@ ZEND_API ZEND_COLD void zend_throw_exception_internal(zend_object *exception) /*
 			return;
 		}
 		if (EG(exception)) {
-			if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
+			if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF
+			 && !zend_is_unwind_exit(EG(exception))
+			 && !zend_is_graceful_exit(EG(exception))) {
 				zend_user_exception_handler();
+				if (EG(exception)) {
+					zend_exception_error(EG(exception), E_ERROR);
+				}
+				return;
 			} else {
 				zend_exception_error(EG(exception), E_ERROR);
 			}

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -1010,11 +1010,7 @@ cleanup_args:
 
 	if (UNEXPECTED(EG(exception))) {
 		if (UNEXPECTED(!EG(current_execute_data))) {
-			if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
-				zend_user_exception_handler();
-			} else {
-				zend_throw_exception_internal(NULL);
-			}
+			zend_throw_exception_internal(NULL);
 		} else if (EG(current_execute_data)->func &&
 		           ZEND_USER_CODE(EG(current_execute_data)->func->common.type)) {
 			zend_rethrow_exception(EG(current_execute_data));


### PR DESCRIPTION
These exceptions should not invoke the user error handler.

Fixes GH-11601

I was unable to create a reproducer, but this fixes the issue running phpMyAdmin for me.

/cc @nielsdos 