### PR TITLE
ext/calendar: Allow easter_date to process years after 2037 on 64bit systems

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -303,6 +303,10 @@ PHP 8.3 UPGRADE NOTES
     significant digits before the decimal point. Previously negative $decimals
     got silently ignored and the number got rounded to zero decimal places.
 
+- Calendar
+  . easter_date() now supports years from 1970 to 2,000,000,000 on 64-bit systems,
+    previously it only supported years in the range from 1970 to 2037.
+
 ========================================
 6. New Functions
 ========================================

--- a/ext/calendar/tests/easter_date_32bit.phpt
+++ b/ext/calendar/tests/easter_date_32bit.phpt
@@ -1,5 +1,7 @@
 --TEST--
-easter_date()
+Test easter_date() on 32bit systems
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 4) die("skip 32-bit only"); ?>
 --INI--
 date.timezone=UTC
 --ENV--

--- a/ext/calendar/tests/easter_date_64bit.phpt
+++ b/ext/calendar/tests/easter_date_64bit.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test easter_date() on 64bit systems
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip 64-bit only"); ?>
+--INI--
+date.timezone=UTC
+--ENV--
+TZ=UTC
+--EXTENSIONS--
+calendar
+--FILE--
+<?php
+putenv('TZ=UTC');
+echo date("Y-m-d", easter_date(2000))."\n";
+echo date("Y-m-d", easter_date(2001))."\n";
+echo date("Y-m-d", easter_date(2002))."\n";
+echo date("Y-m-d", easter_date(2045))."\n";
+echo date("Y-m-d", easter_date(2046))."\n";
+echo date("Y-m-d", easter_date(2047))."\n";
+try {
+    easter_date(1492);
+} catch (ValueError $ex) {
+    echo "{$ex->getMessage()}\n";
+}
+?>
+--EXPECT--
+2000-04-23
+2001-04-15
+2002-03-31
+2045-04-09
+2046-03-25
+2047-04-14
+easter_date(): Argument #1 ($year) must be a year after 1970 (inclusive)

--- a/ext/calendar/tests/easter_date_checks_upper_bound_32bit.phpt
+++ b/ext/calendar/tests/easter_date_checks_upper_bound_32bit.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test easter_date() on 32bit systems checks the upper year limit
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 4) die("skip 32-bit only"); ?>
+--INI--
+date.timezone=UTC
+--ENV--
+TZ=UTC
+--EXTENSIONS--
+calendar
+--FILE--
+<?php
+putenv('TZ=UTC');
+try {
+    easter_date(2040);
+} catch (ValueError $ex) {
+    echo "{$ex->getMessage()}\n";
+}
+?>
+--EXPECT--
+easter_date(): Argument #1 ($year) must be between 1970 and 2037 (inclusive)

--- a/ext/calendar/tests/easter_date_checks_upper_bound_64bit.phpt
+++ b/ext/calendar/tests/easter_date_checks_upper_bound_64bit.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test easter_date() on 64bit systems checks the upper year limit
+--SKIPIF--
+<?php if (PHP_INT_SIZE != 8) die("skip 64-bit only"); ?>
+--INI--
+date.timezone=UTC
+--ENV--
+TZ=UTC
+--EXTENSIONS--
+calendar
+--FILE--
+<?php
+putenv('TZ=UTC');
+try {
+    easter_date(293274701009);
+} catch (ValueError $ex) {
+    echo "{$ex->getMessage()}\n";
+}
+?>
+--EXPECT--
+easter_date(): Argument #1 ($year) must be a year before 2.000.000.000 (inclusive)


### PR DESCRIPTION
Until now, easter_date always threw an error if executed with a year after 2037. This was done to prevent an integer overflow with Unix timestamps in the years after 2038 from appearing. ([Y2K38 bug](https://en.wikipedia.org/wiki/Year_2038_problem))

Since the overflow does not happen with signed 64-bit integers, I added a check to allow easter_date to run on 64bit systems with years after 2037.
