### PR TITLE
Update listen backlog on reload and stop enforcing default backlog

### DIFF
--- a/sapi/fpm/fpm/fpm_conf.c
+++ b/sapi/fpm/fpm/fpm_conf.c
@@ -916,7 +916,6 @@ static int fpm_conf_process_all_pools(void)
 
 			if (config->listen_backlog < FPM_BACKLOG_DEFAULT) {
 				zlog(ZLOG_WARNING, "[pool %s] listen.backlog(%d) was too low for the ondemand process manager. I updated it for you to %d.", wp->config->name, config->listen_backlog, FPM_BACKLOG_DEFAULT);
-				config->listen_backlog = FPM_BACKLOG_DEFAULT;
 			}
 
 			/* certainly useless but proper */

--- a/sapi/fpm/fpm/fpm_sockets.c
+++ b/sapi/fpm/fpm/fpm_sockets.c
@@ -278,6 +278,7 @@ static int fpm_sockets_get_listening_socket(struct fpm_worker_pool_s *wp, struct
 
 	sock = fpm_sockets_hash_op(0, sa, 0, wp->listen_address_domain, FPM_GET_USE_SOCKET);
 	if (sock >= 0) {
+		listen(sock, wp->config->listen_backlog); /* change backlog via listen() */
 		return sock;
 	}
 


### PR DESCRIPTION
Add support for adjusting the listen backlog when reloading php-fpm and stop enforcing the default listen backlog because some setups might legitimately require lower values.