### PR TITLE
ext/zend_test: Move object handler test objects to their own file

### DIFF
--- a/ext/zend_test/config.m4
+++ b/ext/zend_test/config.m4
@@ -4,5 +4,5 @@ PHP_ARG_ENABLE([zend-test],
     [Enable zend_test extension])])
 
 if test "$PHP_ZEND_TEST" != "no"; then
-  PHP_NEW_EXTENSION(zend_test, test.c observer.c fiber.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+  PHP_NEW_EXTENSION(zend_test, test.c observer.c fiber.c object_handlers.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 fi

--- a/ext/zend_test/config.w32
+++ b/ext/zend_test/config.w32
@@ -3,6 +3,6 @@
 ARG_ENABLE("zend-test", "enable zend_test extension", "no");
 
 if (PHP_ZEND_TEST != "no") {
-	EXTENSION("zend_test", "test.c observer.c fiber.c", PHP_ZEND_TEST_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+	EXTENSION("zend_test", "test.c observer.c fiber.c object_handlers.c", PHP_ZEND_TEST_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 	ADD_FLAG("CFLAGS_ZEND_TEST", "/D PHP_ZEND_TEST_EXPORTS ");
 }

--- a/ext/zend_test/object_handlers.c
+++ b/ext/zend_test/object_handlers.c
@@ -1,0 +1,258 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) The PHP Group                                          |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://www.php.net/license/3_01.txt                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: George Peter Banyard <girgias@php.net>                      |
+  +----------------------------------------------------------------------+
+*/
+
+#include "object_handlers.h"
+#include "zend_API.h"
+#include "object_handlers_arginfo.h"
+
+/* donc refers to DoOperationNoCast */
+static zend_class_entry *donc_ce;
+static zend_object_handlers donc_object_handlers;
+
+static zend_object* donc_object_create_ex(zend_class_entry* ce, zend_long l) {
+	zend_object *obj = zend_objects_new(ce);
+	object_properties_init(obj, ce);
+	obj->handlers = &donc_object_handlers;
+	ZVAL_LONG(OBJ_PROP_NUM(obj, 0), l);
+	return obj;
+}
+static zend_object *donc_object_create(zend_class_entry *ce) /* {{{ */
+{
+	return donc_object_create_ex(ce, 0);
+}
+/* }}} */
+
+static inline void donc_create(zval *target, zend_long l) /* {{{ */
+{
+	ZVAL_OBJ(target, donc_object_create_ex(donc_ce, l));
+}
+
+#define IS_DONC(zval) \
+	(Z_TYPE_P(zval) == IS_OBJECT && instanceof_function(Z_OBJCE_P(zval), donc_ce))
+
+static void donc_add(zval *result, zval *op1, zval *op2)
+{
+	zend_long val_1;
+	zend_long val_2;
+	if (IS_DONC(op1)) {
+		val_1 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op1), 0));
+	} else {
+		val_1 = zval_get_long(op1);
+	}
+	if (IS_DONC(op2)) {
+		val_2 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op2), 0));
+	} else {
+		val_2 = zval_get_long(op2);
+	}
+
+	donc_create(result, val_1 + val_2);
+}
+static void donc_mul(zval *result, zval *op1, zval *op2)
+{
+	zend_long val_1;
+	zend_long val_2;
+	if (IS_DONC(op1)) {
+		val_1 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op1), 0));
+	} else {
+		val_1 = zval_get_long(op1);
+	}
+	if (IS_DONC(op2)) {
+		val_2 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op2), 0));
+	} else {
+		val_2 = zval_get_long(op2);
+	}
+
+	donc_create(result, val_1 * val_2);
+}
+
+static zend_result donc_do_operation(zend_uchar opcode, zval *result, zval *op1, zval *op2)
+{
+	zval op1_copy;
+	zend_result status;
+
+	if (result == op1) {
+		ZVAL_COPY_VALUE(&op1_copy, op1);
+		op1 = &op1_copy;
+	}
+
+	switch (opcode) {
+		case ZEND_ADD:
+			donc_add(result, op1, op2);
+			if (UNEXPECTED(EG(exception))) { status = FAILURE; }
+			status = SUCCESS;
+			break;
+		case ZEND_MUL:
+			donc_mul(result, op1, op2);
+			if (UNEXPECTED(EG(exception))) { status = FAILURE; }
+			status = SUCCESS;
+			break;
+		default:
+			status = FAILURE;
+			break;
+	}
+
+	if (status == SUCCESS && op1 == &op1_copy) {
+		zval_ptr_dtor(op1);
+	}
+
+	return status;
+}
+
+ZEND_METHOD(DoOperationNoCast, __construct)
+{
+	zend_long l;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(l)
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_LONG(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), l);
+}
+
+static zend_class_entry *long_castable_no_operation_ce;
+static zend_object_handlers long_castable_no_operation_object_handlers;
+
+static zend_object* long_castable_no_operation_object_create_ex(zend_class_entry* ce, zend_long l) {
+	zend_object *obj = zend_objects_new(ce);
+	object_properties_init(obj, ce);
+	obj->handlers = &long_castable_no_operation_object_handlers;
+	ZVAL_LONG(OBJ_PROP_NUM(obj, 0), l);
+	return obj;
+}
+
+static zend_object *long_castable_no_operation_object_create(zend_class_entry *ce)
+{
+	return long_castable_no_operation_object_create_ex(ce, 0);
+}
+
+static zend_result long_castable_no_operation_cast_object(zend_object *obj, zval *result, int type)
+{
+	if (type == IS_LONG) {
+		ZVAL_COPY(result, OBJ_PROP_NUM(obj, 0));
+		return SUCCESS;
+	}
+	return FAILURE;
+}
+
+ZEND_METHOD(LongCastableNoOperations, __construct)
+{
+	zend_long l;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(l)
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_LONG(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), l);
+}
+
+static zend_class_entry *float_castable_no_operation_ce;
+static zend_object_handlers float_castable_no_operation_object_handlers;
+
+static zend_object* float_castable_no_operation_object_create_ex(zend_class_entry* ce, double d) {
+	zend_object *obj = zend_objects_new(ce);
+	object_properties_init(obj, ce);
+	obj->handlers = &float_castable_no_operation_object_handlers;
+	ZVAL_DOUBLE(OBJ_PROP_NUM(obj, 0), d);
+	return obj;
+}
+
+static zend_object *float_castable_no_operation_object_create(zend_class_entry *ce)
+{
+	return float_castable_no_operation_object_create_ex(ce, 0.0);
+}
+
+static zend_result float_castable_no_operation_cast_object(zend_object *obj, zval *result, int type)
+{
+	if (type == IS_DOUBLE) {
+		ZVAL_COPY(result, OBJ_PROP_NUM(obj, 0));
+		return SUCCESS;
+	}
+	return FAILURE;
+}
+
+ZEND_METHOD(FloatCastableNoOperations, __construct)
+{
+	double d;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_DOUBLE(d)
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_DOUBLE(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), d);
+}
+
+static zend_class_entry *numeric_castable_no_operation_ce;
+static zend_object_handlers numeric_castable_no_operation_object_handlers;
+
+static zend_object* numeric_castable_no_operation_object_create_ex(zend_class_entry* ce, const zval *n) {
+	zend_object *obj = zend_objects_new(ce);
+	object_properties_init(obj, ce);
+	obj->handlers = &numeric_castable_no_operation_object_handlers;
+	ZVAL_COPY(OBJ_PROP_NUM(obj, 0), n);
+	return obj;
+}
+
+static zend_object *numeric_castable_no_operation_object_create(zend_class_entry *ce)
+{
+	zval tmp;
+	ZVAL_LONG(&tmp, 0);
+	return numeric_castable_no_operation_object_create_ex(ce, &tmp);
+}
+
+static zend_result numeric_castable_no_operation_cast_object(zend_object *obj, zval *result, int type)
+{
+	if (type == _IS_NUMBER) {
+		ZVAL_COPY(result, OBJ_PROP_NUM(obj, 0));
+		return SUCCESS;
+	}
+	return FAILURE;
+}
+
+ZEND_METHOD(NumericCastableNoOperations, __construct)
+{
+	zval *n;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_NUMBER(n)
+	ZEND_PARSE_PARAMETERS_END();
+
+	ZVAL_COPY(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), n);
+}
+
+void zend_test_object_handlers_init(void)
+{
+	/* DoOperationNoCast class */
+	donc_ce = register_class_DoOperationNoCast();
+	donc_ce->create_object = donc_object_create;
+	memcpy(&donc_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	donc_object_handlers.do_operation = donc_do_operation;
+
+	/* CastableNoOperation classes */
+	long_castable_no_operation_ce = register_class_LongCastableNoOperations();
+	long_castable_no_operation_ce->create_object = long_castable_no_operation_object_create;
+	memcpy(&long_castable_no_operation_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	long_castable_no_operation_object_handlers.cast_object = long_castable_no_operation_cast_object;
+
+	float_castable_no_operation_ce = register_class_FloatCastableNoOperations();
+	float_castable_no_operation_ce->create_object = float_castable_no_operation_object_create;
+	memcpy(&float_castable_no_operation_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	float_castable_no_operation_object_handlers.cast_object = float_castable_no_operation_cast_object;
+
+	numeric_castable_no_operation_ce = register_class_NumericCastableNoOperations();
+	numeric_castable_no_operation_ce->create_object = numeric_castable_no_operation_object_create;
+	memcpy(&numeric_castable_no_operation_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+	numeric_castable_no_operation_object_handlers.cast_object = numeric_castable_no_operation_cast_object;
+}

--- a/ext/zend_test/object_handlers.h
+++ b/ext/zend_test/object_handlers.h
@@ -1,0 +1,22 @@
+/*
+  +----------------------------------------------------------------------+
+  | Copyright (c) The PHP Group                                          |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | https://www.php.net/license/3_01.txt                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: George Peter Banyard <girgias@php.net>                        |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef ZEND_TEST_OBJECT_HANDLERS_H
+#define ZEND_TEST_OBJECT_HANDLERS_H
+
+void zend_test_object_handlers_init(void);
+
+#endif

--- a/ext/zend_test/object_handlers.stub.php
+++ b/ext/zend_test/object_handlers.stub.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @generate-class-entries static
+ * @undocumentable
+ */
+
+final class DoOperationNoCast {
+    private int $val;
+    public function __construct(int $val) {}
+}
+
+final class LongCastableNoOperations {
+    private int $val;
+    public function __construct(int $val) {}
+}
+final class FloatCastableNoOperations {
+    private float $val;
+    public function __construct(float $val) {}
+}
+final class NumericCastableNoOperations {
+    private int|float $val;
+    public function __construct(int|float $val) {}
+}

--- a/ext/zend_test/object_handlers_arginfo.h
+++ b/ext/zend_test/object_handlers_arginfo.h
@@ -1,0 +1,114 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 164cdd464289c8db351f4ec49979a66d44ba3e87 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DoOperationNoCast___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, val, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_LongCastableNoOperations___construct arginfo_class_DoOperationNoCast___construct
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_FloatCastableNoOperations___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, val, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_NumericCastableNoOperations___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_MASK(0, val, MAY_BE_LONG|MAY_BE_DOUBLE, NULL)
+ZEND_END_ARG_INFO()
+
+
+static ZEND_METHOD(DoOperationNoCast, __construct);
+static ZEND_METHOD(LongCastableNoOperations, __construct);
+static ZEND_METHOD(FloatCastableNoOperations, __construct);
+static ZEND_METHOD(NumericCastableNoOperations, __construct);
+
+
+static const zend_function_entry class_DoOperationNoCast_methods[] = {
+	ZEND_ME(DoOperationNoCast, __construct, arginfo_class_DoOperationNoCast___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_LongCastableNoOperations_methods[] = {
+	ZEND_ME(LongCastableNoOperations, __construct, arginfo_class_LongCastableNoOperations___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_FloatCastableNoOperations_methods[] = {
+	ZEND_ME(FloatCastableNoOperations, __construct, arginfo_class_FloatCastableNoOperations___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_NumericCastableNoOperations_methods[] = {
+	ZEND_ME(NumericCastableNoOperations, __construct, arginfo_class_NumericCastableNoOperations___construct, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_DoOperationNoCast(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "DoOperationNoCast", class_DoOperationNoCast_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	zval property_val_default_value;
+	ZVAL_UNDEF(&property_val_default_value);
+	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_val_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_LongCastableNoOperations(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "LongCastableNoOperations", class_LongCastableNoOperations_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	zval property_val_default_value;
+	ZVAL_UNDEF(&property_val_default_value);
+	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
+	zend_string_release(property_val_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_FloatCastableNoOperations(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "FloatCastableNoOperations", class_FloatCastableNoOperations_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	zval property_val_default_value;
+	ZVAL_UNDEF(&property_val_default_value);
+	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
+	zend_string_release(property_val_name);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_NumericCastableNoOperations(void)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "NumericCastableNoOperations", class_NumericCastableNoOperations_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+
+	zval property_val_default_value;
+	ZVAL_UNDEF(&property_val_default_value);
+	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
+	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_DOUBLE));
+	zend_string_release(property_val_name);
+
+	return class_entry;
+}

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -24,6 +24,7 @@
 #include "php_test.h"
 #include "observer.h"
 #include "fiber.h"
+#include "object_handlers.h"
 #include "zend_attributes.h"
 #include "zend_enum.h"
 #include "zend_interfaces.h"
@@ -860,220 +861,6 @@ static ZEND_METHOD(ZendTestForbidDynamicCall, callStatic)
 	zend_forbid_dynamic_call();
 }
 
-/* donc refers to DoOperationNoCast */
-static zend_class_entry *donc_ce;
-static zend_object_handlers donc_object_handlers;
-
-static zend_object* donc_object_create_ex(zend_class_entry* ce, zend_long l) {
-	zend_object *obj = zend_objects_new(ce);
-	object_properties_init(obj, ce);
-	obj->handlers = &donc_object_handlers;
-	ZVAL_LONG(OBJ_PROP_NUM(obj, 0), l);
-	return obj;
-}
-static zend_object *donc_object_create(zend_class_entry *ce) /* {{{ */
-{
-	return donc_object_create_ex(ce, 0);
-}
-/* }}} */
-
-static inline void donc_create(zval *target, zend_long l) /* {{{ */
-{
-	ZVAL_OBJ(target, donc_object_create_ex(donc_ce, l));
-}
-
-#define IS_DONC(zval) \
-	(Z_TYPE_P(zval) == IS_OBJECT && instanceof_function(Z_OBJCE_P(zval), donc_ce))
-
-static void donc_add(zval *result, zval *op1, zval *op2)
-{
-	zend_long val_1;
-	zend_long val_2;
-	if (IS_DONC(op1)) {
-		val_1 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op1), 0));
-	} else {
-		val_1 = zval_get_long(op1);
-	}
-	if (IS_DONC(op2)) {
-		val_2 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op2), 0));
-	} else {
-		val_2 = zval_get_long(op2);
-	}
-
-	donc_create(result, val_1 + val_2);
-}
-static void donc_mul(zval *result, zval *op1, zval *op2)
-{
-	zend_long val_1;
-	zend_long val_2;
-	if (IS_DONC(op1)) {
-		val_1 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op1), 0));
-	} else {
-		val_1 = zval_get_long(op1);
-	}
-	if (IS_DONC(op2)) {
-		val_2 = Z_LVAL_P(OBJ_PROP_NUM(Z_OBJ_P(op2), 0));
-	} else {
-		val_2 = zval_get_long(op2);
-	}
-
-	donc_create(result, val_1 * val_2);
-}
-
-static zend_result donc_do_operation(zend_uchar opcode, zval *result, zval *op1, zval *op2)
-{
-	zval op1_copy;
-	zend_result status;
-
-	if (result == op1) {
-		ZVAL_COPY_VALUE(&op1_copy, op1);
-		op1 = &op1_copy;
-	}
-
-	switch (opcode) {
-		case ZEND_ADD:
-			donc_add(result, op1, op2);
-			if (UNEXPECTED(EG(exception))) { status = FAILURE; }
-			status = SUCCESS;
-			break;
-		case ZEND_MUL:
-			donc_mul(result, op1, op2);
-			if (UNEXPECTED(EG(exception))) { status = FAILURE; }
-			status = SUCCESS;
-			break;
-		default:
-			status = FAILURE;
-			break;
-	}
-
-	if (status == SUCCESS && op1 == &op1_copy) {
-		zval_ptr_dtor(op1);
-	}
-
-	return status;
-}
-
-PHP_METHOD(DoOperationNoCast, __construct)
-{
-	zend_long l;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_LONG(l)
-	ZEND_PARSE_PARAMETERS_END();
-
-	ZVAL_LONG(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), l);
-}
-
-static zend_class_entry *long_castable_no_operation_ce;
-static zend_object_handlers long_castable_no_operation_object_handlers;
-
-static zend_object* long_castable_no_operation_object_create_ex(zend_class_entry* ce, zend_long l) {
-	zend_object *obj = zend_objects_new(ce);
-	object_properties_init(obj, ce);
-	obj->handlers = &long_castable_no_operation_object_handlers;
-	ZVAL_LONG(OBJ_PROP_NUM(obj, 0), l);
-	return obj;
-}
-
-static zend_object *long_castable_no_operation_object_create(zend_class_entry *ce)
-{
-	return long_castable_no_operation_object_create_ex(ce, 0);
-}
-
-static zend_result long_castable_no_operation_cast_object(zend_object *obj, zval *result, int type)
-{
-	if (type == IS_LONG) {
-		ZVAL_COPY(result, OBJ_PROP_NUM(obj, 0));
-		return SUCCESS;
-	}
-	return FAILURE;
-}
-
-PHP_METHOD(LongCastableNoOperations, __construct)
-{
-	zend_long l;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_LONG(l)
-	ZEND_PARSE_PARAMETERS_END();
-
-	ZVAL_LONG(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), l);
-}
-
-static zend_class_entry *float_castable_no_operation_ce;
-static zend_object_handlers float_castable_no_operation_object_handlers;
-
-static zend_object* float_castable_no_operation_object_create_ex(zend_class_entry* ce, double d) {
-	zend_object *obj = zend_objects_new(ce);
-	object_properties_init(obj, ce);
-	obj->handlers = &float_castable_no_operation_object_handlers;
-	ZVAL_DOUBLE(OBJ_PROP_NUM(obj, 0), d);
-	return obj;
-}
-
-static zend_object *float_castable_no_operation_object_create(zend_class_entry *ce)
-{
-	return float_castable_no_operation_object_create_ex(ce, 0.0);
-}
-
-static zend_result float_castable_no_operation_cast_object(zend_object *obj, zval *result, int type)
-{
-	if (type == IS_DOUBLE) {
-		ZVAL_COPY(result, OBJ_PROP_NUM(obj, 0));
-		return SUCCESS;
-	}
-	return FAILURE;
-}
-
-PHP_METHOD(FloatCastableNoOperations, __construct)
-{
-	double d;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_DOUBLE(d)
-	ZEND_PARSE_PARAMETERS_END();
-
-	ZVAL_DOUBLE(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), d);
-}
-
-static zend_class_entry *numeric_castable_no_operation_ce;
-static zend_object_handlers numeric_castable_no_operation_object_handlers;
-
-static zend_object* numeric_castable_no_operation_object_create_ex(zend_class_entry* ce, const zval *n) {
-	zend_object *obj = zend_objects_new(ce);
-	object_properties_init(obj, ce);
-	obj->handlers = &numeric_castable_no_operation_object_handlers;
-	ZVAL_COPY(OBJ_PROP_NUM(obj, 0), n);
-	return obj;
-}
-
-static zend_object *numeric_castable_no_operation_object_create(zend_class_entry *ce)
-{
-	zval tmp;
-	ZVAL_LONG(&tmp, 0);
-	return numeric_castable_no_operation_object_create_ex(ce, &tmp);
-}
-
-static zend_result numeric_castable_no_operation_cast_object(zend_object *obj, zval *result, int type)
-{
-	if (type == _IS_NUMBER) {
-		ZVAL_COPY(result, OBJ_PROP_NUM(obj, 0));
-		return SUCCESS;
-	}
-	return FAILURE;
-}
-
-PHP_METHOD(NumericCastableNoOperations, __construct)
-{
-	zval *n;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_NUMBER(n)
-	ZEND_PARSE_PARAMETERS_END();
-
-	ZVAL_COPY(OBJ_PROP_NUM(Z_OBJ_P(ZEND_THIS), 0), n);
-}
-
 PHP_INI_BEGIN()
 	STD_PHP_INI_BOOLEAN("zend_test.replace_zend_execute_ex", "0", PHP_INI_SYSTEM, OnUpdateBool, replace_zend_execute_ex, zend_zend_test_globals, zend_test_globals)
 	STD_PHP_INI_BOOLEAN("zend_test.register_passes", "0", PHP_INI_SYSTEM, OnUpdateBool, register_passes, zend_zend_test_globals, zend_test_globals)
@@ -1140,28 +927,6 @@ PHP_MINIT_FUNCTION(zend_test)
 	zend_test_string_enum = register_class_ZendTestStringEnum();
 	zend_test_int_enum = register_class_ZendTestIntEnum();
 
-	/* DoOperationNoCast class */
-	donc_ce = register_class_DoOperationNoCast();
-	donc_ce->create_object = donc_object_create;
-	memcpy(&donc_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	donc_object_handlers.do_operation = donc_do_operation;
-
-	/* CastableNoOperation classes */
-	long_castable_no_operation_ce = register_class_LongCastableNoOperations();
-	long_castable_no_operation_ce->create_object = long_castable_no_operation_object_create;
-	memcpy(&long_castable_no_operation_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	long_castable_no_operation_object_handlers.cast_object = long_castable_no_operation_cast_object;
-
-	float_castable_no_operation_ce = register_class_FloatCastableNoOperations();
-	float_castable_no_operation_ce->create_object = float_castable_no_operation_object_create;
-	memcpy(&float_castable_no_operation_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	float_castable_no_operation_object_handlers.cast_object = float_castable_no_operation_cast_object;
-
-	numeric_castable_no_operation_ce = register_class_NumericCastableNoOperations();
-	numeric_castable_no_operation_ce->create_object = numeric_castable_no_operation_object_create;
-	memcpy(&numeric_castable_no_operation_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	numeric_castable_no_operation_object_handlers.cast_object = numeric_castable_no_operation_cast_object;
-
 	zend_register_functions(NULL, ext_function_legacy, NULL, EG(current_module)->type);
 
 	// Loading via dl() not supported with the observer API
@@ -1183,6 +948,7 @@ PHP_MINIT_FUNCTION(zend_test)
 
 	zend_test_observer_init(INIT_FUNC_ARGS_PASSTHRU);
 	zend_test_fiber_init();
+	zend_test_object_handlers_init();
 
 	le_throwing_resource = zend_register_list_destructors_ex(le_throwing_resource_dtor, NULL, "throwing resource", module_number);
 

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -127,24 +127,6 @@ namespace {
         case Baz = -1;
     }
 
-    final class DoOperationNoCast {
-        private int $val;
-        public function __construct(int $val) {}
-    }
-
-    final class LongCastableNoOperations {
-        private int $val;
-        public function __construct(int $val) {}
-    }
-    final class FloatCastableNoOperations {
-        private float $val;
-        public function __construct(float $val) {}
-    }
-    final class NumericCastableNoOperations {
-        private int|float $val;
-        public function __construct(int|float $val) {}
-    }
-
     function zend_test_array_return(): array {}
 
     function zend_test_nullable_array_return(): null|array {}

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3cfbf478e8c6bc52f97749161e35f9003097bb4c */
+ * Stub hash: abd7a656256f9cf05466f09efcc78ef4c4c9f62b */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -193,20 +193,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_ZendTestForbidDynamicCall_callStatic arginfo_zend_test_void_return
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_DoOperationNoCast___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, val, IS_LONG, 0)
-ZEND_END_ARG_INFO()
-
-#define arginfo_class_LongCastableNoOperations___construct arginfo_class_DoOperationNoCast___construct
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_FloatCastableNoOperations___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, val, IS_DOUBLE, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_NumericCastableNoOperations___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_MASK(0, val, MAY_BE_LONG|MAY_BE_DOUBLE, NULL)
-ZEND_END_ARG_INFO()
-
 #if (PHP_VERSION_ID >= 80100)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_ZendTestNS_Foo_method, 0, 0, IS_LONG, 0)
 #else
@@ -281,10 +267,6 @@ static ZEND_METHOD(ZendTestClassWithMethodWithParameterAttribute, override);
 static ZEND_METHOD(ZendTestChildClassWithMethodWithParameterAttribute, override);
 static ZEND_METHOD(ZendTestForbidDynamicCall, call);
 static ZEND_METHOD(ZendTestForbidDynamicCall, callStatic);
-static ZEND_METHOD(DoOperationNoCast, __construct);
-static ZEND_METHOD(LongCastableNoOperations, __construct);
-static ZEND_METHOD(FloatCastableNoOperations, __construct);
-static ZEND_METHOD(NumericCastableNoOperations, __construct);
 static ZEND_METHOD(ZendTestNS_Foo, method);
 static ZEND_METHOD(ZendTestNS_UnlikelyCompileError, method);
 static ZEND_METHOD(ZendTestNS2_Foo, method);
@@ -422,30 +404,6 @@ static const zend_function_entry class_ZendTestStringEnum_methods[] = {
 
 
 static const zend_function_entry class_ZendTestIntEnum_methods[] = {
-	ZEND_FE_END
-};
-
-
-static const zend_function_entry class_DoOperationNoCast_methods[] = {
-	ZEND_ME(DoOperationNoCast, __construct, arginfo_class_DoOperationNoCast___construct, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-
-static const zend_function_entry class_LongCastableNoOperations_methods[] = {
-	ZEND_ME(LongCastableNoOperations, __construct, arginfo_class_LongCastableNoOperations___construct, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-
-static const zend_function_entry class_FloatCastableNoOperations_methods[] = {
-	ZEND_ME(FloatCastableNoOperations, __construct, arginfo_class_FloatCastableNoOperations___construct, ZEND_ACC_PUBLIC)
-	ZEND_FE_END
-};
-
-
-static const zend_function_entry class_NumericCastableNoOperations_methods[] = {
-	ZEND_ME(NumericCastableNoOperations, __construct, arginfo_class_NumericCastableNoOperations___construct, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -821,74 +779,6 @@ static zend_class_entry *register_class_ZendTestIntEnum(void)
 	return class_entry;
 }
 #endif
-
-static zend_class_entry *register_class_DoOperationNoCast(void)
-{
-	zend_class_entry ce, *class_entry;
-
-	INIT_CLASS_ENTRY(ce, "DoOperationNoCast", class_DoOperationNoCast_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
-	class_entry->ce_flags |= ZEND_ACC_FINAL;
-
-	zval property_val_default_value;
-	ZVAL_UNDEF(&property_val_default_value);
-	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
-	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_val_name);
-
-	return class_entry;
-}
-
-static zend_class_entry *register_class_LongCastableNoOperations(void)
-{
-	zend_class_entry ce, *class_entry;
-
-	INIT_CLASS_ENTRY(ce, "LongCastableNoOperations", class_LongCastableNoOperations_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
-	class_entry->ce_flags |= ZEND_ACC_FINAL;
-
-	zval property_val_default_value;
-	ZVAL_UNDEF(&property_val_default_value);
-	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
-	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG));
-	zend_string_release(property_val_name);
-
-	return class_entry;
-}
-
-static zend_class_entry *register_class_FloatCastableNoOperations(void)
-{
-	zend_class_entry ce, *class_entry;
-
-	INIT_CLASS_ENTRY(ce, "FloatCastableNoOperations", class_FloatCastableNoOperations_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
-	class_entry->ce_flags |= ZEND_ACC_FINAL;
-
-	zval property_val_default_value;
-	ZVAL_UNDEF(&property_val_default_value);
-	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
-	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_DOUBLE));
-	zend_string_release(property_val_name);
-
-	return class_entry;
-}
-
-static zend_class_entry *register_class_NumericCastableNoOperations(void)
-{
-	zend_class_entry ce, *class_entry;
-
-	INIT_CLASS_ENTRY(ce, "NumericCastableNoOperations", class_NumericCastableNoOperations_methods);
-	class_entry = zend_register_internal_class_ex(&ce, NULL);
-	class_entry->ce_flags |= ZEND_ACC_FINAL;
-
-	zval property_val_default_value;
-	ZVAL_UNDEF(&property_val_default_value);
-	zend_string *property_val_name = zend_string_init("val", sizeof("val") - 1, 1);
-	zend_declare_typed_property(class_entry, property_val_name, &property_val_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_LONG|MAY_BE_DOUBLE));
-	zend_string_release(property_val_name);
-
-	return class_entry;
-}
 
 static zend_class_entry *register_class_ZendTestNS_Foo(void)
 {


### PR DESCRIPTION
I think this makes sense to split up as setting up an object to test one of the handler requires quite a bit of boilerplate that pollutes the base test file.

This would also reduce the amount of conflicts, as every time I rebased PRs introducing such objects I had permanent conflicts :/

Kinda related to #9218 as I want to work on this again.