### PR TITLE
Fix GH-12854: 8.3 - as final trait-used method does not correctly report visibility in Reflection

### DIFF
--- a/Zend/tests/traits/gh12854.phpt
+++ b/Zend/tests/traits/gh12854.phpt
@@ -8,6 +8,10 @@ trait SimpleTrait
     public function pub() {}
     protected function prot() {}
     private function priv() {}
+
+    public final function final1() {}
+    public final function final2() {}
+    public final function final3() {}
 }
 
 
@@ -17,10 +21,14 @@ class Test
         pub as final;
         prot as final;
         priv as final;
+
+        final1 as private;
+        final2 as protected;
+        final3 as public;
     }
 }
 
-foreach (['pub', 'prot', 'priv'] as $method) {
+foreach (['pub', 'prot', 'priv', 'final1', 'final2', 'final3'] as $method) {
     echo "--- Method: $method ---\n";
     $rm = new ReflectionMethod(Test::class, $method);
     var_dump($rm->isFinal());
@@ -31,6 +39,8 @@ foreach (['pub', 'prot', 'priv'] as $method) {
 
 ?>
 --EXPECTF--
+Warning: Private methods cannot be final as they are never overridden by other classes in %s on line %d
+
 Warning: Private methods cannot be final as they are never overridden by other classes in %s on line %d
 --- Method: pub ---
 bool(true)
@@ -47,3 +57,18 @@ bool(true)
 bool(false)
 bool(false)
 bool(true)
+--- Method: final1 ---
+bool(true)
+bool(false)
+bool(false)
+bool(true)
+--- Method: final2 ---
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+--- Method: final3 ---
+bool(true)
+bool(true)
+bool(false)
+bool(false)

--- a/Zend/tests/traits/gh12854.phpt
+++ b/Zend/tests/traits/gh12854.phpt
@@ -1,0 +1,49 @@
+--TEST--
+GH-12854 (8.3 - as final trait-used method does not correctly report visibility in Reflection)
+--FILE--
+<?php
+
+trait SimpleTrait
+{
+    public function pub() {}
+    protected function prot() {}
+    private function priv() {}
+}
+
+
+class Test
+{
+    use SimpleTrait {
+        pub as final;
+        prot as final;
+        priv as final;
+    }
+}
+
+foreach (['pub', 'prot', 'priv'] as $method) {
+    echo "--- Method: $method ---\n";
+    $rm = new ReflectionMethod(Test::class, $method);
+    var_dump($rm->isFinal());
+    var_dump($rm->isPublic());
+    var_dump($rm->isProtected());
+    var_dump($rm->isPrivate());
+}
+
+?>
+--EXPECTF--
+Warning: Private methods cannot be final as they are never overridden by other classes in %s on line %d
+--- Method: pub ---
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+--- Method: prot ---
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+--- Method: priv ---
+bool(true)
+bool(false)
+bool(false)
+bool(true)


### PR DESCRIPTION
The message `Private methods cannot be final as they are never overridden by other classes` could be improved further here to clarify it comes from traits, but not sure what to put instead...