### PR TITLE
Fix GH-12727: NumberFormatter constructor throws an exception on

### DIFF
--- a/ext/intl/dateformat/dateformat_create.cpp
+++ b/ext/intl/dateformat/dateformat_create.cpp
@@ -113,7 +113,8 @@ static zend_result datefmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handlin
 	locale = Locale::createFromName(locale_str);
 	/* get*Name accessors being set does not preclude being bogus */
 	if (locale.isBogus() || strlen(locale.getISO3Language()) == 0) {
-		goto error;
+        zend_argument_value_error(1, "\"%s\" is invalid", locale_str);
+		return FAILURE;
 	}
 
 	/* process calendar */

--- a/ext/intl/formatter/formatter_main.c
+++ b/ext/intl/formatter/formatter_main.c
@@ -17,6 +17,7 @@
 #endif
 
 #include <unicode/ustring.h>
+#include <unicode/uloc.h>
 
 #include "php_intl.h"
 #include "formatter_class.h"
@@ -63,6 +64,11 @@ static int numfmt_ctor(INTERNAL_FUNCTION_PARAMETERS, zend_error_handling *error_
 		locale = intl_locale_get_default();
 	}
 
+	if (strlen(uloc_getISO3Language(locale)) == 0) {
+		zend_argument_value_error(1, "\"%s\" is invalid", locale);
+		return FAILURE;
+	}
+    
 	/* Create an ICU number formatter. */
 	FORMATTER_OBJECT(nfo) = unum_open(style, spattern, spattern_len, locale, NULL, &INTL_DATA_ERROR_CODE(nfo));
 

--- a/ext/intl/tests/formatter_fail.phpt
+++ b/ext/intl/tests/formatter_fail.phpt
@@ -119,10 +119,14 @@ Deprecated: numfmt_create(): Passing null to parameter #1 ($locale) of type stri
 
 Deprecated: numfmt_create(): Passing null to parameter #2 ($style) of type int is deprecated in %s on line %d
 
-IntlException: Constructor failed in %s on line %d
-'numfmt_create: number formatter creation failed: U_UNSUPPORTED_ERROR'
-'numfmt_create: number formatter creation failed: U_UNSUPPORTED_ERROR'
-'numfmt_create: number formatter creation failed: U_UNSUPPORTED_ERROR'
+ValueError: NumberFormatter::__construct(): Argument #1 ($locale) "%s" is invalid in %s on line %d
+'U_ZERO_ERROR'
+
+ValueError: NumberFormatter::create(): Argument #1 ($locale) "%s" is invalid in %s on line %d
+'U_ZERO_ERROR'
+
+ValueError: numfmt_create(): Argument #1 ($locale) "%s" is invalid in %s on line %d
+'U_ZERO_ERROR'
 
 TypeError: NumberFormatter::__construct(): Argument #1 ($locale) must be of type string, array given in %s on line %d
 'U_ZERO_ERROR'

--- a/ext/intl/tests/gh12282.phpt
+++ b/ext/intl/tests/gh12282.phpt
@@ -5,18 +5,25 @@ intl
 --FILE--
 <?php
 
-var_dump(new IntlDateFormatter(
-	'xx',
-	IntlDateFormatter::FULL,
-	IntlDateFormatter::FULL,
-	null,
-	null,
-	'w'
-));
+try {
+    new IntlDateFormatter(
+	    'xx',
+	    IntlDateFormatter::FULL,
+	    IntlDateFormatter::FULL,
+	    null,
+	    null,
+	    'w'
+    );
+} catch (\ValueError $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
 Locale::setDefault('xx');
-var_dump(new IntlDateFormatter(Locale::getDefault()));
+try {
+    new IntlDateFormatter(Locale::getDefault());
+} catch (\ValueError $e) {
+    echo $e->getMessage();
+}
 --EXPECT--
-object(IntlDateFormatter)#1 (0) {
-}
-object(IntlDateFormatter)#1 (0) {
-}
+IntlDateFormatter::__construct(): Argument #1 ($locale) "xx" is invalid
+IntlDateFormatter::__construct(): Argument #1 ($locale) "xx" is invalid

--- a/ext/intl/tests/gh12727.phpt
+++ b/ext/intl/tests/gh12727.phpt
@@ -1,0 +1,15 @@
+--TEST--
+numfmt creation failures
+--EXTENSIONS--
+intl
+--FILE--
+<?php
+
+try {
+    new NumberFormatter('xx', NumberFormatter::DECIMAL);
+} catch (ValueError $e) {
+    echo $e->getMessage();
+}
+?>
+--EXPECTF--
+NumberFormatter::__construct(): Argument #1 ($locale) "%s" is invalid


### PR DESCRIPTION
invalid locale.

Also re-establishing exception throwing on IntlDateFormatter constructor overwritten by accident most likely so postponing it for next major release.