### PR TITLE
Zend/zend_atomic.h: fix build for upcoming `gcc-14`

### DIFF
--- a/Zend/zend_atomic.h
+++ b/Zend/zend_atomic.h
@@ -24,6 +24,7 @@
 
 /* Builtins are used to avoid library linkage */
 #if __has_feature(c_atomic)
+#include <stdatomic.h>
 #define	HAVE_C11_ATOMICS 1
 #elif ZEND_GCC_PREREQ(4, 7)
 #define	HAVE_GNUC_ATOMICS 1
@@ -82,18 +83,18 @@ static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, 
 
 #elif defined(HAVE_C11_ATOMICS)
 
-#define ZEND_ATOMIC_BOOL_INIT(obj, desired) __c11_atomic_init(&(obj)->value, (desired))
+#define ZEND_ATOMIC_BOOL_INIT(obj, desired) atomic_init(&(obj)->value, (desired))
 
 static zend_always_inline bool zend_atomic_bool_exchange_ex(zend_atomic_bool *obj, bool desired) {
-	return __c11_atomic_exchange(&obj->value, desired, __ATOMIC_SEQ_CST);
+	return atomic_exchange_explicit(&obj->value, desired, memory_order_seq_cst);
 }
 
 static zend_always_inline bool zend_atomic_bool_load_ex(const zend_atomic_bool *obj) {
-	return __c11_atomic_load(&obj->value, __ATOMIC_SEQ_CST);
+	return atomic_load_explicit(&obj->value, memory_order_seq_cst);
 }
 
 static zend_always_inline void zend_atomic_bool_store_ex(zend_atomic_bool *obj, bool desired) {
-	__c11_atomic_store(&obj->value, desired, __ATOMIC_SEQ_CST);
+	atomic_store_explicit(&obj->value, desired, memory_order_seq_cst);
 }
 
 #elif defined(HAVE_GNUC_ATOMICS)


### PR DESCRIPTION
In https://gcc.gnu.org/PR60512 `gcc-14` implemented `c_atomic` feature and exposed build failure on `php` as:

    /build/php-8.2.13/Zend/zend_atomic.h: In function 'zend_atomic_bool_store_ex':
    /build/php-8.2.13/Zend/zend_atomic.h:96:9: warning: implicit declaration of function '__c11_atomic_store'; did you mean '__atomic_store'? [-Wimplicit-function-declaration]
       96 |         __c11_atomic_store(&obj->value, desired, __ATOMIC_SEQ_CST);
          |         ^~~~~~~~~~~~~~~~~~
          |         __atomic_store
    ...
    ld: /build/php-8.2.13/Zend/zend_atomic.h:96:(.text+0x1301): undefined reference to `__c11_atomic_store'
    ld: /build/php-8.2.13/Zend/zend_atomic.h:96:(.text+0x1e49): undefined reference to `__c11_atomic_store'

As I understand the build failure happens because `php` uses `clang`'s internal functions prefixed with `__c11_*` that implement atomics instead of standard-defined `atomic_*` ones. `gcc` implements ony standard-defined ones.

The change fixes build for me.