### PR TITLE
Allow calls to static methods with `zend_vm_init_call_frame`

### DIFF
--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -253,7 +253,7 @@ static zend_always_inline zend_vm_stack zend_vm_stack_new_page(size_t size, zend
 
 static zend_always_inline void zend_vm_init_call_frame(zend_execute_data *call, uint32_t call_info, zend_function *func, uint32_t num_args, void *object_or_called_scope)
 {
-	ZEND_ASSERT(!func->common.scope || object_or_called_scope);
+    ZEND_ASSERT(!func->common.scope || object_or_called_scope || func->common.fn_flags & ZEND_ACC_STATIC);
 	call->func = func;
 	Z_PTR(call->This) = object_or_called_scope;
 	ZEND_CALL_INFO(call) = call_info;


### PR DESCRIPTION
Hey :wave:

I'm working at Datadog on the [PHP Tracing extension](https://github.com/DataDog/dd-trace-php). I stumbled on an assertion failure while working on an experimental feature, which I believe may be fixed by considering static function flags during `zend_vm_init_call_frame`.

```
php: /usr/local/src/php/Zend/zend_execute.h:223: zend_vm_init_call_frame: Assertion `!func->common.scope || object_or_called_scope' failed.
```

A sample test file _(with DDog's extension...)_ would be:
```php
<?php

$counter = 0;

class MyCounter
{
    public static function increment()
    {
        global $counter;
        $counter++;
    }
}

$closure = Closure::fromCallable('MyCounter::increment');

function greet()
{
    echo "Hello World!\n";
}

\DDTrace\trace_function('greet', $closure);

greet();

?>
```

Which results in the following backtrace:

```gdb
tmp/build_extension/tests/ext/span_callback_static.sh gdb
GNU gdb (Debian 8.2.1-2+b3) 8.2.1
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "aarch64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/local/bin/php...done.
(gdb) r
Starting program: /usr/local/bin/php -n -d output_handler= -d open_basedir= -d disable_functions= -d output_buffering=Off -d error_reporting=32767 -d display_errors=1 -d display_startup_errors=1 -d log_errors=0 -d html_errors=0 -d track_errors=0 -d report_memleaks=1 -d report_zend_debug=0 -d docref_root= -d docref_ext=.html -d error_prepend_string= -d error_append_string= -d auto_prepend_file= -d auto_append_file= -d ignore_repeated_errors=0 -d precision=14 -d serialize_precision=-1 -d memory_limit=128M -d opcache.fast_shutdown=0 -d opcache.file_update_protection=0 -d opcache.revalidate_freq=0 -d opcache.jit_hot_loop=1 -d opcache.jit_hot_func=1 -d opcache.jit_hot_return=1 -d opcache.jit_hot_side_exit=1 -d zend.assertions=1 -d zend.exception_ignore_args=0 -d zend.exception_string_param_max_len=15 -d short_open_tag=0 -d extension=/home/circleci/app/tmp/build_extension/modules/ddtrace.so -d session.auto_start=0 -d zlib.output_compression=Off -f /home/circleci/app/tmp/build_extension/tests/ext/span_callback_static.php
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
warning: Missing auto-load script at offset 0 in section .debug_gdb_scripts
of file /home/circleci/app/tmp/build_extension/modules/ddtrace.so.
Use `info auto-load python-scripts [REGEXP]' to list them.
[New Thread 0xfffff2e27b50 (LWP 76617)]
Hello World!
php: /usr/local/src/php/Zend/zend_execute.h:223: zend_vm_init_call_frame: Assertion `!func->common.scope || object_or_called_scope' failed.

Thread 1 "php" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x0000fffff519a968 in __GI_abort () at abort.c:79
#2  0x0000fffff51a60c8 in __assert_fail_base (fmt=0xfffff529ebb8 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0xaaaaabe0e340 "!func->common.scope || object_or_called_scope", file=file@entry=0xaaaaabe0e318 "/usr/local/src/php/Zend/zend_execute.h", line=line@entry=223, 
    function=function@entry=0xaaaaabe0eca8 <__PRETTY_FUNCTION__.13540> "zend_vm_init_call_frame") at assert.c:92
#3  0x0000fffff51a6130 in __GI___assert_fail (assertion=0xaaaaabe0e340 "!func->common.scope || object_or_called_scope", file=0xaaaaabe0e318 "/usr/local/src/php/Zend/zend_execute.h", line=223, function=0xaaaaabe0eca8 <__PRETTY_FUNCTION__.13540> "zend_vm_init_call_frame") at assert.c:101
#4  0x0000aaaaab355aac in zend_vm_init_call_frame (call=0xfffff4419150, call_info=33685504, func=0xfffff449d3b8, num_args=4, object_or_called_scope=0x0) at /usr/local/src/php/Zend/zend_execute.h:223
#5  0x0000aaaaab355ca8 in zend_vm_stack_push_call_frame_ex (used_stack=192, call_info=33685504, func=0xfffff449d3b8, num_args=4, object_or_called_scope=0x0) at /usr/local/src/php/Zend/zend_execute.h:243
#6  0x0000aaaaab355d7c in zend_vm_stack_push_call_frame (call_info=33685504, func=0xfffff449d3b8, num_args=4, object_or_called_scope=0x0) at /usr/local/src/php/Zend/zend_execute.h:262
#7  0x0000aaaaab3587b8 in zend_call_function (fci=0xffffffffaf60, fci_cache=0xffffffffaf40) at /usr/local/src/php/Zend/zend_execute_API.c:803
#8  0x0000fffff305d62c in zend_call_function_wrapper (fci=0xffffffffaf60, fci_cache=0xffffffffaf40) at /home/circleci/app/tmp/build_extension/zend_abstract_interface/symbols/call.c:30
#9  0x0000fffff305d790 in zai_symbol_try_call (fci=0xffffffffaf60, fcc=0xffffffffaf40) at /home/circleci/app/tmp/build_extension/zend_abstract_interface/symbols/call.c:82
#10 0x0000fffff305ddc4 in zai_symbol_call_impl (scope_type=ZAI_SYMBOL_SCOPE_GLOBAL, scope=0x0, function_type=ZAI_SYMBOL_FUNCTION_CLOSURE, function=0xffffffffb228, rv=0xffffffffb238, argc=4, args=0xffffffffb078) at /home/circleci/app/tmp/build_extension/zend_abstract_interface/symbols/call.c:269
#11 0x0000fffff30aaf58 in zai_symbol_call (scope_type=ZAI_SYMBOL_SCOPE_GLOBAL, scope=0x0, function_type=ZAI_SYMBOL_FUNCTION_CLOSURE, function=0xffffffffb228, rv=0xffffffffb238, argc=2147483652) at /home/circleci/app/tmp/build_extension/zend_abstract_interface/hook/../symbols/api/call.h:13
#12 0x0000fffff30ab16c in dd_uhook_call (closure=0xfffff449d380, tracing=true, dyn=0xfffff44b37e0, execute_data=0xfffff44190f0, retval=0xffffffffb608) at /home/circleci/app/tmp/build_extension/ext/hook/uhook_legacy.c:55
#13 0x0000fffff30aba70 in dd_uhook_end (invocation=2, execute_data=0xfffff44190f0, retval=0xffffffffb608, auxiliary=0xfffff4401188, dynamic=0xfffff44b37e0) at /home/circleci/app/tmp/build_extension/ext/hook/uhook_legacy.c:225
#14 0x0000fffff305a320 in zai_hook_finish (ex=0xfffff44190f0, rv=0xffffffffb608, memory=0xfffff44b36e0) at /home/circleci/app/tmp/build_extension/zend_abstract_interface/hook/hook.c:1039
#15 0x0000fffff304f7e8 in zai_hook_safe_finish (execute_data=0xfffff44190f0, retval=0xffffffffb608, frame_memory=0xfffff44b36e0) at /home/circleci/app/tmp/build_extension/zend_abstract_interface/interceptor/php8/interceptor.c:50
#16 0x0000fffff304f948 in zai_interceptor_observer_end_handler (execute_data=0xfffff44190f0, retval=0xffffffffb608) at /home/circleci/app/tmp/build_extension/zend_abstract_interface/interceptor/php8/interceptor.c:156
#17 0x0000aaaaab48d8c4 in call_end_observers (execute_data=0xfffff44190f0, return_value=0xffffffffb608) at /usr/local/src/php/Zend/zend_observer.c:274
#18 0x0000aaaaab48d934 in zend_observer_fcall_end (execute_data=0xfffff44190f0, return_value=0xffffffffb608) at /usr/local/src/php/Zend/zend_observer.c:283
#19 0x0000aaaaab43f4cc in execute_ex (ex=0xfffff4419020) at /usr/local/src/php/Zend/zend_vm_execute.h:56406
#20 0x0000aaaaab443424 in zend_execute (op_array=0xfffff446a3c0, return_value=0x0) at /usr/local/src/php/Zend/zend_vm_execute.h:60408
#21 0x0000aaaaab373a58 in zend_execute_scripts (type=8, retval=0x0, file_count=3) at /usr/local/src/php/Zend/zend.c:1827
#22 0x0000aaaaab2c58b0 in php_execute_script (primary_file=0xffffffffdf20) at /usr/local/src/php/main/main.c:2542
#23 0x0000aaaaab508c80 in do_cli (argc=76, argv=0xaaaaac076110) at /usr/local/src/php/sapi/cli/php_cli.c:964
#24 0x0000aaaaab509894 in main (argc=76, argv=0xaaaaac076110) at /usr/local/src/php/sapi/cli/php_cli.c:1333
(gdb) up
#1  0x0000fffff519a968 in __GI_abort () at abort.c:79
79	abort.c: No such file or directory.
(gdb) 
#2  0x0000fffff51a60c8 in __assert_fail_base (fmt=0xfffff529ebb8 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0xaaaaabe0e340 "!func->common.scope || object_or_called_scope", file=file@entry=0xaaaaabe0e318 "/usr/local/src/php/Zend/zend_execute.h", line=line@entry=223, 
    function=function@entry=0xaaaaabe0eca8 <__PRETTY_FUNCTION__.13540> "zend_vm_init_call_frame") at assert.c:92
92	assert.c: No such file or directory.
(gdb) 
#3  0x0000fffff51a6130 in __GI___assert_fail (assertion=0xaaaaabe0e340 "!func->common.scope || object_or_called_scope", file=0xaaaaabe0e318 "/usr/local/src/php/Zend/zend_execute.h", line=223, function=0xaaaaabe0eca8 <__PRETTY_FUNCTION__.13540> "zend_vm_init_call_frame") at assert.c:101
101	in assert.c
(gdb) 
#4  0x0000aaaaab355aac in zend_vm_init_call_frame (call=0xfffff4419150, call_info=33685504, func=0xfffff449d3b8, num_args=4, object_or_called_scope=0x0) at /usr/local/src/php/Zend/zend_execute.h:223
223		ZEND_ASSERT(!func->common.scope || object_or_called_scope);
(gdb) p func->common.scope
$1 = (zend_class_entry *) 0xfffff44c8018
(gdb) p *func->common.scope
$2 = {type = 2 '\002', name = 0xfffff44b38c0, {parent = 0x0, parent_name = 0x0}, refcount = 1, ce_flags = 4616, default_properties_count = 0, default_static_members_count = 0, default_properties_table = 0x0, default_static_members_table = 0x0, static_members_table__ptr = 0x0, function_table = {gc = {refcount = 1, u = {type_info = 7}}, u = {v = {
        flags = 16 '\020', _unused = 0 '\000', nIteratorsCount = 0 '\000', _unused2 = 0 '\000'}, flags = 16}, nTableMask = 4294967280, {arHash = 0xfffff449d540, arData = 0xfffff449d540, arPacked = 0xfffff449d540}, nNumUsed = 1, nNumOfElements = 1, nTableSize = 8, nInternalPointer = 0, nNextFreeElement = -9223372036854775808, 
    pDestructor = 0xaaaaab35e3d0 <zend_function_dtor>}, properties_info = {gc = {refcount = 1, u = {type_info = 7}}, u = {v = {flags = 8 '\b', _unused = 0 '\000', nIteratorsCount = 0 '\000', _unused2 = 0 '\000'}, flags = 8}, nTableMask = 4294967294, {arHash = 0xaaaaabe14ac0, arData = 0xaaaaabe14ac0, arPacked = 0xaaaaabe14ac0}, nNumUsed = 0, nNumOfElements = 0, 
    nTableSize = 8, nInternalPointer = 0, nNextFreeElement = -9223372036854775808, pDestructor = 0x0}, constants_table = {gc = {refcount = 1, u = {type_info = 7}}, u = {v = {flags = 8 '\b', _unused = 0 '\000', nIteratorsCount = 0 '\000', _unused2 = 0 '\000'}, flags = 8}, nTableMask = 4294967294, {arHash = 0xaaaaabe14ac0, arData = 0xaaaaabe14ac0, 
      arPacked = 0xaaaaabe14ac0}, nNumUsed = 0, nNumOfElements = 0, nTableSize = 8, nInternalPointer = 0, nNextFreeElement = -9223372036854775808, pDestructor = 0x0}, mutable_data__ptr = 0x0, inheritance_cache = 0x0, properties_info_table = 0x0, constructor = 0x0, destructor = 0x0, clone = 0x0, __get = 0x0, __set = 0x0, __unset = 0x0, __isset = 0x0, 
  __call = 0x0, __callstatic = 0x0, __tostring = 0x0, __debugInfo = 0x0, __serialize = 0x0, __unserialize = 0x0, iterator_funcs_ptr = 0x0, arrayaccess_funcs_ptr = 0x0, {create_object = 0x0, interface_gets_implemented = 0x0}, get_iterator = 0x0, get_static_method = 0x0, serialize = 0x0, unserialize = 0x0, num_interfaces = 0, num_traits = 0, {interfaces = 0x0, 
    interface_names = 0x0}, trait_names = 0x0, trait_aliases = 0x0, trait_precedences = 0x0, attributes = 0x0, enum_backing_type = 0, backed_enum_table = 0x0, info = {user = {filename = 0xfffff449fa00, line_start = 5, line_end = 12, doc_comment = 0x0}, internal = {builtin_functions = 0xfffff449fa00, module = 0xc00000005}}}
(gdb) p (char*)func->common.scope->name->val
$3 = 0xfffff44b38d8 "MyCounter"
(gdb) p object_or_called_scope 
$4 = (void *) 0x0
(gdb) p func->common.fn_flags
$5 = 113246225
(gdb) p func->common.fn_flags & (1<<4)
$6 = 16
```

I would greatly appreciate your input on this small addition. It effectively resolves the issue and passes all tests, but I welcome any corrections you may suggest 😃 