### PR TITLE
Use a single version of strnlen 

### DIFF
--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -1499,14 +1499,6 @@ ZEND_API zend_string *zend_mangle_property_name(const char *src1, size_t src1_le
 }
 /* }}} */
 
-static zend_always_inline size_t zend_strnlen(const char* s, size_t maxlen) /* {{{ */
-{
-	size_t len = 0;
-	while (*s++ && maxlen--) len++;
-	return len;
-}
-/* }}} */
-
 ZEND_API zend_result zend_unmangle_property_name_ex(const zend_string *name, const char **class_name, const char **prop_name, size_t *prop_len) /* {{{ */
 {
 	size_t class_name_len;

--- a/Zend/zend_operators.h
+++ b/Zend/zend_operators.h
@@ -264,6 +264,16 @@ zend_memnrstr(const char *haystack, const char *needle, size_t needle_len, const
 	}
 }
 
+static zend_always_inline size_t zend_strnlen(const char* s, size_t maxlen)
+{
+#if defined(HAVE_STRNLEN)
+	return strnlen(s, maxlen);
+#else
+	const char *p = memchr(s, '\0', maxlen);
+	return p ? p-s : maxlen;
+#endif
+}
+
 ZEND_API zend_result ZEND_FASTCALL increment_function(zval *op1);
 ZEND_API zend_result ZEND_FASTCALL decrement_function(zval *op2);
 

--- a/ext/phar/tar.c
+++ b/ext/phar/tar.c
@@ -200,13 +200,6 @@ static int phar_tar_process_metadata(phar_entry_info *entry, php_stream *fp) /* 
 }
 /* }}} */
 
-#ifndef HAVE_STRNLEN
-static size_t strnlen(const char *s, size_t maxlen) {
-	char *r = (char *)memchr(s, '\0', maxlen);
-	return r ? r-s : maxlen;
-}
-#endif
-
 int phar_parse_tarfile(php_stream* fp, char *fname, size_t fname_len, char *alias, size_t alias_len, phar_archive_data** pphar, int is_data, uint32_t compression, char **error) /* {{{ */
 {
 	char buf[512], *actual_alias = NULL, *p;
@@ -286,7 +279,7 @@ int phar_parse_tarfile(php_stream* fp, char *fname, size_t fname_len, char *alia
 			goto next;
 		}
 
-		if (((!old && hdr->prefix[0] == 0) || old) && strnlen(hdr->name, 100) == sizeof(".phar/signature.bin")-1 && !strncmp(hdr->name, ".phar/signature.bin", sizeof(".phar/signature.bin")-1)) {
+		if (((!old && hdr->prefix[0] == 0) || old) && zend_strnlen(hdr->name, 100) == sizeof(".phar/signature.bin")-1 && !strncmp(hdr->name, ".phar/signature.bin", sizeof(".phar/signature.bin")-1)) {
 			zend_off_t curloc;
 			size_t sig_len;
 
@@ -499,7 +492,7 @@ bail:
 		entry.link = NULL;
 		/* link field is null-terminated unless it has 100 non-null chars.
 		 * Thus we cannot use strlen. */
-		linkname_len = strnlen(hdr->linkname, 100);
+		linkname_len = zend_strnlen(hdr->linkname, 100);
 		if (entry.tar_type == TAR_LINK) {
 			if (!zend_hash_str_exists(&myphar->manifest, hdr->linkname, linkname_len)) {
 				if (error) {

--- a/main/spprintf.c
+++ b/main/spprintf.c
@@ -175,13 +175,6 @@
 
 /* }}} */
 
-#if !HAVE_STRNLEN
-static size_t strnlen(const char *s, size_t maxlen) {
-	char *r = memchr(s, '\0', maxlen);
-	return r ? r-s : maxlen;
-}
-#endif
-
 /*
  * Do format conversion placing the output in buffer
  */
@@ -552,7 +545,7 @@ static void xbuf_format_converter(void *xbuf, bool is_char, const char *fmt, va_
 						if (!adjust_precision) {
 							s_len = strlen(s);
 						} else {
-							s_len = strnlen(s, precision);
+							s_len = zend_strnlen(s, precision);
 						}
 					} else {
 						s = S_NULL;


### PR DESCRIPTION
There are multiple internal definitions of the posix 2008 strnlen function, consolidate them by exporting zend_strnlen and use it everywhere.