### PR TITLE
Fix GH-12675: MEMORY_LEAK in phpdbg_prompt.c

### DIFF
--- a/sapi/phpdbg/phpdbg_prompt.c
+++ b/sapi/phpdbg/phpdbg_prompt.c
@@ -408,6 +408,7 @@ PHPDBG_COMMAND(exec) /* {{{ */
 			if ((res_len != PHPDBG_G(exec_len)) || (memcmp(res, PHPDBG_G(exec), res_len) != SUCCESS)) {
 				if (PHPDBG_G(in_execution)) {
 					if (phpdbg_ask_user_permission("Do you really want to stop execution to set a new execution context?") == FAILURE) {
+						free(res);
 						return FAILURE;
 					}
 				}
@@ -441,6 +442,7 @@ PHPDBG_COMMAND(exec) /* {{{ */
 
 				phpdbg_compile();
 			} else {
+				free(res);
 				phpdbg_notice("Execution context not changed");
 			}
 		} else {

--- a/sapi/phpdbg/tests/gh12675.phpt
+++ b/sapi/phpdbg/tests/gh12675.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-12675 (MEMORY_LEAK in phpdbg_prompt.c)
+--PHPDBG--
+ev file_put_contents("gh12675_1.tmp", "<?php echo 'hi';\necho 2;")
+ev file_put_contents("gh12675_2.tmp", "<?php echo 'hi';")
+exec nonexistent.php
+exec gh12675_1.tmp
+exec gh12675_1.tmp
+b gh12675_1.tmp:2
+r
+exec gh12675_2.tmp
+n
+q
+--EXPECTF--
+prompt> 24
+prompt> 16
+prompt> [Cannot stat nonexistent.php, ensure the file exists]
+prompt> [Set execution context: %sgh12675_1.tmp]
+[Successful compilation of %sgh12675_1.tmp]
+prompt> [Execution context not changed]
+prompt> [Breakpoint #0 added at %sgh12675_1.tmp:2]
+prompt> hi
+[Breakpoint #0 at %sgh12675_1.tmp:2, hits: 1]
+>00002: echo 2;
+prompt> Do you really want to stop execution to set a new execution context? (type y or n): prompt>
+--CLEAN--
+<?php
+@unlink("gh12675_1.tmp");
+@unlink("gh12675_2.tmp");
+?>

--- a/sapi/phpdbg/tests/gh12675.phpt
+++ b/sapi/phpdbg/tests/gh12675.phpt
@@ -1,5 +1,7 @@
 --TEST--
 GH-12675 (MEMORY_LEAK in phpdbg_prompt.c)
+--INI--
+opcache.enable=0
 --PHPDBG--
 ev file_put_contents("gh12675_1.tmp", "<?php echo 'hi';\necho 2;")
 ev file_put_contents("gh12675_2.tmp", "<?php echo 'hi';")


### PR DESCRIPTION
Have to use file_put_contents() instead of --FILE-- because we have to actually load it using the exec command, *and* have to make multiple files, and note that we can only load files relative from the current directory, so we can't rely on files being in the sapi/phpdbg/tests folder.