### PR TITLE
Refactor attribution for code portions in ext/random via README.REDIST.BINS

### DIFF
--- a/README.REDIST.BINS
+++ b/README.REDIST.BINS
@@ -1,9 +1,9 @@
  1. libmagic (ext/fileinfo) see ext/fileinfo/libmagic/LICENSE
  2. libmbfl (ext/mbstring) see ext/mbstring/libmbfl/LICENSE
  3. pcre2lib (ext/pcre)
- 4. ext/standard crypt
- 5. ext/standard crypt's blowfish implementation
- 6. ext/standard/rand
+ 4. ext/random portions
+ 5. ext/standard crypt
+ 6. ext/standard crypt's blowfish implementation
  7. ext/standard/scanf
  8. ext/standard/strnatcmp.c
  9. ext/standard/uuencode
@@ -117,7 +117,94 @@ PCRE2 independently.
 End
 
 
-4. ext/standard crypt
+4. ext/random portions
+
+* Portions of mt19937 code:
+
+The following mt19937 algorithms are based on a C++ class MTRand by
+Richard J. Wagner. For more information see the web page at
+http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/VERSIONS/C-LANG/MersenneTwister.h
+
+Mersenne Twister random number generator -- a C++ class MTRand
+Based on code by Makoto Matsumoto, Takuji Nishimura, and Shawn Cokus
+Richard J. Wagner  v1.0  15 May 2003  rjwagner@writeme.com
+
+The Mersenne Twister is an algorithm for generating random numbers.  It
+was designed with consideration of the flaws in various other generators.
+The period, 2^19937-1, and the order of equidistribution, 623 dimensions,
+are far greater.  The generator is also fast; it avoids multiplication and
+division, and it benefits from caches and pipelines.  For more information
+see the inventors' web page at http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
+
+Reference
+M. Matsumoto and T. Nishimura, "Mersenne Twister: A 623-Dimensionally
+Equidistributed Uniform Pseudo-Random Number Generator", ACM Transactions on
+Modeling and Computer Simulation, Vol. 8, No. 1, January 1998, pp 3-30.
+
+Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+Copyright (C) 2000 - 2003, Richard J. Wagner
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. The names of its contributors may not be used to endorse or promote
+   products derived from this software without specific prior written
+   permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+* Portions of xoshiro256 code are based on xoshiro256 generator:
+
+Written in 2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+* Portions of pcgoneseq128xslrr64 code:
+
+PCG Random Number Generation for C.
+
+Copyright 2014-2019 Melissa O'Neill <oneill@pcg-random.org>,
+                    and the PCG Project contributors.
+
+SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+Licensed under the Apache License, Version 2.0 (provided in
+LICENSE-APACHE.txt and at http://www.apache.org/licenses/LICENSE-2.0)
+or under the MIT license (provided in LICENSE-MIT.txt and at
+http://opensource.org/licenses/MIT), at your option. This file may not
+be copied, modified, or distributed except according to those terms.
+
+Distributed on an "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, either
+express or implied.  See your chosen license for details.
+
+For additional information about the PCG random number generation scheme,
+visit http://www.pcg-random.org/.
+
+
+5. ext/standard crypt
 
 FreeSec: libcrypt for NetBSD
 
@@ -149,7 +236,7 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 
-5. ext/standard crypt's blowfish implementation
+6. ext/standard crypt's blowfish implementation
 
 The crypt_blowfish homepage is:
 
@@ -193,60 +280,6 @@ http://www.usenix.org/events/usenix99/provos.html
 Some of the tricks in BF_ROUND might be inspired by Eric Young's
 Blowfish library (I can't be sure if I would think of something if I
 hadn't seen his code).
-
-
-6. ext/standard/rand
-
-The following php_mt_...() functions are based on a C++ class MTRand by
-Richard J. Wagner. For more information see the web page at
-http://www-personal.engin.umich.edu/~wagnerr/MersenneTwister.html
-
-Mersenne Twister random number generator -- a C++ class MTRand
-Based on code by Makoto Matsumoto, Takuji Nishimura, and Shawn Cokus
-Richard J. Wagner  v1.0  15 May 2003  rjwagner@writeme.com
-
-The Mersenne Twister is an algorithm for generating random numbers.  It
-was designed with consideration of the flaws in various other generators.
-The period, 2^19937-1, and the order of equidistribution, 623 dimensions,
-are far greater.  The generator is also fast; it avoids multiplication and
-division, and it benefits from caches and pipelines.  For more information
-see the inventors' web page at http://www.math.keio.ac.jp/~matumoto/emt.html
-
-Reference
-M. Matsumoto and T. Nishimura, "Mersenne Twister: A 623-Dimensionally
-Equidistributed Uniform Pseudo-Random Number Generator", ACM Transactions on
-Modeling and Computer Simulation, Vol. 8, No. 1, January 1998, pp 3-30.
-
-Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-Copyright (C) 2000 - 2003, Richard J. Wagner
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-
-3. The names of its contributors may not be used to endorse or promote
-   products derived from this software without specific prior written
-   permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 7. ext/standard/scanf


### PR DESCRIPTION
This updates README.REDIST.BINS from ext/standard/rand to current ext/random extension. Just to have it synced.