### PR TITLE
Fix segfault in format_default_value due to unexpected enum/object

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1468,7 +1468,7 @@ static bool can_ct_eval_const(zend_constant *c) {
 				&& (CG(compiler_options) & ZEND_COMPILE_WITH_FILE_CACHE))) {
 		return 1;
 	}
-	if (Z_TYPE(c->value) < IS_OBJECT
+	if (Z_TYPE(c->value) < IS_ARRAY
 			&& !(CG(compiler_options) & ZEND_COMPILE_NO_CONSTANT_SUBSTITUTION)) {
 		return 1;
 	}
@@ -1690,7 +1690,7 @@ static bool zend_try_ct_eval_class_const(zval *zv, zend_string *class_name, zend
 	c = &cc->value;
 
 	/* Substitute case-sensitive (or lowercase) persistent class constants */
-	if (Z_TYPE_P(c) < IS_OBJECT) {
+	if (Z_TYPE_P(c) < IS_ARRAY) {
 		ZVAL_COPY_OR_DUP(zv, c);
 		return 1;
 	}

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1458,6 +1458,33 @@ ZEND_API zend_result zend_unmangle_property_name_ex(const zend_string *name, con
 }
 /* }}} */
 
+static bool array_is_const_ex(zend_array *array, uint32_t *max_checks)
+{
+	if (zend_hash_num_elements(array) > *max_checks) {
+		return false;
+	}
+	*max_checks -= zend_hash_num_elements(array);
+
+	zval *element;
+	ZEND_HASH_FOREACH_VAL(array, element) {
+		if (Z_TYPE_P(element) == IS_ARRAY) {
+			if (!array_is_const_ex(array, max_checks)) {
+				return false;
+			}
+		} else if (UNEXPECTED(Z_TYPE_P(element) == IS_OBJECT)) {
+			return false;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	return true;
+}
+
+static bool array_is_const(zend_array *array)
+{
+	uint32_t max_checks = 50;
+	return array_is_const_ex(array, &max_checks);
+}
+
 static bool can_ct_eval_const(zend_constant *c) {
 	if (ZEND_CONSTANT_FLAGS(c) & CONST_DEPRECATED) {
 		return 0;
@@ -1470,6 +1497,10 @@ static bool can_ct_eval_const(zend_constant *c) {
 	}
 	if (Z_TYPE(c->value) < IS_ARRAY
 			&& !(CG(compiler_options) & ZEND_COMPILE_NO_CONSTANT_SUBSTITUTION)) {
+		return 1;
+	} else if (Z_TYPE(c->value) == IS_ARRAY
+			&& !(CG(compiler_options) & ZEND_COMPILE_NO_CONSTANT_SUBSTITUTION)
+			&& array_is_const(Z_ARR(c->value))) {
 		return 1;
 	}
 	return 0;
@@ -1691,6 +1722,9 @@ static bool zend_try_ct_eval_class_const(zval *zv, zend_string *class_name, zend
 
 	/* Substitute case-sensitive (or lowercase) persistent class constants */
 	if (Z_TYPE_P(c) < IS_ARRAY) {
+		ZVAL_COPY_OR_DUP(zv, c);
+		return 1;
+	} else if (Z_TYPE_P(c) == IS_ARRAY && array_is_const(Z_ARR_P(c))) {
 		ZVAL_COPY_OR_DUP(zv, c);
 		return 1;
 	}

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -639,6 +639,7 @@ static int format_default_value(smart_str *str, zval *value) {
 		} ZEND_HASH_FOREACH_END();
 		smart_str_appendc(str, ']');
 	} else if (Z_TYPE_P(value) == IS_OBJECT) {
+		/* This branch may only be reached for default properties, which don't support arbitrary objects. */
 		zend_object *obj = Z_OBJ_P(value);
 		zend_class_entry *class = obj->ce;
 		ZEND_ASSERT(class->ce_flags & ZEND_ACC_ENUM);

--- a/ext/reflection/tests/gh11937_1.inc
+++ b/ext/reflection/tests/gh11937_1.inc
@@ -1,0 +1,13 @@
+<?php
+
+#[Attribute]
+class Attr {
+    public function __construct(public $value) {}
+}
+
+class Foo {
+    public function __construct(public $value) {}
+}
+
+#[Attr(new Foo(TestEnum::CASES))]
+function test() {}

--- a/ext/reflection/tests/gh11937_1.phpt
+++ b/ext/reflection/tests/gh11937_1.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-11937: Segfault in format_default_value due to unexpected enum/object
+--FILE--
+<?php
+
+enum TestEnum {
+    case One;
+    case Two;
+    const CASES = [self::One, self::Two];
+}
+
+var_dump(TestEnum::CASES);
+
+require __DIR__ . '/gh11937_1.inc';
+
+echo (new ReflectionFunction('test'))->getAttributes('Attr')[0];
+
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  enum(TestEnum::One)
+  [1]=>
+  enum(TestEnum::Two)
+}
+Attribute [ Attr ] {
+  - Arguments [1] {
+    Argument #0 [ new \Foo(TestEnum::CASES) ]
+  }
+}

--- a/ext/reflection/tests/gh11937_2.inc
+++ b/ext/reflection/tests/gh11937_2.inc
@@ -1,0 +1,4 @@
+<?php
+
+#[Attr(FOOS)]
+function test() {}

--- a/ext/reflection/tests/gh11937_2.phpt
+++ b/ext/reflection/tests/gh11937_2.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-11937: Segfault in format_default_value due to unexpected enum/object
+--FILE--
+<?php
+
+class Foo {}
+
+const FOOS = [new Foo()];
+
+var_dump(FOOS);
+
+require __DIR__ . '/gh11937_2.inc';
+
+echo (new ReflectionFunction('test'))->getAttributes('Attr')[0];
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  object(Foo)#1 (0) {
+  }
+}
+Attribute [ Attr ] {
+  - Arguments [1] {
+    Argument #0 [ FOOS ]
+  }
+}


### PR DESCRIPTION
Evaluating constants at comptime can result in arrays that contain objects. This is problematic for printing the default value of constant ASTs containing objects, because we don't actually know what the constructor arguments were. Avoid this by not propagating array constants.

I will need to check whether this leads to a performance regression.

Fixes GH-11937