### PR TITLE
[skip-ci] Minor Markdown and typo fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,8 @@ accompanied by [pull requests](#pull-requests). You can find the extremely large
 list of RFCs that have been previously considered on the
 [PHP Wiki](https://wiki.php.net/rfc).
 
-To create a RFC, discuss it with the extension maintainer, and discuss it on the
-development mailing list internals@lists.php.net. RFC Wiki accounts can be
+To create an RFC, discuss it with the extension maintainer, and discuss it on
+the development mailing list internals@lists.php.net. RFC Wiki accounts can be
 requested on https://wiki.php.net/start?do=register. PHP extension maintainers
 can be found in the [EXTENSIONS](/EXTENSIONS) file in the PHP source code
 repository. Mailing list subscription is explained on the
@@ -318,7 +318,7 @@ detailed [information on Git](https://git-scm.com/).
 
 PHP is developed through the efforts of a large number of people. Collaboration
 is a Good Thing(tm), and Git lets us do this. Thus, following some basic rules
-with regards to Git usage will:
+with regard to Git usage will:
 
 * Make everybody happier, especially those responsible for maintaining PHP
   itself.
@@ -348,7 +348,7 @@ Having said that, here are the organizational rules:
    `--enable-zts` switch to ensure your code handles TSRM correctly and doesn't
    break for those who need that.
 
-Currently we have the following branches in use:
+Currently, we have the following branches in use:
 
 | Branch    |           |
 | --------- | --------- |

--- a/UPGRADING
+++ b/UPGRADING
@@ -252,7 +252,7 @@ PHP 8.3 UPGRADE NOTES
     now returns true on success, previously null was returned.
   . IntlBreakiterator::setText() now returns false on failure, previously
     null was returned.
-    now returns true on sucess, previously null was returned.
+    now returns true on success, previously null was returned.
   . IntlChar::enumCharNames is now returning a boolean.
     Previously it returned null on success and false on failure.
 
@@ -443,7 +443,7 @@ PHP 8.3 UPGRADE NOTES
     A warning is emitted when trying to decrement values of type null, as
     this will change in the next major version.
     Internal objects that implement an _IS_NUMBER cast but not a do_operator
-    handler that overrides addition and substraction now can be incremented
+    handler that overrides addition and subtraction now can be incremented
     and decrement as if one would do $o += 1 or $o -= 1
 
 - DOM:


### PR DESCRIPTION
Fixes a few typo and Markdown list numbering patterns in `CODING_STANDARDS.md`, `CONTRIBUTING.md`, and `UPGRADING` files