### PR TITLE
Use autoconf for recognizing __builtin_unreachable()

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -92,7 +92,7 @@
 #elif defined(__clang__) && __has_builtin(__builtin_assume)
 # pragma clang diagnostic ignored "-Wassume"
 # define ZEND_ASSUME(c)	__builtin_assume(c)
-#elif ((defined(__GNUC__) && ZEND_GCC_VERSION >= 4005) || __has_builtin(__builtin_unreachable)) && PHP_HAVE_BUILTIN_EXPECT
+#elif PHP_HAVE_BUILTIN_UNREACHABLE && PHP_HAVE_BUILTIN_EXPECT
 # define ZEND_ASSUME(c)	do { \
 		if (__builtin_expect(!(c), 0)) __builtin_unreachable(); \
 	} while (0)
@@ -106,12 +106,9 @@
 # define ZEND_ASSERT(c) ZEND_ASSUME(c)
 #endif
 
-#ifdef __has_builtin
-# if __has_builtin(__builtin_unreachable)
-#  define _ZEND_UNREACHABLE() __builtin_unreachable()
-# endif
-#endif
-#ifndef _ZEND_UNREACHABLE
+#ifdef PHP_HAVE_BUILTIN_UNREACHABLE
+# define _ZEND_UNREACHABLE() __builtin_unreachable()
+#else
 # define _ZEND_UNREACHABLE() ZEND_ASSUME(0)
 #endif
 

--- a/build/php.m4
+++ b/build/php.m4
@@ -2465,6 +2465,25 @@ AC_DEFUN([PHP_CHECK_BUILTIN_EXPECT], [
 ])
 
 dnl
+dnl PHP_CHECK_BUILTIN_UNREACHABLE
+dnl
+AC_DEFUN([PHP_CHECK_BUILTIN_UNREACHABLE], [
+  AC_MSG_CHECKING([for __builtin_unreachable])
+
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[
+    __builtin_unreachable();
+  ]])], [
+    have_builtin_unreachable=1
+    AC_MSG_RESULT([yes])
+  ], [
+    have_builtin_unreachable=0
+    AC_MSG_RESULT([no])
+  ])
+
+  AC_DEFINE_UNQUOTED([PHP_HAVE_BUILTIN_UNREACHABLE], [$have_builtin_unreachable], [Whether the compiler supports __builtin_unreachable])
+])
+
+dnl
 dnl PHP_CHECK_BUILTIN_CLZ
 dnl
 AC_DEFUN([PHP_CHECK_BUILTIN_CLZ], [

--- a/configure.ac
+++ b/configure.ac
@@ -494,6 +494,8 @@ PHP_CHECK_STDINT_TYPES
 
 dnl Check __builtin_expect
 PHP_CHECK_BUILTIN_EXPECT
+dnl Check __builtin_unreachable
+PHP_CHECK_BUILTIN_UNREACHABLE
 dnl Check __builtin_clz
 PHP_CHECK_BUILTIN_CLZ
 dnl Check __builtin_clzl


### PR DESCRIPTION
Older versions of GCC don't support __has_builtin(), but do support __builtin_unreachable().