### PR TITLE
Sync ODBC version

### DIFF
--- a/ext/odbc/config.m4
+++ b/ext/odbc/config.m4
@@ -439,7 +439,7 @@ if test "no" != "$PHP_ODBCVER"; then
     AC_DEFINE_UNQUOTED(ODBCVER, $PHP_ODBCVER, [ The highest supported ODBC version ])
   fi
 else
-  AC_DEFINE(ODBCVER, 0x0300, [ The highest supported ODBC version ])
+  AC_DEFINE(ODBCVER, 0x0350, [ The highest supported ODBC version ])
 fi
 
 dnl Extension setup


### PR DESCRIPTION
When passing `--without-odbcver` or `--with-odbcver=no` to configure, the ODBC version has been designed to be highest supported version (0x0350). This syncs the behavior with the Windows build system.