### PR TITLE
Fix GH-12850: DOMNameSpaceNode parent not unset when namespace gets unlinked

### DIFF
--- a/ext/dom/tests/gh12850.phpt
+++ b/ext/dom/tests/gh12850.phpt
@@ -1,0 +1,32 @@
+--TEST--
+GH-12850 (DOMNameSpaceNode parent not unset when namespace gets unlinked)
+--EXTENSIONS--
+dom
+--FILE--
+<?php
+
+$dom = new DOMDocument;
+$dom->loadXML("<container xmlns=\"urn:foo\"/>");
+$container = $dom->documentElement;
+$ns = $container->getAttributeNode("xmlns");
+
+echo "--- Before removal ---\n";
+
+var_dump(is_null($ns->parentNode));
+var_dump($ns->isConnected);
+
+$container->removeAttributeNs("urn:foo", "");
+
+echo "--- After removal ---\n";
+
+var_dump(is_null($ns->parentNode));
+var_dump($ns->isConnected);
+
+?>
+--EXPECT--
+--- Before removal ---
+bool(false)
+bool(true)
+--- After removal ---
+bool(true)
+bool(false)


### PR DESCRIPTION
The problem is that the namespace nodes are exposed as fake nodes because of their different underlying data structure, which means that the parent link isn't actually updated when it gets removed; and we don't have a simple way of tracking it.

So just perform a check for the node type and check whether the namespace declaration associated with the fake node is still in existence.

Note that the namespace nodes are created when query() executes, so just before the foreach loops. Hence we are able to test that the node can be fetched but the parent is already unset upon first time the object is read.