### PR TITLE
Add `php_version` and `php_version_id` PHPAPI funcs

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -96,6 +96,16 @@ PHPAPI size_t core_globals_offset;
 
 #define SAFE_FILENAME(f) ((f)?(f):"-")
 
+PHPAPI const char *php_version(void)
+{
+	return PHP_VERSION;
+}
+
+PHPAPI unsigned int php_version_id(void)
+{
+	return PHP_VERSION_ID;
+}
+
 /* {{{ PHP_INI_MH */
 static PHP_INI_MH(OnSetFacility)
 {

--- a/main/php_main.h
+++ b/main/php_main.h
@@ -23,6 +23,19 @@
 #include "SAPI.h"
 
 BEGIN_EXTERN_C()
+
+/* Returns the PHP version the engine was built with. This is useful for
+ * extensions which want to know the version of PHP at run-time, rather than
+ * the version they were built with at compile-time.
+ */
+PHPAPI const char *php_version(void);
+
+/* Returns the PHP version id the engine was built with. This is useful for
+ * extensions which want to know the version of PHP at run-time, rather than
+ * the version they were built with at compile-time.
+ */
+PHPAPI unsigned int php_version_id(void);
+
 PHPAPI zend_result php_request_startup(void);
 PHPAPI void php_request_shutdown(void *dummy);
 PHPAPI zend_result php_module_startup(sapi_module_struct *sf, zend_module_entry *additional_module);


### PR DESCRIPTION
Mostly, extensions will use `PHP_VERSION` and `PHP_VERSION_ID` respectfully but sometimes they want to grab the version at run-time rather than at compile-time. For example, extensions which distribute pre-built binaries may want this.