### PR TITLE
Fix unspecified behaviour in zend_alloc in heap->limit computation

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -1914,7 +1914,7 @@ static zend_mm_heap *zend_mm_init(void)
 	heap->peak = 0;
 #endif
 #if ZEND_MM_LIMIT
-	heap->limit = ((size_t)Z_L(-1) >> (size_t)Z_L(1));
+	heap->limit = Z_UL(-1) >> Z_UL(1);
 	heap->overflow = 0;
 #endif
 #if ZEND_MM_CUSTOM
@@ -2859,7 +2859,7 @@ static void alloc_globals_ctor(zend_alloc_globals *alloc_globals)
 		zend_mm_heap *mm_heap = alloc_globals->mm_heap = malloc(sizeof(zend_mm_heap));
 		memset(mm_heap, 0, sizeof(zend_mm_heap));
 		mm_heap->use_custom_heap = ZEND_MM_CUSTOM_HEAP_STD;
-		mm_heap->limit = ((size_t)Z_L(-1) >> (size_t)Z_L(1));
+		mm_heap->limit = Z_UL(-1) >> Z_UL(1);
 		mm_heap->overflow = 0;
 
 		if (!tracked) {
@@ -3048,7 +3048,7 @@ ZEND_API zend_mm_heap *zend_mm_startup_ex(const zend_mm_handlers *handlers, void
 	heap->peak = 0;
 #endif
 #if ZEND_MM_LIMIT
-	heap->limit = (Z_L(-1) >> Z_L(1));
+	heap->limit = Z_UL(-1) >> Z_UL(1);
 	heap->overflow = 0;
 #endif
 #if ZEND_MM_CUSTOM

--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -1914,7 +1914,7 @@ static zend_mm_heap *zend_mm_init(void)
 	heap->peak = 0;
 #endif
 #if ZEND_MM_LIMIT
-	heap->limit = Z_UL(-1) >> Z_UL(1);
+	heap->limit = (size_t)Z_L(-1) >> 1;
 	heap->overflow = 0;
 #endif
 #if ZEND_MM_CUSTOM
@@ -2859,7 +2859,7 @@ static void alloc_globals_ctor(zend_alloc_globals *alloc_globals)
 		zend_mm_heap *mm_heap = alloc_globals->mm_heap = malloc(sizeof(zend_mm_heap));
 		memset(mm_heap, 0, sizeof(zend_mm_heap));
 		mm_heap->use_custom_heap = ZEND_MM_CUSTOM_HEAP_STD;
-		mm_heap->limit = Z_UL(-1) >> Z_UL(1);
+		mm_heap->limit = (size_t)Z_L(-1) >> 1;
 		mm_heap->overflow = 0;
 
 		if (!tracked) {
@@ -3048,7 +3048,7 @@ ZEND_API zend_mm_heap *zend_mm_startup_ex(const zend_mm_handlers *handlers, void
 	heap->peak = 0;
 #endif
 #if ZEND_MM_LIMIT
-	heap->limit = Z_UL(-1) >> Z_UL(1);
+	heap->limit = (size_t)Z_L(-1) >> 1;
 	heap->overflow = 0;
 #endif
 #if ZEND_MM_CUSTOM


### PR DESCRIPTION
Right-shifting a negative number is unspecified (i.e. implementation-defined) behaviour [1]. If we take a look at the generated assembly [2], we see that the wrong value is computed. Fix it by using Z_UL instead of Z_L.

While we're at it, just change every occurrence of this pattern to use Z_UL instead of casting.

[1] https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1548.pdf §6.5.7.5
[2] https://godbolt.org/z/4Y1qKKjsh