### PR TITLE
Revert 479e65933154f1da92e6a820000e3bd3b2392874

### DIFF
--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3272,9 +3272,7 @@ static void instantiate_reflection_method(INTERNAL_FUNCTION_PARAMETERS, bool is_
 		&& (mptr = zend_get_closure_invoke_method(orig_obj)) != NULL)
 	{
 		/* do nothing, mptr already set */
-	} else if ((mptr = zend_hash_str_find_ptr(&ce->function_table, lcname, method_name_len)) == NULL
-		|| ((mptr->common.fn_flags & ZEND_ACC_PRIVATE) && mptr->common.scope != ce))
-	{
+	} else if ((mptr = zend_hash_str_find_ptr(&ce->function_table, lcname, method_name_len)) == NULL) {
 		efree(lcname);
 		zend_throw_exception_ex(reflection_exception_ptr, 0,
 			"Method %s::%s() does not exist", ZSTR_VAL(ce->name), method_name);

--- a/ext/reflection/tests/gh9470.phpt
+++ b/ext/reflection/tests/gh9470.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-9470: ReflectionMethod constructor should not find private parent method
+GH-9470: ReflectionMethod constructor finds private parent method
 --FILE--
 <?php
 
@@ -13,11 +13,12 @@ class B extends A {}
 
 echo (string) new ReflectionMethod('B', 'publicMethod');
 echo (string) new ReflectionMethod('B', 'protectedMethod');
-try {
-    echo (string) new ReflectionMethod('B', 'privateMethod');
-} catch(Throwable $e){
-    echo $e->getMessage(), "\n";
-}
+echo (string) new ReflectionMethod('B', 'privateMethod');
+
+$r = new ReflectionClass('B');
+echo (string) $r->getMethod('publicMethod');
+echo (string) $r->getMethod('protectedMethod');
+echo (string) $r->getMethod('privateMethod');
 
 ?>
 --EXPECTF--
@@ -27,4 +28,15 @@ Method [ <user, inherits A> public method publicMethod ] {
 Method [ <user, inherits A> protected method protectedMethod ] {
   @@ %s 6 - 6
 }
-Method B::privateMethod() does not exist
+Method [ <user, inherits A> private method privateMethod ] {
+  @@ %s 7 - 7
+}
+Method [ <user, inherits A> public method publicMethod ] {
+  @@ %s 5 - 5
+}
+Method [ <user, inherits A> protected method protectedMethod ] {
+  @@ %s 6 - 6
+}
+Method [ <user, inherits A> private method privateMethod ] {
+  @@ %s 7 - 7
+}


### PR DESCRIPTION
There were 4 different reports of this breaking behavior. This is higher than I expected. This bug fix may still be desirable, but should be discussed on the list beforehand.