### PR TITLE
Fix creating a first-class callable from FFI

### DIFF
--- a/ext/ffi/tests/bug79177.phpt
+++ b/ext/ffi/tests/bug79177.phpt
@@ -32,7 +32,7 @@ echo "done\n";
 --EXPECTF--
 Warning: Uncaught RuntimeException: Not allowed in %s:%d
 Stack trace:
-#0 %s(%d): {closure}()
+#0 [internal function]: {closure}()
 #1 %s(%d): FFI->bug79177()
 #2 {main}
   thrown in %s on line %d

--- a/ext/ffi/tests/first_class_callable.phpt
+++ b/ext/ffi/tests/first_class_callable.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Bug: Cannot create first-class callable from CData function
+--EXTENSIONS--
+ffi
+--SKIPIF--
+<?php
+try {
+    $libc = FFI::cdef("int printf(const char *format, ...);", "libc.so.6");
+} catch (Throwable $_) {
+    die('skip libc.so.6 not available');
+}
+?>
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+$libc = FFI::cdef("int printf(const char *format, ...);", "libc.so.6");
+$libc->printf("Hello world\n");
+$closure = $libc->printf;
+$closure("%s %s\n", "Hello", "world");
+$closure = $libc->printf(...);
+$closure("%s %s\n", "Hello", "world");
+?>
+--EXPECT--
+Hello world
+Hello world
+Hello world


### PR DESCRIPTION
This causes a NULL pointer access because the scope field is being accessed in `zend_closure_call_magic`. We get to that function because of the ZEND_ACC_CALL_VIA_TRAMPOLINE fn_flag that is checked in `zend_closure_from_frame`. The `zend_closure_from_frame` function does not take into account the reserved data or the internal handler function, causing us to end up in `zend_closure_call_magic` instead of the FFI trampoline.

Get rid of the flag, and store the temporary internal function in another reserved slot so we can clean that up at the end of the FFI trampoline's execution.