### PR TITLE
ext/intl: change when the locale is invalid for the 8.1/8.2 serie.

### DIFF
--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -113,8 +113,7 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 	locale = Locale::createFromName(locale_str);
 	/* get*Name accessors being set does not preclude being bogus */
 	if (locale.isBogus() || strlen(locale.getISO3Language()) == 0) {
-		intl_error_set(NULL, U_ILLEGAL_ARGUMENT_ERROR, "datefmt_create: invalid locale", 0);
-		return FAILURE;
+		goto error;
 	}
 
 	/* process calendar */

--- a/ext/intl/tests/gh12282.phpt
+++ b/ext/intl/tests/gh12282.phpt
@@ -5,17 +5,18 @@ intl
 --FILE--
 <?php
 
-try {
-    new IntlDateFormatter(
+var_dump(new IntlDateFormatter(
 	'xx',
 	IntlDateFormatter::FULL,
 	IntlDateFormatter::FULL,
 	null,
 	null,
 	'w'
-    );
-} catch (\IntlException $e) {
-    echo $e->getMessage();
-}
+));
+Locale::setDefault('xx');
+var_dump(new IntlDateFormatter(Locale::getDefault()));
 --EXPECT--
-datefmt_create: invalid locale: U_ILLEGAL_ARGUMENT_ERROR
+object(IntlDateFormatter)#1 (0) {
+}
+object(IntlDateFormatter)#1 (0) {
+}


### PR DESCRIPTION
does not throws an exception as it's considered as a too string change, but the code user still needs to double check.