### PR TITLE
add SKIP_SLOW_TEST's + slow locator script

### DIFF
--- a/benchmark/find_slow_tests.php
+++ b/benchmark/find_slow_tests.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use function var_dump as d;
+use function arsort as arrsort;
+
+define("IS_WINDOWS", PHP_OS_FAMILY === "Windows");
+$php_binary = implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'sapi', 'cli', 'php']);
+if (IS_WINDOWS) {
+    $php_binary .= '.exe';
+}
+if (!is_executable($php_binary)) {
+    echo "Error: Cannot find php binary at '{$php_binary}'\n";
+    exit(1);
+}
+$php_binary = realpath($php_binary);
+$php_src_dir = realpath(implode(DIRECTORY_SEPARATOR, [__DIR__, '..']));
+$php_src_dir_relative_cutoff = strlen($php_src_dir) + strlen(DIRECTORY_SEPARATOR);
+$test_files = (function () use ($php_src_dir): array {
+    $test_files = [];
+    $dir = new RecursiveDirectoryIterator($php_src_dir);
+    $iterator = new RecursiveIteratorIterator($dir);
+    foreach ($iterator as $file) {
+        /** @var SplFileInfo $file */
+        if ($file->getExtension() !== 'phpt') {
+            continue;
+        }
+        $test_files[] = $file->getPathname();
+    }
+    return $test_files;
+})();
+$results_raw = [];
+$cmd_template = implode(" ", array(
+    escapeshellarg($php_binary),
+    escapeshellarg(realpath(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'run-tests.php']))),
+//    '-p ' . escapeshellarg($php_binary),
+    '--no-color',
+    '--no-progress',
+    '-q',
+    '-x', // SKIP_SLOW_TESTS 
+    '',
+));
+$total = count($test_files);
+$null_path = IS_WINDOWS ? 'NUL' : '/dev/null'; // funfact, on Windows, every single directory has a null device file named "NUL" ...
+foreach ($test_files as $test_no => $test_file) {
+    $test_file_relative = substr($test_file, $php_src_dir_relative_cutoff);
+    echo "Running test " . ($test_no + 1) . "/{$total}: {$test_file_relative}\n";
+    $best_time = INF;
+    $cmd = $cmd_template . escapeshellarg($test_file) . " > {$null_path} 2>&1";
+    for ($testrun = 0; $testrun < 3; ++$testrun) {
+        $start = microtime(true);
+        passthru($cmd);
+        $end = microtime(true);
+        $best_time = min($best_time, $end - $start);
+    }
+    echo "Best time: {$best_time}s\n";
+    $results_raw[$test_file_relative] = $best_time;
+}
+$results_sorted = $results_raw;
+arrsort($results_sorted, SORT_NUMERIC);
+var_export($results_sorted);

--- a/ext/curl/tests/bug48203_multi.phpt
+++ b/ext/curl/tests/bug48203_multi.phpt
@@ -2,6 +2,13 @@
 Variation of bug #48203 with curl_multi_exec (Crash when file pointers passed to curl are closed before calling curl_multi_exec)
 --EXTENSIONS--
 curl
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.34s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 include 'server.inc';

--- a/ext/curl/tests/bug54798-unix.phpt
+++ b/ext/curl/tests/bug54798-unix.phpt
@@ -7,6 +7,10 @@ curl
 if(substr(PHP_OS, 0, 3) == 'WIN' ) {
     die('skip not for Windows');
 }
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.37s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
 ?>
 --FILE--
 <?php

--- a/ext/curl/tests/bug54798.phpt
+++ b/ext/curl/tests/bug54798.phpt
@@ -2,6 +2,13 @@
 Bug #54798 (Segfault when CURLOPT_STDERR file pointer is closed before calling curl_exec)
 --EXTENSIONS--
 curl
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.34s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/curl/tests/curl_pause_001.phpt
+++ b/ext/curl/tests/curl_pause_001.phpt
@@ -2,6 +2,13 @@
 Test CURL_READFUNC_PAUSE and curl_pause()
 --EXTENSIONS--
 curl
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.32s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 include 'server.inc';

--- a/ext/curl/tests/curl_setopt_ssl.phpt
+++ b/ext/curl/tests/curl_setopt_ssl.phpt
@@ -4,6 +4,10 @@ CURLOPT_SSL* basic client auth tests
 curl
 --SKIPIF--
 <?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.57s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
 if (!function_exists("proc_open")) die("skip no proc_open");
 exec('openssl version', $out, $code);
 if ($code > 0) die("skip couldn't locate openssl binary");

--- a/ext/pdo_sqlite/tests/common.phpt
+++ b/ext/pdo_sqlite/tests/common.phpt
@@ -2,6 +2,13 @@
 SQLite
 --EXTENSIONS--
 pdo_sqlite
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 2.22s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --REDIRECTTEST--
 return array(
 	'ENV' => array(

--- a/ext/standard/tests/general_functions/proc_open_pipes1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes1.phpt
@@ -1,5 +1,12 @@
 --TEST--
 proc_open() with > 16 pipes
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.14s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/proc_open_pipes2.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes2.phpt
@@ -1,5 +1,12 @@
 --TEST--
 proc_open() with no pipes
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.14s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/proc_open_pipes3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_pipes3.phpt
@@ -1,5 +1,12 @@
 --TEST--
 proc_open() with invalid pipes
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.15s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/proc_open_sockets1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets1.phpt
@@ -1,5 +1,12 @@
 --TEST--
 proc_open() with output socketpairs
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 2.14s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/proc_open_sockets2.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets2.phpt
@@ -1,5 +1,12 @@
 --TEST--
 proc_open() with IO socketpairs
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.15s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 

--- a/ext/standard/tests/general_functions/proc_open_sockets3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets3.phpt
@@ -1,5 +1,12 @@
 --TEST--
 proc_open() with socket and pipe
+--SKIPIF--
+<?php
+if (getenv("SKIP_SLOW_TESTS")) {
+    // finished in 1.15s in a best-of-3 on an idle Intel Xeon X5670 on PHP 8.3.0-dev
+    die("skip slow test");
+}
+?>
 --FILE--
 <?php
 

--- a/run-tests.php
+++ b/run-tests.php
@@ -386,7 +386,7 @@ function main(): void
         $argc = count($argv);
     }
 
-    for ($i = 1; $i < $argc; $i++) {
+    for ($i = 1; $i < $argc; ++$i) {
         $is_switch = false;
         $switch = substr($argv[$i], 1, 1);
         $repeat = substr($argv[$i], 0, 1) == '-';


### PR DESCRIPTION
made a script to look for tests everywhere, and run them all 3 times with SKIP_SLOW_TESTS set, and rank them all by best-of-3-runs, and found a couple of slow-ish tests and added SKIP_SLOW_TEST to them.

oh, and the run-tests.php thing is just a performance optimization really, in PHP (and some other languages) ++i is faster than i++ , also i++ is a strange operator, here is what i++ means: 
> make a copy of i, then increment the original, then return the copy.

by comparison, here is what ++i means:
> increment i and return it.

even in GCC you'll see ++i being faster than i++ on -O0 (disable optimizations), but gcc auto-optimize i++ to ++i on O1 and above ~ (at least this was true back in the gcc 4.x days)