### PR TITLE
Replace old/deprecated pspell interface with aspell

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,7 +68,6 @@ arm_task:
         libtidy-dev
         libenchant-2-dev
         libaspell-dev
-        libpspell-dev
         libsasl2-dev
         libxpm-dev
         libzip-dev

--- a/.github/actions/apt-x32/action.yml
+++ b/.github/actions/apt-x32/action.yml
@@ -31,7 +31,6 @@ runs:
           libonig-dev:i386 \
           libpng-dev:i386 \
           libpq-dev:i386 \
-          libpspell-dev:i386 \
           libreadline-dev:i386 \
           libsasl2-dev:i386 \
           libsodium-dev:i386 \

--- a/.github/actions/apt-x64/action.yml
+++ b/.github/actions/apt-x64/action.yml
@@ -20,7 +20,6 @@ runs:
           libtidy-dev \
           libenchant-2-dev \
           libaspell-dev \
-          libpspell-dev \
           libsasl2-dev \
           libxpm-dev \
           libzip-dev \

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
       - libonig-dev
       - libpng-dev
       - libpq-dev
-      - libpspell-dev
       - libsasl2-dev
       - libsqlite3-dev
       - libsodium-dev

--- a/ext/pspell/config.m4
+++ b/ext/pspell/config.m4
@@ -24,7 +24,7 @@ if test "$PHP_PSPELL" != "no"; then
 
 	PSPELL_LIBDIR=$PSPELL_DIR/$PHP_LIBDIR
 
-	PHP_ADD_LIBRARY_WITH_PATH(pspell, $PSPELL_LIBDIR, PSPELL_SHARED_LIBADD)
+	PHP_ADD_LIBRARY_WITH_PATH(aspell, $PSPELL_LIBDIR, PSPELL_SHARED_LIBADD)
 
 	dnl Add -laspell to LIBS if it exists
 	PHP_CHECK_LIBRARY(aspell,new_aspell_config,

--- a/ext/pspell/config.m4
+++ b/ext/pspell/config.m4
@@ -1,7 +1,7 @@
 PHP_ARG_WITH([pspell],
-  [for PSPELL support],
+  [for spell checker support],
   [AS_HELP_STRING([[--with-pspell[=DIR]]],
-    [Include PSPELL support. GNU Aspell version 0.50.0 or higher required])])
+    [Include Aspell support. GNU Aspell version 0.50.0 or higher required])])
 
 if test "$PHP_PSPELL" != "no"; then
 	dnl Add -Wno-strict-prototypes as depends on user libs
@@ -12,17 +12,14 @@ if test "$PHP_PSPELL" != "no"; then
 	    PSPELL_SEARCH_DIRS="/usr/local /usr"
 	fi
 	for i in $PSPELL_SEARCH_DIRS; do
-		if test -f $i/include/pspell/pspell.h; then
-			PSPELL_DIR=$i
-			PSPELL_INCDIR=$i/include/pspell
-		elif test -f $i/include/pspell.h; then
+		if test -f $i/include/aspell.h; then
 			PSPELL_DIR=$i
 			PSPELL_INCDIR=$i/include
 		fi
 	done
 
 	if test -z "$PSPELL_DIR"; then
-		AC_MSG_ERROR(Cannot find pspell)
+		AC_MSG_ERROR(Cannot find aspell library)
 	fi
 
 	PSPELL_LIBDIR=$PSPELL_DIR/$PHP_LIBDIR

--- a/ext/pspell/config.w32
+++ b/ext/pspell/config.w32
@@ -1,10 +1,10 @@
 // vim:ft=javascript
 
-ARG_WITH("pspell", "pspell/aspell (whatever it's called this month) support", "no");
+ARG_WITH("pspell", "Aspell support", "no");
 
 if (PHP_PSPELL != "no") {
 
-	if (CHECK_HEADER_ADD_INCLUDE("pspell.h", "CFLAGS_PSPELL", PHP_PHP_BUILD + "\\include\\pspell;" + PHP_PSPELL) &&
+	if (CHECK_HEADER_ADD_INCLUDE("aspell.h", "CFLAGS_PSPELL", PHP_PHP_BUILD + "\\include;" + PHP_PSPELL) &&
 			CHECK_LIB("aspell*.lib", "pspell", PHP_PSPELL)) {
 		EXTENSION('pspell', 'pspell.c');
 		AC_DEFINE('HAVE_PSPELL', 1);

--- a/ext/pspell/pspell.c
+++ b/ext/pspell/pspell.c
@@ -473,7 +473,7 @@ PHP_FUNCTION(pspell_add_to_personal)
 		RETURN_FALSE;
 	}
 
-	aspell_speller_add_to_personal(manager, ZSTR_VAL(word), -1);
+	aspell_speller_add_to_personal(manager, ZSTR_VAL(word), ZSTR_LEN(word));
 	if (aspell_speller_error_number(manager) == 0) {
 		RETURN_TRUE;
 	} else {

--- a/ext/pspell/pspell.c
+++ b/ext/pspell/pspell.c
@@ -396,7 +396,7 @@ PHP_FUNCTION(pspell_check)
 	}
 	manager = php_pspell_object_from_zend_object(Z_OBJ_P(zmgr))->mgr;
 
-	if (aspell_speller_check(manager, ZSTR_VAL(word), -1)) {
+	if (aspell_speller_check(manager, ZSTR_VAL(word), ZSTR_LEN(word))) {
 		RETURN_TRUE;
 	} else {
 		RETURN_FALSE;

--- a/ext/pspell/pspell.c
+++ b/ext/pspell/pspell.c
@@ -500,7 +500,7 @@ PHP_FUNCTION(pspell_add_to_session)
 		RETURN_FALSE;
 	}
 
-	aspell_speller_add_to_session(manager, ZSTR_VAL(word), -1);
+	aspell_speller_add_to_session(manager, ZSTR_VAL(word), ZSTR_LEN(word));
 	if (aspell_speller_error_number(manager) == 0) {
 		RETURN_TRUE;
 	} else {

--- a/ext/pspell/pspell.c
+++ b/ext/pspell/pspell.c
@@ -446,7 +446,7 @@ PHP_FUNCTION(pspell_store_replacement)
 	}
 	manager = php_pspell_object_from_zend_object(Z_OBJ_P(zmgr))->mgr;
 
-	aspell_speller_store_replacement(manager, ZSTR_VAL(miss), -1, ZSTR_VAL(corr), -1);
+	aspell_speller_store_replacement(manager, ZSTR_VAL(miss), ZSTR_LEN(miss), ZSTR_VAL(corr), ZSTR_LEN(corr));
 	if (aspell_speller_error_number(manager) == 0) {
 		RETURN_TRUE;
 	} else {

--- a/ext/pspell/pspell.c
+++ b/ext/pspell/pspell.c
@@ -420,7 +420,7 @@ PHP_FUNCTION(pspell_suggest)
 
 	array_init(return_value);
 
-	wl = aspell_speller_suggest(manager, ZSTR_VAL(word), -1);
+	wl = aspell_speller_suggest(manager, ZSTR_VAL(word), ZSTR_LEN(word));
 	if (wl) {
 		AspellStringEnumeration *els = aspell_word_list_elements(wl);
 		while ((sug = aspell_string_enumeration_next(els)) != 0) {


### PR DESCRIPTION
The [Pspell library][1] was superseded by [GNU Aspell library][2] and Pspell was integrated into it. The GNU Aspell library includes a simple interface for the old pspell library due to backwards compatibility ([pspell.h][3]) which only defines old pspell_ symbol as aspell_ ones. Instead of using the old pspell symbol names, this patch uses the current Aspell.

The libpspell-dev on some *nix systems is part of the GNU Aspell. So the libaspell-dev is automatically installed when installing libpspell-dev. Meaning, the requirements will work also for build systems where libpspell-dev is installed, however the libaspell-dev should be encouraged to be used instead.

Additionally:
- Unused custom constant PSPELL_LARGEST_WORD is removed.

[1]: https://sourceforge.net/projects/pspell/
[2]: http://aspell.net/
[3]: https://github.com/GNUAspell/aspell/blob/e8eb747/interfaces/cc/pspell.h


I'm not sure if this is for PHP-8.3, otherwise, there isn't any BC break here. I'm just noting it as a possible simplification. And it can work on all systems out there as was previously. PHP Windows build, currently doesn't have ext/pspell support - the ext/enchant seems to be used and recommended there.

NEWS/UPGRADING.INTERNALS:
```
* Old Pspell interface has been updated with GNU Aspell. When using the
  --with-pspell[=path/to/aspell/pspell], path should include the aspell.h file
  which is located one level above the pspell/pspell.h:
  --with-pspell[=path/to/aspell]. Instead of the libpspell dependency, only the
  libapspell can be now used.
```
