### PR TITLE
PHP 8.3 Upgrading: fix typo

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -355,7 +355,7 @@ PHP 8.3 UPGRADE NOTES
   . Added posix_eaccess call to check the effective user id's permission for a path.
 
 - PGSQL:
-  . Added pg_set_error_context_visilibity to set the visibility of the context
+  . Added pg_set_error_context_visibility to set the visibility of the context
     in error messages (with libpq >= 9.6).
 
 - Random:


### PR DESCRIPTION
Ref: https://github.com/php/php-src/commit/21aaf3321fe47aa4e19a79616ca1966c212aa158