### PR TITLE
ODBC unit tests shouldn't override odbc.ini location

### DIFF
--- a/ext/odbc/tests/config.inc
+++ b/ext/odbc/tests/config.inc
@@ -1,8 +1,5 @@
 <?php
 
-putenv('ODBCINI=/etc/odbc.ini');
-putenv('ODBCSYSINI=/etc');
-
 $dsn  = getenv("ODBC_TEST_DSN");
 $user = getenv("ODBC_TEST_USER");
 $pass = getenv("ODBC_TEST_PASS");


### PR DESCRIPTION
`ext/odbc/tests/config.inc` overrides the INIs used for the ODBC driver manager pointlessly. It's not pointing to some custom PHP test suite specific one, but the system one in `/etc/odbc(inst).ini`. Which doesn't necessarily exist, on i.e. NixOS, MacPorts, etc.

Fixes running the test suite on macOS with MacPorts, which puts it in `/opt/local/etc`.

I'm applying this to 8.1 since it is a bug fix, but I can retarget if needed.