### PR TITLE
Fix tests for stat rdev

### DIFF
--- a/ext/standard/tests/file/lstat_stat_variation18.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation18.phpt
@@ -88,7 +88,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>
@@ -144,7 +144,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>

--- a/ext/standard/tests/file/lstat_stat_variation19.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation19.phpt
@@ -89,7 +89,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>
@@ -143,7 +143,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>
@@ -199,7 +199,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>
@@ -253,7 +253,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>

--- a/ext/standard/tests/file/lstat_stat_variation20.phpt
+++ b/ext/standard/tests/file/lstat_stat_variation20.phpt
@@ -98,7 +98,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>
@@ -154,7 +154,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>
@@ -208,7 +208,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>
@@ -262,7 +262,7 @@ array(26) {
   ["gid"]=>
   int(%d)
   ["rdev"]=>
-  int(%d)
+  int(%i)
   ["size"]=>
   int(%d)
   ["atime"]=>


### PR DESCRIPTION
If HAVE_STRUCT_STAT_ST_RDEV is not set, rdev will be -1. %d only matches a natural number, we should let it match negative numbers too.
This is a partial fix for GH-11666, the diskfreespace test fails but that's for a unknown yet reason.