### PR TITLE
Feature: Output correct error message from `pdo_firebird`

### DIFF
--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -60,6 +60,12 @@ typedef void (*info_func_t)(char*);
 #endif
 
 typedef struct {
+	int sqlcode;
+	char *errmsg;
+	size_t errmsg_length;
+} pdo_firebird_error_info;
+
+typedef struct {
 
 	/* the result of the last API call */
 	ISC_STATUS isc_status[20];
@@ -69,9 +75,6 @@ typedef struct {
 
 	/* the transaction handle */
 	isc_tr_handle tr;
-
-	/* the last error that didn't come from the API */
-	char const *last_app_error;
 
 	/* date and time format strings, can be set by the set_attribute method */
 	char *date_format;
@@ -85,6 +88,7 @@ typedef struct {
 
 	unsigned _reserved:29;
 
+	pdo_firebird_error_info einfo;
 } pdo_firebird_db_handle;
 
 
@@ -125,7 +129,12 @@ extern const pdo_driver_t pdo_firebird_driver;
 
 extern const struct pdo_stmt_methods firebird_stmt_methods;
 
-void _firebird_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, char const *file, zend_long line);
+extern void _firebird_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *state, const size_t state_len,
+	const char *msg, const size_t msg_len);
+#define firebird_error(d) _firebird_error(d, NULL, NULL, 0, NULL, 0)
+#define firebird_error_stmt(s) _firebird_error(s->dbh, s, NULL, 0, NULL, 0)
+#define firebird_error_with_info(d,e,el,m,ml) _firebird_error(d, NULL, e, el, m, ml)
+#define firebird_error_stmt_with_info(s,e,el,m,ml) _firebird_error(s->dbh, s, e, el, m, ml)
 
 enum {
 	PDO_FB_ATTR_DATE_FORMAT = PDO_ATTR_DRIVER_SPECIFIC,

--- a/ext/pdo_firebird/tests/error_handle.phpt
+++ b/ext/pdo_firebird/tests/error_handle.phpt
@@ -1,0 +1,41 @@
+--TEST--
+PDO_Firebird: error handle
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
+--FILE--
+<?php
+
+require("testdb.inc");
+$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+
+$table = 'error_handle';
+$dbh->query("CREATE TABLE {$table} (val int)");
+
+echo "dbh error";
+$dbh->query("INSERT INTO {$table} VALUES ('str')");
+
+echo "\n";
+
+echo "stmt error";
+$stmt = $dbh->prepare("INSERT INTO {$table} VALUES ('str')");
+$stmt->execute();
+
+unset($dbh);
+?>
+--CLEAN--
+<?php
+require 'testdb.inc';
+@$dbh->exec('DROP TABLE error_handle');
+unset($dbh);
+?>
+--EXPECTF--
+dbh error
+Warning: PDO::query(): SQLSTATE[22018]: Invalid character value for cast specification: -413 conversion error from string "str" in %s on line 10
+
+stmt error
+Warning: PDOStatement::execute(): SQLSTATE[22018]: Invalid character value for cast specification: -413 conversion error from string "str" in %s on line 16


### PR DESCRIPTION
The current implementation does not retrieve `sqlstatus` from the DB, and any errors will be treated as General errors.

So I changed it to get the SQL state and error messages from the vendor driver.

I also used the same naming conventions as other PDO drivers for function names, etc.

Other changes require error handling, so I'd be happy if I could merge them from this PR.