### PR TITLE
fix mbstring.c -Wsingle-bit-bitfield-constant-conversion

### DIFF
--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -4202,10 +4202,8 @@ PHP_FUNCTION(mb_send_mail)
 	size_t i;
 	char *to_r = NULL;
 	char *force_extra_parameters = INI_STR("mail.force_extra_parameters");
-	struct {
-		int cnt_type:1;
-		int cnt_trans_enc:1;
-	} suppressed_hdrs = { 0, 0 };
+	bool uses_content_type = false;
+	bool uses_content_transfer_encoding = false;
 
 	char *p;
 	enum mbfl_no_encoding;
@@ -4288,7 +4286,7 @@ PHP_FUNCTION(mb_send_mail)
 				}
 			}
 		}
-		suppressed_hdrs.cnt_type = 1;
+		uses_content_type = true;
 	}
 
 	if ((s = zend_hash_str_find(&ht_headers, "content-transfer-encoding", sizeof("content-transfer-encoding") - 1))) {
@@ -4308,7 +4306,7 @@ PHP_FUNCTION(mb_send_mail)
 				body_enc =	&mbfl_encoding_8bit;
 				break;
 		}
-		suppressed_hdrs.cnt_trans_enc = 1;
+		uses_content_transfer_encoding = true;
 	}
 
 	/* To: */
@@ -4393,7 +4391,7 @@ PHP_FUNCTION(mb_send_mail)
 		empty = false;
 	}
 
-	if (!suppressed_hdrs.cnt_type) {
+	if (!uses_content_type) {
 		if (!empty) {
 			smart_str_appendl(&str, line_sep, line_sep_len);
 		}
@@ -4407,7 +4405,7 @@ PHP_FUNCTION(mb_send_mail)
 		empty = false;
 	}
 
-	if (!suppressed_hdrs.cnt_trans_enc) {
+	if (!uses_content_transfer_encoding) {
 		if (!empty) {
 			smart_str_appendl(&str, line_sep, line_sep_len);
 		}

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -4202,8 +4202,8 @@ PHP_FUNCTION(mb_send_mail)
 	size_t i;
 	char *to_r = NULL;
 	char *force_extra_parameters = INI_STR("mail.force_extra_parameters");
-	bool uses_content_type = false;
-	bool uses_content_transfer_encoding = false;
+	bool suppress_content_type = false;
+	bool suppress_content_transfer_encoding = false;
 
 	char *p;
 	enum mbfl_no_encoding;
@@ -4286,7 +4286,7 @@ PHP_FUNCTION(mb_send_mail)
 				}
 			}
 		}
-		uses_content_type = true;
+		suppress_content_type = true;
 	}
 
 	if ((s = zend_hash_str_find(&ht_headers, "content-transfer-encoding", sizeof("content-transfer-encoding") - 1))) {
@@ -4306,7 +4306,7 @@ PHP_FUNCTION(mb_send_mail)
 				body_enc =	&mbfl_encoding_8bit;
 				break;
 		}
-		uses_content_transfer_encoding = true;
+		suppress_content_transfer_encoding = true;
 	}
 
 	/* To: */
@@ -4391,7 +4391,7 @@ PHP_FUNCTION(mb_send_mail)
 		empty = false;
 	}
 
-	if (!uses_content_type) {
+	if (!suppress_content_type) {
 		if (!empty) {
 			smart_str_appendl(&str, line_sep, line_sep_len);
 		}
@@ -4405,7 +4405,7 @@ PHP_FUNCTION(mb_send_mail)
 		empty = false;
 	}
 
-	if (!uses_content_transfer_encoding) {
+	if (!suppress_content_transfer_encoding) {
 		if (!empty) {
 			smart_str_appendl(&str, line_sep, line_sep_len);
 		}


### PR DESCRIPTION
This opts to fix it in the same way as GH-11729 did, by converting it to a boolean.

I don't see why these would need to be bitfields at all, they could just be booleans as it's an unnamed struct and the struct as a whole isn't used for anything. However, I am a bit tired and it's a Friday afternoon, and we're in RC phase already, so I just did the safer thing.

Edit: as suggested in review, I've updated the PR to just make them local variables.