### PR TITLE
Tweak behaviour of dynamic properties wrt error handlers

### DIFF
--- a/Zend/tests/oss_fuzz_61712b.phpt
+++ b/Zend/tests/oss_fuzz_61712b.phpt
@@ -1,0 +1,20 @@
+--TEST--
+OSS-Fuzz #61712 (assertion failure with error handler during binary op)
+--FILE--
+<?php
+#[AllowDynamicProperties]
+class C {
+    function error($_, $msg) {
+        echo $msg, "\n";
+        $this->a = 12345;
+    }
+}
+
+$c = new C;
+set_error_handler([$c, 'error']);
+$c->a %= 10;
+var_dump($c->a);
+?>
+--EXPECT--
+Undefined property: C::$a
+int(5)

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1163,7 +1163,7 @@ ZEND_API zval *zend_std_get_property_ptr_ptr(zend_object *zobj, zend_string *nam
 			if (UNEXPECTED(type == BP_VAR_RW || type == BP_VAR_R)) {
 				zend_error(E_WARNING, "Undefined property: %s::$%s", ZSTR_VAL(zobj->ce->name), ZSTR_VAL(name));
 			}
-			retval = zend_hash_update(zobj->properties, name, &EG(uninitialized_zval));
+			retval = zend_hash_add(zobj->properties, name, &EG(uninitialized_zval));
 		}
 	} else if (zobj->ce->__get == NULL) {
 		retval = &EG(error_zval);


### PR DESCRIPTION
With the fix in https://github.com/php/php-src/pull/12114, the behaviour would change for non-dynamic properties. Align the behaviour for dynamic properties to be the same.