### PR TITLE
Fix GH-12643: Stack limit tests failing on ppc64le

### DIFF
--- a/Zend/tests/stack_limit/stack_limit_001.phpt
+++ b/Zend/tests/stack_limit/stack_limit_001.phpt
@@ -76,7 +76,7 @@ array(4) {
   ["EG(stack_limit)"]=>
   string(%d) "0x%x"
 }
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/stack_limit/stack_limit_002.phpt
+++ b/Zend/tests/stack_limit/stack_limit_002.phpt
@@ -79,7 +79,7 @@ array(4) {
   ["EG(stack_limit)"]=>
   string(%d) "0x%x"
 }
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/stack_limit/stack_limit_003.phpt
+++ b/Zend/tests/stack_limit/stack_limit_003.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=256K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_003.phpt
+++ b/Zend/tests/stack_limit/stack_limit_003.phpt
@@ -61,6 +61,6 @@ array(4) {
   ["EG(stack_limit)"]=>
   string(%d) "0x%x"
 }
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/stack_limit/stack_limit_005.phpt
+++ b/Zend/tests/stack_limit/stack_limit_005.phpt
@@ -65,4 +65,4 @@ $test
 ;
 
 --EXPECTF--
-Fatal error: Maximum call stack size of %d bytes reached during compilation. Try splitting expression in %s on line %d
+Fatal error: Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached during compilation. Try splitting expression in %s on line %d

--- a/Zend/tests/stack_limit/stack_limit_006.phpt
+++ b/Zend/tests/stack_limit/stack_limit_006.phpt
@@ -320,6 +320,6 @@ array(4) {
   ["EG(stack_limit)"]=>
   string(%d) "0x%x"
 }
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Maximum call stack size of %d bytes reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/stack_limit/stack_limit_007.phpt
+++ b/Zend/tests/stack_limit/stack_limit_007.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=256K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_007.phpt
+++ b/Zend/tests/stack_limit/stack_limit_007.phpt
@@ -41,5 +41,5 @@ array(4) {
   ["EG(stack_limit)"]=>
   string(%d) "0x%x"
 }
-Maximum call stack size of %d bytes reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
 Try executed: 1

--- a/Zend/tests/stack_limit/stack_limit_008.phpt
+++ b/Zend/tests/stack_limit/stack_limit_008.phpt
@@ -55,4 +55,4 @@ array(4) {
   string(%d) "0x%x"
 }
 Will throw:
-Maximum call stack size of %d bytes reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/stack_limit/stack_limit_008.phpt
+++ b/Zend/tests/stack_limit/stack_limit_008.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=256K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_011.phpt
+++ b/Zend/tests/stack_limit/stack_limit_011.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=256K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_011.phpt
+++ b/Zend/tests/stack_limit/stack_limit_011.phpt
@@ -48,5 +48,5 @@ array(4) {
   ["EG(stack_limit)"]=>
   string(%d) "0x%x"
 }
-Maximum call stack size of %d bytes reached. Infinite recursion?
-Previous: Maximum call stack size of %d bytes reached. Infinite recursion?
+Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?
+Previous: Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?

--- a/Zend/tests/stack_limit/stack_limit_012.phpt
+++ b/Zend/tests/stack_limit/stack_limit_012.phpt
@@ -7,7 +7,7 @@ if (!function_exists('zend_test_zend_call_stack_get')) die("skip zend_test_zend_
 --EXTENSIONS--
 zend_test
 --INI--
-zend.max_allowed_stack_size=128K
+zend.max_allowed_stack_size=256K
 --FILE--
 <?php
 

--- a/Zend/tests/stack_limit/stack_limit_012.phpt
+++ b/Zend/tests/stack_limit/stack_limit_012.phpt
@@ -38,4 +38,4 @@ array(4) {
   string(%d) "0x%x"
 }
 
-Fatal error: Maximum call stack size of %d bytes reached during compilation. Try splitting expression in %s on line %d
+Fatal error: Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached during compilation. Try splitting expression in %s on line %d

--- a/Zend/tests/stack_limit/stack_limit_013.phpt
+++ b/Zend/tests/stack_limit/stack_limit_013.phpt
@@ -117,4 +117,4 @@ $test = [
 ];
 
 --EXPECTF--
-Fatal error: Maximum call stack size of %d bytes reached during compilation. Try splitting expression in %s on line %d
+Fatal error: Maximum call stack size of %d bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached during compilation. Try splitting expression in %s on line %d

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -103,7 +103,7 @@ static void zend_compile_assign(znode *result, zend_ast *ast);
 zend_never_inline static void zend_stack_limit_error(void)
 {
 	zend_error_noreturn(E_COMPILE_ERROR,
-		"Maximum call stack size of %zu bytes reached during compilation. Try splitting expression",
+		"Maximum call stack size of %zu bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached during compilation. Try splitting expression",
 		(size_t) ((uintptr_t) EG(stack_base) - (uintptr_t) EG(stack_limit)));
 }
 

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -2311,7 +2311,7 @@ static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_use_new_element_for_s
 #ifdef ZEND_CHECK_STACK_LIMIT
 static zend_never_inline ZEND_COLD void ZEND_FASTCALL zend_call_stack_size_error(void)
 {
-	zend_throw_error(NULL, "Maximum call stack size of %zu bytes reached. Infinite recursion?",
+	zend_throw_error(NULL, "Maximum call stack size of %zu bytes (zend.max_allowed_stack_size-zend.reserved_stack_size) reached. Infinite recursion?",
 		(size_t) ((uintptr_t) EG(stack_base) - (uintptr_t) EG(stack_limit)));
 }
 #endif /* ZEND_CHECK_STACK_LIMIT */


### PR DESCRIPTION
Some tests are setting the max_allowed_stack_size too low for ppc64le builds. In this PR I increase the max_allowed_stack_size in these tests, and also clarify the max_allowed_stack_size error message.

Fixes GH-12643