### PR TITLE
Refactor checks for fpathconf and pathconf

### DIFF
--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -10,7 +10,12 @@ if test "$PHP_POSIX" = "yes"; then
 
   AC_CHECK_HEADERS([sys/mkdev.h sys/sysmacros.h])
 
-  AC_CHECK_FUNCS(seteuid setegid setsid getsid getpgid ctermid mkfifo mknod setrlimit getrlimit getgroups makedev initgroups getgrgid_r posix_pathconf eaccess)
+  AC_CHECK_FUNCS(seteuid setegid setsid getsid getpgid ctermid mkfifo mknod setrlimit getrlimit getgroups makedev initgroups getgrgid_r eaccess)
+
+dnl Skip pathconf and fpathconf check on musl libc due to limited implementation
+dnl (first argument is not validated and has different error).
+  AS_IF([command -v ldd >/dev/null && ldd --version 2>&1 | grep -q "^musl"],[],
+    [AC_CHECK_FUNCS(pathconf fpathconf)])
 
   AC_MSG_CHECKING([for working ttyname_r() implementation])
   AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/ext/posix/posix.c
+++ b/ext/posix/posix.c
@@ -533,8 +533,8 @@ PHP_FUNCTION(posix_isatty)
 /* }}} */
 
 /*
-	POSIX.1, 4.8.1 sysconf() - TODO
-	POSIX.1, 5.7.1 pathconf(), fpathconf() - TODO
+	POSIX.1, 4.8.1 sysconf()
+	POSIX.1, 5.7.1 pathconf(), fpathconf()
 
 	POSIX.1, 5.1.2 opendir(), readdir(), rewinddir(), closedir()
 	POSIX.1, 5.2.1 chdir()
@@ -1240,7 +1240,7 @@ PHP_FUNCTION(posix_sysconf)
 	RETURN_LONG(sysconf(conf_id));
 }
 
-#ifdef HAVE_POSIX_PATHCONF
+#ifdef HAVE_PATHCONF
 PHP_FUNCTION(posix_pathconf)
 {
 	zend_long name, ret;
@@ -1269,7 +1269,9 @@ PHP_FUNCTION(posix_pathconf)
 
 	RETURN_LONG(ret);
 }
+#endif
 
+#ifdef HAVE_FPATHCONF
 PHP_FUNCTION(posix_fpathconf)
 {
 	zend_long name, ret, fd = 0;

--- a/ext/posix/posix.stub.php
+++ b/ext/posix/posix.stub.php
@@ -432,8 +432,11 @@ function posix_initgroups(string $username, int $group_id): bool {}
 
 function posix_sysconf(int $conf_id): int {}
 
-#ifdef HAVE_POSIX_PATHCONF
+#ifdef HAVE_PATHCONF
 function posix_pathconf(string $path, int $name): int|false {}
+#endif
+
+#ifdef HAVE_FPATHCONF
 /** @param resource|int $file_descriptor */
 function posix_fpathconf($file_descriptor, int $name): int|false {}
 #endif

--- a/ext/posix/posix_arginfo.h
+++ b/ext/posix/posix_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5a4a863892761475f2d34d9463e0660b0a8ede5d */
+ * Stub hash: 372ab42a8aebd30ac41f4219d87a5ef6e8b03b24 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_posix_kill, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, process_id, IS_LONG, 0)
@@ -171,14 +171,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_posix_sysconf, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, conf_id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-#if defined(HAVE_POSIX_PATHCONF)
+#if defined(HAVE_PATHCONF)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_posix_pathconf, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if defined(HAVE_POSIX_PATHCONF)
+#if defined(HAVE_FPATHCONF)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_posix_fpathconf, 0, 2, MAY_BE_LONG|MAY_BE_FALSE)
 	ZEND_ARG_INFO(0, file_descriptor)
 	ZEND_ARG_TYPE_INFO(0, name, IS_LONG, 0)
@@ -252,10 +252,10 @@ ZEND_FUNCTION(posix_strerror);
 ZEND_FUNCTION(posix_initgroups);
 #endif
 ZEND_FUNCTION(posix_sysconf);
-#if defined(HAVE_POSIX_PATHCONF)
+#if defined(HAVE_PATHCONF)
 ZEND_FUNCTION(posix_pathconf);
 #endif
-#if defined(HAVE_POSIX_PATHCONF)
+#if defined(HAVE_FPATHCONF)
 ZEND_FUNCTION(posix_fpathconf);
 #endif
 
@@ -328,10 +328,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(posix_initgroups, arginfo_posix_initgroups)
 #endif
 	ZEND_FE(posix_sysconf, arginfo_posix_sysconf)
-#if defined(HAVE_POSIX_PATHCONF)
+#if defined(HAVE_PATHCONF)
 	ZEND_FE(posix_pathconf, arginfo_posix_pathconf)
 #endif
-#if defined(HAVE_POSIX_PATHCONF)
+#if defined(HAVE_FPATHCONF)
 	ZEND_FE(posix_fpathconf, arginfo_posix_fpathconf)
 #endif
 	ZEND_FE_END


### PR DESCRIPTION
Hello, this was found recently. The posix_pathconf and posix_fpathconf are PHP function names. On the system these are `pathconf` and `fpathconf` therefore the typos fixed in the M4 stub file. Otherwise, with the current code in the master branch these functions won't be enabled on any system.

These two might not be available everywhere so we check them in config.m4 when doing the configure step.

Constants that are defined into main/php_config.h: HAVE_FPATHCONF
HAVE_PATHCONF

Implemented via GH-10238
Related to GH-10350