### PR TITLE
JIT/AArch64: Fix an undefined symbol issue

### DIFF
--- a/ext/opcache/jit/zend_jit_ir.c
+++ b/ext/opcache/jit/zend_jit_ir.c
@@ -384,6 +384,7 @@ static bool zend_jit_set_veneer(ir_ctx *ctx, const void *addr, const void *venee
 		if (zend_jit_stub_handlers[i] == addr) {
 			const void **ptr = (const void**)&zend_jit_stub_handlers[count + i];
 			*ptr = veneer;
+#ifdef HAVE_CAPSTONE
 		    if (JIT_G(debug) & ZEND_JIT_DEBUG_ASM) {
 				const char *name = ir_disasm_find_symbol((uint64_t)(uintptr_t)addr, &offset);
 
@@ -399,6 +400,7 @@ static bool zend_jit_set_veneer(ir_ctx *ctx, const void *addr, const void *venee
 					}
 				}
 			}
+#endif
 			return 1;
 		}
 	}


### PR DESCRIPTION
In AArch64 function `zend_jit_set_veneer()`, some debug code calls two other functions `ir_disasm_find_symbol()` and `ir_disasm_add_symbol()` defined in `ir_disasm.c`. However, `ir_disasm.c` is compiled under the condition that capstone is available. This causes an undefined symbol issue while loading `opcache.so` when JIT is triggered if PHP is built without `--with-capstone`.

We find this issue on MacOS 12.5 if we build PHP with Clang 14. It does not appear immediately when using other versions of toolchains because of lazy binding. To reproduce this with Linux/GCC, we can disable lazy binding by `export LD_BIND_NOW=1` before building PHP.

This fixes the issue by making the debug code conditionally compile.