### PR TITLE
Improve invalid cpp modifier message

### DIFF
--- a/Zend/tests/ctor_promotion_additional_modifiers.phpt
+++ b/Zend/tests/ctor_promotion_additional_modifiers.phpt
@@ -9,4 +9,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use the static modifier on a promoted property in %s on line %d
+Fatal error: Cannot use the static modifier on a parameter in %s on line %d

--- a/Zend/tests/type_declarations/static_type_param.phpt
+++ b/Zend/tests/type_declarations/static_type_param.phpt
@@ -12,4 +12,4 @@ class Test {
 
 ?>
 --EXPECTF--
-Fatal error: Cannot use the static modifier on a promoted property in %s on line %d
+Fatal error: Cannot use the static modifier on a parameter in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -869,7 +869,7 @@ uint32_t zend_modifier_token_to_flag(zend_modifier_target target, uint32_t token
 	} else if (target == ZEND_MODIFIER_TARGET_CONSTANT) {
 		member = "class constant";
 	} else if (target == ZEND_MODIFIER_TARGET_CPP) {
-		member = "promoted property";
+		member = "parameter";
 	} else {
 		ZEND_UNREACHABLE();
 	}


### PR DESCRIPTION
The ZEND_MODIFIER_TARGET_CPP should really have been called _PARAM, but we shouldn't break API at this point.

Closes GH-12069