### PR TITLE
fix: don't delete an unitialized timer

### DIFF
--- a/Zend/zend_max_execution_timer.c
+++ b/Zend/zend_max_execution_timer.c
@@ -41,11 +41,12 @@ ZEND_API void zend_max_execution_timer_init(void) /* {{{ */
 	sev.sigev_signo = SIGRTMIN;
 	sev.sigev_notify_thread_id = (pid_t) syscall(SYS_gettid);
 
-	EG(pid) = getpid();
 	// Measure wall time instead of CPU time as originally planned now that it is possible https://github.com/php/php-src/pull/6504#issuecomment-1370303727
 	if (timer_create(CLOCK_BOOTTIME, &sev, &EG(max_execution_timer_timer)) != 0) {
 		zend_strerror_noreturn(E_ERROR, errno, "Could not create timer");
 	}
+
+	EG(pid) = getpid();
 
 #  ifdef MAX_EXECUTION_TIMERS_DEBUG
 		fprintf(stderr, "Timer %#jx created on thread %d\n", (uintmax_t) EG(max_execution_timer_timer), sev.sigev_notify_thread_id);


### PR DESCRIPTION
This change (proposed by @arnaud-lb) prevents calling `timer_delete()` on an uninitialized timer in https://github.com/php/php-src/blob/php-8.1.25/Zend/zend_max_execution_timer.c#L96 in case the timer has not been created (e.g.: when running out of available kernel timers under high loads).

