### PR TITLE
Add macro parameter for ARG_INFO( Zend send & receive )

### DIFF
--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1021,6 +1021,19 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 #define ZEND_SEND_BY_REF     1u
 #define ZEND_SEND_PREFER_REF 2u
 
+/* allow_null for zend_internal_arg_info.type.type_mask */
+#define ZEND_SEND_OPTIONAL     1u
+#define ZEND_SEND_NOTNULL      0u
+
+/* Z_PARAM_ZVAL_EX2 check_null */
+#define ZEND_RECEIVE_CONTAINER 0
+#define ZEND_RECEIVE_OPTIONAL 1
+
+/* Z_PARAM_ZVAL_EX2 deref */
+#define ZEND_RECEIVE_BY_REF 0
+#define ZEND_RECEIVE_BY_VAL 1
+
+
 #define ZEND_THROW_IS_EXPR 1u
 
 #define ZEND_FCALL_MAY_HAVE_EXTRA_NAMED_PARAMS 1

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -129,6 +129,18 @@ static ZEND_FUNCTION(zend_terminate_string)
 
 	ZSTR_VAL(str)[ZSTR_LEN(str)] = '\0';
 }
+/* Allow undeclared variable as output parameter. */
+static ZEND_FUNCTION(zend_out_param)
+{
+	zval *z_ref_preg_match;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL_EX2(z_ref_preg_match, ZEND_RECEIVE_CONTAINER, ZEND_RECEIVE_BY_REF, 0)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zval *z_preg_match = &(Z_REF_P(z_ref_preg_match)->val);
+	ZVAL_LONG(z_preg_match, 8);
+}
 
 /* Cause an intentional memory leak, for testing/debugging purposes */
 static ZEND_FUNCTION(zend_leak_bytes)

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -395,8 +395,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_iterable_legacy, 0, 1, IS_I
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, arg2, IS_ITERABLE, 1, "null")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_zend_out_param, 0, ZEND_SEND_BY_VAL, 1)
+    ZEND_ARG_TYPE_INFO(ZEND_SEND_BY_REF, z_ref_preg_match, IS_LONG, ZEND_SEND_OPTIONAL)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry ext_function_legacy[] = {
 	ZEND_FE(zend_iterable_legacy, arginfo_zend_iterable_legacy)
+	ZEND_FE(zend_out_param, arginfo_zend_out_param)
 	ZEND_FE_END
 };
 

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -156,7 +156,7 @@ namespace {
 
     function zend_terminate_string(string &$str): void {}
 
-    function zend_out_param(?int &$preg_match=null): void {}
+    function zend_out_param(int &$preg_match=null): void {}
 
     function zend_leak_variable(mixed $variable): void {}
 

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -156,6 +156,8 @@ namespace {
 
     function zend_terminate_string(string &$str): void {}
 
+    function zend_out_param(?int &$preg_match=null): void {}
+
     function zend_leak_variable(mixed $variable): void {}
 
     function zend_leak_bytes(int $bytes = 3): void {}


### PR DESCRIPTION
For review.

I have a doubt for ZEND_SEND_OPTIONAL. Would it be better to use ZEND_SEND_NULLABLE ?

It would be useful to add ZEND_RETURN_BY_VAL, ZEND_RETURN_BY_REF. 

Thanks.