### PR TITLE
Deprecate mysqli_kill

### DIFF
--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -851,10 +851,10 @@ class mysqli
     public function init() {}
 
     /**
-     * @deprecated
      * @tentative-return-type
      * @alias mysqli_kill
      */
+    #[\Deprecated(since: '8.4', message: 'use KILL CONNECTION/QUERY SQL statement instead')]
     public function kill(int $process_id): bool {}
 
     /**
@@ -1506,7 +1506,7 @@ function mysqli_info(mysqli $mysql): ?string {}
 /** @refcount 1 */
 function mysqli_insert_id(mysqli $mysql): int|string {}
 
-/** @deprecated */
+#[\Deprecated(since: '8.4', message: 'use KILL CONNECTION/QUERY SQL statement instead')]
 function mysqli_kill(mysqli $mysql, int $process_id): bool {}
 
 function mysqli_more_results(mysqli $mysql): bool {}

--- a/ext/mysqli/mysqli.stub.php
+++ b/ext/mysqli/mysqli.stub.php
@@ -851,6 +851,7 @@ class mysqli
     public function init() {}
 
     /**
+     * @deprecated
      * @tentative-return-type
      * @alias mysqli_kill
      */
@@ -1505,6 +1506,7 @@ function mysqli_info(mysqli $mysql): ?string {}
 /** @refcount 1 */
 function mysqli_insert_id(mysqli $mysql): int|string {}
 
+/** @deprecated */
 function mysqli_kill(mysqli $mysql, int $process_id): bool {}
 
 function mysqli_more_results(mysqli $mysql): bool {}

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0753cb7bb96af4893bb4f8ba52f16ff985c2fe53 */
+ * Stub hash: 31397bc497dfc1e3c1904d5c816eb601b378257e */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -1171,6 +1171,18 @@ static void register_mysqli_symbols(int module_number)
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_connect", sizeof("mysqli_connect") - 1), 2, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
+	zend_attribute *attribute_Deprecated_func_mysqli_kill_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_kill", sizeof("mysqli_kill") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_mysqli_kill_0_arg0;
+	zend_string *attribute_Deprecated_func_mysqli_kill_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mysqli_kill_0_arg0, attribute_Deprecated_func_mysqli_kill_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mysqli_kill_0->args[0].value, &attribute_Deprecated_func_mysqli_kill_0_arg0);
+	attribute_Deprecated_func_mysqli_kill_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_mysqli_kill_0_arg1;
+	zend_string *attribute_Deprecated_func_mysqli_kill_0_arg1_str = zend_string_init("use KILL CONNECTION/QUERY SQL statement instead", strlen("use KILL CONNECTION/QUERY SQL statement instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_mysqli_kill_0_arg1, attribute_Deprecated_func_mysqli_kill_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_mysqli_kill_0->args[1].value, &attribute_Deprecated_func_mysqli_kill_0_arg1);
+	attribute_Deprecated_func_mysqli_kill_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
 	zend_attribute *attribute_Deprecated_func_mysqli_ping_0 = zend_add_function_attribute(zend_hash_str_find_ptr(CG(function_table), "mysqli_ping", sizeof("mysqli_ping") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
 	zval attribute_Deprecated_func_mysqli_ping_0_arg0;
 	zend_string *attribute_Deprecated_func_mysqli_ping_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
@@ -1378,6 +1390,18 @@ static zend_class_entry *register_class_mysqli(void)
 	ZVAL_STR(&attribute_Deprecated_func_init_0_arg1, attribute_Deprecated_func_init_0_arg1_str);
 	ZVAL_COPY_VALUE(&attribute_Deprecated_func_init_0->args[1].value, &attribute_Deprecated_func_init_0_arg1);
 	attribute_Deprecated_func_init_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
+
+	zend_attribute *attribute_Deprecated_func_kill_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "kill", sizeof("kill") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
+	zval attribute_Deprecated_func_kill_0_arg0;
+	zend_string *attribute_Deprecated_func_kill_0_arg0_str = zend_string_init("8.4", strlen("8.4"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_kill_0_arg0, attribute_Deprecated_func_kill_0_arg0_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_kill_0->args[0].value, &attribute_Deprecated_func_kill_0_arg0);
+	attribute_Deprecated_func_kill_0->args[0].name = ZSTR_KNOWN(ZEND_STR_SINCE);
+	zval attribute_Deprecated_func_kill_0_arg1;
+	zend_string *attribute_Deprecated_func_kill_0_arg1_str = zend_string_init("use KILL CONNECTION/QUERY SQL statement instead", strlen("use KILL CONNECTION/QUERY SQL statement instead"), 1);
+	ZVAL_STR(&attribute_Deprecated_func_kill_0_arg1, attribute_Deprecated_func_kill_0_arg1_str);
+	ZVAL_COPY_VALUE(&attribute_Deprecated_func_kill_0->args[1].value, &attribute_Deprecated_func_kill_0_arg1);
+	attribute_Deprecated_func_kill_0->args[1].name = ZSTR_KNOWN(ZEND_STR_MESSAGE);
 
 	zend_attribute *attribute_Deprecated_func_ping_0 = zend_add_function_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "ping", sizeof("ping") - 1), ZSTR_KNOWN(ZEND_STR_DEPRECATED), 2);
 	zval attribute_Deprecated_func_ping_0_arg0;

--- a/ext/mysqli/mysqli_arginfo.h
+++ b/ext/mysqli/mysqli_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 97775c6aba92e347f93a2d38cd41c4769eed738f */
+ * Stub hash: 0753cb7bb96af4893bb4f8ba52f16ff985c2fe53 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_mysqli_affected_rows, 0, 1, MAY_BE_LONG|MAY_BE_STRING)
 	ZEND_ARG_OBJ_INFO(0, mysql, mysqli, 0)
@@ -867,7 +867,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(mysqli_init, arginfo_mysqli_init)
 	ZEND_FE(mysqli_info, arginfo_mysqli_info)
 	ZEND_FE(mysqli_insert_id, arginfo_mysqli_insert_id)
-	ZEND_FE(mysqli_kill, arginfo_mysqli_kill)
+	ZEND_RAW_FENTRY("mysqli_kill", zif_mysqli_kill, arginfo_mysqli_kill, ZEND_ACC_DEPRECATED, NULL, NULL)
 	ZEND_FE(mysqli_more_results, arginfo_mysqli_more_results)
 	ZEND_FE(mysqli_multi_query, arginfo_mysqli_multi_query)
 	ZEND_FE(mysqli_next_result, arginfo_mysqli_next_result)
@@ -951,7 +951,7 @@ static const zend_function_entry class_mysqli_methods[] = {
 	ZEND_RAW_FENTRY("get_server_info", zif_mysqli_get_server_info, arginfo_class_mysqli_get_server_info, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("get_warnings", zif_mysqli_get_warnings, arginfo_class_mysqli_get_warnings, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_ME(mysqli, init, arginfo_class_mysqli_init, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
-	ZEND_RAW_FENTRY("kill", zif_mysqli_kill, arginfo_class_mysqli_kill, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_RAW_FENTRY("kill", zif_mysqli_kill, arginfo_class_mysqli_kill, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED, NULL, NULL)
 	ZEND_RAW_FENTRY("multi_query", zif_mysqli_multi_query, arginfo_class_mysqli_multi_query, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("more_results", zif_mysqli_more_results, arginfo_class_mysqli_more_results, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("next_result", zif_mysqli_next_result, arginfo_class_mysqli_next_result, ZEND_ACC_PUBLIC, NULL, NULL)

--- a/ext/mysqli/tests/071.phpt
+++ b/ext/mysqli/tests/071.phpt
@@ -38,9 +38,13 @@ require_once 'skipifconnectfailure.inc';
     $mysql->close();
     print "done!";
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
+
+Deprecated: Method mysqli::kill() is deprecated in %s
 bool(false)
 bool(true)
+
+Deprecated: Method mysqli::kill() is deprecated in %s
 bool(false)
 done!

--- a/ext/mysqli/tests/071.phpt
+++ b/ext/mysqli/tests/071.phpt
@@ -41,10 +41,10 @@ require_once 'skipifconnectfailure.inc';
 --EXPECTF--
 bool(true)
 
-Deprecated: Method mysqli::kill() is deprecated in %s
+Deprecated: Method mysqli::kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 bool(false)
 bool(true)
 
-Deprecated: Method mysqli::kill() is deprecated in %s
+Deprecated: Method mysqli::kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 bool(false)
 done!

--- a/ext/mysqli/tests/mysqli_kill.phpt
+++ b/ext/mysqli/tests/mysqli_kill.phpt
@@ -73,10 +73,10 @@ require_once 'skipifconnectfailure.inc';
 ?>
 --EXPECTF--
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 string(%d) "%s"
 bool(false)
 object(mysqli)#%d (%d) {
@@ -128,13 +128,13 @@ object(mysqli)#%d (%d) {
   int(0)
 }
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 array(1) {
   ["id"]=>
   string(1) "1"
 }
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 done!

--- a/ext/mysqli/tests/mysqli_kill.phpt
+++ b/ext/mysqli/tests/mysqli_kill.phpt
@@ -72,7 +72,11 @@ require_once 'skipifconnectfailure.inc';
     require_once 'clean_table.inc';
 ?>
 --EXPECTF--
+
+Deprecated: Function mysqli_kill() is deprecated in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
+
+Deprecated: Function mysqli_kill() is deprecated in %s
 string(%d) "%s"
 bool(false)
 object(mysqli)#%d (%d) {
@@ -123,10 +127,14 @@ object(mysqli)#%d (%d) {
   ["warning_count"]=>
   int(0)
 }
+
+Deprecated: Function mysqli_kill() is deprecated in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 array(1) {
   ["id"]=>
   string(1) "1"
 }
+
+Deprecated: Function mysqli_kill() is deprecated in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 done!

--- a/ext/mysqli/tests/mysqli_poll_kill.phpt
+++ b/ext/mysqli/tests/mysqli_poll_kill.phpt
@@ -27,7 +27,7 @@ require_once 'skipifconnectfailure.inc';
     // Sleep 0.1s - the asynchronous query should have been processed after the wait period
     usleep(100000);
     $thread_id = mysqli_thread_id($link);
-    mysqli_kill(get_connection(), $thread_id);
+    get_connection()->query('KILL '.$thread_id);
 
     $links = array($link);
     $errors = array($link);
@@ -82,7 +82,7 @@ require_once 'skipifconnectfailure.inc';
 
     usleep(100000);
     $thread_id = mysqli_thread_id($link);
-    mysqli_kill(get_connection(), $thread_id);
+    get_connection()->query('KILL '.$thread_id);
 
     // Yes, 1 - fetch OK packet of kill!
     $processed = 0;
@@ -140,7 +140,7 @@ require_once 'skipifconnectfailure.inc';
 
     $link = get_connection();
     $thread_id = mysqli_thread_id($link);
-    mysqli_kill(get_connection(), $thread_id);
+    get_connection()->query('KILL '.$thread_id);
     // Sleep 0.1s  to ensure the KILL gets recognized
     usleep(100000);
     if (false !== ($tmp = mysqli_query($link, "SELECT 1 AS 'processed before killed'", MYSQLI_ASYNC |  MYSQLI_USE_RESULT)))

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -315,7 +315,7 @@ Warning: mysqli_multi_query(): (%d/%d): You have an error in your SQL syntax; ch
 
 Warning: mysqli_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
@@ -336,16 +336,16 @@ Warning: mysqli_store_result(): (%s/%d): You have an error in your SQL syntax; c
 
 Warning: mysqli_stmt_attr_set(): (%s/%d): Not implemented in %s on line %d
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_stmt_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 
-Deprecated: Function mysqli_kill() is deprecated in %s
+Deprecated: Function mysqli_kill() is deprecated since 8.4, use KILL CONNECTION/QUERY SQL statement instead in %s
 [013] Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
 [016] Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
 done!

--- a/ext/mysqli/tests/mysqli_report.phpt
+++ b/ext/mysqli/tests/mysqli_report.phpt
@@ -314,6 +314,8 @@ require_once 'clean_table.inc';
 Warning: mysqli_multi_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'BAR; FOO' at line 1 in %s on line %d
 
 Warning: mysqli_query(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
+
+Deprecated: Function mysqli_kill() is deprecated in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
@@ -333,9 +335,17 @@ Warning: mysqli_next_result(): (%s/%d): You have an error in your SQL syntax; ch
 Warning: mysqli_store_result(): (%s/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
 
 Warning: mysqli_stmt_attr_set(): (%s/%d): Not implemented in %s on line %d
+
+Deprecated: Function mysqli_kill() is deprecated in %s
 mysqli_kill(): Argument #2 ($process_id) must be greater than 0
 
 Warning: mysqli_stmt_prepare(): (%d/%d): You have an error in your SQL syntax; check the manual that corresponds to your %s server version for the right syntax to use near 'FOO' at line 1 in %s on line %d
+
+Deprecated: Function mysqli_kill() is deprecated in %s
+
+Deprecated: Function mysqli_kill() is deprecated in %s
+
+Deprecated: Function mysqli_kill() is deprecated in %s
 [013] Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
 [016] Access denied for user '%s'@'%s'%r( \(using password: \w+\)){0,1}%r
 done!

--- a/ext/mysqli/tests/mysqli_stmt_close.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_close.phpt
@@ -46,7 +46,7 @@ require_once 'skipifconnectfailure.inc';
     if (!mysqli_stmt_execute($stmt))
         printf("[011] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
-    mysqli_kill($link, mysqli_thread_id($link));
+    $link->query('KILL '.mysqli_thread_id($link));
 
     if (true !== ($tmp = mysqli_stmt_close($stmt)))
         printf("[012] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);
@@ -67,7 +67,7 @@ require_once 'skipifconnectfailure.inc';
     if (!mysqli_stmt_execute($stmt) || !mysqli_stmt_fetch($stmt))
         printf("[016] [%d] %s\n", mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
-    mysqli_kill($link, mysqli_thread_id($link));
+    $link->query('KILL '.mysqli_thread_id($link));
 
     if (true !== ($tmp = mysqli_stmt_close($stmt)))
         printf("[017] Expecting boolean/true, got %s/%s\n", gettype($tmp), $tmp);

--- a/ext/mysqli/tests/mysqli_stmt_errno.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_errno.phpt
@@ -31,7 +31,7 @@ require_once 'skipifconnectfailure.inc';
     if (0 != ($tmp = mysqli_stmt_errno($stmt)))
         printf("[008] Expecting zero, got %s/%s\n", gettype($tmp), $tmp);
 
-    mysqli_kill($link, mysqli_thread_id($link));
+    $link->query('KILL '.mysqli_thread_id($link));
 
     if (true === ($tmp = mysqli_stmt_execute($stmt)))
         printf("[009] Expecting boolean/false, got %s/%s\n", gettype($tmp), $tmp);

--- a/ext/mysqli/tests/mysqli_stmt_error.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_error.phpt
@@ -31,7 +31,7 @@ require_once 'skipifconnectfailure.inc';
     if ('' !== ($tmp = mysqli_stmt_error($stmt)))
         printf("[008] Expecting empty string, got %s/%s\n", gettype($tmp), $tmp);
 
-    mysqli_kill($link, mysqli_thread_id($link));
+    $link->query('KILL '.mysqli_thread_id($link));
 
     if (true === ($tmp = mysqli_stmt_execute($stmt)))
         printf("[009] Expecting boolean/false, got %s/%s\n", gettype($tmp), $tmp);

--- a/ext/mysqli/tests/mysqli_stmt_execute.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_execute.phpt
@@ -108,7 +108,7 @@ require_once 'skipifconnectfailure.inc';
     var_dump(mysqli_stmt_execute($stmt));
     var_dump(mysqli_stmt_fetch($stmt));
 
-    mysqli_kill($link, mysqli_thread_id($link));
+    $link->query('KILL '.mysqli_thread_id($link));
 
     if (false !== ($tmp = mysqli_stmt_execute($stmt)))
         printf("[027] Expecting boolean/false, got %s/%s\n", gettype($tmp), $tmp);

--- a/ext/mysqli/tests/mysqli_stmt_fetch.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_fetch.phpt
@@ -57,7 +57,7 @@ require_once 'skipifconnectfailure.inc';
         printf("[013] Expecting boolean/true, got %s/%s, [%d] %s\n",
             gettype($tmp), $tmp, mysqli_stmt_errno($stmt), mysqli_stmt_error($stmt));
 
-    if (!mysqli_kill($link, mysqli_thread_id($link)))
+    if (!$link->query('KILL '.mysqli_thread_id($link)))
         printf("[014] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
     if (true !== ($tmp = mysqli_stmt_fetch($stmt)))

--- a/ext/mysqli/tests/mysqli_stmt_get_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result.phpt
@@ -154,7 +154,7 @@ require_once 'skipifconnectfailure.inc';
     mysqli_free_result($result);
 
     $link->real_query('KILL '.mysqli_thread_id($link));
-    // We kill out own connecton so we should get "Query execution was interrupted"
+    // We kill our own connection so we should get "Query execution was interrupted"
 	if ($link->errno !== 1317)
 		printf("[042] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 

--- a/ext/mysqli/tests/mysqli_stmt_get_result.phpt
+++ b/ext/mysqli/tests/mysqli_stmt_get_result.phpt
@@ -153,7 +153,9 @@ require_once 'skipifconnectfailure.inc';
     }
     mysqli_free_result($result);
 
-	if (!mysqli_kill($link, mysqli_thread_id($link)))
+    $link->real_query('KILL '.mysqli_thread_id($link));
+    // We kill out own connecton so we should get "Query execution was interrupted"
+	if ($link->errno !== 1317)
 		printf("[042] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
 
 	if (false !== ($tmp = mysqli_stmt_get_result($stmt)))

--- a/ext/mysqli/tests/mysqli_thread_id.phpt
+++ b/ext/mysqli/tests/mysqli_thread_id.phpt
@@ -20,8 +20,11 @@ require_once 'skipifconnectfailure.inc';
             gettype($tmp), $tmp, mysqli_errno($link), mysqli_error($link));
 
     // should work if the thread id is correct
-    mysqli_kill($link, mysqli_thread_id($link));
-
+    $link->real_query('KILL '.mysqli_thread_id($link));
+    // We kill out own connecton so we should get "Query execution was interrupted"
+	if ($link->errno !== 1317)
+		printf("[042] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
+    
     mysqli_close($link);
 
     try {

--- a/ext/mysqli/tests/mysqli_thread_id.phpt
+++ b/ext/mysqli/tests/mysqli_thread_id.phpt
@@ -21,7 +21,7 @@ require_once 'skipifconnectfailure.inc';
 
     // should work if the thread id is correct
     $link->real_query('KILL '.mysqli_thread_id($link));
-    // We kill out own connecton so we should get "Query execution was interrupted"
+    // We kill our own connection so we should get "Query execution was interrupted"
 	if ($link->errno !== 1317)
 		printf("[042] [%d] %s\n", mysqli_errno($link), mysqli_error($link));
     


### PR DESCRIPTION
MySQL 5.7 has deprecated `COM_PROCESS_KILL` which is used under the hood by mysqli. See:
- https://dev.mysql.com/worklog/task/?id=8754
- https://dev.mysql.com/doc/c-api/8.0/en/mysql-kill.html
- https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_process_kill.html

I understand it may be controversial for PHP, but we shouldn't support commands that are deprecated in MySQL. The only problem with this is that the way that PHP tests used this function is actually problematic. When we use `mysqli_kill` to kill our own process there's no error, but when we use SQL `KILL` then we get an error about aborted query. It makes sense, but creates a problematic upgrade path. Not sure if there's a way to deal with this. 

We could emulate that command in mysqlnd, but that's an undesirable solution.