### PR TITLE
Synchronize zend_jit_stop_counter_handlers()

### DIFF
--- a/ext/opcache/ZendAccelerator.h
+++ b/ext/opcache/ZendAccelerator.h
@@ -266,6 +266,7 @@ typedef struct _zend_accel_shared_globals {
 	LONGLONG   restart_in;
 #endif
 	bool       restart_in_progress;
+	bool       jit_counters_stopped;
 
 	/* Preloading */
 	zend_persistent_script *preload_script;


### PR DESCRIPTION
Avoid stopping counters repeatedly from different threads/processes.

Fixes GH-11609