### PR TITLE
Disable global state test on Windows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,13 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.0.30
 
+- Libxml:
+  . Fixed bug GHSA-3qrf-m4j2-pcrr (Security issue with external entity loading
+    in XML without enabling it). (nielsdos, ilutov)
+
+- Phar:
+  . Fixed bug GHSA-jqcx-ccgc-xwhv (Buffer mismanagement in phar_dir_read()).
+    (nielsdos)
 
 08 Jun 2023, PHP 8.0.29
 

--- a/NEWS
+++ b/NEWS
@@ -4,11 +4,11 @@ PHP                                                                        NEWS
 
 - Libxml:
   . Fixed bug GHSA-3qrf-m4j2-pcrr (Security issue with external entity loading
-    in XML without enabling it). (nielsdos, ilutov)
+    in XML without enabling it). (CVE-2023-3823) (nielsdos, ilutov)
 
 - Phar:
   . Fixed bug GHSA-jqcx-ccgc-xwhv (Buffer mismanagement in phar_dir_read()).
-    (nielsdos)
+    (CVE-2023-3824) (nielsdos)
 
 08 Jun 2023, PHP 8.0.29
 

--- a/ext/dom/tests/libxml_global_state_entity_loader_bypass.phpt
+++ b/ext/dom/tests/libxml_global_state_entity_loader_bypass.phpt
@@ -5,6 +5,7 @@ GHSA-3qrf-m4j2-pcrr (libxml global state entity loader bypass)
 if (!extension_loaded('libxml')) die('skip libxml extension not available');
 if (!extension_loaded('dom')) die('skip dom extension not available');
 if (!extension_loaded('zend-test')) die('skip zend-test extension not available');
+if (!function_exists('zend_test_override_libxml_global_state')) die('skip not for Windows');
 ?>
 --FILE--
 <?php

--- a/ext/simplexml/tests/libxml_global_state_entity_loader_bypass.phpt
+++ b/ext/simplexml/tests/libxml_global_state_entity_loader_bypass.phpt
@@ -5,6 +5,7 @@ GHSA-3qrf-m4j2-pcrr (libxml global state entity loader bypass)
 if (!extension_loaded('libxml')) die('skip libxml extension not available');
 if (!extension_loaded('simplexml')) die('skip simplexml extension not available');
 if (!extension_loaded('zend-test')) die('skip zend-test extension not available');
+if (!function_exists('zend_test_override_libxml_global_state')) die('skip not for Windows');
 ?>
 --FILE--
 <?php

--- a/ext/xmlreader/tests/libxml_global_state_entity_loader_bypass.phpt
+++ b/ext/xmlreader/tests/libxml_global_state_entity_loader_bypass.phpt
@@ -5,6 +5,7 @@ GHSA-3qrf-m4j2-pcrr (libxml global state entity loader bypass)
 if (!extension_loaded('libxml')) die('skip libxml extension not available');
 if (!extension_loaded('xmlreader')) die('skip xmlreader extension not available');
 if (!extension_loaded('zend-test')) die('skip zend-test extension not available');
+if (!function_exists('zend_test_override_libxml_global_state')) die('skip not for Windows');
 ?>
 --FILE--
 <?php

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -29,7 +29,7 @@
 #include "zend_smart_str.h"
 #include "zend_weakrefs.h"
 
-#ifdef HAVE_LIBXML
+#if defined(HAVE_LIBXML) && !defined(PHP_WIN32)
 # include <libxml/globals.h>
 # include <libxml/parser.h>
 #endif
@@ -275,6 +275,7 @@ static ZEND_FUNCTION(zend_get_current_func_name)
     RETURN_STR(function_name);
 }
 
+#if defined(HAVE_LIBXML) && !defined(PHP_WIN32)
 static ZEND_FUNCTION(zend_test_override_libxml_global_state)
 {
 	ZEND_PARSE_PARAMETERS_NONE();
@@ -286,6 +287,7 @@ static ZEND_FUNCTION(zend_test_override_libxml_global_state)
 	(void) xmlLineNumbersDefault(1);
 	(void) xmlKeepBlanksDefault(0);
 }
+#endif
 
 /* TESTS Z_PARAM_ITERABLE and Z_PARAM_ITERABLE_OR_NULL */
 static ZEND_FUNCTION(zend_iterable)

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -68,7 +68,7 @@ function zend_weakmap_dump(): array {}
 
 function zend_get_current_func_name(): string {}
 
-#ifdef HAVE_LIBXML
+#if defined(HAVE_LIBXML) && !defined(PHP_WIN32)
 function zend_test_override_libxml_global_state(): void {}
 #endif
 

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8cfd05fb9f7524837d23f92b185fcd30f964521f */
+ * Stub hash: eb79a01021e58731bfbefab320569fbb0997276a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -65,7 +65,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_get_current_func_name, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-#if defined(HAVE_LIBXML)
+#if defined(HAVE_LIBXML) && !defined(PHP_WIN32)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_override_libxml_global_state, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 #endif
@@ -106,7 +106,7 @@ static ZEND_FUNCTION(zend_weakmap_attach);
 static ZEND_FUNCTION(zend_weakmap_remove);
 static ZEND_FUNCTION(zend_weakmap_dump);
 static ZEND_FUNCTION(zend_get_current_func_name);
-#if defined(HAVE_LIBXML)
+#if defined(HAVE_LIBXML) && !defined(PHP_WIN32)
 static ZEND_FUNCTION(zend_test_override_libxml_global_state);
 #endif
 static ZEND_FUNCTION(namespaced_func);
@@ -136,7 +136,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_weakmap_remove, arginfo_zend_weakmap_remove)
 	ZEND_FE(zend_weakmap_dump, arginfo_zend_weakmap_dump)
 	ZEND_FE(zend_get_current_func_name, arginfo_zend_get_current_func_name)
-#if defined(HAVE_LIBXML)
+#if defined(HAVE_LIBXML) && !defined(PHP_WIN32)
 	ZEND_FE(zend_test_override_libxml_global_state, arginfo_zend_test_override_libxml_global_state)
 #endif
 	ZEND_NS_FE("ZendTestNS2\\ZendSubNS", namespaced_func, arginfo_ZendTestNS2_ZendSubNS_namespaced_func)


### PR DESCRIPTION
It looks like the config.w32 uses CHECK_HEADER_ADD_INCLUDE to add the include path to libxml into the search path.
That doesn't happen in zend-test.
To add to the Windows trouble, libxml is statically linked in, ext/libxml can only be built statically but ext/zend-test can be built both statically and dynamically.
So the regression tests won't work in all possible configurations anyway on Windows. All of this is no problem on Linux because it just uses dynamic linking and pkg-config, without any magic.