### PR TITLE
Fix GH-12905: FFI::new interacts badly with observers

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -5302,6 +5302,12 @@ static zend_result zend_ffi_preload(char *preload) /* {{{ */
 }
 /* }}} */
 
+/* The startup code for observers adds a temporary to each function for internal use.
+ * The "new", "cast", and "type" functions in FFI are both static and non-static.
+ * Only the static versions are in the function table and the non-static versions are not.
+ * This means the non-static versions will be skipped by the observers startup code.
+ * This function fixes that by incrementing the temporary count for the non-static versions.
+ */
 static zend_result (*prev_zend_post_startup_cb)(void);
 static zend_result ffi_fixup_temporaries(void) {
 	if (ZEND_OBSERVER_ENABLED) {

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -26,6 +26,7 @@
 #include "zend_closures.h"
 #include "zend_weakrefs.h"
 #include "main/SAPI.h"
+#include "zend_observer.h"
 
 #include <ffi.h>
 
@@ -5301,6 +5302,19 @@ static zend_result zend_ffi_preload(char *preload) /* {{{ */
 }
 /* }}} */
 
+static zend_result (*prev_zend_post_startup_cb)(void);
+static zend_result ffi_fixup_temporaries(void) {
+	if (ZEND_OBSERVER_ENABLED) {
+		++zend_ffi_new_fn.T;
+		++zend_ffi_cast_fn.T;
+		++zend_ffi_type_fn.T;
+	}
+	if (prev_zend_post_startup_cb) {
+		return prev_zend_post_startup_cb();
+	}
+	return SUCCESS;
+}
+
 /* {{{ ZEND_MINIT_FUNCTION */
 ZEND_MINIT_FUNCTION(ffi)
 {
@@ -5321,6 +5335,9 @@ ZEND_MINIT_FUNCTION(ffi)
 	zend_ffi_cast_fn.fn_flags &= ~ZEND_ACC_STATIC;
 	memcpy(&zend_ffi_type_fn, zend_hash_str_find_ptr(&zend_ffi_ce->function_table, "type", sizeof("type")-1), sizeof(zend_internal_function));
 	zend_ffi_type_fn.fn_flags &= ~ZEND_ACC_STATIC;
+
+	prev_zend_post_startup_cb = zend_post_startup_cb;
+	zend_post_startup_cb = ffi_fixup_temporaries;
 
 	memcpy(&zend_ffi_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 	zend_ffi_handlers.get_constructor      = zend_fake_get_constructor;

--- a/ext/ffi/tests/gh12905.phpt
+++ b/ext/ffi/tests/gh12905.phpt
@@ -1,0 +1,33 @@
+--TEST--
+GH-12905 (FFI::new interacts badly with observers)
+--EXTENSIONS--
+ffi
+zend_test
+--SKIPIF--
+<?php
+try {
+    $libc = FFI::cdef("int printf(const char *format, ...);", "libc.so.6");
+} catch (Throwable $_) {
+    die('skip libc.so.6 not available');
+}
+?>
+--INI--
+ffi.enable=1
+zend_test.observer.enabled=1
+zend_test.observer.observe_all=1
+zend_test.observer.show_return_value=0
+--FILE--
+<?php
+$ffi = FFI::cdef("", "libc.so.6");
+$ffi->new("int");
+?>
+--EXPECTF--
+<!-- init '%sgh12905.php' -->
+<file '%sgh12905.php'>
+  <!-- init FFI::cdef() -->
+  <FFI::cdef>
+  </FFI::cdef>
+  <!-- init FFI::new() -->
+  <FFI::new>
+  </FFI::new>
+</file '%sgh12905.php'>


### PR DESCRIPTION
This is basically https://github.com/php/php-src/issues/11548 but for FFI.

Because these functions are copied and not properly registered (which we can't), the observer code doesn't add the temporaries on startup. Add them via a callback during startup.