### PR TITLE
Fix memory leak when calling xml_parse_into_struct() twice

### DIFF
--- a/ext/xml/tests/gh12254.phpt
+++ b/ext/xml/tests/gh12254.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GH-12254: xml_parse_into_struct() memory leak when called twice
+--EXTENSIONS--
+xml
+--FILE--
+<?php
+
+$parser = xml_parser_create();
+xml_set_element_handler($parser, function ($parser, $name, $attrs) {
+    echo "open\n";
+    var_dump($name, $attrs);
+    var_dump(xml_parse_into_struct($parser, "<container/>", $values, $tags));
+}, function ($parser, $name) {
+    echo "close\n";
+    var_dump($name);
+});
+xml_parse_into_struct($parser, "<container/>", $values, $tags);
+// Yes, this doesn't do anything but it at least shouldn't leak...
+xml_parse_into_struct($parser, "<container/>", $values, $tags);
+
+?>
+--EXPECTF--
+open
+string(9) "CONTAINER"
+array(0) {
+}
+
+Warning: xml_parse_into_struct(): Parser must not be called recursively in %s on line %d
+bool(false)
+close
+string(9) "CONTAINER"


### PR DESCRIPTION
Note: test will fail unless https://github.com/php/php-src/pull/12253 is also merged. The fix of that PR is not included here.

Two bugs:
* Recursion checked too late, causing memory leak
* Memory leak on ltags