### PR TITLE
Fix empty argument cases for DOMParentNode methods

### DIFF
--- a/ext/dom/characterdata.c
+++ b/ext/dom/characterdata.c
@@ -364,12 +364,12 @@ PHP_METHOD(DOMCharacterData, remove)
 
 PHP_METHOD(DOMCharacterData, after)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -381,12 +381,12 @@ PHP_METHOD(DOMCharacterData, after)
 
 PHP_METHOD(DOMCharacterData, before)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -398,12 +398,12 @@ PHP_METHOD(DOMCharacterData, before)
 
 PHP_METHOD(DOMCharacterData, replaceWith)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -2092,12 +2092,12 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(DOMDocument, append)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -2113,12 +2113,12 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(DOMDocument, prepend)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/documentfragment.c
+++ b/ext/dom/documentfragment.c
@@ -135,12 +135,12 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(DOMDocumentFragment, append)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -156,12 +156,12 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(DOMDocumentFragment, prepend)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1137,12 +1137,12 @@ PHP_METHOD(DOMElement, remove)
 
 PHP_METHOD(DOMElement, after)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -1154,12 +1154,12 @@ PHP_METHOD(DOMElement, after)
 
 PHP_METHOD(DOMElement, before)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -1174,12 +1174,12 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(DOMElement, append)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -1195,12 +1195,12 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(DOMElement, prepend)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 
@@ -1216,12 +1216,12 @@ Since: DOM Living Standard (DOM4)
 */
 PHP_METHOD(DOMElement, replaceWith)
 {
-	int argc;
+	int argc = 0;
 	zval *args, *id;
 	dom_object *intern;
 	xmlNode *context;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "+", &args, &argc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "*", &args, &argc) == FAILURE) {
 		RETURN_THROWS();
 	}
 

--- a/ext/dom/tests/DOMParentNode_empty_argument.phpt
+++ b/ext/dom/tests/DOMParentNode_empty_argument.phpt
@@ -1,0 +1,84 @@
+--TEST--
+DOMParentNode functions with empty argument
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$dom = new DOMDocument();
+$dom->loadXML('<?xml version="1.0"?><root><node/></root>');
+
+$emptyFragment = $dom->createDocumentFragment();
+
+echo "--- DOMElement test ---\n";
+
+$dom->documentElement->after(...$emptyFragment->childNodes);
+$dom->documentElement->before(...$emptyFragment->childNodes);
+$dom->documentElement->append(...$emptyFragment->childNodes);
+$dom->documentElement->prepend(...$emptyFragment->childNodes);
+$dom->documentElement->after();
+$dom->documentElement->before();
+$dom->documentElement->append();
+$dom->documentElement->prepend();
+echo $dom->saveXML();
+
+$dom->documentElement->firstChild->replaceWith(...$emptyFragment->childNodes);
+echo $dom->saveXML();
+
+$dom->documentElement->replaceWith(...$emptyFragment->childNodes);
+echo $dom->saveXML();
+
+echo "--- DOMDocumentFragment test ---\n";
+
+$fragment = $dom->createDocumentFragment();
+$fragment->append($dom->createElement('foo'));
+$fragment->append(...$emptyFragment->childNodes);
+$fragment->prepend(...$emptyFragment->childNodes);
+$fragment->append();
+$fragment->prepend();
+echo $dom->saveXML($fragment), "\n";
+
+echo "--- DOMDocument test ---\n";
+
+$dom->append(...$emptyFragment->childNodes);
+$dom->prepend(...$emptyFragment->childNodes);
+$dom->append();
+$dom->prepend();
+echo $dom->saveXML(), "\n";
+
+echo "--- DOMCharacterData test ---\n";
+
+$cdata = $dom->createCDATASection('foo');
+$dom->appendChild($cdata);
+
+$cdata->after(...$emptyFragment->childNodes);
+$cdata->before(...$emptyFragment->childNodes);
+$cdata->after();
+$cdata->before();
+echo $dom->saveXML(), "\n";
+$cdata->replaceWith(...$emptyFragment->childNodes);
+echo $dom->saveXML(), "\n";
+
+$cdata = $dom->createCDATASection('foo');
+$dom->appendChild($cdata);
+$cdata->replaceWith(...$emptyFragment->childNodes);
+echo $dom->saveXML(), "\n";
+?>
+--EXPECT--
+--- DOMElement test ---
+<?xml version="1.0"?>
+<root><node/></root>
+<?xml version="1.0"?>
+<root/>
+<?xml version="1.0"?>
+--- DOMDocumentFragment test ---
+<foo/>
+--- DOMDocument test ---
+<?xml version="1.0"?>
+
+--- DOMCharacterData test ---
+<?xml version="1.0"?>
+<![CDATA[foo]]>
+
+<?xml version="1.0"?>
+
+<?xml version="1.0"?>


### PR DESCRIPTION
They should be callable with empty arguments. It might seem useless but this can happen with empty fragments (as seen in the attached testcase).
This aligns the behaviour to spec.