### PR TITLE
Remove redundant code in ext/mysqlnd build

### DIFF
--- a/ext/mysqlnd/config9.m4
+++ b/ext/mysqlnd/config9.m4
@@ -40,10 +40,5 @@ if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes"; then
 
   mysqlnd_sources="$mysqlnd_base_sources $mysqlnd_ps_sources"
   PHP_NEW_EXTENSION(mysqlnd, $mysqlnd_sources, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  PHP_ADD_BUILD_DIR([ext/mysqlnd], 1)
   PHP_INSTALL_HEADERS([ext/mysqlnd/])
-fi
-
-if test "$PHP_MYSQLND" != "no" || test "$PHP_MYSQLND_ENABLED" = "yes" || test "$PHP_MYSQLI" != "no"; then
-  PHP_ADD_BUILD_DIR([ext/mysqlnd], 1)
 fi


### PR DESCRIPTION
Here's one more redundant code cleanup. This was once used by the ext/mysqli when building without ext/mysqlnd and the ext/mysqlnd/php_mysqlnd_config.h file was created in the build directory. This has been tested with in-source build, out-of-source build, shared extensions, compiled in the php binary etc. So it's safe to remove it today.