### PR TITLE
Curl: Add `CURL_HTTP_VERSION_3` constant

### DIFF
--- a/ext/curl/curl.stub.php
+++ b/ext/curl/curl.stub.php
@@ -3166,6 +3166,11 @@ const CURLOPT_SASL_AUTHZID = UNKNOWN;
 const CURL_VERSION_HTTP3 = UNKNOWN;
 /**
  * @var int
+ * @cvalue CURL_HTTP_VERSION_3
+ */
+const CURL_HTTP_VERSION_3  = UNKNOWN;
+/**
+ * @var int
  * @cvalue CURLINFO_RETRY_AFTER
  */
 const CURLINFO_RETRY_AFTER = UNKNOWN;

--- a/ext/curl/curl_arginfo.h
+++ b/ext/curl/curl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d524d2fd58e484682c860d8a72eafc9a7d544911 */
+ * Stub hash: d59eebc1f49c60af9bc69e3aef510c38c160cc57 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_curl_close, 0, 1, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, handle, CurlHandle, 0)
@@ -1095,6 +1095,9 @@ static void register_curl_symbols(int module_number)
 #endif
 #if LIBCURL_VERSION_NUM >= 0x074200 /* Available since 7.66.0 */
 	REGISTER_LONG_CONSTANT("CURL_VERSION_HTTP3", CURL_VERSION_HTTP3, CONST_PERSISTENT);
+#endif
+#if LIBCURL_VERSION_NUM >= 0x074200 /* Available since 7.66.0 */
+	REGISTER_LONG_CONSTANT("CURL_HTTP_VERSION_3", CURL_HTTP_VERSION_3, CONST_PERSISTENT);
 #endif
 #if LIBCURL_VERSION_NUM >= 0x074200 /* Available since 7.66.0 */
 	REGISTER_LONG_CONSTANT("CURLINFO_RETRY_AFTER", CURLINFO_RETRY_AFTER, CONST_PERSISTENT);


### PR DESCRIPTION
Declares the `CURL_HTTP_VERSION_3` (libcurl >= 7.66), along with the arginfo updates.

We already have `CURL_VERSION_HTTP3` constant declared. However, there are not the same. `CURL_HTTP_VERSION_3` (int 30) is one of the `CURLOPT_HTTP_VERSION` options, while `CURL_VERSION_HTTP3` is the feature flag bitmask.

None of the default repos include libcurl with HTTP/3 support enabled, but I could manually get it to work by compiling libcurl with `nghttp3`, `ngtcp2`, and patched `openssl`. Without this patch, it is still possible to make HTTP/3 requests with `curl_setopt($ch, CURLOPT_HTTP_VERSION, 30);`. This patch merely declares the constant for the parity. 

Considering we already declare `CURL_VERSION_HTTP3` feature-flag constant (since PHP 8.2), I think the lack of `CURL_HTTP_VERSION_3` constant is a bit odd. Both constants were declared in the same upstream version (7.66). Also taking it into consideration the rapid HTTP/3 adoption, I would like to request to consider bringing this change to PHP-8.3 branch as well, although we are only a single release candidate behind the first GA. 