### PR TITLE
Fix range inference for UNDEF|NULL operands

### DIFF
--- a/Zend/Optimizer/zend_inference.c
+++ b/Zend/Optimizer/zend_inference.c
@@ -4316,7 +4316,7 @@ static zend_result zend_type_narrowing(const zend_op_array *op_array, const zend
 {
 	uint32_t bitset_len = zend_bitset_len(ssa->vars_count);
 	zend_bitset visited, worklist;
-	int v;
+	int i, v;
 	zend_op *opline;
 	bool narrowed = 0;
 	ALLOCA_FLAG(use_heap)
@@ -4342,6 +4342,11 @@ static zend_result zend_type_narrowing(const zend_op_array *op_array, const zend
 			if (can_convert_to_double(op_array, ssa, v, value, visited)) {
 				narrowed = 1;
 				ssa->var_info[v].use_as_double = 1;
+				/* The "visited" vars are exactly those which may change their type due to
+				 * narrowing. Reset their types and add them to the type inference worklist */
+				ZEND_BITSET_FOREACH(visited, bitset_len, i) {
+					ssa->var_info[i].type |= (MAY_BE_LONG|MAY_BE_DOUBLE);
+				} ZEND_BITSET_FOREACH_END();
 				zend_bitset_union(worklist, visited, bitset_len);
 			}
 		}

--- a/ext/opcache/tests/oss_fuzz_59114.phpt
+++ b/ext/opcache/tests/oss_fuzz_59114.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Incorrect range inference for null|undefined operands
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable_cli=1
+opcache.jit=1205
+opcache.jit_buffer_size=16M
+--FILE--
+<?php
+function test($a){
+    for (; $a < -1;) {
+        42 % ($b = $a + $a);
+    }
+}
+try {
+    test(NULL);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Modulo by zero


### PR DESCRIPTION
Fixes oss-fuzz #59114

Range analysis naively assumes that all operands are integer. This can however lead to incorrect results for non-numeric operands. For example, a PI node resulting from `$a < -1` will contain the [-..-2] range constraint. Since in PHP `null < -1` evaluates to true, this can lead to a cascading effect where `$a + $a` is inferred as [-..-4], whereas the actual result may be 0.

This PR solves this by performing type inference before range inference. This means that we pessimistically assume all arithmetic operations will over- or underflow, adding MAY_BE_DOUBLE. This is fixed by a second pass after range analysis that repeats inference for the relevant opcodes.

Range analysis may now use the available type information to widen the range where necessary.

@dstogov This is just an idea. Please let me know whether you think it makes sense. This might also be relevant for `false`/`true`, I'll verify tomorrow via tests, too tired now. ^^