### PR TITLE
ci: Fixed an issue where GitHub Actions could not connect to PostgreSQL and MySQL.

### DIFF
--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -31,8 +31,10 @@ runs:
         export PDO_OCI_TEST_USER="system"
         export PDO_OCI_TEST_PASS="pass"
         export PDO_OCI_TEST_DSN="oci:dbname=localhost/XEPDB1;charset=AL32UTF8"
-        export PGSQL_TEST_CONNSTR="host=postgres dbname=test port=5432 user=postgres password=postgres"
-        export PDO_PGSQL_TEST_DSN="host=postgres dbname=test port=5432 user=postgres password=postgres"
+        export PGSQL_TEST_CONNSTR="host=localhost dbname=test port=5432 user=postgres password=postgres"
+        if [[ -z "$PDO_PGSQL_TEST_DSN" ]]; then
+          export PDO_PGSQL_TEST_DSN="pgsql:host=localhost port=5432 dbname=test user=postgres password=postgres"
+        fi
         export ODBC_TEST_USER="odbc_test"
         export ODBC_TEST_PASS="password"
         export ODBC_TEST_DSN="Driver={ODBC Driver 17 for SQL Server};Server=127.0.0.1;Database=odbc;uid=$ODBC_TEST_USER;pwd=$ODBC_TEST_PASS"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,7 +62,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
     env:
-      MYSQL_TEST_HOST: mysql
+      MYSQL_TEST_HOST: localhost
       PDO_MYSQL_TEST_HOST: localhost
     strategy:
       fail-fast: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,19 +48,24 @@ jobs:
     services:
       mysql:
         image: mysql:8
+        ports:
+          - 3306:3306
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: root
       postgres:
         image: postgres
+        ports:
+          - 5432:5432
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
     env:
       MYSQL_TEST_HOST: mysql
-      PDO_MYSQL_TEST_DSN: mysql:host=mysql;dbname=test
-      PDO_MYSQL_TEST_HOST: mysql
+      PDO_MYSQL_TEST_DSN: mysql:host=localhost;dbname=test
+      PDO_MYSQL_TEST_HOST: localhost
+      PDO_PGSQL_TEST_DSN: pgsql:host=localhost port=5432 dbname=test user=postgres password=postgres
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,9 +63,7 @@ jobs:
           POSTGRES_DB: test
     env:
       MYSQL_TEST_HOST: mysql
-      PDO_MYSQL_TEST_DSN: mysql:host=localhost;dbname=test
       PDO_MYSQL_TEST_HOST: localhost
-      PDO_PGSQL_TEST_DSN: pgsql:host=localhost port=5432 dbname=test user=postgres password=postgres
     strategy:
       fail-fast: false
       matrix:

--- a/ext/mysqli/tests/gh8978.phpt
+++ b/ext/mysqli/tests/gh8978.phpt
@@ -24,6 +24,6 @@ try {
 echo 'done!';
 ?>
 --EXPECTF--
-Warning: failed loading cafile stream: `x509.ca' in %s
+Warning: mysqli_real_connect(): This stream does not support SSL/crypto in %s
 Cannot connect to MySQL using SSL
 done!


### PR DESCRIPTION
Since the pdo-pgsql tests are only run on CircleCI when merged into the master branch, some contributors seem to be working on setting up CircleCI themselves. for example: https://github.com/php/php-src/pull/12448

As with any other test, it may be more convenient to run it in GitHub Actions.

---

(Added on 2023/10/20 0:00 JST)

### Fix details

All connections to PostgreSQL and MySQL from CI running on GitHub Actions were failing. With this fix, the following tests will now work correctly.

* pdo_pgsql
* pdo_mysql
* ~~mysqli~~
   * Hold. When fixed, tests that are no longer skipped will fail.
* pgsql

There were no problems with SQL Server, Oracle, etc., but only PostgreSQL and MySQL could not be connected. The difference is that they use GitHub Actions Service Containers.

### *Previous implementation:*

* The service name of Service Containers was set as the connection destination from the test.

If the test itself is running inside Service Containers, it can be connected without any problems by name resolution between containers. But the tests are running outside of Service Containers.

### *Implementation after fixing:*

* After exposing the connection port to the database from Service Containers to the host to `localhost`,
* Fixed to set `localhost` also for connection from test.