### PR TITLE
Move --enable/--disable-fiber-asm help output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1255,13 +1255,13 @@ fi
 dnl Configuring Zend and TSRM.
 dnl ----------------------------------------------------------------------------
 
+PHP_HELP_SEPARATOR([Zend:])
+PHP_CONFIGURE_PART(Configuring Zend)
+
 AC_ARG_ENABLE([fiber-asm],
   [AS_HELP_STRING([--disable-fiber-asm],
     [Disable the use of boost fiber assembly files])],
   [fiber_asm=$enableval], [fiber_asm='yes'])
-
-PHP_HELP_SEPARATOR([Zend:])
-PHP_CONFIGURE_PART(Configuring Zend)
 
 AS_CASE([$host_cpu],
   [x86_64*|amd64*], [fiber_cpu="x86_64"],
@@ -1375,7 +1375,6 @@ fi
 ZEND_EXTRA_LIBS="$LIBS"
 unset LIBS
 
-PHP_HELP_SEPARATOR([TSRM:])
 PHP_CONFIGURE_PART(Configuring TSRM)
 if test "$PHP_THREAD_SAFETY" = "yes"; then
   TSRM_CHECK_PTHREADS


### PR DESCRIPTION
This moves the fiber configure option in the Zend section. TSRM doesn't currently have any specific configure options so it can be removed from the `./configure --help` output.