### PR TITLE
Fix GH-12251: Add semicolon to end of odbc dsn

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2120,7 +2120,7 @@ int odbc_sqlconnect(odbc_connection **conn, char *db, char *uid, char *pwd, int 
 				} else {
 					pwd_quoted = pwd;
 				}
-				spprintf(&ldb, 0, "%s;UID=%s;PWD=%s", db, uid_quoted, pwd_quoted);
+				spprintf(&ldb, 0, "%s;UID=%s;PWD=%s;", db, uid_quoted, pwd_quoted);
 				if (uid_quoted && should_quote_uid) {
 					efree(uid_quoted);
 				}


### PR DESCRIPTION
closes #12251 

It seems that if the `$dsn` ends with a quote, it causes a connection error, so I added a semicolon at the end.

Any further modifications should be made to master, so I won't cover them in this PR, but I have some doubts about the specification where the second and third arguments are ignored under certain conditions.