### PR TITLE
Add missing module dependency for xsl

### DIFF
--- a/ext/xsl/php_xsl.c
+++ b/ext/xsl/php_xsl.c
@@ -29,6 +29,7 @@ static zend_object_handlers xsl_object_handlers;
 
 static const zend_module_dep xsl_deps[] = {
 	ZEND_MOD_REQUIRED("libxml")
+	ZEND_MOD_REQUIRED("dom")
 	ZEND_MOD_END
 };
 


### PR DESCRIPTION
This module cannot work without the DOM extension. (e.g. dependency on DOM class entries)