### PR TITLE
Fix GH-12838: [SOAP] Temporary WSDL cache files not being deleted

### DIFF
--- a/ext/soap/php_sdl.c
+++ b/ext/soap/php_sdl.c
@@ -2381,7 +2381,9 @@ static void add_sdl_to_cache(const char *fn, const char *uri, time_t t, sdlPtr s
 	/* Make sure that incomplete files (e.g. due to disk space issues, see bug #66150) are not utilised. */
 	if (valid_file) {
 		/* This is allowed to fail, this means that another process was raced to create the file. */
-		(void) VCWD_RENAME(ZSTR_VAL(temp_file_path), fn);
+		if (VCWD_RENAME(ZSTR_VAL(temp_file_path), fn) < 0) {
+			VCWD_UNLINK(ZSTR_VAL(temp_file_path));
+		}
 	}
 
 	smart_str_free(&buf);


### PR DESCRIPTION
If there are two users that can execute the script that caches a WSDL, but the script is owned by a single user, then the caching code will name the cached file with the file owner username and a hash of the uri. When one of the two tries to rename the file created by the other process, this does not work because it has no permission to do so. This then leaves temporary files floating in the temp directory.

To fix the immediate problem, unlink the file after rename has failed. On the long term, this has to be fixed by taking the username of the process instead of the username of the file owner.

Closes #12838.