### PR TITLE
Remove php_xsl_create_object()

### DIFF
--- a/UPGRADING.INTERNALS
+++ b/UPGRADING.INTERNALS
@@ -48,6 +48,10 @@ PHP 8.4 INTERNALS UPGRADE NOTES
      should either be inlined and undefined behavior fixed or it should be
      replaced by a non-biased scaler.
 
+ c. ext/xsl
+   - The function php_xsl_create_object() was removed as it was not used
+     nor exported.
+
 ========================
 4. OpCode changes
 ========================

--- a/ext/xsl/php_xsl.c
+++ b/ext/xsl/php_xsl.c
@@ -169,41 +169,6 @@ void php_xsl_set_object(zval *wrapper, void *obj)
 }
 /* }}} */
 
-/* {{{ php_xsl_create_object */
-void php_xsl_create_object(xsltStylesheetPtr obj, zval *wrapper_in, zval *return_value )
-{
-	zval *wrapper;
-	zend_class_entry *ce;
-
-	if (!obj) {
-		wrapper = wrapper_in;
-		ZVAL_NULL(wrapper);
-		return;
-	}
-
-	if ((wrapper = xsl_object_get_data((void *) obj))) {
-		ZVAL_COPY(wrapper, wrapper_in);
-		return;
-	}
-
-	if (!wrapper_in) {
-		wrapper = return_value;
-	} else {
-		wrapper = wrapper_in;
-	}
-
-
-	ce = xsl_xsltprocessor_class_entry;
-
-	if (!wrapper_in) {
-		object_init_ex(wrapper, ce);
-	}
-	php_xsl_set_object(wrapper, (void *) obj);
-
-	return;
-}
-/* }}} */
-
 /* {{{ PHP_MSHUTDOWN_FUNCTION */
 PHP_MSHUTDOWN_FUNCTION(xsl)
 {

--- a/ext/xsl/php_xsl.h
+++ b/ext/xsl/php_xsl.h
@@ -75,7 +75,6 @@ static inline xsl_object *php_xsl_fetch_object(zend_object *obj) {
 
 void php_xsl_set_object(zval *wrapper, void *obj);
 void xsl_objects_free_storage(zend_object *object);
-void php_xsl_create_object(xsltStylesheetPtr obj, zval *wrapper_in, zval *return_value );
 
 void xsl_ext_function_string_php(xmlXPathParserContextPtr ctxt, int nargs);
 void xsl_ext_function_object_php(xmlXPathParserContextPtr ctxt, int nargs);


### PR DESCRIPTION
Unused and not exported, so let's remove this dead code.