### PR TITLE
Use mysql service consistencly for linux in GitHub actions

### DIFF
--- a/.github/actions/setup-x64/action.yml
+++ b/.github/actions/setup-x64/action.yml
@@ -6,12 +6,9 @@ runs:
       run: |
         set -x
 
-        sudo service mysql start
         sudo service postgresql start
         sudo service slapd start
-        mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS test"
         # Ensure local_infile tests can run.
-        mysql -uroot -proot -e "SET GLOBAL local_infile = true"
         sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
         sudo -u postgres psql -c "CREATE DATABASE test;"
         docker exec sql1 /opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U SA -P "<YourStrong@Passw0rd>" -Q "create login pdo_test with password='password', check_policy=off; create user pdo_test for login pdo_test; grant alter, control to pdo_test;"

--- a/.github/actions/test-libmysqlclient/action.yml
+++ b/.github/actions/test-libmysqlclient/action.yml
@@ -10,8 +10,8 @@ runs:
         set -x
         ${{ inputs.withMysqli == 'true' && 'export MYSQL_TEST_USER=root' || '' }}
         ${{ inputs.withMysqli == 'true' && 'export MYSQL_TEST_PASSWD=root' || '' }}
-        export PDO_MYSQL_TEST_DSN="mysql:host=127.0.0.1;dbname=test"
-        export PDO_MYSQL_TEST_HOST=127.0.0.1
+        export PDO_MYSQL_TEST_DSN="mysql:host=mysql;dbname=test"
+        export PDO_MYSQL_TEST_HOST=mysql
         export PDO_MYSQL_TEST_USER=root
         export PDO_MYSQL_TEST_PASS=root
         export REPORT_EXIT_STATUS=no

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,6 +52,16 @@ jobs:
         include: ${{ fromJson(needs.GENERATE_MATRIX.outputs.matrix-include) }}
     name: "${{ matrix.branch.name }}_LINUX_X64${{ matrix.name }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
     runs-on: ubuntu-20.04
+    env:
+      MYSQL_TEST_HOST: mysql
+      PDO_MYSQL_TEST_DSN: mysql:host=mysql;dbname=test
+      PDO_MYSQL_TEST_HOST: mysql
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -135,8 +145,6 @@ jobs:
     services:
       mysql:
         image: mysql:8
-        ports:
-          - 3306:3306
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: root
@@ -257,6 +265,16 @@ jobs:
   COVERAGE_DEBUG_NTS:
     if: github.repository_owner == 'php' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-20.04
+    env:
+      MYSQL_TEST_HOST: mysql
+      PDO_MYSQL_TEST_DSN: mysql:host=mysql;dbname=test
+      PDO_MYSQL_TEST_HOST: mysql
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -306,6 +324,12 @@ jobs:
       UBSAN_OPTIONS: print_stacktrace=1
       USE_ZEND_ALLOC: 0
       USE_TRACKED_ALLOC: 1
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -401,6 +425,7 @@ jobs:
           export ASAN_OPTIONS=exitcode=139
           php /usr/bin/composer install --no-progress --ignore-platform-reqs
           cp wp-tests-config-sample.php wp-tests-config.php
+          sed -i 's/localhost/mysql/g' wp-tests-config.php
           sed -i 's/youremptytestdbnamehere/test/g' wp-tests-config.php
           sed -i 's/yourusernamehere/root/g' wp-tests-config.php
           sed -i 's/yourpasswordhere/root/g' wp-tests-config.php
@@ -422,6 +447,16 @@ jobs:
         branch: ${{ fromJson(needs.GENERATE_MATRIX.outputs.branches) }}
     name: "${{ matrix.branch.name }}_OPCACHE_VARIATION"
     runs-on: ubuntu-20.04
+    env:
+      MYSQL_TEST_HOST: mysql
+      PDO_MYSQL_TEST_DSN: mysql:host=mysql;dbname=test
+      PDO_MYSQL_TEST_HOST: mysql
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -498,6 +533,16 @@ jobs:
         branch: ${{ fromJson(needs.GENERATE_MATRIX.outputs.branches) }}
     name: "${{ matrix.branch.name }}_MSAN"
     runs-on: ubuntu-22.04
+    env:
+      MYSQL_TEST_HOST: mysql
+      PDO_MYSQL_TEST_DSN: mysql:host=mysql;dbname=test
+      PDO_MYSQL_TEST_HOST: mysql
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -597,6 +642,12 @@ jobs:
           - branch: { name: 'PHP-80', ref: 'PHP-8.0' }
     name: "${{ matrix.branch.name }}_LIBMYSQLCLIENT"
     runs-on: ubuntu-20.04
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
     steps:
       - name: git checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,6 +35,16 @@ jobs:
             zts: true
     name: "LINUX_X64_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
     runs-on: ubuntu-20.04
+    env:
+      MYSQL_TEST_HOST: mysql
+      PDO_MYSQL_TEST_DSN: mysql:host=mysql;dbname=test
+      PDO_MYSQL_TEST_HOST: mysql
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: root
     steps:
       - name: git checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
I'm planning on switching to Docker for all Linux builds. There are two reasons:

* It will make the builds more portable, as we won't depend on GitHubs base image.
* It will allow using the latest Ubuntu version, with newer compiler toolchains.