### PR TITLE
Improve browscap get_browser performance

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -197,3 +197,5 @@ PHP 8.4 UPGRADE NOTES
   They now run in linear time instead of being bounded by quadratic time.
 
 * mb_strcut() is much faster now for UTF-8 and UTF-16 strings.
+
+* get_browser() is much faster now, up to 1.5x - 2.5x for some test cases.

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -585,7 +585,8 @@ static bool browscap_match_string_wildcard(const char *s, const char *s_end, con
 			/* Match */
 			pattern_current++;
 			s_current++;
-			/* If this was the last character of the pattern, either we fully matched s, or we have a mismatch */
+
+			/* If this was the last character of the pattern, we either fully matched s, or we have a mismatch */
 			if (pattern_current == pattern_end) {
 				if (s_current == s_end) {
 					return true;

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -741,6 +741,8 @@ PHP_FUNCTION(get_browser)
 		}
 	}
 
+	zend_string_release_ex(lookup_browser_name, false);
+
 	agent_ht = browscap_entry_to_array(bdata, found_entry);
 
 	if (return_array) {
@@ -759,7 +761,5 @@ PHP_FUNCTION(get_browser)
 
 		browscap_entry_add_kv_to_existing_array(bdata, found_entry, target_ht);
 	}
-
-	zend_string_release_ex(lookup_browser_name, 0);
 }
 /* }}} */

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -280,14 +280,23 @@ static HashTable *browscap_entry_to_array(browser_data *bdata, browscap_entry *e
 	HashTable *ht = zend_new_array(2 + (entry->parent ? 1 : 0) + (entry->kv_end - entry->kv_start));
 
 	ZVAL_STR(&tmp, browscap_convert_pattern(entry->pattern, 0));
-	zend_hash_str_add_new(ht, "browser_name_regex", sizeof("browser_name_regex")-1, &tmp);
+	zend_string *key = ZSTR_INIT_LITERAL("browser_name_regex", 0);
+	ZSTR_H(key) = zend_inline_hash_func("browser_name_regex", sizeof("browser_name_regex")-1);
+	zend_hash_add_new(ht, key, &tmp);
+	zend_string_release_ex(key, false);
 
 	ZVAL_STR_COPY(&tmp, entry->pattern);
-	zend_hash_str_add_new(ht, "browser_name_pattern", sizeof("browser_name_pattern")-1, &tmp);
+	key = ZSTR_INIT_LITERAL("browser_name_pattern", 0);
+	ZSTR_H(key) = zend_inline_hash_func("browser_name_pattern", sizeof("browser_name_pattern")-1);
+	zend_hash_add_new(ht, key, &tmp);
+	zend_string_release_ex(key, false);
 
 	if (entry->parent) {
 		ZVAL_STR_COPY(&tmp, entry->parent);
-		zend_hash_str_add_new(ht, "parent", sizeof("parent")-1, &tmp);
+		key = ZSTR_INIT_LITERAL("parent", 0);
+		ZSTR_H(key) = zend_inline_hash_func("parent", sizeof("parent")-1);
+		zend_hash_add_new(ht, key, &tmp);
+		zend_string_release_ex(key, false);
 	}
 
 	browscap_entry_add_kv_to_existing_array(bdata, entry, ht);

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -272,27 +272,30 @@ static void browscap_add_kv(
 	bdata->kv_used++;
 }
 
-static HashTable *browscap_entry_to_array(browser_data *bdata, browscap_entry *entry) {
-	zval tmp;
-	uint32_t i;
-
-	HashTable *ht = zend_new_array(8);
-
-	ZVAL_STR(&tmp, browscap_convert_pattern(entry->pattern, 0));
-	zend_hash_str_add(ht, "browser_name_regex", sizeof("browser_name_regex")-1, &tmp);
-
-	ZVAL_STR_COPY(&tmp, entry->pattern);
-	zend_hash_str_add(ht, "browser_name_pattern", sizeof("browser_name_pattern")-1, &tmp);
-
-	if (entry->parent) {
-		ZVAL_STR_COPY(&tmp, entry->parent);
-		zend_hash_str_add(ht, "parent", sizeof("parent")-1, &tmp);
-	}
-
-	for (i = entry->kv_start; i < entry->kv_end; i++) {
+static void browscap_entry_add_kv_to_existing_array(browser_data *bdata, browscap_entry *entry, HashTable *ht) {
+	for (uint32_t i = entry->kv_start; i < entry->kv_end; i++) {
+		zval tmp;
 		ZVAL_STR_COPY(&tmp, bdata->kv[i].value);
 		zend_hash_add(ht, bdata->kv[i].key, &tmp);
 	}
+}
+
+static HashTable *browscap_entry_to_array(browser_data *bdata, browscap_entry *entry) {
+	zval tmp;
+	HashTable *ht = zend_new_array(8);
+
+	ZVAL_STR(&tmp, browscap_convert_pattern(entry->pattern, 0));
+	zend_hash_str_add_new(ht, "browser_name_regex", sizeof("browser_name_regex")-1, &tmp);
+
+	ZVAL_STR_COPY(&tmp, entry->pattern);
+	zend_hash_str_add_new(ht, "browser_name_pattern", sizeof("browser_name_pattern")-1, &tmp);
+
+	if (entry->parent) {
+		ZVAL_STR_COPY(&tmp, entry->parent);
+		zend_hash_str_add_new(ht, "parent", sizeof("parent")-1, &tmp);
+	}
+
+	browscap_entry_add_kv_to_existing_array(bdata, entry, ht);
 
 	return ht;
 }

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -666,8 +666,8 @@ static int browser_reg_compare(browscap_entry *entry, zend_string *agent_name, b
 		ZSTR_VAL(agent_name) + entry->prefix_len,
 		ZSTR_VAL(agent_name) + ZSTR_LEN(agent_name),
 		ZSTR_VAL(pattern_lc) + entry->prefix_len,
-		ZSTR_VAL(pattern_lc) + ZSTR_LEN(pattern_lc))
-	) {
+		ZSTR_VAL(pattern_lc) + ZSTR_LEN(pattern_lc)
+	)) {
 		/* If we've found a possible browser, we need to do a comparison of the
 		   number of characters changed in the user agent being checked versus
 		   the previous match found and the current match. */

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -754,21 +754,15 @@ PHP_FUNCTION(get_browser)
 		object_and_properties_init(return_value, zend_standard_class_def, agent_ht);
 	}
 
+	HashTable *target_ht = return_array ? Z_ARRVAL_P(return_value) : Z_OBJPROP_P(return_value);
+
 	while (found_entry->parent) {
 		found_entry = zend_hash_find_ptr(bdata->htab, found_entry->parent);
 		if (found_entry == NULL) {
 			break;
 		}
 
-		agent_ht = browscap_entry_to_array(bdata, found_entry);
-		if (return_array) {
-			zend_hash_merge(Z_ARRVAL_P(return_value), agent_ht, (copy_ctor_func_t) browscap_zval_copy_ctor, 0);
-		} else {
-			zend_hash_merge(Z_OBJPROP_P(return_value), agent_ht, (copy_ctor_func_t) browscap_zval_copy_ctor, 0);
-		}
-
-		zend_hash_destroy(agent_ht);
-		efree(agent_ht);
+		browscap_entry_add_kv_to_existing_array(bdata, found_entry, target_ht);
 	}
 
 	zend_string_release_ex(lookup_browser_name, 0);

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -719,7 +719,7 @@ PHP_FUNCTION(get_browser)
 			found_entry = zend_hash_str_find_ptr(bdata->htab,
 				DEFAULT_SECTION_NAME, sizeof(DEFAULT_SECTION_NAME)-1);
 			if (found_entry == NULL) {
-				zend_string_release(lookup_browser_name);
+				zend_string_release_ex(lookup_browser_name, false);
 				RETURN_FALSE;
 			}
 		}

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -752,9 +752,14 @@ PHP_FUNCTION(get_browser)
 			}
 
 			/* Quickly discard patterns where the prefix doesn't match. */
-			if (zend_binary_strcasecmp(
-					ZSTR_VAL(lookup_browser_name), entry->prefix_len,
-					ZSTR_VAL(entry->pattern), entry->prefix_len) != 0) {
+			bool prefix_matches = true;
+			for (size_t i = 0; i < entry->prefix_len; i++) {
+				if (ZSTR_VAL(lookup_browser_name)[i] != zend_tolower_ascii(ZSTR_VAL(entry->pattern)[i])) {
+					prefix_matches = false;
+					break;
+				}
+			}
+			if (!prefix_matches) {
 				continue;
 			}
 

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -625,18 +625,6 @@ static int browser_reg_compare(browscap_entry *entry, zend_string *agent_name, b
 	const char *cur;
 	int i;
 
-	/* Agent name too short */
-	if (ZSTR_LEN(agent_name) < browscap_get_minimum_length(entry)) {
-		return 0;
-	}
-
-	/* Quickly discard patterns where the prefix doesn't match. */
-	if (zend_binary_strcasecmp(
-			ZSTR_VAL(agent_name), entry->prefix_len,
-			ZSTR_VAL(entry->pattern), entry->prefix_len) != 0) {
-		return 0;
-	}
-
 	/* Lowercase the pattern, the agent name is already lowercase */
 	ZSTR_ALLOCA_ALLOC(pattern_lc, ZSTR_LEN(entry->pattern), use_heap);
 	zend_str_tolower_copy(ZSTR_VAL(pattern_lc), ZSTR_VAL(entry->pattern), ZSTR_LEN(entry->pattern));
@@ -758,6 +746,18 @@ PHP_FUNCTION(get_browser)
 		size_t cached_prev_len = 0; /* silence compiler warning */
 
 		ZEND_HASH_MAP_FOREACH_PTR(bdata->htab, entry) {
+			/* Agent name too short */
+			if (ZSTR_LEN(lookup_browser_name) < browscap_get_minimum_length(entry)) {
+				continue;
+			}
+
+			/* Quickly discard patterns where the prefix doesn't match. */
+			if (zend_binary_strcasecmp(
+					ZSTR_VAL(lookup_browser_name), entry->prefix_len,
+					ZSTR_VAL(entry->pattern), entry->prefix_len) != 0) {
+				continue;
+			}
+
 			if (browser_reg_compare(entry, lookup_browser_name, &found_entry, &cached_prev_len)) {
 				break;
 			}

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -659,22 +659,6 @@ static int browser_reg_compare(browscap_entry *entry, zend_string *agent_name, b
 }
 /* }}} */
 
-static void browscap_zval_copy_ctor(zval *p) /* {{{ */
-{
-	if (Z_REFCOUNTED_P(p)) {
-		zend_string *str;
-
-		ZEND_ASSERT(Z_TYPE_P(p) == IS_STRING);
-		str = Z_STR_P(p);
-		if (!(GC_FLAGS(str) & GC_PERSISTENT)) {
-			GC_ADDREF(str);
-		} else {
-			ZVAL_NEW_STR(p, zend_string_init(ZSTR_VAL(str), ZSTR_LEN(str), 0));
-		}
-	}
-}
-/* }}} */
-
 /* {{{ Get information about the capabilities of a browser. If browser_name is omitted or null, HTTP_USER_AGENT is used. Returns an object by default; if return_array is true, returns an array. */
 PHP_FUNCTION(get_browser)
 {

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -152,20 +152,16 @@ static zend_string *browscap_convert_pattern(zend_string *pattern, int persisten
 	size_t i, j=0;
 	char *t;
 	zend_string *res;
-	char *lc_pattern;
-	ALLOCA_FLAG(use_heap);
 
 	res = zend_string_alloc(browscap_compute_regex_len(pattern), persistent);
 	t = ZSTR_VAL(res);
-
-	lc_pattern = do_alloca(ZSTR_LEN(pattern) + 1, use_heap);
-	zend_str_tolower_copy(lc_pattern, ZSTR_VAL(pattern), ZSTR_LEN(pattern));
 
 	t[j++] = '~';
 	t[j++] = '^';
 
 	for (i = 0; i < ZSTR_LEN(pattern); i++, j++) {
-		switch (lc_pattern[i]) {
+		char c = ZSTR_VAL(pattern)[i];
+		switch (c) {
 			case '?':
 				t[j] = '.';
 				break;
@@ -198,7 +194,7 @@ static zend_string *browscap_convert_pattern(zend_string *pattern, int persisten
 				t[j] = '+';
 				break;
 			default:
-				t[j] = lc_pattern[i];
+				t[j] = zend_tolower_ascii(c);
 				break;
 		}
 	}
@@ -208,7 +204,6 @@ static zend_string *browscap_convert_pattern(zend_string *pattern, int persisten
 	t[j]=0;
 
 	ZSTR_LEN(res) = j;
-	free_alloca(lc_pattern, use_heap);
 	return res;
 }
 /* }}} */

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -725,7 +725,7 @@ PHP_FUNCTION(get_browser)
 	if (found_entry == NULL) {
 		browscap_entry *entry;
 
-		ZEND_HASH_FOREACH_PTR(bdata->htab, entry) {
+		ZEND_HASH_MAP_FOREACH_PTR(bdata->htab, entry) {
 			if (browser_reg_compare(entry, lookup_browser_name, &found_entry)) {
 				break;
 			}

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -755,6 +755,10 @@ PHP_FUNCTION(get_browser)
 		size_t cached_prev_len = 0; /* silence compiler warning */
 
 		ZEND_HASH_MAP_FOREACH_PTR(bdata->htab, entry) {
+			/* The following two early-skip checks are inside this loop instead of inside browser_reg_compare().
+			 * That's because we want to avoid the call frame overhead, especially as browser_reg_compare() is
+			 * a function that uses alloca(). */
+
 			/* Agent name too short */
 			if (ZSTR_LEN(lookup_browser_name) < browscap_get_minimum_length(entry)) {
 				continue;

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -662,9 +662,9 @@ static int browser_reg_compare(browscap_entry *entry, zend_string *agent_name, b
 		/* If we've found a possible browser, we need to do a comparison of the
 		   number of characters changed in the user agent being checked versus
 		   the previous match found and the current match. */
-		size_t curr_len = 0;
+		size_t curr_len = entry->prefix_len; /* Start from the prefix because the prefix is free of wildcards */
 		zend_string *current_match = entry->pattern;
-		for (size_t i = 0; i < ZSTR_LEN(current_match); i++) {
+		for (size_t i = curr_len; i < ZSTR_LEN(current_match); i++) {
 			switch (ZSTR_VAL(current_match)[i]) {
 				case '?':
 				case '*':

--- a/ext/standard/browscap.c
+++ b/ext/standard/browscap.c
@@ -282,7 +282,7 @@ static void browscap_entry_add_kv_to_existing_array(browser_data *bdata, browsca
 
 static HashTable *browscap_entry_to_array(browser_data *bdata, browscap_entry *entry) {
 	zval tmp;
-	HashTable *ht = zend_new_array(8);
+	HashTable *ht = zend_new_array(2 + (entry->parent ? 1 : 0) + (entry->kv_end - entry->kv_start));
 
 	ZVAL_STR(&tmp, browscap_convert_pattern(entry->pattern, 0));
 	zend_hash_str_add_new(ht, "browser_name_regex", sizeof("browser_name_regex")-1, &tmp);


### PR DESCRIPTION
This set of patches improves the browscap support performance. The changes are split in atomic commits to make review easier. Sometimes the commits also contain a description. The most important change here is moving away from regexes and using a specialised wildcard matching algorithm (best case O(n), worst case O(n²)). This gives the most speed-up especially as compilation and conversion to regexes is prevented. The algorithm has the same execution time complexity as the regex.

With the following 3 test scenarios:

### (1) Unknown data lookup

```php
for ($i = 0; $i < 10000; $i++) {
    get_browser("Unknown Browser 1.0");
}
```

### (2) Test all known user agents we test for

```php
$user_agents = file('ext/standard/tests/misc/user_agents.txt', FILE_IGNORE_NEW_LINES);
foreach ($user_agents as $ua) {
    get_browser($ua, true);
}
```

### (3) Result construction

```php
for ($i = 0; $i < 200000; $i++) {
    get_browser("Chromium 123.0");
}
```

## Benchmark results


For (1):
```
Benchmark 1: ./sapi/cli/php bench.php
  Time (mean ± σ):     331.0 ms ±   3.9 ms    [User: 325.9 ms, System: 4.2 ms]
  Range (min … max):   325.7 ms … 339.3 ms    10 runs
 
Benchmark 2: ./sapi/cli/php_old bench.php
  Time (mean ± σ):     478.2 ms ±   4.3 ms    [User: 472.6 ms, System: 4.2 ms]
  Range (min … max):   472.9 ms … 486.1 ms    10 runs
 
Summary
  ./sapi/cli/php bench.php ran
    1.44 ± 0.02 times faster than ./sapi/cli/php_old bench.php
```

For (2):
```
Benchmark 1: ./sapi/cli/php bench.php
  Time (mean ± σ):     243.6 ms ±   3.9 ms    [User: 237.2 ms, System: 5.8 ms]
  Range (min … max):   239.5 ms … 252.2 ms    12 runs
 
Benchmark 2: ./sapi/cli/php_old bench.php
  Time (mean ± σ):     618.5 ms ±   4.1 ms    [User: 603.4 ms, System: 12.7 ms]
  Range (min … max):   614.2 ms … 626.4 ms    10 runs
 
Summary
  ./sapi/cli/php bench.php ran
    2.54 ± 0.04 times faster than ./sapi/cli/php_old bench.php
```

For (3):
```
Benchmark 1: ./sapi/cli/php bench.php
  Time (mean ± σ):      89.3 ms ±   4.6 ms    [User: 85.4 ms, System: 3.5 ms]
  Range (min … max):    85.5 ms … 101.5 ms    33 runs
 
Benchmark 2: ./sapi/cli/php_old bench.php
  Time (mean ± σ):     144.9 ms ±   4.7 ms    [User: 139.4 ms, System: 5.1 ms]
  Range (min … max):   140.8 ms … 162.2 ms    20 runs
 
Summary
  ./sapi/cli/php bench.php ran
    1.62 ± 0.10 times faster than ./sapi/cli/php_old bench.php
```