### PR TITLE
Check host_alias on one place

### DIFF
--- a/TSRM/threads.m4
+++ b/TSRM/threads.m4
@@ -31,12 +31,6 @@ dnl
 dnl Set some magic defines to achieve POSIX threads conformance.
 dnl
 AC_DEFUN([PTHREADS_FLAGS],[
-  if test -z "$host_alias" && test -n "$host"; then
-    host_alias=$host
-  fi
-  if test -z "$host_alias"; then
-    AC_MSG_ERROR(host_alias is not set. Make sure to run config.guess)
-  fi
   case $host_alias in
   *solaris*)
     PTHREAD_FLAGS="-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT";;

--- a/build/php.m4
+++ b/build/php.m4
@@ -124,7 +124,7 @@ AC_DEFUN([PHP_CANONICAL_HOST_TARGET],[
     host_alias=$host
   fi
   if test -z "$host_alias"; then
-    AC_MSG_ERROR([host_alias is not set!])
+    AC_MSG_ERROR([host_alias is not set! Make sure to run config.guess])
   fi
 ])
 


### PR DESCRIPTION
Just one minor simplificaton. Check in the php.m4 is always executed anyway so there's no need to have two. 