### PR TITLE
Fix passing null to parameter of type string

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -683,8 +683,8 @@ function main(): void
     $environment['TEST_PHP_EXECUTABLE_ESCAPED'] = escapeshellarg($php);
     putenv("TEST_PHP_CGI_EXECUTABLE=$php_cgi");
     $environment['TEST_PHP_CGI_EXECUTABLE'] = $php_cgi;
-    putenv("TEST_PHP_CGI_EXECUTABLE_ESCAPED=" . escapeshellarg($php_cgi));
-    $environment['TEST_PHP_CGI_EXECUTABLE_ESCAPED'] = escapeshellarg($php_cgi);
+    putenv("TEST_PHP_CGI_EXECUTABLE_ESCAPED=" . escapeshellarg($php_cgi ?? ''));
+    $environment['TEST_PHP_CGI_EXECUTABLE_ESCAPED'] = escapeshellarg($php_cgi ?? '');
     putenv("TEST_PHPDBG_EXECUTABLE=$phpdbg");
     $environment['TEST_PHPDBG_EXECUTABLE'] = $phpdbg;
     putenv("TEST_PHPDBG_EXECUTABLE_ESCAPED=" . escapeshellarg($phpdbg ?? ''));


### PR DESCRIPTION
This fixes builds without cgi or phpdbg:

```sh
  ./configure --disable-cgi --disable-phpdbg
  make
  ./sapi/cli/php run-tests.php
```

Otherwise, deprecation warnings (since PHP-8.1) are emitted:

```
  Deprecated: escapeshellarg(): Passing null to parameter #1 ($arg) of type string is deprecated in run-tests.php...
```