### PR TITLE
tests: add missing TEST_PHP_EXTRA_ARGS

### DIFF
--- a/.github/scripts/windows/test_task.bat
+++ b/.github/scripts/windows/test_task.bat
@@ -88,9 +88,12 @@ set OPENSSL_CONF=
 rem set SSLEAY_CONF=
 
 rem prepare for OPcache
+set PHP_BUILD_DIR=%PHP_BUILD_OBJ_DIR%\Release
+if "%THREAD_SAFE%" equ "1" set PHP_BUILD_DIR=%PHP_BUILD_DIR%_TS
+
 if "%OPCACHE%" equ "1" set OPCACHE_OPTS=-d opcache.enable=1 -d opcache.enable_cli=1 -d opcache.protect_memory=1 -d opcache.jit_buffer_size=64M -d opcache.jit=tracing
 rem work-around for failing to dl(mysqli) with OPcache (https://github.com/php/php-src/issues/8508)
-if "%OPCACHE%" equ "1" set OPCACHE_OPTS=%OPCACHE_OPTS% -d extension=mysqli
+if "%OPCACHE%" equ "1" set OPCACHE_OPTS=%OPCACHE_OPTS% -d extension=mysqli -d extension_dir=%PHP_BUILD_DIR%
 
 rem prepare for enchant
 mkdir %~d0\usr\local\lib\enchant-2
@@ -110,9 +113,6 @@ rem prepare for snmp
 set MIBDIRS=%DEPS_DIR%\share\mibs
 sed -i "s/exec HexTest .*/exec HexTest cscript\.exe \/nologo %GITHUB_WORKSPACE:\=\/%\/ext\/snmp\/tests\/bigtest\.js/g" %GITHUB_WORKSPACE%\ext\snmp\tests\snmpd.conf
 start %DEPS_DIR%\bin\snmpd.exe -C -c %GITHUB_WORKSPACE%\ext\snmp\tests\snmpd.conf -Ln
-
-set PHP_BUILD_DIR=%PHP_BUILD_OBJ_DIR%\Release
-if "%THREAD_SAFE%" equ "1" set PHP_BUILD_DIR=%PHP_BUILD_DIR%_TS
 
 rem prepare for mail
 curl -sLo hMailServer.exe https://www.hmailserver.com/download_file/?downloadid=271

--- a/ext/standard/tests/file/bug60120.phpt
+++ b/ext/standard/tests/file/bug60120.phpt
@@ -14,7 +14,9 @@ if (PHP_OS_FAMILY === 'Windows') die('skip not for Windows');
 error_reporting(E_ALL);
 
 $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
-$cmd = $php . ' -r "\$in = file_get_contents(\'php://stdin\'); fwrite(STDOUT, \$in); fwrite(STDERR, \$in);"';
+$args = getenv('TEST_PHP_EXTRA_ARGS');
+$cmd = ' -r "\$in = file_get_contents(\'php://stdin\'); fwrite(STDOUT, \$in); fwrite(STDERR, \$in);"';
+$cmd = join(' ', [$php, $args, $cmd]);
 $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
 $stdin = str_repeat('*', 2049 );
 

--- a/ext/standard/tests/general_functions/proc_open_null.phpt
+++ b/ext/standard/tests/general_functions/proc_open_null.phpt
@@ -4,7 +4,8 @@ Null pipes in proc_open()
 <?php
 
 $php = getenv('TEST_PHP_EXECUTABLE');
-$cmd = [$php, '-r', 'echo "Test"; fprintf(STDERR, "Error");'];
+$args = getenv('TEST_PHP_EXTRA_ARGS');
+$cmd = "$php $args -r 'echo \"Test\"; fprintf(STDERR, \"Error\");'";
 
 $proc = proc_open($cmd, [1 => ['null'], 2 => ['pipe', 'w']], $pipes);
 var_dump($pipes);

--- a/ext/standard/tests/general_functions/proc_open_null.phpt
+++ b/ext/standard/tests/general_functions/proc_open_null.phpt
@@ -5,7 +5,9 @@ Null pipes in proc_open()
 
 $php = getenv('TEST_PHP_EXECUTABLE');
 $args = getenv('TEST_PHP_EXTRA_ARGS');
-$cmd = "$php $args -r 'echo \"Test\"; fprintf(STDERR, \"Error\");'";
+$fn = tempnam(sys_get_temp_dir(), "PROC_OPEN_TEST");
+$cmd = "$php $args " . escapeshellarg($fn);
+file_put_contents($fn, '<?php echo "Test"; fprintf(STDERR, "Error");');
 
 $proc = proc_open($cmd, [1 => ['null'], 2 => ['pipe', 'w']], $pipes);
 var_dump($pipes);
@@ -16,16 +18,17 @@ $proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['null']], $pipes);
 var_dump($pipes);
 var_dump(stream_get_contents($pipes[1]));
 proc_close($proc);
+unlink($fn);
 
 ?>
 --EXPECT--
 array(1) {
   [2]=>
-  resource(4) of type (stream)
+  resource(6) of type (stream)
 }
 string(5) "Error"
 array(1) {
   [1]=>
-  resource(6) of type (stream)
+  resource(8) of type (stream)
 }
 string(4) "Test"

--- a/ext/standard/tests/general_functions/proc_open_redirect.phpt
+++ b/ext/standard/tests/general_functions/proc_open_redirect.phpt
@@ -4,26 +4,29 @@ Redirection support in proc_open
 <?php
 
 $php = getenv('TEST_PHP_EXECUTABLE');
+$args = getenv('TEST_PHP_EXTRA_ARGS');
+$cmd = "$php $args";
+
 try {
-    proc_open([$php], [['redirect']], $pipes);
+    proc_open($cmd, [['redirect']], $pipes);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
 try {
-    proc_open([$php], [['redirect', 'foo']], $pipes);
+    proc_open($cmd, [['redirect', 'foo']], $pipes);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
 try {
-    proc_open([$php], [['redirect', 42]], $pipes);
+    proc_open($cmd, [['redirect', 42]], $pipes);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
 echo "\nWith pipe:\n";
-$cmd = [$php, '-r', 'echo "Test\n"; fprintf(STDERR, "Error");'];
+$cmd = "$php $args -r 'echo \"Test\n\"; fprintf(STDERR, \"Error\");'";
 $proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['redirect', 1]], $pipes);
 var_dump($pipes);
 var_dump(stream_get_contents($pipes[1]));

--- a/ext/standard/tests/general_functions/proc_open_redirect.phpt
+++ b/ext/standard/tests/general_functions/proc_open_redirect.phpt
@@ -26,7 +26,9 @@ try {
 }
 
 echo "\nWith pipe:\n";
-$cmd = "$php $args -r 'echo \"Test\n\"; fprintf(STDERR, \"Error\");'";
+$fn = tempnam(sys_get_temp_dir(), "PROC_OPEN_TEST");
+file_put_contents($fn, '<?php echo "Test\n"; fprintf(STDERR, "Error");');
+$cmd = "$php $args " . escapeshellarg($fn);
 $proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['redirect', 1]], $pipes);
 var_dump($pipes);
 var_dump(stream_get_contents($pipes[1]));
@@ -52,6 +54,7 @@ unlink($fileName);
 echo "\nWith inherited stdout:\n";
 $proc = proc_open($cmd, [2 => ['redirect', 1]], $pipes);
 proc_close($proc);
+unlink($fn);
 
 ?>
 --EXPECTF--
@@ -63,7 +66,7 @@ Warning: proc_open(): Redirection target 42 not found in %s
 With pipe:
 array(1) {
   [1]=>
-  resource(4) of type (stream)
+  resource(6) of type (stream)
 }
 string(10) "Test
 Error"

--- a/ext/standard/tests/general_functions/proc_open_sockets1.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets1.phpt
@@ -7,10 +7,9 @@ if (getenv("SKIP_SLOW_TESTS")) die("skip slow test");
 --FILE--
 <?php
 
-$cmd = [
-    getenv("TEST_PHP_EXECUTABLE"),
-    __DIR__ . '/proc_open_sockets1.inc'
-];
+$php = getenv("TEST_PHP_EXECUTABLE");
+$args = getenv("TEST_PHP_EXTRA_ARGS");
+$cmd = "$php $args " . __DIR__ . '/proc_open_sockets1.inc';
 
 $spec = [
     ['null'],

--- a/ext/standard/tests/general_functions/proc_open_sockets2.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets2.phpt
@@ -34,10 +34,9 @@ function write_pipe($pipe, $data)
     }
 }
 
-$cmd = [
-    getenv("TEST_PHP_EXECUTABLE"),
-    __DIR__ . '/proc_open_sockets2.inc'
-];
+$php = getenv("TEST_PHP_EXECUTABLE");
+$args = getenv("TEST_PHP_EXTRA_ARGS");
+$cmd = "$php $args " . __DIR__ . '/proc_open_sockets2.inc';
 
 $spec = [
     ['socket'],

--- a/ext/standard/tests/general_functions/proc_open_sockets3.phpt
+++ b/ext/standard/tests/general_functions/proc_open_sockets3.phpt
@@ -25,10 +25,9 @@ function read_pipe($pipe): string
     return $chunk;
 }
 
-$cmd = [
-    getenv("TEST_PHP_EXECUTABLE"),
-    __DIR__ . '/proc_open_sockets2.inc'
-];
+$php = getenv("TEST_PHP_EXECUTABLE");
+$args = getenv("TEST_PHP_EXTRA_ARGS");
+$cmd = "$php $args " . __DIR__ . '/proc_open_sockets2.inc';
 
 $spec = [
     ['pipe', 'r'],

--- a/ext/standard/tests/ini_info/php_ini_loaded_file.phpt
+++ b/ext/standard/tests/ini_info/php_ini_loaded_file.phpt
@@ -2,15 +2,16 @@
 php_ini_loaded_file() function
 --FILE--
 <?php
-    $inifile = __DIR__.DIRECTORY_SEPARATOR.'loaded.ini';
+    $inifile = escapeshellarg(__DIR__.DIRECTORY_SEPARATOR.'loaded.ini');
     $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+    $args = getenv('TEST_PHP_EXTRA_ARGS');
     $code = '"var_dump(php_ini_loaded_file());"';
 
     // No ini file
-    passthru($php.' -n -r '.$code);
+    passthru("$php $args -n -r $code");
 
     // Specified ini file
-    passthru($php.' -c '.escapeshellarg($inifile).' -r '.$code);
+    passthru("$php $args -c $inifile -r $code");
 ?>
 --EXPECTREGEX--
 bool\(false\)

--- a/sapi/cli/tests/016.phpt
+++ b/sapi/cli/tests/016.phpt
@@ -12,6 +12,7 @@ if (readline_info('done') === NULL) {
 --FILE--
 <?php
 $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+$args = getenv('TEST_PHP_EXTRA_ARGS');
 
 // disallow console escape sequences that may break the output
 putenv('TERM=VT100');
@@ -56,7 +57,7 @@ EOT;
 foreach ($codes as $key => $code) {
     echo "\n--------------\nSnippet no. $key:\n--------------\n";
     $code = escapeshellarg($code);
-    echo `echo $code | $php -a`, "\n";
+    echo `echo $code | $php $args -a`, "\n";
 }
 
 echo "\nDone\n";

--- a/sapi/cli/tests/023.phpt
+++ b/sapi/cli/tests/023.phpt
@@ -8,18 +8,19 @@ if (substr(PHP_OS, 0, 3) == "WIN") die("skip non windows test");
 --FILE--
 <?php
 $php = getenv("TEST_PHP_EXECUTABLE_ESCAPED");
+$args = getenv("TEST_PHP_EXTRA_ARGS");
 $cwd = getcwd();
 $ini_file = __DIR__ . "/023.ini";
 $ini_file_escaped = escapeshellarg($ini_file);
 file_put_contents($ini_file, <<<INI
 ; no sections should match as cli doesn't support any
-memory_limit = 40M
+max_input_vars = 4
 [PATH={$cwd}]
-memory_limit = 50M
+max_input_vars = 5
 [PATH=/does/not/exist]
-memory_limit = 60M
+max_input_vars = 6
 [HOST=some_fake_host]
-memory_limit = 70M
+max_input_vars = 7
 INI
 );
 $desc = array(
@@ -28,7 +29,7 @@ $desc = array(
     2 => array("pipe", "w"),
 );
 $pipes = array();
-$proc = proc_open("$php -c $ini_file_escaped -r 'echo ini_get(\"memory_limit\");'", $desc, $pipes);
+$proc = proc_open("$php $args -c $ini_file_escaped -r 'echo ini_get(\"max_input_vars\");'", $desc, $pipes);
 if (!$proc) {
     exit(1);
 }
@@ -43,5 +44,5 @@ proc_close($proc);
 unlink(__DIR__ . "/023.ini");
 ?>
 --EXPECT--
-string(3) "40M"
+string(1) "4"
 string(0) ""

--- a/sapi/cli/tests/bug65275.phpt
+++ b/sapi/cli/tests/bug65275.phpt
@@ -4,7 +4,8 @@ Bug #65275: Calling exit() in a shutdown function does not change the exit value
 <?php
 
 $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
-exec($php . ' ' . escapeshellarg(__DIR__ . '/bug65275.inc'), $output, $exit_status);
+$args = getenv('TEST_PHP_EXTRA_ARGS');
+exec($php . ' ' . $args . ' ' . escapeshellarg(__DIR__ . '/bug65275.inc'), $output, $exit_status);
 var_dump($exit_status);
 
 ?>

--- a/sapi/cli/tests/bug74600.phpt
+++ b/sapi/cli/tests/bug74600.phpt
@@ -8,6 +8,7 @@ if (substr(PHP_OS, 0, 3) == "WIN") die("skip non windows test");
 --FILE--
 <?php
 $php = getenv("TEST_PHP_EXECUTABLE_ESCAPED");
+$args = getenv("TEST_PHP_EXTRA_ARGS");
 $ini_file = __DIR__ . "/bug74600.ini";
 $ini_file_escaped = escapeshellarg($ini_file);
 file_put_contents($ini_file, <<<INI
@@ -20,7 +21,7 @@ $desc = array(
     2 => array("pipe", "w"),
 );
 $pipes = array();
-$proc = proc_open("$php -c $ini_file_escaped -r 'echo \"okey\";'", $desc, $pipes);
+$proc = proc_open("$php $args -c $ini_file_escaped -r 'echo \"okey\";'", $desc, $pipes);
 if (!$proc) {
     exit(1);
 }

--- a/sapi/cli/tests/bug78323.phpt
+++ b/sapi/cli/tests/bug78323.phpt
@@ -7,6 +7,7 @@ include "skipif.inc";
 --FILE--
 <?php
 $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+$args = getenv('TEST_PHP_EXTRA_ARGS');
 
 // There are 3 types of option errors:
 // 1 : in flags
@@ -16,7 +17,7 @@ $php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
 
 // colon in flags
 ob_start();
-passthru("$php -a:Z 2>&1", $exitCode);
+passthru("$php $args -a:Z 2>&1", $exitCode);
 $output = ob_get_contents();
 ob_end_clean();
 
@@ -28,7 +29,7 @@ echo $lines[0], "\n",
 
 // option not found
 ob_start();
-passthru("$php -Z 2>&1", $exitCode);
+passthru("$php $args -Z 2>&1", $exitCode);
 $output = ob_get_contents();
 ob_end_clean();
 
@@ -40,7 +41,7 @@ echo $lines[0], "\n",
 
 // no argument for option
 ob_start();
-passthru("$php --memory-limit=1G 2>&1", $exitCode);
+passthru("$php $args --memory-limit=1G 2>&1", $exitCode);
 $output = ob_get_contents();
 ob_end_clean();
 
@@ -52,7 +53,7 @@ echo $lines[0], "\n",
 
 // Successful execution
 ob_start();
-passthru("$php -dmemory-limit=1G -v", $exitCode);
+passthru("$php $args -dmemory-limit=1G -v", $exitCode);
 $output = ob_get_contents();
 ob_end_clean();
 


### PR DESCRIPTION
If I test a debug build while I have a non-debug PHP installed on the system, I get a bunch of test failures that can all be traced back to,

```
$ sapi/cli/php 
Failed loading /usr/lib64/php8.2/lib64/opcache.so:  /usr/lib64/php8.2/lib64/opcache.so: undefined symbol: _emalloc_32
```

The non-debug `opcache.so` is trying to load from the system's INI file.

Of course, I'm running the tests with `sapi/cli/php -n ./run-tests.php -n`, but the `-n` is not always passed to sub-invocations of PHP inside the test cases. This PR fixes most of them by passing `TEST_PHP_EXTRA_ARGS` to those invocations, but a few (described in the commit message) were much simpler to fix with only an `-n`.