### PR TITLE
Fix registerNodeClass with abstract class crashing

### DIFF
--- a/ext/dom/document.c
+++ b/ext/dom/document.c
@@ -2096,6 +2096,10 @@ PHP_METHOD(DOMDocument, registerNodeClass)
 	}
 
 	if (ce == NULL || instanceof_function(ce, basece)) {
+		if (UNEXPECTED(ce != NULL && (ce->ce_flags & ZEND_ACC_ABSTRACT))) {
+			zend_argument_value_error(2, "must not be an abstract class");
+			RETURN_THROWS();
+		}
 		DOM_GET_OBJ(docp, id, xmlDocPtr, intern);
 		dom_set_doc_classmap(intern->document, basece, ce);
 		RETURN_TRUE;

--- a/ext/dom/tests/registerNodeClass_abstract_class.phpt
+++ b/ext/dom/tests/registerNodeClass_abstract_class.phpt
@@ -1,0 +1,24 @@
+--TEST--
+registerNodeClass() with an abstract class should fail
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+abstract class Test extends DOMElement {
+    abstract function foo();
+}
+
+$dom = new DOMDocument;
+
+try {
+    $dom->registerNodeClass("DOMElement", "Test");
+} catch (ValueError $e) {
+    echo "ValueError: ", $e->getMessage(), "\n";
+}
+
+$dom->createElement("foo");
+
+?>
+--EXPECT--
+ValueError: DOMDocument::registerNodeClass(): Argument #2 ($extendedClass) must not be an abstract class


### PR DESCRIPTION
This always results in a segfault when trying to instantiate, so this never worked.
At least throw an error instead of segfaulting to prevent developers from being confused.