### PR TITLE
Request #64137: XSLTProcessor::setParameter() should allow both quotes to be used

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -31,6 +31,11 @@ PHP 8.4 UPGRADE NOTES
     for invalid modes. Previously invalid modes would have been interpreted as
     PHP_ROUND_HALF_UP.
 
+- XSL:
+  . XSLTProcessor::setParameter() will now throw a ValueError when its arguments
+    contain null bytes. This never actually worked correctly in the first place,
+    which is why it throws an exception nowadays.
+
 ========================================
 2. New Features
 ========================================

--- a/ext/xsl/tests/bug48221.phpt
+++ b/ext/xsl/tests/bug48221.phpt
@@ -9,8 +9,9 @@ $proc->importStylesheet($xsl);
 $proc->setParameter('', '', '"\'');
 $proc->transformToXml($dom);
 ?>
---EXPECTF--
-Warning: XSLTProcessor::transformToXml(): Cannot create XPath expression (string contains both quote and double-quotes) in %s on line %d
+Done
+--EXPECT--
+Done
 --CREDITS--
 Christian Weiske, cweiske@php.net
 PHP Testfest Berlin 2009-05-09

--- a/ext/xsl/tests/bug64137.phpt
+++ b/ext/xsl/tests/bug64137.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Request #64137 (XSLTProcessor::setParameter() should allow both quotes to be used)
+--EXTENSIONS--
+xsl
+--FILE--
+<?php
+
+function test(string $input) {
+    $xml = new DOMDocument;
+    $xml->loadXML('<X/>');
+
+    $xsl = new DOMDocument;
+    $xsl->loadXML('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:output method="text"/><xsl:param name="foo"/><xsl:template match="/"><xsl:value-of select="$foo"/></xsl:template></xsl:stylesheet>');
+
+    $xslt = new XSLTProcessor;
+    $xslt->importStylesheet($xsl);
+    $xslt->setParameter('', 'foo', $input);
+
+    echo $xslt->transformToXml($xml), "\n";
+}
+
+test("");
+test("a'");
+test("a\"");
+test("fo'o\"ba'r\"ba'z");
+test("\"\"\"fo'o\"ba'r\"ba'z\"\"\"");
+test("'''\"\"\"fo'o\"ba'r\"ba'z\"\"\"'''");
+
+?>
+--EXPECT--
+a'
+a"
+fo'o"ba'r"ba'z
+"""fo'o"ba'r"ba'z"""
+'''"""fo'o"ba'r"ba'z"""'''

--- a/ext/xsl/tests/setParameter_exceptions_test.phpt
+++ b/ext/xsl/tests/setParameter_exceptions_test.phpt
@@ -1,0 +1,102 @@
+--TEST--
+setParameter exceptions test
+--EXTENSIONS--
+xsl
+--FILE--
+<?php
+
+function test(array $options) {
+    $xml = new DOMDocument;
+    $xml->loadXML('<X/>');
+
+    $xsl = new DOMDocument;
+    $xsl->loadXML('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:output method="text"/><xsl:param name="foo"/><xsl:template match="/"><xsl:value-of select="$foo"/></xsl:template></xsl:stylesheet>');
+
+    $xslt = new XSLTProcessor;
+    $xslt->importStylesheet($xsl);
+    $xslt->setParameter('', $options);
+
+    echo $xslt->transformToXml($xml), "\n";
+}
+
+echo "--- Invalid key ---\n";
+
+try {
+    test([
+        12345 => "foo"
+    ]);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "--- Valid key and value, but special cases ---\n";
+
+test([
+    "foo" => null,
+]);
+
+test([
+    "foo" => true,
+]);
+
+echo "--- Exception from Stringable should abort execution ---\n";
+
+class MyStringable {
+    public function __toString(): string {
+        throw new Exception("exception!");
+    }
+}
+
+try {
+    test([
+        "foo" => new MyStringable,
+    ]);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "--- Exception from warning should abort execution ---\n";
+
+set_error_handler(function($errno, $errstr) {
+    throw new Exception($errstr);
+}, E_WARNING);
+
+try {
+    test([
+        "foo" => [],
+        "foo2" => [],
+    ]);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+set_error_handler(null, E_WARNING);
+
+echo "--- Warning may continue execution ---\n";
+
+try {
+    test([
+        "foo" => [],
+        "foo2" => [],
+    ]);
+} catch (Throwable $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+--- Invalid key ---
+XSLTProcessor::setParameter(): Argument #2 ($name) must contain only string keys
+--- Valid key and value, but special cases ---
+
+1
+--- Exception from Stringable should abort execution ---
+exception!
+--- Exception from warning should abort execution ---
+Array to string conversion
+--- Warning may continue execution ---
+
+Warning: Array to string conversion in %s on line %d
+
+Warning: Array to string conversion in %s on line %d
+Array

--- a/ext/xsl/tests/setParameter_null_bytes.phpt
+++ b/ext/xsl/tests/setParameter_null_bytes.phpt
@@ -1,0 +1,43 @@
+--TEST--
+setParameter() with null bytes
+--EXTENSIONS--
+xsl
+--FILE--
+<?php
+
+$xslt = new XSLTProcessor();
+
+try {
+    $xslt->setParameter("", "foo\0", "bar");
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $xslt->setParameter("", "foo", "bar\0");
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $xslt->setParameter("", [
+        "foo\0" => "bar",
+    ]);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+try {
+    $xslt->setParameter("", [
+        "foo" => "bar\0",
+    ]);
+} catch (ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECT--
+XSLTProcessor::setParameter(): Argument #2 ($name) must not contain any null bytes
+XSLTProcessor::setParameter(): Argument #3 ($value) must not contain any null bytes
+XSLTProcessor::setParameter(): Argument #3 ($value) must not contain keys with any null bytes
+XSLTProcessor::setParameter(): Argument #3 ($value) must not contain values with any null bytes

--- a/ext/xsl/tests/xsltprocessor_setparameter-errorquote.phpt
+++ b/ext/xsl/tests/xsltprocessor_setparameter-errorquote.phpt
@@ -11,8 +11,9 @@ $proc->importStylesheet($xsl);
 $proc->setParameter('', '', '"\'');
 $proc->transformToXml($dom);
 ?>
---EXPECTF--
-Warning: XSLTProcessor::transformToXml(): Cannot create XPath expression (string contains both quote and double-quotes) in %s on line %d
+Done
+--EXPECT--
+Done
 --CREDITS--
 Christian Weiske, cweiske@php.net
 PHP Testfest Berlin 2009-05-09

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -686,7 +686,7 @@ PHP_METHOD(XSLTProcessor, getParameter)
 	}
 	intern = Z_XSL_P(id);
 	if ((value = zend_hash_find(intern->parameter, name)) != NULL) {
-		RETURN_STR(zval_get_string(value));
+		RETURN_STR_COPY(Z_STR_P(value));
 	} else {
 		RETURN_FALSE;
 	}

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -37,7 +37,7 @@ static zend_result php_xsl_xslt_apply_params(xsltTransformContextPtr ctxt, HashT
 
 		int result = xsltQuoteOneUserParam(ctxt, (const xmlChar *) ZSTR_VAL(string_key), (const xmlChar *) Z_STRVAL_P(value));
 		if (result < 0) {
-			php_error_docref(NULL, E_WARNING, "Could not apply parameter '%s'", ZSTR_VAL(string_key));
+			php_error_docref(NULL, E_WARNING, "Could not apply parameter \"%s\"", ZSTR_VAL(string_key));
 			return FAILURE;
 		}
 	} ZEND_HASH_FOREACH_END();


### PR DESCRIPTION
This throws away the old parameter handling, which revolved around quoting the string manually.
The new approach instead uses `xsltQuoteOneUserParam()` to pass data literally to libxslt instead of relying on xpath.