### PR TITLE
Align DOMChildNode parent checks with spec

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -46,6 +46,11 @@ PHP 8.3 UPGRADE NOTES
     iterating over the WeakMap (reachability via iteration is considered weak).
     Previously, such entries would never be automatically removed.
 
+- DOM:
+  . DOMChildNode::after(), DOMChildNode::before(), DOMChildNode::replaceWith()
+    on a node that has no parent is now a no-op instead of a hierarchy exception,
+    which is the behaviour spec demands.
+
 - FFI:
   . C functions that have a return type of void now return null instead of
     returning the following object object(FFI\CData:void) { }

--- a/UPGRADING
+++ b/UPGRADING
@@ -50,6 +50,9 @@ PHP 8.3 UPGRADE NOTES
   . DOMChildNode::after(), DOMChildNode::before(), DOMChildNode::replaceWith()
     on a node that has no parent is now a no-op instead of a hierarchy exception,
     which is the behaviour spec demands.
+  . Using the DOMParentNode and DOMChildNode methods without a document now works
+    instead of throwing a HIERARCHY_REQUEST_ERR DOMException. This is in line with
+    the behaviour spec demands.
 
 - FFI:
   . C functions that have a return type of void now return null instead of

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -530,7 +530,7 @@ void dom_child_node_remove(dom_object *context)
 		return;
 	}
 
-	php_libxml_invalidate_node_list_cache_from_doc(context->document->ptr);
+	php_libxml_invalidate_node_list_cache_from_doc(child->doc);
 
 	xmlUnlinkNode(child);
 }
@@ -563,7 +563,8 @@ void dom_child_replace_with(dom_object *context, zval *nodes, uint32_t nodesc)
 		viable_next_sibling = viable_next_sibling->next;
 	}
 
-	php_libxml_invalidate_node_list_cache_from_doc(context->document->ptr);
+	xmlDocPtr doc = parentNode->doc;
+	php_libxml_invalidate_node_list_cache_from_doc(doc);
 
 	/* Spec step 4: convert nodes into fragment */
 	xmlNodePtr fragment = dom_zvals_to_fragment(context->document, parentNode, nodes, nodesc);
@@ -574,7 +575,6 @@ void dom_child_replace_with(dom_object *context, zval *nodes, uint32_t nodesc)
 	/* Spec step 5: perform the replacement */
 
 	xmlNodePtr newchild = fragment->children;
-	xmlDocPtr doc = parentNode->doc;
 
 	/* Unlink it unless it became a part of the fragment.
 	 * Freeing will be taken care of by the lifetime of the returned dom object. */
@@ -609,7 +609,7 @@ void dom_parent_node_replace_children(dom_object *context, zval *nodes, uint32_t
 		return;
 	}
 
-	php_libxml_invalidate_node_list_cache_from_doc(context->document->ptr);
+	php_libxml_invalidate_node_list_cache_from_doc(thisp->doc);
 
 	dom_remove_all_children(thisp);
 

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -240,11 +240,6 @@ static void dom_fragment_assign_parent_node(xmlNodePtr parentNode, xmlNodePtr fr
 
 static zend_result dom_sanity_check_node_list_for_insertion(php_libxml_ref_obj *document, xmlNodePtr parentNode, zval *nodes, int nodesc)
 {
-	if (UNEXPECTED(document == NULL)) {
-		php_dom_throw_error(HIERARCHY_REQUEST_ERR, 1 /* no document, so be strict */);
-		return FAILURE;
-	}
-
 	if (UNEXPECTED(parentNode == NULL)) {
 		/* No error required, this must be a no-op per spec */
 		return FAILURE;

--- a/ext/dom/parentnode.c
+++ b/ext/dom/parentnode.c
@@ -396,8 +396,6 @@ void dom_parent_node_after(dom_object *context, zval *nodes, uint32_t nodesc)
 	parentNode = prevsib->parent;
 	/* Spec step 2 */
 	if (!parentNode) {
-		int stricterror = dom_get_strict_error(context->document);
-		php_dom_throw_error(HIERARCHY_REQUEST_ERR, stricterror);
 		return;
 	}
 
@@ -453,8 +451,6 @@ void dom_parent_node_before(dom_object *context, zval *nodes, uint32_t nodesc)
 	parentNode = nextsib->parent;
 	/* Spec step 2 */
 	if (!parentNode) {
-		int stricterror = dom_get_strict_error(context->document);
-		php_dom_throw_error(HIERARCHY_REQUEST_ERR, stricterror);
 		return;
 	}
 
@@ -555,8 +551,6 @@ void dom_child_replace_with(dom_object *context, zval *nodes, uint32_t nodesc)
 	xmlNodePtr parentNode = child->parent;
 	/* Spec step 2 */
 	if (!parentNode) {
-		int stricterror = dom_get_strict_error(context->document);
-		php_dom_throw_error(HIERARCHY_REQUEST_ERR, stricterror);
 		return;
 	}
 

--- a/ext/dom/tests/DOMChildNode_methods_without_parent.phpt
+++ b/ext/dom/tests/DOMChildNode_methods_without_parent.phpt
@@ -1,0 +1,44 @@
+--TEST--
+DOMChildNode methods without a parent
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$doc = new DOMDocument;
+$doc->loadXML(<<<XML
+<?xml version="1.0"?>
+<container>
+    <child/>
+</container>
+XML);
+
+$container = $doc->documentElement;
+$child = $container->firstElementChild;
+
+$test = $doc->createElement('foo');
+foreach (['before', 'after', 'replaceWith'] as $method) {
+    echo "--- $method ---\n";
+    $test->$method($child);
+    echo $doc->saveXML();
+    echo $doc->saveXML($test), "\n";
+}
+?>
+--EXPECT--
+--- before ---
+<?xml version="1.0"?>
+<container>
+    <child/>
+</container>
+<foo/>
+--- after ---
+<?xml version="1.0"?>
+<container>
+    <child/>
+</container>
+<foo/>
+--- replaceWith ---
+<?xml version="1.0"?>
+<container>
+    <child/>
+</container>
+<foo/>

--- a/ext/dom/tests/bug79968.phpt
+++ b/ext/dom/tests/bug79968.phpt
@@ -7,26 +7,14 @@ dom
 
 $cdata = new DOMText;
 
-try {
-    $cdata->before("string");
-} catch (DOMException $e) {
-    echo $e->getMessage(), "\n";
-}
+$cdata->before("string");
+$cdata->after("string");
+$cdata->replaceWith("string");
 
-try {
-    $cdata->after("string");
-} catch (DOMException $e) {
-    echo $e->getMessage(), "\n";
-}
-
-try {
-    $cdata->replaceWith("string");
-} catch (DOMException $e) {
-    echo $e->getMessage(), "\n";
-}
+$dom = new DOMDocument();
+$dom->adoptNode($cdata);
+var_dump($dom->saveXML($cdata));
 
 ?>
 --EXPECT--
-Hierarchy Request Error
-Hierarchy Request Error
-Hierarchy Request Error
+string(0) ""

--- a/ext/dom/tests/bug79968.phpt
+++ b/ext/dom/tests/bug79968.phpt
@@ -10,8 +10,23 @@ $cdata = new DOMText;
 try {
     $cdata->before("string");
 } catch (DOMException $e) {
-    echo $e->getMessage();
+    echo $e->getMessage(), "\n";
 }
+
+try {
+    $cdata->after("string");
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $cdata->replaceWith("string");
+} catch (DOMException $e) {
+    echo $e->getMessage(), "\n";
+}
+
 ?>
 --EXPECT--
+Hierarchy Request Error
+Hierarchy Request Error
 Hierarchy Request Error

--- a/ext/dom/tests/element_child_and_parent_node_without_document.phpt
+++ b/ext/dom/tests/element_child_and_parent_node_without_document.phpt
@@ -1,0 +1,21 @@
+--TEST--
+DOMElement: DOMChildNode, DOMParentNode modifications without a document
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$element = new DOMElement("p", " Hello World! ");
+$element->append("APPENDED");
+$element->prepend("PREPENDED");
+$element->after("AFTER");
+$element->before("BEFORE");
+$element->replaceWith("REPLACE");
+
+$doc = new DOMDocument();
+$doc->adoptNode($element);
+echo $doc->saveXML($element), "\n";
+
+?>
+--EXPECT--
+<p>PREPENDED Hello World! APPENDED</p>


### PR DESCRIPTION
This is split off from #11888, where I said I could land the parent check fix to master only to prevent BC breaks.
I think the alignment with spec is a great usability improvement.