### PR TITLE
Fix memory leak in by-ref foreach.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ PHP                                                                        NEWS
   . Fixed bug GH-12468 (Double-free of doc_comment when overriding static
     property via trait). (ilutov)
   . Fixed segfault caused by weak references to FFI objects. (sj-i)
+  . Fix memory leak if a circular reference is created inside a by-ref foreach
+    on the array variable. (danog)
 
 - DOM:
   . Fix registerNodeClass with abstract class crashing. (nielsdos)

--- a/Zend/tests/leak_foreach_on_ref.phpt
+++ b/Zend/tests/leak_foreach_on_ref.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Fix memory leak if a circular reference is created inside a by-ref foreach on the array variable.
+--FILE--
+<?php
+
+$a = [0];
+
+foreach ($a as &$v) {
+    $a[0] = &$a;
+    unset($a);
+    gc_collect_cycles();
+}
+
+?>
+==DONE==
+--EXPECT--
+==DONE==

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3125,7 +3125,7 @@ ZEND_VM_HOT_HANDLER(127, ZEND_FE_FREE, TMPVAR, ANY)
 		if (Z_FE_ITER_P(var) != (uint32_t)-1) {
 			zend_hash_iterator_del(Z_FE_ITER_P(var));
 		}
-		zval_ptr_dtor_nogc(var);
+		zval_ptr_dtor(var);
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -14317,7 +14317,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_FE_FREE_SPEC_TMPVA
 		if (Z_FE_ITER_P(var) != (uint32_t)-1) {
 			zend_hash_iterator_del(Z_FE_ITER_P(var));
 		}
-		zval_ptr_dtor_nogc(var);
+		zval_ptr_dtor(var);
 		ZEND_VM_NEXT_OPCODE_CHECK_EXCEPTION();
 	}
 


### PR DESCRIPTION
The issue occurs if a circular reference on the array var of a by-ref foreach is created, all visible references to the array var are removed and the garbage collector is invoked before exiting the foreach.  

Invoking the garbage collector removes the array var from the roots, because the foreach statement itself is still holding a reference to it and thus it's still alive, but when the foreach ends it does not re-add the array var to the GC roots, thus the GC cannot collect it and it leaks.

This PR fixes the issue by invoking the GC-aware zval destructor, which correctly adds the zval to the GC roots.

Fixes oss-fuzz #54515.
