### PR TITLE
Fix date createFromTimestamp test

### DIFF
--- a/ext/date/tests/createFromTimestamp.phpt
+++ b/ext/date/tests/createFromTimestamp.phpt
@@ -9,7 +9,8 @@ class MyDateTime extends DateTime {};
 class MyDateTimeImmutable extends DateTimeImmutable {};
 
 define('MAX_32BIT', 2147483647);
-define('MIN_32BIT', -2147483648);
+// -2147483648 may not be expressed in a literal due to parsing peculiarities.
+define('MIN_32BIT', -2147483647 - 1);
 
 $timestamps = array(
     1696883232,


### PR DESCRIPTION
Unfortuantely, PHP_INT_MIN cannot be expressed as a literal in PHP without overflowing to float, because -NUM is parsed as (-)(NUM). NUM is restricted to PHP_INT_MAX.

/cc @marc-mabe