### PR TITLE
Use __DIR__-relative path in tests

### DIFF
--- a/ext/exif/tests/bug78793.phpt
+++ b/ext/exif/tests/bug78793.phpt
@@ -4,7 +4,7 @@ Bug #78793: Use-after-free in exif parsing under memory sanitizer
 exif
 --FILE--
 <?php
-$f = "ext/exif/tests/bug77950.tiff";
+$f = __DIR__ . "/bug77950.tiff";
 for ($i = 0; $i < 10; $i++) {
     @exif_read_data($f);
 }

--- a/ext/soap/tests/bug75306.phpt
+++ b/ext/soap/tests/bug75306.phpt
@@ -7,11 +7,11 @@ soap
 $options = array("cache_wsdl" => WSDL_CACHE_NONE);
 // Need a warm-up for globals
 for ($i = 0; $i < 10; $i++) {
-    $client = new SoapClient("ext/soap/tests/test.wsdl", $options);
+    $client = new SoapClient(__DIR__ . "/test.wsdl", $options);
 }
 $usage = memory_get_usage();
 for ($i = 0; $i < 10; $i++) {
-    $client = new SoapClient("ext/soap/tests/test.wsdl", $options);
+    $client = new SoapClient(__DIR__ . "/test.wsdl", $options);
 }
 $usage_delta = memory_get_usage() - $usage;
 var_dump($usage_delta);


### PR DESCRIPTION
Otherwise we can't run them from another directory, they'll fail instead.