### PR TITLE
Split strtr zpp

### DIFF
--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -3200,19 +3200,17 @@ PHP_FUNCTION(strtr)
 	char *to = NULL;
 	size_t to_len = 0;
 
-	ZEND_PARSE_PARAMETERS_START(2, 3)
-		Z_PARAM_STR(str)
-		Z_PARAM_ARRAY_HT_OR_STR(from_ht, from_str)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_STRING_OR_NULL(to, to_len)
-	ZEND_PARSE_PARAMETERS_END();
-
-	if (!to && from_ht == NULL) {
-		zend_argument_type_error(2, "must be of type array, string given");
-		RETURN_THROWS();
-	} else if (to && from_str == NULL) {
-		zend_argument_type_error(2, "must be of type string, array given");
-		RETURN_THROWS();
+	if (ZEND_NUM_ARGS() <= 2) {
+		ZEND_PARSE_PARAMETERS_START(2, 2)
+			Z_PARAM_STR(str)
+			Z_PARAM_ARRAY_HT(from_ht)
+		ZEND_PARSE_PARAMETERS_END();
+	} else {
+		ZEND_PARSE_PARAMETERS_START(3, 3)
+			Z_PARAM_STR(str)
+			Z_PARAM_STR(from_str)
+			Z_PARAM_STRING(to, to_len)
+		ZEND_PARSE_PARAMETERS_END();
 	}
 
 	/* shortcut for empty string */

--- a/ext/standard/tests/strings/strtr_variation6.phpt
+++ b/ext/standard/tests/strings/strtr_variation6.phpt
@@ -113,4 +113,4 @@ string(6) "012atm"
 -- Iteration 16 --
 string(6) "012ttm"
 -- Iteration 17 --
-strtr(): Argument #2 ($from) must be of type array|string, resource given
+strtr(): Argument #2 ($from) must be of type string, resource given

--- a/ext/standard/tests/strings/strtr_variation8.phpt
+++ b/ext/standard/tests/strings/strtr_variation8.phpt
@@ -74,26 +74,26 @@ fclose($file_handle);  //closing the file handle
 
 echo "*** Done ***";
 ?>
---EXPECTF--
+--EXPECT--
 *** Testing strtr() function: with unexpected inputs for 'replace_pairs' ***
 
 -- Iteration 1 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, int given
 
 -- Iteration 2 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, int given
 
 -- Iteration 3 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, int given
 
 -- Iteration 4 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, float given
 
 -- Iteration 5 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, float given
 
 -- Iteration 6 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, float given
 
 -- Iteration 7 --
 string(6) "012atm"
@@ -105,30 +105,26 @@ string(6) "012atm"
 string(6) "122atm"
 
 -- Iteration 10 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, true given
 
 -- Iteration 11 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, false given
 
 -- Iteration 12 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, true given
 
 -- Iteration 13 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, false given
 
 -- Iteration 14 --
-
-Deprecated: strtr(): Passing null to parameter #2 ($from) of type array|string is deprecated in %s on line %d
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, null given
 
 -- Iteration 15 --
-
-Deprecated: strtr(): Passing null to parameter #2 ($from) of type array|string is deprecated in %s on line %d
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, null given
 
 -- Iteration 16 --
-strtr(): Argument #2 ($from) must be of type array, string given
+strtr(): Argument #2 ($from) must be of type array, sample given
 
 -- Iteration 17 --
-strtr(): Argument #2 ($from) must be of type array|string, resource given
+strtr(): Argument #2 ($from) must be of type array, resource given
 *** Done ***


### PR DESCRIPTION
This results in more accurate error messages. The actual motivation is https://github.com/php/php-src/pull/12461 which avoids replicating the `Z_PARAM_ARRAY_HT_OR_STR` macro, with a useless array/string check for each overload of the function.