### PR TITLE
Make unrepeatable tests retriable

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -1886,7 +1886,6 @@ function run_test(string $php, $file, array $env): string
         $skipCache = new SkipCache($enableSkipCache, $cfg['keep']['skip']);
     }
 
-    $retriable = true;
     $retried = false;
 retry:
 
@@ -1935,7 +1934,6 @@ TEST $file
     $tested = $test->getName();
 
     if ($test->hasSection('FILE_EXTERNAL')) {
-        $retriable = false;
         if ($num_repeats > 1) {
             return skip_test($tested, $tested_file, $shortname, 'Test with FILE_EXTERNAL might not be repeatable');
         }
@@ -1964,7 +1962,6 @@ TEST $file
         }
         $php = $php_cgi . ' -C ';
         $uses_cgi = true;
-        $retriable = false;
         if ($num_repeats > 1) {
             return skip_test($tested, $tested_file, $shortname, 'CGI does not support --repeat');
         }
@@ -1982,7 +1979,6 @@ TEST $file
         } else {
             return skip_test($tested, $tested_file, $shortname, 'phpdbg not available');
         }
-        $retriable = false;
         if ($num_repeats > 1) {
             return skip_test($tested, $tested_file, $shortname, 'phpdbg does not support --repeat');
         }
@@ -1990,7 +1986,6 @@ TEST $file
 
     foreach (['CLEAN', 'STDIN', 'CAPTURE_STDIO'] as $section) {
         if ($test->hasSection($section)) {
-            $retriable = false;
             if ($num_repeats > 1) {
                 return skip_test($tested, $tested_file, $shortname, "Test with $section might not be repeatable");
             }
@@ -2173,7 +2168,6 @@ TEST $file
         settings2array(preg_split("/[\n\r]+/", $ini), $ini_settings);
 
         if (isset($ini_settings['opcache.opt_debug_level'])) {
-            $retriable = false;
             if ($num_repeats > 1) {
                 return skip_test($tested, $tested_file, $shortname, 'opt_debug_level tests are not repeatable');
             }
@@ -2747,7 +2741,7 @@ COMMAND $cmd
 
         $wanted_re = null;
     }
-    if (!$passed && !$retried && $retriable && error_may_be_retried($test, $output)) {
+    if (!$passed && !$retried && error_may_be_retried($test, $output)) {
         $retried = true;
         goto retry;
     }


### PR DESCRIPTION
This was a error in thinking on my side. The reason these tests are unrepeatable is because --repeat executes the same request in the same process, and skipping the clean section. This is not the case when retrying tests.