### PR TITLE
Fix incorrect attribute existence check in DOMElement::setAttributeNodeNS()

### DIFF
--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -862,7 +862,7 @@ PHP_METHOD(DOMElement, setAttributeNodeNS)
 
 	nsp = attrp->ns;
 	if (nsp != NULL) {
-		existattrp = xmlHasNsProp(nodep, nsp->href, attrp->name);
+		existattrp = xmlHasNsProp(nodep, attrp->name, nsp->href);
 	} else {
 		existattrp = xmlHasProp(nodep, attrp->name);
 	}

--- a/ext/dom/tests/setAttributeNodeNS_same_uri_different_prefix.phpt
+++ b/ext/dom/tests/setAttributeNodeNS_same_uri_different_prefix.phpt
@@ -27,12 +27,12 @@ echo $doc->saveXML(), "\n";
 --EXPECT--
 NULL
 <?xml version="1.0"?>
-<container xmlns:foo="http://php.net/ns1" foo:hello=""/>
+<container xmlns:foo="http://php.net/ns1" foo:hello="1"/>
 
-NULL
+string(1) "1"
 <?xml version="1.0"?>
-<container xmlns:foo="http://php.net/ns1" foo:hello=""/>
+<container xmlns:foo="http://php.net/ns1" foo:hello="2"/>
 
-NULL
+string(1) "2"
 <?xml version="1.0"?>
-<container xmlns:foo="http://php.net/ns1" foo:hello=""/>
+<container xmlns:foo="http://php.net/ns1" foo:hello="3"/>

--- a/ext/dom/tests/setAttributeNodeNS_same_uri_different_prefix.phpt
+++ b/ext/dom/tests/setAttributeNodeNS_same_uri_different_prefix.phpt
@@ -1,0 +1,38 @@
+--TEST--
+setAttributeNodeNS with same URI but different prefix
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+// Spec doesn't require to remove redundant namespace declarations.
+// This means that when appending a new attribute the old namespace declaration is reused, hence the prefix stays "foo".
+// Firefox cleans up the old namespace declaration, so there the prefix does change.
+// Chrome doesn't clean it up, so there the prefix doesn't change.
+// Our behaviour is the same as Chrome's due to implementation difficulties.
+$doc = new DOMDocument();
+$doc->appendChild($doc->createElement('container'));
+$attribute = $doc->createAttributeNS('http://php.net/ns1', 'foo:hello');
+$attribute->nodeValue = '1';
+var_dump($doc->documentElement->setAttributeNodeNS($attribute)?->nodeValue);
+echo $doc->saveXML(), "\n";
+$attribute = $doc->createAttributeNS('http://php.net/ns1', 'bar:hello');
+$attribute->nodeValue = '2';
+var_dump($doc->documentElement->setAttributeNodeNS($attribute)?->nodeValue);
+echo $doc->saveXML(), "\n";
+$attribute = $doc->createAttributeNS('http://php.net/ns1', 'hello');
+$attribute->nodeValue = '3';
+var_dump($doc->documentElement->setAttributeNodeNS($attribute)?->nodeValue);
+echo $doc->saveXML(), "\n";
+?>
+--EXPECT--
+NULL
+<?xml version="1.0"?>
+<container xmlns:foo="http://php.net/ns1" foo:hello=""/>
+
+NULL
+<?xml version="1.0"?>
+<container xmlns:foo="http://php.net/ns1" foo:hello=""/>
+
+NULL
+<?xml version="1.0"?>
+<container xmlns:foo="http://php.net/ns1" foo:hello=""/>


### PR DESCRIPTION
The arguments to xmlHasNsProp were swapped (https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-tree.html#xmlHasNsProp).