### PR TITLE
Sync --enable-mysqlnd-compression-support option

### DIFF
--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -6,8 +6,8 @@ PHP_ARG_ENABLE([mysqlnd],
   [no],
   [yes])
 
-PHP_ARG_ENABLE([mysqlnd_compression_support],
-  [whether to disable compressed protocol support in mysqlnd],
+PHP_ARG_ENABLE([mysqlnd-compression-support],
+  [whether to enable compressed protocol support in mysqlnd],
   [AS_HELP_STRING([--disable-mysqlnd-compression-support],
     [Disable support for the MySQL compressed protocol in mysqlnd])],
   [yes],


### PR DESCRIPTION
This syncs the style of the --enable-mysqlnd-compression-support option name, otherwise in Autoconf both --enable-foo_bar and --enable-foo-bar work.

Also the configure output message is synced to match the check information.

Instead of this:

```sh
./configure --enable-mysqlnd
# ...
# checking whether to disable compressed protocol support in mysqlnd... yes
# ...
```

this reads a bit better:

```sh
./configure --enable-mysqlnd
# ...
# checking whether to enable compressed protocol support in mysqlnd... yes
# ...
```
