### PR TITLE
Fix GH-12655: proc_open() does not take into account references in the descriptor array

### DIFF
--- a/ext/standard/proc_open.c
+++ b/ext/standard/proc_open.c
@@ -1096,6 +1096,7 @@ PHP_FUNCTION(proc_open)
 
 		descriptors[ndesc].index = (int)nindex;
 
+		ZVAL_DEREF(descitem);
 		if (Z_TYPE_P(descitem) == IS_RESOURCE) {
 			if (set_proc_descriptor_from_resource(descitem, &descriptors[ndesc], ndesc) == FAILURE) {
 				goto exit_fail;

--- a/ext/standard/tests/general_functions/gh12655.phpt
+++ b/ext/standard/tests/general_functions/gh12655.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-12655 (proc_open(): Argument #2 ($descriptor_spec) must only contain arrays and streams [Descriptor item must be either an array or a File-Handle])
+--FILE--
+<?php
+
+$descriptor_spec = [
+    0 => [ "pipe", "r" ],  // stdin is a pipe that the child will read from
+    1 => [ "pipe", "w" ],  // stdout is a pipe that the child will write to
+    2 => [ "pipe", "w" ],  // stderr is a file to write to
+];
+
+foreach ( $descriptor_spec as $fd => &$d )
+{
+    // don't do anything, just the fact that we used "&$d" will sink the ship!
+}
+
+$proc = proc_open(PHP_BINARY, $descriptor_spec, $pipes);
+echo $proc === false ? "FAILED\n" : "SUCCEEDED\n";
+
+?>
+--EXPECT--
+SUCCEEDED


### PR DESCRIPTION
Closes GH-12655