### PR TITLE
Fix GH-12190: stream_context_create with address and port at 0.

### DIFF
--- a/ext/standard/tests/network/gh12190.phpt
+++ b/ext/standard/tests/network/gh12190.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #12190 (Setting 0 with port 0 too)
+--SKIPIF--
+<?php
+if (getenv("SKIP_ONLINE_TESTS")) die('skip online test');
+if (!in_array('https', stream_get_wrappers())) die('skip: https wrapper is required');
+?>
+--FILE--
+<?php
+$context = stream_context_create(['socket' => ['bindto' => '0:0']]);
+var_dump(file_get_contents('https://httpbin.org/get', false, $context) !== false);
+?>
+--EXPECT--
+bool(true)

--- a/main/network.c
+++ b/main/network.c
@@ -835,7 +835,7 @@ php_socket_t php_network_connect_socket_to_host(const char *host, unsigned short
 			case AF_INET:
 				((struct sockaddr_in *)sa)->sin_port = htons(port);
 				socklen = sizeof(struct sockaddr_in);
-				if (bindto && strchr(bindto, ':')) {
+				if (bindto && (strchr(bindto, ':') || !strcmp(bindto, "0"))) {
 					/* IPV4 sock can not bind to IPV6 address */
 					bindto = NULL;
 				}


### PR DESCRIPTION
Prior to the 8.1 rewrite, inet_aton was used for ipv4 addresses therefore addresses like `0` passed.
For the bindto's case where both ip and port are set as such, we discard the address binding.