### PR TITLE
Fix GH-11791: Wrong default value of DOMDocument::xmlStandalone

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -187,7 +187,7 @@ int dom_document_standalone_read(dom_object *obj, zval *retval)
 		return FAILURE;
 	}
 
-	ZVAL_BOOL(retval, docp->standalone);
+	ZVAL_BOOL(retval, docp->standalone > 0);
 	return SUCCESS;
 }
 

--- a/ext/dom/tests/domobject_debug_handler.phpt
+++ b/ext/dom/tests/domobject_debug_handler.phpt
@@ -28,8 +28,8 @@ DOMDocument Object
     [actualEncoding] => 
     [encoding] => 
     [xmlEncoding] => 
-    [standalone] => 1
-    [xmlStandalone] => 1
+    [standalone] => 
+    [xmlStandalone] => 
     [version] => 1.0
     [xmlVersion] => 1.0
     [strictErrorChecking] => 1

--- a/ext/dom/tests/gh11791.phpt
+++ b/ext/dom/tests/gh11791.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-11791 (Wrong default value of DOMDocument.xmlStandalone)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument();
+$doc->loadXML('<root/>');
+var_dump($doc->xmlStandalone);
+$doc->xmlStandalone = true;
+var_dump($doc->xmlStandalone);
+
+$doc = new DOMDocument();
+$doc->loadXML('<?xml version="1.0"?><root/>');
+var_dump($doc->xmlStandalone);
+$doc->xmlStandalone = true;
+var_dump($doc->xmlStandalone);
+
+$doc = new DOMDocument();
+$doc->loadXML('<?xml version="1.0" standalone="no"?><root/>');
+var_dump($doc->xmlStandalone);
+$doc->xmlStandalone = true;
+var_dump($doc->xmlStandalone);
+
+$doc = new DOMDocument();
+$doc->loadXML('<?xml version="1.0" standalone="yes"?><root/>');
+var_dump($doc->xmlStandalone);
+$doc->xmlStandalone = false;
+var_dump($doc->xmlStandalone);
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(false)


### PR DESCRIPTION
At one point this was changed from a bool to an int in libxml2, with negative values meaning it is unspecified. Because it is cast to a bool this therefore returned true instead of the expected false.