### PR TITLE
Remove unused PHP_COMPILE and CXX_PHP_COMPILE variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1669,9 +1669,6 @@ PHP_SET_LIBTOOL_VARIABLE([--preserve-dup-deps])
 dnl This needs to be passed explicitly to allow scan-build compiler overrides.
 PHP_SET_LIBTOOL_VARIABLE([--tag CC])
 
-test -z "$PHP_COMPILE" && PHP_COMPILE='$(LIBTOOL) --mode=compile $(COMPILE) -c $<'
-test -z "$CXX_PHP_COMPILE" && CXX_PHP_COMPILE='$(LIBTOOL) --mode=compile $(CXX_COMPILE) -c $<'
-
 CC=$old_CC
 
 PHP_CONFIGURE_PART(Generating files)


### PR DESCRIPTION
These were part of the old build system and are no longer used.