### PR TITLE
Fix GH-12826: Weird pointers issue in nested loops

### DIFF
--- a/Zend/tests/gh12826.phpt
+++ b/Zend/tests/gh12826.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-12826 (Weird pointers issue in nested loops)
+--FILE--
+<?php
+$test = array(
+  'a' => 1,
+  'b' => 2,
+  'c' => 3,
+  'd' => 4,
+);
+
+unset($test['a']);
+unset($test['b']);
+
+foreach($test as $k => &$v) { // Mind the reference!
+    echo "Pass $k : ";
+
+    foreach($test as $kk => $vv) {
+        echo $test[$kk];
+        if ($kk == $k) $test[$kk] = 0;
+    }
+
+    echo "\n";
+}
+
+unset($v);
+?>
+--EXPECT--
+Pass c : 34
+Pass d : 04

--- a/Zend/zend_hash.c
+++ b/Zend/zend_hash.c
@@ -2407,7 +2407,7 @@ static zend_always_inline uint32_t zend_array_dup_elements(HashTable *source, Ha
 					idx++; p++;
 				}
 			} else {
-				target->nNumUsed = source->nNumOfElements;
+				target->nNumUsed = source->nNumUsed;
 				uint32_t iter_pos = zend_hash_iterators_lower_pos(target, idx);
 
 				while (p != end) {


### PR DESCRIPTION
This regressed in cd53ce838a.
The loop with `zend_hash_iterators_update` hangs forever because `iter_pos` can't advance to `idx`. This is because the `zend_hash_iterators_lower_pos` upper bound is `target->nNumUsed`, but that is set to `source->nNumOfElements`.

https://github.com/php/php-src/blob/e3de478f66b4d3e76aba92100cd77c4bbde07f78/Zend/zend_hash.c#L2419-L2422

https://github.com/php/php-src/blob/e3de478f66b4d3e76aba92100cd77c4bbde07f78/Zend/zend_hash.c#L2410

That means that if there are holes in the array, we still loop over all the buckets but the number of bucket slots will not match. Fix it by changing the assignment.

I'm not entirely sure this is the whole story though.