### PR TITLE
Make DOMChildNode::remove() run in O(1) performance

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -572,6 +572,7 @@ PHP 8.3 UPGRADE NOTES
     longer takes quadratic time by default.
   . Getting text content from nodes now avoids an allocation, resulting in a
     performance gain.
+  . DOMChildNode::remove() now runs in O(1) performance.
 
 - Standard:
   . The file() flags error check is now about 7% faster.

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -527,7 +527,6 @@ static zend_result dom_child_removal_preconditions(const xmlNodePtr child, int s
 void dom_child_node_remove(dom_object *context)
 {
 	xmlNode *child = dom_object_get_node(context);
-	xmlNodePtr children;
 	int stricterror;
 
 	stricterror = dom_get_strict_error(context->document);
@@ -536,19 +535,9 @@ void dom_child_node_remove(dom_object *context)
 		return;
 	}
 
-	children = child->parent->children;
-
 	php_libxml_invalidate_node_list_cache_from_doc(context->document->ptr);
 
-	while (children) {
-		if (children == child) {
-			xmlUnlinkNode(child);
-			return;
-		}
-		children = children->next;
-	}
-
-	php_dom_throw_error(NOT_FOUND_ERR, stricterror);
+	xmlUnlinkNode(child);
 }
 
 void dom_child_replace_with(dom_object *context, zval *nodes, uint32_t nodesc)


### PR DESCRIPTION
This method had some useless logic in it. It checked whether the child
node is a child of its parent, which is always true of course.
But I know where this check comes from, if you follow the spec closely
you'll find that the spec used to have explicit child and parent
arguments for the removal algorithm [1].
That's because that algorithm is written in a generic way, where the
parent and child arguments might not come from the same subtree.
However, in this particular case it *is* always the case that the child
is a child of its parent. The checks weren't needed back then for
DOMChildNode::remove(), and are still not needed today.

[1] e.g. https://web.archive.org/web/20180601092634/https://dom.spec.whatwg.org/#concept-node-remove
