### PR TITLE
Fix GH-11416: Crash with DatePeriod when uninitialised objects are passed in

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -4338,6 +4338,12 @@ PHP_METHOD(DatePeriod, __construct)
 		}
 		dpobj->start_ce = date_ce_date;
 	} else {
+		/* check initialisation */
+		DATE_CHECK_INITIALIZED(Z_PHPDATE_P(start)->time, DateTimeInterface);
+		if (end) {
+			DATE_CHECK_INITIALIZED(Z_PHPDATE_P(end)->time, DateTimeInterface);
+		}
+
 		/* init */
 		php_interval_obj *intobj = Z_PHPINTERVAL_P(interval);
 

--- a/ext/date/tests/bug-gh11416.phpt
+++ b/ext/date/tests/bug-gh11416.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Bug GH-11416: Crash with DatePeriod when uninitialised objects are passed in
+--INI--
+date.timezone=UTC
+--FILE--
+<?php
+$now = new DateTimeImmutable();
+
+$date = (new ReflectionClass(DateTime::class))->newInstanceWithoutConstructor();
+try {
+	new DatePeriod($date, new DateInterval('P1D'), 2);
+} catch (Error $e) {
+	echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+
+$date = (new ReflectionClass(DateTime::class))->newInstanceWithoutConstructor();
+try {
+	new DatePeriod($now, new DateInterval('P1D'), $date);
+} catch (Error $e) {
+	echo get_class($e), ': ', $e->getMessage(), "\n";
+}
+
+echo "OK\n";
+?>
+--EXPECT--
+Error: The DateTimeInterface object has not been correctly initialized by its constructor
+Error: The DateTimeInterface object has not been correctly initialized by its constructor
+OK


### PR DESCRIPTION
Fixes the `DatePeriod` aspect of the issue. The `__unserialize` one needs a different PR as it's PHP 8.2 and up only.