### PR TITLE
Fix GH-12635: Test bug69398.phpt fails with ICU 74.1

### DIFF
--- a/ext/intl/tests/bug69398-icu74.1.phpt
+++ b/ext/intl/tests/bug69398-icu74.1.phpt
@@ -4,8 +4,7 @@ IntlDateFormatter::formatObject(): returns wrong value when time style is NONE.
 intl
 --SKIPIF--
 <?php
-if (version_compare(INTL_ICU_VERSION, '50.1.2') < 0) die('skip for ICU < 51.1.2');
-if (version_compare(INTL_ICU_VERSION, '74.1') >= 0) die('skip for ICU >= 74.1');
+if (version_compare(INTL_ICU_VERSION, '74.1') < 0) die('skip for ICU < 74.1');
 ?>
 --FILE--
 <?php
@@ -16,5 +15,5 @@ echo IntlDateFormatter::formatObject($date, array(IntlDateFormatter::SHORT, Intl
 echo IntlDateFormatter::formatObject ($date, array(IntlDateFormatter::SHORT, IntlDateFormatter::NONE), 'ko_KR'), "\n";
 ?>
 --EXPECT--
-04/04/2015
+4/4/15
 15. 4. 4.


### PR DESCRIPTION
ICU 74.1 contains new locale data that breaks the test. Split the test based on the version number to resolve the issue.