### PR TITLE
Fix warning crc32.c on function declaration without a prototype.

### DIFF
--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -39,7 +39,7 @@ static unsigned long getauxval(unsigned long key) {
 }
 # endif
 
-static inline int has_crc32_insn() {
+static inline int has_crc32_insn(void) {
 	/* Only go through the runtime detection once. */
 	static int res = -1;
 	if (res != -1)


### PR DESCRIPTION
I found warning when compiling C language (make).
This PR is fix them.

```
/Users/tekimen/src/youkidearitai-php-src/ext/standard/crc32.c:42:33: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
static inline int has_crc32_insn() {
                                ^
                                 void
```

My environment:
- macOS 13.4.1
- clang 16.0.5