### PR TITLE
Fix GH-9698: stream_wrapper_register crashes with FFI\CData 

### DIFF
--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -1289,6 +1289,10 @@ static zval *zend_ffi_cdata_write_field(zend_object *obj, zend_string *field_nam
 	if (cache_slot && *cache_slot == type) {
 		field = *(cache_slot + 1);
 	} else {
+		if (UNEXPECTED(type == NULL)) {
+			zend_throw_error(zend_ffi_exception_ce, "Attempt to assign field '%s' to uninitialized FFI\\CData object", ZSTR_VAL(field_name));
+			return value;
+		}
 		if (type->kind == ZEND_FFI_TYPE_POINTER) {
 			type = ZEND_FFI_TYPE(type->pointer.type);
 		}

--- a/ext/ffi/tests/gh9698.phpt
+++ b/ext/ffi/tests/gh9698.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-9698 (stream_wrapper_register crashes with FFI\CData provided as class)
+--EXTENSIONS--
+ffi
+--SKIPIF--
+<?php
+?>
+--FILE--
+<?php
+try {
+    stream_wrapper_register('badffi', 'FFI\CData');
+    file_get_contents('badffi://x');
+} catch (Throwable $exception) {
+    echo $exception->getMessage();
+}
+?>
+
+DONE
+--EXPECT--
+Attempt to assign field 'context' to uninitialized FFI\CData object
+DONE

--- a/main/streams/userspace.c
+++ b/main/streams/userspace.c
@@ -304,6 +304,12 @@ static void user_stream_create_object(struct php_user_stream_wrapper *uwrap, php
 		add_property_null(object, "context");
 	}
 
+	if (EG(exception) != NULL) {
+		zval_ptr_dtor(object);
+		ZVAL_UNDEF(object);
+		return;
+	}
+
 	if (uwrap->ce->constructor) {
 		zend_call_known_instance_method_with_0_params(
 			uwrap->ce->constructor, Z_OBJ_P(object), NULL);


### PR DESCRIPTION
The context is provided before constructor is called so there needs to be a bit more checking in FFI and stream user wrapper.