### PR TITLE
Remove unused DBA_CDB_MAKE constant

### DIFF
--- a/ext/dba/config.m4
+++ b/ext/dba/config.m4
@@ -640,7 +640,6 @@ PHP_ARG_ENABLE([flatfile],,
 dnl CDB
 if test "$PHP_CDB" = "yes"; then
   AC_DEFINE(DBA_CDB_BUILTIN, 1, [ ])
-  AC_DEFINE(DBA_CDB_MAKE, 1, [ ])
   AC_DEFINE(DBA_CDB, 1, [ ])
   cdb_sources="libcdb/cdb.c libcdb/cdb_make.c libcdb/uint32.c"
   THIS_RESULT="builtin"

--- a/ext/dba/config.w32
+++ b/ext/dba/config.w32
@@ -11,7 +11,7 @@ if (PHP_DBA != "no") {
 	ADD_SOURCES("ext/dba/libflatfile", "flatfile.c", "dba");
 	ADD_SOURCES("ext/dba/libinifile", "inifile.c", "dba");
 	AC_DEFINE('HAVE_DBA', 1, 'DBA support');
-	ADD_FLAG("CFLAGS_DBA", "/D DBA_FLATFILE=1 /D DBA_CDB=1 /D DBA_CDB_MAKE=1 /D DBA_CDB_BUILTIN=1 /D DBA_INIFILE=1");
+	ADD_FLAG("CFLAGS_DBA", "/D DBA_FLATFILE=1 /D DBA_CDB=1 /D DBA_CDB_BUILTIN=1 /D DBA_INIFILE=1");
 
 	if (PHP_DB != "no") {
 		if (CHECK_LIB("libdb31s.lib;libdb61.lib", "dba", PHP_DBA) &&


### PR DESCRIPTION
This constant is unused in the code. It got in probably from the very early extension days.