### PR TITLE
Improve warning when returning null from the resolver set by libxml_set_external_entity_loader

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -784,10 +784,12 @@ is_string:
 	if (ret == NULL) {
 		if (resource == NULL) {
 			if (ID == NULL) {
-				ID = "NULL";
+				php_libxml_ctx_error(context,
+						"Failed to load external entity because the resolver function returned null\n");
+			} else {
+				php_libxml_ctx_error(context,
+						"Failed to load external entity \"%s\"\n", ID);
 			}
-			php_libxml_ctx_error(context,
-					"Failed to load external entity \"%s\"\n", ID);
 		} else {
 			/* we got the resource in the form of a string; open it */
 			ret = xmlNewInputFromFile(context, resource);

--- a/ext/libxml/tests/null_returned_by_resolver.phpt
+++ b/ext/libxml/tests/null_returned_by_resolver.phpt
@@ -1,0 +1,32 @@
+--TEST--
+null returned by resolver function
+--EXTENSIONS--
+libxml
+dom
+--FILE--
+<?php
+
+libxml_set_external_entity_loader(function ($public_id, $system_id, $context) {
+    var_dump($public_id, $system_id, $context);
+    return null;
+});
+
+$doc = new DOMDocument();
+$doc->loadHTMLFile("foobar");
+
+?>
+--EXPECTF--
+NULL
+string(6) "foobar"
+array(4) {
+  ["directory"]=>
+  NULL
+  ["intSubName"]=>
+  NULL
+  ["extSubURI"]=>
+  NULL
+  ["extSubSystem"]=>
+  NULL
+}
+
+Warning: DOMDocument::loadHTMLFile(): Failed to load external entity because the resolver function returned null in %s on line %d


### PR DESCRIPTION
Fixes GH-11952.