### PR TITLE
Cleanup libxml_get_external_entity_loader()

### DIFF
--- a/ext/libxml/libxml.c
+++ b/ext/libxml/libxml.c
@@ -1213,10 +1213,7 @@ PHP_FUNCTION(libxml_get_external_entity_loader)
 	ZEND_PARSE_PARAMETERS_NONE();
 
 	if (ZEND_FCC_INITIALIZED(LIBXML(entity_loader_callback))) {
-		zval tmp;
-		zend_get_callable_zval_from_fcc(&LIBXML(entity_loader_callback), &tmp);
-		RETVAL_COPY(&tmp);
-		zval_ptr_dtor(&tmp);
+		zend_get_callable_zval_from_fcc(&LIBXML(entity_loader_callback), return_value);
 		return;
 	}
 	RETURN_NULL();


### PR DESCRIPTION
We can directly put the value into return_value instead of copying things around.