### PR TITLE
Fix filter_var with callback and explicit REQUIRE_SCALAR

### DIFF
--- a/ext/filter/filter.c
+++ b/ext/filter/filter.c
@@ -551,14 +551,6 @@ static void php_filter_call(
 			filter = zval_get_long(option);
 		}
 
-		if ((option = zend_hash_str_find(filter_args_ht, "flags", sizeof("flags") - 1)) != NULL) {
-			filter_flags = zval_get_long(option);
-
-			if (!(filter_flags & FILTER_REQUIRE_ARRAY ||  filter_flags & FILTER_FORCE_ARRAY)) {
-				filter_flags |= FILTER_REQUIRE_SCALAR;
-			}
-		}
-
 		if ((option = zend_hash_str_find_deref(filter_args_ht, "options", sizeof("options") - 1)) != NULL) {
 			if (filter != FILTER_CALLBACK) {
 				if (Z_TYPE_P(option) == IS_ARRAY) {
@@ -567,6 +559,14 @@ static void php_filter_call(
 			} else {
 				options = option;
 				filter_flags = 0;
+			}
+		}
+
+		if ((option = zend_hash_str_find(filter_args_ht, "flags", sizeof("flags") - 1)) != NULL) {
+			filter_flags = zval_get_long(option);
+
+			if (!(filter_flags & FILTER_REQUIRE_ARRAY ||  filter_flags & FILTER_FORCE_ARRAY)) {
+				filter_flags |= FILTER_REQUIRE_SCALAR;
 			}
 		}
 	}

--- a/ext/filter/tests/filter_callback_require_scalar.phpt
+++ b/ext/filter/tests/filter_callback_require_scalar.phpt
@@ -1,0 +1,18 @@
+--TEST--
+FILTER_CALLBACK with explicit FILTER_REQUIRE_SCALAR
+--EXTENSIONS--
+filter
+--FILE--
+<?php
+function test($var) {
+    $callback = function ($var) {
+        return $var;
+    };
+    return filter_var($var, FILTER_CALLBACK, ['options' => $callback, 'flags' => FILTER_REQUIRE_SCALAR]);
+}
+var_dump(test('test'));
+var_dump(test(['test']));
+?>
+--EXPECT--
+string(4) "test"
+bool(false)


### PR DESCRIPTION
For some reason, FILTER_CALLBACK disables the FILTER_REQUIRE_SCALAR flag that is normally set by default. While surprising, this is not something we can change.

However, even specifying FILTER_REQUIRE_SCALAR explicitly does not corrently set this flag. This is because FILTER_CALLBACK zeroes the flags after they have been populated from the parameters.

We reverse the checks to make explicitly specifying the flag behave as expected.