### PR TITLE
Fix GH-12969: Fixed PDO::getAttribute() to get PDO::ATTR_STRINGIFY_FETCHES

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,7 +62,7 @@ PHP                                                                        NEWS
 
 - FTP:
   . Fixed bug GH-9348 (FTP & SSL session reuse). (nielsdos)
-   
+
 - Intl:
   . Fixed bug GH-12635 (Test bug69398.phpt fails with ICU 74.1). (nielsdos)
 
@@ -460,6 +460,8 @@ PHP                                                                        NEWS
   . Fix	GH-11587 (After php8.1, when PDO::ATTR_EMULATE_PREPARES is true
     and PDO::ATTR_STRINGIFY_FETCHES is true, decimal zeros are no longer
     filled). (SakiTakamachi)
+  . Fix GH-12969 (Fixed PDO::getAttribute() to get PDO::ATTR_STRINGIFY_FETCHES).
+    (SakiTakamachi)
 
 - PDO SQLite:
   . Fix GH-11492 (Make test failure: ext/pdo_sqlite/tests/bug_42589.phpt).

--- a/UPGRADING
+++ b/UPGRADING
@@ -229,6 +229,9 @@ PHP 8.2 UPGRADE NOTES
     This change only affects the encoding selection,
     not the result of the conversion.
 
+- PDO:
+  . getAttribute, enabled to get the value of ATTR_STRINGIFY_FETCHES.
+
 - Random
   . random_bytes() and random_int() now throw \Random\RandomException on CSPRNG failure.
     Previously a plain \Exception was thrown.

--- a/ext/pdo/pdo_dbh.c
+++ b/ext/pdo/pdo_dbh.c
@@ -930,8 +930,13 @@ PHP_METHOD(PDO, getAttribute)
 				add_next_index_zval(return_value, &dbh->def_stmt_ctor_args);
 			}
 			return;
+
 		case PDO_ATTR_DEFAULT_FETCH_MODE:
 			RETURN_LONG(dbh->default_fetch_type);
+
+		case PDO_ATTR_STRINGIFY_FETCHES:
+			RETURN_BOOL(dbh->stringify);
+
 		default:
 			break;
 	}

--- a/ext/pdo_mysql/tests/bug68371.phpt
+++ b/ext/pdo_mysql/tests/bug68371.phpt
@@ -96,6 +96,6 @@ array(1) {
 ERR
 ERR
 string(5) "mysql"
-ERR
+bool(false)
 ERR
 int(4)

--- a/ext/pdo_pgsql/tests/bug68371.phpt
+++ b/ext/pdo_pgsql/tests/bug68371.phpt
@@ -95,6 +95,6 @@ array(1) {
 ERR
 ERR
 string(5) "pgsql"
-ERR
+bool(true)
 ERR
 int(4)


### PR DESCRIPTION
Partial backport of #12793
(I done cherry-pick and kept only the changes I needed)