### PR TITLE
Mark buildFromIterator test as conflicting

### DIFF
--- a/ext/phar/tests/phar_buildfromiterator10.phpt
+++ b/ext/phar/tests/phar_buildfromiterator10.phpt
@@ -2,6 +2,8 @@
 Phar::buildFromIterator() RegexIterator(RecursiveIteratorIterator), SplFileInfo as current
 --EXTENSIONS--
 phar
+--CONFLICTS--
+all
 --INI--
 phar.require_hash=0
 phar.readonly=0


### PR DESCRIPTION
Commit 0b2e6bc2b0 started caching the directory entry type to improve performance. Shortly after, we've seen flaky failures of the buildFromIterator phar test.

When it fails, it's always a value error in the constructor of RecursiveDirectoryIterator::__construct() with a "no such file or directory" error. What's happening here is this:
1) A parallel test creates a subdirectory in the current working dir.
2) This test checks hasChildren() on a directory entry, the cached entry
   returns "yes" on the subdirectory.
3) The parallel test finishes and removes the subdirectory.
4) The constructor mentioned above is called, causing an exception
   because the directory is gone.

This race has always been possible, even before said commit. It's just that it was very hard to hit before: the expensive stat call made the race window hard to hit. The race is now easier to hit because of the caching that is fast.

Since there's many tests that modify the current working directory, it seems best to mark this as an "all" conflict. We cannot avoid every TOC-TOU race when working with files with these phar tests.

In particular, mounteddir.phpt caused every conflict I saw on CI, but there's more tests that create subdirectories in the current working directory.

EDIT: I actually should've targeted 8.1, I'll do the merge manually anyway so it doesn't really matter ig :shrug: