### PR TITLE
Fix type error on XSLTProcessor::transformToDoc return value with SimpleXML

### DIFF
--- a/ext/xsl/php_xsl.stub.php
+++ b/ext/xsl/php_xsl.stub.php
@@ -14,7 +14,7 @@ class XSLTProcessor
      * @param DOMDocument|SimpleXMLElement $document
      * @tentative-return-type
      */
-    public function transformToDoc(object $document, ?string $returnClass = null): DOMDocument|false {}
+    public function transformToDoc(object $document, ?string $returnClass = null): object|false {}
 
     /**
      * @param DOMDocument|SimpleXMLElement $document

--- a/ext/xsl/php_xsl_arginfo.h
+++ b/ext/xsl/php_xsl_arginfo.h
@@ -1,11 +1,11 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7c920913c15c9cd663f19f7ec5ad81648d6eddbc */
+ * Stub hash: 234923f47c0d9e83ba87d765fa7c1c2ea8d9f9b1 */
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_XSLTProcessor_importStylesheet, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, stylesheet, IS_OBJECT, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_XSLTProcessor_transformToDoc, 0, 1, DOMDocument, MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_MASK_EX(arginfo_class_XSLTProcessor_transformToDoc, 0, 1, MAY_BE_OBJECT|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, document, IS_OBJECT, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, returnClass, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()

--- a/ext/xsl/tests/transformToDoc_sxe_type_error.phpt
+++ b/ext/xsl/tests/transformToDoc_sxe_type_error.phpt
@@ -1,0 +1,52 @@
+--TEST--
+XSLTProcessor::transformToDoc return value type error with SimpleXML
+--EXTENSIONS--
+xsl
+--FILE--
+<?php
+
+class AdvancedXMLElement extends SimpleXMLElement {
+    public function foo() {
+        return "foo: " . (string) $this;
+    }
+}
+
+$sxe = simplexml_load_file(__DIR__ . '/53965/collection.xml', AdvancedXMLElement::class);
+
+$processor = new XSLTProcessor;
+$dom = new DOMDocument;
+$dom->load(__DIR__ . '/53965/collection.xsl');
+$processor->importStylesheet($dom);
+$result = $processor->transformToDoc($sxe, AdvancedXMLElement::class);
+
+var_dump($result);
+var_dump($result->h1->foo());
+
+?>
+--EXPECT--
+object(AdvancedXMLElement)#4 (3) {
+  ["h1"]=>
+  array(2) {
+    [0]=>
+    string(19) "Fight for your mind"
+    [1]=>
+    string(17) "Electric Ladyland"
+  }
+  ["h2"]=>
+  array(2) {
+    [0]=>
+    string(20) "by Ben Harper - 1995"
+    [1]=>
+    string(22) "by Jimi Hendrix - 1997"
+  }
+  ["hr"]=>
+  array(2) {
+    [0]=>
+    object(AdvancedXMLElement)#5 (0) {
+    }
+    [1]=>
+    object(AdvancedXMLElement)#6 (0) {
+    }
+  }
+}
+string(24) "foo: Fight for your mind"


### PR DESCRIPTION
The return type is wrong. You can also use this method with SimpleXML. In fact, PHP provides a way that even third party libraries can hook into its XML handling. Therefore, we cannot even use the SimpleXML|DOMDocument|false union type as third party extensions may extend the possibilities.

Broke in 8.1 in 1b35056a33.