### PR TITLE
Avoid using uninitialised struct

### DIFF
--- a/ext/mysqlnd/mysqlnd_result.c
+++ b/ext/mysqlnd/mysqlnd_result.c
@@ -344,8 +344,8 @@ mysqlnd_query_read_result_set_header(MYSQLND_CONN_DATA * conn, MYSQLND_STMT * s)
 					}
 					MYSQLND_INC_CONN_STATISTIC(conn->stats, statistic);
 				}
+				PACKET_FREE(&fields_eof);
 			} while (0);
-			PACKET_FREE(&fields_eof);
 			break; /* switch break */
 		}
 	} while (0);


### PR DESCRIPTION
In some scenarios, there is a possibility that PACKET_FREE will be called with an uninitialised `fields_eof`.
Added some sanity to avoid negative impact of such an event