### PR TITLE
Improve `ext/pdo_sqlite` tests cleanup

### DIFF
--- a/ext/pdo_sqlite/tests/bug33841.phpt
+++ b/ext/pdo_sqlite/tests/bug33841.phpt
@@ -7,17 +7,23 @@ pdo_sqlite
 require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
 $db = PDOTest::test_factory(__DIR__ . '/common.phpt');
 
-$db->exec('CREATE TABLE test (text)');
+$db->exec('CREATE TABLE test_33841 (text)');
 
-$stmt = $db->prepare("INSERT INTO test VALUES ( :text )");
+$stmt = $db->prepare("INSERT INTO test_33841 VALUES ( :text )");
 $stmt->bindParam(':text', $name);
 $name = 'test1';
 var_dump($stmt->execute(), $stmt->rowCount());
 
-$stmt = $db->prepare("UPDATE test SET text = :text ");
+$stmt = $db->prepare("UPDATE test_33841 SET text = :text ");
 $stmt->bindParam(':text', $name);
 $name = 'test2';
 var_dump($stmt->execute(), $stmt->rowCount());
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/../../../ext/pdo/tests/pdo_test.inc';
+$db = PDOTest::test_factory(__DIR__ . '/common.phpt');
+$db->exec('DROP TABLE IF EXISTS test_33841');
 ?>
 --EXPECT--
 bool(true)

--- a/ext/pdo_sqlite/tests/bug35336.phpt
+++ b/ext/pdo_sqlite/tests/bug35336.phpt
@@ -11,10 +11,10 @@ class EEE {
 }
 
 $a = new PDO("sqlite::memory:");// pool ("sqlite::memory:");
-$a->query ("CREATE TABLE test (a integer primary key, b text)");
-$b = $a->prepare("insert into test (b) values (?)");
+$a->query ("CREATE TABLE test_35336 (a integer primary key, b text)");
+$b = $a->prepare("insert into test_35336 (b) values (?)");
 $b->execute(array (5));
-$rez = $a->query ("SELECT * FROM test")->fetchAll(PDO::FETCH_CLASS, 'EEE');
+$rez = $a->query ("SELECT * FROM test_35336")->fetchAll(PDO::FETCH_CLASS, 'EEE');
 
 echo "Done\n";
 ?>

--- a/ext/pdo_sqlite/tests/bug38334.phpt
+++ b/ext/pdo_sqlite/tests/bug38334.phpt
@@ -6,13 +6,13 @@ pdo_sqlite
 <?php
 
 $db = new PDO('sqlite::memory:');
-$db->exec('CREATE TABLE test (i INTEGER , f DOUBLE, s VARCHAR(255))');
-$db->exec('INSERT INTO test VALUES (42, 46.7, "test")');
-var_dump($db->query('SELECT * FROM test')->fetch(PDO::FETCH_ASSOC));
+$db->exec('CREATE TABLE test_38334 (i INTEGER , f DOUBLE, s VARCHAR(255))');
+$db->exec('INSERT INTO test_38334 VALUES (42, 46.7, "test")');
+var_dump($db->query('SELECT * FROM test_38334')->fetch(PDO::FETCH_ASSOC));
 
 // Check handling of integers larger than 32-bit.
-$db->exec('INSERT INTO test VALUES (10000000000, 0.0, "")');
-$i = $db->query('SELECT i FROM test WHERE f = 0.0')->fetchColumn(0);
+$db->exec('INSERT INTO test_38334 VALUES (10000000000, 0.0, "")');
+$i = $db->query('SELECT i FROM test_38334 WHERE f = 0.0')->fetchColumn(0);
 if (PHP_INT_SIZE >= 8) {
     var_dump($i === 10000000000);
 } else {
@@ -20,8 +20,8 @@ if (PHP_INT_SIZE >= 8) {
 }
 
 // Check storing of strings into integer/float columns.
-$db->exec('INSERT INTO test VALUES ("test", "test", "x")');
-var_dump($db->query('SELECT * FROM test WHERE s = "x"')->fetch(PDO::FETCH_ASSOC));
+$db->exec('INSERT INTO test_38334 VALUES ("test", "test", "x")');
+var_dump($db->query('SELECT * FROM test_38334 WHERE s = "x"')->fetch(PDO::FETCH_ASSOC));
 
 ?>
 --EXPECT--

--- a/ext/pdo_sqlite/tests/bug70862.phpt
+++ b/ext/pdo_sqlite/tests/bug70862.phpt
@@ -8,7 +8,7 @@ pdo_sqlite
 $db = new PDO('sqlite::memory:');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-$db->exec('CREATE TABLE test(field BLOB)');
+$db->exec('CREATE TABLE test_70862(field BLOB)');
 
 $db->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 $db->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
@@ -24,7 +24,7 @@ stream_wrapper_register("hello", "HelloWrapper");
 
 $f = fopen("hello://there", "r");
 
-$stmt = $db->prepare('INSERT INTO test(field) VALUES (:para)');
+$stmt = $db->prepare('INSERT INTO test_70862(field) VALUES (:para)');
 $stmt->bindParam(":para", $f, PDO::PARAM_LOB);
 $stmt->execute();
 

--- a/ext/pdo_sqlite/tests/bug_42589.phpt
+++ b/ext/pdo_sqlite/tests/bug_42589.phpt
@@ -14,15 +14,15 @@ if(!in_array('ENABLE_COLUMN_METADATA', $options, true))
 <?php
 $db = new PDO("sqlite::memory:");
 
-$db->exec('CREATE TABLE test (field1 VARCHAR(10))');
-$db->exec('INSERT INTO test VALUES("test")');
+$db->exec('CREATE TABLE test_42589 (field1 VARCHAR(10))');
+$db->exec('INSERT INTO test_42589 VALUES("test")');
 
-$result = $db->query('SELECT * FROM test t1 LEFT JOIN test t2 ON t1.field1 = t2.field1');
+$result = $db->query('SELECT * FROM test_42589 t1 LEFT JOIN test_42589 t2 ON t1.field1 = t2.field1');
 $meta1 = $result->getColumnMeta(0);
 $meta2 = $result->getColumnMeta(1);
 
-var_dump(!empty($meta1['table']) && $meta1['table'] == 'test');
-var_dump(!empty($meta2['table']) && $meta2['table'] == 'test');
+var_dump(!empty($meta1['table']) && $meta1['table'] == 'test_42589');
+var_dump(!empty($meta2['table']) && $meta2['table'] == 'test_42589');
 ?>
 --EXPECT--
 bool(true)

--- a/ext/pdo_sqlite/tests/pdo_035.phpt
+++ b/ext/pdo_sqlite/tests/pdo_035.phpt
@@ -5,10 +5,10 @@ pdo_sqlite
 --FILE--
 <?php
 $db = new PDO('sqlite::memory:');
-$db->exec('CREATE TABLE test (id int)');
-$db->exec('INSERT INTO test VALUES (23)');
+$db->exec('CREATE TABLE test_pdo_035 (id int)');
+$db->exec('INSERT INTO test_pdo_035 VALUES (23)');
 
-$stmt = $db->prepare('SELECT id FROM test');
+$stmt = $db->prepare('SELECT id FROM test_pdo_035');
 $stmt->execute();
 $result = $stmt->fetch(PDO::FETCH_LAZY);
 

--- a/ext/pdo_sqlite/tests/pdo_fetch_func_001.phpt
+++ b/ext/pdo_sqlite/tests/pdo_fetch_func_001.phpt
@@ -8,46 +8,46 @@ pdo_sqlite
 $db = new PDO('sqlite::memory:');
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
 
-$db->exec('CREATE TABLE testing (id INTEGER , name VARCHAR)');
-$db->exec('INSERT INTO testing VALUES(1, "php")');
-$db->exec('INSERT INTO testing VALUES(2, "")');
+$db->exec('CREATE TABLE test_fetch_func_001 (id INTEGER , name VARCHAR)');
+$db->exec('INSERT INTO test_fetch_func_001 VALUES(1, "php")');
+$db->exec('INSERT INTO test_fetch_func_001 VALUES(2, "")');
 
-$st = $db->query('SELECT * FROM testing');
+$st = $db->query('SELECT * FROM test_fetch_func_001');
 $st->fetchAll(PDO::FETCH_FUNC, function($x, $y) use ($st) { var_dump($st); print "data: $x, $y\n"; });
 
-$st = $db->query('SELECT name FROM testing');
+$st = $db->query('SELECT name FROM test_fetch_func_001');
 var_dump($st->fetchAll(PDO::FETCH_FUNC, 'strtoupper'));
 
 try {
-    $st = $db->query('SELECT * FROM testing');
+    $st = $db->query('SELECT * FROM test_fetch_func_001');
     var_dump($st->fetchAll(PDO::FETCH_FUNC, 'nothing'));
 } catch (\TypeError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    $st = $db->query('SELECT * FROM testing');
+    $st = $db->query('SELECT * FROM test_fetch_func_001');
     var_dump($st->fetchAll(PDO::FETCH_FUNC, ''));
 } catch (\TypeError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    $st = $db->query('SELECT * FROM testing');
+    $st = $db->query('SELECT * FROM test_fetch_func_001');
     var_dump($st->fetchAll(PDO::FETCH_FUNC, NULL));
 } catch (\TypeError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    $st = $db->query('SELECT * FROM testing');
+    $st = $db->query('SELECT * FROM test_fetch_func_001');
     var_dump($st->fetchAll(PDO::FETCH_FUNC, 1));
 } catch (\TypeError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    $st = $db->query('SELECT * FROM testing');
+    $st = $db->query('SELECT * FROM test_fetch_func_001');
     var_dump($st->fetchAll(PDO::FETCH_FUNC, array('self', 'foo')));
 } catch (\TypeError $e) {
     echo $e->getMessage(), \PHP_EOL;
@@ -60,7 +60,7 @@ class foo {
 }
 class bar extends foo {
     public function __construct($db) {
-        $st = $db->query('SELECT * FROM testing');
+        $st = $db->query('SELECT * FROM test_fetch_func_001');
         var_dump($st->fetchAll(PDO::FETCH_FUNC, array($this, 'parent::method')));
     }
 
@@ -79,25 +79,25 @@ class bar extends foo {
 
 new bar($db);
 
-$st = $db->query('SELECT * FROM testing');
+$st = $db->query('SELECT * FROM test_fetch_func_001');
 var_dump($st->fetchAll(PDO::FETCH_FUNC, array('bar', 'test')));
 
 try {
-    $st = $db->query('SELECT * FROM testing');
+    $st = $db->query('SELECT * FROM test_fetch_func_001');
     var_dump($st->fetchAll(PDO::FETCH_FUNC, array('bar', 'test2')));
 } catch (\TypeError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    $st = $db->query('SELECT * FROM testing');
+    $st = $db->query('SELECT * FROM test_fetch_func_001');
     var_dump($st->fetchAll(PDO::FETCH_FUNC, array('bar', 'test3')));
 } catch (\TypeError $e) {
     echo $e->getMessage(), \PHP_EOL;
 }
 
 try {
-    $st = $db->query('SELECT * FROM testing');
+    $st = $db->query('SELECT * FROM test_fetch_func_001');
     var_dump($st->fetchAll(PDO::FETCH_FUNC, array('bar', 'inexistent')));
 } catch (\TypeError $e) {
     echo $e->getMessage(), \PHP_EOL;
@@ -107,12 +107,12 @@ try {
 --EXPECTF--
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(21) "SELECT * FROM testing"
+  string(33) "SELECT * FROM test_fetch_func_001"
 }
 data: 1, php
 object(PDOStatement)#%d (1) {
   ["queryString"]=>
-  string(21) "SELECT * FROM testing"
+  string(33) "SELECT * FROM test_fetch_func_001"
 }
 data: 2, 
 array(2) {

--- a/ext/pdo_sqlite/tests/pdo_sqlite_empty_filename.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_empty_filename.phpt
@@ -8,12 +8,12 @@ pdo_sqlite
 // create with empty filename
 $db = new PDO('sqlite:');
 
-var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+var_dump($db->exec('CREATE TABLE test_sqlite_empty_filename (id INT);'));
 
 // create with empty URI
 $db = new PDO('sqlite:file:?cache=shared');
 
-var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+var_dump($db->exec('CREATE TABLE test_sqlite_empty_filename (id INT);'));
 ?>
 --EXPECT--
 int(0)

--- a/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_filename_uri.phpt
@@ -8,26 +8,26 @@ pdo_sqlite
 // create with in-memory database using shared cached
 $db = new PDO('sqlite:file::memory:?cache=shared');
 
-var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+var_dump($db->exec('CREATE TABLE test_sqlite_filename_uri (id INT);'));
 
 // create second connection to in-memory database
 $db = new PDO('sqlite:file::memory:?cache=shared');
 
-var_dump($db->exec('SELECT * from test1'));
+var_dump($db->exec('SELECT * from test_sqlite_filename_uri'));
 
 // create with default read-write|create mode
 $filename = "file:" . __DIR__ . DIRECTORY_SEPARATOR . "pdo_sqlite_filename_uri.db";
 
 $db = new PDO('sqlite:' . $filename);
 
-var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+var_dump($db->exec('CREATE TABLE test_sqlite_filename_uri (id INT);'));
 
 // create with readonly mode
 $filename = "file:" . __DIR__ . DIRECTORY_SEPARATOR . "pdo_sqlite_filename_uri.db?mode=ro";
 
 $db = new PDO('sqlite:' . $filename);
 
-var_dump($db->exec('CREATE TABLE test2 (id INT);'));
+var_dump($db->exec('CREATE TABLE test_sqlite_filename_uri_2 (id INT);'));
 
 ?>
 --CLEAN--

--- a/ext/pdo_sqlite/tests/pdo_sqlite_open_basedir.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_open_basedir.phpt
@@ -12,7 +12,7 @@ $filename = 'pdo_sqlite_filename.db';
 
 $db = new PDO('sqlite:' . $filename);
 
-var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+var_dump($db->exec('CREATE TABLE test_sqlite_open_basedir (id INT);'));
 
 // create outside basedir
 $filename = '..' . DIRECTORY_SEPARATOR . 'pdo_sqlite_filename.db';

--- a/ext/pdo_sqlite/tests/pdo_sqlite_open_flags.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_open_flags.phpt
@@ -10,11 +10,11 @@ $filename = __DIR__ . DIRECTORY_SEPARATOR . "pdo_sqlite_open_flags.db";
 // Default open flag is read-write|create
 $db = new PDO('sqlite:' . $filename, null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
-var_dump($db->exec('CREATE TABLE test1 (id INT);'));
+var_dump($db->exec('CREATE TABLE test_sqlite_open_flags (id INT);'));
 
 $db = new PDO('sqlite:' . $filename, null, null, [PDO::SQLITE_ATTR_OPEN_FLAGS => PDO::SQLITE_OPEN_READONLY, PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 
-var_dump($db->exec('CREATE TABLE test2 (id INT);'));
+var_dump($db->exec('CREATE TABLE test_sqlite_open_flags_2 (id INT);'));
 ?>
 --CLEAN--
 <?php

--- a/ext/pdo_sqlite/tests/pdo_sqlite_statement_getattribute.phpt
+++ b/ext/pdo_sqlite/tests/pdo_sqlite_statement_getattribute.phpt
@@ -11,7 +11,7 @@ $st = $db->prepare('SELECT 1;');
 
 var_dump($st->getAttribute(PDO::SQLITE_ATTR_READONLY_STATEMENT));
 
-$st = $db->prepare('CREATE TABLE test (a TEXT);');
+$st = $db->prepare('CREATE TABLE test_sqlite_stmt_getattribute (a TEXT);');
 
 var_dump($st->getAttribute(PDO::SQLITE_ATTR_READONLY_STATEMENT));
 ?>


### PR DESCRIPTION
In order to continue what's been started here:

- https://github.com/php/php-src/pull/11872
- https://github.com/php/php-src/pull/11879

I made the same thing for `ext/pdo_sqlite`. This time, the database is in memory, which is why I omitted the `--CLEAN--` section thus time. However, I think it is a good thing to rename tables in tests to keep consistency with the two PRs mentioned above.