### PR TITLE
ext/posix: posix_isatty() fix use-of-uninitialized-value

### DIFF
--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -516,8 +516,9 @@ PHP_FUNCTION(posix_isatty)
 		if (!zend_parse_arg_long(z_fd, &fd, /* is_null */ NULL, /* check_null */ false, /* arg_num */ 1)) {
 			php_error_docref(NULL, E_WARNING, "Argument #1 ($file_descriptor) must be of type int|resource, %s given",
 				zend_zval_value_name(z_fd));
-			fd = zval_get_long(z_fd);
+			RETURN_FALSE;
 		}
+		fd = zval_get_long(z_fd);
 	}
 
 	/* A valid file descriptor must fit in an int and be positive */

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -518,7 +518,6 @@ PHP_FUNCTION(posix_isatty)
 				zend_zval_value_name(z_fd));
 			RETURN_FALSE;
 		}
-		fd = zval_get_long(z_fd);
 	}
 
 	/* A valid file descriptor must fit in an int and be positive */

--- a/ext/posix/tests/posix_isatty_manual_zpp.phpt
+++ b/ext/posix/tests/posix_isatty_manual_zpp.phpt
@@ -58,13 +58,9 @@ Warning: posix_isatty(): Argument #1 ($file_descriptor) must be of type int|reso
 bool(false)
 class:
 Warning: posix_isatty(): Argument #1 ($file_descriptor) must be of type int|resource, stdClass given in %s on line %d
-
-Warning: Object of class stdClass could not be converted to int in %s on line %d
 bool(false)
 stringable class:
 Warning: posix_isatty(): Argument #1 ($file_descriptor) must be of type int|resource, classWithToString given in %s on line %d
-
-Warning: Object of class classWithToString could not be converted to int in %s on line %d
 bool(false)
 int castable class:
 Warning: posix_isatty(): Argument #1 ($file_descriptor) must be of type int|resource, GMP given in %s on line %d


### PR DESCRIPTION
When the value passed is not representable as an int then it is not a TTY and thus should return false immediately. Moreover, we need to actually retrieve the zend_long from the zval.

This was reported by MSAN.