### PR TITLE
Fix GH-11982: str_getcsv returns null byte for unterminated enclosure

### DIFF
--- a/ext/standard/file.c
+++ b/ext/standard/file.c
@@ -2017,7 +2017,14 @@ PHPAPI HashTable *php_fgetcsv(php_stream *stream, char delimiter, char enclosure
 								memcpy(tptr, line_end, line_end_len);
 								tptr += line_end_len;
 
+								/* nothing can be fetched if stream is NULL (e.g. str_getcsv()) */
 								if (stream == NULL) {
+									/* the enclosure is unterminated */
+									if (bptr > limit) {
+										/* if the line ends with enclosure, we need to go back by
+										 * one character so the \0 character is not copied. */
+										--bptr;
+									}
 									goto quit_loop_2;
 								}
 
@@ -2028,6 +2035,11 @@ PHPAPI HashTable *php_fgetcsv(php_stream *stream, char delimiter, char enclosure
 									 * assign all the data from the start of
 									 * the enclosure to end of data to the
 									 * last element */
+									if (bptr > limit) {
+										/* if the line ends with enclosure, we need to go back by
+										 * one character so the \0 character is not copied. */
+										--bptr;
+									}
 									goto quit_loop_2;
 								}
 

--- a/ext/standard/tests/file/fgetcsv_variation33.phpt
+++ b/ext/standard/tests/file/fgetcsv_variation33.phpt
@@ -1,0 +1,29 @@
+--TEST--
+fgetcsv() with unterminated enclosure at the end of file
+--FILE--
+<?php
+$contents = <<<EOS
+"cell1","cell2"
+"cell1","
+EOS;
+$stream = fopen('php://memory', 'w+');
+fwrite($stream, $contents);
+rewind($stream);
+while (($data = fgetcsv($stream)) !== false) {
+    var_dump($data);
+}
+fclose($stream);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(5) "cell1"
+  [1]=>
+  string(5) "cell2"
+}
+array(2) {
+  [0]=>
+  string(5) "cell1"
+  [1]=>
+  string(0) ""
+}

--- a/ext/standard/tests/strings/gh11982.phpt
+++ b/ext/standard/tests/strings/gh11982.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-11982 (str_getcsv returns null byte for unterminated quoted string)
+--FILE--
+<?php
+var_dump(str_getcsv('"'));
+var_dump(str_getcsv('"field","'));
+var_dump(str_getcsv('"","a'));
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(0) ""
+}
+array(2) {
+  [0]=>
+  string(5) "field"
+  [1]=>
+  string(0) ""
+}
+array(2) {
+  [0]=>
+  string(0) ""
+  [1]=>
+  string(1) "a"
+}
+


### PR DESCRIPTION
This is a fix for GH-11982 which is caused by extra increment of the buffer pointer during parsing. It doesn't take into account the fact that it might be incremented too much in case of an enclosure being at the end of line. The fix adds two checks for that in the branches used by `str_getcsv` and `fgetcsv`. If it is identified, it goes back by one character.