### PR TITLE
Fix uaf of MBSTRG(all_encodings_list)

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -1159,8 +1159,7 @@ PHP_RSHUTDOWN_FUNCTION(mbstring)
 
 	if (MBSTRG(all_encodings_list)) {
 		GC_DELREF(MBSTRG(all_encodings_list));
-		zend_hash_destroy(MBSTRG(all_encodings_list));
-		efree(MBSTRG(all_encodings_list));
+		zend_array_destroy(MBSTRG(all_encodings_list));
 		MBSTRG(all_encodings_list) = NULL;
 	}
 

--- a/ext/mbstring/tests/mb_list_encodings_gc_uaf.phpt
+++ b/ext/mbstring/tests/mb_list_encodings_gc_uaf.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Use-after-free of MBSTRG(all_encodings_list) on shutdown
+--EXTENSIONS--
+mbstring
+--FILE--
+<?php
+mb_list_encodings();
+?>
+--EXPECT--


### PR DESCRIPTION
We need to remove the value from the GC buffer before freeing it. Otherwise shutdown will uaf when running the gc.