### PR TITLE
Add test for SimpleXMLElement::asXML() with a fragment and a filename

### DIFF
--- a/ext/simplexml/tests/SimpleXMLElement_asXML_fragment_filename.phpt
+++ b/ext/simplexml/tests/SimpleXMLElement_asXML_fragment_filename.phpt
@@ -1,0 +1,29 @@
+--TEST--
+SimpleXMLElement::asXML() with a fragment and a filename
+--EXTENSIONS--
+simplexml
+--FILE--
+<?php
+
+$sxe = simplexml_load_string(<<<XML
+<?xml version="1.0"?>
+<container>
+    <container2>
+        <child id="foo">bar</child>
+    </container2>
+</container>
+XML);
+$sxe->container2->asXML(__DIR__."/SimpleXMLElement_asXML_fragment_filename_output.tmp");
+
+// Note: the strange indent is correct: the indent text node preceding container2 is not emitted.
+echo file_get_contents(__DIR__."/SimpleXMLElement_asXML_fragment_filename_output.tmp");
+
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__."/SimpleXMLElement_asXML_fragment_filename_output.tmp");
+?>
+--EXPECT--
+<container2>
+        <child id="foo">bar</child>
+    </container2>


### PR DESCRIPTION
Previously, only the case with a full document and a filename was tested. The fragment case was not covered by tests.