### PR TITLE
Align highlight_string|file with HTML standard and modern browsers

### DIFF
--- a/Zend/tests/bug35655.phpt
+++ b/Zend/tests/bug35655.phpt
@@ -19,7 +19,10 @@ EOT
 highlight_string($code);
 ?>
 --EXPECT--
-<code><span style="color: #000000">
-<br /><span style="color: #0000BB">&lt;?php<br />&nbsp;&nbsp;$x&nbsp;</span><span style="color: #007700">=&nbsp;&lt;&lt;&lt;EOT<br /></span><span style="color: #DD0000">some&nbsp;string&nbsp;&nbsp;&nbsp;&nbsp;<br /></span><span style="color: #007700">EOT<br />&nbsp;&nbsp;</span><span style="color: #0000BB">$y&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #0000BB">2</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">?&gt;</span>
-</span>
-</code>
+<pre style="color: #000000">
+<code style="color: #0000BB">&lt;?php
+  $x </code><code style="color: #007700">= &lt;&lt;&lt;EOT
+</code><code style="color: #DD0000">some string    
+</code><code style="color: #007700">EOT
+  </code><code style="color: #0000BB">$y </code><code style="color: #007700">= </code><code style="color: #0000BB">2</code><code style="color: #007700">;
+</code><code style="color: #0000BB">?&gt;</code></pre>

--- a/Zend/tests/bug35655.phpt
+++ b/Zend/tests/bug35655.phpt
@@ -19,10 +19,10 @@ EOT
 highlight_string($code);
 ?>
 --EXPECT--
-<pre style="color: #000000">
-<code style="color: #0000BB">&lt;?php
-  $x </code><code style="color: #007700">= &lt;&lt;&lt;EOT
-</code><code style="color: #DD0000">some string    
-</code><code style="color: #007700">EOT
-  </code><code style="color: #0000BB">$y </code><code style="color: #007700">= </code><code style="color: #0000BB">2</code><code style="color: #007700">;
-</code><code style="color: #0000BB">?&gt;</code></pre>
+<pre><code style="color: #000000">
+<span style="color: #0000BB">&lt;?php
+  $x </span><span style="color: #007700">= &lt;&lt;&lt;EOT
+</span><span style="color: #DD0000">some string    
+</span><span style="color: #007700">EOT
+  </span><span style="color: #0000BB">$y </span><span style="color: #007700">= </span><span style="color: #0000BB">2</span><span style="color: #007700">;
+</span><span style="color: #0000BB">?&gt;</span></code></pre>

--- a/Zend/tests/bug42767.phpt
+++ b/Zend/tests/bug42767.phpt
@@ -11,4 +11,4 @@ highlight.html    = #000000
 highlight_string('<?php /*some comment..');
 ?>
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #FF8000">/*some comment..</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #FF8000">/*some comment..</span></code></pre>

--- a/Zend/tests/bug42767.phpt
+++ b/Zend/tests/bug42767.phpt
@@ -11,7 +11,4 @@ highlight.html    = #000000
 highlight_string('<?php /*some comment..');
 ?>
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #FF8000">/*some&nbsp;comment..</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #FF8000">/*some comment..</code></pre>

--- a/Zend/tests/bug71086.phpt
+++ b/Zend/tests/bug71086.phpt
@@ -8,7 +8,5 @@ var_dump($highlightedString);
 
 ?>
 --EXPECT--
-string(169) "<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;<br />&nbsp;09&nbsp;09&nbsp;09</span><span style="color: #007700">;</span>
-</span>
-</code>"
+string(126) "<pre style="color: #000000"><code style="color: #0000BB">&lt;?php 
+ 09 09 09</code><code style="color: #007700">;</code></pre>"

--- a/Zend/tests/bug71086.phpt
+++ b/Zend/tests/bug71086.phpt
@@ -8,5 +8,5 @@ var_dump($highlightedString);
 
 ?>
 --EXPECT--
-string(126) "<pre style="color: #000000"><code style="color: #0000BB">&lt;?php 
- 09 09 09</code><code style="color: #007700">;</code></pre>"
+string(139) "<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php 
+ 09 09 09</span><span style="color: #007700">;</span></code></pre>"

--- a/Zend/tests/nowdoc_013.phpt
+++ b/Zend/tests/nowdoc_013.phpt
@@ -20,7 +20,9 @@ EOF;
 highlight_string($code);
 ?>
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php<br />&nbsp;&nbsp;$x&nbsp;</span><span style="color: #007700">=&nbsp;&lt;&lt;&lt;'EOT'<br /></span><span style="color: #DD0000">some&nbsp;string&nbsp;&nbsp;&nbsp;&nbsp;<br /></span><span style="color: #007700">EOT<br />&nbsp;&nbsp;</span><span style="color: #0000BB">$y&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #0000BB">2</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">?&gt;</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
+  $x </code><code style="color: #007700">= &lt;&lt;&lt;'EOT'
+</code><code style="color: #DD0000">some string    
+</code><code style="color: #007700">EOT
+  </code><code style="color: #0000BB">$y </code><code style="color: #007700">= </code><code style="color: #0000BB">2</code><code style="color: #007700">;
+</code><code style="color: #0000BB">?&gt;</code></pre>

--- a/Zend/tests/nowdoc_013.phpt
+++ b/Zend/tests/nowdoc_013.phpt
@@ -20,9 +20,9 @@ EOF;
 highlight_string($code);
 ?>
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
-  $x </code><code style="color: #007700">= &lt;&lt;&lt;'EOT'
-</code><code style="color: #DD0000">some string    
-</code><code style="color: #007700">EOT
-  </code><code style="color: #0000BB">$y </code><code style="color: #007700">= </code><code style="color: #0000BB">2</code><code style="color: #007700">;
-</code><code style="color: #0000BB">?&gt;</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php
+  $x </span><span style="color: #007700">= &lt;&lt;&lt;'EOT'
+</span><span style="color: #DD0000">some string    
+</span><span style="color: #007700">EOT
+  </span><span style="color: #0000BB">$y </span><span style="color: #007700">= </span><span style="color: #0000BB">2</span><span style="color: #007700">;
+</span><span style="color: #0000BB">?&gt;</span></code></pre>

--- a/Zend/tests/nowdoc_014.phpt
+++ b/Zend/tests/nowdoc_014.phpt
@@ -18,7 +18,8 @@ EOF;
 highlight_string($code);
 ?>
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php<br />&nbsp;&nbsp;$x&nbsp;</span><span style="color: #007700">=&nbsp;&lt;&lt;&lt;'EOT'<br />EOT<br />&nbsp;&nbsp;</span><span style="color: #0000BB">$y&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #0000BB">2</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">?&gt;</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
+  $x </code><code style="color: #007700">= &lt;&lt;&lt;'EOT'
+EOT
+  </code><code style="color: #0000BB">$y </code><code style="color: #007700">= </code><code style="color: #0000BB">2</code><code style="color: #007700">;
+</code><code style="color: #0000BB">?&gt;</code></pre>

--- a/Zend/tests/nowdoc_014.phpt
+++ b/Zend/tests/nowdoc_014.phpt
@@ -18,8 +18,8 @@ EOF;
 highlight_string($code);
 ?>
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
-  $x </code><code style="color: #007700">= &lt;&lt;&lt;'EOT'
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php
+  $x </span><span style="color: #007700">= &lt;&lt;&lt;'EOT'
 EOT
-  </code><code style="color: #0000BB">$y </code><code style="color: #007700">= </code><code style="color: #0000BB">2</code><code style="color: #007700">;
-</code><code style="color: #0000BB">?&gt;</code></pre>
+  </span><span style="color: #0000BB">$y </span><span style="color: #007700">= </span><span style="color: #0000BB">2</span><span style="color: #007700">;
+</span><span style="color: #0000BB">?&gt;</span></code></pre>

--- a/Zend/zend_highlight.c
+++ b/Zend/zend_highlight.c
@@ -28,9 +28,6 @@
 ZEND_API void zend_html_putc(char c)
 {
 	switch (c) {
-		case '\n':
-			ZEND_PUTS("<br />");
-			break;
 		case '<':
 			ZEND_PUTS("&lt;");
 			break;
@@ -40,11 +37,8 @@ ZEND_API void zend_html_putc(char c)
 		case '&':
 			ZEND_PUTS("&amp;");
 			break;
-		case ' ':
-			ZEND_PUTS("&nbsp;");
-			break;
 		case '\t':
-			ZEND_PUTS("&nbsp;&nbsp;&nbsp;&nbsp;");
+			ZEND_PUTS("    ");
 			break;
 		default:
 			ZEND_PUTC(c);
@@ -88,8 +82,7 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 	char *last_color = syntax_highlighter_ini->highlight_html;
 	char *next_color;
 
-	zend_printf("<code>");
-	zend_printf("<span style=\"color: %s\">\n", last_color);
+	zend_printf("<pre style=\"color: %s\">", last_color);
 	/* highlight stuff coming back from zendlex() */
 	while ((token_type=lex_scan(&token, NULL))) {
 		switch (token_type) {
@@ -134,11 +127,11 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 
 		if (last_color != next_color) {
 			if (last_color != syntax_highlighter_ini->highlight_html) {
-				zend_printf("</span>");
+				zend_printf("</code>");
 			}
 			last_color = next_color;
 			if (last_color != syntax_highlighter_ini->highlight_html) {
-				zend_printf("<span style=\"color: %s\">", last_color);
+				zend_printf("<code style=\"color: %s\">", last_color);
 			}
 		}
 
@@ -162,10 +155,9 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 	}
 
 	if (last_color != syntax_highlighter_ini->highlight_html) {
-		zend_printf("</span>\n");
+		zend_printf("</code>");
 	}
-	zend_printf("</span>\n");
-	zend_printf("</code>");
+	zend_printf("</pre>");
 
 	/* Discard parse errors thrown during tokenization */
 	zend_clear_exception();

--- a/Zend/zend_highlight.c
+++ b/Zend/zend_highlight.c
@@ -82,7 +82,7 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 	char *last_color = syntax_highlighter_ini->highlight_html;
 	char *next_color;
 
-	zend_printf("<pre style=\"color: %s\">", last_color);
+	zend_printf("<pre><code style=\"color: %s\">", last_color);
 	/* highlight stuff coming back from zendlex() */
 	while ((token_type=lex_scan(&token, NULL))) {
 		switch (token_type) {
@@ -127,11 +127,11 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 
 		if (last_color != next_color) {
 			if (last_color != syntax_highlighter_ini->highlight_html) {
-				zend_printf("</code>");
+				zend_printf("</span>");
 			}
 			last_color = next_color;
 			if (last_color != syntax_highlighter_ini->highlight_html) {
-				zend_printf("<code style=\"color: %s\">", last_color);
+				zend_printf("<span style=\"color: %s\">", last_color);
 			}
 		}
 
@@ -155,9 +155,9 @@ ZEND_API void zend_highlight(zend_syntax_highlighter_ini *syntax_highlighter_ini
 	}
 
 	if (last_color != syntax_highlighter_ini->highlight_html) {
-		zend_printf("</code>");
+		zend_printf("</span>");
 	}
-	zend_printf("</pre>");
+	zend_printf("</code></pre>");
 
 	/* Discard parse errors thrown during tokenization */
 	zend_clear_exception();

--- a/ext/phar/tests/cache_list/frontcontroller15.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller15.phpt
@@ -14,7 +14,4 @@ files/frontcontroller8.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/cache_list/frontcontroller15.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller15.phpt
@@ -14,4 +14,4 @@ files/frontcontroller8.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/cache_list/frontcontroller3.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller3.phpt
@@ -14,4 +14,4 @@ files/frontcontroller.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/cache_list/frontcontroller3.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller3.phpt
@@ -14,7 +14,4 @@ files/frontcontroller.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/cache_list/frontcontroller9.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller9.phpt
@@ -14,7 +14,4 @@ files/frontcontroller3.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/cache_list/frontcontroller9.phpt
+++ b/ext/phar/tests/cache_list/frontcontroller9.phpt
@@ -14,4 +14,4 @@ files/frontcontroller3.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/frontcontroller15.phpt
+++ b/ext/phar/tests/frontcontroller15.phpt
@@ -13,4 +13,4 @@ files/frontcontroller8.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/frontcontroller15.phpt
+++ b/ext/phar/tests/frontcontroller15.phpt
@@ -13,7 +13,4 @@ files/frontcontroller8.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/frontcontroller3.phpt
+++ b/ext/phar/tests/frontcontroller3.phpt
@@ -13,4 +13,4 @@ files/frontcontroller.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/frontcontroller3.phpt
+++ b/ext/phar/tests/frontcontroller3.phpt
@@ -13,7 +13,4 @@ files/frontcontroller.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/frontcontroller9.phpt
+++ b/ext/phar/tests/frontcontroller9.phpt
@@ -13,4 +13,4 @@ files/frontcontroller3.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/frontcontroller9.phpt
+++ b/ext/phar/tests/frontcontroller9.phpt
@@ -13,7 +13,4 @@ files/frontcontroller3.phar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/tar/frontcontroller15.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller15.phar.phpt
@@ -13,7 +13,4 @@ files/frontcontroller8.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/tar/frontcontroller15.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller15.phar.phpt
@@ -13,4 +13,4 @@ files/frontcontroller8.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/tar/frontcontroller3.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller3.phar.phpt
@@ -13,4 +13,4 @@ files/frontcontroller.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/tar/frontcontroller3.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller3.phar.phpt
@@ -13,7 +13,4 @@ files/frontcontroller.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/tar/frontcontroller9.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller9.phar.phpt
@@ -13,4 +13,4 @@ files/frontcontroller3.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/tar/frontcontroller9.phar.phpt
+++ b/ext/phar/tests/tar/frontcontroller9.phar.phpt
@@ -13,7 +13,4 @@ files/frontcontroller3.phar.tar
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/zip/frontcontroller15.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller15.phar.phpt
@@ -15,4 +15,4 @@ files/frontcontroller8.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/zip/frontcontroller15.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller15.phar.phpt
@@ -15,7 +15,4 @@ files/frontcontroller8.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/zip/frontcontroller3.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller3.phar.phpt
@@ -15,4 +15,4 @@ files/frontcontroller.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/phar/tests/zip/frontcontroller3.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller3.phar.phpt
@@ -15,7 +15,4 @@ files/frontcontroller.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/zip/frontcontroller9.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller9.phar.phpt
@@ -13,7 +13,4 @@ files/frontcontroller3.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">function&nbsp;</span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>

--- a/ext/phar/tests/zip/frontcontroller9.phar.phpt
+++ b/ext/phar/tests/zip/frontcontroller9.phar.phpt
@@ -13,4 +13,4 @@ files/frontcontroller3.phar.zip
 --EXPECTHEADERS--
 Content-type: text/html; charset=UTF-8
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">function </code><code style="color: #0000BB">hio</code><code style="color: #007700">(){}</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">function </span><span style="color: #0000BB">hio</span><span style="color: #007700">(){}</span></code></pre>

--- a/ext/standard/tests/general_functions/highlight_heredoc.phpt
+++ b/ext/standard/tests/general_functions/highlight_heredoc.phpt
@@ -16,7 +16,7 @@ DDDD;
 highlight_string($str);
 ?>
 --EXPECT--
-<pre style="color: #000000">
+<pre><code style="color: #000000">
 $x=&lt;&lt;&lt;DD
 jhdsjkfhjdsh
 DD
@@ -24,4 +24,4 @@ DD
 $a=&lt;&lt;&lt;DDDD
 jhdsjkfhjdsh
 DDDD;
-</pre>
+</code></pre>

--- a/ext/standard/tests/general_functions/highlight_heredoc.phpt
+++ b/ext/standard/tests/general_functions/highlight_heredoc.phpt
@@ -16,6 +16,12 @@ DDDD;
 highlight_string($str);
 ?>
 --EXPECT--
-<code><span style="color: #000000">
-<br />$x=&lt;&lt;&lt;DD<br />jhdsjkfhjdsh<br />DD<br />."";<br />$a=&lt;&lt;&lt;DDDD<br />jhdsjkfhjdsh<br />DDDD;<br /></span>
-</code>
+<pre style="color: #000000">
+$x=&lt;&lt;&lt;DD
+jhdsjkfhjdsh
+DD
+."";
+$a=&lt;&lt;&lt;DDDD
+jhdsjkfhjdsh
+DDDD;
+</pre>

--- a/ext/standard/tests/strings/highlight_file.phpt
+++ b/ext/standard/tests/strings/highlight_file.phpt
@@ -42,14 +42,14 @@ Warning: highlight_file(%shighlight_file.dat): Failed to open stream: No such fi
 
 Warning: highlight_file(): Failed opening '%shighlight_file.dat' for highlighting in %s on line %d
 bool(false)
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"test"</code><code style="color: #007700">; </code><code style="color: #0000BB">?&gt;</code></pre>bool(true)
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"test ?&gt;</code></pre>bool(true)
-<pre style="color: #000000">
-<code style="color: #0000BB">&lt;?php
-</code><code style="color: #007700">class </code><code style="color: #0000BB">test </code><code style="color: #007700">{
-    public </code><code style="color: #0000BB">$var </code><code style="color: #007700">= </code><code style="color: #0000BB">1</code><code style="color: #007700">;
-    private function </code><code style="color: #0000BB">foo</code><code style="color: #007700">() { echo </code><code style="color: #DD0000">"foo"</code><code style="color: #007700">; }
-    public function </code><code style="color: #0000BB">bar</code><code style="color: #007700">() { </code><code style="color: #0000BB">var_dump</code><code style="color: #007700">(</code><code style="color: #0000BB">test</code><code style="color: #007700">::</code><code style="color: #0000BB">foo</code><code style="color: #007700">()); }
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">echo </span><span style="color: #DD0000">"test"</span><span style="color: #007700">; </span><span style="color: #0000BB">?&gt;</span></code></pre>bool(true)
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">echo </span><span style="color: #DD0000">"test ?&gt;</span></code></pre>bool(true)
+<pre><code style="color: #000000">
+<span style="color: #0000BB">&lt;?php
+</span><span style="color: #007700">class </span><span style="color: #0000BB">test </span><span style="color: #007700">{
+    public </span><span style="color: #0000BB">$var </span><span style="color: #007700">= </span><span style="color: #0000BB">1</span><span style="color: #007700">;
+    private function </span><span style="color: #0000BB">foo</span><span style="color: #007700">() { echo </span><span style="color: #DD0000">"foo"</span><span style="color: #007700">; }
+    public function </span><span style="color: #0000BB">bar</span><span style="color: #007700">() { </span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">test</span><span style="color: #007700">::</span><span style="color: #0000BB">foo</span><span style="color: #007700">()); }
 }
-</code><code style="color: #0000BB">?&gt;</code></pre>bool(true)
+</span><span style="color: #0000BB">?&gt;</span></code></pre>bool(true)
 Done

--- a/ext/standard/tests/strings/highlight_file.phpt
+++ b/ext/standard/tests/strings/highlight_file.phpt
@@ -42,16 +42,14 @@ Warning: highlight_file(%shighlight_file.dat): Failed to open stream: No such fi
 
 Warning: highlight_file(): Failed opening '%shighlight_file.dat' for highlighting in %s on line %d
 bool(false)
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">echo&nbsp;</span><span style="color: #DD0000">"test"</span><span style="color: #007700">;&nbsp;</span><span style="color: #0000BB">?&gt;</span>
-</span>
-</code>bool(true)
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">echo&nbsp;</span><span style="color: #DD0000">"test&nbsp;?&gt;</span>
-</span>
-</code>bool(true)
-<code><span style="color: #000000">
-<br /><span style="color: #0000BB">&lt;?php<br /></span><span style="color: #007700">class&nbsp;</span><span style="color: #0000BB">test&nbsp;</span><span style="color: #007700">{<br />&nbsp;&nbsp;&nbsp;&nbsp;public&nbsp;</span><span style="color: #0000BB">$var&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #0000BB">1</span><span style="color: #007700">;<br />&nbsp;&nbsp;&nbsp;&nbsp;private&nbsp;function&nbsp;</span><span style="color: #0000BB">foo</span><span style="color: #007700">()&nbsp;{&nbsp;echo&nbsp;</span><span style="color: #DD0000">"foo"</span><span style="color: #007700">;&nbsp;}<br />&nbsp;&nbsp;&nbsp;&nbsp;public&nbsp;function&nbsp;</span><span style="color: #0000BB">bar</span><span style="color: #007700">()&nbsp;{&nbsp;</span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">test</span><span style="color: #007700">::</span><span style="color: #0000BB">foo</span><span style="color: #007700">());&nbsp;}<br />}<br /></span><span style="color: #0000BB">?&gt;</span>
-</span>
-</code>bool(true)
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"test"</code><code style="color: #007700">; </code><code style="color: #0000BB">?&gt;</code></pre>bool(true)
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"test ?&gt;</code></pre>bool(true)
+<pre style="color: #000000">
+<code style="color: #0000BB">&lt;?php
+</code><code style="color: #007700">class </code><code style="color: #0000BB">test </code><code style="color: #007700">{
+    public </code><code style="color: #0000BB">$var </code><code style="color: #007700">= </code><code style="color: #0000BB">1</code><code style="color: #007700">;
+    private function </code><code style="color: #0000BB">foo</code><code style="color: #007700">() { echo </code><code style="color: #DD0000">"foo"</code><code style="color: #007700">; }
+    public function </code><code style="color: #0000BB">bar</code><code style="color: #007700">() { </code><code style="color: #0000BB">var_dump</code><code style="color: #007700">(</code><code style="color: #0000BB">test</code><code style="color: #007700">::</code><code style="color: #0000BB">foo</code><code style="color: #007700">()); }
+}
+</code><code style="color: #0000BB">?&gt;</code></pre>bool(true)
 Done

--- a/ext/standard/tests/strings/show_source_basic.phpt
+++ b/ext/standard/tests/strings/show_source_basic.phpt
@@ -21,7 +21,19 @@ show_source(__FILE__);
 ?>
 --EXPECT--
 *** Test by calling method or function with its expected arguments ***
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php<br /></span><span style="color: #007700">echo&nbsp;</span><span style="color: #DD0000">"***&nbsp;Test&nbsp;by&nbsp;calling&nbsp;method&nbsp;or&nbsp;function&nbsp;with&nbsp;its&nbsp;expected&nbsp;arguments&nbsp;***\n"</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">$foo&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">'bar'</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">$baz&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">"something&nbsp;"</span><span style="color: #007700">.</span><span style="color: #0000BB">$foo</span><span style="color: #007700">.</span><span style="color: #DD0000">"\n"</span><span style="color: #007700">;<br /><br />if&nbsp;(&nbsp;</span><span style="color: #0000BB">$foo&nbsp;</span><span style="color: #007700">==&nbsp;</span><span style="color: #DD0000">'bar'&nbsp;</span><span style="color: #007700">)<br />{<br />&nbsp;&nbsp;</span><span style="color: #0000BB">$baz&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">'baz'</span><span style="color: #007700">;<br />}<br /><br />&nbsp;</span><span style="color: #FF8000">/*&nbsp;some&nbsp;code&nbsp;here&nbsp;*/<br /><br /></span><span style="color: #0000BB">show_source</span><span style="color: #007700">(</span><span style="color: #0000BB">__FILE__</span><span style="color: #007700">);<br /><br /></span><span style="color: #0000BB">?&gt;<br /></span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
+</code><code style="color: #007700">echo </code><code style="color: #DD0000">"*** Test by calling method or function with its expected arguments ***\n"</code><code style="color: #007700">;
+</code><code style="color: #0000BB">$foo </code><code style="color: #007700">= </code><code style="color: #DD0000">'bar'</code><code style="color: #007700">;
+</code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"something "</code><code style="color: #007700">.</code><code style="color: #0000BB">$foo</code><code style="color: #007700">.</code><code style="color: #DD0000">"\n"</code><code style="color: #007700">;
+
+if ( </code><code style="color: #0000BB">$foo </code><code style="color: #007700">== </code><code style="color: #DD0000">'bar' </code><code style="color: #007700">)
+{
+  </code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">'baz'</code><code style="color: #007700">;
+}
+
+ </code><code style="color: #FF8000">/* some code here */
+
+</code><code style="color: #0000BB">show_source</code><code style="color: #007700">(</code><code style="color: #0000BB">__FILE__</code><code style="color: #007700">);
+
+</code><code style="color: #0000BB">?&gt;
+</code></pre>

--- a/ext/standard/tests/strings/show_source_basic.phpt
+++ b/ext/standard/tests/strings/show_source_basic.phpt
@@ -21,19 +21,19 @@ show_source(__FILE__);
 ?>
 --EXPECT--
 *** Test by calling method or function with its expected arguments ***
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
-</code><code style="color: #007700">echo </code><code style="color: #DD0000">"*** Test by calling method or function with its expected arguments ***\n"</code><code style="color: #007700">;
-</code><code style="color: #0000BB">$foo </code><code style="color: #007700">= </code><code style="color: #DD0000">'bar'</code><code style="color: #007700">;
-</code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"something "</code><code style="color: #007700">.</code><code style="color: #0000BB">$foo</code><code style="color: #007700">.</code><code style="color: #DD0000">"\n"</code><code style="color: #007700">;
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php
+</span><span style="color: #007700">echo </span><span style="color: #DD0000">"*** Test by calling method or function with its expected arguments ***\n"</span><span style="color: #007700">;
+</span><span style="color: #0000BB">$foo </span><span style="color: #007700">= </span><span style="color: #DD0000">'bar'</span><span style="color: #007700">;
+</span><span style="color: #0000BB">$baz </span><span style="color: #007700">= </span><span style="color: #DD0000">"something "</span><span style="color: #007700">.</span><span style="color: #0000BB">$foo</span><span style="color: #007700">.</span><span style="color: #DD0000">"\n"</span><span style="color: #007700">;
 
-if ( </code><code style="color: #0000BB">$foo </code><code style="color: #007700">== </code><code style="color: #DD0000">'bar' </code><code style="color: #007700">)
+if ( </span><span style="color: #0000BB">$foo </span><span style="color: #007700">== </span><span style="color: #DD0000">'bar' </span><span style="color: #007700">)
 {
-  </code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">'baz'</code><code style="color: #007700">;
+  </span><span style="color: #0000BB">$baz </span><span style="color: #007700">= </span><span style="color: #DD0000">'baz'</span><span style="color: #007700">;
 }
 
- </code><code style="color: #FF8000">/* some code here */
+ </span><span style="color: #FF8000">/* some code here */
 
-</code><code style="color: #0000BB">show_source</code><code style="color: #007700">(</code><code style="color: #0000BB">__FILE__</code><code style="color: #007700">);
+</span><span style="color: #0000BB">show_source</span><span style="color: #007700">(</span><span style="color: #0000BB">__FILE__</span><span style="color: #007700">);
 
-</code><code style="color: #0000BB">?&gt;
-</code></pre>
+</span><span style="color: #0000BB">?&gt;
+</span></code></pre>

--- a/ext/standard/tests/strings/show_source_variation1.phpt
+++ b/ext/standard/tests/strings/show_source_variation1.phpt
@@ -22,7 +22,19 @@ echo $foo;
 --EXPECT--
 *** Test by calling method or function with its expected arguments and php output ***
 baz
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php<br /></span><span style="color: #007700">echo&nbsp;</span><span style="color: #DD0000">"***&nbsp;Test&nbsp;by&nbsp;calling&nbsp;method&nbsp;or&nbsp;function&nbsp;with&nbsp;its&nbsp;expected&nbsp;arguments&nbsp;and&nbsp;php&nbsp;output&nbsp;***\n"</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">$foo&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">'bar'</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">$baz&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">"something&nbsp;"</span><span style="color: #007700">.</span><span style="color: #0000BB">$foo</span><span style="color: #007700">.</span><span style="color: #DD0000">"\n"</span><span style="color: #007700">;<br /><br />if&nbsp;(&nbsp;</span><span style="color: #0000BB">$foo&nbsp;</span><span style="color: #007700">==&nbsp;</span><span style="color: #DD0000">'bar'&nbsp;</span><span style="color: #007700">)<br />{<br />&nbsp;&nbsp;</span><span style="color: #0000BB">$baz&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">"baz\n"</span><span style="color: #007700">;<br />}<br /><br />&nbsp;</span><span style="color: #FF8000">/*&nbsp;some&nbsp;code&nbsp;here&nbsp;*/<br /></span><span style="color: #007700">echo&nbsp;</span><span style="color: #0000BB">$baz</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">show_source</span><span style="color: #007700">(</span><span style="color: #0000BB">__FILE__</span><span style="color: #007700">);<br />echo&nbsp;</span><span style="color: #0000BB">$foo</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">?&gt;<br /></span>
-</span>
-</code>bar
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
+</code><code style="color: #007700">echo </code><code style="color: #DD0000">"*** Test by calling method or function with its expected arguments and php output ***\n"</code><code style="color: #007700">;
+</code><code style="color: #0000BB">$foo </code><code style="color: #007700">= </code><code style="color: #DD0000">'bar'</code><code style="color: #007700">;
+</code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"something "</code><code style="color: #007700">.</code><code style="color: #0000BB">$foo</code><code style="color: #007700">.</code><code style="color: #DD0000">"\n"</code><code style="color: #007700">;
+
+if ( </code><code style="color: #0000BB">$foo </code><code style="color: #007700">== </code><code style="color: #DD0000">'bar' </code><code style="color: #007700">)
+{
+  </code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"baz\n"</code><code style="color: #007700">;
+}
+
+ </code><code style="color: #FF8000">/* some code here */
+</code><code style="color: #007700">echo </code><code style="color: #0000BB">$baz</code><code style="color: #007700">;
+</code><code style="color: #0000BB">show_source</code><code style="color: #007700">(</code><code style="color: #0000BB">__FILE__</code><code style="color: #007700">);
+echo </code><code style="color: #0000BB">$foo</code><code style="color: #007700">;
+</code><code style="color: #0000BB">?&gt;
+</code></pre>bar

--- a/ext/standard/tests/strings/show_source_variation1.phpt
+++ b/ext/standard/tests/strings/show_source_variation1.phpt
@@ -22,19 +22,19 @@ echo $foo;
 --EXPECT--
 *** Test by calling method or function with its expected arguments and php output ***
 baz
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
-</code><code style="color: #007700">echo </code><code style="color: #DD0000">"*** Test by calling method or function with its expected arguments and php output ***\n"</code><code style="color: #007700">;
-</code><code style="color: #0000BB">$foo </code><code style="color: #007700">= </code><code style="color: #DD0000">'bar'</code><code style="color: #007700">;
-</code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"something "</code><code style="color: #007700">.</code><code style="color: #0000BB">$foo</code><code style="color: #007700">.</code><code style="color: #DD0000">"\n"</code><code style="color: #007700">;
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php
+</span><span style="color: #007700">echo </span><span style="color: #DD0000">"*** Test by calling method or function with its expected arguments and php output ***\n"</span><span style="color: #007700">;
+</span><span style="color: #0000BB">$foo </span><span style="color: #007700">= </span><span style="color: #DD0000">'bar'</span><span style="color: #007700">;
+</span><span style="color: #0000BB">$baz </span><span style="color: #007700">= </span><span style="color: #DD0000">"something "</span><span style="color: #007700">.</span><span style="color: #0000BB">$foo</span><span style="color: #007700">.</span><span style="color: #DD0000">"\n"</span><span style="color: #007700">;
 
-if ( </code><code style="color: #0000BB">$foo </code><code style="color: #007700">== </code><code style="color: #DD0000">'bar' </code><code style="color: #007700">)
+if ( </span><span style="color: #0000BB">$foo </span><span style="color: #007700">== </span><span style="color: #DD0000">'bar' </span><span style="color: #007700">)
 {
-  </code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"baz\n"</code><code style="color: #007700">;
+  </span><span style="color: #0000BB">$baz </span><span style="color: #007700">= </span><span style="color: #DD0000">"baz\n"</span><span style="color: #007700">;
 }
 
- </code><code style="color: #FF8000">/* some code here */
-</code><code style="color: #007700">echo </code><code style="color: #0000BB">$baz</code><code style="color: #007700">;
-</code><code style="color: #0000BB">show_source</code><code style="color: #007700">(</code><code style="color: #0000BB">__FILE__</code><code style="color: #007700">);
-echo </code><code style="color: #0000BB">$foo</code><code style="color: #007700">;
-</code><code style="color: #0000BB">?&gt;
-</code></pre>bar
+ </span><span style="color: #FF8000">/* some code here */
+</span><span style="color: #007700">echo </span><span style="color: #0000BB">$baz</span><span style="color: #007700">;
+</span><span style="color: #0000BB">show_source</span><span style="color: #007700">(</span><span style="color: #0000BB">__FILE__</span><span style="color: #007700">);
+echo </span><span style="color: #0000BB">$foo</span><span style="color: #007700">;
+</span><span style="color: #0000BB">?&gt;
+</span></code></pre>bar

--- a/ext/standard/tests/strings/show_source_variation2.phpt
+++ b/ext/standard/tests/strings/show_source_variation2.phpt
@@ -21,7 +21,19 @@ var_dump($source);
 ?>
 --EXPECT--
 *** Test by calling method or function with its expected arguments and output to variable ***
-string(1975) "<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php<br /></span><span style="color: #007700">echo&nbsp;</span><span style="color: #DD0000">"***&nbsp;Test&nbsp;by&nbsp;calling&nbsp;method&nbsp;or&nbsp;function&nbsp;with&nbsp;its&nbsp;expected&nbsp;arguments&nbsp;and&nbsp;output&nbsp;to&nbsp;variable&nbsp;***\n"</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">$foo&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">'bar'</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">$baz&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">"something&nbsp;"</span><span style="color: #007700">.</span><span style="color: #0000BB">$foo</span><span style="color: #007700">.</span><span style="color: #DD0000">"\n"</span><span style="color: #007700">;<br /><br />if&nbsp;(&nbsp;</span><span style="color: #0000BB">$foo&nbsp;</span><span style="color: #007700">==&nbsp;</span><span style="color: #DD0000">'bar'&nbsp;</span><span style="color: #007700">)<br />{<br />&nbsp;&nbsp;</span><span style="color: #0000BB">$baz&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">"baz\n"</span><span style="color: #007700">;<br />}<br /><br />&nbsp;</span><span style="color: #FF8000">/*&nbsp;some&nbsp;code&nbsp;here&nbsp;*/<br /></span><span style="color: #0000BB">$source&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #0000BB">show_source</span><span style="color: #007700">(</span><span style="color: #0000BB">__FILE__</span><span style="color: #007700">,&nbsp;</span><span style="color: #0000BB">true</span><span style="color: #007700">);<br /><br /></span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$source</span><span style="color: #007700">);<br /></span><span style="color: #0000BB">?&gt;<br /></span>
-</span>
-</code>"
+string(1691) "<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
+</code><code style="color: #007700">echo </code><code style="color: #DD0000">"*** Test by calling method or function with its expected arguments and output to variable ***\n"</code><code style="color: #007700">;
+</code><code style="color: #0000BB">$foo </code><code style="color: #007700">= </code><code style="color: #DD0000">'bar'</code><code style="color: #007700">;
+</code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"something "</code><code style="color: #007700">.</code><code style="color: #0000BB">$foo</code><code style="color: #007700">.</code><code style="color: #DD0000">"\n"</code><code style="color: #007700">;
+
+if ( </code><code style="color: #0000BB">$foo </code><code style="color: #007700">== </code><code style="color: #DD0000">'bar' </code><code style="color: #007700">)
+{
+  </code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"baz\n"</code><code style="color: #007700">;
+}
+
+ </code><code style="color: #FF8000">/* some pre here */
+</code><code style="color: #0000BB">$source </code><code style="color: #007700">= </code><code style="color: #0000BB">show_source</code><code style="color: #007700">(</code><code style="color: #0000BB">__FILE__</code><code style="color: #007700">, </code><code style="color: #0000BB">true</code><code style="color: #007700">);
+
+</code><code style="color: #0000BB">var_dump</code><code style="color: #007700">(</code><code style="color: #0000BB">$source</code><code style="color: #007700">);
+</code><code style="color: #0000BB">?&gt;
+</code></pre>"

--- a/ext/standard/tests/strings/show_source_variation2.phpt
+++ b/ext/standard/tests/strings/show_source_variation2.phpt
@@ -21,19 +21,19 @@ var_dump($source);
 ?>
 --EXPECT--
 *** Test by calling method or function with its expected arguments and output to variable ***
-string(1691) "<pre style="color: #000000"><code style="color: #0000BB">&lt;?php
-</code><code style="color: #007700">echo </code><code style="color: #DD0000">"*** Test by calling method or function with its expected arguments and output to variable ***\n"</code><code style="color: #007700">;
-</code><code style="color: #0000BB">$foo </code><code style="color: #007700">= </code><code style="color: #DD0000">'bar'</code><code style="color: #007700">;
-</code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"something "</code><code style="color: #007700">.</code><code style="color: #0000BB">$foo</code><code style="color: #007700">.</code><code style="color: #DD0000">"\n"</code><code style="color: #007700">;
+string(1705) "<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php
+</span><span style="color: #007700">echo </span><span style="color: #DD0000">"*** Test by calling method or function with its expected arguments and output to variable ***\n"</span><span style="color: #007700">;
+</span><span style="color: #0000BB">$foo </span><span style="color: #007700">= </span><span style="color: #DD0000">'bar'</span><span style="color: #007700">;
+</span><span style="color: #0000BB">$baz </span><span style="color: #007700">= </span><span style="color: #DD0000">"something "</span><span style="color: #007700">.</span><span style="color: #0000BB">$foo</span><span style="color: #007700">.</span><span style="color: #DD0000">"\n"</span><span style="color: #007700">;
 
-if ( </code><code style="color: #0000BB">$foo </code><code style="color: #007700">== </code><code style="color: #DD0000">'bar' </code><code style="color: #007700">)
+if ( </span><span style="color: #0000BB">$foo </span><span style="color: #007700">== </span><span style="color: #DD0000">'bar' </span><span style="color: #007700">)
 {
-  </code><code style="color: #0000BB">$baz </code><code style="color: #007700">= </code><code style="color: #DD0000">"baz\n"</code><code style="color: #007700">;
+  </span><span style="color: #0000BB">$baz </span><span style="color: #007700">= </span><span style="color: #DD0000">"baz\n"</span><span style="color: #007700">;
 }
 
- </code><code style="color: #FF8000">/* some pre here */
-</code><code style="color: #0000BB">$source </code><code style="color: #007700">= </code><code style="color: #0000BB">show_source</code><code style="color: #007700">(</code><code style="color: #0000BB">__FILE__</code><code style="color: #007700">, </code><code style="color: #0000BB">true</code><code style="color: #007700">);
+ </span><span style="color: #FF8000">/* some code here */
+</span><span style="color: #0000BB">$source </span><span style="color: #007700">= </span><span style="color: #0000BB">show_source</span><span style="color: #007700">(</span><span style="color: #0000BB">__FILE__</span><span style="color: #007700">, </span><span style="color: #0000BB">true</span><span style="color: #007700">);
 
-</code><code style="color: #0000BB">var_dump</code><code style="color: #007700">(</code><code style="color: #0000BB">$source</code><code style="color: #007700">);
-</code><code style="color: #0000BB">?&gt;
-</code></pre>"
+</span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$source</span><span style="color: #007700">);
+</span><span style="color: #0000BB">?&gt;
+</span></code></pre>"

--- a/sapi/cgi/tests/008.phpt
+++ b/sapi/cgi/tests/008.phpt
@@ -41,22 +41,22 @@ echo "Done\n";
 string(%d) "X-Powered-By: PHP/%s
 Content-type: text/html%r; charset=.*|%r
 
-<pre style="color: #000000">
-<code style="color: #0000BB">&lt;?php
-$test </code><code style="color: #007700">= </code><code style="color: #DD0000">"var"</code><code style="color: #007700">; </code><code style="color: #FF8000">//var
+<pre><code style="color: #000000">
+<span style="color: #0000BB">&lt;?php
+$test </span><span style="color: #007700">= </span><span style="color: #DD0000">"var"</span><span style="color: #007700">; </span><span style="color: #FF8000">//var
 /* test class */
-</code><code style="color: #007700">class </code><code style="color: #0000BB">test </code><code style="color: #007700">{
-    private </code><code style="color: #0000BB">$var </code><code style="color: #007700">= array();
+</span><span style="color: #007700">class </span><span style="color: #0000BB">test </span><span style="color: #007700">{
+    private </span><span style="color: #0000BB">$var </span><span style="color: #007700">= array();
 
-    public static function </code><code style="color: #0000BB">foo</code><code style="color: #007700">(</code><code style="color: #0000BB">Test $arg</code><code style="color: #007700">) {
-        echo </code><code style="color: #DD0000">"hello"</code><code style="color: #007700">;
-        </code><code style="color: #0000BB">var_dump</code><code style="color: #007700">(</code><code style="color: #0000BB">$this</code><code style="color: #007700">);
+    public static function </span><span style="color: #0000BB">foo</span><span style="color: #007700">(</span><span style="color: #0000BB">Test $arg</span><span style="color: #007700">) {
+        echo </span><span style="color: #DD0000">"hello"</span><span style="color: #007700">;
+        </span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">);
     }
 }
 
-</code><code style="color: #0000BB">$o </code><code style="color: #007700">= new </code><code style="color: #0000BB">test</code><code style="color: #007700">;
-</code><code style="color: #0000BB">?&gt;
-</code></pre>"
+</span><span style="color: #0000BB">$o </span><span style="color: #007700">= new </span><span style="color: #0000BB">test</span><span style="color: #007700">;
+</span><span style="color: #0000BB">?&gt;
+</span></code></pre>"
 string(%d) "Status: 404 Not Found
 X-Powered-By: PHP/%s
 Content-type: text/html%r; charset=.*|%r

--- a/sapi/cgi/tests/008.phpt
+++ b/sapi/cgi/tests/008.phpt
@@ -41,10 +41,22 @@ echo "Done\n";
 string(%d) "X-Powered-By: PHP/%s
 Content-type: text/html%r; charset=.*|%r
 
-<code><span style="color: #000000">
-<br /><span style="color: #0000BB">&lt;?php<br />$test&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">"var"</span><span style="color: #007700">;&nbsp;</span><span style="color: #FF8000">//var<br />/*&nbsp;test&nbsp;class&nbsp;*/<br /></span><span style="color: #007700">class&nbsp;</span><span style="color: #0000BB">test&nbsp;</span><span style="color: #007700">{<br />&nbsp;&nbsp;&nbsp;&nbsp;private&nbsp;</span><span style="color: #0000BB">$var&nbsp;</span><span style="color: #007700">=&nbsp;array();<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;public&nbsp;static&nbsp;function&nbsp;</span><span style="color: #0000BB">foo</span><span style="color: #007700">(</span><span style="color: #0000BB">Test&nbsp;$arg</span><span style="color: #007700">)&nbsp;{<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;echo&nbsp;</span><span style="color: #DD0000">"hello"</span><span style="color: #007700">;<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">);<br />&nbsp;&nbsp;&nbsp;&nbsp;}<br />}<br /><br /></span><span style="color: #0000BB">$o&nbsp;</span><span style="color: #007700">=&nbsp;new&nbsp;</span><span style="color: #0000BB">test</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">?&gt;<br /></span>
-</span>
-</code>"
+<pre style="color: #000000">
+<code style="color: #0000BB">&lt;?php
+$test </code><code style="color: #007700">= </code><code style="color: #DD0000">"var"</code><code style="color: #007700">; </code><code style="color: #FF8000">//var
+/* test class */
+</code><code style="color: #007700">class </code><code style="color: #0000BB">test </code><code style="color: #007700">{
+    private </code><code style="color: #0000BB">$var </code><code style="color: #007700">= array();
+
+    public static function </code><code style="color: #0000BB">foo</code><code style="color: #007700">(</code><code style="color: #0000BB">Test $arg</code><code style="color: #007700">) {
+        echo </code><code style="color: #DD0000">"hello"</code><code style="color: #007700">;
+        </code><code style="color: #0000BB">var_dump</code><code style="color: #007700">(</code><code style="color: #0000BB">$this</code><code style="color: #007700">);
+    }
+}
+
+</code><code style="color: #0000BB">$o </code><code style="color: #007700">= new </code><code style="color: #0000BB">test</code><code style="color: #007700">;
+</code><code style="color: #0000BB">?&gt;
+</code></pre>"
 string(%d) "Status: 404 Not Found
 X-Powered-By: PHP/%s
 Content-type: text/html%r; charset=.*|%r

--- a/sapi/cli/tests/014.phpt
+++ b/sapi/cli/tests/014.phpt
@@ -36,22 +36,22 @@ var_dump(`$php -n -s unknown`);
 echo "Done\n";
 ?>
 --EXPECT--
-string(1145) "<pre style="color: #000000">
-<code style="color: #0000BB">&lt;?php
-$test </code><code style="color: #007700">= </code><code style="color: #DD0000">"var"</code><code style="color: #007700">; </code><code style="color: #FF8000">//var
+string(1158) "<pre><code style="color: #000000">
+<span style="color: #0000BB">&lt;?php
+$test </span><span style="color: #007700">= </span><span style="color: #DD0000">"var"</span><span style="color: #007700">; </span><span style="color: #FF8000">//var
 /* test class */
-</code><code style="color: #007700">class </code><code style="color: #0000BB">test </code><code style="color: #007700">{
-    private </code><code style="color: #0000BB">$var </code><code style="color: #007700">= array();
+</span><span style="color: #007700">class </span><span style="color: #0000BB">test </span><span style="color: #007700">{
+    private </span><span style="color: #0000BB">$var </span><span style="color: #007700">= array();
 
-    public static function </code><code style="color: #0000BB">foo</code><code style="color: #007700">(</code><code style="color: #0000BB">Test $arg</code><code style="color: #007700">) {
-        echo </code><code style="color: #DD0000">"hello"</code><code style="color: #007700">;
-        </code><code style="color: #0000BB">var_dump</code><code style="color: #007700">(</code><code style="color: #0000BB">$this</code><code style="color: #007700">);
+    public static function </span><span style="color: #0000BB">foo</span><span style="color: #007700">(</span><span style="color: #0000BB">Test $arg</span><span style="color: #007700">) {
+        echo </span><span style="color: #DD0000">"hello"</span><span style="color: #007700">;
+        </span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">);
     }
 }
 
-</code><code style="color: #0000BB">$o </code><code style="color: #007700">= new </code><code style="color: #0000BB">test</code><code style="color: #007700">;
-</code><code style="color: #0000BB">?&gt;
-</code></pre>"
+</span><span style="color: #0000BB">$o </span><span style="color: #007700">= new </span><span style="color: #0000BB">test</span><span style="color: #007700">;
+</span><span style="color: #0000BB">?&gt;
+</span></code></pre>"
 Could not open input file: unknown
 NULL
 Done

--- a/sapi/cli/tests/014.phpt
+++ b/sapi/cli/tests/014.phpt
@@ -36,10 +36,22 @@ var_dump(`$php -n -s unknown`);
 echo "Done\n";
 ?>
 --EXPECT--
-string(1478) "<code><span style="color: #000000">
-<br /><span style="color: #0000BB">&lt;?php<br />$test&nbsp;</span><span style="color: #007700">=&nbsp;</span><span style="color: #DD0000">"var"</span><span style="color: #007700">;&nbsp;</span><span style="color: #FF8000">//var<br />/*&nbsp;test&nbsp;class&nbsp;*/<br /></span><span style="color: #007700">class&nbsp;</span><span style="color: #0000BB">test&nbsp;</span><span style="color: #007700">{<br />&nbsp;&nbsp;&nbsp;&nbsp;private&nbsp;</span><span style="color: #0000BB">$var&nbsp;</span><span style="color: #007700">=&nbsp;array();<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;public&nbsp;static&nbsp;function&nbsp;</span><span style="color: #0000BB">foo</span><span style="color: #007700">(</span><span style="color: #0000BB">Test&nbsp;$arg</span><span style="color: #007700">)&nbsp;{<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;echo&nbsp;</span><span style="color: #DD0000">"hello"</span><span style="color: #007700">;<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span style="color: #0000BB">var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">);<br />&nbsp;&nbsp;&nbsp;&nbsp;}<br />}<br /><br /></span><span style="color: #0000BB">$o&nbsp;</span><span style="color: #007700">=&nbsp;new&nbsp;</span><span style="color: #0000BB">test</span><span style="color: #007700">;<br /></span><span style="color: #0000BB">?&gt;<br /></span>
-</span>
-</code>"
+string(1145) "<pre style="color: #000000">
+<code style="color: #0000BB">&lt;?php
+$test </code><code style="color: #007700">= </code><code style="color: #DD0000">"var"</code><code style="color: #007700">; </code><code style="color: #FF8000">//var
+/* test class */
+</code><code style="color: #007700">class </code><code style="color: #0000BB">test </code><code style="color: #007700">{
+    private </code><code style="color: #0000BB">$var </code><code style="color: #007700">= array();
+
+    public static function </code><code style="color: #0000BB">foo</code><code style="color: #007700">(</code><code style="color: #0000BB">Test $arg</code><code style="color: #007700">) {
+        echo </code><code style="color: #DD0000">"hello"</code><code style="color: #007700">;
+        </code><code style="color: #0000BB">var_dump</code><code style="color: #007700">(</code><code style="color: #0000BB">$this</code><code style="color: #007700">);
+    }
+}
+
+</code><code style="color: #0000BB">$o </code><code style="color: #007700">= new </code><code style="color: #0000BB">test</code><code style="color: #007700">;
+</code><code style="color: #0000BB">?&gt;
+</code></pre>"
 Could not open input file: unknown
 NULL
 Done

--- a/tests/strings/004.phpt
+++ b/tests/strings/004.phpt
@@ -13,5 +13,5 @@ $var = highlight_string("<br /><?php echo \"bar\"; ?><br />", TRUE);
 echo "\n[$var]\n";
 ?>
 --EXPECT--
-<pre style="color: #000000">&lt;br /&gt;<code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"foo"</code><code style="color: #007700">; </code><code style="color: #0000BB">?&gt;</code>&lt;br /&gt;</pre>
-[<pre style="color: #000000">&lt;br /&gt;<code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"bar"</code><code style="color: #007700">; </code><code style="color: #0000BB">?&gt;</code>&lt;br /&gt;</pre>]
+<pre><code style="color: #000000">&lt;br /&gt;<span style="color: #0000BB">&lt;?php </span><span style="color: #007700">echo </span><span style="color: #DD0000">"foo"</span><span style="color: #007700">; </span><span style="color: #0000BB">?&gt;</span>&lt;br /&gt;</code></pre>
+[<pre><code style="color: #000000">&lt;br /&gt;<span style="color: #0000BB">&lt;?php </span><span style="color: #007700">echo </span><span style="color: #DD0000">"bar"</span><span style="color: #007700">; </span><span style="color: #0000BB">?&gt;</span>&lt;br /&gt;</code></pre>]

--- a/tests/strings/004.phpt
+++ b/tests/strings/004.phpt
@@ -13,9 +13,5 @@ $var = highlight_string("<br /><?php echo \"bar\"; ?><br />", TRUE);
 echo "\n[$var]\n";
 ?>
 --EXPECT--
-<code><span style="color: #000000">
-&lt;br&nbsp;/&gt;<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">echo&nbsp;</span><span style="color: #DD0000">"foo"</span><span style="color: #007700">;&nbsp;</span><span style="color: #0000BB">?&gt;</span>&lt;br&nbsp;/&gt;</span>
-</code>
-[<code><span style="color: #000000">
-&lt;br&nbsp;/&gt;<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">echo&nbsp;</span><span style="color: #DD0000">"bar"</span><span style="color: #007700">;&nbsp;</span><span style="color: #0000BB">?&gt;</span>&lt;br&nbsp;/&gt;</span>
-</code>]
+<pre style="color: #000000">&lt;br /&gt;<code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"foo"</code><code style="color: #007700">; </code><code style="color: #0000BB">?&gt;</code>&lt;br /&gt;</pre>
+[<pre style="color: #000000">&lt;br /&gt;<code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"bar"</code><code style="color: #007700">; </code><code style="color: #0000BB">?&gt;</code>&lt;br /&gt;</pre>]

--- a/tests/strings/bug26703.phpt
+++ b/tests/strings/bug26703.phpt
@@ -11,7 +11,4 @@ highlight.html=#000000
     highlight_string('<?php echo "foo[] $a \n"; ?>');
 ?>
 --EXPECT--
-<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;</span><span style="color: #007700">echo&nbsp;</span><span style="color: #DD0000">"foo[]&nbsp;</span><span style="color: #0000BB">$a</span><span style="color: #DD0000">&nbsp;\n"</span><span style="color: #007700">;&nbsp;</span><span style="color: #0000BB">?&gt;</span>
-</span>
-</code>
+<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"foo[] </code><code style="color: #0000BB">$a</code><code style="color: #DD0000"> \n"</code><code style="color: #007700">; </code><code style="color: #0000BB">?&gt;</code></pre>

--- a/tests/strings/bug26703.phpt
+++ b/tests/strings/bug26703.phpt
@@ -11,4 +11,4 @@ highlight.html=#000000
     highlight_string('<?php echo "foo[] $a \n"; ?>');
 ?>
 --EXPECT--
-<pre style="color: #000000"><code style="color: #0000BB">&lt;?php </code><code style="color: #007700">echo </code><code style="color: #DD0000">"foo[] </code><code style="color: #0000BB">$a</code><code style="color: #DD0000"> \n"</code><code style="color: #007700">; </code><code style="color: #0000BB">?&gt;</code></pre>
+<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php </span><span style="color: #007700">echo </span><span style="color: #DD0000">"foo[] </span><span style="color: #0000BB">$a</span><span style="color: #DD0000"> \n"</span><span style="color: #007700">; </span><span style="color: #0000BB">?&gt;</span></code></pre>


### PR DESCRIPTION
See https://github.com/php/phd/pull/79#issuecomment-1669933579

This PR fixes:
- Instead of `<br>` output `\n`
- Instead of `&nbsp;` output ` `
- Instead of `<code>` use `<pre>`
- Instead of `<span>` use `<code>`
- Remove the first enclosing `<code>` (old `<span>`)
- Remove the enclosing newlines