### PR TITLE
Fixed regular expression to get password from dsn

### DIFF
--- a/ext/pdo_pgsql/tests/gh12423.phpt
+++ b/ext/pdo_pgsql/tests/gh12423.phpt
@@ -19,7 +19,7 @@ if (!$user) {
     $user = $match[1] ?? '';
 }
 if (!$password) {
-    preg_match('/password=(.*?) /', $dsnWithCredentials, $match);
+    preg_match('/password=(.*?)$/', $dsnWithCredentials, $match);
     $password = $match[1] ?? '';
 }
 $dsn = str_replace(" user={$user} password={$password}", '', $dsnWithCredentials);


### PR DESCRIPTION
cc: @devnexen 
The regular expression was wrong

take2 of: https://github.com/php/php-src/pull/12446