### PR TITLE
Fix GH-12633: remove 'PRAGMA writable_schema;'

### DIFF
--- a/ext/sqlite3/tests/sqlite3_defensive.phpt
+++ b/ext/sqlite3/tests/sqlite3_defensive.phpt
@@ -20,7 +20,6 @@ var_dump($db->exec('CREATE TABLE test (a, b);'));
 
 // This does not generate an error!
 var_dump($db->exec('PRAGMA writable_schema = ON;'));
-var_dump($db->querySingle('PRAGMA writable_schema;'));
 
 // Should be 1
 var_dump($db->querySingle('SELECT COUNT(*) FROM sqlite_master;'));
@@ -34,7 +33,6 @@ var_dump($db->querySingle('SELECT COUNT(*) FROM sqlite_master;'));
 --EXPECTF--
 bool(true)
 bool(true)
-int(1)
 int(1)
 
 Warning: SQLite3::querySingle(): Unable to prepare statement: 1, table sqlite_master may not be modified in %s on line %d


### PR DESCRIPTION
Closes #12633 

Originally, `PRAGMA writable_schema;` seems to have no meaning as it simply returns `1`.