### PR TITLE
Upgrade to macOS 12 in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -201,7 +201,7 @@ jobs:
         debug: [true, false]
         zts: [true, false]
     name: "${{ matrix.branch.name }}_MACOS_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Verify generated files are up to date
         uses: ./.github/actions/verify-generated-files
   MACOS_DEBUG_NTS:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We get some mysterious failures on macOS on GA with no evident error.
https://github.com/php/php-src/actions/runs/6179736631/job/16775181890

This is a blind attempt to solve it. There are many similar reports (https://github.com/actions/runner-images/issues/7509#issuecomment-1538294874), but there's no clear resolution.