### PR TITLE
Remove outdated link to PHP introduction in PHP FPM

### DIFF
--- a/sapi/fpm/php-fpm.8.in
+++ b/sapi/fpm/php-fpm.8.in
@@ -186,12 +186,6 @@ For a more or less complete description of PHP look here:
 .P
 .B http://www.php.net/manual/
 .PD 1
-.P
-A nice introduction to PHP by Stig Bakken can be found here:
-.PD 0
-.P
-.B http://www.zend.com/zend/art/intro.php
-.PD 1
 .SH BUGS
 You can view the list of known bugs or report any new bug you
 found at:


### PR DESCRIPTION
I haven't found a working link to the article mentioned in the man page, so I think that linking to only PHP manual would be enough and we can remove this one.