### PR TITLE
Fix GH-12380: JIT+private array property access inside closure accesses private property in child class

### DIFF
--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -650,7 +650,11 @@ static zend_property_info* zend_get_known_property_info(const zend_op_array *op_
 		return info;
 	} else if (on_this) {
 		if (ce == info->ce) {
-			return info;
+			if (ce == op_array->scope) {
+				return info;
+			} else {
+				return NULL;
+			}
 		} else if ((info->flags & ZEND_ACC_PROTECTED)
 				&& instanceof_function_slow(ce, info->ce)) {
 			return info;

--- a/ext/opcache/tests/jit/gh12380.phpt
+++ b/ext/opcache/tests/jit/gh12380.phpt
@@ -1,0 +1,62 @@
+--TEST--
+GH-12380: JIT+private array property access inside closure accesses private property in child class
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.file_update_protection=0
+opcache.jit_buffer_size=1M
+opcache.protect_memory=1
+opcache.jit=tracing
+opcache.jit_hot_loop=1
+opcache.jit_hot_func=1
+opcache.jit_hot_return=1
+opcache.jit_hot_side_exit=1
+--EXTENSIONS--
+opcache
+--FILE--
+<?php
+
+abstract class a
+{
+    private int $v = 1;
+
+    public function test(): void
+    {
+        var_dump($this->v);
+        (function (): void {
+            var_dump($this->v);
+        })();
+    }
+}
+
+final class b extends a {
+    private int $v = 0;
+}
+$a = new b;
+
+for ($i = 0; $i < 10; $i++) {
+    $a->test();
+}
+
+?>
+--EXPECT--
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)
+int(1)


### PR DESCRIPTION
For private fields, the scope has to be taken into account, otherwise the property info may come from the wrong ce.
trace_ce is the class entry for b in the test, so we look up the property info from the wrong ce (should be a).

Maybe this can be improved further by checking `is_derived_class(ce, scope)` and then reading the property info from the scope, e.g. by using `return zend_get_parent_private_property(op_array->scope, ce, member);` instead of `return NULL`? But that API isn't public though.