### PR TITLE
Don't test without opcache on push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,8 +66,6 @@ jobs:
         uses: ./.github/actions/install-linux
       - name: Setup
         uses: ./.github/actions/setup-x64
-      - name: Test
-        uses: ./.github/actions/test-linux
       - name: Test Tracing JIT
         uses: ./.github/actions/test-linux
         with:
@@ -114,8 +112,6 @@ jobs:
         run: make -j$(/usr/bin/nproc) >/dev/null
       - name: make install
         uses: ./.github/actions/install-linux-x32
-      - name: Test
-        uses: ./.github/actions/test-linux
       - name: Test Tracing JIT
         uses: ./.github/actions/test-linux
         with:
@@ -145,8 +141,6 @@ jobs:
           make -j$(sysctl -n hw.logicalcpu) >/dev/null
       - name: make install
         run: sudo make install
-      - name: Test
-        uses: ./.github/actions/test-macos
       - name: Test Tracing JIT
         uses: ./.github/actions/test-macos
         with:


### PR DESCRIPTION
It's very rare for something to fail without opcache but not with opcache. We will still run without opcache in nightly. One valuable information lost here is whether something is caused by opcache/JIT. But this can be verified locally when assessing the problem. Alternatively we may look into triggering specific jobs on-demand.

Let me know what you think. I don't want to remove something useful, but it seems like it wouldn't make much of a difference.