### PR TITLE
random: Perform fewer iterations if SKIP_SLOW_TESTS is set

### DIFF
--- a/ext/random/tests/02_engine/all_serialize_user.phpt
+++ b/ext/random/tests/02_engine/all_serialize_user.phpt
@@ -21,6 +21,7 @@ final class CountingEngine32 implements Engine
 $engines = [];
 $engines[] = new CountingEngine32();
 $engines[] = new TestShaEngine();
+$iterations = getenv("SKIP_SLOW_TESTS") ? 3_000 : 10_000;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
@@ -31,7 +32,7 @@ foreach ($engines as $engine) {
 
     $engine2 = unserialize(serialize($engine));
 
-    for ($i = 0; $i < 10_000; $i++) {
+    for ($i = 0; $i < $iterations; $i++) {
         if ($engine->generate() !== $engine2->generate()) {
             die("failure: state differs at {$i}");
         }

--- a/ext/random/tests/03_randomizer/compatibility_user.phpt
+++ b/ext/random/tests/03_randomizer/compatibility_user.phpt
@@ -16,6 +16,7 @@ $engines = [];
 $engines[] = new Mt19937(1234);
 $engines[] = new PcgOneseq128XslRr64(1234);
 $engines[] = new Xoshiro256StarStar(1234);
+$iterations = getenv("SKIP_SLOW_TESTS") ? 3_000 : 10_000;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
@@ -23,7 +24,7 @@ foreach ($engines as $engine) {
     $native_randomizer = new Randomizer(clone $engine);
     $user_randomizer = new Randomizer(new TestWrapperEngine(clone $engine));
 
-    for ($i = 0; $i < 10_000; $i++) {
+    for ($i = 0; $i < $iterations; $i++) {
         $native = $native_randomizer->getInt(0, $i);
         $user = $user_randomizer->getInt(0, $i);
 

--- a/ext/random/tests/03_randomizer/methods/getBytes.phpt
+++ b/ext/random/tests/03_randomizer/methods/getBytes.phpt
@@ -28,7 +28,7 @@ foreach ($engines as $engine) {
 
     $randomizer = new Randomizer($engine);
 
-    for ($i = 1; $i < $iterations; ++$i) {
+    for ($i = 1; $i < $iterations; $i++) {
         if (\strlen($randomizer->getBytes($i)) !== $i) {
             die("failure: incorrect string length at {$i}");
         }

--- a/ext/random/tests/03_randomizer/methods/getBytes.phpt
+++ b/ext/random/tests/03_randomizer/methods/getBytes.phpt
@@ -27,7 +27,8 @@ foreach ($engines as $engine) {
     $randomizer = new Randomizer($engine);
 
     // Using 10_000 is very slow.
-    for ($i = 1; $i < 1_000; $i++) {
+    $imax = getenv("SKIP_SLOW_TESTS") ? 10 : 1_000;
+    for ($i = 1; $i < $imax; ++$i) {
         if (\strlen($randomizer->getBytes($i)) !== $i) {
             die("failure: incorrect string length at {$i}");
         }

--- a/ext/random/tests/03_randomizer/methods/getBytes.phpt
+++ b/ext/random/tests/03_randomizer/methods/getBytes.phpt
@@ -21,7 +21,7 @@ $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
 // Using 10_000 is very slow.
-$iterations = getenv("SKIP_SLOW_TESTS") ? 10 : 1_000;
+$iterations = getenv("SKIP_SLOW_TESTS") ? 100 : 1_000;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;

--- a/ext/random/tests/03_randomizer/methods/getBytes.phpt
+++ b/ext/random/tests/03_randomizer/methods/getBytes.phpt
@@ -20,15 +20,15 @@ $engines[] = new PcgOneseq128XslRr64();
 $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
+// Using 10_000 is very slow.
+$iterations = getenv("SKIP_SLOW_TESTS") ? 10 : 1_000;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
 
     $randomizer = new Randomizer($engine);
 
-    // Using 10_000 is very slow.
-    $imax = getenv("SKIP_SLOW_TESTS") ? 10 : 1_000;
-    for ($i = 1; $i < $imax; ++$i) {
+    for ($i = 1; $i < $iterations; ++$i) {
         if (\strlen($randomizer->getBytes($i)) !== $i) {
             die("failure: incorrect string length at {$i}");
         }

--- a/ext/random/tests/03_randomizer/methods/getBytesFromString.phpt
+++ b/ext/random/tests/03_randomizer/methods/getBytesFromString.phpt
@@ -29,7 +29,7 @@ foreach ($engines as $engine) {
     var_dump($randomizer->getBytesFromString('a', 10));
     var_dump($randomizer->getBytesFromString(str_repeat('a', 256), 5));
 
-    for ($i = 1; $i < $iterations; $i++) {
+    for ($i = 1; $i < $iterations; ++$i) {
         $output = $randomizer->getBytesFromString(str_repeat('ab', $i), 500);
 
         // This check can theoretically fail with a chance of 0.5**500.

--- a/ext/random/tests/03_randomizer/methods/getBytesFromString.phpt
+++ b/ext/random/tests/03_randomizer/methods/getBytesFromString.phpt
@@ -20,6 +20,7 @@ $engines[] = new PcgOneseq128XslRr64();
 $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
+$iterations = getenv("SKIP_SLOW_TESTS") ? 10 : 250;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
@@ -28,7 +29,7 @@ foreach ($engines as $engine) {
     var_dump($randomizer->getBytesFromString('a', 10));
     var_dump($randomizer->getBytesFromString(str_repeat('a', 256), 5));
 
-    for ($i = 1; $i < 250; $i++) {
+    for ($i = 1; $i < $iterations; $i++) {
         $output = $randomizer->getBytesFromString(str_repeat('ab', $i), 500);
 
         // This check can theoretically fail with a chance of 0.5**500.

--- a/ext/random/tests/03_randomizer/methods/getBytesFromString.phpt
+++ b/ext/random/tests/03_randomizer/methods/getBytesFromString.phpt
@@ -29,7 +29,7 @@ foreach ($engines as $engine) {
     var_dump($randomizer->getBytesFromString('a', 10));
     var_dump($randomizer->getBytesFromString(str_repeat('a', 256), 5));
 
-    for ($i = 1; $i < $iterations; ++$i) {
+    for ($i = 1; $i < $iterations; $i++) {
         $output = $randomizer->getBytesFromString(str_repeat('ab', $i), 500);
 
         // This check can theoretically fail with a chance of 0.5**500.

--- a/ext/random/tests/03_randomizer/methods/getFloat.phpt
+++ b/ext/random/tests/03_randomizer/methods/getFloat.phpt
@@ -21,6 +21,7 @@ $engines[] = new PcgOneseq128XslRr64();
 $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
+$max = getenv("SKIP_SLOW_TESTS") ? 3_000.0 : 10_000.0;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
@@ -28,7 +29,7 @@ foreach ($engines as $engine) {
     $randomizer = new Randomizer($engine);
 
     // Basic range test.
-    for ($i = 0.0; $i < 10_000.0; $i += 1.2345) {
+    for ($i = 0.0; $i < $max; $i += 1.2345) {
         $result = $randomizer->getFloat(-$i, $i, IntervalBoundary::ClosedClosed);
 
         if ($result > $i || $result < -$i) {

--- a/ext/random/tests/03_randomizer/methods/getInt.phpt
+++ b/ext/random/tests/03_randomizer/methods/getInt.phpt
@@ -20,6 +20,7 @@ $engines[] = new PcgOneseq128XslRr64();
 $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
+$iterations = getenv("SKIP_SLOW_TESTS") ? 3_000 : 10_000;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
@@ -27,7 +28,7 @@ foreach ($engines as $engine) {
     $randomizer = new Randomizer($engine);
 
     // Basic range test.
-    for ($i = 0; $i < 10_000; $i++) {
+    for ($i = 0; $i < $iterations; $i++) {
         $result = $randomizer->getInt(-$i, $i);
 
         if ($result > $i || $result < -$i) {
@@ -36,7 +37,7 @@ foreach ($engines as $engine) {
     }
 
     // Test that extreme ranges do not throw.
-    for ($i = 0; $i < 10_000; $i++) {
+    for ($i = 0; $i < $iterations; $i++) {
         $randomizer->getInt(PHP_INT_MIN, PHP_INT_MAX);
     }
 }

--- a/ext/random/tests/03_randomizer/methods/nextFloat.phpt
+++ b/ext/random/tests/03_randomizer/methods/nextFloat.phpt
@@ -20,6 +20,7 @@ $engines[] = new PcgOneseq128XslRr64();
 $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
+$iterations = getenv("SKIP_SLOW_TESTS") ? 3_000 : 10_000;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
@@ -27,7 +28,7 @@ foreach ($engines as $engine) {
     $randomizer = new Randomizer($engine);
 
     // Basic range test.
-    for ($i = 0; $i < 10_000; $i++) {
+    for ($i = 0; $i < $iterations; $i++) {
         $result = $randomizer->nextFloat();
 
         if ($result >= 1 || $result < 0) {

--- a/ext/random/tests/03_randomizer/methods/pickArrayKeys.phpt
+++ b/ext/random/tests/03_randomizer/methods/pickArrayKeys.phpt
@@ -20,6 +20,7 @@ $engines[] = new PcgOneseq128XslRr64();
 $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
+$iterations = getenv("SKIP_SLOW_TESTS") ? 10 : 100;
 
 $array1 = []; // list
 $array2 = []; // associative array with only strings
@@ -38,7 +39,7 @@ foreach ($engines as $engine) {
 
     $randomizer = new Randomizer($engine);
 
-    for ($i = 1; $i < 100; $i++) {
+    for ($i = 1; $i < $iterations; $i++) {
         $result = $randomizer->pickArrayKeys($array1, $i);
 
         if (array_unique($result) !== $result) {

--- a/ext/random/tests/03_randomizer/methods/shuffleArray.phpt
+++ b/ext/random/tests/03_randomizer/methods/shuffleArray.phpt
@@ -20,6 +20,7 @@ $engines[] = new PcgOneseq128XslRr64();
 $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
+$length = getenv("SKIP_SLOW_TESTS") ? 1_000 : 5_000;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
@@ -27,7 +28,7 @@ foreach ($engines as $engine) {
     $randomizer = new Randomizer($engine);
 
     // This test is slow, test all numbers smaller than 50 and then in steps of 677 (which is prime).
-    for ($i = 1; $i < 5_000; $i += ($i < 50 ? 1 : 677)) {
+    for ($i = 1; $i < $length; $i += ($i < 50 ? 1 : 677)) {
         $array = range(1, $i);
 
         $result = $randomizer->shuffleArray($array);

--- a/ext/random/tests/03_randomizer/methods/shuffleBytes.phpt
+++ b/ext/random/tests/03_randomizer/methods/shuffleBytes.phpt
@@ -20,6 +20,7 @@ $engines[] = new PcgOneseq128XslRr64();
 $engines[] = new Xoshiro256StarStar();
 $engines[] = new Secure();
 $engines[] = new TestShaEngine();
+$length = getenv("SKIP_SLOW_TESTS") ? 1_000 : 5_000;
 
 function sort_bytes(string $bytes): string
 {
@@ -34,7 +35,7 @@ foreach ($engines as $engine) {
     $randomizer = new Randomizer($engine);
 
     // This test is slow, test all numbers smaller than 50 and then in steps of 677 (which is prime).
-    for ($i = 1; $i < 5_000; $i += ($i < 50 ? 1 : 677)) {
+    for ($i = 1; $i < $length; $i += ($i < 50 ? 1 : 677)) {
         $bytes = sort_bytes(random_bytes($i));
 
         $result = $randomizer->shuffleBytes($bytes);

--- a/ext/random/tests/03_randomizer/serialize.phpt
+++ b/ext/random/tests/03_randomizer/serialize.phpt
@@ -18,6 +18,7 @@ $engines[] = new Mt19937(1234, MT_RAND_PHP);
 $engines[] = new PcgOneseq128XslRr64(1234);
 $engines[] = new Xoshiro256StarStar(1234);
 $engines[] = new TestShaEngine("1234");
+$iterations = getenv("SKIP_SLOW_TESTS") ? 3_000 : 10_000;
 
 foreach ($engines as $engine) {
     echo $engine::class, PHP_EOL;
@@ -30,7 +31,7 @@ foreach ($engines as $engine) {
 
     $randomizer2 = unserialize(serialize($randomizer));
 
-    for ($i = 0; $i < 10_000; $i++) {
+    for ($i = 0; $i < $iterations; $i++) {
         if ($randomizer->getInt(0, $i) !== $randomizer2->getInt(0, $i)) {
             $className = $engine::class;
 


### PR DESCRIPTION
people running with SKIP_SLOW_TESTS don't want to wait for 1000x iterations of each engine. also 10x iterations should be sufficient to catch many potential issues