### PR TITLE
Fix #12063 convert PHP single-quote to C double-quote string

### DIFF
--- a/build/gen_stub.php
+++ b/build/gen_stub.php
@@ -1768,6 +1768,10 @@ class EvaluatedValue
         // $this->expr has all its PHP constants replaced by C constants
         $prettyPrinter = new Standard;
         $expr = $prettyPrinter->prettyPrintExpr($this->expr);
+        // PHP single-quote to C double-quote string
+        if ($this->type->isString()) {
+            $expr = preg_replace("/(^'|'$)/", '"', $expr);
+        }
         return $expr[0] == '"' ? $expr : preg_replace('(\bnull\b)', 'NULL', str_replace('\\', '', $expr));
     }
 }

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -143,7 +143,7 @@ namespace {
 
     enum ZendTestStringEnum: string {
         case Foo = "Test1";
-        case Bar = "Test2";
+        case Bar = 'Test2';
         case Baz = "Test2\\a";
         case FortyTwo = "42";
     }

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: db7a89e93849c707caa1c536f717e0cf50dcfb74 */
+ * Stub hash: 06ac12255321035a2669fbc5abf2f3fda4c6ad76 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
See #12063 

Ensure we generate C code with properly double-quote strings