### PR TITLE
Make `--enable-embed` libs respect `--libdir`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -293,8 +293,11 @@ dnl SAPI configuration.
 dnl ----------------------------------------------------------------------------
 
 dnl Paths to the targets are relative to the build directory.
-SAPI_SHARED=libs/libphp.[]$SHLIB_DL_SUFFIX_NAME
-SAPI_STATIC=libs/libphp.a
+SAPI_LIBNAME=libphp
+SAPI_LIBNAME_SHARED=$SAPI_LIBNAME.[]$SHLIB_DL_SUFFIX_NAME
+SAPI_LIBNAME_STATIC=$SAPI_LIBNAME.a
+SAPI_SHARED=libs/$SAPI_LIBNAME_SHARED
+SAPI_STATIC=libs/$SAPI_LIBNAME_STATIC
 SAPI_LIBTOOL=libphp.la
 
 PHP_CONFIGURE_PART(Configuring SAPI modules)
@@ -1392,6 +1395,7 @@ test "$exec_prefix" = "NONE" && exec_prefix='${prefix}'
 test "$program_prefix" = "NONE" && program_prefix=
 test "$program_suffix" = "NONE" && program_suffix=
 
+orig_libdir=$libdir
 case $libdir in
   '${exec_prefix}/lib')
     libdir=$libdir/php
@@ -1531,6 +1535,7 @@ PHP_SUBST(exec_prefix)
 PHP_SUBST_OLD(program_prefix)
 PHP_SUBST_OLD(program_suffix)
 PHP_SUBST(includedir)
+PHP_SUBST_OLD(orig_libdir)
 PHP_SUBST(libdir)
 PHP_SUBST(mandir)
 PHP_SUBST(phplibdir)
@@ -1578,6 +1583,8 @@ PHP_SUBST(SHARED_LIBTOOL)
 PHP_SUBST(PHP_FRAMEWORKS)
 PHP_SUBST(PHP_FRAMEWORKPATH)
 PHP_SUBST(INSTALL_HEADERS)
+PHP_SUBST_OLD(SAPI_LIBNAME_SHARED)
+PHP_SUBST_OLD(SAPI_LIBNAME_STATIC)
 
 old_CC=$CC
 

--- a/sapi/embed/config.m4
+++ b/sapi/embed/config.m4
@@ -12,12 +12,12 @@ if test "$PHP_EMBED" != "no"; then
     yes|shared)
       LIBPHP_CFLAGS="-shared"
       PHP_EMBED_TYPE=shared
-      INSTALL_IT="\$(mkinstalldirs) \$(INSTALL_ROOT)\$(prefix)/lib; \$(INSTALL) -m 0755 $SAPI_SHARED \$(INSTALL_ROOT)\$(prefix)/lib"
+      INSTALL_IT="\$(mkinstalldirs) \$(INSTALL_ROOT)\$(orig_libdir); \$(INSTALL) -m 0755 $SAPI_SHARED \$(INSTALL_ROOT)\$(orig_libdir)"
       ;;
     static)
       LIBPHP_CFLAGS="-static"
       PHP_EMBED_TYPE=static
-      INSTALL_IT="\$(mkinstalldirs) \$(INSTALL_ROOT)\$(prefix)/lib; \$(INSTALL) -m 0644 $SAPI_STATIC \$(INSTALL_ROOT)\$(prefix)/lib"
+      INSTALL_IT="\$(mkinstalldirs) \$(INSTALL_ROOT)\$(orig_libdir); \$(INSTALL) -m 0644 $SAPI_STATIC \$(INSTALL_ROOT)\$(orig_libdir)"
       ;;
     *)
       PHP_EMBED_TYPE=no
@@ -29,6 +29,7 @@ if test "$PHP_EMBED" != "no"; then
     PHP_INSTALL_HEADERS([sapi/embed/php_embed.h])
   fi
   AC_MSG_RESULT([$PHP_EMBED_TYPE])
+  PHP_SUBST_OLD(PHP_EMBED_TYPE)
 else
   AC_MSG_RESULT(no)
 fi

--- a/scripts/man1/php-config.1.in
+++ b/scripts/man1/php-config.1.in
@@ -39,6 +39,14 @@ Directory where extensions are searched by default
 Directory prefix where header files are installed by default
 .TP
 .PD 0
+.B \-\-lib-dir
+Directory where libraries are installed by default
+.TP
+.PD 0
+.B \-\-lib-embed
+PHP embed library name
+.TP
+.PD 0
 .B \-\-php-binary
 Full path to php CLI or CGI binary
 .TP

--- a/scripts/php-config.in
+++ b/scripts/php-config.in
@@ -7,6 +7,7 @@ exec_prefix="@exec_prefix@"
 version="@PHP_VERSION@"
 vernum="@PHP_VERSION_ID@"
 include_dir="@includedir@/php"
+lib_dir="@orig_libdir@"
 includes="-I$include_dir -I$include_dir/main -I$include_dir/TSRM -I$include_dir/Zend -I$include_dir/ext -I$include_dir/ext/date/lib"
 ldflags="@PHP_LDFLAGS@"
 libs="@EXTRA_LIBS@"
@@ -21,6 +22,7 @@ configure_options="@CONFIGURE_OPTIONS@"
 php_sapis="@PHP_INSTALLED_SAPIS@"
 ini_dir="@EXPANDED_PHP_CONFIG_FILE_SCAN_DIR@"
 ini_path="@EXPANDED_PHP_CONFIG_FILE_PATH@"
+php_embed_type="@PHP_EMBED_TYPE@"
 
 # Set php_cli_binary and php_cgi_binary if available
 for sapi in $php_sapis; do
@@ -41,6 +43,13 @@ else
   php_binary="$php_cgi_binary"
 fi
 
+# Set embed SAPI library path
+if test "$php_embed_type" = "shared"; then
+  php_embed_lib=@SAPI_LIBNAME_SHARED@
+elif test "$php_embed_type" = "static"; then
+  php_embed_lib=@SAPI_LIBNAME_STATIC@
+fi
+
 # Remove quotes
 configure_options=`echo $configure_options | $SED -e "s#'##g"`
 
@@ -57,6 +66,10 @@ case "$1" in
   echo $extension_dir;;
 --include-dir)
   echo $include_dir;;
+--lib-dir)
+  echo $lib_dir;;
+--lib-embed)
+  echo $php_embed_lib;;
 --php-binary)
   echo $php_binary;;
 --php-sapis)
@@ -83,6 +96,8 @@ Options:
   --libs              [$libs]
   --extension-dir     [$extension_dir]
   --include-dir       [$include_dir]
+  --lib-dir           [$lib_dir]
+  --lib-embed         [$php_embed_lib]
   --man-dir           [$man_dir]
   --php-binary        [$php_binary]
   --php-sapis         [$php_sapis]


### PR DESCRIPTION
And make locatable by via `php-config`. Prior to this, `libphp.*` would always install to `$prefix/lib`. After this, they will install to `$libdir`.

In practice, this will make it so that programs embedding libphp can use `php-config` to determine appropriate compile flags without guessing.

In `configure.ac`, it seems `$libdir` is mutated in some instances. Ideally the mutated version would be stored in `$phplibdir` or something. Instead of tracking down all uses of that variable, I introduced another variable `$orig_libdir` that holds the original value passed to the configure script.

This is a no-op for users unless they are compiling with `--libdir` set to something other than `$prefix/lib`, the default.