### PR TITLE
Prevent potential deadlock if accelerated globals cannot be allocated

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -2863,8 +2863,8 @@ static int zend_accel_init_shm(void)
 		accel_shared_globals = zend_shared_alloc(sizeof(zend_accel_shared_globals) + sizeof(uint32_t));
 	}
 	if (!accel_shared_globals) {
-		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Insufficient shared memory!");
 		zend_shared_alloc_unlock();
+		zend_accel_error_noreturn(ACCEL_LOG_FATAL, "Insufficient shared memory!");
 		return FAILURE;
 	}
 	memset(accel_shared_globals, 0, sizeof(zend_accel_shared_globals));


### PR DESCRIPTION
Not sure if this is possible to hit in practice, zend_accel_error_noreturn doesn't return so the unlock isn't called. Other callsites that use both zend_accel_error_noreturn and zend_shared_alloc_unlock first perform the unlocking.