### PR TITLE
Fix ldap_connec_wallet stub signature

### DIFF
--- a/ext/ldap/ldap.stub.php
+++ b/ext/ldap/ldap.stub.php
@@ -612,7 +612,7 @@ namespace {
 #ifdef HAVE_ORALDAP
     function ldap_connect(?string $uri = null, int $port = 389, string $wallet = UNKNOWN, #[\SensitiveParameter] string $password = UNKNOWN, int $auth_mode = GSLC_SSL_NO_AUTH): LDAP\Connection|false {}
 #ifdef LDAP_API_FEATURE_X_OPENLDAP
-    function ldap_connect_wallet(?string $uri = null, string $wallet, #[\SensitiveParameter] string $password, int $auth_mode = GSLC_SSL_NO_AUTH): LDAP\Connection|false {}
+    function ldap_connect_wallet(?string $uri, string $wallet, #[\SensitiveParameter] string $password, int $auth_mode = GSLC_SSL_NO_AUTH): LDAP\Connection|false {}
 #endif
 #else
     function ldap_connect(?string $uri = null, int $port = 389): LDAP\Connection|false {}


### PR DESCRIPTION
Fixes: 
`Optional parameter $uri declared before required parameter $password is implicitly treated as a required parameter` 
notice when copying the signature for polyfill purposes. 