### PR TITLE
Fix GH-12273 - configure __builtin_cpu_init() check

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2732,7 +2732,7 @@ AC_DEFUN([PHP_CHECK_BUILTIN_CPU_INIT], [
   AC_MSG_CHECKING([for __builtin_cpu_init])
 
   AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[
-    return __builtin_cpu_init()? 1 : 0;
+    __builtin_cpu_init();
   ]])], [
     have_builtin_cpu_init=1
     AC_MSG_RESULT([yes])


### PR DESCRIPTION
__builtin_cpu_init() is documented as having a void return type.  It happens to return int on gcc, but is void on clang.

This blocks ifunc support on clang systems.