### PR TITLE
FPM: Set OBJC_DISABLE_INITIALIZE_FORK_SAFETY on Mac

### DIFF
--- a/sapi/fpm/fpm/fpm_unix.c
+++ b/sapi/fpm/fpm/fpm_unix.c
@@ -587,5 +587,9 @@ int fpm_unix_init_main(void)
 		}
 	}
 
+#ifdef __APPLE__
+	setenv("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES", 0);
+#endif
+
 	return 0;
 }


### PR DESCRIPTION
This is an attempt to fix #11818 