### PR TITLE
Fix: Colon in url path is not parsed by parse_url

### DIFF
--- a/ext/standard/tests/url/bugX.phpt
+++ b/ext/standard/tests/url/bugX.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Bug #X	parse_url() return false on absolute path containing ':' and no query string.
+--FILE--
+<?php
+var_dump(
+    parse_url('/page:1'),
+    parse_url('/page:1', \PHP_URL_SCHEME)
+);
+
+?>
+--EXPECT--
+array(1) {
+  ["path"]=>
+  string(7) "/page:1"
+}
+NULL

--- a/ext/standard/url.c
+++ b/ext/standard/url.c
@@ -118,7 +118,7 @@ PHPAPI php_url *php_url_parse_ex2(char const *str, size_t length, bool *has_port
 		while (p < e) {
 			/* scheme = 1*[ lowalpha | digit | "+" | "-" | "." ] */
 			if (!isalpha(*p) && !isdigit(*p) && *p != '+' && *p != '.' && *p != '-') {
-				if (e + 1 < ue && e < binary_strcspn(s, ue, "?#")) {
+				if (*s != '/' && e + 1 < ue && e < binary_strcspn(s, ue, "?#")) {
 					goto parse_port;
 				} else if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
 					s += 2;


### PR DESCRIPTION
This aims to solve https://github.com/php/php-src/issues/12703