### PR TITLE
fix: handle GNU specific versions of strerror_r() 

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1649,9 +1649,15 @@ ZEND_API ZEND_COLD ZEND_NORETURN void zend_error_noreturn(int type, const char *
 
 ZEND_API ZEND_COLD ZEND_NORETURN void zend_strerror_noreturn(int type, int errn, const char *message)
 {
-#ifdef HAVE_STR_ERROR_R
-	char buf[1024];
-	strerror_r(errn, buf, sizeof(buf));
+#ifdef HAVE_STRERROR_R
+	char b[1024];
+
+# ifdef STRERROR_R_CHAR_P
+	char *buf = strerror_r(errn, b, sizeof(b));
+# else
+	strerror_r(errn, b, sizeof(b));
+	char *buf = b;
+# endif
 #else
 	char *buf = strerror(errn);
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -621,8 +621,10 @@ vasprintf \
 asprintf \
 nanosleep \
 memmem \
-strerror_r \
 )
+
+dnl Check for strerror_r, and if its a POSIX-compatible or a GNU specific version.
+AC_FUNC_STRERROR_R
 
 AX_FUNC_WHICH_GETHOSTBYNAME_R
 


### PR DESCRIPTION
Finishes #11624. Uses [`AC_FUNC_STRERROR_R`](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/html_node/Particular-Functions.html#index-AC_005fFUNC_005fSTRERROR_005fR-1) to detect if we can use the POSIX version or not.