### PR TITLE
Fix GH-12265: Cloning an object breaks serialization recursion

### DIFF
--- a/ext/standard/tests/serialize/gh12265.phpt
+++ b/ext/standard/tests/serialize/gh12265.phpt
@@ -1,0 +1,47 @@
+--TEST--
+GH-12265 (Cloning an object breaks serialization recursion)
+--FILE--
+<?php
+
+class A {
+    public function __construct(public B $x) {
+    }
+}
+
+class B {
+    public A $a;
+
+    public function __serialize()
+    {
+        return ['a' => new A($this)];
+    }
+}
+
+class C {
+    public B $b;
+
+    public function __construct() {
+        $this->b = new B;
+    }
+}
+
+$b = new B();
+$sb = serialize($b);
+$stb = serialize(new B);
+
+printf("serialized original:    %s\n", $sb);
+printf("serialized temp    :    %s\n", $stb);
+
+$c = new C;
+$sc = serialize($c);
+$stc = serialize(new C);
+
+printf("serialized original:    %s\n", $sc);
+printf("serialized temp    :    %s\n", $stc);
+
+?>
+--EXPECT--
+serialized original:    O:1:"B":1:{s:1:"a";O:1:"A":1:{s:1:"x";r:1;}}
+serialized temp    :    O:1:"B":1:{s:1:"a";O:1:"A":1:{s:1:"x";r:1;}}
+serialized original:    O:1:"C":1:{s:1:"b";O:1:"B":1:{s:1:"a";O:1:"A":1:{s:1:"x";r:2;}}}
+serialized temp    :    O:1:"C":1:{s:1:"b";O:1:"B":1:{s:1:"a";O:1:"A":1:{s:1:"x";r:2;}}}

--- a/ext/standard/tests/serialize/gh12265b.phpt
+++ b/ext/standard/tests/serialize/gh12265b.phpt
@@ -1,5 +1,5 @@
 --TEST--
-GH-12265 (Cloning an object breaks serialization recursion) - __serialize variation
+GH-12265 (Cloning an object breaks serialization recursion) - __sleep variation
 --FILE--
 <?php
 
@@ -11,9 +11,10 @@ class A {
 class B {
     public A $a;
 
-    public function __serialize()
+    public function __sleep()
     {
-        return ['a' => new A($this)];
+        $this->a = new A($this);
+        return ['a'];
     }
 }
 

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -682,8 +682,9 @@ static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var, b
 	} else if (!in_rcn_array
 	 && Z_REFCOUNT_P(var) == 1
 	 && (Z_OBJ_P(var)->properties == NULL || GC_REFCOUNT(Z_OBJ_P(var)->properties) == 1)
-	 /* __serialize may arbitrarily increase the refcount */
-	 && Z_OBJCE_P(var)->__serialize == NULL) {
+	 /* __serialize and __sleep may arbitrarily increase the refcount */
+	 && Z_OBJCE_P(var)->__serialize == NULL
+	 && zend_hash_find_known_hash(&Z_OBJCE_P(var)->function_table, ZSTR_KNOWN(ZEND_STR_SLEEP)) == NULL) {
 		return 0;
 	}
 

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -681,7 +681,9 @@ static inline zend_long php_add_var_hash(php_serialize_data_t data, zval *var, b
 		return 0;
 	} else if (!in_rcn_array
 	 && Z_REFCOUNT_P(var) == 1
-	 && (Z_OBJ_P(var)->properties == NULL || GC_REFCOUNT(Z_OBJ_P(var)->properties) == 1)) {
+	 && (Z_OBJ_P(var)->properties == NULL || GC_REFCOUNT(Z_OBJ_P(var)->properties) == 1)
+	 /* __serialize may arbitrarily increase the refcount */
+	 && Z_OBJCE_P(var)->__serialize == NULL) {
 		return 0;
 	}
 


### PR DESCRIPTION
It broke because of the refcount==1 condition added in 6c5942f83590e622b0e59e388912c67a51ea7bb7. Removing that condition would work, but remove an optimization. The test file starts with the outer object at RC1 so it isn't registered in var_hash, but during serialization it gets an additional reference so now we have a problem.