### PR TITLE
Remove unused call to Makefile.frag in ext/zip

### DIFF
--- a/ext/zip/config.m4
+++ b/ext/zip/config.m4
@@ -65,7 +65,4 @@ if test "$PHP_ZIP" != "no"; then
   PHP_NEW_EXTENSION(zip, $PHP_ZIP_SOURCES, $ext_shared)
 
   PHP_SUBST(ZIP_SHARED_LIBADD)
-
-  dnl so we always include the known-good working hack.
-  PHP_ADD_MAKEFILE_FRAGMENT
 fi


### PR DESCRIPTION
The Makefile.frag has been removed in ext/zip a long time ago, so this call is redundant. The corresponding PR has been also opened at https://github.com/pierrejoye/php_zip/pull/36.

