### PR TITLE
Use strcspn() to optimize dom_html5_escape_string()

### DIFF
--- a/ext/dom/html5_serializer.c
+++ b/ext/dom/html5_serializer.c
@@ -70,7 +70,20 @@ static zend_result dom_html5_escape_string(dom_html5_serialize_context *ctx, con
 {
 	const char *last_output = content;
 
-	while (*content != '\0') {
+	while (true) {
+		size_t chunk_length;
+		/* Note: uses UTF-8 internally, so <C2 A0> indicates a non-breaking space */
+		if (attribute_mode) {
+			chunk_length = strcspn(content, "&\xC2\"");
+		} else {
+			chunk_length = strcspn(content, "&\xC2<>");
+		}
+
+		content += chunk_length;
+		if (*content == '\0') {
+			break;
+		}
+
 		switch (*content) {
 			/* Step 1 */
 			case '&': {
@@ -93,29 +106,23 @@ static zend_result dom_html5_escape_string(dom_html5_serialize_context *ctx, con
 
 			/* Step 3 */
 			case '"': {
-				if (attribute_mode) {
-					TRY(ctx->write_string_len(ctx->application_data, last_output, content - last_output));
-					TRY(ctx->write_string_len(ctx->application_data, "&quot;", strlen("&quot;")));
-					last_output = content + 1;
-				}
+				TRY(ctx->write_string_len(ctx->application_data, last_output, content - last_output));
+				TRY(ctx->write_string_len(ctx->application_data, "&quot;", strlen("&quot;")));
+				last_output = content + 1;
 				break;
 			}
 
 			/* Step 4 */
 			case '<': {
-				if (!attribute_mode) {
-					TRY(ctx->write_string_len(ctx->application_data, last_output, content - last_output));
-					TRY(ctx->write_string_len(ctx->application_data, "&lt;", strlen("&lt;")));
-					last_output = content + 1;
-				}
+				TRY(ctx->write_string_len(ctx->application_data, last_output, content - last_output));
+				TRY(ctx->write_string_len(ctx->application_data, "&lt;", strlen("&lt;")));
+				last_output = content + 1;
 				break;
 			}
 			case '>': {
-				if (!attribute_mode) {
-					TRY(ctx->write_string_len(ctx->application_data, last_output, content - last_output));
-					TRY(ctx->write_string_len(ctx->application_data, "&gt;", strlen("&gt;")));
-					last_output = content + 1;
-				}
+				TRY(ctx->write_string_len(ctx->application_data, last_output, content - last_output));
+				TRY(ctx->write_string_len(ctx->application_data, "&gt;", strlen("&gt;")));
+				last_output = content + 1;
 				break;
 			}
 		}

--- a/ext/dom/html5_serializer.c
+++ b/ext/dom/html5_serializer.c
@@ -70,14 +70,11 @@ static zend_result dom_html5_escape_string(dom_html5_serialize_context *ctx, con
 {
 	const char *last_output = content;
 
+	/* Note: uses UTF-8 internally, so <C2 A0> indicates a non-breaking space */
+	const char *mask = attribute_mode ? "&\xC2\"" : "&\xC2<>";
+
 	while (true) {
-		size_t chunk_length;
-		/* Note: uses UTF-8 internally, so <C2 A0> indicates a non-breaking space */
-		if (attribute_mode) {
-			chunk_length = strcspn(content, "&\xC2\"");
-		} else {
-			chunk_length = strcspn(content, "&\xC2<>");
-		}
+		size_t chunk_length = strcspn(content, mask);
 
 		content += chunk_length;
 		if (*content == '\0') {


### PR DESCRIPTION
This routine implemented by libc uses a faster algorithm than the old naive byte-per-byte approach here. It also is often optimized using SIMD.
