### PR TITLE
Show the integer size in phpinfo()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,4 +8,7 @@ Core:
 DOM:
   . Added DOMNode::compareDocumentPosition(). (nielsdos)
 
+Standard:
+  . Implement GH-12188 (Indication for the int size in phpinfo()). (timwolla)
+
 <<< NOTE: Insert NEWS from last stable release here prior to actual release! >>>

--- a/ext/standard/info.c
+++ b/ext/standard/info.c
@@ -865,6 +865,9 @@ PHPAPI ZEND_COLD void php_print_info(int flag)
 		php_info_print_table_row(2, "Zend Extension Build", ZEND_EXTENSION_BUILD_ID);
 		php_info_print_table_row(2, "PHP Extension Build", ZEND_MODULE_BUILD_ID);
 
+		snprintf(temp_api, sizeof(temp_api), "%d bits", SIZEOF_ZEND_LONG * 8);
+		php_info_print_table_row(2, "PHP Integer Size", temp_api);
+
 #if ZEND_DEBUG
 		php_info_print_table_row(2, "Debug Build", "yes" );
 #else

--- a/ext/standard/tests/general_functions/phpinfo.phpt
+++ b/ext/standard/tests/general_functions/phpinfo.phpt
@@ -29,6 +29,7 @@ PHP Extension => %d
 Zend Extension => %d
 Zend Extension Build => API%s
 PHP Extension Build => API%s
+PHP Integer Size => %d bits
 Debug Build => %s
 Thread Safety => %s%A
 Zend Signal Handling => %s


### PR DESCRIPTION
![image](https://github.com/php/php-src/assets/209270/333ffc6c-d210-4d15-a9e0-5e30c121e1d3)

I've opted to place it at the top of the list of "features", but I'm open to bike-shedding the location (directly above IPv6 support?).

I'm also targeting PHP 8.3, as this is a trivial change to a function that does not guarantee stable output in the first place. But pinging the RMs @ericmann, @bukka, @adoy in case they disagree and I'm happy to adjust the target branch.

---------

Resolves GH-12188