### PR TITLE
Fix #47531: No way of removing redundant xmlns: declarations

### DIFF
--- a/ext/dom/tests/DOMElement_toggleAttribute.phpt
+++ b/ext/dom/tests/DOMElement_toggleAttribute.phpt
@@ -123,26 +123,26 @@ bool(true)
 Toggling namespaces:
 bool(false)
 <?xml version="1.0"?>
-<default:container xmlns:foo="some:ns2" xmlns:anotherone="some:ns3" xmlns:default="some:ns"><foo:bar/><default:baz/></default:container>
+<container xmlns:foo="some:ns2" xmlns:anotherone="some:ns3" xmlns="some:ns"><foo:bar/><baz/></container>
 bool(false)
 <?xml version="1.0"?>
-<default:container xmlns:foo="some:ns2" xmlns:default="some:ns"><foo:bar/><default:baz/></default:container>
+<container xmlns:foo="some:ns2" xmlns="some:ns"><foo:bar/><baz/></container>
 bool(true)
 <?xml version="1.0"?>
-<default:container xmlns:foo="some:ns2" xmlns:default="some:ns" xmlns:anotherone=""><foo:bar/><default:baz/></default:container>
+<container xmlns:foo="some:ns2" xmlns="some:ns" xmlns:anotherone=""><foo:bar/><baz/></container>
 bool(false)
 <?xml version="1.0"?>
-<default:container xmlns:default="some:ns" xmlns:anotherone="" xmlns:foo="some:ns2"><foo:bar/><default:baz/></default:container>
+<container xmlns="some:ns" xmlns:anotherone=""><foo:bar xmlns:foo="some:ns2"/><baz/></container>
 bool(false)
 <?xml version="1.0"?>
-<default:container xmlns:default="some:ns" xmlns:anotherone="" xmlns:foo="some:ns2"><foo:bar/><default:baz/></default:container>
+<container xmlns="some:ns" xmlns:anotherone=""><foo:bar xmlns:foo="some:ns2"/><baz/></container>
 Toggling namespaced attributes:
 bool(true)
 bool(true)
 bool(true)
 bool(false)
 <?xml version="1.0"?>
-<default:container xmlns:default="some:ns" xmlns:anotherone="" xmlns:foo="some:ns2" test:test=""><foo:bar foo:test="" doesnotexist:test=""/><default:baz/></default:container>
+<container xmlns="some:ns" xmlns:anotherone="" test:test=""><foo:bar xmlns:foo="some:ns2" foo:test="" doesnotexist:test=""/><baz/></container>
 namespace of test:test = NULL
 namespace of foo:test = string(8) "some:ns2"
 namespace of doesnotexist:test = NULL
@@ -153,6 +153,6 @@ bool(false)
 bool(true)
 bool(false)
 <?xml version="1.0"?>
-<default:container xmlns:default="some:ns" xmlns:anotherone="" xmlns:foo="some:ns2"><foo:bar doesnotexist:test2=""/><default:baz/></default:container>
+<container xmlns="some:ns" xmlns:anotherone=""><foo:bar xmlns:foo="some:ns2" doesnotexist:test2=""/><baz/></container>
 Checking toggled namespace:
 string(0) ""

--- a/ext/dom/tests/bug47531_a.phpt
+++ b/ext/dom/tests/bug47531_a.phpt
@@ -1,0 +1,66 @@
+--TEST--
+Bug #47531 (No way of removing redundant xmlns: declarations)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+$doc->loadXML(<<<XML
+<container xmlns:foo="some:ns">
+    <foo:first/>
+    <second>
+        <foo:child1/>
+        <foo:child2/>
+        <!-- comment -->
+        <child3>
+            <foo:child4/>
+            <foo:child5>
+                <p xmlns:foo="other:ns">
+                    <span foo:foo="bar"/>
+                    <span foo:foo="bar"/>
+                </p>
+                <foo:child6 foo:foo="bar">
+                    <span foo:foo="bar"/>
+                    <span foo:foo="bar"/>
+                </foo:child6>
+            </foo:child5>
+        </child3>
+        <child7 foo:foo="bar">
+            <foo:child8/>
+        </child7>
+    </second>
+</container>
+XML);
+$root = $doc->documentElement;
+var_dump($root->removeAttribute("xmlns:foo"));
+echo $doc->saveXML();
+
+?>
+--EXPECT--
+bool(true)
+<?xml version="1.0"?>
+<container>
+    <foo:first xmlns:foo="some:ns"/>
+    <second>
+        <foo:child1 xmlns:foo="some:ns"/>
+        <foo:child2 xmlns:foo="some:ns"/>
+        <!-- comment -->
+        <child3>
+            <foo:child4 xmlns:foo="some:ns"/>
+            <foo:child5 xmlns:foo="some:ns">
+                <p xmlns:foo="other:ns">
+                    <span foo:foo="bar"/>
+                    <span foo:foo="bar"/>
+                </p>
+                <foo:child6 foo:foo="bar">
+                    <span foo:foo="bar"/>
+                    <span foo:foo="bar"/>
+                </foo:child6>
+            </foo:child5>
+        </child3>
+        <child7 xmlns:foo="some:ns" foo:foo="bar">
+            <foo:child8/>
+        </child7>
+    </second>
+</container>

--- a/ext/dom/tests/bug47531_b.phpt
+++ b/ext/dom/tests/bug47531_b.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Bug #47531 (No way of removing redundant xmlns: declarations)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument;
+$doc->loadXML(<<<XML
+<container xmlns:foo="some:ns">
+    <foo:first/>
+    <foo:second xmlns:foo="some:ns2">
+        <foo:child1/>
+        <foo:child2/>
+        <!-- comment -->
+        <child3>
+            <foo:child4/>
+            <foo:child5 xmlns:foo="some:ns3">
+                <p xmlns:foo="other:ns">
+                    <span foo:foo="bar"/>
+                    <span foo:foo="bar"/>
+                </p>
+                <foo:child6 foo:foo="bar">
+                    <span foo:foo="bar"/>
+                    <span foo:foo="bar"/>
+                </foo:child6>
+            </foo:child5>
+        </child3>
+        <child7 xmlns:foo="some:ns" foo:foo="bar">
+            <foo:child8/>
+        </child7>
+    </foo:second>
+</container>
+XML);
+$root = $doc->documentElement;
+$elem = $root->firstElementChild->nextElementSibling;
+var_dump($elem->removeAttribute("xmlns:foo"));
+echo $doc->saveXML();
+
+?>
+--EXPECT--
+bool(true)
+<?xml version="1.0"?>
+<container xmlns:foo="some:ns">
+    <foo:first/>
+    <foo:second xmlns:foo="some:ns2">
+        <foo:child1/>
+        <foo:child2/>
+        <!-- comment -->
+        <child3>
+            <foo:child4/>
+            <foo:child5 xmlns:foo="some:ns3">
+                <p xmlns:foo="other:ns">
+                    <span foo:foo="bar"/>
+                    <span foo:foo="bar"/>
+                </p>
+                <foo:child6 foo:foo="bar">
+                    <span foo:foo="bar"/>
+                    <span foo:foo="bar"/>
+                </foo:child6>
+            </foo:child5>
+        </child3>
+        <child7 xmlns:foo="some:ns" foo:foo="bar">
+            <foo:child8/>
+        </child7>
+    </foo:second>
+</container>


### PR DESCRIPTION
Now it's possible via removeAttribute("xmlns:prefix"). It was not possible to reuse a libxml2 function to reconcile because it does not align with DOM behaviour.