### PR TITLE
fpm: attempt to fix child process crash on macOs w/o

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -375,6 +375,9 @@ case $host_alias in
       AC_MSG_ERROR([Problem with enabling atomic. Please check config.log for details.])
     ])
     ;;
+  *darwin*)
+    PHP_ADD_FRAMEWORK(Foundation)
+    ;;
 esac
 
 dnl Check for inet_aton in -lc, -lbind and -lresolv.


### PR DESCRIPTION
the `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` env var workaround.