### PR TITLE
Fix configure phpdbg help output

### DIFF
--- a/sapi/phpdbg/config.m4
+++ b/sapi/phpdbg/config.m4
@@ -1,7 +1,7 @@
 PHP_ARG_ENABLE([phpdbg],
   [for phpdbg support],
-  [AS_HELP_STRING([--enable-phpdbg],
-    [Build phpdbg])],
+  [AS_HELP_STRING([--disable-phpdbg],
+    [Disable building of phpdbg])],
   [yes],
   [yes])
 


### PR DESCRIPTION
By default phpdbg is enabled (--enable-phpdbg) and user can get info in the `./configure --help` output if they want to disable it like with the other configuration options.