### PR TITLE
Fix uouv in array_column

### DIFF
--- a/ext/intl/uchar/uchar.c
+++ b/ext/intl/uchar/uchar.c
@@ -86,7 +86,7 @@ IC_METHOD(hasBinaryProperty) {
 	UChar32 cp;
 	zend_long prop;
 	zend_string *string_codepoint;
-	zend_long int_codepoint;
+	zend_long int_codepoint = 0;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
@@ -106,7 +106,7 @@ IC_METHOD(getIntPropertyValue) {
 	UChar32 cp;
 	zend_long prop;
 	zend_string *string_codepoint;
-	zend_long int_codepoint;
+	zend_long int_codepoint = 0;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
@@ -214,7 +214,7 @@ IC_METHOD(getBlockCode) {
 IC_METHOD(charName) {
 	UChar32 cp;
 	zend_string *string_codepoint;
-	zend_long int_codepoint;
+	zend_long int_codepoint = 0;
 	UErrorCode error = U_ZERO_ERROR;
 	zend_long nameChoice = U_UNICODE_CHAR_NAME;
 	zend_string *buffer = NULL;
@@ -294,7 +294,7 @@ static UBool enumCharNames_callback(enumCharNames_data *context,
 IC_METHOD(enumCharNames) {
 	UChar32 start, limit;
 	zend_string *string_start, *string_limit;
-	zend_long int_start, int_limit;
+	zend_long int_start = 0, int_limit = 0;
 	enumCharNames_data context;
 	zend_long nameChoice = U_UNICODE_CHAR_NAME;
 	UErrorCode error = U_ZERO_ERROR;
@@ -391,7 +391,7 @@ IC_METHOD(foldCase) {
 	UChar32 cp, ret;
 	zend_long options = U_FOLD_CASE_DEFAULT;
 	zend_string *string_codepoint;
-	zend_long int_codepoint;
+	zend_long int_codepoint = 0;
 
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)
@@ -421,7 +421,7 @@ IC_METHOD(digit) {
 	zend_long radix = 10;
 	int ret;
 	zend_string *string_codepoint;
-	zend_long int_codepoint;
+	zend_long int_codepoint = 0;
 
 	ZEND_PARSE_PARAMETERS_START(1, 2)
 		Z_PARAM_STR_OR_LONG(string_codepoint, int_codepoint)

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1693,7 +1693,7 @@ PHP_FUNCTION(pg_fetch_result)
 {
 	zval *result;
 	zend_string *field_name;
-	zend_long row, field_offset;
+	zend_long row, field_offset = 0;
 	bool row_is_null = false;
 	PGresult *pgsql_result;
 	pgsql_result_handle *pg_result;
@@ -2004,7 +2004,7 @@ static void php_pgsql_data_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type, bo
 {
 	zval *result;
 	zend_string *field_name;
-	zend_long row, field_offset;
+	zend_long row, field_offset = 0;
 	bool row_is_null = false;
 	PGresult *pgsql_result;
 	pgsql_result_handle *pg_result;

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4513,10 +4513,10 @@ PHP_FUNCTION(array_column)
 	HashTable *input;
 	zval *colval, *data, rv;
 	zend_string *column_str = NULL;
-	zend_long column_long;
+	zend_long column_long = 0;
 	bool column_is_null = 0;
 	zend_string *index_str = NULL;
-	zend_long index_long;
+	zend_long index_long = 0;
 	bool index_is_null = 1;
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)

--- a/ext/standard/password.c
+++ b/ext/standard/password.c
@@ -589,9 +589,9 @@ PHP_FUNCTION(password_needs_rehash)
 	const php_password_algo *old_algo, *new_algo;
 	zend_string *hash;
 	zend_string *new_algo_str;
-	zend_long new_algo_long;
+	zend_long new_algo_long = 0;
 	bool new_algo_is_null;
-	zend_array *options = 0;
+	zend_array *options = NULL;
 
 	ZEND_PARSE_PARAMETERS_START(2, 3)
 		Z_PARAM_STR(hash)
@@ -637,7 +637,7 @@ PHP_FUNCTION(password_hash)
 {
 	zend_string *password, *digest = NULL;
 	zend_string *algo_str;
-	zend_long algo_long;
+	zend_long algo_long = 0;
 	bool algo_is_null;
 	const php_password_algo *algo;
 	zend_array *options = NULL;


### PR DESCRIPTION
column_long and index_long might not be set, but are still used as arguments. They are not actually used if column_str is set, but it's better to initialize them anyway, if only to make MemorySanitizer happy.