### PR TITLE
preserves HASH_FLAG_ALLOW_COW_VIOLATION in zend_hash_real_init_ex()

### DIFF
--- a/ext/zend_test/test.c
+++ b/ext/zend_test/test.c
@@ -73,6 +73,24 @@ static zend_class_entry *zend_test_int_enum;
 static zend_class_entry *zend_test_magic_call;
 static zend_object_handlers zend_test_class_handlers;
 
+static ZEND_FUNCTION(zend_test_gh12986)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	HashTable *ht = _zend_new_array_0();
+	// The HT_ALLOW_COW_VIOLATION() macro is a noop in non-debug builds,
+	// so we have to set the flag directly.
+	HT_FLAGS(ht) |= HASH_FLAG_ALLOW_COW_VIOLATION;
+	zval value;
+	ZVAL_LONG(&value, 1);
+	zend_hash_next_index_insert(ht, &value);
+	if (HT_FLAGS(ht) & HASH_FLAG_ALLOW_COW_VIOLATION) {
+		php_printf("OK: HASH_FLAG_ALLOW_COW_VIOLATION is preserved by zend_hash_real_init_ex\n");
+	} else {
+		php_printf("KO: HASH_FLAG_ALLOW_COW_VIOLATION was cleared by zend_hash_real_init_ex\n");
+	}
+	zend_array_release(ht);
+}
+
 static int le_throwing_resource;
 
 static ZEND_FUNCTION(zend_test_func)

--- a/ext/zend_test/test.stub.php
+++ b/ext/zend_test/test.stub.php
@@ -246,6 +246,8 @@ function zend_test_override_libxml_global_state(): void {}
 #endif
 
     function zend_test_is_pcre_bundled(): bool {}
+
+    function zend_test_gh12986(): void {}
 }
 
 namespace ZendTestNS {

--- a/ext/zend_test/test_arginfo.h
+++ b/ext/zend_test/test_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 39a14fb061199171b0a0a08b821dabcba516ccf5 */
+ * Stub hash: 27be2a99460c562b48b8a6527a4201973a95abe1 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_array_return, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
@@ -144,6 +144,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zend_test_is_pcre_bundled, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_zend_test_gh12986 arginfo_zend_test_void_return
+
 #define arginfo_ZendTestNS2_namespaced_func arginfo_zend_test_is_pcre_bundled
 
 #define arginfo_ZendTestNS2_namespaced_deprecated_func arginfo_zend_test_void_return
@@ -266,6 +268,7 @@ static ZEND_FUNCTION(get_open_basedir);
 static ZEND_FUNCTION(zend_test_override_libxml_global_state);
 #endif
 static ZEND_FUNCTION(zend_test_is_pcre_bundled);
+static ZEND_FUNCTION(zend_test_gh12986);
 static ZEND_FUNCTION(ZendTestNS2_namespaced_func);
 static ZEND_FUNCTION(ZendTestNS2_namespaced_deprecated_func);
 static ZEND_FUNCTION(ZendTestNS2_ZendSubNS_namespaced_func);
@@ -339,6 +342,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(zend_test_override_libxml_global_state, arginfo_zend_test_override_libxml_global_state)
 #endif
 	ZEND_FE(zend_test_is_pcre_bundled, arginfo_zend_test_is_pcre_bundled)
+	ZEND_FE(zend_test_gh12986, arginfo_zend_test_gh12986)
 	ZEND_NS_FALIAS("ZendTestNS2", namespaced_func, ZendTestNS2_namespaced_func, arginfo_ZendTestNS2_namespaced_func)
 	ZEND_NS_DEP_FALIAS("ZendTestNS2", namespaced_deprecated_func, ZendTestNS2_namespaced_deprecated_func, arginfo_ZendTestNS2_namespaced_deprecated_func)
 	ZEND_NS_FALIAS("ZendTestNS2", namespaced_aliased_func, zend_test_void_return, arginfo_ZendTestNS2_namespaced_aliased_func)

--- a/ext/zend_test/tests/gh12986.phpt
+++ b/ext/zend_test/tests/gh12986.phpt
@@ -1,0 +1,12 @@
+--TEST--
+GH-12986 (HASH_FLAG_ALLOW_COW_VIOLATION is not preserved by zend_hash_real_init_ex)
+--EXTENSIONS--
+zend_test
+--FILE--
+<?php
+
+zend_test_gh12986();
+
+?>
+--EXPECT--
+OK: HASH_FLAG_ALLOW_COW_VIOLATION is preserved by zend_hash_real_init_ex


### PR DESCRIPTION
See #12986 for context. 

Closes #12986 