### PR TITLE
Test that objects free handler call zend_weakrefs_notify

### DIFF
--- a/Zend/tests/weakrefs/notify.phpt
+++ b/Zend/tests/weakrefs/notify.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Object free handler must call zend_weakrefs_notify
+--FILE--
+<?php
+
+$classes = get_declared_classes();
+$testedClasses = 0;
+
+foreach ($classes as $class) {
+    $reflector = new \ReflectionClass($class);
+    try {
+        $instance = $reflector->newInstanceWithoutConstructor();
+    } catch (\Throwable $e) {
+        continue;
+    }
+    $testedClasses++;
+    $ref = WeakReference::create($instance);
+    $instance = null;
+    gc_collect_cycles();
+    if ($ref->get() !== null) {
+        printf("free handler of %s did not call zend_weakrefs_notify?\n", $class);
+    }
+}
+
+if ($testedClasses === 0) {
+    print "Did not test any class\n";
+}
+?>
+==DONE==
+--EXPECT--
+==DONE==


### PR DESCRIPTION
This should prevent issues like #12488 for all objects that can be instantiated with `ReflectionClass::newInstanceWithoutConstructor()`.