### PR TITLE
Remove `mysqli.reconnect` from php.ini files

### DIFF
--- a/php.ini-development
+++ b/php.ini-development
@@ -1211,9 +1211,6 @@ mysqli.default_user =
 ; https://php.net/mysqli.default-pw
 mysqli.default_pw =
 
-; Allow or prevent reconnect
-mysqli.reconnect = Off
-
 ; If this option is enabled, closing a persistent connection will rollback
 ; any pending transactions of this connection, before it is put back
 ; into the persistent connection pool.

--- a/php.ini-production
+++ b/php.ini-production
@@ -1213,9 +1213,6 @@ mysqli.default_user =
 ; https://php.net/mysqli.default-pw
 mysqli.default_pw =
 
-; Allow or prevent reconnect
-mysqli.reconnect = Off
-
 ; If this option is enabled, closing a persistent connection will rollback
 ; any pending transactions of this connection, before it is put back
 ; into the persistent connection pool.


### PR DESCRIPTION
The `mysqli.reconnect` ini directive was removed in PHP 8.2.0.

👉🏻 A backport of this commit to the `8.2` branch should maybe be considered ?

Refs:
* https://github.com/php/php-src/blob/5d90c5057dbf88cea49ac53daf5f4622c1588a84/UPGRADING#L320
* https://github.com/php/php-src/pull/7889
* https://github.com/php/php-src/pull/7889/commits/be3d55d3111308a085700f2c409684b11d2ceeb0