### PR TITLE
build/php.m4: Add `PHP_ADD_STATIC_LIBRARY` macro

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -539,6 +539,18 @@ ifelse($3,,[
 ])
 
 dnl
+dnl PHP_ADD_STATIC_LIBRARY(static_library_path)
+dnl
+dnl Add a static library to the link line.
+dnl
+AC_DEFUN([PHP_ADD_STATIC_LIBRARY],[
+  if ! ar t "$1"; then
+    AC_MSG_ERROR([$1 does not appear to be a static library])
+  fi
+  LDFLAGS="$LDFLAGS $1"
+])
+
+dnl
 dnl PHP_ADD_LIBRARY_DEFER_WITH_PATH(library, path[, shared-libadd])
 dnl
 dnl Add a library to the link line (deferred) and path to linkpath/runpath (not


### PR DESCRIPTION
Occasionally it's useful to bundle a static library into a PHP extension. I didn't see a clear way to do this, so I added this macro. If there's already an easy way to do this, apologies, and also I'm curious how.

Downsides:
- Invokes `ar` to test if the param at least looks like a static lib
- libtool outputs a portability warning even if the static lib objects are compiled position-independent. I think that's safe to ignore but I may be wrong. Works on my machine.