### PR TITLE
Feature: [pdo_firebird] Transaction management optimization

### DIFF
--- a/ext/pdo/tests/pdo_017.phpt
+++ b/ext/pdo/tests/pdo_017.phpt
@@ -8,7 +8,6 @@ $dir = getenv('REDIR_TEST_DIR');
 if (false == $dir) die('skip no driver');
 require_once $dir . 'pdo_test.inc';
 PDOTest::skip();
-if (str_starts_with(getenv('PDOTEST_DSN'), "firebird")) die('xfail firebird driver does not behave as expected');
 
 $db = PDOTest::factory();
 try {

--- a/ext/pdo_firebird/firebird_statement.c
+++ b/ext/pdo_firebird/firebird_statement.c
@@ -180,8 +180,7 @@ static int pdo_firebird_stmt_execute(pdo_stmt_t *stmt) /* {{{ */
 				;
 		}
 
-		/* commit? */
-		if (stmt->dbh->auto_commit && isc_commit_retaining(H->isc_status, &H->tr)) {
+		if (stmt->dbh->auto_commit && !S->H->in_manually_txn && !php_firebird_commit_transaction(stmt->dbh, /* retain */ true)) {
 			break;
 		}
 

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -66,7 +66,6 @@ typedef struct {
 } pdo_firebird_error_info;
 
 typedef struct {
-
 	/* the result of the last API call */
 	ISC_STATUS isc_status[20];
 
@@ -75,6 +74,7 @@ typedef struct {
 
 	/* the transaction handle */
 	isc_tr_handle tr;
+	bool in_manually_txn;
 
 	/* date and time format strings, can be set by the set_attribute method */
 	char *date_format;
@@ -93,7 +93,6 @@ typedef struct {
 
 
 typedef struct {
-
 	/* the link that owns this statement */
 	pdo_firebird_db_handle *H;
 
@@ -122,7 +121,6 @@ typedef struct {
 
 	/* the output SQLDA */
 	XSQLDA out_sqlda; /* last member */
-
 } pdo_firebird_stmt;
 
 extern const pdo_driver_t pdo_firebird_driver;
@@ -135,6 +133,8 @@ extern void php_firebird_set_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char 
 #define php_firebird_error_stmt(s) php_firebird_set_error(s->dbh, s, NULL, 0, NULL, 0)
 #define php_firebird_error_with_info(d,e,el,m,ml) php_firebird_set_error(d, NULL, e, el, m, ml)
 #define php_firebird_error_stmt_with_info(s,e,el,m,ml) php_firebird_set_error(s->dbh, s, e, el, m, ml)
+
+extern bool php_firebird_commit_transaction(pdo_dbh_t *dbh, bool retain);
 
 enum {
 	PDO_FB_ATTR_DATE_FORMAT = PDO_ATTR_DRIVER_SPECIFIC,

--- a/ext/pdo_firebird/tests/autocommit.phpt
+++ b/ext/pdo_firebird/tests/autocommit.phpt
@@ -1,0 +1,80 @@
+--TEST--
+PDO_Firebird: auto commit
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
+--FILE--
+<?php
+/* Part of the error messages probably vary depending on the version of Firebird,
+ * so it won't check them in detail. */
+
+require("testdb.inc");
+$table = "autocommit_pdo_firebird";
+
+echo "========== in auto commit mode ==========\n";
+echo "auto commit mode ON\n";
+$dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, true);
+
+echo "create table and insert\n";
+$dbh->exec("CREATE TABLE {$table} (val INT)");
+$dbh->exec("INSERT INTO {$table} VALUES (35)");
+
+echo "new connection\n";
+unset($dbh);
+$dbh = new PDO(PDO_FIREBIRD_TEST_DSN, PDO_FIREBIRD_TEST_USER, PDO_FIREBIRD_TEST_PASS);
+
+$r = $dbh->query("SELECT * FROM {$table}");
+var_dump($r->fetchAll());
+
+echo "========== not in auto commit mode ==========\n";
+echo "auto commit mode OFF\n";
+$dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, false);
+
+echo "insert, expect error\n";
+try {
+    $dbh->exec("INSERT INTO {$table} VALUES (35)");
+} catch (PDOException $e) {
+    echo $e->getMessage()."\n\n";
+}
+
+echo "select, expect error\n";
+try {
+    $r = $dbh->query("SELECT * FROM {$table}");
+} catch (PDOException $e) {
+    echo $e->getMessage()."\n\n";
+}
+
+echo "done!";
+?>
+--CLEAN--
+<?php
+require 'testdb.inc';
+@$dbh->exec("DROP TABLE autocommit_pdo_firebird");
+?>
+--EXPECTF--
+========== in auto commit mode ==========
+auto commit mode ON
+create table and insert
+new connection
+array(1) {
+  [0]=>
+  array(2) {
+    ["VAL"]=>
+    int(35)
+    [0]=>
+    int(35)
+  }
+}
+========== not in auto commit mode ==========
+auto commit mode OFF
+insert, expect error
+SQLSTATE[08003]: Connection does not exist: %s
+
+select, expect error
+SQLSTATE[08003]: Connection does not exist: %s
+
+done!

--- a/ext/pdo_firebird/tests/autocommit_change_mode.phpt
+++ b/ext/pdo_firebird/tests/autocommit_change_mode.phpt
@@ -1,0 +1,134 @@
+--TEST--
+PDO_Firebird: change auto commit
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
+--FILE--
+<?php
+require("testdb.inc");
+$dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, true);
+
+echo "========== not in manually transaction ==========\n";
+
+echo "auto commit ON from ON\n";
+$dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, true);
+var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
+echo "Success\n\n";
+
+echo "auto commit OFF from ON\n";
+$dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, false);
+var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
+echo "Success\n\n";
+
+echo "auto commit OFF from OFF\n";
+$dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, false);
+var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
+echo "Success\n\n";
+
+echo "auto commit ON from OFF\n";
+$dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, true);
+var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
+echo "Success\n\n";
+
+echo "========== in manually transaction ==========\n";
+
+echo "begin transaction\n";
+$dbh->beginTransaction();
+echo "\n";
+
+echo "auto commit ON from ON, expect error\n";
+try {
+    $dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, true);
+} catch (PDOException $e) {
+    var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
+    echo $e->getMessage()."\n\n";
+}
+
+echo "auto commit OFF from ON, expect error\n";
+try {
+    $dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, false);
+} catch (PDOException $e) {
+    var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
+    echo $e->getMessage()."\n\n";
+}
+
+echo "end transaction\n";
+$dbh->rollback();
+
+echo "auto commit OFF\n";
+$dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, false);
+
+echo "begin transaction\n";
+$dbh->beginTransaction();
+echo "\n";
+
+echo "auto commit ON from OFF, expect error\n";
+try {
+    $dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, true);
+} catch (PDOException $e) {
+    var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
+    echo $e->getMessage()."\n\n";
+}
+
+echo "auto commit OFF from OFF, expect error\n";
+try {
+    $dbh->setAttribute(PDO::ATTR_AUTOCOMMIT, false);
+} catch (PDOException $e) {
+    var_dump($dbh->getAttribute(PDO::ATTR_AUTOCOMMIT));
+    echo $e->getMessage()."\n\n";
+}
+
+echo "end transaction\n";
+$dbh->rollback();
+echo "\n";
+
+echo "done!";
+?>
+--EXPECT--
+========== not in manually transaction ==========
+auto commit ON from ON
+int(1)
+Success
+
+auto commit OFF from ON
+int(0)
+Success
+
+auto commit OFF from OFF
+int(0)
+Success
+
+auto commit ON from OFF
+int(1)
+Success
+
+========== in manually transaction ==========
+begin transaction
+
+auto commit ON from ON, expect error
+int(1)
+SQLSTATE[HY000]: General error: Cannot change autocommit mode while a transaction is already open
+
+auto commit OFF from ON, expect error
+int(1)
+SQLSTATE[HY000]: General error: Cannot change autocommit mode while a transaction is already open
+
+end transaction
+auto commit OFF
+begin transaction
+
+auto commit ON from OFF, expect error
+int(0)
+SQLSTATE[HY000]: General error: Cannot change autocommit mode while a transaction is already open
+
+auto commit OFF from OFF, expect error
+int(0)
+SQLSTATE[HY000]: General error: Cannot change autocommit mode while a transaction is already open
+
+end transaction
+
+done!

--- a/ext/pdo_firebird/tests/bug_47415.phpt
+++ b/ext/pdo_firebird/tests/bug_47415.phpt
@@ -16,8 +16,6 @@ $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
 $dbh->exec('CREATE TABLE test47415 (idx int NOT NULL PRIMARY KEY, txt VARCHAR(20))');
 $dbh->exec('INSERT INTO test47415 VALUES(0, \'String0\')');
 
-$dbh->commit();
-
 $query = "SELECT idx, txt FROM test47415 ORDER by idx";
 $idx = $txt = 0;
 $stmt = $dbh->prepare($query);
@@ -31,8 +29,6 @@ var_dump($stmt->rowCount());
 
 $stmt = $dbh->prepare('DELETE FROM test47415');
 $stmt->execute();
-
-$dbh->commit();
 
 unset($stmt);
 unset($dbh);

--- a/ext/pdo_firebird/tests/bug_48877.phpt
+++ b/ext/pdo_firebird/tests/bug_48877.phpt
@@ -18,7 +18,6 @@ $dbh->exec('CREATE TABLE test48877 (A integer)');
 $dbh->exec("INSERT INTO test48877 VALUES ('1')");
 $dbh->exec("INSERT INTO test48877 VALUES ('2')");
 $dbh->exec("INSERT INTO test48877 VALUES ('3')");
-$dbh->commit();
 
 $query = "SELECT * FROM test48877 WHERE A = :paramno";
 
@@ -33,7 +32,6 @@ var_dump($stmt->rowCount());
 $stmt = $dbh->prepare('DELETE FROM test48877');
 $stmt->execute();
 
-$dbh->commit();
 unset($stmt);
 unset($dbh);
 

--- a/ext/pdo_firebird/tests/bug_53280.phpt
+++ b/ext/pdo_firebird/tests/bug_53280.phpt
@@ -14,7 +14,6 @@ require("testdb.inc");
 
 $dbh->exec('CREATE TABLE test53280(A VARCHAR(30), B VARCHAR(30), C VARCHAR(30))');
 $dbh->exec("INSERT INTO test53280 VALUES ('A', 'B', 'C')");
-$dbh->commit();
 
 $stmt1 = "SELECT B FROM test53280 WHERE A = ? AND B = ?";
 $stmt2 = "SELECT B, C FROM test53280 WHERE A = ? AND B = ?";
@@ -29,7 +28,6 @@ $stmth1->execute(array('A', 'B'));
 $rows = $stmth1->fetchAll(); // <------- segfault
 var_dump($rows);
 
-$dbh->commit();
 unset($stmth1);
 unset($stmth2);
 unset($stmt);

--- a/ext/pdo_firebird/tests/bug_62024.phpt
+++ b/ext/pdo_firebird/tests/bug_62024.phpt
@@ -15,8 +15,6 @@ require("testdb.inc");
 $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
 $dbh->exec("CREATE TABLE test62024 (ID INTEGER NOT NULL, TEXT VARCHAR(10))");
 
-$dbh->commit();
-
 //start actual test
 
 $sql = "insert into test62024 (id, text) values (?, ?)";
@@ -31,14 +29,10 @@ var_dump($res);
 $res = $sttmt->execute($args_err);
 var_dump($res);
 
-$dbh->commit();
-
 
 //teardown test data
 $sttmt = $dbh->prepare('DELETE FROM test62024');
 $sttmt->execute();
-
-$dbh->commit();
 
 unset($sttmt);
 unset($dbh);

--- a/ext/pdo_firebird/tests/bug_64037.phpt
+++ b/ext/pdo_firebird/tests/bug_64037.phpt
@@ -18,8 +18,6 @@ $dbh->exec("INSERT INTO test64037 (ID, TEXT, COST) VALUES (1, 'test', -1.0)");
 $dbh->exec("INSERT INTO test64037 (ID, TEXT, COST) VALUES (2, 'test', -0.99)");
 $dbh->exec("INSERT INTO test64037 (ID, TEXT, COST) VALUES (3, 'test', -1.01)");
 
-$dbh->commit();
-
 $query = "SELECT * from test64037 order by ID";
 $stmt = $dbh->prepare($query);
 $stmt->execute();
@@ -31,8 +29,6 @@ var_dump($rows[2]['COST']);
 
 $stmt = $dbh->prepare('DELETE FROM test64037');
 $stmt->execute();
-
-$dbh->commit();
 
 unset($stmt);
 unset($dbh);

--- a/ext/pdo_firebird/tests/ddl2.phpt
+++ b/ext/pdo_firebird/tests/ddl2.phpt
@@ -1,0 +1,37 @@
+--TEST--
+PDO_Firebird: DDL/transactions 2
+--EXTENSIONS--
+pdo_firebird
+--SKIPIF--
+<?php require('skipif.inc'); ?>
+--XLEAK--
+A bug in firebird causes a memory leak when calling `isc_attach_database()`.
+See https://github.com/FirebirdSQL/firebird/issues/7849
+--FILE--
+<?php
+require("testdb.inc");
+
+$dbh->exec("CREATE TABLE test_ddl2 (val int)");
+
+$dbh->beginTransaction();
+$dbh->exec("INSERT INTO test_ddl2 (val) VALUES (120)");
+$dbh->exec("CREATE TABLE test_ddl2_2 (val INT)");
+$dbh->rollback();
+
+$result = $dbh->query("SELECT * FROM test_ddl2");
+var_dump($result->fetchAll());
+
+unset($dbh);
+echo "done\n";
+?>
+--CLEAN--
+<?php
+require("testdb.inc");
+$dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+@$dbh->exec('DROP TABLE test_ddl2');
+@$dbh->exec('DROP TABLE test_ddl2_2');
+?>
+--EXPECT--
+array(0) {
+}
+done

--- a/ext/pdo_firebird/tests/payload_test.phpt
+++ b/ext/pdo_firebird/tests/payload_test.phpt
@@ -17,6 +17,9 @@ $dsn = "firebird:dbname=inet://$address/test";
 $username = 'SYSDBA';
 $password = 'masterkey';
 
-new PDO($dsn, $username, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+new PDO($dsn, $username, $password, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_AUTOCOMMIT => false,
+]);
 ?>
 --EXPECT--

--- a/ext/pdo_firebird/tests/rowCount.phpt
+++ b/ext/pdo_firebird/tests/rowCount.phpt
@@ -16,7 +16,6 @@ $dbh->exec('CREATE TABLE test_rowcount (A VARCHAR(10))');
 $dbh->exec("INSERT INTO test_rowcount VALUES ('A')");
 $dbh->exec("INSERT INTO test_rowcount VALUES ('A')");
 $dbh->exec("INSERT INTO test_rowcount VALUES ('B')");
-$dbh->commit();
 
 $query = "SELECT * FROM test_rowcount WHERE A = ?";
 
@@ -30,13 +29,10 @@ var_dump($stmt->rowCount());
 $stmt = $dbh->prepare('UPDATE test_rowcount SET A="A" WHERE A != ?');
 $stmt->execute(array('A'));
 var_dump($stmt->rowCount());
-$dbh->commit();
 
 $stmt = $dbh->prepare('DELETE FROM test_rowcount');
 $stmt->execute();
 var_dump($stmt->rowCount());
-
-$dbh->commit();
 
 unset($stmt);
 unset($dbh);


### PR DESCRIPTION
take2 of #12657

## About Firebird transaction

Firebird is a full transactional database, so the DB itself does not support autocommit mode. (Strictly, there is an autocommit mode, but it is a different concept from the "autocommit" that we are used to with MySQL and others.)

Therefore, a transaction must have started before any operation is performed, and autocommit mode had to be emulated in php.

I made sure that a transaction always exists when in autocommit mode. Since the `in_transacntion` function does not work as expected, I have introduced `H->in_manually_txn` to determine whether a transaction is being manually manipulated.

## There are two types of commit/rollback

(I'm not talking about two-phase commit. This change does not take into account two-phase commit.)

There are `isc_commit_retaining` which starts a transaction again in the same context immediately after committing, and `isc_commit_transaction` which closes the transaction as is.

Similarly, there are two types of rollback.

-----------

Due to the default value of the transaction isolation level, autocommit mode may obtain unintended results.
Regarding this, it would be too large to include support for transaction isolation levels in this PR, so I will leave it as is for now. (I'll address it with the following changes, I'll probably create a PR soon)