### PR TITLE
Blocklist libxml 2.12.0 and 2.12.1

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -2035,7 +2035,7 @@ dnl
 dnl Common setup macro for libxml.
 dnl
 AC_DEFUN([PHP_SETUP_LIBXML], [
-  PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.9.0])
+  PKG_CHECK_MODULES([LIBXML], [libxml-2.0 >= 2.9.0 libxml-2.0 != 2.12.0 libxml-2.0 != 2.12.1])
 
   PHP_EVAL_INCLINE($LIBXML_CFLAGS)
   PHP_EVAL_LIBLINE($LIBXML_LIBS, $1)


### PR DESCRIPTION
These versions are broken and some functionality will constantly segfault for PHP. Libxml 2.12.2 is released 2 days ago that fixes these issues. To prevent trouble, blocklist 2.12.0 and 2.12.1.

See https://github.com/php/php-src/issues/12847#issuecomment-1844976432 and the discussion leading up to that.