### PR TITLE
Reset inheritance_cache pointer of zend_class_entry upon serialization

### DIFF
--- a/ext/opcache/zend_file_cache.c
+++ b/ext/opcache/zend_file_cache.c
@@ -867,6 +867,8 @@ static void zend_file_cache_serialize_class(zval                     *zv,
 
 	ZEND_MAP_PTR_INIT(ce->static_members_table, NULL);
 	ZEND_MAP_PTR_INIT(ce->mutable_data, NULL);
+
+	ce->inheritance_cache = NULL;
 }
 
 static void zend_file_cache_serialize_warnings(


### PR DESCRIPTION
to opcache filecache. Usually, when a class is being loaded, a dependency tracking is performed after the call to `zend_file_cache_script_store`. But sometimes, when opcache cache is empty and there are many simultaneous outstanding requests for compilation, some classes do have their `inheritance_cache` initialized before the call to `zend_file_cache_script_store`, and in that case this pointer is serialized as-is. And when such a class is loaded from opcache filecache this pointer also loaded as-is, and now it points to some random location in memory. This causes segfaults occuring when traversing `inheritance_cache` of such classes (`zend_accel_inheritance_cache_find`).

We need to reset `inheritance_cache` pointer of `zend_class_entry` upon serialization. This should have been done anyway since it is a sensible strategy to sanitize any memory pointer upon serialization (either by calling `SERIALIZE_x` macros or setting to `NULL` or any other deterministic value).

This fixes #8143 and possibly #11963.

A side note: it might be beneficial to reset `inheritance_cache` pointer in `zend_file_cache_unserialize_class` too. It will enable to load incorrectly serialized classes (but from the other hand, if this patch goes in, it will be another PHP version with a new hashsum for filecache base directory).