### PR TITLE
Fix the gettext config logic to recognize libintl exports prefixed with

### DIFF
--- a/ext/gettext/config.m4
+++ b/ext/gettext/config.m4
@@ -21,12 +21,17 @@ if test "$PHP_GETTEXT" != "no"; then
 	GETTEXT_LIBS=intl
 	GETTEXT_CHECK_IN_LIB=intl
 	],
-	AC_CHECK_LIB(c, bindtextdomain, [
-		GETTEXT_LIBS=
-		GETTEXT_CHECK_IN_LIB=c
-	],[
-		AC_MSG_ERROR(Unable to find required gettext library)
-	])
+	AC_CHECK_LIB(intl, libintl_bindtextdomain, [
+		GETTEXT_LIBS=intl
+		GETTEXT_CHECK_IN_LIB=intl
+		],
+		AC_CHECK_LIB(c, bindtextdomain, [
+			GETTEXT_LIBS=
+			GETTEXT_CHECK_IN_LIB=c
+		],[
+			AC_MSG_ERROR(Unable to find required gettext library)
+		])
+	)
   )
 
   AC_DEFINE(HAVE_LIBINTL,1,[ ])
@@ -35,10 +40,31 @@ if test "$PHP_GETTEXT" != "no"; then
 
   PHP_ADD_INCLUDE($GETTEXT_INCDIR)
 
-  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, ngettext,  [AC_DEFINE(HAVE_NGETTEXT, 1, [ ])])
-  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, dngettext,  [AC_DEFINE(HAVE_DNGETTEXT, 1, [ ])])
-  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, dcngettext,  [AC_DEFINE(HAVE_DCNGETTEXT, 1, [ ])])
-  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, bind_textdomain_codeset,  [AC_DEFINE(HAVE_BIND_TEXTDOMAIN_CODESET, 1, [ ])])
+  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, ngettext,  [
+	AC_DEFINE(HAVE_NGETTEXT, 1,
+	)],
+	AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, libintl_ngettext,
+		[AC_DEFINE(HAVE_NGETTEXT, 1, [ ])]
+	)
+  )
+  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, dngettext,  [
+	AC_DEFINE(HAVE_DNGETTEXT, 1,
+	)],
+	AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, libintl_dngettext, [AC_DEFINE(HAVE_DNGETTEXT, 1, [ ])])
+  )
+  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, dcngettext,  [
+	AC_DEFINE(HAVE_DCNGETTEXT, 1,
+	)],
+	AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, libintl_dcngettext, [AC_DEFINE(HAVE_DCNGETTEXT, 1, [ ])])
+  )
+  AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, bind_textdomain_codeset,  [
+	AC_DEFINE(HAVE_BIND_TEXTDOMAIN_CODESET, 1,
+	)],
+	AC_CHECK_LIB($GETTEXT_CHECK_IN_LIB, libintl_bind_textdomain_codeset,
+		[AC_DEFINE(HAVE_BIND_TEXTDOMAIN_CODESET, 1, [ ])]
+	)
+  )
+
   LDFLAGS=$O_LDFLAGS
 
   if test -n "$GETTEXT_LIBS"; then


### PR DESCRIPTION
'libintl_'.

Needed for use with gettext-0.22.

Fixes GH-12112.