### PR TITLE
Fix GH-11878: SQLite3 callback functions cause a memory leak with a callable array

### DIFF
--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2194,6 +2194,37 @@ static void php_sqlite3_object_free_storage(zend_object *object) /* {{{ */
 }
 /* }}} */
 
+static HashTable *php_sqlite3_get_gc(zend_object *object, zval **table, int *n)
+{
+	php_sqlite3_db_object *intern = php_sqlite3_db_from_obj(object);
+
+	if (intern->funcs == NULL && intern->collations == NULL) {
+		/* Fast path without allocations */
+		*table = NULL;
+		*n = 0;
+	} else {
+		zend_get_gc_buffer *gc_buffer = zend_get_gc_buffer_create();
+
+		php_sqlite3_func *func = intern->funcs;
+		while (func != NULL) {
+			zend_get_gc_buffer_add_zval(gc_buffer, &func->func);
+			zend_get_gc_buffer_add_zval(gc_buffer, &func->step);
+			zend_get_gc_buffer_add_zval(gc_buffer, &func->fini);
+			func = func->next;
+		}
+
+		php_sqlite3_collation *collation = intern->collations;
+		while (collation != NULL) {
+			zend_get_gc_buffer_add_zval(gc_buffer, &collation->cmp_func);
+			collation = collation->next;
+		}
+
+		zend_get_gc_buffer_use(gc_buffer, table, n);
+	}
+
+	return zend_std_get_properties(object);
+}
+
 static void php_sqlite3_stmt_object_free_storage(zend_object *object) /* {{{ */
 {
 	php_sqlite3_stmt *intern = php_sqlite3_stmt_from_obj(object);
@@ -2327,6 +2358,7 @@ PHP_MINIT_FUNCTION(sqlite3)
 	sqlite3_object_handlers.offset = XtOffsetOf(php_sqlite3_db_object, zo);
 	sqlite3_object_handlers.clone_obj = NULL;
 	sqlite3_object_handlers.free_obj = php_sqlite3_object_free_storage;
+	sqlite3_object_handlers.get_gc = php_sqlite3_get_gc;
 	php_sqlite3_sc_entry = register_class_SQLite3();
 	php_sqlite3_sc_entry->create_object = php_sqlite3_object_new;
 

--- a/ext/sqlite3/sqlite3.c
+++ b/ext/sqlite3/sqlite3.c
@@ -2202,6 +2202,7 @@ static HashTable *php_sqlite3_get_gc(zend_object *object, zval **table, int *n)
 		/* Fast path without allocations */
 		*table = NULL;
 		*n = 0;
+		return zend_std_get_gc(object, table, n);
 	} else {
 		zend_get_gc_buffer *gc_buffer = zend_get_gc_buffer_create();
 
@@ -2220,9 +2221,13 @@ static HashTable *php_sqlite3_get_gc(zend_object *object, zval **table, int *n)
 		}
 
 		zend_get_gc_buffer_use(gc_buffer, table, n);
-	}
 
-	return zend_std_get_properties(object);
+		if (object->properties == NULL && object->ce->default_properties_count == 0) {
+			return NULL;
+		} else {
+			return zend_std_get_properties(object);
+		}
+	}
 }
 
 static void php_sqlite3_stmt_object_free_storage(zend_object *object) /* {{{ */

--- a/ext/sqlite3/tests/gh11878.phpt
+++ b/ext/sqlite3/tests/gh11878.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-11878 (SQLite3 callback functions cause a memory leak with a callable array)
+--EXTENSIONS--
+sqlite3
+--FILE--
+<?php
+class Foo {
+    public $sqlite;
+    public function __construct() {
+        $this->sqlite = new SQLite3(":memory:");
+        $this->sqlite->createAggregate("indexes", array($this, "SQLiteIndex"), array($this, "SQLiteFinal"), 0);
+        $this->sqlite->createFunction("func", array($this, "SQLiteIndex"), 0);
+        $this->sqlite->createCollation("collation", array($this, "SQLiteIndex"));
+    }
+    public function SQLiteIndex() {}
+    public function SQLiteFinal() {}
+}
+
+$x = new Foo;
+?>
+Done
+--EXPECT--
+Done

--- a/ext/sqlite3/tests/gh11878.phpt
+++ b/ext/sqlite3/tests/gh11878.phpt
@@ -6,17 +6,25 @@ sqlite3
 <?php
 class Foo {
     public $sqlite;
-    public function __construct() {
+    public function __construct(bool $normalFunctions, bool $aggregates) {
         $this->sqlite = new SQLite3(":memory:");
-        $this->sqlite->createAggregate("indexes", array($this, "SQLiteIndex"), array($this, "SQLiteFinal"), 0);
-        $this->sqlite->createFunction("func", array($this, "SQLiteIndex"), 0);
-        $this->sqlite->createCollation("collation", array($this, "SQLiteIndex"));
+        if ($aggregates) {
+            $this->sqlite->createAggregate("indexes", array($this, "SQLiteIndex"), array($this, "SQLiteFinal"), 0);
+        }
+        if ($normalFunctions) {
+            $this->sqlite->createFunction("func", array($this, "SQLiteIndex"), 0);
+            $this->sqlite->createCollation("collation", array($this, "SQLiteIndex"));
+        }
     }
     public function SQLiteIndex() {}
     public function SQLiteFinal() {}
 }
 
-$x = new Foo;
+// Test different combinations to check for null pointer derefs
+$x = new Foo(true, true);
+$y = new Foo(false, true);
+$z = new Foo(true, false);
+$w = new Foo(false, false);
 ?>
 Done
 --EXPECT--


### PR DESCRIPTION
In this test file, the free_obj handler is called with a refcount of 2, caused by the fact we do a GC_ADDREF() to increase its refcount while its refcount is still 1 because the Foo object hasn't been destroyed yet (due to the cycle caused by the sqlite function callback). Solve this by introducing a get_gc handler.