### PR TITLE
Fix memory leak with failed SQLPrepare

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -845,6 +845,7 @@ PHP_FUNCTION(odbc_prepare)
 			break;
 		default:
 			odbc_sql_error(conn, result->stmt, "SQLPrepare");
+			efree(result);
 			RETURN_FALSE;
 	}
 


### PR DESCRIPTION
If `odbc_prepare` fails in `SQLPrepare`, then it neglects to free `result` like the other codepaths that exit early.