### PR TITLE
Add cross-compiling argument to AC_RUN_IFELSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1586,15 +1586,16 @@ if test "$PHP_UNDEFINED_SANITIZER" = "yes"; then
     dnl cast to void*. In that case, set -fno-sanitize=function.
     OLD_CFLAGS="$CFLAGS"
     CFLAGS="$CFLAGS -fno-sanitize-recover=undefined"
+    AC_CACHE_CHECK([whether to add -fno-sanitize=function],[php_cv_ubsan_no_function],[
     AC_RUN_IFELSE([AC_LANG_SOURCE([[
 void foo(char *string) {}
 int main(void) {
   void (*f)(void *) = (void (*)(void *))foo;
   f("foo");
 }
-    ]])],,[ubsan_needs_no_function=yes],)
+    ]])],[php_cv_ubsan_no_function=no],[php_cv_ubsan_no_function=yes],[php_cv_ubsan_no_function=no])])
     CFLAGS="$OLD_CFLAGS"
-    if test "$ubsan_needs_no_function" = yes; then
+    if test "$php_cv_ubsan_no_function" = yes; then
       CFLAGS="$CFLAGS -fno-sanitize=function"
       CXXFLAGS="$CFLAGS -fno-sanitize=function"
     fi


### PR DESCRIPTION
Autoconf emits a warning if 3rd argument in AC_RUN_IFELSE is empty:

```sh
autoconf -Wall
```

```
configure.ac:1611: warning: AC_RUN_IFELSE called without default to allow cross compiling
./lib/autoconf/general.m4:2981: AC_RUN_IFELSE is expanded from...
lib/m4sugar/m4sh.m4:699: AS_IF is expanded from...
build/ax_check_compile_flag.m4:39: AX_CHECK_COMPILE_FLAG is expanded from...
configure.ac:1611: the top level
```

Additionally, call is wrapped in the AC_CACHE_CHECK with php_cv_* cache variable name according to the [docs](https://www.gnu.org/software/autoconf/manual/autoconf-2.71/autoconf.html#Cache-Variable-Names).

Related to #12642 