### PR TITLE
Fixed int32 underflow on DateTime::createFromTimestamp

### DIFF
--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2522,12 +2522,13 @@ PHPAPI void php_date_initialize_from_ts_long(php_date_obj *dateobj, zend_long se
 PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts) /* {{{ */
 {
 	double sec_dval = trunc(ts);
-	zend_long sec;
-	int usec;
+	zend_long sec = (zend_long)sec_dval;
+	int usec = (int)(fmod(ts, 1) * 1000000);
 
 	if (UNEXPECTED(isnan(sec_dval)
-		|| sec_dval >= (double)TIMELIB_LONG_MAX
+		|| sec_dval > (double)TIMELIB_LONG_MAX
 		|| sec_dval < (double)TIMELIB_LONG_MIN
+		|| (sec == TIMELIB_LONG_MIN && usec < 0)
 	)) {
 		zend_throw_error(
 			date_ce_date_range_error,
@@ -2538,9 +2539,6 @@ PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts)
 		);
 		return false;
 	}
-
-	sec = (zend_long)sec_dval;
-	usec = (int)(fmod(ts, 1) * 1000000);
 
 	if (UNEXPECTED(usec < 0)) {
 		sec = sec - 1;

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2522,14 +2522,10 @@ PHPAPI void php_date_initialize_from_ts_long(php_date_obj *dateobj, zend_long se
 PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts) /* {{{ */
 {
 	double sec_dval = trunc(ts);
-	zend_long sec = (zend_long)sec_dval;
-	int usec = (int)(fmod(ts, 1) * 1000000);
+	zend_long sec;
+	int usec;
 
-	if (UNEXPECTED(isnan(sec_dval)
-		|| sec_dval > (double)TIMELIB_LONG_MAX
-		|| sec_dval < (double)TIMELIB_LONG_MIN
-		|| (sec == TIMELIB_LONG_MIN && usec < 0)
-	)) {
+	if (UNEXPECTED(isnan(sec_dval) || !PHP_DATE_DOUBLE_FITS_LONG(sec_dval))) {
 		zend_throw_error(
 			date_ce_date_range_error,
 			"Seconds must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ", %g given",
@@ -2540,7 +2536,21 @@ PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts)
 		return false;
 	}
 
+	sec = (zend_long)sec_dval;
+	usec = (int)(fmod(ts, 1) * 1000000);
+
 	if (UNEXPECTED(usec < 0)) {
+		if (UNEXPECTED(sec == TIMELIB_LONG_MIN)) {
+			zend_throw_error(
+				date_ce_date_range_error,
+				"Seconds must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ", %g given",
+				TIMELIB_LONG_MIN,
+				TIMELIB_LONG_MAX,
+				sec_dval
+			);
+			return false;
+		}
+	
 		sec = sec - 1;
 		usec = 1000000 + usec;
 	}

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2526,9 +2526,10 @@ PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts)
 	int usec;
 
 	if (UNEXPECTED(isnan(sec_dval) || !PHP_DATE_DOUBLE_FITS_LONG(sec_dval))) {
-		zend_throw_error(
+		zend_argument_error(
 			date_ce_date_range_error,
-			"Timestamp must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ".999999, %g given",
+			1,
+			"must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ".999999, %g given",
 			TIMELIB_LONG_MIN,
 			TIMELIB_LONG_MAX,
 			ts
@@ -2541,9 +2542,10 @@ PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts)
 
 	if (UNEXPECTED(usec < 0)) {
 		if (UNEXPECTED(sec == TIMELIB_LONG_MIN)) {
-			zend_throw_error(
+			zend_argument_error(
 				date_ce_date_range_error,
-				"Timestamp must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ".999999, %g given",
+				1,
+				"must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ".999999, %g given",
 				TIMELIB_LONG_MIN,
 				TIMELIB_LONG_MAX,
 				ts

--- a/ext/date/php_date.c
+++ b/ext/date/php_date.c
@@ -2528,10 +2528,10 @@ PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts)
 	if (UNEXPECTED(isnan(sec_dval) || !PHP_DATE_DOUBLE_FITS_LONG(sec_dval))) {
 		zend_throw_error(
 			date_ce_date_range_error,
-			"Seconds must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ", %g given",
+			"Timestamp must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ".999999, %g given",
 			TIMELIB_LONG_MIN,
 			TIMELIB_LONG_MAX,
-			sec_dval
+			ts
 		);
 		return false;
 	}
@@ -2543,14 +2543,14 @@ PHPAPI bool php_date_initialize_from_ts_double(php_date_obj *dateobj, double ts)
 		if (UNEXPECTED(sec == TIMELIB_LONG_MIN)) {
 			zend_throw_error(
 				date_ce_date_range_error,
-				"Seconds must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ", %g given",
+				"Timestamp must be a finite number between " TIMELIB_LONG_FMT " and " TIMELIB_LONG_FMT ".999999, %g given",
 				TIMELIB_LONG_MIN,
 				TIMELIB_LONG_MAX,
-				sec_dval
+				ts
 			);
 			return false;
 		}
-	
+
 		sec = sec - 1;
 		usec = 1000000 + usec;
 	}

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -20,6 +20,23 @@
 #include "lib/timelib.h"
 #include "Zend/zend_hash.h"
 
+/* Same as SIZEOF_ZEND_LONG but using TIMELIB_LONG_MAX/MIN */
+#if TIMELIB_LONG_MAX == 2147483647
+#	define PHP_DATE_SIZEOF_LONG 4
+#elif TIMELIB_LONG_MAX == 9223372036854775807
+#	define PHP_DATE_SIZEOF_LONG 8
+#else
+#	error "Unknown TIMELIB LONG SIZE"
+#endif
+
+/* Same as ZEND_DOUBLE_FITS_LONG but using TIMELIB_LONG_MAX/MIN */
+#if PHP_DATE_SIZEOF_LONG == 4
+#	define PHP_DATE_DOUBLE_FITS_LONG(d) (!((d) > (double)TIMELIB_LONG_MAX || (d) < (double)TIMELIB_LONG_MIN))
+#elif PHP_DATE_SIZEOF_LONG == 8
+	/* >= as (double)TIMELIB_LONG_MAX is outside signed range */
+#	define PHP_DATE_DOUBLE_FITS_LONG(d) (!((d) >= (double)TIMELIB_LONG_MAX || (d) < (double)TIMELIB_LONG_MIN))
+#endif
+
 #include "php_version.h"
 #define PHP_DATE_VERSION PHP_VERSION
 

--- a/ext/date/php_date.h
+++ b/ext/date/php_date.h
@@ -21,20 +21,20 @@
 #include "Zend/zend_hash.h"
 
 /* Same as SIZEOF_ZEND_LONG but using TIMELIB_LONG_MAX/MIN */
-#if TIMELIB_LONG_MAX == 2147483647
-#	define PHP_DATE_SIZEOF_LONG 4
-#elif TIMELIB_LONG_MAX == 9223372036854775807
-#	define PHP_DATE_SIZEOF_LONG 8
+#if TIMELIB_LONG_MAX == INT32_MAX
+# define PHP_DATE_SIZEOF_LONG 4
+#elif TIMELIB_LONG_MAX == INT64_MAX
+# define PHP_DATE_SIZEOF_LONG 8
 #else
-#	error "Unknown TIMELIB LONG SIZE"
+# error "Unknown TIMELIB LONG SIZE"
 #endif
 
 /* Same as ZEND_DOUBLE_FITS_LONG but using TIMELIB_LONG_MAX/MIN */
 #if PHP_DATE_SIZEOF_LONG == 4
-#	define PHP_DATE_DOUBLE_FITS_LONG(d) (!((d) > (double)TIMELIB_LONG_MAX || (d) < (double)TIMELIB_LONG_MIN))
+# define PHP_DATE_DOUBLE_FITS_LONG(d) (!((d) > (double)TIMELIB_LONG_MAX || (d) < (double)TIMELIB_LONG_MIN))
 #elif PHP_DATE_SIZEOF_LONG == 8
-	/* >= as (double)TIMELIB_LONG_MAX is outside signed range */
-#	define PHP_DATE_DOUBLE_FITS_LONG(d) (!((d) >= (double)TIMELIB_LONG_MAX || (d) < (double)TIMELIB_LONG_MIN))
+  /* >= as (double)TIMELIB_LONG_MAX is outside signed range */
+# define PHP_DATE_DOUBLE_FITS_LONG(d) (!((d) >= (double)TIMELIB_LONG_MAX || (d) < (double)TIMELIB_LONG_MIN))
 #endif
 
 #include "php_version.h"

--- a/ext/date/tests/createFromTimestamp.phpt
+++ b/ext/date/tests/createFromTimestamp.phpt
@@ -227,4 +227,3 @@ MyDateTimeImmutable::createFromTimestamp(0): object(MyDateTimeImmutable)#%d (3) 
   ["timezone"]=>
   string(6) "+00:00"
 }
-

--- a/ext/date/tests/createFromTimestamp.phpt
+++ b/ext/date/tests/createFromTimestamp.phpt
@@ -201,16 +201,16 @@ DateTimeImmutable::createFromTimestamp(-0.0): object(DateTimeImmutable)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTime::createFromTimestamp(%f): DateRangeError: Seconds must be a finite number between %i and %i, %f given
-DateTimeImmutable::createFromTimestamp(%f): DateRangeError: Seconds must be a finite number between %i and %i, %f given
-DateTime::createFromTimestamp(%f): DateRangeError: Seconds must be a finite number between %i and %i, %f given
-DateTimeImmutable::createFromTimestamp(%f): DateRangeError: Seconds must be a finite number between %i and %i, %f given
-DateTime::createFromTimestamp(NAN): DateRangeError: Seconds must be a finite number between %i and %i, NAN given
-DateTimeImmutable::createFromTimestamp(NAN): DateRangeError: Seconds must be a finite number between %i and %i, NAN given
-DateTime::createFromTimestamp(INF): DateRangeError: Seconds must be a finite number between %i and %i, INF given
-DateTimeImmutable::createFromTimestamp(INF): DateRangeError: Seconds must be a finite number between %i and %i, INF given
-DateTime::createFromTimestamp(-INF): DateRangeError: Seconds must be a finite number between %i and %i, -INF given
-DateTimeImmutable::createFromTimestamp(-INF): DateRangeError: Seconds must be a finite number between %i and %i, -INF given
+DateTime::createFromTimestamp(%f): DateRangeError: Timestamp must be a finite number between %i and %i.999999, %f given
+DateTimeImmutable::createFromTimestamp(%f): DateRangeError: Timestamp must be a finite number between %i and %i.999999, %f given
+DateTime::createFromTimestamp(%f): DateRangeError: Timestamp must be a finite number between %i and %i.999999, %f given
+DateTimeImmutable::createFromTimestamp(%f): DateRangeError: Timestamp must be a finite number between %i and %i.999999, %f given
+DateTime::createFromTimestamp(NAN): DateRangeError: Timestamp must be a finite number between %i and %i.999999, NAN given
+DateTimeImmutable::createFromTimestamp(NAN): DateRangeError: Timestamp must be a finite number between %i and %i.999999, NAN given
+DateTime::createFromTimestamp(INF): DateRangeError: Timestamp must be a finite number between %i and %i.999999, INF given
+DateTimeImmutable::createFromTimestamp(INF): DateRangeError: Timestamp must be a finite number between %i and %i.999999, INF given
+DateTime::createFromTimestamp(-INF): DateRangeError: Timestamp must be a finite number between %i and %i.999999, -INF given
+DateTimeImmutable::createFromTimestamp(-INF): DateRangeError: Timestamp must be a finite number between %i and %i.999999, -INF given
 MyDateTime::createFromTimestamp(0): object(MyDateTime)#%d (3) {
   ["date"]=>
   string(26) "1970-01-01 00:00:00.000000"

--- a/ext/date/tests/createFromTimestamp.phpt
+++ b/ext/date/tests/createFromTimestamp.phpt
@@ -201,16 +201,16 @@ DateTimeImmutable::createFromTimestamp(-0.0): object(DateTimeImmutable)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTime::createFromTimestamp(%f): DateRangeError: Timestamp must be a finite number between %i and %i.999999, %f given
-DateTimeImmutable::createFromTimestamp(%f): DateRangeError: Timestamp must be a finite number between %i and %i.999999, %f given
-DateTime::createFromTimestamp(%f): DateRangeError: Timestamp must be a finite number between %i and %i.999999, %f given
-DateTimeImmutable::createFromTimestamp(%f): DateRangeError: Timestamp must be a finite number between %i and %i.999999, %f given
-DateTime::createFromTimestamp(NAN): DateRangeError: Timestamp must be a finite number between %i and %i.999999, NAN given
-DateTimeImmutable::createFromTimestamp(NAN): DateRangeError: Timestamp must be a finite number between %i and %i.999999, NAN given
-DateTime::createFromTimestamp(INF): DateRangeError: Timestamp must be a finite number between %i and %i.999999, INF given
-DateTimeImmutable::createFromTimestamp(INF): DateRangeError: Timestamp must be a finite number between %i and %i.999999, INF given
-DateTime::createFromTimestamp(-INF): DateRangeError: Timestamp must be a finite number between %i and %i.999999, -INF given
-DateTimeImmutable::createFromTimestamp(-INF): DateRangeError: Timestamp must be a finite number between %i and %i.999999, -INF given
+DateTime::createFromTimestamp(%f): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, %f given
+DateTimeImmutable::createFromTimestamp(%f): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, %f given
+DateTime::createFromTimestamp(%f): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, %f given
+DateTimeImmutable::createFromTimestamp(%f): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, %f given
+DateTime::createFromTimestamp(NAN): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, NAN given
+DateTimeImmutable::createFromTimestamp(NAN): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, NAN given
+DateTime::createFromTimestamp(INF): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, INF given
+DateTimeImmutable::createFromTimestamp(INF): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, INF given
+DateTime::createFromTimestamp(-INF): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, -INF given
+DateTimeImmutable::createFromTimestamp(-INF): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between %i and %i.999999, -INF given
 MyDateTime::createFromTimestamp(0): object(MyDateTime)#%d (3) {
   ["date"]=>
   string(26) "1970-01-01 00:00:00.000000"

--- a/ext/date/tests/createFromTimestamp.phpt
+++ b/ext/date/tests/createFromTimestamp.phpt
@@ -1,9 +1,5 @@
 --TEST--
 Tests for DateTime[Immutable]::createFromTimestamp
---SKIPIF--
-<?php
-if (PHP_INT_SIZE === 4) die('xfail fails on 32-bit');
-?>
 --INI--
 date.timezone=Europe/London
 --FILE--
@@ -11,10 +7,6 @@ date.timezone=Europe/London
 
 class MyDateTime extends DateTime {};
 class MyDateTimeImmutable extends DateTimeImmutable {};
-
-define('MAX_32BIT', 2147483647);
-// -2147483648 may not be expressed in a literal due to parsing peculiarities.
-define('MIN_32BIT', -2147483647 - 1);
 
 $timestamps = array(
     1696883232,
@@ -26,9 +18,6 @@ $timestamps = array(
     0,
     0.0,
     -0.0,
-    MAX_32BIT,
-    MIN_32BIT,
-    MIN_32BIT - 0.5,
     PHP_INT_MAX + 1024.0,
     PHP_INT_MIN - 1025.0,
     NAN,
@@ -212,54 +201,6 @@ DateTimeImmutable::createFromTimestamp(-0.0): object(DateTimeImmutable)#%d (3) {
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTime::createFromTimestamp(2147483647): object(DateTime)#%d (3) {
-  ["date"]=>
-  string(26) "2038-01-19 03:14:07.000000"
-  ["timezone_type"]=>
-  int(1)
-  ["timezone"]=>
-  string(6) "+00:00"
-}
-DateTimeImmutable::createFromTimestamp(2147483647): object(DateTimeImmutable)#%d (3) {
-  ["date"]=>
-  string(26) "2038-01-19 03:14:07.000000"
-  ["timezone_type"]=>
-  int(1)
-  ["timezone"]=>
-  string(6) "+00:00"
-}
-DateTime::createFromTimestamp(-2147483648): object(DateTime)#%d (3) {
-  ["date"]=>
-  string(26) "1901-12-13 20:45:52.000000"
-  ["timezone_type"]=>
-  int(1)
-  ["timezone"]=>
-  string(6) "+00:00"
-}
-DateTimeImmutable::createFromTimestamp(-2147483648): object(DateTimeImmutable)#%d (3) {
-  ["date"]=>
-  string(26) "1901-12-13 20:45:52.000000"
-  ["timezone_type"]=>
-  int(1)
-  ["timezone"]=>
-  string(6) "+00:00"
-}
-DateTime::createFromTimestamp(-2147483648.5): object(DateTime)#%d (3) {
-  ["date"]=>
-  string(26) "1901-12-13 20:45:51.500000"
-  ["timezone_type"]=>
-  int(1)
-  ["timezone"]=>
-  string(6) "+00:00"
-}
-DateTimeImmutable::createFromTimestamp(-2147483648.5): object(DateTimeImmutable)#%d (3) {
-  ["date"]=>
-  string(26) "1901-12-13 20:45:51.500000"
-  ["timezone_type"]=>
-  int(1)
-  ["timezone"]=>
-  string(6) "+00:00"
-}
 DateTime::createFromTimestamp(%f): DateRangeError: Seconds must be a finite number between %i and %i, %f given
 DateTimeImmutable::createFromTimestamp(%f): DateRangeError: Seconds must be a finite number between %i and %i, %f given
 DateTime::createFromTimestamp(%f): DateRangeError: Seconds must be a finite number between %i and %i, %f given
@@ -286,3 +227,4 @@ MyDateTimeImmutable::createFromTimestamp(0): object(MyDateTimeImmutable)#%d (3) 
   ["timezone"]=>
   string(6) "+00:00"
 }
+

--- a/ext/date/tests/createFromTimestamp_32bit.phpt
+++ b/ext/date/tests/createFromTimestamp_32bit.phpt
@@ -1,0 +1,127 @@
+--TEST--
+Tests for DateTime[Immutable]::createFromTimestamp 32bit variant
+--SKIPIF--
+<?php
+if (PHP_INT_SIZE != 4) die("skip this test is for 32bit platform only");
+?>
+--INI--
+date.timezone=Europe/London
+--FILE--
+<?php
+
+$timestamps = array(
+    PHP_INT_MAX,
+    PHP_INT_MIN,
+    PHP_INT_MAX + 0.5,
+    PHP_INT_MIN + 0.5,
+    PHP_INT_MAX - 0.5,
+    PHP_INT_MIN - 0.5,
+    PHP_INT_MAX + 1024.0,
+    PHP_INT_MIN - 1025.0,
+);
+
+foreach ($timestamps as $ts) {
+    echo 'DateTime::createFromTimestamp(' . var_export($ts, true) . '): ';
+    try {
+        var_dump(DateTime::createFromTimestamp($ts));
+    } catch (Throwable $e) {
+        echo get_class($e) . ': ' . $e->getMessage() . "\n";
+    }
+
+    echo 'DateTimeImmutable::createFromTimestamp(' . var_export($ts, true) . '): ';
+    try {
+        var_dump(DateTimeImmutable::createFromTimestamp($ts));
+    } catch (Throwable $e) {
+        echo get_class($e) . ': ' . $e->getMessage() . "\n";
+    }
+}
+
+?>
+--EXPECTF--
+DateTime::createFromTimestamp(2147483647): object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2038-01-19 03:14:07.000000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(2147483647): object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "2038-01-19 03:14:07.000000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(-2147483647-1): object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "1901-12-13 20:45:52.000000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(-2147483647-1): object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "1901-12-13 20:45:52.000000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(2147483647.5): object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2038-01-19 03:14:07.500000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(2147483647.5): object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "2038-01-19 03:14:07.500000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(-2147483647.5): object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "1901-12-13 20:45:52.500000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(-2147483647.5): object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "1901-12-13 20:45:52.500000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(2147483646.5): object(DateTime)#%d (3) {
+  ["date"]=>
+  string(26) "2038-01-19 03:14:06.500000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTimeImmutable::createFromTimestamp(2147483646.5): object(DateTimeImmutable)#%d (3) {
+  ["date"]=>
+  string(26) "2038-01-19 03:14:06.500000"
+  ["timezone_type"]=>
+  int(1)
+  ["timezone"]=>
+  string(6) "+00:00"
+}
+DateTime::createFromTimestamp(-2147483648.5): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(-2147483648.5): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
+DateTime::createFromTimestamp(2147484671.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, 2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(2147484671.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, 2.14748e+9 given
+DateTime::createFromTimestamp(-2147484673.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(-2147484673.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
+

--- a/ext/date/tests/createFromTimestamp_32bit.phpt
+++ b/ext/date/tests/createFromTimestamp_32bit.phpt
@@ -124,4 +124,3 @@ DateTime::createFromTimestamp(2147484671.0): DateRangeError: Seconds must be a f
 DateTimeImmutable::createFromTimestamp(2147484671.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, 2.14748e+9 given
 DateTime::createFromTimestamp(-2147484673.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
 DateTimeImmutable::createFromTimestamp(-2147484673.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
-

--- a/ext/date/tests/createFromTimestamp_32bit.phpt
+++ b/ext/date/tests/createFromTimestamp_32bit.phpt
@@ -118,9 +118,9 @@ DateTimeImmutable::createFromTimestamp(2147483646.5): object(DateTimeImmutable)#
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTime::createFromTimestamp(-2147483648.5): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
-DateTimeImmutable::createFromTimestamp(-2147483648.5): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
-DateTime::createFromTimestamp(2147484671.0): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, 2.14748e+9 given
-DateTimeImmutable::createFromTimestamp(2147484671.0): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, 2.14748e+9 given
-DateTime::createFromTimestamp(-2147484673.0): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
-DateTimeImmutable::createFromTimestamp(-2147484673.0): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
+DateTime::createFromTimestamp(-2147483648.5): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(-2147483648.5): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
+DateTime::createFromTimestamp(2147484671.0): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between -2147483648 and 2147483647.999999, 2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(2147484671.0): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between -2147483648 and 2147483647.999999, 2.14748e+9 given
+DateTime::createFromTimestamp(-2147484673.0): DateRangeError: DateTime::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(-2147484673.0): DateRangeError: DateTimeImmutable::createFromTimestamp(): Argument #1 ($timestamp) must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given

--- a/ext/date/tests/createFromTimestamp_32bit.phpt
+++ b/ext/date/tests/createFromTimestamp_32bit.phpt
@@ -118,9 +118,9 @@ DateTimeImmutable::createFromTimestamp(2147483646.5): object(DateTimeImmutable)#
   ["timezone"]=>
   string(6) "+00:00"
 }
-DateTime::createFromTimestamp(-2147483648.5): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
-DateTimeImmutable::createFromTimestamp(-2147483648.5): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
-DateTime::createFromTimestamp(2147484671.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, 2.14748e+9 given
-DateTimeImmutable::createFromTimestamp(2147484671.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, 2.14748e+9 given
-DateTime::createFromTimestamp(-2147484673.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
-DateTimeImmutable::createFromTimestamp(-2147484673.0): DateRangeError: Seconds must be a finite number between -2147483648 and 2147483647, -2.14748e+9 given
+DateTime::createFromTimestamp(-2147483648.5): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(-2147483648.5): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
+DateTime::createFromTimestamp(2147484671.0): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, 2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(2147484671.0): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, 2.14748e+9 given
+DateTime::createFromTimestamp(-2147484673.0): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given
+DateTimeImmutable::createFromTimestamp(-2147484673.0): DateRangeError: Timestamp must be a finite number between -2147483648 and 2147483647.999999, -2.14748e+9 given


### PR DESCRIPTION
This fixes an integer underflow on passing `PHP_INT_MIN - 0.X` to `DateTime[Immutable]::createFromTimestamp()`.
This is due to the fact that the fractional part is handled separately ...

```c
	if (UNEXPECTED(usec < 0)) {
		sec = sec - 1;
		usec = 1000000 + usec;
	}
```

PS: `PHP_INT_MAX + 0.X` does not have this issue 

Similar to `ZEND_DOUBLE_FITS_LONG` this is introducing `PHP_DATE_DOUBLE_FITS_LONG` based on `TIMELIB_LONG_MIN/MAX`

/cc @iluuu1994 @derickr