### PR TITLE
Remove useless hashmap check

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -107,9 +107,7 @@ static void php_libxml_unlink_entity(void *data, void *table, const xmlChar *nam
 {
 	xmlEntityPtr entity = data;
 	if (entity->_private != NULL) {
-		if (xmlHashLookup(table, name) == entity) {
-			xmlHashRemoveEntry(table, name, NULL);
-		}
+		xmlHashRemoveEntry(table, name, NULL);
 	}
 }
 


### PR DESCRIPTION
php_libxml_unlink_entity is called from a hashmap iterator, so using xmlHashLookup to check if it comes from that hashmap will always be true.