### PR TITLE
Add note about ReflectionProperty::setValue() signature deprecation to upgrade guide

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -326,6 +326,8 @@ PHP 8.3 UPGRADE NOTES
 
 - Reflection:
   . Return type of ReflectionClass::getStaticProperties() is no longer nullable.
+  . Calling ReflectionProperty::setValue() with only one parameter is deprecated.
+    To set static properties, pass null as the first parameter.
 
 - Standard:
   . E_NOTICEs emitted by unserialize() have been promoted to E_WARNING.


### PR DESCRIPTION
In PHP 8.3, calling `ReflectionProperty::setValue()` with only a single parameter (to set static properties, where there is no target object) is deprecated in https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#reflectionpropertysetvalue. This PR simply adds a mention of this change to the upgrade guide, as it is not otherwise mentioned in upgrade documentation.