### PR TITLE
Fix #[Override] on traits overriding a parent method without a matching interface

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ PHP                                                                        NEWS
 |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ?? ??? ????, PHP 8.3.0RC3
 
+- Core:
+  . Fixed bug GH-12189 (#[Override] attribute in trait does not check for
+    parent class implementations). (timwolla)
+
 - Filter:
   . Fix explicit FILTER_REQUIRE_SCALAR with FILTER_CALLBACK (ilutov)
 

--- a/Zend/tests/attributes/override/gh12189.phpt
+++ b/Zend/tests/attributes/override/gh12189.phpt
@@ -1,0 +1,42 @@
+--TEST--
+#[Override] attribute in trait does not check for parent class implementations
+--FILE--
+<?php
+
+class A {
+    public function foo(): void {}
+}
+
+interface I {
+    public function foo(): void;
+}
+
+trait T {
+    #[\Override]
+    public function foo(): void {
+        echo 'foo';
+    }
+}
+
+// Works fine
+class B implements I {
+    use T;
+}
+
+// Works fine ("copied and pasted into the target class")
+class C extends A {
+    #[\Override]
+    public function foo(): void {
+        echo 'foo';
+    }
+}
+
+// Does not work
+class D extends A {
+    use T;
+}
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/gh12189_2.phpt
+++ b/Zend/tests/attributes/override/gh12189_2.phpt
@@ -1,0 +1,24 @@
+--TEST--
+#[Override] attribute in trait does not check for parent class implementations (Variant with private parent method)
+--FILE--
+<?php
+
+class A {
+    private function foo(): void {}
+}
+
+trait T {
+    #[\Override]
+    public function foo(): void {
+        echo 'foo';
+    }
+}
+
+class D extends A {
+    use T;
+}
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: D::foo() has #[\Override] attribute, but no matching parent method exists in %s on line %d

--- a/Zend/tests/attributes/override/gh12189_3.phpt
+++ b/Zend/tests/attributes/override/gh12189_3.phpt
@@ -1,0 +1,24 @@
+--TEST--
+#[Override] attribute in trait does not check for parent class implementations (Variant with protected parent method)
+--FILE--
+<?php
+
+class A {
+    protected function foo(): void {}
+}
+
+trait T {
+    #[\Override]
+    public function foo(): void {
+        echo 'foo';
+    }
+}
+
+class D extends A {
+    use T;
+}
+echo "Done";
+
+?>
+--EXPECTF--
+Done

--- a/Zend/tests/attributes/override/gh12189_4.phpt
+++ b/Zend/tests/attributes/override/gh12189_4.phpt
@@ -1,0 +1,24 @@
+--TEST--
+#[Override] attribute in trait does not check for parent class implementations (Variant with __construct)
+--FILE--
+<?php
+
+class A {
+    public function __construct() {}
+}
+
+trait T {
+    #[\Override]
+    public function __construct() {
+        echo 'foo';
+    }
+}
+
+class D extends A {
+    use T;
+}
+echo "Done";
+
+?>
+--EXPECTF--
+Fatal error: D::__construct() has #[\Override] attribute, but no matching parent method exists in %s on line %d

--- a/Zend/tests/attributes/override/gh12189_5.phpt
+++ b/Zend/tests/attributes/override/gh12189_5.phpt
@@ -1,0 +1,24 @@
+--TEST--
+#[Override] attribute in trait does not check for parent class implementations (Variant with abstract __construct)
+--FILE--
+<?php
+
+abstract class A {
+    abstract public function __construct();
+}
+
+trait T {
+    #[\Override]
+    public function __construct() {
+        echo 'foo';
+    }
+}
+
+class D extends A {
+    use T;
+}
+echo "Done";
+
+?>
+--EXPECT--
+Done

--- a/Zend/tests/attributes/override/gh12189_6.phpt
+++ b/Zend/tests/attributes/override/gh12189_6.phpt
@@ -1,0 +1,25 @@
+--TEST--
+#[Override]: Inheritance check of inherited trait method against interface
+--FILE--
+<?php
+
+trait T1 {
+    public abstract function test();
+}
+
+trait T2 {
+    public function test() {}
+}
+
+class A {
+    use T2;
+}
+
+class B extends A {
+    use T1;
+}
+
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
This is a proof of concept fix for #12189. It appears to work fine, but there probably is a cleaner solution that I'm unable to find due to the lack of understanding.