### PR TITLE
Remove obsolete UNIX System V 4.0

### DIFF
--- a/sapi/cgi/config9.m4
+++ b/sapi/cgi/config9.m4
@@ -18,7 +18,7 @@ if test "$PHP_CGI" != "no"; then
 
     AC_MSG_CHECKING([whether cross-process locking is required by accept()])
     case "`uname -sr`" in
-      SunOS\ 5.* | UNIX_System_V\ 4.0)
+      SunOS\ 5.*)
         AC_MSG_RESULT([yes])
         AC_DEFINE([USE_LOCKING], [1],
           [Define if cross-process locking is required by accept()])


### PR DESCRIPTION
UNIX System V is operating system from 1988 and was incoporated later on into various other UNIX systems with different uname outputs so this check can be now safely removed.