### PR TITLE
Convert MAX() assignments for MM stats to if check

### DIFF
--- a/Zend/zend_alloc.c
+++ b/Zend/zend_alloc.c
@@ -1047,9 +1047,10 @@ get_chunk:
 #if ZEND_MM_STAT
 				do {
 					size_t size = heap->real_size + ZEND_MM_CHUNK_SIZE;
-					size_t peak = MAX(heap->real_peak, size);
 					heap->real_size = size;
-					heap->real_peak = peak;
+					if (size > heap->real_peak) {
+						heap->real_peak = size;
+					}
 				} while (0);
 #elif ZEND_MM_LIMIT
 				heap->real_size += ZEND_MM_CHUNK_SIZE;
@@ -1101,9 +1102,10 @@ static zend_always_inline void *zend_mm_alloc_large_ex(zend_mm_heap *heap, size_
 #if ZEND_MM_STAT
 	do {
 		size_t size = heap->size + pages_count * ZEND_MM_PAGE_SIZE;
-		size_t peak = MAX(heap->peak, size);
 		heap->size = size;
-		heap->peak = peak;
+		if (size > heap->peak) {
+			heap->peak = size;
+		}
 	} while (0);
 #endif
 	return ptr;
@@ -1310,9 +1312,10 @@ static zend_always_inline void *zend_mm_alloc_small(zend_mm_heap *heap, int bin_
 #if ZEND_MM_STAT
 	do {
 		size_t size = heap->size + bin_data_size[bin_num];
-		size_t peak = MAX(heap->peak, size);
 		heap->size = size;
-		heap->peak = peak;
+		if (size > heap->peak) {
+			heap->peak = size;
+		}
 	} while (0);
 #endif
 
@@ -1559,9 +1562,13 @@ static zend_never_inline void *zend_mm_realloc_huge(zend_mm_heap *heap, void *pt
 				heap->real_size += new_size - old_size;
 #endif
 #if ZEND_MM_STAT
-				heap->real_peak = MAX(heap->real_peak, heap->real_size);
+				if (heap->real_size > heap->real_peak) {
+					heap->real_peak = heap->real_size;
+				}
 				heap->size += new_size - old_size;
-				heap->peak = MAX(heap->peak, heap->size);
+				if (heap->size > heap->peak) {
+					heap->peak = heap->size;
+				}
 #endif
 #if ZEND_DEBUG
 				zend_mm_change_huge_block_size(heap, ptr, new_size, real_size ZEND_FILE_LINE_RELAY_CC ZEND_FILE_LINE_ORIG_RELAY_CC);
@@ -1699,9 +1706,10 @@ static zend_always_inline void *zend_mm_realloc_heap(zend_mm_heap *heap, void *p
 #if ZEND_MM_STAT
 						do {
 							size_t size = heap->size + (new_size - old_size);
-							size_t peak = MAX(heap->peak, size);
 							heap->size = size;
-							heap->peak = peak;
+							if (size > heap->peak) {
+								heap->peak = size;
+							}
 						} while (0);
 #endif
 						chunk->free_pages -= new_pages_count - old_pages_count;
@@ -1870,15 +1878,17 @@ static void *zend_mm_alloc_huge(zend_mm_heap *heap, size_t size ZEND_FILE_LINE_D
 #if ZEND_MM_STAT
 	do {
 		size_t size = heap->real_size + new_size;
-		size_t peak = MAX(heap->real_peak, size);
 		heap->real_size = size;
-		heap->real_peak = peak;
+		if (size > heap->real_peak) {
+			heap->real_peak = size;
+		}
 	} while (0);
 	do {
 		size_t size = heap->size + new_size;
-		size_t peak = MAX(heap->peak, size);
 		heap->size = size;
-		heap->peak = peak;
+		if (size > heap->peak) {
+			heap->peak = size;
+		}
 	} while (0);
 #elif ZEND_MM_LIMIT
 	heap->real_size += new_size;


### PR DESCRIPTION
When the MAX() macro is used with an unconditional assignment, the memory write will always happen and the maximum is computed using conditional move instructions. In practice, the branch is easily predictable, so it seems more optimal to use an if check.
This patch reduces the instruction count for our benchmarks. Micro benchmarks of emalloc & efree also show an improvement in wall clock run time.