### PR TITLE
Add Laravel demo page to CI

### DIFF
--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -27,6 +27,8 @@ function main() {
     $data['Symfony Demo 2.2.3 JIT'] = runSymfonyDemo(true);
     $data['Wordpress 6.2'] = runWordpress(false);
     $data['Wordpress 6.2 JIT'] = runWordpress(true);
+    $data['Laravel'] = runLaravelDemo(false);
+    $data['Laravel JIT'] = runLaravelDemo(true);
     $result = json_encode($data, JSON_PRETTY_PRINT) . "\n";
 
     fwrite(STDOUT, $result);
@@ -87,6 +89,14 @@ function runWordpress(bool $jit): array {
     // Warmup
     runPhpCommand([$dir . '/index.php'], $dir);
     return runValgrindPhpCgiCommand('wordpress', [$dir . '/index.php'], cwd: $dir, jit: $jit, warmup: 50, repeat: 50);
+}
+
+function runLaravelDemo(bool $jit): array {
+
+    $dir = __DIR__ . '/repos/laravel-demo-10.10';
+    cloneRepo($dir, 'https://github.com/nielsdos/laravel-demo-app.git');
+    runPhpCommand([$dir . '/artisan', 'config:cache']);
+    return runValgrindPhpCgiCommand('laravel-demo', [$dir . '/public/index.php'], cwd: $dir, jit: $jit, warmup: 50, repeat: 100);
 }
 
 function runPhpCommand(array $args, ?string $cwd = null): ProcessResult {


### PR DESCRIPTION
The demo page doesn't do a lot, but might still be useful. 100 runs is enough to get rid of any prominent compilation overhead in the profiles.

Note: Repo must be moved of course.