### PR TITLE
Avoid temporary string allocations in php_mb_parse_encoding_list()

### DIFF
--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.c
@@ -319,6 +319,11 @@ static unsigned int mbfl_name2encoding_perfect_hash(const char *str, size_t len)
 
 const mbfl_encoding *mbfl_name2encoding(const char *name)
 {
+	return mbfl_name2encoding_ex(name, strlen(name));
+}
+
+const mbfl_encoding *mbfl_name2encoding_ex(const char *name, size_t name_len)
+{
 	const mbfl_encoding *const *encoding;
 
 	/* Sanity check perfect hash for name.
@@ -339,14 +344,13 @@ const mbfl_encoding *mbfl_name2encoding(const char *name)
 #endif
 
 	/* Use perfect hash lookup for name */
-	size_t name_len = strlen(name);
 	if (name_len <= NAME_HASH_MAX_NAME_LENGTH && name_len >= NAME_HASH_MIN_NAME_LENGTH) {
 		unsigned int key = mbfl_name2encoding_perfect_hash(name, name_len);
 		if (key <= 186) {
 			int8_t offset = mbfl_encoding_ptr_list_after_hashing[key];
 			if (offset >= 0) {
 				encoding = mbfl_encoding_ptr_list + offset;
-				if (strcasecmp((*encoding)->name, name) == 0) {
+				if (strncasecmp((*encoding)->name, name, name_len) == 0) {
 					return *encoding;
 				}
 			}

--- a/ext/mbstring/libmbfl/mbfl/mbfl_encoding.h
+++ b/ext/mbstring/libmbfl/mbfl/mbfl_encoding.h
@@ -285,6 +285,7 @@ static inline void mb_convert_buf_reset(mb_convert_buf *buf, size_t len)
 }
 
 MBFLAPI extern const mbfl_encoding *mbfl_name2encoding(const char *name);
+MBFLAPI extern const mbfl_encoding *mbfl_name2encoding_ex(const char *name, size_t name_len);
 MBFLAPI extern const mbfl_encoding *mbfl_no2encoding(enum mbfl_no_encoding no_encoding);
 MBFLAPI extern const mbfl_encoding **mbfl_get_supported_encodings(void);
 MBFLAPI extern const char *mbfl_no_encoding2name(enum mbfl_no_encoding no_encoding);

--- a/ext/mbstring/mbstring.c
+++ b/ext/mbstring/mbstring.c
@@ -311,7 +311,6 @@ static zend_result php_mb_parse_encoding_list(const char *value, size_t value_le
 		const char *p1, *endp, *tmpstr;
 		const mbfl_encoding **entry, **list;
 
-		/* copy the value string for work */
 		if (value[0]=='"' && value[value_length-1]=='"' && value_length>2) {
 			tmpstr = value + 1;
 			value_length -= 2;


### PR DESCRIPTION
This brings execution time down from 0.91s to 0.86s on the reference benchmark [1]. (The execution time was measured with this PR on top of my earlier open PR #12712)

[1] https://github.com/php/php-src/issues/12684#issuecomment-1813799924