### PR TITLE
Remove unneeded zend_language_parser.h patch

### DIFF
--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -20,10 +20,6 @@ $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
 	@$(SED) -e 's,^int zendparse\(.*\),ZEND_API int zendparse\1,g' < $(srcdir)/zend_language_parser.h \
 	> $(srcdir)/zend_language_parser.h.tmp && \
 	mv $(srcdir)/zend_language_parser.h.tmp $(srcdir)/zend_language_parser.h
-	@nlinit=`echo 'nl="'; echo '"'`; eval "$$nlinit"; \
-	$(SED) -e "s/^#ifndef YYTOKENTYPE/#include \"zend.h\"\\$${nl}#ifndef YYTOKENTYPE/" < $(srcdir)/zend_language_parser.h \
-	> $(srcdir)/zend_language_parser.h.tmp && \
-	mv $(srcdir)/zend_language_parser.h.tmp $(srcdir)/zend_language_parser.h
 
 $(srcdir)/zend_ini_parser.h: $(srcdir)/zend_ini_parser.c
 $(srcdir)/zend_ini_parser.c: $(srcdir)/zend_ini_parser.y


### PR DESCRIPTION
This was cleaned in 4cbffd89d9e82d81a26746aadca27ad061cab43a and patching the `Zend/zend_language_parser.h` file to include zend.h is not needed anymore. The zend_compile.h inclusion is now added via the `%code requires`.