### PR TITLE
Clean and sync debugging C flags

### DIFF
--- a/Zend/Zend.m4
+++ b/Zend/Zend.m4
@@ -190,7 +190,7 @@ AX_CHECK_COMPILE_FLAG([-Wformat-truncation], CFLAGS="-Wformat-truncation $CFLAGS
 AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes], CFLAGS="-Wstrict-prototypes $CFLAGS", , [-Werror])
 AX_CHECK_COMPILE_FLAG([-fno-common], CFLAGS="-fno-common $CFLAGS", , [-Werror])
 
-test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"
+AS_VAR_IF([DEBUG_CFLAGS],,, [AS_VAR_APPEND([CFLAGS], [" $DEBUG_CFLAGS"])])
 
 if test "$ZEND_ZTS" = "yes"; then
   AC_DEFINE(ZTS,1,[ ])

--- a/configure.ac
+++ b/configure.ac
@@ -938,8 +938,6 @@ if test "$PHP_CONFIG_FILE_SCAN_DIR" = "DEFAULT"; then
 fi
 AC_MSG_RESULT([$PHP_CONFIG_FILE_SCAN_DIR])
 
-test -n "$DEBUG_CFLAGS" && CFLAGS="$CFLAGS $DEBUG_CFLAGS"
-
 PHP_ARG_ENABLE([sigchild],
   [whether to enable PHP's own SIGCHLD handler],
   [AS_HELP_STRING([--enable-sigchild],


### PR DESCRIPTION
~~These are already better set in the main configure.ac file. Also check is done if optimization flags need to be adjusted.~~

The unused DEBUG_CFLAGS variable has been removed from Zend.m4 macros and configure.ac file. DEBUG_CFLAGS has been once set in the build files similarly to Zend.m4 but was then removed and simplified.

Also, this syncs phpize.m4 debug check with configure.ac so that #78788 is fixed there as well.
Related to: 0988f6963420ab26b7804e080380b813ca79cfa8

Edit: Marking this as draft PR, I'll recheck it again...
Edit 2: Marked as ready. I've changed that Zend.m4 changes back because they are needed in possible some edge cases when doing --enable-debug-assertions or using very customized and simplified CFLAGS override. So, let's leave them be then.