### PR TITLE
Remove DOM_NO_ARGS() and DOM_NOT_IMPLEMENTED()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -25,6 +25,7 @@ PHP 8.4 INTERNALS UPGRADE NOTES
  a. ext/dom
    - dom_read_t and dom_write_t now expect the function to return zend_result
      instead of int.
+   - The macros DOM_NO_ARGS() and DOM_NOT_IMPLEMENTED() have been removed.
 
 ========================
 4. OpCode changes

--- a/ext/dom/domimplementation.c
+++ b/ext/dom/domimplementation.c
@@ -227,7 +227,8 @@ PHP_METHOD(DOMImplementation, getFeature)
 		RETURN_THROWS();
 	}
 
-	DOM_NOT_IMPLEMENTED();
+	zend_throw_error(NULL, "Not yet implemented");
+	RETURN_THROWS();
 }
 /* }}} end dom_domimplementation_get_feature */
 

--- a/ext/dom/php_dom.h
+++ b/ext/dom/php_dom.h
@@ -188,15 +188,6 @@ int php_dom_get_nodelist_length(dom_object *obj);
 	__ptr = (__prtype)((php_libxml_node_ptr *)__intern->ptr)->node; \
 }
 
-#define DOM_NO_ARGS() \
-	if (zend_parse_parameters_none() == FAILURE) { \
-		RETURN_THROWS(); \
-	}
-
-#define DOM_NOT_IMPLEMENTED() \
-	zend_throw_error(NULL, "Not yet implemented"); \
-	RETURN_THROWS();
-
 #define DOM_NODELIST 0
 #define DOM_NAMEDNODEMAP 1
 


### PR DESCRIPTION
DOM_NO_ARGS() has no users.
DOM_NOT_IMPLEMENTED() has a single user.

This cleans up php_dom.h a bit, it at least hides some implementation stuff.
The only out-of-tree user I could find is for DOM_NOT_IMPLEMENTED(): https://github.com/jcaesar/org.raydium.ManiaDrive/blob/b54a4dac6e55ab2d4a02c9e2104e01bb69afee4a/php-xmlbuf-dumbfix.patch#L9 but it's unclear what the purpose is and hasn't been updated in 5 years.