### PR TITLE
Fix double-compilation of arrow-function

### DIFF
--- a/Zend/tests/oss_fuzz_60441.phpt
+++ b/Zend/tests/oss_fuzz_60441.phpt
@@ -1,0 +1,11 @@
+--TEST--
+oss-fuzz #60441 (Double compilation of arrow function)
+--FILE--
+<?php
+assert(fn()=>y)[y]??=y;
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Undefined constant "y" in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -7425,7 +7425,7 @@ static void zend_compile_func_decl(znode *result, zend_ast *ast, bool toplevel) 
 		zend_compile_closure_uses(uses_ast);
 	}
 
-	if (ast->kind == ZEND_AST_ARROW_FUNC) {
+	if (ast->kind == ZEND_AST_ARROW_FUNC && decl->child[2]->kind != ZEND_AST_RETURN) {
 		bool needs_return = true;
 		if (op_array->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
 			zend_arg_info *return_info = CG(active_op_array)->arg_info - 1;


### PR DESCRIPTION
We transform the arrow function by nesting the expression into a return statement. If we compile the arrow function twice this would be done twice, leading to a compile assertion.

Fix oss-fuzz #60411

I'm kind of questioning whether it would've been better to force memoization of just assert for now. This would be in line with https://github.com/php/php-src/pull/11592. Regardless, compilation should be idempotent, so this change is good nonetheless.