### PR TITLE
Fix GH-12243, segfault on IntlDateFormatter::construct with dateType

### DIFF
--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -99,7 +99,11 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 	}
 	if (!INTL_UDATE_FMT_OK(time_type)) {
 		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: invalid time format style", 0);
-return FAILURE;
+		return FAILURE;
+	}
+	if (date_type == UDAT_PATTERN && time_type != UDAT_PATTERN) {
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: time format must be UDAT_PATTERN if date format is UDAT_PATTERN", 0);
+		return FAILURE;
 	}
 
 	INTL_CHECK_LOCALE_LEN_OR_FAILURE(locale_len);

--- a/ext/intl/tests/gh12243.phpt
+++ b/ext/intl/tests/gh12243.phpt
@@ -1,0 +1,24 @@
+--TEST--
+GitHub #12043 segfault with IntlDateFormatter::dateType where it equals to UDAT_PATTERN (icu 50) but
+IntldateFormatter::timeType needs to be set as such.
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+$datetime = new \DateTime('2017-05-12 23:11:00 GMT+2');
+static $UDAT_PATTERN = -2;
+
+try {
+    new IntlDateFormatter(
+	    locale: 'en',
+	    dateType: $UDAT_PATTERN,
+	    timeType: 0,
+	    timezone: $datetime->getTimezone(),
+    );
+} catch (\IntlException $e) {
+    echo $e->getMessage();
+}
+
+--EXPECT--
+datefmt_create: time format must be UDAT_PATTERN if date format is UDAT_PATTERN: U_ILLEGAL_ARGUMENT_ERROR


### PR DESCRIPTION
 set to UDAT_PATTERN but not timeType.

udat_open expects its timeStyle's argument to be set to UDAT_PATTERN
 when dateStyle is, regardless if there an actual pattern or not.