### PR TITLE
Bcmath pow improvements

### DIFF
--- a/ext/bcmath/bcmath.c
+++ b/ext/bcmath/bcmath.c
@@ -541,7 +541,11 @@ PHP_FUNCTION(bcpow)
 		goto cleanup;
 	}
 
-	bc_raise(first, exponent, &result, scale);
+	if(exponent == 2) {
+		bc_square(first, &result, scale);
+	} else {
+		bc_raise(first, exponent, &result, scale);
+	}
 
 	RETVAL_STR(bc_num2str_ex(result, scale));
 

--- a/ext/bcmath/libbcmath/src/bcmath.h
+++ b/ext/bcmath/libbcmath/src/bcmath.h
@@ -119,6 +119,8 @@ void bc_sub(bc_num n1, bc_num n2, bc_num *result, size_t scale_min);
 
 void bc_multiply(bc_num n1, bc_num n2, bc_num *prod, size_t scale);
 
+void bc_square(bc_num num, bc_num *prod, size_t scale);
+
 bool bc_divide(bc_num n1, bc_num n2, bc_num *quot, int scale);
 
 bool bc_modulo(bc_num num1, bc_num num2, bc_num *resul, size_t scale);

--- a/ext/bcmath/libbcmath/src/raise.c
+++ b/ext/bcmath/libbcmath/src/raise.c
@@ -69,7 +69,7 @@ void bc_raise(bc_num num1, long exponent, bc_num *result, size_t scale)
 	pwrscale = num1->n_scale;
 	while ((exponent & 1) == 0) {
 		pwrscale = 2 * pwrscale;
-		bc_multiply(power, power, &power, pwrscale);
+		bc_square(power, &power, pwrscale);
 		exponent = exponent >> 1;
 	}
 	temp = bc_copy_num(power);
@@ -79,7 +79,7 @@ void bc_raise(bc_num num1, long exponent, bc_num *result, size_t scale)
 	/* Do the calculation. */
 	while (exponent > 0) {
 		pwrscale = 2 * pwrscale;
-		bc_multiply(power, power, &power, pwrscale);
+		bc_square(power, &power, pwrscale);
 		if ((exponent & 1) == 1) {
 			calcscale = pwrscale + calcscale;
 			bc_multiply(temp, power, &temp, calcscale);


### PR DESCRIPTION
This PR improves the performance of the BCMath function `bcpow`.

We don't need to perform usual multiplication when we square them. I implemented faster version of multiplication of the same number.

Approach with the function `bc_square` is faster about 3,4% in [one of my benchmarks](https://github.com/jorgsowa/php-benchmarks/blob/main/bcpow/README.md?plain=1) when I run `bcpow` of 10000 numbers with the exponent of 16. I suppose for bigger numbers it's more meaningful change.