### PR TITLE
Clean header checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -404,7 +404,6 @@ fcntl.h \
 grp.h \
 ieeefp.h \
 langinfo.h \
-linux/filter.h \
 linux/sock_diag.h \
 malloc.h \
 os/signpost.h \

--- a/ext/sockets/config.m4
+++ b/ext/sockets/config.m4
@@ -6,7 +6,7 @@ PHP_ARG_ENABLE([sockets],
 if test "$PHP_SOCKETS" != "no"; then
   AC_CHECK_FUNCS([hstrerror if_nametoindex if_indextoname])
   AC_CHECK_FUNCS(sockatmark)
-  AC_CHECK_HEADERS([netinet/tcp.h sys/un.h sys/sockio.h linux/filter.h])
+  AC_CHECK_HEADERS([sys/sockio.h linux/filter.h])
   AC_DEFINE([HAVE_SOCKETS], 1, [ ])
 
   dnl Check for fied ss_family in sockaddr_storage (missing in AIX until 5.3)


### PR DESCRIPTION
This cleans few header checks in ext/sockets:
- Unused header checks removed: HAVE_NETINET_TCP_H and HAVE_SYS_UN_H are not used in the code.
- Duplicate linux/filter.h check removed: HAVE_LINUX_FILTER_H is already defined in ext/sockets.