### PR TITLE
Fix GH-9921: Loading ext in FPM config does not register module handlers

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2331,7 +2331,9 @@ ZEND_API void zend_startup_modules(void) /* {{{ */
 ZEND_API void zend_destroy_modules(void) /* {{{ */
 {
 	free(class_cleanup_handlers);
+	class_cleanup_handlers = NULL;
 	free(module_request_startup_handlers);
+	module_request_startup_handlers = NULL;
 	zend_hash_graceful_reverse_destroy(&module_registry);
 }
 /* }}} */

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2326,10 +2326,15 @@ ZEND_API void zend_startup_modules(void) /* {{{ */
 }
 /* }}} */
 
-ZEND_API void zend_destroy_modules(void) /* {{{ */
+ZEND_API void zend_destroy_module_handlers(void)
 {
 	free(class_cleanup_handlers);
 	free(module_request_startup_handlers);
+}
+
+ZEND_API void zend_destroy_modules(void) /* {{{ */
+{
+	zend_destroy_module_handlers();
 	zend_hash_graceful_reverse_destroy(&module_registry);
 }
 /* }}} */

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2271,7 +2271,8 @@ ZEND_API void zend_collect_module_handlers(void) /* {{{ */
 			post_deactivate_count++;
 		}
 	} ZEND_HASH_FOREACH_END();
-	module_request_startup_handlers = (zend_module_entry**)malloc(
+	module_request_startup_handlers = (zend_module_entry**)realloc(
+		module_request_startup_handlers,
 	    sizeof(zend_module_entry*) *
 		(startup_count + 1 +
 		 shutdown_count + 1 +
@@ -2303,7 +2304,8 @@ ZEND_API void zend_collect_module_handlers(void) /* {{{ */
 		}
 	} ZEND_HASH_FOREACH_END();
 
-	class_cleanup_handlers = (zend_class_entry**)malloc(
+	class_cleanup_handlers = (zend_class_entry**)realloc(
+		class_cleanup_handlers,
 		sizeof(zend_class_entry*) *
 		(class_count + 1));
 	class_cleanup_handlers[class_count] = NULL;
@@ -2326,15 +2328,10 @@ ZEND_API void zend_startup_modules(void) /* {{{ */
 }
 /* }}} */
 
-ZEND_API void zend_destroy_module_handlers(void)
+ZEND_API void zend_destroy_modules(void) /* {{{ */
 {
 	free(class_cleanup_handlers);
 	free(module_request_startup_handlers);
-}
-
-ZEND_API void zend_destroy_modules(void) /* {{{ */
-{
-	zend_destroy_module_handlers();
 	zend_hash_graceful_reverse_destroy(&module_registry);
 }
 /* }}} */

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -361,7 +361,6 @@ ZEND_API zend_module_entry* zend_register_module_ex(zend_module_entry *module);
 ZEND_API zend_result zend_startup_module_ex(zend_module_entry *module);
 ZEND_API void zend_startup_modules(void);
 ZEND_API void zend_collect_module_handlers(void);
-ZEND_API void zend_destroy_module_handlers(void);
 ZEND_API void zend_destroy_modules(void);
 ZEND_API void zend_check_magic_method_implementation(
 		const zend_class_entry *ce, const zend_function *fptr, zend_string *lcname, int error_type);

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -361,6 +361,7 @@ ZEND_API zend_module_entry* zend_register_module_ex(zend_module_entry *module);
 ZEND_API zend_result zend_startup_module_ex(zend_module_entry *module);
 ZEND_API void zend_startup_modules(void);
 ZEND_API void zend_collect_module_handlers(void);
+ZEND_API void zend_destroy_module_handlers(void);
 ZEND_API void zend_destroy_modules(void);
 ZEND_API void zend_check_magic_method_implementation(
 		const zend_class_entry *ce, const zend_function *fptr, zend_string *lcname, int error_type);

--- a/ext/dl_test/dl_test.c
+++ b/ext/dl_test/dl_test.c
@@ -69,6 +69,10 @@ PHP_MINIT_FUNCTION(dl_test)
 		REGISTER_INI_ENTRIES();
 	}
 
+	if (getenv("PHP_DL_TEST_MODULE_DEBUG")) {
+		fprintf(stderr, "DL TEST MINIT\n");
+	}
+
 	return SUCCESS;
 }
 /* }}} */
@@ -83,6 +87,10 @@ static PHP_MSHUTDOWN_FUNCTION(dl_test)
 		UNREGISTER_INI_ENTRIES();
 	}
 
+	if (getenv("PHP_DL_TEST_MODULE_DEBUG")) {
+		fprintf(stderr, "DL TEST MSHUTDOWN\n");
+	}
+
 	return SUCCESS;
 }
 /* }}} */
@@ -93,6 +101,21 @@ PHP_RINIT_FUNCTION(dl_test)
 #if defined(ZTS) && defined(COMPILE_DL_DL_TEST)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
+
+	if (getenv("PHP_DL_TEST_MODULE_DEBUG")) {
+		fprintf(stderr, "DL TEST RINIT\n");
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ PHP_RSHUTDOWN_FUNCTION */
+PHP_RSHUTDOWN_FUNCTION(dl_test)
+{
+	if (getenv("PHP_DL_TEST_MODULE_DEBUG")) {
+		fprintf(stderr, "DL TEST RSHUTDOWN\n");
+	}
 
 	return SUCCESS;
 }
@@ -127,7 +150,7 @@ zend_module_entry dl_test_module_entry = {
 	PHP_MINIT(dl_test),
 	PHP_MSHUTDOWN(dl_test),
 	PHP_RINIT(dl_test),
-	NULL,
+	PHP_RSHUTDOWN(dl_test),
 	PHP_MINFO(dl_test),
 	PHP_DL_TEST_VERSION,
 	PHP_MODULE_GLOBALS(dl_test),

--- a/sapi/fpm/fpm/fpm_php.c
+++ b/sapi/fpm/fpm/fpm_php.c
@@ -77,6 +77,11 @@ static void fpm_php_disable(char *value, int (*zend_disable)(const char *, size_
 }
 /* }}} */
 
+#define FPM_PHP_INI_ALTERING_ERROR   -1
+#define FPM_PHP_INI_APPLIED          1
+#define FPM_PHP_INI_EXTENSION_FAILED 0
+#define FPM_PHP_INI_EXTENSION_LOADED 2
+
 int fpm_php_apply_defines_ex(struct key_value_s *kv, int mode) /* {{{ */
 {
 
@@ -90,26 +95,26 @@ int fpm_php_apply_defines_ex(struct key_value_s *kv, int mode) /* {{{ */
 		zend_interned_strings_switch_storage(0);
 		php_dl(value, MODULE_PERSISTENT, &zv, 1);
 		zend_interned_strings_switch_storage(1);
-		return Z_TYPE(zv) == IS_TRUE ? 2 : 0;
+		return Z_TYPE(zv) == IS_TRUE ? FPM_PHP_INI_EXTENSION_LOADED : FPM_PHP_INI_EXTENSION_FAILED;
 	}
 
 	if (fpm_php_zend_ini_alter_master(name, name_len, value, value_len, mode, PHP_INI_STAGE_ACTIVATE) == FAILURE) {
-		return -1;
+		return FPM_PHP_INI_ALTERING_ERROR;
 	}
 
 	if (!strcmp(name, "disable_functions") && *value) {
 		zend_disable_functions(value);
-		return 1;
+		return FPM_PHP_INI_APPLIED;
 	}
 
 	if (!strcmp(name, "disable_classes") && *value) {
 		char *v = strdup(value);
 		PG(disable_classes) = v;
 		fpm_php_disable(v, zend_disable_class);
-		return 1;
+		return FPM_PHP_INI_APPLIED;
 	}
 
-	return 1;
+	return FPM_PHP_INI_APPLIED;
 }
 /* }}} */
 
@@ -121,24 +126,23 @@ static int fpm_php_apply_defines(struct fpm_worker_pool_s *wp) /* {{{ */
 
 	for (kv = wp->config->php_values; kv; kv = kv->next) {
 		apply_result = fpm_php_apply_defines_ex(kv, ZEND_INI_USER);
-		if (apply_result == -1) {
+		if (apply_result == FPM_PHP_INI_ALTERING_ERROR) {
 			zlog(ZLOG_ERROR, "Unable to set php_value '%s'", kv->key);
-		} else if (apply_result == 2) {
+		} else if (apply_result == FPM_PHP_INI_EXTENSION_LOADED) {
 			extension_loaded = true;
 		}
 	}
 
 	for (kv = wp->config->php_admin_values; kv; kv = kv->next) {
 		apply_result = fpm_php_apply_defines_ex(kv, ZEND_INI_SYSTEM);
-		if (apply_result == -1) {
+		if (apply_result == FPM_PHP_INI_ALTERING_ERROR) {
 			zlog(ZLOG_ERROR, "Unable to set php_admin_value '%s'", kv->key);
-		} else if (apply_result == 2) {
+		} else if (apply_result == FPM_PHP_INI_EXTENSION_LOADED) {
 			extension_loaded = true;
 		}
 	}
 
 	if (extension_loaded) {
-		zend_destroy_module_handlers();
 		zend_collect_module_handlers();
 	}
 

--- a/sapi/fpm/tests/gh9921-php-value-ext-mod-handlers.phpt
+++ b/sapi/fpm/tests/gh9921-php-value-ext-mod-handlers.phpt
@@ -1,0 +1,54 @@
+--TEST--
+FPM: GH-9921 - loading shared ext in FPM config does not register module handlers
+--SKIPIF--
+<?php
+include "skipif.inc";
+FPM\Tester::skipIfSharedExtensionNotFound('dl_test');
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+pm.status_path = /status
+catch_workers_output = yes
+env[PHP_DL_TEST_MODULE_DEBUG] = 1
+php_admin_value[extension] = dl_test
+EOT;
+
+$code = <<<EOT
+<?php
+var_dump(extension_loaded('dl_test'));
+EOT;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$tester->request()->expectBody('bool(true)');
+$tester->expectLogPattern('/DL TEST MINIT/');
+$tester->expectLogPattern('/DL TEST RINIT/');
+$tester->expectLogPattern('/DL TEST RSHUTDOWN/');
+$tester->request()->expectBody('bool(true)');
+$tester->expectLogPattern('/DL TEST RINIT/');
+$tester->expectLogPattern('/DL TEST RSHUTDOWN/');
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>
+<?php


### PR DESCRIPTION
The collection of module handlers happened before the loading of extension so the extension loaded in FPM config was not present there. To fix it, it is necessary to re-run collection of module handlers after extensions are loaded in FPM config.