### PR TITLE
Reduce parallelism on frequently crashing jobs

### DIFF
--- a/.github/actions/test-linux/action.yml
+++ b/.github/actions/test-linux/action.yml
@@ -9,6 +9,9 @@ inputs:
   jitType:
     default: 'disable'
     required: false
+  idleCpu:
+    default: 'false'
+    required: false
 runs:
   using: composite
   steps:
@@ -36,7 +39,7 @@ runs:
         sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
           -d opcache.jit=${{ inputs.jitType }} \
           -d opcache.jit_buffer_size=16M \
-          -j$(/usr/bin/nproc) \
+          ${{ inputs.idleCpu == 'true' && '-j$(($(/usr/bin/nproc) - 1))' || '-j$(/usr/bin/nproc)' }} \
           -g FAIL,BORK,LEAK,XLEAK \
           --no-progress \
           --offline \

--- a/.github/actions/test-macos/action.yml
+++ b/.github/actions/test-macos/action.yml
@@ -21,7 +21,7 @@ runs:
         sapi/cli/php run-tests.php -P -q ${{ inputs.runTestsParameters }} \
           -d opcache.jit=${{ inputs.jitType }} \
           -d opcache.jit_buffer_size=16M \
-          -j$(sysctl -n hw.ncpu) \
+          -j$(($(sysctl -n hw.ncpu) - 1)) \
           -g FAIL,BORK,LEAK,XLEAK \
           --no-progress \
           --offline \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,6 +82,7 @@ jobs:
           testArtifacts: ${{ matrix.branch.name }}_${{ matrix.name }}_${{ matrix.debug && 'DEBUG' || 'RELEASE' }}_${{ matrix.zts && 'ZTS' || 'NTS' }}
           runTestsParameters: >-
             ${{ matrix.run_tests_parameters }}
+          idleCpu: ${{ matrix.asan && 'true' || 'false' }}
       - name: Test Tracing JIT
         uses: ./.github/actions/test-linux
         with:


### PR DESCRIPTION
Some jobs on GA apparently consume a lot of CPU resources, possibly hindering communication between master and runner. This only seems to happen on Linux+ASAN and macOS. For these jobs, keep one core idle.

This is a blind attempt. I'm not sure if it will work.