### PR TITLE
perf: reuse timers

### DIFF
--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -407,7 +407,6 @@ void shutdown_executor(void) /* {{{ */
 	zend_shutdown_executor_values(fast_shutdown);
 
 	zend_weakrefs_shutdown();
-	zend_max_execution_timer_shutdown();
 	zend_fiber_shutdown();
 
 	zend_try {

--- a/Zend/zend_max_execution_timer.c
+++ b/Zend/zend_max_execution_timer.c
@@ -35,17 +35,24 @@
 
 ZEND_API void zend_max_execution_timer_init(void) /* {{{ */
 {
+	pid_t pid = getpid();
+
+	if (EG(pid) == pid) {
+		return;
+	}
+
 	struct sigevent sev;
 	sev.sigev_notify = SIGEV_THREAD_ID;
 	sev.sigev_value.sival_ptr = &EG(max_execution_timer_timer);
 	sev.sigev_signo = SIGRTMIN;
 	sev.sigev_notify_thread_id = (pid_t) syscall(SYS_gettid);
 
-	EG(pid) = getpid();
 	// Measure wall time instead of CPU time as originally planned now that it is possible https://github.com/php/php-src/pull/6504#issuecomment-1370303727
 	if (timer_create(CLOCK_BOOTTIME, &sev, &EG(max_execution_timer_timer)) != 0) {
 		zend_strerror_noreturn(E_ERROR, errno, "Could not create timer");
 	}
+
+	EG(pid) = pid;
 
 #  ifdef MAX_EXECUTION_TIMERS_DEBUG
 		fprintf(stderr, "Timer %#jx created on thread %d\n", (uintmax_t) EG(max_execution_timer_timer), sev.sigev_notify_thread_id);


### PR DESCRIPTION
This patch significantly improves performance by allowing reusing timers instead of creating and deleting them at every request. With this patch, PHP does only 2 syscalls per thread (a thread can handle many requests sequentially) instead of 2 per request.

As PHP doesn't manage threads itself, calling `zend_max_execution_timer_shutdown()` when a thread is terminated will now be the responsibility of the caller. I think that this change is acceptable because threads are often used to handle requests until the process terminates (it's what FrankenPHP does for instance), so even if `zend_max_execution_timer_shutdown()` isn't called explicitly (which is better and should be done by SAPIs using threads), the OS will destroy the timers when after the process termination.

cc @arnaud-lb 