### PR TITLE
Initialize syslog device in GINIT

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -230,6 +230,8 @@ static void basic_globals_ctor(php_basic_globals *basic_globals_p) /* {{{ */
 
 	BG(page_uid) = -1;
 	BG(page_gid) = -1;
+
+	BG(syslog_device)=NULL;
 }
 /* }}} */
 

--- a/ext/standard/syslog.c
+++ b/ext/standard/syslog.c
@@ -90,7 +90,6 @@ PHP_MINIT_FUNCTION(syslog)
 	/* AIX doesn't have LOG_PERROR */
 	REGISTER_LONG_CONSTANT("LOG_PERROR", LOG_PERROR, CONST_CS | CONST_PERSISTENT); /*log to stderr*/
 #endif
-	BG(syslog_device)=NULL;
 
 	return SUCCESS;
 }


### PR DESCRIPTION
Initializing global in MINIT won't initialize for all threads (ZTS build fix)