### PR TITLE
Remove unused in_addr_t type alias

### DIFF
--- a/build/php.m4
+++ b/build/php.m4
@@ -1070,28 +1070,6 @@ AC_DEFUN([PHP_CHECK_SIZEOF], [
 ])
 
 dnl
-dnl PHP_CHECK_IN_ADDR_T
-dnl
-AC_DEFUN([PHP_CHECK_IN_ADDR_T], [
-dnl AIX keeps in_addr_t in /usr/include/netinet/in.h
-AC_MSG_CHECKING([for in_addr_t])
-AC_CACHE_VAL(ac_cv_type_in_addr_t,
-[AC_EGREP_CPP(dnl
-changequote(<<,>>)dnl
-<<in_addr_t[^a-zA-Z_0-9]>>dnl
-changequote([,]), [#include <sys/types.h>
-#include <stdlib.h>
-#include <stddef.h>
-#ifdef HAVE_NETINET_IN_H
-#include <netinet/in.h>
-#endif], ac_cv_type_in_addr_t=yes, ac_cv_type_in_addr_t=no)])dnl
-AC_MSG_RESULT([$ac_cv_type_in_addr_t])
-if test $ac_cv_type_in_addr_t = no; then
-  AC_DEFINE(in_addr_t, u_int, [ ])
-fi
-])
-
-dnl
 dnl PHP_TIME_R_TYPE
 dnl
 dnl Check type of reentrant time-related functions. Type can be: irix, hpux or

--- a/configure.ac
+++ b/configure.ac
@@ -752,7 +752,6 @@ fi
 AC_REPLACE_FUNCS(strlcat strlcpy explicit_bzero getopt)
 AC_FUNC_ALLOCA
 PHP_TIME_R_TYPE
-PHP_CHECK_IN_ADDR_T
 
 AC_CACHE_CHECK([for aarch64 CRC32 API], ac_cv_func___crc32d,
 [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <arm_acle.h>]],[[__crc32d(0, 0);]])],[ac_cv_func___crc32d=yes],[ac_cv_func___crc32d="no"])])

--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -31,8 +31,6 @@
 
 #include <windows.h>
 
-typedef unsigned int in_addr_t;
-
 struct sockaddr_un {
 	short   sun_family;
 	char    sun_path[MAXPATHLEN];


### PR DESCRIPTION
The fastcgi code was refactored in
18cf4e0a8a574034f60f4d123407c173e57e54ec and `in_addr_t` is no longer used. The PHP_CHECK_IN_ADDR_T is also obsolete and not recommended way to discover availability of the type. If needed in the future, the AC_CHECK_TYPES can be used instead.