### PR TITLE
Fix #80092 (ZTS + preload = segfault on shutdown)

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -4780,6 +4780,8 @@ static int accel_finish_startup(void)
 			SIGG(check) = 0;
 #endif
 			php_request_shutdown(NULL); /* calls zend_shared_alloc_unlock(); */
+			EG(class_table) = NULL;
+			EG(function_table) = NULL;
 			PG(report_memleaks) = orig_report_memleaks;
 		} else {
 			zend_shared_alloc_unlock();

--- a/sapi/cli/tests/bug80092.phpt
+++ b/sapi/cli/tests/bug80092.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Bug #80092 (ZTS + preload = segfault on shutdown)
+--SKIPIF--
+<?php
+include 'skipif.inc';
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+    die ("skip not for Windows");
+}
+$extDir = ini_get('extension_dir');
+if (!file_exists($extDir . '/opcache.so')) {
+    die ('skip opcache shared object not found in extension_dir');
+}
+?>
+--FILE--
+<?php
+
+$php = getenv('TEST_PHP_EXECUTABLE');
+
+$cmd = [
+    PHP_BINARY, '-n',
+    '-dextension_dir=' . ini_get('extension_dir'),
+    '-dzend_extension=opcache.so',
+    '-dopcache.enable=1',
+    '-dopcache.enable_cli=1',
+    '-dopcache.preload=' . __DIR__ . '/preload.inc',
+    '-v'
+];
+
+$proc = proc_open($cmd, [['null'], ['pipe', 'w'], ['redirect', 1]], $pipes);
+echo stream_get_contents($pipes[1]);
+
+?>
+--EXPECTF--
+preloaded
+PHP %s
+Copyright (c) The PHP Group
+Zend Engine %s
+    with Zend OPcache %s

--- a/sapi/cli/tests/preload.inc
+++ b/sapi/cli/tests/preload.inc
@@ -1,0 +1,7 @@
+<?php
+
+class SomeClass {}
+
+function foo() {}
+
+echo "preloaded\n";


### PR DESCRIPTION
Fixes https://bugs.php.net/bug.php?id=80092

After preloading has executed, the executor globals for class_table and function_table are still referring to the values during preloading. If no request happens after that then these values will remain dangling pointers. If then the -v option on CLI or -h option (and possibly others) on CGI is provided, there is a double free. Fix it by nulling the pointers explicitly after preloading has finished to fix it for all SAPIs.