### PR TITLE
ext/session/tests: more lenient expected output checks

### DIFF
--- a/ext/session/tests/bug74514.phpt
+++ b/ext/session/tests/bug74514.phpt
@@ -25,10 +25,10 @@ var_dump(session_save_path());
 var_dump(session_cache_limiter());
 var_dump(session_cache_expire());
 ?>
---EXPECT--
-string(9) "PHPSESSID"
-string(3) "foo"
-string(5) "files"
-string(0) ""
-string(7) "nocache"
-int(180)
+--EXPECTF--
+string(%d) "%S"
+string(%d) "%S"
+string(%d) "%S"
+string(%d) "%S"
+string(%d) "%S"
+int(%d)

--- a/ext/session/tests/bug74936.phpt
+++ b/ext/session/tests/bug74936.phpt
@@ -14,7 +14,7 @@ var_dump(session_cache_expire());
 var_dump(session_cache_limiter());
 var_dump(session_save_path());
 ?>
---EXPECT--
-int(180)
-string(7) "nocache"
-string(0) ""
+--EXPECTF--
+int(%d)
+string(%d) "%S"
+string(%d) "%S"

--- a/ext/session/tests/user_session_module/gh7787.phpt
+++ b/ext/session/tests/user_session_module/gh7787.phpt
@@ -78,10 +78,10 @@ session_write_close();
 
 ?>
 --EXPECTF--
-Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: MySessionHandler::write) in %s on line %d
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: %S, handler: MySessionHandler::write) in %s on line %d
 
-Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: MySessionHandler::updateTimestamp) in %s on line %d
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: %S, handler: MySessionHandler::updateTimestamp) in %s on line %d
 
-Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: write) in %s on line %d
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: %S, handler: write) in %s on line %d
 
-Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: , handler: update_timestamp) in %s on line %d
+Warning: session_write_close(): Failed to write session data using user defined save handler. (session.save_path: %S, handler: update_timestamp) in %s on line %d


### PR DESCRIPTION
Several session tests incidentally check the values of INI variables like session.name and session.save_path. This isn't the point of the tests, and it can cause spurious failures if (for example) you want to override your temporary directory while testing. So here, we make the expected output patterns more lenient.