### PR TITLE
Remove obsolescent AC_TYPE_SIZE_T

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -553,7 +553,6 @@ if test "`uname -s 2>/dev/null`" != "QNX"; then
 fi
 
 dnl Checks for types.
-AC_TYPE_SIZE_T
 AC_TYPE_UID_T
 
 dnl Checks for sockaddr_storage and sockaddr.sa_len.


### PR DESCRIPTION
The macro checks for existence of size_t in <stddef.h> otherwise it sets it to 'unsigned int'. The size_t is part of C89 standard and all platforms should have it. Macro is also marked to be made obsolete in the future versions of Autoconf.

At this point there is still AC_FUNC_ALLOCA in PHP's configure.ac which uses AC_TYPE_SIZE_T under the hood so the check is still done there in the meantime.