### PR TITLE
fix -Wreturn-type and -Wstrict-prototypes in gd configure

### DIFF
--- a/ext/gd/config.m4
+++ b/ext/gd/config.m4
@@ -194,7 +194,7 @@ dnl Various checks for GD features
 
     PHP_TEST_BUILD(foobar, [], [
       AC_MSG_ERROR([GD build test failed. Please check the config.log for details.])
-    ], [ $GD_SHARED_LIBADD ], [char foobar () {}])
+    ], [ $GD_SHARED_LIBADD ], [char foobar(void) { return '\0'; }])
 
   else
     extra_sources="gd_compat.c"


### PR DESCRIPTION
This kind of thing is why `-Werror` is enabled late, but in this case, I don't see any reason why we shouldn't just fix it. As C23 approaches, I expect more and more compilers to care about `-Wstrict-prototypes` and possibly even turn it to an error by default.