### PR TITLE
Fix #50713: openssl_pkcs7_verify() may ignore untrusted CAs

### DIFF
--- a/ext/openssl/openssl.c
+++ b/ext/openssl/openssl.c
@@ -5266,7 +5266,7 @@ PHP_FUNCTION(openssl_pkcs7_verify)
 					signersfilename, signersfilename_len, 3, PHP_OPENSSL_BIO_MODE_W(PKCS7_BINARY));
 			if (certout) {
 				int i;
-				signers = PKCS7_get0_signers(p7, NULL, (int)flags);
+				signers = PKCS7_get0_signers(p7, others, (int)flags);
 				if (signers != NULL) {
 
 					for (i = 0; i < sk_X509_num(signers); i++) {

--- a/ext/openssl/tests/CertificateGenerator.inc
+++ b/ext/openssl/tests/CertificateGenerator.inc
@@ -85,8 +85,8 @@ class CertificateGenerator
         openssl_x509_export_to_file($this->ca, $file);
     }
 
-    public function saveNewCertAndKey(
-        $commonNameForCert, $certFile, $keyFile, $keyLength = null, $subjectAltName = null
+    private function generateCertAndKey(
+        $commonNameForCert, $file, $keyLength = null, $subjectAltName = null
     ) {
         $dn = [
             'countryName' => 'BY',
@@ -117,51 +117,53 @@ $subjectAltNameConfig
 basicConstraints = CA:FALSE
 $subjectAltNameConfig
 CONFIG;
-        $configFile = $certFile . '.cnf';
+        $configFile = $file . '.cnf';
         file_put_contents($configFile, $configCode);
 
-        try {
-            $config = [
-                'config' => $configFile,
-                'req_extensions' => 'v3_req',
-                'x509_extensions' => 'usr_cert',
-            ];
+        $config = [
+            'config' => $configFile,
+            'req_extensions' => 'v3_req',
+            'x509_extensions' => 'usr_cert',
+        ];
 
-            $this->lastKey = self::generateKey($keyLength);
-            $csr = openssl_csr_new($dn, $this->lastKey, $config);
-            $this->lastCert = openssl_csr_sign(
-                $csr,
-                $this->ca,
-                $this->caKey,
-                /* days */ 2,
-                $config,
-            );
-            if (!$this->lastCert) {
-                throw new Exception('Failed to create certificate');
-            }
+        $this->lastKey = self::generateKey($keyLength);
+        $csr = openssl_csr_new($dn, $this->lastKey, $config);
+        $this->lastCert = openssl_csr_sign(
+            $csr,
+            $this->ca,
+            $this->caKey,
+            /* days */ 2,
+            $config,
+        );
 
-            $certText = '';
-            openssl_x509_export($this->lastCert, $certText);
-
-            $keyText = '';
-            openssl_pkey_export($this->lastKey, $keyText, null, $config);
-
-            if ($certFile === $keyFile) {
-                file_put_contents($certFile, $certText . PHP_EOL . $keyText);
-            } else {
-                file_put_contents($certFile, $certText);
-                file_put_contents($keyFile, $keyText);
-            }
-        } finally {
-            unlink($configFile);
-        }
+        return $config;
     }
-
 
     public function saveNewCertAsFileWithKey(
         $commonNameForCert, $file, $keyLength = null, $subjectAltName = null
     ) {
-        $this->saveNewCertAndKey($commonNameForCert, $file, $file, $keyLength, $subjectAltName);
+        $config = $this->generateCertAndKey($commonNameForCert, $file, $keyLength, $subjectAltName);
+
+        $certText = '';
+        openssl_x509_export($this->lastCert, $certText);
+
+        $keyText = '';
+        openssl_pkey_export($this->lastKey, $keyText, null, $config);
+
+        file_put_contents($file, $certText . PHP_EOL . $keyText);
+
+        unlink($config['config']);
+    }
+
+    public function saveNewCertAndKey(
+        $commonNameForCert, $certFile, $keyFile, $keyLength = null, $subjectAltName = null
+    ) {
+        $config = $this->generateCertAndKey($commonNameForCert, $certFile, $keyLength, $subjectAltName);
+
+        openssl_x509_export_to_file($this->lastCert, $certFile);
+        openssl_pkey_export_to_file($this->lastKey, $keyFile, null, $config);
+
+        unlink($config['config']);
     }
 
     public function getCertDigest($algo)

--- a/ext/openssl/tests/bug50713.phpt
+++ b/ext/openssl/tests/bug50713.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Bug #50713 (openssl_pkcs7_verify() may ignore untrusted CAs)
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$inFile =  __DIR__ . "/plain.txt";
+$outFile = __DIR__ . '/bug50713-out.pem';
+$signersFile = __DIR__ . '/bug50713-signers.pem';
+$keyFile = __DIR__ . '/bug50713-key.pem';
+$certFile = __DIR__ . '/bug50713-crt.pem';
+$cacertFile = __DIR__ . '/bug50713-ca.pem';
+
+include 'CertificateGenerator.inc';
+$certificateGenerator = new CertificateGenerator();
+$certificateGenerator->saveCaCert($cacertFile);
+$certificateGenerator->saveNewCertAndKey('bug50713', $certFile, $keyFile, 1024);
+
+var_dump(openssl_pkcs7_sign($inFile, $outFile, 'file://' . $certFile, 'file://' . $keyFile, [], PKCS7_NOCERTS));
+var_dump(openssl_pkcs7_verify($outFile, 0, $signersFile, [$cacertFile], $certFile));
+var_dump(strlen(file_get_contents($signersFile)) > 0);
+?>
+--CLEAN--
+<?php
+$outFile = __DIR__ . '/bug50713-out.pem';
+$signersFile = __DIR__ . '/bug50713-signers.pem';
+$keyFile = __DIR__ . '/bug50713-key.pem';
+$certFile = __DIR__ . '/bug50713-crt.pem';
+$cacertFile = __DIR__ . '/bug50713-ca.pem';
+
+@unlink($signersFile);
+@unlink($outFile);
+@unlink($keyFile);
+@unlink($certFile);
+@unlink($cacertFile);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
The signers were not correctly retrieved if additional (untrusted) certs were used as they were not used for retrieving the signers. The main part of this work was to create a properly verified certs tests. The sign operation does not include the cert in envelope so it is passed explicitly (main use case for untrusted certs). Before the function would return -1 and empty signers file. This is now fixed.