### PR TITLE
Fix #12143: Improve precision of rounding for FP numbers

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -97,7 +97,8 @@ static inline double php_round_helper(double value, int mode) {
 
 	if (value >= 0.0) {
 		tmp_value = floor(value + 0.5);
-		if ((mode == PHP_ROUND_HALF_DOWN && value == (-0.5 + tmp_value)) ||
+		if ((mode == PHP_ROUND_HALF_UP && value < (-0.5 + tmp_value)) ||
+			(mode == PHP_ROUND_HALF_DOWN && value == (-0.5 + tmp_value)) ||
 			(mode == PHP_ROUND_HALF_EVEN && value == (0.5 + 2 * floor(tmp_value/2.0))) ||
 			(mode == PHP_ROUND_HALF_ODD  && value == (0.5 + 2 * floor(tmp_value/2.0) - 1.0)))
 		{
@@ -105,7 +106,8 @@ static inline double php_round_helper(double value, int mode) {
 		}
 	} else {
 		tmp_value = ceil(value - 0.5);
-		if ((mode == PHP_ROUND_HALF_DOWN && value == (0.5 + tmp_value)) ||
+		if ((mode == PHP_ROUND_HALF_UP && value > (0.5 + tmp_value)) ||
+			(mode == PHP_ROUND_HALF_DOWN && value == (0.5 + tmp_value)) ||
 			(mode == PHP_ROUND_HALF_EVEN && value == (-0.5 + 2 * ceil(tmp_value/2.0))) ||
 			(mode == PHP_ROUND_HALF_ODD  && value == (-0.5 + 2 * ceil(tmp_value/2.0) + 1.0)))
 		{
@@ -131,7 +133,7 @@ PHPAPI double _php_math_round(double value, int places, int mode) {
 		return value;
 	}
 
-	places = places < INT_MIN+1 ? INT_MIN+1 : places;
+	places = places < INT_MIN + 1 ? INT_MIN + 1 : places;
 	precision_places = 14 - php_intlog10abs(value);
 
 	f1 = php_intpow10(abs(places));
@@ -139,8 +141,8 @@ PHPAPI double _php_math_round(double value, int places, int mode) {
 	/* If the decimal precision guaranteed by FP arithmetic is higher than
 	   the requested places BUT is small enough to make sure a non-zero value
 	   is returned, pre-round the result to the precision */
-	if (precision_places > places && precision_places - 15 < places) {
-		int64_t use_precision = precision_places < INT_MIN+1 ? INT_MIN+1 : precision_places;
+	if (precision_places - 1 > places && precision_places - 15 < places) {
+		int64_t use_precision = precision_places < INT_MIN + 1 ? INT_MIN + 1 : precision_places;
 
 		f2 = php_intpow10(abs((int)use_precision));
 		if (use_precision >= 0) {
@@ -153,7 +155,7 @@ PHPAPI double _php_math_round(double value, int places, int mode) {
 		tmp_value = php_round_helper(tmp_value, mode);
 
 		use_precision = places - precision_places;
-		use_precision = use_precision < INT_MIN+1 ? INT_MIN+1 : use_precision;
+		use_precision = use_precision < INT_MIN + 1 ? INT_MIN + 1 : use_precision;
 		/* now correctly move the decimal point */
 		f2 = php_intpow10(abs((int)use_precision));
 		/* because places < precision_places */

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -97,19 +97,19 @@ static inline double php_round_helper(double value, int mode) {
 
 	if (value >= 0.0) {
 		tmp_value = floor(value + 0.5);
-		if ((mode == PHP_ROUND_HALF_UP && value < (-0.5 + tmp_value)) ||
-			(mode == PHP_ROUND_HALF_DOWN && value <= (-0.5 + tmp_value)) ||
+		if ((mode == PHP_ROUND_HALF_DOWN && value == (-0.5 + tmp_value)) ||
 			(mode == PHP_ROUND_HALF_EVEN && value == (0.5 + 2 * floor(tmp_value/2.0))) ||
-			(mode == PHP_ROUND_HALF_ODD  && value == (0.5 + 2 * floor(tmp_value/2.0) - 1.0)))
+			(mode == PHP_ROUND_HALF_ODD  && value == (0.5 + 2 * floor(tmp_value/2.0) - 1.0)) ||
+			value < (-0.5 + tmp_value))
 		{
 			tmp_value = tmp_value - 1.0;
 		}
 	} else {
 		tmp_value = ceil(value - 0.5);
-		if ((mode == PHP_ROUND_HALF_UP && value > (0.5 + tmp_value)) ||
-			(mode == PHP_ROUND_HALF_DOWN && value >= (0.5 + tmp_value)) ||
+		if ((mode == PHP_ROUND_HALF_DOWN && value == (0.5 + tmp_value)) ||
 			(mode == PHP_ROUND_HALF_EVEN && value == (-0.5 + 2 * ceil(tmp_value/2.0))) ||
-			(mode == PHP_ROUND_HALF_ODD  && value == (-0.5 + 2 * ceil(tmp_value/2.0) + 1.0)))
+			(mode == PHP_ROUND_HALF_ODD  && value == (-0.5 + 2 * ceil(tmp_value/2.0) + 1.0)) ||
+			value > (0.5 + tmp_value))
 		{
 			tmp_value = tmp_value + 1.0;
 		}

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -141,7 +141,7 @@ PHPAPI double _php_math_round(double value, int places, int mode) {
 	/* If the decimal precision guaranteed by FP arithmetic is higher than
 	   the requested places BUT is small enough to make sure a non-zero value
 	   is returned, pre-round the result to the precision */
-	if (precision_places - 1 > places && precision_places - 15 < places) {
+	if (precision_places > places && precision_places - 15 < places) {
 		int64_t use_precision = precision_places < INT_MIN + 1 ? INT_MIN + 1 : precision_places;
 
 		f2 = php_intpow10(abs((int)use_precision));

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -98,7 +98,7 @@ static inline double php_round_helper(double value, int mode) {
 	if (value >= 0.0) {
 		tmp_value = floor(value + 0.5);
 		if ((mode == PHP_ROUND_HALF_UP && value < (-0.5 + tmp_value)) ||
-			(mode == PHP_ROUND_HALF_DOWN && value == (-0.5 + tmp_value)) ||
+			(mode == PHP_ROUND_HALF_DOWN && value <= (-0.5 + tmp_value)) ||
 			(mode == PHP_ROUND_HALF_EVEN && value == (0.5 + 2 * floor(tmp_value/2.0))) ||
 			(mode == PHP_ROUND_HALF_ODD  && value == (0.5 + 2 * floor(tmp_value/2.0) - 1.0)))
 		{
@@ -107,7 +107,7 @@ static inline double php_round_helper(double value, int mode) {
 	} else {
 		tmp_value = ceil(value - 0.5);
 		if ((mode == PHP_ROUND_HALF_UP && value > (0.5 + tmp_value)) ||
-			(mode == PHP_ROUND_HALF_DOWN && value == (0.5 + tmp_value)) ||
+			(mode == PHP_ROUND_HALF_DOWN && value >= (0.5 + tmp_value)) ||
 			(mode == PHP_ROUND_HALF_EVEN && value == (-0.5 + 2 * ceil(tmp_value/2.0))) ||
 			(mode == PHP_ROUND_HALF_ODD  && value == (-0.5 + 2 * ceil(tmp_value/2.0) + 1.0)))
 		{

--- a/ext/standard/tests/math/round_bug12143.phpt
+++ b/ext/standard/tests/math/round_bug12143.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Bug #12143 round with large precision
+--FILE--
+<?php
+var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_UP) == 0);
+var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_UP) == 1.7000000000001);
+?>
+--EXPECT--
+bool(true)
+bool(true)

--- a/ext/standard/tests/math/round_bug12143.phpt
+++ b/ext/standard/tests/math/round_bug12143.phpt
@@ -4,14 +4,30 @@ Bug #12143 round() with large FP
 <?php
 var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_UP) == 0);
 var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_DOWN) == 0);
-var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_UP) == 0);
+var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_EVEN) == 0);
+var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_ODD) == 0);
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_UP) == -0);
 var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_DOWN) == 0);
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_EVEN) == 0);
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_ODD) == 0);
 var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_UP) == 1.7000000000001);
 var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_DOWN) == 1.7000000000001);
+var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_EVEN) == 1.7000000000001);
+var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_ODD) == 1.7000000000001);
 var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_UP) == -1.7000000000001);
 var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_DOWN) == -1.7000000000001);
+var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_EVEN) == -1.7000000000001);
+var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_ODD) == -1.7000000000001);
 ?>
 --EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
 bool(true)
 bool(true)
 bool(true)

--- a/ext/standard/tests/math/round_bug12143.phpt
+++ b/ext/standard/tests/math/round_bug12143.phpt
@@ -2,21 +2,37 @@
 Bug #12143 round() with large FP
 --FILE--
 <?php
-var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_UP) == 0);
-var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_DOWN) == 0);
-var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_EVEN) == 0);
-var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_ODD) == 0);
-var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_UP) == -0);
-var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_DOWN) == 0);
-var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_EVEN) == 0);
-var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_ODD) == 0);
+var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_UP));
+var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_DOWN));
+var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_EVEN));
+var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_ODD));
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_UP));
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_DOWN));
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_EVEN));
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_ODD));
+var_dump(round(0.5000000000000004, 0, PHP_ROUND_HALF_UP));
+var_dump(round(0.5000000000000004, 0, PHP_ROUND_HALF_DOWN));
+var_dump(round(0.5000000000000004, 0, PHP_ROUND_HALF_EVEN));
+var_dump(round(0.5000000000000004, 0, PHP_ROUND_HALF_ODD));
+var_dump(round(-0.5000000000000004, 0, PHP_ROUND_HALF_UP));
+var_dump(round(-0.5000000000000004, 0, PHP_ROUND_HALF_DOWN));
+var_dump(round(-0.5000000000000004, 0, PHP_ROUND_HALF_EVEN));
+var_dump(round(-0.5000000000000004, 0, PHP_ROUND_HALF_ODD));
 ?>
 --EXPECT--
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
+float(0)
+float(0)
+float(0)
+float(0)
+float(0)
+float(0)
+float(0)
+float(0)
+float(1)
+float(1)
+float(1)
+float(1)
+float(-1)
+float(-1)
+float(-1)
+float(-1)

--- a/ext/standard/tests/math/round_bug12143.phpt
+++ b/ext/standard/tests/math/round_bug12143.phpt
@@ -1,10 +1,22 @@
 --TEST--
-Bug #12143 round with large precision
+Bug #12143 round() with large FP
 --FILE--
 <?php
 var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_UP) == 0);
+var_dump(round(0.49999999999999994, 0, PHP_ROUND_HALF_DOWN) == 0);
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_UP) == 0);
+var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_DOWN) == 0);
 var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_UP) == 1.7000000000001);
+var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_DOWN) == 1.7000000000001);
+var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_UP) == -1.7000000000001);
+var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_DOWN) == -1.7000000000001);
 ?>
 --EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
 bool(true)
 bool(true)

--- a/ext/standard/tests/math/round_bug12143.phpt
+++ b/ext/standard/tests/math/round_bug12143.phpt
@@ -10,24 +10,8 @@ var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_UP) == -0);
 var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_DOWN) == 0);
 var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_EVEN) == 0);
 var_dump(round(-0.49999999999999994, 0, PHP_ROUND_HALF_ODD) == 0);
-var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_UP) == 1.7000000000001);
-var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_DOWN) == 1.7000000000001);
-var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_EVEN) == 1.7000000000001);
-var_dump(round(1.700000000000145, 13, PHP_ROUND_HALF_ODD) == 1.7000000000001);
-var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_UP) == -1.7000000000001);
-var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_DOWN) == -1.7000000000001);
-var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_EVEN) == -1.7000000000001);
-var_dump(round(-1.700000000000145, 13, PHP_ROUND_HALF_ODD) == -1.7000000000001);
 ?>
 --EXPECT--
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
This PR fixes https://github.com/php/php-src/issues/12143

When we calculate FP numbers with large precision and perform `floor(value + 0.5)` or `ceil(value + 0.5)` we can round the result to the full integer which lead to incorrect result. We need to check if the number is not changed due to FP representation.