### PR TITLE
Remove check for dnet_addr in dnet_stub library

### DIFF
--- a/ext/pdo_dblib/config.m4
+++ b/ext/pdo_dblib/config.m4
@@ -45,9 +45,6 @@ if test "$PHP_PDO_DBLIB" != "no"; then
 
   PDO_DBLIB_DEFS="-DPDO_DBLIB_FLAVOUR=\\\"freetds\\\""
   PHP_NEW_EXTENSION(pdo_dblib, pdo_dblib.c dblib_driver.c dblib_stmt.c, $ext_shared,,-I$pdo_cv_inc_path $PDO_DBLIB_DEFS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-  AC_CHECK_LIB(dnet_stub, dnet_addr, [
-    PHP_ADD_LIBRARY_WITH_PATH(dnet_stub,,PDO_DBLIB_SHARED_LIBADD)
-  ])
   AC_DEFINE(HAVE_PDO_DBLIB,1,[ ])
   PHP_SUBST(PDO_DBLIB_SHARED_LIBADD)
 


### PR DESCRIPTION
The dnet_stub library was once used on some obsolete systems and was needed for transitive linking with Sybase and some PHP extensions. At this point, no known and supported system uses the dnet_stub library name, so it's safe to remove this check. This also came in pdo_dblib as a copy/paste from other removed PHP extensions.

Partially was already removed in 1b969a74d08bff4dc13b613230658245de8d68c8.