### PR TITLE
Fix hash_pbkdf2 options parameter

### DIFF
--- a/ext/hash/hash.c
+++ b/ext/hash/hash.c
@@ -992,7 +992,7 @@ PHP_FUNCTION(hash_pbkdf2)
 	bool raw_output = 0;
 	const php_hash_ops *ops;
 	void *context;
-	HashTable *args;
+	HashTable *args = NULL;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sssl|lbh", &algo, &pass, &pass_len, &salt, &salt_len, &iterations, &length, &raw_output, &args) == FAILURE) {
 		RETURN_THROWS();

--- a/ext/hash/hash.stub.php
+++ b/ext/hash/hash.stub.php
@@ -44,7 +44,7 @@ function hash_algos(): array {}
 function hash_hmac_algos(): array {}
 
 /** @refcount 1 */
-function hash_pbkdf2(string $algo, string $password, string $salt, int $iterations, int $length = 0, bool $binary = false): string {}
+function hash_pbkdf2(string $algo, string $password, string $salt, int $iterations, int $length = 0, bool $binary = false, array $options = []): string {}
 
 function hash_equals(string $known_string, string $user_string): bool {}
 

--- a/ext/hash/hash_arginfo.h
+++ b/ext/hash/hash_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8b5131fd7bd88d1ec0211bcfcb5a4854418aa3c8 */
+ * Stub hash: 66d99527cf6d7b37ff652bb78fa57d5e3d5c78d9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hash, 0, 2, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, algo, IS_STRING, 0)
@@ -74,6 +74,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hash_pbkdf2, 0, 4, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, binary, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 0, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_hash_equals, 0, 2, _IS_BOOL, 0)


### PR DESCRIPTION
The value needs to be initialized to NULL as it is optional. Furthermore, the parameter was completely missing in the stub signature.