### PR TITLE
Fix '++nothing+crc' is not a recognized feature for target when compiling M1 / M2 macOS

### DIFF
--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -68,6 +68,8 @@ static inline int has_crc32_insn(void) {
 #  if!defined(__clang__)
 #   pragma GCC push_options
 #   pragma GCC target ("+nothing+crc")
+#  elif defined(__APPLE__)
+#   pragma clang attribute push(__attribute__((target("crc"))), apply_to=function)
 #  else
 #   pragma clang attribute push(__attribute__((target("+nothing+crc"))), apply_to=function)
 #  endif

--- a/ext/standard/crc32.c
+++ b/ext/standard/crc32.c
@@ -98,6 +98,8 @@ static uint32_t crc32_aarch64(uint32_t crc, const char *p, size_t nr) {
 # if defined(__GNUC__)
 #  if !defined(__clang__)
 #   pragma GCC pop_options
+#  elif defined(__APPLE__)
+#   pragma clang attribute pop
 #  else
 #   pragma clang attribute pop
 #  endif


### PR DESCRIPTION
`#pragma GCC target("+nothing+crc")` is means clear outs aarch64_isa_flags.

However, `#pragma clang attribute push(__attribute__((target("+nothing+crc")` is not means any, then displays ignore feature. (Not reproduce Linux on ARM (ex: Raspberry Pi))

Therefore, Add new `#pragma` when compiling on M1/M2 macOS.

close: #11785 