### PR TITLE
Make the return type of some stream context related functions true

### DIFF
--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -3320,7 +3320,7 @@ function stream_select(?array &$read, ?array &$write, ?array &$except, ?int $sec
 function stream_context_create(?array $options = null, ?array $params = null) {}
 
 /** @param resource $context */
-function stream_context_set_params($context, array $params): bool {}
+function stream_context_set_params($context, array $params): true {}
 
 /**
  * @param resource $context
@@ -3330,10 +3330,10 @@ function stream_context_set_params($context, array $params): bool {}
 function stream_context_get_params($context): array {}
 
 /** @param resource $context */
-function stream_context_set_option($context, array|string $wrapper_or_options, ?string $option_name = null, mixed $value = UNKNOWN): bool {}
+function stream_context_set_option($context, array|string $wrapper_or_options, ?string $option_name = null, mixed $value = UNKNOWN): true {}
 
 /** @param resource $context */
-function stream_context_set_options($context, array $options): bool {}
+function stream_context_set_options($context, array $options): true {}
 
 /**
  * @param resource $stream_or_context

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: ef14c8ce17c75ee21befd09477934f005eabb1ed */
+ * Stub hash: c9edbe45bb7a2b00b413fb3c56683bb8377a725f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -1826,7 +1826,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_stream_context_create, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 1, "null")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stream_context_set_params, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stream_context_set_params, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_INFO(0, context)
 	ZEND_ARG_TYPE_INFO(0, params, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -1835,14 +1835,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stream_context_get_params, 0, 1,
 	ZEND_ARG_INFO(0, context)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stream_context_set_option, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stream_context_set_option, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_INFO(0, context)
 	ZEND_ARG_TYPE_MASK(0, wrapper_or_options, MAY_BE_ARRAY|MAY_BE_STRING, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, option_name, IS_STRING, 1, "null")
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stream_context_set_options, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stream_context_set_options, 0, 2, IS_TRUE, 0)
 	ZEND_ARG_INFO(0, context)
 	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()

--- a/ext/standard/streamsfuncs.c
+++ b/ext/standard/streamsfuncs.c
@@ -1207,7 +1207,7 @@ PHP_FUNCTION(stream_context_create)
 	context = php_stream_context_alloc();
 
 	if (options) {
-		if (parse_context_options(context, options) === FAILURE) {
+		if (parse_context_options(context, options) == FAILURE) {
 			RETURN_THROWS();
 		}
 	}

--- a/ext/standard/tests/streams/stream_context_create_error.phpt
+++ b/ext/standard/tests/streams/stream_context_create_error.phpt
@@ -2,22 +2,21 @@
 Test the error cases of stream_context_create()
 --FILE--
 <?php
-$arr = [];
 try {
-    stream_context_create($arr);
+    stream_context_create(['ssl' => "abc"]);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
 try {
-    stream_context_create(['ssl' => ['verify_peer'=> false]], ["options" => $arr]);
+    stream_context_create(['ssl' => ['verify_peer'=> false]], ["options" => ['ssl' => "abc"]]);
 } catch (ValueError $exception) {
     echo $exception->getMessage() . "\n";
 }
 
 try {
     stream_context_create(['ssl' => ['verify_peer'=> false]], ["options" => false]);
-} catch (ValueError $exception) {
+} catch (TypeError $exception) {
     echo $exception->getMessage() . "\n";
 }
 ?>

--- a/ext/standard/tests/streams/stream_context_create_error.phpt
+++ b/ext/standard/tests/streams/stream_context_create_error.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test the error cases of stream_context_create()
+--FILE--
+<?php
+$arr = [];
+try {
+    stream_context_create($arr);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    stream_context_create(['ssl' => ['verify_peer'=> false]], ["options" => $arr]);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+
+try {
+    stream_context_create(['ssl' => ['verify_peer'=> false]], ["options" => false]);
+} catch (ValueError $exception) {
+    echo $exception->getMessage() . "\n";
+}
+?>
+--EXPECT--
+Options should have the form ["wrappername"]["optionname"] = $value
+Options should have the form ["wrappername"]["optionname"] = $value
+Invalid stream/context parameter


### PR DESCRIPTION
Before the slight refactoring, it wasn't obvious that the related functions could only return true.