### PR TITLE
Implement overloaded function deprecations for PHP 8.4 - part 1

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -155,6 +155,10 @@ PHP 8.4 UPGRADE NOTES
   . Calling pg_field_is_null() with 2 arguments is deprecated. Use the
     3-parameter signature with a null $row parameter instead.
 
+- Reflection:
+  . Calling ReflectionMethod::__construct() with 1 argument is deprecated.
+    Use ReflectionMethod::createFromMethodName() instead.
+
 ========================================
 5. Changed Functions
 ========================================

--- a/UPGRADING
+++ b/UPGRADING
@@ -136,6 +136,11 @@ PHP 8.4 UPGRADE NOTES
   . Calling intlcal_set() as well as calling IntlCalendar::set() with
     more than 2 arguments is deprecated. Use either IntlCalendar::setDate()
     or IntlCalendar::setDateTime() instead.
+  . Calling intlgregcal_create_instance() as well as calling
+    IntlGregorianCalendar::__construct() with more than 2 arguments is
+    deprecated. Use either IntlGregorianCalendar::createFromDate() or
+    IntlGregorianCalendar::createFromDateTime() instead.
+
 ========================================
 5. Changed Functions
 ========================================

--- a/UPGRADING
+++ b/UPGRADING
@@ -141,6 +141,10 @@ PHP 8.4 UPGRADE NOTES
     deprecated. Use either IntlGregorianCalendar::createFromDate() or
     IntlGregorianCalendar::createFromDateTime() instead.
 
+- LDAP:
+  . Calling ldap_connect() with more than 2 arguments is deprecated. Use
+    ldap_connect_wallet() instead.
+
 ========================================
 5. Changed Functions
 ========================================

--- a/UPGRADING
+++ b/UPGRADING
@@ -132,6 +132,10 @@ PHP 8.4 UPGRADE NOTES
   . Calling DatePeriod::__construct(string $isostr, int $options = 0) is
     deprecated. Use DatePeriod::createFromISO8601String() instead.
 
+- Intl:
+  . Calling intlcal_set() as well as calling IntlCalendar::set() with
+    more than 2 arguments is deprecated. Use either IntlCalendar::setDate()
+    or IntlCalendar::setDateTime() instead.
 ========================================
 5. Changed Functions
 ========================================

--- a/UPGRADING
+++ b/UPGRADING
@@ -147,6 +147,14 @@ PHP 8.4 UPGRADE NOTES
   . Calling ldap_exop() with more than 4 arguments is deprecated. Use
     ldap_exop_sync() instead.
 
+- PgSQL:
+  . Calling pgsql_fetch_result() with 2 arguments is deprecated. Use the
+    3-parameter signature with a null $row parameter instead.
+  . Calling pg_field_prtlen() with 2 arguments is deprecated. Use the
+    3-parameter signature with a null $row parameter instead.
+  . Calling pg_field_is_null() with 2 arguments is deprecated. Use the
+    3-parameter signature with a null $row parameter instead.
+
 ========================================
 5. Changed Functions
 ========================================

--- a/UPGRADING
+++ b/UPGRADING
@@ -128,6 +128,10 @@ PHP 8.4 UPGRADE NOTES
 4. Deprecated Functionality
 ========================================
 
+- Date:
+  . Calling DatePeriod::__construct(string $isostr, int $options = 0) is
+    deprecated. Use DatePeriod::createFromISO8601String() instead.
+
 ========================================
 5. Changed Functions
 ========================================

--- a/UPGRADING
+++ b/UPGRADING
@@ -144,6 +144,8 @@ PHP 8.4 UPGRADE NOTES
 - LDAP:
   . Calling ldap_connect() with more than 2 arguments is deprecated. Use
     ldap_connect_wallet() instead.
+  . Calling ldap_exop() with more than 4 arguments is deprecated. Use
+    ldap_exop_sync() instead.
 
 ========================================
 5. Changed Functions

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -5061,6 +5061,12 @@ PHP_METHOD(DatePeriod, __construct)
 	dpobj->current = NULL;
 
 	if (isostr) {
+		zend_error(E_DEPRECATED, "Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, "
+			"use DatePeriod::createFromISO8601String() instead");
+		if (UNEXPECTED(EG(exception))) {
+			RETURN_THROWS();
+		}
+
 		if (!date_period_init_iso8601_string(dpobj, date_ce_date, isostr, isostr_len, options, &recurrences)) {
 			RETURN_THROWS();
 		}

--- a/ext/date/tests/DatePeriod_IteratorAggregate.phpt
+++ b/ext/date/tests/DatePeriod_IteratorAggregate.phpt
@@ -58,7 +58,8 @@ foreach ($period as $i => $notDate) {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 0: 2012-07-01
 1: 2012-07-08
 2: 2012-07-15
@@ -79,10 +80,14 @@ foreach ($period as $i => $notDate) {
 1: 2012-07-08
 2: 2012-07-15
 
+
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 0: 2012-07-01
 1: 2012-07-08
 2: 2012-07-15
 
+
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 0: 1
 1: 2
 2: 3

--- a/ext/date/tests/DatePeriod_wrong_arguments.phpt
+++ b/ext/date/tests/DatePeriod_wrong_arguments.phpt
@@ -21,9 +21,11 @@ try {
 	echo $e::class, ': ', $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
 OK
 OK
+
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 OK
 OK
 TypeError: DatePeriod::__construct() accepts (DateTimeInterface, DateInterval, int [, int]), or (DateTimeInterface, DateInterval, DateTime [, int]), or (string [, int]) as arguments

--- a/ext/date/tests/bug44562.phpt
+++ b/ext/date/tests/bug44562.phpt
@@ -26,7 +26,8 @@ foreach ( $dp as $d )
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 DateMalformedPeriodStringException: Unknown or bad format (2D)
 DateMalformedPeriodStringException: Unknown or bad format (2D)
 string(24) "2008-07-20T22:44:53+0200"

--- a/ext/date/tests/bug54283.phpt
+++ b/ext/date/tests/bug54283.phpt
@@ -12,4 +12,6 @@ try {
 ?>
 --EXPECTF--
 Deprecated: DatePeriod::__construct(): Passing null to parameter #1 ($start) of type string is deprecated in %s on line %d
+
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 string(24) "Unknown or bad format ()"

--- a/ext/date/tests/date_interval_bad_format_leak.phpt
+++ b/ext/date/tests/date_interval_bad_format_leak.phpt
@@ -34,9 +34,13 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
 DateMalformedIntervalStringException: Unknown or bad format (P3"D)
+
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 DateMalformedPeriodStringException: Unknown or bad format (P3"D)
 DateMalformedPeriodStringException: Unknown or bad format (P3"D)
+
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 DateMalformedPeriodStringException: Unknown or bad format (2008-03-01T12:00:00Z1)
 DateMalformedPeriodStringException: Unknown or bad format (2008-03-01T12:00:00Z1)

--- a/ext/date/tests/date_period_bad_iso_format.phpt
+++ b/ext/date/tests/date_period_bad_iso_format.phpt
@@ -40,10 +40,15 @@ try {
 }
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 DateMalformedPeriodStringException: DatePeriod::__construct(): ISO interval must contain a start date, "R4" given
 DateMalformedPeriodStringException: DatePeriod::createFromISO8601String(): ISO interval must contain a start date, "R4" given
+
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 DateMalformedPeriodStringException: DatePeriod::__construct(): ISO interval must contain an interval, "R4/2012-07-01T00:00:00Z" given
 DateMalformedPeriodStringException: DatePeriod::createFromISO8601String(): ISO interval must contain an interval, "R4/2012-07-01T00:00:00Z" given
+
+Deprecated: Calling DatePeriod::__construct(string $isostr, int $options = 0) is deprecated, use DatePeriod::createFromISO8601String() instead in %s on line %d
 DateMalformedPeriodStringException: DatePeriod::__construct(): Recurrence count must be greater than 0
 DateMalformedPeriodStringException: DatePeriod::createFromISO8601String(): Recurrence count must be greater than 0

--- a/ext/intl/calendar/calendar.stub.php
+++ b/ext/intl/calendar/calendar.stub.php
@@ -316,7 +316,7 @@ class IntlCalendar
 
     /**
      * @return true
-     * @alias intlcal_set
+     * @implementation-alias intlcal_set
      */
     public function set(int $year, int $month, int $dayOfMonth = UNKNOWN, int $hour = UNKNOWN, int $minute = UNKNOWN, int $second = UNKNOWN) {} // TODO make return type void
 

--- a/ext/intl/calendar/calendar_arginfo.h
+++ b/ext/intl/calendar/calendar_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cbb02e588a6954e7e92556e7ce656ea36a05cf3f */
+ * Stub hash: dbd7f8dd82cfdca04988aa791523b29b564347e0 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_IntlCalendar___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()

--- a/ext/intl/calendar/calendar_methods.cpp
+++ b/ext/intl/calendar/calendar_methods.cpp
@@ -377,6 +377,14 @@ U_CFUNC PHP_FUNCTION(intlcal_set)
 
 	int arg_num = ZEND_NUM_ARGS() - (object ? 0 : 1);
 
+	if (object && arg_num > 2) {
+		zend_error(E_DEPRECATED, "Calling IntlCalendar::set() with more than 2 arguments is deprecated, "
+			"use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead");
+		if (UNEXPECTED(EG(exception))) {
+			RETURN_THROWS();
+		}
+	}
+
 	if (zend_parse_method_parameters(
 		ZEND_NUM_ARGS(), object, "Oll|llll",
 		&object, Calendar_ce_ptr, &args[0], &args[1], &args[2], &args[3], &args[4], &args[5]

--- a/ext/intl/calendar/gregoriancalendar_methods.cpp
+++ b/ext/intl/calendar/gregoriancalendar_methods.cpp
@@ -91,6 +91,14 @@ static void _php_intlgregcal_constructor_body(
 	int			variant;
 	intl_error_reset(NULL);
 
+	if (is_constructor && ZEND_NUM_ARGS() > 2) {
+		zend_error(E_DEPRECATED, "Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, "
+			"use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead");
+		if (UNEXPECTED(EG(exception))) {
+			RETURN_THROWS();
+		}
+	}
+
 	// parameter number validation / variant determination
 	if (ZEND_NUM_ARGS() > 6 ||
 			zend_get_parameters_array_ex(ZEND_NUM_ARGS(), args) == FAILURE) {

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -201,6 +201,7 @@ function intlcal_after(IntlCalendar $calendar, IntlCalendar $other): bool {}
 
 function intlcal_before(IntlCalendar $calendar, IntlCalendar $other): bool {}
 
+/** @deprecated */
 function intlcal_set(IntlCalendar $calendar, int $year, int $month, int $dayOfMonth = UNKNOWN, int $hour = UNKNOWN, int $minute = UNKNOWN, int $second = UNKNOWN): true {}
 
 /** @param int|bool $value */

--- a/ext/intl/php_intl.stub.php
+++ b/ext/intl/php_intl.stub.php
@@ -278,6 +278,7 @@ function intlcal_get_error_message(IntlCalendar $calendar): string|false {}
  * @param int $hour
  * @param int $minute
  * @param int $second
+ * @deprecated
  */
 function intlgregcal_create_instance($timezoneOrYear = UNKNOWN, $localeOrMonth = UNKNOWN, $day = UNKNOWN, $hour = UNKNOWN, $minute = UNKNOWN, $second = UNKNOWN): ?IntlGregorianCalendar {}
 

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: c32e74bddb55455f69083a302bcaf52f654b1293 */
+ * Stub hash: 9b71cd87f05bb7644a98c9855afba4742ac6203c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -987,7 +987,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(intlcal_set_time_zone, arginfo_intlcal_set_time_zone)
 	ZEND_FE(intlcal_after, arginfo_intlcal_after)
 	ZEND_FE(intlcal_before, arginfo_intlcal_before)
-	ZEND_FE(intlcal_set, arginfo_intlcal_set)
+	ZEND_DEP_FE(intlcal_set, arginfo_intlcal_set)
 	ZEND_FE(intlcal_roll, arginfo_intlcal_roll)
 	ZEND_FE(intlcal_clear, arginfo_intlcal_clear)
 	ZEND_FE(intlcal_field_difference, arginfo_intlcal_field_difference)

--- a/ext/intl/php_intl_arginfo.h
+++ b/ext/intl/php_intl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9b71cd87f05bb7644a98c9855afba4742ac6203c */
+ * Stub hash: 893419f59d38566a8f6a766829250c18663e339c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_intlcal_create_instance, 0, 0, IntlCalendar, 1)
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(0, timezone, "null")
@@ -1021,7 +1021,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(intlcal_to_date_time, arginfo_intlcal_to_date_time)
 	ZEND_FE(intlcal_get_error_code, arginfo_intlcal_get_error_code)
 	ZEND_FE(intlcal_get_error_message, arginfo_intlcal_get_error_message)
-	ZEND_FE(intlgregcal_create_instance, arginfo_intlgregcal_create_instance)
+	ZEND_DEP_FE(intlgregcal_create_instance, arginfo_intlgregcal_create_instance)
 	ZEND_FE(intlgregcal_set_gregorian_change, arginfo_intlgregcal_set_gregorian_change)
 	ZEND_FE(intlgregcal_get_gregorian_change, arginfo_intlgregcal_get_gregorian_change)
 	ZEND_FE(intlgregcal_is_leap_year, arginfo_intlgregcal_is_leap_year)

--- a/ext/intl/tests/calendar_get_setSkippedWallTimeOption_basic.phpt
+++ b/ext/intl/tests/calendar_get_setSkippedWallTimeOption_basic.phpt
@@ -42,7 +42,8 @@ var_dump(
 
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 int(0)
 Should be 3h30
 int(3)

--- a/ext/intl/tests/calendar_isSet_empty_time.phpt
+++ b/ext/intl/tests/calendar_isSet_empty_time.phpt
@@ -21,7 +21,8 @@ var_dump($intlcal->get(IntlCalendar::FIELD_MINUTE));
 var_dump($intlcal->isSet(IntlCalendar::FIELD_SECOND));
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
 bool(false)
 int(58)
 bool(true)

--- a/ext/intl/tests/calendar_roll_basic.phpt
+++ b/ext/intl/tests/calendar_roll_basic.phpt
@@ -21,10 +21,13 @@ var_dump($intlcal->get(IntlCalendar::FIELD_DAY_OF_MONTH)); //1
 
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 bool(true)
 int(1)
 int(1)
+
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 bool(true)
 int(1)
-int(1)
+int(1)

--- a/ext/intl/tests/calendar_roll_variation1.phpt
+++ b/ext/intl/tests/calendar_roll_variation1.phpt
@@ -20,6 +20,8 @@ var_dump($intlcal->get(IntlCalendar::FIELD_DAY_OF_MONTH)); //28
 
 ?>
 --EXPECTF--
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
+
 Deprecated: IntlCalendar::roll(): Passing bool is deprecated, use 1 or -1 instead in %s on line %d
 bool(true)
 int(1)

--- a/ext/intl/tests/calendar_set_basic.phpt
+++ b/ext/intl/tests/calendar_set_basic.phpt
@@ -16,8 +16,10 @@ var_dump(intlcal_set($intlcal, IntlCalendar::FIELD_DAY_OF_MONTH, 3));
 var_dump($intlcal->get(IntlCalendar::FIELD_DAY_OF_MONTH));
 
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
 int(2)
+
+Deprecated: Function intlcal_set() is deprecated in %s on line %d
 bool(true)
-int(3)
+int(3)

--- a/ext/intl/tests/calendar_set_error.phpt
+++ b/ext/intl/tests/calendar_set_error.phpt
@@ -40,9 +40,16 @@ try {
     echo $e->getMessage() . \PHP_EOL;
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
 IntlCalendar::set() expects at most 6 arguments, 7 given
+
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
 IntlCalendar::set() has no variant with exactly 4 parameters
 IntlCalendar::set(): Argument #1 ($year) must be a valid field
+
+Deprecated: Function intlcal_set() is deprecated in %s on line %d
 intlcal_set(): Argument #2 ($year) must be a valid field
+
+Deprecated: Function intlcal_set() is deprecated in %s on line %d
 intlcal_set(): Argument #1 ($calendar) must be of type IntlCalendar, int given

--- a/ext/intl/tests/calendar_set_variation1.phpt
+++ b/ext/intl/tests/calendar_set_variation1.phpt
@@ -25,13 +25,18 @@ var_dump($intlcal->getTime(),
         strtotime('2012-02-29 23:58:31 +0000') * 1000.);
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
 bool(true)
 float(1330473600000)
 float(1330473600000)
+
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
 bool(true)
 float(1330559880000)
 float(1330559880000)
+
+Deprecated: Calling IntlCalendar::set() with more than 2 arguments is deprecated, use either IntlCalendar::setDate() or IntlCalendar::setDateTime() instead in %s on line %d
 bool(true)
 float(1330559911000)
-float(1330559911000)
+float(1330559911000)

--- a/ext/intl/tests/calendar_toDateTime_basic.phpt
+++ b/ext/intl/tests/calendar_toDateTime_basic.phpt
@@ -15,6 +15,6 @@ $dt = $cal->toDateTime();
 var_dump($dt->format("c"), $dt->getTimeZone()->getName());
 ?>
 --EXPECTF--
-Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated in %s on line %d
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 string(25) "2012-05-17T17:35:36+01:00"
 string(13) "Europe/Lisbon"

--- a/ext/intl/tests/calendar_toDateTime_basic.phpt
+++ b/ext/intl/tests/calendar_toDateTime_basic.phpt
@@ -14,6 +14,7 @@ $dt = $cal->toDateTime();
 
 var_dump($dt->format("c"), $dt->getTimeZone()->getName());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated in %s on line %d
 string(25) "2012-05-17T17:35:36+01:00"
 string(13) "Europe/Lisbon"

--- a/ext/intl/tests/gregoriancalendar___construct_basic.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_basic.phpt
@@ -31,7 +31,8 @@ var_dump($intlcal->getLocale(1));
 
 var_dump($intlcal->getType());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
 string(16) "Europe/Amsterdam"
 string(5) "nl_NL"
 string(13) "Europe/Lisbon"
@@ -40,6 +41,8 @@ string(16) "Europe/Amsterdam"
 string(5) "pt_PT"
 string(13) "Europe/Lisbon"
 string(5) "pt_PT"
+
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 string(12) "Europe/Paris"
 string(5) "fr_CA"
 string(9) "gregorian"

--- a/ext/intl/tests/gregoriancalendar___construct_error.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_error.phpt
@@ -39,10 +39,19 @@ try {
     echo $e->getMessage(), "\n";
 }
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
 Too many arguments
+
+Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
 Too many arguments
+
+Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
 No variant with 4 arguments (excluding trailing NULLs)
+
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 No variant with 4 arguments (excluding trailing NULLs)
+
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 IntlGregorianCalendar::__construct(): Argument #6 ($second) must be of type int, array given
 IntlGregorianCalendar object is already constructed

--- a/ext/intl/tests/gregoriancalendar___construct_variant1.phpt
+++ b/ext/intl/tests/gregoriancalendar___construct_variant1.phpt
@@ -17,10 +17,13 @@ var_dump($intlcal->getTime(), (float)strtotime('2012-02-29 16:07:08') * 1000);
 
 var_dump($intlcal->getType());
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Function intlgregcal_create_instance() is deprecated in %s on line %d
 string(16) "Europe/Amsterdam"
 float(1330527600000)
 float(1330527600000)
+
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 float(1330528028000)
 float(1330528028000)
 string(9) "gregorian"

--- a/ext/intl/tests/msgfmt_format_intlcalendar_variant2.phpt
+++ b/ext/intl/tests/msgfmt_format_intlcalendar_variant2.phpt
@@ -24,5 +24,6 @@ echo "msgf2: ", $msgf->format(array($time, 'date')), " ",
 */
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 Quinta-feira, 17 de Maio de 2012 5:35:36 PM ptlis

--- a/ext/intl/tests/msgfmt_format_intlcalendar_variant3.phpt
+++ b/ext/intl/tests/msgfmt_format_intlcalendar_variant3.phpt
@@ -25,5 +25,6 @@ echo "msgf2: ", $msgf->format(array($time, 'date')), " ",
 */
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 quinta-feira, 17 de Maio de 2012 5:35:36 da tarde ptlis

--- a/ext/intl/tests/msgfmt_format_intlcalendar_variant4.phpt
+++ b/ext/intl/tests/msgfmt_format_intlcalendar_variant4.phpt
@@ -29,5 +29,6 @@ echo "msgf2: ", $msgf->format(array($time, 'date')), " ",
 */
 
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling IntlGregorianCalendar::__construct() with more than 2 arguments is deprecated, use either IntlGregorianCalendar::createFromDate() or IntlGregorianCalendar::createFromDateTime() instead in %s on line %d
 quinta-feira, 17 de maio de 2012 5:35:36 da tarde ptlis

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -3898,6 +3898,13 @@ static void php_ldap_exop(INTERNAL_FUNCTION_PARAMETERS, bool force_sync) {
 	LDAPControl **lserverctrls = NULL;
 	int rc, msgid;
 
+	if (force_sync == false && ZEND_NUM_ARGS() > 4) {
+		zend_error(E_DEPRECATED, "Calling ldap_exop() with more than 4 arguments is deprecated, use ldap_exop_sync() instead");
+		if (UNEXPECTED(EG(exception))) {
+			RETURN_THROWS();
+		}
+	}
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "OS|S!a!zz", &link, ldap_link_ce, &reqoid, &reqdata, &serverctrls, &retdata, &retoid) != SUCCESS) {
 		RETURN_THROWS();
 	}

--- a/ext/ldap/ldap.c
+++ b/ext/ldap/ldap.c
@@ -926,8 +926,11 @@ PHP_FUNCTION(ldap_connect)
 	ldap_linkdata *ld;
 	LDAP *ldap = NULL;
 
-	if (ZEND_NUM_ARGS() == 2) {
-	    zend_error(E_DEPRECATED, "Usage of ldap_connect with two arguments is deprecated");
+	if (ZEND_NUM_ARGS() > 2) {
+	    zend_error(E_DEPRECATED, "Calling ldap_connect() with Oracle-specific arguments is deprecated, "
+			"use ldap_connect_wallet() instead");
+	} else if (ZEND_NUM_ARGS() == 2) {
+		zend_error(E_DEPRECATED, "Usage of ldap_connect with two arguments is deprecated");
 	}
 
 #ifdef HAVE_ORALDAP

--- a/ext/ldap/tests/ldap_exop.phpt
+++ b/ext/ldap/tests/ldap_exop.phpt
@@ -68,6 +68,9 @@ $link = ldap_connect_and_bind($uri, $user, $passwd, $protocol_version);
 remove_dummy_data($link, $base);
 ?>
 --EXPECTF--
+Deprecated: Calling ldap_exop() with more than 4 arguments is deprecated, use ldap_exop_sync() instead in %s on line %d
+
+Deprecated: Calling ldap_exop() with more than 4 arguments is deprecated, use ldap_exop_sync() instead in %s on line %d
 bool(true)
 string(%d) "dn:%s"
 string(0) ""

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -1698,6 +1698,14 @@ PHP_FUNCTION(pg_fetch_result)
 	int pgsql_row;
 
 	if (ZEND_NUM_ARGS() == 2) {
+		if (zend_string_equals_literal(EX(func)->common.function_name, "pg_fetch_result")) {
+			zend_error(E_DEPRECATED, "Calling pg_fetch_result() with 2 arguments is deprecated, "
+				"use the 3-parameter signature with a null $row parameter instead");
+			if (UNEXPECTED(EG(exception))) {
+				RETURN_THROWS();
+			}
+		}
+
 		ZEND_PARSE_PARAMETERS_START(2, 2)
 			Z_PARAM_OBJECT_OF_CLASS(result, pgsql_result_ce)
 			Z_PARAM_STR_OR_LONG(field_name, field_offset)
@@ -2009,6 +2017,15 @@ static void php_pgsql_data_info(INTERNAL_FUNCTION_PARAMETERS, int entry_type, bo
 	int pgsql_row;
 
 	if (ZEND_NUM_ARGS() == 2) {
+		if (nullable_row) {
+			zend_error(E_DEPRECATED, "Calling %s() with 2 arguments is deprecated, "
+				"use the 3-parameter signature with a null $row parameter instead",
+				ZSTR_VAL(EX(func)->common.function_name));
+			if (UNEXPECTED(EG(exception))) {
+				RETURN_THROWS();
+			}
+		}
+
 		ZEND_PARSE_PARAMETERS_START(2, 2)
 			Z_PARAM_OBJECT_OF_CLASS(result, pgsql_result_ce)
 			Z_PARAM_STR_OR_LONG(field_name, field_offset)

--- a/ext/pgsql/tests/03sync_query.phpt
+++ b/ext/pgsql/tests/03sync_query.phpt
@@ -89,21 +89,21 @@ pg_field_name($result, 0);
 pg_field_num($result, "num");
 pg_field_size($result, 0);
 pg_field_type($result, 0);
-pg_field_prtlen($result, 0);
-pg_field_is_null($result, 0);
+pg_field_prtlen($result, null, 0);
+pg_field_is_null($result, null, 0);
 
 try {
-    pg_field_is_null($result, -1);
+    pg_field_is_null($result, null, -1);
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
 try {
-    pg_field_is_null($result, 3);
+    pg_field_is_null($result, null, 3);
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
 try {
-    pg_field_is_null($result, "unknown");
+    pg_field_is_null($result, null, "unknown");
 } catch (ValueError $e) {
     echo $e->getMessage(), "\n";
 }
@@ -151,9 +151,9 @@ Argument #3 must be less than the number of fields for this result set
 Argument #3 must be a field name from this result set
 pg_fetch_all_columns(): Argument #2 ($field) must be greater than or equal to 0
 pg_fetch_all_columns(): Argument #2 ($field) must be less than the number of fields for this result set
-Argument #2 must be greater than or equal to 0
-Argument #2 must be less than the number of fields for this result set
-Argument #2 must be a field name from this result set
+Argument #3 must be greater than or equal to 0
+Argument #3 must be less than the number of fields for this result set
+Argument #3 must be a field name from this result set
 pg_field_name(): Argument #2 ($field) must be greater than or equal to 0
 pg_field_name(): Argument #2 ($field) must be less than the number of fields for this result set
 pg_field_table(): Argument #2 ($field) must be greater than or equal to 0

--- a/ext/pgsql/tests/04async_query.phpt
+++ b/ext/pgsql/tests/04async_query.phpt
@@ -74,5 +74,8 @@ $table_name = "table_04async_query";
 $db = pg_connect($conn_str);
 pg_query($db, "DROP TABLE IF EXISTS {$table_name}");
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling pg_field_prtlen() with 2 arguments is deprecated, use the 3-parameter signature with a null $row parameter instead in %s on line %d
+
+Deprecated: Calling pg_field_is_null() with 2 arguments is deprecated, use the 3-parameter signature with a null $row parameter instead in %s on line %d
 OK

--- a/ext/pgsql/tests/24sync_query_prepared.phpt
+++ b/ext/pgsql/tests/24sync_query_prepared.phpt
@@ -49,8 +49,8 @@ pg_field_name($result, 0);
 pg_field_num($result, "num");
 pg_field_size($result, 0);
 pg_field_type($result, 0);
-pg_field_prtlen($result, 0);
-pg_field_is_null($result, 0);
+pg_field_prtlen($result, null, 0);
+pg_field_is_null($result, null, 0);
 
 $result = pg_prepare($db, "php_test2", "INSERT INTO ".$table_name." VALUES (\$1, \$2);");
 pg_result_error($result);

--- a/ext/pgsql/tests/25async_query_params.phpt
+++ b/ext/pgsql/tests/25async_query_params.phpt
@@ -54,8 +54,8 @@ pg_field_name($result, 0);
 pg_field_num($result, "num");
 pg_field_size($result, 0);
 pg_field_type($result, 0);
-pg_field_prtlen($result, 0);
-pg_field_is_null($result, 0);
+pg_field_prtlen($result, null, 0);
+pg_field_is_null($result, null, 0);
 
 if (!pg_send_query_params($db, "INSERT INTO ".$table_name." VALUES (\$1, \$2);", array(9999, "A'BC")))
 {

--- a/ext/pgsql/tests/26async_query_prepared.phpt
+++ b/ext/pgsql/tests/26async_query_prepared.phpt
@@ -68,8 +68,8 @@ pg_field_name($result, 0);
 pg_field_num($result, "num");
 pg_field_size($result, 0);
 pg_field_type($result, 0);
-pg_field_prtlen($result, 0);
-pg_field_is_null($result, 0);
+pg_field_prtlen($result, null, 0);
+pg_field_is_null($result, null, 0);
 
 if (!pg_send_prepare($db, "php_test2", "INSERT INTO ".$table_name." VALUES (\$1, \$2);"))
 {

--- a/ext/pgsql/tests/30nb_async_query_params.phpt
+++ b/ext/pgsql/tests/30nb_async_query_params.phpt
@@ -55,8 +55,8 @@ pg_field_name($result, 0);
 pg_field_num($result, "num");
 pg_field_size($result, 0);
 pg_field_type($result, 0);
-pg_field_prtlen($result, 0);
-pg_field_is_null($result, 0);
+pg_field_prtlen($result, null, 0);
+pg_field_is_null($result, null, 0);
 
 $sent = pg_send_query_params($db, "INSERT INTO ".$table_name." VALUES (\$1, \$2);", array(9999, "A'BC"));
 

--- a/ext/pgsql/tests/31nb_async_query_prepared.phpt
+++ b/ext/pgsql/tests/31nb_async_query_prepared.phpt
@@ -114,5 +114,8 @@ $table_name = "table_31nb_async_query_prepared";
 $db = pg_connect($conn_str);
 pg_query($db, "DROP TABLE IF EXISTS {$table_name}");
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling pg_field_prtlen() with 2 arguments is deprecated, use the 3-parameter signature with a null $row parameter instead in %s on line %d
+
+Deprecated: Calling pg_field_is_null() with 2 arguments is deprecated, use the 3-parameter signature with a null $row parameter instead in %s on line %d
 OK

--- a/ext/pgsql/tests/bug37100.phpt
+++ b/ext/pgsql/tests/bug37100.phpt
@@ -43,8 +43,11 @@ $table_name = 'table_bug37100';
 $db = pg_connect($conn_str);
 pg_query("DROP TABLE IF EXISTS {$table_name}");
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling pg_fetch_result() with 2 arguments is deprecated, use the 3-parameter signature with a null $row parameter instead in %s on line %d
 string(24) "\001\003\252\000\010\022"
 string(12) "0103aa000812"
+
+Deprecated: Calling pg_fetch_result() with 2 arguments is deprecated, use the 3-parameter signature with a null $row parameter instead in %s on line %d
 int(6)
 string(12) "0103aa000812"

--- a/ext/pgsql/tests/bug76548.phpt
+++ b/ext/pgsql/tests/bug76548.phpt
@@ -12,7 +12,7 @@ $conn = pg_connect($conn_str);
 
 $result = pg_query($conn, 'SELECT v FROM (VALUES (1), (2), (3)) AS t(v)');
 
-while ($value = pg_fetch_result($result, 0)) {
+while ($value = pg_fetch_result($result, null, 0)) {
   var_dump($value); // should be 1, 2 then 3.
 }
 

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3204,6 +3204,14 @@ static void instantiate_reflection_method(INTERNAL_FUNCTION_PARAMETERS, bool is_
 	zend_function *mptr;
 
 	if (is_constructor) {
+		if (ZEND_NUM_ARGS() == 1) {
+			zend_error(E_DEPRECATED, "Calling ReflectionMethod::__construct() with 1 argument is deprecated, "
+				"use ReflectionMethod::createFromMethodName() instead");
+			if (UNEXPECTED(EG(exception))) {
+				RETURN_THROWS();
+			}
+		}
+
 		ZEND_PARSE_PARAMETERS_START(1, 2)
 			Z_PARAM_OBJ_OR_STR(arg1_obj, arg1_str)
 			Z_PARAM_OPTIONAL

--- a/ext/reflection/tests/008.phpt
+++ b/ext/reflection/tests/008.phpt
@@ -32,17 +32,28 @@ foreach ($a as $key=>$val) {
 
 echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 string(90) "ReflectionMethod::__construct(): Argument #1 ($objectOrMethod) must be a valid method name"
 string(91) "ReflectionMethod::createFromMethodName(): Argument #1 ($method) must be a valid method name"
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 string(90) "ReflectionMethod::__construct(): Argument #1 ($objectOrMethod) must be a valid method name"
 string(91) "ReflectionMethod::createFromMethodName(): Argument #1 ($method) must be a valid method name"
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 string(23) "Class "" does not exist"
 string(23) "Class "" does not exist"
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 string(24) "Class "a" does not exist"
 string(24) "Class "a" does not exist"
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 string(23) "Class "" does not exist"
 string(23) "Class "" does not exist"
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 string(24) "Class "a" does not exist"
 string(24) "Class "a" does not exist"
 string(23) "Class "" does not exist"

--- a/ext/reflection/tests/ReflectionMethod_constructor_basic.phpt
+++ b/ext/reflection/tests/ReflectionMethod_constructor_basic.phpt
@@ -10,7 +10,7 @@ class NewCtor {
 
 }
 echo "New-style constructor:\n";
-$methodInfo = new ReflectionMethod("NewCtor::__construct");
+$methodInfo = new ReflectionMethod("NewCtor", "__construct");
 var_dump($methodInfo->isConstructor());
 
 class ExtendsNewCtor extends NewCtor {

--- a/ext/reflection/tests/ReflectionMethod_constructor_error1.phpt
+++ b/ext/reflection/tests/ReflectionMethod_constructor_error1.phpt
@@ -65,11 +65,15 @@ try {
 ?>
 --EXPECTF--
 Wrong type of argument (bool):
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 ReflectionException: ReflectionMethod::__construct(): Argument #1 ($objectOrMethod) must be a valid method name in %s:%d
 Stack trace:
 #0 %s ReflectionMethod->__construct('1')
 #1 {main}
 Wrong type of argument (int):
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 ReflectionException: ReflectionMethod::__construct(): Argument #1 ($objectOrMethod) must be a valid method name in %s:%d
 Stack trace:
 #0 %s ReflectionMethod->__construct('3')
@@ -85,18 +89,26 @@ Stack trace:
 #0 %s ReflectionMethod->__construct('TestClass', '1')
 #1 {main}
 No method given:
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 ReflectionException: ReflectionMethod::__construct(): Argument #1 ($objectOrMethod) must be a valid method name in %s:%d
 Stack trace:
 #0 %s ReflectionMethod->__construct('TestClass')
 #1 {main}
 Class and Method in same string, bad method name:
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 ReflectionException: Method TestClass::foop::dedoop() does not exist in %s:%d
 Stack trace:
 #0 %s ReflectionMethod->__construct('TestClass::foop...')
 #1 {main}
 Class and Method in same string, bad class name:
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d
 ReflectionException: Class "TestCla" does not exist in %s:%d
 Stack trace:
 #0 %s ReflectionMethod->__construct('TestCla::foo')
 #1 {main}
 Class and Method in same string (ok):
+
+Deprecated: Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead in %s on line %d

--- a/ext/reflection/tests/ReflectionMethod_getModifiers_basic.phpt
+++ b/ext/reflection/tests/ReflectionMethod_getModifiers_basic.phpt
@@ -87,7 +87,7 @@ reflectMethodModifiers("DerivedClass");
 reflectMethodModifiers("TestInterface");
 reflectMethodModifiers("AbstractClass");
 
-$a = new ReflectionMethod('ReflectionMethod::getModifiers');
+$a = new ReflectionMethod('ReflectionMethod', 'getModifiers');
 
 echo "ReflectionMethod::getModifiers() modifiers:\n";
 printf("0x%08x\n", $a->getModifiers());

--- a/ext/reflection/tests/ReflectionMethod_getStaticVariables_basic.phpt
+++ b/ext/reflection/tests/ReflectionMethod_getStaticVariables_basic.phpt
@@ -21,19 +21,19 @@ class TestClass {
 }
 
 echo "Public method:\n";
-$methodInfo = new ReflectionMethod('TestClass::foo');
+$methodInfo = new ReflectionMethod('TestClass', 'foo');
 var_dump($methodInfo->getStaticVariables());
 
 echo "\nPrivate method:\n";
-$methodInfo = new ReflectionMethod('TestClass::bar');
+$methodInfo = new ReflectionMethod('TestClass', 'bar');
 var_dump($methodInfo->getStaticVariables());
 
 echo "\nMethod with no static variables:\n";
-$methodInfo = new ReflectionMethod('TestClass::noStatics');
+$methodInfo = new ReflectionMethod('TestClass', 'noStatics');
 var_dump($methodInfo->getStaticVariables());
 
 echo "\nInternal Method:\n";
-$methodInfo = new ReflectionMethod('ReflectionClass::getName');
+$methodInfo = new ReflectionMethod('ReflectionClass', 'getName');
 var_dump($methodInfo->getStaticVariables());
 
 ?>

--- a/ext/reflection/tests/ReflectionMethod_invokeArgs_error3.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invokeArgs_error3.phpt
@@ -35,7 +35,7 @@ $testClassInstance->prop = "Hello";
 
 $foo = new ReflectionMethod($testClassInstance, 'foo');
 $staticMethod = ReflectionMethod::createFromMethodName('TestClass::staticMethod');
-$privateMethod = new ReflectionMethod("TestClass::privateMethod");
+$privateMethod = new ReflectionMethod("TestClass", "privateMethod");
 
 echo "\nNon-instance:\n";
 try {
@@ -52,7 +52,7 @@ echo "\nPrivate method:\n";
 var_dump($privateMethod->invokeArgs($testClassInstance, array()));
 
 echo "\nAbstract method:\n";
-$abstractMethod = new ReflectionMethod("AbstractClass::foo");
+$abstractMethod = new ReflectionMethod("AbstractClass", "foo");
 try {
     $abstractMethod->invokeArgs($testClassInstance, array());
 } catch (ReflectionException $e) {

--- a/ext/reflection/tests/ReflectionMethod_invoke_basic.phpt
+++ b/ext/reflection/tests/ReflectionMethod_invoke_basic.phpt
@@ -40,9 +40,9 @@ abstract class AbstractClass {
 
 $foo = new ReflectionMethod('TestClass', 'foo');
 $methodWithArgs = new ReflectionMethod('TestClass', 'methodWithArgs');
-$staticMethod = new ReflectionMethod('TestClass::staticMethod');
-$privateMethod = new ReflectionMethod("TestClass::privateMethod");
-$methodThatThrows = new ReflectionMethod("TestClass::willThrow");
+$staticMethod = new ReflectionMethod('TestClass', 'staticMethod');
+$privateMethod = new ReflectionMethod('TestClass', 'privateMethod');
+$methodThatThrows = new ReflectionMethod('TestClass', 'willThrow');
 
 $testClassInstance = new TestClass();
 $testClassInstance->prop = "Hello";

--- a/tests/classes/autoload_014.phpt
+++ b/tests/classes/autoload_014.phpt
@@ -8,7 +8,7 @@ spl_autoload_register(function ($name) {
 });
 
 try {
-  new ReflectionMethod("UndefC::test");
+  new ReflectionMethod("UndefC", "test");
 }
 catch (ReflectionException $e) {
   echo $e->getMessage();


### PR DESCRIPTION
Implements https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures for PHP 8.4