### PR TITLE
Support index.php fallback for files in built-in server

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -19,6 +19,14 @@ PHP 8.4 UPGRADE NOTES
 1. Backward Incompatible Changes
 ========================================
 
+- CLI:
+  . The builtin server looks for an index file recursively by traversing parent
+    directories in case the specified file cannot be located. This process was
+    previously skipped if the path looked like it was referring to a file, i.e.
+    if the last path component contained a period. In that case, a 404 error was
+    returned. The behavior has been changed to look for an index file in all
+    cases.
+
 - Core:
   . The type of PHP_DEBUG and PHP_ZTS constants changed to bool.
 

--- a/sapi/cli/tests/php_cli_server.inc
+++ b/sapi/cli/tests/php_cli_server.inc
@@ -17,7 +17,7 @@ function php_cli_server_start(
     $error = null;
 
     // Create dedicated doc root to avoid index.php clashes between tests.
-    $doc_root = __DIR__ . '/' . basename($_SERVER['PHP_SELF'], '.php');
+    $doc_root = __DIR__ . DIRECTORY_SEPARATOR . basename($_SERVER['PHP_SELF'], '.php');
     @mkdir($doc_root);
 
     if ($code) {
@@ -103,7 +103,7 @@ function php_cli_server_start(
                 printf("Server output:\n%s\n", file_get_contents($output_file));
             }
             @unlink(__DIR__ . "/{$router}");
-            @rmdir($doc_root);
+            remove_directory($doc_root);
         },
         $handle
     );
@@ -124,6 +124,21 @@ function php_cli_server_connect() {
         die("connect failed");
     }
     return $fp;
+}
+
+function remove_directory($dir) {
+    if (is_dir($dir) === false) {
+        return;
+    }
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($files as $fileinfo) {
+        $todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+        $todo($fileinfo->getRealPath());
+    }
+    @rmdir($dir);
 }
 
 ?>

--- a/sapi/cli/tests/php_cli_server_009.phpt
+++ b/sapi/cli/tests/php_cli_server_009.phpt
@@ -79,4 +79,4 @@ X-Powered-By: PHP/%s
 Content-type: text/html; charset=UTF-8
 
 string(9) "/foo/bar/"
-HTTP/1.0 404 Not Found
+HTTP/1.0 200 OK

--- a/sapi/cli/tests/php_cli_server_014.phpt
+++ b/sapi/cli/tests/php_cli_server_014.phpt
@@ -61,12 +61,11 @@ X-Powered-By: %s
 Content-type: %s
 
 done
-HTTP/1.1 404 Not Found
+HTTP/1.1 200 OK
 Host: %s
 Date: %s
 Connection: close
-Content-Type: %s
-Content-Length: %d
+X-Powered-By: PHP/%s
+Content-type: %s
 
-<!doctype html><html><head><title>404 Not Found</title><style>AAA</style>
-</head><body><h1>Not Found</h1><p>The requested resource <code class="url">/main/no-exists.php</code> was not found on this server.</p></body></html>
+done

--- a/sapi/cli/tests/php_cli_server_016.phpt
+++ b/sapi/cli/tests/php_cli_server_016.phpt
@@ -10,7 +10,9 @@ include "skipif.inc";
 --FILE--
 <?php
 include "php_cli_server.inc";
-php_cli_server_start(<<<'PHP'
+$info = php_cli_server_start(null, 'router.php');
+file_put_contents($info->docRoot . '/router.php', <<<'PHP'
+<?php
 if (preg_match('/\.(?:png|jpg|jpeg|gif)$/', $_SERVER["REQUEST_URI"]))
         return false; // serve the requested resource as-is.
 else {


### PR DESCRIPTION
If no router script is used, the built-in webserver will now look for a fallback index file recursively in all cases, including URLs with a period.

Furthermore, if a router script returns false, we will no longer perform a recursive fallback. Previously, recursive fallback was performed when the URL contained no period. The rationale for this is that it avoids serving the root index.php file when the router has indicated that the file is a static file.

The existing behavior essentially assumes that virtual routes don't contain periods, and that real files do. Both of those assumptions are incorrect.

Fixes GH-12604