### PR TITLE
Expand file path in file stat only for wrapper path

### DIFF
--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -727,28 +727,31 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
 
 		if (wrapper == &php_plain_files_wrapper) {
 			char realpath[MAXPATHLEN];
-			if (expand_filepath(local, realpath) == NULL) {
-				strlcpy(realpath, local, sizeof(realpath));
+			const char *file_path_to_check;
+			if (strstr(local, "://") == NULL || expand_filepath(local, realpath) == NULL) {
+				file_path_to_check = local;
+			} else {
+				file_path_to_check = realpath;
 			}
 			switch (type) {
 #ifdef F_OK
 				case FS_EXISTS:
-					RETURN_BOOL(VCWD_ACCESS(realpath, F_OK) == 0);
+					RETURN_BOOL(VCWD_ACCESS(file_path_to_check, F_OK) == 0);
 					break;
 #endif
 #ifdef W_OK
 				case FS_IS_W:
-					RETURN_BOOL(VCWD_ACCESS(realpath, W_OK) == 0);
+					RETURN_BOOL(VCWD_ACCESS(file_path_to_check, W_OK) == 0);
 					break;
 #endif
 #ifdef R_OK
 				case FS_IS_R:
-					RETURN_BOOL(VCWD_ACCESS(realpath, R_OK) == 0);
+					RETURN_BOOL(VCWD_ACCESS(file_path_to_check, R_OK) == 0);
 					break;
 #endif
 #ifdef X_OK
 				case FS_IS_X:
-					RETURN_BOOL(VCWD_ACCESS(realpath, X_OK) == 0);
+					RETURN_BOOL(VCWD_ACCESS(file_path_to_check, X_OK) == 0);
 					break;
 #endif
 			}


### PR DESCRIPTION
The idea is to expand file path only if local still points to the full wrapper path which should happen only for non existent wrapper.

This should hopefully reduce performance regression caused by https://github.com/php/php-src/commit/766cac072f396dd0914d9d8f1209b673d54b61c1