### PR TITLE
Fix pcre out-of-bounds when using closing symbols as opening delimiter

### DIFF
--- a/ext/pcre/php_pcre.c
+++ b/ext/pcre/php_pcre.c
@@ -655,7 +655,7 @@ PHPAPI pcre_cache_entry* pcre_get_compiled_regex_cache_ex(zend_string *regex, bo
 	}
 
 	start_delimiter = delimiter;
-	if ((pp = strchr("([{< )]}>", delimiter)))
+	if ((pp = strchr("([{< )]}> )]}>", delimiter)))
 		delimiter = pp[5];
 	end_delimiter = delimiter;
 

--- a/ext/pcre/tests/oss-fuzz-65021.phpt
+++ b/ext/pcre/tests/oss-fuzz-65021.phpt
@@ -1,0 +1,11 @@
+--TEST--
+oss-fuzz #65021
+--FILE--
+<?php
+var_dump(preg_match(">",""));
+var_dump(preg_match(">foo>i","FOO"));
+?>
+--EXPECTF--
+Warning: preg_match(): No ending delimiter '>' found in %s on line %d
+bool(false)
+int(1)


### PR DESCRIPTION
Apparently we support using closing symbols )]}> as opening and closing delimiters.

Fixes oss-fuzz #65021