### PR TITLE
Enable `pdo-firebird` Testing in Linux CI Environments

### DIFF
--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -35,6 +35,10 @@ runs:
         if [[ -z "$PDO_PGSQL_TEST_DSN" ]]; then
           export PDO_PGSQL_TEST_DSN="pgsql:host=localhost port=5432 dbname=test user=postgres password=postgres"
         fi
+        export PDO_FIREBIRD_TEST_DATABASE=test.fdb
+        export PDO_FIREBIRD_TEST_DSN=firebird:dbname=localhost:test.fdb
+        export PDO_FIREBIRD_TEST_PASS=test
+        export PDO_FIREBIRD_TEST_USER=test
         export ODBC_TEST_USER="odbc_test"
         export ODBC_TEST_PASS="password"
         export ODBC_TEST_DSN="Driver={ODBC Driver 17 for SQL Server};Server=127.0.0.1;Database=odbc;uid=$ODBC_TEST_USER;pwd=$ODBC_TEST_PASS"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,6 +61,15 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
+      firebird:
+        image: jacobalberty/firebird
+        ports:
+          - 3050:3050
+        env:
+          ISC_PASSWORD: test
+          FIREBIRD_DATABASE: test.fdb
+          FIREBIRD_USER: test
+          FIREBIRD_PASSWORD: test
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request enables `pdo-firebird` tests within Linux containers for CI processes, resolving the current gap where tests are run on Windows but lack artifact outputs for review (see also #12443 on *"strange" skips*). 

The approach taken here mirrors the one used for PostgreSQL and MySQL in our CI pipelines, utilizing GitHub Actions Service Containers. 

I have selected the Docker image [jacobalberty/firebird](https://hub.docker.com/r/jacobalberty/firebird) . Although this is not an official Firebird project distribution, [its longstanding maintenance record and the substantial number of stars](https://github.com/jacobalberty/firebird-docker) it has accumulated are indicative of its reliability and are believed to provide a stable and trusted testing environment.

In addition to testing this Pull Request, just to be safe, I imported #12664 #12657 , which was passed in the Pull Request for the currently open `Extension: pdo_firebird` , into my repository and tested it on Linux. The following has been successful without any problems:

https://github.com/KentarouTakeda/php-src/actions/runs/6877444791?pr=5
https://github.com/KentarouTakeda/php-src/actions/runs/6877441551?pr=6