### PR TITLE
Fix GH-11242: Use dynamic buffer for large length in stream mem copy

### DIFF
--- a/ext/standard/tests/file/file_get_contents_with_large_length.phpt
+++ b/ext/standard/tests/file/file_get_contents_with_large_length.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test file_get_contents() function with large length parameter
+--INI--
+memory_limit=128M
+--FILE--
+<?php
+
+$file_path = __DIR__ . '/file_get_contents_with_large_length_content.txt';
+$file_content = str_repeat('a', 50000);
+file_put_contents($file_path, $file_content);
+
+// test lenght limiting
+$result = file_get_contents($file_path, length: 500000000);
+var_dump($result === $file_content);
+
+// test lenght limiting
+$result = file_get_contents($file_path, length: 40000);
+var_dump($result === str_repeat('a', 40000));
+
+?>
+--CLEAN--
+<?php
+unlink(__DIR__ . '/file_get_contents_with_large_length_content.txt');
+?>
+--EXPECT--
+bool(true)
+bool(true)


### PR DESCRIPTION
This prevents allocating buffer of the supplied `length`, if it is larger than 32KB so it is possible to set maximum length that is way larger than the actual content that will be provided as request in GH-11242. It should still allocate larger buffer where the stat size is working (e.g. files). It will likely result in more reallocation for network transfer but it should use less memory. This applies only if `lengths` parameter is supplied. Functionality without `length` should not be impacted.