### PR TITLE
Fix inappropriate assertion for JIT code buffer and code buffer size

### DIFF
--- a/ext/opcache/jit/ir/ir_x86.dasc
+++ b/ext/opcache/jit/ir/ir_x86.dasc
@@ -9747,8 +9747,6 @@ const void *ir_emit_exitgroup(uint32_t first_exit_point, uint32_t exit_points_pe
 	int ret;
 
 	IR_ASSERT(code_buffer);
-	IR_ASSERT(IR_IS_SIGNED_32BIT((char*)exit_addr - (char*)code_buffer));
-	IR_ASSERT(IR_IS_SIGNED_32BIT((char*)exit_addr - ((char*)code_buffer + code_buffer_size)));
 
 	Dst = &dasm_state;
 	dasm_state = NULL;


### PR DESCRIPTION
Hit the following assertion failure when set opcache.jit_buffer_size=32G

/home/lizhen/php-src/ext/opcache/jit/ir/ir_x86.dasc:9386: ir_emit_exitgroup: Assertion `((((intptr_t)((char*)exit_addr - ((char*)code_buffer + code_buffer_size))) <= 0x7fffffff) && (((intptr_t)((char*)exit_addr - ((char*)code_buffer + code_buffer_size))) >= (-2147483647 - 1)))' failed.

Theoretically, if we can't map the JIT buffer into 4G memory, the two assertions will cause false alarm.