### PR TITLE
zend vm savee registers support for riscv 64.

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -354,6 +354,9 @@ if test "$ZEND_GCC_GLOBAL_REGS" != "no"; then
 #elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__aarch64__)
 # define ZEND_VM_FP_GLOBAL_REG "x27"
 # define ZEND_VM_IP_GLOBAL_REG "x28"
+#elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__riscv) && __riscv_xlen == 64
+# define ZEND_VM_FP_GLOBAL_REG "x18"
+# define ZEND_VM_IP_GLOBAL_REG "x19"
 #else
 # error "global register variables are not supported"
 #endif

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -64,6 +64,9 @@
 # elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__aarch64__)
 #  define ZEND_VM_FP_GLOBAL_REG "x27"
 #  define ZEND_VM_IP_GLOBAL_REG "x28"
+#elif defined(__GNUC__) && ZEND_GCC_VERSION >= 4008 && defined(__riscv) && __riscv_xlen == 64
+#  define ZEND_VM_FP_GLOBAL_REG "x18"
+#  define ZEND_VM_IP_GLOBAL_REG "x19"
 # endif
 #endif
 


### PR DESCRIPTION
x8 being already reserved, we can only pull x18 to x27.