### PR TITLE
Refactor: [pdo_firebird] unified function naming

### DIFF
--- a/ext/pdo_firebird/firebird_driver.c
+++ b/ext/pdo_firebird/firebird_driver.c
@@ -844,7 +844,7 @@ static int php_firebird_alloc_prepare_stmt(pdo_dbh_t *dbh, const zend_string *sq
 
 	/* Firebird allows SQL statements up to 64k, so bail if it doesn't fit */
 	if (ZSTR_LEN(sql) > 65536) {
-		strcpy(dbh->error_code, "01004");
+		php_firebird_error_with_info(dbh, "01004", strlen("01004"), NULL, 0);
 		return 0;
 	}
 
@@ -869,7 +869,7 @@ static int php_firebird_alloc_prepare_stmt(pdo_dbh_t *dbh, const zend_string *sq
 	new_sql = emalloc(ZSTR_LEN(sql)+1);
 	new_sql[0] = '\0';
 	if (!php_firebird_preprocess(sql, new_sql, named_params)) {
-		strcpy(dbh->error_code, "07000");
+		php_firebird_error_with_info(dbh, "07000", strlen("07000"), NULL, 0);
 		efree(new_sql);
 		return 0;
 	}

--- a/ext/pdo_firebird/php_pdo_firebird_int.h
+++ b/ext/pdo_firebird/php_pdo_firebird_int.h
@@ -129,12 +129,12 @@ extern const pdo_driver_t pdo_firebird_driver;
 
 extern const struct pdo_stmt_methods firebird_stmt_methods;
 
-extern void _firebird_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *state, const size_t state_len,
+extern void php_firebird_set_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *state, const size_t state_len,
 	const char *msg, const size_t msg_len);
-#define firebird_error(d) _firebird_error(d, NULL, NULL, 0, NULL, 0)
-#define firebird_error_stmt(s) _firebird_error(s->dbh, s, NULL, 0, NULL, 0)
-#define firebird_error_with_info(d,e,el,m,ml) _firebird_error(d, NULL, e, el, m, ml)
-#define firebird_error_stmt_with_info(s,e,el,m,ml) _firebird_error(s->dbh, s, e, el, m, ml)
+#define php_firebird_error(d) php_firebird_set_error(d, NULL, NULL, 0, NULL, 0)
+#define php_firebird_error_stmt(s) php_firebird_set_error(s->dbh, s, NULL, 0, NULL, 0)
+#define php_firebird_error_with_info(d,e,el,m,ml) php_firebird_set_error(d, NULL, e, el, m, ml)
+#define php_firebird_error_stmt_with_info(s,e,el,m,ml) php_firebird_set_error(s->dbh, s, e, el, m, ml)
 
 enum {
 	PDO_FB_ATTR_DATE_FORMAT = PDO_ATTR_DRIVER_SPECIFIC,


### PR DESCRIPTION
`struct pdo_dbh_methods` => Naming convention similar to other PDOs
`struct pdo_stmt_methods` => Naming convention similar to other PDOs
other func => add `php_firebird_` prefix (Omit `firebird` for some things that get too long)

Also, there were still some parts where only the error code was set using `strcpy`, so I fixed it.