### PR TITLE
Fix GH-11874: intl causing segfault with temporaries

### DIFF
--- a/ext/intl/breakiterator/breakiterator_iterators.cpp
+++ b/ext/intl/breakiterator/breakiterator_iterators.cpp
@@ -231,7 +231,7 @@ void IntlIterator_from_BreakIterator_parts(zval *break_iter_zv,
 	ii->iterator->index = 0;
 
 	((zoi_with_current*)ii->iterator)->destroy_it = _breakiterator_parts_destroy_it;
-	ZVAL_OBJ(&((zoi_with_current*)ii->iterator)->wrapping_obj, Z_OBJ_P(object));
+	ZVAL_UNDEF(&((zoi_with_current*)ii->iterator)->wrapping_obj);
 	ZVAL_UNDEF(&((zoi_with_current*)ii->iterator)->current);
 
 	((zoi_break_iter_parts*)ii->iterator)->bio = Z_INTL_BREAKITERATOR_P(break_iter_zv);

--- a/ext/intl/common/common_enum.cpp
+++ b/ext/intl/common/common_enum.cpp
@@ -115,10 +115,6 @@ static void string_enum_rewind(zend_object_iterator *iter)
 static void string_enum_destroy_it(zend_object_iterator *iter)
 {
 	delete (StringEnumeration*)Z_PTR(iter->data);
-
-	/* Destroy reference created in IntlIterator_get_iterator()
-	 * This isn't the last reference, the last one will be destroyed in IntlIterator_objects_free() */
-	zend_iterator_dtor(iter);
 }
 
 static const zend_object_iterator_funcs string_enum_object_iterator_funcs = {
@@ -152,7 +148,6 @@ static void IntlIterator_objects_free(zend_object *object)
 	IntlIterator_object	*ii = php_intl_iterator_fetch_object(object);
 
 	if (ii->iterator) {
-		/* Destroy reference created in IntlIterator_from_StringEnumeration() */
 		zend_iterator_dtor(ii->iterator);
 	}
 	intl_error_reset(INTLITERATOR_ERROR_P(ii));

--- a/ext/intl/common/common_enum.cpp
+++ b/ext/intl/common/common_enum.cpp
@@ -37,23 +37,14 @@ void zoi_with_current_dtor(zend_object_iterator *iter)
 	zoi_with_current *zoiwc = (zoi_with_current*)iter;
 
 	if (!Z_ISUNDEF(zoiwc->wrapping_obj)) {
-		/* we have to copy the pointer because zoiwc->wrapping_obj may be
-		 * changed midway the execution of zval_ptr_dtor() */
+		/* Destroy reference created in IntlIterator_from_StringEnumeration() */
 		zval *zwo = &zoiwc->wrapping_obj;
-
-		/* object is still here, we can rely on it to call this again and
-		 * destroy this object */
 		zval_ptr_dtor(zwo);
-	} else {
-		/* Object not here anymore (we've been called by the object free handler)
-		 * Note that the iterator wrapper objects (that also depend on this
-		 * structure) call this function earlier, in the destruction phase, which
-		 * precedes the object free phase. Therefore there's no risk on this
-		 * function being called by the iterator wrapper destructor function and
-		 * not finding the memory of this iterator allocated anymore. */
-		iter->funcs->invalidate_current(iter);
-		zoiwc->destroy_it(iter);
+		ZVAL_UNDEF(zwo); /* defensive programming */
 	}
+
+	iter->funcs->invalidate_current(iter);
+	zoiwc->destroy_it(iter);
 }
 
 U_CFUNC int zoi_with_current_valid(zend_object_iterator *iter)
@@ -124,6 +115,10 @@ static void string_enum_rewind(zend_object_iterator *iter)
 static void string_enum_destroy_it(zend_object_iterator *iter)
 {
 	delete (StringEnumeration*)Z_PTR(iter->data);
+
+	/* Destroy reference created in IntlIterator_get_iterator()
+	 * This isn't the last reference, the last one will be destroyed in IntlIterator_objects_free() */
+	zend_iterator_dtor(iter);
 }
 
 static const zend_object_iterator_funcs string_enum_object_iterator_funcs = {
@@ -148,7 +143,7 @@ U_CFUNC void IntlIterator_from_StringEnumeration(StringEnumeration *se, zval *ob
 	ii->iterator->funcs = &string_enum_object_iterator_funcs;
 	ii->iterator->index = 0;
 	((zoi_with_current*)ii->iterator)->destroy_it = string_enum_destroy_it;
-	ZVAL_OBJ(&((zoi_with_current*)ii->iterator)->wrapping_obj, Z_OBJ_P(object));
+	ZVAL_OBJ_COPY(&((zoi_with_current*)ii->iterator)->wrapping_obj, Z_OBJ_P(object));
 	ZVAL_UNDEF(&((zoi_with_current*)ii->iterator)->current);
 }
 
@@ -157,8 +152,7 @@ static void IntlIterator_objects_free(zend_object *object)
 	IntlIterator_object	*ii = php_intl_iterator_fetch_object(object);
 
 	if (ii->iterator) {
-		zval *wrapping_objp = &((zoi_with_current*)ii->iterator)->wrapping_obj;
-		ZVAL_UNDEF(wrapping_objp);
+		/* Destroy reference created in IntlIterator_from_StringEnumeration() */
 		zend_iterator_dtor(ii->iterator);
 	}
 	intl_error_reset(INTLITERATOR_ERROR_P(ii));

--- a/ext/intl/tests/gh11874.phpt
+++ b/ext/intl/tests/gh11874.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-11874 (intl causing segfault with temporaries)
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+foreach (IntlCalendar::getKeywordValuesForLocale('calendar', 'fa_IR', true) as $id) {
+	$id;
+}
+
+foreach(IntlTimeZone::createTimeZoneIDEnumeration(IntlTimeZone::TYPE_ANY) as $id) {
+	$id;
+}
+
+?>
+Done
+--EXPECT--
+Done


### PR DESCRIPTION
The segfault happens because zoi->wrapping_obj points to an object that has been freed. This wrapping_obj is set in
IntlIterator_from_StringEnumeration(). Notice how the refcount is not increased in this function. By switching to ZVAL_OBJ_COPY, the segfault disappears. However, now we get memleaks.

The reason we get a memleak is because now we're responsible for destroying the reference copy we made with ZVAL_OBJ_COPY. It would appear this would already be done in zoi_with_current_dtor. This did work in the past for CVs because the live variable cleanup when the CV gets destroyed would set the object to UNDEF.

To add more confusion:
The zoi_with_current_dtor() comments seem to indicate that it can be called twice. However, that seems to be _not_ the case as it's the dtor for zend_object_iterator_funcs.

This patch reworks how the destruction works in addition to the ZVAL_OBJ_COPY change.

I checked other of wrapping_obj. The only other place is in BreakIterator. BreakIterator doesn't actually use the wrapping_obj for anything however, and doesn't manage that refcount, so set it to UNDEF to be safe.

-------

I'm not 100% confident in this patch, I haven't worked a lot with the intl extension before.