### PR TITLE
Fix GH-11956: PCRE regular expressions with JIT enabled gives different result

### DIFF
--- a/ext/pcre/pcre2lib/pcre2_jit_compile.c
+++ b/ext/pcre/pcre2lib/pcre2_jit_compile.c
@@ -11286,19 +11286,19 @@ if (exact > 1)
     }
   }
 else if (exact == 1)
-  {
   compile_char1_matchingpath(common, type, cc, &backtrack->topbacktracks, TRUE);
 
-  if (early_fail_type == type_fail_range)
-    {
-    OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(SLJIT_SP), early_fail_ptr);
-    OP1(SLJIT_MOV, TMP2, 0, SLJIT_MEM1(SLJIT_SP), early_fail_ptr + (int)sizeof(sljit_sw));
-    OP2(SLJIT_SUB, TMP1, 0, TMP1, 0, TMP2, 0);
-    OP2(SLJIT_SUB, TMP2, 0, STR_PTR, 0, TMP2, 0);
-    add_jump(compiler, &backtrack->topbacktracks, CMP(SLJIT_LESS_EQUAL, TMP2, 0, TMP1, 0));
+if (early_fail_type == type_fail_range)
+  {
+  /* Range end first, followed by range start. */
+  OP1(SLJIT_MOV, TMP1, 0, SLJIT_MEM1(SLJIT_SP), early_fail_ptr);
+  OP1(SLJIT_MOV, TMP2, 0, SLJIT_MEM1(SLJIT_SP), early_fail_ptr + (int)sizeof(sljit_sw));
+  OP2(SLJIT_SUB, TMP1, 0, TMP1, 0, TMP2, 0);
+  OP2(SLJIT_SUB, TMP2, 0, STR_PTR, 0, TMP2, 0);
+  add_jump(compiler, &backtrack->topbacktracks, CMP(SLJIT_LESS_EQUAL, TMP2, 0, TMP1, 0));
 
-    OP1(SLJIT_MOV, SLJIT_MEM1(SLJIT_SP), early_fail_ptr + (int)sizeof(sljit_sw), STR_PTR, 0);
-    }
+  OP1(SLJIT_MOV, SLJIT_MEM1(SLJIT_SP), early_fail_ptr, STR_PTR, 0);
+  OP1(SLJIT_MOV, SLJIT_MEM1(SLJIT_SP), early_fail_ptr + (int)sizeof(sljit_sw), STR_PTR, 0);
   }
 
 switch(opcode)

--- a/ext/pcre/tests/gh11956.phpt
+++ b/ext/pcre/tests/gh11956.phpt
@@ -1,0 +1,16 @@
+--TEST--
+GH-11956 (PCRE regular expressions with JIT enabled gives different result)
+--INI--
+pcre.jit=1
+--FILE--
+<?php
+preg_match( '/<(\w+)[\s\w\-]+ id="S44_i89ew">/', '<br><div id="S44_i89ew">', $matches );
+var_dump($matches);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(20) "<div id="S44_i89ew">"
+  [1]=>
+  string(2) "di"
+}


### PR DESCRIPTION
The code in the attached test used to work correctly in PHP 8.0, but not in 8.1+. This is because PHP 8.1+ uses a more modern version of pcre2 than PHP 8.0, and that pcre2 versions has a regression.

While upgrading pcre2lib seems to be only done for the master branch, it is possible to backport upstream fixes to stable branches. This has been already done in the past in for JIT regressions [1], so it is not unprecedented.

We backport the upstream pcre2 fix [2].

[1] https://github.com/php/php-src/commit/788a701e222
[2] https://github.com/PCRE2Project/pcre2/pull/135

Fixes GH-11956.