### PR TITLE
zend_call_stack_get implementation for NetBSD.

### DIFF
--- a/Zend/zend_call_stack.h
+++ b/Zend/zend_call_stack.h
@@ -30,7 +30,6 @@
 typedef struct _zend_call_stack {
 	void *base;
 	size_t max_size;
-	void *buf;
 } zend_call_stack;
 
 ZEND_API void zend_call_stack_init(void);

--- a/Zend/zend_call_stack.h
+++ b/Zend/zend_call_stack.h
@@ -30,6 +30,7 @@
 typedef struct _zend_call_stack {
 	void *base;
 	size_t max_size;
+	void *buf;
 } zend_call_stack;
 
 ZEND_API void zend_call_stack_init(void);


### PR DESCRIPTION
Despite being OpenBSD's predecessor, the approach is in fact a lot closer to Linux, at least in principle. We purposely avoid reading /proc/N/maps to be more future-proof.