### PR TITLE
Add case 0.0 to the test runtime_compile_time_binary_operands.phpt

### DIFF
--- a/Zend/tests/runtime_compile_time_binary_operands.phpt
+++ b/Zend/tests/runtime_compile_time_binary_operands.phpt
@@ -44,6 +44,7 @@ $unaryOperators = [
 
 $input = [
     0,
+    0.0,
     1,
     2,
     -1,


### PR DESCRIPTION
There is missing case `0.0` in the test `runtime_compile_time_binary_operands.phpt`.