### PR TITLE
Fix bug #76857: Can read "non-existant" files

### DIFF
--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -726,26 +726,29 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
 		}
 
 		if (wrapper == &php_plain_files_wrapper) {
-
+			char realpath[MAXPATHLEN];
+			if (expand_filepath(local, realpath) == NULL) {
+				strlcpy(realpath, local, sizeof(realpath));
+			}
 			switch (type) {
 #ifdef F_OK
 				case FS_EXISTS:
-					RETURN_BOOL(VCWD_ACCESS(local, F_OK) == 0);
+					RETURN_BOOL(VCWD_ACCESS(realpath, F_OK) == 0);
 					break;
 #endif
 #ifdef W_OK
 				case FS_IS_W:
-					RETURN_BOOL(VCWD_ACCESS(local, W_OK) == 0);
+					RETURN_BOOL(VCWD_ACCESS(realpath, W_OK) == 0);
 					break;
 #endif
 #ifdef R_OK
 				case FS_IS_R:
-					RETURN_BOOL(VCWD_ACCESS(local, R_OK) == 0);
+					RETURN_BOOL(VCWD_ACCESS(realpath, R_OK) == 0);
 					break;
 #endif
 #ifdef X_OK
 				case FS_IS_X:
-					RETURN_BOOL(VCWD_ACCESS(local, X_OK) == 0);
+					RETURN_BOOL(VCWD_ACCESS(realpath, X_OK) == 0);
 					break;
 #endif
 			}

--- a/ext/standard/tests/streams/bug76857.phpt
+++ b/ext/standard/tests/streams/bug76857.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #76857 (Can read "non-existant" files)
+--FILE--
+<?php
+file_put_contents(__DIR__ . '/bug76857_data.txt', 'test data');
+$path = "foobar://google.com/../../bug76857_data.txt";
+chdir(__DIR__);
+var_dump(file_exists($path));
+var_dump(file_get_contents($path, false, null, 0, 10));
+?>
+--EXPECTF--
+Warning: file_exists(): Unable to find the wrapper "foobar" - did you forget to enable it when you configured PHP? in %s on line %d
+bool(true)
+
+Warning: file_get_contents(): Unable to find the wrapper "foobar" - did you forget to enable it when you configured PHP? in %s on line %d
+string(9) "test data"
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/bug76857_data.txt');
+?>


### PR DESCRIPTION
This change makes checked and opened file consistent in a way that it is using real path for stat operation in the same way like it is used for open.