### PR TITLE
Fix check for sigsetjmp

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -146,7 +146,13 @@ _LT_AC_TRY_DLOPEN_SELF([
 ])
 
 dnl Checks for library functions.
-AC_CHECK_FUNCS(getpid kill sigsetjmp pthread_getattr_np pthread_attr_get_np pthread_get_stackaddr_np pthread_attr_getstack pthread_stackseg_np gettid)
+AC_CHECK_FUNCS(getpid kill pthread_getattr_np pthread_attr_get_np pthread_get_stackaddr_np pthread_attr_getstack pthread_stackseg_np gettid)
+
+dnl Check for sigsetjmp. If it's defined as a macro, AC_CHECK_FUNCS won't work.
+AC_CHECK_FUNCS([sigsetjmp],,
+  [AC_CHECK_DECL([sigsetjmp],
+    [AC_DEFINE([HAVE_SIGSETJMP],[1],[Define to 1 if you have the 'sigsetjmp' function.])],,
+    [#include <setjmp.h>])])
 
 dnl Test whether the stack grows downwards
 dnl Assumes contiguous stack


### PR DESCRIPTION
The usual check for presence of sigsetjmp will not be sufficient since the sigsetjmp might be defined as a macro.

For example, on Ubuntu the `AC_CHECK_FUNCS` doesn't detect sigsetjmp but it is available as a macro in setjmp.h file.