### PR TITLE
JIT/AArch64: Remove redundant memory unmap

### DIFF
--- a/ext/opcache/jit/ir/ir_aarch64.dasc
+++ b/ext/opcache/jit/ir/ir_aarch64.dasc
@@ -5337,9 +5337,6 @@ void *ir_emit_code(ir_ctx *ctx, size_t *size_ptr)
 	if (ret != DASM_S_OK) {
 		IR_ASSERT(0);
 		dasm_free(&data.dasm_state);
-		if (ctx->code_buffer == NULL) {
-			ir_mem_unmap(entry, size);
-		}
 		ctx->data = NULL;
 		ctx->status = IR_ERROR_LINK;
 		return NULL;


### PR DESCRIPTION
The AArch64 version of function `ir_emit_code()` does an extra memory unmap if DynASM status is not OK. This causes GCC warnings of variables `entry` and `size` are used uninitialized. Actually, the memory unmap here is redundant because the JIT code buffer has never been mmapped at this point.

This patch removes the redundant memory unmap to avoid potential issues.