### PR TITLE
ext/sockets/tests/mcast_ipv6_*.phpt: suppress no-ipv6 warning

### DIFF
--- a/ext/sockets/tests/mcast_ipv6_recv.phpt
+++ b/ext/sockets/tests/mcast_ipv6_recv.phpt
@@ -8,7 +8,9 @@ sockets
 if (!defined('IPPROTO_IPV6')) {
     die('skip IPv6 not available.');
 }
-$s = socket_create(AF_INET6, SOCK_DGRAM, SOL_UDP);
+// hide the output from socket_create() because it can raise
+// a warning if (for example) the linux kernel is lacking ipv6
+$s = @socket_create(AF_INET6, SOCK_DGRAM, SOL_UDP);
 if ($s === false) {
   die("skip unable to create socket");
 }

--- a/ext/sockets/tests/mcast_ipv6_recv_limited.phpt
+++ b/ext/sockets/tests/mcast_ipv6_recv_limited.phpt
@@ -8,7 +8,12 @@ sockets
 if (!defined('IPPROTO_IPV6')) {
     die('skip IPv6 not available.');
 }
-$s = socket_create(AF_INET6, SOCK_DGRAM, SOL_UDP);
+// hide the output from socket_create() because it can raise
+// a warning if (for example) the linux kernel is lacking ipv6
+$s = @socket_create(AF_INET6, SOCK_DGRAM, SOL_UDP);
+if ($s === false) {
+    die("skip unable to create socket");
+}
 $br = socket_bind($s, '::', 3000);
 /* On Linux, there is no route ff00::/8 by default on lo, which makes it
  * troublesome to send multicast traffic from lo, which we must since

--- a/ext/sockets/tests/mcast_ipv6_send.phpt
+++ b/ext/sockets/tests/mcast_ipv6_send.phpt
@@ -9,7 +9,10 @@ if (getenv('CI_NO_IPV6') || !defined('IPPROTO_IPV6')) {
     die('skip IPv6 not available.');
 }
 $level = IPPROTO_IPV6;
-$s = socket_create(AF_INET6, SOCK_DGRAM, SOL_UDP) or die("skip Cannot create socket");
+
+// hide the output from socket_create() because it can raise
+// a warning if (for example) the linux kernel is lacking ipv6
+$s = @socket_create(AF_INET6, SOCK_DGRAM, SOL_UDP) or die("skip Cannot create socket");
 if (socket_set_option($s, $level, IPV6_MULTICAST_IF, 1) === false) {
     die("skip interface 1 either doesn't exist or has no ipv6 address");
 }


### PR DESCRIPTION
These three tests try to create an ipv6 socket with socket_create() to determine if they should be skipped. On certain systems lacking ipv6 support, however, the call to socket_create() itself raises a warning:

  BORK Warning: socket_create(): Unable to create socket [97]: Address
  family not supported by protocol in ...

The output is "borked" because the return value (false) is expected but the text of the warning is not. This commit uses the error control operator (@) to hide the warning. Afterwards the tests are skipped normally on such a system.