### PR TITLE
Make xmlwriter_open_uri use the path within the test directory

### DIFF
--- a/ext/xmlwriter/tests/xmlwriter_open_uri_error_003.phpt
+++ b/ext/xmlwriter/tests/xmlwriter_open_uri_error_003.phpt
@@ -4,7 +4,7 @@ xmlwriter_open_uri with non existing file
 xmlwriter
 --FILE--
 <?php
-var_dump(xmlwriter_open_uri('foo/bar.tmp'));
+var_dump(xmlwriter_open_uri(__DIR__ . '/foo/bar.tmp'));
 ?>
 --CREDITS--
 Koen Kuipers koenk82@gmail.com


### PR DESCRIPTION
This test caused a failure for me because I had a directory named foo in my current working directory. It should use __DIR__ to make sure no files in the filesystem are overwritten and the test is reproducible in different environments.