### PR TITLE
Backport deprecation warning ignores to unbreak CI

### DIFF
--- a/ext/libxml/php_libxml.h
+++ b/ext/libxml/php_libxml.h
@@ -119,12 +119,30 @@ PHP_LIBXML_API void php_libxml_shutdown(void);
 ZEND_TSRMLS_CACHE_EXTERN()
 #endif
 
+#if defined(__clang__)
+# define PHP_LIBXML_IGNORE_DEPRECATIONS_START \
+	_Pragma("clang diagnostic push") \
+	_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+# define PHP_LIBXML_IGNORE_DEPRECATIONS_END \
+	_Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+# define PHP_LIBXML_IGNORE_DEPRECATIONS_START \
+	_Pragma("GCC diagnostic push") \
+	_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+# define PHP_LIBXML_IGNORE_DEPRECATIONS_END \
+	_Pragma("GCC diagnostic pop")
+#else
+# define PHP_LIBXML_IGNORE_DEPRECATIONS_START
+# define PHP_LIBXML_IGNORE_DEPRECATIONS_END
+#endif
+
 /* Other extension may override the global state options, these global options
  * are copied initially to ctxt->options. Set the options to a known good value.
  * See libxml2 globals.c and parserInternals.c.
  * The unique_name argument allows multiple sanitizes and restores within the
  * same function, even nested is necessary. */
 #define PHP_LIBXML_SANITIZE_GLOBALS(unique_name) \
+	PHP_LIBXML_IGNORE_DEPRECATIONS_START \
 	int xml_old_loadsubset_##unique_name = xmlLoadExtDtdDefaultValue; \
 	xmlLoadExtDtdDefaultValue = 0; \
 	int xml_old_validate_##unique_name = xmlDoValidityCheckingDefaultValue; \
@@ -132,15 +150,18 @@ ZEND_TSRMLS_CACHE_EXTERN()
 	int xml_old_pedantic_##unique_name = xmlPedanticParserDefault(0); \
 	int xml_old_substitute_##unique_name = xmlSubstituteEntitiesDefault(0); \
 	int xml_old_linenrs_##unique_name = xmlLineNumbersDefault(0); \
-	int xml_old_blanks_##unique_name = xmlKeepBlanksDefault(1);
+	int xml_old_blanks_##unique_name = xmlKeepBlanksDefault(1); \
+	PHP_LIBXML_IGNORE_DEPRECATIONS_END
 
 #define PHP_LIBXML_RESTORE_GLOBALS(unique_name) \
+	PHP_LIBXML_IGNORE_DEPRECATIONS_START \
 	xmlLoadExtDtdDefaultValue = xml_old_loadsubset_##unique_name; \
 	xmlDoValidityCheckingDefaultValue = xml_old_validate_##unique_name; \
 	(void) xmlPedanticParserDefault(xml_old_pedantic_##unique_name); \
 	(void) xmlSubstituteEntitiesDefault(xml_old_substitute_##unique_name); \
 	(void) xmlLineNumbersDefault(xml_old_linenrs_##unique_name); \
-	(void) xmlKeepBlanksDefault(xml_old_blanks_##unique_name);
+	(void) xmlKeepBlanksDefault(xml_old_blanks_##unique_name); \
+	PHP_LIBXML_IGNORE_DEPRECATIONS_END
 
 /* Alternative for above, working directly on the context and not setting globals.
  * Generally faster because no locking is involved, and this has the advantage that it sets the options to a known good value. */

--- a/ext/xsl/xsltprocessor.c
+++ b/ext/xsl/xsltprocessor.c
@@ -338,8 +338,10 @@ PHP_METHOD(XSLTProcessor, importStylesheet)
 	newdoc = xmlCopyDoc(doc, 1);
 	xmlNodeSetBase((xmlNodePtr) newdoc, (xmlChar *)doc->URL);
 	PHP_LIBXML_SANITIZE_GLOBALS(parse);
+	PHP_LIBXML_IGNORE_DEPRECATIONS_START
 	xmlSubstituteEntitiesDefault(1);
 	xmlLoadExtDtdDefaultValue = XML_DETECT_IDS | XML_COMPLETE_ATTRS;
+	PHP_LIBXML_IGNORE_DEPRECATIONS_END
 
 	sheetp = xsltParseStylesheetDoc(newdoc);
 	PHP_LIBXML_RESTORE_GLOBALS(parse);


### PR DESCRIPTION
In master I use ZEND_DIAGNOSTIC_IGNORED_START, but that doesn't exist on 8.2 or 8.3 (8.3 has a similar macro though).
So to unbreak CI I just made a variation of this directly in the php_libxml.h header.

See https://github.com/php/php-src/commit/683e78786070ab77d33f7787598ac1b90d68390a#commitcomment-134301083