### PR TITLE
unserialize: Deprecate the 'S' tag

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,9 @@ PHP                                                                        NEWS
   . array out of bounds, stack overflow handled for segfault handler on windows.
     (David Carlier)
 
+- Standard:
+  . Unserializing the uppercase 'S' tag is now deprecated. (timwolla)
+
 01 Aug 2024, PHP 8.4.0alpha4
 
 - GMP:

--- a/UPGRADING
+++ b/UPGRADING
@@ -446,6 +446,8 @@ PHP 8.4 UPGRADE NOTES
   . Calling stream_context_set_option() with 2 arguments is deprecated.
     Use stream_context_set_options() instead.
   . Raising zero to the power of negative number is deprecated.
+  . Unserializing strings using the uppercase 'S' tag is deprecated.
+    RFC: https://wiki.php.net/rfc/deprecations_php_8_4
 
 ========================================
 5. Changed Functions

--- a/ext/standard/tests/serialize/unserialize_uppercase_s.phpt
+++ b/ext/standard/tests/serialize/unserialize_uppercase_s.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test unserialize() with the 'S' format emits a deprecation.
+--FILE--
+<?php
+
+var_dump(unserialize('S:1:"e";'));
+var_dump(unserialize('S:1:"\65";'));
+
+?>
+--EXPECTF--
+Deprecated: unserialize(): Unserializing the 'S' format is deprecated in %s on line %d
+string(1) "e"
+
+Deprecated: unserialize(): Unserializing the 'S' format is deprecated in %s on line %d
+string(1) "e"

--- a/ext/standard/var_unserializer.re
+++ b/ext/standard/var_unserializer.re
@@ -1089,6 +1089,9 @@ use_double:
 	*p = YYCURSOR;
 
 	ZVAL_STR(rval, str);
+
+	php_error_docref(NULL, E_DEPRECATED, "Unserializing the 'S' format is deprecated");
+
 	return 1;
 }
 


### PR DESCRIPTION
Support for this was added in 8f5310afad0eeef6f2e45a03f6ff7d4a2a7653ce for forward-compatibility with PHP 6. There should not be any data that is legitimately using this format and removing it simplifies the unserializer as a security-sensitive piece of code.

RFC: https://wiki.php.net/rfc/deprecations_php_8_4#unserialize_s_s_tag