### PR TITLE
Use size_t for string lengths in ext/xml compat layer

### DIFF
--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -311,7 +311,7 @@ _notation_decl_handler(void *user, const xmlChar *notation, const xmlChar *pub_i
 }
 
 static void
-_build_comment(const xmlChar *data, int data_len, xmlChar **comment, int *comment_len)
+_build_comment(const xmlChar *data, size_t data_len, xmlChar **comment, size_t *comment_len)
 {
 	*comment_len = data_len + 7;
 
@@ -330,7 +330,7 @@ _comment_handler(void *user, const xmlChar *comment)
 
 	if (parser->h_default) {
 		xmlChar *d_comment;
-		int      d_comment_len;
+		size_t   d_comment_len;
 
 		_build_comment(comment, xmlStrlen(comment), &d_comment, &d_comment_len);
 		parser->h_default(parser->user, d_comment, d_comment_len);
@@ -339,7 +339,7 @@ _comment_handler(void *user, const xmlChar *comment)
 }
 
 static void
-_build_entity(const xmlChar *name, int len, xmlChar **entity, int *entity_len)
+_build_entity(const xmlChar *name, size_t len, xmlChar **entity, size_t *entity_len)
 {
 	*entity_len = len + 2;
 	*entity = xmlMalloc(*entity_len + 1);
@@ -380,7 +380,7 @@ _get_entity(void *user, const xmlChar *name)
 				/* Predefined entities will expand unless no cdata handler is present */
 				if (parser->h_default && ! (ret && ret->etype == XML_INTERNAL_PREDEFINED_ENTITY && parser->h_cdata)) {
 					xmlChar *entity;
-					int      len;
+					size_t   len;
 
 					_build_entity(name, xmlStrlen(name), &entity, &len);
 					parser->h_default(parser->user, (const xmlChar *) entity, len);

--- a/ext/xml/compat.c
+++ b/ext/xml/compat.c
@@ -332,7 +332,7 @@ _comment_handler(void *user, const xmlChar *comment)
 		xmlChar *d_comment;
 		size_t   d_comment_len;
 
-		_build_comment(comment, xmlStrlen(comment), &d_comment, &d_comment_len);
+		_build_comment(comment, (size_t) xmlStrlen(comment), &d_comment, &d_comment_len);
 		parser->h_default(parser->user, d_comment, d_comment_len);
 		xmlFree(d_comment);
 	}
@@ -382,7 +382,7 @@ _get_entity(void *user, const xmlChar *name)
 					xmlChar *entity;
 					size_t   len;
 
-					_build_entity(name, xmlStrlen(name), &entity, &len);
+					_build_entity(name, (size_t) xmlStrlen(name), &entity, &len);
 					parser->h_default(parser->user, (const xmlChar *) entity, len);
 					xmlFree(entity);
 				} else {


### PR DESCRIPTION
This is _not_ exploitable right now because libxml guarantees right now a maximum string length of 1M bytes. But if that limit were to ever change this could overflow in the future leading to exploits. Again, not exploitable right now, but just making it more future-proof.