### PR TITLE
Fix GH-12297: PHP Startup: Invalid library (maybe not a PHP library) …

### DIFF
--- a/ext/mysqlnd/php_mysqlnd.c
+++ b/ext/mysqlnd/php_mysqlnd.c
@@ -15,6 +15,9 @@
   +----------------------------------------------------------------------+
 */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include "php.h"
 #include "mysqlnd.h"
 #include "mysqlnd_priv.h"


### PR DESCRIPTION
…'mysqlnd.so' in Unknown on line

On some configurations, the COMPILE_DL_MYSQLND must come from config.h. If it isn't set, the get_module function won't be exposed, resulting in a failure when trying to load the library.
It's the same issue ext/fileinfo had a while back that was fixed in b0ba368d5.