### PR TITLE
Remove ODBCRouter artifacts

### DIFF
--- a/ext/pdo_odbc/config.m4
+++ b/ext/pdo_odbc/config.m4
@@ -59,12 +59,6 @@ if test "$PHP_PDO_ODBC" != "no"; then
         pdo_odbc_def_lib=odbc
         ;;
 
-    ODBCRouter|odbcrouter)
-        pdo_odbc_def_libdir=/usr/$PHP_LIBDIR
-        pdo_odbc_def_incdir=/usr/include
-        pdo_odbc_def_lib=odbcsdk
-        ;;
-
     generic)
         pdo_odbc_def_lib="`echo $PHP_PDO_ODBC | cut -d, -f3`"
         pdo_odbc_def_ldflags="`echo $PHP_PDO_ODBC | cut -d, -f4`"
@@ -94,7 +88,6 @@ if test "$PHP_PDO_ODBC" != "no"; then
   fi
 
   PDO_ODBC_CHECK_HEADER(odbc.h)
-  PDO_ODBC_CHECK_HEADER(odbcsdk.h)
   PDO_ODBC_CHECK_HEADER(iodbc.h)
   PDO_ODBC_CHECK_HEADER(sqlunix.h)
   PDO_ODBC_CHECK_HEADER(sqltypes.h)

--- a/ext/pdo_odbc/php_pdo_odbc_int.h
+++ b/ext/pdo_odbc/php_pdo_odbc_int.h
@@ -91,10 +91,6 @@
 # include <cli0env.h>
 #endif
 
-#ifdef HAVE_ODBCSDK_H
-# include <odbcsdk.h>
-#endif
-
 /* }}} */
 
 /* {{{ Figure out the type for handles */


### PR DESCRIPTION
ODBCRouter flavor in odbc extension(s) was removed in PHP 7.3 via 398be731e67113a860c43564370e3a22af46d2ec.