### PR TITLE
Include branch in benchmarking information

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -277,6 +277,7 @@ jobs:
       - name: Show diff
         if: github.event_name == 'pull_request'
         run: |-
+          set -x
           php benchmark/generate_diff.php \
             ${{ github.sha }} \
             $(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.sha }}) \

--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -13,6 +13,9 @@ function main() {
     global $storeResult;
 
     $data = [];
+    if (false !== $branch = getenv('GITHUB_REF_NAME')) {
+        $data['branch'] = $branch;
+    }
     $data['Zend/bench.php'] = runBench(false);
     $data['Zend/bench.php JIT'] = runBench(true);
     $data['Symfony Demo 2.2.3'] = runSymfonyDemo(false);
@@ -66,7 +69,7 @@ function runWordpress(bool $jit): array {
      * easily alter the phar file */
     runPhpCommand([
         '-d error_reporting=0',
-        'wp-cli.phar', 
+        'wp-cli.phar',
         'core',
         'install',
         '--url=wordpress.local',

--- a/benchmark/generate_diff.php
+++ b/benchmark/generate_diff.php
@@ -26,6 +26,9 @@ function main(?string $headCommitHash, ?string $baseCommitHash) {
     $output = "| Benchmark | Base ($baseCommitHashShort) | Head ($headCommitHashShort) | Diff |\n";
     $output .= "|---|---|---|---|\n";
     foreach ($headSummary as $name => $headBenchmark) {
+        if ($name === 'branch') {
+            continue;
+        }
         $baseInstructions = $baseSummary[$name]['instructions'] ?? null;
         $headInstructions = $headSummary[$name]['instructions'];
         $output .= "| $name | "


### PR DESCRIPTION
This allows https://nielsdos.github.io/php-benchmark-visualisation/ to only show commits from master (or a specific branch). Otherwise we get confusing, undulating commits from different branches, with potentially wildly different performance.