### PR TITLE
ext/standard: make debug_zval_dump() output whether the array is packed

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -126,6 +126,7 @@ Standard:
   . Cast large floats that are within int range to int in number_format so
     the precision is not lost. (Marc Bennewitz)
   . Add support for 4 new rounding modes to the round() function. (Jorg Sowa)
+  . debug_zval_dump() now indicates whether an array is packed. (Max Semenik)
 
 XML:
   . Added XML_OPTION_PARSE_HUGE parser option. (nielsdos)

--- a/UPGRADING
+++ b/UPGRADING
@@ -283,6 +283,7 @@ PHP 8.4 UPGRADE NOTES
     PHP_ROUND_FLOOR, PHP_ROUND_TOWARD_ZERO, PHP_ROUND_AWAY_FROM_ZERO.
 
     RFC: https://wiki.php.net/rfc/new_rounding_modes_to_round_function
+  . debug_zval_dump() now indicates whether an array is packed.
 
 ========================================
 6. New Functions

--- a/ext/mysqli/tests/mysqli_result_references.phpt
+++ b/ext/mysqli/tests/mysqli_result_references.phpt
@@ -84,7 +84,7 @@ opcache.enable=0
     require_once 'clean_table.inc';
 ?>
 --EXPECTF--
-array(7) refcount(2){
+array(7) packed refcount(2){
   [0]=>
   array(2) refcount(1){
     ["id"]=>

--- a/ext/mysqli/tests/mysqli_result_references_mysqlnd.phpt
+++ b/ext/mysqli/tests/mysqli_result_references_mysqlnd.phpt
@@ -52,7 +52,7 @@ require_once 'skipifconnectfailure.inc';
 require_once 'clean_table.inc';
 ?>
 --EXPECTF--
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   array(4) refcount(%d){
     ["row_ref"]=>
@@ -74,7 +74,7 @@ array(1) refcount(%d){
     string(1) "1" interned
   }
 }
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
   array(4) refcount(%d){
     ["row_ref"]=>

--- a/ext/standard/tests/general_functions/debug_zval_dump_b.phpt
+++ b/ext/standard/tests/general_functions/debug_zval_dump_b.phpt
@@ -184,36 +184,36 @@ bool(false)
 array(0) interned {
 }
 -- Iteration 44 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   NULL
 }
 -- Iteration 45 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   bool(true)
 }
 -- Iteration 46 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   string(0) "" interned
 }
 -- Iteration 47 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   string(0) "" interned
 }
 -- Iteration 48 --
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
-  array(2) refcount(%d){
+  array(2) packed refcount(%d){
     [0]=>
     int(1)
     [1]=>
     int(2)
   }
   [1]=>
-  array(2) refcount(%d){
+  array(2) packed refcount(%d){
     [0]=>
     string(1) "a" interned
     [1]=>
@@ -228,31 +228,31 @@ array(2) refcount(%d){
   string(3) "One" refcount(%d)
 }
 -- Iteration 50 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   int(0)
 }
 -- Iteration 51 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   int(-1)
 }
 -- Iteration 52 --
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
   float(10.5)
   [1]=>
   float(5.6)
 }
 -- Iteration 53 --
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
   string(6) "string" refcount(%d)
   [1]=>
   string(4) "test" refcount(%d)
 }
 -- Iteration 54 --
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
   string(6) "string" refcount(%d)
   [1]=>

--- a/ext/standard/tests/general_functions/debug_zval_dump_b_64bit.phpt
+++ b/ext/standard/tests/general_functions/debug_zval_dump_b_64bit.phpt
@@ -188,36 +188,36 @@ bool(false)
 array(0) interned {
 }
 -- Iteration 44 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   NULL
 }
 -- Iteration 45 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   bool(true)
 }
 -- Iteration 46 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   string(0) "" interned
 }
 -- Iteration 47 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   string(0) "" interned
 }
 -- Iteration 48 --
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
-  array(2) refcount(%d){
+  array(2) packed refcount(%d){
     [0]=>
     int(1)
     [1]=>
     int(2)
   }
   [1]=>
-  array(2) refcount(%d){
+  array(2) packed refcount(%d){
     [0]=>
     string(1) "a" interned
     [1]=>
@@ -232,31 +232,31 @@ array(2) refcount(%d){
   string(3) "One" refcount(%d)
 }
 -- Iteration 50 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   int(0)
 }
 -- Iteration 51 --
-array(1) refcount(%d){
+array(1) packed refcount(%d){
   [0]=>
   int(-1)
 }
 -- Iteration 52 --
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
   float(10.5)
   [1]=>
   float(5.6)
 }
 -- Iteration 53 --
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
   string(6) "string" refcount(%d)
   [1]=>
   string(4) "test" refcount(%d)
 }
 -- Iteration 54 --
-array(2) refcount(%d){
+array(2) packed refcount(%d){
   [0]=>
   string(6) "string" refcount(%d)
   [1]=>

--- a/ext/standard/tests/general_functions/debug_zval_dump_refs.phpt
+++ b/ext/standard/tests/general_functions/debug_zval_dump_refs.phpt
@@ -16,13 +16,13 @@ debug_zval_dump($a);
 
 ?>
 --EXPECT--
-array(1) refcount(2){
+array(1) packed refcount(2){
   [0]=>
   reference refcount(2) {
     int(1)
   }
 }
-array(2) refcount(2){
+array(2) packed refcount(2){
   [0]=>
   reference refcount(3) {
     int(1)
@@ -32,13 +32,13 @@ array(2) refcount(2){
     int(1)
   }
 }
-array(1) refcount(2){
+array(1) packed refcount(2){
   [0]=>
   reference refcount(2) {
     int(1)
   }
 }
-array(1) refcount(2){
+array(1) packed refcount(2){
   [0]=>
   reference refcount(1) {
     int(1)

--- a/ext/standard/var.c
+++ b/ext/standard/var.c
@@ -284,6 +284,7 @@ PHPAPI void php_debug_zval_dump(zval *struc, int level) /* {{{ */
 	zend_string *key;
 	zval *val;
 	uint32_t count;
+	char *packed;
 
 	if (level > 1) {
 		php_printf("%*c", level - 1, ' ');
@@ -325,11 +326,12 @@ PHPAPI void php_debug_zval_dump(zval *struc, int level) /* {{{ */
 			GC_PROTECT_RECURSION(myht);
 		}
 		count = zend_hash_num_elements(myht);
+		packed = HT_IS_PACKED(myht) ? "packed " : "";
 		if (Z_REFCOUNTED_P(struc)) {
 			/* -1 because of ADDREF above. */
-			php_printf("array(%d) refcount(%u){\n", count, Z_REFCOUNT_P(struc) - 1);
+			php_printf("array(%d) %srefcount(%u){\n", count, packed, Z_REFCOUNT_P(struc) - 1);
 		} else {
-			php_printf("array(%d) interned {\n", count);
+			php_printf("array(%d) %sinterned {\n", count, packed);
 		}
 		ZEND_HASH_FOREACH_KEY_VAL(myht, index, key, val) {
 			zval_array_element_dump(val, index, key, level);


### PR DESCRIPTION
Packed arrays can make a lot of difference, however lots of developers simply don't
know about them or when an array can be packed. Thus I propose to make this
information available to userspace, but as a debug tool, not something like array_is_list().