### PR TITLE
chore: More readable Windows ci tasks

### DIFF
--- a/.github/scripts/windows/test.bat
+++ b/.github/scripts/windows/test.bat
@@ -3,7 +3,11 @@ if /i "%GITHUB_ACTIONS%" neq "True" (
     exit /b 3
 )
 
+set WIN_SCRIPTS_DIR=%~dp0
+set SCRIPT_DRIVE=%~d0
+
 set SDK_RUNNER=%PHP_BUILD_CACHE_SDK_DIR%\phpsdk-%PHP_BUILD_CRT%-%PLATFORM%.bat
+rem SDK_RUNNER=%PHP_BUILD_CACHE_SDK_DIR%\phpsdk-%PHP_BUILD_CRT%-%PLATFORM%.bat
 if not exist "%SDK_RUNNER%" (
 	echo "%SDK_RUNNER%" doesn't exist
 	exit /b 3

--- a/.gitignore
+++ b/.gitignore
@@ -297,3 +297,5 @@ tmp-php.ini
 !/ext/fileinfo/magicdata.patch
 !/ext/pcre/pcre2lib/config.h
 !/win32/build/Makefile
+Firebird.zip
+hMailServer.exe


### PR DESCRIPTION
refactor: more readable CI tasks

    - test.bat
      - named variables for capturing drive and script
    - test_task.bat
      - using named variables from parent script
      - more readable psql & mysql
      - safer commands

This is intended to lead to a future refactor, in which these scripts are removed from a GitHub actions specific folder