### PR TITLE
Reimplement `php_round_helper()` using `modf()`

### DIFF
--- a/ext/standard/tests/math/round_gh12143_1.phpt
+++ b/ext/standard/tests/math/round_gh12143_1.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-12143: Test rounding of 0.49999999999999994.
+--FILE--
+<?php
+foreach ([
+    0.49999999999999994,
+    -0.49999999999999994,
+] as $number) {
+    foreach ([
+        'PHP_ROUND_HALF_UP',
+        'PHP_ROUND_HALF_DOWN',
+        'PHP_ROUND_HALF_EVEN',
+        'PHP_ROUND_HALF_ODD',
+    ] as $mode) {
+        printf("%-20s: %+.17g -> %+.17g\n", $mode, $number, round($number, 0, constant($mode)));
+    }
+}
+?>
+--EXPECT--
+PHP_ROUND_HALF_UP   : +0.49999999999999994 -> +0
+PHP_ROUND_HALF_DOWN : +0.49999999999999994 -> +0
+PHP_ROUND_HALF_EVEN : +0.49999999999999994 -> +0
+PHP_ROUND_HALF_ODD  : +0.49999999999999994 -> +0
+PHP_ROUND_HALF_UP   : -0.49999999999999994 -> -0
+PHP_ROUND_HALF_DOWN : -0.49999999999999994 -> -0
+PHP_ROUND_HALF_EVEN : -0.49999999999999994 -> -0
+PHP_ROUND_HALF_ODD  : -0.49999999999999994 -> -0

--- a/ext/standard/tests/math/round_gh12143_2.phpt
+++ b/ext/standard/tests/math/round_gh12143_2.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-12143: Test rounding of 0.50000000000000011.
+--FILE--
+<?php
+foreach ([
+    0.50000000000000011,
+    -0.50000000000000011,
+] as $number) {
+    foreach ([
+        'PHP_ROUND_HALF_UP',
+        'PHP_ROUND_HALF_DOWN',
+        'PHP_ROUND_HALF_EVEN',
+        'PHP_ROUND_HALF_ODD',
+    ] as $mode) {
+        printf("%-20s: %+.17g -> %+.17g\n", $mode, $number, round($number, 0, constant($mode)));
+    }
+}
+?>
+--EXPECT--
+PHP_ROUND_HALF_UP   : +0.50000000000000011 -> +1
+PHP_ROUND_HALF_DOWN : +0.50000000000000011 -> +1
+PHP_ROUND_HALF_EVEN : +0.50000000000000011 -> +1
+PHP_ROUND_HALF_ODD  : +0.50000000000000011 -> +1
+PHP_ROUND_HALF_UP   : -0.50000000000000011 -> -1
+PHP_ROUND_HALF_DOWN : -0.50000000000000011 -> -1
+PHP_ROUND_HALF_EVEN : -0.50000000000000011 -> -1
+PHP_ROUND_HALF_ODD  : -0.50000000000000011 -> -1

--- a/ext/standard/tests/math/round_gh12143_3.phpt
+++ b/ext/standard/tests/math/round_gh12143_3.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-12143: Test rounding of 0.5.
+--FILE--
+<?php
+foreach ([
+    0.5,
+    -0.5,
+] as $number) {
+    foreach ([
+        'PHP_ROUND_HALF_UP',
+        'PHP_ROUND_HALF_DOWN',
+        'PHP_ROUND_HALF_EVEN',
+        'PHP_ROUND_HALF_ODD',
+    ] as $mode) {
+        printf("%-20s: %+.17g -> %+.17g\n", $mode, $number, round($number, 0, constant($mode)));
+    }
+}
+?>
+--EXPECT--
+PHP_ROUND_HALF_UP   : +0.5 -> +1
+PHP_ROUND_HALF_DOWN : +0.5 -> +0
+PHP_ROUND_HALF_EVEN : +0.5 -> +0
+PHP_ROUND_HALF_ODD  : +0.5 -> +1
+PHP_ROUND_HALF_UP   : -0.5 -> -1
+PHP_ROUND_HALF_DOWN : -0.5 -> -0
+PHP_ROUND_HALF_EVEN : -0.5 -> -0
+PHP_ROUND_HALF_ODD  : -0.5 -> -1

--- a/ext/standard/tests/math/round_gh12143_4.phpt
+++ b/ext/standard/tests/math/round_gh12143_4.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-12143: Test rounding of 1.5.
+--FILE--
+<?php
+foreach ([
+    1.5,
+    -1.5,
+] as $number) {
+    foreach ([
+        'PHP_ROUND_HALF_UP',
+        'PHP_ROUND_HALF_DOWN',
+        'PHP_ROUND_HALF_EVEN',
+        'PHP_ROUND_HALF_ODD',
+    ] as $mode) {
+        printf("%-20s: %+.17g -> %+.17g\n", $mode, $number, round($number, 0, constant($mode)));
+    }
+}
+?>
+--EXPECT--
+PHP_ROUND_HALF_UP   : +1.5 -> +2
+PHP_ROUND_HALF_DOWN : +1.5 -> +1
+PHP_ROUND_HALF_EVEN : +1.5 -> +2
+PHP_ROUND_HALF_ODD  : +1.5 -> +1
+PHP_ROUND_HALF_UP   : -1.5 -> -2
+PHP_ROUND_HALF_DOWN : -1.5 -> -1
+PHP_ROUND_HALF_EVEN : -1.5 -> -2
+PHP_ROUND_HALF_ODD  : -1.5 -> -1


### PR DESCRIPTION
This change makes the implementation much easier to understand, by explicitly handling the various cases.

It fixes rounding for `0.49999999999999994`, because no loss of precision happens by adding / subtracing `0.5` before turning the result into an integral float. Instead the fractional parts are explicitly compared.

see GH-12143 (this fixes one of the reported cases)
Closes GH-12159 which was an alternative attempt to fix the rounding issue for `0.49999999999999994`

/cc @jorgsowa 