### PR TITLE
php_cli_server: ensure a single Date header is present

### DIFF
--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -348,10 +348,26 @@ static void append_http_status_line(smart_str *buffer, int protocol_version, int
 	smart_str_appendl_ex(buffer, "\r\n", 2, persistent);
 } /* }}} */
 
-static void append_essential_headers(smart_str* buffer, php_cli_server_client *client, int persistent) /* {{{ */
+static void append_essential_headers(smart_str* buffer, php_cli_server_client *client, int persistent, sapi_headers_struct *sapi_headers) /* {{{ */
 {
 	char *val;
 	struct timeval tv = {0};
+	sapi_header_struct *h;
+	zend_llist_position pos;
+	bool append_date_header = 1;
+
+	if (sapi_headers != NULL) {
+		h = (sapi_header_struct*)zend_llist_get_first_ex(&sapi_headers->headers, &pos);
+		while (h) {
+			if (h->header_len) {
+				if (strncmp(h->header, "Date:", strlen("Date:")) == 0) {
+					append_date_header = 0;
+					break;
+				}
+			}
+			h = (sapi_header_struct*)zend_llist_get_next_ex(&sapi_headers->headers, &pos);
+		}
+	}
 
 	if (NULL != (val = zend_hash_str_find_ptr(&client->request.headers, "host", sizeof("host")-1))) {
 		smart_str_appends_ex(buffer, "Host: ", persistent);
@@ -359,7 +375,7 @@ static void append_essential_headers(smart_str* buffer, php_cli_server_client *c
 		smart_str_appends_ex(buffer, "\r\n", persistent);
 	}
 
-	if (!gettimeofday(&tv, NULL)) {
+	if (append_date_header && !gettimeofday(&tv, NULL)) {
 		zend_string *dt = php_format_date("D, d M Y H:i:s", sizeof("D, d M Y H:i:s") - 1, tv.tv_sec, 0);
 		smart_str_appends_ex(buffer, "Date: ", persistent);
 		smart_str_appends_ex(buffer, dt->val, persistent);
@@ -552,7 +568,7 @@ static int sapi_cli_server_send_headers(sapi_headers_struct *sapi_headers) /* {{
 		append_http_status_line(&buffer, client->request.protocol_version, SG(sapi_headers).http_response_code, 0);
 	}
 
-	append_essential_headers(&buffer, client, 0);
+	append_essential_headers(&buffer, client, 0, sapi_headers);
 
 	h = (sapi_header_struct*)zend_llist_get_first_ex(&sapi_headers->headers, &pos);
 	while (h) {
@@ -1997,7 +2013,7 @@ static int php_cli_server_send_error_page(php_cli_server *server, php_cli_server
 			/* out of memory */
 			goto fail;
 		}
-		append_essential_headers(&buffer, client, 1);
+		append_essential_headers(&buffer, client, 1, NULL);
 		smart_str_appends_ex(&buffer, "Content-Type: text/html; charset=UTF-8\r\n", 1);
 		smart_str_appends_ex(&buffer, "Content-Length: ", 1);
 		smart_str_append_unsigned_ex(&buffer, php_cli_server_buffer_size(&client->content_sender.buffer), 1);
@@ -2093,7 +2109,7 @@ static int php_cli_server_begin_send_static(php_cli_server *server, php_cli_serv
 			php_cli_server_log_response(client, 500, NULL);
 			return FAILURE;
 		}
-		append_essential_headers(&buffer, client, 1);
+		append_essential_headers(&buffer, client, 1, NULL);
 		if (mime_type) {
 			smart_str_appendl_ex(&buffer, "Content-Type: ", sizeof("Content-Type: ") - 1, 1);
 			smart_str_appends_ex(&buffer, mime_type, 1);

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -352,16 +352,15 @@ static void append_essential_headers(smart_str* buffer, php_cli_server_client *c
 {
 	char *val;
 	struct timeval tv = {0};
-	sapi_header_struct *h;
-	zend_llist_position pos;
-	bool append_date_header = 1;
+	bool append_date_header = true;
 
 	if (sapi_headers != NULL) {
-		h = (sapi_header_struct*)zend_llist_get_first_ex(&sapi_headers->headers, &pos);
+		zend_llist_position pos;
+		sapi_header_struct *h = (sapi_header_struct*)zend_llist_get_first_ex(&sapi_headers->headers, &pos);
 		while (h) {
-			if (h->header_len) {
-				if (strncmp(h->header, "Date:", strlen("Date:")) == 0) {
-					append_date_header = 0;
+			if (h->header_len > strlen("Date:")-1) {
+				if (strncasecmp(h->header, "Date:", strlen("Date:")-1) == 0) {
+					append_date_header = false;
 					break;
 				}
 			}

--- a/sapi/cli/php_cli_server.c
+++ b/sapi/cli/php_cli_server.c
@@ -358,8 +358,8 @@ static void append_essential_headers(smart_str* buffer, php_cli_server_client *c
 		zend_llist_position pos;
 		sapi_header_struct *h = (sapi_header_struct*)zend_llist_get_first_ex(&sapi_headers->headers, &pos);
 		while (h) {
-			if (h->header_len > strlen("Date:")-1) {
-				if (strncasecmp(h->header, "Date:", strlen("Date:")-1) == 0) {
+			if (h->header_len > strlen("Date:")) {
+				if (strncasecmp(h->header, "Date:", strlen("Date:")) == 0) {
 					append_date_header = false;
 					break;
 				}

--- a/sapi/cli/tests/php_cli_server_022.phpt
+++ b/sapi/cli/tests/php_cli_server_022.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Ensure a single Date header is present
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+include "php_cli_server.inc";
+php_cli_server_start(<<<'PHP'
+header('Date: Mon, 25 Mar 1985 00:20:00 GMT');
+PHP
+);
+
+$host = PHP_CLI_SERVER_HOSTNAME;
+$fp = php_cli_server_connect();
+
+if(fwrite($fp, <<<HEADER
+GET / HTTP/1.1
+Host: {$host}
+
+
+HEADER
+)) {
+    while (!feof($fp)) {
+        echo fgets($fp);
+    }
+}
+
+fclose($fp);
+?>
+--EXPECTF--
+HTTP/1.1 200 OK
+Host: %s
+Connection: close
+X-Powered-By: %s
+Date: Mon, 25 Mar 1985 00:20:00 GMT
+Content-type: text/html; charset=UTF-8
+


### PR DESCRIPTION
Currently the PHP Development Server appends a Date header in the response, despite already set from user code.

### Steps to reproduce
index.php:
`<?php header('Date: Mon, 25 Mar 1985 00:20:00 GMT');`

terminal 1:
`$  php -S localhost:8080 index.php`

terminal 2:
```
$ curl -i localhost:8080
HTTP/1.1 200 OK
Host: localhost:8080
Date: Thu, 05 Oct 2023 07:45:57 GMT
Connection: close
X-Powered-By: PHP/8.2.10
Date: Mon, 25 Mar 1985 00:20:00 GMT
Content-type: text/html; charset=UTF-8
```

I have added a check condition before append the header, and a test file.