### PR TITLE
Fix GH-12282: IntlDateFormatter::construct should throw an exception is

### DIFF
--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -111,6 +111,11 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 		locale_str = (char *) intl_locale_get_default();
 	}
 	locale = Locale::createFromName(locale_str);
+	/* get*Name accessors being set does not preclude being bogus */
+	if (locale.isBogus() || strlen(locale.getISO3Language()) == 0) {
+		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: invalid locale", 0);
+		return FAILURE;
+	}
 
 	/* process calendar */
 	if (datefmt_process_calendar_arg(calendar_obj, calendar_long, calendar_is_null, locale, "datefmt_create",

--- a/ext/intl/tests/gh12282.phpt
+++ b/ext/intl/tests/gh12282.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GitHub #12282 IntlDateFormatter::locale with invalid value.
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+try {
+    new IntlDateFormatter(
+	'xx',
+	IntlDateFormatter::FULL,
+	IntlDateFormatter::FULL,
+	null,
+	null,
+	'w'
+    );
+} catch (\IntlException $e) {
+    echo $e->getMessage();
+}
+--EXPECT--
+datefmt_create: invalid locale: U_ILLEGAL_ARGUMENT_ERROR


### PR DESCRIPTION
the locale field has an invalid value.