### PR TITLE
Introduce Z_PARAM_FUNC_EX2 to maintain compatibility

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -23,6 +23,8 @@ PHP 8.4 INTERNALS UPGRADE NOTES
   This is identical to the 'f' or Z_PARAM_FUNC type check, except the FCC is
   always initialized because it doesn't free trampolines.
   Trampolines MUST be freed using zend_release_fcall_info_cache() or consumed.
+  Z_PARAM_FUNC_EX2 was added as well with the same arguments as Z_PARAM_FUNC_EX
+  plus an additional argument free_trampoline.
 
 ========================
 2. Build system changes

--- a/Zend/zend_API.h
+++ b/Zend/zend_API.h
@@ -1794,7 +1794,7 @@ ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *
 	Z_PARAM_DOUBLE_EX(dest, is_null, 1, 0)
 
 /* old "f" */
-#define Z_PARAM_FUNC_EX(dest_fci, dest_fcc, check_null, deref, free_trampoline) \
+#define Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, check_null, deref, free_trampoline) \
 		Z_PARAM_PROLOGUE(deref, 0); \
 		if (UNEXPECTED(!zend_parse_arg_func(_arg, &dest_fci, &dest_fcc, check_null, &_error, free_trampoline))) { \
 			if (!_error) { \
@@ -1806,20 +1806,22 @@ ZEND_API ZEND_COLD void zend_argument_value_error(uint32_t arg_num, const char *
 			break; \
 		} \
 
+#define Z_PARAM_FUNC_EX(dest_fci, dest_fcc, check_null, deref) Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, check_null, deref, true)
+
 #define Z_PARAM_FUNC(dest_fci, dest_fcc) \
-	Z_PARAM_FUNC_EX(dest_fci, dest_fcc, 0, 0, true)
+	Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, 0, 0, true)
 
 #define Z_PARAM_FUNC_NO_TRAMPOLINE_FREE(dest_fci, dest_fcc) \
-	Z_PARAM_FUNC_EX(dest_fci, dest_fcc, 0, 0, false)
+	Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, 0, 0, false)
 
 #define Z_PARAM_FUNC_OR_NULL(dest_fci, dest_fcc) \
-	Z_PARAM_FUNC_EX(dest_fci, dest_fcc, 1, 0, true)
+	Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, 1, 0, true)
 
 #define Z_PARAM_FUNC_NO_TRAMPOLINE_FREE_OR_NULL(dest_fci, dest_fcc) \
-	Z_PARAM_FUNC_EX(dest_fci, dest_fcc, 1, 0, false)
+	Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, 1, 0, false)
 
 #define Z_PARAM_FUNC_OR_NULL_WITH_ZVAL(dest_fci, dest_fcc, dest_zp) \
-	Z_PARAM_FUNC_EX(dest_fci, dest_fcc, 1, 0, true) \
+	Z_PARAM_FUNC_EX2(dest_fci, dest_fcc, 1, 0, true) \
 	Z_PARAM_GET_PREV_ZVAL(dest_zp)
 
 /* old "h" */


### PR DESCRIPTION
Commit d86314939c added an additional parameter to Z_PARAM_FUNC_EX. To maintain compatibility with third-party extensions, we keep Z_PARAM_FUNC_EX as it used to be, and add Z_PARAM_FUNC_EX2 instead.