### PR TITLE
Move opnum_start for goto for clarification

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5334,11 +5334,11 @@ static void zend_compile_goto(zend_ast *ast) /* {{{ */
 	zend_ast *label_ast = ast->child[0];
 	znode label_node;
 	zend_op *opline;
-	uint32_t opnum_start = get_next_op_number();
 
 	zend_compile_expr(&label_node, label_ast);
 
 	/* Label resolution and unwinding adjustments happen in pass two. */
+	uint32_t opnum_start = get_next_op_number();
 	zend_handle_loops_and_finally(NULL);
 	opline = zend_emit_op(NULL, ZEND_GOTO, NULL, &label_node);
 	opline->op1.num = get_next_op_number() - opnum_start - 1;


### PR DESCRIPTION
opnum_start denotes the start of the ZEND_FREE block of skipped consuming opcodes. Storing the number before zend_compile_expr(..., label_ast) makes it seem like it denotes the start of the label block. However, label_ast must only be a zval string AST, and as such never results in an actual opcode.