### PR TITLE
number_format: float within range of int can be cast to int …

### DIFF
--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1328,10 +1328,10 @@ PHP_FUNCTION(number_format)
 			break;
 
 		case IS_DOUBLE:
-			// On 64bit a given float within range of int but greater than 2^53 can be cast to int
-			// to not loose precision
+			// double values of >= 2^52 can not have fractional digits anymore
+			// Casting to long on 64bit will not loose precision on rounding
 			if (UNEXPECTED(
-				(Z_DVAL_P(num) > 9007199254740992.0 || Z_DVAL_P(num) < -9007199254740992.0)
+				(Z_DVAL_P(num) >= 4503599627370496.0 || Z_DVAL_P(num) <= -4503599627370496.0)
 				&& ZEND_DOUBLE_FITS_LONG(Z_DVAL_P(num))
 			)) {
 				RETURN_STR(_php_math_number_format_long((zend_long)Z_DVAL_P(num), dec, dec_point, dec_point_len, thousand_sep, thousand_sep_len));

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1328,6 +1328,16 @@ PHP_FUNCTION(number_format)
 			break;
 
 		case IS_DOUBLE:
+			// On 64bit a given float within range of int but greater than 2^53 can be cast to int
+			// to not loose precision
+			if (UNEXPECTED(
+				(Z_DVAL_P(num) > 9007199254740992.0 || Z_DVAL_P(num) < -9007199254740992.0)
+				&& Z_DVAL_P(num) < ZEND_LONG_MAX && Z_DVAL_P(num) > ZEND_LONG_MIN
+			)) {
+				RETURN_STR(_php_math_number_format_long((zend_long)Z_DVAL_P(num), dec, dec_point, dec_point_len, thousand_sep, thousand_sep_len));
+                break;
+			}
+
 			if (dec >= 0) {
 				dec_int = ZEND_LONG_INT_OVFL(dec) ? INT_MAX : (int)dec;
 			} else {

--- a/ext/standard/math.c
+++ b/ext/standard/math.c
@@ -1332,7 +1332,7 @@ PHP_FUNCTION(number_format)
 			// to not loose precision
 			if (UNEXPECTED(
 				(Z_DVAL_P(num) > 9007199254740992.0 || Z_DVAL_P(num) < -9007199254740992.0)
-				&& Z_DVAL_P(num) < ZEND_LONG_MAX && Z_DVAL_P(num) > ZEND_LONG_MIN
+				&& ZEND_DOUBLE_FITS_LONG(Z_DVAL_P(num))
 			)) {
 				RETURN_STR(_php_math_number_format_long((zend_long)Z_DVAL_P(num), dec, dec_point, dec_point_len, thousand_sep, thousand_sep_len));
                 break;

--- a/ext/standard/tests/math/number_format_basiclong_64bit.phpt
+++ b/ext/standard/tests/math/number_format_basiclong_64bit.phpt
@@ -201,8 +201,8 @@ foreach ($numbers as $longVal) {
 --- testing: float(-9.223372036854776E+18)
 ... with precision 5: string(32) "-9,223,372,036,854,775,808.00000"
 ... with precision 0: string(26) "-9,223,372,036,854,775,808"
-... with precision -1: string(26) "-9,223,372,036,854,775,808"
-... with precision -5: string(26) "-9,223,372,036,854,800,384"
+... with precision -1: string(26) "-9,223,372,036,854,775,810"
+... with precision -5: string(26) "-9,223,372,036,854,800,000"
 ... with precision -10: string(26) "-9,223,372,040,000,000,000"
 ... with precision -11: string(26) "-9,223,372,000,000,000,000"
 ... with precision -17: string(26) "-9,200,000,000,000,000,000"

--- a/ext/standard/tests/math/number_format_basiclong_64bit.phpt
+++ b/ext/standard/tests/math/number_format_basiclong_64bit.phpt
@@ -17,7 +17,7 @@ $numbers = array(
     MAX_32Bit + 1, MIN_32Bit - 1, MAX_32Bit * 2, (MAX_32Bit * 2) + 1, (MAX_32Bit * 2) - 1,
     MAX_64Bit - 1, MAX_64Bit + 1, MIN_64Bit + 1, MIN_64Bit - 1,
     // floats rounded as int
-    9223372036854774784.0, -9223372036854774784.0
+    MAX_64Bit - 1024.0, MIN_64Bit + 1024.0
 );
 
 $precisions = array(
@@ -33,12 +33,12 @@ $precisions = array(
     PHP_INT_MIN,
 );
 
-foreach ($numbers as $longVal) {
+foreach ($numbers as $number) {
     echo "--- testing: ";
-    var_dump($longVal);
+    var_dump($number);
     foreach ($precisions as $precision) {
         echo "... with precision " . $precision . ": ";
-        var_dump(number_format($longVal, $precision));
+        var_dump(number_format($number, $precision));
     }
 }
 

--- a/ext/standard/tests/math/number_format_basiclong_64bit.phpt
+++ b/ext/standard/tests/math/number_format_basiclong_64bit.phpt
@@ -12,10 +12,12 @@ define("MAX_32Bit", 2147483647);
 define("MIN_64Bit", -9223372036854775807 - 1);
 define("MIN_32Bit", -2147483647 - 1);
 
-$longVals = array(
+$numbers = array(
     MAX_64Bit, MIN_64Bit, MAX_32Bit, MIN_32Bit, MAX_64Bit - MAX_32Bit, MIN_64Bit - MIN_32Bit,
     MAX_32Bit + 1, MIN_32Bit - 1, MAX_32Bit * 2, (MAX_32Bit * 2) + 1, (MAX_32Bit * 2) - 1,
-    MAX_64Bit -1, MAX_64Bit + 1, MIN_64Bit + 1, MIN_64Bit - 1
+    MAX_64Bit - 1, MAX_64Bit + 1, MIN_64Bit + 1, MIN_64Bit - 1,
+    // floats rounded as int
+    9223372036854774784.0, -9223372036854774784.0
 );
 
 $precisions = array(
@@ -31,7 +33,7 @@ $precisions = array(
     PHP_INT_MIN,
 );
 
-foreach ($longVals as $longVal) {
+foreach ($numbers as $longVal) {
     echo "--- testing: ";
     var_dump($longVal);
     foreach ($precisions as $precision) {
@@ -201,6 +203,28 @@ foreach ($longVals as $longVal) {
 ... with precision 0: string(26) "-9,223,372,036,854,775,808"
 ... with precision -1: string(26) "-9,223,372,036,854,775,808"
 ... with precision -5: string(26) "-9,223,372,036,854,800,384"
+... with precision -10: string(26) "-9,223,372,040,000,000,000"
+... with precision -11: string(26) "-9,223,372,000,000,000,000"
+... with precision -17: string(26) "-9,200,000,000,000,000,000"
+... with precision -19: string(27) "-10,000,000,000,000,000,000"
+... with precision -20: string(1) "0"
+... with precision -9223372036854775808: string(1) "0"
+--- testing: float(9.223372036854775E+18)
+... with precision 5: string(31) "9,223,372,036,854,774,784.00000"
+... with precision 0: string(25) "9,223,372,036,854,774,784"
+... with precision -1: string(25) "9,223,372,036,854,774,780"
+... with precision -5: string(25) "9,223,372,036,854,800,000"
+... with precision -10: string(25) "9,223,372,040,000,000,000"
+... with precision -11: string(25) "9,223,372,000,000,000,000"
+... with precision -17: string(25) "9,200,000,000,000,000,000"
+... with precision -19: string(26) "10,000,000,000,000,000,000"
+... with precision -20: string(1) "0"
+... with precision -9223372036854775808: string(1) "0"
+--- testing: float(-9.223372036854775E+18)
+... with precision 5: string(32) "-9,223,372,036,854,774,784.00000"
+... with precision 0: string(26) "-9,223,372,036,854,774,784"
+... with precision -1: string(26) "-9,223,372,036,854,774,780"
+... with precision -5: string(26) "-9,223,372,036,854,800,000"
 ... with precision -10: string(26) "-9,223,372,040,000,000,000"
 ... with precision -11: string(26) "-9,223,372,000,000,000,000"
 ... with precision -17: string(26) "-9,200,000,000,000,000,000"


### PR DESCRIPTION
…before rounding of numbers above 2^52 to not loose precision.

On casting float to int fractional digits gets truncated but as far as I'm aware of `double` numbers above 2^52 can't store fractions anymore.

This is the diff of the added test numbers without this change:
```
--
     --- testing: float(9.223372036854775E+18)
     ... with precision 5: string(31) "9,223,372,036,854,774,784.00000"
     ... with precision 0: string(25) "9,223,372,036,854,774,784"
169- ... with precision -1: string(25) "9,223,372,036,854,774,780"
170- ... with precision -5: string(25) "9,223,372,036,854,800,000"
169+ ... with precision -1: string(25) "9,223,372,036,854,774,784"
170+ ... with precision -5: string(25) "9,223,372,036,854,800,384"
     ... with precision -10: string(25) "9,223,372,040,000,000,000"
     ... with precision -11: string(25) "9,223,372,000,000,000,000"
     ... with precision -17: string(25) "9,200,000,000,000,000,000"
--
     --- testing: float(-9.223372036854775E+18)
     ... with precision 5: string(32) "-9,223,372,036,854,774,784.00000"
     ... with precision 0: string(26) "-9,223,372,036,854,774,784"
180- ... with precision -1: string(26) "-9,223,372,036,854,774,780"
181- ... with precision -5: string(26) "-9,223,372,036,854,800,000"
180+ ... with precision -1: string(26) "-9,223,372,036,854,774,784"
181+ ... with precision -5: string(26) "-9,223,372,036,854,800,384"
     ... with precision -10: string(26) "-9,223,372,040,000,000,000"
     ... with precision -11: string(26) "-9,223,372,000,000,000,000"
     ... with precision -17: string(26) "-9,200,000,000,000,000,000"
--
```