### PR TITLE
Fix parent check and viable next sibling search for replaceWith

### DIFF
--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -545,20 +545,38 @@ void dom_child_node_remove(dom_object *context)
 
 void dom_child_replace_with(dom_object *context, zval *nodes, int nodesc)
 {
+	/* Spec link: https://dom.spec.whatwg.org/#dom-childnode-replacewith*/
+
 	xmlNodePtr child = dom_object_get_node(context);
+
+	/* Spec step 1 */
 	xmlNodePtr parentNode = child->parent;
+	/* Spec step 2 */
+	if (!parentNode) {
+		return;
+	}
 
 	int stricterror = dom_get_strict_error(context->document);
 	if (UNEXPECTED(dom_child_removal_preconditions(child, stricterror) != SUCCESS)) {
 		return;
 	}
 
-	xmlNodePtr insertion_point = child->next;
+	/* Spec step 3: find first following child not in nodes; otherwise null */
+	xmlNodePtr viable_next_sibling = child->next;
+	while (viable_next_sibling) {
+		if (!dom_is_node_in_list(nodes, nodesc, viable_next_sibling)) {
+			break;
+		}
+		viable_next_sibling = viable_next_sibling->next;
+	}
 
+	/* Spec step 4: convert nodes into fragment */
 	xmlNodePtr fragment = dom_zvals_to_fragment(context->document, parentNode, nodes, nodesc);
 	if (UNEXPECTED(fragment == NULL)) {
 		return;
 	}
+
+	/* Spec step 5: perform the replacement */
 
 	xmlNodePtr newchild = fragment->children;
 	xmlDocPtr doc = parentNode->doc;
@@ -571,7 +589,7 @@ void dom_child_replace_with(dom_object *context, zval *nodes, int nodesc)
 	if (newchild) {
 		xmlNodePtr last = fragment->last;
 
-		dom_pre_insert(insertion_point, parentNode, newchild, fragment);
+		dom_pre_insert(viable_next_sibling, parentNode, newchild, fragment);
 
 		dom_fragment_assign_parent_node(parentNode, fragment);
 		dom_reconcile_ns_list(doc, newchild, last);

--- a/ext/dom/tests/replaceWith_no_parent.phpt
+++ b/ext/dom/tests/replaceWith_no_parent.phpt
@@ -1,0 +1,28 @@
+--TEST--
+replaceWith() without a parent
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML(<<<XML
+<?xml version="1.0"?>
+<container>
+    <child/>
+</container>
+XML);
+
+$container = $doc->documentElement;
+$child = $container->firstElementChild;
+
+$test = $doc->createElement('foo');
+$test->replaceWith($child);
+echo $doc->saveXML();
+echo $doc->saveXML($test);
+?>
+--EXPECTF--
+Fatal error: Uncaught DOMException: Not Found Error in %s:%d
+Stack trace:
+#0 %s(%d): DOMElement->replaceWith(Object(DOMElement))
+#1 {main}
+  thrown in %s on line %d

--- a/ext/dom/tests/replaceWith_no_parent.phpt
+++ b/ext/dom/tests/replaceWith_no_parent.phpt
@@ -20,9 +20,9 @@ $test->replaceWith($child);
 echo $doc->saveXML();
 echo $doc->saveXML($test);
 ?>
---EXPECTF--
-Fatal error: Uncaught DOMException: Not Found Error in %s:%d
-Stack trace:
-#0 %s(%d): DOMElement->replaceWith(Object(DOMElement))
-#1 {main}
-  thrown in %s on line %d
+--EXPECT--
+<?xml version="1.0"?>
+<container>
+    <child/>
+</container>
+<foo/>

--- a/ext/dom/tests/replaceWith_non_viable_next_sibling.phpt
+++ b/ext/dom/tests/replaceWith_non_viable_next_sibling.phpt
@@ -32,14 +32,5 @@ echo $doc->saveXML();
 </container>
 <?xml version="1.0"?>
 <container>
-    
+    <alone/>
 </container>
-
-=================================================================
-==1151863==ERROR: LeakSanitizer: detected memory leaks
-
-Direct leak of 120 byte(s) in 1 object(s) allocated from:
-    #0 0x7fc122ee1369 in __interceptor_malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
-    #1 0x7fc122d02bd0 in xmlNewNodeEatName /home/niels/libxml2/tree.c:2317
-
-SUMMARY: AddressSanitizer: 120 byte(s) leaked in 1 allocation(s).

--- a/ext/dom/tests/replaceWith_non_viable_next_sibling.phpt
+++ b/ext/dom/tests/replaceWith_non_viable_next_sibling.phpt
@@ -1,0 +1,45 @@
+--TEST--
+replaceWith() with a non-variable next sibling
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML(<<<XML
+<?xml version="1.0"?>
+<container>
+    <child>
+        <alone/>
+    </child>
+</container>
+XML);
+
+$container = $doc->documentElement;
+$child = $container->firstElementChild;
+$alone = $child->firstElementChild;
+
+$child->after($alone);
+echo $doc->saveXML();
+$child->replaceWith($alone);
+echo $doc->saveXML();
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<container>
+    <child>
+        
+    </child><alone/>
+</container>
+<?xml version="1.0"?>
+<container>
+    
+</container>
+
+=================================================================
+==1151863==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 120 byte(s) in 1 object(s) allocated from:
+    #0 0x7fc122ee1369 in __interceptor_malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
+    #1 0x7fc122d02bd0 in xmlNewNodeEatName /home/niels/libxml2/tree.c:2317
+
+SUMMARY: AddressSanitizer: 120 byte(s) leaked in 1 allocation(s).


### PR DESCRIPTION
I can land the parent check fix in master for the BC.