### PR TITLE
Fix GH-11854: 8.2.9 DateTime:createFromFormat stopped parsing datetim…

### DIFF
--- a/ext/date/lib/parse_date.c
+++ b/ext/date/lib/parse_date.c
@@ -663,20 +663,21 @@ static timelib_long timelib_get_month(const char **ptr)
 
 static void timelib_eat_spaces(const char **ptr)
 {
-	do {
+	/* Repetition is safe because it will fail as soon as a '\0' is encountered. */
+	again: {
 		if (**ptr == ' ' || **ptr == '\t') {
 			++*ptr;
-			continue;
+			goto again;
 		}
 		if ((*ptr)[0] == '\xe2' && (*ptr)[1] == '\x80' && (*ptr)[2] == '\xaf') { // NNBSP
 			*ptr += 3;
-			continue;
+			goto again;
 		}
 		if ((*ptr)[0] == '\xc2' && (*ptr)[1] == '\xa0') { // NBSP
 			*ptr += 2;
-			continue;
+			goto again;
 		}
-	} while (false);
+	}
 }
 
 static void timelib_eat_until_separator(const char **ptr)

--- a/ext/date/lib/parse_date.re
+++ b/ext/date/lib/parse_date.re
@@ -661,20 +661,21 @@ static timelib_long timelib_get_month(const char **ptr)
 
 static void timelib_eat_spaces(const char **ptr)
 {
-	do {
+	/* Repetition is safe because it will fail as soon as a '\0' is encountered. */
+	again: {
 		if (**ptr == ' ' || **ptr == '\t') {
 			++*ptr;
-			continue;
+			goto again;
 		}
 		if ((*ptr)[0] == '\xe2' && (*ptr)[1] == '\x80' && (*ptr)[2] == '\xaf') { // NNBSP
 			*ptr += 3;
-			continue;
+			goto again;
 		}
 		if ((*ptr)[0] == '\xc2' && (*ptr)[1] == '\xa0') { // NBSP
 			*ptr += 2;
-			continue;
+			goto again;
 		}
-	} while (false);
+	}
 }
 
 static void timelib_eat_until_separator(const char **ptr)

--- a/ext/date/tests/gh11854.phpt
+++ b/ext/date/tests/gh11854.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-11854 (8.2.9 DateTime:createFromFormat stopped parsing datetime with containing extra space.)
+--FILE--
+<?php
+$dateTime = \DateTime::createFromFormat("D M d H:i:s Y", "Wed Aug  2 08:37:50 2023");
+var_dump($dateTime);
+?>
+--EXPECT--
+object(DateTime)#1 (3) {
+  ["date"]=>
+  string(26) "2023-08-02 08:37:50.000000"
+  ["timezone_type"]=>
+  int(3)
+  ["timezone"]=>
+  string(3) "UTC"
+}


### PR DESCRIPTION
…e with containing extra space.

I went for the minimal-diff approach.
It'd be nice if we can prevent the regression from happening before the 8.2.9 release imo.

EDIT: FreeBSD failure unrelated (`Test function pcntl_rfork() with no wait flag. [ext/pcntl/tests/pcntl_rfork_nowait.phpt]`)