### PR TITLE
Fix GH-11716: cli server crashes on SIGINT when compiled with ZEND_RC_DEBUG=1

### DIFF
--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -878,6 +878,11 @@ add_to_hash:
 	ht->nNumOfElements++;
 	p = ht->arData + idx;
 	p->key = key = zend_string_init(str, len, GC_FLAGS(ht) & IS_ARRAY_PERSISTENT);
+#if ZEND_RC_DEBUG
+	if (GC_FLAGS(ht) & GC_PERSISTENT_LOCAL) {
+		GC_MAKE_PERSISTENT_LOCAL(key);
+	}
+#endif
 	p->h = ZSTR_H(key) = h;
 	HT_FLAGS(ht) &= ~HASH_FLAG_STATIC_KEYS;
 	if (flag & HASH_LOOKUP) {

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -1340,7 +1340,9 @@ static int php_cli_server_request_ctor(php_cli_server_request *req) /* {{{ */
 	req->query_string = NULL;
 	req->query_string_len = 0;
 	zend_hash_init(&req->headers, 0, NULL, char_ptr_dtor_p, 1);
+	GC_MAKE_PERSISTENT_LOCAL(&req->headers);
 	zend_hash_init(&req->headers_original_case, 0, NULL, NULL, 1);
+	GC_MAKE_PERSISTENT_LOCAL(&req->headers_original_case);
 	req->content = NULL;
 	req->content_len = 0;
 	req->ext = NULL;
@@ -2248,6 +2250,7 @@ static int php_cli_server_mime_type_ctor(php_cli_server *server, const php_cli_s
 	const php_cli_server_ext_mime_type_pair *pair;
 
 	zend_hash_init(&server->extension_mime_types, 0, NULL, NULL, 1);
+	GC_MAKE_PERSISTENT_LOCAL(&server->extension_mime_types);
 
 	for (pair = mime_type_map; pair->ext; pair++) {
 		size_t ext_len = strlen(pair->ext);


### PR DESCRIPTION
~~@arnaud-lb You talked about the `req->headers` and `req->headers_original_case` tables having the same problem. However, it doesn't trigger because it seems these hashtables are never used? In that case, maybe we should just remove those hashtables on master? For now, I have left them alone until a decision is taken.~~

EDIT: wait, nvm, they are used, my grep skills failed me... I fixed it now to also mark those tables as persistent local, sorry.

Closes GH-11716.