### PR TITLE
Remove useless SKIP_TEXT() invokes

### DIFF
--- a/ext/simplexml/simplexml.c
+++ b/ext/simplexml/simplexml.c
@@ -123,7 +123,6 @@ static xmlNodePtr sxe_get_element_by_offset(php_sxe_object *sxe, zend_long offse
 		}
 	}
 	while (node && nodendx <= offset) {
-		SKIP_TEXT(node)
 		if (node->type == XML_ELEMENT_NODE && match_ns(sxe, node, sxe->iter.nsprefix, sxe->iter.isprefix)) {
 			if (sxe->iter.type == SXE_ITER_CHILD || (
 				sxe->iter.type == SXE_ITER_ELEMENT && xmlStrEqual(node->name, sxe->iter.name))) {
@@ -133,7 +132,6 @@ static xmlNodePtr sxe_get_element_by_offset(php_sxe_object *sxe, zend_long offse
 				nodendx++;
 			}
 		}
-next_iter:
 		node = node->next;
 	}
 
@@ -148,13 +146,11 @@ next_iter:
 static xmlNodePtr sxe_find_element_by_name(php_sxe_object *sxe, xmlNodePtr node, xmlChar *name) /* {{{ */
 {
 	while (node) {
-		SKIP_TEXT(node)
 		if (node->type == XML_ELEMENT_NODE && match_ns(sxe, node, sxe->iter.nsprefix, sxe->iter.isprefix)) {
 			if (xmlStrEqual(node->name, name)) {
 				return node;
 			}
 		}
-next_iter:
 		node = node->next;
 	}
 	return NULL;
@@ -184,14 +180,12 @@ static xmlNodePtr sxe_get_element_by_name(php_sxe_object *sxe, xmlNodePtr node, 
 	}
 
 	while (node) {
-		SKIP_TEXT(node)
 		if (node->type == XML_ELEMENT_NODE && match_ns(sxe, node, sxe->iter.nsprefix, sxe->iter.isprefix)) {
 			if (xmlStrEqual(node->name, (xmlChar *)name)) {
 				*type = SXE_ITER_ELEMENT;
 				return orgnode;
 			}
 		}
-next_iter:
 		node = node->next;
 	}
 


### PR DESCRIPTION
In the places I removed them, they were useless because there is already a type check for a single node type, so I found it confusing having them there.