### PR TITLE
Clean duplicate headers check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,7 +398,6 @@ netinet/in.h \
 alloca.h \
 arpa/inet.h \
 arpa/nameser.h \
-crypt.h \
 dns.h \
 fcntl.h \
 grp.h \
@@ -666,7 +665,6 @@ dnl getaddrinfo.
 AC_CACHE_CHECK([for getaddrinfo], ac_cv_func_getaddrinfo,
 [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <netdb.h>]],
   [[struct addrinfo *g,h;g=&h;getaddrinfo("","",g,&g);]])],[AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <string.h>
 #include <netdb.h>
 #include <sys/types.h>
 #include <string.h>

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -68,8 +68,6 @@ if test "$PHP_EXTERNAL_LIBCRYPT" != "no"; then
 
   AC_CACHE_CHECK(for standard DES crypt, ac_cv_crypt_des,[
     AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <string.h>
-
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -98,8 +96,6 @@ int main(void) {
 
   AC_CACHE_CHECK(for extended DES crypt, ac_cv_crypt_ext_des,[
     AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <string.h>
-
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -128,8 +124,6 @@ int main(void) {
 
   AC_CACHE_CHECK(for MD5 crypt, ac_cv_crypt_md5,[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <string.h>
-
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -168,8 +162,6 @@ int main(void) {
 
   AC_CACHE_CHECK(for Blowfish crypt, ac_cv_crypt_blowfish,[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <string.h>
-
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -205,8 +197,6 @@ int main(void) {
 
   AC_CACHE_CHECK(for SHA512 crypt, ac_cv_crypt_sha512,[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <string.h>
-
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -241,8 +231,6 @@ int main(void) {
 
   AC_CACHE_CHECK(for SHA256 crypt, ac_cv_crypt_sha256,[
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <string.h>
-
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -417,15 +405,16 @@ if test "$PHP_PASSWORD_ARGON2" != "no"; then
 fi
 
 dnl
-dnl net_get_interfaces
+dnl Check net/if.h for net_get_interfaces. Darwin and BSD-like systems need
+dnl sys/socket.h to be included with net/if.h.
 dnl
 AC_CHECK_HEADERS([net/if.h],[], [],
 [
   #ifdef HAVE_SYS_SOCKET_H
   #include <sys/socket.h>
   #endif
-  #include <net/if.h>
 ])
+
 AC_MSG_CHECKING([for usable getifaddrs])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   #include <sys/types.h>


### PR DESCRIPTION
- AC_CHECK_HEADERS already includes the header(s) listed in the first argument, so additional net/if.h is redundant.
- The crypt.h is checked two times and HAVE_CRYPT_H is only needed in ext/standard.
- Remove duplicate <string.h> in ext/standard
- Remove duplicate <string.h> in getaddrinfo check in configure.ac