### PR TITLE
Make FFI callbacks thread safe

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -937,7 +937,7 @@ static void zend_ffi_callback_hash_dtor(zval *zv) /* {{{ */
 
 static void (*orig_interrupt_function)(zend_execute_data *execute_data);
 
-static void zend_ffi_interrupt_function(zend_execute_data *execute_data){
+static void zend_ffi_interrupt_function(zend_execute_data *execute_data){ /* {{{ */
 	if(!zend_atomic_bool_load_ex(&FFI_G(callback_in_progress))) goto end;
 
 
@@ -1001,8 +1001,9 @@ static void zend_ffi_interrupt_function(zend_execute_data *execute_data){
 		orig_interrupt_function(execute_data);
 	}
 }
+/* }}} */
 
-static void zend_ffi_wait_request_barrier(void){
+static void zend_ffi_wait_request_barrier(void){ /* {{{ */
 	// get lock, first
 	pthread_mutex_lock(&FFI_G(vm_lock));
 	
@@ -1012,6 +1013,7 @@ static void zend_ffi_wait_request_barrier(void){
 		pthread_cond_wait(&FFI_G(vm_ack), &FFI_G(vm_lock));
 	}
 }
+/* }}} */
 
 static void zend_ffi_callback_trampoline(ffi_cif* cif, void* ret, void** args, void* data) /* {{{ */
 {

--- a/ext/ffi/php_ffi.h
+++ b/ext/ffi/php_ffi.h
@@ -47,6 +47,7 @@ ZEND_BEGIN_MODULE_GLOBALS(ffi)
 	/* predefined ffi_types */
 	HashTable types;
 
+	zend_atomic_bool callback_in_progress;
 	pthread_mutex_t vm_lock;
 	pthread_cond_t vm_ack;
 	zend_ffi_call_data callback_data;

--- a/ext/ffi/php_ffi.h
+++ b/ext/ffi/php_ffi.h
@@ -17,6 +17,9 @@
 #ifndef PHP_FFI_H
 #define PHP_FFI_H
 
+#include <ffi.h>
+#include <pthread.h>
+
 extern zend_module_entry ffi_module_entry;
 #define phpext_ffi_ptr &ffi_module_entry
 
@@ -27,6 +30,15 @@ typedef enum _zend_ffi_api_restriction {
 } zend_ffi_api_restriction;
 
 typedef struct _zend_ffi_type  zend_ffi_type;
+typedef struct _zend_ffi_callback_data zend_ffi_callback_data;
+
+
+typedef struct _zend_ffi_call_data {
+	ffi_cif* cif;
+	void* ret;
+	void** args;
+	zend_ffi_callback_data* data;
+} zend_ffi_call_data;
 
 ZEND_BEGIN_MODULE_GLOBALS(ffi)
 	zend_ffi_api_restriction restriction;
@@ -34,6 +46,10 @@ ZEND_BEGIN_MODULE_GLOBALS(ffi)
 
 	/* predefined ffi_types */
 	HashTable types;
+
+	pthread_mutex_t vm_lock;
+	pthread_cond_t vm_ack;
+	zend_ffi_call_data callback_data;
 
 	/* preloading */
 	char *preload;


### PR DESCRIPTION
Makes FFI callbacks work, regardless of the thread they are invoked from

Fixes https://github.com/php/php-src/issues/9214