### PR TITLE
Fix RCn inference for [QM_]ASSIGN

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -2667,7 +2667,7 @@ static zend_always_inline int _zend_update_type_info(
 			}
 			if (t1 & (MAY_BE_RC1|MAY_BE_RCN)) {
 				tmp |= (t1 & (MAY_BE_RC1|MAY_BE_RCN));
-				if (opline->opcode == ZEND_COPY_TMP || opline->op1_type == IS_CV) {
+				if (opline->opcode == ZEND_COPY_TMP || opline->op1_type == IS_CV || opline->result_type == IS_CV) {
 					tmp |= MAY_BE_RCN;
 				}
 			}
@@ -3033,7 +3033,7 @@ static zend_always_inline int _zend_update_type_info(
 			if (t1 & MAY_BE_REF) {
 				tmp |= MAY_BE_REF;
 			}
-			if (t2 & MAY_BE_REF) {
+			if (opline->op1_type == IS_CV || (t2 & MAY_BE_REF)) {
 				tmp |= MAY_BE_RC1 | MAY_BE_RCN;
 			} else if (opline->op2_type & (IS_TMP_VAR|IS_VAR)) {
 				tmp |= t2 & (MAY_BE_RC1|MAY_BE_RCN);

--- a/Zend/tests/inference_verification_001.phpt
+++ b/Zend/tests/inference_verification_001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Type inference verification 001
+--FILE--
+<?php
+function escape($val) {
+    global $g;
+    $g = $val;
+}
+function test() {
+    $val = date_create();
+    escape($val);
+    spl_object_id($val);
+}
+test();
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/inference_verification_002.phpt
+++ b/Zend/tests/inference_verification_002.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Type inference verification 002
+--FILE--
+<?php
+function test() {
+    $val = date_create();
+    $alias = $val;
+    spl_object_id($val);
+}
+test();
+?>
+===DONE===
+--EXPECT--
+===DONE===

--- a/Zend/tests/inference_verification_003.phpt
+++ b/Zend/tests/inference_verification_003.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Type inference verification 003
+--FILE--
+<?php
+function test() {
+    $val = date_create();
+    [$val, spl_object_id($val)];
+}
+test();
+?>
+===DONE===
+--EXPECT--
+===DONE===


### PR DESCRIPTION
If we infer the rhs of an assignment as RC1, the type of a CV should still add RCn. Otherwise, every use of the variable would constitute a definition from RC1 to RCn, which is likely not desirable.

These issues were found using type inference verification PR. The tests are obviously quite useless without it.