### PR TITLE
Add some typed class consts

### DIFF
--- a/ext/ffi/ffi.stub.php
+++ b/ext/ffi/ffi.stub.php
@@ -3,16 +3,14 @@
 /** @generate-class-entries */
 
 namespace {
-
 	/** @not-serializable */
     final class FFI
     {
         /**
-         * @var int
          * @cvalue __BIGGEST_ALIGNMENT__
          * @link ffi-ffi.constants.biggest-alignment
          */
-        public const __BIGGEST_ALIGNMENT__ = UNKNOWN;
+        public const int __BIGGEST_ALIGNMENT__ = UNKNOWN;
 
         public static function cdef(string $code = "", ?string $lib = null): FFI {}
 
@@ -82,200 +80,86 @@ namespace FFI {
 
 	/** @not-serializable */
     final class CType {
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_VOID
-         */
-        public const TYPE_VOID = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_FLOAT
-         */
-        public const TYPE_FLOAT = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_DOUBLE
-         */
-        public const TYPE_DOUBLE = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_VOID */
+        public const int TYPE_VOID = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_FLOAT */
+        public const int TYPE_FLOAT = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_DOUBLE */
+        public const int TYPE_DOUBLE = UNKNOWN;
 #ifdef HAVE_LONG_DOUBLE
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_LONGDOUBLE
-         */
-        public const TYPE_LONGDOUBLE = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_LONGDOUBLE */
+        public const int TYPE_LONGDOUBLE = UNKNOWN;
 #endif
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_UINT8
-         */
-        public const TYPE_UINT8 = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_SINT8
-         */
-        public const TYPE_SINT8 = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_UINT16
-         */
-        public const TYPE_UINT16 = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_SINT16
-         */
-        public const TYPE_SINT16 = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_UINT32
-         */
-        public const TYPE_UINT32 = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_SINT32
-         */
-        public const TYPE_SINT32 = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_UINT64
-         */
-        public const TYPE_UINT64 = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_SINT64
-         */
-        public const TYPE_SINT64 = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_ENUM
-         */
-        public const TYPE_ENUM = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_BOOL
-         */
-        public const TYPE_BOOL = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_CHAR
-         */
-        public const TYPE_CHAR = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_POINTER
-         */
-        public const TYPE_POINTER = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_FUNC
-         */
-        public const TYPE_FUNC = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_ARRAY
-         */
-        public const TYPE_ARRAY = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_TYPE_STRUCT
-         */
-        public const TYPE_STRUCT = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_UINT8 */
+        public const int TYPE_UINT8 = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_SINT8 */
+        public const int TYPE_SINT8 = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_UINT16 */
+        public const int TYPE_UINT16 = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_SINT16 */
+        public const int TYPE_SINT16 = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_UINT32 */
+        public const int TYPE_UINT32 = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_SINT32 */
+        public const int TYPE_SINT32 = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_UINT64 */
+        public const int TYPE_UINT64 = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_SINT64 */
+        public const int TYPE_SINT64 = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_ENUM */
+        public const int TYPE_ENUM = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_BOOL */
+        public const int TYPE_BOOL = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_CHAR */
+        public const int TYPE_CHAR = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_POINTER */
+        public const int TYPE_POINTER = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_FUNC */
+        public const int TYPE_FUNC = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_ARRAY */
+        public const int TYPE_ARRAY = UNKNOWN;
+        /** @cvalue ZEND_FFI_TYPE_STRUCT */
+        public const int TYPE_STRUCT = UNKNOWN;
 
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_CONST
-         */
-        public const ATTR_CONST = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_INCOMPLETE_TAG
-         */
-        public const ATTR_INCOMPLETE_TAG = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_VARIADIC
-         */
-        public const ATTR_VARIADIC = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_INCOMPLETE_ARRAY
-         */
-        public const ATTR_INCOMPLETE_ARRAY = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_VLA
-         */
-        public const ATTR_VLA = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_UNION
-         */
-        public const ATTR_UNION = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_PACKED
-         */
-        public const ATTR_PACKED = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_MS_STRUCT
-         */
-        public const ATTR_MS_STRUCT = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ATTR_GCC_STRUCT
-         */
-        public const ATTR_GCC_STRUCT = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_CONST */
+        public const int ATTR_CONST = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_INCOMPLETE_TAG */
+        public const int ATTR_INCOMPLETE_TAG = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_VARIADIC */
+        public const int ATTR_VARIADIC = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_INCOMPLETE_ARRAY */
+        public const int ATTR_INCOMPLETE_ARRAY = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_VLA */
+        public const int ATTR_VLA = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_UNION */
+        public const int ATTR_UNION = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_PACKED */
+        public const int ATTR_PACKED = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_MS_STRUCT */
+        public const int ATTR_MS_STRUCT = UNKNOWN;
+        /** @cvalue ZEND_FFI_ATTR_GCC_STRUCT */
+        public const int ATTR_GCC_STRUCT = UNKNOWN;
 
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_DEFAULT
-         */
-        public const ABI_DEFAULT = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_CDECL
-         */
-        public const ABI_CDECL = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_FASTCALL
-         */
-        public const ABI_FASTCALL = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_THISCALL
-         */
-        public const ABI_THISCALL = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_STDCALL
-         */
-        public const ABI_STDCALL = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_PASCAL
-         */
-        public const ABI_PASCAL = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_REGISTER
-         */
-        public const ABI_REGISTER = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_MS
-         */
-        public const ABI_MS = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_SYSV
-         */
-        public const ABI_SYSV = UNKNOWN;
-        /**
-         * @var int
-         * @cvalue ZEND_FFI_ABI_VECTORCALL
-         */
-        public const ABI_VECTORCALL = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_DEFAULT */
+        public const int ABI_DEFAULT = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_CDECL */
+        public const int ABI_CDECL = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_FASTCALL */
+        public const int ABI_FASTCALL = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_THISCALL */
+        public const int ABI_THISCALL = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_STDCALL */
+        public const int ABI_STDCALL = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_PASCAL */
+        public const int ABI_PASCAL = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_REGISTER */
+        public const int ABI_REGISTER = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_MS */
+        public const int ABI_MS = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_SYSV */
+        public const int ABI_SYSV = UNKNOWN;
+        /** @cvalue ZEND_FFI_ABI_VECTORCALL */
+        public const int ABI_VECTORCALL = UNKNOWN;
 
         public function getName(): string {}
 
@@ -306,5 +190,4 @@ namespace FFI {
 
     final class ParserException extends Exception {
     }
-
 }

--- a/ext/ffi/ffi_arginfo.h
+++ b/ext/ffi/ffi_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dd91ae1826acbc9b89cd74477edf8784216f1a63 */
+ * Stub hash: 81892d30ea498304dfa4105fc430a3d43f0ad54f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_FFI_cdef, 0, 0, FFI, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, code, IS_STRING, 0, "\"\"")
@@ -225,7 +225,7 @@ static zend_class_entry *register_class_FFI(void)
 	zval const___BIGGEST_ALIGNMENT___value;
 	ZVAL_LONG(&const___BIGGEST_ALIGNMENT___value, __BIGGEST_ALIGNMENT__);
 	zend_string *const___BIGGEST_ALIGNMENT___name = zend_string_init_interned("__BIGGEST_ALIGNMENT__", sizeof("__BIGGEST_ALIGNMENT__") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const___BIGGEST_ALIGNMENT___name, &const___BIGGEST_ALIGNMENT___value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const___BIGGEST_ALIGNMENT___name, &const___BIGGEST_ALIGNMENT___value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const___BIGGEST_ALIGNMENT___name);
 
 	return class_entry;
@@ -253,231 +253,231 @@ static zend_class_entry *register_class_FFI_CType(void)
 	zval const_TYPE_VOID_value;
 	ZVAL_LONG(&const_TYPE_VOID_value, ZEND_FFI_TYPE_VOID);
 	zend_string *const_TYPE_VOID_name = zend_string_init_interned("TYPE_VOID", sizeof("TYPE_VOID") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_VOID_name, &const_TYPE_VOID_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_VOID_name, &const_TYPE_VOID_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_VOID_name);
 
 	zval const_TYPE_FLOAT_value;
 	ZVAL_LONG(&const_TYPE_FLOAT_value, ZEND_FFI_TYPE_FLOAT);
 	zend_string *const_TYPE_FLOAT_name = zend_string_init_interned("TYPE_FLOAT", sizeof("TYPE_FLOAT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_FLOAT_name, &const_TYPE_FLOAT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_FLOAT_name, &const_TYPE_FLOAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_FLOAT_name);
 
 	zval const_TYPE_DOUBLE_value;
 	ZVAL_LONG(&const_TYPE_DOUBLE_value, ZEND_FFI_TYPE_DOUBLE);
 	zend_string *const_TYPE_DOUBLE_name = zend_string_init_interned("TYPE_DOUBLE", sizeof("TYPE_DOUBLE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_DOUBLE_name, &const_TYPE_DOUBLE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_DOUBLE_name, &const_TYPE_DOUBLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_DOUBLE_name);
 #if defined(HAVE_LONG_DOUBLE)
 
 	zval const_TYPE_LONGDOUBLE_value;
 	ZVAL_LONG(&const_TYPE_LONGDOUBLE_value, ZEND_FFI_TYPE_LONGDOUBLE);
 	zend_string *const_TYPE_LONGDOUBLE_name = zend_string_init_interned("TYPE_LONGDOUBLE", sizeof("TYPE_LONGDOUBLE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_LONGDOUBLE_name, &const_TYPE_LONGDOUBLE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_LONGDOUBLE_name, &const_TYPE_LONGDOUBLE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_LONGDOUBLE_name);
 #endif
 
 	zval const_TYPE_UINT8_value;
 	ZVAL_LONG(&const_TYPE_UINT8_value, ZEND_FFI_TYPE_UINT8);
 	zend_string *const_TYPE_UINT8_name = zend_string_init_interned("TYPE_UINT8", sizeof("TYPE_UINT8") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_UINT8_name, &const_TYPE_UINT8_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_UINT8_name, &const_TYPE_UINT8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UINT8_name);
 
 	zval const_TYPE_SINT8_value;
 	ZVAL_LONG(&const_TYPE_SINT8_value, ZEND_FFI_TYPE_SINT8);
 	zend_string *const_TYPE_SINT8_name = zend_string_init_interned("TYPE_SINT8", sizeof("TYPE_SINT8") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_SINT8_name, &const_TYPE_SINT8_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_SINT8_name, &const_TYPE_SINT8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_SINT8_name);
 
 	zval const_TYPE_UINT16_value;
 	ZVAL_LONG(&const_TYPE_UINT16_value, ZEND_FFI_TYPE_UINT16);
 	zend_string *const_TYPE_UINT16_name = zend_string_init_interned("TYPE_UINT16", sizeof("TYPE_UINT16") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_UINT16_name, &const_TYPE_UINT16_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_UINT16_name, &const_TYPE_UINT16_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UINT16_name);
 
 	zval const_TYPE_SINT16_value;
 	ZVAL_LONG(&const_TYPE_SINT16_value, ZEND_FFI_TYPE_SINT16);
 	zend_string *const_TYPE_SINT16_name = zend_string_init_interned("TYPE_SINT16", sizeof("TYPE_SINT16") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_SINT16_name, &const_TYPE_SINT16_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_SINT16_name, &const_TYPE_SINT16_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_SINT16_name);
 
 	zval const_TYPE_UINT32_value;
 	ZVAL_LONG(&const_TYPE_UINT32_value, ZEND_FFI_TYPE_UINT32);
 	zend_string *const_TYPE_UINT32_name = zend_string_init_interned("TYPE_UINT32", sizeof("TYPE_UINT32") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_UINT32_name, &const_TYPE_UINT32_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_UINT32_name, &const_TYPE_UINT32_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UINT32_name);
 
 	zval const_TYPE_SINT32_value;
 	ZVAL_LONG(&const_TYPE_SINT32_value, ZEND_FFI_TYPE_SINT32);
 	zend_string *const_TYPE_SINT32_name = zend_string_init_interned("TYPE_SINT32", sizeof("TYPE_SINT32") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_SINT32_name, &const_TYPE_SINT32_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_SINT32_name, &const_TYPE_SINT32_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_SINT32_name);
 
 	zval const_TYPE_UINT64_value;
 	ZVAL_LONG(&const_TYPE_UINT64_value, ZEND_FFI_TYPE_UINT64);
 	zend_string *const_TYPE_UINT64_name = zend_string_init_interned("TYPE_UINT64", sizeof("TYPE_UINT64") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_UINT64_name, &const_TYPE_UINT64_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_UINT64_name, &const_TYPE_UINT64_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_UINT64_name);
 
 	zval const_TYPE_SINT64_value;
 	ZVAL_LONG(&const_TYPE_SINT64_value, ZEND_FFI_TYPE_SINT64);
 	zend_string *const_TYPE_SINT64_name = zend_string_init_interned("TYPE_SINT64", sizeof("TYPE_SINT64") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_SINT64_name, &const_TYPE_SINT64_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_SINT64_name, &const_TYPE_SINT64_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_SINT64_name);
 
 	zval const_TYPE_ENUM_value;
 	ZVAL_LONG(&const_TYPE_ENUM_value, ZEND_FFI_TYPE_ENUM);
 	zend_string *const_TYPE_ENUM_name = zend_string_init_interned("TYPE_ENUM", sizeof("TYPE_ENUM") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_ENUM_name, &const_TYPE_ENUM_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_ENUM_name, &const_TYPE_ENUM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_ENUM_name);
 
 	zval const_TYPE_BOOL_value;
 	ZVAL_LONG(&const_TYPE_BOOL_value, ZEND_FFI_TYPE_BOOL);
 	zend_string *const_TYPE_BOOL_name = zend_string_init_interned("TYPE_BOOL", sizeof("TYPE_BOOL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_BOOL_name, &const_TYPE_BOOL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_BOOL_name, &const_TYPE_BOOL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_BOOL_name);
 
 	zval const_TYPE_CHAR_value;
 	ZVAL_LONG(&const_TYPE_CHAR_value, ZEND_FFI_TYPE_CHAR);
 	zend_string *const_TYPE_CHAR_name = zend_string_init_interned("TYPE_CHAR", sizeof("TYPE_CHAR") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_CHAR_name, &const_TYPE_CHAR_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_CHAR_name, &const_TYPE_CHAR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_CHAR_name);
 
 	zval const_TYPE_POINTER_value;
 	ZVAL_LONG(&const_TYPE_POINTER_value, ZEND_FFI_TYPE_POINTER);
 	zend_string *const_TYPE_POINTER_name = zend_string_init_interned("TYPE_POINTER", sizeof("TYPE_POINTER") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_POINTER_name, &const_TYPE_POINTER_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_POINTER_name, &const_TYPE_POINTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_POINTER_name);
 
 	zval const_TYPE_FUNC_value;
 	ZVAL_LONG(&const_TYPE_FUNC_value, ZEND_FFI_TYPE_FUNC);
 	zend_string *const_TYPE_FUNC_name = zend_string_init_interned("TYPE_FUNC", sizeof("TYPE_FUNC") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_FUNC_name, &const_TYPE_FUNC_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_FUNC_name, &const_TYPE_FUNC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_FUNC_name);
 
 	zval const_TYPE_ARRAY_value;
 	ZVAL_LONG(&const_TYPE_ARRAY_value, ZEND_FFI_TYPE_ARRAY);
 	zend_string *const_TYPE_ARRAY_name = zend_string_init_interned("TYPE_ARRAY", sizeof("TYPE_ARRAY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_ARRAY_name, &const_TYPE_ARRAY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_ARRAY_name, &const_TYPE_ARRAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_ARRAY_name);
 
 	zval const_TYPE_STRUCT_value;
 	ZVAL_LONG(&const_TYPE_STRUCT_value, ZEND_FFI_TYPE_STRUCT);
 	zend_string *const_TYPE_STRUCT_name = zend_string_init_interned("TYPE_STRUCT", sizeof("TYPE_STRUCT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_TYPE_STRUCT_name, &const_TYPE_STRUCT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_TYPE_STRUCT_name, &const_TYPE_STRUCT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_TYPE_STRUCT_name);
 
 	zval const_ATTR_CONST_value;
 	ZVAL_LONG(&const_ATTR_CONST_value, ZEND_FFI_ATTR_CONST);
 	zend_string *const_ATTR_CONST_name = zend_string_init_interned("ATTR_CONST", sizeof("ATTR_CONST") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_CONST_name, &const_ATTR_CONST_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_CONST_name, &const_ATTR_CONST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_CONST_name);
 
 	zval const_ATTR_INCOMPLETE_TAG_value;
 	ZVAL_LONG(&const_ATTR_INCOMPLETE_TAG_value, ZEND_FFI_ATTR_INCOMPLETE_TAG);
 	zend_string *const_ATTR_INCOMPLETE_TAG_name = zend_string_init_interned("ATTR_INCOMPLETE_TAG", sizeof("ATTR_INCOMPLETE_TAG") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_INCOMPLETE_TAG_name, &const_ATTR_INCOMPLETE_TAG_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_INCOMPLETE_TAG_name, &const_ATTR_INCOMPLETE_TAG_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_INCOMPLETE_TAG_name);
 
 	zval const_ATTR_VARIADIC_value;
 	ZVAL_LONG(&const_ATTR_VARIADIC_value, ZEND_FFI_ATTR_VARIADIC);
 	zend_string *const_ATTR_VARIADIC_name = zend_string_init_interned("ATTR_VARIADIC", sizeof("ATTR_VARIADIC") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_VARIADIC_name, &const_ATTR_VARIADIC_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_VARIADIC_name, &const_ATTR_VARIADIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_VARIADIC_name);
 
 	zval const_ATTR_INCOMPLETE_ARRAY_value;
 	ZVAL_LONG(&const_ATTR_INCOMPLETE_ARRAY_value, ZEND_FFI_ATTR_INCOMPLETE_ARRAY);
 	zend_string *const_ATTR_INCOMPLETE_ARRAY_name = zend_string_init_interned("ATTR_INCOMPLETE_ARRAY", sizeof("ATTR_INCOMPLETE_ARRAY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_INCOMPLETE_ARRAY_name, &const_ATTR_INCOMPLETE_ARRAY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_INCOMPLETE_ARRAY_name, &const_ATTR_INCOMPLETE_ARRAY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_INCOMPLETE_ARRAY_name);
 
 	zval const_ATTR_VLA_value;
 	ZVAL_LONG(&const_ATTR_VLA_value, ZEND_FFI_ATTR_VLA);
 	zend_string *const_ATTR_VLA_name = zend_string_init_interned("ATTR_VLA", sizeof("ATTR_VLA") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_VLA_name, &const_ATTR_VLA_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_VLA_name, &const_ATTR_VLA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_VLA_name);
 
 	zval const_ATTR_UNION_value;
 	ZVAL_LONG(&const_ATTR_UNION_value, ZEND_FFI_ATTR_UNION);
 	zend_string *const_ATTR_UNION_name = zend_string_init_interned("ATTR_UNION", sizeof("ATTR_UNION") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_UNION_name, &const_ATTR_UNION_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_UNION_name, &const_ATTR_UNION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_UNION_name);
 
 	zval const_ATTR_PACKED_value;
 	ZVAL_LONG(&const_ATTR_PACKED_value, ZEND_FFI_ATTR_PACKED);
 	zend_string *const_ATTR_PACKED_name = zend_string_init_interned("ATTR_PACKED", sizeof("ATTR_PACKED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_PACKED_name, &const_ATTR_PACKED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_PACKED_name, &const_ATTR_PACKED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_PACKED_name);
 
 	zval const_ATTR_MS_STRUCT_value;
 	ZVAL_LONG(&const_ATTR_MS_STRUCT_value, ZEND_FFI_ATTR_MS_STRUCT);
 	zend_string *const_ATTR_MS_STRUCT_name = zend_string_init_interned("ATTR_MS_STRUCT", sizeof("ATTR_MS_STRUCT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_MS_STRUCT_name, &const_ATTR_MS_STRUCT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_MS_STRUCT_name, &const_ATTR_MS_STRUCT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_MS_STRUCT_name);
 
 	zval const_ATTR_GCC_STRUCT_value;
 	ZVAL_LONG(&const_ATTR_GCC_STRUCT_value, ZEND_FFI_ATTR_GCC_STRUCT);
 	zend_string *const_ATTR_GCC_STRUCT_name = zend_string_init_interned("ATTR_GCC_STRUCT", sizeof("ATTR_GCC_STRUCT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ATTR_GCC_STRUCT_name, &const_ATTR_GCC_STRUCT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ATTR_GCC_STRUCT_name, &const_ATTR_GCC_STRUCT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ATTR_GCC_STRUCT_name);
 
 	zval const_ABI_DEFAULT_value;
 	ZVAL_LONG(&const_ABI_DEFAULT_value, ZEND_FFI_ABI_DEFAULT);
 	zend_string *const_ABI_DEFAULT_name = zend_string_init_interned("ABI_DEFAULT", sizeof("ABI_DEFAULT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_DEFAULT_name, &const_ABI_DEFAULT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_DEFAULT_name, &const_ABI_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_DEFAULT_name);
 
 	zval const_ABI_CDECL_value;
 	ZVAL_LONG(&const_ABI_CDECL_value, ZEND_FFI_ABI_CDECL);
 	zend_string *const_ABI_CDECL_name = zend_string_init_interned("ABI_CDECL", sizeof("ABI_CDECL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_CDECL_name, &const_ABI_CDECL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_CDECL_name, &const_ABI_CDECL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_CDECL_name);
 
 	zval const_ABI_FASTCALL_value;
 	ZVAL_LONG(&const_ABI_FASTCALL_value, ZEND_FFI_ABI_FASTCALL);
 	zend_string *const_ABI_FASTCALL_name = zend_string_init_interned("ABI_FASTCALL", sizeof("ABI_FASTCALL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_FASTCALL_name, &const_ABI_FASTCALL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_FASTCALL_name, &const_ABI_FASTCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_FASTCALL_name);
 
 	zval const_ABI_THISCALL_value;
 	ZVAL_LONG(&const_ABI_THISCALL_value, ZEND_FFI_ABI_THISCALL);
 	zend_string *const_ABI_THISCALL_name = zend_string_init_interned("ABI_THISCALL", sizeof("ABI_THISCALL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_THISCALL_name, &const_ABI_THISCALL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_THISCALL_name, &const_ABI_THISCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_THISCALL_name);
 
 	zval const_ABI_STDCALL_value;
 	ZVAL_LONG(&const_ABI_STDCALL_value, ZEND_FFI_ABI_STDCALL);
 	zend_string *const_ABI_STDCALL_name = zend_string_init_interned("ABI_STDCALL", sizeof("ABI_STDCALL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_STDCALL_name, &const_ABI_STDCALL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_STDCALL_name, &const_ABI_STDCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_STDCALL_name);
 
 	zval const_ABI_PASCAL_value;
 	ZVAL_LONG(&const_ABI_PASCAL_value, ZEND_FFI_ABI_PASCAL);
 	zend_string *const_ABI_PASCAL_name = zend_string_init_interned("ABI_PASCAL", sizeof("ABI_PASCAL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_PASCAL_name, &const_ABI_PASCAL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_PASCAL_name, &const_ABI_PASCAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_PASCAL_name);
 
 	zval const_ABI_REGISTER_value;
 	ZVAL_LONG(&const_ABI_REGISTER_value, ZEND_FFI_ABI_REGISTER);
 	zend_string *const_ABI_REGISTER_name = zend_string_init_interned("ABI_REGISTER", sizeof("ABI_REGISTER") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_REGISTER_name, &const_ABI_REGISTER_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_REGISTER_name, &const_ABI_REGISTER_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_REGISTER_name);
 
 	zval const_ABI_MS_value;
 	ZVAL_LONG(&const_ABI_MS_value, ZEND_FFI_ABI_MS);
 	zend_string *const_ABI_MS_name = zend_string_init_interned("ABI_MS", sizeof("ABI_MS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_MS_name, &const_ABI_MS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_MS_name, &const_ABI_MS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_MS_name);
 
 	zval const_ABI_SYSV_value;
 	ZVAL_LONG(&const_ABI_SYSV_value, ZEND_FFI_ABI_SYSV);
 	zend_string *const_ABI_SYSV_name = zend_string_init_interned("ABI_SYSV", sizeof("ABI_SYSV") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_SYSV_name, &const_ABI_SYSV_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_SYSV_name, &const_ABI_SYSV_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_SYSV_name);
 
 	zval const_ABI_VECTORCALL_value;
 	ZVAL_LONG(&const_ABI_VECTORCALL_value, ZEND_FFI_ABI_VECTORCALL);
 	zend_string *const_ABI_VECTORCALL_name = zend_string_init_interned("ABI_VECTORCALL", sizeof("ABI_VECTORCALL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ABI_VECTORCALL_name, &const_ABI_VECTORCALL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ABI_VECTORCALL_name, &const_ABI_VECTORCALL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ABI_VECTORCALL_name);
 
 	return class_entry;

--- a/ext/snmp/snmp.stub.php
+++ b/ext/snmp/snmp.stub.php
@@ -184,78 +184,66 @@ function snmp_read_mib(string $filename): bool {}
 class SNMP
 {
     /**
-     * @var int
      * @cvalue SNMP_VERSION_1
      * @link snmp.class.constants.version-1
      */
-    public const VERSION_1 = UNKNOWN;
+    public const int VERSION_1 = UNKNOWN;
     /**
-     * @var int
      * @cvalue SNMP_VERSION_2c
      * @link snmp.class.constants.version-2c
      */
-    public const VERSION_2c = UNKNOWN;
+    public const int VERSION_2c = UNKNOWN;
     /**
-     * @var int
      * @cvalue SNMP_VERSION_2c
      * @link snmp.class.constants.version-2c
      */
-    public const VERSION_2C = UNKNOWN;
+    public const int VERSION_2C = UNKNOWN;
     /**
-     * @var int
      * @cvalue SNMP_VERSION_3
      * @link snmp.class.constants.version-3
      */
-    public const VERSION_3 = UNKNOWN;
+    public const int VERSION_3 = UNKNOWN;
 
     /**
-     * @var int
      * @cvalue PHP_SNMP_ERRNO_NOERROR
      * @link snmp.class.constants.errno-noerror
      */
-    public const ERRNO_NOERROR = UNKNOWN;
+    public const int ERRNO_NOERROR = UNKNOWN;
     /**
-     * @var int
      * @cvalue PHP_SNMP_ERRNO_ANY
      * @link snmp.class.constants.errno-any
      */
-    public const ERRNO_ANY = UNKNOWN;
+    public const int ERRNO_ANY = UNKNOWN;
     /**
-     * @var int
      * @cvalue PHP_SNMP_ERRNO_GENERIC
      * @link snmp.class.constants.errno-generic
      */
-    public const ERRNO_GENERIC = UNKNOWN;
+    public const int ERRNO_GENERIC = UNKNOWN;
     /**
-     * @var int
      * @cvalue PHP_SNMP_ERRNO_TIMEOUT
      * @link snmp.class.constants.errno-timeout
      */
-    public const ERRNO_TIMEOUT = UNKNOWN;
+    public const int ERRNO_TIMEOUT = UNKNOWN;
     /**
-     * @var int
      * @cvalue PHP_SNMP_ERRNO_ERROR_IN_REPLY
      * @link snmp.class.constants.errno-error-in-reply
      */
-    public const ERRNO_ERROR_IN_REPLY = UNKNOWN;
+    public const int ERRNO_ERROR_IN_REPLY = UNKNOWN;
     /**
-     * @var int
      * @cvalue PHP_SNMP_ERRNO_OID_NOT_INCREASING
      * @link snmp.class.constants.errno-oid-not-increasing
      */
-    public const ERRNO_OID_NOT_INCREASING = UNKNOWN;
+    public const int ERRNO_OID_NOT_INCREASING = UNKNOWN;
     /**
-     * @var int
      * @cvalue PHP_SNMP_ERRNO_OID_PARSING_ERROR
      * @link snmp.class.constants.errno-oid-parsing-error
      */
-    public const ERRNO_OID_PARSING_ERROR = UNKNOWN;
+    public const int ERRNO_OID_PARSING_ERROR = UNKNOWN;
     /**
-     * @var int
      * @cvalue PHP_SNMP_ERRNO_MULTIPLE_SET_QUERIES
      * @link snmp.class.constants.errno-multiple-set-queries
      */
-    public const ERRNO_MULTIPLE_SET_QUERIES = UNKNOWN;
+    public const int ERRNO_MULTIPLE_SET_QUERIES = UNKNOWN;
 
     /** @readonly */
     public array $info;

--- a/ext/snmp/snmp_arginfo.h
+++ b/ext/snmp/snmp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 659db99d46c15b508e992d55a1e421f48b51f6e3 */
+ * Stub hash: ada00ea99d91d7e48e9965c5891227f97fd779a6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_snmpget, 0, 3, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
@@ -281,73 +281,73 @@ static zend_class_entry *register_class_SNMP(void)
 	zval const_VERSION_1_value;
 	ZVAL_LONG(&const_VERSION_1_value, SNMP_VERSION_1);
 	zend_string *const_VERSION_1_name = zend_string_init_interned("VERSION_1", sizeof("VERSION_1") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_VERSION_1_name, &const_VERSION_1_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_VERSION_1_name, &const_VERSION_1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VERSION_1_name);
 
 	zval const_VERSION_2c_value;
 	ZVAL_LONG(&const_VERSION_2c_value, SNMP_VERSION_2c);
 	zend_string *const_VERSION_2c_name = zend_string_init_interned("VERSION_2c", sizeof("VERSION_2c") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_VERSION_2c_name, &const_VERSION_2c_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_VERSION_2c_name, &const_VERSION_2c_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VERSION_2c_name);
 
 	zval const_VERSION_2C_value;
 	ZVAL_LONG(&const_VERSION_2C_value, SNMP_VERSION_2c);
 	zend_string *const_VERSION_2C_name = zend_string_init_interned("VERSION_2C", sizeof("VERSION_2C") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_VERSION_2C_name, &const_VERSION_2C_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_VERSION_2C_name, &const_VERSION_2C_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VERSION_2C_name);
 
 	zval const_VERSION_3_value;
 	ZVAL_LONG(&const_VERSION_3_value, SNMP_VERSION_3);
 	zend_string *const_VERSION_3_name = zend_string_init_interned("VERSION_3", sizeof("VERSION_3") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_VERSION_3_name, &const_VERSION_3_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_VERSION_3_name, &const_VERSION_3_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_VERSION_3_name);
 
 	zval const_ERRNO_NOERROR_value;
 	ZVAL_LONG(&const_ERRNO_NOERROR_value, PHP_SNMP_ERRNO_NOERROR);
 	zend_string *const_ERRNO_NOERROR_name = zend_string_init_interned("ERRNO_NOERROR", sizeof("ERRNO_NOERROR") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ERRNO_NOERROR_name, &const_ERRNO_NOERROR_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ERRNO_NOERROR_name, &const_ERRNO_NOERROR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_NOERROR_name);
 
 	zval const_ERRNO_ANY_value;
 	ZVAL_LONG(&const_ERRNO_ANY_value, PHP_SNMP_ERRNO_ANY);
 	zend_string *const_ERRNO_ANY_name = zend_string_init_interned("ERRNO_ANY", sizeof("ERRNO_ANY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ERRNO_ANY_name, &const_ERRNO_ANY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ERRNO_ANY_name, &const_ERRNO_ANY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_ANY_name);
 
 	zval const_ERRNO_GENERIC_value;
 	ZVAL_LONG(&const_ERRNO_GENERIC_value, PHP_SNMP_ERRNO_GENERIC);
 	zend_string *const_ERRNO_GENERIC_name = zend_string_init_interned("ERRNO_GENERIC", sizeof("ERRNO_GENERIC") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ERRNO_GENERIC_name, &const_ERRNO_GENERIC_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ERRNO_GENERIC_name, &const_ERRNO_GENERIC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_GENERIC_name);
 
 	zval const_ERRNO_TIMEOUT_value;
 	ZVAL_LONG(&const_ERRNO_TIMEOUT_value, PHP_SNMP_ERRNO_TIMEOUT);
 	zend_string *const_ERRNO_TIMEOUT_name = zend_string_init_interned("ERRNO_TIMEOUT", sizeof("ERRNO_TIMEOUT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ERRNO_TIMEOUT_name, &const_ERRNO_TIMEOUT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ERRNO_TIMEOUT_name, &const_ERRNO_TIMEOUT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_TIMEOUT_name);
 
 	zval const_ERRNO_ERROR_IN_REPLY_value;
 	ZVAL_LONG(&const_ERRNO_ERROR_IN_REPLY_value, PHP_SNMP_ERRNO_ERROR_IN_REPLY);
 	zend_string *const_ERRNO_ERROR_IN_REPLY_name = zend_string_init_interned("ERRNO_ERROR_IN_REPLY", sizeof("ERRNO_ERROR_IN_REPLY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ERRNO_ERROR_IN_REPLY_name, &const_ERRNO_ERROR_IN_REPLY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ERRNO_ERROR_IN_REPLY_name, &const_ERRNO_ERROR_IN_REPLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_ERROR_IN_REPLY_name);
 
 	zval const_ERRNO_OID_NOT_INCREASING_value;
 	ZVAL_LONG(&const_ERRNO_OID_NOT_INCREASING_value, PHP_SNMP_ERRNO_OID_NOT_INCREASING);
 	zend_string *const_ERRNO_OID_NOT_INCREASING_name = zend_string_init_interned("ERRNO_OID_NOT_INCREASING", sizeof("ERRNO_OID_NOT_INCREASING") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ERRNO_OID_NOT_INCREASING_name, &const_ERRNO_OID_NOT_INCREASING_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ERRNO_OID_NOT_INCREASING_name, &const_ERRNO_OID_NOT_INCREASING_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_OID_NOT_INCREASING_name);
 
 	zval const_ERRNO_OID_PARSING_ERROR_value;
 	ZVAL_LONG(&const_ERRNO_OID_PARSING_ERROR_value, PHP_SNMP_ERRNO_OID_PARSING_ERROR);
 	zend_string *const_ERRNO_OID_PARSING_ERROR_name = zend_string_init_interned("ERRNO_OID_PARSING_ERROR", sizeof("ERRNO_OID_PARSING_ERROR") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ERRNO_OID_PARSING_ERROR_name, &const_ERRNO_OID_PARSING_ERROR_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ERRNO_OID_PARSING_ERROR_name, &const_ERRNO_OID_PARSING_ERROR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_OID_PARSING_ERROR_name);
 
 	zval const_ERRNO_MULTIPLE_SET_QUERIES_value;
 	ZVAL_LONG(&const_ERRNO_MULTIPLE_SET_QUERIES_value, PHP_SNMP_ERRNO_MULTIPLE_SET_QUERIES);
 	zend_string *const_ERRNO_MULTIPLE_SET_QUERIES_name = zend_string_init_interned("ERRNO_MULTIPLE_SET_QUERIES", sizeof("ERRNO_MULTIPLE_SET_QUERIES") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ERRNO_MULTIPLE_SET_QUERIES_name, &const_ERRNO_MULTIPLE_SET_QUERIES_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ERRNO_MULTIPLE_SET_QUERIES_name, &const_ERRNO_MULTIPLE_SET_QUERIES_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ERRNO_MULTIPLE_SET_QUERIES_name);
 
 	zval property_info_default_value;


### PR DESCRIPTION
ext/ffi ones are straightforward since they are in final classes. `SNMP` class constants are debatable, but I think it shouldn't cause a big issue.