### PR TITLE
Corrections to return type of loading DOM documents

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -202,6 +202,11 @@ PHP 8.3 UPGRADE NOTES
 
 - Dom:
   . Changed DOMCharacterData::appendData() tentative return type to true.
+  . DOMDocument::loadHTML(), DOMDocument::loadHTMLFile(), DOMDocument::loadXML(),
+    and DOMDocument::loadXMLFile() now have a tentative return type of bool.
+    Previously, this was documented as having a return type of DOMDocument|bool,
+    but DOMDocument cannot be returned since PHP 8.0 as it is no longer statically
+    callable.
 
 - Gd:
   . Changed imagerotate signature, removed the `ignore_transparent` argument

--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -1317,19 +1317,13 @@ static xmlDocPtr dom_document_parser(zval *id, int mode, char *source, size_t so
 
 /* {{{ static void dom_parse_document(INTERNAL_FUNCTION_PARAMETERS, int mode) */
 static void dom_parse_document(INTERNAL_FUNCTION_PARAMETERS, int mode) {
-	zval *id;
 	xmlDoc *docp = NULL, *newdoc;
 	dom_doc_propsptr doc_prop;
 	dom_object *intern;
 	char *source;
 	size_t source_len;
-	int refcount, ret;
+	int refcount;
 	zend_long options = 0;
-
-	id = getThis();
-	if (id != NULL && ! instanceof_function(Z_OBJCE_P(id), dom_document_class_entry)) {
-		id = NULL;
-	}
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &source, &source_len, &options) == FAILURE) {
 		RETURN_THROWS();
@@ -1348,48 +1342,44 @@ static void dom_parse_document(INTERNAL_FUNCTION_PARAMETERS, int mode) {
 		RETURN_FALSE;
 	}
 
-	newdoc = dom_document_parser(id, mode, source, source_len, options);
+	newdoc = dom_document_parser(ZEND_THIS, mode, source, source_len, options);
 
 	if (!newdoc)
 		RETURN_FALSE;
 
-	if (id != NULL) {
-		intern = Z_DOMOBJ_P(id);
-		size_t old_modification_nr = 0;
-		if (intern != NULL) {
-			docp = (xmlDocPtr) dom_object_get_node(intern);
-			doc_prop = NULL;
-			if (docp != NULL) {
-				const php_libxml_doc_ptr *doc_ptr = docp->_private;
-				ZEND_ASSERT(doc_ptr != NULL); /* Must exist, we have a document */
-				old_modification_nr = doc_ptr->cache_tag.modification_nr;
-				php_libxml_decrement_node_ptr((php_libxml_node_object *) intern);
-				doc_prop = intern->document->doc_props;
-				intern->document->doc_props = NULL;
-				refcount = php_libxml_decrement_doc_ref((php_libxml_node_object *)intern);
-				if (refcount != 0) {
-					docp->_private = NULL;
-				}
+	intern = Z_DOMOBJ_P(ZEND_THIS);
+	size_t old_modification_nr = 0;
+	if (intern != NULL) {
+		docp = (xmlDocPtr) dom_object_get_node(intern);
+		doc_prop = NULL;
+		if (docp != NULL) {
+			const php_libxml_doc_ptr *doc_ptr = docp->_private;
+			ZEND_ASSERT(doc_ptr != NULL); /* Must exist, we have a document */
+			old_modification_nr = doc_ptr->cache_tag.modification_nr;
+			php_libxml_decrement_node_ptr((php_libxml_node_object *) intern);
+			doc_prop = intern->document->doc_props;
+			intern->document->doc_props = NULL;
+			refcount = php_libxml_decrement_doc_ref((php_libxml_node_object *)intern);
+			if (refcount != 0) {
+				docp->_private = NULL;
 			}
-			intern->document = NULL;
-			if (php_libxml_increment_doc_ref((php_libxml_node_object *)intern, newdoc) == -1) {
-				RETURN_FALSE;
-			}
-			intern->document->doc_props = doc_prop;
 		}
-
-		php_libxml_increment_node_ptr((php_libxml_node_object *)intern, (xmlNodePtr)newdoc, (void *)intern);
-		/* Since iterators should invalidate, we need to start the modification number from the old counter */
-		if (old_modification_nr != 0) {
-			php_libxml_doc_ptr* doc_ptr = (php_libxml_doc_ptr*) ((php_libxml_node_object*) intern)->node; /* downcast */
-			doc_ptr->cache_tag.modification_nr = old_modification_nr;
-			php_libxml_invalidate_node_list_cache(doc_ptr);
+		intern->document = NULL;
+		if (php_libxml_increment_doc_ref((php_libxml_node_object *)intern, newdoc) == -1) {
+			RETURN_FALSE;
 		}
-
-		RETURN_TRUE;
-	} else {
-		DOM_RET_OBJ((xmlNodePtr) newdoc, &ret, NULL);
+		intern->document->doc_props = doc_prop;
 	}
+
+	php_libxml_increment_node_ptr((php_libxml_node_object *)intern, (xmlNodePtr)newdoc, (void *)intern);
+	/* Since iterators should invalidate, we need to start the modification number from the old counter */
+	if (old_modification_nr != 0) {
+		php_libxml_doc_ptr* doc_ptr = (php_libxml_doc_ptr*) ((php_libxml_node_object*) intern)->node; /* downcast */
+		doc_ptr->cache_tag.modification_nr = old_modification_nr;
+		php_libxml_invalidate_node_list_cache(doc_ptr);
+	}
+
+	RETURN_TRUE;
 }
 /* }}} end dom_parser_document */
 
@@ -1847,17 +1837,14 @@ PHP_METHOD(DOMDocument, relaxNGValidateSource)
 
 static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 {
-	zval *id;
 	xmlDoc *docp = NULL, *newdoc;
 	dom_object *intern;
 	dom_doc_propsptr doc_prop;
 	char *source;
 	size_t source_len;
-	int refcount, ret;
+	int refcount;
 	zend_long options = 0;
 	htmlParserCtxtPtr ctxt;
-
-	id = getThis();
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &source, &source_len, &options) == FAILURE) {
 		RETURN_THROWS();
@@ -1908,43 +1895,39 @@ static void dom_load_html(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 	if (!newdoc)
 		RETURN_FALSE;
 
-	if (id != NULL && instanceof_function(Z_OBJCE_P(id), dom_document_class_entry)) {
-		intern = Z_DOMOBJ_P(id);
-		size_t old_modification_nr = 0;
-		if (intern != NULL) {
-			docp = (xmlDocPtr) dom_object_get_node(intern);
-			doc_prop = NULL;
-			if (docp != NULL) {
-				const php_libxml_doc_ptr *doc_ptr = docp->_private;
-				ZEND_ASSERT(doc_ptr != NULL); /* Must exist, we have a document */
-				old_modification_nr = doc_ptr->cache_tag.modification_nr;
-				php_libxml_decrement_node_ptr((php_libxml_node_object *) intern);
-				doc_prop = intern->document->doc_props;
-				intern->document->doc_props = NULL;
-				refcount = php_libxml_decrement_doc_ref((php_libxml_node_object *)intern);
-				if (refcount != 0) {
-					docp->_private = NULL;
-				}
+	intern = Z_DOMOBJ_P(ZEND_THIS);
+	size_t old_modification_nr = 0;
+	if (intern != NULL) {
+		docp = (xmlDocPtr) dom_object_get_node(intern);
+		doc_prop = NULL;
+		if (docp != NULL) {
+			const php_libxml_doc_ptr *doc_ptr = docp->_private;
+			ZEND_ASSERT(doc_ptr != NULL); /* Must exist, we have a document */
+			old_modification_nr = doc_ptr->cache_tag.modification_nr;
+			php_libxml_decrement_node_ptr((php_libxml_node_object *) intern);
+			doc_prop = intern->document->doc_props;
+			intern->document->doc_props = NULL;
+			refcount = php_libxml_decrement_doc_ref((php_libxml_node_object *)intern);
+			if (refcount != 0) {
+				docp->_private = NULL;
 			}
-			intern->document = NULL;
-			if (php_libxml_increment_doc_ref((php_libxml_node_object *)intern, newdoc) == -1) {
-				RETURN_FALSE;
-			}
-			intern->document->doc_props = doc_prop;
 		}
-
-		php_libxml_increment_node_ptr((php_libxml_node_object *)intern, (xmlNodePtr)newdoc, (void *)intern);
-		/* Since iterators should invalidate, we need to start the modification number from the old counter */
-		if (old_modification_nr != 0) {
-			php_libxml_doc_ptr* doc_ptr = (php_libxml_doc_ptr*) ((php_libxml_node_object*) intern)->node; /* downcast */
-			doc_ptr->cache_tag.modification_nr = old_modification_nr;
-			php_libxml_invalidate_node_list_cache(doc_ptr);
+		intern->document = NULL;
+		if (php_libxml_increment_doc_ref((php_libxml_node_object *)intern, newdoc) == -1) {
+			RETURN_FALSE;
 		}
-
-		RETURN_TRUE;
-	} else {
-		DOM_RET_OBJ((xmlNodePtr) newdoc, &ret, NULL);
+		intern->document->doc_props = doc_prop;
 	}
+
+	php_libxml_increment_node_ptr((php_libxml_node_object *)intern, (xmlNodePtr)newdoc, (void *)intern);
+	/* Since iterators should invalidate, we need to start the modification number from the old counter */
+	if (old_modification_nr != 0) {
+		php_libxml_doc_ptr* doc_ptr = (php_libxml_doc_ptr*) ((php_libxml_node_object*) intern)->node; /* downcast */
+		doc_ptr->cache_tag.modification_nr = old_modification_nr;
+		php_libxml_invalidate_node_list_cache(doc_ptr);
+	}
+
+	RETURN_TRUE;
 }
 /* }}} */
 

--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -774,11 +774,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
     /** @return DOMNode|false */
     public function importNode(DOMNode $node, bool $deep = false) {}
 
-    /** @return DOMDocument|bool */
-    public function load(string $filename, int $options = 0) {} // TODO return type shouldn't depend on the call scope
+    /** @tentative-return-type */
+    public function load(string $filename, int $options = 0): bool {}
 
-    /** @return DOMDocument|bool */
-    public function loadXML(string $source, int $options = 0) {} // TODO return type shouldn't depend on the call scope
+    /** @tentative-return-type */
+    public function loadXML(string $source, int $options = 0): bool {}
 
     /** @tentative-return-type */
     public function normalizeDocument(): void {}
@@ -790,11 +790,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
     public function save(string $filename, int $options = 0): int|false {}
 
 #ifdef LIBXML_HTML_ENABLED
-    /** @return DOMDocument|bool */
-    public function loadHTML(string $source, int $options = 0) {} // TODO return type shouldn't depend on the call scope
+    /** @tentative-return-type */
+    public function loadHTML(string $source, int $options = 0): bool {}
 
-    /** @return DOMDocument|bool */
-    public function loadHTMLFile(string $filename, int $options = 0) {} // TODO return type shouldn't depend on the call scope
+    /** @tentative-return-type */
+    public function loadHTMLFile(string $filename, int $options = 0): bool {}
 
     /** @tentative-return-type */
     public function saveHTML(?DOMNode $node = null): string|false {}

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3a37adaf011606d10ae1fa12ce135a23b3e07cf4 */
+ * Stub hash: 8bfa8e742552be6f1fb85593dcab2e755f1d5089 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
@@ -371,12 +371,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_importNode, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, deep, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_load, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_load, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_loadXML, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_loadXML, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, source, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
@@ -394,14 +394,14 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_DOMDocument_save
 ZEND_END_ARG_INFO()
 
 #if defined(LIBXML_HTML_ENABLED)
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_loadHTML, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_loadHTML, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, source, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 #endif
 
 #if defined(LIBXML_HTML_ENABLED)
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DOMDocument_loadHTMLFile, 0, 0, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_DOMDocument_loadHTMLFile, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
I saw an issue on doc-en about confusion of the static calling part and the return type.
This cannot return DOMDocument since PHP 8.0, so let's fix up the return type and remove the dead code from the implementation.

PR to docs will follow after this one is merged.