### PR TITLE
Fix GH-12455: Namespace prefixes reused incorrectly depending on libxml2 version

### DIFF
--- a/ext/dom/php_dom.c
+++ b/ext/dom/php_dom.c
@@ -1519,7 +1519,8 @@ static void dom_reconcile_ns_list_internal(xmlDocPtr doc, xmlNodePtr nodep, xmlN
 		if (nodep->type == XML_ELEMENT_NODE) {
 			dom_reconcile_ns_internal(doc, nodep, search_parent);
 			if (nodep->children) {
-				dom_reconcile_ns_list_internal(doc, nodep->children, nodep->last /* process the whole children list */, search_parent);
+				/* Normally we can use search_parent, but older versions of libxml2 break on that because the closest namespace may not be in the search_parent */
+				dom_reconcile_ns_list_internal(doc, nodep->children, nodep->last /* process the whole children list */, nodep->parent);
 			}
 		}
 		if (nodep == last) {

--- a/ext/dom/tests/bug67440.phpt
+++ b/ext/dom/tests/bug67440.phpt
@@ -58,12 +58,6 @@ echo "-- children manually document element --\n"; case2('insertBefore'); echo "
 echo "-- fragment to document where first element is not a text node --\n"; case3('insertBefore'); echo "\n";
 echo "-- fragment with namespace declarations in children --\n"; case4('insertBefore'); echo "\n";
 
-echo "== insertAfter ==\n";
-echo "-- fragment to document element --\n"; case1('insertBefore'); echo "\n";
-echo "-- children manually document element --\n"; case2('insertBefore'); echo "\n";
-echo "-- fragment to document where first element is not a text node --\n"; case3('insertBefore'); echo "\n";
-echo "-- fragment with namespace declarations in children --\n"; case4('insertBefore'); echo "\n";
-
 ?>
 --EXPECT--
 == appendChild ==
@@ -95,34 +89,6 @@ echo "-- fragment with namespace declarations in children --\n"; case4('insertBe
 </rootElement>
 
 == insertBefore ==
--- fragment to document element --
-<?xml version="1.0"?>
-<rootElement xmlns:myns="http://example/ns" xmlns:myns2="http://example/ns2">
-<myns:childNode>1</myns:childNode>
-<myns:childNode>2</myns:childNode>
-</rootElement>
-
--- children manually document element --
-<?xml version="1.0"?>
-<rootElement xmlns:myns="http://example/ns" xmlns:myns2="http://example/ns2">
-<myns:childNode>1</myns:childNode>
-<myns:childNode>2</myns:childNode>
-</rootElement>
-
--- fragment to document where first element is not a text node --
-<?xml version="1.0"?>
-<rootElement xmlns:myns="http://example/ns" xmlns:myns2="http://example/ns2"><myns:childNode>1</myns:childNode>
-<myns:childNode>2</myns:childNode>
-</rootElement>
-
--- fragment with namespace declarations in children --
-<?xml version="1.0"?>
-<rootElement xmlns:myns="http://example/ns" xmlns:myns2="http://example/ns2">
-<myns:childNode>1<myns2:childNode>3</myns2:childNode></myns:childNode>
-<myns:childNode>2</myns:childNode>
-</rootElement>
-
-== insertAfter ==
 -- fragment to document element --
 <?xml version="1.0"?>
 <rootElement xmlns:myns="http://example/ns" xmlns:myns2="http://example/ns2">

--- a/ext/dom/tests/gh12455.phpt
+++ b/ext/dom/tests/gh12455.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-12455 (Namespace prefixes reused incorrectly depending on libxml2 version)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument();
+$element = $doc->createElementNS('http://test', 'a:x');
+$doc->appendChild($element);
+$element1 = $doc->createElementNS('http://test', 'b:y');
+$element->appendChild($element1);
+$element1->appendChild($doc->createElementNS('http://test', 'b:z'));
+echo $doc->saveXml();
+
+$xpath = new DOMXPath($doc);
+$xpath->registerNodeNamespaces = true;
+$xpath->registerNamespace('b', 'http://test');
+
+$elements = $xpath->query('//b:z');
+foreach ($elements as $e) {
+    var_dump($e->nodeName);
+}
+
+$elements = $xpath->query('//*[name()="b:z"]');
+echo $elements->length;
+
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<a:x xmlns:a="http://test"><b:y xmlns:b="http://test"><b:z/></b:y></a:x>
+string(3) "b:z"
+1


### PR DESCRIPTION
On old libxml2 versions, if you reconcile against a parent that does not contain your own prefix, the prefix may shift. Avoid this by reconciling against your own parent, which will work correctly in both new and old versions, at the potential cost of performance.

Also remove the insertAfter part of that one test, because insertAfter does not exist and I apparently forgot to remove that part ...