### PR TITLE
ext/opcache: disable JIT build for OpenBSD/NetBSD.

### DIFF
--- a/ext/opcache/config.m4
+++ b/ext/opcache/config.m4
@@ -92,6 +92,9 @@ if test "$PHP_OPCACHE" != "no"; then
     PHP_SUBST(IR_TARGET)
     PHP_SUBST(DASM_FLAGS)
     PHP_SUBST(DASM_ARCH)
+    AC_CHECK_FUNC(qsort_r,[], [
+      AC_MSG_ERROR([qsort_r required but not found])
+    ])
 
     JIT_CFLAGS="-I@ext_builddir@/jit/ir -D${IR_TARGET} -DIR_PHP"
     if test "$ZEND_DEBUG" = "yes"; then

--- a/ext/opcache/jit/ir/ir_ra.c
+++ b/ext/opcache/jit/ir/ir_ra.c
@@ -1849,8 +1849,10 @@ int ir_coalesce(ir_ctx *ctx)
 # define qsort_fn(base, num, width, func, data) qsort_s(base, num, width, func, data)
 #elif defined(__APPLE__) || defined(__FreeBSD__)
 # define qsort_fn(base, num, width, func, data) qsort_r(base, num, width, data, func)
-#else
+#elif defined(__linux__)
 # define qsort_fn(base, num, width, func, data) qsort_r(base, num, width, func, data)
+#else
+# error "no re-entrant qsort implementation available"
 #endif
 	qsort_fn(blocks.l.a.refs, ir_worklist_len(&blocks), sizeof(ir_ref), ir_block_cmp, ctx);
 


### PR DESCRIPTION
they do not have re-entrant qsort variant.