### PR TITLE
zend call stack for DragonFlyBSD.

### DIFF
--- a/Zend/zend_call_stack.c
+++ b/Zend/zend_call_stack.c
@@ -35,10 +35,10 @@
 #  include <sys/types.h>
 # endif
 #endif /* ZEND_WIN32 */
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 # include <pthread.h>
 #endif
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 # include <pthread_np.h>
 # include <sys/mman.h>
 # include <sys/sysctl.h>
@@ -251,7 +251,7 @@ static bool zend_call_stack_get_linux(zend_call_stack *stack)
 }
 #endif /* __linux__ */
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 static bool zend_call_stack_is_main_thread(void)
 {
 	int is_main = pthread_main_np();

--- a/Zend/zend_call_stack.h
+++ b/Zend/zend_call_stack.h
@@ -76,6 +76,9 @@ static inline size_t zend_call_stack_default_size(void)
 #if defined(__FreeBSD__) || defined(__NetBSD__)
 	return 4 * 1024 * 1024;
 #endif
+#if defined(__DragonFly__)
+	return 2 * 1024 * 1024;
+#endif
 #ifdef __OpenBSD__
 	return 512 * 1024;
 #endif


### PR DESCRIPTION
Shares the same codepaths as FreeBSD for the most part.