### PR TITLE
Skip slow tests on Travis

### DIFF
--- a/travis/test.sh
+++ b/travis/test.sh
@@ -4,6 +4,7 @@ set -ex
 # ARM64 CI reports nproc=32, which is excessive.
 if [ -z "$ARM64" ]; then export JOBS=$(nproc); else export JOBS=16; fi
 
+export SKIP_SLOW_TESTS=1
 export SKIP_IO_CAPTURE_TESTS=1
 ./sapi/cli/php run-tests.php -P \
     -g "FAIL,BORK,LEAK" --offline --show-diff --show-slow 1000 \


### PR DESCRIPTION
Travis jobs often fails due to not completing in 50 minutes. When it's successful, it's very close to 50 minutes so we need to do something about reducing the time of tests of travis. The most effective option should be to skip all slow tests which is probably fine on travis as it's just for s390x arch which is primarily to test a big endian so missing out on few slow tests should be hopefully fine...