### PR TITLE
Fix GH-12232: FPM: segfault dynamically loading extension without opcache

### DIFF
--- a/Zend/zend_ini.c
+++ b/Zend/zend_ini.c
@@ -211,7 +211,6 @@ ZEND_API zend_result zend_register_ini_entries_ex(const zend_ini_entry_def *ini_
 	 * lead to death.
 	 */
 	if (directives != EG(ini_directives)) {
-		ZEND_ASSERT(module_type == MODULE_TEMPORARY);
 		directives = EG(ini_directives);
 	} else {
 		ZEND_ASSERT(module_type == MODULE_PERSISTENT);

--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -87,7 +87,9 @@ int fpm_php_apply_defines_ex(struct key_value_s *kv, int mode) /* {{{ */
 
 	if (!strcmp(name, "extension") && *value) {
 		zval zv;
+		zend_interned_strings_switch_storage(0);
 		php_dl(value, MODULE_PERSISTENT, &zv, 1);
+		zend_interned_strings_switch_storage(1);
 		return Z_TYPE(zv) == IS_TRUE;
 	}
 

--- a/sapi/fpm/tests/gh12232-php-value-extension.phpt
+++ b/sapi/fpm/tests/gh12232-php-value-extension.phpt
@@ -1,0 +1,51 @@
+--TEST--
+FPM: gh12232 - loading shared ext in FPM config
+--SKIPIF--
+<?php
+include "skipif.inc";
+FPM\Tester::skipIfSharedExtensionNotFound('dl_test');
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+pm.status_path = /status
+catch_workers_output = yes
+php_admin_value[extension] = dl_test
+EOT;
+
+$code = <<<EOT
+<?php
+var_dump(extension_loaded('dl_test'));
+var_dump(ini_get('dl_test.string'));
+ini_set('dl_test.string', 'test');
+var_dump(ini_get('dl_test.string'));
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectBody(['bool(true)', 'string(5) "hello"', 'string(4) "test"']);
+$tester->request()->expectBody(['bool(true)', 'string(5) "hello"', 'string(4) "test"']);
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>
+<?php

--- a/sapi/fpm/tests/tester.inc
+++ b/sapi/fpm/tests/tester.inc
@@ -320,6 +320,17 @@ class Tester
     }
 
     /**
+     * Skip if shared extension is not available in extension directory.
+     */
+    static public function skipIfSharedExtensionNotFound($extensionName)
+    {
+        $soPath = ini_get('extension_dir') . '/' . $extensionName . '.so';
+        if ( ! file_exists($soPath)) {
+            die("skip $extensionName extension not present in extension_dir");
+        }
+    }
+
+    /**
      * Tester constructor.
      *
      * @param string|array $configTemplate


### PR DESCRIPTION
This is alternative fix that uses `zend_interned_strings_switch_storage` before using `php_dl` to make sure that permanent internet string storage is used instead of request storage. Suggested by @dstogov in #12233