### PR TITLE
Remove obsolete DG/UX check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,9 +229,6 @@ case $host_alias in
   *solaris*)
     CPPFLAGS="$CPPFLAGS -D_POSIX_PTHREAD_SEMANTICS"
     ;;
-  *dgux*)
-    CPPFLAGS="$CPPFLAGS -D_BSD_TIMEOFDAY_FLAVOR"
-    ;;
   *mips*)
     CPPFLAGS="$CPPFLAGS -D_XPG_IV"
     ;;


### PR DESCRIPTION
DG/UX is a discontinued Unix OS, the support for which ended in 2001.