### PR TITLE
Remove duplicated socket check

### DIFF
--- a/sapi/fpm/config.m4
+++ b/sapi/fpm/config.m4
@@ -9,7 +9,6 @@ AC_DEFUN([AC_FPM_STDLIBS],
 [
   AC_CHECK_FUNCS(clearenv setproctitle setproctitle_fast)
 
-  AC_SEARCH_LIBS(socket, socket)
   AC_SEARCH_LIBS(inet_addr, nsl)
 ])
 


### PR DESCRIPTION
Check is already done in configure.ac using `PHP_CHECK_FUNC(socket, socket, network)`.