### PR TITLE
Fix uouv on oom on object allocation

### DIFF
--- a/Zend/tests/gh11734.phpt
+++ b/Zend/tests/gh11734.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-11734: Use-of-uninitialized-value when OOM on object allocation
+--INI--
+memory_limit=2M
+--SKIPIF--
+<?php
+$zend_mm_enabled = getenv("USE_ZEND_ALLOC");
+if ($zend_mm_enabled === "0") {
+    die("skip Zend MM disabled");
+}
+?>
+--FILE--
+<?php
+$objs = [];
+while (true) {
+    $objs[] = new SplPriorityQueue;
+}
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted%S (tried to allocate %d bytes) in %s on line %d

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -91,6 +91,11 @@ static zend_always_inline size_t zend_object_properties_size(zend_class_entry *c
 static zend_always_inline void *zend_object_alloc(size_t obj_size, zend_class_entry *ce) {
 	void *obj = emalloc(obj_size + zend_object_properties_size(ce));
 	memset(obj, 0, obj_size - sizeof(zend_object));
+	/* Set to std_object_handlers in case there is an OOM error before any other handlers are
+	 * installed. This avoids a use-of-uninitialized-value on shutdown. This would be more fitting in
+	 * zend_object_std_init(), but some extensions set handlers before calling
+	 * zend_object_std_init(). */
+	((zend_object *)((uintptr_t)obj + obj_size - sizeof(zend_object)))->handlers = &std_object_handlers;
 	return obj;
 }
 


### PR DESCRIPTION
Initialize object.handlers to std_object_handlers in zend_object_alloc. This avoids a use-after-free for objects using custom handlers that are installed after allocation, accessing the handlers on shutdown when they haven't been set yet.

Fixes GH-11734