### PR TITLE
Improve `ext/pdo_mysql` tests cleanup

### DIFF
--- a/ext/pdo_mysql/tests/bug44327.phpt
+++ b/ext/pdo_mysql/tests/bug44327.phpt
@@ -24,15 +24,13 @@ $db = MySQLPDOTest::factory();
 
     print "----------------------------------\n";
 
-    @$db->exec("DROP TABLE test");
-    $db->exec("CREATE TABLE test (id INT)");
-    $db->exec("INSERT INTO test(id) VALUES (1)");
-    $stmt = $db->prepare("SELECT id FROM test");
+    $db->exec("CREATE TABLE test_44327 (id INT)");
+    $db->exec("INSERT INTO test_44327(id) VALUES (1)");
+    $stmt = $db->prepare("SELECT id FROM test_44327");
     $stmt->execute();
     $row = $stmt->fetch(PDO::FETCH_LAZY);
     var_dump($row);
     var_dump($row->queryString);
-    @$db->exec("DROP TABLE test");
 
     print "----------------------------------\n";
 
@@ -41,6 +39,12 @@ $db = MySQLPDOTest::factory();
     $row = $stmt->fetch();
     var_dump($row->queryString);
 
+?>
+--CLEAN--
+<?php
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+$db = MySQLPDOTest::factory();
+$db->exec("DROP TABLE test_44327");
 ?>
 --EXPECTF--
 object(PDORow)#%d (2) {
@@ -55,11 +59,11 @@ string(17) "SELECT 1 AS "one""
 ----------------------------------
 object(PDORow)#5 (2) {
   ["queryString"]=>
-  string(19) "SELECT id FROM test"
+  string(25) "SELECT id FROM test_44327"
   ["id"]=>
   string(1) "1"
 }
-string(19) "SELECT id FROM test"
+string(25) "SELECT id FROM test_44327"
 ----------------------------------
 
 Warning: Attempt to read property "queryString" on false in %s on line %d

--- a/ext/pdo_mysql/tests/bug46292.phpt
+++ b/ext/pdo_mysql/tests/bug46292.phpt
@@ -27,13 +27,11 @@ MySQLPDOTest::skip();
     $pdoDb->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
     $pdoDb->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
-    $pdoDb->query('DROP TABLE IF EXISTS testz');
+    $pdoDb->query('CREATE TABLE test_46292 (name VARCHAR(20) NOT NULL, value INT)');
 
-    $pdoDb->query('CREATE TABLE testz (name VARCHAR(20) NOT NULL, value INT)');
+    $pdoDb->query("INSERT INTO test_46292 VALUES ('myclass', 1), ('myclass2', 2), ('myclass', NULL), ('myclass3', NULL)");
 
-    $pdoDb->query("INSERT INTO testz VALUES ('myclass', 1), ('myclass2', 2), ('myclass', NULL), ('myclass3', NULL)");
-
-    $stmt = $pdoDb->prepare("SELECT * FROM testz");
+    $stmt = $pdoDb->prepare("SELECT * FROM test_46292");
 
     var_dump($stmt->setFetchMode(PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE | PDO::FETCH_GROUP));
     $stmt->execute();
@@ -46,7 +44,7 @@ MySQLPDOTest::skip();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS testz');
+$db->exec('DROP TABLE IF EXISTS test_46292');
 ?>
 --EXPECTF--
 bool(true)

--- a/ext/pdo_mysql/tests/bug66528.phpt
+++ b/ext/pdo_mysql/tests/bug66528.phpt
@@ -16,11 +16,10 @@ $dbh = MySQLPDOTest::factory();
 $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $dbh->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
 
-$dbh->exec('DROP TABLE IF EXISTS test');
-$dbh->exec('CREATE TABLE test (a int) engine=innodb');
+$dbh->exec('CREATE TABLE test_66528 (a int) engine=innodb');
 $dbh->beginTransaction();
-$dbh->exec('INSERT INTO test (a) VALUES (1), (2)');
-$stmt = $dbh->query('SELECT * FROM test');
+$dbh->exec('INSERT INTO test_66528 (a) VALUES (1), (2)');
+$stmt = $dbh->query('SELECT * FROM test_66528');
 
 try {
 	$dbh->commit();
@@ -44,7 +43,7 @@ try {
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+MySQLPDOTest::dropTestTable(NULL, 'test_66528');
 ?>
 --EXPECT--
 SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other unbuffered queries are active.  Consider using PDOStatement::fetchAll().  Alternatively, if your code is only ever going to run against mysql, you may enable query buffering by setting the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY attribute.

--- a/ext/pdo_mysql/tests/bug70862.phpt
+++ b/ext/pdo_mysql/tests/bug70862.phpt
@@ -12,8 +12,7 @@ MySQLPDOTest::skip();
     require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
     $db = MySQLPDOTest::factory();
 
-    $db->exec('DROP TABLE IF EXISTS test');
-    $db->exec(sprintf('CREATE TABLE test(id INT, label BLOB)'));
+    $db->exec(sprintf('CREATE TABLE test_70862(id INT, label BLOB)'));
 
     $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
     $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
@@ -29,7 +28,7 @@ MySQLPDOTest::skip();
 
     $f = fopen("hello://there", "r");
 
-    $stmt = $db->prepare('INSERT INTO test(id, label) VALUES (1, :para)');
+    $stmt = $db->prepare('INSERT INTO test_70862(id, label) VALUES (1, :para)');
     $stmt->bindParam(":para", $f, PDO::PARAM_LOB);
     $stmt->execute();
 
@@ -41,7 +40,7 @@ MySQLPDOTest::skip();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_70862');
 ?>
 --EXPECT--
 string(0) ""

--- a/ext/pdo_mysql/tests/bug75177.phpt
+++ b/ext/pdo_mysql/tests/bug75177.phpt
@@ -13,21 +13,17 @@ if (!MySQLPDOTest::isPDOMySQLnd()) die('skip only for mysqlnd');
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $pdo = MySQLPDOTest::factory();
 
-$tbl = "test";
-$pdo->query("DROP TABLE IF EXISTS $tbl");
-$pdo->query("CREATE TABLE $tbl (`bit` bit(8)) ENGINE=InnoDB");
-$pdo->query("INSERT INTO $tbl (`bit`) VALUES (1)");
-$pdo->query("INSERT INTO $tbl (`bit`) VALUES (0b011)");
-$pdo->query("INSERT INTO $tbl (`bit`) VALUES (0b01100)");
+$pdo->query("CREATE TABLE test_75177 (`bit` bit(8)) ENGINE=InnoDB");
+$pdo->query("INSERT INTO test_75177 (`bit`) VALUES (1), (0b011), (0b01100)");
 
 $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
-$ret = $pdo->query("SELECT * FROM $tbl")->fetchAll();
+$ret = $pdo->query("SELECT * FROM test_75177")->fetchAll();
 foreach ($ret as $i) {
     var_dump($i["bit"]);
 }
 
 $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
-$ret = $pdo->query("SELECT * FROM $tbl")->fetchAll();
+$ret = $pdo->query("SELECT * FROM test_75177")->fetchAll();
 foreach ($ret as $i) {
     var_dump($i["bit"]);
 }
@@ -36,7 +32,7 @@ foreach ($ret as $i) {
 --CLEAN--
 <?php
 require dirname(__FILE__) . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+MySQLPDOTest::dropTestTable(NULL, 'test_75177');
 ?>
 --EXPECT--
 int(1)

--- a/ext/pdo_mysql/tests/bug79375.phpt
+++ b/ext/pdo_mysql/tests/bug79375.phpt
@@ -22,14 +22,13 @@ function createDB(): PDO {
 
 $db = createDB();
 $db2 = createDB();
-$db->query('DROP TABLE IF EXISTS test');
-$db->query('CREATE TABLE test (first int) ENGINE = InnoDB');
-$db->query('INSERT INTO test VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9)');
+$db->query('CREATE TABLE test_79375 (first int) ENGINE = InnoDB');
+$db->query('INSERT INTO test_79375 VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9)');
 
 function testNormalQuery(PDO $db, string $name) {
     $db->exec("SET innodb_lock_wait_timeout = 1");
     $db->exec("START TRANSACTION");
-    $query = "SELECT first FROM test WHERE first = 1 FOR UPDATE";
+    $query = "SELECT first FROM test_79375 WHERE first = 1 FOR UPDATE";
     echo "Running query on $name\n";
     try {
         $stmt = $db->query($query);
@@ -42,7 +41,7 @@ function testNormalQuery(PDO $db, string $name) {
 function testPrepareExecute(PDO $db, string $name) {
     $db->exec("SET innodb_lock_wait_timeout = 1");
     $db->exec("START TRANSACTION");
-    $query = "SELECT first FROM test WHERE first = 1 FOR UPDATE";
+    $query = "SELECT first FROM test_79375 WHERE first = 1 FOR UPDATE";
     echo "Running query on $name\n";
     $stmt = $db->prepare($query);
     try {
@@ -57,7 +56,7 @@ function testUnbuffered(PDO $db, string $name) {
     $db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
     $db->exec("SET innodb_lock_wait_timeout = 1");
     $db->exec("START TRANSACTION");
-    $query = "SELECT first FROM test WHERE first = 1 FOR UPDATE";
+    $query = "SELECT first FROM test_79375 WHERE first = 1 FOR UPDATE";
     echo "Running query on $name\n";
     $stmt = $db->prepare($query);
     $stmt->execute();
@@ -96,7 +95,8 @@ echo "\n";
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_79375');
 ?>
 --EXPECT--
 Running query on first connection

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -17,41 +17,38 @@ $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
-$db->query('DROP TABLE IF EXISTS test');
-$db->query('CREATE TABLE test (first int) ENGINE = InnoDB');
-$res = $db->query('INSERT INTO test(first) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16)');
+$db->query('CREATE TABLE test_80458 (first int) ENGINE = InnoDB');
+$res = $db->query('INSERT INTO test_80458(first) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16)');
 var_dump($res->fetchAll());
 
-$stmt = $db->prepare('DELETE FROM test WHERE first=1');
+$stmt = $db->prepare('DELETE FROM test_80458 WHERE first=1');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
-$res = $db->query('DELETE FROM test WHERE first=2');
+$res = $db->query('DELETE FROM test_80458 WHERE first=2');
 var_dump($res->fetchAll());
 
-$stmt2 = $db->prepare('DELETE FROM test WHERE first=3');
+$stmt2 = $db->prepare('DELETE FROM test_80458 WHERE first=3');
 $stmt2->execute();
 foreach($stmt2 as $row){
     // expect nothing
 }
 
-$stmt3 = $db->prepare('DELETE FROM test WHERE first=4');
+$stmt3 = $db->prepare('DELETE FROM test_80458 WHERE first=4');
 $stmt3->execute();
 var_dump($stmt3->fetch(PDO::FETCH_ASSOC));
 
-$stmt = $db->prepare('SELECT first FROM test WHERE first=5');
+$stmt = $db->prepare('SELECT first FROM test_80458 WHERE first=5');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
-$db->exec('DROP PROCEDURE IF EXISTS nores');
-$db->exec('CREATE PROCEDURE nores() BEGIN DELETE FROM test WHERE first=6; END;');
+$db->exec('CREATE PROCEDURE nores() BEGIN DELETE FROM test_80458 WHERE first=6; END;');
 $stmt4 = $db->prepare('CALL nores()');
 $stmt4->execute();
 var_dump($stmt4->fetchAll());
 $db->exec('DROP PROCEDURE IF EXISTS nores');
 
-$db->exec('DROP PROCEDURE IF EXISTS ret');
-$db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test WHERE first=7; END;');
+$db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test_80458 WHERE first=7; END;');
 $stmt5 = $db->prepare('CALL ret()');
 $stmt5->execute();
 var_dump($stmt5->fetchAll());
@@ -63,36 +60,36 @@ $db->exec('DROP PROCEDURE IF EXISTS ret');
 print("Emulated prepares\n");
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
-$stmt = $db->prepare('DELETE FROM test WHERE first=8');
+$stmt = $db->prepare('DELETE FROM test_80458 WHERE first=8');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
-$res = $db->query('DELETE FROM test WHERE first=9');
+$res = $db->query('DELETE FROM test_80458 WHERE first=9');
 var_dump($res->fetchAll());
 
-$stmt2 = $db->prepare('DELETE FROM test WHERE first=10');
+$stmt2 = $db->prepare('DELETE FROM test_80458 WHERE first=10');
 $stmt2->execute();
 foreach($stmt2 as $row){
     // expect nothing
 }
 
-$stmt3 = $db->prepare('DELETE FROM test WHERE first=11');
+$stmt3 = $db->prepare('DELETE FROM test_80458 WHERE first=11');
 $stmt3->execute();
 var_dump($stmt3->fetch(PDO::FETCH_ASSOC));
 
-$stmt = $db->prepare('SELECT first FROM test WHERE first=12');
+$stmt = $db->prepare('SELECT first FROM test_80458 WHERE first=12');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
 $db->exec('DROP PROCEDURE IF EXISTS nores');
-$db->exec('CREATE PROCEDURE nores() BEGIN DELETE FROM test WHERE first=13; END;');
+$db->exec('CREATE PROCEDURE nores() BEGIN DELETE FROM test_80458 WHERE first=13; END;');
 $stmt4 = $db->prepare('CALL nores()');
 $stmt4->execute();
 var_dump($stmt4->fetchAll());
 $db->exec('DROP PROCEDURE IF EXISTS nores');
 
 $db->exec('DROP PROCEDURE IF EXISTS ret');
-$db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test WHERE first=14; END;');
+$db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test_80458 WHERE first=14; END;');
 $stmt5 = $db->prepare('CALL ret()');
 $stmt5->execute();
 var_dump($stmt5->fetchAll());
@@ -103,11 +100,11 @@ $db->exec('DROP PROCEDURE IF EXISTS ret');
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 $db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
 
-$stmt = $db->prepare('DELETE FROM test WHERE first=15');
+$stmt = $db->prepare('DELETE FROM test_80458 WHERE first=15');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
-$stmt = $db->prepare('SELECT first FROM test WHERE first=16');
+$stmt = $db->prepare('SELECT first FROM test_80458 WHERE first=16');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
@@ -115,7 +112,10 @@ var_dump($stmt->fetchAll());
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+MySQLPDOTest::dropTestTable($db, 'test_80458');
+$db->exec('DROP PROCEDURE IF EXISTS nores');
+$db->exec('DROP PROCEDURE IF EXISTS ret');
 ?>
 --EXPECT--
 array(0) {

--- a/ext/pdo_mysql/tests/bug80458.phpt
+++ b/ext/pdo_mysql/tests/bug80458.phpt
@@ -81,14 +81,10 @@ $stmt = $db->prepare('SELECT first FROM test_80458 WHERE first=12');
 $stmt->execute();
 var_dump($stmt->fetchAll());
 
-$db->exec('DROP PROCEDURE IF EXISTS nores');
 $db->exec('CREATE PROCEDURE nores() BEGIN DELETE FROM test_80458 WHERE first=13; END;');
 $stmt4 = $db->prepare('CALL nores()');
 $stmt4->execute();
 var_dump($stmt4->fetchAll());
-$db->exec('DROP PROCEDURE IF EXISTS nores');
-
-$db->exec('DROP PROCEDURE IF EXISTS ret');
 $db->exec('CREATE PROCEDURE ret() BEGIN SELECT first FROM test_80458 WHERE first=14; END;');
 $stmt5 = $db->prepare('CALL ret()');
 $stmt5->execute();

--- a/ext/pdo_mysql/tests/bug80808.phpt
+++ b/ext/pdo_mysql/tests/bug80808.phpt
@@ -13,15 +13,20 @@ MySQLPDOTest::skip();
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $pdo = MySQLPDOTest::factory();
 
-$pdo->exec('DROP TABLE IF EXISTS test');
-$pdo->exec('CREATE TABLE test (postcode INT(4) UNSIGNED ZEROFILL)');
-$pdo->exec('INSERT INTO test (postcode) VALUES (\'0800\')');
+$pdo->exec('CREATE TABLE test_80808 (postcode INT(4) UNSIGNED ZEROFILL)');
+$pdo->exec('INSERT INTO test_80808 (postcode) VALUES (\'0800\')');
 
 $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
-var_dump($pdo->query('SELECT * FROM test')->fetchColumn(0));
+var_dump($pdo->query('SELECT * FROM test_80808')->fetchColumn(0));
 $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
-var_dump($pdo->query('SELECT * FROM test')->fetchColumn(0));
+var_dump($pdo->query('SELECT * FROM test_80808')->fetchColumn(0));
 
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_80808');
 ?>
 --EXPECT--
 string(4) "0800"

--- a/ext/pdo_mysql/tests/bug80908.phpt
+++ b/ext/pdo_mysql/tests/bug80908.phpt
@@ -20,14 +20,13 @@ function createDB(): PDO {
 }
 
 $db = createDB();
-$db->exec('DROP TABLE IF EXISTS test');
-$db->exec('CREATE TABLE test (`id` bigint(20) unsigned AUTO_INCREMENT, `name` varchar(5), primary key (`id`)) ENGINE = InnoDB AUTO_INCREMENT=10376293541461622799');
+$db->exec('CREATE TABLE test_80908 (`id` bigint(20) unsigned AUTO_INCREMENT, `name` varchar(5), primary key (`id`)) ENGINE = InnoDB AUTO_INCREMENT=10376293541461622799');
 
 function testLastInsertId(PDO $db) {
     echo "Running test lastInsertId\n";
     $db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
     try {
-        $db->exec("insert into test (`name`) values ('bar')");
+        $db->exec("insert into test_80908 (`name`) values ('bar')");
         $id = $db->lastInsertId();
         echo "Last insert id is " . $id . "\n";
     } catch (PDOException $e) {
@@ -43,7 +42,8 @@ echo "\n";
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_80908');
 ?>
 --EXPECT--
 Running test lastInsertId

--- a/ext/pdo_mysql/tests/bug_33689.phpt
+++ b/ext/pdo_mysql/tests/bug_33689.phpt
@@ -15,15 +15,15 @@ require __DIR__ . '/config.inc';
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 
-$db->exec('CREATE TABLE test (bar INT NOT NULL)');
-$db->exec('INSERT INTO test VALUES(1)');
+$db->exec('CREATE TABLE test_33689 (bar INT NOT NULL)');
+$db->exec('INSERT INTO test_33689 VALUES(1)');
 
-var_dump($db->query('SELECT * from test'));
-foreach ($db->query('SELECT * from test') as $row) {
+var_dump($db->query('SELECT * from test_33689'));
+foreach ($db->query('SELECT * from test_33689') as $row) {
     print_r($row);
 }
 
-$stmt = $db->prepare('SELECT * from test');
+$stmt = $db->prepare('SELECT * from test_33689');
 print_r($stmt->getColumnMeta(0));
 $stmt->execute();
 $tmp = $stmt->getColumnMeta(0);
@@ -40,12 +40,13 @@ print_r($tmp);
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_33689');
 ?>
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(18) "SELECT * from test"
+  string(24) "SELECT * from test_33689"
 }
 Array
 (
@@ -60,7 +61,7 @@ Array
             [0] => not_null
         )
 
-    [table] => test
+    [table] => test_33689
     [name] => bar
     [len] => 11
     [precision] => 0

--- a/ext/pdo_mysql/tests/bug_38546.phpt
+++ b/ext/pdo_mysql/tests/bug_38546.phpt
@@ -20,9 +20,7 @@ $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 // To test error cases.
 $db->exec("SET sql_mode='STRICT_TRANS_TABLES'");
 
-$db->exec("DROP TABLE IF EXISTS test");
-
-$query = "CREATE TABLE test(
+$query = "CREATE TABLE test_38546(
             uid MEDIUMINT UNSIGNED NOT NULL,
             some_bool_1 BOOL NOT NULL,
             some_bool_2 BOOL NOT NULL,
@@ -30,7 +28,7 @@ $query = "CREATE TABLE test(
         )";
 $db->exec($query);
 
-$st = $db->prepare("INSERT INTO test (uid, some_bool_1, some_bool_2, some_int) VALUES (?, ?, ?, ?)");
+$st = $db->prepare("INSERT INTO test_38546 (uid, some_bool_1, some_bool_2, some_int) VALUES (?, ?, ?, ?)");
 
 $values = [
     'uid' => 6,
@@ -51,11 +49,11 @@ if ($result === false) {
     print("ok insert\n");
 }
 
-foreach ($db->query('SELECT * from test') as $row) {
+foreach ($db->query('SELECT * from test_38546') as $row) {
     print_r($row);
 }
 
-$st = $db->prepare("UPDATE test SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
+$st = $db->prepare("UPDATE test_38546 SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
 
 $values = [
     'uid' => 6,
@@ -77,11 +75,11 @@ if ($result === false) {
     print("ok prepare 1\n");
 }
 
-foreach ($db->query('SELECT * from test') as $row) {
+foreach ($db->query('SELECT * from test_38546') as $row) {
     print_r($row);
 }
 
-$st = $db->prepare("UPDATE test SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
+$st = $db->prepare("UPDATE test_38546 SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
 
 $values = [
     'uid' => 6,
@@ -103,12 +101,12 @@ if ($result === false) {
     print("ok prepare 2\n");
 }
 
-foreach ($db->query('SELECT * from test') as $row) {
+foreach ($db->query('SELECT * from test_38546') as $row) {
     print_r($row);
 }
 
 // String true and false should fail
-$st = $db->prepare("UPDATE test SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
+$st = $db->prepare("UPDATE test_38546 SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
 
 $values = [
     'uid' => 6,
@@ -130,12 +128,12 @@ if ($result === false) {
     print("ok prepare 3\n");
 }
 
-foreach ($db->query('SELECT * from test') as $row) {
+foreach ($db->query('SELECT * from test_38546') as $row) {
     print_r($row);
 }
 
 // Null should not be treated as false
-$st = $db->prepare("UPDATE test SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
+$st = $db->prepare("UPDATE test_38546 SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
 
 $values = [
     'uid' => 6,
@@ -157,12 +155,12 @@ if ($result === false) {
     print("ok prepare 4\n");
 }
 
-foreach ($db->query('SELECT * from test') as $row) {
+foreach ($db->query('SELECT * from test_38546') as $row) {
     print_r($row);
 }
 
 // Integers converted correctly
-$st = $db->prepare("UPDATE test SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
+$st = $db->prepare("UPDATE test_38546 SET some_bool_1=?, some_bool_2=?, some_int=? WHERE uid=?");
 
 $values = [
     'uid' => 6,
@@ -184,7 +182,7 @@ if ($result === false) {
     print("ok prepare 5\n");
 }
 
-foreach ($db->query('SELECT * from test') as $row) {
+foreach ($db->query('SELECT * from test_38546') as $row) {
     print_r($row);
 }
 
@@ -192,7 +190,8 @@ foreach ($db->query('SELECT * from test') as $row) {
 --CLEAN--
 <?php
 require dirname(__FILE__) . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_38546');
 ?>
 --EXPECTF--
 ok insert

--- a/ext/pdo_mysql/tests/bug_41125.phpt
+++ b/ext/pdo_mysql/tests/bug_41125.phpt
@@ -23,11 +23,10 @@ if ($version < 40100)
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $db = MySQLPDOTest::factory();
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
-$db->exec("DROP TABLE IF EXISTS test");
 
 // And now allow the evil to do his work
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 1);
-$sql = "CREATE TABLE IF NOT EXISTS test(id INT); INSERT INTO test(id) VALUES (1); SELECT * FROM test; INSERT INTO test(id) VALUES (2); SELECT * FROM test;";
+$sql = "CREATE TABLE IF NOT EXISTS test_41125(id INT); INSERT INTO test_41125(id) VALUES (1); SELECT * FROM test_41125; INSERT INTO test_41125(id) VALUES (2); SELECT * FROM test_41125;";
 $stmt = $db->query($sql);
 do {
     var_dump($stmt->fetchAll());
@@ -39,7 +38,7 @@ print "done!";
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec("DROP TABLE IF EXISTS test");
+$db->exec("DROP TABLE IF EXISTS test_41125");
 ?>
 --EXPECT--
 array(0) {

--- a/ext/pdo_mysql/tests/bug_42499.phpt
+++ b/ext/pdo_mysql/tests/bug_42499.phpt
@@ -28,16 +28,16 @@ $db = MySQLPDOTest::factory();
 
 function bug_42499($db) {
 
-    $db->exec('DROP TABLE IF EXISTS test');
-    $db->exec("CREATE TABLE test(id CHAR(1)); INSERT INTO test(id) VALUES ('a')");
+    $db->exec("DROP TABLE IF EXISTS test_42499");
+    $db->exec("CREATE TABLE test_42499(id CHAR(1)); INSERT INTO test_42499(id) VALUES ('a')");
 
-    $stmt = $db->query('SELECT id AS _id FROM test');
+    $stmt = $db->query('SELECT id AS _id FROM test_42499');
     var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
     // You must not use exec() to run statements that create a result set!
-    $db->exec('SELECT id FROM test');
+    $db->exec('SELECT id FROM test_42499');
     // This will bail at you because you have not fetched the SELECT results: this is not a bug!
-    $db->exec("INSERT INTO test(id) VALUES ('b')");
+    $db->exec("INSERT INTO test_42499(id) VALUES ('b')");
 
 }
 
@@ -53,10 +53,13 @@ $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 $db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, 1);
 bug_42499($db);
 
-$db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
-
 print "done!";
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+$db = MySQLPDOTest::factory();
+$db->exec("DROP TABLE IF EXISTS test_42499");
 ?>
 --EXPECTF--
 Emulated Prepared Statements...

--- a/ext/pdo_mysql/tests/bug_44454.phpt
+++ b/ext/pdo_mysql/tests/bug_44454.phpt
@@ -19,36 +19,36 @@ function bug_44454($db) {
 
     try {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec('CREATE TABLE test(a INT, b INT, UNIQUE KEY idx_ab (a, b))');
-        $db->exec('INSERT INTO test(a, b) VALUES (1, 1)');
+        $db->exec('DROP TABLE IF EXISTS test_44454');
+        $db->exec('CREATE TABLE test_44454(a INT, b INT, UNIQUE KEY idx_ab (a, b))');
+        $db->exec('INSERT INTO test_44454(a, b) VALUES (1, 1)');
 
-        $stmt = $db->query('SELECT a, b FROM test');
+        $stmt = $db->query('SELECT a, b FROM test_44454');
         printf("... SELECT has returned %d row...\n", $stmt->rowCount());
         while ($row = $stmt->fetch()) {
             try {
                 printf("... INSERT should fail...\n");
-                $db->exec('INSERT INTO test(a, b) VALUES (1, 1)');
+                $db->exec('INSERT INTO test_44454(a, b) VALUES (1, 1)');
             } catch (Exception $e) {
                 printf("... STMT - %s\n", var_export($stmt->errorCode(), true));
                 printf("... PDO  - %s\n", var_export($db->errorInfo(), true));
             }
         }
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec('CREATE TABLE test(a INT, b INT, UNIQUE KEY idx_ab (a, b))');
-        $db->exec('INSERT INTO test(a, b) VALUES (1, 1)');
+        $db->exec('DROP TABLE IF EXISTS test_44454');
+        $db->exec('CREATE TABLE test_44454(a INT, b INT, UNIQUE KEY idx_ab (a, b))');
+        $db->exec('INSERT INTO test_44454(a, b) VALUES (1, 1)');
 
     } catch (Exception $e) {
         printf("... While error %s\n", $e->getMessage()); ;
     }
 
-    $stmt = $db->query('SELECT a, b FROM test');
+    $stmt = $db->query('SELECT a, b FROM test_44454');
     printf("... SELECT has returned %d row...\n", $stmt->rowCount());
     foreach ($stmt as $row) {
         try {
             printf("... INSERT should fail...\n");
-            $db->exec('INSERT INTO test(a, b) VALUES (1, 1)');
+            $db->exec('INSERT INTO test_44454(a, b) VALUES (1, 1)');
         } catch (Exception $e) {
             printf("... STMT - %s\n", var_export($stmt->errorCode(), true));
             printf("... PDO  - %s\n", var_export($db->errorInfo(), true));
@@ -73,7 +73,7 @@ print "done!";
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_44454');
 ?>
 --EXPECTF--
 Native Prepared Statements

--- a/ext/pdo_mysql/tests/bug_44707.phpt
+++ b/ext/pdo_mysql/tests/bug_44707.phpt
@@ -29,14 +29,13 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 
 function bug_44707($db) {
 
-    $db->exec('DROP TABLE IF EXISTS test');
-    $db->exec('CREATE TABLE test(id INT, mybool TINYINT)');
+    $db->exec('CREATE TABLE test_44707(id INT, mybool TINYINT)');
 
     $id = 1;
     $mybool = false;
     var_dump($mybool);
 
-    $stmt = $db->prepare('INSERT INTO test(id, mybool) VALUES (?, ?)');
+    $stmt = $db->prepare('INSERT INTO test_44707(id, mybool) VALUES (?, ?)');
     $stmt->bindParam(1, $id);
     $stmt->bindParam(2, $mybool, PDO::PARAM_BOOL);
     var_dump($mybool);
@@ -44,16 +43,16 @@ function bug_44707($db) {
     $stmt->execute();
     var_dump($mybool);
 
-    $stmt = $db->query('SELECT * FROM test');
+    $stmt = $db->query('SELECT * FROM test_44707');
     var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
-    $stmt = $db->prepare('INSERT INTO test(id, mybool) VALUES (?, ?)');
+    $stmt = $db->prepare('INSERT INTO test_44707(id, mybool) VALUES (?, ?)');
     $stmt->bindParam(1, $id);
     // INT and integer work well together
     $stmt->bindParam(2, $mybool, PDO::PARAM_INT);
     $stmt->execute();
 
-    $stmt = $db->query('SELECT * FROM test');
+    $stmt = $db->query('SELECT * FROM test_44707');
     var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
 }
@@ -71,6 +70,12 @@ $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 bug_44707($db);
 
 print "done!";
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_44707');
 ?>
 --EXPECT--
 Native Prepared Statements

--- a/ext/pdo_mysql/tests/bug_61207.phpt
+++ b/ext/pdo_mysql/tests/bug_61207.phpt
@@ -14,12 +14,11 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 /** @var PDO $db */
 $db = MySQLPDOTest::factory();
 
-$db->query('DROP TABLE IF EXISTS test');
-$db->query('create table `test`( `id` int )');
+$db->query('create table `test_61207`( `id` int )');
 
-$handle1 = $db->prepare('insert into test(id) values(1);
-                          select * from test where id = ?;
-                          update test set id = 2 where id = ?;');
+$handle1 = $db->prepare('insert into test_61207(id) values(1);
+                          select * from test_61207 where id = ?;
+                          update test_61207 set id = 2 where id = ?;');
 
 $handle1->bindValue(1, '1');
 $handle1->bindValue(2, '1');
@@ -33,8 +32,8 @@ do {
         print("Results detected\n");
 } while($handle1->nextRowset());
 
-$handle2 = $db->prepare('select * from test where id = ?;
-                           update test set id = 1 where id = ?;');
+$handle2 = $db->prepare('select * from test_61207 where id = ?;
+                           update test_61207 set id = 1 where id = ?;');
 
 $handle2->bindValue(1, '2');
 $handle2->bindValue(2, '2');
@@ -49,8 +48,8 @@ do {
         print("Results detected\n");
 } while($handle2->nextRowset());
 
-$handle3 = $db->prepare('update test set id = 2 where id = ?;
-                           select * from test where id = ?;');
+$handle3 = $db->prepare('update test_61207 set id = 2 where id = ?;
+                           select * from test_61207 where id = ?;');
 
 $handle3->bindValue(1, '1');
 $handle3->bindValue(2, '2');
@@ -65,9 +64,9 @@ do {
         print("Results detected\n");
 } while($handle3->nextRowset());
 
-$handle4 = $db->prepare('insert into test(id) values(3);
-                           update test set id = 2 where id = ?;
-                           select * from test where id = ?;');
+$handle4 = $db->prepare('insert into test_61207(id) values(3);
+                           update test_61207 set id = 2 where id = ?;
+                           select * from test_61207 where id = ?;');
 
 $handle4->bindValue(1, '3');
 $handle4->bindValue(2, '2');
@@ -81,13 +80,12 @@ do {
     if ($handle1->columnCount() > 0)
         print("Results detected\n");
 } while($handle1->nextRowset());
-
-$db->query("DROP TABLE test");
 ?>
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_61207');
 ?>
 --EXPECT--
 Handle 1:

--- a/ext/pdo_mysql/tests/bug_pecl_12925.phpt
+++ b/ext/pdo_mysql/tests/bug_pecl_12925.phpt
@@ -16,14 +16,14 @@ $db = MySQLPDOTest::factory();
 
 function bug_pecl_1295($db) {
 
-    $db->exec('DROP TABLE IF EXISTS test');
-    $db->exec('CREATE TABLE test(id CHAR(1))');
-    $db->exec("INSERT INTO test(id) VALUES ('a')");
-    $stmt = $db->prepare("UPDATE test SET id = 'b'");
+    $db->exec('DROP TABLE IF EXISTS test_12925');
+    $db->exec('CREATE TABLE test_12925(id CHAR(1))');
+    $db->exec("INSERT INTO test_12925(id) VALUES ('a')");
+    $stmt = $db->prepare("UPDATE test_12925 SET id = 'b'");
     $stmt->execute();
-    $stmt = $db->prepare("UPDATE test SET id = 'c'");
+    $stmt = $db->prepare("UPDATE test_12925 SET id = 'c'");
     $stmt->execute();
-    $stmt = $db->prepare('SELECT id FROM test');
+    $stmt = $db->prepare('SELECT id FROM test_12925');
     $stmt->execute();
     var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
     $stmt->closeCursor();
@@ -40,8 +40,13 @@ $db = MySQLPDOTest::factory();
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 bug_pecl_1295($db);
 
-$db->exec('DROP TABLE IF EXISTS test');
 print "done!";
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_12925');
 ?>
 --EXPECT--
 Emulated...

--- a/ext/pdo_mysql/tests/change_column_count.phpt
+++ b/ext/pdo_mysql/tests/change_column_count.phpt
@@ -16,20 +16,19 @@ $db = MySQLPDOTest::factory();
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 
-$db->exec('DROP TABLE IF EXISTS test');
-$db->exec('CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(255) NOT NULL)');
+$db->exec('CREATE TABLE test_change_column_count (id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(255) NOT NULL)');
 
-$stmt = $db->prepare('INSERT INTO test (id, name) VALUES(:id, :name)');
+$stmt = $db->prepare('INSERT INTO test_change_column_count (id, name) VALUES(:id, :name)');
 $stmt->execute([
     'id'   => 10,
     'name' => 'test',
 ]);
 
-$stmt = $db->prepare('SELECT * FROM test WHERE id = :id');
+$stmt = $db->prepare('SELECT * FROM test_change_column_count WHERE id = :id');
 $stmt->execute(['id' => 10]);
 var_dump($stmt->fetchAll(\PDO::FETCH_ASSOC));
 
-$db->exec('ALTER TABLE test ADD new_col VARCHAR(255)');
+$db->exec('ALTER TABLE test_change_column_count ADD new_col VARCHAR(255)');
 $stmt->execute(['id' => 10]);
 var_dump($stmt->fetchAll(\PDO::FETCH_ASSOC));
 
@@ -37,7 +36,8 @@ var_dump($stmt->fetchAll(\PDO::FETCH_ASSOC));
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_change_column_count');
 ?>
 --EXPECT--
 array(1) {

--- a/ext/pdo_mysql/tests/gh-11587.phpt
+++ b/ext/pdo_mysql/tests/gh-11587.phpt
@@ -13,10 +13,8 @@ if (!extension_loaded('mysqlnd')) die('skip: This test requires the loading of m
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $db = MySQLPDOTest::factory();
 
-$db->exec('DROP TABLE IF EXISTS test');
-
 $createTestTable = <<<SQL
-CREATE TABLE test(
+CREATE TABLE test_11587(
    id INT,
   `float_col` FLOAT(3,2) DEFAULT NULL,
   `double_col` DOUBLE(3,2) DEFAULT NULL,
@@ -27,7 +25,7 @@ SQL;
 $db->exec($createTestTable);
 
 $insertTestTable = <<<SQL
-INSERT INTO test(id, float_col, double_col, decimal_col) VALUES(1, 2.60, 3.60, 4.60)
+INSERT INTO test_11587(id, float_col, double_col, decimal_col) VALUES(1, 2.60, 3.60, 4.60)
 SQL;
 
 $db->exec($insertTestTable);
@@ -35,7 +33,7 @@ $db->exec($insertTestTable);
 echo "PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = true\n";
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
-$results = $db->query('SELECT * FROM test');
+$results = $db->query('SELECT * FROM test_11587');
 foreach ($results as $result) {
     var_dump($result);
 }
@@ -45,7 +43,7 @@ echo "\n";
 echo "PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = false\n";
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
-$results = $db->query('SELECT * FROM test');
+$results = $db->query('SELECT * FROM test_11587');
 foreach ($results as $result) {
     var_dump($result);
 }
@@ -55,7 +53,7 @@ echo "\n";
 echo "PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = true\n";
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
-$results = $db->query('SELECT * FROM test');
+$results = $db->query('SELECT * FROM test_11587');
 foreach ($results as $result) {
     var_dump($result);
 }
@@ -65,7 +63,7 @@ echo "\n";
 echo "PDO::ATTR_EMULATE_PREPARES = false, PDO::ATTR_STRINGIFY_FETCHES = false\n";
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
-$results = $db->query('SELECT * FROM test');
+$results = $db->query('SELECT * FROM test_11587');
 foreach ($results as $result) {
     var_dump($result);
 }
@@ -77,7 +75,8 @@ echo 'done!';
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_11587');
 ?>
 --EXPECT--
 PDO::ATTR_EMULATE_PREPARES = true, PDO::ATTR_STRINGIFY_FETCHES = true

--- a/ext/pdo_mysql/tests/last_insert_id.phpt
+++ b/ext/pdo_mysql/tests/last_insert_id.phpt
@@ -14,30 +14,30 @@ PDOTest::skip();
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 
-print_r($db->query("CREATE TABLE test (id int auto_increment primary key, num int)"));
+print_r($db->query("CREATE TABLE test_last_insert_id (id int auto_increment primary key, num int)"));
 
-print_r($db->query("INSERT INTO test (id, num) VALUES (23, 42)"));
+print_r($db->query("INSERT INTO test_last_insert_id (id, num) VALUES (23, 42)"));
 
-print_r($db->query("INSERT INTO test (num) VALUES (451)"));
+print_r($db->query("INSERT INTO test_last_insert_id (num) VALUES (451)"));
 
 print_r($db->lastInsertId());
 ?>
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+MySQLPDOTest::dropTestTable(NULL, 'test_last_insert_id');
 ?>
 --EXPECT--
 PDOStatement Object
 (
-    [queryString] => CREATE TABLE test (id int auto_increment primary key, num int)
+    [queryString] => CREATE TABLE test_last_insert_id (id int auto_increment primary key, num int)
 )
 PDOStatement Object
 (
-    [queryString] => INSERT INTO test (id, num) VALUES (23, 42)
+    [queryString] => INSERT INTO test_last_insert_id (id, num) VALUES (23, 42)
 )
 PDOStatement Object
 (
-    [queryString] => INSERT INTO test (num) VALUES (451)
+    [queryString] => INSERT INTO test_last_insert_id (num) VALUES (451)
 )
 24

--- a/ext/pdo_mysql/tests/mysql_pdo_test.inc
+++ b/ext/pdo_mysql/tests/mysql_pdo_test.inc
@@ -166,11 +166,11 @@ class MySQLPDOTest extends PDOTest {
                 preg_match('/Client API version.*mysqlnd/', $tmp));
     }
 
-    static function dropTestTable($db = NULL) {
+    static function dropTestTable($db = NULL, $tableName = 'test') {
         if (is_null($db))
             $db = self::factory();
 
-        $db->exec('DROP TABLE IF EXISTS test');
+        $db->exec('DROP TABLE IF EXISTS '.$tableName);
     }
 
 }

--- a/ext/pdo_mysql/tests/native_types.phpt
+++ b/ext/pdo_mysql/tests/native_types.phpt
@@ -15,20 +15,20 @@ require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $db = MySQLPDOTest::factory();
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-$db->exec('DROP TABLE IF EXISTS test');
-$db->exec('CREATE TABLE test (i INT, f FLOAT)');
-$db->exec('INSERT INTO test VALUES (42, 42.5)');
+$db->exec('CREATE TABLE test_native_types (i INT, f FLOAT)');
+$db->exec('INSERT INTO test_native_types VALUES (42, 42.5)');
 
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
-var_dump($db->query('SELECT * FROM test')->fetchAll(PDO::FETCH_ASSOC));
+var_dump($db->query('SELECT * FROM test_native_types')->fetchAll(PDO::FETCH_ASSOC));
 
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
-var_dump($db->query('SELECT * FROM test')->fetchAll(PDO::FETCH_ASSOC));
+var_dump($db->query('SELECT * FROM test_native_types')->fetchAll(PDO::FETCH_ASSOC));
 ?>
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_native_types');
 ?>
 --EXPECT--
 array(1) {

--- a/ext/pdo_mysql/tests/pdo_mysql_attr_max_buffer_size.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_attr_max_buffer_size.phpt
@@ -30,13 +30,12 @@ if (MySQLPDOTest::isPDOMySQLnd())
                 PDO::ATTR_EMULATE_PREPARES => 0,
             ));
 
-            $db->exec('DROP TABLE IF EXISTS test');
-            $db->exec(sprintf('CREATE TABLE test(id INT, val LONGBLOB) ENGINE = %s', PDO_MYSQL_TEST_ENGINE));
+            $db->exec(sprintf('CREATE TABLE test_attr_max_buffer_size(id INT, val LONGBLOB) ENGINE = %s', PDO_MYSQL_TEST_ENGINE));
 
             // 10 * (10 * 1024) = 10 * (10 * 1k) = 100k
-            $db->exec('INSERT INTO test(id, val) VALUES (1, REPEAT("01234567890", 10240))');
+            $db->exec('INSERT INTO test_attr_max_buffer_size(id, val) VALUES (1, REPEAT("01234567890", 10240))');
 
-            $stmt = $db->prepare('SELECT id, val FROM test');
+            $stmt = $db->prepare('SELECT id, val FROM test_attr_max_buffer_size');
             $stmt->execute();
 
             $id = $val = NULL;
@@ -46,7 +45,6 @@ if (MySQLPDOTest::isPDOMySQLnd())
                 printf("[%03d] id = %d, val = %s... (length: %d)\n",
                     $offset, $id, substr($val, 0, 10), strlen($val));
             }
-            $db->exec('DROP TABLE IF EXISTS test');
 
         } catch (PDOException $e) {
             printf("[%03d] %s, [%s] %s\n",
@@ -71,8 +69,7 @@ if (MySQLPDOTest::isPDOMySQLnd())
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-$db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+MySQLPDOTest::dropTestTable(NULL, 'test_attr_max_buffer_size');
 ?>
 --EXPECTF--
 [001] id = 1, val = 0123456789... (length: %d)

--- a/ext/pdo_mysql/tests/pdo_mysql_bit.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_bit.phpt
@@ -16,22 +16,21 @@ if (MySQLPDOTest::isPDOMySQLnd())
 
     function test_type(&$db, $offset, $sql_type, $value, $ret_value = NULL, $pattern = NULL) {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $sql = sprintf('CREATE TABLE test(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
+        $sql = sprintf('CREATE TABLE test_mysql_bit(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
         @$db->exec($sql);
         if ($db->errorCode() != 0) {
             // not all MySQL Server versions and/or engines might support the type
             return true;
         }
 
-        $stmt = $db->prepare('INSERT INTO test(id, label) VALUES (?, ?)');
+        $stmt = $db->prepare('INSERT INTO test_mysql_bit(id, label) VALUES (?, ?)');
         $stmt->bindValue(1, $offset);
         $stmt->bindValue(2, $value);
         if (!$stmt->execute()) {
             printf("[%03d + 1] INSERT failed, %s\n", $offset, var_export($stmt->errorInfo(), true));
             return false;
         }
-        $stmt = $db->query('SELECT  id, label FROM test');
+        $stmt = $db->query('SELECT  id, label FROM test_mysql_bit');
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         var_dump($row);
         var_dump($value);
@@ -52,7 +51,7 @@ if (MySQLPDOTest::isPDOMySQLnd())
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_mysql_bit');
 ?>
 --EXPECT--
 array(2) {

--- a/ext/pdo_mysql/tests/pdo_mysql_exec.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_exec.phpt
@@ -37,28 +37,28 @@ MySQLPDOTest::skip();
     /* affected rows related */
     try {
 
-        exec_and_count(2, $db, 'DROP TABLE IF EXISTS test', 0);
-        exec_and_count(3, $db, sprintf('CREATE TABLE test(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
-        exec_and_count(4, $db, "INSERT INTO test(id, col1) VALUES (1, 'a')", 1);
-        exec_and_count(5, $db, "INSERT INTO test(id, col1) VALUES (2, 'b'), (3, 'c')", 2);
-        exec_and_count(6, $db, "UPDATE test SET id = 4 WHERE id = 3", 1);
-        exec_and_count(7, $db, "INSERT INTO test(id, col1) VALUES (1, 'd') ON DUPLICATE KEY UPDATE id = 3", 2);
-        exec_and_count(8, $db, "UPDATE test SET id = 5 WHERE id = 5", 0);
-        exec_and_count(9, $db, "INSERT INTO test(id, col1) VALUES (5, 'e') ON DUPLICATE KEY UPDATE id = 6", 1);
-        exec_and_count(10, $db, "REPLACE INTO test(id, col1) VALUES (5, 'f')", 2);
-        exec_and_count(11, $db, "REPLACE INTO test(id, col1) VALUES (6, 'g')", 1);
-        exec_and_count(12, $db, 'DELETE FROM test WHERE id > 2', 4);
-        exec_and_count(13, $db, 'DROP TABLE test', 0);
+        exec_and_count(2, $db, 'DROP TABLE IF EXISTS test_mysql_exec', 0);
+        exec_and_count(3, $db, sprintf('CREATE TABLE test_mysql_exec(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
+        exec_and_count(4, $db, "INSERT INTO test_mysql_exec(id, col1) VALUES (1, 'a')", 1);
+        exec_and_count(5, $db, "INSERT INTO test_mysql_exec(id, col1) VALUES (2, 'b'), (3, 'c')", 2);
+        exec_and_count(6, $db, "UPDATE test_mysql_exec SET id = 4 WHERE id = 3", 1);
+        exec_and_count(7, $db, "INSERT INTO test_mysql_exec(id, col1) VALUES (1, 'd') ON DUPLICATE KEY UPDATE id = 3", 2);
+        exec_and_count(8, $db, "UPDATE test_mysql_exec SET id = 5 WHERE id = 5", 0);
+        exec_and_count(9, $db, "INSERT INTO test_mysql_exec(id, col1) VALUES (5, 'e') ON DUPLICATE KEY UPDATE id = 6", 1);
+        exec_and_count(10, $db, "REPLACE INTO test_mysql_exec(id, col1) VALUES (5, 'f')", 2);
+        exec_and_count(11, $db, "REPLACE INTO test_mysql_exec(id, col1) VALUES (6, 'g')", 1);
+        exec_and_count(12, $db, 'DELETE FROM test_mysql_exec WHERE id > 2', 4);
+        exec_and_count(13, $db, 'DROP TABLE test_mysql_exec', 0);
         exec_and_count(14, $db, 'SET @myvar = 1', 0);
 
         exec_and_count(15, $db, 'THIS IS NOT VALID SQL, I HOPE', false);
         printf("[016] [%s] %s\n", $db->errorCode(), implode(' ', $db->errorInfo()));
 
-        exec_and_count(36, $db, sprintf('CREATE TABLE test(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
-        exec_and_count(37, $db, "INSERT INTO test(id, col1) VALUES (1, 'a')", 1);
+        exec_and_count(36, $db, sprintf('CREATE TABLE test_mysql_exec(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
+        exec_and_count(37, $db, "INSERT INTO test_mysql_exec(id, col1) VALUES (1, 'a')", 1);
         // Results may vary. Typically you will get 1. But the MySQL 5.1 manual states: Truncation operations do not return the number of deleted rows.
         // Don't rely on any return value!
-        exec_and_count(38, $db, 'TRUNCATE TABLE test', NULL);
+        exec_and_count(38, $db, 'TRUNCATE TABLE test_mysql_exec', NULL);
 
     } catch (PDOException $e) {
         printf("[001] %s, [%s] %s\n",
@@ -152,7 +152,7 @@ MySQLPDOTest::skip();
         $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 1);
         $exp = 0;
 
-        $tmp = @$db->exec(sprintf('DROP TABLE IF EXISTS test; CREATE TABLE test(id INT) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        $tmp = @$db->exec(sprintf('DROP TABLE IF EXISTS test_mysql_exec; CREATE TABLE test_mysql_exec(id INT) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
         if ($exp !== $tmp)
             printf("[034] Expecting %s/%s got %s/%s, [%s] %s\n",
                 $exp, gettype($exp),
@@ -160,7 +160,7 @@ MySQLPDOTest::skip();
                 $db->errorCode(), var_export($db->errorInfo(), true));
 
         // this is interesting: if we get sort of affected rows, what will happen now?
-        $tmp = @$db->exec('INSERT INTO test(id) VALUES (1); INSERT INTO test(id) VALUES (2)');
+        $tmp = @$db->exec('INSERT INTO test_mysql_exec(id) VALUES (1); INSERT INTO test_mysql_exec(id) VALUES (2)');
         printf("[035] With emulated PS it works but makes no sense given that exec() returns sort of affected rows...\n");
 
 
@@ -176,9 +176,7 @@ MySQLPDOTest::skip();
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-$db = MySQLPDOTest::factory();
-$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
-@$db->exec('DROP TABLE IF EXISTS test');
+MySQLPDOTest::dropTestTable(NULL, 'test_mysql_exec');
 ?>
 --EXPECTF--
 Warning: PDO::exec(): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'THIS IS NOT VALID SQL, I HOPE' at line 1 in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_exec_load_data.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_exec_load_data.phpt
@@ -66,8 +66,7 @@ if (($row = $stmt->fetch(PDO::FETCH_ASSOC)) && ($row['value'] != '')) {
 
     /* affected rows related */
 
-    exec_and_count(2, $db, 'DROP TABLE IF EXISTS test', 0);
-    exec_and_count(3, $db, sprintf('CREATE TABLE test(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
+    exec_and_count(3, $db, sprintf('CREATE TABLE test_mysql_exec_load_data(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
 
     $stmt = $db->query("SHOW VARIABLES LIKE 'secure_file_priv'");
     if (($row = $stmt->fetch(PDO::FETCH_ASSOC)) && ($row['value'] != '')) {
@@ -81,11 +80,11 @@ if (($row = $stmt->fetch(PDO::FETCH_ASSOC)) && ($row['value'] != '')) {
     fwrite($fp, "2;bar");
     fclose($fp);
 
-    $sql = sprintf("LOAD DATA LOCAL INFILE %s INTO TABLE test FIELDS TERMINATED BY ';' LINES TERMINATED  BY '\n'", $db->quote($filename));
+    $sql = sprintf("LOAD DATA LOCAL INFILE %s INTO TABLE test_mysql_exec_load_data FIELDS TERMINATED BY ';' LINES TERMINATED  BY '\n'", $db->quote($filename));
 
     if (exec_and_count(4, $db, $sql, 2)) {
 
-        $stmt = $db->query('SELECT id, col1 FROM test ORDER BY id ASC');
+        $stmt = $db->query('SELECT id, col1 FROM test_mysql_exec_load_data ORDER BY id ASC');
         $expected = array(array("id" => 1, "col1" => "foo"), array("id" => 2, "col1" => "bar"));
         $ret = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($expected as $offset => $exp) {
@@ -107,8 +106,7 @@ if (($row = $stmt->fetch(PDO::FETCH_ASSOC)) && ($row['value'] != '')) {
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-$db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+MySQLPDOTest::factory(NULL, 'test_mysql_exec_load_data');
 ?>
 --EXPECT--
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_exec_select.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_exec_select.phpt
@@ -37,14 +37,13 @@ MySQLPDOTest::skip();
     /* affected rows related */
     try {
 
-        exec_and_count(2, $db, 'DROP TABLE IF EXISTS test', 0);
-        exec_and_count(3, $db, sprintf('CREATE TABLE test(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
-        exec_and_count(4, $db, "INSERT INTO test(id, col1) VALUES (1, 'a')", 1);
+        exec_and_count(3, $db, sprintf('CREATE TABLE test_mysql_exec_select(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
+        exec_and_count(4, $db, "INSERT INTO test_mysql_exec_select(id, col1) VALUES (1, 'a')", 1);
         // question is: will the result set be cleaned up, will it be possible to run more queries on the line?
         // buffered or unbuffered does not matter!
         $db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
-        exec_and_count(5, $db, 'SELECT id FROM test', 0);
-        exec_and_count(6, $db, "INSERT INTO test(id, col1) VALUES (2, 'b')", 1);
+        exec_and_count(5, $db, 'SELECT id FROM test_mysql_exec_select', 0);
+        exec_and_count(6, $db, "INSERT INTO test_mysql_exec_select(id, col1) VALUES (2, 'b')", 1);
 
     } catch (PDOException $e) {
         printf("[001] %s, [%s] %s\n",
@@ -57,10 +56,9 @@ MySQLPDOTest::skip();
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-$db = MySQLPDOTest::factory();
-@$db->exec('DROP TABLE IF EXISTS test');
+MySQLPDOTest::dropTestTable(NULL, 'test_mysql_exec_select');
 ?>
 --EXPECTF--
 Warning: PDO::exec(): SQLSTATE[HY000]: General error: 2014 Cannot execute queries while other unbuffered queries are active.  Consider using PDOStatement::fetchAll().  Alternatively, if your code is only ever going to run against mysql, you may enable query buffering by setting the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY attribute. in %s on line %d
-[006] Expecting '1'/integer got ''/boolean when running 'INSERT INTO test(id, col1) VALUES (2, 'b')', [HY000] HY000 2014 Cannot execute queries while other unbuffered queries are active.  Consider using PDOStatement::fetchAll().  Alternatively, if your code is only ever going to run against mysql, you may enable query buffering by setting the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY attribute.
+[006] Expecting '1'/integer got ''/boolean when running 'INSERT INTO test_mysql_exec_select(id, col1) VALUES (2, 'b')', [HY000] HY000 2014 Cannot execute queries while other unbuffered queries are active.  Consider using PDOStatement::fetchAll().  Alternatively, if your code is only ever going to run against mysql, you may enable query buffering by setting the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY attribute.
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_last_insert_id.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_last_insert_id.phpt
@@ -22,39 +22,38 @@ $db = MySQLPDOTest::factory();
             printf("[002] MySQL does not support sequences, expecting '0'/string got '%s'/%s\n",
                 var_export($tmp, true), gettype($tmp));
 
-        $db->exec('DROP TABLE IF EXISTS test');
         if ('0' !== ($tmp = $db->lastInsertId()))
             printf("[003] Expecting '0'/string got '%s'/%s", var_export($tmp, true), gettype($tmp));
 
-        $db->exec(sprintf('CREATE TABLE test(id INT, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        $db->exec(sprintf('CREATE TABLE test_pdo_mysql_last_insert_id(id INT, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
         if ('0' !== ($tmp = $db->lastInsertId()))
             printf("[004] Expecting '0'/string got '%s'/%s", var_export($tmp, true), gettype($tmp));
 
-        $stmt = $db->query('SELECT id FROM test LIMIT 1');
+        $stmt = $db->query('SELECT id FROM test_pdo_mysql_last_insert_id LIMIT 1');
         if ('0' !== ($tmp = $db->lastInsertId()))
             printf("[005] Expecting '0'/string got '%s'/%s", var_export($tmp, true), gettype($tmp));
 
         // no auto increment column
-        $db->exec("INSERT INTO test(id, col1) VALUES (100, 'a')");
+        $db->exec("INSERT INTO test_pdo_mysql_last_insert_id(id, col1) VALUES (100, 'a')");
         if ('0' !== ($tmp = $db->lastInsertId()))
             printf("[006] Expecting '0'/string got '%s'/%s", var_export($tmp, true), gettype($tmp));
 
-        $db->exec('ALTER TABLE test MODIFY id INT AUTO_INCREMENT PRIMARY KEY');
+        $db->exec('ALTER TABLE test_pdo_mysql_last_insert_id MODIFY id INT AUTO_INCREMENT PRIMARY KEY');
         if ('0' !== ($tmp = $db->lastInsertId()))
             printf("[006] Expecting '0'/string got '%s'/%s", var_export($tmp, true), gettype($tmp));
 
         // duplicate key
-        @$db->exec("INSERT INTO test(id, col1) VALUES (100, 'a')");
+        @$db->exec("INSERT INTO test_pdo_mysql_last_insert_id(id, col1) VALUES (100, 'a')");
         if ('0' !== ($tmp = $db->lastInsertId()))
             printf("[007] Expecting '0'/string got '%s'/%s", var_export($tmp, true), gettype($tmp));
 
-        $db->exec("INSERT INTO test(id, col1) VALUES (101, 'b')");
+        $db->exec("INSERT INTO test_pdo_mysql_last_insert_id(id, col1) VALUES (101, 'b')");
         if ('101' !== ($tmp = $db->lastInsertId()))
             printf("[008] Expecting '0'/string got '%s'/%s", var_export($tmp, true), gettype($tmp));
 
-        $db->exec('ALTER TABLE test MODIFY col1 CHAR(10) UNIQUE');
+        $db->exec('ALTER TABLE test_pdo_mysql_last_insert_id MODIFY col1 CHAR(10) UNIQUE');
         // replace = delete + insert -> new auto increment value
-        $db->exec("REPLACE INTO test(col1) VALUES ('b')");
+        $db->exec("REPLACE INTO test_pdo_mysql_last_insert_id(col1) VALUES ('b')");
         $next_id = (int)$db->lastInsertId();
 
         if ($next_id <= 101)
@@ -68,7 +67,7 @@ $db = MySQLPDOTest::factory();
                 $last_id, $next_id);
         }
 
-        $db->exec("INSERT INTO test(col1) VALUES ('c'), ('d'), ('e')");
+        $db->exec("INSERT INTO test_pdo_mysql_last_insert_id(col1) VALUES ('c'), ('d'), ('e')");
         $next_id = (int)$db->lastInsertId();
         if ($next_id <= $last_id)
             printf("[011] Expecting at least %d, got %d\n", $last_id + 1, $next_id);
@@ -77,7 +76,7 @@ $db = MySQLPDOTest::factory();
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         try {
             $ignore_exception = true;
-            $db->exec('LOCK TABLE test WRITE');
+            $db->exec('LOCK TABLE test_pdo_mysql_last_insert_id WRITE');
             $ignore_exception = false;
 
             if (MySQLPDOTest::getServerVersion($db) >= 50000) {
@@ -92,7 +91,7 @@ $db = MySQLPDOTest::factory();
             $row = $stmt->fetch(PDO::FETCH_ASSOC);
             $last_id = $row['_last_id'];
 
-            $db->exec("INSERT INTO test(col1) VALUES ('z')");
+            $db->exec("INSERT INTO test_pdo_mysql_last_insert_id(col1) VALUES ('z')");
             $next_id = (int)$db->lastInsertId();
             if ($next_id < ($last_id + $inc))
                 printf("[012] Expecting at least %d, got %d\n", $last_id + $inc, $next_id);
@@ -102,7 +101,7 @@ $db = MySQLPDOTest::factory();
                 printf("[014] %s, [%s} %s\n", $e->getMessage(), $db->errorCode(), implode(' ', $db->errorInfo()));
         }
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
-        @$db->exec('UNLOCK TABLE test');
+        @$db->exec('UNLOCK TABLE test_pdo_mysql_last_insert_id');
 
     } catch (PDOException $e) {
         printf("[001] %s [%s] %s\n",
@@ -114,7 +113,7 @@ $db = MySQLPDOTest::factory();
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+MySQLPDOTest::dropTestTable(NULL, 'test_pdo_mysql_last_insert_id');
 ?>
 --EXPECT--
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_local_infile_directory_allowed.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_local_infile_directory_allowed.phpt
@@ -40,14 +40,13 @@ if (!defined('PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY')) {
 	MySQLPDOTest::createTestTable($db, MySQLPDOTest::detect_transactional_mysql_engine($db));
 
 	try {
-		exec_and_count(1, $db, 'DROP TABLE IF EXISTS test', 0);
-		exec_and_count(2, $db, sprintf('CREATE TABLE test(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
+		exec_and_count(2, $db, sprintf('CREATE TABLE test_local_inifile_dir_allowed(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
 
 		$filepath = str_replace('\\', '/', __DIR__.'/foo/bar/bar.data');
 
-		$sql = sprintf("LOAD DATA LOCAL INFILE %s INTO TABLE test FIELDS TERMINATED BY ';' LINES TERMINATED  BY '\n'", $db->quote($filepath));
+		$sql = sprintf("LOAD DATA LOCAL INFILE %s INTO TABLE test_local_inifile_dir_allowed FIELDS TERMINATED BY ';' LINES TERMINATED  BY '\n'", $db->quote($filepath));
 		if (exec_and_count(3, $db, $sql, 3)) {
-			$stmt = $db->query('SELECT id, col1 FROM test ORDER BY id ASC');
+			$stmt = $db->query('SELECT id, col1 FROM test_local_inifile_dir_allowed ORDER BY id ASC');
 			$expected = array(
 				array("id" => 97, "col1" => "first"),
 				array("id" => 98, "col1" => "second"),
@@ -80,7 +79,7 @@ if (!defined('PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY')) {
 <?php
 require dirname(__FILE__) . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_local_inifile_dir_allowed');
 ?>
 --EXPECT--
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_local_infile_directory_denied.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_local_infile_directory_denied.phpt
@@ -40,14 +40,13 @@ if (!defined('PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY')) {
 	MySQLPDOTest::createTestTable($db, MySQLPDOTest::detect_transactional_mysql_engine($db));
 
 	try {
-		exec_and_count(1, $db, 'DROP TABLE IF EXISTS test', 0);
-		exec_and_count(2, $db, sprintf('CREATE TABLE test(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
+		exec_and_count(2, $db, sprintf('CREATE TABLE test_local_inifile_dir_denied(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
 
 		$filepath = str_replace('\\', '/', __DIR__.'/foo/foo.data');
 
-		$sql = sprintf("LOAD DATA LOCAL INFILE %s INTO TABLE test FIELDS TERMINATED BY ';' LINES TERMINATED  BY '\n'", $db->quote($filepath));
+		$sql = sprintf("LOAD DATA LOCAL INFILE %s INTO TABLE test_local_inifile_dir_denied FIELDS TERMINATED BY ';' LINES TERMINATED  BY '\n'", $db->quote($filepath));
 		if (exec_and_count(3, $db, $sql, false)) {
-			$stmt = $db->query('SELECT id, col1 FROM test ORDER BY id ASC');
+			$stmt = $db->query('SELECT id, col1 FROM test_local_inifile_dir_denied ORDER BY id ASC');
 			$expected = array();
 			$ret = $stmt->fetchAll(PDO::FETCH_ASSOC);
 			if ($ret != $expected) {
@@ -69,8 +68,7 @@ if (!defined('PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY')) {
 --CLEAN--
 <?php
 require dirname(__FILE__) . '/mysql_pdo_test.inc';
-$db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db = MySQLPDOTest::dropTestTable(NULL, 'test_local_inifile_dir_denied');
 ?>
 --EXPECTF--
 Warning: PDO::exec(): SQLSTATE[HY000]: General error: 2068 LOAD DATA LOCAL INFILE %s in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_local_infile_overrides_local_infile_directory.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_local_infile_overrides_local_infile_directory.phpt
@@ -40,14 +40,13 @@ if (!defined('PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY')) {
 	MySQLPDOTest::createTestTable($db, MySQLPDOTest::detect_transactional_mysql_engine($db));
 
 	try {
-		exec_and_count(1, $db, 'DROP TABLE IF EXISTS test', 0);
-		exec_and_count(2, $db, sprintf('CREATE TABLE test(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
+		exec_and_count(2, $db, sprintf('CREATE TABLE test_local_inifile_overrides(id INT NOT NULL PRIMARY KEY, col1 CHAR(10)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE), 0);
 
 		$filepath = str_replace('\\', '/', __DIR__.'/foo/foo.data');
 
-		$sql = sprintf("LOAD DATA LOCAL INFILE %s INTO TABLE test FIELDS TERMINATED BY ';' LINES TERMINATED  BY '\n'", $db->quote($filepath));
+		$sql = sprintf("LOAD DATA LOCAL INFILE %s INTO TABLE test_local_inifile_overrides FIELDS TERMINATED BY ';' LINES TERMINATED  BY '\n'", $db->quote($filepath));
 		if (exec_and_count(3, $db, $sql, 3)) {
-			$stmt = $db->query('SELECT id, col1 FROM test ORDER BY id ASC');
+			$stmt = $db->query('SELECT id, col1 FROM test_local_inifile_overrides ORDER BY id ASC');
 			$expected = array(
 				array("id" => 1, "col1" => "one"),
 				array("id" => 2, "col1" => "two"),
@@ -80,7 +79,7 @@ if (!defined('PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY')) {
 <?php
 require dirname(__FILE__) . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_local_inifile_overrides');
 ?>
 --EXPECT--
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_param_str_natl.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_param_str_natl.phpt
@@ -17,14 +17,14 @@ $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 
-$db->exec('CREATE TABLE test (bar NCHAR(4) NOT NULL)');
+$db->exec('CREATE TABLE test_param_str_natl (bar NCHAR(4) NOT NULL)');
 
-$stmt = $db->prepare('INSERT INTO test VALUES(?)');
+$stmt = $db->prepare('INSERT INTO test_param_str_natl VALUES(?)');
 $stmt->bindValue(1, 'foo', PDO::PARAM_STR | PDO::PARAM_STR_NATL);
 $stmt->execute();
 
-var_dump($db->query('SELECT * from test'));
-foreach ($db->query('SELECT * from test') as $row) {
+var_dump($db->query('SELECT * from test_param_str_natl'));
+foreach ($db->query('SELECT * from test_param_str_natl') as $row) {
     print_r($row);
 }
 
@@ -32,12 +32,13 @@ foreach ($db->query('SELECT * from test') as $row) {
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_param_str_natl');
 ?>
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(18) "SELECT * from test"
+  string(33) "SELECT * from test_param_str_natl"
 }
 Array
 (

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_anonymous.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_anonymous.phpt
@@ -18,10 +18,9 @@ $db = MySQLPDOTest::factory();
         if (1 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[002] Unable to switch to emulated prepared statements, test will fail\n");
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec(sprintf('CREATE TABLE test(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        $db->exec(sprintf('CREATE TABLE test_prepare_emulated_anonymous(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
 
-        $stmt = $db->prepare("INSERT INTO test(id, label) VALUES(1, '?')");
+        $stmt = $db->prepare("INSERT INTO test_prepare_emulated_anonymous(id, label) VALUES(1, '?')");
         // you can bind as many values as you want no matter if they can be replaced or not
         $stmt->execute(array('first row'));
         if ('00000' !== $stmt->errorCode())
@@ -29,7 +28,7 @@ $db = MySQLPDOTest::factory();
                 var_export($stmt->errorCode(), true),
                 var_export($stmt->errorInfo(), true));
 
-        $stmt = $db->prepare('SELECT id, label FROM test');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_emulated_anonymous');
         $stmt->execute();
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
@@ -39,8 +38,8 @@ $db = MySQLPDOTest::factory();
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[004] Unable to switch off emulated prepared statements, test will fail\n");
 
-        $db->exec('DELETE FROM test');
-        $stmt = $db->prepare("INSERT INTO test(id, label) VALUES(1, '?')");
+        $db->exec('DELETE FROM test_prepare_emulated_anonymous');
+        $stmt = $db->prepare("INSERT INTO test_prepare_emulated_anonymous(id, label) VALUES(1, '?')");
         // you can bind as many values as you want no matter if they can be replaced or not
         $stmt->execute(array('first row'));
         if ('00000' !== $stmt->errorCode())
@@ -48,7 +47,7 @@ $db = MySQLPDOTest::factory();
                 var_export($stmt->errorCode(), true),
                 var_export($stmt->errorInfo(), true));
 
-        $stmt = $db->prepare('SELECT id, label FROM test');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_emulated_anonymous');
         $stmt->execute();
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
@@ -63,7 +62,7 @@ $db = MySQLPDOTest::factory();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_prepare_emulated_anonymous');
 ?>
 --EXPECTF--
 Warning: PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_myisam.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_myisam.phpt
@@ -96,62 +96,52 @@ $db = MySQLPDOTest::factory();
             echo $e->getMessage(), \PHP_EOL;
         }
 
-        // lets be fair and do the most simple SELECT first
-        $stmt = prepex(4, $db, 'SELECT 1 as "one"');
-        var_dump($stmt->fetch(PDO::FETCH_ASSOC));
-
-        prepex(6, $db, sprintf('CREATE TABLE test_prepare_emulated(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
-        prepex(7, $db, "INSERT INTO test_prepare_emulated(id, label) VALUES(1, ':placeholder')");
-        $stmt = prepex(8, $db, 'SELECT label FROM test_prepare_emulated');
-        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
-
-        prepex(9, $db, 'DELETE FROM test_prepare_emulated');
-        prepex(10, $db, "INSERT INTO test_prepare_emulated(id, label) VALUES(1, ':placeholder')",
-            array(':placeholder' => 'first row'));
-        $stmt = prepex(11, $db, 'SELECT label FROM test_prepare_emulated');
-
-        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
-        prepex(12, $db, 'DELETE FROM test_prepare_emulated');
-        prepex(13, $db, 'INSERT INTO test_prepare_emulated(id, label) VALUES(1, :placeholder)',
-            array(':placeholder' => 'first row'));
-        prepex(14, $db, 'INSERT INTO test_prepare_emulated(id, label) VALUES(2, :placeholder)',
-            array(':placeholder' => 'second row'));
-        $stmt = prepex(15, $db, 'SELECT label FROM test_prepare_emulated');
-        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
-
-        // Is PDO fun?
-        prepex(16, $db, 'SELECT label FROM test_prepare_emulated WHERE :placeholder > 1',
-            array(':placeholder' => 'id'));
-        prepex(17, $db, 'SELECT :placeholder FROM test_prepare_emulated WHERE id > 1',
-            array(':placeholder' => 'id'));
-        prepex(18, $db, 'SELECT :placeholder FROM test_prepare_emulated WHERE :placeholder > :placeholder',
-            array(':placeholder' => 'test'));
-
-        for ($num_params = 2; $num_params < 100; $num_params++) {
-            $params = array(':placeholder' => 'a');
-            for ($i = 1; $i < $num_params; $i++) {
-                $params[str_repeat('a', $i)] = 'some data';
-            }
-            prepex(19, $db, 'SELECT id, label FROM test_prepare_emulated WHERE label > :placeholder',
-                $params, array('execute' => array('sqlstate' => 'HY093')));
+        prepex(4, $db, 'CREATE TABLE test_prepare_emulated_myisam(id INT, label CHAR(255)) ENGINE=MyISAM');
+        if (is_object(prepex(5, $db, 'CREATE FULLTEXT INDEX idx1 ON test_prepare_emulated_myisam(label)'))) {
+            prepex(6, $db, 'INSERT INTO test_prepare_emulated_myisam(id, label) VALUES (1, :placeholder)',
+                array(':placeholder' => 'MySQL is the best database in the world!'));
+            prepex(7, $db, 'INSERT INTO test_prepare_emulated_myisam(id, label) VALUES (1, :placeholder)',
+                array(':placeholder' => 'If I have the freedom to choose, I would always go again for the MySQL Server'));
+            $stmt = prepex(8, $db, 'SELECT id, label FROM test_prepare_emulated_myisam WHERE MATCH label AGAINST (:placeholder)',
+                array(':placeholder' => 'mysql'));
+            /*
+            Lets ignore this
+            if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
+                printf("[033] Expecting two rows, got %d rows\n", $tmp);
+            */
         }
-
-        prepex(20, $db, 'DELETE FROM test_prepare_emulated');
-        prepex(21, $db, 'INSERT INTO test_prepare_emulated(id, label) VALUES (1, :placeholder), (2, :placeholder)',
+        prepex(9, $db, 'DELETE FROM test_prepare_emulated_myisam');
+        prepex(10, $db, 'INSERT INTO test_prepare_emulated_myisam(id, label) VALUES (1, :placeholder), (2, :placeholder)',
             array(':placeholder' => 'row'));
-        $stmt = prepex(22, $db, 'SELECT id, label FROM test_prepare_emulated');
-        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
+/*
+        $stmt = prepex(11, $db, 'SELECT id, label FROM "test_prepare_emulated_myisam WHERE MATCH label AGAINST (:placeholder)',
+            array(':placeholder' => 'row'),
+            array('execute' => array('sqlstate' => '42000', 'mysql' => 1064)));
+*/
+        $stmt = prepex(12, $db, 'SELECT id, label FROM \'test_prepare_emulated_myisam WHERE MATCH label AGAINST (:placeholder)',
+            array(':placeholder' => 'row'),
+            array('execute' => array('sqlstate' => '42000', 'mysql' => 1064)));
 
-        $stmt = prepex(23, $db, 'SELECT id, label FROM test_prepare_emulated WHERE :placeholder IS NOT NULL',
-            array(':placeholder' => 1));
-        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
-            printf("[024] '1' IS NOT NULL evaluates to true, expecting two rows, got %d rows\n", $tmp);
+        $stmt = prepex(13, $db, 'SELECT id, label AS "label" FROM test_prepare_emulated_myisam WHERE label = :placeholder',
+            array(':placeholder' => 'row'));
 
-        $stmt = prepex(25, $db, 'SELECT id, label FROM test_prepare_emulated WHERE :placeholder IS NULL',
-            array(':placeholder' => 1));
+        $sql = sprintf("SELECT id, label FROM test_prepare_emulated_myisam WHERE (label LIKE %s) AND (id = :placeholder)",
+            $db->quote('%ro%'));
+        $stmt = prepex(14, $db, $sql,	array('placeholder' => -1));
         if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 0)
-            printf("[026] '1' IS NOT NULL evaluates to true, expecting zero rows, got %d rows\n", $tmp);
+                printf("[040] Expecting zero rows, got %d rows\n", $tmp);
 
+
+        $sql = sprintf("SELECT id, label FROM test_prepare_emulated_myisam WHERE  (id = :placeholder) OR (label LIKE %s)",
+            $db->quote('%ro%'));
+        $stmt = prepex(15, $db, $sql,	array('placeholder' => 1));
+        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
+                printf("[042] Expecting two rows, got %d rows\n", $tmp);
+
+        $sql = "SELECT id, label FROM test_prepare_emulated_myisam WHERE id = :placeholder AND label = (SELECT label AS 'SELECT' FROM test_prepare_emulated_myisam WHERE id = :placeholder)";
+        $stmt = prepex(16, $db, $sql,	array('placeholder' => 1));
+        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 1)
+                printf("[044] Expecting onw row, got %d rows\n", $tmp);
     } catch (PDOException $e) {
         printf("[001] %s [%s] %s\n",
             $e->getMessage(), $db->errorCode(), implode(' ', $db->errorInfo()));
@@ -162,51 +152,8 @@ $db = MySQLPDOTest::factory();
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable(NULL, 'test_prepare_emulated');
+MySQLPDOTest::dropTestTable(NULL, 'test_prepare_emulated_myisam');
 ?>
 --EXPECTF--
 PDO::prepare(): Argument #1 ($query) cannot be empty
-array(1) {
-  ["one"]=>
-  string(1) "1"
-}
-array(1) {
-  [0]=>
-  array(1) {
-    ["label"]=>
-    string(12) ":placeholder"
-  }
-}
-
-Warning: PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens in %s on line %d
-array(0) {
-}
-array(2) {
-  [0]=>
-  array(1) {
-    ["label"]=>
-    string(9) "first row"
-  }
-  [1]=>
-  array(1) {
-    ["label"]=>
-    string(10) "second row"
-  }
-}
-array(2) {
-  [0]=>
-  array(2) {
-    ["id"]=>
-    string(1) "1"
-    ["label"]=>
-    string(3) "row"
-  }
-  [1]=>
-  array(2) {
-    ["id"]=>
-    string(1) "2"
-    ["label"]=>
-    string(3) "row"
-  }
-}
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_placeholder_everywhere.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_emulated_placeholder_everywhere.phpt
@@ -19,13 +19,12 @@ MySQLPDOTest::skip();
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[002] Unable to switch off emulated prepared statements, test will fail\n");
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec(sprintf('CREATE TABLE test(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
-        $db->exec("INSERT INTO test(id, label) VALUES (1, 'row1')");
+        $db->exec(sprintf('CREATE TABLE test_prepare_emulated_placeholder_everywhere(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        $db->exec("INSERT INTO test_prepare_emulated_placeholder_everywhere(id, label) VALUES (1, 'row1')");
 
         // So, what will happen? More placeholder but values and
         // placeholders in interesting places...
-        $stmt = $db->prepare('SELECT ? FROM test WHERE ? > ?');
+        $stmt = $db->prepare('SELECT ? FROM test_prepare_emulated_placeholder_everywhere WHERE ? > ?');
         $stmt->execute(array('test'));
         if ('00000' !== $stmt->errorCode()) {
             printf("[003] Execute has failed, %s %s\n",
@@ -40,7 +39,7 @@ MySQLPDOTest::skip();
         if (1 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[004] Unable to switch on emulated prepared statements, test will fail\n");
 
-        $stmt = $db->prepare('SELECT ? FROM test WHERE ? > ?');
+        $stmt = $db->prepare('SELECT ? FROM test_prepare_emulated_placeholder_everywhere WHERE ? > ?');
         $stmt->execute(array('test'));
         if ('00000' !== $stmt->errorCode())
             printf("[005] Execute has failed, %s %s\n",
@@ -59,7 +58,7 @@ MySQLPDOTest::skip();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_prepare_emulated_placeholder_everywhere');
 ?>
 --EXPECTF--
 Warning: PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_match_against.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_match_against.phpt
@@ -14,19 +14,18 @@ MySQLPDOTest::skip();
 
     try {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec('CREATE TABLE test(id INT, label CHAR(255)) ENGINE=MyISAM');
-        $db->exec('CREATE FULLTEXT INDEX idx1 ON test(label)');
+        $db->exec('CREATE TABLE test_prepare_match_against(id INT, label CHAR(255)) ENGINE=MyISAM');
+        $db->exec('CREATE FULLTEXT INDEX idx1 ON test_prepare_match_against(label)');
 
-        $stmt = $db->prepare('SELECT id, label FROM test WHERE MATCH label AGAINST (:placeholder)');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_match_against WHERE MATCH label AGAINST (:placeholder)');
         $stmt->execute(array(':placeholder' => 'row'));
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
-        $stmt = $db->prepare('SELECT id, label FROM test WHERE MATCH label AGAINST (:placeholder)');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_match_against WHERE MATCH label AGAINST (:placeholder)');
         $stmt->execute(array('placeholder' => 'row'));
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
-        $stmt = $db->prepare('SELECT id, label FROM test WHERE MATCH label AGAINST (?)');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_match_against WHERE MATCH label AGAINST (?)');
         $stmt->execute(array('row'));
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
@@ -43,7 +42,7 @@ MySQLPDOTest::skip();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_prepare_match_against');
 ?>
 --EXPECT--
 array(0) {

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_anonymous_placeholder.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_anonymous_placeholder.phpt
@@ -1,0 +1,270 @@
+--TEST--
+MySQL PDO->prepare(), native PS
+--EXTENSIONS--
+pdo_mysql
+--SKIPIF--
+<?php
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+MySQLPDOTest::skip();
+$db = MySQLPDOTest::factory();
+?>
+--FILE--
+<?php
+    require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
+    $db = MySQLPDOTest::factory();
+
+    function prepex($offset, &$db, $query, $input_params = null, $error_info = null, $suppress_warning = false) {
+
+        try {
+
+            if ($suppress_warning || (is_array($error_info) && isset($error_info['prepare'])))
+                $stmt = @$db->prepare($query);
+            else
+                $stmt = $db->prepare($query);
+
+            if (is_array($error_info) && isset($error_info['prepare'])) {
+                $tmp = $db->errorInfo();
+
+                if (isset($error_info['prepare']['sqlstate']) &&
+                    ($error_info['prepare']['sqlstate'] !== $tmp[0])) {
+                    printf("[%03d] prepare() - expecting SQLSTATE '%s' got '%s'\n",
+                        $offset, $error_info['prepare']['sqlstate'], $tmp[0]);
+                    return false;
+                }
+
+                if (isset($error_info['prepare']['mysql']) &&
+                    ($error_info['prepare']['mysql'] !== $tmp[1])) {
+                    printf("[%03d] prepare() - expecting MySQL Code '%s' got '%s'\n",
+                        $offset, $error_info['prepare']['mysql'], $tmp[0]);
+                    return false;
+                }
+
+                return false;
+            }
+
+            if (!is_object($stmt))
+                return false;
+
+            if (is_null($input_params))
+                $input_params = array();
+// 5.0.18, 5.1.14 @ 15
+// printf("[%03d]\n", $offset);
+            if ($suppress_warning || (is_array($error_info) && isset($error_info['execute'])))
+                $ret = @$stmt->execute($input_params);
+            else
+                $ret = $stmt->execute($input_params);
+
+            if (!is_bool($ret))
+                printf("[%03d] PDO::execute() should return a boolean value, got %s/%s\n",
+                    var_export($ret, true), $ret);
+
+            $tmp = $stmt->errorInfo();
+            if (isset($tmp[1]) && ($tmp[1] == 2030)) {
+                // Trying to hack around MySQL Server version dependent features
+                // 2030 This command is not supported in the prepared statement protocol yet
+                return false;
+            }
+
+            if (is_array($error_info) && isset($error_info['execute'])) {
+
+                if (isset($error_info['execute']['sqlstate']) &&
+                    ($error_info['execute']['sqlstate'] !== $tmp[0])) {
+                    printf("[%03d] execute() - expecting SQLSTATE '%s' got '%s'\n",
+                        $offset, $error_info['execute']['sqlstate'], $tmp[0]);
+                    return false;
+                }
+
+                if (isset($error_info['execute']['mysql']) &&
+                    ($error_info['execute']['mysql'] !== $tmp[1])) {
+                    printf("[%03d] execute() - expecting MySQL Code '%s' got '%s'\n",
+                        $offset, $error_info['execute']['mysql'], $tmp[0]);
+                    return false;
+                }
+
+                return false;
+
+            }
+
+        } catch (PDOException $e) {
+            printf("[%03d] %s, [%s} %s\n",
+                $offset, $e->getMessage(),
+                $db->errorCode(), implode(' ', $db->errorInfo()));
+            return false;
+        }
+
+        return $stmt;
+    }
+
+    try {
+        $db->setAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY, 0);
+        if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
+            printf("[002] Unable to turn off emulated prepared statements\n");
+
+        try {
+            prepex(3, $db, '', [], ['prepare' => ['sqlstate' => '42000']]);
+        } catch (\ValueError $e) {
+            echo $e->getMessage(), \PHP_EOL;
+        }
+
+        prepex(4, $db, sprintf('CREATE TABLE test_prepare_native_anonymous_placeholder(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        prepex(5, $db, "INSERT INTO test_prepare_native_anonymous_placeholder(id, label) VALUES(1, '?')");
+        $stmt = prepex(6, $db, 'SELECT label FROM test_prepare_native_anonymous_placeholder');
+        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
+
+        prepex(7, $db, 'DELETE FROM test_prepare_native_anonymous_placeholder');
+        prepex(8, $db, 'INSERT INTO test_prepare_native_anonymous_placeholder(id, label) VALUES(1, ?)',
+            array('first row'));
+        prepex(9, $db, 'INSERT INTO test_prepare_native_anonymous_placeholder(id, label) VALUES(2, ?)',
+            array('second row'));
+        $stmt = prepex(10, $db, 'SELECT label FROM test_prepare_native_anonymous_placeholder');
+        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
+
+        // Is PDO fun?
+        prepex(10, $db, 'SELECT label FROM test_prepare_native_anonymous_placeholder WHERE ? > 1',
+            array('id'));
+        prepex(11, $db, 'SELECT ? FROM test_prepare_native_anonymous_placeholder WHERE id > 1',
+            array('id'));
+        prepex(12, $db, 'SELECT ? FROM test_prepare_native_anonymous_placeholder WHERE ? > ?',
+            array('id', 'label', 'value'));
+
+        for ($num_params = 2; $num_params < 100; $num_params++) {
+            $params = array('a');
+            for ($i = 1; $i < $num_params; $i++) {
+                $params[] = 'some data';
+            }
+            prepex(13, $db, 'SELECT id, label FROM test_prepare_native_anonymous_placeholder WHERE label > ?',
+                $params, array('execute' => array('sqlstate' => 'HY093')));
+        }
+
+        prepex(14, $db, 'DELETE FROM test_prepare_native_anonymous_placeholder');
+        prepex(15, $db, 'INSERT INTO test_prepare_native_anonymous_placeholder(id, label) VALUES (1, ?), (2, ?)',
+            array('row', 'row'));
+        $stmt = prepex(16, $db, 'SELECT id, label FROM test_prepare_native_anonymous_placeholder ORDER BY id');
+        $tmp = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $exp = array(
+            0 => array(
+                "id"  => "1",
+                "label" => "row"
+            ),
+            1 => array(
+                "id" => "2",
+                "label" => "row"
+            ),
+        );
+
+        if (MySQLPDOTest::isPDOMySQLnd()) {
+            // mysqlnd returns native types
+            $exp[0]['id'] = 1;
+            $exp[1]['id'] = 2;
+        }
+        if ($tmp !== $exp) {
+            printf("[064] Results seem wrong. Please check dumps manually.\n");
+            var_dump($exp);
+            var_dump($tmp);
+        }
+
+        $stmt = prepex(17, $db, 'SELECT id, label FROM test_prepare_native_anonymous_placeholder WHERE ? IS NOT NULL',
+            array(1));
+        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
+            printf("[048] '1' IS NOT NULL evaluates to true, expecting two rows, got %d rows\n", $tmp);
+
+        $stmt = prepex(19, $db, 'SELECT id, label FROM test_prepare_native_anonymous_placeholder WHERE ? IS NULL',
+            array(1));
+        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 0)
+            printf("[050] '1' IS NOT NULL evaluates to true, expecting zero rows, got %d rows\n", $tmp);
+
+        prepex(21, $db, 'DROP TABLE IF EXISTS test_prepare_native_anonymous_placeholder');
+        prepex(22, $db, 'CREATE TABLE test_prepare_native_anonymous_placeholder(id INT, label CHAR(255)) ENGINE=MyISAM');
+        if (is_object(prepex(23, $db, 'CREATE FULLTEXT INDEX idx1 ON test_prepare_native_anonymous_placeholder(label)', null, null, true))) {
+            prepex(24, $db, 'INSERT INTO test_prepare_native_anonymous_placeholder(id, label) VALUES (1, ?)',
+                array('MySQL is the best database in the world!'));
+            prepex(25, $db, 'INSERT INTO test_prepare_native_anonymous_placeholder(id, label) VALUES (1, ?)',
+                array('If I have the freedom to choose, I would always go again for the MySQL Server'));
+            $stmt = prepex(26, $db, 'SELECT id, label FROM test_prepare_native_anonymous_placeholder WHERE MATCH label AGAINST (?)',
+                array('mysql'), null, true);
+            /*
+            Lets ignore that
+            if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
+                printf("[074] Expecting two rows, got %d rows\n", $tmp);
+            */
+        }
+
+        prepex(27, $db, 'DELETE FROM test_prepare_native_anonymous_placeholder');
+        prepex(28, $db, 'INSERT INTO test_prepare_native_anonymous_placeholder(id, label) VALUES (1, ?), (2, ?)',
+            array('row1', 'row2'));
+
+        /*
+        TODO enable after fix
+        $stmt = prepex(27, $db, 'SELECT id, label FROM \'test_prepare_native_anonymous_placeholder WHERE MATCH label AGAINST (:placeholder)',
+            array(':placeholder' => 'row'),
+            array('execute' => array('sqlstate' => '42000', 'mysql' => 1064)));
+        */
+
+        $stmt = prepex(29, $db, 'SELECT id, label AS "label" FROM test_prepare_native_anonymous_placeholder WHERE label = ?',
+            array('row1'));
+        $tmp = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $exp = array(
+            0 => array("id" => "1", "label" => "row1")
+        );
+
+        if (MySQLPDOTest::isPDOMySQLnd()) {
+            // mysqlnd returns native types
+            $exp[0]['id'] = 1;
+        }
+        if ($tmp !== $exp) {
+            printf("[065] Results seem wrong. Please check dumps manually.\n");
+            var_dump($exp);
+            var_dump($tmp);
+        }
+
+        $sql = sprintf("SELECT id, label FROM test_prepare_native_anonymous_placeholder WHERE (label LIKE %s) AND (id = ?)",
+            $db->quote('%ro%'));
+        $stmt = prepex(30, $db, $sql,	array(-1));
+        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 0)
+                printf("[061] Expecting zero rows, got %d rows\n", $tmp);
+
+        $sql = sprintf("SELECT id, label FROM test_prepare_native_anonymous_placeholder WHERE  (id = ?) OR (label LIKE %s)",
+            $db->quote('%ro%'));
+        $stmt = prepex(31, $db, $sql,	array(1));
+        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
+                printf("[062] Expecting two rows, got %d rows\n", $tmp);
+
+        $sql = "SELECT id, label FROM test_prepare_native_anonymous_placeholder WHERE id = ? AND label = (SELECT label AS 'SELECT' FROM test_prepare_native_anonymous_placeholder WHERE id = ?)";
+        $stmt = prepex(33, $db, $sql,	array(1, 1));
+        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 1)
+                printf("[064] Expecting one row, got %d rows\n", $tmp);
+
+    } catch (PDOException $e) {
+        printf("[001] %s [%s] %s\n",
+            $e->getMessage(), $db->errorCode(), implode(' ', $db->errorInfo()));
+    }
+
+    print "done!";
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+MySQLPDOTest::dropTestTable(NULL, 'test_prepare_native_anonymous_placeholder');
+?>
+--EXPECT--
+PDO::prepare(): Argument #1 ($query) cannot be empty
+array(1) {
+  [0]=>
+  array(1) {
+    ["label"]=>
+    string(1) "?"
+  }
+}
+array(2) {
+  [0]=>
+  array(1) {
+    ["label"]=>
+    string(9) "first row"
+  }
+  [1]=>
+  array(1) {
+    ["label"]=>
+    string(10) "second row"
+  }
+}
+done!

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_clear_error.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_clear_error.phpt
@@ -16,8 +16,7 @@ $db = MySQLPDOTest::factory();
 
     try {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec(sprintf('CREATE TABLE test(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        $db->exec(sprintf('CREATE TABLE test_prepare_native_clear_error(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
 
         // We need to run the emulated version first. Native version will cause a fatal error
         $db->setAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY, 1);
@@ -25,16 +24,16 @@ $db = MySQLPDOTest::factory();
             printf("[002] Unable to turn on emulated prepared statements\n");
 
         // INSERT a single row
-        $db->exec("INSERT INTO test(id, label) VALUES (1, 'row1')");
+        $db->exec("INSERT INTO test_prepare_native_clear_error(id, label) VALUES (1, 'row1')");
 
-        $stmt = $db->prepare('SELECT unknown_column FROM test WHERE id > :placeholder ORDER BY id ASC');
+        $stmt = $db->prepare('SELECT unknown_column FROM test_prepare_native_clear_error WHERE id > :placeholder ORDER BY id ASC');
         $stmt->execute(array(':placeholder' => 0));
         if ('00000' !== $stmt->errorCode())
             printf("[003] Execute has failed, %s %s\n",
                 var_export($stmt->errorCode(), true),
                 var_export($stmt->errorInfo(), true));
 
-        $stmt = $db->prepare('SELECT id, label FROM test WHERE id > :placeholder ORDER BY id ASC');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_native_clear_error WHERE id > :placeholder ORDER BY id ASC');
         $stmt->execute(array(':placeholder' => 0));
         if ('00000' !== $stmt->errorCode())
             printf("[004] Execute has failed, %s %s\n",
@@ -47,14 +46,14 @@ $db = MySQLPDOTest::factory();
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[005] Unable to turn off emulated prepared statements\n");
 
-        $stmt = $db->prepare('SELECT unknown_column FROM test WHERE id > :placeholder ORDER BY id ASC');
+        $stmt = $db->prepare('SELECT unknown_column FROM test_prepare_native_clear_error WHERE id > :placeholder ORDER BY id ASC');
         $stmt->execute(array(':placeholder' => 0));
         if ('00000' !== $stmt->errorCode())
             printf("[006] Execute has failed, %s %s\n",
                 var_export($stmt->errorCode(), true),
                 var_export($stmt->errorInfo(), true));
 
-        $stmt = $db->prepare('SELECT id, label FROM test WHERE id > :placeholder ORDER BY id ASC');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_native_clear_error WHERE id > :placeholder ORDER BY id ASC');
         $stmt->execute(array(':placeholder' => 0));
         if ('00000' !== $stmt->errorCode())
             printf("[007] Execute has failed, %s %s\n",
@@ -74,7 +73,7 @@ $db = MySQLPDOTest::factory();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_prepare_native_clear_error');
 ?>
 --EXPECTF--
 Warning: PDOStatement::execute(): SQLSTATE[42S22]: Column not found: 1054 Unknown column 'unknown_column' in 'field list' in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_dup_named_placeholder.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_dup_named_placeholder.phpt
@@ -16,8 +16,7 @@ $db = MySQLPDOTest::factory();
 
     try {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec(sprintf('CREATE TABLE test(id INT, label1 CHAR(255), label2 CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        $db->exec(sprintf('CREATE TABLE test_prepare_native_dup_named(id INT, label1 CHAR(255), label2 CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
 
         $db->setAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY, 0);
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
@@ -25,7 +24,7 @@ $db = MySQLPDOTest::factory();
         printf("Native...\n");
 
         // INSERT a single row
-        $stmt = $db->prepare('INSERT INTO test(id, label1, label2) VALUES (1, :placeholder, :placeholder)');
+        $stmt = $db->prepare('INSERT INTO test_prepare_native_dup_named(id, label1, label2) VALUES (1, :placeholder, :placeholder)');
 
         $stmt->execute(array(':placeholder' => 'row1'));
         if ('00000' !== $stmt->errorCode())
@@ -34,7 +33,7 @@ $db = MySQLPDOTest::factory();
                 var_export($stmt->errorInfo(), true));
 
         // Ok, what has happened: anything inserted into the DB?
-        $stmt = $db->prepare('SELECT id, label1, label2 FROM test WHERE id = 1');
+        $stmt = $db->prepare('SELECT id, label1, label2 FROM test_prepare_native_dup_named WHERE id = 1');
         $stmt->execute();
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
@@ -44,7 +43,7 @@ $db = MySQLPDOTest::factory();
             printf("[004] Unable to turn on emulated prepared statements\n");
         printf("Emulated...\n");
 
-        $stmt = $db->prepare('INSERT INTO test(id, label1, label2) VALUES(2, :placeholder, :placeholder)');
+        $stmt = $db->prepare('INSERT INTO test_prepare_native_dup_named(id, label1, label2) VALUES(2, :placeholder, :placeholder)');
         // No replacement shall be made
         $stmt->execute(array(':placeholder' => 'row2'));
         if ('00000' !== $stmt->errorCode())
@@ -53,7 +52,7 @@ $db = MySQLPDOTest::factory();
                 var_export($stmt->errorInfo(), true));
 
         // Now, what do we have in the DB?
-        $stmt = $db->prepare('SELECT id, label1, label2 FROM test WHERE id = 2');
+        $stmt = $db->prepare('SELECT id, label1, label2 FROM test_prepare_native_dup_named WHERE id = 2');
         $stmt->execute();
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
@@ -61,9 +60,9 @@ $db = MySQLPDOTest::factory();
         // Another variation of the theme
         //
 
-        $db->exec('DELETE FROM test');
-        $db->exec("INSERT INTO test (id, label1, label2) VALUES (1, 'row1', 'row2')");
-        $sql = "SELECT id, label1 FROM test WHERE id = :placeholder AND label1 = (SELECT label1 AS 'SELECT' FROM test WHERE id = :placeholder)";
+        $db->exec('DELETE FROM test_prepare_native_dup_named');
+        $db->exec("INSERT INTO test_prepare_native_dup_named (id, label1, label2) VALUES (1, 'row1', 'row2')");
+        $sql = "SELECT id, label1 FROM test_prepare_native_dup_named WHERE id = :placeholder AND label1 = (SELECT label1 AS 'SELECT' FROM test_prepare_native_dup_named WHERE id = :placeholder)";
 
         // emulated...
         $stmt = $db->prepare($sql);
@@ -100,7 +99,7 @@ $db = MySQLPDOTest::factory();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_prepare_native_dup_named');
 ?>
 --EXPECTF--
 Native...

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_myisam.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_myisam.phpt
@@ -106,56 +106,46 @@ $db = MySQLPDOTest::factory();
             echo $e->getMessage(), \PHP_EOL;
         }
 
-        // lets be fair and do the most simple SELECT first
-        $stmt = prepex(4, $db, 'SELECT 1 as "one"');
-        if (MySQLPDOTest::isPDOMySQLnd())
-            // native types - int
-            $expected = array('one' => 1);
-        else
-            // always strings, like STRINGIFY flag
-            $expected = array('one' => '1');
+        prepex(4, $db, 'CREATE TABLE test_prepare_native_myisam(id INT, label CHAR(255)) ENGINE=MyISAM');
+        // Not every MySQL Server version supports this
+        if (is_object(prepex(5, $db, 'CREATE FULLTEXT INDEX idx1 ON test_prepare_native_myisam(label)', null, null, true))) {
+            prepex(6, $db, 'INSERT INTO test_prepare_native_myisam(id, label) VALUES (1, :placeholder)',
+                array(':placeholder' => 'MySQL is the best database in the world!'));
+            prepex(7, $db, 'INSERT INTO test_prepare_native_myisam(id, label) VALUES (2, :placeholder)',
+                array(':placeholder' => 'If I have the freedom to choose, I would always go again for the MySQL Server'));
+            $stmt = prepex(8, $db, 'SELECT id, label FROM test_prepare_native_myisam WHERE MATCH label AGAINST (:placeholder)',
+                array(':placeholder' => 'mysql'), null, true);
+            if (is_object($stmt)) {
+                /*
+                Lets ignore this
+                if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
+                    printf("[033] Expecting two rows, got %d rows\n", $tmp);
+                */
+                $stmt = prepex(9, $db, 'SELECT id, label FROM test_prepare_native_myisam ORDER BY id ASC');
+                if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
+                    printf("[027] Expecting two rows, got %d rows\n", $tmp);
 
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        if ($row !== $expected) {
-            printf("[004a] Expecting %s got %s\n", var_export($expected, true), var_export($row, true));
-        }
-
-        prepex(6, $db, sprintf('CREATE TABLE test_prepare_native(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
-        prepex(7, $db, "INSERT INTO test_prepare_native(id, label) VALUES(1, ':placeholder')");
-        $stmt = prepex(8, $db, 'SELECT label FROM test_prepare_native ORDER BY id ASC');
-        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
-
-        prepex(9, $db, 'DELETE FROM test_prepare_native');
-        prepex(10, $db, 'INSERT INTO test_prepare_native(id, label) VALUES(1, :placeholder)',
-            array(':placeholder' => 'first row'));
-        prepex(11, $db, 'INSERT INTO test_prepare_native(id, label) VALUES(2, :placeholder)',
-            array(':placeholder' => 'second row'));
-        $stmt = prepex(12, $db, 'SELECT label FROM test_prepare_native ORDER BY id ASC');
-        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
-
-        // Is PDO fun?
-        $stmt = prepex(13, $db, 'SELECT label FROM test_prepare_native WHERE :placeholder > 1',
-            array(':placeholder' => 'id'));
-        var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
-
-        for ($num_params = 2; $num_params < 100; $num_params++) {
-            $params = array(':placeholder' => 'a');
-            for ($i = 1; $i < $num_params; $i++) {
-                $params[str_repeat('a', $i)] = 'some data';
+                if ($tmp[0]['label'] !== 'MySQL is the best database in the world!') {
+                    printf("[028] INSERT seems to have failed, dumping data, check manually\n");
+                    var_dump($tmp);
+                }
             }
-            prepex(16, $db, 'SELECT id, label FROM test_prepare_native WHERE label > :placeholder',
-                $params, array('execute' => array('sqlstate' => 'HY093')));
         }
 
-        $stmt = prepex(16, $db, 'SELECT id, label FROM test_prepare_native WHERE :placeholder IS NOT NULL',
-            array(':placeholder' => 1));
-        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 2)
-            printf("[017] '1' IS NOT NULL evaluates to true, expecting two rows, got %d rows\n", $tmp);
+        $db->exec('DELETE FROM test_prepare_native_myisam');
+        $db->exec("INSERT INTO test_prepare_native_myisam(id, label) VALUES (1, 'row1'), (2, 'row2')");
 
-        $stmt = prepex(18, $db, 'SELECT id, label FROM test_prepare_native WHERE :placeholder IS NULL',
-            array(':placeholder' => 1));
+        $sql = sprintf("SELECT id, label FROM test_prepare_native_myisam WHERE (label LIKE %s) AND (id = :placeholder)",
+            $db->quote('%ro%'));
+        $stmt = prepex(10, $db, $sql,	array('placeholder' => -1));
         if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 0)
-            printf("[019] '1' IS NOT NULL evaluates to true, expecting zero rows, got %d rows\n", $tmp);
+                printf("[030] Expecting zero rows, got %d rows\n", $tmp);
+
+        $sql = sprintf("SELECT id, label FROM test_prepare_native_myisam WHERE  (id = :placeholder) OR (label LIKE %s)",
+            $db->quote('%go%'));
+        $stmt = prepex(11, $db, $sql,	array('placeholder' => 1));
+        if (count(($tmp = $stmt->fetchAll(PDO::FETCH_ASSOC))) != 1)
+            printf("[032] Expecting one row, got %d rows\n", $tmp);
     } catch (PDOException $e) {
         printf("[001] %s [%s] %s\n",
             $e->getMessage(), $db->errorCode(), implode(' ', $db->errorInfo()));
@@ -166,29 +156,8 @@ $db = MySQLPDOTest::factory();
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable(NULL, 'test_prepare_native');
+MySQLPDOTest::dropTestTable(NULL, 'test_prepare_native_myisam');
 ?>
 --EXPECT--
 PDO::prepare(): Argument #1 ($query) cannot be empty
-array(1) {
-  [0]=>
-  array(1) {
-    ["label"]=>
-    string(12) ":placeholder"
-  }
-}
-array(2) {
-  [0]=>
-  array(1) {
-    ["label"]=>
-    string(9) "first row"
-  }
-  [1]=>
-  array(1) {
-    ["label"]=>
-    string(10) "second row"
-  }
-}
-array(0) {
-}
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_named_placeholder.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_named_placeholder.phpt
@@ -15,15 +15,14 @@ $db = MySQLPDOTest::factory();
 
     try {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec(sprintf('CREATE TABLE test(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        $db->exec(sprintf('CREATE TABLE test_prepare_native_named_placeholder(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
 
         $db->setAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY, 0);
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[002] Unable to turn off emulated prepared statements\n");
 
         // INSERT a single row
-        $stmt = $db->prepare("INSERT INTO test(id, label) VALUES (100, ':placeholder')");
+        $stmt = $db->prepare("INSERT INTO test_prepare_native_named_placeholder(id, label) VALUES (100, ':placeholder')");
 
         // Yes, there is no placeholder to bind to and named placeholder
         // do not work with MySQL native PS, but lets see what happens!
@@ -36,7 +35,7 @@ $db = MySQLPDOTest::factory();
                 var_export($stmt->errorInfo(), true));
 
         // Ok, what has happened: anything inserted into the DB?
-        $stmt = $db->prepare('SELECT id, label FROM test');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_native_named_placeholder');
         $stmt->execute();
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
@@ -46,7 +45,7 @@ $db = MySQLPDOTest::factory();
             printf("[004] Unable to turn on emulated prepared statements\n");
 
         // Note that the "named placeholder" is enclosed by double quotes.
-        $stmt = $db->prepare("INSERT INTO test(id, label) VALUES(101, ':placeholder')");
+        $stmt = $db->prepare("INSERT INTO test_prepare_native_named_placeholder(id, label) VALUES(101, ':placeholder')");
         // No replacement shall be made
         $stmt->execute(array(':placeholder' => 'row1'));
         // Again, I'd like to see an error message
@@ -56,7 +55,7 @@ $db = MySQLPDOTest::factory();
                 var_export($stmt->errorInfo(), true));
 
         // Now, what do we have in the DB?
-        $stmt = $db->prepare('SELECT id, label FROM test ORDER BY id');
+        $stmt = $db->prepare('SELECT id, label FROM test_prepare_native_named_placeholder ORDER BY id');
         $stmt->execute();
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
 
@@ -71,7 +70,7 @@ $db = MySQLPDOTest::factory();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_prepare_native_named_placeholder');
 ?>
 --EXPECTF--
 Warning: PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_prepare_native_placeholder_everywhere.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_prepare_native_placeholder_everywhere.phpt
@@ -19,11 +19,10 @@ $db = MySQLPDOTest::factory();
         if (1 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[002] Unable to switch on emulated prepared statements, test will fail\n");
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec(sprintf('CREATE TABLE test(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
-        $db->exec("INSERT INTO test(id, label) VALUES (1, 'row1')");
+        $db->exec(sprintf('CREATE TABLE test_prepare_native_named_placeholder_everywhere(id INT, label CHAR(255)) ENGINE=%s', PDO_MYSQL_TEST_ENGINE));
+        $db->exec("INSERT INTO test_prepare_native_named_placeholder_everywhere(id, label) VALUES (1, 'row1')");
 
-        $stmt = $db->prepare('SELECT ?, id, label FROM test WHERE ? = ? ORDER BY id ASC');
+        $stmt = $db->prepare('SELECT ?, id, label FROM test_prepare_native_named_placeholder_everywhere WHERE ? = ? ORDER BY id ASC');
         $stmt->execute(array('id', 'label', 'label'));
         if ('00000' !== $stmt->errorCode())
             printf("[003] Execute has failed, %s %s\n",
@@ -35,9 +34,9 @@ $db = MySQLPDOTest::factory();
         printf("now the same with native PS\n");
         $db->setAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY, 0);
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
-            printf("[004] Unable to switch off emulated prepared statements, test will fail\n");
+            printf("[004] Unable to switch off emulated prepared statements, test_prepare_native_named_placeholder_everywhere will fail\n");
 
-        $stmt = $db->prepare('SELECT ?, id, label FROM test WHERE ? = ? ORDER BY id ASC');
+        $stmt = $db->prepare('SELECT ?, id, label FROM test_prepare_native_named_placeholder_everywhere WHERE ? = ? ORDER BY id ASC');
         $stmt->execute(array('id', 'label', 'label'));
         if ('00000' !== $stmt->errorCode())
             printf("[005] Execute has failed, %s %s\n",
@@ -57,7 +56,7 @@ $db = MySQLPDOTest::factory();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_prepare_native_named_placeholder_everywhere');
 ?>
 --EXPECT--
 array(1) {

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_bindparam_types.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_bindparam_types.phpt
@@ -21,13 +21,12 @@ $db = MySQLPDOTest::factory();
             else
                 $db->setAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY, 1);
 
-            $db->exec('DROP TABLE IF EXISTS test');
-            $sql = sprintf('CREATE TABLE test(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
+            $sql = sprintf('CREATE TABLE test_stmt_bindparam_types(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
             if ((!$stmt = @$db->prepare($sql)) || (!@$stmt->execute()))
                 // Server might not support column type - skip it
                 return true;
 
-            $stmt = $db->prepare('INSERT INTO test(id, label) VALUES (1, ?)');
+            $stmt = $db->prepare('INSERT INTO test_stmt_bindparam_types(id, label) VALUES (1, ?)');
             if (!$stmt->bindParam(1, $value)) {
                 printf("[%03d/%s + 1] %s\n", $offset, ($native) ? 'native' : 'emulated',
                     var_export($stmt->errorInfo(), true));
@@ -39,7 +38,7 @@ $db = MySQLPDOTest::factory();
                 return false;
             }
 
-            $stmt = $db->query('SELECT id, label FROM test');
+            $stmt = $db->query('SELECT id, label FROM test_stmt_bindparam_types');
             $id = $label = null;
             if (!$stmt->bindColumn(1, $id)) {
                 printf("[%03d/%s + 3] %s\n", $offset, ($native) ? 'native' : 'emulated',
@@ -88,7 +87,7 @@ $db = MySQLPDOTest::factory();
                 return false;
             }
 
-            $db->exec('DROP TABLE IF EXISTS test');
+            $db->exec('DROP TABLE IF EXISTS test_stmt_bindparam_types');
             return true;
     }
 
@@ -168,7 +167,8 @@ $db = MySQLPDOTest::factory();
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable();
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_stmt_bindparam_types');
 ?>
 --EXPECT--
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_blobfromstream.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_blobfromstream.phpt
@@ -53,11 +53,10 @@ unlink($file);
                 return false;
             }
 
-            $db->exec('DROP TABLE IF EXISTS test');
-            $sql = sprintf('CREATE TABLE test(id INT, label BLOB) ENGINE=%s', PDO_MYSQL_TEST_ENGINE);
+            $sql = sprintf('CREATE TABLE test_stmt_blobfromstream(id INT, label BLOB) ENGINE=%s', PDO_MYSQL_TEST_ENGINE);
             $db->exec($sql);
 
-            if (!$stmt = $db->prepare('INSERT INTO test(id, label) VALUES (?, ?)')) {
+            if (!$stmt = $db->prepare('INSERT INTO test_stmt_blobfromstream(id, label) VALUES (?, ?)')) {
                 printf("[%03d + 4] %s\n", $offset, var_export($db->errorInfo(), true));
                 return false;
             }
@@ -84,7 +83,7 @@ unlink($file);
                 return false;
             }
 
-            $stmt2 = $db->query('SELECT id, label FROM test WHERE id = 1');
+            $stmt2 = $db->query('SELECT id, label FROM test_stmt_blobfromstream WHERE id = 1');
             $row = $stmt2->fetch(PDO::FETCH_ASSOC);
             if ($row['label'] != $blob) {
                 printf("[%03d + 8] INSERT and/or SELECT has failed, dumping data.\n", $offset);
@@ -95,14 +94,14 @@ unlink($file);
 
             // Lets test the chr(0) handling in case the streaming has failed:
             // is the bug about chr(0) or the streaming...
-            $db->exec('DELETE FROM test');
-            $stmt = $db->prepare('INSERT INTO test(id, label) VALUES (?, ?)');
+            $db->exec('DELETE FROM test_stmt_blobfromstream');
+            $stmt = $db->prepare('INSERT INTO test_stmt_blobfromstream(id, label) VALUES (?, ?)');
             $stmt->bindParam(1, $id);
             $stmt->bindParam(2, $blob);
             if (true !== $stmt->execute())
                 printf("[%03d + 9] %s\n", $offset, var_export($stmt->errorInfo(), true));
 
-            $stmt2 = $db->query('SELECT id, label FROM test WHERE id = 1');
+            $stmt2 = $db->query('SELECT id, label FROM test_stmt_blobfromstream WHERE id = 1');
             $row = $stmt2->fetch(PDO::FETCH_ASSOC);
             if ($row['label'] != $blob) {
                 printf("[%03d + 10] INSERT and/or SELECT has failed, dumping data.\n", $offset);
@@ -125,6 +124,8 @@ unlink($file);
         $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 1);
         blob_from_stream(10, $db, $file, $blob);
 
+        $db->exec('DROP TABLE IF EXISTS test_stmt_blobfromstream');
+
         printf("Native PS...\n");
         $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
         blob_from_stream(30, $db, $file, $blob);
@@ -139,8 +140,7 @@ unlink($file);
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-$db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+MySQLPDOTest::dropTestTable(NULL, 'test_stmt_blobfromstream');
 @unlink(MySQLPDOTest::getTempDir() . DIRECTORY_SEPARATOR . 'pdoblob.tst');
 ?>
 --EXPECT--

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_blobs.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_blobs.phpt
@@ -25,11 +25,11 @@ MySQLPDOTest::skip();
 
     function test_blob($db, $offset, $sql_type, $test_len) {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec(sprintf('CREATE TABLE test(id INT, label %s) ENGINE=%s', $sql_type, PDO_MYSQL_TEST_ENGINE));
+        $db->exec('DROP TABLE IF EXISTS test_stmt_blobs');
+        $db->exec(sprintf('CREATE TABLE test_stmt_blobs(id INT, label %s) ENGINE=%s', $sql_type, PDO_MYSQL_TEST_ENGINE));
 
         $value = str_repeat('a', $test_len);
-        $stmt = $db->prepare('INSERT INTO test(id, label) VALUES (?, ?)');
+        $stmt = $db->prepare('INSERT INTO test_stmt_blobs(id, label) VALUES (?, ?)');
         $stmt->bindValue(1, 1);
         $stmt->bindValue(2, $value);
         if (!$stmt->execute()) {
@@ -38,7 +38,7 @@ MySQLPDOTest::skip();
             return false;
         }
 
-        $stmt = $db->query('SELECT id, label FROM test');
+        $stmt = $db->query('SELECT id, label FROM test_stmt_blobs');
         $id = $label = NULL;
         $stmt->bindColumn(1, $id, PDO::PARAM_INT);
         $stmt->bindColumn(2, $label, PDO::PARAM_LOB);
@@ -67,7 +67,7 @@ MySQLPDOTest::skip();
             return false;
         }
 
-        $stmt = $db->query('SELECT id, label FROM test');
+        $stmt = $db->query('SELECT id, label FROM test_stmt_blobs');
         $ret = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if ($ret['label'] !== $value) {
@@ -99,7 +99,7 @@ MySQLPDOTest::skip();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_stmt_blobs');
 ?>
 --EXPECT--
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_class.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MySQL PDOStatement->fetch(), PDO::FETCH_SERIALIZE
+MySQL PDOStatement->fetch(), PDO::FETCH_CLASS
 --EXTENSIONS--
 pdo_mysql
 --SKIPIF--
@@ -79,20 +79,23 @@ MySQLPDOTest::skip();
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[002] Unable to turn off emulated prepared statements\n");
 
-        $db->exec(sprintf('CREATE TABLE test_stmt_fetch_serialize(id INT, myobj BLOB) ENGINE=%s',
+        $db->exec(sprintf('CREATE TABLE test_stmt_fetch_class(id INT, myobj BLOB) ENGINE=%s',
             MySQLPDOTest::getTableEngine()));
 
         printf("Creating an object, serializing it and writing it to DB...\n");
         $id = 1;
         $obj = myclass::singleton('Creating object');
         $myobj = serialize($obj);
-        $stmt = $db->prepare('INSERT INTO test_stmt_fetch_serialize(id, myobj) VALUES (?, ?)');
+        $stmt = $db->prepare('INSERT INTO test_stmt_fetch_class(id, myobj) VALUES (?, ?)');
         $stmt->bindValue(1, $id);
         $stmt->bindValue(2, $myobj);
         $stmt->execute();
 
-        printf("\nUnserializing the previously serialized object...\n");
-        var_dump(unserialize($myobj));
+        printf("\nUsing PDO::FETCH_CLASS to fetch the object from DB and unserialize it...\n");
+        $stmt = $db->prepare('SELECT myobj FROM test_stmt_fetch_class');
+        $stmt->setFetchMode(PDO::FETCH_CLASS, 'myclass', array('PDO shall call __construct()'));
+        $stmt->execute();
+        var_dump($stmt->fetch());
     } catch (PDOException $e) {
         printf("[001] %s [%s] %s\n",
             $e->getMessage(), $db->errorCode(), implode(' ', $db->errorInfo()));
@@ -103,7 +106,7 @@ MySQLPDOTest::skip();
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable(NULL, 'test_stmt_fetch_serialize');
+MySQLPDOTest::dropTestTable(NULL, 'test_stmt_fetch_class');
 ?>
 --EXPECTF--
 Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
@@ -112,10 +115,13 @@ myclass::singleton(Creating object)
 myclass::__construct(Creating object)
 myclass::serialize()
 
-Unserializing the previously serialized object...
-myclass::unserialize('Data from serialize')
-object(myclass)#4 (1) {
+Using PDO::FETCH_CLASS to fetch the object from DB and unserialize it...
+myclass::__set(myobj, 'C:7:"myclass":19:{Data from serialize}')
+myclass::__construct(PDO shall call __construct())
+object(myclass)#%d (2) {
   ["myprotected":protected]=>
   string(20) "a protected property"
+  ["myobj"]=>
+  string(38) "C:7:"myclass":19:{Data from serialize}"
 }
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_fetch_class.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_fetch_class.phpt
@@ -1,5 +1,5 @@
 --TEST--
-MySQL PDOStatement->fetch(), PDO::FETCH_SERIALIZE
+MySQL PDOStatement->fetch(), PDO::FETCH_SERIALIZE|PDO::FETCH_CLASS
 --EXTENSIONS--
 pdo_mysql
 --SKIPIF--
@@ -79,20 +79,23 @@ MySQLPDOTest::skip();
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[002] Unable to turn off emulated prepared statements\n");
 
-        $db->exec(sprintf('CREATE TABLE test_stmt_fetch_serialize(id INT, myobj BLOB) ENGINE=%s',
+        $db->exec(sprintf('CREATE TABLE test_stmt_fetchserialize_fetch_class(id INT, myobj BLOB) ENGINE=%s',
             MySQLPDOTest::getTableEngine()));
 
         printf("Creating an object, serializing it and writing it to DB...\n");
         $id = 1;
         $obj = myclass::singleton('Creating object');
         $myobj = serialize($obj);
-        $stmt = $db->prepare('INSERT INTO test_stmt_fetch_serialize(id, myobj) VALUES (?, ?)');
+        $stmt = $db->prepare('INSERT INTO test_stmt_fetchserialize_fetch_class(id, myobj) VALUES (?, ?)');
         $stmt->bindValue(1, $id);
         $stmt->bindValue(2, $myobj);
         $stmt->execute();
 
-        printf("\nUnserializing the previously serialized object...\n");
-        var_dump(unserialize($myobj));
+        printf("\nUsing PDO::FETCH_CLASS|PDO::FETCH_SERIALIZE to fetch the object from DB and unserialize it...\n");
+        $stmt = $db->prepare('SELECT myobj FROM test_stmt_fetchserialize_fetch_class');
+        $stmt->setFetchMode(PDO::FETCH_CLASS|PDO::FETCH_SERIALIZE, 'myclass', array('PDO shall not call __construct()'));
+        $stmt->execute();
+        var_dump($stmt->fetch());
     } catch (PDOException $e) {
         printf("[001] %s [%s] %s\n",
             $e->getMessage(), $db->errorCode(), implode(' ', $db->errorInfo()));
@@ -103,7 +106,7 @@ MySQLPDOTest::skip();
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-MySQLPDOTest::dropTestTable(NULL, 'test_stmt_fetch_serialize');
+MySQLPDOTest::dropTestTable(NULL, 'test_stmt_fetchserialize_fetch_class');
 ?>
 --EXPECTF--
 Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d
@@ -112,9 +115,13 @@ myclass::singleton(Creating object)
 myclass::__construct(Creating object)
 myclass::serialize()
 
-Unserializing the previously serialized object...
-myclass::unserialize('Data from serialize')
-object(myclass)#4 (1) {
+Using PDO::FETCH_CLASS|PDO::FETCH_SERIALIZE to fetch the object from DB and unserialize it...
+
+Deprecated: PDOStatement::setFetchMode(): The PDO::FETCH_SERIALIZE mode is deprecated in %s on line %d
+
+Deprecated: PDOStatement::fetch(): The PDO::FETCH_SERIALIZE mode is deprecated in %s on line %d
+myclass::unserialize('C:7:"myclass":19:{Data from serialize}')
+object(myclass)#%d (1) {
   ["myprotected":protected]=>
   string(20) "a protected property"
 }

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_simple.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_fetch_serialize_simple.phpt
@@ -42,11 +42,10 @@ MySQLPDOTest::skip();
         var_dump($tmp);
 
         printf("\nAnd now magic PDO using fetchAll(PDO::FETCH_CLASS|PDO::FETCH_SERIALIZE)...\n");
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec(sprintf('CREATE TABLE test(myobj BLOB) ENGINE=%s', MySQLPDOTest::getTableEngine()));
-        $db->exec("INSERT INTO test(myobj) VALUES ('Data fetched from DB to be given to unserialize()')");
+        $db->exec(sprintf('CREATE TABLE test_stmt_fetchserialize_simple(myobj BLOB) ENGINE=%s', MySQLPDOTest::getTableEngine()));
+        $db->exec("INSERT INTO test_stmt_fetchserialize_simple(myobj) VALUES ('Data fetched from DB to be given to unserialize()')");
 
-        $stmt = $db->prepare('SELECT myobj FROM test');
+        $stmt = $db->prepare('SELECT myobj FROM test_stmt_fetchserialize_simple');
         $stmt->execute();
         $rows = $stmt->fetchAll(PDO::FETCH_CLASS|PDO::FETCH_SERIALIZE, 'myclass', array('Called by PDO'));
         var_dump($rows[0]);
@@ -56,7 +55,7 @@ MySQLPDOTest::skip();
         var_dump($rows[0]);
 
         printf("\nAnd now PDO using setFetchMode(PDO::FETCH:CLASS|PDO::FETCH_SERIALIZE) + fetch()...\n");
-        $stmt = $db->prepare('SELECT myobj FROM test');
+        $stmt = $db->prepare('SELECT myobj FROM test_stmt_fetchserialize_simple');
         $stmt->setFetchMode(PDO::FETCH_CLASS|PDO::FETCH_SERIALIZE, 'myclass', array('Called by PDO'));
         $stmt->execute();
         var_dump($stmt->fetch());
@@ -66,8 +65,13 @@ MySQLPDOTest::skip();
             $e->getMessage(), $db->errorCode(), implode(' ', $db->errorInfo()));
     }
 
-    $db->exec('DROP TABLE IF EXISTS test');
     print "done!\n";
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_stmt_fetchserialize_simple');
 ?>
 --EXPECTF--
 Deprecated: %s implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %s on line %d

--- a/ext/pdo_mysql/tests/pdo_mysql_stmt_getcolumnmeta.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_stmt_getcolumnmeta.phpt
@@ -19,11 +19,13 @@ if ($version < 51)
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'mysql_pdo_test.inc');
 $db = MySQLPDOTest::factory();
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
-MySQLPDOTest::createTestTable($db);
+
+$db->exec('CREATE TABLE test_stmt_getcolumnmeta(id INT, label CHAR(1), PRIMARY KEY(id)) ENGINE=InnoDB');
+$db->exec("INSERT INTO test_stmt_getcolumnmeta(id, label) VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e'), (6, 'f')");
 
 try {
 
-    $stmt = $db->prepare('SELECT id FROM test ORDER BY id ASC');
+    $stmt = $db->prepare('SELECT id FROM test_stmt_getcolumnmeta ORDER BY id ASC');
 
     // execute() has not been called yet
     // NOTE: no warning
@@ -46,7 +48,7 @@ try {
         if (0 != $db->getAttribute(PDO::MYSQL_ATTR_DIRECT_QUERY))
             printf("[007] Unable to turn off emulated prepared statements\n");
 
-    $stmt = $db->prepare('SELECT id FROM test ORDER BY id ASC');
+    $stmt = $db->prepare('SELECT id FROM test_stmt_getcolumnmeta ORDER BY id ASC');
     $stmt->execute();
     $native = $stmt->getColumnMeta(0);
     if (count($native) == 0) {
@@ -61,21 +63,21 @@ try {
 
     function test_meta(&$db, $offset, $sql_type, $value, $native_type, $pdo_type) {
 
-        $db->exec('DROP TABLE IF EXISTS test');
+        $db->exec('DROP TABLE IF EXISTS test_stmt_getcolumnmeta');
 
-        $sql = sprintf('CREATE TABLE test(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
+        $sql = sprintf('CREATE TABLE test_stmt_getcolumnmeta(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
         if (!($stmt = @$db->prepare($sql)) || (!@$stmt->execute())) {
             // Some engines and/or MySQL server versions might not support the data type
             return true;
         }
 
-        if (!$db->exec(sprintf("INSERT INTO test(id, label) VALUES (1, '%s')", $value))) {
+        if (!$db->exec(sprintf("INSERT INTO test_stmt_getcolumnmeta(id, label) VALUES (1, '%s')", $value))) {
             printf("[%03d] + 1] Insert failed, %d - %s\n", $offset,
                 $db->errorCode(), var_export($db->errorInfo(), true));
             return false;
         }
 
-        $stmt = $db->prepare('SELECT id, label FROM test');
+        $stmt = $db->prepare('SELECT id, label FROM test_stmt_getcolumnmeta');
         $stmt->execute();
         $meta = $stmt->getColumnMeta(1);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -94,7 +96,7 @@ try {
                 return false;
             }
 
-        if (($meta['table'] != 'test') || ($meta['name'] != 'label')) {
+        if (($meta['table'] != 'test_stmt_getcolumnmeta') || ($meta['name'] != 'label')) {
             printf("[%03d + 4] Table or field name is wrong, %s\n", $offset,
                 var_export($meta, true));
             return false;
@@ -225,11 +227,11 @@ try {
 */
 
     // unique key
-    $db->exec('DROP TABLE IF EXISTS test');
-    $sql = sprintf('CREATE TABLE test(id INT, label INT UNIQUE) ENGINE = %s', MySQLPDOTest::getTableEngine());
+    $db->exec('DROP TABLE IF EXISTS test_stmt_getcolumnmeta');
+    $sql = sprintf('CREATE TABLE test_stmt_getcolumnmeta(id INT, label INT UNIQUE) ENGINE = %s', MySQLPDOTest::getTableEngine());
     if (($stmt = @$db->prepare($sql)) && @$stmt->execute()) {
-        $db->exec('INSERT INTO test(id, label) VALUES (1, 2)');
-        $stmt = $db->query('SELECT id, label FROM test');
+        $db->exec('INSERT INTO test_stmt_getcolumnmeta(id, label) VALUES (1, 2)');
+        $stmt = $db->query('SELECT id, label FROM test_stmt_getcolumnmeta');
         $meta = $stmt->getColumnMeta(1);
         if (!isset($meta['flags'])) {
             printf("[1000] No flags contained in metadata %s\n", var_export($meta, true));
@@ -246,11 +248,11 @@ try {
     }
 
     // primary key
-    $db->exec('DROP TABLE IF EXISTS test');
-    $sql = sprintf('CREATE TABLE test(id INT PRIMARY KEY NOT NULL AUTO_INCREMENT) ENGINE = %s', MySQLPDOTest::getTableEngine());
+    $db->exec('DROP TABLE IF EXISTS test_stmt_getcolumnmeta');
+    $sql = sprintf('CREATE TABLE test_stmt_getcolumnmeta(id INT PRIMARY KEY NOT NULL AUTO_INCREMENT) ENGINE = %s', MySQLPDOTest::getTableEngine());
     if (($stmt = @$db->prepare($sql)) && @$stmt->execute()) {
-        $db->exec('INSERT INTO test(id) VALUES (1)');
-        $stmt = $db->query('SELECT id FROM test');
+        $db->exec('INSERT INTO test_stmt_getcolumnmeta(id) VALUES (1)');
+        $stmt = $db->query('SELECT id FROM test_stmt_getcolumnmeta');
         $meta = $stmt->getColumnMeta(0);
         if (!isset($meta['flags'])) {
             printf("[1002] No flags contained in metadata %s\n", var_export($meta, true));
@@ -267,11 +269,11 @@ try {
     }
 
     // multiple key
-    $db->exec('DROP TABLE IF EXISTS test');
-    $sql = sprintf('CREATE TABLE test(id INT, label1 INT, label2 INT, INDEX idx1(label1, label2)) ENGINE = %s', MySQLPDOTest::getTableEngine());
+    $db->exec('DROP TABLE IF EXISTS test_stmt_getcolumnmeta');
+    $sql = sprintf('CREATE TABLE test_stmt_getcolumnmeta(id INT, label1 INT, label2 INT, INDEX idx1(label1, label2)) ENGINE = %s', MySQLPDOTest::getTableEngine());
     if (($stmt = @$db->prepare($sql)) && @$stmt->execute()) {
-        $db->exec('INSERT INTO test(id, label1, label2) VALUES (1, 2, 3)');
-        $stmt = $db->query('SELECT id, label1, label2 FROM test');
+        $db->exec('INSERT INTO test_stmt_getcolumnmeta(id, label1, label2) VALUES (1, 2, 3)');
+        $stmt = $db->query('SELECT id, label1, label2 FROM test_stmt_getcolumnmeta');
         $meta = $stmt->getColumnMeta(1);
         if (!isset($meta['flags'])) {
             printf("[1004] No flags contained in metadata %s\n", var_export($meta, true));
@@ -298,8 +300,13 @@ try {
         $e->getMessage(), $db->errorInfo(), implode(' ', $db->errorInfo()));
 }
 
-$db->exec('DROP TABLE IF EXISTS test');
 print "done!";
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/mysql_pdo_test.inc';
+$db = MySQLPDOTest::factory();
+$db->exec('DROP TABLE IF EXISTS test_stmt_getcolumnmeta');
 ?>
 --EXPECT--
 PDOStatement::getColumnMeta(): Argument #1 ($column) must be greater than or equal to 0

--- a/ext/pdo_mysql/tests/pdo_mysql_subclass.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_subclass.phpt
@@ -53,10 +53,9 @@ MySQLPDOTest::skip();
 
         $db = new MyPDO(PDO_MYSQL_TEST_DSN, PDO_MYSQL_TEST_USER, PDO_MYSQL_TEST_PASS);
         $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
-        $db->exec('DROP TABLE IF EXISTS test');
-        $db->exec('CREATE TABLE test(id INT)');
-        $db->exec('INSERT INTO test(id) VALUES (1), (2)');
-        $stmt = $db->query('SELECT * FROM test ORDER BY id ASC');
+        $db->exec('CREATE TABLE test_subclass(id INT)');
+        $db->exec('INSERT INTO test_subclass(id) VALUES (1), (2)');
+        $stmt = $db->query('SELECT * FROM test_subclass ORDER BY id ASC');
         var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
         var_dump($stmt->fetch());
         $db->intercept_call();
@@ -67,23 +66,22 @@ MySQLPDOTest::skip();
             $e->getMessage(), $db->errorCode(), implode(' ', $db->errorInfo()));
     }
 
-    $db->exec('DROP TABLE IF EXISTS test');
+    $db->exec('DROP TABLE IF EXISTS test_subclass');
     print "done!\n";
 ?>
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_subclass');
 ?>
 --EXPECTF--
 __construct('%S', '%S', %s)
 
 Deprecated: Callables of the form ["MyPDO", "parent::__construct"] are deprecated in %s on line %d
-exec('DROP TABLE IF EXISTS test')
-exec('CREATE TABLE test(id INT)')
-exec('INSERT INTO test(id) VALUES (1), (2)')
-query('SELECT * FROM test ORDER BY id ASC')
+exec('CREATE TABLE test_subclass(id INT)')
+exec('INSERT INTO test_subclass(id) VALUES (1), (2)')
+query('SELECT * FROM test_subclass ORDER BY id ASC')
 array(2) {
   [0]=>
   array(1) {
@@ -99,5 +97,5 @@ array(2) {
 bool(false)
 __call('intercept_call', array (
 ))
-exec('DROP TABLE IF EXISTS test')
+exec('DROP TABLE IF EXISTS test_subclass')
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_types.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_types.phpt
@@ -13,15 +13,15 @@ MySQLPDOTest::skip();
 
     function test_type(&$db, $offset, $sql_type, $value, $ret_value = NULL, $pattern = NULL, $alternative_type = NULL) {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $sql = sprintf('CREATE TABLE test(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
+        $db->exec('DROP TABLE IF EXISTS test_mysql_types');
+        $sql = sprintf('CREATE TABLE test_mysql_types(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
         @$db->exec($sql);
         if ($db->errorCode() != 0) {
             // not all MySQL Server versions and/or engines might support the type
             return true;
         }
 
-        $stmt = $db->prepare('INSERT INTO test(id, label) VALUES (?, ?)');
+        $stmt = $db->prepare('INSERT INTO test_mysql_types(id, label) VALUES (?, ?)');
         $stmt->bindValue(1, $offset);
         $stmt->bindValue(2, $value);
         if (!$stmt->execute()) {
@@ -29,7 +29,7 @@ MySQLPDOTest::skip();
             return false;
         }
         $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
-        $stmt = $db->query('SELECT  id, label FROM test');
+        $stmt = $db->query('SELECT  id, label FROM test_mysql_types');
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         $stmt->closeCursor();
 
@@ -69,7 +69,7 @@ MySQLPDOTest::skip();
         }
 
         $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
-        $stmt = $db->query('SELECT id, label FROM test');
+        $stmt = $db->query('SELECT id, label FROM test_mysql_types');
         $row_string = $stmt->fetch(PDO::FETCH_ASSOC);
         $stmt->closeCursor();
         if (is_null($pattern) && ($row['label'] != $row_string['label'])) {
@@ -179,7 +179,7 @@ MySQLPDOTest::skip();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_mysql_types');
 ?>
 --EXPECT--
 done!

--- a/ext/pdo_mysql/tests/pdo_mysql_types_zerofill.phpt
+++ b/ext/pdo_mysql/tests/pdo_mysql_types_zerofill.phpt
@@ -13,15 +13,15 @@ MySQLPDOTest::skip();
 
     function test_type(&$db, $offset, $sql_type, $value, $ret_value = NULL, $pattern = NULL) {
 
-        $db->exec('DROP TABLE IF EXISTS test');
-        $sql = sprintf('CREATE TABLE test(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
+        $db->exec('DROP TABLE IF EXISTS test_mysql_types_zerofill');
+        $sql = sprintf('CREATE TABLE test_mysql_types_zerofill(id INT, label %s) ENGINE=%s', $sql_type, MySQLPDOTest::getTableEngine());
         @$db->exec($sql);
         if ($db->errorCode() != 0) {
             // not all MySQL Server versions and/or engines might support the type
             return true;
         }
 
-        $stmt = $db->prepare('INSERT INTO test(id, label) VALUES (?, ?)');
+        $stmt = $db->prepare('INSERT INTO test_mysql_types_zerofill(id, label) VALUES (?, ?)');
         $stmt->bindValue(1, $offset);
         $stmt->bindValue(2, $value);
         try {
@@ -36,7 +36,7 @@ MySQLPDOTest::skip();
         }
 
         $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
-        $stmt = $db->query('SELECT id, label FROM test');
+        $stmt = $db->query('SELECT id, label FROM test_mysql_types_zerofill');
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         $stmt->closeCursor();
         if (!isset($row['id']) || !isset($row['label'])) {
@@ -76,7 +76,7 @@ MySQLPDOTest::skip();
         }
 
         $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
-        $stmt = $db->query('SELECT id, label FROM test');
+        $stmt = $db->query('SELECT id, label FROM test_mysql_types_zerofill');
         $row_string = $stmt->fetch(PDO::FETCH_ASSOC);
         $stmt->closeCursor();
         if ($row['label'] != $row_string['label']) {
@@ -123,7 +123,7 @@ MySQLPDOTest::skip();
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_mysql_types_zerofill');
 ?>
 --EXPECT--
 done!

--- a/ext/pdo_mysql/tests/pecl_bug_5200.phpt
+++ b/ext/pdo_mysql/tests/pecl_bug_5200.phpt
@@ -14,17 +14,16 @@ PDOTest::skip();
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__. '/common.phpt');
 
-$db->exec("CREATE TABLE test (bar INT NOT NULL, phase enum('please_select', 'I', 'II', 'IIa', 'IIb', 'III', 'IV'))");
+$db->exec("CREATE TABLE test_pecl_bug_5200 (bar INT NOT NULL, phase enum('please_select', 'I', 'II', 'IIa', 'IIb', 'III', 'IV'))");
 
-foreach ($db->query('DESCRIBE test phase')->fetchAll(PDO::FETCH_ASSOC) as $row) {
+foreach ($db->query('DESCRIBE test_pecl_bug_5200 phase')->fetchAll(PDO::FETCH_ASSOC) as $row) {
     print_r($row);
 }
 ?>
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-$db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+MySQLPDOTest::dropTestTable(NULL, 'test_pecl_bug_5200');
 ?>
 --EXPECT--
 Array

--- a/ext/pdo_mysql/tests/pecl_bug_5780.phpt
+++ b/ext/pdo_mysql/tests/pecl_bug_5780.phpt
@@ -14,13 +14,13 @@ PDOTest::skip();
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__. '/common.phpt');
 
-$db->exec("CREATE TABLE test (login varchar(32) NOT NULL, data varchar(64) NOT NULL)");
-$db->exec("CREATE TABLE test2 (login varchar(32) NOT NULL, password varchar(64) NOT NULL)");
-$db->exec("INSERT INTO test2 (login, password) VALUES ('testing', 'testing')");
-$db->exec("INSERT INTO test2 (login, password) VALUES ('test2', 'testpw2')");
+$db->exec("CREATE TABLE test_pecl_bug_5780 (login varchar(32) NOT NULL, data varchar(64) NOT NULL)");
+$db->exec("CREATE TABLE test_pecl_bug_5780_2 (login varchar(32) NOT NULL, password varchar(64) NOT NULL)");
+$db->exec("INSERT INTO test_pecl_bug_5780_2 (login, password) VALUES ('testing', 'testing')");
+$db->exec("INSERT INTO test_pecl_bug_5780_2 (login, password) VALUES ('test2', 'testpw2')");
 
-$logstmt = $db->prepare('INSERT INTO test (login, data) VALUES (:var1, :var2)');
-$authstmt = $db->prepare('SELECT * FROM test2 WHERE login = :varlog AND password = :varpass');
+$logstmt = $db->prepare('INSERT INTO test_pecl_bug_5780 (login, data) VALUES (:var1, :var2)');
+$authstmt = $db->prepare('SELECT * FROM test_pecl_bug_5780_2 WHERE login = :varlog AND password = :varpass');
 $authstmt->execute(array(':varlog' => 'testing', ':varpass' => 'testing'));
 var_dump($authstmt->fetch(PDO::FETCH_NUM));
 @var_dump($logstmt->execute(array(':var1' => 'test1', ':var2' => 'test2')));
@@ -31,9 +31,8 @@ var_dump($info);
 --CLEAN--
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
-$db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
-$db->exec('DROP TABLE IF EXISTS test2');
+MySQLPDOTest::dropTestTable(NULL, 'test_pecl_bug_5780');
+MySQLPDOTest::dropTestTable(NULL, 'test_pecl_bug_5780_2');
 ?>
 --EXPECT--
 array(2) {

--- a/ext/pdo_mysql/tests/pecl_bug_5802.phpt
+++ b/ext/pdo_mysql/tests/pecl_bug_5802.phpt
@@ -14,8 +14,8 @@ PDOTest::skip();
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__. '/common.phpt');
 
-$db->exec('create table test ( bar char(3) NULL )');
-$stmt = $db->prepare('insert into test (bar) values(:bar)') or var_dump($db->errorInfo());
+$db->exec('create table test_pcl_bug_5802 ( bar char(3) NULL )');
+$stmt = $db->prepare('insert into test_pcl_bug_5802 (bar) values(:bar)') or var_dump($db->errorInfo());
 
 $bar = 'foo';
 $stmt->bindParam(':bar', $bar);
@@ -29,7 +29,7 @@ $bar = 'qaz';
 $stmt->bindParam(':bar', $bar);
 $stmt->execute() or var_dump($stmt->errorInfo());
 
-$stmt = $db->prepare('select * from test') or var_dump($db->errorInfo());
+$stmt = $db->prepare('select * from test_pcl_bug_5802') or var_dump($db->errorInfo());
 
 if($stmt) $stmt->execute();
 if($stmt) var_dump($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -40,7 +40,7 @@ print "done!";
 <?php
 require __DIR__ . '/mysql_pdo_test.inc';
 $db = MySQLPDOTest::factory();
-$db->exec('DROP TABLE IF EXISTS test');
+$db->exec('DROP TABLE IF EXISTS test_pcl_bug_5802');
 ?>
 --EXPECT--
 array(3) {


### PR DESCRIPTION
Follow-up of https://github.com/php/php-src/pull/11855, same but for `ext/pdo_mysql`