### PR TITLE
Reduce impact of stream file path check in filestat

### DIFF
--- a/ext/standard/filestat.c
+++ b/ext/standard/filestat.c
@@ -729,7 +729,7 @@ PHPAPI void php_stat(zend_string *filename, int type, zval *return_value)
 			char realpath[MAXPATHLEN];
 			const char *file_path_to_check;
 			/* if the wrapper is not found, we need to expand path to match open behavior */
-			if (EXPECTED(strstr(local, "://") == NULL || expand_filepath(local, realpath) == NULL)) {
+			if (EXPECTED(!php_is_stream_path(local) || expand_filepath(local, realpath) == NULL)) {
 				file_path_to_check = local;
 			} else {
 				file_path_to_check = realpath;

--- a/main/php_streams.h
+++ b/main/php_streams.h
@@ -619,6 +619,20 @@ PHPAPI HashTable *_php_get_stream_filters_hash(void);
 #define php_get_stream_filters_hash()	_php_get_stream_filters_hash()
 PHPAPI HashTable *php_get_stream_filters_hash_global(void);
 extern const php_stream_wrapper_ops *php_stream_user_wrapper_ops;
+
+static inline bool php_is_stream_path(const char *filename)
+{
+	const char *p;
+
+	for (p = filename;
+	     (*p >= 'a' && *p <= 'z') ||
+	     (*p >= 'A' && *p <= 'Z') ||
+	     (*p >= '0' && *p <= '9') ||
+	     *p == '+' || *p == '-' || *p == '.';
+	     p++);
+	return ((p != filename) && (p[0] == ':') && (p[1] == '/') && (p[2] == '/'));
+}
+
 END_EXTERN_C()
 #endif
 


### PR DESCRIPTION
Fix for #76857 introduced slight perf regression so this is an attempt to fix it. The idea is to re-use stream path check from ZendAccelerator that should be quicker than strstr.