### PR TITLE
Fix memory leak in error path of zend_register_list_destructors_ex

### DIFF
--- a/Zend/zend_list.c
+++ b/Zend/zend_list.c
@@ -275,6 +275,7 @@ ZEND_API int zend_register_list_destructors_ex(rsrc_dtor_func_t ld, rsrc_dtor_fu
 	ZVAL_PTR(&zv, lde);
 
 	if (zend_hash_next_index_insert(&list_destructors, &zv) == NULL) {
+		free(lde);
 		return FAILURE;
 	}
 	return list_destructors.nNextFreeElement-1;


### PR DESCRIPTION
I don't know if this error condition is ever _actually_ hit, most callers of this function don't actually care about the return value despite the check on `zend_hash_next_index_insert`. Anyway, for precaution, frees the memory allocated by this function if it fails.