### PR TITLE
Removed misleading comments in tests on expected output

### DIFF
--- a/tests/classes/visibility_000c.phpt
+++ b/tests/classes/visibility_000c.phpt
@@ -25,7 +25,7 @@ class fail extends same {
     function f0() {}
 }
 
-echo "Done\n"; // shouldn't be displayed
+echo "Done\n";
 ?>
 --EXPECT--
 Done

--- a/tests/classes/visibility_001c.phpt
+++ b/tests/classes/visibility_001c.phpt
@@ -25,7 +25,7 @@ class fail extends same {
     function f1() {}
 }
 
-echo "Done\n"; // shouldn't be displayed
+echo "Done\n";
 ?>
 --EXPECT--
 Done

--- a/tests/classes/visibility_002c.phpt
+++ b/tests/classes/visibility_002c.phpt
@@ -25,7 +25,7 @@ class fail extends same {
     function f2() {}
 }
 
-echo "Done\n"; // shouldn't be displayed
+echo "Done\n";
 ?>
 --EXPECT--
 Done

--- a/tests/classes/visibility_004b.phpt
+++ b/tests/classes/visibility_004b.phpt
@@ -25,7 +25,7 @@ class fail extends same {
     protected function f4() {}
 }
 
-echo "Done\n"; // shouldn't be displayed
+echo "Done\n";
 ?>
 --EXPECT--
 Done


### PR DESCRIPTION
This is a small MR that fixes misleading comments in tests.