### PR TITLE
Add all README.* files to paths-ignore

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ on:
       - NEWS
       - UPGRADING
       - UPGRADING.INTERNALS
-      - README.md
+      - '**/README.*'
       - CONTRIBUTING.md
       - CODING_STANDARDS.md
     branches:
@@ -21,7 +21,7 @@ on:
       - NEWS
       - UPGRADING
       - UPGRADING.INTERNALS
-      - README.md
+      - '**/README.*'
       - CONTRIBUTING.md
       - CODING_STANDARDS.md
     branches:


### PR DESCRIPTION
Within the entire repository these are documentation files and CI don't need to run when they are changed.

This now includes also README.REDIST.BINS, README.md, and similar README files within the sapi and ext directories.

README files in tests directories are also only for internals documentations purposes.