### PR TITLE
inc/dec with undefined vars

### DIFF
--- a/Zend/tests/in-de-crement/incdec_undefined_vars_exception.phpt
+++ b/Zend/tests/in-de-crement/incdec_undefined_vars_exception.phpt
@@ -12,28 +12,28 @@ try {
     $x++;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (compact('x') == []) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     $x--;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (compact('x') == []) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     ++$x;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (compact('x') == []) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     --$x;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (compact('x') == []) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 ?>

--- a/Zend/tests/in-de-crement/incdec_undefined_vars_exception.phpt
+++ b/Zend/tests/in-de-crement/incdec_undefined_vars_exception.phpt
@@ -12,37 +12,37 @@ try {
     $x++;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     $x--;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     ++$x;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     --$x;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 ?>
 --EXPECT--
 Undefined variable $x
-UNDEF
+NULL
 Undefined variable $x
-UNDEF
+NULL
 Undefined variable $x
-UNDEF
+NULL
 Undefined variable $x
-UNDEF
+NULL

--- a/Zend/tests/in-de-crement/incdec_undefined_vars_exception.phpt
+++ b/Zend/tests/in-de-crement/incdec_undefined_vars_exception.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Inc/dec on undefined variable: warning converted to exception
+--FILE--
+<?php
+
+set_error_handler(function($severity, $m) {
+    throw new Exception($m, $severity);
+});
+
+unset($x);
+try {
+    $x++;
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+}
+unset($x);
+try {
+    $x--;
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+}
+unset($x);
+try {
+    ++$x;
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+}
+unset($x);
+try {
+    --$x;
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+}
+unset($x);
+?>
+--EXPECT--
+Undefined variable $x
+UNDEF
+Undefined variable $x
+UNDEF
+Undefined variable $x
+UNDEF
+Undefined variable $x
+UNDEF

--- a/Zend/tests/in-de-crement/incdec_undefined_vars_exception_use_result_op.phpt
+++ b/Zend/tests/in-de-crement/incdec_undefined_vars_exception_use_result_op.phpt
@@ -12,37 +12,37 @@ try {
     $y = $x++;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     $y = $x--;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     $y = ++$x;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     $y = --$x;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 ?>
 --EXPECT--
 Undefined variable $x
-UNDEF
+NULL
 Undefined variable $x
-UNDEF
+NULL
 Undefined variable $x
-UNDEF
+NULL
 Undefined variable $x
-UNDEF
+NULL

--- a/Zend/tests/in-de-crement/incdec_undefined_vars_exception_use_result_op.phpt
+++ b/Zend/tests/in-de-crement/incdec_undefined_vars_exception_use_result_op.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Inc/dec on undefined variable: warning converted to exception
+--FILE--
+<?php
+
+set_error_handler(function($severity, $m) {
+    throw new Exception($m, $severity);
+});
+
+unset($x);
+try {
+    $y = $x++;
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+}
+unset($x);
+try {
+    $y = $x--;
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+}
+unset($x);
+try {
+    $y = ++$x;
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+}
+unset($x);
+try {
+    $y = --$x;
+} catch (\Exception $e) {
+    echo $e->getMessage(), PHP_EOL;
+    if (!isset($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+}
+unset($x);
+?>
+--EXPECT--
+Undefined variable $x
+UNDEF
+Undefined variable $x
+UNDEF
+Undefined variable $x
+UNDEF
+Undefined variable $x
+UNDEF

--- a/Zend/tests/in-de-crement/incdec_undefined_vars_exception_use_result_op.phpt
+++ b/Zend/tests/in-de-crement/incdec_undefined_vars_exception_use_result_op.phpt
@@ -12,28 +12,28 @@ try {
     $y = $x++;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (compact('x') == []) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     $y = $x--;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (compact('x') == []) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     $y = ++$x;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (compact('x') == []) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 try {
     $y = --$x;
 } catch (\Exception $e) {
     echo $e->getMessage(), PHP_EOL;
-    if (!isset($x) && !@is_null($x)) { echo("UNDEF\n"); } else { var_dump($x); }
+    if (compact('x') == []) { echo("UNDEF\n"); } else { var_dump($x); }
 }
 unset($x);
 ?>

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1487,6 +1487,13 @@ ZEND_VM_HELPER(zend_pre_inc_helper, VAR|CV, ANY)
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -1538,6 +1545,13 @@ ZEND_VM_HELPER(zend_pre_dec_helper, VAR|CV, ANY)
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -1590,6 +1604,13 @@ ZEND_VM_HELPER(zend_post_inc_helper, VAR|CV, ANY)
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -1641,6 +1662,13 @@ ZEND_VM_HELPER(zend_post_dec_helper, VAR|CV, ANY)
 	SAVE_OPLINE();
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -1488,7 +1488,7 @@ ZEND_VM_HELPER(zend_pre_inc_helper, VAR|CV, ANY)
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -1546,7 +1546,7 @@ ZEND_VM_HELPER(zend_pre_dec_helper, VAR|CV, ANY)
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -1605,7 +1605,7 @@ ZEND_VM_HELPER(zend_post_inc_helper, VAR|CV, ANY)
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -1663,7 +1663,7 @@ ZEND_VM_HELPER(zend_post_dec_helper, VAR|CV, ANY)
 	if (OP1_TYPE == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -21611,6 +21611,13 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_inc_help
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -21680,6 +21687,13 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_dec_help
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -21750,6 +21764,13 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_inc_hel
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -21801,6 +21822,13 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_dec_hel
 	SAVE_OPLINE();
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -38980,6 +39008,13 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_inc_help
 	SAVE_OPLINE();
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -39048,6 +39083,13 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_dec_help
 	SAVE_OPLINE();
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -39117,6 +39159,13 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_inc_hel
 	SAVE_OPLINE();
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 
@@ -39167,6 +39216,13 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_dec_hel
 	SAVE_OPLINE();
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
+		if (UNEXPECTED(EG(exception))) {
+			/* Smart branch expects result to be set with exceptions */
+			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
+				ZVAL_NULL(EX_VAR(opline->result.var));
+			}
+			HANDLE_EXCEPTION();
+		}
 		ZVAL_NULL(var_ptr);
 	}
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -21612,7 +21612,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_inc_help
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -21688,7 +21688,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_dec_help
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -21765,7 +21765,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_inc_hel
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -21823,7 +21823,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_dec_hel
 	if (IS_VAR == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -39009,7 +39009,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_inc_help
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -39084,7 +39084,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_pre_dec_help
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -39160,7 +39160,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_inc_hel
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}
@@ -39217,7 +39217,7 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_post_dec_hel
 	if (IS_CV == IS_CV && UNEXPECTED(Z_TYPE_P(var_ptr) == IS_UNDEF)) {
 		ZVAL_UNDEFINED_OP1();
 		if (UNEXPECTED(EG(exception))) {
-			/* Smart branch expects result to be set with exceptions */
+			/* opcodes are expected to set the result value */
 			if (UNEXPECTED(RETURN_VALUE_USED(opline))) {
 				ZVAL_NULL(EX_VAR(opline->result.var));
 			}

--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -3883,6 +3883,8 @@ static int zend_jit_inc_dec(dasm_State **Dst, const zend_op *opline, uint32_t op
 				|	// zend_error(E_WARNING, "Undefined variable $%s", ZSTR_VAL(CV_DEF_OF(EX_VAR_TO_NUM(opline->op1.var))));
 				|	LOAD_32BIT_VAL FCARG1w, opline->op1.var
 				|	EXT_CALL zend_jit_undefined_op_helper, REG0
+				|	// Check if undefined error was converted to exception and abort
+				|	cbz RETVALx, ->exception_handler_undef
 				|	SET_ZVAL_TYPE_INFO op1_addr, IS_NULL, TMP1w, TMP2
 				op1_info |= MAY_BE_NULL;
 			}

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -4264,6 +4264,9 @@ static int zend_jit_inc_dec(dasm_State **Dst, const zend_op *opline, uint32_t op
 				|	mov FCARG1d, opline->op1.var
 				|	EXT_CALL zend_jit_undefined_op_helper, r0
 				|	SET_ZVAL_TYPE_INFO op1_addr, IS_NULL
+				|	// Check if undefined error was converted to exception and abort
+				|	test r0, r0
+				|	jz ->exception_handler_undef
 				op1_info |= MAY_BE_NULL;
 			}
 			|2:


### PR DESCRIPTION
I split the first commit from #11759 into its own PR as it is not an OSS-fuzz fix, and like said it is a pre-existing issue so maybe should be backported.

The rationale is that, considering undefined variables will become Errors at one point, the behaviour of this and what happens now when the warning is converted to an exception should be, IMHO, identical.

However, it seems that a lot of the VM handlers that use ``ZVAL_UNDEFINED_OP1()`` do not explicitly check if an exception is thrown from an undefined operand.