### PR TITLE
Don't point to bugs.php.net for security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Documentation issue
     url: https://github.com/php/doc-en/issues
     about: Please report documentation issues on the doc-en repository.
-  - name: Security issue
-    url: https://bugs.php.net/report.php?security_bug
-    about: Please report security issues in this private bug tracker.


### PR DESCRIPTION
When submitting a new issue, there is already a "Report a security vulnerability" option for creating a GH security advisory. Remove the additional link for creating a security issue on bugs.php.net.