### PR TITLE
Improve `ext/pdo_pgsql` tests cleanup

### DIFF
--- a/ext/pdo_pgsql/tests/bug46274.phpt
+++ b/ext/pdo_pgsql/tests/bug46274.phpt
@@ -21,7 +21,6 @@ try {
 } catch (Exception $e) {
 }
 
-$db->query('DROP TABLE IF EXISTS test_one_blob_46274_1 CASCADE');
 $db->query('CREATE TABLE test_one_blob_46274_1 (id SERIAL NOT NULL, blob1 BYTEA)');
 
 $stmt = $db->prepare("INSERT INTO test_one_blob_46274_1 (blob1) VALUES (:foo)");
@@ -62,9 +61,12 @@ var_dump($res->fetch());
 
 // NULL
 var_dump($res->fetch());
-
-$db->query('DROP TABLE test_one_blob_46274_1');
-
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS test_one_blob_46274_1');
 ?>
 --EXPECT--
 array(2) {

--- a/ext/pdo_pgsql/tests/bug46274_2.phpt
+++ b/ext/pdo_pgsql/tests/bug46274_2.phpt
@@ -21,7 +21,6 @@ try {
 } catch (Exception $e) {
 }
 
-$db->query('DROP TABLE IF EXISTS test_one_blob_46274_2 CASCADE');
 $db->query('CREATE TABLE test_one_blob_46274_2 (id SERIAL NOT NULL, blob1 BYTEA)');
 
 $stmt = $db->prepare("INSERT INTO test_one_blob_46274_2 (blob1) VALUES (:foo)");
@@ -65,9 +64,12 @@ var_dump(fread($x['blob1'], 10));
 
 // NULL
 var_dump($res->fetch());
-
-$db->query('DROP TABLE test_one_blob_46274_2');
-
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS test_one_blob_46274_2');
 ?>
 --EXPECTF--
 array(2) {

--- a/ext/pdo_pgsql/tests/bug66584.phpt
+++ b/ext/pdo_pgsql/tests/bug66584.phpt
@@ -57,6 +57,12 @@ function run($pdo, $data)
 }
 
 ?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->query("DROP TABLE IF EXISTS b66584");
+?>
 --EXPECTF--
 int(3)
 string(%d) "SQLSTATE%s"

--- a/ext/pdo_pgsql/tests/bug67462.phpt
+++ b/ext/pdo_pgsql/tests/bug67462.phpt
@@ -30,6 +30,12 @@ try {
 }
 
 ?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$pdo = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$pdo->query("DROP TABLE IF EXISTS b67462");
+?>
 --EXPECT--
 bool(true)
 bool(false)

--- a/ext/pdo_pgsql/tests/bug70861.phpt
+++ b/ext/pdo_pgsql/tests/bug70861.phpt
@@ -21,7 +21,6 @@ try {
 } catch (Exception $e) {
 }
 
-$db->query('DROP TABLE IF EXISTS test_blob_crash_70861 CASCADE');
 $db->query('CREATE TABLE test_blob_crash_70861 (id SERIAL NOT NULL, blob1 BYTEA)');
 
 class HelloWrapper {
@@ -41,8 +40,16 @@ $stmt->execute();
 
 fclose($f);
 
+$db->exec('DROP TABLE test_blob_crash');
+
 ?>
 +++DONE+++
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS test_blob_crash_70861 CASCADE');
+?>
 --EXPECTF--
 %a
 +++DONE+++

--- a/ext/pdo_pgsql/tests/bug72633.phpt
+++ b/ext/pdo_pgsql/tests/bug72633.phpt
@@ -18,7 +18,6 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->query('DROP TABLE IF EXISTS test_last_id_72633 CASCADE');
 $db->query('CREATE TABLE test_last_id_72633 (id SERIAL NOT NULL, field1 VARCHAR(10))');
 
 $stmt = $db->prepare("INSERT INTO test_last_id_72633 (field1) VALUES ('test')");
@@ -34,8 +33,12 @@ var_dump($db->lastInsertId());
  */
 var_dump($db->lastInsertId('test_last_id_72633_id_seq'));
 
-$db->query('DROP TABLE test_last_id_72633');
-
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS test_last_id_72633');
 ?>
 --EXPECTREGEX--
 string\([0-9]*\)\ \"[0-9]*\"

--- a/ext/pdo_pgsql/tests/bug75402.phpt
+++ b/ext/pdo_pgsql/tests/bug75402.phpt
@@ -17,7 +17,6 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $resp = new \stdClass();
 $resp->entries = [];
 
-$db->query('DROP TABLE IF EXISTS bug75402 CASCADE');
 $db->query('CREATE TABLE bug75402 (
     "id" character varying(64) NOT NULL,
     "group_id" character varying(64) NOT NULL,
@@ -83,6 +82,12 @@ if ($db) {
 }
 
 var_dump($resp);
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->exec('DROP TABLE IF EXISTS bug75402');
 ?>
 --EXPECT--
 object(stdClass)#2 (1) {

--- a/ext/pdo_pgsql/tests/bug_33876.phpt
+++ b/ext/pdo_pgsql/tests/bug_33876.phpt
@@ -16,7 +16,6 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
 $db->exec("SET LC_MESSAGES='C'");
-$db->query('DROP TABLE IF EXISTS b33876 CASCADE');
 $db->exec('CREATE TABLE b33876 (foo varchar(5) NOT NULL, bar bool NOT NULL)');
 $db->exec("INSERT INTO b33876 VALUES('false','f')");
 $db->exec("INSERT INTO b33876 VALUES('true', 't')");
@@ -95,6 +94,12 @@ function normalizeErrorInfo(array $err): array {
     return $err;
 }
 
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS b33876 CASCADE');
 ?>
 --EXPECTF--
 Array

--- a/ext/pdo_pgsql/tests/bug_49985.phpt
+++ b/ext/pdo_pgsql/tests/bug_49985.phpt
@@ -15,7 +15,6 @@ require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-$db->query('DROP TABLE IF EXISTS b49985 CASCADE');
 $db->exec("CREATE TABLE b49985 (a int PRIMARY KEY)");
 
 for ($i = 0; $i < 3; $i++) {
@@ -30,6 +29,12 @@ for ($i = 0; $i < 3; $i++) {
     }
 }
 
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS b49985 CASCADE');
 ?>
 --EXPECTF--
 bool(true)

--- a/ext/pdo_pgsql/tests/copy_from.phpt
+++ b/ext/pdo_pgsql/tests/copy_from.phpt
@@ -16,7 +16,6 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->query('DROP TABLE IF EXISTS test_copy_from CASCADE');
 $db->exec('CREATE TABLE test_copy_from (a integer not null primary key, b text, c integer)');
 
 echo "Preparing test file and array for CopyFrom tests\n";
@@ -126,6 +125,12 @@ $db->rollback();
 foreach (array($filename, $filenameWithDifferentNullValues, $filenameWithDifferentNullValuesAndSelectedFields) as $f) {
     @unlink($f);
 }
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->query('DROP TABLE IF EXISTS test_copy_from CASCADE');
 ?>
 --EXPECTF--
 Preparing test file and array for CopyFrom tests

--- a/ext/pdo_pgsql/tests/copy_to.phpt
+++ b/ext/pdo_pgsql/tests/copy_to.phpt
@@ -16,7 +16,6 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->query('DROP TABLE IF EXISTS test_copy_to CASCADE');
 $db->exec('CREATE TABLE test_copy_to (a integer not null primary key, b text, c integer)');
 
 $db->beginTransaction();
@@ -79,6 +78,12 @@ try {
 if(isset($filename)) {
     @unlink($filename);
 }
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->exec('DROP TABLE test_copy_to');
 ?>
 --EXPECTF--
 Preparing test table for CopyTo tests

--- a/ext/pdo_pgsql/tests/is_in_transaction.phpt
+++ b/ext/pdo_pgsql/tests/is_in_transaction.phpt
@@ -16,7 +16,6 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->query('DROP TABLE IF EXISTS test_is_in_transaction CASCADE');
 $db->exec('CREATE TABLE test_is_in_transaction (a integer not null primary key, b text)');
 
 $db->beginTransaction();
@@ -56,7 +55,12 @@ var_dump($db->inTransaction());
     echo "Exception! at line ", $e->getLine(), "\n";
     var_dump($e->getMessage());
 }
-
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->exec('DROP TABLE test_is_in_transaction');
 ?>
 --EXPECT--
 Test PDO::PGSQL_TRANSACTION_INTRANS

--- a/ext/pdo_pgsql/tests/large_objects.phpt
+++ b/ext/pdo_pgsql/tests/large_objects.phpt
@@ -16,7 +16,6 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->query('DROP TABLE IF EXISTS test_large_objects CASCADE');
 $db->exec('CREATE TABLE test_large_objects (blobid integer not null primary key, bloboid OID)');
 
 $db->beginTransaction();
@@ -78,7 +77,12 @@ echo "Fetched!\n";
 /* Now to remove the large object from the database, so it doesn't
  * linger and clutter up the storage */
 $db->pgsqlLOBUnlink($oid);
-
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->exec('DROP TABLE test_large_objects');
 ?>
 --EXPECT--
 Fetching:


### PR DESCRIPTION
Following https://github.com/php/php-src/commit/66b359e4de3e0f4f49b8a213407f0bf4b9a7fb11, adding a few queries to clean-up database after executing tests of `ext/pdo_pgsql`.