### PR TITLE
Add vm_interrupt checks in JIT after zend_observer_fcall_begin

### DIFF
--- a/ext/opcache/jit/zend_jit_arm64.dasc
+++ b/ext/opcache/jit/zend_jit_arm64.dasc
@@ -9537,6 +9537,9 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 							|	SAVE_IP
 							|	mov FCARG1x, FP
 							|	EXT_CALL zend_observer_fcall_begin, REG0
+							/* check for interrupt to ensure execution in inlined functions can be observed via interrupt and possibly deoptimized */
+							|	MEM_LOAD_8_ZTS ldrb, TMP1w, executor_globals, vm_interrupt, TMP1
+							|	cbnz TMP1w, ->interrupt_handler
 						}
 #ifdef CONTEXT_THREADED_JIT
 						|	NIY	// TODO
@@ -9636,6 +9639,9 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			|	SAVE_IP
 			|	mov FCARG1x, FP
 			|	EXT_CALL zend_observer_fcall_begin, REG0
+			/* check for interrupt to ensure execution in inlined functions can be observed via interrupt and possibly deoptimized */
+			|	MEM_LOAD_8_ZTS ldrb, TMP1w, executor_globals, vm_interrupt, TMP1
+			|	cbnz TMP1w, ->interrupt_handler
 		}
 
 		if (trace) {

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -10218,6 +10218,9 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 							|	SAVE_IP
 							|	mov FCARG1a, FP
 							|	EXT_CALL zend_observer_fcall_begin, r0
+							/* check for interrupt to ensure execution in inlined functions can be observed via interrupt and possibly deoptimized */
+							|	MEM_CMP_ZTS byte, executor_globals, vm_interrupt, 0, r0
+							|	jne ->interrupt_handler
 						}
 #ifdef CONTEXT_THREADED_JIT
 						|	call >1
@@ -10328,6 +10331,9 @@ static int zend_jit_do_fcall(dasm_State **Dst, const zend_op *opline, const zend
 			|	SAVE_IP
 			|	mov FCARG1a, FP
 			|	EXT_CALL zend_observer_fcall_begin, r0
+			/* check for interrupt to ensure execution in inlined functions can be observed via interrupt and possibly deoptimized */
+			|	MEM_CMP_ZTS byte, executor_globals, vm_interrupt, 0, r0
+			|	jne ->interrupt_handler
 		}
 
 		if (trace) {


### PR DESCRIPTION
This ensures that it's possible to:
a) Sample inlined functions via vm_interrupt
b) Forcefully drop out of JIT in extraordinary circumstances, e.g. values of current stack frame changed, violating the assumptions the tracing jit does

The impact is minimal as we only do this when we have observing callbacks enabled.