### PR TITLE
ext/intl: Fix memory leak in MessageFormatter::format() 

### DIFF
--- a/ext/intl/tests/gh11658.phpt
+++ b/ext/intl/tests/gh11658.phpt
@@ -1,0 +1,15 @@
+--TEST--
+GitHub #11658 MessageFormatter::format() leaks memory
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+ini_set("intl.error_level", E_WARNING);
+
+$s = MessageFormatter::formatMessage('en', 'some {wrong.format}', []);
+var_dump($s);
+?>
+--EXPECTF--
+Warning: MessageFormatter::formatMessage(): pattern syntax error (parse error at offset 6, after "some {", before or at "wrong.format}") in %s on line %d
+bool(false)


### PR DESCRIPTION
Found while investigating #11614 this is probably present in all versions of PHP and we need a regression test, and probably inform about the proper reason.

@danog do you know which test in https://github.com/zoonru/Valinor might have caused this leak to happen?