### PR TITLE
Fix: Do not pass `null` to function that expects `string`

### DIFF
--- a/run-tests.php
+++ b/run-tests.php
@@ -243,7 +243,7 @@ function main(): void
         $environment["SystemRoot"] = getenv("SystemRoot");
     }
 
-    $php = null;
+    $php = '';
     $php_cgi = null;
     $phpdbg = null;
 


### PR DESCRIPTION
This pull request

- [x] stops passing `null` to a function that expects `string`

Follows https://github.com/php/web-php/pull/850.