### PR TITLE
Fix in-place modification of filename in php_message_handler_for_zend

### DIFF
--- a/Zend/tests/oss_fuzz_64209.phpt
+++ b/Zend/tests/oss_fuzz_64209.phpt
@@ -1,0 +1,15 @@
+--TEST--
+oss-fuzz #64209: Fix in-place modification of filename
+--INI--
+opcache.enable_cli=1
+--FILE--
+<?php
+require '://@';
+?>
+--EXPECTF--
+Warning: require(://@): Failed to open stream: No such file or directory in %s on line %d
+
+Fatal error: Uncaught Error: Failed opening required '://@' (include_path='.:') in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/main/main.c
+++ b/main/main.c
@@ -1600,15 +1600,24 @@ static void php_free_request_globals(void)
 static ZEND_COLD void php_message_handler_for_zend(zend_long message, const void *data)
 {
 	switch (message) {
-		case ZMSG_FAILED_INCLUDE_FOPEN:
-			php_error_docref("function.include", E_WARNING, "Failed opening '%s' for inclusion (include_path='%s')", php_strip_url_passwd((char *) data), STR_PRINT(PG(include_path)));
+		case ZMSG_FAILED_INCLUDE_FOPEN: {
+			char *tmp = estrdup((char *) data);
+			php_error_docref("function.include", E_WARNING, "Failed opening '%s' for inclusion (include_path='%s')", php_strip_url_passwd(tmp), STR_PRINT(PG(include_path)));
+			efree(tmp);
 			break;
-		case ZMSG_FAILED_REQUIRE_FOPEN:
-			zend_throw_error(NULL, "Failed opening required '%s' (include_path='%s')", php_strip_url_passwd((char *) data), STR_PRINT(PG(include_path)));
+		}
+		case ZMSG_FAILED_REQUIRE_FOPEN: {
+			char *tmp = estrdup((char *) data);
+			zend_throw_error(NULL, "Failed opening required '%s' (include_path='%s')", php_strip_url_passwd(tmp), STR_PRINT(PG(include_path)));
+			efree(tmp);
 			break;
-		case ZMSG_FAILED_HIGHLIGHT_FOPEN:
-			php_error_docref(NULL, E_WARNING, "Failed opening '%s' for highlighting", php_strip_url_passwd((char *) data));
+		}
+		case ZMSG_FAILED_HIGHLIGHT_FOPEN: {
+			char *tmp = estrdup((char *) data);
+			php_error_docref(NULL, E_WARNING, "Failed opening '%s' for highlighting", php_strip_url_passwd(tmp));
+			efree(tmp);
 			break;
+		}
 		case ZMSG_MEMORY_LEAK_DETECTED:
 		case ZMSG_MEMORY_LEAK_REPEATED:
 #if ZEND_DEBUG


### PR DESCRIPTION
php_strip_url_passwd modifies url in-place. We cannot assume from php_message_handler_for_zend that data is a temporary, modifiable string.

Fix oss-fuzz #64209