### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,5 +25,5 @@
 /Zend/zend_vm_handlers.h linguist-generated -diff
 /Zend/zend_vm_opcodes.[ch] linguist-generated -diff
 
-# The OSS fuzz files are bunary
+# The OSS fuzz files are binary
 /ext/date/tests/ossfuzz*.txt binary

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -992,7 +992,7 @@ volunteers to begin the selection process for the next release managers.
    ```shell
    cd /path/to/repos/php/web-php
    git submodule update
-   cd distributions           # This is the submodule refering to web-php-distributions
+   cd distributions           # This is the submodule referring to web-php-distributions
    git pull origin master
    cd ..
    git add distributions

--- a/ext/mbstring/tests/data/JISX0212.txt
+++ b/ext/mbstring/tests/data/JISX0212.txt
@@ -53,7 +53,7 @@
 #
 #	   However, JIS X 0212 maintains the distinction between
 #	   the lowercase forms of these two elements at 0x2942 and 0x2943.
-#	   Given the structre of these JIS encodings, it is clear that
+#	   Given the structure of these JIS encodings, it is clear that
 #	   0x2922 and 0x2942 are intended to be a capital/small pair.
 #	   Consequently, in the Unicode mapping, 0x2922 is treated as
 #	   LATIN CAPITAL LETTER D WITH STROKE.

--- a/ext/mbstring/tests/data/KSX1001.txt
+++ b/ext/mbstring/tests/data/KSX1001.txt
@@ -29,7 +29,7 @@
 # (at ftp://ftp.unicode.org/Public/MAPPING/EASTASIA/KSC) which is
 # actually NOT the mapping between KS X 1001(KS C 5601-1992) and Unicode 2.0
 # BUT the mapping table between UHC (Microsoft Unified Hangul Code)
-# and Unicode 2.0. Hence, in this pacakge, I renamed it as UHC.TXT
+# and Unicode 2.0. Hence, in this package, I renamed it as UHC.TXT
 #
 # Please, note that there was a change in naming scheme of
 # Korean standard for information exchange. 
@@ -50,7 +50,7 @@
 #    printf ("0x%04X  0x%04X  %s\n",$k-0x8080, $u,join(' ',@rest));
 #  }
 #
-# Column #1 : KS X 1001(KS C 5601-1992 excluding addtional Hangul
+# Column #1 : KS X 1001(KS C 5601-1992 excluding additional Hangul
 #            syllables defined for Johab encoding in Annex 3)
 #            in hex as 0xXXXX
 # Column #2 : the Unicode (in hex as 0xXXXX)

--- a/ext/reflection/tests/bug46064.phpt
+++ b/ext/reflection/tests/bug46064.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #46064 (Exception when creating ReflectionProperty object on dynamicly created property)
+Bug #46064 (Exception when creating ReflectionProperty object on dynamically created property)
 --FILE--
 <?php
 

--- a/ext/reflection/tests/bug46064_2.phpt
+++ b/ext/reflection/tests/bug46064_2.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #46064.2 (Exception when creating ReflectionProperty object on dynamicly created property)
+Bug #46064.2 (Exception when creating ReflectionProperty object on dynamically created property)
 --FILE--
 <?php
 

--- a/ext/session/tests/user_session_module/session_set_save_handler_class_012.phpt
+++ b/ext/session/tests/user_session_module/session_set_save_handler_class_012.phpt
@@ -19,7 +19,7 @@ class MySession extends SessionHandler {
         ++$this->i;
         echo 'Open:', session_id(), "\n";
         // This test was written for broken return value handling
-        // Mimmick what was actually being tested by returning true here
+        // Mimic what was actually being tested by returning true here
         return (null === parent::open());
     }
     public function read($key): string|false {

--- a/main/streams/xp_socket.c
+++ b/main/streams/xp_socket.c
@@ -173,7 +173,7 @@ static ssize_t php_sockop_read(php_stream *stream, char *buf, size_t count)
 		bool dont_wait = has_buffered_data ||
 				(sock->timeout.tv_sec == 0 && sock->timeout.tv_usec == 0);
 		/* Set MSG_DONTWAIT if no wait is needed or there is unlimited timeout which was
-		 * added by fix for #41984 commited in 9343c5404. */
+		 * added by fix for #41984 committed in 9343c5404. */
 		if (dont_wait || sock->timeout.tv_sec != -1) {
 			recv_flags = MSG_DONTWAIT;
 		}

--- a/sapi/cli/tests/php_cli_server_014.phpt
+++ b/sapi/cli/tests/php_cli_server_014.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Bug #60477: Segfault after two multipart/form-data POST requestes
+Bug #60477: Segfault after two multipart/form-data POST requests
 --SKIPIF--
 <?php
 include "skipif.inc";

--- a/sapi/fpm/fpm/fpm_events.h
+++ b/sapi/fpm/fpm/fpm_events.h
@@ -43,7 +43,7 @@ int fpm_event_init_main(void);
 int fpm_event_set(struct fpm_event_s *ev, int fd, int flags, void (*callback)(struct fpm_event_s *, short, void *), void *arg);
 int fpm_event_add(struct fpm_event_s *ev, unsigned long int timeout);
 int fpm_event_del(struct fpm_event_s *ev);
-int fpm_event_pre_init(char *machanism);
+int fpm_event_pre_init(char *mechanism);
 const char *fpm_event_mechanism_name(void);
 int fpm_event_support_edge_trigger(void);
 

--- a/sapi/fpm/fpm/fpm_log.c
+++ b/sapi/fpm/fpm/fpm_log.c
@@ -225,8 +225,8 @@ int fpm_log_write(char *log_format) /* {{{ */
 
 					/* milliseconds */
 					} else if (!strcasecmp(format, "milliseconds") || !strcasecmp(format, "milli") ||
-						   /* mili/milliseconds are supported for backwards compatibility */
-						   !strcasecmp(format, "milliseconds") || !strcasecmp(format, "mili")
+						   /* mili/miliseconds are supported for backwards compatibility */
+						   !strcasecmp(format, "miliseconds") || !strcasecmp(format, "mili")
 					) {
 						if (!test) {
 							len2 = snprintf(b, FPM_LOG_BUFFER - len, "%.3f", proc.duration.tv_sec * 1000. + proc.duration.tv_usec / 1000.);

--- a/sapi/fpm/fpm/fpm_log.c
+++ b/sapi/fpm/fpm/fpm_log.c
@@ -225,8 +225,8 @@ int fpm_log_write(char *log_format) /* {{{ */
 
 					/* milliseconds */
 					} else if (!strcasecmp(format, "milliseconds") || !strcasecmp(format, "milli") ||
-						   /* mili/miliseconds are supported for backwards compatibility */
-						   !strcasecmp(format, "miliseconds") || !strcasecmp(format, "mili")
+						   /* mili/milliseconds are supported for backwards compatibility */
+						   !strcasecmp(format, "milliseconds") || !strcasecmp(format, "mili")
 					) {
 						if (!test) {
 							len2 = snprintf(b, FPM_LOG_BUFFER - len, "%.3f", proc.duration.tv_sec * 1000. + proc.duration.tv_usec / 1000.);

--- a/sapi/fpm/tests/response.inc
+++ b/sapi/fpm/tests/response.inc
@@ -184,7 +184,7 @@ class Response
     /**
      * Expect error pattern in the response.
      *
-     * @param string $errorMessagePattern Expected error message RegExp patter.
+     * @param string $errorMessagePattern Expected error message RegExp pattern.
      *
      * @return Response
      */

--- a/sapi/fpm/www.conf.in
+++ b/sapi/fpm/www.conf.in
@@ -229,8 +229,8 @@ pm.max_spare_servers = 3
 ;                          it's always 0 if the process is not in Idle state
 ;                          because memory calculation is done when the request
 ;                          processing has terminated;
-; If the process is in Idle state, then informations are related to the
-; last request the process has served. Otherwise informations are related to
+; If the process is in Idle state, then information is related to the
+; last request the process has served. Otherwise information is related to
 ; the current request being served.
 ; Example output:
 ;   ************************
@@ -355,7 +355,7 @@ pm.max_spare_servers = 3
 
 ; A list of request_uri values which should be filtered from the access log.
 ;
-; As a security precuation, this setting will be ignored if:
+; As a security precaution, this setting will be ignored if:
 ;     - the request method is not GET or HEAD; or
 ;     - there is a request body; or
 ;     - there are query parameters; or

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3348,7 +3348,7 @@ function toolset_setup_intrinsic_cflags()
 		if (TARGET_ARCH == 'arm64') {
 			/* arm64 supports neon */
 			configure_subst.Add("PHP_SIMD_SCALE", 'NEON');
-			/* all offically supported arm64 cpu supports crc32 (TODO: to be confirmed) */
+			/* all officially supported arm64 cpu supports crc32 (TODO: to be confirmed) */
 			AC_DEFINE('HAVE_ARCH64_CRC32', 1);
 			return;
 		}

--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -271,7 +271,7 @@ foreach ($general_files as $src => $dest) {
 }
 
 /* include a snapshot identifier */
-$branch = "HEAD"; // TODO - determine this from SVN branche name
+$branch = "HEAD"; // TODO - determine this from SVN branch name
 $fp = fopen("$dist_dir/snapshot.txt", "w");
 $now = date("r");
 fwrite($fp, <<<EOT

--- a/win32/build/mkdist.php
+++ b/win32/build/mkdist.php
@@ -271,7 +271,7 @@ foreach ($general_files as $src => $dest) {
 }
 
 /* include a snapshot identifier */
-$branch = "HEAD"; // TODO - determine this from SVN branch name
+$branch = "HEAD"; // TODO - determine this from GitHub branch name
 $fp = fopen("$dist_dir/snapshot.txt", "w");
 $now = date("r");
 fwrite($fp, <<<EOT


### PR DESCRIPTION
https://pypi.org/project/codespell

```
codespell  --count --skip="./build/shtool,./sapi/cli/mime_type_map.h,./ext/*,./Zend/*" -q=3 \
          --ignore-words-list=ake,blong,clen,fo,gord,mis,mye,nam,miliseconds,nd,sav,ser,siz,statics,ths,suppressable
```