### PR TITLE
Remove check for time.h and HAVE_TIME_H

### DIFF
--- a/Zend/zend_hrtime.h
+++ b/Zend/zend_hrtime.h
@@ -24,7 +24,7 @@
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif
-#ifdef HAVE_TIME_H
+#ifndef PHP_WIN32
 # include <time.h>
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -398,7 +398,6 @@ dirent.h \
 sys/param.h \
 sys/types.h \
 sys/time.h \
-time.h \
 netinet/in.h \
 alloca.h \
 arpa/inet.h \


### PR DESCRIPTION
The `<time.h>` header file is part of the standard C89 headers [1] and on current systems can be included unconditionally.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2 [2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4

In [PHP 7.4](https://github.com/php/php-src/blob/PHP-7.4/UPGRADING.INTERNALS) these were already cleaned a bit. Probably we don't need to re-add it in PHP 8.3.