### PR TITLE
pcre: Stop special-casing /e

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -34,8 +34,6 @@
 #define PREG_SPLIT_DELIM_CAPTURE	(1<<1)
 #define PREG_SPLIT_OFFSET_CAPTURE	(1<<2)
 
-#define PREG_REPLACE_EVAL			(1<<0)
-
 #define PREG_GREP_INVERT			(1<<0)
 
 #define PREG_JIT                    (1<<3)
@@ -737,14 +735,12 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, in
 				break;
 			case 'J':	coptions |= PCRE2_DUPNAMES;		break;
 
-			/* Custom preg options */
-			case 'e':	poptions |= PREG_REPLACE_EVAL;	break;
-
 			case ' ':
 			case '\n':
 			case '\r':
 				break;
 
+			case 'e': /* legacy eval */
 			default:
 				if (pp[-1]) {
 					php_error_docref(NULL, E_WARNING, "Unknown modifier '%c'", pp[-1]);
@@ -758,16 +754,6 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, in
 				}
 				return NULL;
 		}
-	}
-
-	if (poptions & PREG_REPLACE_EVAL) {
-		php_error_docref(NULL, E_WARNING, "The /e modifier is no longer supported, use preg_replace_callback instead");
-		pcre_handle_exec_error(PCRE2_ERROR_INTERNAL);
-		efree(pattern);
-		if (key != regex) {
-			zend_string_release_ex(key, 0);
-		}
-		return NULL;
 	}
 
 	if (key != regex) {

--- a/ext/pcre/tests/002.phpt
+++ b/ext/pcre/tests/002.phpt
@@ -24,5 +24,5 @@ string(12) "a${1b${1c${1"
 Warning: preg_replace(): Compilation failed: missing terminating ] for character class at offset 8 in %s002.php on line %d
 NULL
 
-Warning: preg_replace(): The /e modifier is no longer supported, use preg_replace_callback instead in %s on line %d
+Warning: preg_replace(): Unknown modifier 'e' in %s on line %d
 NULL

--- a/ext/pcre/tests/null_bytes.phpt
+++ b/ext/pcre/tests/null_bytes.phpt
@@ -27,8 +27,6 @@ var_dump(preg_match("[abc\0def]", "abc"));
 var_dump(preg_match("[abc\0def]", "abc\0def"));
 var_dump(preg_match("[abc\0def]", "abc\0fed"));
 
-preg_replace("/foo/e\0/i", "echo('Eek');", "");
-
 ?>
 --EXPECTF--
 Warning: preg_match(): Delimiter must not be alphanumeric, backslash, or NUL in %snull_bytes.php on line 3
@@ -62,5 +60,3 @@ int(0)
 int(0)
 int(1)
 int(0)
-
-Warning: preg_replace(): NUL is not a valid modifier in %snull_bytes.php on line 27


### PR DESCRIPTION
Support for /e was removed in PHP 7.0, remove the custom error message and stop special casing it to simplify the logic.