### PR TITLE
Fix GH-12099: phpdbg abort/segfault (php 8.1.21)

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -1708,8 +1708,10 @@ static int user_shutdown_function_call(zval *zv) /* {{{ */
 	/* set retval zval for FCI struct */
 	shutdown_function_entry->fci.retval = &retval;
 	call_status = zend_call_function(&shutdown_function_entry->fci, &shutdown_function_entry->fci_cache);
-	ZEND_ASSERT(call_status == SUCCESS);
 	zval_ptr_dtor(&retval);
+	if (UNEXPECTED(call_status != SUCCESS)) {
+		ZEND_ASSERT(EG(exception));
+	}
 
 	return 0;
 }


### PR DESCRIPTION
In the reporter's example, an unwinding exception is pending in EG(exception) causing zend_call_function() called from user_shutdown_function_call() to return FAILURE. This then triggers the assertion in user_shutdown_function_call().

This only happens in PHP 8.1. In PHP 8.2 and up this was indirectly fixed via 485d3acfe6. That commit made sure that only when EG(active) is false FAILURE can be returned. In other cases SUCCESS will be returned. As shutdown handlers are only called when EG(active) is true, this means the assertion never triggers.

We fix it in PHP 8.1 by relaxing the assertion. We should not abort when an exception is pending. Therefore, when FAILURE is returned, we will check if an exception is pending. If it is not, then we will fail the assertion. This is more in line with that commit on PHP 8.2 and up.

I wasn't able to make an isolated test for this, I used the reporter's reproducer.