### PR TITLE
Print host CPU info in CI build log on Linux

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,6 +72,14 @@ jobs:
         uses: ./.github/actions/setup-oracle
       - name: apt
         uses: ./.github/actions/apt-x64
+      - name: System info
+        run: |
+          echo "::group::Show host CPU info"
+          lscpu
+          echo "::endgroup::"
+          echo "::group::Show installed package versions"
+          dpkg -l
+          echo "::endgroup::"
       - name: ./configure
         uses: ./.github/actions/configure-x64
         with:
@@ -160,6 +168,14 @@ jobs:
           ref: ${{ matrix.branch.ref }}
       - name: apt
         uses: ./.github/actions/apt-x32
+      - name: System info
+        run: |
+          echo "::group::Show host CPU info"
+          lscpu
+          echo "::endgroup::"
+          echo "::group::Show installed package versions"
+          dpkg -l
+          echo "::endgroup::"
       - name: ./configure
         uses: ./.github/actions/configure-x32
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,6 +66,14 @@ jobs:
         uses: ./.github/actions/setup-caddy
       - name: apt
         uses: ./.github/actions/apt-x64
+      - name: System info
+        run: |
+          echo "::group::Show host CPU info"
+          lscpu
+          echo "::endgroup::"
+          echo "::group::Show installed package versions"
+          dpkg -l
+          echo "::endgroup::"
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:


### PR DESCRIPTION
On one of the nightly CI builds last week, there were test failures in mbstring which appear like they might be related to SIMD-accelerated code. The function which failed testing has multiple implementations, and the specific implementation which is used depends on the features of the host CPU and the build configuration.

The CI build log does not offer any clues about what implementation was actually used when the tests failed. If the same thing happens again, it will be helpful to (at least) know what CPU features the host CPU supports. This will also be helpful when diagnosing any other CI build failures which relate to CPU-specific code.

It would be better to print even more information about the build configuration. It would also be better to print host CPU information on Windows CI builds as well. However, this commit is an improvement over the present state.