### PR TITLE
Use zend_error_noreturn for E_ERROR consistently

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -1725,7 +1725,7 @@ ZEND_API ZEND_COLD void zend_throw_error(zend_class_entry *exception_ce, const c
 	if (EG(current_execute_data) && !CG(in_compilation)) {
 		zend_throw_exception(exception_ce, message, 0);
 	} else {
-		zend_error(E_ERROR, "%s", message);
+		zend_error_noreturn(E_ERROR, "%s", message);
 	}
 
 	efree(message);

--- a/Zend/zend_arena.h
+++ b/Zend/zend_arena.h
@@ -84,7 +84,7 @@ static zend_always_inline void* zend_arena_calloc(zend_arena **arena_ptr, size_t
 
 	size = zend_safe_address(unit_size, count, 0, &overflow);
 	if (UNEXPECTED(overflow)) {
-		zend_error(E_ERROR, "Possible integer overflow in zend_arena_calloc() (%zu * %zu)", unit_size, count);
+		zend_error_noreturn(E_ERROR, "Possible integer overflow in zend_arena_calloc() (%zu * %zu)", unit_size, count);
 	}
 	ret = zend_arena_alloc(arena_ptr, size);
 	memset(ret, 0, size);
@@ -180,7 +180,7 @@ static zend_always_inline void* zend_arena_calloc(zend_arena **arena_ptr, size_t
 
 	size = zend_safe_address(unit_size, count, 0, &overflow);
 	if (UNEXPECTED(overflow)) {
-		zend_error(E_ERROR, "Possible integer overflow in zend_arena_calloc() (%zu * %zu)", unit_size, count);
+		zend_error_noreturn(E_ERROR, "Possible integer overflow in zend_arena_calloc() (%zu * %zu)", unit_size, count);
 	}
 	ret = zend_arena_alloc(arena_ptr, size);
 	memset(ret, 0, size);

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -1297,7 +1297,7 @@ ZEND_API bool zend_internal_call_should_throw(zend_function *fbc, zend_execute_d
 
 ZEND_API ZEND_COLD void zend_internal_call_arginfo_violation(zend_function *fbc)
 {
-	zend_error(E_ERROR, "Arginfo / zpp mismatch during call of %s%s%s()",
+	zend_error_noreturn(E_ERROR, "Arginfo / zpp mismatch during call of %s%s%s()",
 		fbc->common.scope ? ZSTR_VAL(fbc->common.scope->name) : "",
 		fbc->common.scope ? "::" : "",
 		ZSTR_VAL(fbc->common.function_name));

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -240,7 +240,7 @@ static ZEND_COLD void zend_throw_or_error(int fetch_type, zend_class_entry *exce
 	if (fetch_type & ZEND_FETCH_CLASS_EXCEPTION) {
 		zend_throw_error(exception_ce, "%s", message);
 	} else {
-		zend_error(E_ERROR, "%s", message);
+		zend_error_noreturn(E_ERROR, "%s", message);
 	}
 
 	efree(message);

--- a/Zend/zend_smart_str.c
+++ b/Zend/zend_smart_str.c
@@ -147,7 +147,7 @@ ZEND_API void ZEND_FASTCALL _smart_string_alloc_persistent(smart_string *str, si
 		str->c = pemalloc(str->a + 1, 1);
 	} else {
 		if (UNEXPECTED((size_t) len > SIZE_MAX - str->len)) {
-			zend_error(E_ERROR, "String size overflow");
+			zend_error_noreturn(E_ERROR, "String size overflow");
 		}
 		len += str->len;
 		str->a = ZEND_MM_ALIGNED_SIZE_EX(len + SMART_STRING_OVERHEAD, SMART_STRING_PAGE) - SMART_STRING_OVERHEAD;
@@ -173,7 +173,7 @@ ZEND_API void ZEND_FASTCALL _smart_string_alloc(smart_string *str, size_t len)
 		}
 	} else {
 		if (UNEXPECTED((size_t) len > SIZE_MAX - str->len)) {
-			zend_error(E_ERROR, "String size overflow");
+			zend_error_noreturn(E_ERROR, "String size overflow");
 		}
 		len += str->len;
 		str->a = ZEND_MM_ALIGNED_SIZE_EX(len + SMART_STRING_OVERHEAD, SMART_STRING_PAGE) - SMART_STRING_OVERHEAD;

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -1723,7 +1723,7 @@ static int implement_date_interface_handler(zend_class_entry *interface, zend_cl
 		!instanceof_function(implementor, date_ce_date) &&
 		!instanceof_function(implementor, date_ce_immutable)
 	) {
-		zend_error(E_ERROR, "DateTimeInterface can't be implemented by user classes");
+		zend_error_noreturn(E_ERROR, "DateTimeInterface can't be implemented by user classes");
 	}
 
 	return SUCCESS;

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -976,7 +976,7 @@ static void zend_ffi_callback_trampoline(ffi_cif* cif, void* ret, void** args, v
 	free_alloca(fci.params, use_heap);
 
 	if (EG(exception)) {
-		zend_error(E_ERROR, "Throwing from FFI callbacks is not allowed");
+		zend_error_noreturn(E_ERROR, "Throwing from FFI callbacks is not allowed");
 	}
 
 	ret_type = ZEND_FFI_TYPE(callback_data->type->func.ret_type);

--- a/ext/gd/libgd/gd_webp.c
+++ b/ext/gd/libgd/gd_webp.c
@@ -56,7 +56,7 @@ gdImagePtr gdImageCreateFromWebpCtx (gdIOCtx * infile)
 			if (filedata) {
 				gdFree(filedata);
 			}
-			zend_error(E_ERROR, "WebP decode: realloc failed");
+			zend_error_noreturn(E_ERROR, "WebP decode: realloc failed");
 			return NULL;
 		}
 
@@ -67,7 +67,7 @@ gdImagePtr gdImageCreateFromWebpCtx (gdIOCtx * infile)
 	} while (n>0 && n!=EOF);
 
 	if (WebPGetInfo(filedata,size, &width, &height) == 0) {
-		zend_error(E_ERROR, "gd-webp cannot get webp info");
+		zend_error_noreturn(E_ERROR, "gd-webp cannot get webp info");
 		gdFree(filedata);
 		return NULL;
 	}
@@ -79,7 +79,7 @@ gdImagePtr gdImageCreateFromWebpCtx (gdIOCtx * infile)
 	}
 	argb = WebPDecodeARGB(filedata, size, &width, &height);
 	if (!argb) {
-		zend_error(E_ERROR, "gd-webp cannot allocate temporary buffer");
+		zend_error_noreturn(E_ERROR, "gd-webp cannot allocate temporary buffer");
 		gdFree(filedata);
 		gdImageDestroy(im);
 		return NULL;
@@ -113,7 +113,7 @@ void gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
 	}
 
 	if (!gdImageTrueColor(im)) {
-		zend_error(E_ERROR, "Palette image not supported by webp");
+		zend_error_noreturn(E_ERROR, "Palette image not supported by webp");
 		return;
 	}
 
@@ -159,7 +159,7 @@ void gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
 	}
 
 	if (out_size == 0) {
-		zend_error(E_ERROR, "gd-webp encoding failed");
+		zend_error_noreturn(E_ERROR, "gd-webp encoding failed");
 		goto freeargb;
 	}
 	gdPutBuf(out, out_size, outfile);

--- a/ext/intl/spoofchecker/spoofchecker_class.c
+++ b/ext/intl/spoofchecker/spoofchecker_class.c
@@ -77,7 +77,7 @@ static zend_object *spoofchecker_clone_obj(zend_object *object) /* {{{ */
 		/* set up error in case error handler is interested */
 		intl_error_set( NULL, SPOOFCHECKER_ERROR_CODE(new_sfo), "Failed to clone SpoofChecker object", 0 );
 		Spoofchecker_objects_free(&new_sfo->zo); /* free new object */
-		zend_error(E_ERROR, "Failed to clone SpoofChecker object");
+		zend_error_noreturn(E_ERROR, "Failed to clone SpoofChecker object");
 	}
 	return new_obj_val;
 }

--- a/ext/opcache/zend_accelerator_util_funcs.c
+++ b/ext/opcache/zend_accelerator_util_funcs.c
@@ -178,12 +178,12 @@ failure:
 	CG(zend_lineno) = function1->op_array.opcodes[0].lineno;
 	if (function2->type == ZEND_USER_FUNCTION
 		&& function2->op_array.last > 0) {
-		zend_error(E_ERROR, "Cannot redeclare %s() (previously declared in %s:%d)",
+		zend_error_noreturn(E_ERROR, "Cannot redeclare %s() (previously declared in %s:%d)",
 				   ZSTR_VAL(function1->common.function_name),
 				   ZSTR_VAL(function2->op_array.filename),
 				   (int)function2->op_array.opcodes[0].lineno);
 	} else {
-		zend_error(E_ERROR, "Cannot redeclare %s()", ZSTR_VAL(function1->common.function_name));
+		zend_error_noreturn(E_ERROR, "Cannot redeclare %s()", ZSTR_VAL(function1->common.function_name));
 	}
 }
 
@@ -227,7 +227,7 @@ static zend_always_inline void _zend_accel_class_hash_copy(HashTable *target, Ha
 					CG(in_compilation) = 1;
 					zend_set_compiled_filename(ce1->info.user.filename);
 					CG(zend_lineno) = ce1->info.user.line_start;
-					zend_error(E_ERROR,
+					zend_error_noreturn(E_ERROR,
 							"Cannot declare %s %s, because the name is already in use",
 							zend_get_object_type(ce1), ZSTR_VAL(ce1->name));
 					return;

--- a/ext/pdo/pdo.c
+++ b/ext/pdo/pdo.c
@@ -110,12 +110,12 @@ ZEND_GET_MODULE(pdo)
 PDO_API zend_result php_pdo_register_driver(const pdo_driver_t *driver) /* {{{ */
 {
 	if (driver->api_version != PDO_DRIVER_API) {
-		zend_error(E_ERROR, "PDO: driver %s requires PDO API version " ZEND_ULONG_FMT "; this is PDO version %d",
+		zend_error_noreturn(E_ERROR, "PDO: driver %s requires PDO API version " ZEND_ULONG_FMT "; this is PDO version %d",
 			driver->driver_name, driver->api_version, PDO_DRIVER_API);
 		return FAILURE;
 	}
 	if (!zend_hash_str_exists(&module_registry, "pdo", sizeof("pdo") - 1)) {
-		zend_error(E_ERROR, "You MUST load PDO before loading any PDO drivers");
+		zend_error_noreturn(E_ERROR, "You MUST load PDO before loading any PDO drivers");
 		return FAILURE;	/* NOTREACHED */
 	}
 

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -3298,7 +3298,7 @@ PHP_FUNCTION(pg_unescape_bytea)
 
 	tmp = (char *)PQunescapeBytea((unsigned char*)from, &to_len);
 	if (!tmp) {
-		zend_error(E_ERROR, "Out of memory");
+		zend_error_noreturn(E_ERROR, "Out of memory");
 		return;
 	}
 

--- a/ext/sodium/libsodium.c
+++ b/ext/sodium/libsodium.c
@@ -158,7 +158,7 @@ static void sodium_separate_string(zval *zv) {
 PHP_MINIT_FUNCTION(sodium)
 {
 	if (sodium_init() < 0) {
-		zend_error(E_ERROR, "sodium_init()");
+		zend_error_noreturn(E_ERROR, "sodium_init()");
 	}
 
 	sodium_exception_ce = register_class_SodiumException(zend_ce_exception);

--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -435,7 +435,7 @@ static ZEND_FUNCTION(zend_call_method)
 	} else if (Z_TYPE_P(class_or_object) == IS_STRING) {
 		ce = zend_lookup_class(Z_STR_P(class_or_object));
 		if (!ce) {
-			zend_error(E_ERROR, "Unknown class '%s'", Z_STRVAL_P(class_or_object));
+			zend_error_noreturn(E_ERROR, "Unknown class '%s'", Z_STRVAL_P(class_or_object));
 			return;
 		}
 	} else {

--- a/main/output.c
+++ b/main/output.c
@@ -597,7 +597,7 @@ PHPAPI int php_output_handler_conflict_register(const char *name, size_t name_le
 	zend_string *str;
 
 	if (!EG(current_module)) {
-		zend_error(E_ERROR, "Cannot register an output handler conflict outside of MINIT");
+		zend_error_noreturn(E_ERROR, "Cannot register an output handler conflict outside of MINIT");
 		return FAILURE;
 	}
 	str = zend_string_init_interned(name, name_len, 1);
@@ -614,7 +614,7 @@ PHPAPI int php_output_handler_reverse_conflict_register(const char *name, size_t
 	HashTable rev, *rev_ptr = NULL;
 
 	if (!EG(current_module)) {
-		zend_error(E_ERROR, "Cannot register a reverse output handler conflict outside of MINIT");
+		zend_error_noreturn(E_ERROR, "Cannot register a reverse output handler conflict outside of MINIT");
 		return FAILURE;
 	}
 
@@ -651,7 +651,7 @@ PHPAPI int php_output_handler_alias_register(const char *name, size_t name_len, 
 	zend_string *str;
 
 	if (!EG(current_module)) {
-		zend_error(E_ERROR, "Cannot register an output handler alias outside of MINIT");
+		zend_error_noreturn(E_ERROR, "Cannot register an output handler alias outside of MINIT");
 		return FAILURE;
 	}
 	str = zend_string_init_interned(name, name_len, 1);


### PR DESCRIPTION
To be clear, these already don't return. zend_error_noreturn just hints at this fact through the ZEND_NORETURN attribute.