### PR TITLE
Disable LSan tls

### DIFF
--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -6,6 +6,12 @@ runs:
       run: |
         set -x
 
+        echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse
+        deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
+        deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
+        sudo tee -a /etc/apt/sources.list.d/ddebs.list
+        sudo apt-get install ubuntu-dbgsym-keyring
+
         sudo apt-get update
         sudo apt-get install \
           bison \
@@ -45,8 +51,6 @@ runs:
           snmp-mibs-downloader \
           freetds-dev \
           unixodbc-dev \
-          llvm \
-          clang \
           libc-client-dev \
           dovecot-core \
           dovecot-pop3d \

--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -83,5 +83,4 @@ runs:
           --with-config-file-scan-dir=/etc/php.d \
           ${{ inputs.skipSlow == 'false' && '--with-pdo-firebird' || '' }} \
           ${{ inputs.skipSlow == 'false' && '--with-pdo-dblib' || '' }} \
-          --enable-werror \
           ${{ inputs.configurationParameters }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,6 +66,10 @@ jobs:
         uses: ./.github/actions/setup-caddy
       - name: apt
         uses: ./.github/actions/apt-x64
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "16.0"
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -80,7 +84,7 @@ jobs:
           configurationParameters: >-
             --${{ matrix.debug && 'enable' || 'disable' }}-debug
             --${{ matrix.zts && 'enable' || 'disable' }}-zts
-            ${{ matrix.asan && 'CFLAGS="-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC" LDFLAGS="-fsanitize=undefined,address" CC=clang CXX=clang++ --disable-opcache-jit' || '' }}
+            ${{ matrix.asan && 'CFLAGS="-fsanitize=undefined,address -DZEND_TRACK_ARENA_ALLOC -fno-omit-frame-pointer" LDFLAGS="-fsanitize=undefined,address" CC=clang CXX=clang++ --disable-opcache-jit' || '' }}
           skipSlow: ${{ matrix.asan }}
       - name: make
         run: make -j$(/usr/bin/nproc) >/dev/null

--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -178,11 +178,22 @@ static inline void *zend_dlopen(const char *file, int mode)
 #  define DL_LOAD(libname)			zend_dlopen(libname, PHP_RTLD_MODE | RTLD_GLOBAL)
 # endif
 
+static inline void *zend_dlsym(void *__restrict handle, const char *__restrict name)
+{
+# ifdef __SANITIZE_ADDRESS__
+	__lsan_disable();
+# endif
+	void *ptr = dlsym(handle, name);
+# ifdef __SANITIZE_ADDRESS__
+	__lsan_enable();
+# endif
+	return ptr;
+}
 # define DL_UNLOAD					dlclose
 # if defined(DLSYM_NEEDS_UNDERSCORE)
-#  define DL_FETCH_SYMBOL(h,s)		dlsym((h), "_" s)
+#  define DL_FETCH_SYMBOL(h,s)		zend_dlsym((h), "_" s)
 # else
-#  define DL_FETCH_SYMBOL			dlsym
+#  define DL_FETCH_SYMBOL			zend_dlsym
 # endif
 # define DL_ERROR					dlerror
 # define DL_HANDLE					void *

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -754,7 +754,7 @@ this extension sharedto offer compatibility.
 	do { \
 		(cb) = NULL; \
 		cli_shell_callbacks_t *(*get_callbacks)(void); \
-		get_callbacks = dlsym(RTLD_DEFAULT, "php_cli_get_shell_callbacks"); \
+		get_callbacks = DL_FETCH_SYMBOL(RTLD_DEFAULT, "php_cli_get_shell_callbacks"); \
 		if (get_callbacks) { \
 			(cb) = get_callbacks(); \
 		} \

--- a/run-tests.php
+++ b/run-tests.php
@@ -586,7 +586,7 @@ function main(): void
                     $lsanSuppressions = __DIR__ . '/.github/lsan-suppressions.txt';
                     if (file_exists($lsanSuppressions)) {
                         $environment['LSAN_OPTIONS'] = 'suppressions=' . $lsanSuppressions
-                            . ':print_suppressions=0';
+                            . ':print_suppressions=0:use_tls=0';
                     }
                     break;
                 case '--repeat':

--- a/run-tests.php
+++ b/run-tests.php
@@ -586,7 +586,7 @@ function main(): void
                     $lsanSuppressions = __DIR__ . '/.github/lsan-suppressions.txt';
                     if (file_exists($lsanSuppressions)) {
                         $environment['LSAN_OPTIONS'] = 'suppressions=' . $lsanSuppressions
-                            . ':print_suppressions=0:use_tls=0';
+                            . ':print_suppressions=0:use_tls=0:fast_unwind_on_malloc=false';
                     }
                     break;
                 case '--repeat':


### PR DESCRIPTION
LSan crashes a lot recently, and it seems to be caused by tls. Since we're not actually making use of C11s _Thread_local we can set the use_tls=0 option. This causes a false positive in dlopen() that apprently uses thread locals. We suppress this with __lsan_disable()/__lsan_enable().

This might also cause new leaks in other libraries, we'll have to run CI to see. :slightly_smiling_face: 

/cc @ju1ius