### PR TITLE
Fix #80927: Removing documentElement after creating attribute node: p…

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -150,6 +150,8 @@ PHP 8.3 INTERNALS UPGRADE NOTES
      dom_parent_node_before() now use an uint32_t argument for the number of nodes instead of int.
    - There is now a helper function php_dom_get_content_into_zval() to get the contents of a node.
      This avoids allocation if possible.
+   - The function dom_set_old_ns() has been moved into ext/libxml as php_libxml_set_old_ns() and
+     is now publicly exposed as an API.
 
  g. ext/libxml
    - Two new functions: php_libxml_invalidate_node_list_cache_from_doc() and

--- a/ext/dom/element.c
+++ b/ext/dom/element.c
@@ -1497,7 +1497,7 @@ PHP_METHOD(DOMElement, toggleAttribute)
 			}
 
 			ns->next = NULL;
-			dom_set_old_ns(thisp->doc, ns);
+			php_libxml_set_old_ns(thisp->doc, ns);
 			dom_reconcile_ns(thisp->doc, thisp);
 		} else {
 			/* TODO: in the future when namespace bugs are fixed,

--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1436,35 +1436,6 @@ void dom_normalize (xmlNodePtr nodep)
 }
 /* }}} end dom_normalize */
 
-
-/* {{{ void dom_set_old_ns(xmlDoc *doc, xmlNs *ns) */
-void dom_set_old_ns(xmlDoc *doc, xmlNs *ns) {
-	if (doc == NULL)
-		return;
-
-	ZEND_ASSERT(ns->next == NULL);
-
-	/* Note: we'll use a prepend strategy instead of append to
-	 * make sure we don't lose performance when the list is long.
-	 * As libxml2 could assume the xml node is the first one, we'll place our
-	 * new entries after the first one. */
-
-	if (doc->oldNs == NULL) {
-		doc->oldNs = (xmlNsPtr) xmlMalloc(sizeof(xmlNs));
-		if (doc->oldNs == NULL) {
-			return;
-		}
-		memset(doc->oldNs, 0, sizeof(xmlNs));
-		doc->oldNs->type = XML_LOCAL_NAMESPACE;
-		doc->oldNs->href = xmlStrdup(XML_XML_NAMESPACE);
-		doc->oldNs->prefix = xmlStrdup((const xmlChar *)"xml");
-	} else {
-		ns->next = doc->oldNs->next;
-	}
-	doc->oldNs->next = ns;
-}
-/* }}} end dom_set_old_ns */
-
 static void dom_reconcile_ns_internal(xmlDocPtr doc, xmlNodePtr nodep, xmlNodePtr search_parent)
 {
 	xmlNsPtr nsptr, nsdftptr, curns, prevns = NULL;
@@ -1486,7 +1457,7 @@ static void dom_reconcile_ns_internal(xmlDocPtr doc, xmlNodePtr nodep, xmlNodePt
 					/* Note: we can't get here if the ns is already on the oldNs list.
 					 * This is because in that case the definition won't be on the node, and
 					 * therefore won't be in the nodep->nsDef list. */
-					dom_set_old_ns(doc, curns);
+					php_libxml_set_old_ns(doc, curns);
 					curns = prevns;
 				}
 			}

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -128,7 +128,6 @@ void php_dom_throw_error_with_message(int error_code, char *error_message, int s
 void node_list_unlink(xmlNodePtr node);
 int dom_check_qname(char *qname, char **localname, char **prefix, int uri_len, int name_len);
 xmlNsPtr dom_get_ns(xmlNodePtr node, char *uri, int *errorcode, char *prefix);
-void dom_set_old_ns(xmlDoc *doc, xmlNs *ns);
 void dom_reconcile_ns(xmlDocPtr doc, xmlNodePtr nodep);
 void dom_reconcile_ns_list(xmlDocPtr doc, xmlNodePtr nodep, xmlNodePtr last);
 xmlNsPtr dom_get_nsdecl(xmlNode *node, xmlChar *localName);

--- a/ext/dom/tests/bug80927.phpt
+++ b/ext/dom/tests/bug80927.phpt
@@ -17,7 +17,12 @@ function test1() {
     var_dump($a->prefix);
 }
 
-function test2($variation) {
+enum Test2Variation {
+    case REMOVE_DOCUMENT;
+    case REMOVE_CHILD;
+}
+
+function test2(Test2Variation $variation) {
     $dom = new DOMDocument();
     $dom->appendChild($dom->createElement("html"));
     $a = $dom->createAttributeNS("fake_ns", "test:test");
@@ -27,13 +32,10 @@ function test2($variation) {
 
     unset($foo);
 
-    if ($variation === 1) {
-        $dom->documentElement->remove();
-    } else if ($variation === 2) {
-        $dom->documentElement->firstElementChild->remove();
-    } else {
-        assert(false);
-    }
+    match ($variation) {
+        Test2Variation::REMOVE_DOCUMENT => $dom->documentElement->remove(),
+        Test2Variation::REMOVE_CHILD => $dom->documentElement->firstElementChild->remove(),
+    };
 
     echo $dom->saveXML();
 
@@ -59,9 +61,9 @@ function test3() {
 echo "--- Remove namespace declarator for attribute, root ---\n";
 test1();
 echo "--- Remove namespace declarator for attribute, moved root ---\n";
-test2(1);
+test2(Test2Variation::REMOVE_DOCUMENT);
 echo "--- Remove namespace declarator for attribute, moved root child ---\n";
-test2(2);
+test2(Test2Variation::REMOVE_CHILD);
 echo "--- Remove namespace declarator for element ---\n";
 test3();
 

--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -279,7 +279,8 @@ static void php_libxml_node_free(xmlNodePtr node)
 					php_libxml_set_old_ns_list(node->doc, ns, last);
 					node->nsDef = NULL;
 				}
-				ZEND_FALLTHROUGH;
+				xmlFreeNode(node);
+				break;
 			default:
 				xmlFreeNode(node);
 				break;

--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -134,6 +134,7 @@ PHP_LIBXML_API int php_libxml_xmlCheckUTF8(const unsigned char *s);
 PHP_LIBXML_API void php_libxml_switch_context(zval *context, zval *oldcontext);
 PHP_LIBXML_API void php_libxml_issue_error(int level, const char *msg);
 PHP_LIBXML_API bool php_libxml_disable_entity_loader(bool disable);
+PHP_LIBXML_API void php_libxml_set_old_ns(xmlDocPtr doc, xmlNsPtr ns);
 
 /* Init/shutdown functions*/
 PHP_LIBXML_API void php_libxml_initialize(void);


### PR DESCRIPTION
…ossible use-after-free

Not 100% convinced that this solution is optimal. Also targeting master only because this is a non-trivial change in how the destruction works.
Marking as draft for now until I convince myself more that there's no better alternative.