### PR TITLE
Fix json_encode result on DOMDocument

### DIFF
--- a/ext/dom/php_dom.stub.php
+++ b/ext/dom/php_dom.stub.php
@@ -433,7 +433,7 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @readonly
      * @deprecated
      */
-    public mixed $config = null;
+    public mixed $config;
 
     public bool $formatOutput;
 

--- a/ext/dom/php_dom_arginfo.h
+++ b/ext/dom/php_dom_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a62e383b05df81ea245a7993215fb8ff4e1c7f9d */
+ * Stub hash: 20a0ff883af3bbf073d9c8bc8246646ffafe7818 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_dom_import_simplexml, 0, 1, DOMElement, 0)
 	ZEND_ARG_TYPE_INFO(0, node, IS_OBJECT, 0)
@@ -1436,7 +1436,7 @@ static zend_class_entry *register_class_DOMDocument(zend_class_entry *class_entr
 	zend_string_release(property_documentURI_name);
 
 	zval property_config_default_value;
-	ZVAL_NULL(&property_config_default_value);
+	ZVAL_UNDEF(&property_config_default_value);
 	zend_string *property_config_name = zend_string_init("config", sizeof("config") - 1, 1);
 	zend_declare_typed_property(class_entry, property_config_name, &property_config_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ANY));
 	zend_string_release(property_config_name);

--- a/ext/dom/tests/DOMDocument_json_encode.phpt
+++ b/ext/dom/tests/DOMDocument_json_encode.phpt
@@ -1,0 +1,11 @@
+--TEST--
+JSON encoding a DOMDocument
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+echo json_encode($doc);
+?>
+--EXPECT--
+{}

--- a/ext/dom/tests/domobject_debug_handler.phpt
+++ b/ext/dom/tests/domobject_debug_handler.phpt
@@ -16,8 +16,6 @@ var_dump($d);
 ?>
 --EXPECTF--
 object(DOMDocument)#1 (39) {
-  ["config"]=>
-  NULL
   ["dynamicProperty"]=>
   object(stdClass)#2 (0) {
   }
@@ -45,6 +43,8 @@ object(DOMDocument)#1 (39) {
   bool(true)
   ["documentURI"]=>
   string(%d) %s
+  ["config"]=>
+  NULL
   ["formatOutput"]=>
   bool(false)
   ["validateOnParse"]=>


### PR DESCRIPTION
According to https://www.php.net/manual/en/class.domdocument:
  When using json_encode() on a DOMDocument object the result will be
  that of encoding an empty object.

But this was broken in 8.1. The output was `{"config": null}`. That's because the config property is defined with a default value of NULL, hence it was included. The other properties are not included because they don't have a default property, and nothing is ever written to their backing field. Hence, the JSON encoder excludes them. Similarly, `(array) $doc` would yield the same `config` key in the array.