### PR TITLE
Remove _IO_cookie_io_functions_t in favor of cookie_io_functions_t

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1431,18 +1431,14 @@ AC_DEFUN([PHP_FOPENCOOKIE], [
   AC_CHECK_FUNC(fopencookie, [have_glibc_fopencookie=yes])
 
   if test "$have_glibc_fopencookie" = "yes"; then
-dnl This comes in two flavors: newer glibcs (since 2.1.2?) have a type called
-dnl cookie_io_functions_t.
+dnl glibcs (since 2.1.2?) have a type called cookie_io_functions_t.
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #define _GNU_SOURCE
 #include <stdio.h>
 ]], [[cookie_io_functions_t cookie;]])],[have_cookie_io_functions_t=yes],[])
 
     if test "$have_cookie_io_functions_t" = "yes"; then
-      cookie_io_functions_t=cookie_io_functions_t
-      have_fopen_cookie=yes
-
-dnl Even newer glibcs have a different seeker definition.
+dnl Newer glibcs have a different seeker definition.
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #define _GNU_SOURCE
 #include <stdio.h>
@@ -1488,22 +1484,8 @@ int main(void) {
   esac
 ])
 
-    else
-
-dnl Older glibc versions (up to 2.1.2?) call it _IO_cookie_io_functions_t.
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#define _GNU_SOURCE
-#include <stdio.h>
-]], [[_IO_cookie_io_functions_t cookie;]])], [have_IO_cookie_io_functions_t=yes], [])
-      if test "$have_cookie_io_functions_t" = "yes" ; then
-        cookie_io_functions_t=_IO_cookie_io_functions_t
-        have_fopen_cookie=yes
-      fi
-    fi
-
-    if test "$have_fopen_cookie" = "yes" ; then
       AC_DEFINE(HAVE_FOPENCOOKIE, 1, [ ])
-      AC_DEFINE_UNQUOTED(COOKIE_IO_FUNCTIONS_T, $cookie_io_functions_t, [ ])
+
       if test "$cookie_io_functions_use_off64_t" = "yes" ; then
         AC_DEFINE(COOKIE_SEEKER_USES_OFF64_T, 1, [ ])
       fi

--- a/main/streams/cast.c
+++ b/main/streams/cast.c
@@ -42,9 +42,9 @@ typedef struct {
 	int (*writer)(void *, const char *, int);
 	PHP_FPOS_T (*seeker)(void *, PHP_FPOS_T, int);
 	int (*closer)(void *);
-} COOKIE_IO_FUNCTIONS_T;
+} cookie_io_functions_t;
 
-FILE *fopencookie(void *cookie, const char *mode, COOKIE_IO_FUNCTIONS_T *funcs)
+FILE *fopencookie(void *cookie, const char *mode, cookie_io_functions_t *funcs)
 {
 	return funopen(cookie, funcs->reader, funcs->writer, funcs->seeker, funcs->closer);
 }
@@ -133,7 +133,7 @@ static int stream_cookie_closer(void *cookie)
 #endif /* elif defined(HAVE_FOPENCOOKIE) */
 
 #if HAVE_FOPENCOOKIE
-static COOKIE_IO_FUNCTIONS_T stream_cookie_functions =
+static cookie_io_functions_t stream_cookie_functions =
 {
 	stream_cookie_reader, stream_cookie_writer,
 	stream_cookie_seeker, stream_cookie_closer


### PR DESCRIPTION
As noted in glibc, the cookie_io_functions_t should be used instead of internal _IO_cookie_io_functions_t.

The _IO_cookie_io_functions_t was once used as a convenience for not having the cookie_io_functions_t available (glibc <=2.1.1) as noted in 67bb9d1ae23fe4c7e4160dabfb4f07b51dccabf1.

Check in the build system was also always setting the COOKIE_IO_FUNCTIONS_T to cookie_io_functions_t due to a typo. There is unused variable have_IO_cookie_io_functions_t vs.
have_cookie_io_functions_t.

- COOKIE_IO_FUNCTIONS_T removed