### PR TITLE
Make sure core module has number 0

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -3271,7 +3271,7 @@ ZEND_API void zend_post_deactivate_modules(void) /* {{{ */
 /* return the next free module number */
 ZEND_API int zend_next_free_module(void) /* {{{ */
 {
-	return zend_hash_num_elements(&module_registry) + 1;
+	return zend_hash_num_elements(&module_registry);
 }
 /* }}} */
 

--- a/Zend/zend_builtin_functions.c
+++ b/Zend/zend_builtin_functions.c
@@ -59,7 +59,13 @@ zend_module_entry zend_builtin_module = { /* {{{ */
 
 zend_result zend_startup_builtin_functions(void) /* {{{ */
 {
-	return (EG(current_module) = zend_register_module_ex(&zend_builtin_module, MODULE_PERSISTENT)) == NULL ? FAILURE : SUCCESS;
+	zend_module_entry *module;
+	EG(current_module) = module = zend_register_module_ex(&zend_builtin_module, MODULE_PERSISTENT);
+	if (UNEXPECTED(module == NULL)) {
+		return FAILURE;
+	}
+	ZEND_ASSERT(module->module_number == 0);
+	return SUCCESS;
 }
 /* }}} */
 

--- a/sapi/cli/tests/025.phpt
+++ b/sapi/cli/tests/025.phpt
@@ -1,0 +1,19 @@
+--TEST--
+CLI php -i extension_dir
+--SKIPIF--
+<?php
+include "skipif.inc";
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die ("skip not for Windows");
+}
+?>
+--FILE--
+<?php
+
+$php = getenv('TEST_PHP_EXECUTABLE_ESCAPED');
+$output = `$php -n -i`;
+var_dump(str_contains($output, "extension_dir => "));
+
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
Some places, possibly also outside PHP, assume the core extension has module number 0. After 8a812c3fda this wasn't the case anymore as reported in [1]. Fix it by changing how the next module ID is computed.

[1] https://github.com/php/php-src/pull/12246#issuecomment-1731432377