### PR TITLE
Fix missing instantclient in CI

### DIFF
--- a/.github/actions/configure-x64/action.yml
+++ b/.github/actions/configure-x64/action.yml
@@ -74,8 +74,8 @@ runs:
           --with-imap \
           --with-imap-ssl \
           --with-pdo-odbc=unixODBC,/usr \
-          --with-pdo-oci=shared,instantclient,/opt/oracle/instantclient \
-          --with-oci8=shared,instantclient,/opt/oracle/instantclient \
+          $([ -d "/opt/oracle/instantclient" ] && echo '--with-pdo-oci=shared,instantclient,/opt/oracle/instantclient') \
+          $([ -d "/opt/oracle/instantclient" ] && echo '--with-oci8=shared,instantclient,/opt/oracle/instantclient') \
           --with-config-file-path=/etc \
           --with-config-file-scan-dir=/etc/php.d \
           --with-pdo-firebird \


### PR DESCRIPTION
We should only pass the --with-pdo-oci and --with-oci8 flags if instantclient is installed.