### PR TITLE
Fix unused variable in phpdbg_cmd.c

### DIFF
--- a/sapi/phpdbg/phpdbg_cmd.c
+++ b/sapi/phpdbg/phpdbg_cmd.c
@@ -740,7 +740,6 @@ PHPDBG_API int phpdbg_stack_execute(phpdbg_param_t *stack, bool allow_async_unsa
 
 PHPDBG_API char *phpdbg_read_input(const char *buffered) /* {{{ */
 {
-	char buf[PHPDBG_MAX_CMD];
 	char *buffer = NULL;
 
 	if ((PHPDBG_G(flags) & (PHPDBG_IS_STOPPING | PHPDBG_IS_RUNNING)) != PHPDBG_IS_STOPPING) {
@@ -758,6 +757,7 @@ PHPDBG_API char *phpdbg_read_input(const char *buffered) /* {{{ */
 			buffer = estrdup(cmd);
 			free(cmd);
 #else
+			char buf[PHPDBG_MAX_CMD];
 			phpdbg_write("%s", phpdbg_get_prompt());
 			phpdbg_consume_stdin_line(buf);
 			buffer = estrdup(buf);


### PR DESCRIPTION
```
/usr/src/php/sapi/phpdbg/phpdbg_cmd.c:743:14: warning: unused variable 'buf' [-Wunused-variable]
  743 |         char buf[PHPDBG_MAX_CMD];
      |              ^~~
```