### PR TITLE
Move sys/sysmacros.h check to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -422,6 +422,7 @@ sys/socket.h \
 sys/stat.h \
 sys/statfs.h \
 sys/statvfs.h \
+sys/sysmacros.h \
 sys/vfs.h \
 sys/sysexits.h \
 sys/uio.h \

--- a/ext/posix/config.m4
+++ b/ext/posix/config.m4
@@ -8,7 +8,7 @@ if test "$PHP_POSIX" = "yes"; then
   AC_DEFINE(HAVE_POSIX, 1, [whether to include POSIX-like functions])
   PHP_NEW_EXTENSION(posix, posix.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 
-  AC_CHECK_HEADERS([sys/mkdev.h sys/sysmacros.h])
+  AC_CHECK_HEADERS([sys/mkdev.h])
 
   AC_CHECK_FUNCS(seteuid setegid setsid getsid getpgid ctermid mkfifo mknod setrlimit getrlimit getgroups makedev initgroups getgrgid_r eaccess)
 


### PR DESCRIPTION
HAVE_SYS_SYSMACROS_H is used in ext/fileinfo/libmagic and ext/posix. It makes less error prone to check it on one place for both extensions. Otherwise, in case posix is disabled when building PHP, the fileinfo extension doesn't check existence of sys/sysmacros.h.