### PR TITLE
JIT/AArch64: Fix incorrect value of "ctx->code_size"

### DIFF
--- a/ext/opcache/jit/ir/ir_aarch64.dasc
+++ b/ext/opcache/jit/ir/ir_aarch64.dasc
@@ -5809,7 +5809,7 @@ void *ir_emit_code(ir_ctx *ctx, size_t *size_ptr)
 	if (data.jmp_table_label) {
 		ctx->code_size = dasm_getpclabel(&data.dasm_state, data.jmp_table_label);
 	} else if (data.rodata_label) {
-		ctx->code_size = dasm_getpclabel(&data.dasm_state, data.jmp_table_label);
+		ctx->code_size = dasm_getpclabel(&data.dasm_state, data.rodata_label);
 	} else {
 		ctx->code_size = size;
 	}


### PR DESCRIPTION
There is a typo in `ir_aarch64.dasc` that may set `ctx->code_size` to an invalid value (-2). We don't find any test failure with the typo because currently `ctx->code_size` is only used in `zend_jit_get_veneer()`. This patch fixes the typo to avoid potential issues in the future.