### PR TITLE
Update DOM test to work around libxml2 bug

### DIFF
--- a/ext/dom/tests/DOMDocument_saveXML_XML_SAVE_NO_DECL.phpt
+++ b/ext/dom/tests/DOMDocument_saveXML_XML_SAVE_NO_DECL.phpt
@@ -13,7 +13,8 @@ $doc->loadXML('<root>é</root>');
 
 echo $doc->saveXML(options: 0);
 echo $doc->saveXML(options: LIBXML_NOXMLDECL);
-$doc->encoding = "BIG5";
+// Explicit encoding test, to ensure no encoding declaration.
+$doc->encoding = "UTF-8";
 echo $doc->saveXML(options: LIBXML_NOXMLDECL);
 
 // Edge case
@@ -24,5 +25,5 @@ var_dump($doc->saveXML(options: LIBXML_NOXMLDECL));
 <?xml version="1.0"?>
 <root>&#xE9;</root>
 <root>&#xE9;</root>
-<root>&#233;</root>
+<root>é</root>
 string(0) ""


### PR DESCRIPTION
As reported in GH-12024, the test fails in the encoding part of the test file. This is due to a libxml2 bug (that's been fixed in modern versions, but of course various systems and distros are always behind). The goal of this part of the test is to check if an encoding declaration is outputted. So the actual encoding used doesn't matter. Switch to UTF-8, which seems to always work, to work around the issue.