### PR TITLE
Automatically mark tests as flaky

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -2873,10 +2873,32 @@ SH;
     return $restype[0] . 'ED';
 }
 
+function is_flaky(TestFile $test): bool
+{
+    if ($test->hasSection('FLAKY')) {
+        return true;
+    }
+    if (!$test->hasSection('FILE')) {
+        return false;
+    }
+    $file = $test->getSection('FILE');
+    $flaky_functions = [
+        'clearstatcache',
+        'hrtime',
+        'lstat',
+        'microtime',
+        'sleep',
+        'stat',
+        'usleep',
+    ];
+    $regex = '(\b(' . implode('|', $flaky_functions) . ')\()i';
+    return preg_match($regex, $file) === 1;
+}
+
 function error_may_be_retried(TestFile $test, string $output): bool
 {
     return preg_match('((timed out)|(connection refused)|(404: page not found)|(address already in use)|(mailbox already exists))i', $output) === 1
-        || $test->hasSection('FLAKY');
+        || is_flaky($test);
 }
 
 /**


### PR DESCRIPTION
Marking all of these tests as flaky is annoying, so attempt to recognize them automatically.

I'm getting tired of the red nightly builds. This catches the most frequently failing tests. The list may be extended later.