### PR TITLE
GH-10141: Fix typo

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1639,7 +1639,7 @@ ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_noreturn(int type, const char *
 
 ZEND_API ZEND_COLD ZEND_NORETURN void zend_strerror_noreturn(int type, int errn, const char *message)
 {
-#ifdef HAVE_STR_ERROR_R
+#ifdef HAVE_STRERROR_R
 	char buf[1024];
 	strerror_r(errn, buf, sizeof(buf));
 #else


### PR DESCRIPTION
In configure.ac check for function strerror_r defines constant HAVE_STRERROR_R.

The functionality was added in #10141 but I think that due to this change maybe PHP 8.3 version would be enough to fix it like this. Otherwise, in PHP 8.2 and 8.1 it will always do only this `char *buf = strerror(errn);`.

Edit: This needs to be adjusted a bit further due to unused result issue in the strerror_r() call.