### PR TITLE
[sodium] Add AEGIS-128L and AEGIS-256

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -84,6 +84,10 @@ SOAP:
 Sockets:
   . Removed the deprecated inet_ntoa call support. (David Carlier)
 
+Sodium:
+  . Add support for AEGIS-128L and AEGIS-256 (jedisct1)
+  . Enable AES-GCM on aarch64 with the ARM crypto extensions (jedisct1)
+
 Standard:
   . Implement GH-12188 (Indication for the int size in phpinfo()). (timwolla)
   . Partly fix GH-12143 (Incorrect round() result for 0.49999999999999994).

--- a/UPGRADING
+++ b/UPGRADING
@@ -191,6 +191,13 @@ PHP 8.4 UPGRADE NOTES
   . If JIT is enabled, PHP will now exit with a fatal error on startup in case
     of JIT startup initialization issues.
 
+- Sodium:
+  . Added the sodium_crypto_aead_aegis128l_*() and sodium_crypto_aead_aegis256l_*()
+    functions to support the AEGIS family of authenticated encryption algorithms,
+    that was introduced in libsodium 1.0.19.
+  . sodium_crypto_aead_aes256gcm_*() functions are now enabled on aarch64 CPUs
+    with the ARM cryptographic extensions.
+
 ========================================
 7. New Classes and Interfaces
 ========================================

--- a/ext/sodium/libsodium.stub.php
+++ b/ext/sodium/libsodium.stub.php
@@ -40,6 +40,52 @@ const SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES = UNKNOWN;
 const SODIUM_CRYPTO_AEAD_AES256GCM_ABYTES = UNKNOWN;
 #endif
 
+#ifdef crypto_aead_aegis128l_KEYBYTES
+/**
+ * @var int
+ * @cvalue crypto_aead_aegis128l_KEYBYTES
+ */
+const SODIUM_CRYPTO_AEAD_AEGIS128L_KEYBYTES = UNKNOWN;
+/**
+ * @var int
+ * @cvalue crypto_aead_aegis128l_NSECBYTES
+ */
+const SODIUM_CRYPTO_AEAD_AEGIS128L_NSECBYTES = UNKNOWN;
+/**
+ * @var int
+ * @cvalue crypto_aead_aegis128l_NPUBBYTES
+ */
+const SODIUM_CRYPTO_AEAD_AEGIS128L_NPUBBYTES = UNKNOWN;
+/**
+ * @var int
+ * @cvalue crypto_aead_aegis128l_ABYTES
+ */
+const SODIUM_CRYPTO_AEAD_AEGIS128L_ABYTES = UNKNOWN;
+#endif
+
+#ifdef crypto_aead_aegis256_KEYBYTES
+/**
+ * @var int
+ * @cvalue crypto_aead_aegis256_KEYBYTES
+ */
+const SODIUM_CRYPTO_AEAD_AEGIS256_KEYBYTES = UNKNOWN;
+/**
+ * @var int
+ * @cvalue crypto_aead_aegis256_NSECBYTES
+ */
+const SODIUM_CRYPTO_AEAD_AEGIS256_NSECBYTES = UNKNOWN;
+/**
+ * @var int
+ * @cvalue crypto_aead_aegis256_NPUBBYTES
+ */
+const SODIUM_CRYPTO_AEAD_AEGIS256_NPUBBYTES = UNKNOWN;
+/**
+ * @var int
+ * @cvalue crypto_aead_aegis256_ABYTES
+ */
+const SODIUM_CRYPTO_AEAD_AEGIS256_ABYTES = UNKNOWN;
+#endif
+
 /**
  * @var int
  * @cvalue crypto_aead_chacha20poly1305_KEYBYTES
@@ -505,6 +551,22 @@ function sodium_crypto_aead_aes256gcm_decrypt(string $ciphertext, string $additi
 function sodium_crypto_aead_aes256gcm_encrypt(#[\SensitiveParameter] string $message, string $additional_data, string $nonce, #[\SensitiveParameter] string $key): string {}
 
 function sodium_crypto_aead_aes256gcm_keygen(): string {}
+#endif
+
+#ifdef crypto_aead_aegis128l_KEYBYTES
+function sodium_crypto_aead_aegis128l_decrypt(string $ciphertext, string $additional_data, string $nonce, #[\SensitiveParameter] string $key): string|false {}
+
+function sodium_crypto_aead_aegis128l_encrypt(#[\SensitiveParameter] string $message, string $additional_data, string $nonce, #[\SensitiveParameter] string $key): string {}
+
+function sodium_crypto_aead_aegis128l_keygen(): string {}
+#endif
+
+#ifdef crypto_aead_aegis256_KEYBYTES
+function sodium_crypto_aead_aegis256_decrypt(string $ciphertext, string $additional_data, string $nonce, #[\SensitiveParameter] string $key): string|false {}
+
+function sodium_crypto_aead_aegis256_encrypt(#[\SensitiveParameter] string $message, string $additional_data, string $nonce, #[\SensitiveParameter] string $key): string {}
+
+function sodium_crypto_aead_aegis256_keygen(): string {}
 #endif
 
 function sodium_crypto_aead_chacha20poly1305_decrypt(string $ciphertext, string $additional_data, string $nonce, #[\SensitiveParameter] string $key): string|false {}

--- a/ext/sodium/libsodium_arginfo.h
+++ b/ext/sodium/libsodium_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5711a4c90afa943e660fdc5fa15a0e91ae554057 */
+ * Stub hash: 89cbb449ee6146dc8d50ba4bb1e76f83444a2db2 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aes256gcm_is_available, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
@@ -24,6 +24,52 @@ ZEND_END_ARG_INFO()
 
 #if defined(HAVE_AESGCM)
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aes256gcm_keygen, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sodium_crypto_aead_aegis128l_decrypt, 0, 4, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, ciphertext, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, additional_data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aegis128l_encrypt, 0, 4, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, additional_data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aegis128l_keygen, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if defined(crypto_aead_aegis256_KEYBYTES)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sodium_crypto_aead_aegis256_decrypt, 0, 4, MAY_BE_STRING|MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, ciphertext, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, additional_data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if defined(crypto_aead_aegis256_KEYBYTES)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aegis256_encrypt, 0, 4, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, additional_data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, nonce, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+#if defined(crypto_aead_aegis256_KEYBYTES)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_sodium_crypto_aead_aegis256_keygen, 0, 0, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -516,6 +562,24 @@ ZEND_FUNCTION(sodium_crypto_aead_aes256gcm_encrypt);
 #if defined(HAVE_AESGCM)
 ZEND_FUNCTION(sodium_crypto_aead_aes256gcm_keygen);
 #endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+ZEND_FUNCTION(sodium_crypto_aead_aegis128l_decrypt);
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+ZEND_FUNCTION(sodium_crypto_aead_aegis128l_encrypt);
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+ZEND_FUNCTION(sodium_crypto_aead_aegis128l_keygen);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+ZEND_FUNCTION(sodium_crypto_aead_aegis256_decrypt);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+ZEND_FUNCTION(sodium_crypto_aead_aegis256_encrypt);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+ZEND_FUNCTION(sodium_crypto_aead_aegis256_keygen);
+#endif
 ZEND_FUNCTION(sodium_crypto_aead_chacha20poly1305_decrypt);
 ZEND_FUNCTION(sodium_crypto_aead_chacha20poly1305_encrypt);
 ZEND_FUNCTION(sodium_crypto_aead_chacha20poly1305_keygen);
@@ -701,6 +765,24 @@ static const zend_function_entry ext_functions[] = {
 #endif
 #if defined(HAVE_AESGCM)
 	ZEND_FE(sodium_crypto_aead_aes256gcm_keygen, arginfo_sodium_crypto_aead_aes256gcm_keygen)
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+	ZEND_FE(sodium_crypto_aead_aegis128l_decrypt, arginfo_sodium_crypto_aead_aegis128l_decrypt)
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+	ZEND_FE(sodium_crypto_aead_aegis128l_encrypt, arginfo_sodium_crypto_aead_aegis128l_encrypt)
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+	ZEND_FE(sodium_crypto_aead_aegis128l_keygen, arginfo_sodium_crypto_aead_aegis128l_keygen)
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+	ZEND_FE(sodium_crypto_aead_aegis256_decrypt, arginfo_sodium_crypto_aead_aegis256_decrypt)
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+	ZEND_FE(sodium_crypto_aead_aegis256_encrypt, arginfo_sodium_crypto_aead_aegis256_encrypt)
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+	ZEND_FE(sodium_crypto_aead_aegis256_keygen, arginfo_sodium_crypto_aead_aegis256_keygen)
 #endif
 	ZEND_FE(sodium_crypto_aead_chacha20poly1305_decrypt, arginfo_sodium_crypto_aead_chacha20poly1305_decrypt)
 	ZEND_FE(sodium_crypto_aead_chacha20poly1305_encrypt, arginfo_sodium_crypto_aead_chacha20poly1305_encrypt)
@@ -901,6 +983,30 @@ static void register_libsodium_symbols(int module_number)
 #if defined(HAVE_AESGCM)
 	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AES256GCM_ABYTES", crypto_aead_aes256gcm_ABYTES, CONST_PERSISTENT);
 #endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AEGIS128L_KEYBYTES", crypto_aead_aegis128l_KEYBYTES, CONST_PERSISTENT);
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AEGIS128L_NSECBYTES", crypto_aead_aegis128l_NSECBYTES, CONST_PERSISTENT);
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AEGIS128L_NPUBBYTES", crypto_aead_aegis128l_NPUBBYTES, CONST_PERSISTENT);
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AEGIS128L_ABYTES", crypto_aead_aegis128l_ABYTES, CONST_PERSISTENT);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AEGIS256_KEYBYTES", crypto_aead_aegis256_KEYBYTES, CONST_PERSISTENT);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AEGIS256_NSECBYTES", crypto_aead_aegis256_NSECBYTES, CONST_PERSISTENT);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AEGIS256_NPUBBYTES", crypto_aead_aegis256_NPUBBYTES, CONST_PERSISTENT);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_AEGIS256_ABYTES", crypto_aead_aegis256_ABYTES, CONST_PERSISTENT);
+#endif
 	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES", crypto_aead_chacha20poly1305_KEYBYTES, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_NSECBYTES", crypto_aead_chacha20poly1305_NSECBYTES, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_NPUBBYTES", crypto_aead_chacha20poly1305_NPUBBYTES, CONST_PERSISTENT);
@@ -1080,6 +1186,26 @@ static void register_libsodium_symbols(int module_number)
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aes256gcm_encrypt", sizeof("sodium_crypto_aead_aes256gcm_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_decrypt", sizeof("sodium_crypto_aead_aegis128l_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#endif
+#if defined(crypto_aead_aegis128l_KEYBYTES)
+
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_encrypt", sizeof("sodium_crypto_aead_aegis128l_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis128l_encrypt", sizeof("sodium_crypto_aead_aegis128l_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_decrypt", sizeof("sodium_crypto_aead_aegis256_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+#endif
+#if defined(crypto_aead_aegis256_KEYBYTES)
+
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_encrypt", sizeof("sodium_crypto_aead_aegis256_encrypt") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_aegis256_encrypt", sizeof("sodium_crypto_aead_aegis256_encrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
 #endif
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(CG(function_table), "sodium_crypto_aead_chacha20poly1305_decrypt", sizeof("sodium_crypto_aead_chacha20poly1305_decrypt") - 1), 3, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);

--- a/ext/sodium/tests/crypto_aead.phpt
+++ b/ext/sodium/tests/crypto_aead.phpt
@@ -5,6 +5,8 @@ sodium
 --SKIPIF--
 <?php
 if (!defined('SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES')) print "skip libsodium without AESGCM";
+if (!defined('SODIUM_CRYPTO_AEAD_AEGIS128L_NPUBBYTES')) print "skip libsodium without AEGIS-128L";
+if (!defined('SODIUM_CRYPTO_AEAD_AEGIS256_NPUBBYTES')) print "skip libsodium without AEGIS-256";
 ?>
 --FILE--
 <?php
@@ -111,6 +113,58 @@ if (sodium_crypto_aead_aes256gcm_is_available()) {
     var_dump(false);
     var_dump(true);
 }
+
+echo "aead_aegis128l:\n";
+
+if (defined('SODIUM_CRYPTO_AEAD_AEGIS128L_NPUBBYTES')) {
+    $msg = random_bytes(random_int(1, 1000));
+    $nonce = random_bytes(SODIUM_CRYPTO_AEAD_AEGIS128L_NPUBBYTES);
+    $ad = random_bytes(random_int(1, 1000));
+    $key = sodium_crypto_aead_aegis128l_keygen();
+    $ciphertext = sodium_crypto_aead_aegis128l_encrypt($msg, $ad, $nonce, $key);
+    $msg2 = sodium_crypto_aead_aegis128l_decrypt($ciphertext, $ad, $nonce, $key);
+    var_dump($ciphertext !== $msg);
+    var_dump($msg === $msg2);
+    var_dump(sodium_crypto_aead_aegis128l_decrypt($ciphertext, 'x' . $ad, $nonce, $key));
+    try {
+        // Switched order
+        $msg2 = sodium_crypto_aead_aegis128l_decrypt($ciphertext, $ad, $key, $nonce);
+        var_dump(false);
+    } catch (SodiumException $ex) {
+        var_dump(true);
+    }
+} else {
+    var_dump(true);
+    var_dump(true);
+    var_dump(false);
+    var_dump(false);
+}
+
+echo "aead_aegis256:\n";
+
+if (defined('SODIUM_CRYPTO_AEAD_AEGIS256_NPUBBYTES')) {
+    $msg = random_bytes(random_int(1, 1000));
+    $nonce = random_bytes(SODIUM_CRYPTO_AEAD_AEGIS256_NPUBBYTES);
+    $ad = random_bytes(random_int(1, 1000));
+    $key = sodium_crypto_aead_aegis256_keygen();
+    $ciphertext = sodium_crypto_aead_aegis256_encrypt($msg, $ad, $nonce, $key);
+    $msg2 = sodium_crypto_aead_aegis256_decrypt($ciphertext, $ad, $nonce, $key);
+    var_dump($ciphertext !== $msg);
+    var_dump($msg === $msg2);
+    var_dump(sodium_crypto_aead_aegis256_decrypt($ciphertext, 'x' . $ad, $nonce, $key));
+    try {
+        // Switched order
+        $msg2 = sodium_crypto_aead_aegis256_decrypt($ciphertext, $ad, $key, $nonce);
+        var_dump(false);
+    } catch (SodiumException $ex) {
+        var_dump(true);
+    }
+} else {
+    var_dump(true);
+    var_dump(true);
+    var_dump(false);
+    var_dump(false);
+}
 ?>
 --EXPECT--
 aead_chacha20poly1305:
@@ -133,3 +187,13 @@ bool(true)
 bool(true)
 bool(false)
 bool(true)
+aead_aegis128l:
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+aead_aegis256:
+bool(true)
+bool(true)
+bool(false)
+bool(false)


### PR DESCRIPTION
Also don't prevent usage of AES-GCM on aarch64, it's been supported since libsodium 1.0.18.

Fixes #12312