### PR TITLE
Use AC_CHECK_MEMBERS instead of AC_EGREP_HEADER

### DIFF
--- a/main/fastcgi.c
+++ b/main/fastcgi.c
@@ -745,7 +745,7 @@ int fcgi_listen(const char *path, int backlog)
 		sa.sa_unix.sun_family = AF_UNIX;
 		memcpy(sa.sa_unix.sun_path, path, path_len + 1);
 		sock_len = (size_t)(((struct sockaddr_un *)0)->sun_path)	+ path_len;
-#ifdef HAVE_SOCKADDR_UN_SUN_LEN
+#ifdef HAVE_STRUCT_SOCKADDR_UN_SUN_LEN
 		sa.sa_unix.sun_len = sock_len;
 #endif
 		unlink(path);

--- a/sapi/cgi/config9.m4
+++ b/sapi/cgi/config9.m4
@@ -9,12 +9,8 @@ AC_MSG_CHECKING(for CGI build)
 if test "$PHP_CGI" != "no"; then
     AC_MSG_RESULT(yes)
 
-    AC_MSG_CHECKING([for sun_len in sys/un.h])
-    AC_EGREP_HEADER([sun_len], [sys/un.h],
-      [AC_MSG_RESULT([yes])
-       AC_DEFINE([HAVE_SOCKADDR_UN_SUN_LEN], [1],
-        [Define if sockaddr_un in sys/un.h contains a sun_len component])],
-      AC_MSG_RESULT([no]))
+    dnl BSD systems.
+    AC_CHECK_MEMBERS([struct sockaddr_un.sun_len],,,[#include <sys/un.h>])
 
     AC_MSG_CHECKING([whether cross-process locking is required by accept()])
     case "`uname -sr`" in


### PR DESCRIPTION
AC_EGREP_* macros are not recommended due to their unreliability in certain cases, checking for struct member can be done here using the usual AC_CHECK_MEMBERS instead.

AC_CHECK_MEMBERS macro by default defines constant HAVE_STRUCT_SOCKADDR_UN_SUN_LEN.