### PR TITLE
ext/imap/tests/*mutf7*.phpt: update for missing utf8_to_mutf7()

### DIFF
--- a/ext/imap/tests/imap_mutf7_to_utf8.phpt
+++ b/ext/imap/tests/imap_mutf7_to_utf8.phpt
@@ -2,6 +2,15 @@
 imap_mutf7_to_utf8
 --EXTENSIONS--
 imap
+--SKIPIF--
+<?php
+    // The underlying utf8_from_mutf7 function can be missing; there's
+    // a ./configure check for it that disables the corresponding PHP
+    // function.
+    if (!function_exists('imap_mutf7_to_utf8')) {
+        die("skip no imap_mutf7_to_utf8 function");
+    }
+?>
 --FILE--
 <?php
 

--- a/ext/imap/tests/imap_mutf7_to_utf8.phpt
+++ b/ext/imap/tests/imap_mutf7_to_utf8.phpt
@@ -4,12 +4,11 @@ imap_mutf7_to_utf8
 imap
 --SKIPIF--
 <?php
-    // The underlying utf8_from_mutf7 function can be missing; there's
-    // a ./configure check for it that disables the corresponding PHP
-    // function.
-    if (!function_exists('imap_mutf7_to_utf8')) {
-        die("skip no imap_mutf7_to_utf8 function");
-    }
+// The underlying imap_mutf7_to_utf8 function can be missing; there's a
+// ./configure check for it that disables the corresponding PHP function.
+if (!function_exists('imap_mutf7_to_utf8')) {
+    die("skip no imap_mutf7_to_utf8 function");
+}
 ?>
 --FILE--
 <?php

--- a/ext/imap/tests/imap_utf8_to_mutf7_basic.phpt
+++ b/ext/imap/tests/imap_utf8_to_mutf7_basic.phpt
@@ -2,6 +2,15 @@
 imap_utf8_to_mutf7
 --EXTENSIONS--
 imap
+--SKIPIF--
+<?php
+    // The underlying utf8_to_mutf7 function can be missing; there's
+    // a ./configure check for it that disables the corresponding PHP
+    // function.
+    if (!function_exists('imap_utf8_to_mutf7')) {
+        die("skip no imap_utf8_to_mutf7 function");
+    }
+?>
 --FILE--
 <?php
 

--- a/ext/imap/tests/imap_utf8_to_mutf7_basic.phpt
+++ b/ext/imap/tests/imap_utf8_to_mutf7_basic.phpt
@@ -4,12 +4,11 @@ imap_utf8_to_mutf7
 imap
 --SKIPIF--
 <?php
-    // The underlying utf8_to_mutf7 function can be missing; there's
-    // a ./configure check for it that disables the corresponding PHP
-    // function.
-    if (!function_exists('imap_utf8_to_mutf7')) {
-        die("skip no imap_utf8_to_mutf7 function");
-    }
+// The underlying imap_utf8_to_mutf7 function can be missing; there's a
+// ./configure check for it that disables the corresponding PHP function.
+if (!function_exists('imap_utf8_to_mutf7')) {
+    die("skip no imap_utf8_to_mutf7 function");
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
Our ./configure script (ext/imap/config.m4) checks for the utf8_to_mutf7() function in the c-client library, and defines HAVE_IMAP_MUTF7 only if it exists. The two corresponding PHP functions are disabled when it does not, but their tests do not account for that. Here we add two SKIPIFs to hand that scenario.