### PR TITLE
fix function declaration isn't a prototype [-Wstrict-prototypes]

### DIFF
--- a/sapi/litespeed/lsapilib.c
+++ b/sapi/litespeed/lsapilib.c
@@ -301,7 +301,7 @@ void lsapi_perror(const char * pMessage, int err_no)
 }
 
 
-static int lsapi_parent_dead()
+static int lsapi_parent_dead(void)
 {
     // Return non-zero if the parent is dead.  0 if still alive.
     if (!s_ppid) {


### PR DESCRIPTION
Build warning

```
/builddir/build/BUILD/php-8.3.1RC1/sapi/litespeed/lsapilib.c:305:12: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  305 | static int lsapi_parent_dead()
      |            ^~~~~~~~~~~~~~~~~

```