### PR TITLE
Improve database naming in `ext/pdo_pgsql` for better para-tests

### DIFF
--- a/ext/pdo_pgsql/tests/bug46274.phpt
+++ b/ext/pdo_pgsql/tests/bug46274.phpt
@@ -21,9 +21,10 @@ try {
 } catch (Exception $e) {
 }
 
-$db->query('CREATE TABLE test_one_blob (id SERIAL NOT NULL, blob1 BYTEA)');
+$db->query('DROP TABLE IF EXISTS test_one_blob_46274_1 CASCADE');
+$db->query('CREATE TABLE test_one_blob_46274_1 (id SERIAL NOT NULL, blob1 BYTEA)');
 
-$stmt = $db->prepare("INSERT INTO test_one_blob (blob1) VALUES (:foo)");
+$stmt = $db->prepare("INSERT INTO test_one_blob_46274_1 (blob1) VALUES (:foo)");
 
 $data = 'foo';
 $blob = fopen('php://memory', 'a');
@@ -49,7 +50,7 @@ $blob = NULL;
 $stmt->bindparam(':foo', $blob, PDO::PARAM_LOB);
 $stmt->execute();
 
-$res = $db->query("SELECT blob1 from test_one_blob");
+$res = $db->query("SELECT blob1 from test_one_blob_46274_1");
 // Resource
 var_dump($res->fetch());
 
@@ -62,7 +63,7 @@ var_dump($res->fetch());
 // NULL
 var_dump($res->fetch());
 
-$db->query('DROP TABLE test_one_blob');
+$db->query('DROP TABLE test_one_blob_46274_1');
 
 ?>
 --EXPECT--

--- a/ext/pdo_pgsql/tests/bug46274_2.phpt
+++ b/ext/pdo_pgsql/tests/bug46274_2.phpt
@@ -21,9 +21,10 @@ try {
 } catch (Exception $e) {
 }
 
-$db->query('CREATE TABLE test_one_blob (id SERIAL NOT NULL, blob1 BYTEA)');
+$db->query('DROP TABLE IF EXISTS test_one_blob_46274_2 CASCADE');
+$db->query('CREATE TABLE test_one_blob_46274_2 (id SERIAL NOT NULL, blob1 BYTEA)');
 
-$stmt = $db->prepare("INSERT INTO test_one_blob (blob1) VALUES (:foo)");
+$stmt = $db->prepare("INSERT INTO test_one_blob_46274_2 (blob1) VALUES (:foo)");
 
 $data = 'foo';
 $blob = fopen('php://memory', 'a');
@@ -49,7 +50,7 @@ $blob = NULL;
 $stmt->bindparam(':foo', $blob, PDO::PARAM_LOB);
 $stmt->execute();
 
-$res = $db->query("SELECT blob1 from test_one_blob");
+$res = $db->query("SELECT blob1 from test_one_blob_46274_2");
 // Resource
 var_dump($x = $res->fetch());
 var_dump(fread($x['blob1'], 10));
@@ -65,7 +66,7 @@ var_dump(fread($x['blob1'], 10));
 // NULL
 var_dump($res->fetch());
 
-$db->query('DROP TABLE test_one_blob');
+$db->query('DROP TABLE test_one_blob_46274_2');
 
 ?>
 --EXPECTF--

--- a/ext/pdo_pgsql/tests/bug70861.phpt
+++ b/ext/pdo_pgsql/tests/bug70861.phpt
@@ -21,8 +21,8 @@ try {
 } catch (Exception $e) {
 }
 
-$db->query('DROP TABLE IF EXISTS test_blob_crash CASCADE');
-$db->query('CREATE TABLE test_blob_crash (id SERIAL NOT NULL, blob1 BYTEA)');
+$db->query('DROP TABLE IF EXISTS test_blob_crash_70861 CASCADE');
+$db->query('CREATE TABLE test_blob_crash_70861 (id SERIAL NOT NULL, blob1 BYTEA)');
 
 class HelloWrapper {
     public function stream_open() { return true; }

--- a/ext/pdo_pgsql/tests/bug72633.phpt
+++ b/ext/pdo_pgsql/tests/bug72633.phpt
@@ -18,9 +18,10 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->query('CREATE TABLE test_last_id (id SERIAL NOT NULL, field1 VARCHAR(10))');
+$db->query('DROP TABLE IF EXISTS test_last_id_72633 CASCADE');
+$db->query('CREATE TABLE test_last_id_72633 (id SERIAL NOT NULL, field1 VARCHAR(10))');
 
-$stmt = $db->prepare("INSERT INTO test_last_id (field1) VALUES ('test')");
+$stmt = $db->prepare("INSERT INTO test_last_id_72633 (field1) VALUES ('test')");
 
 $stmt->execute();
 
@@ -31,9 +32,9 @@ var_dump($db->lastInsertId());
 /**
  * Sequence name informed
  */
-var_dump($db->lastInsertId('test_last_id_id_seq'));
+var_dump($db->lastInsertId('test_last_id_72633_id_seq'));
 
-$db->query('DROP TABLE test_last_id');
+$db->query('DROP TABLE test_last_id_72633');
 
 ?>
 --EXPECTREGEX--

--- a/ext/pdo_pgsql/tests/bug_33876.phpt
+++ b/ext/pdo_pgsql/tests/bug_33876.phpt
@@ -16,11 +16,12 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
 $db->exec("SET LC_MESSAGES='C'");
-$db->exec('CREATE TABLE test (foo varchar(5) NOT NULL, bar bool NOT NULL)');
-$db->exec("INSERT INTO test VALUES('false','f')");
-$db->exec("INSERT INTO test VALUES('true', 't')");
+$db->query('DROP TABLE IF EXISTS b33876 CASCADE');
+$db->exec('CREATE TABLE b33876 (foo varchar(5) NOT NULL, bar bool NOT NULL)');
+$db->exec("INSERT INTO b33876 VALUES('false','f')");
+$db->exec("INSERT INTO b33876 VALUES('true', 't')");
 
-$res = $db->prepare('SELECT foo from test where bar = ?');
+$res = $db->prepare('SELECT foo from b33876 where bar = ?');
 
 # this is the portable approach to binding a bool
 $res->bindValue(1, false, PDO::PARAM_BOOL);
@@ -55,7 +56,7 @@ else
 echo "EMUL\n";
 
 
-$res = $db->prepare('SELECT foo from test where bar = ?', array(
+$res = $db->prepare('SELECT foo from b33876 where bar = ?', array(
     PDO::ATTR_EMULATE_PREPARES => true));
 
 # this is the portable approach to binding a bool

--- a/ext/pdo_pgsql/tests/bug_49985.phpt
+++ b/ext/pdo_pgsql/tests/bug_49985.phpt
@@ -15,12 +15,13 @@ require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-$db->exec("CREATE TABLE test (a int PRIMARY KEY)");
+$db->query('DROP TABLE IF EXISTS b49985 CASCADE');
+$db->exec("CREATE TABLE b49985 (a int PRIMARY KEY)");
 
 for ($i = 0; $i < 3; $i++) {
     try {
         $db->beginTransaction();
-        $stmt = $db->prepare("INSERT INTO test (a) VALUES (?)");
+        $stmt = $db->prepare("INSERT INTO b49985 (a) VALUES (?)");
         var_dump($stmt->execute(array(1)));
         $db->commit();
     } catch (Exception $e) {
@@ -32,5 +33,5 @@ for ($i = 0; $i < 3; $i++) {
 ?>
 --EXPECTF--
 bool(true)
-SQLSTATE[23505]: %stest_pkey%s
-SQLSTATE[23505]: %stest_pkey%s
+SQLSTATE[23505]: %sb49985_pkey%s
+SQLSTATE[23505]: %sb49985_pkey%s

--- a/ext/pdo_pgsql/tests/copy_from.phpt
+++ b/ext/pdo_pgsql/tests/copy_from.phpt
@@ -16,7 +16,8 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->exec('CREATE TABLE test (a integer not null primary key, b text, c integer)');
+$db->query('DROP TABLE IF EXISTS test_copy_from CASCADE');
+$db->exec('CREATE TABLE test_copy_from (a integer not null primary key, b text, c integer)');
 
 echo "Preparing test file and array for CopyFrom tests\n";
 
@@ -40,9 +41,9 @@ file_put_contents($filenameWithDifferentNullValuesAndSelectedFields, implode("\n
 
 echo "Testing pgsqlCopyFromArray() with default parameters\n";
 $db->beginTransaction();
-var_dump($db->pgsqlCopyFromArray('test',$tableRows));
+var_dump($db->pgsqlCopyFromArray('test_copy_from',$tableRows));
 
-$stmt = $db->query("select * from test");
+$stmt = $db->query("select * from test_copy_from");
 foreach($stmt as $r) {
     var_dump($r);
 }
@@ -50,8 +51,8 @@ $db->rollback();
 
 echo "Testing pgsqlCopyFromArray() with different field separator and not null indicator\n";
 $db->beginTransaction();
-var_dump($db->pgsqlCopyFromArray('test',$tableRowsWithDifferentNullValues,";","NULL"));
-$stmt = $db->query("select * from test");
+var_dump($db->pgsqlCopyFromArray('test_copy_from',$tableRowsWithDifferentNullValues,";","NULL"));
+$stmt = $db->query("select * from test_copy_from");
 foreach($stmt as $r) {
     var_dump($r);
 }
@@ -59,8 +60,8 @@ $db->rollback();
 
 echo "Testing pgsqlCopyFromArray() with only selected fields\n";
 $db->beginTransaction();
-var_dump($db->pgsqlCopyFromArray('test',$tableRowsWithDifferentNullValuesAndSelectedFields,";","NULL",'a,c'));
-$stmt = $db->query("select * from test");
+var_dump($db->pgsqlCopyFromArray('test_copy_from',$tableRowsWithDifferentNullValuesAndSelectedFields,";","NULL",'a,c'));
+$stmt = $db->query("select * from test_copy_from");
 foreach($stmt as $r) {
     var_dump($r);
 }
@@ -77,9 +78,9 @@ $db->rollback();
 
 echo "Testing pgsqlCopyFromFile() with default parameters\n";
 $db->beginTransaction();
-var_dump($db->pgsqlCopyFromFile('test',$filename));
+var_dump($db->pgsqlCopyFromFile('test_copy_from',$filename));
 
-$stmt = $db->query("select * from test");
+$stmt = $db->query("select * from test_copy_from");
 foreach($stmt as $r) {
     var_dump($r);
 }
@@ -87,8 +88,8 @@ $db->rollback();
 
 echo "Testing pgsqlCopyFromFile() with different field separator and not null indicator\n";
 $db->beginTransaction();
-var_dump($db->pgsqlCopyFromFile('test',$filenameWithDifferentNullValues,";","NULL"));
-$stmt = $db->query("select * from test");
+var_dump($db->pgsqlCopyFromFile('test_copy_from',$filenameWithDifferentNullValues,";","NULL"));
+$stmt = $db->query("select * from test_copy_from");
 foreach($stmt as $r) {
     var_dump($r);
 }
@@ -96,8 +97,8 @@ $db->rollback();
 
 echo "Testing pgsqlCopyFromFile() with only selected fields\n";
 $db->beginTransaction();
-var_dump($db->pgsqlCopyFromFile('test',$filenameWithDifferentNullValuesAndSelectedFields,";","NULL",'a,c'));
-$stmt = $db->query("select * from test");
+var_dump($db->pgsqlCopyFromFile('test_copy_from',$filenameWithDifferentNullValuesAndSelectedFields,";","NULL",'a,c'));
+$stmt = $db->query("select * from test_copy_from");
 foreach($stmt as $r) {
     var_dump($r);
 }
@@ -115,7 +116,7 @@ $db->rollback();
 echo "Testing pgsqlCopyFromFile() with non existing file\n";
 $db->beginTransaction();
 try {
-    var_dump($db->pgsqlCopyFromFile('test',"nonexisting/foo.csv",";","NULL",'a,c'));
+    var_dump($db->pgsqlCopyFromFile('test_copy_from',"nonexisting/foo.csv",";","NULL",'a,c'));
 } catch (Exception $e) {
     echo "Exception: {$e->getMessage()}\n";
 }

--- a/ext/pdo_pgsql/tests/copy_to.phpt
+++ b/ext/pdo_pgsql/tests/copy_to.phpt
@@ -16,12 +16,13 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->exec('CREATE TABLE test (a integer not null primary key, b text, c integer)');
+$db->query('DROP TABLE IF EXISTS test_copy_to CASCADE');
+$db->exec('CREATE TABLE test_copy_to (a integer not null primary key, b text, c integer)');
 
 $db->beginTransaction();
 
 echo "Preparing test table for CopyTo tests\n";
-$stmt = $db->prepare("INSERT INTO test (a, b, c) values (?, ?, ?)");
+$stmt = $db->prepare("INSERT INTO test_copy_to (a, b, c) values (?, ?, ?)");
 
 for($i=0;$i<3;$i++) {
     $firstParameter = $i;
@@ -36,11 +37,11 @@ for($i=0;$i<3;$i++) {
 $db->commit();
 
 echo "Testing pgsqlCopyToArray() with default parameters\n";
-var_dump($db->pgsqlCopyToArray('test'));
+var_dump($db->pgsqlCopyToArray('test_copy_to'));
 echo "Testing pgsqlCopyToArray() with different field separator and not null indicator\n";
-var_dump($db->pgsqlCopyToArray('test',";","NULL"));
+var_dump($db->pgsqlCopyToArray('test_copy_to',";","NULL"));
 echo "Testing pgsqlCopyToArray() with only selected fields\n";
-var_dump($db->pgsqlCopyToArray('test',";","NULL",'a,c'));
+var_dump($db->pgsqlCopyToArray('test_copy_to',";","NULL",'a,c'));
 
 echo "Testing pgsqlCopyToArray() with error\n";
 try {
@@ -52,13 +53,13 @@ try {
 echo "Testing pgsqlCopyToFile() with default parameters\n";
 
 $filename="test_pgsqlCopyToFile.csv";
-var_dump($db->pgsqlCopyToFile('test',$filename));
+var_dump($db->pgsqlCopyToFile('test_copy_to',$filename));
 echo file_get_contents($filename);
 echo "Testing pgsqlCopyToFile() with different field separator and not null indicator\n";
-var_dump($db->pgsqlCopyToFile('test',$filename,";","NULL"));
+var_dump($db->pgsqlCopyToFile('test_copy_to',$filename,";","NULL"));
 echo file_get_contents($filename);
 echo "Testing pgsqlCopyToFile() with only selected fields\n";
-var_dump($db->pgsqlCopyToFile('test',$filename,";","NULL",'a,c'));
+var_dump($db->pgsqlCopyToFile('test_copy_to',$filename,";","NULL",'a,c'));
 echo file_get_contents($filename);
 
 echo "Testing pgsqlCopyToFile() with error\n";
@@ -70,7 +71,7 @@ try {
 
 echo "Testing pgsqlCopyToFile() to unwritable file\n";
 try {
-    var_dump($db->pgsqlCopyToFile('test', 'nonexistent/foo.csv'));
+    var_dump($db->pgsqlCopyToFile('test_copy_to', 'nonexistent/foo.csv'));
 } catch (Exception $e) {
     echo "Exception: {$e->getMessage()}\n";
 }

--- a/ext/pdo_pgsql/tests/is_in_transaction.phpt
+++ b/ext/pdo_pgsql/tests/is_in_transaction.phpt
@@ -16,14 +16,15 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
 
-$db->exec('CREATE TABLE test (a integer not null primary key, b text)');
+$db->query('DROP TABLE IF EXISTS test_is_in_transaction CASCADE');
+$db->exec('CREATE TABLE test_is_in_transaction (a integer not null primary key, b text)');
 
 $db->beginTransaction();
 try {
 echo "Test PDO::PGSQL_TRANSACTION_INTRANS\n";
 var_dump($db->inTransaction());
 
-$stmt = $db->prepare("INSERT INTO test (a, b) values (?, ?)");
+$stmt = $db->prepare("INSERT INTO test_is_in_transaction (a, b) values (?, ?)");
 $stmt->bindValue(1, 1);
 $stmt->bindValue(2, "test insert");
 $stmt->execute();
@@ -36,7 +37,7 @@ var_dump($db->inTransaction());
 $db->beginTransaction();
 
 try {
-$stmt = $db->prepare("INSERT INTO test (a, b) values (?, ?)");
+$stmt = $db->prepare("INSERT INTO test_is_in_transaction (a, b) values (?, ?)");
 $stmt->bindValue(1, "error");
 $stmt->bindValue(2, "test insert");
 $stmt->execute();


### PR DESCRIPTION
Following @Girgias' comment (https://github.com/php/php-src/pull/11855#discussion_r1282092294), I propose this PR to improve tests under `ext/pdo_pgsql` by renaming tables. Each table takes the test name, making them unique which is better to run tests in parallel.

If this gets merged, I'll try to have a look at other drivers! :slightly_smiling_face: 