### PR TITLE
Fix GH-12616: DOM: Removing XMLNS namespace node results in invalid default: prefix

### DIFF
--- a/ext/dom/tests/gh12616_1.phpt
+++ b/ext/dom/tests/gh12616_1.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GH-12616 (DOM: Removing XMLNS namespace node results in invalid default: prefix)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument();
+$doc->loadXML(
+    <<<XML
+    <container xmlns="http://symfony.com/schema/dic/services">
+      CHILDREN
+    </container>
+    XML
+);
+
+$doc->documentElement->removeAttributeNS('http://symfony.com/schema/dic/services', '');
+echo $doc->saveXML();
+
+$new = new DOMDocument();
+$new->append(
+    $new->importNode($doc->documentElement, true)
+);
+
+echo $new->saveXML();
+
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<container>
+  CHILDREN
+</container>
+<?xml version="1.0"?>
+<container>
+  CHILDREN
+</container>

--- a/ext/dom/tests/gh12616_2.phpt
+++ b/ext/dom/tests/gh12616_2.phpt
@@ -1,0 +1,39 @@
+--TEST--
+GH-12616 (DOM: Removing XMLNS namespace node results in invalid default: prefix)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument();
+$doc->loadXML(
+    <<<XML
+    <container xmlns:test="urn:test" xmlns:symfony="http://symfony.com/schema/dic/services">
+        <symfony:services>
+            <test:service id="hello" />
+        </symfony:services>
+    </container>
+    XML
+);
+
+$doc->documentElement->removeAttributeNS('http://symfony.com/schema/dic/services', 'symfony');
+$xpath = new DOMXPath($doc);
+$xpath->registerNamespace('test', 'urn:test');
+
+echo $doc->saveXML();
+
+$result = $xpath->query('//container/services/test:service[@id="hello"]');
+var_dump($result);
+
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<container xmlns:test="urn:test">
+    <services>
+        <test:service id="hello"/>
+    </services>
+</container>
+object(DOMNodeList)#4 (1) {
+  ["length"]=>
+  int(1)
+}

--- a/ext/dom/tests/gh12616_3.phpt
+++ b/ext/dom/tests/gh12616_3.phpt
@@ -1,0 +1,152 @@
+--TEST--
+GH-12616 (DOM: Removing XMLNS namespace node results in invalid default: prefix)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$doc = new DOMDocument();
+$doc->loadXML(
+    <<<XML
+    <container>
+      <child1 xmlns:x="http://symfony.com/schema/dic/services">
+        <x:foo x:bar=""/>
+        <x:foo x:bar=""/>
+      </child1>
+      <child2 xmlns:x="http://symfony.com/schema/dic/services">
+        <x:foo x:bar=""/>
+        <x:foo x:bar=""/>
+      </child2>
+    </container>
+    XML
+);
+
+$doc->documentElement->firstElementChild->removeAttributeNS('http://symfony.com/schema/dic/services', 'x');
+echo $doc->saveXML();
+
+$xpath = new DOMXPath($doc);
+
+echo "--- Namespaces of child1 ---\n";
+
+foreach ($xpath->query("/container/child1/namespace::*") as $ns) {
+    var_dump($ns);
+}
+
+echo "--- Namespaces of child1/foo (both nodes) ---\n";
+
+foreach ($xpath->query("/container/child1/foo/namespace::*") as $ns) {
+    var_dump($ns);
+}
+
+echo "--- Namespaces of child2 ---\n";
+
+foreach ($xpath->query("/container/child2/namespace::*") as $ns) {
+    var_dump($ns);
+}
+
+?>
+--EXPECT--
+<?xml version="1.0"?>
+<container>
+  <child1>
+    <foo bar=""/>
+    <foo bar=""/>
+  </child1>
+  <child2 xmlns:x="http://symfony.com/schema/dic/services">
+    <x:foo x:bar=""/>
+    <x:foo x:bar=""/>
+  </child2>
+</container>
+--- Namespaces of child1 ---
+object(DOMNameSpaceNode)#4 (8) {
+  ["nodeName"]=>
+  string(9) "xmlns:xml"
+  ["nodeValue"]=>
+  string(36) "http://www.w3.org/XML/1998/namespace"
+  ["nodeType"]=>
+  int(18)
+  ["prefix"]=>
+  string(3) "xml"
+  ["localName"]=>
+  string(3) "xml"
+  ["namespaceURI"]=>
+  string(36) "http://www.w3.org/XML/1998/namespace"
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["parentNode"]=>
+  string(22) "(object value omitted)"
+}
+--- Namespaces of child1/foo (both nodes) ---
+object(DOMNameSpaceNode)#5 (8) {
+  ["nodeName"]=>
+  string(9) "xmlns:xml"
+  ["nodeValue"]=>
+  string(36) "http://www.w3.org/XML/1998/namespace"
+  ["nodeType"]=>
+  int(18)
+  ["prefix"]=>
+  string(3) "xml"
+  ["localName"]=>
+  string(3) "xml"
+  ["namespaceURI"]=>
+  string(36) "http://www.w3.org/XML/1998/namespace"
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["parentNode"]=>
+  string(22) "(object value omitted)"
+}
+object(DOMNameSpaceNode)#8 (8) {
+  ["nodeName"]=>
+  string(9) "xmlns:xml"
+  ["nodeValue"]=>
+  string(36) "http://www.w3.org/XML/1998/namespace"
+  ["nodeType"]=>
+  int(18)
+  ["prefix"]=>
+  string(3) "xml"
+  ["localName"]=>
+  string(3) "xml"
+  ["namespaceURI"]=>
+  string(36) "http://www.w3.org/XML/1998/namespace"
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["parentNode"]=>
+  string(22) "(object value omitted)"
+}
+--- Namespaces of child2 ---
+object(DOMNameSpaceNode)#9 (8) {
+  ["nodeName"]=>
+  string(9) "xmlns:xml"
+  ["nodeValue"]=>
+  string(36) "http://www.w3.org/XML/1998/namespace"
+  ["nodeType"]=>
+  int(18)
+  ["prefix"]=>
+  string(3) "xml"
+  ["localName"]=>
+  string(3) "xml"
+  ["namespaceURI"]=>
+  string(36) "http://www.w3.org/XML/1998/namespace"
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["parentNode"]=>
+  string(22) "(object value omitted)"
+}
+object(DOMNameSpaceNode)#5 (8) {
+  ["nodeName"]=>
+  string(7) "xmlns:x"
+  ["nodeValue"]=>
+  string(38) "http://symfony.com/schema/dic/services"
+  ["nodeType"]=>
+  int(18)
+  ["prefix"]=>
+  string(1) "x"
+  ["localName"]=>
+  string(1) "x"
+  ["namespaceURI"]=>
+  string(38) "http://symfony.com/schema/dic/services"
+  ["ownerDocument"]=>
+  string(22) "(object value omitted)"
+  ["parentNode"]=>
+  string(22) "(object value omitted)"
+}


### PR DESCRIPTION
The namespace data is freed and set to NULL, but there remain references to the namespace declaration nodes. This (rightfully) confuses libxml2 because its invariants are broken. We also have to remove all remaining references from the subtree. This fixes the data corruption bug.