### PR TITLE
Fix error checking in mysqlnd

### DIFF
--- a/ext/mysqlnd/mysqlnd_protocol_frame_codec.c
+++ b/ext/mysqlnd/mysqlnd_protocol_frame_codec.c
@@ -202,6 +202,7 @@ MYSQLND_METHOD(mysqlnd_pfc, send)(MYSQLND_PFC * const pfc, MYSQLND_VIO * const v
 	if (bytes_sent <= 0) {
 		DBG_ERR_FMT("Can't %zu send bytes", count);
 		SET_CLIENT_ERROR(error_info, CR_SERVER_GONE_ERROR, UNKNOWN_SQLSTATE, mysqlnd_server_gone);
+		bytes_sent = 0; // the return type is unsigned and 0 represents an error condition
 	}
 	DBG_RETURN(bytes_sent);
 }


### PR DESCRIPTION
The variable `bytes_sent` is `ssize_t` while the calling applications expect `size_t`. If the socket returns -1 then we overflow our unsigned return type and the calling code doesn't know the command failed. 

I don't know how to write a test case for this. This was discovered thanks to this bug #11897. It definitely fixes a bug when a socket connection drops connection. 