### PR TITLE
Remove obsolete _XPG_IV preprocessor directive

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,9 +229,6 @@ case $host_alias in
   *solaris*)
     CPPFLAGS="$CPPFLAGS -D_POSIX_PTHREAD_SEMANTICS"
     ;;
-  *mips*)
-    CPPFLAGS="$CPPFLAGS -D_XPG_IV"
-    ;;
   *hpux*)
     if test "$GCC" = "yes"; then
       CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE_EXTENDED"


### PR DESCRIPTION
This was once used on SINIX UNIX variant and MIPS processors with the last release in 1995 to have working gettimeofday().