### PR TITLE
JIT/AArch64: Add code-generation for IR_TRAP

### DIFF
--- a/ext/opcache/jit/ir/ir_aarch64.dasc
+++ b/ext/opcache/jit/ir/ir_aarch64.dasc
@@ -5198,6 +5198,9 @@ void *ir_emit_code(ir_ctx *ctx, size_t *size_ptr)
 				case IR_TLS:
 					ir_emit_tls(ctx, i, insn);
 					break;
+				case IR_TRAP:
+					|	brk;
+					break;
 				default:
 					IR_ASSERT(0 && "NIY rule/instruction");
 					dasm_free(&data.dasm_state);


### PR DESCRIPTION
This adds missing AArch64 code-generation for IR_TRAP. It can help debug JIT-ed code on platforms where GDB is not available, such as Mac M1.

Tested with GDB and LLDB manually.