### PR TITLE
FIX GH-11587 PHP8.1: Fixed the condition for result set values to be of native type, making it compatible with previous versions.

### DIFF
--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -792,6 +792,9 @@ static bool pdo_dbh_attribute_set(pdo_dbh_t *dbh, zend_long attr, zval *value) /
 				return false;
 			}
 			dbh->stringify = bval;
+			if (dbh->methods->set_attribute) {
+				dbh->methods->set_attribute(dbh, attr, value);
+			}
 			return true;
 
 		case PDO_ATTR_STATEMENT_CLASS: {

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -903,7 +903,7 @@ static int pdo_mysql_handle_factory(pdo_dbh_t *dbh, zval *driver_options)
 	}
 
 #ifdef PDO_USE_MYSQLND
-	!pdo_attr_lval(driver_options, PDO_ATTR_STRINGIFY_FETCHES, dbh->stringify);
+	unsigned int int_and_float_native = !pdo_attr_lval(driver_options, PDO_ATTR_STRINGIFY_FETCHES, dbh->stringify);
 	if (mysql_options(H->server, MYSQLND_OPT_INT_AND_FLOAT_NATIVE, (const char *) &int_and_float_native)) {
 		pdo_mysql_error(dbh);
 		goto cleanup;

--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -417,7 +417,7 @@ static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 	switch (attr) {
 		case PDO_ATTR_AUTOCOMMIT:
 			if (!pdo_get_bool_param(&bval, val)) {
-				return false;
+				PDO_DBG_RETURN(false);
 			}
 			/* ignore if the new value equals the old one */
 			if (dbh->auto_commit ^ bval) {
@@ -437,7 +437,7 @@ static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 
 		case PDO_MYSQL_ATTR_USE_BUFFERED_QUERY:
 			if (!pdo_get_bool_param(&bval, val)) {
-				return false;
+				PDO_DBG_RETURN(false);
 			}
 			/* ignore if the new value equals the old one */
 			((pdo_mysql_db_handle *)dbh->driver_data)->buffered = bval;
@@ -446,7 +446,7 @@ static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 		case PDO_MYSQL_ATTR_DIRECT_QUERY:
 		case PDO_ATTR_EMULATE_PREPARES:
 			if (!pdo_get_bool_param(&bval, val)) {
-				return false;
+				PDO_DBG_RETURN(false);
 			}
 			/* ignore if the new value equals the old one */
 			((pdo_mysql_db_handle *)dbh->driver_data)->emulate_prepare = bval;
@@ -454,7 +454,7 @@ static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 
 		case PDO_ATTR_FETCH_TABLE_NAMES:
 			if (!pdo_get_bool_param(&bval, val)) {
-				return false;
+				PDO_DBG_RETURN(false);
 			}
 			((pdo_mysql_db_handle *)dbh->driver_data)->fetch_table_names = bval;
 			PDO_DBG_RETURN(true);
@@ -462,13 +462,13 @@ static bool pdo_mysql_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val)
 #ifdef PDO_USE_MYSQLND
 		case PDO_ATTR_STRINGIFY_FETCHES:
 			if (!pdo_get_bool_param(&bval, val)) {
-				return false;
+				PDO_DBG_RETURN(false);
 			}
 			unsigned int int_and_float_native = !bval;
 			pdo_mysql_db_handle *H = (pdo_mysql_db_handle *)dbh->driver_data;
 			if (mysql_options(H->server, MYSQLND_OPT_INT_AND_FLOAT_NATIVE, (const char *) &int_and_float_native)) {
 				pdo_mysql_error(dbh);
-				return false;
+				PDO_DBG_RETURN(false);
 			}
 			PDO_DBG_RETURN(true);
 #else

--- a/ext/pdo_mysql/tests/gh-11587.phpt
+++ b/ext/pdo_mysql/tests/gh-11587.phpt
@@ -1,0 +1,149 @@
+--TEST--
+GH-11587 PHP8.1: Fixed the condition for result set values to be of native type, making it compatible with previous versions. #11622
+--EXTENSIONS--
+pdo_mysql
+--SKIPIF--
+<?php
+if (!extension_loaded('mysqli') || !extension_loaded('mysqlnd')) {
+    /* Need connection to detect library version */
+    require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+    MySQLPDOTest::skip();
+}
+?>
+--FILE--
+<?php
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+$db = MySQLPDOTest::factory();
+
+$db->exec('DROP TABLE IF EXISTS test');
+
+$createTestTable = <<<SQL
+CREATE TABLE test(
+   id INT,
+  `float_col` FLOAT(3,2) DEFAULT NULL,
+  `double_col` DOUBLE(3,2) DEFAULT NULL,
+  `decimal_col` DECIMAL(3,2) DEFAULT NULL
+)
+SQL;
+
+$db->exec($createTestTable);
+
+$insertTestTable = <<<SQL
+INSERT INTO test(id, float_col, double_col, decimal_col) VALUES(1, 2.60, 3.60, 4.60)
+SQL;
+
+$db->exec($insertTestTable);
+
+// PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = true
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+$results = $db->query('SELECT * FROM test');
+foreach ($results as $result) {
+    var_dump($result);
+}
+
+// PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = false
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+$results = $db->query('SELECT * FROM test');
+foreach ($results as $result) {
+    var_dump($result);
+}
+
+// PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = true
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false;
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+$results = $db->query('SELECT * FROM test');
+foreach ($results as $result) {
+    var_dump($result);
+}
+
+// PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = false
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+$db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+$results = $db->query('SELECT * FROM test');
+foreach ($results as $result) {
+    var_dump($result);
+}
+
+echo 'done!';
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+MySQLPDOTest::dropTestTable();
+?>
+--EXPECT--
+array(8) {
+  ["id"]=>
+  string(1) "1"
+  [0]=>
+  string(1) "1"
+  ["float_col"]=>
+  string(4) "2.60"
+  [1]=>
+  string(4) "2.60"
+  ["double_col"]=>
+  string(4) "3.60"
+  [2]=>
+  string(4) "3.60"
+  ["decimal_col"]=>
+  string(4) "4.60"
+  [3]=>
+  string(4) "4.60"
+}
+array(8) {
+  ["id"]=>
+  int(1)
+  [0]=>
+  int(1)
+  ["float_col"]=>
+  float(2.6)
+  [1]=>
+  float(2.6)
+  ["double_col"]=>
+  float(3.6)
+  [2]=>
+  float(3.6)
+  ["decimal_col"]=>
+  string(4) "4.60"
+  [3]=>
+  string(4) "4.60"
+}
+array(8) {
+  ["id"]=>
+  string(1) "1"
+  [0]=>
+  string(1) "1"
+  ["float_col"]=>
+  string(3) "2.6"
+  [1]=>
+  string(3) "2.6"
+  ["double_col"]=>
+  string(3) "3.6"
+  [2]=>
+  string(3) "3.6"
+  ["decimal_col"]=>
+  string(4) "4.60"
+  [3]=>
+  string(4) "4.60"
+}
+array(8) {
+  ["id"]=>
+  int(1)
+  [0]=>
+  int(1)
+  ["float_col"]=>
+  float(2.6)
+  [1]=>
+  float(2.6)
+  ["double_col"]=>
+  float(3.6)
+  [2]=>
+  float(3.6)
+  ["decimal_col"]=>
+  string(4) "4.60"
+  [3]=>
+  string(4) "4.60"
+}
+done!

--- a/ext/pdo_mysql/tests/gh-11587.phpt
+++ b/ext/pdo_mysql/tests/gh-11587.phpt
@@ -51,7 +51,7 @@ foreach ($results as $result) {
 }
 
 // PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = true
-$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false;
+$db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 $results = $db->query('SELECT * FROM test');
 foreach ($results as $result) {

--- a/ext/pdo_mysql/tests/gh-11587.phpt
+++ b/ext/pdo_mysql/tests/gh-11587.phpt
@@ -6,9 +6,7 @@ pdo_mysql
 <?php
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 MySQLPDOTest::skip();
-if (!extension_loaded('mysqli') || !extension_loaded('mysqlnd')) {
-    die('skip: This test requires the loading of mysqli and mysqlnd');
-}
+if (!extension_loaded('mysqlnd')) die('skip: This test requires the loading of mysqlnd');
 ?>
 --FILE--
 <?php

--- a/ext/pdo_mysql/tests/gh-11587.phpt
+++ b/ext/pdo_mysql/tests/gh-11587.phpt
@@ -4,10 +4,10 @@ GH-11587 PHP8.1: Fixed the condition for result set values to be of native type,
 pdo_mysql
 --SKIPIF--
 <?php
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+MySQLPDOTest::skip();
 if (!extension_loaded('mysqli') || !extension_loaded('mysqlnd')) {
-    /* Need connection to detect library version */
-    require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
-    MySQLPDOTest::skip();
+    die('skip: This test requires the loading of mysqli and mysqlnd');
 }
 ?>
 --FILE--
@@ -34,7 +34,7 @@ SQL;
 
 $db->exec($insertTestTable);
 
-// PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = true
+echo "PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = true\n";
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 $results = $db->query('SELECT * FROM test');
@@ -42,7 +42,9 @@ foreach ($results as $result) {
     var_dump($result);
 }
 
-// PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = false
+echo "\n";
+
+echo "PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = false\n";
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 $results = $db->query('SELECT * FROM test');
@@ -50,7 +52,9 @@ foreach ($results as $result) {
     var_dump($result);
 }
 
-// PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = true
+echo "\n";
+
+echo "PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = true\n";
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 $results = $db->query('SELECT * FROM test');
@@ -58,13 +62,17 @@ foreach ($results as $result) {
     var_dump($result);
 }
 
-// PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = false
+echo "\n";
+
+echo "PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = false\n";
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 $results = $db->query('SELECT * FROM test');
 foreach ($results as $result) {
     var_dump($result);
 }
+
+echo "\n";
 
 echo 'done!';
 ?>
@@ -74,6 +82,7 @@ require __DIR__ . '/mysql_pdo_test.inc';
 MySQLPDOTest::dropTestTable();
 ?>
 --EXPECT--
+PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = true
 array(8) {
   ["id"]=>
   string(1) "1"
@@ -92,6 +101,8 @@ array(8) {
   [3]=>
   string(4) "4.60"
 }
+
+PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = false
 array(8) {
   ["id"]=>
   int(1)
@@ -110,6 +121,8 @@ array(8) {
   [3]=>
   string(4) "4.60"
 }
+
+PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = true
 array(8) {
   ["id"]=>
   string(1) "1"
@@ -128,6 +141,8 @@ array(8) {
   [3]=>
   string(4) "4.60"
 }
+
+PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = false
 array(8) {
   ["id"]=>
   int(1)
@@ -146,4 +161,5 @@ array(8) {
   [3]=>
   string(4) "4.60"
 }
+
 done!


### PR DESCRIPTION
Issue: https://github.com/php/php-src/issues/11587
Original PR: https://github.com/php/php-src/pull/11616

```
PDO::ATTR_EMULATE_PREPARES = true
PDO::ATTR_STRINGIFY_FETCHES = true
```

Fixed a problem in which the float(M, D) type and double(M, D) type values retrieved from mysql changed between php8.0 or earlier and 8.1 or later when the above conditions were met.

Please see issue for details.