### PR TITLE
Fix GH-12077: Check lsof functionality in socket on close test

### DIFF
--- a/sapi/fpm/tests/socket-close-on-exec.phpt
+++ b/sapi/fpm/tests/socket-close-on-exec.phpt
@@ -3,7 +3,7 @@ FPM: Set CLOEXEC on the listen and connection socket
 --SKIPIF--
 <?php
 require_once "skipif.inc";
-FPM\Tester::skipIfShellCommandFails('lsof -v 2> /dev/null');
+FPM\Tester::skipIfShellCommandFails('lsof -v', 'lsof-org/lsof');
 ?>
 --FILE--
 <?php

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -342,12 +342,24 @@ class Tester
      * Skip test if supplied shell command fails.
      *
      * @param string $command
+     * @param string|null $expectedPartOfOutput
      */
-    static public function skipIfShellCommandFails($command)
+    static public function skipIfShellCommandFails(string $command, string $expectedPartOfOutput = null)
     {
-        $output = system($command, $code);
-        if ($code) {
-            die("skip command '$command' faield with code $code and output: $output");
+        $result = exec("$command 2>&1", $output, $code);
+        if ($result === false || $code) {
+            die("skip command '$command' faieled with code $code");
+        }
+        if (!is_null($expectedPartOfOutput)) {
+            if (is_array($output)) {
+                foreach ($output as $line) {
+                    if (str_contains($line, $expectedPartOfOutput)) {
+                        // string found so no need to skip
+                        return;
+                    }
+                }
+            }
+            die("skip command '$command' did not contain output '$expectedPartOfOutput'");
         }
     }
 


### PR DESCRIPTION
It looks like lsof in Busybox does not accept any params so skip it if version does not show the tested [lsof](https://github.com/lsof-org/lsof).