### PR TITLE
Fix GH-10914: OPCache with Enum and Callback functions results in segmentation fault

### DIFF
--- a/ext/opcache/tests/gh10914.phpt
+++ b/ext/opcache/tests/gh10914.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-10914 (OPCache with Enum and Callback functions results in segmentation fault)
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.protect_memory=1
+opcache.preload={PWD}/preload_gh10914.inc
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY == 'Windows') die('skip Preloading is not supported on Windows');
+?>
+--FILE--
+<?php
+$x = new ReflectionEnum(ExampleEnum::class);
+var_dump($x->getCases()[0]->getValue());
+var_dump($x->getCases()[0]->getBackingValue());
+var_dump($x->getCase('FIRST')->getValue());
+var_dump($x->getCase('FIRST')->getBackingValue());
+?>
+--EXPECT--
+enum(ExampleEnum::FIRST)
+string(4) "AAAb"
+enum(ExampleEnum::FIRST)
+string(4) "AAAb"

--- a/ext/opcache/tests/preload_gh10914.inc
+++ b/ext/opcache/tests/preload_gh10914.inc
@@ -1,0 +1,5 @@
+<?php
+enum ExampleEnum: string
+{
+    case FIRST = "AAA"."b";
+}

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -6798,7 +6798,7 @@ ZEND_METHOD(ReflectionEnum, getCase)
 
 	GET_REFLECTION_OBJECT_PTR(ce);
 
-	zend_class_constant *constant = zend_hash_find_ptr(&ce->constants_table, name);
+	zend_class_constant *constant = zend_hash_find_ptr(CE_CONSTANTS_TABLE(ce), name);
 	if (constant == NULL) {
 		zend_throw_exception_ex(reflection_exception_ptr, 0, "Case %s::%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(name));
 		RETURN_THROWS();
@@ -6825,7 +6825,7 @@ ZEND_METHOD(ReflectionEnum, getCases)
 	GET_REFLECTION_OBJECT_PTR(ce);
 
 	array_init(return_value);
-	ZEND_HASH_FOREACH_STR_KEY_PTR(&ce->constants_table, name, constant) {
+	ZEND_HASH_FOREACH_STR_KEY_PTR(CE_CONSTANTS_TABLE(ce), name, constant) {
 		if (ZEND_CLASS_CONST_FLAGS(constant) & ZEND_CLASS_CONST_IS_CASE) {
 			zval class_const;
 			reflection_enum_case_factory(ce, name, constant, &class_const);


### PR DESCRIPTION
Closes GH-10914.

See linked issue for analysis.