### PR TITLE
add ZipArchive::LENGTH_TO_END and ZipArchive::LENGTH_UNCHECKED constants

### DIFF
--- a/ext/zip/php_zip.h
+++ b/ext/zip/php_zip.h
@@ -31,6 +31,11 @@ extern zend_module_entry zip_module_entry;
 #define ZIP_OVERWRITE ZIP_TRUNCATE
 #endif
 
+/* since 1.10.1 */
+#ifndef ZIP_LENGTH_TO_END
+#define ZIP_LENGTH_TO_END 0
+#endif
+
 /* Additionnal flags not from libzip */
 #define ZIP_FL_OPEN_FILE_NOW (1u<<30)
 

--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -67,671 +67,562 @@ function zip_entry_compressionmethod($zip_entry): string|false {}
 class ZipArchive implements Countable
 {
     /**
-     * @var int
      * @cvalue ZIP_CREATE
      */
-    public const CREATE = UNKNOWN;
+    public const int CREATE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_EXCL
      */
-    public const EXCL = UNKNOWN;
+    public const int EXCL = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CHECKCONS
      */
-    public const CHECKCONS = UNKNOWN;
+    public const int CHECKCONS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OVERWRITE
      */
-    public const OVERWRITE = UNKNOWN;
+    public const int OVERWRITE = UNKNOWN;
 #ifdef ZIP_RDONLY
     /**
-     * @var int
      * @cvalue ZIP_RDONLY
      */
-    public const RDONLY = UNKNOWN;
+    public const int RDONLY = UNKNOWN;
 #endif
 
     /**
-     * @var int
      * @cvalue ZIP_FL_NOCASE
      */
-    public const FL_NOCASE = UNKNOWN;
+    public const int FL_NOCASE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_NODIR
      */
-    public const FL_NODIR = UNKNOWN;
+    public const int FL_NODIR = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_COMPRESSED
      */
-    public const FL_COMPRESSED = UNKNOWN;
+    public const int FL_COMPRESSED = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_UNCHANGED
      */
-    public const FL_UNCHANGED = UNKNOWN;
+    public const int FL_UNCHANGED = UNKNOWN;
 /* deprecated in libzip 1.10.0 */
 #ifdef ZIP_FL_RECOMPRESS
     /**
-     * @var int
      * @cvalue ZIP_FL_RECOMPRESS
      * @deprecated
      */
-    public const FL_RECOMPRESS = UNKNOWN;
+    public const int FL_RECOMPRESS = UNKNOWN;
 #endif
     /**
-     * @var int
      * @cvalue ZIP_FL_ENCRYPTED
      */
-    public const FL_ENCRYPTED = UNKNOWN;
+    public const int FL_ENCRYPTED = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_OVERWRITE
      */
-    public const FL_OVERWRITE = UNKNOWN;
+    public const int FL_OVERWRITE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_LOCAL
      */
-    public const FL_LOCAL = UNKNOWN;
+    public const int FL_LOCAL = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_CENTRAL
      */
-    public const FL_CENTRAL = UNKNOWN;
+    public const int FL_CENTRAL = UNKNOWN;
 
     /* Default filename encoding policy. */
 
     /**
-     * @var int
      * @cvalue ZIP_FL_ENC_GUESS
      */
-    public const FL_ENC_GUESS = UNKNOWN;
+    public const int FL_ENC_GUESS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_ENC_RAW
      */
-    public const FL_ENC_RAW = UNKNOWN;
+    public const int FL_ENC_RAW = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_ENC_STRICT
      */
-    public const FL_ENC_STRICT = UNKNOWN;
+    public const int FL_ENC_STRICT = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_ENC_UTF_8
      */
-    public const FL_ENC_UTF_8 = UNKNOWN;
+    public const int FL_ENC_UTF_8 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_FL_ENC_CP437
      */
-    public const FL_ENC_CP437 = UNKNOWN;
+    public const int FL_ENC_CP437 = UNKNOWN;
 
     /**
      * Additionnal flags not from libzip
-     * @var int
      * @cvalue ZIP_FL_OPEN_FILE_NOW
      */
-    public const FL_OPEN_FILE_NOW = UNKNOWN;
+    public const int FL_OPEN_FILE_NOW = UNKNOWN;
 
     /**
-     * @var int
      * @cvalue ZIP_CM_DEFAULT
      */
-    public const CM_DEFAULT = UNKNOWN;
+    public const int CM_DEFAULT = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_STORE
      */
-    public const CM_STORE = UNKNOWN;
+    public const int CM_STORE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_SHRINK
      */
-    public const CM_SHRINK = UNKNOWN;
+    public const int CM_SHRINK = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_REDUCE_1
      */
-    public const CM_REDUCE_1 = UNKNOWN;
+    public const int CM_REDUCE_1 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_REDUCE_2
      */
-    public const CM_REDUCE_2 = UNKNOWN;
+    public const int CM_REDUCE_2 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_REDUCE_3
      */
-    public const CM_REDUCE_3 = UNKNOWN;
+    public const int CM_REDUCE_3 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_REDUCE_4
      */
-    public const CM_REDUCE_4 = UNKNOWN;
+    public const int CM_REDUCE_4 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_IMPLODE
      */
-    public const CM_IMPLODE = UNKNOWN;
+    public const int CM_IMPLODE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_DEFLATE
      */
-    public const CM_DEFLATE = UNKNOWN;
+    public const int CM_DEFLATE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_DEFLATE64
      */
-    public const CM_DEFLATE64 = UNKNOWN;
+    public const int CM_DEFLATE64 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_PKWARE_IMPLODE
      */
-    public const CM_PKWARE_IMPLODE = UNKNOWN;
+    public const int CM_PKWARE_IMPLODE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_BZIP2
      */
-    public const CM_BZIP2 = UNKNOWN;
+    public const int CM_BZIP2 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_LZMA
      */
-    public const CM_LZMA = UNKNOWN;
+    public const int CM_LZMA = UNKNOWN;
 #ifdef ZIP_CM_LZMA2
     /**
-     * @var int
      * @cvalue ZIP_CM_LZMA2
      */
-    public const CM_LZMA2 = UNKNOWN;
+    public const int CM_LZMA2 = UNKNOWN;
 #endif
 
 #ifdef ZIP_CM_ZSTD
     /**
-     * @var int
      * @cvalue ZIP_CM_ZSTD
      */
-    public const CM_ZSTD = UNKNOWN;
+    public const int CM_ZSTD = UNKNOWN;
 #endif
 #ifdef ZIP_CM_XZ
     /**
-     * @var int
      * @cvalue ZIP_CM_XZ
      */
-    public const CM_XZ = UNKNOWN;
+    public const int CM_XZ = UNKNOWN;
 #endif
     /**
-     * @var int
      * @cvalue ZIP_CM_TERSE
      */
-    public const CM_TERSE = UNKNOWN;
+    public const int CM_TERSE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_LZ77
      */
-    public const CM_LZ77 = UNKNOWN;
+    public const int CM_LZ77 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_WAVPACK
      */
-    public const CM_WAVPACK = UNKNOWN;
+    public const int CM_WAVPACK = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_CM_PPMD
      */
-    public const CM_PPMD = UNKNOWN;
+    public const int CM_PPMD = UNKNOWN;
 
     /* Error code */
 
     /**
      * N No error
-     * @var int
      * @cvalue ZIP_ER_OK
      */
-    public const ER_OK = UNKNOWN;
+    public const int ER_OK = UNKNOWN;
     /**
      * N Multi-disk zip archives not supported
-     * @var int
      * @cvalue ZIP_ER_MULTIDISK
      */
-    public const ER_MULTIDISK = UNKNOWN;
+    public const int ER_MULTIDISK = UNKNOWN;
     /**
      * S Renaming temporary file failed
-     * @var int
      * @cvalue ZIP_ER_RENAME
      */
-    public const ER_RENAME = UNKNOWN;
+    public const int ER_RENAME = UNKNOWN;
     /**
      * S Closing zip archive failed
-     * @var int
      * @cvalue ZIP_ER_CLOSE
      */
-    public const ER_CLOSE = UNKNOWN;
+    public const int ER_CLOSE = UNKNOWN;
     /**
      * S Seek error
-     * @var int
      * @cvalue ZIP_ER_SEEK
      */
-    public const ER_SEEK = UNKNOWN;
+    public const int ER_SEEK = UNKNOWN;
     /**
      * S Read error
-     * @var int
      * @cvalue ZIP_ER_READ
      */
-    public const ER_READ = UNKNOWN;
+    public const int ER_READ = UNKNOWN;
     /**
      * S Write error
-     * @var int
      * @cvalue ZIP_ER_WRITE
      */
-    public const ER_WRITE = UNKNOWN;
+    public const int ER_WRITE = UNKNOWN;
     /**
      * N CRC error
-     * @var int
      * @cvalue ZIP_ER_CRC
      */
-    public const ER_CRC = UNKNOWN;
+    public const int ER_CRC = UNKNOWN;
     /**
      * N Containing zip archive was closed
-     * @var int
      * @cvalue ZIP_ER_ZIPCLOSED
      */
-    public const ER_ZIPCLOSED = UNKNOWN;
+    public const int ER_ZIPCLOSED = UNKNOWN;
     /**
      * N No such file
-     * @var int
      * @cvalue ZIP_ER_NOENT
      */
-    public const ER_NOENT = UNKNOWN;
+    public const int ER_NOENT = UNKNOWN;
     /**
      * N File already exists
-     * @var int
      * @cvalue ZIP_ER_EXISTS
      */
-    public const ER_EXISTS = UNKNOWN;
+    public const int ER_EXISTS = UNKNOWN;
     /**
      * S Can't open file
-     * @var int
      * @cvalue ZIP_ER_OPEN
      */
-    public const ER_OPEN = UNKNOWN;
+    public const int ER_OPEN = UNKNOWN;
     /**
      * S Failure to create temporary file
-     * @var int
      * @cvalue ZIP_ER_TMPOPEN
      */
-    public const ER_TMPOPEN = UNKNOWN;
+    public const int ER_TMPOPEN = UNKNOWN;
     /**
      * Z Zlib error
-     * @var int
      * @cvalue ZIP_ER_ZLIB
      */
-    public const ER_ZLIB = UNKNOWN;
+    public const int ER_ZLIB = UNKNOWN;
     /**
      * N Malloc failure
-     * @var int
      * @cvalue ZIP_ER_MEMORY
      */
-    public const ER_MEMORY = UNKNOWN;
+    public const int ER_MEMORY = UNKNOWN;
     /**
      * N Entry has been changed
-     * @var int
      * @cvalue ZIP_ER_CHANGED
      */
-    public const ER_CHANGED = UNKNOWN;
+    public const int ER_CHANGED = UNKNOWN;
     /**
      * N Compression method not supported
-     * @var int
      * @cvalue ZIP_ER_COMPNOTSUPP
      */
-    public const ER_COMPNOTSUPP = UNKNOWN;
+    public const int ER_COMPNOTSUPP = UNKNOWN;
     /**
      * N Premature EOF
-     * @var int
      * @cvalue ZIP_ER_EOF
      */
-    public const ER_EOF = UNKNOWN;
+    public const int ER_EOF = UNKNOWN;
     /**
      * N Invalid argument
-     * @var int
      * @cvalue ZIP_ER_INVAL
      */
-    public const ER_INVAL = UNKNOWN;
+    public const int ER_INVAL = UNKNOWN;
     /**
      * N Not a zip archive
-     * @var int
      * @cvalue ZIP_ER_NOZIP
      */
-    public const ER_NOZIP = UNKNOWN;
+    public const int ER_NOZIP = UNKNOWN;
     /**
      * N Internal error
-     * @var int
      * @cvalue ZIP_ER_INTERNAL
      */
-    public const ER_INTERNAL = UNKNOWN;
+    public const int ER_INTERNAL = UNKNOWN;
     /**
      * N Zip archive inconsistent
-     * @var int
      * @cvalue ZIP_ER_INCONS
      */
-    public const ER_INCONS = UNKNOWN;
+    public const int ER_INCONS = UNKNOWN;
     /**
      * S Can't remove file
-     * @var int
      * @cvalue ZIP_ER_REMOVE
      */
-    public const ER_REMOVE = UNKNOWN;
+    public const int ER_REMOVE = UNKNOWN;
     /**
      * N Entry has been deleted
-     * @var int
      * @cvalue ZIP_ER_DELETED
      */
-    public const ER_DELETED = UNKNOWN;
+    public const int ER_DELETED = UNKNOWN;
     /**
      * N Encryption method not supported
-     * @var int
      * @cvalue ZIP_ER_ENCRNOTSUPP
      */
-    public const ER_ENCRNOTSUPP = UNKNOWN;
+    public const int ER_ENCRNOTSUPP = UNKNOWN;
     /**
      * N Read-only archive
-     * @var int
      * @cvalue ZIP_ER_RDONLY
      */
-    public const ER_RDONLY = UNKNOWN;
+    public const int ER_RDONLY = UNKNOWN;
     /**
      * N Entry has been deleted
-     * @var int
      * @cvalue ZIP_ER_NOPASSWD
      */
-    public const ER_NOPASSWD = UNKNOWN;
+    public const int ER_NOPASSWD = UNKNOWN;
     /**
      * N Wrong password provided
-     * @var int
      * @cvalue ZIP_ER_WRONGPASSWD
      */
-    public const ER_WRONGPASSWD = UNKNOWN;
+    public const int ER_WRONGPASSWD = UNKNOWN;
 
     /* since 1.0.0 */
 #ifdef ZIP_ER_OPNOTSUPP
     /**
      * N Operation not supported
-     * @var int
      * @cvalue ZIP_ER_OPNOTSUPP
      */
-    public const ER_OPNOTSUPP = UNKNOWN;
+    public const int ER_OPNOTSUPP = UNKNOWN;
 #endif
 #ifdef ZIP_ER_INUSE
     /**
      * N Resource still in use
-     * @var int
      * @cvalue ZIP_ER_INUSE
      */
-    public const ER_INUSE = UNKNOWN;
+    public const int ER_INUSE = UNKNOWN;
 #endif
 #ifdef ZIP_ER_TELL
     /**
      * S Tell error
-     * @var int
      * @cvalue ZIP_ER_TELL
      */
-    public const ER_TELL = UNKNOWN;
+    public const int ER_TELL = UNKNOWN;
 #endif
 
     /* since 1.6.0 */
 #ifdef ZIP_ER_COMPRESSED_DATA
     /**
      * N Compressed data invalid
-     * @var int
      * @cvalue ZIP_ER_COMPRESSED_DATA
      */
-    public const ER_COMPRESSED_DATA = UNKNOWN;
+    public const int ER_COMPRESSED_DATA = UNKNOWN;
 #endif
 #ifdef ZIP_ER_CANCELLED
     /**
      * N Operation cancelled
-     * @var int
      * @cvalue ZIP_ER_CANCELLED
      */
-    public const ER_CANCELLED = UNKNOWN;
+    public const int ER_CANCELLED = UNKNOWN;
 #endif
 
     /* since 1.10.0 */
 #ifdef ZIP_ER_DATA_LENGTH
     /**
      * N Unexpected length of data
-     * @var int
      * @cvalue ZIP_ER_DATA_LENGTH
      */
-    public const ER_DATA_LENGTH = UNKNOWN;
+    public const int ER_DATA_LENGTH = UNKNOWN;
 #endif
 #ifdef ZIP_ER_NOT_ALLOWED
     /**
      * Not allowed in torrentzip
-     * @var int
      * @cvalue ZIP_ER_NOT_ALLOWED
      */
-    public const ER_NOT_ALLOWED = UNKNOWN;
+    public const int ER_NOT_ALLOWED = UNKNOWN;
 #endif
 #ifdef ZIP_AFL_RDONLY
     /**
      * read only -- cannot be cleared
-     * @var int
      * @cvalue ZIP_AFL_RDONLY
      */
-    public const AFL_RDONLY = UNKNOWN;
+    public const int AFL_RDONLY = UNKNOWN;
 #endif
 #ifdef ZIP_AFL_IS_TORRENTZIP
     /**
      * current archive is torrentzipped
-     * @var int
      * @cvalue ZIP_AFL_IS_TORRENTZIP
      */
-    public const AFL_IS_TORRENTZIP = UNKNOWN;
+    public const int AFL_IS_TORRENTZIP = UNKNOWN;
 #endif
 #ifdef ZIP_AFL_WANT_TORRENTZIP
     /**
      * write archive in torrentzip format
-     * @var int
      * @cvalue ZIP_AFL_WANT_TORRENTZIP
      */
-    public const AFL_WANT_TORRENTZIP = UNKNOWN;
+    public const int AFL_WANT_TORRENTZIP = UNKNOWN;
 #endif
 #ifdef ZIP_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE
     /**
      * don't remove file if archive is empty
-     * @var int
      * @cvalue ZIP_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE
      */
-    public const AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE = UNKNOWN;
+    public const int AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE = UNKNOWN;
 #endif
 
 #ifdef ZIP_OPSYS_DEFAULT
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_DOS
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_DOS = UNKNOWN;
+    public const int OPSYS_DOS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_AMIGA
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_AMIGA = UNKNOWN;
+    public const int OPSYS_AMIGA = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_OPENVMS
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_OPENVMS = UNKNOWN;
+    public const int OPSYS_OPENVMS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_UNIX
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_UNIX = UNKNOWN;
+    public const int OPSYS_UNIX = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_VM_CMS
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_VM_CMS = UNKNOWN;
+    public const int OPSYS_VM_CMS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_ATARI_ST
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_ATARI_ST = UNKNOWN;
+    public const int OPSYS_ATARI_ST = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_OS_2
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_OS_2 = UNKNOWN;
+    public const int OPSYS_OS_2 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_MACINTOSH
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_MACINTOSH = UNKNOWN;
+    public const int OPSYS_MACINTOSH = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_Z_SYSTEM
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_Z_SYSTEM = UNKNOWN;
+    public const int OPSYS_Z_SYSTEM = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_CPM
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_CPM = UNKNOWN;
+    public const int OPSYS_CPM = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_WINDOWS_NTFS
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_WINDOWS_NTFS = UNKNOWN;
+    public const int OPSYS_WINDOWS_NTFS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_MVS
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_MVS = UNKNOWN;
+    public const int OPSYS_MVS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_VSE
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_VSE = UNKNOWN;
+    public const int OPSYS_VSE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_ACORN_RISC
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_ACORN_RISC = UNKNOWN;
+    public const int OPSYS_ACORN_RISC = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_VFAT
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_VFAT = UNKNOWN;
+    public const int OPSYS_VFAT = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_ALTERNATE_MVS
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_ALTERNATE_MVS = UNKNOWN;
+    public const int OPSYS_ALTERNATE_MVS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_BEOS
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_BEOS = UNKNOWN;
+    public const int OPSYS_BEOS = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_TANDEM
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_TANDEM = UNKNOWN;
+    public const int OPSYS_TANDEM = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_OS_400
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_OS_400 = UNKNOWN;
+    public const int OPSYS_OS_400 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_OS_X
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_OS_X = UNKNOWN;
+    public const int OPSYS_OS_X = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_OPSYS_DEFAULT
      * @link ziparchive.constants.opsys
      */
-    public const OPSYS_DEFAULT = UNKNOWN;
+    public const int OPSYS_DEFAULT = UNKNOWN;
 #endif
 
     /**
-     * @var int
      * @cvalue ZIP_EM_NONE
      */
-    public const EM_NONE = UNKNOWN;
+    public const int EM_NONE = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_EM_TRAD_PKWARE
      */
-    public const EM_TRAD_PKWARE = UNKNOWN;
+    public const int EM_TRAD_PKWARE = UNKNOWN;
 #ifdef HAVE_ENCRYPTION
     /**
-     * @var int
      * @cvalue ZIP_EM_AES_128
      */
-    public const EM_AES_128 = UNKNOWN;
+    public const int EM_AES_128 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_EM_AES_192
      */
-    public const EM_AES_192 = UNKNOWN;
+    public const int EM_AES_192 = UNKNOWN;
     /**
-     * @var int
      * @cvalue ZIP_EM_AES_256
      */
-    public const EM_AES_256 = UNKNOWN;
+    public const int EM_AES_256 = UNKNOWN;
 #endif
     /**
-     * @var int
      * @cvalue ZIP_EM_UNKNOWN
      */
-    public const EM_UNKNOWN = UNKNOWN;
+    public const int EM_UNKNOWN = UNKNOWN;
 
     /**
-     * @var string
      * @cvalue LIBZIP_VERSION_STR
      */
-    public const LIBZIP_VERSION = UNKNOWN;
+    public const string LIBZIP_VERSION = UNKNOWN;
 
     /**
-     * @var int
      * @cvalue ZIP_LENGTH_TO_END
      */
-    public const LENGTH_TO_END = UNKNOWN;
+    public const int LENGTH_TO_END = UNKNOWN;
     /* since 1.10.1 */
 #ifdef ZIP_LENGTH_UNCHECKED
     /**
-     * @var int
      * @cvalue ZIP_LENGTH_UNCHECKED
      */
-    public const LENGTH_UNCHECKED = UNKNOWN;
+    public const int LENGTH_UNCHECKED = UNKNOWN;
 #endif
 
     /** @readonly */

--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -459,7 +459,6 @@ class ZipArchive implements Countable
     public const ER_WRONGPASSWD = UNKNOWN;
 
     /* since 1.0.0 */
-
 #ifdef ZIP_ER_OPNOTSUPP
     /**
      * N Operation not supported
@@ -721,6 +720,27 @@ class ZipArchive implements Countable
      */
     public const LIBZIP_VERSION = UNKNOWN;
 
+    /* since 1.10.1 */
+#ifdef ZIP_LENGTH_TO_END
+    /**
+     * @var int
+     * @cvalue ZIP_LENGTH_TO_END
+     */
+    public const LENGTH_TO_END = UNKNOWN;
+#else
+    /**
+     * @var int
+     */
+    public const LENGTH_TO_END = 0;
+#endif
+#ifdef ZIP_LENGTH_UNCHECKED
+    /**
+     * @var int
+     * @cvalue ZIP_LENGTH_UNCHECKED
+     */
+    public const LENGTH_UNCHECKED = UNKNOWN;
+#endif
+
     /** @readonly */
     public int $lastId;
     /** @readonly */
@@ -760,10 +780,10 @@ class ZipArchive implements Countable
     public function addFromString(string $name, string $content, int $flags = ZipArchive::FL_OVERWRITE): bool {}
 
     /** @tentative-return-type */
-    public function addFile(string $filepath, string $entryname = "", int $start = 0, int $length = 0, int $flags = ZipArchive::FL_OVERWRITE): bool {}
+    public function addFile(string $filepath, string $entryname = "", int $start = 0, int $length = ZipArchive::LENGTH_TO_END, int $flags = ZipArchive::FL_OVERWRITE): bool {}
 
     /** @tentative-return-type */
-    public function replaceFile(string $filepath, int $index, int $start = 0, int $length = 0, int $flags = 0): bool {}
+    public function replaceFile(string $filepath, int $index, int $start = 0, int $length = ZipArchive::LENGTH_TO_END, int $flags = 0): bool {}
 
     /** @tentative-return-type */
     public function addGlob(string $pattern, int $flags = 0, array $options = []): array|false {}

--- a/ext/zip/php_zip.stub.php
+++ b/ext/zip/php_zip.stub.php
@@ -720,19 +720,12 @@ class ZipArchive implements Countable
      */
     public const LIBZIP_VERSION = UNKNOWN;
 
-    /* since 1.10.1 */
-#ifdef ZIP_LENGTH_TO_END
     /**
      * @var int
      * @cvalue ZIP_LENGTH_TO_END
      */
     public const LENGTH_TO_END = UNKNOWN;
-#else
-    /**
-     * @var int
-     */
-    public const LENGTH_TO_END = 0;
-#endif
+    /* since 1.10.1 */
 #ifdef ZIP_LENGTH_UNCHECKED
     /**
      * @var int

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ac1969b19efd54bb9a2b9e2f228e66f4d22000b1 */
+ * Stub hash: 95564c667a51a548f5d43025c90546b991970ddd */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -511,210 +511,210 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_CREATE_value;
 	ZVAL_LONG(&const_CREATE_value, ZIP_CREATE);
 	zend_string *const_CREATE_name = zend_string_init_interned("CREATE", sizeof("CREATE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CREATE_name, &const_CREATE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CREATE_name, &const_CREATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CREATE_name);
 
 	zval const_EXCL_value;
 	ZVAL_LONG(&const_EXCL_value, ZIP_EXCL);
 	zend_string *const_EXCL_name = zend_string_init_interned("EXCL", sizeof("EXCL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_EXCL_name, &const_EXCL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_EXCL_name, &const_EXCL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EXCL_name);
 
 	zval const_CHECKCONS_value;
 	ZVAL_LONG(&const_CHECKCONS_value, ZIP_CHECKCONS);
 	zend_string *const_CHECKCONS_name = zend_string_init_interned("CHECKCONS", sizeof("CHECKCONS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CHECKCONS_name, &const_CHECKCONS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CHECKCONS_name, &const_CHECKCONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CHECKCONS_name);
 
 	zval const_OVERWRITE_value;
 	ZVAL_LONG(&const_OVERWRITE_value, ZIP_OVERWRITE);
 	zend_string *const_OVERWRITE_name = zend_string_init_interned("OVERWRITE", sizeof("OVERWRITE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OVERWRITE_name, &const_OVERWRITE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OVERWRITE_name, &const_OVERWRITE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OVERWRITE_name);
 #if defined(ZIP_RDONLY)
 
 	zval const_RDONLY_value;
 	ZVAL_LONG(&const_RDONLY_value, ZIP_RDONLY);
 	zend_string *const_RDONLY_name = zend_string_init_interned("RDONLY", sizeof("RDONLY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_RDONLY_name, &const_RDONLY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_RDONLY_name, &const_RDONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_RDONLY_name);
 #endif
 
 	zval const_FL_NOCASE_value;
 	ZVAL_LONG(&const_FL_NOCASE_value, ZIP_FL_NOCASE);
 	zend_string *const_FL_NOCASE_name = zend_string_init_interned("FL_NOCASE", sizeof("FL_NOCASE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_NOCASE_name, &const_FL_NOCASE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_NOCASE_name, &const_FL_NOCASE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_NOCASE_name);
 
 	zval const_FL_NODIR_value;
 	ZVAL_LONG(&const_FL_NODIR_value, ZIP_FL_NODIR);
 	zend_string *const_FL_NODIR_name = zend_string_init_interned("FL_NODIR", sizeof("FL_NODIR") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_NODIR_name, &const_FL_NODIR_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_NODIR_name, &const_FL_NODIR_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_NODIR_name);
 
 	zval const_FL_COMPRESSED_value;
 	ZVAL_LONG(&const_FL_COMPRESSED_value, ZIP_FL_COMPRESSED);
 	zend_string *const_FL_COMPRESSED_name = zend_string_init_interned("FL_COMPRESSED", sizeof("FL_COMPRESSED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_COMPRESSED_name, &const_FL_COMPRESSED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_COMPRESSED_name, &const_FL_COMPRESSED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_COMPRESSED_name);
 
 	zval const_FL_UNCHANGED_value;
 	ZVAL_LONG(&const_FL_UNCHANGED_value, ZIP_FL_UNCHANGED);
 	zend_string *const_FL_UNCHANGED_name = zend_string_init_interned("FL_UNCHANGED", sizeof("FL_UNCHANGED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_UNCHANGED_name, &const_FL_UNCHANGED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_UNCHANGED_name, &const_FL_UNCHANGED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_UNCHANGED_name);
 #if defined(ZIP_FL_RECOMPRESS)
 
 	zval const_FL_RECOMPRESS_value;
 	ZVAL_LONG(&const_FL_RECOMPRESS_value, ZIP_FL_RECOMPRESS);
 	zend_string *const_FL_RECOMPRESS_name = zend_string_init_interned("FL_RECOMPRESS", sizeof("FL_RECOMPRESS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_RECOMPRESS_name, &const_FL_RECOMPRESS_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_RECOMPRESS_name, &const_FL_RECOMPRESS_value, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_RECOMPRESS_name);
 #endif
 
 	zval const_FL_ENCRYPTED_value;
 	ZVAL_LONG(&const_FL_ENCRYPTED_value, ZIP_FL_ENCRYPTED);
 	zend_string *const_FL_ENCRYPTED_name = zend_string_init_interned("FL_ENCRYPTED", sizeof("FL_ENCRYPTED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_ENCRYPTED_name, &const_FL_ENCRYPTED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_ENCRYPTED_name, &const_FL_ENCRYPTED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENCRYPTED_name);
 
 	zval const_FL_OVERWRITE_value;
 	ZVAL_LONG(&const_FL_OVERWRITE_value, ZIP_FL_OVERWRITE);
 	zend_string *const_FL_OVERWRITE_name = zend_string_init_interned("FL_OVERWRITE", sizeof("FL_OVERWRITE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_OVERWRITE_name, &const_FL_OVERWRITE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_OVERWRITE_name, &const_FL_OVERWRITE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_OVERWRITE_name);
 
 	zval const_FL_LOCAL_value;
 	ZVAL_LONG(&const_FL_LOCAL_value, ZIP_FL_LOCAL);
 	zend_string *const_FL_LOCAL_name = zend_string_init_interned("FL_LOCAL", sizeof("FL_LOCAL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_LOCAL_name, &const_FL_LOCAL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_LOCAL_name, &const_FL_LOCAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_LOCAL_name);
 
 	zval const_FL_CENTRAL_value;
 	ZVAL_LONG(&const_FL_CENTRAL_value, ZIP_FL_CENTRAL);
 	zend_string *const_FL_CENTRAL_name = zend_string_init_interned("FL_CENTRAL", sizeof("FL_CENTRAL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_CENTRAL_name, &const_FL_CENTRAL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_CENTRAL_name, &const_FL_CENTRAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_CENTRAL_name);
 
 	zval const_FL_ENC_GUESS_value;
 	ZVAL_LONG(&const_FL_ENC_GUESS_value, ZIP_FL_ENC_GUESS);
 	zend_string *const_FL_ENC_GUESS_name = zend_string_init_interned("FL_ENC_GUESS", sizeof("FL_ENC_GUESS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_ENC_GUESS_name, &const_FL_ENC_GUESS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_ENC_GUESS_name, &const_FL_ENC_GUESS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_GUESS_name);
 
 	zval const_FL_ENC_RAW_value;
 	ZVAL_LONG(&const_FL_ENC_RAW_value, ZIP_FL_ENC_RAW);
 	zend_string *const_FL_ENC_RAW_name = zend_string_init_interned("FL_ENC_RAW", sizeof("FL_ENC_RAW") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_ENC_RAW_name, &const_FL_ENC_RAW_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_ENC_RAW_name, &const_FL_ENC_RAW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_RAW_name);
 
 	zval const_FL_ENC_STRICT_value;
 	ZVAL_LONG(&const_FL_ENC_STRICT_value, ZIP_FL_ENC_STRICT);
 	zend_string *const_FL_ENC_STRICT_name = zend_string_init_interned("FL_ENC_STRICT", sizeof("FL_ENC_STRICT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_ENC_STRICT_name, &const_FL_ENC_STRICT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_ENC_STRICT_name, &const_FL_ENC_STRICT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_STRICT_name);
 
 	zval const_FL_ENC_UTF_8_value;
 	ZVAL_LONG(&const_FL_ENC_UTF_8_value, ZIP_FL_ENC_UTF_8);
 	zend_string *const_FL_ENC_UTF_8_name = zend_string_init_interned("FL_ENC_UTF_8", sizeof("FL_ENC_UTF_8") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_ENC_UTF_8_name, &const_FL_ENC_UTF_8_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_ENC_UTF_8_name, &const_FL_ENC_UTF_8_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_UTF_8_name);
 
 	zval const_FL_ENC_CP437_value;
 	ZVAL_LONG(&const_FL_ENC_CP437_value, ZIP_FL_ENC_CP437);
 	zend_string *const_FL_ENC_CP437_name = zend_string_init_interned("FL_ENC_CP437", sizeof("FL_ENC_CP437") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_ENC_CP437_name, &const_FL_ENC_CP437_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_ENC_CP437_name, &const_FL_ENC_CP437_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_ENC_CP437_name);
 
 	zval const_FL_OPEN_FILE_NOW_value;
 	ZVAL_LONG(&const_FL_OPEN_FILE_NOW_value, ZIP_FL_OPEN_FILE_NOW);
 	zend_string *const_FL_OPEN_FILE_NOW_name = zend_string_init_interned("FL_OPEN_FILE_NOW", sizeof("FL_OPEN_FILE_NOW") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_FL_OPEN_FILE_NOW_name, &const_FL_OPEN_FILE_NOW_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_FL_OPEN_FILE_NOW_name, &const_FL_OPEN_FILE_NOW_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_FL_OPEN_FILE_NOW_name);
 
 	zval const_CM_DEFAULT_value;
 	ZVAL_LONG(&const_CM_DEFAULT_value, ZIP_CM_DEFAULT);
 	zend_string *const_CM_DEFAULT_name = zend_string_init_interned("CM_DEFAULT", sizeof("CM_DEFAULT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_DEFAULT_name, &const_CM_DEFAULT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_DEFAULT_name, &const_CM_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_DEFAULT_name);
 
 	zval const_CM_STORE_value;
 	ZVAL_LONG(&const_CM_STORE_value, ZIP_CM_STORE);
 	zend_string *const_CM_STORE_name = zend_string_init_interned("CM_STORE", sizeof("CM_STORE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_STORE_name, &const_CM_STORE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_STORE_name, &const_CM_STORE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_STORE_name);
 
 	zval const_CM_SHRINK_value;
 	ZVAL_LONG(&const_CM_SHRINK_value, ZIP_CM_SHRINK);
 	zend_string *const_CM_SHRINK_name = zend_string_init_interned("CM_SHRINK", sizeof("CM_SHRINK") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_SHRINK_name, &const_CM_SHRINK_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_SHRINK_name, &const_CM_SHRINK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_SHRINK_name);
 
 	zval const_CM_REDUCE_1_value;
 	ZVAL_LONG(&const_CM_REDUCE_1_value, ZIP_CM_REDUCE_1);
 	zend_string *const_CM_REDUCE_1_name = zend_string_init_interned("CM_REDUCE_1", sizeof("CM_REDUCE_1") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_REDUCE_1_name, &const_CM_REDUCE_1_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_REDUCE_1_name, &const_CM_REDUCE_1_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_REDUCE_1_name);
 
 	zval const_CM_REDUCE_2_value;
 	ZVAL_LONG(&const_CM_REDUCE_2_value, ZIP_CM_REDUCE_2);
 	zend_string *const_CM_REDUCE_2_name = zend_string_init_interned("CM_REDUCE_2", sizeof("CM_REDUCE_2") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_REDUCE_2_name, &const_CM_REDUCE_2_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_REDUCE_2_name, &const_CM_REDUCE_2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_REDUCE_2_name);
 
 	zval const_CM_REDUCE_3_value;
 	ZVAL_LONG(&const_CM_REDUCE_3_value, ZIP_CM_REDUCE_3);
 	zend_string *const_CM_REDUCE_3_name = zend_string_init_interned("CM_REDUCE_3", sizeof("CM_REDUCE_3") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_REDUCE_3_name, &const_CM_REDUCE_3_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_REDUCE_3_name, &const_CM_REDUCE_3_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_REDUCE_3_name);
 
 	zval const_CM_REDUCE_4_value;
 	ZVAL_LONG(&const_CM_REDUCE_4_value, ZIP_CM_REDUCE_4);
 	zend_string *const_CM_REDUCE_4_name = zend_string_init_interned("CM_REDUCE_4", sizeof("CM_REDUCE_4") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_REDUCE_4_name, &const_CM_REDUCE_4_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_REDUCE_4_name, &const_CM_REDUCE_4_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_REDUCE_4_name);
 
 	zval const_CM_IMPLODE_value;
 	ZVAL_LONG(&const_CM_IMPLODE_value, ZIP_CM_IMPLODE);
 	zend_string *const_CM_IMPLODE_name = zend_string_init_interned("CM_IMPLODE", sizeof("CM_IMPLODE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_IMPLODE_name, &const_CM_IMPLODE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_IMPLODE_name, &const_CM_IMPLODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_IMPLODE_name);
 
 	zval const_CM_DEFLATE_value;
 	ZVAL_LONG(&const_CM_DEFLATE_value, ZIP_CM_DEFLATE);
 	zend_string *const_CM_DEFLATE_name = zend_string_init_interned("CM_DEFLATE", sizeof("CM_DEFLATE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_DEFLATE_name, &const_CM_DEFLATE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_DEFLATE_name, &const_CM_DEFLATE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_DEFLATE_name);
 
 	zval const_CM_DEFLATE64_value;
 	ZVAL_LONG(&const_CM_DEFLATE64_value, ZIP_CM_DEFLATE64);
 	zend_string *const_CM_DEFLATE64_name = zend_string_init_interned("CM_DEFLATE64", sizeof("CM_DEFLATE64") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_DEFLATE64_name, &const_CM_DEFLATE64_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_DEFLATE64_name, &const_CM_DEFLATE64_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_DEFLATE64_name);
 
 	zval const_CM_PKWARE_IMPLODE_value;
 	ZVAL_LONG(&const_CM_PKWARE_IMPLODE_value, ZIP_CM_PKWARE_IMPLODE);
 	zend_string *const_CM_PKWARE_IMPLODE_name = zend_string_init_interned("CM_PKWARE_IMPLODE", sizeof("CM_PKWARE_IMPLODE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_PKWARE_IMPLODE_name, &const_CM_PKWARE_IMPLODE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_PKWARE_IMPLODE_name, &const_CM_PKWARE_IMPLODE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_PKWARE_IMPLODE_name);
 
 	zval const_CM_BZIP2_value;
 	ZVAL_LONG(&const_CM_BZIP2_value, ZIP_CM_BZIP2);
 	zend_string *const_CM_BZIP2_name = zend_string_init_interned("CM_BZIP2", sizeof("CM_BZIP2") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_BZIP2_name, &const_CM_BZIP2_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_BZIP2_name, &const_CM_BZIP2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_BZIP2_name);
 
 	zval const_CM_LZMA_value;
 	ZVAL_LONG(&const_CM_LZMA_value, ZIP_CM_LZMA);
 	zend_string *const_CM_LZMA_name = zend_string_init_interned("CM_LZMA", sizeof("CM_LZMA") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_LZMA_name, &const_CM_LZMA_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_LZMA_name, &const_CM_LZMA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_LZMA_name);
 #if defined(ZIP_CM_LZMA2)
 
 	zval const_CM_LZMA2_value;
 	ZVAL_LONG(&const_CM_LZMA2_value, ZIP_CM_LZMA2);
 	zend_string *const_CM_LZMA2_name = zend_string_init_interned("CM_LZMA2", sizeof("CM_LZMA2") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_LZMA2_name, &const_CM_LZMA2_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_LZMA2_name, &const_CM_LZMA2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_LZMA2_name);
 #endif
 #if defined(ZIP_CM_ZSTD)
@@ -722,7 +722,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_CM_ZSTD_value;
 	ZVAL_LONG(&const_CM_ZSTD_value, ZIP_CM_ZSTD);
 	zend_string *const_CM_ZSTD_name = zend_string_init_interned("CM_ZSTD", sizeof("CM_ZSTD") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_ZSTD_name, &const_CM_ZSTD_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_ZSTD_name, &const_CM_ZSTD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_ZSTD_name);
 #endif
 #if defined(ZIP_CM_XZ)
@@ -730,207 +730,207 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_CM_XZ_value;
 	ZVAL_LONG(&const_CM_XZ_value, ZIP_CM_XZ);
 	zend_string *const_CM_XZ_name = zend_string_init_interned("CM_XZ", sizeof("CM_XZ") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_XZ_name, &const_CM_XZ_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_XZ_name, &const_CM_XZ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_XZ_name);
 #endif
 
 	zval const_CM_TERSE_value;
 	ZVAL_LONG(&const_CM_TERSE_value, ZIP_CM_TERSE);
 	zend_string *const_CM_TERSE_name = zend_string_init_interned("CM_TERSE", sizeof("CM_TERSE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_TERSE_name, &const_CM_TERSE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_TERSE_name, &const_CM_TERSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_TERSE_name);
 
 	zval const_CM_LZ77_value;
 	ZVAL_LONG(&const_CM_LZ77_value, ZIP_CM_LZ77);
 	zend_string *const_CM_LZ77_name = zend_string_init_interned("CM_LZ77", sizeof("CM_LZ77") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_LZ77_name, &const_CM_LZ77_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_LZ77_name, &const_CM_LZ77_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_LZ77_name);
 
 	zval const_CM_WAVPACK_value;
 	ZVAL_LONG(&const_CM_WAVPACK_value, ZIP_CM_WAVPACK);
 	zend_string *const_CM_WAVPACK_name = zend_string_init_interned("CM_WAVPACK", sizeof("CM_WAVPACK") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_WAVPACK_name, &const_CM_WAVPACK_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_WAVPACK_name, &const_CM_WAVPACK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_WAVPACK_name);
 
 	zval const_CM_PPMD_value;
 	ZVAL_LONG(&const_CM_PPMD_value, ZIP_CM_PPMD);
 	zend_string *const_CM_PPMD_name = zend_string_init_interned("CM_PPMD", sizeof("CM_PPMD") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_CM_PPMD_name, &const_CM_PPMD_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_CM_PPMD_name, &const_CM_PPMD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_CM_PPMD_name);
 
 	zval const_ER_OK_value;
 	ZVAL_LONG(&const_ER_OK_value, ZIP_ER_OK);
 	zend_string *const_ER_OK_name = zend_string_init_interned("ER_OK", sizeof("ER_OK") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_OK_name, &const_ER_OK_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_OK_name, &const_ER_OK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_OK_name);
 
 	zval const_ER_MULTIDISK_value;
 	ZVAL_LONG(&const_ER_MULTIDISK_value, ZIP_ER_MULTIDISK);
 	zend_string *const_ER_MULTIDISK_name = zend_string_init_interned("ER_MULTIDISK", sizeof("ER_MULTIDISK") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_MULTIDISK_name, &const_ER_MULTIDISK_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_MULTIDISK_name, &const_ER_MULTIDISK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_MULTIDISK_name);
 
 	zval const_ER_RENAME_value;
 	ZVAL_LONG(&const_ER_RENAME_value, ZIP_ER_RENAME);
 	zend_string *const_ER_RENAME_name = zend_string_init_interned("ER_RENAME", sizeof("ER_RENAME") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_RENAME_name, &const_ER_RENAME_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_RENAME_name, &const_ER_RENAME_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_RENAME_name);
 
 	zval const_ER_CLOSE_value;
 	ZVAL_LONG(&const_ER_CLOSE_value, ZIP_ER_CLOSE);
 	zend_string *const_ER_CLOSE_name = zend_string_init_interned("ER_CLOSE", sizeof("ER_CLOSE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_CLOSE_name, &const_ER_CLOSE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_CLOSE_name, &const_ER_CLOSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_CLOSE_name);
 
 	zval const_ER_SEEK_value;
 	ZVAL_LONG(&const_ER_SEEK_value, ZIP_ER_SEEK);
 	zend_string *const_ER_SEEK_name = zend_string_init_interned("ER_SEEK", sizeof("ER_SEEK") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_SEEK_name, &const_ER_SEEK_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_SEEK_name, &const_ER_SEEK_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_SEEK_name);
 
 	zval const_ER_READ_value;
 	ZVAL_LONG(&const_ER_READ_value, ZIP_ER_READ);
 	zend_string *const_ER_READ_name = zend_string_init_interned("ER_READ", sizeof("ER_READ") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_READ_name, &const_ER_READ_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_READ_name, &const_ER_READ_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_READ_name);
 
 	zval const_ER_WRITE_value;
 	ZVAL_LONG(&const_ER_WRITE_value, ZIP_ER_WRITE);
 	zend_string *const_ER_WRITE_name = zend_string_init_interned("ER_WRITE", sizeof("ER_WRITE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_WRITE_name, &const_ER_WRITE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_WRITE_name, &const_ER_WRITE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_WRITE_name);
 
 	zval const_ER_CRC_value;
 	ZVAL_LONG(&const_ER_CRC_value, ZIP_ER_CRC);
 	zend_string *const_ER_CRC_name = zend_string_init_interned("ER_CRC", sizeof("ER_CRC") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_CRC_name, &const_ER_CRC_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_CRC_name, &const_ER_CRC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_CRC_name);
 
 	zval const_ER_ZIPCLOSED_value;
 	ZVAL_LONG(&const_ER_ZIPCLOSED_value, ZIP_ER_ZIPCLOSED);
 	zend_string *const_ER_ZIPCLOSED_name = zend_string_init_interned("ER_ZIPCLOSED", sizeof("ER_ZIPCLOSED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_ZIPCLOSED_name, &const_ER_ZIPCLOSED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_ZIPCLOSED_name, &const_ER_ZIPCLOSED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_ZIPCLOSED_name);
 
 	zval const_ER_NOENT_value;
 	ZVAL_LONG(&const_ER_NOENT_value, ZIP_ER_NOENT);
 	zend_string *const_ER_NOENT_name = zend_string_init_interned("ER_NOENT", sizeof("ER_NOENT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_NOENT_name, &const_ER_NOENT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_NOENT_name, &const_ER_NOENT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_NOENT_name);
 
 	zval const_ER_EXISTS_value;
 	ZVAL_LONG(&const_ER_EXISTS_value, ZIP_ER_EXISTS);
 	zend_string *const_ER_EXISTS_name = zend_string_init_interned("ER_EXISTS", sizeof("ER_EXISTS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_EXISTS_name, &const_ER_EXISTS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_EXISTS_name, &const_ER_EXISTS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_EXISTS_name);
 
 	zval const_ER_OPEN_value;
 	ZVAL_LONG(&const_ER_OPEN_value, ZIP_ER_OPEN);
 	zend_string *const_ER_OPEN_name = zend_string_init_interned("ER_OPEN", sizeof("ER_OPEN") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_OPEN_name, &const_ER_OPEN_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_OPEN_name, &const_ER_OPEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_OPEN_name);
 
 	zval const_ER_TMPOPEN_value;
 	ZVAL_LONG(&const_ER_TMPOPEN_value, ZIP_ER_TMPOPEN);
 	zend_string *const_ER_TMPOPEN_name = zend_string_init_interned("ER_TMPOPEN", sizeof("ER_TMPOPEN") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_TMPOPEN_name, &const_ER_TMPOPEN_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_TMPOPEN_name, &const_ER_TMPOPEN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_TMPOPEN_name);
 
 	zval const_ER_ZLIB_value;
 	ZVAL_LONG(&const_ER_ZLIB_value, ZIP_ER_ZLIB);
 	zend_string *const_ER_ZLIB_name = zend_string_init_interned("ER_ZLIB", sizeof("ER_ZLIB") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_ZLIB_name, &const_ER_ZLIB_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_ZLIB_name, &const_ER_ZLIB_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_ZLIB_name);
 
 	zval const_ER_MEMORY_value;
 	ZVAL_LONG(&const_ER_MEMORY_value, ZIP_ER_MEMORY);
 	zend_string *const_ER_MEMORY_name = zend_string_init_interned("ER_MEMORY", sizeof("ER_MEMORY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_MEMORY_name, &const_ER_MEMORY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_MEMORY_name, &const_ER_MEMORY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_MEMORY_name);
 
 	zval const_ER_CHANGED_value;
 	ZVAL_LONG(&const_ER_CHANGED_value, ZIP_ER_CHANGED);
 	zend_string *const_ER_CHANGED_name = zend_string_init_interned("ER_CHANGED", sizeof("ER_CHANGED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_CHANGED_name, &const_ER_CHANGED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_CHANGED_name, &const_ER_CHANGED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_CHANGED_name);
 
 	zval const_ER_COMPNOTSUPP_value;
 	ZVAL_LONG(&const_ER_COMPNOTSUPP_value, ZIP_ER_COMPNOTSUPP);
 	zend_string *const_ER_COMPNOTSUPP_name = zend_string_init_interned("ER_COMPNOTSUPP", sizeof("ER_COMPNOTSUPP") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_COMPNOTSUPP_name, &const_ER_COMPNOTSUPP_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_COMPNOTSUPP_name, &const_ER_COMPNOTSUPP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_COMPNOTSUPP_name);
 
 	zval const_ER_EOF_value;
 	ZVAL_LONG(&const_ER_EOF_value, ZIP_ER_EOF);
 	zend_string *const_ER_EOF_name = zend_string_init_interned("ER_EOF", sizeof("ER_EOF") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_EOF_name, &const_ER_EOF_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_EOF_name, &const_ER_EOF_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_EOF_name);
 
 	zval const_ER_INVAL_value;
 	ZVAL_LONG(&const_ER_INVAL_value, ZIP_ER_INVAL);
 	zend_string *const_ER_INVAL_name = zend_string_init_interned("ER_INVAL", sizeof("ER_INVAL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_INVAL_name, &const_ER_INVAL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_INVAL_name, &const_ER_INVAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_INVAL_name);
 
 	zval const_ER_NOZIP_value;
 	ZVAL_LONG(&const_ER_NOZIP_value, ZIP_ER_NOZIP);
 	zend_string *const_ER_NOZIP_name = zend_string_init_interned("ER_NOZIP", sizeof("ER_NOZIP") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_NOZIP_name, &const_ER_NOZIP_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_NOZIP_name, &const_ER_NOZIP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_NOZIP_name);
 
 	zval const_ER_INTERNAL_value;
 	ZVAL_LONG(&const_ER_INTERNAL_value, ZIP_ER_INTERNAL);
 	zend_string *const_ER_INTERNAL_name = zend_string_init_interned("ER_INTERNAL", sizeof("ER_INTERNAL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_INTERNAL_name, &const_ER_INTERNAL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_INTERNAL_name, &const_ER_INTERNAL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_INTERNAL_name);
 
 	zval const_ER_INCONS_value;
 	ZVAL_LONG(&const_ER_INCONS_value, ZIP_ER_INCONS);
 	zend_string *const_ER_INCONS_name = zend_string_init_interned("ER_INCONS", sizeof("ER_INCONS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_INCONS_name, &const_ER_INCONS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_INCONS_name, &const_ER_INCONS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_INCONS_name);
 
 	zval const_ER_REMOVE_value;
 	ZVAL_LONG(&const_ER_REMOVE_value, ZIP_ER_REMOVE);
 	zend_string *const_ER_REMOVE_name = zend_string_init_interned("ER_REMOVE", sizeof("ER_REMOVE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_REMOVE_name, &const_ER_REMOVE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_REMOVE_name, &const_ER_REMOVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_REMOVE_name);
 
 	zval const_ER_DELETED_value;
 	ZVAL_LONG(&const_ER_DELETED_value, ZIP_ER_DELETED);
 	zend_string *const_ER_DELETED_name = zend_string_init_interned("ER_DELETED", sizeof("ER_DELETED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_DELETED_name, &const_ER_DELETED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_DELETED_name, &const_ER_DELETED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_DELETED_name);
 
 	zval const_ER_ENCRNOTSUPP_value;
 	ZVAL_LONG(&const_ER_ENCRNOTSUPP_value, ZIP_ER_ENCRNOTSUPP);
 	zend_string *const_ER_ENCRNOTSUPP_name = zend_string_init_interned("ER_ENCRNOTSUPP", sizeof("ER_ENCRNOTSUPP") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_ENCRNOTSUPP_name, &const_ER_ENCRNOTSUPP_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_ENCRNOTSUPP_name, &const_ER_ENCRNOTSUPP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_ENCRNOTSUPP_name);
 
 	zval const_ER_RDONLY_value;
 	ZVAL_LONG(&const_ER_RDONLY_value, ZIP_ER_RDONLY);
 	zend_string *const_ER_RDONLY_name = zend_string_init_interned("ER_RDONLY", sizeof("ER_RDONLY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_RDONLY_name, &const_ER_RDONLY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_RDONLY_name, &const_ER_RDONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_RDONLY_name);
 
 	zval const_ER_NOPASSWD_value;
 	ZVAL_LONG(&const_ER_NOPASSWD_value, ZIP_ER_NOPASSWD);
 	zend_string *const_ER_NOPASSWD_name = zend_string_init_interned("ER_NOPASSWD", sizeof("ER_NOPASSWD") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_NOPASSWD_name, &const_ER_NOPASSWD_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_NOPASSWD_name, &const_ER_NOPASSWD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_NOPASSWD_name);
 
 	zval const_ER_WRONGPASSWD_value;
 	ZVAL_LONG(&const_ER_WRONGPASSWD_value, ZIP_ER_WRONGPASSWD);
 	zend_string *const_ER_WRONGPASSWD_name = zend_string_init_interned("ER_WRONGPASSWD", sizeof("ER_WRONGPASSWD") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_WRONGPASSWD_name, &const_ER_WRONGPASSWD_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_WRONGPASSWD_name, &const_ER_WRONGPASSWD_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_WRONGPASSWD_name);
 #if defined(ZIP_ER_OPNOTSUPP)
 
 	zval const_ER_OPNOTSUPP_value;
 	ZVAL_LONG(&const_ER_OPNOTSUPP_value, ZIP_ER_OPNOTSUPP);
 	zend_string *const_ER_OPNOTSUPP_name = zend_string_init_interned("ER_OPNOTSUPP", sizeof("ER_OPNOTSUPP") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_OPNOTSUPP_name, &const_ER_OPNOTSUPP_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_OPNOTSUPP_name, &const_ER_OPNOTSUPP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_OPNOTSUPP_name);
 #endif
 #if defined(ZIP_ER_INUSE)
@@ -938,7 +938,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_ER_INUSE_value;
 	ZVAL_LONG(&const_ER_INUSE_value, ZIP_ER_INUSE);
 	zend_string *const_ER_INUSE_name = zend_string_init_interned("ER_INUSE", sizeof("ER_INUSE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_INUSE_name, &const_ER_INUSE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_INUSE_name, &const_ER_INUSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_INUSE_name);
 #endif
 #if defined(ZIP_ER_TELL)
@@ -946,7 +946,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_ER_TELL_value;
 	ZVAL_LONG(&const_ER_TELL_value, ZIP_ER_TELL);
 	zend_string *const_ER_TELL_name = zend_string_init_interned("ER_TELL", sizeof("ER_TELL") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_TELL_name, &const_ER_TELL_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_TELL_name, &const_ER_TELL_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_TELL_name);
 #endif
 #if defined(ZIP_ER_COMPRESSED_DATA)
@@ -954,7 +954,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_ER_COMPRESSED_DATA_value;
 	ZVAL_LONG(&const_ER_COMPRESSED_DATA_value, ZIP_ER_COMPRESSED_DATA);
 	zend_string *const_ER_COMPRESSED_DATA_name = zend_string_init_interned("ER_COMPRESSED_DATA", sizeof("ER_COMPRESSED_DATA") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_COMPRESSED_DATA_name, &const_ER_COMPRESSED_DATA_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_COMPRESSED_DATA_name, &const_ER_COMPRESSED_DATA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_COMPRESSED_DATA_name);
 #endif
 #if defined(ZIP_ER_CANCELLED)
@@ -962,7 +962,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_ER_CANCELLED_value;
 	ZVAL_LONG(&const_ER_CANCELLED_value, ZIP_ER_CANCELLED);
 	zend_string *const_ER_CANCELLED_name = zend_string_init_interned("ER_CANCELLED", sizeof("ER_CANCELLED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_CANCELLED_name, &const_ER_CANCELLED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_CANCELLED_name, &const_ER_CANCELLED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_CANCELLED_name);
 #endif
 #if defined(ZIP_ER_DATA_LENGTH)
@@ -970,7 +970,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_ER_DATA_LENGTH_value;
 	ZVAL_LONG(&const_ER_DATA_LENGTH_value, ZIP_ER_DATA_LENGTH);
 	zend_string *const_ER_DATA_LENGTH_name = zend_string_init_interned("ER_DATA_LENGTH", sizeof("ER_DATA_LENGTH") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_DATA_LENGTH_name, &const_ER_DATA_LENGTH_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_DATA_LENGTH_name, &const_ER_DATA_LENGTH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_DATA_LENGTH_name);
 #endif
 #if defined(ZIP_ER_NOT_ALLOWED)
@@ -978,7 +978,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_ER_NOT_ALLOWED_value;
 	ZVAL_LONG(&const_ER_NOT_ALLOWED_value, ZIP_ER_NOT_ALLOWED);
 	zend_string *const_ER_NOT_ALLOWED_name = zend_string_init_interned("ER_NOT_ALLOWED", sizeof("ER_NOT_ALLOWED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_ER_NOT_ALLOWED_name, &const_ER_NOT_ALLOWED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_ER_NOT_ALLOWED_name, &const_ER_NOT_ALLOWED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_ER_NOT_ALLOWED_name);
 #endif
 #if defined(ZIP_AFL_RDONLY)
@@ -986,7 +986,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_AFL_RDONLY_value;
 	ZVAL_LONG(&const_AFL_RDONLY_value, ZIP_AFL_RDONLY);
 	zend_string *const_AFL_RDONLY_name = zend_string_init_interned("AFL_RDONLY", sizeof("AFL_RDONLY") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_AFL_RDONLY_name, &const_AFL_RDONLY_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_AFL_RDONLY_name, &const_AFL_RDONLY_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFL_RDONLY_name);
 #endif
 #if defined(ZIP_AFL_IS_TORRENTZIP)
@@ -994,7 +994,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_AFL_IS_TORRENTZIP_value;
 	ZVAL_LONG(&const_AFL_IS_TORRENTZIP_value, ZIP_AFL_IS_TORRENTZIP);
 	zend_string *const_AFL_IS_TORRENTZIP_name = zend_string_init_interned("AFL_IS_TORRENTZIP", sizeof("AFL_IS_TORRENTZIP") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_AFL_IS_TORRENTZIP_name, &const_AFL_IS_TORRENTZIP_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_AFL_IS_TORRENTZIP_name, &const_AFL_IS_TORRENTZIP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFL_IS_TORRENTZIP_name);
 #endif
 #if defined(ZIP_AFL_WANT_TORRENTZIP)
@@ -1002,7 +1002,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_AFL_WANT_TORRENTZIP_value;
 	ZVAL_LONG(&const_AFL_WANT_TORRENTZIP_value, ZIP_AFL_WANT_TORRENTZIP);
 	zend_string *const_AFL_WANT_TORRENTZIP_name = zend_string_init_interned("AFL_WANT_TORRENTZIP", sizeof("AFL_WANT_TORRENTZIP") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_AFL_WANT_TORRENTZIP_name, &const_AFL_WANT_TORRENTZIP_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_AFL_WANT_TORRENTZIP_name, &const_AFL_WANT_TORRENTZIP_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFL_WANT_TORRENTZIP_name);
 #endif
 #if defined(ZIP_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE)
@@ -1010,7 +1010,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_value;
 	ZVAL_LONG(&const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_value, ZIP_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE);
 	zend_string *const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_name = zend_string_init_interned("AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE", sizeof("AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_name, &const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_name, &const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1018,7 +1018,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_DOS_value;
 	ZVAL_LONG(&const_OPSYS_DOS_value, ZIP_OPSYS_DOS);
 	zend_string *const_OPSYS_DOS_name = zend_string_init_interned("OPSYS_DOS", sizeof("OPSYS_DOS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_DOS_name, &const_OPSYS_DOS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_DOS_name, &const_OPSYS_DOS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_DOS_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1026,7 +1026,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_AMIGA_value;
 	ZVAL_LONG(&const_OPSYS_AMIGA_value, ZIP_OPSYS_AMIGA);
 	zend_string *const_OPSYS_AMIGA_name = zend_string_init_interned("OPSYS_AMIGA", sizeof("OPSYS_AMIGA") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_AMIGA_name, &const_OPSYS_AMIGA_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_AMIGA_name, &const_OPSYS_AMIGA_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_AMIGA_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1034,7 +1034,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_OPENVMS_value;
 	ZVAL_LONG(&const_OPSYS_OPENVMS_value, ZIP_OPSYS_OPENVMS);
 	zend_string *const_OPSYS_OPENVMS_name = zend_string_init_interned("OPSYS_OPENVMS", sizeof("OPSYS_OPENVMS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_OPENVMS_name, &const_OPSYS_OPENVMS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_OPENVMS_name, &const_OPSYS_OPENVMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_OPENVMS_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1042,7 +1042,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_UNIX_value;
 	ZVAL_LONG(&const_OPSYS_UNIX_value, ZIP_OPSYS_UNIX);
 	zend_string *const_OPSYS_UNIX_name = zend_string_init_interned("OPSYS_UNIX", sizeof("OPSYS_UNIX") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_UNIX_name, &const_OPSYS_UNIX_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_UNIX_name, &const_OPSYS_UNIX_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_UNIX_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1050,7 +1050,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_VM_CMS_value;
 	ZVAL_LONG(&const_OPSYS_VM_CMS_value, ZIP_OPSYS_VM_CMS);
 	zend_string *const_OPSYS_VM_CMS_name = zend_string_init_interned("OPSYS_VM_CMS", sizeof("OPSYS_VM_CMS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_VM_CMS_name, &const_OPSYS_VM_CMS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_VM_CMS_name, &const_OPSYS_VM_CMS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_VM_CMS_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1058,7 +1058,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_ATARI_ST_value;
 	ZVAL_LONG(&const_OPSYS_ATARI_ST_value, ZIP_OPSYS_ATARI_ST);
 	zend_string *const_OPSYS_ATARI_ST_name = zend_string_init_interned("OPSYS_ATARI_ST", sizeof("OPSYS_ATARI_ST") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_ATARI_ST_name, &const_OPSYS_ATARI_ST_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_ATARI_ST_name, &const_OPSYS_ATARI_ST_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_ATARI_ST_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1066,7 +1066,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_OS_2_value;
 	ZVAL_LONG(&const_OPSYS_OS_2_value, ZIP_OPSYS_OS_2);
 	zend_string *const_OPSYS_OS_2_name = zend_string_init_interned("OPSYS_OS_2", sizeof("OPSYS_OS_2") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_OS_2_name, &const_OPSYS_OS_2_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_OS_2_name, &const_OPSYS_OS_2_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_OS_2_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1074,7 +1074,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_MACINTOSH_value;
 	ZVAL_LONG(&const_OPSYS_MACINTOSH_value, ZIP_OPSYS_MACINTOSH);
 	zend_string *const_OPSYS_MACINTOSH_name = zend_string_init_interned("OPSYS_MACINTOSH", sizeof("OPSYS_MACINTOSH") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_MACINTOSH_name, &const_OPSYS_MACINTOSH_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_MACINTOSH_name, &const_OPSYS_MACINTOSH_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_MACINTOSH_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1082,7 +1082,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_Z_SYSTEM_value;
 	ZVAL_LONG(&const_OPSYS_Z_SYSTEM_value, ZIP_OPSYS_Z_SYSTEM);
 	zend_string *const_OPSYS_Z_SYSTEM_name = zend_string_init_interned("OPSYS_Z_SYSTEM", sizeof("OPSYS_Z_SYSTEM") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_Z_SYSTEM_name, &const_OPSYS_Z_SYSTEM_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_Z_SYSTEM_name, &const_OPSYS_Z_SYSTEM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_Z_SYSTEM_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1090,7 +1090,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_CPM_value;
 	ZVAL_LONG(&const_OPSYS_CPM_value, ZIP_OPSYS_CPM);
 	zend_string *const_OPSYS_CPM_name = zend_string_init_interned("OPSYS_CPM", sizeof("OPSYS_CPM") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_CPM_name, &const_OPSYS_CPM_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_CPM_name, &const_OPSYS_CPM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_CPM_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1098,7 +1098,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_WINDOWS_NTFS_value;
 	ZVAL_LONG(&const_OPSYS_WINDOWS_NTFS_value, ZIP_OPSYS_WINDOWS_NTFS);
 	zend_string *const_OPSYS_WINDOWS_NTFS_name = zend_string_init_interned("OPSYS_WINDOWS_NTFS", sizeof("OPSYS_WINDOWS_NTFS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_WINDOWS_NTFS_name, &const_OPSYS_WINDOWS_NTFS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_WINDOWS_NTFS_name, &const_OPSYS_WINDOWS_NTFS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_WINDOWS_NTFS_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1106,7 +1106,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_MVS_value;
 	ZVAL_LONG(&const_OPSYS_MVS_value, ZIP_OPSYS_MVS);
 	zend_string *const_OPSYS_MVS_name = zend_string_init_interned("OPSYS_MVS", sizeof("OPSYS_MVS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_MVS_name, &const_OPSYS_MVS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_MVS_name, &const_OPSYS_MVS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_MVS_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1114,7 +1114,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_VSE_value;
 	ZVAL_LONG(&const_OPSYS_VSE_value, ZIP_OPSYS_VSE);
 	zend_string *const_OPSYS_VSE_name = zend_string_init_interned("OPSYS_VSE", sizeof("OPSYS_VSE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_VSE_name, &const_OPSYS_VSE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_VSE_name, &const_OPSYS_VSE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_VSE_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1122,7 +1122,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_ACORN_RISC_value;
 	ZVAL_LONG(&const_OPSYS_ACORN_RISC_value, ZIP_OPSYS_ACORN_RISC);
 	zend_string *const_OPSYS_ACORN_RISC_name = zend_string_init_interned("OPSYS_ACORN_RISC", sizeof("OPSYS_ACORN_RISC") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_ACORN_RISC_name, &const_OPSYS_ACORN_RISC_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_ACORN_RISC_name, &const_OPSYS_ACORN_RISC_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_ACORN_RISC_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1130,7 +1130,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_VFAT_value;
 	ZVAL_LONG(&const_OPSYS_VFAT_value, ZIP_OPSYS_VFAT);
 	zend_string *const_OPSYS_VFAT_name = zend_string_init_interned("OPSYS_VFAT", sizeof("OPSYS_VFAT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_VFAT_name, &const_OPSYS_VFAT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_VFAT_name, &const_OPSYS_VFAT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_VFAT_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1138,7 +1138,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_ALTERNATE_MVS_value;
 	ZVAL_LONG(&const_OPSYS_ALTERNATE_MVS_value, ZIP_OPSYS_ALTERNATE_MVS);
 	zend_string *const_OPSYS_ALTERNATE_MVS_name = zend_string_init_interned("OPSYS_ALTERNATE_MVS", sizeof("OPSYS_ALTERNATE_MVS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_ALTERNATE_MVS_name, &const_OPSYS_ALTERNATE_MVS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_ALTERNATE_MVS_name, &const_OPSYS_ALTERNATE_MVS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_ALTERNATE_MVS_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1146,7 +1146,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_BEOS_value;
 	ZVAL_LONG(&const_OPSYS_BEOS_value, ZIP_OPSYS_BEOS);
 	zend_string *const_OPSYS_BEOS_name = zend_string_init_interned("OPSYS_BEOS", sizeof("OPSYS_BEOS") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_BEOS_name, &const_OPSYS_BEOS_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_BEOS_name, &const_OPSYS_BEOS_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_BEOS_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1154,7 +1154,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_TANDEM_value;
 	ZVAL_LONG(&const_OPSYS_TANDEM_value, ZIP_OPSYS_TANDEM);
 	zend_string *const_OPSYS_TANDEM_name = zend_string_init_interned("OPSYS_TANDEM", sizeof("OPSYS_TANDEM") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_TANDEM_name, &const_OPSYS_TANDEM_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_TANDEM_name, &const_OPSYS_TANDEM_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_TANDEM_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1162,7 +1162,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_OS_400_value;
 	ZVAL_LONG(&const_OPSYS_OS_400_value, ZIP_OPSYS_OS_400);
 	zend_string *const_OPSYS_OS_400_name = zend_string_init_interned("OPSYS_OS_400", sizeof("OPSYS_OS_400") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_OS_400_name, &const_OPSYS_OS_400_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_OS_400_name, &const_OPSYS_OS_400_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_OS_400_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1170,7 +1170,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_OS_X_value;
 	ZVAL_LONG(&const_OPSYS_OS_X_value, ZIP_OPSYS_OS_X);
 	zend_string *const_OPSYS_OS_X_name = zend_string_init_interned("OPSYS_OS_X", sizeof("OPSYS_OS_X") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_OS_X_name, &const_OPSYS_OS_X_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_OS_X_name, &const_OPSYS_OS_X_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_OS_X_name);
 #endif
 #if defined(ZIP_OPSYS_DEFAULT)
@@ -1178,27 +1178,27 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_OPSYS_DEFAULT_value;
 	ZVAL_LONG(&const_OPSYS_DEFAULT_value, ZIP_OPSYS_DEFAULT);
 	zend_string *const_OPSYS_DEFAULT_name = zend_string_init_interned("OPSYS_DEFAULT", sizeof("OPSYS_DEFAULT") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_OPSYS_DEFAULT_name, &const_OPSYS_DEFAULT_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_OPSYS_DEFAULT_name, &const_OPSYS_DEFAULT_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_OPSYS_DEFAULT_name);
 #endif
 
 	zval const_EM_NONE_value;
 	ZVAL_LONG(&const_EM_NONE_value, ZIP_EM_NONE);
 	zend_string *const_EM_NONE_name = zend_string_init_interned("EM_NONE", sizeof("EM_NONE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_EM_NONE_name, &const_EM_NONE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_EM_NONE_name, &const_EM_NONE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_NONE_name);
 
 	zval const_EM_TRAD_PKWARE_value;
 	ZVAL_LONG(&const_EM_TRAD_PKWARE_value, ZIP_EM_TRAD_PKWARE);
 	zend_string *const_EM_TRAD_PKWARE_name = zend_string_init_interned("EM_TRAD_PKWARE", sizeof("EM_TRAD_PKWARE") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_EM_TRAD_PKWARE_name, &const_EM_TRAD_PKWARE_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_EM_TRAD_PKWARE_name, &const_EM_TRAD_PKWARE_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_TRAD_PKWARE_name);
 #if defined(HAVE_ENCRYPTION)
 
 	zval const_EM_AES_128_value;
 	ZVAL_LONG(&const_EM_AES_128_value, ZIP_EM_AES_128);
 	zend_string *const_EM_AES_128_name = zend_string_init_interned("EM_AES_128", sizeof("EM_AES_128") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_EM_AES_128_name, &const_EM_AES_128_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_EM_AES_128_name, &const_EM_AES_128_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_AES_128_name);
 #endif
 #if defined(HAVE_ENCRYPTION)
@@ -1206,7 +1206,7 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_EM_AES_192_value;
 	ZVAL_LONG(&const_EM_AES_192_value, ZIP_EM_AES_192);
 	zend_string *const_EM_AES_192_name = zend_string_init_interned("EM_AES_192", sizeof("EM_AES_192") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_EM_AES_192_name, &const_EM_AES_192_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_EM_AES_192_name, &const_EM_AES_192_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_AES_192_name);
 #endif
 #if defined(HAVE_ENCRYPTION)
@@ -1214,34 +1214,34 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zval const_EM_AES_256_value;
 	ZVAL_LONG(&const_EM_AES_256_value, ZIP_EM_AES_256);
 	zend_string *const_EM_AES_256_name = zend_string_init_interned("EM_AES_256", sizeof("EM_AES_256") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_EM_AES_256_name, &const_EM_AES_256_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_EM_AES_256_name, &const_EM_AES_256_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_AES_256_name);
 #endif
 
 	zval const_EM_UNKNOWN_value;
 	ZVAL_LONG(&const_EM_UNKNOWN_value, ZIP_EM_UNKNOWN);
 	zend_string *const_EM_UNKNOWN_name = zend_string_init_interned("EM_UNKNOWN", sizeof("EM_UNKNOWN") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_EM_UNKNOWN_name, &const_EM_UNKNOWN_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_EM_UNKNOWN_name, &const_EM_UNKNOWN_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_EM_UNKNOWN_name);
 
 	zval const_LIBZIP_VERSION_value;
 	zend_string *const_LIBZIP_VERSION_value_str = zend_string_init(LIBZIP_VERSION_STR, strlen(LIBZIP_VERSION_STR), 1);
 	ZVAL_STR(&const_LIBZIP_VERSION_value, const_LIBZIP_VERSION_value_str);
 	zend_string *const_LIBZIP_VERSION_name = zend_string_init_interned("LIBZIP_VERSION", sizeof("LIBZIP_VERSION") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_LIBZIP_VERSION_name, &const_LIBZIP_VERSION_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_LIBZIP_VERSION_name, &const_LIBZIP_VERSION_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 	zend_string_release(const_LIBZIP_VERSION_name);
 
 	zval const_LENGTH_TO_END_value;
 	ZVAL_LONG(&const_LENGTH_TO_END_value, ZIP_LENGTH_TO_END);
 	zend_string *const_LENGTH_TO_END_name = zend_string_init_interned("LENGTH_TO_END", sizeof("LENGTH_TO_END") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_LENGTH_TO_END_name, &const_LENGTH_TO_END_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_LENGTH_TO_END_name, &const_LENGTH_TO_END_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LENGTH_TO_END_name);
 #if defined(ZIP_LENGTH_UNCHECKED)
 
 	zval const_LENGTH_UNCHECKED_value;
 	ZVAL_LONG(&const_LENGTH_UNCHECKED_value, ZIP_LENGTH_UNCHECKED);
 	zend_string *const_LENGTH_UNCHECKED_name = zend_string_init_interned("LENGTH_UNCHECKED", sizeof("LENGTH_UNCHECKED") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_LENGTH_UNCHECKED_name, &const_LENGTH_UNCHECKED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_declare_typed_class_constant(class_entry, const_LENGTH_UNCHECKED_name, &const_LENGTH_UNCHECKED_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
 	zend_string_release(const_LENGTH_UNCHECKED_name);
 #endif
 

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 46d06bea2d0c38bb9c17d0be0388b4833d7b4e06 */
+ * Stub hash: ac1969b19efd54bb9a2b9e2f228e66f4d22000b1 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -1230,22 +1230,12 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zend_string *const_LIBZIP_VERSION_name = zend_string_init_interned("LIBZIP_VERSION", sizeof("LIBZIP_VERSION") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_LIBZIP_VERSION_name, &const_LIBZIP_VERSION_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_LIBZIP_VERSION_name);
-#if defined(ZIP_LENGTH_TO_END)
 
 	zval const_LENGTH_TO_END_value;
 	ZVAL_LONG(&const_LENGTH_TO_END_value, ZIP_LENGTH_TO_END);
 	zend_string *const_LENGTH_TO_END_name = zend_string_init_interned("LENGTH_TO_END", sizeof("LENGTH_TO_END") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_LENGTH_TO_END_name, &const_LENGTH_TO_END_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_LENGTH_TO_END_name);
-#endif
-#if !(defined(ZIP_LENGTH_TO_END))
-
-	zval const_LENGTH_TO_END_value;
-	ZVAL_LONG(&const_LENGTH_TO_END_value, 0);
-	zend_string *const_LENGTH_TO_END_name = zend_string_init_interned("LENGTH_TO_END", sizeof("LENGTH_TO_END") - 1, 1);
-	zend_declare_class_constant_ex(class_entry, const_LENGTH_TO_END_name, &const_LENGTH_TO_END_value, ZEND_ACC_PUBLIC, NULL);
-	zend_string_release(const_LENGTH_TO_END_name);
-#endif
 #if defined(ZIP_LENGTH_UNCHECKED)
 
 	zval const_LENGTH_UNCHECKED_value;

--- a/ext/zip/php_zip_arginfo.h
+++ b/ext/zip/php_zip_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fb9b6fa0a8e3da62a85e13b455573ee876ea2d61 */
+ * Stub hash: 46d06bea2d0c38bb9c17d0be0388b4833d7b4e06 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_zip_open, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
@@ -76,7 +76,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_addFi
 	ZEND_ARG_TYPE_INFO(0, filepath, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, entryname, IS_STRING, 0, "\"\"")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "ZipArchive::LENGTH_TO_END")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "ZipArchive::FL_OVERWRITE")
 ZEND_END_ARG_INFO()
 
@@ -84,7 +84,7 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZipArchive_repla
 	ZEND_ARG_TYPE_INFO(0, filepath, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, start, IS_LONG, 0, "0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, length, IS_LONG, 0, "ZipArchive::LENGTH_TO_END")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, flags, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
@@ -1230,6 +1230,30 @@ static zend_class_entry *register_class_ZipArchive(zend_class_entry *class_entry
 	zend_string *const_LIBZIP_VERSION_name = zend_string_init_interned("LIBZIP_VERSION", sizeof("LIBZIP_VERSION") - 1, 1);
 	zend_declare_class_constant_ex(class_entry, const_LIBZIP_VERSION_name, &const_LIBZIP_VERSION_value, ZEND_ACC_PUBLIC, NULL);
 	zend_string_release(const_LIBZIP_VERSION_name);
+#if defined(ZIP_LENGTH_TO_END)
+
+	zval const_LENGTH_TO_END_value;
+	ZVAL_LONG(&const_LENGTH_TO_END_value, ZIP_LENGTH_TO_END);
+	zend_string *const_LENGTH_TO_END_name = zend_string_init_interned("LENGTH_TO_END", sizeof("LENGTH_TO_END") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_LENGTH_TO_END_name, &const_LENGTH_TO_END_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_LENGTH_TO_END_name);
+#endif
+#if !(defined(ZIP_LENGTH_TO_END))
+
+	zval const_LENGTH_TO_END_value;
+	ZVAL_LONG(&const_LENGTH_TO_END_value, 0);
+	zend_string *const_LENGTH_TO_END_name = zend_string_init_interned("LENGTH_TO_END", sizeof("LENGTH_TO_END") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_LENGTH_TO_END_name, &const_LENGTH_TO_END_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_LENGTH_TO_END_name);
+#endif
+#if defined(ZIP_LENGTH_UNCHECKED)
+
+	zval const_LENGTH_UNCHECKED_value;
+	ZVAL_LONG(&const_LENGTH_UNCHECKED_value, ZIP_LENGTH_UNCHECKED);
+	zend_string *const_LENGTH_UNCHECKED_name = zend_string_init_interned("LENGTH_UNCHECKED", sizeof("LENGTH_UNCHECKED") - 1, 1);
+	zend_declare_class_constant_ex(class_entry, const_LENGTH_UNCHECKED_name, &const_LENGTH_UNCHECKED_value, ZEND_ACC_PUBLIC, NULL);
+	zend_string_release(const_LENGTH_UNCHECKED_name);
+#endif
 
 	zval property_lastId_default_value;
 	ZVAL_UNDEF(&property_lastId_default_value);

--- a/ext/zip/tests/oo_addfile.phpt
+++ b/ext/zip/tests/oo_addfile.phpt
@@ -24,7 +24,7 @@ if (!$zip->addFile($dirname . 'utils.inc', 'mini.txt', 12, 34)) {
     echo "failed\n";
 }
 var_dump($zip->lastId);
-if (!$zip->addFile($dirname . 'utils.inc', 'other.txt', 0, 0, ZipArchive::FL_OPEN_FILE_NOW)) {
+if (!$zip->addFile($dirname . 'utils.inc', 'other.txt', 0, ZipArchive::LENGTH_TO_END, ZipArchive::FL_OPEN_FILE_NOW)) {
     echo "failed\n";
 }
 var_dump($zip->lastId);


### PR DESCRIPTION
- `ZipArchive::LENGTH_TO_END` is always defined as 0
- `ZipArchive::LENGTH_UNCHECKED` will be defined with libzip 1.10.1 planned for August

Already in pecl/zip, will be in version 1.22.2 planned to be released immediately after libzip

I think this is better to have in 8.3 before RC