### PR TITLE
Switch GA to macos-13-large to test on ARM

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -203,7 +203,7 @@ jobs:
         debug: [true, false]
         zts: [true, false]
     name: "${{ matrix.branch.name }}_MACOS_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}"
-    runs-on: macos-12
+    runs-on: macos-13-large
     steps:
       - name: git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Verify generated files are up to date
         uses: ./.github/actions/verify-generated-files
   MACOS_DEBUG_NTS:
-    runs-on: macos-12
+    runs-on: macos-13-large
     steps:
       - name: git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
As an alternative to our Cirrus ARM build.