### PR TITLE
Fix off-by-one bug when truncating tempnam prefix

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -834,7 +834,7 @@ PHP_FUNCTION(tempnam)
 	ZEND_PARSE_PARAMETERS_END();
 
 	p = php_basename(prefix, prefix_len, NULL, 0);
-	if (ZSTR_LEN(p) > 64) {
+	if (ZSTR_LEN(p) >= 64) {
 		ZSTR_VAL(p)[63] = '\0';
 	}
 

--- a/ext/standard/tests/file/tempnam_variation9.phpt
+++ b/ext/standard/tests/file/tempnam_variation9.phpt
@@ -1,0 +1,76 @@
+--TEST--
+Test tempnam() function: usage variations - test prefix maximum size
+--SKIPIF--
+<?php
+if(substr(PHP_OS, 0, 3) == "WIN")
+  die("skip Do not run on Windows");
+?>
+--FILE--
+<?php
+/* Testing the maximum prefix size */
+
+echo "*** Testing tempnam() maximum prefix size ***\n";
+$file_path = __DIR__."/tempnamVar9";
+mkdir($file_path);
+
+$pre_prefix = "begin_";
+$post_prefix = "_end";
+$fixed_length = strlen($pre_prefix) + strlen($post_prefix);
+/* An array of prefixes */
+$names_arr = array(
+  $pre_prefix . str_repeat("x", 7) . $post_prefix,
+  $pre_prefix . str_repeat("x", 63 - $fixed_length) . $post_prefix,
+  $pre_prefix . str_repeat("x", 64 - $fixed_length) . $post_prefix,
+  $pre_prefix . str_repeat("x", 65 - $fixed_length) . $post_prefix,
+  $pre_prefix . str_repeat("x", 300) . $post_prefix,
+);
+
+foreach($names_arr as $i=>$prefix) {
+  echo "-- Iteration $i --\n";
+  try {
+    $file_name = tempnam("$file_path", $prefix);
+  } catch (Error $e) {
+    echo $e->getMessage(), "\n";
+    continue;
+  }
+
+  $base_name = basename($file_name);
+  echo "File name is => ";
+  print($base_name);
+  echo "\n";
+  echo "File name length is => ";
+  print(strlen($base_name));
+  echo "\n";
+
+  if (file_exists($file_name)) {
+    unlink($file_name);
+  }
+}
+rmdir($file_path);
+
+?>
+--CLEAN--
+<?php
+$file_path = __DIR__."/tempnamVar9";
+if (file_exists($file_path)) {
+    array_map('unlink', glob($file_path . "/*"));
+    rmdir($file_path);
+}
+?>
+--EXPECTF--
+*** Testing tempnam() maximum prefix size ***
+-- Iteration 0 --
+File name is => begin_%rx{7}%r_end%r.{6}%r
+File name length is => 23
+-- Iteration 1 --
+File name is => begin_%rx{53}%r_end%r.{6}%r
+File name length is => 69
+-- Iteration 2 --
+File name is => begin_%rx{54}%r_en%r.{6}%r
+File name length is => 69
+-- Iteration 3 --
+File name is => begin_%rx{55}%r_e%r.{6}%r
+File name length is => 69
+-- Iteration 4 --
+File name is => begin_%rx{57}%r%r.{6}%r
+File name length is => 69


### PR DESCRIPTION
The tempnam documentation currently states that "Only the first 63
characters of the prefix are used, the rest are ignored". However when
the prefix is 64 characters-long, the current implementation fails to
strip the last character, diverging from the documented behavior. This
patch fixes the implementation so it matches the documented behavior for
that specific case where the prefix is 64 characters long.