### PR TITLE
Fix #81992: SplFixedArray::setSize() causes use-after-free

### DIFF
--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -150,7 +150,13 @@ static void spl_fixedarray_dtor_range(spl_fixedarray *array, zend_long from, zen
 {
 	zval *begin = array->elements + from, *end = array->elements + to;
 	while (begin != end) {
-		zval_ptr_dtor(begin++);
+		if (Z_REFCOUNTED_P(begin)) {
+			/* Using inline variant to get rid of the redundant check */
+			i_zval_ptr_dtor(begin);
+			/* Get rid of the dangling zval, there might be a destructor or error handling accessing the array */
+			ZVAL_NULL(begin);
+		}
+		begin++;
 	}
 }
 

--- a/ext/spl/spl_fixedarray.c
+++ b/ext/spl/spl_fixedarray.c
@@ -46,6 +46,8 @@ typedef struct _spl_fixedarray {
 	zval *elements;
 	/* True if this was modified after the last call to get_properties or the hash table wasn't rebuilt. */
 	bool                 should_rebuild_properties;
+	/* If positive, it's a resize within a resize and the value gives the desired size. If -1, it's not. */
+	zend_long cached_resize;
 } spl_fixedarray;
 
 typedef struct _spl_fixedarray_methods {
@@ -117,6 +119,7 @@ static void spl_fixedarray_init(spl_fixedarray *array, zend_long size)
 	} else {
 		spl_fixedarray_default_ctor(array);
 	}
+	array->cached_resize = -1;
 }
 
 /* Copies the range [begin, end) into the fixedarray, beginning at `offset`.
@@ -185,6 +188,14 @@ static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size)
 		return;
 	}
 
+	if (UNEXPECTED(array->cached_resize >= 0)) {
+		/* We're already resizing, so just remember the desired size.
+		 * The resize will happen later. */
+		array->cached_resize = size;
+		return;
+	}
+	array->cached_resize = size;
+
 	/* clearing the array */
 	if (size == 0) {
 		spl_fixedarray_dtor(array);
@@ -195,8 +206,16 @@ static void spl_fixedarray_resize(spl_fixedarray *array, zend_long size)
 		spl_fixedarray_init_elems(array, array->size, size);
 		array->size = size;
 	} else { /* size < array->size */
+		/* Size set in spl_fixedarray_dtor_range() */
 		spl_fixedarray_dtor_range(array, size, array->size);
 		array->elements = erealloc(array->elements, sizeof(zval) * size);
+	}
+
+	/* If resized within the destructor, take the last resize command and perform it */
+	zend_long cached_resize = array->cached_resize;
+	array->cached_resize = -1;
+	if (cached_resize != size) {
+		spl_fixedarray_resize(array, cached_resize);
 	}
 }
 

--- a/ext/spl/tests/bug81992.phpt
+++ b/ext/spl/tests/bug81992.phpt
@@ -5,16 +5,28 @@ Bug #81992 (SplFixedArray::setSize() causes use-after-free)
 class InvalidDestructor {
     public function __destruct() {
         global $obj;
-        var_dump($obj[2], $obj[4]);
+        var_dump($obj[0]);
+        try {
+            var_dump($obj[2]);
+        } catch (Throwable $e) {
+            echo $e->getMessage(), "\n";
+        }
+        try {
+            var_dump($obj[4]);
+        } catch (Throwable $e) {
+            echo $e->getMessage(), "\n";
+        }
     }
 }
 
 $obj = new SplFixedArray(5);
+$obj[0] = str_repeat("A", 10);
 $obj[2] = str_repeat('B', 10);
 $obj[3] = new InvalidDestructor();
 $obj[4] = str_repeat('C', 10);
 $obj->setSize(2);
 ?>
 --EXPECT--
-NULL
-string(10) "CCCCCCCCCC"
+string(10) "AAAAAAAAAA"
+Index invalid or out of range
+Index invalid or out of range

--- a/ext/spl/tests/bug81992.phpt
+++ b/ext/spl/tests/bug81992.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #81992 (SplFixedArray::setSize() causes use-after-free)
+--FILE--
+<?php
+class InvalidDestructor {
+    public function __destruct() {
+        global $obj;
+        var_dump($obj[2], $obj[4]);
+    }
+}
+
+$obj = new SplFixedArray(5);
+$obj[2] = str_repeat('B', 10);
+$obj[3] = new InvalidDestructor();
+$obj[4] = str_repeat('C', 10);
+$obj->setSize(2);
+?>
+--EXPECT--
+NULL
+string(10) "CCCCCCCCCC"

--- a/ext/spl/tests/bug81992b.phpt
+++ b/ext/spl/tests/bug81992b.phpt
@@ -3,21 +3,64 @@ Bug #81992 (SplFixedArray::setSize() causes use-after-free) - setSize variation
 --FILE--
 <?php
 class InvalidDestructor {
+    public function __construct(
+        private int $desiredSize,
+        private SplFixedArray $obj,
+    ) {}
+
     public function __destruct() {
-        global $obj;
-        $obj->setSize(1);
-        echo "Destroyed\n";
+        echo "In destructor\n";
+        $this->obj->setSize($this->desiredSize);
+        echo "Destroyed, size is now still ", $this->obj->getSize(), "\n";
     }
 }
 
-$obj = new SplFixedArray(5);
-$obj[0] = str_repeat("A", 10);
-$obj[2] = str_repeat('B', 10);
-$obj[3] = new InvalidDestructor();
-$obj[4] = str_repeat('C', 10);
-$obj->setSize(2);
-echo "Done\n";
+class DestructorLogger {
+    public function __construct(private int $id) {}
+
+    public function __destruct() {
+        echo "Destroyed the logger with id ", $this->id, "\n";
+    }
+}
+
+function test(int $desiredSize) {
+    $obj = new SplFixedArray(5);
+    $obj[0] = str_repeat("A", 10);
+    $obj[1] = new DestructorLogger(1);
+    $obj[2] = str_repeat('B', 10);
+    $obj[3] = new InvalidDestructor($desiredSize, $obj);
+    $obj[4] = new DestructorLogger(4);
+    $obj->setSize(2);
+    echo "Size is now ", $obj->getSize(), "\n";
+    echo "Done\n";
+}
+
+echo "--- Smaller size test ---\n";
+test(1);
+echo "--- Equal size test ---\n";
+test(2);
+echo "--- Larger size test ---\n";
+test(10);
 ?>
 --EXPECT--
-Destroyed
+--- Smaller size test ---
+In destructor
+Destroyed, size is now still 2
+Destroyed the logger with id 4
+Destroyed the logger with id 1
+Size is now 1
 Done
+--- Equal size test ---
+In destructor
+Destroyed, size is now still 2
+Destroyed the logger with id 4
+Size is now 2
+Done
+Destroyed the logger with id 1
+--- Larger size test ---
+In destructor
+Destroyed, size is now still 2
+Destroyed the logger with id 4
+Size is now 10
+Done
+Destroyed the logger with id 1

--- a/ext/spl/tests/bug81992b.phpt
+++ b/ext/spl/tests/bug81992b.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Bug #81992 (SplFixedArray::setSize() causes use-after-free) - setSize variation
+--FILE--
+<?php
+class InvalidDestructor {
+    public function __destruct() {
+        global $obj;
+        $obj->setSize(1);
+        echo "Destroyed\n";
+    }
+}
+
+$obj = new SplFixedArray(5);
+$obj[0] = str_repeat("A", 10);
+$obj[2] = str_repeat('B', 10);
+$obj[3] = new InvalidDestructor();
+$obj[4] = str_repeat('C', 10);
+$obj->setSize(2);
+echo "Done\n";
+?>
+--EXPECT--
+Destroyed
+Done


### PR DESCRIPTION
Upon resizing, the elements are destroyed from lower index to higher index. When an element contains an object with a destructor, that destructor can access a lower (i.e. already destroyed) element, causing a uaf. Set refcounted zvals to NULL after destroying them to avoid a uaf.

Alternative solution I thought about: Maybe it's possible to do it in two passes. First run all destructors and then destroy everything. But I don't know off the top of my head if the engine supports that (in an easy way). It seems complicated, and would also be technically a BC break because the destructors see still alive data that they might've expected to be destroyed.

The solution in this PR is BC-preserving because it previously just crashed instead of doing anything useful.