### PR TITLE
Support neighbouring extension in the ZendMM custom handlers hook in `zend_test`

### DIFF
--- a/ext/zend_test/php_test.h
+++ b/ext/zend_test/php_test.h
@@ -56,8 +56,11 @@ ZEND_BEGIN_MODULE_GLOBALS(zend_test)
 	bool print_stderr_mshutdown;
 	zend_long limit_copy_file_range;
 	int observe_opline_in_zendmm;
-	zend_mm_heap* zend_orig_heap;
-	zend_mm_heap* zend_test_heap;
+	// previous handlers that might have been installed
+	// `USE_ZEND_ALLOC=0` installs custom handlers
+	void* (*zendmm_orig_malloc)(size_t);
+	void (*zendmm_orig_free)(void*);
+	void* (*zendmm_orig_realloc)(void *, size_t);
 	zend_test_fiber *active_fiber;
 	zend_long quantity_value;
 	zend_string *str_test;

--- a/ext/zend_test/tests/opline_dangling.phpt
+++ b/ext/zend_test/tests/opline_dangling.phpt
@@ -4,8 +4,6 @@ possible segfault in `ZEND_BIND_STATIC`
 https://github.com/php/php-src/pull/12758
 --EXTENSIONS--
 zend_test
---ENV--
-USE_ZEND_ALLOC=1
 --INI--
 zend_test.observe_opline_in_zendmm=1
 --FILE--

--- a/ext/zend_test/tests/opline_dangling_02.phpt
+++ b/ext/zend_test/tests/opline_dangling_02.phpt
@@ -2,8 +2,6 @@
 possible segfault in `ZEND_FUNC_GET_ARGS`
 --EXTENSIONS--
 zend_test
---ENV--
-USE_ZEND_ALLOC=1
 --INI--
 zend_test.observe_opline_in_zendmm=1
 --FILE--


### PR DESCRIPTION
This PR will add support for neighouring extensions in the `zend_mm_set_custom_handlers()` hook, as `USE_ZEND_ALLOC=0` technically installs a custom memory handler in the ZendMM and is used for the ASAN tests.

This realtes to #12768 and #12758

As the PHP 8.1 merge window has closed, this targets PHP 8.2