### PR TITLE
Use __builtin_unreachable() for ZEND_UNREACHABLE

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -106,10 +106,19 @@
 # define ZEND_ASSERT(c) ZEND_ASSUME(c)
 #endif
 
+#ifdef __has_builtin
+# if __has_builtin(__builtin_unreachable)
+#  define _ZEND_UNREACHABLE() __builtin_unreachable()
+# endif
+#endif
+#ifndef _ZEND_UNREACHABLE
+# define _ZEND_UNREACHABLE() ZEND_ASSUME(0)
+#endif
+
 #if ZEND_DEBUG
-# define ZEND_UNREACHABLE() do {ZEND_ASSERT(0); ZEND_ASSUME(0);} while (0)
+# define ZEND_UNREACHABLE() do {ZEND_ASSERT(0); _ZEND_UNREACHABLE();} while (0)
 #else
-# define ZEND_UNREACHABLE() ZEND_ASSUME(0)
+# define ZEND_UNREACHABLE() _ZEND_UNREACHABLE()
 #endif
 
 /* pseudo fallthrough keyword; */


### PR DESCRIPTION
~~__builtin_assume() is only supported on Clang. __builtin_unreachable() may provide additional hints to GCC.~~

More accurately, on GCC the code `if (__builtin_expect(!(0), 0)) __builtin_unreachable();` is generated for unreachable. However, GCC does not seem to accurately mark the path as unreachable due to the `if` statement. Removing it fixes the warning.

Motivated by the compile error in https://github.com/php/php-src/actions/runs/6242795686/job/16947298463.

/cc @TimWolla