### PR TITLE
On riscv64 require libatomic if actually needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -377,11 +377,7 @@ AC_CHECK_LIB(m, sin)
 
 case $host_alias in
   riscv64*)
-    AC_CHECK_LIB(atomic, __atomic_exchange_1, [
-      PHP_ADD_LIBRARY(atomic)
-    ], [
-      AC_MSG_ERROR([Problem with enabling atomic. Please check config.log for details.])
-    ])
+    PHP_CHECK_FUNC(__atomic_exchange_1, atomic)
     ;;
 esac
 


### PR DESCRIPTION
clang and newer gcc releases support byte-sized atomic accesses on riscv64 through inline builtins.  In both cases the hard dependency on libatomic added by GH-11321 isn't useful.

Stop using AC_CHECK_LIB() which is too naive to notice that libatomic isn't needed.  Instead, PHP_CHECK_FUNC() will retry the check with -latomic if required.