### PR TITLE
Skip oci8 tests when no database is available

### DIFF
--- a/ext/oci8/tests/array_bind_001.phpt
+++ b/ext/oci8/tests/array_bind_001.phpt
@@ -2,6 +2,10 @@
 oci_bind_array_by_name() and invalid values 1
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/array_bind_002.phpt
+++ b/ext/oci8/tests/array_bind_002.phpt
@@ -2,6 +2,10 @@
 oci_bind_array_by_name() and invalid values 2
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/array_bind_003.phpt
+++ b/ext/oci8/tests/array_bind_003.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and invalid values 3
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_004.phpt
+++ b/ext/oci8/tests/array_bind_004.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and invalid values 4
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_005.phpt
+++ b/ext/oci8/tests/array_bind_005.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and invalid values 5
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_006.phpt
+++ b/ext/oci8/tests/array_bind_006.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name(), SQLT_CHR and default max_length
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_007.phpt
+++ b/ext/oci8/tests/array_bind_007.phpt
@@ -2,6 +2,10 @@
 oci_bind_array_by_name() and invalid values 7
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/array_bind_008.phpt
+++ b/ext/oci8/tests/array_bind_008.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and invalid values 8
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_009.phpt
+++ b/ext/oci8/tests/array_bind_009.phpt
@@ -2,6 +2,10 @@
 oci_bind_array_by_name() and invalid values 9
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/array_bind_010.phpt
+++ b/ext/oci8/tests/array_bind_010.phpt
@@ -2,6 +2,10 @@
 oci_bind_array_by_name() and invalid values 8
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/array_bind_011.phpt
+++ b/ext/oci8/tests/array_bind_011.phpt
@@ -2,6 +2,10 @@
 oci_bind_array_by_name(), SQLT_CHR, default max_length and empty array
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/array_bind_012.phpt
+++ b/ext/oci8/tests/array_bind_012.phpt
@@ -2,6 +2,10 @@
 oci_bind_array_by_name(), SQLT_CHR, default max_length and empty array
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/array_bind_013.phpt
+++ b/ext/oci8/tests/array_bind_013.phpt
@@ -2,6 +2,10 @@
 oci_bind_array_by_name(), SQLT_CHR, default max_length and empty array
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/array_bind_014.phpt
+++ b/ext/oci8/tests/array_bind_014.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and NUMBERs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_bdouble.phpt
+++ b/ext/oci8/tests/array_bind_bdouble.phpt
@@ -4,6 +4,7 @@ Unsupported type: oci_bind_array_by_name() and SQLT_BDOUBLE
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (!defined('SQLT_BDOUBLE')) die('skip SQLT_BDOUBLE type not available on older Oracle clients');

--- a/ext/oci8/tests/array_bind_bfloat.phpt
+++ b/ext/oci8/tests/array_bind_bfloat.phpt
@@ -4,6 +4,7 @@ Unsupported type: oci_bind_array_by_name() and SQLT_BFLOAT
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (!defined('SQLT_BFLOAT')) die('skip SQLT_BFLOAT type not available on older Oracle clients');

--- a/ext/oci8/tests/array_bind_date.phpt
+++ b/ext/oci8/tests/array_bind_date.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and SQLT_ODT
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_date1.phpt
+++ b/ext/oci8/tests/array_bind_date1.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and SQLT_ODT
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_float.phpt
+++ b/ext/oci8/tests/array_bind_float.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and SQLT_FLT
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_float1.phpt
+++ b/ext/oci8/tests/array_bind_float1.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and SQLT_FLT
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_int.phpt
+++ b/ext/oci8/tests/array_bind_int.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and SQLT_INT
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_int1.phpt
+++ b/ext/oci8/tests/array_bind_int1.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and SQLT_INT
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_str.phpt
+++ b/ext/oci8/tests/array_bind_str.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and SQLT_CHR
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_str1.phpt
+++ b/ext/oci8/tests/array_bind_str1.phpt
@@ -4,6 +4,7 @@ oci_bind_array_by_name() and SQLT_CHR
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/array_bind_uin.phpt
+++ b/ext/oci8/tests/array_bind_uin.phpt
@@ -4,6 +4,7 @@ Unsupported type: oci_bind_array_by_name() and SQLT_UIN
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/b47243_1.phpt
+++ b/ext/oci8/tests/b47243_1.phpt
@@ -4,6 +4,7 @@ Bug #47243 (Crash on exit with ZTS mode)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/b47243_2.phpt
+++ b/ext/oci8/tests/b47243_2.phpt
@@ -4,6 +4,7 @@ Bug #47243 (Crash on exit with ZTS mode)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/b47243_3.phpt
+++ b/ext/oci8/tests/b47243_3.phpt
@@ -4,6 +4,7 @@ Bug #47243 (Crash on exit with ZTS mode)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bind_boolean_1.phpt
+++ b/ext/oci8/tests/bind_boolean_1.phpt
@@ -4,6 +4,7 @@ Basic PL/SQL "BOOLEAN" (SQLT_BOL) bind test
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__.'/connect.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);
 if (!(isset($matches[0]) && $matches[1] >= 12)) {

--- a/ext/oci8/tests/bind_char_1.phpt
+++ b/ext/oci8/tests/bind_char_1.phpt
@@ -4,6 +4,7 @@ SELECT oci_bind_by_name with SQLT_AFC aka CHAR
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 // The bind buffer size edge cases seem to change each DB version.
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/bind_char_2.phpt
+++ b/ext/oci8/tests/bind_char_2.phpt
@@ -4,6 +4,7 @@ SELECT oci_bind_by_name with SQLT_AFC aka CHAR and dates
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 // The bind buffer size edge cases seem to change each DB version.
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/bind_char_3.phpt
+++ b/ext/oci8/tests/bind_char_3.phpt
@@ -4,6 +4,7 @@ PL/SQL oci_bind_by_name with SQLT_AFC aka CHAR to CHAR parameter
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 // The bind buffer size edge cases seem to change each DB version.
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/bind_char_4.phpt
+++ b/ext/oci8/tests/bind_char_4.phpt
@@ -4,6 +4,7 @@ PL/SQL oci_bind_by_name with SQLT_AFC aka CHAR to VARCHAR2 parameter
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 // The bind buffer size edge cases seem to change each DB version.
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/bind_empty.phpt
+++ b/ext/oci8/tests/bind_empty.phpt
@@ -2,6 +2,10 @@
 binding empty values
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_long.phpt
+++ b/ext/oci8/tests/bind_long.phpt
@@ -4,6 +4,7 @@ bind LONG field
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bind_long_raw.phpt
+++ b/ext/oci8/tests/bind_long_raw.phpt
@@ -4,6 +4,7 @@ bind LONG RAW field
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bind_misccoltypes.phpt
+++ b/ext/oci8/tests/bind_misccoltypes.phpt
@@ -4,6 +4,7 @@ Bind miscellaneous column types using default types
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bind_misccoltypes_errs.phpt
+++ b/ext/oci8/tests/bind_misccoltypes_errs.phpt
@@ -2,6 +2,10 @@
 Bind miscellaneous column types and generating errors
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_number.phpt
+++ b/ext/oci8/tests/bind_number.phpt
@@ -2,6 +2,10 @@
 Bind with NUMBER column variants
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 precision = 14
 --FILE--

--- a/ext/oci8/tests/bind_query.phpt
+++ b/ext/oci8/tests/bind_query.phpt
@@ -2,6 +2,10 @@
 Bind with various WHERE conditions
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_raw.phpt
+++ b/ext/oci8/tests/bind_raw.phpt
@@ -4,6 +4,7 @@ bind RAW field
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bind_raw_2.phpt
+++ b/ext/oci8/tests/bind_raw_2.phpt
@@ -4,6 +4,7 @@ bind RAW field with OCI_B_BIN
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bind_rowid.phpt
+++ b/ext/oci8/tests/bind_rowid.phpt
@@ -2,6 +2,10 @@
 Test ROWID bind
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_sqltafc.phpt
+++ b/ext/oci8/tests/bind_sqltafc.phpt
@@ -2,6 +2,10 @@
 Bind tests with SQLT_AFC
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_sqltchr_1.phpt
+++ b/ext/oci8/tests/bind_sqltchr_1.phpt
@@ -2,6 +2,10 @@
 Bind with SQLT_CHR
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_sqltchr_2.phpt
+++ b/ext/oci8/tests/bind_sqltchr_2.phpt
@@ -2,6 +2,10 @@
 PL/SQL bind with SQLT_CHR
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_sqltint.phpt
+++ b/ext/oci8/tests/bind_sqltint.phpt
@@ -2,6 +2,10 @@
 Bind with SQLT_INT
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_sqltnum.phpt
+++ b/ext/oci8/tests/bind_sqltnum.phpt
@@ -4,6 +4,7 @@ Bind with SQLT_NUM
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 preg_match('/^[[:digit:]]+/', oci_client_version(), $matches);
 if (!(isset($matches[0]) && $matches[0] >= 12)) {
     die("skip works only with Oracle 12c or greater version of Oracle client libraries");

--- a/ext/oci8/tests/bind_unsupported_1.phpt
+++ b/ext/oci8/tests/bind_unsupported_1.phpt
@@ -2,6 +2,10 @@
 Bind with various unsupported bind types
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_unsupported_2.phpt
+++ b/ext/oci8/tests/bind_unsupported_2.phpt
@@ -2,6 +2,10 @@
 Bind with various unsupported 10g+ bind types
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bind_unsupported_3.phpt
+++ b/ext/oci8/tests/bind_unsupported_3.phpt
@@ -4,6 +4,7 @@ Bind with various bind types not supported by TimesTen
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => false, 'timesten' => true);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug26133.phpt
+++ b/ext/oci8/tests/bug26133.phpt
@@ -2,6 +2,10 @@
 Bug #26133 (ocifreedesc() segfault)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bug27303_1.phpt
+++ b/ext/oci8/tests/bug27303_1.phpt
@@ -4,6 +4,7 @@ Bug #27303 (OCIBindByName binds numeric PHP values as characters)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 // The bind buffer size edge cases seem to change each DB version.
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/bug27303_2.phpt
+++ b/ext/oci8/tests/bug27303_2.phpt
@@ -4,6 +4,7 @@ Bug #27303 (OCIBindByName binds numeric PHP values as characters)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 // The bind buffer size edge cases seem to change each DB version.
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/bug27303_3.phpt
+++ b/ext/oci8/tests/bug27303_3.phpt
@@ -2,6 +2,10 @@
 Bug #27303 (OCIBindByName binds numeric PHP values as characters)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bug27303_4.phpt
+++ b/ext/oci8/tests/bug27303_4.phpt
@@ -4,6 +4,7 @@ Bug #27303 (OCIBindByName binds numeric PHP values as characters)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 // The bind buffer size edge cases seem to change each DB version.
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/bug32325.phpt
+++ b/ext/oci8/tests/bug32325.phpt
@@ -4,6 +4,7 @@ Bug #32325 (Cannot retrieve collection using OCI8)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug35973.phpt
+++ b/ext/oci8/tests/bug35973.phpt
@@ -4,6 +4,7 @@ Bug #35973 (Error ORA-24806 occurs when trying to fetch a NCLOB field)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug36010.phpt
+++ b/ext/oci8/tests/bug36010.phpt
@@ -4,6 +4,7 @@ Bug #36010 (Crash when executing SQL statement with lob parameter twice)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug36096.phpt
+++ b/ext/oci8/tests/bug36096.phpt
@@ -2,6 +2,10 @@
 Bug #36096 (oci_result() returns garbage after oci_fetch() failed)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bug36403.phpt
+++ b/ext/oci8/tests/bug36403.phpt
@@ -2,6 +2,10 @@
 Bug #36403 (oci_execute no longer supports OCI_DESCRIBE_ONLY)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bug37220.phpt
+++ b/ext/oci8/tests/bug37220.phpt
@@ -4,6 +4,7 @@ Bug #37220 (LOB Type mismatch when using windows & oci8.dll)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug37581.phpt
+++ b/ext/oci8/tests/bug37581.phpt
@@ -4,6 +4,7 @@ Bug #37581 (oci_bind_array_by_name clobbers input array when using SQLT_AFC, AVC
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug38161.phpt
+++ b/ext/oci8/tests/bug38161.phpt
@@ -2,6 +2,10 @@
 Bug #38161 (oci_bind_by_name() returns garbage when Oracle didn't set the variable)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bug38173.phpt
+++ b/ext/oci8/tests/bug38173.phpt
@@ -4,6 +4,7 @@ Bug #38173 (Freeing nested cursors causes OCI8 to segfault)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug40078.phpt
+++ b/ext/oci8/tests/bug40078.phpt
@@ -4,6 +4,7 @@ Bug #40078 (ORA-01405 when fetching NULL values using oci_bind_array_by_name())
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug40415.phpt
+++ b/ext/oci8/tests/bug40415.phpt
@@ -4,6 +4,7 @@ Bug #40415 (Using oci_fetchall with nested cursors)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug41069.phpt
+++ b/ext/oci8/tests/bug41069.phpt
@@ -4,6 +4,7 @@ Bug #41069 (Oracle crash with certain data over a DB-link when prefetch memory l
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (empty($dbase)) die ("skip requires network connection alias for DB link loopback");

--- a/ext/oci8/tests/bug42134.phpt
+++ b/ext/oci8/tests/bug42134.phpt
@@ -4,6 +4,7 @@ Bug #42134 (Collection error for invalid collection name)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug42173.phpt
+++ b/ext/oci8/tests/bug42173.phpt
@@ -4,6 +4,7 @@ Bug #42173 (TIMESTAMP and INTERVAL query and field functions)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug42496_1.phpt
+++ b/ext/oci8/tests/bug42496_1.phpt
@@ -4,9 +4,10 @@ Bug #42496 (LOB fetch leaks cursors, eventually failing with ORA-1000 maximum op
 oci8
 --SKIPIF--
 <?php
+if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
-if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
 ?>
 --FILE--
 <?php

--- a/ext/oci8/tests/bug42496_2.phpt
+++ b/ext/oci8/tests/bug42496_2.phpt
@@ -4,9 +4,10 @@ Bug #42496 (LOB fetch leaks cursors, eventually failing with ORA-1000 maximum op
 oci8
 --SKIPIF--
 <?php
+if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
-if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
 ?>
 --FILE--
 <?php

--- a/ext/oci8/tests/bug42841.phpt
+++ b/ext/oci8/tests/bug42841.phpt
@@ -4,6 +4,7 @@ Bug #42841 (REF CURSOR and oci_new_cursor PHP crash)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug43492.phpt
+++ b/ext/oci8/tests/bug43492.phpt
@@ -4,6 +4,7 @@ Bug #43492 (Nested cursor leaks)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug43492_2.phpt
+++ b/ext/oci8/tests/bug43492_2.phpt
@@ -4,6 +4,7 @@ Bug #43492 (Nested cursor leaks after related bug #44206 fixed)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug43497.phpt
+++ b/ext/oci8/tests/bug43497.phpt
@@ -4,6 +4,7 @@ Bug #43497 (OCI8 XML/getClobVal aka temporary LOBs leak UGA memory)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');

--- a/ext/oci8/tests/bug44008.phpt
+++ b/ext/oci8/tests/bug44008.phpt
@@ -4,6 +4,7 @@ Bug #44008 (Incorrect usage of OCILob->close crashes PHP)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug44113.phpt
+++ b/ext/oci8/tests/bug44113.phpt
@@ -4,6 +4,7 @@ Bug #44113 (New collection creation can fail with OCI-22303)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');

--- a/ext/oci8/tests/bug44206.phpt
+++ b/ext/oci8/tests/bug44206.phpt
@@ -4,6 +4,7 @@ Bug #44206 (Test if selecting ref cursors leads to ORA-1000 maximum open cursors
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug45458.phpt
+++ b/ext/oci8/tests/bug45458.phpt
@@ -2,6 +2,10 @@
 Bug #45458 (OCI8: Numeric keys for associative arrays are not handled properly)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bug46994.phpt
+++ b/ext/oci8/tests/bug46994.phpt
@@ -4,6 +4,7 @@ Bug #46994 (CLOB size does not update when using CLOB IN OUT param in stored pro
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug47189.phpt
+++ b/ext/oci8/tests/bug47189.phpt
@@ -4,6 +4,7 @@ Bug #47189 (Multiple oci_fetch_all calls)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs: different error handling for this undefined behavior
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug47281.phpt
+++ b/ext/oci8/tests/bug47281.phpt
@@ -4,6 +4,7 @@ Bug #47281 ($php_errormsg is limited in size of characters)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 // error3.phpt obsoletes this test for newer Oracle client versions

--- a/ext/oci8/tests/bug47281_tt.phpt
+++ b/ext/oci8/tests/bug47281_tt.phpt
@@ -4,6 +4,7 @@ Bug #47281 ($php_errormsg is limited in size of characters)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => false, 'timesten' => true);  // test runs on these DBs: shorter message length in TimesTen
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug51253.phpt
+++ b/ext/oci8/tests/bug51253.phpt
@@ -4,6 +4,7 @@ Bug #51253 (oci_bind_array_by_name() array references)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug51291_1.phpt
+++ b/ext/oci8/tests/bug51291_1.phpt
@@ -2,6 +2,10 @@
 Bug #51291 (oci_error() doesn't report last error when called two times)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bug51291_2.phpt
+++ b/ext/oci8/tests/bug51291_2.phpt
@@ -4,6 +4,7 @@ Bug #51291 (oci_error() doesn't report last error when called two times)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs: different error messages from TimesTen
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug68298.phpt
+++ b/ext/oci8/tests/bug68298.phpt
@@ -5,6 +5,7 @@ oci8
 --SKIPIF--
 <?php
 if (PHP_INT_SIZE != 8) die("skip this test is for 64bit platforms only");
+require_once('skipifconnectfailure.inc');
 ?>
 --FILE--
 <?php

--- a/ext/oci8/tests/bug70700.phpt
+++ b/ext/oci8/tests/bug70700.phpt
@@ -9,6 +9,7 @@ mbstring
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug71148.phpt
+++ b/ext/oci8/tests/bug71148.phpt
@@ -4,6 +4,7 @@ Bug #71448 (Binding reference overwritten on php7)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => true);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug71422.phpt
+++ b/ext/oci8/tests/bug71422.phpt
@@ -2,6 +2,10 @@
 Bug #71422 (Fix ORA-01438: value larger than specified precision allowed for this column)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/bug71600.phpt
+++ b/ext/oci8/tests/bug71600.phpt
@@ -4,6 +4,7 @@ Bug #71600 (oci_fetch_all result in segfault when select more than 8 columns)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => true);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug72524.phpt
+++ b/ext/oci8/tests/bug72524.phpt
@@ -4,6 +4,7 @@ Bug #72524 (Binding null values triggers ORA-24816 error)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => true);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/bug74625.phpt
+++ b/ext/oci8/tests/bug74625.phpt
@@ -2,6 +2,10 @@
 Bug #74625 (Integer overflow in oci_bind_array_by_name)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 require(__DIR__.'/connect.inc');

--- a/ext/oci8/tests/calltimeout1.phpt
+++ b/ext/oci8/tests/calltimeout1.phpt
@@ -5,6 +5,7 @@ oci8
 --SKIPIF--
 <?php
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (strcasecmp($user, "system") && strcasecmp($user, "sys")) {

--- a/ext/oci8/tests/close.phpt
+++ b/ext/oci8/tests/close.phpt
@@ -2,6 +2,10 @@
 connect/close/connect
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/coll_001.phpt
+++ b/ext/oci8/tests/coll_001.phpt
@@ -4,6 +4,7 @@ oci_new_collection()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_002.phpt
+++ b/ext/oci8/tests/coll_002.phpt
@@ -4,6 +4,7 @@ oci_new_collection() + free()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_002_func.phpt
+++ b/ext/oci8/tests/coll_002_func.phpt
@@ -4,6 +4,7 @@ oci_new_collection() + free()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_003.phpt
+++ b/ext/oci8/tests/coll_003.phpt
@@ -4,6 +4,7 @@ collection methods
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_003_func.phpt
+++ b/ext/oci8/tests/coll_003_func.phpt
@@ -4,6 +4,7 @@ collection methods
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_004.phpt
+++ b/ext/oci8/tests/coll_004.phpt
@@ -4,6 +4,7 @@ oci_collection_assign()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_004_func.phpt
+++ b/ext/oci8/tests/coll_004_func.phpt
@@ -4,6 +4,7 @@ oci_collection_assign()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_009.phpt
+++ b/ext/oci8/tests/coll_009.phpt
@@ -4,6 +4,7 @@ collections and wrong dates
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_009_func.phpt
+++ b/ext/oci8/tests/coll_009_func.phpt
@@ -4,6 +4,7 @@ collections and wrong dates
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_010.phpt
+++ b/ext/oci8/tests/coll_010.phpt
@@ -4,6 +4,7 @@ collections and nulls
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_010_func.phpt
+++ b/ext/oci8/tests/coll_010_func.phpt
@@ -4,6 +4,7 @@ collections and nulls
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_011.phpt
+++ b/ext/oci8/tests/coll_011.phpt
@@ -4,6 +4,7 @@ collections and strings
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_011_func.phpt
+++ b/ext/oci8/tests/coll_011_func.phpt
@@ -4,6 +4,7 @@ collections and strings
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_012.phpt
+++ b/ext/oci8/tests/coll_012.phpt
@@ -4,6 +4,7 @@ collections and correct dates
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_012_func.phpt
+++ b/ext/oci8/tests/coll_012_func.phpt
@@ -4,6 +4,7 @@ collections and correct dates
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_013.phpt
+++ b/ext/oci8/tests/coll_013.phpt
@@ -4,6 +4,7 @@ collections and correct dates (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_013_func.phpt
+++ b/ext/oci8/tests/coll_013_func.phpt
@@ -4,6 +4,7 @@ collections and correct dates (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_014.phpt
+++ b/ext/oci8/tests/coll_014.phpt
@@ -4,6 +4,7 @@ collections and strings (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_014_func.phpt
+++ b/ext/oci8/tests/coll_014_func.phpt
@@ -4,6 +4,7 @@ collections and strings (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_015.phpt
+++ b/ext/oci8/tests/coll_015.phpt
@@ -4,6 +4,7 @@ collections and numbers (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_015_func.phpt
+++ b/ext/oci8/tests/coll_015_func.phpt
@@ -4,6 +4,7 @@ collections and numbers (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_016.phpt
+++ b/ext/oci8/tests/coll_016.phpt
@@ -4,6 +4,7 @@ collections and negative/too big element indexes
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_016_func.phpt
+++ b/ext/oci8/tests/coll_016_func.phpt
@@ -4,6 +4,7 @@ collections and negative/too big element indexes
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_017.phpt
+++ b/ext/oci8/tests/coll_017.phpt
@@ -4,6 +4,7 @@ collections and nulls (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_017_func.phpt
+++ b/ext/oci8/tests/coll_017_func.phpt
@@ -4,6 +4,7 @@ collections and nulls (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_018.phpt
+++ b/ext/oci8/tests/coll_018.phpt
@@ -4,6 +4,7 @@ Collection trim tests
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/coll_019.phpt
+++ b/ext/oci8/tests/coll_019.phpt
@@ -4,6 +4,7 @@ Test collection Oracle error handling collections and numbers (2)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/commit_001.phpt
+++ b/ext/oci8/tests/commit_001.phpt
@@ -4,6 +4,7 @@ Test OCI_NO_AUTO_COMMIT constant
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/commit_002.phpt
+++ b/ext/oci8/tests/commit_002.phpt
@@ -4,6 +4,7 @@ Test oci_commit failure
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/conn_attr_1.phpt
+++ b/ext/oci8/tests/conn_attr_1.phpt
@@ -5,6 +5,7 @@ oci8
 --SKIPIF--
 <?php
 if (getenv('SKIP_REPEAT')) die('skip fails with repeat');
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 

--- a/ext/oci8/tests/conn_attr_2.phpt
+++ b/ext/oci8/tests/conn_attr_2.phpt
@@ -5,6 +5,7 @@ oci8
 --SKIPIF--
 <?php
 if (getenv('SKIP_REPEAT')) die('skip fails with repeat');
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 

--- a/ext/oci8/tests/conn_attr_3.phpt
+++ b/ext/oci8/tests/conn_attr_3.phpt
@@ -5,6 +5,7 @@ oci8
 --SKIPIF--
 <?php
 if (getenv('SKIP_REPEAT')) die('skip fails with repeat');
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 

--- a/ext/oci8/tests/conn_attr_4.phpt
+++ b/ext/oci8/tests/conn_attr_4.phpt
@@ -4,6 +4,7 @@ Set and get of connection attributes with errors.
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');

--- a/ext/oci8/tests/conn_attr_5.phpt
+++ b/ext/oci8/tests/conn_attr_5.phpt
@@ -5,6 +5,7 @@ oci8
 --SKIPIF--
 <?php
 if (getenv('SKIP_REPEAT')) die('skip fails with repeat');
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 

--- a/ext/oci8/tests/connect.phpt
+++ b/ext/oci8/tests/connect.phpt
@@ -2,6 +2,10 @@
 oci_connect()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/connect_1.phpt
+++ b/ext/oci8/tests/connect_1.phpt
@@ -2,6 +2,10 @@
 oci_pconnect() & oci_new_connect()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/connect_scope1.phpt
+++ b/ext/oci8/tests/connect_scope1.phpt
@@ -2,6 +2,10 @@
 Test oci_connect end-of-scope when statement returned
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/connect_scope2.phpt
+++ b/ext/oci8/tests/connect_scope2.phpt
@@ -2,6 +2,10 @@
 Test oci_pconnect end-of-scope when statement returned
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/connect_scope_try1.phpt
+++ b/ext/oci8/tests/connect_scope_try1.phpt
@@ -2,6 +2,10 @@
 Check oci_connect try/catch end-of-scope with old_oci_close_semantics Off
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=0
 --FILE--

--- a/ext/oci8/tests/connect_scope_try2.phpt
+++ b/ext/oci8/tests/connect_scope_try2.phpt
@@ -2,6 +2,10 @@
 Check oci_connect try/catch end-of-scope with old_oci_close_semantics On
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 --FILE--

--- a/ext/oci8/tests/connect_scope_try3.phpt
+++ b/ext/oci8/tests/connect_scope_try3.phpt
@@ -2,6 +2,10 @@
 Check oci_new_connect try/catch end-of-scope with old_oci_close_semantics Off
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=0
 --FILE--

--- a/ext/oci8/tests/connect_scope_try4.phpt
+++ b/ext/oci8/tests/connect_scope_try4.phpt
@@ -2,6 +2,10 @@
 Check oci_new_connect try/catch end-of-scope with old_oci_close_semantics On
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 --FILE--

--- a/ext/oci8/tests/connect_scope_try5.phpt
+++ b/ext/oci8/tests/connect_scope_try5.phpt
@@ -2,6 +2,10 @@
 Check oci_pconnect try/catch end-of-scope with old_oci_close_semantics Off
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=0
 --FILE--

--- a/ext/oci8/tests/connect_scope_try6.phpt
+++ b/ext/oci8/tests/connect_scope_try6.phpt
@@ -2,6 +2,10 @@
 Check oci_pconnect try/catch end-of-scope with old_oci_close_semantics On
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 --FILE--

--- a/ext/oci8/tests/connect_with_charset_001.phpt
+++ b/ext/oci8/tests/connect_with_charset_001.phpt
@@ -2,6 +2,10 @@
 oci_connect() with invalid character set
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/connect_without_oracle_home_11.phpt
+++ b/ext/oci8/tests/connect_without_oracle_home_11.phpt
@@ -4,6 +4,7 @@ oci_connect() without ORACLE_HOME set (OCIServerAttach() segfaults)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 ob_start();
 phpinfo(INFO_MODULES);
 $phpinfo = ob_get_clean();

--- a/ext/oci8/tests/cursor_bind.phpt
+++ b/ext/oci8/tests/cursor_bind.phpt
@@ -4,6 +4,7 @@ bind and fetch cursor from a statement
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/cursor_bind_err.phpt
+++ b/ext/oci8/tests/cursor_bind_err.phpt
@@ -4,6 +4,7 @@ binding a cursor (with errors)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/cursors.phpt
+++ b/ext/oci8/tests/cursors.phpt
@@ -4,6 +4,7 @@ fetching cursor from a statement
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/db_op_1.phpt
+++ b/ext/oci8/tests/db_op_1.phpt
@@ -4,6 +4,7 @@ oci_set_db_operation: basic test for end-to-end tracing
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (strcasecmp($user, "system") && strcasecmp($user, "sys")) {

--- a/ext/oci8/tests/db_op_2.phpt
+++ b/ext/oci8/tests/db_op_2.phpt
@@ -4,6 +4,7 @@ oci_set_db_operation: test DBOP for end-to-end tracing
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (strcasecmp($user, "system") && strcasecmp($user, "sys")) {

--- a/ext/oci8/tests/dbmsoutput.phpt
+++ b/ext/oci8/tests/dbmsoutput.phpt
@@ -4,6 +4,7 @@ PL/SQL: dbms_output
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/default_prefetch0.phpt
+++ b/ext/oci8/tests/default_prefetch0.phpt
@@ -2,6 +2,10 @@
 oci8.default_prefetch ini option
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.default_prefetch=20
 --FILE--

--- a/ext/oci8/tests/default_prefetch1.phpt
+++ b/ext/oci8/tests/default_prefetch1.phpt
@@ -2,6 +2,10 @@
 oci8.default_prefetch ini option
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.default_prefetch=100
 --FILE--

--- a/ext/oci8/tests/default_prefetch2.phpt
+++ b/ext/oci8/tests/default_prefetch2.phpt
@@ -2,6 +2,10 @@
 oci8.default_prefetch ini option
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.default_prefetch=100
 --FILE--

--- a/ext/oci8/tests/define.phpt
+++ b/ext/oci8/tests/define.phpt
@@ -2,6 +2,10 @@
 oci_define_by_name()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/define0.phpt
+++ b/ext/oci8/tests/define0.phpt
@@ -2,6 +2,10 @@
 oci_define_by_name()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/define1.phpt
+++ b/ext/oci8/tests/define1.phpt
@@ -2,6 +2,10 @@
 oci_define_by_name()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/define2.phpt
+++ b/ext/oci8/tests/define2.phpt
@@ -4,6 +4,7 @@ Test oci_define_by_name types
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/define3.phpt
+++ b/ext/oci8/tests/define3.phpt
@@ -4,6 +4,7 @@ Test oci_define_by_name() LOB descriptor
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/define4.phpt
+++ b/ext/oci8/tests/define4.phpt
@@ -2,6 +2,10 @@
 oci_define_by_name() on partial number of columns
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/define5.phpt
+++ b/ext/oci8/tests/define5.phpt
@@ -2,6 +2,10 @@
 oci_define_by_name() for statement re-execution
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/define6.phpt
+++ b/ext/oci8/tests/define6.phpt
@@ -4,6 +4,7 @@ oci_define_by_name tests with REF CURSORs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/descriptors.phpt
+++ b/ext/oci8/tests/descriptors.phpt
@@ -4,6 +4,7 @@ commit connection after destroying the descriptor
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/drcp_cclass1.phpt
+++ b/ext/oci8/tests/drcp_cclass1.phpt
@@ -4,6 +4,7 @@ DRCP: Test setting connection class inline
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__.'/connect.inc');
 if (!$test_drcp) die("skip testing DRCP connection class only works in DRCP mode");
 // Looked for :pooled in EZ connect string

--- a/ext/oci8/tests/drcp_characterset.phpt
+++ b/ext/oci8/tests/drcp_characterset.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_pconnect() and oci_connect() with different character sets
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/drcp_conn_close1.phpt
+++ b/ext/oci8/tests/drcp_conn_close1.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_connect() with oci_close() and oci8.old_oci_close_semantics ON
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 oci8.connection_class=test

--- a/ext/oci8/tests/drcp_conn_close2.phpt
+++ b/ext/oci8/tests/drcp_conn_close2.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_connect() with oci_close() and oci8.old_oci_close_semantics OFF
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=0
 oci8.connection_class=test

--- a/ext/oci8/tests/drcp_connect1.phpt
+++ b/ext/oci8/tests/drcp_connect1.phpt
@@ -4,6 +4,7 @@ DRCP: oci_connect()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs (Calling PL/SQL from SQL is not supported in TimesTen)
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/drcp_newconnect.phpt
+++ b/ext/oci8/tests/drcp_newconnect.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_new_connect()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.connection_class=test
 oci8.old_oci_close_semantics=0

--- a/ext/oci8/tests/drcp_pconn_close1.phpt
+++ b/ext/oci8/tests/drcp_pconn_close1.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_pconnect() with oci_close() and oci8.old_oci_close_semantics ON
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 oci8.connection_class=test

--- a/ext/oci8/tests/drcp_pconn_close2.phpt
+++ b/ext/oci8/tests/drcp_pconn_close2.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_pconnect() with oci_close() and oci8.old_oci_close_semantics OFF
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=0
 oci8.connection_class=test

--- a/ext/oci8/tests/drcp_privileged.phpt
+++ b/ext/oci8/tests/drcp_privileged.phpt
@@ -4,6 +4,7 @@ DRCP: privileged connect
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 if (!$test_drcp) die("skip requires DRCP connection");
 // Looked for :pooled in EZ connect string

--- a/ext/oci8/tests/drcp_scope1.phpt
+++ b/ext/oci8/tests/drcp_scope1.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_new_connect() and oci_connect() with scope end when oci8.old_oci_close_semantics ON
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 --FILE--

--- a/ext/oci8/tests/drcp_scope2.phpt
+++ b/ext/oci8/tests/drcp_scope2.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_new_connect() and oci_connect with scope end when oci8.old_oci_close_semantics OFF
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=0
 --FILE--

--- a/ext/oci8/tests/drcp_scope3.phpt
+++ b/ext/oci8/tests/drcp_scope3.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_pconnect() with scope end when oci8.old_oci_close_semantics ON
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 --FILE--

--- a/ext/oci8/tests/drcp_scope4.phpt
+++ b/ext/oci8/tests/drcp_scope4.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_pconnect() with scope end when oci8.old_oci_close_semantics OFF
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=0
 --FILE--

--- a/ext/oci8/tests/drcp_scope5.phpt
+++ b/ext/oci8/tests/drcp_scope5.phpt
@@ -2,6 +2,10 @@
 DRCP: oci_pconnect() with scope end when oci8.old_oci_close_semantics ON
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 --FILE--

--- a/ext/oci8/tests/driver_name.phpt
+++ b/ext/oci8/tests/driver_name.phpt
@@ -3,7 +3,9 @@ Verify that the Driver Name attribute is set
 --EXTENSIONS--
 oci8
 --SKIPIF--
-<?php require(__DIR__."/connect.inc");
+<?php
+require_once('skipifconnectfailure.inc');
+require(__DIR__."/connect.inc");
 if (strcasecmp($user, "system") && strcasecmp($user, "sys")) die("skip needs to be run as a DBA user");
 if ($test_drcp) die("skip as Output might vary with DRCP");
 

--- a/ext/oci8/tests/driver_name_11gR2.phpt
+++ b/ext/oci8/tests/driver_name_11gR2.phpt
@@ -3,7 +3,9 @@ Verify that the Driver Name attribute is set
 --EXTENSIONS--
 oci8
 --SKIPIF--
-<?php require(__DIR__."/connect.inc");
+<?php
+require_once('skipifconnectfailure.inc');
+require(__DIR__."/connect.inc");
 if (strcasecmp($user, "system") && strcasecmp($user, "sys")) die("skip needs to be run as a DBA user");
 if ($test_drcp) die("skip as Output might vary with DRCP");
 

--- a/ext/oci8/tests/dupcolnames.phpt
+++ b/ext/oci8/tests/dupcolnames.phpt
@@ -2,6 +2,10 @@
 SELECT tests with duplicate column anmes
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/edition_1.phpt
+++ b/ext/oci8/tests/edition_1.phpt
@@ -4,6 +4,7 @@ Basic test for setting Oracle 11gR2 "edition" attribute
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 if (strcasecmp($user, "system") && strcasecmp($user, "sys")) {
     die("skip needs to be run as a DBA user");

--- a/ext/oci8/tests/edition_2.phpt
+++ b/ext/oci8/tests/edition_2.phpt
@@ -5,6 +5,7 @@ oci8
 --SKIPIF--
 <?php
 if (getenv('SKIP_REPEAT')) die('skip fails with repeat');
+require_once('skipifconnectfailure.inc');
 require(__DIR__."/connect.inc");
 if (strcasecmp($user, "system") && strcasecmp($user, "sys"))
     die("skip needs to be run as a DBA user");

--- a/ext/oci8/tests/error.phpt
+++ b/ext/oci8/tests/error.phpt
@@ -4,6 +4,7 @@ oci_error() error message for parsing error
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs: different error messages from TimesTen
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/error2.phpt
+++ b/ext/oci8/tests/error2.phpt
@@ -4,6 +4,7 @@ Exercise error code for SUCCESS_WITH_INFO
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');

--- a/ext/oci8/tests/error3.phpt
+++ b/ext/oci8/tests/error3.phpt
@@ -4,6 +4,7 @@ Maximum Oracle error length
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 // Assume runtime client version is >= compile time client version

--- a/ext/oci8/tests/error_bind.phpt
+++ b/ext/oci8/tests/error_bind.phpt
@@ -2,6 +2,10 @@
 Test some oci_bind_by_name error conditions
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/error_bind_2.phpt
+++ b/ext/oci8/tests/error_bind_2.phpt
@@ -4,6 +4,7 @@ Test some more oci_bind_by_name error conditions
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => true);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/error_bind_3.phpt
+++ b/ext/oci8/tests/error_bind_3.phpt
@@ -4,6 +4,7 @@ Test some more oci_bind_by_name error conditions
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => true);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/error_parse.phpt
+++ b/ext/oci8/tests/error_parse.phpt
@@ -2,6 +2,10 @@
 Test error handling when persistent connection is passed to oci_error()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/error_set.phpt
+++ b/ext/oci8/tests/error_set.phpt
@@ -2,6 +2,10 @@
 Check oci_set_{action,client_identifier,module_name,client_info} error handling
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/exec_fetch.phpt
+++ b/ext/oci8/tests/exec_fetch.phpt
@@ -2,6 +2,10 @@
 fetch after failed oci_execute()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/execute_mode.phpt
+++ b/ext/oci8/tests/execute_mode.phpt
@@ -2,6 +2,10 @@
 oci_execute() and invalid execute mode
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/fetch.phpt
+++ b/ext/oci8/tests/fetch.phpt
@@ -2,6 +2,10 @@
 ocifetch() & ociresult()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/fetch_all1.phpt
+++ b/ext/oci8/tests/fetch_all1.phpt
@@ -2,6 +2,10 @@
 oci_fetch_all()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/fetch_all2.phpt
+++ b/ext/oci8/tests/fetch_all2.phpt
@@ -4,6 +4,7 @@ oci_fetch_all() - 2
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/fetch_all3.phpt
+++ b/ext/oci8/tests/fetch_all3.phpt
@@ -2,6 +2,10 @@
 oci_fetch_all() - all combinations of flags
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/fetch_all4.phpt
+++ b/ext/oci8/tests/fetch_all4.phpt
@@ -2,6 +2,10 @@
 Test oci_fetch_* array overwriting when query returns no rows
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/fetch_all5.phpt
+++ b/ext/oci8/tests/fetch_all5.phpt
@@ -2,6 +2,10 @@
 Test oci_fetch_all with 0 and -1 skip & maxrows
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/fetch_array.phpt
+++ b/ext/oci8/tests/fetch_array.phpt
@@ -4,6 +4,7 @@ oci_fetch_array()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/fetch_assoc.phpt
+++ b/ext/oci8/tests/fetch_assoc.phpt
@@ -2,6 +2,10 @@
 oci_fetch_assoc()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/fetch_object.phpt
+++ b/ext/oci8/tests/fetch_object.phpt
@@ -4,6 +4,7 @@ oci_fetch_object()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/fetch_object_1.phpt
+++ b/ext/oci8/tests/fetch_object_1.phpt
@@ -4,6 +4,7 @@ oci_fetch_object()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/fetch_object_2.phpt
+++ b/ext/oci8/tests/fetch_object_2.phpt
@@ -4,6 +4,7 @@ oci_fetch_object() with CLOB and NULL
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/fetch_row.phpt
+++ b/ext/oci8/tests/fetch_row.phpt
@@ -2,6 +2,10 @@
 oci_fetch_row()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/field_funcs.phpt
+++ b/ext/oci8/tests/field_funcs.phpt
@@ -4,6 +4,7 @@ oci_field_*() family
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/field_funcs1.phpt
+++ b/ext/oci8/tests/field_funcs1.phpt
@@ -2,6 +2,10 @@
 oci_field_*() family: error cases
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/field_funcs2.phpt
+++ b/ext/oci8/tests/field_funcs2.phpt
@@ -2,6 +2,10 @@
 Bug #41917 (invalid scale and precision)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/field_funcs3.phpt
+++ b/ext/oci8/tests/field_funcs3.phpt
@@ -2,6 +2,10 @@
 oci_field_*() family: basic column types
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/imp_res_1.phpt
+++ b/ext/oci8/tests/imp_res_1.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: basic test
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_2.phpt
+++ b/ext/oci8/tests/imp_res_2.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: Zero Rows
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_3.phpt
+++ b/ext/oci8/tests/imp_res_3.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: bigger data size
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_4.phpt
+++ b/ext/oci8/tests/imp_res_4.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_fetch
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_5.phpt
+++ b/ext/oci8/tests/imp_res_5.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_fetch_all
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_6.phpt
+++ b/ext/oci8/tests/imp_res_6.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: alternating oci_fetch_* calls
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_7.phpt
+++ b/ext/oci8/tests/imp_res_7.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: bigger data size
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_call_error.phpt
+++ b/ext/oci8/tests/imp_res_call_error.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: using SQL 'CALL'
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_cancel.phpt
+++ b/ext/oci8/tests/imp_res_cancel.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_cancel
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_close.phpt
+++ b/ext/oci8/tests/imp_res_close.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_free_statement #1
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_cursor.phpt
+++ b/ext/oci8/tests/imp_res_cursor.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: nested cursor
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_dbmsoutput.phpt
+++ b/ext/oci8/tests/imp_res_dbmsoutput.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: interleaved with DBMS_OUTPUT
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_field.phpt
+++ b/ext/oci8/tests/imp_res_field.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: field tests
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_func_error.phpt
+++ b/ext/oci8/tests/imp_res_func_error.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: test with a PL/SQL function
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_1.phpt
+++ b/ext/oci8/tests/imp_res_get_1.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: basic test
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_2.phpt
+++ b/ext/oci8/tests/imp_res_get_2.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: similar to
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_3.phpt
+++ b/ext/oci8/tests/imp_res_get_3.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: basic test
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_4.phpt
+++ b/ext/oci8/tests/imp_res_get_4.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: interleave
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_5.phpt
+++ b/ext/oci8/tests/imp_res_get_5.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: get from w
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_all.phpt
+++ b/ext/oci8/tests/imp_res_get_all.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: oci_fetch_
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_cancel.phpt
+++ b/ext/oci8/tests/imp_res_get_cancel.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: oci_cancel
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_close_1.phpt
+++ b/ext/oci8/tests/imp_res_get_close_1.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: oci_free_s
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_close_2.phpt
+++ b/ext/oci8/tests/imp_res_get_close_2.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: oci_free_s
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_close_3.phpt
+++ b/ext/oci8/tests/imp_res_get_close_3.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: oci_free_s
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_cursor.phpt
+++ b/ext/oci8/tests/imp_res_get_cursor.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: nested cur
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_dbmsoutput.phpt
+++ b/ext/oci8/tests/imp_res_get_dbmsoutput.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: interleave
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_exec.phpt
+++ b/ext/oci8/tests/imp_res_get_exec.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: Execute tw
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_get_none.phpt
+++ b/ext/oci8/tests/imp_res_get_none.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: oci_get_implicit_resultset: no implici
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_insert.phpt
+++ b/ext/oci8/tests/imp_res_insert.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: Commit modes
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_lob.phpt
+++ b/ext/oci8/tests/imp_res_lob.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: LOBs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/imp_res_prefetch.phpt
+++ b/ext/oci8/tests/imp_res_prefetch.phpt
@@ -4,6 +4,7 @@ Oracle Database 12c Implicit Result Sets: basic test
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);

--- a/ext/oci8/tests/lob_001.phpt
+++ b/ext/oci8/tests/lob_001.phpt
@@ -4,6 +4,7 @@ oci_lob_write() and friends
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_002.phpt
+++ b/ext/oci8/tests/lob_002.phpt
@@ -4,6 +4,7 @@ oci_lob_write() and friends (with errors)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_003.phpt
+++ b/ext/oci8/tests/lob_003.phpt
@@ -4,6 +4,7 @@ oci_lob_read() and friends
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_004.phpt
+++ b/ext/oci8/tests/lob_004.phpt
@@ -4,6 +4,7 @@ oci_lob_seek()/rewind()/append()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_005.phpt
+++ b/ext/oci8/tests/lob_005.phpt
@@ -4,6 +4,7 @@ oci_lob_is_equal()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_006.phpt
+++ b/ext/oci8/tests/lob_006.phpt
@@ -4,6 +4,7 @@ oci_lob_write()/truncate()/erase()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_007.phpt
+++ b/ext/oci8/tests/lob_007.phpt
@@ -4,6 +4,7 @@ oci_lob_write()/size()/load()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_008.phpt
+++ b/ext/oci8/tests/lob_008.phpt
@@ -4,6 +4,7 @@ oci_lob_write()/read()/eof()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_009.phpt
+++ b/ext/oci8/tests/lob_009.phpt
@@ -4,6 +4,7 @@ oci_lob_import()/read()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_010.phpt
+++ b/ext/oci8/tests/lob_010.phpt
@@ -4,6 +4,7 @@ oci_lob_save()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_011.phpt
+++ b/ext/oci8/tests/lob_011.phpt
@@ -4,6 +4,7 @@ oci_lob_copy()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_012.phpt
+++ b/ext/oci8/tests/lob_012.phpt
@@ -4,6 +4,7 @@ oci_lob_export()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_013.phpt
+++ b/ext/oci8/tests/lob_013.phpt
@@ -4,6 +4,7 @@ lob buffering
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_014.phpt
+++ b/ext/oci8/tests/lob_014.phpt
@@ -4,6 +4,7 @@ oci_lob_free()/close()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_016.phpt
+++ b/ext/oci8/tests/lob_016.phpt
@@ -4,6 +4,7 @@ returning multiple lobs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_017.phpt
+++ b/ext/oci8/tests/lob_017.phpt
@@ -4,6 +4,7 @@ returning multiple lobs (using persistent connection)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_018.phpt
+++ b/ext/oci8/tests/lob_018.phpt
@@ -4,6 +4,7 @@ fetching the same lob several times
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_019.phpt
+++ b/ext/oci8/tests/lob_019.phpt
@@ -4,6 +4,7 @@ oci_lob_write()/erase()/read() with BLOBs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_020.phpt
+++ b/ext/oci8/tests/lob_020.phpt
@@ -4,6 +4,7 @@ oci_lob_write()/erase()/read() with CLOBs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_021.phpt
+++ b/ext/oci8/tests/lob_021.phpt
@@ -4,6 +4,7 @@ oci_lob_free()/close()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_022.phpt
+++ b/ext/oci8/tests/lob_022.phpt
@@ -4,6 +4,7 @@ fetching the same lob several times
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_023.phpt
+++ b/ext/oci8/tests/lob_023.phpt
@@ -4,6 +4,7 @@ oci_lob_import()/read()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_024.phpt
+++ b/ext/oci8/tests/lob_024.phpt
@@ -4,6 +4,7 @@ oci_lob_load()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_025.phpt
+++ b/ext/oci8/tests/lob_025.phpt
@@ -4,6 +4,7 @@ oci_lob_read() tests
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_026.phpt
+++ b/ext/oci8/tests/lob_026.phpt
@@ -4,6 +4,7 @@ oci_lob_seek()/rewind()/append()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_027.phpt
+++ b/ext/oci8/tests/lob_027.phpt
@@ -4,6 +4,7 @@ oci_lob_truncate()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_028.phpt
+++ b/ext/oci8/tests/lob_028.phpt
@@ -4,6 +4,7 @@ Test descriptor types for oci_new_descriptor()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_029.phpt
+++ b/ext/oci8/tests/lob_029.phpt
@@ -4,6 +4,7 @@ reading/writing BFILE LOBs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ob_start();

--- a/ext/oci8/tests/lob_030.phpt
+++ b/ext/oci8/tests/lob_030.phpt
@@ -4,6 +4,7 @@ Test piecewise fetch of CLOBs equal to, and larger than PHP_OCI_LOB_BUFFER_SIZE
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_031.phpt
+++ b/ext/oci8/tests/lob_031.phpt
@@ -4,6 +4,7 @@ Test LOB->read(), LOB->seek() and LOB->tell() with nul bytes in data
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_032.phpt
+++ b/ext/oci8/tests/lob_032.phpt
@@ -4,6 +4,7 @@ oci_lob_write() and friends
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_033.phpt
+++ b/ext/oci8/tests/lob_033.phpt
@@ -4,6 +4,7 @@ various oci_lob_write() error messages
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_034.phpt
+++ b/ext/oci8/tests/lob_034.phpt
@@ -4,6 +4,7 @@ lob buffering - 2
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_035.phpt
+++ b/ext/oci8/tests/lob_035.phpt
@@ -4,6 +4,7 @@ oci_lob_copy() - 2
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_036.phpt
+++ b/ext/oci8/tests/lob_036.phpt
@@ -4,6 +4,7 @@ Exercise cleanup code when LOB buffering is on
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_037.phpt
+++ b/ext/oci8/tests/lob_037.phpt
@@ -4,6 +4,7 @@ Fetching two different lobs and using them after fetch
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_038.phpt
+++ b/ext/oci8/tests/lob_038.phpt
@@ -4,6 +4,7 @@ Array fetch CLOB and BLOB
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_039.phpt
+++ b/ext/oci8/tests/lob_039.phpt
@@ -4,6 +4,7 @@ Test CLOB->write() for multiple inserts
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_040.phpt
+++ b/ext/oci8/tests/lob_040.phpt
@@ -4,6 +4,7 @@ Bug #37706 (Test LOB locator reuse. Extends simple test of lob_037.phpt)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_041.phpt
+++ b/ext/oci8/tests/lob_041.phpt
@@ -4,6 +4,7 @@ Check LOBS are valid after statement free
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_042.phpt
+++ b/ext/oci8/tests/lob_042.phpt
@@ -4,6 +4,7 @@ Check various LOB error messages
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_043.phpt
+++ b/ext/oci8/tests/lob_043.phpt
@@ -4,6 +4,7 @@ Bug #49560 (LOB resource destructor and refcount test)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');

--- a/ext/oci8/tests/lob_044.phpt
+++ b/ext/oci8/tests/lob_044.phpt
@@ -4,6 +4,7 @@ oci_lob_truncate() with default parameter value
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_aliases.phpt
+++ b/ext/oci8/tests/lob_aliases.phpt
@@ -2,11 +2,6 @@
 LOB method aliases
 --EXTENSIONS--
 oci8
---SKIPIF--
-<?php
-$target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
-require(__DIR__.'/skipif.inc');
-?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/lob_null.phpt
+++ b/ext/oci8/tests/lob_null.phpt
@@ -4,6 +4,7 @@ Test null data for CLOBs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_prefetch.phpt
+++ b/ext/oci8/tests/lob_prefetch.phpt
@@ -4,6 +4,7 @@ LOB prefetching
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_prefetch_ini.phpt
+++ b/ext/oci8/tests/lob_prefetch_ini.phpt
@@ -4,6 +4,7 @@ LOB prefetching with oci8.
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_temp.phpt
+++ b/ext/oci8/tests/lob_temp.phpt
@@ -4,6 +4,7 @@ temporary lobs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_temp1.phpt
+++ b/ext/oci8/tests/lob_temp1.phpt
@@ -4,6 +4,7 @@ closing temporary lobs
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/lob_temp2.phpt
+++ b/ext/oci8/tests/lob_temp2.phpt
@@ -4,6 +4,7 @@ Writing temporary lob before binding
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/null_byte_1.phpt
+++ b/ext/oci8/tests/null_byte_1.phpt
@@ -4,6 +4,7 @@ Protect against null bytes in LOB filenames
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 if (PHP_MAJOR_VERSION < 5 || (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 4))
     die ("skip Test only valid for PHP 5.4 onwards");
 ?>

--- a/ext/oci8/tests/null_byte_2.phpt
+++ b/ext/oci8/tests/null_byte_2.phpt
@@ -4,6 +4,7 @@ Null bytes in SQL statements
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/null_byte_3.phpt
+++ b/ext/oci8/tests/null_byte_3.phpt
@@ -2,6 +2,10 @@
 Null bytes in SQL statements
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 display_errors = On
 error_reporting = E_WARNING

--- a/ext/oci8/tests/num.phpt
+++ b/ext/oci8/tests/num.phpt
@@ -2,6 +2,10 @@
 oci_num_*() family
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/oci_execute_segfault.phpt
+++ b/ext/oci8/tests/oci_execute_segfault.phpt
@@ -4,6 +4,7 @@ oci_execute() segfault after repeated bind of LOB descriptor
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/old_oci_close.phpt
+++ b/ext/oci8/tests/old_oci_close.phpt
@@ -2,6 +2,10 @@
 oci8.old_oci_close_semantics On
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=1
 --FILE--

--- a/ext/oci8/tests/old_oci_close1.phpt
+++ b/ext/oci8/tests/old_oci_close1.phpt
@@ -2,6 +2,10 @@
 oci8.old_oci_close_semantics Off
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.old_oci_close_semantics=0
 --FILE--

--- a/ext/oci8/tests/password.phpt
+++ b/ext/oci8/tests/password.phpt
@@ -4,8 +4,8 @@ oci_password_change() for non-persistent connections
 oci8
 --SKIPIF--
 <?php
-require(__DIR__."/details.inc");
-if (empty($dbase)) die ("skip requires database connection string be set");
+require_once('skipifconnectfailure.inc');
+if (is_null($dbase)) die ("skip requires database connection string be set");
 if (strcasecmp($user, "system") && strcasecmp($user, "sys")) die("skip needs to be run as a DBA user");
 if ($test_drcp) die("skip password change not supported in DRCP Mode");
 ?>

--- a/ext/oci8/tests/password_2.phpt
+++ b/ext/oci8/tests/password_2.phpt
@@ -4,8 +4,8 @@ oci_password_change() for persistent connections
 oci8
 --SKIPIF--
 <?php
-require(__DIR__."/details.inc");
-if (empty($dbase)) die ("skip requires database connection string be set");
+require_once('skipifconnectfailure.inc');
+if (is_null($dbase)) die ("skip requires database connection string be set");
 if (strcasecmp($user, "system") && strcasecmp($user, "sys")) die("skip needs to be run as a DBA user");
 if ($test_drcp) die("skip password change not supported in DRCP Mode");
 ?>

--- a/ext/oci8/tests/password_new.phpt
+++ b/ext/oci8/tests/password_new.phpt
@@ -4,6 +4,7 @@ oci_password_change()
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 require(__DIR__.'/connect.inc');

--- a/ext/oci8/tests/pecl_bug10194.phpt
+++ b/ext/oci8/tests/pecl_bug10194.phpt
@@ -4,6 +4,7 @@ PECL Bug #10194 (segfault in Instant Client when memory_limit is reached inside 
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');

--- a/ext/oci8/tests/pecl_bug10194_blob.phpt
+++ b/ext/oci8/tests/pecl_bug10194_blob.phpt
@@ -4,6 +4,7 @@ PECL Bug #10194 (segfault in Instant Client when memory_limit is reached inside 
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platforms only");

--- a/ext/oci8/tests/pecl_bug10194_blob_64.phpt
+++ b/ext/oci8/tests/pecl_bug10194_blob_64.phpt
@@ -4,6 +4,7 @@ PECL Bug #10194 (segfault in Instant Client when memory_limit is reached inside 
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on thes
 require(__DIR__.'/skipif.inc');
 if (getenv('SKIP_SLOW_TESTS')) die('skip slow tests excluded by request');

--- a/ext/oci8/tests/pecl_bug16842.phpt
+++ b/ext/oci8/tests/pecl_bug16842.phpt
@@ -4,6 +4,7 @@ PECL Bug #16842 (NO_DATA_FOUND exception is a warning)
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/pecl_bug6109.phpt
+++ b/ext/oci8/tests/pecl_bug6109.phpt
@@ -2,6 +2,10 @@
 PECL Bug #6109 (Error messages not kept)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/pecl_bug8816.phpt
+++ b/ext/oci8/tests/pecl_bug8816.phpt
@@ -4,6 +4,7 @@ PECL Bug #8816 (issue in php_oci_statement_fetch with more than one piecewise co
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/persistent.phpt
+++ b/ext/oci8/tests/persistent.phpt
@@ -2,6 +2,10 @@
 reusing persistent connections
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/prefetch.phpt
+++ b/ext/oci8/tests/prefetch.phpt
@@ -2,6 +2,10 @@
 oci_set_prefetch()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/privileged_connect.phpt
+++ b/ext/oci8/tests/privileged_connect.phpt
@@ -2,6 +2,10 @@
 privileged connect tests
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/privileged_connect1.phpt
+++ b/ext/oci8/tests/privileged_connect1.phpt
@@ -3,7 +3,8 @@ privileged connect tests
 --EXTENSIONS--
 oci8
 --SKIPIF--
-<?php 
+<?php
+require_once('skipifconnectfailure.inc');
 if (getenv('SKIP_ASAN')) die('xleak leaks memory under asan');
 ?>
 --INI--

--- a/ext/oci8/tests/refcur_prefetch_1.phpt
+++ b/ext/oci8/tests/refcur_prefetch_1.phpt
@@ -3,7 +3,9 @@ Prefetch with REF cursor. Test different values for prefetch with oci_set_prefet
 --EXTENSIONS--
 oci8
 --SKIPIF--
-<?php require(__DIR__."/connect.inc");
+<?php
+require_once('skipifconnectfailure.inc');
+require(__DIR__."/connect.inc");
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);
 if (!(isset($matches[0]) &&
       ($matches[1] >= 10))) {

--- a/ext/oci8/tests/refcur_prefetch_2.phpt
+++ b/ext/oci8/tests/refcur_prefetch_2.phpt
@@ -3,7 +3,9 @@ Prefetch with REF cursor. Test No 2
 --EXTENSIONS--
 oci8
 --SKIPIF--
-<?php require(__DIR__."/connect.inc");
+<?php
+require_once('skipifconnectfailure.inc');
+require(__DIR__."/connect.inc");
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);
 if (!(isset($matches[0]) &&
       ($matches[1] >= 10))) {

--- a/ext/oci8/tests/refcur_prefetch_3.phpt
+++ b/ext/oci8/tests/refcur_prefetch_3.phpt
@@ -5,7 +5,9 @@ oci8.default_prefetch=5
 --EXTENSIONS--
 oci8
 --SKIPIF--
-<?php require(__DIR__."/connect.inc");
+<?php
+require_once('skipifconnectfailure.inc');
+require(__DIR__."/connect.inc");
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);
 if (!(isset($matches[0]) &&
       (($matches[1] == 11 && $matches[2] >= 2) ||

--- a/ext/oci8/tests/refcur_prefetch_4.phpt
+++ b/ext/oci8/tests/refcur_prefetch_4.phpt
@@ -3,7 +3,9 @@ Prefetch with REF cursor. Test No 4
 --EXTENSIONS--
 oci8
 --SKIPIF--
-<?php require(__DIR__."/connect.inc");
+<?php
+require_once('skipifconnectfailure.inc');
+require(__DIR__."/connect.inc");
 preg_match('/.*Release ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)*/', oci_server_version($c), $matches);
 if (!(isset($matches[0]) &&
       ($matches[1] >= 10))) {

--- a/ext/oci8/tests/select_null.phpt
+++ b/ext/oci8/tests/select_null.phpt
@@ -2,6 +2,10 @@
 SELECTing NULL values
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/serverversion.phpt
+++ b/ext/oci8/tests/serverversion.phpt
@@ -2,6 +2,10 @@
 oci_server_version()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/skipifconnectfailure.inc
+++ b/ext/oci8/tests/skipifconnectfailure.inc
@@ -1,0 +1,29 @@
+<?php
+
+require("details.inc");
+
+// the oci_connect parameter corresponding to $dbase defaults to null
+if (!isset($dbase)) {
+    $dbase = null;
+}
+
+$c = @oci_connect($user, $password, $dbase);
+
+if ($c) {
+    oci_close($c);
+}
+else {
+    $msg = "skip Failed to connect to Oracle instance ";
+    if (is_null($dbase)) {
+        $msg .= "<default>";
+    }
+    else {
+        $msg .= "\"$dbase\"";
+    }
+    $msg .= " as user \"$user\"";
+    $e = oci_error();
+    $msg .= ": {$e['message']}";
+    die($msg);
+}
+
+?>

--- a/ext/oci8/tests/skipifconnectfailure.inc
+++ b/ext/oci8/tests/skipifconnectfailure.inc
@@ -13,7 +13,7 @@ if ($c) {
     oci_close($c);
 }
 else {
-    $msg = "skip Failed to connect to Oracle instance ";
+    $msg = "skip Failed to connect to Oracle Database instance ";
     if (is_null($dbase)) {
         $msg .= "<default>";
     }

--- a/ext/oci8/tests/statement_cache.phpt
+++ b/ext/oci8/tests/statement_cache.phpt
@@ -4,6 +4,7 @@ statement cache
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => true);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/statement_type.phpt
+++ b/ext/oci8/tests/statement_type.phpt
@@ -2,6 +2,10 @@
 oci_statement_type()
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/testping.phpt
+++ b/ext/oci8/tests/testping.phpt
@@ -2,6 +2,10 @@
 Exercise OCIPing functionality on reconnect (code coverage test)
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --INI--
 oci8.ping_interval=0
 --FILE--

--- a/ext/oci8/tests/uncommitted.phpt
+++ b/ext/oci8/tests/uncommitted.phpt
@@ -2,6 +2,10 @@
 uncommitted connection
 --EXTENSIONS--
 oci8
+--SKIPIF--
+<?php
+require_once('skipifconnectfailure.inc');
+?>
 --FILE--
 <?php
 

--- a/ext/oci8/tests/xmltype_01.phpt
+++ b/ext/oci8/tests/xmltype_01.phpt
@@ -5,6 +5,7 @@ simplexml
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>

--- a/ext/oci8/tests/xmltype_02.phpt
+++ b/ext/oci8/tests/xmltype_02.phpt
@@ -5,6 +5,7 @@ simplexml
 oci8
 --SKIPIF--
 <?php
+require_once('skipifconnectfailure.inc');
 $target_dbs = array('oracledb' => true, 'timesten' => false);  // test runs on these DBs
 require(__DIR__.'/skipif.inc');
 ?>


### PR DESCRIPTION
This is basically a copy/paste of the mysqli and pgsql approaches. Only a few editorial decisions were made:

1. I have declined to include `skipifconnectfailure.inc` within the pre-existing `skipif.inc`. The check in `skipif.inc` is for one specific condition (the type of the database) and is not universal; keeping them separate results in us having one logical "skip" check per include file. This comes at the expense of a few extra lines, but I think the end result is cleaner, and would be especially nice if `skipif.inc` was renamed to something like `skipifwrongdbtype.inc`.
2. To avoid an extra case, I've set `$dbase` (from `details.inc`) to `null` if it is unset. As a result, two `empty()` checks in  `ext/oci8/tests/password.phpt` and `ext/oci8/tests/password_2.phpt` have to be changed to `is_null()`.