### PR TITLE
Cleanup internal FTP APIs.

### DIFF
--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -1912,9 +1912,9 @@ static void ftp_ssl_shutdown(ftpbuf_t *ftp, php_socket_t fd, SSL *ssl_handle) {
 /* }}} */
 
 /* {{{ data_close */
-void
-data_close(ftpbuf_t *ftp)
+void data_close(ftpbuf_t *ftp)
 {
+	ZEND_ASSERT(ftp != NULL);
 	databuf_t *data = ftp->data;
 	if (data == NULL) {
 		return;

--- a/ext/ftp/ftp.c
+++ b/ext/ftp/ftp.c
@@ -878,8 +878,6 @@ ftp_get(ftpbuf_t *ftp, php_stream *outstream, const char *path, const size_t pat
 		goto bail;
 	}
 
-	ftp->data = data;
-
 	if (resumepos > 0) {
 		int arg_len = snprintf(arg, sizeof(arg), ZEND_LONG_FMT, resumepos);
 
@@ -973,7 +971,6 @@ ftp_put(ftpbuf_t *ftp, const char *path, const size_t path_len, php_stream *inst
 	if ((data = ftp_getdata(ftp)) == NULL) {
 		goto bail;
 	}
-	ftp->data = data;
 
 	if (startpos > 0) {
 		int arg_len = snprintf(arg, sizeof(arg), ZEND_LONG_FMT, startpos);


### PR DESCRIPTION
[Cleanup internal data_close API](https://github.com/php/php-src/commit/99fbb8a9e3c938f9a822042c6266fe0998ef6942)

This always returns NULL. Also passing in data is not necessary as it is
always equal to ftp->data.

[Remove redundant assignments to ftp->data](https://github.com/php/php-src/commit/f676f0e3aea597dd5876091909a77407d8fd309a)

ftp_getdata() already does this.