### PR TITLE
zend call stack fix freebsd code path.

### DIFF
--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -258,7 +258,6 @@ static bool zend_call_stack_get_freebsd_pthread(zend_call_stack *stack)
 	int error;
 	void *addr;
 	size_t max_size;
-	size_t guard_size;
 
 	/* pthread will return bogus values for the main thread */
 	ZEND_ASSERT(!zend_call_stack_is_main_thread());
@@ -274,14 +273,6 @@ static bool zend_call_stack_get_freebsd_pthread(zend_call_stack *stack)
 	if (error) {
 		goto fail;
 	}
-
-    error = pthread_attr_getguardsize(&attr, &guard_size);
-    if (error) {
-        return false;
-    }
-
-    addr = (char *)addr + guard_size;
-    max_size -= guard_size;
 
 	stack->base = (int8_t*)addr + max_size;
 	stack->max_size = max_size;


### PR DESCRIPTION
The typo in HAVE_PTHREAD_ATTR_GET`_`STACK (might be due to pthread_attr_get_np being different from Linux's pthread_getattr_np) led to this code path never get called on FreeBSD. Anyway, like Linux the first condition alone is enough, pthread_attr_getstack being present
 even in the 9.x release's serie.