### PR TITLE
Introduce new serial_hex parameter to openssl_csr_sign

### DIFF
--- a/ext/openssl/openssl.stub.php
+++ b/ext/openssl/openssl.stub.php
@@ -440,7 +440,7 @@ function openssl_csr_export(OpenSSLCertificateSigningRequest|string $csr, &$outp
 /**
  * @param OpenSSLAsymmetricKey|OpenSSLCertificate|array|string $private_key
  */
-function openssl_csr_sign(OpenSSLCertificateSigningRequest|string $csr, OpenSSLCertificate|string|null $ca_certificate, #[\SensitiveParameter] $private_key, int $days, ?array $options = null, int $serial = 0): OpenSSLCertificate|false {}
+function openssl_csr_sign(OpenSSLCertificateSigningRequest|string $csr, OpenSSLCertificate|string|null $ca_certificate, #[\SensitiveParameter] $private_key, int $days, ?array $options = null, int $serial = 0, ?string $serial_hex = null): OpenSSLCertificate|false {}
 
 /**
  * @param OpenSSLAsymmetricKey $private_key

--- a/ext/openssl/openssl_arginfo.h
+++ b/ext/openssl/openssl_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 549946c91248fddc4d43502d32335b68cfbe71f2 */
+ * Stub hash: 1bb1eab5199d2e72e624f7e93f59dd5114ed7c86 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_openssl_x509_export_to_file, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, certificate, OpenSSLCertificate, MAY_BE_STRING, NULL)
@@ -90,6 +90,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_openssl_csr_sign, 0, 4, Open
 	ZEND_ARG_TYPE_INFO(0, days, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, options, IS_ARRAY, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, serial, IS_LONG, 0, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, serial_hex, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_openssl_csr_new, 0, 2, OpenSSLCertificateSigningRequest, MAY_BE_FALSE)

--- a/ext/openssl/tests/openssl_csr_sign_with_serial_hex.phpt
+++ b/ext/openssl/tests/openssl_csr_sign_with_serial_hex.phpt
@@ -1,0 +1,65 @@
+--TEST--
+openssl_csr_sign() with serial and serial_hex parameters
+--EXTENSIONS--
+openssl
+--FILE--
+<?php
+$config = __DIR__ . DIRECTORY_SEPARATOR . 'openssl.cnf';
+$config_arg = array('config' => $config);
+
+$dn = array(
+    "countryName" => "BR",
+    "stateOrProvinceName" => "Rio Grande do Sul",
+    "localityName" => "Porto Alegre",
+    "commonName" => "Henrique do N. Angelo",
+    "emailAddress" => "hnangelo@php.net"
+);
+
+$args = array(
+    "digest_alg" => "sha256",
+    "private_key_bits" => 2048,
+    "private_key_type" => OPENSSL_KEYTYPE_DSA,
+    "encrypt_key" => true,
+    "config" => $config
+);
+
+$privkey = openssl_pkey_new($config_arg);
+$csr = openssl_csr_new($dn, $privkey, $args);
+
+var_dump($cert1 = openssl_csr_sign($csr, null, $privkey, 365, $args, 1234567));
+var_dump($cert2 = openssl_csr_sign($csr, null, $privkey, 365, $args, serial_hex: 'DEADBEEF'));
+var_dump($cert3 = openssl_csr_sign($csr, null, $privkey, 365, $args, 10, 'DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF'));
+
+var_dump(openssl_csr_sign($csr, null, $privkey, 365, $args, 0, 'DEADBEEG'));
+var_dump(openssl_csr_sign($csr, null, $privkey, 365, $args, 0, '0xDEADBEEF'));
+var_dump(openssl_csr_sign($csr, null, $privkey, 365, $args, 0, str_repeat('FF', 500)));
+
+var_dump(openssl_x509_parse($cert1)['serialNumber']);
+var_dump(openssl_x509_parse($cert1)['serialNumberHex']);
+var_dump(openssl_x509_parse($cert2)['serialNumber']);
+var_dump(openssl_x509_parse($cert2)['serialNumberHex']);
+var_dump(openssl_x509_parse($cert3)['serialNumber']);
+var_dump(openssl_x509_parse($cert3)['serialNumberHex']);
+?>
+--EXPECTF--
+object(OpenSSLCertificate)#%d (0) {
+}
+object(OpenSSLCertificate)#%d (0) {
+}
+object(OpenSSLCertificate)#%d (0) {
+}
+
+Warning: openssl_csr_sign(): Error parsing serial number in %s on line %d
+bool(false)
+
+Warning: openssl_csr_sign(): Error parsing serial number in %s on line %d
+bool(false)
+
+Warning: openssl_csr_sign(): Error parsing serial number because it is too long in %s on line %d
+bool(false)
+string(7) "1234567"
+string(6) "12D687"
+string(10) "3735928559"
+string(8) "DEADBEEF"
+string(42) "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+string(40) "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"


### PR DESCRIPTION
This is based on https://github.com/php/php-src/pull/9851 but adds a new `serial_hex` parameter instead of re-using the existing `serial` which was a significant BC break.