### PR TITLE
Remove libbind from build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -378,8 +378,8 @@ case $host_alias in
     ;;
 esac
 
-dnl Check for inet_aton in -lc, -lbind and -lresolv.
-PHP_CHECK_FUNC(inet_aton, resolv, bind)
+dnl Check for inet_aton in -lc and -lresolv.
+PHP_CHECK_FUNC(inet_aton, resolv)
 
 dnl Then headers.
 dnl ----------------------------------------------------------------------------

--- a/ext/standard/config.m4
+++ b/ext/standard/config.m4
@@ -352,17 +352,17 @@ dnl Detect library functions needed by php dns_xxx functions
 dnl ext/standard/php_dns.h will collect these in a single define
 dnl HAVE_FULL_DNS_FUNCS
 dnl
-PHP_CHECK_FUNC(res_nsearch, resolv, bind, socket)
-PHP_CHECK_FUNC(res_ndestroy, resolv, bind, socket)
-PHP_CHECK_FUNC(dns_search, resolv, bind, socket)
-PHP_CHECK_FUNC(dn_expand, resolv, bind, socket)
-PHP_CHECK_FUNC(dn_skipname, resolv, bind, socket)
+PHP_CHECK_FUNC(res_nsearch, resolv, socket)
+PHP_CHECK_FUNC(res_ndestroy, resolv, socket)
+PHP_CHECK_FUNC(dns_search, resolv, socket)
+PHP_CHECK_FUNC(dn_expand, resolv, socket)
+PHP_CHECK_FUNC(dn_skipname, resolv, socket)
 
 dnl
 dnl These are old deprecated functions
 dnl
 
-PHP_CHECK_FUNC(res_search, resolv, bind, socket)
+PHP_CHECK_FUNC(res_search, resolv, socket)
 
 PHP_CHECK_FUNC(posix_spawn_file_actions_addchdir_np)
 


### PR DESCRIPTION
Linking with -lbind is no longer relevant. The libbind was once part of the ISC project bind9. In 2013, maintenance was moved to NetBSD which integrated it into netresolv.

- https://www.isc.org/othersoftware/#libbind
- https://wiki.netbsd.org/individual-software-releases/netresolv/