### PR TITLE
Update ob get status tests

### DIFF
--- a/tests/output/ob_013.phpt
+++ b/tests/output/ob_013.phpt
@@ -15,6 +15,10 @@ class E {
     public function g($s) {
         return $s;
     }
+
+    public function __invoke($s) {
+        return $s;
+    }
 }
 
 $e = new E();
@@ -26,6 +30,7 @@ ob_start('c');
 ob_start('d');
 ob_start(['E', 'f']);
 ob_start([$e, 'g']);
+ob_start($e);
 ob_start(function ($s) { return $s; });
 ob_start();
 
@@ -51,14 +56,15 @@ Array
     [4] => d
     [5] => E::f
     [6] => E::g
-    [7] => Closure::__invoke
+    [7] => E::__invoke
+    [8] => Closure::__invoke
 )
 Array
 (
     [name] => Closure::__invoke
     [type] => 1
     [flags] => 20593
-    [level] => 7
+    [level] => 8
     [chunk_size] => 0
     [buffer_size] => 16384
     [buffer_used] => %d
@@ -139,15 +145,26 @@ Array
             [level] => 6
             [chunk_size] => 0
             [buffer_size] => 16384
-            [buffer_used] => %d
+            [buffer_used] => 0
         )
 
     [7] => Array
         (
+            [name] => E::__invoke
+            [type] => 1
+            [flags] => 113
+            [level] => 7
+            [chunk_size] => 0
+            [buffer_size] => 16384
+            [buffer_used] => %d
+        )
+
+    [8] => Array
+        (
             [name] => Closure::__invoke
             [type] => 1
             [flags] => 20593
-            [level] => 7
+            [level] => 8
             [chunk_size] => 0
             [buffer_size] => 16384
             [buffer_used] => %d

--- a/tests/output/ob_013.phpt
+++ b/tests/output/ob_013.phpt
@@ -7,11 +7,26 @@ function b($s){return $s;}
 function c($s){return $s;}
 function d($s){return $s;}
 
+class E {
+    public static function f($s) {
+        return $s;
+    }
+
+    public function g($s) {
+        return $s;
+    }
+}
+
+$e = new E();
+
 ob_start();
 ob_start('a');
 ob_start('b');
 ob_start('c');
 ob_start('d');
+ob_start(['E', 'f']);
+ob_start([$e, 'g']);
+ob_start(function ($s) { return $s; });
 ob_start();
 
 echo "foo\n";
@@ -34,16 +49,19 @@ Array
     [2] => b
     [3] => c
     [4] => d
+    [5] => E::f
+    [6] => E::g
+    [7] => Closure::__invoke
 )
 Array
 (
-    [name] => d
+    [name] => Closure::__invoke
     [type] => 1
     [flags] => 20593
-    [level] => 4
-    [chunk_size] => %d
+    [level] => 7
+    [chunk_size] => 0
     [buffer_size] => 16384
-    [buffer_used] => 96
+    [buffer_used] => %d
 )
 Array
 (
@@ -53,7 +71,7 @@ Array
             [type] => 0
             [flags] => 112
             [level] => 0
-            [chunk_size] => %d
+            [chunk_size] => 0
             [buffer_size] => 16384
             [buffer_used] => 0
         )
@@ -64,7 +82,7 @@ Array
             [type] => 1
             [flags] => 113
             [level] => 1
-            [chunk_size] => %d
+            [chunk_size] => 0
             [buffer_size] => 16384
             [buffer_used] => 0
         )
@@ -75,7 +93,7 @@ Array
             [type] => 1
             [flags] => 113
             [level] => 2
-            [chunk_size] => %d
+            [chunk_size] => 0
             [buffer_size] => 16384
             [buffer_used] => 0
         )
@@ -86,18 +104,51 @@ Array
             [type] => 1
             [flags] => 113
             [level] => 3
-            [chunk_size] => %d
+            [chunk_size] => 0
             [buffer_size] => 16384
-            [buffer_used] => 4
+            [buffer_used] => 0
         )
 
     [4] => Array
         (
             [name] => d
             [type] => 1
-            [flags] => 20593
+            [flags] => 113
             [level] => 4
-            [chunk_size] => %d
+            [chunk_size] => 0
+            [buffer_size] => 16384
+            [buffer_used] => 0
+        )
+
+    [5] => Array
+        (
+            [name] => E::f
+            [type] => 1
+            [flags] => 113
+            [level] => 5
+            [chunk_size] => 0
+            [buffer_size] => 16384
+            [buffer_used] => 0
+        )
+
+    [6] => Array
+        (
+            [name] => E::g
+            [type] => 1
+            [flags] => 113
+            [level] => 6
+            [chunk_size] => 0
+            [buffer_size] => 16384
+            [buffer_used] => %d
+        )
+
+    [7] => Array
+        (
+            [name] => Closure::__invoke
+            [type] => 1
+            [flags] => 20593
+            [level] => 7
+            [chunk_size] => 0
             [buffer_size] => 16384
             [buffer_used] => %d
         )

--- a/tests/output/ob_get_status.phpt
+++ b/tests/output/ob_get_status.phpt
@@ -7,11 +7,53 @@ Testfest 2009 Munich
 --FILE--
 <?php
 ob_start();
+$status = ob_get_status();
+ob_end_clean();
+var_dump($status);
+
+ob_start();
+$status = ob_get_status(false);
+ob_end_clean();
+var_dump($status);
+
+ob_start();
 $status = ob_get_status(true);
 ob_end_clean();
 var_dump($status);
 ?>
 --EXPECT--
+array(7) {
+  ["name"]=>
+  string(22) "default output handler"
+  ["type"]=>
+  int(0)
+  ["flags"]=>
+  int(112)
+  ["level"]=>
+  int(0)
+  ["chunk_size"]=>
+  int(0)
+  ["buffer_size"]=>
+  int(16384)
+  ["buffer_used"]=>
+  int(0)
+}
+array(7) {
+  ["name"]=>
+  string(22) "default output handler"
+  ["type"]=>
+  int(0)
+  ["flags"]=>
+  int(112)
+  ["level"]=>
+  int(0)
+  ["chunk_size"]=>
+  int(0)
+  ["buffer_size"]=>
+  int(16384)
+  ["buffer_used"]=>
+  int(0)
+}
 array(1) {
   [0]=>
   array(7) {


### PR DESCRIPTION
Updated two output buffering tests:
 - basic ob_get_status():  test without the full_status parameter and with full_status being passed false
 - ob handlers/status:  test using class methods or an anonymous function as handlers