### PR TITLE
Enable ifunc checks on FreeBSD 12+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -568,10 +568,12 @@ dnl Checks for GCC function attributes on all systems except ones without glibc
 dnl Fix for these systems is already included in GCC 7, but not on GCC 6.
 dnl
 dnl At least some versions of FreeBSD seem to have buggy ifunc support, see
-dnl bug #77284. Conservatively don't use ifuncs on FreeBSD.
-AS_CASE([$host_alias], [*-*-*android*|*-*-*uclibc*|*-*-*musl*|*freebsd*|*openbsd*], [true], [
-  AX_GCC_FUNC_ATTRIBUTE([ifunc])
-  AX_GCC_FUNC_ATTRIBUTE([target])
+dnl bug #77284. Conservatively don't use ifuncs on FreeBSD prior to version 12.
+AS_CASE([$host_alias], [*-*-*android*|*-*-*uclibc*|*-*-*musl*|*openbsd*], [true], [
+  if test "`uname -s 2>/dev/null`" != "FreeBSD" || test "`uname -U 2>/dev/null`" -ge 1200000; then
+    AX_GCC_FUNC_ATTRIBUTE([ifunc])
+    AX_GCC_FUNC_ATTRIBUTE([target])
+  fi
 ])
 
 dnl Check for IPv6 support.


### PR DESCRIPTION
This was disabled in 2019 due to problems reported in FreeBSD 11. The original report (PHP bug 77284) includes a comment that FreeBSD 12 worked - which also happens to be the first version ifunc use appeared in libc.

---

A similar patch is currently in FreeBSD ports lang/php83, but backporting to earlier versions will only be done if nothing crops up.