### PR TITLE
[skip ci] Minor fix in `NEWS` alignment

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,8 +28,8 @@ PHP                                                                        NEWS
     upgrading to 8.1.3 due to corrupt on-disk file cache). (turchanov)
 
 - OpenSSL:
-  Fixed bug GH-12489 (Missing sigbio creation checking in openssl_cms_verify).
-  (Jakub Zelenka)
+  . Fixed bug GH-12489 (Missing sigbio creation checking in openssl_cms_verify).
+    (Jakub Zelenka)
 
 - Random:
   . Fix Randomizer::getFloat() returning incorrect results under


### PR DESCRIPTION
Fixes a minor misalignment in `NEWS` file, following the other list items in the rest of the file.