### PR TITLE
Add fast mb_strcut implementation for UTF-16

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -95,6 +95,10 @@ PHP 8.4 UPGRADE NOTES
 5. Changed Functions
 ========================================
 
+- MBString:
+  . The behavior of mb_strcut is more consistent now on invalid UTF-8 and UTF-16
+    strings. (For valid UTF-8 and UTF-16 strings, there is no change.)
+
 - PGSQL:
   . pg_select, the conditions arguments accepts an empty array and is optional.
 
@@ -168,3 +172,5 @@ PHP 8.4 UPGRADE NOTES
 
 * The performance of strspn() is greatly improved. It now runs in linear time
   instead of being bounded by quadratic time.
+
+* mb_strcut() is much faster now for UTF-8 and UTF-16 strings.

--- a/ext/mbstring/tests/mb_strcut.phpt
+++ b/ext/mbstring/tests/mb_strcut.phpt
@@ -248,7 +248,7 @@ OK
 Single byte: []
 With from=1: []
 Bad surrogate: []
-Bad surrogate followed by other bytes: [003f1243]
+Bad surrogate followed by other bytes: [d9001243]
 BE byte order mark: []
 LE byte order mark: []
 Length=0: []


### PR DESCRIPTION
Similar to the fast, specialized mb_strcut implementation for UTF-8 in 1f0cf133db, this new implementation of mb_strcut for UTF-16 strings just examines a few bytes before each cut point.

Even for short strings, the new implementation is around 2x faster. For strings around 10,000 bytes in length, it comes out about 100-500x faster in my microbenchmarks.

The new implementation behaves identically to the old one on valid UTF-16 strings; a fuzzer was used to help verify this.

@Girgias @cmb69 @youkidearitai @kamil-tekiela @iluuu1994 