### PR TITLE
Don't try to use C11 atomics, which are not const

### DIFF
--- a/Zend/zend_atomic.h
+++ b/Zend/zend_atomic.h
@@ -23,8 +23,8 @@
 	((__GNUC__ == (x) && __GNUC_MINOR__ >= (y)) || (__GNUC__ > (x)))
 
 /* Builtins are used to avoid library linkage */
-#if __has_feature(c_atomic)
-#define	HAVE_C11_ATOMICS 1
+#if __has_feature(c_atomic) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201710L
+#define	HAVE_C17_ATOMICS 1
 #elif ZEND_GCC_PREREQ(4, 7)
 #define	HAVE_GNUC_ATOMICS 1
 #elif defined(__GNUC__)
@@ -43,7 +43,7 @@
 typedef struct zend_atomic_bool_s {
 	volatile char value;
 } zend_atomic_bool;
-#elif defined(HAVE_C11_ATOMICS)
+#elif defined(HAVE_C17_ATOMICS)
 typedef struct zend_atomic_bool_s {
 	_Atomic(bool) value;
 } zend_atomic_bool;
@@ -80,7 +80,7 @@ static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, 
 	(void)InterlockedExchange8(&obj->value, desired);
 }
 
-#elif defined(HAVE_C11_ATOMICS)
+#elif defined(HAVE_C17_ATOMICS)
 
 #define ZEND_ATOMIC_BOOL_INIT(obj, desired) __c11_atomic_init(&(obj)->value, (desired))
 


### PR DESCRIPTION
[C11 did not have](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1807.htm) the `const` qualifier on `atomic_load`; C17 does. One can either use C11 atomics by casting away the `const`ness, which was proposed and rejected in GH-8764, or one can avoid using C11 atomics altogether, instead using C17 atomics if available, which is what this change does.

Fixes GH-8881

-----

This issue only affects the PHP 8.2 and later branches.

This issue only affects compilers in C11 mode that do not support C17. Compilers that do support C17 behave as though the `const` qualifier was present even when in C11 mode. It might only affect clang.

-----

I'm not sure if I've written a satisfactory commit message. If not, feel free to reword it or let me know what needs to be changed.