### PR TITLE
Remove warning "use statement with non-compound name '...' has no effect"

### DIFF
--- a/Zend/tests/bug69388.phpt
+++ b/Zend/tests/bug69388.phpt
@@ -15,4 +15,3 @@ eval('namespace {use Exception;}');
 
 ?>
 --EXPECT--
-The use statement with non-compound name 'Exception' has no effect

--- a/Zend/tests/bug69388_2.phpt
+++ b/Zend/tests/bug69388_2.phpt
@@ -12,4 +12,3 @@ eval('namespace {use Exception;}');
 
 ?>
 --EXPECT--
-The use statement with non-compound name 'Exception' has no effect

--- a/Zend/tests/ns_033.phpt
+++ b/Zend/tests/ns_033.phpt
@@ -6,6 +6,3 @@ use A;
 use \B;
 ?>
 --EXPECTF--
-Warning: The use statement with non-compound name 'A' has no effect in %sns_033.php on line 2
-
-Warning: The use statement with non-compound name 'B' has no effect in %sns_033.php on line 3

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -8377,11 +8377,6 @@ static void zend_compile_use(zend_ast *ast) /* {{{ */
 				new_name = zend_string_init(unqualified_name, unqualified_name_len, 0);
 			} else {
 				new_name = zend_string_copy(old_name);
-
-				if (!current_ns) {
-					zend_error(E_WARNING, "The use statement with non-compound name '%s' "
-						"has no effect", ZSTR_VAL(new_name));
-				}
 			}
 		}
 


### PR DESCRIPTION
This message was in fact not true, as the statement indeed *has* an effect, that is fixing the case for a potential autoloading invocation, as in:

    use Alpha;
    new alpha();  // will issue autoload for "Alpha" instead of "alpha"

This is very relevant for case-sensitive file systems that load classes using their name as file name.

Moreover, there is not a reason to issue a warning for no-ops, this is a task for static analyzers, not the language itself.