### PR TITLE
Fix GH-12296: Ignore pwd empty check

### DIFF
--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -2099,9 +2099,7 @@ int odbc_sqlconnect(odbc_connection **conn, char *db, char *uid, char *pwd, int 
 			bool is_uid_set = uid && *uid
 				&& !strstr(db, "uid=")
 				&& !strstr(db, "UID=");
-			bool is_pwd_set = pwd && *pwd
-				&& !strstr(db, "pwd=")
-				&& !strstr(db, "PWD=");
+			bool is_pwd_set = !strstr(db, "pwd=") && !strstr(db, "PWD=");
 			if (is_uid_set && is_pwd_set) {
 				char *uid_quoted = NULL, *pwd_quoted = NULL;
 				bool should_quote_uid = !php_odbc_connstr_is_quoted(uid) && php_odbc_connstr_should_quote(uid);


### PR DESCRIPTION
fixes #12296 

This is a minimal fix. It now works even if we specify an empty string for the password.
Other modifications will be made to master.