### PR TITLE
sapi/fpm: adding listen.rtable option for OpenBSD.

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -129,6 +129,9 @@ static const struct ini_value_parser_s ini_fpm_pool_options[] = {
 #ifdef SO_SETFIB
 	{ "listen.setfib",             &fpm_conf_set_integer,     WPO(listen_setfib) },
 #endif
+#ifdef SO_RTABLE
+	{ "listen.rtable",             &fpm_conf_set_integer,     WPO(listen_rtable) },
+#endif
 	{ "process.priority",          &fpm_conf_set_integer,     WPO(process_priority) },
 	{ "process.dumpable",          &fpm_conf_set_boolean,     WPO(process_dumpable) },
 	{ "pm",                        &fpm_conf_set_pm,          WPO(pm) },
@@ -626,6 +629,9 @@ static void *fpm_worker_pool_config_alloc(void)
 	wp->config->decorate_workers_output = 1;
 #ifdef SO_SETFIB
 	wp->config->listen_setfib = -1;
+#endif
+#ifdef SO_RTABLE
+	wp->config->listen_rtable = -1;
 #endif
 
 	if (!fpm_worker_all_pools) {
@@ -1764,6 +1770,9 @@ static void fpm_conf_dump(void)
 		zlog(ZLOG_NOTICE, "\tlisten.allowed_clients = %s",     STR2STR(wp->config->listen_allowed_clients));
 #ifdef SO_SETFIB
 		zlog(ZLOG_NOTICE, "\tlisten.setfib = %d",              wp->config->listen_setfib);
+#endif
+#ifdef SO_RTABLE
+		zlog(ZLOG_NOTICE, "\tlisten.rtable = %d",              wp->config->listen_rtable);
 #endif
 		if (wp->config->process_priority == 64) {
 			zlog(ZLOG_NOTICE, "\tprocess.priority = undefined");

--- a/sapi/fpm/fpm/fpm_conf.h
+++ b/sapi/fpm/fpm/fpm_conf.h
@@ -107,6 +107,9 @@ struct fpm_worker_pool_config_s {
 #ifdef SO_SETFIB
 	int listen_setfib;
 #endif
+#ifdef SO_RTABLE
+	int listen_rtable;
+#endif
 };
 
 struct ini_value_parser_s {

--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -267,6 +267,13 @@ static int fpm_sockets_new_listening_socket(struct fpm_worker_pool_s *wp, struct
 		}
 	}
 #endif
+#ifdef SO_RTABLE
+	if (-1 < wp->config->listen_rtable) {
+		if (0 > setsockopt(sock, SOL_SOCKET, SO_RTABLE, &wp->config->listen_rtable, sizeof(wp->config->listen_rtable))) {
+			zlog(ZLOG_WARNING, "failed to change socket SO_RTABLE attribute");
+		}
+	}
+#endif
 
 	return sock;
 }

--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -72,6 +72,10 @@ listen = 127.0.0.1:9000
 ; Default Value: -1
 ;listen.setfib = 1
 
+; Set the associated the route table. OpenBSD only
+; Default Value: -1
+;listen.rtable = 1
+
 ; Specify the nice(2) priority to apply to the pool processes (only if set)
 ; The value can vary from -19 (highest priority) to 20 (lower priority)
 ; Note: - It will only work if the FPM master process is launched as root


### PR DESCRIPTION
Similarly to FreeBSD's `listen.setfib`, `listen.rtable` allows to set on a socket basis the routing table.