### PR TITLE
Fix memory leak of doc blocks of static properties

### DIFF
--- a/Zend/tests/traits/bugs/overridding-static-property-with-doc-block.phpt
+++ b/Zend/tests/traits/bugs/overridding-static-property-with-doc-block.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Overriding a static property where both declarations have a doc block does not leak memory
+--FILE--
+<?php
+trait MyTrait {
+    /**
+     * trait comment
+     */
+    static $property;
+}
+
+class MyClass {
+    use MyTrait;
+
+    /**
+     * class comment
+     */
+    static $property;
+}
+--EXPECT--

--- a/Zend/tests/traits/bugs/overridding-static-property-with-doc-block.phpt
+++ b/Zend/tests/traits/bugs/overridding-static-property-with-doc-block.phpt
@@ -17,4 +17,5 @@ class MyClass {
      */
     static $property;
 }
+?>
 --EXPECT--

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4332,6 +4332,9 @@ ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, z
 		    (property_info_ptr->flags & ZEND_ACC_STATIC) != 0) {
 			property_info->offset = property_info_ptr->offset;
 			zval_ptr_dtor(&ce->default_static_members_table[property_info->offset]);
+			if (property_info_ptr->doc_comment) {
+				zend_string_release(property_info_ptr->doc_comment);
+			}
 			zend_hash_del(&ce->properties_info, name);
 		} else {
 			property_info->offset = ce->default_static_members_count++;
@@ -4350,6 +4353,9 @@ ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, z
 		    (property_info_ptr->flags & ZEND_ACC_STATIC) == 0) {
 			property_info->offset = property_info_ptr->offset;
 			zval_ptr_dtor(&ce->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]);
+            if (property_info_ptr->doc_comment) {
+                zend_string_release_ex(property_info_ptr->doc_comment, 1);
+            }
 			zend_hash_del(&ce->properties_info, name);
 
 			ZEND_ASSERT(ce->type == ZEND_INTERNAL_CLASS);

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4353,9 +4353,9 @@ ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, z
 		    (property_info_ptr->flags & ZEND_ACC_STATIC) == 0) {
 			property_info->offset = property_info_ptr->offset;
 			zval_ptr_dtor(&ce->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]);
-            if (property_info_ptr->doc_comment) {
-                zend_string_release_ex(property_info_ptr->doc_comment, 1);
-            }
+			if (property_info_ptr->doc_comment) {
+				zend_string_release_ex(property_info_ptr->doc_comment, 1);
+			}
 			zend_hash_del(&ce->properties_info, name);
 
 			ZEND_ASSERT(ce->type == ZEND_INTERNAL_CLASS);


### PR DESCRIPTION
When declaring the same static property with a doc block in a class and in a trait, the doc block of the property in the class is leaked.

This fixes #12207.