### PR TITLE
Fix refcounting of doc_comment

### DIFF
--- a/Zend/tests/gh12468_1.phpt
+++ b/Zend/tests/gh12468_1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-12468: Double-free of shared doc_comment in trait
+--FILE--
+<?php
+trait T {
+	/** some doc */
+	static protected $a = 0;
+}
+class A {
+	use T;
+}
+class B extends A {
+	use T;
+}
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/gh12468_2.phpt
+++ b/Zend/tests/gh12468_2.phpt
@@ -1,0 +1,19 @@
+--TEST--
+GH-12468: Double-free of shared doc_comment in trait
+--FILE--
+<?php
+trait T {
+	/** some doc */
+	static protected $a = 0;
+}
+class A {
+	/** some doc */
+	static protected $a = 0;
+}
+class B extends A {
+	use T;
+}
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -4120,7 +4120,7 @@ ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, z
 		    (property_info_ptr->flags & ZEND_ACC_STATIC) != 0) {
 			property_info->offset = property_info_ptr->offset;
 			zval_ptr_dtor(&ce->default_static_members_table[property_info->offset]);
-			if (property_info_ptr->doc_comment) {
+			if (property_info_ptr->doc_comment && property_info_ptr->ce == ce) {
 				zend_string_release(property_info_ptr->doc_comment);
 			}
 			zend_hash_del(&ce->properties_info, name);
@@ -4145,7 +4145,7 @@ ZEND_API zend_property_info *zend_declare_typed_property(zend_class_entry *ce, z
 		    (property_info_ptr->flags & ZEND_ACC_STATIC) == 0) {
 			property_info->offset = property_info_ptr->offset;
 			zval_ptr_dtor(&ce->default_properties_table[OBJ_PROP_TO_NUM(property_info->offset)]);
-			if (property_info_ptr->doc_comment) {
+			if (property_info_ptr->doc_comment && property_info_ptr->ce == ce) {
 				zend_string_release_ex(property_info_ptr->doc_comment, 1);
 			}
 			zend_hash_del(&ce->properties_info, name);


### PR DESCRIPTION
When redeclaring an overridden static property with a trait we're removing the property from the class. However, because the property itself does not belong to the class we must not free its associated data.

This issue is exposed by 9a250cc9d6 in PHP 8.3+ because duplicate static properties in traits are no longer skipped, but redeclared.

Fixes GH-12468