### PR TITLE
Sync YFLAGS in scripts/dev/genfiles with PHP_PROG_BISON macro defaults

### DIFF
--- a/Zend/Makefile.frag
+++ b/Zend/Makefile.frag
@@ -23,7 +23,7 @@ $(srcdir)/zend_language_parser.c: $(srcdir)/zend_language_parser.y
 
 $(srcdir)/zend_ini_parser.h: $(srcdir)/zend_ini_parser.c
 $(srcdir)/zend_ini_parser.c: $(srcdir)/zend_ini_parser.y
-	$(YACC) $(YFLAGS) -v -d $(srcdir)/zend_ini_parser.y -o $@
+	@$(YACC) $(YFLAGS) -v -d $(srcdir)/zend_ini_parser.y -o $@
 
 $(srcdir)/zend_ini_scanner.c: $(srcdir)/zend_ini_scanner.l
 	@(cd $(top_srcdir); $(RE2C) $(RE2C_FLAGS) --no-generation-date --case-inverted -cbdFt Zend/zend_ini_scanner_defs.h -oZend/zend_ini_scanner.c Zend/zend_ini_scanner.l)

--- a/scripts/dev/genfiles
+++ b/scripts/dev/genfiles
@@ -35,6 +35,7 @@
 
 YACC=${YACC:-bison}
 YACC="$YACC -l"
+YFLAGS="-Wall"
 RE2C=${RE2C:-re2c}
 RE2C_FLAGS="-i"
 SED=${SED:-sed}
@@ -100,7 +101,7 @@ if ! test -x "$(command -v $MAKE)"; then
 fi
 
 echo "genfiles: Generating Zend parser and lexer files"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" SED="$SED" srcdir=Zend builddir=Zend top_srcdir=. \
+$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" YFLAGS="$YFLAGS" SED="$SED" srcdir=Zend builddir=Zend top_srcdir=. \
   -f Zend/Makefile.frag \
   Zend/zend_language_parser.c \
   Zend/zend_language_scanner.c \
@@ -108,13 +109,13 @@ $MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" SED="$SED" srcdir=Zend 
   Zend/zend_ini_scanner.c
 
 echo "genfiles: Generating phpdbg parser and lexer files"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" srcdir=sapi/phpdbg builddir=sapi/phpdbg top_srcdir=. \
+$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" YFLAGS="$YFLAGS" srcdir=sapi/phpdbg builddir=sapi/phpdbg top_srcdir=. \
   -f sapi/phpdbg/Makefile.frag \
   sapi/phpdbg/phpdbg_parser.c \
   sapi/phpdbg/phpdbg_lexer.c
 
 echo "genfiles: Generating json extension parser and lexer files"
-$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" srcdir=ext/json builddir=ext/json top_srcdir=. \
+$MAKE RE2C="$RE2C" RE2C_FLAGS="$RE2C_FLAGS" YACC="$YACC" YFLAGS="$YFLAGS" srcdir=ext/json builddir=ext/json top_srcdir=. \
   -f ext/json/Makefile.frag \
   ext/json/json_parser.tab.c \
   ext/json/json_scanner.c


### PR DESCRIPTION
- Adds -Wall YFLAGS when using the scripts/dev/genfiles to have similar output there in case things need to be fixed.
- Syncs @ suppression operators across the bison calls.

The scripts/dev/genfiles script is used when releasing the PHP. Flags can be to some extent synced with the M4 macro here. 