### PR TITLE
Implement GH-12385: flush headers without body when calling flush()

### DIFF
--- a/sapi/cgi/cgi_main.c
+++ b/sapi/cgi/cgi_main.c
@@ -355,11 +355,11 @@ static void sapi_fcgi_flush(void *server_context)
 {
 	fcgi_request *request = (fcgi_request*) server_context;
 
-	if (
-		!parent &&
-		request && !fcgi_flush(request, 0)) {
-
-		php_handle_aborted_connection();
+	if (!parent && request) {
+		sapi_send_headers();
+		if (!fcgi_flush(request, 0)) {
+			php_handle_aborted_connection();
+		}
 	}
 }
 

--- a/sapi/fpm/fpm/fpm_main.c
+++ b/sapi/fpm/fpm/fpm_main.c
@@ -291,8 +291,11 @@ static void sapi_cgibin_flush(void *server_context) /* {{{ */
 	/* fpm has started, let use fcgi instead of stdout */
 	if (fpm_is_running) {
 		fcgi_request *request = (fcgi_request*) server_context;
-		if (!parent && request && !fcgi_flush(request, 0)) {
-			php_handle_aborted_connection();
+		if (!parent && request) {
+			sapi_send_headers();
+			if (!fcgi_flush(request, 0)) {
+				php_handle_aborted_connection();
+			}
 		}
 		return;
 	}

--- a/sapi/fpm/tests/gh12385.phpt
+++ b/sapi/fpm/tests/gh12385.phpt
@@ -1,0 +1,46 @@
+--TEST--
+GH-12385 (flush with fastcgi does not force headers to be sent)
+--SKIPIF--
+<?php
+include "skipif.inc";
+?>
+--FILE--
+<?php
+
+require_once "tester.inc";
+
+$cfg = <<<EOT
+[global]
+error_log = {{FILE:LOG}}
+[unconfined]
+listen = {{ADDR}}
+pm = static
+pm.max_children = 1
+EOT;
+
+$code = <<<PHP
+<?php
+header("X-Test: 12345");
+flush();
+var_dump(headers_sent());
+PHP;
+
+$tester = new FPM\Tester($cfg, $code);
+$tester->start();
+$tester->expectLogStartNotices();
+$response = $tester->request();
+$response->expectHeader("X-Test", "12345");
+$response->expectBody("bool(true)");
+$tester->terminate();
+$tester->expectLogTerminatingNotices();
+$tester->close();
+
+?>
+Done
+--EXPECT--
+Done
+--CLEAN--
+<?php
+require_once "tester.inc";
+FPM\Tester::clean();
+?>


### PR DESCRIPTION
I confirmed in my testing that two FCGI packets will be sent: one for the header and one for the content, which is what is requested.

I did notice however that on my nginx setup only one time it sends HTTP content to my browser.
However, that seems already to be the case with the flush functionality with normal body content. If we have only few bytes to flush then nginx waits for more bytes to send in the TCP packet. When creating a very large header is do see two times nginx sending HTTP data to my browser. I guess this is configurable in some way but just wanted to point out that this might have limited usefulness depending on the configuration.