### PR TITLE
Fix implicit/explicit port in mysqlnd

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,9 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.1.24
 
-
+- MySQLnd:
+  . Fixed bug GH-10270 (Invalid error message when connection via SSL fails:
+    "trying to connect via (null)"). (Kamil Tekiela)
 
 31 Aug 2023, PHP 8.1.23
 

--- a/ext/mysqli/tests/gh8978.phpt
+++ b/ext/mysqli/tests/gh8978.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Bug GH-8267 (Invalid error message when connection via SSL fails)
+--EXTENSIONS--
+mysqli
+--SKIPIF--
+<?php
+require_once 'skipifconnectfailure.inc';
+?>
+--FILE--
+<?php
+require_once "connect.inc";
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+$mysql = mysqli_init();
+// Ignore this warning as we are providing wrong information on purpose
+mysqli_ssl_set($mysql, 'x509.key', 'x509.pem', 'x509.ca', null, null);
+try {
+    // There should be no warning here, only exception
+    mysqli_real_connect($mysql, '127.0.0.1:3306', 'username', 'password', null, null, null, MYSQLI_CLIENT_SSL);
+} catch (mysqli_sql_exception $e) {
+    echo $e->getMessage()."\n";
+}
+
+echo 'done!';
+?>
+--EXPECTF--
+Warning: failed loading cafile stream: `x509.ca' in %s
+Cannot connect to MySQL using SSL
+done!

--- a/ext/mysqlnd/mysqlnd_commands.c
+++ b/ext/mysqlnd/mysqlnd_commands.c
@@ -571,6 +571,8 @@ MYSQLND_METHOD(mysqlnd_command, enable_ssl)(MYSQLND_CONN_DATA * const conn, cons
 			conn->vio->data->m.set_client_option(conn->vio, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (const char *) &verify);
 
 			if (FAIL == conn->vio->data->m.enable_ssl(conn->vio)) {
+				SET_CONNECTION_STATE(&conn->state, CONN_QUIT_SENT);
+				SET_CLIENT_ERROR(conn->error_info, CR_CONNECTION_ERROR, UNKNOWN_SQLSTATE, "Cannot connect to MySQL using SSL");
 				goto end;
 			}
 		}

--- a/ext/mysqlnd/mysqlnd_connection.c
+++ b/ext/mysqlnd/mysqlnd_connection.c
@@ -289,7 +289,7 @@ MYSQLND_METHOD(mysqlnd_conn_data, free_contents)(MYSQLND_CONN_DATA * conn)
 	mysqlnd_set_persistent_string(&conn->unix_socket, NULL, 0, pers);
 	DBG_INF_FMT("scheme=%s", conn->scheme.s);
 	mysqlnd_set_persistent_string(&conn->scheme, NULL, 0, pers);
-	
+
 	if (conn->server_version) {
 		mnd_pefree(conn->server_version, pers);
 		conn->server_version = NULL;
@@ -726,17 +726,18 @@ MYSQLND_METHOD(mysqlnd_conn_data, connect)(MYSQLND_CONN_DATA * conn,
 		DBG_RETURN(PASS);
 	}
 err:
+	DBG_ERR_FMT("[%u] %.128s (trying to connect via %s)", conn->error_info->error_no, conn->error_info->error, transport.s ? transport.s : conn->scheme.s);
+	if (!conn->error_info->error_no) {
+		/* There was an unknown error if the connection failed but we have no error number */
+		char * msg;
+		mnd_sprintf(&msg, 0, "Unknown error while trying to connect via %s", transport.s ? transport.s : conn->scheme.s);
+		SET_CLIENT_ERROR(conn->error_info, CR_CONNECTION_ERROR, UNKNOWN_SQLSTATE, msg);
+		mnd_sprintf_free(msg);
+	}
+
 	if (transport.s) {
 		mnd_sprintf_free(transport.s);
 		transport.s = NULL;
-	}
-
-	DBG_ERR_FMT("[%u] %.128s (trying to connect via %s)", conn->error_info->error_no, conn->error_info->error, conn->scheme.s);
-	if (!conn->error_info->error_no) {
-		char * msg;
-		mnd_sprintf(&msg, 0, "%s (trying to connect via %s)",conn->error_info->error, conn->scheme.s);
-		SET_CLIENT_ERROR(conn->error_info, CR_CONNECTION_ERROR, UNKNOWN_SQLSTATE, msg);
-		mnd_sprintf_free(msg);
 	}
 
 	conn->m->free_contents(conn);

--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -569,7 +569,6 @@ MYSQLND_METHOD(mysqlnd_vio, enable_ssl)(MYSQLND_VIO * const net)
 	    php_stream_xport_crypto_enable(net_stream, 1) < 0)
 	{
 		DBG_ERR("Cannot connect to MySQL by using SSL");
-		php_error_docref(NULL, E_WARNING, "Cannot connect to MySQL by using SSL");
 		DBG_RETURN(FAIL);
 	}
 	net->data->ssl = TRUE;


### PR DESCRIPTION
Fixes #8978 (partially). Ref #10922

@nielsdos I had another look at this. I observed that the connection is opened just fine even with the doubled port. The SSL fails due to missing certificate. However, the error message was incorrect and misleading. I don't know if we should still fix the doubled port, but at least to fix the reported issue we should only fix error message. What do you think?