### PR TITLE
Zend: Remove dependency on zend.h for certain headers

### DIFF
--- a/Zend/zend_alloc.h
+++ b/Zend/zend_alloc.h
@@ -24,7 +24,6 @@
 #include <stdio.h>
 
 #include "../TSRM/TSRM.h"
-#include "zend.h"
 
 #ifndef ZEND_MM_ALIGNMENT
 # error "ZEND_MM_ALIGNMENT was not defined during configure"

--- a/Zend/zend_ast.h
+++ b/Zend/zend_ast.h
@@ -213,37 +213,6 @@ typedef struct _zend_ast_decl {
 	zend_ast *child[5];
 } zend_ast_decl;
 
-typedef union _znode_op {
-	uint32_t      constant;
-	uint32_t      var;
-	uint32_t      num;
-	uint32_t      opline_num; /*  Needs to be signed */
-#if ZEND_USE_ABS_JMP_ADDR
-	zend_op       *jmp_addr;
-#else
-	uint32_t      jmp_offset;
-#endif
-#if ZEND_USE_ABS_CONST_ADDR
-	zval          *zv;
-#endif
-} znode_op;
-
-typedef struct _znode { /* used only during compilation */
-	uint8_t op_type;
-	uint8_t flag;
-	union {
-		znode_op op;
-		zval constant; /* replaced by literal/zv */
-	} u;
-} znode;
-
-typedef struct _zend_ast_znode {
-	zend_ast_kind kind;
-	zend_ast_attr attr;
-	uint32_t lineno;
-	znode node;
-} zend_ast_znode;
-
 typedef void (*zend_ast_process_t)(zend_ast *ast);
 extern ZEND_API zend_ast_process_t zend_ast_process;
 
@@ -255,7 +224,6 @@ ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_zval_from_long(zend_long lval)
 
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_constant(zend_string *name, zend_ast_attr attr);
 ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_class_const_or_name(zend_ast *class_name, zend_ast *name);
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_znode(znode *node);
 
 #if ZEND_AST_SPEC
 # define ZEND_AST_SPEC_CALL(name, ...) \
@@ -390,10 +358,6 @@ static zend_always_inline uint32_t zend_ast_get_lineno(zend_ast *ast) {
 	} else {
 		return ast->lineno;
 	}
-}
-
-static zend_always_inline znode *zend_ast_get_znode(zend_ast *ast) {
-	return &((zend_ast_znode *) ast)->node;
 }
 
 static zend_always_inline zend_ast *zend_ast_create_binary_op(uint32_t opcode, zend_ast *op0, zend_ast *op1) {

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -20,8 +20,10 @@
 #ifndef ZEND_COMPILE_H
 #define ZEND_COMPILE_H
 
-#include "zend.h"
 #include "zend_ast.h"
+#include "zend_types.h"
+#include "zend_map_ptr.h"
+#include "zend_alloc.h"
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -60,44 +62,6 @@ typedef struct _zend_op zend_op;
 # define ZEND_USE_ABS_JMP_ADDR      0
 # define ZEND_USE_ABS_CONST_ADDR    0
 #endif
-
-typedef union _znode_op {
-	uint32_t      constant;
-	uint32_t      var;
-	uint32_t      num;
-	uint32_t      opline_num; /*  Needs to be signed */
-#if ZEND_USE_ABS_JMP_ADDR
-	zend_op       *jmp_addr;
-#else
-	uint32_t      jmp_offset;
-#endif
-#if ZEND_USE_ABS_CONST_ADDR
-	zval          *zv;
-#endif
-} znode_op;
-
-typedef struct _znode { /* used only during compilation */
-	uint8_t op_type;
-	uint8_t flag;
-	union {
-		znode_op op;
-		zval constant; /* replaced by literal/zv */
-	} u;
-} znode;
-
-/* Temporarily defined here, to avoid header ordering issues */
-typedef struct _zend_ast_znode {
-	zend_ast_kind kind;
-	zend_ast_attr attr;
-	uint32_t lineno;
-	znode node;
-} zend_ast_znode;
-
-ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_znode(znode *node);
-
-static zend_always_inline znode *zend_ast_get_znode(zend_ast *ast) {
-	return &((zend_ast_znode *) ast)->node;
-}
 
 typedef struct _zend_declarables {
 	zend_long ticks;
@@ -491,6 +455,9 @@ struct _zend_op_array {
 
 #define ZEND_RETURN_VALUE				0
 #define ZEND_RETURN_REFERENCE			1
+
+#define INTERNAL_FUNCTION_PARAMETERS zend_execute_data *execute_data, zval *return_value
+#define INTERNAL_FUNCTION_PARAM_PASSTHRU execute_data, return_value
 
 /* zend_internal_function_handler */
 typedef void (ZEND_FASTCALL *zif_handler)(INTERNAL_FUNCTION_PARAMETERS);

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -63,6 +63,43 @@ typedef struct _zend_op zend_op;
 # define ZEND_USE_ABS_CONST_ADDR    0
 #endif
 
+typedef union _znode_op {
+	uint32_t      constant;
+	uint32_t      var;
+	uint32_t      num;
+	uint32_t      opline_num; /*  Needs to be signed */
+#if ZEND_USE_ABS_JMP_ADDR
+	zend_op       *jmp_addr;
+#else
+	uint32_t      jmp_offset;
+#endif
+#if ZEND_USE_ABS_CONST_ADDR
+	zval          *zv;
+#endif
+} znode_op;
+
+typedef struct _znode { /* used only during compilation */
+	uint8_t op_type;
+	uint8_t flag;
+	union {
+		znode_op op;
+		zval constant; /* replaced by literal/zv */
+	} u;
+} znode;
+
+typedef struct _zend_ast_znode {
+	zend_ast_kind kind;
+	zend_ast_attr attr;
+	uint32_t lineno;
+	znode node;
+} zend_ast_znode;
+
+ZEND_API zend_ast * ZEND_FASTCALL zend_ast_create_znode(znode *node);
+
+static zend_always_inline znode *zend_ast_get_znode(zend_ast *ast) {
+	return &((zend_ast_znode *) ast)->node;
+}
+
 typedef struct _zend_declarables {
 	zend_long ticks;
 } zend_declarables;

--- a/Zend/zend_hash.h
+++ b/Zend/zend_hash.h
@@ -21,7 +21,9 @@
 #ifndef ZEND_HASH_H
 #define ZEND_HASH_H
 
-#include "zend.h"
+#include "zend_types.h"
+#include "zend_gc.h"
+#include "zend_string.h"
 #include "zend_sort.h"
 
 #define HASH_KEY_IS_STRING 1

--- a/Zend/zend_objects_API.h
+++ b/Zend/zend_objects_API.h
@@ -20,8 +20,10 @@
 #ifndef ZEND_OBJECTS_API_H
 #define ZEND_OBJECTS_API_H
 
-#include "zend.h"
-#include "zend_compile.h"
+#include "zend_types.h"
+#include "zend_gc.h"
+#include "zend_alloc.h"
+#include "zend_compile.h" /* For zend_property_info */
 
 #define OBJ_BUCKET_INVALID			(1<<0)
 

--- a/Zend/zend_string.h
+++ b/Zend/zend_string.h
@@ -19,7 +19,9 @@
 #ifndef ZEND_STRING_H
 #define ZEND_STRING_H
 
-#include "zend.h"
+#include "zend_types.h"
+#include "zend_gc.h"
+#include "zend_alloc.h"
 
 BEGIN_EXTERN_C()
 

--- a/Zend/zend_variables.h
+++ b/Zend/zend_variables.h
@@ -23,6 +23,7 @@
 
 #include "zend_types.h"
 #include "zend_gc.h"
+#include "zend_hash.h"
 
 BEGIN_EXTERN_C()
 


### PR DESCRIPTION
Allows to move AST definitions out from zend_compile.h and into zend_ast.h

The motivation for this is to be able to move the FCC/FCI struct declarations and the relevant functions into their own header, so that it can be included in ``zend_gc.h`` and move ``zend_get_gc_buffer_add_fcc()`` from ``Zend_API.h`` to ``zend_gc.h``.

However, currently ``zend_gc.h`` does not depend on ``zend.h`` and I don't think it should, however ``OBJ_RELEASE()`` which is used by ``zend_fcc_dtor()`` (which would logically be moved to the new header for FCI/FCC strucs) means it would have a dependency on ``Zend/zend_objects_API.h`` thus the starting point for the dependency reduction.