### PR TITLE
Fix asan shadow memory and shared_alloc_mmap clash

### DIFF
--- a/ext/opcache/shared_alloc_mmap.c
+++ b/ext/opcache/shared_alloc_mmap.c
@@ -45,7 +45,7 @@
 # define MAP_HUGETLB MAP_ALIGNED_SUPER
 #endif
 
-#if (defined(__linux__) || defined(__FreeBSD__)) && (defined(__x86_64__) || defined (__aarch64__))
+#if (defined(__linux__) || defined(__FreeBSD__)) && (defined(__x86_64__) || defined (__aarch64__)) && !defined(__SANITIZE_ADDRESS__)
 static void *find_prefered_mmap_base(size_t requested_size)
 {
 	size_t huge_page_size = 2 * 1024 * 1024;
@@ -169,7 +169,7 @@ static int create_segments(size_t requested_size, zend_shared_segment ***shared_
 #ifdef MAP_JIT
 	flags |= MAP_JIT;
 #endif
-#if (defined(__linux__) || defined(__FreeBSD__)) && (defined(__x86_64__) || defined (__aarch64__))
+#if (defined(__linux__) || defined(__FreeBSD__)) && (defined(__x86_64__) || defined (__aarch64__)) && !defined(__SANITIZE_ADDRESS__)
 	void *hint = find_prefered_mmap_base(requested_size);
 	if (hint != MAP_FAILED) {
 # ifdef MAP_HUGETLB


### PR DESCRIPTION
The memory region found by find_prefered_mmap_base may clash with memory regions reserved by asan for tracking memory. The symptom of this is that mprotect for JIT fails adding the PROT_EXEC flag to the shared memory region.

I'm getting this error since upgrading to Fedora 39, likely due to changes in the LLVM toolchain.