### PR TITLE
Add deprecation notice when enabling mhash

### DIFF
--- a/ext/hash/config.m4
+++ b/ext/hash/config.m4
@@ -4,6 +4,7 @@ PHP_ARG_WITH([mhash],
     [Include mhash support])])
 
 if test "$PHP_MHASH" != "no"; then
+  AC_MSG_WARN([The --with-mhash option and mhash* functions are deprecated as of PHP 8.1.0])
   AC_DEFINE(PHP_MHASH_BC, 1, [ ])
 fi
 

--- a/ext/hash/config.w32
+++ b/ext/hash/config.w32
@@ -3,6 +3,7 @@
 ARG_WITH('mhash', 'mhash support (BC via hash)', 'no');
 
 if (PHP_MHASH != 'no') {
+	WARNING("mhash* functions are deprecated as of PHP 8.1.0");
 	AC_DEFINE('PHP_MHASH_BC', 1);
 }
 


### PR DESCRIPTION
The mhash* functions are deprecated as of PHP 8.1.0. https://wiki.php.net/rfc/deprecations_php_8_1

This adds a warning to build log in case mhash gets enabled.