### PR TITLE
[WIP] Fix: Corrected and optimized `pdo_firebird` transaction handling.

### DIFF
--- a/ext/pdo/tests/pdo_017.phpt
+++ b/ext/pdo/tests/pdo_017.phpt
@@ -8,7 +8,6 @@ $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
-if (str_starts_with(getenv('PDOTEST_DSN'), "firebird")) die('xfail firebird driver does not behave as expected');
 
 $db = PDOTest::factory();
 try {

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -884,7 +884,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 						}
 					} else {
 						/* close the transaction */
-						if (H->tr && !firebird_handle_commit(dbh)) {
+						if (H->tr && isc_commit_transaction(H->isc_status, &H->tr)) {
 							return false;
 						}
 						H->in_manually_txn = 0;

--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -884,7 +884,7 @@ static bool firebird_handle_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *
 						}
 					} else {
 						/* close the transaction */
-						if (!H->tr && !firebird_handle_commit(dbh)) {
+						if (H->tr && !firebird_handle_commit(dbh)) {
 							return false;
 						}
 						H->in_manually_txn = 0;

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -177,9 +177,10 @@ static int firebird_stmt_execute(pdo_stmt_t *stmt) /* {{{ */
 				;
 		}
 
-		/* commit? */
-		if (stmt->dbh->auto_commit && isc_commit_retaining(H->isc_status, &H->tr)) {
-			break;
+		if (stmt->dbh->auto_commit && !S->H->in_manually_txn) {
+			if (isc_commit_retaining(H->isc_status, &H->tr)) {
+				break;
+			}
 		}
 
 		*S->name = 0;

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -177,10 +177,8 @@ static int firebird_stmt_execute(pdo_stmt_t *stmt) /* {{{ */
 				;
 		}
 
-		if (stmt->dbh->auto_commit && !S->H->in_manually_txn) {
-			if (isc_commit_retaining(H->isc_status, &H->tr)) {
-				break;
-			}
+		if (stmt->dbh->auto_commit && !S->H->in_manually_txn && !firebird_commit_transaction(stmt->dbh, true)) {
+			break;
 		}
 
 		*S->name = 0;

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -59,6 +59,12 @@ typedef void (*info_func_t)(char*);
 # define PDO_FIREBIRD_HANDLE_INITIALIZER NULL
 #endif
 
+extern bool _firebird_commit_transaction(pdo_dbh_t *dbh, bool retain);
+#define firebird_commit_transaction(d, r)	_firebird_commit_transaction(d, r)
+
+extern bool _firebird_rollback_transaction(pdo_dbh_t *dbh, bool retain);
+#define firebird_rollback_transaction(d, r)	_firebird_rollback_transaction(d, r)
+
 typedef struct {
 
 	/* the result of the last API call */

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -69,6 +69,7 @@ typedef struct {
 
 	/* the transaction handle */
 	isc_tr_handle tr;
+	bool in_manually_txn:1;
 
 	/* the last error that didn't come from the API */
 	char const *last_app_error;

--- a/ext/pdo_firebird/tests/bug_47415.phpt
+++ b/ext/pdo_firebird/tests/bug_47415.phpt
@@ -15,8 +15,6 @@ $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
 $dbh->exec('CREATE TABLE test47415 (idx int NOT NULL PRIMARY KEY, txt VARCHAR(20))');
 $dbh->exec('INSERT INTO test47415 VALUES(0, \'String0\')');
 
-$dbh->commit();
-
 $query = "SELECT idx, txt FROM test47415 ORDER by idx";
 $idx = $txt = 0;
 $stmt = $dbh->prepare($query);
@@ -30,8 +28,6 @@ var_dump($stmt->rowCount());
 
 $stmt = $dbh->prepare('DELETE FROM test47415');
 $stmt->execute();
-
-$dbh->commit();
 
 unset($stmt);
 unset($dbh);

--- a/ext/pdo_firebird/tests/bug_48877.phpt
+++ b/ext/pdo_firebird/tests/bug_48877.phpt
@@ -17,7 +17,6 @@ $dbh->exec('CREATE TABLE test48877 (A integer)');
 $dbh->exec("INSERT INTO test48877 VALUES ('1')");
 $dbh->exec("INSERT INTO test48877 VALUES ('2')");
 $dbh->exec("INSERT INTO test48877 VALUES ('3')");
-$dbh->commit();
 
 $query = "SELECT * FROM test48877 WHERE A = :paramno";
 
@@ -32,7 +31,6 @@ var_dump($stmt->rowCount());
 $stmt = $dbh->prepare('DELETE FROM test48877');
 $stmt->execute();
 
-$dbh->commit();
 unset($stmt);
 unset($dbh);
 

--- a/ext/pdo_firebird/tests/bug_53280.phpt
+++ b/ext/pdo_firebird/tests/bug_53280.phpt
@@ -13,7 +13,6 @@ require("testdb.inc");
 
 $dbh->exec('CREATE TABLE test53280(A VARCHAR(30), B VARCHAR(30), C VARCHAR(30))');
 $dbh->exec("INSERT INTO test53280 VALUES ('A', 'B', 'C')");
-$dbh->commit();
 
 $stmt1 = "SELECT B FROM test53280 WHERE A = ? AND B = ?";
 $stmt2 = "SELECT B, C FROM test53280 WHERE A = ? AND B = ?";
@@ -28,7 +27,6 @@ $stmth1->execute(array('A', 'B'));
 $rows = $stmth1->fetchAll(); // <------- segfault
 var_dump($rows);
 
-$dbh->commit();
 unset($stmth1);
 unset($stmth2);
 unset($stmt);

--- a/ext/pdo_firebird/tests/bug_62024.phpt
+++ b/ext/pdo_firebird/tests/bug_62024.phpt
@@ -14,8 +14,6 @@ require("testdb.inc");
 $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
 $dbh->exec("CREATE TABLE test62024 (ID INTEGER NOT NULL, TEXT VARCHAR(10))");
 
-$dbh->commit();
-
 //start actual test
 
 $sql = "insert into test62024 (id, text) values (?, ?)";
@@ -30,14 +28,10 @@ var_dump($res);
 $res = $sttmt->execute($args_err);
 var_dump($res);
 
-$dbh->commit();
-
 
 //teardown test data
 $sttmt = $dbh->prepare('DELETE FROM test62024');
 $sttmt->execute();
-
-$dbh->commit();
 
 unset($sttmt);
 unset($dbh);

--- a/ext/pdo_firebird/tests/bug_64037.phpt
+++ b/ext/pdo_firebird/tests/bug_64037.phpt
@@ -17,8 +17,6 @@ $dbh->exec("INSERT INTO test64037 (ID, TEXT, COST) VALUES (1, 'test', -1.0)");
 $dbh->exec("INSERT INTO test64037 (ID, TEXT, COST) VALUES (2, 'test', -0.99)");
 $dbh->exec("INSERT INTO test64037 (ID, TEXT, COST) VALUES (3, 'test', -1.01)");
 
-$dbh->commit();
-
 $query = "SELECT * from test64037 order by ID";
 $stmt = $dbh->prepare($query);
 $stmt->execute();
@@ -30,8 +28,6 @@ var_dump($rows[2]['COST']);
 
 $stmt = $dbh->prepare('DELETE FROM test64037');
 $stmt->execute();
-
-$dbh->commit();
 
 unset($stmt);
 unset($dbh);

--- a/ext/pdo_firebird/tests/ddl2.phpt
+++ b/ext/pdo_firebird/tests/ddl2.phpt
@@ -1,0 +1,36 @@
+--TEST--
+PDO_Firebird: DDL/transactions 2
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--ENV--
+LSAN_OPTIONS=detect_leaks=0
+--FILE--
+<?php
+require("testdb.inc");
+
+$dbh->exec("CREATE TABLE test_ddl2 (val int)");
+
+$dbh->beginTransaction();
+$dbh->exec("INSERT INTO test_ddl2 (val) VALUES (120)");
+$dbh->exec("CREATE TABLE test_ddl2_2 (val INT)");
+$dbh->rollback();
+
+$result = $dbh->query("SELECT * FROM test_ddl2");
+foreach ($result as $r) {
+    var_dump($r);
+}
+
+unset($dbh);
+echo "done\n";
+?>
+--CLEAN--
+<?php
+require("testdb.inc");
+$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+@$dbh->exec('DROP TABLE test_ddl2');
+@$dbh->exec('DROP TABLE test_ddl2_2');
+?>
+--EXPECT--
+done

--- a/ext/pdo_firebird/tests/payload_test.phpt
+++ b/ext/pdo_firebird/tests/payload_test.phpt
@@ -16,6 +16,9 @@ $dsn = "firebird:dbname=inet://$address/test";
 $username = 'SYSDBA';
 $password = 'masterkey';
 
-new PDO($dsn, $username, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+new PDO($dsn, $username, $password, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_AUTOCOMMIT => false,
+]);
 ?>
 --EXPECT--

--- a/ext/pdo_firebird/tests/rowCount.phpt
+++ b/ext/pdo_firebird/tests/rowCount.phpt
@@ -15,7 +15,6 @@ $dbh->exec('CREATE TABLE test_rowcount (A VARCHAR(10))');
 $dbh->exec("INSERT INTO test_rowcount VALUES ('A')");
 $dbh->exec("INSERT INTO test_rowcount VALUES ('A')");
 $dbh->exec("INSERT INTO test_rowcount VALUES ('B')");
-$dbh->commit();
 
 $query = "SELECT * FROM test_rowcount WHERE A = ?";
 
@@ -29,13 +28,10 @@ var_dump($stmt->rowCount());
 $stmt = $dbh->prepare('UPDATE test_rowcount SET A="A" WHERE A != ?');
 $stmt->execute(array('A'));
 var_dump($stmt->rowCount());
-$dbh->commit();
 
 $stmt = $dbh->prepare('DELETE FROM test_rowcount');
 $stmt->execute();
 var_dump($stmt->rowCount());
-
-$dbh->commit();
 
 unset($stmt);
 unset($dbh);


### PR DESCRIPTION
Follow up https://github.com/php/php-src/pull/12545

Firebird doesn't have anything like an autocommit mode, so we need to implement such behavior on the pdo side. Also, whatever we do with firebird, we must operate within a transaction.

This means that in many cases a transaction must already be started in order to achieve autocommit mode.

----

~~To begin with, I'm a little doubtful that there's a need to emulate autocommit mode with pdo since it doesn't exist in firebird. I'm starting to feel like it's okay to decide that autocommit mode is not supported.~~

I was able to implement it