### PR TITLE
Prevent int overflow on $decimals in number_format for PHP < 8.3

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1136,6 +1136,7 @@ PHP_FUNCTION(number_format)
 {
 	double num;
 	zend_long dec = 0;
+	int dec_int;
 	char *thousand_sep = NULL, *dec_point = NULL;
 	size_t thousand_sep_len = 0, dec_point_len = 0;
 
@@ -1156,7 +1157,17 @@ PHP_FUNCTION(number_format)
 		thousand_sep_len = 1;
 	}
 
-	RETURN_STR(_php_math_number_format_ex(num, (int)dec, dec_point, dec_point_len, thousand_sep, thousand_sep_len));
+#if SIZEOF_ZEND_LONG > SIZEOF_INT
+	if (dec >= 0) {
+		dec_int = dec > INT_MAX ? INT_MAX : (int)dec;
+	} else {
+		dec_int = dec <= INT_MIN ? INT_MIN : (int)dec;
+	}
+#else
+	dec_int = dec;
+#endif
+
+	RETURN_STR(_php_math_number_format_ex(num, dec_int, dec_point, dec_point_len, thousand_sep, thousand_sep_len));
 }
 /* }}} */
 

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1157,15 +1157,11 @@ PHP_FUNCTION(number_format)
 		thousand_sep_len = 1;
 	}
 
-#if SIZEOF_ZEND_LONG > SIZEOF_INT
 	if (dec >= 0) {
-		dec_int = dec > INT_MAX ? INT_MAX : (int)dec;
+		dec_int = ZEND_LONG_INT_OVFL(dec) ? INT_MAX : (int)dec;
 	} else {
-		dec_int = dec <= INT_MIN ? INT_MIN : (int)dec;
+		dec_int = ZEND_LONG_INT_UDFL(dec) ? INT_MIN : (int)dec;
 	}
-#else
-	dec_int = dec;
-#endif
 
 	RETURN_STR(_php_math_number_format_ex(num, dec_int, dec_point, dec_point_len, thousand_sep, thousand_sep_len));
 }


### PR DESCRIPTION
This is a follow-up PR for #11649 targeting 8.2 

As #11487 is available in 8.3 only and a positive `$decimals` will most probably end up in OOM error ... I don't have a good idea how to test this