### PR TITLE
Remove unneeded zend_language_parser.h patch

### DIFF
--- a/win32/build/Makefile
+++ b/win32/build/Makefile
@@ -84,7 +84,6 @@ Zend\zend_language_parser.c Zend\zend_language_parser.h: Zend\zend_language_pars
 	$(BISON) --output=Zend/zend_language_parser.c -v -d Zend/zend_language_parser.y
 	@if "$(SED)" neq "" $(SED) -i "s,^int zendparse\(.*\),ZEND_API int zendparse\1,g" Zend/zend_language_parser.c
 	@if "$(SED)" neq "" $(SED) -i "s,^int zendparse\(.*\),ZEND_API int zendparse\1,g" Zend/zend_language_parser.h
-	@if "$(SED)" neq "" $(SED) -i "s,^#ifndef YYTOKENTYPE,#include \"zend.h\"\n#ifndef YYTOKENTYPE,g" Zend/zend_language_parser.h
 
 sapi\phpdbg\phpdbg_parser.c sapi\phpdbg\phpdbg_parser.h: sapi\phpdbg\phpdbg_parser.y
 	$(BISON) --output=sapi/phpdbg/phpdbg_parser.c -v -d sapi/phpdbg/phpdbg_parser.y


### PR DESCRIPTION
This was cleaned in 4cbffd89d9e82d81a26746aadca27ad061cab43a and patching the Zend/zend_language_parser.h file to include zend.h is not needed anymore.

Autotools build system part has been similarly cleaned via 32cdd330f33f01605f17d39c9ddd27cbe783f00c

This one should be done via #11974 cleanup but let's add it to the master branch I guess at this point since PHP-8.3 is branched and has stricter commit policy now.