### PR TITLE
#53655: Improve speed of DOMNode::C14N() on large XML documents

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -102,3 +102,6 @@ PHP 8.4 UPGRADE NOTES
 14. Performance Improvements
 ========================================
 
+* The performance of DOMNode::C14N() is greatly improved for the case without
+  an xpath query. This can give a time improvement of easily two order of
+  magnitude for documents with tens of thousands of nodes.

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1736,6 +1736,25 @@ PHP_METHOD(DOMNode, lookupNamespaceURI)
 }
 /* }}} end dom_node_lookup_namespace_uri */
 
+static int dom_canonicalize_node_parent_lookup_cb(void *user_data, xmlNodePtr node, xmlNodePtr parent)
+{
+	xmlNodePtr root = user_data;
+	/* We have to unroll the first iteration because node->parent
+	 * is not necessarily equal to parent due to libxml2 tree rules (ns decls out of the tree for example). */
+	if (node == root) {
+		return 1;
+	}
+	node = parent;
+	while (node != NULL) {
+		if (node == root) {
+			return 1;
+		}
+		node = node->parent;
+	}
+
+	return 0;
+}
+
 static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ */
 {
 	zval *id;
@@ -1779,22 +1798,10 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 
 	php_libxml_invalidate_node_list_cache_from_doc(docp);
 
+	bool simple_node_parent_lookup_callback = false;
 	if (xpath_array == NULL) {
 		if (nodep->type != XML_DOCUMENT_NODE) {
-			ctxp = xmlXPathNewContext(docp);
-			ctxp->node = nodep;
-			xpathobjp = xmlXPathEvalExpression((xmlChar *) "(.//. | .//@* | .//namespace::*)", ctxp);
-			ctxp->node = NULL;
-			if (xpathobjp && xpathobjp->type == XPATH_NODESET) {
-				nodeset = xpathobjp->nodesetval;
-			} else {
-				if (xpathobjp) {
-					xmlXPathFreeObject(xpathobjp);
-				}
-				xmlXPathFreeContext(ctxp);
-				zend_throw_error(NULL, "XPath query did not return a nodeset");
-				RETURN_THROWS();
-			}
+			simple_node_parent_lookup_callback = true;
 		}
 	} else {
 		/*xpath query from xpath_array */
@@ -1873,8 +1880,11 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 	}
 
 	if (buf != NULL) {
-		ret = xmlC14NDocSaveTo(docp, nodeset, exclusive, inclusive_ns_prefixes,
-			with_comments, buf);
+		if (simple_node_parent_lookup_callback) {
+			ret = xmlC14NExecute(docp, dom_canonicalize_node_parent_lookup_cb, nodep, exclusive, inclusive_ns_prefixes, with_comments, buf);
+		} else {
+			ret = xmlC14NDocSaveTo(docp, nodeset, exclusive, inclusive_ns_prefixes, with_comments, buf);
+		}
 	}
 
 	if (inclusive_ns_prefixes != NULL) {

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -1796,8 +1796,6 @@ static void dom_canonicalization(INTERNAL_FUNCTION_PARAMETERS, int mode) /* {{{ 
 		RETURN_THROWS();
 	}
 
-	php_libxml_invalidate_node_list_cache_from_doc(docp);
-
 	bool simple_node_parent_lookup_callback = false;
 	if (xpath_array == NULL) {
 		if (nodep->type != XML_DOCUMENT_NODE) {

--- a/ext/dom/tests/canonicalization_special_nodes.phpt
+++ b/ext/dom/tests/canonicalization_special_nodes.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test: Canonicalization with special nodes
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+$xml = <<<EOXML
+<?xml version="1.0"?>
+<!DOCTYPE doc [
+]>
+<doc xmlns="">
+    <![CDATA[bar]]>
+    <!-- x -->
+    <temp xmlns=""/>
+    <?pi-no-data          ?>
+</doc>
+EOXML;
+
+$dom = new DOMDocument();
+$dom->loadXML($xml);
+$doc = $dom->documentElement;
+echo $doc->C14N(withComments: true);
+echo $doc->C14N(withComments: false);
+
+?>
+--EXPECT--
+<doc>
+    bar
+    <!-- x -->
+    <temp></temp>
+    <?pi-no-data?>
+</doc><doc>
+    bar
+    
+    <temp></temp>
+    <?pi-no-data?>
+</doc>


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=53655

The XPath query is in accordance to spec [1]. However, we can do it in a
simpler way. We can use a custom callback function instead of a linear
search in XPath to check if a node is visible. Note that comment nodes
are handled internally by libxml2 already, so we do not need to
differentiate between node types. The callback will do an upwards
traversal of the tree until the root of the canonicalization is reached.
In practice this will speed up the application a lot.

[1] https://www.w3.org/TR/2001/REC-xml-c14n-20010315 section 2.1

This can make processing easily 100 times faster for a large document. I generated some random XML documents with https://codebeautify.org/generate-random-xml: https://gist.github.com/nielsdos/369813d1b1c5c146a6fd7992b8ddbc28

file.xml: before -> after:
random.xml: 0.159s -> 0.004s
large.xml: 1.256s -> 0.008s

There's another speed-up I could do by replacing the linear search with a search in a HashTable, that's orthogonal to this but also a smaller time save. That's important for the cases that do use a nodeset. something to do as a follow-up probably.