### PR TITLE
Fix GH-12232: FPM: segfault dynamically loading extension without opache

### DIFF
--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -119,6 +119,7 @@ struct _zend_compiler_globals {
 	bool multibyte;
 	bool detect_unicode;
 	bool encoding_declared;
+	bool interned_strings_initialized;
 
 	zend_ast *ast;
 	zend_arena *ast_arena;

--- a/Zend/zend_string.c
+++ b/Zend/zend_string.c
@@ -231,6 +231,9 @@ static zend_string* ZEND_FASTCALL zend_new_interned_string_request(zend_string *
 		return ret;
 	}
 
+	if (!CG(interned_strings_initialized)) {
+		zend_interned_strings_activate();
+	}
 	ret = zend_interned_string_ht_lookup(str, &CG(interned_strings));
 	if (ret) {
 		zend_string_release(str);
@@ -339,6 +342,7 @@ static zend_string* ZEND_FASTCALL zend_string_init_existing_interned_request(con
 ZEND_API void zend_interned_strings_activate(void)
 {
 	zend_init_interned_strings_ht(&CG(interned_strings), 0);
+	CG(interned_strings_initialized) = true;
 }
 
 ZEND_API void zend_interned_strings_deactivate(void)


### PR DESCRIPTION
The reason for the cache is that loading happens after the child is forked before the interned strings are initialiazed if opcache is not loaded. If opcache is loaded, it overwrites `zend_new_interned_string_request` and uses its own version which does not have this issue.

The fix makes sure that the interned string hast table is initialized before used.