### PR TITLE
Fix GH-12974: Apache crashes on shutdown when using pg_pconnect()

### DIFF
--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -400,14 +400,8 @@ static void php_oci_pconnection_list_dtor(zend_resource *entry)
 
 	if (connection) {
 		php_oci_connection_close(connection);
-		/* See https://github.com/php/php-src/issues/12974 why we need to check the if */
-#ifdef ZTS
-		if (oci8_module_entry.module_started)
-#endif
-		{
-			OCI_G(num_persistent)--;
-			OCI_G(num_links)--;
-		}
+		OCI_G(num_persistent)--;
+		OCI_G(num_links)--;
 	}
 }
 /* }}} */

--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -400,8 +400,14 @@ static void php_oci_pconnection_list_dtor(zend_resource *entry)
 
 	if (connection) {
 		php_oci_connection_close(connection);
-		OCI_G(num_persistent)--;
-		OCI_G(num_links)--;
+		/* See https://github.com/php/php-src/issues/12974 why we need to check the if */
+#ifdef ZTS
+		if (oci8_module_entry.module_started)
+#endif
+		{
+			OCI_G(num_persistent)--;
+			OCI_G(num_links)--;
+		}
 	}
 }
 /* }}} */

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -168,7 +168,12 @@ static void _close_odbc_conn(zend_resource *rsrc)
 		SQLFreeEnv(conn->henv);
 	}
 	efree(conn);
-	ODBCG(num_links)--;
+	/* See https://github.com/php/php-src/issues/12974 why we need to check the if */
+#ifdef ZTS
+	if (odbc_module_entry.module_started) {
+#endif
+		ODBCG(num_links)--;
+	}
 }
 /* }}} */
 

--- a/ext/odbc/php_odbc.c
+++ b/ext/odbc/php_odbc.c
@@ -170,8 +170,9 @@ static void _close_odbc_conn(zend_resource *rsrc)
 	efree(conn);
 	/* See https://github.com/php/php-src/issues/12974 why we need to check the if */
 #ifdef ZTS
-	if (odbc_module_entry.module_started) {
+	if (odbc_module_entry.module_started)
 #endif
+	{
 		ODBCG(num_links)--;
 	}
 }

--- a/ext/pgsql/pgsql.c
+++ b/ext/pgsql/pgsql.c
@@ -314,8 +314,14 @@ static void _close_pgsql_plink(zend_resource *rsrc)
 		PQclear(res);
 	}
 	PQfinish(link);
-	PGG(num_persistent)--;
-	PGG(num_links)--;
+	/* See https://github.com/php/php-src/issues/12974 why we need to check the if */
+#ifdef ZTS
+	if (pgsql_module_entry.module_started)
+#endif
+	{
+		PGG(num_persistent)--;
+		PGG(num_links)--;
+	}
 	rsrc->ptr = NULL;
 }
 


### PR DESCRIPTION
On ZTS, the global variables are stored in dynamically allocated memory. When the module gets shut down this memory is released. After the module is shut down, only then are the persistent resources cleared. Normally this isn't an issue, but pgsql and odbc refer to the globals to modify some counters, after the globals have been freed.
Fix this by guarding the modification.

We don't have Apache tests unfortunately, but I tested this manually with Valgrind (instructions in the linked issue).