### PR TITLE
Invalidate path even if the file was deleted

### DIFF
--- a/ext/opcache/ZendAccelerator.c
+++ b/ext/opcache/ZendAccelerator.c
@@ -1322,6 +1322,7 @@ int zend_accel_invalidate(zend_string *filename, bool force)
 {
 	zend_string *realpath;
 	zend_persistent_script *persistent_script;
+	zend_bool file_found = true;
 
 	if (!ZCG(accelerator_enabled) || accelerator_shm_read_lock() != SUCCESS) {
 		return FAILURE;
@@ -1330,7 +1331,10 @@ int zend_accel_invalidate(zend_string *filename, bool force)
 	realpath = accelerator_orig_zend_resolve_path(filename);
 
 	if (!realpath) {
-		return FAILURE;
+		//file could have been deleted, but we still need to invalidate it.
+		//so instead of failing, just use the provided filename for the lookup
+		realpath = zend_string_copy(filename);
+		file_found = false;
 	}
 
 	if (ZCG(accel_directives).file_cache) {
@@ -1366,12 +1370,13 @@ int zend_accel_invalidate(zend_string *filename, bool force)
 
 		file_handle.opened_path = NULL;
 		zend_destroy_file_handle(&file_handle);
+		file_found = true;
 	}
 
 	accelerator_shm_read_unlock();
 	zend_string_release_ex(realpath, 0);
 
-	return SUCCESS;
+	return file_found ? SUCCESS : FAILURE;
 }
 
 static zend_string* accel_new_interned_key(zend_string *key)

--- a/ext/opcache/tests/opcache_invalidate_deleted_file.phpt
+++ b/ext/opcache/tests/opcache_invalidate_deleted_file.phpt
@@ -1,0 +1,26 @@
+--TEST--
+opcache_invalidate() should invalidate deleted file
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable_cli=1
+opcache.validate_timestamps=0
+--FILE--
+<?php
+
+$file = __DIR__ . DIRECTORY_SEPARATOR . pathinfo(__FILE__, PATHINFO_FILENAME) . '.inc';
+file_put_contents($file, <<<PHP
+<?php
+return 42;
+PHP);
+var_dump(include $file);
+unlink($file);
+var_dump(include $file);
+opcache_invalidate($file);
+var_dump(@(include $file));
+
+?>
+--EXPECT--
+int(42)
+int(42)
+bool(false)


### PR DESCRIPTION
If the script was cached and deleted, the current implementation will not be able to invalidate it.
This change makes it still possible to delete script and then force its invalidation