### PR TITLE
[WIP] Auto-extend live-ranges

### DIFF
--- a/Zend/Optimizer/dfa_pass.c
+++ b/Zend/Optimizer/dfa_pass.c
@@ -138,19 +138,12 @@ static void zend_ssa_remove_nops(zend_op_array *op_array, zend_ssa *ssa, zend_op
 	}
 
 	for (b = blocks; b < blocks_end; b++) {
-		if (b->flags & (ZEND_BB_REACHABLE|ZEND_BB_UNREACHABLE_FREE)) {
+		if (b->flags & ZEND_BB_REACHABLE) {
 			if (b->len) {
 				uint32_t new_start, old_end;
 				while (i < b->start) {
 					shiftlist[i] = i - target;
 					i++;
-				}
-
-				if (b->flags & ZEND_BB_UNREACHABLE_FREE) {
-					/* Only keep the FREE for the loop var */
-					ZEND_ASSERT(op_array->opcodes[b->start].opcode == ZEND_FREE
-							|| op_array->opcodes[b->start].opcode == ZEND_FE_FREE);
-					b->len = 1;
 				}
 
 				new_start = target;
@@ -757,9 +750,6 @@ static int zend_dfa_optimize_jmps(zend_op_array *op_array, zend_ssa *ssa)
 
 		while (next_block_num < ssa->cfg.blocks_count
 			&& !(ssa->cfg.blocks[next_block_num].flags & ZEND_BB_REACHABLE)) {
-			if (ssa->cfg.blocks[next_block_num].flags & ZEND_BB_UNREACHABLE_FREE) {
-				can_follow = 0;
-			}
 			next_block_num++;
 		}
 

--- a/Zend/Optimizer/zend_cfg.h
+++ b/Zend/Optimizer/zend_cfg.h
@@ -29,7 +29,6 @@
 #define ZEND_BB_CATCH            (1<<6)  /* start of catch block   */
 #define ZEND_BB_FINALLY          (1<<7)  /* start of finally block */
 #define ZEND_BB_FINALLY_END      (1<<8)  /* end of finally block   */
-#define ZEND_BB_UNREACHABLE_FREE (1<<11) /* unreachable loop free  */
 #define ZEND_BB_RECV_ENTRY       (1<<12) /* RECV entry             */
 
 #define ZEND_BB_LOOP_HEADER      (1<<16)
@@ -37,7 +36,7 @@
 
 #define ZEND_BB_REACHABLE        (1U<<31)
 
-#define ZEND_BB_PROTECTED        (ZEND_BB_ENTRY|ZEND_BB_RECV_ENTRY|ZEND_BB_TRY|ZEND_BB_CATCH|ZEND_BB_FINALLY|ZEND_BB_FINALLY_END|ZEND_BB_UNREACHABLE_FREE)
+#define ZEND_BB_PROTECTED        (ZEND_BB_ENTRY|ZEND_BB_RECV_ENTRY|ZEND_BB_TRY|ZEND_BB_CATCH|ZEND_BB_FINALLY|ZEND_BB_FINALLY_END)
 
 typedef struct _zend_basic_block {
 	int              *successors;         /* successor block indices     */

--- a/Zend/Optimizer/zend_dump.c
+++ b/Zend/Optimizer/zend_dump.c
@@ -803,9 +803,6 @@ static void zend_dump_block_info(const zend_cfg *cfg, int n, uint32_t dump_flags
 	if (!(dump_flags & ZEND_DUMP_HIDE_UNREACHABLE) && !(b->flags & ZEND_BB_REACHABLE)) {
 		fprintf(stderr, " unreachable");
 	}
-	if (b->flags & ZEND_BB_UNREACHABLE_FREE) {
-		fprintf(stderr, " unreachable_free");
-	}
 	if (b->flags & ZEND_BB_LOOP_HEADER) {
 		fprintf(stderr, " loop_header");
 	}

--- a/Zend/Optimizer/zend_optimizer.c
+++ b/Zend/Optimizer/zend_optimizer.c
@@ -1027,7 +1027,7 @@ static void zend_optimize(zend_op_array      *op_array,
 	 */
 	if ((ZEND_OPTIMIZER_PASS_9 & ctx->optimization_level) &&
 	    !(ZEND_OPTIMIZER_PASS_7 & ctx->optimization_level)) {
-		zend_optimize_temporary_variables(op_array, ctx);
+		// zend_optimize_temporary_variables(op_array, ctx);
 		if (ctx->debug_level & ZEND_DUMP_AFTER_PASS_9) {
 			zend_dump_op_array(op_array, 0, "after pass 9", NULL);
 		}
@@ -1536,7 +1536,7 @@ ZEND_API void zend_optimize_script(zend_script *script, zend_long optimization_l
 
 		if (ZEND_OPTIMIZER_PASS_9 & optimization_level) {
 			for (i = 0; i < call_graph.op_arrays_count; i++) {
-				zend_optimize_temporary_variables(call_graph.op_arrays[i], &ctx);
+				// zend_optimize_temporary_variables(call_graph.op_arrays[i], &ctx);
 				if (debug_level & ZEND_DUMP_AFTER_PASS_9) {
 					zend_dump_op_array(call_graph.op_arrays[i], 0, "after pass 9", NULL);
 				}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5181,10 +5181,8 @@ static void zend_compile_throw(znode *result, zend_ast *ast) /* {{{ */
 	znode expr_node;
 	zend_compile_expr(&expr_node, expr_ast);
 
-	zend_op *opline = zend_emit_op(NULL, ZEND_THROW, &expr_node, NULL);
+	zend_emit_op(NULL, ZEND_THROW, &expr_node, NULL);
 	if (result) {
-		/* Mark this as an "expression throw" for opcache. */
-		opline->extended_value = ZEND_THROW_IS_EXPR;
 		result->op_type = IS_CONST;
 		ZVAL_TRUE(&result->u.constant);
 	}
@@ -5946,10 +5944,6 @@ static void zend_compile_match(znode *result, zend_ast *ast)
 		zend_op *opline = zend_emit_op(NULL, ZEND_MATCH_ERROR, &expr_node, NULL);
 		if (opline->op1_type == IS_CONST) {
 			Z_TRY_ADDREF_P(CT_CONSTANT(opline->op1));
-		}
-		if (arms->children == 0) {
-			/* Mark this as an "expression throw" for opcache. */
-			opline->extended_value = ZEND_THROW_IS_EXPR;
 		}
 	}
 
@@ -9432,10 +9426,8 @@ static void zend_compile_exit(znode *result, zend_ast *ast) /* {{{ */
 		expr_node.op_type = IS_UNUSED;
 	}
 
-	zend_op *opline = zend_emit_op(NULL, ZEND_EXIT, &expr_node, NULL);
+	zend_emit_op(NULL, ZEND_EXIT, &expr_node, NULL);
 	if (result) {
-		/* Mark this as an "expression throw" for opcache. */
-		opline->extended_value = ZEND_THROW_IS_EXPR;
 		result->op_type = IS_CONST;
 		ZVAL_TRUE(&result->u.constant);
 	}

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -1021,8 +1021,6 @@ ZEND_API zend_string *zend_type_to_string(zend_type type);
 #define ZEND_SEND_BY_REF     1u
 #define ZEND_SEND_PREFER_REF 2u
 
-#define ZEND_THROW_IS_EXPR 1u
-
 #define ZEND_FCALL_MAY_HAVE_EXTRA_NAMED_PARAMS 1
 
 /* The send mode, the is_variadic, the is_promoted, and the is_tentative flags are stored as part of zend_type */

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -7680,6 +7680,7 @@ ZEND_VM_COLD_CONST_HANDLER(169, ZEND_COALESCE, CONST|TMP|VAR|CV, JMP_ADDR)
 			efree_size(ref, sizeof(zend_reference));
 		}
 	}
+	ZVAL_UNDEF(EX_VAR(opline->result.var));
 	ZEND_VM_NEXT_OPCODE();
 }
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -5374,6 +5374,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_COALESCE_SPEC_CON
 			efree_size(ref, sizeof(zend_reference));
 		}
 	}
+	ZVAL_UNDEF(EX_VAR(opline->result.var));
 	ZEND_VM_NEXT_OPCODE();
 }
 
@@ -19737,6 +19738,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_COALESCE_SPEC_TMP_HANDLER(ZEND
 			efree_size(ref, sizeof(zend_reference));
 		}
 	}
+	ZVAL_UNDEF(EX_VAR(opline->result.var));
 	ZEND_VM_NEXT_OPCODE();
 }
 
@@ -22685,6 +22687,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_COALESCE_SPEC_VAR_HANDLER(ZEND
 			efree_size(ref, sizeof(zend_reference));
 		}
 	}
+	ZVAL_UNDEF(EX_VAR(opline->result.var));
 	ZEND_VM_NEXT_OPCODE();
 }
 
@@ -40135,6 +40138,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_COALESCE_SPEC_CV_HANDLER(ZEND_
 			efree_size(ref, sizeof(zend_reference));
 		}
 	}
+	ZVAL_UNDEF(EX_VAR(opline->result.var));
 	ZEND_VM_NEXT_OPCODE();
 }
 

--- a/ext/opcache/tests/match/001.phpt
+++ b/ext/opcache/tests/match/001.phpt
@@ -27,26 +27,26 @@ foreach (range('a', 'i') as $char) {
 ?>
 --EXPECTF--
 $_main:
-     ; (lines=15, args=0, vars=1, tmps=2)
+     ; (lines=15, args=0, vars=1, tmps=3)
      ; (after optimizer)
      ; %s
 0000 INIT_FCALL 2 %d string("range")
 0001 SEND_VAL string("a") 1
 0002 SEND_VAL string("i") 2
-0003 V2 = DO_ICALL
-0004 V1 = FE_RESET_R V2 0013
-0005 FE_FETCH_R V1 CV0($char) 0013
+0003 V1 = DO_ICALL
+0004 V2 = FE_RESET_R V1 0013
+0005 FE_FETCH_R V2 CV0($char) 0013
 0006 INIT_FCALL 1 %d string("var_dump")
 0007 INIT_FCALL 1 %d string("test")
 0008 SEND_VAR CV0($char) 1
-0009 V2 = DO_UCALL
-0010 SEND_VAR V2 1
+0009 V3 = DO_UCALL
+0010 SEND_VAR V3 1
 0011 DO_ICALL
 0012 JMP 0005
-0013 FE_FREE V1
+0013 FE_FREE V2
 0014 RETURN int(1)
 LIVE RANGES:
-     1: 0005 - 0013 (loop)
+     2: 0005 - 0013 (loop)
 
 test:
      ; (lines=9, args=1, vars=1, tmps=0)

--- a/ext/opcache/tests/match/003.phpt
+++ b/ext/opcache/tests/match/003.phpt
@@ -28,26 +28,26 @@ foreach (range(0, 10) as $char) {
 ?>
 --EXPECTF--
 $_main:
-     ; (lines=15, args=0, vars=1, tmps=2)
+     ; (lines=15, args=0, vars=1, tmps=3)
      ; (after optimizer)
      ; %s
 0000 INIT_FCALL 2 %d string("range")
 0001 SEND_VAL int(0) 1
 0002 SEND_VAL int(10) 2
-0003 V2 = DO_ICALL
-0004 V1 = FE_RESET_R V2 0013
-0005 FE_FETCH_R V1 CV0($char) 0013
+0003 V1 = DO_ICALL
+0004 V2 = FE_RESET_R V1 0013
+0005 FE_FETCH_R V2 CV0($char) 0013
 0006 INIT_FCALL 1 %d string("var_dump")
 0007 INIT_FCALL 1 %d string("test")
 0008 SEND_VAR CV0($char) 1
-0009 V2 = DO_UCALL
-0010 SEND_VAR V2 1
+0009 V3 = DO_UCALL
+0010 SEND_VAR V3 1
 0011 DO_ICALL
 0012 JMP 0005
-0013 FE_FREE V1
+0013 FE_FREE V2
 0014 RETURN int(1)
 LIVE RANGES:
-     1: 0005 - 0013 (loop)
+     2: 0005 - 0013 (loop)
 
 test:
      ; (lines=9, args=1, vars=1, tmps=0)

--- a/ext/opcache/tests/match/004.phpt
+++ b/ext/opcache/tests/match/004.phpt
@@ -33,33 +33,33 @@ foreach (range(0, 6) as $number) {
 ?>
 --EXPECTF--
 $_main:
-     ; (lines=22, args=0, vars=1, tmps=2)
+     ; (lines=22, args=0, vars=1, tmps=5)
      ; (after optimizer)
      ; %s.php:1-25
 0000 INIT_FCALL 2 %d string("range")
 0001 SEND_VAL int(0) 1
 0002 SEND_VAL int(6) 2
-0003 V2 = DO_ICALL
-0004 V1 = FE_RESET_R V2 0020
-0005 FE_FETCH_R V1 CV0($number) 0020
+0003 V1 = DO_ICALL
+0004 V2 = FE_RESET_R V1 0020
+0005 FE_FETCH_R V2 CV0($number) 0020
 0006 INIT_FCALL 1 %d string("var_dump")
 0007 INIT_FCALL 1 %d string("test")
 0008 SEND_VAR CV0($number) 1
-0009 V2 = DO_UCALL
-0010 SEND_VAR V2 1
+0009 V3 = DO_UCALL
+0010 SEND_VAR V3 1
 0011 DO_ICALL
 0012 INIT_FCALL 1 %d string("var_dump")
 0013 INIT_FCALL 1 %d string("test")
-0014 T2 = CAST (string) CV0($number)
-0015 SEND_VAL T2 1
-0016 V2 = DO_UCALL
-0017 SEND_VAR V2 1
+0014 T4 = CAST (string) CV0($number)
+0015 SEND_VAL T4 1
+0016 V5 = DO_UCALL
+0017 SEND_VAR V5 1
 0018 DO_ICALL
 0019 JMP 0005
-0020 FE_FREE V1
+0020 FE_FREE V2
 0021 RETURN int(1)
 LIVE RANGES:
-     1: 0005 - 0020 (loop)
+     2: 0005 - 0020 (loop)
 
 test:
      ; (lines=13, args=1, vars=1, tmps=0)

--- a/ext/opcache/tests/opt/nullsafe_001.phpt
+++ b/ext/opcache/tests/opt/nullsafe_001.phpt
@@ -47,7 +47,7 @@ test:
 0009 RETURN null
 
 test2:
-     ; (lines=17, args=1, vars=1, tmps=1)
+     ; (lines=17, args=1, vars=1, tmps=3)
      ; (after optimizer)
      ; %s
 0000 CV0($obj) = RECV 1
@@ -57,13 +57,13 @@ test2:
 0004 SEND_VAL T1 1
 0005 DO_ICALL
 0006 INIT_FCALL 1 %d string("var_dump")
-0007 T1 = JMP_NULL CV0($obj) 0009
-0008 T1 = ISSET_ISEMPTY_PROP_OBJ (isset) CV0($obj) string("foo")
-0009 SEND_VAL T1 1
+0007 T2 = JMP_NULL CV0($obj) 0009
+0008 T2 = ISSET_ISEMPTY_PROP_OBJ (isset) CV0($obj) string("foo")
+0009 SEND_VAL T2 1
 0010 DO_ICALL
 0011 INIT_FCALL 1 %d string("var_dump")
-0012 T1 = JMP_NULL CV0($obj) 0014
-0013 T1 = ISSET_ISEMPTY_PROP_OBJ (empty) CV0($obj) string("foo")
-0014 SEND_VAL T1 1
+0012 T3 = JMP_NULL CV0($obj) 0014
+0013 T3 = ISSET_ISEMPTY_PROP_OBJ (empty) CV0($obj) string("foo")
+0014 SEND_VAL T3 1
 0015 DO_ICALL
 0016 RETURN null

--- a/ext/opcache/tests/opt/sccp_006.phpt
+++ b/ext/opcache/tests/opt/sccp_006.phpt
@@ -23,7 +23,7 @@ $_main:
 0000 RETURN int(1)
 
 foo:
-     ; (lines=8, args=1, vars=2, tmps=1)
+     ; (lines=8, args=1, vars=2, tmps=2)
      ; (after optimizer)
      ; %ssccp_006.php:2-5
 0000 CV0($x) = RECV 1
@@ -31,8 +31,8 @@ foo:
 0002 T2 = ADD_ARRAY_ELEMENT int(2) string("a")
 0003 T2 = ADD_ARRAY_ELEMENT CV0($x) string("a")
 0004 CV1($a) = QM_ASSIGN T2
-0005 T2 = FETCH_DIM_R CV1($a) string("a")
-0006 ECHO T2
+0005 T3 = FETCH_DIM_R CV1($a) string("a")
+0006 ECHO T3
 0007 RETURN null
 LIVE RANGES:
      2: 0002 - 0004 (tmp/var)

--- a/ext/opcache/tests/opt/sccp_024.phpt
+++ b/ext/opcache/tests/opt/sccp_024.phpt
@@ -29,16 +29,16 @@ $_main:
 0000 RETURN int(1)
 
 A::t:
-     ; (lines=10, args=1, vars=2, tmps=2)
+     ; (lines=10, args=1, vars=2, tmps=4)
      ; (after optimizer)
      ; %ssccp_024.php:3-10
 0000 CV0($obj) = RECV 1
 0001 CV1($c) = QM_ASSIGN int(1)
 0002 T2 = INSTANCEOF CV0($obj) string("A")
 0003 ECHO T2
-0004 T2 = INSTANCEOF CV0($obj) string("self")
-0005 ECHO T2
-0006 V3 = FETCH_CLASS (no-autoload) (silent) (exception) CV1($c)
-0007 T2 = INSTANCEOF CV0($obj) V3
-0008 ECHO T2
+0004 T3 = INSTANCEOF CV0($obj) string("self")
+0005 ECHO T3
+0006 V4 = FETCH_CLASS (no-autoload) (silent) (exception) CV1($c)
+0007 T5 = INSTANCEOF CV0($obj) V4
+0008 ECHO T5
 0009 RETURN null

--- a/ext/opcache/tests/opt/sccp_032.phpt
+++ b/ext/opcache/tests/opt/sccp_032.phpt
@@ -29,19 +29,19 @@ $_main:
      ; (after optimizer)
      ; %ssccp_032.php:1-15
 0000 INIT_FCALL 0 %d string("test")
-0001 V2 = DO_UCALL
-0002 V1 = FE_RESET_R V2 0009
-0003 FE_FETCH_R V1 CV0($x) 0009
+0001 V1 = DO_UCALL
+0002 V2 = FE_RESET_R V1 0009
+0003 FE_FETCH_R V2 CV0($x) 0009
 0004 INIT_FCALL 1 %d string("var_export")
 0005 SEND_VAR CV0($x) 1
 0006 DO_ICALL
 0007 ECHO string("
 ")
 0008 JMP 0003
-0009 FE_FREE V1
+0009 FE_FREE V2
 0010 RETURN int(1)
 LIVE RANGES:
-     1: 0003 - 0009 (loop)
+     2: 0003 - 0009 (loop)
 
 test:
      ; (lines=5, args=0, vars=0, tmps=1)


### PR DESCRIPTION
Instead of relying on the optimizer to retain FREE/FE_FREE opcodes, extend live-ranges to the end of the try block.

Just some experimentation to solve issues that arise with `match` blocks. This attempts to solve the issue described in https://github.com/php/php-src/pull/5448, which arises with the following scenario:

```php
foo() + throw new Exception();
```

```
$_main:
     ; (lines=8, args=0, vars=0, tmps=4)
     ; (before optimizer)
     ; /home/ilutov/Developer/php-src/test.php:1-3
     ; return  [] RANGE[0..0]
0000 INIT_FCALL_BY_NAME 0 string("foo")
0001 V0 = DO_FCALL_BY_NAME
0002 V1 = NEW 0 string("Exception")
0003 DO_FCALL
0004 THROW V1
0005 T3 = ADD V0 bool(true)
0006 FREE T3
0007 RETURN int(1)
LIVE RANGES:
     0: 0002 - 0005 (tmp/var)
     1: 0003 - 0004 (new)
```

Because `THROW` will jump out of the current context, it needs to free all the temporary `VAR`s (and `TMPVAR`s) that would normally be consumed by the skipped opcodes. We calculate live-ranges for this purpose. A live-range defines the "time" (sequence of opcodes) in which the `VAR` holds a valid value which has to be freed if exited prematurely. Live-ranges are calculated by scanning the opcodes backwards to find the first (i.e. lowest) usage, and the first (i.e. lowest) definition of the `VAR`. In this case, `V0` (the result of the `foo()` function call) lives from opcode `0002` to `0005` (exclusive). The `THROW` opcode at position `0004` will look at which values are live at its position, and won't be used after (i.e. don't outlive) the `try` block, if available. This will free `V0` in this case.

Normally, DCE would eliminate everything after `THROW` since it is unreachable, removing `ADD V0 bool(true)` which is the only use of `V0`. This would break calculation of the live-range of this `V0` with the current implementation. As such, the `VAR` would no longer be freed. This issue only arose with `throw` expressions because in statement context no `VAR`s are live (with some exceptions live `switch` conditions, loop iterators, etc). The current solution (https://github.com/php/php-src/pull/5450) is to treat `throw` expressions as non-terminators when building the CFG. This will persist the unreachable opcodes that follow.

With `match` blocks, we will once again experience this issue, even for `throw` statements.

```php
foo() + match (1) {
    1 {
        throw new Exception();
    }
}
```

With DCE, this is essentially equivalent to `foo() + throw new Exception()`. Our current solution does not work for this case however, because the `throw` statement is treated as a terminator. We might also disable splitting CFG nodes for all `throw` statements in `match` blocks, that might actually be the easiest solution.

I've tried a different approach in this PR. Instead of relying on the retention of the dead consuming opcodes, the live-range of unused `VAR`s may be extended until the end of the current `try` block, if available. The idea is that the consuming opcode will only be eliminated if the current context is guaranteed to exit. A exception will always at least skip over the opcodes in the current `try` block. We also rely on the fact that a `VAR` can't begin outside of a `try` block and end inside of it, and vice versa. The upside is that we may get rid of some other hack that retain dead opcodes exclusively for the sake of live-range calculation.

There are a few problems with this approach too.

1. It is incompatible with `zend_optimize_temporary_variables()`. `zend_optimize_temporary_variables()` will reuse the `VAR` of a definition with no use. This will eliminate the live-range for the first definition. This algorithm would need to be adjusted.
2. This approach is incompatible with two (or more) consuming uses of a `VAR` in different branches.
    ```
      V1 = ...
      JMPZ true false
    true:
      echo V1
    false:
      // throw
      echo V1
    ```
    The `THROW` must not eliminate the use of `V1` in the lower branch, because that will shorten its live-range to the first usage. I'm unaware of such a sequence of opcodes being emitted in PHP, but it's easy to imagine. To my understanding, all other cases can eliminate the used opcodes.
3. The `COALESCE` opcode only conditionally initializes the result, in case the null branch is skipped. If the null branch contains a `throw`, we will optimize away the second definition of the `VAR`, elongating the live-range. However, in the null branch the `VAR` isn't actually live, leading to a use-of-uninitialized-value. We could initialize result in `COALESCE` to `IS_UNDEF`, but that will lead to a slight performance regression. I'm not yet sure what the best way is to solve this.

A similar problem exists for `return`, `continue`, `break`, `goto`, etc. in `match` blocks. These will need to emit `FREE` opcodes for `VAR`s that are live. This is similar to https://github.com/php/php-src/pull/5448. That's a different issue to tackle.