### PR TITLE
Add host_cpu type for FreeBSD

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -29,7 +29,7 @@ if test "$PHP_OPCACHE" != "no"; then
 
   if test "$PHP_OPCACHE_JIT" = "yes"; then
     case $host_cpu in
-      i[[34567]]86*|x86*|aarch64)
+      i[[34567]]86*|x86*|aarch64|amd64)
         ;;
       *)
         AC_MSG_WARN([JIT not supported by host architecture])
@@ -48,7 +48,8 @@ if test "$PHP_OPCACHE" != "no"; then
         DASM_FLAGS="-D X64APPLE=1 -D X64=1"
         DASM_ARCH="x86"
         ;;
-      x86_64*)
+      *x86_64*|amd64-*-freebsd*)
+        IR_TARGET=IR_TARGET_X64
         DASM_FLAGS="-D X64=1"
         DASM_ARCH="x86"
         ;;


### PR DESCRIPTION
In FreeBSD world x86_64 host type is identified as amd64 so add proper checks for FreeBSD amd64 hosts.

(cherry picked from commit 778072ab4fcb34d7b620396621b07a80386c3467)