### PR TITLE
Enable `pdo-firebird` nightly testing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,6 +48,15 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
+      firebird:
+        image: jacobalberty/firebird
+        ports:
+          - 3050:3050
+        env:
+          ISC_PASSWORD: test
+          FIREBIRD_DATABASE: test.fdb
+          FIREBIRD_USER: test
+          FIREBIRD_PASSWORD: test
     strategy:
       fail-fast: false
       matrix:
@@ -287,6 +296,15 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
+      firebird:
+        image: jacobalberty/firebird
+        ports:
+          - 3050:3050
+        env:
+          ISC_PASSWORD: test
+          FIREBIRD_DATABASE: test.fdb
+          FIREBIRD_USER: test
+          FIREBIRD_PASSWORD: test
     runs-on: ubuntu-22.04
     steps:
       - name: git checkout
@@ -518,6 +536,15 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
+      firebird:
+        image: jacobalberty/firebird
+        ports:
+          - 3050:3050
+        env:
+          ISC_PASSWORD: test
+          FIREBIRD_DATABASE: test.fdb
+          FIREBIRD_USER: test
+          FIREBIRD_PASSWORD: test
     strategy:
       fail-fast: false
       matrix:

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -51,6 +51,11 @@ static zend_always_inline double get_double_from_sqldata(const ISC_SCHAR *sqldat
 	READ_AND_RETURN_USING_MEMCPY(double, sqldata);
 }
 
+static zend_always_inline float get_float_from_sqldata(const ISC_SCHAR *sqldata)
+{
+	READ_AND_RETURN_USING_MEMCPY(float, sqldata);
+}
+
 static zend_always_inline ISC_TIMESTAMP get_isc_timestamp_from_sqldata(const ISC_SCHAR *sqldata)
 {
 	READ_AND_RETURN_USING_MEMCPY(ISC_TIMESTAMP, sqldata);
@@ -459,7 +464,7 @@ static int firebird_stmt_get_col(
 					break;
 				case SQL_FLOAT:
 					/* TODO: Why is this not returned as the native type? */
-					ZVAL_STR(result, zend_strpprintf(0, "%F", *(float*)var->sqldata));
+					ZVAL_STR(result, zend_strpprintf(0, "%F", get_float_from_sqldata(var->sqldata)));
 					break;
 				case SQL_DOUBLE:
 					/* TODO: Why is this not returned as the native type? */

--- a/ext/pdo_firebird/tests/bug_47415.phpt
+++ b/ext/pdo_firebird/tests/bug_47415.phpt
@@ -4,8 +4,9 @@ Bug #47415 PDO_Firebird segfaults when passing lowercased column name to bindCol
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/bug_48877.phpt
+++ b/ext/pdo_firebird/tests/bug_48877.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: bug 48877 The "bindValue" and "bindParam" do not work for PDO Fire
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 

--- a/ext/pdo_firebird/tests/bug_53280.phpt
+++ b/ext/pdo_firebird/tests/bug_53280.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: bug 53280 segfaults if query column count is less than param count
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 

--- a/ext/pdo_firebird/tests/bug_62024.phpt
+++ b/ext/pdo_firebird/tests/bug_62024.phpt
@@ -4,8 +4,9 @@ Bug #62024 Cannot insert second row with null using parametrized query (Firebird
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 

--- a/ext/pdo_firebird/tests/bug_64037.phpt
+++ b/ext/pdo_firebird/tests/bug_64037.phpt
@@ -4,8 +4,9 @@ Bug #64037 Firebird return wrong value for numeric field
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 

--- a/ext/pdo_firebird/tests/bug_72583.phpt
+++ b/ext/pdo_firebird/tests/bug_72583.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: Feature 72583 Fetch integers as php integers not as strings
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/bug_72931.phpt
+++ b/ext/pdo_firebird/tests/bug_72931.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: Bug 72931 Insert returning fails on Firebird 3
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/bug_73087.phpt
+++ b/ext/pdo_firebird/tests/bug_73087.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: bug 73087 segfault binding blob parameter
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/bug_74462.phpt
+++ b/ext/pdo_firebird/tests/bug_74462.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: Bug #74462 Returns only NULLs for boolean fields
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/bug_76448.phpt
+++ b/ext/pdo_firebird/tests/bug_76448.phpt
@@ -3,8 +3,9 @@ Bug #76448 (Stack buffer overflow in firebird_info_cb)
 --EXTENSIONS--
 pdo_firebird
 sockets
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require_once "payload_server.inc";

--- a/ext/pdo_firebird/tests/bug_76449.phpt
+++ b/ext/pdo_firebird/tests/bug_76449.phpt
@@ -3,8 +3,9 @@ Bug #76449 (SIGSEGV in firebird_handle_doer)
 --EXTENSIONS--
 pdo_firebird
 sockets
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require_once "payload_server.inc";

--- a/ext/pdo_firebird/tests/bug_76450.phpt
+++ b/ext/pdo_firebird/tests/bug_76450.phpt
@@ -3,8 +3,9 @@ Bug #76450 (SIGSEGV in firebird_stmt_execute)
 --EXTENSIONS--
 pdo_firebird
 sockets
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require_once "payload_server.inc";

--- a/ext/pdo_firebird/tests/bug_76452.phpt
+++ b/ext/pdo_firebird/tests/bug_76452.phpt
@@ -4,6 +4,9 @@ Bug ##76452 (Crash while parsing blob data in firebird_fetch_blob)
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require_once "payload_server.inc";

--- a/ext/pdo_firebird/tests/bug_76488.phpt
+++ b/ext/pdo_firebird/tests/bug_76488.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: Bug #76488 Memory leak when fetching a BLOB field
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/bug_77863.phpt
+++ b/ext/pdo_firebird/tests/bug_77863.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: Bug #76488 PDO Firebird does not support boolean datatype in input
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 

--- a/ext/pdo_firebird/tests/bug_80521.phpt
+++ b/ext/pdo_firebird/tests/bug_80521.phpt
@@ -4,8 +4,9 @@ Bug #80521 (Parameters with underscores no longer recognized)
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/bug_aaa.phpt
+++ b/ext/pdo_firebird/tests/bug_aaa.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: cursor should not be marked as opened on singleton statements
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/common.phpt
+++ b/ext/pdo_firebird/tests/common.phpt
@@ -9,6 +9,7 @@ pdo_firebird
 # magic auto-configuration
 
 $config = array(
+    // A bug in firebird causes a memory leak when calling `isc_attach_database()`. See https://github.com/FirebirdSQL/firebird/issues/7849
 	'ENV' => ['LSAN_OPTIONS' => 'detect_leaks=0'],
 	'TESTS' => 'ext/pdo/tests'
 );

--- a/ext/pdo_firebird/tests/connect.phpt
+++ b/ext/pdo_firebird/tests/connect.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: connect/disconnect
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
     require("testdb.inc");

--- a/ext/pdo_firebird/tests/ddl.phpt
+++ b/ext/pdo_firebird/tests/ddl.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: DDL/transactions
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 

--- a/ext/pdo_firebird/tests/dialect_1.phpt
+++ b/ext/pdo_firebird/tests/dialect_1.phpt
@@ -8,8 +8,9 @@ if (strpos(getenv('PDO_FIREBIRD_TEST_DSN'), 'dialect=1')===false) {
     die('skip: PDO_FIREBIRD_TEST_DSN must contain a string "dialect=1"');
 }
 ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require("testdb.inc");

--- a/ext/pdo_firebird/tests/execute.phpt
+++ b/ext/pdo_firebird/tests/execute.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: prepare/execute/binding
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require("testdb.inc");

--- a/ext/pdo_firebird/tests/execute_block.phpt
+++ b/ext/pdo_firebird/tests/execute_block.phpt
@@ -5,8 +5,9 @@ pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); 	
 ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 	require("testdb.inc");

--- a/ext/pdo_firebird/tests/gh10908.phpt
+++ b/ext/pdo_firebird/tests/gh10908.phpt
@@ -4,8 +4,9 @@ GH-10908 (Bus error with PDO Firebird on RPI with 64 bit kernel and 32 bit userl
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 

--- a/ext/pdo_firebird/tests/gh8576.phpt
+++ b/ext/pdo_firebird/tests/gh8576.phpt
@@ -4,6 +4,9 @@ GH-8576 (Bad interpretation of length when char is UTF-8)
 pdo_firebird
 --SKIPIF--
 <?php require 'skipif.inc'; ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require 'testdb.inc';

--- a/ext/pdo_firebird/tests/ignore_parammarks.phpt
+++ b/ext/pdo_firebird/tests/ignore_parammarks.phpt
@@ -5,8 +5,9 @@ pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); 	
 ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 	require("testdb.inc");

--- a/ext/pdo_firebird/tests/payload_test.phpt
+++ b/ext/pdo_firebird/tests/payload_test.phpt
@@ -3,8 +3,9 @@ FB payload server satisfies connection attempt
 --EXTENSIONS--
 pdo_firebird
 sockets
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 require_once "payload_server.inc";

--- a/ext/pdo_firebird/tests/rowCount.phpt
+++ b/ext/pdo_firebird/tests/rowCount.phpt
@@ -4,8 +4,9 @@ PDO_Firebird: rowCount
 pdo_firebird
 --SKIPIF--
 <?php require('skipif.inc'); ?>
---ENV--
-LSAN_OPTIONS=detect_leaks=0
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
 --FILE--
 <?php
 


### PR DESCRIPTION
This pull request enables the `pdo-firebird` test provided in #12677 for nightly testing.

The solution is the same. `nightly.yml` uses `test-linux/action.yml` in the same way as `push.yml` to execute the test, so i created a firebird service container for all Jobs that reference the test action.

### Note

Even after merging this pull request, some tests fail in `nightly.yml`. There are tests that are fine in `push.yml` but fail only in `nightly.yml`. You can see the results in my repository:

https://github.com/KentarouTakeda/php-src/actions/runs/6901762828/job/18777809789#step:12:151

We plan to create another pull request to resolve this issue.