### PR TITLE
Implement diagnostic ignore macro for Clang

### DIFF
--- a/Zend/zend_portability.h
+++ b/Zend/zend_portability.h
@@ -737,18 +737,29 @@ extern "C++" {
 # define ZEND_INDIRECT_RETURN
 #endif
 
-#if __GNUC__ && !defined(__clang__)
-# define __DO_PRAGMA(x) _Pragma(#x)
-# define _DO_PRAGMA(x) __DO_PRAGMA(x)
-# define ZEND_CGG_DIAGNOSTIC_IGNORED_START(warning) \
+#define __ZEND_DO_PRAGMA(x) _Pragma(#x)
+#define _ZEND_DO_PRAGMA(x) __ZEND_DO_PRAGMA(x)
+#if defined(__clang__)
+# define ZEND_DIAGNOSTIC_IGNORED_START(warning) \
+	_Pragma("clang diagnostic push") \
+	_ZEND_DO_PRAGMA(clang diagnostic ignored warning)
+# define ZEND_DIAGNOSTIC_IGNORED_END \
+	_Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+# define ZEND_DIAGNOSTIC_IGNORED_START(warning) \
 	_Pragma("GCC diagnostic push") \
-	_DO_PRAGMA(GCC diagnostic ignored warning)
-# define ZEND_CGG_DIAGNOSTIC_IGNORED_END \
+	_ZEND_DO_PRAGMA(GCC diagnostic ignored warning)
+# define ZEND_DIAGNOSTIC_IGNORED_END \
 	_Pragma("GCC diagnostic pop")
 #else
-# define ZEND_CGG_DIAGNOSTIC_IGNORED_START(warning)
-# define ZEND_CGG_DIAGNOSTIC_IGNORED_END
+# define ZEND_DIAGNOSTIC_IGNORED_START(warning)
+# define ZEND_DIAGNOSTIC_IGNORED_END
 #endif
+
+/** @deprecated */
+#define ZEND_CGG_DIAGNOSTIC_IGNORED_START ZEND_DIAGNOSTIC_IGNORED_START
+/** @deprecated */
+#define ZEND_CGG_DIAGNOSTIC_IGNORED_END ZEND_DIAGNOSTIC_IGNORED_END
 
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */
 # define ZEND_STATIC_ASSERT(c, m) _Static_assert((c), m)

--- a/ext/imap/php_imap.h
+++ b/ext/imap/php_imap.h
@@ -47,9 +47,9 @@
 # endif
 
  /* these are used for quota support */
- ZEND_CGG_DIAGNOSTIC_IGNORED_START("-Wstrict-prototypes")
+ ZEND_DIAGNOSTIC_IGNORED_START("-Wstrict-prototypes")
 # include "c-client.h"	/* includes mail.h and rfc822.h */
- ZEND_CGG_DIAGNOSTIC_IGNORED_END
+ ZEND_DIAGNOSTIC_IGNORED_END
 # include "imap4r1.h"	/* location of c-client quota functions */
 #else
 # include "mail.h"

--- a/ext/oci8/php_oci8_int.h
+++ b/ext/oci8/php_oci8_int.h
@@ -53,9 +53,9 @@
 /* }}} */
 
 #include "ext/standard/php_string.h"
-ZEND_CGG_DIAGNOSTIC_IGNORED_START("-Wstrict-prototypes")
+ZEND_DIAGNOSTIC_IGNORED_START("-Wstrict-prototypes")
 #include <oci.h>
-ZEND_CGG_DIAGNOSTIC_IGNORED_END
+ZEND_DIAGNOSTIC_IGNORED_END
 
 #if !defined(OCI_MAJOR_VERSION) || OCI_MAJOR_VERSION < 11 || ((OCI_MAJOR_VERSION == 11) && (OCI_MINOR_VERSION < 2))
 #error This version of PHP OCI8 requires Oracle Client libraries from 11.2 or later.

--- a/ext/pdo_oci/php_pdo_oci_int.h
+++ b/ext/pdo_oci/php_pdo_oci_int.h
@@ -19,9 +19,9 @@
 
 #include "zend_portability.h"
 
-ZEND_CGG_DIAGNOSTIC_IGNORED_START("-Wstrict-prototypes")
+ZEND_DIAGNOSTIC_IGNORED_START("-Wstrict-prototypes")
 #include <oci.h>
-ZEND_CGG_DIAGNOSTIC_IGNORED_END
+ZEND_DIAGNOSTIC_IGNORED_END
 
 typedef struct {
 	const char *file;

--- a/ext/soap/php_encoding.c
+++ b/ext/soap/php_encoding.c
@@ -2387,11 +2387,11 @@ iterator_done:
 			if (soap_version == SOAP_1_1) {
 				smart_str_0(&array_type);
 #if defined(__GNUC__) && __GNUC__ >= 11
-				ZEND_CGG_DIAGNOSTIC_IGNORED_START("-Wstringop-overread")
+				ZEND_DIAGNOSTIC_IGNORED_START("-Wstringop-overread")
 #endif
 				bool is_xsd_any_type = strcmp(ZSTR_VAL(array_type.s),"xsd:anyType") == 0;
 #if defined(__GNUC__) && __GNUC__ >= 11
-				ZEND_CGG_DIAGNOSTIC_IGNORED_END
+				ZEND_DIAGNOSTIC_IGNORED_END
 #endif
 				if (is_xsd_any_type) {
 					smart_str_free(&array_type);


### PR DESCRIPTION
Apparently I called the old macro CGG accidentally :smile: 