### PR TITLE
GH Actions: auto-skip CI on PRs containing only docs changes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,6 +16,14 @@ on:
       - PHP-8.2
       - master
   pull_request:
+    paths-ignore:
+      - docs/*
+      - NEWS
+      - UPGRADING
+      - UPGRADING.INTERNALS
+      - README.md
+      - CONTRIBUTING.md
+      - CODING_STANDARDS.md
     branches:
       - '**'
 permissions:


### PR DESCRIPTION
As per https://github.com/php/php-src/pull/11838#issuecomment-1658648817