### PR TITLE
gen_stub: fix regexps with unintentional range due to `-` character placement

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -272,7 +272,7 @@ class SimpleType {
         }
 
         $matches = [];
-        $isArray = preg_match("/array\s*<\s*([A-Za-z0-9_-|]+)?(\s*,\s*)?([A-Za-z0-9_-|]+)?\s*>/i", $typeString, $matches);
+        $isArray = preg_match("/array\s*<\s*([A-Za-z0-9_|-]+)?(\s*,\s*)?([A-Za-z0-9_|-]+)?\s*>/i", $typeString, $matches);
         if ($isArray) {
             if (empty($matches[1]) || empty($matches[3])) {
                 throw new Exception("array<> type hint must have both a key and a value");


### PR DESCRIPTION
`[A-Za-z0-9_-|]` regex range is interpreted as any character in ranges `A-Z`, `a-z`, `0-9`, and `_-|`. The last three characters (`_-|`) are interpretted as a range, because the dash character is placed between `_` and `|`. This means the regexp matches any ASCII character between ASCII index 95 and 124. This means that this expression unexpectedly (?) matches characters such as `\`` and `{`

This changes the regexp to place the dash character at the end, so instead of any character in ASCII 95-124, it only matches `-`, `|`, and `_` characters only. 

![image](https://github.com/php/php-src/assets/811553/5303c354-ccfe-410e-bfb4-4dde565be78d)
Regex101 also highlighting this: https://regex101.com/r/gEq3wc/1